### PR TITLE
Add DOCX session log for 2026-04-19

### DIFF
--- a/packages/docx/SESSION_LOG_2026-04-19.md
+++ b/packages/docx/SESSION_LOG_2026-04-19.md
@@ -1,0 +1,72 @@
+# DOCX セッションログ — 2026-04-19
+
+## 概要
+
+DOCX パッケージの継続実装セッション。P1/P2 機能追加、`<w:sdt>` コンテンツコントロール対応、および CI の Storybook ビルド失敗の修正を行った。
+
+## マージ済み PR
+
+| PR   | コミット    | 内容                                                              |
+| ---- | ----------- | ----------------------------------------------------------------- |
+| #8   | `5c241a9`   | Superscript/subscript、hyperlink URL、custom tab stops、mid-body section breaks |
+| #13  | `5ae924e`   | `<w:sdt>` / `<w:sdtContent>` ラッパーの透過展開                   |
+| #15  | `e6cd142`   | `packages/pptx/public/.gitkeep`（CI Storybook ビルド失敗の修正）  |
+
+## 主な成果
+
+### 1. P1/P2 機能追加 (PR #8)
+- Superscript / subscript (`w:vertAlign`)
+- Hyperlink URL の解決と色・下線のデフォルト適用
+- Custom tab stops (`w:tabs`)
+- Mid-body `<w:sectPr>` をページブレークとして扱う
+
+### 2. SDT コンテンツコントロール対応 (PR #13)
+**問題**: sample-3（Taylor Phillips 履歴書）のテーブルセルが空で描画されていた。
+**原因**: `<w:sdt>` / `<w:sdtContent>` ラッパー配下に約 84 の可視テキストブロックが隠れていた。
+**修正**:
+- `xml_util.rs` に `element_children_flat` / `children_w_flat` ヘルパー追加
+- `parser.rs` の 5 箇所 (body / paragraph / table / table-row / table-cell) で SDT を透過展開
+
+### 3. Storybook サンプルストーリーの pptx パターン踏襲
+- `Samples.sample.stories.ts` を `title: 'DocxViewer/Samples'` で作成 (gitignore 済み)
+- `makeSampleStory` ヘルパーと Vite `?url` インポートを採用
+
+### 4. CI 修正 (PR #15)
+- `packages/pptx/public/.gitkeep` を追加
+- Storybook の `staticDirs` が `packages/pptx/public` を参照するが、sample-*.pptx が gitignore されているため CI 上で空ディレクトリすら存在せずビルド失敗していた
+- docx/xlsx で既に採用されていた `.gitkeep` パターンと揃えた
+
+## 現在の VRT 状況 (sample-3)
+
+| ページ | actual size | ref size | match  | 判定   |
+| ------ | ----------- | -------- | ------ | ------ |
+| 1      | 595×841     | 595×842  | 8.0%   | fail   |
+| 2      | 595×841     | 595×842  | 85.4%  | pass   |
+| 3      | 595×841     | 595×842  | 85.2%  | pass   |
+
+page 1 はテキストは描画されるものの、page-1 ref にあるティール背景矩形・左サイドバーシェイプ・スコアバー等が未実装のため diff が大きい。
+
+## 残課題 (次回以降)
+
+### 優先度高
+1. **sample-3 ページ背景シェイプ (`wps:wsp` + `a:prstGeom rect`)**
+   - 左サイドバーのティール矩形、下部の装飾バー
+   - `wps:wsp` の `prstGeom val="rect"` を背景色塗り潰し矩形として描画
+2. **テーブルセル内テキスト折り返し**
+   - 現状 1 行に詰め込まれて隣接セルにオーバーフロー
+   - セル幅 (`tcW`) を上限にした word-wrap 実装が必要
+3. **sample-3 ページネーション**
+   - actual 画像がページ 1/2/3 とも同じ内容（page 1 の内容）になっている
+   - mid-body `<w:sectPr>` をページブレーク化済みだが、sample-3 はセクション区切りを使わず長い連続コンテンツのため自動改ページが必要
+   - 自動改ページは別途大きな工数 (現 MVP スコープ外)
+
+### 優先度中
+4. **P2-4 Heading styles の目視検証** (StyleMap 解決ロジック自体は実装済み、ユーザー提供サンプル待ち)
+5. **P3-6 Footnotes / endnotes** (MVP: 上付き番号のみ表示)
+
+## 運用メモ
+
+- `packages/pptx/public/.gitkeep` は docx/xlsx と同じく **コミット済み**
+- `packages/docx/src/*.sample.stories.ts` は gitignore 済み (個人作業用)
+- 別 worktree (`nifty-chaplygin-adb789`) が port 5180 を占有していたため、VRT 実行時は 5181 に切り替えた後に 5180 へ戻した
+- WASM は `.claude/worktrees/docx/packages/docx/src/wasm/` と `packages/docx/src/wasm/`（main worktree）の両方にコピーしている


### PR DESCRIPTION
## Summary
Day-end session log capturing PR #8 / #13 / #15 landings, current VRT status for sample-3, and outstanding shape/pagination work so the next session can resume without re-deriving context.

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)