### PR TITLE
fix(xlsx): cell indent width per ECMA-376 §18.8.1 (sub-project B)

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1097,7 +1097,9 @@ function renderQuadrant(
     const isNumeric = cell.value.type === 'number';
     const alignH = xf.alignH ?? (isNumeric ? 'right' : 'left');
     const alignV = xf.alignV ?? 'bottom';
-    const indentPx = xf.indent ? Math.round(xf.indent * font.size * PT_TO_PX * 0.5) : 0;
+    // Indent: ECMA-376 §18.8.1 alignment@indent — one level indents by 3
+    // character widths (MDW) of the workbook's normal-style font.
+    const indentPx = xf.indent ? Math.round(xf.indent * 3 * rc.mdw) : 0;
     const leftPad = paddingX + (alignH === 'left' || !xf.alignH ? indentPx : 0);
 
     ctx.save();
@@ -1405,8 +1407,9 @@ function renderQuadrant(
       const isNumeric = cell.value.type === 'number';
       const alignH = xf.alignH ?? (isNumeric ? 'right' : 'left');
       const alignV = xf.alignV ?? 'bottom';
-      // Indent: each level ≈ one character width (ECMA-376 §18.8.44)
-      const indentPx = xf.indent ? Math.round(xf.indent * font.size * PT_TO_PX * 0.5) : 0;
+      // Indent: ECMA-376 §18.8.1 alignment@indent — one level indents by 3
+      // character widths (MDW) of the workbook's normal-style font.
+      const indentPx = xf.indent ? Math.round(xf.indent * 3 * rc.mdw) : 0;
       // IconSet: reserve space on the left for the icon
       const iconSz = cf.iconSet ? Math.max(8, Math.round(Math.min(cellW, cellH) * 0.55)) : 0;
       const iconPad = iconSz > 0 ? iconSz + 4 : 0;


### PR DESCRIPTION
## Summary

Sub-project **B** (fidelity over heuristics) of the stable-release roadmap.
First item: replace the cell-indent rendering heuristic with the
ECMA-376-specified formula.

## The heuristic

```js
// Indent: each level ≈ one character width (ECMA-376 §18.8.44)   ← wrong cite
const indentPx = xf.indent ? Math.round(xf.indent * font.size * PT_TO_PX * 0.5) : 0;
```

Two problems, both ungrounded:
- factor `0.5` on `font.size` (the **cell** font) is arbitrary;
- it under-indents to roughly one character (~7px at Calibri 11) and uses
  the wrong font and the wrong spec section.

## The spec

ECMA-376 §18.8.1 `alignment@indent`. Confirmed by the OpenXML / DevExpress
reference docs: *"an indent increment is equal to three spaces of the Normal
style font."* Excel measures character width as the **MDW** (max digit width)
— the same unit used for column widths (§18.3.1.13). So:

```js
// one level = 3 character widths (MDW) of the workbook's normal-style font
const indentPx = xf.indent ? Math.round(xf.indent * 3 * rc.mdw) : 0;
```

`rc.mdw` is already computed from the worksheet's default (normal-style) font,
so it is exactly the spec's unit. Applied at both draw paths (plain cell and
CF/iconSet).

## Verification

- `pnpm typecheck` passes.
- Regression VRT vs the pre-change baseline isolates the footprint: **only
  cells with `indent>0` change** — ~19 of 65 sheets shift horizontally
  (0.5–6.2% pixel diff); every non-indented sheet is byte-identical. That is
  exactly the expected blast radius for an indent-width change.
- Visual spot-check against the **Excel export** of `demo/sample-1` (Region
  column): the region-name indent now matches Excel's magnitude instead of the
  previous ~1-char under-indent.

## Reference caveat (needs maintainer's Excel eyes)

Pixel-exact confirmation is limited because the indent-bearing demo references
are stale for an unrelated reason (`demo/sample-1` sheet 1/2 row-height, noted
in the roadmap) and most `private/*` samples have no committed reference. The
formula is spec-grounded and visually consistent, but to lock it in as a clean
fidelity baseline, please re-export `demo/sample-1` from Excel and run
`UPDATE_REFS=1 pnpm --filter @silurus/ooxml-xlsx vrt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
