### PR TITLE
fix(xlsx): drop lightGray density (50% → ~37%) so E17 reads lighter than D17

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -209,7 +209,10 @@ const PATTERN_BITMAPS: Record<string, number[]> = {
   // Relative ordering: darkGray > mediumGray > lightGray > gray125 > gray0625.
   gray0625:   [0b10001000, 0b00000000, 0b00100010, 0b00000000, 0b10001000, 0b00000000, 0b00100010, 0b00000000], // ≈ 12%
   gray125:    [0b10101010, 0b00000000, 0b01010101, 0b00000000, 0b10101010, 0b00000000, 0b01010101, 0b00000000], // ≈ 25%
-  lightGray:  [0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101], // ≈ 50%
+  // ≈ 37% — sits clearly between gray125 (25%) and mediumGray (65%) so the
+  // five gray tiers stay visually distinguishable. The earlier 50% checker
+  // had E17 reading nearly as dark as the mediumGray cell next to it.
+  lightGray:  [0b10101010, 0b00100010, 0b01010101, 0b00100010, 0b10101010, 0b00100010, 0b01010101, 0b00100010], // ≈ 37%
   // 65% — a 25% sparse mask added on top of the 50% checker so the cell
   // reads visibly denser than lightGray without horizontal banding.
   mediumGray: [0b11101010, 0b01010101, 0b10111010, 0b01010101, 0b10101110, 0b01010101, 0b10101011, 0b01010101], // ≈ 65%


### PR DESCRIPTION
## Summary

User feedback: E17 alone reads as too dark — its bitmap was bumped to a 50% checker in #208 to compensate for the smaller dots, but that landed visually close to the new ~65% `mediumGray`, collapsing the `lightGray` / `mediumGray` distinction the user is comparing against in Excel.

Use `[10101010, 00100010, 01010101, 00100010] × 2` — coverage 24/64 = 37.5%. The cascade now reads:

| pattern | before | after |
|---|---|---|
| `gray0625`   | ≈ 12% | ≈ 12% |
| `gray125`    | ≈ 25% | ≈ 25% |
| `lightGray`  | ≈ 50% | **≈ 37%** |
| `mediumGray` | ≈ 65% | ≈ 65% |
| `darkGray`   | ≈ 75% | ≈ 75% |

Five tiers stay visually distinct, with `lightGray` now clearly between `gray125` and `mediumGray` instead of leaning into `mediumGray`'s range.

## Test plan

- [x] `tsc --noEmit` passes for `@silurus/ooxml-xlsx`.
- [x] Visual: `private/sample-27` row 17 — E17 reads as a clearly lighter gray than D17, matching Excel's reference better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)