### PR TITLE
feat(docx): section breaks, nested tables, prst shapes, ruby base text, rStyle cascade

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -227,17 +227,23 @@ fn parse_body_elements(
                     DocRun::Break { break_type: BreakType::Page }
                 );
                 if is_page_break_only {
-                    body.push(BodyElement::PageBreak);
+                    body.push(BodyElement::PageBreak { parity: None });
                     continue;
                 }
                 body.push(BodyElement::Paragraph(result));
-                // A section break inside pPr (that isn't the final body-level sectPr)
-                // terminates the current section and starts a new one on a new page.
-                let has_mid_section_break = child_w(child, "pPr")
-                    .and_then(|ppr| child_w(ppr, "sectPr"))
-                    .is_some();
-                if has_mid_section_break {
-                    body.push(BodyElement::PageBreak);
+                // ECMA-376 §17.6.1: a section break inside pPr defines the
+                // section that ENDS at this paragraph. The break TYPE
+                // (`<w:type w:val>`) controls how the next section starts:
+                //   - "continuous" → no page break
+                //   - "nextPage" / missing → plain page break
+                //   - "oddPage" / "evenPage" → page break + parity padding
+                if let Some(sect_pr) = child_w(child, "pPr").and_then(|ppr| child_w(ppr, "sectPr")) {
+                    match read_section_break_type(sect_pr).as_deref() {
+                        Some("continuous") => { /* no page break */ }
+                        Some("oddPage") => body.push(BodyElement::PageBreak { parity: Some("odd".to_string()) }),
+                        Some("evenPage") => body.push(BodyElement::PageBreak { parity: Some("even".to_string()) }),
+                        _ => body.push(BodyElement::PageBreak { parity: None }),
+                    }
                 }
             }
             "tbl" => {
@@ -248,13 +254,28 @@ fn parse_body_elements(
                 // Mid-body loose sectPr (rare) would behave like a page break.
                 // The final body-level sectPr only defines section settings — skip it.
                 if Some(child.id()) != body_level_sect_id {
-                    body.push(BodyElement::PageBreak);
+                    match read_section_break_type(child).as_deref() {
+                        Some("continuous") => {}
+                        Some("oddPage") => body.push(BodyElement::PageBreak { parity: Some("odd".to_string()) }),
+                        Some("evenPage") => body.push(BodyElement::PageBreak { parity: Some("even".to_string()) }),
+                        _ => body.push(BodyElement::PageBreak { parity: None }),
+                    }
                 }
             }
             _ => {}
         }
     }
     body
+}
+
+/// Read `<w:type w:val>` from a sectPr node, normalized to the ECMA-376
+/// ST_SectionMark values ("continuous" | "nextPage" | "oddPage" | "evenPage" |
+/// "nextColumn"). `None` if the element is absent (default = "nextPage").
+fn read_section_break_type(sect_pr: roxmltree::Node) -> Option<String> {
+    sect_pr
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "type")
+        .find_map(|n| attr_w(n, "val"))
 }
 
 fn load_media_map(
@@ -700,10 +721,12 @@ fn parse_run_inner(
     let rpr_node = child_w(node, "rPr");
     let mut fmt = base_run.clone();
 
-    // Apply rStyle
+    // Apply rStyle. ECMA-376 §17.7.5: character styles overlay on top of the
+    // paragraph's run formatting; they must not re-introduce docDefaults or
+    // the default paragraph style — those are already baked into base_run.
     if let Some(rpr) = rpr_node {
         if let Some(rs) = child_w(rpr, "rStyle").and_then(|n| attr_w(n, "val")) {
-            let (_, style_run) = style_map.resolve_para(Some(&rs), None);
+            let style_run = style_map.resolve_run_style(&rs);
             apply_direct_run(&mut fmt, &style_run);
         }
         let direct = parse_run_fmt(rpr);
@@ -788,6 +811,19 @@ fn parse_run_inner(
                     _ => BreakType::Line,
                 }).unwrap_or(BreakType::Line);
                 runs.push(DocRun::Break { break_type });
+            }
+            "ruby" => {
+                // ECMA-376 §17.3.3.25 w:ruby — phonetic guide (furigana).
+                // Layout: w:rubyBase carries the base glyph(s); w:rt carries
+                // the small annotation rendered above. We emit only the base
+                // text for now (full ruby layout is not implemented), which
+                // is what would otherwise be silently dropped — leaving
+                // ruby-annotated kanji missing from the output.
+                if let Some(rb) = child_w(child, "rubyBase") {
+                    for inner in rb.children().filter(|n| n.is_element() && n.tag_name().name() == "r") {
+                        parse_run_inner(inner, &fmt, style_map, media_map, theme, runs, link_href.clone());
+                    }
+                }
             }
             "drawing" => {
                 for r in parse_inline_drawing(child, media_map, theme) {
@@ -1221,7 +1257,20 @@ fn parse_wsp_shape(
     let anchor_y_pt = anchor_pos_y + group_off_pt_y + oy * sy / 12700.0;
 
     let cust_geom = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "custGeom");
-    let subpaths = cust_geom.map(parse_custom_geometry).unwrap_or_default();
+    let subpaths = if let Some(cg) = cust_geom {
+        parse_custom_geometry(cg)
+    } else {
+        // Fall back to prstGeom when custGeom is absent. Generate normalized
+        // [0,1] subpaths for the preset shapes used by our sample corpus
+        // (rect, line). Unknown presets fall back to rect so they remain
+        // visible — adj values (avLst) are intentionally not honored here.
+        let prst = sp_pr
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "prstGeom")
+            .and_then(|n| n.attribute("prst"))
+            .unwrap_or("rect");
+        preset_subpaths(prst)
+    };
     if subpaths.is_empty() { return None; }
 
     let fill = parse_shape_fill(sp_pr, theme);
@@ -1295,6 +1344,27 @@ fn parse_grad_fill(node: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeFi
     };
 
     Some(ShapeFill::Gradient { stops, angle, grad_type })
+}
+
+/// Generate normalized [0,1] subpaths for OOXML preset geometries used by
+/// our docx sample corpus. Unknown presets fall back to rect so the shape
+/// remains visible at its bounding box. `avLst` adjustment values are not
+/// honored — add per-shape handling here if a sample needs it.
+fn preset_subpaths(prst: &str) -> Vec<Vec<PathCmd>> {
+    match prst {
+        "line" => vec![vec![
+            PathCmd::MoveTo { x: 0.0, y: 0.0 },
+            PathCmd::LineTo { x: 1.0, y: 1.0 },
+        ]],
+        // "rect" | unknown
+        _ => vec![vec![
+            PathCmd::MoveTo { x: 0.0, y: 0.0 },
+            PathCmd::LineTo { x: 1.0, y: 0.0 },
+            PathCmd::LineTo { x: 1.0, y: 1.0 },
+            PathCmd::LineTo { x: 0.0, y: 1.0 },
+            PathCmd::Close,
+        ]],
+    }
 }
 
 /// Parse <a:custGeom><a:pathLst><a:path w="W" h="H">...</a:path></a:pathLst>.
@@ -1516,10 +1586,14 @@ fn parse_table_row(
     table_style_id: Option<&str>,
 ) -> DocTableRow {
     let tr_pr = child_w(node, "trPr");
-    let row_height = tr_pr
-        .and_then(|p| child_w(p, "trHeight"))
+    let tr_height_node = tr_pr.and_then(|p| child_w(p, "trHeight"));
+    let row_height = tr_height_node
         .and_then(|h| attr_w(h, "val"))
         .map(|v| twips_to_pt(&v));
+    // ECMA-376 §17.4.80: default hRule is "auto".
+    let row_height_rule = tr_height_node
+        .and_then(|h| attr_w(h, "hRule"))
+        .unwrap_or_else(|| "auto".to_string());
     let is_header = tr_pr.and_then(|p| child_w(p, "tblHeader")).is_some();
 
     let mut cells = vec![];
@@ -1528,7 +1602,7 @@ fn parse_table_row(
         cells.push(cell);
     }
 
-    DocTableRow { cells, row_height, is_header }
+    DocTableRow { cells, row_height, row_height_rule, is_header }
 }
 
 fn parse_table_cell(
@@ -1580,9 +1654,19 @@ fn parse_table_cell(
             }
         });
 
-    let mut content = vec![];
-    for p_node in children_w_flat(node, "p") {
-        content.push(parse_paragraph(p_node, style_map, num_map, media_map, rel_map, theme, table_style_id));
+    // ECMA-376 §17.4.7: a cell may contain paragraphs AND nested tables in
+    // any order. element_children_flat unwraps sdt wrappers like elsewhere.
+    let mut content: Vec<CellElement> = vec![];
+    for child in element_children_flat(node) {
+        match child.tag_name().name() {
+            "p" => content.push(CellElement::Paragraph(
+                parse_paragraph(child, style_map, num_map, media_map, rel_map, theme, table_style_id)
+            )),
+            "tbl" => content.push(CellElement::Table(
+                parse_table(child, style_map, num_map, media_map, rel_map, theme)
+            )),
+            _ => {}
+        }
     }
 
     DocTableCell { content, col_span, v_merge, borders, background, v_align, width_pt }

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -219,6 +219,22 @@ impl StyleMap {
             apply_run(merged_run, &def.para.run);
         }
     }
+
+    /// Resolve a character style (rStyle) chain WITHOUT prepending docDefaults
+    /// or the default paragraph style. ECMA-376 §17.7.5: rStyle layers ON TOP
+    /// of the paragraph's already-resolved run formatting — pulling docDefaults
+    /// in here would overwrite values the paragraph style legitimately set
+    /// (e.g. Normal's Meiryo UI 9pt being clobbered by docDefault Calibri 11pt
+    /// for a run that only says `<w:rStyle w:val="PlaceholderText"/>`).
+    pub fn resolve_run_style(&self, style_id: &str) -> RunFmt {
+        let mut merged_run = RunFmt::default();
+        // Walk only the rStyle's basedOn chain. No docDefaults, no table
+        // style, no default paragraph style — those are baseline contributions
+        // already folded into the caller's `base_run`.
+        let mut merged_para = ParaFmt::default();
+        self.apply_style_chain(style_id, &mut merged_para, &mut merged_run);
+        merged_run
+    }
 }
 
 fn apply_para(dst: &mut ParaFmt, src: &ParaFmt) {

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -70,7 +70,14 @@ pub struct SectionProps {
 pub enum BodyElement {
     Paragraph(DocParagraph),
     Table(DocTable),
-    PageBreak,
+    /// Page break. `parity` carries section-break parity intent:
+    /// `Some("odd")` = oddPage break (next content must start on an odd
+    /// 1-based page), `Some("even")` = evenPage. `None` = a plain `nextPage`
+    /// or `<w:br w:type="page"/>` break.
+    PageBreak {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        parity: Option<String>,
+    },
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
@@ -439,13 +446,27 @@ pub struct DocTableRow {
     pub cells: Vec<DocTableCell>,
     /// pt, None = auto
     pub row_height: Option<f64>,
+    /// ECMA-376 §17.4.80 w:trHeight/@hRule. "auto" (default) = treat row_height
+    /// as informational and size to content; "atLeast" = use as a lower bound;
+    /// "exact" = honor the value exactly. Stored as the raw OOXML token so the
+    /// renderer can branch without re-parsing.
+    pub row_height_rule: String,
     pub is_header: bool,
+}
+
+/// One block-level entry inside a table cell. ECMA-376 §17.4.7 (w:tc) allows
+/// any BlockLevelElts inside a cell — paragraphs and nested tables.
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum CellElement {
+    Paragraph(DocParagraph),
+    Table(DocTable),
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DocTableCell {
-    pub content: Vec<DocParagraph>,
+    pub content: Vec<CellElement>,
     pub col_span: u32,
     /// VMerge: None = no merge, Some(true) = start of vertical merge, Some(false) = continuation
     pub v_merge: Option<bool>,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,5 +1,5 @@
 import type {
-  Document, BodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell,
+  Document, BodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, TextRun, ImageRun, ShapeRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, SectionProps,
 } from './types';
@@ -115,15 +115,18 @@ function collectImagePairs(doc: Document): ImagePair[] {
       }
     }
   };
+  const walkTable = (tbl: DocTable) => {
+    for (const row of tbl.rows)
+      for (const cell of row.cells)
+        for (const ce of cell.content) {
+          if (ce.type === 'paragraph') walk((ce as unknown as DocParagraph).runs);
+          else if (ce.type === 'table') walkTable(ce as unknown as DocTable);
+        }
+  };
   const walkBody = (body: BodyElement[]) => {
     for (const el of body) {
       if (el.type === 'paragraph') walk((el as unknown as DocParagraph).runs);
-      if (el.type === 'table') {
-        const tbl = el as unknown as DocTable;
-        for (const row of tbl.rows)
-          for (const cell of row.cells)
-            for (const para of cell.content) walk(para.runs);
-      }
+      if (el.type === 'table') walkTable(el as unknown as DocTable);
     }
   };
   walkBody(doc.body);
@@ -321,6 +324,17 @@ export function computePages(
       pages.push([]);
       y = 0;
       prevPara = null;
+      prevSpaceAfter = 0;
+      measureState.y = section.marginTop;
+      measureState.floats = [];
+      // ECMA-376 §17.18.79 ST_SectionMark: oddPage / evenPage breaks pad
+      // with a blank page when the new section would otherwise start on the
+      // wrong parity. pages.length here is the next page's 1-based index.
+      if (el.parity === 'odd' && pages.length % 2 === 0) {
+        pages.push([]);
+      } else if (el.parity === 'even' && pages.length % 2 === 1) {
+        pages.push([]);
+      }
       continue;
     }
     if (el.type === 'paragraph') {
@@ -436,19 +450,23 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
   const colWidths = table.colWidths.map((w) => w * colScale);
   let h = 0;
   for (const row of table.rows) {
-    if (row.rowHeight != null) {
+    if (row.rowHeight != null && row.rowHeightRule === 'exact') {
       h += row.rowHeight;
       continue;
     }
-    let rowH = 10;
+    let rowH = row.rowHeight != null ? row.rowHeight : 10;
     let ci = 0;
     for (const cell of row.cells) {
       const span = Math.min(cell.colSpan, colWidths.length - ci);
       const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
       const innerW = Math.max(1, cellW - table.cellMarginLeft - table.cellMarginRight);
       let ch = table.cellMarginTop + table.cellMarginBottom;
-      for (const para of cell.content) {
-        ch += estimateParagraphHeight(state, para, innerW);
+      for (const ce of cell.content) {
+        if (ce.type === 'paragraph') {
+          ch += estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
+        } else if (ce.type === 'table') {
+          ch += estimateTableHeight(state, ce as unknown as DocTable, innerW);
+        }
       }
       if (ch > rowH) rowH = ch;
       ci += span;
@@ -1526,9 +1544,21 @@ function calculateRowHeight(
   scale: number,
   state: RenderState,
 ): number {
-  if (row.rowHeight != null) return row.rowHeight * scale;
+  // ECMA-376 §17.4.80:
+  //   exact   — honor w:trHeight verbatim, clip overflow.
+  //   atLeast / auto (default) — w:trHeight is a lower bound that content
+  //                               can exceed. In practice Word treats the
+  //                               default `auto` like `atLeast` when a value
+  //                               is present: it preserves the saved layout
+  //                               height even though the spec text describes
+  //                               auto as content-driven. Resume / cover
+  //                               templates rely on this — their row heights
+  //                               (trHeight=1872, 2448, 1152 …) shape the
+  //                               whole page composition.
+  if (row.rowHeight != null && row.rowHeightRule === 'exact') return row.rowHeight * scale;
+  const minH = row.rowHeight != null ? row.rowHeight * scale : 10 * scale;
 
-  let maxH = 10 * scale;
+  let maxH = minH;
   let ci = 0;
   for (const cell of row.cells) {
     const span = Math.min(cell.colSpan, colWidths.length - ci);
@@ -1536,9 +1566,8 @@ function calculateRowHeight(
     const contentW = cellW - (table.cellMarginLeft + table.cellMarginRight) * scale;
 
     let h = (table.cellMarginTop + table.cellMarginBottom) * scale;
-    for (const para of cell.content) {
-      h += measureParaHeight(state, para, contentW, scale);
-      h += (para.spaceBefore + para.spaceAfter) * scale;
+    for (const ce of cell.content) {
+      h += measureCellElementHeight(state, ce, contentW, scale);
     }
     if (h > maxH) maxH = h;
     ci += span;
@@ -1572,9 +1601,27 @@ function measureCellContent(
   const ml = table.cellMarginLeft * scale;
   const mr = table.cellMarginRight * scale;
   const innerW = cellW - ml - mr;
-  for (const para of cell.content) {
-    measureParaHeight(state, para, innerW, scale);
+  for (const ce of cell.content) {
+    measureCellElementHeight(state, ce, innerW, scale);
   }
+}
+
+/** Measure a cell-level element (paragraph or nested table) at the rendering
+ *  scale. Returns total occupied height including paragraph spacing. */
+function measureCellElementHeight(
+  state: RenderState,
+  ce: CellElement,
+  innerWPx: number,
+  scale: number,
+): number {
+  if (ce.type === 'paragraph') {
+    const para = ce as unknown as DocParagraph;
+    return measureParaHeight(state, para, innerWPx, scale)
+      + (para.spaceBefore + para.spaceAfter) * scale;
+  }
+  // Nested table — estimateTableHeight works in pt; convert to px.
+  const tbl = ce as unknown as DocTable;
+  return estimateTableHeight(state, tbl, innerWPx / scale) * scale;
 }
 
 function renderCell(
@@ -1615,13 +1662,60 @@ function renderCell(
   };
 
   if (cell.vAlign === 'center' || cell.vAlign === 'bottom') {
-    const contentH = cell.content.reduce((s, p) =>
-      s + measureParaHeight(cellState, p, w - ml - mr, scale) + (p.spaceBefore + p.spaceAfter) * scale, 0);
+    // ECMA-376 §17.4.7 requires every <w:tc> to end with a <w:p>. When a cell's
+    // visible content is a nested table, Word emits a trailing empty paragraph
+    // purely as that syntactic anchor. Including it in the centering content
+    // height would balloon contentH ≈ rowHeight and pin the visible block to
+    // the top of the cell — matching neither Word nor LibreOffice's
+    // rendering of resume "bar chart" cells. Skip a single trailing empty
+    // paragraph after a non-paragraph block.
+    const visibleContent = trimTrailingStructuralMarker(cell.content);
+    const contentH = visibleContent.reduce(
+      (s, ce) => s + measureCellElementHeight(cellState, ce, w - ml - mr, scale), 0);
     if (cell.vAlign === 'center') cellState.y = y + (h - contentH) / 2;
     else cellState.y = y + h - contentH - mb;
   }
 
-  renderParaList(cell.content, cellState);
+  renderCellContent(cell.content, cellState);
+}
+
+/** Drop a trailing empty paragraph that follows a non-paragraph block (nested
+ *  table). ECMA-376 §17.4.7 requires every cell to end with a paragraph; when
+ *  the visible content is a nested table, Word's emitted trailing <w:p/> is a
+ *  structural anchor with no visible role. Returns the original array if no
+ *  such pattern matches. */
+function trimTrailingStructuralMarker(content: CellElement[]): CellElement[] {
+  if (content.length < 2) return content;
+  const last = content[content.length - 1];
+  const prev = content[content.length - 2];
+  if (last.type !== 'paragraph' || prev.type === 'paragraph') return content;
+  const lastPara = last as unknown as DocParagraph;
+  if (lastPara.runs.length > 0) return content;
+  return content.slice(0, -1);
+}
+
+/** Render a cell's interleaved paragraphs and nested tables in document order.
+ *  Mirrors renderBodyElements but without page-break handling (cells never
+ *  contain page breaks in our model). */
+function renderCellContent(content: CellElement[], state: RenderState): void {
+  let prevPara: DocParagraph | null = null;
+  let prevSpaceAfter = 0;
+  for (const ce of content) {
+    if (ce.type === 'paragraph') {
+      const para = ce as unknown as DocParagraph;
+      const suppress = contextualSuppressed(prevPara, para);
+      const effBefore = suppress ? 0 : para.spaceBefore;
+      const overlap = Math.min(prevSpaceAfter, effBefore);
+      state.y -= overlap * state.scale;
+      renderParagraph(para, state, suppress);
+      prevPara = para;
+      prevSpaceAfter = para.spaceAfter;
+    } else if (ce.type === 'table') {
+      renderTable(ce as unknown as DocTable, state);
+      prevPara = null;
+      prevSpaceAfter = 0;
+    }
+  }
 }
 
 function drawCellBorders(

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -43,7 +43,7 @@ export interface SectionProps {
 export type BodyElement =
   | { type: 'paragraph' } & DocParagraph
   | { type: 'table' } & DocTable
-  | { type: 'pageBreak' };
+  | { type: 'pageBreak'; parity?: 'odd' | 'even' };
 
 export interface DocParagraph {
   /**
@@ -291,11 +291,19 @@ export interface BorderSpec {
 export interface DocTableRow {
   cells: DocTableCell[];
   rowHeight: number | null;  // pt
+  /** ECMA-376 §17.4.80 hRule. "auto" (default) = informational; "atLeast" =
+   *  lower bound; "exact" = fixed clip. */
+  rowHeightRule: 'auto' | 'atLeast' | 'exact' | string;
   isHeader: boolean;
 }
 
+/** ECMA-376 §17.4.7: a table cell may contain paragraphs AND nested tables. */
+export type CellElement =
+  | { type: 'paragraph' } & DocParagraph
+  | { type: 'table' } & DocTable;
+
 export interface DocTableCell {
-  content: DocParagraph[];
+  content: CellElement[];
   colSpan: number;
   vMerge: boolean | null;  // null=no merge, true=start, false=continuation
   borders: CellBorders;

--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -8,6 +8,7 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   { name: 'private/sample-2', pageCount: 1, width: 595 },
   { name: 'private/sample-3', pageCount: 3, width: 595 },
   { name: 'private/sample-4', pageCount: 1, width: 595 },
+  { name: 'private/sample-5', pageCount: 7, width: 595 },
   { name: 'demo/sample-1', pageCount: 6, width: 595 },
 ];
 


### PR DESCRIPTION
## Summary

Set of related DOCX rendering improvements driven by sample-3 (resume) and sample-5 (Soseki 夢十夜) private samples:

### Parser (Rust)
- **Section break types** — read `<w:sectPr><w:type w:val>`; `continuous` no longer forces a page break, and `oddPage` / `evenPage` carry parity through to the renderer.
- **prstGeom rect / line** — wsp shapes that use preset geometry (no `<a:custGeom>`) now emit normalized subpaths. Without this, sample-3's rotated white title bar on the cover panel was silently dropped.
- **Nested tables in cells** — `DocTableCell.content` is now `Vec<CellElement>` (Paragraph | Table) so resume "skill bar" cells (a 1-row 2-cell table inside a cell) round-trip correctly.
- **Ruby base text** — handle `<w:ruby><w:rubyBase>` so kanji like 坐 / 仰向 / 輪郭 / 柔 / 瓜実 / 鮮 / 透 / 徹 etc. are no longer dropped from sample-5 (60+ kanji recovered).
- **rStyle cascade fix** — character styles must layer on top of the paragraph's already-resolved run formatting; pulling `docDefaults` back in here clobbered Normal's Meiryo UI 9pt with docDefault Calibri 11pt for any run that only sets `<w:rStyle w:val="PlaceholderText"/>`. Fixed by adding `StyleMap::resolve_run_style` that walks only the rStyle's basedOn chain.
- **DocTableRow.rowHeightRule** — parse `<w:trHeight @hRule>` so the renderer can branch on exact / atLeast / auto.

### Renderer (TypeScript)
- `BodyElement.parity` consumed by `computePages`: oddPage / evenPage breaks pad an extra blank page when the next page's parity is wrong.
- vAlign=center / =bottom now drops a trailing empty paragraph that follows a non-paragraph block (the syntactic `<w:p/>` required by §17.4.7 after a nested table) from the centering content-height. Without this, "bar chart" cells reported `contentH ≈ rowH` and the bar landed at the top of the cell instead of being centered.
- Cell content walks (font preload, row-height estimation, vAlign measurement, in-flow render) all recurse into nested tables.

### Tests
- `private/sample-5` added to the VRT manifest (7 A4 pages). Pages 2-7 land at 87-100% match; page 1 cover (theme `fillRef` → `bgFillStyleLst` not implemented) fails the 20% threshold and is being tracked separately.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt` — `demo/sample-1` all 6 pages 100% match (no regression).
- [x] sample-3 page 1-3 visual confirmation (skill bars centered, Taylor Phillips title spacing, "10/10" rendering).
- [x] sample-5 page 2/3 confirmation (continuous section break joins paras 9+10 on the same page; kanji visible).
- [x] sample-5 oddPage parity: page 4 is the parity-padding blank page.
- [ ] Theme `fillRef` / `bgFillStyleLst` for sample-5 cover — follow-up.
- [ ] docGrid line snapping for full-justification body text — follow-up.
- [ ] Ruby annotation display (rt above base) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)