### PR TITLE
fix(site): remove demo text overlay that left a large gap below the page

### DIFF
--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -34,14 +34,19 @@ type ViewerCtl = {
 };
 
 function makeViewer(format: Format, canvas: HTMLCanvasElement, width: number): ViewerCtl {
+  // NB: no enableTextSelection here. The demo canvases are downscaled with CSS
+  // (.demo-page width:100%/height:auto) to fit the card, but the viewer's text
+  // overlay is sized to the un-scaled page — leaving it on would inflate the
+  // scroll area and add a big empty gap below the page. Text selection is shown
+  // in the API reference instead.
   if (format === 'pptx') {
-    const v = new PptxViewer(canvas, { width, useGoogleFonts: true, enableTextSelection: true });
+    const v = new PptxViewer(canvas, { width, useGoogleFonts: true });
     return {
       load: (u) => v.load(u), go: (i) => v.goToSlide(i), next: () => v.nextSlide(),
       prev: () => v.prevSlide(), index: () => v.slideIndex, count: () => v.slideCount,
     };
   }
-  const v = new DocxViewer(canvas, { width, dpr: DPR(), useGoogleFonts: true, enableTextSelection: true });
+  const v = new DocxViewer(canvas, { width, dpr: DPR(), useGoogleFonts: true });
   return {
     load: (u) => v.load(u), go: (i) => v.goToPage(i), next: () => v.nextPage(),
     prev: () => v.prevPage(), index: () => v.currentPage, count: () => v.pageCount,


### PR DESCRIPTION
On the detail pages, the **Single viewer** (and Master-detail) demos showed a large empty backdrop below the rendered page.

**Cause:** the demo canvases are downscaled with CSS (`.demo-page { width:100%; height:auto }`) to fit the card, but the built-in viewer's `enableTextSelection` overlay is sized to the *un-scaled* page (e.g. 1357px tall for a 960px-wide page). That inflated the stage scroll area to ~1380px while the visible page was only ~578px — leaving ~800px of empty backdrop below it.

**Fix:** drop `enableTextSelection` from the demo viewers (`makeViewer` in `demos.ts`). The demos are about navigation; text selection remains documented in each page's API reference. Verified: stage scrollHeight dropped from 1380 → 600 (page height + padding), overlay child gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)