### PR TITLE
fix(xlsx,core): honor <c:majorTickMark>/<c:minorTickMark> on chart axes

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -449,16 +449,23 @@ function drawLegendForLayout(
 
 function drawAxisTick(
   ctx: CanvasRenderingContext2D,
-  mode: string,
+  mode: string | null | undefined,
   axis: 'val' | 'cat',
   anchorXOrY: number,
   perpendicular: number,
+  color?: string,
+  lineWidth?: number,
 ): void {
   if (mode === 'none' || !mode) return;
-  const len = 4;
-  const prev = ctx.strokeStyle;
-  ctx.strokeStyle = '#888';
-  ctx.lineWidth = 1;
+  // Tick length scales mildly with the axis line weight so a thick
+  // ruler-style axis (e.g. Vertex42 Gantt 5 pt) produces ticks that
+  // are visible without being huge.
+  const baseLen = 4;
+  const len = lineWidth ? Math.max(baseLen, lineWidth + 2) : baseLen;
+  const prevS = ctx.strokeStyle;
+  const prevW = ctx.lineWidth;
+  ctx.strokeStyle = color ?? '#888';
+  ctx.lineWidth = lineWidth ?? 1;
   ctx.beginPath();
   if (axis === 'val') {
     // val axis is vertical (x = anchor, y varies). Ticks extend horizontally.
@@ -478,7 +485,8 @@ function drawAxisTick(
     ctx.lineTo(xc, y0 + inner);
   }
   ctx.stroke();
-  ctx.strokeStyle = prev;
+  ctx.strokeStyle = prevS;
+  ctx.lineWidth = prevW;
 }
 
 function chartTitleFontPx(chart: ChartModel, h: number, ptToPx: number): number {
@@ -1414,7 +1422,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   const toX = (v: number) => px0 + ((v - xMin) / (xMax - xMin)) * pw;
   const toY = (v: number) => py0 + ph - ((v - yMin) / (yMax - yMin)) * ph;
 
-  // Y-axis gridlines + labels.
+  // Y-axis gridlines + labels + major tick marks.
   if (!chart.valAxisHidden) {
     const yTickFontPx = Math.max(8, Math.min(11, ph / 20));
     ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${yTickFontPx}px sans-serif`;
@@ -1427,6 +1435,10 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
       ctx.fillStyle = '#555'; ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
       ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
+      const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
+      const yAxisLineWidth = chart.valAxisLineWidthEmu
+        ? Math.max(0.5, chart.valAxisLineWidthEmu / 12700) : undefined;
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, yAxisLineColor, yAxisLineWidth);
     }
   }
 
@@ -1476,7 +1488,10 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   // X-axis tick labels (catAxis), formatted via catAxisFormatCode (typically
   // a date code like "m/d/yyyy"). Skipped when catAxisHidden. Drawn just
   // below the axis line wherever it sits (axis crossing in the middle of
-  // the plot still anchors the labels to the line itself).
+  // the plot still anchors the labels to the line itself). Major tick
+  // marks also get drawn here so `<c:majorTickMark val="cross">` produces
+  // the crossing ruler look that templates like the Vertex42 timeline
+  // depend on.
   if (!chart.catAxisHidden) {
     const tickFontPx = Math.max(8, Math.min(11, ph / 20));
     ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${tickFontPx}px sans-serif`;
@@ -1487,6 +1502,10 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       const v = xMin + si * xStep; if (v > xMax + xStep * 0.01) break;
       const gx = toX(v);
       ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode), gx, xAxisY + 4);
+      const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
+      const xAxisLineWidth = chart.catAxisLineWidthEmu
+        ? Math.max(0.5, chart.catAxisLineWidthEmu / 12700) : undefined;
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, xAxisLineWidth);
     }
   }
 

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -181,6 +181,9 @@ export interface ChartModel {
   valAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
   /** `<c:catAx><c:majorTickMark>`. */
   catAxisMajorTickMark: 'cross' | 'out' | 'in' | 'none' | string;
+  /** `<c:valAx | catAx><c:minorTickMark>`. ECMA-376 default is "none". */
+  valAxisMinorTickMark?: 'cross' | 'out' | 'in' | 'none' | string | null;
+  catAxisMinorTickMark?: 'cross' | 'out' | 'in' | 'none' | string | null;
   /** Title font size in OOXML hundredths of a point (1600 = 16pt). null = default. */
   titleFontSizeHpt: number | null;
   /** Title font color as a hex string without '#' (e.g. "1B4332"). null = default. */

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -498,6 +498,18 @@ pub struct ChartData {
     /// `<c:valAx><c:txPr>...defRPr@b>` — bold flag for Y-axis tick labels.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub val_axis_font_bold: Option<bool>,
+    /// `<c:catAx><c:majorTickMark val>` (ECMA-376 §21.2.2.49) — one of
+    /// `none` / `out` / `in` / `cross`. Default `out`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_major_tick_mark: Option<String>,
+    /// `<c:catAx><c:minorTickMark val>` — same vocabulary. Default `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_minor_tick_mark: Option<String>,
+    /// `<c:valAx><c:majorTickMark val>` and `<c:minorTickMark val>`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_major_tick_mark: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_tick_mark: Option<String>,
     /// `<c:catAx><c:spPr><a:ln>` resolved color (hex without `#`) and
     /// width in EMU. Renders the X-axis line itself; default light gray
     /// at 1 px when absent.
@@ -3452,6 +3464,10 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
     let mut cat_axis_line_width_emu: Option<u32> = None;
     let mut val_axis_line_color: Option<String> = None;
     let mut val_axis_line_width_emu: Option<u32> = None;
+    let mut cat_axis_major_tick_mark: Option<String> = None;
+    let mut cat_axis_minor_tick_mark: Option<String> = None;
+    let mut val_axis_major_tick_mark: Option<String> = None;
+    let mut val_axis_minor_tick_mark: Option<String> = None;
     let mut cat_axis_crosses: Option<String> = None;
     let mut cat_axis_crosses_at: Option<f64> = None;
     let mut val_axis_crosses: Option<String> = None;
@@ -3500,6 +3516,12 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                     if cat_axis_line_color.is_none() { cat_axis_line_color = col; }
                     if cat_axis_line_width_emu.is_none() { cat_axis_line_width_emu = w; }
                 }
+                if cat_axis_major_tick_mark.is_none() {
+                    cat_axis_major_tick_mark = extract_axis_tick_mark(&child, c_ns, "majorTickMark");
+                }
+                if cat_axis_minor_tick_mark.is_none() {
+                    cat_axis_minor_tick_mark = extract_axis_tick_mark(&child, c_ns, "minorTickMark");
+                }
                 if let Some((mn, mx)) = extract_axis_scaling(&child, c_ns) {
                     if cat_axis_min.is_none() { cat_axis_min = mn; }
                     if cat_axis_max.is_none() { cat_axis_max = mx; }
@@ -3539,6 +3561,12 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                         if cat_axis_line_color.is_none() { cat_axis_line_color = col; }
                         if cat_axis_line_width_emu.is_none() { cat_axis_line_width_emu = w; }
                     }
+                    if cat_axis_major_tick_mark.is_none() {
+                        cat_axis_major_tick_mark = extract_axis_tick_mark(&child, c_ns, "majorTickMark");
+                    }
+                    if cat_axis_minor_tick_mark.is_none() {
+                        cat_axis_minor_tick_mark = extract_axis_tick_mark(&child, c_ns, "minorTickMark");
+                    }
                     let (cr, cra) = extract_axis_crosses(&child, c_ns);
                     if cat_axis_crosses.is_none() { cat_axis_crosses = cr; }
                     if cat_axis_crosses_at.is_none() { cat_axis_crosses_at = cra; }
@@ -3567,6 +3595,12 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                         let (col, w) = extract_axis_line_style(&child, c_ns, theme_colors);
                         if val_axis_line_color.is_none() { val_axis_line_color = col; }
                         if val_axis_line_width_emu.is_none() { val_axis_line_width_emu = w; }
+                    }
+                    if val_axis_major_tick_mark.is_none() {
+                        val_axis_major_tick_mark = extract_axis_tick_mark(&child, c_ns, "majorTickMark");
+                    }
+                    if val_axis_minor_tick_mark.is_none() {
+                        val_axis_minor_tick_mark = extract_axis_tick_mark(&child, c_ns, "minorTickMark");
                     }
                     if axis_is_deleted(&child, c_ns) { val_axis_hidden = true; }
                 }
@@ -3761,6 +3795,10 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
         cat_axis_line_width_emu,
         val_axis_line_color,
         val_axis_line_width_emu,
+        cat_axis_major_tick_mark,
+        cat_axis_minor_tick_mark,
+        val_axis_major_tick_mark,
+        val_axis_minor_tick_mark,
         cat_axis_font_size_hpt,
         val_axis_font_size_hpt,
         val_axis_format_code,
@@ -3790,6 +3828,15 @@ fn extract_axis_format_code(axis_node: &roxmltree::Node, c_ns: &str) -> Option<S
         .find(|n| n.tag_name().name() == "numFmt" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("formatCode").map(|s| s.to_string()))
         .filter(|s| !s.is_empty() && s != "General")
+}
+
+/// `<c:catAx|valAx><c:majorTickMark val>` / `<c:minorTickMark val>` —
+/// `none` / `out` / `in` / `cross` (ECMA-376 §21.2.2.49 ST_TickMark).
+fn extract_axis_tick_mark(axis_node: &roxmltree::Node, c_ns: &str, name: &str) -> Option<String> {
+    axis_node.children()
+        .find(|n| n.tag_name().name() == name && n.tag_name().namespace() == Some(c_ns))
+        .and_then(|n| n.attribute("val"))
+        .map(|s| s.to_string())
 }
 
 /// `<c:catAx|valAx><c:spPr><a:ln>` — resolved color (no `#`) and width

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3680,8 +3680,14 @@ function adaptChartData(chart: ChartData): ChartModel {
     showLegend: chart.showLegend ?? false,
     legendPos: chart.legendPos ?? null,
     catAxisCrossBetween: 'between',
-    valAxisMajorTickMark: 'cross',
-    catAxisMajorTickMark: 'cross',
+    // Default `out` per ECMA-376 §21.2.2.49 ST_TickMark when the spec
+    // didn't say. (We previously hard-coded `cross` which made every
+    // chart pretend it had crossing ticks even when the file said
+    // none / out.)
+    valAxisMajorTickMark: chart.valAxisMajorTickMark ?? 'out',
+    catAxisMajorTickMark: chart.catAxisMajorTickMark ?? 'out',
+    valAxisMinorTickMark: chart.valAxisMinorTickMark ?? null,
+    catAxisMinorTickMark: chart.catAxisMinorTickMark ?? null,
     titleFontSizeHpt: chart.titleFontSizeHpt ?? null,
     titleFontColor: chart.titleFontColor ?? null,
     titleFontFace: chart.titleFontFace ?? null,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -324,6 +324,12 @@ export interface ChartData {
   catAxisLineWidthEmu?: number;
   valAxisLineColor?: string;
   valAxisLineWidthEmu?: number;
+  /** `<c:catAx | valAx><c:majorTickMark val>` / `<c:minorTickMark val>` —
+   *  one of `none`/`out`/`in`/`cross` (ECMA-376 §21.2.2.49). */
+  catAxisMajorTickMark?: string;
+  catAxisMinorTickMark?: string;
+  valAxisMajorTickMark?: string;
+  valAxisMinorTickMark?: string;
   /** `<c:catAx><c:numFmt@formatCode>` (or scatter X-axis valAx). */
   catAxisFormatCode?: string;
   /** `<c:catAx><c:scaling><c:min/max>` — explicit X-axis range. */


### PR DESCRIPTION
## Summary

The XLSX adapter was **hard-coding** \`valAxisMajorTickMark\` and \`catAxisMajorTickMark\` to \`"cross"\` before passing the chart to the core renderer:

\`\`\`ts
valAxisMajorTickMark: 'cross',
catAxisMajorTickMark: 'cross',
\`\`\`

So the spec value was being ignored. Sample-26 has \`<c:majorTickMark val="cross"/>\` on the X-axis, which happened to match — but on charts that say \`out\` or \`none\` we were still drawing crossing ticks.

Even with the right value, scatter charts weren't drawing axis ticks at all (only bar / line / area / radar / pie did via their internal loops; scatter never called \`drawAxisTick\`).

## Fix

- Parse \`<c:catAx | valAx><c:majorTickMark>\` and \`<c:minorTickMark>\` into ChartData.
- Adapter forwards parsed strings (default \`out\` per ECMA-376 §21.2.2.49 ST_TickMark).
- ChartModel gains optional \`catAxisMinorTickMark\` / \`valAxisMinorTickMark\`.
- \`renderScatterChart\` calls \`drawAxisTick\` at every major tick on both axes.
- \`drawAxisTick\` accepts optional axis line color + width so a thick \`<c:spPr><a:ln>\` ruler (e.g. sample-26's 5 pt) gets matching tick strokes; tick length scales mildly with line weight.

## Test plan

- [x] Visual: private/sample-26 X-axis shows crossing notches at each major date label, matching Excel.
- [x] No regression to private/sample-25 / sample-7 (sparklines unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)