### PR TITLE
fix(xlsx): skip table-style overlay for None-style table outer-edge cells

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2618,7 +2618,10 @@ function renderQuadrant(
       // thicker bottom edge under the header row (ECMA-376 §18.5). Drawn on
       // top of cell borders so an empty-border data cell still shows table
       // structure.
-      if (tableStyle) {
+      // Skip for "None"-style table cells (identified by `suppressEdge` being
+      // present): those cells only need the border-suppression path above, not
+      // the named-style overlay.
+      if (tableStyle && !tableStyle.suppressEdge) {
         const horiz = tsDxfWhole?.border?.horizontal;
         const vert  = tsDxfWhole?.border?.vertical;
         const wtTop = tsDxfWhole?.border?.top;


### PR DESCRIPTION
## Summary

Regression introduced in PR #168.

**Root cause**: PR #168 added `tableStyleMap` entries (carrying `suppressEdge`) for cells at the outer boundary of "None"-style tables so the renderer could null out their baked-in `xf` borders. However it also caused the existing table-style overlay block (`if (tableStyle) { … }`) to execute for those cells. The fallback `else` branch in that block draws horizontal lines using `tableStyle.accent`, which is `''` for None-style entries. Canvas2D silently ignores an invalid CSS colour and keeps the previous `strokeStyle`, so those lines were rendered in whatever colour was set last — producing spurious horizontal borders visible across every table section (e.g. rows 24–32 of sample-7.xlsx).

**Fix**: one-line guard `if (tableStyle && !tableStyle.suppressEdge)` on the overlay block. Cells with `suppressEdge` (None-style outer edges) skip the overlay entirely and only go through the `suppressEdge` path that nulls their baked-in `xf` borders before `renderBorder`.

## Test plan

- [ ] sample-7.xlsx rows 24–32, 33–43, … show **no horizontal borders** in Storybook
- [ ] Named-style tables (e.g. `TableStyleLight18`) still draw their overlay correctly
- [ ] C10, C21 left borders still suppressed (PR #168 suppressEdge path unaffected)
- [ ] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)