### PR TITLE
fix(stories): import @silurus/ooxml-markdown via workspace-relative path

### DIFF
--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "@silurus/ooxml-markdown": "workspace:*",
     "@types/pngjs": "^6.0.5",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.59.1",

--- a/packages/docx/src/Markdown.stories.ts
+++ b/packages/docx/src/Markdown.stories.ts
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/html';
-import { docxToMarkdown, initDocxFromBytes } from '@silurus/ooxml-markdown';
+// Direct workspace-relative import (instead of `@silurus/ooxml-markdown`)
+// so this story works without depending on whether pnpm has been re-run
+// after the workspace dep was added. Vite resolves the path directly.
+import { docxToMarkdown, initDocxFromBytes } from '../../markdown/src/index';
 import docxWasmUrl from './wasm/docx_parser_bg.wasm?url';
 
 type Args = Record<string, never>;

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "@silurus/ooxml-markdown": "workspace:*",
     "@types/pngjs": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.4",
     "pixelmatch": "^7.1.0",

--- a/packages/pptx/src/Markdown.stories.ts
+++ b/packages/pptx/src/Markdown.stories.ts
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/html';
-import { pptxToMarkdown, initPptxFromBytes } from '@silurus/ooxml-markdown';
+// Direct workspace-relative import (instead of `@silurus/ooxml-markdown`)
+// so this story works without depending on whether pnpm has been re-run
+// after the workspace dep was added. Vite resolves the path directly.
+import { pptxToMarkdown, initPptxFromBytes } from '../../markdown/src/index';
 import pptxWasmUrl from './wasm/pptx_parser_bg.wasm?url';
 
 type Args = Record<string, never>;

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "@silurus/ooxml-markdown": "workspace:*",
     "@types/pngjs": "^6.0.5",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.59.1",

--- a/packages/xlsx/src/Markdown.stories.ts
+++ b/packages/xlsx/src/Markdown.stories.ts
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/html';
-import { xlsxToMarkdown, initXlsxFromBytes } from '@silurus/ooxml-markdown';
+// Direct workspace-relative import (instead of `@silurus/ooxml-markdown`)
+// so this story works without depending on whether pnpm has been re-run
+// after the workspace dep was added. Vite resolves the path directly.
+import { xlsxToMarkdown, initXlsxFromBytes } from '../../markdown/src/index';
 import xlsxWasmUrl from './wasm/xlsx_parser_bg.wasm?url';
 
 type Args = Record<string, never>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
-      '@silurus/ooxml-markdown':
-        specifier: workspace:*
-        version: link:../markdown
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
@@ -122,9 +119,6 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
-      '@silurus/ooxml-markdown':
-        specifier: workspace:*
-        version: link:../markdown
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
@@ -187,9 +181,6 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
-      '@silurus/ooxml-markdown':
-        specifier: workspace:*
-        version: link:../markdown
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5


### PR DESCRIPTION
## 原因

前回 PR で `@silurus/ooxml-markdown` を各 format パッケージの workspace devDep として宣言したが、これは **クリーンインストール時のみ** 機能する。既に `node_modules` が存在する状態で `git pull` した場合、pnpm は再リンクしないことがあり (もしくは `pnpm install` を再実行しないユーザー操作で)、`packages/pptx/node_modules/@silurus/ooxml-markdown` が作られず Vite が以下のエラー:

```
[plugin:vite:import-analysis] Failed to resolve import "@silurus/ooxml-markdown"
from "packages/pptx/src/Markdown.stories.ts"
```

## 修正

bare-name インポートをやめて、workspace 相対パスに切り替え:

```ts
// before
import { pptxToMarkdown } from '@silurus/ooxml-markdown';
// after
import { pptxToMarkdown } from '../../markdown/src/index';
```

Vite は `node_modules` を経由せず相対パスを直接解決するので、インストール状態に関係なく動作する。各 format パッケージから `@silurus/ooxml-markdown` workspace devDep も削除 (不要になった)。

## 確認

- ヘッドレス Chromium で全 18 ストーリー巡回: OK
- storybook **dev mode** で `/packages/pptx/src/Markdown.stories.ts` をフェッチ → 200 + 解決エラーなし

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mv9n2Z3juqqwbZvjLkgoXf)_