### PR TITLE
docs: make intro page deep links navigate the top frame

### DIFF
--- a/.storybook/Introduction.mdx
+++ b/.storybook/Introduction.mdx
@@ -100,7 +100,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>PowerPoint (.pptx)</h3>
       <p>Slides with shapes, groups, tables, charts, theme inheritance, and text layout.</p>
-      <a href="?path=/story/pptxviewer-examples--demo">Open PptxViewer stories →</a>
+      <a href="?path=/story/pptxviewer-examples--demo" target="_top">Open PptxViewer stories →</a>
     </div>
   </div>
   <div className="sb-format-card">
@@ -108,7 +108,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>Word (.docx)</h3>
       <p>Paragraphs, runs, tables, headers/footers, inline and anchored images.</p>
-      <a href="?path=/story/docxviewer-examples--demo">Open DocxViewer stories →</a>
+      <a href="?path=/story/docxviewer-examples--demo" target="_top">Open DocxViewer stories →</a>
     </div>
   </div>
   <div className="sb-format-card">
@@ -116,7 +116,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>Excel (.xlsx)</h3>
       <p>Cells, styles, merged/frozen panes, number formats, conditional formatting, charts.</p>
-      <a href="?path=/story/xlsxviewer-examples--demo">Open XlsxViewer stories →</a>
+      <a href="?path=/story/xlsxviewer-examples--demo" target="_top">Open XlsxViewer stories →</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Storybook's docs MDX is rendered inside an iframe, so \`<a href=\"?path=...\">\` was navigating the iframe itself (outer Storybook UI stayed on the Introduction page).
- Add \`target=\"_top\"\` to the three format-card deep links so clicking opens the targeted Example/Demo story in the main window.

## Test plan
- [ ] Click each card on the Introduction page and verify the main frame navigates to the correct viewer demo