### PR TITLE
chore(vscode-extension): drop icon copy from vscode:prepublish

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "compile": "node esbuild.config.mjs",
     "watch": "node esbuild.config.mjs --watch",
-    "vscode:prepublish": "cp ../../docs/images/icon.png ./icon.png && node esbuild.config.mjs --production",
+    "vscode:prepublish": "node esbuild.config.mjs --production",
     "package": "vsce package"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Remove the `cp ../../docs/images/icon.png ./icon.png` step from `vscode:prepublish` in `packages/vscode-extension/package.json`.
- The VS Code extension icon will be maintained directly at `packages/vscode-extension/icon.png` going forward, decoupled from `docs/images/icon.png`.

## Test plan
- [ ] `pnpm --filter ooxml-vscode-extension package` produces a `.vsix` whose embedded `icon.png` matches the file currently committed at `packages/vscode-extension/icon.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)