### PR TITLE
feat(xlsx): render sheet-tab colors and add an Excel-style zoom slider

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -98,11 +98,74 @@ fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
     let shared_strings = read_shared_strings(&mut archive, &theme_colors);
     let styles = parse_styles(&mut archive, &theme_colors)?;
 
+    // Surface each sheet's tab color (`<sheetPr><tabColor>`) on the workbook
+    // sheet list so the viewer can paint every tab up front. `<sheetPr>` is the
+    // first child of `<worksheet>` (ECMA-376 §18.3.1.99 element order), so a
+    // small head read of each sheet entry is enough — we never decompress the
+    // (potentially huge) `<sheetData>` body just to read the tab color.
+    let mut sheets = sheets;
+    if let Ok(rels_xml) = read_zip_entry(&mut archive, "xl/_rels/workbook.xml.rels") {
+        if let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) {
+            for sheet in sheets.iter_mut() {
+                let Some(path) = resolve_sheet_path(&rels_doc, &sheet.r_id) else { continue; };
+                let Ok(head) = read_zip_entry_head(&mut archive, &format!("xl/{}", path), 16_384)
+                else { continue; };
+                sheet.tab_color = extract_tab_color_from_head(&head, &theme_colors);
+            }
+        }
+    }
+
     Ok(ParsedWorkbook {
         workbook: Workbook { sheets },
         styles,
         shared_strings,
     })
+}
+
+/// Read only the first `max_bytes` of a ZIP entry as text. Used to probe the
+/// top of a worksheet (its `<sheetPr>`) without inflating the whole sheet.
+/// Lossy UTF-8 keeps a multibyte character split at the cut from erroring; the
+/// region we care about (`<sheetPr><tabColor>`) is pure ASCII near the start.
+fn read_zip_entry_head(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    name: &str,
+    max_bytes: u64,
+) -> Result<String, String> {
+    let mut file = archive
+        .by_name(name)
+        .map_err(|e| format!("entry '{}' not found: {}", name, e))?;
+    let mut buf = Vec::new();
+    file.by_ref().take(max_bytes).read_to_end(&mut buf).map_err(|e| e.to_string())?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Extract the resolved tab color from the head of a worksheet XML. Locates the
+/// single `<tabColor .../>` element (it lives in `<sheetPr>`, before
+/// `<sheetData>`) and resolves its `rgb` / `theme`+`tint` / `indexed` attributes
+/// through the same rules as cell colors. Returns `None` when no tab color is
+/// declared or the tag is truncated by the head limit. A lightweight attribute
+/// scan avoids any namespace-prefix assumptions in the partial document.
+fn extract_tab_color_from_head(head: &str, theme_colors: &[String]) -> Option<String> {
+    // Don't look past the data body — `tabColor` only appears in `<sheetPr>`.
+    let scope = head.split("<sheetData").next().unwrap_or(head);
+    let start = scope.find("tabColor")?;
+    let rest = &scope[start..];
+    // The element is self-closing (`<tabColor ... />`); read up to its `>`.
+    let end = rest.find('>')?;
+    let tag = &rest[..end];
+    let attr = |name: &str| -> Option<&str> {
+        let key = format!("{}=\"", name);
+        let i = tag.find(&key)? + key.len();
+        let j = tag[i..].find('"')? + i;
+        Some(&tag[i..j])
+    };
+    resolve_color_attrs(
+        attr("rgb"),
+        attr("theme"),
+        attr("tint"),
+        attr("indexed"),
+        theme_colors,
+    )
 }
 
 pub(crate) fn read_zip_entry(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, name: &str) -> Result<String, String> {
@@ -223,8 +286,28 @@ fn hue_to_rgb(p: f64, q: f64, mut t: f64) -> f64 {
 }
 
 pub(crate) fn parse_color(node: &roxmltree::Node, theme_colors: &[String]) -> Option<String> {
+    resolve_color_attrs(
+        node.attribute("rgb"),
+        node.attribute("theme"),
+        node.attribute("tint"),
+        node.attribute("indexed"),
+        theme_colors,
+    )
+}
+
+/// Resolve a DrawingML/SpreadsheetML color from its raw attribute values
+/// (`rgb` / `theme` + `tint` / `indexed`). Split out from [`parse_color`] so
+/// callers that scan attributes without a roxmltree node (e.g. the bounded
+/// tab-color head probe) share the exact same resolution rules.
+pub(crate) fn resolve_color_attrs(
+    rgb: Option<&str>,
+    theme: Option<&str>,
+    tint: Option<&str>,
+    indexed: Option<&str>,
+    theme_colors: &[String],
+) -> Option<String> {
     // rgb attribute (ARGB: 8 chars, drop alpha; or 6-char RGB)
-    if let Some(rgb) = node.attribute("rgb") {
+    if let Some(rgb) = rgb {
         if rgb.len() == 8 {
             return Some(format!("#{}", &rgb[2..].to_uppercase()));
         }
@@ -240,7 +323,7 @@ pub(crate) fn parse_color(node: &roxmltree::Node, theme_colors: &[String]) -> Op
     //   0=lt1, 1=dk1, 2=lt2, 3=dk2, 4..11 unchanged.
     // This is a well-known interoperability quirk (see Open-XML-SDK issue #46
     // and ECMA-376 §22.1.2.7 where "index values of 0 and 1 are swapped").
-    if let Some(theme_str) = node.attribute("theme") {
+    if let Some(theme_str) = theme {
         if let Ok(idx) = theme_str.parse::<usize>() {
             let mapped = match idx {
                 0 => 1,
@@ -250,7 +333,7 @@ pub(crate) fn parse_color(node: &roxmltree::Node, theme_colors: &[String]) -> Op
                 n => n,
             };
             if let Some(base) = theme_colors.get(mapped) {
-                let tint = node.attribute("tint").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
+                let tint = tint.and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
                 if tint == 0.0 {
                     return Some(base.clone());
                 }
@@ -260,7 +343,7 @@ pub(crate) fn parse_color(node: &roxmltree::Node, theme_colors: &[String]) -> Op
     }
 
     // indexed attribute → Excel built-in palette
-    if let Some(indexed_str) = node.attribute("indexed") {
+    if let Some(indexed_str) = indexed {
         if let Ok(idx) = indexed_str.parse::<usize>() {
             // indices 64 (foreground) and 65 (background) are special: use black/white
             let color = match idx {
@@ -290,7 +373,7 @@ fn parse_workbook_sheets(doc: &roxmltree::Document) -> Vec<SheetMeta> {
                 .attribute((r_ns, "id"))
                 .unwrap_or("")
                 .to_string();
-            sheets.push(SheetMeta { name, sheet_id, r_id });
+            sheets.push(SheetMeta { name, sheet_id, r_id, tab_color: None });
         }
     }
     sheets
@@ -1449,4 +1532,47 @@ pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<S
     ws.default_font_size = df_size;
 
     serde_json::to_string(&ws).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tab_color_tests {
+    use super::extract_tab_color_from_head;
+
+    const THEME: &[&str] = &[
+        "#000000", "#FFFFFF", "#44546A", "#E7E6E6", "#4472C4", "#ED7D31",
+        "#A5A5A5", "#FFC000", "#5B9BD5", "#70AD47", "#0563C1", "#954F72",
+    ];
+
+    fn theme() -> Vec<String> {
+        THEME.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn tab_color_rgb() {
+        let head = r#"<?xml version="1.0"?><worksheet><sheetPr><tabColor rgb="FFFF0000"/></sheetPr><dimension ref="A1"/><sheetData>"#;
+        assert_eq!(extract_tab_color_from_head(head, &theme()).as_deref(), Some("#FF0000"));
+    }
+
+    #[test]
+    fn tab_color_theme_with_tint() {
+        // theme="4" (Excel-internal accent1) resolves to #4472C4; a tint just
+        // needs to produce *something* different — exact value covered by apply_tint.
+        let head = r#"<worksheet><sheetPr codeName="S1"><tabColor theme="4" tint="-0.249977111117893"/></sheetPr><sheetData/></worksheet>"#;
+        let got = extract_tab_color_from_head(head, &theme());
+        assert!(got.is_some(), "theme tab color should resolve");
+        assert_ne!(got.as_deref(), Some("#4472C4"), "tint should darken the base");
+    }
+
+    #[test]
+    fn tab_color_absent() {
+        let head = r#"<worksheet><sheetPr/><dimension ref="A1"/><sheetData><row/></sheetData></worksheet>"#;
+        assert_eq!(extract_tab_color_from_head(head, &theme()), None);
+    }
+
+    #[test]
+    fn tab_color_not_searched_past_sheetdata() {
+        // A stray "tabColor" token inside the body must not be misread.
+        let head = r#"<worksheet><sheetPr/><sheetData><c><is><t>tabColor rgb="00FF00"</t></is></c>"#;
+        assert_eq!(extract_tab_color_from_head(head, &theme()), None);
+    }
 }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -13,6 +13,12 @@ pub struct SheetMeta {
     pub name: String,
     pub sheet_id: u32,
     pub r_id: String,
+    /// Sheet tab color (`<sheetPr><tabColor>`, ECMA-376 §18.3.1.93) resolved
+    /// to `#RRGGBB`. Surfaced at workbook-list time so the viewer can paint
+    /// every tab without eagerly parsing each worksheet. `None` when the
+    /// sheet declares no tab color.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tab_color: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -6,6 +6,10 @@ export interface SheetMeta {
   name: string;
   sheetId: number;
   rId: string;
+  /** Sheet tab color (`<sheetPr><tabColor>`, ECMA-376 §18.3.1.93) resolved to
+   *  `#RRGGBB`. Surfaced at workbook-list time so tabs can be painted up front.
+   *  Absent when the sheet declares no tab color. */
+  tabColor?: string | null;
 }
 
 export interface MergeCell {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -11,6 +11,14 @@ const TAB_GAP = 1;
 export interface XlsxViewerOptions {
   /** Scale factor for cell/header dimensions (default 1). 0.5 = half size. */
   cellScale?: number;
+  /** Show the Excel-style zoom slider at the right end of the sheet-tab bar.
+   *  Default `true`. Set `false` to hide it (e.g. when the host supplies its
+   *  own zoom control). */
+  showZoomSlider?: boolean;
+  /** Lower/upper bounds for the zoom slider as scale factors. Default 0.1–4
+   *  (10%–400%, matching Excel's zoom range). */
+  zoomMin?: number;
+  zoomMax?: number;
   onReady?: (sheetNames: string[]) => void;
   onSheetChange?: (index: number, name: string) => void;
   onError?: (err: Error) => void;
@@ -128,7 +136,12 @@ export class XlsxViewer {
   private tabStrip: HTMLDivElement;
   private navPrev: HTMLButtonElement;
   private navNext: HTMLButtonElement;
+  private navGroup!: HTMLDivElement;
   private tabs: HTMLButtonElement[] = [];
+  /** Per-tab colors parallel to `tabs`, from `<sheetPr><tabColor>`. */
+  private tabColors: (string | null)[] = [];
+  private zoomSlider: HTMLInputElement | null = null;
+  private zoomLabel: HTMLSpanElement | null = null;
   private currentSheet = 0;
   private currentWorksheet: Worksheet | null = null;
   private opts: XlsxViewerOptions;
@@ -198,6 +211,7 @@ export class XlsxViewer {
       `display:flex;flex-shrink:0;width:${headerW}px;height:100%;`;
     navGroup.appendChild(this.navPrev);
     navGroup.appendChild(this.navNext);
+    this.navGroup = navGroup;
 
     // The scrollable strip that actually holds the sheet tabs. position:relative
     // so each tab's offsetLeft is measured against the strip's scroll content.
@@ -213,12 +227,23 @@ export class XlsxViewer {
     style.textContent =
       `.xlsx-tab-strip::-webkit-scrollbar{display:none}` +
       `.xlsx-tab-nav{background:transparent;transition:background 0.1s;}` +
-      `.xlsx-tab-nav:hover{background:rgba(0,0,0,0.08);}`;
+      `.xlsx-tab-nav:hover{background:rgba(0,0,0,0.08);}` +
+      // Excel-status-bar zoom slider: a thin uniform gray track (no colored
+      // fill on either side of the thumb) with a small round gray handle.
+      `.xlsx-zoom-slider{-webkit-appearance:none;appearance:none;background:transparent;height:15px;margin:0;}` +
+      `.xlsx-zoom-slider::-webkit-slider-runnable-track{height:4px;background:#c4c4c4;border-radius:2px;}` +
+      `.xlsx-zoom-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;width:12px;height:12px;margin-top:-4px;border-radius:50%;background:#808080;cursor:pointer;}` +
+      `.xlsx-zoom-slider:hover::-webkit-slider-thumb{background:#5f5f5f;}` +
+      `.xlsx-zoom-slider::-moz-range-track{height:4px;background:#c4c4c4;border-radius:2px;}` +
+      `.xlsx-zoom-slider::-moz-range-thumb{width:12px;height:12px;border:none;border-radius:50%;background:#808080;cursor:pointer;}`;
     document.head.appendChild(style);
     this.tabStrip.addEventListener('scroll', () => this.updateNavButtons());
 
     this.tabBar.appendChild(navGroup);
     this.tabBar.appendChild(this.tabStrip);
+    if (this.opts.showZoomSlider !== false) {
+      this.tabBar.appendChild(this.buildZoomControl());
+    }
 
     wrapper.appendChild(this.canvasArea);
     wrapper.appendChild(this.tabBar);
@@ -784,11 +809,12 @@ export class XlsxViewer {
   private buildTabs(): void {
     this.tabStrip.innerHTML = '';
     this.tabs = [];
+    this.tabColors = this.wb.tabColors;
     this.wb.sheetNames.forEach((name, i) => {
       const btn = document.createElement('button');
       btn.textContent = name;
       btn.title = name;
-      btn.style.cssText = this.tabStyle(false);
+      btn.style.cssText = this.tabStyle(false, this.tabColors[i]);
       btn.addEventListener('click', () => this.showSheet(i));
       this.tabStrip.appendChild(btn);
       this.tabs.push(btn);
@@ -864,29 +890,136 @@ export class XlsxViewer {
 
   private updateTabActive(index: number): void {
     this.tabs.forEach((btn, i) => {
-      btn.style.cssText = this.tabStyle(i === index);
+      btn.style.cssText = this.tabStyle(i === index, this.tabColors[i]);
     });
     this.tabs[index]?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
   }
 
-  private tabStyle(active: boolean): string {
+  private tabStyle(active: boolean, tabColor?: string | null): string {
     // Active tab renders taller than inactive so the selected sheet draws the
     // eye. Tabs align to flex-end, so shorter inactive tabs sit lower and the
     // active tab sticks up. Font size also bumps a hair on active.
     const activeH = TAB_BAR_H - 2;
     const inactiveH = TAB_BAR_H - 5;
     const base =
-      `display:inline-block;flex:none;padding:0 14px;` +
+      `display:inline-block;flex:none;padding:0 14px;position:relative;` +
       `border:1px solid #c8ccd0;border-bottom:none;border-radius:3px 3px 0 0;` +
       `cursor:pointer;white-space:nowrap;max-width:160px;overflow:hidden;text-overflow:ellipsis;` +
       `outline:none;box-sizing:border-box;`;
+    // `<sheetPr><tabColor>` renders as a color bar along the tab's bottom edge
+    // (Excel's "sheet tab color" treatment), drawn as an inset bottom shadow so
+    // it doesn't fight the tab's own border/background. The active tab keeps a
+    // thinner bar since its bottom merges into the white sheet body.
+    const bar = tabColor
+      ? `box-shadow:inset 0 -${active ? 2 : 3}px 0 0 ${tabColor};`
+      : '';
     return active
       ? base +
         `height:${activeH}px;font-size:13px;` +
-        `background:#fff;color:#000;border-bottom:1px solid #fff;font-weight:600;position:relative;top:1px;`
+        `background:#fff;color:#000;border-bottom:1px solid #fff;font-weight:600;top:1px;` +
+        bar
       : base +
         `height:${inactiveH}px;font-size:11px;` +
-        `background:#e0e0e0;color:#555;`;
+        `background:#e0e0e0;color:#555;` +
+        bar;
+  }
+
+  /** Excel-style zoom control pinned to the right end of the tab bar:
+   *  `−  [────slider────]  +  100%`. Live-updates the cell scale on input. */
+  private buildZoomControl(): HTMLDivElement {
+    const zoomMin = this.opts.zoomMin ?? 0.1;
+    const zoomMax = this.opts.zoomMax ?? 4;
+    const cur = this.opts.cellScale ?? 1;
+
+    const wrap = document.createElement('div');
+    wrap.style.cssText =
+      `display:flex;align-items:center;flex-shrink:0;gap:2px;` +
+      `padding:0 10px;height:100%;color:#555;font-size:12px;user-select:none;`;
+
+    const mkBtn = (glyph: string, label: string, delta: number): HTMLButtonElement => {
+      const b = document.createElement('button');
+      b.textContent = glyph;
+      b.setAttribute('aria-label', label);
+      b.title = label;
+      b.style.cssText =
+        `width:18px;height:18px;padding:0;border:none;background:transparent;` +
+        `color:#555;font-size:14px;line-height:1;cursor:pointer;border-radius:3px;`;
+      b.addEventListener('click', () => this.setScale((this.opts.cellScale ?? 1) + delta));
+      return b;
+    };
+
+    // The slider works in "position" units [0,100]; 50 is dead-center and maps
+    // to 100% so each half is its own linear segment (zoomMin→1 on the left,
+    // 1→zoomMax on the right), mirroring Excel's status-bar zoom where 100% sits
+    // in the middle even though the range (10%–400%) is asymmetric.
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.min = '0';
+    slider.max = '100';
+    slider.step = 'any';
+    slider.value = String(this.zoomScaleToPos(cur, zoomMin, zoomMax));
+    slider.setAttribute('aria-label', 'Zoom');
+    slider.title = 'Zoom';
+    slider.classList.add('xlsx-zoom-slider');
+    slider.style.cssText = `width:90px;cursor:pointer;`;
+    slider.addEventListener('input', () =>
+      this.setScale(this.zoomPosToScale(Number(slider.value), zoomMin, zoomMax)),
+    );
+
+    const label = document.createElement('span');
+    label.textContent = `${Math.round(cur * 100)}%`;
+    label.style.cssText = `min-width:42px;margin-left:6px;text-align:right;font-variant-numeric:tabular-nums;`;
+
+    wrap.appendChild(mkBtn('−', 'Zoom out', -0.1));
+    wrap.appendChild(slider);
+    wrap.appendChild(mkBtn('+', 'Zoom in', 0.1));
+    wrap.appendChild(label);
+
+    this.zoomSlider = slider;
+    this.zoomLabel = label;
+    return wrap;
+  }
+
+  /** Map a slider position [0,100] to a scale factor. 50 → 1.0 (100%), with a
+   *  separate linear segment on each side so the center is always 100%. */
+  private zoomPosToScale(pos: number, min: number, max: number): number {
+    return pos <= 50
+      ? min + (pos / 50) * (1 - min)
+      : 1 + ((pos - 50) / 50) * (max - 1);
+  }
+
+  /** Inverse of {@link zoomPosToScale}: scale factor → slider position [0,100]. */
+  private zoomScaleToPos(scale: number, min: number, max: number): number {
+    const clamped = Math.min(max, Math.max(min, scale));
+    return clamped <= 1
+      ? ((clamped - min) / (1 - min)) * 50
+      : 50 + ((clamped - 1) / (max - 1)) * 50;
+  }
+
+  /** Set the cell/header scale and re-lay-out the current sheet. Clamped to the
+   *  zoom bounds; keeps the slider thumb, percentage label and the row-header-
+   *  aligned tab-nav width in sync. */
+  setScale(scale: number): void {
+    const zoomMin = this.opts.zoomMin ?? 0.1;
+    const zoomMax = this.opts.zoomMax ?? 4;
+    // Snap to whole percent so the label and cellScale stay tidy.
+    const pct = Math.min(
+      Math.round(zoomMax * 100),
+      Math.max(Math.round(zoomMin * 100), Math.round(scale * 100)),
+    );
+    const next = pct / 100;
+    if (next === (this.opts.cellScale ?? 1)) return;
+    this.opts.cellScale = next;
+
+    if (this.zoomSlider) this.zoomSlider.value = String(this.zoomScaleToPos(next, zoomMin, zoomMax));
+    if (this.zoomLabel) this.zoomLabel.textContent = `${pct}%`;
+    // The tab-nav block spans the row-header width, which scales with the cells.
+    this.navGroup.style.width = `${Math.round(HEADER_W * next)}px`;
+
+    if (this.currentWorksheet) this.updateSpacerSize(this.currentWorksheet);
+    void this.renderCurrentSheet();
+    this.updateSelectionOverlay();
+    this.updateNavButtons();
   }
 
   private updateSpacerSize(ws: Worksheet): void {

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -82,6 +82,12 @@ export class XlsxWorkbook {
     return this.parsedWorkbook?.workbook.sheets.length ?? 0;
   }
 
+  /** Per-sheet tab colors (`#RRGGBB`) parallel to {@link sheetNames}.
+   *  `null` for sheets that declare no tab color. */
+  get tabColors(): (string | null)[] {
+    return this.parsedWorkbook?.workbook.sheets.map((s) => s.tabColor ?? null) ?? [];
+  }
+
   async getWorksheet(sheetIndex: number): Promise<Worksheet> {
     if (this.sheetCache.has(sheetIndex)) {
       return this.sheetCache.get(sheetIndex)!;


### PR DESCRIPTION
## Sheet tab color (`<sheetPr><tabColor>`, ECMA-376 §18.3.1.93)

The tab color was already parsed per-worksheet but only reached the viewer once a sheet was loaded — too late for the tab strip, which is built from the workbook-level sheet list. Surface it on `SheetMeta` by probing each worksheet's head (sheetPr is the first child, so a bounded 16 KiB read avoids inflating `<sheetData>`); refactor `parse_color` into a shared `resolve_color_attrs` so the head probe resolves rgb / theme+tint / indexed identically to cell colors. The viewer paints it as a color bar along each tab's bottom edge (inset box-shadow) — the "bottom bar only" treatment.

## Zoom slider

Excel-style zoom control pinned to the right end of the sheet-tab bar: `−  [slider]  +  NNN%`.

- Gray status-bar look (custom `::-webkit-slider-*` / `::-moz-range-*`: uniform gray track, round gray handle — no colored fill).
- **100% sits at the slider's center** via a piecewise-linear position→scale map (10%→100% on the left half, 100%→400% on the right), mirroring Excel's asymmetric range.
- Range 10%–400% (matching Excel). Live-updates `cellScale` and re-lays-out the sheet, keeping slider, percentage label and the row-header-aligned tab-nav width in sync.
- Gated by the new `showZoomSlider` option (default on); `zoomMin` / `zoomMax` configurable.

## Verification

- Tab colors resolve through the existing theme/tint path (sample-1: accent2 #9F2121, accent1 #5C7D21, accent3 #D8BC56).
- Slider mapping verified: pos 0→10%, 25→55%, **50→100%**, 75→250%, 100→400%.
- Rust unit tests (4) pass; xlsx typecheck + build pass.
- Canvas rendering unchanged — xlsx VRT diffs are identical with the parser change reverted (the 2 over-threshold demo sheets are pre-existing Excel-fidelity gaps, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)