### PR TITLE
chore(release): 0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.21.2 — 2026-04-29
+
+Patch release. XLSX `centerContinuous` border rendering fixes.
+
+- **XLSX engine** (`packages/xlsx`):
+  - **Default gridlines hidden inside `centerContinuous` runs**: a
+    contiguous run of cells with `horizontal="centerContinuous"` is now
+    rendered as a single visual span — internal default gridlines are
+    suppressed so the centered text reads as one (PR #152, ECMA-376
+    §18.18.40).
+  - **Explicit cell borders also hidden inside `centerContinuous`
+    runs**: matching Excel's behavior, internal `left`/`right` borders
+    of cells inside a centerContinuous run are masked, leaving only the
+    outer perimeter visible — even when the run cells carry an
+    explicit thin/medium/thick box border (PR #153).
+
 ## 0.21.1 — 2026-04-29
 
 Patch release. Re-capture `docs/images/xlsx.png` at the correct landscape

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
Patch release for two centerContinuous border-rendering fixes:
- [#152](https://github.com/yukiyokotani/office-open-xml-viewer/pull/152) — suppress default gridlines inside a `centerContinuous` run.
- [#153](https://github.com/yukiyokotani/office-open-xml-viewer/pull/153) — suppress explicit cell borders inside a `centerContinuous` run; only the outer perimeter is rendered, matching Excel.

Bumps all six `package.json` files (root + core/docx/pptx/xlsx/vscode-extension) to 0.21.2 and adds a CHANGELOG entry. Existing screenshots in `docs/images/` remain valid for this release (none of the README sample stories use centerContinuous).

## Test plan
- [x] Verified visually against Excel's rendering of sample-27.xlsx (A3:D3 centerContinuous + thin box border): outer rectangle only, no internal verticals.
- [x] All package.json versions match (0.21.2).
- [x] CHANGELOG.md entry added at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)