### PR TITLE
ci: typecheck-gate the npm publish workflow (sub-project A)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Build WASM (all packages)
         run: pnpm build:wasm
 
+      # Gate the release on a clean typecheck so a tag never publishes
+      # type-broken code (defence in depth alongside the PR CI workflow).
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Build library
         run: pnpm build
 


### PR DESCRIPTION
## Summary

Sub-project **A** follow-up. `publish.yml` built the WASM + library and then
ran `pnpm publish` straight to npm with **no type validation** — a `v*` tag
could ship type-broken code. Adds a `pnpm typecheck` step before the build so
a release aborts on a type error.

This is defence-in-depth alongside the PR CI workflow (#287): PR CI keeps `main`
clean, and this keeps the tag→publish path from regressing independently.

## Note

Cannot be exercised by PR CI (the publish workflow only triggers on `v*` tags).
The inserted step mirrors the existing step formatting; the same `pnpm typecheck`
command is already proven green in the PR CI run on #287. Left for review rather
than auto-merged since it touches the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
