### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.10.0 — 2026-04-22
+
+xlsx number-format and volatile-function release. Cells with `TODAY()` /
+`NOW()` formulas now show today's date at render time instead of the
+cached `<v>` from when the file was last saved, and the format-code
+renderer gains Japanese weekday / imperial era support plus several
+internationally important codes (elapsed time, literal preservation,
+scientific notation).
+
+### xlsx
+
+- **Volatile formula recompute** (§18.3.1.40): the parser now carries
+  each cell's `<f>` text, and the renderer detects `TODAY()` / `NOW()`
+  and substitutes the live serial before formatting. Dates no longer
+  appear frozen to the file's last-save date.
+- **Japanese weekday format codes** (§18.8.30): `aaa` → 水, `aaaa` →
+  水曜日. Detected as date formats even without a `y`/`d` specifier.
+- **Japanese imperial era format codes** (§18.8.30): `g` / `gg` / `ggg`
+  render the era name (R / 令 / 令和) and `e` / `ee` / `r` / `rr` render
+  the era year. Era table covers Meiji through Reiwa; no runtime
+  dependency added.
+- **Elapsed-time brackets** `[h]` / `[m]` / `[s]` (§18.8.30): render the
+  full duration instead of wrapping at 24h / 60m / 60s, so a 54-hour
+  value formatted `[h]:mm` reads `54:00`.
+- **Literal text preservation in number formats**: quoted strings
+  (`"$"#,##0.00`) and backslash-escaped characters (`\$#,##0`), as well
+  as non-placeholder currency glyphs like `¥` / `€`, are now kept around
+  the formatted number instead of being stripped.
+- **Scientific notation** `0.00E+00` / `0.00E-00`: honors the exponent
+  sign placeholder and pads the exponent to at least two digits.
+
 ## 0.9.0 — 2026-04-22
 
 Focused xlsx release: conditional formatting now evaluates formula-based

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -265,6 +265,12 @@ pub struct Cell {
     pub col_ref: String,
     pub value: CellValue,
     pub style_index: u32,
+    /// Raw `<f>` formula text (ECMA-376 §18.3.1.40), when present. The
+    /// renderer uses this to recompute volatile functions like TODAY() /
+    /// NOW() at display time so the cached `<v>` (frozen when the file was
+    /// last saved) doesn't show a stale date.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub formula: Option<String>,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -2219,6 +2225,15 @@ fn parse_row_cells(
         // Inline string: <c t="inlineStr"><is>...</is></c>
         let is_node = c_node.children().find(|n| n.tag_name().name() == "is");
 
+        // Formula text, if any (<f>…</f>). Kept so the renderer can
+        // recompute volatile builtins (TODAY, NOW) at display time.
+        let formula: Option<String> = c_node
+            .children()
+            .find(|n| n.tag_name().name() == "f")
+            .and_then(|n| n.text())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let v_text = c_node
             .children()
             .find(|n| n.tag_name().name() == "v")
@@ -2259,7 +2274,7 @@ fn parse_row_cells(
             }
         };
 
-        cells.push(Cell { col, row, col_ref: cell_ref, value, style_index });
+        cells.push(Cell { col, row, col_ref: cell_ref, value, style_index, formula });
     }
     cells
 }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -322,9 +322,22 @@ function formatCellValue(cell: Cell, styles: Styles): string {
   if (cell.value.type !== 'number') return cellValueText(cell.value);
   const xf = styles.cellXfs[cell.styleIndex ?? 0];
   const numFmtId = xf?.numFmtId ?? 0;
-  const num = cell.value.number;
+  // Volatile builtins: TODAY()/NOW() cells have a cached `<v>` from the last
+  // save, which the viewer would otherwise show as a stale date. Recompute
+  // them against the current system clock at render time.
+  const num = recomputeVolatile(cell.formula) ?? cell.value.number;
   const customFmt = styles.numFmts?.find(f => f.numFmtId === numFmtId);
   return applyFormat(num, numFmtId, customFmt?.formatCode ?? null);
+}
+
+/** If `formula` is a volatile builtin (TODAY/NOW), return the current Excel
+ *  serial. Tolerates surrounding whitespace and an optional leading `=`. */
+function recomputeVolatile(formula: string | undefined): number | null {
+  if (!formula) return null;
+  const f = formula.trim().replace(/^=/, '').toUpperCase().replace(/\s+/g, '');
+  if (f === 'TODAY()') return todaySerial();
+  if (f === 'NOW()') return nowSerial();
+  return null;
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -349,6 +362,36 @@ const MONTH_NAMES = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+/** Japanese short weekday names (aaa format code, e.g. "水"). */
+const JP_WEEKDAY_SHORT = ['日', '月', '火', '水', '木', '金', '土'];
+/** Japanese long weekday names (aaaa format code, e.g. "水曜日"). */
+const JP_WEEKDAY_LONG = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日'];
+
+/** Japanese imperial eras, newest-first. First entry whose `start` is
+ *  ≤ the target date wins (ECMA-376 §18.8.30 — g/gg/ggg and e/ee codes). */
+const JP_ERAS: Array<{ start: Date; abbr: string; short: string; long: string }> = [
+  { start: new Date(Date.UTC(2019, 4,  1)), abbr: 'R', short: '令', long: '令和' },
+  { start: new Date(Date.UTC(1989, 0,  8)), abbr: 'H', short: '平', long: '平成' },
+  { start: new Date(Date.UTC(1926, 11, 25)), abbr: 'S', short: '昭', long: '昭和' },
+  { start: new Date(Date.UTC(1912, 6,  30)), abbr: 'T', short: '大', long: '大正' },
+  { start: new Date(Date.UTC(1868, 0,  25)), abbr: 'M', short: '明', long: '明治' },
+];
+
+function resolveJpEra(date: Date): { abbr: string; short: string; long: string; year: number } {
+  for (const era of JP_ERAS) {
+    if (date.getTime() >= era.start.getTime()) {
+      return {
+        abbr: era.abbr,
+        short: era.short,
+        long: era.long,
+        year: date.getUTCFullYear() - era.start.getUTCFullYear() + 1,
+      };
+    }
+  }
+  // Pre-Meiji: fall back to Gregorian year, keep Meiji names as a best effort.
+  const last = JP_ERAS[JP_ERAS.length - 1];
+  return { abbr: last.abbr, short: last.short, long: last.long, year: date.getUTCFullYear() };
+}
 
 /** Convert an Excel date serial to a UTC Date (avoids local-timezone off-by-one errors). */
 function excelSerialToUTCDate(serial: number): Date {
@@ -374,6 +417,8 @@ function formatExcelDateCode(serial: number, fmtCode: string): string {
   // Take the first section (positive / no-sign section)
   const section = fmtCode.split(';')[0];
   const hasAmPm = /am\/pm|a\/p/i.test(section);
+  let era: ReturnType<typeof resolveJpEra> | null = null;
+  const getEra = (): ReturnType<typeof resolveJpEra> => era ?? (era = resolveJpEra(date));
 
   let result = '';
   let i = 0;
@@ -390,9 +435,29 @@ function formatExcelDateCode(serial: number, fmtCode: string): string {
       prevWasHour = false;
 
     } else if (ch === '[') {
-      // Locale / colour / condition bracket — skip entirely
-      while (i < section.length && section[i] !== ']') i++;
-      if (i < section.length) i++;
+      // ECMA-376 §18.8.30: `[h]` / `[m]` / `[s]` are elapsed-time tokens that
+      // suppress the h < 24 / m < 60 / s < 60 wrap-around and instead render
+      // the full duration. Any other bracket content (locale IDs, colours,
+      // conditions) is metadata and skipped.
+      const end = section.indexOf(']', i);
+      const inner = end > i ? section.slice(i + 1, end) : '';
+      const elapsed = inner.match(/^([hms])\1*$/i);
+      if (elapsed) {
+        const kind = elapsed[1].toLowerCase();
+        const sign = serial < 0 ? '-' : '';
+        const absSec = Math.floor(Math.abs(serial) * 86400);
+        let v: number;
+        if      (kind === 'h') v = Math.floor(absSec / 3600);
+        else if (kind === 'm') v = Math.floor(absSec / 60);
+        else                   v = absSec;
+        const padded = inner.length >= 2 ? String(v).padStart(inner.length, '0') : String(v);
+        result += sign + padded;
+        i = end + 1;
+        prevWasHour = kind === 'h';
+      } else {
+        while (i < section.length && section[i] !== ']') i++;
+        if (i < section.length) i++;
+      }
 
     } else if (ch === '_') {
       i += 2; // _ followed by a padding character — skip both
@@ -451,9 +516,45 @@ function formatExcelDateCode(serial: number, fmtCode: string): string {
       result += n >= 2 ? String(sc).padStart(2, '0') : String(sc);
       prevWasHour = false;
 
+    } else if (ch === 'g' || ch === 'G') {
+      // Japanese era name (ECMA-376 §18.8.30 ja locale):
+      //   g   → 'R' / 'H' / 'S' / 'T' / 'M'
+      //   gg  → '令' / '平' / '昭' / '大' / '明'
+      //   ggg → '令和' / '平成' / '昭和' / '大正' / '明治'
+      let n = 0;
+      while (i < section.length && section[i].toLowerCase() === 'g') { n++; i++; }
+      const e = getEra();
+      if      (n === 1) result += e.abbr;
+      else if (n === 2) result += e.short;
+      else              result += e.long;
+      prevWasHour = false;
+
+    } else if (ch === 'e' || ch === 'E') {
+      // Japanese era year: `e` → unpadded, `ee` → 2-digit zero-padded.
+      let n = 0;
+      while (i < section.length && section[i].toLowerCase() === 'e') { n++; i++; }
+      const y = getEra().year;
+      result += n >= 2 ? String(y).padStart(2, '0') : String(y);
+      prevWasHour = false;
+
+    } else if (ch === 'r' || ch === 'R') {
+      // Some Japanese Excel variants expose `r` / `rr` as era-year aliases.
+      let n = 0;
+      while (i < section.length && section[i].toLowerCase() === 'r') { n++; i++; }
+      const y = getEra().year;
+      result += n >= 2 ? String(y).padStart(2, '0') : String(y);
+      prevWasHour = false;
+
     } else if (ch === 'A' || ch === 'a') {
       const upper = section.slice(i).toUpperCase();
-      if (upper.startsWith('AM/PM')) {
+      // Japanese weekday format codes (Excel ja locale). `aaaa` = "水曜日",
+      // `aaa` = "水". Checked before AM/PM because those are shorter matches
+      // and would otherwise swallow the leading 'a'.
+      if (upper.startsWith('AAAA')) {
+        result += JP_WEEKDAY_LONG[wd]; i += 4;
+      } else if (upper.startsWith('AAA')) {
+        result += JP_WEEKDAY_SHORT[wd]; i += 3;
+      } else if (upper.startsWith('AM/PM')) {
         result += hr < 12 ? 'AM' : 'PM'; i += 5;
       } else if (upper.startsWith('A/P')) {
         result += hr < 12 ? 'A' : 'P'; i += 3;
@@ -477,10 +578,16 @@ function formatExcelDateCode(serial: number, fmtCode: string): string {
 
 /** Returns true if a custom formatCode is a date/time format. */
 function isDateFormatCode(code: string): boolean {
+  // Elapsed-time brackets `[h]`, `[m]`, `[s]` (ECMA-376 §18.8.30) are themselves
+  // time formats, so detect those *before* stripping bracket content below.
+  if (/\[[hms]+\]/i.test(code)) return true;
   // Strip quoted literals and bracket content, then look for unambiguous date specifiers.
   // 'y' = year, 'd' = day — both are unambiguous. 'm' alone is ambiguous (month or minutes).
   const stripped = code.replace(/"[^"]*"/g, '').replace(/\[[^\]]*\]/g, '');
-  return /[yd]/i.test(stripped);
+  // y / d are unambiguous date specifiers. `aaa+` is the Japanese-locale
+  // weekday code and implies a date format even without y/d (e.g. the
+  // bare `aaa` custom format).
+  return /[yd]/i.test(stripped) || /a{3,}/i.test(stripped);
 }
 
 function applyFormat(num: number, numFmtId: number, formatCode: string | null): string {
@@ -518,17 +625,117 @@ function countDecimalPlaces(fmt: string): number {
   return m ? m[1].length : 0;
 }
 
+/**
+ * Split a format section into an ordered list of tokens, preserving the exact
+ * literal surroundings (quoted strings, backslash escapes, non-placeholder
+ * characters like `$`, `€`, `¥` when unquoted) so they can be reassembled
+ * around the formatted number. Drops bracket metadata (`[Red]`, `[>0]`),
+ * underscore-pad pairs and `*`-fill pairs, per ECMA-376 §18.8.30.
+ */
+type FmtToken =
+  | { kind: 'lit'; text: string }
+  | { kind: 'num' }
+  | { kind: 'percent' }
+  | { kind: 'sci'; expSign: boolean };
+
+function tokenizeNumberFormat(section: string): { tokens: FmtToken[]; numSpec: string } {
+  const tokens: FmtToken[] = [];
+  let numSpec = '';
+  let numPushed = false;
+  let sciPushed = false;
+  const pushLit = (s: string) => {
+    if (!s) return;
+    const last = tokens[tokens.length - 1];
+    if (last && last.kind === 'lit') last.text += s;
+    else tokens.push({ kind: 'lit', text: s });
+  };
+  const ensureNum = () => {
+    if (!numPushed) { tokens.push({ kind: 'num' }); numPushed = true; }
+  };
+
+  let i = 0;
+  while (i < section.length) {
+    const ch = section[i];
+    if (ch === '"') {
+      i++;
+      let s = '';
+      while (i < section.length && section[i] !== '"') s += section[i++];
+      if (i < section.length) i++;
+      pushLit(s);
+    } else if (ch === '\\') {
+      if (i + 1 < section.length) pushLit(section[i + 1]);
+      i += 2;
+    } else if (ch === '[') {
+      while (i < section.length && section[i] !== ']') i++;
+      if (i < section.length) i++;
+    } else if (ch === '_') {
+      i += 2;
+    } else if (ch === '*') {
+      i += 2;
+    } else if (ch === '#' || ch === '0' || ch === '?' || ch === '.' || ch === ',') {
+      ensureNum();
+      numSpec += ch;
+      i++;
+    } else if (ch === '%') {
+      tokens.push({ kind: 'percent' });
+      i++;
+    } else if ((ch === 'E' || ch === 'e') && (section[i + 1] === '+' || section[i + 1] === '-')) {
+      if (!sciPushed) {
+        tokens.push({ kind: 'sci', expSign: section[i + 1] === '+' });
+        sciPushed = true;
+      }
+      i += 2;
+      while (i < section.length && section[i] === '0') i++;
+    } else {
+      pushLit(ch);
+      i++;
+    }
+  }
+  return { tokens, numSpec };
+}
+
+function formatNumberSpec(value: number, numSpec: string): string {
+  const hasThousands = numSpec.includes(',') && /[#0]/.test(numSpec);
+  const dec = countDecimalPlaces(numSpec);
+  if (hasThousands) return formatThousands(value, dec);
+  if (numSpec.includes('.')) return value.toFixed(dec);
+  if (/[#0?]/.test(numSpec)) return Math.round(value).toString();
+  return String(value);
+}
+
 function applyFormatCode(num: number, formatCode: string): string {
   const sections = formatCode.split(';');
   const section = num < 0 && sections.length > 1 ? sections[1] : sections[0];
-  const cleaned = section.replace(/\[.*?\]/g, '').replace(/_./g, '').replace(/\*/g, '');
-  if (cleaned.includes('%')) return (num * 100).toFixed(countDecimalPlaces(cleaned)) + '%';
-  const hasThousands = cleaned.includes(',') && (cleaned.includes('#') || cleaned.includes('0'));
-  const dec = countDecimalPlaces(cleaned);
-  if (hasThousands) return formatThousands(num, dec);
-  if (cleaned.includes('.')) return num.toFixed(dec);
-  if (cleaned.match(/[#0]/)) return Math.round(num).toString();
-  return String(num);
+  const { tokens, numSpec } = tokenizeNumberFormat(section);
+  const hasPercent = tokens.some(t => t.kind === 'percent');
+  const sciTok = tokens.find(t => t.kind === 'sci') as Extract<FmtToken, { kind: 'sci' }> | undefined;
+
+  let value = num;
+  if (hasPercent) value = value * 100;
+
+  let numberText: string;
+  let expText = '';
+  if (sciTok) {
+    const dec = countDecimalPlaces(numSpec);
+    const [mantissa, exp] = value.toExponential(dec).split('e');
+    numberText = mantissa;
+    const e = parseInt(exp, 10);
+    const sign = e < 0 ? '-' : (sciTok.expSign ? '+' : '');
+    expText = sign + String(Math.abs(e)).padStart(2, '0');
+  } else {
+    numberText = formatNumberSpec(value, numSpec);
+  }
+
+  let result = '';
+  let numberEmitted = false;
+  for (const t of tokens) {
+    if (t.kind === 'lit') result += t.text;
+    else if (t.kind === 'percent') result += '%';
+    else if (t.kind === 'num') { result += numberText; numberEmitted = true; }
+    else if (t.kind === 'sci') result += 'E' + expText;
+  }
+  if (!numberEmitted && (numSpec.length > 0 || sciTok)) result += numberText;
+  return result;
 }
 
 function wrapTextLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -186,6 +186,11 @@ export interface Cell {
   colRef: string;
   value: CellValue;
   styleIndex: number;
+  /** Raw `<f>` formula text (ECMA-376 §18.3.1.40), when present. The renderer
+   *  uses this to recompute volatile functions (TODAY, NOW) at display time
+   *  so the cached `<v>` — frozen when the file was last saved — doesn't
+   *  show a stale date. */
+  formula?: string;
 }
 
 export type CellValue =


### PR DESCRIPTION
## Summary

xlsx number-format and volatile-function release.

- **TODAY() / NOW() recompute** — cells with volatile formulas now show the live date/time at render time instead of the cached `<v>` from when the file was last saved.
- **Japanese weekday / era format codes** — `aaa`/`aaaa` (水 / 水曜日), `g`/`gg`/`ggg` (R / 令 / 令和), `e`/`ee`/`r`/`rr` (era year). Hand-rolled era table covering Meiji–Reiwa; no dependency added.
- **Elapsed-time brackets** `[h]` / `[m]` / `[s]` — render full duration without 24h/60m/60s wrap-around.
- **Literal preservation** in number formats — `"$"#,##0.00`, `\$#,##0`, and bare currency glyphs (¥/€) are now kept around the formatted number.
- **Scientific notation** `0.00E+00` / `0.00E-00` — honors the exponent sign placeholder and pads to 2 digits.

See [CHANGELOG](CHANGELOG.md) for spec references.

## Test plan

- [x] `pnpm typecheck` — no new errors (pre-existing BorderEdge + core-dist warnings unrelated)
- [x] WASM rebuilt
- [ ] Manual spot-check in Storybook for a sample containing `TODAY()` and `aaa` format codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)