### PR TITLE
fix(chart): Excel-faithful auto axis max (sub-project B)

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -42,18 +42,14 @@ function niceStep(range: number, targetSteps = 5): number {
 
 function niceAxisMax(dataMax: number, step: number): number {
   if (dataMax <= 0) return step;
-  const ax = Math.ceil(dataMax / step) * step;
-  // Bump up by one step when the data fills the computed axis too tightly.
-  // PowerPoint adds breathing room above the highest bar so the data
-  // doesn't run flush against the plot edge; without this our stacked
-  // bar charts spill into adjacent shapes (sample-2 slide-16's right
-  // text column gets overlapped because the 9715 stack lands at exactly
-  // 9715/10000 = 97% of plot, with only 3% of slack). Threshold 0.9
-  // matches Excel's observed behaviour: data in [0.9, 1.0] of niceMax
-  // triggers the bump; below 0.9 the breathing room comes from the
-  // existing margin.
-  if (dataMax / ax >= 0.9) return ax + step;
-  return ax;
+  // Excel's automatic value-axis maximum is the smallest major-unit multiple
+  // that is >= dataMax — no extra headroom step. A bar filling 97% of the axis
+  // stays at 97%, exactly as Excel renders it. (Earlier code added one step
+  // when data exceeded 90% of the axis to stop stacked bars spilling into
+  // adjacent shapes, but that distorted the scale of every chart. Overlap is
+  // handled correctly by honoring <c:plotArea><c:manualLayout> — ECMA-376
+  // §21.2.2.32 — which constrains the plot rect, not by inflating the axis.)
+  return Math.ceil(dataMax / step) * step;
 }
 
 function niceAxisMin(dataMin: number, step: number): number {


### PR DESCRIPTION
## Summary

Sub-project **B** (fidelity over heuristics). `niceAxisMax` added a whole extra major-unit step whenever data filled ≥90% of the axis — a sample-fit hack (sample-2 slide-16) that distorted the scale of **every** chart.

Excel's automatic value-axis maximum is the smallest major-unit multiple ≥ dataMax; a series reaching 97% of the axis stays at 97%. The overlap the bump papered over is already handled by honoring `<c:plotArea><c:manualLayout>` (ECMA-376 §21.2.2.32).

## Verification

- Footprint: chart-bearing sheets/slides only (11 xlsx, 1 pptx); all else byte-identical.
- **xlsx private/sample-13**: stacked area now fills to its true max (40, was 50) — matches Excel.
- **pptx sample-2 slide-16**: bars fill correctly, **no overlap** into the right text column (manualLayout still constrains the plot rect).

Visual before/after checked locally; final Storybook review at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)