### PR TITLE
fix(docx): per-cell tcMar margins + empty-paragraph font metrics

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -779,6 +779,11 @@ fn parse_paragraph(
             .or_else(|| style_map.default_para_style_id().map(str::to_string))
             .or_else(|| Some("Normal".to_string())),
         default_font_size: base_run.font_size,
+        // Resolve the paragraph's default font the same way runs do (ascii
+        // first, then eastAsia, through theme refs) so empty paragraphs can be
+        // sized with the intended font's line metrics.
+        default_font_family: theme.resolve_font_ref(base_run.font_family_ascii.clone())
+            .or_else(|| theme.resolve_font_ref(base_run.font_family_east_asia.clone())),
         outline_level: base_para.outline_level,
     }
 }
@@ -2212,6 +2217,19 @@ fn parse_table_cell(
             }
         });
 
+    // Per-cell margins (ECMA-376 §17.4.42 `<w:tcPr><w:tcMar>`). Each edge,
+    // when present, overrides the table-level `<w:tblCellMar>` default; absent
+    // edges stay None so the renderer falls back to the table default.
+    let tc_mar = tc_pr.and_then(|p| child_w(p, "tcMar"));
+    let edge_mar = |name: &str| tc_mar
+        .and_then(|m| child_w(m, name))
+        .and_then(|n| attr_w(n, "w"))
+        .map(|v| twips_to_pt(&v));
+    let margin_top = edge_mar("top");
+    let margin_bottom = edge_mar("bottom");
+    let margin_left = edge_mar("left");
+    let margin_right = edge_mar("right");
+
     // ECMA-376 §17.4.7: a cell may contain paragraphs AND nested tables in
     // any order. element_children_flat unwraps sdt wrappers like elsewhere.
     let mut content: Vec<CellElement> = vec![];
@@ -2227,7 +2245,10 @@ fn parse_table_cell(
         }
     }
 
-    DocTableCell { content, col_span, v_merge, borders, background, v_align, width_pt }
+    DocTableCell {
+        content, col_span, v_merge, borders, background, v_align, width_pt,
+        margin_top, margin_bottom, margin_left, margin_right,
+    }
 }
 
 fn parse_table_borders(node: roxmltree::Node) -> TableBorders {

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -194,6 +194,12 @@ pub struct DocParagraph {
     /// sizing empty paragraphs (lines with no runs) correctly.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_font_size: Option<f64>,
+    /// Default font family resolved from the style chain + direct pPr/rPr.
+    /// Used to size empty paragraphs (no runs) when the intended font's line
+    /// height differs from the fallback (e.g. an empty Meiryo cell that forms a
+    /// résumé "bar" must reserve Meiryo's tall line box). None when unresolved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_font_family: Option<String>,
     /// ECMA-376 §17.3.1.20 `<w:outlineLvl w:val="N">` (0–8). Resolved through
     /// the style chain: explicit pPr → linked paragraph style → docDefaults.
     /// `None` for body paragraphs that don't appear in the document outline.
@@ -700,6 +706,18 @@ pub struct DocTableCell {
     pub v_align: String,
     /// pt
     pub width_pt: Option<f64>,
+    /// Per-cell margins from `<w:tcPr><w:tcMar>` (ECMA-376 §17.4.42), in pt.
+    /// Each edge overrides the table-level `<w:tblCellMar>` default (§17.4.41)
+    /// when present; None = inherit the table default. Used e.g. by résumé
+    /// templates that add a top margin to a single cell to space its content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin_top: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin_bottom: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin_left: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin_right: Option<f64>,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -675,8 +675,9 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
     for (const cell of row.cells) {
       const span = Math.min(cell.colSpan, colWidths.length - ci);
       const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
-      const innerW = Math.max(1, cellW - table.cellMarginLeft - table.cellMarginRight);
-      let ch = table.cellMarginTop + table.cellMarginBottom;
+      const cm = effCellMargins(cell, table);
+      const innerW = Math.max(1, cellW - cm.left - cm.right);
+      let ch = cm.top + cm.bottom;
       for (const ce of cell.content) {
         if (ce.type === 'paragraph') {
           ch += estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
@@ -2195,7 +2196,8 @@ function calculateRowHeight(
   for (const cell of row.cells) {
     const span = Math.min(cell.colSpan, colWidths.length - ci);
     const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
-    const contentW = cellW - (table.cellMarginLeft + table.cellMarginRight) * scale;
+    const cm = effCellMargins(cell, table);
+    const contentW = cellW - (cm.left + cm.right) * scale;
 
     // ECMA-376 §17.4.85 (w:vMerge): a vMerge=restart cell's content occupies
     // the entire merged span (this row + following rows whose same column
@@ -2215,7 +2217,7 @@ function calculateRowHeight(
       continue;
     }
 
-    let h = (table.cellMarginTop + table.cellMarginBottom) * scale;
+    let h = (cm.top + cm.bottom) * scale;
     for (const ce of cell.content) {
       h += measureCellElementHeight(state, ce, contentW, scale);
     }
@@ -2234,8 +2236,9 @@ function measureRestartCellContentHeight(
   scale: number,
   state: RenderState,
 ): number {
-  const contentW = cellW - (table.cellMarginLeft + table.cellMarginRight) * scale;
-  let h = (table.cellMarginTop + table.cellMarginBottom) * scale;
+  const cm = effCellMargins(cell, table);
+  const contentW = cellW - (cm.left + cm.right) * scale;
+  let h = (cm.top + cm.bottom) * scale;
   for (const ce of cell.content) {
     h += measureCellElementHeight(state, ce, contentW, scale);
   }
@@ -2259,6 +2262,22 @@ function measureParaHeight(
   return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, paraHasRuby, l.intendedSingle), 0);
 }
 
+/** Effective cell margins (pt). Per-cell `<w:tcMar>` overrides (ECMA-376
+ *  §17.4.42) take precedence per edge over the table-level `<w:tblCellMar>`
+ *  default (§17.4.41). A résumé template, for example, gives one cell a larger
+ *  top margin to add space above its content. */
+function effCellMargins(
+  cell: DocTableCell,
+  table: DocTable,
+): { top: number; bottom: number; left: number; right: number } {
+  return {
+    top: cell.marginTop ?? table.cellMarginTop,
+    bottom: cell.marginBottom ?? table.cellMarginBottom,
+    left: cell.marginLeft ?? table.cellMarginLeft,
+    right: cell.marginRight ?? table.cellMarginRight,
+  };
+}
+
 function measureCellContent(
   cell: DocTableCell,
   table: DocTable,
@@ -2266,8 +2285,9 @@ function measureCellContent(
   scale: number,
   state: RenderState,
 ): void {
-  const ml = table.cellMarginLeft * scale;
-  const mr = table.cellMarginRight * scale;
+  const cm = effCellMargins(cell, table);
+  const ml = cm.left * scale;
+  const mr = cm.right * scale;
   const innerW = cellW - ml - mr;
   for (const ce of cell.content) {
     measureCellElementHeight(state, ce, innerW, scale);
@@ -2310,10 +2330,11 @@ function renderCell(
 
   drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale);
 
-  const mt = table.cellMarginTop * scale;
-  const mb = table.cellMarginBottom * scale;
-  const ml = table.cellMarginLeft * scale;
-  const mr = table.cellMarginRight * scale;
+  const cm = effCellMargins(cell, table);
+  const mt = cm.top * scale;
+  const mb = cm.bottom * scale;
+  const ml = cm.left * scale;
+  const mr = cm.right * scale;
 
   // ECMA-376 §17.6.5 defines w:docGrid as a section-level constraint on
   // Cell paragraphs inherit the section's docGrid, but their line-spacing
@@ -2555,13 +2576,16 @@ function getDefaultFontSize(para: DocParagraph): number {
 }
 
 /** First text/field run's font family — used to size empty paragraphs whose
- *  intended font (e.g. Meiryo) has a larger win line height than the fallback. */
+ *  intended font (e.g. Meiryo) has a larger win line height than the fallback.
+ *  Empty paragraphs (no runs) fall back to the paragraph's style-resolved
+ *  default font so e.g. an empty Meiryo cell that forms a résumé "bar" reserves
+ *  Meiryo's tall line box rather than the generic fallback's. */
 function getDefaultFontFamily(para: DocParagraph): string | null {
   for (const run of para.runs) {
     if (run.type === 'text') return (run as unknown as TextRun).fontFamily;
     if (run.type === 'field') return (run as unknown as FieldRun).fontFamily;
   }
-  return null;
+  return para.defaultFontFamily ?? null;
 }
 
 /** Intended single-line height (px) for an empty paragraph, from its default

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -139,6 +139,9 @@ export interface DocParagraph {
   styleId?: string | null;
   /** Default font size (pt) inherited from style + direct pPr/rPr. Falls back to 10pt. */
   defaultFontSize?: number;
+  /** Default font family resolved from the style chain. Used to size empty
+   *  paragraphs (no runs) with the intended font's line metrics. */
+  defaultFontFamily?: string | null;
 }
 
 export interface ParagraphBorders {
@@ -442,6 +445,13 @@ export interface DocTableCell {
   background: string | null;
   vAlign: 'top' | 'center' | 'bottom';
   widthPt: number | null;
+  /** Per-cell margins (pt) from `<w:tcPr><w:tcMar>` (ECMA-376 §17.4.42). Each
+   *  edge overrides the table-level `cellMargin*` default when set; null/absent
+   *  = inherit the table default. */
+  marginTop?: number | null;
+  marginBottom?: number | null;
+  marginLeft?: number | null;
+  marginRight?: number | null;
 }
 
 export interface CellBorders {


### PR DESCRIPTION
Two sample-3 layout gaps vs the Word PDF, both spec-grounded.

## 1. Missing space before the job-description paragraphs
Each description's table cell carries a **per-cell** `<w:tcPr><w:tcMar><w:top w:w="360"/>` (18pt) that overrides the table-level `<w:tblCellMar>` default (ECMA-376 §17.4.42 over §17.4.41). Our renderer applied only the single **table-level** margin to every cell, so the override was lost.

**Fix:** parse per-cell `tcMar` into `DocTableCell.margin{Top,Bottom,Left,Right}` and resolve effective margins per edge (`cell override ?? table default`) at every cell measure/render site (new `effCellMargins` helper).

## 2. Skill "bars" too thin
The résumé skill bars are empty, black-shaded **Meiryo** cells. A bar row is an empty paragraph, and #306's empty-paragraph font-metric path only consulted `para.runs` — which is empty — so it never applied Meiryo's 1.6× line height and the bar collapsed to the fallback ~9pt instead of Word's ~14.9pt.

**Fix:** add a style-resolved `defaultFontFamily` to the paragraph model and fall back to it in `getDefaultFontFamily`, so empty paragraphs are sized with the intended font's metrics. All three bars now measure ~14pt (Word ~14.9pt).

## Verification
- Both the description gap and the three skill bars now match the Word PDF (side-by-side confirmed).
- **No regression on the committed reference** `demo/sample-1`: it has **zero** per-cell `tcMar` and **no Meiryo**, so both changes are provable no-ops there.
- Grid-active docs (`sample-5`, `docGrid type=lines`) keep sizing empty lines by the grid pitch, not the font ratio — untouched.
- docx typecheck + lint clean; `vitest` + Rust tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)