### PR TITLE
fix(docx): size auto/single line spacing from the intended font's win metrics

### DIFF
--- a/packages/docx/src/font-metrics.test.ts
+++ b/packages/docx/src/font-metrics.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { fontWinLineHeightRatio, intendedSingleLinePx } from './font-metrics.js';
+
+describe('fontWinLineHeightRatio', () => {
+  it('returns Meiryo / Meiryo UI win line-height ratio (≈1.60 em)', () => {
+    expect(fontWinLineHeightRatio('Meiryo UI')).toBe(1.6);
+    expect(fontWinLineHeightRatio('Meiryo')).toBe(1.6);
+    expect(fontWinLineHeightRatio('メイリオ')).toBe(1.6);
+  });
+  it('is case-insensitive', () => {
+    expect(fontWinLineHeightRatio('meiryo ui')).toBe(1.6);
+    expect(fontWinLineHeightRatio('MEIRYO')).toBe(1.6);
+  });
+  it('returns null for untabled fonts (Latin / unknown / null)', () => {
+    // Latin fonts are intentionally absent — their win ratio (~1.15–1.22) is
+    // close to the browser fallback, so no correction is needed.
+    expect(fontWinLineHeightRatio('Arial')).toBeNull();
+    expect(fontWinLineHeightRatio('Calibri')).toBeNull();
+    expect(fontWinLineHeightRatio('Arial Nova')).toBeNull();
+    expect(fontWinLineHeightRatio(null)).toBeNull();
+    expect(fontWinLineHeightRatio(undefined)).toBeNull();
+    expect(fontWinLineHeightRatio('')).toBeNull();
+  });
+});
+
+describe('intendedSingleLinePx', () => {
+  it('scales the ratio by the em size (px)', () => {
+    // 48 pt title at deviceScaleFactor 2 → em = 96 px → 1.6 × 96 = 153.6.
+    expect(intendedSingleLinePx('Meiryo UI', 96)).toBeCloseTo(153.6, 5);
+    // Single-spaced 9 pt body at scale 2 → em = 18 px → 1.6 × 18 = 28.8.
+    expect(intendedSingleLinePx('Meiryo UI', 18)).toBeCloseTo(28.8, 5);
+  });
+  it('returns 0 (no-op sentinel) for untabled fonts', () => {
+    expect(intendedSingleLinePx('Arial', 96)).toBe(0);
+    expect(intendedSingleLinePx(null, 96)).toBe(0);
+  });
+});

--- a/packages/docx/src/font-metrics.ts
+++ b/packages/docx/src/font-metrics.ts
@@ -1,0 +1,68 @@
+// Font line-height metrics for fonts whose real vertical metrics differ
+// substantially from whatever the browser substitutes when the font is not
+// installed.
+//
+// Why this exists
+// ---------------
+// For `lineRule="auto"` / single spacing (ECMA-376 §17.3.1.33), Word's line
+// height is `multiplier × singleLineHeight`, where the single-line height is
+// the font's design line height. On Windows (the platform Word's PDF export
+// targets) that single line height is `(usWinAscent + usWinDescent) /
+// unitsPerEm` per the OS/2 table.
+//
+// Our renderer normally derives the single-line height from the Canvas
+// `fontBoundingBoxAscent + fontBoundingBoxDescent` of the font the browser
+// actually used. That is correct when the document's font is installed, but
+// when it is substituted the fallback's metrics can be far smaller than the
+// intended font's — and for fonts with large win-metrics (Japanese UI fonts
+// especially) the gap is big enough to overlap lines and accumulate vertical
+// drift down the page.
+//
+// `Meiryo` / `Meiryo UI` are the canonical example: their win line height is
+// ≈1.60 em (unitsPerEm 2048, usWinAscent+usWinDescent ≈ 3269), while the
+// macOS/Chromium fallback (`Hiragino Sans`) reports only ≈1.0 em from
+// `fontBoundingBox`. A 48 pt Meiryo title with `line="168"` (0.7×) therefore
+// renders at 0.7 × 1.60 × 48 ≈ 53.8 pt in Word but collapses to ≈34 pt with
+// the fallback metric, overlapping the lines.
+//
+// This table provides the intended font's win line-height ratio so the line
+// box can be sized as Word would, independent of which fallback ends up
+// drawing the glyphs. Only fonts whose ratio is verified from real metrics
+// belong here — never a value tuned to make one sample look right. Latin
+// fonts are intentionally absent: their win ratio (~1.15–1.22 em) is close to
+// what the browser fallback already reports, so the correction is negligible.
+
+/** A known font's win line-height ratio: `(usWinAscent + usWinDescent) /
+ *  unitsPerEm`. Keyed by a normalized (lowercased) family name. */
+const WIN_LINE_HEIGHT_RATIO: ReadonlyArray<readonly [test: (n: string) => boolean, ratio: number]> = [
+  // Meiryo / Meiryo UI — unitsPerEm 2048, usWinAscent 2210 + usWinDescent 1059
+  // ≈ 3269 → 1.596. Cross-checked against the sample-3 reference PDF: the 48 pt
+  // Title (`line="168"` = 0.7×) measures 53.8 pt cap-top to cap-top
+  // → singleLine = 53.8 / 0.7 / 48 = 1.60 em.
+  [(n) => n.includes('meiryo') || n.includes('メイリオ'), 1.6],
+];
+
+/**
+ * Win line-height ratio (`(usWinAscent+usWinDescent)/unitsPerEm`) for a
+ * requested font family, or `null` when the font is not in the table (the
+ * caller should then fall back to the substituted font's Canvas metrics).
+ */
+export function fontWinLineHeightRatio(family: string | null | undefined): number | null {
+  if (!family) return null;
+  const n = family.toLowerCase();
+  for (const [test, ratio] of WIN_LINE_HEIGHT_RATIO) {
+    if (test(n)) return ratio;
+  }
+  return null;
+}
+
+/**
+ * Intended single-line height in px for a run of `family` at `emPx` (the font
+ * size already multiplied by the render scale), or `0` when the font is not in
+ * the table. `0` is a no-op sentinel for the line-box math, which takes the
+ * max of this and the substituted font's natural ascent+descent.
+ */
+export function intendedSingleLinePx(family: string | null | undefined, emPx: number): number {
+  const ratio = fontWinLineHeightRatio(family);
+  return ratio === null ? 0 : ratio * emPx;
+}

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4,6 +4,7 @@ import type {
   TabStop, ParagraphBorders, ParaBorderEdge, SectionProps,
 } from './types';
 import { buildCustomPath, buildShapePath, hexToRgba, resolveFill } from '@silurus/ooxml-core';
+import { intendedSingleLinePx } from './font-metrics.js';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -506,7 +507,7 @@ function estimateParagraphHeight(
   if (segs.length === 0) {
     const fs = getDefaultFontSize(para);
     const { asc, desc } = emptyLineNaturalPx(fs, 1);
-    textH = lineBoxHeight(para.lineSpacing, asc, desc, 1, state.docGrid, paraHasRuby);
+    textH = lineBoxHeight(para.lineSpacing, asc, desc, 1, state.docGrid, paraHasRuby, emptyIntendedSinglePx(para, 1));
   } else {
     // When anchor-image floats are active on the current page the paragraph
     // wraps around them, adding lines compared to a full-width layout. Use
@@ -515,7 +516,7 @@ function estimateParagraphHeight(
       startPageY: state.y,
       paraX: paraXPt,
       floats: state.floats,
-      lineBoxH: (a, d, _h) => lineBoxHeight(para.lineSpacing, a, d, 1, state.docGrid, paraHasRuby),
+      lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, state.docGrid, paraHasRuby, is ?? 0),
       pageH: state.pageH,
     } : undefined;
     const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses);
@@ -523,13 +524,13 @@ function estimateParagraphHeight(
       // Word uses the same line height for every line in a ruby paragraph,
       // snapped to an integer docGrid pitch.
       const uniform = snapParaLineToGrid(
-        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, state.docGrid, true))),
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, state.docGrid, true, l.intendedSingle))),
         state.docGrid,
         1,
       );
       textH = uniform * lines.length;
     } else {
-      textH = lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, state.docGrid, false), 0);
+      textH = lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, state.docGrid, false, l.intendedSingle), 0);
     }
   }
   return textH + (suppressSpaceBefore ? 0 : para.spaceBefore) + para.spaceAfter;
@@ -593,13 +594,13 @@ function splitParagraphAcrossPages(
     startPageY: measureState.y,
     paraX: marginLeftPt,
     floats: measureState.floats,
-    lineBoxH: (a, d) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para)),
+    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0),
     pageH: measureState.pageH,
   } : undefined;
   const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses);
   const paraHasRuby = paragraphHasRuby(para);
 
-  const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby);
+  const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby, l.intendedSingle);
   const uniformH = paraHasRuby
     ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), measureState.docGrid, 1)
     : 0;
@@ -864,7 +865,7 @@ function renderParagraph(
   if (segments.length === 0) {
     const fontSizePt = getDefaultFontSize(para);
     const { asc, desc } = emptyLineNaturalPx(fontSizePt, scale);
-    const emptyH = lineBoxHeight(para.lineSpacing, asc, desc, scale, state.docGrid, paraHasRuby);
+    const emptyH = lineBoxHeight(para.lineSpacing, asc, desc, scale, state.docGrid, paraHasRuby, emptyIntendedSinglePx(para, scale));
     if (para.shading && !dryRun) {
       ctx.fillStyle = `#${para.shading}`;
       ctx.fillRect(contentX + indLeft, textAreaTopY, paraW, emptyH);
@@ -882,7 +883,7 @@ function renderParagraph(
     startPageY: state.y,
     paraX,
     floats: state.floats,
-    lineBoxH: (a, d, _h) => lineBoxHeight(para.lineSpacing, a, d, scale, state.docGrid, paraHasRuby),
+    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, scale, state.docGrid, paraHasRuby, is ?? 0),
     pageH: state.pageH,
   } : undefined;
 
@@ -898,7 +899,7 @@ function renderParagraph(
   // else just the max natural.
   const uniformLineH = paraHasRuby
     ? snapParaLineToGrid(
-        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, true))),
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, true, l.intendedSingle))),
         state.docGrid,
         scale,
       )
@@ -906,7 +907,7 @@ function renderParagraph(
   const lineHForLine = (l: typeof lines[number]): number =>
     paraHasRuby
       ? uniformLineH
-      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, false);
+      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, false, l.intendedSingle);
 
   if (para.shading && !dryRun) {
     const totalTextH = lines.reduce((s, l) => s + lineHForLine(l), 0);
@@ -1195,6 +1196,10 @@ interface LayoutLine {
   height: number;  // pt — max fontSize on line (for empty-line sizing fallback)
   ascent: number;  // px — fontBoundingBoxAscent (font-metric, stable per font+size)
   descent: number; // px — fontBoundingBoxDescent
+  /** px — intended single-line height (max over segments of the requested
+   *  font's win line-height ratio × em), for fonts whose substituted Canvas
+   *  metrics understate Word's line spacing. 0 when no segment needs it. */
+  intendedSingle: number;
   /** Additional horizontal offset (px) from paraX, caused by wrap-around floats. */
   xOffset: number;
   /** Effective available width (px) for this line after float exclusion. */
@@ -1212,7 +1217,7 @@ interface WrapLayoutCtx {
   paraX: number;        // absolute canvas X of the paragraph's content left edge
   floats: FloatRect[];  // floats active on the current page
   /** Per-line box-height resolver (line natural ascent+descent → total px box height). */
-  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean) => number;
+  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number) => number;
   /** Hard cap on Y to keep layout from running past the page. */
   pageH: number;
 }
@@ -1398,6 +1403,7 @@ function layoutLines(
   let lineHeight = 0;   // pt
   let lineAscent = 0;   // px
   let lineDescent = 0;  // px
+  let lineIntendedSingle = 0; // px — max intended single-line height on the line
   let isFirst = true;
   // Effective width/offset for the current line after float exclusion.
   let lineMaxWidth = maxWidth;
@@ -1476,13 +1482,14 @@ function layoutLines(
       height: h,
       ascent: asc,
       descent: desc,
+      intendedSingle: lineIntendedSingle,
       xOffset: lineXOffset,
       availWidth: lineMaxWidth,
       topY: wrapCtx ? currentLineTopY : undefined,
       hasRuby: lineHasRuby,
     });
     if (wrapCtx) {
-      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby);
+      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle);
     }
     currentLine = [];
     currentWidth = 0;
@@ -1490,6 +1497,7 @@ function layoutLines(
     lineHeight = 0;
     lineAscent = 0;
     lineDescent = 0;
+    lineIntendedSingle = 0;
     lineHasRuby = false;
     isFirst = false;
     startLine();
@@ -1509,7 +1517,14 @@ function layoutLines(
     if (h > lineHeight) lineHeight = h;
     if (asc > lineAscent) lineAscent = asc;
     if (desc > lineDescent) lineDescent = desc;
-    if (!('isTab' in s) && !('dataUrl' in s) && (s as LayoutTextSeg).ruby) lineHasRuby = true;
+    if (!('isTab' in s) && !('dataUrl' in s)) {
+      const ts = s as LayoutTextSeg;
+      if (ts.ruby) lineHasRuby = true;
+      // Intended single-line height for fonts whose substituted Canvas metrics
+      // understate Word's line spacing (font-metrics.ts). 0 for untabled fonts.
+      const intended = intendedSingleLinePx(ts.fontFamily, effectiveFontPx(ts));
+      if (intended > lineIntendedSingle) lineIntendedSingle = intended;
+    }
   };
 
   const effectiveFontPx = (s: LayoutTextSeg): number => calcEffectiveFontPx(s, scale);
@@ -2238,10 +2253,10 @@ function measureParaHeight(
   if (segs.length === 0) {
     const fs = getDefaultFontSize(para);
     const { asc, desc } = emptyLineNaturalPx(fs, scale);
-    return lineBoxHeight(para.lineSpacing, asc, desc, scale, state.docGrid, paraHasRuby);
+    return lineBoxHeight(para.lineSpacing, asc, desc, scale, state.docGrid, paraHasRuby, emptyIntendedSinglePx(para, scale));
   }
   const lines = layoutLines(state.ctx, segs, maxWidth, 0, scale, para.tabStops, undefined, state.fontFamilyClasses);
-  return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, paraHasRuby), 0);
+  return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, paraHasRuby, l.intendedSingle), 0);
 }
 
 function measureCellContent(
@@ -2539,6 +2554,22 @@ function getDefaultFontSize(para: DocParagraph): number {
   return 10; // pt fallback
 }
 
+/** First text/field run's font family — used to size empty paragraphs whose
+ *  intended font (e.g. Meiryo) has a larger win line height than the fallback. */
+function getDefaultFontFamily(para: DocParagraph): string | null {
+  for (const run of para.runs) {
+    if (run.type === 'text') return (run as unknown as TextRun).fontFamily;
+    if (run.type === 'field') return (run as unknown as FieldRun).fontFamily;
+  }
+  return null;
+}
+
+/** Intended single-line height (px) for an empty paragraph, from its default
+ *  font's win line-height ratio. 0 when the font is not in the metrics table. */
+function emptyIntendedSinglePx(para: DocParagraph, scale: number): number {
+  return intendedSingleLinePx(getDefaultFontFamily(para), getDefaultFontSize(para) * scale);
+}
+
 /** Document-grid context passed to line-box computation.  When the section's
  *  `w:docGrid` is "lines"/"linesAndChars" with a positive pitch (ECMA-376
  *  §17.6.5), auto line spacing multiplies against the grid pitch instead of
@@ -2577,8 +2608,17 @@ function lineBoxHeight(
   scale: number,
   grid?: DocGridCtx,
   hasRuby?: boolean,
+  intendedSinglePx = 0,
 ): number {
-  const natural = ascentPx + descentPx;
+  const glyphNatural = ascentPx + descentPx;
+  // For `auto`/single spacing the multiplier applies to the intended font's
+  // design line height (ECMA-376 §17.3.1.33). When the document's font is
+  // substituted, the Canvas glyph extent (`glyphNatural`) understates that —
+  // see font-metrics.ts. `base` restores the intended single-line height so
+  // line spacing matches Word, while never dropping below the substituted
+  // glyph extent (so glyphs are not clipped). Grid-snapped lines are governed
+  // by the grid pitch instead, so the metric correction stays out of them.
+  const natural = Math.max(glyphNatural, intendedSinglePx);
   const hasGrid = isGridLineRule(grid);
   const pitchPx = hasGrid ? grid!.linePitchPt! * scale : 0;
   // Per ECMA-376 §17.6.5, a paragraph whose `line` attribute is NOT
@@ -2600,12 +2640,15 @@ function lineBoxHeight(
   // reservation, and lineBoxHeight stays format-agnostic.
   const inheritedOnly = ls !== null && ls.explicit !== true;
   if (!ls) {
-    return hasGrid ? Math.max(natural, pitchPx) : natural;
+    // No explicit spacing → single line. Use the intended single-line height
+    // (`natural`) off-grid; on-grid, snap to the pitch with the glyph extent
+    // as the overflow floor (the grid, not the font metric, governs height).
+    return hasGrid ? Math.max(glyphNatural, pitchPx) : natural;
   }
   if (ls.rule === 'auto') {
     if (hasGrid) {
-      if (inheritedOnly) return Math.max(natural, pitchPx);
-      return Math.max(natural, pitchPx * ls.value);
+      if (inheritedOnly) return Math.max(glyphNatural, pitchPx);
+      return Math.max(glyphNatural, pitchPx * ls.value);
     }
     return natural * ls.value;
   }


### PR DESCRIPTION
## Problem

`private/sample-3.docx` (a Meiryo UI résumé) drifts vertically vs the Word PDF. Most visibly, the 48 pt Title's two lines ("Taylor" / "Phillips") **overlap**, and the deficit accumulates down the page.

## Root cause (font metrics, not line-rule logic)

- The Title style sets `line="168" lineRule="auto"` = **0.7× single line** (ECMA-376 §17.3.1.33).
- Word's PDF embeds **MeiryoUI** for all text. On Windows the single-line height for `auto`/single spacing is `(usWinAscent + usWinDescent) / unitsPerEm` ≈ **1.60 em** for Meiryo, so `0.7 × 1.60 × 48 ≈ 53.8 pt` — no overlap.
- We derive the single-line height from the **substituted fallback's** Canvas `fontBoundingBox`. Meiryo UI isn't installed, and Hiragino (macOS) reports only ~1.0 em, so `0.7 × 1.0 × 48 ≈ 34 pt` collapses the lines.

| metric source | single-line ratio | 48 pt title line height |
|---|---|---|
| Meiryo win metrics (Word) | 1.60 em | 53.8 pt ✓ |
| Hiragino `fontBoundingBox` (our fallback) | ~1.0 em | 34 pt (overlap) |

## Fix

`font-metrics.ts` adds a table of **verified** win line-height ratios (Meiryo / Meiryo UI = 1.60, cross-checked against the reference PDF's title measured at 300 dpi *and* the font's published win metrics). `lineBoxHeight` sizes the `auto`/single line box from `max(glyphExtent, intendedSingleLine)`, so spacing matches Word regardless of which fallback draws the glyphs, and never drops below the glyph extent (no clipping).

**Deliberately narrow, no sample-tuned constants:**
- Only fonts whose real win ratio differs materially from the browser fallback are tabled (Latin ~1.15–1.22 em omitted — negligible correction).
- Applies **off-grid only**. `docGrid type=lines` sections (e.g. sample-5) stay governed by the grid pitch — unchanged.
- Non-Meiryo docs get `intendedSingle=0` → **byte-identical output**.

## Verification

- **sample-3**: title lines no longer overlap (line separation now matches Word at 0.064 of page height); bottom skills bars realign with Word.
- **sample-5** (active grid + ruby + Meiryo): cover page unchanged vs its PDF.
- **demo/sample-1** (committed reference, no Meiryo): provably unaffected (`intendedSingle=0`).
- `pnpm vitest run` — 45 passed (5 new in `font-metrics.test.ts`); `pnpm lint` clean; docx typecheck clean.

A residual mid-page offset remains from column text **wrapping** (Word wraps to more lines) — a separate root cause, tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)