### PR TITLE
fix(core): mark every tied high/low sparkline point, not just the first

### DIFF
--- a/packages/core/src/sparkline/renderer.ts
+++ b/packages/core/src/sparkline/renderer.ts
@@ -179,12 +179,10 @@ function computeFlagged(
     if (numeric[i] != null) { lastIdx = i; break; }
   }
   const present = numeric.filter((v): v is number => v != null);
-  let highIdx = -1, lowIdx = -1;
+  let hi = NaN, lo = NaN;
   if (present.length > 0) {
-    const hi = Math.max(...present);
-    const lo = Math.min(...present);
-    highIdx = numeric.findIndex(v => v === hi);
-    lowIdx = numeric.findIndex(v => v === lo);
+    hi = Math.max(...present);
+    lo = Math.min(...present);
   }
   if (m.negative && m.colorNegative) {
     for (let i = 0; i < numeric.length; i++) {
@@ -194,8 +192,20 @@ function computeFlagged(
   }
   if (m.first && m.colorFirst && firstIdx >= 0) flagged[firstIdx] = m.colorFirst;
   if (m.last && m.colorLast && lastIdx >= 0) flagged[lastIdx] = m.colorLast;
-  if (m.high && m.colorHigh && highIdx >= 0) flagged[highIdx] = m.colorHigh;
-  if (m.low && m.colorLow && lowIdx >= 0) flagged[lowIdx] = m.colorLow;
+  // ECMA-376 §18.18.74 doesn't say so explicitly, but Excel highlights
+  // *every* point tied for the high or low value (not just the first
+  // occurrence). With a 12-point series of 9 zeros + 3 non-zeros and
+  // `low="1"`, all 9 zero points are dotted, not just the first.
+  if (m.high && m.colorHigh && !Number.isNaN(hi)) {
+    for (let i = 0; i < numeric.length; i++) {
+      if (numeric[i] === hi) flagged[i] = m.colorHigh;
+    }
+  }
+  if (m.low && m.colorLow && !Number.isNaN(lo)) {
+    for (let i = 0; i < numeric.length; i++) {
+      if (numeric[i] === lo) flagged[i] = m.colorLow;
+    }
+  }
   return flagged;
 }
 


### PR DESCRIPTION
## Summary

\`computeFlagged\` (sparkline renderer) used \`findIndex(v => v === hi)\` to locate the high / low marker indices, so when multiple data points were tied at the maximum or minimum, only the **first** occurrence was rendered as a dot. Excel highlights every tied point.

## Repro

\`private/sample-7.xlsx\` cell Q10 (budget summary "集計" row): the source range \`D10:O10\` is 3 non-zero values followed by 9 zeros, with \`<x14:sparklineGroup low="1" high="1">\`. Excel renders 1 high dot + 9 low dots = **10 visible dots**. Our render was showing only 2 (1 high + 1 low at the first zero).

## Fix

Iterate the values and flag every index whose value equals \`hi\` / \`lo\`. Other highlight kinds (\`first\` / \`last\` / \`negative\`) keep their existing semantics — they're inherently single-index or per-point so no tied-value case applies.

## Test plan

- [x] Visual: sample-7 Q7/Q8/Q9/Q10 sparklines now show every tied zero point as a dot.
- [x] No regression to sample-25 (sparkline groups with \`markers="1"\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)