### PR TITLE
fix(vscode-ext): open in active column instead of forcing a split

### DIFF
--- a/packages/vscode-extension/src/providers/docxEditor.ts
+++ b/packages/vscode-extension/src/providers/docxEditor.ts
@@ -8,7 +8,6 @@ export class DocxEditorProvider implements vscode.CustomReadonlyEditorProvider {
     return vscode.window.registerCustomEditorProvider(
       DocxEditorProvider.viewType,
       new DocxEditorProvider(context),
-      { supportsMultipleEditorsPerDocument: true },
     );
   }
 

--- a/packages/vscode-extension/src/providers/pptxEditor.ts
+++ b/packages/vscode-extension/src/providers/pptxEditor.ts
@@ -8,7 +8,6 @@ export class PptxEditorProvider implements vscode.CustomReadonlyEditorProvider {
     return vscode.window.registerCustomEditorProvider(
       PptxEditorProvider.viewType,
       new PptxEditorProvider(context),
-      { supportsMultipleEditorsPerDocument: true },
     );
   }
 

--- a/packages/vscode-extension/src/providers/xlsxEditor.ts
+++ b/packages/vscode-extension/src/providers/xlsxEditor.ts
@@ -8,7 +8,6 @@ export class XlsxEditorProvider implements vscode.CustomReadonlyEditorProvider {
     return vscode.window.registerCustomEditorProvider(
       XlsxEditorProvider.viewType,
       new XlsxEditorProvider(context),
-      { supportsMultipleEditorsPerDocument: true },
     );
   }
 


### PR DESCRIPTION
## Summary
\`supportsMultipleEditorsPerDocument: true\` was telling VS Code that the
same OOXML document can be open in multiple editor panes simultaneously,
which caused the editor to open in a beside column on click — splitting
the workspace into two columns instead of replacing the active editor.

We don't actually rely on multiple editors per document, so dropping the
option (default false) lets VS Code reuse the currently active column,
matching the behaviour of normal text editors.

## Test plan
- [ ] Click a \`.docx\` / \`.xlsx\` / \`.pptx\` from the file explorer — opens in the current active column without splitting
- [ ] Already-open file is reused on re-click (no duplicate panel)