### PR TITLE
fix(site): symmetric top/bottom margin in single-viewer demo

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -231,7 +231,10 @@ h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
 .demo-status { font-family: var(--mono); font-size: 13px; color: var(--text-dim); padding: 36px; text-align: center; }
 
 /* single-viewer demo */
-.demo-stage { padding: 22px; display: flex; justify-content: center; max-height: 560px; overflow: auto; }
+/* Block (not flex) scroll container + text-align centres the viewer's
+ * inline-block wrapper, and keeps the top/bottom padding symmetric — a flex
+ * scroll container drops the padding-bottom from the scroll area. */
+.demo-stage { padding: 22px; max-height: 560px; overflow: auto; text-align: center; }
 .demo-stage .demo-page { width: 100%; max-width: 760px; height: auto; }
 
 /* scroll demo */


### PR DESCRIPTION
The single-viewer demo stage used a flex scroll container, which drops `padding-bottom` from the scroll area — the page had a 22px top margin but 0 at the bottom. Switched to a block scroll container with `text-align:center` (centres the viewer's inline-block wrapper). Verified: scrollHeight 1119 = 22 + 1075 (page) + 22, equal top/bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)