### PR TITLE
fix(docx): preserve requested font; classify serif vs sans-serif by family name

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2143,20 +2143,64 @@ function buildFont(bold: boolean, italic: boolean, sizePx: number, family: strin
 
 function normalizeFontFamily(family: string | null): string {
   if (!family) return '"Noto Sans JP", "Hiragino Sans", "Meiryo", sans-serif';
+
+  // 1) Always lead with the requested family verbatim. If the user has it
+  //    installed (or a webfont is registered for it) the canvas resolver
+  //    picks it up; downstream entries are fallbacks for missing fonts.
+  // 2) Detect serif (Mincho) vs sans-serif (Gothic / Sans) from the family
+  //    name. ECMA-376 doesn't carry a generic-family hint, so we inspect
+  //    the typeface name for the well-known Japanese / Latin serif
+  //    markers ("明朝", "Mincho", "Times", "Caladea", …) and the
+  //    sans-serif ones ("ゴシック", "Gothic", "Sans", "Calibri", "Meiryo", …).
+  //    Without this, every Japanese font fell through the heuristic and
+  //    rendered as Gothic — sample-5 dream text in 游明朝 came out in
+  //    Yu Gothic instead of the requested Mincho serif.
+  const escape = (s: string) => s.replace(/"/g, '\\"');
+  const head = `"${escape(family)}"`;
   const lower = family.toLowerCase();
-  if (lower.includes('meiryo') || lower.includes('メイリオ')) {
-    return '"Meiryo UI", "Meiryo", "Noto Sans JP", sans-serif';
+
+  const isSerif =
+    family.includes('明朝') ||
+    family.includes('明朝体') ||
+    /\bmincho\b/i.test(family) ||
+    /\bmin\s*cho\b/i.test(family) ||
+    family.includes('ＭＳ 明朝') ||
+    family.includes('MS Mincho') ||
+    family.includes('Yu Mincho') ||
+    family.includes('游明朝') ||
+    family.includes('Hiragino Mincho') ||
+    family.includes('ヒラギノ明朝') ||
+    family.includes('Cambria') ||
+    family.includes('Caladea') ||
+    family.includes('Times') ||
+    family.includes('Georgia') ||
+    family.includes('Bodoni') ||
+    family.includes('Garamond') ||
+    family.includes('Playfair') ||
+    family.includes('Source Serif') ||
+    family.includes('Noto Serif');
+
+  if (isSerif) {
+    // Japanese serif fallback chain — prefers Yu Mincho (Japan) → Hiragino
+    // Mincho ProN (macOS) → MS Mincho (Windows) → Noto Serif JP (web).
+    return `${head}, "Yu Mincho", "YuMincho", "Hiragino Mincho ProN", "MS Mincho", "Noto Serif JP", "Noto Serif", serif`;
   }
-  if (lower.includes('游') || lower.includes('yu ')) {
-    return '"Yu Gothic", "YuGothic", "Noto Sans JP", sans-serif';
+
+  // Sans-serif specific known fonts.
+  if (lower.includes('meiryo') || family.includes('メイリオ')) {
+    return `${head}, "Meiryo UI", "Meiryo", "Noto Sans JP", "Hiragino Sans", sans-serif`;
+  }
+  if (family.includes('游ゴシック') || /\byu\s*gothic\b/i.test(family) || lower.includes('yugothic')) {
+    return `${head}, "Yu Gothic", "YuGothic", "Noto Sans JP", "Hiragino Sans", sans-serif`;
   }
   if (lower.includes('ipa')) {
-    return '"IPAexGothic", "Noto Sans JP", sans-serif';
+    return `${head}, "IPAexGothic", "Noto Sans JP", "Hiragino Sans", sans-serif`;
   }
   if (lower.includes('segoe')) {
-    return '"Segoe UI", sans-serif';
+    return `${head}, "Segoe UI", sans-serif`;
   }
-  return `"${family}", sans-serif`;
+  // Generic Japanese / Latin sans-serif fallback chain.
+  return `${head}, "Noto Sans JP", "Hiragino Sans", "Meiryo", sans-serif`;
 }
 
 function getDefaultFontSize(para: DocParagraph): number {


### PR DESCRIPTION
## Summary

Two related issues with `normalizeFontFamily`:

### 1. The requested typeface name was thrown away

The fallback chain emitted only generic substitutes (Yu Gothic / Meiryo / IPA), so even when the user had the requested font installed it never resolved — Canvas would always pick a substitute. Fix: lead the fallback chain with the verbatim family name, then degrade through the platform substitutes.

### 2. Every Japanese font fell through to sans-serif

The only family-aware branch matched on the kanji `游` and routed both `游ゴシック` (Yu Gothic — sans-serif) AND `游明朝` (Yu Mincho — serif) to a Yu Gothic fallback chain. Sample-5's dream paragraphs use `<w:rFonts w:eastAsiaTheme="minorHAnsi">` which resolves to 游明朝 via the theme's `<a:minorFont><a:latin typeface="游明朝">` — so the body text came out in Gothic instead of Mincho.

Fix: classify the requested family by name. Serif matches include `明朝` / `Mincho` / `Times` / `Cambria` / `Georgia` / `Caladea` / `Playfair` / `Source Serif` / `Noto Serif`. Serif families fall through to a Japanese serif chain (Yu Mincho → Hiragino Mincho ProN → MS Mincho → Noto Serif JP → serif). Everything else stays on the existing sans-serif chains.

```ts
"游明朝, \"Yu Mincho\", YuMincho, \"Hiragino Mincho ProN\", \"MS Mincho\", \"Noto Serif JP\", \"Noto Serif\", serif"
```

### VRT

| sample / page | before | after |
|---|---:|---:|
| sample-5 page 2 | 94.8% | **95.1%** |
| sample-5 page 3 | 92.7% | **93.2%** |
| sample-5 page 4 | 98.6% | **98.7%** |
| sample-5 page 5 | 91.5% | 92.1% |
| sample-5 page 6 | 91.7% | 92.8% |
| **demo/sample-1 (6 pages)** | **100%** | **100%** |

Visible improvement: sample-5 dream pages now render with proper Mincho serif strokes and ruby annotations land correctly above the base glyphs.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt`
- [x] sample-5 page 3 visual: text in Mincho serif, ruby annotations above kanji.
- [x] demo/sample-1 100% match preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)