### PR TITLE
fix(chart): restore Excel auto-axis headroom (Ymax + range/20)

### DIFF
--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -13,14 +13,18 @@ describe('niceStep', () => {
   });
 });
 
-describe('niceAxisMax (Excel-faithful, no headroom step)', () => {
-  it('rounds up to the next major-unit multiple', () => {
-    expect(niceAxisMax(41, 10)).toBe(50);
-    expect(niceAxisMax(9715, 2000)).toBe(10000); // 97% — stays, no bump
+describe('niceAxisMax (Excel headroom: first major unit above Ymax + range/20)', () => {
+  it('rounds up past the ~5% headroom to the next major unit', () => {
+    expect(niceAxisMax(41, 10)).toBe(50);        // 41 + 2.05 = 43.05 → 50
+    expect(niceAxisMax(9715, 2000)).toBe(12000); // 9715 + 485.75 = 10200.75 → 12000
   });
-  it('data exactly on a gridline stays put (the 0.9-bump regression guard)', () => {
-    expect(niceAxisMax(40, 10)).toBe(40);
-    expect(niceAxisMax(100, 20)).toBe(100);
+  it('adds headroom even when data sits on a gridline (not flush against the top)', () => {
+    expect(niceAxisMax(40, 10)).toBe(50);   // 40 + 2 = 42 → 50
+    expect(niceAxisMax(100, 20)).toBe(120); // 100 + 5 = 105 → 120
+  });
+  it('uses dataMin for the range', () => {
+    // range 100-(-100)=200, headroom 10 → 110 → step 50 → 150
+    expect(niceAxisMax(100, 50, -100)).toBe(150);
   });
   it('non-positive max returns one step', () => {
     expect(niceAxisMax(0, 10)).toBe(10);

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -12,14 +12,21 @@ export function niceStep(range: number, targetSteps = 5): number {
   return nice * mag;
 }
 
-/** Excel's automatic value-axis maximum: the smallest major-unit multiple that
- *  is >= dataMax — no extra headroom step. A series filling 97% of the axis
- *  stays at 97%, exactly as Excel renders it. (Overlap with sibling shapes is
- *  handled by honoring <c:plotArea><c:manualLayout> — ECMA-376 §21.2.2.32 —
- *  not by inflating the axis.) */
-export function niceAxisMax(dataMax: number, step: number): number {
+/** Excel / PowerPoint automatic value-axis maximum. Microsoft's documented
+ *  algorithm (per Peltier Tech) is "the first major unit above
+ *  `Ymax + (Ymax − Ymin)/20`": ~5% of the data range is added as headroom so the
+ *  tallest series sits just below the top gridline rather than flush against it,
+ *  then the result is rounded up to the next major unit. `dataMin` is the axis
+ *  minimum (0 for bar/column charts; the data minimum otherwise).
+ *
+ *  The major unit itself is Excel-proprietary (it varies with plot size, tick
+ *  font, etc. and is not documented), so we approximate it with `niceStep`; the
+ *  computed max can therefore differ from PowerPoint by one major unit on some
+ *  charts. */
+export function niceAxisMax(dataMax: number, step: number, dataMin = 0): number {
   if (dataMax <= 0) return step;
-  return Math.ceil(dataMax / step) * step;
+  const withHeadroom = dataMax + (dataMax - dataMin) / 20;
+  return Math.ceil(withHeadroom / step) * step;
 }
 
 /** Axis minimum for data that dips below zero: the largest major-unit multiple


### PR DESCRIPTION
## Summary

PR #292 removed the value-axis 'headroom', believing Excel rounds the max straight up to the next major unit. That was wrong. Microsoft's **documented** auto-scale algorithm (per [Peltier Tech](https://peltiertech.com/how-excel-calculates-automatic-chart-axis-limits/)) is:

> the first major unit above `Ymax + (Ymax − Ymin)/20`

i.e. ~5% of the data range is added as headroom *before* rounding up, so the tallest series sits just below the top gridline. Removing it made auto-scaled bars ~10% too wide — reported on **sample-2 slide-16** (a stacked horizontal bar filling its plot).

Restored in `niceAxisMax` (with a `dataMin` param for the range).

## Verification
- Against the PowerPoint **PDF** export of sample-2 slide-16: the bar's right edge now lands at **596px vs PowerPoint 595px** (was 639px, 44px too wide).
- Unit tests updated to the documented behavior (32/32 pass).

Note: the *major unit* itself is Excel-proprietary (varies with plot size), so the computed max can still differ by one unit on some charts. Only auto-scaled charts are affected (explicit-`<c:max>` charts are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)