### PR TITLE
Update CLAUDE.md workflow rules and fix Storybook static paths for xlsx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 1. `pwd` → パスから worktree ロールを判定
    - `.claude/worktrees/pptx` または `ooxml-pptx` → PPTX session（packages/pptx のみ編集可）
-2. `packages/pptx/CLAUDE.md` を必ず読む（PPTX 固有の詳細ルール）
+2. 各パッケージの `CLAUDE.md` を必ず読む（パッケージ固有の詳細ルール）
 3. 他 package のファイルは読み取り OK、編集は禁止
 
 ## プロジェクト概要
@@ -18,27 +18,47 @@ Rust/WASM parser + TypeScript Canvas renderer 構成。
 
 - `packages/core/` — 共有レンダリングプリミティブ + 共有型
 - `packages/pptx/` — PPTX 固有（Session A 所有）
-- `packages/docx/` — DOCX 固有（Session B、未作成）
-- `packages/xlsx/` — XLSX 固有（Session C、未作成）
+- `packages/docx/` — DOCX 固有（Session B 所有）
+- `packages/xlsx/` — XLSX 固有（Session C 所有）
+
+## Git ワークフロー
+
+**複数セッションが並列で作業するため、main への直接 push は禁止。**
+
+- 作業は必ず feature branch で行う（例: `feature/xlsx-xxx`、`feature/pptx-xxx`）
+- `git push origin <branch>` して PR を作成し、main へマージする
+- `git push origin main` は絶対に行わない
+- `git push` 前に `git config http.postBuffer 524288000` を設定すること
 
 ## 自律作業の原則
 
 - AM1時〜AM9時はユーザー確認不要。破壊的操作以外はすべて自律的に進めること。
-- 確認なしで進めてよい作業: コード修正・WASM ビルド・テスト実行・commit/push・Python/npm スクリプト実行。
-- `git push` は `http.postBuffer 524288000` を設定してから実行。
+- 確認なしで進めてよい作業: コード修正・WASM ビルド・テスト実行・commit/push（feature branch のみ）・Python/npm スクリプト実行。
 - 参照画像（`packages/*/tests/visual/references/`）はユーザー指示のみ更新。絶対に自動更新しない。
-- pptx ファイルは git にコミットしない。
+- pptx/xlsx/docx ファイルは git にコミットしない。
 
 ## WASM ビルド手順
 
 ```bash
-cd packages/pptx/parser && wasm-pack build --target web
-cp pkg/pptx_parser_bg.wasm pkg/pptx_parser.js ../src/wasm/
+# パッケージ別
+cd packages/pptx/parser  && wasm-pack build --target web && cp pkg/pptx_parser_bg.wasm pkg/pptx_parser.js ../src/wasm/
+cd packages/xlsx/parser  && wasm-pack build --target web && cp pkg/xlsx_parser_bg.wasm  pkg/xlsx_parser.js  ../src/wasm/
+cd packages/docx/parser  && wasm-pack build --target web && cp pkg/docx_parser_bg.wasm  pkg/docx_parser.js  ../src/wasm/
+
+# 全パッケージ一括
+pnpm build:wasm
 ```
 
 ## Storybook
 
-Storybook はルートに一本化。各パッケージのストーリーは `packages/*/src/*.stories.ts` に置く。
+Storybook はルートに一本化（port 6006）。各パッケージのストーリーは `packages/*/src/*.stories.ts` に置く。
+
+静的ファイルのパスプレフィックス（`.storybook/main.ts` の `staticDirs` で定義）:
+- `packages/pptx/tests/visual/` → `/pptx/`
+- `packages/xlsx/public/`        → `/xlsx/`
+- `packages/docx/public/`        → `/docx/`
+
+サンプルファイルを fetch する際は必ずプレフィックスを付ける（例: `/xlsx/sample-1.xlsx`）。
 
 ```bash
 pnpm storybook        # dev server (port 6006)

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -1,7 +1,7 @@
 import init, { parse_xlsx, parse_sheet } from './wasm/xlsx_parser.js';
 import type { WorkerRequest, WorkerResponse } from './types.js';
 
-let initPromise: Promise<void> | null = null;
+let initPromise: Promise<unknown> | null = null;
 
 self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add Git workflow section explicitly forbidding direct pushes to `main`. Multiple sessions (pptx/docx/xlsx) work in parallel, so all changes must go through feature branches and PRs.
- **CLAUDE.md**: Document consolidated Storybook (port 6006) static path prefixes (`/pptx/`, `/xlsx/`, `/docx/`) so sample file fetches use the correct URL.
- **CLAUDE.md**: Update package ownership (docx/xlsx now created, not "未作成").
- **worker.ts**: Fix TS2322 — `initPromise` typed as `Promise<void>` but `init()` returns `Promise<InitOutput>`; widened to `Promise<unknown>`.

Note: `Samples.sample.stories.ts` URL fix (`/sample-N.xlsx` → `/xlsx/sample-N.xlsx`) is in the gitignored local file and takes effect locally without being committed.

## Test plan

- [ ] `pnpm --filter @ooxml/xlsx typecheck` passes
- [ ] `pnpm storybook` starts on port 6006 and xlsx/pptx/docx stories all load
- [ ] Sample xlsx stories fetch from `/xlsx/sample-N.xlsx` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)