### PR TITLE
charts: honor title font color from chart XML

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -153,15 +153,15 @@ function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: numb
 
 function drawChartTitle(
   ctx: CanvasRenderingContext2D,
-  title: string | null,
+  chart: ChartModel,
   x: number, y: number, w: number, fontSize: number,
 ): void {
-  if (!title) return;
+  if (!chart.title) return;
   ctx.font = `bold ${fontSize}px sans-serif`;
-  ctx.fillStyle = '#333';
+  ctx.fillStyle = chart.titleFontColor ? `#${chart.titleFontColor}` : '#333';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
-  ctx.fillText(title, x + w / 2, y);
+  ctx.fillText(chart.title, x + w / 2, y);
 }
 
 // ─── Category helper ────────────────────────────────────────────────────────
@@ -209,7 +209,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   };
   if (isH) { pad.l = w * 0.22 + valTitleW; pad.b = h * 0.08 + catTitleH; }
 
-  drawChartTitle(ctx, chart.title, x, y + titleTopPad, w, titleFontPx);
+  drawChartTitle(ctx, chart, x, y + titleTopPad, w, titleFontPx);
 
   const px0 = x + pad.l; const py0 = y + pad.t;
   const pw  = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
@@ -408,7 +408,7 @@ function renderLineChart(
     l: valAxFontPx * 2.2 + 10 + valTitleW,
   };
 
-  drawChartTitle(ctx, chart.title, x, y + titleTopPad, w, titleFontPx);
+  drawChartTitle(ctx, chart, x, y + titleTopPad, w, titleFontPx);
 
   const px0 = x + pad.l; const py0 = y + pad.t;
   const pw = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
@@ -531,7 +531,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const valTitleW  = chart.valAxisTitle ? axisFontSz + 4 : 0;
   const pad = { t: titleH + h * 0.04, r: legendW + w * 0.05, b: h * 0.14 + catTitleH, l: w * 0.12 + valTitleW };
 
-  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+  drawChartTitle(ctx, chart, x, y + 2, w, Math.max(11, titleH * 0.7));
 
   const px0 = x + pad.l; const py0 = y + pad.t;
   const pw = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
@@ -632,7 +632,7 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   if (total === 0) return;
 
   const titleH = chart.title ? Math.max(14, h * 0.06) : 0;
-  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+  drawChartTitle(ctx, chart, x, y + 2, w, Math.max(11, titleH * 0.7));
 
   const legendW = chart.showLegend ? Math.max(80, w * 0.28) : 0;
   const pw = w - legendW; const ph = h - titleH - h * 0.04;
@@ -697,7 +697,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
 
   const titleH  = chart.title ? Math.max(14, h * 0.06) : 0;
   const legendW = chart.showLegend ? Math.max(70, w * 0.2) : 0;
-  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+  drawChartTitle(ctx, chart, x, y + 2, w, Math.max(11, titleH * 0.7));
 
   const pw = w - legendW; const ph = h - titleH - h * 0.04;
   const cx2 = x + pw / 2; const cy2 = y + titleH + h * 0.04 + ph / 2;
@@ -778,7 +778,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   const valTitleW  = chart.valAxisTitle ? axisFontSz + 4 : 0;
   const pad = { t: titleH + h * 0.06, r: legendW + w * 0.05, b: h * 0.12 + catTitleH, l: w * 0.12 + valTitleW };
 
-  drawChartTitle(ctx, chart.title, x, y + 2, w, Math.max(11, titleH * 0.7));
+  drawChartTitle(ctx, chart, x, y + 2, w, Math.max(11, titleH * 0.7));
 
   const px0 = x + pad.l; const py0 = y + pad.t;
   const pw = w - pad.l - pad.r; const ph = h - pad.t - pad.b;

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -76,6 +76,8 @@ export interface ChartModel {
   catAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
   /** Title font size in OOXML hundredths of a point (1600 = 16pt). null = default. */
   titleFontSizeHpt: number | null;
+  /** Title font color as a hex string without '#' (e.g. "1B4332"). null = default. */
+  titleFontColor: string | null;
   /** `<c:catAx><c:txPr>` font size (hpt). null = fall back to proportional default. */
   catAxisFontSizeHpt: number | null;
   /** `<c:valAx><c:txPr>` font size (hpt). null = fall back to proportional default. */

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2878,6 +2878,7 @@ export async function renderSlide(
           valAxisMajorTickMark: el.valAxisMajorTickMark,
           catAxisMajorTickMark: el.catAxisMajorTickMark,
           titleFontSizeHpt: el.titleFontSizeHpt,
+          titleFontColor: el.titleFontColor ?? null,
           catAxisFontSizeHpt: el.catAxisFontSizeHpt,
           valAxisFontSizeHpt: el.valAxisFontSizeHpt,
           dataLabelFontSizeHpt: el.dataLabelFontSizeHpt,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -166,6 +166,8 @@ export interface ChartElement {
   catAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
   /** Title font size in OOXML hundredths of a point (1600 = 16pt). null = default. */
   titleFontSizeHpt: number | null;
+  /** Title font color as a hex string without '#'. null = default/theme. */
+  titleFontColor?: string | null;
   /** `<c:catAx><c:txPr>` font size (hpt). null = proportional default. */
   catAxisFontSizeHpt: number | null;
   /** `<c:valAx><c:txPr>` font size (hpt). null = proportional default. */

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -109,6 +109,10 @@ pub struct ChartData {
     /// not specified; renderer falls back to a proportional default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_size_hpt: Option<i32>,
+    /// Chart title font color as a hex string without '#'. Taken from the
+    /// first `a:solidFill/a:srgbClr@val` inside `c:title`. None = default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_font_color: Option<String>,
 }
 
 /// A chart anchored to a rectangular range of cells (ECMA-376 §20.5 twoCellAnchor).
@@ -1677,6 +1681,7 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str) -> Option<ChartData> {
     // Parse optional title
     let title = extract_chart_title(&chart_root, c_ns, a_ns);
     let title_font_size_hpt = extract_chart_title_size(&chart_root, c_ns, a_ns);
+    let title_font_color = extract_chart_title_color(&chart_root, c_ns, a_ns);
 
     // Legend presence: <c:chart><c:legend> is the authoritative signal. Absence
     // means Excel hides the legend (default for a single-series chart with no
@@ -1794,6 +1799,7 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str) -> Option<ChartData> {
         val_axis_title,
         show_legend,
         title_font_size_hpt,
+        title_font_color,
     })
 }
 
@@ -1808,6 +1814,26 @@ fn extract_chart_title_size(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str
         let tag = n.tag_name().name();
         if tag != "defRPr" && tag != "rPr" { return None; }
         n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
+    })
+}
+
+/// Extract the chart title's font color (hex without '#') from the first
+/// `a:solidFill/a:srgbClr@val` inside `c:title`. Only srgb is resolved here —
+/// scheme colors would require the workbook theme, which isn't wired through
+/// to chart parsing yet.
+fn extract_chart_title_color(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<String> {
+    let title_node = chart_root.children()
+        .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
+    title_node.descendants().find_map(|n| {
+        if !n.is_element() { return None; }
+        if n.tag_name().namespace() != Some(a_ns) { return None; }
+        if n.tag_name().name() != "srgbClr" { return None; }
+        // Skip srgbClr nodes that aren't inside a solidFill (e.g. a gradient stop).
+        let parent_is_solid = n.parent()
+            .map(|p| p.tag_name().name() == "solidFill" && p.tag_name().namespace() == Some(a_ns))
+            .unwrap_or(false);
+        if !parent_is_solid { return None; }
+        n.attribute("val").map(|s| s.to_string())
     })
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2024,6 +2024,7 @@ function adaptChartData(chart: ChartData): ChartModel {
     valAxisMajorTickMark: 'cross',
     catAxisMajorTickMark: 'cross',
     titleFontSizeHpt: chart.titleFontSizeHpt ?? null,
+    titleFontColor: chart.titleFontColor ?? null,
     catAxisFontSizeHpt: null,
     valAxisFontSizeHpt: null,
     dataLabelFontSizeHpt: null,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -82,6 +82,8 @@ export interface ChartData {
   showLegend?: boolean;
   /** Chart title font size in OOXML hundredths of a point (e.g. 1400 = 14pt). */
   titleFontSizeHpt?: number | null;
+  /** Chart title font color as a hex string without '#' (srgbClr only). */
+  titleFontColor?: string | null;
 }
 
 export interface ChartAnchor {


### PR DESCRIPTION
## Summary
Follow-up to #61. The chart title's color was hardcoded to `#333` regardless of what the OOXML `<c:title>` specified; for sample-1's Species Analysis chart, Excel renders the title in dark green `#1B4332` while our output was gray.

- Add `ChartModel.titleFontColor` and thread it through `drawChartTitle`.
- xlsx parser: extract the first `a:srgbClr@val` found under `c:title`'s `a:solidFill`.
- pptx: add an optional `titleFontColor` so the shared core type stays consistent (pptx parser-side support can follow if needed).

## Test plan
- [x] Species Analysis chart in sample-1.xlsx now renders the title in dark green matching the Excel export.
- [ ] `pnpm vrt` to confirm no regressions elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)