### PR TITLE
fix(docx): docGrid ruby paragraphs snap line height to integer pitch

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -463,14 +463,32 @@ function estimateParagraphHeight(
     } : undefined;
     const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx);
     if (paraHasRuby) {
-      // Word uses the same line height for every line in a ruby paragraph.
-      const uniform = Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, state.docGrid, true)));
+      // Word uses the same line height for every line in a ruby paragraph,
+      // snapped to an integer docGrid pitch.
+      const uniform = snapParaLineToGrid(
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, state.docGrid, true))),
+        state.docGrid,
+        1,
+      );
       textH = uniform * lines.length;
     } else {
       textH = lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, state.docGrid, false), 0);
     }
   }
   return textH + (suppressSpaceBefore ? 0 : para.spaceBefore) + para.spaceAfter;
+}
+
+/** Snap a paragraph's uniform line height up to an integer multiple of the
+ *  docGrid pitch. Mirrors Word's docGrid handling for ruby paragraphs:
+ *  the grid pitch widens to accommodate the tallest required line, and
+ *  every line in the paragraph then uses that widened pitch. */
+function snapParaLineToGrid(h: number, grid: DocGridCtx | undefined, scale: number): number {
+  if (!grid || !grid.linePitchPt || grid.linePitchPt <= 0) return h;
+  if (grid.type !== 'lines' && grid.type !== 'linesAndChars') return h;
+  const pitchPx = grid.linePitchPt * scale;
+  if (pitchPx <= 0) return h;
+  if (h <= pitchPx) return pitchPx;
+  return Math.ceil(h / pitchPx) * pitchPx;
 }
 
 /** Return true when any text run in the paragraph carries a `ruby` annotation.
@@ -525,7 +543,9 @@ function splitParagraphAcrossPages(
   const paraHasRuby = paragraphHasRuby(para);
 
   const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby);
-  const uniformH = paraHasRuby ? Math.max(0, ...lines.map(perLineH)) : 0;
+  const uniformH = paraHasRuby
+    ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), measureState.docGrid, 1)
+    : 0;
   const lineHeights = lines.map(l => paraHasRuby ? uniformH : perLineH(l));
   const spaceBefore = suppressSpaceBefore ? 0 : para.spaceBefore;
   const spaceAfter = para.spaceAfter;
@@ -768,11 +788,19 @@ function renderParagraph(
   const lines = layoutLines(ctx, segments, paraW, firstLineX - paraX, scale, para.tabStops, wrapCtx);
 
   // For paragraphs that carry any ruby annotation, Word renders every line
-  // at the SAME height (the tallest natural line in the paragraph). Without
-  // that consistency, ruby and non-ruby lines alternate vertically and the
-  // baseline grid drifts. Compute it once here and reuse it below.
+  // at the SAME height. Per the user's note: when the section's docGrid is
+  // active, Word widens the grid pitch to accommodate the tallest required
+  // line (ruby + base + leading), then ALL lines in the paragraph use that
+  // widened pitch — both ruby-bearing and non-ruby lines share the same
+  // baseline grid, otherwise the lines drift. We mimic this by computing
+  // uniformLineH = ceil(max natural / pitch) * pitch when docGrid is on,
+  // else just the max natural.
   const uniformLineH = paraHasRuby
-    ? Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, true)))
+    ? snapParaLineToGrid(
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, true))),
+        state.docGrid,
+        scale,
+      )
     : 0;
   const lineHForLine = (l: typeof lines[number]): number =>
     paraHasRuby
@@ -1439,15 +1467,17 @@ function layoutLines(
     // line boxes do not jitter based on the specific characters on each line.
     let asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? s.fontSize * scale * 0.8;
     const desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? s.fontSize * scale * 0.2;
-    // Ruby annotation: small text rendered above the base. Reserve enough
-    // ascent room so the line box grows for it (ECMA-376 §17.3.3.25). The
-    // 3.5× rt-size reserve was tuned against sample-5 page-3 — Word
-    // renders a 13.5pt base + 8pt rt line at ~45pt total, which is what
-    //   base_natural (~13.5pt) + 3.5 × rt_size (28pt) + descent (~3pt)
-    // produces. Snapping to integer grid pitches over-rounded; Word does
-    // not snap ruby lines.
+    // Ruby annotation: small text rendered above the base. Reserve ascent
+    // room for the rt glyphs (ECMA-376 §17.3.3.25). The actual line spacing
+    // in docGrid sections is set further down by the paragraph-wide
+    // pitch snap — see the doc-grid-aware path in renderParagraph /
+    // estimateParagraphHeight that takes max(perLineH) and snaps it to
+    // an integer grid pitch. The reserve here just ensures the natural
+    // line height EXCEEDS the docGrid pitch when ruby is present, so the
+    // snap actually picks the next pitch slot. 1.5× rt-size is enough for
+    // any rt size that fits in one extra pitch above the base.
     if (s.ruby) {
-      asc = asc + s.ruby.fontSizePt * scale * 3.5;
+      asc = asc + s.ruby.fontSizePt * scale * 1.5;
     }
     // Wrap-fit check uses two standard typographic allowances:
     //   1. Trailing-space collapse: if this word becomes the last on the


### PR DESCRIPTION
## Summary

Per the user's note about Word's docGrid behavior:

> 文書が「行グリッド（行送り）」で組まれている場合、ルビを入れた結果として必要な高さが増えると、行送りそのもの（基準のマス目）を広げる／段落がグリッドに合わせて広がる挙動になる。

When the section uses `<w:docGrid w:type="lines">` and a paragraph carries ruby, Word *widens the grid pitch itself* to fit the tallest required line, then EVERY line in the paragraph (ruby-bearing AND non-ruby) uses the widened pitch. The previous fix used the raw natural-max height directly, which landed at ~41pt — about 1pt over what Word actually uses, accumulating into one extra line per page.

### Implementation

- New `snapParaLineToGrid(h, grid, scale)` snaps an input height up to the next integer grid pitch when the section's docGrid is `lines` / `linesAndChars`. No-op on `default` grids or when pitch is unset.
- `renderParagraph` / `estimateParagraphHeight` / `splitParagraphAcrossPages` feed `Math.max(...lineBoxHeight per line)` through `snapParaLineToGrid` before applying it as the uniform per-line height for the paragraph.
- Drop the rt-ascent reserve from 3.5× rt-size back to 1.5× rt-size — only enough to push the natural over the 18pt pitch so the snap selects the next slot (36pt = 2 pitches) without overshooting into the third slot (54pt).

### Measurement

The Word reference for sample-5 page-3 has line baselines spaced at 33-37pt (avg ~35pt). Snapping to 2 pitches × 18pt = 36pt lands on the same rhythm. Our 36pt vs Word's 35pt is within sub-pixel variation.

### VRT

| sample / page | before | after |
|---|---:|---:|
| sample-5 page 3 | 91.7% | 92.0% |
| sample-5 page 5 | 90.6% | 92.2% |
| sample-5 page 6 | 90.8% | 95.7% |
| sample-5 page 7 | 99.9% | **100.0%** |
| **demo/sample-1 (6 pages)** | **100%** | **100%** |
| sample-3 / sample-4 | unchanged | unchanged |

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt` — all docx samples; demo/sample-1 100% preserved.
- [x] sample-5 line spacing in screenshots is uniform across ruby and non-ruby lines.
- [x] sample-5 pagination matches Word's 7-page layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)