### PR TITLE
feat(vscode-ext): scroll view, theme-aware bg, README rewrite, fix pptx wasm typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ packages/xlsx/src/*.privateDemo.stories.ts
 packages/docx/src/*.privateDemo.stories.ts
 # TypeScript build info
 *.tsbuildinfo
+# VS Code extension package output
+*.vsix
 # npm lockfile (using pnpm)
 package-lock.json
 # Per-session scratch notes (keep local, do not commit)

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -3,11 +3,21 @@ import type { WorkerRequest, WorkerResponse } from './types';
 
 let initPromise: Promise<unknown> | null = null;
 
+function decodeDataUrl(url: string): ArrayBuffer | null {
+  if (!url.startsWith('data:')) return null;
+  const comma = url.indexOf(',');
+  if (comma === -1) return null;
+  const binary = atob(url.slice(comma + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
 self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;
 
   if (req.type === 'init') {
-    initPromise = init(req.wasmUrl);
+    initPromise = init(decodeDataUrl(req.wasmUrl) ?? req.wasmUrl);
     return;
   }
 

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -23,7 +23,7 @@
     "dev": "vite",
     "build": "tsc --build && vite build",
     "preview": "vite preview",
-    "wasm": "cd parser && wasm-pack build --target web && mkdir -p ../src/wasm && cp pkg/pptx_parser_bg.wasm pkg/pptx_parser.js ../src/wasm/",
+    "wasm": "cd parser && wasm-pack build --target web --out-dir ../src/wasm",
     "vrt": "playwright test --config playwright.config.ts"
   },
   "devDependencies": {

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -4,8 +4,18 @@ import init, { parse_pptx, extract_media } from './wasm/pptx_parser.js';
 let ready = false;
 let currentBuffer: Uint8Array | null = null;
 
+function decodeDataUrl(url: string): ArrayBuffer | null {
+  if (!url.startsWith('data:')) return null;
+  const comma = url.indexOf(',');
+  if (comma === -1) return null;
+  const binary = atob(url.slice(comma + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
 async function initWasm(wasmUrl: string) {
-  await init(wasmUrl);
+  await init(decodeDataUrl(wasmUrl) ?? wasmUrl);
   ready = true;
   const msg: WorkerResponse = { kind: 'ready' };
   self.postMessage(msg);

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,59 +1,63 @@
 # OOXML Viewer for VS Code
 
-A high-fidelity viewer for `.xlsx`, `.docx`, and `.pptx` files powered by a Rust/WASM parser and HTML Canvas renderer.
+A high-fidelity viewer for `.xlsx`, `.docx`, and `.pptx` files — powered by a Rust/WASM parser and an HTML Canvas renderer.
+
+> **Private by design.** All parsing and rendering happens locally inside the VS Code Webview via WebAssembly. **No file contents, no metadata, and no telemetry leave your machine.** The extension makes no network requests.
+
+## Screenshots
+
+### XLSX
+
+![XLSX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/xlsx.png)
+
+### DOCX
+
+![DOCX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/docx.png)
+
+### PPTX
+
+![PPTX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/pptx.png)
 
 ## Features
 
-- **XLSX** — Spreadsheet viewer with cell/row/column selection, range copy (Ctrl+C), freeze-pane support, and multi-sheet tab bar.
-- **DOCX** — Word document viewer with transparent text selection overlay (native drag-to-select + copy).
-- **PPTX** — Presentation viewer with slide navigation, transparent text selection overlay, and media poster rendering.
+- **XLSX** — Spreadsheet viewer with cell / row / column / range selection, tab-separated copy (Ctrl+C / Cmd+C), freeze-pane support, and a multi-sheet tab bar.
+- **DOCX** — Continuous **scroll view** of every page with a transparent text layer (PDF.js-style) — drag to select, copy as plain text.
+- **PPTX** — Continuous **scroll view** of every slide with a transparent text layer that handles rotated text boxes correctly.
+- **Theme-aware** — Background and foreground follow the active VS Code theme (light / dark / high-contrast).
+- **High fidelity** — Charts, conditional formatting, theme colors, custom geometry shapes, and more rendered straight from the OOXML spec.
 
-All three formats share the same underlying Rust parser (`wasm-pack`) for maximum accuracy and speed.
+All three formats share the same Rust parser (`wasm-pack`) for accuracy and speed.
 
 ## Usage
 
-Simply open any `.xlsx`, `.docx`, or `.pptx` file in VS Code — the OOXML Viewer activates automatically as the default editor for those file types.
+Open any `.xlsx`, `.docx`, or `.pptx` file in VS Code — the OOXML Viewer takes over as the default editor for those file types.
 
-### Navigation
+If a different editor opens by default, right-click the file → **Reopen Editor With…** → select **OOXML Viewer**, then optionally **Configure default editor** to make it the default.
 
-| Format | Shortcut |
-|--------|---------|
-| PPTX | Prev / Next slide buttons in toolbar |
-| DOCX | Prev / Next page buttons in toolbar |
-| XLSX | Click tabs at the bottom to switch sheets |
+### Selection & copy
 
-### Text Selection
+- **DOCX / PPTX** — Drag across rendered text to select, then **Ctrl+C / Cmd+C** to copy as plain text. The transparent overlay matches the canvas glyph positions, so selection feels native.
+- **XLSX** — Click a cell to select it, drag for a range, click row/column headers for full-row/column selection, click the corner box for sheet-wide selection. **Ctrl+C / Cmd+C** copies as TSV.
 
-PPTX and DOCX files support transparent text overlays. Drag to select text, then use **Ctrl+C** (or **Cmd+C** on macOS) to copy.
+## Privacy & Security
 
-For XLSX, click a cell to select it, or drag across a range. **Ctrl+C** copies the selected cells as tab-separated values.
+- **Zero network access.** The Webview's Content Security Policy disallows outbound connections to any origin other than the extension itself. There is no analytics, no font CDN, no remote API.
+- **Local file I/O only.** The extension reads bytes via `vscode.workspace.fs.readFile` and never writes back — files are opened read-only.
+- **Open source.** Source code at [github.com/yukiyokotani/office-open-xml-viewer](https://github.com/yukiyokotani/office-open-xml-viewer).
 
-## Extension Settings
-
-No settings are required. The extension activates automatically for the registered file types.
+VS Code's own telemetry is independent of this extension and can be controlled via the `telemetry.telemetryLevel` setting.
 
 ## Known Limitations
 
-- XLSX: formula evaluation is not yet supported (raw values are shown).
-- DOCX: automatic image float wrap, footnotes, and header/footer rendering may differ slightly from Word.
-- PPTX: some obscure preset shapes fall back to a rectangle placeholder.
-- Media playback (audio/video) is not supported in the Webview.
+- XLSX: formula evaluation is not yet supported (raw cached values are shown).
+- DOCX: image-anchored float wrap, footnotes, and header/footer rendering may differ slightly from Word.
+- PPTX: a small number of obscure preset shapes fall back to a rectangle placeholder.
+- Media playback (audio / video) is not supported in the Webview.
 
-## Development
+## Issues & Contributions
 
-```bash
-# Build extension + webview bundle
-cd packages/vscode-extension
-node esbuild.config.mjs
+Report bugs or request features at [github.com/yukiyokotani/office-open-xml-viewer/issues](https://github.com/yukiyokotani/office-open-xml-viewer/issues).
 
-# Watch mode
-node esbuild.config.mjs --watch
+## License
 
-# Package as .vsix
-pnpm package
-```
-
-To test in the Extension Development Host:
-1. Open this repo in VS Code.
-2. Press **F5** — a new VS Code window opens with the extension loaded.
-3. Open any `.xlsx`, `.docx`, or `.pptx` sample file from `packages/*/public/`.
+MIT

--- a/packages/vscode-extension/src/providers/docxEditor.ts
+++ b/packages/vscode-extension/src/providers/docxEditor.ts
@@ -38,14 +38,15 @@ export class DocxEditorProvider implements vscode.CustomReadonlyEditorProvider {
     );
 
     const bytes = await vscode.workspace.fs.readFile(document.uri);
-    await webviewPanel.webview.postMessage({
-      type: 'ooxml-init',
-      fileType: 'docx',
-      data: Array.from(bytes),
-    });
 
-    webviewPanel.webview.onDidReceiveMessage((msg) => {
-      if (msg.type === 'copy') {
+    webviewPanel.webview.onDidReceiveMessage(async (msg) => {
+      if (msg.type === 'webview-ready') {
+        await webviewPanel.webview.postMessage({
+          type: 'ooxml-init',
+          fileType: 'docx',
+          data: Array.from(bytes),
+        });
+      } else if (msg.type === 'copy') {
         vscode.env.clipboard.writeText(msg.text);
       }
     });

--- a/packages/vscode-extension/src/providers/pptxEditor.ts
+++ b/packages/vscode-extension/src/providers/pptxEditor.ts
@@ -38,14 +38,15 @@ export class PptxEditorProvider implements vscode.CustomReadonlyEditorProvider {
     );
 
     const bytes = await vscode.workspace.fs.readFile(document.uri);
-    await webviewPanel.webview.postMessage({
-      type: 'ooxml-init',
-      fileType: 'pptx',
-      data: Array.from(bytes),
-    });
 
-    webviewPanel.webview.onDidReceiveMessage((msg) => {
-      if (msg.type === 'copy') {
+    webviewPanel.webview.onDidReceiveMessage(async (msg) => {
+      if (msg.type === 'webview-ready') {
+        await webviewPanel.webview.postMessage({
+          type: 'ooxml-init',
+          fileType: 'pptx',
+          data: Array.from(bytes),
+        });
+      } else if (msg.type === 'copy') {
         vscode.env.clipboard.writeText(msg.text);
       }
     });

--- a/packages/vscode-extension/src/providers/xlsxEditor.ts
+++ b/packages/vscode-extension/src/providers/xlsxEditor.ts
@@ -38,14 +38,15 @@ export class XlsxEditorProvider implements vscode.CustomReadonlyEditorProvider {
     );
 
     const bytes = await vscode.workspace.fs.readFile(document.uri);
-    await webviewPanel.webview.postMessage({
-      type: 'ooxml-init',
-      fileType: 'xlsx',
-      data: Array.from(bytes),
-    });
 
-    webviewPanel.webview.onDidReceiveMessage((msg) => {
-      if (msg.type === 'copy') {
+    webviewPanel.webview.onDidReceiveMessage(async (msg) => {
+      if (msg.type === 'webview-ready') {
+        await webviewPanel.webview.postMessage({
+          type: 'ooxml-init',
+          fileType: 'xlsx',
+          data: Array.from(bytes),
+        });
+      } else if (msg.type === 'copy') {
         vscode.env.clipboard.writeText(msg.text);
       }
     });

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -1,36 +1,29 @@
 /**
  * Webview bootstrap script.
  *
- * This script runs inside the VSCode Webview iframe. It:
- * 1. Waits for the `ooxml-init` message from the extension host containing the file bytes.
- * 2. Instantiates the appropriate Viewer (XlsxViewer / DocxViewer / PptxViewer).
- * 3. Bridges selection events back to the extension host via acquireVsCodeApi().postMessage().
+ * Runs inside the VSCode Webview iframe. Receives the file bytes via the
+ * `ooxml-init` message and instantiates the appropriate viewer:
+ *   - xlsx: XlsxViewer (sheet-based, no scroll stack)
+ *   - docx / pptx: scroll-stacked render of every page / slide with a transparent
+ *     text layer for native selection (PDF.js-style).
  */
 
-// These globals are injected by the HTML template.
 declare const __OOXML_FILE_TYPE__: 'xlsx' | 'docx' | 'pptx';
-declare const __OOXML_WASM_URL__: string;
 
-// VSCode API bridge — available only inside a Webview context.
 declare function acquireVsCodeApi(): {
   postMessage(msg: unknown): void;
   getState(): unknown;
   setState(state: unknown): void;
 };
 
-import { XlsxViewer } from '@silurus/ooxml-xlsx';
-import { DocxViewer } from '@silurus/ooxml-docx';
-import { PptxViewer } from '@silurus/ooxml-pptx';
-import type { CellRange } from '@silurus/ooxml-xlsx';
+import { XlsxViewer, type CellRange } from '@silurus/ooxml-xlsx';
+import { DocxDocument, type DocxTextRunInfo } from '@silurus/ooxml-docx';
+import { PptxPresentation, type TextRunInfo } from '@silurus/ooxml-pptx';
 
 const vscodeApi = acquireVsCodeApi();
 const fileType = __OOXML_FILE_TYPE__;
 
 const statusEl = document.getElementById('status')!;
-const navBar = document.getElementById('nav-bar')!;
-const prevBtn = document.getElementById('prev-btn') as HTMLButtonElement;
-const nextBtn = document.getElementById('next-btn') as HTMLButtonElement;
-const pageInfo = document.getElementById('page-info')!;
 const viewerContainer = document.getElementById('viewer-container')!;
 
 function setStatus(msg: string): void {
@@ -41,6 +34,9 @@ function setStatus(msg: string): void {
 function hideStatus(): void {
   statusEl.style.display = 'none';
 }
+
+// Notify extension host that the webview script is ready to receive messages.
+vscodeApi.postMessage({ type: 'webview-ready' });
 
 window.addEventListener('message', async (event: MessageEvent) => {
   const msg = event.data;
@@ -66,7 +62,7 @@ window.addEventListener('message', async (event: MessageEvent) => {
 async function initXlsx(buffer: ArrayBuffer): Promise<void> {
   hideStatus();
   const container = document.createElement('div');
-  container.style.cssText = 'width:100%;height:calc(100vh - 40px);';
+  container.style.cssText = 'width:100%;height:100vh;';
   viewerContainer.appendChild(container);
 
   const viewer = new XlsxViewer(container, {
@@ -85,70 +81,132 @@ async function initXlsx(buffer: ArrayBuffer): Promise<void> {
   await viewer.load(buffer);
   hideStatus();
 
-  // Ctrl+C / Cmd+C: copy selection through VSCode clipboard API
   document.addEventListener('keydown', (e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
       const sel = viewer.selection;
       if (!sel) return;
-      // Let the viewer handle copy internally (it writes to navigator.clipboard),
-      // then also notify the extension host.
       vscodeApi.postMessage({ type: 'copy-request', fileType: 'xlsx', selection: sel });
     }
   });
 }
 
-// ── DOCX ─────────────────────────────────────────────────────────────────────
+// ── DOCX (scroll view) ───────────────────────────────────────────────────────
+
+function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {
+  layer.replaceChildren();
+  for (const run of runs) {
+    const span = document.createElement('span');
+    span.textContent = run.text;
+    span.style.cssText =
+      `position:absolute;left:${run.x}px;top:${run.y}px;` +
+      `font-size:${run.fontSize}px;line-height:${run.h}px;white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
+    layer.appendChild(span);
+  }
+}
 
 async function initDocx(buffer: ArrayBuffer): Promise<void> {
+  setStatus('Parsing…');
+  const doc = await DocxDocument.load(buffer);
+  setStatus(`Rendering ${doc.pageCount} page(s)…`);
+
+  const stack = document.createElement('div');
+  stack.className = 'page-stack';
+  viewerContainer.appendChild(stack);
+
+  const widthPx = Math.min(window.innerWidth - 64, 900);
+
+  for (let i = 0; i < doc.pageCount; i++) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'page-wrapper';
+    wrapper.style.maxWidth = `${widthPx}px`;
+
+    const canvas = document.createElement('canvas');
+    canvas.className = 'page-canvas';
+
+    const textLayer = document.createElement('div');
+    textLayer.className = 'text-layer';
+
+    wrapper.append(canvas, textLayer);
+    stack.appendChild(wrapper);
+
+    const runs: DocxTextRunInfo[] = [];
+    await doc.renderPage(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
+    buildDocxTextLayer(textLayer, runs);
+  }
+
   hideStatus();
-  const canvas = document.createElement('canvas');
-  viewerContainer.appendChild(canvas);
-
-  const viewer = new DocxViewer(canvas, {
-    width: Math.min(window.innerWidth - 32, 900),
-    enableTextSelection: true,
-  });
-
-  await viewer.load(buffer);
-  hideStatus();
-
-  navBar.classList.add('visible');
-  updateDocxNav(viewer);
-
-  prevBtn.addEventListener('click', () => { viewer.prevPage(); updateDocxNav(viewer); });
-  nextBtn.addEventListener('click', () => { viewer.nextPage(); updateDocxNav(viewer); });
 }
 
-function updateDocxNav(viewer: DocxViewer): void {
-  pageInfo.textContent = `Page ${viewer.currentPage + 1} / ${viewer.pageCount}`;
-  prevBtn.disabled = viewer.currentPage === 0;
-  nextBtn.disabled = viewer.currentPage === viewer.pageCount - 1;
-}
+// ── PPTX (scroll view) ───────────────────────────────────────────────────────
 
-// ── PPTX ─────────────────────────────────────────────────────────────────────
+function buildPptxTextLayer(
+  layer: HTMLDivElement,
+  runs: TextRunInfo[],
+  cssWidth: number,
+  cssHeight: number,
+): void {
+  layer.replaceChildren();
+  layer.style.width = `${cssWidth}px`;
+  layer.style.height = `${cssHeight}px`;
+
+  const shapeMap = new Map<string, HTMLDivElement>();
+  for (const run of runs) {
+    const totalRot = run.rotation + (run.textBodyRotation ?? 0);
+    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
+    let shape = shapeMap.get(key);
+    if (!shape) {
+      shape = document.createElement('div');
+      shape.style.cssText =
+        `position:absolute;left:${run.shapeX}px;top:${run.shapeY}px;` +
+        `width:${run.shapeW}px;height:${run.shapeH}px;pointer-events:all;overflow:hidden;`;
+      if (totalRot !== 0) {
+        shape.style.transformOrigin = 'center center';
+        shape.style.transform = `rotate(${totalRot}deg)`;
+      }
+      shapeMap.set(key, shape);
+      layer.appendChild(shape);
+    }
+    const span = document.createElement('span');
+    span.textContent = run.text;
+    span.style.cssText =
+      `position:absolute;left:${run.inShapeX}px;top:${run.inShapeY}px;` +
+      `font-size:${run.fontSize}px;line-height:${run.h}px;white-space:pre;color:transparent;cursor:text;`;
+    shape.appendChild(span);
+  }
+}
 
 async function initPptx(buffer: ArrayBuffer): Promise<void> {
+  setStatus('Parsing…');
+  const pres = await PptxPresentation.load(buffer);
+  setStatus(`Rendering ${pres.slideCount} slide(s)…`);
+
+  const stack = document.createElement('div');
+  stack.className = 'page-stack';
+  viewerContainer.appendChild(stack);
+
+  const widthPx = Math.min(window.innerWidth - 64, 960);
+  const cssHeight = pres.slideWidth > 0
+    ? Math.round((pres.slideHeight * widthPx) / pres.slideWidth)
+    : Math.round((widthPx * 9) / 16);
+
+  for (let i = 0; i < pres.slideCount; i++) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'page-wrapper';
+    wrapper.style.maxWidth = `${widthPx}px`;
+
+    const canvas = document.createElement('canvas');
+    canvas.className = 'page-canvas';
+
+    const textLayer = document.createElement('div');
+    textLayer.className = 'text-layer';
+
+    wrapper.append(canvas, textLayer);
+    stack.appendChild(wrapper);
+
+    const runs: TextRunInfo[] = [];
+    await pres.renderSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
+    buildPptxTextLayer(textLayer, runs, widthPx, cssHeight);
+  }
+
   hideStatus();
-  const container = document.createElement('div');
-  viewerContainer.appendChild(container);
-
-  const viewer = new PptxViewer(container, {
-    width: Math.min(window.innerWidth - 32, 960),
-    enableTextSelection: true,
-    onSlideChange(index, total) {
-      pageInfo.textContent = `Slide ${index + 1} / ${total}`;
-      prevBtn.disabled = index === 0;
-      nextBtn.disabled = index === total - 1;
-    },
-    onError(err) {
-      setStatus(`Error: ${err.message}`);
-    },
-  });
-
-  await viewer.load(buffer);
-  hideStatus();
-  navBar.classList.add('visible');
-
-  prevBtn.addEventListener('click', () => viewer.prevSlide());
-  nextBtn.addEventListener('click', () => viewer.nextSlide());
 }

--- a/packages/vscode-extension/src/webviewHtml.ts
+++ b/packages/vscode-extension/src/webviewHtml.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 /**
  * Generate the HTML for the webview panel.
@@ -14,9 +13,6 @@ export function getWebviewHtml(
   const scriptUri = webview.asWebviewUri(
     vscode.Uri.joinPath(extensionUri, 'dist', 'webview.js'),
   );
-  const wasmUri = webview.asWebviewUri(
-    vscode.Uri.joinPath(extensionUri, 'dist', `${fileType}_parser_bg.wasm`),
-  );
 
   const nonce = getNonce();
 
@@ -30,72 +26,83 @@ export function getWebviewHtml(
              img-src ${webview.cspSource} data: blob:;
              media-src ${webview.cspSource} blob:;
              font-src ${webview.cspSource};
-             script-src 'nonce-${nonce}';
+             script-src 'nonce-${nonce}' 'wasm-unsafe-eval';
+             worker-src data: blob:;
              style-src 'unsafe-inline';
-             connect-src ${webview.cspSource};" />
+             connect-src ${webview.cspSource} data: blob:;" />
   <title>OOXML Viewer</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { width: 100%; height: 100%; overflow: hidden; }
-    body { background: var(--vscode-editor-background, #1e1e1e); }
-    #viewer-root {
+    html, body {
       width: 100%;
       height: 100%;
-      overflow: auto;
+      background: var(--vscode-editor-background);
+      color: var(--vscode-foreground);
+      font-family: var(--vscode-font-family, sans-serif);
+    }
+    /* xlsx fills the whole viewport; docx/pptx scroll inside #viewer-root. */
+    body.layout-xlsx { overflow: hidden; }
+    body.layout-stack { overflow: auto; }
+    #viewer-root {
+      width: 100%;
+      min-height: 100%;
       display: flex;
       justify-content: center;
       align-items: flex-start;
       padding: 16px;
     }
-    #viewer-container {
-      max-width: 100%;
+    body.layout-xlsx #viewer-root { padding: 0; height: 100%; }
+    #viewer-container { max-width: 100%; width: 100%; }
+    body.layout-stack #viewer-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
     }
     #status {
-      color: var(--vscode-foreground, #ccc);
-      font-family: var(--vscode-font-family, sans-serif);
+      color: var(--vscode-descriptionForeground, var(--vscode-foreground));
       font-size: 13px;
       padding: 8px;
     }
-    /* Slide/page navigation bar */
-    #nav-bar {
-      display: none;
+    /* docx / pptx scroll-stack styling */
+    .page-stack {
+      display: flex;
+      flex-direction: column;
       align-items: center;
-      gap: 8px;
-      padding: 4px 0 8px;
-      font-family: var(--vscode-font-family, sans-serif);
-      font-size: 13px;
-      color: var(--vscode-foreground, #ccc);
+      gap: 16px;
+      width: 100%;
     }
-    #nav-bar.visible { display: flex; }
-    #nav-bar button {
-      background: var(--vscode-button-background, #0e639c);
-      color: var(--vscode-button-foreground, #fff);
-      border: none;
-      border-radius: 2px;
-      padding: 2px 10px;
-      cursor: pointer;
-      font-size: 12px;
+    .page-wrapper {
+      position: relative;
+      width: 100%;
+      margin: 0 auto;
     }
-    #nav-bar button:disabled {
-      opacity: 0.4;
-      cursor: default;
+    .page-canvas {
+      display: block;
+      width: 100%;
+      background: #fff;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+    }
+    .text-layer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      pointer-events: none;
+      user-select: text;
+      -webkit-user-select: text;
     }
   </style>
 </head>
-<body>
+<body class="${fileType === 'xlsx' ? 'layout-xlsx' : 'layout-stack'}">
   <div id="viewer-root">
     <div id="viewer-container">
-      <div id="nav-bar">
-        <button id="prev-btn">← Prev</button>
-        <span id="page-info"></span>
-        <button id="next-btn">Next →</button>
-      </div>
       <div id="status">Loading…</div>
     </div>
   </div>
   <script nonce="${nonce}">
     window.__OOXML_FILE_TYPE__ = ${JSON.stringify(fileType)};
-    window.__OOXML_WASM_URL__ = ${JSON.stringify(wasmUri.toString())};
   </script>
   <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -3,11 +3,21 @@ import type { WorkerRequest, WorkerResponse } from './types.js';
 
 let initPromise: Promise<unknown> | null = null;
 
+function decodeDataUrl(url: string): ArrayBuffer | null {
+  if (!url.startsWith('data:')) return null;
+  const comma = url.indexOf(',');
+  if (comma === -1) return null;
+  const binary = atob(url.slice(comma + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
 self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;
 
   if (req.type === 'init') {
-    initPromise = init(req.wasmUrl);
+    initPromise = init(decodeDataUrl(req.wasmUrl) ?? req.wasmUrl);
     return;
   }
 


### PR DESCRIPTION
## Summary

- **docx/pptx are now scroll-stack views** — every page/slide rendered at once with a transparent text layer (PDF.js style). Removes the prev/next pager.
- **Theme-aware Webview** — background and foreground driven by `--vscode-editor-background` / `--vscode-foreground` so the chrome around documents follows VS Code's light/dark/high-contrast theme.
- **CSP + handshake** — workers receive the wasm asset as a `data:` URL (decoded inside the worker) so the Webview CSP can stay strict; the extension waits for a `webview-ready` ping before sending the file payload to avoid an init-before-listener race.
- **Marketplace README rewrite** — adds screenshots (absolute raw.githubusercontent URLs so they render on the Marketplace page), a "Privacy & Security" section asserting zero-network operation, and reflects the new scroll-view UX.
- **Fix pptx wasm script** — switch to `wasm-pack build --out-dir`, matching xlsx/docx, so the generated `.d.ts` lands in `src/wasm/`. Resolves the CI failure where per-package `tsc --build` errored on `worker.ts` with TS7016.
- `.gitignore`: exclude `*.vsix` build output.

## Test plan

- [ ] Build extension locally (`node esbuild.config.mjs`) and load via F5 — verified locally
- [ ] Open .xlsx / .docx / .pptx in Extension Development Host — scroll view, theme switching, text selection
- [ ] CI: `Build library packages` step passes (pptx tsc no longer fails on missing wasm typings)
- [ ] CI: `Publish VS Code Extension` workflow packages the .vsix successfully on next `v*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)