### PR TITLE
feat(xlsx): Excel-style prev/next buttons for sheet tab bar

### DIFF
--- a/docs/superpowers/plans/2026-05-30-xlsx-tab-nav-buttons.md
+++ b/docs/superpowers/plans/2026-05-30-xlsx-tab-nav-buttons.md
@@ -1,0 +1,401 @@
+# XLSX Sheet Tab Navigation Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Excel-style ◀▶ navigation buttons to the XLSX viewer's sheet tab bar so tabs that overflow the container width can be scrolled into view without relying on a hidden scrollbar.
+
+**Architecture:** Split the existing single scroll-container tab bar into a fixed left-side nav-button group plus a scrollable tab strip. The buttons scroll the strip (they do not change the active sheet) and disable themselves at the ends / when there is no overflow. The strip keeps `overflow-x:auto` so trackpad / Shift+wheel still work.
+
+**Tech Stack:** TypeScript, DOM API (no framework), Playwright (real-browser interaction test), Vite dev server.
+
+---
+
+## File Structure
+
+- **Modify:** `packages/xlsx/src/viewer.ts` — all production changes live here (DOM construction in the constructor, `buildTabs`, new `makeNavButton` / `navButtonStyle` / `scrollTabs` / `updateNavButtons`, ResizeObserver wiring, new fields).
+- **Create:** `packages/xlsx/tests/visual/viewer-fixture.html` — mounts a real `XlsxViewer` in a deliberately narrow (360px) container so the 5 long-named sheets in `demo/sample-1.xlsx` overflow.
+- **Create:** `packages/xlsx/tests/visual/tab-nav.spec.ts` — Playwright interaction test driving the buttons.
+
+`demo/sample-1.xlsx` has 5 sheets (`Dashboard`, `Forest Inventory`, `Species Analysis`, `Carbon & Growth`, `Biodiversity Index`). At up to `max-width:160px` per tab these always overflow a 360px container, giving a stable overflow condition without committing a new `.xlsx` fixture (committing xlsx files is forbidden by repo rules).
+
+All paths below are relative to the repo root. Run commands from `packages/xlsx/`.
+
+---
+
+## Task 1: Failing interaction test (red)
+
+**Files:**
+- Create: `packages/xlsx/tests/visual/viewer-fixture.html`
+- Create: `packages/xlsx/tests/visual/tab-nav.spec.ts`
+
+- [ ] **Step 1: Create the viewer fixture page**
+
+Create `packages/xlsx/tests/visual/viewer-fixture.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>XLSX Viewer – tab nav fixture</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { height: 100%; background: #fff; }
+    /* Narrow host so the 5 sheet tabs in sample-1 overflow horizontally. */
+    #host { width: 360px; height: 480px; }
+  </style>
+</head>
+<body>
+<div id="host"></div>
+<script type="module">
+  import { XlsxViewer } from '/src/index.ts';
+
+  const params = new URLSearchParams(location.search);
+  const file = params.get('file') ?? 'demo/sample-1.xlsx';
+  const host = document.getElementById('host');
+
+  const viewer = new XlsxViewer(host, {
+    onReady: () => { document.body.dataset.status = 'ready'; },
+    onError: (e) => {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = e instanceof Error ? e.message : String(e);
+    },
+  });
+
+  await viewer.load('/' + file);
+</script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Write the failing Playwright spec**
+
+Create `packages/xlsx/tests/visual/tab-nav.spec.ts`:
+
+```ts
+import { test, expect, type Locator } from '@playwright/test';
+
+test.describe('xlsx sheet tab navigation buttons', () => {
+  test('prev/next scroll the tab strip and disable at the ends', async ({ page }) => {
+    await page.goto('/tests/visual/viewer-fixture.html');
+    await expect(page.locator('body')).toHaveAttribute('data-status', 'ready');
+
+    const prev = page.locator('[data-xlsx-tab-nav="prev"]');
+    const next = page.locator('[data-xlsx-tab-nav="next"]');
+    await expect(prev).toBeVisible();
+    await expect(next).toBeVisible();
+
+    const scrollLeft = () =>
+      page.evaluate(() => {
+        const strip = document.querySelector('.xlsx-tab-strip');
+        return strip ? (strip as HTMLElement).scrollLeft : -1;
+      });
+
+    // Disabled is encoded as pointer-events:none on the button's inline style.
+    const isDisabled = (loc: Locator) =>
+      loc.evaluate((el) => (el as HTMLElement).style.pointerEvents === 'none');
+
+    // Initial state: scrolled to start, prev disabled, next enabled (5 long
+    // tabs overflow the 360px host).
+    await expect.poll(scrollLeft).toBe(0);
+    await expect.poll(() => isDisabled(prev)).toBe(true);
+    await expect.poll(() => isDisabled(next)).toBe(false);
+
+    // One next click must increase scrollLeft.
+    const before = await scrollLeft();
+    await next.click();
+    await expect.poll(scrollLeft).toBeGreaterThan(before);
+
+    // Click next until it disables (reached the end).
+    for (let i = 0; i < 12; i++) {
+      if (await isDisabled(next)) break;
+      await next.click();
+    }
+    await expect.poll(() => isDisabled(next)).toBe(true);
+    await expect.poll(() => isDisabled(prev)).toBe(false);
+
+    // Click prev back to the start.
+    for (let i = 0; i < 12; i++) {
+      if (await isDisabled(prev)) break;
+      await prev.click();
+    }
+    await expect.poll(() => isDisabled(prev)).toBe(true);
+    await expect.poll(scrollLeft).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm --filter @silurus/ooxml-xlsx vrt -- tab-nav.spec.ts`
+
+(Equivalent: from `packages/xlsx/`, `npx playwright test --config playwright.config.ts tab-nav.spec.ts`.)
+
+Expected: FAIL. The locators `[data-xlsx-tab-nav="prev"]` / `"next"` do not exist yet, so `expect(prev).toBeVisible()` times out.
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add packages/xlsx/tests/visual/viewer-fixture.html packages/xlsx/tests/visual/tab-nav.spec.ts
+git commit -m "test(xlsx): add failing interaction test for sheet tab nav buttons"
+```
+
+---
+
+## Task 2: Restructure the tab bar DOM (nav group + scrollable strip)
+
+**Files:**
+- Modify: `packages/xlsx/src/viewer.ts`
+
+- [ ] **Step 1: Add the new private fields**
+
+In the field declaration block (currently around `packages/xlsx/src/viewer.ts:50-51`, after `private tabBar: HTMLDivElement;` and `private tabs: HTMLButtonElement[] = [];`), add three fields. Follow the existing pattern (no `!` definite-assignment — they are assigned in the constructor, like `canvas` / `canvasArea`):
+
+```ts
+  private tabBar: HTMLDivElement;
+  private tabStrip: HTMLDivElement;
+  private navPrev: HTMLButtonElement;
+  private navNext: HTMLButtonElement;
+  private tabs: HTMLButtonElement[] = [];
+```
+
+- [ ] **Step 2: Replace the tab-bar construction block**
+
+In the constructor, replace the current block (`packages/xlsx/src/viewer.ts:100-108`):
+
+```ts
+    this.tabBar = document.createElement('div');
+    this.tabBar.style.cssText =
+      `display:flex;align-items:flex-end;height:${TAB_BAR_H}px;flex-shrink:0;` +
+      `background:#f0f0f0;border-top:1px solid #c8ccd0;` +
+      `overflow-x:auto;overflow-y:hidden;padding:0 4px;gap:1px;scrollbar-width:none;`;
+    const style = document.createElement('style');
+    style.textContent = `.xlsx-tab-bar::-webkit-scrollbar{display:none}`;
+    document.head.appendChild(style);
+    this.tabBar.classList.add('xlsx-tab-bar');
+```
+
+with this (tabBar no longer scrolls; it holds the nav buttons + a scrollable strip):
+
+```ts
+    this.tabBar = document.createElement('div');
+    this.tabBar.style.cssText =
+      `display:flex;align-items:flex-end;height:${TAB_BAR_H}px;flex-shrink:0;` +
+      `background:#f0f0f0;border-top:1px solid #c8ccd0;padding:0 4px;gap:2px;`;
+
+    // Excel-style scroll buttons. They scroll the tab strip; they do NOT change
+    // the active sheet. Disabled (greyed) at the ends / when there is no overflow.
+    this.navPrev = this.makeNavButton('◀', 'Scroll tabs left', () => this.scrollTabs(-1));
+    this.navNext = this.makeNavButton('▶', 'Scroll tabs right', () => this.scrollTabs(1));
+    this.navPrev.dataset.xlsxTabNav = 'prev';
+    this.navNext.dataset.xlsxTabNav = 'next';
+    this.navNext.style.marginRight = '4px';
+
+    // The scrollable strip that actually holds the sheet tabs. position:relative
+    // so each tab's offsetLeft is measured against the strip's scroll content.
+    this.tabStrip = document.createElement('div');
+    this.tabStrip.style.cssText =
+      `position:relative;display:flex;align-items:flex-end;flex:1;min-width:0;height:100%;` +
+      `overflow-x:auto;overflow-y:hidden;gap:1px;scrollbar-width:none;`;
+    this.tabStrip.classList.add('xlsx-tab-strip');
+    const style = document.createElement('style');
+    style.textContent = `.xlsx-tab-strip::-webkit-scrollbar{display:none}`;
+    document.head.appendChild(style);
+    this.tabStrip.addEventListener('scroll', () => this.updateNavButtons());
+
+    this.tabBar.appendChild(this.navPrev);
+    this.tabBar.appendChild(this.navNext);
+    this.tabBar.appendChild(this.tabStrip);
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `pnpm --filter @silurus/ooxml-xlsx typecheck`
+
+Expected: FAIL — `makeNavButton`, `scrollTabs`, and `updateNavButtons` are referenced but not yet defined (errors like `Property 'makeNavButton' does not exist`). This confirms the wiring points at the methods added in Task 3. (Do not commit yet — the next task makes it compile.)
+
+---
+
+## Task 3: Implement nav-button helpers, scrolling, and disabled state
+
+**Files:**
+- Modify: `packages/xlsx/src/viewer.ts`
+
+- [ ] **Step 1: Point `buildTabs` at the strip and refresh button state**
+
+Replace `buildTabs` (`packages/xlsx/src/viewer.ts:682-694`):
+
+```ts
+  private buildTabs(): void {
+    this.tabBar.innerHTML = '';
+    this.tabs = [];
+    this.wb.sheetNames.forEach((name, i) => {
+      const btn = document.createElement('button');
+      btn.textContent = name;
+      btn.title = name;
+      btn.style.cssText = this.tabStyle(false);
+      btn.addEventListener('click', () => this.showSheet(i));
+      this.tabBar.appendChild(btn);
+      this.tabs.push(btn);
+    });
+  }
+```
+
+with (append to `tabStrip`, not `tabBar`, and refresh nav state after building):
+
+```ts
+  private buildTabs(): void {
+    this.tabStrip.innerHTML = '';
+    this.tabs = [];
+    this.wb.sheetNames.forEach((name, i) => {
+      const btn = document.createElement('button');
+      btn.textContent = name;
+      btn.title = name;
+      btn.style.cssText = this.tabStyle(false);
+      btn.addEventListener('click', () => this.showSheet(i));
+      this.tabStrip.appendChild(btn);
+      this.tabs.push(btn);
+    });
+    this.updateNavButtons();
+  }
+```
+
+- [ ] **Step 2: Add the nav-button helpers and scroll/state logic**
+
+Insert these four methods immediately after `buildTabs` (before `updateTabActive` at `packages/xlsx/src/viewer.ts:696`):
+
+```ts
+  private makeNavButton(glyph: string, label: string, onClick: () => void): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.textContent = glyph;
+    btn.setAttribute('aria-label', label);
+    btn.title = label;
+    btn.style.cssText = this.navButtonStyle(false);
+    btn.addEventListener('click', onClick);
+    return btn;
+  }
+
+  private navButtonStyle(disabled: boolean): string {
+    // Sit a touch lower than the active tab (matches inactive tab height) and
+    // share the tab palette so the buttons read as part of the tab strip.
+    const base =
+      `flex-shrink:0;width:22px;height:${TAB_BAR_H - 5}px;` +
+      `display:flex;align-items:center;justify-content:center;` +
+      `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
+      `background:#e0e0e0;color:#555;font-size:9px;line-height:1;` +
+      `box-sizing:border-box;outline:none;`;
+    return disabled
+      ? base + `opacity:0.35;cursor:default;pointer-events:none;`
+      : base + `cursor:pointer;`;
+  }
+
+  private scrollTabs(dir: -1 | 1): void {
+    const strip = this.tabStrip;
+    const viewLeft = strip.scrollLeft;
+    const viewRight = viewLeft + strip.clientWidth;
+    let target: number | null = null;
+    if (dir === 1) {
+      // First tab clipped on the right; align its right edge to the viewport.
+      for (const tab of this.tabs) {
+        const right = tab.offsetLeft + tab.offsetWidth;
+        if (right > viewRight + 1) {
+          target = right - strip.clientWidth;
+          break;
+        }
+      }
+    } else {
+      // Last tab clipped on the left; align its left edge to the viewport.
+      for (let i = this.tabs.length - 1; i >= 0; i--) {
+        const left = this.tabs[i].offsetLeft;
+        if (left < viewLeft - 1) {
+          target = left;
+          break;
+        }
+      }
+    }
+    if (target !== null) {
+      // Instant (not smooth) so the disabled state is consistent the moment the
+      // click resolves — keeps the interaction deterministic to drive/test.
+      strip.scrollLeft = Math.max(0, target);
+    }
+    this.updateNavButtons();
+  }
+
+  private updateNavButtons(): void {
+    const strip = this.tabStrip;
+    const atStart = strip.scrollLeft <= 0;
+    const atEnd = strip.scrollLeft + strip.clientWidth >= strip.scrollWidth - 1;
+    // No overflow => scrollWidth ≈ clientWidth => both ends true => both disabled.
+    this.navPrev.style.cssText = this.navButtonStyle(atStart);
+    this.navNext.style.cssText = this.navButtonStyle(atEnd);
+  }
+```
+
+- [ ] **Step 3: Refresh nav state on resize**
+
+The constructor already has a `ResizeObserver` observing `canvasArea` (currently `packages/xlsx/src/viewer.ts:120-124`):
+
+```ts
+    this.resizeObserver = new ResizeObserver(() => {
+      this.renderCurrentSheet();
+      this.updateSelectionOverlay();
+    });
+    this.resizeObserver.observe(this.canvasArea);
+```
+
+Add `this.updateNavButtons();` to the callback (the tab bar resizes together with `canvasArea`, so overflow state can change):
+
+```ts
+    this.resizeObserver = new ResizeObserver(() => {
+      this.renderCurrentSheet();
+      this.updateSelectionOverlay();
+      this.updateNavButtons();
+    });
+    this.resizeObserver.observe(this.canvasArea);
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `pnpm --filter @silurus/ooxml-xlsx typecheck`
+
+Expected: PASS (no errors).
+
+---
+
+## Task 4: Green + commit
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the interaction test**
+
+Run: `pnpm --filter @silurus/ooxml-xlsx vrt -- tab-nav.spec.ts`
+
+Expected: PASS (1 passed).
+
+- [ ] **Step 2: Run the full xlsx VRT to confirm no regression**
+
+First rebuild the parser per repo rule, then run the full suite:
+
+Run: `pnpm --filter @silurus/ooxml-xlsx vrt`
+
+Expected: PASS. The existing visual specs render via `XlsxWorkbook.renderViewport` straight to a canvas and never mount `XlsxViewer`, so the tab-bar change cannot affect the reference-image comparisons. (If `demo/sample-1.xlsx` is missing locally, the existing visual tests are skipped/fail for that reason, not because of this change — the new `tab-nav` test still runs against the same sample.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/xlsx/src/viewer.ts
+git commit -m "feat(xlsx): add Excel-style prev/next buttons to sheet tab bar
+
+The tab strip hides its scrollbar, leaving plain-mouse users with no way to
+reach overflowing sheet tabs. Add fixed ◀▶ buttons at the left of the tab bar
+that scroll the strip one clipped tab per click and disable at the ends / when
+there is no overflow. overflow-x:auto stays so trackpad / Shift+wheel still work."
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** left ◀▶ always-visible buttons (Task 2), scroll-the-strip semantics not active-sheet change (Task 3 `scrollTabs`), disabled at ends + no-overflow (Task 3 `updateNavButtons`), DOM split into navGroup + tabStrip (Task 2), `buildTabs` retargeted (Task 3), state hooks on scroll/resize/buildTabs (Tasks 2–3), kept `overflow-x:auto` + hidden scrollbar (Task 2), Playwright interaction test, VRT references untouched (Tasks 1 & 4). All covered.
+- **Type consistency:** `tabStrip` / `navPrev` / `navNext` declared in Task 2 and used in Tasks 2–3; method names `makeNavButton` / `navButtonStyle` / `scrollTabs` / `updateNavButtons` consistent across wiring (Task 2) and definitions (Task 3); `.xlsx-tab-strip` class used in both product code and the test selector.
+- **Deviation from spec (deliberate):** spec mentioned `scrollTo({ behavior:'smooth' })`; the plan uses an instant `scrollLeft` assignment so the disabled state is settled when the click resolves, keeping the test deterministic without arbitrary waits. UX impact is negligible for one-tab steps.

--- a/docs/superpowers/specs/2026-05-30-xlsx-tab-nav-buttons-design.md
+++ b/docs/superpowers/specs/2026-05-30-xlsx-tab-nav-buttons-design.md
@@ -1,0 +1,108 @@
+# XLSX シートタブ送りボタン 設計
+
+- 日付: 2026-05-30
+- パッケージ: `packages/xlsx`
+- 対象ファイル: `packages/xlsx/src/viewer.ts`
+
+## 背景・課題
+
+シートタブ帯は `overflow-x:auto` でスクロール可能だが、スクロールバーを
+CSS で非表示にしている（`scrollbar-width:none` + `::-webkit-scrollbar{display:none}`）。
+そのため:
+
+- タブがコンテナ幅に入り切らなくても、スクロールできることが視覚的に伝わらない。
+- プレーンなマウス（縦ホイールのみ）ユーザーには事実上スクロール手段がない。
+  トラックパッド横スワイプ / Shift+ホイール / Magic Mouse 横スワイプを知らないと操作不能。
+
+Excel 同様に明示的な送りボタンを設けて、この affordance 欠如を解消する。
+
+## 方針
+
+- タブ帯の**左端に ◀▶ の2ボタンを常時表示**する（Excel 準拠）。
+- ボタンはタブ帯（スクロール領域）を**スクロールさせるだけ**で、アクティブシートは変更しない。
+- オーバーフローしていない、またはスクロール端に達したら該当ボタンを **disabled（グレーアウト）** にする。
+- 既存の `overflow-x:auto` は残し、トラックパッド横スワイプ / Shift+ホイールも併用可能なままにする。
+- スクロールバー非表示は維持（ボタンが affordance を担うため）。
+
+## DOM 構造の変更
+
+現状は `this.tabBar` 自体がスクロールコンテナ（`overflow-x:auto`）で、タブボタンを
+直接子に持つ。これを2層に分割する:
+
+```
+tabBar (flex, align-items:flex-end, height:TAB_BAR_H, flex-shrink:0, スクロールしない)
+├── navGroup (flex-shrink:0)        ◀ ▶  ← 固定。左端
+└── tabStrip (flex:1, overflow-x:auto, overflow-y:hidden, scrollbar 非表示)
+        └── tab buttons ...         ← buildTabs() の append 先をここに変更
+```
+
+- `overflow-x:auto` 等のスクロール関連スタイルは `tabBar` から `tabStrip` へ移す。
+- `tabBar` 自体はスクロールせず、navGroup と tabStrip を横並びにするだけ。
+- `.xlsx-tab-bar::-webkit-scrollbar{display:none}` のセレクタは tabStrip に付けたクラスへ合わせる。
+
+## コンポーネント / メソッド
+
+### フィールド
+- `private tabStrip: HTMLDivElement` — スクロール領域。タブボタンの親。
+- `private navPrev: HTMLButtonElement` — ◀
+- `private navNext: HTMLButtonElement` — ▶
+
+### `buildTabs()`（変更）
+タブボタンの append 先を `this.tabBar` → `this.tabStrip` に変更。生成後に
+`this.updateNavButtons()` を呼ぶ。
+
+### `updateTabActive(index)`（変更なしで動作）
+`scrollIntoView` の対象タブは `tabStrip` の子のままなので従来どおり機能する。
+スクロール後に `updateNavButtons()` が `scroll` イベント経由で呼ばれる。
+
+### `scrollTabs(dir: -1 | 1)`（新設）
+クリック方向で「見切れている次のタブ」が見える位置までスクロールする
+（1タブずつ送るフィール）:
+
+- `dir === -1`（◀）: tabStrip の左端より左に隠れているタブのうち最も右のものを探し、
+  その左端が見えるよう `scrollTo({ left, behavior: 'smooth' })`。
+- `dir === 1`（▶）: 右端より右に隠れているタブのうち最も左のものを探し、
+  その右端が見えるよう `scrollTo`。
+- 各タブの `offsetLeft` / `offsetWidth` と tabStrip の `scrollLeft` / `clientWidth` から境界を算出。
+
+### `updateNavButtons()`（新設）
+disabled 状態を再計算してボタンに反映:
+
+- ◀ disabled: `scrollLeft <= 0`
+- ▶ disabled: `scrollLeft + clientWidth >= scrollWidth - ε`（ε は 1px 程度）
+- disabled 時は `opacity` を下げ、`pointer-events:none`、`cursor:default`。
+
+### 呼び出し箇所
+`updateNavButtons()` を以下から呼ぶ:
+
+- `tabStrip` の `scroll` イベントリスナー
+- 既存の `ResizeObserver`（canvasArea を観測中。タブ帯幅も連動して変わる）
+- `buildTabs()` 直後
+- ボタンクリック（`scrollTabs` 内のスクロール後 / scroll イベントでも更新される）
+
+## スタイル
+
+- ボタンはタブ帯の色調（`#f0f0f0` 系）に馴染む小型の矢印ボタン。
+- 高さは `TAB_BAR_H` に揃え、`align-items` 基準で他タブと整合させる。
+- 矢印グリフは `◀` `▶`（または `‹` `›`）。`font-size` で小さめに。
+- `flex-shrink:0` で潰れない。`white-space:nowrap`。
+
+## テスト
+
+ロジックは `scrollWidth` / `clientWidth` 等のレイアウト計算に依存し、jsdom では
+0 になり検証できない。よって **Playwright で実ブラウザのインタラクションテスト**を追加する:
+
+1. 多数シート（横幅を確実に超える数）の workbook を読み込む。
+2. 初期状態: ◀ は disabled、▶ は enabled。
+3. ▶ をクリック → `tabStrip.scrollLeft` が増加することを確認。
+4. 末尾まで送ると ▶ が disabled、◀ が enabled になることを確認。
+5. ◀ で戻れることを確認。
+
+VRT 参照画像（`tests/visual/references/`、Excel export PNG）は対象外。送りボタンは
+viewer の chrome であり Excel export には存在しないため、参照画像は更新しない。
+
+## 非対象 (YAGNI)
+
+- ボタン長押しでの連続スクロール（Excel にはあるが MVP では見送り）。
+- 先頭/末尾ジャンプ（⏮⏭）。
+- 右クリックでのシート一覧ポップアップ。

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -100,10 +100,12 @@ export class XlsxViewer {
     this.canvasArea.appendChild(this.selectionOverlay);
     this.canvasArea.appendChild(this.scrollHost);
 
+    const headerW = Math.round(HEADER_W * (this.opts.cellScale ?? 1));
+
     this.tabBar = document.createElement('div');
     this.tabBar.style.cssText =
       `display:flex;align-items:flex-end;height:${TAB_BAR_H}px;flex-shrink:0;` +
-      `background:#f0f0f0;border-top:1px solid #c8ccd0;padding:0 4px;gap:2px;`;
+      `background:#f0f0f0;border-top:1px solid #c8ccd0;`;
 
     // Excel-style scroll buttons. They scroll the tab strip; they do NOT change
     // the active sheet. Disabled (greyed) at the ends / when there is no overflow.
@@ -111,7 +113,14 @@ export class XlsxViewer {
     this.navNext = this.makeNavButton('▶', 'Scroll tabs right', () => this.scrollTabs(1));
     this.navPrev.dataset.xlsxTabNav = 'prev';
     this.navNext.dataset.xlsxTabNav = 'next';
-    this.navNext.style.marginRight = '4px';
+
+    // The two buttons together span the row-header width so the tab strip starts
+    // at the same x as the data columns (which begin after the HEADER_W header).
+    const navGroup = document.createElement('div');
+    navGroup.style.cssText =
+      `display:flex;flex-shrink:0;width:${headerW}px;height:100%;`;
+    navGroup.appendChild(this.navPrev);
+    navGroup.appendChild(this.navNext);
 
     // The scrollable strip that actually holds the sheet tabs. position:relative
     // so each tab's offsetLeft is measured against the strip's scroll content.
@@ -128,8 +137,7 @@ export class XlsxViewer {
     document.head.appendChild(style);
     this.tabStrip.addEventListener('scroll', () => this.updateNavButtons());
 
-    this.tabBar.appendChild(this.navPrev);
-    this.tabBar.appendChild(this.navNext);
+    this.tabBar.appendChild(navGroup);
     this.tabBar.appendChild(this.tabStrip);
 
     wrapper.appendChild(this.canvasArea);
@@ -736,9 +744,9 @@ export class XlsxViewer {
     // hover tint) lives in the injected `.xlsx-tab-nav` stylesheet so the inline
     // style does not shadow the `:hover` rule.
     const base =
-      `flex-shrink:0;align-self:center;width:18px;height:18px;padding:0;` +
+      `flex:1;height:100%;padding:0;` +
       `display:flex;align-items:center;justify-content:center;` +
-      `border:none;border-radius:3px;color:#666;font-size:8px;line-height:1;` +
+      `border:none;color:#666;font-size:9px;line-height:1;` +
       `box-sizing:border-box;outline:none;`;
     return disabled
       ? base + `opacity:0.3;cursor:default;pointer-events:none;`

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -121,7 +121,10 @@ export class XlsxViewer {
       `overflow-x:auto;overflow-y:hidden;gap:1px;scrollbar-width:none;`;
     this.tabStrip.classList.add('xlsx-tab-strip');
     const style = document.createElement('style');
-    style.textContent = `.xlsx-tab-strip::-webkit-scrollbar{display:none}`;
+    style.textContent =
+      `.xlsx-tab-strip::-webkit-scrollbar{display:none}` +
+      `.xlsx-tab-nav{background:transparent;transition:background 0.1s;}` +
+      `.xlsx-tab-nav:hover{background:rgba(0,0,0,0.08);}`;
     document.head.appendChild(style);
     this.tabStrip.addEventListener('scroll', () => this.updateNavButtons());
 
@@ -722,22 +725,23 @@ export class XlsxViewer {
     btn.textContent = glyph;
     btn.setAttribute('aria-label', label);
     btn.title = label;
+    btn.classList.add('xlsx-tab-nav');
     btn.style.cssText = this.navButtonStyle(false);
     btn.addEventListener('click', onClick);
     return btn;
   }
 
   private navButtonStyle(disabled: boolean): string {
-    // Sit a touch lower than the active tab (matches inactive tab height) and
-    // share the tab palette so the buttons read as part of the tab strip.
+    // Plain triangle icons — no border / tab chrome. The background (incl. the
+    // hover tint) lives in the injected `.xlsx-tab-nav` stylesheet so the inline
+    // style does not shadow the `:hover` rule.
     const base =
-      `flex-shrink:0;width:22px;height:${TAB_BAR_H - 5}px;` +
+      `flex-shrink:0;align-self:center;width:18px;height:18px;padding:0;` +
       `display:flex;align-items:center;justify-content:center;` +
-      `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
-      `background:#e0e0e0;color:#555;font-size:9px;line-height:1;` +
+      `border:none;border-radius:3px;color:#666;font-size:8px;line-height:1;` +
       `box-sizing:border-box;outline:none;`;
     return disabled
-      ? base + `opacity:0.35;cursor:default;pointer-events:none;`
+      ? base + `opacity:0.3;cursor:default;pointer-events:none;`
       : base + `cursor:pointer;`;
   }
 

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -48,6 +48,9 @@ export class XlsxViewer {
   private scrollHost: HTMLDivElement;
   private spacer: HTMLDivElement;
   private tabBar: HTMLDivElement;
+  private tabStrip: HTMLDivElement;
+  private navPrev: HTMLButtonElement;
+  private navNext: HTMLButtonElement;
   private tabs: HTMLButtonElement[] = [];
   private currentSheet = 0;
   private currentWorksheet: Worksheet | null = null;
@@ -100,12 +103,31 @@ export class XlsxViewer {
     this.tabBar = document.createElement('div');
     this.tabBar.style.cssText =
       `display:flex;align-items:flex-end;height:${TAB_BAR_H}px;flex-shrink:0;` +
-      `background:#f0f0f0;border-top:1px solid #c8ccd0;` +
-      `overflow-x:auto;overflow-y:hidden;padding:0 4px;gap:1px;scrollbar-width:none;`;
+      `background:#f0f0f0;border-top:1px solid #c8ccd0;padding:0 4px;gap:2px;`;
+
+    // Excel-style scroll buttons. They scroll the tab strip; they do NOT change
+    // the active sheet. Disabled (greyed) at the ends / when there is no overflow.
+    this.navPrev = this.makeNavButton('◀', 'Scroll tabs left', () => this.scrollTabs(-1));
+    this.navNext = this.makeNavButton('▶', 'Scroll tabs right', () => this.scrollTabs(1));
+    this.navPrev.dataset.xlsxTabNav = 'prev';
+    this.navNext.dataset.xlsxTabNav = 'next';
+    this.navNext.style.marginRight = '4px';
+
+    // The scrollable strip that actually holds the sheet tabs. position:relative
+    // so each tab's offsetLeft is measured against the strip's scroll content.
+    this.tabStrip = document.createElement('div');
+    this.tabStrip.style.cssText =
+      `position:relative;display:flex;align-items:flex-end;flex:1;min-width:0;height:100%;` +
+      `overflow-x:auto;overflow-y:hidden;gap:1px;scrollbar-width:none;`;
+    this.tabStrip.classList.add('xlsx-tab-strip');
     const style = document.createElement('style');
-    style.textContent = `.xlsx-tab-bar::-webkit-scrollbar{display:none}`;
+    style.textContent = `.xlsx-tab-strip::-webkit-scrollbar{display:none}`;
     document.head.appendChild(style);
-    this.tabBar.classList.add('xlsx-tab-bar');
+    this.tabStrip.addEventListener('scroll', () => this.updateNavButtons());
+
+    this.tabBar.appendChild(this.navPrev);
+    this.tabBar.appendChild(this.navNext);
+    this.tabBar.appendChild(this.tabStrip);
 
     wrapper.appendChild(this.canvasArea);
     wrapper.appendChild(this.tabBar);
@@ -120,6 +142,7 @@ export class XlsxViewer {
     this.resizeObserver = new ResizeObserver(() => {
       this.renderCurrentSheet();
       this.updateSelectionOverlay();
+      this.updateNavButtons();
     });
     this.resizeObserver.observe(this.canvasArea);
 
@@ -680,7 +703,7 @@ export class XlsxViewer {
   }
 
   private buildTabs(): void {
-    this.tabBar.innerHTML = '';
+    this.tabStrip.innerHTML = '';
     this.tabs = [];
     this.wb.sheetNames.forEach((name, i) => {
       const btn = document.createElement('button');
@@ -688,9 +711,75 @@ export class XlsxViewer {
       btn.title = name;
       btn.style.cssText = this.tabStyle(false);
       btn.addEventListener('click', () => this.showSheet(i));
-      this.tabBar.appendChild(btn);
+      this.tabStrip.appendChild(btn);
       this.tabs.push(btn);
     });
+    this.updateNavButtons();
+  }
+
+  private makeNavButton(glyph: string, label: string, onClick: () => void): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.textContent = glyph;
+    btn.setAttribute('aria-label', label);
+    btn.title = label;
+    btn.style.cssText = this.navButtonStyle(false);
+    btn.addEventListener('click', onClick);
+    return btn;
+  }
+
+  private navButtonStyle(disabled: boolean): string {
+    // Sit a touch lower than the active tab (matches inactive tab height) and
+    // share the tab palette so the buttons read as part of the tab strip.
+    const base =
+      `flex-shrink:0;width:22px;height:${TAB_BAR_H - 5}px;` +
+      `display:flex;align-items:center;justify-content:center;` +
+      `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
+      `background:#e0e0e0;color:#555;font-size:9px;line-height:1;` +
+      `box-sizing:border-box;outline:none;`;
+    return disabled
+      ? base + `opacity:0.35;cursor:default;pointer-events:none;`
+      : base + `cursor:pointer;`;
+  }
+
+  private scrollTabs(dir: -1 | 1): void {
+    const strip = this.tabStrip;
+    const viewLeft = strip.scrollLeft;
+    const viewRight = viewLeft + strip.clientWidth;
+    let target: number | null = null;
+    if (dir === 1) {
+      // First tab clipped on the right; align its right edge to the viewport.
+      for (const tab of this.tabs) {
+        const right = tab.offsetLeft + tab.offsetWidth;
+        if (right > viewRight + 1) {
+          target = right - strip.clientWidth;
+          break;
+        }
+      }
+    } else {
+      // Last tab clipped on the left; align its left edge to the viewport.
+      for (let i = this.tabs.length - 1; i >= 0; i--) {
+        const left = this.tabs[i].offsetLeft;
+        if (left < viewLeft - 1) {
+          target = left;
+          break;
+        }
+      }
+    }
+    if (target !== null) {
+      // Instant (not smooth) so the disabled state is consistent the moment the
+      // click resolves — keeps the interaction deterministic to drive/test.
+      strip.scrollLeft = Math.max(0, target);
+    }
+    this.updateNavButtons();
+  }
+
+  private updateNavButtons(): void {
+    const strip = this.tabStrip;
+    const atStart = strip.scrollLeft <= 0;
+    const atEnd = strip.scrollLeft + strip.clientWidth >= strip.scrollWidth - 1;
+    // No overflow => scrollWidth ≈ clientWidth => both ends true => both disabled.
+    this.navPrev.style.cssText = this.navButtonStyle(atStart);
+    this.navNext.style.cssText = this.navButtonStyle(atEnd);
   }
 
   private updateTabActive(index: number): void {
@@ -707,7 +796,7 @@ export class XlsxViewer {
     const activeH = TAB_BAR_H - 2;
     const inactiveH = TAB_BAR_H - 5;
     const base =
-      `display:inline-block;padding:0 14px;` +
+      `display:inline-block;flex:none;padding:0 14px;` +
       `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
       `cursor:pointer;white-space:nowrap;max-width:160px;overflow:hidden;text-overflow:ellipsis;` +
       `outline:none;box-sizing:border-box;`;

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -3,6 +3,10 @@ import type { ViewportRange, Worksheet } from './types.js';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, getMdwForWorksheet } from './renderer.js';
 
 const TAB_BAR_H = 30;
+// Gap between adjacent sheet tabs. The first tab also gets this much leading
+// space so it is offset from the row-header boundary by the same margin that
+// separates tabs from each other.
+const TAB_GAP = 1;
 
 export interface XlsxViewerOptions {
   /** Scale factor for cell/header dimensions (default 1). 0.5 = half size. */
@@ -125,9 +129,12 @@ export class XlsxViewer {
     // The scrollable strip that actually holds the sheet tabs. position:relative
     // so each tab's offsetLeft is measured against the strip's scroll content.
     this.tabStrip = document.createElement('div');
+    // margin-left (not padding) keeps the leading gap OUTSIDE the scroll content
+    // so each tab's offsetLeft / scrollLeft math is unaffected and scrolling
+    // still returns to exactly 0.
     this.tabStrip.style.cssText =
       `position:relative;display:flex;align-items:flex-end;flex:1;min-width:0;height:100%;` +
-      `overflow-x:auto;overflow-y:hidden;gap:1px;scrollbar-width:none;`;
+      `margin-left:${TAB_GAP}px;overflow-x:auto;overflow-y:hidden;gap:${TAB_GAP}px;scrollbar-width:none;`;
     this.tabStrip.classList.add('xlsx-tab-strip');
     const style = document.createElement('style');
     style.textContent =

--- a/packages/xlsx/tests/visual/tab-nav.spec.ts
+++ b/packages/xlsx/tests/visual/tab-nav.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect, type Locator } from '@playwright/test';
+
+test.describe('xlsx sheet tab navigation buttons', () => {
+  test('prev/next scroll the tab strip and disable at the ends', async ({ page }) => {
+    await page.goto('/tests/visual/viewer-fixture.html');
+    await expect(page.locator('body')).toHaveAttribute('data-status', 'ready');
+
+    const prev = page.locator('[data-xlsx-tab-nav="prev"]');
+    const next = page.locator('[data-xlsx-tab-nav="next"]');
+    await expect(prev).toBeVisible();
+    await expect(next).toBeVisible();
+
+    const scrollLeft = () =>
+      page.evaluate(() => {
+        const strip = document.querySelector('.xlsx-tab-strip');
+        return strip ? (strip as HTMLElement).scrollLeft : -1;
+      });
+
+    // Disabled is encoded as pointer-events:none on the button's inline style.
+    const isDisabled = (loc: Locator) =>
+      loc.evaluate((el) => (el as HTMLElement).style.pointerEvents === 'none');
+
+    // Initial state: scrolled to start, prev disabled, next enabled (5 long
+    // tabs overflow the 360px host).
+    await expect.poll(scrollLeft).toBe(0);
+    await expect.poll(() => isDisabled(prev)).toBe(true);
+    await expect.poll(() => isDisabled(next)).toBe(false);
+
+    // One next click must increase scrollLeft.
+    const before = await scrollLeft();
+    await next.click();
+    await expect.poll(scrollLeft).toBeGreaterThan(before);
+
+    // Click next until it disables (reached the end).
+    for (let i = 0; i < 12; i++) {
+      if (await isDisabled(next)) break;
+      await next.click();
+    }
+    await expect.poll(() => isDisabled(next)).toBe(true);
+    await expect.poll(() => isDisabled(prev)).toBe(false);
+
+    // Click prev back to the start.
+    for (let i = 0; i < 12; i++) {
+      if (await isDisabled(prev)) break;
+      await prev.click();
+    }
+    await expect.poll(() => isDisabled(prev)).toBe(true);
+    await expect.poll(scrollLeft).toBe(0);
+  });
+});

--- a/packages/xlsx/tests/visual/viewer-fixture.html
+++ b/packages/xlsx/tests/visual/viewer-fixture.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>XLSX Viewer – tab nav fixture</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { height: 100%; background: #fff; }
+    /* Narrow host so the 5 sheet tabs in sample-1 overflow horizontally. */
+    #host { width: 360px; height: 480px; }
+  </style>
+</head>
+<body>
+<div id="host"></div>
+<script type="module">
+  import { XlsxViewer } from '/src/index.ts';
+
+  const params = new URLSearchParams(location.search);
+  const file = params.get('file') ?? 'demo/sample-1.xlsx';
+  const host = document.getElementById('host');
+
+  const viewer = new XlsxViewer(host, {
+    onReady: () => { document.body.dataset.status = 'ready'; },
+    onError: (e) => {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = e instanceof Error ? e.message : String(e);
+    },
+  });
+
+  await viewer.load('/' + file);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Sheet tabs that overflow the container were only reachable via trackpad/Shift+wheel because the tab bar's scrollbar is hidden — plain-mouse users had no affordance to scroll.
- Add fixed Excel-style ◀▶ buttons at the left of the tab bar. They scroll the tab strip one clipped tab per click (they do **not** change the active sheet) and grey out (disabled) at the ends / when there is no overflow.
- Split the single scroll-container tab bar into a fixed nav-button group + a scrollable `tabStrip`; tabs now keep their natural width (`flex:none`) so the strip genuinely overflows. `overflow-x:auto` stays, so trackpad / Shift+wheel still work.

## Implementation
- All production changes in `packages/xlsx/src/viewer.ts`: DOM restructure, `makeNavButton` / `navButtonStyle` / `scrollTabs` / `updateNavButtons`, `buildTabs` retargeted to the strip, and nav-state refresh wired into the existing `ResizeObserver` and the strip's `scroll` event.
- Design + plan docs under `docs/superpowers/`.

## Test Plan
- [x] New Playwright interaction test `packages/xlsx/tests/visual/tab-nav.spec.ts` (mounts the viewer in a 360px host where `demo/sample-1`'s 5 tabs overflow): asserts initial state (prev disabled, next enabled), that next/prev scroll the strip, and that buttons disable at each end. Passes.
- [x] `tsc --noEmit` clean.
- Note: the pre-existing `demo/sample-1` VRT pixel diffs and missing `private/*` samples are unrelated — they come from the `XlsxWorkbook` canvas-render path (`visual.spec.ts` never mounts the viewer), confirmed by reverting `viewer.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)