### PR TITLE
fix(docx): gap between TOC dot leader and page number

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1903,7 +1903,9 @@ function drawTabLeader(
     // Dots sit on a loose grid; other leaders are drawn solid.
     const step = leader === 'dot' || leader === 'middleDot' ? chW * 1.5 : chW;
     const margin = chW * 0.5;
-    const end = x + width - margin;
+    // Leave a clear gap (about one dot-step) before the page number so the
+    // leader doesn't run right up against it.
+    const end = x + width - step - margin;
     for (let cx = x + margin; cx <= end; cx += step) {
       ctx.fillText(ch, cx, baseline);
     }


### PR DESCRIPTION
The dot leader ran flush against the page number; leave ~one dot-step gap before it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)