### PR TITLE
docs(vscode-extension): shorten Marketplace displayName to "Office Viewer"

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-open-xml-viewer",
-  "displayName": "Office Viewer — DOCX, XLSX, PPTX",
+  "displayName": "Office Viewer",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
   "version": "0.14.1",
   "publisher": "silurus",


### PR DESCRIPTION
## Summary

Drop the `— DOCX, XLSX, PPTX` suffix from the VS Code extension's top-level `displayName`, so the Marketplace listing title is simply **Office Viewer**.

The README's description and feature list already cover the supported formats, so the suffix was redundant.

### Not changed
- The per-`customEditor` `displayName` entries (`"OOXML Viewer (DOCX)"` etc., L36/44/52) are kept as-is. Those drive the labels shown in VS Code's *Reopen Editor With…* menu — different surface, different naming concern.
- The previous PR #116 already updated the README's H1 to "Office Viewer", which is now consistent with this Marketplace title. Let me know if you'd rather revert that.

## Test plan

- [x] `packages/vscode-extension/package.json` top-level `displayName` reads `Office Viewer`.
- [x] No other displayName entries touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iqZje9YRmdwvM9DhC16Cb)_