### PR TITLE
chore: upgrade pnpm to 10.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "provenance": true
   },
   "type": "module",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
@@ -53,7 +55,7 @@
       "types": "./dist/types/docx.d.ts"
     }
   },
-  "packageManager": "pnpm@9.12.0",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "scripts": {
     "build": "vite build",
     "build:packages": "pnpm -r build",


### PR DESCRIPTION
## Summary
- Bump `packageManager` from `pnpm@9.12.0` to `pnpm@10.33.0` (with SHA512 integrity hash added by corepack).
- pnpm 10 is required to use npm Trusted Publishing from GitHub Actions; this change unblocks the future switch.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds on the existing `pnpm-lock.yaml` (lockfile v9.0, still supported by pnpm 10)
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)