### PR TITLE
fix(xlsx): tighten preset hatch density (dark=50%, light=25%)

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -204,30 +204,36 @@ const PATTERN_BITMAPS: Record<string, number[]> = {
   darkGray:   [0b01110111, 0b11011101, 0b01110111, 0b11011101, 0b01110111, 0b11011101, 0b01110111, 0b11011101],
 
   // ── Horizontal / vertical lines ───────────────────────────────────────
-  // Dark variants render as a thin line every 4 rows / cols (~25% coverage),
-  // light variants every 8 (~12.5%). The previous "every 2" spacing read as
-  // a near-solid block at typical zoom; Excel paints these as distinct
-  // separate lines. ECMA-376 §18.8.22 doesn't pin down the geometry, so
-  // these match the Office implementation's visual instead.
-  darkHorizontal:  [0b11111111, 0b00000000, 0b00000000, 0b00000000, 0b11111111, 0b00000000, 0b00000000, 0b00000000],
-  lightHorizontal: [0b11111111, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000],
-  darkVertical:    [0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000],
-  lightVertical:   [0b10000000, 0b10000000, 0b10000000, 0b10000000, 0b10000000, 0b10000000, 0b10000000, 0b10000000],
+  // Dark variants render as a 1-px line every other row / column (50%
+  // coverage, ≈ 2-px pitch); light variants drop to every fourth (25%,
+  // ≈ 4-px pitch). Earlier 25%/12.5% revisions read as too-sparse for Excel
+  // parity. ECMA-376 §18.8.22 doesn't pin down the geometry, so these
+  // match the Office implementation's visual.
+  darkHorizontal:  [0b11111111, 0b00000000, 0b11111111, 0b00000000, 0b11111111, 0b00000000, 0b11111111, 0b00000000],
+  lightHorizontal: [0b11111111, 0b00000000, 0b00000000, 0b00000000, 0b11111111, 0b00000000, 0b00000000, 0b00000000],
+  darkVertical:    [0b10101010, 0b10101010, 0b10101010, 0b10101010, 0b10101010, 0b10101010, 0b10101010, 0b10101010],
+  lightVertical:   [0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000],
 
   // ── Diagonals ─────────────────────────────────────────────────────────
-  // darkDown: stripes every 4 px (\\); lightDown: every 8 px (one stripe per tile).
-  darkDown:   [0b10001000, 0b01000100, 0b00100010, 0b00010001, 0b10001000, 0b01000100, 0b00100010, 0b00010001],
-  lightDown:  [0b10000000, 0b01000000, 0b00100000, 0b00010000, 0b00001000, 0b00000100, 0b00000010, 0b00000001],
-  darkUp:     [0b00010001, 0b00100010, 0b01000100, 0b10001000, 0b00010001, 0b00100010, 0b01000100, 0b10001000],
-  lightUp:    [0b00000001, 0b00000010, 0b00000100, 0b00001000, 0b00010000, 0b00100000, 0b01000000, 0b10000000],
+  // darkDown: 2-px-wide diagonal stripes every 4 columns (≈ 50% coverage).
+  // lightDown: single 1-px diagonal stripes every 4 columns (≈ 25%).
+  darkDown:   [0b11001100, 0b01100110, 0b00110011, 0b10011001, 0b11001100, 0b01100110, 0b00110011, 0b10011001],
+  lightDown:  [0b10001000, 0b01000100, 0b00100010, 0b00010001, 0b10001000, 0b01000100, 0b00100010, 0b00010001],
+  darkUp:     [0b00110011, 0b01100110, 0b11001100, 0b10011001, 0b00110011, 0b01100110, 0b11001100, 0b10011001],
+  lightUp:    [0b00010001, 0b00100010, 0b01000100, 0b10001000, 0b00010001, 0b00100010, 0b01000100, 0b10001000],
 
   // ── Grid (horizontal + vertical) ──────────────────────────────────────
-  darkGrid:   [0b11111111, 0b10001000, 0b10001000, 0b10001000, 0b11111111, 0b10001000, 0b10001000, 0b10001000],
-  lightGrid:  [0b11111111, 0b10000000, 0b10000000, 0b10000000, 0b10000000, 0b10000000, 0b10000000, 0b10000000],
+  // darkGrid = darkHorizontal | darkVertical (≈ 75% — Excel's darkGrid is a
+  // very dense lattice, not a sparse one).
+  darkGrid:   [0b11111111, 0b10101010, 0b11111111, 0b10101010, 0b11111111, 0b10101010, 0b11111111, 0b10101010],
+  // lightGrid = lightHorizontal | lightVertical.
+  lightGrid:  [0b11111111, 0b10001000, 0b10001000, 0b10001000, 0b11111111, 0b10001000, 0b10001000, 0b10001000],
 
-  // ── Trellis (both diagonals at the dark/light density) ────────────────
-  darkTrellis:  [0b10011001, 0b01000010, 0b00100100, 0b00011000, 0b00011000, 0b00100100, 0b01000010, 0b10000001],
-  lightTrellis: [0b10000001, 0b01000010, 0b00100100, 0b00011000, 0b00011000, 0b00100100, 0b01000010, 0b10000001],
+  // ── Trellis (both diagonals) ──────────────────────────────────────────
+  // darkTrellis = darkDown | darkUp (≈ 75% cross-hatch).
+  darkTrellis:  [0b11111111, 0b01100110, 0b11111111, 0b10011001, 0b11111111, 0b01100110, 0b11111111, 0b10011001],
+  // lightTrellis = lightDown | lightUp (≈ 50% diagonal cross).
+  lightTrellis: [0b10011001, 0b01100110, 0b01100110, 0b10011001, 0b10011001, 0b01100110, 0b01100110, 0b10011001],
 };
 
 /**


### PR DESCRIPTION
## Summary

User feedback after #198: the line-pattern variants still read as too sparse versus Excel's actual rendering. Bump the density tier:

- **`darkHorizontal` / `darkVertical`**: line every other row/col (≈ 50% coverage). Was every 4 rows/cols, which left ~5 px gaps that read as individual lines instead of a continuous hatch.
- **`lightHorizontal` / `lightVertical`**: every 4 rows/cols (≈ 25%). Was every 8 (one line per tile), which only left a single line in most cells.
- **`darkDown` / `darkUp`**: 2-px-wide diagonal stripes every 4 columns (≈ 50%).
- **`lightDown` / `lightUp`**: single 1-px diagonal stripes every 4 columns (≈ 25%, same as the prior `dark*` variants).
- **`darkGrid` / `lightGrid` / `darkTrellis` / `lightTrellis`**: derived as the OR of their horizontal+vertical / down+up bases at the same 50%/25% density tier.

Spec (ECMA-376 §18.8.22) is geometric only; matches Office's visual.

## Test plan

- [x] `tsc --noEmit` passes for `@silurus/ooxml-xlsx`.
- [x] Visual: `private/sample-27` rows 17–19 — `dark*` line patterns now read as dense hatches; `light*` variants as visibly sparser but still continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)