### PR TITLE
fix(stories): declare @silurus/ooxml-diff as workspace devDep on pptx/docx/xlsx

### DIFF
--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@silurus/ooxml-diff": "workspace:*",
     "@types/pngjs": "^6.0.5",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.59.1",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@silurus/ooxml-diff": "workspace:*",
     "@types/pngjs": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.4",
     "pixelmatch": "^7.1.0",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@silurus/ooxml-diff": "workspace:*",
     "@types/pngjs": "^6.0.5",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@storybook/html-vite':
         specifier: ^10.3.5
         version: 10.3.5(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
-      pdf-lib:
-        specifier: ^1.17.1
-        version: 1.17.1
       storybook:
         specifier: ^10.3.5
         version: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -73,6 +70,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@silurus/ooxml-diff':
+        specifier: workspace:*
+        version: link:../diff
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
@@ -141,6 +141,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@silurus/ooxml-diff':
+        specifier: workspace:*
+        version: link:../diff
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
@@ -203,6 +206,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@silurus/ooxml-diff':
+        specifier: workspace:*
+        version: link:../diff
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
@@ -708,12 +714,6 @@ packages:
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
-
-  '@pdf-lib/standard-fonts@1.0.0':
-    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
-
-  '@pdf-lib/upng@1.0.1':
-    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -2459,9 +2459,6 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  pako@1.0.11:
-    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-
   parenthesis@3.1.8:
     resolution: {integrity: sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==}
 
@@ -2509,9 +2506,6 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
-
-  pdf-lib@1.17.1:
-    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -2910,9 +2904,6 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
-
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3617,14 +3608,6 @@ snapshots:
       fastq: 1.20.1
 
   '@oxc-project/types@0.124.0': {}
-
-  '@pdf-lib/standard-fonts@1.0.0':
-    dependencies:
-      pako: 1.0.11
-
-  '@pdf-lib/upng@1.0.1':
-    dependencies:
-      pako: 1.0.11
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -5348,8 +5331,6 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  pako@1.0.11: {}
-
   parenthesis@3.1.8: {}
 
   parse-json@8.3.0:
@@ -5393,13 +5374,6 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
-
-  pdf-lib@1.17.1:
-    dependencies:
-      '@pdf-lib/standard-fonts': 1.0.0
-      '@pdf-lib/upng': 1.0.1
-      pako: 1.0.11
-      tslib: 1.14.1
 
   pend@1.2.0: {}
 
@@ -5886,8 +5860,6 @@ snapshots:
   tr46@0.0.3: {}
 
   ts-dedent@2.2.0: {}
-
-  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
Storybook を起動するとローカルで以下のエラーが出る問題の修正:

```
[plugin:vite:import-analysis] Failed to resolve import "@silurus/ooxml-diff"
from "packages/pptx/src/Diff.stories.ts".
```

## 原因

`packages/{pptx,docx,xlsx}/src/Diff.stories.ts` が `@silurus/ooxml-diff` を import しているのに、依存宣言が root `package.json` の devDep にしか入っていなかった。pnpm のデフォルト isolated インストーラは workspace パッケージを宣言したパッケージにしか symlink しないため、format パッケージ側 (`packages/pptx/node_modules/...`) では `@silurus/ooxml-diff` が見つからず Vite が解決失敗していた。

## 修正

各 format パッケージの `devDependencies` に `@silurus/ooxml-diff: workspace:*` を追加。これにより `packages/pptx/node_modules/@silurus/ooxml-diff` が作成され Vite が解決できる。

`.stories.ts` は npm 公開時のエントリグラフに含まれないため (viewer の `index.ts` から参照していない)、devDep で正しい。`@silurus/ooxml` の zero runtime deps は引き続き維持。

## 確認

```bash
pnpm install && pnpm build-storybook   # 成功
ls packages/pptx/node_modules/@silurus/  # ooxml-diff symlink あり
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mv9n2Z3juqqwbZvjLkgoXf)_