### PR TITLE
revert: restore VS Code extension README H1

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,4 +1,4 @@
-# Office Viewer
+# OOXML Viewer for VS Code
 
 A high-fidelity viewer for `.docx`, `.xlsx`, and `.pptx` files — powered by a Rust/WASM parser and an HTML Canvas renderer.
 


### PR DESCRIPTION
## Summary

Revert the README H1 change from PR #116. The Marketplace listing title is controlled by `package.json#displayName` (changed in PR #117), so the README's own H1 should keep its original wording.

## Test plan

- [x] `packages/vscode-extension/README.md` line 1 reads `# OOXML Viewer for VS Code` again.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iqZje9YRmdwvM9DhC16Cb)_