### PR TITLE
test: expand unit coverage; extract chart axis-scale math for testing

### DIFF
--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { niceStep, niceAxisMax, niceAxisMin } from './axis-scale.js';
+
+describe('niceStep', () => {
+  it('picks 1/2/5 × 10ⁿ for ~5 gridlines', () => {
+    expect(niceStep(100)).toBe(20);  // raw 20 → 2×10
+    expect(niceStep(50)).toBe(10);   // raw 10 → 1×10
+    expect(niceStep(7)).toBe(1);     // raw 1.4 → 1×1
+    expect(niceStep(40)).toBe(10);   // raw 8 → 1×10 (8 ≥ 7.5 → 10)
+  });
+  it('zero range falls back to 1', () => {
+    expect(niceStep(0)).toBe(1);
+  });
+});
+
+describe('niceAxisMax (Excel-faithful, no headroom step)', () => {
+  it('rounds up to the next major-unit multiple', () => {
+    expect(niceAxisMax(41, 10)).toBe(50);
+    expect(niceAxisMax(9715, 2000)).toBe(10000); // 97% — stays, no bump
+  });
+  it('data exactly on a gridline stays put (the 0.9-bump regression guard)', () => {
+    expect(niceAxisMax(40, 10)).toBe(40);
+    expect(niceAxisMax(100, 20)).toBe(100);
+  });
+  it('non-positive max returns one step', () => {
+    expect(niceAxisMax(0, 10)).toBe(10);
+    expect(niceAxisMax(-5, 10)).toBe(10);
+  });
+});
+
+describe('niceAxisMin', () => {
+  it('non-negative data anchors at 0', () => {
+    expect(niceAxisMin(15, 10)).toBe(0);
+    expect(niceAxisMin(0, 10)).toBe(0);
+  });
+  it('negative data floors to a major-unit multiple', () => {
+    expect(niceAxisMin(-15, 10)).toBe(-20);
+  });
+  it('data exactly on a gridline drops one extra step', () => {
+    expect(niceAxisMin(-20, 10)).toBe(-30);
+  });
+});

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -1,0 +1,33 @@
+// Excel-style "nice" value-axis scaling. Pure math (no canvas), extracted so it
+// can be unit-tested and reused independently of the chart renderer.
+
+/** A round major-unit step that yields roughly `targetSteps` gridlines across
+ *  `range` (1 / 2 / 5 × 10ⁿ — Excel's default ladder). */
+export function niceStep(range: number, targetSteps = 5): number {
+  if (range === 0) return 1;
+  const raw = range / targetSteps;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const normed = raw / mag;
+  const nice = normed < 1.5 ? 1 : normed < 3.5 ? 2 : normed < 7.5 ? 5 : 10;
+  return nice * mag;
+}
+
+/** Excel's automatic value-axis maximum: the smallest major-unit multiple that
+ *  is >= dataMax — no extra headroom step. A series filling 97% of the axis
+ *  stays at 97%, exactly as Excel renders it. (Overlap with sibling shapes is
+ *  handled by honoring <c:plotArea><c:manualLayout> — ECMA-376 §21.2.2.32 —
+ *  not by inflating the axis.) */
+export function niceAxisMax(dataMax: number, step: number): number {
+  if (dataMax <= 0) return step;
+  return Math.ceil(dataMax / step) * step;
+}
+
+/** Axis minimum for data that dips below zero: the largest major-unit multiple
+ *  <= dataMin, dropping one extra step when the data sits exactly on a
+ *  gridline so the lowest point isn't flush against the axis. Non-negative data
+ *  anchors the axis at 0. */
+export function niceAxisMin(dataMin: number, step: number): number {
+  if (dataMin >= 0) return 0;
+  const ax = Math.floor(dataMin / step) * step;
+  return Math.abs(ax - dataMin) < step * 1e-9 ? ax - step : ax;
+}

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -4,6 +4,7 @@
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
 import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
+import { niceStep, niceAxisMax, niceAxisMin } from './axis-scale.js';
 
 // ─── Palette + helpers ──────────────────────────────────────────────────────
 
@@ -29,33 +30,6 @@ function hexToRgba(hex: string, alpha: number): string {
   const g = parseInt(h.slice(2, 4), 16);
   const b = parseInt(h.slice(4, 6), 16);
   return `rgba(${r},${g},${b},${alpha})`;
-}
-
-function niceStep(range: number, targetSteps = 5): number {
-  if (range === 0) return 1;
-  const raw = range / targetSteps;
-  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
-  const normed = raw / mag;
-  const nice = normed < 1.5 ? 1 : normed < 3.5 ? 2 : normed < 7.5 ? 5 : 10;
-  return nice * mag;
-}
-
-function niceAxisMax(dataMax: number, step: number): number {
-  if (dataMax <= 0) return step;
-  // Excel's automatic value-axis maximum is the smallest major-unit multiple
-  // that is >= dataMax — no extra headroom step. A bar filling 97% of the axis
-  // stays at 97%, exactly as Excel renders it. (Earlier code added one step
-  // when data exceeded 90% of the axis to stop stacked bars spilling into
-  // adjacent shapes, but that distorted the scale of every chart. Overlap is
-  // handled correctly by honoring <c:plotArea><c:manualLayout> — ECMA-376
-  // §21.2.2.32 — which constrains the plot rect, not by inflating the axis.)
-  return Math.ceil(dataMax / step) * step;
-}
-
-function niceAxisMin(dataMin: number, step: number): number {
-  if (dataMin >= 0) return 0;
-  const ax = Math.floor(dataMin / step) * step;
-  return Math.abs(ax - dataMin) < step * 1e-9 ? ax - step : ax;
 }
 
 function formatChartVal(v: number): string {

--- a/packages/xlsx/src/formula.test.ts
+++ b/packages/xlsx/src/formula.test.ts
@@ -73,3 +73,44 @@ describe('evalFormulaToBool — cell references', () => {
     expect(evalFormulaToBool('A1>90', c)).toBe(false);
   });
 });
+
+describe('evalFormulaToBool — numeric functions', () => {
+  it('ABS / INT / MOD', () => {
+    expect(ev('ABS(-5)=5')).toBe(true);
+    expect(ev('INT(5.9)=5')).toBe(true);
+    expect(ev('INT(-5.1)=-6')).toBe(true); // Excel INT rounds toward -infinity
+    expect(ev('MOD(7,3)=1')).toBe(true);
+  });
+  it('CEILING / FLOOR', () => {
+    expect(ev('CEILING(4.2,1)=5')).toBe(true);
+    expect(ev('FLOOR(4.8,1)=4')).toBe(true);
+  });
+});
+
+describe('evalFormulaToBool — IS / text functions', () => {
+  it('ISBLANK', () => {
+    const c = ctx({ cells: [numCell(1, 1, 0)], row: 1, col: 1 });
+    expect(evalFormulaToBool('ISBLANK(B1)', c)).toBe(true);  // B1 absent → blank
+    expect(evalFormulaToBool('ISBLANK(A1)', c)).toBe(false); // A1 present
+  });
+  it('EXACT', () => {
+    expect(ev('EXACT("abc","abc")')).toBe(true);
+    expect(ev('EXACT("abc","abC")')).toBe(false);
+  });
+});
+
+describe('evalFormulaToBool — conditional aggregates', () => {
+  it('COUNTIF over a range', () => {
+    // A1:A3 = 90, 50, 95 ; count of >=90 is 2
+    const cells = [numCell(1, 1, 90), numCell(2, 1, 50), numCell(3, 1, 95)];
+    const c = ctx({ cells, row: 1, col: 1 });
+    expect(evalFormulaToBool('COUNTIF(A1:A3,">=90")=2', c)).toBe(true);
+  });
+});
+
+describe('evalFormulaToBool — DATE', () => {
+  it('builds an Excel serial', () => {
+    expect(ev('DATE(2024,1,1)=45292')).toBe(true);
+    expect(ev('DATE(2024,1,15)=45306')).toBe(true);
+  });
+});

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -68,3 +68,16 @@ describe('non-numeric cells', () => {
     expect(formatCellValue(cell, styles('0.00'))).toBe('hello');
   });
 });
+
+describe('date formats (Excel serial; 45292 = 2024-01-01)', () => {
+  it('ISO and slash dates', () => {
+    expect(fmt(45306, 'yyyy-mm-dd')).toBe('2024-01-15');
+    expect(fmt(45306, 'm/d/yy')).toBe('1/15/24');
+    expect(fmt(45306, 'mm/dd/yyyy')).toBe('01/15/2024');
+  });
+  it('day and month parts', () => {
+    expect(fmt(45292, 'yyyy')).toBe('2024');
+    expect(fmt(45292, 'd')).toBe('1');
+    expect(fmt(45292, 'dd')).toBe('01');
+  });
+});


### PR DESCRIPTION
## Summary

Continued test-coverage work (idle/foundation).

### Expanded xlsx coverage
- **formula**: ABS/INT/MOD, CEILING/FLOOR, ISBLANK, EXACT, COUNTIF over a range, DATE serial construction.
- **number-format**: date format codes (yyyy-mm-dd, m/d/yy, mm/dd/yyyy, parts).
All pass — locks current correct behavior.

### Chart axis-scale math extracted + tested
Moved `niceStep` / `niceAxisMax` / `niceAxisMin` out of `core/chart/renderer.ts` into a canvas-free `axis-scale.ts` so they're unit-testable (also a first slice of the chart-renderer split). Tests lock the **Excel-faithful auto-max** behavior — notably the *'data exactly on a gridline stays put'* case that the removed 0.9 headroom heuristic used to violate.

## Verification
- `pnpm test` → 31/31 pass (3 files). typecheck + lint clean.
- Chart extraction is a pure code move → VRT regression vs main: **xlsx 65/65, pptx 69/69, 0.0%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)