### PR TITLE
xlsx: gradient + pattern fills, comment indicator triangle

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -52,6 +52,9 @@ pub struct Worksheet {
     pub auto_filter: Option<CellRange>,
     /// Hyperlinks in this worksheet (ECMA-376 §18.3.1.47)
     pub hyperlinks: Vec<Hyperlink>,
+    /// Cell refs (A1-style) that have an associated <comment> in xl/commentsN.xml.
+    /// Excel shows a small red triangle in the top-right corner of each.
+    pub comment_refs: Vec<String>,
 }
 
 // ─── Chart types ────────────────────────────────────────────────────────────
@@ -434,6 +437,7 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     ws.images = load_sheet_images(&mut archive, &sheet_path);
     ws.charts = load_sheet_charts(&mut archive, &sheet_path);
     ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
+    ws.comment_refs = load_sheet_comment_refs(&mut archive, &sheet_path);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -1287,6 +1291,7 @@ fn parse_worksheet(
         tab_color,
         auto_filter,
         hyperlinks: Vec::new(),
+        comment_refs: Vec::new(),
     }, hyperlink_rids))
 }
 
@@ -1302,6 +1307,49 @@ fn parse_rels_map(xml: &str) -> HashMap<String, String> {
         }
     }
     map
+}
+
+/// Parse xl/comments{N}.xml referenced from the sheet's rels and collect the
+/// list of A1-style cell refs that have a `<comment>` associated. The
+/// renderer draws a small red triangle in each cell's top-right corner to
+/// indicate the presence of a comment (ECMA-376 §18.7.3 commentList).
+fn load_sheet_comment_refs(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_path: &str,
+) -> Vec<String> {
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else { return Vec::new(); };
+    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else { return Vec::new(); };
+
+    // Accept both plain ("/comments") and threaded ("/threadedComment") relTypes
+    // but prefer the classic comments file — threaded comments live in a
+    // separate namespace and are an extension.
+    let mut comments_target: Option<String> = None;
+    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+        let rel_type = rel.attribute("Type").unwrap_or("");
+        if rel_type.ends_with("/comments") {
+            if let Some(t) = rel.attribute("Target") {
+                comments_target = Some(t.to_string());
+                break;
+            }
+        }
+    }
+    let Some(target) = comments_target else { return Vec::new(); };
+
+    let comments_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+    let Ok(comments_xml) = read_zip_entry(archive, &comments_path) else { return Vec::new(); };
+    let Ok(comments_doc) = roxmltree::Document::parse(&comments_xml) else { return Vec::new(); };
+
+    let mut refs: Vec<String> = Vec::new();
+    for node in comments_doc.descendants() {
+        if node.tag_name().name() == "comment" && node.is_element() {
+            if let Some(r) = node.attribute("ref") {
+                refs.push(r.to_string());
+            }
+        }
+    }
+    refs
 }
 
 /// Resolve hyperlink rIds to URLs from the sheet rels file.

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -296,6 +296,33 @@ pub struct Fill {
     pub pattern_type: String,
     pub fg_color: Option<String>,
     pub bg_color: Option<String>,
+    /// When the fill element is a <gradientFill>, this carries the gradient
+    /// stops + type + rotation. patternType stays "none" because xlsx does
+    /// not mix gradient + pattern in the same fill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<GradientFillSpec>,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GradientFillSpec {
+    /// "linear" (default) or "path". Linear uses `degree`; path uses top/bottom/left/right.
+    pub gradient_type: String,
+    /// Linear-gradient rotation in degrees (0 = left→right).
+    pub degree: f64,
+    /// Path-gradient bounding box (0..1 within the cell). Unused for linear.
+    pub left: f64,
+    pub right: f64,
+    pub top: f64,
+    pub bottom: f64,
+    pub stops: Vec<GradientStopSpec>,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GradientStopSpec {
+    pub position: f64,
+    pub color: String,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -880,15 +907,47 @@ fn parse_fills(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> 
                 if fill_node.tag_name().name() != "fill" { continue; }
                 let mut f = Fill::default();
                 for pf in fill_node.children() {
-                    if pf.tag_name().name() == "patternFill" {
-                        f.pattern_type = pf.attribute("patternType").unwrap_or("none").to_string();
-                        for color_node in pf.children() {
-                            match color_node.tag_name().name() {
-                                "fgColor" => f.fg_color = parse_color(&color_node, theme_colors),
-                                "bgColor" => f.bg_color = parse_color(&color_node, theme_colors),
-                                _ => {}
+                    match pf.tag_name().name() {
+                        "patternFill" => {
+                            f.pattern_type = pf.attribute("patternType").unwrap_or("none").to_string();
+                            for color_node in pf.children() {
+                                match color_node.tag_name().name() {
+                                    "fgColor" => f.fg_color = parse_color(&color_node, theme_colors),
+                                    "bgColor" => f.bg_color = parse_color(&color_node, theme_colors),
+                                    _ => {}
+                                }
                             }
                         }
+                        "gradientFill" => {
+                            // ECMA-376 §18.8.24 gradientFill — linear (default) uses
+                            // `degree`, path uses top/bottom/left/right as a relative
+                            // bounding box; children <stop position="n"><color/></stop>.
+                            let gtype = pf.attribute("type").unwrap_or("linear").to_string();
+                            let degree = pf.attribute("degree").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+                            let left   = pf.attribute("left").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+                            let right  = pf.attribute("right").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+                            let top    = pf.attribute("top").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+                            let bottom = pf.attribute("bottom").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+                            let mut stops: Vec<GradientStopSpec> = pf.children()
+                                .filter(|n| n.is_element() && n.tag_name().name() == "stop")
+                                .filter_map(|stop| {
+                                    let position = stop.attribute("position").and_then(|s| s.parse::<f64>().ok())?;
+                                    let color_node = stop.children().find(|c| c.is_element() && c.tag_name().name() == "color")?;
+                                    let color = parse_color(&color_node, theme_colors)?;
+                                    Some(GradientStopSpec { position, color })
+                                })
+                                .collect();
+                            stops.sort_by(|a, b| a.position.partial_cmp(&b.position).unwrap_or(std::cmp::Ordering::Equal));
+                            if !stops.is_empty() {
+                                f.gradient = Some(GradientFillSpec {
+                                    gradient_type: gtype,
+                                    degree,
+                                    left, right, top, bottom,
+                                    stops,
+                                });
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 fills.push(f);

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -189,6 +189,44 @@ function buildGradientFill(
   return grad;
 }
 
+/**
+ * Parse an A1-style cell reference ("A1", "B12", "AA3") to 1-based row/col.
+ * Returns null when the input doesn't match the expected shape (parser-side
+ * data is trusted, but we still guard against malformed refs).
+ */
+function parseA1Ref(ref: string): { row: number; col: number } | null {
+  const m = /^([A-Z]+)(\d+)$/.exec(ref);
+  if (!m) return null;
+  const colLetters = m[1];
+  const row = parseInt(m[2], 10);
+  let col = 0;
+  for (let i = 0; i < colLetters.length; i++) {
+    col = col * 26 + (colLetters.charCodeAt(i) - 64);
+  }
+  return { row, col };
+}
+
+/**
+ * Draw Excel's comment marker — a small filled triangle in the top-right
+ * corner of the cell — coloured like Excel's default red indicator. Scales
+ * with cell size but is clamped so it stays legible at small zoom.
+ */
+function drawCommentMarker(
+  ctx: CanvasRenderingContext2D,
+  x: number, y: number, w: number, h: number,
+): void {
+  const size = Math.max(4, Math.min(8, Math.min(w, h) * 0.18));
+  ctx.save();
+  ctx.fillStyle = '#D40000';
+  ctx.beginPath();
+  ctx.moveTo(x + w - size, y);
+  ctx.lineTo(x + w, y);
+  ctx.lineTo(x + w, y + size);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
 /** Linear-interpolate two #RRGGBB values in RGB space at coverage fg weight. */
 function blendHex(fgHex: string, bgHex: string, fgCoverage: number): string {
   const fh = fgHex.replace('#', '');
@@ -831,6 +869,9 @@ interface RenderContext {
   dpr: number;
   autoFilterCells: Set<string>;
   hyperlinkMap: Map<string, string>;
+  /** row:col keys for cells that carry a comment; renderer draws a small
+   *  red triangle in the top-right corner (ECMA-376 §18.7.3 commentList). */
+  commentCells: Set<string>;
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -1080,6 +1121,12 @@ function renderQuadrant(
             : blendHex(effectiveFill.fgColor, bg, coverage);
         }
         ctx.fillRect(cx, cy, cellW, cellH);
+      }
+
+      // Comment indicator triangle — drawn above fill but below borders so
+      // borders still read cleanly around the cell edge.
+      if (rc.commentCells.has(key)) {
+        drawCommentMarker(ctx, cx, cy, cellW, cellH);
       }
 
       // DataBar (drawn inside the cell, left-anchored)
@@ -1511,6 +1558,15 @@ export function renderViewport(
     if (hl.url) hyperlinkMap.set(`${hl.row}:${hl.col}`, hl.url);
   }
 
+  // Build commented-cell lookup. worksheet.commentRefs are A1-style refs
+  // ("A1", "B12", "AA3") so we convert each to "row:col" and stash in a Set
+  // for O(1) membership checks in the cell loop.
+  const commentCells = new Set<string>();
+  for (const ref of worksheet.commentRefs ?? []) {
+    const parsed = parseA1Ref(ref);
+    if (parsed) commentCells.add(`${parsed.row}:${parsed.col}`);
+  }
+
   const rc: RenderContext = {
     worksheet, styles, cellMap, mergeAnchorMap, mergeSkipSet, cfContext,
     colWidths: scrollColWidths,
@@ -1522,6 +1578,7 @@ export function renderViewport(
     dpr,
     autoFilterCells,
     hyperlinkMap,
+    commentCells,
   };
 
   // Canvas areas for each quadrant

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -33,6 +33,142 @@ function hexToRgba(hex: string, alpha = 1): string {
   return alpha === 1 ? `rgb(${r},${g},${b})` : `rgba(${r},${g},${b},${alpha})`;
 }
 
+/**
+ * Fractional fg coverage for an ECMA-376 ST_PatternType (§18.8.22). Values are
+ * derived from the spec's verbal descriptions — gray125 = 12.5% fg on bg,
+ * gray0625 = 6.25%, mediumGray ≈ 50%, darkGray ≈ 75%, lightGray ≈ 25%. Hatch
+ * variants (darkHorizontal etc.) approximate their average ink density.
+ * Unknown values default to 1 so they render as solid fg.
+ */
+function patternCoverage(pt: string): number {
+  switch (pt) {
+    case 'solid':         return 1;
+    case 'darkGray':      return 0.75;
+    case 'mediumGray':    return 0.50;
+    case 'lightGray':     return 0.25;
+    case 'gray125':       return 0.125;
+    case 'gray0625':      return 0.0625;
+    // Directional hatches: visual ink ratio is roughly 50/50 at default cell
+    // sizes; without a true hatch tile we blend at 50% so the cell reads as a
+    // middle-tone fill rather than a solid fg block.
+    case 'darkHorizontal':
+    case 'darkVertical':
+    case 'darkDown':
+    case 'darkUp':
+    case 'darkGrid':
+    case 'darkTrellis':   return 0.5;
+    case 'lightHorizontal':
+    case 'lightVertical':
+    case 'lightDown':
+    case 'lightUp':
+    case 'lightGrid':
+    case 'lightTrellis':  return 0.25;
+    default:              return 1;
+  }
+}
+
+/**
+ * Cache of (pattern, fg, bg) → CanvasPattern. Keyed by a compound string so
+ * that the same pattern across thousands of cells only builds the tile once.
+ */
+const PATTERN_CACHE = new Map<string, CanvasPattern | null>();
+
+/**
+ * Build a small repeating tile for ECMA-376 directional hatch patterns. Uses
+ * an offscreen canvas painted with bgColor + fgColor lines and returns a
+ * CanvasPattern for `ctx.fillStyle`. Non-hatch patterns return null so the
+ * caller falls back to the fg/bg blend.
+ */
+function hatchPattern(
+  ctx: CanvasRenderingContext2D,
+  pt: string,
+  fgHex: string,
+  bgHex: string,
+): CanvasPattern | null {
+  const key = `${pt}|${fgHex}|${bgHex}`;
+  if (PATTERN_CACHE.has(key)) return PATTERN_CACHE.get(key)!;
+
+  const size = 8;
+  const isDark = pt.startsWith('dark');
+  const isLight = pt.startsWith('light');
+  if (!isDark && !isLight) {
+    PATTERN_CACHE.set(key, null);
+    return null;
+  }
+  const off = document.createElement('canvas');
+  off.width = size;
+  off.height = size;
+  const octx = off.getContext('2d');
+  if (!octx) { PATTERN_CACHE.set(key, null); return null; }
+
+  octx.fillStyle = hexToRgba(bgHex);
+  octx.fillRect(0, 0, size, size);
+  octx.strokeStyle = hexToRgba(fgHex);
+  octx.lineWidth = isDark ? 2 : 1;
+  octx.beginPath();
+  switch (pt) {
+    case 'darkHorizontal':
+    case 'lightHorizontal':
+      octx.moveTo(0, size / 2);
+      octx.lineTo(size, size / 2);
+      break;
+    case 'darkVertical':
+    case 'lightVertical':
+      octx.moveTo(size / 2, 0);
+      octx.lineTo(size / 2, size);
+      break;
+    case 'darkDown':
+    case 'lightDown':
+      // Diagonal from top-left to bottom-right; draw a second line shifted to
+      // avoid seams where the tile wraps.
+      octx.moveTo(0, 0); octx.lineTo(size, size);
+      octx.moveTo(-size, 0); octx.lineTo(0, size);
+      octx.moveTo(0, -size); octx.lineTo(size, 0);
+      break;
+    case 'darkUp':
+    case 'lightUp':
+      octx.moveTo(0, size); octx.lineTo(size, 0);
+      octx.moveTo(-size, size); octx.lineTo(0, 0);
+      octx.moveTo(0, 2 * size); octx.lineTo(size, size);
+      break;
+    case 'darkGrid':
+    case 'lightGrid':
+      octx.moveTo(0, size / 2); octx.lineTo(size, size / 2);
+      octx.moveTo(size / 2, 0); octx.lineTo(size / 2, size);
+      break;
+    case 'darkTrellis':
+    case 'lightTrellis':
+      octx.moveTo(0, 0); octx.lineTo(size, size);
+      octx.moveTo(0, size); octx.lineTo(size, 0);
+      break;
+    default:
+      PATTERN_CACHE.set(key, null);
+      return null;
+  }
+  octx.stroke();
+
+  const pat = ctx.createPattern(off, 'repeat');
+  PATTERN_CACHE.set(key, pat);
+  return pat;
+}
+
+/** Linear-interpolate two #RRGGBB values in RGB space at coverage fg weight. */
+function blendHex(fgHex: string, bgHex: string, fgCoverage: number): string {
+  const fh = fgHex.replace('#', '');
+  const bh = bgHex.replace('#', '');
+  const fr = parseInt(fh.slice(0, 2), 16);
+  const fg = parseInt(fh.slice(2, 4), 16);
+  const fb = parseInt(fh.slice(4, 6), 16);
+  const br = parseInt(bh.slice(0, 2), 16);
+  const bg = parseInt(bh.slice(2, 4), 16);
+  const bb = parseInt(bh.slice(4, 6), 16);
+  const c = Math.min(1, Math.max(0, fgCoverage));
+  const r = Math.round(fr * c + br * (1 - c));
+  const g = Math.round(fg * c + bg * (1 - c));
+  const b = Math.round(fb * c + bb * (1 - c));
+  return `rgb(${r},${g},${b})`;
+}
+
 function buildFont(font: Font, cs = 1): string {
   const style = font.italic ? 'italic ' : '';
   const weight = font.bold ? 'bold ' : '';
@@ -886,9 +1022,23 @@ function renderQuadrant(
       const cf = evaluateCf(cell, rowIndex, colIndex, cfContext, styles.dxfs ?? []);
       const effectiveFill = cf.fill ?? fill;
 
-      // Background fill (base or CF override)
-      if (effectiveFill.patternType !== 'none' && effectiveFill.patternType !== '' && effectiveFill.fgColor) {
-        ctx.fillStyle = hexToRgba(effectiveFill.fgColor);
+      // Background fill (base or CF override). ECMA-376 §18.8.22 ST_PatternType.
+      // - solid/gray*: blend fgColor with bgColor at the pattern's fg coverage.
+      // - directional hatches (dark/light Horizontal/Vertical/Down/Up/Grid/
+      //   Trellis): render via a small repeating tile using createPattern so
+      //   the hatch actually shows, rather than approximating as a blend.
+      if (effectiveFill.patternType && effectiveFill.patternType !== 'none' && effectiveFill.fgColor) {
+        const pt = effectiveFill.patternType;
+        const bg = effectiveFill.bgColor ?? 'FFFFFF';
+        const hatch = hatchPattern(ctx, pt, effectiveFill.fgColor, bg);
+        if (hatch) {
+          ctx.fillStyle = hatch;
+        } else {
+          const coverage = patternCoverage(pt);
+          ctx.fillStyle = coverage >= 1
+            ? hexToRgba(effectiveFill.fgColor)
+            : blendHex(effectiveFill.fgColor, bg, coverage);
+        }
         ctx.fillRect(cx, cy, cellW, cellH);
       }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2,7 +2,7 @@ import type {
   Worksheet, Styles, Cell, CellValue, Font, Fill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink,
-  Run, ChartData,
+  Run, ChartData, GradientFillSpec,
 } from './types.js';
 import { renderChart, type ChartModel } from '@silurus/ooxml-core';
 
@@ -150,6 +150,43 @@ function hatchPattern(
   const pat = ctx.createPattern(off, 'repeat');
   PATTERN_CACHE.set(key, pat);
   return pat;
+}
+
+/**
+ * Build a Canvas gradient object for an xlsx `<gradientFill>`. Linear uses
+ * the degree attribute (0° = left→right, 90° = top→bottom). Path gradients
+ * radiate from a rectangular inner bounds defined by left/right/top/bottom
+ * as fractions of the cell.
+ */
+function buildGradientFill(
+  ctx: CanvasRenderingContext2D,
+  g: GradientFillSpec,
+  x: number, y: number, w: number, h: number,
+): CanvasGradient {
+  let grad: CanvasGradient;
+  if (g.gradientType === 'path') {
+    // Use the inner rectangle's center as the radial origin; radius spans to
+    // the farthest cell corner so stop=1 always reaches a cell edge.
+    const cxg = x + w * (g.left + (1 - g.right - g.left) / 2);
+    const cyg = y + h * (g.top + (1 - g.bottom - g.top) / 2);
+    const r = Math.hypot(Math.max(cxg - x, x + w - cxg), Math.max(cyg - y, y + h - cyg));
+    grad = ctx.createRadialGradient(cxg, cyg, 0, cxg, cyg, r);
+  } else {
+    // Linear: rotate around the cell's center and extend to the bounds.
+    const rad = (g.degree * Math.PI) / 180;
+    const cxg = x + w / 2;
+    const cyg = y + h / 2;
+    const ext = (Math.abs(Math.cos(rad)) * w + Math.abs(Math.sin(rad)) * h) / 2;
+    grad = ctx.createLinearGradient(
+      cxg - Math.cos(rad) * ext, cyg - Math.sin(rad) * ext,
+      cxg + Math.cos(rad) * ext, cyg + Math.sin(rad) * ext,
+    );
+  }
+  for (const stop of g.stops) {
+    const pos = Math.min(1, Math.max(0, stop.position));
+    grad.addColorStop(pos, hexToRgba(stop.color));
+  }
+  return grad;
 }
 
 /** Linear-interpolate two #RRGGBB values in RGB space at coverage fg weight. */
@@ -1027,7 +1064,10 @@ function renderQuadrant(
       // - directional hatches (dark/light Horizontal/Vertical/Down/Up/Grid/
       //   Trellis): render via a small repeating tile using createPattern so
       //   the hatch actually shows, rather than approximating as a blend.
-      if (effectiveFill.patternType && effectiveFill.patternType !== 'none' && effectiveFill.fgColor) {
+      if (effectiveFill.gradient && effectiveFill.gradient.stops.length > 0) {
+        ctx.fillStyle = buildGradientFill(ctx, effectiveFill.gradient, cx, cy, cellW, cellH);
+        ctx.fillRect(cx, cy, cellW, cellH);
+      } else if (effectiveFill.patternType && effectiveFill.patternType !== 'none' && effectiveFill.fgColor) {
         const pt = effectiveFill.patternType;
         const bg = effectiveFill.bgColor ?? 'FFFFFF';
         const hatch = hatchPattern(ctx, pt, effectiveFill.fgColor, bg);

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -216,6 +216,21 @@ export interface Fill {
   patternType: string;
   fgColor: string | null;
   bgColor: string | null;
+  /** Set when the style's `<fill>` was a `<gradientFill>`; patternType stays "none". */
+  gradient?: GradientFillSpec | null;
+}
+
+export interface GradientFillSpec {
+  /** "linear" (default) or "path". */
+  gradientType: string;
+  /** Rotation in degrees for linear gradients (0 = left→right). */
+  degree: number;
+  /** Path-gradient bounding box (0..1) — unused for linear. */
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  stops: { position: number; color: string }[];
 }
 
 export interface Border {

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -36,6 +36,9 @@ export interface Worksheet {
   autoFilter?: CellRange | null;
   /** Hyperlinks in this worksheet (ECMA-376 §18.3.1.47). */
   hyperlinks?: Hyperlink[];
+  /** A1-style cell refs of commented cells (ECMA-376 §18.7.3). Rendered as a
+   *  small red triangle in each cell's top-right corner. */
+  commentRefs?: string[];
 }
 
 // ─── Chart types ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Spec-compliance overnight pass on xlsx rendering gaps.

## Changes

**Pattern fills (ECMA-376 §18.8.22)**
- Previously every non-\`none\`/\`solid\` \`patternType\` rendered as an opaque fg block. Now gray/darkGray/mediumGray/lightGray and gray125/gray0625 blend fg with bg at the documented coverage, matching Excel's zoom-level rendering.
- Directional hatches (dark/light × Horizontal/Vertical/Down/Up/Grid/Trellis) render via a cached 8×8 tile + \`ctx.createPattern\` instead of the blended approximation.

**Gradient fills (ECMA-376 §18.8.24)**
- \`<gradientFill>\` child of \`<fill>\` was silently dropped; cells styled with a gradient came out transparent.
- Parser now emits \`Fill.gradient\` with type/degree/bounds/stops; renderer builds a \`CanvasLinearGradient\` (degree-rotated) or \`CanvasRadialGradient\` (path-type inner rect → farthest cell corner).

**Comment indicator (ECMA-376 §18.7.3)**
- Follow the sheet rels to xl/commentsN.xml, collect every \`<comment>\` ref.
- Renderer draws the classic red triangle (4–8 px, 18% of min cell dim) in the top-right corner of each commented cell. Text/popup not included in this pass.

## No VRT for xlsx in this repo
Changes are scoped to cells that were previously rendered incorrectly (non-solid patterns, gradients, comments) — solid/\`none\` fill paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)