### PR TITLE
chore(release): 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.15.1 — 2026-04-26
+
+Patch release. Mobile UX fix for the XLSX viewer plus Storybook tidy-up.
+
+- **XLSX viewer** (`packages/xlsx`):
+  - Distinguish tap from swipe on touch / pen input. `pointerdown` no longer
+    commits a cell selection for non-mouse pointers; the gesture is buffered
+    and only commits on `pointerup` if the pointer stayed within an 8 px slop.
+    A swipe to scroll on a phone or tablet now leaves the selected cell
+    alone. Mouse input is unchanged so drag-to-extend keeps working.
+- **Storybook**:
+  - Drop the `Selectable — file upload` / `Selectable — sample-1.xlsx`
+    stories. The public demo already exercises cell selection, so the stories
+    were redundant.
+
 ## 0.15.0 — 2026-04-25
 
 VS Code extension polish + selection overlay accuracy fix. No new format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
- Patch release. Bumps `@silurus/ooxml`, `@silurus/ooxml-core`, `@silurus/ooxml-pptx`, `@silurus/ooxml-xlsx`, `@silurus/ooxml-docx`, and the `office-open-xml-viewer` VS Code extension from `0.15.0` to `0.15.1`.
- Adds a `0.15.1` section to `CHANGELOG.md` covering:
  - **xlsx**: distinguish tap from swipe on touch / pen input — `pointerdown` no longer commits a cell selection for non-mouse pointers; selection only commits on `pointerup` if the pointer stayed within an 8 px slop. Mouse drag-to-extend is unchanged. (#121)
  - **storybook**: drop the redundant `Selectable — *` stories now that the public demo covers cell selection.
- README screenshots and the Feature Support table are intentionally left untouched — no new format support, only a UX bug fix.

## Test plan
- [ ] After merge: tag `v0.15.1` on main; the `publish-vscode-extension` workflow publishes the VS Code extension to the Marketplace.
- [ ] `gh release create v0.15.1` publishes the GitHub Release.
- [ ] Spot-check Storybook xlsx panel — `Selectable — *` no longer present.
- [ ] Spot-check mobile (or DevTools touch emulation) — swipe scrolls without changing the selected cell.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RugfFX6JVdqdoq2KrEJpQf)_