### PR TITLE
feat(xlsx): honor bar gap/overlap, dLblPos, number formats in charts

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -54,11 +54,166 @@ function niceAxisMin(dataMin: number, step: number): number {
 
 function formatChartVal(v: number): string {
   // Matches Excel's default `<c:valAx><c:numFmt formatCode="General">` which
-  // shows raw numbers — no "k"/"M" abbreviation. An upcoming change will honor
-  // the parsed formatCode per ECMA-376 §21.2.2.33 for non-General codes.
+  // shows raw numbers — no "k"/"M" abbreviation.
   if (Number.isInteger(v)) return String(v);
   // Trim trailing zeros on decimals (so 0.50 → "0.5") but cap at 6 digits.
   return v.toFixed(6).replace(/\.?0+$/, '');
+}
+
+/**
+ * Format a chart value with an Excel number-format code. Honors ECMA-376
+ * §18.8.30 section syntax (positive;negative;zero;text), common literal
+ * escapes (`"..."`, `\x`, `_x` → space), and numeric patterns built from
+ * `#`, `0`, `.`, `,`. Unknown tokens are emitted verbatim so currency
+ * symbols like `¥` or `$` keep working even when the workbook stored them
+ * unquoted. Returns the default `formatChartVal` output when `code` is null
+ * or an empty section tells the caller to hide the value.
+ */
+function formatChartValWithCode(v: number, code: string | null | undefined): string {
+  if (!code) return formatChartVal(v);
+  const sections = splitFormatSections(code);
+  // Section selection per §18.8.30: positive;negative;zero;text. When the
+  // negative section is omitted a negative number is formatted with the
+  // positive section and a leading minus, which the caller must prepend.
+  let section: string;
+  if (v > 0) section = sections[0] ?? code;
+  else if (v < 0) section = sections[1] ?? sections[0] ?? code;
+  else section = sections[2] ?? sections[0] ?? code;
+  if (section === '') return '';
+  // Negative-without-explicit-section: format absolute value with positive
+  // section and prepend '-' unless the section itself already begins with a
+  // literal minus.
+  const needsLeadingMinus = v < 0 && sections.length < 2;
+  const abs = Math.abs(v);
+  return (needsLeadingMinus ? '-' : '') + applyChartNumberSection(abs, section);
+}
+
+/**
+ * Split a format code on unescaped semicolons. Quotes, `[...]` metadata, and
+ * `\;` are treated as opaque so `"a;b"` and `\;` stay in a single section.
+ */
+function splitFormatSections(code: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  for (let i = 0; i < code.length; i++) {
+    const c = code[i];
+    if (c === '\\' && i + 1 < code.length) { buf += c + code[i + 1]; i++; continue; }
+    if (c === '"') {
+      buf += c;
+      i++;
+      while (i < code.length && code[i] !== '"') { buf += code[i]; i++; }
+      if (i < code.length) buf += code[i];
+      continue;
+    }
+    if (c === '[') {
+      buf += c;
+      i++;
+      while (i < code.length && code[i] !== ']') { buf += code[i]; i++; }
+      if (i < code.length) buf += code[i];
+      continue;
+    }
+    if (c === ';') { out.push(buf); buf = ''; continue; }
+    buf += c;
+  }
+  out.push(buf);
+  return out;
+}
+
+function applyChartNumberSection(abs: number, section: string): string {
+  // Tokenize the section, separating numeric-pattern runs (`#`, `0`, `.`,
+  // `,`, `?`) from literal runs so percent / decimal handling runs once.
+  type Tok = { kind: 'lit' | 'num'; text: string };
+  const toks: Tok[] = [];
+  let i = 0;
+  let pushedNum = false;
+  let percent = false;
+  while (i < section.length) {
+    const c = section[i];
+    if (c === '"') {
+      i++;
+      let s = '';
+      while (i < section.length && section[i] !== '"') { s += section[i]; i++; }
+      if (i < section.length) i++;
+      toks.push({ kind: 'lit', text: s });
+      continue;
+    }
+    if (c === '\\' && i + 1 < section.length) {
+      toks.push({ kind: 'lit', text: section[i + 1] });
+      i += 2;
+      continue;
+    }
+    if (c === '_' && i + 1 < section.length) {
+      // `_x` pads a width of x — render as a single space, matching Excel
+      // alignment padding without caring about exact glyph metrics.
+      toks.push({ kind: 'lit', text: ' ' });
+      i += 2;
+      continue;
+    }
+    if (c === '*' && i + 1 < section.length) {
+      // `*x` fills the remaining column width with x; we can't know the
+      // column width at this layer so we drop it.
+      i += 2;
+      continue;
+    }
+    if (c === '[') {
+      i++;
+      while (i < section.length && section[i] !== ']') i++;
+      if (i < section.length) i++;
+      continue;
+    }
+    if (c === '%') { percent = true; toks.push({ kind: 'lit', text: '%' }); i++; continue; }
+    if (c === '#' || c === '0' || c === '.' || c === ',' || c === '?') {
+      let run = '';
+      while (
+        i < section.length &&
+        (section[i] === '#' || section[i] === '0' || section[i] === '.' ||
+         section[i] === ',' || section[i] === '?')
+      ) { run += section[i]; i++; }
+      toks.push({ kind: 'num', text: run });
+      pushedNum = true;
+      continue;
+    }
+    // Everything else (currency symbols like ¥, $, parens, spaces) is literal.
+    toks.push({ kind: 'lit', text: c });
+    i++;
+  }
+  if (!pushedNum) {
+    // No numeric pattern at all — section is purely literal (e.g. `"N/A"`).
+    return toks.map(t => t.text).join('');
+  }
+  const value = percent ? abs * 100 : abs;
+  // Merge numeric tokens into one pattern — Excel treats `#,##0.00` as a
+  // single pattern even when flanked by literals. We keep the literal tokens
+  // where they are and replace the first num token with the formatted number,
+  // dropping subsequent num tokens (they're all part of the same pattern).
+  let pattern = '';
+  for (const t of toks) if (t.kind === 'num') pattern += t.text;
+  const formatted = formatNumericPattern(value, pattern);
+  let seenNum = false;
+  return toks.map(t => {
+    if (t.kind === 'lit') return t.text;
+    if (seenNum) return '';
+    seenNum = true;
+    return formatted;
+  }).join('');
+}
+
+function formatNumericPattern(value: number, pattern: string): string {
+  // Detect thousands separator (a `,` between digit placeholders) and the
+  // number of decimal places (digit chars after `.`).
+  let dotIdx = pattern.indexOf('.');
+  const intPart = dotIdx >= 0 ? pattern.slice(0, dotIdx) : pattern;
+  const fracPart = dotIdx >= 0 ? pattern.slice(dotIdx + 1) : '';
+  const thousands = /,/.test(intPart);
+  const fracDigits = (fracPart.match(/[#0?]/g) ?? []).length;
+  // Minimum integer digits = count of `0` in integer part.
+  const minIntDigits = (intPart.replace(/,/g, '').match(/0/g) ?? []).length;
+  const rounded = value.toFixed(fracDigits);
+  const [ints, fracs = ''] = rounded.split('.');
+  const paddedInts = ints.padStart(minIntDigits, '0');
+  const withSeparators = thousands ? paddedInts.replace(/\B(?=(\d{3})+(?!\d))/g, ',') : paddedInts;
+  if (fracDigits === 0) return withSeparators;
+  return `${withSeparators}.${fracs.padEnd(fracDigits, '0')}`;
 }
 
 function drawAxisTitle(
@@ -268,6 +423,66 @@ function chartCategories(chart: ChartModel): string[] {
   return n > 0 ? Array.from({ length: n }, (_, i) => String(i + 1)) : [];
 }
 
+/**
+ * Draw a bar data label with the ECMA-376 §21.2.2.16 `dLblPos` semantics.
+ *
+ * For a vertical bar the coordinates describe the rectangle top-left + width +
+ * height; for a horizontal bar they describe the bar's left-edge `bx`, top `by`,
+ * length `barL`, and thickness `barW`. When `position` is "inBase" / "inEnd" /
+ * "ctr" the label sits inside the bar; "outEnd" (default for clustered bars)
+ * nudges the text just past the far edge. An explicit `color` overrides the
+ * default dark label fill — Excel's workbook typically pairs "inBase" with a
+ * white text color so labels stay readable against the bar fill.
+ */
+function drawBarDataLabel(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bx: number, by: number, barL: number, barW: number,
+  orient: 'vertical' | 'horizontal',
+  position: string | null,
+  color: string | null,
+): void {
+  const pos = (position ?? 'outEnd');
+  const fill = color ? `#${color}` : '#333';
+  ctx.fillStyle = fill;
+  if (orient === 'vertical') {
+    // bx/by = top-left of bar rect (bar grows upward from by+barL toward by).
+    // barL here is bar height (pixels) and barW is bar width.
+    const cx = bx + barW / 2;
+    if (pos === 'inBase') {
+      ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
+      ctx.fillText(text, cx, by + barL - 2);
+    } else if (pos === 'inEnd') {
+      ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+      ctx.fillText(text, cx, by + 2);
+    } else if (pos === 'ctr') {
+      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, cx, by + barL / 2);
+    } else {
+      // outEnd / default: just above the bar's top edge (by).
+      ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
+      ctx.fillText(text, cx, by - 1);
+    }
+  } else {
+    // Horizontal: bar grows to the right from bx.
+    const cy = by + barW / 2;
+    if (pos === 'inBase') {
+      ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, bx + 4, cy);
+    } else if (pos === 'inEnd') {
+      ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, bx + barL - 4, cy);
+    } else if (pos === 'ctr') {
+      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, bx + barL / 2, cy);
+    } else {
+      // outEnd / default: just past the bar's right edge.
+      ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, bx + barL + 2, cy);
+    }
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Bar chart — vertical columns + horizontal bars, clustered + stacked +
 // percentStacked. Also handles mixed bar+line series (seriesType per series).
@@ -308,8 +523,11 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     l: w * 0.12 + valTitleW + legLeftW,
   };
   if (isH) {
-    pad.l = w * 0.22 + valTitleW + legLeftW;
-    pad.b = h * 0.08 + catTitleH + legBottomH;
+    // With the category axis hidden (`c:catAx/c:delete val="1"`) there are no
+    // category tick labels to reserve room for — tighten the left margin so
+    // the bars can extend to the chart edge, matching Excel's rendering.
+    pad.l = (chart.catAxisHidden ? w * 0.03 : w * 0.22) + valTitleW + legLeftW;
+    pad.b = (chart.valAxisHidden ? h * 0.02 : h * 0.08) + catTitleH + legBottomH;
   }
 
   drawChartTitle(ctx, chart, x, y + titleTopPad, w, titleFontPx);
@@ -349,7 +567,9 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   if (!chart.valAxisHidden) {
     for (let si = 0; si <= steps; si++) {
       const val = si * step;
-      const label = pct ? `${Math.round(val)}%` : formatChartVal(val);
+      const label = pct
+        ? `${Math.round(val)}%`
+        : formatChartValWithCode(val, chart.valAxisFormatCode);
       if (!isH) {
         const gy = py0 + ph - (val / axMax) * ph;
         ctx.strokeStyle = si === 0 ? '#aaa' : gridColor;
@@ -375,10 +595,28 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
   }
 
+  // Bar cluster geometry — ECMA-376 §21.2.2.13 (gapWidth = % of bar width
+  // between categories, default 150) and §21.2.2.25 (overlap = signed % of
+  // bar width within a cluster, default 0). Within a cluster the pitch
+  // between consecutive bars is `barW * (1 - overlap/100)`, so with N series:
+  //   clusterWidth = barW + (N - 1) * barW * (1 - overlap/100)
+  //   catGap       = clusterWidth + barW * gapWidth/100
+  //                = barW * (1 + (N-1) * (1 - overlap/100) + gapWidth/100)
+  // Solving for barW gives the formula below. Stacked charts render one bar
+  // per category so we treat them as N=1 and overlap=0.
   const catGap = !isH ? pw / n : ph / n;
-  const barW   = catGap * (stacked ? 0.6 : 0.6 / Math.max(1, barSeries.length));
-  const clusterGap = stacked ? 0 : catGap * 0.6 / Math.max(1, barSeries.length);
-  const catStart   = catGap * 0.2;
+  const nSeriesEffective = stacked ? 1 : Math.max(1, barSeries.length);
+  const overlapPct  = stacked ? 0 : (chart.barOverlap ?? 0);
+  const gapWidthPct = chart.barGapWidth ?? 150;
+  const denom = 1 + (nSeriesEffective - 1) * (1 - overlapPct / 100) + gapWidthPct / 100;
+  const barW  = catGap / denom;
+  // Pitch between bars within a cluster (not the gap — the left-edge to
+  // left-edge distance). Kept named `clusterGap` for continuity with the
+  // prior implementation, which also used it as a pitch.
+  const clusterGap = stacked ? 0 : barW * (1 - overlapPct / 100);
+  const clusterWidth = barW + (nSeriesEffective - 1) * clusterGap;
+  // Center the cluster inside the category slot.
+  const catStart   = (catGap - clusterWidth) / 2;
 
   for (let ci = 0; ci < n; ci++) {
     let stackOffset = 0;
@@ -403,24 +641,51 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         ctx.fillStyle = color;
         ctx.fillRect(bx, by, barW, barH);
         if (chart.showDataLabels && val > 0) {
-          const lsz = Math.max(7, Math.min(10, barW * 0.7));
+          const lsz = Math.max(7, Math.min(11, barW * 0.6));
           ctx.font = `bold ${lsz}px sans-serif`;
-          ctx.fillStyle = '#333'; ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
-          ctx.fillText(pct ? `${Math.round(val)}%` : formatChartVal(val), bx + barW / 2, by - 1);
+          const text = pct
+            ? `${Math.round(val)}%`
+            : formatChartValWithCode(
+                val,
+                chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
+              );
+          drawBarDataLabel(
+            ctx, text,
+            bx, by, barW, barH,
+            'vertical',
+            chart.dataLabelPosition ?? null,
+            chart.dataLabelFontColor ?? null,
+          );
         }
       } else {
+        // Excel renders horizontal clustered bars with series 0 at the BOTTOM
+        // of each category cluster (so the legend's top entry matches the bar
+        // at the top of the plot). Reverse the per-series offset so `order=0`
+        // ends up at the bottom; stacked horizontal bars use a single anchor.
+        const siVisual = stacked ? si : (barSeries.length - 1 - si);
         const by = stacked
           ? py0 + (n - 1 - ci) * catGap + catStart
-          : py0 + (n - 1 - ci) * catGap + catStart + si * clusterGap;
+          : py0 + (n - 1 - ci) * catGap + catStart + siVisual * clusterGap;
         const barL = (val / axMax) * pw;
         const bx   = stacked ? px0 + (stackOffset / axMax) * pw : px0;
         ctx.fillStyle = color;
         ctx.fillRect(bx, by, barL, barW);
         if (chart.showDataLabels && val > 0) {
-          const lsz = Math.max(7, Math.min(10, barW * 0.7));
+          const lsz = Math.max(7, Math.min(11, barW * 0.6));
           ctx.font = `bold ${lsz}px sans-serif`;
-          ctx.fillStyle = '#333'; ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
-          ctx.fillText(pct ? `${Math.round(val)}%` : formatChartVal(val), bx + barL + 2, by + barW / 2);
+          const text = pct
+            ? `${Math.round(val)}%`
+            : formatChartValWithCode(
+                val,
+                chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
+              );
+          drawBarDataLabel(
+            ctx, text,
+            bx, by, barL, barW,
+            'horizontal',
+            chart.dataLabelPosition ?? null,
+            chart.dataLabelFontColor ?? null,
+          );
         }
       }
       if (stacked) stackOffset += val;
@@ -472,7 +737,13 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     }
   }
 
-  drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleH + 2);
+  // Horizontal clustered bars: Excel mirrors the series order between the
+  // plot and the legend so the legend's first entry matches the top bar. We
+  // already flipped the bar rendering; reverse the legend series too.
+  const legendChart = isH && !stacked
+    ? { ...chart, series: [...chart.series].reverse() }
+    : chart;
+  drawLegendForLayout(ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph, titleH + 2);
   if (chart.catAxisTitle) drawAxisTitle(ctx, chart.catAxisTitle, px0, py0, pw, ph, 'cat', axisFontSz);
   if (chart.valAxisTitle) drawAxisTitle(ctx, chart.valAxisTitle, px0, py0, pw, ph, 'val', axisFontSz);
 }
@@ -562,7 +833,7 @@ function renderLineChart(
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy);
       ctx.fillStyle = '#555'; ctx.textAlign = 'right';
-      ctx.fillText(formatChartVal(v), px0 - 6, gy);
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 6, gy);
     }
   }
 
@@ -698,7 +969,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       ctx.lineWidth = si === 0 ? 1 : 0.5;
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
       ctx.fillStyle = '#555'; ctx.textAlign = 'right';
-      ctx.fillText(formatChartVal(v), px0 - 4, gy);
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
     }
   }
   ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
@@ -1012,7 +1283,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.strokeStyle = '#e0e0e0'; ctx.lineWidth = 0.5;
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
       ctx.fillStyle = '#555'; ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
-      ctx.fillText(formatChartVal(v), px0 - 4, gy);
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
     }
   }
   ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -35,6 +35,12 @@ export interface ChartSeries {
    * that don't parse markers (e.g. pptx today) keep their existing behavior.
    */
   showMarker?: boolean | null;
+  /**
+   * Excel number-format code for this series' values (ECMA-376 §21.2.2.37,
+   * `<c:val>/<c:numRef>/<c:formatCode>`). Used to format data labels when the
+   * chart-level `<c:dLbls><c:numFmt>` is not set. null = no series-level code.
+   */
+  valFormatCode?: string | null;
 }
 
 /**
@@ -103,6 +109,36 @@ export interface ChartModel {
    *  rectangle while still letting `legendPos` decide which side of the plot
    *  gets the reserved band. null = use default layout. */
   legendManualLayout?: LegendManualLayout | null;
+  /**
+   * `<c:valAx><c:numFmt@formatCode>` — format code applied to value-axis tick
+   * labels (ECMA-376 §21.2.2.21). null = plain numeric formatting.
+   */
+  valAxisFormatCode?: string | null;
+  /**
+   * `<c:barChart><c:gapWidth>` — space between category groups as a
+   * percentage of bar width (ECMA-376 §21.2.2.13). Default per spec is 150.
+   * null = renderer default.
+   */
+  barGapWidth?: number | null;
+  /**
+   * `<c:barChart><c:overlap>` — signed percentage overlap between bars in the
+   * same category cluster (ECMA-376 §21.2.2.25). Negative = gap, positive =
+   * overlap, 0 = flush. Range [-100, 100]. null = renderer default (0).
+   */
+  barOverlap?: number | null;
+  /**
+   * `<c:dLbls><c:dLblPos>` — data label position (ECMA-376 §21.2.2.16).
+   * "ctr"|"inBase"|"inEnd"|"outEnd"|"l"|"r"|"t"|"b"|"bestFit" etc.
+   */
+  dataLabelPosition?: string | null;
+  /** Hex (no `#`) for data label text, resolved from `<c:dLbls><c:txPr>`. */
+  dataLabelFontColor?: string | null;
+  /**
+   * `<c:dLbls><c:numFmt@formatCode>` — chart-level override for data label
+   * number format (ECMA-376 §21.2.2.35). When absent, `valFormatCode` on each
+   * series is used.
+   */
+  dataLabelFormatCode?: string | null;
 }
 
 export interface LegendManualLayout {

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -155,6 +155,17 @@ pub struct ChartSeries {
     /// falling back to the chart-type-level `<c:lineChart><c:marker val>`
     /// (§21.2.2.33). Absent markers default to hidden for line charts.
     pub show_marker: bool,
+    /// `<c:val>/<c:numRef>/<c:numCache>/<c:formatCode>` — Excel number format
+    /// code applied to the series' numeric values (e.g. `"¥"#,##0`). When the
+    /// chart-level `<c:dLbls><c:numFmt>` is absent this governs how data
+    /// labels are formatted per ECMA-376 §21.2.2.37.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_format_code: Option<String>,
+    /// `<c:ser><c:order val>` — display order of this series (stacking
+    /// ordering + legend ordering) per ECMA-376 §21.2.2.28. Lower `order`
+    /// renders first/below; Excel's legend for horizontal bar charts reverses
+    /// this so low-order series end up at the bottom of the plot.
+    pub order: usize,
 }
 
 /// Parsed chart data extracted from `xl/charts/chartN.xml`.
@@ -215,6 +226,14 @@ pub struct ChartData {
     /// Value axis tick-label font size in hundredths of a point.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub val_axis_font_size_hpt: Option<i32>,
+    /// ECMA-376 §21.2.2.40 — `<c:catAx><c:delete val="1"/>` hides the category
+    /// axis (labels, ticks, and axis line).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub cat_axis_hidden: bool,
+    /// ECMA-376 §21.2.2.40 — `<c:valAx><c:delete val="1"/>` hides the value
+    /// axis (labels, ticks, and axis line).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub val_axis_hidden: bool,
     /// Outer `<c:chartSpace><c:spPr>` fill resolution (ECMA-376 §21.2.2.5).
     /// `Some(hex)` for `<a:solidFill>`, `None` for `<a:noFill>` or when spPr is
     /// absent *and* no explicit fill is declared. An absent `chart_bg` on the
@@ -232,6 +251,29 @@ pub struct ChartData {
     /// None = use the default side-based layout from `legend_pos`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub legend_manual_layout: Option<LegendManualLayout>,
+    /// `<c:barChart><c:gapWidth val>` — space between category groups as a
+    /// percentage of bar width (ECMA-376 §21.2.2.13). Default per spec is 150.
+    /// None = renderer default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bar_gap_width: Option<i32>,
+    /// `<c:barChart><c:overlap val>` — overlap/gap between bars in a cluster as
+    /// a signed percentage (ECMA-376 §21.2.2.25). Positive = bars overlap,
+    /// negative = gap between bars, 0 = flush. Range [-100, 100].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bar_overlap: Option<i32>,
+    /// `<c:dLbls><c:dLblPos val>` (ECMA-376 §21.2.2.16). One of
+    /// "ctr"|"inBase"|"inEnd"|"outEnd"|"l"|"r"|"t"|"b"|"bestFit" etc.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_label_position: Option<String>,
+    /// Hex (no `#`) resolved from `<c:dLbls><c:txPr>` text fill. Used for data
+    /// label text color (e.g. "FFFFFF" when labels sit inside filled bars).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_label_font_color: Option<String>,
+    /// `<c:dLbls><c:numFmt@formatCode>` — optional chart-level override for
+    /// data label number format (ECMA-376 §21.2.2.35). Takes precedence over
+    /// per-series `val_format_code` at render time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_label_format_code: Option<String>,
 }
 
 /// `<c:manualLayout>` coordinates for a legend (ECMA-376 §21.2.2.31). Fractions
@@ -3083,6 +3125,15 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
     let mut cat_axis_font_size_hpt: Option<i32> = None;
     let mut val_axis_font_size_hpt: Option<i32> = None;
     let mut val_axis_format_code: Option<String> = None;
+    // ECMA-376 §21.2.2.40 — `<c:delete val="1"/>` on a `<c:catAx>`/`<c:valAx>`
+    // hides the axis (labels, ticks, and lines). Default is "0" (visible).
+    let mut cat_axis_hidden = false;
+    let mut val_axis_hidden = false;
+    let mut bar_gap_width: Option<i32> = None;
+    let mut bar_overlap: Option<i32> = None;
+    let mut data_label_position: Option<String> = None;
+    let mut data_label_font_color: Option<String> = None;
+    let mut data_label_format_code: Option<String> = None;
 
     // Recognised chart-type element names → our internal type strings
     let type_map: &[(&str, &str)] = &[
@@ -3111,6 +3162,13 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                 if cat_axis_font_size_hpt.is_none() {
                     cat_axis_font_size_hpt = extract_axis_tick_label_size(&child, c_ns, a_ns);
                 }
+                if let Some(del) = child.children()
+                    .find(|n| n.tag_name().name() == "delete" && n.tag_name().namespace() == Some(c_ns))
+                {
+                    if del.attribute("val").unwrap_or("0") != "0" {
+                        cat_axis_hidden = true;
+                    }
+                }
                 continue;
             }
             "valAx" => {
@@ -3125,6 +3183,13 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                         .find(|n| n.tag_name().name() == "numFmt" && n.tag_name().namespace() == Some(c_ns))
                         .and_then(|n| n.attribute("formatCode").map(|s| s.to_string()))
                         .filter(|s| !s.is_empty() && s != "General");
+                }
+                if let Some(del) = child.children()
+                    .find(|n| n.tag_name().name() == "delete" && n.tag_name().namespace() == Some(c_ns))
+                {
+                    if del.attribute("val").unwrap_or("0") != "0" {
+                        val_axis_hidden = true;
+                    }
                 }
                 continue;
             }
@@ -3157,12 +3222,54 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                 "marker"   => {
                     chart_marker_default = attr_node.attribute("val").unwrap_or("0") != "0";
                 }
+                "gapWidth" => {
+                    // ECMA-376 §21.2.2.13 — percent of bar width between category
+                    // groups (default 150 per spec). Only meaningful on bar charts.
+                    if bar_gap_width.is_none() {
+                        bar_gap_width = attr_node.attribute("val").and_then(|v| v.parse().ok());
+                    }
+                }
+                "overlap"  => {
+                    // ECMA-376 §21.2.2.25 — signed percent of bar width for the
+                    // overlap within a cluster (negative = gap).
+                    if bar_overlap.is_none() {
+                        bar_overlap = attr_node.attribute("val").and_then(|v| v.parse().ok());
+                    }
+                }
                 "dLbls"    => {
                     for d in attr_node.children().filter(|n| n.is_element()) {
                         match d.tag_name().name() {
                             "showVal" | "showPercent" => {
                                 if d.attribute("val").unwrap_or("1") != "0" {
                                     show_data_labels = true;
+                                }
+                            }
+                            "dLblPos" => {
+                                if data_label_position.is_none() {
+                                    data_label_position = d.attribute("val").map(|s| s.to_string());
+                                }
+                            }
+                            "numFmt" => {
+                                if data_label_format_code.is_none() {
+                                    data_label_format_code = d.attribute("formatCode")
+                                        .map(|s| s.to_string())
+                                        .filter(|s| !s.is_empty() && s != "General");
+                                }
+                            }
+                            "txPr" => {
+                                // Resolve first solidFill under defRPr/rPr for
+                                // the data label text color. Common Excel
+                                // pattern: <a:solidFill><a:schemeClr val="bg1"/>
+                                // → white when bars are dark.
+                                if data_label_font_color.is_none() {
+                                    for desc in d.descendants().filter(|n| n.is_element()) {
+                                        if desc.tag_name().namespace() != Some(a_ns) { continue; }
+                                        if desc.tag_name().name() != "solidFill" { continue; }
+                                        if let Some(c) = resolve_fill_color(&desc, theme_colors) {
+                                            data_label_font_color = Some(c);
+                                            break;
+                                        }
+                                    }
                                 }
                             }
                             _ => {}
@@ -3194,6 +3301,11 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
         }
     }
 
+    // Stable-sort by `c:order` so the array is in Excel's display order.
+    // ECMA-376 §21.2.2.28 — `<c:order>` is the authoritative stacking /
+    // legend order, independent of document order.
+    all_series.sort_by_key(|s| s.order);
+
     Some(ChartData {
         chart_type: primary_type,
         bar_dir,
@@ -3215,6 +3327,13 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
         chart_bg,
         has_chart_sp_pr,
         legend_manual_layout,
+        cat_axis_hidden,
+        val_axis_hidden,
+        bar_gap_width,
+        bar_overlap,
+        data_label_position,
+        data_label_font_color,
+        data_label_format_code,
     })
 }
 
@@ -3378,12 +3497,32 @@ fn parse_chart_series(
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(0);
 
+    // `<c:order val>` (ECMA-376 §21.2.2.28) — series display order. Used for
+    // stacking and legend ordering. Defaults to 0.
+    let order: usize = node.children()
+        .find(|n| n.tag_name().name() == "order" && n.tag_name().namespace() == Some(c_ns))
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+
     // For scatter: xVal → categories (as strings), yVal → values
     // For others:  cat  → categories,             val  → values
     let (cat_tag, val_tag) = if ser_type == "scatter" { ("xVal", "yVal") } else { ("cat", "val") };
 
     let categories = collect_str_cache(node, c_ns, cat_tag);
     let values     = collect_num_cache(node, c_ns, val_tag);
+    // `<c:val><c:numRef><c:numCache><c:formatCode>` (ECMA-376 §21.2.2.37)
+    // preserves the Excel number format Excel stamped onto the cached values
+    // at save time; absent "General" codes return None so the renderer can
+    // fall back cleanly.
+    let val_format_code = node.children()
+        .find(|n| n.tag_name().name() == val_tag && n.tag_name().namespace() == Some(c_ns))
+        .and_then(|val_node| val_node.descendants()
+            .find(|n| n.is_element()
+                && n.tag_name().name() == "formatCode"
+                && n.tag_name().namespace() == Some(c_ns)))
+        .and_then(|n| n.text().map(|s| s.to_string()))
+        .filter(|s| !s.is_empty() && s != "General");
 
     // Series fill color from c:spPr/a:solidFill (supports a:srgbClr and a:schemeClr).
     // For schemeClr, resolves "accentN"/"dk1"/etc. against the workbook theme.
@@ -3423,6 +3562,8 @@ fn parse_chart_series(
         values,
         color,
         show_marker,
+        val_format_code,
+        order,
     }
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3550,14 +3550,15 @@ function adaptChartData(chart: ChartData): ChartModel {
       seriesType: s.seriesType ?? null,
       categories: s.categories.length > 0 ? s.categories : null,
       showMarker: s.showMarker ?? null,
+      valFormatCode: s.valFormatCode ?? null,
     })),
     showDataLabels: chart.showDataLabels ?? false,
     valMin: null,
     valMax: null,
     catAxisTitle: chart.catAxisTitle ?? null,
     valAxisTitle: chart.valAxisTitle ?? null,
-    catAxisHidden: false,
-    valAxisHidden: false,
+    catAxisHidden: chart.catAxisHidden ?? false,
+    valAxisHidden: chart.valAxisHidden ?? false,
     plotAreaBg: null,
     // `<c:chartSpace><c:spPr>` resolution: when the spPr element was present
     // we honor whatever it said (solid hex or `<a:noFill/>` → null =
@@ -3581,6 +3582,12 @@ function adaptChartData(chart: ChartData): ChartModel {
     valAxisFontSizeHpt: chart.valAxisFontSizeHpt ?? null,
     dataLabelFontSizeHpt: null,
     subtotalIndices: [],
+    valAxisFormatCode: chart.valAxisFormatCode ?? null,
+    barGapWidth: chart.barGapWidth ?? null,
+    barOverlap: chart.barOverlap ?? null,
+    dataLabelPosition: chart.dataLabelPosition ?? null,
+    dataLabelFontColor: chart.dataLabelFontColor ?? null,
+    dataLabelFormatCode: chart.dataLabelFormatCode ?? null,
   };
 }
 

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -121,6 +121,11 @@ export interface XlsxChartSeries {
   /** Marker visibility resolved from `<c:marker>`/chart-level default
    *  (ECMA-376 §21.2.2.32). */
   showMarker?: boolean;
+  /** `<c:val>/<c:numRef>/<c:formatCode>` — Excel number format for series
+   *  values (ECMA-376 §21.2.2.37). */
+  valFormatCode?: string | null;
+  /** `<c:ser><c:order>` — stacking/legend display order (§21.2.2.28). */
+  order?: number;
 }
 
 /**
@@ -168,6 +173,26 @@ export interface ChartData {
   hasChartSpPr?: boolean;
   /** `<c:legend><c:manualLayout>` fractions of chart space (§21.2.2.31). */
   legendManualLayout?: LegendManualLayout | null;
+  /** `<c:catAx><c:delete val="1"/>` — hide the category axis (§21.2.2.40). */
+  catAxisHidden?: boolean;
+  /** `<c:valAx><c:delete val="1"/>` — hide the value axis (§21.2.2.40). */
+  valAxisHidden?: boolean;
+  /** `<c:valAx><c:numFmt@formatCode>` — number format for value-axis tick
+   *  labels (ECMA-376 §21.2.2.21). */
+  valAxisFormatCode?: string | null;
+  /** `<c:barChart><c:gapWidth>` — space between category groups as a percent
+   *  of bar width (§21.2.2.13). */
+  barGapWidth?: number | null;
+  /** `<c:barChart><c:overlap>` — signed percent overlap between bars in a
+   *  cluster (§21.2.2.25). Negative = gap. */
+  barOverlap?: number | null;
+  /** `<c:dLbls><c:dLblPos>` — data label position (§21.2.2.16). */
+  dataLabelPosition?: string | null;
+  /** Hex (no `#`) for data label text color, resolved from `<c:dLbls><c:txPr>`. */
+  dataLabelFontColor?: string | null;
+  /** `<c:dLbls><c:numFmt@formatCode>` — chart-level override for data label
+   *  number format (§21.2.2.35). */
+  dataLabelFormatCode?: string | null;
 }
 
 export interface LegendManualLayout {


### PR DESCRIPTION
## Summary
- Parses and renders ECMA-376 bar-chart properties that were being dropped: `<c:gapWidth>`, `<c:overlap>`, `<c:dLblPos>`, per-series `<c:order>`, chart-level and series-level `<c:numFmt>/<c:formatCode>`, and axis `<c:delete>`.
- Adds an Excel-format-code tokenizer in the core chart renderer (`formatChartValWithCode`) so currency-prefixed values like `"¥"#,##0` now render correctly on both value-axis tick labels and data labels.
- Reverses series for horizontal clustered bars so the legend's first entry maps to the top bar, matching Excel's convention.

**Sample:** In private/sample-1.xlsx's 休日の予算 sheet the budget bar chart now shows the two bars with the correct gap, white `¥377.00` / `¥233.00` data labels inside the bars, and ¥-prefixed axis tick labels — matching the Excel rendering.

## Test plan
- [x] Manual: `pnpm storybook` → XlsxViewer → PrivateExamples → Sample 1, visually compared against Excel reference
- [x] `pnpm tsc --noEmit` clean for `packages/core` and `packages/xlsx`
- [x] `wasm-pack build` clean; copied artifacts to `packages/xlsx/src/wasm`
- [x] pptx VRT: 10 public tests pass (61 private-sample 404s unrelated)