### PR TITLE
fix(docx): TOC page numbers flush right (indent double-scale)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -974,7 +974,7 @@ function renderParagraph(
     pageH: state.pageH,
   } : undefined;
 
-  const lines = layoutLines(ctx, segments, paraW, firstLineX - paraX, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft * scale);
+  const lines = layoutLines(ctx, segments, paraW, firstLineX - paraX, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft);
 
   // For paragraphs that carry any ruby annotation, Word renders every line
   // at the SAME height. Per the user's note: when the section's docGrid is


### PR DESCRIPTION
Follow-up to #320. The render call double-scaled the paragraph indent when offsetting tab stops, leaving a ~2.5px-per-level residual so TOC page numbers didn't line up. Pass indLeft (already px) directly. Measured right-edge spread across all TOC entries is now 0px (verified by pixel analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)