### PR TITLE
chore(release): 0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.24.2 — 2026-04-30
+
+Patch release fixing a centerContinuous regression introduced by the
+0.23.0 row-z-order fix.
+
+- **XLSX engine** (`packages/xlsx`):
+  - **centerContinuous internal verticals stay hidden** (ECMA-376
+    §18.18.40 ST_HorizontalAlignment): the row-z-order repair added in
+    0.23.0 — which inherits the cell-to-the-left's `xf.right` as the
+    current cell's `left` when the latter is unset — also fired for the
+    *empty* left edges that the centerContinuous block deliberately
+    nulled, re-introducing the internal verticals between e.g. A3-D3 and
+    E3-H3 in sample-27. Gate the inherit pass on
+    `!suppressLeftGridCol.has(ci)` so cells participating in a
+    centerContinuous run keep the run reading as one visual span. The
+    top-inherit doesn't need the guard because centerContinuous only
+    suppresses verticals (PR #174).
+
 ## 0.24.1 — 2026-04-30
 
 Patch release fixing column-width pixel conversion for files whose Normal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Patch release fixing a centerContinuous regression that surfaced after the 0.23.0 row-z-order repair.

### Highlights

- **centerContinuous internal verticals stay hidden** (PR #174, ECMA-376 §18.18.40): the inherit-from-left-neighbor pass added in 0.23.0 fired for the empty left edges that the centerContinuous block intentionally nulled, re-introducing internal verticals (e.g. A3-D3 and E3-H3 in sample-27). Gated the inherit on `!suppressLeftGridCol.has(ci)`.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes
- [ ] sample-27 in Storybook: A3-D3 and E3-H3 read as one continuous span (no internal verticals)
- [ ] sample-7 row 2: medium bottom borders still uniform (PR #164 inherit pass preserved for non-centerContinuous cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)