### PR TITLE
ci(pages): deploy Storybook on tag push instead of every main commit

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -2,7 +2,8 @@ name: Deploy Storybook to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Switch the GitHub Pages Storybook deploy trigger from \`push: branches: [main]\` to \`push: tags: ['v*']\` so that the demo site always matches the currently released npm version — not whatever is in-progress on main.

\`workflow_dispatch\` is kept for manual redeploys when needed.

## Notes

- v0.2.0 is already deployed (the pre-change \`main\` push trigger fired on #36), so no immediate manual redeploy is needed.
- Next release tag push will be the first one to exercise the new trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)