### PR TITLE
fix(xlsx): sample-10 follow-ups (scroll flicker, dxf numFmt/fill, group images)

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -275,6 +275,7 @@ pub enum ShapeGeom {
     /// Bitmap image leaf inside a `<xdr:grpSp>` tree (ECMA-376 §20.5.2.17).
     /// `data_url` is a `data:<mime>;base64,…` URL produced from the drawing's
     /// relationship target (png/jpg/gif/…).
+    #[serde(rename_all = "camelCase")]
     Image { data_url: String },
 }
 

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -481,6 +481,11 @@ pub struct Dxf {
     pub font: Option<Font>,
     pub fill: Option<Fill>,
     pub border: Option<Border>,
+    /// Number format override applied when the conditional-formatting rule
+    /// matches. ECMA-376 §18.8.17 allows `<dxf>` to carry a `<numFmt>` that
+    /// replaces the cell's own style numFmt (e.g. switching a calendar cell
+    /// from `d` to `m"月"d"日"` on the first of each month).
+    pub num_fmt: Option<NumFmt>,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -1076,6 +1081,13 @@ fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> V
                             }
                         }
                         d.border = Some(b);
+                    }
+                    "numFmt" => {
+                        let num_fmt_id = child.attribute("numFmtId")
+                            .and_then(|v| v.parse().ok()).unwrap_or(0);
+                        let format_code = child.attribute("formatCode")
+                            .unwrap_or("").to_string();
+                        d.num_fmt = Some(NumFmt { num_fmt_id, format_code });
                     }
                     _ => {}
                 }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1177,7 +1177,15 @@ function colorScaleAt(num: number, stops: CfStop[], stopValues: number[]): strin
 function applyDxfToResult(result: CfResult, dxf: Dxf | null | undefined): void {
   if (!dxf) return;
   // First-match-wins (higher priority) for each property. See compileCf.
-  if (dxf.fill?.fgColor && !result.fill) result.fill = dxf.fill;
+  // A dxf fill overrides the cell's base fill in two cases:
+  //   • `<patternFill>` with a solid/non-empty color → paints that color
+  //   • `<patternFill patternType="none">` → explicitly CLEARS the base fill
+  //     (ECMA-376 §18.8.20). The sample-10 calendar relies on this: month
+  //     boundaries have a CF rule that clears the "inactive gray" base fill
+  //     so the row reads as a normal white cell.
+  if (dxf.fill && !result.fill && (dxf.fill.fgColor || dxf.fill.patternType === 'none')) {
+    result.fill = dxf.fill;
+  }
   if (dxf.font?.color && result.fontColor == null) result.fontColor = dxf.font.color;
   if (dxf.font?.bold && result.fontBold == null) result.fontBold = true;
   if (dxf.font?.italic && result.fontItalic == null) result.fontItalic = true;

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -318,14 +318,24 @@ function cellValueText(value: CellValue): string {
   }
 }
 
-function formatCellValue(cell: Cell, styles: Styles): string {
+function formatCellValue(
+  cell: Cell,
+  styles: Styles,
+  cfNumFmt?: { numFmtId: number; formatCode: string | null } | null,
+): string {
   if (cell.value.type !== 'number') return cellValueText(cell.value);
-  const xf = styles.cellXfs[cell.styleIndex ?? 0];
-  const numFmtId = xf?.numFmtId ?? 0;
   // Volatile builtins: TODAY()/NOW() cells have a cached `<v>` from the last
   // save, which the viewer would otherwise show as a stale date. Recompute
   // them against the current system clock at render time.
   const num = recomputeVolatile(cell.formula) ?? cell.value.number;
+  // A matched CF dxf numFmt overrides the cell's own style numFmt (ECMA-376
+  // §18.8.17 — e.g. the first day of a new month in a calendar flipping from
+  // `d` to `m"月"d"日"`).
+  if (cfNumFmt) {
+    return applyFormat(num, cfNumFmt.numFmtId, cfNumFmt.formatCode);
+  }
+  const xf = styles.cellXfs[cell.styleIndex ?? 0];
+  const numFmtId = xf?.numFmtId ?? 0;
   const customFmt = styles.numFmts?.find(f => f.numFmtId === numFmtId);
   return applyFormat(num, numFmtId, customFmt?.formatCode ?? null);
 }
@@ -973,6 +983,10 @@ interface CfResult {
   fontItalic?: boolean;
   fontUnderline?: boolean;
   fontStrike?: boolean;
+  /** Number format override from a matched CF dxf. Higher-priority rules win
+   *  (first match through the rule list). Falls back to the cell's own style
+   *  numFmt if unset. */
+  numFmt?: { numFmtId: number; formatCode: string | null };
   dataBar?: { color: string; ratio: number; gradient: boolean };
   iconSet?: { name: string; index: number };
   /** Per-edge borders from matched CF rules (merged on top of the cell's base
@@ -1169,6 +1183,12 @@ function applyDxfToResult(result: CfResult, dxf: Dxf | null | undefined): void {
   if (dxf.font?.italic && result.fontItalic == null) result.fontItalic = true;
   if (dxf.font?.underline && result.fontUnderline == null) result.fontUnderline = true;
   if (dxf.font?.strike && result.fontStrike == null) result.fontStrike = true;
+  if (dxf.numFmt && result.numFmt == null) {
+    result.numFmt = {
+      numFmtId: dxf.numFmt.numFmtId,
+      formatCode: dxf.numFmt.formatCode || null,
+    };
+  }
   if (dxf.border) {
     // Merge per-edge — higher-priority edges stay; lower-priority edges fill
     // in unset ones. dxf `border` typically sets only the edges the rule
@@ -2123,7 +2143,7 @@ function renderQuadrant(
     renderBorder(ctx, mergeBorders(mergedBorder, cf.border), aCx, aCy, cW, cH);
 
     if (!cell) continue;
-    const text = formatCellValue(cell, styles);
+    const text = formatCellValue(cell, styles, cf.numFmt);
     if (!text || (text === '0' && rc.worksheet.showZeros === false)) continue;
 
     const effectiveBold = font.bold || !!cf.fontBold;
@@ -2324,7 +2344,7 @@ function renderQuadrant(
       }
 
       if (!cell) continue;
-      const text = formatCellValue(cell, styles);
+      const text = formatCellValue(cell, styles, cf.numFmt);
       if (!text || (text === '0' && rc.worksheet.showZeros === false)) continue;
 
       const tableBold = !!(tableStyle && (tableStyle.isHeader || tableStyle.isTotals));

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1177,15 +1177,15 @@ function colorScaleAt(num: number, stops: CfStop[], stopValues: number[]): strin
 function applyDxfToResult(result: CfResult, dxf: Dxf | null | undefined): void {
   if (!dxf) return;
   // First-match-wins (higher priority) for each property. See compileCf.
-  // A dxf fill overrides the cell's base fill in two cases:
-  //   • `<patternFill>` with a solid/non-empty color → paints that color
-  //   • `<patternFill patternType="none">` → explicitly CLEARS the base fill
-  //     (ECMA-376 §18.8.20). The sample-10 calendar relies on this: month
-  //     boundaries have a CF rule that clears the "inactive gray" base fill
-  //     so the row reads as a normal white cell.
-  if (dxf.fill && !result.fill && (dxf.fill.fgColor || dxf.fill.patternType === 'none')) {
-    result.fill = dxf.fill;
-  }
+  // Per ECMA-376 §18.3.1.11, a `<dxf>` is a *differential* format: any child
+  // element it contains is an override of the base cell format. So the mere
+  // presence of `dxf.fill` means "replace the base fill with this", whatever
+  // its patternType / color — including `patternType="none"` (explicit clear)
+  // and gradient fills. The paint-site guard (`patternType !== 'none' &&
+  // fgColor`) handles whether the result actually paints a color or leaves
+  // the cell transparent, so this override stays spec-faithful without
+  // second-guessing the fill's shape here.
+  if (dxf.fill && !result.fill) result.fill = dxf.fill;
   if (dxf.font?.color && result.fontColor == null) result.fontColor = dxf.font.color;
   if (dxf.font?.bold && result.fontBold == null) result.fontBold = true;
   if (dxf.font?.italic && result.fontItalic == null) result.fontItalic = true;

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -315,6 +315,11 @@ export interface Dxf {
   font: Font | null;
   fill: Fill | null;
   border: Border | null;
+  /** Number format override from the dxf (ECMA-376 §18.8.17). When a
+   *  conditional-formatting rule matches, this numFmt replaces the cell's own
+   *  style numFmt for rendering — e.g. switching a calendar cell from `d` to
+   *  `m"月"d"日"` on the first day of each month. */
+  numFmt?: NumFmt | null;
 }
 
 export interface Font {

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -61,9 +61,55 @@ export class XlsxWorkbook {
     opts: RenderViewportOptions = {},
   ): Promise<void> {
     if (!this.parsedWorkbook) throw new Error('Workbook not loaded');
-    const ws = await this.getWorksheet(sheetIndex);
+    // Hot path: during scroll the worksheet is already cached. Skip the await
+    // to keep the whole render in a single synchronous task so the browser
+    // doesn't paint between the canvas clear (below) and the draw.
+    const ws = this.sheetCache.get(sheetIndex) ?? await this.getWorksheet(sheetIndex);
     const styles = this.parsedWorkbook.styles;
 
+    // ── Step 1: Preload any uncached image bitmaps BEFORE touching the canvas.
+    //
+    // Images can appear either as top-level twoCellAnchor `<xdr:pic>` (captured
+    // in `ws.images`) or as a leaf inside an `<xdr:grpSp>` (captured as a
+    // ShapeGeom with `type: 'image'`). We collect both so the renderer never
+    // hits a missing bitmap during the synchronous draw pass.
+    //
+    // Doing this *before* the canvas resize is critical for scroll smoothness:
+    // setting `canvas.width` wipes the canvas, and an `await` after that wipe
+    // yields to the browser's paint cycle, causing a visible white flash on
+    // every scroll frame. By awaiting first (and only when there's something
+    // uncached), the whole resize+draw runs synchronously in a single tick and
+    // the old frame stays visible until the new one is ready.
+    const uncached: string[] = [];
+    if (ws.images) {
+      for (const img of ws.images) {
+        if (!this.imageCache.has(img.dataUrl)) uncached.push(img.dataUrl);
+      }
+    }
+    if (ws.shapeGroups) {
+      for (const grp of ws.shapeGroups) {
+        for (const shape of grp.shapes) {
+          if (shape.geom.type === 'image' && !this.imageCache.has(shape.geom.dataUrl)) {
+            uncached.push(shape.geom.dataUrl);
+          }
+        }
+      }
+    }
+    if (uncached.length > 0) {
+      await Promise.all(
+        uncached.map(async (url) => {
+          const el = new Image();
+          el.src = url;
+          await new Promise<void>((resolve, reject) => {
+            el.onload = () => resolve();
+            el.onerror = () => reject(new Error('image decode failed'));
+          });
+          this.imageCache.set(url, el);
+        }),
+      ).catch(() => { /* swallow image failures so the grid still renders */ });
+    }
+
+    // ── Step 2: Resize + draw, all synchronous from here.
     const dpr = opts.dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio : 1);
     const rawW = target instanceof HTMLCanvasElement ? (target.clientWidth || 800) : target.width;
     const rawH = target instanceof HTMLCanvasElement ? (target.clientHeight || 600) : target.height;
@@ -82,37 +128,6 @@ export class XlsxWorkbook {
 
     const ctx = (target as HTMLCanvasElement).getContext('2d') as CanvasRenderingContext2D;
     ctx.scale(dpr, dpr);
-
-    // Preload any image bitmaps that this sheet uses (data URLs → HTMLImageElement).
-    // Images can appear either as top-level twoCellAnchor `<xdr:pic>` (captured
-    // in `ws.images`) or as a leaf inside an `<xdr:grpSp>` (captured as a
-    // ShapeGeom with `type: 'image'`). We collect both so the renderer never
-    // hits a missing bitmap during the synchronous draw pass.
-    const dataUrlsToLoad: string[] = [];
-    if (ws.images) {
-      for (const img of ws.images) dataUrlsToLoad.push(img.dataUrl);
-    }
-    if (ws.shapeGroups) {
-      for (const grp of ws.shapeGroups) {
-        for (const shape of grp.shapes) {
-          if (shape.geom.type === 'image') dataUrlsToLoad.push(shape.geom.dataUrl);
-        }
-      }
-    }
-    if (dataUrlsToLoad.length > 0) {
-      await Promise.all(
-        dataUrlsToLoad.map(async (url) => {
-          if (this.imageCache.has(url)) return;
-          const el = new Image();
-          el.src = url;
-          await new Promise<void>((resolve, reject) => {
-            el.onload = () => resolve();
-            el.onerror = () => reject(new Error('image decode failed'));
-          });
-          this.imageCache.set(url, el);
-        }),
-      ).catch(() => { /* swallow image failures so the grid still renders */ });
-    }
 
     renderViewport(ctx, ws, styles, viewport, { ...opts, dpr, loadedImages: this.imageCache });
   }


### PR DESCRIPTION
## Summary
Follow-up fixes on top of PR #90 for sample-10 (夏休みアクティビティ カレンダー 2026).

- **Scroll flicker**: restructure `renderViewport` so the image-preload `await` happens *before* the canvas resize (which clears the canvas). Preserves the old frame until the new one is fully ready, eliminating the white flash on every scroll tick.
- **dxf numFmt override** (ECMA-376 §18.3.1.11 / §18.8.17): parse `<numFmt>` inside `<dxf>` and apply it at render time. Required so the month-boundary CF rule on the calendar correctly re-formats `7/1`, `8/1`, `9/1` as `7月1日` / `8月1日` / `9月1日` instead of showing only `1日`.
- **ShapeGeom::Image serialization**: add per-variant `#[serde(rename_all = "camelCase")]` — serde's enum-level rename does not cascade into struct variants, so `data_url` was leaking through and the TypeScript side (`dataUrl`) never found the bitmap, hiding images nested inside `<xdr:grpSp>` (e.g. the sun clipart in group 2).
- **dxf fill override is spec-faithful**: per ECMA-376 §18.3.1.11, the mere presence of `dxf.fill` means "override the base". Replace the `fgColor || patternType==='none'` guard with the literal spec rule and let the paint-site guard decide whether to actually paint. Fixes C5 rendering as gray when Excel shows white.

## Test plan
- [ ] Storybook `XlsxViewer/Samples` → sample-10: scroll smoothly with no white flash
- [ ] Month-header cells render `7月1日` / `8月1日` / `9月1日`
- [ ] Sun clipart in group 2 is visible
- [ ] C5 renders white, not gray
- [ ] Existing VRT suite (`pnpm vrt`) stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)