### PR TITLE
refactor(parsers): share data-label font-color extraction via ColorResolver

### DIFF
--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -36,6 +36,27 @@ fn child<'a, 'i>(parent: Node<'a, 'i>, name: &str) -> Option<Node<'a, 'i>> {
     parent.children().find(|n| n.is_element() && n.tag_name().name() == name)
 }
 
+/// Theme-aware color resolution for chart text-color helpers.
+///
+/// pptx and xlsx store their theme palettes in different shapes
+/// (`HashMap<String, String>` vs. `&[String]`) and apply DrawingML
+/// transforms with different `tint` formulas (Word-literal vs. linear
+/// sRGB lerp), so each crate keeps its own resolver. The shared chart
+/// helpers take a `&dyn ColorResolver` instead of either concrete type so
+/// fields like `<c:dLbls><c:txPr>...<a:solidFill>` can be extracted once.
+pub trait ColorResolver {
+    /// Resolve an `<a:solidFill>` node to a hex string (no leading `#`),
+    /// or `None` when the contained color child can't be mapped to a
+    /// concrete RGB value (for example a `<a:schemeClr val="phClr"/>`
+    /// that the implementation chooses not to substitute).
+    ///
+    /// The node passed in is the `<a:solidFill>` element itself; the
+    /// implementation reads its direct children for the actual color
+    /// (`<a:srgbClr>` / `<a:schemeClr>` / `<a:sysClr>` / `<a:prstClr>`)
+    /// and applies the surrounding lumMod/lumOff/tint/shade transforms.
+    fn resolve_solid_fill(&self, node: Node) -> Option<String>;
+}
+
 /// `<c:legend>` presence + `<c:legendPos val>` (ECMA-376 §21.2.2.10).
 ///
 /// `(show_legend, legend_pos)`. When the chart omits `<c:legend>` Office
@@ -162,6 +183,32 @@ pub fn extract_data_label_font_size(root: Node) -> Option<i32> {
         })
 }
 
+/// First `<c:dLbls><c:txPr>...<a:solidFill>` resolved to a hex color.
+///
+/// Walks each `<c:dLbls>` (chart-level + per-series) in document order,
+/// drills into its `<c:txPr>` and looks for the first descendant
+/// `<a:solidFill>` whose color the resolver can map. Stops on the first
+/// successful resolution — this matches the chart-then-series fallback
+/// pattern Office writers actually emit (e.g. a top-level `<c:dLbls>`
+/// declaring the label color globally and the `<c:ser><c:dLbls>` blocks
+/// inheriting it).
+///
+/// Note we deliberately scope the search to inside `<c:txPr>` so a
+/// sibling `<c:dLbls><c:spPr><a:solidFill>` (the label *background*
+/// fill, distinct from the text color) can't shadow the answer.
+pub fn extract_data_label_font_color(root: Node, resolver: &dyn ColorResolver) -> Option<String> {
+    for dlbls in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "dLbls") {
+        let Some(txpr) = child(dlbls, "txPr") else { continue; };
+        for desc in txpr.descendants().filter(|n| n.is_element()) {
+            if desc.tag_name().name() != "solidFill" { continue; }
+            if let Some(c) = resolver.resolve_solid_fill(desc) {
+                return Some(c);
+            }
+        }
+    }
+    None
+}
+
 /// chartEx (`<cx:chartSpace>`) axis visibility. ChartEx encodes the
 /// scale type via a `<cx:catScaling>` / `<cx:valScaling>` child rather
 /// than separate `<c:catAx>` / `<c:valAx>` elements, so callers can't just
@@ -282,6 +329,73 @@ mod tests {
         </c:valAx>"#;
         let d = root_of(xml);
         assert_eq!(extract_axis_format_code(d.root_element()).as_deref(), Some("0.0%"));
+    }
+
+    /// Test resolver: returns the schemeClr@val verbatim, or the srgbClr@val
+    /// uppercased. Just enough to drive `extract_data_label_font_color`.
+    struct StubResolver;
+    impl ColorResolver for StubResolver {
+        fn resolve_solid_fill(&self, node: Node) -> Option<String> {
+            for c in node.children().filter(|n| n.is_element()) {
+                match c.tag_name().name() {
+                    "srgbClr" => return c.attribute("val").map(|v| v.to_uppercase()),
+                    "schemeClr" => return c.attribute("val").map(|v| v.to_string()),
+                    _ => {}
+                }
+            }
+            None
+        }
+    }
+
+    #[test]
+    fn data_label_font_color_resolves_via_resolver() {
+        let xml = r#"<c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <c:plotArea>
+                <c:dLbls>
+                    <c:txPr><a:p><a:r><a:rPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:rPr></a:r></a:p></c:txPr>
+                </c:dLbls>
+            </c:plotArea>
+        </c:chart>"#;
+        let d = root_of(xml);
+        let got = extract_data_label_font_color(d.root_element(), &StubResolver);
+        assert_eq!(got.as_deref(), Some("bg1"));
+    }
+
+    #[test]
+    fn data_label_font_color_skips_label_background_fill() {
+        // `<c:spPr><a:solidFill>` (label background) must not be picked up;
+        // only the text fill inside `<c:txPr>` counts.
+        let xml = r#"<c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <c:plotArea>
+                <c:dLbls>
+                    <c:spPr><a:solidFill><a:srgbClr val="aabbcc"/></a:solidFill></c:spPr>
+                </c:dLbls>
+            </c:plotArea>
+        </c:chart>"#;
+        let d = root_of(xml);
+        let got = extract_data_label_font_color(d.root_element(), &StubResolver);
+        assert!(got.is_none(), "spPr fill must not leak into the font color: got {got:?}");
+    }
+
+    #[test]
+    fn data_label_font_color_first_dlbls_wins() {
+        // Mimics Office writers that put a chart-level dLbls block AND
+        // per-series ones — the first txPr resolution wins.
+        let xml = r#"<c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <c:plotArea>
+                <c:dLbls>
+                    <c:txPr><a:p><a:r><a:rPr><a:solidFill><a:srgbClr val="ffffff"/></a:solidFill></a:rPr></a:r></a:p></c:txPr>
+                </c:dLbls>
+                <c:barChart>
+                    <c:ser><c:dLbls>
+                        <c:txPr><a:p><a:r><a:rPr><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:rPr></a:r></a:p></c:txPr>
+                    </c:dLbls></c:ser>
+                </c:barChart>
+            </c:plotArea>
+        </c:chart>"#;
+        let d = root_of(xml);
+        let got = extract_data_label_font_color(d.root_element(), &StubResolver);
+        assert_eq!(got.as_deref(), Some("FFFFFF"));
     }
 
     #[test]

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -961,6 +961,20 @@ fn resolve_theme_typeface(typeface: &str, theme: &HashMap<String, String>) -> St
     typeface.to_string()
 }
 
+/// `ooxml_common::chart::ColorResolver` implementation backed by pptx's
+/// `HashMap<String, String>` theme palette and PowerPoint's tint formula.
+/// Used by chart helpers in ooxml-common that need to resolve
+/// `<a:solidFill>` text colors without owning the theme storage.
+struct PptxColorResolver<'a> {
+    theme: &'a HashMap<String, String>,
+}
+
+impl ooxml_common::chart::ColorResolver for PptxColorResolver<'_> {
+    fn resolve_solid_fill(&self, node: roxmltree::Node<'_, '_>) -> Option<String> {
+        parse_color_node(node, self.theme)
+    }
+}
+
 /// Resolve a color node (solidFill child / run rPr child) to a hex string.
 /// Handles srgbClr, sysClr, prstClr, and schemeClr (with transform support).
 fn parse_color_node(
@@ -2693,22 +2707,12 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     let data_label_position = ooxml_common::chart::extract_data_label_position(root);
     let data_label_format_code = ooxml_common::chart::extract_data_label_format_code(root);
 
-    // Data-label font color still needs theme-aware color resolution, which
-    // pptx does via parse_color_node + a HashMap theme map. Keep that part
-    // local until ooxml-common gains a generic ColorResolver.
-    let mut data_label_font_color: Option<String> = None;
-    for dlbls in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "dLbls") {
-        if let Some(txpr) = dlbls.children().find(|n| n.is_element() && n.tag_name().name() == "txPr") {
-            for desc in txpr.descendants().filter(|n| n.is_element()) {
-                if desc.tag_name().name() != "solidFill" { continue; }
-                if let Some(c) = parse_color_node(desc, theme) {
-                    data_label_font_color = Some(c);
-                    break;
-                }
-            }
-            if data_label_font_color.is_some() { break; }
-        }
-    }
+    // Data-label font color uses the shared helper too — pptx supplies a
+    // ColorResolver wrapper around `parse_color_node` so the
+    // ECMA-376 §21.2.2.16 dLbls > txPr > solidFill walk lives in one place.
+    let resolver = PptxColorResolver { theme };
+    let data_label_font_color =
+        ooxml_common::chart::extract_data_label_font_color(root, &resolver);
 
     // `<c:valAx><c:numFmt formatCode>` — value-axis tick label number format.
     let val_axis_format_code = val_ax.and_then(ooxml_common::chart::extract_axis_format_code);

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -3871,8 +3871,14 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
     let mut bar_gap_width: Option<i32> = None;
     let mut bar_overlap: Option<i32> = None;
     let mut data_label_position: Option<String> = None;
-    let mut data_label_font_color: Option<String> = None;
     let mut data_label_format_code: Option<String> = None;
+    // Data-label text color is theme-aware, so we hoist the extraction to a
+    // shared helper backed by an `XlsxColorResolver`. It walks chart-level
+    // and per-series `<c:dLbls><c:txPr>...<a:solidFill>` in document order
+    // and returns the first one it can resolve.
+    let xlsx_resolver = XlsxColorResolver { theme_colors };
+    let data_label_font_color =
+        ooxml_common::chart::extract_data_label_font_color(chart_root, &xlsx_resolver);
 
     // Recognised chart-type element names → our internal type strings
     let type_map: &[(&str, &str)] = &[
@@ -4065,22 +4071,8 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                                         .filter(|s| !s.is_empty() && s != "General");
                                 }
                             }
-                            "txPr" => {
-                                // Resolve first solidFill under defRPr/rPr for
-                                // the data label text color. Common Excel
-                                // pattern: <a:solidFill><a:schemeClr val="bg1"/>
-                                // → white when bars are dark.
-                                if data_label_font_color.is_none() {
-                                    for desc in d.descendants().filter(|n| n.is_element()) {
-                                        if desc.tag_name().namespace() != Some(a_ns) { continue; }
-                                        if desc.tag_name().name() != "solidFill" { continue; }
-                                        if let Some(c) = resolve_fill_color(&desc, theme_colors) {
-                                            data_label_font_color = Some(c);
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
+                            // txPr (data-label text color) is now resolved
+                            // up front via ooxml_common::chart::extract_data_label_font_color.
                             _ => {}
                         }
                     }
@@ -4132,18 +4124,8 @@ fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -
                                     .filter(|s| !s.is_empty() && s != "General");
                             }
                         }
-                        "txPr" => {
-                            if data_label_font_color.is_none() {
-                                for desc in d.descendants().filter(|n| n.is_element()) {
-                                    if desc.tag_name().namespace() != Some(a_ns) { continue; }
-                                    if desc.tag_name().name() != "solidFill" { continue; }
-                                    if let Some(c) = resolve_fill_color(&desc, theme_colors) {
-                                        data_label_font_color = Some(c);
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+                        // txPr (data-label text color) handled by the
+                        // shared helper before this loop runs.
                         _ => {}
                     }
                 }
@@ -4414,6 +4396,20 @@ fn extract_chart_title(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> 
 /// Theme colors use drawingML names (`accent1`..`accent6`, `dk1`/`dk2`/`lt1`/`lt2`)
 /// which map to the parser's natural-order theme array (dk1@0, lt1@1, dk2@2,
 /// lt2@3, accent1@4 … accent6@9).
+/// `ooxml_common::chart::ColorResolver` implementation backed by xlsx's
+/// indexed `theme_colors` slice. Drives the chart helpers in ooxml-common
+/// that need theme-aware color resolution (e.g. data-label text color)
+/// without leaking the slice shape into the shared crate.
+struct XlsxColorResolver<'a> {
+    theme_colors: &'a [String],
+}
+
+impl ooxml_common::chart::ColorResolver for XlsxColorResolver<'_> {
+    fn resolve_solid_fill(&self, node: roxmltree::Node<'_, '_>) -> Option<String> {
+        resolve_fill_color(&node, self.theme_colors)
+    }
+}
+
 fn resolve_fill_color(fill_node: &roxmltree::Node, theme_colors: &[String]) -> Option<String> {
     // Accept either a `<a:solidFill>` directly or a `<c:spPr>` whose first
     // fill-ish child is `<a:solidFill>`. Looking at *direct* children (not


### PR DESCRIPTION
## Summary
Final piece of the chart-parser consolidation started in [#239](https://github.com/yukiyokotani/office-open-xml-viewer/pull/239). The data-label font-color walk (`<c:dLbls><c:txPr>...<a:solidFill>`) was the last bit of duplicated chart logic between pptx and xlsx — same DOM traversal, but different theme palette shapes (`HashMap<String, String>` vs. `&[String]`) and different DrawingML tint semantics (PowerPoint-linear vs. Word-literal) made it un-mergeable until now.

## What's new
- `ooxml_common::chart::ColorResolver` trait — single method, `solidFill node → Option<hex>`.
- `extract_data_label_font_color(root, &resolver)` helper that walks every `<c:dLbls>` in document order, restricts to `<c:txPr>` (so the label *background* `<c:spPr><a:solidFill>` can't shadow it), and asks the resolver for the first resolvable color.
- 3 new unit tests covering the resolver contract: txPr resolution, label-background-fill exclusion, chart-then-series first-wins ordering. Total now 14 / 14 passing.

## Migration
- pptx: `PptxColorResolver { theme: &HashMap<String, String> }` wraps `parse_color_node`. The 13-line walk becomes a single call.
- xlsx: `XlsxColorResolver { theme_colors: &[String] }` wraps `resolve_fill_color`. The extraction is hoisted out of the per-chart-type-element loop (where it was duplicated for chart-level vs. per-series dLbls) so there's exactly one resolution pass per chart.

## Test plan
- [x] `cargo test -p ooxml-common` → 14 / 14 pass
- [x] `cargo check` clean for `pptx-parser`, `xlsx-parser`
- [x] `pnpm build:wasm`
- [x] Visual: pptx sample-2 slide-7 still renders white in-bar data labels (the `bg1` schemeClr that originally motivated #238)
- [x] Visual: xlsx demo `Carbon & Growth` chart unchanged

This closes the follow-up noted in #239 — chart parsing now lives in a single place across the pptx and xlsx Rust parsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)