### PR TITLE
docx: apply table style pPr to cell paragraphs (ECMA-376 §17.7.6)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -211,7 +211,7 @@ fn parse_body_elements(
     for child in body_children {
         match child.tag_name().name() {
             "p" => {
-                let result = parse_paragraph(child, style_map, num_map, media_map, rel_map, theme);
+                let result = parse_paragraph(child, style_map, num_map, media_map, rel_map, theme, None);
                 let is_page_break_only = result.runs.len() == 1 && matches!(
                     result.runs[0],
                     DocRun::Break { break_type: BreakType::Page }
@@ -394,6 +394,7 @@ fn parse_paragraph(
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
     theme: &ThemeColors,
+    table_style_id: Option<&str>,
 ) -> DocParagraph {
     // Get style ID from pPr/pStyle. When absent, resolve_para falls back to the
     // paragraph style marked w:default="1" via StyleMap::default_para_style_id.
@@ -403,7 +404,7 @@ fn parse_paragraph(
         .and_then(|s| attr_w(s, "val"));
 
     // Resolve base formatting from style
-    let (mut base_para, mut base_run) = style_map.resolve_para(explicit_style_id.as_deref());
+    let (mut base_para, mut base_run) = style_map.resolve_para(explicit_style_id.as_deref(), table_style_id);
 
     // Apply direct paragraph formatting overrides
     if let Some(ppr) = ppr_node {
@@ -692,7 +693,7 @@ fn parse_run_inner(
     // Apply rStyle
     if let Some(rpr) = rpr_node {
         if let Some(rs) = child_w(rpr, "rStyle").and_then(|n| attr_w(n, "val")) {
-            let (_, style_run) = style_map.resolve_para(Some(&rs));
+            let (_, style_run) = style_map.resolve_para(Some(&rs), None);
             apply_direct_run(&mut fmt, &style_run);
         }
         let direct = parse_run_fmt(rpr);
@@ -1446,6 +1447,14 @@ fn parse_table(
     let tbl_pr = child_w(node, "tblPr");
     let tbl_grid = child_w(node, "tblGrid");
 
+    // Resolve the table style ID (§17.4.63 w:tblStyle). Cell paragraphs
+    // inherit this style's pPr — e.g. "Table Grid" (style `af3` in this
+    // sample) sets line="240" after="0", which tightens cell line spacing
+    // below the body-text default inherited from docDefault.
+    let table_style_id = tbl_pr
+        .and_then(|p| child_w(p, "tblStyle"))
+        .and_then(|s| attr_w(s, "val"));
+
     // Column widths from tblGrid
     let col_widths: Vec<f64> = tbl_grid.map(|g| {
         children_w(g, "gridCol")
@@ -1472,7 +1481,7 @@ fn parse_table(
 
     let mut rows = vec![];
     for tr_node in children_w_flat(node, "tr") {
-        let row = parse_table_row(tr_node, style_map, num_map, media_map, rel_map, theme);
+        let row = parse_table_row(tr_node, style_map, num_map, media_map, rel_map, theme, table_style_id.as_deref());
         rows.push(row);
     }
 
@@ -1494,6 +1503,7 @@ fn parse_table_row(
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
     theme: &ThemeColors,
+    table_style_id: Option<&str>,
 ) -> DocTableRow {
     let tr_pr = child_w(node, "trPr");
     let row_height = tr_pr
@@ -1504,7 +1514,7 @@ fn parse_table_row(
 
     let mut cells = vec![];
     for tc_node in children_w_flat(node, "tc") {
-        let cell = parse_table_cell(tc_node, style_map, num_map, media_map, rel_map, theme);
+        let cell = parse_table_cell(tc_node, style_map, num_map, media_map, rel_map, theme, table_style_id);
         cells.push(cell);
     }
 
@@ -1518,6 +1528,7 @@ fn parse_table_cell(
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
     theme: &ThemeColors,
+    table_style_id: Option<&str>,
 ) -> DocTableCell {
     let tc_pr = child_w(node, "tcPr");
 
@@ -1561,7 +1572,7 @@ fn parse_table_cell(
 
     let mut content = vec![];
     for p_node in children_w_flat(node, "p") {
-        content.push(parse_paragraph(p_node, style_map, num_map, media_map, rel_map, theme));
+        content.push(parse_paragraph(p_node, style_map, num_map, media_map, rel_map, theme, table_style_id));
     }
 
     DocTableCell { content, col_span, v_merge, borders, background, v_align, width_pt }

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -124,12 +124,19 @@ impl StyleMap {
             }
         }
 
-        // Parse each style
+        // Parse each style (paragraph, character, or table).
+        // ECMA-376 §17.7.6 ST_StyleType: table styles may carry pPr that
+        // applies to cell paragraphs (e.g. "Table Grid" sets
+        // `w:spacing w:line="240" w:lineRule="auto" w:after="0"`). We
+        // index them in the same StyleMap so cell resolution can look
+        // them up by ID.
         let mut default_para_style_id: Option<String> = None;
         for style_node in children_w(root, "style") {
             let Some(style_id) = attr_w(style_node, "styleId") else { continue };
             let style_type = attr_w(style_node, "type").unwrap_or_default();
-            if style_type != "paragraph" && style_type != "character" { continue; }
+            if style_type != "paragraph"
+                && style_type != "character"
+                && style_type != "table" { continue; }
 
             if style_type == "paragraph"
                 && attr_w(style_node, "default").as_deref() == Some("1")
@@ -167,14 +174,27 @@ impl StyleMap {
     }
 
     /// Resolve all formatting for a paragraph style ID, merging inherited chain.
-    /// Priority (lowest to highest): docDefaults → basedOn chain → style itself.
+    /// Priority (lowest to highest): docDefaults → table style pPr (if inside a
+    /// table) → basedOn chain of the paragraph style → paragraph style itself.
     /// Within each level: style rPr then pPr/rPr (both are paragraph-level run defaults).
-    pub fn resolve_para(&self, style_id: Option<&str>) -> (ParaFmt, RunFmt) {
+    pub fn resolve_para(
+        &self,
+        style_id: Option<&str>,
+        table_style_id: Option<&str>,
+    ) -> (ParaFmt, RunFmt) {
         let mut merged_para = ParaFmt::default();
         let mut merged_run = RunFmt::default();
 
         apply_para(&mut merged_para, &self.defaults_para);
         apply_run(&mut merged_run, &self.defaults_run);
+
+        // Table style pPr applies to every paragraph inside the table, below
+        // the paragraph style (§17.7.6). "Table Grid" sets line=240 after=0;
+        // without this, cell paragraphs inherit docDefault's M=1.15 spacing
+        // and render ~3pt taller per line than Word.
+        if let Some(tid) = table_style_id {
+            self.apply_style_chain(tid, &mut merged_para, &mut merged_run);
+        }
 
         // Use explicit pStyle if present, otherwise fall back to the
         // paragraph style marked w:default="1" (typically "Normal").

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -332,10 +332,6 @@ export function computePages(
       const needNext = para.keepNext ? estimateNextBlockHeight(i + 1) : 0;
       const fitHeight = h - para.spaceAfter;
       const needed = fitHeight + needNext;
-      {
-        const firstText = (para.runs.find((r) => r.type === 'text' || r.type === 'field') as { text?: string } | undefined)?.text ?? '(empty)';
-        console.log(`PAG[${i}] y=${y.toFixed(1)} h=${h.toFixed(1)} fit=${fitHeight.toFixed(1)} olap=${overlap.toFixed(1)} next=${needNext.toFixed(1)} contentH=${contentH.toFixed(1)} ${firstText.slice(0, 30)}`);
-      }
       if (y > 0 && y + needed > contentH) {
         newPage();
       }
@@ -416,8 +412,6 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
   const totalColW = table.colWidths.reduce((s, w) => s + w, 0);
   const colScale = totalColW > contentWPt ? contentWPt / totalColW : 1;
   const colWidths = table.colWidths.map((w) => w * colScale);
-  // Table cells don't snap to the section docGrid — see comment in renderCell.
-  const cellState: RenderState = { ...state, docGrid: { type: null, linePitchPt: null } };
   let h = 0;
   for (const row of table.rows) {
     if (row.rowHeight != null) {
@@ -432,7 +426,7 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
       const innerW = Math.max(1, cellW - table.cellMarginLeft - table.cellMarginRight);
       let ch = table.cellMarginTop + table.cellMarginBottom;
       for (const para of cell.content) {
-        ch += estimateParagraphHeight(cellState, para, innerW);
+        ch += estimateParagraphHeight(state, para, innerW);
       }
       if (ch > rowH) rowH = ch;
       ci += span;
@@ -1507,12 +1501,9 @@ function calculateRowHeight(
     const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
     const contentW = cellW - (table.cellMarginLeft + table.cellMarginRight) * scale;
 
-    // Cell paragraphs don't snap to the section's line grid (see comment in
-    // renderCell); use a grid-less measurement state for row-height estimate.
-    const cellMeasureState: RenderState = { ...state, docGrid: { type: null, linePitchPt: null } };
     let h = (table.cellMarginTop + table.cellMarginBottom) * scale;
     for (const para of cell.content) {
-      h += measureParaHeight(cellMeasureState, para, contentW, scale);
+      h += measureParaHeight(state, para, contentW, scale);
       h += (para.spaceBefore + para.spaceAfter) * scale;
     }
     if (h > maxH) maxH = h;
@@ -1576,18 +1567,17 @@ function renderCell(
   const mr = table.cellMarginRight * scale;
 
   // ECMA-376 §17.6.5 defines w:docGrid as a section-level constraint on
-  // body-text lines. Word's observed behavior is that line-grid snapping
-  // does NOT carry into table cells — a cell's own paragraphs render at
-  // their natural font line height regardless of the enclosing section's
-  // grid pitch. Disable the grid on the cell state so cell paragraphs use
-  // `natural × M` line boxes (or `natural` for inherited line spacing),
-  // matching Word's layout on tables like demo/sample-1 page 3.
+  // Cell paragraphs inherit the section's docGrid, but their line-spacing
+  // rule comes from the table style's pPr (see parse_table + StyleMap's
+  // `resolve_para` with a `table_style_id`). "Table Grid" sets line=240
+  // (M=1.0), so with docGrid a cell line box is `max(natural, pitch × 1.0)`
+  // = pitch (~18pt), matching Word's observed in-cell baseline advance
+  // on demo/sample-1 page 3.
   const cellState: RenderState = {
     ...state,
     contentX: x + ml,
     contentW: w - ml - mr,
     y: y + mt,
-    docGrid: { type: null, linePitchPt: null },
   };
 
   if (cell.vAlign === 'center' || cell.vAlign === 'bottom') {


### PR DESCRIPTION
Follows up PR #66. During layout-diff investigation against the Word-exported PDF, we found that cell paragraphs in demo/sample-1's "Forest by the Numbers" table were ~6pt taller per line than Word's. Root cause: we weren't resolving `w:tblStyle`'s paragraph formatting.

## Spec path

ECMA-376 §17.7.6 (ST_StyleType) defines \`table\`-typed styles. Their \`w:pPr\` contributes to every paragraph in the table, resolved below the paragraph's named style but above docDefault.

The default "Table Grid" style (\`w:styleId="af3"\` in this sample) declares:
\`\`\`xml
<w:pPr>
  <w:spacing w:after="0" w:line="240" w:lineRule="auto"/>
</w:pPr>
\`\`\`

Without this merge, cell paragraphs inherited docDefault's M=1.15 (+ after=200), producing ~28pt per line vs Word's ~18pt.

## Changes

- \`StyleMap\` now indexes table-type styles (parsed the same way as paragraph/character).
- \`resolve_para(style_id, table_style_id)\` — table style pPr injected into the cascade when a \`table_style_id\` is provided.
- \`parse_table\` reads \`w:tblPr/w:tblStyle\` once and threads the id through row → cell → paragraph.
- Renderer's earlier "disable docGrid for cells" workaround (from PR #66) is reverted; with table-style M=1.0 in place, \`max(natural, pitch × 1.0)\` = pitch correctly gives 18pt per cell line.

## VRT (demo/sample-1)

Visual: table rows now render at ~30pt (was ~42pt with the earlier workaround), matching Word. Quote still on page 2; "of the world's..." on page 3. Known residual: "FIELD NOTES · CHAPTER THREE" still lands at the bottom of page 3 instead of the top of page 4 — ECMA-376 defines keepNext as 1-step, but Word appears to chain headings transitively (follow-up).

| page                 | before | after  |
| -------------------- | ------ | ------ |
| demo/sample-1 page 3 | 89.5 % | 89.7 % |
| demo/sample-1 page 6 | 95.7 % | 96.5 % |

Other pages ±0.5pp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)