### PR TITLE
chore: change demo domain to ooxml.silurus.dev and bump to 0.8.1

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -46,7 +46,7 @@ jobs:
         run: pnpm build-storybook
 
       - name: Write CNAME for custom domain
-        run: echo "demo.silurus.dev" > storybook-static/CNAME
+        run: echo "ooxml.silurus.dev" > storybook-static/CNAME
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.8.1 — 2026-04-21
+
+### Infrastructure
+
+- **Demo URL changed to `https://ooxml.silurus.dev`** — custom domain updated
+  from `demo.silurus.dev` to `ooxml.silurus.dev` for scalability across future libraries.
+
 ## 0.8.0 — 2026-04-21
 
 ### Infrastructure

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![npm downloads](https://img.shields.io/npm/dm/@silurus/ooxml.svg)](https://www.npmjs.com/package/@silurus/ooxml)
 [![license](https://img.shields.io/npm/l/@silurus/ooxml.svg)](./LICENSE)
 
-**[Demo (Storybook)](https://demo.silurus.dev)**
+**[Demo (Storybook)](https://ooxml.silurus.dev)**
 
 A browser-based viewer for Office Open XML documents that renders to an HTML Canvas element.
 The parsers are written in Rust and compiled to WebAssembly; the renderers use the Canvas 2D API.
-Each format also exposes a headless engine (`PptxPresentation` / `DocxDocument` / `XlsxWorkbook`) that renders into any caller-supplied canvas, so you can compose your own UI — scroll views, thumbnail grids, master-detail panes — instead of being locked into the built-in viewer. See the `Examples` section in [the Storybook demo](https://demo.silurus.dev).
+Each format also exposes a headless engine (`PptxPresentation` / `DocxDocument` / `XlsxWorkbook`) that renders into any caller-supplied canvas, so you can compose your own UI — scroll views, thumbnail grids, master-detail panes — instead of being locked into the built-in viewer. See the `Examples` section in [the Storybook demo](https://ooxml.silurus.dev).
 
 | PPTX | DOCX | XLSX |
 |:---:|:---:|:---:|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git"
   },
-  "homepage": "https://demo.silurus.dev",
+  "homepage": "https://ooxml.silurus.dev",
   "bugs": {
     "url": "https://github.com/yukiyokotani/office-open-xml-viewer/issues"
   },


### PR DESCRIPTION
## Summary
- Demo URL: `demo.silurus.dev` → `ooxml.silurus.dev`
- CNAME artifact updated accordingly
- Version bumped to 0.8.1

## Why
`ooxml.silurus.dev` にすることで、今後別ライブラリは `other.silurus.dev` のように独立したサブドメインを使えるようになる。