### PR TITLE
ci(mcp): cross-compile x86_64 macOS from arm64 runner

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -34,8 +34,14 @@ jobs:
             os: macos-14
             binary: ooxml-mcp-server
             asset: ooxml-mcp-server-aarch64-apple-darwin
+          # Build the x86_64 macOS binary by cross-compiling from the
+          # arm64 runner. Apple Silicon's clang / ld handle the x86_64
+          # target natively, so no extra linker setup is needed — and
+          # this avoids the macos-13 (Intel) runner queue, which GitHub
+          # Actions has stopped scheduling reliably (jobs sit in
+          # `queued` for 30+ minutes before dispatch).
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             binary: ooxml-mcp-server
             asset: ooxml-mcp-server-x86_64-apple-darwin
           - target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary

The `macos-13` (Intel) runner queue has stopped scheduling reliably for this repo — the v0.28.0 retry sat in `queued` for 26+ minutes while every other matrix entry finished in 1–3 min. Apple Silicon's clang / ld can target `x86_64-apple-darwin` natively without any extra linker setup, so move both Apple matrix entries onto `macos-14` and let `cargo build --target x86_64-apple-darwin` cross-compile.

## Test plan

- [ ] Re-run the workflow against `v0.28.0` after merge — both `aarch64-apple-darwin` and `x86_64-apple-darwin` should finish in ~2 min on the arm64 runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)