### PR TITLE
test: add vitest unit suite (+ fix a latent number-format bug it found)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      # Unit tests for pure-logic modules (formula engine, number formats).
+      # No WASM needed.
+      - name: Unit tests
+        run: pnpm test
+
       # The WASM parsers are git-ignored build output; the TypeScript packages
       # import their generated .d.ts/.js, so typecheck requires building them first.
       - name: Build WASM

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "build-storybook": "storybook build",
     "build:wasm": "pnpm --filter @silurus/ooxml-docx wasm && pnpm --filter @silurus/ooxml-xlsx wasm && pnpm --filter @silurus/ooxml-pptx wasm",
     "vrt": "pnpm -r vrt",
+    "test": "vitest run",
     "lint": "ast-grep scan",
     "lint:test": "ast-grep test --skip-snapshot-tests"
   },
@@ -77,6 +78,7 @@
     "vite": "^8.0.8",
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-top-level-await": "^1.6.0",
-    "vite-plugin-wasm": "^3.6.0"
+    "vite-plugin-wasm": "^3.6.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/xlsx/src/formula.test.ts
+++ b/packages/xlsx/src/formula.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { evalFormulaToBool } from './formula.js';
+import type { Cell } from './types.js';
+
+function numCell(row: number, col: number, n: number): Cell {
+  return { row, col, colRef: '', value: { type: 'number', number: n }, styleIndex: 0 };
+}
+
+function ctx(opts: { cells?: Cell[]; row?: number; col?: number } = {}) {
+  const cellIndex = new Map<string, Cell>();
+  for (const c of opts.cells ?? []) cellIndex.set(`${c.row}:${c.col}`, c);
+  return {
+    row: opts.row ?? 1,
+    col: opts.col ?? 1,
+    anchorRow: 1,
+    anchorCol: 1,
+    cellIndex,
+    definedNames: new Map(),
+    depth: 0,
+  };
+}
+
+const ev = (f: string, c = ctx()) => evalFormulaToBool(f, c);
+
+describe('evalFormulaToBool — comparisons', () => {
+  it('numeric comparisons', () => {
+    expect(ev('1>0')).toBe(true);
+    expect(ev('1<0')).toBe(false);
+    expect(ev('2>=2')).toBe(true);
+    expect(ev('2<=1')).toBe(false);
+    expect(ev('3=3')).toBe(true);
+    expect(ev('3<>3')).toBe(false);
+    expect(ev('3<>4')).toBe(true);
+  });
+
+  it('arithmetic before comparison', () => {
+    expect(ev('2+2=4')).toBe(true);
+    expect(ev('10-3*2=4')).toBe(true);
+    expect(ev('(10-2)/4=2')).toBe(true);
+  });
+
+  it('string comparison', () => {
+    expect(ev('"a"="a"')).toBe(true);
+    expect(ev('"a"="b"')).toBe(false);
+  });
+});
+
+describe('evalFormulaToBool — logical functions', () => {
+  it('AND / OR / NOT', () => {
+    expect(ev('AND(1>0,2>1)')).toBe(true);
+    expect(ev('AND(1>0,2>3)')).toBe(false);
+    expect(ev('OR(1>2,3>2)')).toBe(true);
+    expect(ev('OR(1>2,3>4)')).toBe(false);
+    expect(ev('NOT(1>2)')).toBe(true);
+    expect(ev('NOT(1>0)')).toBe(false);
+  });
+
+  it('IF', () => {
+    expect(ev('IF(1>0,1>0,1<0)')).toBe(true);
+    expect(ev('IF(1<0,1>0,1<0)')).toBe(false);
+  });
+
+  it('nested logic', () => {
+    expect(ev('AND(OR(1>2,2>1),NOT(3>4))')).toBe(true);
+  });
+});
+
+describe('evalFormulaToBool — cell references', () => {
+  it('reads a referenced cell (relative shift from anchor)', () => {
+    // anchor A1, evaluated at A1 → A1 resolves to the cell at (1,1)
+    const c = ctx({ cells: [numCell(1, 1, 90)], row: 1, col: 1 });
+    expect(evalFormulaToBool('A1>=90', c)).toBe(true);
+    expect(evalFormulaToBool('A1>90', c)).toBe(false);
+  });
+});

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { formatCellValue } from './number-format.js';
+import type { Cell, Styles } from './types.js';
+
+const FMT_ID = 164; // first free custom id
+
+function styles(formatCode: string): Styles {
+  return {
+    fonts: [],
+    fills: [],
+    borders: [],
+    cellXfs: [{ fontId: 0, fillId: 0, borderId: 0, numFmtId: FMT_ID, alignH: null, alignV: null, wrapText: false }],
+    numFmts: [{ numFmtId: FMT_ID, formatCode }],
+    dxfs: [],
+  };
+}
+
+function numCell(n: number): Cell {
+  return { row: 1, col: 1, colRef: 'A1', value: { type: 'number', number: n }, styleIndex: 0 };
+}
+
+/** Format a number with a custom format code, as Excel would render it. */
+const fmt = (n: number, code: string) => formatCellValue(numCell(n), styles(code));
+
+describe('number formats — integers & decimals', () => {
+  it('plain integer', () => {
+    expect(fmt(5, '0')).toBe('5');
+    expect(fmt(5.6, '0')).toBe('6'); // rounds
+  });
+  it('fixed decimals', () => {
+    expect(fmt(5, '0.00')).toBe('5.00');
+    expect(fmt(5.125, '0.00')).toBe('5.13');
+  });
+  it('thousands separator', () => {
+    expect(fmt(1234567, '#,##0')).toBe('1,234,567');
+    expect(fmt(1234.5, '#,##0.0')).toBe('1,234.5');
+  });
+});
+
+describe('number formats — percent', () => {
+  it('scales by 100', () => {
+    expect(fmt(0.5, '0%')).toBe('50%');
+    expect(fmt(0.1234, '0.0%')).toBe('12.3%');
+  });
+});
+
+describe('number formats — sign sections (§18.8.30)', () => {
+  it('positive / negative / zero selection', () => {
+    // positive;negative;zero
+    expect(fmt(5, '0;(0);"-"')).toBe('5');
+    expect(fmt(-5, '0;(0);"-"')).toBe('(5)');
+    expect(fmt(0, '0;(0);"-"')).toBe('-');
+  });
+  it('negative falls back to positive section when absent', () => {
+    expect(fmt(-5, '0.0')).toBe('-5.0');
+  });
+});
+
+describe('number formats — literals', () => {
+  it('keeps quoted literal text around the number', () => {
+    expect(fmt(3, '0" units"')).toBe('3 units');
+  });
+});
+
+describe('non-numeric cells', () => {
+  it('passes text through when no 4th section', () => {
+    const cell: Cell = { row: 1, col: 1, colRef: 'A1', value: { type: 'text', text: 'hello' }, styleIndex: 0 };
+    expect(formatCellValue(cell, styles('0.00'))).toBe('hello');
+  });
+});

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -483,14 +483,21 @@ function applyFormatCode(num: number, formatCode: string): string {
   // (§18.8.30). Pick the section matching `num`, falling back to the positive
   // section when the target one is absent.
   let section: string;
+  // When a dedicated negative section is present, Excel formats the negative
+  // value's *magnitude* in it — the minus is conveyed by the section's own
+  // literals (e.g. parentheses). `0;(0)` renders -5 as "(5)", not "(-5)".
+  let useMagnitude = false;
   if (num > 0) section = sections[0];
-  else if (num < 0) section = sections.length > 1 ? sections[1] : sections[0];
+  else if (num < 0) {
+    if (sections.length > 1) { section = sections[1]; useMagnitude = true; }
+    else section = sections[0];
+  }
   else section = sections.length > 2 ? sections[2] : sections[0];
   const { tokens, numSpec } = tokenizeNumberFormat(section);
   const hasPercent = tokens.some(t => t.kind === 'percent');
   const sciTok = tokens.find(t => t.kind === 'sci') as Extract<FmtToken, { kind: 'sci' }> | undefined;
 
-  let value = num;
+  let value = useMagnitude ? Math.abs(num) : num;
   if (hasPercent) value = value * 100;
 
   let numberText: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
 
   packages/core:
     devDependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Unit tests only. `*.spec.ts` is reserved for the Playwright visual-regression
+// suites (run via `pnpm vrt`), so restrict vitest to `*.test.ts` under src and
+// keep it out of the tests/visual directories.
+export default defineConfig({
+  test: {
+    include: ['packages/**/src/**/*.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/tests/visual/**'],
+  },
+});


### PR DESCRIPTION
## Summary

Idle/foundation work. The project had **no unit tests** — only the local-only Playwright VRT suites, which exercise rendered output at scroll-0 and can't reach logic edge cases. Add **vitest** and cover the two most complex pure-logic engines.

### Tests
- `formula.test.ts`: `evalFormulaToBool` — numeric/string comparisons, arithmetic precedence, AND/OR/NOT/IF, nested logic, cell-reference resolution.
- `number-format.test.ts`: `formatCellValue` — integers/rounding, fixed decimals, thousands, percent, sign sections (§18.8.30), quoted literals, non-numeric passthrough.

vitest is scoped to `*.test.ts` (a `vitest.config.ts` excludes `tests/visual`) so it never collides with the `*.spec.ts` Playwright suites. Wired into CI as a source-only step (no WASM).

### Bug it caught (fixed here)
A format with a dedicated negative section must format the **magnitude** (§18.8.30): `0;(0)` should render -5 as `(5)`, but the formatter kept the sign → `(-5)`. Fixed. It's latent in the current corpus (**VRT regression 0.0%**), so no rendered sample changes — but any workbook using e.g. an accounting format with negatives was affected.

## Verification

- `pnpm test` → 15/15 pass.
- `pnpm typecheck`, `pnpm lint` clean.
- VRT regression vs main → 65/65, 0.0% (the fix doesn't touch any current sample).

🤖 Generated with [Claude Code](https://claude.com/claude-code)