### PR TITLE
fix(core/chart): waterfall padT aligns bar bottom with callout tips

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1874,12 +1874,21 @@ function dashPatternForPreset(preset: string | undefined): number[] {
 function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect): void {
   const { x, y, w, h } = r;
   // PowerPoint's chartEx waterfall uses very thin side margins when the
-  // value axis is hidden — there's no axis label area to reserve. Our prior
-  // 4% pads on each side made the plot ~8% narrower than the file intended,
-  // visibly shrinking the bars relative to PowerPoint's PDF export.
+  // value axis is hidden — there's no axis label area to reserve.
   const padL = chart.valAxisHidden ? w * 0.01 : w * 0.11;
   const padR = w * 0.01;
-  const padT = h * 0.06;
+  // Top / bottom padding sets where bar bottoms (value 0) and tops (value
+  // padded) land in absolute slide coordinates. Sibling shapes — e.g. the
+  // sample-2 slide-8 callouts whose `<a:prstGeom prst="callout1">` adj3/adj4
+  // tips are placed in absolute slide EMU — assume a specific y for the
+  // bar's lower-left corner (the running-total line). Working that
+  // backwards from id=14's tip at ((5015880 + 1468672*0.95815),
+  // (3748214 + 516167*(-0.67286))) = (6423117, 3400921) EMU and solving
+  // for the padT that puts 人件費変化's bar.start (value 388, the
+  // running-total line for that bar) at that y gives padT ≈ 12% with
+  // padB ≈ 14%. Smaller padT shifts bar bottoms upward and the callout
+  // tips render below the bars (the regression PR #248 introduced).
+  const padT = h * 0.12;
   const padB = h * 0.14;
   const px0 = x + padL;
   const py0 = y + padT;


### PR DESCRIPTION
## Summary
sample-2 slide-8's "CS部門増員による人件費を計上" callout connector lands a few pixels *below* the 人件費変化 candle in our render — in PowerPoint it touches the bar's lower-left corner. The diagnosis traces back to [#248](https://github.com/yukiyokotani/office-open-xml-viewer/pull/248): shrinking padT from 8% to 6% moved bar bottoms down past the absolute-EMU callout tips.

## Math
- callout id=14 tip y (from `<a:prstGeom prst="callout1">` adj3/adj4) = 3,748,214 + 516,167 × (-0.67286) = **3,400,921 EMU**
- chart frame: y=2,032,600, h=4,304,968 EMU
- 人件費変化 bar.start (running-total line, value 388 of padded 528) must land at 3,400,921 EMU
- Solving `chart_top + (padT + 0.265 × (1 - padT - padB)) × chart_h = 3,400,921` with padB=14% → **padT ≈ 12%**

## Verification
With padT=12%, the 人件費変化 outline bottom in canvas coords sits at y=889; the callout tip is at y=892.6 (3.6 px below in a 1800-px canvas — visually aligned). Pre-fix gap was ~50px.

The padding values aren't formally specified by chartEx, but the absolute-coord nature of the surrounding callouts pins the right answer empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)