### PR TITLE
docs: standardize Viewer.load examples on URL string input

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ await xlsx.load('/workbook.xlsx');
 
 // PPTX — viewer manages its own <canvas>
 const pptx = new PptxViewer(document.getElementById('pptx-container')!);
-const buf = await fetch('/deck.pptx').then(r => r.arrayBuffer());
-await pptx.load(buf);
+await pptx.load('/deck.pptx');
 pptx.nextSlide();
 ```
 
@@ -150,13 +149,7 @@ export function PptxViewerComponent({ src }: { src: string }) {
       onSlideChange: (i, total) => setSlide({ current: i, total }),
     });
     viewerRef.current = viewer;
-
-    let cancelled = false;
-    fetch(src)
-      .then(r => r.arrayBuffer())
-      .then(buf => { if (!cancelled) viewer.load(buf); });
-
-    return () => { cancelled = true; };
+    viewer.load(src);
   }, [src]);
 
   return (
@@ -192,8 +185,7 @@ onMounted(async () => {
   viewer = new PptxViewer(container.value!, {
     onSlideChange: (i, t) => { current.value = i; total.value = t; },
   });
-  const buf = await fetch(props.src).then(r => r.arrayBuffer());
-  await viewer.load(buf);
+  await viewer.load(props.src);
 });
 </script>
 
@@ -242,9 +234,7 @@ export class PptxViewerComponent implements AfterViewInit {
     this.viewer = new PptxViewer(this.containerEl().nativeElement, {
       onSlideChange: (i, t) => { this.current.set(i); this.total.set(t); },
     });
-    fetch('/deck.pptx')
-      .then(r => r.arrayBuffer())
-      .then(buf => this.viewer!.load(buf));
+    this.viewer.load('/deck.pptx');
   }
 
   prev(): void { this.viewer?.prevSlide(); }
@@ -276,8 +266,7 @@ export class PptxViewerComponent implements AfterViewInit {
     viewer = new PptxViewer(container, {
       onSlideChange: (i, t) => { current = i; total = t; },
     });
-    const buf = await fetch(src).then(r => r.arrayBuffer());
-    await viewer.load(buf);
+    await viewer.load(src);
   });
 </script>
 
@@ -309,8 +298,7 @@ export function PptxViewerComponent(props: { src: string }) {
     viewer = new PptxViewer(containerEl, {
       onSlideChange: (i, t) => { setCurrent(i); setTotal(t); },
     });
-    const buf = await fetch(props.src).then(r => r.arrayBuffer());
-    await viewer.load(buf);
+    await viewer.load(props.src);
   });
 
   onCleanup(() => { /* viewer?.destroy?.() */ });
@@ -349,8 +337,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
     viewer = new PptxViewer(containerRef.value, {
       onSlideChange: (i, t) => { current.value = i; total.value = t; },
     });
-    const buf = await fetch(src).then(r => r.arrayBuffer());
-    await viewer.load(buf);
+    await viewer.load(src);
   });
 
   return (

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -75,15 +75,7 @@ export function buildViewerUI(
 
   if (autoLoadUrl) {
     status.textContent = 'Loading…';
-    fetch(autoLoadUrl)
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status} from ${autoLoadUrl}`);
-        return r.arrayBuffer();
-      })
-      .then((buf) => {
-        status.textContent = 'Parsing…';
-        return viewer.load(buf);
-      })
+    viewer.load(autoLoadUrl)
       .then(() => {
         status.textContent = 'Loaded';
         spinner.remove();

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -52,12 +52,7 @@ export function buildViewerUI(
 
   if (autoLoadUrl) {
     status.textContent = 'Loading…';
-    fetch(autoLoadUrl)
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.arrayBuffer();
-      })
-      .then((buf) => viewer.load(buf))
+    viewer.load(autoLoadUrl)
       .catch((err) => { status.textContent = `Failed: ${err.message}`; });
   }
 


### PR DESCRIPTION
## Summary

`PptxViewer.load` already accepts `string | ArrayBuffer` (same as `DocxViewer.load` / `XlsxViewer.load`), and `PptxPresentation.load` does the `fetch().then(arrayBuffer())` internally when given a string. The public API is therefore symmetric across all three formats.

The README and Storybook helpers, however, were still showing the PPTX viewer being driven through a manual `fetch + arrayBuffer` dance. That suggests an asymmetry that does not exist (and used to make readers think PPTX needs a buffer for media playback — it doesn't; the worker reads the original buffer either way).

This PR aligns the demos with the actual API:

- README Quick Start + all six framework examples (React / Vue / Angular / Svelte / SolidJS / Qwik) now do `await viewer.load(src)`.
- `PptxViewer.stories.ts` and `XlsxViewer.stories.ts` `buildViewerUI` helpers now pass the URL straight to `viewer.load()` instead of fetching it themselves (matching DOCX).

No library code is changed.

## Test plan

- [ ] `pnpm storybook` — open PPTX/XLSX sample stories and confirm autoload still works.
- [ ] Skim README rendering on GitHub to confirm code blocks read consistently across formats.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tzYDPpsbchtqy3xGSZXj9)_