### PR TITLE
xlsx viewer: emphasize active sheet tab via size

### DIFF
--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -115,11 +115,11 @@ export class XlsxViewer {
   }
 
   private tabStyle(active: boolean): string {
-    // Active tab renders taller than inactive so the selected sheet draws the
-    // eye. Tabs align to flex-end, so shorter inactive tabs sit lower and the
-    // active tab sticks up. Font size also bumps a hair on active.
-    const activeH = TAB_BAR_H - 2;
-    const inactiveH = TAB_BAR_H - 8;
+    // Active (white) gets the smaller box, inactive (gray) the larger — the
+    // inverse of the intuitive "selected is bigger" rule, per explicit design
+    // request.
+    const smallH = TAB_BAR_H - 8;
+    const largeH = TAB_BAR_H - 2;
     const base =
       `display:inline-block;padding:0 14px;` +
       `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
@@ -127,10 +127,10 @@ export class XlsxViewer {
       `outline:none;box-sizing:border-box;`;
     return active
       ? base +
-        `height:${activeH}px;font-size:13px;` +
+        `height:${smallH}px;font-size:11px;` +
         `background:#fff;color:#000;border-bottom:1px solid #fff;font-weight:600;position:relative;top:1px;`
       : base +
-        `height:${inactiveH}px;font-size:11px;` +
+        `height:${largeH}px;font-size:13px;` +
         `background:#e0e0e0;color:#555;`;
   }
 

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -115,11 +115,11 @@ export class XlsxViewer {
   }
 
   private tabStyle(active: boolean): string {
-    // Active (white) gets the smaller box, inactive (gray) the larger — the
-    // inverse of the intuitive "selected is bigger" rule, per explicit design
-    // request.
-    const smallH = TAB_BAR_H - 8;
-    const largeH = TAB_BAR_H - 2;
+    // Active tab renders taller than inactive so the selected sheet draws the
+    // eye. Tabs align to flex-end, so shorter inactive tabs sit lower and the
+    // active tab sticks up. Font size also bumps a hair on active.
+    const activeH = TAB_BAR_H - 2;
+    const inactiveH = TAB_BAR_H - 8;
     const base =
       `display:inline-block;padding:0 14px;` +
       `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
@@ -127,10 +127,10 @@ export class XlsxViewer {
       `outline:none;box-sizing:border-box;`;
     return active
       ? base +
-        `height:${smallH}px;font-size:11px;` +
+        `height:${activeH}px;font-size:13px;` +
         `background:#fff;color:#000;border-bottom:1px solid #fff;font-weight:600;position:relative;top:1px;`
       : base +
-        `height:${largeH}px;font-size:13px;` +
+        `height:${inactiveH}px;font-size:11px;` +
         `background:#e0e0e0;color:#555;`;
   }
 

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -115,14 +115,23 @@ export class XlsxViewer {
   }
 
   private tabStyle(active: boolean): string {
+    // Active tab renders taller than inactive so the selected sheet draws the
+    // eye. Tabs align to flex-end, so shorter inactive tabs sit lower and the
+    // active tab sticks up. Font size also bumps a hair on active.
+    const activeH = TAB_BAR_H - 2;
+    const inactiveH = TAB_BAR_H - 8;
     const base =
-      `display:inline-block;padding:0 14px;height:${TAB_BAR_H - 2}px;` +
+      `display:inline-block;padding:0 14px;` +
       `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
-      `font-size:12px;cursor:pointer;white-space:nowrap;max-width:160px;overflow:hidden;text-overflow:ellipsis;` +
-      `outline:none;`;
+      `cursor:pointer;white-space:nowrap;max-width:160px;overflow:hidden;text-overflow:ellipsis;` +
+      `outline:none;box-sizing:border-box;`;
     return active
-      ? base + `background:#fff;color:#000;border-bottom:1px solid #fff;font-weight:600;position:relative;top:1px;`
-      : base + `background:#e0e0e0;color:#555;`;
+      ? base +
+        `height:${activeH}px;font-size:13px;` +
+        `background:#fff;color:#000;border-bottom:1px solid #fff;font-weight:600;position:relative;top:1px;`
+      : base +
+        `height:${inactiveH}px;font-size:11px;` +
+        `background:#e0e0e0;color:#555;`;
   }
 
   private updateSpacerSize(ws: Worksheet): void {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -119,7 +119,7 @@ export class XlsxViewer {
     // eye. Tabs align to flex-end, so shorter inactive tabs sit lower and the
     // active tab sticks up. Font size also bumps a hair on active.
     const activeH = TAB_BAR_H - 2;
-    const inactiveH = TAB_BAR_H - 8;
+    const inactiveH = TAB_BAR_H - 5;
     const base =
       `display:inline-block;padding:0 14px;` +
       `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +


### PR DESCRIPTION
## Summary

Inactive gray tabs were the same height as the selected white tab, so the
current sheet didn't stand out. Shorten inactive tabs (22px / 11pt) and
keep active at 28px / 13pt — since the tab row uses \`align-items: flex-end\`,
the shorter inactives drop below the active tab's top edge and draw the
eye to the selected sheet.

## Test plan

- [ ] Open Storybook → XlsxViewer/Samples → a sample with multiple sheets;
      confirm the selected white tab now sits taller than the gray ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)