### PR TITLE
fix(xlsx): change MDW from 7 to 8 for correct Calibri 11pt column widths

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -17,7 +17,16 @@ import { renderChart, renderSparkline, type ChartModel, type SparklineModel } fr
 // for Cambria.
 const DEFAULT_FONT_FAMILY = '"Calibri", "Carlito", "Cambria", "Caladea", Arial, sans-serif';
 const DEFAULT_FONT_SIZE = 11;
-const MDW = 7;
+// Max Digit Width of the Normal-style font (Calibri 11 pt at 96 DPI).
+// ECMA-376 §18.3.1.13 uses MDW to convert the column-width character
+// measure into pixels.  Empirical measurement with Canvas2D (Calibri /
+// Carlito 11pt, 96 DPI) yields ≈ 8 px for the widest digit, matching
+// the EMU offsets that Excel 365 writes into <xdr:twoCellAnchor> (e.g.
+// a 12.25-char column stored as 932 657 EMU ≈ 97.9 px → colWidthToPx
+// returns 98 with MDW=8).  The older MDW=7 value came from the
+// traditional GDI metrics; it produced columns that were ≈14 % too
+// narrow, causing anchor colOff values to overflow the rendered column.
+const MDW = 8;
 /** Standard pt → CSS px conversion at 96 DPI. ECMA-376 §18.4.11 (font sz),
  * §18.8.5 (border width margins, etc.) all express their dimensions in
  * points. Multiply by this constant to obtain the display pixel value. */


### PR DESCRIPTION
## Summary

- Change `MDW` constant from 7 to 8 in `packages/xlsx/src/renderer.ts`
- ECMA-376 §18.3.1.13 uses the Normal-style font's Max Digit Width to convert character-widths to pixels. Canvas2D rendering of Calibri/Carlito 11pt at 96 DPI gives MDW≈8, matching what Excel 365 assumes when writing `<xdr:twoCellAnchor>` anchor offsets.

## Root cause

In `sample-7.xlsx`, the "2018" rectangle has `to.col=16 (Q), to.colOff=929348 EMU ≈ 97.6 px`. With `MDW=7`, `colWidthToPx(12.25) = 86 px` so `colOff > colWidth` — the shape overflowed column Q's right edge by 11.6 px. With `MDW=8`, `colWidthToPx(12.25) = 98 px`, and the shape fits correctly within column Q.

More broadly, the default 8-char column: `56 px → 64 px`, which matches the ~64 px default column width visible in Excel at 100% zoom on 96 DPI.

## Impact

All column widths increase by ~14 %. VRT reference images will need updating (requires separate user-authorised step).

## Test plan

- [ ] `pnpm -r build` passes clean
- [ ] `XlsxViewer / private/sample-7`: "2018" shape right edge aligns with column Q's right border
- [ ] Note: VRT tests will show layout diffs (expected — column widths changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)