### PR TITLE
xlsx: honor chart title font size and legend visibility

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -177,7 +177,7 @@ function chartCategories(chart: ChartModel): string[] {
 // percentStacked. Also handles mixed bar+line series (seriesType per series).
 // ═══════════════════════════════════════════════════════════════════════════
 
-function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect): void {
+function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect, ptToPx: number): void {
   const { x, y, w, h } = r;
   const isH = chart.chartType === 'clusteredBarH' || chart.chartType === 'stackedBarH' || chart.chartType === 'stackedBarHPct';
   const stacked = chart.chartType.startsWith('stacked');
@@ -190,20 +190,26 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const n = cats.length;
   if (n === 0) return;
 
-  const titleH   = chart.title ? Math.max(14, h * 0.06) : 0;
+  // Honor the XML-specified title font size when present; otherwise fall back
+  // to the proportional heuristic. Reserve the title band based on the actual
+  // drawn height so the plot shrinks to avoid overlap.
+  const titleFontPx = chart.title ? chartTitleFontPx(chart, h, ptToPx) : 0;
+  const titleTopPad    = chart.title ? h * 0.02 : 0;
+  const titleBottomPad = chart.title ? h * 0.025 : 0;
+  const titleH   = chart.title ? titleFontPx + titleTopPad + titleBottomPad : 0;
   const legendW  = chart.showLegend ? Math.max(80, w * 0.22) : 0;
   const axisFontSz = Math.max(8, Math.min(10, h * 0.045));
   const catTitleH  = chart.catAxisTitle ? axisFontSz + 4 : 0;
   const valTitleW  = chart.valAxisTitle ? axisFontSz + 4 : 0;
   const pad = {
-    t: titleH + h * 0.04,
+    t: titleH + h * 0.02,
     r: legendW + w * 0.03,
     b: h * 0.14 + catTitleH,
     l: w * 0.12 + valTitleW,
   };
   if (isH) { pad.l = w * 0.22 + valTitleW; pad.b = h * 0.08 + catTitleH; }
 
-  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+  drawChartTitle(ctx, chart.title, x, y + titleTopPad, w, titleFontPx);
 
   const px0 = x + pad.l; const py0 = y + pad.t;
   const pw  = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
@@ -1015,7 +1021,7 @@ export function renderChart(
     case 'stackedBarH':
     case 'stackedBarPct':
     case 'stackedBarHPct':
-      renderBarChart(ctx, chart, rect); break;
+      renderBarChart(ctx, chart, rect, ptToPx); break;
     case 'line':
     case 'stackedLine':
     case 'stackedLinePct':

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -102,6 +102,13 @@ pub struct ChartData {
     /// Value axis title (c:valAx/c:title).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub val_axis_title: Option<String>,
+    /// True when `<c:legend>` is present in the chart; false means no legend.
+    pub show_legend: bool,
+    /// Chart title font size in OOXML hundredths of a point (e.g. 1400 = 14pt).
+    /// Taken from the first `defRPr@sz` or `rPr@sz` inside `c:title`. None =
+    /// not specified; renderer falls back to a proportional default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_font_size_hpt: Option<i32>,
 }
 
 /// A chart anchored to a rectangular range of cells (ECMA-376 §20.5 twoCellAnchor).
@@ -1669,6 +1676,13 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str) -> Option<ChartData> {
 
     // Parse optional title
     let title = extract_chart_title(&chart_root, c_ns, a_ns);
+    let title_font_size_hpt = extract_chart_title_size(&chart_root, c_ns, a_ns);
+
+    // Legend presence: <c:chart><c:legend> is the authoritative signal. Absence
+    // means Excel hides the legend (default for a single-series chart with no
+    // explicit legend element).
+    let show_legend = chart_root.children()
+        .any(|n| n.tag_name().name() == "legend" && n.tag_name().namespace() == Some(c_ns));
 
     // Find c:plotArea
     let plot_area = chart_root.children()
@@ -1778,6 +1792,22 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str) -> Option<ChartData> {
         show_data_labels,
         cat_axis_title,
         val_axis_title,
+        show_legend,
+        title_font_size_hpt,
+    })
+}
+
+/// Extract the chart title's font size (hundredths of a point) from the first
+/// `a:defRPr@sz` or `a:rPr@sz` found under `c:title`. Returns None when absent.
+fn extract_chart_title_size(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<i32> {
+    let title_node = chart_root.children()
+        .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
+    title_node.descendants().find_map(|n| {
+        if !n.is_element() { return None; }
+        if n.tag_name().namespace() != Some(a_ns) { return None; }
+        let tag = n.tag_name().name();
+        if tag != "defRPr" && tag != "rPr" { return None; }
+        n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
     })
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2016,11 +2016,14 @@ function adaptChartData(chart: ChartData): ChartModel {
     // Excel charts default to an opaque white chart area with a light border.
     // Keep that appearance; pptx sets chartBg from the chartSpace spPr instead.
     chartBg: 'FFFFFF',
-    showLegend: (chart.series?.length ?? 0) > 0,
+    // <c:legend> is the authoritative signal: present → show, absent → hide.
+    // A single-series bar chart in Excel typically omits <c:legend>, so we
+    // must honor that rather than deriving from series count.
+    showLegend: chart.showLegend ?? false,
     catAxisCrossBetween: 'between',
     valAxisMajorTickMark: 'cross',
     catAxisMajorTickMark: 'cross',
-    titleFontSizeHpt: null,
+    titleFontSizeHpt: chart.titleFontSizeHpt ?? null,
     catAxisFontSizeHpt: null,
     valAxisFontSizeHpt: null,
     dataLabelFontSizeHpt: null,
@@ -2074,7 +2077,10 @@ function renderCharts(
     ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
     ctx.clip();
 
-    renderChart(ctx, adaptChartData(anchor.chart), { x: cx, y: cy, w: cw, h: ch });
+    // XLSX natural rendering is device-px at 96 DPI where 1pt = 4/3 px. Scale
+    // that by `cs` so OOXML-specified font sizes (title/axes) scale with zoom.
+    const ptToPx = (4 / 3) * cs;
+    renderChart(ctx, adaptChartData(anchor.chart), { x: cx, y: cy, w: cw, h: ch }, ptToPx);
     ctx.restore();
   }
 }

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -78,6 +78,10 @@ export interface ChartData {
   catAxisTitle?: string | null;
   /** Value axis title (c:valAx/c:title). */
   valAxisTitle?: string | null;
+  /** True when <c:legend> is present. Absence means the legend is hidden. */
+  showLegend?: boolean;
+  /** Chart title font size in OOXML hundredths of a point (e.g. 1400 = 14pt). */
+  titleFontSizeHpt?: number | null;
 }
 
 export interface ChartAnchor {


### PR DESCRIPTION
## Summary
- XLSX charts now honor `<c:legend>` presence and `<c:title>` `defRPr@sz`; previously the renderer hardcoded `showLegend = (series.length > 0)` and `titleFontSizeHpt = null`, so single-series charts always drew a (non-existent) legend and the title ignored the XML-specified size (14pt in sample-1 → rendered at ~12.6px).
- Pass a sheet-scaled `ptToPx = (4/3) * cs` to `renderChart` so sized text tracks zoom.
- Fix `renderBarChart` in `packages/core`, which was the only chart type that ignored `titleFontSizeHpt` — it now uses `chartTitleFontPx` like the other kinds (pptx bar charts benefit too since they already pass the field).

## Test plan
- [x] Visual check of `sample-1.xlsx` Species Analysis sheet in Storybook — title now bold at 14pt, no legend, matches Excel export.
- [ ] Run existing VRT (`pnpm vrt`) to confirm no regressions in other charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)