### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.14.0 — 2026-04-25
+
+VS Code extension UX overhaul. The `.docx` and `.pptx` editors switch from a
+prev/next pager to a **continuous scroll-stack** that renders every page or
+slide at once with a transparent text layer (PDF.js style). The Webview chrome
+now follows the active VS Code theme (light / dark / high-contrast) via
+`--vscode-editor-background` and `--vscode-foreground`. The Marketplace README
+gains screenshots and a privacy statement asserting zero network access.
+
+### vscode-extension
+
+- **Scroll-stack viewer** (`packages/vscode-extension`) — replaces the
+  page-by-page navigation for docx/pptx. Every page/slide is rendered
+  vertically with its own transparent text layer; selection and copy work
+  across the whole document.
+- **Theme-aware backgrounds** — body/foreground driven by VS Code CSS
+  variables; the chrome around documents follows the active theme without
+  hardcoded fallbacks.
+- **CSP + handshake** — workers accept a `data:`-URL wasm asset (decoded
+  inside the worker) so the Webview CSP can stay strict; the editor waits for
+  a `webview-ready` ping before posting the file payload, fixing an init
+  ordering race.
+- **Marketplace README** — adds screenshots (absolute raw URLs so they render
+  on the Marketplace page), a "Privacy & Security" section, and reflects the
+  scroll-view UX.
+
+### tooling
+
+- **pptx wasm script** (`packages/pptx`) — switch to `wasm-pack build
+  --out-dir`, matching xlsx/docx, so the generated `pptx_parser.d.ts` is
+  written into `src/wasm/`. Resolves the CI `Build library packages` failure
+  where per-package `tsc --build` errored on `worker.ts` with TS7016.
+- `.gitignore`: exclude `*.vsix` build output.
+
 ## 0.13.0 — 2026-04-25
 
 UX and tooling release. The core viewer packages gain **text and cell

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ooxml-viewer",
   "displayName": "OOXML Viewer",
   "description": "High-fidelity viewer for .xlsx, .docx, and .pptx files powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publisher": "silurus",
   "license": "MIT",
   "engines": {

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

VS Code extension UX overhaul + pptx wasm typings fix.

- **Scroll-stack viewer for .docx / .pptx** — replaces the prev/next pager with a PDF.js-style continuous scroll of every page/slide, each with its own transparent text layer.
- **Theme-aware Webview** — backgrounds and foreground follow the active VS Code theme (light / dark / high-contrast).
- **Marketplace README** — adds screenshots, a privacy statement (zero network access), and reflects the new scroll-view UX.
- **CI fix** — pptx `wasm` script now uses `wasm-pack build --out-dir` so the generated `.d.ts` lands in `src/wasm/`, unblocking per-package `tsc --build`.

See `CHANGELOG.md` for the full list.

## Test plan

- [ ] Merge → tag `v0.14.0` → confirm `Publish to npm` workflow succeeds for the four library packages.
- [ ] Same tag fires `Publish VS Code Extension` workflow → .vsix uploaded as artifact and published to Marketplace.
- [ ] Verify `ooxml-viewer 0.14.0` appears on the Marketplace page with the new screenshots and privacy section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)