### PR TITLE
Detect audio/video in p:pic and render poster + play badge

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -52,6 +52,7 @@ enum SlideElement {
     Picture(PictureElement),
     Table(TableElement),
     Chart(ChartElement),
+    Media(MediaElement),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -206,6 +207,28 @@ struct SrcRect {
 }
 
 fn is_zero_f64(v: &f64) -> bool { v.abs() < 1e-9 }
+
+/// ECMA-376 §19.3.1.17/18 a:audioFile / a:videoFile and the
+/// p14:media extension (embed attribute).
+/// Represents a p:pic that acts as an audio/video placeholder.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct MediaElement {
+    x: i64,
+    y: i64,
+    width: i64,
+    height: i64,
+    /// "audio" or "video"
+    media_kind: String,
+    /// Poster image shown before playback starts (data URL).
+    poster_data_url: String,
+    /// Path inside the pptx zip (e.g. "ppt/media/media2.mp4"). The renderer
+    /// uses this with a separate getMedia API to pull bytes lazily, avoiding
+    /// the cost of base64-encoding large videos into the parse result.
+    media_path: String,
+    /// Media MIME type (e.g. "audio/mpeg", "video/mp4")
+    mime_type: String,
+}
 
 /// Parse `<a:blip><a:alphaModFix amt="..."/></a:blip>` from a blipFill node.
 /// Returns fraction (amt / 100000) when present and < 1.0; None otherwise.
@@ -1197,6 +1220,11 @@ fn apply_group_transform_to_element(el: &mut SlideElement, gt: &GroupTransform) 
             let t = Transform { x: ex, y: ey, cx: ecx, cy: ecy, rot: 0.0, flip_h: false, flip_v: false };
             let nt = gt.apply_to_transform(t);
             chart.x = nt.x; chart.y = nt.y; chart.width = nt.cx; chart.height = nt.cy;
+        }
+        SlideElement::Media(m) => {
+            let t = Transform { x: m.x, y: m.y, cx: m.width, cy: m.height, rot: 0.0, flip_h: false, flip_v: false };
+            let nt = gt.apply_to_transform(t);
+            m.x = nt.x; m.y = nt.y; m.width = nt.cx; m.height = nt.cy;
         }
     }
 }
@@ -2722,8 +2750,99 @@ fn mime_from_ext(path: &str) -> &'static str {
         "bmp"  => "image/bmp",
         "svg"  => "image/svg+xml",
         "webp" => "image/webp",
+        "mp3"  => "audio/mpeg",
+        "m4a"  => "audio/mp4",
+        "wav"  => "audio/wav",
+        "aac"  => "audio/aac",
+        "ogg" | "oga" => "audio/ogg",
+        "mp4"  => "video/mp4",
+        "mov"  => "video/quicktime",
+        "webm" => "video/webm",
+        "ogv"  => "video/ogg",
         _      => "application/octet-stream",
     }
+}
+
+/// If a `p:pic` declares an `a:audioFile` / `a:videoFile` in its `nvPr`
+/// (or the newer `p14:media` extension), emit a `MediaElement` with the
+/// poster image and the media bytes. Returns None for regular pictures.
+fn parse_media(
+    pic_node: roxmltree::Node<'_, '_>,
+    slide_dir: &str,
+    rels: &HashMap<String, String>,
+    zip: &mut PptxZip<'_>,
+) -> Option<MediaElement> {
+    let nv_pic_pr = child(pic_node, "nvPicPr")?;
+    let nv_pr = child(nv_pic_pr, "nvPr")?;
+
+    // Prefer a:videoFile/a:audioFile (r:link or r:embed), then fall back to
+    // the p14:media extension. All three resolve to the same media rel target.
+    let (media_kind, media_rid) = nv_pr
+        .children()
+        .find_map(|n| {
+            if !n.is_element() { return None; }
+            let name = n.tag_name().name();
+            if name == "videoFile" || name == "audioFile" {
+                let rid = attr_r(&n, "link").or_else(|| attr_r(&n, "embed"))?;
+                let kind = if name == "videoFile" { "video" } else { "audio" };
+                Some((kind, rid))
+            } else {
+                None
+            }
+        })
+        .or_else(|| {
+            // p14:media lives inside p:extLst > p:ext
+            let ext_lst = child(nv_pr, "extLst")?;
+            ext_lst.children().filter(|c| c.is_element()).find_map(|ext| {
+                ext.children().filter(|c| c.is_element()).find_map(|m| {
+                    if m.tag_name().name() != "media" { return None; }
+                    let rid = attr_r(&m, "link").or_else(|| attr_r(&m, "embed"))?;
+                    // ext has no way to say audio vs video by itself; decide from file ext
+                    Some(("", rid))
+                })
+            })
+        })?;
+
+    let rel_target = rels.get(&media_rid)?;
+    let media_path = resolve_path(slide_dir, rel_target);
+    let mime = mime_from_ext(&media_path);
+
+    // Finalize media_kind once MIME is known (p14:media-only path).
+    let media_kind = if !media_kind.is_empty() {
+        media_kind.to_string()
+    } else if mime.starts_with("video/") {
+        "video".to_string()
+    } else if mime.starts_with("audio/") {
+        "audio".to_string()
+    } else {
+        return None;
+    };
+
+    // Geometry
+    let sp_pr = child(pic_node, "spPr")?;
+    let xfrm_node = child(sp_pr, "xfrm")?;
+    let t = parse_xfrm(xfrm_node);
+    if t.cx == 0 || t.cy == 0 { return None; }
+
+    // Poster image (from blipFill). Optional — renders with a fallback icon when missing.
+    let poster_data_url = (|| -> Option<String> {
+        let blip_fill = child(pic_node, "blipFill")?;
+        let r_id = child(blip_fill, "blip").and_then(|b| attr_r(&b, "embed"))?;
+        let rel_target = rels.get(&r_id)?;
+        let image_path = resolve_path(slide_dir, rel_target);
+        let image_bytes = read_zip_bytes(zip, &image_path)?;
+        let img_mime = mime_from_ext(&image_path);
+        Some(format!("data:{img_mime};base64,{}", B64.encode(&image_bytes)))
+    })()
+    .unwrap_or_default();
+
+    Some(MediaElement {
+        x: t.x, y: t.y, width: t.cx, height: t.cy,
+        media_kind,
+        poster_data_url,
+        media_path,
+        mime_type: mime.to_string(),
+    })
 }
 
 // ===========================
@@ -3232,7 +3351,9 @@ fn parse_sp_tree_node(
             }
         }
         "pic" => {
-            if let Some(pic) = parse_picture(node, slide_dir, rels, zip) {
+            if let Some(media) = parse_media(node, slide_dir, rels, zip) {
+                out.push(SlideElement::Media(media));
+            } else if let Some(pic) = parse_picture(node, slide_dir, rels, zip) {
                 out.push(SlideElement::Picture(pic));
             } else {
                 // Placeholder pic: no xfrm in spPr — position comes from layout by_idx
@@ -3508,6 +3629,7 @@ fn offset_slide_element(el: &mut SlideElement, dx: i64, dy: i64) {
         SlideElement::Picture(p) => { p.x += dx; p.y += dy; }
         SlideElement::Table(t)   => { t.x += dx; t.y += dy; }
         SlideElement::Chart(c)   => { c.x += dx; c.y += dy; }
+        SlideElement::Media(m)   => { m.x += dx; m.y += dy; }
     }
 }
 
@@ -3805,6 +3927,7 @@ mod tests {
                 SlideElement::Shape(s) => println!("  [{}] shape x={}", i, s.x),
                 SlideElement::Table(_) => println!("  [{}] table", i),
                 SlideElement::Picture(_) => println!("  [{}] picture", i),
+                SlideElement::Media(m) => println!("  [{}] media kind={}", i, m.media_kind),
             }
         }
     }

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -6,7 +6,6 @@ type DemoArgs = { width: number };
 type LayoutArgs = Record<string, never>;
 
 const SAMPLE_URL = `${import.meta.env.BASE_URL}pptx/demo/sample-1.pptx`;
-const SAMPLE6_URL = `${import.meta.env.BASE_URL}pptx/private/sample-6.pptx`;
 
 const meta: Meta<DemoArgs> = {
   title: 'PptxViewer/Examples',
@@ -27,14 +26,6 @@ export const Demo: DemoStory = {
   name: 'Demo — single viewer (demo.pptx)',
   render(args) {
     const { root } = buildViewerUI(args, SAMPLE_URL);
-    return root;
-  },
-};
-
-export const Sample6: DemoStory = {
-  name: 'Sample-6 — single viewer (private/sample-6.pptx)',
-  render(args) {
-    const { root } = buildViewerUI(args, SAMPLE6_URL);
     return root;
   },
 };

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3,6 +3,7 @@ import type {
   SlideElement,
   ShapeElement,
   PictureElement,
+  MediaElement,
   TableElement,
   Fill,
   Stroke,
@@ -2556,6 +2557,52 @@ async function renderPicture(
   }
 }
 
+async function renderMedia(
+  ctx: CanvasRenderingContext2D,
+  el: MediaElement,
+  scale: number,
+) {
+  const x = emuToPx(el.x, scale);
+  const y = emuToPx(el.y, scale);
+  const w = emuToPx(el.width, scale);
+  const h = emuToPx(el.height, scale);
+
+  if (el.posterDataUrl) {
+    try {
+      const resp = await fetch(el.posterDataUrl);
+      const blob = await resp.blob();
+      const bitmap = await createImageBitmap(blob);
+      ctx.drawImage(bitmap, x, y, w, h);
+      bitmap.close();
+    } catch {
+      // fall through to plain fill
+    }
+  }
+  if (!el.posterDataUrl) {
+    ctx.fillStyle = el.mediaKind === 'video' ? '#111' : '#f0f0f0';
+    ctx.fillRect(x, y, w, h);
+  }
+
+  // Play-badge overlay: centered filled circle with a triangle cue
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const r = Math.min(w, h) * 0.18;
+  ctx.save();
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.55)';
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  const tri = r * 0.55;
+  ctx.moveTo(cx - tri * 0.5, cy - tri);
+  ctx.lineTo(cx - tri * 0.5, cy + tri);
+  ctx.lineTo(cx + tri, cy);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
 // ===== Table renderer =====
 
 /** Draw an arrowhead at `tip` pointing in `angle` radians (0 = right). */
@@ -2777,6 +2824,8 @@ export async function renderSlide(
       await renderPicture(ctx, el, scale);
     } else if (el.type === 'table') {
       renderTable(ctx, el, scale, slideNumber, rc);
+    } else if (el.type === 'media') {
+      await renderMedia(ctx, el, scale);
     } else if (el.type === 'chart') {
       renderChart(
         ctx,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -40,7 +40,23 @@ export interface Slide {
   elements: SlideElement[];
 }
 
-export type SlideElement = ShapeElement | PictureElement | TableElement | ChartElement;
+export type SlideElement = ShapeElement | PictureElement | TableElement | ChartElement | MediaElement;
+
+export interface MediaElement {
+  type: 'media';
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** "audio" or "video" */
+  mediaKind: 'audio' | 'video';
+  /** Poster frame shown before playback (image data URL, may be empty). */
+  posterDataUrl: string;
+  /** Path inside the pptx zip (e.g. "ppt/media/media2.mp4"). Used by getMedia. */
+  mediaPath: string;
+  /** MIME type of the underlying media (e.g. "audio/mpeg", "video/mp4"). */
+  mimeType: string;
+}
 
 export interface ShapeElement {
   type: 'shape';


### PR DESCRIPTION
## Summary
Phase A of PPTX audio/video support.

- Parser detects \`a:audioFile\` / \`a:videoFile\` (r:link/r:embed) and the \`p14:media\` extension inside \`p:pic > p:nvPicPr > p:nvPr\`, and emits a \`MediaElement\` carrying the poster image + zip mediaPath + MIME type.
- Media bytes are not inlined in the parse result — keeps the payload small for large videos. Phase B will add a lazy \`getMedia(path)\` API.
- Renderer paints the poster and overlays a play-badge circle (static representation).
- Also reverts a \`Sample6\` story that was mistakenly committed to \`Examples.stories.ts\` in #48 — private samples belong in the gitignored \`Samples.privateDemo.stories.ts\`.

## Scope
No playback yet (that's Phase B). This PR ensures the media shape is parsed, positioned, and rendered as a static poster with a visible play indicator.

## Test plan
- [x] WASM rebuilt; \`npx tsc --noEmit -p packages/pptx/tsconfig.json\` clean
- [x] VRT: 60 passed (unchanged from baseline), 3 pre-existing failures unrelated
- [ ] Storybook visual check: \`PptxViewer/PrivateExamples/Sample7\` → slides 1–2 show poster + play badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)