### PR TITLE
fix(xlsx): darkGrid → 2×2 checker, lightGrid → wider 4-px grid

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -234,10 +234,17 @@ const PATTERN_BITMAPS: Record<string, number[]> = {
   // lightVertical: 1-col lines at every other col (0,2,4,6) → 0xAA = 0b10101010
   lightVertical:   Array(8).fill(0xAA),
 
-  // darkGrid = darkHorizontal | darkVertical
-  darkGrid: [0xFF, 0xFF, 0xCC, 0xCC, 0xFF, 0xFF, 0xCC, 0xCC],
-  // lightGrid = lightHorizontal | lightVertical
-  lightGrid: [0xFF, 0xAA, 0xFF, 0xAA, 0xFF, 0xAA, 0xFF, 0xAA],
+  // darkGrid: Excel renders this as a fine 2×2 checkerboard, not a thick
+  // horizontal+vertical lattice. Each black/white "cell" is 2×2 source
+  // pixels, so the cell reads as a clear "市松模様" rather than a solid
+  // 50% gray (the 1×1 checkerboard mediumGray we already ship).
+  darkGrid:  [0b11001100, 0b11001100, 0b00110011, 0b00110011, 0b11001100, 0b11001100, 0b00110011, 0b00110011],
+  // lightGrid: a sparse grid with 4-px pitch — horizontal lines at rows
+  // 0 and 4, vertical lines at cols 0 and 4. Grid cells (white squares
+  // between the lines) are 3×3 source pixels, matching Excel's rendering
+  // of lightGrid where the lattice is clearly larger than the dense
+  // version and a true "格子" pattern is recognisable.
+  lightGrid: [0b11111111, 0b10001000, 0b10001000, 0b10001000, 0b11111111, 0b10001000, 0b10001000, 0b10001000],
 
   // ── 8×8 — diagonals & trellis ─────────────────────────────────────────
   // darkDown / darkUp: 2-px-wide diagonal stripes every 4 cells.


### PR DESCRIPTION
## Summary

User feedback: F18 (`darkGrid`) should read as a 市松模様 (checkerboard) at the cell scale, not as the thick horizontal+vertical lattice we'd been rendering. F19 (`lightGrid`) is correctly a grid but the cells were too small — Excel renders `lightGrid` with visibly larger grid squares.

Replace the bitmaps:

- **`darkGrid`** — 2×2 checker tile: `[CC CC 33 33 CC CC 33 33]`. `0xCC` fills cols 0,1,4,5 on two consecutive rows, `0x33` fills cols 2,3,6,7 on the next two — produces 2-pixel black squares interlocked with 2-pixel white squares. Coverage ≈ 50%, but with a clear checker texture rather than the uniform grey of the 1×1 `mediumGray` pattern.
- **`lightGrid`** — 4-px-pitch grid: `[FF 88 88 88 FF 88 88 88]`. Full horizontal lines at rows 0 and 4, single-column verticals at cols 0 and 4 on the rest. Each grid cell (white area) is now 3×3 source px instead of the previous 1×1, giving the visible "格子" texture Excel produces.

`darkTrellis` / `lightTrellis` untouched.

## Test plan

- [x] `tsc --noEmit` passes for `@silurus/ooxml-xlsx`.
- [x] Visual: `private/sample-27` row 18 F-cell now reads as a fine checker; row 19 F-cell shows a clearly larger grid lattice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)