### PR TITLE
feat(site): favicon + social meta tags

### DIFF
--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="@silurus/ooxml">
+  <rect width="64" height="64" rx="14" fill="#0b0e14"/>
+  <rect x="16" y="14" width="8" height="36" rx="3" fill="#2b7cff"/>
+  <rect x="28" y="14" width="8" height="36" rx="3" fill="#22c55e"/>
+  <rect x="40" y="14" width="8" height="36" rx="3" fill="#f97316"/>
+</svg>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -10,6 +10,13 @@ const base = import.meta.env.BASE_URL;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`.replace(/([^:])\/\/+/g, '$1/')} />
+    <link rel="apple-touch-icon" href={`${base}icon.png`.replace(/([^:])\/\/+/g, '$1/')} />
+    <meta name="theme-color" content="#07090e" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={`${base}icon.png`.replace(/([^:])\/\/+/g, '$1/')} />
+    <meta name="twitter:card" content="summary" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
The showcase site had no favicon (browsers were 404ing on `/favicon.ico`).

- Adds a lightweight brand-mark **SVG favicon** — the docx/xlsx/pptx tri-colour bars on a dark rounded square, matching the nav mark.
- `apple-touch-icon` + `og:image` reuse the project `icon.png`.
- Adds `theme-color` and OpenGraph/Twitter meta to `Base.astro`, inherited by every page.

Verified: `/favicon.svg` serves `image/svg+xml` (200) and is linked in `<head>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)