### PR TITLE
feat(docx): theme fillRef + wp:align — resolves sample-5 cover gradient

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -92,13 +92,19 @@ pub struct ThemeColors {
     /// rFonts @asciiTheme / @hAnsiTheme / @eastAsiaTheme / @cstheme.
     /// Keys: "minor" + "major" crossed with "latin"/"ea"/"cs".
     fonts: HashMap<String, String>,
+    /// Raw theme XML, retained so wps:style/fillRef → fillStyleLst /
+    /// bgFillStyleLst lookups (ECMA-376 §20.1.4.1.7) can be resolved on demand.
+    /// Re-parsing per shape is fine — the cover usually has only a handful of
+    /// shapes that take a fillRef, and theme XML is small.
+    theme_xml: Option<String>,
 }
 
 impl ThemeColors {
     fn parse(xml: &str) -> Self {
         let mut map: HashMap<String, String> = HashMap::new();
         let mut fonts: HashMap<String, String> = HashMap::new();
-        let doc = match XmlDoc::parse(xml) { Ok(d) => d, Err(_) => return Self { map, fonts } };
+        let theme_xml = Some(xml.to_string());
+        let doc = match XmlDoc::parse(xml) { Ok(d) => d, Err(_) => return Self { map, fonts, theme_xml } };
         let root = doc.root_element();
         if let Some(scheme) = root.descendants().find(|n| n.is_element() && n.tag_name().name() == "clrScheme") {
             for child in scheme.children().filter(|n| n.is_element()) {
@@ -135,7 +141,7 @@ impl ThemeColors {
                 }
             }
         }
-        Self { map, fonts }
+        Self { map, fonts, theme_xml }
     }
 
     fn resolve(&self, scheme_name: &str) -> Option<String> {
@@ -936,8 +942,8 @@ fn parse_inline_drawing(
     };
 
     // Parse positionH / positionV with relativeFrom
-    let (pos_x, x_from_margin) = parse_anchor_pos_h(&container);
-    let (pos_y, y_from_para)   = parse_anchor_pos_v(&container);
+    let (pos_x, x_from_margin, x_align) = parse_anchor_pos_h(&container);
+    let (pos_y, y_from_para,   y_align) = parse_anchor_pos_v(&container);
     let anchor_meta = parse_anchor_wrap(&container);
 
     // behindDoc="1" flag — renderer uses this to draw shapes before text
@@ -951,6 +957,8 @@ fn parse_inline_drawing(
         }
         for mut shp in parse_wgp_shapes(wgp, theme, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta) {
             shp.behind_doc = behind_doc;
+            shp.anchor_x_align = x_align.clone();
+            shp.anchor_y_align = y_align.clone();
             out.push(DocRun::Shape(shp));
         }
         return out;
@@ -960,6 +968,8 @@ fn parse_inline_drawing(
     if let Some(wsp) = container.descendants().find(|n| n.tag_name().name() == "wsp") {
         if let Some(mut shp) = parse_wsp_shape(wsp, theme, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta, 1.0, 1.0, 0.0, 0.0, 0) {
             shp.behind_doc = behind_doc;
+            shp.anchor_x_align = x_align;
+            shp.anchor_y_align = y_align;
             return vec![DocRun::Shape(shp)];
         }
     }
@@ -1046,10 +1056,10 @@ fn parse_anchor_wrap(container: &roxmltree::Node) -> AnchorMeta {
 
 /// Parse positionH — returns (posOffset_pt, needs_margin_offset).
 /// "column" and "margin" relative offsets both mean: add marginLeft in the renderer.
-fn parse_anchor_pos_h(container: &roxmltree::Node) -> (f64, bool) {
+fn parse_anchor_pos_h(container: &roxmltree::Node) -> (f64, bool, Option<String>) {
     let pos = match container.children().find(|n| n.tag_name().name() == "positionH") {
         Some(p) => p,
-        None => return (0.0, false),
+        None => return (0.0, false, None),
     };
     let rel = pos.attribute("relativeFrom").unwrap_or("page");
     let offset = pos.children()
@@ -1058,15 +1068,22 @@ fn parse_anchor_pos_h(container: &roxmltree::Node) -> (f64, bool) {
         .and_then(|t| t.parse::<f64>().ok())
         .map(|emu| emu / 12700.0)
         .unwrap_or(0.0);
+    // ECMA-376 §20.4.3.1: <wp:align>left|center|right</wp:align> takes
+    // precedence over posOffset when both are present.
+    let align = pos.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "align")
+        .and_then(|n| n.text())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     let from_margin = matches!(rel, "column" | "margin" | "leftMargin" | "insideMargin");
-    (offset, from_margin)
+    (offset, from_margin, align)
 }
 
-/// Parse positionV — returns (posOffset_pt, is_paragraph_relative).
-fn parse_anchor_pos_v(container: &roxmltree::Node) -> (f64, bool) {
+/// Parse positionV — returns (posOffset_pt, is_paragraph_relative, align).
+fn parse_anchor_pos_v(container: &roxmltree::Node) -> (f64, bool, Option<String>) {
     let pos = match container.children().find(|n| n.tag_name().name() == "positionV") {
         Some(p) => p,
-        None => return (0.0, false),
+        None => return (0.0, false, None),
     };
     let rel = pos.attribute("relativeFrom").unwrap_or("page");
     let offset = pos.children()
@@ -1075,8 +1092,13 @@ fn parse_anchor_pos_v(container: &roxmltree::Node) -> (f64, bool) {
         .and_then(|t| t.parse::<f64>().ok())
         .map(|emu| emu / 12700.0)
         .unwrap_or(0.0);
+    let align = pos.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "align")
+        .and_then(|n| n.text())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     let from_para = matches!(rel, "paragraph" | "line");
-    (offset, from_para)
+    (offset, from_para, align)
 }
 
 /// Expand a wp:wgp group into individual ImageRun entries.
@@ -1273,7 +1295,16 @@ fn parse_wsp_shape(
     };
     if subpaths.is_empty() { return None; }
 
-    let fill = parse_shape_fill(sp_pr, theme);
+    // Direct fills on spPr take priority over wps:style/fillRef. ECMA-376
+    // §20.1.4.1.30: when no direct fill is set, the shape's appearance comes
+    // from the theme's fillStyleLst / bgFillStyleLst entry referenced by idx,
+    // recolored using the schemeClr embedded in the fillRef.
+    let fill = parse_shape_fill(sp_pr, theme).or_else(|| {
+        wsp.children()
+            .find(|n| n.is_element() && n.tag_name().name() == "style")
+            .and_then(|st| st.children().find(|n| n.is_element() && n.tag_name().name() == "fillRef"))
+            .and_then(|fr| resolve_fill_ref(fr, theme))
+    });
     let (stroke, stroke_width) = sp_pr.children()
         .find(|n| n.is_element() && n.tag_name().name() == "ln")
         .map(|ln| {
@@ -1302,6 +1333,7 @@ fn parse_wsp_shape(
         stroke_width,
         rotation,
         wrap_mode: anchor_meta.wrap_mode.clone(),
+        ..Default::default()
     })
 }
 
@@ -1322,12 +1354,67 @@ fn parse_shape_fill(sp_pr: roxmltree::Node, theme: &ThemeColors) -> Option<Shape
     None
 }
 
+/// Resolve a wps:style/a:fillRef into a concrete ShapeFill using the theme's
+/// fmtScheme/fillStyleLst (idx 1..) or bgFillStyleLst (idx 1000+). The fillRef
+/// also carries a `<a:schemeClr>` child whose name substitutes for `phClr`
+/// placeholders in the recipe (ECMA-376 §20.1.4.1.7 / §20.1.4.1.30).
+///
+/// Resume / cover templates lean on this: their backgrounds are described
+/// indirectly as `fillRef idx="1003"` with the actual color and gradient
+/// parameters living in the theme part. Without this lookup, the shape ends
+/// up with no fill and the cover panel renders blank.
+fn resolve_fill_ref(
+    fill_ref: roxmltree::Node,
+    theme: &ThemeColors,
+) -> Option<ShapeFill> {
+    let idx: u32 = fill_ref.attribute("idx")?.parse().ok()?;
+    if idx == 0 { return None; }
+    let scheme_clr = fill_ref.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "schemeClr")
+        .and_then(|n| n.attribute("val"))
+        .unwrap_or("dk1");
+
+    let xml = theme.theme_xml.as_ref()?;
+    let doc = XmlDoc::parse(xml).ok()?;
+    let fmt = doc.root_element()
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "fmtScheme")?;
+    // ECMA-376 §20.1.4.1.30: fillRef idx is 1-indexed.
+    //   idx 1..999  → fillStyleLst[idx - 1]
+    //   idx 1001+   → bgFillStyleLst[idx - 1001]
+    let (lst_name, local_idx) = if idx >= 1001 {
+        ("bgFillStyleLst", (idx - 1001) as usize)
+    } else {
+        ("fillStyleLst", (idx - 1) as usize)
+    };
+    let lst = fmt.children().find(|n| n.is_element() && n.tag_name().name() == lst_name)?;
+    let entry = lst.children().filter(|n| n.is_element()).nth(local_idx)?;
+
+    match entry.tag_name().name() {
+        "solidFill" => {
+            resolve_color_element_with_phclr(entry, theme, scheme_clr)
+                .map(|c| ShapeFill::Solid { color: c })
+        }
+        "gradFill" => parse_grad_fill_phclr(entry, theme, scheme_clr),
+        // blipFill / pattFill recipes aren't supported yet — fall back to no fill.
+        _ => None,
+    }
+}
+
 fn parse_grad_fill(node: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeFill> {
+    parse_grad_fill_phclr(node, theme, "")
+}
+
+fn parse_grad_fill_phclr(
+    node: roxmltree::Node,
+    theme: &ThemeColors,
+    ph_clr: &str,
+) -> Option<ShapeFill> {
     let gs_lst = node.children().find(|n| n.is_element() && n.tag_name().name() == "gsLst")?;
     let mut stops: Vec<GradientStop> = Vec::new();
     for gs in gs_lst.children().filter(|n| n.is_element() && n.tag_name().name() == "gs") {
         let pos = gs.attribute("pos").and_then(|v| v.parse::<f64>().ok()).map(|p| p / 100000.0).unwrap_or(0.0);
-        if let Some(color) = resolve_color_element(gs, theme) {
+        if let Some(color) = resolve_color_element_with_phclr(gs, theme, ph_clr) {
             stops.push(GradientStop { position: pos, color });
         }
     }
@@ -1421,10 +1508,26 @@ fn parse_custom_geometry(cust_geom: roxmltree::Node) -> Vec<Vec<PathCmd>> {
 /// inspecting its child: <a:srgbClr>, <a:schemeClr>, or <a:sysClr>, applying
 /// any lumMod/lumOff/alpha modifiers declared on the inner color element.
 fn resolve_color_element(container: roxmltree::Node, theme: &ThemeColors) -> Option<String> {
+    resolve_color_element_with_phclr(container, theme, "")
+}
+
+/// Like `resolve_color_element` but, when an inner `<a:schemeClr val="phClr"/>`
+/// is encountered, substitutes the scheme name `ph_clr` (the `<a:schemeClr>`
+/// child of the wps:style/fillRef that triggered theme lookup). Pass an empty
+/// string to disable the substitution.
+fn resolve_color_element_with_phclr(
+    container: roxmltree::Node,
+    theme: &ThemeColors,
+    ph_clr: &str,
+) -> Option<String> {
     for c in container.children().filter(|n| n.is_element()) {
         let base = match c.tag_name().name() {
             "srgbClr" => c.attribute("val").map(|v| v.to_uppercase()),
-            "schemeClr" => c.attribute("val").and_then(|name| theme.resolve(name)),
+            "schemeClr" => {
+                let raw_name = c.attribute("val")?;
+                let name = if raw_name == "phClr" && !ph_clr.is_empty() { ph_clr } else { raw_name };
+                theme.resolve(name)
+            }
             "sysClr" => c.attribute("lastClr").map(|v| v.to_uppercase())
                 .or_else(|| c.attribute("val").map(|v| v.to_uppercase())),
             _ => None,
@@ -1451,8 +1554,12 @@ fn apply_color_mods(hex: &str, color_node: roxmltree::Node) -> String {
             "satOff" => s += val,
             "hueMod" => h *= val,
             "hueOff" => h += val,
-            "shade" => { l *= val; s *= val; }
-            "tint" => { l = l + (1.0 - l) * val; }
+            // ECMA-376 §20.1.2.3.31 shade: result = val·input + (1-val)·black,
+            // i.e. scale lightness by val. Saturation is unaffected.
+            "shade" => l *= val,
+            // ECMA-376 §20.1.2.3.34 tint: result = val·input + (1-val)·white.
+            // In HSL we approximate by interpolating lightness toward 1.
+            "tint" => l = val * l + (1.0 - val),
             _ => {}
         }
     }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -217,12 +217,22 @@ pub struct ShapeRun {
     pub width_pt: f64,
     /// pt
     pub height_pt: f64,
-    /// anchor X (pt)
+    /// anchor X (pt). Ignored if `anchor_x_align` is set.
     pub anchor_x_pt: f64,
-    /// anchor Y (pt)
+    /// anchor Y (pt). Ignored if `anchor_y_align` is set.
     pub anchor_y_pt: f64,
     pub anchor_x_from_margin: bool,
     pub anchor_y_from_para: bool,
+    /// ECMA-376 §20.4.3.1 wp:align (positionH/wp:align). When present the
+    /// renderer centers / left-aligns / right-aligns the shape within the
+    /// container indicated by `anchor_x_from_margin`. Values: "left",
+    /// "center", "right" (others fall back to "left").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_x_align: Option<String>,
+    /// Vertical equivalent of anchor_x_align (positionV/wp:align).
+    /// Values: "top", "center", "bottom".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_y_align: Option<String>,
     /// If true, draw the shape behind text (wp:anchor behindDoc="1"). Renderer
     /// should draw background shapes BEFORE body text.
     #[serde(skip_serializing_if = "std::ops::Not::not")]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1360,17 +1360,71 @@ function renderAnchorImages(
 }
 
 /** Draw a wps:wsp shape via core's custGeom primitive. */
+/** Resolve a shape's page X by combining the explicit `anchorXPt` offset with
+ *  any `anchorXAlign` (ECMA-376 §20.4.3.1 wp:align). When align is set we
+ *  position the shape inside the container indicated by `anchorXFromMargin`:
+ *  the page margin area when true, the full page rect when false. */
+/** Resolve the page X for an anchored shape. With `align` unset the result is
+ *  the existing offset semantics; with `align` set we interpret `offsetPt` as
+ *  a child offset RELATIVE to the aligned origin of the group container. */
+function resolveAnchorX(
+  align: string | null | undefined,
+  fromMargin: boolean,
+  offsetPt: number,
+  widthPx: number,
+  state: RenderState,
+): number {
+  const { scale } = state;
+  if (!align) {
+    return fromMargin ? (state.marginLeft + offsetPt) * scale : offsetPt * scale;
+  }
+  const containerStart = fromMargin ? state.marginLeft * scale : 0;
+  const containerEnd = fromMargin
+    ? state.marginLeft * scale + state.contentW
+    : state.marginLeft * scale + state.contentW + state.marginLeft * scale; // page width
+  const containerW = containerEnd - containerStart;
+  const offsetPx = offsetPt * scale;
+  switch (align) {
+    case 'center': return containerStart + (containerW - widthPx) / 2 + offsetPx;
+    case 'right':  return containerEnd - widthPx + offsetPx;
+    case 'inside':
+    case 'outside':
+    case 'left':
+    default:       return containerStart + offsetPx;
+  }
+}
+
+function resolveAnchorY(
+  align: string | null | undefined,
+  fromPara: boolean,
+  offsetPt: number,
+  heightPx: number,
+  paragraphTopPx: number,
+  state: RenderState,
+): number {
+  const { scale } = state;
+  if (!align) {
+    return fromPara ? paragraphTopPx + offsetPt * scale : offsetPt * scale;
+  }
+  const containerStart = fromPara ? paragraphTopPx : 0;
+  const containerEnd = state.pageH;
+  const containerH = containerEnd - containerStart;
+  const offsetPx = offsetPt * scale;
+  switch (align) {
+    case 'center': return containerStart + (containerH - heightPx) / 2 + offsetPx;
+    case 'bottom': return containerEnd - heightPx + offsetPx;
+    case 'top':
+    default:       return containerStart + offsetPx;
+  }
+}
+
 function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: number): void {
   const { ctx, scale } = state;
   const w = shape.widthPt * scale;
   const h = shape.heightPt * scale;
   if (w <= 0 || h <= 0) return;
-  const x = shape.anchorXFromMargin
-    ? (state.marginLeft + shape.anchorXPt) * scale
-    : shape.anchorXPt * scale;
-  const y = shape.anchorYFromPara
-    ? paragraphTopPx + shape.anchorYPt * scale
-    : shape.anchorYPt * scale;
+  const x = resolveAnchorX(shape.anchorXAlign, shape.anchorXFromMargin, shape.anchorXPt, w, state);
+  const y = resolveAnchorY(shape.anchorYAlign, shape.anchorYFromPara, shape.anchorYPt, h, paragraphTopPx, state);
 
   const rot = shape.rotation ?? 0;
   ctx.save();

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -153,6 +153,12 @@ export interface ShapeRun {
   anchorYPt: number;
   anchorXFromMargin: boolean;
   anchorYFromPara: boolean;
+  /** ECMA-376 §20.4.3.1 wp:align horizontal: "left" | "center" | "right" |
+   *  "inside" | "outside". When set the renderer aligns the shape inside the
+   *  container indicated by `anchorXFromMargin` and ignores `anchorXPt`. */
+  anchorXAlign?: string | null;
+  /** Vertical equivalent of anchorXAlign: "top" | "center" | "bottom". */
+  anchorYAlign?: string | null;
   /** Draw behind text when true (wp:anchor behindDoc="1"). */
   behindDoc?: boolean;
   /** Document-order index within a group; lower values render first. */


### PR DESCRIPTION
## Summary

Cover panels of resume / story templates are described as `wps:style/fillRef idx="1003"` referencing the theme's `bgFillStyleLst` rather than carrying their fill inline. Without that lookup the shape ended up with no fill and rendered as a blank rectangle. This PR plumbs theme `fmtScheme` lookups through the docx parser and adds the missing `wp:align` positioning hint, then fixes a couple of OOXML color-modifier bugs that turned up while validating the resolved gradients.

### Parser
- **`resolve_fill_ref`**: ThemeColors now retains the raw theme XML so a wsp's `<wps:style><a:fillRef idx>` can pick the entry from `fillStyleLst` (1..1000) / `bgFillStyleLst` (1001+) on demand. The `<a:schemeClr>` child of `fillRef` substitutes for `phClr` placeholders in the recipe before colors are resolved.
- **Color modifier fixes** (ECMA-376 §20.1.2.3.31 / §20.1.2.3.34):
  - `tint val=X` was applied as `l + (1-l)·val`, which lightens in the wrong direction. Correct formula is `val·input + (1-val)·white` → `l = val·l + (1-val)`.
  - `shade` was scaling both L and S; per spec only L is scaled.
- **`wp:align`**: positionH / positionV now extract `<wp:align>` (left/center/right, top/center/bottom). When set we ignore `wp:posOffset` for the alignment direction, matching §20.4.3.1.

### Renderer
- `ShapeRun.anchorXAlign / anchorYAlign` plumbed end-to-end. `resolveAnchorX` / `resolveAnchorY` align inside the container indicated by `anchorXFromMargin / anchorYFromPara` (margin area or page rect), treating any explicit offset as a child offset within the aligned origin so wgp child shapes still pick up their `xfrm.off` correctly.

### VRT
| sample | before | after |
|---|---:|---:|
| sample-3 (3 pages) | 89.5% / 88.8% / 88.6% | unchanged |
| sample-4 | 92.0% | unchanged |
| **sample-5 cover** | **46.9%** | **86.2%** |
| demo/sample-1 (6 pages) | 100% | 100% |

(sample-5 pages 6 / 7 still report 43% match because we render only 5 pages and the test framework falls back to page 0 — fixing pagination is the next follow-up.)

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt`
- [x] sample-5 page 1 visual confirmation (gradient + curve cutout + [年] badge)
- [x] sample-3 page 1-3 unchanged
- [x] demo/sample-1 100% match preserved
- [ ] Text inside `<wps:txBody>` (the 夢十夜 / 第一夜 / [会社名] labels on the cover) — separate follow-up
- [ ] docGrid line snapping for paginating long body paragraphs to match Word's page count

🤖 Generated with [Claude Code](https://claude.com/claude-code)