### PR TITLE
chore(release): 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.36.0 — 2026-05-19
+
+Single security-surface change: the 512 MiB per-entry ZIP decompression cap that
+backed the "zip-bomb safe" guarantee is now caller-configurable. Default is
+unchanged, so renderers / VRT references / `demo/sample-*` outputs are
+byte-identical to 0.35.0 — README screenshots were not refreshed for that
+reason.
+
+### Features
+
+- **core / pptx / docx / xlsx**: viewer constructor option `maxZipEntryBytes` now overrides the per-entry ZIP decompression cap that backs the "zip-bomb safe" guarantee. Default stays at 512 MiB; raise it for legitimate decks with large embedded media, or lower it to tighten the budget for untrusted input. Plumbed through `PptxViewer` / `DocxViewer` / `XlsxViewer` constructors → worker `parse_*` messages → new `Option<u64>` argument on the `#[wasm_bindgen]` entry points (`parse_pptx`, `parse_docx`, `parse_xlsx`, `parse_sheet`, `extract_media`, plus the `*_to_markdown` variants). The Rust parsers consult the cap via a new shared `ooxml-common::zip` thread-local, replacing the three near-identical `const MAX_ZIP_ENTRY_BYTES: u64 = 512 * 1024 * 1024;` duplicates. Zero / negative values fall back to the default. Existing callers that omit the option see no behavior change.
+
 ## 0.35.0 — 2026-05-17
 
 Two new companion packages (`@silurus/ooxml-node`, `@silurus/ooxml-markdown`) and an inline render of DOCX track-changes. Browser viewer renderers are unchanged for pptx / xlsx; for docx, the markup overlay only fires on runs that sit inside `<w:ins>` / `<w:del>` blocks, so `demo/sample-1.docx` (no tracked changes) renders byte-identically. README screenshots not updated for this reason. Zero runtime dependencies preserved.

--- a/README.md
+++ b/README.md
@@ -566,7 +566,11 @@ cd packages/pptx/parser && wasm-pack build --target web && cp pkg/pptx_parser_bg
 ## Security & Privacy
 
 - **Canvas-only rendering.** Documents are decoded and drawn to an `HTMLCanvasElement`. No script, link, form, or other active content from the source file is executed or injected into the DOM.
-- **ZIP decompression cap.** Each entry in the source archive is limited to 512 MiB of uncompressed output to block zip-bomb DoS.
+- **ZIP decompression cap.** Each entry in the source archive is limited to 512 MiB of uncompressed output by default to block zip-bomb DoS. Override per viewer with `maxZipEntryBytes` (bytes) — raise it for legitimate decks with large embedded media, lower it to tighten the budget for untrusted input:
+  ```ts
+  new PptxViewer(canvas, { maxZipEntryBytes: 64 * 1024 * 1024 }); // 64 MiB
+  ```
+  Supported uniformly by `DocxViewer`, `PptxViewer`, and `XlsxViewer`. Zero / negative values fall back to the default.
 - **No network by default.** The library does not send telemetry or analytics, and does not contact third-party services unless you ask it to. In particular, theme webfonts (and Office font metric substitutes for XLSX) are **not** loaded from Google Fonts unless you pass `useGoogleFonts: true` to the relevant `Viewer` / `load(...)` options — supported uniformly by `DocxViewer`, `PptxViewer`, and `XlsxViewer`. Enabling that option causes the end-user's browser to send an HTTP request (IP and User-Agent) to `fonts.googleapis.com`, which may have GDPR implications for your application — consider self-hosting the required fonts via `@font-face` instead.
 - **XML parsing.** Uses `roxmltree`, which does not resolve external entities (XXE-safe by default).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -8,8 +8,9 @@ mod parser;
 mod markdown;
 
 #[wasm_bindgen]
-pub fn parse_docx(data: &[u8]) -> String {
+pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> String {
     console_error_panic_hook::set_once();
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     match parser::parse(data) {
         Ok(doc) => serde_json::to_string(&doc).unwrap_or_else(|e| {
             format!("{{\"error\":\"{}\"}}", e)
@@ -22,8 +23,9 @@ pub fn parse_docx(data: &[u8]) -> String {
 /// GitHub-flavoured markdown of headings / paragraphs / tables / footnotes,
 /// discarding positioning, section properties, fonts, and drawing shapes.
 #[wasm_bindgen]
-pub fn docx_to_markdown(data: &[u8]) -> Result<String, JsValue> {
+pub fn docx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let doc = parser::parse(data).map_err(|e| JsValue::from_str(&e))?;
     Ok(markdown::render_document(&doc))
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2325,26 +2325,24 @@ fn parse_rels(xml: &str) -> HashMap<String, String> {
     map
 }
 
-/// Refuse to decompress individual ZIP entries larger than 512 MiB to prevent
-/// zip-bomb DoS.
-const MAX_ZIP_ENTRY_BYTES: u64 = 512 * 1024 * 1024;
-
 fn read_zip_entry(zip: &mut Zip, path: &str) -> Result<String, String> {
+    let max = ooxml_common::zip::current_max();
     let mut entry = zip.by_name(path).map_err(|e| format!("{}: {}", path, e))?;
-    if entry.size() > MAX_ZIP_ENTRY_BYTES {
+    if entry.size() > max {
         return Err(format!("{}: exceeds size limit", path));
     }
     let mut s = String::new();
-    entry.by_ref().take(MAX_ZIP_ENTRY_BYTES).read_to_string(&mut s).map_err(|e| e.to_string())?;
+    entry.by_ref().take(max).read_to_string(&mut s).map_err(|e| e.to_string())?;
     Ok(s)
 }
 
 fn read_zip_bytes(zip: &mut Zip, path: &str) -> Result<Vec<u8>, String> {
+    let max = ooxml_common::zip::current_max();
     let mut entry = zip.by_name(path).map_err(|e| format!("{}: {}", path, e))?;
-    if entry.size() > MAX_ZIP_ENTRY_BYTES {
+    if entry.size() > max {
         return Err(format!("{}: exceeds size limit", path));
     }
     let mut buf = vec![];
-    entry.by_ref().take(MAX_ZIP_ENTRY_BYTES).read_to_end(&mut buf).map_err(|e| e.to_string())?;
+    entry.by_ref().take(max).read_to_end(&mut buf).map_err(|e| e.to_string())?;
     Ok(buf)
 }

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -23,9 +23,16 @@ const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
 };
 
-/** Options for {@link DocxDocument.load}. Re-exports the shared
+/** Options for {@link DocxDocument.load}. Extends the shared
  *  `LoadOptions` shape from `@silurus/ooxml-core`. */
-export type LoadOptions = CoreLoadOptions;
+export interface LoadOptions extends CoreLoadOptions {
+  /**
+   * Override the per-entry ZIP decompression cap (bytes) used by the
+   * zip-bomb guard in the Rust parser. Defaults to 512 MiB. Zero / negative
+   * values fall back to the default.
+   */
+  maxZipEntryBytes?: number;
+}
 
 export class DocxDocument {
   private _document: Document | null = null;
@@ -48,7 +55,7 @@ export class DocxDocument {
     } else {
       buffer = source;
     }
-    await doc._parse(buffer);
+    await doc._parse(buffer, opts.maxZipEntryBytes);
     if (opts.useGoogleFonts) {
       await preloadGoogleFonts(
         [doc._document?.majorFont, doc._document?.minorFont],
@@ -58,7 +65,7 @@ export class DocxDocument {
     return doc;
   }
 
-  private _parse(buffer: ArrayBuffer): Promise<void> {
+  private _parse(buffer: ArrayBuffer, maxZipEntryBytes?: number): Promise<void> {
     return new Promise((resolve, reject) => {
       const handler = (e: MessageEvent<WorkerResponse>) => {
         this._worker.removeEventListener('message', handler);
@@ -70,7 +77,7 @@ export class DocxDocument {
         }
       };
       this._worker.addEventListener('message', handler);
-      this._worker.postMessage({ type: 'parse', data: buffer }, [buffer]);
+      this._worker.postMessage({ type: 'parse', data: buffer, maxZipEntryBytes }, [buffer]);
     });
   }
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -455,7 +455,7 @@ export interface CellBorders {
 
 export type WorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; data: ArrayBuffer };
+  | { type: 'parse'; data: ArrayBuffer; maxZipEntryBytes?: number };
 
 export type WorkerResponse =
   | { type: 'parsed'; document: Document }

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -51,7 +51,10 @@ export class DocxViewer {
   }
 
   async load(source: string | ArrayBuffer): Promise<void> {
-    this._doc = await DocxDocument.load(source, { useGoogleFonts: this._opts.useGoogleFonts });
+    this._doc = await DocxDocument.load(source, {
+      useGoogleFonts: this._opts.useGoogleFonts,
+      maxZipEntryBytes: this._opts.maxZipEntryBytes,
+    });
     this._currentPage = 0;
     await this._render();
   }

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -24,7 +24,11 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   try {
     await initPromise;
     if (req.type === 'parse') {
-      const json = parse_docx(new Uint8Array(req.data));
+      const maxBytes =
+        typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
+          ? BigInt(req.maxZipEntryBytes)
+          : undefined;
+      const json = parse_docx(new Uint8Array(req.data), maxBytes);
       const document = JSON.parse(json);
       if (document.error) throw new Error(`Parse error: ${document.error}`);
       const res: WorkerResponse = { type: 'parsed', document };

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -7,3 +7,4 @@
 
 pub mod chart;
 pub mod color;
+pub mod zip;

--- a/packages/ooxml-common/src/zip.rs
+++ b/packages/ooxml-common/src/zip.rs
@@ -1,0 +1,56 @@
+//! Shared configuration for ZIP entry decompression limits.
+//!
+//! OOXML parsers must cap per-entry decompressed output to block zip-bomb DoS.
+//! The cap defaults to 512 MiB — large enough for legitimate embedded video /
+//! 4K media but small enough to refuse pathological archives — and can be
+//! overridden per-parse via the `wasm_bindgen` entry points so library users
+//! can tighten the budget (untrusted gateways) or loosen it (legitimate huge
+//! decks) without forking.
+//!
+//! The current cap is stored in a thread-local so existing `read_zip_*`
+//! helpers in each parser can consult it without threading a parameter
+//! through ~70 call sites. Each WASM entry point installs a [`Guard`] for
+//! its scope and the cap is restored on drop, so concurrent JS callers never
+//! interfere (WASM is single-threaded; each invocation runs to completion).
+
+use std::cell::Cell;
+
+/// 512 MiB. OOXML legitimately reaches tens of MB (embedded video, 4K
+/// images) but not hundreds, so this cap blocks zip-bomb DoS without
+/// rejecting real files.
+pub const DEFAULT_MAX_ZIP_ENTRY_BYTES: u64 = 512 * 1024 * 1024;
+
+thread_local! {
+    static MAX_ZIP_ENTRY_BYTES: Cell<u64> = const { Cell::new(DEFAULT_MAX_ZIP_ENTRY_BYTES) };
+}
+
+/// RAII guard that restores the previous cap when dropped. Created by
+/// [`scoped_max`]; the caller should bind it to a `let _guard = …` for the
+/// full duration of the parse call.
+#[must_use = "binding the guard keeps the cap installed for this scope"]
+pub struct Guard {
+    previous: u64,
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        MAX_ZIP_ENTRY_BYTES.with(|c| c.set(self.previous));
+    }
+}
+
+/// Install a per-call ZIP entry size cap for the lifetime of the returned
+/// guard. `None`, zero, or any non-positive value falls back to
+/// [`DEFAULT_MAX_ZIP_ENTRY_BYTES`].
+pub fn scoped_max(value: Option<u64>) -> Guard {
+    let resolved = value
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_MAX_ZIP_ENTRY_BYTES);
+    let previous = MAX_ZIP_ENTRY_BYTES.with(|c| c.replace(resolved));
+    Guard { previous }
+}
+
+/// Current cap in effect on this thread. Parsers consult this from their
+/// `read_zip_*` helpers when validating entry sizes.
+pub fn current_max() -> u64 {
+    MAX_ZIP_ENTRY_BYTES.with(Cell::get)
+}

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -11,8 +11,9 @@ mod table_style_presets;
 // ===========================
 
 #[wasm_bindgen]
-pub fn parse_pptx(data: &[u8]) -> Result<String, JsValue> {
+pub fn parse_pptx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let presentation = parse_presentation(data)
         .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
     serde_json::to_string(&presentation)
@@ -23,8 +24,9 @@ pub fn parse_pptx(data: &[u8]) -> Result<String, JsValue> {
 /// so the browser / Node WASM path and the native mcp-server path stay in
 /// lock-step. See `to_markdown_native` for the design rationale.
 #[wasm_bindgen]
-pub fn pptx_to_markdown(data: &[u8]) -> Result<String, JsValue> {
+pub fn pptx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let pres = parse_presentation(data)
         .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
     let mut out = String::new();
@@ -354,15 +356,24 @@ fn render_chart_md(c: &ChartElement, out: &mut String) {
 /// pptx zip archive. Used by the main thread to materialize media blobs for
 /// interactive playback without re-parsing the whole file.
 #[wasm_bindgen]
-pub fn extract_media(data: &[u8], path: &str) -> Result<Vec<u8>, JsValue> {
+pub fn extract_media(data: &[u8], path: &str, max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let max = ooxml_common::zip::current_max();
     let cursor = Cursor::new(data);
     let mut zip = zip::ZipArchive::new(cursor)
         .map_err(|e| JsValue::from_str(&format!("zip open error: {e}")))?;
     let mut entry = zip
         .by_name(path)
         .map_err(|e| JsValue::from_str(&format!("entry not found: {path}: {e}")))?;
+    if entry.size() > max {
+        return Err(JsValue::from_str(&format!(
+            "ZIP entry exceeds size limit: {path}"
+        )));
+    }
     let mut buf = Vec::with_capacity(entry.size() as usize);
     entry
+        .by_ref()
+        .take(max)
         .read_to_end(&mut buf)
         .map_err(|e| JsValue::from_str(&format!("read error: {e}")))?;
     Ok(buf)
@@ -1141,30 +1152,27 @@ struct TextOutline {
 
 type PptxZip<'a> = zip::ZipArchive<Cursor<&'a [u8]>>;
 
-/// Refuse to decompress individual ZIP entries larger than 512 MiB.
-/// OOXML legitimately reaches tens of MB (embedded video, 4K images) but not
-/// hundreds, so this cap blocks zip-bomb DoS without rejecting real files.
-const MAX_ZIP_ENTRY_BYTES: u64 = 512 * 1024 * 1024;
-
 fn read_zip_str(zip: &mut PptxZip<'_>, path: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let max = ooxml_common::zip::current_max();
     let mut file = zip
         .by_name(path)
         .map_err(|_| format!("missing ZIP entry: {path}"))?;
-    if file.size() > MAX_ZIP_ENTRY_BYTES {
+    if file.size() > max {
         return Err(format!("ZIP entry exceeds size limit: {path}").into());
     }
     let mut buf = String::new();
-    file.by_ref().take(MAX_ZIP_ENTRY_BYTES).read_to_string(&mut buf)?;
+    file.by_ref().take(max).read_to_string(&mut buf)?;
     Ok(buf)
 }
 
 fn read_zip_bytes(zip: &mut PptxZip<'_>, path: &str) -> Option<Vec<u8>> {
+    let max = ooxml_common::zip::current_max();
     let mut file = zip.by_name(path).ok()?;
-    if file.size() > MAX_ZIP_ENTRY_BYTES {
+    if file.size() > max {
         return None;
     }
     let mut buf = Vec::new();
-    file.by_ref().take(MAX_ZIP_ENTRY_BYTES).read_to_end(&mut buf).ok()?;
+    file.by_ref().take(max).read_to_end(&mut buf).ok()?;
     Some(buf)
 }
 

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -20,9 +20,18 @@ const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
 };
 
-/** Options for {@link PptxPresentation.load}. Re-exports the shared
+/** Options for {@link PptxPresentation.load}. Extends the shared
  *  `LoadOptions` shape from `@silurus/ooxml-core`. */
-export type LoadOptions = CoreLoadOptions;
+export interface LoadOptions extends CoreLoadOptions {
+  /**
+   * Override the per-entry ZIP decompression cap (bytes). Defaults to
+   * 512 MiB — matches `MAX_ZIP_ENTRY_BYTES` in the Rust parser. Raising
+   * this past 4 GiB requires a 64-bit WASM build; lowering it makes the
+   * loader reject otherwise-legitimate large media decks. Zero or
+   * negative values fall back to the default.
+   */
+  maxZipEntryBytes?: number;
+}
 
 /** Options for rendering a single slide onto a canvas. */
 export interface RenderSlideOptions {
@@ -135,7 +144,7 @@ export class PptxPresentation {
     } else {
       buffer = source;
     }
-    await pres._parse(buffer);
+    await pres._parse(buffer, opts.maxZipEntryBytes);
     if (opts.useGoogleFonts) {
       await preloadGoogleFonts(
         [pres._presentation!.majorFont, pres._presentation!.minorFont],
@@ -150,12 +159,12 @@ export class PptxPresentation {
     return new Promise((resolve) => this._workerReadyCallbacks.push(resolve));
   }
 
-  private async _parse(buffer: ArrayBuffer): Promise<void> {
+  private async _parse(buffer: ArrayBuffer, maxZipEntryBytes?: number): Promise<void> {
     await this._waitForWorker();
     const id = this._nextId++;
     const presentation = await new Promise<Presentation>((resolve, reject) => {
       this._pendingParseCallbacks.set(id, { resolve, reject });
-      this._worker.postMessage({ kind: 'parse', id, buffer } satisfies WorkerRequest, [buffer]);
+      this._worker.postMessage({ kind: 'parse', id, buffer, maxZipEntryBytes } satisfies WorkerRequest, [buffer]);
     });
     this._presentation = presentation;
   }

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -253,7 +253,7 @@ export interface PictureElement {
 
 export type WorkerRequest =
   | { kind: 'init'; wasmUrl: string }
-  | { kind: 'parse'; id: number; buffer: ArrayBuffer }
+  | { kind: 'parse'; id: number; buffer: ArrayBuffer; maxZipEntryBytes?: number }
   | { kind: 'extractMedia'; id: number; path: string };
 
 export type WorkerResponse =

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -13,6 +13,13 @@ export interface PptxViewerOptions extends RenderOptions {
    */
   useGoogleFonts?: boolean;
   /**
+   * Override the per-entry ZIP decompression cap (bytes) used by the zip-bomb
+   * guard in the Rust parser. Defaults to 512 MiB. Raise this to load decks
+   * with very large embedded media, or lower it to tighten the budget for
+   * untrusted input. Zero / negative values fall back to the default.
+   */
+  maxZipEntryBytes?: number;
+  /**
    * Enable interactive audio/video playback. When true, slides are rendered
    * via {@link PptxPresentation.presentSlide} so media elements become
    * clickable and the viewer draws its own play/pause chrome. When false
@@ -78,6 +85,7 @@ export class PptxViewer {
     try {
       this.engine = await PptxPresentation.load(source, {
         useGoogleFonts: this.opts.useGoogleFonts,
+        maxZipEntryBytes: this.opts.maxZipEntryBytes,
       });
       this.currentSlide = 0;
       await this.renderCurrentSlide();

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -3,6 +3,7 @@ import init, { parse_pptx, extract_media } from './wasm/pptx_parser.js';
 
 let ready = false;
 let currentBuffer: Uint8Array | null = null;
+let currentMaxZipEntryBytes: bigint | undefined;
 
 function decodeDataUrl(url: string): ArrayBuffer | null {
   if (!url.startsWith('data:')) return null;
@@ -40,7 +41,11 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
     try {
       const bytes = new Uint8Array(req.buffer);
       currentBuffer = bytes;
-      const jsonStr = parse_pptx(bytes);
+      currentMaxZipEntryBytes =
+        typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
+          ? BigInt(req.maxZipEntryBytes)
+          : undefined;
+      const jsonStr = parse_pptx(bytes, currentMaxZipEntryBytes);
       const presentation: Presentation = JSON.parse(jsonStr);
       const msg: WorkerResponse = { kind: 'parsed', id: req.id, presentation };
       self.postMessage(msg);
@@ -62,7 +67,7 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
       return;
     }
     try {
-      const bytes = extract_media(currentBuffer, req.path);
+      const bytes = extract_media(currentBuffer, req.path, currentMaxZipEntryBytes);
       const copy = new Uint8Array(bytes).slice().buffer;
       const msg: WorkerResponse = { kind: 'mediaExtracted', id: req.id, bytes: copy };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [copy]);

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <yokotani.yuki@gmail.com>",

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1207,16 +1207,18 @@ const INDEXED_COLORS: &[&str] = &[
 ];
 
 #[wasm_bindgen]
-pub fn parse_xlsx(data: &[u8]) -> Result<String, JsValue> {
+pub fn parse_xlsx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     parse_xlsx_inner(data)
         .map(|wb| serde_json::to_string(&wb).unwrap())
         .map_err(|e| JsValue::from_str(&e))
 }
 
 #[wasm_bindgen]
-pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str) -> Result<String, JsValue> {
+pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str, max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let cursor = Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
 
@@ -1277,19 +1279,16 @@ fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
     })
 }
 
-/// Refuse to decompress individual ZIP entries larger than 512 MiB to prevent
-/// zip-bomb DoS.
-const MAX_ZIP_ENTRY_BYTES: u64 = 512 * 1024 * 1024;
-
 fn read_zip_entry(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, name: &str) -> Result<String, String> {
+    let max = ooxml_common::zip::current_max();
     let mut file = archive
         .by_name(name)
         .map_err(|e| format!("entry '{}' not found: {}", name, e))?;
-    if file.size() > MAX_ZIP_ENTRY_BYTES {
+    if file.size() > max {
         return Err(format!("entry '{}' exceeds size limit", name));
     }
     let mut buf = String::new();
-    file.by_ref().take(MAX_ZIP_ENTRY_BYTES).read_to_string(&mut buf).map_err(|e| e.to_string())?;
+    file.by_ref().take(max).read_to_string(&mut buf).map_err(|e| e.to_string())?;
     Ok(buf)
 }
 
@@ -2706,12 +2705,13 @@ fn load_hyperlinks(
 
 /// Read a binary file from the zip.
 fn read_zip_bytes(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, path: &str) -> Option<Vec<u8>> {
+    let max = ooxml_common::zip::current_max();
     let mut file = archive.by_name(path).ok()?;
-    if file.size() > MAX_ZIP_ENTRY_BYTES {
+    if file.size() > max {
         return None;
     }
     let mut buf = Vec::new();
-    file.by_ref().take(MAX_ZIP_ENTRY_BYTES).read_to_end(&mut buf).ok()?;
+    file.by_ref().take(max).read_to_end(&mut buf).ok()?;
     Some(buf)
 }
 
@@ -5594,8 +5594,9 @@ pub fn parse_workbook_native(data: &[u8]) -> Result<String, String> {
 /// continuation cells are rendered as empty; the display value comes from the
 /// WASM-callable markdown projection (mirrors `to_markdown_native`).
 #[wasm_bindgen]
-pub fn xlsx_to_markdown(data: &[u8]) -> Result<String, JsValue> {
+pub fn xlsx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
+    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     to_markdown_impl(data).map_err(|e| JsValue::from_str(&e))
 }
 

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -740,8 +740,8 @@ export interface RenderViewportOptions {
 
 export type WorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; data: ArrayBuffer }
-  | { type: 'parseSheet'; data: ArrayBuffer; sheetIndex: number; sheetName: string };
+  | { type: 'parse'; data: ArrayBuffer; maxZipEntryBytes?: number }
+  | { type: 'parseSheet'; data: ArrayBuffer; sheetIndex: number; sheetName: string; maxZipEntryBytes?: number };
 
 export type WorkerResponse =
   | { type: 'parsed'; workbook: ParsedWorkbook }

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -20,6 +20,12 @@ export interface XlsxViewerOptions {
    * privacy implications.
    */
   useGoogleFonts?: boolean;
+  /**
+   * Override the per-entry ZIP decompression cap (bytes) used by the
+   * zip-bomb guard in the Rust parser. Defaults to 512 MiB. Zero / negative
+   * values fall back to the default.
+   */
+  maxZipEntryBytes?: number;
 }
 
 export interface CellAddress {
@@ -122,7 +128,10 @@ export class XlsxViewer {
 
   async load(source: string | ArrayBuffer): Promise<void> {
     try {
-      await this.wb.load(source, { useGoogleFonts: this.opts.useGoogleFonts });
+      await this.wb.load(source, {
+        useGoogleFonts: this.opts.useGoogleFonts,
+        maxZipEntryBytes: this.opts.maxZipEntryBytes,
+      });
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
       await this.showSheet(0);

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -22,9 +22,17 @@ const XLSX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   },
 };
 
-/** Options for {@link XlsxWorkbook.load}. Re-exports the shared
+/** Options for {@link XlsxWorkbook.load}. Extends the shared
  *  `LoadOptions` shape from `@silurus/ooxml-core`. */
-export type LoadOptions = CoreLoadOptions;
+export interface LoadOptions extends CoreLoadOptions {
+  /**
+   * Override the per-entry ZIP decompression cap (bytes) used by the
+   * zip-bomb guard in the Rust parser. Defaults to 512 MiB. Applies to both
+   * the initial workbook parse and per-sheet parse. Zero / negative values
+   * fall back to the default.
+   */
+  maxZipEntryBytes?: number;
+}
 
 export class XlsxWorkbook {
   private worker: Worker;
@@ -33,6 +41,7 @@ export class XlsxWorkbook {
   /** Cache of loaded images keyed by their data URL. Shared across sheets. */
   private imageCache = new Map<string, HTMLImageElement>();
   private rawData: ArrayBuffer | null = null;
+  private maxZipEntryBytes: number | undefined;
 
   constructor() {
     this.worker = new InlineWorker();
@@ -46,7 +55,12 @@ export class XlsxWorkbook {
         ? await fetch(source).then((r) => r.arrayBuffer())
         : source;
     this.rawData = data;
-    this.parsedWorkbook = await this.sendMessage({ type: 'parse', data: data.slice(0) }) as ParsedWorkbook;
+    this.maxZipEntryBytes = opts.maxZipEntryBytes;
+    this.parsedWorkbook = await this.sendMessage({
+      type: 'parse',
+      data: data.slice(0),
+      maxZipEntryBytes: this.maxZipEntryBytes,
+    }) as ParsedWorkbook;
     if (opts.useGoogleFonts) {
       // Walk every styled font in the workbook and queue Google Fonts
       // substitutes for any Office faces (Calibri → Carlito, Cambria →
@@ -83,6 +97,7 @@ export class XlsxWorkbook {
       data: this.rawData.slice(0),
       sheetIndex,
       sheetName: sheetMeta.name,
+      maxZipEntryBytes: this.maxZipEntryBytes,
     }) as Worksheet;
     this.sheetCache.set(sheetIndex, ws);
     return ws;

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -24,12 +24,20 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   try {
     await initPromise;
     if (req.type === 'parse') {
-      const json = parse_xlsx(new Uint8Array(req.data));
+      const maxBytes =
+        typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
+          ? BigInt(req.maxZipEntryBytes)
+          : undefined;
+      const json = parse_xlsx(new Uint8Array(req.data), maxBytes);
       const workbook = JSON.parse(json);
       const res: WorkerResponse = { type: 'parsed', workbook };
       self.postMessage(res);
     } else if (req.type === 'parseSheet') {
-      const json = parse_sheet(new Uint8Array(req.data), req.sheetIndex, req.sheetName);
+      const maxBytes =
+        typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
+          ? BigInt(req.maxZipEntryBytes)
+          : undefined;
+      const json = parse_sheet(new Uint8Array(req.data), req.sheetIndex, req.sheetName, maxBytes);
       const worksheet = JSON.parse(json);
       const res: WorkerResponse = { type: 'parsedSheet', worksheet };
       self.postMessage(res);


### PR DESCRIPTION
## Summary

- Make the per-entry ZIP decompression cap (the "Zip-bomb safe (512 MiB)" guarantee) caller-configurable via a new `maxZipEntryBytes` constructor option on `PptxViewer` / `DocxViewer` / `XlsxViewer`. Default unchanged.
- Extract the cap into the shared `ooxml-common::zip` crate (thread-local + RAII guard) and remove the three duplicated `const MAX_ZIP_ENTRY_BYTES` definitions across the parsers.
- Add `Option<u64>` argument to the `#[wasm_bindgen]` entry points (`parse_pptx`, `parse_docx`, `parse_xlsx`, `parse_sheet`, `extract_media`, `*_to_markdown`). Native (MCP-server) entry points are unchanged.

Bug fix / precision improvement only — README screenshot table is not refreshed.

## Test plan

- [x] `pnpm build:wasm` — all 3 packages build with new signatures.
- [x] `pnpm -r typecheck` — all workspace packages pass.
- [x] Storybook smoke test (`docxviewer-examples--demo`): default cap renders normally; `parse_docx(bytes, 1024n)` returns `{"error":"word/document.xml: exceeds size limit"}`. Same for `parse_pptx` / `parse_xlsx`.
- [ ] Run `pnpm vrt` locally before tagging — references not regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)