### PR TITLE
docs: README catch-up for cmpd / softEdge / reflection PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,11 +467,12 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | **Strokes** | Solid line color and width | ✅ |
 | | Dash / dot styles | ✅ |
 | | Arrow heads (`headEnd` / `tailEnd`) | ✅ |
-| | Compound / double lines | ❌ |
+| | Compound / double lines (`<a:ln cmpd="dbl|thinThick|thickThin|tri">` — straight connectors) | ✅ |
 | **Shape effects** | Drop shadow (`outerShdw`) | ✅ |
 | | Glow (`glow` — radius + colour) | ✅ |
 | | Inner shadow (`innerShdw` — parsed; rendering follow-up) | ⚠️ |
-| | Reflection / soft edge | ❌ |
+| | Soft edge (`softEdge` — parsed; rendering follow-up) | ⚠️ |
+| | Reflection (`reflection` — parsed; rendering follow-up) | ⚠️ |
 | | Bevel / 3D extrusion | ❌ |
 | **Text — characters** | Bold, italic, strikethrough (incl. `dblStrike`) | ✅ |
 | | Underline styles (`sng` / `dbl` / `dotted` / `dash` / `dashLong` / `dotDash` / `dotDotDash` / `wavy` / `wavyDbl` and `*Heavy` variants) | ✅ |


### PR DESCRIPTION
## Summary

Updates the pptx feature table for what shipped after the previous sweep:

- Compound / double lines flipped to ✅ — straight connectors render the four ECMA-376 §20.1.8.42 compound styles (#201). Curved / preset shapes still use the single-stroke fast path; the model carries `cmpd` for them already.
- Soft edge moved into its own ⚠️ row (parsed; render TBD).
- Reflection split out from the soft-edge row, also ⚠️ (parsed; render TBD).

## Test plan

- [x] No code changes — README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)