### PR TITLE
chore(release): 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.34.0 — 2026-05-16
+
+Single xlsx-focused change. pptx / docx renderers are byte-identical to 0.33.2, and the xlsx grid render with no active selection is unchanged — header colors only diverge once the viewer holds a selection. No README screenshot updates because of this.
+
+### Features
+
+- **xlsx**: `XlsxViewer` now highlights the row / column headers that the current selection belongs to, matching Excel's two-tier indicator. Cell selection (`cells` mode) paints the row & column headers of the selected range in a slightly darker grey (`#e8eaed`). Whole-row / whole-column selection (`rows` / `cols` mode) paints the selection-axis headers in light blue (`#caddf6`) with a blue border (`#5b9bd5`) and the other axis in the grey accent. Select-all paints every header in light blue. Two new `RenderViewportOptions` fields (`selectedRowRange` / `selectedColRange`, each carrying `start` / `end` / `strong`) flow from the viewer through `XlsxWorkbook.renderViewport` into `renderer.renderHeaders`, where `drawColHeader` / `drawRowHeader` pick fill and stroke colors per index. Canvas re-render is now triggered alongside every `updateSelectionOverlay()` call so headers repaint in lock-step with the overlay border.
+
 ## 0.33.2 — 2026-05-12
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Pivot tables | ❌ Not planned |
 | | Data validation / comments | ❌ Not planned |
 | **Interaction** | Cell selection (single / range / row / column / all) | ✅ |
+| | Excel-style row / column header highlight on selection | ✅ |
 | | Shift+click to extend, Ctrl+C to copy as TSV | ✅ |
 | | Text selection inside cells (transparent overlay) | ✅ |
 | | `onSelectionChange` callback, `getCellAt(x, y)` API | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.33.2",
+  "version": "0.34.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.33.2",
+  "version": "0.34.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.33.2",
+  "version": "0.34.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.33.2",
+  "version": "0.34.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.33.2",
+  "version": "0.34.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.33.2",
+  "version": "0.34.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3507,6 +3507,8 @@ export function renderViewport(
     frozenColWidths, frozenRowHeights,
     frozenW, frozenH,
     hw, hh, cs, dpr,
+    opts.selectedRowRange ?? null,
+    opts.selectedColRange ?? null,
   );
 
   // ── Freeze pane separator lines ──────────────────────────────
@@ -3545,10 +3547,32 @@ function renderHeaders(
   frozenColWidths: number[], frozenRowHeights: number[],
   frozenW: number, frozenH: number,
   hw: number, hh: number, cs: number, dpr: number,
+  selectedRowRange: { start: number; end: number; strong: boolean } | null,
+  selectedColRange: { start: number; end: number; strong: boolean } | null,
 ): void {
   const HEADER_BG = '#f8f9fa';
+  const HEADER_BG_SUBTLE = '#e8eaed';
+  const HEADER_BG_STRONG = '#caddf6';
   const HEADER_BORDER = '#c8ccd0';
+  const HEADER_BORDER_STRONG = '#5b9bd5';
   const HEADER_TEXT = '#444';
+
+  const colBg = (col: number): string => {
+    if (!selectedColRange || col < selectedColRange.start || col > selectedColRange.end) return HEADER_BG;
+    return selectedColRange.strong ? HEADER_BG_STRONG : HEADER_BG_SUBTLE;
+  };
+  const colBorder = (col: number): string => {
+    if (!selectedColRange || col < selectedColRange.start || col > selectedColRange.end) return HEADER_BORDER;
+    return selectedColRange.strong ? HEADER_BORDER_STRONG : HEADER_BORDER;
+  };
+  const rowBg = (row: number): string => {
+    if (!selectedRowRange || row < selectedRowRange.start || row > selectedRowRange.end) return HEADER_BG;
+    return selectedRowRange.strong ? HEADER_BG_STRONG : HEADER_BG_SUBTLE;
+  };
+  const rowBorder = (row: number): string => {
+    if (!selectedRowRange || row < selectedRowRange.start || row > selectedRowRange.end) return HEADER_BORDER;
+    return selectedRowRange.strong ? HEADER_BORDER_STRONG : HEADER_BORDER;
+  };
   const headerFontSize = Math.max(1, Math.round(11 * cs));
   const HEADER_FONT = `${headerFontSize}px ${DEFAULT_FONT_FAMILY}`;
   const scrollAreaX = hw + frozenW;
@@ -3574,9 +3598,9 @@ function renderHeaders(
   // Borders are drawn INSET (-hp) so that the next cell's fillRect (which starts at cx+cw)
   // never overwrites the current cell's right/bottom border line.
   const drawColHeader = (col: number, cx: number, cw: number) => {
-    ctx.fillStyle = HEADER_BG;
+    ctx.fillStyle = colBg(col);
     ctx.fillRect(cx, 0, cw, hh);
-    ctx.strokeStyle = HEADER_BORDER;
+    ctx.strokeStyle = colBorder(col);
     ctx.lineWidth = 0.5;
     ctx.beginPath();
     ctx.moveTo(cx + cw - hp, 0);     ctx.lineTo(cx + cw - hp, hh);  // right (inset)
@@ -3592,9 +3616,9 @@ function renderHeaders(
   // Helper: draw one row header cell.
   // Borders drawn inset so adjacent cell's fill never overwrites them.
   const drawRowHeader = (row: number, cy: number, ch: number) => {
-    ctx.fillStyle = HEADER_BG;
+    ctx.fillStyle = rowBg(row);
     ctx.fillRect(0, cy, hw, ch);
-    ctx.strokeStyle = HEADER_BORDER;
+    ctx.strokeStyle = rowBorder(row);
     ctx.lineWidth = 0.5;
     ctx.beginPath();
     ctx.moveTo(hw - hp, cy);  ctx.lineTo(hw - hp, cy + ch);   // right (inset)

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -730,6 +730,12 @@ export interface RenderViewportOptions {
   loadedImages?: Map<string, HTMLImageElement>;
   /** Called once per cell that contains text, with canvas-pixel position and cell address. */
   onTextRun?: (info: TextRunInfo) => void;
+  /** Highlighted row range for selected row headers (1-indexed inclusive).
+   *  `strong: true` → light blue + blue border (rows / cols / all selection modes).
+   *  `strong: false` → slightly darker grey (cells selection mode). */
+  selectedRowRange?: { start: number; end: number; strong: boolean } | null;
+  /** Same shape as selectedRowRange, for column headers. */
+  selectedColRange?: { start: number; end: number; strong: boolean } | null;
 }
 
 export type WorkerRequest =

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -569,6 +569,7 @@ export class XlsxViewer {
         }
       }
       this.updateSelectionOverlay();
+      void this.renderCurrentSheet();
       this.opts.onSelectionChange?.(this.selection);
       return;
     }
@@ -588,6 +589,7 @@ export class XlsxViewer {
       this.scrollHost.setPointerCapture(pointerId);
     }
     this.updateSelectionOverlay();
+    void this.renderCurrentSheet();
     this.opts.onSelectionChange?.(this.selection);
   }
 
@@ -637,6 +639,7 @@ export class XlsxViewer {
       }
 
       this.updateSelectionOverlay();
+      void this.renderCurrentSheet();
       this.opts.onSelectionChange?.(this.selection);
     });
 
@@ -819,6 +822,8 @@ export class XlsxViewer {
 
     const viewport: ViewportRange = { row: startRow, col: startCol, rows, cols };
 
+    const { selectedRowRange, selectedColRange } = this.computeHeaderHighlight();
+
     await this.wb.renderViewport(this.canvas, this.currentSheet, viewport, {
       width: w,
       height: h,
@@ -828,7 +833,45 @@ export class XlsxViewer {
       scrollOffsetY: offsetY,
       freezeRows,
       freezeCols,
+      selectedRowRange,
+      selectedColRange,
     });
+  }
+
+  private computeHeaderHighlight(): {
+    selectedRowRange: { start: number; end: number; strong: boolean } | null;
+    selectedColRange: { start: number; end: number; strong: boolean } | null;
+  } {
+    if (!this.anchorCell || !this.activeCell) {
+      return { selectedRowRange: null, selectedColRange: null };
+    }
+    const ALL = Number.MAX_SAFE_INTEGER;
+    const r1 = Math.min(this.anchorCell.row, this.activeCell.row);
+    const r2 = Math.max(this.anchorCell.row, this.activeCell.row);
+    const c1 = Math.min(this.anchorCell.col, this.activeCell.col);
+    const c2 = Math.max(this.anchorCell.col, this.activeCell.col);
+    switch (this.selectionMode) {
+      case 'cells':
+        return {
+          selectedRowRange: { start: r1, end: r2, strong: false },
+          selectedColRange: { start: c1, end: c2, strong: false },
+        };
+      case 'rows':
+        return {
+          selectedRowRange: { start: r1, end: r2, strong: true },
+          selectedColRange: { start: 1, end: ALL, strong: false },
+        };
+      case 'cols':
+        return {
+          selectedRowRange: { start: 1, end: ALL, strong: false },
+          selectedColRange: { start: c1, end: c2, strong: true },
+        };
+      case 'all':
+        return {
+          selectedRowRange: { start: 1, end: ALL, strong: true },
+          selectedColRange: { start: 1, end: ALL, strong: true },
+        };
+    }
   }
 
   get sheetNames(): string[] {


### PR DESCRIPTION
## Summary

- **xlsx**: `XlsxViewer` now highlights the row / column headers that the current selection belongs to, matching Excel's two-tier indicator. Cell selection paints the corresponding headers in a slightly darker grey (`#e8eaed`); whole-row / column selection paints the selection-axis headers in light blue (`#caddf6`) with a blue border (`#5b9bd5`) and the other axis in the grey accent; select-all paints every header in light blue.

The HTML selection overlay (the blue range border) is untouched — this purely adds the header indicator that Excel users expect when scanning which row / column a selection belongs to. pptx / docx renderers and the xlsx grid render with no active selection are byte-identical to 0.33.2, so README header images are not updated.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-xlsx exec tsc --noEmit` passes
- [x] Storybook xlsx demo: click a column header → that column's header turns light blue, row headers turn the darker grey
- [x] Click a row header → row header turns blue, column headers turn grey
- [x] Click a cell → only the selected row / column headers turn the darker grey; light blue not applied
- [x] Pixel sampling confirms `#caddf6` (selected axis) and `#e8eaed` (other axis) are painted at the expected positions