### PR TITLE
Release 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,5 @@ export * from './types/common';
 export * from './types/chart';
 export { renderChart } from './chart/renderer';
 export { autoResize, type AutoResizeOptions } from './autoResize';
+export { buildCustomPath } from './shape/custGeom';
+export { hexToRgba, resolveFill, applyStroke } from './shape/paint';

--- a/packages/core/src/shape/custGeom.ts
+++ b/packages/core/src/shape/custGeom.ts
@@ -1,0 +1,62 @@
+import type { PathCmd } from '../types/common';
+
+/**
+ * Build a canvas path from normalised custGeom sub-paths.
+ * Coordinates in each PathCmd are in [0,1] relative to the shape bounding box;
+ * this function maps them to the canvas pixel rectangle (x, y, w, h).
+ *
+ * Pen position is tracked so `arcTo` can back-calculate the ellipse centre
+ * from the current pen point and `stAng`.
+ */
+export function buildCustomPath(
+  ctx: CanvasRenderingContext2D,
+  subpaths: PathCmd[][],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): void {
+  for (const cmds of subpaths) {
+    let penX = 0;
+    let penY = 0;
+    for (const cmd of cmds) {
+      switch (cmd.cmd) {
+        case 'moveTo':
+          ctx.moveTo(x + cmd.x * w, y + cmd.y * h);
+          penX = cmd.x; penY = cmd.y;
+          break;
+        case 'lineTo':
+          ctx.lineTo(x + cmd.x * w, y + cmd.y * h);
+          penX = cmd.x; penY = cmd.y;
+          break;
+        case 'cubicBezTo':
+          ctx.bezierCurveTo(
+            x + cmd.x1 * w, y + cmd.y1 * h,
+            x + cmd.x2 * w, y + cmd.y2 * h,
+            x + cmd.x  * w, y + cmd.y  * h,
+          );
+          penX = cmd.x; penY = cmd.y;
+          break;
+        case 'arcTo': {
+          const rw = cmd.wr * w;
+          const rh = cmd.hr * h;
+          if (rw <= 0 || rh <= 0) break;
+          const stRad = (cmd.stAng * Math.PI) / 180;
+          const swRad = (cmd.swAng * Math.PI) / 180;
+          const penAbsX = x + penX * w;
+          const penAbsY = y + penY * h;
+          const cx = penAbsX - rw * Math.cos(stRad);
+          const cy = penAbsY - rh * Math.sin(stRad);
+          const endRad = stRad + swRad;
+          ctx.ellipse(cx, cy, rw, rh, 0, stRad, endRad, swRad < 0);
+          penX = (cx + rw * Math.cos(endRad) - x) / w;
+          penY = (cy + rh * Math.sin(endRad) - y) / h;
+          break;
+        }
+        case 'close':
+          ctx.closePath();
+          break;
+      }
+    }
+  }
+}

--- a/packages/core/src/shape/paint.ts
+++ b/packages/core/src/shape/paint.ts
@@ -1,0 +1,89 @@
+import type { Fill, Stroke } from '../types/common';
+
+/**
+ * Convert a 6- or 8-char hex colour to a CSS `rgba()` string.
+ * 8-char hex encodes alpha in the last two chars (RRGGBBAA).
+ * `alpha` applies to 6-char hex; ignored for 8-char.
+ */
+export function hexToRgba(hex: string, alpha = 1): string {
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const a = hex.length >= 8 ? parseInt(hex.slice(6, 8), 16) / 255 : alpha;
+  return `rgba(${r},${g},${b},${a})`;
+}
+
+/**
+ * Resolve a Fill to a CanvasRenderingContext2D-compatible paint.
+ * Gradients require pixel bounds (x, y, w, h) to construct the CanvasGradient.
+ * Returns null for noFill.
+ */
+export function resolveFill(
+  fill: Fill | null,
+  ctx: CanvasRenderingContext2D,
+  x: number, y: number, w: number, h: number,
+): string | CanvasGradient | null {
+  if (!fill || fill.fillType === 'none') return null;
+  if (fill.fillType === 'solid') return hexToRgba(fill.color);
+  if (fill.fillType === 'gradient') {
+    const stops = fill.stops;
+    if (stops.length === 0) return null;
+    if (stops.length === 1) return hexToRgba(stops[0].color);
+
+    let gradient: CanvasGradient;
+    if (fill.gradType === 'radial') {
+      const cx = x + w / 2;
+      const cy = y + h / 2;
+      const r = Math.sqrt(w * w + h * h) / 2;
+      gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+    } else {
+      const rad = (fill.angle * Math.PI) / 180;
+      const cx = x + w / 2;
+      const cy = y + h / 2;
+      const gradLen = (Math.abs(Math.cos(rad)) * w + Math.abs(Math.sin(rad)) * h) / 2;
+      gradient = ctx.createLinearGradient(
+        cx - Math.cos(rad) * gradLen, cy - Math.sin(rad) * gradLen,
+        cx + Math.cos(rad) * gradLen, cy + Math.sin(rad) * gradLen,
+      );
+    }
+    for (const stop of stops) {
+      gradient.addColorStop(Math.min(1, Math.max(0, stop.position)), hexToRgba(stop.color));
+    }
+    return gradient;
+  }
+  return null;
+}
+
+const DASH_PATTERNS: Record<string, number[]> = {
+  dash:         [6, 3],
+  dot:          [1.5, 3],
+  dashDot:      [6, 3, 1.5, 3],
+  lgDash:       [10, 4],
+  lgDashDot:    [10, 4, 1.5, 4],
+  lgDashDotDot: [10, 4, 1.5, 4, 1.5, 4],
+  sysDash:      [4, 2],
+  sysDot:       [1, 2],
+  sysDashDot:   [4, 2, 1, 2],
+};
+
+/**
+ * Apply a Stroke to ctx. `emuPerPx` converts stroke width from EMU to px
+ * (e.g. scale factor from pptx's emuToPx).
+ */
+export function applyStroke(
+  ctx: CanvasRenderingContext2D,
+  stroke: Stroke | null,
+  emuPerPx: number,
+): void {
+  if (!stroke) {
+    ctx.strokeStyle = 'transparent';
+    ctx.lineWidth = 0;
+    ctx.setLineDash([]);
+    return;
+  }
+  ctx.strokeStyle = hexToRgba(stroke.color);
+  const lw = Math.max(0.5, stroke.width * emuPerPx);
+  ctx.lineWidth = lw;
+  const pat = stroke.dashStyle ? DASH_PATTERNS[stroke.dashStyle] : null;
+  ctx.setLineDash(pat ? pat.map((v) => v * lw) : []);
+}

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -26,17 +26,34 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     let cursor = std::io::Cursor::new(data);
     let mut zip = ZipArchive::new(cursor).map_err(|e| e.to_string())?;
 
-    let style_map = read_zip_entry(&mut zip, "word/styles.xml")
+    let rels_xml = read_zip_entry(&mut zip, "word/_rels/document.xml.rels")
+        .unwrap_or_default();
+    let rel_map = parse_rels(&rels_xml);
+
+    // Styles are referenced from the document relationships (Target may be
+    // "styles.xml" or "styles2.xml"). Fall back to "word/styles.xml" for old files.
+    let styles_path = find_rel_target(&rels_xml, "styles")
+        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .unwrap_or_else(|| "word/styles.xml".to_string());
+    let style_map = read_zip_entry(&mut zip, &styles_path)
         .map(|s| StyleMap::parse(&s))
         .unwrap_or_else(|_| StyleMap::parse(""));
 
-    let mut num_map = read_zip_entry(&mut zip, "word/numbering.xml")
+    let numbering_path = find_rel_target(&rels_xml, "numbering")
+        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .unwrap_or_else(|| "word/numbering.xml".to_string());
+    let mut num_map = read_zip_entry(&mut zip, &numbering_path)
         .map(|s| NumberingMap::parse(&s))
         .unwrap_or_default();
 
-    let rels = read_zip_entry(&mut zip, "word/_rels/document.xml.rels")
+    // Theme is referenced by a relationship with Type ending in "/theme" — resolve
+    // to word/<target> and parse the clrScheme.
+    let theme = find_rel_target(&rels_xml, "theme")
+        .map(|t| {
+            let p = if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) };
+            read_zip_entry(&mut zip, &p).map(|s| ThemeColors::parse(&s)).unwrap_or_default()
+        })
         .unwrap_or_default();
-    let rel_map = parse_rels(&rels);
 
     let media_map = load_media_map(&mut zip, &rel_map, "word/");
 
@@ -55,12 +72,66 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
 
     let (section, refs) = parse_section(sect_pr, &rel_map);
 
-    let body = parse_body_elements(body_node, &style_map, &mut num_map, &media_map, &rel_map);
+    let body = parse_body_elements(body_node, &style_map, &mut num_map, &media_map, &rel_map, &theme);
 
-    let headers = load_header_footer_set(&mut zip, &refs.headers, "hdr", &style_map, &mut num_map);
-    let footers = load_header_footer_set(&mut zip, &refs.footers, "ftr", &style_map, &mut num_map);
+    let headers = load_header_footer_set(&mut zip, &refs.headers, "hdr", &style_map, &mut num_map, &theme);
+    let footers = load_header_footer_set(&mut zip, &refs.footers, "ftr", &style_map, &mut num_map, &theme);
 
     Ok(Document { section, body, headers, footers })
+}
+
+/// Resolve scheme color names (accent1..6, dk1, dk2, lt1, lt2, hlink, folHlink)
+/// to hex strings parsed from word/theme/themeN.xml clrScheme.
+#[derive(Debug, Default, Clone)]
+pub struct ThemeColors {
+    map: HashMap<String, String>,
+}
+
+impl ThemeColors {
+    fn parse(xml: &str) -> Self {
+        let mut map: HashMap<String, String> = HashMap::new();
+        let doc = match XmlDoc::parse(xml) { Ok(d) => d, Err(_) => return Self { map } };
+        let Some(scheme) = doc.descendants().find(|n| n.is_element() && n.tag_name().name() == "clrScheme") else {
+            return Self { map };
+        };
+        for child in scheme.children().filter(|n| n.is_element()) {
+            let name = child.tag_name().name().to_string();
+            let hex = child.children().filter(|n| n.is_element()).find_map(|n| {
+                match n.tag_name().name() {
+                    "srgbClr" => n.attribute("val").map(|v| v.to_uppercase()),
+                    "sysClr" => n.attribute("lastClr").map(|v| v.to_uppercase()),
+                    _ => None,
+                }
+            });
+            if let Some(h) = hex { map.insert(name, h); }
+        }
+        Self { map }
+    }
+
+    fn resolve(&self, scheme_name: &str) -> Option<String> {
+        // "bg1"/"bg2"/"tx1"/"tx2" map onto lt1/lt2/dk1/dk2 per spec
+        let key = match scheme_name {
+            "bg1" => "lt1",
+            "bg2" => "lt2",
+            "tx1" => "dk1",
+            "tx2" => "dk2",
+            other => other,
+        };
+        self.map.get(key).cloned()
+    }
+}
+
+fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
+    if rels_xml.is_empty() { return None; }
+    let doc = XmlDoc::parse(rels_xml).ok()?;
+    for rel in doc.root_element().children().filter(|n| n.tag_name().name() == "Relationship") {
+        if let (Some(ty), Some(target)) = (rel.attribute("Type"), rel.attribute("Target")) {
+            if ty.ends_with(&format!("/{}", type_suffix)) {
+                return Some(target.to_string());
+            }
+        }
+    }
+    None
 }
 
 fn parse_body_elements(
@@ -69,6 +140,7 @@ fn parse_body_elements(
     num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
+    theme: &ThemeColors,
 ) -> Vec<BodyElement> {
     let mut body: Vec<BodyElement> = Vec::new();
     // The body-level sectPr (the last element) defines the final section and
@@ -84,7 +156,7 @@ fn parse_body_elements(
     for child in body_children {
         match child.tag_name().name() {
             "p" => {
-                let result = parse_paragraph(child, style_map, num_map, media_map, rel_map);
+                let result = parse_paragraph(child, style_map, num_map, media_map, rel_map, theme);
                 let is_page_break_only = result.runs.len() == 1 && matches!(
                     result.runs[0],
                     DocRun::Break { break_type: BreakType::Page }
@@ -104,7 +176,7 @@ fn parse_body_elements(
                 }
             }
             "tbl" => {
-                let tbl = parse_table(child, style_map, num_map, media_map, rel_map);
+                let tbl = parse_table(child, style_map, num_map, media_map, rel_map, theme);
                 body.push(BodyElement::Table(tbl));
             }
             "sectPr" => {
@@ -152,6 +224,7 @@ fn load_header_footer_set(
     root_tag: &str,
     style_map: &StyleMap,
     num_map: &mut NumberingMap,
+    theme: &ThemeColors,
 ) -> HeadersFooters {
     let mut out = HeadersFooters::default();
     for (kind, target) in type_to_target {
@@ -176,7 +249,7 @@ fn load_header_footer_set(
             continue;
         };
 
-        let body = parse_body_elements(root, style_map, num_map, &local_media_map, &local_rel_map);
+        let body = parse_body_elements(root, style_map, num_map, &local_media_map, &local_rel_map, theme);
         let hf = HeaderFooter { body };
         match kind.as_str() {
             "first" => out.first = Some(hf),
@@ -246,16 +319,17 @@ fn parse_paragraph(
     num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
+    theme: &ThemeColors,
 ) -> DocParagraph {
-    // Get style ID from pPr/pStyle; fall back to "Normal" (default paragraph style)
+    // Get style ID from pPr/pStyle. When absent, resolve_para falls back to the
+    // paragraph style marked w:default="1" via StyleMap::default_para_style_id.
     let ppr_node = child_w(node, "pPr");
-    let style_id = ppr_node
+    let explicit_style_id = ppr_node
         .and_then(|p| child_w(p, "pStyle"))
-        .and_then(|s| attr_w(s, "val"))
-        .or_else(|| Some("Normal".to_string()));
+        .and_then(|s| attr_w(s, "val"));
 
     // Resolve base formatting from style
-    let (mut base_para, mut base_run) = style_map.resolve_para(style_id.as_deref());
+    let (mut base_para, mut base_run) = style_map.resolve_para(explicit_style_id.as_deref());
 
     // Apply direct paragraph formatting overrides
     if let Some(ppr) = ppr_node {
@@ -300,7 +374,7 @@ fn parse_paragraph(
 
     // Parse runs
     let mut runs = vec![];
-    parse_para_content(node, &base_run, style_map, media_map, rel_map, &mut runs);
+    parse_para_content(node, &base_run, style_map, media_map, rel_map, theme, &mut runs);
 
     let tab_stops = base_para.tab_stops.clone().unwrap_or_default().into_iter()
         .map(|(pos, alignment, leader)| TabStop { pos, alignment, leader })
@@ -321,10 +395,7 @@ fn parse_paragraph(
         page_break_before: base_para.page_break_before.unwrap_or(false),
         contextual_spacing: base_para.contextual_spacing.unwrap_or(false),
         borders: base_para.para_borders.clone(),
-        style_id: ppr_node
-            .and_then(|p| child_w(p, "pStyle"))
-            .and_then(|s| attr_w(s, "val"))
-            .or_else(|| Some("Normal".to_string())),
+        style_id: explicit_style_id.clone().or_else(|| Some("Normal".to_string())),
         default_font_size: base_run.font_size,
     }
 }
@@ -349,6 +420,7 @@ fn parse_para_content(
     style_map: &StyleMap,
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
+    theme: &ThemeColors,
     runs: &mut Vec<DocRun>,
 ) {
     let mut field = FieldState::default();
@@ -356,7 +428,7 @@ fn parse_para_content(
     for child in element_children_flat(node) {
         match child.tag_name().name() {
             "r" => {
-                handle_run_in_para(child, base_run, style_map, media_map, runs, &mut field, None);
+                handle_run_in_para(child, base_run, style_map, media_map, theme, runs, &mut field, None);
             }
             "hyperlink" => {
                 // Resolve URL from r:id via relationships
@@ -364,11 +436,11 @@ fn parse_para_content(
                     .or_else(|| child.attribute("id"))
                     .and_then(|rid| rel_map.get(rid).cloned());
                 for r in child.children().filter(|n| n.is_element() && n.tag_name().name() == "r") {
-                    handle_run_in_para(r, base_run, style_map, media_map, runs, &mut field, Some(href.clone()));
+                    handle_run_in_para(r, base_run, style_map, media_map, theme, runs, &mut field, Some(href.clone()));
                 }
             }
             "ins" | "del" | "smartTag" => {
-                parse_para_content(child, base_run, style_map, media_map, rel_map, runs);
+                parse_para_content(child, base_run, style_map, media_map, rel_map, theme, runs);
             }
             "fldSimple" => {
                 let instr = attr_w(child, "instr").unwrap_or_default();
@@ -392,6 +464,7 @@ fn handle_run_in_para(
     base_run: &RunFmt,
     style_map: &StyleMap,
     media_map: &HashMap<String, String>,
+    theme: &ThemeColors,
     runs: &mut Vec<DocRun>,
     field: &mut FieldState,
     // Outer None = not inside a hyperlink. Some(None) = hyperlink without URL. Some(Some(url)) = hyperlink with URL.
@@ -465,7 +538,7 @@ fn handle_run_in_para(
     }
 
     // Normal run
-    parse_run_inner(r_node, base_run, style_map, media_map, runs, link_href);
+    parse_run_inner(r_node, base_run, style_map, media_map, theme, runs, link_href);
 }
 
 fn extract_text_from_runs(node: roxmltree::Node) -> String {
@@ -516,6 +589,7 @@ fn parse_run_inner(
     base_run: &RunFmt,
     style_map: &StyleMap,
     media_map: &HashMap<String, String>,
+    theme: &ThemeColors,
     runs: &mut Vec<DocRun>,
     link_href: Option<Option<String>>,
 ) {
@@ -611,8 +685,8 @@ fn parse_run_inner(
                 runs.push(DocRun::Break { break_type });
             }
             "drawing" => {
-                for img in parse_inline_drawing(child, media_map) {
-                    runs.push(DocRun::Image(img));
+                for r in parse_inline_drawing(child, media_map, theme) {
+                    runs.push(r);
                 }
             }
             "AlternateContent" => {
@@ -620,8 +694,8 @@ fn parse_run_inner(
                 if let Some(choice) = child.children().find(|n| n.tag_name().name() == "Choice") {
                     for inner in choice.children().filter(|n| n.is_element()) {
                         if inner.tag_name().name() == "drawing" {
-                            for img in parse_inline_drawing(inner, media_map) {
-                                runs.push(DocRun::Image(img));
+                            for r in parse_inline_drawing(inner, media_map, theme) {
+                                runs.push(r);
                             }
                         }
                     }
@@ -632,7 +706,11 @@ fn parse_run_inner(
     }
 }
 
-fn parse_inline_drawing(node: roxmltree::Node, media_map: &HashMap<String, String>) -> Vec<ImageRun> {
+fn parse_inline_drawing(
+    node: roxmltree::Node,
+    media_map: &HashMap<String, String>,
+    theme: &ThemeColors,
+) -> Vec<DocRun> {
     // Distinguish inline vs anchor
     let is_anchor = node.descendants().any(|n| n.tag_name().name() == "anchor");
 
@@ -665,7 +743,7 @@ fn parse_inline_drawing(node: roxmltree::Node, media_map: &HashMap<String, Strin
             Some(u) => u.clone(),
             None => return vec![],
         };
-        return vec![ImageRun {
+        return vec![DocRun::Image(ImageRun {
             data_url,
             width_pt: cx / 12700.0,
             height_pt: cy / 12700.0,
@@ -681,10 +759,10 @@ fn parse_inline_drawing(node: roxmltree::Node, media_map: &HashMap<String, Strin
             dist_left: 0.0,
             dist_right: 0.0,
             wrap_side: None,
-        }];
+        })];
     }
 
-    // ── Anchor image ──────────────────────────────────────
+    // ── Anchor image/shape ─────────────────────────────────
     let container = match node.descendants().find(|n| n.tag_name().name() == "anchor") {
         Some(c) => c,
         None => return vec![],
@@ -695,9 +773,28 @@ fn parse_inline_drawing(node: roxmltree::Node, media_map: &HashMap<String, Strin
     let (pos_y, y_from_para)   = parse_anchor_pos_v(&container);
     let anchor_meta = parse_anchor_wrap(&container);
 
-    // Check for wgp (Word Graphics Group) — expands to multiple per-image entries
+    // behindDoc="1" flag — renderer uses this to draw shapes before text
+    let behind_doc = container.attribute("behindDoc").map(|v| v == "1" || v == "true").unwrap_or(false);
+
+    // Check for wgp (Word Graphics Group) — expands to multiple per-element entries
     if let Some(wgp) = container.descendants().find(|n| n.tag_name().name() == "wgp") {
-        return parse_wgp_images(wgp, media_map, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta);
+        let mut out: Vec<DocRun> = Vec::new();
+        for img in parse_wgp_images(wgp, media_map, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta) {
+            out.push(DocRun::Image(img));
+        }
+        for mut shp in parse_wgp_shapes(wgp, theme, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta) {
+            shp.behind_doc = behind_doc;
+            out.push(DocRun::Shape(shp));
+        }
+        return out;
+    }
+
+    // wps:wsp directly under the anchor (no wgp wrapper)
+    if let Some(wsp) = container.descendants().find(|n| n.tag_name().name() == "wsp") {
+        if let Some(mut shp) = parse_wsp_shape(wsp, theme, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta, 1.0, 1.0, 0.0, 0.0, 0) {
+            shp.behind_doc = behind_doc;
+            return vec![DocRun::Shape(shp)];
+        }
     }
 
     // Regular single-blip anchor
@@ -725,7 +822,7 @@ fn parse_inline_drawing(node: roxmltree::Node, media_map: &HashMap<String, Strin
         Some(u) => u.clone(),
         None => return vec![],
     };
-    vec![ImageRun {
+    vec![DocRun::Image(ImageRun {
         data_url,
         width_pt: cx / 12700.0,
         height_pt: cy / 12700.0,
@@ -741,7 +838,7 @@ fn parse_inline_drawing(node: roxmltree::Node, media_map: &HashMap<String, Strin
         dist_left: anchor_meta.dist_left,
         dist_right: anchor_meta.dist_right,
         wrap_side: anchor_meta.wrap_side.clone(),
-    }]
+    })]
 }
 
 #[derive(Default, Clone)]
@@ -897,6 +994,325 @@ fn parse_wgp_images(
     results
 }
 
+/// Expand wps:wsp descendants of a wgp into ShapeRun entries. Applies
+/// wgp grpSpPr transform (chOff/chExt → off/ext scale) to each child shape.
+fn parse_wgp_shapes(
+    wgp: roxmltree::Node,
+    theme: &ThemeColors,
+    anchor_pos_x: f64,
+    x_from_margin: bool,
+    anchor_pos_y: f64,
+    y_from_para: bool,
+    anchor_meta: &AnchorMeta,
+) -> Vec<ShapeRun> {
+    // Read group transform: off/ext (page-relative) vs chOff/chExt (child coord space).
+    let grp_xfrm = wgp.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "grpSpPr")
+        .and_then(|gsp| gsp.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm"));
+    let (off_x, off_y, ext_cx, ext_cy, ch_off_x, ch_off_y, ch_ext_cx, ch_ext_cy) = grp_xfrm
+        .map(|x| {
+            let off = x.children().find(|n| n.is_element() && n.tag_name().name() == "off");
+            let ext = x.children().find(|n| n.is_element() && n.tag_name().name() == "ext");
+            let ch_off = x.children().find(|n| n.is_element() && n.tag_name().name() == "chOff");
+            let ch_ext = x.children().find(|n| n.is_element() && n.tag_name().name() == "chExt");
+            (
+                off.and_then(|o| o.attribute("x").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                off.and_then(|o| o.attribute("y").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                ext.and_then(|e| e.attribute("cx").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                ext.and_then(|e| e.attribute("cy").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                ch_off.and_then(|o| o.attribute("x").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                ch_off.and_then(|o| o.attribute("y").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                ch_ext.and_then(|e| e.attribute("cx").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                ch_ext.and_then(|e| e.attribute("cy").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+            )
+        })
+        .unwrap_or((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+
+    let sx = if ch_ext_cx > 0.0 && ext_cx > 0.0 { ext_cx / ch_ext_cx } else { 1.0 };
+    let sy = if ch_ext_cy > 0.0 && ext_cy > 0.0 { ext_cy / ch_ext_cy } else { 1.0 };
+    // Page-relative offset of the group origin, in EMU. ch_off is subtracted
+    // because child coordinates are measured relative to chOff.
+    let group_page_off_x_emu = off_x - ch_off_x * sx;
+    let group_page_off_y_emu = off_y - ch_off_y * sy;
+
+    let mut results = Vec::new();
+    for (idx, wsp) in wgp.descendants().filter(|n| n.is_element() && n.tag_name().name() == "wsp").enumerate() {
+        if let Some(shape) = parse_wsp_shape(
+            wsp, theme,
+            anchor_pos_x, x_from_margin,
+            anchor_pos_y, y_from_para,
+            anchor_meta,
+            sx, sy,
+            group_page_off_x_emu / 12700.0, group_page_off_y_emu / 12700.0,
+            idx as u32,
+        ) {
+            results.push(shape);
+        }
+    }
+    results
+}
+
+/// Parse a single wps:wsp into ShapeRun. `sx,sy` scale the shape's spPr/xfrm
+/// from group child coord space to page EMU; `group_off_pt_*` are the group origin
+/// on the page (in pt) so the shape's off.x/off.y (in child coord space) can be
+/// translated to page-relative pt. For a standalone wsp (no wgp), pass sx=sy=1, group_off=0.
+fn parse_wsp_shape(
+    wsp: roxmltree::Node,
+    theme: &ThemeColors,
+    anchor_pos_x: f64,
+    x_from_margin: bool,
+    anchor_pos_y: f64,
+    y_from_para: bool,
+    anchor_meta: &AnchorMeta,
+    sx: f64,
+    sy: f64,
+    group_off_pt_x: f64,
+    group_off_pt_y: f64,
+    z_order: u32,
+) -> Option<ShapeRun> {
+    let sp_pr = wsp.children().find(|n| n.is_element() && n.tag_name().name() == "spPr")?;
+    let xfrm = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm")?;
+    let off = xfrm.children().find(|n| n.is_element() && n.tag_name().name() == "off")?;
+    let ext = xfrm.children().find(|n| n.is_element() && n.tag_name().name() == "ext")?;
+    let ox = off.attribute("x").and_then(|v| v.parse::<f64>().ok())?;
+    let oy = off.attribute("y").and_then(|v| v.parse::<f64>().ok())?;
+    let cx = ext.attribute("cx").and_then(|v| v.parse::<f64>().ok())?;
+    let cy = ext.attribute("cy").and_then(|v| v.parse::<f64>().ok())?;
+    if cx <= 0.0 || cy <= 0.0 { return None; }
+    let rotation = xfrm.attribute("rot")
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|r| r / 60000.0) // OOXML rotation: 60000ths of a degree
+        .unwrap_or(0.0);
+
+    let width_pt = cx * sx / 12700.0;
+    let height_pt = cy * sy / 12700.0;
+    let anchor_x_pt = anchor_pos_x + group_off_pt_x + ox * sx / 12700.0;
+    let anchor_y_pt = anchor_pos_y + group_off_pt_y + oy * sy / 12700.0;
+
+    let cust_geom = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "custGeom");
+    let subpaths = cust_geom.map(parse_custom_geometry).unwrap_or_default();
+    if subpaths.is_empty() { return None; }
+
+    let fill = parse_shape_fill(sp_pr, theme);
+    let (stroke, stroke_width) = sp_pr.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "ln")
+        .map(|ln| {
+            let has_no_fill = ln.children().any(|n| n.is_element() && n.tag_name().name() == "noFill");
+            if has_no_fill { return (None, 0.0); }
+            let color = ln.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+                .and_then(|sf| resolve_color_element(sf, theme));
+            let w_emu = ln.attribute("w").and_then(|v| v.parse::<f64>().ok()).unwrap_or(9525.0);
+            (color, w_emu / 12700.0)
+        })
+        .unwrap_or((None, 0.0));
+
+    Some(ShapeRun {
+        width_pt,
+        height_pt,
+        anchor_x_pt,
+        anchor_y_pt,
+        anchor_x_from_margin: x_from_margin,
+        anchor_y_from_para: y_from_para,
+        behind_doc: false,
+        z_order,
+        subpaths,
+        fill,
+        stroke,
+        stroke_width,
+        rotation,
+        wrap_mode: anchor_meta.wrap_mode.clone(),
+    })
+}
+
+/// Parse a shape's fill (solidFill or gradFill). Returns None for noFill/missing.
+fn parse_shape_fill(sp_pr: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeFill> {
+    for child in sp_pr.children().filter(|n| n.is_element()) {
+        match child.tag_name().name() {
+            "solidFill" => {
+                return resolve_color_element(child, theme).map(|c| ShapeFill::Solid { color: c });
+            }
+            "gradFill" => {
+                return parse_grad_fill(child, theme);
+            }
+            "noFill" => return None,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn parse_grad_fill(node: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeFill> {
+    let gs_lst = node.children().find(|n| n.is_element() && n.tag_name().name() == "gsLst")?;
+    let mut stops: Vec<GradientStop> = Vec::new();
+    for gs in gs_lst.children().filter(|n| n.is_element() && n.tag_name().name() == "gs") {
+        let pos = gs.attribute("pos").and_then(|v| v.parse::<f64>().ok()).map(|p| p / 100000.0).unwrap_or(0.0);
+        if let Some(color) = resolve_color_element(gs, theme) {
+            stops.push(GradientStop { position: pos, color });
+        }
+    }
+    if stops.is_empty() { return None; }
+
+    // Linear direction (a:lin ang = "60000"ths of a degree)
+    let (angle, grad_type) = if let Some(lin) = node.children().find(|n| n.is_element() && n.tag_name().name() == "lin") {
+        let ang = lin.attribute("ang").and_then(|v| v.parse::<f64>().ok()).map(|a| a / 60000.0).unwrap_or(0.0);
+        (ang, "linear".to_string())
+    } else if node.children().any(|n| n.is_element() && n.tag_name().name() == "path") {
+        (0.0, "radial".to_string())
+    } else {
+        (0.0, "linear".to_string())
+    };
+
+    Some(ShapeFill::Gradient { stops, angle, grad_type })
+}
+
+/// Parse <a:custGeom><a:pathLst><a:path w="W" h="H">...</a:path></a:pathLst>.
+/// Path coords inside each <a:path> are absolute within W×H; normalize to [0,1].
+fn parse_custom_geometry(cust_geom: roxmltree::Node) -> Vec<Vec<PathCmd>> {
+    let Some(path_lst) = cust_geom.children().find(|n| n.is_element() && n.tag_name().name() == "pathLst") else {
+        return vec![];
+    };
+    let mut subpaths: Vec<Vec<PathCmd>> = Vec::new();
+    for path in path_lst.children().filter(|n| n.is_element() && n.tag_name().name() == "path") {
+        let pw = path.attribute("w").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0);
+        let ph = path.attribute("h").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0);
+        if pw <= 0.0 || ph <= 0.0 { continue; }
+        let mut cmds: Vec<PathCmd> = Vec::new();
+        for cmd in path.children().filter(|n| n.is_element()) {
+            let name = cmd.tag_name().name();
+            let pts: Vec<(f64, f64)> = cmd.children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+                .filter_map(|p| {
+                    let x = p.attribute("x").and_then(|v| v.parse::<f64>().ok())?;
+                    let y = p.attribute("y").and_then(|v| v.parse::<f64>().ok())?;
+                    Some((x / pw, y / ph))
+                })
+                .collect();
+            match name {
+                "moveTo" => { if let Some(p) = pts.first() { cmds.push(PathCmd::MoveTo { x: p.0, y: p.1 }); } }
+                "lnTo" => { if let Some(p) = pts.first() { cmds.push(PathCmd::LineTo { x: p.0, y: p.1 }); } }
+                "cubicBezTo" => {
+                    if pts.len() >= 3 {
+                        cmds.push(PathCmd::CubicBezTo {
+                            x1: pts[0].0, y1: pts[0].1,
+                            x2: pts[1].0, y2: pts[1].1,
+                            x:  pts[2].0, y:  pts[2].1,
+                        });
+                    }
+                }
+                "arcTo" => {
+                    let wr = cmd.attribute("wR").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / pw;
+                    let hr = cmd.attribute("hR").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / ph;
+                    let st_ang = cmd.attribute("stAng").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 60000.0;
+                    let sw_ang = cmd.attribute("swAng").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 60000.0;
+                    cmds.push(PathCmd::ArcTo { wr, hr, st_ang, sw_ang });
+                }
+                "close" => cmds.push(PathCmd::Close),
+                _ => {}
+            }
+        }
+        if !cmds.is_empty() { subpaths.push(cmds); }
+    }
+    subpaths
+}
+
+/// Resolve a color container (e.g. <a:solidFill>, <a:gs>) into a hex string by
+/// inspecting its child: <a:srgbClr>, <a:schemeClr>, or <a:sysClr>, applying
+/// any lumMod/lumOff/alpha modifiers declared on the inner color element.
+fn resolve_color_element(container: roxmltree::Node, theme: &ThemeColors) -> Option<String> {
+    for c in container.children().filter(|n| n.is_element()) {
+        let base = match c.tag_name().name() {
+            "srgbClr" => c.attribute("val").map(|v| v.to_uppercase()),
+            "schemeClr" => c.attribute("val").and_then(|name| theme.resolve(name)),
+            "sysClr" => c.attribute("lastClr").map(|v| v.to_uppercase())
+                .or_else(|| c.attribute("val").map(|v| v.to_uppercase())),
+            _ => None,
+        };
+        let Some(hex) = base else { continue };
+        return Some(apply_color_mods(&hex, c));
+    }
+    None
+}
+
+/// Apply OOXML color modifiers (lumMod / lumOff) declared as child elements.
+/// lumMod multiplies L by mod/100000; lumOff adds off/100000 to L. Both are
+/// evaluated in HSL space per ECMA-376.
+fn apply_color_mods(hex: &str, color_node: roxmltree::Node) -> String {
+    let (r, g, b) = hex_to_rgb(hex);
+    let (mut h, mut s, mut l) = rgb_to_hsl(r, g, b);
+
+    for m in color_node.children().filter(|n| n.is_element()) {
+        let val = m.attribute("val").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 100000.0;
+        match m.tag_name().name() {
+            "lumMod" => l *= val,
+            "lumOff" => l += val,
+            "satMod" => s *= val,
+            "satOff" => s += val,
+            "hueMod" => h *= val,
+            "hueOff" => h += val,
+            "shade" => { l *= val; s *= val; }
+            "tint" => { l = l + (1.0 - l) * val; }
+            _ => {}
+        }
+    }
+    l = l.clamp(0.0, 1.0);
+    s = s.clamp(0.0, 1.0);
+    let (nr, ng, nb) = hsl_to_rgb(h, s, l);
+    format!("{:02X}{:02X}{:02X}", nr, ng, nb)
+}
+
+fn hex_to_rgb(hex: &str) -> (u8, u8, u8) {
+    let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
+    let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
+    let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
+    (r, g, b)
+}
+
+fn rgb_to_hsl(r: u8, g: u8, b: u8) -> (f64, f64, f64) {
+    let rf = r as f64 / 255.0;
+    let gf = g as f64 / 255.0;
+    let bf = b as f64 / 255.0;
+    let max = rf.max(gf.max(bf));
+    let min = rf.min(gf.min(bf));
+    let l = (max + min) / 2.0;
+    let d = max - min;
+    if d == 0.0 { return (0.0, 0.0, l); }
+    let s = if l > 0.5 { d / (2.0 - max - min) } else { d / (max + min) };
+    let h = if max == rf {
+        ((gf - bf) / d + if gf < bf { 6.0 } else { 0.0 }) / 6.0
+    } else if max == gf {
+        ((bf - rf) / d + 2.0) / 6.0
+    } else {
+        ((rf - gf) / d + 4.0) / 6.0
+    };
+    (h, s, l)
+}
+
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
+    if s == 0.0 {
+        let v = (l * 255.0).round().clamp(0.0, 255.0) as u8;
+        return (v, v, v);
+    }
+    let q = if l < 0.5 { l * (1.0 + s) } else { l + s - l * s };
+    let p = 2.0 * l - q;
+    let hue2rgb = |p: f64, q: f64, mut t: f64| -> f64 {
+        if t < 0.0 { t += 1.0; }
+        if t > 1.0 { t -= 1.0; }
+        if t < 1.0 / 6.0 { return p + (q - p) * 6.0 * t; }
+        if t < 1.0 / 2.0 { return q; }
+        if t < 2.0 / 3.0 { return p + (q - p) * (2.0 / 3.0 - t) * 6.0; }
+        p
+    };
+    let r = hue2rgb(p, q, h + 1.0 / 3.0);
+    let g = hue2rgb(p, q, h);
+    let b = hue2rgb(p, q, h - 1.0 / 3.0);
+    (
+        (r * 255.0).round().clamp(0.0, 255.0) as u8,
+        (g * 255.0).round().clamp(0.0, 255.0) as u8,
+        (b * 255.0).round().clamp(0.0, 255.0) as u8,
+    )
+}
+
 // ===== Table parsing =====
 
 fn parse_table(
@@ -905,6 +1321,7 @@ fn parse_table(
     num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
+    theme: &ThemeColors,
 ) -> DocTable {
     let tbl_pr = child_w(node, "tblPr");
     let tbl_grid = child_w(node, "tblGrid");
@@ -935,7 +1352,7 @@ fn parse_table(
 
     let mut rows = vec![];
     for tr_node in children_w_flat(node, "tr") {
-        let row = parse_table_row(tr_node, style_map, num_map, media_map, rel_map);
+        let row = parse_table_row(tr_node, style_map, num_map, media_map, rel_map, theme);
         rows.push(row);
     }
 
@@ -956,6 +1373,7 @@ fn parse_table_row(
     num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
+    theme: &ThemeColors,
 ) -> DocTableRow {
     let tr_pr = child_w(node, "trPr");
     let row_height = tr_pr
@@ -966,7 +1384,7 @@ fn parse_table_row(
 
     let mut cells = vec![];
     for tc_node in children_w_flat(node, "tc") {
-        let cell = parse_table_cell(tc_node, style_map, num_map, media_map, rel_map);
+        let cell = parse_table_cell(tc_node, style_map, num_map, media_map, rel_map, theme);
         cells.push(cell);
     }
 
@@ -979,6 +1397,7 @@ fn parse_table_cell(
     num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
+    theme: &ThemeColors,
 ) -> DocTableCell {
     let tc_pr = child_w(node, "tcPr");
 
@@ -1015,7 +1434,7 @@ fn parse_table_cell(
 
     let mut content = vec![];
     for p_node in children_w_flat(node, "p") {
-        content.push(parse_paragraph(p_node, style_map, num_map, media_map, rel_map));
+        content.push(parse_paragraph(p_node, style_map, num_map, media_map, rel_map, theme));
     }
 
     DocTableCell { content, col_span, v_merge, borders, background, v_align, width_pt }

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -67,6 +67,9 @@ pub struct StyleMap {
     styles: HashMap<String, StyleDef>,
     defaults_para: ParaFmt,
     defaults_run: RunFmt,
+    /// styleId of the style with w:default="1" and w:type="paragraph".
+    /// Applied to paragraphs that have no explicit pStyle.
+    default_para_style_id: Option<String>,
 }
 
 impl StyleMap {
@@ -91,10 +94,17 @@ impl StyleMap {
         }
 
         // Parse each style
+        let mut default_para_style_id: Option<String> = None;
         for style_node in children_w(root, "style") {
             let Some(style_id) = attr_w(style_node, "styleId") else { continue };
             let style_type = attr_w(style_node, "type").unwrap_or_default();
             if style_type != "paragraph" && style_type != "character" { continue; }
+
+            if style_type == "paragraph"
+                && attr_w(style_node, "default").as_deref() == Some("1")
+            {
+                default_para_style_id = Some(style_id.clone());
+            }
 
             let based_on = child_w(style_node, "basedOn").and_then(|n| attr_w(n, "val"));
 
@@ -113,7 +123,7 @@ impl StyleMap {
             styles.insert(style_id, StyleDef { para, run, based_on });
         }
 
-        StyleMap { styles, defaults_para, defaults_run }
+        StyleMap { styles, defaults_para, defaults_run, default_para_style_id }
     }
 
     fn empty() -> Self {
@@ -121,6 +131,7 @@ impl StyleMap {
             styles: HashMap::new(),
             defaults_para: ParaFmt::default(),
             defaults_run: RunFmt::default(),
+            default_para_style_id: None,
         }
     }
 
@@ -134,7 +145,12 @@ impl StyleMap {
         apply_para(&mut merged_para, &self.defaults_para);
         apply_run(&mut merged_run, &self.defaults_run);
 
-        if let Some(id) = style_id {
+        // Use explicit pStyle if present, otherwise fall back to the
+        // paragraph style marked w:default="1" (typically "Normal").
+        let effective_id = style_id
+            .map(str::to_string)
+            .or_else(|| self.default_para_style_id.clone());
+        if let Some(id) = effective_id.as_deref() {
             self.apply_style_chain(id, &mut merged_para, &mut merged_run);
         }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -163,6 +163,81 @@ pub enum DocRun {
     Image(ImageRun),
     Break { break_type: BreakType },
     Field(FieldRun),
+    Shape(ShapeRun),
+}
+
+/// A drawn shape (wps:wsp inside wp:anchor). Positioned like an anchor image
+/// and rendered via core's buildCustomPath + paint primitives.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ShapeRun {
+    /// pt
+    pub width_pt: f64,
+    /// pt
+    pub height_pt: f64,
+    /// anchor X (pt)
+    pub anchor_x_pt: f64,
+    /// anchor Y (pt)
+    pub anchor_y_pt: f64,
+    pub anchor_x_from_margin: bool,
+    pub anchor_y_from_para: bool,
+    /// If true, draw the shape behind text (wp:anchor behindDoc="1"). Renderer
+    /// should draw background shapes BEFORE body text.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub behind_doc: bool,
+    /// Document order within the wp:anchor (for correct z-ordering among shapes
+    /// sharing the same behindDoc value). Lower value = drawn first.
+    pub z_order: u32,
+    /// normalized [0,1] custom path commands (one or more sub-paths)
+    pub subpaths: Vec<Vec<PathCmd>>,
+    /// Fill (solid or gradient). None = no fill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill: Option<ShapeFill>,
+    /// stroke hex. None = no stroke.
+    pub stroke: Option<String>,
+    /// stroke width in pt.
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub stroke_width: f64,
+    /// rotation in degrees (clockwise).
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub rotation: f64,
+    /// Wrap mode matching ImageRun.wrap_mode semantics.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wrap_mode: Option<String>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "fillType", rename_all = "camelCase")]
+pub enum ShapeFill {
+    Solid { color: String },
+    Gradient {
+        stops: Vec<GradientStop>,
+        /// degrees: 0 = left→right, 90 = top→bottom
+        angle: f64,
+        /// "linear" | "radial"
+        grad_type: String,
+    },
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GradientStop {
+    /// 0.0–1.0
+    pub position: f64,
+    /// hex 6-char
+    pub color: String,
+}
+
+/// Custom geometry path command (shape rendering). Mirrors the pptx
+/// PathCmd type to keep JSON output compatible with core's buildCustomPath.
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "cmd", rename_all = "camelCase")]
+pub enum PathCmd {
+    MoveTo { x: f64, y: f64 },
+    LineTo { x: f64, y: f64 },
+    CubicBezTo { x1: f64, y1: f64, x2: f64, y2: f64, x: f64, y: f64 },
+    ArcTo { wr: f64, hr: f64, st_ang: f64, sw_ang: f64 },
+    Close,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,8 +1,9 @@
 import type {
   Document, BodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell,
-  DocRun, TextRun, ImageRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
+  DocRun, TextRun, ImageRun, ShapeRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, SectionProps,
 } from './types';
+import { buildCustomPath, hexToRgba } from '@silurus/ooxml-core';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -421,6 +422,9 @@ function renderParagraph(para: DocParagraph, state: RenderState, suppressSpaceBe
   // Register anchor floats from this paragraph (must happen after spaceBefore so that
   // paragraph-relative Y resolves against the textAreaTop, matching Word).
   registerAnchorFloats(para, state, state.y);
+
+  // behindDoc shapes must render before text so they appear behind it.
+  renderAnchorImages(para, state, paragraphStartY, 'behind');
 
   // If any topAndBottom float already extends past state.y, skip past it before text starts.
   state.y = skipPastTopAndBottom(state.y, state.floats);
@@ -1035,14 +1039,34 @@ function renderInlineImage(
 }
 
 /** Collect and draw anchor images with wrapMode='none' (or unspecified).
- * Wrap floats (square/topAndBottom/tight/through) are drawn by registerAnchorFloats. */
+ * Wrap floats (square/topAndBottom/tight/through) are drawn by registerAnchorFloats.
+ *
+ * `phase` = 'behind' draws only shapes with behindDoc=true (sorted by zOrder asc);
+ * `phase` = 'front' draws shapes without behindDoc + all anchor images. */
 function renderAnchorImages(
   para: DocParagraph,
   state: RenderState,
   paragraphTopPx: number,
+  phase: 'behind' | 'front' = 'front',
 ): void {
   if (state.dryRun) return;
+  if (phase === 'behind') {
+    const shapes = para.runs
+      .filter((r): r is ShapeRun & { type: 'shape' } =>
+        r.type === 'shape' && !!(r as unknown as ShapeRun).behindDoc)
+      .slice()
+      .sort((a, b) =>
+        ((a as unknown as ShapeRun).zOrder ?? 0) - ((b as unknown as ShapeRun).zOrder ?? 0));
+    for (const s of shapes) renderAnchorShape(s as unknown as ShapeRun, state, paragraphTopPx);
+    return;
+  }
   for (const run of para.runs) {
+    if (run.type === 'shape') {
+      const s = run as unknown as ShapeRun;
+      if (s.behindDoc) continue;
+      renderAnchorShape(s, state, paragraphTopPx);
+      continue;
+    }
     if (run.type !== 'image') continue;
     const img = run as unknown as ImageRun;
     if (!img.anchor) continue;
@@ -1064,6 +1088,73 @@ function renderAnchorImages(
 
     state.ctx.drawImage(bmp, pageX, pageY, w, h);
   }
+}
+
+/** Draw a wps:wsp shape via core's custGeom primitive. */
+function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: number): void {
+  const { ctx, scale } = state;
+  const w = shape.widthPt * scale;
+  const h = shape.heightPt * scale;
+  if (w <= 0 || h <= 0) return;
+  const x = shape.anchorXFromMargin
+    ? (state.marginLeft + shape.anchorXPt) * scale
+    : shape.anchorXPt * scale;
+  const y = shape.anchorYFromPara
+    ? paragraphTopPx + shape.anchorYPt * scale
+    : shape.anchorYPt * scale;
+
+  const rot = shape.rotation ?? 0;
+  ctx.save();
+  if (rot !== 0) {
+    ctx.translate(x + w / 2, y + h / 2);
+    ctx.rotate((rot * Math.PI) / 180);
+    ctx.translate(-(x + w / 2), -(y + h / 2));
+  }
+  ctx.beginPath();
+  buildCustomPath(ctx as CanvasRenderingContext2D, shape.subpaths, x, y, w, h);
+  const fillStyle = resolveShapeFillStyle(shape.fill, ctx as CanvasRenderingContext2D, x, y, w, h);
+  if (fillStyle) {
+    ctx.fillStyle = fillStyle;
+    ctx.fill();
+  }
+  if (shape.stroke && (shape.strokeWidth ?? 0) > 0) {
+    ctx.strokeStyle = hexToRgba(shape.stroke);
+    ctx.lineWidth = Math.max(0.5, (shape.strokeWidth ?? 0) * scale);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function resolveShapeFillStyle(
+  fill: ShapeRun['fill'],
+  ctx: CanvasRenderingContext2D,
+  x: number, y: number, w: number, h: number,
+): string | CanvasGradient | null {
+  if (!fill) return null;
+  if (fill.fillType === 'solid') return hexToRgba(fill.color);
+  if (fill.fillType === 'gradient') {
+    if (fill.stops.length === 0) return null;
+    if (fill.stops.length === 1) return hexToRgba(fill.stops[0].color);
+    let gradient: CanvasGradient;
+    if (fill.gradType === 'radial') {
+      const cx = x + w / 2, cy = y + h / 2;
+      const r = Math.sqrt(w * w + h * h) / 2;
+      gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+    } else {
+      const rad = (fill.angle * Math.PI) / 180;
+      const cx = x + w / 2, cy = y + h / 2;
+      const gradLen = (Math.abs(Math.cos(rad)) * w + Math.abs(Math.sin(rad)) * h) / 2;
+      gradient = ctx.createLinearGradient(
+        cx - Math.cos(rad) * gradLen, cy - Math.sin(rad) * gradLen,
+        cx + Math.cos(rad) * gradLen, cy + Math.sin(rad) * gradLen,
+      );
+    }
+    for (const s of fill.stops) {
+      gradient.addColorStop(Math.min(1, Math.max(0, s.position)), hexToRgba(s.color));
+    }
+    return gradient;
+  }
+  return null;
 }
 
 function isWrapFloat(mode?: string): boolean {

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -102,7 +102,48 @@ export type DocRun =
   | { type: 'text' } & TextRun
   | { type: 'image' } & ImageRun
   | { type: 'break'; breakType: 'line' | 'page' | 'column' }
-  | { type: 'field' } & FieldRun;
+  | { type: 'field' } & FieldRun
+  | { type: 'shape' } & ShapeRun;
+
+export type PathCmd =
+  | { cmd: 'moveTo'; x: number; y: number }
+  | { cmd: 'lineTo'; x: number; y: number }
+  | { cmd: 'cubicBezTo'; x1: number; y1: number; x2: number; y2: number; x: number; y: number }
+  | { cmd: 'arcTo'; wr: number; hr: number; stAng: number; swAng: number }
+  | { cmd: 'close' };
+
+export interface ShapeRun {
+  widthPt: number;
+  heightPt: number;
+  /** X offset in pt */
+  anchorXPt: number;
+  /** Y offset in pt */
+  anchorYPt: number;
+  anchorXFromMargin: boolean;
+  anchorYFromPara: boolean;
+  /** Draw behind text when true (wp:anchor behindDoc="1"). */
+  behindDoc?: boolean;
+  /** Document-order index within a group; lower values render first. */
+  zOrder: number;
+  /** Normalized [0,1] custom-geometry sub-paths */
+  subpaths: PathCmd[][];
+  fill: ShapeFill | null;
+  stroke: string | null;
+  strokeWidth?: number;
+  rotation?: number;
+  wrapMode?: string | null;
+}
+
+export type ShapeFill =
+  | { fillType: 'solid'; color: string }
+  | { fillType: 'gradient'; stops: GradientStop[]; angle: number; gradType: string };
+
+export interface GradientStop {
+  /** 0.0–1.0 */
+  position: number;
+  /** hex 6-char */
+  color: string;
+}
 
 export interface FieldRun {
   /** "page" | "numPages" | "other" */

--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -7,6 +7,7 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   { name: 'private/sample-1', pageCount: 1, width: 612 },
   { name: 'private/sample-2', pageCount: 1, width: 595 },
   { name: 'private/sample-3', pageCount: 3, width: 595 },
+  { name: 'private/sample-4', pageCount: 1, width: 595 },
   { name: 'demo/sample-1', pageCount: 6, width: 595 },
 ];
 

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -182,6 +182,9 @@ struct PictureElement {
     /// source width/height. Only serialized when any edge is non-zero.
     #[serde(skip_serializing_if = "Option::is_none")]
     src_rect: Option<SrcRect>,
+    /// a:blip > a:alphaModFix@amt (0.0–1.0). None = fully opaque.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alpha: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -203,6 +206,16 @@ struct SrcRect {
 }
 
 fn is_zero_f64(v: &f64) -> bool { v.abs() < 1e-9 }
+
+/// Parse `<a:blip><a:alphaModFix amt="..."/></a:blip>` from a blipFill node.
+/// Returns fraction (amt / 100000) when present and < 1.0; None otherwise.
+fn parse_blip_alpha(blip_fill: roxmltree::Node<'_, '_>) -> Option<f64> {
+    let blip = child(blip_fill, "blip")?;
+    let amf = child(blip, "alphaModFix")?;
+    let amt: f64 = attr(&amf, "amt")?.parse().ok()?;
+    let frac = amt / 100_000.0;
+    if frac >= 0.9999 { None } else { Some(frac.max(0.0)) }
+}
 
 /// Parse `<a:srcRect l t r b>` from a `<p:blipFill>` (or `<a:blipFill>`) node.
 /// Returns None if no srcRect or all edges are zero.
@@ -1187,6 +1200,17 @@ struct LayoutPlaceholders {
     by_type_master_alignment: HashMap<String, String>,
     /// Default line spacing from master txStyles (fallback when layout has none)
     by_type_master_line_spacing: HashMap<String, f64>,
+    /// Inherited blipFill (data URL + src rect) per placeholder idx from layout spPr
+    by_idx_blip_fill: HashMap<u32, InheritedBlipFill>,
+    /// Inherited blipFill per placeholder type from layout spPr
+    by_type_blip_fill: HashMap<String, InheritedBlipFill>,
+}
+
+#[derive(Debug, Clone)]
+struct InheritedBlipFill {
+    data_url: String,
+    src_rect: Option<SrcRect>,
+    alpha: Option<f64>,
 }
 
 impl LayoutPlaceholders {
@@ -1248,6 +1272,15 @@ impl LayoutPlaceholders {
             .or_else(|| if ph_type == "body" { self.by_type_space_after.get("").copied() } else { None })
             .or_else(|| self.by_type_master_space_after.get(ph_type).copied())
             .or_else(|| if ph_type == "body" { self.by_type_master_space_after.get("").copied() } else { None })
+    }
+
+    /// Look up inherited blipFill from the layout placeholder spPr. Used when a slide
+    /// references a picture placeholder (e.g. ph type="pic") without its own blipFill —
+    /// the image defined on the layout's matching placeholder should render through.
+    fn lookup_blip_fill(&self, ph_type: &str, ph_idx: Option<u32>) -> Option<InheritedBlipFill> {
+        ph_idx
+            .and_then(|i| self.by_idx_blip_fill.get(&i).cloned())
+            .or_else(|| self.by_type_blip_fill.get(ph_type).cloned())
     }
 
     /// Look up inherited stroke from the layout placeholder spPr > ln.
@@ -1382,6 +1415,39 @@ fn parse_master_font_sizes(master_xml: &str) -> HashMap<String, f64> {
     map
 }
 
+/// Parse default bold/italic from master txStyles (titleStyle / bodyStyle / otherStyle)
+/// > lvl1pPr > defRPr @b and @i. Keyed by ph_type.
+/// Only populated when the attribute is explicitly present on the master.
+fn parse_master_txstyle_bold_italic(master_xml: &str) -> (HashMap<String, bool>, HashMap<String, bool>) {
+    let mut bold_map: HashMap<String, bool> = HashMap::new();
+    let mut italic_map: HashMap<String, bool> = HashMap::new();
+    let doc = match roxmltree::Document::parse(master_xml) {
+        Ok(d) => d,
+        Err(_) => return (bold_map, italic_map),
+    };
+    let root = doc.root_element();
+    let Some(tx_styles) = child(root, "txStyles") else { return (bold_map, italic_map); };
+    let style_ph_map: &[(&str, &[&str])] = &[
+        ("titleStyle",  &["title", "ctrTitle"]),
+        ("bodyStyle",   &["body", "subTitle", "obj", ""]),
+        ("otherStyle",  &["dt", "ftr", "sldNum"]),
+    ];
+    for (style_name, ph_types) in style_ph_map {
+        let def_rpr = child(tx_styles, style_name)
+            .and_then(|sn| child(sn, "lvl1pPr"))
+            .and_then(|lp| child(lp, "defRPr"));
+        let b = def_rpr.and_then(|rp| attr(&rp, "b")).map(|v| v == "1" || v == "true");
+        let i = def_rpr.and_then(|rp| attr(&rp, "i")).map(|v| v == "1" || v == "true");
+        if let Some(bv) = b {
+            for t in *ph_types { bold_map.entry(t.to_string()).or_insert(bv); }
+        }
+        if let Some(iv) = i {
+            for t in *ph_types { italic_map.entry(t.to_string()).or_insert(iv); }
+        }
+    }
+    (bold_map, italic_map)
+}
+
 /// Parse default paragraph spacing from master txStyles.
 /// Returns (space_before_map, space_after_map, line_spacing_map) keyed by ph_type string.
 /// space_before/after values are in hundredths of a point (same as Paragraph.space_before/after).
@@ -1448,7 +1514,7 @@ fn parse_master_transforms(master_xml: &str) -> HashMap<String, Transform> {
     map
 }
 
-fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<String, f64>, master_anchors: &HashMap<String, String>, master_transforms: &HashMap<String, Transform>, master_alignments: &HashMap<String, String>, master_space_before: &HashMap<String, i64>, master_space_after: &HashMap<String, i64>, master_line_spacing: &HashMap<String, f64>, theme: &HashMap<String, String>) -> LayoutPlaceholders {
+fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<String, f64>, master_anchors: &HashMap<String, String>, master_transforms: &HashMap<String, Transform>, master_alignments: &HashMap<String, String>, master_space_before: &HashMap<String, i64>, master_space_after: &HashMap<String, i64>, master_line_spacing: &HashMap<String, f64>, theme: &HashMap<String, String>, layout_dir: &str, layout_rels: &HashMap<String, String>, zip: &mut PptxZip<'_>) -> LayoutPlaceholders {
     let mut lph = LayoutPlaceholders::default();
     lph.master_by_type = master_transforms.clone();
     lph.by_type_master_alignment = master_alignments.clone();
@@ -1519,6 +1585,23 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
         let layout_stroke: Option<Stroke> = child(sp_pr, "ln")
             .and_then(|n| parse_stroke(n, theme));
 
+        // Layout spPr > blipFill → image that bleeds through when the slide's
+        // matching placeholder has no own blipFill (picture placeholder inheritance).
+        let layout_blip_fill: Option<InheritedBlipFill> = child(sp_pr, "blipFill")
+            .and_then(|bf| {
+                let rid = child(bf, "blip").and_then(|b| attr_r(&b, "embed"))?;
+                let rel_target = layout_rels.get(&rid)?;
+                let image_path = resolve_path(layout_dir, rel_target);
+                let bytes = read_zip_bytes(zip, &image_path)?;
+                let mime = mime_from_ext(&image_path);
+                let data_url = format!("data:{mime};base64,{}", B64.encode(&bytes));
+                Some(InheritedBlipFill {
+                    data_url,
+                    src_rect: parse_src_rect(bf),
+                    alpha: parse_blip_alpha(bf),
+                })
+            });
+
         if let Some(ph) = ph_node {
             let ph_type = attr(&ph, "type").unwrap_or_default();
             let ph_idx: Option<u32> = attr(&ph, "idx").and_then(|v| v.parse().ok());
@@ -1538,6 +1621,9 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
                 }
                 if let Some(ls) = layout_line_spacing {
                     lph.by_idx_line_spacing.entry(idx).or_insert(ls);
+                }
+                if let Some(ref bf) = layout_blip_fill {
+                    lph.by_idx_blip_fill.entry(idx).or_insert(bf.clone());
                 }
             }
             let effective_fs = layout_font_size
@@ -1571,6 +1657,9 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
             }
             if let Some(s) = layout_stroke {
                 lph.by_type_stroke.entry(ph_type.clone()).or_insert(s);
+            }
+            if let Some(bf) = layout_blip_fill {
+                lph.by_type_blip_fill.entry(ph_type.clone()).or_insert(bf);
             }
             if let Some(t) = t_opt {
                 lph.by_type.entry(ph_type).or_insert(t);
@@ -2477,6 +2566,7 @@ fn parse_picture(
         rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
         data_url, clip_adjust: None,
         src_rect: parse_src_rect(blip_fill),
+        alpha: parse_blip_alpha(blip_fill),
     })
 }
 
@@ -2837,14 +2927,26 @@ fn parse_slide(
     master_space_before: &HashMap<String, i64>,
     master_space_after: &HashMap<String, i64>,
     master_line_spacing: &HashMap<String, f64>,
+    master_bold: &HashMap<String, bool>,
+    master_italic: &HashMap<String, bool>,
     index: usize,
     rels: &HashMap<String, String>,
     zip: &mut PptxZip<'_>,
     theme: &HashMap<String, String>,
 ) -> Result<Slide, Box<dyn std::error::Error>> {
-    let lph = layout_xml
-        .map(|x| parse_layout_placeholders(x, master_font_sizes, master_anchors, master_transforms, master_alignments, master_space_before, master_space_after, master_line_spacing, theme))
-        .unwrap_or_default();
+    let mut lph = match layout_xml {
+        Some(x) => parse_layout_placeholders(x, master_font_sizes, master_anchors, master_transforms, master_alignments, master_space_before, master_space_after, master_line_spacing, theme, layout_dir, layout_rels, zip),
+        None => LayoutPlaceholders::default(),
+    };
+    // Fall back to master txStyles defRPr @b/@i when the layout did not specify
+    // bold/italic for a placeholder type. Without this, e.g. the master titleStyle's
+    // b="1" is not applied to ctrTitle / title placeholders.
+    for (t, b) in master_bold.iter() {
+        lph.by_type_bold.entry(t.clone()).or_insert(*b);
+    }
+    for (t, i) in master_italic.iter() {
+        lph.by_type_italic.entry(t.clone()).or_insert(*i);
+    }
 
     let doc = roxmltree::Document::parse(xml)?;
     let root = doc.root_element(); // <p:sld>
@@ -2919,11 +3021,11 @@ fn parse_sp_tree_node(
             let blip_rid = blip_fill_node
                 .and_then(|bf| child(bf, "blip"))
                 .and_then(|b| attr_r(&b, "embed"));
-            if let Some(rid) = blip_rid {
+            if let Some(ref rid) = blip_rid {
                 if let Some(xfrm_node) = sp_pr_node.and_then(|p| child(p, "xfrm")) {
                     let t = parse_xfrm(xfrm_node);
                     if t.cx > 0 && t.cy > 0 {
-                        if let Some(target) = rels.get(&rid) {
+                        if let Some(target) = rels.get(rid) {
                             let image_path = resolve_path(slide_dir, target);
                             if let Some(bytes) = read_zip_bytes(zip, &image_path) {
                                 let mime = mime_from_ext(&image_path);
@@ -2941,6 +3043,33 @@ fn parse_sp_tree_node(
                                     rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
                                     data_url, clip_adjust,
                                     src_rect: blip_fill_node.and_then(parse_src_rect),
+                                    alpha: blip_fill_node.and_then(parse_blip_alpha),
+                                }));
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            // Picture-placeholder inheritance: slide sp has a ph but no own blipFill →
+            // look up an inherited blipFill from the layout placeholder. Transform
+            // comes from the slide's xfrm when present, otherwise from the layout.
+            if blip_rid.is_none() {
+                if let Some(ph) = node.descendants().find(|n| n.is_element() && n.tag_name().name() == "ph") {
+                    let ph_type = attr(&ph, "type").unwrap_or_else(|| "body".into());
+                    let ph_idx: Option<u32> = attr(&ph, "idx").and_then(|v| v.parse().ok());
+                    if let Some(bf) = lph.lookup_blip_fill(&ph_type, ph_idx) {
+                        let slide_xfrm = sp_pr_node.and_then(|p| child(p, "xfrm")).map(parse_xfrm);
+                        let t = slide_xfrm
+                            .or_else(|| lph.lookup(&ph_type, ph_idx).cloned());
+                        if let Some(t) = t {
+                            if t.cx > 0 && t.cy > 0 {
+                                out.push(SlideElement::Picture(PictureElement {
+                                    x: t.x, y: t.y, width: t.cx, height: t.cy,
+                                    rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
+                                    data_url: bf.data_url, clip_adjust: None,
+                                    src_rect: bf.src_rect,
+                                    alpha: bf.alpha,
                                 }));
                                 return;
                             }
@@ -2978,6 +3107,7 @@ fn parse_sp_tree_node(
                                         rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
                                         data_url, clip_adjust: None,
                                         src_rect: blip_fill.and_then(parse_src_rect),
+                                        alpha: blip_fill.and_then(parse_blip_alpha),
                                     }));
                                 }
                             }
@@ -3229,6 +3359,11 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         .map(|xml| parse_master_txstyle_spacing(xml))
         .unwrap_or_default();
 
+    let (master_bold, master_italic): (HashMap<String, bool>, HashMap<String, bool>) = master_xml_opt
+        .as_deref()
+        .map(|xml| parse_master_txstyle_bold_italic(xml))
+        .unwrap_or_default();
+
     // Pre-collect slide XMLs, their rels, the layout XML, and layout rels
     struct SlideRaw {
         index: usize,
@@ -3297,6 +3432,8 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
             &master_space_before,
             &master_space_after,
             &master_line_spacing,
+            &master_bold,
+            &master_italic,
             raw.index,
             &raw.slide_rels,
             &mut zip,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -14,7 +14,13 @@ import type {
   RenderOptions,
   TabStop,
 } from './types';
-import { renderChart } from '@silurus/ooxml-core';
+import {
+  renderChart,
+  buildCustomPath as buildCustomPathCore,
+  hexToRgba as hexToRgbaCore,
+  resolveFill as resolveFillCore,
+  applyStroke as applyStrokeCore,
+} from '@silurus/ooxml-core';
 
 /** EMU per point (OOXML: 1 pt = 12700 EMU). Used to scale font sizes with the canvas. */
 const PT_TO_EMU = 12700;
@@ -33,14 +39,7 @@ function emuToPx(emu: number, scale: number): number {
   return emu * scale;
 }
 
-function hexToRgba(hex: string, alpha = 1): string {
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  // 8-char hex (RRGGBBAA) encodes alpha in the last two chars
-  const a = hex.length >= 8 ? parseInt(hex.slice(6, 8), 16) / 255 : alpha;
-  return `rgba(${r},${g},${b},${a})`;
-}
+const hexToRgba = hexToRgbaCore;
 
 /** Simple fill resolver that returns a CSS color string.
  *  For gradient fills, returns the first stop's color (used by table cells etc.) */
@@ -57,40 +56,9 @@ function resolveFill(fill: Fill | null): string | null {
 function resolveShapeFill(
   fill: Fill | null,
   ctx: CanvasRenderingContext2D,
-  x: number, y: number, w: number, h: number
+  x: number, y: number, w: number, h: number,
 ): string | CanvasGradient | null {
-  if (!fill || fill.fillType === 'none') return null;
-  if (fill.fillType === 'solid') return hexToRgba(fill.color);
-  if (fill.fillType === 'gradient') {
-    const stops = fill.stops;
-    if (stops.length === 0) return null;
-    if (stops.length === 1) return hexToRgba(stops[0].color);
-
-    let gradient: CanvasGradient;
-    if (fill.gradType === 'radial') {
-      const cx = x + w / 2;
-      const cy = y + h / 2;
-      const r = Math.sqrt(w * w + h * h) / 2;
-      gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
-    } else {
-      // Linear gradient — OOXML angle: 0 = left→right, 90 = top→bottom
-      const rad = (fill.angle * Math.PI) / 180;
-      const cx = x + w / 2;
-      const cy = y + h / 2;
-      // Compute extent so the gradient line covers the entire bounding box
-      const gradLen = (Math.abs(Math.cos(rad)) * w + Math.abs(Math.sin(rad)) * h) / 2;
-      gradient = ctx.createLinearGradient(
-        cx - Math.cos(rad) * gradLen, cy - Math.sin(rad) * gradLen,
-        cx + Math.cos(rad) * gradLen, cy + Math.sin(rad) * gradLen
-      );
-    }
-
-    for (const stop of stops) {
-      gradient.addColorStop(Math.min(1, Math.max(0, stop.position)), hexToRgba(stop.color));
-    }
-    return gradient;
-  }
-  return null;
+  return resolveFillCore(fill, ctx, x, y, w, h);
 }
 
 // ===== Text layout helpers =====
@@ -484,62 +452,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
  * the renderer maps them to canvas pixels.
  * Tracks pen position so arcTo can compute the ellipse centre correctly.
  */
-function buildCustomPath(
-  ctx: CanvasRenderingContext2D,
-  subpaths: PathCmd[][],
-  x: number,
-  y: number,
-  w: number,
-  h: number
-) {
-  for (const cmds of subpaths) {
-    // Pen position in normalised [0,1] space
-    let penX = 0, penY = 0;
-    for (const cmd of cmds) {
-      switch (cmd.cmd) {
-        case 'moveTo':
-          ctx.moveTo(x + cmd.x * w, y + cmd.y * h);
-          penX = cmd.x; penY = cmd.y;
-          break;
-        case 'lineTo':
-          ctx.lineTo(x + cmd.x * w, y + cmd.y * h);
-          penX = cmd.x; penY = cmd.y;
-          break;
-        case 'cubicBezTo':
-          ctx.bezierCurveTo(
-            x + cmd.x1 * w, y + cmd.y1 * h,
-            x + cmd.x2 * w, y + cmd.y2 * h,
-            x + cmd.x  * w, y + cmd.y  * h
-          );
-          penX = cmd.x; penY = cmd.y;
-          break;
-        case 'arcTo': {
-          // OOXML arcTo: the current pen is on the ellipse at angle stAng.
-          // Back-calculate the ellipse centre, then draw to stAng+swAng.
-          const rw = cmd.wr * w;
-          const rh = cmd.hr * h;
-          if (rw <= 0 || rh <= 0) break;
-          const stRad = (cmd.stAng * Math.PI) / 180;
-          const swRad = (cmd.swAng * Math.PI) / 180;
-          const penAbsX = x + penX * w;
-          const penAbsY = y + penY * h;
-          // Centre of the ellipse that passes through the current pen at stAng
-          const cx = penAbsX - rw * Math.cos(stRad);
-          const cy = penAbsY - rh * Math.sin(stRad);
-          const endRad = stRad + swRad;
-          ctx.ellipse(cx, cy, rw, rh, 0, stRad, endRad, swRad < 0);
-          // Update pen to the arc end point
-          penX = (cx + rw * Math.cos(endRad) - x) / w;
-          penY = (cy + rh * Math.sin(endRad) - y) / h;
-          break;
-        }
-        case 'close':
-          ctx.closePath();
-          break;
-      }
-    }
-  }
-}
+const buildCustomPath = buildCustomPathCore;
 
 // ── Star polygon helper ─────────────────────────────────────────────────────
 function drawStar(
@@ -2599,6 +2512,7 @@ async function renderPicture(
     const blob = await resp.blob();
     const bitmap = await createImageBitmap(blob);
     ctx.save();
+    if (el.alpha != null) ctx.globalAlpha *= el.alpha;
     const x = emuToPx(el.x, scale);
     const y = emuToPx(el.y, scale);
     const w = emuToPx(el.width, scale);
@@ -2643,18 +2557,6 @@ async function renderPicture(
 }
 
 // ===== Table renderer =====
-
-const DASH_PATTERNS: Record<string, number[]> = {
-  dash:       [6, 3],
-  dot:        [1.5, 3],
-  dashDot:    [6, 3, 1.5, 3],
-  lgDash:     [10, 4],
-  lgDashDot:  [10, 4, 1.5, 4],
-  lgDashDotDot: [10, 4, 1.5, 4, 1.5, 4],
-  sysDash:    [4, 2],
-  sysDot:     [1, 2],
-  sysDashDot: [4, 2, 1, 2],
-};
 
 /** Draw an arrowhead at `tip` pointing in `angle` radians (0 = right). */
 function drawArrowHead(
@@ -2715,17 +2617,8 @@ function drawArrowHead(
 }
 
 function applyStroke(ctx: CanvasRenderingContext2D, stroke: Stroke | null, scale: number) {
-  if (!stroke) {
-    ctx.strokeStyle = 'transparent';
-    ctx.lineWidth = 0;
-    ctx.setLineDash([]);
-    return;
-  }
-  ctx.strokeStyle = hexToRgba(stroke.color);
-  const lw = Math.max(0.5, emuToPx(stroke.width, scale));
-  ctx.lineWidth = lw;
-  const pat = stroke.dashStyle ? DASH_PATTERNS[stroke.dashStyle] : null;
-  ctx.setLineDash(pat ? pat.map(v => v * lw) : []);
+  // `scale` is EMU → px factor (canvasWidthPx / slideWidthEMU).
+  applyStrokeCore(ctx, stroke, scale);
 }
 
 // ─── Chart rendering ────────────────────────────────────────────────────────

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -156,6 +156,8 @@ export interface PictureElement {
    * width/height. Omitted when the image is not cropped.
    */
   srcRect?: { l?: number; t?: number; r?: number; b?: number };
+  /** a:blip > a:alphaModFix@amt as 0..1. Undefined = fully opaque. */
+  alpha?: number;
 }
 
 // ===== Worker message protocol =====

--- a/packages/pptx/tests/visual/visual.spec.ts
+++ b/packages/pptx/tests/visual/visual.spec.ts
@@ -13,6 +13,7 @@ const PPTX_FILES: { name: string; slideCount: number }[] = [
   { name: 'private/sample-2', slideCount: 17 },
   { name: 'private/sample-3', slideCount: 9 },
   { name: 'private/sample-4', slideCount: 15 },
+  { name: 'private/sample-5', slideCount: 3 },
   { name: 'demo/sample-1', slideCount: 9 },
 ];
 

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

- **DOCX**: wps:wsp shape parsing (solid / gradient fill with lumMod/lumOff, stroke), behindDoc z-ordering, anchor image text wrap (Square + TopAndBottom), default paragraph style fallback via `w:default="1"` (fixes pStyle-less paragraphs inheriting Normal), styles path resolution via rels (supports `styles2.xml`), header/footer cell borders, date format detection
- **PPTX**: master `txStyles` bold/italic inheritance (titleStyle / bodyStyle / otherStyle > lvl1pPr > defRPr), `a:alphaModFix` support for placeholder image `blipFill` (fixes sample-5 placeholder images rendering at full opacity instead of 60%), shape fill/stroke/custGeom helpers extracted to `@silurus/ooxml-core`
- **Core**: new `shape/paint.ts` (`hexToRgba`, `resolveFill`, `applyStroke`) and `shape/custGeom.ts` (`buildCustomPath`) shared helpers
- **Release**: bump all packages to 0.3.0

## Test plan

- [x] `npx tsc --noEmit` passes for core / docx / pptx
- [x] DOCX VRT: `private/sample-4` page 1 match=91.9%
- [x] PPTX VRT: `private/sample-5` slide 1=98.5%, slide 2=94.1%, slide 3=93.6%
- [ ] After merge, tag `v0.3.0` to trigger npm publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)