### PR TITLE
fix(math): CDN-load MathJax v4 (drop mathjax-full) + tight overline bars

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,8 +28,5 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "typescript": "^6.0.2"
-  },
-  "dependencies": {
-    "mathjax-full": "^3.2.2"
   }
 }

--- a/packages/core/src/math/index.ts
+++ b/packages/core/src/math/index.ts
@@ -4,5 +4,6 @@ export {
   mathMLToSvg,
   svgExtents,
   recolorSvg,
+  setMathJaxUrl,
   type MathSvg,
 } from './mathjax';

--- a/packages/core/src/math/mathjax.test.ts
+++ b/packages/core/src/math/mathjax.test.ts
@@ -1,39 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { mathMLToSvg, svgExtents, recolorSvg } from './mathjax';
-import { mathToMathML } from './mathml';
-import type { MathNode } from '../types/math';
+import { svgExtents, recolorSvg } from './mathjax';
 
-describe('mathMLToSvg (MathJax)', () => {
-  it('renders a fraction with a radical to SVG with positive extents', async () => {
-    const nodes: MathNode[] = [
-      { kind: 'run', text: 'x', style: 'italic' },
-      { kind: 'run', text: '=', style: 'roman' },
-      {
-        kind: 'fraction',
-        num: [
-          { kind: 'run', text: '-b', style: 'italic' },
-          { kind: 'radical', radicand: [{ kind: 'run', text: 'c', style: 'italic' }] },
-        ],
-        den: [{ kind: 'run', text: '2a', style: 'italic' }],
-      },
-    ];
-    const out = await mathMLToSvg(mathToMathML(nodes, true));
-    expect(out.svg).toContain('<svg');
-    expect(out.svg).toContain('<path'); // inlined glyph outlines
-    expect(out.widthEm).toBeGreaterThan(0);
-    expect(out.ascentEm).toBeGreaterThan(0);
-    expect(out.descentEm).toBeGreaterThan(0);
-  }, 20000);
+// mathMLToSvg loads MathJax from a CDN and needs a DOM, so it is exercised in the
+// browser (Storybook / VRT), not here. These cover the pure helpers.
 
-  it('svgExtents parses the viewBox', () => {
-    const svg = '<svg viewBox="0 -1642.5 9178 2338.5"></svg>';
-    const e = svgExtents(svg);
+describe('svgExtents', () => {
+  it('parses the viewBox into baseline-relative em extents', () => {
+    const e = svgExtents('<svg viewBox="0 -1642.5 9178 2338.5"></svg>');
     expect(e.widthEm).toBeCloseTo(9.178, 3);
     expect(e.ascentEm).toBeCloseTo(1.6425, 3);
     expect(e.descentEm).toBeCloseTo(0.696, 3);
   });
 
-  it('recolorSvg replaces currentColor', () => {
-    expect(recolorSvg('fill="currentColor"', '#f00')).toBe('fill="#f00"');
+  it('returns zeros when no viewBox is present', () => {
+    expect(svgExtents('<svg></svg>')).toEqual({ widthEm: 0, ascentEm: 0, descentEm: 0 });
+  });
+});
+
+describe('recolorSvg', () => {
+  it('replaces currentColor', () => {
+    expect(recolorSvg('fill="currentColor" stroke="currentColor"', '#f00')).toBe(
+      'fill="#f00" stroke="#f00"',
+    );
   });
 });

--- a/packages/core/src/math/mathjax.ts
+++ b/packages/core/src/math/mathjax.ts
@@ -1,43 +1,60 @@
-// MathJax (DOM-free, via liteAdaptor) turns MathML into an SVG string. The SVG is
-// rasterized to the canvas by the consumer. MathJax is loaded lazily so it only ships
-// to pages that actually render equations.
+// MathJax turns MathML into an SVG string that the consumer rasterizes onto the canvas.
+//
+// MathJax is loaded lazily AT RUNTIME from a CDN (no npm dependency) so that:
+//   1. bundlers in consuming apps have no bare `mathjax-*` import to resolve, and
+//   2. we use maintained MathJax v4 rather than the frozen/superseded `mathjax-full` v3.
+// Browser-only (it needs a DOM); the load is triggered only when a document actually
+// contains equations. The URL is overridable for self-hosting / offline.
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-interface MathJaxInstance {
-  adaptor: any;
-  doc: any;
+
+let mathJaxUrl = 'https://cdn.jsdelivr.net/npm/mathjax@4/mml-svg.js';
+let mjPromise: Promise<any> | null = null;
+
+/** Override the MathJax script URL (e.g. a self-hosted / pinned copy). Call before load. */
+export function setMathJaxUrl(url: string): void {
+  mathJaxUrl = url;
 }
 
-let mjPromise: Promise<MathJaxInstance> | null = null;
+function loadScript(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.async = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error(`Failed to load MathJax from ${src}`));
+    document.head.appendChild(s);
+  });
+}
 
-async function getMathJax(): Promise<MathJaxInstance> {
-  if (!mjPromise) {
-    mjPromise = (async () => {
-      const [{ mathjax }, { MathML }, { SVG }, { liteAdaptor }, { RegisterHTMLHandler }] =
-        await Promise.all([
-          import('mathjax-full/js/mathjax.js'),
-          import('mathjax-full/js/input/mathml.js'),
-          import('mathjax-full/js/output/svg.js'),
-          import('mathjax-full/js/adaptors/liteAdaptor.js'),
-          import('mathjax-full/js/handlers/html.js'),
-        ]);
-      const adaptor = liteAdaptor();
-      RegisterHTMLHandler(adaptor);
-      // fontCache: 'none' inlines glyph outlines as <path> (no <use>/<defs>), which
-      // keeps each SVG self-contained and rasterizable as a standalone image.
-      const doc = mathjax.document('', {
-        InputJax: new MathML(),
-        OutputJax: new SVG({ fontCache: 'none' }),
-      });
-      return { adaptor, doc };
-    })();
-  }
+async function ensureMathJax(): Promise<any> {
+  if (mjPromise) return mjPromise;
+  mjPromise = (async () => {
+    const w = globalThis as any;
+    if (w.MathJax?.startup?.promise) {
+      await w.MathJax.startup.promise;
+      return w.MathJax;
+    }
+    if (typeof document === 'undefined') {
+      throw new Error('MathJax rendering requires a DOM (browser environment)');
+    }
+    // Configure before the component script runs: don't auto-typeset the page, and
+    // inline glyph outlines (fontCache:'none') so each SVG is self-contained.
+    w.MathJax = {
+      ...(w.MathJax || {}),
+      startup: { ...(w.MathJax?.startup || {}), typeset: false },
+      svg: { ...(w.MathJax?.svg || {}), fontCache: 'none' },
+    };
+    await loadScript(mathJaxUrl);
+    await w.MathJax.startup.promise;
+    return w.MathJax;
+  })();
   return mjPromise;
 }
 
 /** Preload MathJax. Call once before rendering equations. */
 export async function loadMathJax(): Promise<void> {
-  await getMathJax();
+  await ensureMathJax();
 }
 
 export interface MathSvg {
@@ -69,10 +86,11 @@ export function svgExtents(svg: string): { widthEm: number; ascentEm: number; de
 
 /** Convert a MathML string to an SVG + its baseline-relative extents. */
 export async function mathMLToSvg(mathml: string): Promise<MathSvg> {
-  const { adaptor, doc } = await getMathJax();
-  const container = doc.convert(mathml, { display: true });
-  const svgNode = adaptor.firstChild(container);
-  const svg: string = adaptor.outerHTML(svgNode);
+  const MathJax = await ensureMathJax();
+  const container = MathJax.mathml2svg(mathml, { display: true });
+  const svgEl: Element | null =
+    typeof container.querySelector === 'function' ? container.querySelector('svg') : null;
+  const svg: string = svgEl ? svgEl.outerHTML : MathJax.startup.adaptor.outerHTML(container);
   return { svg, ...svgExtents(svg) };
 }
 

--- a/packages/core/src/math/mathml.ts
+++ b/packages/core/src/math/mathml.ts
@@ -102,18 +102,44 @@ function nodeToMathML(node: MathNode): string {
       return node.pos === 'top' ? `<mover>${b}${mo}</mover>` : `<munder>${b}${mo}</munder>`;
     }
     case 'bar': {
-      // A tight stretchy bar hugging the base (overline / underline), not a padded box.
+      // Tight stretchy overline/underline (like \overline). NOTE: accent="true" adds a
+      // gap above the base in MathJax, so we omit it — the stretchy bar hugs the base.
       const b = row(node.base);
       const barOp = '<mo stretchy="true">&#x00AF;</mo>';
-      return node.pos === 'bot'
-        ? `<munder accent="true">${b}${barOp}</munder>`
-        : `<mover accent="true">${b}${barOp}</mover>`;
+      return node.pos === 'bot' ? `<munder>${b}${barOp}</munder>` : `<mover>${b}${barOp}</mover>`;
     }
     case 'accent':
-      return `<mover accent="true">${row(node.base)}<mo stretchy="false">${esc(node.char)}</mo></mover>`;
+      return accentToMathML(node);
     case 'func':
       return `<mrow>${row(node.name)}<mo>&#x2061;</mo>${row(node.arg)}</mrow>`;
   }
+}
+
+// Map an OMML accent character to a MathJax-friendly accent. Combining marks (zero
+// advance) float when used as <mo> content, so we translate to spacing equivalents.
+const ACCENT_MAP: Record<string, string> = {
+  '̀': '`', // grave
+  '́': '´', // acute
+  '̂': '^', // circumflex / hat
+  '̃': '~', // tilde
+  '̆': '˘', // breve
+  '̇': '˙', // dot above
+  '̈': '¨', // diaeresis
+  '̌': 'ˇ', // caron
+  '⃗': '→', // vector arrow
+  '⃖': '←', // left arrow
+};
+// Overline / macron family → rendered as a tight stretchy bar (\overline), no accent gap.
+const OVERLINE_CHARS = new Set(['̅', '̄', '¯', '‾', '̲', '̳']);
+
+function accentToMathML(node: Extract<MathNode, { kind: 'accent' }>): string {
+  const b = row(node.base);
+  if (OVERLINE_CHARS.has(node.char)) {
+    return `<mover>${b}<mo stretchy="true">&#x00AF;</mo></mover>`;
+  }
+  const ch = ACCENT_MAP[node.char] ?? node.char;
+  const stretchy = ch === '→' || ch === '←' ? 'true' : 'false';
+  return `<mover accent="true">${b}<mo stretchy="${stretchy}">${esc(ch)}</mo></mover>`;
 }
 
 function limitToMathML(node: Extract<MathNode, { kind: 'limit' }>): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,10 +43,6 @@ importers:
         version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
 
   packages/core:
-    dependencies:
-      mathjax-full:
-        specifier: ^3.2.2
-        version: 3.2.2
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -1714,10 +1710,6 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
-
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
@@ -2025,10 +2017,6 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
-
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
@@ -2268,10 +2256,6 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-
-  esm@3.2.25:
-    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
-    engines: {node: '>=6'}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -2821,10 +2805,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mathjax-full@3.2.2:
-    resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
-    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
-
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
 
@@ -2876,9 +2856,6 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  mhchemparser@4.2.1:
-    resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3018,9 +2995,6 @@ packages:
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
-
-  mj-context-menu@0.6.1:
-    resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -3555,10 +3529,6 @@ packages:
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
-
-  speech-rule-engine@4.1.4:
-    resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
-    hasBin: true
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -4113,9 +4083,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wicked-good-xpath@1.3.0:
-    resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
@@ -5572,8 +5539,6 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@xmldom/xmldom@0.9.10': {}
-
   abbrev@1.1.1: {}
 
   acorn@8.16.0: {}
@@ -5945,8 +5910,6 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@13.1.0: {}
-
   common-ancestor-path@1.0.1: {}
 
   compare-versions@6.1.1: {}
@@ -6197,8 +6160,6 @@ snapshots:
       '@esbuild/win32-x64': 0.27.7
 
   escape-string-regexp@5.0.0: {}
-
-  esm@3.2.25: {}
 
   esprima@4.0.1: {}
 
@@ -6782,13 +6743,6 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mathjax-full@3.2.2:
-    dependencies:
-      esm: 3.2.25
-      mhchemparser: 4.2.1
-      mj-context-menu: 0.6.1
-      speech-rule-engine: 4.1.4
-
   mdast-util-definitions@6.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6916,8 +6870,6 @@ snapshots:
   mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
-
-  mhchemparser@4.2.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -7154,8 +7106,6 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
-
-  mj-context-menu@0.6.1: {}
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -7833,12 +7783,6 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  speech-rule-engine@4.1.4:
-    dependencies:
-      '@xmldom/xmldom': 0.9.10
-      commander: 13.1.0
-      wicked-good-xpath: 1.3.0
-
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
@@ -8312,8 +8256,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wicked-good-xpath@1.3.0: {}
 
   wide-align@1.1.5:
     dependencies:


### PR DESCRIPTION
## Why
- The showcase site failed to build: `Failed to resolve import "mathjax-full/js/mathjax.js"`. `mathjax-full` is frozen at v3 (superseded by `@mathjax/src` in v4) and its bare dynamic import isn't resolvable in consumer bundlers.
- The mean x̄ bar floated far above the letter.

## Changes
- **Drop the `mathjax-full` npm dependency.** Load maintained **MathJax v4** (`mml-svg`) from a CDN via runtime `<script>` injection — no bare import for bundlers to resolve, lazy (only when a doc has equations), URL overridable via `setMathJaxUrl()` for self-hosting/offline. Browser-only (node math is a separate follow-up).
- **Tight overline for `m:bar` / overline `m:acc`.** MathJax `accent="true"` adds a gap, and combining marks (U+0305 …) float as `<mo>` content. Render overline/macron accents as a tight stretchy `\overline`; map other combining accents (hat/tilde/dot/vec) to spacing equivalents. Verified against MathJax v4 output.

Unblocks the site build and fixes x̄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)