### PR TITLE
Add 6 XLSX parser features per ECMA-376 (showZeros, autoFilter, hyperlinks, iconSet CF, etc.)

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -42,6 +42,16 @@ pub struct Worksheet {
     pub conditional_formats: Vec<ConditionalFormat>,
     pub images: Vec<ImageAnchor>,
     pub charts: Vec<ChartAnchor>,
+    /// Whether to display zero values in cells (ECMA-376 §18.3.1.94)
+    pub show_zeros: bool,
+    /// Tab color for the sheet tab (ECMA-376 §18.3.1.79)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tab_color: Option<String>,
+    /// AutoFilter range (ECMA-376 §18.3.1.2)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_filter: Option<CellRange>,
+    /// Hyperlinks in this worksheet (ECMA-376 §18.3.1.47)
+    pub hyperlinks: Vec<Hyperlink>,
 }
 
 // ─── Chart types ────────────────────────────────────────────────────────────
@@ -136,6 +146,9 @@ pub enum CfRule {
     Expression { formula: String, dxf_id: Option<u32>, priority: i32 },
     ColorScale { stops: Vec<CfStop>, priority: i32 },
     DataBar { color: String, min: CfValue, max: CfValue, priority: i32 },
+    Top10 { top: bool, percent: bool, rank: u32, dxf_id: Option<u32>, priority: i32 },
+    AboveAverage { above_average: bool, dxf_id: Option<u32>, priority: i32 },
+    IconSet { icon_set: String, cfvos: Vec<CfValue>, reverse: bool, priority: i32 },
     Other { kind: String, priority: i32 },
 }
 
@@ -152,6 +165,14 @@ pub struct CfStop {
 pub struct CfValue {
     pub kind: String,
     pub value: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Hyperlink {
+    pub col: u32,
+    pub row: u32,
+    pub url: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -359,12 +380,13 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     let theme_colors = parse_theme_colors(&mut archive);
     let shared_strings = read_shared_strings(&mut archive, &theme_colors);
     let sheet_xml = read_zip_entry(&mut archive, &format!("xl/{}", sheet_path))?;
-    let mut ws = parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
+    let (mut ws, hyperlink_rids) = parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
         .map_err(|e| e.to_string())?;
 
     // Attach any drawing-anchored images and charts for this sheet
     ws.images = load_sheet_images(&mut archive, &sheet_path);
     ws.charts = load_sheet_charts(&mut archive, &sheet_path);
+    ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -906,9 +928,10 @@ fn parse_worksheet(
     shared_strings: &[SharedString],
     theme_colors: &[String],
     name: &str,
-) -> Result<Worksheet, String> {
+) -> Result<(Worksheet, Vec<(u32, u32, String)>), String> {
     let doc = roxmltree::Document::parse(xml).map_err(|e| e.to_string())?;
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
     let mut rows = Vec::new();
     let mut col_widths: HashMap<u32, f64> = HashMap::new();
@@ -919,6 +942,10 @@ fn parse_worksheet(
     let mut default_col_width = 8.43;
     let mut default_row_height = 15.0;
     let mut conditional_formats: Vec<ConditionalFormat> = Vec::new();
+    let mut show_zeros = true;
+    let mut tab_color: Option<String> = None;
+    let mut auto_filter: Option<CellRange> = None;
+    let mut hyperlink_rids: Vec<(u32, u32, String)> = Vec::new();
 
     for node in doc.descendants() {
         match node.tag_name().name() {
@@ -946,6 +973,40 @@ fn parse_worksheet(
                 };
                 for c in min..=max {
                     col_widths.insert(c, width);
+                }
+            }
+            "sheetView" if node.tag_name().namespace() == Some(ns) => {
+                show_zeros = node.attribute("showZeros").map(|v| v != "0").unwrap_or(true);
+            }
+            "tabColor" if node.tag_name().namespace() == Some(ns) => {
+                tab_color = parse_color(&node, theme_colors);
+            }
+            "autoFilter" if node.tag_name().namespace() == Some(ns) => {
+                if let Some(r) = node.attribute("ref") {
+                    let parts: Vec<&str> = r.split(':').collect();
+                    auto_filter = if parts.len() == 2 {
+                        let (left, top) = parse_cell_ref(parts[0]);
+                        let (right, bottom) = parse_cell_ref(parts[1]);
+                        Some(CellRange { top, left, bottom, right })
+                    } else {
+                        let (col, row) = parse_cell_ref(parts[0]);
+                        Some(CellRange { top: row, left: col, bottom: row, right: col })
+                    };
+                }
+            }
+            "hyperlinks" if node.tag_name().namespace() == Some(ns) => {
+                for hl in node.children() {
+                    if !hl.is_element() || hl.tag_name().name() != "hyperlink" { continue; }
+                    let Some(ref_str) = hl.attribute("ref") else { continue };
+                    // Only first cell of ref range
+                    let ref_single = ref_str.split(':').next().unwrap_or(ref_str);
+                    let (col, row) = parse_cell_ref(ref_single);
+                    if let Some(rid) = hl.attributes()
+                        .find(|a| a.name() == "id" && a.namespace() == Some(r_ns))
+                        .map(|a| a.value().to_string())
+                    {
+                        hyperlink_rids.push((col, row, rid));
+                    }
                 }
             }
             "pane" if node.tag_name().namespace() == Some(ns) => {
@@ -1065,6 +1126,38 @@ fn parse_worksheet(
                                 .unwrap_or(CfValue { kind: "max".into(), value: None });
                             rules.push(CfRule::DataBar { color, min, max, priority });
                         }
+                        "top10" => {
+                            let top = !cf.attribute("bottom").map(|v| v == "1" || v == "true").unwrap_or(false);
+                            let percent = cf.attribute("percent").map(|v| v == "1" || v == "true").unwrap_or(false);
+                            let rank = cf.attribute("rank").and_then(|s| s.parse().ok()).unwrap_or(10);
+                            rules.push(CfRule::Top10 { top, percent, rank, dxf_id, priority });
+                        }
+                        "aboveAverage" => {
+                            let above_average = cf.attribute("aboveAverage").map(|v| v != "0").unwrap_or(true);
+                            rules.push(CfRule::AboveAverage { above_average, dxf_id, priority });
+                        }
+                        "iconSet" => {
+                            let icon_set_node = cf.children().find(|n| n.tag_name().name() == "iconSet");
+                            let icon_set = icon_set_node
+                                .and_then(|n| n.attribute("iconSet"))
+                                .unwrap_or("3TrafficLights1")
+                                .to_string();
+                            let reverse = icon_set_node
+                                .and_then(|n| n.attribute("reverse"))
+                                .map(|v| v == "1" || v == "true")
+                                .unwrap_or(false);
+                            let cfvos: Vec<CfValue> = icon_set_node
+                                .map(|n| n.children()
+                                    .filter(|c| c.is_element() && c.tag_name().name() == "cfvo")
+                                    .map(|c| CfValue {
+                                        kind: c.attribute("type").unwrap_or("percent").to_string(),
+                                        value: c.attribute("val").map(|s| s.to_string()),
+                                    })
+                                    .collect()
+                                )
+                                .unwrap_or_default();
+                            rules.push(CfRule::IconSet { icon_set, cfvos, reverse, priority });
+                        }
                         other => {
                             rules.push(CfRule::Other { kind: other.to_string(), priority });
                         }
@@ -1076,7 +1169,7 @@ fn parse_worksheet(
         }
     }
 
-    Ok(Worksheet {
+    Ok((Worksheet {
         name: name.to_string(),
         rows,
         col_widths,
@@ -1089,7 +1182,11 @@ fn parse_worksheet(
         conditional_formats,
         images: Vec::new(),
         charts: Vec::new(),
-    })
+        show_zeros,
+        tab_color,
+        auto_filter,
+        hyperlinks: Vec::new(),
+    }, hyperlink_rids))
 }
 
 /// Parse a .rels file into rId → Target map.
@@ -1104,6 +1201,24 @@ fn parse_rels_map(xml: &str) -> HashMap<String, String> {
         }
     }
     map
+}
+
+/// Resolve hyperlink rIds to URLs from the sheet rels file.
+fn load_hyperlinks(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_path: &str,
+    hyperlink_rids: Vec<(u32, u32, String)>,
+) -> Vec<Hyperlink> {
+    if hyperlink_rids.is_empty() { return Vec::new(); }
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    let rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+    let rels = read_zip_entry(archive, &rels_path)
+        .ok()
+        .map(|xml| parse_rels_map(&xml))
+        .unwrap_or_default();
+    hyperlink_rids.into_iter().map(|(col, row, rid)| Hyperlink {
+        col, row, url: rels.get(&rid).cloned(),
+    }).collect()
 }
 
 /// Read a binary file from the zip.

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   Worksheet, Styles, Cell, CellValue, Font, Fill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions,
-  CfRule, CellRange, CfStop, CfValue, Dxf,
+  CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink,
   Run, ChartData,
 } from './types.js';
 
@@ -328,9 +328,14 @@ interface CompiledCfRule {
   sqref: CellRange[];
   scaleMin?: number;
   scaleMax?: number;
-  scaleStops?: number[];  // numeric values at each color stop
+  scaleStops?: number[];
   barMin?: number;
   barMax?: number;
+  top10Threshold?: number;
+  top10IsTop?: boolean;
+  avgValue?: number;
+  avgIsAbove?: boolean;
+  iconThresholds?: number[];
 }
 
 interface CfContext {
@@ -343,6 +348,7 @@ interface CfResult {
   fontBold?: boolean;
   fontItalic?: boolean;
   dataBar?: { color: string; ratio: number };
+  iconSet?: { name: string; index: number };
 }
 
 function rangeContains(ranges: CellRange[], row: number, col: number): boolean {
@@ -403,6 +409,27 @@ function compileCf(worksheet: Worksheet): CfContext {
       } else if (rule.type === 'dataBar') {
         entry.barMin = resolveCfvoValue(rule.min, samples);
         entry.barMax = resolveCfvoValue(rule.max, samples);
+      } else if (rule.type === 'top10') {
+        const sorted = [...samples].sort((a, b) => a - b);
+        const n = sorted.length;
+        if (n > 0) {
+          const rank = Math.min(rule.rank, n);
+          if (rule.percent) {
+            const p = rule.top ? (1 - rank / 100) : (rank / 100);
+            const idx = Math.max(0, Math.min(n - 1, Math.round(p * (n - 1))));
+            entry.top10Threshold = sorted[idx];
+          } else {
+            entry.top10Threshold = rule.top ? sorted[Math.max(0, n - rank)] : sorted[Math.min(n - 1, rank - 1)];
+          }
+          entry.top10IsTop = rule.top;
+        }
+      } else if (rule.type === 'aboveAverage') {
+        if (samples.length > 0) {
+          entry.avgValue = samples.reduce((a, b) => a + b, 0) / samples.length;
+          entry.avgIsAbove = rule.aboveAverage;
+        }
+      } else if (rule.type === 'iconSet') {
+        entry.iconThresholds = rule.cfvos.map(cfv => resolveCfvoValue(cfv, samples));
       }
       compiled.push(entry);
     }
@@ -456,6 +483,14 @@ function colorScaleAt(num: number, stops: CfStop[], stopValues: number[]): strin
   return stops[stops.length - 1].color;
 }
 
+function applyDxfToResult(result: CfResult, dxf: Dxf | null | undefined): void {
+  if (!dxf) return;
+  if (dxf.fill?.fgColor) result.fill = dxf.fill;
+  if (dxf.font?.color) result.fontColor = dxf.font.color;
+  if (dxf.font?.bold) result.fontBold = true;
+  if (dxf.font?.italic) result.fontItalic = true;
+}
+
 function evaluateCf(cell: Cell | undefined, row: number, col: number, cfCtx: CfContext, dxfs: Dxf[]): CfResult {
   const result: CfResult = {};
   if (!cfCtx.compiled.length) return result;
@@ -468,12 +503,26 @@ function evaluateCf(cell: Cell | undefined, row: number, col: number, cfCtx: CfC
       if (numVal == null) continue;
       const args = rule.formulas.map(f => parseFloat(f)).filter(n => !isNaN(n));
       if (cellIsMatch(numVal, rule.operator, args)) {
-        const dxf = rule.dxfId != null ? dxfs[rule.dxfId] : null;
-        if (dxf?.fill?.fgColor) result.fill = dxf.fill;
-        if (dxf?.font?.color) result.fontColor = dxf.font.color;
-        if (dxf?.font?.bold) result.fontBold = true;
-        if (dxf?.font?.italic) result.fontItalic = true;
+        applyDxfToResult(result, rule.dxfId != null ? dxfs[rule.dxfId] : null);
       }
+    } else if (rule.type === 'top10') {
+      if (numVal == null || entry.top10Threshold == null) continue;
+      const matches = entry.top10IsTop ? numVal >= entry.top10Threshold : numVal <= entry.top10Threshold;
+      if (matches) applyDxfToResult(result, rule.dxfId != null ? dxfs[rule.dxfId] : null);
+    } else if (rule.type === 'aboveAverage') {
+      if (numVal == null || entry.avgValue == null) continue;
+      const matches = entry.avgIsAbove ? numVal > entry.avgValue : numVal < entry.avgValue;
+      if (matches) applyDxfToResult(result, rule.dxfId != null ? dxfs[rule.dxfId] : null);
+    } else if (rule.type === 'iconSet') {
+      if (numVal == null || !entry.iconThresholds?.length) continue;
+      const thresholds = entry.iconThresholds;
+      const n = thresholds.length;
+      let iconIdx = 0;
+      for (let i = 1; i < n; i++) {
+        if (numVal >= thresholds[i]) iconIdx = i;
+      }
+      if (rule.reverse) iconIdx = n - 1 - iconIdx;
+      result.iconSet = { name: rule.iconSet, index: iconIdx };
     } else if (rule.type === 'colorScale') {
       if (numVal == null || !entry.scaleStops) continue;
       const color = colorScaleAt(numVal, rule.stops, entry.scaleStops);
@@ -498,16 +547,76 @@ interface RenderContext {
   mergeAnchorMap: Map<string, { totalW: number; totalH: number }>;
   mergeSkipSet: Set<string>;
   cfContext: CfContext;
-  colWidths: number[];  // widths of scrollable cols (viewport.col..)
-  rowHeights: number[]; // heights of scrollable rows (viewport.row..)
-  frozenColWidths: number[];  // widths of frozen cols (cols 1..freezeCols)
-  frozenRowHeights: number[]; // heights of frozen rows (rows 1..freezeRows)
+  colWidths: number[];
+  rowHeights: number[];
+  frozenColWidths: number[];
+  frozenRowHeights: number[];
   frozenW: number;
   frozenH: number;
-  startRow: number;  // first scrollable row index
-  startCol: number;  // first scrollable col index
-  cs: number;        // cell scale factor (default 1)
-  dpr: number;       // device pixel ratio
+  startRow: number;
+  startCol: number;
+  cs: number;
+  dpr: number;
+  autoFilterCells: Set<string>;
+  hyperlinkMap: Map<string, string>;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Icon Set drawing
+// ────────────────────────────────────────────────────────────────
+const ICON_COLORS_3 = ['#FF0000', '#FFFF00', '#00B050'];
+const ICON_COLORS_4 = ['#FF0000', '#FF6600', '#FFFF00', '#00B050'];
+const ICON_COLORS_5 = ['#FF0000', '#FF6600', '#FFFF00', '#92D050', '#00B050'];
+
+function drawCfIcon(ctx: CanvasRenderingContext2D, name: string, index: number, x: number, y: number, sz: number): void {
+  const nIcons = parseInt(name[0]) || 3;
+  const palette = nIcons === 5 ? ICON_COLORS_5 : nIcons === 4 ? ICON_COLORS_4 : ICON_COLORS_3;
+  const color = palette[Math.max(0, Math.min(index, palette.length - 1))];
+  ctx.save();
+  ctx.fillStyle = color;
+  if (name.includes('Arrow')) {
+    const half = sz / 2;
+    ctx.beginPath();
+    if (index === nIcons - 1) {
+      ctx.moveTo(x + half, y); ctx.lineTo(x + sz, y + sz); ctx.lineTo(x, y + sz);
+    } else if (index === 0) {
+      ctx.moveTo(x, y); ctx.lineTo(x + sz, y); ctx.lineTo(x + half, y + sz);
+    } else {
+      ctx.moveTo(x, y + sz * 0.3); ctx.lineTo(x + sz, y + half); ctx.lineTo(x, y + sz * 0.7);
+    }
+    ctx.closePath();
+    ctx.fill();
+  } else if (name.includes('Flag')) {
+    ctx.beginPath();
+    ctx.moveTo(x, y); ctx.lineTo(x + sz, y); ctx.lineTo(x, y + sz);
+    ctx.closePath();
+    ctx.fill();
+  } else {
+    ctx.beginPath();
+    ctx.arc(x + sz / 2, y + sz / 2, sz / 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function drawAutoFilterArrow(ctx: CanvasRenderingContext2D, cx: number, cy: number, cw: number, ch: number): void {
+  const sz = Math.max(6, Math.round(Math.min(cw, ch) * 0.45));
+  const x = cx + cw - sz - 1;
+  const y = cy + ch - sz - 1;
+  ctx.save();
+  ctx.fillStyle = '#D0D0D0';
+  ctx.fillRect(x, y, sz, sz);
+  ctx.fillStyle = '#444444';
+  const tri = sz * 0.55;
+  const tx = x + (sz - tri) / 2;
+  const ty = y + (sz - tri * 0.5) / 2;
+  ctx.beginPath();
+  ctx.moveTo(tx, ty);
+  ctx.lineTo(tx + tri, ty);
+  ctx.lineTo(tx + tri / 2, ty + tri * 0.5);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -616,9 +725,14 @@ function renderQuadrant(
       // Cell borders
       renderBorder(ctx, border, cx, cy, cellW, cellH);
 
+      // AutoFilter dropdown indicator
+      if (rc.autoFilterCells.has(key)) {
+        drawAutoFilterArrow(ctx, cx, cy, cw, cellH);
+      }
+
       if (!cell) continue;
       const text = formatCellValue(cell, styles);
-      if (!text) continue;
+      if (!text || (text === '0' && rc.worksheet.showZeros === false)) continue;
 
       const effectiveBold = font.bold || !!cf.fontBold;
       const effectiveItalic = font.italic || !!cf.fontItalic;
@@ -626,7 +740,8 @@ function renderQuadrant(
         ? { ...font, bold: effectiveBold, italic: effectiveItalic }
         : font;
       ctx.font = buildFont(fontForDraw, cs);
-      const textColor = cf.fontColor ?? font.color;
+      const hyperlinkUrl = rc.hyperlinkMap.get(key);
+      const textColor = hyperlinkUrl ? '#0563C1' : (cf.fontColor ?? font.color);
       ctx.fillStyle = textColor ? hexToRgba(textColor) : '#000000';
 
       const paddingX = 3;
@@ -636,7 +751,10 @@ function renderQuadrant(
       const alignV = xf.alignV ?? 'bottom';
       // Indent: each level ≈ one character width (ECMA-376 §18.8.44)
       const indentPx = xf.indent ? Math.round(xf.indent * font.size * ROW_HEIGHT_TO_PX * 0.5) : 0;
-      const leftPad = paddingX + (alignH === 'left' || !xf.alignH ? indentPx : 0);
+      // IconSet: reserve space on the left for the icon
+      const iconSz = cf.iconSet ? Math.max(8, Math.round(Math.min(cellW, cellH) * 0.55)) : 0;
+      const iconPad = iconSz > 0 ? iconSz + 4 : 0;
+      const leftPad = paddingX + (alignH === 'left' || !xf.alignH ? indentPx : 0) + iconPad;
 
       // Text overflow for left-aligned non-merged non-wrap cells
       let drawW = cellW;
@@ -669,6 +787,16 @@ function renderQuadrant(
       const rotation = xf.textRotation ?? 0;
       const isStacked = rotation === 255;
       const isRotated = rotation > 0 && rotation !== 255;
+
+      // Draw icon set icon (before text clip block)
+      if (cf.iconSet && iconSz > 0) {
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(cx, cy, cellW, cellH);
+        ctx.clip();
+        drawCfIcon(ctx, cf.iconSet.name, cf.iconSet.index, cx + 2, cy + (cellH - iconSz) / 2, iconSz);
+        ctx.restore();
+      }
 
       ctx.save();
       ctx.beginPath();
@@ -804,7 +932,7 @@ function renderQuadrant(
         };
         const sizePx = Math.round(font.size * ROW_HEIGHT_TO_PX);
 
-        if (font.underline) {
+        if (font.underline || hyperlinkUrl) {
           const { x: ux, width: tW } = overlayX();
           const uy = alignV === 'top'
             ? cy + paddingY + sizePx + 1
@@ -812,7 +940,7 @@ function renderQuadrant(
               ? cy + cellH / 2 + Math.round(sizePx * 0.55)
               : cy + cellH - paddingY + 1;
           ctx.save();
-          ctx.strokeStyle = font.color ? hexToRgba(font.color) : '#000000';
+          ctx.strokeStyle = hyperlinkUrl ? '#0563C1' : (font.color ? hexToRgba(font.color) : '#000000');
           ctx.lineWidth = 0.5;
           ctx.beginPath(); ctx.moveTo(ux, uy); ctx.lineTo(ux + tW, uy); ctx.stroke();
           ctx.restore();
@@ -927,6 +1055,21 @@ export function renderViewport(
 
   const cfContext = compileCf(worksheet);
 
+  // Build autoFilter indicator cell set
+  const autoFilterCells = new Set<string>();
+  if (worksheet.autoFilter) {
+    const af = worksheet.autoFilter;
+    for (let c = af.left; c <= af.right; c++) {
+      autoFilterCells.add(`${af.top}:${c}`);
+    }
+  }
+
+  // Build hyperlink lookup map
+  const hyperlinkMap = new Map<string, string>();
+  for (const hl of worksheet.hyperlinks ?? []) {
+    if (hl.url) hyperlinkMap.set(`${hl.row}:${hl.col}`, hl.url);
+  }
+
   const rc: RenderContext = {
     worksheet, styles, cellMap, mergeAnchorMap, mergeSkipSet, cfContext,
     colWidths: scrollColWidths,
@@ -936,6 +1079,8 @@ export function renderViewport(
     startRow, startCol,
     cs,
     dpr,
+    autoFilterCells,
+    hyperlinkMap,
   };
 
   // Canvas areas for each quadrant

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -28,6 +28,14 @@ export interface Worksheet {
   conditionalFormats: ConditionalFormat[];
   images: ImageAnchor[];
   charts: ChartAnchor[];
+  /** Whether to display zero values (ECMA-376 §18.3.1.94). Defaults to true. */
+  showZeros?: boolean;
+  /** Sheet tab color (ECMA-376 §18.3.1.79). */
+  tabColor?: string | null;
+  /** AutoFilter header range (ECMA-376 §18.3.1.2). */
+  autoFilter?: CellRange | null;
+  /** Hyperlinks in this worksheet (ECMA-376 §18.3.1.47). */
+  hyperlinks?: Hyperlink[];
 }
 
 // ─── Chart types ─────────────────────────────────────────────────────────────
@@ -84,6 +92,12 @@ export interface CellRange {
   right: number;
 }
 
+export interface Hyperlink {
+  col: number;
+  row: number;
+  url: string | null;
+}
+
 export interface ConditionalFormat {
   sqref: CellRange[];
   rules: CfRule[];
@@ -94,6 +108,9 @@ export type CfRule =
   | { type: 'expression'; formula: string; dxfId: number | null; priority: number }
   | { type: 'colorScale'; stops: CfStop[]; priority: number }
   | { type: 'dataBar'; color: string; min: CfValue; max: CfValue; priority: number }
+  | { type: 'top10'; top: boolean; percent: boolean; rank: number; dxfId: number | null; priority: number }
+  | { type: 'aboveAverage'; aboveAverage: boolean; dxfId: number | null; priority: number }
+  | { type: 'iconSet'; iconSet: string; cfvos: CfValue[]; reverse: boolean; priority: number }
   | { type: 'other'; kind: string; priority: number };
 
 export interface CfStop {


### PR DESCRIPTION
## Summary

Implements 6 XLSX worksheet features per ECMA-376 §18:

- **showZeros** (§18.3.1.94): Parse `<sheetView showZeros="0">` and skip rendering cells with value `"0"` when disabled
- **tabColor** (§18.3.1.79): Parse `<sheetPr><tabColor>` into `Worksheet.tabColor` (API surface for UI use)
- **autoFilter** (§18.3.1.2): Parse `<autoFilter ref="...">` and draw ▾ dropdown indicators on header cells
- **hyperlinks** (§18.3.1.47): Parse `<hyperlinks>`, resolve URLs from sheet `.rels`, render cells in blue with underline
- **top10/aboveAverage CF** (§18.3.1.44): Compute column statistics at compile time, evaluate and apply dxf styling
- **iconSet CF** (§18.3.1.44): Compute per-icon thresholds, draw colored circle/arrow/flag icons left of cell text

## Implementation details

**Rust parser (`lib.rs`)**:
- Added `Hyperlink` struct, `show_zeros`/`tab_color`/`auto_filter`/`hyperlinks` to `Worksheet`
- Added `Top10`, `AboveAverage`, `IconSet` variants to `CfRule`
- `parse_worksheet` now returns `(Worksheet, hyperlink_rids)` tuple; `parse_sheet` resolves URLs via `load_hyperlinks`

**TypeScript types (`types.ts`)**:
- Added `Hyperlink` interface, new optional `Worksheet` fields
- Extended `CfRule` union with `top10`, `aboveAverage`, `iconSet` variants

**Renderer (`renderer.ts`)**:
- `applyDxfToResult` helper to reduce `cellIs`/`top10`/`aboveAverage` duplication
- `compileCf`: compute thresholds for top10/aboveAverage/iconSet
- `evaluateCf`: evaluate all new rule types
- `drawCfIcon`: draw TrafficLight circles / Arrow triangles / Flag shapes
- `drawAutoFilterArrow`: draw small ▾ button at cell bottom-right
- `RenderContext`: added `autoFilterCells` and `hyperlinkMap`

## Test plan

- [ ] Open a XLSX with `autoFilter` — header row should show ▾ in each column
- [ ] Open a XLSX with `hyperlinks` — linked cells should appear blue with underline
- [ ] Open a XLSX with `top10`/`aboveAverage` CF — correct cells should be highlighted
- [ ] Open a XLSX with `iconSet` CF — colored icons appear left of cell values
- [ ] Open a XLSX with `showZeros=false` — zero-value cells appear empty
- [ ] TypeScript typecheck passes: `pnpm --filter @silurus/ooxml-xlsx typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)