### PR TITLE
feat(docx): enrich parser and renderer with display properties

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -317,6 +317,14 @@ fn parse_paragraph(
         numbering,
         tab_stops,
         runs,
+        shading: base_para.shading.clone(),
+        page_break_before: base_para.page_break_before.unwrap_or(false),
+        contextual_spacing: base_para.contextual_spacing.unwrap_or(false),
+        borders: base_para.para_borders.clone(),
+        style_id: ppr_node
+            .and_then(|p| child_w(p, "pStyle"))
+            .and_then(|s| attr_w(s, "val"))
+            .or_else(|| Some("Normal".to_string())),
     }
 }
 
@@ -486,6 +494,10 @@ fn make_field_run(instr: &str, fmt: &RunFmt, fallback: &str) -> DocRun {
         font_family: fmt.font_family_ascii.clone().or(fmt.font_family_east_asia.clone()),
         background: fmt.background.clone(),
         vert_align: fmt.vert_align.clone(),
+        all_caps: fmt.all_caps.unwrap_or(false),
+        small_caps: fmt.small_caps.unwrap_or(false),
+        double_strikethrough: fmt.dstrike.unwrap_or(false),
+        highlight: fmt.highlight.clone(),
     })
 }
 
@@ -520,6 +532,9 @@ fn parse_run_inner(
         apply_direct_run(&mut fmt, &direct);
     }
 
+    // Skip hidden runs entirely
+    if fmt.vanish.unwrap_or(false) { return; }
+
     let is_link = link_href.is_some();
     let hyperlink = link_href.clone().flatten();
 
@@ -535,6 +550,10 @@ fn parse_run_inner(
     };
     let font_family = fmt.font_family_ascii.clone().or(fmt.font_family_east_asia.clone());
     let vert_align = fmt.vert_align.clone();
+    let all_caps = fmt.all_caps.unwrap_or(false);
+    let small_caps = fmt.small_caps.unwrap_or(false);
+    let double_strikethrough = fmt.dstrike.unwrap_or(false);
+    let highlight = fmt.highlight.clone();
 
     for child in node.children().filter(|n| n.is_element()) {
         match child.tag_name().name() {
@@ -554,6 +573,10 @@ fn parse_run_inner(
                         background: fmt.background.clone(),
                         vert_align: vert_align.clone(),
                         hyperlink: hyperlink.clone(),
+                        all_caps,
+                        small_caps,
+                        double_strikethrough,
+                        highlight: highlight.clone(),
                     }));
                 }
             }
@@ -572,6 +595,10 @@ fn parse_run_inner(
                     background: fmt.background.clone(),
                     vert_align: vert_align.clone(),
                     hyperlink: hyperlink.clone(),
+                    all_caps,
+                    small_caps,
+                    double_strikethrough,
+                    highlight: highlight.clone(),
                 }));
             }
             "br" => {

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -16,6 +16,16 @@ pub struct RunFmt {
     pub background: Option<String>,   // hex 6
     /// "super" | "sub" — mapped from w:vertAlign val="superscript|subscript"
     pub vert_align: Option<String>,
+    /// All caps (w:caps)
+    pub all_caps: Option<bool>,
+    /// Small capitals (w:smallCaps)
+    pub small_caps: Option<bool>,
+    /// Double strikethrough (w:dstrike)
+    pub dstrike: Option<bool>,
+    /// Hidden text — run should not be rendered (w:vanish / w:webHidden)
+    pub vanish: Option<bool>,
+    /// Highlight color name: "yellow" | "cyan" | "green" | ... (w:highlight)
+    pub highlight: Option<String>,
 }
 
 /// Resolved paragraph formatting.
@@ -36,6 +46,14 @@ pub struct ParaFmt {
     /// merged run defaults from pPr/rPr
     pub run: RunFmt,
     pub based_on: Option<String>,
+    /// Paragraph background hex color (w:shd fill on paragraph)
+    pub shading: Option<String>,
+    /// Force page break before paragraph (w:pageBreakBefore)
+    pub page_break_before: Option<bool>,
+    /// Suppress spacing between adjacent same-style paragraphs (w:contextualSpacing)
+    pub contextual_spacing: Option<bool>,
+    /// Paragraph border edges (w:pBdr)
+    pub para_borders: Option<crate::types::ParagraphBorders>,
 }
 
 #[derive(Debug, Default)]
@@ -148,6 +166,10 @@ fn apply_para(dst: &mut ParaFmt, src: &ParaFmt) {
     if src.num_id.is_some() { dst.num_id = src.num_id; }
     if src.num_level.is_some() { dst.num_level = src.num_level; }
     if src.tab_stops.is_some() { dst.tab_stops = src.tab_stops.clone(); }
+    if src.shading.is_some() { dst.shading = src.shading.clone(); }
+    if src.page_break_before.is_some() { dst.page_break_before = src.page_break_before; }
+    if src.contextual_spacing.is_some() { dst.contextual_spacing = src.contextual_spacing; }
+    if src.para_borders.is_some() { dst.para_borders = src.para_borders.clone(); }
 }
 
 fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
@@ -161,6 +183,11 @@ fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.font_family_east_asia.is_some() { dst.font_family_east_asia = src.font_family_east_asia.clone(); }
     if src.background.is_some() { dst.background = src.background.clone(); }
     if src.vert_align.is_some() { dst.vert_align = src.vert_align.clone(); }
+    if src.all_caps.is_some() { dst.all_caps = src.all_caps; }
+    if src.small_caps.is_some() { dst.small_caps = src.small_caps; }
+    if src.dstrike.is_some() { dst.dstrike = src.dstrike; }
+    if src.vanish.is_some() { dst.vanish = src.vanish; }
+    if src.highlight.is_some() { dst.highlight = src.highlight.clone(); }
 }
 
 pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
@@ -233,6 +260,52 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
         fmt.run = parse_run_fmt(rpr);
     }
 
+    // Paragraph shading
+    if let Some(shd) = child_w(ppr, "shd") {
+        if let Some(fill) = attr_w(shd, "fill") {
+            if fill != "auto" && fill.len() == 6 {
+                fmt.shading = Some(fill.to_lowercase());
+            }
+        }
+    }
+
+    // Page break before paragraph
+    fmt.page_break_before = bool_prop(ppr, "pageBreakBefore");
+
+    // Contextual spacing
+    fmt.contextual_spacing = bool_prop(ppr, "contextualSpacing");
+
+    // Paragraph borders (pBdr)
+    if let Some(pbdr) = child_w(ppr, "pBdr") {
+        use crate::types::{ParagraphBorders, ParaBorderEdge};
+        let parse_edge = |name: &str| -> Option<ParaBorderEdge> {
+            let node = child_w(pbdr, name)?;
+            let style = attr_w(node, "val").unwrap_or_else(|| "none".to_string());
+            if style == "none" || style == "nil" { return None; }
+            let width = attr_w(node, "sz")
+                .and_then(|s| s.parse::<f64>().ok())
+                .map(|v| v / 8.0)
+                .unwrap_or(0.5);
+            let space = attr_w(node, "space")
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(1.0);
+            let color = attr_w(node, "color")
+                .filter(|c| c != "auto")
+                .map(|c| c.to_lowercase());
+            Some(ParaBorderEdge { style, color, width, space })
+        };
+        let borders = ParagraphBorders {
+            top: parse_edge("top"),
+            bottom: parse_edge("bottom"),
+            left: parse_edge("left"),
+            right: parse_edge("right"),
+            between: parse_edge("between"),
+        };
+        if borders.top.is_some() || borders.bottom.is_some() || borders.left.is_some() || borders.right.is_some() {
+            fmt.para_borders = Some(borders);
+        }
+    }
+
     fmt
 }
 
@@ -289,6 +362,21 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
                 _ => None,
             };
         }
+    }
+
+    // All caps / small caps
+    fmt.all_caps = bool_prop(rpr, "caps");
+    fmt.small_caps = bool_prop(rpr, "smallCaps");
+
+    // Double strikethrough
+    fmt.dstrike = bool_prop(rpr, "dstrike");
+
+    // Hidden text (vanish or webHidden)
+    fmt.vanish = bool_prop(rpr, "vanish").or_else(|| bool_prop(rpr, "webHidden"));
+
+    // Highlight
+    if let Some(hl) = child_w(rpr, "highlight") {
+        fmt.highlight = attr_w(hl, "val").filter(|v| v != "none");
     }
 
     fmt

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -73,6 +73,48 @@ pub struct DocParagraph {
     /// Explicit tab stops from w:tabs. Empty means use default tab interval.
     pub tab_stops: Vec<TabStop>,
     pub runs: Vec<DocRun>,
+    /// Paragraph background hex color (w:shd fill on paragraph)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shading: Option<String>,
+    /// Force a page break before this paragraph (w:pageBreakBefore)
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub page_break_before: bool,
+    /// Suppress spacing between adjacent same-style paragraphs (w:contextualSpacing)
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub contextual_spacing: bool,
+    /// Paragraph borders (w:pBdr)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub borders: Option<ParagraphBorders>,
+    /// Style ID of the applied paragraph style (for contextual spacing resolution)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style_id: Option<String>,
+}
+
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ParagraphBorders {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top: Option<ParaBorderEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bottom: Option<ParaBorderEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left: Option<ParaBorderEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub right: Option<ParaBorderEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub between: Option<ParaBorderEdge>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ParaBorderEdge {
+    /// "single" | "double" | "dashed" | ...
+    pub style: String,
+    pub color: Option<String>,
+    /// pt (sz / 8)
+    pub width: f64,
+    /// pt spacing between border and text
+    pub space: f64,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -139,6 +181,14 @@ pub struct FieldRun {
     pub background: Option<String>,
     /// "super" | "sub" | None
     pub vert_align: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub all_caps: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub small_caps: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub double_strikethrough: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub highlight: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
@@ -159,6 +209,18 @@ pub struct TextRun {
     pub vert_align: Option<String>,
     /// Target URL for hyperlinks (from relationships.xml), None if not a link or no URL
     pub hyperlink: Option<String>,
+    /// Transform all characters to uppercase (w:caps)
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub all_caps: bool,
+    /// Render as small capitals (uppercase at ~80% size, w:smallCaps)
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub small_caps: bool,
+    /// Double strikethrough (w:dstrike)
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub double_strikethrough: bool,
+    /// OOXML highlight color name: "yellow" | "cyan" | "green" | ... (w:highlight)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub highlight: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,8 +1,16 @@
 import type {
   Document, BodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell,
   DocRun, TextRun, ImageRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop,
+  TabStop, ParagraphBorders, ParaBorderEdge,
 } from './types';
+
+const HIGHLIGHT_COLORS: Record<string, string> = {
+  yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
+  blue: '#0000FF', red: '#FF0000', darkBlue: '#000080', darkCyan: '#008080',
+  darkGreen: '#008000', darkMagenta: '#800080', darkRed: '#800000',
+  darkYellow: '#808000', darkGray: '#808080', lightGray: '#C0C0C0',
+  black: '#000000', white: '#FFFFFF',
+};
 
 // 1pt = 96/72 CSS px at screen
 const PT_TO_PX = 96 / 72;
@@ -190,9 +198,7 @@ export async function renderDocumentToCanvas(
 
   // Body
   const bodyState: RenderState = { ...baseState, y: sec.marginTop * scale };
-  for (const el of elements) {
-    renderBodyElement(el, bodyState);
-  }
+  renderBodyElements(elements, bodyState);
 }
 
 function splitPages(body: BodyElement[]): BodyElement[][] {
@@ -201,6 +207,12 @@ function splitPages(body: BodyElement[]): BodyElement[][] {
     if (el.type === 'pageBreak') {
       pages.push([]);
     } else {
+      if (el.type === 'paragraph') {
+        const para = el as unknown as DocParagraph;
+        if (para.pageBreakBefore && pages[pages.length - 1].length > 0) {
+          pages.push([]);
+        }
+      }
       pages[pages.length - 1].push(el);
     }
   }
@@ -221,12 +233,12 @@ function pickHeaderFooter(
 
 function renderHeaderFooter(hf: HeaderFooter, topY: number, base: RenderState): void {
   const state: RenderState = { ...base, y: topY };
-  for (const el of hf.body) renderBodyElement(el, state);
+  renderBodyElements(hf.body, state);
 }
 
 function measureHeaderFooterHeight(hf: HeaderFooter, base: RenderState): number {
   const state: RenderState = { ...base, y: 0, dryRun: true };
-  for (const el of hf.body) renderBodyElement(el, state);
+  renderBodyElements(hf.body, state);
   return state.y;
 }
 
@@ -240,14 +252,41 @@ function renderBodyElement(el: BodyElement, state: RenderState): void {
   }
 }
 
+function contextualSuppressed(prev: DocParagraph | null, curr: DocParagraph): boolean {
+  return !!(prev?.contextualSpacing && curr.contextualSpacing && prev.styleId && prev.styleId === curr.styleId);
+}
+
+function renderBodyElements(elements: BodyElement[], state: RenderState): void {
+  let prevPara: DocParagraph | null = null;
+  for (const el of elements) {
+    if (el.type === 'paragraph') {
+      const para = el as unknown as DocParagraph;
+      renderParagraph(para, state, contextualSuppressed(prevPara, para));
+      prevPara = para;
+    } else if (el.type === 'table') {
+      renderTable(el as unknown as DocTable, state);
+      prevPara = null;
+    }
+  }
+}
+
+function renderParaList(paras: DocParagraph[], state: RenderState): void {
+  let prevPara: DocParagraph | null = null;
+  for (const para of paras) {
+    renderParagraph(para, state, contextualSuppressed(prevPara, para));
+    prevPara = para;
+  }
+}
+
 // ===== Paragraph rendering =====
 
-function renderParagraph(para: DocParagraph, state: RenderState): void {
+function renderParagraph(para: DocParagraph, state: RenderState, suppressSpaceBefore = false): void {
   const { ctx, scale, contentX, contentW, defaultColor, dryRun } = state;
   // Capture Y before spaceBefore — used for paragraph-relative anchor image positioning
   const paragraphStartY = state.y;
 
-  state.y += para.spaceBefore * scale;
+  if (!suppressSpaceBefore) state.y += para.spaceBefore * scale;
+  const textAreaTopY = state.y;
 
   const indLeft = para.indentLeft * scale;
   const indRight = para.indentRight * scale;
@@ -270,12 +309,27 @@ function renderParagraph(para: DocParagraph, state: RenderState): void {
 
   if (segments.length === 0) {
     const fontSize = getDefaultFontSize(para) * scale;
-    state.y += fontSize * lineSpacingMultiplier(para.lineSpacing);
+    const emptyH = fontSize * lineSpacingMultiplier(para.lineSpacing);
+    if (para.shading && !dryRun) {
+      ctx.fillStyle = `#${para.shading}`;
+      ctx.fillRect(contentX + indLeft, textAreaTopY, paraW, emptyH);
+    }
+    state.y += emptyH;
+    if (para.borders && !dryRun) {
+      drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, emptyH, para.borders, scale);
+    }
     state.y += para.spaceAfter * scale;
+    renderAnchorImages(para, state, paragraphStartY);
     return;
   }
 
   const lines = layoutLines(ctx, segments, paraW, firstLineX - paraX, scale, para.tabStops);
+
+  if (para.shading && !dryRun) {
+    const totalTextH = lines.reduce((s, l) => s + l.height * scale * lineSpacingMultiplier(para.lineSpacing), 0);
+    ctx.fillStyle = `#${para.shading}`;
+    ctx.fillRect(contentX + indLeft, textAreaTopY, paraW, totalTextH);
+  }
 
   let firstLine = true;
   for (const line of lines) {
@@ -311,37 +365,47 @@ function renderParagraph(para: DocParagraph, state: RenderState): void {
       }
       const s = seg as LayoutTextSeg;
       if (!dryRun) {
-        const effSizePx = s.fontSize * scale * (s.vertAlign ? 0.65 : 1);
+        const effSizePx = calcEffectiveFontPx(s, scale);
         const yOffset = s.vertAlign === 'super'
           ? -s.fontSize * scale * 0.35
           : s.vertAlign === 'sub'
             ? s.fontSize * scale * 0.15
             : 0;
         ctx.font = buildFont(s.bold, s.italic, effSizePx, s.fontFamily);
-        ctx.fillStyle = s.color ? `#${s.color}` : defaultColor;
 
+        if (s.highlight) {
+          ctx.fillStyle = HIGHLIGHT_COLORS[s.highlight] ?? '#FFFF00';
+          ctx.fillRect(x, baseline + yOffset - effSizePx * 0.85, s.measuredWidth, effSizePx * 1.1);
+        }
+
+        ctx.fillStyle = s.color ? `#${s.color}` : defaultColor;
         ctx.fillText(s.text, x, baseline + yOffset);
 
+        const lineColor = s.color ? `#${s.color}` : defaultColor;
+        const lineW = Math.max(0.5, effSizePx * 0.05);
+        const textW = ctx.measureText(s.text).width;
+
         if (s.underline) {
-          const lw = ctx.measureText(s.text).width;
-          ctx.strokeStyle = s.color ? `#${s.color}` : defaultColor;
-          ctx.lineWidth = Math.max(0.5, effSizePx * 0.05);
+          ctx.strokeStyle = lineColor;
+          ctx.lineWidth = lineW;
           const uy = baseline + yOffset + effSizePx * 0.12;
-          ctx.beginPath();
-          ctx.moveTo(x, uy);
-          ctx.lineTo(x + lw, uy);
-          ctx.stroke();
+          ctx.beginPath(); ctx.moveTo(x, uy); ctx.lineTo(x + textW, uy); ctx.stroke();
         }
 
         if (s.strikethrough) {
-          const lw = ctx.measureText(s.text).width;
-          ctx.strokeStyle = s.color ? `#${s.color}` : defaultColor;
-          ctx.lineWidth = Math.max(0.5, effSizePx * 0.05);
+          ctx.strokeStyle = lineColor;
+          ctx.lineWidth = lineW;
           const sy = baseline + yOffset - effSizePx * 0.3;
-          ctx.beginPath();
-          ctx.moveTo(x, sy);
-          ctx.lineTo(x + lw, sy);
-          ctx.stroke();
+          ctx.beginPath(); ctx.moveTo(x, sy); ctx.lineTo(x + textW, sy); ctx.stroke();
+        }
+
+        if (s.doubleStrikethrough) {
+          ctx.strokeStyle = lineColor;
+          ctx.lineWidth = lineW;
+          const sy1 = baseline + yOffset - effSizePx * 0.35;
+          const sy2 = baseline + yOffset - effSizePx * 0.22;
+          ctx.beginPath(); ctx.moveTo(x, sy1); ctx.lineTo(x + textW, sy1); ctx.stroke();
+          ctx.beginPath(); ctx.moveTo(x, sy2); ctx.lineTo(x + textW, sy2); ctx.stroke();
         }
       }
 
@@ -350,6 +414,11 @@ function renderParagraph(para: DocParagraph, state: RenderState): void {
 
     state.y += lineH;
     firstLine = false;
+  }
+
+  if (para.borders && !dryRun) {
+    const textH = state.y - textAreaTopY;
+    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale);
   }
 
   state.y += para.spaceAfter * scale;
@@ -371,6 +440,9 @@ interface LayoutTextSeg {
   fontFamily: string | null;
   vertAlign: 'super' | 'sub' | null;
   measuredWidth: number;  // px (set during layout)
+  smallCaps?: boolean;
+  doubleStrikethrough?: boolean;
+  highlight?: string | null;
 }
 
 /**
@@ -420,7 +492,8 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
     base: TextRun | FieldRun,
     vertAlign: 'super' | 'sub' | null,
   ) => {
-    for (const word of splitTextForLayout(text)) {
+    const displayText = (base.allCaps || base.smallCaps) ? text.toUpperCase() : text;
+    for (const word of splitTextForLayout(displayText)) {
       segs.push({
         text: word,
         bold: base.bold,
@@ -432,6 +505,9 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         fontFamily: base.fontFamily,
         vertAlign,
         measuredWidth: 0,
+        smallCaps: base.smallCaps ?? false,
+        doubleStrikethrough: base.doubleStrikethrough ?? false,
+        highlight: base.highlight ?? null,
       });
     }
   };
@@ -584,9 +660,7 @@ function layoutLines(
     if (asc > lineAscent) lineAscent = asc;
   };
 
-  /** Font size after super/sub scaling, in px. */
-  const effectiveFontPx = (s: LayoutTextSeg): number =>
-    s.fontSize * scale * (s.vertAlign ? 0.65 : 1);
+  const effectiveFontPx = (s: LayoutTextSeg): number => calcEffectiveFontPx(s, scale);
 
   const measureText = (s: LayoutTextSeg): TextMetrics => {
     ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily);
@@ -875,9 +949,7 @@ function renderCell(
     else cellState.y = y + h - contentH - mb;
   }
 
-  for (const para of cell.content) {
-    renderParagraph(para, cellState);
-  }
+  renderParaList(cell.content, cellState);
 }
 
 function drawCellBorders(
@@ -914,7 +986,32 @@ function drawBorderLine(
   ctx.restore();
 }
 
+function drawParaBorders(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  x: number, y: number, w: number, h: number,
+  borders: ParagraphBorders,
+  scale: number,
+): void {
+  const drawEdge = (edge: ParaBorderEdge | null, x1: number, y1: number, x2: number, y2: number) => {
+    if (!edge || edge.style === 'none') return;
+    const spec: BorderSpec = { width: edge.width, color: edge.color, style: edge.style };
+    drawBorderLine(ctx, x1, y1, x2, y2, spec, scale);
+  };
+  const sp = (edge: ParaBorderEdge | null) => (edge?.space ?? 0) * scale;
+  drawEdge(borders.top,    x, y - sp(borders.top),         x + w, y - sp(borders.top));
+  drawEdge(borders.bottom, x, y + h + sp(borders.bottom),  x + w, y + h + sp(borders.bottom));
+  drawEdge(borders.left,   x - sp(borders.left), y,        x - sp(borders.left), y + h);
+  drawEdge(borders.right,  x + w + sp(borders.right), y,   x + w + sp(borders.right), y + h);
+}
+
 // ===== Utilities =====
+
+function calcEffectiveFontPx(s: LayoutTextSeg, scale: number): number {
+  let size = s.fontSize * scale;
+  if (s.smallCaps) size *= 0.8;
+  if (s.vertAlign) size *= 0.65;
+  return size;
+}
 
 function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string | null): string {
   const w = bold ? 'bold' : 'normal';

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -46,6 +46,33 @@ export interface DocParagraph {
   numbering: NumberingInfo | null;
   tabStops: TabStop[];
   runs: DocRun[];
+  /** Paragraph background hex color (w:shd fill) */
+  shading?: string | null;
+  /** Force a page break before this paragraph (w:pageBreakBefore) */
+  pageBreakBefore?: boolean;
+  /** Suppress spacing between adjacent same-style paragraphs (w:contextualSpacing) */
+  contextualSpacing?: boolean;
+  /** Paragraph borders (w:pBdr) */
+  borders?: ParagraphBorders | null;
+  /** Style ID of the applied paragraph style */
+  styleId?: string | null;
+}
+
+export interface ParagraphBorders {
+  top: ParaBorderEdge | null;
+  bottom: ParaBorderEdge | null;
+  left: ParaBorderEdge | null;
+  right: ParaBorderEdge | null;
+  between: ParaBorderEdge | null;
+}
+
+export interface ParaBorderEdge {
+  style: string;
+  color: string | null;
+  /** pt (sz / 8) */
+  width: number;
+  /** pt spacing between border and text */
+  space: number;
 }
 
 export interface TabStop {
@@ -89,6 +116,10 @@ export interface FieldRun {
   fontFamily: string | null;
   background: string | null;
   vertAlign: 'super' | 'sub' | null;
+  allCaps?: boolean;
+  smallCaps?: boolean;
+  doubleStrikethrough?: boolean;
+  highlight?: string | null;
 }
 
 export interface TextRun {
@@ -105,6 +136,10 @@ export interface TextRun {
   vertAlign: 'super' | 'sub' | null;
   /** Target URL for hyperlinks (resolved from relationships.xml) */
   hyperlink: string | null;
+  allCaps?: boolean;
+  smallCaps?: boolean;
+  doubleStrikethrough?: boolean;
+  highlight?: string | null;
 }
 
 export interface ImageRun {


### PR DESCRIPTION
## Summary

- **Paragraph**: shading (background fill), borders (top/bottom/left/right with spacing), `pageBreakBefore` (inserts page break in `splitPages`), `contextualSpacing` (suppresses spacing between adjacent same-style paragraphs), `styleId` (for contextual spacing resolution)
- **Run-level**: `allCaps` / `smallCaps` (uppercase text, smallCaps at 80% font size), `doubleStrikethrough` (two parallel lines), `highlight` (OOXML named highlight colors as background rect)
- Rust parser (`styles.rs`, `parser.rs`, `types.rs`): parses and resolves all new fields from `w:pBdr`, `w:shd`, `w:pageBreakBefore`, `w:contextualSpacing`, `w:caps`, `w:smallCaps`, `w:dstrike`, `w:highlight`
- TypeScript types and renderer updated to consume all new fields

## Test plan

- [ ] TypeScript type check passes (`tsc --noEmit`)
- [ ] WASM build succeeds (`wasm-pack build`)
- [ ] Visually verify paragraph shading, borders, and text decorations in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)