### PR TITLE
chore(release): 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.18.0 — 2026-04-27
+
+Minor release. Excel scatter / bubble charts gain a spec-faithful set of
+features so Gantt-style "Project Timeline" templates render against the
+reference. Sparkline release reused — no docx/pptx behavioral changes.
+
+- **PPTX engine** (`packages/xlsx`, `packages/core`):
+  - Per-point `<c:dPt>` overrides (color, marker shape / size / fill /
+    line) — ECMA-376 §21.2.2.39.
+  - `<c:marker>` symbol / size resolution with all 10 ECMA shapes
+    (circle / square / diamond / triangle / x / plus / star / dot /
+    dash / picture). `picture` falls back to circle pending image-marker
+    resolution.
+  - `<c:dLbl>` per-point custom data labels (§21.2.2.45) with rich-text
+    flattening and `<a:fld type="CELLRANGE">` substitution from the
+    series' `<c15:datalabelsRange>` cache. Position (`l`/`r`/`t`/`b`/
+    `ctr`/`outEnd`) is honored.
+  - `<c:errBars>` (§21.2.2.20) X / Y direction with all five
+    `errValType` modes — `cust` (cell-range), `fixedVal`, `stdErr`,
+    `stdDev`, `percentage`. Cust values can be signed (Vertex42 Gantt
+    uses negative minus values to flip stems toward the X-axis).
+    Dashed strokes and end caps via `<a:prstDash>` / `<c:noEndCap>`.
+  - `<c:title><c:layout>` and `<c:plotArea><c:layout>` manual layout
+    (§21.2.2.27) — when present, used directly for absolute placement.
+  - Scatter's dual `<c:valAx>` blocks are now disambiguated by
+    `<c:axPos>` so X-axis (`b`/`t`) and Y-axis (`l`/`r`) settings end
+    up in their respective slots. `<c:scaling><c:min/max>` and
+    `<c:numFmt>` are picked up per axis. `<c:delete val="1"/>` on
+    either axis hides it correctly.
+  - `formatChartValWithCode` recognises date format codes (m/d/y/h/s
+    outside quotes) and routes through a new `formatExcelDate` so
+    scatter X-axis tick labels for date series come out as
+    `2018/4/12` instead of raw serial numbers.
+
+The unified `ChartModel` / `ChartSeries` gained the corresponding
+optional fields. PPTX charts continue rendering unchanged — the PPTX
+parser hasn't been updated to populate them yet (follow-up).
+
 ## 0.17.0 — 2026-04-27
 
 Minor release. Handwritten ink strokes now render via PowerPoint's

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Minor release. Excel scatter / bubble charts gain a spec-faithful set of features (markers / dPt / dLbl with CELLRANGE / errBars / manualLayout / axis disambiguation / date format codes) so Gantt-style "Project Timeline" templates render against the reference.

- **PPTX engine** (`packages/xlsx`, `packages/core`): see CHANGELOG.
- README compatibility table: replaced \`Charts (pie, scatter, bubble) | ❌\` row with rows describing the implemented capabilities (markers, dLbl with CELLRANGE, errBars, manual layout, all alongside the existing chart types). Pie / bubble drawing remains unchanged.
- README screenshots (\`docs/images/{docx,xlsx,pptx}.png\`) unchanged: the demo \`sample-1.xlsx\` does not contain scatter charts, error bars, or manual layouts, so renders are byte-identical.

## Test plan

- [x] private/sample-26.xlsx (Vertex42 Gantt) — visually matches Excel reference.
- [x] private/sample-25.xlsx (sparklines) — unchanged.
- [x] PPTX visual.spec.ts: 70/70 passing (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)