### PR TITLE
fix(pptx): correct star inner-radius to match OOXML spec defaults

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -685,33 +685,34 @@ function buildShapePath(
       break;
 
     // ── Stars ─────────────────────────────────────────────────────────────────
+    // Inner-radius defaults from ECMA-376 prstGeom avLst: adj / 50000 = innerR / outerR.
     case 'star4':
-      drawStar(ctx, cx, cy, w / 2, h / 2, 4, 0.38);
+      drawStar(ctx, cx, cy, w / 2, h / 2, 4, (adj ?? 12500) / 50000);
       break;
     case 'star5':
     case 'star':
-      drawStar(ctx, cx, cy, w / 2, h / 2, 5, 0.382);
+      drawStar(ctx, cx, cy, w / 2, h / 2, 5, (adj ?? 19098) / 50000);
       break;
     case 'star6':
-      drawStar(ctx, cx, cy, w / 2, h / 2, 6, 0.5, 0);
+      drawStar(ctx, cx, cy, w / 2, h / 2, 6, (adj ?? 28868) / 50000, 0);
       break;
     case 'star7':
-      drawStar(ctx, cx, cy, w / 2, h / 2, 7, 0.37);
+      drawStar(ctx, cx, cy, w / 2, h / 2, 7, (adj ?? 34142) / 50000);
       break;
     case 'star8':
       drawStar(ctx, cx, cy, w / 2, h / 2, 8, (adj ?? 37500) / 50000, -Math.PI / 2);
       break;
     case 'star10':
-      drawStar(ctx, cx, cy, w / 2, h / 2, 10, 0.45);
+      drawStar(ctx, cx, cy, w / 2, h / 2, 10, (adj ?? 41421) / 50000);
       break;
     case 'star12':
-      drawStar(ctx, cx, cy, w / 2, h / 2, 12, 0.45, 0);
+      drawStar(ctx, cx, cy, w / 2, h / 2, 12, (adj ?? 37500) / 50000, 0);
       break;
     case 'star16':
       drawStar(ctx, cx, cy, w / 2, h / 2, 16, (adj ?? 37500) / 50000, -Math.PI / 2);
       break;
     case 'star24':
-      drawStar(ctx, cx, cy, w / 2, h / 2, 24, 0.6, 0);
+      drawStar(ctx, cx, cy, w / 2, h / 2, 24, (adj ?? 37500) / 50000, 0);
       break;
     case 'star32':
       drawStar(ctx, cx, cy, w / 2, h / 2, 32, (adj ?? 37500) / 50000, -Math.PI / 2);


### PR DESCRIPTION
## Summary

All star shapes now use their ECMA-376 prstGeom `avLst` default `adj` values (`adj / 50000 = innerR / outerR`) and honour any per-shape `adj` override from the XML.

| Shape  | Old innerRatio | New innerRatio | OOXML adj |
|--------|---------------|---------------|-----------|
| star4  | 0.38  | **0.25**  | 12500 |
| star5  | 0.382 | 0.382 (unchanged) | 19098 |
| star6  | 0.50  | **0.577** | 28868 |
| star7  | 0.37  | **0.683** | 34142 |
| star8  | 0.75  | 0.75 (unchanged, already fixed) | 37500 |
| star10 | 0.45  | **0.828** | 41421 |
| star12 | 0.45  | **0.75**  | 37500 |
| star16 | 0.75  | 0.75 (unchanged, already fixed) | 37500 |
| star24 | 0.60  | **0.75**  | 37500 |
| star32 | 0.75  | 0.75 (unchanged, already fixed) | 37500 |

## Test plan

- [ ] Visually compare sample-3 slide 5 against PowerPoint reference — star6/7/10/12/24 should now have the correct shallow-spike appearance
- [ ] Run `pnpm vrt` to confirm no regressions on other slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)