### PR TITLE
fix(xlsx): extend chart value axis when data lands on a gridline

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1489,6 +1489,21 @@ function niceStep(range: number, targetSteps = 5): number {
   return nice * mag;
 }
 
+// Excel's default auto-scale rounds dataMax up to a grid line, but when the
+// data lands exactly on one it extends by one more step for breathing room
+// (e.g. dataMax=20, step=5 → 25, not 20).
+function niceAxisMax(dataMax: number, step: number): number {
+  if (dataMax <= 0) return step;
+  const ax = Math.ceil(dataMax / step) * step;
+  return Math.abs(ax - dataMax) < step * 1e-9 ? ax + step : ax;
+}
+
+function niceAxisMin(dataMin: number, step: number): number {
+  if (dataMin >= 0) return 0;
+  const ax = Math.floor(dataMin / step) * step;
+  return Math.abs(ax - dataMin) < step * 1e-9 ? ax - step : ax;
+}
+
 function formatChartVal(v: number): string {
   if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
   if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
@@ -1708,7 +1723,7 @@ function renderBarChart(
   if (dataMax === 0) dataMax = 1;
 
   const step  = niceStep(dataMax);
-  const axMax = Math.ceil(dataMax / step) * step;
+  const axMax = niceAxisMax(dataMax, step);
 
   // Draw grid + value axis
   const gridColor = '#e0e0e0';
@@ -1887,8 +1902,8 @@ function renderLineChartXlsx(
   if (dataMax === dataMin) dataMax = dataMin + 1;
 
   const step  = niceStep(dataMax - dataMin);
-  const axMin = Math.floor(dataMin / step) * step;
-  const axMax = Math.ceil(dataMax / step) * step;
+  const axMin = niceAxisMin(dataMin, step);
+  const axMax = niceAxisMax(dataMax, step);
   const range = axMax - axMin; if (range === 0) return;
 
   const toY = (v: number) => py0 + ph - ((v - axMin) / range) * ph;
@@ -1992,7 +2007,7 @@ function renderAreaChartXlsx(
   }
   if (dataMax === 0) dataMax = 1;
   const step  = niceStep(dataMax);
-  const axMax = Math.ceil(dataMax / step) * step;
+  const axMax = niceAxisMax(dataMax, step);
 
   const toX = (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
   const toY = (v: number) => py0 + ph - (v / axMax) * ph;
@@ -2154,7 +2169,7 @@ function renderRadarChart(
   for (const s of chart.series) for (const v of s.values) dataMax = Math.max(dataMax, v ?? 0);
   if (dataMax === 0) dataMax = 1;
   const step  = niceStep(dataMax);
-  const axMax = Math.ceil(dataMax / step) * step;
+  const axMax = niceAxisMax(dataMax, step);
 
   const angle0 = -Math.PI / 2;
   const spoke  = (i: number) => angle0 + (i / n) * Math.PI * 2;


### PR DESCRIPTION
## Summary
- sample-17 を含むチャートで Excel は `y=25` を最大値として描画するが、現状は `y=20` で切れて最上バーがフレームに接していた
- Excel の自動スケーリング仕様は「データが step 境界にピッタリ合う場合は 1 step 分の余白を追加」というもの
- `niceAxisMax` / `niceAxisMin` ヘルパーを追加して bar/line/area/radar の 4 箇所に適用

## Spec reference
ECMA-376 §21.2.2.170 (valAx/scaling): 明示的な `<c:min>`/`<c:max>` が無い場合は自動スケール。Excel の実装では gridline-boundary で breathing room を追加する。

## Test plan
- [x] sample-17: チャート y 軸が `0, 5, 10, 15, 20, 25` の 6 分割で表示される
- [x] 型チェック通過 (`tsc --noEmit`)
- [ ] 既存の線グラフ / 面グラフ / レーダーチャートで軸ラベルが 1 ステップ増える程度の見た目変化。VRT 参照画像は目視で確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)