### PR TITLE
feat(pptx): expand formatAutoNum to cover ECMA-376 §20.1.10.61 schemes

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2636,17 +2636,56 @@ function buildShapePath(
   }
 }
 
-/** Format an autoNum bullet label from a counter value and OOXML numType. */
+/**
+ * Format an autoNum bullet label from a counter value and OOXML numType.
+ * Spec: ECMA-376 §20.1.10.61 (ST_TextAutonumberScheme).
+ *
+ * Supports the symmetric Plain / Period / ParenR / ParenBoth variants for
+ * the four core scripts (arabic, alphaLc/Uc, romanLc/Uc) plus arabicDb
+ * (full-width Arabic digits). CJK / Thai / Hebrew / Arabic-Abjad schemes
+ * are intentionally not handled here — they fall through to the default
+ * `arabicPeriod` rendering rather than emitting a wrong-looking glyph.
+ */
 function formatAutoNum(counter: number, numType: string): string {
+  const arabic = `${counter}`;
+  const alphaLc = counter >= 1 && counter <= 26
+    ? String.fromCharCode(96 + counter)
+    : arabic;
+  const alphaUc = counter >= 1 && counter <= 26
+    ? String.fromCharCode(64 + counter)
+    : arabic;
+  const romanLc = toRoman(counter).toLowerCase();
+  const romanUc = toRoman(counter);
+  // ECMA-376 §20.1.10.61 lists `arabicDb*` as full-width Arabic digits
+  // (U+FF10–U+FF19), used in East Asian numbered lists.
+  const arabicDb = arabic.replace(/[0-9]/g, (d) =>
+    String.fromCharCode(0xff10 + (d.charCodeAt(0) - 0x30)),
+  );
+
   switch (numType) {
-    case 'arabicPeriod':    return `${counter}.`;
-    case 'arabicParenR':    return `${counter})`;
-    case 'arabicParenBoth': return `(${counter})`;
-    case 'alphaLcPeriod':   return `${String.fromCharCode(96 + counter)}.`;
-    case 'alphaUcPeriod':   return `${String.fromCharCode(64 + counter)}.`;
-    case 'romanLcPeriod':   return `${toRoman(counter).toLowerCase()}.`;
-    case 'romanUcPeriod':   return `${toRoman(counter)}.`;
-    default:                return `${counter}.`;
+    case 'arabicPlain':       return arabic;
+    case 'arabicPeriod':      return `${arabic}.`;
+    case 'arabicParenR':      return `${arabic})`;
+    case 'arabicParenBoth':   return `(${arabic})`;
+    case 'arabicDbPlain':     return arabicDb;
+    case 'arabicDbPeriod':    return `${arabicDb}.`;
+    case 'alphaLcPlain':      return alphaLc;
+    case 'alphaLcPeriod':     return `${alphaLc}.`;
+    case 'alphaLcParenR':     return `${alphaLc})`;
+    case 'alphaLcParenBoth':  return `(${alphaLc})`;
+    case 'alphaUcPlain':      return alphaUc;
+    case 'alphaUcPeriod':     return `${alphaUc}.`;
+    case 'alphaUcParenR':     return `${alphaUc})`;
+    case 'alphaUcParenBoth':  return `(${alphaUc})`;
+    case 'romanLcPlain':      return romanLc;
+    case 'romanLcPeriod':     return `${romanLc}.`;
+    case 'romanLcParenR':     return `${romanLc})`;
+    case 'romanLcParenBoth':  return `(${romanLc})`;
+    case 'romanUcPlain':      return romanUc;
+    case 'romanUcPeriod':     return `${romanUc}.`;
+    case 'romanUcParenR':     return `${romanUc})`;
+    case 'romanUcParenBoth':  return `(${romanUc})`;
+    default:                  return `${arabic}.`;
   }
 }
 


### PR DESCRIPTION
## Summary

Extend `formatAutoNum` (used to render `a:buAutoNum` paragraph bullets) so that all symmetric Plain / Period / ParenR / ParenBoth variants are covered for the four core scripts the spec defines arithmetically:

- `arabicPlain` / `arabicPeriod` / `arabicParenR` / `arabicParenBoth`
- `arabicDbPlain` / `arabicDbPeriod` (U+FF10–U+FF19 full-width digits)
- `alphaLcPlain` / `alphaLcPeriod` / `alphaLcParenR` / `alphaLcParenBoth`
- `alphaUcPlain` / `alphaUcPeriod` / `alphaUcParenR` / `alphaUcParenBoth`
- `romanLcPlain` / `romanLcPeriod` / `romanLcParenR` / `romanLcParenBoth`
- `romanUcPlain` / `romanUcPeriod` / `romanUcParenR` / `romanUcParenBoth`

Counter values past 26 in alpha schemes now fall back to the arabic numeral instead of emitting characters past `z`/`Z` — the spec does not define `aa, bb, …` repetition, so guessing past the well-defined range would be a heuristic.

CJK / Thai / Hebrew / Arabic-Abjad schemes are intentionally left to fall through to the default `arabicPeriod` rendering. They need glyph tables rather than arithmetic and would otherwise emit wrong-looking output silently.

Spec: ECMA-376 §20.1.10.61 (`ST_TextAutonumberScheme`).

## Test plan

- [x] `tsc --noEmit` passes for `@silurus/ooxml-pptx`.
- [ ] VRT — existing demo samples don't appear to exercise the new schemes; no reference change expected. (Will report if any diff appears.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)