### PR TITLE
fix(stories): Storybook DebugJson — surface wasm-init race instead of stalling

### DIFF
--- a/packages/docx/src/DocxViewer.stories.ts
+++ b/packages/docx/src/DocxViewer.stories.ts
@@ -114,13 +114,19 @@ export const DebugJson: Story = {
 
     root.append(fileInput, pre);
 
-    let wasmReady = false;
-    init().then(() => { wasmReady = true; });
+    // Kick off wasm init eagerly so it overlaps with the user picking a file.
+    // The change handler awaits the same promise — wasm-pack's init() is
+    // idempotent and cached, so the second await resolves instantly. This
+    // closes the race where picking a file before init resolved would silently
+    // return and leave the placeholder visible.
+    const wasmReady = init();
 
     fileInput.addEventListener('change', async () => {
       const file = fileInput.files?.[0];
-      if (!file || !wasmReady) return;
+      if (!file) return;
+      pre.textContent = `Parsing ${file.name}…`;
       try {
+        await wasmReady;
         const buf = await file.arrayBuffer();
         const json = parse_docx(new Uint8Array(buf));
         const parsed = JSON.parse(json);

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -146,13 +146,19 @@ export const DebugJson: Story = {
 
     root.append(fileInput, pre);
 
-    let wasmReady = false;
-    init().then(() => { wasmReady = true; });
+    // Kick off wasm init eagerly so it overlaps with the user picking a file.
+    // The change handler also awaits the same promise — wasm-pack's init() is
+    // idempotent and cached, so the second await resolves instantly. This
+    // closes the race where picking a file before init resolved would silently
+    // return without ever updating the pre.
+    const wasmReady = init();
 
     fileInput.addEventListener('change', async () => {
       const file = fileInput.files?.[0];
-      if (!file || !wasmReady) return;
+      if (!file) return;
+      pre.textContent = `Parsing ${file.name}…`;
       try {
+        await wasmReady;
         const buf = await file.arrayBuffer();
         const json = parse_pptx(new Uint8Array(buf));
         const parsed = JSON.parse(json);

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -80,13 +80,19 @@ export const DebugJson: Story = {
 
     root.append(fileInput, pre);
 
-    let wasmReady = false;
-    init().then(() => { wasmReady = true; });
+    // Kick off wasm init eagerly so it overlaps with the user picking a file.
+    // The change handler awaits the same promise — wasm-pack's init() is
+    // idempotent and cached, so the second await resolves instantly. This
+    // closes the race where picking a file before init resolved would silently
+    // return and leave the placeholder visible.
+    const wasmReady = init();
 
     fileInput.addEventListener('change', async () => {
       const file = fileInput.files?.[0];
-      if (!file || !wasmReady) return;
+      if (!file) return;
+      pre.textContent = `Parsing ${file.name}…`;
       try {
+        await wasmReady;
         const buf = await file.arrayBuffer();
         const json = parse_xlsx(new Uint8Array(buf));
         const parsed = JSON.parse(json);


### PR DESCRIPTION
## Summary

The "Debug – raw parse JSON" story in xlsx/docx/pptx had a race where, if you selected a file **before** the wasm module finished loading, the change handler silently returned and the placeholder text stayed visible forever — no error, no progress signal. Reported by the user against the docx + pptx Debug stories on `release/0.32.0`.

## Cause

```ts
let wasmReady = false;
init().then(() => { wasmReady = true; });

fileInput.addEventListener('change', async () => {
  const file = fileInput.files?.[0];
  if (!file || !wasmReady) return;  // ← silent return on race
  ...
});
```

The latent race has been there since the stories were added (0.25.0). The 0.32.0 wasm size bump (~+9 KB across all three) widens the window slightly but doesn't introduce the bug.

## Fix

- Keep the `init()` promise itself instead of just a boolean. The change handler `await`s it before parsing — wasm-pack's `init()` is idempotent + cached, so subsequent awaits resolve instantly.
- Show "Parsing `<filename>`…" as soon as a file is picked so the user gets immediate feedback regardless of init latency.
- Same pattern applied across xlsx / docx / pptx Debug stories for consistency.

## Test plan

- [x] Verified in `pnpm storybook` (port 6007). Hard-reload the page and dispatch a change event 200–500 ms in (before `init()` could possibly resolve on a cold load). Before this patch: pre stays at "Load a .docx to see the parsed JSON here." After: pre shows "Parsing sample-1.docx…" then the parsed JSON.
- [ ] Manual: open `Debug – raw parse JSON` for docx and pptx, pick a private sample, confirm JSON appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)