### PR TITLE
feat(xlsx): render static pivot/table slicers from Office 2010 extension

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -72,6 +72,12 @@ pub struct Worksheet {
     /// built-in table style (bold header, banded rows, etc.) on top of the
     /// cells' own styles.
     pub tables: Vec<TableInfo>,
+    /// Slicers anchored to the sheet's drawing (Office 2010+ extension —
+    /// `http://schemas.microsoft.com/office/drawing/2010/slicer` inside
+    /// `<mc:AlternateContent>/<mc:Choice>`). Each slicer resolves its cache
+    /// and referenced pivotCacheDefinition so the renderer can draw a static
+    /// button list with the saved selection state.
+    pub slicers: Vec<SlicerAnchor>,
 }
 
 /// Excel Table metadata (ECMA-376 §18.5 `<table>`). The renderer overlays a
@@ -335,6 +341,39 @@ pub enum PathCmd {
     /// center is derived so the pen lies on the ellipse at `stAng`.
     ArcTo { wr: f64, hr: f64, st_ang: f64, sw_ang: f64 },
     Close,
+}
+
+/// Slicer anchor — a button bank that filters a connected pivot table or
+/// Excel Table. Office stores slicers in a 2010 extension namespace
+/// (`sle:slicer`) wrapped in `<mc:AlternateContent>`, with the cache data in
+/// `xl/slicerCaches/*.xml` and the underlying item list in the linked
+/// pivotCache's `sharedItems`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlicerAnchor {
+    pub from_col: u32,
+    pub from_col_off: i64,
+    pub from_row: u32,
+    pub from_row_off: i64,
+    pub to_col: u32,
+    pub to_col_off: i64,
+    pub to_row: u32,
+    pub to_row_off: i64,
+    /// Slicer header text. Typically the `caption` of the slicer definition
+    /// (`xl/slicers/slicerN.xml`), falling back to the drawing `cNvPr` name.
+    pub caption: String,
+    /// One row per cache item in display order. Items flagged "selected" are
+    /// the ones currently active in the filter; non-selected items are drawn
+    /// with the ghost style. When the cache selection state is unavailable,
+    /// all items are emitted as selected (Excel's default).
+    pub items: Vec<SlicerItem>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlicerItem {
+    pub name: String,
+    pub selected: bool,
 }
 
 /// An image anchored to a rectangular range of cells
@@ -692,6 +731,7 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     ws.comment_refs = load_sheet_comment_refs(&mut archive, &sheet_path);
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
     ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
+    ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -1694,6 +1734,7 @@ fn parse_worksheet(
         comment_refs: Vec::new(),
         defined_names: Vec::new(),
         tables: Vec::new(),
+        slicers: Vec::new(),
     }, hyperlink_rids))
 }
 
@@ -2542,6 +2583,287 @@ fn load_sheet_images(
         all_anchors.append(&mut anchors);
     }
     all_anchors
+}
+
+// ─── Slicer loading ─────────────────────────────────────────────────────────
+//
+// Office 2010+ extension (`sle:slicer` inside `<mc:AlternateContent>`).
+// Resolving one slicer graphicFrame into a drawable anchor takes four
+// XML files:
+//   1. The sheet's drawing (for the anchor rect + graphicFrame name).
+//   2. `xl/slicers/slicerN.xml` — slicer definition: graphicFrame name →
+//      caption + cache name.
+//   3. `xl/slicerCaches/slicerCacheN.xml` — cache definition: cache name →
+//      source field + list of (item index, selected?).
+//   4. `xl/pivotCache/pivotCacheDefinitionN.xml` — pivot cache: field name →
+//      ordered string values.
+// Excel also allows slicers bound to Excel Tables (`tableSlicerCache`), but
+// the present sample is pivot-only; we only implement the pivot path.
+
+#[derive(Default)]
+struct SlicerCacheInfo {
+    source_name: String,
+    items: Vec<(u32, bool)>, // (index into pivot field, selected)
+}
+
+#[derive(Default)]
+struct PivotCacheFields {
+    by_name: HashMap<String, Vec<String>>, // field name → ordered string items
+}
+
+/// Parse every `xl/pivotCache/pivotCacheDefinition*.xml` and merge its
+/// cacheFields (indexed by `@name`) into a single map. Sample workbooks
+/// typically have one pivotCache but the loop keeps the code general.
+fn load_all_pivot_cache_fields(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+) -> PivotCacheFields {
+    let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    let mut out = PivotCacheFields::default();
+    let names: Vec<String> = (0..archive.len())
+        .filter_map(|i| archive.by_index(i).ok().map(|f| f.name().to_string()))
+        .filter(|n| n.starts_with("xl/pivotCache/pivotCacheDefinition") && n.ends_with(".xml"))
+        .collect();
+    for name in names {
+        let Ok(xml) = read_zip_entry(archive, &name) else { continue; };
+        let Ok(doc) = roxmltree::Document::parse(&xml) else { continue; };
+        for field in doc.descendants() {
+            if field.tag_name().name() != "cacheField"
+                || field.tag_name().namespace() != Some(ns)
+            { continue; }
+            let Some(field_name) = field.attribute("name") else { continue; };
+            let mut items: Vec<String> = Vec::new();
+            for shared in field.children().filter(|n| n.is_element() && n.tag_name().name() == "sharedItems") {
+                for item in shared.children().filter(|n| n.is_element()) {
+                    match item.tag_name().name() {
+                        "s" => items.push(item.attribute("v").unwrap_or("").to_string()),
+                        "n" => items.push(item.attribute("v").unwrap_or("").to_string()),
+                        "d" => items.push(item.attribute("v").unwrap_or("").to_string()),
+                        "b" => items.push(item.attribute("v").unwrap_or("").to_string()),
+                        "m" => items.push(String::new()),
+                        _ => {}
+                    }
+                }
+            }
+            if !items.is_empty() {
+                out.by_name.insert(field_name.to_string(), items);
+            }
+        }
+    }
+    out
+}
+
+/// Parse every `xl/slicerCaches/slicerCache*.xml` and build a map keyed by
+/// the slicerCache's `@name` attribute (e.g. `"スライサー_贈答相手1"`). That
+/// name is what `<slicer cache="…"/>` in `xl/slicers/slicerN.xml` references.
+fn load_all_slicer_caches(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+) -> HashMap<String, SlicerCacheInfo> {
+    let mut out: HashMap<String, SlicerCacheInfo> = HashMap::new();
+    let names: Vec<String> = (0..archive.len())
+        .filter_map(|i| archive.by_index(i).ok().map(|f| f.name().to_string()))
+        .filter(|n| n.starts_with("xl/slicerCaches/slicerCache") && n.ends_with(".xml"))
+        .collect();
+    for path in names {
+        let Ok(xml) = read_zip_entry(archive, &path) else { continue; };
+        let Ok(doc) = roxmltree::Document::parse(&xml) else { continue; };
+        let root = doc.root_element();
+        let cache_name = root.attribute("name").unwrap_or("").to_string();
+        let source_name = root.attribute("sourceName").unwrap_or("").to_string();
+        let mut items: Vec<(u32, bool)> = Vec::new();
+        for tabular in doc.descendants().filter(|n| n.is_element() && n.tag_name().name() == "tabular") {
+            for i_el in tabular.descendants().filter(|n| n.is_element() && n.tag_name().name() == "i") {
+                let x: u32 = i_el.attribute("x").and_then(|v| v.parse().ok()).unwrap_or(0);
+                // `s` defaults to "1" (selected) when absent — ECMA-376
+                // extension schema for slicer caches.
+                let selected = i_el.attribute("s").map(|v| v != "0").unwrap_or(true);
+                items.push((x, selected));
+            }
+        }
+        if !cache_name.is_empty() {
+            out.insert(cache_name, SlicerCacheInfo { source_name, items });
+        }
+    }
+    out
+}
+
+/// Slicer definition (`xl/slicers/slicerN.xml`): maps each graphicFrame name
+/// on the sheet to its display caption and the slicerCache it's backed by.
+#[derive(Default)]
+struct SlicerDef {
+    caption: String,
+    cache: String,
+}
+
+fn parse_slicers_xml(xml: &str) -> HashMap<String, SlicerDef> {
+    let mut out: HashMap<String, SlicerDef> = HashMap::new();
+    let Ok(doc) = roxmltree::Document::parse(xml) else { return out; };
+    for slicer in doc.descendants().filter(|n| n.is_element() && n.tag_name().name() == "slicer") {
+        let name = slicer.attribute("name").unwrap_or("").to_string();
+        let caption = slicer.attribute("caption").unwrap_or("").to_string();
+        let cache = slicer.attribute("cache").unwrap_or("").to_string();
+        if !name.is_empty() {
+            out.insert(name, SlicerDef { caption, cache });
+        }
+    }
+    out
+}
+
+fn load_sheet_slicers(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_path: &str, // e.g. "worksheets/sheet1.xml"
+) -> Vec<SlicerAnchor> {
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
+        return Vec::new();
+    };
+    let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+        return Vec::new();
+    };
+    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+        return Vec::new();
+    };
+
+    // 1. Collect slicer-definition and drawing targets from the sheet rels.
+    let mut drawing_targets: Vec<String> = Vec::new();
+    let mut slicer_targets: Vec<String> = Vec::new();
+    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+        let rel_type = rel.attribute("Type").unwrap_or("");
+        let Some(target) = rel.attribute("Target") else { continue; };
+        if rel_type.ends_with("/drawing") {
+            drawing_targets.push(target.to_string());
+        } else if rel_type.ends_with("/slicer") {
+            slicer_targets.push(target.to_string());
+        }
+    }
+    if drawing_targets.is_empty() || slicer_targets.is_empty() {
+        return Vec::new();
+    }
+
+    // 2. Parse all slicer definitions referenced by this sheet, keyed by
+    //    graphicFrame name.
+    let mut slicer_defs: HashMap<String, SlicerDef> = HashMap::new();
+    for target in &slicer_targets {
+        let slicer_path = resolve_zip_path(&format!("xl/{}", sheet_dir), target);
+        let Ok(xml) = read_zip_entry(archive, &slicer_path) else { continue; };
+        for (k, v) in parse_slicers_xml(&xml) {
+            slicer_defs.insert(k, v);
+        }
+    }
+    if slicer_defs.is_empty() { return Vec::new(); }
+
+    // 3. Resolve caches (and their backing pivot fields) once.
+    let slicer_caches = load_all_slicer_caches(archive);
+    let pivot_fields = load_all_pivot_cache_fields(archive);
+
+    // 4. Walk each drawing and pick up slicer graphicFrames.
+    let mut out: Vec<SlicerAnchor> = Vec::new();
+    for target in drawing_targets {
+        let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
+        out.extend(parse_slicer_anchors(&drawing_xml, &slicer_defs, &slicer_caches, &pivot_fields));
+    }
+    out
+}
+
+fn parse_slicer_anchors(
+    drawing_xml: &str,
+    slicer_defs: &HashMap<String, SlicerDef>,
+    slicer_caches: &HashMap<String, SlicerCacheInfo>,
+    pivot_fields: &PivotCacheFields,
+) -> Vec<SlicerAnchor> {
+    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
+        return Vec::new();
+    };
+    let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+    let mc_ns = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+    let slicer_uri = "http://schemas.microsoft.com/office/drawing/2010/slicer";
+    let mut out: Vec<SlicerAnchor> = Vec::new();
+
+    for anchor in doc.descendants() {
+        if anchor.tag_name().name() != "twoCellAnchor"
+            || anchor.tag_name().namespace() != Some(xdr_ns)
+        { continue; }
+
+        // Anchor rect.
+        let mut from = (0u32, 0i64, 0u32, 0i64);
+        let mut to   = (0u32, 0i64, 0u32, 0i64);
+        for child in anchor.children().filter(|n| n.is_element()) {
+            match child.tag_name().name() {
+                "from" | "to" => {
+                    let is_from = child.tag_name().name() == "from";
+                    let mut col: u32 = 0; let mut col_off: i64 = 0;
+                    let mut row: u32 = 0; let mut row_off: i64 = 0;
+                    for c in child.children() {
+                        match (c.tag_name().name(), c.text()) {
+                            ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                            ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
+                            ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                            ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
+                            _ => {}
+                        }
+                    }
+                    if is_from { from = (col, col_off, row, row_off); }
+                    else       { to   = (col, col_off, row, row_off); }
+                }
+                _ => {}
+            }
+        }
+
+        // Slicers live inside `<mc:AlternateContent><mc:Choice>` — descend
+        // until we find a `<xdr:graphicFrame>` whose graphicData uri is the
+        // 2010 slicer namespace, then harvest the graphicFrame's cNvPr name.
+        let Some(frame_name) = anchor.descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "Choice" && n.tag_name().namespace() == Some(mc_ns))
+            .flat_map(|choice| choice.descendants())
+            .find_map(|n| {
+                if n.is_element()
+                    && n.tag_name().name() == "graphicData"
+                    && n.attribute("uri") == Some(slicer_uri)
+                {
+                    // graphicData → ancestor graphicFrame → nvGraphicFramePr → cNvPr
+                    let mut p = n.parent();
+                    while let Some(pp) = p {
+                        if pp.tag_name().name() == "graphicFrame" { break; }
+                        p = pp.parent();
+                    }
+                    let frame = p?;
+                    let cnvpr = frame.descendants()
+                        .find(|d| d.is_element() && d.tag_name().name() == "cNvPr")?;
+                    cnvpr.attribute("name").map(|s| s.to_string())
+                } else { None }
+            }) else { continue };
+
+        let Some(slicer_def) = slicer_defs.get(&frame_name) else { continue; };
+
+        // Resolve items via cache → pivot field; fall back to an empty list
+        // if any link is broken (still renders the header and box).
+        let items: Vec<SlicerItem> = slicer_caches.get(&slicer_def.cache)
+            .map(|cache| {
+                let field_items = pivot_fields.by_name.get(&cache.source_name);
+                cache.items.iter().map(|(x, selected)| {
+                    let name = field_items
+                        .and_then(|list| list.get(*x as usize))
+                        .cloned()
+                        .unwrap_or_default();
+                    SlicerItem { name, selected: *selected }
+                }).collect()
+            })
+            .unwrap_or_default();
+
+        let caption = if !slicer_def.caption.is_empty() {
+            slicer_def.caption.clone()
+        } else {
+            frame_name.clone()
+        };
+
+        out.push(SlicerAnchor {
+            from_col: from.0, from_col_off: from.1, from_row: from.2, from_row_off: from.3,
+            to_col:   to.0,   to_col_off:   to.1,   to_row:   to.2,   to_row_off:   to.3,
+            caption,
+            items,
+        });
+    }
+    out
 }
 
 // ─── Chart loading ──────────────────────────────────────────────────────────

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2,7 +2,7 @@ import type {
   Worksheet, Styles, Cell, CellValue, Font, Fill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
-  Run, ChartData, GradientFillSpec, ShapeInfo,
+  Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
 import { renderChart, type ChartModel } from '@silurus/ooxml-core';
 
@@ -2956,6 +2956,17 @@ export function renderViewport(
     );
   }
 
+  // ── Anchored slicers (Office 2010+ pivot/table filter buttons) ──
+  if (worksheet.slicers && worksheet.slicers.length > 0) {
+    renderSlicers(
+      ctx, worksheet, cs,
+      startRow, startCol,
+      scrollOffsetX, scrollOffsetY,
+      scrollAreaX, scrollAreaY,
+      scrollAreaW, scrollAreaH,
+    );
+  }
+
   // ── Row/col headers (drawn last, always on top) ──────────────
   renderHeaders(ctx, canvasW, canvasH,
     startRow, startCol, numRows, numCols,
@@ -3625,4 +3636,168 @@ function renderCharts(
     renderChart(ctx, adaptChartData(anchor.chart), { x: cx, y: cy, w: cw, h: ch }, ptToPx);
     ctx.restore();
   }
+}
+
+// ── renderSlicers ───────────────────────────────────────────────────────────
+//
+// Office 2010+ pivot / table slicer. We don't own a slicer engine, so this
+// renders a static button bank: header with the slicer caption, then one
+// button per saved item using the selection flags from the slicerCache. The
+// visual language (pale blue outline, white "selected" buttons on a darker
+// background, gray "deselected" buttons) intentionally mirrors Excel's
+// default slicer style — the workbook may ship a custom `slicerStyle` but
+// rendering that is deferred (the built-in look is already recognisable).
+
+const SLICER_HEADER_FONT = '600 12px "Meiryo UI", "Segoe UI", sans-serif';
+const SLICER_ITEM_FONT   = '11px "Meiryo UI", "Segoe UI", sans-serif';
+const SLICER_BG           = '#FFFFFF';
+const SLICER_BORDER       = '#BFBFBF';
+const SLICER_HEADER_BG    = '#F2F2F2';
+const SLICER_HEADER_FG    = '#404040';
+const SLICER_ITEM_SEL_BG  = '#FFFFFF';
+const SLICER_ITEM_SEL_FG  = '#000000';
+const SLICER_ITEM_SEL_BD  = '#A5A5A5';
+const SLICER_ITEM_OFF_BG  = '#E7E6E6';
+const SLICER_ITEM_OFF_FG  = '#A6A6A6';
+const SLICER_ITEM_OFF_BD  = '#C6C6C6';
+
+function renderSlicers(
+  ctx: CanvasRenderingContext2D,
+  ws: Worksheet,
+  cs: number,
+  startRow: number,
+  startCol: number,
+  scrollOffsetX: number,
+  scrollOffsetY: number,
+  scrollAreaX: number,
+  scrollAreaY: number,
+  scrollAreaW: number,
+  scrollAreaH: number,
+): void {
+  if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
+  const slicers = ws.slicers;
+  if (!slicers) return;
+
+  const scrollOriginSheetX = sheetXForCol(ws, startCol, cs);
+  const scrollOriginSheetY = sheetYForRow(ws, startRow, cs);
+
+  for (const anchor of slicers) {
+    const fromCol1 = anchor.fromCol + 1;
+    const fromRow1 = anchor.fromRow + 1;
+    const toCol1   = anchor.toCol   + 1;
+    const toRow1   = anchor.toRow   + 1;
+
+    const shX1 = sheetXForCol(ws, fromCol1, cs) + (anchor.fromColOff * cs) / EMU_PER_PX;
+    const shY1 = sheetYForRow(ws, fromRow1, cs) + (anchor.fromRowOff * cs) / EMU_PER_PX;
+    const shX2 = sheetXForCol(ws, toCol1,   cs) + (anchor.toColOff   * cs) / EMU_PER_PX;
+    const shY2 = sheetYForRow(ws, toRow1,   cs) + (anchor.toRowOff   * cs) / EMU_PER_PX;
+
+    const w = shX2 - shX1;
+    const h = shY2 - shY1;
+    if (w <= 0 || h <= 0) continue;
+
+    const x = scrollAreaX + (shX1 - scrollOriginSheetX) - scrollOffsetX;
+    const y = scrollAreaY + (shY1 - scrollOriginSheetY) - scrollOffsetY;
+
+    if (x + w < scrollAreaX || x > scrollAreaX + scrollAreaW) continue;
+    if (y + h < scrollAreaY || y > scrollAreaY + scrollAreaH) continue;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+    ctx.clip();
+
+    drawSlicerFrame(ctx, anchor.caption, anchor.items, x, y, w, h, cs);
+
+    ctx.restore();
+  }
+}
+
+function drawSlicerFrame(
+  ctx: CanvasRenderingContext2D,
+  caption: string,
+  items: SlicerItem[],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  cs: number,
+): void {
+  // Outer frame (white with a soft gray hairline).
+  ctx.fillStyle = SLICER_BG;
+  ctx.fillRect(x, y, w, h);
+  ctx.strokeStyle = SLICER_BORDER;
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x + 0.5, y + 0.5, w - 1, h - 1);
+
+  // Header band with caption.
+  const headerH = Math.max(20 * cs, 14);
+  ctx.fillStyle = SLICER_HEADER_BG;
+  ctx.fillRect(x + 1, y + 1, w - 2, headerH);
+  ctx.fillStyle = SLICER_HEADER_FG;
+  ctx.font = scaleFont(SLICER_HEADER_FONT, cs);
+  ctx.textBaseline = 'middle';
+  ctx.textAlign = 'left';
+  const headerPad = 6 * cs;
+  drawClippedText(ctx, caption, x + headerPad, y + headerH / 2 + 1, w - 2 * headerPad);
+
+  // Item buttons. Items expand to fill the available height (up to a
+  // minimum button size) and are clipped by the slicer rect. We don't
+  // implement scroll arrows because this renderer is non-interactive.
+  if (items.length === 0) return;
+  const gap = Math.max(1, Math.round(2 * cs));
+  const innerPad = 4 * cs;
+  const listX = x + innerPad;
+  const listY = y + headerH + innerPad;
+  const listW = w - 2 * innerPad;
+  const listH = h - headerH - 2 * innerPad;
+  if (listW <= 0 || listH <= 0) return;
+
+  // Prefer Excel's rough row height (~20 sheet-px) but compress if the
+  // slicer is shallow so at least the first items fit.
+  const preferredItemH = Math.max(18 * cs, 16);
+  const maxVisibleByH = Math.max(1, Math.floor((listH + gap) / (preferredItemH + gap)));
+  const visible = Math.min(items.length, maxVisibleByH);
+  const itemH = Math.min(preferredItemH, (listH - gap * (visible - 1)) / visible);
+  if (itemH <= 0) return;
+
+  ctx.font = scaleFont(SLICER_ITEM_FONT, cs);
+  const itemPad = 8 * cs;
+  for (let i = 0; i < visible; i++) {
+    const item = items[i];
+    const iy = listY + i * (itemH + gap);
+    const selected = item.selected;
+    ctx.fillStyle = selected ? SLICER_ITEM_SEL_BG : SLICER_ITEM_OFF_BG;
+    ctx.fillRect(listX, iy, listW, itemH);
+    ctx.strokeStyle = selected ? SLICER_ITEM_SEL_BD : SLICER_ITEM_OFF_BD;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(listX + 0.5, iy + 0.5, listW - 1, itemH - 1);
+    ctx.fillStyle = selected ? SLICER_ITEM_SEL_FG : SLICER_ITEM_OFF_FG;
+    drawClippedText(ctx, item.name, listX + itemPad, iy + itemH / 2 + 1, listW - 2 * itemPad);
+  }
+}
+
+function scaleFont(css: string, cs: number): string {
+  // Re-scale the leading `<size>px` token by `cs`. Safe fallback: leave the
+  // string as-is so the slicer remains readable when parsing fails.
+  return css.replace(/(\d+(?:\.\d+)?)px/, (_, n) => `${Math.round(Number(n) * cs)}px`);
+}
+
+function drawClippedText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+): void {
+  if (maxWidth <= 0) return;
+  let s = text;
+  if (ctx.measureText(s).width > maxWidth) {
+    const ellipsis = '…';
+    while (s.length > 0 && ctx.measureText(s + ellipsis).width > maxWidth) {
+      s = s.slice(0, -1);
+    }
+    s = s.length > 0 ? s + ellipsis : '';
+  }
+  ctx.fillText(s, x, y);
 }

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -54,6 +54,28 @@ export interface Worksheet {
   /** Excel Tables on this sheet (ECMA-376 §18.5). The renderer overlays a
    *  built-in style (bold header, banded rows) on the given ranges. */
   tables?: TableInfo[];
+  /** Pivot / table slicers (Office 2010+ extension). Each anchor carries a
+   *  caption and the saved item list (with selection flags) so the renderer
+   *  can draw a static button bank without the live pivot engine. */
+  slicers?: SlicerAnchor[];
+}
+
+export interface SlicerAnchor {
+  fromCol: number;
+  fromColOff: number;
+  fromRow: number;
+  fromRowOff: number;
+  toCol: number;
+  toColOff: number;
+  toRow: number;
+  toRowOff: number;
+  caption: string;
+  items: SlicerItem[];
+}
+
+export interface SlicerItem {
+  name: string;
+  selected: boolean;
 }
 
 export interface TableInfo {


### PR DESCRIPTION
## Summary

Fills the biggest remaining visual gap on private sample-1 (holiday budget): the five pivot slicers on the 休日の予算 sheet now render in-place with their item lists (贈答相手 / ラッピングの状態 / 購入済み / 配達の状態 / ギフトのカテゴリ), instead of being invisible.

Slicers are an Office 2010+ extension (ISO/IEC 29500-4). Excel wraps each slicer's graphicFrame in `<mc:AlternateContent>/<mc:Choice Requires=\"a14\">` and declares a `sle:slicer` graphicData node under a separate namespace — `core` drawingML never saw it before, so nothing was rendered.

## Pipeline

Parser joins three XML files per slicer:

| File | Role |
|---|---|
| `xl/slicers/slicerN.xml` | graphicFrame name → caption + slicerCache name |
| `xl/slicerCaches/slicerCacheN.xml` | cache → sourceName + saved `<i x=… s=…/>` list |
| `xl/pivotCache/pivotCacheDefinitionN.xml` | field name → ordered `<sharedItems>` values |

Emits a new `SlicerAnchor` per sheet with `{ fromCol/colOff/row/rowOff ...toRow..., caption, items[{name, selected}] }`.

Renderer paints a static button bank mirroring Excel's default slicer look: white frame with hairline border, light gray caption band, white/bold buttons for selected items and gray/muted for deselected. Non-interactive (no scroll arrows, no filter), matching the viewer's read-only contract.

## Out of scope

- Slicer-driven pivot filtering — would require a full pivot-cache engine.
- Custom `slicerStyle` resolution — Excel's default look is already a strong match.
- Table-backed slicers (`tableSlicerCache`) — sample-1 is pivot-only; the code path is additive when the need arises.

## Test plan

- [x] Rebuild WASM + verify all 5 slicers draw on 休日の予算 with correct captions
- [x] `tsc --noEmit` clean on @silurus/ooxml-xlsx
- [ ] VRT re-baseline — this adds visible content, so the existing reference will diff; new baseline needed per the standard VRT workflow