### PR TITLE
fix: use BASE_URL prefix for demo story asset paths on GitHub Pages

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -20,6 +20,7 @@ const config: StorybookConfig = {
     const { default: wasm } = await import('vite-plugin-wasm');
     return {
       ...config,
+      base: process.env.GITHUB_ACTIONS ? '/office-open-xml-viewer/' : '/',
       plugins: [...(config.plugins ?? []), wasm()],
       worker: { format: 'es' as const, plugins: () => [wasm()] },
     };

--- a/packages/docx/src/Demo.stories.ts
+++ b/packages/docx/src/Demo.stories.ts
@@ -19,7 +19,7 @@ type Story = StoryObj<Args>;
 export const Demo: Story = {
   name: 'demo.docx',
   render(args) {
-    const { root } = buildViewerUI(args, '/docx/demo/sample-1.docx');
+    const { root } = buildViewerUI(args, `${import.meta.env.BASE_URL}docx/demo/sample-1.docx`);
     return root;
   },
 };

--- a/packages/pptx/src/Demo.stories.ts
+++ b/packages/pptx/src/Demo.stories.ts
@@ -19,7 +19,7 @@ type Story = StoryObj<Args>;
 export const Demo: Story = {
   name: 'demo.pptx',
   render(args) {
-    const { root } = buildViewerUI(args, '/pptx/demo/sample-1.pptx');
+    const { root } = buildViewerUI(args, `${import.meta.env.BASE_URL}pptx/demo/sample-1.pptx`);
     return root;
   },
 };

--- a/packages/xlsx/src/Demo.stories.ts
+++ b/packages/xlsx/src/Demo.stories.ts
@@ -19,7 +19,7 @@ type Story = StoryObj<Args>;
 export const Demo: Story = {
   name: 'demo.xlsx',
   render(args) {
-    const { root } = buildViewerUI(args, '/xlsx/demo/sample-1.xlsx');
+    const { root } = buildViewerUI(args, `${import.meta.env.BASE_URL}xlsx/demo/sample-1.xlsx`);
     return root;
   },
 };


### PR DESCRIPTION
## Summary

- Demo stories used absolute paths (`/pptx/demo/sample-1.pptx`) which resolve to the domain root on GitHub Pages, causing 404 errors
- Set Vite `base` to `/office-open-xml-viewer/` when building in GitHub Actions (`GITHUB_ACTIONS=true`)
- Prefix all demo story fetch URLs with `import.meta.env.BASE_URL` so they work at both `http://localhost:6006/` and `https://yukiyokotani.github.io/office-open-xml-viewer/`

## Test plan

- [ ] GitHub Actions deploy completes and demo stories load correctly on GitHub Pages
- [ ] Local `pnpm storybook` still works (BASE_URL = `/` by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)