### PR TITLE
feat: add framework-agnostic autoResize utility

### DIFF
--- a/.storybook/Introduction.mdx
+++ b/.storybook/Introduction.mdx
@@ -140,6 +140,27 @@ Each format also exposes a headless engine — `PptxPresentation` / `DocxDocumen
 that renders into any caller-supplied canvas, so you can compose scroll views,
 thumbnail grids, or master-detail panes freely. See the **Layouts** stories under each viewer.
 
+## Responsive rendering
+
+`autoResize` observes an element and re-runs the render callback on every size
+change, coalesced to one call per animation frame. It is framework-agnostic —
+call it from React `useEffect`, Vue `onMounted`, Svelte `onMount`, etc., and
+invoke the returned disposer in the matching teardown hook.
+
+```typescript
+import { PptxPresentation, autoResize } from '@silurus/ooxml/pptx';
+
+const pres = await PptxPresentation.load('/deck.pptx');
+const detach = autoResize(
+  (width) => pres.renderSlide(canvas, 0, { width }),
+  canvas.parentElement!, // observe the container so canvas can fill it
+);
+
+// teardown
+detach();
+pres.destroy();
+```
+
 ## Highlights
 
 - **Canvas-only rendering.** No HTML/script from the source file is ever executed or injected into the DOM.

--- a/packages/core/src/autoResize.ts
+++ b/packages/core/src/autoResize.ts
@@ -1,0 +1,97 @@
+export interface AutoResizeOptions {
+  /**
+   * Skip rendering while `document.hidden` is true and fire once with the latest
+   * observed size when the tab becomes visible again. Default: true.
+   */
+  pauseWhenHidden?: boolean;
+}
+
+/**
+ * Observe an element's size and invoke a render callback, coalescing bursts to
+ * one call per animation frame and serializing overlapping async renders.
+ *
+ * Framework-agnostic: call from any mount/setup hook and invoke the returned
+ * disposer in the corresponding teardown hook.
+ *
+ * @example
+ * const detach = autoResize(
+ *   (width) => pres.renderSlide(canvas, 0, { width }),
+ *   canvas,
+ * );
+ * // later
+ * detach();
+ */
+export function autoResize(
+  render: (width: number, height: number) => void | Promise<void>,
+  element: Element,
+  opts: AutoResizeOptions = {},
+): () => void {
+  const pauseWhenHidden = opts.pauseWhenHidden ?? true;
+
+  let rafId: number | null = null;
+  let pendingWidth = 0;
+  let pendingHeight = 0;
+  let renderInFlight: Promise<void> | null = null;
+  let rerunAfter = false;
+  let disposed = false;
+
+  const schedule = (): void => {
+    if (disposed) return;
+    if (pauseWhenHidden && typeof document !== 'undefined' && document.hidden) return;
+    if (renderInFlight) {
+      rerunAfter = true;
+      return;
+    }
+    if (rafId !== null) return;
+    rafId = requestAnimationFrame(runFrame);
+  };
+
+  const runFrame = async (): Promise<void> => {
+    rafId = null;
+    if (disposed) return;
+    const w = pendingWidth;
+    const h = pendingHeight;
+    try {
+      const result = render(w, h);
+      renderInFlight = result instanceof Promise ? result : Promise.resolve();
+      await renderInFlight;
+    } catch (err) {
+      console.error('[autoResize] render failed:', err);
+    } finally {
+      renderInFlight = null;
+      if (rerunAfter && !disposed) {
+        rerunAfter = false;
+        schedule();
+      }
+    }
+  };
+
+  const ro = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const rect = entry.contentRect;
+      pendingWidth = rect.width;
+      pendingHeight = rect.height;
+    }
+    schedule();
+  });
+  ro.observe(element);
+
+  const onVisibility = (): void => {
+    if (typeof document !== 'undefined' && !document.hidden) schedule();
+  };
+  if (pauseWhenHidden && typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', onVisibility);
+  }
+
+  return () => {
+    disposed = true;
+    ro.disconnect();
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    if (pauseWhenHidden && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibility);
+    }
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types/common';
 export * from './types/chart';
 export { renderChart } from './chart/renderer';
+export { autoResize, type AutoResizeOptions } from './autoResize';

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -37,5 +37,8 @@
     "vite": "^6.3.5",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0"
+  },
+  "dependencies": {
+    "@silurus/ooxml-core": "workspace:*"
   }
 }

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -1,3 +1,4 @@
 export { DocxDocument } from './document';
 export { DocxViewer } from './viewer';
+export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type { Document, SectionProps, DocParagraph, DocRun, TextRun, ImageRun, RenderPageOptions } from './types';

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -1,6 +1,7 @@
 export { PptxViewer, type PptxViewerOptions } from './viewer';
 export { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 export { renderSlide, type RenderOptions } from './renderer';
+export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Presentation,
   Slide,

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -1,6 +1,7 @@
 export { XlsxWorkbook } from './workbook.js';
 export { XlsxViewer } from './viewer.js';
 export type { XlsxViewerOptions } from './viewer.js';
+export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Workbook,
   SheetMeta,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,10 @@ importers:
         version: 6.0.3
 
   packages/docx:
+    dependencies:
+      '@silurus/ooxml-core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1
@@ -597,36 +601,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -706,66 +716,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -913,36 +936,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.26':
     resolution: {integrity: sha512-iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.26':
     resolution: {integrity: sha512-AuuEOtG+YXKIjIUup4RsxYNklx6XVB3WKWfhxG6hnfPrn7vp89RNOLbbyyprgj6Sk7k9ulwGVTJElEvmBNPSCA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.26':
     resolution: {integrity: sha512-JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.26':
     resolution: {integrity: sha512-FW7V7Mbpq4+PA7BiAq76LJs8MdNuUSylyuRVfQRkhIyeWadFroZ+KOPgjku8Z/fXzngxBRvsk+PGGB0t8mGcjA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.26':
     resolution: {integrity: sha512-w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.26':
     resolution: {integrity: sha512-uDCWCNpUiqkbvPmsuPUTn/P7ag9SqNXD2JT/W3dUu7yZ2krzN+nmmoQ2xRX63/J6RYiHI7aT4jo7Z++lsljlPA==}
@@ -1471,24 +1500,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Summary
Ship a shared \`autoResize\` helper so consumers of any UI framework (React / Vue / Svelte / Solid / Qwik / Angular / vanilla) can get responsive canvas rendering without wiring up ResizeObserver themselves.

### What it does
- Observes an element's size via \`ResizeObserver\`
- Coalesces resize bursts to **one callback per animation frame**
- Serializes overlapping async renders (never starts the next while the previous is in-flight — queues instead)
- Pauses while the document is hidden; fires once with the latest size when the tab becomes visible again
- Returns a disposer that disconnects the observer, cancels any pending frame, and detaches the visibility listener

### API
\`\`\`ts
import { autoResize } from '@silurus/ooxml/pptx'; // also /docx, /xlsx, or core

const detach = autoResize(
  (width, height) => pres.renderSlide(canvas, slideIdx, { width }),
  canvas.parentElement!,
);
detach(); // teardown
\`\`\`

### Files changed
- \`packages/core/src/autoResize.ts\` — new utility
- \`packages/core/src/index.ts\` — export
- \`packages/{pptx,docx,xlsx}/src/index.ts\` — re-export
- \`packages/docx/package.json\` — declare \`@silurus/ooxml-core\` as runtime dep (was missing; only needed after this change)
- \`.storybook/Introduction.mdx\` — add a "Responsive rendering" section with a usage example

## Test plan
- [x] \`pnpm typecheck\` passes across all packages
- [x] \`pnpm build\` produces \`dist/autoResize-*.cjs\` chunk (1.07 kB)
- [x] \`pnpm build-storybook\` succeeds with the new docs section