### PR TITLE
docs(vscode-extension): drop Theme-aware bullet from README

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -19,7 +19,6 @@ A high-fidelity viewer for `.docx`, `.xlsx`, and `.pptx` files — powered by a 
 - **DOCX** — Continuous **scroll view** of every page with a transparent text layer (PDF.js-style) — drag to select, copy as plain text.
 - **XLSX** — Spreadsheet viewer with cell / row / column / range selection, tab-separated copy (Ctrl+C / Cmd+C), freeze-pane support, and a multi-sheet tab bar.
 - **PPTX** — Continuous **scroll view** of every slide with a transparent text layer that handles rotated text boxes correctly.
-- **Theme-aware** — Background and foreground follow the active VS Code theme (light / dark / high-contrast).
 - **High fidelity** — Charts, conditional formatting, theme colors, custom geometry shapes, and more rendered straight from the OOXML spec.
 
 All three formats share the same Rust parser (`wasm-pack`) for accuracy and speed.


### PR DESCRIPTION
## Summary

Theme awareness (light/dark/high-contrast) is a baseline expectation for any VS Code custom editor, not a marquee feature. Drop the bullet so the Features list focuses on the user-facing viewing capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)