### PR TITLE
chore: migrate demo to demo.silurus.dev and bump to 0.8.0

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build Storybook
         run: pnpm build-storybook
 
+      - name: Write CNAME for custom domain
+        run: echo "demo.silurus.dev" > storybook-static/CNAME
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,7 +21,7 @@ const config: StorybookConfig = {
     const { default: wasm } = await import('vite-plugin-wasm');
     return {
       ...config,
-      base: process.env.GITHUB_ACTIONS ? '/office-open-xml-viewer/' : '/',
+      base: '/',
       plugins: [...(config.plugins ?? []), wasm()],
       worker: { format: 'es' as const, plugins: () => [wasm()] },
     };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.8.0 — 2026-04-21
+
+### Infrastructure
+
+- **Demo URL changed to `https://demo.silurus.dev`** — GitHub Pages now served
+  from a custom domain. README and npm `homepage` field updated accordingly.
+- Storybook build base path simplified to `/` (was `/office-open-xml-viewer/`
+  on CI); `CNAME` file is now written into the artifact on every deploy.
+
 ## 0.7.0 — 2026-04-21
 
 Quality pass across pptx shape rendering and chart legends — no new

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![npm downloads](https://img.shields.io/npm/dm/@silurus/ooxml.svg)](https://www.npmjs.com/package/@silurus/ooxml)
 [![license](https://img.shields.io/npm/l/@silurus/ooxml.svg)](./LICENSE)
 
-**[Demo (Storybook)](https://yukiyokotani.github.io/office-open-xml-viewer/)**
+**[Demo (Storybook)](https://demo.silurus.dev)**
 
 A browser-based viewer for Office Open XML documents that renders to an HTML Canvas element.
 The parsers are written in Rust and compiled to WebAssembly; the renderers use the Canvas 2D API.
-Each format also exposes a headless engine (`PptxPresentation` / `DocxDocument` / `XlsxWorkbook`) that renders into any caller-supplied canvas, so you can compose your own UI — scroll views, thumbnail grids, master-detail panes — instead of being locked into the built-in viewer. See the `Examples` section in [the Storybook demo](https://yukiyokotani.github.io/office-open-xml-viewer/).
+Each format also exposes a headless engine (`PptxPresentation` / `DocxDocument` / `XlsxWorkbook`) that renders into any caller-supplied canvas, so you can compose your own UI — scroll views, thumbnail grids, master-detail panes — instead of being locked into the built-in viewer. See the `Examples` section in [the Storybook demo](https://demo.silurus.dev).
 
 | PPTX | DOCX | XLSX |
 |:---:|:---:|:---:|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git"
   },
-  "homepage": "https://github.com/yukiyokotani/office-open-xml-viewer#readme",
+  "homepage": "https://demo.silurus.dev",
   "bugs": {
     "url": "https://github.com/yukiyokotani/office-open-xml-viewer/issues"
   },


### PR DESCRIPTION
## Summary
- Demo URL changed from `https://yukiyokotani.github.io/office-open-xml-viewer/` to `https://demo.silurus.dev`
- Storybook Vite base path changed from `/office-open-xml-viewer/` to `/` (custom domain serves from root)
- `CNAME` file written into `storybook-static/` on every deploy to prevent GitHub Pages from resetting the custom domain
- npm `homepage` updated to `https://demo.silurus.dev`
- Version bumped to 0.8.0

## Test plan
- [ ] Merge triggers `deploy-storybook.yml` via `v0.8.0` tag
- [ ] `storybook-static/CNAME` contains `demo.silurus.dev`
- [ ] `https://demo.silurus.dev` serves Storybook correctly