### PR TITLE
fix(xlsx): clean 50% checker for mediumGray (eliminate diagonal moiré)

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -213,9 +213,10 @@ const PATTERN_BITMAPS: Record<string, number[]> = {
   // five gray tiers stay visually distinguishable. The earlier 50% checker
   // had E17 reading nearly as dark as the mediumGray cell next to it.
   lightGray:  [0b10101010, 0b00100010, 0b01010101, 0b00100010, 0b10101010, 0b00100010, 0b01010101, 0b00100010], // ≈ 37%
-  // 65% — a 25% sparse mask added on top of the 50% checker so the cell
-  // reads visibly denser than lightGray without horizontal banding.
-  mediumGray: [0b11101010, 0b01010101, 0b10111010, 0b01010101, 0b10101110, 0b01010101, 0b10101011, 0b01010101], // ≈ 65%
+  // 50% — clean 1×1 checker. Earlier "65%" attempts that added an extra
+  // bit per row caused a visible diagonal moiré at typical cell sizes
+  // because the offset bit shifted by one column on each lit row.
+  mediumGray: [0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101, 0b10101010, 0b01010101], // ≈ 50%
   // 80% — solid rows alternated with a checker so it reads as near-black
   // grey at typical zoom while still showing the texture.
   darkGray:   [0b11111111, 0b01010101, 0b11111111, 0b01010101, 0b11111111, 0b01010101, 0b11111111, 0b01010101], // ≈ 75%


### PR DESCRIPTION
## Summary

User feedback: D17 (`mediumGray`) was showing a faint diagonal pattern.

Cause: the prior bitmap added an extra `1` bit per lit row at a column that shifted by one each row:

```
row 0: 11101010   ← extra bit at col 1
row 2: 10111010   ← extra bit at col 2
row 4: 10101110   ← extra bit at col 4
row 6: 10101011   ← extra bit at col 6
```

The diagonal stair-step of those extra bits read as a visible moiré at typical cell sizes.

Replace with a clean 1×1 checker `[AA 55] × 4` — perfectly symmetric, 50% coverage, no directional bias. The full cascade now reads:

| pattern | density |
|---|---|
| `gray0625`   | ≈ 12% |
| `gray125`    | ≈ 25% |
| `lightGray`  | ≈ 37% |
| `mediumGray` | **≈ 50%** ← was ~56% with moiré |
| `darkGray`   | ≈ 75% |

Five tiers stay distinct (`mediumGray ↔ darkGray` spread is 25 pp, matches the `lightGray ↔ mediumGray` spread).

## Test plan

- [x] `tsc --noEmit` passes for `@silurus/ooxml-xlsx`.
- [x] Visual: `private/sample-27` D17 — uniform 50% gray with no diagonal artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)