### PR TITLE
chore(release): 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.28.0 — 2026-05-10
+
+### Features
+
+- **pptx**: parse `a:hlinkClick` on text runs and resolve to URLs via slide _rels (ECMA-376 §21.1.2.3.5). Hyperlink runs now also pick up the theme `hlink` colour and render with a forced underline. `Presentation.hlinkColor` / `RenderContext.themeHlinkColor` are exposed to consumers.
+- **pptx**: full `rPr` underline-style enum (`single` / `double` / `singleAccounting` / `doubleAccounting` / `dotted` / `dotDash` / `dotDotDash` / `dash` / `dashLong` / `wavy` / `wavyDbl` and the `*Heavy` variants — ECMA-376 §21.1.2.3.16). New `drawTextDecoLine` helper handles dashed / dotted / wavy / double / heavy in both rich-text and plain-text paths.
+- **pptx**: per-run `uFill` underline colour (§21.1.2.3.20) — the line can render in a separate colour from the glyph.
+- **pptx**: `vertAlign` superscript / subscript (§21.1.2.3.13), caps `all` / `small` (§21.1.2.3.13), letter spacing `spc` (§21.1.2.3.5), and `strike="dblStrike"` two-line strikethrough (§21.1.2.3.10) all flow through to the renderer.
+- **pptx**: `rPr > a:ea` East Asian typeface (§21.1.2.3.7) — CJK glyphs in mixed-script runs now use the theme / explicit ea font instead of falling back to the latin one.
+- **pptx**: pattern fill (`a:pattFill`, §20.1.8.40 / §20.1.10.59) ships 30 preset bitmaps (`pct5`–`pct90` / `horz` / `vert` / `cross` / `diag*` / `grid` / `brick` / `check` / `trellis` etc.) tiled via `CanvasPattern`.
+- **pptx**: `a:glow` (§20.1.8.17) renders as a coloured Canvas shadow with zero offset; `a:innerShdw` (§20.1.8.21), `a:softEdge` (§20.1.8.31), and `a:reflection` (§20.1.8.27) are now parsed (rendering for those three lands in a follow-up release). `apply_color_transforms` also gained `alphaModFix` / `alphaMod` / `alphaOff` so existing `outerShdw` colours emitted with `alphaModFix` honour their alpha.
+- **pptx**: compound stroke styles `<a:ln cmpd="dbl|thinThick|thickThin|tri">` (§20.1.8.42) are parsed for every shape and rendered for straight lines / connectors. The base centre stroke is erased with `destination-out` before the sub-lines paint so dash / arrow heads / glow remain consistent.
+- **pptx**: `formatAutoNum` (§20.1.10.61) covers all symmetric Plain / Period / ParenR / ParenBoth variants for arabic, alphaLc / Uc, romanLc / Uc, plus arabicDb (full-width digits). 8 → 22 schemes.
+- **xlsx**: rPr / cell font `<vertAlign>` (§18.4.6) and `<u>` enum (§18.4.13) — superscript / subscript apply `~65%` size + baseline shift; `double` / `doubleAccounting` underline draws as two parallel lines via the new `drawTextDecoLine`.
+
+### Fixes
+
+- **xlsx renderer**: default `fg` / `bg` colours for `<patternFill>` when the colour children are absent (ECMA-376 §18.8.20). Excel emits `darkHorizontal` / `darkVertical` etc. without explicit colours; the prior truthy-check on `fgColor` rendered them as nothing. Same fix flows through merged-anchor cells via the new `paintCellPatternFill` helper.
+- **xlsx renderer**: every preset `patternType` now ships an explicit 8×8 (or 12×12 for matched-line-count `*Horizontal` / `*Vertical` / `*Grid`) bitmap tuned by sight against Excel's actual output. Gray family (`gray0625` → `darkGray`) reads as a continuous dot-density gradient (~6% → ~75%) starting from the `gray0625` motif and adding dots at each tier; directional hatches (`*Horizontal` / `*Vertical`) match dark / light line counts at the same pitch with `dark*` using a 2-px-thick bar and `light*` a 1-px line; `darkGrid` renders as a 2×2 checker, `lightGrid` as a wider 4-px-pitch grid.
+- **xlsx renderer**: `hatchPattern` now pre-bakes `pat.setTransform(scale(1/sx, 1/sy))` so each source bit lands on exactly one destination *device* pixel at integer scales (`scale=2`, retina), and tiles at native resolution at non-integer scales (`scale=1.5`) instead of triggering Canvas's bilinear pattern resampler — which previously smeared `lightHorizontal` into a uniform half-tone. Cache key includes the rounded scale so two render passes at different scales don't collide.
+- **xlsx renderer**: render `<diagonal style="double"/>` borders as two parallel lines along the diagonal's perpendicular (ECMA-376 §18.18.3). Diagonals previously fell back to a single line.
+- **xlsx viewer**: selection overlay aligns with cell borders at any `cellScale`. The renderer rounds each cell's scaled width per-cell; `viewer.getCellRect` / `updateSelectionOverlay` / `updateSpacerSize` now mirror the same per-cell rounding, eliminating the up-to-several-pixel drift visible at non-integer scales.
+
+### Docs
+
+- README feature support table reflects all of the above. PowerPoint animations / transitions are explicitly marked "Not planned" per scope.
+
 ## 0.27.0 — 2026-05-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## 0.28.0 — 2026-05-10

A wide-ranging release driven by the `private/sample-27` audit. The pptx side fills in the remaining text-formatting and effect gaps that ECMA-376 spec'd unambiguously; the xlsx side gets a thorough pattern-fill rebuild plus several rendering-precision fixes that surfaced from the same sample.

See [CHANGELOG.md](CHANGELOG.md#0280--2026-05-10) for the full list. Highlights:

### pptx
- **Text formatting** parity catch-up: `a:hlinkClick` → URL + theme `hlink` colour + auto-underline, full underline-style enum (`single` / `double` / `dotted` / `dash` / `wavy` / `*Heavy` / etc.), per-run `uFill` underline colour, `vertAlign` super / subscript, `caps` (`all` / `small`), `letter spacing` (`spc`), `dblStrike` two-line strikethrough, `rPr > a:ea` East Asian typeface for CJK glyphs, full `formatAutoNum` enum (8 → 22 schemes).
- **Effects**: `pattFill` ships 30 preset bitmaps tiled via `CanvasPattern`; `glow` renders as zero-offset coloured shadow; `innerShdw` / `softEdge` / `reflection` are now parsed (rendering follow-up); `apply_color_transforms` honours `alphaModFix` so existing `outerShdw` colours keep their alpha.
- **Strokes**: compound line styles (`<a:ln cmpd="dbl|thinThick|thickThin|tri">`) parsed everywhere and rendered for straight connectors.

### xlsx
- **Pattern fills** completely rebuilt: 19 ECMA-376 preset types each ship an explicit 8×8 / 12×12 bitmap tuned by sight against Excel's actual rendering. Gray family (`gray0625` → `darkGray`) reads as a continuous dot-density gradient; directional hatches keep matched line counts between dark and light variants with stroke thickness as the visual differentiator; `darkGrid` is a 2×2 checker; `lightGrid` is a wider 4-px-pitch lattice.
- **Pattern transform**: `hatchPattern` pre-bakes `pat.setTransform(scale(1/sx, 1/sy))` at integer scales so each source bit lands on exactly one destination *device* pixel — fixes the chunky-looking dots / lines users saw at retina / Storybook scale=2.
- **Borders**: `<diagonal style=\"double\"/>` renders as two parallel lines.
- **Text formatting**: rPr / cell font `vertAlign` (super / sub) and `<u>` enum (incl. `double`).
- **Selection overlay**: aligns with cell borders at any non-integer `cellScale`. Cause was renderer's per-cell `Math.round(width × cs)` vs viewer's single-multiply; viewer now mirrors the renderer's per-cell rounding.

### docs

- README feature support table updated for all of the above. PowerPoint animations / transitions explicitly marked \"Not planned\".

### Notes

- README screenshots (`docs/images/{pptx,xlsx,docx}.png`) **not** refreshed this release — the demo samples in `packages/*/public/demo/` don't exercise the new features (most of them landed via `private/sample-27` which is gitignored). The screenshots still represent the typical viewer output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)