### PR TITLE
feat(xlsx): cell selection UI (cells/rows/cols/all + Shift+click + Ctrl+C copy)

### DIFF
--- a/packages/xlsx/src/SelectableViewer.stories.ts
+++ b/packages/xlsx/src/SelectableViewer.stories.ts
@@ -1,0 +1,139 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { XlsxViewer } from './viewer';
+import type { CellRange } from './viewer';
+
+type Args = {
+  scale: number;
+};
+
+const meta: Meta<Args> = {
+  title: 'XlsxViewer/SelectableViewer',
+  argTypes: {
+    scale: {
+      control: { type: 'range', min: 0.25, max: 2, step: 0.05 },
+      description: 'Cell/header scale (1 = normal size)',
+    },
+  },
+  args: { scale: 1 },
+};
+export default meta;
+type Story = StoryObj<Args>;
+
+function buildSelectableUI(args: Args, autoLoadUrl?: string): HTMLElement {
+  const root = document.createElement('div');
+  root.style.cssText =
+    'width:100%;height:100vh;display:flex;flex-direction:column;overflow:hidden;font-family:sans-serif;box-sizing:border-box;';
+
+  // Toolbar
+  const toolbar = document.createElement('div');
+  toolbar.style.cssText =
+    'display:flex;align-items:center;gap:12px;padding:4px 12px;height:36px;flex-shrink:0;' +
+    'background:#f8f9fa;border-bottom:1px solid #dadce0;font-size:13px;';
+
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = '.xlsx';
+  fileInput.style.cssText = 'font-size:12px;';
+
+  const selectionLabel = document.createElement('span');
+  selectionLabel.style.cssText = 'color:#555;flex:1;';
+  selectionLabel.textContent = 'Click or drag to select cells. Ctrl+C to copy.';
+
+  const copyBtn = document.createElement('button');
+  copyBtn.textContent = 'Copy selection';
+  copyBtn.style.cssText =
+    'padding:2px 10px;font-size:12px;cursor:pointer;border:1px solid #c8ccd0;border-radius:3px;background:#fff;';
+  copyBtn.disabled = true;
+
+  toolbar.append(fileInput, selectionLabel, copyBtn);
+  root.appendChild(toolbar);
+
+  const viewerContainer = document.createElement('div');
+  viewerContainer.style.cssText = 'flex:1;min-height:0;';
+  root.appendChild(viewerContainer);
+
+  let currentViewer: XlsxViewer | null = null;
+
+  function onSelectionChange(sel: CellRange | null): void {
+    if (!sel) {
+      selectionLabel.textContent = 'Click or drag to select cells. Ctrl+C to copy.';
+      copyBtn.disabled = true;
+      return;
+    }
+    const r1 = Math.min(sel.anchor.row, sel.active.row);
+    const r2 = Math.max(sel.anchor.row, sel.active.row);
+    const c1 = Math.min(sel.anchor.col, sel.active.col);
+    const c2 = Math.max(sel.anchor.col, sel.active.col);
+    const colLabel = (n: number) => {
+      let s = '';
+      while (n > 0) { n--; s = String.fromCharCode(65 + (n % 26)) + s; n = Math.floor(n / 26); }
+      return s;
+    };
+    const topLeft = `${colLabel(c1)}${r1}`;
+    const bottomRight = `${colLabel(c2)}${r2}`;
+    selectionLabel.textContent =
+      r1 === r2 && c1 === c2
+        ? `Selected: ${topLeft}`
+        : `Selected: ${topLeft}:${bottomRight} (${r2 - r1 + 1}×${c2 - c1 + 1})`;
+    copyBtn.disabled = false;
+  }
+
+  function createViewer(): XlsxViewer {
+    viewerContainer.innerHTML = '';
+    const viewer = new XlsxViewer(viewerContainer, {
+      cellScale: args.scale,
+      onReady: (names) => { selectionLabel.textContent = `Loaded — ${names.length} sheet(s). Click a cell to select.`; },
+      onSheetChange: (_idx, name) => { selectionLabel.textContent = `Sheet: ${name} — Click a cell to select.`; },
+      onError: (err) => { selectionLabel.textContent = `Error: ${err.message}`; },
+      onSelectionChange,
+    });
+    return viewer;
+  }
+
+  copyBtn.addEventListener('click', () => {
+    if (!currentViewer) return;
+    const sel = currentViewer.selection;
+    if (!sel) return;
+    // Trigger the keyboard copy path by dispatching a synthetic Ctrl+C
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }));
+    copyBtn.textContent = 'Copied!';
+    setTimeout(() => { copyBtn.textContent = 'Copy selection'; }, 1200);
+  });
+
+  fileInput.addEventListener('change', async () => {
+    const file = fileInput.files?.[0];
+    if (!file) return;
+    selectionLabel.textContent = 'Parsing…';
+    currentViewer?.destroy();
+    currentViewer = createViewer();
+    const buf = await file.arrayBuffer();
+    await currentViewer.load(buf);
+  });
+
+  if (autoLoadUrl) {
+    selectionLabel.textContent = 'Loading…';
+    currentViewer = createViewer();
+    fetch(autoLoadUrl)
+      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.arrayBuffer(); })
+      .then((buf) => currentViewer!.load(buf))
+      .catch((err) => { selectionLabel.textContent = `Failed: ${err.message}`; });
+  } else {
+    currentViewer = createViewer();
+  }
+
+  return root;
+}
+
+export const FileUpload: Story = {
+  name: 'Cell Selection — file upload',
+  render(args) {
+    return buildSelectableUI(args);
+  },
+};
+
+export const Sample1: Story = {
+  name: 'Cell Selection — sample-1.xlsx',
+  render(args) {
+    return buildSelectableUI(args, '/xlsx/sample-1.xlsx');
+  },
+};

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -197,23 +197,34 @@ function buildSelectableUI(args: Args, autoLoadUrl?: string): HTMLElement {
 
   function onSelectionChange(sel: CellRange | null): void {
     if (!sel) {
-      selectionLabel.textContent = 'Click or drag to select cells. Ctrl+C to copy.';
+      selectionLabel.textContent = 'Click/drag cells · Click row/col headers · Click corner for all · Shift+click to extend · Ctrl+C to copy';
       copyBtn.disabled = true;
       return;
     }
-    const r1 = Math.min(sel.anchor.row, sel.active.row);
-    const r2 = Math.max(sel.anchor.row, sel.active.row);
-    const c1 = Math.min(sel.anchor.col, sel.active.col);
-    const c2 = Math.max(sel.anchor.col, sel.active.col);
     const colLabel = (n: number) => {
       let s = '';
       while (n > 0) { n--; s = String.fromCharCode(65 + (n % 26)) + s; n = Math.floor(n / 26); }
       return s;
     };
-    const tl = `${colLabel(c1)}${r1}`;
-    const br = `${colLabel(c2)}${r2}`;
-    selectionLabel.textContent =
-      r1 === r2 && c1 === c2 ? `Selected: ${tl}` : `Selected: ${tl}:${br} (${r2 - r1 + 1}×${c2 - c1 + 1})`;
+    if (sel.mode === 'all') {
+      selectionLabel.textContent = 'Selected: all cells';
+    } else if (sel.mode === 'rows') {
+      const r1 = Math.min(sel.anchor.row, sel.active.row);
+      const r2 = Math.max(sel.anchor.row, sel.active.row);
+      selectionLabel.textContent = r1 === r2 ? `Selected: row ${r1}` : `Selected: rows ${r1}–${r2}`;
+    } else if (sel.mode === 'cols') {
+      const c1 = Math.min(sel.anchor.col, sel.active.col);
+      const c2 = Math.max(sel.anchor.col, sel.active.col);
+      selectionLabel.textContent = c1 === c2 ? `Selected: col ${colLabel(c1)}` : `Selected: cols ${colLabel(c1)}–${colLabel(c2)}`;
+    } else {
+      const r1 = Math.min(sel.anchor.row, sel.active.row);
+      const r2 = Math.max(sel.anchor.row, sel.active.row);
+      const c1 = Math.min(sel.anchor.col, sel.active.col);
+      const c2 = Math.max(sel.anchor.col, sel.active.col);
+      const tl = `${colLabel(c1)}${r1}`;
+      const br = `${colLabel(c2)}${r2}`;
+      selectionLabel.textContent = r1 === r2 && c1 === c2 ? `Selected: ${tl}` : `Selected: ${tl}:${br} (${r2 - r1 + 1}×${c2 - c1 + 1})`;
+    }
     copyBtn.disabled = false;
   }
 

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { XlsxViewer } from './viewer';
+import type { CellRange } from './viewer';
 import init, { parse_xlsx } from './wasm/xlsx_parser.js';
 
 type Args = {
@@ -154,4 +155,113 @@ export const FileUpload: Story = {
 
     return root;
   },
+};
+
+// ---------------------------------------------------------------------------
+// Selectable Viewer (cell selection + Ctrl+C copy)
+// ---------------------------------------------------------------------------
+
+function buildSelectableUI(args: Args, autoLoadUrl?: string): HTMLElement {
+  const root = document.createElement('div');
+  root.style.cssText =
+    'width:100%;height:100vh;display:flex;flex-direction:column;overflow:hidden;font-family:sans-serif;box-sizing:border-box;';
+
+  const toolbar = document.createElement('div');
+  toolbar.style.cssText =
+    'display:flex;align-items:center;gap:12px;padding:4px 12px;height:36px;flex-shrink:0;' +
+    'background:#f8f9fa;border-bottom:1px solid #dadce0;font-size:13px;';
+
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = '.xlsx';
+  fileInput.style.cssText = 'font-size:12px;';
+
+  const selectionLabel = document.createElement('span');
+  selectionLabel.style.cssText = 'color:#555;flex:1;';
+  selectionLabel.textContent = 'Click or drag to select cells. Ctrl+C to copy.';
+
+  const copyBtn = document.createElement('button');
+  copyBtn.textContent = 'Copy selection';
+  copyBtn.style.cssText =
+    'padding:2px 10px;font-size:12px;cursor:pointer;border:1px solid #c8ccd0;border-radius:3px;background:#fff;';
+  copyBtn.disabled = true;
+
+  toolbar.append(fileInput, selectionLabel, copyBtn);
+  root.appendChild(toolbar);
+
+  const viewerContainer = document.createElement('div');
+  viewerContainer.style.cssText = 'flex:1;min-height:0;';
+  root.appendChild(viewerContainer);
+
+  let currentViewer: XlsxViewer | null = null;
+
+  function onSelectionChange(sel: CellRange | null): void {
+    if (!sel) {
+      selectionLabel.textContent = 'Click or drag to select cells. Ctrl+C to copy.';
+      copyBtn.disabled = true;
+      return;
+    }
+    const r1 = Math.min(sel.anchor.row, sel.active.row);
+    const r2 = Math.max(sel.anchor.row, sel.active.row);
+    const c1 = Math.min(sel.anchor.col, sel.active.col);
+    const c2 = Math.max(sel.anchor.col, sel.active.col);
+    const colLabel = (n: number) => {
+      let s = '';
+      while (n > 0) { n--; s = String.fromCharCode(65 + (n % 26)) + s; n = Math.floor(n / 26); }
+      return s;
+    };
+    const tl = `${colLabel(c1)}${r1}`;
+    const br = `${colLabel(c2)}${r2}`;
+    selectionLabel.textContent =
+      r1 === r2 && c1 === c2 ? `Selected: ${tl}` : `Selected: ${tl}:${br} (${r2 - r1 + 1}×${c2 - c1 + 1})`;
+    copyBtn.disabled = false;
+  }
+
+  function createViewer(): XlsxViewer {
+    viewerContainer.innerHTML = '';
+    return new XlsxViewer(viewerContainer, {
+      cellScale: args.scale,
+      onReady: (names) => { selectionLabel.textContent = `Loaded — ${names.length} sheet(s). Click a cell to select.`; },
+      onSheetChange: (_idx, name) => { selectionLabel.textContent = `Sheet: ${name} — Click to select.`; },
+      onError: (err) => { selectionLabel.textContent = `Error: ${err.message}`; },
+      onSelectionChange,
+    });
+  }
+
+  copyBtn.addEventListener('click', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }));
+    copyBtn.textContent = 'Copied!';
+    setTimeout(() => { copyBtn.textContent = 'Copy selection'; }, 1200);
+  });
+
+  fileInput.addEventListener('change', async () => {
+    const file = fileInput.files?.[0];
+    if (!file) return;
+    selectionLabel.textContent = 'Parsing…';
+    currentViewer?.destroy();
+    currentViewer = createViewer();
+    await currentViewer.load(await file.arrayBuffer());
+  });
+
+  currentViewer = createViewer();
+
+  if (autoLoadUrl) {
+    selectionLabel.textContent = 'Loading…';
+    fetch(autoLoadUrl)
+      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.arrayBuffer(); })
+      .then((buf) => currentViewer!.load(buf))
+      .catch((err) => { selectionLabel.textContent = `Failed: ${err.message}`; });
+  }
+
+  return root;
+}
+
+export const SelectableFileUpload: Story = {
+  name: 'Selectable — file upload',
+  render(args) { return buildSelectableUI(args); },
+};
+
+export const SelectableSample1: Story = {
+  name: 'Selectable — sample-1.xlsx',
+  render(args) { return buildSelectableUI(args, `${import.meta.env.BASE_URL}xlsx/demo/sample-1.xlsx`); },
 };

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -1,6 +1,6 @@
 export { XlsxWorkbook } from './workbook.js';
 export { XlsxViewer } from './viewer.js';
-export type { XlsxViewerOptions } from './viewer.js';
+export type { XlsxViewerOptions, CellAddress, CellRange } from './viewer.js';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Workbook,
@@ -20,4 +20,5 @@ export type {
   ParsedWorkbook,
   ViewportRange,
   RenderViewportOptions,
+  TextRunInfo,
 } from './types.js';

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -1,6 +1,6 @@
 export { XlsxWorkbook } from './workbook.js';
 export { XlsxViewer } from './viewer.js';
-export type { XlsxViewerOptions, CellAddress, CellRange } from './viewer.js';
+export type { XlsxViewerOptions, CellAddress, CellRange, SelectionMode } from './viewer.js';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Workbook,

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type {
   Worksheet, Styles, Cell, CellValue, Font, Fill, Border, BorderEdge, CellXf,
-  ViewportRange, RenderViewportOptions,
+  ViewportRange, RenderViewportOptions, TextRunInfo,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
@@ -1972,6 +1972,7 @@ interface RenderContext {
   commentCells: Set<string>;
   /** row:col → table-style overlay (bold header, banded rows, borders). */
   tableStyleMap: Map<string, TableCellStyle>;
+  onTextRun?: (info: TextRunInfo) => void;
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -2747,6 +2748,10 @@ function renderQuadrant(
       }
 
       ctx.restore();
+
+      if (text && rc.onTextRun) {
+        rc.onTextRun({ text, x: cx, y: cy, width: cellW, height: cellH, row: rowIndex, col: colIndex });
+      }
     }
   }
 
@@ -2874,6 +2879,7 @@ export function renderViewport(
     hyperlinkMap,
     commentCells,
     tableStyleMap,
+    onTextRun: opts.onTextRun,
   };
 
   // Canvas areas for each quadrant

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -467,6 +467,21 @@ export interface ViewportRange {
   cols: number;
 }
 
+/** Emitted once per cell that has text, with the cell's canvas-pixel bounds. */
+export interface TextRunInfo {
+  text: string;
+  /** Canvas CSS-pixel x of the cell's top-left corner. */
+  x: number;
+  /** Canvas CSS-pixel y of the cell's top-left corner. */
+  y: number;
+  /** Cell width in canvas CSS pixels. */
+  width: number;
+  /** Cell height in canvas CSS pixels. */
+  height: number;
+  row: number;
+  col: number;
+}
+
 export interface RenderViewportOptions {
   width?: number;
   height?: number;
@@ -481,6 +496,8 @@ export interface RenderViewportOptions {
   cellScale?: number;
   /** Pre-loaded Image elements keyed by their dataUrl (for ImageAnchor rendering). */
   loadedImages?: Map<string, HTMLImageElement>;
+  /** Called once per cell that contains text, with canvas-pixel position and cell address. */
+  onTextRun?: (info: TextRunInfo) => void;
 }
 
 export type WorkerRequest =

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -10,6 +10,18 @@ export interface XlsxViewerOptions {
   onReady?: (sheetNames: string[]) => void;
   onSheetChange?: (index: number, name: string) => void;
   onError?: (err: Error) => void;
+  /** Called when the selected cell range changes. null means no selection. */
+  onSelectionChange?: (selection: CellRange | null) => void;
+}
+
+export interface CellAddress {
+  row: number;
+  col: number;
+}
+
+export interface CellRange {
+  anchor: CellAddress;
+  active: CellAddress;
 }
 
 export class XlsxViewer {
@@ -24,6 +36,13 @@ export class XlsxViewer {
   private currentWorksheet: Worksheet | null = null;
   private opts: XlsxViewerOptions;
   private resizeObserver: ResizeObserver | null = null;
+
+  // Selection state
+  private anchorCell: CellAddress | null = null;
+  private activeCell: CellAddress | null = null;
+  private isSelecting = false;
+  private selectionOverlay: HTMLDivElement;
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
 
   constructor(container: HTMLElement, opts: XlsxViewerOptions = {}) {
     this.opts = opts;
@@ -40,14 +59,21 @@ export class XlsxViewer {
     this.canvas = document.createElement('canvas');
     this.canvas.style.cssText = `position:absolute;top:0;left:0;z-index:0;display:block;`;
 
+    // Selection overlay: sits above canvas, below scrollHost (z-index 0.5 via fractional z not possible,
+    // use pointer-events:none so scrollHost still receives events)
+    this.selectionOverlay = document.createElement('div');
+    this.selectionOverlay.style.cssText =
+      `position:absolute;top:0;left:0;z-index:1;pointer-events:none;overflow:hidden;width:100%;height:100%;`;
+
     this.scrollHost = document.createElement('div');
-    this.scrollHost.style.cssText = `position:absolute;inset:0;overflow:auto;z-index:1;background:transparent;`;
+    this.scrollHost.style.cssText = `position:absolute;inset:0;overflow:auto;z-index:2;background:transparent;`;
 
     this.spacer = document.createElement('div');
     this.spacer.style.cssText = `position:absolute;top:0;left:0;pointer-events:none;`;
     this.scrollHost.appendChild(this.spacer);
 
     this.canvasArea.appendChild(this.canvas);
+    this.canvasArea.appendChild(this.selectionOverlay);
     this.canvasArea.appendChild(this.scrollHost);
 
     this.tabBar = document.createElement('div');
@@ -64,11 +90,19 @@ export class XlsxViewer {
     wrapper.appendChild(this.tabBar);
     container.appendChild(wrapper);
 
-    this.scrollHost.addEventListener('scroll', () => this.renderCurrentSheet());
+    this.scrollHost.addEventListener('scroll', () => {
+      this.renderCurrentSheet();
+      this.updateSelectionOverlay();
+    });
 
     // Re-render whenever the canvas area changes size
-    this.resizeObserver = new ResizeObserver(() => this.renderCurrentSheet());
+    this.resizeObserver = new ResizeObserver(() => {
+      this.renderCurrentSheet();
+      this.updateSelectionOverlay();
+    });
     this.resizeObserver.observe(this.canvasArea);
+
+    this.setupSelectionEvents();
   }
 
   async load(source: string | ArrayBuffer): Promise<void> {
@@ -86,11 +120,241 @@ export class XlsxViewer {
     this.currentSheet = index;
     this.scrollHost.scrollLeft = 0;
     this.scrollHost.scrollTop = 0;
+    this.anchorCell = null;
+    this.activeCell = null;
+    this.updateSelectionOverlay();
     this.updateTabActive(index);
     this.currentWorksheet = await this.wb.getWorksheet(index);
     this.updateSpacerSize(this.currentWorksheet);
     await this.renderCurrentSheet();
     this.opts.onSheetChange?.(index, this.wb.sheetNames[index] ?? '');
+  }
+
+  /** Returns the cell at canvas-client coordinates, or null if outside the cell grid. */
+  getCellAt(clientX: number, clientY: number): CellAddress | null {
+    const ws = this.currentWorksheet;
+    if (!ws) return null;
+    const cs = this.opts.cellScale ?? 1;
+
+    const rect = this.canvasArea.getBoundingClientRect();
+    const lx = (clientX - rect.left) / cs;
+    const ly = (clientY - rect.top) / cs;
+
+    if (lx < HEADER_W || ly < HEADER_H) return null;
+
+    const innerX = lx - HEADER_W;
+    const innerY = ly - HEADER_H;
+
+    const freezeRows = ws.freezeRows ?? 0;
+    const freezeCols = ws.freezeCols ?? 0;
+
+    // Compute frozen pixel dimensions (unscaled)
+    let frozenH = 0;
+    const frozenRowH: number[] = [];
+    for (let r = 1; r <= freezeRows; r++) {
+      const h = rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+      frozenRowH.push(h);
+      frozenH += h;
+    }
+    let frozenW = 0;
+    const frozenColW: number[] = [];
+    for (let c = 1; c <= freezeCols; c++) {
+      const w = colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth);
+      frozenColW.push(w);
+      frozenW += w;
+    }
+
+    // Find row
+    let row: number;
+    if (innerY < frozenH) {
+      row = -1;
+      let acc = 0;
+      for (let r = 0; r < freezeRows; r++) {
+        acc += frozenRowH[r];
+        if (innerY < acc) { row = r + 1; break; }
+      }
+      if (row === -1) return null;
+    } else {
+      const contentY = innerY - frozenH + this.scrollHost.scrollTop / cs;
+      row = -1;
+      let acc = 0;
+      for (let r = freezeRows + 1; r <= 1048576; r++) {
+        acc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+        if (contentY < acc) { row = r; break; }
+      }
+      if (row === -1) return null;
+    }
+
+    // Find col
+    let col: number;
+    if (innerX < frozenW) {
+      col = -1;
+      let acc = 0;
+      for (let c = 0; c < freezeCols; c++) {
+        acc += frozenColW[c];
+        if (innerX < acc) { col = c + 1; break; }
+      }
+      if (col === -1) return null;
+    } else {
+      const contentX = innerX - frozenW + this.scrollHost.scrollLeft / cs;
+      col = -1;
+      let acc = 0;
+      for (let c = freezeCols + 1; c <= 16384; c++) {
+        acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth);
+        if (contentX < acc) { col = c; break; }
+      }
+      if (col === -1) return null;
+    }
+
+    return { row, col };
+  }
+
+  /** Returns the CSS-pixel rect of a cell within canvasArea, or null if not computable. */
+  private getCellRect(row: number, col: number): { x: number; y: number; w: number; h: number } | null {
+    const ws = this.currentWorksheet;
+    if (!ws) return null;
+    const cs = this.opts.cellScale ?? 1;
+
+    const freezeRows = ws.freezeRows ?? 0;
+    const freezeCols = ws.freezeCols ?? 0;
+
+    // Compute x
+    let x: number;
+    if (col <= freezeCols) {
+      let acc = HEADER_W;
+      for (let c = 1; c < col; c++) acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth);
+      x = acc * cs;
+    } else {
+      let frozenW = 0;
+      for (let c = 1; c <= freezeCols; c++) frozenW += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth);
+      let acc = HEADER_W + frozenW;
+      for (let c = freezeCols + 1; c < col; c++) acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth);
+      x = (acc - this.scrollHost.scrollLeft / cs) * cs;
+    }
+
+    // Compute y
+    let y: number;
+    if (row <= freezeRows) {
+      let acc = HEADER_H;
+      for (let r = 1; r < row; r++) acc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+      y = acc * cs;
+    } else {
+      let frozenH = 0;
+      for (let r = 1; r <= freezeRows; r++) frozenH += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+      let acc = HEADER_H + frozenH;
+      for (let r = freezeRows + 1; r < row; r++) acc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+      y = (acc - this.scrollHost.scrollTop / cs) * cs;
+    }
+
+    const w = colWidthToPx(ws.colWidths[col] ?? ws.defaultColWidth) * cs;
+    const h = rowHeightToPx(ws.rowHeights[row] ?? ws.defaultRowHeight) * cs;
+
+    return { x, y, w, h };
+  }
+
+  /** Returns the normalized selection range (top-left anchor, bottom-right active). */
+  get selection(): CellRange | null {
+    if (!this.anchorCell || !this.activeCell) return null;
+    return { anchor: this.anchorCell, active: this.activeCell };
+  }
+
+  /** Copy the selected cell range as tab-separated text to the clipboard. */
+  private copySelection(): void {
+    const ws = this.currentWorksheet;
+    if (!ws || !this.anchorCell || !this.activeCell) return;
+
+    const r1 = Math.min(this.anchorCell.row, this.activeCell.row);
+    const r2 = Math.max(this.anchorCell.row, this.activeCell.row);
+    const c1 = Math.min(this.anchorCell.col, this.activeCell.col);
+    const c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+
+    // Build cell map for the selection range
+    const cellMap = new Map<string, string>();
+    for (const row of ws.rows) {
+      if (row.index < r1 || row.index > r2) continue;
+      for (const cell of row.cells) {
+        if (cell.col < c1 || cell.col > c2) continue;
+        const v = cell.value;
+        let text = '';
+        if (v.type === 'text') text = v.runs ? v.runs.map((r) => r.text).join('') : v.text;
+        else if (v.type === 'number') text = String(v.number);
+        else if (v.type === 'bool') text = v.bool ? 'TRUE' : 'FALSE';
+        else if (v.type === 'error') text = v.error;
+        if (text) cellMap.set(`${row.index}:${cell.col}`, text);
+      }
+    }
+
+    const lines: string[] = [];
+    for (let r = r1; r <= r2; r++) {
+      const cols: string[] = [];
+      for (let c = c1; c <= c2; c++) cols.push(cellMap.get(`${r}:${c}`) ?? '');
+      lines.push(cols.join('\t'));
+    }
+    navigator.clipboard.writeText(lines.join('\n')).catch(() => undefined);
+  }
+
+  private updateSelectionOverlay(): void {
+    this.selectionOverlay.innerHTML = '';
+    if (!this.anchorCell || !this.activeCell) return;
+
+    const r1 = Math.min(this.anchorCell.row, this.activeCell.row);
+    const r2 = Math.max(this.anchorCell.row, this.activeCell.row);
+    const c1 = Math.min(this.anchorCell.col, this.activeCell.col);
+    const c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+
+    const topLeft = this.getCellRect(r1, c1);
+    const bottomRight = this.getCellRect(r2, c2);
+    if (!topLeft || !bottomRight) return;
+
+    const x = topLeft.x;
+    const y = topLeft.y;
+    const w = bottomRight.x + bottomRight.w - topLeft.x;
+    const h = bottomRight.y + bottomRight.h - topLeft.y;
+
+    const box = document.createElement('div');
+    box.style.cssText =
+      `position:absolute;` +
+      `left:${x}px;top:${y}px;width:${w}px;height:${h}px;` +
+      `box-sizing:border-box;` +
+      `border:2px solid #1a73e8;` +
+      `background:rgba(26,115,232,0.08);` +
+      `pointer-events:none;`;
+    this.selectionOverlay.appendChild(box);
+  }
+
+  private setupSelectionEvents(): void {
+    this.scrollHost.addEventListener('pointerdown', (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      const cell = this.getCellAt(e.clientX, e.clientY);
+      if (!cell) return;
+      this.anchorCell = cell;
+      this.activeCell = cell;
+      this.isSelecting = true;
+      this.scrollHost.setPointerCapture(e.pointerId);
+      this.updateSelectionOverlay();
+      this.opts.onSelectionChange?.(this.selection);
+    });
+
+    this.scrollHost.addEventListener('pointermove', (e: PointerEvent) => {
+      if (!this.isSelecting) return;
+      const cell = this.getCellAt(e.clientX, e.clientY);
+      if (!cell) return;
+      if (cell.row === this.activeCell?.row && cell.col === this.activeCell?.col) return;
+      this.activeCell = cell;
+      this.updateSelectionOverlay();
+      this.opts.onSelectionChange?.(this.selection);
+    });
+
+    this.scrollHost.addEventListener('pointerup', () => {
+      this.isSelecting = false;
+    });
+
+    this.keydownHandler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
+        this.copySelection();
+      }
+    };
+    document.addEventListener('keydown', this.keydownHandler);
   }
 
   private buildTabs(): void {
@@ -268,6 +532,9 @@ export class XlsxViewer {
 
   destroy(): void {
     this.resizeObserver?.disconnect();
+    if (this.keydownHandler) {
+      document.removeEventListener('keydown', this.keydownHandler);
+    }
     this.wb.destroy();
   }
 }

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -19,9 +19,12 @@ export interface CellAddress {
   col: number;
 }
 
+export type SelectionMode = 'cells' | 'rows' | 'cols' | 'all';
+
 export interface CellRange {
   anchor: CellAddress;
   active: CellAddress;
+  mode: SelectionMode;
 }
 
 export class XlsxViewer {
@@ -40,6 +43,7 @@ export class XlsxViewer {
   // Selection state
   private anchorCell: CellAddress | null = null;
   private activeCell: CellAddress | null = null;
+  private selectionMode: SelectionMode = 'cells';
   private isSelecting = false;
   private selectionOverlay: HTMLDivElement;
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
@@ -122,6 +126,7 @@ export class XlsxViewer {
     this.scrollHost.scrollTop = 0;
     this.anchorCell = null;
     this.activeCell = null;
+    this.selectionMode = 'cells';
     this.updateSelectionOverlay();
     this.updateTabActive(index);
     this.currentWorksheet = await this.wb.getWorksheet(index);
@@ -252,10 +257,86 @@ export class XlsxViewer {
     return { x, y, w, h };
   }
 
-  /** Returns the normalized selection range (top-left anchor, bottom-right active). */
+  /** Returns the current selection, including mode. */
   get selection(): CellRange | null {
     if (!this.anchorCell || !this.activeCell) return null;
-    return { anchor: this.anchorCell, active: this.activeCell };
+    return { anchor: this.anchorCell, active: this.activeCell, mode: this.selectionMode };
+  }
+
+  /**
+   * Returns what the header area contains at the given client coordinates.
+   * Returns null when the point is in the cell grid (not a header).
+   */
+  private getHeaderHit(
+    clientX: number,
+    clientY: number,
+  ): { kind: 'corner' } | { kind: 'row'; row: number } | { kind: 'col'; col: number } | null {
+    const ws = this.currentWorksheet;
+    if (!ws) return null;
+    const cs = this.opts.cellScale ?? 1;
+    const rect = this.canvasArea.getBoundingClientRect();
+    const lx = (clientX - rect.left) / cs;
+    const ly = (clientY - rect.top) / cs;
+
+    const inRowHeader = lx < HEADER_W;
+    const inColHeader = ly < HEADER_H;
+    if (!inRowHeader && !inColHeader) return null;
+    if (inRowHeader && inColHeader) return { kind: 'corner' };
+
+    const freezeRows = ws.freezeRows ?? 0;
+    const freezeCols = ws.freezeCols ?? 0;
+
+    if (inRowHeader) {
+      // Determine which row was clicked
+      const innerY = ly - HEADER_H;
+      if (innerY < 0) return { kind: 'corner' };
+      let frozenH = 0;
+      const frozenRowH: number[] = [];
+      for (let r = 1; r <= freezeRows; r++) {
+        const h = rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+        frozenRowH.push(h); frozenH += h;
+      }
+      if (innerY < frozenH) {
+        let acc = 0;
+        for (let r = 0; r < freezeRows; r++) {
+          acc += frozenRowH[r];
+          if (innerY < acc) return { kind: 'row', row: r + 1 };
+        }
+        return null;
+      }
+      const contentY = innerY - frozenH + this.scrollHost.scrollTop / cs;
+      let acc = 0;
+      for (let r = freezeRows + 1; r <= 1048576; r++) {
+        acc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+        if (contentY < acc) return { kind: 'row', row: r };
+      }
+      return null;
+    }
+
+    // inColHeader
+    const innerX = lx - HEADER_W;
+    if (innerX < 0) return { kind: 'corner' };
+    let frozenW = 0;
+    const frozenColW: number[] = [];
+    for (let c = 1; c <= freezeCols; c++) {
+      const w = colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth);
+      frozenColW.push(w); frozenW += w;
+    }
+    if (innerX < frozenW) {
+      let acc = 0;
+      for (let c = 0; c < freezeCols; c++) {
+        acc += frozenColW[c];
+        if (innerX < acc) return { kind: 'col', col: c + 1 };
+      }
+      return null;
+    }
+    const contentX = innerX - frozenW + this.scrollHost.scrollLeft / cs;
+    let acc = 0;
+    for (let c = freezeCols + 1; c <= 16384; c++) {
+      acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth);
+      if (contentX < acc) return { kind: 'col', col: c };
+    }
+    return null;
   }
 
   /** Copy the selected cell range as tab-separated text to the clipboard. */
@@ -263,12 +344,33 @@ export class XlsxViewer {
     const ws = this.currentWorksheet;
     if (!ws || !this.anchorCell || !this.activeCell) return;
 
-    const r1 = Math.min(this.anchorCell.row, this.activeCell.row);
-    const r2 = Math.max(this.anchorCell.row, this.activeCell.row);
-    const c1 = Math.min(this.anchorCell.col, this.activeCell.col);
-    const c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+    // Determine actual data extent for rows/cols/all modes
+    let maxRow = 1, maxCol = 1;
+    for (const row of ws.rows) {
+      if (row.index > maxRow) maxRow = row.index;
+      for (const cell of row.cells) {
+        if (cell.col > maxCol) maxCol = cell.col;
+      }
+    }
 
-    // Build cell map for the selection range
+    let r1: number, r2: number, c1: number, c2: number;
+    if (this.selectionMode === 'all') {
+      r1 = 1; r2 = maxRow; c1 = 1; c2 = maxCol;
+    } else if (this.selectionMode === 'rows') {
+      r1 = Math.min(this.anchorCell.row, this.activeCell.row);
+      r2 = Math.max(this.anchorCell.row, this.activeCell.row);
+      c1 = 1; c2 = maxCol;
+    } else if (this.selectionMode === 'cols') {
+      c1 = Math.min(this.anchorCell.col, this.activeCell.col);
+      c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+      r1 = 1; r2 = maxRow;
+    } else {
+      r1 = Math.min(this.anchorCell.row, this.activeCell.row);
+      r2 = Math.max(this.anchorCell.row, this.activeCell.row);
+      c1 = Math.min(this.anchorCell.col, this.activeCell.col);
+      c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+    }
+
     const cellMap = new Map<string, string>();
     for (const row of ws.rows) {
       if (row.index < r1 || row.index > r2) continue;
@@ -297,38 +399,108 @@ export class XlsxViewer {
     this.selectionOverlay.innerHTML = '';
     if (!this.anchorCell || !this.activeCell) return;
 
-    const r1 = Math.min(this.anchorCell.row, this.activeCell.row);
-    const r2 = Math.max(this.anchorCell.row, this.activeCell.row);
-    const c1 = Math.min(this.anchorCell.col, this.activeCell.col);
-    const c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+    const cs = this.opts.cellScale ?? 1;
+    let x: number, y: number, w: number, h: number;
 
-    const topLeft = this.getCellRect(r1, c1);
-    const bottomRight = this.getCellRect(r2, c2);
-    if (!topLeft || !bottomRight) return;
+    if (this.selectionMode === 'all') {
+      x = HEADER_W * cs;
+      y = HEADER_H * cs;
+      w = this.canvasArea.clientWidth - HEADER_W * cs;
+      h = this.canvasArea.clientHeight - HEADER_H * cs;
+    } else if (this.selectionMode === 'rows') {
+      const r1 = Math.min(this.anchorCell.row, this.activeCell.row);
+      const r2 = Math.max(this.anchorCell.row, this.activeCell.row);
+      const top = this.getCellRect(r1, 1);
+      const bot = this.getCellRect(r2, 1);
+      if (!top || !bot) return;
+      x = HEADER_W * cs;
+      y = top.y;
+      w = this.canvasArea.clientWidth - HEADER_W * cs;
+      h = bot.y + bot.h - top.y;
+    } else if (this.selectionMode === 'cols') {
+      const c1 = Math.min(this.anchorCell.col, this.activeCell.col);
+      const c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+      const left = this.getCellRect(1, c1);
+      const right = this.getCellRect(1, c2);
+      if (!left || !right) return;
+      x = left.x;
+      y = HEADER_H * cs;
+      w = right.x + right.w - left.x;
+      h = this.canvasArea.clientHeight - HEADER_H * cs;
+    } else {
+      const r1 = Math.min(this.anchorCell.row, this.activeCell.row);
+      const r2 = Math.max(this.anchorCell.row, this.activeCell.row);
+      const c1 = Math.min(this.anchorCell.col, this.activeCell.col);
+      const c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+      const tl = this.getCellRect(r1, c1);
+      const br = this.getCellRect(r2, c2);
+      if (!tl || !br) return;
+      x = tl.x; y = tl.y;
+      w = br.x + br.w - tl.x;
+      h = br.y + br.h - tl.y;
+    }
 
-    const x = topLeft.x;
-    const y = topLeft.y;
-    const w = bottomRight.x + bottomRight.w - topLeft.x;
-    const h = bottomRight.y + bottomRight.h - topLeft.y;
-
+    if (w <= 0 || h <= 0) return;
     const box = document.createElement('div');
     box.style.cssText =
       `position:absolute;` +
       `left:${x}px;top:${y}px;width:${w}px;height:${h}px;` +
-      `box-sizing:border-box;` +
-      `border:2px solid #1a73e8;` +
-      `background:rgba(26,115,232,0.08);` +
-      `pointer-events:none;`;
+      `box-sizing:border-box;border:2px solid #1a73e8;` +
+      `background:rgba(26,115,232,0.08);pointer-events:none;`;
     this.selectionOverlay.appendChild(box);
   }
 
   private setupSelectionEvents(): void {
     this.scrollHost.addEventListener('pointerdown', (e: PointerEvent) => {
       if (e.button !== 0) return;
+
+      const headerHit = this.getHeaderHit(e.clientX, e.clientY);
+
+      if (headerHit) {
+        if (headerHit.kind === 'corner') {
+          // Select all — no drag extension needed
+          this.selectionMode = 'all';
+          this.anchorCell = { row: 1, col: 1 };
+          this.activeCell = { row: 1, col: 1 };
+          this.isSelecting = false;
+        } else if (headerHit.kind === 'row') {
+          if (e.shiftKey && this.anchorCell && this.selectionMode === 'rows') {
+            // Extend existing row selection
+            this.activeCell = { row: headerHit.row, col: 1 };
+          } else {
+            this.selectionMode = 'rows';
+            this.anchorCell = { row: headerHit.row, col: 1 };
+            this.activeCell = { row: headerHit.row, col: 1 };
+            this.isSelecting = true;
+            this.scrollHost.setPointerCapture(e.pointerId);
+          }
+        } else {
+          if (e.shiftKey && this.anchorCell && this.selectionMode === 'cols') {
+            this.activeCell = { row: 1, col: headerHit.col };
+          } else {
+            this.selectionMode = 'cols';
+            this.anchorCell = { row: 1, col: headerHit.col };
+            this.activeCell = { row: 1, col: headerHit.col };
+            this.isSelecting = true;
+            this.scrollHost.setPointerCapture(e.pointerId);
+          }
+        }
+        this.updateSelectionOverlay();
+        this.opts.onSelectionChange?.(this.selection);
+        return;
+      }
+
       const cell = this.getCellAt(e.clientX, e.clientY);
       if (!cell) return;
-      this.anchorCell = cell;
-      this.activeCell = cell;
+
+      if (e.shiftKey && this.anchorCell && this.selectionMode === 'cells') {
+        // Extend current selection; keep anchor
+        this.activeCell = cell;
+      } else {
+        this.selectionMode = 'cells';
+        this.anchorCell = cell;
+        this.activeCell = cell;
+      }
       this.isSelecting = true;
       this.scrollHost.setPointerCapture(e.pointerId);
       this.updateSelectionOverlay();
@@ -337,10 +509,23 @@ export class XlsxViewer {
 
     this.scrollHost.addEventListener('pointermove', (e: PointerEvent) => {
       if (!this.isSelecting) return;
-      const cell = this.getCellAt(e.clientX, e.clientY);
-      if (!cell) return;
-      if (cell.row === this.activeCell?.row && cell.col === this.activeCell?.col) return;
-      this.activeCell = cell;
+
+      if (this.selectionMode === 'rows') {
+        const hit = this.getHeaderHit(e.clientX, e.clientY);
+        const row = hit?.kind === 'row' ? hit.row : this.getCellAt(e.clientX, e.clientY)?.row;
+        if (!row || row === this.activeCell?.row) return;
+        this.activeCell = { row, col: 1 };
+      } else if (this.selectionMode === 'cols') {
+        const hit = this.getHeaderHit(e.clientX, e.clientY);
+        const col = hit?.kind === 'col' ? hit.col : this.getCellAt(e.clientX, e.clientY)?.col;
+        if (!col || col === this.activeCell?.col) return;
+        this.activeCell = { row: 1, col };
+      } else {
+        const cell = this.getCellAt(e.clientX, e.clientY);
+        if (!cell || (cell.row === this.activeCell?.row && cell.col === this.activeCell?.col)) return;
+        this.activeCell = cell;
+      }
+
       this.updateSelectionOverlay();
       this.opts.onSelectionChange?.(this.selection);
     });


### PR DESCRIPTION
## Summary

- `getCellAt(clientX, clientY)` — hit-tests canvas coords to row/col address
- Selection overlay (blue border div, `pointer-events:none`) renders above canvas for all 4 modes
- **Click cell** → single-cell selection; **drag** → range selection
- **Click row header** → full row selection; **drag** → multi-row
- **Click col header** → full column selection; **drag** → multi-col
- **Click corner** → select all cells
- **Shift+click** → extend selection (keeps anchor, updates active)
- **Ctrl+C** → tab-separated clipboard copy, mode-aware
- `onSelectionChange` callback on `XlsxViewerOptions`; `selection` getter on `XlsxViewer`
- Exports: `CellAddress`, `CellRange`, `SelectionMode`, `TextRunInfo`
- Storybook: "Selectable — file upload" and "Selectable — sample-1.xlsx" stories added

## Test plan

- [x] Cell click → "Selected: B6" label
- [x] Shift+click → "Selected: B6:E12 (7×4)"
- [x] Col header click → "Selected: col B" + full-column blue overlay
- [x] Row header click → "Selected: row 20"
- [x] Corner click → "Selected: all cells"
- [x] Storybook screenshot verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)