### PR TITLE
fix(xlsx): preserve centerContinuous border suppression against neighbor-inherit pass

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2592,7 +2592,11 @@ function renderQuadrant(
           mergedBorder = { ...mergedBorder, top: aboveBottom };
         }
       }
-      if (!mergedBorder.left?.style) {
+      if (!mergedBorder.left?.style && !suppressLeftGridCol.has(ci)) {
+        // Skip the inherit when the left edge was deliberately suppressed for
+        // a centerContinuous run (ECMA-376 §18.18.40) — otherwise the
+        // neighbour's xf.right re-introduces the internal vertical that we
+        // just hid.
         const leftCell = cellMap.get(`${rowIndex}:${colIndex - 1}`);
         const leftRight = leftCell
           ? resolveXf(styles, leftCell.styleIndex).border.right


### PR DESCRIPTION
## Summary

Regression introduced by PR #164 (the row-z-order fix that re-draws a cell-to-the-left's `xf.right` as the current cell's `left` when the current cell's left is unset).

That neighbor-inherit pass also fires for the *empty* left edges that the centerContinuous block (ECMA-376 §18.18.40) deliberately nulled — so the internal verticals between **A3-D3** and **E3-H3** in sample-27, which were correctly hidden by the centerContinuous logic, were brought back by the inherit pass.

## Fix

Gate the left-inherit on `!suppressLeftGridCol.has(ci)`. Cells participating in a centerContinuous run keep their internal vertical suppressed. The top-inherit doesn't need a similar guard because centerContinuous only hides verticals.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes
- [ ] sample-27 in Storybook: A3-D3 and E3-H3 read as one continuous span (no internal verticals)
- [ ] sample-7 row 2: medium bottom borders still uniform (PR #164 fix preserved for non-centerContinuous cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)