### PR TITLE
feat(pptx): bodyPr numCol multi-column + spAutoFit no-wrap + waterfall axis anchor

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1881,8 +1881,12 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
   const rawMin = Math.min(...allStarts, 0);
   const dataRange = rawMax - rawMin;
   if (dataRange <= 0) return;
-  const padded = dataRange * 1.1;
-  const dataMin = rawMin - dataRange * 0.05;
+  // PowerPoint anchors waterfall bars to value=0 when all data is non-negative
+  // (the x-axis sits flush against the bar bases). Adding a 5% pad below 0
+  // would lift the bars off the axis. Only pad when there are actual negatives
+  // to display below zero.
+  const dataMin = rawMin < 0 ? rawMin - dataRange * 0.05 : 0;
+  const padded = (rawMax - dataMin) * 1.1;
   const dataMax = dataMin + padded;
 
   const step = niceStep(padded);

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -138,6 +138,14 @@ export interface TextBody {
   vert: string;
   /** Auto-fit: "sp" = shape grows to fit text, "norm" = font shrinks, "none" = no fit */
   autoFit: string;
+  /**
+   * `<a:bodyPr numCol>` (ECMA-376 §20.1.10.34) — number of text columns inside
+   * the shape. Defaults to 1; values > 1 cause the renderer to flow paragraphs
+   * across N columns left-to-right, top-to-bottom.
+   */
+  numCol?: number;
+  /** `<a:bodyPr spcCol>` — gap between columns in EMU. Default 0. */
+  spcCol?: number;
 }
 
 export type SpaceLine =

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -543,7 +543,22 @@ struct TextBody {
     vert: String,
     /// Auto-fit mode from bodyPr: "sp" = spAutoFit (shape grows), "norm" = normAutoFit (font shrinks), "none" = noAutofit
     auto_fit: String,
+    /// `<a:bodyPr numCol>` (ECMA-376 §20.1.10.34 / §21.1.2.1.1) — number of
+    /// text columns inside the shape. Default 1. PowerPoint distributes
+    /// paragraphs across columns left-to-right, top-to-bottom.
+    #[serde(skip_serializing_if = "is_one")]
+    #[serde(default = "one_u32")]
+    num_col: u32,
+    /// `<a:bodyPr spcCol>` — gap between columns in EMU. Default 0.
+    /// Only meaningful when `num_col > 1`.
+    #[serde(skip_serializing_if = "is_zero_i64")]
+    #[serde(default)]
+    spc_col: i64,
 }
+
+fn one_u32() -> u32 { 1 }
+fn is_one(n: &u32) -> bool { *n == 1 }
+fn is_zero_i64(n: &i64) -> bool { *n == 0 }
 
 /// Line spacing specification
 #[derive(Serialize, Deserialize, Debug)]
@@ -2142,6 +2157,17 @@ fn parse_text_body(
         else if child(n, "normAutofit").is_some() { "norm".to_owned() }
         else { "none".to_owned() }
     }).unwrap_or_else(|| "none".to_owned());
+    // ECMA-376 §20.1.10.34: numCol on <a:bodyPr> tells the renderer to
+    // distribute paragraphs across N columns within the shape. Default 1.
+    // spcCol is the inter-column gutter in EMU (default 0).
+    let num_col = body_pr
+        .and_then(|n| attr(&n, "numCol"))
+        .and_then(|v| v.parse::<u32>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(1);
+    let spc_col = body_pr
+        .and_then(|n| attr_i64(&n, "spcCol"))
+        .unwrap_or(0);
 
     // Own lstStyle > lvl1pPr, then fall back to layout/master inherited values
     let own_lvl1_ppr = child(tx_body, "lstStyle")
@@ -2186,7 +2212,7 @@ fn parse_text_body(
         .map(|p| parse_paragraph(p, theme, rels, body_default_alignment.as_deref(), body_default_space_before, body_default_space_after, body_default_line_spacing))
         .collect();
 
-    TextBody { vertical_anchor, paragraphs, default_font_size, default_bold, default_italic, l_ins, r_ins, t_ins, b_ins, wrap, vert, auto_fit }
+    TextBody { vertical_anchor, paragraphs, default_font_size, default_bold, default_italic, l_ins, r_ins, t_ins, b_ins, wrap, vert, auto_fit, num_col, spc_col }
 }
 
 fn parse_paragraph(

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -873,7 +873,16 @@ function renderTextBody(
   const rPad = emuToPx(body.rIns, scale);
   const tPad = emuToPx(body.tIns, scale);
   const bPad = emuToPx(body.bIns, scale);
-  const doWrap = body.wrap !== 'none';
+  // ECMA-376 §20.1.10.5 spAutoFit: "the shape's height and width should resize
+  // to accommodate the text". The bbox is no longer a wrap boundary in that
+  // mode — the shape grows to fit. Treating spAutoFit as wrap=none on the
+  // horizontal axis keeps mixed-size sequences (e.g. "20代", "YoY+11.9%")
+  // on one line, matching PowerPoint. Vertical growth is handled below by
+  // the spAutoFit branch in the height calculation.
+  const doWrap = body.wrap !== 'none' && body.autoFit !== 'sp';
+  // ECMA-376 §20.1.10.34 numCol — distribute paragraphs across N text columns.
+  const numCol = Math.max(1, body.numCol ?? 1);
+  const spcColPx = emuToPx(body.spcCol ?? 0, scale);
 
   const bodyDefaultBold   = body.defaultBold   ?? false;
   const bodyDefaultItalic = body.defaultItalic ?? false;
@@ -968,12 +977,20 @@ function renderTextBody(
       autoNumCounters.clear();
     }
 
-    // Text start X and wrap width
-    // For bullet paragraphs: text always at marL, bullet at marL+indent (hanging)
-    // For non-bullet with positive indent: first line at marL+indent, others at marL
+    // Text start X and wrap width.
+    //
+    // ECMA-376 §20.1.10.34 numCol — the bbox is split into N equal columns
+    // separated by `spcCol` gutters, and paragraphs flow column-by-column.
+    // For Pass 1 we lay out at the column width so wrapping & line counts are
+    // correct; Pass 2 reuses the same lines and just shifts the X origin per
+    // column. textX/bulletX below are relative to column 0; the column shift
+    // is added later when we walk `allLines`.
+    const colWidth = numCol > 1
+      ? (bw - lPad - rPad - (numCol - 1) * spcColPx) / numCol
+      : bw - lPad - rPad;
     const textX    = bx + lPad + marLPx;
     const bulletX  = bx + lPad + marLPx + indentPx;
-    const textMaxW = bw - lPad - rPad - marLPx - marRPx;
+    const textMaxW = colWidth - marLPx - marRPx;
 
     const maxW = doWrap ? textMaxW : Infinity;
     const lines = layoutParagraph(ctx, para, maxW, paraDefaultFontSizePx, paraDefaultColor, scale, marLPx, bodyDefaultBold, bodyDefaultItalic, fontScale, slideNumber, rc);
@@ -1094,9 +1111,38 @@ function renderTextBody(
   // `body.wrap === "none"` means horizontal non-wrap; it doesn't affect
   // clipping per spec either, so we just don't clip.
 
+  // Multi-column flow state. When numCol > 1 we walk the lines top-to-bottom
+  // and advance to the next column whenever the current column's content
+  // height would be exceeded. Column 0 starts at the initial cursorY; each
+  // subsequent column resets the cursor and shifts X by colWidth + spcCol.
+  // When numCol === 1 these stay at 0 / `cursorY` / and never advance.
+  let colIdx = 0;
+  const colTopY = cursorY;
+  const colWidthShift = numCol > 1
+    ? (bw - lPad - rPad - (numCol - 1) * spcColPx) / numCol + spcColPx
+    : 0;
+  const colHeight = Math.max(0, effectiveBh - tPad - bPad);
+
   for (const entry of allLines) {
-    const { line, linePx, lineHeight, topGapPx, textXOffset, bulletLabel, bulletFont, bulletColor, bulletX, textX, textMaxW, alignment } = entry;
+    const { line, linePx, lineHeight, topGapPx, textXOffset, bulletLabel, bulletFont, bulletColor, alignment } = entry;
     cursorY += topGapPx;
+    // Advance to the next column when the current line would not fit. We only
+    // advance once per line (PowerPoint never breaks a single line across
+    // columns) and never past the last column — anything that overflows the
+    // last column simply runs past the bbox, matching PPT's spill behavior.
+    if (
+      numCol > 1 &&
+      colIdx < numCol - 1 &&
+      cursorY - colTopY + linePx > colHeight + 0.5 &&
+      cursorY > colTopY
+    ) {
+      colIdx++;
+      cursorY = colTopY + topGapPx;
+    }
+    const xShift = colIdx * colWidthShift;
+    const textX = entry.textX + xShift;
+    const bulletX = entry.bulletX + xShift;
+    const textMaxW = entry.textMaxW;
 
     // Measure line for alignment AND baseline ascent in one pass.
     // actualBoundingBoxAscent gives the real font ascent for the rendered glyphs,


### PR DESCRIPTION
## Summary
A cluster of sample-2 regressions all traced back to the same shape of problem: ECMA-376 features on `<a:bodyPr>` and waterfall axis geometry that we parsed superficially or not at all. They are independent in the spec but show up as a cluster because PowerPoint templates that use one tend to use the others. Fixing them together keeps the text-body code in one consistent state instead of accreting band-aids.

## Changes

### numCol — multi-column text body (ECMA-376 §20.1.10.34)
- **Symptom**: slide-13's "ターゲット条件 / 新機能" box looked like its blue 利用履歴 / 価値観 / 属性詳細 paragraphs were missing. They weren't; they were below the bbox because we ignored `numCol="2"` and laid all 8 paragraphs out in a single column.
- Rust parser reads `numCol` (default 1) and `spcCol` (gutter EMU, default 0) on `<a:bodyPr>`. Serialised on `TextBody` and skipped at defaults so existing JSON stays unchanged.
- pptx renderer pre-computes per-column width and uses it as the wrap width during Pass 1, so each line is measured against the column it'll actually live in.
- Pass 2 grows a column-flow state (`colIdx`, `colTopY`, `colWidthShift`): when the next line wouldn't fit, advance to the next column with X shift.

### spAutoFit must disable horizontal wrap (ECMA-376 §20.1.10.5)
- **Symptom**: slide-13's "20代" / "30代" / "40代" labels wrapped "代" to a second line in a tight `wrap="square"` + `spAutoFit` textbox, even though PowerPoint shows them on one line.
- spAutoFit means *"the shape grows to fit the text"*, so the bbox is no longer a wrap boundary. `doWrap = body.wrap !== 'none' && body.autoFit !== 'sp'`.

### Waterfall: dataMin = 0 when all bars ≥ 0
- **Symptom**: slide-8 had a visible gap between bar bottoms and x-axis. The renderer was extending the value scale 5% below `rawMin` even when `rawMin === 0`.
- Fix: `dataMin = rawMin < 0 ? rawMin - dataRange * 0.05 : 0`. When data crosses zero (negative bars), the 5% pad still applies.

## Test plan
- [x] sample-2 slide-13: blue 利用履歴 / 価値観 / 属性詳細 column visible; 20代/30代/40代 labels each on one line
- [x] sample-2 slide-8: bar bases sit on x-axis; rest of waterfall unchanged
- [x] sample-2 slide-7 (charts) — no regression
- [x] sample-2 slide-12 (laptop+phone) — no regression
- [x] `npx tsc --build` clean
- [x] `pnpm build:wasm` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)