### PR TITLE
fix(xlsx): skip table-style overlay for tables with no style name (None)

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2346,9 +2346,12 @@ fn load_sheet_tables(
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
         let style_info = root.children().find(|n| n.tag_name().name() == "tableStyleInfo");
+        // ECMA-376 §18.5.1.4: when `name` is absent the table has "None" style —
+        // no visual table formatting. Default to "" rather than a named style so
+        // the renderer can skip table-style overlay for these cells.
         let style_name = style_info
             .and_then(|n| n.attribute("name"))
-            .unwrap_or("TableStyleMedium2")
+            .unwrap_or("")
             .to_string();
         let bool_attr = |n: &roxmltree::Node, key: &str| n.attribute(key).map(|v| v == "1" || v == "true").unwrap_or(false);
         let (show_row_stripes, show_column_stripes, show_first_column, show_last_column) = match style_info {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2099,6 +2099,9 @@ export interface TableCellStyle {
 function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
   const map = new Map<string, TableCellStyle>();
   for (const t of worksheet.tables ?? []) {
+    // ECMA-376 §18.5.1.4: empty styleName means the table has "None" style —
+    // no visual table formatting overlay should be applied.
+    if (!t.styleName) continue;
     const accent = t.accentColor || '#808080';
     const hdr = Math.max(0, t.headerRowCount ?? 1);
     const tot = Math.max(0, t.totalsRowCount ?? 0);


### PR DESCRIPTION
## Summary

- **Root cause**: `<tableStyleInfo>` with no `name` attribute means the Excel table has "None" style — no visual table formatting. The parser was defaulting to `"TableStyleMedium2"` for the missing `name`, causing the renderer's fallback accent-colour rule to draw a bottom border on every cell in the table.
- **Parser fix** (`lib.rs`): When `tableStyleInfo` has no `name` attribute, default to `""` instead of `"TableStyleMedium2"`. Ref: ECMA-376 §18.5.1.4.
- **Renderer fix** (`renderer.ts`): `buildTableStyleMap()` now skips adding map entries for tables whose `styleName` is empty, so `tableStyle` is undefined for those cells and the entire overlay block is skipped.

## Affected sample
`sample-7.xlsx` — rows 4–10, 13–21 (and further) are covered by Excel tables whose `tableStyleInfo` has no `name` attribute. Our renderer was showing spurious bottom-border underlines on those rows; Excel shows none.

## Test plan
- [ ] Load `sample-7.xlsx` in Storybook; rows 4–10, 13–21 should show no underlines below data cells
- [ ] Verify tables that *do* have a named style (e.g. `TableStyleMedium2`) still render their horizontal rule overlays
- [ ] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)