### PR TITLE
chore(release): 0.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.24.3 — 2026-04-30
+
+Documentation-only patch standardizing the `Viewer.load` examples across
+all three formats.
+
+- **Documentation** (`README.md`, Storybook):
+  - **README Quick Start + framework examples now show `viewer.load(url)`
+    for PPTX**: previously the README and the six framework code samples
+    (React / Vue / Angular / Svelte / SolidJS / Qwik) demonstrated the
+    PPTX viewer being driven through a manual
+    `fetch(url).then(r => r.arrayBuffer()).then(viewer.load)` dance,
+    while the DOCX and XLSX examples passed the URL string directly to
+    `viewer.load(url)`. The asymmetry was misleading: `PptxViewer.load`
+    has always accepted `string | ArrayBuffer` and internally calls
+    `fetch + arrayBuffer` for the string form, identical to
+    `DocxViewer` and `XlsxViewer`. Updated all examples to the
+    URL-string form so the three viewers read the same way (PR #176).
+  - **Storybook `buildViewerUI` helpers (PPTX, XLSX) pass the URL
+    directly**: matched the existing DOCX `buildViewerUI` style by
+    dropping the manual fetch + ArrayBuffer step and letting the viewer
+    do the network call itself (PR #176).
+
 ## 0.24.2 — 2026-04-30
 
 Patch release fixing a centerContinuous regression introduced by the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
Documentation-only patch release standardizing the `Viewer.load` examples across all three formats (PPTX / DOCX / XLSX).

See `CHANGELOG.md` for the full entry.

## Summary

- README Quick Start + the six framework examples (React / Vue / Angular / Svelte / SolidJS / Qwik) now show `await viewer.load(url)` for PPTX, matching the existing DOCX / XLSX style.
- PPTX and XLSX Storybook `buildViewerUI` helpers pass the URL straight to the viewer (matching the existing DOCX helper).
- No library code or feature support changes.

Bumps to 0.24.3 across the 6 package.json files.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tzYDPpsbchtqy3xGSZXj9)_