### PR TITLE
feat(docx): render w:ruby annotations (furigana) above base text

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -786,6 +786,7 @@ fn parse_run_inner(
                         small_caps,
                         double_strikethrough,
                         highlight: highlight.clone(),
+                        ruby: None,
                     }));
                 }
             }
@@ -808,6 +809,7 @@ fn parse_run_inner(
                     small_caps,
                     double_strikethrough,
                     highlight: highlight.clone(),
+                    ruby: None,
                 }));
             }
             "br" => {
@@ -820,14 +822,45 @@ fn parse_run_inner(
             }
             "ruby" => {
                 // ECMA-376 §17.3.3.25 w:ruby — phonetic guide (furigana).
-                // Layout: w:rubyBase carries the base glyph(s); w:rt carries
-                // the small annotation rendered above. We emit only the base
-                // text for now (full ruby layout is not implemented), which
-                // is what would otherwise be silently dropped — leaving
-                // ruby-annotated kanji missing from the output.
+                // The rubyBase carries the base glyph(s); the rt carries the
+                // small annotation rendered above. We emit each rubyBase run
+                // as a TextRun, attaching the rt text as a `ruby` annotation
+                // so the renderer can draw it above the base.
+                let rt_text: String = child_w(child, "rt")
+                    .map(|rt| {
+                        rt.descendants()
+                            .filter(|n| n.is_element() && n.tag_name().name() == "t")
+                            .filter_map(|n| n.text())
+                            .collect::<String>()
+                    })
+                    .unwrap_or_default();
+                let rt_size_pt: f64 = child_w(child, "rubyPr")
+                    .and_then(|rp| child_w(rp, "hps"))
+                    .and_then(|hps| attr_w(hps, "val"))
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .map(|hp| hp / 2.0) // half-points → points
+                    .unwrap_or_else(|| fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE) / 2.0);
+                let ruby = if !rt_text.is_empty() {
+                    Some(RubyAnnotation { text: rt_text, font_size_pt: rt_size_pt })
+                } else {
+                    None
+                };
                 if let Some(rb) = child_w(child, "rubyBase") {
+                    let before = runs.len();
                     for inner in rb.children().filter(|n| n.is_element() && n.tag_name().name() == "r") {
                         parse_run_inner(inner, &fmt, style_map, media_map, theme, runs, link_href.clone());
+                    }
+                    // Attach ruby to the FIRST text run produced from rubyBase
+                    // (typical case is a single base run carrying one or two
+                    // glyphs). Splitting the annotation across multiple runs
+                    // is uncommon — sample data has 1 base run per ruby.
+                    if let Some(rb_anno) = ruby {
+                        for r in &mut runs[before..] {
+                            if let DocRun::Text(t) = r {
+                                t.ruby = Some(rb_anno.clone());
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -860,6 +893,7 @@ fn parse_run_inner(
                     small_caps,
                     double_strikethrough,
                     highlight: highlight.clone(),
+                    ruby: None,
                 }));
             }
             "AlternateContent" => {

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -352,6 +352,21 @@ pub struct TextRun {
     /// OOXML highlight color name: "yellow" | "cyan" | "green" | ... (w:highlight)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub highlight: Option<String>,
+    /// ECMA-376 §17.3.3.25 ruby annotation (furigana). Set on the rubyBase
+    /// text run; renders as a small inline annotation above the base glyphs.
+    /// `text` is the annotation string (e.g. "すわ" above "坐"). `font_size_pt`
+    /// is the annotation's font size in pt — Word stores this as `<w:hps>`
+    /// (half-points) inside the rubyPr.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ruby: Option<RubyAnnotation>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RubyAnnotation {
+    pub text: String,
+    /// pt
+    pub font_size_pt: f64,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -732,6 +732,24 @@ function renderParagraph(para: DocParagraph, state: RenderState, suppressSpaceBe
         ctx.fillStyle = s.color ? `#${s.color}` : defaultColor;
         ctx.fillText(s.text, x, baseline + yOffset);
 
+        // Ruby annotation: small text centered above the base glyphs.
+        if (s.ruby) {
+          const rubySizePx = s.ruby.fontSizePt * scale;
+          const rubyFont = buildFont(s.bold, s.italic, rubySizePx, s.fontFamily);
+          ctx.save();
+          ctx.font = rubyFont;
+          const rubyW = ctx.measureText(s.ruby.text).width;
+          const rubyX = x + (s.measuredWidth - rubyW) / 2;
+          // Sit the ruby's baseline a small gap above the base ascent so the
+          // characters don't touch. fillText baseline is at the line of the
+          // characters, so subtract the ruby descent + small gap from the
+          // base's ascent line to position correctly.
+          const rubyBaseline = baseline + yOffset - effSizePx * 0.85 - rubySizePx * 0.1;
+          ctx.fillStyle = s.color ? `#${s.color}` : defaultColor;
+          ctx.fillText(s.ruby.text, rubyX, rubyBaseline);
+          ctx.restore();
+        }
+
         if (state.onTextRun && s.text) {
           state.onTextRun({
             text: s.text,
@@ -812,6 +830,8 @@ interface LayoutTextSeg {
   smallCaps?: boolean;
   doubleStrikethrough?: boolean;
   highlight?: string | null;
+  /** Ruby annotation rendered in a small font directly above this segment. */
+  ruby?: { text: string; fontSizePt: number };
 }
 
 /**
@@ -880,6 +900,13 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
     vertAlign: 'super' | 'sub' | null,
   ) => {
     const displayText = (base.allCaps || base.smallCaps) ? text.toUpperCase() : text;
+    // Ruby annotation rides with the WHOLE base text (typically 1-2 chars).
+    // Splitting on word boundaries would lose the association, so attach
+    // the annotation only to the first emitted segment.
+    const ruby = (base as TextRun).ruby
+      ? { text: (base as TextRun).ruby!.text, fontSizePt: (base as TextRun).ruby!.fontSizePt }
+      : undefined;
+    let firstSeg = true;
     for (const word of splitTextForLayout(displayText)) {
       segs.push({
         text: word,
@@ -895,7 +922,9 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         smallCaps: base.smallCaps ?? false,
         doubleStrikethrough: base.doubleStrikethrough ?? false,
         highlight: base.highlight ?? null,
+        ruby: firstSeg ? ruby : undefined,
       });
+      firstSeg = false;
     }
   };
 
@@ -1220,8 +1249,15 @@ function layoutLines(
     const h = s.fontSize;
     // Prefer font-metric ascent/descent (stable per font+size) so baselines and
     // line boxes do not jitter based on the specific characters on each line.
-    const asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? s.fontSize * scale * 0.8;
+    let asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? s.fontSize * scale * 0.8;
     const desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? s.fontSize * scale * 0.2;
+    // Ruby annotation: a small string rendered above the base. Reserve space
+    // for it in the line's ascent so the line box grows to fit (ECMA-376
+    // §17.3.3.25). 1.1× of the annotation font gives a small gap above the
+    // base glyphs.
+    if (s.ruby) {
+      asc = asc + s.ruby.fontSizePt * scale * 1.1;
+    }
     // Wrap-fit check uses two standard typographic allowances:
     //   1. Trailing-space collapse: if this word becomes the last on the
     //      line, its trailing space (if any) collapses. We subtract it from

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -221,6 +221,15 @@ export interface TextRun {
   smallCaps?: boolean;
   doubleStrikethrough?: boolean;
   highlight?: string | null;
+  /** ECMA-376 §17.3.3.25 ruby annotation (furigana). Renders above the
+   *  base text in a smaller font; line height is expanded to fit it. */
+  ruby?: RubyAnnotation;
+}
+
+export interface RubyAnnotation {
+  text: string;
+  /** Annotation font size in pt. Word stores this as half-points in `<w:hps>`. */
+  fontSizePt: number;
 }
 
 export interface ImageRun {


### PR DESCRIPTION
## Summary

Adds furigana rendering for `<w:ruby>` annotations. Sample-5 (夏目漱石「夢十夜」) carries a phonetic reading above almost every kanji; previously we only emitted the base text with the rt annotation silently dropped.

### Parser
- `TextRun.ruby?: { text, fontSizePt }` — populated from the `<w:rt>` payload of a `<w:ruby>` element. Word stores the annotation font size in half-points inside `<w:rubyPr><w:hps>`.
- The ruby handler attaches the annotation to the first base TextRun emitted from `<w:rubyBase>`. Splitting across multiple runs is uncommon; sample data has one base run per ruby.

### Renderer
- `LayoutTextSeg` propagates the ruby payload through `buildSegments` so word-boundary splitting only attaches the annotation to the first emitted segment.
- During layout the line ascent grows by `ruby.fontSizePt × 1.1` so the line box fits the annotation without colliding with the previous line's descent.
- During paint, after `fillText` of the base, the ruby text is drawn in the same color sized at `hps`, horizontally centered over the base segment, with its baseline placed above the base ascent.

### VRT

| sample | before | after |
|---|---:|---:|
| sample-5 page 2 | 89.3% | 89.0% |
| sample-5 page 3 | 86.9% | 86.9% |
| demo/sample-1 (6 pages) | 100% | 100% |
| sample-3 (3 pages) | 89.5/88.8/88.6 | unchanged |
| sample-4 | 92.0% | unchanged |

(VRT match ratio is roughly flat because line height grew uniformly — the annotations are now visible but do not yet expand pagination enough to match Word's 7-page render of sample-5. Pagination follow-up still pending.)

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt`
- [x] sample-5 page 2 visual: furigana visible above 坐, 仰向, 輪郭, 柔, 瓜実, 顔, 唇, 判然, 確, 覗, 開, 潤, 睫, 眸, 鮮, 透, 徹, 色沢, 傍 …
- [x] demo/sample-1 100% match preserved
- [ ] docGrid `w:lines` line snapping for body paragraphs — separate follow-up
- [ ] Text inside `<wps:txBody>` (cover title 夢十夜) — separate follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)