### PR TITLE
Fix SmartArt connector shapes being tilted by cy=0 auto-height fallback

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2525,12 +2525,6 @@ fn parse_shape(
             .and_then(|bp| attr(&bp, "anchor"))
             .map(|a| a == "b")
             .unwrap_or(false);
-    let cy = if t.cy == 0 {
-        if is_bottom_anchor { 0_i64 } else { 2_000_000_i64 }
-    } else {
-        t.cy
-    };
-
     // custGeom takes priority over prstGeom
     let cust_geom_node = sp_pr.and_then(|p| child(p, "custGeom"));
     let prst_geom_node = sp_pr.and_then(|p| child(p, "prstGeom"));
@@ -2540,6 +2534,20 @@ fn parse_shape(
         prst_geom_node
             .and_then(|n| attr(&n, "prst"))
             .unwrap_or_else(|| "rect".into())
+    };
+
+    // cy=0 means "auto-height" for body-text shapes, but connector-type
+    // geometries (line, *Connector*) legitimately use cy=0 to represent
+    // a perfectly horizontal segment — don't inflate their height.
+    let is_connector_geom = matches!(geometry.as_str(),
+        "line" | "straightConnector1"
+        | "bentConnector2" | "bentConnector3" | "bentConnector4" | "bentConnector5"
+        | "curvedConnector2" | "curvedConnector3" | "curvedConnector4" | "curvedConnector5"
+    );
+    let cy = if t.cy == 0 && !is_connector_geom {
+        if is_bottom_anchor { 0_i64 } else { 2_000_000_i64 }
+    } else {
+        t.cy
     };
     let cust_geom = cust_geom_node.map(|n| parse_cust_geom(n));
 


### PR DESCRIPTION
## Summary
- Connector-type geometries (line, *Connector*) encode a perfectly horizontal or vertical segment via cy=0
- `parse_shape` was inflating that to 2,000,000 EMU as an auto-height fallback for body-text shapes
- Result: horizontal connectors in SmartArt diagrams (e.g. sample-6 slide 3 timeline) rendered as diagonal lines
- Move geometry detection before the cy fallback and skip the fallback when the geometry is a connector

## Test plan
- [x] VRT on sample-6 slide 3 — horizontal connector renders horizontal (96.7% → 96.8%)
- [x] Full VRT — 60 pass, 3 pre-existing failures (unrelated)
- [ ] Manual Storybook inspection of SmartArt slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)