### PR TITLE
fix(pptx,core): bar-chart data-label colour, thousands separator, visibility

### DIFF
--- a/packages/core/src/chart/chart-number-format.test.ts
+++ b/packages/core/src/chart/chart-number-format.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
+
+describe('formatChartVal (General)', () => {
+  it('shows integers raw with no abbreviation', () => {
+    expect(formatChartVal(7507)).toBe('7507');
+    expect(formatChartVal(0)).toBe('0');
+  });
+  it('trims trailing decimal zeros', () => {
+    expect(formatChartVal(0.5)).toBe('0.5');
+    expect(formatChartVal(1.25)).toBe('1.25');
+  });
+});
+
+describe('formatChartValWithCode — thousands separator', () => {
+  it('adds commas with #,##0', () => {
+    expect(formatChartValWithCode(1234567, '#,##0')).toBe('1,234,567');
+    expect(formatChartValWithCode(7507, '#,##0')).toBe('7,507');
+  });
+  it('keeps decimals alongside the separator', () => {
+    expect(formatChartValWithCode(1234.5, '#,##0.0')).toBe('1,234.5');
+  });
+});
+
+describe('formatChartValWithCode — sample-2 slide-16 data labels (§18.8.30)', () => {
+  // The bar-chart series number format is `#,##0_);[Red]\(#,##0\)`. Before the
+  // parser wired `valFormatCode` through, these labels rendered as "7507" with
+  // no comma; PowerPoint shows "7,507". The positive section's `_)` reserves a
+  // glyph-width of ')' so the value aligns with parenthesised negatives — we
+  // render it as a trailing space, matching Excel.
+  const CODE = '#,##0_);[Red]\\(#,##0\\)';
+  it('positive value gets a comma (the reported bug)', () => {
+    expect(formatChartValWithCode(7507, CODE)).toBe('7,507 ');
+    expect(formatChartValWithCode(2208, CODE)).toBe('2,208 ');
+    expect(formatChartValWithCode(6117, CODE)).toBe('6,117 ');
+  });
+  it('negative value uses the parenthesised section', () => {
+    expect(formatChartValWithCode(-7507, CODE)).toBe('(7,507)');
+  });
+});
+
+describe('formatChartValWithCode — percent & null', () => {
+  it('scales by 100 with %', () => {
+    expect(formatChartValWithCode(0.5, '0%')).toBe('50%');
+  });
+  it('falls back to General when code is null/General', () => {
+    expect(formatChartValWithCode(7507, null)).toBe('7507');
+  });
+});

--- a/packages/core/src/chart/chart-number-format.ts
+++ b/packages/core/src/chart/chart-number-format.ts
@@ -1,0 +1,273 @@
+// Chart value number-formatting. Pure string/number logic (no canvas),
+// extracted from the chart renderer so it can be unit-tested and reused.
+// Implements the subset of ECMA-376 §18.8.30 number-format codes that chart
+// axis ticks and data labels need: section syntax (positive;negative;zero),
+// literal escapes, thousands separators, decimals, percent, and Excel serial
+// dates.
+
+/** Excel's default `formatCode="General"` for charts: raw numbers with no
+ *  "k"/"M" abbreviation, trailing decimal zeros trimmed. */
+export function formatChartVal(v: number): string {
+  // Matches Excel's default `<c:valAx><c:numFmt formatCode="General">` which
+  // shows raw numbers — no "k"/"M" abbreviation.
+  if (Number.isInteger(v)) return String(v);
+  // Trim trailing zeros on decimals (so 0.50 → "0.5") but cap at 6 digits.
+  return v.toFixed(6).replace(/\.?0+$/, '');
+}
+
+/**
+ * Format a chart value with an Excel number-format code. Honors ECMA-376
+ * §18.8.30 section syntax (positive;negative;zero;text), common literal
+ * escapes (`"..."`, `\x`, `_x` → space), and numeric patterns built from
+ * `#`, `0`, `.`, `,`. Unknown tokens are emitted verbatim so currency
+ * symbols like `¥` or `$` keep working even when the workbook stored them
+ * unquoted. Returns the default `formatChartVal` output when `code` is null
+ * or an empty section tells the caller to hide the value.
+ */
+export function formatChartValWithCode(v: number, code: string | null | undefined): string {
+  if (!code) return formatChartVal(v);
+  // Detect Excel date format codes (m/d/y/h/s tokens outside quotes) and
+  // route to the date formatter. Charts use this on the X axis of scatter
+  // / time-series charts where the value is a serial date.
+  if (isDateFormatCode(code)) {
+    return formatExcelDate(v, code);
+  }
+  const sections = splitFormatSections(code);
+  // Section selection per §18.8.30: positive;negative;zero;text. When the
+  // negative section is omitted a negative number is formatted with the
+  // positive section and a leading minus, which the caller must prepend.
+  let section: string;
+  if (v > 0) section = sections[0] ?? code;
+  else if (v < 0) section = sections[1] ?? sections[0] ?? code;
+  else section = sections[2] ?? sections[0] ?? code;
+  if (section === '') return '';
+  // Negative-without-explicit-section: format absolute value with positive
+  // section and prepend '-' unless the section itself already begins with a
+  // literal minus.
+  const needsLeadingMinus = v < 0 && sections.length < 2;
+  const abs = Math.abs(v);
+  return (needsLeadingMinus ? '-' : '') + applyChartNumberSection(abs, section);
+}
+
+/**
+ * True when `code` contains date tokens (m / d / y / h / s) outside of
+ * quotes. Heuristic but robust: ECMA-376 number-format codes never use
+ * those letters as numeric placeholders.
+ */
+function isDateFormatCode(code: string): boolean {
+  let inQuote = false;
+  for (let i = 0; i < code.length; i++) {
+    const c = code[i];
+    if (c === '"') { inQuote = !inQuote; continue; }
+    if (inQuote) continue;
+    if (c === '\\') { i++; continue; }
+    if (c === '[') {
+      while (i < code.length && code[i] !== ']') i++;
+      continue;
+    }
+    if (c === 'y' || c === 'Y' || c === 'd' || c === 'D'
+        || c === 'm' || c === 'M' || c === 'h' || c === 'H' || c === 's' || c === 'S') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Format an Excel serial date with the supplied code. Uses the conventional
+ * 1900-based epoch with the spec's leap-year bug (i.e. serial 60 maps to
+ * March 1, 1900, treating Feb 29, 1900 as a real day). For most chart
+ * usage (post-1900 dates) this matches Excel's display.
+ */
+function formatExcelDate(serial: number, code: string): string {
+  // Days since 1899-12-30 (so serial 1 → 1900-01-01). The leap-year bug
+  // means serials 60..62 are off by one if you use a strict Date — we
+  // mimic Excel by subtracting an extra day for serials < 60.
+  const baseUtcMs = Date.UTC(1899, 11, 30);
+  const adjusted = serial < 60 ? serial + 1 : serial;
+  const ms = baseUtcMs + Math.floor(adjusted) * 86400000;
+  const date = new Date(ms);
+  const yyyy = date.getUTCFullYear();
+  const M = date.getUTCMonth() + 1;
+  const D = date.getUTCDate();
+  const totalSeconds = (serial - Math.floor(serial)) * 86400;
+  const hh = Math.floor(totalSeconds / 3600);
+  const mm = Math.floor((totalSeconds % 3600) / 60);
+  const ss = Math.floor(totalSeconds % 60);
+  let out = '';
+  let inQuote = false;
+  let i = 0;
+  while (i < code.length) {
+    const c = code[i];
+    if (c === '"') { inQuote = !inQuote; i++; continue; }
+    if (inQuote) { out += c; i++; continue; }
+    if (c === '\\' && i + 1 < code.length) { out += code[i + 1]; i += 2; continue; }
+    if (c === '[') {
+      while (i < code.length && code[i] !== ']') i++;
+      if (i < code.length) i++;
+      continue;
+    }
+    // Token runs.
+    if (c === 'y' || c === 'Y') {
+      let n = 0; while (i < code.length && (code[i] === 'y' || code[i] === 'Y')) { n++; i++; }
+      out += n >= 3 ? String(yyyy) : String(yyyy % 100).padStart(2, '0');
+      continue;
+    }
+    if (c === 'm' || c === 'M') {
+      let n = 0; while (i < code.length && (code[i] === 'm' || code[i] === 'M')) { n++; i++; }
+      // `mm` after an h/hh switches to minutes; use a simple lookbehind.
+      const prev = (out.match(/[Hh]+\W*$/));
+      if (prev) {
+        out += n >= 2 ? String(mm).padStart(2, '0') : String(mm);
+      } else {
+        out += n >= 2 ? String(M).padStart(2, '0') : String(M);
+      }
+      continue;
+    }
+    if (c === 'd' || c === 'D') {
+      let n = 0; while (i < code.length && (code[i] === 'd' || code[i] === 'D')) { n++; i++; }
+      out += n >= 2 ? String(D).padStart(2, '0') : String(D);
+      continue;
+    }
+    if (c === 'h' || c === 'H') {
+      let n = 0; while (i < code.length && (code[i] === 'h' || code[i] === 'H')) { n++; i++; }
+      out += n >= 2 ? String(hh).padStart(2, '0') : String(hh);
+      continue;
+    }
+    if (c === 's' || c === 'S') {
+      let n = 0; while (i < code.length && (code[i] === 's' || code[i] === 'S')) { n++; i++; }
+      out += n >= 2 ? String(ss).padStart(2, '0') : String(ss);
+      continue;
+    }
+    out += c; i++;
+  }
+  return out;
+}
+
+/**
+ * Split a format code on unescaped semicolons. Quotes, `[...]` metadata, and
+ * `\;` are treated as opaque so `"a;b"` and `\;` stay in a single section.
+ */
+function splitFormatSections(code: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  for (let i = 0; i < code.length; i++) {
+    const c = code[i];
+    if (c === '\\' && i + 1 < code.length) { buf += c + code[i + 1]; i++; continue; }
+    if (c === '"') {
+      buf += c;
+      i++;
+      while (i < code.length && code[i] !== '"') { buf += code[i]; i++; }
+      if (i < code.length) buf += code[i];
+      continue;
+    }
+    if (c === '[') {
+      buf += c;
+      i++;
+      while (i < code.length && code[i] !== ']') { buf += code[i]; i++; }
+      if (i < code.length) buf += code[i];
+      continue;
+    }
+    if (c === ';') { out.push(buf); buf = ''; continue; }
+    buf += c;
+  }
+  out.push(buf);
+  return out;
+}
+
+function applyChartNumberSection(abs: number, section: string): string {
+  // Tokenize the section, separating numeric-pattern runs (`#`, `0`, `.`,
+  // `,`, `?`) from literal runs so percent / decimal handling runs once.
+  type Tok = { kind: 'lit' | 'num'; text: string };
+  const toks: Tok[] = [];
+  let i = 0;
+  let pushedNum = false;
+  let percent = false;
+  while (i < section.length) {
+    const c = section[i];
+    if (c === '"') {
+      i++;
+      let s = '';
+      while (i < section.length && section[i] !== '"') { s += section[i]; i++; }
+      if (i < section.length) i++;
+      toks.push({ kind: 'lit', text: s });
+      continue;
+    }
+    if (c === '\\' && i + 1 < section.length) {
+      toks.push({ kind: 'lit', text: section[i + 1] });
+      i += 2;
+      continue;
+    }
+    if (c === '_' && i + 1 < section.length) {
+      // `_x` pads a width of x — render as a single space, matching Excel
+      // alignment padding without caring about exact glyph metrics.
+      toks.push({ kind: 'lit', text: ' ' });
+      i += 2;
+      continue;
+    }
+    if (c === '*' && i + 1 < section.length) {
+      // `*x` fills the remaining column width with x; we can't know the
+      // column width at this layer so we drop it.
+      i += 2;
+      continue;
+    }
+    if (c === '[') {
+      i++;
+      while (i < section.length && section[i] !== ']') i++;
+      if (i < section.length) i++;
+      continue;
+    }
+    if (c === '%') { percent = true; toks.push({ kind: 'lit', text: '%' }); i++; continue; }
+    if (c === '#' || c === '0' || c === '.' || c === ',' || c === '?') {
+      let run = '';
+      while (
+        i < section.length &&
+        (section[i] === '#' || section[i] === '0' || section[i] === '.' ||
+         section[i] === ',' || section[i] === '?')
+      ) { run += section[i]; i++; }
+      toks.push({ kind: 'num', text: run });
+      pushedNum = true;
+      continue;
+    }
+    // Everything else (currency symbols like ¥, $, parens, spaces) is literal.
+    toks.push({ kind: 'lit', text: c });
+    i++;
+  }
+  if (!pushedNum) {
+    // No numeric pattern at all — section is purely literal (e.g. `"N/A"`).
+    return toks.map(t => t.text).join('');
+  }
+  const value = percent ? abs * 100 : abs;
+  // Merge numeric tokens into one pattern — Excel treats `#,##0.00` as a
+  // single pattern even when flanked by literals. We keep the literal tokens
+  // where they are and replace the first num token with the formatted number,
+  // dropping subsequent num tokens (they're all part of the same pattern).
+  let pattern = '';
+  for (const t of toks) if (t.kind === 'num') pattern += t.text;
+  const formatted = formatNumericPattern(value, pattern);
+  let seenNum = false;
+  return toks.map(t => {
+    if (t.kind === 'lit') return t.text;
+    if (seenNum) return '';
+    seenNum = true;
+    return formatted;
+  }).join('');
+}
+
+function formatNumericPattern(value: number, pattern: string): string {
+  // Detect thousands separator (a `,` between digit placeholders) and the
+  // number of decimal places (digit chars after `.`).
+  const dotIdx = pattern.indexOf('.');
+  const intPart = dotIdx >= 0 ? pattern.slice(0, dotIdx) : pattern;
+  const fracPart = dotIdx >= 0 ? pattern.slice(dotIdx + 1) : '';
+  const thousands = /,/.test(intPart);
+  const fracDigits = (fracPart.match(/[#0?]/g) ?? []).length;
+  // Minimum integer digits = count of `0` in integer part.
+  const minIntDigits = (intPart.replace(/,/g, '').match(/0/g) ?? []).length;
+  const rounded = value.toFixed(fracDigits);
+  const [ints, fracs = ''] = rounded.split('.');
+  const paddedInts = ints.padStart(minIntDigits, '0');
+  const withSeparators = thousands ? paddedInts.replace(/\B(?=(\d{3})+(?!\d))/g, ',') : paddedInts;
+  if (fracDigits === 0) return withSeparators;
+  return `${withSeparators}.${fracs.padEnd(fracDigits, '0')}`;
+}

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -5,6 +5,7 @@
 
 import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
 import { niceStep, niceAxisMax, niceAxisMin } from './axis-scale.js';
+import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
 
 // ─── Palette + helpers ──────────────────────────────────────────────────────
 
@@ -30,271 +31,6 @@ function hexToRgba(hex: string, alpha: number): string {
   const g = parseInt(h.slice(2, 4), 16);
   const b = parseInt(h.slice(4, 6), 16);
   return `rgba(${r},${g},${b},${alpha})`;
-}
-
-function formatChartVal(v: number): string {
-  // Matches Excel's default `<c:valAx><c:numFmt formatCode="General">` which
-  // shows raw numbers — no "k"/"M" abbreviation.
-  if (Number.isInteger(v)) return String(v);
-  // Trim trailing zeros on decimals (so 0.50 → "0.5") but cap at 6 digits.
-  return v.toFixed(6).replace(/\.?0+$/, '');
-}
-
-/**
- * Format a chart value with an Excel number-format code. Honors ECMA-376
- * §18.8.30 section syntax (positive;negative;zero;text), common literal
- * escapes (`"..."`, `\x`, `_x` → space), and numeric patterns built from
- * `#`, `0`, `.`, `,`. Unknown tokens are emitted verbatim so currency
- * symbols like `¥` or `$` keep working even when the workbook stored them
- * unquoted. Returns the default `formatChartVal` output when `code` is null
- * or an empty section tells the caller to hide the value.
- */
-function formatChartValWithCode(v: number, code: string | null | undefined): string {
-  if (!code) return formatChartVal(v);
-  // Detect Excel date format codes (m/d/y/h/s tokens outside quotes) and
-  // route to the date formatter. Charts use this on the X axis of scatter
-  // / time-series charts where the value is a serial date.
-  if (isDateFormatCode(code)) {
-    return formatExcelDate(v, code);
-  }
-  const sections = splitFormatSections(code);
-  // Section selection per §18.8.30: positive;negative;zero;text. When the
-  // negative section is omitted a negative number is formatted with the
-  // positive section and a leading minus, which the caller must prepend.
-  let section: string;
-  if (v > 0) section = sections[0] ?? code;
-  else if (v < 0) section = sections[1] ?? sections[0] ?? code;
-  else section = sections[2] ?? sections[0] ?? code;
-  if (section === '') return '';
-  // Negative-without-explicit-section: format absolute value with positive
-  // section and prepend '-' unless the section itself already begins with a
-  // literal minus.
-  const needsLeadingMinus = v < 0 && sections.length < 2;
-  const abs = Math.abs(v);
-  return (needsLeadingMinus ? '-' : '') + applyChartNumberSection(abs, section);
-}
-
-/**
- * True when `code` contains date tokens (m / d / y / h / s) outside of
- * quotes. Heuristic but robust: ECMA-376 number-format codes never use
- * those letters as numeric placeholders.
- */
-function isDateFormatCode(code: string): boolean {
-  let inQuote = false;
-  for (let i = 0; i < code.length; i++) {
-    const c = code[i];
-    if (c === '"') { inQuote = !inQuote; continue; }
-    if (inQuote) continue;
-    if (c === '\\') { i++; continue; }
-    if (c === '[') {
-      while (i < code.length && code[i] !== ']') i++;
-      continue;
-    }
-    if (c === 'y' || c === 'Y' || c === 'd' || c === 'D'
-        || c === 'm' || c === 'M' || c === 'h' || c === 'H' || c === 's' || c === 'S') {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Format an Excel serial date with the supplied code. Uses the conventional
- * 1900-based epoch with the spec's leap-year bug (i.e. serial 60 maps to
- * March 1, 1900, treating Feb 29, 1900 as a real day). For most chart
- * usage (post-1900 dates) this matches Excel's display.
- */
-function formatExcelDate(serial: number, code: string): string {
-  // Days since 1899-12-30 (so serial 1 → 1900-01-01). The leap-year bug
-  // means serials 60..62 are off by one if you use a strict Date — we
-  // mimic Excel by subtracting an extra day for serials < 60.
-  const baseUtcMs = Date.UTC(1899, 11, 30);
-  const adjusted = serial < 60 ? serial + 1 : serial;
-  const ms = baseUtcMs + Math.floor(adjusted) * 86400000;
-  const date = new Date(ms);
-  const yyyy = date.getUTCFullYear();
-  const M = date.getUTCMonth() + 1;
-  const D = date.getUTCDate();
-  const totalSeconds = (serial - Math.floor(serial)) * 86400;
-  const hh = Math.floor(totalSeconds / 3600);
-  const mm = Math.floor((totalSeconds % 3600) / 60);
-  const ss = Math.floor(totalSeconds % 60);
-  let out = '';
-  let inQuote = false;
-  let i = 0;
-  while (i < code.length) {
-    const c = code[i];
-    if (c === '"') { inQuote = !inQuote; i++; continue; }
-    if (inQuote) { out += c; i++; continue; }
-    if (c === '\\' && i + 1 < code.length) { out += code[i + 1]; i += 2; continue; }
-    if (c === '[') {
-      while (i < code.length && code[i] !== ']') i++;
-      if (i < code.length) i++;
-      continue;
-    }
-    // Token runs.
-    if (c === 'y' || c === 'Y') {
-      let n = 0; while (i < code.length && (code[i] === 'y' || code[i] === 'Y')) { n++; i++; }
-      out += n >= 3 ? String(yyyy) : String(yyyy % 100).padStart(2, '0');
-      continue;
-    }
-    if (c === 'm' || c === 'M') {
-      let n = 0; while (i < code.length && (code[i] === 'm' || code[i] === 'M')) { n++; i++; }
-      // `mm` after an h/hh switches to minutes; use a simple lookbehind.
-      const prev = (out.match(/[Hh]+\W*$/));
-      if (prev) {
-        out += n >= 2 ? String(mm).padStart(2, '0') : String(mm);
-      } else {
-        out += n >= 2 ? String(M).padStart(2, '0') : String(M);
-      }
-      continue;
-    }
-    if (c === 'd' || c === 'D') {
-      let n = 0; while (i < code.length && (code[i] === 'd' || code[i] === 'D')) { n++; i++; }
-      out += n >= 2 ? String(D).padStart(2, '0') : String(D);
-      continue;
-    }
-    if (c === 'h' || c === 'H') {
-      let n = 0; while (i < code.length && (code[i] === 'h' || code[i] === 'H')) { n++; i++; }
-      out += n >= 2 ? String(hh).padStart(2, '0') : String(hh);
-      continue;
-    }
-    if (c === 's' || c === 'S') {
-      let n = 0; while (i < code.length && (code[i] === 's' || code[i] === 'S')) { n++; i++; }
-      out += n >= 2 ? String(ss).padStart(2, '0') : String(ss);
-      continue;
-    }
-    out += c; i++;
-  }
-  return out;
-}
-
-/**
- * Split a format code on unescaped semicolons. Quotes, `[...]` metadata, and
- * `\;` are treated as opaque so `"a;b"` and `\;` stay in a single section.
- */
-function splitFormatSections(code: string): string[] {
-  const out: string[] = [];
-  let buf = '';
-  for (let i = 0; i < code.length; i++) {
-    const c = code[i];
-    if (c === '\\' && i + 1 < code.length) { buf += c + code[i + 1]; i++; continue; }
-    if (c === '"') {
-      buf += c;
-      i++;
-      while (i < code.length && code[i] !== '"') { buf += code[i]; i++; }
-      if (i < code.length) buf += code[i];
-      continue;
-    }
-    if (c === '[') {
-      buf += c;
-      i++;
-      while (i < code.length && code[i] !== ']') { buf += code[i]; i++; }
-      if (i < code.length) buf += code[i];
-      continue;
-    }
-    if (c === ';') { out.push(buf); buf = ''; continue; }
-    buf += c;
-  }
-  out.push(buf);
-  return out;
-}
-
-function applyChartNumberSection(abs: number, section: string): string {
-  // Tokenize the section, separating numeric-pattern runs (`#`, `0`, `.`,
-  // `,`, `?`) from literal runs so percent / decimal handling runs once.
-  type Tok = { kind: 'lit' | 'num'; text: string };
-  const toks: Tok[] = [];
-  let i = 0;
-  let pushedNum = false;
-  let percent = false;
-  while (i < section.length) {
-    const c = section[i];
-    if (c === '"') {
-      i++;
-      let s = '';
-      while (i < section.length && section[i] !== '"') { s += section[i]; i++; }
-      if (i < section.length) i++;
-      toks.push({ kind: 'lit', text: s });
-      continue;
-    }
-    if (c === '\\' && i + 1 < section.length) {
-      toks.push({ kind: 'lit', text: section[i + 1] });
-      i += 2;
-      continue;
-    }
-    if (c === '_' && i + 1 < section.length) {
-      // `_x` pads a width of x — render as a single space, matching Excel
-      // alignment padding without caring about exact glyph metrics.
-      toks.push({ kind: 'lit', text: ' ' });
-      i += 2;
-      continue;
-    }
-    if (c === '*' && i + 1 < section.length) {
-      // `*x` fills the remaining column width with x; we can't know the
-      // column width at this layer so we drop it.
-      i += 2;
-      continue;
-    }
-    if (c === '[') {
-      i++;
-      while (i < section.length && section[i] !== ']') i++;
-      if (i < section.length) i++;
-      continue;
-    }
-    if (c === '%') { percent = true; toks.push({ kind: 'lit', text: '%' }); i++; continue; }
-    if (c === '#' || c === '0' || c === '.' || c === ',' || c === '?') {
-      let run = '';
-      while (
-        i < section.length &&
-        (section[i] === '#' || section[i] === '0' || section[i] === '.' ||
-         section[i] === ',' || section[i] === '?')
-      ) { run += section[i]; i++; }
-      toks.push({ kind: 'num', text: run });
-      pushedNum = true;
-      continue;
-    }
-    // Everything else (currency symbols like ¥, $, parens, spaces) is literal.
-    toks.push({ kind: 'lit', text: c });
-    i++;
-  }
-  if (!pushedNum) {
-    // No numeric pattern at all — section is purely literal (e.g. `"N/A"`).
-    return toks.map(t => t.text).join('');
-  }
-  const value = percent ? abs * 100 : abs;
-  // Merge numeric tokens into one pattern — Excel treats `#,##0.00` as a
-  // single pattern even when flanked by literals. We keep the literal tokens
-  // where they are and replace the first num token with the formatted number,
-  // dropping subsequent num tokens (they're all part of the same pattern).
-  let pattern = '';
-  for (const t of toks) if (t.kind === 'num') pattern += t.text;
-  const formatted = formatNumericPattern(value, pattern);
-  let seenNum = false;
-  return toks.map(t => {
-    if (t.kind === 'lit') return t.text;
-    if (seenNum) return '';
-    seenNum = true;
-    return formatted;
-  }).join('');
-}
-
-function formatNumericPattern(value: number, pattern: string): string {
-  // Detect thousands separator (a `,` between digit placeholders) and the
-  // number of decimal places (digit chars after `.`).
-  let dotIdx = pattern.indexOf('.');
-  const intPart = dotIdx >= 0 ? pattern.slice(0, dotIdx) : pattern;
-  const fracPart = dotIdx >= 0 ? pattern.slice(dotIdx + 1) : '';
-  const thousands = /,/.test(intPart);
-  const fracDigits = (fracPart.match(/[#0?]/g) ?? []).length;
-  // Minimum integer digits = count of `0` in integer part.
-  const minIntDigits = (intPart.replace(/,/g, '').match(/0/g) ?? []).length;
-  const rounded = value.toFixed(fracDigits);
-  const [ints, fracs = ''] = rounded.split('.');
-  const paddedInts = ints.padStart(minIntDigits, '0');
-  const withSeparators = thousands ? paddedInts.replace(/\B(?=(\d{3})+(?!\d))/g, ',') : paddedInts;
-  if (fracDigits === 0) return withSeparators;
-  return `${withSeparators}.${fracs.padEnd(fracDigits, '0')}`;
 }
 
 function drawAxisTitle(
@@ -823,7 +559,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             bx, by, barH, barW,
             'vertical',
             chart.dataLabelPosition ?? null,
-            chart.dataLabelFontColor ?? null,
+            s.labelColor ?? chart.dataLabelFontColor ?? null,
           );
         }
       } else {
@@ -855,7 +591,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             bx, by, barL, barW,
             'horizontal',
             chart.dataLabelPosition ?? null,
-            chart.dataLabelFontColor ?? null,
+            s.labelColor ?? chart.dataLabelFontColor ?? null,
           );
         }
       }

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -25,6 +25,14 @@ export interface ChartSeries {
    */
   dataLabelColors?: (string | null)[] | null;
   /**
+   * Series-level data-label text colour (`<c:ser><c:dLbls><c:txPr>…solidFill`,
+   * ECMA-376 §21.2.2.216). Hex without '#'. Stacked-bar charts colour each
+   * segment's label independently (e.g. white on the dark segment, black on
+   * the light one), which a single chart-level `dataLabelFontColor` can't
+   * express. Takes precedence over `dataLabelFontColor`; null = no override.
+   */
+  labelColor?: string | null;
+  /**
    * Mixed chart: per-series chart type override. Currently only "line" (XLSX)
    * is honoured; other values are treated as the chart's primary type.
    */

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -475,6 +475,18 @@ struct ChartSeriesData {
     /// non-bubble series.
     #[serde(skip_serializing_if = "Option::is_none")]
     bubble_sizes: Option<Vec<Option<f64>>>,
+    /// `<c:val><c:numRef><c:numCache><c:formatCode>` — the series value number
+    /// format (ECMA-376 §21.2.2.121). Drives data-label formatting (thousands
+    /// separators, decimals, etc.) when the `<c:dLbls>` block has no explicit
+    /// `<c:numFmt>` of its own. `None` for "General" / unformatted series.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    val_format_code: Option<String>,
+    /// `<c:ser><c:dLbls><c:txPr>…<a:solidFill>` — series-level data-label text
+    /// colour (ECMA-376 §21.2.2.216). Stacked bars colour each segment's label
+    /// independently (e.g. white on the dark segment, black on the light one),
+    /// so a single chart-level colour cannot represent both series.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label_color: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -3398,6 +3410,26 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
         }).collect();
 
         let has_dpt_colors = data_point_colors.iter().any(|c| c.is_some());
+
+        // Series value number format from `<c:val>…<c:numCache><c:formatCode>`.
+        // Used for data labels when `<c:dLbls>` carries no explicit `<c:numFmt>`
+        // (ECMA-376 §21.2.2.121). "General" means "no format" → drop it so the
+        // renderer's default integer/decimal formatter takes over.
+        let val_format_code = val_cache
+            .and_then(|cache| cache.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "formatCode")
+                .and_then(|fc| fc.text().map(|t| t.to_string())))
+            .filter(|s| !s.is_empty() && s != "General");
+
+        // Series-level data-label text colour from `<c:dLbls><c:txPr>…solidFill`.
+        // Scoped to this `<c:ser>` (not chart-root) so stacked-bar segments keep
+        // their independent label colours (white on dark fill, black on light).
+        let label_color = ser.children()
+            .find(|n| n.is_element() && n.tag_name().name() == "dLbls")
+            .and_then(|dlbls| dlbls.children().find(|n| n.is_element() && n.tag_name().name() == "txPr"))
+            .and_then(|txpr| txpr.descendants().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
+            .and_then(|fill| parse_color_node(fill, theme));
+
         ChartSeriesData {
             name, values, color,
             data_point_colors: if has_dpt_colors { Some(data_point_colors) } else { None },
@@ -3407,6 +3439,8 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             data_label_colors: None,
             categories: series_categories,
             bubble_sizes,
+            val_format_code,
+            label_color,
         }
     }).collect();
 
@@ -3643,6 +3677,8 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         data_label_colors: if has_per_label_color { Some(data_label_colors_vec) } else { None },
         categories: None,
         bubble_sizes: None,
+        val_format_code: None,
+        label_color: None,
     }];
 
     // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`


### PR DESCRIPTION
## Problem

On `private/sample-2.pptx` slide-16, the stacked bar chart's data labels did not match PowerPoint:

1. **Colour** — "2-4Q予測 7,507" (on the light segment) rendered **white/illegible** instead of black.
2. **Thousands separator** — values showed "7507" instead of "7,507".
3. **Apparent mis-centering** — caused by #1 (the value was invisible).

## Root causes & fixes (spec-faithful)

| # | Root cause | Fix |
|---|------------|-----|
| 1 | Chart sets **per-series** label colours via `<c:ser><c:dLbls><c:txPr>` (bg1 white on dark, tx1 black on light, §21.2.2.216). Parser only read a single chart-level `dataLabelFontColor`. | Parse per-series `labelColor`; bar renderer prefers it over the chart-level colour. |
| 2 | Series number format `#,##0_);[Red]\(#,##0\)` was never read from `<c:val><c:numCache><c:formatCode>` (§21.2.2.121). | Parse it into `valFormatCode` (renderer already prefers it when `<c:dLbls>` has no `<c:numFmt>`). |
| 3 | `dLblPos=ctr` was already honoured. | No change — resolved by #1. |

## Refactor

Extracted the chart value-formatting helpers into a pure, unit-tested `chart-number-format.ts` (same pattern as `axis-scale.ts`), locking §18.8.30 section/thousands behaviour. **Rendering is byte-identical** (0-pixel diff on slide-16 before/after).

## Verification

- Compared against the PowerPoint-exported PDF: **sample-2 page 16** (slide-16) and **page 7** (other charts with the same format) — colour, commas, and stacked/centred layout now match.
- `pnpm vitest run` — 40 passed (8 new in `chart-number-format.test.ts`).
- `pnpm lint` (ast-grep) clean; core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)