### PR TITLE
chore(release): 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.15.2 — 2026-04-26
+
+Patch release. Project icon refresh.
+
+- **Project icon**:
+  - Adopt a new high-resolution master at `docs/images/icon.png` (2048×2048)
+    and reference it from the root README.
+  - **VS Code extension** (`packages/vscode-extension`):
+    - Replace the previous 128×128 Marketplace icon with the new master so the
+      Marketplace listing renders crisply on retina displays.
+    - Show the icon at the top of the extension README (via the GitHub raw
+      URL — Marketplace ignores relative image paths).
+    - Add a `cp ../../docs/images/icon.png ./icon.png` step to
+      `vscode:prepublish` so the bundled `.vsix` icon is always re-synced from
+      the master at publish time and never drifts.
+
 ## 0.15.1 — 2026-04-26
 
 Patch release. Mobile UX fix for the XLSX viewer plus Storybook tidy-up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
Patch release. Project icon refresh — adopt a high-resolution master at `docs/images/icon.png` (2048×2048), reference it from both READMEs, replace the previous 128×128 Marketplace icon, and add a `vscode:prepublish` cp step so the bundled `.vsix` icon never drifts.

No functional / rendering changes. Bumps 0.15.1 → 0.15.2 across all 6 `package.json` files.

See [CHANGELOG.md](https://github.com/yukiyokotani/office-open-xml-viewer/blob/release/0.15.2/CHANGELOG.md) for details.

## Test plan
- [ ] CI green.
- [ ] After merge + tag push, the `publish-vscode-extension` workflow publishes 0.15.2 to the Marketplace successfully.
- [ ] Marketplace listing shows the new icon at full resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)