### PR TITLE
chore(release): 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.21.0 — 2026-04-29
+
+Patch-level release. XLSX overflow rendering fixes and refreshed project icon.
+
+- **XLSX engine** (`packages/xlsx`):
+  - **`centerContinuous` overflow**: when text was wider than the
+    selection range, it was clipped at the range boundary. Excel keeps
+    overflowing the text symmetrically into adjacent empty cells, so the
+    renderer now extends the draw rect using the same logic as
+    `center` alignment (PR #148, ECMA-376 §18.18.40).
+  - **Neighbour fill no longer overpaints overflow text**: cell text is
+    drawn in a deferred second pass after every cell's background, so
+    e.g. a left-aligned overflow stays visible on top of an adjacent
+    cell with a non-default fill — matching Excel's z-order (PR #148).
+- **Assets**:
+  - Refreshed `docs/images/icon.png` and the VS Code extension icon
+    (PR #149).
+
 ## 0.20.0 — 2026-04-28
 
 Minor release. Built-in PowerPoint table styles and additional XLSX cell alignments.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
- XLSX `centerContinuous` overflow no longer clips at the selection-range boundary (PR #148).
- XLSX cell text is now drawn in a deferred second pass so a neighbour's fill no longer overpaints overflow text (PR #148).
- Refreshed `docs/images/icon.png` and the VS Code extension icon (PR #149).

## Test plan
- [x] Bumped 6 `package.json` files to `0.21.0`.
- [x] CHANGELOG entry added.
- [x] Verified visually with `private/sample-27.xlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)