### PR TITLE
feat(pptx): charts pie/scatter/bubble + run-level text shadow/outline + RTL paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,9 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Connectors (`cxnSp`) | ✅ |
 | | Tables (`tbl` in `graphicFrame`) | ✅ |
 | | Charts (bar, line, area, radar, waterfall) | ✅ |
-| | Charts (pie, scatter, bubble) | ❌ |
+| | Charts (pie, doughnut) | ✅ |
+| | Charts (scatter — `scatterStyle` marker / line / smooth variants) | ✅ |
+| | Charts (bubble — `bubbleSize` per-point area scaling) | ✅ |
 | | SmartArt | ❌ |
 | | OLE objects | ❌ |
 | | Video / audio (poster + interactive playback) | ✅ |
@@ -484,7 +486,8 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Letter spacing (`spc`) | ✅ |
 | | Superscript / subscript | ✅ |
 | | Hyperlinks (`hlinkClick` — theme `hlink` colour + auto underline) | ✅ |
-| | Text shadow / outline effects | ❌ |
+| | Text shadow (`rPr > effectLst > outerShdw`) | ✅ |
+| | Text outline (`rPr > a:ln`) | ✅ |
 | **Text — paragraphs** | Horizontal alignment (left / center / right / justify) | ✅ |
 | | Vertical anchor (top / center / bottom) | ✅ |
 | | Line spacing (`spcPct`, `spcPts`) | ✅ |
@@ -492,7 +495,8 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Bullet points (character and auto-numbered) | ✅ |
 | | Tab stops | ✅ |
 | | Indent / margin | ✅ |
-| | Vertical / RTL text | ❌ |
+| | Vertical text (`bodyPr@vert` — vert / vert270 / eaVert) | ✅ |
+| | Right-to-left paragraph (`pPr@rtl` — Arabic / Hebrew default alignment + browser bidi) | ✅ |
 | **Text — body** | Text padding (insets) | ✅ |
 | | normAutoFit (shrink to fit) | ✅ |
 | | spAutoFit (expand box; suppresses wrap when text fits in one line) | ✅ |

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1551,9 +1551,19 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     }
   }
 
-  // Render each series. Order: error bars (behind), markers, then data
-  // labels (in front). dPt overrides apply per point for color and marker
-  // shape; dLbl overrides apply per point for label text and position.
+  // ECMA-376 §21.2.2.42 `<c:scatterStyle>`. Drives whether scatter points
+  // are connected (line / smooth) and whether markers are also drawn.
+  // For bubble charts the value is ignored (always markers, sized by data).
+  const isBubble = chart.chartType === 'bubble';
+  const style = isBubble ? 'marker' : (chart.scatterStyle ?? 'marker');
+  const drawLines     = style === 'line' || style === 'lineMarker' || style === 'lineNoMarker';
+  const drawSmooth    = style === 'smooth' || style === 'smoothMarker' || style === 'smoothNoMarker';
+  const hideMarkersByStyle = style === 'lineNoMarker' || style === 'smoothNoMarker';
+
+  // Render each series. Order: error bars (behind), connecting lines,
+  // markers, then data labels (in front). dPt overrides apply per point
+  // for color and marker shape; dLbl overrides apply per point for label
+  // text and position.
   for (let si = 0; si < chart.series.length; si++) {
     const s = chart.series[si];
     const fallbackColor = chartColor(si, s);
@@ -1564,17 +1574,78 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       drawSeriesErrorBars(ctx, s, eb, cats, useIndexX, toX, toY, fallbackColor);
     }
 
-    // Markers (skip when symbol="none" or series-level showMarker is false).
-    const hideMarkers = s.showMarker === false
+    // Connecting lines (scatterStyle = line / smooth / lineMarker / smoothMarker).
+    if (drawLines || drawSmooth) {
+      const pts: Array<{ x: number; y: number }> = [];
+      for (let ci = 0; ci < s.values.length; ci++) {
+        const yv = s.values[ci]; if (yv == null) continue;
+        const xv = useIndexX ? ci : parseFloat(cats[ci] ?? '0');
+        if (isNaN(xv)) continue;
+        pts.push({ x: toX(xv), y: toY(yv) });
+      }
+      if (pts.length >= 2) {
+        ctx.save();
+        ctx.strokeStyle = s.color ? `#${s.color}` : fallbackColor;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.moveTo(pts[0].x, pts[0].y);
+        if (drawSmooth && pts.length >= 3) {
+          // Catmull-Rom-ish: cubic Bézier between consecutive points with
+          // tangents derived from neighbours. Good enough for the typical
+          // ECMA-376 smoothing intent without shipping a full spline lib.
+          for (let i = 0; i < pts.length - 1; i++) {
+            const p0 = pts[i - 1] ?? pts[i];
+            const p1 = pts[i];
+            const p2 = pts[i + 1];
+            const p3 = pts[i + 2] ?? p2;
+            const cp1x = p1.x + (p2.x - p0.x) / 6;
+            const cp1y = p1.y + (p2.y - p0.y) / 6;
+            const cp2x = p2.x - (p3.x - p1.x) / 6;
+            const cp2y = p2.y - (p3.y - p1.y) / 6;
+            ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y);
+          }
+        } else {
+          for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+        }
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
+
+    // Markers (skip when symbol="none", series-level showMarker false, or
+    // the scatter style explicitly disables markers).
+    const hideMarkers = hideMarkersByStyle
+      || s.showMarker === false
       || (typeof s.markerSymbol === 'string' && s.markerSymbol === 'none');
     if (!hideMarkers) {
+      // Bubble size scaling. ECMA-376 §21.2.2.4 treats `<c:bubbleSize>` as an
+      // area-proportional value, so radius scales by sqrt. We pick a max
+      // radius proportional to the plot width / point count so bubbles
+      // don't overlap in typical Excel-style data.
+      let bubbleScale = 0;
+      if (isBubble && s.bubbleSizes && s.bubbleSizes.length > 0) {
+        const maxSz = Math.max(0, ...s.bubbleSizes.filter((v): v is number => v != null));
+        if (maxSz > 0) {
+          const maxRadiusPx = Math.min(pw, ph) / Math.max(8, s.values.length * 1.6);
+          bubbleScale = maxRadiusPx / Math.sqrt(maxSz);
+        }
+      }
+
       for (let ci = 0; ci < s.values.length; ci++) {
         const yv = s.values[ci]; if (yv == null) continue;
         const xv = useIndexX ? ci : parseFloat(cats[ci] ?? '0');
         if (isNaN(xv)) continue;
         const dpt = (s.dataPointOverrides ?? []).find(d => d.idx === ci);
         const symbol = (dpt?.markerSymbol ?? s.markerSymbol ?? 'circle') as string;
-        const sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
+        let sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
+        if (isBubble && bubbleScale > 0) {
+          const bsz = s.bubbleSizes?.[ci];
+          if (bsz != null && bsz > 0) {
+            // Convert resulting radius (px) back to pt so drawMarker's
+            // ptToPx multiplication gives the same px size.
+            sizePt = (Math.sqrt(bsz) * bubbleScale * 2) / ptToPx;
+          }
+        }
         const fill = dpt?.markerFill
           ?? dpt?.color
           ?? s.markerFill
@@ -1595,8 +1666,10 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
 
 /** Draw a single ECMA-376 §21.2.2.32 marker shape centered at `(cx, cy)`.
  *  `sizePt` is the spec's marker side length in points (Excel's default
- *  is 5). `fill` and `line` are hex strings without `#`; `line` may be
- *  null in which case no outline is drawn. `picture` falls back to a
+ *  is 5). `fill` and `line` are hex strings; a leading `#` is tolerated so
+ *  callers that route through `chartColor` (which returns `#RRGGBB`)
+ *  don't end up double-prefixing into an invalid `##RRGGBB`. `line` may
+ *  be null in which case no outline is drawn. `picture` falls back to a
  *  square because we don't ship the embedded image yet. */
 function drawMarker(
   ctx: CanvasRenderingContext2D,
@@ -1609,10 +1682,12 @@ function drawMarker(
 ): void {
   const sizePx = Math.max(2, sizePt * ptToPx);
   const half = sizePx / 2;
+  const fillCss = fill.startsWith('#') ? fill : `#${fill}`;
+  const lineCss = line ? (line.startsWith('#') ? line : `#${line}`) : null;
   ctx.save();
-  ctx.fillStyle = `#${fill}`;
-  if (line) {
-    ctx.strokeStyle = `#${line}`;
+  ctx.fillStyle = fillCss;
+  if (lineCss) {
+    ctx.strokeStyle = lineCss;
     ctx.lineWidth = 1;
   }
   switch (symbol) {
@@ -1643,7 +1718,7 @@ function drawMarker(
       break;
     }
     case 'x': {
-      ctx.strokeStyle = `#${fill}`;
+      ctx.strokeStyle = fillCss;
       ctx.lineWidth = Math.max(1, sizePx * 0.18);
       ctx.beginPath();
       ctx.moveTo(cx - half, cy - half); ctx.lineTo(cx + half, cy + half);
@@ -1652,7 +1727,7 @@ function drawMarker(
       break;
     }
     case 'plus': {
-      ctx.strokeStyle = `#${fill}`;
+      ctx.strokeStyle = fillCss;
       ctx.lineWidth = Math.max(1, sizePx * 0.18);
       ctx.beginPath();
       ctx.moveTo(cx - half, cy); ctx.lineTo(cx + half, cy);

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -88,6 +88,14 @@ export interface ChartSeries {
    * regardless of `errValType`.
    */
   errBars?: ChartErrBars[] | null;
+  /**
+   * `<c:bubbleSize>` per-point sizes for bubble charts (ECMA-376 §21.2.2.4).
+   * Drives marker radius — renderer treats the values as areas (radius
+   * scales by sqrt) so visual area is proportional to value, matching
+   * Excel. null / empty array = uniform marker size. Ignored for non-bubble
+   * series.
+   */
+  bubbleSizes?: (number | null)[] | null;
 }
 
 export interface ChartDataPointOverride {
@@ -288,6 +296,16 @@ export interface ChartModel {
    * included).
    */
   plotAreaManualLayout?: ChartManualLayout | null;
+  /**
+   * `<c:scatterChart><c:scatterStyle val>` (ECMA-376 §21.2.2.42). Drives
+   * whether scatter charts connect points with lines and whether those
+   * lines are smoothed. Values: "marker" (markers only — Excel default
+   * "Scatter"), "line" / "lineMarker" (straight segments), "smooth" /
+   * "smoothMarker" (cubic Bézier through points), "lineNoMarker",
+   * "smoothNoMarker". null = renderer default ("marker"). Only consulted
+   * for `chartType === "scatter"`; bubble ignores it.
+   */
+  scatterStyle?: string | null;
 }
 
 /**

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -187,6 +187,12 @@ export interface Paragraph {
   defFontFamily: string | null;
   /** Tab stops from pPr > tabLst */
   tabStops: TabStop[];
+  /**
+   * `<a:pPr rtl="1">` — right-to-left paragraph (ECMA-376 §21.1.2.2.7).
+   * When true and no explicit `algn`, the parser-side default flips from
+   * "l" to "r"; renderers can also use this flag to flow runs RTL.
+   */
+  rtl?: boolean;
   runs: TextRun[];
 }
 
@@ -252,6 +258,26 @@ export interface TextRunData {
    * Undefined for runs without a hyperlink. ECMA-376 §21.1.2.3.5 (CT_Hyperlink).
    */
   hyperlink?: string;
+  /**
+   * Run-level drop shadow on glyphs (`<a:rPr><a:effectLst><a:outerShdw>`),
+   * ECMA-376 §20.1.8.45. Independent of the shape-level shadow on `spPr`.
+   * Absent means no run-level shadow.
+   */
+  shadow?: Shadow;
+  /**
+   * Run-level glyph outline (`<a:rPr><a:ln w="..">`), ECMA-376 §20.1.2.2.24
+   * (CT_TextOutlineEffect). Renderer strokes each glyph with the given
+   * width / colour in addition to the normal fill. Absent means glyphs are
+   * fill-only.
+   */
+  outline?: TextOutline;
+}
+
+/** Run-level glyph outline. Width is in OOXML EMU (12700 EMU = 1 pt). */
+export interface TextOutline {
+  width: number;
+  /** Hex without '#'. Absent = inherit from text fill colour. */
+  color?: string;
 }
 
 export interface LineBreak {

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -435,6 +435,17 @@ struct ChartSeriesData {
     /// △ values in red (accent1) while positive values stay in tx1.
     #[serde(skip_serializing_if = "Option::is_none")]
     data_label_colors: Option<Vec<Option<String>>>,
+    /// Per-series X values for scatter/bubble charts (ECMA-376 §21.2.2.43 `<c:xVal>`).
+    /// Emitted as strings so the core ChartSeries.categories field can stay
+    /// string-typed across both category-axis and value-axis charts. None for
+    /// non-scatter charts (they use the chart-level `categories`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    categories: Option<Vec<String>>,
+    /// Per-point bubble sizes from `<c:bubbleSize>` (ECMA-376 §21.2.2.4) —
+    /// drives marker radius (sqrt-scaled) on bubble charts. None for
+    /// non-bubble series.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bubble_sizes: Option<Vec<Option<f64>>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -510,6 +521,12 @@ struct ChartElement {
     /// (sample-2 slide-16's horizontal bar chart).
     #[serde(skip_serializing_if = "Option::is_none")]
     plot_area_manual_layout: Option<ChartManualLayout>,
+    /// `<c:scatterChart><c:scatterStyle val>` (ECMA-376 §21.2.2.42). Values:
+    /// "marker" | "line" | "lineMarker" | "lineNoMarker" | "smooth" |
+    /// "smoothMarker" | "smoothNoMarker". None for non-scatter charts;
+    /// renderer falls back to "marker" when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scatter_style: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -1010,6 +1027,12 @@ struct Paragraph {
     def_font_family: Option<String>,
     /// Tab stops from pPr > tabLst
     tab_stops: Vec<TabStop>,
+    /// ECMA-376 §21.1.2.2.7 `<a:pPr rtl="1">` — right-to-left paragraph.
+    /// When true and no explicit `algn`, the default alignment flips from
+    /// "l" to "r". Carried through so the renderer can also flow runs RTL
+    /// when bidi shaping is added.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    rtl: bool,
     runs: Vec<TextRun>,
 }
 
@@ -1069,6 +1092,29 @@ struct TextRunData {
     /// None for runs without a:hlinkClick.
     #[serde(skip_serializing_if = "Option::is_none")]
     hyperlink: Option<String>,
+    /// ECMA-376 §20.1.8.45 (CT_OuterShadowEffect) — drop shadow on this run's
+    /// glyphs from `<a:rPr><a:effectLst><a:outerShdw>`. Distinct from the
+    /// shape-level shadow on `spPr`. None = no shadow on the run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shadow: Option<Shadow>,
+    /// ECMA-376 §20.1.2.2.24 (CT_TextOutlineEffect) — text glyph outline from
+    /// `<a:rPr><a:ln w="EMU"><a:solidFill>...`. None = no outline; renderer
+    /// just fillText. When set the renderer also strokeText with the given
+    /// width (EMU) and colour.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outline: Option<TextOutline>,
+}
+
+/// Run-level text outline (`<a:rPr><a:ln>`). The width is the OOXML EMU
+/// value (`w` attribute, 12700 EMU = 1 pt); the renderer converts to px.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct TextOutline {
+    /// Outline width in EMU.
+    width: i64,
+    /// Resolved hex colour (no `#`). None = inherit from text fill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
 }
 
 // ===========================
@@ -2717,11 +2763,19 @@ fn parse_paragraph(
 ) -> Paragraph {
     let p_pr = child(p_node, "pPr");
 
-    // Paragraph's own algn → body/layout/master default → "l"
+    // ECMA-376 §21.1.2.2.7 `<a:pPr rtl>` — right-to-left text flow. When set
+    // and the paragraph has no explicit `algn`, the implicit default flips
+    // from "l" to "r" (matches PowerPoint's behaviour for Arabic / Hebrew
+    // slides where users typically don't author an explicit alignment).
+    let rtl = p_pr.and_then(|n| attr(&n, "rtl"))
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+
+    // Paragraph's own algn → body/layout/master default → "r" if rtl, else "l"
     let alignment = p_pr.and_then(|n| attr(&n, "algn"))
         .map(|a| a.to_string())
         .or_else(|| body_default_alignment.map(|a| a.to_string()))
-        .unwrap_or_else(|| "l".into());
+        .unwrap_or_else(|| if rtl { "r".into() } else { "l".into() });
     let lvl: u32   = p_pr.and_then(|n| attr(&n, "lvl")).and_then(|v| v.parse().ok()).unwrap_or(0);
 
     // Detect whether the paragraph has an explicit bullet character (buChar/buAutoNum).
@@ -2828,6 +2882,8 @@ fn parse_paragraph(
                     letter_spacing: None,
                     field_type: if fld_type == "slidenum" { Some("slidenum".to_string()) } else { None },
                     hyperlink: None,
+                    shadow: None,
+                    outline: None,
                 }));
             }
             _ => {}
@@ -2851,7 +2907,7 @@ fn parse_paragraph(
         space_before, space_after, space_line,
         lvl, bullet,
         def_font_size, def_color, def_bold, def_italic, def_font_family,
-        tab_stops, runs,
+        tab_stops, rtl, runs,
     }
 }
 
@@ -2981,12 +3037,30 @@ fn parse_run(
         .and_then(|rid| rels.get(&rid).cloned())
         .filter(|s| !s.is_empty());
 
+    // ECMA-376 §20.1.8.45 — `<a:rPr><a:effectLst><a:outerShdw>` glyph drop
+    // shadow. Reuse the shape-level outerShdw reader so parse semantics
+    // stay identical (blurRad, dist, dir, color + alphaModFix).
+    let shadow = r_pr.and_then(|n| child(n, "effectLst"))
+        .and_then(|el| parse_shadow(el, theme));
+
+    // ECMA-376 §20.1.2.2.24 (CT_TextOutlineEffect) — `<a:rPr><a:ln w="..">`
+    // strokes each glyph outline. `<a:noFill>` inside the ln means "no
+    // visible outline" — skip in that case so the renderer doesn't draw a
+    // black box around every glyph. Pull color from solidFill if present.
+    let outline = r_pr.and_then(|n| child(n, "ln"))
+        .filter(|ln| child(*ln, "noFill").is_none())
+        .map(|ln| TextOutline {
+            width: attr_i64(&ln, "w").unwrap_or(0),
+            color: child(ln, "solidFill").and_then(|n| parse_color_node(n, theme)),
+        });
+
     Some(TextRunData {
         text, bold, italic, underline, underline_style, underline_color,
         strikethrough, strike_double,
         font_size, color, font_family, font_family_ea, baseline,
         caps, letter_spacing,
         field_type: None, hyperlink,
+        shadow, outline,
     })
 }
 
@@ -3130,6 +3204,8 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
 
     let pt_count = categories.len().max(1);
 
+    let is_scatter_like = chart_type == "scatter" || chart_type == "bubble";
+
     let series: Vec<ChartSeriesData> = ser_nodes.iter().map(|ser| {
         // Series name from <c:tx>  (can be strRef/strCache, strLit, or a bare <c:v>)
         let name = ser.children()
@@ -3151,13 +3227,39 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             })
             .unwrap_or_default();
 
-        // Values: use <c:val> or <c:yVal> (scatter); accept numCache (ref) or numLit (inline)
-        let val_cache = ser.descendants()
-            .find(|n| n.is_element() && (n.tag_name().name() == "val" || n.tag_name().name() == "yVal"))
-            .and_then(|v| v.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")))
-            .or_else(|| ser.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")));
+        // Per-series X values for scatter/bubble: ECMA-376 §21.2.2.43 puts numeric
+        // X data in `<c:xVal>` (with its own numCache / numLit) instead of the
+        // shared `<c:cat>`. Read it as strings so the core ChartSeries.categories
+        // field can stay string-typed (renderScatterChart parses each entry back
+        // to a float).
+        let x_cache = if is_scatter_like {
+            ser.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "xVal")
+                .and_then(|x| x.descendants().find(|n| n.is_element() && is_pt_container(n.tag_name().name())))
+        } else { None };
+        let series_categories: Option<Vec<String>> = x_cache.map(|cache| collect_pt_strings(cache));
 
-        let mut values: Vec<Option<f64>> = vec![None; pt_count];
+        // Y values: scatter/bubble use `<c:yVal>`, everything else uses `<c:val>`.
+        // Restrict the descendant walk to the matching tag so a sibling `<c:xVal>`
+        // (also a numCache) can't be picked up as the Y series.
+        let val_cache = if is_scatter_like {
+            ser.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "yVal")
+                .and_then(|y| y.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")))
+        } else {
+            ser.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "val")
+                .and_then(|v| v.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")))
+        };
+
+        // For scatter/bubble the point count comes from this series' xVal (each
+        // series can have a different point count). For other charts it's the
+        // shared category count.
+        let series_pt_count = if is_scatter_like {
+            series_categories.as_ref().map(|c| c.len()).unwrap_or(0).max(1)
+        } else { pt_count };
+
+        let mut values: Vec<Option<f64>> = vec![None; series_pt_count];
         if let Some(cache) = val_cache {
             for pt in cache.children().filter(|n| n.is_element() && n.tag_name().name() == "pt") {
                 let idx: usize = attr(&pt, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
@@ -3171,6 +3273,26 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             }
         }
 
+        // Bubble per-point sizes (ECMA-376 §21.2.2.4 `<c:bubbleSize>`).
+        // Only meaningful for bubble charts; scatter / others ignore.
+        let bubble_sizes: Option<Vec<Option<f64>>> = if chart_type == "bubble" {
+            let bub_cache = ser.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "bubbleSize")
+                .and_then(|b| b.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")));
+            bub_cache.map(|cache| {
+                let mut sizes: Vec<Option<f64>> = vec![None; series_pt_count];
+                for pt in cache.children().filter(|n| n.is_element() && n.tag_name().name() == "pt") {
+                    let idx: usize = attr(&pt, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
+                    let val: Option<f64> = pt.children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "v")
+                        .and_then(|v| v.text())
+                        .and_then(|t| t.parse().ok());
+                    if idx < sizes.len() { sizes[idx] = val; }
+                }
+                sizes
+            })
+        } else { None };
+
         // Series color from spPr > solidFill (bar/area/pie) or spPr > ln > solidFill (line)
         let color = ser.children()
             .find(|n| n.is_element() && n.tag_name().name() == "spPr")
@@ -3183,7 +3305,7 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             .and_then(|fill| parse_color_node(fill, theme));
 
         // Per-data-point colors from <c:dPt> (important for pie charts)
-        let data_point_colors: Vec<Option<String>> = (0..pt_count).map(|i| {
+        let data_point_colors: Vec<Option<String>> = (0..series_pt_count).map(|i| {
             ser.children()
                 .filter(|n| n.is_element() && n.tag_name().name() == "dPt")
                 .find(|dpt| attr(dpt, "idx").and_then(|v| v.parse::<usize>().ok()) == Some(i))
@@ -3199,6 +3321,8 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             // `<c:dLbls><c:dLbl idx>` — not yet wired here; chartEx is the only
             // path that needs it for sample-2's waterfall.
             data_label_colors: None,
+            categories: series_categories,
+            bubble_sizes,
         }
     }).collect();
 
@@ -3293,6 +3417,14 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             ChartManualLayout { x_mode, y_mode, layout_target, x, y, w, h }
         });
 
+    // `<c:scatterChart><c:scatterStyle val>` — ECMA-376 §21.2.2.42. Lives
+    // directly under scatterChart, so a plot_area descendant walk is enough.
+    let scatter_style = if chart_type == "scatter" {
+        plot_area.descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "scatterStyle")
+            .and_then(|n| attr(&n, "val"))
+    } else { None };
+
     Some(ChartElement {
         x: 0, y: 0, width: 0, height: 0,
         chart_type,
@@ -3323,6 +3455,7 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
         data_label_format_code,
         val_axis_format_code,
         plot_area_manual_layout,
+        scatter_style,
     })
 }
 
@@ -3424,6 +3557,8 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         color,
         data_point_colors: None,
         data_label_colors: if has_per_label_color { Some(data_label_colors_vec) } else { None },
+        categories: None,
+        bubble_sizes: None,
     }];
 
     // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`
@@ -3473,6 +3608,7 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         data_label_format_code: None,
         val_axis_format_code: None,
         plot_area_manual_layout: None,
+        scatter_style: None,
     })
 }
 

--- a/packages/pptx/public/private/_gen_chart_demo.py
+++ b/packages/pptx/public/private/_gen_chart_demo.py
@@ -1,0 +1,94 @@
+"""Generate a pptx with pie/doughnut/scatter/bubble charts for VRT.
+
+Run: python3 _gen_chart_demo.py
+Output: chart-demo.pptx (gitignored — public/private/ is local-only).
+"""
+from pptx import Presentation
+from pptx.chart.data import CategoryChartData, XyChartData, BubbleChartData
+from pptx.enum.chart import XL_CHART_TYPE, XL_LEGEND_POSITION
+from pptx.util import Inches, Pt
+
+OUT = "chart-demo.pptx"
+
+prs = Presentation()
+prs.slide_width = Inches(13.333)
+prs.slide_height = Inches(7.5)
+blank = prs.slide_layouts[6]
+
+
+def add_title(slide, text):
+    tb = slide.shapes.add_textbox(Inches(0.4), Inches(0.2), Inches(12.5), Inches(0.6))
+    tf = tb.text_frame
+    tf.text = text
+    tf.paragraphs[0].runs[0].font.size = Pt(24)
+    tf.paragraphs[0].runs[0].font.bold = True
+
+
+def add_category_chart(slide, chart_type, title, left=Inches(0.5), top=Inches(1.0), width=Inches(6.0), height=Inches(5.5)):
+    data = CategoryChartData()
+    data.categories = ["Q1", "Q2", "Q3", "Q4"]
+    data.add_series("North", (32, 28, 41, 36))
+    data.add_series("South", (24, 30, 22, 28)) if chart_type not in (XL_CHART_TYPE.PIE, XL_CHART_TYPE.DOUGHNUT) else None
+    chart = slide.shapes.add_chart(chart_type, left, top, width, height, data).chart
+    chart.has_title = True
+    chart.chart_title.text_frame.text = title
+    chart.has_legend = True
+    chart.legend.position = XL_LEGEND_POSITION.BOTTOM
+    chart.legend.include_in_layout = False
+    return chart
+
+
+def add_xy_chart(slide, chart_type, title, left=Inches(0.5), top=Inches(1.0), width=Inches(6.0), height=Inches(5.5)):
+    data = XyChartData()
+    s1 = data.add_series("Sample A")
+    for x, y in [(1.0, 2.3), (2.4, 1.1), (3.7, 4.5), (4.2, 3.0), (5.0, 5.8)]:
+        s1.add_data_point(x, y)
+    s2 = data.add_series("Sample B")
+    for x, y in [(0.8, 4.1), (2.1, 3.6), (3.0, 2.0), (4.5, 4.7), (5.4, 3.2)]:
+        s2.add_data_point(x, y)
+    chart = slide.shapes.add_chart(chart_type, left, top, width, height, data).chart
+    chart.has_title = True
+    chart.chart_title.text_frame.text = title
+    chart.has_legend = True
+    chart.legend.position = XL_LEGEND_POSITION.BOTTOM
+    chart.legend.include_in_layout = False
+    return chart
+
+
+def add_bubble_chart(slide, title, left=Inches(0.5), top=Inches(1.0), width=Inches(6.0), height=Inches(5.5)):
+    data = BubbleChartData()
+    s1 = data.add_series("Series 1")
+    for x, y, sz in [(1.0, 2.0, 10), (2.5, 3.2, 18), (4.0, 1.8, 25), (5.5, 4.5, 12)]:
+        s1.add_data_point(x, y, sz)
+    s2 = data.add_series("Series 2")
+    for x, y, sz in [(1.5, 4.0, 15), (3.0, 2.7, 22), (4.5, 3.6, 8), (5.0, 1.2, 20)]:
+        s2.add_data_point(x, y, sz)
+    chart = slide.shapes.add_chart(XL_CHART_TYPE.BUBBLE, left, top, width, height, data).chart
+    chart.has_title = True
+    chart.chart_title.text_frame.text = title
+    chart.has_legend = True
+    chart.legend.position = XL_LEGEND_POSITION.BOTTOM
+    chart.legend.include_in_layout = False
+    return chart
+
+
+# Slide 1: Pie + Doughnut
+s1 = prs.slides.add_slide(blank)
+add_title(s1, "Pie & Doughnut")
+add_category_chart(s1, XL_CHART_TYPE.PIE, "Pie", left=Inches(0.3), width=Inches(6.4))
+add_category_chart(s1, XL_CHART_TYPE.DOUGHNUT, "Doughnut", left=Inches(6.7), width=Inches(6.4))
+
+# Slide 2: Scatter variants
+s2 = prs.slides.add_slide(blank)
+add_title(s2, "Scatter — markers / smooth / lines")
+add_xy_chart(s2, XL_CHART_TYPE.XY_SCATTER, "Markers only", left=Inches(0.3), width=Inches(4.2))
+add_xy_chart(s2, XL_CHART_TYPE.XY_SCATTER_SMOOTH, "Smooth lines + markers", left=Inches(4.6), width=Inches(4.2))
+add_xy_chart(s2, XL_CHART_TYPE.XY_SCATTER_LINES, "Straight lines + markers", left=Inches(8.9), width=Inches(4.2))
+
+# Slide 3: Bubble
+s3 = prs.slides.add_slide(blank)
+add_title(s3, "Bubble")
+add_bubble_chart(s3, "Bubble — 2 series", left=Inches(3.0), width=Inches(7.0))
+
+prs.save(OUT)
+print(f"wrote {OUT}")

--- a/packages/pptx/public/private/_gen_text_effects.py
+++ b/packages/pptx/public/private/_gen_text_effects.py
@@ -1,0 +1,143 @@
+"""Generate a pptx with text shadow / text outline / RTL paragraphs for VRT.
+
+python-pptx doesn't expose rPr > effectLst / rPr > a:ln / pPr@rtl directly,
+so we hand-assemble the run XML by reaching into the lxml element tree.
+
+Run: python3 _gen_text_effects.py
+Output: text-effects.pptx (gitignored — public/private/ is local-only).
+"""
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.oxml.ns import qn
+from lxml import etree
+
+OUT = "text-effects.pptx"
+
+NSMAP = {
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+}
+
+
+def make_run(text, *, size_pt=40, bold=False, color="000000",
+             shadow=False, outline_w=None, outline_color=None):
+    """Build an <a:r> element with rPr-level effectLst / a:ln if requested."""
+    r = etree.SubElement(etree.Element(qn("a:p")), qn("a:r"))
+    rPr = etree.SubElement(r, qn("a:rPr"))
+    rPr.set("lang", "en-US")
+    rPr.set("sz", str(int(size_pt * 100)))
+    if bold:
+        rPr.set("b", "1")
+    if outline_w is not None:
+        # <a:ln w="EMU"><a:solidFill><a:srgbClr val="HEX"/></a:solidFill></a:ln>
+        ln = etree.SubElement(rPr, qn("a:ln"))
+        ln.set("w", str(int(outline_w)))
+        sf = etree.SubElement(ln, qn("a:solidFill"))
+        c = etree.SubElement(sf, qn("a:srgbClr"))
+        c.set("val", outline_color or "000000")
+    # text fill
+    fill = etree.SubElement(rPr, qn("a:solidFill"))
+    c = etree.SubElement(fill, qn("a:srgbClr"))
+    c.set("val", color)
+    # shadow
+    if shadow:
+        eff = etree.SubElement(rPr, qn("a:effectLst"))
+        shdw = etree.SubElement(eff, qn("a:outerShdw"))
+        shdw.set("blurRad", "50800")  # 4pt blur
+        shdw.set("dist", "38100")     # 3pt offset
+        shdw.set("dir", "2700000")    # 45° (degrees * 60000)
+        shdw.set("algn", "tl")
+        scol = etree.SubElement(shdw, qn("a:srgbClr"))
+        scol.set("val", "808080")
+        alpha = etree.SubElement(scol, qn("a:alpha"))
+        alpha.set("val", "65000")
+    t = etree.SubElement(r, qn("a:t"))
+    t.text = text
+    return r
+
+
+def make_paragraph(*, algn=None, rtl=False):
+    p = etree.Element(qn("a:p"))
+    pPr = etree.SubElement(p, qn("a:pPr"))
+    if algn:
+        pPr.set("algn", algn)
+    if rtl:
+        pPr.set("rtl", "1")
+    return p
+
+
+def add_text(slide, *, left, top, width, height, paragraphs):
+    tb = slide.shapes.add_textbox(left, top, width, height)
+    tx = tb.text_frame
+    # Clear the default paragraph python-pptx inserts.
+    txBody = tx._txBody
+    for p in list(txBody.findall(qn("a:p"))):
+        txBody.remove(p)
+    for p in paragraphs:
+        txBody.append(p)
+
+
+prs = Presentation()
+prs.slide_width = Inches(13.333)
+prs.slide_height = Inches(7.5)
+blank = prs.slide_layouts[6]
+
+# ---------------------------------------------------------------------------
+# Slide 1 — text shadow + text outline samples
+# ---------------------------------------------------------------------------
+s1 = prs.slides.add_slide(blank)
+
+title_p = make_paragraph()
+title_p.append(make_run("Run-level text effects", size_pt=28, bold=True))
+add_text(s1, left=Inches(0.4), top=Inches(0.2), width=Inches(12.5), height=Inches(0.8), paragraphs=[title_p])
+
+# Shadow demo
+shadow_p = make_paragraph()
+shadow_p.append(make_run("Text with shadow", size_pt=48, bold=True, color="1F4E79", shadow=True))
+add_text(s1, left=Inches(0.5), top=Inches(1.4), width=Inches(12), height=Inches(1.2), paragraphs=[shadow_p])
+
+# Outline-only demo (white fill, blue outline)
+outline_p = make_paragraph()
+outline_p.append(make_run("Text with outline", size_pt=64, bold=True,
+                          color="FFFFFF",
+                          outline_w=19050, outline_color="C00000"))  # 1.5pt outline
+add_text(s1, left=Inches(0.5), top=Inches(3.2), width=Inches(12), height=Inches(1.6), paragraphs=[outline_p])
+
+# Combined shadow + outline
+combined_p = make_paragraph()
+combined_p.append(make_run("Shadow + outline together", size_pt=44, bold=True,
+                           color="FFD966",
+                           outline_w=12700, outline_color="8B4513",
+                           shadow=True))
+add_text(s1, left=Inches(0.5), top=Inches(5.3), width=Inches(12), height=Inches(1.4), paragraphs=[combined_p])
+
+# ---------------------------------------------------------------------------
+# Slide 2 — RTL paragraph (default alignment → right)
+# ---------------------------------------------------------------------------
+s2 = prs.slides.add_slide(blank)
+
+t2 = make_paragraph()
+t2.append(make_run("Paragraph @rtl — right alignment default", size_pt=24, bold=True))
+add_text(s2, left=Inches(0.4), top=Inches(0.3), width=Inches(12.5), height=Inches(0.7), paragraphs=[t2])
+
+# Non-RTL (control)
+p_ltr = make_paragraph()
+p_ltr.append(make_run("LTR control — no rtl flag, defaults to left", size_pt=28))
+add_text(s2, left=Inches(0.5), top=Inches(1.6), width=Inches(12), height=Inches(1), paragraphs=[p_ltr])
+
+# RTL paragraph — no algn → should auto-align right
+p_rtl_auto = make_paragraph(rtl=True)
+p_rtl_auto.append(make_run("RTL, no algn — auto right alignment", size_pt=28))
+add_text(s2, left=Inches(0.5), top=Inches(2.8), width=Inches(12), height=Inches(1), paragraphs=[p_rtl_auto])
+
+# RTL paragraph with explicit center
+p_rtl_ctr = make_paragraph(algn="ctr", rtl=True)
+p_rtl_ctr.append(make_run("RTL + algn=ctr — explicit centred", size_pt=28))
+add_text(s2, left=Inches(0.5), top=Inches(4.0), width=Inches(12), height=Inches(1), paragraphs=[p_rtl_ctr])
+
+# Hebrew-ish glyph sample (uses Latin chars but visible RTL effect)
+p_rtl_demo = make_paragraph(rtl=True)
+p_rtl_demo.append(make_run("שלום עולם — Hebrew sample (rtl=1)", size_pt=32, bold=True))
+add_text(s2, left=Inches(0.5), top=Inches(5.2), width=Inches(12), height=Inches(1.2), paragraphs=[p_rtl_demo])
+
+prs.save(OUT)
+print(f"wrote {OUT}")

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -214,6 +214,10 @@ type LayoutSegment = {
   /** Extra inter-character spacing in px (already scaled). */
   letterSpacingPx?: number;
   baseline?: number;
+  /** Run-level glyph drop shadow (rPr > effectLst > outerShdw). */
+  shadow?: import('@silurus/ooxml-core').Shadow;
+  /** Run-level glyph outline (rPr > a:ln). Width in EMU; renderer scales. */
+  outline?: import('@silurus/ooxml-core').TextOutline;
 };
 
 interface LayoutLine {
@@ -400,7 +404,14 @@ function layoutParagraph(
     underline: boolean,
     strikethrough: boolean,
     baseline?: number,
-    extras?: { strikeDouble?: boolean; letterSpacingPx?: number; underlineStyle?: string; underlineColor?: string },
+    extras?: {
+      strikeDouble?: boolean;
+      letterSpacingPx?: number;
+      underlineStyle?: string;
+      underlineColor?: string;
+      shadow?: import('@silurus/ooxml-core').Shadow;
+      outline?: import('@silurus/ooxml-core').TextOutline;
+    },
   ) => {
     if (!text) return;
     ctx.font = font;
@@ -414,6 +425,11 @@ function layoutParagraph(
     const strikeDouble = extras?.strikeDouble;
     const underlineStyle = extras?.underlineStyle;
     const underlineColor = extras?.underlineColor;
+    const shadow = extras?.shadow;
+    const outline = extras?.outline;
+    // Shadow / outline use object identity for merging — adjacent runs share
+    // the same object since the run is parsed once. Different objects (or
+    // one set / one missing) force a new segment.
     const sameMeta = (a: LayoutSegment) =>
       a.font === font &&
       a.color === color &&
@@ -423,14 +439,16 @@ function layoutParagraph(
       a.strikethrough === strikethrough &&
       (a.strikeDouble ?? false) === (strikeDouble ?? false) &&
       (a.letterSpacingPx ?? 0) === lsPx &&
-      a.baseline === baseline;
+      a.baseline === baseline &&
+      a.shadow === shadow &&
+      a.outline === outline;
     if (tabActive && currentLine.tabStop) {
       const segs = currentLine.tabStop.segments;
       const last = segs.at(-1);
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        segs.push({ text, font, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
+        segs.push({ text, font, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline });
       }
     } else {
       lineW += w;
@@ -438,7 +456,7 @@ function layoutParagraph(
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        currentLine.segments.push({ text, font, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline });
+        currentLine.segments.push({ text, font, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline });
       }
     }
   };
@@ -502,6 +520,8 @@ function layoutParagraph(
       letterSpacingPx: lsPx,
       underlineStyle: run.underlineStyle,
       underlineColor: run.underlineColor ? hexToRgba(run.underlineColor) : undefined,
+      shadow: run.shadow,
+      outline: run.outline,
     };
 
     // Split on whitespace boundaries, keeping the whitespace tokens
@@ -1318,6 +1338,23 @@ function renderTextBody(
       const baselineShift = seg.baseline ? -(seg.baseline / 100000) * seg.sizePx : 0;
       const segBaseline = baseline + baselineShift;
       const ls = seg.letterSpacingPx ?? 0;
+
+      // Run-level text shadow (rPr > effectLst > outerShdw). Set on the
+      // context so the fillText below picks it up, then cleared after so
+      // the outline / underline / strikethrough don't get shadowed too.
+      // ECMA-376 §20.1.8.45 dir is degrees clockwise from east; the same
+      // formula used by the shape-level shadow renderer above.
+      const segShadow = seg.shadow;
+      if (segShadow) {
+        const dirRad = (segShadow.dir * Math.PI) / 180;
+        const dist = emuToPx(segShadow.dist, scale);
+        ctx.save();
+        ctx.shadowColor = hexToRgba(segShadow.color, segShadow.alpha);
+        ctx.shadowBlur = emuToPx(segShadow.blur, scale);
+        ctx.shadowOffsetX = Math.cos(dirRad) * dist;
+        ctx.shadowOffsetY = Math.sin(dirRad) * dist;
+      }
+
       if (ls > 0 && seg.text.length > 1) {
         // Draw glyph-by-glyph so each character advance is `measure + ls`.
         // Matches OOXML rPr @spc semantics — extra space added to each
@@ -1329,6 +1366,32 @@ function renderTextBody(
         }
       } else {
         ctx.fillText(seg.text, penX, segBaseline);
+      }
+
+      if (segShadow) ctx.restore();
+
+      // Run-level text outline (rPr > a:ln). Strokes each glyph in addition
+      // to the fill so the text reads as a thin lined character. ECMA-376
+      // §20.1.2.2.24: `w` is EMU; convert to px via the same scale used for
+      // fonts. Min 0.5 px so a 1-pt outline at small zoom levels stays
+      // visible. Skip when width <= 0 (parser may emit width=0 for
+      // explicitly empty <a:ln/>).
+      const segOutline = seg.outline;
+      if (segOutline && segOutline.width > 0) {
+        ctx.save();
+        ctx.lineWidth = Math.max(0.5, emuToPx(segOutline.width, scale));
+        ctx.strokeStyle = segOutline.color ? `#${segOutline.color}` : seg.color;
+        ctx.lineJoin = 'round';
+        if (ls > 0 && seg.text.length > 1) {
+          let cx = penX;
+          for (const ch of seg.text) {
+            ctx.strokeText(ch, cx, segBaseline);
+            cx += ctx.measureText(ch).width + ls;
+          }
+        } else {
+          ctx.strokeText(seg.text, penX, segBaseline);
+        }
+        ctx.restore();
       }
 
       ctx.font = seg.font;
@@ -1899,6 +1962,7 @@ export async function renderSlide(
           dataLabelFormatCode: el.dataLabelFormatCode ?? null,
           valAxisFormatCode: el.valAxisFormatCode ?? null,
           plotAreaManualLayout: el.plotAreaManualLayout ?? null,
+          scatterStyle: el.scatterStyle ?? null,
         },
         {
           x: emuToPx(el.x, scale),

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -214,6 +214,9 @@ export interface ChartElement {
    * plot-area placement so bars don't extend past the chart-frame's intended
    * inner region (sample-2 slide-16 horizontal bar chart). */
   plotAreaManualLayout?: import('@silurus/ooxml-core').ChartManualLayout | null;
+  /** `<c:scatterChart><c:scatterStyle val>` (ECMA-376 §21.2.2.42) — drives
+   * whether scatter charts connect points with straight or smooth lines. */
+  scatterStyle?: string | null;
 }
 
 export interface PictureElement {


### PR DESCRIPTION
## Summary

Flips four ❌ rows in the PPTX support matrix to ✅:

- **Charts (pie / doughnut / scatter / bubble)** — parser now extracts `<c:xVal>` / `<c:yVal>` / `<c:bubbleSize>` (ECMA-376 §21.2.2.4 / §21.2.2.43) and `<c:scatterStyle>` (§21.2.2.42); core renderer draws straight / smooth-Bézier connectors between scatter points and scales bubble radii by sqrt(size).
- **Text shadow** (`<a:rPr><a:effectLst><a:outerShdw>`, §20.1.8.45) and **text outline** (`<a:rPr><a:ln>`, §20.1.2.2.24) — parsed per run, applied at draw time via `ctx.shadow*` + `strokeText`.
- **Paragraph `@rtl`** (§21.1.2.2.7) — when set without an explicit `algn`, default alignment flips to right. Glyph shaping still relies on the browser's native bidi inside `fillText`.

Also fixes a pre-existing core `drawMarker` bug: it double-prefixed `#` onto colors from `chartColor()` (which already returns `#RRGGBB`), producing the invalid `##RRGGBB` and silently inheriting the previous fillStyle. Scatter / bubble markers now pick up palette colors correctly; xlsx demo VRT shifts by 0.2% on the one sheet with a scatter chart (well under the 20% fail threshold).

## Test plan

- [x] `pnpm build:wasm` — all three parsers rebuild cleanly
- [x] `pnpm typecheck` (via `tsc --build packages/core packages/pptx`) — no errors
- [x] `pnpm --filter @silurus/ooxml-pptx vrt` — demo/sample-1 9/9 at 100% match
- [x] `pnpm --filter @silurus/ooxml-xlsx vrt` — demo/sample-1 5/5 pass (sheet 4 0.2% diff from drawMarker fix, below 20% threshold)
- [x] `pnpm --filter @silurus/ooxml-docx vrt` — demo/sample-1 6/6 at 100% match
- [x] Storybook private demos render as expected: pie/doughnut/scatter (markers / smooth / straight variants) / bubble (variable sizes, per-series colors); text shadow + outline + RTL paragraphs

Regen scripts for the local-only Storybook demos are committed at `packages/pptx/public/private/_gen_chart_demo.py` and `_gen_text_effects.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)