### PR TITLE
fix(core): give sparkline lines proportional vertical padding

### DIFF
--- a/packages/core/src/sparkline/renderer.ts
+++ b/packages/core/src/sparkline/renderer.ts
@@ -60,11 +60,14 @@ export function renderSparkline(
   if (values.length === 0 || rect.w <= 0 || rect.h <= 0) return;
 
   // Inset the drawing area so strokes / markers don't kiss the cell edge.
-  // Half a pixel on each side is plenty at typical sizes; a marker radius
-  // worth on the top / bottom keeps high / low dots inside.
+  // Excel reserves ~20% of the cell height as top + bottom margin so the
+  // peak / trough of the line sits clearly inside the row separators
+  // rather than coinciding with them. The proportional rule scales with
+  // zoom so the breathing room stays visually consistent; floored at 2 px
+  // so tiny cells still get a hair of clearance.
   const series = model.colorSeries ?? '#5B9BD5';
   const PAD_X = Math.min(2, rect.w * 0.08);
-  const PAD_Y = Math.min(2, rect.h * 0.12);
+  const PAD_Y = Math.max(2, rect.h * 0.20);
   const dx = rect.x + PAD_X;
   const dy = rect.y + PAD_Y;
   const dw = Math.max(1, rect.w - PAD_X * 2);


### PR DESCRIPTION
## Summary

The sparkline renderer's \`PAD_Y\` was \`Math.min(2, rect.h * 0.12)\`, capped at 2 px. On typical row heights the peak / trough of the line and high / low marker dots ended up sitting on the row separators, so it visually read like the line was overlapping the cell border.

Switch to a proportional rule — \`Math.max(2, rect.h * 0.20)\` — so the inset scales with zoom and the breathing room stays consistent. The 2 px floor preserves a hair of clearance on tiny rows.

## Test plan

- [x] Visual: \`private/sample-7.xlsx\` Q7–Q10 — line and tied-low dots no longer touch the row borders.
- [x] Visual: \`private/sample-25.xlsx\` (sparklines with markers + first/last/high/low highlights) — markers stay inside the cell, first/last accents read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)