### PR TITLE
xlsx: render anchored images from drawingsML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
 name = "xlsx-parser"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "console_error_panic_hook",
  "roxmltree",
  "serde",

--- a/packages/xlsx/parser/Cargo.toml
+++ b/packages/xlsx/parser/Cargo.toml
@@ -12,6 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 zip = { workspace = true }
 roxmltree = { workspace = true }
+base64 = { workspace = true }
 console_error_panic_hook = { workspace = true }
 
 [profile.release]

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2,6 +2,7 @@ use wasm_bindgen::prelude::*;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -39,6 +40,25 @@ pub struct Worksheet {
     pub freeze_rows: u32,
     pub freeze_cols: u32,
     pub conditional_formats: Vec<ConditionalFormat>,
+    pub images: Vec<ImageAnchor>,
+}
+
+/// An image anchored to a rectangular range of cells
+/// (ECMA-376 §20.5, `<xdr:twoCellAnchor>`). Offsets are EMU (English
+/// Metric Unit): 914400 EMU = 1 inch, and 9525 EMU = 1 pixel at 96 DPI.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageAnchor {
+    pub from_col: u32,
+    pub from_col_off: i64,
+    pub from_row: u32,
+    pub from_row_off: i64,
+    pub to_col: u32,
+    pub to_col_off: i64,
+    pub to_row: u32,
+    pub to_row_off: i64,
+    /// Data URL: "data:image/png;base64,..."
+    pub data_url: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -272,8 +292,11 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     let theme_colors = parse_theme_colors(&mut archive);
     let shared_strings = read_shared_strings(&mut archive, &theme_colors);
     let sheet_xml = read_zip_entry(&mut archive, &format!("xl/{}", sheet_path))?;
-    let ws = parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
+    let mut ws = parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
         .map_err(|e| e.to_string())?;
+
+    // Attach any drawing-anchored images for this sheet
+    ws.images = load_sheet_images(&mut archive, &sheet_path);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -986,7 +1009,190 @@ fn parse_worksheet(
         freeze_rows,
         freeze_cols,
         conditional_formats,
+        images: Vec::new(),
     })
+}
+
+/// Parse a .rels file into rId → Target map.
+fn parse_rels_map(xml: &str) -> HashMap<String, String> {
+    let Ok(doc) = roxmltree::Document::parse(xml) else {
+        return HashMap::new();
+    };
+    let mut map = HashMap::new();
+    for rel in doc.root_element().children().filter(|n| n.is_element()) {
+        if let (Some(id), Some(target)) = (rel.attribute("Id"), rel.attribute("Target")) {
+            map.insert(id.to_string(), target.to_string());
+        }
+    }
+    map
+}
+
+/// Read a binary file from the zip.
+fn read_zip_bytes(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, path: &str) -> Option<Vec<u8>> {
+    let mut file = archive.by_name(path).ok()?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).ok()?;
+    Some(buf)
+}
+
+/// Resolve a relative path ("../media/image1.png") against a base dir ("xl/drawings").
+fn resolve_zip_path(base_dir: &str, target: &str) -> String {
+    let mut parts: Vec<&str> = base_dir.split('/').filter(|s| !s.is_empty()).collect();
+    for seg in target.split('/') {
+        match seg {
+            ".." => { parts.pop(); }
+            "." | "" => {}
+            s => parts.push(s),
+        }
+    }
+    parts.join("/")
+}
+
+fn mime_from_ext(path: &str) -> &'static str {
+    match path.rsplit('.').next().unwrap_or("").to_ascii_lowercase().as_str() {
+        "png"  => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif"  => "image/gif",
+        "bmp"  => "image/bmp",
+        "webp" => "image/webp",
+        _      => "application/octet-stream",
+    }
+}
+
+/// Parse `<xdr:twoCellAnchor>` elements from a drawing XML and resolve
+/// embedded pictures into data URLs. `drawing_dir` is the folder that
+/// contains `drawing_path` so relative `Target`s resolve correctly.
+fn parse_drawing_anchors(
+    drawing_xml: &str,
+    drawing_rels: &HashMap<String, String>,
+    drawing_dir: &str,
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+) -> Vec<ImageAnchor> {
+    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
+        return Vec::new();
+    };
+    let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    let mut anchors: Vec<ImageAnchor> = Vec::new();
+
+    for anchor in doc.descendants() {
+        if anchor.tag_name().name() != "twoCellAnchor"
+            || anchor.tag_name().namespace() != Some(xdr_ns)
+        {
+            continue;
+        }
+        let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) = (0u32, 0i64, 0u32, 0i64);
+        let (mut to_col,   mut to_col_off,   mut to_row,   mut to_row_off)   = (0u32, 0i64, 0u32, 0i64);
+        let mut pic_rid: Option<String> = None;
+
+        for child in anchor.children() {
+            if !child.is_element() { continue; }
+            match child.tag_name().name() {
+                "from" | "to" => {
+                    let is_from = child.tag_name().name() == "from";
+                    let mut col: u32 = 0;
+                    let mut col_off: i64 = 0;
+                    let mut row: u32 = 0;
+                    let mut row_off: i64 = 0;
+                    for c in child.children() {
+                        match (c.tag_name().name(), c.text()) {
+                            ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                            ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
+                            ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                            ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
+                            _ => {}
+                        }
+                    }
+                    if is_from {
+                        from_col = col; from_col_off = col_off; from_row = row; from_row_off = row_off;
+                    } else {
+                        to_col = col; to_col_off = col_off; to_row = row; to_row_off = row_off;
+                    }
+                }
+                "pic" => {
+                    // <xdr:pic><xdr:blipFill><a:blip r:embed="rId1"/></xdr:blipFill></xdr:pic>
+                    let blip_fill = child.children()
+                        .find(|n| n.tag_name().name() == "blipFill" && n.tag_name().namespace() == Some(xdr_ns));
+                    if let Some(bf) = blip_fill {
+                        let blip = bf.children()
+                            .find(|n| n.tag_name().name() == "blip" && n.tag_name().namespace() == Some(a_ns));
+                        if let Some(b) = blip {
+                            // r:embed attribute
+                            pic_rid = b.attributes()
+                                .find(|a| a.name() == "embed" && a.namespace() == Some(r_ns))
+                                .map(|a| a.value().to_string());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let Some(rid) = pic_rid else { continue; };
+        let Some(target) = drawing_rels.get(&rid) else { continue; };
+        let media_path = resolve_zip_path(drawing_dir, target);
+        let Some(bytes) = read_zip_bytes(archive, &media_path) else { continue; };
+        let mime = mime_from_ext(&media_path);
+        let data_url = format!("data:{mime};base64,{}", B64.encode(&bytes));
+
+        anchors.push(ImageAnchor {
+            from_col, from_col_off, from_row, from_row_off,
+            to_col, to_col_off, to_row, to_row_off,
+            data_url,
+        });
+    }
+    anchors
+}
+
+/// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse
+/// its drawing(s), and return all image anchors found.
+fn load_sheet_images(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_path: &str, // e.g. "worksheets/sheet1.xml"
+) -> Vec<ImageAnchor> {
+    // sheet rels path:  xl/worksheets/_rels/sheet1.xml.rels
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
+        return Vec::new();
+    };
+    let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+        return Vec::new();
+    };
+
+    // Find all drawing relationships
+    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+        return Vec::new();
+    };
+    let mut drawing_targets: Vec<String> = Vec::new();
+    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+        let rel_type = rel.attribute("Type").unwrap_or("");
+        if rel_type.ends_with("/drawing") {
+            if let Some(t) = rel.attribute("Target") {
+                drawing_targets.push(t.to_string());
+            }
+        }
+    }
+    if drawing_targets.is_empty() { return Vec::new(); }
+
+    let mut all_anchors: Vec<ImageAnchor> = Vec::new();
+    for target in drawing_targets {
+        // sheet_dir is "worksheets", target typically "../drawings/drawing1.xml"
+        // base dir for the drawing = "xl/worksheets" + "../drawings" → "xl/drawings"
+        let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
+        // Drawing rels:  xl/drawings/_rels/drawing1.xml.rels
+        let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else { continue; };
+        let drawing_rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
+        let drawing_rels = read_zip_entry(archive, &drawing_rels_path)
+            .ok()
+            .map(|xml| parse_rels_map(&xml))
+            .unwrap_or_default();
+
+        let mut anchors = parse_drawing_anchors(&drawing_xml, &drawing_rels, drawing_dir, archive);
+        all_anchors.append(&mut anchors);
+    }
+    all_anchors
 }
 
 fn parse_sqref(s: &str) -> Vec<CellRange> {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -933,6 +933,17 @@ export function renderViewport(
     scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH,
   );
 
+  // ── Anchored images (clipped to scrollable area) ─────────────
+  if (worksheet.images && worksheet.images.length > 0 && opts.loadedImages) {
+    renderImages(
+      ctx, worksheet, opts.loadedImages, cs,
+      startRow, startCol,
+      scrollOffsetX, scrollOffsetY,
+      scrollAreaX, scrollAreaY,
+      scrollAreaW, scrollAreaH,
+    );
+  }
+
   // ── Row/col headers (drawn last, always on top) ──────────────
   renderHeaders(ctx, canvasW, canvasH,
     startRow, startCol, numRows, numCols,
@@ -1109,6 +1120,96 @@ function renderHeaders(
       ctx.fillRect(hw, 0, frozenW, hh);
     }
   }
+}
+
+// ────────────────────────────────────────────────────────────────
+// Image anchors  (ECMA-376 §20.5, <xdr:twoCellAnchor>)
+// ────────────────────────────────────────────────────────────────
+const EMU_PER_PX = 9525;
+
+/** Sum scaled column widths for cols 1..n-1 (sheet-space X of col n in scaled px). */
+function sheetXForCol(
+  ws: Worksheet,
+  col1: number, // 1-indexed column number
+  cs: number,
+): number {
+  let x = 0;
+  for (let c = 1; c < col1; c++) {
+    x += Math.round(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth) * cs);
+  }
+  return x;
+}
+
+/** Sum scaled row heights for rows 1..n-1 (sheet-space Y of row n in scaled px). */
+function sheetYForRow(
+  ws: Worksheet,
+  row1: number, // 1-indexed row number
+  cs: number,
+): number {
+  let y = 0;
+  for (let r = 1; r < row1; r++) {
+    y += Math.round(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight) * cs);
+  }
+  return y;
+}
+
+function renderImages(
+  ctx: CanvasRenderingContext2D,
+  ws: Worksheet,
+  loadedImages: Map<string, HTMLImageElement>,
+  cs: number,
+  startRow: number,
+  startCol: number,
+  scrollOffsetX: number,
+  scrollOffsetY: number,
+  scrollAreaX: number,
+  scrollAreaY: number,
+  scrollAreaW: number,
+  scrollAreaH: number,
+): void {
+  if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
+
+  // Sheet-space origin of the current scroll viewport's first visible cell
+  const scrollOriginSheetX = sheetXForCol(ws, startCol, cs);
+  const scrollOriginSheetY = sheetYForRow(ws, startRow, cs);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+  ctx.clip();
+
+  for (const anchor of ws.images) {
+    const img = loadedImages.get(anchor.dataUrl);
+    if (!img) continue;
+
+    // xdr col/row are 0-indexed; our widths map is 1-indexed.
+    const fromCol1 = anchor.fromCol + 1;
+    const fromRow1 = anchor.fromRow + 1;
+    const toCol1   = anchor.toCol   + 1;
+    const toRow1   = anchor.toRow   + 1;
+
+    // Image sheet-space rect (in scaled px)
+    const imgSheetX1 = sheetXForCol(ws, fromCol1, cs) + (anchor.fromColOff * cs) / EMU_PER_PX;
+    const imgSheetY1 = sheetYForRow(ws, fromRow1, cs) + (anchor.fromRowOff * cs) / EMU_PER_PX;
+    const imgSheetX2 = sheetXForCol(ws, toCol1,   cs) + (anchor.toColOff   * cs) / EMU_PER_PX;
+    const imgSheetY2 = sheetYForRow(ws, toRow1,   cs) + (anchor.toRowOff   * cs) / EMU_PER_PX;
+
+    const imgW = imgSheetX2 - imgSheetX1;
+    const imgH = imgSheetY2 - imgSheetY1;
+    if (imgW <= 0 || imgH <= 0) continue;
+
+    // Translate to canvas coordinates of the scrollable viewport
+    const canvasX = scrollAreaX + (imgSheetX1 - scrollOriginSheetX) - scrollOffsetX;
+    const canvasY = scrollAreaY + (imgSheetY1 - scrollOriginSheetY) - scrollOffsetY;
+
+    // Early out when entirely off-screen
+    if (canvasX + imgW < scrollAreaX || canvasX > scrollAreaX + scrollAreaW) continue;
+    if (canvasY + imgH < scrollAreaY || canvasY > scrollAreaY + scrollAreaH) continue;
+
+    ctx.drawImage(img, canvasX, canvasY, imgW, imgH);
+  }
+
+  ctx.restore();
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -26,6 +26,24 @@ export interface Worksheet {
   freezeRows: number;
   freezeCols: number;
   conditionalFormats: ConditionalFormat[];
+  images: ImageAnchor[];
+}
+
+/**
+ * Image anchored to a rectangle of cells (EMU offsets within the anchor cells).
+ * 914400 EMU = 1 inch, 9525 EMU = 1 px @ 96 DPI.
+ */
+export interface ImageAnchor {
+  fromCol: number;
+  fromColOff: number;
+  fromRow: number;
+  fromRowOff: number;
+  toCol: number;
+  toColOff: number;
+  toRow: number;
+  toRowOff: number;
+  /** Data URL (data:image/png;base64,...) */
+  dataUrl: string;
 }
 
 export interface CellRange {
@@ -182,6 +200,8 @@ export interface RenderViewportOptions {
   freezeCols?: number;
   /** Scale factor applied to all cell/header dimensions (default 1). */
   cellScale?: number;
+  /** Pre-loaded Image elements keyed by their dataUrl (for ImageAnchor rendering). */
+  loadedImages?: Map<string, HTMLImageElement>;
 }
 
 export type WorkerRequest =

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -7,6 +7,8 @@ export class XlsxWorkbook {
   private worker: Worker;
   private parsedWorkbook: ParsedWorkbook | null = null;
   private sheetCache = new Map<number, Worksheet>();
+  /** Cache of loaded images keyed by their data URL. Shared across sheets. */
+  private imageCache = new Map<string, HTMLImageElement>();
   private rawData: ArrayBuffer | null = null;
 
   constructor() {
@@ -81,7 +83,23 @@ export class XlsxWorkbook {
     const ctx = (target as HTMLCanvasElement).getContext('2d') as CanvasRenderingContext2D;
     ctx.scale(dpr, dpr);
 
-    renderViewport(ctx, ws, styles, viewport, { ...opts, dpr });
+    // Preload any image bitmaps that this sheet uses (data URLs → HTMLImageElement)
+    if (ws.images && ws.images.length > 0) {
+      await Promise.all(
+        ws.images.map(async (img) => {
+          if (this.imageCache.has(img.dataUrl)) return;
+          const el = new Image();
+          el.src = img.dataUrl;
+          await new Promise<void>((resolve, reject) => {
+            el.onload = () => resolve();
+            el.onerror = () => reject(new Error('image decode failed'));
+          });
+          this.imageCache.set(img.dataUrl, el);
+        }),
+      ).catch(() => { /* swallow image failures so the grid still renders */ });
+    }
+
+    renderViewport(ctx, ws, styles, viewport, { ...opts, dpr, loadedImages: this.imageCache });
   }
 
   destroy(): void {


### PR DESCRIPTION
## Summary

Support `<xdr:twoCellAnchor>` + `<xdr:pic>` + `<a:blip r:embed>` per ECMA-376 §20.5. Images embedded in `xl/media/` are extracted, base64-encoded as data URLs, and anchored to a rectangle of cells (EMU offsets within those anchor cells).

### Rust
- Add `base64` dep; new `ImageAnchor` struct; `Worksheet.images`
- Helpers: `parse_rels_map`, `read_zip_bytes`, `resolve_zip_path`, `mime_from_ext`, `parse_drawing_anchors`, `load_sheet_images`
- `parse_sheet_inner` now follows sheet rels → drawing XML → drawing rels → media bytes and populates `ws.images`

### TypeScript
- types: `ImageAnchor`, `Worksheet.images`, `RenderViewportOptions.loadedImages`
- `workbook.ts`: `imageCache` (dataUrl → HTMLImageElement); preloads bitmaps before calling the sync renderer
- `renderer.ts`: `renderImages()` draws after cells but before headers, clipped to the scrollable area. Positions use scaled sheet-space (`EMU / 9525`) translated via the scroll origin + offset

## Scope / deferred

- `twoCellAnchor` only (oneCellAnchor / absoluteAnchor are deferred)
- Images in the scrollable area only (frozen-area overlap deferred)
- Image failures swallowed so the grid still renders

## Test plan

- [x] `pnpm --filter @ooxml/xlsx typecheck` passes
- [x] `pnpm build:wasm` compiles
- [ ] Storybook: an xlsx with an embedded picture shows the image at the correct cell location, scrolls correctly, and scales with the `scale` arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)