### PR TITLE
Implement chart rendering for xlsx

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -41,6 +41,58 @@ pub struct Worksheet {
     pub freeze_cols: u32,
     pub conditional_formats: Vec<ConditionalFormat>,
     pub images: Vec<ImageAnchor>,
+    pub charts: Vec<ChartAnchor>,
+}
+
+// ─── Chart types ────────────────────────────────────────────────────────────
+
+/// A data series inside a chart.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartSeries {
+    /// Display name of the series.
+    pub name: String,
+    /// Chart type for this series ("bar"|"line"|"area"|"pie"|"radar"|"scatter").
+    /// Allows mixed charts (e.g. bar + line sharing the same axes).
+    pub series_type: String,
+    /// Category labels (X-axis for most charts).
+    pub categories: Vec<String>,
+    /// Numeric values; `None` = missing data point.
+    pub values: Vec<Option<f64>>,
+}
+
+/// Parsed chart data extracted from `xl/charts/chartN.xml`.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartData {
+    /// Primary chart type: "bar"|"line"|"area"|"pie"|"doughnut"|"radar"|"scatter"
+    pub chart_type: String,
+    /// Bar direction: "col" (vertical) | "row" (horizontal). Only relevant for bar charts.
+    pub bar_dir: String,
+    /// Grouping mode: "clustered"|"stacked"|"standard"|"percentStacked"
+    pub grouping: String,
+    /// Optional chart title.
+    pub title: Option<String>,
+    /// Shared category list (from first series that has categories).
+    pub categories: Vec<String>,
+    /// All series across all chart-type elements in plotArea.
+    pub series: Vec<ChartSeries>,
+}
+
+/// A chart anchored to a rectangular range of cells (ECMA-376 §20.5 twoCellAnchor).
+/// Offsets are EMU (914400 EMU = 1 inch, 9525 EMU = 1 px @ 96 DPI).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartAnchor {
+    pub from_col: u32,
+    pub from_col_off: i64,
+    pub from_row: u32,
+    pub from_row_off: i64,
+    pub to_col: u32,
+    pub to_col_off: i64,
+    pub to_row: u32,
+    pub to_row_off: i64,
+    pub chart: ChartData,
 }
 
 /// An image anchored to a rectangular range of cells
@@ -295,8 +347,9 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     let mut ws = parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
         .map_err(|e| e.to_string())?;
 
-    // Attach any drawing-anchored images for this sheet
+    // Attach any drawing-anchored images and charts for this sheet
     ws.images = load_sheet_images(&mut archive, &sheet_path);
+    ws.charts = load_sheet_charts(&mut archive, &sheet_path);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -1010,6 +1063,7 @@ fn parse_worksheet(
         freeze_cols,
         conditional_formats,
         images: Vec::new(),
+        charts: Vec::new(),
     })
 }
 
@@ -1193,6 +1247,332 @@ fn load_sheet_images(
         all_anchors.append(&mut anchors);
     }
     all_anchors
+}
+
+// ─── Chart loading ──────────────────────────────────────────────────────────
+
+/// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse
+/// its drawing(s) for chart anchors (`<xdr:graphicFrame>` elements).
+fn load_sheet_charts(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_path: &str,
+) -> Vec<ChartAnchor> {
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
+        return Vec::new();
+    };
+    let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+        return Vec::new();
+    };
+    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+        return Vec::new();
+    };
+
+    // Collect all drawing relationship targets
+    let mut drawing_targets: Vec<String> = Vec::new();
+    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+        if rel.attribute("Type").unwrap_or("").ends_with("/drawing") {
+            if let Some(t) = rel.attribute("Target") {
+                drawing_targets.push(t.to_string());
+            }
+        }
+    }
+    if drawing_targets.is_empty() { return Vec::new(); }
+
+    let mut all_charts: Vec<ChartAnchor> = Vec::new();
+    let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+    let a_ns   = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    let c_ns   = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    let r_ns   = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+    for target in drawing_targets {
+        // Resolve drawing path relative to the sheet directory
+        let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
+        let Ok(draw_doc) = roxmltree::Document::parse(&drawing_xml) else { continue; };
+
+        // Load drawing rels (to resolve chart rIds)
+        let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else { continue; };
+        let drawing_rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
+        let drawing_rels = read_zip_entry(archive, &drawing_rels_path)
+            .ok()
+            .map(|xml| parse_rels_map(&xml))
+            .unwrap_or_default();
+
+        // Iterate over twoCellAnchor elements
+        for anchor in draw_doc.root_element().children().filter(|n| n.is_element()) {
+            if anchor.tag_name().name() != "twoCellAnchor"
+                || anchor.tag_name().namespace() != Some(xdr_ns)
+            {
+                continue;
+            }
+
+            let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) = (0u32, 0i64, 0u32, 0i64);
+            let (mut to_col,   mut to_col_off,   mut to_row,   mut to_row_off)   = (0u32, 0i64, 0u32, 0i64);
+            let mut chart_rid: Option<String> = None;
+
+            for child in anchor.children() {
+                if !child.is_element() { continue; }
+                match child.tag_name().name() {
+                    "from" | "to" => {
+                        let is_from = child.tag_name().name() == "from";
+                        let mut col: u32 = 0; let mut col_off: i64 = 0;
+                        let mut row: u32 = 0; let mut row_off: i64 = 0;
+                        for c in child.children() {
+                            match (c.tag_name().name(), c.text()) {
+                                ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                                ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
+                                ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                                ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
+                                _ => {}
+                            }
+                        }
+                        if is_from { from_col = col; from_col_off = col_off; from_row = row; from_row_off = row_off; }
+                        else       { to_col   = col; to_col_off   = col_off; to_row   = row; to_row_off   = row_off; }
+                    }
+                    "graphicFrame" => {
+                        // Look for a:graphic/a:graphicData/c:chart[@r:id]
+                        for gf_child in child.descendants() {
+                            if gf_child.tag_name().name() == "chart"
+                                && gf_child.tag_name().namespace() == Some(c_ns)
+                            {
+                                if let Some(rid) = gf_child.attributes()
+                                    .find(|a| a.name() == "id" && a.namespace() == Some(r_ns))
+                                    .map(|a| a.value().to_string())
+                                {
+                                    chart_rid = Some(rid);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            let Some(rid) = chart_rid else { continue; };
+            let Some(chart_target) = drawing_rels.get(&rid) else { continue; };
+            let chart_path = resolve_zip_path(drawing_dir, chart_target);
+            let Ok(chart_xml) = read_zip_entry(archive, &chart_path) else { continue; };
+            let Some(chart_data) = parse_chart_xml(&chart_xml, c_ns, a_ns) else { continue; };
+
+            all_charts.push(ChartAnchor {
+                from_col, from_col_off, from_row, from_row_off,
+                to_col,   to_col_off,   to_row,   to_row_off,
+                chart: chart_data,
+            });
+        }
+    }
+    all_charts
+}
+
+// ─── Chart XML parser ────────────────────────────────────────────────────────
+
+/// Parse a `xl/charts/chartN.xml` file into a `ChartData`.
+fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str) -> Option<ChartData> {
+    let doc = roxmltree::Document::parse(xml).ok()?;
+
+    // Find c:chart root element
+    let chart_root = doc.descendants()
+        .find(|n| n.tag_name().name() == "chart" && n.tag_name().namespace() == Some(c_ns))?;
+
+    // Parse optional title
+    let title = extract_chart_title(&chart_root, c_ns, a_ns);
+
+    // Find c:plotArea
+    let plot_area = chart_root.children()
+        .find(|n| n.tag_name().name() == "plotArea" && n.tag_name().namespace() == Some(c_ns))?;
+
+    let mut primary_type = String::new();
+    let mut bar_dir      = "col".to_string();
+    let mut grouping     = "clustered".to_string();
+    let mut all_series: Vec<ChartSeries> = Vec::new();
+    let mut shared_categories: Vec<String> = Vec::new();
+
+    // Recognised chart-type element names → our internal type strings
+    let type_map: &[(&str, &str)] = &[
+        ("barChart",      "bar"),
+        ("lineChart",     "line"),
+        ("areaChart",     "area"),
+        ("pieChart",      "pie"),
+        ("doughnutChart", "doughnut"),
+        ("radarChart",    "radar"),
+        ("scatterChart",  "scatter"),
+        ("bubbleChart",   "scatter"), // treat bubble as scatter
+    ];
+
+    for child in plot_area.children() {
+        if !child.is_element() { continue; }
+        if child.tag_name().namespace() != Some(c_ns) { continue; }
+        let elem_name = child.tag_name().name();
+
+        let ser_type = match type_map.iter().find(|(k, _)| *k == elem_name) {
+            Some((_, v)) => *v,
+            None => continue,
+        };
+
+        if primary_type.is_empty() {
+            primary_type = ser_type.to_string();
+        }
+
+        // barDir / grouping (only meaningful for bar/line/area)
+        for attr_node in child.children().filter(|n| n.is_element()) {
+            match attr_node.tag_name().name() {
+                "barDir"   => { bar_dir  = attr_node.attribute("val").unwrap_or("col").to_string(); }
+                "grouping" => { grouping = attr_node.attribute("val").unwrap_or("clustered").to_string(); }
+                _ => {}
+            }
+        }
+
+        // Parse series
+        for ser_node in child.children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "ser" && n.tag_name().namespace() == Some(c_ns))
+        {
+            let s = parse_chart_series(&ser_node, c_ns, ser_type);
+            if shared_categories.is_empty() && !s.categories.is_empty() {
+                shared_categories = s.categories.clone();
+            }
+            all_series.push(s);
+        }
+    }
+
+    if primary_type.is_empty() { return None; }
+
+    // Fill in categories for series that have none (mixed charts share categories)
+    for s in &mut all_series {
+        if s.categories.is_empty() {
+            s.categories = shared_categories.clone();
+        }
+    }
+
+    Some(ChartData {
+        chart_type: primary_type,
+        bar_dir,
+        grouping,
+        title,
+        categories: shared_categories,
+        series: all_series,
+    })
+}
+
+/// Extract plain text from `c:chart/c:title`.
+fn extract_chart_title(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<String> {
+    let title_node = chart_root.children()
+        .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
+    // c:title/c:tx/c:rich/a:p/a:r/a:t  or  c:title/c:tx/c:strRef/c:strCache/c:pt/c:v
+    let mut text = String::new();
+    for node in title_node.descendants() {
+        if node.tag_name().name() == "t" && node.tag_name().namespace() == Some(a_ns) {
+            if let Some(t) = node.text() { text.push_str(t); }
+        }
+        if node.tag_name().name() == "v" && node.tag_name().namespace() == Some(c_ns) {
+            if let Some(t) = node.text() { text.push_str(t); }
+        }
+    }
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Parse one `<c:ser>` element.
+fn parse_chart_series(node: &roxmltree::Node, c_ns: &str, ser_type: &str) -> ChartSeries {
+    let name = extract_series_name(node, c_ns);
+
+    // For scatter: xVal → categories (as strings), yVal → values
+    // For others:  cat  → categories,             val  → values
+    let (cat_tag, val_tag) = if ser_type == "scatter" { ("xVal", "yVal") } else { ("cat", "val") };
+
+    let categories = collect_str_cache(node, c_ns, cat_tag);
+    let values     = collect_num_cache(node, c_ns, val_tag);
+
+    ChartSeries {
+        name,
+        series_type: ser_type.to_string(),
+        categories,
+        values,
+    }
+}
+
+/// Extract series name from `c:tx`.
+fn extract_series_name(node: &roxmltree::Node, c_ns: &str) -> String {
+    // c:tx/c:strRef/c:strCache/c:pt[@idx=0]/c:v
+    // or c:tx/c:v
+    if let Some(tx) = node.children().find(|n| n.tag_name().name() == "tx" && n.tag_name().namespace() == Some(c_ns)) {
+        for desc in tx.descendants() {
+            if desc.tag_name().name() == "v" && desc.tag_name().namespace() == Some(c_ns) {
+                if let Some(t) = desc.text() {
+                    if !t.is_empty() { return t.to_string(); }
+                }
+            }
+        }
+    }
+    String::new()
+}
+
+/// Collect string values from a cache child element (e.g. `<c:cat>` or `<c:xVal>`).
+/// Reads `c:strRef/c:strCache` and also `c:numRef/c:numCache` (formats numbers as strings).
+fn collect_str_cache(ser_node: &roxmltree::Node, c_ns: &str, child_tag: &str) -> Vec<String> {
+    let Some(child) = ser_node.children()
+        .find(|n| n.tag_name().name() == child_tag && n.tag_name().namespace() == Some(c_ns))
+    else { return Vec::new(); };
+
+    // Try strCache first, then numCache
+    let mut pt_count: usize = 0;
+    let mut pts: Vec<(usize, String)> = Vec::new();
+    for desc in child.descendants() {
+        match desc.tag_name().name() {
+            "ptCount" if desc.tag_name().namespace() == Some(c_ns) => {
+                pt_count = desc.attribute("val").and_then(|v| v.parse().ok()).unwrap_or(0);
+            }
+            "pt" if desc.tag_name().namespace() == Some(c_ns) => {
+                let idx: usize = desc.attribute("idx").and_then(|v| v.parse().ok()).unwrap_or(0);
+                let val = desc.children()
+                    .find(|n| n.tag_name().name() == "v")
+                    .and_then(|n| n.text())
+                    .unwrap_or("")
+                    .to_string();
+                pts.push((idx, val));
+            }
+            _ => {}
+        }
+    }
+    if pt_count == 0 { pt_count = pts.len(); }
+    let mut result = vec![String::new(); pt_count];
+    for (idx, val) in pts {
+        if idx < result.len() { result[idx] = val; }
+    }
+    result
+}
+
+/// Collect numeric values from a cache child element (e.g. `<c:val>` or `<c:yVal>`).
+fn collect_num_cache(ser_node: &roxmltree::Node, c_ns: &str, child_tag: &str) -> Vec<Option<f64>> {
+    let Some(child) = ser_node.children()
+        .find(|n| n.tag_name().name() == child_tag && n.tag_name().namespace() == Some(c_ns))
+    else { return Vec::new(); };
+
+    let mut pt_count: usize = 0;
+    let mut pts: Vec<(usize, f64)> = Vec::new();
+    for desc in child.descendants() {
+        match desc.tag_name().name() {
+            "ptCount" if desc.tag_name().namespace() == Some(c_ns) => {
+                pt_count = desc.attribute("val").and_then(|v| v.parse().ok()).unwrap_or(0);
+            }
+            "pt" if desc.tag_name().namespace() == Some(c_ns) => {
+                let idx: usize = desc.attribute("idx").and_then(|v| v.parse().ok()).unwrap_or(0);
+                if let Some(v) = desc.children()
+                    .find(|n| n.tag_name().name() == "v")
+                    .and_then(|n| n.text())
+                    .and_then(|t| t.parse::<f64>().ok())
+                {
+                    pts.push((idx, v));
+                }
+            }
+            _ => {}
+        }
+    }
+    if pt_count == 0 { pt_count = pts.len(); }
+    let mut result: Vec<Option<f64>> = vec![None; pt_count];
+    for (idx, val) in pts {
+        if idx < result.len() { result[idx] = Some(val); }
+    }
+    result
 }
 
 fn parse_sqref(s: &str) -> Vec<CellRange> {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2,7 +2,7 @@ import type {
   Worksheet, Styles, Cell, CellValue, Font, Fill, Border, CellXf,
   ViewportRange, RenderViewportOptions,
   CfRule, CellRange, CfStop, CfValue, Dxf,
-  Run,
+  Run, ChartData,
 } from './types.js';
 
 const DEFAULT_FONT_FAMILY = 'Calibri, Arial, sans-serif';
@@ -944,6 +944,17 @@ export function renderViewport(
     );
   }
 
+  // ── Anchored charts (clipped to scrollable area) ──────────────
+  if (worksheet.charts && worksheet.charts.length > 0) {
+    renderCharts(
+      ctx, worksheet, cs,
+      startRow, startCol,
+      scrollOffsetX, scrollOffsetY,
+      scrollAreaX, scrollAreaY,
+      scrollAreaW, scrollAreaH,
+    );
+  }
+
   // ── Row/col headers (drawn last, always on top) ──────────────
   renderHeaders(ctx, canvasW, canvasH,
     startRow, startCol, numRows, numCols,
@@ -1245,4 +1256,746 @@ function borderStyleWidth(style: string): number {
     case 'medium': case 'mediumDashed': case 'mediumDashDot': return 0.5;
     default: return 0.5;
   }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Chart rendering
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Standard Excel chart colour palette (matches Office default theme)
+const CHART_PALETTE = [
+  '4472C4','ED7D31','A9D18E','FF0000','70AD47','4BACC6',
+  'FFC000','9E480E','843C0C','636363','255E91','967300',
+];
+
+function chartColor(idx: number, explicit?: string | null): string {
+  return explicit ? `#${explicit}` : `#${CHART_PALETTE[idx % CHART_PALETTE.length]}`;
+}
+
+function niceStep(range: number, targetSteps = 5): number {
+  if (range === 0) return 1;
+  const raw = range / targetSteps;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const normed = raw / mag;
+  const nice = normed < 1.5 ? 1 : normed < 3.5 ? 2 : normed < 7.5 ? 5 : 10;
+  return nice * mag;
+}
+
+// ── renderCharts ────────────────────────────────────────────────────────────
+
+function renderCharts(
+  ctx: CanvasRenderingContext2D,
+  ws: Worksheet,
+  cs: number,
+  startRow: number,
+  startCol: number,
+  scrollOffsetX: number,
+  scrollOffsetY: number,
+  scrollAreaX: number,
+  scrollAreaY: number,
+  scrollAreaW: number,
+  scrollAreaH: number,
+): void {
+  if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
+
+  const scrollOriginSheetX = sheetXForCol(ws, startCol, cs);
+  const scrollOriginSheetY = sheetYForRow(ws, startRow, cs);
+
+  for (const anchor of ws.charts) {
+    const fromCol1 = anchor.fromCol + 1;
+    const fromRow1 = anchor.fromRow + 1;
+    const toCol1   = anchor.toCol   + 1;
+    const toRow1   = anchor.toRow   + 1;
+
+    const shX1 = sheetXForCol(ws, fromCol1, cs) + (anchor.fromColOff * cs) / EMU_PER_PX;
+    const shY1 = sheetYForRow(ws, fromRow1, cs) + (anchor.fromRowOff * cs) / EMU_PER_PX;
+    const shX2 = sheetXForCol(ws, toCol1,   cs) + (anchor.toColOff   * cs) / EMU_PER_PX;
+    const shY2 = sheetYForRow(ws, toRow1,   cs) + (anchor.toRowOff   * cs) / EMU_PER_PX;
+
+    const cw = shX2 - shX1;
+    const ch = shY2 - shY1;
+    if (cw <= 0 || ch <= 0) continue;
+
+    const cx = scrollAreaX + (shX1 - scrollOriginSheetX) - scrollOffsetX;
+    const cy = scrollAreaY + (shY1 - scrollOriginSheetY) - scrollOffsetY;
+
+    if (cx + cw < scrollAreaX || cx > scrollAreaX + scrollAreaW) continue;
+    if (cy + ch < scrollAreaY || cy > scrollAreaY + scrollAreaH) continue;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+    ctx.clip();
+
+    renderChartData(ctx, anchor.chart, cx, cy, cw, ch);
+    ctx.restore();
+  }
+}
+
+// ── Dispatcher ──────────────────────────────────────────────────────────────
+
+function renderChartData(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartData,
+  x: number, y: number, w: number, h: number,
+): void {
+  // White background + light border
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(x, y, w, h);
+  ctx.strokeStyle = '#d0d0d0';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x + 0.5, y + 0.5, w - 1, h - 1);
+
+  if (chart.series.length === 0) {
+    ctx.fillStyle = '#888';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('(no data)', x + w / 2, y + h / 2);
+    return;
+  }
+
+  switch (chart.chartType) {
+    case 'bar':     renderBarChart(ctx, chart, x, y, w, h);                break;
+    case 'line':    renderLineChartXlsx(ctx, chart, x, y, w, h);           break;
+    case 'area':    renderAreaChartXlsx(ctx, chart, x, y, w, h);           break;
+    case 'pie':     renderPieChartXlsx(ctx, chart, x, y, w, h, false);     break;
+    case 'doughnut':renderPieChartXlsx(ctx, chart, x, y, w, h, true);      break;
+    case 'radar':   renderRadarChart(ctx, chart, x, y, w, h);              break;
+    case 'scatter': renderScatterChartXlsx(ctx, chart, x, y, w, h);        break;
+    default:
+      ctx.fillStyle = '#888';
+      ctx.font = '11px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(`Chart: ${chart.chartType}`, x + w / 2, y + h / 2);
+  }
+}
+
+// ── Legend helper ────────────────────────────────────────────────────────────
+
+function drawLegend(
+  ctx: CanvasRenderingContext2D,
+  series: ChartData['series'],
+  lx: number, ly: number, lw: number, lh: number,
+): void {
+  const fontSize = Math.max(9, Math.min(12, lh / (series.length + 1)));
+  ctx.font = `${fontSize}px sans-serif`;
+  ctx.textBaseline = 'middle';
+  const sw = 10; const gap = 4;
+  const rowH = fontSize + 4;
+  let ry = ly + (lh - rowH * series.length) / 2;
+  for (let i = 0; i < series.length; i++) {
+    const color = chartColor(i, null);
+    ctx.fillStyle = color;
+    ctx.fillRect(lx, ry, sw, fontSize);
+    ctx.fillStyle = '#333';
+    ctx.textAlign = 'left';
+    const label = series[i].name || `Series ${i + 1}`;
+    ctx.fillText(label.slice(0, 20), lx + sw + gap, ry + fontSize / 2);
+    ry += rowH;
+  }
+}
+
+// ── Title helper ─────────────────────────────────────────────────────────────
+
+function drawChartTitle(
+  ctx: CanvasRenderingContext2D,
+  title: string | null,
+  x: number, y: number, w: number, fontSize: number,
+): void {
+  if (!title) return;
+  ctx.font = `bold ${fontSize}px sans-serif`;
+  ctx.fillStyle = '#333';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillText(title, x + w / 2, y);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Bar chart (vertical columns + horizontal bars, clustered + stacked)
+// Also handles mixed bar+line series (seriesType per series)
+// ═══════════════════════════════════════════════════════════════════════════
+
+function renderBarChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartData,
+  x: number, y: number, w: number, h: number,
+): void {
+  const isH    = chart.barDir === 'row';
+  const stacked = chart.grouping === 'stacked' || chart.grouping === 'percentStacked';
+  const pct    = chart.grouping === 'percentStacked';
+
+  // Separate bar and line series (for mixed charts)
+  const barSeries  = chart.series.filter(s => s.seriesType !== 'line');
+  const lineSeries = chart.series.filter(s => s.seriesType === 'line');
+  const allSeries  = barSeries; // for axis calculation include bar only
+
+  const cats = chart.categories.length > 0
+    ? chart.categories
+    : (chart.series[0]?.categories ?? []);
+  const n = cats.length;
+  if (n === 0) return;
+
+  // Layout
+  const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
+  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const pad = { t: titleH + h * 0.04, r: legendW + w * 0.03, b: h * 0.14, l: w * 0.12 };
+  if (isH) { pad.l = w * 0.22; pad.b = h * 0.08; }
+
+  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+
+  const px0 = x + pad.l; const py0 = y + pad.t;
+  const pw  = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
+  if (pw <= 0 || ph <= 0) return;
+
+  // Compute data max
+  let dataMax = 0;
+  for (let ci = 0; ci < n; ci++) {
+    let stackSum = 0;
+    for (const s of allSeries) {
+      const v = s.values[ci] ?? 0;
+      if (stacked) stackSum += Math.abs(v);
+      else dataMax = Math.max(dataMax, Math.abs(v));
+    }
+    if (stacked) dataMax = Math.max(dataMax, stackSum);
+  }
+  if (pct) dataMax = 100;
+  if (dataMax === 0) dataMax = 1;
+
+  const step  = niceStep(dataMax);
+  const axMax = Math.ceil(dataMax / step) * step;
+
+  // Draw grid + value axis
+  const gridColor = '#e0e0e0';
+  const steps = Math.round(axMax / step);
+  ctx.textBaseline = 'middle';
+  ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+  ctx.fillStyle = '#555';
+
+  for (let si = 0; si <= steps; si++) {
+    const val = si * step;
+    const label = pct ? `${Math.round(val)}%` : val >= 1000 ? `${(val / 1000).toFixed(1)}k` : String(val);
+    if (!isH) {
+      const gy = py0 + ph - (val / axMax) * ph;
+      ctx.strokeStyle = si === 0 ? '#aaa' : gridColor;
+      ctx.lineWidth = si === 0 ? 1 : 0.5;
+      ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+      ctx.textAlign = 'right';
+      ctx.fillText(label, px0 - 4, gy);
+    } else {
+      const gx = px0 + (val / axMax) * pw;
+      ctx.strokeStyle = si === 0 ? '#aaa' : gridColor;
+      ctx.lineWidth = si === 0 ? 1 : 0.5;
+      ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
+      ctx.textAlign = 'center';
+      ctx.fillText(label, gx, py0 + ph + 10);
+    }
+  }
+
+  // Draw category axis line
+  ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
+  if (!isH) {
+    ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+  } else {
+    ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+  }
+
+  // Draw bars
+  const catGap = !isH ? pw / n : ph / n;
+  const barW   = catGap * (stacked ? 0.6 : 0.6 / Math.max(1, barSeries.length));
+  const clusterGap = stacked ? 0 : catGap * 0.6 / Math.max(1, barSeries.length);
+  const catStart   = stacked ? catGap * 0.2 : catGap * 0.2;
+
+  for (let ci = 0; ci < n; ci++) {
+    let stackOffset = 0;
+    let stackSum = 0;
+    if (pct) {
+      for (const s of barSeries) stackSum += Math.abs(s.values[ci] ?? 0);
+      if (stackSum === 0) stackSum = 1;
+    }
+
+    for (let si = 0; si < barSeries.length; si++) {
+      const s = barSeries[si];
+      const raw = s.values[ci] ?? 0;
+      const val = pct ? (Math.abs(raw) / stackSum) * 100 : Math.abs(raw);
+      const color = chartColor(si, null);
+
+      if (!isH) {
+        const bx = stacked
+          ? px0 + ci * catGap + catStart
+          : px0 + ci * catGap + catStart + si * clusterGap;
+        const barH = (val / axMax) * ph;
+        const by   = py0 + ph - (stacked ? (stackOffset + val) : val) / axMax * ph;
+        ctx.fillStyle = color;
+        ctx.fillRect(bx, by, barW, barH);
+      } else {
+        const by = stacked
+          ? py0 + (n - 1 - ci) * catGap + catStart
+          : py0 + (n - 1 - ci) * catGap + catStart + si * clusterGap;
+        const barL = (val / axMax) * pw;
+        const bx   = stacked ? px0 + (stackOffset / axMax) * pw : px0;
+        ctx.fillStyle = color;
+        ctx.fillRect(bx, by, barL, barW);
+      }
+      if (stacked) stackOffset += val;
+    }
+  }
+
+  // Draw category labels
+  ctx.fillStyle = '#555';
+  ctx.font = `${Math.max(8, Math.min(11, catGap * 0.5))}px sans-serif`;
+  for (let ci = 0; ci < n; ci++) {
+    const label = (cats[ci] ?? '').toString().slice(0, 12);
+    if (!isH) {
+      const lx = px0 + ci * catGap + catGap / 2;
+      ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+      ctx.fillText(label, lx, py0 + ph + 3);
+    } else {
+      const ly = py0 + (n - 1 - ci) * catGap + catGap / 2;
+      ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+      ctx.fillText(label, px0 - 4, ly);
+    }
+  }
+
+  // Overlay line series (mixed bar+line)
+  if (lineSeries.length > 0) {
+    for (let si = 0; si < lineSeries.length; si++) {
+      const s = lineSeries[si];
+      const color = chartColor(barSeries.length + si, null);
+      ctx.strokeStyle = color; ctx.lineWidth = 2;
+      ctx.setLineDash([]);
+      ctx.beginPath();
+      let started = false;
+      for (let ci = 0; ci < n; ci++) {
+        const v = s.values[ci];
+        if (v == null) { started = false; continue; }
+        const lx = px0 + ci * catGap + catGap / 2;
+        const ly = py0 + ph - (v / axMax) * ph;
+        if (!started) { ctx.moveTo(lx, ly); started = true; } else ctx.lineTo(lx, ly);
+      }
+      ctx.stroke();
+      // Markers
+      for (let ci = 0; ci < n; ci++) {
+        const v = s.values[ci];
+        if (v == null) continue;
+        const lx = px0 + ci * catGap + catGap / 2;
+        const ly = py0 + ph - (v / axMax) * ph;
+        ctx.fillStyle = color;
+        ctx.beginPath(); ctx.arc(lx, ly, 3, 0, Math.PI * 2); ctx.fill();
+      }
+    }
+  }
+
+  // Legend
+  if (legendW > 0) {
+    drawLegend(ctx, chart.series, x + w - legendW + 4, py0, legendW - 8, ph);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Line chart
+// ═══════════════════════════════════════════════════════════════════════════
+
+function renderLineChartXlsx(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartData,
+  x: number, y: number, w: number, h: number,
+): void {
+  const cats = chart.categories.length > 0 ? chart.categories : (chart.series[0]?.categories ?? []);
+  const n = cats.length; if (n === 0) return;
+
+  const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
+  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const pad = { t: titleH + h * 0.04, r: legendW + w * 0.05, b: h * 0.14, l: w * 0.12 };
+
+  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+
+  const px0 = x + pad.l; const py0 = y + pad.t;
+  const pw = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
+  if (pw <= 0 || ph <= 0) return;
+
+  // Y range
+  let dataMin = Infinity; let dataMax = -Infinity;
+  for (const s of chart.series) for (const v of s.values) if (v != null) { dataMin = Math.min(dataMin, v); dataMax = Math.max(dataMax, v); }
+  if (!isFinite(dataMin)) { dataMin = 0; dataMax = 1; }
+  if (dataMin > 0) dataMin = 0;
+  if (dataMax < 0) dataMax = 0;
+  if (dataMax === dataMin) dataMax = dataMin + 1;
+
+  const step  = niceStep(dataMax - dataMin);
+  const axMin = Math.floor(dataMin / step) * step;
+  const axMax = Math.ceil(dataMax / step) * step;
+  const range = axMax - axMin; if (range === 0) return;
+
+  const toY = (v: number) => py0 + ph - ((v - axMin) / range) * ph;
+  const toX = (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
+
+  // Grid
+  const steps = Math.round((axMax - axMin) / step);
+  ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+  ctx.textBaseline = 'middle';
+  for (let si = 0; si <= steps; si++) {
+    const v = axMin + si * step;
+    const gy = toY(v);
+    ctx.strokeStyle = v === 0 ? '#aaa' : '#e0e0e0';
+    ctx.lineWidth = v === 0 ? 1 : 0.5;
+    ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+    ctx.fillStyle = '#555'; ctx.textAlign = 'right';
+    ctx.fillText(String(v), px0 - 4, gy);
+  }
+
+  // Baseline
+  ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+
+  // Series
+  const markerR = Math.max(3, ph * 0.015);
+  for (let si = 0; si < chart.series.length; si++) {
+    const s = chart.series[si];
+    const color = chartColor(si, null);
+    ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.setLineDash([]);
+    ctx.beginPath();
+    let started = false;
+    for (let ci = 0; ci < n; ci++) {
+      const v = s.values[ci]; if (v == null) { started = false; continue; }
+      const px = toX(ci); const py = toY(v);
+      if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+    ctx.fillStyle = color;
+    for (let ci = 0; ci < n; ci++) {
+      const v = s.values[ci]; if (v == null) continue;
+      ctx.beginPath(); ctx.arc(toX(ci), toY(v), markerR, 0, Math.PI * 2); ctx.fill();
+    }
+  }
+
+  // Category labels
+  const labelInterval = Math.max(1, Math.ceil(n / 8));
+  ctx.fillStyle = '#555'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+  ctx.font = `${Math.max(8, Math.min(11, pw / n * 0.8))}px sans-serif`;
+  for (let ci = 0; ci < n; ci += labelInterval) {
+    ctx.fillText((cats[ci] ?? '').toString().slice(0, 10), toX(ci), py0 + ph + 3);
+  }
+
+  if (legendW > 0) drawLegend(ctx, chart.series, x + w - legendW + 4, py0, legendW - 8, ph);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Area chart
+// ═══════════════════════════════════════════════════════════════════════════
+
+function renderAreaChartXlsx(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartData,
+  x: number, y: number, w: number, h: number,
+): void {
+  const cats = chart.categories.length > 0 ? chart.categories : (chart.series[0]?.categories ?? []);
+  const n = cats.length; if (n === 0) return;
+  const stacked = chart.grouping === 'stacked' || chart.grouping === 'percentStacked';
+
+  const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
+  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const pad = { t: titleH + h * 0.04, r: legendW + w * 0.05, b: h * 0.14, l: w * 0.12 };
+
+  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+
+  const px0 = x + pad.l; const py0 = y + pad.t;
+  const pw = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
+  if (pw <= 0 || ph <= 0) return;
+
+  // Compute max (stacked: sum per category)
+  let dataMax = 0;
+  for (let ci = 0; ci < n; ci++) {
+    if (stacked) {
+      let sum = 0;
+      for (const s of chart.series) sum += s.values[ci] ?? 0;
+      dataMax = Math.max(dataMax, sum);
+    } else {
+      for (const s of chart.series) dataMax = Math.max(dataMax, s.values[ci] ?? 0);
+    }
+  }
+  if (dataMax === 0) dataMax = 1;
+  const step  = niceStep(dataMax);
+  const axMax = Math.ceil(dataMax / step) * step;
+
+  const toX = (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
+  const toY = (v: number) => py0 + ph - (v / axMax) * ph;
+
+  // Grid
+  ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+  ctx.textBaseline = 'middle';
+  const steps = Math.round(axMax / step);
+  for (let si = 0; si <= steps; si++) {
+    const v = si * step; const gy = toY(v);
+    ctx.strokeStyle = si === 0 ? '#aaa' : '#e0e0e0';
+    ctx.lineWidth = si === 0 ? 1 : 0.5;
+    ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+    ctx.fillStyle = '#555'; ctx.textAlign = 'right';
+    ctx.fillText(String(v), px0 - 4, gy);
+  }
+  ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+
+  // Areas (render back-to-front)
+  const stackBase = stacked ? new Array(n).fill(0) as number[] : null;
+  for (let si = chart.series.length - 1; si >= 0; si--) {
+    const s = chart.series[si];
+    const color = chartColor(si, null);
+    const baseY = py0 + ph;
+
+    ctx.beginPath();
+    if (stacked && stackBase) {
+      // top edge: from first to last
+      for (let ci = 0; ci < n; ci++) {
+        const v = (s.values[ci] ?? 0) + stackBase[ci];
+        const px = toX(ci); const py = toY(v);
+        if (ci === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+      }
+      // bottom edge: base stack values in reverse
+      for (let ci = n - 1; ci >= 0; ci--) {
+        ctx.lineTo(toX(ci), toY(stackBase[ci]));
+      }
+      for (let ci = 0; ci < n; ci++) stackBase[ci] += s.values[ci] ?? 0;
+    } else {
+      ctx.moveTo(toX(0), baseY);
+      for (let ci = 0; ci < n; ci++) ctx.lineTo(toX(ci), toY(s.values[ci] ?? 0));
+      ctx.lineTo(toX(n - 1), baseY);
+    }
+    ctx.closePath();
+    ctx.fillStyle = hexToRgba(color, 0.6);
+    ctx.fill();
+    ctx.strokeStyle = color; ctx.lineWidth = 1.5; ctx.setLineDash([]);
+    ctx.stroke();
+  }
+
+  // Category labels
+  const labelInterval = Math.max(1, Math.ceil(n / 8));
+  ctx.fillStyle = '#555'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+  ctx.font = `${Math.max(8, Math.min(11, pw / n * 0.8))}px sans-serif`;
+  for (let ci = 0; ci < n; ci += labelInterval) {
+    ctx.fillText((cats[ci] ?? '').toString().slice(0, 10), toX(ci), py0 + ph + 3);
+  }
+
+  if (legendW > 0) drawLegend(ctx, chart.series, x + w - legendW + 4, py0, legendW - 8, ph);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Pie / Doughnut chart
+// ═══════════════════════════════════════════════════════════════════════════
+
+function renderPieChartXlsx(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartData,
+  x: number, y: number, w: number, h: number,
+  isDoughnut: boolean,
+): void {
+  const s = chart.series[0]; if (!s) return;
+  const cats = s.categories.length > 0 ? s.categories : chart.categories;
+  const vals = s.values.map(v => Math.abs(v ?? 0));
+  const total = vals.reduce((a, b) => a + b, 0);
+  if (total === 0) return;
+
+  const titleH = chart.title ? Math.max(14, h * 0.06) : 0;
+  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+
+  const legendW = Math.max(80, w * 0.28);
+  const pw = w - legendW; const ph = h - titleH - h * 0.04;
+  const cx2 = x + pw / 2; const cy2 = y + titleH + h * 0.04 + ph / 2;
+  const outerR = Math.min(pw, ph) * 0.42;
+  const innerR = isDoughnut ? outerR * 0.5 : 0;
+
+  let angle = -Math.PI / 2;
+  for (let i = 0; i < vals.length; i++) {
+    const slice = (vals[i] / total) * Math.PI * 2;
+    const color = chartColor(i, null);
+    ctx.beginPath();
+    ctx.moveTo(cx2, cy2);
+    ctx.arc(cx2, cy2, outerR, angle, angle + slice);
+    ctx.closePath();
+    ctx.fillStyle = color; ctx.fill();
+    ctx.strokeStyle = '#fff'; ctx.lineWidth = 1; ctx.stroke();
+    angle += slice;
+  }
+
+  if (isDoughnut) {
+    ctx.beginPath(); ctx.arc(cx2, cy2, innerR, 0, Math.PI * 2);
+    ctx.fillStyle = '#fff'; ctx.fill();
+  }
+
+  // Legend
+  const lx = x + pw + 4;
+  const fontSize = Math.max(9, Math.min(12, h / (vals.length + 2)));
+  ctx.font = `${fontSize}px sans-serif`;
+  ctx.textBaseline = 'middle';
+  const rowH = fontSize + 4;
+  let ry = y + (h - rowH * vals.length) / 2;
+  for (let i = 0; i < vals.length; i++) {
+    ctx.fillStyle = chartColor(i, null);
+    ctx.fillRect(lx, ry, 10, fontSize);
+    ctx.fillStyle = '#333'; ctx.textAlign = 'left';
+    ctx.fillText((cats[i] ?? `Item ${i + 1}`).toString().slice(0, 18), lx + 14, ry + fontSize / 2);
+    ry += rowH;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Radar / Spider chart
+// ═══════════════════════════════════════════════════════════════════════════
+
+function renderRadarChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartData,
+  x: number, y: number, w: number, h: number,
+): void {
+  const cats = chart.categories.length > 0 ? chart.categories : (chart.series[0]?.categories ?? []);
+  const n = cats.length; if (n < 3) return;
+
+  const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
+  const legendW = chart.series.length > 1 ? Math.max(70, w * 0.2) : 0;
+  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+
+  const pw = w - legendW; const ph = h - titleH - h * 0.04;
+  const cx2 = x + pw / 2; const cy2 = y + titleH + h * 0.04 + ph / 2;
+  const r   = Math.min(pw, ph) * 0.38;
+
+  // Find max across all series
+  let dataMax = 0;
+  for (const s of chart.series) for (const v of s.values) dataMax = Math.max(dataMax, v ?? 0);
+  if (dataMax === 0) dataMax = 1;
+  const step  = niceStep(dataMax);
+  const axMax = Math.ceil(dataMax / step) * step;
+
+  const angle0 = -Math.PI / 2;
+  const spoke  = (i: number) => angle0 + (i / n) * Math.PI * 2;
+
+  // Concentric rings (grid)
+  const rings = Math.round(axMax / step);
+  ctx.strokeStyle = '#ddd'; ctx.lineWidth = 0.5;
+  for (let ri = 1; ri <= rings; ri++) {
+    const rr = (ri / rings) * r;
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) {
+      const a = spoke(i);
+      const px = cx2 + Math.cos(a) * rr; const py = cy2 + Math.sin(a) * rr;
+      if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+    }
+    ctx.closePath(); ctx.stroke();
+  }
+
+  // Spokes
+  ctx.strokeStyle = '#bbb'; ctx.lineWidth = 0.5;
+  for (let i = 0; i < n; i++) {
+    const a = spoke(i);
+    ctx.beginPath(); ctx.moveTo(cx2, cy2);
+    ctx.lineTo(cx2 + Math.cos(a) * r, cy2 + Math.sin(a) * r); ctx.stroke();
+  }
+
+  // Category labels
+  ctx.font = `${Math.max(8, Math.min(11, r * 0.2))}px sans-serif`;
+  ctx.fillStyle = '#444'; ctx.textBaseline = 'middle';
+  for (let i = 0; i < n; i++) {
+    const a = spoke(i);
+    const lx = cx2 + Math.cos(a) * (r + 12);
+    const ly = cy2 + Math.sin(a) * (r + 12);
+    ctx.textAlign = Math.cos(a) < -0.1 ? 'right' : Math.cos(a) > 0.1 ? 'left' : 'center';
+    ctx.fillText((cats[i] ?? '').toString().slice(0, 12), lx, ly);
+  }
+
+  // Series polygons
+  for (let si = 0; si < chart.series.length; si++) {
+    const s = chart.series[si];
+    const color = chartColor(si, null);
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) {
+      const v = s.values[i] ?? 0;
+      const frac = v / axMax;
+      const a = spoke(i);
+      const px = cx2 + Math.cos(a) * r * frac;
+      const py = cy2 + Math.sin(a) * r * frac;
+      if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fillStyle = hexToRgba(color, 0.25); ctx.fill();
+    ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.stroke();
+  }
+
+  if (legendW > 0) {
+    drawLegend(ctx, chart.series, x + w - legendW + 4, y + titleH + h * 0.04, legendW - 8, ph);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scatter chart
+// ═══════════════════════════════════════════════════════════════════════════
+
+function renderScatterChartXlsx(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartData,
+  x: number, y: number, w: number, h: number,
+): void {
+  const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
+  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const pad = { t: titleH + h * 0.06, r: legendW + w * 0.05, b: h * 0.12, l: w * 0.12 };
+
+  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+
+  const px0 = x + pad.l; const py0 = y + pad.t;
+  const pw = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
+  if (pw <= 0 || ph <= 0) return;
+
+  // For scatter: categories hold X values (as strings), values hold Y
+  let allX: number[] = []; let allY: number[] = [];
+  for (const s of chart.series) {
+    for (const c of s.categories) { const v = parseFloat(c); if (!isNaN(v)) allX.push(v); }
+    for (const v of s.values) if (v != null) allY.push(v);
+  }
+  // If no numeric X, use index
+  let useIndexX = allX.length === 0;
+  if (useIndexX) {
+    const maxLen = Math.max(...chart.series.map(s => s.values.length));
+    for (let i = 0; i < maxLen; i++) allX.push(i);
+  }
+
+  let xMin = Math.min(...allX); let xMax = Math.max(...allX);
+  let yMin = Math.min(...allY); let yMax = Math.max(...allY);
+  if (xMin === xMax) { xMin -= 1; xMax += 1; }
+  if (yMin === yMax) { yMin -= 1; yMax += 1; }
+  if (yMin > 0) yMin = 0;
+
+  const toX = (v: number) => px0 + ((v - xMin) / (xMax - xMin)) * pw;
+  const toY = (v: number) => py0 + ph - ((v - yMin) / (yMax - yMin)) * ph;
+
+  // Grid lines
+  ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+  const yStep = niceStep(yMax - yMin);
+  const ySteps = Math.round((yMax - yMin) / yStep) + 1;
+  for (let si = 0; si < ySteps; si++) {
+    const v = yMin + si * yStep; if (v > yMax + yStep * 0.01) break;
+    const gy = toY(v);
+    ctx.strokeStyle = '#e0e0e0'; ctx.lineWidth = 0.5;
+    ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+    ctx.fillStyle = '#555'; ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+    ctx.fillText(String(v), px0 - 4, gy);
+  }
+  // Axes
+  ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+
+  // Points
+  const markerR = Math.max(3, ph * 0.015);
+  for (let si = 0; si < chart.series.length; si++) {
+    const s = chart.series[si];
+    const color = chartColor(si, null);
+    ctx.fillStyle = color;
+    for (let ci = 0; ci < s.values.length; ci++) {
+      const yv = s.values[ci]; if (yv == null) continue;
+      const xv = useIndexX ? ci : parseFloat(s.categories[ci] ?? '0');
+      if (isNaN(xv)) continue;
+      ctx.beginPath(); ctx.arc(toX(xv), toY(yv), markerR, 0, Math.PI * 2); ctx.fill();
+    }
+  }
+
+  if (legendW > 0) drawLegend(ctx, chart.series, x + w - legendW + 4, py0, legendW - 8, ph);
 }

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -27,6 +27,37 @@ export interface Worksheet {
   freezeCols: number;
   conditionalFormats: ConditionalFormat[];
   images: ImageAnchor[];
+  charts: ChartAnchor[];
+}
+
+// ─── Chart types ─────────────────────────────────────────────────────────────
+
+export interface ChartSeries {
+  name: string;
+  /** Chart sub-type for this series (allows mixed charts). */
+  seriesType: string;
+  categories: string[];
+  values: (number | null)[];
+}
+
+export interface ChartData {
+  /** Primary chart type: "bar"|"line"|"area"|"pie"|"doughnut"|"radar"|"scatter" */
+  chartType: string;
+  /** "col" (vertical bars) | "row" (horizontal bars) */
+  barDir: string;
+  /** "clustered"|"stacked"|"standard"|"percentStacked" */
+  grouping: string;
+  title: string | null;
+  categories: string[];
+  series: ChartSeries[];
+}
+
+export interface ChartAnchor {
+  fromCol: number; fromColOff: number;
+  fromRow: number; fromRowOff: number;
+  toCol: number;   toColOff: number;
+  toRow: number;   toRowOff: number;
+  chart: ChartData;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Rust/WASM parser**: Adds `ChartSeries`, `ChartData`, `ChartAnchor` structs; `load_sheet_charts()` walks drawing XML to find `<xdr:graphicFrame>` chart references; `parse_chart_xml()` extracts chart type, bar direction, grouping, title, and series data from cached values
- **TypeScript types**: Adds `ChartSeries`, `ChartData`, `ChartAnchor` interfaces + `Worksheet.charts` field
- **Canvas renderer**: `renderCharts()` maps EMU anchors to canvas coordinates (same logic as image rendering); dispatches to per-type renderers: bar (col/row, clustered/stacked/percentStacked/mixed line), line, area, pie, doughnut, radar, scatter

Covers all chart types found in samples 13–23.

## Test plan

- [ ] \`pnpm --filter @ooxml/xlsx typecheck\` passes
- [ ] \`pnpm build:wasm\` succeeds
- [ ] Storybook samples 13–23 show charts (switch to "Table" sheet to see data, "Chart" sheet shows the rendered chart)
- [ ] sample-21 (pie), 22 (radar), 23 (scatter) render correctly
- [ ] Charts resize correctly with scale=0.5/1/2
- [ ] Charts scroll correctly (off-screen charts hidden, appear when scrolled to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)