### PR TITLE
fix(xlsx): revert suppressEdge heuristic and add column-level DXF parsing

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -193,6 +193,31 @@ pub struct TableInfo {
     /// vertical separator borders shown between header cells.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub header_row_dxf: Option<u32>,
+    /// Per-column DXF references (ECMA-376 §18.5.1.3 `tableColumn`). Length
+    /// matches the number of `<tableColumn>` children in the table XML, so
+    /// `columns[c - range.left]` gives the DXFs for the cell column. The
+    /// renderer can use these to apply column-level overlays for named-style
+    /// tables that don't pre-bake column DXFs into the cell `xf`. For files
+    /// where Excel pre-bakes the result into `xf` (the common case), reading
+    /// the cell `xf` already reflects the column DXF and these fields are
+    /// purely informational.
+    pub columns: Vec<TableColumnInfo>,
+}
+
+/// Per-column DXF references inside a `<table>` element
+/// (ECMA-376 §18.5.1.3 `tableColumn`).
+#[derive(Debug, Serialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TableColumnInfo {
+    /// `<tableColumn dataDxfId>` — applied to data-region cells in this column.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_dxf_id: Option<u32>,
+    /// `<tableColumn headerRowDxfId>` — applied to the header cell of this column.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header_row_dxf_id: Option<u32>,
+    /// `<tableColumn totalsRowDxfId>` — applied to the totals cell of this column.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub totals_row_dxf_id: Option<u32>,
 }
 
 /// Workbook- or sheet-scoped defined name (ECMA-376 §18.2.5 `definedName`).
@@ -2368,6 +2393,19 @@ fn load_sheet_tables(
             Some(e) => (e.whole_table, e.header_row),
             None => (None, None),
         };
+        // ECMA-376 §18.5.1.3: each `<tableColumn>` may carry its own
+        // `dataDxfId`, `headerRowDxfId`, `totalsRowDxfId`. We collect them in
+        // document order so the renderer can index them via
+        // `columns[cellCol - range.left]`.
+        let columns: Vec<TableColumnInfo> = root
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "tableColumn")
+            .map(|tc| TableColumnInfo {
+                data_dxf_id:       tc.attribute("dataDxfId").and_then(|s| s.parse().ok()),
+                header_row_dxf_id: tc.attribute("headerRowDxfId").and_then(|s| s.parse().ok()),
+                totals_row_dxf_id: tc.attribute("totalsRowDxfId").and_then(|s| s.parse().ok()),
+            })
+            .collect();
         tables.push(TableInfo {
             range,
             style_name,
@@ -2380,6 +2418,7 @@ fn load_sheet_tables(
             accent_color,
             whole_table_dxf,
             header_row_dxf,
+            columns,
         });
     }
     tables

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2094,58 +2094,17 @@ export interface TableCellStyle {
   /** Dxf for the header-row element of a custom `<tableStyle>`. Provides
    *  header fill, font color/weight, and vertical separators. */
   headerRowDxf?: number;
-  /** Per-edge flags for border suppression on cells at the outer edge of a
-   *  table with "None" style (ECMA-376 §18.5.1.4: absent `name` = no style).
-   *  Excel bakes table-generated borders into the cell's `xf` but does not
-   *  render them when the table style is None. We replicate this by nulling
-   *  out the corresponding edge before calling `renderBorder`. */
-  suppressEdge?: { left: boolean; right: boolean; top: boolean; bottom: boolean };
 }
 
 function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
   const map = new Map<string, TableCellStyle>();
   for (const t of worksheet.tables ?? []) {
+    // ECMA-376 §18.5.1.4: empty styleName means the table has "None" style —
+    // no visual table formatting overlay should be applied. Cell xf borders
+    // and fills are still rendered as defined (per §18.8.45); only the
+    // table-style overlay (banded fills, separator rules, etc.) is skipped.
+    if (!t.styleName) continue;
     const { top, bottom, left, right } = t.range;
-
-    if (!t.styleName) {
-      // ECMA-376 §18.5.1.4: absent `name` = "None" style — no visual table
-      // formatting. However Excel bakes table-generated borders into the cells'
-      // own `xf` styles and suppresses them at render time when the style is
-      // None. We replicate this by recording `suppressEdge` for every outer-
-      // edge cell so the renderer can null out those borders before drawing.
-      for (let r = top; r <= bottom; r++) {
-        const isTopEdge    = r === top;
-        const isBottomEdge = r === bottom;
-        if (!isTopEdge && !isBottomEdge) continue; // only need rows at the edges
-        for (let c = left; c <= right; c++) {
-          const isLeftEdge  = c === left;
-          const isRightEdge = c === right;
-          if (!isLeftEdge && !isRightEdge && !isTopEdge && !isBottomEdge) continue;
-          map.set(`${r}:${c}`, {
-            accent: '', isHeader: false, isTotals: false, isBanded: false,
-            isFirstCol: false, isLastCol: false,
-            isTopEdge, isBottomEdge,
-            suppressEdge: { left: isLeftEdge, right: isRightEdge, top: isTopEdge, bottom: isBottomEdge },
-          });
-        }
-      }
-      // Also record left/right edge cells for non-edge rows
-      for (let r = top + 1; r < bottom; r++) {
-        const entry = (c: number, isLeft: boolean): [string, TableCellStyle] => [
-          `${r}:${c}`,
-          {
-            accent: '', isHeader: false, isTotals: false, isBanded: false,
-            isFirstCol: false, isLastCol: false,
-            isTopEdge: false, isBottomEdge: false,
-            suppressEdge: { left: isLeft, right: !isLeft, top: false, bottom: false },
-          },
-        ];
-        map.set(...entry(left, true));
-        map.set(...entry(right, false));
-      }
-      continue;
-    }
-
     const accent = t.accentColor || '#808080';
     const hdr = Math.max(0, t.headerRowCount ?? 1);
     const tot = Math.max(0, t.totalsRowCount ?? 0);
@@ -2599,29 +2558,14 @@ function renderQuadrant(
           mergedBorder = { ...mergedBorder, left: leftRight };
         }
       }
-      // Suppress outer-edge borders for "None"-style table cells.
-      // Excel bakes table-generated borders into the cell xf but does not
-      // render them when tableStyleInfo has no name (ECMA-376 §18.5.1.4).
-      const se = tableStyle?.suppressEdge;
-      if (se) {
-        mergedBorder = {
-          ...mergedBorder,
-          ...(se.left   && { left:   null }),
-          ...(se.right  && { right:  null }),
-          ...(se.top    && { top:    null }),
-          ...(se.bottom && { bottom: null }),
-        };
-      }
       renderBorder(ctx, mergedBorder, cx, cy, cellW, cellH);
 
       // Excel Table style overlay: thin horizontal rules between rows and a
       // thicker bottom edge under the header row (ECMA-376 §18.5). Drawn on
       // top of cell borders so an empty-border data cell still shows table
-      // structure.
-      // Skip for "None"-style table cells (identified by `suppressEdge` being
-      // present): those cells only need the border-suppression path above, not
-      // the named-style overlay.
-      if (tableStyle && !tableStyle.suppressEdge) {
+      // structure. None-style tables produce no entry in `tableStyleMap`
+      // (see `buildTableStyleMap`), so this block is naturally skipped.
+      if (tableStyle) {
         const horiz = tsDxfWhole?.border?.horizontal;
         const vert  = tsDxfWhole?.border?.vertical;
         const wtTop = tsDxfWhole?.border?.top;

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -143,6 +143,23 @@ export interface TableInfo {
   /** Dxf index for the `headerRow` element of a custom `<tableStyle>` —
    *  provides header background, font color/weight, and vertical separators. */
   headerRowDxf?: number;
+  /** Per-column DXF references (ECMA-376 §18.5.1.3 `tableColumn`). Index by
+   *  `cellCol - range.left`. The renderer can use these to apply column-level
+   *  overlays for named-style tables; for files where Excel pre-bakes the
+   *  column DXF result into the cell `xf` (the common case), reading `xf` is
+   *  sufficient and these fields are informational. */
+  columns: TableColumnInfo[];
+}
+
+/** Per-column DXF references inside a `<table>` element
+ *  (ECMA-376 §18.5.1.3 `tableColumn`). */
+export interface TableColumnInfo {
+  /** `<tableColumn dataDxfId>` — applied to data cells in this column. */
+  dataDxfId?: number;
+  /** `<tableColumn headerRowDxfId>` — applied to the header cell of this column. */
+  headerRowDxfId?: number;
+  /** `<tableColumn totalsRowDxfId>` — applied to the totals cell of this column. */
+  totalsRowDxfId?: number;
 }
 
 export interface DefinedName {


### PR DESCRIPTION
## Summary

**Reverts** PRs #168 and #169 which were built on a misinterpretation, and **adds spec-faithful column-level DXF parsing** to the Rust parser.

### Why

The user clarified that C10's left border *IS* drawn in Excel (their original \"not visible in Excel\" complaint was specifically about the horizontal borders in C24-Q32, which PR #167 already fixed correctly). PR #168 introduced a positional `suppressEdge` heuristic that incorrectly suppressed legitimate user-set borders such as `C52.left=thick` (table5 totals row), producing the inconsistent thick vertical line at the B/C boundary that the user noticed in rows 50-60.

### What changed

**Phase 1 — Revert** (`packages/xlsx/src/renderer.ts`):
- Drop `suppressEdge` field from `TableCellStyle`
- Drop the None-style branch in `buildTableStyleMap` that fabricated outer-edge entries; restore the simple `if (!t.styleName) continue;` short-circuit
- Drop the `suppressEdge` application code in the per-cell render loop
- Restore plain `if (tableStyle)` (no `&& !tableStyle.suppressEdge` guard)

PR #167's overlay skip for None-style tables remains effective and continues to suppress the spurious horizontal borders in C24-Q32.

**Phase 2 — Column DXF parsing** (`packages/xlsx/parser/src/lib.rs`, `packages/xlsx/src/types.ts`):
- New `TableColumnInfo` struct/interface with `dataDxfId`, `headerRowDxfId`, `totalsRowDxfId`
- `TableInfo.columns: Vec<TableColumnInfo>` populated by iterating `<tableColumn>` children of each `<table>` (ECMA-376 §18.5.1.3)
- The renderer does not consume these in this commit — Excel pre-bakes column DXF results into the cell `xf` for the common case, so reading `xf` is already sufficient. The data is now available for future named-style overlay logic.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes
- [x] WASM rebuilds successfully
- [ ] sample-7.xlsx in Storybook:
  - C10, C21, C52, C60, … show their xf left borders drawn (table totals leftmost cells)
  - B/C boundary in rows 50-60 is a uniform thick teal vertical line (B.right=thick or C.left=thick, both at the same boundary in the same theme=5 colour)
  - C24-Q32 (and equivalent) show no horizontal borders (PR #167 still active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)