### PR TITLE
chore: bootstrap ast-grep lint + CI (sub-project A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # ast-grep lint runs on source only (no WASM needed) — fail fast.
+      - name: ast-grep rule tests
+        run: pnpm lint:test
+
+      - name: Lint
+        run: pnpm lint
+
       # The WASM parsers are git-ignored build output; the TypeScript packages
       # import their generated .d.ts/.js, so typecheck requires building them first.
       - name: Build WASM

--- a/package.json
+++ b/package.json
@@ -63,9 +63,12 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "build:wasm": "pnpm --filter @silurus/ooxml-docx wasm && pnpm --filter @silurus/ooxml-xlsx wasm && pnpm --filter @silurus/ooxml-pptx wasm",
-    "vrt": "pnpm -r vrt"
+    "vrt": "pnpm -r vrt",
+    "lint": "ast-grep scan",
+    "lint:test": "ast-grep test --skip-snapshot-tests"
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.43.0",
     "@chromatic-com/storybook": "^5.1.2",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -61,7 +61,7 @@ function buildPptxTextLayer(layer: HTMLDivElement, runs: TextRunInfo[], cssWidth
       shapeMap.set(key, div);
       layer.appendChild(div);
     }
-    const shape = shapeMap.get(key)!;
+    const shape = shapeMap.get(key) as HTMLDivElement;
     const span = document.createElement('span');
     span.textContent = run.text;
     span.style.cssText =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@ast-grep/cli':
+        specifier: ^0.43.0
+        version: 0.43.0
       '@chromatic-com/storybook':
         specifier: ^5.1.2
         version: 5.1.2(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -207,6 +210,55 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ast-grep/cli-darwin-arm64@0.43.0':
+    resolution: {integrity: sha512-0i63gSBbgriPaRpFsbP3yETxolHPK2JAZbpcGbFOytB7QTnKAguwhlKmIOkUGKfsCzYiEq1awY0EBmvjMONXOg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.43.0':
+    resolution: {integrity: sha512-SPkj00HGKpYdqReUmso2ftG5Xgd+bWNFH4i9fubLxsWzn4ey2G6sotPruaOtcrzxb9xH+8kmhN7KJfm1k8Atzg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.43.0':
+    resolution: {integrity: sha512-U8+2fkcY8sBxNHHBYZ33vTa7C97GFAB+Kj6gFzVMSqK8Ve1Aw+DxhVWD4i/PBryDdmWb4/erjGSkTQtdhVa2vg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-linux-x64-gnu@0.43.0':
+    resolution: {integrity: sha512-r/o9Mag6OZmGevY9OJjatuUKDOX1rSvgo29qSfxpMbIciiH3hkzEW/2w1xTPZI8xnM7iC+k+CkGoknmoXVTYGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.43.0':
+    resolution: {integrity: sha512-oHa4ruD87xccnqFuR+Pmx6F/suHV0YtibuyZ6SxUqgpNJAFZiUNAiFblzhEgQ5gp03e8B012P/Yy/7GYOvxOLg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.43.0':
+    resolution: {integrity: sha512-RSzz9bKzSEutWgX7/g84guudEp75Q990CYpG/TBasdJP+U27zX8aA9d5p1+o/lF0hw3UoTYuFCGG8PU/QelfNQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.43.0':
+    resolution: {integrity: sha512-/5dDD9B65vVuHCdVHN5+tIDquhE5s43S5CgEn88w1BgQaoayf+nRnUO4ZFez6SqyCGqAfa/yZdoaOQ9N2ySa1w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.43.0':
+    resolution: {integrity: sha512-DGi6xXAOBJubGg9QWqTeW8PzKSGHWEOa3uxXspEfYf532yb3lHmNJAcKMl1d+O9Xs9bTcNeDLC8se+O+tirEFQ==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -3179,6 +3231,39 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ast-grep/cli-darwin-arm64@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/cli@0.43.0':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.43.0
+      '@ast-grep/cli-darwin-x64': 0.43.0
+      '@ast-grep/cli-linux-arm64-gnu': 0.43.0
+      '@ast-grep/cli-linux-x64-gnu': 0.43.0
+      '@ast-grep/cli-win32-arm64-msvc': 0.43.0
+      '@ast-grep/cli-win32-ia32-msvc': 0.43.0
+      '@ast-grep/cli-win32-x64-msvc': 0.43.0
 
   '@azu/format-text@1.0.2': {}
 

--- a/rule-tests/no-non-null-assertion-in-examples-test.yml
+++ b/rule-tests/no-non-null-assertion-in-examples-test.yml
@@ -1,0 +1,8 @@
+id: no-non-null-assertion-in-examples
+valid:
+  - "const c = document.getElementById('x') as HTMLCanvasElement;"
+  - "const v = map.get(k) as Foo;"
+  - "const negated = !flag;"
+invalid:
+  - "const s = map.get(k)!;"
+  - "const c = document.getElementById('x')!;"

--- a/rules/no-non-null-assertion-in-examples.yml
+++ b/rules/no-non-null-assertion-in-examples.yml
@@ -1,0 +1,12 @@
+id: no-non-null-assertion-in-examples
+language: TypeScript
+severity: error
+rule:
+  pattern: $X!
+message: Public-facing examples must use `as Type`, not the non-null assertion `!` (root CLAUDE.md "コード例の規約").
+note: |
+  README / docs / Storybook example code uses explicit `as Type` assertions
+  instead of postfix `!`. No auto-fix: the correct target type cannot be
+  inferred mechanically — rewrite e.g. `map.get(k)!` as `map.get(k) as Foo`.
+files:
+  - "**/*.stories.ts"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - rules
+testConfigs:
+  - testDir: rule-tests


### PR DESCRIPTION
## Summary

Sub-project **A** (engineering foundation). CLAUDE.md asks for
statically-checkable conventions to live in a linter rather than prose, and
flagged the absence of any lint/ast-grep. This bootstraps **ast-grep** (the
repo's chosen tool) with the infrastructure plus one grounded, green rule.

### What's added

- `sgconfig.yml`, `rules/`, `rule-tests/`, `@ast-grep/cli` devDep.
- Rule **no-non-null-assertion-in-examples**: bans the postfix `!` non-null
  assertion in `*.stories.ts` (the public-facing examples), enforcing the
  CLAUDE.md "コード例の規約" rule (`as Type`, not `!`). Detection-only — the
  correct `as Type` target can't be inferred mechanically.
- `pnpm lint` (scan) and `pnpm lint:test` (rule classification tests).
- CI runs both, fail-fast, before the WASM/typecheck/build steps.

### Caught a real violation

The rule found one existing offender — `Examples.stories.ts` used
`shapeMap.get(key)!`. Converted to `shapeMap.get(key) as HTMLDivElement` in a
separate commit, so the scan is now clean.

## Verification

- `pnpm lint:test` → 1 passed.
- `pnpm lint` → clean (exit 0).
- `pnpm typecheck` → PASS (including the edited story).
- This PR's CI exercises the new lint steps end-to-end.

The rule is intentionally narrow; the value here is the lint *infrastructure*
(config, tests, CI wiring) that future structural rules plug into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
