### PR TITLE
fix(vscode-extension): unlink cached binary before overwriting

### DIFF
--- a/packages/vscode-extension/src/mcp/installer.ts
+++ b/packages/vscode-extension/src/mcp/installer.ts
@@ -171,6 +171,14 @@ export async function downloadBinary(context: vscode.ExtensionContext): Promise<
         );
       }
 
+      // macOS caches the kernel's code-signing decision for an executable
+      // keyed by path. If we overwrite an existing ad-hoc-signed binary in
+      // place (same path, different content hash), amfid keeps the old
+      // decision, refuses the new binary on launch, and `execve` hangs at
+      // dyld bootstrap with no log output — exactly the symptom seen when the
+      // version-pin fix from v0.32.1 first kicks in and replaces the cached
+      // 0.32.0 binary. Unlinking first severs the cache association.
+      await fs.promises.rm(dest, { force: true });
       await fs.promises.writeFile(dest, buf);
       if (process.platform !== 'win32') {
         await fs.promises.chmod(dest, 0o755);


### PR DESCRIPTION
## Summary

When the v0.32.1 version-pin fix first kicks in on a user's machine (i.e. on the 0.32.x → 0.33.0 upgrade), the resulting in-place overwrite of the cached executable hangs at \`execve\` on macOS. The MCP server never reaches \`main()\`, never prints a log line, and VS Code shows the symptom you reported:

\`\`\`
2026-05-12 00:08:18.795 [info] 接続状態: 実行中
2026-05-12 00:08:23.796 [info] Waiting for server to respond to \`initialize\` request...
... (forever)
\`\`\`

## Root cause

macOS \`amfid\` caches the kernel's code-signing decision for an executable keyed by its on-disk path. \`fs.promises.writeFile(dest, buf)\` overwrites the file but reuses the existing inode + path association, so amfid keeps the stale decision tied to the previous content hash. The new ad-hoc-signed binary fails verification, the kernel refuses the exec, dyld blocks before reaching \`main()\`, and the process spins silently.

Verified locally on macOS 14.6.1:

| Setup | Result |
|---|---|
| Overwrite cached \`ooxml-mcp-server\` with v0.33.0 binary | execve hangs, no output |
| \`rm\` cached file, then write v0.33.0 binary | runs normally, responds to \`initialize\` |
| Same v0.33.0 binary copied to a fresh filename in the same dir | works |
| A trivial hello-world Rust binary written to the same path | works |

So the path itself is fine. The *in-place overwrite* is what amfid won't accept.

## Fix

Add \`await fs.promises.rm(dest, { force: true })\` immediately before \`fs.promises.writeFile(dest, buf)\` in \`downloadBinary\`. The next exec sees a freshly-created file and amfid evaluates the new signature from scratch.

## Immediate workaround for users already on 0.33.0

Until they upgrade to 0.33.1:

1. Quit VS Code.
2. Delete the cached binary and its pin file: \`rm ~/Library/Application\\ Support/Code/User/globalStorage/silurus.office-open-xml-viewer/bin/ooxml-mcp-server*\`
3. Reopen VS Code; the extension prompts to (re)install. The download path now writes to a non-existent file, which works correctly.

## Test plan

- [x] Reproduce: \`cp v0.33.0-binary ~/Library/Application\\ Support/Code/User/globalStorage/.../bin/ooxml-mcp-server\` → hang.
- [x] Repro fix: \`rm\` + \`cp\` → works.
- [x] \`pnpm typecheck\` clean.
- [ ] Manual: on a machine already running 0.33.0 with the broken cached binary, upgrade to 0.33.1, confirm the next file-open triggers a clean reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)