### PR TITLE
fix(build): exclude *.stories.ts from per-package tsconfig builds

### DIFF
--- a/packages/docx/tsconfig.json
+++ b/packages/docx/tsconfig.json
@@ -14,5 +14,6 @@
     "rootDir": "./src",
     "outDir": "./dist"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"]
 }

--- a/packages/pptx/tsconfig.json
+++ b/packages/pptx/tsconfig.json
@@ -12,5 +12,6 @@
     }
   },
   "include": ["src", "src/**/*.json"],
+  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"],
   "references": [{ "path": "../core" }]
 }

--- a/packages/xlsx/tsconfig.json
+++ b/packages/xlsx/tsconfig.json
@@ -11,5 +11,6 @@
     }
   },
   "include": ["src"],
+  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"],
   "references": [{ "path": "../core" }]
 }


### PR DESCRIPTION
## Summary

The new VS Code extension publish workflow runs `pnpm -r --filter "@silurus/*" build`, which invokes `tsc --build` inside each package. That fails because story files (`src/*.stories.ts`) import from `@storybook/html` — a type only declared in the workspace-root devDependencies, not per package. The existing npm publish workflow happened to mask this because it runs the root `vite build` which doesn't touch those files.

Stories are dev-time artifacts (Storybook only) and never ship in the published library. Excluding them from each package's tsconfig keeps `tsc --build` working without changing the published `dist/`.

## Verification

- `pnpm -r --filter "@silurus/*" build` succeeds locally after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)