### PR TITLE
fix(xlsx): white data labels via per-series c:dLbls/txPr

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -3289,6 +3289,56 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                 shared_categories = s.categories.clone();
             }
             all_series.push(s);
+
+            // Per-series `<c:ser><c:dLbls>` fallback for chart-level
+            // properties that Excel commonly writes on each series instead
+            // of (or in addition to) the chart-level `<c:dLbls>`. Per
+            // ECMA-376 §21.2.2.47 a series-level dLbls applies to that
+            // series's data points; for the renderer we only need one
+            // value, so the first series encountered "wins". This is how
+            // the default-color/position/format travels when Excel emits
+            // `<c:dLblPos val="inBase"/>` + `<c:txPr>` per series rather
+            // than on the chart.
+            if let Some(ser_dlbls) = ser_node.children()
+                .find(|n| n.is_element()
+                    && n.tag_name().name() == "dLbls"
+                    && n.tag_name().namespace() == Some(c_ns))
+            {
+                for d in ser_dlbls.children().filter(|n| n.is_element()) {
+                    match d.tag_name().name() {
+                        "showVal" | "showPercent" => {
+                            if d.attribute("val").unwrap_or("1") != "0" {
+                                show_data_labels = true;
+                            }
+                        }
+                        "dLblPos" => {
+                            if data_label_position.is_none() {
+                                data_label_position = d.attribute("val").map(|s| s.to_string());
+                            }
+                        }
+                        "numFmt" => {
+                            if data_label_format_code.is_none() {
+                                data_label_format_code = d.attribute("formatCode")
+                                    .map(|s| s.to_string())
+                                    .filter(|s| !s.is_empty() && s != "General");
+                            }
+                        }
+                        "txPr" => {
+                            if data_label_font_color.is_none() {
+                                for desc in d.descendants().filter(|n| n.is_element()) {
+                                    if desc.tag_name().namespace() != Some(a_ns) { continue; }
+                                    if desc.tag_name().name() != "solidFill" { continue; }
+                                    if let Some(c) = resolve_fill_color(&desc, theme_colors) {
+                                        data_label_font_color = Some(c);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to #95. Excel (at least Office 365) writes the data-label text run properties inside each `<c:ser><c:dLbls><c:txPr>` rather than on the chart-level `<c:dLbls>`. Without scanning the series-level block, white-on-bar labels rendered in the default dark color.
- The parser now also picks up `dLblPos`, `numFmt`, and `showVal/showPercent` from the per-series dLbls when the chart-level dLbls is silent. First series wins, which matches how the renderer consumes these single-value fields.

## Test plan
- [x] Storybook `XlsxViewer/PrivateExamples/Sample 1` — budget bar chart now shows ¥377.00 / ¥233.00 in white on the green / red bars (matches Excel).
- [x] Other bar charts that don't set a series-level txPr still render with the existing defaults (chart-level color is preferred when present — the per-series scan only fills in when `data_label_font_color.is_none()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)