### PR TITLE
chore(release): 0.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.32.1 — 2026-05-11
+
+Two bug fixes that surfaced shortly after 0.32.0. Renderer is unchanged from 0.32.0.
+
+### Fixes
+
+- **vscode-extension**: redownload the bundled `ooxml-mcp-server` binary when the extension upgrades. `resolveBinaryPath` previously kept any cached binary as long as it existed on disk, so after `silurus.office-open-xml-viewer` updated 0.31.0 → 0.32.0 the workspace kept running the old 0.31.0 binary indefinitely — silently missing the v0.32.0 fixes (the `pptx_extract_text` empty-text bug being the most visible). Now writes a sibling `<binary>.version` pin file at download time and forces a redownload on extension-version mismatch. Explicit user override paths are still honored unchanged. PATH fallback only applies on a clean install (no cache yet) so a stale globally-installed `cargo install`'d binary can no longer mask the version-pin check.
+- **stories (xlsx / docx / pptx)**: the "Debug – raw parse JSON" story silently returned from the file-change handler when wasm `init()` had not yet resolved, leaving the placeholder visible forever. The change handler now `await`s the same init promise (idempotent + cached, so subsequent awaits resolve instantly) and shows a "Parsing `<filename>`…" status as soon as a file is picked, regardless of init latency.
+
 ## 0.32.0 — 2026-05-11
 
 This release is **MCP-server-focused**. The renderer (xlsx / docx / pptx viewers) is byte-identical to 0.31.0 — confirmed by running the full demo VRT against the rebuilt WASM (xlsx 5/5, docx 6/6, pptx 9/9 at 100% match). No README screenshot updates because of this.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Two bug fixes since 0.32.0; renderer is unchanged.

- **PR #255** vscode-extension: redownload mcp-server binary on extension upgrade. After 0.31.0 → 0.32.0 auto-update, the cached binary stayed at 0.31.0 indefinitely. Now version-pinned via a sibling \`<binary>.version\` file.
- **PR #254** stories: Storybook DebugJson — surface wasm-init race instead of stalling. Race window between \`init()\` and the user picking a file caused the placeholder to remain forever; now awaits the cached init promise inside the handler.

Version bump: 6 package.json files (root + core/pptx/xlsx/docx/vscode-extension) → 0.32.1.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] mcp-server cargo tests still pass (38)
- [ ] Manual: upgrade VS Code extension and confirm binary redownload
- [ ] Manual: open Debug — raw parse JSON and verify file selection works regardless of init timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)