### PR TITLE
feat(pptx): full rPr underline-style enum (dbl/dotted/dash/wavy/heavy)

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -160,6 +160,15 @@ export interface TextRunData {
   /** null = not set, inherit from paragraph/body defaults */
   italic: boolean | null;
   underline: boolean;
+  /**
+   * Specific underline style when not the default single line. Values come
+   * from ECMA-376 §21.1.2.3.16 (ST_TextUnderlineType): "dbl", "heavy",
+   * "dotted", "dottedHeavy", "dash", "dashHeavy", "dashLong",
+   * "dashLongHeavy", "dotDash", "dotDashHeavy", "dotDotDash",
+   * "dotDotDashHeavy", "wavy", "wavyHeavy", "wavyDbl". Absent means either
+   * no underline (when `underline` is false) or the default single line.
+   */
+  underlineStyle?: string;
   /** True when rPr strike is sngStrike or dblStrike. */
   strikethrough: boolean;
   /**

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -552,6 +552,12 @@ struct TextRunData {
     /// None = not set; Some(true/false) = explicit
     italic: Option<bool>,
     underline: bool,
+    /// OOXML rPr @u value when explicit and != "sng" — e.g. "dbl", "dotted",
+    /// "dash", "wavy", "heavy", "dotDash", … None means either no underline
+    /// or the default single-line style (rPr @u = "sng" or unset truthy).
+    /// ECMA-376 §21.1.2.3.16 (ST_TextUnderlineType).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    underline_style: Option<String>,
     /// true when strike == "sngStrike" or "dblStrike"
     strikethrough: bool,
     /// true only when strike == "dblStrike" (renderer draws two parallel lines)
@@ -2229,6 +2235,7 @@ fn parse_paragraph(
                     bold,
                     italic,
                     underline: false,
+                    underline_style: None,
                     strikethrough: false,
                     strike_double: false,
                     font_size,
@@ -2321,9 +2328,14 @@ fn parse_run(
     let italic = r_pr.and_then(|n| attr(&n, "i"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "i")))
         .map(|v| v == "1" || v == "true");
-    let underline = r_pr.and_then(|n| attr(&n, "u"))
-        .or_else(|| def_rpr.and_then(|n| attr(&n, "u")))
-        .map(|v| v != "none").unwrap_or(false);
+    // ECMA-376 §21.1.2.3.16 — underline style enum: none/sng/dbl/heavy/dotted/
+    // dash/dashLong/dotDash/dotDotDash/wavy plus *Heavy variants. Carry the
+    // exact value through for the renderer to dispatch on; the bool stays
+    // true for any non-"none" value so existing code paths keep working.
+    let underline_attr = r_pr.and_then(|n| attr(&n, "u"))
+        .or_else(|| def_rpr.and_then(|n| attr(&n, "u")));
+    let underline = underline_attr.as_deref().map(|v| v != "none").unwrap_or(false);
+    let underline_style = underline_attr.filter(|v| v != "none" && v != "sng");
 
     // strikethrough: "sngStrike" or "dblStrike" → true; double tracked separately
     let strike_attr = r_pr.and_then(|n| attr(&n, "strike"))
@@ -2374,7 +2386,8 @@ fn parse_run(
         .filter(|s| !s.is_empty());
 
     Some(TextRunData {
-        text, bold, italic, underline, strikethrough, strike_double,
+        text, bold, italic, underline, underline_style,
+        strikethrough, strike_double,
         font_size, color, font_family, baseline,
         caps, letter_spacing,
         field_type: None, hyperlink,
@@ -4636,6 +4649,34 @@ mod tests {
         assert!((s.dir - 45.0).abs() < 0.001);
         assert!((s.alpha - 0.5).abs() < 0.01);
         assert_eq!(s.color.to_lowercase(), "000000");
+    }
+
+    /// ECMA-376 §21.1.2.3.16 — underline_style carries non-default underline
+    /// values (dbl, dotted, wavy, …) verbatim. The plain bool stays true for
+    /// any non-"none" value; "sng" and absent both leave underline_style None
+    /// because the renderer's default is already a single line.
+    #[test]
+    fn test_parse_run_underline_style_passthrough() {
+        let theme = HashMap::new();
+        let rels = HashMap::new();
+        let cases: &[(&str, bool, Option<&str>)] = &[
+            ("none",    false, None),
+            ("sng",     true,  None),
+            ("dbl",     true,  Some("dbl")),
+            ("heavy",   true,  Some("heavy")),
+            ("dotted",  true,  Some("dotted")),
+            ("wavy",    true,  Some("wavy")),
+            ("dashLong",true,  Some("dashLong")),
+        ];
+        for (val, expected_bool, expected_style) in cases {
+            let xml = format!(
+                r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr u="{val}"/><t>x</t></r>"#
+            );
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
+            assert_eq!(r.underline, *expected_bool, "u={val}");
+            assert_eq!(r.underline_style.as_deref(), *expected_style, "u={val}");
+        }
     }
 
     /// ECMA-376 §20.1.8.17 — glow has a single rad attribute and a colour

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -108,12 +108,100 @@ function resolveShapeFill(
 
 // ===== Text layout helpers =====
 
+/**
+ * Draw a text underline at the given baseline. ECMA-376 §21.1.2.3.16
+ * defines the OOXML underline enum; we map each value to a Canvas dash
+ * pattern + line-weight pair. "wavy*" is approximated by a sine curve
+ * traced as a polyline so the glyph stays legibly distinct from "dotted".
+ */
+function drawUnderline(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  baseline: number,
+  width: number,
+  sizePx: number,
+  color: string,
+  style: string | undefined,
+): void {
+  const baseLineW = Math.max(1, sizePx * 0.05);
+  const heavy = style?.endsWith('Heavy') ?? false;
+  const lineW = heavy ? baseLineW * 1.8 : baseLineW;
+  const y = baseline + Math.max(2, lineW);
+  ctx.strokeStyle = color;
+  ctx.lineWidth = lineW;
+  ctx.setLineDash([]);
+
+  // Dash patterns scaled by lineW so they stay proportional at any font size.
+  // Values mirror prstDash (§20.1.10.49 ST_PresetLineDashVal) where the
+  // underline enum reuses the same shape names.
+  const dashFor = (s: string): number[] => {
+    switch (s) {
+      case 'dotted':
+      case 'dottedHeavy':         return [1.5, 3];
+      case 'dash':
+      case 'dashHeavy':           return [6, 3];
+      case 'dashLong':
+      case 'dashLongHeavy':       return [10, 4];
+      case 'dotDash':
+      case 'dotDashHeavy':        return [6, 3, 1.5, 3];
+      case 'dotDotDash':
+      case 'dotDotDashHeavy':     return [6, 3, 1.5, 3, 1.5, 3];
+      default:                    return [];
+    }
+  };
+
+  if (style && style.startsWith('wavy')) {
+    // Sine wave with amplitude ≈ lineW and wavelength ≈ 6×lineW.
+    const amp = lineW;
+    const wavelength = lineW * 6;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    const step = Math.max(1, lineW * 0.5);
+    for (let dx = 0; dx <= width; dx += step) {
+      const yy = y + Math.sin((dx / wavelength) * Math.PI * 2) * amp;
+      ctx.lineTo(x + dx, yy);
+    }
+    ctx.stroke();
+    if (style === 'wavyDbl') {
+      // Second wave below, offset by 2.5×amp.
+      ctx.beginPath();
+      ctx.moveTo(x, y + amp * 2.5);
+      for (let dx = 0; dx <= width; dx += step) {
+        const yy = y + amp * 2.5 + Math.sin((dx / wavelength) * Math.PI * 2) * amp;
+        ctx.lineTo(x + dx, yy);
+      }
+      ctx.stroke();
+    }
+    return;
+  }
+
+  if (style === 'dbl') {
+    const offset = lineW * 1.4;
+    ctx.beginPath();
+    ctx.moveTo(x, y - offset / 2);
+    ctx.lineTo(x + width, y - offset / 2);
+    ctx.moveTo(x, y + offset / 2);
+    ctx.lineTo(x + width, y + offset / 2);
+    ctx.stroke();
+    return;
+  }
+
+  ctx.setLineDash(dashFor(style ?? 'sng').map((v) => v * lineW));
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(x + width, y);
+  ctx.stroke();
+  ctx.setLineDash([]);
+}
+
 type LayoutSegment = {
   text: string;
   font: string;
   sizePx: number;
   color: string;
   underline: boolean;
+  /** OOXML rPr @u value when not the default "sng": "dbl"/"dotted"/"wavy"/etc. */
+  underlineStyle?: string;
   strikethrough: boolean;
   /** Two parallel strike lines (rPr strike="dblStrike"). */
   strikeDouble?: boolean;
@@ -247,7 +335,7 @@ function layoutParagraph(
     underline: boolean,
     strikethrough: boolean,
     baseline?: number,
-    extras?: { strikeDouble?: boolean; letterSpacingPx?: number },
+    extras?: { strikeDouble?: boolean; letterSpacingPx?: number; underlineStyle?: string },
   ) => {
     if (!text) return;
     ctx.font = font;
@@ -259,10 +347,12 @@ function layoutParagraph(
     // same way so this stays consistent with measureText below.
     const w = baseW + lsPx * text.length;
     const strikeDouble = extras?.strikeDouble;
+    const underlineStyle = extras?.underlineStyle;
     const sameMeta = (a: LayoutSegment) =>
       a.font === font &&
       a.color === color &&
       a.underline === underline &&
+      (a.underlineStyle ?? '') === (underlineStyle ?? '') &&
       a.strikethrough === strikethrough &&
       (a.strikeDouble ?? false) === (strikeDouble ?? false) &&
       (a.letterSpacingPx ?? 0) === lsPx &&
@@ -273,7 +363,7 @@ function layoutParagraph(
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        segs.push({ text, font, sizePx, color, underline, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
+        segs.push({ text, font, sizePx, color, underline, underlineStyle, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
       }
     } else {
       lineW += w;
@@ -281,7 +371,7 @@ function layoutParagraph(
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        currentLine.segments.push({ text, font, sizePx, color, underline, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
+        currentLine.segments.push({ text, font, sizePx, color, underline, underlineStyle, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
       }
     }
   };
@@ -332,7 +422,11 @@ function layoutParagraph(
     // letterSpacing arrives in points; convert to canvas px using the same
     // EMU→px scale the renderer applies to font sizes.
     const lsPx = run.letterSpacing != null ? run.letterSpacing * PT_TO_EMU * scale : 0;
-    const segExtras = { strikeDouble: segStrikeDouble, letterSpacingPx: lsPx };
+    const segExtras = {
+      strikeDouble: segStrikeDouble,
+      letterSpacingPx: lsPx,
+      underlineStyle: run.underlineStyle,
+    };
 
     // Split on whitespace boundaries, keeping the whitespace tokens
     const tokens = runText.split(/(\s+)/);
@@ -3156,13 +3250,7 @@ function renderTextBody(
       }
 
       if (seg.underline) {
-        ctx.beginPath();
-        ctx.moveTo(penX, segBaseline + 2);
-        ctx.lineTo(penX + segW, segBaseline + 2);
-        ctx.strokeStyle = seg.color;
-        ctx.lineWidth = Math.max(1, seg.sizePx * 0.05);
-        ctx.setLineDash([]);
-        ctx.stroke();
+        drawUnderline(ctx, penX, segBaseline, segW, seg.sizePx, seg.color, seg.underlineStyle);
       }
 
       if (seg.strikethrough) {


### PR DESCRIPTION
## Summary

ECMA-376 §21.1.2.3.16 (`ST_TextUnderlineType`) defines 16 underline values; the parser only exposed a boolean before, collapsing every variant into a single solid line. This change carries the original value through to the renderer and dispatches each style onto the right Canvas primitive.

- **parser** — `TextRunData.underline_style` preserves `rPr @u` when it is set and ≠ `\"sng\"` (and ≠ `\"none\"`, where the boolean already encodes \"off\"). `\"sng\"` stays `None` so the default rendering path still draws a single line.
- **types** — `TextRunData.underlineStyle` exposes the same value to consumers.
- **renderer** — `drawUnderline` maps each enum value:
  - `sng` (default), `heavy`, `*Heavy` → solid line, lineWidth bumped 1.8× for `*Heavy`
  - `dbl` → two parallel lines straddling the baseline
  - `dotted` / `dottedHeavy` → `setLineDash([1.5, 3])` × `lineW`
  - `dash` / `dashHeavy` → `[6, 3]`
  - `dashLong` / `dashLongHeavy` → `[10, 4]`
  - `dotDash` / `dotDashHeavy` → `[6, 3, 1.5, 3]`
  - `dotDotDash` / `dotDotDashHeavy` → `[6, 3, 1.5, 3, 1.5, 3]`
  - `wavy` / `wavyHeavy` → sine polyline (amp = lineW, λ = 6×lineW)
  - `wavyDbl` → two stacked sine polylines

  Dash arrays match `prstDash` (§20.1.10.49) which the underline enum reuses.

`buAutoNum @startAt` was already used by `formatAutoNum` (renderer.ts:2941), so no change is needed there.

## Test plan

- [x] `cargo test test_parse_run_underline_style_passthrough` — 7-case matrix passes (none / sng / dbl / heavy / dotted / wavy / dashLong).
- [x] `tsc --build` (core) and `tsc --noEmit` (pptx) pass.
- [x] `pnpm --filter @silurus/ooxml-pptx wasm` rebuilds cleanly.
- [x] `pnpm --filter @silurus/ooxml-pptx vrt` — 9/9 demo specs pass; the 60 private-sample failures are pre-existing 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)