### PR TITLE
chore(release): 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.27.0 — 2026-05-08
+
+### Features
+
+- **vscode-extension**: auto-install integration for `ooxml-mcp-server`. When the workspace contains an `.xlsx`, `.docx`, or `.pptx` file, the extension offers to enable the MCP server so AI agents (Copilot Agent, Claude, etc.) can read those files via dedicated tools instead of unzipping XML by hand. The binary is downloaded on demand from GitHub Releases (~5 MB, SHA256-verified) into the extension's globalStorage; existing `cargo install` / Homebrew users on `PATH` are reused as-is. New settings: `ooxmlViewer.mcpServer.enabled` (`auto` / `always` / `never`) and `ooxmlViewer.mcpServer.binaryPath`. Requires VS Code 1.101+ for the finalised MCP API.
+- **mcp-server**: each release now ships prebuilt binaries for macOS (arm64 / x64), Linux (x64 / arm64), and Windows (x64) on the GitHub Release page, removing the Rust toolchain requirement for end users.
+
 ## 0.26.0 — 2026-05-08
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

- Bumps all 6 package.json files (root + core/pptx/xlsx/docx/vscode-extension) to 0.27.0.
- Adds CHANGELOG entry covering the new VS Code extension MCP auto-install integration (#184) and the prebuilt `ooxml-mcp-server` binary releases.

## Notable in 0.27.0

- VS Code extension auto-registers `ooxml-mcp-server` so AI agents (Copilot Agent, Claude, …) can read `.xlsx` / `.docx` / `.pptx` directly via dedicated tools. Binary is downloaded on demand (~5 MB, SHA256-verified) — not bundled into the VSIX.
- `ooxml-mcp-server` prebuilt binaries (macOS arm64/x64, Linux x64/arm64, Windows x64) are now attached to every GitHub Release.
- `engines.vscode` bumped to `^1.101.0` for the finalised MCP API.

## Post-merge steps

After this merges:
1. `git tag -a v0.27.0 -m v0.27.0 && git push origin v0.27.0`
2. `gh release create v0.27.0 --title v0.27.0 --notes "..."` — this also fires `release-mcp-server.yml` to attach the prebuilt MCP binaries.

## Test plan

- [ ] Extension publish workflow (`publish-vscode-extension.yml`) succeeds on tag push.
- [ ] `release-mcp-server.yml` attaches all 5 binaries + sha256 files on `gh release create`.
- [ ] Fresh VS Code (1.101+) install of the 0.27.0 extension prompts in a workspace with `*.xlsx`, downloads, and the MCP server is visible in `MCP: List Servers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)