### PR TITLE
fix(pptx): suppress spcBef on first paragraph of text body

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1034,7 +1034,8 @@ function renderTextBody(
   // AutoNum counters per list level
   const autoNumCounters = new Map<number, number>();
 
-  for (const para of body.paragraphs) {
+  for (let paraIdx = 0; paraIdx < body.paragraphs.length; paraIdx++) {
+    const para = body.paragraphs[paraIdx];
     const marLPx   = emuToPx(para.marL,   scale);
     const marRPx   = emuToPx(para.marR,   scale);
     const indentPx = emuToPx(para.indent, scale);
@@ -1170,7 +1171,13 @@ function renderTextBody(
         lineHeight = maxSizePx * 1.2;
       }
       const linePx  = lineHeight + (isLast ? spaceAfterPx : 0);
-      const topGap  = isFirst ? spaceBeforePx : 0;
+      // ECMA-376 §21.1.2.2.6 (a:spcBef): paragraph "space before" is the gap
+      // *between* paragraphs. PowerPoint suppresses it on the first paragraph
+      // of a text body — otherwise placeholders whose layout-default `spcBef`
+      // is 10 pt (sample-1 slide-5 "Figure 1." caption inherits this from the
+      // layout body lstStyle) get pushed ~10 px below the placeholder top and
+      // collide with the chart title sitting just below in the slide.
+      const topGap  = isFirst && paraIdx > 0 ? spaceBeforePx : 0;
       // Non-bullet first-line indent
       const textXOffset = (!hasBullet && isFirst) ? indentPx : 0;
 


### PR DESCRIPTION
## Summary

ECMA-376 §21.1.2.2.6 (`a:spcBef`) is the gap *between* paragraphs; PowerPoint suppresses it on the first paragraph of any text body. The renderer was applying it unconditionally, pushing first-paragraph text ~`spcBef` pt below the placeholder top.

`public/demo/sample-1.pptx` slide-5 shows this clearly: the "Figure 1. Canopy cover index by quarter, 2019–2025. Source: aerial LIDAR composites." caption inherits a layout-level `spcBef=1000` (10 pt) from the slide layout's body lstStyle. With the unconditional spcBef the caption rendered ~10 px below the placeholder top, dropping it onto the chart frame just below (chart `graphicFrame@y` is only 93026 EMU ≈ 10 px below the placeholder), so the caption visually overlapped the "Canopy Cover Index" chart title.

PowerPoint exports the same file with the caption stacked cleanly above the chart title (see `public/demo/sample-1.pdf`).

The fix gates `topGap` on `paraIdx > 0` in `buildLayout`.

## Test plan

- [x] `pnpm --filter @silurus/ooxml-pptx vrt` — all 9 demo references still pass (private samples fail with 404 because the worktree doesn't carry them; expected per CLAUDE.md)
- [x] Storybook PptxViewer demo, slide 5: caption and chart title visually separated, matching the PowerPoint PDF export

🤖 Generated with [Claude Code](https://claude.com/claude-code)