### PR TITLE
chore(release): 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.43.0 — 2026-06-03
+
+Adds Excel-style sheet-tab colors and a zoom slider to the xlsx viewer, plus a
+PowerPoint chart-axis fidelity fix verified against the PDF exports of the test
+decks.
+
+### xlsx
+
+- **Sheet tab colors**: `<sheetPr><tabColor>` (ECMA-376 §18.3.1.93; theme +
+  tint / indexed / rgb) now renders as a color bar along each sheet tab's bottom
+  edge. The color is surfaced on the workbook sheet list via a bounded
+  worksheet-head read (`<sheetPr>` is the first child, so `<sheetData>` is never
+  inflated), so every tab paints up front without eagerly parsing each sheet
+  (#315).
+- **Zoom slider**: an Excel-style zoom control pinned to the right end of the
+  sheet-tab bar (10%–400%, with 100% at the slider's center via a
+  piecewise-linear position→scale map). Gated by the new `showZoomSlider`
+  viewer option (default on); `zoomMin` / `zoomMax` are configurable (#315).
+
+### pptx
+
+- **Chart axes**: horizontal bar charts now draw the category-axis line
+  PowerPoint renders. The left rule was previously misattributed to the value
+  axis — in a bar chart the category axis is the vertical/left one — so a chart
+  whose value axis is `<c:delete val="1">` (sample-2 slide-16) drew no axis line
+  at all. Axis tick labels now honor the file's `<c:txPr>` text color and
+  `<c:spPr><a:ln>` line color (ECMA-376 §21.2.2.*) instead of a hardcoded gray,
+  resolved through the lumMod/lumOff path (tx1 15%/85% → ~#D9D9D9, bg1 75% →
+  #BFBFBF); this also fixes slide-7's column charts (#314).
+
 ## 0.42.0 — 2026-06-03
 
 Rendering-fidelity release, verified against the Word / PowerPoint / Excel PDF

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | Category | Feature | Status |
 |----------|---------|--------|
 | **Workbook** | Multiple sheets, sheet names | ✅ |
+| | Sheet tab colors (`<sheetPr><tabColor>` — theme / tint / indexed / rgb) | ✅ |
 | **Cells** | Text, number, boolean, error values | ✅ |
 | | Formula results (from cached `<v>`) | ✅ |
 | | Dates (ECMA-376 date format codes) | ✅ |
@@ -433,6 +434,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Shift+click to extend, Ctrl+C to copy as TSV | ✅ |
 | | Text selection inside cells (transparent overlay) | ✅ |
 | | `onSelectionChange` callback, `getCellAt(x, y)` API | ✅ |
+| | Zoom slider (Excel-style, right of the tab bar, 10–400% with 100% centered; `showZoomSlider` option) | ✅ |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.43.0.

## Highlights

### xlsx
- **Sheet tab colors** — `<sheetPr><tabColor>` (theme / tint / indexed / rgb) renders as a color bar along each sheet tab's bottom edge, surfaced on the workbook sheet list via a bounded worksheet-head read ([#315](https://github.com/yukiyokotani/office-open-xml-viewer/pull/315)).
- **Zoom slider** — Excel-style zoom control at the right end of the tab bar, 10%–400% with 100% centered; `showZoomSlider` option (default on) ([#315](https://github.com/yukiyokotani/office-open-xml-viewer/pull/315)).

### pptx
- **Chart axes** — horizontal bar charts draw the category-axis line PowerPoint renders, and axis tick labels honor the file's `<c:txPr>` text color / `<c:spPr><a:ln>` line color instead of a hardcoded gray ([#314](https://github.com/yukiyokotani/office-open-xml-viewer/pull/314)).

## Release chores
- CHANGELOG `0.43.0` section.
- README Feature Support: +2 xlsx rows (sheet tab colors, zoom slider).
- All 8 packages bumped 0.42.0 → 0.43.0.

Screenshots intentionally not refreshed this release — the visible changes (tab colors / zoom slider at the bottom tab bar) don't appear in the current README crops, and the demo sample has no tab colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)