### PR TITLE
chore(release): 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.26.0 — 2026-05-08
+
+### Fixes
+
+- **xlsx renderer**: pick the higher-precedence ST_BorderStyle (none<hair<dotted<…<medium<thick<double) when two adjacent cells specify a border on the shared edge. Previously the lower / right cell's thinner top / left would partially erase the upper / left cell's medium or thick edge — most visible on sample-27 row 9 where the medium top was shown as roughly the same weight as the thick bottom even though the styles differed. ECMA-376 §18.3.1.4 doesn't spell out conflict resolution, but Excel renders the stronger style at a conflict.
+- **xlsx renderer**: render `hair` as a 1-px on / 1-px off dashed pattern instead of a faint solid line. ECMA-376 §18.18.3 ST_BorderStyle "hair" is the finest dashing in Excel's border picker; the previous solid render was indistinguishable from `thin` (e.g. sample-27 G13 outer frame).
+- **xlsx renderer**: close `double`-border corners when the lower / right cell has to redraw the over-painted segment. The inherited top / left now uses the upper / left cell's outer-vs-inner extension so the line restored after the lower cell's fill is the *outer* (extended) one — eliminating 1-px gaps at the four outer corners (visible on isolated double-bordered cells such as sample-27 E5).
+- **xlsx renderer**: widen `medium` (1.5 → 2) and `thick` (2 → 3) `lineWidth` to match Excel's pt convention (thin=1pt / medium=2pt / thick=3pt). Previously medium and thick both rasterised to roughly a 2-pixel band on canvas, so a row with medium-on-top and thick-on-bottom (e.g. sample-27 row 9 driven by `thickBot` / `thickTop` row attributes) read as the same weight.
+
+### Tooling
+
+- **vrt**: dropped the GitHub Actions VRT workflow and rebuilt the flow as local-only. The `private/sample-*` fixtures are not redistributable so cannot be committed; running VRT on CI provided no signal beyond `demo/sample-*`. `pnpm vrt` now expects the developer to have private fixtures locally and gates reference updates behind `UPDATE_REFS=1`.
+
 ## 0.25.0 — 2026-04-30
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

XLSX border rendering fixes (PR #181) plus VRT tooling cleanup (PR #180).

- **xlsx renderer**: pick stronger ST_BorderStyle at shared edges (medium/thick no longer half-erased by adjacent thin top/left).
- **xlsx renderer**: render \`hair\` as a 1-px on / 1-px off dashed pattern (was a faint solid line).
- **xlsx renderer**: close \`double\`-border corners via inverted extension on inherited top / left.
- **xlsx renderer**: widen \`medium\` (1.5 → 2) and \`thick\` (2 → 3) lineWidth to Excel's pt convention.
- **vrt**: dropped CI VRT, kept local-only flow with \`UPDATE_REFS=1\` for reference regeneration.

## Notes

- README screenshots not retaken — the dashboard view in \`docs/images/xlsx.png\` doesn't visibly change with these border fixes (the affected styles are most prominent on cells with explicit medium/thick/double/hair borders, not on the table-style banded cells in the demo).
- Support table unchanged: borders is already ✅; only precision improvements.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm vrt\` (demo passes; private gitignored)
- [ ] Manual verification on private fixtures (sample-27 row 9, E5, G13)