### PR TITLE
chore(release): 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.33.0 — 2026-05-11
+
+MCP-server-focused release introducing a **text-focused projection** tier alongside the rich structured tools. Renderer is unchanged from 0.32.1 (demo VRT 20/20 at 100% match).
+
+### Features
+
+- **mcp-server**: `pptx_to_markdown`, `docx_to_markdown`, `xlsx_to_markdown` — convert OOXML files to GitHub-flavoured markdown, designed for AI agents that need to *read* content efficiently rather than reason about layout. Each parser exposes a native `to_markdown_native(data)` projection that walks the already-parsed model and emits semantic markdown:
+  - **PPTX**: slide titles via `placeholderType ∈ {title, ctrTitle}`, body shapes as nested bullets at the paragraph `lvl` depth, tables, chart summaries, speaker notes, comments. Auto-generated metadata placeholders (`sldNum`/`dt`/`ftr`/`hdr`) and decorative pictures/connectors are dropped.
+  - **DOCX**: headings via `<w:outlineLvl>` → `#`-`######`, numbered/bullet paragraphs honour the resolved abstractNum format, tables with vMerge continuation, footnotes/endnotes collated as `[^N]: …`, comments as `> **author**: text`. Per-run `**bold**` / `*italic*` / `~~strikethrough~~` / `[link](url)` preserved with whitespace pulled outside the wrappers.
+  - **XLSX**: `## SheetName` per sheet followed by a pipe table of the populated bbox, merged-cell continuation cells rendered empty, fully-empty middle rows trimmed, IEEE-754 ULP noise masked so `702.6` no longer renders as `702.5999999999999`.
+- For demo/sample-1.pptx the markdown is ~21× smaller than the raw XML, ~3× smaller than the structured tools, and only ~8% bigger than the flat-text extractor.
+
+### Fixes
+
+- **mcp-server/xlsx**: `xlsx_get_cell_range`, `xlsx_get_formulas`, and `xlsx_search_cells` were matching the wrong CellValue serde tag (PascalCase `"Text"`/`"Number"` vs. the camelCase `"text"`/`"number"` actually emitted), silently returning empty strings for every cell value since these tools were introduced in 0.32.0. Same class of bug as the v0.32.0 `pptx_extract_text` fix. Caught while testing the new `xlsx_to_markdown` against demo/sample-1.xlsx; the regression window is exactly one release.
+
 ## 0.32.1 — 2026-05-11
 
 Two bug fixes that surfaced shortly after 0.32.0. Renderer is unchanged from 0.32.0.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

MCP-server-focused release introducing a **text-focused projection tier** alongside the existing structured tools. Renderer is unchanged from 0.32.1 — demo VRT 20/20 at 100% match.

### Features

- New tools: \`pptx_to_markdown\` / \`docx_to_markdown\` / \`xlsx_to_markdown\` — convert OOXML to GitHub-flavoured markdown for agents that need to *read* the content (PR #257 + #258).
- Each parser exposes a native \`to_markdown_native()\` projection that walks the parsed model and emits semantic markdown: headings, bullets, tables, footnotes, comments, bold/italic/hyperlinks, chart summaries.
- ~21× smaller than raw XML, ~3× smaller than the structured JSON tools.

### Fixes

- xlsx cell-value tools (\`xlsx_get_cell_range\`, \`xlsx_get_formulas\`, \`xlsx_search_cells\`) had a latent PascalCase/camelCase tag mismatch and silently returned empty cell values since they were introduced in 0.32.0. Caught and fixed in #258. Regression window: exactly one release.

Version bump: 6 package.json files → 0.33.0.

## Test plan

- [x] \`cargo test -p ooxml-mcp-server\` — 41 tests pass
- [x] \`pnpm build:wasm\` + \`pnpm typecheck\` clean
- [x] \`pnpm vrt\` — demo samples 20/20 at 100% match

🤖 Generated with [Claude Code](https://claude.com/claude-code)