### PR TITLE
fix(storybook): pin sidebar order so viewers render consistently

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -11,6 +11,15 @@ const preview: Preview = {
     a11y: {
       test: 'todo',
     },
+    options: {
+      storySort: {
+        order: [
+          'PptxViewer', ['*', 'Examples', 'PrivateExamples'],
+          'DocxViewer', ['*', 'Examples', 'PrivateExamples'],
+          'XlsxViewer', ['*', 'Examples', 'PrivateExamples'],
+        ],
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- Under the `packages/*/src/**/*.stories.@(...)` glob, Storybook discovers story files alphabetically by filename. Since \`Examples.stories.ts\` (E) loaded **before** \`PptxViewer.stories.ts\` (P) and \`XlsxViewer.stories.ts\` (X), the top-level \`PptxViewer\` / \`XlsxViewer\` entries rendered as component folders instead of section headers. \`DocxViewer\` happened to work because D < E.
- Fix: add an explicit `storySort.order` in `.storybook/preview.ts` that places direct stories first, then \`Examples\`, then \`PrivateExamples\` under each viewer. All three sidebars now render as sections with the same layout.

## Test plan
- [x] \`pnpm build-storybook\` succeeds and \`storybook-static/index.json\` shows direct stories before \`Examples\` for all three viewers
- [ ] After deploy, verify GitHub Pages sidebar shows PPTXVIEWER / DOCXVIEWER / XLSXVIEWER as uppercase section headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)