### PR TITLE
fix(vscode-ext): center loading spinner on the viewport

### DIFF
--- a/packages/vscode-extension/src/webviewHtml.ts
+++ b/packages/vscode-extension/src/webviewHtml.ts
@@ -59,17 +59,20 @@ export function getWebviewHtml(
       align-items: center;
     }
     #status {
+      position: fixed;
+      inset: 0;
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 24px;
-      min-height: 80px;
+      pointer-events: none;
+      z-index: 10;
     }
     #status[data-state="error"] {
+      position: static;
+      pointer-events: auto;
       color: var(--vscode-errorForeground, #f44747);
       font-size: 13px;
       padding: 8px;
-      min-height: auto;
       justify-content: flex-start;
     }
     .spinner {

--- a/packages/vscode-extension/src/webviewHtml.ts
+++ b/packages/vscode-extension/src/webviewHtml.ts
@@ -68,12 +68,11 @@ export function getWebviewHtml(
       z-index: 10;
     }
     #status[data-state="error"] {
-      position: static;
       pointer-events: auto;
       color: var(--vscode-errorForeground, #f44747);
       font-size: 13px;
-      padding: 8px;
-      justify-content: flex-start;
+      padding: 16px;
+      text-align: center;
     }
     .spinner {
       width: 28px;


### PR DESCRIPTION
## Summary
- Make the loading spinner sit in the middle of the webview instead of anchored to the top of the viewer container.
- Use \`position: fixed; inset: 0\` for the default state; the error variant falls back to static top-left.

## Test plan
- [ ] Open a docx / xlsx / pptx file in the extension — spinner appears centered while loading
- [ ] Trigger an error path — error text still renders at the top-left in the error color