### PR TITLE
Fix xlsx chart rendering issues

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1507,13 +1507,47 @@ fn extract_series_name(node: &roxmltree::Node, c_ns: &str) -> String {
 }
 
 /// Collect string values from a cache child element (e.g. `<c:cat>` or `<c:xVal>`).
-/// Reads `c:strRef/c:strCache` and also `c:numRef/c:numCache` (formats numbers as strings).
+/// Reads `c:strRef/c:strCache`, `c:multiLvlStrRef/c:multiLvlStrCache`, or
+/// `c:numRef/c:numCache` (formats numbers as strings).
 fn collect_str_cache(ser_node: &roxmltree::Node, c_ns: &str, child_tag: &str) -> Vec<String> {
     let Some(child) = ser_node.children()
         .find(|n| n.tag_name().name() == child_tag && n.tag_name().namespace() == Some(c_ns))
     else { return Vec::new(); };
 
-    // Try strCache first, then numCache
+    // Multi-level categories: use only the first (innermost) lvl to get primary labels.
+    if let Some(multi_cache) = child.descendants()
+        .find(|n| n.tag_name().name() == "multiLvlStrCache" && n.tag_name().namespace() == Some(c_ns))
+    {
+        let pt_count: usize = multi_cache.children()
+            .find(|n| n.tag_name().name() == "ptCount" && n.tag_name().namespace() == Some(c_ns))
+            .and_then(|n| n.attribute("val"))
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        if let Some(first_lvl) = multi_cache.children()
+            .find(|n| n.tag_name().name() == "lvl" && n.tag_name().namespace() == Some(c_ns))
+        {
+            let mut pts: Vec<(usize, String)> = Vec::new();
+            for pt in first_lvl.children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "pt" && n.tag_name().namespace() == Some(c_ns))
+            {
+                let idx: usize = pt.attribute("idx").and_then(|v| v.parse().ok()).unwrap_or(0);
+                let val = pt.children()
+                    .find(|n| n.tag_name().name() == "v")
+                    .and_then(|n| n.text())
+                    .unwrap_or("")
+                    .to_string();
+                pts.push((idx, val));
+            }
+            let len = pt_count.max(pts.iter().map(|(i, _)| i + 1).max().unwrap_or(0));
+            let mut result = vec![String::new(); len];
+            for (idx, val) in pts {
+                if idx < result.len() { result[idx] = val; }
+            }
+            return result;
+        }
+    }
+
+    // Standard strRef/strCache or numRef/numCache
     let mut pt_count: usize = 0;
     let mut pts: Vec<(usize, String)> = Vec::new();
     for desc in child.descendants() {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1422,7 +1422,7 @@ function renderBarChart(
   chart: ChartData,
   x: number, y: number, w: number, h: number,
 ): void {
-  const isH    = chart.barDir === 'row';
+  const isH    = chart.barDir === 'bar';
   const stacked = chart.grouping === 'stacked' || chart.grouping === 'percentStacked';
   const pct    = chart.grouping === 'percentStacked';
 
@@ -1439,7 +1439,7 @@ function renderBarChart(
 
   // Layout
   const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const legendW = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
   const pad = { t: titleH + h * 0.04, r: legendW + w * 0.03, b: h * 0.14, l: w * 0.12 };
   if (isH) { pad.l = w * 0.22; pad.b = h * 0.08; }
 
@@ -1606,7 +1606,7 @@ function renderLineChartXlsx(
   const n = cats.length; if (n === 0) return;
 
   const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const legendW = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
   const pad = { t: titleH + h * 0.04, r: legendW + w * 0.05, b: h * 0.14, l: w * 0.12 };
 
   drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
@@ -1695,7 +1695,7 @@ function renderAreaChartXlsx(
   const stacked = chart.grouping === 'stacked' || chart.grouping === 'percentStacked';
 
   const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const legendW = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
   const pad = { t: titleH + h * 0.04, r: legendW + w * 0.05, b: h * 0.14, l: w * 0.12 };
 
   drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
@@ -1935,7 +1935,7 @@ function renderScatterChartXlsx(
   x: number, y: number, w: number, h: number,
 ): void {
   const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW = chart.series.length > 1 ? Math.max(80, w * 0.22) : 0;
+  const legendW = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
   const pad = { t: titleH + h * 0.06, r: legendW + w * 0.05, b: h * 0.12, l: w * 0.12 };
 
   drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -76,23 +76,10 @@ export class XlsxViewer {
       await this.wb.load(source);
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
-      await this.showSheet(await this.findInitialSheet());
+      await this.showSheet(0);
     } catch (err) {
       this.opts.onError?.(err instanceof Error ? err : new Error(String(err)));
     }
-  }
-
-  /**
-   * Pick the first sheet that contains data rows.
-   * Falls back to sheet 0 if all sheets are empty (e.g. chart-only workbooks).
-   */
-  private async findInitialSheet(): Promise<number> {
-    const count = this.wb.sheetCount;
-    for (let i = 0; i < count; i++) {
-      const ws = await this.wb.getWorksheet(i);
-      if (ws.rows.length > 0) return i;
-    }
-    return 0;
   }
 
   async showSheet(index: number): Promise<void> {


### PR DESCRIPTION
## Summary

- **Bar direction**: `barDir === 'bar'` (was `'row'`) — OOXML uses `bar`/`col`, not `row`/`col`; horizontal bar charts now render correctly
- **Legend visibility**: Show legend for single-series charts (`>= 1`, was `> 1`)
- **Multi-level categories**: Handle `<c:multiLvlStrRef>/<c:multiLvlStrCache>` by extracting the first (innermost) `<c:lvl>` as primary category labels — fixes sample-17's x-axis grouping
- **Sheet selection**: Remove `findInitialSheet()` auto-skip; always open sheet 0

## Test plan

- [ ] sample-14: renders as horizontal bars (not vertical columns)
- [ ] sample-17: x-axis shows Attr1–Attr5 labels, legend shows "Value"
- [ ] sample-15/20: vertical column charts unchanged
- [ ] Opening any workbook opens sheet 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)