### PR TITLE
fix(xlsx): render Excel Tables + show frozen row numbers

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -64,6 +64,33 @@ pub struct Worksheet {
     /// workbook. Used by conditional-formatting `expression` rules that call
     /// named ranges like `task_start`, `today`, etc. (ECMA-376 §18.2.5).
     pub defined_names: Vec<DefinedName>,
+    /// Excel Tables defined for this sheet (ECMA-376 §18.5). Rendered with a
+    /// built-in table style (bold header, banded rows, etc.) on top of the
+    /// cells' own styles.
+    pub tables: Vec<TableInfo>,
+}
+
+/// Excel Table metadata (ECMA-376 §18.5 `<table>`). The renderer overlays a
+/// built-in style on top of the cell styles inside `range`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TableInfo {
+    /// Inclusive table area including the header row.
+    pub range: CellRange,
+    /// Built-in style name like "TableStyleLight18" (ECMA-376 §18.5.1.4).
+    pub style_name: String,
+    /// Number of header rows (default 1).
+    pub header_row_count: u32,
+    /// Number of totals rows at the bottom (default 0).
+    pub totals_row_count: u32,
+    /// `<tableStyleInfo showRowStripes>` — banded rows in the data region.
+    pub show_row_stripes: bool,
+    /// `<tableStyleInfo showColumnStripes>`.
+    pub show_column_stripes: bool,
+    /// `<tableStyleInfo showFirstColumn>`.
+    pub show_first_column: bool,
+    /// `<tableStyleInfo showLastColumn>`.
+    pub show_last_column: bool,
 }
 
 /// Workbook- or sheet-scoped defined name (ECMA-376 §18.2.5 `definedName`).
@@ -510,6 +537,7 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
     ws.comment_refs = load_sheet_comment_refs(&mut archive, &sheet_path);
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
+    ws.tables = load_sheet_tables(&mut archive, &sheet_path);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -1493,6 +1521,7 @@ fn parse_worksheet(
         hyperlinks: Vec::new(),
         comment_refs: Vec::new(),
         defined_names: Vec::new(),
+        tables: Vec::new(),
     }, hyperlink_rids))
 }
 
@@ -1551,6 +1580,79 @@ fn load_sheet_comment_refs(
         }
     }
     refs
+}
+
+/// Parse `xl/tables/tableN.xml` files referenced from the sheet rels and
+/// collect them for the renderer. Each table carries a ref range, style name
+/// (e.g. "TableStyleLight18"), and the banded-rows / banded-cols flags from
+/// `<tableStyleInfo>` (ECMA-376 §18.5).
+fn load_sheet_tables(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_path: &str,
+) -> Vec<TableInfo> {
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else { return Vec::new(); };
+    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else { return Vec::new(); };
+
+    let mut table_targets: Vec<String> = Vec::new();
+    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+        if rel.attribute("Type").unwrap_or("").ends_with("/table") {
+            if let Some(t) = rel.attribute("Target") {
+                table_targets.push(t.to_string());
+            }
+        }
+    }
+
+    let mut tables: Vec<TableInfo> = Vec::new();
+    for target in table_targets {
+        let table_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+        let Ok(xml) = read_zip_entry(archive, &table_path) else { continue; };
+        let Ok(doc) = roxmltree::Document::parse(&xml) else { continue; };
+        let root = doc.root_element();
+        let Some(ref_attr) = root.attribute("ref") else { continue };
+        let parts: Vec<&str> = ref_attr.split(':').collect();
+        let range = if parts.len() == 2 {
+            let (left, top) = parse_cell_ref(parts[0]);
+            let (right, bottom) = parse_cell_ref(parts[1]);
+            CellRange { top, left, bottom, right }
+        } else {
+            let (col, row) = parse_cell_ref(parts[0]);
+            CellRange { top: row, left: col, bottom: row, right: col }
+        };
+        let header_row_count: u32 = root.attribute("headerRowCount")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1);
+        let totals_row_count: u32 = root.attribute("totalsRowCount")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        let style_info = root.children().find(|n| n.tag_name().name() == "tableStyleInfo");
+        let style_name = style_info
+            .and_then(|n| n.attribute("name"))
+            .unwrap_or("TableStyleMedium2")
+            .to_string();
+        let bool_attr = |n: &roxmltree::Node, key: &str| n.attribute(key).map(|v| v == "1" || v == "true").unwrap_or(false);
+        let (show_row_stripes, show_column_stripes, show_first_column, show_last_column) = match style_info {
+            Some(n) => (
+                bool_attr(&n, "showRowStripes"),
+                bool_attr(&n, "showColumnStripes"),
+                bool_attr(&n, "showFirstColumn"),
+                bool_attr(&n, "showLastColumn"),
+            ),
+            None => (false, false, false, false),
+        };
+        tables.push(TableInfo {
+            range,
+            style_name,
+            header_row_count,
+            totals_row_count,
+            show_row_stripes,
+            show_column_stripes,
+            show_first_column,
+            show_last_column,
+        });
+    }
+    tables
 }
 
 /// Resolve hyperlink rIds to URLs from the sheet rels file.

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -91,6 +91,10 @@ pub struct TableInfo {
     pub show_first_column: bool,
     /// `<tableStyleInfo showLastColumn>`.
     pub show_last_column: bool,
+    /// Accent color resolved from the built-in style name against this file's
+    /// theme accents (e.g. `TableStyleLight18` → accent3 of theme1.xml). Used
+    /// by the renderer to draw banding, header background, and rules.
+    pub accent_color: String,
 }
 
 /// Workbook- or sheet-scoped defined name (ECMA-376 §18.2.5 `definedName`).
@@ -537,7 +541,7 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
     ws.comment_refs = load_sheet_comment_refs(&mut archive, &sheet_path);
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
-    ws.tables = load_sheet_tables(&mut archive, &sheet_path);
+    ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -1586,9 +1590,33 @@ fn load_sheet_comment_refs(
 /// collect them for the renderer. Each table carries a ref range, style name
 /// (e.g. "TableStyleLight18"), and the banded-rows / banded-cols flags from
 /// `<tableStyleInfo>` (ECMA-376 §18.5).
+/// Resolve a built-in table style's accent color from the theme.
+///
+/// Built-in style names follow the pattern `TableStyle{Light|Medium|Dark}{N}`
+/// (ECMA-376 §18.5.1.4). Excel's UI lays the 21/28/11 built-ins out in a grid
+/// of rows × 7 columns: column 0 is a "none" style (no accent), columns 1–6
+/// map to accent1–accent6. So the accent index is `(N - 1) mod 7` where 0
+/// means "no accent" and 1..=6 map to the theme's accent slots.
+///
+/// `theme_colors` is in OOXML natural order — accent1 lives at index 4, so
+/// accent_n is at `theme_colors[3 + n]`. Falls back to a neutral gray when
+/// the style name is unrecognised or the theme is missing accents.
+fn resolve_table_style_accent(style_name: &str, theme_colors: &[String]) -> String {
+    let fallback = "#808080".to_string();
+    let Some(rest) = style_name.strip_prefix("TableStyle") else { return fallback; };
+    let digits_start = rest.find(|c: char| c.is_ascii_digit());
+    let Some(start) = digits_start else { return fallback; };
+    let Ok(n) = rest[start..].parse::<u32>() else { return fallback; };
+    if n == 0 { return fallback; }
+    let slot = ((n - 1) % 7) as usize;
+    if slot == 0 { return fallback; }
+    theme_colors.get(3 + slot).cloned().unwrap_or(fallback)
+}
+
 fn load_sheet_tables(
     archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
     sheet_path: &str,
+    theme_colors: &[String],
 ) -> Vec<TableInfo> {
     let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
@@ -1641,6 +1669,7 @@ fn load_sheet_tables(
             ),
             None => (false, false, false, false),
         };
+        let accent_color = resolve_table_style_accent(&style_name, theme_colors);
         tables.push(TableInfo {
             range,
             style_name,
@@ -1650,6 +1679,7 @@ fn load_sheet_tables(
             show_column_stripes,
             show_first_column,
             show_last_column,
+            accent_color,
         });
     }
     tables

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1858,24 +1858,10 @@ export interface TableCellStyle {
   isBottomEdge: boolean;
 }
 
-// Office 2016 default-theme accent palette. Used only as a fallback when
-// `TableStyleLight<N>` is resolved without any file-level theme lookup.
-const DEFAULT_ACCENTS = ['#4472C4', '#ED7D31', '#A5A5A5', '#FFC000', '#5B9BD5', '#70AD47'];
-
-function accentForTableStyle(name: string): string {
-  const m = name.match(/^TableStyle(Light|Medium|Dark)(\d+)$/);
-  if (!m) return '#808080';
-  const n = parseInt(m[2], 10);
-  if (m[1] === 'Light' && n === 1) return '#000000';
-  if (m[1] === 'Medium' && n === 1) return '#808080';
-  if (m[1] === 'Dark' && n === 1) return '#000000';
-  return DEFAULT_ACCENTS[((n - 2) % 6 + 6) % 6];
-}
-
 function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
   const map = new Map<string, TableCellStyle>();
   for (const t of worksheet.tables ?? []) {
-    const accent = accentForTableStyle(t.styleName);
+    const accent = t.accentColor || '#808080';
     const hdr = Math.max(0, t.headerRowCount ?? 1);
     const tot = Math.max(0, t.totalsRowCount ?? 0);
     const { top, bottom, left, right } = t.range;

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1775,6 +1775,8 @@ interface RenderContext {
   /** row:col keys for cells that carry a comment; renderer draws a small
    *  red triangle in the top-right corner (ECMA-376 §18.7.3 commentList). */
   commentCells: Set<string>;
+  /** row:col → table-style overlay (bold header, banded rows, borders). */
+  tableStyleMap: Map<string, TableCellStyle>;
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -1835,6 +1837,81 @@ function drawAutoFilterArrow(ctx: CanvasRenderingContext2D, cx: number, cy: numb
   ctx.closePath();
   ctx.fill();
   ctx.restore();
+}
+
+// ────────────────────────────────────────────────────────────────
+// Excel Table style overlays (ECMA-376 §18.5)
+// ────────────────────────────────────────────────────────────────
+// We don't ship the full built-in table-style catalog — instead we derive a
+// single "accent" color from the style name and overlay bold header + banded
+// fills + horizontal rules so that `TableStyle*` files render with visible
+// structure rather than as blank ranges.
+export interface TableCellStyle {
+  accent: string;
+  isHeader: boolean;
+  isTotals: boolean;
+  /** `true` when this is a banded data row that should get the stripe fill. */
+  isBanded: boolean;
+  isFirstCol: boolean;
+  isLastCol: boolean;
+  isTopEdge: boolean;
+  isBottomEdge: boolean;
+}
+
+// Office 2016 default-theme accent palette. Used only as a fallback when
+// `TableStyleLight<N>` is resolved without any file-level theme lookup.
+const DEFAULT_ACCENTS = ['#4472C4', '#ED7D31', '#A5A5A5', '#FFC000', '#5B9BD5', '#70AD47'];
+
+function accentForTableStyle(name: string): string {
+  const m = name.match(/^TableStyle(Light|Medium|Dark)(\d+)$/);
+  if (!m) return '#808080';
+  const n = parseInt(m[2], 10);
+  if (m[1] === 'Light' && n === 1) return '#000000';
+  if (m[1] === 'Medium' && n === 1) return '#808080';
+  if (m[1] === 'Dark' && n === 1) return '#000000';
+  return DEFAULT_ACCENTS[((n - 2) % 6 + 6) % 6];
+}
+
+function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
+  const map = new Map<string, TableCellStyle>();
+  for (const t of worksheet.tables ?? []) {
+    const accent = accentForTableStyle(t.styleName);
+    const hdr = Math.max(0, t.headerRowCount ?? 1);
+    const tot = Math.max(0, t.totalsRowCount ?? 0);
+    const { top, bottom, left, right } = t.range;
+    const headerEnd = top + hdr - 1;
+    const totalsStart = bottom - tot + 1;
+    for (let r = top; r <= bottom; r++) {
+      const isHeader = hdr > 0 && r <= headerEnd;
+      const isTotals = tot > 0 && r >= totalsStart;
+      const dataIdx = (!isHeader && !isTotals) ? (r - headerEnd - 1) : -1;
+      for (let c = left; c <= right; c++) {
+        map.set(`${r}:${c}`, {
+          accent,
+          isHeader,
+          isTotals,
+          isBanded: t.showRowStripes && dataIdx >= 0 && dataIdx % 2 === 1,
+          isFirstCol: t.showFirstColumn && c === left,
+          isLastCol: t.showLastColumn && c === right,
+          isTopEdge: r === top,
+          isBottomEdge: r === bottom,
+        });
+      }
+    }
+  }
+  return map;
+}
+
+function stripeColorFor(accent: string): string {
+  // Light tint of the accent — mimics TableStyleLight* banded rows.
+  const hex = accent.replace('#', '');
+  if (hex.length < 6) return '#F2F2F2';
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const mix = (ch: number) => Math.round(ch * 0.2 + 255 * 0.8);
+  const toHex = (v: number) => v.toString(16).padStart(2, '0').toUpperCase();
+  return `#${toHex(mix(r))}${toHex(mix(g))}${toHex(mix(b))}`;
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -2001,6 +2078,7 @@ function renderQuadrant(
       const { font, fill, border, xf } = resolveXf(styles, styleIndex);
       const cf = evaluateCf(cell, rowIndex, colIndex, cfContext, styles.dxfs ?? []);
       const effectiveFill = cf.fill ?? fill;
+      const tableStyle = rc.tableStyleMap.get(key);
 
       // Background fill (base or CF override). ECMA-376 §18.8.22 ST_PatternType.
       // - solid/gray*: blend fgColor with bgColor at the pattern's fg coverage.
@@ -2022,6 +2100,9 @@ function renderQuadrant(
             ? hexToRgba(effectiveFill.fgColor)
             : blendHex(effectiveFill.fgColor, bg, coverage);
         }
+        ctx.fillRect(cx, cy, cellW, cellH);
+      } else if (tableStyle && tableStyle.isBanded) {
+        ctx.fillStyle = stripeColorFor(tableStyle.accent);
         ctx.fillRect(cx, cy, cellW, cellH);
       }
 
@@ -2072,6 +2153,24 @@ function renderQuadrant(
         : border;
       renderBorder(ctx, mergeBorders(baseBorder, cf.border), cx, cy, cellW, cellH);
 
+      // Excel Table style overlay: thin horizontal rules between rows and a
+      // thicker bottom edge under the header row (ECMA-376 §18.5). Drawn on
+      // top of cell borders so an empty-border data cell still shows table
+      // structure.
+      if (tableStyle) {
+        const hp = 0.5 / dpr;
+        ctx.strokeStyle = tableStyle.accent;
+        ctx.lineWidth = tableStyle.isHeader ? 1.5 : 1;
+        ctx.beginPath();
+        ctx.moveTo(cx, cy + cellH - hp);
+        ctx.lineTo(cx + cellW, cy + cellH - hp);
+        if (tableStyle.isTopEdge) {
+          ctx.moveTo(cx, cy + hp);
+          ctx.lineTo(cx + cellW, cy + hp);
+        }
+        ctx.stroke();
+      }
+
       // AutoFilter dropdown indicator
       if (rc.autoFilterCells.has(key)) {
         drawAutoFilterArrow(ctx, cx, cy, cw, cellH);
@@ -2081,7 +2180,8 @@ function renderQuadrant(
       const text = formatCellValue(cell, styles);
       if (!text || (text === '0' && rc.worksheet.showZeros === false)) continue;
 
-      const effectiveBold = font.bold || !!cf.fontBold;
+      const tableBold = !!(tableStyle && (tableStyle.isHeader || tableStyle.isTotals));
+      const effectiveBold = font.bold || !!cf.fontBold || tableBold;
       const effectiveItalic = font.italic || !!cf.fontItalic;
       const effectiveUnderline = font.underline || !!cf.fontUnderline;
       const effectiveStrike = font.strike || !!cf.fontStrike;
@@ -2528,6 +2628,8 @@ export function renderViewport(
     if (parsed) commentCells.add(`${parsed.row}:${parsed.col}`);
   }
 
+  const tableStyleMap = buildTableStyleMap(worksheet);
+
   const rc: RenderContext = {
     worksheet, styles, cellMap, mergeAnchorMap, mergeSkipSet, cfContext,
     colWidths: scrollColWidths,
@@ -2540,6 +2642,7 @@ export function renderViewport(
     autoFilterCells,
     hyperlinkMap,
     commentCells,
+    tableStyleMap,
   };
 
   // Canvas areas for each quadrant
@@ -2776,16 +2879,6 @@ function renderHeaders(
   }
   ctx.restore();
 
-  // Cover frozen area corner (where row/col headers meet)
-  if (frozenW > 0 || frozenH > 0) {
-    ctx.fillStyle = HEADER_BG;
-    if (frozenW > 0) {
-      ctx.fillRect(0, hh, hw, frozenH);
-    }
-    if (frozenH > 0) {
-      ctx.fillRect(hw, 0, frozenW, hh);
-    }
-  }
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -61,6 +61,9 @@ export interface TableInfo {
   showColumnStripes: boolean;
   showFirstColumn: boolean;
   showLastColumn: boolean;
+  /** Accent color resolved by the parser from the built-in style name against
+   *  the file's theme accents (e.g. `TableStyleLight18` → accent3). */
+  accentColor: string;
 }
 
 export interface DefinedName {

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -47,6 +47,20 @@ export interface Worksheet {
    *  conditional-formatting `expression` rules that call named ranges
    *  (e.g. `task_start`, `today`). */
   definedNames?: DefinedName[];
+  /** Excel Tables on this sheet (ECMA-376 §18.5). The renderer overlays a
+   *  built-in style (bold header, banded rows) on the given ranges. */
+  tables?: TableInfo[];
+}
+
+export interface TableInfo {
+  range: CellRange;
+  styleName: string;
+  headerRowCount: number;
+  totalsRowCount: number;
+  showRowStripes: boolean;
+  showColumnStripes: boolean;
+  showFirstColumn: boolean;
+  showLastColumn: boolean;
 }
 
 export interface DefinedName {


### PR DESCRIPTION
## Summary

Three fixes reported on private/sample-8:

1. **Row numbers 1 and 2 were missing from the row header gutter.** The post-draw "cover frozen area corner" block was wiping the freshly drawn frozen row/col header strips. The top-left corner is already painted at the start of `renderHeaders`, so the extra cover is dropped.

2. **Row 2 (table header) was not bold** and **rows 3-7 had no borders or fills.** The file defines an Excel Table (`xl/tables/table1.xml`) with `TableStyleLight18` + `showRowStripes="1"` — the bold header, horizontal rules, and banded-row fills come from the built-in table style, which we did not read.

## Implementation

- **Parser**: `load_sheet_tables` walks the sheet rels for `/table` relationships, parses each `xl/tables/tableN.xml`, and exposes `TableInfo { range, styleName, headerRowCount, totalsRowCount, showRowStripes, ... }` on `Worksheet`.
- **Renderer**: `buildTableStyleMap` produces a row:col → `TableCellStyle` lookup. During cell render:
  - Header (and totals) rows get a bold overlay.
  - Every row in the table range gets a thin horizontal rule; the header row's bottom is thicker.
  - Banded data rows get a light stripe fill only when the cell has no explicit fill.
- The accent color is derived from `TableStyle{Light,Medium,Dark}N` by index into the Office 2016 default accent palette — full theme-aware table-style lookup is left as future work.

## Test plan

- [x] sample-8 renders row 1 + 2 gutter numbers, bold row 2 headers, visible borders on rows 3–7
- [x] sample-4 (existing custom iconSet with its own table) continues to render correctly
- [x] sample-5 (merge borders, hard line break, numeric overflow) unchanged
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)