### PR TITLE
feat(pptx): rPr ea typeface — separate East Asian font for CJK

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -185,6 +185,12 @@ export interface TextRunData {
   fontSize: number | null;
   color: string | null;
   fontFamily: string | null;
+  /**
+   * East Asian font family from rPr > a:ea (ECMA-376 §21.1.2.3.7),
+   * resolved through the theme. Renderer uses this for CJK glyphs when
+   * present; absent means CJK falls back to fontFamily.
+   */
+  fontFamilyEa?: string;
   /** Baseline shift in thousandths of a point. Positive = superscript, negative = subscript. */
   baseline?: number;
   /**

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -571,6 +571,11 @@ struct TextRunData {
     font_size: Option<f64>,
     color: Option<String>,
     font_family: Option<String>,
+    /// East Asian font family from rPr > ea (resolved through the theme).
+    /// Renderer uses this for CJK runs. None = inherit from latin font.
+    /// ECMA-376 §21.1.2.3.7 (CT_TextFont, ea variant).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_family_ea: Option<String>,
     /// Baseline shift in thousandths of a point. Positive = superscript, negative = subscript.
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline: Option<i32>,
@@ -2247,6 +2252,7 @@ fn parse_paragraph(
                     font_size,
                     color,
                     font_family,
+                    font_family_ea: None,
                     baseline: None,
                     caps: None,
                     letter_spacing: None,
@@ -2384,6 +2390,13 @@ fn parse_run(
     let font_family = r_pr.and_then(|n| child(n, "latin")).and_then(|n| attr(&n, "typeface"))
         .or_else(|| def_rpr.and_then(|n| child(n, "latin")).and_then(|n| attr(&n, "typeface")))
         .map(|tf| resolve_theme_typeface(&tf, theme));
+    // ECMA-376 §21.1.2.3.7 — <a:ea typeface="..."/> sets a separate font for
+    // East Asian glyphs (CJK). Defaults to the theme's +mn-ea slot when the
+    // run doesn't specify one explicitly.
+    let font_family_ea = r_pr.and_then(|n| child(n, "ea")).and_then(|n| attr(&n, "typeface"))
+        .or_else(|| def_rpr.and_then(|n| child(n, "ea")).and_then(|n| attr(&n, "typeface")))
+        .map(|tf| resolve_theme_typeface(&tf, theme))
+        .filter(|tf| !tf.is_empty());
 
     // baseline in thousandths of a point; 30000=superscript, -25000=subscript (OOXML typical)
     let baseline = r_pr.and_then(|n| attr(&n, "baseline"))
@@ -2401,7 +2414,7 @@ fn parse_run(
     Some(TextRunData {
         text, bold, italic, underline, underline_style, underline_color,
         strikethrough, strike_double,
-        font_size, color, font_family, baseline,
+        font_size, color, font_family, font_family_ea, baseline,
         caps, letter_spacing,
         field_type: None, hyperlink,
     })
@@ -4709,6 +4722,34 @@ mod tests {
         let doc = roxmltree::Document::parse(with_ufilltx).unwrap();
         let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
         assert!(r.underline_color.is_none());
+    }
+
+    /// ECMA-376 §21.1.2.3.7 — rPr > ea sets a separate East Asian font.
+    /// Resolves through the theme map: "+mn-ea" should expand to whatever
+    /// the theme registered, while a literal name is preserved.
+    #[test]
+    fn test_parse_run_ea_typeface() {
+        let rels = HashMap::new();
+        let mut theme = HashMap::new();
+        theme.insert("+mn-ea".to_owned(), "MS Mincho".to_owned());
+
+        // Theme reference resolves through the map.
+        let xml = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr><ea typeface="+mn-ea"/></rPr><t>あ</t></r>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
+        assert_eq!(r.font_family_ea.as_deref(), Some("MS Mincho"));
+
+        // Literal name passes through unchanged.
+        let xml = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr><ea typeface="Yu Gothic"/></rPr><t>あ</t></r>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
+        assert_eq!(r.font_family_ea.as_deref(), Some("Yu Gothic"));
+
+        // Empty typeface is filtered out.
+        let xml = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr><ea typeface=""/></rPr><t>あ</t></r>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
+        assert!(r.font_family_ea.is_none());
     }
 
     /// ECMA-376 §20.1.8.17 — glow has a single rad attribute and a colour

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -389,6 +389,11 @@ function layoutParagraph(
     const sizePx = run.fontSize != null ? run.fontSize * PT_TO_EMU * scale * fontScale : defaultFontSizePx;
     // Font family cascade: run → paragraph defFontFamily → theme minor font → 'sans-serif'
     const family = normalizeFontFamily(run.fontFamily ?? para.defFontFamily ?? null, rc);
+    // East Asian font (rPr > ea) — used for CJK glyphs when set; otherwise
+    // CJK characters reuse the latin font. ECMA-376 §21.1.2.3.7.
+    const familyEa = run.fontFamilyEa
+      ? normalizeFontFamily(run.fontFamilyEa, rc)
+      : null;
     // Hyperlink runs without an explicit colour pick up the theme hlink colour
     // (ECMA-376 §20.1.2.3.5 — hyperlinks inherit theme hyperlink slot).
     let color: string;
@@ -403,6 +408,9 @@ function layoutParagraph(
     const isBold   = run.bold   ?? para.defBold   ?? defaultBold;
     const isItalic = run.italic ?? para.defItalic ?? defaultItalic;
     const font   = buildFont(isBold, isItalic, sizePx, family, rc);
+    const fontEa = familyEa
+      ? buildFont(isBold, isItalic, sizePx, familyEa, rc)
+      : font;
     ctx.font = font;
 
     // ECMA-376 §21.1.2.3.13 — caps transforms the rendered glyphs without
@@ -476,13 +484,18 @@ function layoutParagraph(
       // CJK characters allow line-breaking at any character boundary (no whitespace
       // needed). When a token contains CJK, wrap character-by-character so that CJK
       // text flows onto the same line as preceding Latin text (e.g. "EC市場で…").
-      const hasCJK = /[\u3000-\u9FFF\uAC00-\uD7FF\uF900-\uFAFF\uFF00-\uFFEF]/.test(token);
+      // Per-character font dispatch picks `fontEa` for CJK glyphs when the run
+      // declared an explicit East Asian typeface (rPr > ea); other characters
+      // keep the Latin font so the latin/ea boundary mid-token stays clean.
+      const CJK_RE = /[\u3000-\u9FFF\uAC00-\uD7FF\uF900-\uFAFF\uFF00-\uFFEF]/;
+      const hasCJK = CJK_RE.test(token);
       if (hasCJK) {
         for (const ch of token) {
-          ctx.font = font;
+          const chFont = CJK_RE.test(ch) ? fontEa : font;
+          ctx.font = chFont;
           const chW = ctx.measureText(ch).width;
           if (lineW + chW > maxWidthPx && lineW > 0) newLine();
-          push(ch, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
+          push(ch, chFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
         continue;
       }


### PR DESCRIPTION
## Summary

ECMA-376 §21.1.2.3.7 lets each run declare distinct typefaces for Latin, East Asian and Complex Script glyphs (`a:latin` / `a:ea` / `a:cs`). The parser was reading only `a:latin`, which meant CJK characters in a Japanese deck fell back to whatever Latin font the theme picked — producing wrong-shape glyphs (e.g. Aptos rendering Hiragana via fallback).

- **parser** — `TextRunData.font_family_ea` reads `rPr > ea @typeface`, resolved through the same theme map used for `latin` (so `\"+mn-ea\"` expands to the theme's East Asian font). Empty typeface filters to `None`.
- **types** — `TextRunData.fontFamilyEa` exposes the value.
- **renderer** — when the CJK character branch fires, dispatches per-character between the Latin font and `ea` font. A token like `\"EC市場で\"` now uses the Latin font for `\"EC\"` and the `ea` font for `\"市場で\"` — segment merging keeps the layout coherent.

## Test plan

- [x] `cargo test test_parse_run_ea_typeface` — three cases (theme reference, literal name, empty-typeface filter).
- [x] `tsc --build` (core) and `tsc --noEmit` (pptx) pass.
- [x] `pnpm --filter @silurus/ooxml-pptx wasm` rebuilds cleanly.
- [x] `pnpm --filter @silurus/ooxml-pptx vrt` — 9/9 demo specs pass; the 60 private-sample failures are pre-existing 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)