### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.17.0 — 2026-04-27
+
+Minor release. Handwritten ink strokes now render via PowerPoint's
+rasterized fallback, plus rendering accuracy fixes for the PowerPoint
+engine.
+
+- **PPTX engine** (`packages/pptx`):
+  - `mc:AlternateContent` now walks `mc:Fallback` when `mc:Choice`
+    produces no output (previously Choice was always taken and Fallback
+    silently discarded). PowerPoint embeds ink / handwriting as
+    `p:contentPart` (InkML) inside Choice with a rasterized `p:pic`
+    inside Fallback; this restores those strokes.
+  - When the Choice subtree is an ink `p:contentPart`, the fallback PNG
+    is rendered at its natural pixel size centered in the bounding box
+    rather than always stretched. Empty / single-tap strokes (whose
+    fallback PNG is only a few pixels) no longer blow up into blocky
+    artifacts. Visible strokes are unaffected.
+  - Fix preset-shape arc visual-to-parametric angle conversion for
+    non-square shape boxes (ECMA-376 §20.1.9.18 `<a:arcTo>`). The
+    path-executor was using canvas-scaled radii where path-local radii
+    were required, skewing every arc segment when `sx ≠ sy`. Visible
+    on `cloudCallout` placed in a landscape box, where the inner cloud
+    detail arcs were misaligned even though the outline looked plausible.
+  - `PptxViewer` wrapper sets `vertical-align: top` so the inline-block
+    line-box descender (~6 px on default font metrics) no longer leaks
+    the host container's background through below the canvas.
+- **VS Code extension** (`packages/vscode-extension`):
+  - Downsize `icon.png` to 512×512 to match the practical Marketplace
+    icon range. No functional change.
+
 ## 0.16.1 — 2026-04-26
 
 Patch release. Project icon refresh.

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | SmartArt | ❌ |
 | | OLE objects | ❌ |
 | | Video / audio (poster + interactive playback) | ✅ |
+| | Ink / handwriting (`p:contentPart`, raster fallback) | ✅ |
 | **Shape geometry** | 130+ preset shapes (`prstGeom`) | ✅ |
 | | Custom geometry (`custGeom`) | ✅ |
 | | Rotation and flip (flipH / flipV) | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Minor release. Restores handwritten ink stroke rendering via PowerPoint's rasterized fallback, plus a few PowerPoint-engine accuracy fixes.

- **PPTX engine**:
  - `mc:AlternateContent` walks `mc:Fallback` when `mc:Choice` produces no output (was always taking Choice and dropping Fallback). Restores ink/handwriting strokes via the rasterized `p:pic` Office writes alongside InkML.
  - Ink fallback PNGs render at natural pixel size centered in the bbox; empty/single-tap strokes (6×6 px PNG) draw as a tiny dot instead of a stretched blocky cross.
  - Preset-shape arc visual→parametric angle conversion fixed for non-square shape boxes (ECMA-376 §20.1.9.18). `cloudCallout` and other `<a:arcTo>` shapes in landscape boxes now have correctly aligned inner detail.
  - `PptxViewer` wrapper sets `vertical-align: top` so the inline-block descender no longer shows the host container's background through a 6 px gap below the canvas.
- **VS Code extension**: `icon.png` downsized to 512×512 (no functional change).

## Notes

- README screenshots (`docs/images/{docx,xlsx,pptx}.png`) are unchanged: the demo sample (`sample-1.pptx`) contains no `cloudCallout`, no `arcTo`, and no `mc:AlternateContent`, so the rendering for these specific captures is byte-identical.
- Compatibility table gets one new row: PPTX → Element types → Ink / handwriting (`p:contentPart`, raster fallback) ✅.

## Test plan

- [x] Manually verified `private/sample-3` slide-9 (ink) and slide-12 (cloudCallout) against `sample-3.pdf`.
- [ ] Existing VRT suites (`pnpm vrt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)