### PR TITLE
fix(xlsx): preload Carlito/Caladea so Calibri text matches Excel widths

### DIFF
--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -40,6 +40,7 @@ export function buildViewerUI(
 
   const viewer = new XlsxViewer(viewerContainer, {
     cellScale: args.scale,
+    useGoogleFonts: true,
     onReady: (names) => {
       status.textContent = `Loaded — ${names.length} sheet(s)`;
     },
@@ -138,6 +139,7 @@ export const FileUpload: Story = {
       viewerContainer.innerHTML = '';
       viewer = new XlsxViewer(viewerContainer, {
         cellScale: args.scale,
+        useGoogleFonts: true,
         onReady: (names) => { status.textContent = `${names.length} sheet(s)`; },
         onSheetChange: (_idx, name) => { status.textContent = `Sheet: ${name}`; },
         onError: (err) => { status.textContent = `Error: ${err.message}`; },

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -6,7 +6,16 @@ import type {
 } from './types.js';
 import { renderChart, renderSparkline, type ChartModel, type SparklineModel } from '@silurus/ooxml-core';
 
-const DEFAULT_FONT_FAMILY = 'Calibri, Arial, sans-serif';
+// Default font stack. Calibri is the workbook default font in Excel; on
+// systems without Office (macOS / Linux) the browser would otherwise fall
+// back to Arial / Helvetica, which is meaningfully wider than Calibri at
+// every weight/size combination. Carlito is the Google-released, metric-
+// compatible Calibri clone (same advance widths and ascender / descender
+// metrics) and is loaded opt-in by `XlsxWorkbook.load({ useGoogleFonts:
+// true })`. Listing it in the cascade means: Calibri (Windows / Office)
+// → Carlito (loaded webfont) → Arial → sans-serif. Caladea is the same
+// for Cambria.
+const DEFAULT_FONT_FAMILY = '"Calibri", "Carlito", "Cambria", "Caladea", Arial, sans-serif';
 const DEFAULT_FONT_SIZE = 11;
 const MDW = 7;
 const ROW_HEIGHT_TO_PX = 4 / 3;

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -12,6 +12,14 @@ export interface XlsxViewerOptions {
   onError?: (err: Error) => void;
   /** Called when the selected cell range changes. null means no selection. */
   onSelectionChange?: (selection: CellRange | null) => void;
+  /**
+   * Opt in to Google-Fonts-hosted, metric-compatible substitutes for the
+   * Office default fonts (Carlito for Calibri, Caladea for Cambria) so
+   * column layouts match Excel on systems without Office installed.
+   * Default `false`. See `XlsxWorkbook.LoadOptions.useGoogleFonts` for the
+   * privacy implications.
+   */
+  useGoogleFonts?: boolean;
 }
 
 export interface CellAddress {
@@ -114,7 +122,7 @@ export class XlsxViewer {
 
   async load(source: string | ArrayBuffer): Promise<void> {
     try {
-      await this.wb.load(source);
+      await this.wb.load(source, { useGoogleFonts: this.opts.useGoogleFonts });
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
       await this.showSheet(0);

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -3,6 +3,76 @@ import wasmAssetUrl from './wasm/xlsx_parser_bg.wasm?url';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, WorkerResponse } from './types.js';
 import { renderViewport } from './renderer.js';
 
+/** Office font name → Google Fonts URL for a metric-compatible substitute.
+ *  These pairings are the well-known Office substitutes that Microsoft and
+ *  Google both publish and ship on Linux distributions:
+ *    Calibri → Carlito (same metrics — advance widths, ascender / descender)
+ *    Cambria → Caladea (likewise)
+ *  Loading them on a system that lacks Calibri / Cambria (macOS, Linux
+ *  without Office) keeps text width measurements close to Excel's. */
+const OFFICE_FONT_FALLBACK_MAP: Record<string, string> = {
+  'calibri': 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap',
+  'cambria': 'https://fonts.googleapis.com/css2?family=Caladea:ital,wght@0,400;0,700;1,400;1,700&display=swap',
+};
+
+async function preloadOfficeFonts(fontNames: Iterable<string>): Promise<void> {
+  if (typeof document === 'undefined') return;
+  const seen = new Set<string>();
+  const families: string[] = [];
+  for (const name of fontNames) {
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const url = OFFICE_FONT_FALLBACK_MAP[key];
+    if (!url) continue;
+    if (document.querySelector(`link[href="${url}"]`)) continue;
+    try {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = url;
+      document.head.appendChild(link);
+    } catch {
+      // Network or DOM error — silently skip; renderer falls back to system fonts.
+    }
+    // We need the *substitute* family loaded into FontFaceSet, not the
+    // requested Office name. Map calibri → Carlito, cambria → Caladea.
+    families.push(key === 'calibri' ? 'Carlito' : key === 'cambria' ? 'Caladea' : name);
+  }
+  // Trigger explicit loads so Canvas measureText sees real glyph metrics
+  // before the first render. @font-face declarations alone don't fetch.
+  const loads: Promise<unknown>[] = [];
+  for (const family of families) {
+    for (const weight of ['400', '700']) {
+      for (const style of ['normal', 'italic']) {
+        loads.push(
+          document.fonts.load(`${style} ${weight} 16px "${family}"`).catch(() => undefined),
+        );
+      }
+    }
+  }
+  await Promise.race([
+    Promise.all(loads).then(() => document.fonts.ready),
+    new Promise<void>((resolve) => setTimeout(resolve, 3000)),
+  ]);
+}
+
+/** Options for {@link XlsxWorkbook.load}. */
+export interface LoadOptions {
+  /**
+   * Opt in to loading Office-font metric substitutes (Carlito for Calibri,
+   * Caladea for Cambria) from Google Fonts (`fonts.googleapis.com`). Without
+   * these the canvas falls back to system Arial / Helvetica which is
+   * noticeably wider per character, so column layouts diverge from Excel.
+   *
+   * When enabled, end-user IP / User-Agent is sent to Google, which may have
+   * privacy / GDPR implications for your application. Default `false` — host
+   * the substitute webfonts yourself and reference them via `@font-face` in
+   * your application CSS to avoid the third-party request.
+   */
+  useGoogleFonts?: boolean;
+}
+
 export class XlsxWorkbook {
   private worker: Worker;
   private parsedWorkbook: ParsedWorkbook | null = null;
@@ -17,13 +87,24 @@ export class XlsxWorkbook {
     this.worker.postMessage({ type: 'init', wasmUrl });
   }
 
-  async load(source: string | ArrayBuffer): Promise<void> {
+  async load(source: string | ArrayBuffer, opts: LoadOptions = {}): Promise<void> {
     const data =
       typeof source === 'string'
         ? await fetch(source).then((r) => r.arrayBuffer())
         : source;
     this.rawData = data;
     this.parsedWorkbook = await this.sendMessage({ type: 'parse', data: data.slice(0) }) as ParsedWorkbook;
+    if (opts.useGoogleFonts) {
+      // Walk every styled font in the workbook and queue Google Fonts
+      // substitutes for any Office faces (Calibri → Carlito, Cambria →
+      // Caladea). Documents that use only system fonts produce zero
+      // network requests.
+      const names = new Set<string>();
+      for (const f of this.parsedWorkbook.styles?.fonts ?? []) {
+        if (f.name) names.add(f.name);
+      }
+      await preloadOfficeFonts(names);
+    }
   }
 
   get sheetNames(): string[] {


### PR DESCRIPTION
## Summary

Cells styled with Calibri (Excel's workbook default font) fell back to system **Arial / Helvetica** on macOS / Linux, which is noticeably wider per character at every weight × size. Visible on \`demo/sample-1\`: the B2 title \`Evergreen Research Reserve\` overflowed past column F instead of stopping inside column E like Excel.

## Root cause

The font cascade was \`Calibri, Arial, sans-serif\`. On systems without Office installed, neither Calibri nor any metric-compatible substitute was on the system, so the browser jumped straight to Arial. Arial advance widths are ~10–15 % wider than Calibri.

## Fix

[Carlito](https://fonts.google.com/specimen/Carlito) and [Caladea](https://fonts.google.com/specimen/Caladea) are Google's open-source releases that are *metric compatible* with Calibri and Cambria — same advance widths, ascender / descender, x-height. Loading them gives Excel-equivalent measurements without requiring Office.

- New opt-in \`useGoogleFonts\` on \`XlsxWorkbook.load\` (and forwarded from \`XlsxViewer\`'s constructor option). Default **off** — zero third-party requests unless the host opts in. Mirrors existing PPTX plumbing.
- When enabled, scans the workbook's styles fonts and pulls the matching Google Fonts stylesheet for any Office face it finds. Loads weights 400 / 700 in normal + italic with a 3 s timeout; \`document.fonts.ready\` is awaited so the first paint already has correct metrics.
- \`DEFAULT_FONT_FAMILY\` updated to: \`"Calibri", "Carlito", "Cambria", "Caladea", Arial, sans-serif\`. Calibri / Cambria still win on Windows / Office; the substitutes only kick in on systems that lack the Microsoft faces.
- Storybook stories opt in so the bundled demo shows Excel-matching layout out of the box.

## Test plan

- [x] Visual: \`demo/sample-1\` B2 title now lands inside column E, matching the Excel screenshot the user shared.
- [x] \`Plots (ha)\` column on \`Regional Overview\` no longer overflows to \`###\`.
- [x] No regression to charts (sample-26 Gantt) / sparklines (sample-7, sample-25).
- [x] \`tsc --build\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)