### PR TITLE
chore(release): 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.24.0 — 2026-04-30
+
+Minor release fixing spurious horizontal borders inside None-style Excel
+tables and exposing column-level DXF references on `TableInfo`.
+
+- **XLSX engine** (`packages/xlsx`):
+  - **Skip the table-style overlay for "None"-style tables**
+    (ECMA-376 §18.5.1.4): when `<tableStyleInfo>` has no `name` attribute
+    the table uses the "None" style — no visual table formatting overlay
+    should be applied. The previous renderer always entered the overlay
+    block, whose fallback `else` branch drew a horizontal accent rule on
+    every cell of the table. The Rust parser now defaults `style_name` to
+    `""` (instead of `"TableStyleMedium2"`) when `name` is absent, and
+    `buildTableStyleMap` skips tables with empty `styleName`. Eliminates
+    the spurious horizontal borders that were visible across all 13 None-
+    style tables of sample-7.xlsx (PR #167).
+  - **Spec-faithful cell-border rendering**: an interim `suppressEdge`
+    heuristic that tried to hide the leftmost-totals-cell xf borders for
+    None-style tables (PR #168/#169) was reverted — those borders are
+    legitimate user-set formatting per ECMA-376 §18.8.45 and Excel does
+    render them. The B/C boundary across rows 50-60 is now a uniform
+    thick teal vertical line, supplied by `B.right=thick` on most rows
+    and `C.left=thick` on totals rows (same theme=5 colour at the same
+    column boundary) (PR #170).
+  - **Column-level DXF references** (ECMA-376 §18.5.1.3 `tableColumn`):
+    the parser now exposes `TableInfo.columns: TableColumnInfo[]` with
+    each column's `dataDxfId` / `headerRowDxfId` / `totalsRowDxfId`. The
+    renderer does not consume them yet (Excel pre-bakes column DXF
+    results into the cell `xf` for the common case), but the data is
+    available for future named-style overlay logic that needs to layer
+    column-specific DXFs on top of `wholeTable`/`headerRow` overlays
+    (PR #170).
+
 ## 0.23.0 — 2026-04-30
 
 Minor release adding drawing-shape text rendering for XLSX and correcting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Minor release fixing spurious horizontal borders in None-style Excel tables and exposing column-level DXF references on `TableInfo`.

### Highlights

- **None-style table overlay skip** (PR #167): tables with `<tableStyleInfo>` lacking a `name` attribute no longer trigger the table-style overlay, eliminating the spurious horizontal borders that were visible across all 13 None-style tables in sample-7.xlsx (rows 4-10, 13-21, 24-32, …). ECMA-376 §18.5.1.4.
- **Spec-faithful cell-border rendering** (PR #170): an interim `suppressEdge` heuristic (PR #168/#169) that hid leftmost-totals-cell `xf` borders was reverted — those borders are legitimate user formatting per ECMA-376 §18.8.45 and Excel does render them. The B/C boundary across rows 50-60 of sample-7 is now a uniform thick teal vertical line.
- **Column-level DXF parsing** (PR #170): `TableInfo.columns: TableColumnInfo[]` now exposes each column's `dataDxfId` / `headerRowDxfId` / `totalsRowDxfId` (ECMA-376 §18.5.1.3). The renderer does not consume them yet — Excel pre-bakes column DXF results into the cell `xf` for the common case — but the data is available for future named-style overlay extensions.

No new feature row added to the README support table; this release is bug-fix + parser extension. README screenshots are not refreshed because sample-1.xlsx (the demo file) doesn't exercise None-style tables.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes
- [x] `wasm-pack build` succeeds and `packages/xlsx/src/wasm/` is regenerated
- [ ] sample-7.xlsx in Storybook: no horizontal borders inside None-style tables; uniform thick vertical line at B/C boundary across rows 50-60; C10 / C21 / C52 / C60 left borders visible
- [ ] Named-style tables (sample-1.xlsx) render their overlay correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)