### PR TITLE
fix(pptx): tabular figures for media playback time (no jitter)

### DIFF
--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -1,5 +1,6 @@
 import type { MediaElement, Slide } from './types';
 import { drawPlayBadge } from './media-chrome';
+import { tabularDigitWidth, tabularTextWidth, drawTabularText } from './tabular-text';
 
 const EMU_PER_PX = 9525;
 const emuToPx = (v: number, scale: number) => (v / EMU_PER_PX) * scale;
@@ -365,10 +366,10 @@ function drawAudioPill(
 }
 
 /**
- * Render "m:ss / m:ss" such that the separator stays at a fixed x even as the
- * current-time digits tick, by right-aligning the current side into a fixed
- * slot and left-aligning the duration side. Side slot width is sized once per
- * call from the duration string so the layout fits longer clips too.
+ * Render "m:ss / m:ss" with tabular (fixed-advance) digits so neither the
+ * separator nor the individual current-time digits shift as playback ticks.
+ * The current side is right-aligned into a fixed slot (sized from the wider of
+ * the two sides) and the duration side is left-aligned after the separator.
  */
 function drawFixedSlotTime(
   ctx: CanvasRenderingContext2D,
@@ -376,23 +377,25 @@ function drawFixedSlotTime(
   duration: number,
   x: number,
   anchorY: number,
-  anchor: 'middle' | 'bottom',
+  _anchor: 'middle' | 'bottom',
 ): void {
   const curText = formatTime(current);
   const durText = formatTime(duration);
   const sep = ' / ';
-  // Widest representation of either side: use the longer of the two formatted
-  // strings. In practice duration dominates since current ≤ duration.
-  const slotW = Math.max(ctx.measureText(curText).width, ctx.measureText(durText).width);
+  const digitW = tabularDigitWidth(ctx);
+  const curW = tabularTextWidth(ctx, curText, digitW);
+  const durW = tabularTextWidth(ctx, durText, digitW);
   const sepW = ctx.measureText(sep).width;
-  const y = anchor === 'bottom' ? anchorY : anchorY;
+  // Slot wide enough for the longer side (duration dominates since current ≤
+  // duration), so the separator sits at a fixed x regardless of current time.
+  const slotW = Math.max(curW, durW);
+  // Current time right-aligned within the slot (its right edge fixed at x+slotW).
+  drawTabularText(ctx, curText, x + slotW - curW, anchorY, digitW);
   const prevAlign = ctx.textAlign;
-  ctx.textAlign = 'right';
-  ctx.fillText(curText, x + slotW, y);
   ctx.textAlign = 'left';
-  ctx.fillText(sep, x + slotW, y);
-  ctx.fillText(durText, x + slotW + sepW, y);
+  ctx.fillText(sep, x + slotW, anchorY);
   ctx.textAlign = prevAlign;
+  drawTabularText(ctx, durText, x + slotW + sepW, anchorY, digitW);
 }
 
 function drawBar(

--- a/packages/pptx/src/tabular-text.test.ts
+++ b/packages/pptx/src/tabular-text.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { tabularDigitWidth, tabularTextWidth, drawTabularText } from './tabular-text.js';
+
+// Mock a Canvas-like text context with deliberately UNEQUAL digit widths (as a
+// proportional font has — '1' is narrow, '8'/'0' wide) plus punctuation. This
+// is what makes a naive layout jitter; the tabular helpers must neutralize it.
+const ADVANCE: Record<string, number> = {
+  '0': 10, '1': 5, '2': 9, '3': 9, '4': 9, '5': 9, '6': 10, '7': 8, '8': 10, '9': 10,
+  ':': 4, ' ': 3, '/': 5,
+};
+
+function mockCtx() {
+  const calls: { ch: string; x: number }[] = [];
+  const ctx = {
+    textAlign: 'left' as CanvasTextAlign,
+    measureText: (s: string) => ({ width: [...s].reduce((w, c) => w + (ADVANCE[c] ?? 6), 0) }),
+    fillText: (t: string, x: number) => { calls.push({ ch: t, x }); },
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+describe('tabularDigitWidth', () => {
+  it('returns the widest digit advance', () => {
+    expect(tabularDigitWidth(mockCtx().ctx)).toBe(10); // max over 0–9
+  });
+});
+
+describe('tabularTextWidth', () => {
+  it('is identical for same-shape time strings regardless of digit values', () => {
+    const { ctx } = mockCtx();
+    const dw = tabularDigitWidth(ctx);
+    // "m:ss" → digit, ':', digit, digit. Different values, same shape ⇒ same width.
+    const a = tabularTextWidth(ctx, '0:01', dw);
+    const b = tabularTextWidth(ctx, '0:08', dw);
+    const c = tabularTextWidth(ctx, '9:59', dw);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(a).toBe(dw + ADVANCE[':'] + dw + dw); // 3 digit cells + colon
+  });
+});
+
+describe('drawTabularText — no jitter', () => {
+  it('places every digit cell at the same x for any digit values', () => {
+    const dw = tabularDigitWidth(mockCtx().ctx);
+    const draw = (s: string) => {
+      const { ctx, calls } = mockCtx();
+      drawTabularText(ctx, s, 100, 20, dw);
+      return calls;
+    };
+    const c1 = draw('0:01');
+    const c2 = draw('0:08');
+    const c3 = draw('1:11');
+    // Same number of glyphs, and each glyph's cell advances identically.
+    // We verify the LAST glyph lands at the same x across all three (its
+    // position is the sum of all preceding fixed cells), which is exactly the
+    // "separator/duration don't move" guarantee.
+    const lastX = (calls: { ch: string; x: number }[]) => calls[calls.length - 1].x;
+    // The trailing glyph is a digit; its cell start is identical, only the
+    // intra-cell centering offset varies with the glyph width — but the cell
+    // boundary (and thus everything after) is fixed. Assert cell starts match
+    // by removing the centering offset.
+    const cellStart = (entry: { ch: string; x: number }) =>
+      entry.x - (dw - (ADVANCE[entry.ch] ?? 6)) / 2;
+    expect(cellStart(c2[c2.length - 1])).toBeCloseTo(cellStart(c1[c1.length - 1]), 9);
+    expect(cellStart(c3[c3.length - 1])).toBeCloseTo(cellStart(c1[c1.length - 1]), 9);
+    // And the digits are centered (offset ≥ 0, glyph never overflows the cell).
+    expect(lastX(c1)).toBeGreaterThanOrEqual(cellStart(c1[c1.length - 1]));
+  });
+
+  it('restores textAlign', () => {
+    const { ctx } = mockCtx();
+    (ctx as { textAlign: CanvasTextAlign }).textAlign = 'center';
+    drawTabularText(ctx, '0:00', 0, 0, 10);
+    expect(ctx.textAlign).toBe('center');
+  });
+});

--- a/packages/pptx/src/tabular-text.ts
+++ b/packages/pptx/src/tabular-text.ts
@@ -1,0 +1,59 @@
+// Tabular (fixed-advance) digit rendering for Canvas 2D.
+//
+// The media playback time ("m:ss / m:ss") is drawn with a proportional UI font,
+// so as the digits tick (e.g. "0:01" → "0:08" → "0:11") their differing widths
+// shift the layout and the text appears to jitter. CSS solves this with
+// `font-variant-numeric: tabular-nums`, but Canvas 2D exposes no way to set it.
+//
+// Instead we lay each digit out in a fixed-width cell (the widest digit's
+// advance) and center the glyph within it — the same visual result as tabular
+// figures, while keeping the natural (non-monospace) typeface. Punctuation
+// (':', '/', spaces) keeps its natural advance.
+//
+// Only `measureText`/`fillText`/`textAlign` are used, so any object providing
+// them works (the production caller passes a CanvasRenderingContext2D).
+type TextCtx = Pick<CanvasRenderingContext2D, 'measureText' | 'fillText' | 'textAlign'>;
+
+const isDigit = (ch: string): boolean => ch >= '0' && ch <= '9';
+
+/** Widest advance among the digits 0–9 for the context's current font. */
+export function tabularDigitWidth(ctx: TextCtx): number {
+  let w = 0;
+  for (let d = 0; d < 10; d++) w = Math.max(w, ctx.measureText(String(d)).width);
+  return w;
+}
+
+/** Width of `text` when every digit occupies a fixed `digitW` cell and other
+ *  glyphs keep their natural advance. Equal for any two strings with the same
+ *  digit/non-digit shape — which is what removes the jitter. */
+export function tabularTextWidth(ctx: TextCtx, text: string, digitW: number): number {
+  let w = 0;
+  for (const ch of text) w += isDigit(ch) ? digitW : ctx.measureText(ch).width;
+  return w;
+}
+
+/** Draw `text` from left edge `leftX`, centering each digit inside a fixed
+ *  `digitW` cell (tabular figures) while keeping the natural font. Honors the
+ *  current baseline/fill; saves and restores `textAlign`. */
+export function drawTabularText(
+  ctx: TextCtx,
+  text: string,
+  leftX: number,
+  y: number,
+  digitW: number,
+): void {
+  const prevAlign = ctx.textAlign;
+  ctx.textAlign = 'left';
+  let cx = leftX;
+  for (const ch of text) {
+    if (isDigit(ch)) {
+      const gw = ctx.measureText(ch).width;
+      ctx.fillText(ch, cx + (digitW - gw) / 2, y); // center the glyph in its cell
+      cx += digitW;
+    } else {
+      ctx.fillText(ch, cx, y);
+      cx += ctx.measureText(ch).width;
+    }
+  }
+  ctx.textAlign = prevAlign;
+}


### PR DESCRIPTION
## Problem

The audio/video playback time (`m:ss / m:ss`, drawn on the canvas) uses a proportional UI font, so as digits tick (`0:01 → 0:08 → 0:11`) their differing advances shift the layout and the time **visibly jitters**. The existing fixed-slot right-alignment pinned the separator but not the individual digits.

## Answer to "can we use a natural-looking monospace, like YouTube?"

Yes — and it's not actually a monospace *font*. YouTube keeps its normal UI font and turns on **tabular figures** (`font-variant-numeric: tabular-nums`), which makes only the digits equal-width. Canvas 2D can't set that CSS property, so we reproduce it: lay each digit in a fixed-width cell (the widest digit's advance) and center the glyph within it. Punctuation keeps its natural advance.

Result: digits stay put as they change, the typeface remains the natural `system-ui` sans-serif (no typewriter look). No need to switch fonts or abandon the proportional font.

## Implementation

Extracted to a pure, unit-tested `tabular-text.ts` (mirrors `axis-scale.ts` / `chart-number-format.ts`):
- `tabularDigitWidth`, `tabularTextWidth`, `drawTabularText`.
- `drawFixedSlotTime` now uses them.

## Verification

- `tabular-text.test.ts` (4 tests) locks the no-jitter invariant: equal width and fixed digit-cell positions for any digit values; `textAlign` restored.
- Real-font canvas render confirmed the separator stays pinned across `0:01 / 0:08 / 0:18` and the figures look natural.
- `pnpm vitest` 49 passed; pptx typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)