### PR TITLE
chore: switch npm author email to silurus.dev@gmail.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.37.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
-  "author": "Yuki Yokotani <26348105+yukiyokotani@users.noreply.github.com>",
+  "author": "Yuki Yokotani <silurus.dev@gmail.com>",
   "keywords": [
     "ooxml",
     "docx",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "version": "0.37.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
-  "author": "Yuki Yokotani <26348105+yukiyokotani@users.noreply.github.com>",
+  "author": "Yuki Yokotani <silurus.dev@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -4,7 +4,7 @@
   "version": "0.37.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
-  "author": "Yuki Yokotani <26348105+yukiyokotani@users.noreply.github.com>",
+  "author": "Yuki Yokotani <silurus.dev@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -4,7 +4,7 @@
   "version": "0.36.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
-  "author": "Yuki Yokotani <26348105+yukiyokotani@users.noreply.github.com>",
+  "author": "Yuki Yokotani <silurus.dev@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,7 @@
   "version": "0.36.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
-  "author": "Yuki Yokotani <26348105+yukiyokotani@users.noreply.github.com>",
+  "author": "Yuki Yokotani <silurus.dev@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -4,7 +4,7 @@
   "version": "0.37.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
-  "author": "Yuki Yokotani <26348105+yukiyokotani@users.noreply.github.com>",
+  "author": "Yuki Yokotani <silurus.dev@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -4,7 +4,7 @@
   "version": "0.37.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
-  "author": "Yuki Yokotani <26348105+yukiyokotani@users.noreply.github.com>",
+  "author": "Yuki Yokotani <silurus.dev@gmail.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yukiyokotani/office-open-xml-viewer.git",


### PR DESCRIPTION
## Summary

- Replaces the `26348105+yukiyokotani@users.noreply.github.com` placeholder added in 0.37.0 with a dedicated `silurus.dev@gmail.com` address in all 7 npm package author fields.
- Keeps the everyday gmail inbox out of npm registry scrapes while still giving consumers a real reply path.

## Test plan

- [x] `grep -H author package.json packages/*/package.json` — 7 files updated, vscode-extension unchanged (publisher-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)