### PR TITLE
fix(pptx,core/chart): sample-2 slide-8 / 13 / 16 follow-ups

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -641,8 +641,25 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
 
   drawChartTitle(ctx, chart, x, y + titleTopPad, w, titleFontPx);
 
-  const px0 = x + pad.l; const py0 = y + pad.t;
-  const pw  = w - pad.l - pad.r; const ph = h - pad.t - pad.b;
+  // Plot-area placement: honor `<c:plotArea><c:layout><c:manualLayout>` when
+  // present (ECMA-376 §21.2.2.32). Templates use this to keep bars from
+  // overflowing into side annotations — sample-2 slide-16's horizontal bar
+  // chart has the chart frame extending into the right-hand text column,
+  // and the explicit `x=0.184, w=0.797` keeps the actual bars on the left.
+  // `layoutTarget="inner"` (default) means the rectangle covers the inner
+  // data region; "outer" includes axes/labels. We treat both identically
+  // because the inner padding stays the same either way.
+  const pml = chart.plotAreaManualLayout;
+  let px0: number, py0: number, pw: number, ph: number;
+  if (pml && pml.w != null && pml.h != null) {
+    px0 = x + pml.x * w;
+    py0 = y + pml.y * h;
+    pw  = pml.w * w;
+    ph  = pml.h * h;
+  } else {
+    px0 = x + pad.l; py0 = y + pad.t;
+    pw  = w - pad.l - pad.r; ph = h - pad.t - pad.b;
+  }
   if (pw <= 0 || ph <= 0) return;
 
   if (chart.plotAreaBg) {
@@ -1979,11 +1996,28 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
     const labelText = rawVal < 0
       ? `△ ${Math.abs(rawVal).toLocaleString()}`
       : rawVal.toLocaleString();
-    ctx.fillStyle = '#595959';
+    // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
+    // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
+    // then to neutral grey. PowerPoint paints negative-bar labels in
+    // accent1 (red) for sample-2's waterfall.
+    const perPointColor = chart.series[0]?.dataLabelColors?.[i] ?? null;
+    const labelColor = perPointColor
+      ? `#${perPointColor}`
+      : chart.dataLabelFontColor
+        ? `#${chart.dataLabelFontColor}`
+        : '#595959';
+    ctx.fillStyle = labelColor;
     ctx.font = `bold ${Math.round(h * 0.044)}px sans-serif`;
     ctx.textAlign = 'center';
-    ctx.textBaseline = 'bottom';
-    ctx.fillText(labelText, bx + barW / 2, yTop - 3);
+    // Negative bars: label sits BELOW the bar (`outEnd` for a negative value
+    // points downward in chartEx). Positive bars and subtotals: label ABOVE.
+    if (rawVal < 0) {
+      ctx.textBaseline = 'top';
+      ctx.fillText(labelText, bx + barW / 2, yBot + 3);
+    } else {
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(labelText, bx + barW / 2, yTop - 3);
+    }
   });
 
   ctx.textAlign = 'center';

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -18,6 +18,13 @@ export interface ChartSeries {
    */
   dataPointColors?: (string | null)[] | null;
   /**
+   * Per-data-point data-label text colors. Used by chartEx (`<cx:dataLabel idx>`)
+   * to override label colour per bar — sample-2's waterfall paints negative
+   * △ values in red while positive values stay black. Null inside the array =
+   * fall back to the chart-level `dataLabelFontColor`.
+   */
+  dataLabelColors?: (string | null)[] | null;
+  /**
    * Mixed chart: per-series chart type override. Currently only "line" (XLSX)
    * is honoured; other values are treated as the chart's primary type.
    */

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -100,6 +100,11 @@ struct ChartSeriesData {
     /// Per-data-point colors (used for pie/doughnut charts). None if all points use series color.
     #[serde(skip_serializing_if = "Option::is_none")]
     data_point_colors: Option<Vec<Option<String>>>,
+    /// Per-data-point data-label text colors. ChartEx (`<cx:dataLabel idx>`) uses this
+    /// to switch label colour per bar — sample-2's waterfall paints the negative
+    /// △ values in red (accent1) while positive values stay in tx1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data_label_colors: Option<Vec<Option<String>>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -168,6 +173,32 @@ struct ChartElement {
     /// `<c:valAx><c:numFmt formatCode>` — value-axis tick label number format.
     #[serde(skip_serializing_if = "Option::is_none")]
     val_axis_format_code: Option<String>,
+    /// `<c:plotArea><c:layout><c:manualLayout>` — explicit plot-area placement
+    /// (ECMA-376 §21.2.2.32). Templates use this to keep the chart's bars from
+    /// occupying the full chart-frame width when callout text sits beside the
+    /// frame; without honouring it the bars overflow into the side annotations
+    /// (sample-2 slide-16's horizontal bar chart).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plot_area_manual_layout: Option<ChartManualLayout>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct ChartManualLayout {
+    /// "edge" = x/y are absolute fractions from top-left of chart space;
+    /// "factor" = fractions offset from the renderer's default placement.
+    x_mode: String,
+    y_mode: String,
+    /// "inner" (excludes axes / tick labels) | "outer" (includes them).
+    /// Only meaningful for plotArea — title/legend ignore it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    layout_target: Option<String>,
+    x: f64,
+    y: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    w: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    h: Option<f64>,
 }
 
 // ===== Table data model =====
@@ -2815,6 +2846,10 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
         ChartSeriesData {
             name, values, color,
             data_point_colors: if has_dpt_colors { Some(data_point_colors) } else { None },
+            // Legacy `<c:chart>` per-point label colors are extracted via
+            // `<c:dLbls><c:dLbl idx>` — not yet wired here; chartEx is the only
+            // path that needs it for sample-2's waterfall.
+            data_label_colors: None,
         }
     }).collect();
 
@@ -2877,6 +2912,38 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     // `<c:valAx><c:numFmt formatCode>` — value-axis tick label number format.
     let val_axis_format_code = val_ax.and_then(ooxml_common::chart::extract_axis_format_code);
 
+    // `<c:plotArea><c:layout><c:manualLayout>` — explicit plot-area rectangle
+    // (fractions of chart space). ECMA-376 §21.2.2.32. Sample-2 slide-16 uses
+    // this to keep its horizontal bar chart from spilling into the side
+    // annotation column. We parse the same shape xlsx already exposes
+    // (xMode, yMode, layoutTarget, x, y, w?, h?).
+    let plot_area_manual_layout = plot_area.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "layout")
+        .and_then(|layout| layout.children().find(|n| n.is_element() && n.tag_name().name() == "manualLayout"))
+        .map(|ml| {
+            let mut x_mode = "edge".to_string();
+            let mut y_mode = "edge".to_string();
+            let mut layout_target: Option<String> = None;
+            let mut x = 0.0_f64;
+            let mut y = 0.0_f64;
+            let mut w: Option<f64> = None;
+            let mut h: Option<f64> = None;
+            for ch in ml.children().filter(|n| n.is_element()) {
+                let val_str = attr(&ch, "val");
+                match ch.tag_name().name() {
+                    "xMode" => { if let Some(v) = val_str { x_mode = v; } }
+                    "yMode" => { if let Some(v) = val_str { y_mode = v; } }
+                    "layoutTarget" => { layout_target = val_str; }
+                    "x" => { if let Some(v) = val_str.and_then(|s| s.parse::<f64>().ok()) { x = v; } }
+                    "y" => { if let Some(v) = val_str.and_then(|s| s.parse::<f64>().ok()) { y = v; } }
+                    "w" => { w = val_str.and_then(|s| s.parse::<f64>().ok()); }
+                    "h" => { h = val_str.and_then(|s| s.parse::<f64>().ok()); }
+                    _ => {}
+                }
+            }
+            ChartManualLayout { x_mode, y_mode, layout_target, x, y, w, h }
+        });
+
     Some(ChartElement {
         x: 0, y: 0, width: 0, height: 0,
         chart_type,
@@ -2906,6 +2973,7 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
         data_label_font_color,
         data_label_format_code,
         val_axis_format_code,
+        plot_area_manual_layout,
     })
 }
 
@@ -2974,11 +3042,39 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         .and_then(|sp| sp.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
         .and_then(|fill| parse_color_node(fill, theme));
 
+    // Per-idx data-label colors. ChartEx writes `<cx:dataLabels>` with
+    // `<cx:dataLabel idx="N">` overrides; each carries its own `<cx:txPr>`
+    // whose first `<a:solidFill>` is the label colour for that bar. Sample-2
+    // waterfall uses this to paint negative-bar labels in accent1 (red) while
+    // positive-bar labels stay tx1 (black).
+    let mut data_label_colors_vec: Vec<Option<String>> = vec![None; raw_values.len().max(1)];
+    let mut has_per_label_color = false;
+    for dl in series_node.descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dataLabel")
+    {
+        let Some(idx) = attr(&dl, "idx").and_then(|v| v.parse::<usize>().ok()) else { continue; };
+        if idx >= data_label_colors_vec.len() { continue; }
+        // First `<a:solidFill>` inside the per-idx <cx:txPr>.
+        let txpr = match dl.children().find(|n| n.is_element() && n.tag_name().name() == "txPr") {
+            Some(n) => n,
+            None => continue,
+        };
+        for desc in txpr.descendants().filter(|n| n.is_element()) {
+            if desc.tag_name().name() != "solidFill" { continue; }
+            if let Some(c) = parse_color_node(desc, theme) {
+                data_label_colors_vec[idx] = Some(c);
+                has_per_label_color = true;
+                break;
+            }
+        }
+    }
+
     let series = vec![ChartSeriesData {
         name: String::new(),
         values: raw_values,
         color,
         data_point_colors: None,
+        data_label_colors: if has_per_label_color { Some(data_label_colors_vec) } else { None },
     }];
 
     // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`
@@ -3015,6 +3111,7 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         data_label_font_color: None,
         data_label_format_code: None,
         val_axis_format_code: None,
+        plot_area_manual_layout: None,
     })
 }
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -639,6 +639,12 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     'curvedconnector2', 'curvedconnector3', 'curvedconnector4', 'curvedconnector5',
   ]);
 
+  // callout1 family — `<a:ln><a:headEnd|tailEnd>` decorate the line path
+  // (path 1 in presets.json), not the surrounding text rectangle (path 0).
+  const CALLOUT1_GEOMS = new Set([
+    'callout1', 'bordercallout1', 'accentcallout1', 'accentbordercallout1',
+  ]);
+
   const applyAndStroke = el.stroke
     ? () => {
         applyStroke(ctx, el.stroke!, scale);
@@ -700,6 +706,29 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       if (el.stroke.headEnd) {
         drawArrowHead(ctx, anchors.start.x, anchors.start.y, anchors.start.angle, el.stroke.headEnd, el.stroke, scale);
       }
+    }
+  } else if (el.stroke && CALLOUT1_GEOMS.has(geom)) {
+    // Callout1 family carries an `<a:ln>` whose head/tail decorations belong
+    // on the *line* (path 1: m,x1,y1 → l,x2,y2), not on the rectangle (path 0).
+    // ECMA-376 callout1 gd: y1=h·adj1/100000, x1=w·adj2/100000 (attach point);
+    // y2=h·adj3/100000, x2=w·adj4/100000 (tip). Tip and attach may sit
+    // outside the bbox. Compute both, then orient the head/tail along the
+    // attach→tip direction.
+    const attXf = ((el.adj2 ?? -8333) as number) / 100000;
+    const attYf = ((el.adj  ?? 18750) as number) / 100000;
+    const tipXf = ((el.adj4 ?? -38333) as number) / 100000;
+    const tipYf = ((el.adj3 ?? 112500) as number) / 100000;
+    const attX = x + attXf * w;
+    const attY = y + attYf * h;
+    const tipX = x + tipXf * w;
+    const tipY = y + tipYf * h;
+    const tailAngle = Math.atan2(tipY - attY, tipX - attX);
+    const headAngle = tailAngle + Math.PI;
+    if (el.stroke.tailEnd) {
+      drawArrowHead(ctx, tipX, tipY, tailAngle, el.stroke.tailEnd, el.stroke, scale);
+    }
+    if (el.stroke.headEnd) {
+      drawArrowHead(ctx, attX, attY, headAngle, el.stroke.headEnd, el.stroke, scale);
     }
   }
 
@@ -1128,13 +1157,21 @@ function renderTextBody(
   // `body.wrap === "none"` means horizontal non-wrap; it doesn't affect
   // clipping per spec either, so we just don't clip.
 
-  // Multi-column flow state. We use a *balanced* split rather than a greedy
-  // height-fill: PowerPoint distributes paragraphs so each column gets
-  // roughly ⌈N/numCol⌉ entries, which keeps parallel rows across columns
-  // aligned (e.g. on sample-2 slide-13 the right column starts with a blank
-  // paragraph so the blue 利用履歴/価値観/属性詳細 sit at the same y as
-  // the left column's 年齢/性別/居住地). A pure overflow-driven advance
-  // would pack the left column maximally and shift the right column up.
+  // Multi-column flow state. PowerPoint's actual behaviour with `numCol`:
+  //
+  // - If the total content height fits within a single column, ALL paragraphs
+  //   stay in column 0 even when `numCol > 1`. (Sample-2 slide-13's "従来"
+  //   box has 4 paragraphs in a `numCol="2"` body; PowerPoint stacks them
+  //   vertically because they fit, not 2+2.)
+  // - Otherwise, paragraphs are distributed *balanced* (each column gets
+  //   roughly ⌈N/numCol⌉ entries) so parallel rows across columns line up.
+  //   (Sample-2 slide-13's "新機能" box has 9 paragraphs that overflow a
+  //   single column; the right column starts with a blank paragraph so the
+  //   blue 利用履歴/価値観/属性詳細 sit at the same y as 年齢/性別/居住地.)
+  //
+  // A pure overflow-driven advance would either pack column 0 maximally and
+  // shift the right column up (breaking row alignment) or never collapse
+  // multi-col to single when content fits.
   //
   // We pre-compute, for each entry, which column it belongs to. Column 0
   // starts at the initial cursorY; each subsequent column resets the cursor
@@ -1143,7 +1180,12 @@ function renderTextBody(
   const colWidthShift = numCol > 1
     ? (bw - lPad - rPad - (numCol - 1) * spcColPx) / numCol + spcColPx
     : 0;
-  const linesPerCol = numCol > 1 ? Math.ceil(allLines.length / numCol) : allLines.length;
+  const colHeightCapacity = Math.max(0, effectiveBh - tPad - bPad);
+  // When `bh === 0` (caller relies on auto-height) the capacity is unbounded
+  // and content always fits, so a multi-col directive collapses to single col.
+  const fitsInOneCol = bh === 0 || totalHeight <= colHeightCapacity + 0.5;
+  const useMultiCol = numCol > 1 && !fitsInOneCol;
+  const linesPerCol = useMultiCol ? Math.ceil(allLines.length / numCol) : allLines.length;
   let colIdx = 0;
   let entriesInCol = 0;
 
@@ -1786,6 +1828,7 @@ export async function renderSlide(
           dataLabelFontColor: el.dataLabelFontColor ?? null,
           dataLabelFormatCode: el.dataLabelFormatCode ?? null,
           valAxisFormatCode: el.valAxisFormatCode ?? null,
+          plotAreaManualLayout: el.plotAreaManualLayout ?? null,
         },
         {
           x: emuToPx(el.x, scale),

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -210,6 +210,10 @@ export interface ChartElement {
   dataLabelFormatCode?: string | null;
   /** `<c:valAx><c:numFmt formatCode>` — value-axis tick label number format. */
   valAxisFormatCode?: string | null;
+  /** `<c:plotArea><c:layout><c:manualLayout>` (ECMA-376 §21.2.2.32) — explicit
+   * plot-area placement so bars don't extend past the chart-frame's intended
+   * inner region (sample-2 slide-16 horizontal bar chart). */
+  plotAreaManualLayout?: import('@silurus/ooxml-core').ChartManualLayout | null;
 }
 
 export interface PictureElement {


### PR DESCRIPTION
## Summary
Four independent issues reported on sample-2 that all trace back to features the spec carries but our renderer was ignoring or hard-coding.

### slide-8 — callout1 oval terminator + endpoint arrows
Callout1-family shapes carry `<a:ln><a:tailEnd type="oval">`; previously arrow ends were only drawn for `CONNECTOR_GEOMS`. New `CALLOUT1_GEOMS` branch computes the line-path endpoints directly from the (Y, X) adjustment pairing and reuses `drawArrowHead` (which already supported `oval`).

### slide-8 — waterfall per-data-point label colour + negative-below positioning
`<cx:dataLabel idx="N">` blocks carry per-bar `<cx:txPr>` overrides — sample-2 paints `△ 52 / △ 40 / △ 108` in accent1 (red). New `data_label_colors` on `ChartSeriesData` flows through to `ChartSeries.dataLabelColors`. `renderWaterfallChart` reads it per bar and positions negative labels BELOW the bar (`outEnd` for a downward-pointing bar).

### slide-13 — collapse multi-col when content fits
Both 従来 and 新機能 boxes carry `numCol="2"`, but PowerPoint stacks 従来 vertically because its 4 paragraphs fit in one column. New rule: when `totalHeight ≤ colHeightCapacity`, the multi-col split collapses to single-column flow regardless of `numCol`. The 新機能 box still overflows and gets the existing balanced 5+4 distribution.

### slide-16 — honor `<c:plotArea><c:layout><c:manualLayout>`
chart3 declares `x=0.184, w=0.797, layoutTarget="inner"` to keep the bars on the left so the right-hand annotation column stays clear. New `ChartManualLayout` type mirrors xlsx's; the pptx parser reads `<c:plotArea><c:layout><c:manualLayout>` and the bar renderer uses it to compute the plot rect when present (same path the scatter chart already had).

## Test plan
- [x] sample-2 slide-8: oval terminators on callouts; negative labels red and below bars
- [x] sample-2 slide-13: 従来 box vertical stack; 新機能 box still 2-column aligned
- [x] sample-2 slide-16: horizontal bar chart in declared inner region, no overlap with right text
- [x] sample-2 slide-7: column chart labels still centered + correct size

🤖 Generated with [Claude Code](https://claude.com/claude-code)