### PR TITLE
docs: resolve intro deep links against Storybook root

### DIFF
--- a/.storybook/Introduction.mdx
+++ b/.storybook/Introduction.mdx
@@ -100,7 +100,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>PowerPoint (.pptx)</h3>
       <p>Slides with shapes, groups, tables, charts, theme inheritance, and text layout.</p>
-      <a href="?path=/story/pptxviewer-examples--demo" target="_top">Open PptxViewer stories →</a>
+      <a href="./?path=/story/pptxviewer-examples--demo" target="_top">Open PptxViewer stories →</a>
     </div>
   </div>
   <div className="sb-format-card">
@@ -108,7 +108,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>Word (.docx)</h3>
       <p>Paragraphs, runs, tables, headers/footers, inline and anchored images.</p>
-      <a href="?path=/story/docxviewer-examples--demo" target="_top">Open DocxViewer stories →</a>
+      <a href="./?path=/story/docxviewer-examples--demo" target="_top">Open DocxViewer stories →</a>
     </div>
   </div>
   <div className="sb-format-card">
@@ -116,7 +116,7 @@ import xlsxImg from '../docs/images/xlsx.png';
     <div className="body">
       <h3>Excel (.xlsx)</h3>
       <p>Cells, styles, merged/frozen panes, number formats, conditional formatting, charts.</p>
-      <a href="?path=/story/xlsxviewer-examples--demo" target="_top">Open XlsxViewer stories →</a>
+      <a href="./?path=/story/xlsxviewer-examples--demo" target="_top">Open XlsxViewer stories →</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- With \`target=\"_top\"\` but a query-only href, the outer frame was navigated to \`/iframe.html?path=...\` because the browser resolved the relative URL against the docs iframe's URL (\`/iframe.html\`). That hit the sandboxed story-only iframe view, not the full Storybook manager.
- Prefix the href with \`./\` so it resolves to the iframe's directory — which is the Storybook root — producing \`/?path=...\` locally and \`/office-open-xml-viewer/?path=...\` on GitHub Pages.

## Test plan
- [ ] Click each card from the Introduction page and verify the Storybook manager sidebar is visible with the target story selected