### PR TITLE
chore(release): 0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.33.1 — 2026-05-12
+
+### Fixes
+
+- **vscode-extension**: unlink the cached `ooxml-mcp-server` binary before overwriting it. The version-pin fix introduced in 0.32.1 first triggered an in-place rewrite on the 0.32.x → 0.33.0 upgrade, and macOS `amfid` caches the kernel's code-signing decision for an executable by path. Writing a new ad-hoc-signed binary (different content hash) over the existing file leaves the stale decision attached; the next exec is silently refused, dyld blocks before reaching `main()`, and VS Code logs `Waiting for server to respond to "initialize" request...` forever. `fs.promises.rm(dest, { force: true })` immediately before the writeFile severs the cache association so amfid evaluates the new file from scratch.
+
+**Affected users on 0.33.0**: until you upgrade to 0.33.1, manually delete the cached binary and reload VS Code so the extension can prompt to (re)install:
+
+```
+rm ~/Library/Application\ Support/Code/User/globalStorage/silurus.office-open-xml-viewer/bin/ooxml-mcp-server*
+```
+
 ## 0.33.0 — 2026-05-11
 
 MCP-server-focused release introducing a **text-focused projection** tier alongside the rich structured tools. Renderer is unchanged from 0.32.1 (demo VRT 20/20 at 100% match).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## Summary

Fixes the in-place binary overwrite that broke MCP launch on macOS for every user upgrading from 0.32.x → 0.33.0 — symptom was VS Code logging \`Waiting for server to respond to \"initialize\" request...\` forever after the auto-redownload kicked in (PR #260).

See [v0.33.1 CHANGELOG entry](CHANGELOG.md) for the manual workaround for users still on 0.33.0.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] Reproduced the bug locally and verified that \`fs.rm\` + \`fs.writeFile\` resolves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)