### PR TITLE
fix(xlsx): hide internal gridlines inside centerContinuous runs

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2333,6 +2333,34 @@ function renderQuadrant(
     const ch = rowHeights[ri];
     if (cy + ch <= clipY || cy >= clipY + clipH) continue;
 
+    // Pre-compute centerContinuous ranges in this row. ECMA-376 §18.18.40:
+    // a contiguous run of cells whose alignment is `centerContinuous` is
+    // treated as a single visual span — Excel hides the default gridlines
+    // inside the run so the centered text (or empty span) reads as one.
+    // Detect runs of length ≥ 2 (regardless of whether they contain text)
+    // and mark the internal right edges for suppression.
+    const suppressRightGridCol = new Set<number>();
+    let runStart = -1;
+    for (let ci = 0; ci <= numCols; ci++) {
+      let isCC = false;
+      if (ci < numCols) {
+        const ckey = `${rowIndex}:${startCol + ci}`;
+        if (!mergeSkipSet.has(ckey) && !mergeAnchorMap.has(ckey)) {
+          const c = cellMap.get(ckey);
+          const cXf = resolveXf(styles, c?.styleIndex ?? 0).xf;
+          isCC = cXf.alignH === 'centerContinuous';
+        }
+      }
+      if (isCC) {
+        if (runStart < 0) runStart = ci;
+      } else {
+        if (runStart >= 0 && ci - runStart >= 2) {
+          for (let k = runStart; k < ci - 1; k++) suppressRightGridCol.add(k);
+        }
+        runStart = -1;
+      }
+    }
+
     for (let ci = 0; ci < numCols; ci++) {
       const colIndex = startCol + ci;
       const cx = originX + colXs[ci];
@@ -2425,8 +2453,10 @@ function renderQuadrant(
         ctx.strokeStyle = '#d0d0d0';
         ctx.lineWidth = 0.5;
         ctx.beginPath();
-        ctx.moveTo(cx + cellW + hp, cy);          // right edge
-        ctx.lineTo(cx + cellW + hp, cy + cellH);
+        if (!suppressRightGridCol.has(ci)) {
+          ctx.moveTo(cx + cellW + hp, cy);        // right edge
+          ctx.lineTo(cx + cellW + hp, cy + cellH);
+        }
         ctx.moveTo(cx, cy + cellH + hp);           // bottom edge
         ctx.lineTo(cx + cellW, cy + cellH + hp);
         if (ri === 0) {                            // top edge for first row


### PR DESCRIPTION
## Summary

- Implements ECMA-376 §18.18.40: a contiguous run of cells with `alignH = "centerContinuous"` is treated as a single visual span, so Excel hides the default gridlines inside the run.
- Pre-computes suppressed right-edge columns per row before the cell loop, then skips drawing the right gridline edge for cells flagged.
- Detection is purely alignment-based, so empty centerContinuous ranges (e.g. A3:D3 with no values) also collapse correctly.

## Test plan

- [x] Visual: sample-27.xlsx row 1 (A1:D1 centerContinuous with text) — internal gridlines between A/B/C/D are gone, outer D|E gridline still drawn.
- [x] Pixel sampling: at row 1 in cell-empty band, x=109/168/227 are clean white; at row 3+ (no centerContinuous), same x positions show the regular `#d0d0d0` gridline.
- [x] Existing VRT pass (no reference image change expected for the existing samples that don't use centerContinuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)