### PR TITLE
feat(xlsx): support custom iconSet conditional formatting (x14)

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -221,9 +221,23 @@ pub enum CfRule {
     #[serde(rename_all = "camelCase")]
     AboveAverage { above_average: bool, dxf_id: Option<u32>, priority: i32 },
     #[serde(rename_all = "camelCase")]
-    IconSet { icon_set: String, cfvos: Vec<CfValue>, reverse: bool, priority: i32 },
+    IconSet {
+        icon_set: String,
+        cfvos: Vec<CfValue>,
+        reverse: bool,
+        priority: i32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        custom_icons: Option<Vec<CfIcon>>,
+    },
     #[serde(rename_all = "camelCase")]
     Other { kind: String, priority: i32 },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CfIcon {
+    pub icon_set: String,
+    pub icon_id: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -1147,6 +1161,63 @@ fn parse_worksheet(
         }
     }
 
+    // Pre-scan worksheet-level extLst for x14:conditionalFormatting with
+    // iconSet rules. Excel 2010+ stores custom icon sets (custom="1") here
+    // with per-threshold `<x14:cfIcon iconSet="X" iconId="N"/>` overrides,
+    // and cfvo values inside `<xm:f>` children instead of `val` attributes.
+    // The sqref for x14 CF rules lives in a `<xm:sqref>` sibling.
+    let mut x14_icon_formats: Vec<ConditionalFormat> = Vec::new();
+    for x14_cf in doc.descendants().filter(|n| n.tag_name().name() == "conditionalFormatting" && n.tag_name().namespace().map(|u| u.contains("/spreadsheetml/2009/9")).unwrap_or(false)) {
+        let sqref: Vec<CellRange> = x14_cf.children()
+            .find(|n| n.tag_name().name() == "sqref")
+            .and_then(|n| n.text())
+            .map(parse_sqref)
+            .unwrap_or_default();
+        if sqref.is_empty() { continue; }
+        let mut rules: Vec<CfRule> = Vec::new();
+        for x14_rule in x14_cf.children().filter(|n| n.tag_name().name() == "cfRule" && n.attribute("type") == Some("iconSet")) {
+            let priority: i32 = x14_rule.attribute("priority").and_then(|s| s.parse().ok()).unwrap_or(0);
+            let Some(icon_node) = x14_rule.children().find(|n| n.tag_name().name() == "iconSet") else { continue };
+            let custom = icon_node.attribute("custom").map(|v| v == "1" || v == "true").unwrap_or(false);
+            let icon_set_name = icon_node.attribute("iconSet")
+                .unwrap_or(if custom { "" } else { "3TrafficLights1" })
+                .to_string();
+            let reverse = icon_node.attribute("reverse").map(|v| v == "1" || v == "true").unwrap_or(false);
+            let mut cfvos: Vec<CfValue> = Vec::new();
+            let mut custom_icons: Vec<CfIcon> = Vec::new();
+            for ch in icon_node.children().filter(|n| n.is_element()) {
+                match ch.tag_name().name() {
+                    "cfvo" => {
+                        let kind = ch.attribute("type").unwrap_or("percent").to_string();
+                        // x14:cfvo stores the value in `<xm:f>` child; attribute val fallback.
+                        let value = ch.children()
+                            .find(|n| n.tag_name().name() == "f")
+                            .and_then(|n| n.text())
+                            .map(|s| s.to_string())
+                            .or_else(|| ch.attribute("val").map(|s| s.to_string()));
+                        cfvos.push(CfValue { kind, value });
+                    }
+                    "cfIcon" => {
+                        let set = ch.attribute("iconSet").unwrap_or("NoIcons").to_string();
+                        let id = ch.attribute("iconId").and_then(|s| s.parse().ok()).unwrap_or(0);
+                        custom_icons.push(CfIcon { icon_set: set, icon_id: id });
+                    }
+                    _ => {}
+                }
+            }
+            rules.push(CfRule::IconSet {
+                icon_set: icon_set_name,
+                cfvos,
+                reverse,
+                priority,
+                custom_icons: if custom { Some(custom_icons) } else { None },
+            });
+        }
+        if !rules.is_empty() {
+            x14_icon_formats.push(ConditionalFormat { sqref, rules });
+        }
+    }
+
     for node in doc.descendants() {
         match node.tag_name().name() {
             "sheetFormatPr" if node.tag_name().namespace() == Some(ns) => {
@@ -1387,7 +1458,7 @@ fn parse_worksheet(
                                     .collect()
                                 )
                                 .unwrap_or_default();
-                            rules.push(CfRule::IconSet { icon_set, cfvos, reverse, priority });
+                            rules.push(CfRule::IconSet { icon_set, cfvos, reverse, priority, custom_icons: None });
                         }
                         other => {
                             rules.push(CfRule::Other { kind: other.to_string(), priority });
@@ -1399,6 +1470,8 @@ fn parse_worksheet(
             _ => {}
         }
     }
+
+    conditional_formats.extend(x14_icon_formats);
 
     Ok((Worksheet {
         name: name.to_string(),

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -705,7 +705,13 @@ function formatNumberSpec(value: number, numSpec: string): string {
 
 function applyFormatCode(num: number, formatCode: string): string {
   const sections = formatCode.split(';');
-  const section = num < 0 && sections.length > 1 ? sections[1] : sections[0];
+  // Excel number formats have up to 4 sections: positive;negative;zero;text
+  // (§18.8.30). Pick the section matching `num`, falling back to the positive
+  // section when the target one is absent.
+  let section: string;
+  if (num > 0) section = sections[0];
+  else if (num < 0) section = sections.length > 1 ? sections[1] : sections[0];
+  else section = sections.length > 2 ? sections[2] : sections[0];
   const { tokens, numSpec } = tokenizeNumberFormat(section);
   const hasPercent = tokens.some(t => t.kind === 'percent');
   const sciTok = tokens.find(t => t.kind === 'sci') as Extract<FmtToken, { kind: 'sci' }> | undefined;
@@ -1122,7 +1128,15 @@ function evaluateCf(cell: Cell | undefined, row: number, col: number, cfCtx: CfC
         if (numVal >= thresholds[i]) iconIdx = i;
       }
       if (rule.reverse) iconIdx = n - 1 - iconIdx;
-      result.iconSet = { name: rule.iconSet, index: iconIdx };
+      // Custom iconSets (Excel 2010+ x14 extension) override per-threshold icons.
+      if (rule.customIcons && rule.customIcons[iconIdx]) {
+        const ci = rule.customIcons[iconIdx];
+        if (ci.iconSet !== 'NoIcons') {
+          result.iconSet = { name: ci.iconSet, index: ci.iconId };
+        }
+      } else {
+        result.iconSet = { name: rule.iconSet, index: iconIdx };
+      }
     } else if (rule.type === 'colorScale') {
       if (numVal == null || !entry.scaleStops) continue;
       if (result.fill) continue;
@@ -1771,6 +1785,7 @@ const ICON_COLORS_4 = ['#FF0000', '#FF6600', '#FFFF00', '#00B050'];
 const ICON_COLORS_5 = ['#FF0000', '#FF6600', '#FFFF00', '#92D050', '#00B050'];
 
 function drawCfIcon(ctx: CanvasRenderingContext2D, name: string, index: number, x: number, y: number, sz: number): void {
+  if (name === 'NoIcons') return;
   const safeName = name || '3TrafficLights1';
   const nIcons = parseInt(safeName[0]) || 3;
   const palette = nIcons === 5 ? ICON_COLORS_5 : nIcons === 4 ? ICON_COLORS_4 : ICON_COLORS_3;

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -160,8 +160,13 @@ export type CfRule =
   | { type: 'dataBar'; color: string; min: CfValue; max: CfValue; priority: number; gradient: boolean }
   | { type: 'top10'; top: boolean; percent: boolean; rank: number; dxfId: number | null; priority: number }
   | { type: 'aboveAverage'; aboveAverage: boolean; dxfId: number | null; priority: number }
-  | { type: 'iconSet'; iconSet: string; cfvos: CfValue[]; reverse: boolean; priority: number }
+  | { type: 'iconSet'; iconSet: string; cfvos: CfValue[]; reverse: boolean; priority: number; customIcons?: CfIcon[] }
   | { type: 'other'; kind: string; priority: number };
+
+export interface CfIcon {
+  iconSet: string;
+  iconId: number;
+}
 
 export interface CfStop {
   kind: string;


### PR DESCRIPTION
## Summary
- Parse **x14 custom icon sets** from worksheet extLst (Excel 2010+ extension, ECMA-376 §2.6). Custom iconSets define per-threshold icons via \`<x14:cfIcon iconSet iconId/>\` and cfvo values in \`<xm:f>\` children.
- Extend \`CfRule::IconSet\` with optional \`customIcons\`; renderer picks the active icon per threshold and skips \`NoIcons\` entries (no icon, no reserved padding).
- Fix **number-format zero section**: pick section 3 for \`num === 0\` instead of falling back to the positive section. Required so \`\"再発注\";\"\";\"\"\` renders empty for 0.
- Fixes sample-4 column A: red flag icon now appears on A=1 rows, blank on A=0 rows (previously showed stray \"再\").

## Test plan
- [x] WASM rebuild succeeds
- [x] Visual check on private/sample-4.xlsx: A=1 rows show red flag icon, A=0 rows are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)