### PR TITLE
docs: refresh feature support table for recent xlsx + pptx work

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,10 +400,13 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Formula results (from cached `<v>`) | ✅ |
 | | Dates (ECMA-376 date format codes) | ✅ |
 | | Rich text (per-run formatting) | ✅ |
-| **Formatting** | Bold, italic, underline, strikethrough | ✅ |
+| **Formatting** | Bold, italic, underline (`single` / `double` / `singleAccounting` / `doubleAccounting`), strikethrough | ✅ |
+| | Superscript / subscript (`vertAlign`) | ✅ |
 | | Font family, size, color | ✅ |
-| | Cell background color | ✅ |
-| | Borders | ✅ |
+| | Cell background color (solid + gradient) | ✅ |
+| | Pattern fills (`gray125` / `gray0625` / `lightGray` / `mediumGray` / `darkGray` and the 12 `light*` / `dark*` directional hatches) | ✅ |
+| | Borders (thin, medium, thick, hair, double, dashed, dotted, dashDotDot, …) | ✅ |
+| | Diagonal borders (`diagonalUp` / `diagonalDown`, single + double) | ✅ |
 | | Horizontal / vertical alignment | ✅ |
 | | Text wrapping | ✅ |
 | | Number formats (`0.00`, `%`, `#,##0`, custom date/time) | ✅ |
@@ -440,7 +443,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Slide background (solid, gradient, image) | ✅ |
 | | Slide numbers | ✅ |
 | | Notes pages | ❌ |
-| | Animations / transitions | ❌ |
+| | Animations / transitions | ❌ Not planned |
 | **Element types** | Shapes (`sp`) | ✅ |
 | | Pictures (`pic`) | ✅ |
 | | Groups (`grpSp`) with nested transforms | ✅ |
@@ -459,19 +462,26 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | **Fills** | Solid fill (`solidFill`) | ✅ |
 | | Linear / radial gradient (`gradFill`) | ✅ |
 | | No fill (`noFill`) | ✅ |
-| | Pattern fill (`pattFill`) | ❌ |
+| | Pattern fill (`pattFill`) — 30 preset bitmaps incl. pct5–pct90 / horz / vert / cross / diag / grid / brick / check / trellis | ✅ |
 | | Image fill on shapes (`blipFill` in `sp`) | ✅ |
 | **Strokes** | Solid line color and width | ✅ |
 | | Dash / dot styles | ✅ |
 | | Arrow heads (`headEnd` / `tailEnd`) | ✅ |
 | | Compound / double lines | ❌ |
 | **Shape effects** | Drop shadow (`outerShdw`) | ✅ |
-| | Inner shadow / glow / reflection | ❌ |
+| | Glow (`glow` — radius + colour) | ✅ |
+| | Inner shadow (`innerShdw` — parsed; rendering follow-up) | ⚠️ |
+| | Reflection / soft edge | ❌ |
 | | Bevel / 3D extrusion | ❌ |
-| **Text — characters** | Bold, italic, underline, strikethrough | ✅ |
+| **Text — characters** | Bold, italic, strikethrough (incl. `dblStrike`) | ✅ |
+| | Underline styles (`sng` / `dbl` / `dotted` / `dash` / `dashLong` / `dotDash` / `dotDotDash` / `wavy` / `wavyDbl` and `*Heavy` variants) | ✅ |
+| | Per-run underline colour (`uFill` / `uFillTx`) | ✅ |
 | | Font family, size, color | ✅ |
+| | East Asian font (`rPr > a:ea` — separate typeface for CJK glyphs) | ✅ |
+| | Caps transform (`all` / `small`) | ✅ |
+| | Letter spacing (`spc`) | ✅ |
 | | Superscript / subscript | ✅ |
-| | Hyperlinks | ❌ |
+| | Hyperlinks (`hlinkClick` — theme `hlink` colour + auto underline) | ✅ |
 | | Text shadow / outline effects | ❌ |
 | **Text — paragraphs** | Horizontal alignment (left / center / right / justify) | ✅ |
 | | Vertical anchor (top / center / bottom) | ✅ |


### PR DESCRIPTION
## Summary

Pulls the README in line with what shipped over the past few PR rounds.

**xlsx**
- Underline now lists `single` / `double` / `*Accounting` variants.
- New row for pattern fills — covers the gray family (`gray125` / `gray0625` / `lightGray` / `mediumGray` / `darkGray`) and all 12 `dark*` / `light*` directional hatches that #195 / #198 light up.
- New row for diagonal borders (single + double).
- Superscript / subscript called out explicitly.

**pptx**
- `pattFill` flipped from ❌ to ✅, with a note on the 30 preset bitmaps #189 ships.
- `glow` (`a:glow`) flipped to ✅.
- `innerShdw` moved into its own ⚠️ row (parsed; rendering TBD).
- Reflection / soft edge split out from the inner-shadow row.
- Hyperlinks flipped to ✅, with the theme `hlink` colour behaviour noted.
- New rows: underline-style enum, `uFill` underline colour, `dblStrike`, `caps`, letter spacing, East Asian font.
- Animations / transitions marked \"Not planned\" per scope.

## Test plan

- [x] No code changes — README only.
- [ ] Visual check on rendered README in GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)