### PR TITLE
charts: honor title font family from chart XML

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Rust/WASM parser + TypeScript Canvas renderer 構成。
 - まず ECMA-376 / ISO-29500 の該当節を読み、Word が実際にどう解釈しているか（docGrid の snap ルール、line rule の各意味、paragraph mark sz の扱い、spacing 継承の各属性、compat フラグなど）を突き止める。
 - 仕様との差の原因が分からないときは、parser 側で情報を捨てていないか（inherit / merge で潰れていないか）を先に疑う。情報が足りなければ parser を拡張するのが正道。
 - 工数が増えても spec に忠実な実装を選ぶ。empirical な定数（1.15、0.25、ceiling 付きの条件分岐など）を入れそうになったら、いったん手を止めて「どの §x.x.x の挙動なのか」を書き出す。書き出せないなら実装しない。
+- Excel / PowerPoint / Word の UI 挙動（spec に書かれていないランタイム autofit 等）を reverse-engineering して合わせる場合は、事前にユーザー承認を得ること。迷ったら spec 通りを選ぶ。
 - 既存コードに上の原則に反するコードが残っている場合は、触る機会があったら正道に寄せる。
 
 ## WASM ビルド手順

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -157,7 +157,8 @@ function drawChartTitle(
   x: number, y: number, w: number, fontSize: number,
 ): void {
   if (!chart.title) return;
-  ctx.font = `bold ${fontSize}px sans-serif`;
+  const face = chart.titleFontFace ? `"${chart.titleFontFace}", Calibri, Arial, sans-serif` : 'Calibri, Arial, sans-serif';
+  ctx.font = `bold ${fontSize}px ${face}`;
   ctx.fillStyle = chart.titleFontColor ? `#${chart.titleFontColor}` : '#333';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -78,6 +78,8 @@ export interface ChartModel {
   titleFontSizeHpt: number | null;
   /** Title font color as a hex string without '#' (e.g. "1B4332"). null = default. */
   titleFontColor: string | null;
+  /** Title font family from `<a:latin typeface>` (ECMA-376 §20.1.4.2.24). null = default. */
+  titleFontFace: string | null;
   /** `<c:catAx><c:txPr>` font size (hpt). null = fall back to proportional default. */
   catAxisFontSizeHpt: number | null;
   /** `<c:valAx><c:txPr>` font size (hpt). null = fall back to proportional default. */

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2879,6 +2879,7 @@ export async function renderSlide(
           catAxisMajorTickMark: el.catAxisMajorTickMark,
           titleFontSizeHpt: el.titleFontSizeHpt,
           titleFontColor: el.titleFontColor ?? null,
+          titleFontFace: el.titleFontFace ?? null,
           catAxisFontSizeHpt: el.catAxisFontSizeHpt,
           valAxisFontSizeHpt: el.valAxisFontSizeHpt,
           dataLabelFontSizeHpt: el.dataLabelFontSizeHpt,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -168,6 +168,8 @@ export interface ChartElement {
   titleFontSizeHpt: number | null;
   /** Title font color as a hex string without '#'. null = default/theme. */
   titleFontColor?: string | null;
+  /** Title font family (`<a:latin typeface>`). null = default/theme. */
+  titleFontFace?: string | null;
   /** `<c:catAx><c:txPr>` font size (hpt). null = proportional default. */
   catAxisFontSizeHpt: number | null;
   /** `<c:valAx><c:txPr>` font size (hpt). null = proportional default. */

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -113,6 +113,10 @@ pub struct ChartData {
     /// first `a:solidFill/a:srgbClr@val` inside `c:title`. None = default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_color: Option<String>,
+    /// Chart title font family (ECMA-376 DrawingML §20.1.4.2.24 `a:latin@typeface`).
+    /// Taken from the first `a:latin` element inside `c:title`. None = default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_font_face: Option<String>,
 }
 
 /// A chart anchored to a rectangular range of cells (ECMA-376 §20.5 twoCellAnchor).
@@ -1682,6 +1686,7 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str) -> Option<ChartData> {
     let title = extract_chart_title(&chart_root, c_ns, a_ns);
     let title_font_size_hpt = extract_chart_title_size(&chart_root, c_ns, a_ns);
     let title_font_color = extract_chart_title_color(&chart_root, c_ns, a_ns);
+    let title_font_face = extract_chart_title_face(&chart_root, c_ns, a_ns);
 
     // Legend presence: <c:chart><c:legend> is the authoritative signal. Absence
     // means Excel hides the legend (default for a single-series chart with no
@@ -1800,6 +1805,7 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str) -> Option<ChartData> {
         show_legend,
         title_font_size_hpt,
         title_font_color,
+        title_font_face,
     })
 }
 
@@ -1834,6 +1840,19 @@ fn extract_chart_title_color(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &st
             .unwrap_or(false);
         if !parent_is_solid { return None; }
         n.attribute("val").map(|s| s.to_string())
+    })
+}
+
+/// Extract the chart title's font family from the first `a:latin@typeface`
+/// descendant of `c:title` (ECMA-376 DrawingML §20.1.4.2.24).
+fn extract_chart_title_face(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<String> {
+    let title_node = chart_root.children()
+        .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
+    title_node.descendants().find_map(|n| {
+        if !n.is_element() { return None; }
+        if n.tag_name().namespace() != Some(a_ns) { return None; }
+        if n.tag_name().name() != "latin" { return None; }
+        n.attribute("typeface").map(|s| s.to_string())
     })
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2025,6 +2025,7 @@ function adaptChartData(chart: ChartData): ChartModel {
     catAxisMajorTickMark: 'cross',
     titleFontSizeHpt: chart.titleFontSizeHpt ?? null,
     titleFontColor: chart.titleFontColor ?? null,
+    titleFontFace: chart.titleFontFace ?? null,
     catAxisFontSizeHpt: null,
     valAxisFontSizeHpt: null,
     dataLabelFontSizeHpt: null,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -84,6 +84,8 @@ export interface ChartData {
   titleFontSizeHpt?: number | null;
   /** Chart title font color as a hex string without '#' (srgbClr only). */
   titleFontColor?: string | null;
+  /** Chart title font family from `<a:latin typeface>` (ECMA-376 §20.1.4.2.24). */
+  titleFontFace?: string | null;
 }
 
 export interface ChartAnchor {


### PR DESCRIPTION
## Summary

- Parse `<a:latin typeface>` inside `<c:title>` (ECMA-376 §20.1.4.2.24) in the XLSX Rust parser and thread it through `ChartModel.titleFontFace`.
- `drawChartTitle` now uses the XML-specified typeface (fallback: Calibri, matching Excel's default), instead of hard-coded generic `sans-serif` which resolved to the system UI font (SF Pro on macOS) and rendered visibly heavier than cell text.
- PPTX gets parallel pass-through (optional field) so the shared `ChartModel` stays consistent.
- CLAUDE.md: short note requiring user approval before reverse-engineering runtime autofit that is not in the spec.

## Why

sample-1 Species Analysis chart title XML specifies `<a:latin typeface="Calibri"/>`, but we were drawing it in `sans-serif`, making 14pt bold titles look much larger / heavier than the 10-11pt Calibri cells below them. The title font size itself was already correct (14pt = 18.67 CSS px literal per spec); only the font family was wrong.

## Test plan

- [x] Typecheck clean for `@silurus/ooxml-xlsx`, `@silurus/ooxml-pptx`, `@silurus/ooxml-core`.
- [x] WASM rebuild (`wasm-pack build` in packages/xlsx/parser) + manual copy to `src/wasm/`.
- [x] Storybook visual check: `ctx.font` for "Population by Species" now reads `bold 18.6667px Calibri, Calibri, Arial, sans-serif`.
- [ ] CI Playwright VRT (will run on PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)