### PR TITLE
xlsx: add strikethrough support

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -136,6 +136,7 @@ pub struct Font {
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,
+    pub strike: bool,
     pub size: f64,
     pub color: Option<String>,
     pub name: Option<String>,
@@ -502,6 +503,7 @@ fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> V
                                 "b" => f.bold = true,
                                 "i" => f.italic = true,
                                 "u" => f.underline = true,
+                                "strike" => f.strike = true,
                                 "sz" => {
                                     if let Some(v) = fc.attribute("val").and_then(|s| s.parse().ok()) {
                                         f.size = v;
@@ -594,6 +596,7 @@ fn parse_fonts(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> 
                         "b" => f.bold = true,
                         "i" => f.italic = true,
                         "u" => f.underline = true,
+                        "strike" => f.strike = true,
                         "sz" => {
                             if let Some(v) = child.attribute("val").and_then(|s| s.parse().ok()) {
                                 f.size = v;

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -43,7 +43,7 @@ function resolveXf(styles: Styles, styleIndex: number): { font: Font; fill: Fill
   const xf: CellXf = styles.cellXfs[styleIndex] ?? styles.cellXfs[0] ?? {
     fontId: 0, fillId: 0, borderId: 0, numFmtId: 0, alignH: null, alignV: null, wrapText: false,
   };
-  const font: Font = styles.fonts[xf.fontId] ?? { bold: false, italic: false, underline: false, size: DEFAULT_FONT_SIZE, color: null, name: null };
+  const font: Font = styles.fonts[xf.fontId] ?? { bold: false, italic: false, underline: false, strike: false, size: DEFAULT_FONT_SIZE, color: null, name: null };
   const fill: Fill = styles.fills[xf.fillId] ?? { patternType: 'none', fgColor: null, bgColor: null };
   const border: Border = styles.borders[xf.borderId] ?? { left: null, right: null, top: null, bottom: null };
   return { font, fill, border, xf };
@@ -661,21 +661,45 @@ function renderQuadrant(
           ctx.fillText(lines[li], textX, startY + li * lineH);
         }
       } else {
+        // Measure once for both underline and strike
+        let overlayMetrics: TextMetrics | null = null;
+        const measureOverlay = () => overlayMetrics ??= ctx.measureText(text);
+        const overlayX = () => {
+          const tW = Math.min(measureOverlay().width, drawW - paddingX * 2);
+          return {
+            x: alignH === 'right' ? cx + cellW - paddingX - tW
+              : alignH === 'center' ? cx + cellW / 2 - tW / 2
+              : cx + paddingX,
+            width: tW,
+          };
+        };
+        const sizePx = Math.round(font.size * ROW_HEIGHT_TO_PX);
+
         if (font.underline) {
-          const metrics = ctx.measureText(text);
-          const tW = Math.min(metrics.width, drawW - paddingX * 2);
+          const { x: ux, width: tW } = overlayX();
           const uy = alignV === 'top'
-            ? cy + paddingY + Math.round(font.size * ROW_HEIGHT_TO_PX) + 1
+            ? cy + paddingY + sizePx + 1
             : alignV === 'center'
-              ? cy + cellH / 2 + Math.round(font.size * ROW_HEIGHT_TO_PX * 0.55)
+              ? cy + cellH / 2 + Math.round(sizePx * 0.55)
               : cy + cellH - paddingY + 1;
-          const ux = alignH === 'right' ? cx + cellW - paddingX - tW
-            : alignH === 'center' ? cx + cellW / 2 - tW / 2
-            : cx + paddingX;
           ctx.save();
           ctx.strokeStyle = font.color ? hexToRgba(font.color) : '#000000';
           ctx.lineWidth = 0.5;
           ctx.beginPath(); ctx.moveTo(ux, uy); ctx.lineTo(ux + tW, uy); ctx.stroke();
+          ctx.restore();
+        }
+        if (font.strike) {
+          const { x: sx, width: tW } = overlayX();
+          // Strike line sits roughly at the x-height mid-line (~45% up from baseline)
+          const sy = alignV === 'top'
+            ? cy + paddingY + Math.round(sizePx * 0.5)
+            : alignV === 'center'
+              ? cy + cellH / 2
+              : cy + cellH - paddingY - Math.round(sizePx * 0.35);
+          ctx.save();
+          ctx.strokeStyle = font.color ? hexToRgba(font.color) : '#000000';
+          ctx.lineWidth = 0.5;
+          ctx.beginPath(); ctx.moveTo(sx, sy); ctx.lineTo(sx + tW, sy); ctx.stroke();
           ctx.restore();
         }
         let textY: number;

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -103,6 +103,7 @@ export interface Font {
   bold: boolean;
   italic: boolean;
   underline: boolean;
+  strike: boolean;
   size: number;
   color: string | null;
   name: string | null;


### PR DESCRIPTION
## Summary

Add strikethrough (`<strike/>`) support to xlsx font rendering — ECMA-376 §18.8.22.

- **Rust parser**: `Font` struct gains `strike: bool`. `parse_fonts()` and `parse_dxfs()` recognize the `<strike/>` child.
- **TypeScript**: `Font` type mirrors the new field. `renderer.ts` draws a horizontal line through text center (alignment-aware x, reusing the underline code path).
- A lazy `measureText()` helper is shared between underline and strike to avoid double measurement.

Note: this is the non-wrap path only (same scope as the existing underline). Wrap + strike is a follow-up if needed.

## Test plan

- [ ] `pnpm --filter @ooxml/xlsx typecheck` passes ✅
- [ ] `pnpm build:wasm` compiles the Rust parser ✅
- [ ] Storybook shows strikethrough on cells with `<strike/>` font style

🤖 Generated with [Claude Code](https://claude.com/claude-code)