### PR TITLE
ci(mcp): drop duplicate `release: published` trigger

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -10,7 +10,9 @@ name: Release MCP Server Binaries
 
 on:
   release:
-    types: [created, published]
+    # Only `created` — `gh release create` fires both `created` and `published`,
+    # so listening to both would build every binary twice.
+    types: [created]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

- `gh release create` fires both `release: created` and `release: published` in sequence, so subscribing to both caused every binary to build twice on v0.27.0.
- Listening to `created` alone is sufficient and halves the CI cost per release.

## Test plan

- [ ] Next release (`gh release create v0.28.0 ...`) shows exactly one `Release MCP Server Binaries` workflow run, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)