### PR TITLE
chore(release): 0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.21.3 — 2026-04-29
+
+Patch release. XLSX cell sizing, border-style coverage, and
+`centerContinuous` run accounting fixes.
+
+- **XLSX engine** (`packages/xlsx`):
+  - **`centerContinuous` run split at value-bearing anchors**: ECMA-376
+    §18.18.40 says spanned cells reference the same style id while only
+    the anchor holds a value. Two adjacent anchors therefore form two
+    separate runs, with the border between them visible. The renderer
+    now closes the previous run and starts a fresh one whenever it
+    encounters a centerContinuous cell that itself carries a value
+    (PR #155).
+  - **`defaultColWidth` derived from `baseColWidth`**: ECMA-376
+    §18.3.1.81 specifies that when `<sheetFormatPr>` provides
+    `baseColWidth` but no `defaultColWidth`, the default column width
+    is `baseColWidth + 5 px / maxDigitWidth` characters (4 px margin +
+    1 px gridline). The Rust parser now applies that fallback so
+    sample-27.xlsx (`baseColWidth="10"`, no `defaultColWidth`) renders
+    columns at 75 px instead of the previous 8.43-char baseline
+    (PR #156).
+  - **`defaultRowHeight` honored only when `customHeight` is true**:
+    ECMA-376 §18.3.1.81 `customHeight` describes the
+    `defaultRowHeight` attribute as informational unless the flag is
+    set; Excel falls back to its intrinsic 20-px baseline otherwise.
+    The parser now matches that behavior (PR #157).
+  - **Row heights treated as display pixels (1:1)**: Excel writes row
+    heights as the resolved display-pixel value rather than the
+    nominal point size — `defaultRowHeight="20"` renders 20 px,
+    `ht="21"` with `thickBot` renders 21 px, etc. The renderer's
+    pt→px multiplier is dropped for row metrics (the 4/3 conversion
+    is preserved for fonts, indent, and line-height) and the parser
+    intrinsic moves from 15 → 20 (PR #158).
+  - **`double` border style** (ECMA-376 §18.18.3 `ST_BorderStyle`):
+    previously rendered as a single line because the dispatcher only
+    handled thick / medium / dashed-family / dotted / hair. Now drawn
+    as two parallel 1-px lines flanking the cell edge with closed
+    corners — outer pair extended past corners by 1 px so adjacent
+    doubled edges meet outside, inner pair trimmed by 1 px so the
+    perpendicular inner segments meet exactly at the inner corner
+    (PRs #158, #159).
+
 ## 0.21.2 — 2026-04-29
 
 Patch release. XLSX `centerContinuous` border rendering fixes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
XLSX engine improvements rolled up:
- [#155](https://github.com/yukiyokotani/office-open-xml-viewer/pull/155) centerContinuous run split at value-bearing anchors (ECMA-376 §18.18.40)
- [#156](https://github.com/yukiyokotani/office-open-xml-viewer/pull/156) defaultColWidth derivation from baseColWidth fallback (ECMA-376 §18.3.1.81)
- [#157](https://github.com/yukiyokotani/office-open-xml-viewer/pull/157) defaultRowHeight honored only when customHeight is true
- [#158](https://github.com/yukiyokotani/office-open-xml-viewer/pull/158) row heights as 1:1 display pixels + `double` border style (ECMA-376 §18.18.3)
- [#159](https://github.com/yukiyokotani/office-open-xml-viewer/pull/159) trim inner double-border lines at the corner

Verified end-to-end against sample-27.xlsx — A1 now renders at Excel's exact 75 × 20 px display, rows 4/5/6 at 21/22/21 px, and the four border styles in row 5 (dashDotDot, dotted, double, medium) all match Excel's appearance.

## Test plan
- [x] sample-27 columns 75 CSS px (8 col span verified by canvas pixel sampling)
- [x] sample-27 default rows 20 CSS px, custom rows 4=21 / 5=22 / 6=21 px
- [x] sample-27 row 5 E5 / G5 double border closes at corners
- [x] All 6 package.json versions bumped to 0.21.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)