### PR TITLE
feat(pptx)!: PptxViewer constructor canvas-first (0.25.0 breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.25.0 — 2026-04-30
+
+### Breaking Changes
+
+- **pptx**: `PptxViewer` constructor signature changed from
+  `new PptxViewer(container: HTMLElement)` to `new PptxViewer(canvas: HTMLCanvasElement)`.
+  Callers must now create and place the `<canvas>` element themselves; the viewer
+  wraps it internally (same reparent pattern as `DocxViewer`).
+
+  **Migration**:
+  ```diff
+  -const pptx = new PptxViewer(document.getElementById('pptx-container')!);
+  +const canvas = document.getElementById('pptx-canvas') as HTMLCanvasElement;
+  +const pptx = new PptxViewer(canvas);
+  ```
+
 ## 0.24.3 — 2026-04-30
 
 Documentation-only patch standardizing the `Viewer.load` examples across

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ docx.nextPage();
 const xlsx = new XlsxViewer(document.getElementById('xlsx-container')!);
 await xlsx.load('/workbook.xlsx');
 
-// PPTX — viewer manages its own <canvas>
-const pptx = new PptxViewer(document.getElementById('pptx-container')!);
+// PPTX — caller provides the <canvas>
+const pptxCanvas = document.getElementById('pptx-canvas') as HTMLCanvasElement;
+const pptx = new PptxViewer(pptxCanvas);
 await pptx.load('/deck.pptx');
 pptx.nextSlide();
 ```
@@ -137,15 +138,15 @@ import { useEffect, useRef, useState } from 'react';
 import { PptxViewer } from '@silurus/ooxml/pptx';
 
 export function PptxViewerComponent({ src }: { src: string }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const viewerRef   = useRef<PptxViewer | null>(null);
+  const canvasRef  = useRef<HTMLCanvasElement>(null);
+  const viewerRef  = useRef<PptxViewer | null>(null);
   const [slide, setSlide] = useState({ current: 0, total: 0 });
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-    const viewer = new PptxViewer(container, {
+    const viewer = new PptxViewer(canvas, {
       onSlideChange: (i, total) => setSlide({ current: i, total }),
     });
     viewerRef.current = viewer;
@@ -154,7 +155,7 @@ export function PptxViewerComponent({ src }: { src: string }) {
 
   return (
     <div>
-      <div ref={containerRef} style={{ width: 800 }} />
+      <canvas ref={canvasRef} style={{ width: 800 }} />
       <button onClick={() => viewerRef.current?.prevSlide()}>‹ Prev</button>
       <span> {slide.current + 1} / {slide.total} </span>
       <button onClick={() => viewerRef.current?.nextSlide()}>Next ›</button>
@@ -176,13 +177,13 @@ import { PptxViewer } from '@silurus/ooxml/pptx';
 
 const props = defineProps<{ src: string }>();
 
-const container = useTemplateRef<HTMLDivElement>('container');
+const canvas  = useTemplateRef<HTMLCanvasElement>('canvas');
 let viewer: PptxViewer | null = null;
 const current = ref(0);
 const total   = ref(0);
 
 onMounted(async () => {
-  viewer = new PptxViewer(container.value!, {
+  viewer = new PptxViewer(canvas.value!, {
     onSlideChange: (i, t) => { current.value = i; total.value = t; },
   });
   await viewer.load(props.src);
@@ -191,7 +192,7 @@ onMounted(async () => {
 
 <template>
   <div>
-    <div ref="container" style="width: 800px" />
+    <canvas ref="canvas" style="width: 800px" />
     <button @click="viewer?.prevSlide()">‹ Prev</button>
     <span> {{ current + 1 }} / {{ total }} </span>
     <button @click="viewer?.nextSlide()">Next ›</button>
@@ -217,7 +218,7 @@ import { PptxViewer } from '@silurus/ooxml/pptx';
   standalone: true,
   template: `
     <div>
-      <div #container style="width: 800px"></div>
+      <canvas #canvas style="width: 800px"></canvas>
       <button (click)="prev()">‹ Prev</button>
       <span> {{ current() + 1 }} / {{ total() }} </span>
       <button (click)="next()">Next ›</button>
@@ -225,13 +226,13 @@ import { PptxViewer } from '@silurus/ooxml/pptx';
   `,
 })
 export class PptxViewerComponent implements AfterViewInit {
-  containerEl = viewChild.required<ElementRef<HTMLDivElement>>('container');
+  canvasEl = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
   current = signal(0);
   total   = signal(0);
   private viewer?: PptxViewer;
 
   ngAfterViewInit(): void {
-    this.viewer = new PptxViewer(this.containerEl().nativeElement, {
+    this.viewer = new PptxViewer(this.canvasEl().nativeElement, {
       onSlideChange: (i, t) => { this.current.set(i); this.total.set(t); },
     });
     this.viewer.load('/deck.pptx');
@@ -257,13 +258,13 @@ export class PptxViewerComponent implements AfterViewInit {
 
   let { src }: { src: string } = $props();
 
-  let container: HTMLDivElement;
+  let canvas: HTMLCanvasElement;
   let viewer: PptxViewer;
   let current = $state(0);
   let total   = $state(0);
 
   onMount(async () => {
-    viewer = new PptxViewer(container, {
+    viewer = new PptxViewer(canvas, {
       onSlideChange: (i, t) => { current = i; total = t; },
     });
     await viewer.load(src);
@@ -271,7 +272,7 @@ export class PptxViewerComponent implements AfterViewInit {
 </script>
 
 <div>
-  <div bind:this={container} style="width: 800px"></div>
+  <canvas bind:this={canvas} style="width: 800px"></canvas>
   <button onclick={() => viewer?.prevSlide()}>‹ Prev</button>
   <span> {current + 1} / {total} </span>
   <button onclick={() => viewer?.nextSlide()}>Next ›</button>
@@ -289,13 +290,13 @@ import { createSignal, onMount, onCleanup } from 'solid-js';
 import { PptxViewer } from '@silurus/ooxml/pptx';
 
 export function PptxViewerComponent(props: { src: string }) {
-  let containerEl!: HTMLDivElement;
+  let canvasEl!: HTMLCanvasElement;
   let viewer: PptxViewer | undefined;
   const [current, setCurrent] = createSignal(0);
   const [total,   setTotal  ] = createSignal(0);
 
   onMount(async () => {
-    viewer = new PptxViewer(containerEl, {
+    viewer = new PptxViewer(canvasEl, {
       onSlideChange: (i, t) => { setCurrent(i); setTotal(t); },
     });
     await viewer.load(props.src);
@@ -305,7 +306,7 @@ export function PptxViewerComponent(props: { src: string }) {
 
   return (
     <div>
-      <div ref={containerEl} style={{ width: '800px' }} />
+      <canvas ref={canvasEl} style={{ width: '800px' }} />
       <button onClick={() => viewer?.prevSlide()}>‹ Prev</button>
       <span> {current() + 1} / {total()} </span>
       <button onClick={() => viewer?.nextSlide()}>Next ›</button>
@@ -325,16 +326,16 @@ import { component$, useSignal, useVisibleTask$ } from '@builder.io/qwik';
 import type { PptxViewer as PptxViewerType } from '@silurus/ooxml/pptx';
 
 export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
-  const containerRef = useSignal<HTMLDivElement>();
+  const canvasRef = useSignal<HTMLCanvasElement>();
   const current = useSignal(0);
   const total   = useSignal(0);
   let viewer: PptxViewerType | undefined;
 
   // useVisibleTask$ runs only in the browser, never during SSR
   useVisibleTask$(async () => {
-    if (!containerRef.value) return;
+    if (!canvasRef.value) return;
     const { PptxViewer } = await import('@silurus/ooxml/pptx');
-    viewer = new PptxViewer(containerRef.value, {
+    viewer = new PptxViewer(canvasRef.value, {
       onSlideChange: (i, t) => { current.value = i; total.value = t; },
     });
     await viewer.load(src);
@@ -342,7 +343,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 
   return (
     <div>
-      <div ref={containerRef} style={{ width: '800px' }} />
+      <canvas ref={canvasRef} style={{ width: '800px' }} />
       <button onClick$={() => viewer?.prevSlide()}>‹ Prev</button>
       <span> {current.value + 1} / {total.value} </span>
       <button onClick$={() => viewer?.nextSlide()}>Next ›</button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.24.3",
+  "version": "0.25.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.24.3",
+  "version": "0.25.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.24.3",
+  "version": "0.25.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -26,7 +26,10 @@ export class DocxViewer {
     // Wrap canvas in a positioned container for the optional text layer overlay
     const parent = canvas.parentElement;
     this._wrapper = document.createElement('div');
-    this._wrapper.style.cssText = 'position:relative;display:inline-block;';
+    // vertical-align:top removes the inline-block baseline descender gap that
+    // otherwise lets the host container's background show through below the
+    // canvas (~6 px on default font metrics).
+    this._wrapper.style.cssText = 'position:relative;display:inline-block;vertical-align:top;';
     if (parent) {
       parent.insertBefore(this._wrapper, canvas);
     }

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.24.3",
+  "version": "0.25.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -201,7 +201,9 @@ export const MasterDetail: LayoutStory = {
     layout.append(thumbCol, detailCol);
 
     // Detail viewer with text selection
-    const detailViewer = new PptxViewer(detailCol, {
+    const detailCanvas = document.createElement('canvas');
+    detailCol.appendChild(detailCanvas);
+    const detailViewer = new PptxViewer(detailCanvas, {
       width: 800,
       useGoogleFonts: true,
       enableTextSelection: true,

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -58,7 +58,10 @@ export function buildViewerUI(
   const spinner = createCanvasSpinner();
   container.appendChild(spinner);
 
-  const viewer = new PptxViewer(container, {
+  const canvas = document.createElement('canvas');
+  container.appendChild(canvas);
+
+  const viewer = new PptxViewer(canvas, {
     width: args.width,
     useGoogleFonts: true,
     enableTextSelection: true,
@@ -226,7 +229,9 @@ export const FileUpload: Story = {
       status.textContent = `Parsing ${name}…`;
       viewer?.destroy();
       container.innerHTML = '';
-      viewer = new PptxViewer(container, {
+      const canvas = document.createElement('canvas');
+      container.appendChild(canvas);
+      viewer = new PptxViewer(canvas, {
         width: args.width,
         enableMediaPlayback: true,
         onSlideChange: (idx, total) => {

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -30,8 +30,10 @@ export interface PptxViewerOptions extends RenderOptions {
 /**
  * Opinionated single-canvas PPTX viewer.
  *
- * Creates a <canvas> element, appends it to the provided container, and manages
- * slide navigation.
+ * Accepts a caller-supplied `<canvas>` element and wraps it in a positioned
+ * container for the optional text-selection overlay.  The wrapper is inserted
+ * into the canvas's existing parent (reparent), so the canvas stays at its
+ * original position in the DOM.
  *
  * For custom layouts (multi-canvas, thumbnails, scroll view) use PptxPresentation directly.
  */
@@ -44,20 +46,18 @@ export class PptxViewer {
   private currentSlide = 0;
   private handle: PresentationHandle | null = null;
 
-  constructor(container: HTMLElement, opts: PptxViewerOptions = {}) {
+  constructor(canvas: HTMLCanvasElement, opts: PptxViewerOptions = {}) {
     this.opts = opts;
+    this.canvas = canvas;
 
+    const parent = canvas.parentElement;
     this.wrapper = document.createElement('div');
     // vertical-align:top removes the inline-block baseline descender gap that
     // otherwise lets the host container's background show through below the
     // canvas (~6 px on default font metrics).
     this.wrapper.style.cssText = 'position:relative;display:inline-block;vertical-align:top;';
-
-    this.canvas = document.createElement('canvas');
-    this.canvas.style.display = 'block';
-    this.canvas.style.maxWidth = '100%';
-    this.canvas.style.height = 'auto';
-    this.wrapper.appendChild(this.canvas);
+    if (parent) parent.insertBefore(this.wrapper, canvas);
+    this.wrapper.appendChild(canvas);
 
     if (opts.enableTextSelection) {
       this.textLayer = document.createElement('div');
@@ -66,8 +66,6 @@ export class PptxViewer {
         'overflow:hidden;pointer-events:none;user-select:text;-webkit-user-select:text;';
       this.wrapper.appendChild(this.textLayer);
     }
-
-    container.appendChild(this.wrapper);
   }
 
   /** Load a PPTX from URL or ArrayBuffer and render the first slide. */

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.24.3",
+  "version": "0.25.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.24.3",
+  "version": "0.25.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

- **Breaking change**: `PptxViewer` constructor changed from `new PptxViewer(container: HTMLElement)` to `new PptxViewer(canvas: HTMLCanvasElement)` — aligns with `DocxViewer` (same reparent pattern). `XlsxViewer` is unchanged.
- Viewer wraps the supplied canvas in an internal `wrapper` div via `insertBefore` reparent; no DOM structure change visible to callers.
- All call sites updated: `PptxViewer.stories.ts` (2), `Examples.stories.ts` (1), README Quick Start + 6 framework examples (React/Vue/Angular/Svelte/SolidJS/Qwik).
- `CHANGELOG.md` updated with 0.25.0 breaking change + migration snippet.
- All 6 `package.json` files bumped to `0.25.0`.

### Migration

```diff
-const pptx = new PptxViewer(document.getElementById('pptx-container')!);
+const canvas = document.getElementById('pptx-canvas') as HTMLCanvasElement;
+const pptx = new PptxViewer(canvas);
```

## Test plan

- [ ] `pnpm storybook` on port 6007 — verify `PptxViewer / Load from file` and `PptxViewer/Examples / MasterDetail` stories render correctly
- [ ] Upload a `.pptx` in the `Load from file` story to confirm slide navigation works
- [ ] Check `MasterDetail` story: thumbnails + detail viewer both display

🤖 Generated with [Claude Code](https://claude.com/claude-code)