### PR TITLE
fix(xlsx): only honor defaultRowHeight when customHeight is true

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1826,8 +1826,27 @@ fn parse_worksheet(
                 if let Some(v) = node.attribute("defaultColWidth").and_then(|s| s.parse().ok()) {
                     default_col_width = v;
                 }
-                if let Some(v) = node.attribute("defaultRowHeight").and_then(|s| s.parse().ok()) {
-                    default_row_height = v;
+                // ECMA-376 §18.3.1.81 customHeight: "'True' if
+                // defaultRowHeight value has been manually set, or is
+                // different from the default value." When customHeight is
+                // false/absent, the written defaultRowHeight is purely
+                // informational — applications use their intrinsic default
+                // (15 pt for the Calibri 11 baseline → 20 px at 96 DPI).
+                // Honoring the file value unconditionally caused sample-27
+                // (defaultRowHeight=20pt, no customHeight) to render rows
+                // at 27 px instead of Excel's actual 20 px.
+                let custom_height = node
+                    .attribute("customHeight")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                if let Some(v) = node
+                    .attribute("defaultRowHeight")
+                    .and_then(|s| s.parse::<f64>().ok())
+                {
+                    if custom_height {
+                        default_row_height = v;
+                    }
+                    // else: leave intrinsic 15.0 in place
                 }
             }
             "col" if node.tag_name().namespace() == Some(ns) => {


### PR DESCRIPTION
## Summary
- ECMA-376 §18.3.1.81 customHeight: *\"'True' if defaultRowHeight value has been manually set, or is different from the default value.\"*
- Excel treats `defaultRowHeight` as informational when `customHeight` is false/absent and falls back to its intrinsic 15 pt baseline (20 px at 96 DPI for Calibri 11).
- Previously the parser unconditionally adopted the file value, so sample-27.xlsx (`defaultRowHeight=\"20\"`, no `customHeight`) rendered 27 px rows instead of Excel's actual 20 px.
- Combined with #156 (75 px column width from `baseColWidth`), A1 now matches Excel's exact 75 × 20 px display (3.75:1 aspect ratio).

## Test plan
- [x] sample-27 row stride confirmed at 40 device px / 20 CSS px via canvas pixel sampling.
- [x] Custom-height rows in the same sheet (row 4 ht=21, row 5 ht=22) still apply their per-row values — only the *default* changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)