### PR TITLE
chore(release): 0.14.1 — rename VS Code extension for Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.14.1 — 2026-04-25
+
+VS Code Marketplace metadata fix. The Marketplace `vsce publish` of 0.14.0
+failed because the extension `name` (`ooxml-viewer`) collided with an existing
+listing. This release renames the extension and broadens the displayName so
+that users searching the Marketplace for "Office", "XLSX", "DOCX", or "PPTX"
+discover it.
+
+- **Rename** (`packages/vscode-extension`):
+  - `name`: `ooxml-viewer` → `office-open-xml-viewer`
+  - `displayName`: `OOXML Viewer` → `Office Viewer — XLSX, DOCX, PPTX`
+  - `description`: emphasizes Office file support and the local-only privacy
+    posture for Marketplace searchers.
+- Library packages (`@silurus/ooxml{,-pptx,-xlsx,-docx,-core}`) are bumped to
+  0.14.1 to keep tag-driven CI in sync; **no code changes for the libraries.**
+
 ## 0.14.0 — 2026-04-25
 
 VS Code extension UX overhaul. The `.docx` and `.pptx` editors switch from a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Browser-based OOXML viewer (pptx/xlsx/docx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ooxml-viewer",
-  "displayName": "OOXML Viewer",
-  "description": "High-fidelity viewer for .xlsx, .docx, and .pptx files powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.14.0",
+  "name": "office-open-xml-viewer",
+  "displayName": "Office Viewer — XLSX, DOCX, PPTX",
+  "description": "High-fidelity viewer for Office files (.xlsx / .docx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
+  "version": "0.14.1",
   "publisher": "silurus",
   "license": "MIT",
   "engines": {

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

The 0.14.0 Marketplace publish failed because the extension name `ooxml-viewer` collided with an existing listing. Rename and broaden discoverability metadata:

- `name`: `ooxml-viewer` → `office-open-xml-viewer`
- `displayName`: `OOXML Viewer` → `Office Viewer — XLSX, DOCX, PPTX`
- `description`: now leads with "Office files" and the local-only privacy posture
- Library packages bumped in lockstep (no code changes) so the tag-driven CI does not collide with already-published 0.14.0 versions on npm.

## Test plan

- [ ] Merge → tag `v0.14.1` → `Publish to npm` succeeds for all four library packages.
- [ ] `Publish VS Code Extension` succeeds; the extension appears on the Marketplace as **Office Viewer — XLSX, DOCX, PPTX** (publisher: silurus, name: office-open-xml-viewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)