### PR TITLE
Respect OOXML-specified chart/text sizes and sample loading UX

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -102,6 +102,55 @@ function drawLegend(
   void lw;
 }
 
+function drawAxisTick(
+  ctx: CanvasRenderingContext2D,
+  mode: string,
+  axis: 'val' | 'cat',
+  anchorXOrY: number,
+  perpendicular: number,
+): void {
+  if (mode === 'none' || !mode) return;
+  const len = 4;
+  const prev = ctx.strokeStyle;
+  ctx.strokeStyle = '#888';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  if (axis === 'val') {
+    // val axis is vertical (x = anchor, y varies). Ticks extend horizontally.
+    const x0 = anchorXOrY;
+    const y = perpendicular;
+    const outer = mode === 'out' || mode === 'cross' ? -len : 0;
+    const inner = mode === 'in' || mode === 'cross' ? len : 0;
+    ctx.moveTo(x0 + outer, y);
+    ctx.lineTo(x0 + inner, y);
+  } else {
+    // cat axis is horizontal (y = anchor, x varies). Ticks extend vertically.
+    const y0 = anchorXOrY;
+    const xc = perpendicular;
+    const outer = mode === 'out' || mode === 'cross' ? len : 0;
+    const inner = mode === 'in' || mode === 'cross' ? -len : 0;
+    ctx.moveTo(xc, y0 + outer);
+    ctx.lineTo(xc, y0 + inner);
+  }
+  ctx.stroke();
+  ctx.strokeStyle = prev;
+}
+
+function chartTitleFontPx(chart: ChartModel, h: number, ptToPx: number): number {
+  // Honor the XML-specified title font size (hundredths of a point) when
+  // present. ptToPx is the pixels-per-point at the current slide scale, so
+  // a 16pt title renders at the same proportional size as PowerPoint.
+  if (chart.titleFontSizeHpt) return (chart.titleFontSizeHpt / 100) * ptToPx;
+  return Math.max(10, h * 0.085);
+}
+
+/** Resolve an axis label font size (px) from <c:txPr> hpt or a proportional
+ *  fallback. ptToPx comes from the host renderer (EMU/px scale at display). */
+function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: number): number {
+  if (sizeHpt) return (sizeHpt / 100) * ptToPx;
+  return Math.max(8, h * 0.045);
+}
+
 function drawChartTitle(
   ctx: CanvasRenderingContext2D,
   title: string | null,
@@ -142,7 +191,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   if (n === 0) return;
 
   const titleH   = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW  = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
+  const legendW  = chart.showLegend ? Math.max(80, w * 0.22) : 0;
   const axisFontSz = Math.max(8, Math.min(10, h * 0.045));
   const catTitleH  = chart.catAxisTitle ? axisFontSz + 4 : 0;
   const valTitleW  = chart.valAxisTitle ? axisFontSz + 4 : 0;
@@ -321,19 +370,39 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
 // Line chart
 // ═══════════════════════════════════════════════════════════════════════════
 
-function renderLineChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect): void {
+function renderLineChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+): void {
   const { x, y, w, h } = r;
   const cats = chartCategories(chart);
   const n = cats.length; if (n === 0) return;
 
-  const titleH   = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW  = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
-  const axisFontSz = Math.max(8, Math.min(10, h * 0.045));
+  const titleFontPx = chart.title ? chartTitleFontPx(chart, h, ptToPx) : 0;
+  // PowerPoint's auto-layout reserves a title band with air above and below
+  // the text; pinning the title to y+0 and the plot to y+titleFontPx+2 is too
+  // tight. Use proportional pads so scaling preserves the same feel.
+  const titleTopPad    = chart.title ? h * 0.045 : 0;
+  const titleBottomPad = chart.title ? h * 0.035 : 0;
+  const titleH   = chart.title ? titleFontPx + titleTopPad + titleBottomPad : 0;
+  const legendW  = chart.showLegend ? Math.max(80, w * 0.22) : 0;
+  const catAxFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  const valAxFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+  const axisFontSz = Math.max(catAxFontPx, valAxFontPx);
   const catTitleH  = chart.catAxisTitle ? axisFontSz + 4 : 0;
   const valTitleW  = chart.valAxisTitle ? axisFontSz + 4 : 0;
-  const pad = { t: titleH + h * 0.04, r: legendW + w * 0.05, b: h * 0.14 + catTitleH, l: w * 0.12 + valTitleW };
+  // Pad based on actual label metrics rather than magic percents so an explicit
+  // <c:txPr sz="1000"> (10pt) correctly compresses the plot area.
+  const pad = {
+    t: titleH + valAxFontPx / 2 + 2,
+    r: legendW + w * 0.05,
+    b: catAxFontPx + 12 + catTitleH,
+    l: valAxFontPx * 2.2 + 10 + valTitleW,
+  };
 
-  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+  drawChartTitle(ctx, chart.title, x, y + titleTopPad, w, titleFontPx);
 
   const px0 = x + pad.l; const py0 = y + pad.t;
   const pw = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
@@ -359,11 +428,16 @@ function renderLineChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const range = axMax - axMin; if (range === 0) return;
 
   const toY = (v: number) => py0 + ph - ((v - axMin) / range) * ph;
-  const toX = (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
+  // crossBetween="between" (default) insets the first/last category by half a
+  // step so points aren't flush against the axes. "midCat" anchors them.
+  const between = chart.catAxisCrossBetween !== 'midCat';
+  const toX = between
+    ? (i: number) => px0 + ((i + 0.5) / n) * pw
+    : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
 
   if (!chart.valAxisHidden) {
     const steps = Math.round((axMax - axMin) / step);
-    ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+    ctx.font = `${valAxFontPx}px sans-serif`;
     ctx.textBaseline = 'middle';
     for (let si = 0; si <= steps; si++) {
       const v = axMin + si * step;
@@ -371,19 +445,31 @@ function renderLineChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       ctx.strokeStyle = v === 0 ? '#aaa' : '#e0e0e0';
       ctx.lineWidth = v === 0 ? 1 : 0.5;
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy);
       ctx.fillStyle = '#555'; ctx.textAlign = 'right';
-      ctx.fillText(formatChartVal(v), px0 - 4, gy);
+      ctx.fillText(formatChartVal(v), px0 - 6, gy);
     }
   }
 
+  // Axis lines: bottom (category) + left (value). Both default to visible
+  // unless hidden explicitly.
   ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
   ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+  if (!chart.valAxisHidden) {
+    ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+  }
 
-  const markerR = Math.max(3, ph * 0.015);
+  // Line width and marker size come from OOXML in points (<a:ln w=EMU> /
+  // <c:marker><c:size val=pt>). We don't parse per-series overrides yet so
+  // use the PowerPoint defaults (2.25pt line, 5pt marker diameter) scaled to
+  // the current slide pt-per-px so both shrink with the viewport.
+  const lineWidthPx = Math.max(1, 2.25 * ptToPx);
+  const markerR = Math.max(2, 2.5 * ptToPx);
+  const dataLabelPx = axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
   for (let si = 0; si < chart.series.length; si++) {
     const s = chart.series[si];
     const color = chartColor(si, s);
-    ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.setLineDash([]);
+    ctx.strokeStyle = color; ctx.lineWidth = lineWidthPx; ctx.setLineDash([]);
     ctx.beginPath();
     let started = false;
     for (let ci = 0; ci < n; ci++) {
@@ -397,8 +483,7 @@ function renderLineChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       const v = s.values[ci]; if (v == null) continue;
       ctx.beginPath(); ctx.arc(toX(ci), toY(v), markerR, 0, Math.PI * 2); ctx.fill();
       if (chart.showDataLabels) {
-        const lsz = Math.max(7, Math.round(markerR * 1.5));
-        ctx.font = `${lsz}px sans-serif`;
+        ctx.font = `${dataLabelPx}px sans-serif`;
         ctx.fillStyle = '#333'; ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
         ctx.fillText(formatChartVal(v), toX(ci), toY(v) - markerR - 1);
         ctx.fillStyle = color;
@@ -409,9 +494,12 @@ function renderLineChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   if (!chart.catAxisHidden) {
     const labelInterval = Math.max(1, Math.ceil(n / 8));
     ctx.fillStyle = '#555'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-    ctx.font = `${Math.max(8, Math.min(11, pw / n * 0.8))}px sans-serif`;
+    ctx.font = `${catAxFontPx}px sans-serif`;
     for (let ci = 0; ci < n; ci += labelInterval) {
-      ctx.fillText((cats[ci] ?? '').toString().slice(0, 10), toX(ci), py0 + ph + 3);
+      const tx = toX(ci);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx);
+      ctx.fillStyle = '#555';
+      ctx.fillText((cats[ci] ?? '').toString().slice(0, 10), tx, py0 + ph + 5);
     }
   }
 
@@ -431,7 +519,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const stacked = chart.chartType === 'stackedArea' || chart.chartType === 'stackedAreaPct';
 
   const titleH   = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW  = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
+  const legendW  = chart.showLegend ? Math.max(80, w * 0.22) : 0;
   const axisFontSz = Math.max(8, Math.min(10, h * 0.045));
   const catTitleH  = chart.catAxisTitle ? axisFontSz + 4 : 0;
   const valTitleW  = chart.valAxisTitle ? axisFontSz + 4 : 0;
@@ -540,7 +628,7 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const titleH = chart.title ? Math.max(14, h * 0.06) : 0;
   drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
 
-  const legendW = Math.max(80, w * 0.28);
+  const legendW = chart.showLegend ? Math.max(80, w * 0.28) : 0;
   const pw = w - legendW; const ph = h - titleH - h * 0.04;
   const cx2 = x + pw / 2; const cy2 = y + titleH + h * 0.04 + ph / 2;
   const outerR = Math.min(pw, ph) * 0.42;
@@ -602,7 +690,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
   const n = cats.length; if (n < 3) return;
 
   const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW = chart.series.length > 1 ? Math.max(70, w * 0.2) : 0;
+  const legendW = chart.showLegend ? Math.max(70, w * 0.2) : 0;
   drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
 
   const pw = w - legendW; const ph = h - titleH - h * 0.04;
@@ -678,7 +766,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
 function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect): void {
   const { x, y, w, h } = r;
   const titleH   = chart.title ? Math.max(14, h * 0.06) : 0;
-  const legendW  = chart.series.length >= 1 ? Math.max(80, w * 0.22) : 0;
+  const legendW  = chart.showLegend ? Math.max(80, w * 0.22) : 0;
   const axisFontSz = Math.max(8, Math.min(10, h * 0.045));
   const catTitleH  = chart.catAxisTitle ? axisFontSz + 4 : 0;
   const valTitleW  = chart.valAxisTitle ? axisFontSz + 4 : 0;
@@ -895,15 +983,21 @@ export function renderChart(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
   rect: ChartRect,
+  /**
+   * Pixels per point at the caller's current display scale. For PPTX at
+   * 960px/12192000EMU the value is ~1.05; xlsx's sheet view renders at
+   * device-px where 1pt≈1.333. Used to size title/axis labels whose
+   * XML-specified sizes are in OOXML hundredths of a point.
+   */
+  ptToPx: number = 1.333,
 ): void {
   const { x, y, w, h } = rect;
-  // White background + light border (xlsx-style frame). PPTX charts are
-  // inside shape boxes with their own backgrounds so the frame is harmless.
-  ctx.fillStyle = '#ffffff';
-  ctx.fillRect(x, y, w, h);
-  ctx.strokeStyle = '#d0d0d0';
-  ctx.lineWidth = 1;
-  ctx.strokeRect(x + 0.5, y + 0.5, w - 1, h - 1);
+  // Only fill the outer chartSpace when chartBg is set; a null means noFill
+  // (transparent) per OOXML, so the underlying slide/sheet shows through.
+  if (chart.chartBg) {
+    ctx.fillStyle = `#${chart.chartBg}`;
+    ctx.fillRect(x, y, w, h);
+  }
 
   if (chart.series.length === 0) {
     ctx.fillStyle = '#888';
@@ -925,7 +1019,7 @@ export function renderChart(
     case 'line':
     case 'stackedLine':
     case 'stackedLinePct':
-      renderLineChart(ctx, chart, rect); break;
+      renderLineChart(ctx, chart, rect, ptToPx); break;
     case 'area':
     case 'stackedArea':
     case 'stackedAreaPct':

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -63,6 +63,25 @@ export interface ChartModel {
   valAxisHidden: boolean;
   /** Hex without '#'. From `<c:plotArea><c:spPr><a:solidFill>`. */
   plotAreaBg: string | null;
+  /** Outer chartSpace background (hex without '#'). null when noFill/absent. */
+  chartBg: string | null;
+  /** True when `<c:legend>` is declared in the chart XML. False = no legend. */
+  showLegend: boolean;
+  /** `<c:catAx><c:crossBetween val="..."/>`. "between" inserts 0.5-step padding
+   *  on each end of the category axis; "midCat" anchors endpoints to the axes. */
+  catAxisCrossBetween: 'between' | 'midCat' | string;
+  /** `<c:valAx><c:majorTickMark>`. ECMA-376 default is "cross". */
+  valAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
+  /** `<c:catAx><c:majorTickMark>`. */
+  catAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
+  /** Title font size in OOXML hundredths of a point (1600 = 16pt). null = default. */
+  titleFontSizeHpt: number | null;
+  /** `<c:catAx><c:txPr>` font size (hpt). null = fall back to proportional default. */
+  catAxisFontSizeHpt: number | null;
+  /** `<c:valAx><c:txPr>` font size (hpt). null = fall back to proportional default. */
+  valAxisFontSizeHpt: number | null;
+  /** `<c:dLbls><c:txPr>` font size (hpt) for data-point value labels. */
+  dataLabelFontSizeHpt: number | null;
   /** Waterfall subtotal category indices. */
   subtotalIndices: number[];
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -103,6 +103,28 @@ struct ChartElement {
     val_axis_hidden: bool,
     /// Plot area background color from <c:plotArea><c:spPr><a:solidFill> (hex without #)
     plot_area_bg: Option<String>,
+    /// Outer chartSpace background (hex without #). None when chartSpace spPr is
+    /// noFill or absent — in which case the slide background shows through.
+    chart_bg: Option<String>,
+    /// True when <c:legend> is present; false means no legend should render.
+    show_legend: bool,
+    /// <c:catAx><c:crossBetween val="..."/>. "between" → inset category positions
+    /// by half a step so the first/last point aren't flush against the axes.
+    /// "midCat" → points sit exactly on the axes. Defaults to "between" when absent.
+    cat_axis_cross_between: String,
+    /// <c:valAx><c:majorTickMark val="..."/>: "out" | "cross" | "in" | "none".
+    val_axis_major_tick_mark: String,
+    /// <c:catAx><c:majorTickMark val="..."/>.
+    cat_axis_major_tick_mark: String,
+    /// Title rPr@sz in OOXML hundredths of a point (e.g. 1600 = 16pt). None
+    /// falls back to a proportional default.
+    title_font_size_hpt: Option<i32>,
+    /// <c:catAx><c:txPr>…defRPr@sz — category-axis label font size (hpt).
+    cat_axis_font_size_hpt: Option<i32>,
+    /// <c:valAx><c:txPr>…defRPr@sz — value-axis label font size (hpt).
+    val_axis_font_size_hpt: Option<i32>,
+    /// <c:dLbls><c:txPr>…defRPr@sz — data-label font size (hpt).
+    data_label_font_size_hpt: Option<i32>,
 }
 
 // ===== Table data model =====
@@ -2221,15 +2243,24 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     };
 
     // Title text
-    let title = root.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "title")
-        .and_then(|title_node| {
-            let texts: Vec<String> = title_node.descendants()
-                .filter(|n| n.is_element() && n.tag_name().name() == "t")
-                .filter_map(|n| n.text().map(|t| t.to_string()))
-                .collect();
-            if texts.is_empty() { None } else { Some(texts.join("")) }
-        });
+    let title_node_opt = root.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "title");
+    let title = title_node_opt.and_then(|title_node| {
+        let texts: Vec<String> = title_node.descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "t")
+            .filter_map(|n| n.text().map(|t| t.to_string()))
+            .collect();
+        if texts.is_empty() { None } else { Some(texts.join("")) }
+    });
+    // Title font size in hundredths of a point — taken from the first
+    // defRPr@sz or rPr@sz we find inside the title. ECMA-376 uses hpt for size.
+    let title_font_size_hpt = title_node_opt
+        .and_then(|t| t.descendants().find_map(|n| {
+            if !n.is_element() { return None; }
+            let tag = n.tag_name().name();
+            if tag != "defRPr" && tag != "rPr" { return None; }
+            attr(&n, "sz").and_then(|v| v.parse::<i32>().ok())
+        }));
 
     // val axis max / min
     let val_ax = root.descendants()
@@ -2376,6 +2407,67 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
                     && attr(&c, "val").as_deref() == Some("1"))
         });
 
+    // Outer chartSpace spPr: we want the child of chartSpace (not plotArea).
+    let chart_bg = root.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "spPr")
+        .and_then(|sp| sp.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
+        .and_then(|fill| parse_color_node(fill, theme));
+
+    let show_legend = root.descendants()
+        .any(|n| n.is_element() && n.tag_name().name() == "legend");
+
+    // ECMA-376 §21.2.2.35: `<c:crossBetween>` lives on the VALUE axis (not cat),
+    // and describes whether value gridlines land between or on category ticks.
+    // Default is "between" (categories inset by half a step each side).
+    let cat_axis_cross_between = root.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "valAx")
+        .and_then(|ax| ax.children().find(|n| n.is_element() && n.tag_name().name() == "crossBetween"))
+        .and_then(|n| attr(&n, "val"))
+        .unwrap_or_else(|| "between".to_string());
+
+    let read_major_tick_mark = |ax_name: &str| -> String {
+        root.descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == ax_name)
+            .and_then(|ax| ax.children().find(|n| n.is_element() && n.tag_name().name() == "majorTickMark"))
+            .and_then(|n| attr(&n, "val"))
+            // ECMA-376 default for majorTickMark is "cross".
+            .unwrap_or_else(|| "cross".to_string())
+    };
+    let val_axis_major_tick_mark = read_major_tick_mark("valAx");
+    let cat_axis_major_tick_mark = read_major_tick_mark("catAx");
+
+    // <c:catAx>/<c:valAx><c:txPr> → defRPr/rPr@sz gives axis label font size
+    // in OOXML hundredths of a point. This drives both font rendering and
+    // the bottom/left padding so the plot area shrinks to leave room.
+    let read_axis_font_hpt = |ax_name: &str| -> Option<i32> {
+        root.descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == ax_name)
+            .and_then(|ax| ax.children().find(|n| n.is_element() && n.tag_name().name() == "txPr"))
+            .and_then(|tx| tx.descendants().find_map(|n| {
+                if !n.is_element() { return None; }
+                let tag = n.tag_name().name();
+                if tag != "defRPr" && tag != "rPr" { return None; }
+                attr(&n, "sz").and_then(|v| v.parse::<i32>().ok())
+            }))
+    };
+    let cat_axis_font_size_hpt = read_axis_font_hpt("catAx");
+    let val_axis_font_size_hpt = read_axis_font_hpt("valAx");
+
+    // First <c:dLbls> we can find — per-series or plotArea-level. Drill down
+    // to the defRPr@sz the same way we do for axes.
+    let data_label_font_size_hpt = root.descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .find_map(|dl| {
+            dl.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "txPr")
+                .and_then(|tx| tx.descendants().find_map(|n| {
+                    if !n.is_element() { return None; }
+                    let tag = n.tag_name().name();
+                    if tag != "defRPr" && tag != "rPr" { return None; }
+                    attr(&n, "sz").and_then(|v| v.parse::<i32>().ok())
+                }))
+        });
+
     Some(ChartElement {
         x: 0, y: 0, width: 0, height: 0,
         chart_type,
@@ -2389,6 +2481,15 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
         cat_axis_hidden,
         val_axis_hidden,
         plot_area_bg,
+        chart_bg,
+        show_legend,
+        cat_axis_cross_between,
+        val_axis_major_tick_mark,
+        cat_axis_major_tick_mark,
+        title_font_size_hpt,
+        cat_axis_font_size_hpt,
+        val_axis_font_size_hpt,
+        data_label_font_size_hpt,
     })
 }
 
@@ -2477,6 +2578,15 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         cat_axis_hidden: false,
         val_axis_hidden: false,
         plot_area_bg: None,
+        chart_bg: None,
+        show_legend: false,
+        cat_axis_cross_between: "between".to_string(),
+        val_axis_major_tick_mark: "cross".to_string(),
+        cat_axis_major_tick_mark: "cross".to_string(),
+        title_font_size_hpt: None,
+        cat_axis_font_size_hpt: None,
+        val_axis_font_size_hpt: None,
+        data_label_font_size_hpt: None,
     })
 }
 

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -8,7 +8,7 @@ type Args = {
 
 const meta: Meta<Args> = {
   title: 'PptxViewer',
-  excludeStories: ['buildViewerUI'],
+  excludeStories: ['buildViewerUI', 'createCanvasSpinner'],
   argTypes: {
     width: {
       control: { type: 'range', min: 400, max: 1600, step: 40 },
@@ -52,8 +52,11 @@ export function buildViewerUI(
 
   const container = document.createElement('div');
   container.style.cssText =
-    `width:${args.width}px;max-width:100%;border:1px solid #ccc;background:#f0f0f0;min-height:120px;`;
+    `position:relative;width:${args.width}px;max-width:100%;border:1px solid #ccc;background:#f0f0f0;min-height:120px;`;
   root.appendChild(container);
+
+  const spinner = createCanvasSpinner();
+  container.appendChild(spinner);
 
   const viewer = new PptxViewer(container, {
     width: args.width,
@@ -70,6 +73,7 @@ export function buildViewerUI(
   nextBtn.addEventListener('click', () => viewer.nextSlide());
 
   if (autoLoadUrl) {
+    status.textContent = 'Loading…';
     fetch(autoLoadUrl)
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status} from ${autoLoadUrl}`);
@@ -79,13 +83,49 @@ export function buildViewerUI(
         status.textContent = 'Parsing…';
         return viewer.load(buf);
       })
-      .then(() => { status.textContent = 'Loaded'; })
+      .then(() => {
+        status.textContent = 'Loaded';
+        spinner.remove();
+      })
       .catch((err) => {
         status.textContent = `Failed: ${err.message}`;
+        spinner.remove();
       });
+  } else {
+    spinner.remove();
   }
 
   return { root, viewer };
+}
+
+/**
+ * Returns an absolutely-positioned spinner overlay. The element is a simple
+ * CSS-keyframe ring centered in its parent — the parent must be positioned
+ * (set `position:relative`) so the overlay anchors correctly.
+ */
+export function createCanvasSpinner(): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('aria-label', 'Loading');
+  el.style.cssText = [
+    'position:absolute',
+    'top:50%', 'left:50%',
+    'width:40px', 'height:40px',
+    'margin:-20px 0 0 -20px',
+    'border:3px solid rgba(0,0,0,0.12)',
+    'border-top-color:rgba(0,0,0,0.55)',
+    'border-radius:50%',
+    'pointer-events:none',
+    'animation:pptxSpinnerRotate 0.9s linear infinite',
+  ].join(';');
+  // Inject keyframes once per document.
+  const keyframesId = '__pptx-spinner-keyframes';
+  if (!document.getElementById(keyframesId)) {
+    const style = document.createElement('style');
+    style.id = keyframesId;
+    style.textContent = '@keyframes pptxSpinnerRotate { to { transform: rotate(360deg); } }';
+    document.head.appendChild(style);
+  }
+  return el;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2248,15 +2248,30 @@ function renderTextBody(
     // Bullet resolution
     const hasBullet = para.bullet.type === 'char' || para.bullet.type === 'autoNum';
 
+    // Per ECMA-376 §21.1.2.4.13: when no buSz* is declared, the bullet takes
+    // the first run's font size. Using paraDefaultFontSizePx here (the layout
+    // lvl1pPr defRPr fallback, typically 18pt) oversizes the bullet so a
+    // hanging indent calibrated against the run (12pt) can't contain it —
+    // that's why the em-dash was overlapping the text.
+    const firstRunSizePt = (() => {
+      for (const r of para.runs) {
+        if (r.type === 'text' && r.fontSize != null) return r.fontSize;
+      }
+      return null;
+    })();
+    const bulletBaseSizePx = firstRunSizePt != null
+      ? firstRunSizePt * PT_TO_EMU * scale * fontScale
+      : paraDefaultFontSizePx;
+
     let bulletLabel  = '';
-    let bulletFont   = buildFont(false, false, paraDefaultFontSizePx, 'sans-serif', rc);
+    let bulletFont   = buildFont(false, false, bulletBaseSizePx, 'sans-serif', rc);
     let bulletColor  = paraDefaultColor;
 
     if (para.bullet.type === 'char') {
       const b = para.bullet;
       const bSizePx = b.sizePct != null
-        ? paraDefaultFontSizePx * (b.sizePct / 100)
-        : paraDefaultFontSizePx;
+        ? bulletBaseSizePx * (b.sizePct / 100)
+        : bulletBaseSizePx;
       bulletLabel = applySymbolFont(b.char, b.fontFamily ?? '');
       // If the char was mapped to a Unicode symbol, use sans-serif for reliable rendering.
       // Otherwise use the specified font (e.g. Wingdings on systems that have it).
@@ -2274,7 +2289,7 @@ function renderTextBody(
         autoNumCounters.set(lvl, autoNumCounters.get(lvl)! + 1);
       }
       bulletLabel = formatAutoNum(autoNumCounters.get(lvl)!, b.numType);
-      bulletFont  = buildFont(false, false, paraDefaultFontSizePx, 'sans-serif', rc);
+      bulletFont  = buildFont(false, false, bulletBaseSizePx, 'sans-serif', rc);
       bulletColor = paraDefaultColor;
     } else {
       // Not a list paragraph — reset autoNum counters
@@ -2300,11 +2315,16 @@ function renderTextBody(
       const isFirst = i === 0;
       const isLast  = i === lines.length - 1;
 
-      // Line height: use max font size in the line
-      let maxSizePx = paraDefaultFontSizePx;
+      // Line height: use the max font size among rendered segments. The layout
+      // default (paraDefaultFontSizePx) is used only as a fallback for empty
+      // paragraphs — otherwise PowerPoint slide-layouts with placeholder
+      // defaults like `defRPr sz="30000"` (300pt prompt-text marker) would
+      // inflate lineHeight and push real 24pt runs far below the anchor.
+      let maxSizePx = 0;
       for (const seg of line.segments) {
         if (seg.sizePx > maxSizePx) maxSizePx = seg.sizePx;
       }
+      if (maxSizePx === 0) maxSizePx = paraDefaultFontSizePx;
       // Bullet font size also counts
       if (isFirst && bulletLabel) {
         ctx.font = bulletFont;
@@ -2833,6 +2853,9 @@ export async function renderSlide(
     } else if (el.type === 'media') {
       await renderMedia(ctx, el, scale, opts.fetchMedia, opts.skipMediaControls);
     } else if (el.type === 'chart') {
+      // OOXML: 1pt = 12700 EMU. The slide renderer's `scale` is px-per-EMU,
+      // so 12700 * scale gives pixels-per-point at the current display size.
+      const chartPtToPx = 12700 * scale;
       renderChart(
         ctx,
         {
@@ -2848,6 +2871,15 @@ export async function renderSlide(
           catAxisHidden: el.catAxisHidden,
           valAxisHidden: el.valAxisHidden,
           plotAreaBg: el.plotAreaBg,
+          chartBg: el.chartBg,
+          showLegend: el.showLegend,
+          catAxisCrossBetween: el.catAxisCrossBetween,
+          valAxisMajorTickMark: el.valAxisMajorTickMark,
+          catAxisMajorTickMark: el.catAxisMajorTickMark,
+          titleFontSizeHpt: el.titleFontSizeHpt,
+          catAxisFontSizeHpt: el.catAxisFontSizeHpt,
+          valAxisFontSizeHpt: el.valAxisFontSizeHpt,
+          dataLabelFontSizeHpt: el.dataLabelFontSizeHpt,
           subtotalIndices: el.subtotalIndices,
         },
         {
@@ -2856,6 +2888,7 @@ export async function renderSlide(
           w: emuToPx(el.width, scale),
           h: emuToPx(el.height, scale),
         },
+        chartPtToPx,
       );
     }
   }

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -154,6 +154,24 @@ export interface ChartElement {
   catAxisHidden: boolean;
   valAxisHidden: boolean;
   plotAreaBg: string | null;
+  /** Outer chartSpace background (hex without '#'). null when noFill/absent. */
+  chartBg: string | null;
+  /** True when <c:legend> is declared; false suppresses the legend entirely. */
+  showLegend: boolean;
+  /** catAx crossBetween: "between" (default, 0.5-step padding) or "midCat". */
+  catAxisCrossBetween: 'between' | 'midCat' | string;
+  /** `<c:valAx><c:majorTickMark>`. "cross" (default) | "out" | "in" | "none". */
+  valAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
+  /** `<c:catAx><c:majorTickMark>`. */
+  catAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
+  /** Title font size in OOXML hundredths of a point (1600 = 16pt). null = default. */
+  titleFontSizeHpt: number | null;
+  /** `<c:catAx><c:txPr>` font size (hpt). null = proportional default. */
+  catAxisFontSizeHpt: number | null;
+  /** `<c:valAx><c:txPr>` font size (hpt). null = proportional default. */
+  valAxisFontSizeHpt: number | null;
+  /** `<c:dLbls><c:txPr>` font size (hpt) for data-point value labels. */
+  dataLabelFontSizeHpt: number | null;
 }
 
 export interface PictureElement {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1766,6 +1766,17 @@ function adaptChartData(chart: ChartData): ChartModel {
     catAxisHidden: false,
     valAxisHidden: false,
     plotAreaBg: null,
+    // Excel charts default to an opaque white chart area with a light border.
+    // Keep that appearance; pptx sets chartBg from the chartSpace spPr instead.
+    chartBg: 'FFFFFF',
+    showLegend: (chart.series?.length ?? 0) > 0,
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'cross',
+    catAxisMajorTickMark: 'cross',
+    titleFontSizeHpt: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
     subtotalIndices: [],
   };
 }


### PR DESCRIPTION
## Chart (core + pptx/xlsx adapters)
- Outer \`<c:chartSpace><c:spPr>\` vs \`<c:plotArea><c:spPr>\` are now distinct; \`noFill\` on chartSpace lets the slide background show through instead of filling white.
- \`<c:legend>\` presence drives legend visibility (no longer shown by default).
- \`<c:crossBetween>\` honored (0.5-step category padding for \"between\").
- Value-axis line + major tick marks drawn (respect \`majorTickMark\` val).
- Title / axis label / data label sizes come from XML \`<c:txPr>\`/\`<c:rich>\` \`sz\` (hpt). Proportional defaults only when absent.
- Fonts, line width, and marker radius scale by px-per-point at the current slide scale.
- Title band tightened (proportional top/bottom air).

## pptx text
- Line-height max uses actual run sizes; placeholder lstStyle \`defRPr sz=\"30000\"\` (300pt prompt marker) no longer inflates lineHeight. Fixes demo/sample-1 slide 8 \"Every transect…\" landing ~260px too low.
- Bullet size comes from the first run's fontSize (ECMA-376 §21.1.2.4.13). Fixes demo/sample-1 slide 7 em-dash overlapping text.

## Stories
- Interactive sample story auto-disposes the \`PresentationHandle\` + \`PptxPresentation\` when its root detaches (Storybook story swap no longer leaks playing audio).
- CSS spinner overlay (\`createCanvasSpinner\`) shows while a sample is loading.

## Test plan
- [x] Type check: core / pptx / xlsx
- [x] pptx VRT: 60 pass (3 pre-existing missing-reference failures unrelated)
- [x] demo/sample-1 slide 7/8 visually match PowerPoint layout
- [ ] Manual Storybook check of spinner + story-swap audio cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)