### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.13.0 — 2026-04-25
+
+UX and tooling release. The core viewer packages gain **text and cell
+selection** (PDF.js-style transparent overlay so the browser's native
+selection/copy work on top of Canvas). Two new companion packages ship
+alongside: a **VS Code extension** (`ooxml-viewer`) that registers custom
+editors for `.xlsx` / `.docx` / `.pptx`, and a **Rust MCP server**
+(`ooxml-mcp-server`) that exposes the parsers as structured tools for AI
+agents. No rendering-fidelity changes.
+
+### viewer UX
+
+- **Text selection overlay (pptx/docx/xlsx)** — each viewer now emits an
+  `onTextRun` stream from the renderer and mounts an absolute-positioned
+  `<span>` per text run above the canvas with `color: transparent`. The
+  browser's native selection, copy, and `::selection` styling all work
+  against the overlay, so users can select, Ctrl+C copy, or drag text
+  exactly as they would in a DOM-rendered document. pptx handles rotated
+  and vertical text via `transform: rotate(...)` on the overlay spans.
+- **xlsx cell selection** (`packages/xlsx`):
+  - `getCellAt(clientX, clientY)` on `XlsxViewer` hit-tests canvas
+    coordinates to row/col addresses (respects merged cells and freeze
+    panes).
+  - Four selection modes: single cell, range, row (click row header),
+    column (click col header), all (corner click). Drag to extend.
+    Shift+click extends from the current anchor.
+  - `Ctrl+C` copies the selected range as tab-separated text (TSV) to the
+    clipboard, mode-aware (full row → entire row; range → block).
+  - `onSelectionChange` callback on `XlsxViewerOptions`; `selection`
+    getter on the viewer. New exports: `CellAddress`, `CellRange`,
+    `SelectionMode`, `TextRunInfo`.
+  - Selection overlay clamps to the header/freeze-pane boundaries so the
+    highlight doesn't bleed over the sticky row/column bands.
+
+### New package: VS Code extension (`packages/vscode-extension`)
+
+- Registers `CustomEditorProvider` for `.xlsx`, `.docx`, and `.pptx`, so
+  double-clicking an Office file in the VS Code explorer opens it in the
+  same Canvas viewer used by the Storybook demo.
+- Webview bundles the existing `XlsxViewer` / `DocxViewer` / `PptxViewer`
+  classes; selection events can be relayed to the extension host via
+  `acquireVsCodeApi().postMessage()`.
+
+### New package: Rust MCP server (`packages/mcp-server`)
+
+- Exposes the existing xlsx/docx/pptx parsers as an MCP server so agents
+  (Claude, Copilot, Codex, …) can query OOXML files without shelling out
+  to `unzip` + ad-hoc Python. Structured tools include
+  `xlsx_get_cell_range`, `xlsx_get_formulas`, `docx_get_structure`,
+  `docx_get_tables`, `pptx_get_slide_structure`, and format-specific
+  search helpers.
+- Built natively from the same Rust crates (the `rlib` output of
+  `packages/{xlsx,docx,pptx}/parser`), so the parser logic is shared
+  with the browser build one-to-one.
+
 ## 0.12.0 — 2026-04-25
 
 xlsx fidelity release focused on sample-1 ("Holiday shopping budget") and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,5 +101,7 @@ pnpm vrt
 3. **CHANGELOG 追記**: `CHANGELOG.md` の先頭に `## 0.x.0 — YYYY-MM-DD` セクションを追加し、docx/pptx/xlsx/charts ごとに 1〜3 行の bullet で要点を書く。ECMA-376 節番号や PR 番号を適宜併記。
 4. **バージョン bump**: ルート `package.json` と `packages/{core,pptx,xlsx,docx}/package.json` の計 5 ファイルを同じ minor バージョンへ揃える。
 5. **PR 作成**: ブランチ名は `release/0.x.0`。PR タイトルは `chore(release): 0.x.0`。マージは必ず `--merge` か `--rebase`（squash 禁止）。
+6. **タグ作成**: PR マージ後、main を pull して `git tag -a v0.x.0 -m "v0.x.0"` → `git push origin v0.x.0`。
+7. **GitHub Release 作成**: `gh release create v0.x.0 --title v0.x.0 --notes "..."` でリリースノート公開。本文は CHANGELOG の該当セクションを要約し、末尾に `**Full Changelog**: https://github.com/yukiyokotani/office-open-xml-viewer/compare/v0.(x-1).0...v0.x.0` を追記する。既存 v0.12.0 のフォーマットを踏襲すること (`gh release view v0.12.0` で確認可能)。
 
 参照画像（`tests/visual/references/`）はこの手順の対象外。README のスクリーンショットは `docs/images/` 配下のみ。

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | **Theme** | Scheme colors (dk1/lt1/accent1–6) | ✅ |
 | | Font scheme (`+mj-lt`, `+mn-lt`) | ✅ |
 | | lumMod / lumOff / alpha transforms | ✅ |
+| **Interaction** | Text selection (transparent overlay, native copy) | ✅ |
 
 ---
 
@@ -448,6 +449,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | **Advanced** | Footnote / endnote reference markers | ✅ |
 | | Track changes / comments | ❌ |
 | | Mail merge fields | ❌ Not planned |
+| **Interaction** | Text selection (transparent overlay, native copy) | ✅ |
 
 ---
 
@@ -478,6 +480,17 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Slicers (static, Office 2010 extension) | ✅ |
 | | Pivot tables | ❌ Not planned |
 | | Data validation / comments | ❌ Not planned |
+| **Interaction** | Cell selection (single / range / row / column / all) | ✅ |
+| | Shift+click to extend, Ctrl+C to copy as TSV | ✅ |
+| | Text selection inside cells (transparent overlay) | ✅ |
+| | `onSelectionChange` callback, `getCellAt(x, y)` API | ✅ |
+
+---
+
+## Companion packages
+
+- **[`packages/vscode-extension/`](packages/vscode-extension/)** — VS Code extension (`ooxml-viewer`) that registers `CustomEditorProvider`s for `.xlsx`, `.docx`, and `.pptx`. Open Office files directly in the editor with the same Canvas renderer plus selection/copy.
+- **[`packages/mcp-server/`](packages/mcp-server/)** — Rust MCP server (`ooxml-mcp-server`) exposing the parsers as tools for AI agents (Claude, Copilot, Codex, etc.). Provides structured queries (`xlsx_get_cell_range`, `docx_get_structure`, `pptx_get_slide_structure`, …) so agents can inspect OOXML files without shelling out to `unzip`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

UX and tooling release — no rendering-fidelity changes.

- **Text selection overlay** (pptx/docx/xlsx): PDF.js-style transparent `<span>` overlay on top of Canvas so browser-native selection and Ctrl+C work. pptx handles rotated/vertical text via `transform: rotate(...)`.
- **xlsx cell selection**: `getCellAt(x, y)` hit-test + four modes (single/range/row/col/all), Shift+click to extend, Ctrl+C → TSV copy. `onSelectionChange` callback + `selection` getter on `XlsxViewer`.
- **New companion package — VS Code extension** (`packages/vscode-extension`, `ooxml-viewer`): registers `CustomEditorProvider` for `.xlsx`/`.docx`/`.pptx`. Opens Office files in the editor using the same Canvas renderer.
- **New companion package — Rust MCP server** (`packages/mcp-server`, `ooxml-mcp-server`): exposes the parsers as structured MCP tools (`xlsx_get_cell_range`, `docx_get_structure`, `pptx_get_slide_structure`, …) so AI agents can query OOXML without shelling out to `unzip`.

See [`CHANGELOG.md`](CHANGELOG.md) for details.

## README / screenshots

- Added **Interaction** rows to the pptx/docx/xlsx feature-support tables.
- Added a **Companion packages** section pointing at `packages/vscode-extension` and `packages/mcp-server`.
- `docs/images/{pptx,docx,xlsx}.png` **intentionally not regenerated** — this release contains no rendering changes (the 0.12.0 captures remain representative). Per CLAUDE.md the README table move is justified by the CHANGELOG entry.

## CLAUDE.md

- Added steps 6 (tag creation) and 7 (GitHub Release) to the release procedure so future releases always tag + publish release notes.

## Test plan

- [x] 5 `package.json` versions all bumped to `0.13.0`
- [x] `CHANGELOG.md` 0.13.0 section added above 0.12.0
- [x] Feature-support tables gain `Interaction` row per format
- [x] Companion packages section links to `packages/vscode-extension` and `packages/mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)