### PR TITLE
chore(release): 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
-## Unreleased
+## 0.35.0 — 2026-05-17
+
+Two new companion packages (`@silurus/ooxml-node`, `@silurus/ooxml-markdown`) and an inline render of DOCX track-changes. Browser viewer renderers are unchanged for pptx / xlsx; for docx, the markup overlay only fires on runs that sit inside `<w:ins>` / `<w:del>` blocks, so `demo/sample-1.docx` (no tracked changes) renders byte-identically. README screenshots not updated for this reason. Zero runtime dependencies preserved.
 
 ### Features
 
@@ -12,6 +14,7 @@ changes that remain compatible with existing API surfaces.
 - **pptx / docx / xlsx**: each format package now declares `./wasm` and `./wasm-binary` subpath exports so Node-side consumers (and bundlers) can locate the wasm-pack JS shim and the underlying `.wasm` file without reaching into `src/wasm/` paths.
 - **docx**: ECMA-376 §17.13.5 track-changes (`<w:ins>` / `<w:del>`) now render inline. The Rust parser tags each `TextRun` produced inside a tracked block with `{ kind: 'insertion' | 'deletion', author, date }`; the renderer overlays the author-derived colour (8-hue stable palette hashed by author name), an underline for insertions, and a strikethrough for deletions. The new `RenderPageOptions.showTrackChanges` flag (default `true`) toggles the markup off for a "Final / No Markup" view. Deletion text inside `<w:delText>` is now surfaced (was silently dropped) alongside insertion text inside `<w:t>`. Public TS surface now also exposes the previously parser-only `Document.revisions` / `comments` / `footnotes` / `endnotes` fields (CHANGELOG 0.32.0) with proper TS types (`DocRevision`, `DocComment`, `DocNote`, `RunRevision`).
 - **markdown**: new `@silurus/ooxml-markdown` workspace package exposing `pptxToMarkdown` / `docxToMarkdown` / `xlsxToMarkdown` as pure WASM calls (no JSON round-trip). The Rust `*_to_markdown` functions used to be native-only (mcp-server); they're now also `#[wasm_bindgen]`-exported so the same projection runs in browser, Node, or via the new `ooxml-md` CLI. Markdown output matches the v0.33.0 MCP projections byte-for-byte (titles via `placeholderType`, bullets via `<w:outlineLvl>`, pipe-table XLSX per sheet). Includes a node20-based GitHub Action under `packages/markdown/action/` for bulk-converting an entire repository's OOXML files in CI.
+- **storybook**: new `PptxViewer/Markdown`, `DocxViewer/Markdown`, `XlsxViewer/Markdown` stories that load demo/sample-1 (or a user file), invoke the WASM-backed conversion, and display the markdown output alongside size / compression ratio / latency.
 
 ## 0.34.0 — 2026-05-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",


### PR DESCRIPTION
## 0.35.0

Two new companion packages (`@silurus/ooxml-node`, `@silurus/ooxml-markdown`) と DOCX track-changes inline rendering。Browser viewer renderer は pptx / xlsx は変更なし、docx は `<w:ins>` / `<w:del>` を含む文書のみ markup overlay が動くので、`demo/sample-1.docx` (tracked changes 無し) はバイト同一でレンダリングされる。**README screenshots は更新不要**。ランタイム依存ゼロ維持。

### Features

- **node**: `@silurus/ooxml-node` — Node-side parsers (`parsePptx` / `parseDocx` / `parseXlsx` / `parseXlsxAllSheets`) + `ooxml-thumbnail` CLI scaffold (skia-canvas は optional peer)
- **pptx / docx / xlsx**: `./wasm` / `./wasm-binary` subpath exports
- **docx**: track-changes inline rendering (author-coloured underline / strikethrough), `showTrackChanges` toggle, `Document.revisions` / `comments` / `footnotes` / `endnotes` を TS surface
- **markdown**: `@silurus/ooxml-markdown` + `ooxml-md` CLI + GitHub Action skeleton
- **storybook**: `PptxViewer/Markdown` / `DocxViewer/Markdown` / `XlsxViewer/Markdown` ストーリー

### Version bump

`0.34.0 → 0.35.0` を 6 + 2 ファイルで揃え:
- root `package.json`
- `packages/{core,pptx,xlsx,docx,vscode-extension}/package.json`
- 新規 `packages/{node,markdown}/package.json` (workspace-internal)

### 確認

- `tsc --build` EXIT=0
- `pnpm build-storybook` 成功
- ヘッドレス Chromium で全 18 ストーリー巡回 → エラー 0 (前 PR で確認済み)
- マージ後の手順: `git tag -a v0.35.0` → `git push origin v0.35.0` → `gh release create v0.35.0`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mv9n2Z3juqqwbZvjLkgoXf)_