### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Version bump for the 0.2.0 release.

Scope since 0.1.0 (all merged via #35):
- **Breaking (minor-level for 0.x)**: PPTX Google Fonts loading is now opt-in. Consumers must pass \`useGoogleFonts: true\` to \`PptxPresentation.load()\` / \`new PptxViewer(...)\` to load webfonts from \`fonts.googleapis.com\`; default is off for privacy/GDPR.
- 512 MiB per-entry ZIP decompression cap in pptx / xlsx / docx Rust parsers to block zip-bomb DoS.
- README: npm badges, screenshot table, Security & Privacy section.

## Test plan
- [ ] Merge this PR to main
- [ ] Tag \`v0.2.0\` and push → triggers \`.github/workflows/publish.yml\`
- [ ] Verify \`@silurus/ooxml@0.2.0\` appears on npm with provenance attestation

🤖 Generated with [Claude Code](https://claude.com/claude-code)