### PR TITLE
docs: fix broken story deep links on Storybook intro page

### DIFF
--- a/.storybook/Introduction.mdx
+++ b/.storybook/Introduction.mdx
@@ -100,7 +100,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>PowerPoint (.pptx)</h3>
       <p>Slides with shapes, groups, tables, charts, theme inheritance, and text layout.</p>
-      <a href="?path=/story/pptxviewer--default">Open PptxViewer stories →</a>
+      <a href="?path=/story/pptxviewer-examples--demo">Open PptxViewer stories →</a>
     </div>
   </div>
   <div className="sb-format-card">
@@ -108,7 +108,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>Word (.docx)</h3>
       <p>Paragraphs, runs, tables, headers/footers, inline and anchored images.</p>
-      <a href="?path=/story/docxviewer--default">Open DocxViewer stories →</a>
+      <a href="?path=/story/docxviewer-examples--demo">Open DocxViewer stories →</a>
     </div>
   </div>
   <div className="sb-format-card">
@@ -116,7 +116,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>Excel (.xlsx)</h3>
       <p>Cells, styles, merged/frozen panes, number formats, conditional formatting, charts.</p>
-      <a href="?path=/story/xlsxviewer--default">Open XlsxViewer stories →</a>
+      <a href="?path=/story/xlsxviewer-examples--demo">Open XlsxViewer stories →</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- The \"Open <Format>Viewer stories →\" links on the intro page pointed at non-existent story IDs (\`pptxviewer--default\` etc.). The actual story IDs are \`pptxviewer-examples--demo\`, \`docxviewer-examples--demo\`, \`xlsxviewer-examples--demo\` — the Examples/Demo stories under each viewer that load the bundled sample file.

## Test plan
- [x] Confirmed valid story IDs via \`storybook-static/index.json\`
- [ ] After deploy, clicking each card lands on the correct viewer demo