### PR TITLE
chore(release): 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.18.1 — 2026-04-27
+
+Patch release. One sparkline correctness fix.
+
+- **Core sparkline** (`packages/core/src/sparkline/renderer.ts`):
+  - `computeFlagged` now marks **every** point tied for the high or low
+    value, not just the first occurrence. Excel does the same. Visible
+    on `private/sample-7.xlsx` Q10 (3 non-zero leading values + 9 zeros
+    under `low="1"`): all 9 zero points are now dotted. Other
+    highlights (`first` / `last` / `negative`) are unchanged — only
+    `high` / `low` had the tied-value case.
+
 ## 0.18.0 — 2026-04-27
 
 Minor release. Excel scatter / bubble charts gain a spec-faithful set of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Patch release. One sparkline correctness fix from PR #136.

- **Core sparkline**: `computeFlagged` now marks **every** point tied for the high or low value, not just the first occurrence. Visible on private/sample-7 Q10 (12-point series with 9 zeros under `low="1"` — Excel paints all 9 zero points; we were painting just one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)