### PR TITLE
feat(xlsx): enrich parser with indent, textRotation, shrinkToFit, diagonal borders

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -264,9 +264,15 @@ pub struct Border {
     pub right: Option<BorderEdge>,
     pub top: Option<BorderEdge>,
     pub bottom: Option<BorderEdge>,
+    /// Diagonal line from bottom-left to top-right (ECMA-376 §18.8.4 diagonalUp)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagonal_up: Option<BorderEdge>,
+    /// Diagonal line from top-left to bottom-right (ECMA-376 §18.8.4 diagonalDown)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagonal_down: Option<BorderEdge>,
 }
 
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BorderEdge {
     pub style: String,
@@ -283,6 +289,15 @@ pub struct CellXf {
     pub align_h: Option<String>,
     pub align_v: Option<String>,
     pub wrap_text: bool,
+    /// Text indentation level (each level ≈ 3 characters wide, ECMA-376 §18.8.44)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent: Option<u32>,
+    /// Text rotation in degrees: 0–90 = counter-clockwise, 91–180 = (value−90)° clockwise, 255 = stacked (ECMA-376 §18.8.44)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_rotation: Option<u32>,
+    /// Shrink text to fit the cell width (ECMA-376 §18.8.44)
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub shrink_to_fit: bool,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -826,20 +841,24 @@ fn parse_borders(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -
         if borders_node.tag_name().name() == "borders" && borders_node.tag_name().namespace() == Some(ns) {
             for border_node in borders_node.children() {
                 if border_node.tag_name().name() != "border" { continue; }
+                let has_diag_up = border_node.attribute("diagonalUp").map(|v| v == "1" || v == "true").unwrap_or(false);
+                let has_diag_down = border_node.attribute("diagonalDown").map(|v| v == "1" || v == "true").unwrap_or(false);
                 let mut b = Border::default();
+                let mut diag_edge: Option<BorderEdge> = None;
                 for edge_node in border_node.children() {
                     let style = edge_node.attribute("style").unwrap_or("").to_string();
-                    if style.is_empty() { continue; }
                     let color = edge_node.children().find(|c| c.is_element()).and_then(|c| parse_color(&c, theme_colors));
-                    let edge = Some(BorderEdge { style, color });
                     match edge_node.tag_name().name() {
-                        "left" => b.left = edge,
-                        "right" => b.right = edge,
-                        "top" => b.top = edge,
-                        "bottom" => b.bottom = edge,
+                        "left" if !style.is_empty() => b.left = Some(BorderEdge { style, color }),
+                        "right" if !style.is_empty() => b.right = Some(BorderEdge { style, color }),
+                        "top" if !style.is_empty() => b.top = Some(BorderEdge { style, color }),
+                        "bottom" if !style.is_empty() => b.bottom = Some(BorderEdge { style, color }),
+                        "diagonal" if !style.is_empty() => diag_edge = Some(BorderEdge { style, color }),
                         _ => {}
                     }
                 }
+                if has_diag_up { b.diagonal_up = diag_edge.clone(); }
+                if has_diag_down { b.diagonal_down = diag_edge; }
                 borders.push(b);
             }
             break;
@@ -861,14 +880,20 @@ fn parse_cell_xfs(doc: &roxmltree::Document, ns: &str) -> Vec<CellXf> {
                 let mut align_h = None;
                 let mut align_v = None;
                 let mut wrap_text = false;
+                let mut indent = None;
+                let mut text_rotation = None;
+                let mut shrink_to_fit = false;
                 for child in xf_node.children() {
                     if child.tag_name().name() == "alignment" {
                         align_h = child.attribute("horizontal").map(|s| s.to_string());
                         align_v = child.attribute("vertical").map(|s| s.to_string());
                         wrap_text = child.attribute("wrapText").map(|v| v == "1" || v == "true").unwrap_or(false);
+                        indent = child.attribute("indent").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
+                        text_rotation = child.attribute("textRotation").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
+                        shrink_to_fit = child.attribute("shrinkToFit").map(|v| v == "1" || v == "true").unwrap_or(false);
                     }
                 }
-                xfs.push(CellXf { font_id, fill_id, border_id, num_fmt_id, align_h, align_v, wrap_text });
+                xfs.push(CellXf { font_id, fill_id, border_id, num_fmt_id, align_h, align_v, wrap_text, indent, text_rotation, shrink_to_fit });
             }
             break;
         }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1,5 +1,5 @@
 import type {
-  Worksheet, Styles, Cell, CellValue, Font, Fill, Border, CellXf,
+  Worksheet, Styles, Cell, CellValue, Font, Fill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions,
   CfRule, CellRange, CfStop, CfValue, Dxf,
   Run, ChartData,
@@ -634,11 +634,14 @@ function renderQuadrant(
       const isNumeric = cell.value.type === 'number';
       const alignH = xf.alignH ?? (isNumeric ? 'right' : 'left');
       const alignV = xf.alignV ?? 'bottom';
+      // Indent: each level ≈ one character width (ECMA-376 §18.8.44)
+      const indentPx = xf.indent ? Math.round(xf.indent * font.size * ROW_HEIGHT_TO_PX * 0.5) : 0;
+      const leftPad = paddingX + (alignH === 'left' || !xf.alignH ? indentPx : 0);
 
       // Text overflow for left-aligned non-merged non-wrap cells
       let drawW = cellW;
       if (!mergeInfo && !xf.wrapText && alignH !== 'right' && alignH !== 'center') {
-        const textPx = ctx.measureText(text).width + paddingX * 2;
+        const textPx = ctx.measureText(text).width + leftPad + paddingX;
         if (textPx > cellW) {
           for (let oci = ci + 1; oci < numCols; oci++) {
             const adjKey = `${rowIndex}:${startCol + oci}`;
@@ -659,16 +662,64 @@ function renderQuadrant(
         textX = cx + cellW / 2;
         textAlign = 'center';
       } else {
-        textX = cx + paddingX;
+        textX = cx + leftPad;
         textAlign = 'left';
       }
 
-      ctx.textAlign = textAlign;
+      const rotation = xf.textRotation ?? 0;
+      const isStacked = rotation === 255;
+      const isRotated = rotation > 0 && rotation !== 255;
 
       ctx.save();
       ctx.beginPath();
       ctx.rect(cx, cy, drawW, cellH);
       ctx.clip();
+
+      // Stacked text (textRotation=255): draw each character on its own line
+      if (isStacked) {
+        const charH = Math.round(font.size * ROW_HEIGHT_TO_PX * 1.1);
+        const totalH = text.length * charH;
+        let charY = alignV === 'top' ? cy + paddingY
+          : alignV === 'center' ? cy + (cellH - totalH) / 2
+          : cy + cellH - totalH - paddingY;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        for (const ch of text) {
+          ctx.fillText(ch, cx + cellW / 2, charY);
+          charY += charH;
+        }
+        ctx.restore();
+        continue;
+      }
+
+      // Rotated text: translate to cell center, rotate, draw, restore
+      if (isRotated) {
+        const angleRad = rotation <= 90
+          ? -(rotation * Math.PI / 180)
+          : ((rotation - 90) * Math.PI / 180);
+        ctx.translate(cx + cellW / 2, cy + cellH / 2);
+        ctx.rotate(angleRad);
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(text, 0, 0);
+        ctx.restore();
+        continue;
+      }
+
+      // shrinkToFit: scale context horizontally if text is wider than cell
+      if (xf.shrinkToFit) {
+        const textW = ctx.measureText(text).width;
+        const availW = cellW - leftPad - paddingX;
+        if (textW > availW && textW > 0) {
+          const scale = availW / textW;
+          const pivotX = alignH === 'right' ? cx + cellW - paddingX
+            : alignH === 'center' ? cx + cellW / 2
+            : cx + leftPad;
+          ctx.transform(scale, 0, 0, 1, pivotX * (1 - scale), 0);
+        }
+      }
+
+      ctx.textAlign = textAlign;
 
       // Rich text: draw each run with its own font. Only supported for the
       // non-wrap path (wrap with mixed fonts is significantly more complex).
@@ -676,7 +727,7 @@ function renderQuadrant(
       const hasRichText = runs && runs.length > 0 && !xf.wrapText;
 
       if (xf.wrapText) {
-        const lines = wrapTextLines(ctx, text, cellW - paddingX * 2);
+        const lines = wrapTextLines(ctx, text, cellW - leftPad - paddingX);
         const lineH = Math.round(font.size * ROW_HEIGHT_TO_PX * 1.2);
         const totalTextH = lines.length * lineH;
         let startY: number;
@@ -697,7 +748,7 @@ function renderQuadrant(
         let startX: number;
         if (alignH === 'right') startX = cx + cellW - paddingX - totalWidth;
         else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
-        else startX = cx + paddingX;
+        else startX = cx + leftPad;
         // Use left alignment since we position each run ourselves
         ctx.textAlign = 'left';
         let textY: number;
@@ -743,11 +794,11 @@ function renderQuadrant(
         let overlayMetrics: TextMetrics | null = null;
         const measureOverlay = () => overlayMetrics ??= ctx.measureText(text);
         const overlayX = () => {
-          const tW = Math.min(measureOverlay().width, drawW - paddingX * 2);
+          const tW = Math.min(measureOverlay().width, drawW - leftPad - paddingX);
           return {
             x: alignH === 'right' ? cx + cellW - paddingX - tW
               : alignH === 'center' ? cx + cellW / 2 - tW / 2
-              : cx + paddingX,
+              : cx + leftPad,
             width: tW,
           };
         };
@@ -1227,22 +1278,21 @@ function renderImages(
 // Border drawing
 // ────────────────────────────────────────────────────────────────
 function renderBorder(ctx: CanvasRenderingContext2D, border: Border, x: number, y: number, w: number, h: number): void {
-  const edges = [
-    { edge: border.top,    x1: x,     y1: y,     x2: x + w, y2: y },
-    { edge: border.bottom, x1: x,     y1: y + h, x2: x + w, y2: y + h },
-    { edge: border.left,   x1: x,     y1: y,     x2: x,     y2: y + h },
-    { edge: border.right,  x1: x + w, y1: y,     x2: x + w, y2: y + h },
+  const edges: Array<{ edge: BorderEdge | null | undefined; x1: number; y1: number; x2: number; y2: number }> = [
+    { edge: border.top,         x1: x,     y1: y,     x2: x + w, y2: y },
+    { edge: border.bottom,      x1: x,     y1: y + h, x2: x + w, y2: y + h },
+    { edge: border.left,        x1: x,     y1: y,     x2: x,     y2: y + h },
+    { edge: border.right,       x1: x + w, y1: y,     x2: x + w, y2: y + h },
+    { edge: border.diagonalUp,  x1: x,     y1: y + h, x2: x + w, y2: y },
+    { edge: border.diagonalDown,x1: x,     y1: y,     x2: x + w, y2: y + h },
   ];
   for (const { edge, x1, y1, x2, y2 } of edges) {
     if (!edge || !edge.style || edge.style === 'none') continue;
     ctx.beginPath();
     ctx.strokeStyle = edge.color ? hexToRgba(edge.color) : '#000000';
     ctx.lineWidth = borderStyleWidth(edge.style);
-    if (edge.style === 'dashed' || edge.style === 'dotted' || edge.style === 'dashDot') {
-      ctx.setLineDash(edge.style === 'dotted' ? [2, 2] : [4, 2]);
-    } else {
-      ctx.setLineDash([]);
-    }
+    const dash = borderStyleDash(edge.style);
+    ctx.setLineDash(dash);
     ctx.moveTo(x1, y1);
     ctx.lineTo(x2, y2);
     ctx.stroke();
@@ -1252,9 +1302,21 @@ function renderBorder(ctx: CanvasRenderingContext2D, border: Border, x: number, 
 
 function borderStyleWidth(style: string): number {
   switch (style) {
-    case 'thick': return 0.5;
-    case 'medium': case 'mediumDashed': case 'mediumDashDot': return 0.5;
-    default: return 0.5;
+    case 'thick': return 2;
+    case 'medium': case 'mediumDashed': case 'mediumDashDot': case 'mediumDashDotDot': case 'slantDashDot': return 1.5;
+    case 'hair': return 0.5;
+    default: return 1;
+  }
+}
+
+function borderStyleDash(style: string): number[] {
+  switch (style) {
+    case 'dashed': case 'mediumDashed': return [4, 3];
+    case 'dotted': return [2, 2];
+    case 'dashDot': case 'mediumDashDot': return [4, 2, 1, 2];
+    case 'dashDotDot': case 'mediumDashDotDot': return [4, 2, 1, 2, 1, 2];
+    case 'slantDashDot': return [5, 3, 1, 3];
+    default: return [];
   }
 }
 

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -189,6 +189,8 @@ export interface Border {
   right: BorderEdge | null;
   top: BorderEdge | null;
   bottom: BorderEdge | null;
+  diagonalUp?: BorderEdge | null;
+  diagonalDown?: BorderEdge | null;
 }
 
 export interface BorderEdge {
@@ -204,6 +206,11 @@ export interface CellXf {
   alignH: string | null;
   alignV: string | null;
   wrapText: boolean;
+  /** Indentation level (each level ≈ 3 characters, ECMA-376 §18.8.44) */
+  indent?: number;
+  /** Text rotation: 1–90 = counter-clockwise °, 91–180 = (val−90)° clockwise, 255 = stacked */
+  textRotation?: number;
+  shrinkToFit?: boolean;
 }
 
 export interface ParsedWorkbook {


### PR DESCRIPTION
## Summary

ECMA-376 仕様に基づき、XLSXパーサーとレンダラーを拡充しました。

### Parser (Rust `lib.rs`)
- **`CellXf`**: `<alignment>` から `indent`・`textRotation`・`shrinkToFit` を解析 (§18.8.44)
- **`Border`**: `<border diagonalUp/Down>` 属性と `<diagonal>` 要素から対角線ボーダーを解析 (§18.8.4)
- **`BorderEdge`**: `Clone` derive を追加（対角線エッジの共有に必要）

### Types (TypeScript `types.ts`)
- `CellXf`: `indent?`, `textRotation?`, `shrinkToFit?` フィールド追加
- `Border`: `diagonalUp?`, `diagonalDown?` フィールド追加

### Renderer (`renderer.ts`)
- **indent**: フォントサイズ基準の左パディングを各レベルに適用
- **textRotation 1–90**: Canvas を反時計回りに回転
- **textRotation 91–180**: Canvas を時計回りに (value−90)° 回転
- **textRotation 255**: 文字を縦積み（スタック）描画
- **shrinkToFit**: テキスト幅がセル幅を超えた場合に水平スケール
- **diagonalUp/Down**: 対角線ボーダーの描画
- **borderStyleWidth**: thin=1px, medium=1.5px, thick=2px, hair=0.5px に修正
- **borderStyleDash**: ECMA-376 ボーダースタイル名に対応した正しいダッシュパターン

## Test plan

- [ ] インデントを持つセルで左パディングが正しく表示される
- [ ] `textRotation` を持つセルで文字が回転して表示される (45°, 90°, 255=スタック)
- [ ] `shrinkToFit` が設定されたセルで長いテキストが縮小される
- [ ] `diagonalUp`/`diagonalDown` ボーダーが対角線として描画される
- [ ] 各ボーダースタイル (thin/medium/thick/dashed/dotted 等) の太さが正しく描画される
- [ ] `pnpm typecheck` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)