### PR TITLE
fix(docx): serialize DocRun::Break.break_type as camelCase

### DIFF
--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -203,6 +203,11 @@ pub struct NumberingInfo {
 pub enum DocRun {
     Text(TextRun),
     Image(ImageRun),
+    /// `rename_all` on the enum only renames variant tags; the field
+    /// `break_type` would otherwise serialize as snake_case while the TS
+    /// side reads `breakType`. Re-apply camelCase at the variant level so
+    /// the JSON tag matches.
+    #[serde(rename_all = "camelCase")]
     Break { break_type: BreakType },
     Field(FieldRun),
     Shape(ShapeRun),


### PR DESCRIPTION
## Summary

User noticed `<w:br/>` line breaks weren't taking effect in sample-5 — most visibly the break before 「百年はもう来ていたんだな」 was getting collapsed into the surrounding sentence.

Root cause: `#[serde(rename_all = "camelCase")]` on a tagged enum only renames the variant tags (`break`, `text`, `image`, …), not the field names *inside* each variant. The `DocRun::Break` struct field was therefore emitting `break_type` (snake_case) into JSON while the TS renderer's discriminator check reads `breakType`. Every `<w:br/>` ran through `buildSegments` as `run.breakType === undefined`, the line-break sentinel was never queued, and the line break was lost.

Adding `#[serde(rename_all = "camelCase")]` on the variant restores the JSON tag and routes `<w:br/>` back through the existing `breakType === 'line'` branch.

### Visible result

sample-5 page 6 now shows the line break before 「百年はもう来ていたんだな」とこの時始めて気がついた。 — and several other intra-paragraph `<w:br/>`-driven breaks earlier in the same paragraph (between "勘定した。" / "自分はこう云う風..." and between "思い出した。" / "すると石の下...").

### VRT

| sample / page | before | after |
|---|---:|---:|
| sample-5 page 2 | 95.1% | 95.4% |
| sample-5 page 3 | 93.2% | 94.8% |
| sample-5 page 4 | 98.7% | **99.0%** |
| sample-5 page 5 | 92.1% | 93.0% |
| sample-5 page 6 | 92.8% | 93.9% |
| **demo/sample-1 (6 pages)** | **100%** | **100%** |
| sample-3 / sample-4 | unchanged | ±0.1% drift only |

(Per-page match% climbs because reinstating the line breaks adds a few pt of vertical content per paragraph, shifting layout slightly closer to Word's reference.)

## Test plan

- [x] `pnpm --filter @silurus/ooxml-docx vrt`
- [x] sample-5 page 6 visual: line break before 「百年はもう来ていたんだな」 and other intra-paragraph breaks visible.
- [x] demo/sample-1 100% match preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)