### PR TITLE
Add interactive audio/video playback (presentSlide API)

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -160,4 +160,17 @@ export interface RenderOptions {
   dpr?: number;
   majorFont?: string | null;
   minorFont?: string | null;
+  /**
+   * Lazily resolve an archive-internal asset (by zip path) to a Blob. The
+   * renderer uses this to fetch posters and other large embedded assets on
+   * demand, keeping the parse output free of inlined base64.
+   */
+  fetchMedia?: (path: string) => Promise<Blob>;
+  /**
+   * When true, renderMedia draws only the poster frame — play/pause badges
+   * and progress bars are left to the caller. Set by the pptx presentSlide
+   * API so its interactive handle can own all control chrome without
+   * the static renderer drawing a duplicate play badge.
+   */
+  skipMediaControls?: boolean;
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -17,6 +17,24 @@ pub fn parse_pptx(data: &[u8]) -> Result<String, JsValue> {
         .map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
+/// Extract raw bytes for a single entry (e.g. "ppt/media/media2.mp4") from a
+/// pptx zip archive. Used by the main thread to materialize media blobs for
+/// interactive playback without re-parsing the whole file.
+#[wasm_bindgen]
+pub fn extract_media(data: &[u8], path: &str) -> Result<Vec<u8>, JsValue> {
+    let cursor = Cursor::new(data);
+    let mut zip = zip::ZipArchive::new(cursor)
+        .map_err(|e| JsValue::from_str(&format!("zip open error: {e}")))?;
+    let mut entry = zip
+        .by_name(path)
+        .map_err(|e| JsValue::from_str(&format!("entry not found: {path}: {e}")))?;
+    let mut buf = Vec::with_capacity(entry.size() as usize);
+    entry
+        .read_to_end(&mut buf)
+        .map_err(|e| JsValue::from_str(&format!("read error: {e}")))?;
+    Ok(buf)
+}
+
 // ===========================
 //  Data types  (camelCase JSON → TypeScript)
 // ===========================
@@ -220,8 +238,13 @@ struct MediaElement {
     height: i64,
     /// "audio" or "video"
     media_kind: String,
-    /// Poster image shown before playback starts (data URL).
-    poster_data_url: String,
+    /// Zip path of the poster image (e.g. "ppt/media/image2.png"). Empty when
+    /// the media element has no blipFill poster. Fetched lazily through the
+    /// same getMedia API as `media_path` so large posters don't bloat the
+    /// parse output's JSON.
+    poster_path: String,
+    /// Poster image MIME type (derived from extension). Empty when no poster.
+    poster_mime_type: String,
     /// Path inside the pptx zip (e.g. "ppt/media/media2.mp4"). The renderer
     /// uses this with a separate getMedia API to pull bytes lazily, avoiding
     /// the cost of base64-encoding large videos into the parse result.
@@ -2770,7 +2793,6 @@ fn parse_media(
     pic_node: roxmltree::Node<'_, '_>,
     slide_dir: &str,
     rels: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
 ) -> Option<MediaElement> {
     let nv_pic_pr = child(pic_node, "nvPicPr")?;
     let nv_pr = child(nv_pic_pr, "nvPr")?;
@@ -2824,22 +2846,25 @@ fn parse_media(
     let t = parse_xfrm(xfrm_node);
     if t.cx == 0 || t.cy == 0 { return None; }
 
-    // Poster image (from blipFill). Optional — renders with a fallback icon when missing.
-    let poster_data_url = (|| -> Option<String> {
+    // Poster image (from blipFill). Optional — the renderer falls back to a
+    // solid fill when the poster is absent or still loading. We emit just the
+    // zip path so the main thread can lazily `getMedia` it; embedding large
+    // posters inline ballooned the parse output for video-heavy decks.
+    let (poster_path, poster_mime_type) = (|| -> Option<(String, String)> {
         let blip_fill = child(pic_node, "blipFill")?;
         let r_id = child(blip_fill, "blip").and_then(|b| attr_r(&b, "embed"))?;
         let rel_target = rels.get(&r_id)?;
         let image_path = resolve_path(slide_dir, rel_target);
-        let image_bytes = read_zip_bytes(zip, &image_path)?;
-        let img_mime = mime_from_ext(&image_path);
-        Some(format!("data:{img_mime};base64,{}", B64.encode(&image_bytes)))
+        let img_mime = mime_from_ext(&image_path).to_string();
+        Some((image_path, img_mime))
     })()
     .unwrap_or_default();
 
     Some(MediaElement {
         x: t.x, y: t.y, width: t.cx, height: t.cy,
         media_kind,
-        poster_data_url,
+        poster_path,
+        poster_mime_type,
         media_path,
         mime_type: mime.to_string(),
     })
@@ -3351,7 +3376,7 @@ fn parse_sp_tree_node(
             }
         }
         "pic" => {
-            if let Some(media) = parse_media(node, slide_dir, rels, zip) {
+            if let Some(media) = parse_media(node, slide_dir, rels) {
                 out.push(SlideElement::Media(media));
             } else if let Some(pic) = parse_picture(node, slide_dir, rels, zip) {
                 out.push(SlideElement::Picture(pic));

--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -1,0 +1,511 @@
+import type { MediaElement, Slide } from './types';
+
+const EMU_PER_PX = 9525;
+const emuToPx = (v: number, scale: number) => (v / EMU_PER_PX) * scale;
+
+interface MediaState {
+  el: MediaElement;
+  /** Interaction bounds — drives hit testing and progress bar placement. For
+   *  audio this is enlarged below the icon so the bar has room. */
+  rect: { x: number; y: number; w: number; h: number };
+  /** The original poster/icon bounds from EMU coords. Badge anchors to this
+   *  so the play/pause circle stays on top of the icon, not on the bar. */
+  posterRect: { x: number; y: number; w: number; h: number };
+  media: HTMLVideoElement | HTMLAudioElement;
+  objectUrl: string;
+}
+
+export interface PresentationHandle {
+  play(mediaPath?: string): void;
+  pause(mediaPath?: string): void;
+  dispose(): void;
+}
+
+export interface PresentOptions {
+  /** Display width in CSS pixels (same value used to render the base slide). */
+  width: number;
+  /** Device pixel ratio used when sizing the canvas backing store. */
+  dpr: number;
+  /** Slide width in EMU (from Presentation.slideWidth). */
+  slideWidthEmu: number;
+  /** Retrieve the raw media bytes for the given zip path. */
+  fetchMedia: (mediaPath: string) => Promise<Blob>;
+  /** Draw the static slide (poster + play badge) onto the canvas. */
+  drawBase: () => Promise<void>;
+}
+
+/**
+ * Attach canvas-native playback to a slide. Layers each media element's video
+ * frame (via HTMLVideoElement → drawImage) and a self-drawn play/progress
+ * overlay on top of the base rendering. Click on a media element to toggle
+ * playback. Call dispose() to stop the RAF loop and release blob URLs.
+ */
+export async function createPresentationHandle(
+  canvas: HTMLCanvasElement,
+  slide: Slide,
+  opts: PresentOptions,
+): Promise<PresentationHandle> {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2D context not available');
+
+  const slideScale = opts.width / (opts.slideWidthEmu / EMU_PER_PX);
+
+  await opts.drawBase();
+
+  const base = document.createElement('canvas');
+  base.width = canvas.width;
+  base.height = canvas.height;
+  const baseCtx = base.getContext('2d');
+  if (!baseCtx) throw new Error('base 2D context not available');
+  baseCtx.drawImage(canvas, 0, 0);
+
+  const mediaElements = slide.elements.filter((e): e is MediaElement => e.type === 'media');
+  const states: MediaState[] = [];
+
+  for (const el of mediaElements) {
+    let blob: Blob;
+    try {
+      blob = await opts.fetchMedia(el.mediaPath);
+    } catch {
+      continue;
+    }
+    const typed = new Blob([blob], { type: el.mimeType || blob.type });
+    const url = URL.createObjectURL(typed);
+    const media: HTMLVideoElement | HTMLAudioElement = el.mediaKind === 'video'
+      ? document.createElement('video')
+      : document.createElement('audio');
+    media.src = url;
+    media.preload = 'metadata';
+    if (el.mediaKind === 'video') {
+      (media as HTMLVideoElement).playsInline = true;
+    }
+    const posterRect = {
+      x: emuToPx(el.x, slideScale),
+      y: emuToPx(el.y, slideScale),
+      w: emuToPx(el.width, slideScale),
+      h: emuToPx(el.height, slideScale),
+    };
+    // Audio icons in pptx are often small (40–80 px); a bar that narrow is
+    // unusable, so expand the control surface horizontally and push it
+    // downward below the icon so the bar sits clearly under the speaker —
+    // not across its bottom edge. Video keeps its native bounds since the
+    // bar overlays the frame.
+    const rect = el.mediaKind === 'audio'
+      ? {
+          x: posterRect.x + posterRect.w / 2 - Math.max(posterRect.w, 260) / 2,
+          y: posterRect.y,
+          w: Math.max(posterRect.w, 260),
+          h: posterRect.h + 36,
+        }
+      : posterRect;
+    states.push({ el, rect, posterRect, media, objectUrl: url });
+  }
+
+  let rafId: number | null = null;
+  let disposed = false;
+  let hoveredState: MediaState | null = null;
+
+  const drawFrame = () => {
+    ctx.setTransform(opts.dpr, 0, 0, opts.dpr, 0, 0);
+    const cssW = canvas.width / opts.dpr;
+    const cssH = canvas.height / opts.dpr;
+    ctx.drawImage(base, 0, 0, canvas.width, canvas.height, 0, 0, cssW, cssH);
+
+    for (const s of states) {
+      const media = s.media;
+
+      // Draw the current video frame whenever the element has pixel data —
+      // paused or playing. Paused should hold the frame you stopped on, not
+      // snap back to the poster (which is the base render underneath).
+      if (s.el.mediaKind === 'video' && media.readyState >= 2) {
+        const { x, y, w, h } = s.posterRect;
+        ctx.drawImage(media as HTMLVideoElement, x, y, w, h);
+      }
+
+      // Controls fade in on hover. While actively dragging the scrubber
+      // (`seeking`), keep the hovered state latched to that element so the
+      // bar doesn't disappear when the pointer strays off-element mid-drag.
+      const isActive = s === hoveredState || seeking?.state === s;
+      if (isActive) drawControls(ctx, s, media);
+    }
+  };
+
+  const tick = () => {
+    if (disposed) return;
+    drawFrame();
+    rafId = requestAnimationFrame(tick);
+  };
+
+  const toLocal = (clientX: number, clientY: number) => {
+    const bb = canvas.getBoundingClientRect();
+    const cssW = canvas.width / opts.dpr;
+    const cssH = canvas.height / opts.dpr;
+    return {
+      x: ((clientX - bb.left) / bb.width) * cssW,
+      y: ((clientY - bb.top) / bb.height) * cssH,
+    };
+  };
+
+  type Hit =
+    | { kind: 'seek'; state: MediaState; fraction: number }
+    | { kind: 'toggle'; state: MediaState };
+
+  const hitTest = (localX: number, localY: number): Hit | null => {
+    for (const s of states) {
+      const { x, y, w, h } = s.rect;
+      if (localX < x || localX > x + w || localY < y || localY > y + h) continue;
+      const bar = barGeometry(s);
+      // Expand the bar's vertical hit area so a 2–4 px visual bar is still easy
+      // to grab on high-DPI displays; horizontally use the visual bounds.
+      const hitYTop = bar.y - 12;
+      const hitYBot = bar.y + bar.h + 8;
+      const duration = Number.isFinite(s.media.duration) ? s.media.duration : 0;
+      if (
+        duration > 0 &&
+        localX >= bar.x && localX <= bar.x + bar.w &&
+        localY >= hitYTop && localY <= hitYBot
+      ) {
+        const fraction = Math.max(0, Math.min(1, (localX - bar.x) / bar.w));
+        return { kind: 'seek', state: s, fraction };
+      }
+      return { kind: 'toggle', state: s };
+    }
+    return null;
+  };
+
+  let seeking: { state: MediaState; wasPlaying: boolean } | null = null;
+
+  const seekTo = (state: MediaState, fraction: number) => {
+    const duration = Number.isFinite(state.media.duration) ? state.media.duration : 0;
+    if (duration <= 0) return;
+    state.media.currentTime = duration * fraction;
+  };
+
+  const onPointerDown = (e: PointerEvent) => {
+    const { x: lx, y: ly } = toLocal(e.clientX, e.clientY);
+    const hit = hitTest(lx, ly);
+    if (!hit) return;
+    if (hit.kind === 'seek') {
+      seeking = { state: hit.state, wasPlaying: !hit.state.media.paused };
+      hit.state.media.pause();
+      seekTo(hit.state, hit.fraction);
+      canvas.setPointerCapture(e.pointerId);
+      e.preventDefault();
+    } else {
+      if (hit.state.media.paused) void hit.state.media.play().catch(() => undefined);
+      else hit.state.media.pause();
+    }
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    const { x: lx, y: ly } = toLocal(e.clientX, e.clientY);
+
+    // Hover tracking — update which element the pointer is over each move.
+    hoveredState = null;
+    for (const s of states) {
+      const { x, y, w, h } = s.rect;
+      if (lx >= x && lx <= x + w && ly >= y && ly <= y + h) {
+        hoveredState = s;
+        break;
+      }
+    }
+
+    if (seeking) {
+      const bar = barGeometry(seeking.state);
+      const fraction = Math.max(0, Math.min(1, (lx - bar.x) / bar.w));
+      seekTo(seeking.state, fraction);
+    }
+  };
+
+  const onPointerLeave = () => { hoveredState = null; };
+
+  const onPointerUp = (e: PointerEvent) => {
+    if (!seeking) return;
+    const { wasPlaying, state } = seeking;
+    seeking = null;
+    canvas.releasePointerCapture(e.pointerId);
+    if (wasPlaying) void state.media.play().catch(() => undefined);
+  };
+
+  canvas.addEventListener('pointerdown', onPointerDown);
+  canvas.addEventListener('pointermove', onPointerMove);
+  canvas.addEventListener('pointerleave', onPointerLeave);
+  canvas.addEventListener('pointerup', onPointerUp);
+  canvas.addEventListener('pointercancel', onPointerUp);
+  canvas.style.cursor = 'pointer';
+  tick();
+
+  return {
+    play(mediaPath) {
+      for (const s of states) {
+        if (!mediaPath || s.el.mediaPath === mediaPath) {
+          void s.media.play().catch(() => undefined);
+        }
+      }
+    },
+    pause(mediaPath) {
+      for (const s of states) {
+        if (!mediaPath || s.el.mediaPath === mediaPath) s.media.pause();
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      canvas.removeEventListener('pointerdown', onPointerDown);
+      canvas.removeEventListener('pointermove', onPointerMove);
+      canvas.removeEventListener('pointerleave', onPointerLeave);
+      canvas.removeEventListener('pointerup', onPointerUp);
+      canvas.removeEventListener('pointercancel', onPointerUp);
+      canvas.style.cursor = '';
+      for (const s of states) {
+        s.media.pause();
+        s.media.removeAttribute('src');
+        s.media.load();
+        URL.revokeObjectURL(s.objectUrl);
+      }
+    },
+  };
+}
+
+const AUDIO_PILL_H = 28;
+const AUDIO_PILL_SIDE_PAD = 14;
+const AUDIO_TIME_RESERVE = 72;
+const AUDIO_TIME_GAP = 10;
+const BAR_H = 3;
+
+function drawControls(
+  ctx: CanvasRenderingContext2D,
+  state: MediaState,
+  media: HTMLVideoElement | HTMLAudioElement,
+): void {
+  const duration = Number.isFinite(media.duration) ? media.duration : 0;
+  const progress = duration > 0 ? Math.min(1, media.currentTime / duration) : 0;
+
+  drawPlayBadge(ctx, state, media);
+
+  if (state.el.mediaKind === 'audio') {
+    drawAudioPill(ctx, state, media, duration, progress);
+  } else {
+    drawVideoChrome(ctx, state, media, duration, progress);
+  }
+}
+
+function drawPlayBadge(
+  ctx: CanvasRenderingContext2D,
+  state: MediaState,
+  media: HTMLVideoElement | HTMLAudioElement,
+): void {
+  const poster = state.posterRect;
+  const badgeR = Math.max(18, Math.min(32, Math.min(poster.w, poster.h) * 0.25));
+  const cx = poster.x + poster.w / 2;
+  const cy = poster.y + poster.h / 2;
+  ctx.save();
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.3)';
+  ctx.shadowBlur = badgeR * 0.35;
+  ctx.fillStyle = 'rgba(20, 20, 20, 0.7)';
+  ctx.beginPath();
+  ctx.arc(cx, cy, badgeR, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.shadowColor = 'transparent';
+  ctx.shadowBlur = 0;
+  ctx.fillStyle = '#fff';
+  if (media.paused) {
+    ctx.beginPath();
+    const tri = badgeR * 0.48;
+    ctx.moveTo(cx - tri * 0.4, cy - tri);
+    ctx.lineTo(cx - tri * 0.4, cy + tri);
+    ctx.lineTo(cx + tri * 0.75, cy);
+    ctx.closePath();
+    ctx.fill();
+  } else {
+    const bw = badgeR * 0.2;
+    const bh = badgeR * 0.8;
+    const gap = badgeR * 0.15;
+    ctx.fillRect(cx - gap - bw, cy - bh / 2, bw, bh);
+    ctx.fillRect(cx + gap, cy - bh / 2, bw, bh);
+  }
+  ctx.restore();
+}
+
+function drawVideoChrome(
+  ctx: CanvasRenderingContext2D,
+  state: MediaState,
+  media: HTMLVideoElement | HTMLAudioElement,
+  duration: number,
+  progress: number,
+): void {
+  const { x, y, w, h } = state.rect;
+  const chromeH = Math.max(28, Math.min(56, h * 0.22));
+  const chromeY = y + h - chromeH;
+
+  ctx.save();
+  const grad = ctx.createLinearGradient(0, chromeY, 0, y + h);
+  grad.addColorStop(0, 'rgba(0, 0, 0, 0)');
+  grad.addColorStop(1, 'rgba(0, 0, 0, 0.55)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(x, chromeY, w, chromeH);
+  ctx.restore();
+
+  const bar = barGeometry(state);
+  drawBar(ctx, bar, progress, duration > 0);
+
+  const fontPx = 11;
+  ctx.save();
+  ctx.font = `500 ${fontPx}px system-ui, -apple-system, sans-serif`;
+  ctx.textBaseline = 'middle';
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.75)';
+  ctx.shadowBlur = 3;
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+  drawFixedSlotTime(ctx, media.currentTime, duration, bar.x, bar.y - 10, 'bottom');
+  ctx.restore();
+}
+
+function drawAudioPill(
+  ctx: CanvasRenderingContext2D,
+  state: MediaState,
+  media: HTMLVideoElement | HTMLAudioElement,
+  duration: number,
+  progress: number,
+): void {
+  const stadium = audioStadium(state.rect);
+  ctx.save();
+  roundedRect(ctx, stadium.x, stadium.y, stadium.w, stadium.h, stadium.h / 2);
+  ctx.fillStyle = 'rgba(20, 20, 20, 0.72)';
+  ctx.fill();
+
+  const fontPx = 11;
+  ctx.font = `500 ${fontPx}px system-ui, -apple-system, sans-serif`;
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+  drawFixedSlotTime(
+    ctx, media.currentTime, duration,
+    stadium.x + AUDIO_PILL_SIDE_PAD, stadium.y + stadium.h / 2, 'middle',
+  );
+  ctx.restore();
+
+  const bar = barGeometry(state);
+  drawBar(ctx, bar, progress, duration > 0);
+}
+
+/**
+ * Render "m:ss / m:ss" such that the separator stays at a fixed x even as the
+ * current-time digits tick, by right-aligning the current side into a fixed
+ * slot and left-aligning the duration side. Side slot width is sized once per
+ * call from the duration string so the layout fits longer clips too.
+ */
+function drawFixedSlotTime(
+  ctx: CanvasRenderingContext2D,
+  current: number,
+  duration: number,
+  x: number,
+  anchorY: number,
+  anchor: 'middle' | 'bottom',
+): void {
+  const curText = formatTime(current);
+  const durText = formatTime(duration);
+  const sep = ' / ';
+  // Widest representation of either side: use the longer of the two formatted
+  // strings. In practice duration dominates since current ≤ duration.
+  const slotW = Math.max(ctx.measureText(curText).width, ctx.measureText(durText).width);
+  const sepW = ctx.measureText(sep).width;
+  const y = anchor === 'bottom' ? anchorY : anchorY;
+  const prevAlign = ctx.textAlign;
+  ctx.textAlign = 'right';
+  ctx.fillText(curText, x + slotW, y);
+  ctx.textAlign = 'left';
+  ctx.fillText(sep, x + slotW, y);
+  ctx.fillText(durText, x + slotW + sepW, y);
+  ctx.textAlign = prevAlign;
+}
+
+function drawBar(
+  ctx: CanvasRenderingContext2D,
+  bar: { x: number; y: number; w: number; h: number },
+  progress: number,
+  hasDuration: boolean,
+): void {
+  const radius = bar.h / 2;
+  ctx.save();
+  roundedRect(ctx, bar.x, bar.y, bar.w, bar.h, radius);
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.35)';
+  ctx.fill();
+
+  if (progress > 0) {
+    roundedRect(ctx, bar.x, bar.y, bar.w * progress, bar.h, radius);
+    ctx.fillStyle = '#fff';
+    ctx.fill();
+  }
+
+  if (hasDuration) {
+    const handleR = 5;
+    const handleX = Math.max(bar.x + handleR, Math.min(bar.x + bar.w - handleR, bar.x + bar.w * progress));
+    ctx.shadowColor = 'rgba(0, 0, 0, 0.3)';
+    ctx.shadowBlur = 3;
+    ctx.fillStyle = '#fff';
+    ctx.beginPath();
+    ctx.arc(handleX, bar.y + bar.h / 2, handleR, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function audioStadium(rect: { x: number; y: number; w: number; h: number }) {
+  const w = Math.max(220, rect.w - 24);
+  return {
+    x: rect.x + rect.w / 2 - w / 2,
+    y: rect.y + rect.h - AUDIO_PILL_H - 4,
+    w,
+    h: AUDIO_PILL_H,
+  };
+}
+
+function barGeometry(state: MediaState) {
+  if (state.el.mediaKind === 'audio') {
+    const stadium = audioStadium(state.rect);
+    const barX = stadium.x + AUDIO_PILL_SIDE_PAD + AUDIO_TIME_RESERVE + AUDIO_TIME_GAP;
+    const barW = Math.max(40, stadium.x + stadium.w - AUDIO_PILL_SIDE_PAD - barX);
+    return {
+      x: barX,
+      y: stadium.y + (stadium.h - BAR_H) / 2,
+      w: barW,
+      h: BAR_H,
+    };
+  }
+  const rect = state.rect;
+  const margin = Math.max(12, rect.w * 0.025);
+  const bottomPad = Math.max(12, Math.min(18, rect.h * 0.05));
+  return {
+    x: rect.x + margin,
+    y: rect.y + rect.h - BAR_H - bottomPad,
+    w: rect.w - margin * 2,
+    h: BAR_H,
+  };
+}
+
+function roundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number, y: number, w: number, h: number,
+  r: number,
+): void {
+  const rr = Math.min(r, h / 2, w / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.lineTo(x + w - rr, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + rr);
+  ctx.lineTo(x + w, y + h - rr);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - rr, y + h);
+  ctx.lineTo(x + rr, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - rr);
+  ctx.lineTo(x, y + rr);
+  ctx.quadraticCurveTo(x, y, x + rr, y);
+  ctx.closePath();
+}
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+  const s = Math.floor(seconds);
+  const m = Math.floor(s / 60);
+  const ss = (s % 60).toString().padStart(2, '0');
+  return `${m}:${ss}`;
+}

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1,5 +1,6 @@
-import type { Presentation, WorkerRequest, WorkerResponse } from './types';
+import type { MediaElement, Presentation, WorkerRequest, WorkerResponse } from './types';
 import { renderSlide } from './renderer';
+import { createPresentationHandle, type PresentationHandle } from './presentation-handle';
 import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/pptx_parser_bg.wasm?url';
 
@@ -77,6 +78,12 @@ export interface RenderSlideOptions {
   width?: number;
   /** Device pixel ratio. Defaults to window.devicePixelRatio or 1. */
   dpr?: number;
+  /**
+   * Skip drawing the play badge overlay on media elements. Used internally by
+   * {@link PptxPresentation.presentSlide} so its interactive handle can draw
+   * its own play/pause chrome without duplication.
+   */
+  skipMediaControls?: boolean;
 }
 
 /**
@@ -101,6 +108,11 @@ export class PptxPresentation {
     number,
     { resolve: (p: Presentation) => void; reject: (e: Error) => void }
   >();
+  private _pendingMediaCallbacks = new Map<
+    number,
+    { resolve: (b: ArrayBuffer) => void; reject: (e: Error) => void }
+  >();
+  private _mediaCache = new Map<string, Promise<Blob>>();
   private _nextId = 1;
   private _workerReady = false;
   private _workerReadyCallbacks: Array<() => void> = [];
@@ -129,12 +141,27 @@ export class PptxPresentation {
         return;
       }
 
+      if (msg.kind === 'mediaExtracted') {
+        const cb = this._pendingMediaCallbacks.get(msg.id);
+        if (cb) {
+          this._pendingMediaCallbacks.delete(msg.id);
+          cb.resolve(msg.bytes);
+        }
+        return;
+      }
+
       if (msg.kind === 'error') {
-        const parseCb = this._pendingParseCallbacks.get(msg.id);
         const err = new Error(msg.message);
+        const parseCb = this._pendingParseCallbacks.get(msg.id);
         if (parseCb) {
           this._pendingParseCallbacks.delete(msg.id);
           parseCb.reject(err);
+          return;
+        }
+        const mediaCb = this._pendingMediaCallbacks.get(msg.id);
+        if (mediaCb) {
+          this._pendingMediaCallbacks.delete(msg.id);
+          mediaCb.reject(err);
         }
       }
     };
@@ -207,13 +234,75 @@ export class PptxPresentation {
         defaultTextColor: this._presentation.defaultTextColor,
         majorFont: this._presentation.majorFont,
         minorFont: this._presentation.minorFont,
+        fetchMedia: (path) => this.getMedia(path),
+        skipMediaControls: opts.skipMediaControls,
       },
     );
+  }
+
+  /**
+   * Extract raw media bytes for a zip path referenced by {@link MediaElement}.
+   * Results are cached by path for the lifetime of this instance.
+   */
+  async getMedia(mediaPath: string): Promise<Blob> {
+    const hit = this._mediaCache.get(mediaPath);
+    if (hit) return hit;
+    const mimeType = this._findMimeTypeForPath(mediaPath);
+    const p = (async () => {
+      await this._waitForWorker();
+      const id = this._nextId++;
+      const bytes = await new Promise<ArrayBuffer>((resolve, reject) => {
+        this._pendingMediaCallbacks.set(id, { resolve, reject });
+        this._worker.postMessage({ kind: 'extractMedia', id, path: mediaPath } satisfies WorkerRequest);
+      });
+      return new Blob([bytes], { type: mimeType });
+    })();
+    this._mediaCache.set(mediaPath, p);
+    return p;
+  }
+
+  private _findMimeTypeForPath(mediaPath: string): string {
+    if (!this._presentation) return '';
+    for (const slide of this._presentation.slides) {
+      for (const el of slide.elements) {
+        if (el.type !== 'media') continue;
+        const m = el as MediaElement;
+        if (m.mediaPath === mediaPath) return m.mimeType;
+        if (m.posterPath === mediaPath) return m.posterMimeType;
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Render a slide and attach canvas-native playback controls for any
+   * embedded audio/video. Returns a disposable handle that owns the RAF loop,
+   * media elements, and object URLs. Unlike {@link renderSlide}, this method
+   * is stateful — always call `handle.dispose()` when leaving the slide.
+   */
+  async presentSlide(
+    canvas: HTMLCanvasElement,
+    slideIndex: number,
+    opts: RenderSlideOptions = {},
+  ): Promise<PresentationHandle> {
+    if (!this._presentation) throw new Error('Presentation not loaded');
+    const slide = this._presentation.slides[slideIndex];
+    if (!slide) throw new Error(`Slide index ${slideIndex} out of range (count: ${this.slideCount})`);
+    const dpr = opts.dpr ?? (typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1);
+    const width = opts.width ?? (canvas.offsetWidth || 960);
+    return createPresentationHandle(canvas, slide, {
+      width,
+      dpr,
+      slideWidthEmu: this._presentation.slideWidth,
+      fetchMedia: (path) => this.getMedia(path),
+      drawBase: () => this.renderSlide(canvas, slideIndex, { width, dpr, skipMediaControls: true }),
+    });
   }
 
   /** Terminate the worker and release all resources. */
   destroy(): void {
     this._worker.terminate();
     this._presentation = null;
+    this._mediaCache.clear();
   }
 }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2561,27 +2561,33 @@ async function renderMedia(
   ctx: CanvasRenderingContext2D,
   el: MediaElement,
   scale: number,
+  fetchMedia?: (path: string) => Promise<Blob>,
+  skipControls?: boolean,
 ) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
   const w = emuToPx(el.width, scale);
   const h = emuToPx(el.height, scale);
 
-  if (el.posterDataUrl) {
+  let drewPoster = false;
+  if (el.posterPath && fetchMedia) {
     try {
-      const resp = await fetch(el.posterDataUrl);
-      const blob = await resp.blob();
-      const bitmap = await createImageBitmap(blob);
+      const blob = await fetchMedia(el.posterPath);
+      const typed = el.posterMimeType ? new Blob([blob], { type: el.posterMimeType }) : blob;
+      const bitmap = await createImageBitmap(typed);
       ctx.drawImage(bitmap, x, y, w, h);
       bitmap.close();
+      drewPoster = true;
     } catch {
       // fall through to plain fill
     }
   }
-  if (!el.posterDataUrl) {
+  if (!drewPoster) {
     ctx.fillStyle = el.mediaKind === 'video' ? '#111' : '#f0f0f0';
     ctx.fillRect(x, y, w, h);
   }
+
+  if (skipControls) return;
 
   // Play-badge overlay: centered filled circle with a triangle cue
   const cx = x + w / 2;
@@ -2825,7 +2831,7 @@ export async function renderSlide(
     } else if (el.type === 'table') {
       renderTable(ctx, el, scale, slideNumber, rc);
     } else if (el.type === 'media') {
-      await renderMedia(ctx, el, scale);
+      await renderMedia(ctx, el, scale, opts.fetchMedia, opts.skipMediaControls);
     } else if (el.type === 'chart') {
       renderChart(
         ctx,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -50,8 +50,10 @@ export interface MediaElement {
   height: number;
   /** "audio" or "video" */
   mediaKind: 'audio' | 'video';
-  /** Poster frame shown before playback (image data URL, may be empty). */
-  posterDataUrl: string;
+  /** Poster image zip path (e.g. "ppt/media/image2.png"). Empty when no poster. */
+  posterPath: string;
+  /** Poster image MIME type (empty when no poster). */
+  posterMimeType: string;
   /** Path inside the pptx zip (e.g. "ppt/media/media2.mp4"). Used by getMedia. */
   mediaPath: string;
   /** MIME type of the underlying media (e.g. "audio/mpeg", "video/mp4"). */
@@ -180,9 +182,11 @@ export interface PictureElement {
 
 export type WorkerRequest =
   | { kind: 'init'; wasmUrl: string }
-  | { kind: 'parse'; id: number; buffer: ArrayBuffer };
+  | { kind: 'parse'; id: number; buffer: ArrayBuffer }
+  | { kind: 'extractMedia'; id: number; path: string };
 
 export type WorkerResponse =
   | { kind: 'ready' }
   | { kind: 'parsed'; id: number; presentation: Presentation }
+  | { kind: 'mediaExtracted'; id: number; bytes: ArrayBuffer }
   | { kind: 'error'; id: number; message: string };

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -1,7 +1,8 @@
 import type { Presentation, WorkerRequest, WorkerResponse } from './types';
-import init, { parse_pptx } from './wasm/pptx_parser.js';
+import init, { parse_pptx, extract_media } from './wasm/pptx_parser.js';
 
 let ready = false;
+let currentBuffer: Uint8Array | null = null;
 
 async function initWasm(wasmUrl: string) {
   await init(wasmUrl);
@@ -27,10 +28,34 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
       return;
     }
     try {
-      const jsonStr = parse_pptx(new Uint8Array(req.buffer));
+      const bytes = new Uint8Array(req.buffer);
+      currentBuffer = bytes;
+      const jsonStr = parse_pptx(bytes);
       const presentation: Presentation = JSON.parse(jsonStr);
       const msg: WorkerResponse = { kind: 'parsed', id: req.id, presentation };
       self.postMessage(msg);
+    } catch (err) {
+      const msg: WorkerResponse = {
+        kind: 'error',
+        id: req.id,
+        message: err instanceof Error ? err.message : String(err),
+      };
+      self.postMessage(msg);
+    }
+    return;
+  }
+
+  if (req.kind === 'extractMedia') {
+    if (!currentBuffer) {
+      const msg: WorkerResponse = { kind: 'error', id: req.id, message: 'No pptx loaded' };
+      self.postMessage(msg);
+      return;
+    }
+    try {
+      const bytes = extract_media(currentBuffer, req.path);
+      const copy = new Uint8Array(bytes).slice().buffer;
+      const msg: WorkerResponse = { kind: 'mediaExtracted', id: req.id, bytes: copy };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [copy]);
     } catch (err) {
       const msg: WorkerResponse = {
         kind: 'error',


### PR DESCRIPTION
## Summary
- New \`PptxPresentation.presentSlide(canvas, index, opts)\` returns a disposable \`PresentationHandle\` that owns a RAF loop, HTML media elements, and self-drawn canvas controls.
- Static \`renderSlide\` is unchanged — interactive mode is strictly additive.
- Poster images are no longer inlined as base64 in the parse output; extracted lazily via a new \`extract_media\` WASM export and the worker \`extractMedia\` handler.

## Interactive chrome
- Controls appear on hover only; seek-drag latches the hovered state so the bar stays visible during a drag.
- Thin capsule progress bar (3px) with a small 5px handle clamped inside the bar.
- Play/pause icon toggles based on \`media.paused\`.
- Paused video holds its current frame (drawImage while \`readyState >= 2\`), not the poster.
- Audio gets a horizontal stadium pill with time on the left, bar on the right; sized for usable tap targets even on tiny (40–80 px) speaker icons.
- Fixed-slot time layout keeps the \`/\` at a constant x as seconds tick.

## Test plan
- [x] Type check: \`npx tsc --noEmit -p packages/pptx/tsconfig.json\`
- [x] Rust build: \`wasm-pack build --target web\` in \`packages/pptx/parser\`
- [x] Manual Storybook verification of sample-7 (private) — audio + video play, pause holds current frame, hover-to-show, seek-drag works
- [ ] VRT: public demos have no media, so sample-1 VRT is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)