### PR TITLE
fix(xlsx): support per-series chart data-label color (parity with pptx)

### DIFF
--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -914,6 +914,16 @@ pub(crate) fn parse_chart_series(
         _                 => chart_marker_default,
     };
 
+    // Per-series data-label text color from `<c:ser><c:dLbls><c:txPr>…solidFill`.
+    // Scoped to THIS series (not chart-root) so stacked/clustered charts keep
+    // their independent label colors instead of all collapsing to the single
+    // chart-level color. Reuses the shared dLbls-txPr walker + xlsx theme
+    // resolver. None when the series has no own dLbls text color.
+    let label_color = ooxml_common::chart::extract_data_label_font_color(
+        *node,
+        &XlsxColorResolver { theme_colors },
+    );
+
     let data_point_overrides = parse_data_point_overrides(node, c_ns, theme_colors);
     // `<c15:datalabelsRange>` lookup table for `<a:fld type="CELLRANGE">`
     // labels. Excel saves the actual cached label strings here; we resolve
@@ -931,6 +941,7 @@ pub(crate) fn parse_chart_series(
         color,
         show_marker,
         val_format_code,
+        label_color,
         order,
         marker_symbol,
         marker_size,
@@ -1550,3 +1561,69 @@ pub(crate) fn collect_num_cache(ser_node: &roxmltree::Node, c_ns: &str, child_ta
     result
 }
 
+
+#[cfg(test)]
+mod label_color_tests {
+    use super::*;
+    use roxmltree::Document;
+
+    const C_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+
+    fn ser_xml(scheme: &str) -> String {
+        format!(
+            r#"<c:ser xmlns:c="{c}" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                 <c:idx val="0"/><c:order val="0"/>
+                 <c:dLbls>
+                   <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr>
+                     <a:solidFill><a:schemeClr val="{s}"/></a:solidFill>
+                   </a:defRPr></a:pPr></a:p></c:txPr>
+                   <c:showVal val="1"/>
+                 </c:dLbls>
+                 <c:val><c:numRef><c:numCache>
+                   <c:pt idx="0"><c:v>1</c:v></c:pt>
+                 </c:numCache></c:numRef></c:val>
+               </c:ser>"#,
+            c = C_NS, s = scheme
+        )
+    }
+
+    // Theme order: dk1@0, lt1@1, dk2@2, lt2@3, accent1@4 …
+    fn theme() -> Vec<String> {
+        vec![
+            "111111".into(), "fefefe".into(), "222222".into(), "eeeeee".into(),
+            "aa0000".into(), "00aa00".into(), "0000aa".into(),
+            "aaaa00".into(), "00aaaa".into(), "aa00aa".into(),
+        ]
+    }
+
+    #[test]
+    fn per_series_label_color_resolves_tx1_to_dk1() {
+        let xml = ser_xml("tx1");
+        let doc = Document::parse(&xml).unwrap();
+        let s = parse_chart_series(&doc.root_element(), C_NS, "bar", false, &theme());
+        // tx1 maps to dk1 → theme[0]
+        assert_eq!(s.label_color.as_deref(), Some("111111"));
+    }
+
+    #[test]
+    fn per_series_label_color_resolves_bg1_to_lt1() {
+        let xml = ser_xml("bg1");
+        let doc = Document::parse(&xml).unwrap();
+        let s = parse_chart_series(&doc.root_element(), C_NS, "bar", false, &theme());
+        // bg1 maps to lt1 → theme[1]
+        assert_eq!(s.label_color.as_deref(), Some("fefefe"));
+    }
+
+    #[test]
+    fn no_series_dlbls_color_is_none() {
+        let xml = format!(
+            r#"<c:ser xmlns:c="{c}"><c:idx val="0"/><c:order val="0"/>
+                 <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+               </c:ser>"#,
+            c = C_NS
+        );
+        let doc = Document::parse(&xml).unwrap();
+        let s = parse_chart_series(&doc.root_element(), C_NS, "bar", false, &theme());
+        assert_eq!(s.label_color, None);
+    }
+}

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -330,6 +330,14 @@ pub struct ChartSeries {
     /// labels are formatted per ECMA-376 §21.2.2.37.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub val_format_code: Option<String>,
+    /// `<c:ser><c:dLbls><c:txPr>…<a:solidFill>` — series-level data-label text
+    /// color (ECMA-376 §21.2.2.216). Resolved against the workbook theme.
+    /// Stacked/clustered charts can color each series's labels independently
+    /// (e.g. white on a dark bar, black on a light one), which a single
+    /// chart-level color can't express. None = fall back to the chart-level
+    /// `data_label_font_color` in the renderer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_color: Option<String>,
     /// `<c:ser><c:order val>` — display order of this series (stacking
     /// ordering + legend ordering) per ECMA-376 §21.2.2.28. Lower `order`
     /// renders first/below; Excel's legend for horizontal bar charts reverses

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3016,6 +3016,7 @@ function adaptChartData(chart: ChartData): ChartModel {
       categories: s.categories.length > 0 ? s.categories : null,
       showMarker: s.showMarker ?? null,
       valFormatCode: s.valFormatCode ?? null,
+      labelColor: s.labelColor ?? null,
       markerSymbol: s.markerSymbol ?? null,
       markerSize: s.markerSize ?? null,
       markerFill: s.markerFill ?? null,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -195,6 +195,10 @@ export interface XlsxChartSeries {
   /** `<c:val>/<c:numRef>/<c:formatCode>` — Excel number format for series
    *  values (ECMA-376 §21.2.2.37). */
   valFormatCode?: string | null;
+  /** `<c:ser><c:dLbls><c:txPr>…solidFill` — per-series data-label text color
+   *  (ECMA-376 §21.2.2.216). Takes precedence over the chart-level color so
+   *  each series can color its labels independently. */
+  labelColor?: string | null;
   /** `<c:ser><c:order>` — stacking/legend display order (§21.2.2.28). */
   order?: number;
   /** `<c:marker><c:symbol val>` — point marker shape (ECMA-376 §21.2.2.32). */


### PR DESCRIPTION
## Context

Follow-up to the pptx slide-16 chart fix (#305): the user asked whether the same class of bug exists elsewhere. It does — in the **xlsx** chart parser.

## Gap

The pptx fix added **per-series** data-label color (`<c:ser><c:dLbls><c:txPr>`). xlsx still read only a **single chart-level** `extract_data_label_font_color`, so a chart whose series specify different label colors (white-on-dark + black-on-light, like pptx slide-16) would collapse them all to the first series' color.

- xlsx already parsed per-series `val_format_code`, so the thousands-separator half of the pptx fix has **no analog** here. ✓
- docx has **no chart rendering** → N/A.

## Fix

Add a per-series `label_color` to the xlsx `ChartSeries` (resolved against the workbook theme via the shared dLbls-txPr walker, scoped to each `<c:ser>`), plumbed through `XlsxChartSeries` → `adaptChartData` → the core renderer, which already prefers `series.labelColor` over the chart-level color (ECMA-376 §21.2.2.216).

## Impact & verification

**No visual change on any current sample** — they all resolve to the same colors as before:
- `demo/sample-1` (committed reference): all 4 charts carry **zero** per-series label color → provably a no-op.
- `private/sample-1`: both series are `bg1` (same color).
- `private/sample-26`: ser0 `tx1` + ser1 none → both resolve to the chart-level color anyway.

This closes the latent multi-color case and makes xlsx consistent with pptx. Adds Rust unit tests (`cargo test` → 3 passed: tx1→dk1, bg1→lt1, absent→None). `pnpm vitest` 45 passed; xlsx + core typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)