### PR TITLE
feat(vscode): auto-install ooxml-mcp-server on demand

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -1,0 +1,133 @@
+name: Release MCP Server Binaries
+
+# Builds prebuilt `ooxml-mcp-server` binaries for macOS (arm64/x64), Linux x64,
+# and Windows x64, and uploads them to the matching GitHub Release. The VS Code
+# extension downloads these on demand instead of bundling them, keeping the
+# extension small.
+#
+# Triggered when a `gh release create v*` is run (per the release procedure in
+# the root CLAUDE.md). Can also be invoked manually for an existing tag.
+
+on:
+  release:
+    types: [created, published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach binaries to (e.g. v0.27.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-14
+            binary: ooxml-mcp-server
+            asset: ooxml-mcp-server-aarch64-apple-darwin
+          - target: x86_64-apple-darwin
+            os: macos-13
+            binary: ooxml-mcp-server
+            asset: ooxml-mcp-server-x86_64-apple-darwin
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: ooxml-mcp-server
+            asset: ooxml-mcp-server-x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: ooxml-mcp-server
+            asset: ooxml-mcp-server-aarch64-unknown-linux-gnu
+            cross: true
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary: ooxml-mcp-server.exe
+            asset: ooxml-mcp-server-x86_64-pc-windows-msvc.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/mcp-server
+          key: ${{ matrix.target }}
+
+      - name: Install cross-compile linker (aarch64-linux)
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          mkdir -p ~/.cargo
+          echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
+
+      - name: Build
+        working-directory: packages/mcp-server
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Stage binary
+        shell: bash
+        run: |
+          mkdir -p staging
+          cp "packages/mcp-server/target/${{ matrix.target }}/release/${{ matrix.binary }}" "staging/${{ matrix.asset }}"
+
+      - name: Compute SHA256
+        shell: bash
+        working-directory: staging
+        run: |
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+          else
+            shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+          fi
+          cat "${{ matrix.asset }}.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: staging/*
+          if-no-files-found: error
+
+  release:
+    name: Attach binaries to release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag name
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -n "${DISPATCH_TAG:-}" ]; then
+            echo "name=${DISPATCH_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          ls -la artifacts
+          gh release upload "$TAG" artifacts/* --clobber

--- a/README.md
+++ b/README.md
@@ -504,8 +504,8 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 
 ## Companion packages
 
-- **[`packages/vscode-extension/`](packages/vscode-extension/)** — VS Code extension (`ooxml-viewer`) that registers `CustomEditorProvider`s for `.docx`, `.xlsx`, and `.pptx`. Open Office files directly in the editor with the same Canvas renderer plus selection/copy.
-- **[`packages/mcp-server/`](packages/mcp-server/)** — Rust MCP server (`ooxml-mcp-server`) exposing the parsers as tools for AI agents (Claude, Copilot, Codex, etc.). Provides structured queries (`docx_get_structure`, `xlsx_get_cell_range`, `pptx_get_slide_structure`, …) so agents can inspect OOXML files without shelling out to `unzip`.
+- **[`packages/vscode-extension/`](packages/vscode-extension/)** — VS Code extension (`ooxml-viewer`) that registers `CustomEditorProvider`s for `.docx`, `.xlsx`, and `.pptx`, and (opt-in) auto-installs and registers the `ooxml-mcp-server` so AI coding agents in the same window (Copilot Agent mode, Claude, …) can read those files via dedicated tools.
+- **[`packages/mcp-server/`](packages/mcp-server/)** — Rust MCP server (`ooxml-mcp-server`) exposing the parsers as tools for AI agents (Claude, Copilot, Codex, etc.). Provides structured queries (`docx_get_structure`, `xlsx_get_cell_range`, `pptx_get_slide_structure`, …) so agents can inspect OOXML files without shelling out to `unzip`. Prebuilt binaries are attached to each [GitHub Release](https://github.com/yukiyokotani/office-open-xml-viewer/releases) for macOS / Linux / Windows; the VS Code extension downloads them on demand.
 
 ---
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -4,48 +4,57 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that l
 
 ---
 
-## Quick start
+## Easiest: VS Code extension (recommended for VS Code users)
 
-### Step 1 — Install Rust
+Install the [Office Viewer extension](https://marketplace.visualstudio.com/items?itemName=silurus.office-open-xml-viewer). Open a workspace that contains an `.xlsx`, `.docx`, or `.pptx` file and accept the prompt — the extension downloads a prebuilt binary (~5 MB, SHA256-verified) and registers the MCP server with VS Code automatically. Copilot Agent mode and any other MCP-aware agent in VS Code picks it up with no further configuration.
 
-Skip this if `rustc --version` already prints a version number.
+If you don't use VS Code, or want to wire this into Claude Code / Codex CLI / a different editor, follow the manual install below.
+
+---
+
+## Manual install: prebuilt binaries
+
+Each release ships prebuilt binaries on the [Releases page](https://github.com/yukiyokotani/office-open-xml-viewer/releases/latest):
+
+| Platform | Asset name |
+|----------|------------|
+| macOS (Apple Silicon) | `ooxml-mcp-server-aarch64-apple-darwin` |
+| macOS (Intel) | `ooxml-mcp-server-x86_64-apple-darwin` |
+| Linux x64 | `ooxml-mcp-server-x86_64-unknown-linux-gnu` |
+| Linux arm64 | `ooxml-mcp-server-aarch64-unknown-linux-gnu` |
+| Windows x64 | `ooxml-mcp-server-x86_64-pc-windows-msvc.exe` |
+
+Each asset has an accompanying `.sha256` file. Download, verify, mark executable, and place anywhere on your `PATH`:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-# Follow the on-screen prompt, then open a new terminal tab.
+TAG=v0.27.0   # pick the latest release
+ASSET=ooxml-mcp-server-aarch64-apple-darwin   # pick your platform
+curl -L -o ooxml-mcp-server  "https://github.com/yukiyokotani/office-open-xml-viewer/releases/download/${TAG}/${ASSET}"
+curl -L -o sums.txt         "https://github.com/yukiyokotani/office-open-xml-viewer/releases/download/${TAG}/${ASSET}.sha256"
+shasum -a 256 -c sums.txt   # must print "OK"
+chmod +x ooxml-mcp-server
+mv ooxml-mcp-server /usr/local/bin/
 ```
 
-### Step 2 — Install the MCP server
+---
 
-No need to clone the repository. Run this single command:
+## Manual install: build from source
+
+Skip this section unless you want to build from source.
 
 ```bash
+# Install Rust if needed: https://rustup.rs
 cargo install --git https://github.com/yukiyokotani/office-open-xml-viewer.git \
   --package ooxml-mcp-server
 ```
 
-The first run downloads and compiles everything (~2 minutes). The binary is placed in `~/.cargo/bin/ooxml-mcp-server`.
-
-**Check it is on your PATH:**
-
-```bash
-which ooxml-mcp-server
-# expected: /Users/you/.cargo/bin/ooxml-mcp-server
-```
-
-If the command is not found, add this line to your shell profile (`~/.zshrc` or `~/.bashrc`) and open a new terminal:
-
-```bash
-export PATH="$HOME/.cargo/bin:$PATH"
-```
-
-### Step 3 — Configure your AI client
-
-Pick the client you use and follow the instructions in the section below.
+The binary is placed in `~/.cargo/bin/ooxml-mcp-server`. Make sure `~/.cargo/bin` is on your `PATH`.
 
 ---
 
-## Configuration
+## Configure your AI client
+
+Pick the client you use and follow the instructions below.
 
 ### Claude Code
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -20,6 +20,7 @@ A high-fidelity viewer for `.docx`, `.xlsx`, and `.pptx` files — powered by a 
 - **XLSX** — Spreadsheet viewer with cell / row / column / range selection, tab-separated copy (Ctrl+C / Cmd+C), freeze-pane support, and a multi-sheet tab bar.
 - **PPTX** — Continuous **scroll view** of every slide with a transparent text layer that handles rotated text boxes correctly.
 - **High fidelity** — Charts, conditional formatting, theme colors, custom geometry shapes, and more rendered straight from the OOXML spec.
+- **MCP server (opt-in)** — Lets AI coding agents (Copilot, Claude, etc.) read `.xlsx` / `.docx` / `.pptx` files in your workspace through dedicated tools instead of unzipping XML by hand. See [MCP server for AI agents](#mcp-server-for-ai-agents) below.
 
 All three formats share the same Rust parser (`wasm-pack`) for accuracy and speed.
 
@@ -34,10 +35,27 @@ If a different editor opens by default, right-click the file → **Reopen Editor
 - **DOCX / PPTX** — Drag across rendered text to select, then **Ctrl+C / Cmd+C** to copy as plain text. The transparent overlay matches the canvas glyph positions, so selection feels native. *(This dual-layer rendering is planned to be unified once the Canvas [`drawElement`](https://github.com/WICG/html-in-canvas) API ships across browsers.)*
 - **XLSX** — Click a cell to select it, drag for a range, click row/column headers for full-row/column selection, click the corner box for sheet-wide selection. **Ctrl+C / Cmd+C** copies as TSV.
 
+## MCP server for AI agents
+
+Open a workspace that contains a `.xlsx` / `.docx` / `.pptx` file and the extension offers to enable an [MCP server](https://modelcontextprotocol.io/) — a tiny native binary that lets AI coding agents read those files directly. Without it, agents typically resort to running `unzip` + XML parsing in Python; with it, they call typed tools like `xlsx_get_cell_range`, `docx_extract_text`, or `pptx_get_slide_structure`.
+
+- The first time you click **Enable**, a ~5 MB prebuilt binary is downloaded from this repo's [GitHub Releases](https://github.com/yukiyokotani/office-open-xml-viewer/releases) and verified by SHA256. Subsequent workspaces reuse the cached binary.
+- If you already have `ooxml-mcp-server` on your `PATH` (e.g. installed via `cargo install --git ...`), it is used as-is — no download.
+- The server is registered with VS Code's MCP API, so any agent that supports MCP (GitHub Copilot Agent mode, Claude, etc.) picks it up automatically.
+
+**Settings:**
+- `ooxmlViewer.mcpServer.enabled`: `auto` (default — prompt only when the workspace contains OOXML files), `always`, or `never`.
+- `ooxmlViewer.mcpServer.binaryPath`: optional override pointing at a pre-installed binary.
+
+**Commands (Command Palette):**
+- `OOXML Viewer: Install / Enable MCP Server`
+- `OOXML Viewer: Disable MCP Server`
+
 ## Privacy & Security
 
-- **Zero network access.** The Webview's Content Security Policy disallows outbound connections to any origin other than the extension itself. There is no analytics, no font CDN, no remote API.
-- **Local file I/O only.** The extension reads bytes via `vscode.workspace.fs.readFile` and never writes back — files are opened read-only.
+- **Local file I/O only.** The viewer reads bytes via `vscode.workspace.fs.readFile` and never writes back — files are opened read-only.
+- **Webview is offline.** The Webview's Content Security Policy disallows outbound connections to any origin other than the extension itself. No analytics, no font CDN, no remote API.
+- **MCP server is opt-in and offline-after-install.** Until you accept the install prompt the extension makes no network requests. The download itself only contacts `github.com`, is checksum-verified, and the resulting binary parses local files only — it does not phone home. Whatever the connected AI agent does with the data is governed by that agent's own privacy settings.
 - **Open source.** Source code at [github.com/yukiyokotani/office-open-xml-viewer](https://github.com/yukiyokotani/office-open-xml-viewer).
 
 VS Code's own telemetry is independent of this extension and can be controlled via the `telemetry.telemetryLevel` setting.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "icon": "icon.png",
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Visualization",
@@ -62,8 +62,45 @@
         "command": "ooxmlViewer.copySelection",
         "title": "Copy Selection",
         "category": "OOXML Viewer"
+      },
+      {
+        "command": "ooxmlViewer.installMcpServer",
+        "title": "Install / Enable MCP Server",
+        "category": "OOXML Viewer"
+      },
+      {
+        "command": "ooxmlViewer.disableMcpServer",
+        "title": "Disable MCP Server",
+        "category": "OOXML Viewer"
       }
-    ]
+    ],
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "ooxml-mcp",
+        "label": "OOXML (Word / Excel / PowerPoint)"
+      }
+    ],
+    "configuration": {
+      "title": "OOXML Viewer",
+      "properties": {
+        "ooxmlViewer.mcpServer.enabled": {
+          "type": "string",
+          "enum": ["auto", "always", "never"],
+          "enumDescriptions": [
+            "Offer to enable when the workspace contains .xlsx / .docx / .pptx files.",
+            "Always register the MCP server (downloading the binary on first use).",
+            "Never register the MCP server."
+          ],
+          "default": "auto",
+          "description": "Controls when the OOXML MCP server is registered with AI agents (Copilot, Claude, etc.). The server lets agents read .xlsx / .docx / .pptx files via dedicated tools instead of unzipping XML by hand."
+        },
+        "ooxmlViewer.mcpServer.binaryPath": {
+          "type": "string",
+          "default": "",
+          "description": "Optional absolute path to a pre-installed `ooxml-mcp-server` binary (e.g. one installed via `cargo install`). When empty, the extension downloads a prebuilt binary on demand."
+        }
+      }
+    }
   },
   "scripts": {
     "compile": "node esbuild.config.mjs",
@@ -72,7 +109,7 @@
     "package": "vsce package"
   },
   "devDependencies": {
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.101.0",
     "@vscode/vsce": "^3.0.0",
     "esbuild": "^0.25.0",
     "typescript": "^5.7.0"

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { DocxEditorProvider } from './providers/docxEditor';
 import { XlsxEditorProvider } from './providers/xlsxEditor';
 import { PptxEditorProvider } from './providers/pptxEditor';
+import { activateMcp } from './mcp';
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
@@ -9,6 +10,7 @@ export function activate(context: vscode.ExtensionContext): void {
     XlsxEditorProvider.register(context),
     PptxEditorProvider.register(context),
   );
+  activateMcp(context);
 }
 
 export function deactivate(): void {

--- a/packages/vscode-extension/src/mcp/index.ts
+++ b/packages/vscode-extension/src/mcp/index.ts
@@ -1,0 +1,118 @@
+import * as vscode from 'vscode';
+import {
+  McpServerNotInstalledError,
+  cachedBinaryPath,
+  resolveBinaryPath,
+} from './installer';
+import { OoxmlMcpProvider, workspaceHasOoxmlFiles } from './provider';
+
+const PROVIDER_ID = 'ooxml-mcp';
+const NEVER_ASK_KEY = 'ooxmlViewer.mcp.neverAskAgain';
+
+export function activateMcp(context: vscode.ExtensionContext): void {
+  // The MCP API was finalised in VS Code 1.101. If the host runs an older
+  // VS Code, skip MCP integration silently — the editor features still work.
+  const lm = (vscode as unknown as { lm?: typeof vscode.lm }).lm;
+  if (!lm || typeof lm.registerMcpServerDefinitionProvider !== 'function') {
+    return;
+  }
+
+  const provider = new OoxmlMcpProvider(context);
+  context.subscriptions.push(
+    lm.registerMcpServerDefinitionProvider(PROVIDER_ID, provider),
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('ooxmlViewer.mcpServer')) {
+        provider.refresh();
+      }
+    }),
+    vscode.commands.registerCommand('ooxmlViewer.installMcpServer', () =>
+      installCommand(context, provider),
+    ),
+    vscode.commands.registerCommand('ooxmlViewer.disableMcpServer', () =>
+      disableCommand(provider),
+    ),
+  );
+
+  void promptIfNeeded(context, provider);
+}
+
+async function promptIfNeeded(
+  context: vscode.ExtensionContext,
+  provider: OoxmlMcpProvider,
+): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration('ooxmlViewer.mcpServer');
+  const enabled = cfg.get<'auto' | 'always' | 'never'>('enabled', 'auto');
+  if (enabled === 'never') return;
+
+  if (enabled === 'auto') {
+    if (!(await workspaceHasOoxmlFiles())) return;
+    if (context.globalState.get<boolean>(NEVER_ASK_KEY)) return;
+  }
+
+  // Already resolvable (override / cache / PATH) — just refresh and exit.
+  try {
+    await resolveBinaryPath(context, {
+      override: cfg.get<string>('binaryPath', ''),
+      consentToDownload: false,
+    });
+    provider.refresh();
+    return;
+  } catch (err) {
+    if (!(err instanceof McpServerNotInstalledError)) {
+      void vscode.window.showErrorMessage(
+        `OOXML MCP server: ${(err as Error).message}`,
+      );
+      return;
+    }
+  }
+
+  const enableLabel = 'Enable';
+  const notNowLabel = 'Not now';
+  const neverLabel = "Don't ask again";
+  const choice = await vscode.window.showInformationMessage(
+    'Enable the OOXML MCP server so AI agents (Copilot, Claude, etc.) can read .xlsx/.docx/.pptx files in this workspace? A small (~5 MB) binary will be downloaded on first use.',
+    enableLabel,
+    notNowLabel,
+    neverLabel,
+  );
+
+  if (choice === enableLabel) {
+    await installCommand(context, provider);
+  } else if (choice === neverLabel) {
+    await context.globalState.update(NEVER_ASK_KEY, true);
+  }
+}
+
+async function installCommand(
+  context: vscode.ExtensionContext,
+  provider: OoxmlMcpProvider,
+): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration('ooxmlViewer.mcpServer');
+  try {
+    const path = await resolveBinaryPath(context, {
+      override: cfg.get<string>('binaryPath', ''),
+      consentToDownload: true,
+    });
+    provider.refresh();
+    void vscode.window.showInformationMessage(
+      `OOXML MCP server is ready (${path === cachedBinaryPath(context) ? 'downloaded' : 'using existing binary'}).`,
+    );
+  } catch (err) {
+    void vscode.window.showErrorMessage(
+      `Failed to install ooxml-mcp-server: ${(err as Error).message}`,
+    );
+  }
+}
+
+async function disableCommand(provider: OoxmlMcpProvider): Promise<void> {
+  await vscode.workspace
+    .getConfiguration('ooxmlViewer.mcpServer')
+    .update('enabled', 'never', vscode.ConfigurationTarget.Global);
+  provider.refresh();
+  void vscode.window.showInformationMessage(
+    'OOXML MCP server disabled. Re-enable it via the "ooxmlViewer.mcpServer.enabled" setting.',
+  );
+}

--- a/packages/vscode-extension/src/mcp/installer.ts
+++ b/packages/vscode-extension/src/mcp/installer.ts
@@ -1,0 +1,156 @@
+// Resolves the `ooxml-mcp-server` binary path for the MCP server provider.
+//
+// Resolution order:
+//   1. User override (`ooxmlViewer.mcpServer.binaryPath` setting)
+//   2. Cached binary previously downloaded into the extension's globalStorage
+//   3. Binary on PATH (e.g. installed via `cargo install` or Homebrew)
+//   4. Download from GitHub Releases (only when the caller consents)
+//
+// The binary is intentionally NOT bundled into the extension — keeping the VSIX
+// small. Users who want the MCP server pay the ~5 MB download once.
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const REPO_OWNER = 'yukiyokotani';
+const REPO_NAME = 'office-open-xml-viewer';
+
+export class McpServerNotInstalledError extends Error {
+  constructor() {
+    super('ooxml-mcp-server binary is not installed');
+    this.name = 'McpServerNotInstalledError';
+  }
+}
+
+export interface ResolveOptions {
+  /** User override path. Empty string = unset. */
+  override: string;
+  /** Whether to download the binary if not already available. */
+  consentToDownload: boolean;
+}
+
+export async function resolveBinaryPath(
+  context: vscode.ExtensionContext,
+  opts: ResolveOptions,
+): Promise<string> {
+  if (opts.override && opts.override.trim()) {
+    const p = opts.override.trim();
+    if (!fs.existsSync(p)) {
+      throw new Error(`Configured ooxml-mcp-server binary not found: ${p}`);
+    }
+    return p;
+  }
+
+  const cached = cachedBinaryPath(context);
+  if (fs.existsSync(cached)) return cached;
+
+  const onPath = await findOnPath(binaryFileName());
+  if (onPath) return onPath;
+
+  if (opts.consentToDownload) {
+    await downloadBinary(context);
+    return cached;
+  }
+
+  throw new McpServerNotInstalledError();
+}
+
+export function cachedBinaryPath(context: vscode.ExtensionContext): string {
+  return path.join(context.globalStorageUri.fsPath, 'bin', binaryFileName());
+}
+
+function binaryFileName(): string {
+  return process.platform === 'win32' ? 'ooxml-mcp-server.exe' : 'ooxml-mcp-server';
+}
+
+function targetTriple(): string {
+  const platform = process.platform;
+  const arch = process.arch;
+  if (platform === 'darwin' && arch === 'arm64') return 'aarch64-apple-darwin';
+  if (platform === 'darwin' && arch === 'x64') return 'x86_64-apple-darwin';
+  if (platform === 'linux' && arch === 'x64') return 'x86_64-unknown-linux-gnu';
+  if (platform === 'linux' && arch === 'arm64') return 'aarch64-unknown-linux-gnu';
+  if (platform === 'win32' && arch === 'x64') return 'x86_64-pc-windows-msvc';
+  throw new Error(`Unsupported platform/arch: ${platform}/${arch}`);
+}
+
+function assetName(): string {
+  const triple = targetTriple();
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  return `ooxml-mcp-server-${triple}${ext}`;
+}
+
+async function findOnPath(name: string): Promise<string | undefined> {
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    const { stdout } = await execFileAsync(cmd, [name]);
+    const first = stdout
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .find((l) => l.length > 0);
+    return first || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function downloadBinary(context: vscode.ExtensionContext): Promise<void> {
+  const version = (context.extension.packageJSON as { version: string }).version;
+  const tag = `v${version}`;
+  const asset = assetName();
+  const baseUrl = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${tag}`;
+  const binUrl = `${baseUrl}/${asset}`;
+  const sumUrl = `${binUrl}.sha256`;
+
+  const dest = cachedBinaryPath(context);
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: `Downloading ooxml-mcp-server ${tag}`,
+      cancellable: false,
+    },
+    async (progress) => {
+      progress.report({ message: 'Fetching checksum…' });
+      const sumText = await fetchText(sumUrl);
+      const expectedSha = sumText.trim().split(/\s+/)[0]?.toLowerCase();
+      if (!expectedSha || !/^[0-9a-f]{64}$/.test(expectedSha)) {
+        throw new Error(`Invalid SHA256 file at ${sumUrl}`);
+      }
+
+      progress.report({ message: 'Downloading binary…' });
+      const buf = await fetchBinary(binUrl);
+
+      const actualSha = crypto.createHash('sha256').update(buf).digest('hex');
+      if (actualSha !== expectedSha) {
+        throw new Error(
+          `SHA256 mismatch for ${asset}: expected ${expectedSha}, got ${actualSha}`,
+        );
+      }
+
+      await fs.promises.writeFile(dest, buf);
+      if (process.platform !== 'win32') {
+        await fs.promises.chmod(dest, 0o755);
+      }
+    },
+  );
+}
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return await res.text();
+}
+
+async function fetchBinary(url: string): Promise<Buffer> {
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return Buffer.from(await res.arrayBuffer());
+}

--- a/packages/vscode-extension/src/mcp/provider.ts
+++ b/packages/vscode-extension/src/mcp/provider.ts
@@ -1,0 +1,63 @@
+import * as vscode from 'vscode';
+import { McpServerNotInstalledError, resolveBinaryPath } from './installer';
+
+export class OoxmlMcpProvider implements vscode.McpServerDefinitionProvider {
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChangeMcpServerDefinitions = this._onDidChange.event;
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  refresh(): void {
+    this._onDidChange.fire();
+  }
+
+  async provideMcpServerDefinitions(
+    _token: vscode.CancellationToken,
+  ): Promise<vscode.McpServerDefinition[]> {
+    const cfg = vscode.workspace.getConfiguration('ooxmlViewer.mcpServer');
+    const enabled = cfg.get<'auto' | 'always' | 'never'>('enabled', 'auto');
+
+    if (enabled === 'never') return [];
+    if (enabled === 'auto' && !(await workspaceHasOoxmlFiles())) return [];
+
+    let binPath: string;
+    try {
+      binPath = await resolveBinaryPath(this.context, {
+        override: cfg.get<string>('binaryPath', ''),
+        consentToDownload: false,
+      });
+    } catch (err) {
+      if (err instanceof McpServerNotInstalledError) {
+        // Activation flow handles the install prompt and calls refresh().
+        return [];
+      }
+      throw err;
+    }
+
+    return [
+      new vscode.McpStdioServerDefinition(
+        'ooxml-mcp-server',
+        binPath,
+        [],
+        { RUST_LOG: 'warn' },
+        (this.context.extension.packageJSON as { version: string }).version,
+      ),
+    ];
+  }
+
+  async resolveMcpServerDefinition(
+    server: vscode.McpServerDefinition,
+    _token: vscode.CancellationToken,
+  ): Promise<vscode.McpServerDefinition> {
+    return server;
+  }
+}
+
+export async function workspaceHasOoxmlFiles(): Promise<boolean> {
+  const found = await vscode.workspace.findFiles(
+    '**/*.{xlsx,docx,pptx}',
+    '{**/node_modules/**,**/.git/**,**/dist/**,**/build/**,**/target/**,**/.venv/**}',
+    1,
+  );
+  return found.length > 0;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,7 +129,7 @@ importers:
         version: link:../xlsx
     devDependencies:
       '@types/vscode':
-        specifier: ^1.85.0
+        specifier: ^1.101.0
         version: 1.116.0
       '@vscode/vsce':
         specifier: ^3.0.0


### PR DESCRIPTION
## Summary

- Adds VS Code extension integration that registers the `ooxml-mcp-server` with VS Code's MCP API (1.101+) so AI agents in the same window can read `.xlsx`/`.docx`/`.pptx` files via dedicated tools, instead of shelling out to `unzip` + XML parsing.
- The binary is **not** bundled into the VSIX (avoids ~15 MB cross-platform bloat). Instead the extension downloads a prebuilt binary on demand from GitHub Releases and verifies it with SHA256.
- Adds a release workflow (`release-mcp-server.yml`) that builds and attaches prebuilt `ooxml-mcp-server` binaries to every release: macOS arm64/x64, Linux x64/arm64, Windows x64.

## How it works

1. On activation, the extension scans the workspace for `*.{xlsx,docx,pptx}` (excluding common ignore dirs).
2. If found and the user has not opted out, prompts: **Enable / Not now / Don't ask again**.
3. Resolution order for the binary: ` ooxmlViewer.mcpServer.binaryPath` setting → globalStorage cache → `which ooxml-mcp-server` → download from this repo's Releases.
4. Existing ` cargo install` / Homebrew users are picked up automatically — no duplicate download.

## New settings

- `ooxmlViewer.mcpServer.enabled`: `auto` (default — prompt only when OOXML files exist), `always`, `never`.
- `ooxmlViewer.mcpServer.binaryPath`: optional absolute path override.

## New commands

- `OOXML Viewer: Install / Enable MCP Server`
- `OOXML Viewer: Disable MCP Server`

## Test plan

- [ ] After this lands and a release is cut, the new `release-mcp-server.yml` workflow fires on `release: created` and attaches all 5 binaries + sha256 files.
- [ ] Open a workspace containing `*.xlsx` in VS Code 1.101+ → prompt appears → click Enable → progress notification → MCP server shows under `MCP: List Servers`.
- [ ] In Copilot Agent mode, ask "what sheets are in `<file>.xlsx`?" → tool call to `xlsx_get_sheet_names`.
- [ ] Workspace with no OOXML files in `auto` mode → no prompt, no server registration.
- [ ] User with `~/.cargo/bin/ooxml-mcp-server` already installed → no download triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)