### PR TITLE
fix(xlsx): drop preset-gray densities one tier to match Excel visual

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -196,13 +196,19 @@ const PATTERN_CACHE = new Map<string, CanvasPattern | null>();
  */
 const PATTERN_BITMAPS: Record<string, number[]> = {
   // ── 8×8 — gray-family dot patterns ────────────────────────────────────
-  gray125:    [0b10000000, 0b00000000, 0b00001000, 0b00000000, 0b10000000, 0b00000000, 0b00001000, 0b00000000],
-  gray0625:   [0b10000000, 0b00000000, 0b00000000, 0b00000000, 0b00001000, 0b00000000, 0b00000000, 0b00000000],
-  lightGray:  [0b10101010, 0b00000000, 0b01010101, 0b00000000, 0b10101010, 0b00000000, 0b01010101, 0b00000000],
-  mediumGray: [0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101],
-  // 75% — distribute the empty pixels evenly so the cell reads as solid
-  // dark grey, not as alternating black/dot stripes.
-  darkGray:   [0b01110111, 0b11011101, 0b01110111, 0b11011101, 0b01110111, 0b11011101, 0b01110111, 0b11011101],
+  // Tuned by sight against Excel's actual rendering of these names. The
+  // ECMA-376 verbal coverages (12.5% / 6.25% / 25% / 50% / 75%) give cells
+  // that read distinctly darker than Excel's anti-aliased output, so each
+  // tier is dropped one step (≈ 6% → 3%, 12% → 6%, 25% → 12%, 50% → 25%,
+  // 75% → 50%). The relative ordering is preserved so users can still
+  // tell darkGray > mediumGray > lightGray > gray125 > gray0625.
+  gray0625:   [0b10000000, 0b00000000, 0b00000000, 0b00000000, 0b00001000, 0b00000000, 0b00000000, 0b00000000], // ≈ 3%
+  gray125:    [0b10000000, 0b00000000, 0b00001000, 0b00000000, 0b10000000, 0b00000000, 0b00001000, 0b00000000], // ≈ 6%
+  lightGray:  [0b10001000, 0b00000000, 0b00100010, 0b00000000, 0b10001000, 0b00000000, 0b00100010, 0b00000000], // ≈ 12%
+  mediumGray: [0b10101010, 0b00000000, 0b01010101, 0b00000000, 0b10101010, 0b00000000, 0b01010101, 0b00000000], // ≈ 25%
+  // 50% checker — distributed evenly so the cell reads as solid grey at
+  // typical zoom rather than alternating black / dot stripes.
+  darkGray:   [0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101], // ≈ 50%
 
   // ── 12×12 — horizontal / vertical / grid (matched line count) ─────────
   // 4 lines per tile in both dark and light variants. dark uses a 2-px-thick


### PR DESCRIPTION
## Summary

User feedback: even after the bitmap rewrites, the gray family rendered notably darker than Excel's own preview of the same patterns. Excel's anti-aliased dot rendering reads visibly lighter than crisp 1×1 `fillRect`s at the spec's verbal coverage (12.5% / 25% / 50% / 75%).

Drop each tier one step so the visual matches a typical Excel sheet:

| pattern | before | after |
|---|---|---|
| `gray0625`  | ≈ 3% | ≈ 3% (unchanged) |
| `gray125`   | ≈ 6% | ≈ 6% (unchanged) |
| `lightGray` | 25% | **≈ 12%** |
| `mediumGray` | 50% | **≈ 25%** |
| `darkGray`  | 75% | **≈ 50%** |

Relative ordering is preserved (`darkGray` > `mediumGray` > `lightGray` > `gray125` > `gray0625`), so users can still tell the patterns apart, but the absolute gray weight now reads close to Excel.

`darkGray` uses an evenly-distributed 50% checkerboard so the cell reads as solid grey instead of horizontal banding.

## Test plan

- [x] `tsc --noEmit` passes for `@silurus/ooxml-xlsx`.
- [x] Visual: `private/sample-27` row 17 — C17/D17/E17 read as visibly lighter shades, matching the Excel reference more closely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)