### PR TITLE
fix(xlsx): sample-10 calendar rendering fixes

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -42,6 +42,10 @@ pub struct Worksheet {
     pub conditional_formats: Vec<ConditionalFormat>,
     pub images: Vec<ImageAnchor>,
     pub charts: Vec<ChartAnchor>,
+    /// Grouped shapes from `<xdr:grpSp>` inside a twoCellAnchor (ECMA-376
+    /// §20.5.2.17). Each anchor flattens its shape tree to a list of leaf
+    /// shapes with normalized geometry for the renderer.
+    pub shape_groups: Vec<ShapeAnchor>,
     /// Whether to display zero values in cells (ECMA-376 §18.3.1.94)
     pub show_zeros: bool,
     /// Whether to draw default grid lines on this sheet. Mirrors the "View →
@@ -218,6 +222,80 @@ pub struct ChartAnchor {
     pub to_row: u32,
     pub to_row_off: i64,
     pub chart: ChartData,
+}
+
+/// A grouped-shape anchor (ECMA-376 §20.5.2.17, `<xdr:grpSp>` inside a
+/// `<xdr:twoCellAnchor>`). Leaf shape elements (`<xdr:sp>`) from any nesting
+/// level are flattened into `shapes` with normalized coordinates so the
+/// renderer only needs to scale to the anchor rect.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShapeAnchor {
+    pub from_col: u32,
+    pub from_col_off: i64,
+    pub from_row: u32,
+    pub from_row_off: i64,
+    pub to_col: u32,
+    pub to_col_off: i64,
+    pub to_row: u32,
+    pub to_row_off: i64,
+    pub shapes: Vec<ShapeInfo>,
+}
+
+/// A leaf shape extracted from a grpSp/sp tree. Position/size are normalized
+/// to [0,1] relative to the top-level grpSp extent (which itself maps to the
+/// anchor rect).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShapeInfo {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+    /// Rotation in degrees (clockwise). DrawingML `a:xfrm/@rot` is in 60000ths
+    /// of a degree; the parser converts to degrees here.
+    pub rot: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stroke_color: Option<String>,
+    /// Stroke width in EMU (914400 = 1 inch). 0 = no stroke.
+    pub stroke_width: i64,
+    pub geom: ShapeGeom,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ShapeGeom {
+    /// Preset geometry (rect, ellipse, roundRect, triangle, etc.).
+    /// ECMA-376 §20.1.9.18 `a:prstGeom/@prst`.
+    Preset { name: String },
+    /// Freeform path geometry (ECMA-376 §20.1.9.2 `a:custGeom`).
+    Custom { paths: Vec<PathInfo> },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathInfo {
+    /// Path's own coordinate system width.
+    pub w: f64,
+    /// Path's own coordinate system height.
+    pub h: f64,
+    pub commands: Vec<PathCmd>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "op", rename_all = "camelCase")]
+pub enum PathCmd {
+    MoveTo { x: f64, y: f64 },
+    LineTo { x: f64, y: f64 },
+    CubicBezTo { x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64 },
+    QuadBezTo { x1: f64, y1: f64, x2: f64, y2: f64 },
+    /// ECMA-376 §20.1.9.3 `a:arcTo`. `stAng`/`swAng` are in 60000ths of a
+    /// degree. The start point is the current pen position; the ellipse
+    /// center is derived so the pen lies on the ellipse at `stAng`.
+    ArcTo { wr: f64, hr: f64, st_ang: f64, sw_ang: f64 },
+    Close,
 }
 
 /// An image anchored to a rectangular range of cells
@@ -565,6 +643,7 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     // Attach any drawing-anchored images and charts for this sheet
     ws.images = load_sheet_images(&mut archive, &sheet_path);
     ws.charts = load_sheet_charts(&mut archive, &sheet_path, &theme_colors);
+    ws.shape_groups = load_sheet_shape_groups(&mut archive, &sheet_path, &theme_colors);
     ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
     ws.comment_refs = load_sheet_comment_refs(&mut archive, &sheet_path);
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
@@ -1398,7 +1477,15 @@ fn parse_worksheet(
                                 .collect();
                             rules.push(CfRule::CellIs { operator, formulas, dxf_id, priority });
                         }
-                        "expression" => {
+                        "expression"
+                        | "containsBlanks" | "notContainsBlanks"
+                        | "containsText" | "notContainsText"
+                        | "beginsWith" | "endsWith"
+                        | "containsErrors" | "notContainsErrors" => {
+                            // For `containsBlanks`/`notContainsBlanks`/`containsText` etc.,
+                            // Excel serializes an equivalent boolean formula (e.g.
+                            // `LEN(TRIM(C8))>0`) as the rule's `<formula>` child
+                            // (ECMA-376 §18.3.1.10). Evaluate as an expression rule.
                             let formula = cf.children()
                                 .find(|n| n.tag_name().name() == "formula")
                                 .and_then(|n| n.text())
@@ -1547,6 +1634,7 @@ fn parse_worksheet(
         conditional_formats,
         images: Vec::new(),
         charts: Vec::new(),
+        shape_groups: Vec::new(),
         show_zeros,
         show_gridlines,
         tab_color,
@@ -1896,6 +1984,375 @@ fn parse_drawing_anchors(
         });
     }
     anchors
+}
+
+// ─── Shape group parsing ────────────────────────────────────────────────────
+//
+// ECMA-376 §20.5.2.17 `<xdr:grpSp>` / §20.1.9 DrawingML shapes. Each
+// top-level grpSp inside a twoCellAnchor has its own coordinate system:
+//   - grpSpPr/xfrm/off,ext     : group's position/size in parent coords
+//   - grpSpPr/xfrm/chOff,chExt : origin/extent of the group's child coords
+//
+// A child sp at child coord (cx, cy) maps to parent coord:
+//   parent.x = off.x + (cx - chOff.x) / chExt.cx * ext.cx
+//
+// For rendering, we chain these transforms down to the top-level grpSp and
+// then normalize each leaf shape's rect into [0,1] of the top-level ext.
+
+#[derive(Clone, Copy)]
+struct Xfrm {
+    off_x: f64, off_y: f64,
+    ext_x: f64, ext_y: f64,
+    ch_off_x: f64, ch_off_y: f64,
+    ch_ext_x: f64, ch_ext_y: f64,
+    has_ch: bool,
+}
+
+fn parse_xfrm(xfrm_node: &roxmltree::Node) -> Option<Xfrm> {
+    let mut off = (0.0_f64, 0.0_f64);
+    let mut ext = (0.0_f64, 0.0_f64);
+    let mut ch_off = (0.0_f64, 0.0_f64);
+    let mut ch_ext = (0.0_f64, 0.0_f64);
+    let mut has_ext = false;
+    let mut has_ch = false;
+    for c in xfrm_node.children() {
+        match c.tag_name().name() {
+            "off" => {
+                off.0 = c.attribute("x").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                off.1 = c.attribute("y").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+            }
+            "ext" => {
+                ext.0 = c.attribute("cx").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                ext.1 = c.attribute("cy").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                has_ext = true;
+            }
+            "chOff" => {
+                ch_off.0 = c.attribute("x").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                ch_off.1 = c.attribute("y").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                has_ch = true;
+            }
+            "chExt" => {
+                ch_ext.0 = c.attribute("cx").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                ch_ext.1 = c.attribute("cy").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                has_ch = true;
+            }
+            _ => {}
+        }
+    }
+    if !has_ext { return None; }
+    Some(Xfrm {
+        off_x: off.0, off_y: off.1,
+        ext_x: ext.0, ext_y: ext.1,
+        ch_off_x: ch_off.0, ch_off_y: ch_off.1,
+        ch_ext_x: if ch_ext.0 == 0.0 { ext.0 } else { ch_ext.0 },
+        ch_ext_y: if ch_ext.1 == 0.0 { ext.1 } else { ch_ext.1 },
+        has_ch,
+    })
+}
+
+fn parse_solid_fill(fill_node: &roxmltree::Node, theme_colors: &[String]) -> Option<String> {
+    for c in fill_node.children() {
+        match c.tag_name().name() {
+            "srgbClr" => {
+                let v = c.attribute("val")?;
+                return Some(format!("#{}", v.to_uppercase()));
+            }
+            "schemeClr" => {
+                let v = c.attribute("val")?;
+                let idx = match v {
+                    "lt1" | "bg1"    => Some(0),
+                    "dk1" | "tx1"    => Some(1),
+                    "lt2" | "bg2"    => Some(2),
+                    "dk2" | "tx2"    => Some(3),
+                    "accent1"        => Some(4),
+                    "accent2"        => Some(5),
+                    "accent3"        => Some(6),
+                    "accent4"        => Some(7),
+                    "accent5"        => Some(8),
+                    "accent6"        => Some(9),
+                    "hlink"          => Some(10),
+                    "folHlink"       => Some(11),
+                    _ => None,
+                };
+                return idx.and_then(|i| theme_colors.get(i).cloned());
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Parse a single custGeom path element. Each path has its own coordinate
+/// system (`a:path/@w`, `@h`) that the renderer scales to the shape's rect.
+fn parse_custom_path(path_node: &roxmltree::Node) -> PathInfo {
+    let w: f64 = path_node.attribute("w").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+    let h: f64 = path_node.attribute("h").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+    let mut commands: Vec<PathCmd> = Vec::new();
+    for cmd in path_node.children().filter(|n| n.is_element()) {
+        let name = cmd.tag_name().name();
+        // Collect `<a:pt x=.. y=..>` points in order.
+        let pts: Vec<(f64, f64)> = cmd.children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+            .map(|n| (
+                n.attribute("x").and_then(|s| s.parse().ok()).unwrap_or(0.0),
+                n.attribute("y").and_then(|s| s.parse().ok()).unwrap_or(0.0),
+            ))
+            .collect();
+        match name {
+            "moveTo"       => if let Some(p) = pts.first() { commands.push(PathCmd::MoveTo { x: p.0, y: p.1 }); },
+            "lnTo"         => if let Some(p) = pts.first() { commands.push(PathCmd::LineTo { x: p.0, y: p.1 }); },
+            "cubicBezTo"   => if pts.len() >= 3 {
+                commands.push(PathCmd::CubicBezTo {
+                    x1: pts[0].0, y1: pts[0].1,
+                    x2: pts[1].0, y2: pts[1].1,
+                    x3: pts[2].0, y3: pts[2].1,
+                });
+            },
+            "quadBezTo"    => if pts.len() >= 2 {
+                commands.push(PathCmd::QuadBezTo {
+                    x1: pts[0].0, y1: pts[0].1,
+                    x2: pts[1].0, y2: pts[1].1,
+                });
+            },
+            "close"        => commands.push(PathCmd::Close),
+            "arcTo" => {
+                // ECMA-376 §20.1.9.3: `wR`/`hR` in path-coord units;
+                // `stAng`/`swAng` in 60000ths of a degree.
+                let wr:     f64 = cmd.attribute("wR").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                let hr:     f64 = cmd.attribute("hR").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                let st_ang: f64 = cmd.attribute("stAng").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                let sw_ang: f64 = cmd.attribute("swAng").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                commands.push(PathCmd::ArcTo { wr, hr, st_ang, sw_ang });
+            }
+            _ => {}
+        }
+    }
+    PathInfo { w, h, commands }
+}
+
+fn parse_sp_geom(sp_pr: &roxmltree::Node) -> Option<ShapeGeom> {
+    for c in sp_pr.children().filter(|n| n.is_element()) {
+        match c.tag_name().name() {
+            "prstGeom" => {
+                return Some(ShapeGeom::Preset {
+                    name: c.attribute("prst").unwrap_or("rect").to_string(),
+                });
+            }
+            "custGeom" => {
+                let mut paths: Vec<PathInfo> = Vec::new();
+                for pl in c.children().filter(|n| n.is_element() && n.tag_name().name() == "pathLst") {
+                    for p in pl.children().filter(|n| n.is_element() && n.tag_name().name() == "path") {
+                        paths.push(parse_custom_path(&p));
+                    }
+                }
+                return Some(ShapeGeom::Custom { paths });
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Recursively walk an `xdr:grpSp` / `xdr:sp` tree, chaining coordinate
+/// transforms, and push leaf shapes (normalized to [0,1] of `root_ext`) into
+/// `out`.
+fn collect_shapes(
+    node: &roxmltree::Node,
+    root_off_x: f64, root_off_y: f64,
+    root_ext_x: f64, root_ext_y: f64,
+    // transform from current local coords into root (top-level grpSp) coords
+    scale_x: f64, scale_y: f64,
+    trans_x: f64, trans_y: f64,
+    theme_colors: &[String],
+    out: &mut Vec<ShapeInfo>,
+) {
+    for child in node.children().filter(|n| n.is_element()) {
+        let tag = child.tag_name().name();
+        if tag == "grpSp" {
+            // Nested grpSp: compose the transform by the group's own xfrm.
+            let grp_sp_pr = child.children().find(|n| n.is_element() && n.tag_name().name() == "grpSpPr");
+            let xfrm = grp_sp_pr
+                .and_then(|n| n.children().find(|c| c.is_element() && c.tag_name().name() == "xfrm"))
+                .as_ref()
+                .and_then(parse_xfrm);
+            let (sx, sy, tx, ty) = if let Some(x) = xfrm {
+                if x.has_ch && x.ch_ext_x != 0.0 && x.ch_ext_y != 0.0 {
+                    let csx = x.ext_x / x.ch_ext_x;
+                    let csy = x.ext_y / x.ch_ext_y;
+                    // Child point (cx, cy) → (x.off_x + (cx - x.ch_off_x)*csx) in parent coords,
+                    // then apply outer (scale/trans) to reach root coords.
+                    (
+                        scale_x * csx,
+                        scale_y * csy,
+                        trans_x + scale_x * (x.off_x - x.ch_off_x * csx),
+                        trans_y + scale_y * (x.off_y - x.ch_off_y * csy),
+                    )
+                } else {
+                    // No child coord system: treat as identity mapping inside the group.
+                    (scale_x, scale_y,
+                     trans_x + scale_x * x.off_x,
+                     trans_y + scale_y * x.off_y)
+                }
+            } else {
+                (scale_x, scale_y, trans_x, trans_y)
+            };
+            collect_shapes(&child, root_off_x, root_off_y, root_ext_x, root_ext_y,
+                           sx, sy, tx, ty, theme_colors, out);
+        } else if tag == "sp" {
+            let sp_pr = child.children().find(|n| n.is_element() && n.tag_name().name() == "spPr");
+            let Some(sp_pr) = sp_pr else { continue; };
+            let xfrm_node = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm");
+            let Some(xfrm_n) = xfrm_node else { continue; };
+            let Some(xfrm) = parse_xfrm(&xfrm_n) else { continue; };
+            let rot_raw: f64 = xfrm_n.attribute("rot")
+                .and_then(|s| s.parse().ok()).unwrap_or(0.0);
+
+            // Shape rect in root coords
+            let root_x = trans_x + scale_x * xfrm.off_x;
+            let root_y = trans_y + scale_y * xfrm.off_y;
+            let root_w = scale_x * xfrm.ext_x;
+            let root_h = scale_y * xfrm.ext_y;
+
+            // Normalize to [0,1] of root ext
+            if root_ext_x == 0.0 || root_ext_y == 0.0 { continue; }
+            let nx = (root_x - root_off_x) / root_ext_x;
+            let ny = (root_y - root_off_y) / root_ext_y;
+            let nw = root_w / root_ext_x;
+            let nh = root_h / root_ext_y;
+
+            let geom = parse_sp_geom(&sp_pr);
+            let Some(geom) = geom else { continue; };
+
+            // Fill
+            let mut fill_color: Option<String> = None;
+            let mut has_no_fill = false;
+            for c in sp_pr.children().filter(|n| n.is_element()) {
+                match c.tag_name().name() {
+                    "solidFill" => { fill_color = parse_solid_fill(&c, theme_colors); }
+                    "noFill"    => { has_no_fill = true; }
+                    _ => {}
+                }
+            }
+            if has_no_fill { fill_color = None; }
+
+            // Stroke (line)
+            let mut stroke_color: Option<String> = None;
+            let mut stroke_width: i64 = 0;
+            if let Some(ln) = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "ln") {
+                stroke_width = ln.attribute("w").and_then(|s| s.parse().ok()).unwrap_or(0);
+                for c in ln.children().filter(|n| n.is_element()) {
+                    if c.tag_name().name() == "solidFill" {
+                        stroke_color = parse_solid_fill(&c, theme_colors);
+                    } else if c.tag_name().name() == "noFill" {
+                        stroke_color = None;
+                        stroke_width = 0;
+                    }
+                }
+            }
+
+            out.push(ShapeInfo {
+                x: nx, y: ny, w: nw, h: nh,
+                rot: rot_raw / 60000.0,
+                fill_color,
+                stroke_color,
+                stroke_width,
+                geom,
+            });
+        }
+        // Ignore `xdr:pic` / `xdr:cxnSp` / text elements for this minimal pass.
+    }
+}
+
+fn parse_shape_anchors(
+    drawing_xml: &str,
+    theme_colors: &[String],
+) -> Vec<ShapeAnchor> {
+    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else { return Vec::new(); };
+    let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+    let mut anchors: Vec<ShapeAnchor> = Vec::new();
+
+    for anchor in doc.descendants() {
+        if anchor.tag_name().name() != "twoCellAnchor"
+            || anchor.tag_name().namespace() != Some(xdr_ns) { continue; }
+        // Only anchors whose top-level child is `<xdr:grpSp>`.
+        let grp = anchor.children().find(|n| n.is_element() && n.tag_name().name() == "grpSp");
+        let Some(grp) = grp else { continue; };
+        let grp_sp_pr = grp.children().find(|n| n.is_element() && n.tag_name().name() == "grpSpPr");
+        let xfrm = grp_sp_pr
+            .and_then(|n| n.children().find(|c| c.is_element() && c.tag_name().name() == "xfrm"))
+            .as_ref()
+            .and_then(parse_xfrm);
+        let Some(root) = xfrm else { continue; };
+        if !root.has_ch || root.ch_ext_x == 0.0 || root.ch_ext_y == 0.0 { continue; }
+
+        // Parse from/to anchor rect
+        let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) = (0u32, 0i64, 0u32, 0i64);
+        let (mut to_col,   mut to_col_off,   mut to_row,   mut to_row_off)   = (0u32, 0i64, 0u32, 0i64);
+        for c in anchor.children() {
+            if !c.is_element() { continue; }
+            if c.tag_name().name() == "from" || c.tag_name().name() == "to" {
+                let is_from = c.tag_name().name() == "from";
+                let mut col: u32 = 0; let mut col_off: i64 = 0;
+                let mut row: u32 = 0; let mut row_off: i64 = 0;
+                for cc in c.children() {
+                    match (cc.tag_name().name(), cc.text()) {
+                        ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                        ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
+                        ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                        ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
+                        _ => {}
+                    }
+                }
+                if is_from {
+                    from_col = col; from_col_off = col_off; from_row = row; from_row_off = row_off;
+                } else {
+                    to_col = col; to_col_off = col_off; to_row = row; to_row_off = row_off;
+                }
+            }
+        }
+
+        // Map child coords → root coords with the grpSp's own chOff/chExt.
+        let csx = root.ext_x / root.ch_ext_x;
+        let csy = root.ext_y / root.ch_ext_y;
+        let tx = root.off_x - root.ch_off_x * csx;
+        let ty = root.off_y - root.ch_off_y * csy;
+
+        let mut shapes: Vec<ShapeInfo> = Vec::new();
+        collect_shapes(&grp, root.off_x, root.off_y, root.ext_x, root.ext_y,
+                       csx, csy, tx, ty, theme_colors, &mut shapes);
+        if shapes.is_empty() { continue; }
+
+        anchors.push(ShapeAnchor {
+            from_col, from_col_off, from_row, from_row_off,
+            to_col, to_col_off, to_row, to_row_off,
+            shapes,
+        });
+    }
+    anchors
+}
+
+fn load_sheet_shape_groups(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_path: &str,
+    theme_colors: &[String],
+) -> Vec<ShapeAnchor> {
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else { return Vec::new(); };
+    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else { return Vec::new(); };
+    let mut drawing_targets: Vec<String> = Vec::new();
+    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+        if rel.attribute("Type").unwrap_or("").ends_with("/drawing") {
+            if let Some(t) = rel.attribute("Target") { drawing_targets.push(t.to_string()); }
+        }
+    }
+    let mut all: Vec<ShapeAnchor> = Vec::new();
+    for target in drawing_targets {
+        let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
+        all.extend(parse_shape_anchors(&drawing_xml, theme_colors));
+    }
+    all
 }
 
 /// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -272,6 +272,10 @@ pub enum ShapeGeom {
     Preset { name: String },
     /// Freeform path geometry (ECMA-376 §20.1.9.2 `a:custGeom`).
     Custom { paths: Vec<PathInfo> },
+    /// Bitmap image leaf inside a `<xdr:grpSp>` tree (ECMA-376 §20.5.2.17).
+    /// `data_url` is a `data:<mime>;base64,…` URL produced from the drawing's
+    /// relationship target (png/jpg/gif/…).
+    Image { data_url: String },
 }
 
 #[derive(Debug, Serialize)]
@@ -2059,11 +2063,16 @@ fn parse_solid_fill(fill_node: &roxmltree::Node, theme_colors: &[String]) -> Opt
             }
             "schemeClr" => {
                 let v = c.attribute("val")?;
+                // `theme_colors` is collected in OOXML clrScheme document
+                // order: dk1, lt1, dk2, lt2, accent1..accent6, hlink,
+                // folHlink. See `parse_theme_colors`. The earlier mapping
+                // here had dk1/lt1 and dk2/lt2 swapped which darkened
+                // shapes that painted "lt1" (the sheet paper colour).
                 let idx = match v {
-                    "lt1" | "bg1"    => Some(0),
-                    "dk1" | "tx1"    => Some(1),
-                    "lt2" | "bg2"    => Some(2),
-                    "dk2" | "tx2"    => Some(3),
+                    "dk1" | "tx1"    => Some(0),
+                    "lt1" | "bg1"    => Some(1),
+                    "dk2" | "tx2"    => Some(2),
+                    "lt2" | "bg2"    => Some(3),
                     "accent1"        => Some(4),
                     "accent2"        => Some(5),
                     "accent3"        => Some(6),
@@ -2164,6 +2173,7 @@ fn collect_shapes(
     scale_x: f64, scale_y: f64,
     trans_x: f64, trans_y: f64,
     theme_colors: &[String],
+    rid_urls: &HashMap<String, String>,
     out: &mut Vec<ShapeInfo>,
 ) {
     for child in node.children().filter(|n| n.is_element()) {
@@ -2197,7 +2207,7 @@ fn collect_shapes(
                 (scale_x, scale_y, trans_x, trans_y)
             };
             collect_shapes(&child, root_off_x, root_off_y, root_ext_x, root_ext_y,
-                           sx, sy, tx, ty, theme_colors, out);
+                           sx, sy, tx, ty, theme_colors, rid_urls, out);
         } else if tag == "sp" {
             let sp_pr = child.children().find(|n| n.is_element() && n.tag_name().name() == "spPr");
             let Some(sp_pr) = sp_pr else { continue; };
@@ -2258,14 +2268,59 @@ fn collect_shapes(
                 stroke_width,
                 geom,
             });
+        } else if tag == "pic" {
+            // `<xdr:pic>` leaf inside a group (ECMA-376 §20.5.2.17). The image
+            // binary is resolved via the drawing's .rels file; `rid_urls` maps
+            // each r:id to its pre-encoded `data:<mime>;base64,…` URL.
+            let sp_pr = child.children().find(|n| n.is_element() && n.tag_name().name() == "spPr");
+            let Some(sp_pr) = sp_pr else { continue; };
+            let xfrm_node = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm");
+            let Some(xfrm_n) = xfrm_node else { continue; };
+            let Some(xfrm) = parse_xfrm(&xfrm_n) else { continue; };
+            let rot_raw: f64 = xfrm_n.attribute("rot")
+                .and_then(|s| s.parse().ok()).unwrap_or(0.0);
+
+            // Resolve <a:blip r:embed="rIdN"/>. The r:embed attribute lives in
+            // the relationships namespace, not the drawingml namespace.
+            let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+            let pic_rid = child.descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "blip")
+                .and_then(|b| {
+                    b.attributes()
+                        .find(|a| a.name() == "embed" && a.namespace() == Some(r_ns))
+                        .map(|a| a.value().to_string())
+                });
+            let Some(rid) = pic_rid else { continue; };
+            let Some(data_url) = rid_urls.get(&rid) else { continue; };
+
+            let root_x = trans_x + scale_x * xfrm.off_x;
+            let root_y = trans_y + scale_y * xfrm.off_y;
+            let root_w = scale_x * xfrm.ext_x;
+            let root_h = scale_y * xfrm.ext_y;
+            if root_ext_x == 0.0 || root_ext_y == 0.0 { continue; }
+            let nx = (root_x - root_off_x) / root_ext_x;
+            let ny = (root_y - root_off_y) / root_ext_y;
+            let nw = root_w / root_ext_x;
+            let nh = root_h / root_ext_y;
+            if nw <= 0.0 || nh <= 0.0 { continue; }
+
+            out.push(ShapeInfo {
+                x: nx, y: ny, w: nw, h: nh,
+                rot: rot_raw / 60000.0,
+                fill_color: None,
+                stroke_color: None,
+                stroke_width: 0,
+                geom: ShapeGeom::Image { data_url: data_url.clone() },
+            });
         }
-        // Ignore `xdr:pic` / `xdr:cxnSp` / text elements for this minimal pass.
+        // Ignore `xdr:cxnSp` / text-only elements for this minimal pass.
     }
 }
 
 fn parse_shape_anchors(
     drawing_xml: &str,
     theme_colors: &[String],
+    rid_urls: &HashMap<String, String>,
 ) -> Vec<ShapeAnchor> {
     let Ok(doc) = roxmltree::Document::parse(drawing_xml) else { return Vec::new(); };
     let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
@@ -2319,7 +2374,7 @@ fn parse_shape_anchors(
 
         let mut shapes: Vec<ShapeInfo> = Vec::new();
         collect_shapes(&grp, root.off_x, root.off_y, root.ext_x, root.ext_y,
-                       csx, csy, tx, ty, theme_colors, &mut shapes);
+                       csx, csy, tx, ty, theme_colors, rid_urls, &mut shapes);
         if shapes.is_empty() { continue; }
 
         anchors.push(ShapeAnchor {
@@ -2350,9 +2405,46 @@ fn load_sheet_shape_groups(
     for target in drawing_targets {
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
         let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
-        all.extend(parse_shape_anchors(&drawing_xml, theme_colors));
+        let rid_urls = build_drawing_rid_urls(archive, &drawing_path);
+        all.extend(parse_shape_anchors(&drawing_xml, theme_colors, &rid_urls));
     }
     all
+}
+
+/// Build a `HashMap<rId, data-URL>` for every image (png/jpg/…) target in
+/// a drawing's `.rels` file. Used by `collect_shapes` to resolve `<xdr:pic>`
+/// leaves inside a group. Mirrors the logic in `parse_drawing_anchors` but
+/// eagerly encodes each referenced image so per-shape lookup is a single
+/// HashMap hit.
+fn build_drawing_rid_urls(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    drawing_path: &str,
+) -> HashMap<String, String> {
+    let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else {
+        return HashMap::new();
+    };
+    let rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
+    let rels = read_zip_entry(archive, &rels_path)
+        .ok()
+        .map(|xml| parse_rels_map(&xml))
+        .unwrap_or_default();
+
+    let mut result: HashMap<String, String> = HashMap::new();
+    for (rid, target) in rels {
+        let lower = target.to_lowercase();
+        if !(lower.ends_with(".png") || lower.ends_with(".jpg")
+            || lower.ends_with(".jpeg") || lower.ends_with(".gif")
+            || lower.ends_with(".bmp")  || lower.ends_with(".webp"))
+        {
+            continue;
+        }
+        let media_path = resolve_zip_path(drawing_dir, &target);
+        if let Some(bytes) = read_zip_bytes(archive, &media_path) {
+            let mime = mime_from_ext(&media_path);
+            result.insert(rid, format!("data:{mime};base64,{}", B64.encode(&bytes)));
+        }
+    }
+    result
 }
 
 /// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2,7 +2,7 @@ import type {
   Worksheet, Styles, Cell, CellValue, Font, Fill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
-  Run, ChartData, GradientFillSpec,
+  Run, ChartData, GradientFillSpec, ShapeInfo,
 } from './types.js';
 import { renderChart, type ChartModel } from '@silurus/ooxml-core';
 
@@ -2777,6 +2777,17 @@ export function renderViewport(
     );
   }
 
+  // ── Anchored shape groups (custom geometry) ────────────────────
+  if (worksheet.shapeGroups && worksheet.shapeGroups.length > 0) {
+    renderShapeGroups(
+      ctx, worksheet, cs,
+      startRow, startCol,
+      scrollOffsetX, scrollOffsetY,
+      scrollAreaX, scrollAreaY,
+      scrollAreaW, scrollAreaH,
+    );
+  }
+
   // ── Anchored charts (clipped to scrollable area) ──────────────
   if (worksheet.charts && worksheet.charts.length > 0) {
     renderCharts(
@@ -3044,6 +3055,170 @@ function renderImages(
   }
 
   ctx.restore();
+}
+
+function renderShapeGroups(
+  ctx: CanvasRenderingContext2D,
+  ws: Worksheet,
+  cs: number,
+  startRow: number,
+  startCol: number,
+  scrollOffsetX: number,
+  scrollOffsetY: number,
+  scrollAreaX: number,
+  scrollAreaY: number,
+  scrollAreaW: number,
+  scrollAreaH: number,
+): void {
+  if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
+  const anchors = ws.shapeGroups;
+  if (!anchors || anchors.length === 0) return;
+
+  const scrollOriginSheetX = sheetXForCol(ws, startCol, cs);
+  const scrollOriginSheetY = sheetYForRow(ws, startRow, cs);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+  ctx.clip();
+
+  for (const anchor of anchors) {
+    const fromCol1 = anchor.fromCol + 1;
+    const fromRow1 = anchor.fromRow + 1;
+    const toCol1   = anchor.toCol   + 1;
+    const toRow1   = anchor.toRow   + 1;
+
+    const x1 = sheetXForCol(ws, fromCol1, cs) + (anchor.fromColOff * cs) / EMU_PER_PX;
+    const y1 = sheetYForRow(ws, fromRow1, cs) + (anchor.fromRowOff * cs) / EMU_PER_PX;
+    const x2 = sheetXForCol(ws, toCol1,   cs) + (anchor.toColOff   * cs) / EMU_PER_PX;
+    const y2 = sheetYForRow(ws, toRow1,   cs) + (anchor.toRowOff   * cs) / EMU_PER_PX;
+    const w = x2 - x1;
+    const h = y2 - y1;
+    if (w <= 0 || h <= 0) continue;
+
+    const canvasX = scrollAreaX + (x1 - scrollOriginSheetX) - scrollOffsetX;
+    const canvasY = scrollAreaY + (y1 - scrollOriginSheetY) - scrollOffsetY;
+
+    if (canvasX + w < scrollAreaX || canvasX > scrollAreaX + scrollAreaW) continue;
+    if (canvasY + h < scrollAreaY || canvasY > scrollAreaY + scrollAreaH) continue;
+
+    for (const shape of anchor.shapes) {
+      const sx = canvasX + shape.x * w;
+      const sy = canvasY + shape.y * h;
+      const sw = shape.w * w;
+      const sh = shape.h * h;
+      if (sw <= 0 || sh <= 0) continue;
+      drawShape(ctx, shape, sx, sy, sw, sh);
+    }
+  }
+
+  ctx.restore();
+}
+
+function drawShape(
+  ctx: CanvasRenderingContext2D,
+  shape: ShapeInfo,
+  sx: number, sy: number, sw: number, sh: number,
+): void {
+  ctx.save();
+  if (shape.rot !== 0) {
+    ctx.translate(sx + sw / 2, sy + sh / 2);
+    ctx.rotate((shape.rot * Math.PI) / 180);
+    ctx.translate(-sw / 2, -sh / 2);
+  } else {
+    ctx.translate(sx, sy);
+  }
+
+  if (shape.geom.type === 'custom') {
+    for (const path of shape.geom.paths) {
+      if (path.w <= 0 || path.h <= 0) continue;
+      const kx = sw / path.w;
+      const ky = sh / path.h;
+      ctx.beginPath();
+      // Track pen position for arcTo center computation.
+      let penX = 0, penY = 0;
+      // Track subpath start for close lineTo.
+      let subX = 0, subY = 0;
+      for (const cmd of path.commands) {
+        switch (cmd.op) {
+          case 'moveTo': {
+            const px = cmd.x * kx, py = cmd.y * ky;
+            ctx.moveTo(px, py);
+            penX = subX = px; penY = subY = py;
+            break;
+          }
+          case 'lineTo': {
+            const px = cmd.x * kx, py = cmd.y * ky;
+            ctx.lineTo(px, py);
+            penX = px; penY = py;
+            break;
+          }
+          case 'cubicBezTo': {
+            const ex = cmd.x3 * kx, ey = cmd.y3 * ky;
+            ctx.bezierCurveTo(
+              cmd.x1 * kx, cmd.y1 * ky,
+              cmd.x2 * kx, cmd.y2 * ky,
+              ex, ey,
+            );
+            penX = ex; penY = ey;
+            break;
+          }
+          case 'quadBezTo': {
+            const ex = cmd.x2 * kx, ey = cmd.y2 * ky;
+            ctx.quadraticCurveTo(cmd.x1 * kx, cmd.y1 * ky, ex, ey);
+            penX = ex; penY = ey;
+            break;
+          }
+          case 'arcTo': {
+            // ECMA-376 §20.1.9.3: pen lies on ellipse at stAng;
+            // derive center from pen + stAng, then sweep swAng.
+            const rx = cmd.wr * kx, ry = cmd.hr * ky;
+            if (rx <= 0 || ry <= 0) break;
+            const stRad = (cmd.stAng / 60000) * (Math.PI / 180);
+            const swRad = (cmd.swAng / 60000) * (Math.PI / 180);
+            const cx = penX - Math.cos(stRad) * rx;
+            const cy = penY - Math.sin(stRad) * ry;
+            const endRad = stRad + swRad;
+            ctx.ellipse(cx, cy, rx, ry, 0, stRad, endRad, swRad < 0);
+            penX = cx + Math.cos(endRad) * rx;
+            penY = cy + Math.sin(endRad) * ry;
+            break;
+          }
+          case 'close':
+            ctx.closePath();
+            penX = subX; penY = subY;
+            break;
+        }
+      }
+      fillAndStroke(ctx, shape);
+    }
+  } else if (shape.geom.type === 'preset') {
+    ctx.beginPath();
+    switch (shape.geom.name) {
+      case 'ellipse':
+      case 'roundRect': {
+        const rx = sw / 2, ry = sh / 2;
+        ctx.ellipse(rx, ry, rx, ry, 0, 0, Math.PI * 2);
+        break;
+      }
+      default:
+        ctx.rect(0, 0, sw, sh);
+    }
+    fillAndStroke(ctx, shape);
+  }
+  ctx.restore();
+}
+
+function fillAndStroke(ctx: CanvasRenderingContext2D, shape: ShapeInfo): void {
+  if (shape.fillColor) {
+    ctx.fillStyle = shape.fillColor;
+    ctx.fill();
+  }
+  if (shape.strokeColor && shape.strokeWidth > 0) {
+    ctx.strokeStyle = shape.strokeColor;
+    ctx.lineWidth = Math.max(0.5, shape.strokeWidth / EMU_PER_PX);
+    ctx.stroke();
+  }
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -344,7 +344,12 @@ function recomputeVolatile(formula: string | undefined): number | null {
 // Date / time formatting  (ECMA-376 §18.8.30)
 // ────────────────────────────────────────────────────────────────
 
-// Built-in numFmtId → format code (US English locale, as per the spec)
+// Built-in numFmtId → format code. IDs 14-22 are the ECMA-376 US-English
+// built-ins; IDs 27-31 and 50-58 are East-Asian (Japanese) locale built-ins
+// that Office ships pre-assigned when the file was authored in ja-JP. The
+// spec lists the codes under §18.8.30 Table "Built-in formats" (the
+// locale-dependent block is given without format strings but the de-facto
+// codes match the ones that Office writes back when opening and re-saving).
 const BUILTIN_DATE_FMT: Record<number, string> = {
   14: 'm/d/yyyy',
   15: 'd-mmm-yy',
@@ -355,6 +360,22 @@ const BUILTIN_DATE_FMT: Record<number, string> = {
   20: 'h:mm',
   21: 'h:mm:ss',
   22: 'm/d/yyyy h:mm',
+  // Japanese locale built-ins (East-Asian Office). Values mirror what
+  // Excel ja-JP writes for these IDs.
+  27: '[$-411]ge.m.d',
+  28: '[$-411]ggge"年"m"月"d"日"',
+  29: '[$-411]ggge"年"m"月"d"日"',
+  30: 'm/d/yy',
+  31: 'yyyy"年"m"月"d"日"',
+  50: '[$-411]ge.m.d',
+  51: '[$-411]ggge"年"m"月"d"日"',
+  52: 'yyyy"年"m"月"',
+  53: 'm"月"d"日"',
+  54: '[$-411]ggge"年"m"月"d"日"',
+  55: 'yyyy"年"m"月"',
+  56: 'm"月"d"日"',
+  57: '[$-411]ge.m.d',
+  58: '[$-411]ggge"年"m"月"d"日"',
 };
 
 const MONTH_NAMES = [
@@ -748,19 +769,71 @@ function wrapTextLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: nu
   const lines: string[] = [];
   // Hard line breaks (\n from Alt+Enter) always split regardless of wrapText.
   for (const paragraph of text.split('\n')) {
-    const words = paragraph.split(' ');
-    let current = '';
-    for (const word of words) {
-      const test = current ? `${current} ${word}` : word;
-      if (ctx.measureText(test).width <= maxWidth || !current) {
-        current = test;
-      } else {
-        lines.push(current);
-        current = word;
-      }
-    }
-    lines.push(current);
+    lines.push(...wrapParagraphLines(ctx, paragraph, maxWidth));
   }
+  return lines;
+}
+
+/** Codepoints in the CJK ranges get broken per-character (Excel / JIS X 4051
+ *  behaviour). This mirrors the tokenizer in `layoutRichTextLines`. */
+function isCJKCodePoint(cp: number): boolean {
+  return (cp >= 0x3000 && cp <= 0x9FFF)  // CJK punctuation + CJK Unified Ideographs
+      || (cp >= 0xF900 && cp <= 0xFAFF)  // CJK Compatibility Ideographs
+      || (cp >= 0xAC00 && cp <= 0xD7AF)  // Hangul Syllables
+      || (cp >= 0xFF00 && cp <= 0xFFEF); // Halfwidth/Fullwidth
+}
+
+/** Word-wrap a single paragraph (no embedded \n). Unlike a naive
+ *  `split(' ')`, CJK characters are treated as individual break opportunities
+ *  so that Japanese headings like "夏休みアクティビティ カレンダー 2026"
+ *  actually wrap inside a merged cell. ECMA-376 doesn't spec the break
+ *  algorithm but this matches what Excel renders on the same input. */
+function wrapParagraphLines(ctx: CanvasRenderingContext2D, paragraph: string, maxWidth: number): string[] {
+  const lines: string[] = [];
+  // Tokenise: runs of non-space non-CJK, single ASCII-space runs, individual
+  // CJK characters. Then greedy-fit each token onto the current line.
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < paragraph.length) {
+    const ch = paragraph[i];
+    const cp = ch.codePointAt(0) ?? 0;
+    if (isCJKCodePoint(cp)) {
+      tokens.push(ch);
+      i += cp > 0xFFFF ? 2 : 1;
+    } else if (ch === ' ') {
+      let j = i;
+      while (j < paragraph.length && paragraph[j] === ' ') j++;
+      tokens.push(paragraph.slice(i, j));
+      i = j;
+    } else {
+      let j = i;
+      while (j < paragraph.length) {
+        const c = paragraph[j];
+        const p = c.codePointAt(0) ?? 0;
+        if (c === ' ' || isCJKCodePoint(p)) break;
+        j += p > 0xFFFF ? 2 : 1;
+      }
+      tokens.push(paragraph.slice(i, j));
+      i = j;
+    }
+  }
+  let current = '';
+  for (const tok of tokens) {
+    if (current === '') { current = tok; continue; }
+    const candidate = current + tok;
+    if (ctx.measureText(candidate).width <= maxWidth) {
+      current = candidate;
+    } else {
+      // Token doesn't fit at the end of the current line — break here.
+      // Leading spaces at the start of the next line are dropped (matches
+      // Excel: wrapped-continuation lines don't preserve the space that
+      // caused the break).
+      lines.push(current);
+      current = tok.replace(/^ +/, '');
+      if (current === '') current = tok; // all-space token (preserve width on its own line)
+    }
+  }
+  lines.push(current);
   return lines;
 }
 
@@ -1578,14 +1651,20 @@ function resolveRange(
 }
 
 function cellValueToEval(cell: Cell | undefined): EvalScalar {
-  if (!cell) return 0;
+  // An empty / missing cell is *not* the same as 0. CF expressions like
+  // `=$C5=0` or `NOT(ISBLANK($C5))` will match a missing cell if we return
+  // 0 here, which is exactly the bug that turned C5-C8 beige on sample-10.
+  // Return null and let the arithmetic / comparison operators coerce as
+  // needed (null+0 → 0, null="" → true, null=0 → false). See ECMA-376
+  // §18.18.62 and the actual Excel evaluation behaviour.
+  if (!cell) return null;
   switch (cell.value.type) {
     case 'number': return cell.value.number;
     case 'bool':   return cell.value.bool;
     case 'text':   return cell.value.text;
     case 'error':  return null;
     case 'empty':
-    default:       return 0;
+    default:       return null;
   }
 }
 
@@ -1607,7 +1686,7 @@ function callFunc(nameRaw: string, args: EvalValue[], ctx: EvalCtx): EvalValue {
     case 'TRUE':       return true;
     case 'FALSE':      return false;
     // ── Type checks ─────────────────────────────────────────────────────────
-    case 'ISBLANK':    { const s = toScalar(args[0]); return s == null || s === '' || s === 0; }
+    case 'ISBLANK':    { const s = toScalar(args[0]); return s == null || s === ''; }
     case 'ISNUMBER':   return typeof toScalar(args[0]) === 'number';
     case 'ISTEXT':     return typeof toScalar(args[0]) === 'string';
     case 'ISNONTEXT':  return typeof toScalar(args[0]) !== 'string';
@@ -2777,7 +2856,7 @@ export function renderViewport(
     );
   }
 
-  // ── Anchored shape groups (custom geometry) ────────────────────
+  // ── Anchored shape groups (custom geometry, incl. embedded images) ────
   if (worksheet.shapeGroups && worksheet.shapeGroups.length > 0) {
     renderShapeGroups(
       ctx, worksheet, cs,
@@ -2785,6 +2864,7 @@ export function renderViewport(
       scrollOffsetX, scrollOffsetY,
       scrollAreaX, scrollAreaY,
       scrollAreaW, scrollAreaH,
+      opts.loadedImages,
     );
   }
 
@@ -3069,6 +3149,7 @@ function renderShapeGroups(
   scrollAreaY: number,
   scrollAreaW: number,
   scrollAreaH: number,
+  loadedImages?: Map<string, HTMLImageElement>,
 ): void {
   if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
   const anchors = ws.shapeGroups;
@@ -3108,7 +3189,7 @@ function renderShapeGroups(
       const sw = shape.w * w;
       const sh = shape.h * h;
       if (sw <= 0 || sh <= 0) continue;
-      drawShape(ctx, shape, sx, sy, sw, sh);
+      drawShape(ctx, shape, sx, sy, sw, sh, loadedImages);
     }
   }
 
@@ -3119,6 +3200,7 @@ function drawShape(
   ctx: CanvasRenderingContext2D,
   shape: ShapeInfo,
   sx: number, sy: number, sw: number, sh: number,
+  loadedImages?: Map<string, HTMLImageElement>,
 ): void {
   ctx.save();
   if (shape.rot !== 0) {
@@ -3205,6 +3287,16 @@ function drawShape(
         ctx.rect(0, 0, sw, sh);
     }
     fillAndStroke(ctx, shape);
+  } else if (shape.geom.type === 'image') {
+    // Image leaf inside a group (e.g. a sun-emoji clip-art nested in the
+    // calendar header). The caller pre-decodes every data URL seen in
+    // `ws.shapeGroups[*].shapes[*].geom` via XlsxWorkbook.renderViewport,
+    // so we should normally have it in `loadedImages`. If not, fall back
+    // to a silent skip — drawing an empty rect would look worse.
+    const img = loadedImages?.get(shape.geom.dataUrl);
+    if (img) {
+      ctx.drawImage(img, 0, 0, sw, sh);
+    }
   }
   ctx.restore();
 }

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -168,7 +168,11 @@ export interface ShapeInfo {
 
 export type ShapeGeom =
   | { type: 'preset'; name: string }
-  | { type: 'custom'; paths: PathInfo[] };
+  | { type: 'custom'; paths: PathInfo[] }
+  /** Bitmap picture leaf inside a `<xdr:grpSp>`. `dataUrl` is a pre-encoded
+   *  `data:<mime>;base64,…` produced by the Rust parser from the drawing's
+   *  relationship target. */
+  | { type: 'image'; dataUrl: string };
 
 export interface PathInfo {
   w: number;

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -28,6 +28,10 @@ export interface Worksheet {
   conditionalFormats: ConditionalFormat[];
   images: ImageAnchor[];
   charts: ChartAnchor[];
+  /** Grouped shapes from `<xdr:grpSp>` inside twoCellAnchors
+   *  (ECMA-376 §20.5.2.17). Each anchor holds leaf shapes pre-flattened
+   *  with normalized [0,1] geometry relative to the anchor rect. */
+  shapeGroups?: ShapeAnchor[];
   /** Whether to display zero values (ECMA-376 §18.3.1.94). Defaults to true. */
   showZeros?: boolean;
   /** Whether to draw default grid lines (ECMA-376 §18.3.1.83
@@ -141,6 +145,46 @@ export interface ChartAnchor {
   toRow: number;   toRowOff: number;
   chart: ChartData;
 }
+
+export interface ShapeAnchor {
+  fromCol: number; fromColOff: number;
+  fromRow: number; fromRowOff: number;
+  toCol: number;   toColOff: number;
+  toRow: number;   toRowOff: number;
+  shapes: ShapeInfo[];
+}
+
+export interface ShapeInfo {
+  /** Normalized [0,1] position/size relative to the anchor rect. */
+  x: number; y: number; w: number; h: number;
+  /** Rotation in degrees, clockwise. */
+  rot: number;
+  fillColor?: string;
+  strokeColor?: string;
+  /** Stroke width in EMU. 0 = no stroke. */
+  strokeWidth: number;
+  geom: ShapeGeom;
+}
+
+export type ShapeGeom =
+  | { type: 'preset'; name: string }
+  | { type: 'custom'; paths: PathInfo[] };
+
+export interface PathInfo {
+  w: number;
+  h: number;
+  commands: PathCmd[];
+}
+
+export type PathCmd =
+  | { op: 'moveTo'; x: number; y: number }
+  | { op: 'lineTo'; x: number; y: number }
+  | { op: 'cubicBezTo'; x1: number; y1: number; x2: number; y2: number; x3: number; y3: number }
+  | { op: 'quadBezTo'; x1: number; y1: number; x2: number; y2: number }
+  /** ECMA-376 §20.1.9.3. stAng/swAng in 60000ths of a degree. wr/hr in
+   *  the path's own coordinate units. Pen position is the arc start. */
+  | { op: 'arcTo'; wr: number; hr: number; stAng: number; swAng: number }
+  | { op: 'close' };
 
 /**
  * Image anchored to a rectangle of cells (EMU offsets within the anchor cells).

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -83,18 +83,33 @@ export class XlsxWorkbook {
     const ctx = (target as HTMLCanvasElement).getContext('2d') as CanvasRenderingContext2D;
     ctx.scale(dpr, dpr);
 
-    // Preload any image bitmaps that this sheet uses (data URLs → HTMLImageElement)
-    if (ws.images && ws.images.length > 0) {
+    // Preload any image bitmaps that this sheet uses (data URLs → HTMLImageElement).
+    // Images can appear either as top-level twoCellAnchor `<xdr:pic>` (captured
+    // in `ws.images`) or as a leaf inside an `<xdr:grpSp>` (captured as a
+    // ShapeGeom with `type: 'image'`). We collect both so the renderer never
+    // hits a missing bitmap during the synchronous draw pass.
+    const dataUrlsToLoad: string[] = [];
+    if (ws.images) {
+      for (const img of ws.images) dataUrlsToLoad.push(img.dataUrl);
+    }
+    if (ws.shapeGroups) {
+      for (const grp of ws.shapeGroups) {
+        for (const shape of grp.shapes) {
+          if (shape.geom.type === 'image') dataUrlsToLoad.push(shape.geom.dataUrl);
+        }
+      }
+    }
+    if (dataUrlsToLoad.length > 0) {
       await Promise.all(
-        ws.images.map(async (img) => {
-          if (this.imageCache.has(img.dataUrl)) return;
+        dataUrlsToLoad.map(async (url) => {
+          if (this.imageCache.has(url)) return;
           const el = new Image();
-          el.src = img.dataUrl;
+          el.src = url;
           await new Promise<void>((resolve, reject) => {
             el.onload = () => resolve();
             el.onerror = () => reject(new Error('image decode failed'));
           });
-          this.imageCache.set(img.dataUrl, el);
+          this.imageCache.set(url, el);
         }),
       ).catch(() => { /* swallow image failures so the grid still renders */ });
     }


### PR DESCRIPTION
## Summary

Fixes five independent issues surfaced by the `夏休みアクティビティ カレンダー` sample (sample-10):

- **CF empty-cell false positive** — `cellValueToEval` returned `0` for missing / empty cells, so CF rules like `=\$C5=0` or `NOT(ISBLANK(\$C5))` matched every blank and painted C5–C8 beige. It now returns `null`, and `ISBLANK` drops its `s === 0` workaround.
- **`numFmtId=56` → "46180"** — The East-Asian Office built-in date IDs (27–31, 50–58) were missing from `BUILTIN_DATE_FMT`. Cells formatted with `56` (`m"月"d"日"`) fell through to `String(num)`. Populated the ja-JP block so F11 / I19 show `7月1日` / `8月1日`.
- **Missing image leaves inside `<xdr:grpSp>`** — The group-shape walker only handled `xdr:sp`. Added an `xdr:pic` branch that resolves each `<a:blip r:embed>` via the drawing's .rels file and emits a new `ShapeGeom::Image` variant carrying a pre-encoded data URL. The TS renderer paints it with `drawImage`; the workbook pre-loads both `ws.images` *and* shape-group image leaves.
- **Theme colour indices swapped** — `parse_solid_fill` mapped `dk1`/`lt1` and `dk2`/`lt2` to the wrong slots. `parse_theme_colors` stores clrScheme children in OOXML document order (dk1, lt1, dk2, lt2, accent1, …); the fill lookup now matches.
- **Merged-cell CJK wrapping** — `wrapTextLines` only broke at ASCII spaces, so headers like `夏休みアクティビティ カレンダー 2026` stayed on one line inside L2:P3. The helper now tokenises CJK code points individually (CJK Unified, Kana, Hangul, Halfwidth/Fullwidth), matching `layoutRichTextLines`.

This PR also carries the earlier `fix(xlsx): notContainsBlanks CF + xdr:grpSp custom geometry rendering` commit (2812307) so it can ship standalone.

## Test plan

- [ ] Open `sample-10.xlsx` in Storybook (`XlsxViewer/Samples`) and verify:
  - [ ] C5–C8 are blank (no beige CF fill)
  - [ ] C5 / F11 / I19 show Japanese dates (`6月7日` etc.), not serial numbers
  - [ ] The umbrella / sun / waves emoji clip-art inside the header group all render (including グラフィック 17)
  - [ ] The "夏休みアクティビティ カレンダー 2026" header wraps across two lines inside L2:P3
  - [ ] Shape fills that use `schemeClr val="lt1"` paint white, not black
- [ ] Run existing Playwright VRT (`pnpm vrt`) to confirm no regressions on sample-1 … sample-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)