### PR TITLE
feat(docx): wire prstGeom rendering through core.buildShapePath

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1313,21 +1313,38 @@ fn parse_wsp_shape(
     let anchor_y_pt = anchor_pos_y + group_off_pt_y + oy * sy / 12700.0;
 
     let cust_geom = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "custGeom");
-    let subpaths = if let Some(cg) = cust_geom {
-        parse_custom_geometry(cg)
+    let (subpaths, preset_geometry, adj_values) = if let Some(cg) = cust_geom {
+        (parse_custom_geometry(cg), None, Vec::new())
     } else {
-        // Fall back to prstGeom when custGeom is absent. Generate normalized
-        // [0,1] subpaths for the preset shapes used by our sample corpus
-        // (rect, line). Unknown presets fall back to rect so they remain
-        // visible — adj values (avLst) are intentionally not honored here.
-        let prst = sp_pr
+        // Defer prstGeom rendering to core's buildShapePath. Carry the preset
+        // name + adjustment values so the renderer can call into the shared
+        // catalog (matches pptx coverage: ellipse, roundRect, triangles,
+        // arrows, callouts, ribbons, …). Unknown presets are still passed
+        // through; buildShapePath falls back to rect for anything it doesn't
+        // recognize.
+        let prst_node = sp_pr
             .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "prstGeom")
+            .find(|n| n.is_element() && n.tag_name().name() == "prstGeom");
+        let prst = prst_node
             .and_then(|n| n.attribute("prst"))
-            .unwrap_or("rect");
-        preset_subpaths(prst)
+            .unwrap_or("rect")
+            .to_string();
+        let adj_values = prst_node
+            .and_then(|p| p.children().find(|n| n.is_element() && n.tag_name().name() == "avLst"))
+            .map(|av| {
+                av.children()
+                    .filter(|n| n.is_element() && n.tag_name().name() == "gd")
+                    .filter_map(|gd| {
+                        gd.attribute("fmla")
+                            .and_then(|f| f.strip_prefix("val "))
+                            .and_then(|s| s.parse::<f64>().ok())
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        (Vec::new(), Some(prst), adj_values)
     };
-    if subpaths.is_empty() { return None; }
+    if subpaths.is_empty() && preset_geometry.is_none() { return None; }
 
     // Direct fills on spPr take priority over wps:style/fillRef. ECMA-376
     // §20.1.4.1.30: when no direct fill is set, the shape's appearance comes
@@ -1367,6 +1384,8 @@ fn parse_wsp_shape(
         behind_doc: false,
         z_order,
         subpaths,
+        preset_geometry,
+        adj_values,
         fill,
         stroke,
         stroke_width,
@@ -1554,27 +1573,6 @@ fn parse_grad_fill_phclr(
     };
 
     Some(ShapeFill::Gradient { stops, angle, grad_type })
-}
-
-/// Generate normalized [0,1] subpaths for OOXML preset geometries used by
-/// our docx sample corpus. Unknown presets fall back to rect so the shape
-/// remains visible at its bounding box. `avLst` adjustment values are not
-/// honored — add per-shape handling here if a sample needs it.
-fn preset_subpaths(prst: &str) -> Vec<Vec<PathCmd>> {
-    match prst {
-        "line" => vec![vec![
-            PathCmd::MoveTo { x: 0.0, y: 0.0 },
-            PathCmd::LineTo { x: 1.0, y: 1.0 },
-        ]],
-        // "rect" | unknown
-        _ => vec![vec![
-            PathCmd::MoveTo { x: 0.0, y: 0.0 },
-            PathCmd::LineTo { x: 1.0, y: 0.0 },
-            PathCmd::LineTo { x: 1.0, y: 1.0 },
-            PathCmd::LineTo { x: 0.0, y: 1.0 },
-            PathCmd::Close,
-        ]],
-    }
 }
 
 /// Parse <a:custGeom><a:pathLst><a:path w="W" h="H">...</a:path></a:pathLst>.

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -240,8 +240,18 @@ pub struct ShapeRun {
     /// Document order within the wp:anchor (for correct z-ordering among shapes
     /// sharing the same behindDoc value). Lower value = drawn first.
     pub z_order: u32,
-    /// normalized [0,1] custom path commands (one or more sub-paths)
+    /// normalized [0,1] custom path commands (one or more sub-paths). Empty
+    /// when `preset_geometry` is set; the renderer chooses between
+    /// buildCustomPath (custGeom) and buildShapePath (prstGeom).
     pub subpaths: Vec<Vec<PathCmd>>,
+    /// OOXML <a:prstGeom prst="..."> name (e.g. "rect", "ellipse",
+    /// "roundRect", "rtTriangle"). Empty when the shape is custGeom.
+    /// `adj_values` carries up to four <a:gd name="adj{n}"> values (0–100000
+    /// scale) for shapes that support adjustment handles (trapezoid, callouts).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preset_geometry: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub adj_values: Vec<f64>,
     /// Fill (solid or gradient). None = no fill.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<ShapeFill>,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3,7 +3,7 @@ import type {
   DocRun, TextRun, ImageRun, ShapeRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, SectionProps,
 } from './types';
-import { buildCustomPath, hexToRgba, resolveFill } from '@silurus/ooxml-core';
+import { buildCustomPath, buildShapePath, hexToRgba, resolveFill } from '@silurus/ooxml-core';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -1470,7 +1470,23 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     ctx.translate(-(x + w / 2), -(y + h / 2));
   }
   ctx.beginPath();
-  buildCustomPath(ctx as CanvasRenderingContext2D, shape.subpaths, x, y, w, h);
+  if (shape.presetGeometry) {
+    // OOXML <a:prstGeom> — delegate to core's buildShapePath which has the
+    // full preset shape catalog (rect / ellipse / triangles / arrows /
+    // callouts / ribbons / flowchart / …) shared with the pptx renderer.
+    const adj = shape.adjValues ?? [];
+    buildShapePath(
+      ctx as CanvasRenderingContext2D,
+      shape.presetGeometry,
+      x, y, w, h,
+      adj[0] ?? null,
+      adj[1] ?? null,
+      adj[2] ?? null,
+      adj[3] ?? null,
+    );
+  } else {
+    buildCustomPath(ctx as CanvasRenderingContext2D, shape.subpaths, x, y, w, h);
+  }
   const fillStyle = resolveFill(shape.fill, ctx as CanvasRenderingContext2D, x, y, w, h);
   if (fillStyle) {
     ctx.fillStyle = fillStyle;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -163,8 +163,14 @@ export interface ShapeRun {
   behindDoc?: boolean;
   /** Document-order index within a group; lower values render first. */
   zOrder: number;
-  /** Normalized [0,1] custom-geometry sub-paths */
+  /** Normalized [0,1] custom-geometry sub-paths. Empty when `presetGeometry`
+   *  is set; the renderer chooses between buildCustomPath and buildShapePath. */
   subpaths: PathCmd[][];
+  /** OOXML <a:prstGeom prst> name (e.g. "rect", "ellipse", "rtTriangle").
+   *  When set the renderer calls core's buildShapePath with `adjValues`. */
+  presetGeometry?: string | null;
+  /** Up to four <a:gd name="adj{n}"> values from prstGeom/avLst (0–100000). */
+  adjValues?: number[];
   fill: ShapeFill | null;
   stroke: string | null;
   strokeWidth?: number;


### PR DESCRIPTION
## Summary

Follow-up to #225 — the docx parser/renderer now emits the OOXML preset name + adjustment values for `<a:prstGeom>` shapes and delegates path construction to the shared `buildShapePath` in `@silurus/ooxml-core` (the function moved from the pptx renderer in #225). docx picks up the full preset shape catalog (ellipse, triangles, arrows, callouts, ribbons, flowchart, …) without per-shape Rust additions.

### Parser

- `ShapeRun` gains `preset_geometry: Option<String>` and `adj_values: Vec<f64>`.
- `<a:custGeom>` path: emit `subpaths`, leave preset_geometry None (existing behavior).
- `<a:prstGeom prst="..."><a:avLst><a:gd name="adj{n}" fmla="val 25000"/></a:avLst></a:prstGeom>` path: emit the preset name + parsed adjustment values, leave subpaths empty.
- Drop the now-unused `preset_subpaths` helper that previously covered only rect/line.

### Renderer

- `renderAnchorShape` branches on `shape.presetGeometry`: if present, `buildShapePath(ctx, presetGeometry, x, y, w, h, adj0, adj1, adj2, adj3)`; otherwise `buildCustomPath(ctx, subpaths, x, y, w, h)`.

### VRT

Match percentages unchanged (rect / line cases remap onto buildShapePath's `rect`/`line` branches with identical output):

| sample | match% |
|---|---:|
| sample-3 (3 pages) | 89.5 / 88.8 / 88.6 |
| sample-4 | 92.0 |
| sample-5 page 1 | 85.9 |
| demo/sample-1 (6 pages) | 100% |

The win is the new capability: a docx that uses `<a:prstGeom prst="ellipse">` or any other catalog shape now Just Works, without hand-coding subpaths in the parser.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt`
- [x] demo/sample-1 100% preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)