### PR TITLE
feat(xlsx): support centerContinuous / fill / distributed / justify / readingOrder cell alignment

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1013,6 +1013,10 @@ pub struct CellXf {
     /// Shrink text to fit the cell width (ECMA-376 §18.8.44)
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub shrink_to_fit: bool,
+    /// `<alignment readingOrder>` (ECMA-376 §18.8.1) — 0 = context (default),
+    /// 1 = left-to-right, 2 = right-to-left. Drives canvas `direction`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reading_order: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -1328,7 +1332,17 @@ fn resolve_sheet_path(doc: &roxmltree::Document, r_id: &str) -> Option<String> {
     for node in doc.descendants() {
         if node.tag_name().name() == "Relationship" && node.tag_name().namespace() == Some(ns) {
             if node.attribute("Id") == Some(r_id) {
-                return node.attribute("Target").map(|s| s.to_string());
+                let target = node.attribute("Target")?;
+                // ECMA-376 / Open Packaging Conventions: Target may be a
+                // package-absolute path (`/xl/worksheets/sheet1.xml`, used
+                // by openpyxl and some online tools) or a path relative to
+                // the .rels file's parent (`worksheets/sheet1.xml`, the
+                // common Office-saved form). Callers prepend `xl/` to the
+                // returned value, so strip a leading `/xl/` to convert
+                // absolute paths into the relative form they expect.
+                let t = target.strip_prefix('/').unwrap_or(target);
+                let t = t.strip_prefix("xl/").unwrap_or(t);
+                return Some(t.to_string());
             }
         }
     }
@@ -1687,6 +1701,7 @@ fn parse_cell_xfs(doc: &roxmltree::Document, ns: &str) -> Vec<CellXf> {
                 let mut indent = None;
                 let mut text_rotation = None;
                 let mut shrink_to_fit = false;
+                let mut reading_order: Option<u32> = None;
                 for child in xf_node.children() {
                     if child.tag_name().name() == "alignment" {
                         align_h = child.attribute("horizontal").map(|s| s.to_string());
@@ -1695,9 +1710,10 @@ fn parse_cell_xfs(doc: &roxmltree::Document, ns: &str) -> Vec<CellXf> {
                         indent = child.attribute("indent").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
                         text_rotation = child.attribute("textRotation").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
                         shrink_to_fit = child.attribute("shrinkToFit").map(|v| v == "1" || v == "true").unwrap_or(false);
+                        reading_order = child.attribute("readingOrder").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
                     }
                 }
-                xfs.push(CellXf { font_id, fill_id, border_id, num_fmt_id, align_h, align_v, wrap_text, indent, text_rotation, shrink_to_fit });
+                xfs.push(CellXf { font_id, fill_id, border_id, num_fmt_id, align_h, align_v, wrap_text, indent, text_rotation, shrink_to_fit, reading_order });
             }
             break;
         }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2526,6 +2526,27 @@ function renderQuadrant(
       const iconPad = iconSz > 0 ? iconSz + 4 : 0;
       const leftPad = paddingX + (alignH === 'left' || !xf.alignH ? indentPx : 0) + iconPad;
 
+      // ECMA-376 §18.18.40 ST_HorizontalAlignment value `centerContinuous`:
+      // text is centered across the **selection range** — the leftmost cell
+      // with content + adjacent empty cells to the right that also carry
+      // `centerContinuous`. Cells stay independent (unlike merge), but the
+      // centering uses the combined width. Walk right collecting empty
+      // centerContinuous neighbours so we know how wide to center over.
+      let centerContinuousW = cellW;
+      let centerContinuousX = cx;
+      if (alignH === 'centerContinuous' && !mergeInfo) {
+        for (let oci = ci + 1; oci < numCols; oci++) {
+          const adjKey = `${rowIndex}:${startCol + oci}`;
+          if (mergeSkipSet.has(adjKey) || mergeAnchorMap.has(adjKey)) break;
+          const adjCell = cellMap.get(adjKey);
+          if (adjCell && adjCell.value.type !== 'empty') break;
+          const adjStyleIndex = adjCell?.styleIndex ?? 0;
+          const adjXf = resolveXf(styles, adjStyleIndex).xf;
+          if (adjXf.alignH !== 'centerContinuous') break;
+          centerContinuousW += colWidths[oci];
+        }
+      }
+
       // Text overflow into adjacent empty cells (ECMA-376 §18.3.1.4 "spans"
       // — Excel behavior when `wrapText=false`). Left-aligned text flows
       // rightward, right-aligned flows leftward, and centered splits evenly.
@@ -2537,9 +2558,10 @@ function renderQuadrant(
       // Excel only overflows text into adjacent empty cells; numeric values
       // that don't fit are rendered as "####" (they never spill). Cells
       // containing hard line breaks render multi-line in place, so they don't
-      // overflow either.
+      // overflow either. Skip overflow for centerContinuous — its centering
+      // is across the selection range, handled below.
       const hasHardBreak = text.includes('\n');
-      if (!mergeInfo && !xf.wrapText && !xf.textRotation && !isNumeric && !hasHardBreak) {
+      if (!mergeInfo && !xf.wrapText && !xf.textRotation && !isNumeric && !hasHardBreak && alignH !== 'centerContinuous') {
         const textW = ctx.measureText(text).width;
         const textPx = textW + leftPad + paddingX;
         if (textPx > cellW) {
@@ -2580,6 +2602,37 @@ function renderQuadrant(
         }
       }
 
+      // ECMA-376 §18.18.40 horizontal alignment:
+      // - `fill`: repeat the cell content until the cell fills horizontally.
+      //   We resolve to the repeated string here; layout is then standard
+      //   left-aligned.
+      // - `distributed`: distribute characters evenly across the cell width
+      //   so the first char hugs the left edge and the last hugs the right.
+      //   Implemented via Canvas `letterSpacing` (a string CSS length).
+      // - `justify`: full-line justification. Multi-line distribution would
+      //   need the wrap engine; for the single-line case we fall back to
+      //   `distributed` if the text is short, else left-aligned (matches
+      //   what Excel does when justify cannot expand a one-line string).
+      // Anything we don't recognise falls through to left-align (general).
+      let drawText = text;
+      let letterSpacingPx = 0;
+      if (alignH === 'fill' && !isNumeric && text.length > 0) {
+        const innerW = Math.max(1, cellW - paddingX * 2);
+        const oneW = ctx.measureText(text).width;
+        if (oneW > 0 && oneW < innerW) {
+          const reps = Math.max(1, Math.floor(innerW / oneW));
+          drawText = text.repeat(reps);
+        }
+      }
+      if (alignH === 'distributed' || (alignH === 'justify' && !xf.wrapText && !hasHardBreak)) {
+        const innerW = Math.max(1, cellW - paddingX * 2);
+        const naturalW = ctx.measureText(drawText).width;
+        const gaps = Math.max(1, [...drawText].length - 1);
+        if (naturalW < innerW) {
+          letterSpacingPx = Math.max(0, (innerW - naturalW) / gaps);
+        }
+      }
+
       let textX: number;
       let textAlign: CanvasTextAlign;
       if (alignH === 'right') {
@@ -2588,6 +2641,16 @@ function renderQuadrant(
       } else if (alignH === 'center') {
         textX = cx + cellW / 2;
         textAlign = 'center';
+      } else if (alignH === 'centerContinuous') {
+        textX = centerContinuousX + centerContinuousW / 2;
+        textAlign = 'center';
+        // Expand the draw rect so the clip below covers the whole span.
+        drawX = centerContinuousX;
+        drawW = centerContinuousW;
+      } else if (alignH === 'distributed' || (alignH === 'justify' && !xf.wrapText && !hasHardBreak)) {
+        // Distribute characters evenly: first hugs left edge, last hugs right.
+        textX = cx + paddingX;
+        textAlign = 'left';
       } else {
         textX = cx + leftPad;
         textAlign = 'left';
@@ -2657,6 +2720,18 @@ function renderQuadrant(
       }
 
       ctx.textAlign = textAlign;
+      // ECMA-376 §18.18.39 distributed / §18.18.40 readingOrder. Canvas
+      // `letterSpacing` (CSS length string, supported in modern browsers)
+      // implements distributed by stretching the gap between glyphs;
+      // `direction` flips the writing direction for RTL languages.
+      if (letterSpacingPx > 0) {
+        try { (ctx as CanvasRenderingContext2D & { letterSpacing: string }).letterSpacing = `${letterSpacingPx}px`; } catch { /* ignore */ }
+      }
+      if (xf.readingOrder === 2) {
+        try { (ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' }).direction = 'rtl'; } catch { /* ignore */ }
+      } else if (xf.readingOrder === 1) {
+        try { (ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' }).direction = 'ltr'; } catch { /* ignore */ }
+      }
 
       // Rich text: draw each run with its own font. Only supported for the
       // non-wrap path (wrap with mixed fonts is significantly more complex).
@@ -2829,7 +2904,7 @@ function renderQuadrant(
           if (alignV === 'top') { ctx.textBaseline = 'top'; textY = cy + paddingY; }
           else if (alignV === 'center') { ctx.textBaseline = 'middle'; textY = cy + cellH / 2; }
           else { ctx.textBaseline = 'bottom'; textY = cy + cellH - paddingY; }
-          ctx.fillText(text, textX, textY);
+          ctx.fillText(drawText, textX, textY);
         }
       }
 

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -612,6 +612,9 @@ export interface CellXf {
   /** Text rotation: 1–90 = counter-clockwise °, 91–180 = (val−90)° clockwise, 255 = stacked */
   textRotation?: number;
   shrinkToFit?: boolean;
+  /** `<alignment readingOrder>` (ECMA-376 §18.8.1) — 0 = context (default),
+   *  1 = LTR, 2 = RTL. Drives canvas `direction`. */
+  readingOrder?: number;
 }
 
 export interface ParsedWorkbook {


### PR DESCRIPTION
## Summary

We only handled \`left\` / \`center\` / \`right\` for \`<alignment horizontal>\`; everything else (\`centerContinuous\`, \`fill\`, \`distributed\`, \`justify\`, \`general\`) silently fell through to left, and RTL via \`readingOrder\` was ignored.

This PR covers the full ECMA-376 §18.18.40 ST_HorizontalAlignment vocabulary except multi-line \`justify\` / \`distributed\` (those need wrap-engine integration — tracked separately).

| Option | Behavior |
|--------|----------|
| **centerContinuous** | Walk right collecting empty \`centerContinuous\` neighbours, center the leftmost cell's text across the combined width. Cells stay independent (unlike merge). Stops at non-empty cells, merge boundaries, or non-\`centerContinuous\` neighbours. |
| **fill** | Repeat cell content to fill the cell width (only for non-numeric non-empty text). |
| **distributed** | Distribute glyphs evenly via Canvas \`letterSpacing\` so the first character hugs the left edge and the last hugs the right. |
| **justify** (single-line) | Same as \`distributed\`. Multi-line still falls back to left until the wrap engine can split-and-justify. |
| **readingOrder=2** | \`ctx.direction = 'rtl'\` so Arabic / Hebrew cells render with the spec'd direction. |

Parser also captures \`<alignment readingOrder>\` into \`CellXf.reading_order\`.

## Drive-by parser fix

\`resolve_sheet_path\` now strips a leading \`/\` and a leading \`xl/\` from the relationship \`Target\` so package-absolute paths (used by openpyxl and some online tools — e.g. \`Target="/xl/worksheets/sheet1.xml"\`) resolve correctly. Excel-saved files use relative paths and aren't affected.

## Test plan

- [x] Synthetic alignment test fixture — every option renders correctly.
- [x] No regression to existing samples (sample-1, sample-25, sample-26).
- [x] \`tsc --build\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)