### PR TITLE
fix(pptx): apply PowerPoint's stored normAutofit fontScale/lnSpcReduction (sub-project B)

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -139,6 +139,17 @@ export interface TextBody {
   /** Auto-fit: "sp" = shape grows to fit text, "norm" = font shrinks, "none" = no fit */
   autoFit: string;
   /**
+   * `<a:normAutofit fontScale>` (ECMA-376 §21.1.2.1.3) — PowerPoint's stored,
+   * pre-computed font-shrink ratio for `autoFit === "norm"`, as a fraction
+   * (e.g. 0.625 for `fontScale="62500"`). Null/absent when PowerPoint stored no
+   * scale; the renderer then re-derives one. Applying the stored value matches
+   * PowerPoint exactly instead of guessing from our own text metrics.
+   */
+  fontScale?: number | null;
+  /** `<a:normAutofit lnSpcReduction>` — stored line-spacing reduction fraction
+   *  (e.g. 0.20 for `lnSpcReduction="20000"`). Null/absent when not stored. */
+  lnSpcReduction?: number | null;
+  /**
    * `<a:bodyPr numCol>` (ECMA-376 §20.1.10.34) — number of text columns inside
    * the shape. Defaults to 1; values > 1 cause the renderer to flow paragraphs
    * across N columns left-to-right, top-to-bottom.

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -969,6 +969,15 @@ struct TextBody {
     vert: String,
     /// Auto-fit mode from bodyPr: "sp" = spAutoFit (shape grows), "norm" = normAutoFit (font shrinks), "none" = noAutofit
     auto_fit: String,
+    /// `<a:normAutofit fontScale>` (ECMA-376 §21.1.2.1.3) — PowerPoint's stored
+    /// pre-computed font-shrink ratio as a fraction (62500 → 0.625). None when
+    /// absent; the renderer then re-derives the scale itself.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_scale: Option<f64>,
+    /// `<a:normAutofit lnSpcReduction>` — stored line-spacing reduction fraction
+    /// (20000 → 0.20). None when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ln_spc_reduction: Option<f64>,
     /// `<a:bodyPr numCol>` (ECMA-376 §20.1.10.34 / §21.1.2.1.1) — number of
     /// text columns inside the shape. Default 1. PowerPoint distributes
     /// paragraphs across columns left-to-right, top-to-bottom.
@@ -2705,10 +2714,19 @@ fn parse_text_body(
         .unwrap_or_else(|| "horz".into());
     // Auto-fit child element (spAutoFit / normAutofit). When the shape's own
     // bodyPr is absent or contains no autofit child, defer to theme txDef.
+    // For normAutofit, also capture PowerPoint's stored fontScale /
+    // lnSpcReduction (ECMA-376 §21.1.2.1.3) — ST_Percentage in 1000ths of a
+    // percent, so 62500 → 0.625. The renderer applies these directly.
+    let mut font_scale: Option<f64> = None;
+    let mut ln_spc_reduction: Option<f64> = None;
     let auto_fit = if let Some(n) = body_pr {
         if child(n, "spAutoFit").is_some() { "sp".to_owned() }
         // OOXML uses lowercase 'f': normAutofit (not normAutoFit).
-        else if child(n, "normAutofit").is_some() { "norm".to_owned() }
+        else if let Some(na) = child(n, "normAutofit") {
+            font_scale = attr_f64(&na, "fontScale").map(|v| v / 100000.0);
+            ln_spc_reduction = attr_f64(&na, "lnSpcReduction").map(|v| v / 100000.0);
+            "norm".to_owned()
+        }
         else if child(n, "noAutofit").is_some() { "none".to_owned() }
         else {
             // bodyPr present but no autofit child — fall back to theme.
@@ -2775,7 +2793,7 @@ fn parse_text_body(
         .map(|p| parse_paragraph(p, theme, rels, body_default_alignment.as_deref(), body_default_space_before, body_default_space_after, body_default_line_spacing))
         .collect();
 
-    TextBody { vertical_anchor, paragraphs, default_font_size, default_bold, default_italic, l_ins, r_ins, t_ins, b_ins, wrap, vert, auto_fit, num_col, spc_col }
+    TextBody { vertical_anchor, paragraphs, default_font_size, default_bold, default_italic, l_ins, r_ins, t_ins, b_ins, wrap, vert, auto_fit, font_scale, ln_spc_reduction, num_col, spc_col }
 }
 
 fn parse_paragraph(

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1170,6 +1170,12 @@ function renderTextBody(
       } else {
         lineHeight = maxSizePx * 1.2;
       }
+      // normAutofit lnSpcReduction (ECMA-376 §21.1.2.1.3): PowerPoint reduces
+      // each paragraph's line spacing by this fraction alongside the font
+      // shrink. Apply it only when normAutofit actually stored a value.
+      if (body.autoFit === 'norm' && body.lnSpcReduction != null) {
+        lineHeight *= 1 - body.lnSpcReduction;
+      }
       const linePx  = lineHeight + (isLast ? spaceAfterPx : 0);
       // ECMA-376 §21.1.2.2.6 (a:spcBef): paragraph "space before" is the gap
       // *between* paragraphs. PowerPoint suppresses it on the first paragraph
@@ -1199,16 +1205,25 @@ function renderTextBody(
 
   let { allLines, totalHeight } = buildLayout(1.0);
 
-  // ── normAutoFit: shrink font until text fits ─────────────────────────────
+  // ── normAutoFit ──────────────────────────────────────────────────────────
+  // PowerPoint stores the font-shrink ratio it computed at edit time in
+  // <a:normAutofit fontScale> (ECMA-376 §21.1.2.1.3). When present, apply it
+  // directly — this reproduces PowerPoint's exact layout instead of guessing a
+  // scale from our own (slightly different) text metrics. Only when no scale
+  // was stored do we fall back to fitting the text by search.
   if (body.autoFit === 'norm') {
-    const maxContentH = bh - tPad - bPad;
-    if (totalHeight > maxContentH && maxContentH > 0) {
-      let lo = 0.1, hi = 1.0;
-      for (let i = 0; i < 6; i++) {
-        const mid = (lo + hi) / 2;
-        if (buildLayout(mid).totalHeight <= maxContentH) lo = mid; else hi = mid;
+    if (body.fontScale != null && body.fontScale > 0) {
+      if (body.fontScale < 1.0) ({ allLines, totalHeight } = buildLayout(body.fontScale));
+    } else {
+      const maxContentH = bh - tPad - bPad;
+      if (totalHeight > maxContentH && maxContentH > 0) {
+        let lo = 0.1, hi = 1.0;
+        for (let i = 0; i < 6; i++) {
+          const mid = (lo + hi) / 2;
+          if (buildLayout(mid).totalHeight <= maxContentH) lo = mid; else hi = mid;
+        }
+        ({ allLines, totalHeight } = buildLayout(lo));
       }
-      ({ allLines, totalHeight } = buildLayout(lo));
     }
   }
 


### PR DESCRIPTION
## Summary

Sub-project **B**. The renderer re-derived the normAutofit font-shrink with a 6-step binary search because the parser **discarded the values PowerPoint had already computed**. PowerPoint stores them in `<a:normAutofit fontScale lnSpcReduction>` (ECMA-376 §21.1.2.1.3); reproducing its layout means using those, not re-fitting against our own slightly-different text metrics.

- **parser**: capture `fontScale` / `lnSpcReduction` (ST_Percentage ÷100000 → fraction) onto TextBody.
- **core**: add the two fields to the `TextBody` type.
- **renderer**: apply the stored fontScale directly and reduce line spacing by lnSpcReduction. The binary search remains **only** as a fallback for shapes where PowerPoint stored no scale → no behavior change there.

## Verification

- typecheck + lint clean; WASM rebuilds.
- Regression vs pre-change main: only **2 slides** touched (private/sample-4 slide-1 0.1%, demo/sample-1 slide-1 0.3%) — i.e. only shapes that actually carry a stored scale; all others byte-identical.
- **demo/sample-1 slide-1** (committed PowerPoint reference): the stored-scale render matches the reference title sizing — faithful.

Final Storybook review at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)