### PR TITLE
feat(pptx): rPr uFill — distinct underline colour

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -169,6 +169,11 @@ export interface TextRunData {
    * no underline (when `underline` is false) or the default single line.
    */
   underlineStyle?: string;
+  /**
+   * Underline-only colour from rPr > uFill (ECMA-376 §21.1.2.3.20). Absent
+   * means the underline follows the text colour (uFillTx default).
+   */
+  underlineColor?: string;
   /** True when rPr strike is sngStrike or dblStrike. */
   strikethrough: boolean;
   /**

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -558,6 +558,11 @@ struct TextRunData {
     /// ECMA-376 §21.1.2.3.16 (ST_TextUnderlineType).
     #[serde(skip_serializing_if = "Option::is_none")]
     underline_style: Option<String>,
+    /// Underline-specific colour from rPr > uFill > solidFill. None means the
+    /// underline follows the text colour (uFillTx behaviour, the default).
+    /// ECMA-376 §21.1.2.3.20 (CT_TextUnderlineFillGroupWrapper).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    underline_color: Option<String>,
     /// true when strike == "sngStrike" or "dblStrike"
     strikethrough: bool,
     /// true only when strike == "dblStrike" (renderer draws two parallel lines)
@@ -2236,6 +2241,7 @@ fn parse_paragraph(
                     italic,
                     underline: false,
                     underline_style: None,
+                    underline_color: None,
                     strikethrough: false,
                     strike_double: false,
                     font_size,
@@ -2337,6 +2343,13 @@ fn parse_run(
     let underline = underline_attr.as_deref().map(|v| v != "none").unwrap_or(false);
     let underline_style = underline_attr.filter(|v| v != "none" && v != "sng");
 
+    // ECMA-376 §21.1.2.3.20 — uFill specifies a per-underline colour that
+    // overrides the text colour. uFillTx (or absence) means "follow text".
+    let underline_color = r_pr.and_then(|n| child(n, "uFill"))
+        .or_else(|| def_rpr.and_then(|n| child(n, "uFill")))
+        .and_then(|n| child(n, "solidFill"))
+        .and_then(|n| parse_color_node(n, theme));
+
     // strikethrough: "sngStrike" or "dblStrike" → true; double tracked separately
     let strike_attr = r_pr.and_then(|n| attr(&n, "strike"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "strike")));
@@ -2386,7 +2399,7 @@ fn parse_run(
         .filter(|s| !s.is_empty());
 
     Some(TextRunData {
-        text, bold, italic, underline, underline_style,
+        text, bold, italic, underline, underline_style, underline_color,
         strikethrough, strike_double,
         font_size, color, font_family, baseline,
         caps, letter_spacing,
@@ -4677,6 +4690,25 @@ mod tests {
             assert_eq!(r.underline, *expected_bool, "u={val}");
             assert_eq!(r.underline_style.as_deref(), *expected_style, "u={val}");
         }
+    }
+
+    /// ECMA-376 §21.1.2.3.20 — rPr > uFill > solidFill yields a per-run
+    /// underline colour distinct from the text colour. uFillTx (or absent)
+    /// leaves underline_color as None so the renderer falls back to text.
+    #[test]
+    fn test_parse_run_underline_color() {
+        let theme = HashMap::new();
+        let rels = HashMap::new();
+
+        let with_ufill = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr u="sng"><uFill><solidFill><srgbClr val="FF0000"/></solidFill></uFill></rPr><t>x</t></r>"#;
+        let doc = roxmltree::Document::parse(with_ufill).unwrap();
+        let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
+        assert_eq!(r.underline_color.as_deref().map(str::to_uppercase).as_deref(), Some("FF0000"));
+
+        let with_ufilltx = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr u="sng"><uFillTx/></rPr><t>x</t></r>"#;
+        let doc = roxmltree::Document::parse(with_ufilltx).unwrap();
+        let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
+        assert!(r.underline_color.is_none());
     }
 
     /// ECMA-376 §20.1.8.17 — glow has a single rad attribute and a colour

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -202,6 +202,8 @@ type LayoutSegment = {
   underline: boolean;
   /** OOXML rPr @u value when not the default "sng": "dbl"/"dotted"/"wavy"/etc. */
   underlineStyle?: string;
+  /** rgba() colour for the underline when uFill overrides the text colour. */
+  underlineColor?: string;
   strikethrough: boolean;
   /** Two parallel strike lines (rPr strike="dblStrike"). */
   strikeDouble?: boolean;
@@ -335,7 +337,7 @@ function layoutParagraph(
     underline: boolean,
     strikethrough: boolean,
     baseline?: number,
-    extras?: { strikeDouble?: boolean; letterSpacingPx?: number; underlineStyle?: string },
+    extras?: { strikeDouble?: boolean; letterSpacingPx?: number; underlineStyle?: string; underlineColor?: string },
   ) => {
     if (!text) return;
     ctx.font = font;
@@ -348,11 +350,13 @@ function layoutParagraph(
     const w = baseW + lsPx * text.length;
     const strikeDouble = extras?.strikeDouble;
     const underlineStyle = extras?.underlineStyle;
+    const underlineColor = extras?.underlineColor;
     const sameMeta = (a: LayoutSegment) =>
       a.font === font &&
       a.color === color &&
       a.underline === underline &&
       (a.underlineStyle ?? '') === (underlineStyle ?? '') &&
+      (a.underlineColor ?? '') === (underlineColor ?? '') &&
       a.strikethrough === strikethrough &&
       (a.strikeDouble ?? false) === (strikeDouble ?? false) &&
       (a.letterSpacingPx ?? 0) === lsPx &&
@@ -363,7 +367,7 @@ function layoutParagraph(
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        segs.push({ text, font, sizePx, color, underline, underlineStyle, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
+        segs.push({ text, font, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
       }
     } else {
       lineW += w;
@@ -371,7 +375,7 @@ function layoutParagraph(
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        currentLine.segments.push({ text, font, sizePx, color, underline, underlineStyle, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
+        currentLine.segments.push({ text, font, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
       }
     }
   };
@@ -426,6 +430,7 @@ function layoutParagraph(
       strikeDouble: segStrikeDouble,
       letterSpacingPx: lsPx,
       underlineStyle: run.underlineStyle,
+      underlineColor: run.underlineColor ? hexToRgba(run.underlineColor) : undefined,
     };
 
     // Split on whitespace boundaries, keeping the whitespace tokens
@@ -3250,7 +3255,7 @@ function renderTextBody(
       }
 
       if (seg.underline) {
-        drawUnderline(ctx, penX, segBaseline, segW, seg.sizePx, seg.color, seg.underlineStyle);
+        drawUnderline(ctx, penX, segBaseline, segW, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle);
       }
 
       if (seg.strikethrough) {


### PR DESCRIPTION
## Summary

ECMA-376 §21.1.2.3.20 lets a run override only its underline's colour via `rPr > uFill > solidFill` (`uFillTx`, the default, follows the text colour). The renderer was already drawing underlines; this change carries the explicit colour through so the line can render in red while the glyph stays black, for example.

- **parser** — `TextRunData.underline_color` reads `rPr > uFill > solidFill` via `parse_color_node`, so theme references / `lumMod` / `alphaModFix` all reuse the same colour pipeline as text colour.
- **types** — `TextRunData.underlineColor` exposes the value to consumers.
- **renderer** — `drawUnderline` strokes with `seg.underlineColor ?? seg.color`. Layout-segment merging keeps two adjacent runs apart when their underline colour differs, so a Latin-then-CJK boundary still picks up the right colour either side.

> **Deferred**: paragraph `spcBef` / `spcAft` `<a:spcPct>` (spacing as percentage) was considered but applying it correctly requires plumbing a paragraph-relative font size through the inheritance maps in `LayoutPlaceholders`, which doesn't fit a small change.

## Test plan

- [x] `cargo test test_parse_run_underline_color` — both `uFill` (custom colour) and `uFillTx` (no override → `underline_color` stays `None`).
- [x] `tsc --build` (core) and `tsc --noEmit` (pptx) pass.
- [x] `pnpm --filter @silurus/ooxml-pptx wasm` rebuilds cleanly.
- [x] `pnpm --filter @silurus/ooxml-pptx vrt` — 9/9 demo specs pass; the 60 private-sample failures are pre-existing 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)