### PR TITLE
chore(release): 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.16.0 — 2026-04-26
+
+Minor release. Audio / video–embedded files now open in the VS Code
+extension and play back interactively.
+
+- **VS Code extension** (`packages/vscode-extension`):
+  - Replace the `Array.from(bytes)` + `webview.postMessage` data path with
+    `webview.asWebviewUri()` + `fetch().arrayBuffer()` in the webview. The
+    previous IPC route serialized file bytes as a JSON number array, which
+    hung the spinner indefinitely on media-embedded pptx (50–200 MB) and,
+    after a stop-gap that sent `Uint8Array` directly, returned zero-byte
+    buffers (`Could not find EOCD` for every file) because VS Code's
+    webview `postMessage` does not reliably structured-clone typed arrays.
+    Same approach the bundled PDF viewer uses; native binary path, no IPC
+    size or type cliff.
+  - Switch the scroll-stack pptx renderer from `PptxPresentation.renderSlide`
+    to `presentSlide` so embedded audio / video become clickable with a
+    canvas-native play / pause / progress bar.
+- **PPTX engine** (`packages/pptx`):
+  - `presentSlide` now forwards `opts.onTextRun` to its inner `renderSlide`
+    call so the transparent text-selection layer keeps working when
+    interactive playback is enabled. The same bug existed when calling
+    `PptxViewer` with both `enableMediaPlayback: true` and
+    `enableTextSelection: true`; fixed at the engine level so both paths
+    benefit.
+  - `createPresentationHandle` now skips its `requestAnimationFrame` loop
+    and pointer wiring for slides without media, so a 50-slide deck no
+    longer spawns 50 idle animation loops.
+
 ## 0.15.2 — 2026-04-26
 
 Patch release. Project icon refresh.

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Charts (pie, scatter, bubble) | ❌ |
 | | SmartArt | ❌ |
 | | OLE objects | ❌ |
-| | Video / audio | ❌ |
+| | Video / audio (poster + interactive playback) | ✅ |
 | **Shape geometry** | 130+ preset shapes (`prstGeom`) | ✅ |
 | | Custom geometry (`custGeom`) | ✅ |
 | | Rotation and flip (flipH / flipV) | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

- Bump all six `package.json` files (root + 5 workspace packages) from 0.15.2 to 0.16.0.
- CHANGELOG entry covering the VS Code extension fix in [#125](https://github.com/yukiyokotani/office-open-xml-viewer/pull/125): file delivery via `webview.asWebviewUri()` + `fetch()` and interactive audio / video playback in the scroll-stack pptx renderer.
- Flip the README PowerPoint feature table row "Video / audio" from ❌ to ✅ now that interactive playback is end-to-end through the VS Code extension and the npm library viewer.

No rendering changes, so `docs/images/{pptx,docx,xlsx}.png` are unchanged. VRT references untouched.

## Test plan

- [x] All six `package.json` files at 0.16.0
- [x] CHANGELOG entry references [#125](https://github.com/yukiyokotani/office-open-xml-viewer/pull/125) substance
- [x] README feature table reflects the new state

🤖 Generated with [Claude Code](https://claude.com/claude-code)