### PR TITLE
fix(viewer): align selection overlay glyph metrics with canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,10 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 
 ---
 
+> **A note on text selection.** Across DOCX / PPTX / XLSX, text selection is currently implemented by rendering glyphs to the canvas while overlaying a transparent DOM layer that mirrors the canvas text positions for native browser selection. This dual-layer approach is a deliberate stop-gap: once the Canvas [`drawElement` API](https://chromestatus.com/feature/6051647656558592) (proposed in [WICG/html-in-canvas](https://github.com/WICG/html-in-canvas), currently in Chromium Origin Trial) ships across browsers, the project plans to migrate to a single DOM-as-source-of-truth pipeline where the canvas mirrors the DOM directly — eliminating the duplication while keeping z-order correctness and native selection / a11y.
+
+---
+
 ## Companion packages
 
 - **[`packages/vscode-extension/`](packages/vscode-extension/)** — VS Code extension (`ooxml-viewer`) that registers `CustomEditorProvider`s for `.docx`, `.xlsx`, and `.pptx`. Open Office files directly in the editor with the same Canvas renderer plus selection/copy.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -76,6 +76,8 @@ export interface DocxTextRunInfo {
   h: number;
   /** Font size in CSS px. */
   fontSize: number;
+  /** CSS `font` shorthand used for canvas drawing (e.g. `"bold 16px Arial"`). */
+  font: string;
 }
 
 export interface RenderDocumentOptions {
@@ -720,6 +722,7 @@ function renderParagraph(para: DocParagraph, state: RenderState, suppressSpaceBe
             w: s.measuredWidth,
             h: lineH,
             fontSize: effSizePx,
+            font: ctx.font,
           });
         }
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -325,5 +325,5 @@ export interface RenderPageOptions {
   dpr?: number;
   defaultTextColor?: string;
   /** Called for each rendered text segment. Used to build a transparent text selection overlay. */
-  onTextRun?: (run: { text: string; x: number; y: number; w: number; h: number; fontSize: number }) => void;
+  onTextRun?: (run: { text: string; x: number; y: number; w: number; h: number; fontSize: number; font: string }) => void;
 }

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -84,10 +84,15 @@ export class DocxViewer {
     for (const run of runs) {
       const span = document.createElement('span');
       span.textContent = run.text;
+      // The `font` shorthand must precede `line-height` because the shorthand
+      // resets `line-height` to `normal`. Disable kerning / ligatures / letter-spacing
+      // to match canvas `measureText` so the span width tracks the drawn glyph width
+      // exactly (otherwise the trailing edge of the selection drifts).
       span.style.cssText =
         `position:absolute;` +
         `left:${run.x}px;top:${run.y}px;` +
-        `font-size:${run.fontSize}px;line-height:${run.h}px;` +
+        `font:${run.font};line-height:${run.h}px;` +
+        `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
         `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
       layer.appendChild(span);
     }

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -85,14 +85,15 @@ export class DocxViewer {
       const span = document.createElement('span');
       span.textContent = run.text;
       // The `font` shorthand must precede `line-height` because the shorthand
-      // resets `line-height` to `normal`. Disable kerning / ligatures / letter-spacing
-      // to match canvas `measureText` so the span width tracks the drawn glyph width
-      // exactly (otherwise the trailing edge of the selection drifts).
+      // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
+      // CSS rule cannot drift the trailing edge of the selection. Kerning /
+      // ligatures are left at the browser default ('auto') because canvas
+      // `measureText` / `fillText` also apply them by default — forcing them
+      // off here would make the span wider than the drawn text.
       span.style.cssText =
         `position:absolute;` +
         `left:${run.x}px;top:${run.y}px;` +
-        `font:${run.font};line-height:${run.h}px;` +
-        `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
+        `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
         `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
       layer.appendChild(span);
     }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -47,6 +47,8 @@ export interface TextRunInfo {
   h: number;
   /** Font size in CSS px. */
   fontSize: number;
+  /** CSS `font` shorthand used for canvas drawing (e.g. `"bold 16px Arial"`). */
+  font: string;
   /** Shape's left edge in canvas CSS px. */
   shapeX: number;
   /** Shape's top edge in canvas CSS px. */
@@ -3002,6 +3004,7 @@ function renderTextBody(
           w: segW,
           h: lineHeight,
           fontSize: seg.sizePx,
+          font: seg.font,
           shapeX: bx,
           shapeY: by,
           shapeW: bw,
@@ -3063,6 +3066,7 @@ function renderTextBody(
             w: tabSegW,
             h: lineHeight,
             fontSize: seg.sizePx,
+            font: seg.font,
             shapeX: bx,
             shapeY: by,
             shapeW: bw,

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -169,10 +169,15 @@ export class PptxViewer {
       const shape = shapeMap.get(key)!;
       const span = document.createElement('span');
       span.textContent = run.text;
+      // The `font` shorthand must precede `line-height` because the shorthand
+      // resets `line-height` to `normal`. Disable kerning / ligatures / letter-spacing
+      // to match canvas `measureText` so the span width tracks the drawn glyph width
+      // exactly (otherwise the trailing edge of the selection drifts).
       span.style.cssText =
         `position:absolute;` +
         `left:${run.inShapeX}px;top:${run.inShapeY}px;` +
-        `font-size:${run.fontSize}px;line-height:${run.h}px;` +
+        `font:${run.font};line-height:${run.h}px;` +
+        `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
         `white-space:pre;color:transparent;cursor:text;`;
       shape.div.appendChild(span);
     }

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -170,14 +170,15 @@ export class PptxViewer {
       const span = document.createElement('span');
       span.textContent = run.text;
       // The `font` shorthand must precede `line-height` because the shorthand
-      // resets `line-height` to `normal`. Disable kerning / ligatures / letter-spacing
-      // to match canvas `measureText` so the span width tracks the drawn glyph width
-      // exactly (otherwise the trailing edge of the selection drifts).
+      // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
+      // CSS rule cannot drift the trailing edge of the selection. Kerning /
+      // ligatures are left at the browser default ('auto') because canvas
+      // `measureText` / `fillText` also apply them by default — forcing them
+      // off here would make the span wider than the drawn text.
       span.style.cssText =
         `position:absolute;` +
         `left:${run.inShapeX}px;top:${run.inShapeY}px;` +
-        `font:${run.font};line-height:${run.h}px;` +
-        `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
+        `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
         `white-space:pre;color:transparent;cursor:text;`;
       shape.div.appendChild(span);
     }

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -6,17 +6,9 @@ A high-fidelity viewer for `.docx`, `.xlsx`, and `.pptx` files — powered by a 
 
 ## Screenshots
 
-### DOCX
-
-![DOCX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/docx.png)
-
-### XLSX
-
-![XLSX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/xlsx.png)
-
-### PPTX
-
-![PPTX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/pptx.png)
+| DOCX | XLSX | PPTX |
+|:---:|:---:|:---:|
+| ![DOCX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/docx.png) | ![XLSX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/xlsx.png) | ![PPTX viewer](https://raw.githubusercontent.com/yukiyokotani/office-open-xml-viewer/main/docs/images/pptx.png) |
 
 ## Features
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -36,7 +36,7 @@ If a different editor opens by default, right-click the file → **Reopen Editor
 
 ### Selection & copy
 
-- **DOCX / PPTX** — Drag across rendered text to select, then **Ctrl+C / Cmd+C** to copy as plain text. The transparent overlay matches the canvas glyph positions, so selection feels native.
+- **DOCX / PPTX** — Drag across rendered text to select, then **Ctrl+C / Cmd+C** to copy as plain text. The transparent overlay matches the canvas glyph positions, so selection feels native. *(This dual-layer rendering is planned to be unified once the Canvas [`drawElement`](https://github.com/WICG/html-in-canvas) API ships across browsers.)*
 - **XLSX** — Click a cell to select it, drag for a range, click row/column headers for full-row/column selection, click the corner box for sheet-wide selection. **Ctrl+C / Cmd+C** copies as TSV.
 
 ## Privacy & Security

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -94,9 +94,14 @@ function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): voi
   for (const run of runs) {
     const span = document.createElement('span');
     span.textContent = run.text;
+    // Mirror the canvas font (incl. weight / style / family) and disable
+    // kerning / ligatures so the span width tracks `measureText` exactly,
+    // otherwise the trailing edge of the selection drifts on European text.
     span.style.cssText =
       `position:absolute;left:${run.x}px;top:${run.y}px;` +
-      `font-size:${run.fontSize}px;line-height:${run.h}px;white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
+      `font:${run.font};line-height:${run.h}px;` +
+      `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
+      `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
     layer.appendChild(span);
   }
 }
@@ -163,9 +168,13 @@ function buildPptxTextLayer(
     }
     const span = document.createElement('span');
     span.textContent = run.text;
+    // See buildDocxTextLayer: mirror canvas font and disable kerning/ligatures
+    // so the span trailing edge tracks `measureText`.
     span.style.cssText =
       `position:absolute;left:${run.inShapeX}px;top:${run.inShapeY}px;` +
-      `font-size:${run.fontSize}px;line-height:${run.h}px;white-space:pre;color:transparent;cursor:text;`;
+      `font:${run.font};line-height:${run.h}px;` +
+      `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
+      `white-space:pre;color:transparent;cursor:text;`;
     shape.appendChild(span);
   }
 }

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -94,13 +94,13 @@ function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): voi
   for (const run of runs) {
     const span = document.createElement('span');
     span.textContent = run.text;
-    // Mirror the canvas font (incl. weight / style / family) and disable
-    // kerning / ligatures so the span width tracks `measureText` exactly,
-    // otherwise the trailing edge of the selection drifts on European text.
+    // Mirror the canvas font (incl. weight / style / family) so glyph widths
+    // line up. `letter-spacing` is reset so parent CSS cannot drift the
+    // selection edge. Kerning / ligatures are left at the browser default
+    // because canvas applies them by default too.
     span.style.cssText =
       `position:absolute;left:${run.x}px;top:${run.y}px;` +
-      `font:${run.font};line-height:${run.h}px;` +
-      `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
+      `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
       `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
     layer.appendChild(span);
   }
@@ -168,12 +168,10 @@ function buildPptxTextLayer(
     }
     const span = document.createElement('span');
     span.textContent = run.text;
-    // See buildDocxTextLayer: mirror canvas font and disable kerning/ligatures
-    // so the span trailing edge tracks `measureText`.
+    // See buildDocxTextLayer: mirror canvas font, only reset letter-spacing.
     span.style.cssText =
       `position:absolute;left:${run.inShapeX}px;top:${run.inShapeY}px;` +
-      `font:${run.font};line-height:${run.h}px;` +
-      `font-kerning:none;font-feature-settings:"liga" 0,"kern" 0;letter-spacing:0;` +
+      `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
       `white-space:pre;color:transparent;cursor:text;`;
     shape.appendChild(span);
   }


### PR DESCRIPTION
## Summary

Improve the transparent text-selection overlay in DOCX / PPTX viewers (and the VS Code webview) so the `<span>` widths track the canvas-drawn glyphs more closely. Plus a couple of docs touch-ups.

### What changed

- **`fix(viewer): align selection overlay glyph metrics with canvas`**
  The overlay only set `font-size` and `line-height` on each `<span>`, leaving font-family / weight / style to fall back to the layer default. The substitute font's glyph widths diverged from the canvas-drawn text, producing a visible drift at the trailing edge of European text. Carry the canvas `ctx.font` shorthand through `TextRunInfo` / `DocxTextRunInfo` and apply it directly on each span.

- **`fix(viewer): drop overzealous font-kerning / feature-settings overrides`**
  An initial attempt forced `font-kerning: none` and `font-feature-settings: "liga" 0, "kern" 0` on the spans, which actually made them **wider** than the canvas text — modern Chrome canvas applies kerning and ligatures by default for both `measureText` and `fillText`. Reverted to leave kerning / ligatures at the browser default; only `letter-spacing: 0` is forced (to insulate against parent CSS).

- **`docs: note future migration to Canvas drawElement for text selection`**
  Added a brief note to root README and the VS Code extension README explaining that the current dual-layer (canvas + transparent DOM) approach is a deliberate stop-gap, with the planned migration to the WICG html-in-canvas `drawElement` API once it ships across browsers.

- **`docs(vscode-extension): use 3-column screenshot table`**
  Replace three full-width screenshot sections with a single 3-column table, matching the root README so the images display at a sensible size on the VS Code Marketplace listing.

## Test plan

- [x] Type-check passes (the remaining errors are all pre-existing wasm / core-not-built issues, unrelated)
- [x] Storybook starts and PPTX / DOCX viewers render
- [x] Manual confirmation in PPTX `Demo/sample-1` slide-1 that European text selection alignment is improved (some residual drift remains; accepted as a known limitation pending the planned `drawElement` migration)

Closes the experimental work on the `claude/refactor-canvas-html-rendering-*` exploration — the broader DOM-as-source-of-truth refactor stays deferred until `drawElement` is available cross-browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iqZje9YRmdwvM9DhC16Cb)_