### PR TITLE
feat(xlsx): render Office 2010 sparklines (line / column / win-loss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Hidden rows / columns | ✅ |
 | **Elements** | Images (`<xdr:twoCellAnchor>`) | ✅ |
 | | Charts (bar, line, area, radar) | ✅ |
-| | Sparklines | ❌ Not planned |
+| | Sparklines (`x14:sparklineGroup` — line / column / win-loss, with markers and high/low/first/last/negative highlights) | ✅ |
 | **Advanced** | Conditional formatting (`cellIs`, `colorScale`, `dataBar`, `iconSet`, `top10`, `aboveAverage`) | ✅ |
 | | Slicers (static, Office 2010 extension) | ✅ |
 | | Pivot tables | ❌ Not planned |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,9 @@ export { renderChart } from './chart/renderer';
 export { autoResize, type AutoResizeOptions } from './autoResize';
 export { buildCustomPath } from './shape/custGeom';
 export { hexToRgba, resolveFill, applyStroke } from './shape/paint';
+export {
+  renderSparkline,
+  type SparklineKind,
+  type SparklineModel,
+  type SparklineRect,
+} from './sparkline/renderer';

--- a/packages/core/src/sparkline/renderer.ts
+++ b/packages/core/src/sparkline/renderer.ts
@@ -1,0 +1,264 @@
+// Sparkline renderer (Office 2010 `x14:sparklineGroup`, ECMA-376 §18.2).
+// Drawn directly inside a single cell's pixel rect — no axis labels, legend,
+// or title. Theme colors are expected to be flattened to `#RRGGBB` strings
+// at parse time so this module has zero theme awareness.
+
+export type SparklineKind = 'line' | 'column' | 'stem';
+
+/** Render-ready sparkline. The xlsx renderer flattens its parser output into
+ *  this shape (resolving group-level colors / flags onto every cell) and
+ *  passes it to {@link renderSparkline}. */
+export interface SparklineModel {
+  kind: SparklineKind;
+  /** Numeric values; null = empty / non-numeric (rendered as a gap). */
+  values: (number | null)[];
+  /** Optional axis bounds. Used directly when present; otherwise derived
+   *  from the values themselves. For the `group` axis sharing mode the
+   *  caller computes the shared bounds and passes them in. */
+  min?: number;
+  max?: number;
+  /** ECMA-376 §18.2.7. `gap` (default) breaks the line at empty cells;
+   *  `zero` substitutes 0; `span` connects across empty cells. */
+  displayEmptyCellsAs?: 'gap' | 'zero' | 'span';
+  /** Show horizontal axis line at y=0 when the data crosses zero
+   *  (`displayXAxis`). */
+  displayXAxis?: boolean;
+  /** Stroke weight in pt for `line`. ECMA-376 default 0.75. */
+  lineWeight?: number;
+  /** Show a marker dot at every data point (line type only). */
+  markers?: boolean;
+  /** Enable individual point highlights (resolved colors below override
+   *  `colorSeries` for that point). */
+  high?: boolean;
+  low?: boolean;
+  first?: boolean;
+  last?: boolean;
+  negative?: boolean;
+  /** Resolved RGB hex strings (`#RRGGBB`). */
+  colorSeries?: string;
+  colorNegative?: string;
+  colorAxis?: string;
+  colorMarkers?: string;
+  colorFirst?: string;
+  colorLast?: string;
+  colorHigh?: string;
+  colorLow?: string;
+}
+
+export interface SparklineRect {
+  x: number; y: number; w: number; h: number;
+}
+
+/** EMU-free, theme-free sparkline renderer. The cell rect is in device px
+ *  matching the canvas's current transform; padding is applied internally. */
+export function renderSparkline(
+  ctx: CanvasRenderingContext2D,
+  rect: SparklineRect,
+  model: SparklineModel,
+): void {
+  const { values } = model;
+  if (values.length === 0 || rect.w <= 0 || rect.h <= 0) return;
+
+  // Inset the drawing area so strokes / markers don't kiss the cell edge.
+  // Half a pixel on each side is plenty at typical sizes; a marker radius
+  // worth on the top / bottom keeps high / low dots inside.
+  const series = model.colorSeries ?? '#5B9BD5';
+  const PAD_X = Math.min(2, rect.w * 0.08);
+  const PAD_Y = Math.min(2, rect.h * 0.12);
+  const dx = rect.x + PAD_X;
+  const dy = rect.y + PAD_Y;
+  const dw = Math.max(1, rect.w - PAD_X * 2);
+  const dh = Math.max(1, rect.h - PAD_Y * 2);
+
+  // Bounds. Empty data → bail quietly.
+  const numeric = values.filter((v): v is number => typeof v === 'number');
+  if (numeric.length === 0) return;
+  const dataMin = Math.min(...numeric);
+  const dataMax = Math.max(...numeric);
+  let lo = model.min ?? dataMin;
+  let hi = model.max ?? dataMax;
+  if (lo === hi) {
+    // Flat data — center it in the rect.
+    hi = lo + 1;
+    lo = lo - 1;
+  }
+  const range = hi - lo;
+  const yOf = (v: number) => dy + dh - ((v - lo) / range) * dh;
+
+  if (model.kind === 'stem') {
+    drawStem(ctx, model, dx, dy, dw, dh);
+    return;
+  }
+
+  if (model.kind === 'column') {
+    drawColumn(ctx, model, values, dx, dy, dw, dh, lo, hi);
+    return;
+  }
+
+  // ---- line ----
+  // Axis line at y=0 when the data crosses zero and displayXAxis is on.
+  if (model.displayXAxis && lo < 0 && hi > 0) {
+    ctx.save();
+    ctx.strokeStyle = model.colorAxis ?? '#000000';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    const ay = yOf(0);
+    ctx.moveTo(dx, ay);
+    ctx.lineTo(dx + dw, ay);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Each point's center X. With one point we still want a stable position.
+  const n = values.length;
+  const xOf = (i: number) => n === 1 ? dx + dw / 2 : dx + (i / (n - 1)) * dw;
+
+  // Stroke the polyline, breaking at gaps unless `span` was requested.
+  ctx.save();
+  ctx.strokeStyle = series;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  // ECMA-376 lineWeight is in points; the canvas is already scaled, so
+  // 1 pt ≈ 1.333 px at 96 DPI. We multiply by ptToPx to keep visual weight
+  // consistent with PowerPoint / Excel.
+  const PT_TO_PX = 1.333;
+  ctx.lineWidth = (model.lineWeight ?? 0.75) * PT_TO_PX;
+  ctx.beginPath();
+  let penDown = false;
+  const empty = model.displayEmptyCellsAs ?? 'gap';
+  for (let i = 0; i < n; i++) {
+    const v = values[i];
+    if (v == null) {
+      if (empty === 'zero') {
+        const x = xOf(i), y = yOf(0);
+        if (!penDown) { ctx.moveTo(x, y); penDown = true; }
+        else ctx.lineTo(x, y);
+      } else if (empty === 'gap') {
+        penDown = false;
+      }
+      // span: skip — the next non-null point will continue the line.
+      continue;
+    }
+    const x = xOf(i), y = yOf(v);
+    if (!penDown) { ctx.moveTo(x, y); penDown = true; }
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  ctx.restore();
+
+  // Markers / highlights. Only line type honors these visually.
+  const dotR = Math.max(1, Math.min(2.5, dh * 0.12));
+  const flagged = computeFlagged(values, model);
+  for (let i = 0; i < n; i++) {
+    const v = values[i];
+    if (v == null) continue;
+    const flagColor = flagged[i];
+    const drawDot = model.markers || flagColor != null;
+    if (!drawDot) continue;
+    ctx.save();
+    ctx.fillStyle = flagColor ?? model.colorMarkers ?? series;
+    ctx.beginPath();
+    ctx.arc(xOf(i), yOf(v), dotR, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
+}
+
+/** Resolve the per-point highlight color for line / column. Returns
+ *  `null` for points with no special treatment. Order of precedence
+ *  (later wins): negative < first < last < high < low. */
+function computeFlagged(
+  values: (number | null)[],
+  m: SparklineModel,
+): Array<string | null> {
+  const flagged: Array<string | null> = values.map(() => null);
+  const numeric = values.map(v => (typeof v === 'number' ? v : null));
+  const firstIdx = numeric.findIndex(v => v != null);
+  let lastIdx = -1;
+  for (let i = numeric.length - 1; i >= 0; i--) {
+    if (numeric[i] != null) { lastIdx = i; break; }
+  }
+  const present = numeric.filter((v): v is number => v != null);
+  let highIdx = -1, lowIdx = -1;
+  if (present.length > 0) {
+    const hi = Math.max(...present);
+    const lo = Math.min(...present);
+    highIdx = numeric.findIndex(v => v === hi);
+    lowIdx = numeric.findIndex(v => v === lo);
+  }
+  if (m.negative && m.colorNegative) {
+    for (let i = 0; i < numeric.length; i++) {
+      const v = numeric[i];
+      if (v != null && v < 0) flagged[i] = m.colorNegative;
+    }
+  }
+  if (m.first && m.colorFirst && firstIdx >= 0) flagged[firstIdx] = m.colorFirst;
+  if (m.last && m.colorLast && lastIdx >= 0) flagged[lastIdx] = m.colorLast;
+  if (m.high && m.colorHigh && highIdx >= 0) flagged[highIdx] = m.colorHigh;
+  if (m.low && m.colorLow && lowIdx >= 0) flagged[lowIdx] = m.colorLow;
+  return flagged;
+}
+
+function drawColumn(
+  ctx: CanvasRenderingContext2D,
+  m: SparklineModel,
+  values: (number | null)[],
+  x: number, y: number, w: number, h: number,
+  lo: number, hi: number,
+) {
+  const n = values.length;
+  if (n === 0) return;
+  // Bars share a baseline of 0 when the data crosses it; otherwise the
+  // baseline is the min edge (matches Excel's positive-only / negative-only
+  // sparkline columns growing from the bottom / top of the cell).
+  const baseValue = (lo < 0 && hi > 0) ? 0 : lo;
+  const range = hi - lo;
+  const yOf = (v: number) => y + h - ((v - lo) / range) * h;
+  const baseY = yOf(baseValue);
+  const slot = w / n;
+  // Tiny cell-side gap so adjacent bars are distinguishable. Excel uses
+  // ~1 px on a small bar and we match by clamping at 1.
+  const gap = Math.min(1.5, slot * 0.15);
+  const flagged = computeFlagged(values, m);
+  for (let i = 0; i < n; i++) {
+    const v = values[i];
+    if (v == null) continue;
+    const fill = flagged[i] ?? (v < 0 && m.colorNegative ? m.colorNegative : (m.colorSeries ?? '#5B9BD5'));
+    const top = yOf(v);
+    const barX = x + slot * i + gap / 2;
+    const barW = Math.max(1, slot - gap);
+    ctx.save();
+    ctx.fillStyle = fill;
+    ctx.fillRect(barX, Math.min(baseY, top), barW, Math.abs(baseY - top));
+    ctx.restore();
+  }
+}
+
+function drawStem(
+  ctx: CanvasRenderingContext2D,
+  m: SparklineModel,
+  x: number, y: number, w: number, h: number,
+) {
+  // ECMA-376: win/loss bars are fixed half-height — positives reach up
+  // from a midline, negatives reach down. Zeros are skipped.
+  const n = m.values.length;
+  if (n === 0) return;
+  const midY = y + h / 2;
+  const halfH = h / 2;
+  const slot = w / n;
+  const gap = Math.min(1.5, slot * 0.15);
+  const flagged = computeFlagged(m.values, m);
+  for (let i = 0; i < n; i++) {
+    const v = m.values[i];
+    if (v == null || v === 0) continue;
+    const isNeg = v < 0;
+    const fill = flagged[i] ?? (isNeg && m.colorNegative ? m.colorNegative : (m.colorSeries ?? '#5B9BD5'));
+    const barX = x + slot * i + gap / 2;
+    const barW = Math.max(1, slot - gap);
+    ctx.save();
+    ctx.fillStyle = fill;
+    if (isNeg) ctx.fillRect(barX, midY, barW, halfH);
+    else ctx.fillRect(barX, midY - halfH, barW, halfH);
+    ctx.restore();
+  }
+}

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -78,6 +78,83 @@ pub struct Worksheet {
     /// and referenced pivotCacheDefinition so the renderer can draw a static
     /// button list with the saved selection state.
     pub slicers: Vec<SlicerAnchor>,
+    /// Sparkline groups defined in the worksheet's `<extLst>` (Office 2010
+    /// extension `http://schemas.microsoft.com/office/spreadsheetml/2009/9/main`,
+    /// element `<x14:sparklineGroup>`, ECMA-376 §18.2 / Part 4).
+    pub sparkline_groups: Vec<SparklineGroup>,
+}
+
+/// Single sparkline group (`<x14:sparklineGroup>`). Holds the shared formatting
+/// for every individual sparkline cell that belongs to the group.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SparklineGroup {
+    /// `line` (default) | `column` | `stem` (win/loss).
+    pub kind: SparklineType,
+    /// Show a marker dot at every data point (line type only).
+    pub markers: bool,
+    /// Highlight high / low / first / last / negative points.
+    pub high: bool,
+    pub low: bool,
+    pub first: bool,
+    pub last: bool,
+    pub negative: bool,
+    /// Show the horizontal axis line when data crosses zero.
+    pub display_x_axis: bool,
+    /// `gap` (default) | `zero` | `span` — how empty cells in the source
+    /// range are treated. We only honor `gap` (default) at render time.
+    pub display_empty_cells_as: String,
+    /// Per-axis-bound type: `individual` (default) / `group` / `custom`.
+    pub min_axis_type: String,
+    pub max_axis_type: String,
+    /// Used when *AxisType=`custom`. f64::NAN otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manual_min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manual_max: Option<f64>,
+    /// Stroke weight in pt (line type). ECMA-376 default 0.75.
+    pub line_weight: f64,
+    /// Resolved RGB hex strings (e.g. `#4472C4`) — theme + tint flattened
+    /// at parse time so the renderer never sees a theme index. `None` means
+    /// the property was not specified and the renderer should fall back.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_series: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_negative: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_axis: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_markers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_first: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_last: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_high: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_low: Option<String>,
+    /// Individual sparklines (one per destination cell).
+    pub sparklines: Vec<Sparkline>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum SparklineType {
+    Line,
+    Column,
+    Stem,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Sparkline {
+    /// 1-based row of the cell that displays this sparkline (`<xm:sqref>`).
+    pub row: u32,
+    /// 1-based column of the cell.
+    pub col: u32,
+    /// Numeric values resolved from the `<xm:f>` data range. `None` for
+    /// empty / non-numeric / out-of-bounds cells.
+    pub values: Vec<Option<f64>>,
 }
 
 /// Excel Table metadata (ECMA-376 §18.5 `<table>`). The renderer overlays a
@@ -774,6 +851,7 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, 
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
     ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
     ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
+    ws.sparkline_groups = load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
 
     serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -1777,6 +1855,7 @@ fn parse_worksheet(
         defined_names: Vec::new(),
         tables: Vec::new(),
         slicers: Vec::new(),
+        sparkline_groups: Vec::new(),
     }, hyperlink_rids))
 }
 
@@ -3749,6 +3828,176 @@ fn parse_sqref(s: &str) -> Vec<CellRange> {
     }).collect()
 }
 
+/// Split an `<xm:f>` reference like `Sheet1!A1:A10` or `'My Sheet'!$B$3:$B$8`
+/// into `(sheet_name, range)`. Returns `None` if the reference has no sheet
+/// qualifier — sparkline data refs always do, so unqualified is treated as
+/// "same sheet" by callers.
+fn split_sheet_ref(s: &str) -> (Option<String>, String) {
+    let s = s.trim();
+    let Some(bang) = s.rfind('!') else { return (None, s.to_string()); };
+    let mut sheet = s[..bang].to_string();
+    // Strip absolute-ref dollars from the range part.
+    let range = s[bang + 1..].replace('$', "");
+    // Quoted sheet names ('foo''s sheet' uses doubled quotes for inner ').
+    if sheet.starts_with('\'') && sheet.ends_with('\'') {
+        sheet = sheet[1..sheet.len() - 1].replace("''", "'");
+    }
+    (Some(sheet), range)
+}
+
+/// Read a worksheet XML and extract numeric `<v>` values for the cells in
+/// `range`. Returns one value per cell in row-major order across the range.
+/// Empty cells, non-numeric values, and cells outside the range yield `None`.
+///
+/// This is intentionally lighter than `parse_row_cells`: sparklines only need
+/// raw numbers, no styles, formulas, or shared strings.
+fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> {
+    let total = ((range.bottom - range.top + 1) as usize)
+        .saturating_mul((range.right - range.left + 1) as usize);
+    let mut values: Vec<Option<f64>> = vec![None; total];
+    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else { return values; };
+    let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    let row_span = (range.right - range.left + 1) as usize;
+    for c in doc.descendants().filter(|n| n.tag_name().name() == "c" && n.tag_name().namespace() == Some(ns)) {
+        let Some(r_attr) = c.attribute("r") else { continue };
+        let (col, row) = parse_cell_ref(r_attr);
+        if row < range.top || row > range.bottom || col < range.left || col > range.right {
+            continue;
+        }
+        // Only honor numeric / formula-numeric cells. `t` of "s" / "str" /
+        // "inlineStr" / "b" / "e" all map to None for sparkline values.
+        let t = c.attribute("t").unwrap_or("");
+        if matches!(t, "s" | "str" | "inlineStr" | "b" | "e") { continue; }
+        let v = c.children()
+            .find(|n| n.tag_name().name() == "v" && n.tag_name().namespace() == Some(ns))
+            .and_then(|n| n.text())
+            .and_then(|s| s.trim().parse::<f64>().ok());
+        if let Some(num) = v {
+            let idx = (row - range.top) as usize * row_span + (col - range.left) as usize;
+            if idx < values.len() {
+                values[idx] = Some(num);
+            }
+        }
+    }
+    values
+}
+
+/// Walk the worksheet XML's `<extLst>` and produce one `SparklineGroup` per
+/// `<x14:sparklineGroup>`. Resolves cross-sheet `<xm:f>` data references by
+/// reading the referenced sheet from the archive (cached per call to avoid
+/// re-reads). Theme colors are flattened to `#RRGGBB` via `parse_color`.
+fn load_sheet_sparklines(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    sheet_xml: &str,
+    sheets: &[SheetMeta],
+    rels_doc: &roxmltree::Document,
+    theme_colors: &[String],
+) -> Vec<SparklineGroup> {
+    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else { return Vec::new(); };
+    let mut groups: Vec<SparklineGroup> = Vec::new();
+    // Cache: sheet name → loaded XML. Saves re-reading when many sparklines
+    // reference the same source sheet (typical: one "data" sheet feeds many
+    // dashboard sparklines).
+    let mut xml_cache: HashMap<String, Option<String>> = HashMap::new();
+
+    let parse_bool_attr = |n: &roxmltree::Node, key: &str, default: bool| -> bool {
+        match n.attribute(key) {
+            Some(v) => v == "1" || v.eq_ignore_ascii_case("true"),
+            None => default,
+        }
+    };
+    let parse_f64_attr = |n: &roxmltree::Node, key: &str| -> Option<f64> {
+        n.attribute(key).and_then(|v| v.parse::<f64>().ok())
+    };
+
+    for group_node in doc.descendants().filter(|n| n.tag_name().name() == "sparklineGroup") {
+        let kind = match group_node.attribute("type").unwrap_or("line") {
+            "column" => SparklineType::Column,
+            "stacked" => SparklineType::Stem,  // historical alias
+            "stem" => SparklineType::Stem,
+            // ECMA-376 lists `line` and a planned `stairStep`; treat unknown
+            // types as line (closest visual fallback).
+            _ => SparklineType::Line,
+        };
+
+        let resolve_color = |child_name: &str| -> Option<String> {
+            group_node.children()
+                .find(|n| n.is_element() && n.tag_name().name() == child_name)
+                .and_then(|n| parse_color(&n, theme_colors))
+        };
+
+        let mut sparklines: Vec<Sparkline> = Vec::new();
+        // <x14:sparklines> is the wrapper; <x14:sparkline> are the children.
+        for sparklines_node in group_node.children().filter(|n| n.is_element() && n.tag_name().name() == "sparklines") {
+            for sl in sparklines_node.children().filter(|n| n.is_element() && n.tag_name().name() == "sparkline") {
+                let f_text = sl.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "f")
+                    .and_then(|n| n.text())
+                    .unwrap_or("");
+                let sqref_text = sl.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "sqref")
+                    .and_then(|n| n.text())
+                    .unwrap_or("");
+                if f_text.is_empty() || sqref_text.is_empty() { continue; }
+                let (col, row) = parse_cell_ref(sqref_text.trim());
+                let (source_sheet, range_str) = split_sheet_ref(f_text);
+                let ranges = parse_sqref(&range_str);
+                let Some(range) = ranges.into_iter().next() else { continue };
+
+                // Look up source sheet XML (cross-sheet ref). When the ref
+                // has no sheet qualifier, fall back to the *current* sheet
+                // XML.
+                let source_xml: Option<&str> = match source_sheet {
+                    Some(name) => {
+                        if !xml_cache.contains_key(&name) {
+                            let path = sheets.iter()
+                                .find(|s| s.name == name)
+                                .and_then(|s| resolve_sheet_path(rels_doc, &s.r_id))
+                                .map(|p| format!("xl/{}", p));
+                            let xml = path.and_then(|p| read_zip_entry(archive, &p).ok());
+                            xml_cache.insert(name.clone(), xml);
+                        }
+                        xml_cache.get(&name).and_then(|o| o.as_deref())
+                    }
+                    None => Some(sheet_xml),
+                };
+                let values = source_xml
+                    .map(|xml| extract_range_values(xml, &range))
+                    .unwrap_or_default();
+
+                sparklines.push(Sparkline { row, col, values });
+            }
+        }
+
+        groups.push(SparklineGroup {
+            kind,
+            markers: parse_bool_attr(&group_node, "markers", false),
+            high: parse_bool_attr(&group_node, "high", false),
+            low: parse_bool_attr(&group_node, "low", false),
+            first: parse_bool_attr(&group_node, "first", false),
+            last: parse_bool_attr(&group_node, "last", false),
+            negative: parse_bool_attr(&group_node, "negative", false),
+            display_x_axis: parse_bool_attr(&group_node, "displayXAxis", false),
+            display_empty_cells_as: group_node.attribute("displayEmptyCellsAs").unwrap_or("gap").to_string(),
+            min_axis_type: group_node.attribute("minAxisType").unwrap_or("individual").to_string(),
+            max_axis_type: group_node.attribute("maxAxisType").unwrap_or("individual").to_string(),
+            manual_min: parse_f64_attr(&group_node, "manualMin"),
+            manual_max: parse_f64_attr(&group_node, "manualMax"),
+            line_weight: parse_f64_attr(&group_node, "lineWeight").unwrap_or(0.75),
+            color_series: resolve_color("colorSeries"),
+            color_negative: resolve_color("colorNegative"),
+            color_axis: resolve_color("colorAxis"),
+            color_markers: resolve_color("colorMarkers"),
+            color_first: resolve_color("colorFirst"),
+            color_last: resolve_color("colorLast"),
+            color_high: resolve_color("colorHigh"),
+            color_low: resolve_color("colorLow"),
+            sparklines,
+        });
+    }
+    groups
+}
+
 fn parse_row_cells(
     row_node: &roxmltree::Node,
     shared_strings: &[SharedString],
@@ -3877,6 +4126,7 @@ pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<S
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
     ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
     ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
+    ws.sparkline_groups = load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
 
     serde_json::to_string(&ws).map_err(|e| e.to_string())
 }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { renderChart, type ChartModel } from '@silurus/ooxml-core';
+import { renderChart, renderSparkline, type ChartModel, type SparklineModel } from '@silurus/ooxml-core';
 
 const DEFAULT_FONT_FAMILY = 'Calibri, Arial, sans-serif';
 const DEFAULT_FONT_SIZE = 11;
@@ -1972,6 +1972,10 @@ interface RenderContext {
   commentCells: Set<string>;
   /** row:col → table-style overlay (bold header, banded rows, borders). */
   tableStyleMap: Map<string, TableCellStyle>;
+  /** row:col → render-ready SparklineModel for cells that host an
+   *  `x14:sparkline`. Built once at viewport start by flattening the
+   *  parser's SparklineGroup + per-cell Sparkline pair. */
+  sparklineMap: Map<string, SparklineModel>;
   onTextRun?: (info: TextRunInfo) => void;
 }
 
@@ -2087,6 +2091,70 @@ function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
           headerRowDxf: t.headerRowDxf,
         });
       }
+    }
+  }
+  return map;
+}
+
+/** Flatten the worksheet's parsed `sparklineGroups` into a per-cell render
+ *  model. Each Sparkline inherits its group's formatting; min/max are
+ *  computed from the values when the group's `*AxisType` is `individual`,
+ *  shared across the group when `group`, or taken from `manualMin/Max` when
+ *  `custom`. The renderer can then look up `row:col` and call core's
+ *  `renderSparkline` without further work. */
+function buildSparklineMap(worksheet: Worksheet): Map<string, SparklineModel> {
+  const map = new Map<string, SparklineModel>();
+  for (const g of worksheet.sparklineGroups ?? []) {
+    // Group-wide min/max if needed.
+    let groupMin = Infinity, groupMax = -Infinity;
+    if (g.minAxisType === 'group' || g.maxAxisType === 'group') {
+      for (const sl of g.sparklines) {
+        for (const v of sl.values) {
+          if (typeof v === 'number') {
+            if (v < groupMin) groupMin = v;
+            if (v > groupMax) groupMax = v;
+          }
+        }
+      }
+      if (!isFinite(groupMin) || !isFinite(groupMax)) {
+        groupMin = 0; groupMax = 1;
+      }
+    }
+    for (const sl of g.sparklines) {
+      const numeric = sl.values.filter((v): v is number => typeof v === 'number');
+      const indMin = numeric.length ? Math.min(...numeric) : 0;
+      const indMax = numeric.length ? Math.max(...numeric) : 1;
+      const min = g.minAxisType === 'custom' && typeof g.manualMin === 'number'
+        ? g.manualMin
+        : g.minAxisType === 'group' ? groupMin : indMin;
+      const max = g.maxAxisType === 'custom' && typeof g.manualMax === 'number'
+        ? g.manualMax
+        : g.maxAxisType === 'group' ? groupMax : indMax;
+      map.set(`${sl.row}:${sl.col}`, {
+        kind: g.kind,
+        values: sl.values,
+        min,
+        max,
+        displayEmptyCellsAs: (g.displayEmptyCellsAs === 'zero' || g.displayEmptyCellsAs === 'span')
+          ? g.displayEmptyCellsAs
+          : 'gap',
+        displayXAxis: g.displayXAxis,
+        lineWeight: g.lineWeight,
+        markers: g.markers,
+        high: g.high,
+        low: g.low,
+        first: g.first,
+        last: g.last,
+        negative: g.negative,
+        colorSeries: g.colorSeries,
+        colorNegative: g.colorNegative,
+        colorAxis: g.colorAxis,
+        colorMarkers: g.colorMarkers,
+        colorFirst: g.colorFirst,
+        colorLast: g.colorLast,
+        colorHigh: g.colorHigh,
+        colorLow: g.colorLow,
+      });
     }
   }
   return map;
@@ -2321,6 +2389,15 @@ function renderQuadrant(
         const barInset = 2;
         const barW = Math.max(0, (cellW - barInset * 2) * cf.dataBar.ratio);
         fillDataBar(ctx, cf.dataBar.color, cx + barInset, cy + barInset, barW, cellH - barInset * 2, cf.dataBar.gradient);
+      }
+
+      // Sparkline (Office 2010 x14:sparklineGroup). Drawn after the cell
+      // background but before borders / text so borders frame the sparkline
+      // and any cell text overlays it (matches Excel's z-order, and lets
+      // a label like "Trend" share the same cell as the sparkline).
+      const sparkModel = rc.sparklineMap.get(key);
+      if (sparkModel) {
+        renderSparkline(ctx, { x: cx, y: cy, w: cellW, h: cellH }, sparkModel);
       }
 
       // Grid lines – draw only right + bottom edges once per cell (avoids double-drawing at
@@ -2865,6 +2942,7 @@ export function renderViewport(
   }
 
   const tableStyleMap = buildTableStyleMap(worksheet);
+  const sparklineMap = buildSparklineMap(worksheet);
 
   const rc: RenderContext = {
     worksheet, styles, cellMap, mergeAnchorMap, mergeSkipSet, cfContext,
@@ -2879,6 +2957,7 @@ export function renderViewport(
     hyperlinkMap,
     commentCells,
     tableStyleMap,
+    sparklineMap,
     onTextRun: opts.onTextRun,
   };
 

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -58,6 +58,52 @@ export interface Worksheet {
    *  caption and the saved item list (with selection flags) so the renderer
    *  can draw a static button bank without the live pivot engine. */
   slicers?: SlicerAnchor[];
+  /** Sparkline groups (Office 2010+ extension `x14:sparklineGroup`).
+   *  Cross-sheet `<xm:f>` data references are resolved to numeric values at
+   *  parse time, and theme + tint colors are flattened to `#RRGGBB`. */
+  sparklineGroups?: SparklineGroup[];
+}
+
+export interface SparklineGroup {
+  /** `line` (default) | `column` | `stem` (win-loss). */
+  kind: 'line' | 'column' | 'stem';
+  markers: boolean;
+  high: boolean;
+  low: boolean;
+  first: boolean;
+  last: boolean;
+  negative: boolean;
+  /** Show the horizontal axis line through 0 when data crosses it. */
+  displayXAxis: boolean;
+  /** `gap` (default) | `zero` | `span`. */
+  displayEmptyCellsAs: string;
+  /** `individual` (default) | `group` | `custom`. */
+  minAxisType: string;
+  maxAxisType: string;
+  manualMin?: number;
+  manualMax?: number;
+  /** Stroke weight in pt for `line`. ECMA-376 default 0.75. */
+  lineWeight: number;
+  /** Resolved RGB hex strings (theme/tint already flattened by the parser). */
+  colorSeries?: string;
+  colorNegative?: string;
+  colorAxis?: string;
+  colorMarkers?: string;
+  colorFirst?: string;
+  colorLast?: string;
+  colorHigh?: string;
+  colorLow?: string;
+  sparklines: Sparkline[];
+}
+
+export interface Sparkline {
+  /** 1-based row of the destination cell (`<xm:sqref>`). */
+  row: number;
+  /** 1-based column of the destination cell. */
+  col: number;
+  /** Numeric values resolved from the `<xm:f>` range. `null` for empty
+   *  / non-numeric cells; honored as gaps at render time. */
+  values: (number | null)[];
 }
 
 export interface SlicerAnchor {


### PR DESCRIPTION
## Summary

Excel sparklines (\`x14:sparklineGroup\`, Office 2010 extension) were marked **❌ Not planned** in the README without a documented rationale. There was no parser or renderer code at all in \`packages/xlsx/\`. This PR adds full support, using the same \`<extLst>\` pattern the parser already uses for x14 conditional formatting / icon sets.

## What's covered

- **Types**: line / column / **win-loss** (ECMA-376 \`stem\`).
- **Highlights**: \`markers\` (all points) + \`high\` / \`low\` / \`first\` / \`last\` / \`negative\` per-point overrides.
- **Axis bounds**: \`individual\` (default) / \`group\` (shared across the group) / \`custom\` (\`manualMin\`/\`Max\`).
- **Empty-cell handling**: \`gap\` (default) / \`zero\` / \`span\`.
- **Cross-sheet data references**: e.g. \`計算!C15:G15\` is resolved at parse time by reading the source sheet from the ZIP archive (cached per-load).
- **Theme + tint colors**: flattened to \`#RRGGBB\` using the existing \`parse_color\` helper (with the standard dk1↔lt1 / dk2↔lt2 swap). Renderer never sees a theme index.

## Architecture

| Layer | File | Change |
|-------|------|--------|
| Rust parser | \`packages/xlsx/parser/src/lib.rs\` | New \`SparklineGroup\` / \`Sparkline\` structs; \`Worksheet.sparklineGroups\` field; \`load_sheet_sparklines\` walker that resolves \`<xm:f>\` ranges across sheets |
| TS types | \`packages/xlsx/src/types.ts\` | Mirror parser output (\`sparklineGroups\`, \`SparklineGroup\`, \`Sparkline\`) |
| Core renderer | \`packages/core/src/sparkline/renderer.ts\` (new) | Standalone \`renderSparkline(ctx, rect, model)\` — no axes / legend / labels |
| Core export | \`packages/core/src/index.ts\` | Re-export \`renderSparkline\`, \`SparklineModel\`, \`SparklineKind\`, \`SparklineRect\` |
| XLSX renderer | \`packages/xlsx/src/renderer.ts\` | \`buildSparklineMap\` (per-viewport) + per-cell draw call after the data-bar layer |
| README | \`README.md\` | Flip \`Sparklines\` row from ❌ Not planned to ✅ |

## Test plan

- [x] Visual: \`private/sample-25.xlsx\` (financial dashboard, line type with markers, two groups including \`first="1" last="1"\` highlights, all data cross-references the \`計算\` sheet) — top KPI tiles and per-row trend column both render with correct line + markers.
- [x] No regression to existing PPTX visual specs (\`visual.spec.ts\`: 70/70 passing).
- [x] \`tsc --build\` clean across \`@silurus/ooxml\`, \`@silurus/ooxml-core\`, \`@silurus/ooxml-xlsx\`.

## Out of scope

- \`stairStep\` type — rare in real-world files; falls back to \`line\` rendering.
- Custom \`displayXAxis\` baseline rendering for column / win-loss types (only line gets the dashed zero axis right now; column / win-loss anchor visually).
- Number formatting on sparkline tooltips (no tooltips yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)