### PR TITLE
refactor(parsers): hoist chart-XML extractors into ooxml-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "console_error_panic_hook",
+ "ooxml-common",
  "roxmltree",
  "serde",
  "serde_json",

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -1,0 +1,296 @@
+//! Shared OOXML chart-XML extractors used by both the xlsx and pptx Rust
+//! parsers.
+//!
+//! Both crates parse a chart `<c:chartSpace>` (and the modern
+//! `<cx:chartSpace>` for waterfall / treemap / box-and-whisker etc.) but
+//! historically did so with two near-identical bodies sitting in
+//! `packages/xlsx/parser/src/lib.rs` and `packages/pptx/parser/src/lib.rs`.
+//! The result was that fields added on one side stayed missing on the other
+//! until somebody noticed (e.g. PowerPoint sample-2 slide-7 displaying its
+//! legend on the right because the pptx adapter had a hard-coded
+//! `legendPos: null` while xlsx already passed it through).
+//!
+//! This module hosts the helpers that don't need any crate-private state:
+//! they're pure XML probes that take a roxmltree node and return the parsed
+//! property. The data-structure layer (xlsx's `ChartData`, pptx's
+//! `ChartElement`) intentionally stays in each crate so we don't pull
+//! schema-specific types into the shared one.
+//!
+//! ## Namespace handling
+//!
+//! All helpers match elements by local name only. Real chart documents put
+//! everything under either the `c:` (chart 2006) or `cx:` (chartEx 2014)
+//! namespace and never mix non-chart elements at these paths, so the strict
+//! `tag_name().namespace() == Some(c_ns)` check in xlsx adds nothing in
+//! practice — this module drops it for symmetry with the pptx side and to
+//! keep the API simple. If a future format wedges a non-chart element into
+//! `<c:plotArea>` the caller can pre-filter before delegating here.
+//!
+//! All field references are to ECMA-376 / ISO-29500 part 1 §21.2 (DrawingML
+//! Charts) unless stated otherwise.
+
+use roxmltree::Node;
+
+/// Find a direct child of `parent` whose local name is `name`.
+fn child<'a, 'i>(parent: Node<'a, 'i>, name: &str) -> Option<Node<'a, 'i>> {
+    parent.children().find(|n| n.is_element() && n.tag_name().name() == name)
+}
+
+/// `<c:legend>` presence + `<c:legendPos val>` (ECMA-376 §21.2.2.10).
+///
+/// `(show_legend, legend_pos)`. When the chart omits `<c:legend>` Office
+/// hides the legend even if a default position would otherwise apply, so
+/// `show_legend = false` is the authoritative "no legend" signal.
+pub fn extract_legend(root: Node) -> (bool, Option<String>) {
+    // The legend can sit anywhere inside `<c:chart>` but in practice it's a
+    // direct child of `<c:chart>`. Use descendants to be tolerant of either
+    // structure — there's only one `<c:legend>` element per chart.
+    let legend = root.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "legend");
+    let show = legend.is_some();
+    let pos = legend.and_then(|ln| {
+        child(ln, "legendPos").and_then(|p| p.attribute("val")).map(|s| s.to_string())
+    });
+    (show, pos)
+}
+
+/// `<c:barChart><c:gapWidth val>` / `<c:overlap val>` (ECMA-376 §21.2.2.13,
+/// §21.2.2.25). Returns `(gap%, overlap%)`. Defaults to (None, None) when
+/// the file relies on Office's defaults (gap 150, overlap 0).
+pub fn extract_bar_gap_overlap(root: Node) -> (Option<i32>, Option<i32>) {
+    let gap = root.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "gapWidth")
+        .and_then(|n| n.attribute("val").and_then(|v| v.parse::<i32>().ok()));
+    let ov = root.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "overlap")
+        .and_then(|n| n.attribute("val").and_then(|v| v.parse::<i32>().ok()));
+    (gap, ov)
+}
+
+/// First `<c:dLbls><c:dLblPos val>` found anywhere in the chart (chart-level
+/// or per-series). ECMA-376 §21.2.2.49.
+pub fn extract_data_label_position(root: Node) -> Option<String> {
+    root.descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .find_map(|dlbls| {
+            child(dlbls, "dLblPos").and_then(|n| n.attribute("val")).map(|s| s.to_string())
+        })
+}
+
+/// First non-`General` `<c:dLbls><c:numFmt formatCode>` in the chart.
+/// ECMA-376 §21.2.2.37.
+pub fn extract_data_label_format_code(root: Node) -> Option<String> {
+    root.descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .find_map(|dlbls| {
+            child(dlbls, "numFmt")
+                .and_then(|n| n.attribute("formatCode"))
+                .map(|s| s.to_string())
+                .filter(|s| !s.is_empty() && s != "General")
+        })
+}
+
+/// `<c:catAx|valAx><c:numFmt formatCode>` — the value-axis tick label
+/// number format (ECMA-376 §21.2.2.21). Caller passes the already-located
+/// `<c:catAx>` / `<c:valAx>` node.
+pub fn extract_axis_format_code(axis_node: Node) -> Option<String> {
+    child(axis_node, "numFmt")
+        .and_then(|n| n.attribute("formatCode"))
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty() && s != "General")
+}
+
+/// `<c:catAx|valAx><c:scaling>` — read explicit `<c:min val>` / `<c:max val>`.
+/// Returns `(min, max)`; either can be `None` when the file leaves Excel to
+/// pick the auto bound.
+pub fn extract_axis_min_max(axis_node: Node) -> (Option<f64>, Option<f64>) {
+    let Some(scaling) = child(axis_node, "scaling") else {
+        return (None, None);
+    };
+    let mn = child(scaling, "min")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<f64>().ok());
+    let mx = child(scaling, "max")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<f64>().ok());
+    (mn, mx)
+}
+
+/// `<c:catAx|valAx><c:delete val="1"/>` — true when the axis (labels, ticks
+/// and line) should be hidden. ECMA-376 §21.2.2.40.
+pub fn axis_is_deleted(axis_node: Node) -> bool {
+    child(axis_node, "delete")
+        .and_then(|n| n.attribute("val"))
+        .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+        .unwrap_or(false)
+}
+
+/// `<c:catAx|valAx><c:majorTickMark val>` / `<c:minorTickMark val>`. Values
+/// are the ECMA-376 §21.2.2.49 ST_TickMark enum: `none` | `out` | `in` |
+/// `cross`. Returns the raw string.
+pub fn extract_axis_tick_mark(axis_node: Node, name: &str) -> Option<String> {
+    child(axis_node, name)
+        .and_then(|n| n.attribute("val"))
+        .map(|s| s.to_string())
+}
+
+/// First `<a:defRPr@sz>` or `<a:rPr@sz>` found inside the axis's `<c:txPr>`.
+/// Sizes are OOXML hundredths of a point (e.g. 1200 = 12 pt).
+pub fn extract_axis_tick_label_size(axis_node: Node) -> Option<i32> {
+    let txpr = child(axis_node, "txPr")?;
+    txpr.descendants().find_map(|n| {
+        if !n.is_element() { return None; }
+        let tag = n.tag_name().name();
+        if tag != "defRPr" && tag != "rPr" { return None; }
+        n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
+    })
+}
+
+/// First `<c:dLbls><c:txPr>` font size (hpt). Mirrors the per-series + chart
+/// fallback chain: walk every `<c:dLbls>` in document order, returning the
+/// first inner `<a:defRPr@sz>` / `<a:rPr@sz>` we find.
+pub fn extract_data_label_font_size(root: Node) -> Option<i32> {
+    root.descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .find_map(|dl| {
+            child(dl, "txPr").and_then(|tx| tx.descendants().find_map(|n| {
+                if !n.is_element() { return None; }
+                let tag = n.tag_name().name();
+                if tag != "defRPr" && tag != "rPr" { return None; }
+                n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
+            }))
+        })
+}
+
+/// chartEx (`<cx:chartSpace>`) axis visibility. ChartEx encodes the
+/// scale type via a `<cx:catScaling>` / `<cx:valScaling>` child rather
+/// than separate `<c:catAx>` / `<c:valAx>` elements, so callers can't just
+/// reuse `axis_is_deleted` — this helper walks `<cx:axis hidden="1">` and
+/// pairs each one with its scaling kind.
+///
+/// Returns `(cat_hidden, val_hidden)`. Defaults to `(false, false)` when no
+/// `<cx:axis>` declares `hidden`.
+pub fn extract_chartex_axis_hidden(root: Node) -> (bool, bool) {
+    let mut cat_hidden = false;
+    let mut val_hidden = false;
+    for ax in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "axis") {
+        let hidden = ax.attribute("hidden").map(|v| v == "1").unwrap_or(false);
+        if !hidden { continue; }
+        let is_val = ax.children().any(|c| c.is_element() && c.tag_name().name() == "valScaling");
+        let is_cat = ax.children().any(|c| c.is_element() && c.tag_name().name() == "catScaling");
+        if is_val { val_hidden = true; }
+        if is_cat { cat_hidden = true; }
+    }
+    (cat_hidden, val_hidden)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roxmltree::Document;
+
+    fn root_of(xml: &str) -> Document<'_> {
+        Document::parse(xml).expect("parse fixture")
+    }
+
+    #[test]
+    fn legend_present_with_pos() {
+        let xml = r#"<c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+            <c:legend><c:legendPos val="t"/></c:legend>
+        </c:chart>"#;
+        let d = root_of(xml);
+        let (show, pos) = extract_legend(d.root_element());
+        assert!(show);
+        assert_eq!(pos.as_deref(), Some("t"));
+    }
+
+    #[test]
+    fn legend_absent() {
+        let xml = r#"<c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
+        let d = root_of(xml);
+        let (show, pos) = extract_legend(d.root_element());
+        assert!(!show);
+        assert!(pos.is_none());
+    }
+
+    #[test]
+    fn bar_gap_overlap_default_to_none() {
+        let xml = r#"<c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
+        let d = root_of(xml);
+        assert_eq!(extract_bar_gap_overlap(d.root_element()), (None, None));
+    }
+
+    #[test]
+    fn bar_gap_overlap_explicit() {
+        let xml = r#"<c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+            <c:gapWidth val="50"/>
+            <c:overlap val="100"/>
+        </c:barChart>"#;
+        let d = root_of(xml);
+        assert_eq!(extract_bar_gap_overlap(d.root_element()), (Some(50), Some(100)));
+    }
+
+    #[test]
+    fn data_label_position() {
+        let xml = r#"<c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+            <c:plotArea><c:dLbls><c:dLblPos val="ctr"/></c:dLbls></c:plotArea>
+        </c:chart>"#;
+        let d = root_of(xml);
+        assert_eq!(extract_data_label_position(d.root_element()).as_deref(), Some("ctr"));
+    }
+
+    #[test]
+    fn axis_delete_truthy_variants() {
+        for (val, expect) in [("1", true), ("0", false), ("true", true), ("false", false), ("True", true)] {
+            let xml = format!(r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                <c:delete val="{val}"/>
+            </c:valAx>"#);
+            let d = root_of(&xml);
+            assert_eq!(axis_is_deleted(d.root_element()), expect, "val={val}");
+        }
+    }
+
+    #[test]
+    fn axis_delete_default_false() {
+        let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
+        let d = root_of(xml);
+        assert!(!axis_is_deleted(d.root_element()));
+    }
+
+    #[test]
+    fn axis_min_max() {
+        let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+            <c:scaling><c:max val="2500"/><c:min val="0"/></c:scaling>
+        </c:valAx>"#;
+        let d = root_of(xml);
+        assert_eq!(extract_axis_min_max(d.root_element()), (Some(0.0), Some(2500.0)));
+    }
+
+    #[test]
+    fn axis_format_code_skips_general() {
+        let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+            <c:numFmt formatCode="General"/>
+        </c:valAx>"#;
+        let d = root_of(xml);
+        assert!(extract_axis_format_code(d.root_element()).is_none());
+    }
+
+    #[test]
+    fn axis_format_code_passes_through() {
+        let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+            <c:numFmt formatCode="0.0%"/>
+        </c:valAx>"#;
+        let d = root_of(xml);
+        assert_eq!(extract_axis_format_code(d.root_element()).as_deref(), Some("0.0%"));
+    }
+
+    #[test]
+    fn chartex_axis_hidden_value_only() {
+        let xml = r#"<cx:chartSpace xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex">
+            <cx:axis id="0"><cx:catScaling/></cx:axis>
+            <cx:axis id="1" hidden="1"><cx:valScaling/></cx:axis>
+        </cx:chartSpace>"#;
+        let d = root_of(xml);
+        assert_eq!(extract_chartex_axis_hidden(d.root_element()), (false, true));
+    }
+}

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -5,4 +5,5 @@
 //! schema-specific (DocParagraph, ShapeRun, Slide, etc.) stays in the
 //! consuming crate.
 
+pub mod chart;
 pub mod color;

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2518,28 +2518,18 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             attr(&n, "sz").and_then(|v| v.parse::<i32>().ok())
         }));
 
-    // val axis max / min
+    // val axis max / min and visibility — shared helpers in ooxml-common
+    // so xlsx & pptx stay in sync (`<c:scaling><c:min|max val>` and
+    // `<c:delete val>` ECMA-376 §21.2.2.40 / §21.2.2.43).
     let val_ax = root.descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "valAx");
-    let val_max = val_ax
-        .and_then(|ax| ax.descendants().find(|n| n.is_element() && n.tag_name().name() == "max"))
-        .and_then(|n| attr(&n, "val"))
-        .and_then(|v| v.parse::<f64>().ok());
-    let val_min = val_ax
-        .and_then(|ax| ax.descendants().find(|n| n.is_element() && n.tag_name().name() == "min"))
-        .and_then(|n| attr(&n, "val"))
-        .and_then(|v| v.parse::<f64>().ok());
-
-    // Axis visibility: <c:catAx>/<c:valAx><c:delete val="1"/> hides the entire axis
-    let axis_hidden = |ax_name: &str| -> bool {
-        root.descendants()
-            .filter(|n| n.is_element() && n.tag_name().name() == ax_name)
-            .any(|ax| ax.children().any(|c|
-                c.is_element() && c.tag_name().name() == "delete"
-                    && attr(&c, "val").as_deref() == Some("1")))
-    };
-    let cat_axis_hidden = axis_hidden("catAx");
-    let val_axis_hidden = axis_hidden("valAx");
+    let cat_ax = root.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "catAx");
+    let (val_min, val_max) = val_ax
+        .map(ooxml_common::chart::extract_axis_min_max)
+        .unwrap_or((None, None));
+    let val_axis_hidden = val_ax.map(ooxml_common::chart::axis_is_deleted).unwrap_or(false);
+    let cat_axis_hidden = cat_ax.map(ooxml_common::chart::axis_is_deleted).unwrap_or(false);
 
     // Series
     let plot_area = root.descendants()
@@ -2669,16 +2659,8 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
         .and_then(|sp| sp.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
         .and_then(|fill| parse_color_node(fill, theme));
 
-    // <c:legend> determines whether the legend is shown; <c:legendPos val>
-    // (ECMA-376 §21.2.2.10) picks the side ("r" default | "l" | "t" | "b" | "tr").
-    let legend_node = root.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "legend");
-    let show_legend = legend_node.is_some();
-    let legend_pos = legend_node.and_then(|ln| {
-        ln.children()
-            .find(|n| n.is_element() && n.tag_name().name() == "legendPos")
-            .and_then(|p| attr(&p, "val"))
-    });
+    // <c:legend> + <c:legendPos val> — shared helper.
+    let (show_legend, legend_pos) = ooxml_common::chart::extract_legend(root);
 
     // ECMA-376 §21.2.2.35: `<c:crossBetween>` lives on the VALUE axis (not cat),
     // and describes whether value gridlines land between or on category ticks.
@@ -2689,102 +2671,47 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
         .and_then(|n| attr(&n, "val"))
         .unwrap_or_else(|| "between".to_string());
 
-    let read_major_tick_mark = |ax_name: &str| -> String {
-        root.descendants()
-            .find(|n| n.is_element() && n.tag_name().name() == ax_name)
-            .and_then(|ax| ax.children().find(|n| n.is_element() && n.tag_name().name() == "majorTickMark"))
-            .and_then(|n| attr(&n, "val"))
-            // ECMA-376 default for majorTickMark is "cross".
+    // Major tick marks (ECMA-376 §21.2.2.49 ST_TickMark, default "cross").
+    let read_major_tick_mark = |ax: Option<roxmltree::Node>| -> String {
+        ax.and_then(|n| ooxml_common::chart::extract_axis_tick_mark(n, "majorTickMark"))
             .unwrap_or_else(|| "cross".to_string())
     };
-    let val_axis_major_tick_mark = read_major_tick_mark("valAx");
-    let cat_axis_major_tick_mark = read_major_tick_mark("catAx");
+    let val_axis_major_tick_mark = read_major_tick_mark(val_ax);
+    let cat_axis_major_tick_mark = read_major_tick_mark(cat_ax);
 
-    // <c:catAx>/<c:valAx><c:txPr> → defRPr/rPr@sz gives axis label font size
-    // in OOXML hundredths of a point. This drives both font rendering and
-    // the bottom/left padding so the plot area shrinks to leave room.
-    let read_axis_font_hpt = |ax_name: &str| -> Option<i32> {
-        root.descendants()
-            .find(|n| n.is_element() && n.tag_name().name() == ax_name)
-            .and_then(|ax| ax.children().find(|n| n.is_element() && n.tag_name().name() == "txPr"))
-            .and_then(|tx| tx.descendants().find_map(|n| {
-                if !n.is_element() { return None; }
-                let tag = n.tag_name().name();
-                if tag != "defRPr" && tag != "rPr" { return None; }
-                attr(&n, "sz").and_then(|v| v.parse::<i32>().ok())
-            }))
-    };
-    let cat_axis_font_size_hpt = read_axis_font_hpt("catAx");
-    let val_axis_font_size_hpt = read_axis_font_hpt("valAx");
+    // Axis tick-label font size from `<c:txPr>` (in OOXML hundredths of a point).
+    let cat_axis_font_size_hpt = cat_ax.and_then(ooxml_common::chart::extract_axis_tick_label_size);
+    let val_axis_font_size_hpt = val_ax.and_then(ooxml_common::chart::extract_axis_tick_label_size);
 
-    // First <c:dLbls> we can find — per-series or plotArea-level. Drill down
-    // to the defRPr@sz the same way we do for axes.
-    let data_label_font_size_hpt = root.descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
-        .find_map(|dl| {
-            dl.children()
-                .find(|n| n.is_element() && n.tag_name().name() == "txPr")
-                .and_then(|tx| tx.descendants().find_map(|n| {
-                    if !n.is_element() { return None; }
-                    let tag = n.tag_name().name();
-                    if tag != "defRPr" && tag != "rPr" { return None; }
-                    attr(&n, "sz").and_then(|v| v.parse::<i32>().ok())
-                }))
-        });
+    // Data-label font size — first `<c:dLbls><c:txPr>` defRPr/rPr@sz we find.
+    let data_label_font_size_hpt = ooxml_common::chart::extract_data_label_font_size(root);
 
-    // ECMA-376 §21.2.2.13 / §21.2.2.25 — `<c:gapWidth val>` and `<c:overlap val>`
-    // are siblings of `<c:ser>` inside the bar/area chart-type wrapper. Default
-    // gapWidth=150 (per spec). overlap default 0; +100 = stacked.
-    let bar_gap_width = root.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "gapWidth")
-        .and_then(|n| attr(&n, "val"))
-        .and_then(|v| v.parse::<i32>().ok());
-    let bar_overlap = root.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "overlap")
-        .and_then(|n| attr(&n, "val"))
-        .and_then(|v| v.parse::<i32>().ok());
+    // Bar gap / overlap, dLblPos and numFmt — all shared helpers so any new
+    // chart property added to the xlsx side stays applied to pptx without
+    // a manual port (the slide-7 / sample-2 issue this PR avoids).
+    let (bar_gap_width, bar_overlap) = ooxml_common::chart::extract_bar_gap_overlap(root);
+    let data_label_position = ooxml_common::chart::extract_data_label_position(root);
+    let data_label_format_code = ooxml_common::chart::extract_data_label_format_code(root);
 
-    // Walk every `<c:dLbls>` (chart-level + per-series) and pick the first
-    // dLblPos / numFmt / fill that we find. ECMA-376 §21.2.2.49: dLblPos values
-    // include "ctr" | "inEnd" | "outEnd" | "inBase" | "l" | "r" | "t" | "b".
-    let mut data_label_position: Option<String> = None;
-    let mut data_label_format_code: Option<String> = None;
+    // Data-label font color still needs theme-aware color resolution, which
+    // pptx does via parse_color_node + a HashMap theme map. Keep that part
+    // local until ooxml-common gains a generic ColorResolver.
     let mut data_label_font_color: Option<String> = None;
     for dlbls in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "dLbls") {
-        for child in dlbls.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
-                "dLblPos" => {
-                    if data_label_position.is_none() {
-                        data_label_position = attr(&child, "val");
-                    }
+        if let Some(txpr) = dlbls.children().find(|n| n.is_element() && n.tag_name().name() == "txPr") {
+            for desc in txpr.descendants().filter(|n| n.is_element()) {
+                if desc.tag_name().name() != "solidFill" { continue; }
+                if let Some(c) = parse_color_node(desc, theme) {
+                    data_label_font_color = Some(c);
+                    break;
                 }
-                "numFmt" => {
-                    if data_label_format_code.is_none() {
-                        data_label_format_code = attr(&child, "formatCode")
-                            .filter(|s| !s.is_empty() && s != "General");
-                    }
-                }
-                "txPr" => {
-                    if data_label_font_color.is_none() {
-                        for desc in child.descendants().filter(|n| n.is_element()) {
-                            if desc.tag_name().name() != "solidFill" { continue; }
-                            if let Some(c) = parse_color_node(desc, theme) {
-                                data_label_font_color = Some(c);
-                                break;
-                            }
-                        }
-                    }
-                }
-                _ => {}
             }
+            if data_label_font_color.is_some() { break; }
         }
     }
 
     // `<c:valAx><c:numFmt formatCode>` — value-axis tick label number format.
-    let val_axis_format_code = val_ax
-        .and_then(|ax| ax.children().find(|n| n.is_element() && n.tag_name().name() == "numFmt"))
-        .and_then(|n| attr(&n, "formatCode"))
-        .filter(|s| !s.is_empty() && s != "General");
+    let val_axis_format_code = val_ax.and_then(ooxml_common::chart::extract_axis_format_code);
 
     Some(ChartElement {
         x: 0, y: 0, width: 0, height: 0,
@@ -2890,19 +2817,10 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         data_point_colors: None,
     }];
 
-    // ChartEx axis visibility — `<cx:axis hidden="1">`. Each axis carries either
-    // `<cx:catScaling>` or `<cx:valScaling>` so we can disambiguate even when
-    // the spec doesn't declare `id` semantics. Default visible.
-    let mut cat_axis_hidden = false;
-    let mut val_axis_hidden = false;
-    for ax in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "axis") {
-        let hidden = attr(&ax, "hidden").as_deref() == Some("1");
-        if !hidden { continue; }
-        let is_val = ax.children().any(|c| c.is_element() && c.tag_name().name() == "valScaling");
-        let is_cat = ax.children().any(|c| c.is_element() && c.tag_name().name() == "catScaling");
-        if is_val { val_axis_hidden = true; }
-        if is_cat { cat_axis_hidden = true; }
-    }
+    // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`
+    // with its `<cx:catScaling>` / `<cx:valScaling>` child to disambiguate cat
+    // vs. val (chartEx doesn't declare axis kind via the `id` attribute).
+    let (cat_axis_hidden, val_axis_hidden) = ooxml_common::chart::extract_chartex_axis_hidden(root);
 
     Some(ChartElement {
         x: 0, y: 0, width: 0, height: 0,

--- a/packages/xlsx/parser/Cargo.toml
+++ b/packages/xlsx/parser/Cargo.toml
@@ -14,6 +14,7 @@ zip = { workspace = true }
 roxmltree = { workspace = true }
 base64 = { workspace = true }
 console_error_panic_hook = { workspace = true }
+ooxml-common = { workspace = true }
 
 [profile.release]
 opt-level = "s"

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -3758,16 +3758,12 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
 
     // Legend presence: <c:chart><c:legend> is the authoritative signal. Absence
     // means Excel hides the legend (default for a single-series chart with no
-    // explicit legend element). When present, `<c:legendPos val>` picks a side
-    // ("r"|"l"|"t"|"b"|"tr") — default "r" per ECMA-376 §21.2.2.10.
+    // explicit legend element). `<c:legendPos val>` picks a side per
+    // ECMA-376 §21.2.2.10 — both parts come from the shared ooxml-common helper
+    // so pptx & xlsx stay in lockstep.
+    let (show_legend, legend_pos) = ooxml_common::chart::extract_legend(chart_root);
     let legend_node = chart_root.children()
         .find(|n| n.tag_name().name() == "legend" && n.tag_name().namespace() == Some(c_ns));
-    let show_legend = legend_node.is_some();
-    let legend_pos = legend_node.and_then(|ln| {
-        ln.children()
-            .find(|n| n.tag_name().name() == "legendPos" && n.tag_name().namespace() == Some(c_ns))
-            .and_then(|p| p.attribute("val").map(|s| s.to_string()))
-    });
     // Legend <c:layout><c:manualLayout> (ECMA-376 §21.2.2.31) — when present,
     // gives explicit x/y/w/h fractions of the chart space. Used by the Excel
     // templates that position a top legend into a narrow band, e.g. over the
@@ -4222,21 +4218,17 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
     })
 }
 
-/// `<c:catAx|valAx><c:numFmt@formatCode>` (ECMA-376 §21.2.2.21).
-fn extract_axis_format_code(axis_node: &roxmltree::Node, c_ns: &str) -> Option<String> {
-    axis_node.children()
-        .find(|n| n.tag_name().name() == "numFmt" && n.tag_name().namespace() == Some(c_ns))
-        .and_then(|n| n.attribute("formatCode").map(|s| s.to_string()))
-        .filter(|s| !s.is_empty() && s != "General")
+/// `<c:catAx|valAx><c:numFmt@formatCode>` (ECMA-376 §21.2.2.21). Thin
+/// wrapper around `ooxml_common::chart::extract_axis_format_code` so the
+/// pptx and xlsx parsers stay in lockstep on the format-code rules.
+fn extract_axis_format_code(axis_node: &roxmltree::Node, _c_ns: &str) -> Option<String> {
+    ooxml_common::chart::extract_axis_format_code(*axis_node)
 }
 
 /// `<c:catAx|valAx><c:majorTickMark val>` / `<c:minorTickMark val>` —
 /// `none` / `out` / `in` / `cross` (ECMA-376 §21.2.2.49 ST_TickMark).
-fn extract_axis_tick_mark(axis_node: &roxmltree::Node, c_ns: &str, name: &str) -> Option<String> {
-    axis_node.children()
-        .find(|n| n.tag_name().name() == name && n.tag_name().namespace() == Some(c_ns))
-        .and_then(|n| n.attribute("val"))
-        .map(|s| s.to_string())
+fn extract_axis_tick_mark(axis_node: &roxmltree::Node, _c_ns: &str, name: &str) -> Option<String> {
+    ooxml_common::chart::extract_axis_tick_mark(*axis_node, name)
 }
 
 /// `<c:catAx|valAx><c:spPr><a:ln>` — resolved color (no `#`) and width
@@ -4285,31 +4277,17 @@ fn extract_axis_crosses(axis_node: &roxmltree::Node, c_ns: &str) -> (Option<Stri
 
 /// Read explicit `<c:scaling><c:min>` / `<c:scaling><c:max>` values, returning
 /// `(min, max)` where each is `None` if the axis didn't override that bound.
-fn extract_axis_scaling(axis_node: &roxmltree::Node, c_ns: &str) -> Option<(Option<f64>, Option<f64>)> {
-    let scaling = axis_node.children()
-        .find(|n| n.tag_name().name() == "scaling" && n.tag_name().namespace() == Some(c_ns))?;
-    let mn = scaling.children()
-        .find(|n| n.tag_name().name() == "min" && n.tag_name().namespace() == Some(c_ns))
-        .and_then(|n| n.attribute("val"))
-        .and_then(|v| v.parse::<f64>().ok());
-    let mx = scaling.children()
-        .find(|n| n.tag_name().name() == "max" && n.tag_name().namespace() == Some(c_ns))
-        .and_then(|n| n.attribute("val"))
-        .and_then(|v| v.parse::<f64>().ok());
-    if mn.is_some() || mx.is_some() {
-        Some((mn, mx))
-    } else {
-        None
-    }
+/// Returns `None` only when neither bound is set (matches the prior xlsx
+/// callsite shape `if let Some((mn, mx)) = …`).
+fn extract_axis_scaling(axis_node: &roxmltree::Node, _c_ns: &str) -> Option<(Option<f64>, Option<f64>)> {
+    let (mn, mx) = ooxml_common::chart::extract_axis_min_max(*axis_node);
+    if mn.is_some() || mx.is_some() { Some((mn, mx)) } else { None }
 }
 
-/// `<c:catAx|valAx><c:delete val="1"/>` — true when the axis is hidden.
-fn axis_is_deleted(axis_node: &roxmltree::Node, c_ns: &str) -> bool {
-    axis_node.children()
-        .find(|n| n.tag_name().name() == "delete" && n.tag_name().namespace() == Some(c_ns))
-        .and_then(|n| n.attribute("val"))
-        .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-        .unwrap_or(false)
+/// `<c:catAx|valAx><c:delete val="1"/>` — true when the axis is hidden
+/// (ECMA-376 §21.2.2.40). Thin wrapper around the shared helper.
+fn axis_is_deleted(axis_node: &roxmltree::Node, _c_ns: &str) -> bool {
+    ooxml_common::chart::axis_is_deleted(*axis_node)
 }
 
 /// Extract a `<c:layout><c:manualLayout>` block. The given `layout_node` is
@@ -4344,16 +4322,8 @@ fn extract_manual_layout(layout_node: &roxmltree::Node, c_ns: &str) -> Option<Ma
 /// Extract a category/value axis tick-label font size (hundredths of a point)
 /// from the first `a:defRPr@sz` (or `a:rPr@sz`) inside the axis' `c:txPr`.
 /// ECMA-376 §21.2.2.17 — `<c:txPr>` controls tick label text properties.
-fn extract_axis_tick_label_size(axis_node: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<i32> {
-    let txpr = axis_node.children()
-        .find(|n| n.tag_name().name() == "txPr" && n.tag_name().namespace() == Some(c_ns))?;
-    txpr.descendants().find_map(|n| {
-        if !n.is_element() { return None; }
-        if n.tag_name().namespace() != Some(a_ns) { return None; }
-        let tag = n.tag_name().name();
-        if tag != "defRPr" && tag != "rPr" { return None; }
-        n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
-    })
+fn extract_axis_tick_label_size(axis_node: &roxmltree::Node, _c_ns: &str, _a_ns: &str) -> Option<i32> {
+    ooxml_common::chart::extract_axis_tick_label_size(*axis_node)
 }
 
 /// Extract the chart title's font size (hundredths of a point) from the first


### PR DESCRIPTION
## Summary
Follow-up to [#238](https://github.com/yukiyokotani/office-open-xml-viewer/pull/238). The pptx and xlsx Rust parsers were re-implementing the same chart-XML probes (legend / bar gap / dLblPos / axis delete & scaling / chartEx hidden), and the cost showed up in #238 as missing fields on the pptx side that xlsx already had. This PR moves those helpers into `packages/ooxml-common/src/chart.rs` and rewires both parsers to call them.

## What's in `ooxml_common::chart`
Each backed by a unit test in `chart::tests` (11 tests, all passing):

- `extract_legend(root) -> (show, legendPos)` — §21.2.2.10
- `extract_bar_gap_overlap(root) -> (gap%, overlap%)` — §21.2.2.13 / §21.2.2.25
- `extract_data_label_position(root)`, `extract_data_label_format_code(root)`, `extract_data_label_font_size(root)`
- `extract_axis_format_code(axis_node)` — §21.2.2.21
- `extract_axis_min_max(axis_node)` reading `<c:scaling>`
- `axis_is_deleted(axis_node)` — §21.2.2.40, accepts `1` / `true` / `0` / `false`
- `extract_axis_tick_mark(axis_node, name)` — §21.2.2.49
- `extract_axis_tick_label_size(axis_node)` walking `<c:txPr>` for the first `defRPr/rPr@sz`
- `extract_chartex_axis_hidden(root) -> (cat_hidden, val_hidden)` pairing each `<cx:axis hidden="1">` with its `<cx:catScaling>` / `<cx:valScaling>` child

## Migration shape
- pptx `parse_legacy_chart` / `parse_chartex` now call into the shared helpers; ~100 lines of duplication removed.
- xlsx's existing `extract_axis_format_code` / `axis_is_deleted` / `extract_axis_scaling` / `extract_axis_tick_mark` / `extract_axis_tick_label_size` are now thin wrappers around `ooxml_common::chart::*`. The wrappers retain their `c_ns` / `a_ns` arguments so the (many) call sites stay unchanged in this PR — they can be inlined further later.
- Data-label font color extraction stays per-crate. It needs theme-aware color resolution and pptx (`HashMap<String, String>`) and xlsx (`&[String]`) disagree on the theme map shape. A future PR can introduce a `ColorResolver` trait to merge that last piece.

## Namespace handling
Shared helpers match by local name only (no namespace check). xlsx had been doing the strict `tag_name().namespace() == Some(c_ns)` check, but real chart XML never wedges non-`c:` elements at these positions, so dropping it doesn't change behavior — verified by xlsx demo `Carbon & Growth` rendering unchanged.

## Test plan
- [x] `cargo test -p ooxml-common` → 11 / 11 pass
- [x] `cargo check` clean for `pptx-parser` and `xlsx-parser`
- [x] `pnpm build:wasm`
- [x] Visual: pptx sample-2 slide-7 (stacked bar w/ top legend, white in-bar data labels, YoY callout one line, gray bullet box) — identical to #238
- [x] Visual: pptx sample-2 slide-8 (chartEx waterfall with hidden value axis + connector callouts) — identical to #238
- [x] Visual: xlsx demo `Carbon & Growth` chart — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)