### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.15.0 — 2026-04-25
+
+VS Code extension polish + selection overlay accuracy fix. No new format
+support compared to 0.14.1; library packages are bumped to 0.15.0 so the
+tag-driven CI keeps the npm versions in sync with the VS Code Marketplace
+release.
+
+- **VS Code extension** (`packages/vscode-extension`):
+  - Add Marketplace icon (`icon.png`, 128×128) and wire it up via `package.json#icon`.
+  - Shorten `displayName` from `Office Viewer — DOCX, XLSX, PPTX` to `Office Viewer`; supported formats remain in the description and feature list.
+  - Replace the plain text loading status with a CSS-only spinner (#107).
+  - Center the loading spinner and error status on the viewport.
+  - Open documents in the currently focused column instead of forcing a split (#114).
+- **Viewer / selection overlay** (`packages/docx`, `packages/pptx`, VS Code webview):
+  - Carry the canvas `ctx.font` shorthand (font-family / weight / style) through `TextRunInfo` / `DocxTextRunInfo` and apply it on the transparent selection `<span>` so its width tracks the drawn glyphs. Previously the overlay relied on a fallback font, which drifted at the trailing edge of European text. Kerning / ligatures are intentionally left at the browser default to match canvas behavior.
+- **Docs**:
+  - Add a forward-looking note explaining the dual-layer (canvas + transparent DOM) selection architecture as a deliberate stop-gap, with a reference to the WICG `html-in-canvas` `drawElement` API as the planned unified replacement.
+  - VS Code extension README: 3-column screenshot table for the Marketplace listing.
+  - Standardize format ordering across READMEs as DOCX → XLSX → PPTX.
+  - Add Marketplace badges to the root README.
+
 ## 0.14.1 — 2026-04-25
 
 VS Code Marketplace metadata fix. The Marketplace `vsce publish` of 0.14.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,9 +2,10 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "publisher": "silurus",
   "license": "MIT",
+  "icon": "icon.png",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

VS Code extension polish + selection overlay accuracy fix. No new format support compared to 0.14.1.

### VS Code extension
- Add Marketplace **icon** (`icon.png`, 128×128) and wire it via `package.json#icon`.
- Shorten `displayName` from `Office Viewer — DOCX, XLSX, PPTX` to `Office Viewer`.
- Replace plain text loading status with a CSS-only spinner (#107).
- Center the loading spinner / error status on the viewport.
- Open documents in the currently focused column instead of forcing a split (#114).

### Viewer / selection overlay
- Carry the canvas `ctx.font` shorthand (font-family / weight / style) through `TextRunInfo` / `DocxTextRunInfo` and apply it on the transparent selection `<span>` so its width tracks the drawn glyphs. Previously the overlay relied on a fallback font, which drifted at the trailing edge of European text. Kerning / ligatures intentionally left at the browser default to match canvas behavior.

### Docs
- Note the dual-layer (canvas + transparent DOM) selection architecture as a deliberate stop-gap, with a forward reference to the WICG `html-in-canvas` `drawElement` API.
- VS Code extension README: 3-column screenshot table.
- Standardize format ordering across READMEs as DOCX → XLSX → PPTX.
- Add Marketplace badges to the root README.

## Test plan

- [x] All 6 `package.json` files bumped to 0.15.0 (root + core + pptx + xlsx + docx + vscode-extension).
- [x] `packages/vscode-extension/icon.png` is committed and `"icon": "icon.png"` is wired up.
- [x] `CHANGELOG.md` has a 0.15.0 entry summarizing the above.
- [x] No screenshot retake — no functional renderer changes vs 0.14.1.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iqZje9YRmdwvM9DhC16Cb)_