### PR TITLE
feat(docx): render text inside shape <wps:txbx>

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1352,6 +1352,11 @@ fn parse_wsp_shape(
         })
         .unwrap_or((None, 0.0));
 
+    // Shape body text: <wps:txbx><w:txbxContent>...</w:txbxContent></wps:txbx>
+    // and the bodyPr (insets / vertical anchor).
+    let (text_blocks, text_anchor, text_inset_l, text_inset_t, text_inset_r, text_inset_b) =
+        parse_shape_text_body(wsp, theme);
+
     Some(ShapeRun {
         width_pt,
         height_pt,
@@ -1367,7 +1372,91 @@ fn parse_wsp_shape(
         stroke_width,
         rotation,
         wrap_mode: anchor_meta.wrap_mode.clone(),
+        text_blocks,
+        text_anchor,
+        text_inset_l,
+        text_inset_t,
+        text_inset_r,
+        text_inset_b,
         ..Default::default()
+    })
+}
+
+/// Extract text blocks and bodyPr from a wsp shape.
+/// Returns (blocks, anchor, inset_l, inset_t, inset_r, inset_b).
+fn parse_shape_text_body(
+    wsp: roxmltree::Node,
+    theme: &ThemeColors,
+) -> (Vec<ShapeText>, Option<String>, f64, f64, f64, f64) {
+    let txbx = wsp.children().find(|n| n.is_element() && n.tag_name().name() == "txbx");
+    let body_pr = wsp.children().find(|n| n.is_element() && n.tag_name().name() == "bodyPr");
+
+    let anchor = body_pr
+        .and_then(|b| b.attribute("anchor"))
+        .map(|s| s.to_string());
+    let emu_to_pt = |v: &str| v.parse::<f64>().ok().map(|e| e / 12700.0).unwrap_or(0.0);
+    let l = body_pr.and_then(|b| b.attribute("lIns")).map(emu_to_pt).unwrap_or(0.0);
+    let t = body_pr.and_then(|b| b.attribute("tIns")).map(emu_to_pt).unwrap_or(0.0);
+    let r = body_pr.and_then(|b| b.attribute("rIns")).map(emu_to_pt).unwrap_or(0.0);
+    let b = body_pr.and_then(|b| b.attribute("bIns")).map(emu_to_pt).unwrap_or(0.0);
+
+    let blocks: Vec<ShapeText> = txbx
+        .and_then(|t| t.children().find(|n| n.is_element() && n.tag_name().name() == "txbxContent"))
+        .map(|content| {
+            children_w_flat(content, "p")
+                .into_iter()
+                .filter_map(|p| extract_simple_paragraph_text(p, theme))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    (blocks, anchor, l, t, r, b)
+}
+
+/// Reduce a <w:p> inside <w:txbxContent> to a single ShapeText. Pulls
+/// formatting from the FIRST run encountered; ignores mixed-format runs.
+fn extract_simple_paragraph_text(p: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeText> {
+    let mut text = String::new();
+    let mut first_rpr: Option<roxmltree::Node> = None;
+    for r in p.descendants().filter(|n| n.is_element() && n.tag_name().name() == "r") {
+        if first_rpr.is_none() {
+            first_rpr = child_w(r, "rPr");
+        }
+        for t in r.descendants().filter(|n| n.is_element() && n.tag_name().name() == "t") {
+            if let Some(text_node) = t.text() {
+                text.push_str(text_node);
+            }
+        }
+    }
+    if text.is_empty() { return None; }
+
+    let alignment = child_w(p, "pPr")
+        .and_then(|ppr| child_w(ppr, "jc"))
+        .and_then(|jc| attr_w(jc, "val"))
+        .unwrap_or_else(|| "left".to_string());
+
+    let (font_size_pt, color, font_family, bold, italic) = if let Some(rpr) = first_rpr {
+        let fmt = parse_run_fmt(rpr);
+        (
+            fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE),
+            fmt.color.clone(),
+            theme.resolve_font_ref(fmt.font_family_ascii.clone())
+                .or_else(|| theme.resolve_font_ref(fmt.font_family_east_asia.clone())),
+            fmt.bold.unwrap_or(false),
+            fmt.italic.unwrap_or(false),
+        )
+    } else {
+        (DEFAULT_FONT_SIZE, None, None, false, false)
+    };
+
+    Some(ShapeText {
+        text,
+        font_size_pt,
+        color,
+        font_family,
+        bold,
+        italic,
+        alignment: normalize_align(&alignment).to_string(),
     })
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -253,6 +253,26 @@ pub struct ShapeRun {
     /// rotation in degrees (clockwise).
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub rotation: f64,
+    /// Text blocks from <wps:txbx><w:txbxContent> — text rendered INSIDE the
+    /// shape's bounding box (ECMA-376 §17.3.4.7). Each block is one paragraph
+    /// reduced to plain text + the first run's formatting; advanced layout
+    /// (numbering, paragraph styles, mixed-format runs within a single
+    /// paragraph) isn't supported in shape bodies yet.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub text_blocks: Vec<ShapeText>,
+    /// Vertical anchor for the shape text box: "t" (top), "ctr" (center),
+    /// "b" (bottom). Read from <wps:bodyPr @anchor>. Default = "t".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_anchor: Option<String>,
+    /// Body-pr text insets in pt (left/top/right/bottom). Default 0 each.
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub text_inset_l: f64,
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub text_inset_t: f64,
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub text_inset_r: f64,
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub text_inset_b: f64,
     /// Wrap mode matching ImageRun.wrap_mode semantics.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wrap_mode: Option<String>,
@@ -367,6 +387,27 @@ pub struct RubyAnnotation {
     pub text: String,
     /// pt
     pub font_size_pt: f64,
+}
+
+/// One paragraph of text rendered inside a shape (`<wps:txbx><w:txbxContent>`).
+/// Reduced to a single combined string + the first run's effective formatting
+/// — the shape-text layouts in our current sample corpus carry one run per
+/// paragraph, so we don't yet support mixed runs / full inline layout here.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ShapeText {
+    pub text: String,
+    pub font_size_pt: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_family: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub bold: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub italic: bool,
+    /// Paragraph alignment ("left" | "center" | "right" | "both").
+    pub alignment: String,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1482,6 +1482,65 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     ctx.stroke();
   }
   ctx.restore();
+
+  // Body text inside the shape (wps:txbx). Drawn AFTER fill/stroke so text
+  // sits on top of the panel. Rotation is intentionally not applied to body
+  // text — the cover-template usage we care about uses anchor-only text.
+  if (shape.textBlocks && shape.textBlocks.length > 0) {
+    renderShapeText(shape, x, y, w, h, ctx as CanvasRenderingContext2D, scale);
+  }
+}
+
+/** Render a shape's body text inside its bounding box, honoring lIns/tIns/
+ *  rIns/bIns and the wps:bodyPr @anchor (t / ctr / b). Alignment within each
+ *  line is read from the per-block paragraph alignment. */
+function renderShapeText(
+  shape: ShapeRun,
+  x: number, y: number, w: number, h: number,
+  ctx: CanvasRenderingContext2D,
+  scale: number,
+): void {
+  const blocks = shape.textBlocks ?? [];
+  const lIns = (shape.textInsetL ?? 0) * scale;
+  const tIns = (shape.textInsetT ?? 0) * scale;
+  const rIns = (shape.textInsetR ?? 0) * scale;
+  const bIns = (shape.textInsetB ?? 0) * scale;
+  const innerX = x + lIns;
+  const innerW = Math.max(0, w - lIns - rIns);
+  const innerY = y + tIns;
+  const innerH = Math.max(0, h - tIns - bIns);
+
+  // First pass: measure each block's natural height (one line at fontSize px)
+  const lineHeights = blocks.map((b) => b.fontSizePt * scale * 1.2);
+  const totalH = lineHeights.reduce((s, lh) => s + lh, 0);
+
+  const anchor = shape.textAnchor ?? 't';
+  let cursorY: number;
+  if (anchor === 'b') {
+    cursorY = innerY + Math.max(0, innerH - totalH);
+  } else if (anchor === 'ctr') {
+    cursorY = innerY + Math.max(0, (innerH - totalH) / 2);
+  } else {
+    cursorY = innerY;
+  }
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    const fontPx = block.fontSizePt * scale;
+    ctx.font = buildFont(block.bold ?? false, block.italic ?? false, fontPx, block.fontFamily ?? null);
+    ctx.fillStyle = block.color ? `#${block.color}` : '#000000';
+    const m = ctx.measureText(block.text);
+    let tx = innerX;
+    if (block.alignment === 'center' || block.alignment === 'distribute') {
+      tx = innerX + Math.max(0, (innerW - m.width) / 2);
+    } else if (block.alignment === 'right' || block.alignment === 'end') {
+      tx = innerX + Math.max(0, innerW - m.width);
+    }
+    // Baseline = cursorY + ascent (approx 0.85 of font size for default fonts).
+    const baseline = cursorY + fontPx * 0.85;
+    ctx.fillText(block.text, tx, baseline);
+    cursorY += lineHeights[i];
+  }
 }
 
 function resolveShapeFillStyle(

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -170,6 +170,24 @@ export interface ShapeRun {
   strokeWidth?: number;
   rotation?: number;
   wrapMode?: string | null;
+  /** Text rendered INSIDE the shape's bounding box (`<wps:txbx><w:txbxContent>`). */
+  textBlocks?: ShapeText[];
+  /** "t" | "ctr" | "b" — vertical anchor for the shape's text body (`<wps:bodyPr @anchor>`). */
+  textAnchor?: string | null;
+  textInsetL?: number;  // pt
+  textInsetT?: number;  // pt
+  textInsetR?: number;  // pt
+  textInsetB?: number;  // pt
+}
+
+export interface ShapeText {
+  text: string;
+  fontSizePt: number;
+  color?: string | null;
+  fontFamily?: string | null;
+  bold?: boolean;
+  italic?: boolean;
+  alignment: string;
 }
 
 export type ShapeFill =


### PR DESCRIPTION
## Summary

Cover-template panels carry their visible labels (title, byline, year, section-marker) inside the shape body rather than as body paragraphs. Sample-5's gradient panel hosts 夢十夜 (title), 第一夜 (section), [年] (year badge), and [会社名] | [会社の住所] (footer line) entirely inside `<wps:txbx><w:txbxContent>`. Previously these were silently dropped and the cover rendered as just the gradient.

### Parser
- New `ShapeText` struct: one paragraph reduced to its combined text + the first run's font/color/size/alignment. Shape body text in our corpus uses one run per paragraph, so we don't yet need a full inline-layout pass inside shapes.
- `ShapeRun` gains `text_blocks`, `text_anchor` (t / ctr / b), and `text_inset_l/t/r/b` in pt. Insets come from `<wps:bodyPr lIns/tIns/rIns/bIns>` (EMU).
- `parse_shape_text_body` extracts `<wps:txbx><w:txbxContent>` paragraphs and the bodyPr metadata. Deliberately avoids plumbing `style_map` / `num_map` / `rel_map` into the shape codepath; instead it pulls the first run's rPr directly via the existing `parse_run_fmt` helper.

### Renderer
- After fill / stroke, `renderShapeText` paints each block in the shape's inner box (bounding box minus insets), honoring bodyPr vertical anchor (t / ctr / b) and the per-block paragraph alignment (left / center / right). Baseline uses a 0.85 ascent ratio.

### VRT

| sample | before | after |
|---|---:|---:|
| sample-5 page 1 (cover) | 86.2% | 85.8% (visual: title + labels now drawn) |
| sample-5 pages 2-7 | unchanged | unchanged |
| sample-3 (3 pages) | 89.5/88.8/88.6 | unchanged |
| demo/sample-1 (6 pages) | 100% | 100% |

The match% drop is small position drift on the labels; visually the cover now shows 夢十夜 / 第一夜 / [年] / [会社名] | [会社の住所] over the gradient, matching the structural intent of the Word reference.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt`
- [x] sample-5 page 1 visual: title 夢十夜 white over gradient; [年] badge; section / footer labels
- [x] demo/sample-1 100% match preserved (no wsp shapes in that document)
- [ ] docGrid line snap for ruby paragraphs — separate follow-up (initial attempt regressed demo/sample-1 page heights, needs a more nuanced rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)