### PR TITLE
chore(release): 0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.44.0 — 2026-06-04
+
+Adds OOXML math (OMML) rendering to the docx viewer via bundled MathJax, plus
+table-style fidelity (shading / banding / borders / alignment) and table-of-
+contents rendering (dot leaders, right-aligned page numbers). Verified against
+the Word PDF export of the test document.
+
+### docx
+
+- **Math equations (OMML)**: `m:oMath` / `m:oMathPara` are extracted in the Rust
+  parser into a shared AST (fractions, sub/superscripts, n-ary with correct
+  limit placement, radicals, delimiters, matrices / `eqArr`, `limLow` / `limUpp`,
+  group chars, bars, accents) and rendered via **MathJax** — converted to MathML,
+  then SVG, then rasterized onto the canvas. MathJax (Apache-2.0) is **bundled and
+  loaded same-origin** (no cross-origin request); `setMathJaxUrl` overrides the
+  source. Equations size to the surrounding text and center as display math.
+- **Table styles**: resolve `w:style type="table"` cell shading, borders, and
+  conditional formatting (`tblStylePr` firstRow / band1Horz / band2Horz),
+  honoring each row's `w:cnfStyle` bitmask (§17.4.7) — so banded tables paint
+  correctly. Table `w:jc` centering and display-equation cell centering added.
+- **Table of contents**: tab **leaders** (dot / hyphen / underscore, §17.3.1.37)
+  and **right / center / decimal tab stops** (measured from the text margin), so
+  TOC entries render `heading … page` on one line with flush right-aligned page
+  numbers. Complex multi-paragraph fields (TOC) now render their result content
+  (only PAGE / NUMPAGES are recomputed), fixing a dropped first entry.
+- Internal-document links (TOC entries, cross-references) render as plain body
+  text instead of the Hyperlink style's blue / underline, matching Word; external
+  URL links stay blue + underlined.
+
 ## 0.43.0 — 2026-06-03
 
 Adds Excel-style sheet-tab colors and a zoom slider to the xlsx viewer, plus a

--- a/README.md
+++ b/README.md
@@ -381,10 +381,14 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Lists (bullet and numbered) | ✅ |
 | | Paragraph styles (Heading 1–9, Normal, custom) | ✅ |
 | | Table style `w:pPr` cascade (§17.7.6) | ✅ |
+| | Table style borders / shading / banding (`tblStylePr`, `cnfStyle`, §17.4.7) | ✅ |
+| | Table of contents (TOC field) — dot leaders, right-aligned page numbers | ✅ |
 | | keepNext / keepLines / widowControl | ✅ |
-| **Elements** | Tables (with borders, fills, merges) | ✅ |
+| **Elements** | Tables (with borders, fills, merges, banding, alignment) | ✅ |
+| | Math equations (OMML `m:oMath` / `m:oMathPara`, rendered via MathJax) | ✅ |
 | | Images (inline and anchored, with text wrap) | ✅ |
 | | Text boxes / drawing shapes | ✅ |
+| | WMF / EMF metafile images (legacy vector) | ❌ Not planned |
 | **Advanced** | Footnote / endnote reference markers | ✅ |
 | | Track changes (`w:ins` / `w:del` — author-coloured underline / strikethrough) | ✅ |
 | | Comments / footnote bodies (parsed, not yet rendered inline) | ⚠️ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",
@@ -27,7 +27,10 @@
     "./wasm": "./src/wasm/docx_parser.js",
     "./wasm-binary": "./src/wasm/docx_parser_bg.wasm"
   },
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc --build && vite build",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",
@@ -38,7 +38,9 @@
     "skia-canvas": "^2.0.0"
   },
   "peerDependenciesMeta": {
-    "skia-canvas": { "optional": true }
+    "skia-canvas": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",
@@ -27,7 +27,10 @@
     "./wasm": "./src/wasm/pptx_parser.js",
     "./wasm-binary": "./src/wasm/pptx_parser_bg.wasm"
   },
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc --build && vite build",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",
@@ -36,7 +36,9 @@
         "viewType": "ooxmlViewer.docxEditor",
         "displayName": "OOXML Viewer (DOCX)",
         "selector": [
-          { "filenamePattern": "*.docx" }
+          {
+            "filenamePattern": "*.docx"
+          }
         ],
         "priority": "default"
       },
@@ -44,7 +46,9 @@
         "viewType": "ooxmlViewer.xlsxEditor",
         "displayName": "OOXML Viewer (XLSX)",
         "selector": [
-          { "filenamePattern": "*.xlsx" }
+          {
+            "filenamePattern": "*.xlsx"
+          }
         ],
         "priority": "default"
       },
@@ -52,7 +56,9 @@
         "viewType": "ooxmlViewer.pptxEditor",
         "displayName": "OOXML Viewer (PPTX)",
         "selector": [
-          { "filenamePattern": "*.pptx" }
+          {
+            "filenamePattern": "*.pptx"
+          }
         ],
         "priority": "default"
       }
@@ -85,7 +91,11 @@
       "properties": {
         "ooxmlViewer.mcpServer.enabled": {
           "type": "string",
-          "enum": ["auto", "always", "never"],
+          "enum": [
+            "auto",
+            "always",
+            "never"
+          ],
           "enumDescriptions": [
             "Offer to enable when the workspace contains .xlsx / .docx / .pptx files.",
             "Always register the MCP server (downloading the binary on first use).",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",
@@ -27,7 +27,10 @@
     "./wasm": "./src/wasm/xlsx_parser.js",
     "./wasm-binary": "./src/wasm/xlsx_parser_bg.wasm"
   },
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",


### PR DESCRIPTION
Release 0.44.0.

## Highlights
- **docx math (OMML)** rendered via bundled MathJax (same-origin, no cross-origin request).
- **Table styles**: shading / banding / borders / `w:jc` centering, honoring `cnfStyle` (§17.4.7).
- **Table of contents**: dot leaders + right/center/decimal tab stops; flush right-aligned page numbers; complex-field results rendered (fixes dropped first entry).
- Internal links (TOC/cross-refs) render as body text; external links stay blue.

CHANGELOG + README feature table updated. 8 package.json bumped 0.43.0 → 0.44.0. WMF/EMF metafile images documented as not planned (legacy vector).

Screenshots: unchanged — the math sample is private/non-redistributable, and pptx/xlsx are visually unchanged this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)