### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,107 @@
+# Changelog
+
+All notable changes to @silurus/ooxml are documented here. The project follows
+semantic versioning; minor releases add spec-compliant features or behavior
+changes that remain compatible with existing API surfaces.
+
+## 0.4.0 — 2026-04-21
+
+### pptx
+
+- **Audio/video playback.** `PptxPresentation.presentSlide(canvas, index, opts?)`
+  returns a disposable `PresentationHandle` that layers the current video
+  frame and self-drawn play/pause + seek chrome on top of the statically
+  rendered slide. Click on a media element to toggle playback; drag the
+  progress handle to scrub. Audio gets a capsule-shaped pill with time on
+  the left and a thin seekable bar on the right. `renderSlide` stays pure
+  and stateless.
+- **Lazy media extraction.** The parse output no longer inlines poster images
+  as base64 data URLs; `PptxPresentation.getMedia(path)` fetches bytes on
+  demand via a new `extract_media` WASM export. Sample decks with 200 MB
+  video now have a <1 KB parse JSON instead of a 16 MB one.
+- **Charts, spec-faithful.**
+  - Chart space vs. plot area fill distinguished (`<c:chartSpace><c:spPr>`
+    separate from `<c:plotArea><c:spPr>`). Transparent outer chart lets the
+    slide background show through.
+  - Legend visibility driven by `<c:legend>` presence.
+  - `<c:crossBetween>` honored (0.5-step category padding for "between").
+  - Value-axis line + `majorTickMark` drawn.
+  - Title / axis / data-label sizes come from XML `<c:txPr>` `sz` in hpt,
+    scaled via `ptToPx = 12700 × slideScale` so fonts track the viewport.
+  - Line width and marker radius also scale by pt-per-px.
+- **Text rendering.**
+  - Line-height maximum is computed from actual run sizes, not placeholder
+    `defRPr sz="30000"` prompt markers — fixes 24pt text rendering ~260px
+    below its anchor in demo/sample-1 slide 8.
+  - Bullet size derives from the first run's font size (ECMA-376
+    §21.1.2.4.13) instead of the layout default — fixes em-dash bullets
+    overlapping text in demo/sample-1 slide 7.
+  - **Text overflow no longer clipped** at shape bounds per §20.1.2.3.6.
+- SmartArt connector shapes with `cy=0` no longer inflated by the body-text
+  auto-height fallback (horizontal timelines now render horizontal).
+
+### docx
+
+- **Pagination properties (ECMA-376 §17.3.1.14 / .15 / .44).** Parse and
+  honor `w:keepNext`, `w:keepLines`, `w:widowControl` through the full
+  style cascade (docDefaults → style → pPr). `widowControl` defaults to
+  true when absent. `keepNext` now causes a page break before the current
+  paragraph when the chain of kept-together paragraphs wouldn't fit.
+- **Justified / distribute alignment (§17.18.44).** Inter-word whitespace
+  is expanded so `<w:jc w:val="both"/>` paragraphs fill the content width;
+  `distribute` also stretches the last line. Previously everything outside
+  `right`/`center` collapsed to left-aligned — big visual change for docs
+  whose docDefaults declare `both`, which includes most Word-authored
+  documents.
+- **Line spacing (§17.3.1.33).** `lineSpacingMultiplier` now respects the
+  pt value on `atLeast` and `exact` rules (previously both collapsed to
+  1.2× font). Decorative titles that encode `lineRule="auto"` with very
+  large values (~720+) now render with correct line height.
+- **Indentation (§17.3.1.12).** Accept logical `start`/`end` aliases in
+  addition to `left`/`right` on `<w:ind>`. `hanging` still wins over
+  `firstLine` per spec.
+- **rFonts theme references (§17.3.2.26 / §20.1.4.1.14).** theme.xml's
+  `<a:fontScheme>` is parsed and rFonts `asciiTheme` / `hAnsiTheme` /
+  `eastAsiaTheme` refs are resolved against it at run assembly. Direct
+  typeface attributes still take precedence per spec.
+- **Default paragraph style.** Fall back to the document's `w:default="1"`
+  style ID (e.g. `a`, `標準`) instead of the hardcoded literal `Normal`.
+  Matters for contextualSpacing grouping on non-English templates.
+- **ST_OnOff (§17.3.2.22).** `bool_prop` now recognises `off` — previously
+  interpreted as `true`.
+- **Footnote / endnote markers (§17.11.16 / §17.11.7).** Render the
+  reference number as a superscript marker inline (previously dropped).
+  Full page-bottom footnote layout is deferred.
+- **Table cell widths (§17.18.87).** `w:type` now defaults to `dxa` when
+  absent; non-dxa types fall back to grid allocation.
+
+### Stories / samples
+
+- Interactive pptx sample story auto-disposes the `PresentationHandle` +
+  `PptxPresentation` when its root detaches from the DOM. Storybook
+  story-swap no longer leaks playing audio.
+- CSS spinner overlay (`createCanvasSpinner`) shows while a sample is
+  loading. Both the opinionated `buildViewerUI` and the interactive
+  `presentSlide` story use the same helper.
+
+### Known follow-up
+
+- Word's auto-rule rendering for very large multipliers (e.g. `line="640"
+  lineRule="auto"` on 28pt headings) still diverges from spec — Word
+  Desktop and Word Web themselves disagree here, so we stick to the letter
+  of the spec instead of empirical tuning.
+- Full bottom-of-page footnote layout.
+- Tab alignment variants beyond `pos` (center / right / decimal).
+- `cstheme` font axis (only `ascii` / `hAnsi` / `eastAsia` resolve today).
+
+## 0.3.0 — 2026-04-20
+
+DOCX shape rendering (solid / gradient fill, lumMod/lumOff, z-order),
+anchor image text wrap (Square + TopAndBottom), default paragraph style
+fallback. PPTX placeholder image alpha (`a:alphaModFix`) and master
+`txStyles` bold/italic inheritance. Shape helpers extracted to
+`@silurus/ooxml-core`.
+
+## 0.2.0 and earlier
+
+See git history.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
Minor version bump from 0.3.0 → 0.4.0.

See `CHANGELOG.md` (new in this PR) for the full notes.

### Highlights

**pptx**
- `PptxPresentation.presentSlide(canvas, index)` for canvas-native audio/video playback (click + seek + auto-dispose).
- Charts: respect chart-vs-plot-area fill, `<c:legend>` presence, crossBetween padding, axis line + major ticks, XML-driven font sizes with slide-aware pt-to-px scaling.
- Fix line-height computed from actual run sizes (prompt-marker \`sz=\"30000\"\` no longer inflates).
- Bullet size from first run's fontSize per ECMA-376 §21.1.2.4.13 (em-dash bullets no longer overlap text).
- Text overflow no longer clipped at shape bounds (§20.1.2.3.6).
- Lazy poster/media extraction: parse output shrinks from ~16 MB to <1 KB for video-heavy decks.

**docx**
- Justified / distribute alignment (§17.18.44) — big visual change for docs with docDefaults \`<w:jc w:val=\"both\"/>\`.
- Pagination: keepNext / keepLines / widowControl (§17.3.1.14 / .15 / .44).
- atLeast/exact line-spacing pt values respected (§17.3.1.33).
- rFonts theme refs resolved against theme.xml fontScheme (§20.1.4.1.14).
- Indent start/end aliases, bool_prop \`off\` handling, default style via \`w:default=\"1\"\`, footnote marker.

### VRT
- docx: 12/12 pass.
- pptx: 60/63 pass (3 pre-existing missing-reference failures unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)