### PR TITLE
ci(mcp): point release workflow at the workspace-root target dir

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -63,7 +63,11 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: packages/mcp-server
+          # The repository's Cargo.toml declares a workspace at the root,
+          # so cargo's target directory is `<repo>/target`, not
+          # `packages/mcp-server/target` — point the cache action at the
+          # workspace root accordingly.
+          workspaces: . -> target
           key: ${{ matrix.target }}
 
       - name: Install cross-compile linker (aarch64-linux)
@@ -76,14 +80,16 @@ jobs:
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
 
       - name: Build
-        working-directory: packages/mcp-server
-        run: cargo build --release --target ${{ matrix.target }}
+        # `-p ooxml-mcp-server` so cargo builds only this crate; the target
+        # directory is the workspace's `<repo>/target/` regardless of which
+        # subdir we run from.
+        run: cargo build --release --target ${{ matrix.target }} -p ooxml-mcp-server
 
       - name: Stage binary
         shell: bash
         run: |
           mkdir -p staging
-          cp "packages/mcp-server/target/${{ matrix.target }}/release/${{ matrix.binary }}" "staging/${{ matrix.asset }}"
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "staging/${{ matrix.asset }}"
 
       - name: Compute SHA256
         shell: bash


### PR DESCRIPTION
## Summary

The repository's `Cargo.toml` declares a workspace at the root (members include `packages/{pptx,docx,xlsx}/parser` + `packages/mcp-server`), so `cargo build` emits binaries into `<repo>/target/<triple>/release/`, not `packages/mcp-server/target/<triple>/release/`. The release workflow copied from the latter and failed every job since v0.27.0 with:

```
cp: cannot stat 'packages/mcp-server/target/aarch64-unknown-linux-gnu/release/ooxml-mcp-server': No such file or directory
```

Fix:

- Build with `cargo build --release --target ... -p ooxml-mcp-server` so we don't need a `working-directory` and cargo respects the workspace.
- Stage the binary from `target/<triple>/release/...` (workspace-root path).
- Update `Swatinem/rust-cache@v2`'s `workspaces:` to `. -> target` to match.

## Test plan

- [ ] After merge, `gh workflow run release-mcp-server.yml -f tag=v0.28.0` should succeed and attach the 5 binaries (+ `.sha256` files) to the v0.28.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)