### PR TITLE
fix(xlsx,core): honor scatter axis line spPr + snap auto-derived range

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1399,6 +1399,17 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   if (chart.valMax != null) yMax = chart.valMax;
   if (chart.catAxisMin != null) xMin = chart.catAxisMin;
   if (chart.catAxisMax != null) xMax = chart.catAxisMax;
+  // Excel snaps auto-derived axis bounds outward to a multiple of the
+  // step so both ends land on round numbers (e.g. dates jump to a date
+  // before the first task and after the last). When the spec set min /
+  // max explicitly we leave them alone.
+  if (chart.catAxisMin == null || chart.catAxisMax == null) {
+    const step = niceStep(xMax - xMin);
+    if (step > 0) {
+      if (chart.catAxisMin == null) xMin = Math.floor(xMin / step) * step;
+      if (chart.catAxisMax == null) xMax = Math.ceil(xMax / step) * step;
+    }
+  }
 
   const toX = (v: number) => px0 + ((v - xMin) / (xMax - xMin)) * pw;
   const toY = (v: number) => py0 + ph - ((v - yMin) / (yMax - yMin)) * ph;
@@ -1442,11 +1453,24 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
 
   // X-axis line (always drawn — the timeline ruler in Gantt-style scatter
   // charts depends on this line's stroke). Tick labels are skipped when the
-  // category axis is hidden via `<c:delete val="1"/>`.
-  ctx.strokeStyle = '#888'; ctx.lineWidth = 1;
+  // category axis is hidden via `<c:delete val="1"/>`. Color and weight come
+  // from `<c:catAx><c:spPr><a:ln>` when present; default otherwise.
+  ctx.save();
+  ctx.strokeStyle = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#888';
+  ctx.lineWidth = chart.catAxisLineWidthEmu
+    ? Math.max(0.5, chart.catAxisLineWidthEmu / 12700)
+    : 1;
+  ctx.lineCap = 'butt';
   ctx.beginPath(); ctx.moveTo(px0, xAxisY); ctx.lineTo(px0 + pw, xAxisY); ctx.stroke();
+  ctx.restore();
   if (!chart.valAxisHidden) {
+    ctx.save();
+    ctx.strokeStyle = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#888';
+    ctx.lineWidth = chart.valAxisLineWidthEmu
+      ? Math.max(0.5, chart.valAxisLineWidthEmu / 12700)
+      : 1;
     ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+    ctx.restore();
   }
 
   // X-axis tick labels (catAxis), formatted via catAxisFormatCode (typically

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -248,6 +248,12 @@ export interface ChartModel {
   catAxisCrossesAt?: number | null;
   valAxisCrosses?: string | null;
   valAxisCrossesAt?: number | null;
+  /** Axis line color (hex without `#`) and width in EMU from
+   *  `<c:catAx|valAx><c:spPr><a:ln>`. */
+  catAxisLineColor?: string | null;
+  catAxisLineWidthEmu?: number | null;
+  valAxisLineColor?: string | null;
+  valAxisLineWidthEmu?: number | null;
   /**
    * `<c:catAx><c:numFmt@formatCode>` (or scatter X-axis valAx). When set,
    * the renderer formats X-axis tick labels with this code (e.g. dates).

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -498,6 +498,17 @@ pub struct ChartData {
     /// `<c:valAx><c:txPr>...defRPr@b>` — bold flag for Y-axis tick labels.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub val_axis_font_bold: Option<bool>,
+    /// `<c:catAx><c:spPr><a:ln>` resolved color (hex without `#`) and
+    /// width in EMU. Renders the X-axis line itself; default light gray
+    /// at 1 px when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_line_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_line_width_emu: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_line_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_line_width_emu: Option<u32>,
     /// `<c:catAx><c:crosses val>` — where the X axis sits along the Y axis
     /// (`autoZero` = at value 0, `min` = at the data min, `max` = at the
     /// data max). Default `autoZero`.
@@ -3437,6 +3448,10 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
     let mut val_axis_max: Option<f64> = None;
     let mut cat_axis_font_bold: Option<bool> = None;
     let mut val_axis_font_bold: Option<bool> = None;
+    let mut cat_axis_line_color: Option<String> = None;
+    let mut cat_axis_line_width_emu: Option<u32> = None;
+    let mut val_axis_line_color: Option<String> = None;
+    let mut val_axis_line_width_emu: Option<u32> = None;
     let mut cat_axis_crosses: Option<String> = None;
     let mut cat_axis_crosses_at: Option<f64> = None;
     let mut val_axis_crosses: Option<String> = None;
@@ -3480,6 +3495,11 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                 if cat_axis_font_bold.is_none() {
                     cat_axis_font_bold = extract_axis_tick_label_bold(&child, c_ns);
                 }
+                if cat_axis_line_color.is_none() || cat_axis_line_width_emu.is_none() {
+                    let (col, w) = extract_axis_line_style(&child, c_ns, theme_colors);
+                    if cat_axis_line_color.is_none() { cat_axis_line_color = col; }
+                    if cat_axis_line_width_emu.is_none() { cat_axis_line_width_emu = w; }
+                }
                 if let Some((mn, mx)) = extract_axis_scaling(&child, c_ns) {
                     if cat_axis_min.is_none() { cat_axis_min = mn; }
                     if cat_axis_max.is_none() { cat_axis_max = mx; }
@@ -3514,6 +3534,11 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                     if cat_axis_font_bold.is_none() {
                         cat_axis_font_bold = extract_axis_tick_label_bold(&child, c_ns);
                     }
+                    if cat_axis_line_color.is_none() || cat_axis_line_width_emu.is_none() {
+                        let (col, w) = extract_axis_line_style(&child, c_ns, theme_colors);
+                        if cat_axis_line_color.is_none() { cat_axis_line_color = col; }
+                        if cat_axis_line_width_emu.is_none() { cat_axis_line_width_emu = w; }
+                    }
                     let (cr, cra) = extract_axis_crosses(&child, c_ns);
                     if cat_axis_crosses.is_none() { cat_axis_crosses = cr; }
                     if cat_axis_crosses_at.is_none() { cat_axis_crosses_at = cra; }
@@ -3538,6 +3563,11 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                     let (cr, cra) = extract_axis_crosses(&child, c_ns);
                     if val_axis_crosses.is_none() { val_axis_crosses = cr; }
                     if val_axis_crosses_at.is_none() { val_axis_crosses_at = cra; }
+                    if val_axis_line_color.is_none() || val_axis_line_width_emu.is_none() {
+                        let (col, w) = extract_axis_line_style(&child, c_ns, theme_colors);
+                        if val_axis_line_color.is_none() { val_axis_line_color = col; }
+                        if val_axis_line_width_emu.is_none() { val_axis_line_width_emu = w; }
+                    }
                     if axis_is_deleted(&child, c_ns) { val_axis_hidden = true; }
                 }
                 continue;
@@ -3727,6 +3757,10 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
         cat_axis_crosses_at,
         val_axis_crosses,
         val_axis_crosses_at,
+        cat_axis_line_color,
+        cat_axis_line_width_emu,
+        val_axis_line_color,
+        val_axis_line_width_emu,
         cat_axis_font_size_hpt,
         val_axis_font_size_hpt,
         val_axis_format_code,
@@ -3756,6 +3790,22 @@ fn extract_axis_format_code(axis_node: &roxmltree::Node, c_ns: &str) -> Option<S
         .find(|n| n.tag_name().name() == "numFmt" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("formatCode").map(|s| s.to_string()))
         .filter(|s| !s.is_empty() && s != "General")
+}
+
+/// `<c:catAx|valAx><c:spPr><a:ln>` — resolved color (no `#`) and width
+/// (EMU) for the axis line itself. None when not set.
+fn extract_axis_line_style(
+    axis_node: &roxmltree::Node,
+    c_ns: &str,
+    theme_colors: &[String],
+) -> (Option<String>, Option<u32>) {
+    let Some(sp_pr) = axis_node.children()
+        .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns))
+    else { return (None, None); };
+    let Some(ln) = sp_pr.children().find(|n| n.tag_name().name() == "ln") else { return (None, None); };
+    let width = ln.attribute("w").and_then(|v| v.parse::<u32>().ok());
+    let color = extract_solid_fill_in_drawingml(&ln, theme_colors);
+    (color, width)
 }
 
 /// `<c:catAx|valAx><c:txPr>...defRPr@b>` — bold flag for axis tick labels.

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3638,6 +3638,10 @@ function adaptChartData(chart: ChartData): ChartModel {
     catAxisCrossesAt: chart.catAxisCrossesAt ?? null,
     valAxisCrosses: chart.valAxisCrosses ?? null,
     valAxisCrossesAt: chart.valAxisCrossesAt ?? null,
+    catAxisLineColor: chart.catAxisLineColor ?? null,
+    catAxisLineWidthEmu: chart.catAxisLineWidthEmu ?? null,
+    valAxisLineColor: chart.valAxisLineColor ?? null,
+    valAxisLineWidthEmu: chart.valAxisLineWidthEmu ?? null,
     series: chart.series.map(s => ({
       name: s.name,
       color: s.color ?? null,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -318,6 +318,12 @@ export interface ChartData {
   catAxisCrossesAt?: number;
   valAxisCrosses?: string;
   valAxisCrossesAt?: number;
+  /** Axis line color (hex without `#`) and width in EMU, from
+   *  `<c:catAx|valAx><c:spPr><a:ln>`. */
+  catAxisLineColor?: string;
+  catAxisLineWidthEmu?: number;
+  valAxisLineColor?: string;
+  valAxisLineWidthEmu?: number;
   /** `<c:catAx><c:numFmt@formatCode>` (or scatter X-axis valAx). */
   catAxisFormatCode?: string;
   /** `<c:catAx><c:scaling><c:min/max>` — explicit X-axis range. */


### PR DESCRIPTION
## Summary

Two more scatter-chart spec gaps on \`private/sample-26\`:

### 1. Axis line styling (\`<c:catAx|valAx><c:spPr><a:ln>\`)

Sample-26's catAx has \`<a:ln w="63500"><a:schemeClr val="tx1"><a:lumMod 50000/><a:lumOff 50000/>\` — a **5 pt 50 % gray timeline ruler**. We were drawing every axis as a hardcoded 1 px gray line. Parse axis-line width + color (theme refs resolved via the existing helper) and apply.

### 2. Auto-derived range collapsed to data extent

Excel snaps both ends of an auto-derived axis outward to a multiple of the major step so the range covers round values. For sample-26's data (2018/3/28 .. 2018/9/10 in scatter X) Excel produces an axis spanning **2018/2/19 .. 2018/10/27** in 50-day steps. We were using the raw data extents, so labels started at 3/28/2018 and the bracket was visually tighter than Excel.

Snap via \`niceStep\` when \`<c:catAx><c:scaling><c:min/max>\` aren't explicitly set. Explicit min/max remain authoritative (sample-26's hidden Y axis with \`<c:scaling><c:min=-100 max=50/>\` is unchanged).

## Test plan

- [x] Visual: private/sample-26 X-axis is now 5 pt gray and runs 2/19/2018 .. 10/27/2018, matching Excel.
- [x] No regression to private/sample-25 sparklines, sample-7 sparklines.

## Notes

The user also asked about cell E31 wrapping (\`タスク 1\\n3 月 28 日 - 4 月 11 日\` shows on 2 lines for us, 1 line in Excel). That's a separate row-height-clipping issue that this PR doesn't address — the cell text genuinely contains \`CHAR(10)\` from a formula, and Excel hides the second line because the row is height-locked at 18 pt. Tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)