### PR TITLE
Align pptx/docx headless APIs and add Layouts stories

### DIFF
--- a/packages/docx/src/Layouts.stories.ts
+++ b/packages/docx/src/Layouts.stories.ts
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { DocxDocument } from './document';
+
+type Args = Record<string, never>;
+
+const SAMPLE_URL = `${import.meta.env.BASE_URL}docx/demo/sample-1.docx`;
+
+const meta: Meta<Args> = {
+  title: 'DocxViewer/Layouts',
+};
+export default meta;
+type Story = StoryObj<Args>;
+
+function makeStatus(root: HTMLElement): HTMLDivElement {
+  const s = document.createElement('div');
+  s.style.cssText = 'color:#666;font-size:13px;margin-bottom:8px;min-height:18px;';
+  s.textContent = 'Loading…';
+  root.appendChild(s);
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Story 1: ScrollView — all pages stacked vertically
+// ---------------------------------------------------------------------------
+export const ScrollView: Story = {
+  name: 'ScrollView — stack all pages',
+  render() {
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'ScrollView — scroll through every page';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    const scroller = document.createElement('div');
+    scroller.style.cssText =
+      'max-height:720px;overflow-y:auto;border:1px solid #ccc;background:#f5f5f5;padding:12px;';
+    root.appendChild(scroller);
+
+    DocxDocument.load(SAMPLE_URL)
+      .then(async (doc) => {
+        status.textContent = `Rendering ${doc.pageCount} pages…`;
+        const widthPx = 700;
+        for (let i = 0; i < doc.pageCount; i++) {
+          const canvas = document.createElement('canvas');
+          canvas.style.cssText =
+            'display:block;width:100%;max-width:700px;margin:0 auto 12px;' +
+            'background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+          scroller.appendChild(canvas);
+          await doc.renderPage(canvas, i, { width: widthPx });
+        }
+        status.textContent = `Loaded ${doc.pageCount} pages`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Story 2: ThumbnailGrid — all pages as a CSS-grid of small canvases
+// ---------------------------------------------------------------------------
+export const ThumbnailGrid: Story = {
+  name: 'ThumbnailGrid — overview of all pages',
+  render() {
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'ThumbnailGrid — every page at a glance';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    const grid = document.createElement('div');
+    grid.style.cssText =
+      'display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:16px;';
+    root.appendChild(grid);
+
+    DocxDocument.load(SAMPLE_URL)
+      .then(async (doc) => {
+        status.textContent = `Rendering ${doc.pageCount} thumbnails…`;
+        const thumbWidth = 160;
+        for (let i = 0; i < doc.pageCount; i++) {
+          const cell = document.createElement('div');
+          cell.style.cssText = 'display:flex;flex-direction:column;align-items:center;cursor:pointer;';
+          const canvas = document.createElement('canvas');
+          canvas.style.cssText =
+            'display:block;width:100%;max-width:160px;background:#fff;' +
+            'box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+          const caption = document.createElement('div');
+          caption.textContent = `Page ${i + 1}`;
+          caption.style.cssText = 'font-size:12px;color:#444;margin-top:4px;';
+          cell.append(canvas, caption);
+          const idx = i;
+          cell.addEventListener('click', () => {
+            console.log(`[docx ThumbnailGrid] clicked page ${idx + 1}`);
+          });
+          grid.appendChild(cell);
+          await doc.renderPage(canvas, i, { width: thumbWidth });
+        }
+        status.textContent = `Loaded ${doc.pageCount} pages`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Story 3: MasterDetail — scrollable thumbnails + a large preview canvas
+// ---------------------------------------------------------------------------
+export const MasterDetail: Story = {
+  name: 'MasterDetail — thumbnails + large preview',
+  render() {
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'MasterDetail — click a thumbnail to preview';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    const layout = document.createElement('div');
+    layout.style.cssText = 'display:flex;gap:16px;height:720px;';
+    root.appendChild(layout);
+
+    const thumbCol = document.createElement('div');
+    thumbCol.style.cssText =
+      'flex:0 0 200px;overflow-y:auto;border:1px solid #ccc;background:#f5f5f5;padding:8px;' +
+      'display:flex;flex-direction:column;gap:10px;';
+    const detailCol = document.createElement('div');
+    detailCol.style.cssText =
+      'flex:1 1 auto;border:1px solid #ccc;background:#f5f5f5;padding:12px;overflow:auto;' +
+      'display:flex;align-items:flex-start;justify-content:center;';
+    const detailCanvas = document.createElement('canvas');
+    detailCanvas.style.cssText = 'display:block;max-width:100%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+    detailCol.appendChild(detailCanvas);
+    layout.append(thumbCol, detailCol);
+
+    DocxDocument.load(SAMPLE_URL)
+      .then(async (doc) => {
+        status.textContent = `Rendering ${doc.pageCount} thumbnails…`;
+        const thumbEntries: HTMLDivElement[] = [];
+
+        const detailWidth = () => detailCol.clientWidth - 24;
+
+        const selectPage = async (i: number) => {
+          for (let k = 0; k < thumbEntries.length; k++) {
+            thumbEntries[k].style.outline = k === i ? '2px solid #0366d6' : 'none';
+          }
+          await doc.renderPage(detailCanvas, i, { width: Math.max(320, detailWidth()) });
+        };
+
+        for (let i = 0; i < doc.pageCount; i++) {
+          const cell = document.createElement('div');
+          cell.style.cssText = 'display:flex;flex-direction:column;align-items:center;cursor:pointer;padding:4px;';
+          const canvas = document.createElement('canvas');
+          canvas.style.cssText =
+            'display:block;width:100%;max-width:180px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+          const caption = document.createElement('div');
+          caption.textContent = `Page ${i + 1}`;
+          caption.style.cssText = 'font-size:12px;color:#444;margin-top:4px;';
+          cell.append(canvas, caption);
+          const idx = i;
+          cell.addEventListener('click', () => {
+            selectPage(idx).catch((e: Error) => {
+              status.textContent = `Render error: ${e.message}`;
+            });
+          });
+          thumbCol.appendChild(cell);
+          thumbEntries.push(cell);
+          await doc.renderPage(canvas, i, { width: 180 });
+        }
+
+        await selectPage(0);
+        status.textContent = `Loaded ${doc.pageCount} pages`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};

--- a/packages/pptx/src/Layouts.stories.ts
+++ b/packages/pptx/src/Layouts.stories.ts
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { PptxPresentation } from './presentation';
+
+type Args = Record<string, never>;
+
+const SAMPLE_URL = `${import.meta.env.BASE_URL}pptx/demo/sample-1.pptx`;
+
+const meta: Meta<Args> = {
+  title: 'PptxViewer/Layouts',
+};
+export default meta;
+type Story = StoryObj<Args>;
+
+function makeStatus(root: HTMLElement): HTMLDivElement {
+  const s = document.createElement('div');
+  s.style.cssText = 'color:#666;font-size:13px;margin-bottom:8px;min-height:18px;';
+  s.textContent = 'Loading…';
+  root.appendChild(s);
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Story 1: ScrollView — all slides stacked vertically
+// ---------------------------------------------------------------------------
+export const ScrollView: Story = {
+  name: 'ScrollView — stack all slides',
+  render() {
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'ScrollView — scroll through every slide';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    const scroller = document.createElement('div');
+    scroller.style.cssText =
+      'max-height:720px;overflow-y:auto;border:1px solid #ccc;background:#f5f5f5;padding:12px;';
+    root.appendChild(scroller);
+
+    PptxPresentation.load(SAMPLE_URL)
+      .then(async (pres) => {
+        status.textContent = `Rendering ${pres.slideCount} slides…`;
+        const widthPx = 800;
+        for (let i = 0; i < pres.slideCount; i++) {
+          const canvas = document.createElement('canvas');
+          canvas.style.cssText =
+            'display:block;width:100%;max-width:800px;margin:0 auto 12px;' +
+            'background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+          scroller.appendChild(canvas);
+          await pres.renderSlide(canvas, i, { width: widthPx });
+        }
+        status.textContent = `Loaded ${pres.slideCount} slides`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Story 2: ThumbnailGrid — all slides as a CSS-grid of small canvases
+// ---------------------------------------------------------------------------
+export const ThumbnailGrid: Story = {
+  name: 'ThumbnailGrid — overview of all slides',
+  render() {
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'ThumbnailGrid — every slide at a glance';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    const grid = document.createElement('div');
+    grid.style.cssText =
+      'display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px;';
+    root.appendChild(grid);
+
+    PptxPresentation.load(SAMPLE_URL)
+      .then(async (pres) => {
+        status.textContent = `Rendering ${pres.slideCount} thumbnails…`;
+        const thumbWidth = 240;
+        for (let i = 0; i < pres.slideCount; i++) {
+          const cell = document.createElement('div');
+          cell.style.cssText = 'display:flex;flex-direction:column;align-items:center;cursor:pointer;';
+          const canvas = document.createElement('canvas');
+          canvas.style.cssText =
+            'display:block;width:100%;max-width:240px;background:#fff;' +
+            'box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+          const caption = document.createElement('div');
+          caption.textContent = `Slide ${i + 1}`;
+          caption.style.cssText = 'font-size:12px;color:#444;margin-top:4px;';
+          cell.append(canvas, caption);
+          const idx = i;
+          cell.addEventListener('click', () => {
+            console.log(`[pptx ThumbnailGrid] clicked slide ${idx + 1}`);
+          });
+          grid.appendChild(cell);
+          await pres.renderSlide(canvas, i, { width: thumbWidth });
+        }
+        status.textContent = `Loaded ${pres.slideCount} slides`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Story 3: MasterDetail — scrollable thumbnails + a large preview canvas
+// ---------------------------------------------------------------------------
+export const MasterDetail: Story = {
+  name: 'MasterDetail — thumbnails + large preview',
+  render() {
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'MasterDetail — click a thumbnail to preview';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    const layout = document.createElement('div');
+    layout.style.cssText = 'display:flex;gap:16px;height:720px;';
+    root.appendChild(layout);
+
+    const thumbCol = document.createElement('div');
+    thumbCol.style.cssText =
+      'flex:0 0 240px;overflow-y:auto;border:1px solid #ccc;background:#f5f5f5;padding:8px;' +
+      'display:flex;flex-direction:column;gap:10px;';
+    const detailCol = document.createElement('div');
+    detailCol.style.cssText =
+      'flex:1 1 auto;border:1px solid #ccc;background:#f5f5f5;padding:12px;overflow:auto;' +
+      'display:flex;align-items:flex-start;justify-content:center;';
+    const detailCanvas = document.createElement('canvas');
+    detailCanvas.style.cssText = 'display:block;max-width:100%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+    detailCol.appendChild(detailCanvas);
+    layout.append(thumbCol, detailCol);
+
+    PptxPresentation.load(SAMPLE_URL)
+      .then(async (pres) => {
+        status.textContent = `Rendering ${pres.slideCount} thumbnails…`;
+        const thumbEntries: HTMLDivElement[] = [];
+
+        const detailWidth = () => detailCol.clientWidth - 24;
+
+        const selectSlide = async (i: number) => {
+          for (let k = 0; k < thumbEntries.length; k++) {
+            thumbEntries[k].style.outline = k === i ? '2px solid #0366d6' : 'none';
+          }
+          await pres.renderSlide(detailCanvas, i, { width: Math.max(320, detailWidth()) });
+        };
+
+        for (let i = 0; i < pres.slideCount; i++) {
+          const cell = document.createElement('div');
+          cell.style.cssText = 'display:flex;flex-direction:column;align-items:center;cursor:pointer;padding:4px;';
+          const canvas = document.createElement('canvas');
+          canvas.style.cssText =
+            'display:block;width:100%;max-width:220px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
+          const caption = document.createElement('div');
+          caption.textContent = `Slide ${i + 1}`;
+          caption.style.cssText = 'font-size:12px;color:#444;margin-top:4px;';
+          cell.append(canvas, caption);
+          const idx = i;
+          cell.addEventListener('click', () => {
+            selectSlide(idx).catch((e: Error) => {
+              status.textContent = `Render error: ${e.message}`;
+            });
+          });
+          thumbCol.appendChild(cell);
+          thumbEntries.push(cell);
+          await pres.renderSlide(canvas, i, { width: 220 });
+        }
+
+        await selectSlide(0);
+        status.textContent = `Loaded ${pres.slideCount} slides`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -57,7 +57,6 @@ export function buildViewerUI(
 
   const viewer = new PptxViewer(container, {
     width: args.width,
-    onReady: () => { status.textContent = 'Ready'; },
     onSlideChange: (idx, total) => {
       slideInfo.textContent = `Slide ${idx + 1} / ${total}`;
       prevBtn.disabled = idx === 0;

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -1,5 +1,5 @@
 export { PptxViewer, type PptxViewerOptions } from './viewer';
-export { PptxPresentation, type PptxPresentationOptions, type RenderTarget } from './presentation';
+export { PptxPresentation, type RenderSlideOptions } from './presentation';
 export { renderSlide, type RenderOptions } from './renderer';
 export type {
   Presentation,

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -57,145 +57,144 @@ async function preloadThemeFonts(majorFont: string | null, minorFont: string | n
   ]);
 }
 
-/** Render target: a canvas plus optional sizing hints. */
-export interface RenderTarget {
-  canvas: HTMLCanvasElement;
+/** Options for rendering a single slide onto a canvas. */
+export interface RenderSlideOptions {
   /** Display width in CSS pixels. Defaults to canvas.offsetWidth or 960. */
   width?: number;
   /** Device pixel ratio. Defaults to window.devicePixelRatio or 1. */
   dpr?: number;
 }
 
-export interface PptxPresentationOptions {
-  /** Called when the WASM worker is ready. */
-  onReady?: () => void;
-  /** Called on parse or render errors. */
-  onError?: (err: Error) => void;
-}
-
 /**
  * Headless PPTX rendering engine.
  *
- * Parses .pptx files in a background worker (WASM) but renders slides
- * synchronously on the main thread, so text measurement uses the document's
- * FontFaceSet — avoiding subtle wrap differences between system fallback fonts
- * and theme-declared webfonts (e.g. Nunito Sans).
+ * Parses `.pptx` archives in a background worker (WASM) but renders slides
+ * synchronously on the main thread, so the canvas shares the document's
+ * `FontFaceSet` — avoiding subtle wrap differences between system fallback
+ * fonts and theme-declared webfonts (e.g. Nunito Sans).
+ *
+ * Construct via the static `load` factory. A single instance can drive any
+ * number of canvases (scroll view, thumbnail grid, master-detail, etc.).
  *
  * @example
- * const pres = new PptxPresentation();
- * await pres.load(buffer);
- * await pres.renderSlide({ canvas, width: 960 }, 0);
+ * const pres = await PptxPresentation.load(buffer);
+ * await pres.renderSlide(canvas, 0, { width: 960 });
  */
 export class PptxPresentation {
-  private worker: Worker | null = null;
-  private presentation: Presentation | null = null;
-  private pendingParseCallbacks = new Map<
+  private readonly _worker: Worker;
+  private _presentation: Presentation | null = null;
+  private _pendingParseCallbacks = new Map<
     number,
     { resolve: (p: Presentation) => void; reject: (e: Error) => void }
   >();
-  private nextId = 1;
-  private workerReady = false;
-  private workerReadyCallbacks: Array<() => void> = [];
-  private readonly opts: PptxPresentationOptions;
+  private _nextId = 1;
+  private _workerReady = false;
+  private _workerReadyCallbacks: Array<() => void> = [];
 
-  constructor(opts: PptxPresentationOptions = {}) {
-    this.opts = opts;
-    this.initWorker();
-  }
-
-  private initWorker() {
-    this.worker = new InlineWorker();
+  private constructor() {
+    this._worker = new InlineWorker();
     const wasmUrl = new URL(wasmAssetUrl, location.href).href;
-    this.worker.postMessage({ kind: 'init', wasmUrl } satisfies WorkerRequest);
+    this._worker.postMessage({ kind: 'init', wasmUrl } satisfies WorkerRequest);
 
-    this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+    this._worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
       const msg = e.data;
 
       if (msg.kind === 'ready') {
-        this.workerReady = true;
-        for (const cb of this.workerReadyCallbacks) cb();
-        this.workerReadyCallbacks = [];
-        this.opts.onReady?.();
+        this._workerReady = true;
+        for (const cb of this._workerReadyCallbacks) cb();
+        this._workerReadyCallbacks = [];
         return;
       }
 
       if (msg.kind === 'parsed') {
-        const cb = this.pendingParseCallbacks.get(msg.id);
+        const cb = this._pendingParseCallbacks.get(msg.id);
         if (cb) {
-          this.pendingParseCallbacks.delete(msg.id);
+          this._pendingParseCallbacks.delete(msg.id);
           cb.resolve(msg.presentation);
         }
         return;
       }
 
       if (msg.kind === 'error') {
-        const parseCb = this.pendingParseCallbacks.get(msg.id);
+        const parseCb = this._pendingParseCallbacks.get(msg.id);
         const err = new Error(msg.message);
         if (parseCb) {
-          this.pendingParseCallbacks.delete(msg.id);
+          this._pendingParseCallbacks.delete(msg.id);
           parseCb.reject(err);
         }
-        this.opts.onError?.(err);
       }
     };
-
-    this.worker.onerror = (e) => {
-      this.opts.onError?.(new Error(e.message));
-    };
   }
 
-  private waitForWorker(): Promise<void> {
-    if (this.workerReady) return Promise.resolve();
-    return new Promise((resolve) => this.workerReadyCallbacks.push(resolve));
+  /** Parse a PPTX from URL or ArrayBuffer. */
+  static async load(source: string | ArrayBuffer): Promise<PptxPresentation> {
+    const pres = new PptxPresentation();
+    let buffer: ArrayBuffer;
+    if (typeof source === 'string') {
+      const res = await fetch(source);
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
+      buffer = await res.arrayBuffer();
+    } else {
+      buffer = source;
+    }
+    await pres._parse(buffer);
+    await preloadThemeFonts(pres._presentation!.majorFont, pres._presentation!.minorFont);
+    return pres;
   }
 
-  /** Parse a PPTX ArrayBuffer. Resolves when parsing is complete. */
-  async load(buffer: ArrayBuffer): Promise<void> {
-    await this.waitForWorker();
-    const id = this.nextId++;
+  private _waitForWorker(): Promise<void> {
+    if (this._workerReady) return Promise.resolve();
+    return new Promise((resolve) => this._workerReadyCallbacks.push(resolve));
+  }
+
+  private async _parse(buffer: ArrayBuffer): Promise<void> {
+    await this._waitForWorker();
+    const id = this._nextId++;
     const presentation = await new Promise<Presentation>((resolve, reject) => {
-      this.pendingParseCallbacks.set(id, { resolve, reject });
-      this.worker!.postMessage({ kind: 'parse', id, buffer } satisfies WorkerRequest, [buffer]);
+      this._pendingParseCallbacks.set(id, { resolve, reject });
+      this._worker.postMessage({ kind: 'parse', id, buffer } satisfies WorkerRequest, [buffer]);
     });
-    this.presentation = presentation;
-    await preloadThemeFonts(presentation.majorFont, presentation.minorFont);
+    this._presentation = presentation;
   }
 
-  /** Total number of slides in the loaded presentation (0 if not loaded). */
-  get slideCount(): number { return this.presentation?.slides.length ?? 0; }
+  /** Total number of slides in the loaded presentation. */
+  get slideCount(): number { return this._presentation?.slides.length ?? 0; }
 
-  /** Slide width in EMU (0 if not loaded). */
-  get slideWidth(): number { return this.presentation?.slideWidth ?? 0; }
+  /** Slide width in EMU. */
+  get slideWidth(): number { return this._presentation?.slideWidth ?? 0; }
 
-  /** Slide height in EMU (0 if not loaded). */
-  get slideHeight(): number { return this.presentation?.slideHeight ?? 0; }
+  /** Slide height in EMU. */
+  get slideHeight(): number { return this._presentation?.slideHeight ?? 0; }
 
-  /** Render a slide directly onto a canvas on the main thread. */
-  async renderSlide(target: RenderTarget, slideIndex: number): Promise<void> {
-    if (!this.presentation) throw new Error('No presentation loaded. Call load() first.');
-    const slide = this.presentation.slides[slideIndex];
+  /** Render a slide onto the given canvas. */
+  async renderSlide(
+    canvas: HTMLCanvasElement,
+    slideIndex: number,
+    opts: RenderSlideOptions = {},
+  ): Promise<void> {
+    if (!this._presentation) throw new Error('Presentation not loaded');
+    const slide = this._presentation.slides[slideIndex];
     if (!slide) throw new Error(`Slide index ${slideIndex} out of range (count: ${this.slideCount})`);
-    const dpr = target.dpr ?? (typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1);
-    const width = target.width ?? (target.canvas.offsetWidth || 960);
+    const dpr = opts.dpr ?? (typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1);
+    const width = opts.width ?? (canvas.offsetWidth || 960);
     await renderSlide(
-      target.canvas,
+      canvas,
       slide,
-      this.presentation.slideWidth,
-      this.presentation.slideHeight,
+      this._presentation.slideWidth,
+      this._presentation.slideHeight,
       {
         width,
         dpr,
-        defaultTextColor: this.presentation.defaultTextColor,
-        majorFont: this.presentation.majorFont,
-        minorFont: this.presentation.minorFont,
+        defaultTextColor: this._presentation.defaultTextColor,
+        majorFont: this._presentation.majorFont,
+        minorFont: this._presentation.minorFont,
       },
     );
   }
 
   /** Terminate the worker and release all resources. */
   destroy(): void {
-    this.worker?.terminate();
-    this.worker = null;
-    this.presentation = null;
+    this._worker.terminate();
+    this._presentation = null;
   }
 }

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -2,8 +2,6 @@ import type { RenderOptions } from './renderer';
 import { PptxPresentation } from './presentation';
 
 export interface PptxViewerOptions extends RenderOptions {
-  /** Called when the viewer is ready to display slides */
-  onReady?: () => void;
   /** Called when a slide finishes rendering */
   onSlideChange?: (index: number, total: number) => void;
   /** Called on parse or render errors */
@@ -14,16 +12,15 @@ export interface PptxViewerOptions extends RenderOptions {
  * Opinionated single-canvas PPTX viewer.
  *
  * Creates a <canvas> element, appends it to the provided container, and manages
- * slide navigation. Public API is unchanged from the previous version.
+ * slide navigation.
  *
  * For custom layouts (multi-canvas, thumbnails, scroll view) use PptxPresentation directly.
  */
 export class PptxViewer {
   private readonly canvas: HTMLCanvasElement;
-  private readonly engine: PptxPresentation;
+  private engine: PptxPresentation | null = null;
   private readonly opts: PptxViewerOptions;
   private currentSlide = 0;
-  private loadedSlideCount = 0;
 
   constructor(container: HTMLElement, opts: PptxViewerOptions = {}) {
     this.opts = opts;
@@ -33,25 +30,25 @@ export class PptxViewer {
     this.canvas.style.maxWidth = '100%';
     this.canvas.style.height = 'auto';
     container.appendChild(this.canvas);
-
-    this.engine = new PptxPresentation({
-      onReady: opts.onReady,
-      onError: opts.onError,
-    });
   }
 
-  /** Load a PPTX file from an ArrayBuffer and render the first slide. */
-  async load(buffer: ArrayBuffer): Promise<void> {
-    await this.engine.load(buffer);
-    this.currentSlide = 0;
-    this.loadedSlideCount = this.engine.slideCount;
-    await this.renderCurrentSlide();
+  /** Load a PPTX from URL or ArrayBuffer and render the first slide. */
+  async load(source: string | ArrayBuffer): Promise<void> {
+    try {
+      this.engine = await PptxPresentation.load(source);
+      this.currentSlide = 0;
+      await this.renderCurrentSlide();
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      this.opts.onError?.(e);
+      throw e;
+    }
   }
 
   /** Navigate to a specific slide (0-indexed). */
   async goToSlide(index: number): Promise<void> {
-    if (this.loadedSlideCount === 0) return;
-    this.currentSlide = Math.max(0, Math.min(index, this.loadedSlideCount - 1));
+    if (!this.engine || this.slideCount === 0) return;
+    this.currentSlide = Math.max(0, Math.min(index, this.slideCount - 1));
     await this.renderCurrentSlide();
   }
 
@@ -64,32 +61,32 @@ export class PptxViewer {
   }
 
   get slideIndex(): number { return this.currentSlide; }
-  get slideCount(): number { return this.loadedSlideCount; }
+  get slideCount(): number { return this.engine?.slideCount ?? 0; }
 
   /** The underlying <canvas> element. */
   get canvasElement(): HTMLCanvasElement { return this.canvas; }
 
   private async renderCurrentSlide(): Promise<void> {
+    if (!this.engine) return;
     const targetWidth = this.opts.width ?? (this.canvas.offsetWidth || 960);
     const dpr = this.opts.dpr ?? (window.devicePixelRatio || 1);
 
-    // Set CSS dimensions so the canvas displays at the correct aspect ratio
     const scale = targetWidth / this.engine.slideWidth;
     const cssHeight = Math.round(this.engine.slideHeight * scale);
     this.canvas.style.width = `${targetWidth}px`;
     this.canvas.style.height = `${cssHeight}px`;
 
-    await this.engine.renderSlide(
-      { canvas: this.canvas, width: targetWidth, dpr },
-      this.currentSlide,
-    );
-
-    this.opts.onSlideChange?.(this.currentSlide, this.loadedSlideCount);
+    try {
+      await this.engine.renderSlide(this.canvas, this.currentSlide, { width: targetWidth, dpr });
+      this.opts.onSlideChange?.(this.currentSlide, this.slideCount);
+    } catch (err) {
+      this.opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+    }
   }
 
   /** Clean up the viewer and terminate the background worker. */
   destroy(): void {
-    this.engine.destroy();
+    this.engine?.destroy();
     this.canvas.remove();
   }
 }

--- a/tests/smoke/layouts.spec.ts
+++ b/tests/smoke/layouts.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test';
+
+// Expected non-zero page/slide counts per sample used by the stories.
+const EXPECTED = {
+  pptx: 9,   // packages/pptx/public/demo/sample-1.pptx
+  docx: 6,   // packages/docx/public/demo/sample-1.docx (see docx visual.spec.ts)
+};
+
+type StoryId =
+  | 'pptxviewer-layouts--scroll-view'
+  | 'pptxviewer-layouts--thumbnail-grid'
+  | 'pptxviewer-layouts--master-detail'
+  | 'docxviewer-layouts--scroll-view'
+  | 'docxviewer-layouts--thumbnail-grid'
+  | 'docxviewer-layouts--master-detail';
+
+async function canvasHasInk(page: import('@playwright/test').Page, index = 0): Promise<boolean> {
+  return page.evaluate((i) => {
+    const canvases = Array.from(document.querySelectorAll('canvas')) as HTMLCanvasElement[];
+    const c = canvases[i];
+    if (!c) return false;
+    const ctx = c.getContext('2d');
+    if (!ctx) return false;
+    const w = c.width, h = c.height;
+    if (w === 0 || h === 0) return false;
+    // Scan a 20x20 grid; count pixels that are neither transparent nor pure white.
+    let inked = 0;
+    for (let gy = 0; gy < 20; gy++) {
+      for (let gx = 0; gx < 20; gx++) {
+        const x = Math.floor(((gx + 0.5) / 20) * w);
+        const y = Math.floor(((gy + 0.5) / 20) * h);
+        const { data } = ctx.getImageData(x, y, 1, 1);
+        const [r, g, b, a] = [data[0], data[1], data[2], data[3]];
+        const notBlank = a > 0 && !(r >= 250 && g >= 250 && b >= 250);
+        if (notBlank) inked++;
+        if (inked >= 3) return true;
+      }
+    }
+    return false;
+  }, index);
+}
+
+async function waitForLoaded(page: import('@playwright/test').Page, text: RegExp): Promise<void> {
+  // The Layouts stories write "Loaded N slides" / "Loaded N pages" to a status div.
+  await page.waitForFunction(
+    (re) => {
+      const matcher = new RegExp(re);
+      for (const el of Array.from(document.querySelectorAll('div'))) {
+        if (matcher.test(el.textContent ?? '')) return true;
+      }
+      return false;
+    },
+    text.source,
+    { timeout: 60_000 },
+  );
+}
+
+async function openStory(page: import('@playwright/test').Page, id: StoryId): Promise<void> {
+  const res = await page.goto(`/iframe.html?id=${id}&viewMode=story`);
+  expect(res?.status(), `HTTP status for ${id}`).toBeLessThan(400);
+}
+
+test.describe('Layouts smoke — pptx', () => {
+  test('ScrollView renders every slide', async ({ page }) => {
+    await openStory(page, 'pptxviewer-layouts--scroll-view');
+    await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.pptx} slides`));
+    const count = await page.locator('canvas').count();
+    expect(count).toBe(EXPECTED.pptx);
+    expect(await canvasHasInk(page, 0)).toBe(true);
+    expect(await canvasHasInk(page, Math.floor(EXPECTED.pptx / 2))).toBe(true);
+    expect(await canvasHasInk(page, EXPECTED.pptx - 1)).toBe(true);
+  });
+
+  test('ThumbnailGrid renders every slide', async ({ page }) => {
+    await openStory(page, 'pptxviewer-layouts--thumbnail-grid');
+    await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.pptx} slides`));
+    const count = await page.locator('canvas').count();
+    expect(count).toBe(EXPECTED.pptx);
+    expect(await canvasHasInk(page, 0)).toBe(true);
+    expect(await canvasHasInk(page, EXPECTED.pptx - 1)).toBe(true);
+  });
+
+  test('MasterDetail renders thumbs + large preview and switches on click', async ({ page }) => {
+    await openStory(page, 'pptxviewer-layouts--master-detail');
+    await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.pptx} slides`));
+    const count = await page.locator('canvas').count();
+    // thumbs + 1 detail
+    expect(count).toBe(EXPECTED.pptx + 1);
+    // detail canvas is the first one we appended (layout is detail after thumbs column)
+    // — regardless of DOM order, all canvases must be inked
+    expect(await canvasHasInk(page, 0)).toBe(true);
+    expect(await canvasHasInk(page, count - 1)).toBe(true);
+
+    // Click last thumbnail cell and ensure the detail canvas is still inked.
+    const cells = page.locator('div[style*="cursor: pointer"]');
+    await cells.nth(EXPECTED.pptx - 1).click();
+    await page.waitForTimeout(500);
+    // The detail canvas is the first canvas in DOM (layout appended detailCol last → but detailCanvas is inside detailCol, thumbs in thumbCol appended first).
+    // Regardless: ensure every canvas still has content after the click.
+    for (let i = 0; i < count; i++) {
+      expect(await canvasHasInk(page, i), `canvas ${i} blank after click`).toBe(true);
+    }
+  });
+});
+
+// docx demo/sample-1 ends with a mostly-blank trailing page, so we require a
+// majority (not every) canvas to contain ink. This still catches broken renders.
+async function countInkedCanvases(page: import('@playwright/test').Page, total: number): Promise<number> {
+  let n = 0;
+  for (let i = 0; i < total; i++) {
+    if (await canvasHasInk(page, i)) n++;
+  }
+  return n;
+}
+
+test.describe('Layouts smoke — docx', () => {
+  test('ScrollView renders every page', async ({ page }) => {
+    await openStory(page, 'docxviewer-layouts--scroll-view');
+    await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.docx} pages`));
+    const count = await page.locator('canvas').count();
+    expect(count).toBe(EXPECTED.docx);
+    // first page must have ink; majority of pages must render non-blank.
+    expect(await canvasHasInk(page, 0)).toBe(true);
+    expect(await countInkedCanvases(page, count)).toBeGreaterThanOrEqual(count - 1);
+  });
+
+  test('ThumbnailGrid renders every page', async ({ page }) => {
+    await openStory(page, 'docxviewer-layouts--thumbnail-grid');
+    await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.docx} pages`));
+    const count = await page.locator('canvas').count();
+    expect(count).toBe(EXPECTED.docx);
+    expect(await canvasHasInk(page, 0)).toBe(true);
+    expect(await countInkedCanvases(page, count)).toBeGreaterThanOrEqual(count - 1);
+  });
+
+  test('MasterDetail renders thumbs + large preview', async ({ page }) => {
+    await openStory(page, 'docxviewer-layouts--master-detail');
+    await waitForLoaded(page, new RegExp(`Loaded ${EXPECTED.docx} pages`));
+    const count = await page.locator('canvas').count();
+    // N thumbs + 1 detail = N+1 canvases (but trailing page may be blank)
+    expect(count).toBe(EXPECTED.docx + 1);
+    expect(await canvasHasInk(page, 0)).toBe(true);
+    expect(await countInkedCanvases(page, count)).toBeGreaterThanOrEqual(count - 1);
+  });
+});

--- a/tests/smoke/playwright.config.ts
+++ b/tests/smoke/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: false,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://localhost:6007',
+    actionTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'chrome',
+      use: {
+        channel: 'chrome',
+        deviceScaleFactor: 1,
+        viewport: { width: 1400, height: 900 },
+      },
+    },
+  ],
+  webServer: {
+    command: 'pnpm storybook --port 6007 --no-open',
+    url: 'http://localhost:6007/iframe.html',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary

- **API alignment:** `PptxPresentation` now uses a static `load(source)` factory (URL | `ArrayBuffer`) and positional `renderSlide(canvas, index, opts)` — matching `DocxDocument` / `renderPage`. Drop `onReady` and `RenderTarget` in favor of `RenderSlideOptions`. `PptxViewer.load(source)` accepts URL or `ArrayBuffer`.
- **Layouts stories:** add `PptxViewer/Layouts` and `DocxViewer/Layouts` with three patterns (`ScrollView`, `ThumbnailGrid`, `MasterDetail`) that drive multiple canvases from a single headless instance. Confirms that the library's public API already supports flexible UI composition without interface redesign.
- **Smoke test:** add `tests/smoke/layouts.spec.ts` + a dedicated Playwright config that spins up Storybook, opens each Layouts story, and verifies the expected number of canvases are produced with non-blank pixels.

## Test plan

- [x] `npx tsc --noEmit -p packages/pptx/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p packages/docx/tsconfig.json` — clean
- [x] `npx playwright test -c tests/smoke/playwright.config.ts` — 6/6 passing
- [x] `pnpm --filter @silurus/ooxml-pptx exec playwright test --grep "demo/sample-1"` — 9/9 passing (no VRT regression; match ≥95% on all demo slides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)