### PR TITLE
fix(xlsx): clamp selection overlay to header boundaries

### DIFF
--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -440,6 +440,12 @@ export class XlsxViewer {
       h = br.y + br.h - tl.y;
     }
 
+    // Clamp to header boundaries so the overlay never overlaps fixed headers.
+    const minX = HEADER_W * cs;
+    const minY = HEADER_H * cs;
+    if (x < minX) { w -= minX - x; x = minX; }
+    if (y < minY) { h -= minY - y; y = minY; }
+
     if (w <= 0 || h <= 0) return;
     const box = document.createElement('div');
     box.style.cssText =


### PR DESCRIPTION
## Summary

- Clamp the selection box `x` to `HEADER_W * cs` and `y` to `HEADER_H * cs` in `updateSelectionOverlay()`
- Adjust `w`/`h` by the clipped amount so the right/bottom edges stay correct
- Prevents the blue border and background from visually overlapping the fixed row-number column and column-letter row

## Test plan

- [x] Column B selected → blue box starts below the column header row, not on top of it  
- [x] Row selection → blue box starts to the right of the row number column
- [x] Select all → same boundaries respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)