### PR TITLE
feat(mcp-server): add OOXML MCP server (xlsx/docx/pptx tools)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +42,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -30,10 +77,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -44,6 +121,12 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -59,6 +142,40 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "derive_arbitrary"
@@ -96,10 +213,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -112,10 +251,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -134,10 +391,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -156,10 +453,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ooxml-mcp-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "docx-parser",
+ "pptx-parser",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "xlsx-parser",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pptx-parser"
@@ -193,6 +571,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +662,38 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -235,6 +726,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,10 +750,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -285,10 +840,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -333,6 +1011,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "packages/pptx/parser",
   "packages/docx/parser",
   "packages/xlsx/parser",
+  "packages/mcp-server",
 ]
 
 [workspace.dependencies]

--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -16,3 +16,10 @@ pub fn parse_docx(data: &[u8]) -> String {
         Err(e) => format!("{{\"error\":\"{}\"}}", e),
     }
 }
+
+/// Native equivalent of `parse_docx` for use from the MCP server.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_docx_native(data: &[u8]) -> Result<String, String> {
+    parser::parse(data)
+        .and_then(|doc| serde_json::to_string(&doc).map_err(|e| e.to_string()))
+}

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ooxml-mcp-server"
+version = "0.1.0"
+edition = "2021"
+description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
+license = "MIT"
+
+[[bin]]
+name = "ooxml-mcp-server"
+path = "src/main.rs"
+
+[dependencies]
+rmcp = { version = "1.5", features = ["server", "transport-io", "macros", "schemars"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+schemars = "1"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+xlsx-parser = { path = "../xlsx/parser" }
+docx-parser = { path = "../docx/parser" }
+pptx-parser = { path = "../pptx/parser" }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,69 +1,47 @@
 # ooxml-mcp-server
 
-A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes the OOXML Rust parsers as structured query tools for AI agents.
+A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that lets AI agents read Excel, Word, and PowerPoint files without any additional code.
 
-Agents can ask questions like *"What formulas are in Sheet1?"* or *"Extract all text from this presentation"* without writing any parsing code themselves.
+---
 
-## Installation
+## Quick start
 
-**Prerequisites:** [Rust toolchain](https://rustup.rs/) (stable, 1.75+)
+### Step 1 — Install Rust
 
-> **Note:** This is a pure-Rust binary. You do **not** need Node.js, npm, or pnpm — those are only required for the browser renderer packages in the rest of the monorepo.
-
-```bash
-# 1. Clone the repository
-git clone https://github.com/yukiyokotani/office-open-xml-viewer.git
-cd office-open-xml-viewer
-
-# 2. Install the binary (builds the Rust parsers automatically)
-cargo install --path packages/mcp-server
-```
-
-The binary lands in `~/.cargo/bin/ooxml-mcp-server`. Confirm it is on your `PATH`:
+Skip this if `rustc --version` already prints a version number.
 
 ```bash
-which ooxml-mcp-server   # → /Users/you/.cargo/bin/ooxml-mcp-server
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+# Follow the on-screen prompt, then open a new terminal tab.
 ```
 
-If `~/.cargo/bin` is not on `PATH`, add this to your shell profile (`~/.zshrc`, `~/.bashrc`, …):
+### Step 2 — Install the MCP server
+
+No need to clone the repository. Run this single command:
+
+```bash
+cargo install --git https://github.com/yukiyokotani/office-open-xml-viewer.git \
+  --package ooxml-mcp-server
+```
+
+The first run downloads and compiles everything (~2 minutes). The binary is placed in `~/.cargo/bin/ooxml-mcp-server`.
+
+**Check it is on your PATH:**
+
+```bash
+which ooxml-mcp-server
+# expected: /Users/you/.cargo/bin/ooxml-mcp-server
+```
+
+If the command is not found, add this line to your shell profile (`~/.zshrc` or `~/.bashrc`) and open a new terminal:
 
 ```bash
 export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
----
+### Step 3 — Configure your AI client
 
-## Available Tools
-
-### xlsx
-
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `xlsx_parse` | `path` | Workbook overview: sheet names, IDs |
-| `xlsx_get_sheet_names` | `path` | Array of sheet names only |
-| `xlsx_get_sheet_dimensions` | `path`, `sheet` | Max row and column in a sheet |
-| `xlsx_get_cell_range` | `path`, `sheet`, `range` | Cell values and formulas for a range (e.g. `"A1:C10"`) |
-| `xlsx_get_formulas` | `path`, `sheet` | All formula cells with their cached values |
-
-`sheet` accepts either a sheet name (`"Sheet1"`) or a 0-based index (`"0"`).
-
-### docx
-
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `docx_extract_text` | `path` | Plain text from the entire document |
-| `docx_get_structure` | `path` | Paragraph/table structure with style info |
-| `docx_get_tables` | `path` | All tables with cell-by-cell contents |
-
-### pptx
-
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `pptx_get_slides` | `path` | Slide count and each slide's title |
-| `pptx_extract_text` | `path`, `slide_index?` | Text from all slides or a specific one (0-based) |
-| `pptx_get_slide_structure` | `path`, `slide_index` | All elements with position, size, and text |
-
-All `path` parameters accept absolute paths.
+Pick the client you use and follow the instructions in the section below.
 
 ---
 
@@ -71,7 +49,7 @@ All `path` parameters accept absolute paths.
 
 ### Claude Code
 
-Add to your project's `.mcp.json` (version-controlled, shared with the team):
+Create `.mcp.json` in your project root (or `~/.claude.json` for all projects):
 
 ```json
 {
@@ -84,35 +62,19 @@ Add to your project's `.mcp.json` (version-controlled, shared with the team):
 }
 ```
 
-Or to your personal global config `~/.claude.json` (applies to every project):
+Start Claude Code in that directory and run `/mcp` to confirm the server shows as connected.
 
-```json
-{
-  "mcpServers": {
-    "ooxml": {
-      "type": "stdio",
-      "command": "ooxml-mcp-server"
-    }
-  }
-}
-```
-
-After adding the config, run `/mcp` inside Claude Code to confirm the server is connected.
-
-**Usage example:**
+**Try it:**
 
 ```
-> What sheets are in /path/to/budget.xlsx?
-
-[Claude calls xlsx_get_sheet_names with {"path": "/path/to/budget.xlsx"}]
-→ ["Summary", "Q1", "Q2", "Q3", "Q4"]
+> What sheets are in /Users/me/Documents/budget.xlsx?
 ```
 
 ---
 
 ### GitHub Copilot (VS Code)
 
-Add `.vscode/mcp.json` to your workspace root:
+Create `.vscode/mcp.json` in your workspace root:
 
 ```json
 {
@@ -125,23 +87,21 @@ Add `.vscode/mcp.json` to your workspace root:
 }
 ```
 
-Then in VS Code, open the Command Palette (`⇧⌘P`) → **"MCP: List Servers"** to confirm the server appears as *running*.
+Open the Command Palette (`⇧⌘P`) → **MCP: List Servers** to confirm the server is running.
 
-> **Note:** MCP tools are only available in **Agent mode** (`@agent` in the Copilot Chat panel). They are not accessible in Ask or Edit modes.
+> MCP tools are only available in **Agent mode**. In the Copilot Chat panel, click the mode selector and choose **Agent** before asking a question.
 
-**Usage example (Copilot Chat, Agent mode):**
+**Try it:**
 
 ```
-@agent Summarise the formulas in Sheet1 of @/path/to/model.xlsx
+Extract all text from /Users/me/Documents/deck.pptx
 ```
-
-Copilot will call `xlsx_get_formulas` and present the results.
 
 ---
 
 ### Codex CLI (OpenAI)
 
-Add to `~/.codex/config.toml` (global, all projects):
+Add to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.ooxml]
@@ -149,37 +109,26 @@ command = "ooxml-mcp-server"
 args = []
 ```
 
-Or to `.codex/config.toml` in the project root (project-scoped):
+Restart Codex, then run `codex mcp list` to verify registration.
 
-```toml
-[mcp_servers.ooxml]
-command = "ooxml-mcp-server"
-args = []
-```
-
-Restart Codex after editing the config. Use `codex mcp list` to verify the server is registered.
-
-**Usage example:**
+**Try it:**
 
 ```bash
-codex "Extract all text from slides 1–3 of /path/to/deck.pptx"
+codex "Show me all formulas in Sheet1 of /Users/me/Documents/model.xlsx"
 ```
-
-Codex will call `pptx_extract_text` with `slide_index` set appropriately.
 
 ---
 
-## Full path (if not on PATH)
+## Troubleshooting: command not found in MCP config
 
-If `~/.cargo/bin` is not on your `PATH`, use the absolute path to the binary:
+Some launchers (VS Code, Codex) do not inherit your shell `PATH`. If the server fails to start with a "command not found" error, use the full path to the binary instead of just the name:
 
 ```bash
-# Find the binary
-which ooxml-mcp-server         # or:
+# Find the full path
 echo ~/.cargo/bin/ooxml-mcp-server
 ```
 
-Then replace `"ooxml-mcp-server"` with the full path in any config above:
+Then in your config:
 
 ```json
 "command": "/Users/you/.cargo/bin/ooxml-mcp-server"
@@ -191,11 +140,34 @@ command = "/Users/you/.cargo/bin/ooxml-mcp-server"
 
 ---
 
-## Building from source (without installing)
+## Available tools
 
-```bash
-cargo build --release -p ooxml-mcp-server
-# binary at: target/release/ooxml-mcp-server
-```
+### xlsx (Excel)
 
-Use the path `target/release/ooxml-mcp-server` in your MCP config.
+| Tool | Parameters | What it returns |
+|------|-----------|-----------------|
+| `xlsx_parse` | `path` | All sheet names and IDs |
+| `xlsx_get_sheet_names` | `path` | Sheet name list |
+| `xlsx_get_sheet_dimensions` | `path`, `sheet` | Number of rows and columns |
+| `xlsx_get_cell_range` | `path`, `sheet`, `range` | Cell values and formulas for a range like `"A1:C10"` |
+| `xlsx_get_formulas` | `path`, `sheet` | Every formula cell with its cached value |
+
+`sheet` can be a name (`"Sheet1"`) or a 0-based index (`"0"`).
+
+### docx (Word)
+
+| Tool | Parameters | What it returns |
+|------|-----------|-----------------|
+| `docx_extract_text` | `path` | All text as plain string |
+| `docx_get_structure` | `path` | Paragraph and table structure with style info |
+| `docx_get_tables` | `path` | All tables with each cell's text |
+
+### pptx (PowerPoint)
+
+| Tool | Parameters | What it returns |
+|------|-----------|-----------------|
+| `pptx_get_slides` | `path` | Slide count and each slide's title |
+| `pptx_extract_text` | `path`, `slide_index?` | Text from all slides, or one slide (0-based index) |
+| `pptx_get_slide_structure` | `path`, `slide_index` | All shapes with position, size, and text |
+
+All `path` parameters require absolute paths (e.g. `/Users/me/Documents/file.xlsx`).

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,17 +6,30 @@ Agents can ask questions like *"What formulas are in Sheet1?"* or *"Extract all 
 
 ## Installation
 
-**Prerequisites:** [Rust toolchain](https://rustup.rs/) (stable)
+**Prerequisites:** [Rust toolchain](https://rustup.rs/) (stable, 1.75+)
+
+> **Note:** This is a pure-Rust binary. You do **not** need Node.js, npm, or pnpm — those are only required for the browser renderer packages in the rest of the monorepo.
 
 ```bash
-# Install the binary globally
-cargo install --path packages/mcp-server
+# 1. Clone the repository
+git clone https://github.com/yukiyokotani/office-open-xml-viewer.git
+cd office-open-xml-viewer
 
-# Verify
-ooxml-mcp-server --help   # should print nothing and wait on stdin (MCP stdio mode)
+# 2. Install the binary (builds the Rust parsers automatically)
+cargo install --path packages/mcp-server
 ```
 
-The binary is placed in `~/.cargo/bin/ooxml-mcp-server` (make sure `~/.cargo/bin` is on `PATH`).
+The binary lands in `~/.cargo/bin/ooxml-mcp-server`. Confirm it is on your `PATH`:
+
+```bash
+which ooxml-mcp-server   # → /Users/you/.cargo/bin/ooxml-mcp-server
+```
+
+If `~/.cargo/bin` is not on `PATH`, add this to your shell profile (`~/.zshrc`, `~/.bashrc`, …):
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
 
 ---
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,188 @@
+# ooxml-mcp-server
+
+A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes the OOXML Rust parsers as structured query tools for AI agents.
+
+Agents can ask questions like *"What formulas are in Sheet1?"* or *"Extract all text from this presentation"* without writing any parsing code themselves.
+
+## Installation
+
+**Prerequisites:** [Rust toolchain](https://rustup.rs/) (stable)
+
+```bash
+# Install the binary globally
+cargo install --path packages/mcp-server
+
+# Verify
+ooxml-mcp-server --help   # should print nothing and wait on stdin (MCP stdio mode)
+```
+
+The binary is placed in `~/.cargo/bin/ooxml-mcp-server` (make sure `~/.cargo/bin` is on `PATH`).
+
+---
+
+## Available Tools
+
+### xlsx
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `xlsx_parse` | `path` | Workbook overview: sheet names, IDs |
+| `xlsx_get_sheet_names` | `path` | Array of sheet names only |
+| `xlsx_get_sheet_dimensions` | `path`, `sheet` | Max row and column in a sheet |
+| `xlsx_get_cell_range` | `path`, `sheet`, `range` | Cell values and formulas for a range (e.g. `"A1:C10"`) |
+| `xlsx_get_formulas` | `path`, `sheet` | All formula cells with their cached values |
+
+`sheet` accepts either a sheet name (`"Sheet1"`) or a 0-based index (`"0"`).
+
+### docx
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `docx_extract_text` | `path` | Plain text from the entire document |
+| `docx_get_structure` | `path` | Paragraph/table structure with style info |
+| `docx_get_tables` | `path` | All tables with cell-by-cell contents |
+
+### pptx
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `pptx_get_slides` | `path` | Slide count and each slide's title |
+| `pptx_extract_text` | `path`, `slide_index?` | Text from all slides or a specific one (0-based) |
+| `pptx_get_slide_structure` | `path`, `slide_index` | All elements with position, size, and text |
+
+All `path` parameters accept absolute paths.
+
+---
+
+## Configuration
+
+### Claude Code
+
+Add to your project's `.mcp.json` (version-controlled, shared with the team):
+
+```json
+{
+  "mcpServers": {
+    "ooxml": {
+      "type": "stdio",
+      "command": "ooxml-mcp-server"
+    }
+  }
+}
+```
+
+Or to your personal global config `~/.claude.json` (applies to every project):
+
+```json
+{
+  "mcpServers": {
+    "ooxml": {
+      "type": "stdio",
+      "command": "ooxml-mcp-server"
+    }
+  }
+}
+```
+
+After adding the config, run `/mcp` inside Claude Code to confirm the server is connected.
+
+**Usage example:**
+
+```
+> What sheets are in /path/to/budget.xlsx?
+
+[Claude calls xlsx_get_sheet_names with {"path": "/path/to/budget.xlsx"}]
+→ ["Summary", "Q1", "Q2", "Q3", "Q4"]
+```
+
+---
+
+### GitHub Copilot (VS Code)
+
+Add `.vscode/mcp.json` to your workspace root:
+
+```json
+{
+  "servers": {
+    "ooxml": {
+      "type": "stdio",
+      "command": "ooxml-mcp-server"
+    }
+  }
+}
+```
+
+Then in VS Code, open the Command Palette (`⇧⌘P`) → **"MCP: List Servers"** to confirm the server appears as *running*.
+
+> **Note:** MCP tools are only available in **Agent mode** (`@agent` in the Copilot Chat panel). They are not accessible in Ask or Edit modes.
+
+**Usage example (Copilot Chat, Agent mode):**
+
+```
+@agent Summarise the formulas in Sheet1 of @/path/to/model.xlsx
+```
+
+Copilot will call `xlsx_get_formulas` and present the results.
+
+---
+
+### Codex CLI (OpenAI)
+
+Add to `~/.codex/config.toml` (global, all projects):
+
+```toml
+[mcp_servers.ooxml]
+command = "ooxml-mcp-server"
+args = []
+```
+
+Or to `.codex/config.toml` in the project root (project-scoped):
+
+```toml
+[mcp_servers.ooxml]
+command = "ooxml-mcp-server"
+args = []
+```
+
+Restart Codex after editing the config. Use `codex mcp list` to verify the server is registered.
+
+**Usage example:**
+
+```bash
+codex "Extract all text from slides 1–3 of /path/to/deck.pptx"
+```
+
+Codex will call `pptx_extract_text` with `slide_index` set appropriately.
+
+---
+
+## Full path (if not on PATH)
+
+If `~/.cargo/bin` is not on your `PATH`, use the absolute path to the binary:
+
+```bash
+# Find the binary
+which ooxml-mcp-server         # or:
+echo ~/.cargo/bin/ooxml-mcp-server
+```
+
+Then replace `"ooxml-mcp-server"` with the full path in any config above:
+
+```json
+"command": "/Users/you/.cargo/bin/ooxml-mcp-server"
+```
+
+```toml
+command = "/Users/you/.cargo/bin/ooxml-mcp-server"
+```
+
+---
+
+## Building from source (without installing)
+
+```bash
+cargo build --release -p ooxml-mcp-server
+# binary at: target/release/ooxml-mcp-server
+```
+
+Use the path `target/release/ooxml-mcp-server` in your MCP config.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -151,8 +151,9 @@ command = "/Users/you/.cargo/bin/ooxml-mcp-server"
 | `xlsx_get_sheet_dimensions` | `path`, `sheet` | Number of rows and columns |
 | `xlsx_get_cell_range` | `path`, `sheet`, `range` | Cell values and formulas for a range like `"A1:C10"` |
 | `xlsx_get_formulas` | `path`, `sheet` | Every formula cell with its cached value |
+| `xlsx_search_cells` | `path`, `query`, `sheet?` | Cells whose value or formula contains the query string |
 
-`sheet` can be a name (`"Sheet1"`) or a 0-based index (`"0"`).
+`sheet` can be a name (`"Sheet1"`) or a 0-based index (`"0"`). For `xlsx_search_cells`, omitting `sheet` searches all sheets.
 
 ### docx (Word)
 
@@ -161,6 +162,7 @@ command = "/Users/you/.cargo/bin/ooxml-mcp-server"
 | `docx_extract_text` | `path` | All text as plain string |
 | `docx_get_structure` | `path` | Paragraph and table structure with style info |
 | `docx_get_tables` | `path` | All tables with each cell's text |
+| `docx_search_text` | `path`, `query` | Matching paragraphs and table cells with their position |
 
 ### pptx (PowerPoint)
 
@@ -169,5 +171,7 @@ command = "/Users/you/.cargo/bin/ooxml-mcp-server"
 | `pptx_get_slides` | `path` | Slide count and each slide's title |
 | `pptx_extract_text` | `path`, `slide_index?` | Text from all slides, or one slide (0-based index) |
 | `pptx_get_slide_structure` | `path`, `slide_index` | All shapes with position, size, and text |
+| `pptx_search_text` | `path`, `query` | Matching slide numbers and text snippets |
 
-All `path` parameters require absolute paths (e.g. `/Users/me/Documents/file.xlsx`).
+All `path` parameters require absolute paths (e.g. `/Users/me/Documents/file.xlsx`).  
+All search tools use **case-insensitive substring matching**.

--- a/packages/mcp-server/src/main.rs
+++ b/packages/mcp-server/src/main.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use rmcp::{ServiceExt, transport::stdio};
+use tracing_subscriber::{self, EnvFilter};
+
+mod server;
+mod tools;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("Starting ooxml-mcp-server");
+
+    let service = server::OoxmlServer::new()
+        .serve(stdio())
+        .await
+        .inspect_err(|e| tracing::error!("Server error: {:?}", e))?;
+
+    service.waiting().await?;
+    Ok(())
+}

--- a/packages/mcp-server/src/server.rs
+++ b/packages/mcp-server/src/server.rs
@@ -11,9 +11,9 @@ use crate::tools::{
     pptx::PptxTools,
     xlsx::XlsxTools,
 };
-use crate::tools::docx::DocxPathParam;
-use crate::tools::pptx::{PptxPathParam, PptxSlideParam, PptxTextParam};
-use crate::tools::xlsx::{XlsxCellRangeParam, XlsxPathParam, XlsxSheetParam};
+use crate::tools::docx::{DocxPathParam, DocxSearchParam};
+use crate::tools::pptx::{PptxPathParam, PptxSearchParam, PptxSlideParam, PptxTextParam};
+use crate::tools::xlsx::{XlsxCellRangeParam, XlsxPathParam, XlsxSearchParam, XlsxSheetParam};
 
 #[derive(Clone)]
 pub struct OoxmlServer {
@@ -56,6 +56,11 @@ impl OoxmlServer {
         XlsxTools::xlsx_get_formulas(Parameters(p))
     }
 
+    #[tool(description = "Search for a substring in cell values and formulas across one or all sheets of an XLSX file")]
+    fn xlsx_search_cells(&self, Parameters(p): Parameters<XlsxSearchParam>) -> String {
+        XlsxTools::xlsx_search_cells(Parameters(p))
+    }
+
     // ── docx tools ────────────────────────────────────────────────────────────
 
     #[tool(description = "Extract all plain text from a DOCX file")]
@@ -73,6 +78,11 @@ impl OoxmlServer {
         DocxTools::docx_get_tables(Parameters(p))
     }
 
+    #[tool(description = "Search for a substring in all paragraph and table text of a DOCX file; returns matching excerpts with their position")]
+    fn docx_search_text(&self, Parameters(p): Parameters<DocxSearchParam>) -> String {
+        DocxTools::docx_search_text(Parameters(p))
+    }
+
     // ── pptx tools ────────────────────────────────────────────────────────────
 
     #[tool(description = "Return the number of slides and each slide's title from a PPTX file")]
@@ -88,6 +98,11 @@ impl OoxmlServer {
     #[tool(description = "Return the structure (elements with position, size, text) of a single slide")]
     fn pptx_get_slide_structure(&self, Parameters(p): Parameters<PptxSlideParam>) -> String {
         PptxTools::pptx_get_slide_structure(Parameters(p))
+    }
+
+    #[tool(description = "Search for a substring across all text in a PPTX file; returns matching slide numbers and the text snippets that matched")]
+    fn pptx_search_text(&self, Parameters(p): Parameters<PptxSearchParam>) -> String {
+        PptxTools::pptx_search_text(Parameters(p))
     }
 }
 

--- a/packages/mcp-server/src/server.rs
+++ b/packages/mcp-server/src/server.rs
@@ -1,0 +1,103 @@
+use rmcp::{
+    ServerHandler,
+    handler::server::router::tool::ToolRouter,
+    handler::server::wrapper::Parameters,
+    model::{ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+};
+
+use crate::tools::{
+    docx::DocxTools,
+    pptx::PptxTools,
+    xlsx::XlsxTools,
+};
+use crate::tools::docx::DocxPathParam;
+use crate::tools::pptx::{PptxPathParam, PptxSlideParam, PptxTextParam};
+use crate::tools::xlsx::{XlsxCellRangeParam, XlsxPathParam, XlsxSheetParam};
+
+#[derive(Clone)]
+pub struct OoxmlServer {
+    #[allow(dead_code)]
+    tool_router: ToolRouter<OoxmlServer>,
+}
+
+#[tool_router]
+impl OoxmlServer {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    // ── xlsx tools ────────────────────────────────────────────────────────────
+
+    #[tool(description = "Parse an XLSX file and return workbook overview including sheet names and IDs")]
+    fn xlsx_parse(&self, Parameters(p): Parameters<XlsxPathParam>) -> String {
+        XlsxTools::xlsx_parse(Parameters(p))
+    }
+
+    #[tool(description = "Return only the list of sheet names from an XLSX file")]
+    fn xlsx_get_sheet_names(&self, Parameters(p): Parameters<XlsxPathParam>) -> String {
+        XlsxTools::xlsx_get_sheet_names(Parameters(p))
+    }
+
+    #[tool(description = "Return the dimensions (max row and column) of a worksheet")]
+    fn xlsx_get_sheet_dimensions(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
+        XlsxTools::xlsx_get_sheet_dimensions(Parameters(p))
+    }
+
+    #[tool(description = "Return cell values and formulas for a given range (e.g. \"A1:C10\") in a worksheet")]
+    fn xlsx_get_cell_range(&self, Parameters(p): Parameters<XlsxCellRangeParam>) -> String {
+        XlsxTools::xlsx_get_cell_range(Parameters(p))
+    }
+
+    #[tool(description = "Return all cells that contain formulas in a worksheet")]
+    fn xlsx_get_formulas(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
+        XlsxTools::xlsx_get_formulas(Parameters(p))
+    }
+
+    // ── docx tools ────────────────────────────────────────────────────────────
+
+    #[tool(description = "Extract all plain text from a DOCX file")]
+    fn docx_extract_text(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
+        DocxTools::docx_extract_text(Parameters(p))
+    }
+
+    #[tool(description = "Return the document structure (paragraphs and tables) of a DOCX file")]
+    fn docx_get_structure(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
+        DocxTools::docx_get_structure(Parameters(p))
+    }
+
+    #[tool(description = "Return all tables from a DOCX file with their cell contents")]
+    fn docx_get_tables(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
+        DocxTools::docx_get_tables(Parameters(p))
+    }
+
+    // ── pptx tools ────────────────────────────────────────────────────────────
+
+    #[tool(description = "Return the number of slides and each slide's title from a PPTX file")]
+    fn pptx_get_slides(&self, Parameters(p): Parameters<PptxPathParam>) -> String {
+        PptxTools::pptx_get_slides(Parameters(p))
+    }
+
+    #[tool(description = "Extract plain text from a PPTX file; optionally filter to a single slide by 0-based index")]
+    fn pptx_extract_text(&self, Parameters(p): Parameters<PptxTextParam>) -> String {
+        PptxTools::pptx_extract_text(Parameters(p))
+    }
+
+    #[tool(description = "Return the structure (elements with position, size, text) of a single slide")]
+    fn pptx_get_slide_structure(&self, Parameters(p): Parameters<PptxSlideParam>) -> String {
+        PptxTools::pptx_get_slide_structure(Parameters(p))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for OoxmlServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+        )
+    }
+}

--- a/packages/mcp-server/src/tools/docx.rs
+++ b/packages/mcp-server/src/tools/docx.rs
@@ -12,6 +12,14 @@ pub struct DocxPathParam {
     pub path: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DocxSearchParam {
+    /// Absolute path to the DOCX file
+    pub path: String,
+    /// Case-insensitive substring to search for in paragraph and table cell text
+    pub query: String,
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 fn read_file(path: &str) -> Result<Vec<u8>, String> {
@@ -199,5 +207,74 @@ impl DocxTools {
             .collect();
 
         serde_json::to_string(&tables).unwrap_or_else(|e| format!("Error: {}", e))
+    }
+
+    #[tool(description = "Search for a substring in all paragraph and table text of a DOCX file; returns matching excerpts with their position")]
+    pub fn docx_search_text(Parameters(p): Parameters<DocxSearchParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc_json = match docx_parser::parse_docx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc: Value = match serde_json::from_str(&doc_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let body = doc["body"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
+        let query_lower = p.query.to_lowercase();
+        let mut matches: Vec<Value> = Vec::new();
+
+        for (idx, element) in body.iter().enumerate() {
+            match element["type"].as_str().unwrap_or("") {
+                "paragraph" => {
+                    let mut text = String::new();
+                    collect_run_texts(&element["runs"], &mut text);
+                    if text.to_lowercase().contains(&query_lower) {
+                        matches.push(serde_json::json!({
+                            "type": "paragraph",
+                            "index": idx,
+                            "styleId": element["styleId"],
+                            "text": text.trim(),
+                        }));
+                    }
+                }
+                "table" => {
+                    if let Some(rows) = element["rows"].as_array() {
+                        for (row_idx, row) in rows.iter().enumerate() {
+                            if let Some(cells) = row["cells"].as_array() {
+                                for (col_idx, cell) in cells.iter().enumerate() {
+                                    let mut text = String::new();
+                                    if let Some(paras) = cell["paragraphs"].as_array() {
+                                        for para in paras {
+                                            collect_run_texts(&para["runs"], &mut text);
+                                        }
+                                    }
+                                    if text.to_lowercase().contains(&query_lower) {
+                                        matches.push(serde_json::json!({
+                                            "type": "tableCell",
+                                            "tableIndex": idx,
+                                            "row": row_idx,
+                                            "col": col_idx,
+                                            "text": text.trim(),
+                                        }));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        serde_json::json!({
+            "query": p.query,
+            "matchCount": matches.len(),
+            "matches": matches,
+        })
+        .to_string()
     }
 }

--- a/packages/mcp-server/src/tools/docx.rs
+++ b/packages/mcp-server/src/tools/docx.rs
@@ -1,0 +1,203 @@
+use rmcp::{handler::server::wrapper::Parameters, tool};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use std::fs;
+
+// ─── Parameter types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DocxPathParam {
+    /// Absolute path to the DOCX file
+    pub path: String,
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn read_file(path: &str) -> Result<Vec<u8>, String> {
+    fs::read(path).map_err(|e| format!("Cannot read '{}': {}", path, e))
+}
+
+fn collect_run_texts(runs: &Value, out: &mut String) {
+    if let Some(arr) = runs.as_array() {
+        for run in arr {
+            if let Some(t) = run["text"].as_str() {
+                out.push_str(t);
+            }
+        }
+    }
+}
+
+fn collect_paragraph_text(para: &Value, out: &mut String) {
+    collect_run_texts(&para["runs"], out);
+    out.push('\n');
+}
+
+fn collect_table_text(table: &Value, out: &mut String) {
+    if let Some(rows) = table["rows"].as_array() {
+        for row in rows {
+            if let Some(cells) = row["cells"].as_array() {
+                let cell_texts: Vec<String> = cells
+                    .iter()
+                    .map(|cell| {
+                        let mut t = String::new();
+                        if let Some(paras) = cell["paragraphs"].as_array() {
+                            for p in paras {
+                                collect_run_texts(&p["runs"], &mut t);
+                            }
+                        }
+                        t
+                    })
+                    .collect();
+                out.push_str(&cell_texts.join("\t"));
+                out.push('\n');
+            }
+        }
+    }
+}
+
+fn extract_body_text(body: &[Value]) -> String {
+    let mut out = String::new();
+    for element in body {
+        match element["type"].as_str().unwrap_or("") {
+            "paragraph" => collect_paragraph_text(element, &mut out),
+            "table" => collect_table_text(element, &mut out),
+            _ => {}
+        }
+    }
+    out
+}
+
+fn body_structure(body: &[Value]) -> Vec<Value> {
+    body.iter()
+        .map(|el| match el["type"].as_str().unwrap_or("") {
+            "paragraph" => {
+                let mut runs_text = String::new();
+                collect_run_texts(&el["runs"], &mut runs_text);
+                serde_json::json!({
+                    "type": "paragraph",
+                    "styleId": el["styleId"],
+                    "text": runs_text.trim().to_string(),
+                    "alignment": el["alignment"],
+                })
+            }
+            "table" => {
+                let rows = el["rows"]
+                    .as_array()
+                    .map(|r| r.len())
+                    .unwrap_or(0);
+                let cols = el["rows"]
+                    .as_array()
+                    .and_then(|r| r.first())
+                    .and_then(|r| r["cells"].as_array())
+                    .map(|c| c.len())
+                    .unwrap_or(0);
+                serde_json::json!({
+                    "type": "table",
+                    "rows": rows,
+                    "cols": cols,
+                })
+            }
+            _ => el.clone(),
+        })
+        .collect()
+}
+
+// ─── Tool implementations ─────────────────────────────────────────────────────
+
+pub struct DocxTools;
+
+impl DocxTools {
+    #[tool(description = "Extract all plain text from a DOCX file")]
+    pub fn docx_extract_text(Parameters(p): Parameters<DocxPathParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc_json = match docx_parser::parse_docx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc: Value = match serde_json::from_str(&doc_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let body = doc["body"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
+        extract_body_text(body)
+    }
+
+    #[tool(description = "Return the document structure (paragraphs and tables) of a DOCX file")]
+    pub fn docx_get_structure(Parameters(p): Parameters<DocxPathParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc_json = match docx_parser::parse_docx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc: Value = match serde_json::from_str(&doc_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let body = doc["body"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
+        let structure = body_structure(body);
+        serde_json::to_string(&structure).unwrap_or_else(|e| format!("Error: {}", e))
+    }
+
+    #[tool(description = "Return all tables from a DOCX file with their cell contents")]
+    pub fn docx_get_tables(Parameters(p): Parameters<DocxPathParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc_json = match docx_parser::parse_docx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let doc: Value = match serde_json::from_str(&doc_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let body = doc["body"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
+
+        let tables: Vec<Value> = body
+            .iter()
+            .filter(|el| el["type"].as_str() == Some("table"))
+            .enumerate()
+            .map(|(table_idx, table)| {
+                let rows = table["rows"]
+                    .as_array()
+                    .map(|rows| {
+                        rows.iter()
+                            .map(|row| {
+                                row["cells"]
+                                    .as_array()
+                                    .map(|cells| {
+                                        cells
+                                            .iter()
+                                            .map(|cell| {
+                                                let mut text = String::new();
+                                                if let Some(paras) =
+                                                    cell["paragraphs"].as_array()
+                                                {
+                                                    for p in paras {
+                                                        collect_run_texts(&p["runs"], &mut text);
+                                                    }
+                                                }
+                                                Value::String(text)
+                                            })
+                                            .collect::<Vec<_>>()
+                                    })
+                                    .unwrap_or_default()
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                serde_json::json!({ "tableIndex": table_idx, "rows": rows })
+            })
+            .collect();
+
+        serde_json::to_string(&tables).unwrap_or_else(|e| format!("Error: {}", e))
+    }
+}

--- a/packages/mcp-server/src/tools/mod.rs
+++ b/packages/mcp-server/src/tools/mod.rs
@@ -1,0 +1,3 @@
+pub mod docx;
+pub mod pptx;
+pub mod xlsx;

--- a/packages/mcp-server/src/tools/pptx.rs
+++ b/packages/mcp-server/src/tools/pptx.rs
@@ -13,6 +13,14 @@ pub struct PptxPathParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct PptxSearchParam {
+    /// Absolute path to the PPTX file
+    pub path: String,
+    /// Case-insensitive substring to search for across all slide text
+    pub query: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct PptxSlideParam {
     /// Absolute path to the PPTX file
     pub path: String,
@@ -254,5 +262,79 @@ impl PptxTools {
             }
         };
         serde_json::to_string(&slide_structure(slide)).unwrap_or_else(|e| format!("Error: {}", e))
+    }
+
+    #[tool(description = "Search for a substring across all text in a PPTX file; returns matching slide numbers and the text snippets that matched")]
+    pub fn pptx_search_text(Parameters(p): Parameters<PptxSearchParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres_json = match pptx_parser::parse_pptx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres: Value = match serde_json::from_str(&pres_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let query_lower = p.query.to_lowercase();
+        let mut matches: Vec<Value> = Vec::new();
+
+        for slide in slides {
+            let slide_index = slide["index"].as_u64().unwrap_or(0) as usize;
+            let slide_number = slide["slideNumber"].as_u64().unwrap_or(0) as usize;
+
+            if let Some(elements) = slide["elements"].as_array() {
+                for el in elements {
+                    // Collect all text from this element
+                    let mut element_text = String::new();
+                    if let Some(tb) = el.get("textBody") {
+                        if let Some(paras) = tb["paragraphs"].as_array() {
+                            for para in paras {
+                                extract_text_runs(para, &mut element_text);
+                                element_text.push('\n');
+                            }
+                        }
+                    }
+                    // Table cells
+                    if el["type"].as_str() == Some("table") {
+                        if let Some(rows) = el["rows"].as_array() {
+                            for row in rows {
+                                if let Some(cells) = row["cells"].as_array() {
+                                    for cell in cells {
+                                        if let Some(paras) = cell["paragraphs"].as_array() {
+                                            for para in paras {
+                                                extract_text_runs(para, &mut element_text);
+                                            }
+                                        }
+                                        element_text.push('\t');
+                                    }
+                                }
+                                element_text.push('\n');
+                            }
+                        }
+                    }
+
+                    if element_text.to_lowercase().contains(&query_lower) {
+                        matches.push(serde_json::json!({
+                            "slideIndex": slide_index,
+                            "slideNumber": slide_number,
+                            "elementType": el["type"],
+                            "placeholderType": el["placeholderType"],
+                            "text": element_text.trim(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        serde_json::json!({
+            "query": p.query,
+            "matchCount": matches.len(),
+            "matches": matches,
+        })
+        .to_string()
     }
 }

--- a/packages/mcp-server/src/tools/pptx.rs
+++ b/packages/mcp-server/src/tools/pptx.rs
@@ -1,0 +1,258 @@
+use rmcp::{handler::server::wrapper::Parameters, tool};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use std::fs;
+
+// ─── Parameter types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PptxPathParam {
+    /// Absolute path to the PPTX file
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PptxSlideParam {
+    /// Absolute path to the PPTX file
+    pub path: String,
+    /// 0-based slide index
+    pub slide_index: usize,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PptxTextParam {
+    /// Absolute path to the PPTX file
+    pub path: String,
+    /// 0-based slide index; omit to extract text from all slides
+    pub slide_index: Option<usize>,
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn read_file(path: &str) -> Result<Vec<u8>, String> {
+    fs::read(path).map_err(|e| format!("Cannot read '{}': {}", path, e))
+}
+
+fn extract_text_runs(node: &Value, out: &mut String) {
+    match node["type"].as_str().unwrap_or("") {
+        "textRun" | "run" => {
+            if let Some(t) = node["text"].as_str() {
+                out.push_str(t);
+            }
+        }
+        _ => {}
+    }
+    // Recurse into common container fields
+    for key in &["runs", "paragraphs", "elements", "children"] {
+        if let Some(arr) = node[key].as_array() {
+            for child in arr {
+                extract_text_runs(child, out);
+            }
+        }
+    }
+}
+
+fn slide_title(slide: &Value) -> Option<String> {
+    if let Some(elements) = slide["elements"].as_array() {
+        for el in elements {
+            if el["type"].as_str() == Some("shape") {
+                if let Some(ph) = el["placeholderType"].as_str() {
+                    if ph == "title" || ph == "centeredTitle" {
+                        let mut text = String::new();
+                        if let Some(tb) = el.get("textBody") {
+                            if let Some(paras) = tb["paragraphs"].as_array() {
+                                for para in paras {
+                                    extract_text_runs(para, &mut text);
+                                }
+                            }
+                        }
+                        let trimmed = text.trim().to_string();
+                        if !trimmed.is_empty() {
+                            return Some(trimmed);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn extract_slide_text(slide: &Value) -> String {
+    let mut out = String::new();
+    if let Some(elements) = slide["elements"].as_array() {
+        for el in elements {
+            if let Some(tb) = el.get("textBody") {
+                if let Some(paras) = tb["paragraphs"].as_array() {
+                    for para in paras {
+                        extract_text_runs(para, &mut out);
+                        out.push('\n');
+                    }
+                }
+            }
+            // Table elements
+            if el["type"].as_str() == Some("table") {
+                if let Some(rows) = el["rows"].as_array() {
+                    for row in rows {
+                        if let Some(cells) = row["cells"].as_array() {
+                            let cell_texts: Vec<String> = cells
+                                .iter()
+                                .map(|c| {
+                                    let mut t = String::new();
+                                    if let Some(paras) = c["paragraphs"].as_array() {
+                                        for para in paras {
+                                            extract_text_runs(para, &mut t);
+                                        }
+                                    }
+                                    t
+                                })
+                                .collect();
+                            out.push_str(&cell_texts.join("\t"));
+                            out.push('\n');
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn slide_structure(slide: &Value) -> Value {
+    let elements: Vec<Value> = slide["elements"]
+        .as_array()
+        .map(|els| {
+            els.iter()
+                .map(|el| {
+                    let mut text = String::new();
+                    if let Some(tb) = el.get("textBody") {
+                        if let Some(paras) = tb["paragraphs"].as_array() {
+                            for para in paras {
+                                extract_text_runs(para, &mut text);
+                            }
+                        }
+                    }
+                    serde_json::json!({
+                        "type": el["type"],
+                        "placeholderType": el["placeholderType"],
+                        "x": el["x"], "y": el["y"],
+                        "width": el["width"], "height": el["height"],
+                        "text": text.trim().to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    serde_json::json!({
+        "index": slide["index"],
+        "slideNumber": slide["slideNumber"],
+        "elements": elements,
+    })
+}
+
+// ─── Tool implementations ─────────────────────────────────────────────────────
+
+pub struct PptxTools;
+
+impl PptxTools {
+    #[tool(description = "Return the number of slides and each slide's title from a PPTX file")]
+    pub fn pptx_get_slides(Parameters(p): Parameters<PptxPathParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres_json = match pptx_parser::parse_pptx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres: Value = match serde_json::from_str(&pres_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let summary: Vec<Value> = slides
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "index": s["index"],
+                    "slideNumber": s["slideNumber"],
+                    "title": slide_title(s),
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "slideCount": slides.len(),
+            "slides": summary,
+        })
+        .to_string()
+    }
+
+    #[tool(description = "Extract plain text from a PPTX file; optionally filter to a single slide by 0-based index")]
+    pub fn pptx_extract_text(Parameters(p): Parameters<PptxTextParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres_json = match pptx_parser::parse_pptx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres: Value = match serde_json::from_str(&pres_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+
+        if let Some(idx) = p.slide_index {
+            let slide = match slides.get(idx) {
+                Some(s) => s,
+                None => {
+                    return format!(
+                        "Error: slide index {} out of range (total: {})",
+                        idx,
+                        slides.len()
+                    )
+                }
+            };
+            return extract_slide_text(slide);
+        }
+
+        let mut out = String::new();
+        for (i, slide) in slides.iter().enumerate() {
+            out.push_str(&format!("=== Slide {} ===\n", i + 1));
+            out.push_str(&extract_slide_text(slide));
+            out.push('\n');
+        }
+        out
+    }
+
+    #[tool(description = "Return the structure (elements with position, size, text) of a single slide")]
+    pub fn pptx_get_slide_structure(Parameters(p): Parameters<PptxSlideParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres_json = match pptx_parser::parse_pptx_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let pres: Value = match serde_json::from_str(&pres_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slide = match slides.get(p.slide_index) {
+            Some(s) => s,
+            None => {
+                return format!(
+                    "Error: slide index {} out of range (total: {})",
+                    p.slide_index,
+                    slides.len()
+                )
+            }
+        };
+        serde_json::to_string(&slide_structure(slide)).unwrap_or_else(|e| format!("Error: {}", e))
+    }
+}

--- a/packages/mcp-server/src/tools/xlsx.rs
+++ b/packages/mcp-server/src/tools/xlsx.rs
@@ -1,0 +1,339 @@
+use rmcp::{handler::server::wrapper::Parameters, tool};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use std::fs;
+
+// ─── Parameter types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct XlsxPathParam {
+    /// Absolute path to the XLSX file
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct XlsxSheetParam {
+    /// Absolute path to the XLSX file
+    pub path: String,
+    /// Sheet name (e.g. "Sheet1") or 0-based numeric index as a string (e.g. "0")
+    pub sheet: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct XlsxCellRangeParam {
+    /// Absolute path to the XLSX file
+    pub path: String,
+    /// Sheet name or 0-based index
+    pub sheet: String,
+    /// Cell range in A1 notation, e.g. "A1:C10"
+    pub range: String,
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn read_file(path: &str) -> Result<Vec<u8>, String> {
+    fs::read(path).map_err(|e| format!("Cannot read '{}': {}", path, e))
+}
+
+/// Resolves a sheet identifier (name or 0-based index string) to (index, name).
+fn resolve_sheet(workbook_json: &str, identifier: &str) -> Result<(u32, String), String> {
+    let wb: Value = serde_json::from_str(workbook_json).map_err(|e| e.to_string())?;
+    let sheets = wb["sheets"]
+        .as_array()
+        .ok_or("workbook has no 'sheets' array")?;
+
+    if let Ok(idx) = identifier.parse::<usize>() {
+        let sheet = sheets
+            .get(idx)
+            .ok_or_else(|| format!("sheet index {} out of range (total: {})", idx, sheets.len()))?;
+        let name = sheet["name"].as_str().unwrap_or("").to_string();
+        return Ok((idx as u32, name));
+    }
+
+    for (idx, sheet) in sheets.iter().enumerate() {
+        if sheet["name"].as_str() == Some(identifier) {
+            return Ok((idx as u32, identifier.to_string()));
+        }
+    }
+
+    Err(format!(
+        "sheet '{}' not found (available: {})",
+        identifier,
+        sheets
+            .iter()
+            .filter_map(|s| s["name"].as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+/// Parses an A1-style cell reference to (col_1based, row_1based).
+fn parse_cell_ref(s: &str) -> Option<(u32, u32)> {
+    let col_str: String = s.chars().take_while(|c| c.is_ascii_alphabetic()).collect();
+    let row_str: String = s.chars().skip_while(|c| c.is_ascii_alphabetic()).collect();
+    if col_str.is_empty() || row_str.is_empty() {
+        return None;
+    }
+    let col = col_str
+        .to_ascii_uppercase()
+        .chars()
+        .fold(0u32, |acc, c| acc * 26 + (c as u32 - 'A' as u32 + 1));
+    let row: u32 = row_str.parse().ok()?;
+    Some((col, row))
+}
+
+/// Converts a 1-based column index to a letter reference (1→"A", 26→"Z", 27→"AA").
+fn col_to_letter(mut col: u32) -> String {
+    let mut s = String::new();
+    while col > 0 {
+        col -= 1;
+        s.insert(0, (b'A' + (col % 26) as u8) as char);
+        col /= 26;
+    }
+    s
+}
+
+/// Returns the display string for a cell value from a `cell` JSON object.
+fn cell_display(cell: &Value) -> String {
+    let val = &cell["value"];
+    match val["type"].as_str().unwrap_or("Empty") {
+        "Text" => val["text"].as_str().unwrap_or("").to_string(),
+        "Number" => val["number"]
+            .as_f64()
+            .map(|n| {
+                if n.fract() == 0.0 && n.abs() < 1e15 {
+                    format!("{}", n as i64)
+                } else {
+                    format!("{}", n)
+                }
+            })
+            .unwrap_or_default(),
+        "Bool" => val["value"].as_bool().map(|b| b.to_string()).unwrap_or_default(),
+        "Error" => val["error"].as_str().unwrap_or("#ERR").to_string(),
+        _ => String::new(),
+    }
+}
+
+// ─── Tool implementations ─────────────────────────────────────────────────────
+
+pub struct XlsxTools;
+
+impl XlsxTools {
+    #[tool(description = "Parse an XLSX file and return workbook overview including sheet names and IDs")]
+    pub fn xlsx_parse(Parameters(p): Parameters<XlsxPathParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        match xlsx_parser::parse_workbook_native(&data) {
+            Ok(json) => json,
+            Err(e) => format!("Error: {}", e),
+        }
+    }
+
+    #[tool(description = "Return only the list of sheet names from an XLSX file")]
+    pub fn xlsx_get_sheet_names(Parameters(p): Parameters<XlsxPathParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let wb_json = match xlsx_parser::parse_workbook_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let wb: Value = match serde_json::from_str(&wb_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error parsing workbook JSON: {}", e),
+        };
+        let names: Vec<&str> = wb["sheets"]
+            .as_array()
+            .map(|sheets| {
+                sheets
+                    .iter()
+                    .filter_map(|s| s["name"].as_str())
+                    .collect()
+            })
+            .unwrap_or_default();
+        serde_json::to_string(&names).unwrap_or_else(|e| format!("Error: {}", e))
+    }
+
+    #[tool(description = "Return the dimensions (max row and column) of a worksheet")]
+    pub fn xlsx_get_sheet_dimensions(Parameters(p): Parameters<XlsxSheetParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let wb_json = match xlsx_parser::parse_workbook_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let (idx, name) = match resolve_sheet(&wb_json, &p.sheet) {
+            Ok(r) => r,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let ws_json = match xlsx_parser::parse_sheet_native(&data, idx, &name) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let ws: Value = match serde_json::from_str(&ws_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+
+        let mut max_row = 0u32;
+        let mut max_col = 0u32;
+        if let Some(rows) = ws["rows"].as_array() {
+            for row in rows {
+                let row_idx = row["index"].as_u64().unwrap_or(0) as u32;
+                if row_idx > max_row {
+                    max_row = row_idx;
+                }
+                if let Some(cells) = row["cells"].as_array() {
+                    for cell in cells {
+                        let col = cell["col"].as_u64().unwrap_or(0) as u32;
+                        if col > max_col {
+                            max_col = col;
+                        }
+                    }
+                }
+            }
+        }
+
+        serde_json::json!({
+            "sheet": name,
+            "maxRow": max_row,
+            "maxCol": max_col,
+            "maxColLetter": col_to_letter(max_col),
+        })
+        .to_string()
+    }
+
+    #[tool(description = "Return cell values and formulas for a given range (e.g. \"A1:C10\") in a worksheet")]
+    pub fn xlsx_get_cell_range(Parameters(p): Parameters<XlsxCellRangeParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let wb_json = match xlsx_parser::parse_workbook_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let (idx, name) = match resolve_sheet(&wb_json, &p.sheet) {
+            Ok(r) => r,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let ws_json = match xlsx_parser::parse_sheet_native(&data, idx, &name) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let ws: Value = match serde_json::from_str(&ws_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+
+        // Parse range "A1:C10"
+        let parts: Vec<&str> = p.range.split(':').collect();
+        if parts.len() != 2 {
+            return format!("Error: range must be in 'A1:C10' format, got '{}'", p.range);
+        }
+        let (c1, r1) = match parse_cell_ref(parts[0]) {
+            Some(v) => v,
+            None => return format!("Error: invalid cell reference '{}'", parts[0]),
+        };
+        let (c2, r2) = match parse_cell_ref(parts[1]) {
+            Some(v) => v,
+            None => return format!("Error: invalid cell reference '{}'", parts[1]),
+        };
+        let (row_min, row_max) = (r1.min(r2), r1.max(r2));
+        let (col_min, col_max) = (c1.min(c2), c1.max(c2));
+
+        let mut result_rows: Vec<Value> = Vec::new();
+
+        if let Some(rows) = ws["rows"].as_array() {
+            for row in rows {
+                let row_idx = row["index"].as_u64().unwrap_or(0) as u32;
+                if row_idx < row_min || row_idx > row_max {
+                    continue;
+                }
+                let mut result_cells: Vec<Value> = Vec::new();
+                if let Some(cells) = row["cells"].as_array() {
+                    for cell in cells {
+                        let col = cell["col"].as_u64().unwrap_or(0) as u32;
+                        if col < col_min || col > col_max {
+                            continue;
+                        }
+                        let mut entry = serde_json::json!({
+                            "ref": format!("{}{}", col_to_letter(col), row_idx),
+                            "value": cell_display(cell),
+                        });
+                        if let Some(formula) = cell["formula"].as_str() {
+                            entry["formula"] = Value::String(formula.to_string());
+                        }
+                        result_cells.push(entry);
+                    }
+                }
+                result_rows.push(serde_json::json!({
+                    "row": row_idx,
+                    "cells": result_cells,
+                }));
+            }
+        }
+
+        serde_json::json!({
+            "sheet": name,
+            "range": p.range,
+            "rows": result_rows,
+        })
+        .to_string()
+    }
+
+    #[tool(description = "Return all cells that contain formulas in a worksheet")]
+    pub fn xlsx_get_formulas(Parameters(p): Parameters<XlsxSheetParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let wb_json = match xlsx_parser::parse_workbook_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let (idx, name) = match resolve_sheet(&wb_json, &p.sheet) {
+            Ok(r) => r,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let ws_json = match xlsx_parser::parse_sheet_native(&data, idx, &name) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let ws: Value = match serde_json::from_str(&ws_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+
+        let mut formulas: Vec<Value> = Vec::new();
+        if let Some(rows) = ws["rows"].as_array() {
+            for row in rows {
+                let row_idx = row["index"].as_u64().unwrap_or(0) as u32;
+                if let Some(cells) = row["cells"].as_array() {
+                    for cell in cells {
+                        if let Some(formula) = cell["formula"].as_str() {
+                            let col = cell["col"].as_u64().unwrap_or(0) as u32;
+                            formulas.push(serde_json::json!({
+                                "ref": format!("{}{}", col_to_letter(col), row_idx),
+                                "formula": formula,
+                                "cachedValue": cell_display(cell),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+
+        serde_json::json!({
+            "sheet": name,
+            "formulas": formulas,
+        })
+        .to_string()
+    }
+}

--- a/packages/mcp-server/src/tools/xlsx.rs
+++ b/packages/mcp-server/src/tools/xlsx.rs
@@ -13,6 +13,16 @@ pub struct XlsxPathParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct XlsxSearchParam {
+    /// Absolute path to the XLSX file
+    pub path: String,
+    /// Sheet name or 0-based index; omit to search all sheets
+    pub sheet: Option<String>,
+    /// Case-insensitive substring to search for in cell values and formulas
+    pub query: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct XlsxSheetParam {
     /// Absolute path to the XLSX file
     pub path: String,
@@ -333,6 +343,87 @@ impl XlsxTools {
         serde_json::json!({
             "sheet": name,
             "formulas": formulas,
+        })
+        .to_string()
+    }
+
+    #[tool(description = "Search for a substring in cell values and formulas across one or all sheets of an XLSX file")]
+    pub fn xlsx_search_cells(Parameters(p): Parameters<XlsxSearchParam>) -> String {
+        let data = match read_file(&p.path) {
+            Ok(d) => d,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let wb_json = match xlsx_parser::parse_workbook_native(&data) {
+            Ok(j) => j,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let wb: Value = match serde_json::from_str(&wb_json) {
+            Ok(v) => v,
+            Err(e) => return format!("Error: {}", e),
+        };
+        let sheets = match wb["sheets"].as_array() {
+            Some(s) => s.clone(),
+            None => return "Error: no sheets found".to_string(),
+        };
+
+        // Collect which sheets to search
+        let targets: Vec<(u32, String)> = if let Some(ref sheet_id) = p.sheet {
+            match resolve_sheet(&wb_json, sheet_id) {
+                Ok((idx, name)) => vec![(idx, name)],
+                Err(e) => return format!("Error: {}", e),
+            }
+        } else {
+            sheets
+                .iter()
+                .enumerate()
+                .map(|(i, s)| (i as u32, s["name"].as_str().unwrap_or("").to_string()))
+                .collect()
+        };
+
+        let query_lower = p.query.to_lowercase();
+        let mut matches: Vec<Value> = Vec::new();
+
+        for (idx, name) in targets {
+            let ws_json = match xlsx_parser::parse_sheet_native(&data, idx, &name) {
+                Ok(j) => j,
+                Err(e) => return format!("Error parsing sheet '{}': {}", name, e),
+            };
+            let ws: Value = match serde_json::from_str(&ws_json) {
+                Ok(v) => v,
+                Err(e) => return format!("Error: {}", e),
+            };
+
+            if let Some(rows) = ws["rows"].as_array() {
+                for row in rows {
+                    let row_idx = row["index"].as_u64().unwrap_or(0) as u32;
+                    if let Some(cells) = row["cells"].as_array() {
+                        for cell in cells {
+                            let value = cell_display(cell);
+                            let formula = cell["formula"].as_str().unwrap_or("");
+                            let hit_value = value.to_lowercase().contains(&query_lower);
+                            let hit_formula = formula.to_lowercase().contains(&query_lower);
+                            if hit_value || hit_formula {
+                                let col = cell["col"].as_u64().unwrap_or(0) as u32;
+                                let mut entry = serde_json::json!({
+                                    "sheet": name,
+                                    "ref": format!("{}{}", col_to_letter(col), row_idx),
+                                    "value": value,
+                                });
+                                if !formula.is_empty() {
+                                    entry["formula"] = Value::String(formula.to_string());
+                                }
+                                matches.push(entry);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        serde_json::json!({
+            "query": p.query,
+            "matchCount": matches.len(),
+            "matches": matches,
         })
         .to_string()
     }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -17,6 +17,13 @@ pub fn parse_pptx(data: &[u8]) -> Result<String, JsValue> {
         .map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
+/// Native equivalent of `parse_pptx` for use from the MCP server.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_pptx_native(data: &[u8]) -> Result<String, String> {
+    let presentation = parse_presentation(data).map_err(|e| e.to_string())?;
+    serde_json::to_string(&presentation).map_err(|e| e.to_string())
+}
+
 /// Extract raw bytes for a single entry (e.g. "ppt/media/media2.mp4") from a
 /// pptx zip archive. Used by the main thread to materialize media blobs for
 /// interactive playback without re-parsing the whole file.

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -3829,3 +3829,54 @@ fn parse_cell_ref(r: &str) -> (u32, u32) {
     let row = row_str.parse().unwrap_or(1);
     (col, row)
 }
+
+// ===========================
+//  Native (non-WASM) API
+// ===========================
+
+/// Returns workbook overview (sheet names and metadata) as JSON.
+/// Native equivalent of `parse_xlsx` for use from the MCP server.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_workbook_native(data: &[u8]) -> Result<String, String> {
+    parse_xlsx_inner(data)
+        .and_then(|wb| serde_json::to_string(&wb.workbook).map_err(|e| e.to_string()))
+}
+
+/// Parses a single worksheet by 0-based index and returns it as JSON.
+/// Native equivalent of `parse_sheet` for use from the MCP server.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<String, String> {
+    let cursor = Cursor::new(data);
+    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
+
+    let workbook_xml = read_zip_entry(&mut archive, "xl/workbook.xml")?;
+    let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
+    let sheets = parse_workbook_sheets(&wb_doc);
+
+    let sheet_meta = sheets
+        .get(sheet_index as usize)
+        .ok_or_else(|| format!("sheet index {} out of range", sheet_index))?;
+
+    let rels_xml = read_zip_entry(&mut archive, "xl/_rels/workbook.xml.rels")?;
+    let rels_doc = roxmltree::Document::parse(&rels_xml).map_err(|e| e.to_string())?;
+    let sheet_path = resolve_sheet_path(&rels_doc, &sheet_meta.r_id)
+        .ok_or_else(|| format!("rId {} not found in rels", sheet_meta.r_id))?;
+
+    let theme_colors = parse_theme_colors(&mut archive);
+    let shared_strings = read_shared_strings(&mut archive, &theme_colors);
+    let sheet_xml = read_zip_entry(&mut archive, &format!("xl/{}", sheet_path))?;
+    let (mut ws, hyperlink_rids) =
+        parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
+            .map_err(|e| e.to_string())?;
+
+    ws.images = load_sheet_images(&mut archive, &sheet_path);
+    ws.charts = load_sheet_charts(&mut archive, &sheet_path, &theme_colors);
+    ws.shape_groups = load_sheet_shape_groups(&mut archive, &sheet_path, &theme_colors);
+    ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
+    ws.comment_refs = load_sheet_comment_refs(&mut archive, &sheet_path);
+    ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
+    ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
+    ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
+
+    serde_json::to_string(&ws).map_err(|e| e.to_string())
+}


### PR DESCRIPTION
## Summary

- Add `packages/mcp-server/` — Rust stdio MCP server built on **rmcp 1.5**
- Add `#[cfg(not(target_arch = "wasm32"))]` native APIs to all three parsers (non-breaking additions only)
- 11 MCP tools total across xlsx, docx, pptx

## MCP Tools

| Format | Tool | Description |
|--------|------|-------------|
| xlsx | `xlsx_parse` | Workbook overview (sheet names + IDs) |
| xlsx | `xlsx_get_sheet_names` | Sheet name list only |
| xlsx | `xlsx_get_sheet_dimensions` | Max row and column |
| xlsx | `xlsx_get_cell_range` | Cell values + formulas for an A1-range |
| xlsx | `xlsx_get_formulas` | All formula cells in a sheet |
| docx | `docx_extract_text` | Plain text extraction |
| docx | `docx_get_structure` | Paragraph/table structure |
| docx | `docx_get_tables` | All tables with cell contents |
| pptx | `pptx_get_slides` | Slide count + titles |
| pptx | `pptx_extract_text` | Text from all or a single slide |
| pptx | `pptx_get_slide_structure` | Elements with position/size/text |

## Install & Usage

```bash
# Install
cargo install --path packages/mcp-server

# Add to ~/.mcp.json
{
  "mcpServers": {
    "ooxml": {
      "command": "ooxml-mcp-server"
    }
  }
}
```

## Test plan

- [ ] `cargo build -p ooxml-mcp-server` passes with no errors
- [ ] Test xlsx tools against `packages/xlsx/public/sample-*.xlsx`
- [ ] Test docx tools against `packages/docx/public/sample-*.docx`
- [ ] Test pptx tools against `packages/pptx/public/sample-*.pptx`
- [ ] Register in Claude Code and call `xlsx_get_cell_range` on a sample file

🤖 Generated with [Claude Code](https://claude.com/claude-code)