### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.7.0 — 2026-04-21
+
+Quality pass across pptx shape rendering and chart legends — no new
+feature categories, but several existing ✅ features now match the
+Office output more faithfully.
+
+### pptx
+
+- **`cxnSp` connectors honor `<p:style><a:lnRef idx="N">`** as a stroke
+  fallback (#74). Previously a connector that only declared
+  `headEnd` / `tailEnd` on `<a:ln>` (no `solidFill`) rendered invisible;
+  the style-level stroke now fills in color and width.
+- **`<p:style><a:lnRef>` stroke width resolves from the theme's
+  `fmtScheme > lnStyleLst`** for both `<p:cxnSp>` (#74) and `<p:sp>`
+  (#76). The previous hard-coded 9525 EMU (0.75 pt) under-weighted
+  every idx ≥ 2 stroke — idx=2 is 19050 EMU (1.5 pt) and idx=3 is
+  25400 EMU (2 pt) in the Office default theme. Brackets, braces, and
+  arcs that inherited the style line now render at the thickness
+  PowerPoint shows.
+- **`<a:tint>` mixes in linear sRGB** (IEC 61966-2-1) rather than
+  straight sRGB (#74). Sampling the PDF export of the reference
+  SmartArt arrow (#156082 + tint=60000) yields ~#D1D6DB, which the
+  linear-sRGB lerp now reproduces pixel-for-pixel.
+- **`bentConnector{2-5}` / `curvedConnector{2-5}` routed through the
+  ECMA-376 preset path evaluator** (#74), and `getConnectorAnchors()`
+  walks the preset cmd list so arrow heads sit on the true tangent
+  angle instead of the bounding-box diagonal.
+- **`rtTriangle` prstGeom** (right-angle at bottom-left) gained a
+  proper path (#74); previously fell back to `rect`.
+- **`adj5`–`adj8` threaded through parser → renderer → preset
+  evaluator** (#74) for callouts whose gdLst references them
+  (e.g. `accentBorderCallout3`).
+
+### charts
+
+- **`c:legendPos` and marker visibility** now drive legend placement
+  and series point rendering across the chart families (#72); radar
+  charts also honor the value-axis scale instead of defaulting to
+  `0–max`.
+
+### xlsx
+
+- **Data bar conditional formatting** renders with the Excel 2010+
+  gradient fill instead of the flat solid color (#73), matching the
+  in-cell gradient Excel draws.
+
+### Docs
+
+- README screenshots refreshed for the release.
+- CLAUDE.md codifies two workflow rules: squash merges to `main` are
+  forbidden (use `--merge` or `--rebase`), and the release process
+  (README screenshots + support table + CHANGELOG + version bump)
+  is documented as a single PR procedure.
+
 ## 0.6.0 — 2026-04-21
 
 ### docx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,20 @@ npx playwright test --reporter=list
 # または
 pnpm vrt
 ```
+
+## リリース手順
+
+ユーザーから「リリースして」と指示されたとき、以下を1つの PR にまとめて実行する。squash merge 禁止ルールに従い、`gh pr merge <N> --merge` でマージする。
+
+1. **README のスクリーンショット更新**（メインタスク）
+   - `docs/images/{pptx,docx,xlsx}.png` の 3 枚を撮り直す。
+   - Storybook を起動して代表的なサンプルを表示し、Playwright / Claude Preview などでスクリーンショット取得。
+   - 構図は既存画像と揃える（viewer + サンプル）。ファイル名は固定。
+2. **README の対応表更新**（メインタスク）
+   - 前リリース以降にマージされた PR を `git log --oneline` で拾い、機能追加があれば `## Feature Support` の該当行を ❌ → ✅ に反転、または新しい行を追加する。
+   - bug fix / 精度向上だけなら対応表は動かさず、根拠は CHANGELOG に書く。
+3. **CHANGELOG 追記**: `CHANGELOG.md` の先頭に `## 0.x.0 — YYYY-MM-DD` セクションを追加し、docx/pptx/xlsx/charts ごとに 1〜3 行の bullet で要点を書く。ECMA-376 節番号や PR 番号を適宜併記。
+4. **バージョン bump**: ルート `package.json` と `packages/{core,pptx,xlsx,docx}/package.json` の計 5 ファイルを同じ minor バージョンへ揃える。
+5. **PR 作成**: ブランチ名は `release/0.x.0`。PR タイトルは `chore(release): 0.x.0`。マージは必ず `--merge` か `--rebase`（squash 禁止）。
+
+参照画像（`tests/visual/references/`）はこの手順の対象外。README のスクリーンショットは `docs/images/` 配下のみ。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
- Version bump 0.6.0 → 0.7.0 across the root and all workspace `package.json` files.
- CHANGELOG entry for 0.7.0 covers pptx shape/connector fidelity (#74, #76), chart legend / radar value axis (#72), and xlsx data-bar gradient fill (#73). All entries are refinements of already-✅ features, so the README support table does not flip any rows — the existing categories remain accurate.
- README screenshots (`docs/images/{pptx,docx,xlsx}.png`) regenerated via `tests/smoke/readme-screenshots.spec.ts`; content is byte-identical to 0.6.0 because the sample decks themselves didn't change.
- CLAUDE.md gains a `リリース手順` section so the next release follows the same procedure (screenshot refresh + support-table review + CHANGELOG + 5-file version bump + PR with `--merge` or `--rebase`, never `--squash`).

## Test plan
- [x] `npx tsc --build` — clean
- [x] `npx playwright test --config tests/smoke/playwright.config.ts` — 9/9 passing, including the 3 README screenshot cases
- [ ] Post-merge: publish `@silurus/ooxml@0.7.0` via the existing release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)