### PR TITLE
docs: clarify npm unpacked size vs consumer bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ pnpm add @silurus/ooxml
 
 > **Bundler note**: this package embeds `.wasm` files. With Vite add [`vite-plugin-wasm`](https://github.com/Menci/vite-plugin-wasm); with webpack use [`experiments.asyncWebAssembly`](https://webpack.js.org/configuration/experiments/).
 
+> **Bundle size note**: npm's *Unpacked Size* figure sums ES (`.mjs`) and CJS (`.cjs`) outputs for all three formats. The size that actually lands in your app is much smaller — import only the format you need (e.g. `@silurus/ooxml/pptx`) and your bundler picks a single module format, so tree-shaking drops the other two formats entirely.
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add a note under the bundler note explaining that npm's *Unpacked Size* figure sums ES (`.mjs`) + CJS (`.cjs`) outputs for all three formats (pptx/docx/xlsx).
- Clarify that consumers importing a single format (e.g. `@silurus/ooxml/pptx`) get a much smaller bundle via tree-shaking — the other two formats are dropped entirely.

## Test plan
- [x] README renders correctly on GitHub