### PR TITLE
pptx: unify media play badge style and add interactive playback opt-in

### DIFF
--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -235,6 +235,7 @@ export const FileUpload: Story = {
       container.innerHTML = '';
       viewer = new PptxViewer(container, {
         width: args.width,
+        enableMediaPlayback: true,
         onSlideChange: (idx, total) => {
           slideInfo.textContent = `Slide ${idx + 1} / ${total}`;
           prevBtn.disabled = idx === 0;

--- a/packages/pptx/src/media-chrome.ts
+++ b/packages/pptx/src/media-chrome.ts
@@ -1,0 +1,43 @@
+/**
+ * Draw a centered play/pause badge over a media poster rectangle.
+ *
+ * Shared by the static renderer ({@link ./renderer.ts}) and the interactive
+ * presentation handle ({@link ./presentation-handle.ts}) so the two paths
+ * produce a visually identical badge.
+ */
+export function drawPlayBadge(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  posterW: number,
+  posterH: number,
+  state: 'paused' | 'playing',
+): void {
+  const badgeR = Math.max(18, Math.min(32, Math.min(posterW, posterH) * 0.25));
+  ctx.save();
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.3)';
+  ctx.shadowBlur = badgeR * 0.35;
+  ctx.fillStyle = 'rgba(20, 20, 20, 0.7)';
+  ctx.beginPath();
+  ctx.arc(cx, cy, badgeR, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.shadowColor = 'transparent';
+  ctx.shadowBlur = 0;
+  ctx.fillStyle = '#fff';
+  if (state === 'paused') {
+    ctx.beginPath();
+    const tri = badgeR * 0.48;
+    ctx.moveTo(cx - tri * 0.4, cy - tri);
+    ctx.lineTo(cx - tri * 0.4, cy + tri);
+    ctx.lineTo(cx + tri * 0.75, cy);
+    ctx.closePath();
+    ctx.fill();
+  } else {
+    const bw = badgeR * 0.2;
+    const bh = badgeR * 0.8;
+    const gap = badgeR * 0.15;
+    ctx.fillRect(cx - gap - bw, cy - bh / 2, bw, bh);
+    ctx.fillRect(cx + gap, cy - bh / 2, bw, bh);
+  }
+  ctx.restore();
+}

--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -1,4 +1,5 @@
 import type { MediaElement, Slide } from './types';
+import { drawPlayBadge } from './media-chrome';
 
 const EMU_PER_PX = 9525;
 const emuToPx = (v: number, scale: number) => (v / EMU_PER_PX) * scale;
@@ -282,50 +283,21 @@ function drawControls(
   const duration = Number.isFinite(media.duration) ? media.duration : 0;
   const progress = duration > 0 ? Math.min(1, media.currentTime / duration) : 0;
 
-  drawPlayBadge(ctx, state, media);
+  const poster = state.posterRect;
+  drawPlayBadge(
+    ctx,
+    poster.x + poster.w / 2,
+    poster.y + poster.h / 2,
+    poster.w,
+    poster.h,
+    media.paused ? 'paused' : 'playing',
+  );
 
   if (state.el.mediaKind === 'audio') {
     drawAudioPill(ctx, state, media, duration, progress);
   } else {
     drawVideoChrome(ctx, state, media, duration, progress);
   }
-}
-
-function drawPlayBadge(
-  ctx: CanvasRenderingContext2D,
-  state: MediaState,
-  media: HTMLVideoElement | HTMLAudioElement,
-): void {
-  const poster = state.posterRect;
-  const badgeR = Math.max(18, Math.min(32, Math.min(poster.w, poster.h) * 0.25));
-  const cx = poster.x + poster.w / 2;
-  const cy = poster.y + poster.h / 2;
-  ctx.save();
-  ctx.shadowColor = 'rgba(0, 0, 0, 0.3)';
-  ctx.shadowBlur = badgeR * 0.35;
-  ctx.fillStyle = 'rgba(20, 20, 20, 0.7)';
-  ctx.beginPath();
-  ctx.arc(cx, cy, badgeR, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.shadowColor = 'transparent';
-  ctx.shadowBlur = 0;
-  ctx.fillStyle = '#fff';
-  if (media.paused) {
-    ctx.beginPath();
-    const tri = badgeR * 0.48;
-    ctx.moveTo(cx - tri * 0.4, cy - tri);
-    ctx.lineTo(cx - tri * 0.4, cy + tri);
-    ctx.lineTo(cx + tri * 0.75, cy);
-    ctx.closePath();
-    ctx.fill();
-  } else {
-    const bw = badgeR * 0.2;
-    const bh = badgeR * 0.8;
-    const gap = badgeR * 0.15;
-    ctx.fillRect(cx - gap - bw, cy - bh / 2, bw, bh);
-    ctx.fillRect(cx + gap, cy - bh / 2, bw, bh);
-  }
-  ctx.restore();
 }
 
 function drawVideoChrome(

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -22,6 +22,7 @@ import {
   resolveFill as resolveFillCore,
   applyStroke as applyStrokeCore,
 } from '@silurus/ooxml-core';
+import { drawPlayBadge } from './media-chrome';
 
 /** EMU per point (OOXML: 1 pt = 12700 EMU). Used to scale font sizes with the canvas. */
 const PT_TO_EMU = 12700;
@@ -2610,24 +2611,7 @@ async function renderMedia(
 
   if (skipControls) return;
 
-  // Play-badge overlay: centered filled circle with a triangle cue
-  const cx = x + w / 2;
-  const cy = y + h / 2;
-  const r = Math.min(w, h) * 0.18;
-  ctx.save();
-  ctx.fillStyle = 'rgba(0, 0, 0, 0.55)';
-  ctx.beginPath();
-  ctx.arc(cx, cy, r, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.fillStyle = '#fff';
-  ctx.beginPath();
-  const tri = r * 0.55;
-  ctx.moveTo(cx - tri * 0.5, cy - tri);
-  ctx.lineTo(cx - tri * 0.5, cy + tri);
-  ctx.lineTo(cx + tri, cy);
-  ctx.closePath();
-  ctx.fill();
-  ctx.restore();
+  drawPlayBadge(ctx, x + w / 2, y + h / 2, w, h, 'paused');
 }
 
 // ===== Table renderer =====

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -1,5 +1,6 @@
 import type { RenderOptions } from './renderer';
 import { PptxPresentation } from './presentation';
+import type { PresentationHandle } from './presentation-handle';
 
 export interface PptxViewerOptions extends RenderOptions {
   /** Called when a slide finishes rendering */
@@ -11,6 +12,14 @@ export interface PptxViewerOptions extends RenderOptions {
    * default — see {@link PptxPresentation.load} for privacy implications.
    */
   useGoogleFonts?: boolean;
+  /**
+   * Enable interactive audio/video playback. When true, slides are rendered
+   * via {@link PptxPresentation.presentSlide} so media elements become
+   * clickable and the viewer draws its own play/pause chrome. When false
+   * (default) the viewer renders a static slide with a non-interactive play
+   * badge over media posters.
+   */
+  enableMediaPlayback?: boolean;
 }
 
 /**
@@ -26,6 +35,7 @@ export class PptxViewer {
   private engine: PptxPresentation | null = null;
   private readonly opts: PptxViewerOptions;
   private currentSlide = 0;
+  private handle: PresentationHandle | null = null;
 
   constructor(container: HTMLElement, opts: PptxViewerOptions = {}) {
     this.opts = opts;
@@ -83,8 +93,18 @@ export class PptxViewer {
     this.canvas.style.width = `${targetWidth}px`;
     this.canvas.style.height = `${cssHeight}px`;
 
+    this.handle?.dispose();
+    this.handle = null;
+
     try {
-      await this.engine.renderSlide(this.canvas, this.currentSlide, { width: targetWidth, dpr });
+      if (this.opts.enableMediaPlayback) {
+        this.handle = await this.engine.presentSlide(this.canvas, this.currentSlide, {
+          width: targetWidth,
+          dpr,
+        });
+      } else {
+        await this.engine.renderSlide(this.canvas, this.currentSlide, { width: targetWidth, dpr });
+      }
       this.opts.onSlideChange?.(this.currentSlide, this.slideCount);
     } catch (err) {
       this.opts.onError?.(err instanceof Error ? err : new Error(String(err)));
@@ -93,6 +113,8 @@ export class PptxViewer {
 
   /** Clean up the viewer and terminate the background worker. */
   destroy(): void {
+    this.handle?.dispose();
+    this.handle = null;
     this.engine?.destroy();
     this.canvas.remove();
   }


### PR DESCRIPTION
## Summary
- Extract the play/pause badge drawing into a shared `media-chrome.ts` helper so the static `renderMedia` path and the interactive `PresentationHandle` draw an identical badge (dark fill + drop shadow + radius cap + matching triangle/pause geometry).
- Add `PptxViewer.enableMediaPlayback` opt-in: when true the viewer renders slides via `presentSlide` and manages the `PresentationHandle` lifecycle across slide navigation and destroy.
- Switch the `Load from file` Storybook story to `enableMediaPlayback: true` so uploaded decks with audio/video are interactive.

## Test plan
- [x] `tsc --noEmit` on `@silurus/ooxml-pptx` passes (after building core + WASM).
- [x] Storybook starts cleanly.
- [ ] Manually load a .pptx with media via `PptxViewer/Load from file` and verify play/pause click works and the badge icon matches the static `Demo` story.
- [ ] Run `pnpm vrt` — badge style has changed; review any diffs before updating references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)