### PR TITLE
fix(vscode-extension): restore unique Marketplace displayName

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-open-xml-viewer",
-  "displayName": "Office Viewer",
+  "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
   "version": "0.15.0",
   "publisher": "silurus",


### PR DESCRIPTION
## Summary
- The shortened `displayName: "Office Viewer"` (introduced in #117) collides with an existing VS Code Marketplace listing, causing the v0.15.0 `vsce publish` step to fail with `Error: This extension display name is taken.`
- Restore the suffixed form `"Office Viewer — DOCX, XLSX, PPTX"` that v0.14.1 was successfully published with.

## Re-publishing v0.15.0
After merge, re-run the publish workflow manually (the `v0.15.0` tag is preserved):

```sh
gh workflow run publish-vscode-extension.yml --ref main
```

`workflow_dispatch` checks out `main`, which will then carry the corrected `displayName`. `package.json` still pins `0.15.0`, so the marketplace entry will be created at that version.

## Test plan
- [ ] Merge to main
- [ ] Trigger `publish-vscode-extension.yml` via `workflow_dispatch`
- [ ] Confirm `vsce publish` succeeds and `silurus.office-open-xml-viewer@0.15.0` appears on Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)