### PR TITLE
chore(release): 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.24.1 — 2026-04-30
+
+Patch release fixing column-width pixel conversion for files whose Normal
+style is not Calibri 11 pt.
+
+- **XLSX engine** (`packages/xlsx`):
+  - **Max Digit Width derived from the workbook's Normal-style font**
+    (ECMA-376 §18.3.1.13): the renderer previously hard-coded `MDW = 8`
+    (the value for Calibri 11 pt at 96 DPI), so files whose Normal style
+    points to a different face produced columns at the wrong pixel width.
+    The parser now resolves `<cellStyleXfs>[0].fontId` →
+    `<fonts>[fontId].name.val` / `.sz.val` and exposes
+    `Worksheet.defaultFontFamily` / `defaultFontSize`. The renderer
+    measures the actual maximum digit width using Canvas2D's
+    `measureText` (cached per `(family, sizePt)` key) and threads it
+    through `RenderContext`. `colWidthToPx(w, mdw?)` now accepts MDW as
+    a parameter; both `renderer.ts` and `viewer.ts` pass the resolved
+    value. For Meiryo UI 10 pt the measured MDW is ≈ 6 px, so e.g.
+    sample-10.xlsx column C (`width="21.125"` chars) now renders at
+    127 px to match Excel — was ~174 px before. Calibri 11 pt files are
+    unchanged (MDW measurement still ≈ 8) (PR #172).
+
 ## 0.24.0 — 2026-04-30
 
 Minor release fixing spurious horizontal borders inside None-style Excel

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Patch release fixing column-width pixel conversion for XLSX files whose Normal-style font is not Calibri 11 pt.

### Highlights

- **MDW derived from the Normal-style font** (PR #172, ECMA-376 §18.3.1.13): parser now resolves `<cellStyleXfs>[0].fontId` → `<fonts>[N]` and exposes `defaultFontFamily` / `defaultFontSize` on `Worksheet`. Renderer measures the actual MDW via Canvas2D `measureText` (cached) and passes it through to `colWidthToPx`. For Meiryo UI 10 pt the measured MDW is ≈ 6 px, so sample-10.xlsx column C (`width="21.125"` chars) now renders at **127 px** to match Excel exactly (was ~174 px). Calibri 11 pt files are unchanged.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes
- [ ] sample-10.xlsx in Storybook: column C is 127 px wide (was ~174 px)
- [ ] sample-1.xlsx, sample-7.xlsx still render with their original Calibri-based column widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)