### PR TITLE
chore(release): 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.22.1 — 2026-04-29
+
+Patch release. Fix a visible layout shift on the Storybook demo when
+the user first scrolled.
+
+- **XLSX engine** (`packages/xlsx`):
+  - **Force every Carlito / Caladea FontFace to actually load before
+    paint**: `document.fonts.load("16px Carlito")` only triggers the
+    sub-ranges that match characters already present in the live DOM.
+    Canvas-only text didn't qualify, so on systems without Calibri the
+    first paint fell back to sans-serif metrics and the moment a scroll
+    re-rendered, the browser had lazy-loaded the substitute and switched
+    to its real metrics — a visible reflow. Iterate `document.fonts` for
+    the requested families and call `face.load()` directly, bypassing
+    the unicode-range gating.
+
 ## 0.22.0 — 2026-04-29
 
 Minor release rolling up the v0.21.x XLSX engine work and refreshing the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary
Patch release: fix the visible layout shift on the Storybook demo's first scroll. Canvas text was rendering with sans-serif fallback metrics on the initial paint because `document.fonts.load(\"16px Carlito\")` only triggers the FontFace sub-ranges that match characters already in the live DOM — canvas-only text didn't qualify so all 28 Carlito faces stayed unloaded. The first scroll re-render then used the real Carlito metrics → reflow.

[#162](https://github.com/yukiyokotani/office-open-xml-viewer/pull/162) iterates `document.fonts` for the requested families and calls `face.load()` directly, forcing every weight × style × subset to be fetched before paint.

## Test plan
- [x] Six package.json bumped to 0.22.1
- [x] CHANGELOG entry added
- [x] All 28 Carlito FontFace entries report `loaded` after `viewer.load()` resolves
- [x] No layout shift on first scroll in the deployed-style preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)