### PR TITLE
fix(vscode-ext): load doc via webview URI and enable media playback

### DIFF
--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -228,13 +228,17 @@ export async function createPresentationHandle(
     if (wasPlaying) void state.media.play().catch(() => undefined);
   };
 
-  canvas.addEventListener('pointerdown', onPointerDown);
-  canvas.addEventListener('pointermove', onPointerMove);
-  canvas.addEventListener('pointerleave', onPointerLeave);
-  canvas.addEventListener('pointerup', onPointerUp);
-  canvas.addEventListener('pointercancel', onPointerUp);
-  canvas.style.cursor = 'pointer';
-  tick();
+  // Slides without media: no playback overlay, so skip the RAF loop and
+  // pointer wiring. drawBase has already painted the canvas; nothing more to do.
+  if (states.length > 0) {
+    canvas.addEventListener('pointerdown', onPointerDown);
+    canvas.addEventListener('pointermove', onPointerMove);
+    canvas.addEventListener('pointerleave', onPointerLeave);
+    canvas.addEventListener('pointerup', onPointerUp);
+    canvas.addEventListener('pointercancel', onPointerUp);
+    canvas.style.cursor = 'pointer';
+    tick();
+  }
 
   return {
     play(mediaPath) {

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -298,7 +298,12 @@ export class PptxPresentation {
       dpr,
       slideWidthEmu: this._presentation.slideWidth,
       fetchMedia: (path) => this.getMedia(path),
-      drawBase: () => this.renderSlide(canvas, slideIndex, { width, dpr, skipMediaControls: true }),
+      drawBase: () => this.renderSlide(canvas, slideIndex, {
+        width,
+        dpr,
+        skipMediaControls: true,
+        onTextRun: opts.onTextRun,
+      }),
     });
   }
 

--- a/packages/vscode-extension/src/providers/docxEditor.ts
+++ b/packages/vscode-extension/src/providers/docxEditor.ts
@@ -27,6 +27,7 @@ export class DocxEditorProvider implements vscode.CustomReadonlyEditorProvider {
       enableScripts: true,
       localResourceRoots: [
         vscode.Uri.joinPath(this.context.extensionUri, 'dist'),
+        vscode.Uri.joinPath(document.uri, '..'),
       ],
     };
 
@@ -36,14 +37,14 @@ export class DocxEditorProvider implements vscode.CustomReadonlyEditorProvider {
       'docx',
     );
 
-    const bytes = await vscode.workspace.fs.readFile(document.uri);
+    const docUrl = webviewPanel.webview.asWebviewUri(document.uri).toString();
 
     webviewPanel.webview.onDidReceiveMessage(async (msg) => {
       if (msg.type === 'webview-ready') {
         await webviewPanel.webview.postMessage({
           type: 'ooxml-init',
           fileType: 'docx',
-          data: Array.from(bytes),
+          url: docUrl,
         });
       } else if (msg.type === 'copy') {
         vscode.env.clipboard.writeText(msg.text);

--- a/packages/vscode-extension/src/providers/pptxEditor.ts
+++ b/packages/vscode-extension/src/providers/pptxEditor.ts
@@ -27,6 +27,7 @@ export class PptxEditorProvider implements vscode.CustomReadonlyEditorProvider {
       enableScripts: true,
       localResourceRoots: [
         vscode.Uri.joinPath(this.context.extensionUri, 'dist'),
+        vscode.Uri.joinPath(document.uri, '..'),
       ],
     };
 
@@ -36,14 +37,14 @@ export class PptxEditorProvider implements vscode.CustomReadonlyEditorProvider {
       'pptx',
     );
 
-    const bytes = await vscode.workspace.fs.readFile(document.uri);
+    const docUrl = webviewPanel.webview.asWebviewUri(document.uri).toString();
 
     webviewPanel.webview.onDidReceiveMessage(async (msg) => {
       if (msg.type === 'webview-ready') {
         await webviewPanel.webview.postMessage({
           type: 'ooxml-init',
           fileType: 'pptx',
-          data: Array.from(bytes),
+          url: docUrl,
         });
       } else if (msg.type === 'copy') {
         vscode.env.clipboard.writeText(msg.text);

--- a/packages/vscode-extension/src/providers/xlsxEditor.ts
+++ b/packages/vscode-extension/src/providers/xlsxEditor.ts
@@ -27,6 +27,7 @@ export class XlsxEditorProvider implements vscode.CustomReadonlyEditorProvider {
       enableScripts: true,
       localResourceRoots: [
         vscode.Uri.joinPath(this.context.extensionUri, 'dist'),
+        vscode.Uri.joinPath(document.uri, '..'),
       ],
     };
 
@@ -36,14 +37,14 @@ export class XlsxEditorProvider implements vscode.CustomReadonlyEditorProvider {
       'xlsx',
     );
 
-    const bytes = await vscode.workspace.fs.readFile(document.uri);
+    const docUrl = webviewPanel.webview.asWebviewUri(document.uri).toString();
 
     webviewPanel.webview.onDidReceiveMessage(async (msg) => {
       if (msg.type === 'webview-ready') {
         await webviewPanel.webview.postMessage({
           type: 'ooxml-init',
           fileType: 'xlsx',
-          data: Array.from(bytes),
+          url: docUrl,
         });
       } else if (msg.type === 'copy') {
         vscode.env.clipboard.writeText(msg.text);

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -43,7 +43,15 @@ window.addEventListener('message', async (event: MessageEvent) => {
   const msg = event.data;
   if (msg.type !== 'ooxml-init') return;
 
-  const buffer = new Uint8Array(msg.data as number[]).buffer;
+  let buffer: ArrayBuffer;
+  try {
+    const res = await fetch(msg.url);
+    if (!res.ok) throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
+    buffer = await res.arrayBuffer();
+  } catch (err) {
+    showError(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
 
   try {
     if (fileType === 'docx') {
@@ -204,7 +212,7 @@ async function initPptx(buffer: ArrayBuffer): Promise<void> {
     stack.appendChild(wrapper);
 
     const runs: TextRunInfo[] = [];
-    await pres.renderSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
+    await pres.presentSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
     buildPptxTextLayer(textLayer, runs, widthPx, cssHeight);
   }
 


### PR DESCRIPTION
## Summary

Fix two issues with the VS Code extension that surfaced when opening pptx files containing audio/video:

1. **Spinner never resolves on media-embedded files** — The extension was sending file bytes through `webview.postMessage` via `Array.from(bytes)`. For 50–200 MB media-embedded pptx, the JSON-serialized number array hung the IPC channel.
2. **No interactive playback** — Even after the file rendered, audio/video was a static poster with a non-interactive play badge.

## Fix

Switch the file delivery from `postMessage(bytes)` to the same approach VS Code's bundled PDF viewer uses:

- Register the document's parent directory as a `localResourceRoot`
- Expose the file via `webview.asWebviewUri(document.uri)` and post the URL
- Let the webview `fetch().arrayBuffer()` — native binary, no IPC round-trip

Switch the scroll-stack pptx renderer from `PptxPresentation.renderSlide` to `presentSlide` so audio/video become clickable.

Two supporting fixes in `@silurus/ooxml-pptx`:

- `presentSlide` now forwards `opts.onTextRun` to the inner `renderSlide` call so the transparent text-selection layer keeps working when playback is enabled. The same bug exists when calling `PptxViewer` with both `enableMediaPlayback: true` and `enableTextSelection: true` — fixed at the engine level so both paths benefit.
- `createPresentationHandle` skips the RAF loop and pointer wiring when the slide has no media. Previously a 50-slide deck spawned 50 idle animation loops.

A first attempt to fix the IPC issue by sending `Uint8Array` directly via structured clone is rolled into this PR's history — it failed because VS Code's webview `postMessage` does not reliably structured-clone typed arrays (they arrived as plain `{0:..,1:..}` objects, yielding zero-byte buffers and `Could not find EOCD` errors). The `asWebviewUri` route avoids the postMessage size/type cliff entirely.

## Test plan

- [x] Verified by reporter: media-embedded pptx now renders and audio/video plays
- [x] esbuild + vite builds pass
- [ ] CI VRT (no rendering changes expected — `presentSlide`'s drawBase delegates to the existing `renderSlide` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)