### PR TITLE
pptx: resolve shape lnRef stroke width from theme lnStyleLst

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2828,13 +2828,22 @@ fn parse_shape(
             }
         });
 
-    // lnRef idx=0 → no line; idx>0 → use referenced color
+    // lnRef idx=0 → no line; idx>0 → resolve width from theme's fmtScheme >
+    // lnStyleLst (stored as "+lnRef-N") and color from the ref's own solidFill.
+    // Falling back to 9525 under-weights idx>=2 strokes (Office default theme
+    // idx=2 is 19050 EMU = 1.5pt, idx=3 is 25400 EMU = 2pt).
     let style_stroke: Option<Stroke> = style_node
         .and_then(|s| child(s, "lnRef"))
         .and_then(|lr| {
             let idx: u32 = attr(&lr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
             if idx == 0 { None } else {
-                parse_color_node(lr, theme).map(|c| Stroke { color: c, width: 9525, dash_style: None, head_end: None, tail_end: None })
+                parse_color_node(lr, theme).map(|c| {
+                    let width = theme
+                        .get(&format!("+lnRef-{}", idx))
+                        .and_then(|s| s.parse::<i64>().ok())
+                        .unwrap_or(9525);
+                    Stroke { color: c, width, dash_style: None, head_end: None, tail_end: None }
+                })
             }
         });
 


### PR DESCRIPTION
## Summary
- Shapes that reference a style-level `<p:style><a:lnRef idx="N">` without an overriding `<a:ln>` (arcs, brackets, braces, etc.) were rendering thinner than PowerPoint because the parser hardcoded the stroke width to 9525 EMU (0.75pt).
- PR #74 fixed the equivalent path for connectors; this PR applies the same theme lookup (`fmtScheme > lnStyleLst`, stored as `+lnRef-N`) to `<p:sp>` shapes.
- In the Office default theme, idx=2 resolves to 19050 EMU (1.5pt) and idx=3 to 25400 EMU (2pt), matching PowerPoint's on-screen thickness.

## Test plan
- [x] `wasm-pack build` succeeds
- [x] Playwright VRT: `private/sample-3` slide 4 match=99.1% (8,554 / 921,600 diff px) at the 20% threshold
- [ ] Visual check against PowerPoint for `{`, `}`, `[`, `]`, and arc shapes on sample-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)