### PR TITLE
docs(vscode-extension): rename README title to Office Viewer

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,4 +1,4 @@
-# OOXML Viewer for VS Code
+# Office Viewer
 
 A high-fidelity viewer for `.docx`, `.xlsx`, and `.pptx` files — powered by a Rust/WASM parser and an HTML Canvas renderer.
 


### PR DESCRIPTION
## Summary

Rename the H1 title of the VS Code extension README from "OOXML Viewer for VS Code" to "Office Viewer".

The body still references "OOXML Viewer" because that is the actual `displayName` shown in the VS Code editor-selection menu (`Reopen Editor With…`). Those references stay accurate as long as `package.json#displayName` is unchanged.

## Test plan

- [x] Title in `packages/vscode-extension/README.md` updated; no other references changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iqZje9YRmdwvM9DhC16Cb)_