### PR TITLE
refactor: v1.0 API/design consistency pass

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -6,6 +6,7 @@
 import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
 import { niceStep, niceAxisMax, niceAxisMin } from './axis-scale.js';
 import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
+import { EMU_PER_PT, PT_TO_PX } from '../units.js';
 
 // ─── Palette + helpers ──────────────────────────────────────────────────────
 
@@ -488,8 +489,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // default (gridlines stand in), so only draw it when the file specifies one.
   const catLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#aaa';
   const valLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#aaa';
-  const catLineW = chart.catAxisLineWidthEmu ? Math.max(0.5, chart.catAxisLineWidthEmu / 12700) : 1;
-  const valLineW = chart.valAxisLineWidthEmu ? Math.max(0.5, chart.valAxisLineWidthEmu / 12700) : 1;
+  const catLineW = chart.catAxisLineWidthEmu ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) : 1;
+  const valLineW = chart.valAxisLineWidthEmu ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) : 1;
   const strokeAxis = (x1: number, y1: number, x2: number, y2: number, color: string, lw: number): void => {
     ctx.strokeStyle = color; ctx.lineWidth = lw;
     ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
@@ -1307,7 +1308,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
       const yAxisLineWidth = chart.valAxisLineWidthEmu
-        ? Math.max(0.5, chart.valAxisLineWidthEmu / 12700) : undefined;
+        ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) : undefined;
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, yAxisLineColor, yAxisLineWidth);
     }
   }
@@ -1343,7 +1344,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.save();
     ctx.strokeStyle = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#888';
     ctx.lineWidth = chart.catAxisLineWidthEmu
-      ? Math.max(0.5, chart.catAxisLineWidthEmu / 12700)
+      ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT)
       : 1;
     ctx.lineCap = 'butt';
     ctx.beginPath(); ctx.moveTo(px0, xAxisY); ctx.lineTo(px0 + pw, xAxisY); ctx.stroke();
@@ -1353,7 +1354,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.save();
     ctx.strokeStyle = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#888';
     ctx.lineWidth = chart.valAxisLineWidthEmu
-      ? Math.max(0.5, chart.valAxisLineWidthEmu / 12700)
+      ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT)
       : 1;
     ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
     ctx.restore();
@@ -1378,7 +1379,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode), gx, xAxisY + 4);
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
       const xAxisLineWidth = chart.catAxisLineWidthEmu
-        ? Math.max(0.5, chart.catAxisLineWidthEmu / 12700) : undefined;
+        ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) : undefined;
       drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, xAxisLineWidth);
     }
   }
@@ -1620,7 +1621,7 @@ function drawSeriesErrorBars(
 ): void {
   ctx.save();
   ctx.strokeStyle = eb.color ? `#${eb.color}` : fallbackColor;
-  ctx.lineWidth = eb.lineWidthEmu ? Math.max(0.5, eb.lineWidthEmu / 12700) : 1;
+  ctx.lineWidth = eb.lineWidthEmu ? Math.max(0.5, eb.lineWidthEmu / EMU_PER_PT) : 1;
   ctx.setLineDash(dashPatternForPreset(eb.dash));
   const drawPlus = eb.barType === 'plus' || eb.barType === 'both';
   const drawMinus = eb.barType === 'minus' || eb.barType === 'both';
@@ -1998,7 +1999,7 @@ export function renderChart(
    * device-px where 1pt≈1.333. Used to size title/axis labels whose
    * XML-specified sizes are in OOXML hundredths of a point.
    */
-  ptToPx: number = 1.333,
+  ptToPx: number = PT_TO_PX,
 ): void {
   const { x, y, w, h } = rect;
   // Only fill the outer chartSpace when chartBg is set; a null means noFill

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,40 @@
-export * from './types/common';
-export * from './types/chart';
+export type {
+  ArrowEnd,
+  Bullet,
+  Fill,
+  Glow,
+  GradientFill,
+  GradientStop,
+  LineBreak,
+  NoFill,
+  Paragraph,
+  PathCmd,
+  PatternFill,
+  Reflection,
+  RenderOptions,
+  Shadow,
+  SoftEdge,
+  SolidFill,
+  SpaceLine,
+  Stroke,
+  TabStop,
+  TextBody,
+  TextOutline,
+  TextRun,
+  TextRunData,
+} from './types/common';
+export type {
+  ChartDataLabelOverride,
+  ChartDataPointOverride,
+  ChartErrBars,
+  ChartManualLayout,
+  ChartModel,
+  ChartRect,
+  ChartSeries,
+  ChartSeriesDataLabels,
+  ChartType,
+  LegendManualLayout,
+} from './types/chart';
 export type { LoadOptions } from './types/load-options';
 export { preloadGoogleFonts, type FontPreloadEntry } from './fonts/preload';
 export { renderChart } from './chart/renderer';
@@ -13,7 +48,15 @@ export {
   type SparklineModel,
   type SparklineRect,
 } from './sparkline/renderer';
-export * from './math';
+export {
+  mathToMathML,
+  loadMathJax,
+  mathMLToSvg,
+  svgExtents,
+  recolorSvg,
+  setMathJaxUrl,
+  type MathSvg,
+} from './math';
 export type { MathNode, MathFormula, MathStyle } from './types/math';
 export { EMU_PER_INCH, EMU_PER_PT, EMU_PER_PX, PT_TO_PX } from './units';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './sparkline/renderer';
 export * from './math';
 export type { MathNode, MathFormula, MathStyle } from './types/math';
+export { EMU_PER_INCH, EMU_PER_PT, EMU_PER_PX, PT_TO_PX } from './units';
 export {
   WorkerBridge,
   type WorkerLike,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,3 +15,9 @@ export {
 } from './sparkline/renderer';
 export * from './math';
 export type { MathNode, MathFormula, MathStyle } from './types/math';
+export {
+  WorkerBridge,
+  type WorkerLike,
+  type WorkerBridgeOptions,
+  decodeDataUrl,
+} from './worker';

--- a/packages/core/src/sparkline/renderer.ts
+++ b/packages/core/src/sparkline/renderer.ts
@@ -3,6 +3,8 @@
 // or title. Theme colors are expected to be flattened to `#RRGGBB` strings
 // at parse time so this module has zero theme awareness.
 
+import { PT_TO_PX } from '../units.js';
+
 export type SparklineKind = 'line' | 'column' | 'stem';
 
 /** Render-ready sparkline. The xlsx renderer flattens its parser output into
@@ -122,9 +124,8 @@ export function renderSparkline(
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
   // ECMA-376 lineWeight is in points; the canvas is already scaled, so
-  // 1 pt ≈ 1.333 px at 96 DPI. We multiply by ptToPx to keep visual weight
+  // 1 pt ≈ 1.333 px at 96 DPI. We multiply by PT_TO_PX to keep visual weight
   // consistent with PowerPoint / Excel.
-  const PT_TO_PX = 1.333;
   ctx.lineWidth = (model.lineWeight ?? 0.75) * PT_TO_PX;
   ctx.beginPath();
   let penDown = false;

--- a/packages/core/src/types/load-options.ts
+++ b/packages/core/src/types/load-options.ts
@@ -1,10 +1,11 @@
 /**
- * Common load-time options shared by the docx / pptx / xlsx viewer
- * `load(source, opts)` methods.
+ * Common load-time options shared by the docx / pptx / xlsx
+ * `Document.load` / `Presentation.load` / `Workbook.load` factories and their
+ * viewer wrappers.
  *
- * Each viewer narrows or extends this in its package-local `LoadOptions` if
- * needed, but the names that overlap (currently `useGoogleFonts`) keep the
- * same shape so application code can pass the same options object.
+ * This is the single source of truth — each package re-exports this exact type
+ * as its `LoadOptions` so application code can pass one options object to any
+ * of the three.
  */
 export interface LoadOptions {
   /**
@@ -18,4 +19,11 @@ export interface LoadOptions {
    * via `@font-face` in your application CSS.
    */
   useGoogleFonts?: boolean;
+  /**
+   * Override the per-entry ZIP decompression cap (bytes) used by the zip-bomb
+   * guard in the Rust parser. Defaults to 512 MiB. Raise it to load documents
+   * with very large embedded media, or lower it to tighten the budget for
+   * untrusted input. Zero / negative values fall back to the default.
+   */
+  maxZipEntryBytes?: number;
 }

--- a/packages/core/src/units.ts
+++ b/packages/core/src/units.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical OOXML / screen unit conversions, shared by all renderers.
+ *
+ * OOXML measures length in EMU (English Metric Units); typography uses points.
+ * Screen rendering targets CSS px at the reference 96 DPI. Centralizing these
+ * factors avoids the drift that comes from re-spelling them per file (e.g.
+ * `4 / 3` vs `96 / 72` vs the lossy literal `1.333`).
+ */
+
+/** EMU per inch (ECMA-376 definition). */
+export const EMU_PER_INCH = 914400;
+
+/** EMU per point: 914400 / 72. */
+export const EMU_PER_PT = 12700;
+
+/** EMU per CSS px at 96 DPI: 914400 / 96. */
+export const EMU_PER_PX = 9525;
+
+/** CSS px per point at 96 DPI: 96 / 72 = 4 / 3. */
+export const PT_TO_PX = 4 / 3;

--- a/packages/core/src/worker/bridge.test.ts
+++ b/packages/core/src/worker/bridge.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { WorkerBridge, type WorkerLike } from './bridge.js';
+
+/** Minimal in-memory Worker stand-in. Records posted messages and lets a test
+ *  deliver responses synchronously via {@link respond}. */
+class FakeWorker implements WorkerLike {
+  posted: unknown[] = [];
+  transfers: (Transferable[] | undefined)[] = [];
+  terminated = false;
+  private listeners = new Set<(e: MessageEvent) => void>();
+
+  postMessage(message: unknown, transfer?: Transferable[]): void {
+    this.posted.push(message);
+    this.transfers.push(transfer);
+  }
+  addEventListener(_type: 'message', listener: (e: MessageEvent) => void): void {
+    this.listeners.add(listener);
+  }
+  removeEventListener(_type: 'message', listener: (e: MessageEvent) => void): void {
+    this.listeners.delete(listener);
+  }
+  terminate(): void {
+    this.terminated = true;
+  }
+  /** Deliver a message to all listeners, like the worker posting back. */
+  respond(data: unknown): void {
+    for (const l of this.listeners) l({ data } as MessageEvent);
+  }
+}
+
+interface Res {
+  id?: number;
+  kind: 'ready' | 'ok' | 'error';
+  value?: string;
+  message?: string;
+}
+
+function makeBridge(worker: FakeWorker, onUnsolicited?: (r: Res) => void) {
+  return new WorkerBridge<Res>(worker, {
+    correlate: (r) => r.id,
+    toError: (r) => (r.kind === 'error' ? (r.message ?? 'error') : undefined),
+    onUnsolicited,
+  });
+}
+
+describe('WorkerBridge', () => {
+  it('correlates a response to its request by id', async () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    const p = bridge.request((id) => ({ kind: 'parse', id }));
+    const sentId = (w.posted[0] as { id: number }).id;
+    w.respond({ id: sentId, kind: 'ok', value: 'A' });
+    await expect(p).resolves.toMatchObject({ value: 'A' });
+  });
+
+  it('routes concurrent responses to the matching request, even out of order', async () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    const p1 = bridge.request((id) => ({ kind: 'parse', id }));
+    const p2 = bridge.request((id) => ({ kind: 'parse', id }));
+    const id1 = (w.posted[0] as { id: number }).id;
+    const id2 = (w.posted[1] as { id: number }).id;
+    expect(id1).not.toBe(id2);
+    // Respond to the second request first.
+    w.respond({ id: id2, kind: 'ok', value: 'second' });
+    w.respond({ id: id1, kind: 'ok', value: 'first' });
+    await expect(p1).resolves.toMatchObject({ value: 'first' });
+    await expect(p2).resolves.toMatchObject({ value: 'second' });
+  });
+
+  it('rejects only the matching request on an error response', async () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    const p1 = bridge.request((id) => ({ kind: 'parse', id }));
+    const p2 = bridge.request((id) => ({ kind: 'parse', id }));
+    const id1 = (w.posted[0] as { id: number }).id;
+    const id2 = (w.posted[1] as { id: number }).id;
+    w.respond({ id: id1, kind: 'error', message: 'boom' });
+    w.respond({ id: id2, kind: 'ok', value: 'fine' });
+    await expect(p1).rejects.toThrow('boom');
+    await expect(p2).resolves.toMatchObject({ value: 'fine' });
+  });
+
+  it('does not resolve or hang the wrong request when an unknown id arrives', async () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    const p = bridge.request((id) => ({ kind: 'parse', id }));
+    const id = (w.posted[0] as { id: number }).id;
+    w.respond({ id: 9999, kind: 'ok', value: 'stray' }); // unknown id: ignored
+    w.respond({ id, kind: 'ok', value: 'real' });
+    await expect(p).resolves.toMatchObject({ value: 'real' });
+  });
+
+  it('forwards unsolicited messages (no id) to onUnsolicited instead of a pending request', async () => {
+    const w = new FakeWorker();
+    const seen: Res[] = [];
+    const bridge = makeBridge(w, (r) => seen.push(r));
+    const p = bridge.request((id) => ({ kind: 'parse', id }));
+    w.respond({ kind: 'ready' }); // no id
+    const id = (w.posted[0] as { id: number }).id;
+    w.respond({ id, kind: 'ok', value: 'done' });
+    await expect(p).resolves.toMatchObject({ value: 'done' });
+    expect(seen).toEqual([{ kind: 'ready' }]);
+  });
+
+  it('rejects all pending requests when terminated', async () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    const p = bridge.request((id) => ({ kind: 'parse', id }));
+    bridge.terminate();
+    expect(w.terminated).toBe(true);
+    await expect(p).rejects.toThrow(/terminated/i);
+  });
+
+  it('passes the transfer list through to postMessage', () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    const buf = new ArrayBuffer(8);
+    bridge.request((id) => ({ kind: 'parse', id, buffer: buf }), [buf]);
+    expect(w.transfers[0]).toEqual([buf]);
+  });
+
+  it('post() sends a fire-and-forget message without allocating an id', () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    bridge.post({ kind: 'init', wasmUrl: 'x' });
+    expect(w.posted[0]).toEqual({ kind: 'init', wasmUrl: 'x' });
+    // The next request should still start from id 1.
+    bridge.request((id) => ({ kind: 'parse', id }));
+    expect((w.posted[1] as { id: number }).id).toBe(1);
+  });
+
+  it('ignores a duplicate/late response after the request already settled', async () => {
+    const w = new FakeWorker();
+    const bridge = makeBridge(w);
+    const p = bridge.request((id) => ({ kind: 'parse', id }));
+    const id = (w.posted[0] as { id: number }).id;
+    w.respond({ id, kind: 'ok', value: 'first' });
+    await expect(p).resolves.toMatchObject({ value: 'first' });
+    // A stray duplicate must not throw or affect anything.
+    expect(() => w.respond({ id, kind: 'ok', value: 'dup' })).not.toThrow();
+  });
+});

--- a/packages/core/src/worker/bridge.ts
+++ b/packages/core/src/worker/bridge.ts
@@ -1,0 +1,107 @@
+/**
+ * Request/response correlation over a Web Worker.
+ *
+ * Each format package (pptx/docx/xlsx) drives a WASM parser in a Worker. The
+ * naive pattern — attach a one-shot `message` listener keyed only on the
+ * response `type` — breaks under concurrency: with two requests in flight, the
+ * first arriving response of a matching type resolves the wrong promise (or, if
+ * an unrelated message arrives, the listener detaches without resolving and the
+ * promise hangs forever).
+ *
+ * `WorkerBridge` fixes this by assigning every request a monotonic id and
+ * resolving against a pending-callback map keyed by that id — the proven
+ * pattern. It is wire-protocol agnostic: the discriminant field (`kind` vs
+ * `type`), the error shape, and any unsolicited messages (e.g. an init `ready`
+ * handshake) are described by the {@link WorkerBridgeOptions} callbacks, so all
+ * three packages can share one correlation mechanism without standardizing
+ * their message envelopes.
+ */
+
+/** The subset of the DOM `Worker` interface the bridge depends on. Keeping it
+ *  structural lets tests substitute an in-memory fake. */
+export interface WorkerLike {
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  addEventListener(type: 'message', listener: (e: MessageEvent) => void): void;
+  removeEventListener(type: 'message', listener: (e: MessageEvent) => void): void;
+  terminate(): void;
+}
+
+export interface WorkerBridgeOptions<TRes> {
+  /**
+   * Extract the correlation id from a response. Return `undefined` for
+   * unsolicited messages that do not answer a request (e.g. a `ready`
+   * handshake); those are routed to {@link onUnsolicited} instead.
+   */
+  readonly correlate: (response: TRes) => number | undefined;
+  /**
+   * Extract an error message from a response, or `undefined` when the response
+   * is a success. When defined, the matching request rejects with `Error(msg)`.
+   */
+  readonly toError?: (response: TRes) => string | undefined;
+  /** Called for every message that does not correlate to a pending request. */
+  readonly onUnsolicited?: (response: TRes) => void;
+}
+
+export class WorkerBridge<TRes = unknown> {
+  private readonly _worker: WorkerLike;
+  private readonly _opts: WorkerBridgeOptions<TRes>;
+  private readonly _pending = new Map<
+    number,
+    { resolve: (r: TRes) => void; reject: (e: Error) => void }
+  >();
+  private _nextId = 1;
+
+  constructor(worker: WorkerLike, opts: WorkerBridgeOptions<TRes>) {
+    this._worker = worker;
+    this._opts = opts;
+    this._worker.addEventListener('message', this._handle);
+  }
+
+  private _handle = (e: MessageEvent<TRes>): void => {
+    const res = e.data;
+    const id = this._opts.correlate(res);
+    if (id === undefined) {
+      this._opts.onUnsolicited?.(res);
+      return;
+    }
+    const cb = this._pending.get(id);
+    if (!cb) return; // unknown / already-settled id: ignore (never hang another request)
+    this._pending.delete(id);
+    const err = this._opts.toError?.(res);
+    if (err !== undefined) cb.reject(new Error(err));
+    else cb.resolve(res);
+  };
+
+  /** Allocate the next correlation id. Useful when the caller must embed the id
+   *  in a transferable-bearing message it builds itself. */
+  nextId(): number {
+    return this._nextId++;
+  }
+
+  /**
+   * Send a correlated request and resolve with its matching response. `build`
+   * receives the freshly allocated id so it can embed it in the message.
+   */
+  request(build: (id: number) => unknown, transfer?: Transferable[]): Promise<TRes> {
+    const id = this._nextId++;
+    return new Promise<TRes>((resolve, reject) => {
+      this._pending.set(id, { resolve, reject });
+      this._worker.postMessage(build(id), transfer);
+    });
+  }
+
+  /** Fire-and-forget message with no correlation (e.g. the `init` message). */
+  post(message: unknown, transfer?: Transferable[]): void {
+    this._worker.postMessage(message, transfer);
+  }
+
+  /** Terminate the worker and reject every still-pending request. */
+  terminate(): void {
+    this._worker.removeEventListener('message', this._handle);
+    this._worker.terminate();
+    for (const cb of this._pending.values()) {
+      cb.reject(new Error('Worker terminated'));
+    }
+    this._pending.clear();
+  }
+}

--- a/packages/core/src/worker/decode-data-url.ts
+++ b/packages/core/src/worker/decode-data-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Decode a `data:` URL into its raw bytes, or `null` for any non-data URL.
+ *
+ * The format workers receive the WASM binary either as a real URL (fetched by
+ * `wasm-bindgen`'s `init`) or, in some bundler/inline-worker setups, as a
+ * base64 `data:` URL. `wasm-bindgen`'s `init` cannot fetch a `data:` URL, so
+ * the worker decodes it to an ArrayBuffer first. Shared by all three package
+ * workers to keep the decoding identical.
+ */
+export function decodeDataUrl(url: string): ArrayBuffer | null {
+  if (!url.startsWith('data:')) return null;
+  const comma = url.indexOf(',');
+  if (comma === -1) return null;
+  const binary = atob(url.slice(comma + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -1,0 +1,2 @@
+export { WorkerBridge, type WorkerLike, type WorkerBridgeOptions } from './bridge.js';
+export { decodeDataUrl } from './decode-data-url.js';

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -6,7 +6,7 @@ import {
   type FontPreloadEntry,
   type LoadOptions as CoreLoadOptions,
 } from '@silurus/ooxml-core';
-import type { PaginatedBodyElement, Document, RenderPageOptions, WorkerResponse } from './types';
+import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerResponse } from './types';
 import { computePages, renderDocumentToCanvas, documentHasMath, prepareMathRuns } from './renderer';
 
 /** Theme-referenced typefaces commonly used by DOCX templates. Mirrors the
@@ -33,7 +33,7 @@ const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
 export type LoadOptions = CoreLoadOptions;
 
 export class DocxDocument {
-  private _document: Document | null = null;
+  private _document: DocxDocumentModel | null = null;
   private _pages: PaginatedBodyElement[][] | null = null;
   private _worker: Worker;
   private _bridge: WorkerBridge<WorkerResponse>;
@@ -90,7 +90,7 @@ export class DocxDocument {
     return this._getPages().length;
   }
 
-  get document(): Document {
+  get document(): DocxDocumentModel {
     if (!this._document) throw new Error('Document not loaded');
     return this._document;
   }

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -28,16 +28,9 @@ const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
 };
 
-/** Options for {@link DocxDocument.load}. Extends the shared
- *  `LoadOptions` shape from `@silurus/ooxml-core`. */
-export interface LoadOptions extends CoreLoadOptions {
-  /**
-   * Override the per-entry ZIP decompression cap (bytes) used by the
-   * zip-bomb guard in the Rust parser. Defaults to 512 MiB. Zero / negative
-   * values fall back to the default.
-   */
-  maxZipEntryBytes?: number;
-}
+/** Options for {@link DocxDocument.load}. The shared load-options type from
+ *  `@silurus/ooxml-core` (`useGoogleFonts`, `maxZipEntryBytes`). */
+export type LoadOptions = CoreLoadOptions;
 
 export class DocxDocument {
   private _document: Document | null = null;

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -1,6 +1,11 @@
 import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/docx_parser_bg.wasm?url';
-import { preloadGoogleFonts, type FontPreloadEntry, type LoadOptions as CoreLoadOptions } from '@silurus/ooxml-core';
+import {
+  preloadGoogleFonts,
+  WorkerBridge,
+  type FontPreloadEntry,
+  type LoadOptions as CoreLoadOptions,
+} from '@silurus/ooxml-core';
 import type { PaginatedBodyElement, Document, RenderPageOptions, WorkerResponse } from './types';
 import { computePages, renderDocumentToCanvas, documentHasMath, prepareMathRuns } from './renderer';
 
@@ -38,11 +43,16 @@ export class DocxDocument {
   private _document: Document | null = null;
   private _pages: PaginatedBodyElement[][] | null = null;
   private _worker: Worker;
+  private _bridge: WorkerBridge<WorkerResponse>;
 
   private constructor() {
     this._worker = new InlineWorker();
+    this._bridge = new WorkerBridge<WorkerResponse>(this._worker, {
+      correlate: (res) => res.id,
+      toError: (res) => (res.type === 'error' ? res.message : undefined),
+    });
     const wasmUrl = new URL(wasmAssetUrl, location.href).href;
-    this._worker.postMessage({ type: 'init', wasmUrl });
+    this._bridge.post({ type: 'init', wasmUrl });
   }
 
   static async load(source: string | ArrayBuffer, opts: LoadOptions = {}): Promise<DocxDocument> {
@@ -70,24 +80,16 @@ export class DocxDocument {
     return doc;
   }
 
-  private _parse(buffer: ArrayBuffer, maxZipEntryBytes?: number): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const handler = (e: MessageEvent<WorkerResponse>) => {
-        this._worker.removeEventListener('message', handler);
-        if (e.data.type === 'error') {
-          reject(new Error(e.data.message));
-        } else if (e.data.type === 'parsed') {
-          this._document = e.data.document;
-          resolve();
-        }
-      };
-      this._worker.addEventListener('message', handler);
-      this._worker.postMessage({ type: 'parse', data: buffer, maxZipEntryBytes }, [buffer]);
-    });
+  private async _parse(buffer: ArrayBuffer, maxZipEntryBytes?: number): Promise<void> {
+    const res = await this._bridge.request(
+      (id) => ({ type: 'parse', id, data: buffer, maxZipEntryBytes }),
+      [buffer],
+    );
+    this._document = (res as Extract<WorkerResponse, { type: 'parsed' }>).document;
   }
 
   destroy(): void {
-    this._worker.terminate();
+    this._bridge.terminate();
   }
 
   get pageCount(): number {

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -7,7 +7,7 @@ export type {
   BodyElement,
   DocParagraph,
   DocRun,
-  TextRun,
+  DocxTextRun,
   ImageRun,
   RenderPageOptions,
   RunRevision,

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -2,7 +2,7 @@ export { DocxDocument, type LoadOptions } from './document';
 export { DocxViewer, type DocxViewerOptions } from './viewer';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
-  Document,
+  DocxDocumentModel,
   SectionProps,
   BodyElement,
   DocParagraph,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,5 +1,5 @@
 import type {
-  Document, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
+  DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ShapeRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, SectionProps,
 } from './types';
@@ -232,7 +232,7 @@ function authorColor(author?: string): string {
   return TRACK_CHANGE_AUTHOR_PALETTE[Math.abs(h) % TRACK_CHANGE_AUTHOR_PALETTE.length];
 }
 
-function collectImagePairs(doc: Document): ImagePair[] {
+function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
   const seen = new Map<string, ImagePair>();
   const walk = (runs: DocRun[]) => {
     for (const run of runs) {
@@ -293,7 +293,7 @@ async function applyColorReplacement(bmp: ImageBitmap, colorHex: string): Promis
   return createImageBitmap(offscreen);
 }
 
-async function preloadImages(doc: Document): Promise<Map<string, ImageBitmap>> {
+async function preloadImages(doc: DocxDocumentModel): Promise<Map<string, ImageBitmap>> {
   const pairs = collectImagePairs(doc);
   const entries = await Promise.all(
     pairs.map(async (pair): Promise<[string, ImageBitmap] | null> => {
@@ -316,7 +316,7 @@ async function preloadImages(doc: Document): Promise<Map<string, ImageBitmap>> {
 // ===== Main entry =====
 
 export async function renderDocumentToCanvas(
-  doc: Document,
+  doc: DocxDocumentModel,
   canvas: HTMLCanvasElement | OffscreenCanvas,
   pageIndex: number,
   opts: RenderDocumentOptions = {},
@@ -818,7 +818,7 @@ function findMergeEndRow(table: DocTable, startRi: number, startCi: number): num
 }
 
 function pickHeaderFooter(
-  set: Document['headers'],
+  set: DocxDocumentModel['headers'],
   pageIndex: number,
   _totalPages: number,
   titlePage: boolean,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type {
   Document, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
-  DocRun, TextRun, ImageRun, ShapeRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
+  DocRun, DocxTextRun, ImageRun, ShapeRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, SectionProps,
 } from './types';
 import {
@@ -641,7 +641,7 @@ function snapParaLineToGrid(h: number, grid: DocGridCtx | undefined, scale: numb
  *  ruby-bearing and ruby-free lines line up on the same baseline grid. */
 function paragraphHasRuby(para: DocParagraph): boolean {
   for (const run of para.runs) {
-    if (run.type === 'text' && (run as unknown as TextRun).ruby) return true;
+    if (run.type === 'text' && (run as unknown as DocxTextRun).ruby) return true;
   }
   return false;
 }
@@ -1342,17 +1342,17 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
   const segs: LayoutSeg[] = [];
   const pushTextPiece = (
     text: string,
-    base: TextRun | FieldRun,
+    base: DocxTextRun | FieldRun,
     vertAlign: 'super' | 'sub' | null,
   ) => {
     const displayText = (base.allCaps || base.smallCaps) ? text.toUpperCase() : text;
     // Ruby annotation rides with the WHOLE base text (typically 1-2 chars).
     // Splitting on word boundaries would lose the association, so attach
     // the annotation only to the first emitted segment.
-    const ruby = (base as TextRun).ruby
-      ? { text: (base as TextRun).ruby!.text, fontSizePt: (base as TextRun).ruby!.fontSizePt }
+    const ruby = (base as DocxTextRun).ruby
+      ? { text: (base as DocxTextRun).ruby!.text, fontSizePt: (base as DocxTextRun).ruby!.fontSizePt }
       : undefined;
-    const revision = (base as TextRun).revision;
+    const revision = (base as DocxTextRun).revision;
     let firstSeg = true;
     for (const word of splitTextForLayout(displayText)) {
       segs.push({
@@ -1378,7 +1378,7 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
 
   for (const run of runs) {
     if (run.type === 'text') {
-      const t = run as unknown as TextRun & { type: 'text' };
+      const t = run as unknown as DocxTextRun & { type: 'text' };
       // Split on tab chars so tab alignment can be resolved during layout.
       const parts = t.text.split('\t');
       for (let i = 0; i < parts.length; i++) {
@@ -1434,12 +1434,12 @@ function findNearbyFontSize(runs: DocRun[], idx: number): number {
   // Look backwards then forwards for a text or field run to get font size
   for (let i = idx - 1; i >= 0; i--) {
     const r = runs[i];
-    if (r.type === 'text') return (r as unknown as TextRun).fontSize;
+    if (r.type === 'text') return (r as unknown as DocxTextRun).fontSize;
     if (r.type === 'field') return (r as unknown as FieldRun).fontSize;
   }
   for (let i = idx + 1; i < runs.length; i++) {
     const r = runs[i];
-    if (r.type === 'text') return (r as unknown as TextRun).fontSize;
+    if (r.type === 'text') return (r as unknown as DocxTextRun).fontSize;
     if (r.type === 'field') return (r as unknown as FieldRun).fontSize;
   }
   return 10; // pt fallback
@@ -2807,7 +2807,7 @@ function normalizeFontFamily(
 function getDefaultFontSize(para: DocParagraph): number {
   for (const run of para.runs) {
     if (run.type === 'text') {
-      return (run as unknown as TextRun).fontSize;
+      return (run as unknown as DocxTextRun).fontSize;
     }
     if (run.type === 'field') {
       return (run as unknown as FieldRun).fontSize;
@@ -2824,7 +2824,7 @@ function getDefaultFontSize(para: DocParagraph): number {
  *  Meiryo's tall line box rather than the generic fallback's. */
 function getDefaultFontFamily(para: DocParagraph): string | null {
   for (const run of para.runs) {
-    if (run.type === 'text') return (run as unknown as TextRun).fontFamily;
+    if (run.type === 'text') return (run as unknown as DocxTextRun).fontFamily;
     if (run.type === 'field') return (run as unknown as FieldRun).fontFamily;
   }
   return para.defaultFontFamily ?? null;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -12,6 +12,7 @@ import {
   loadMathJax,
   mathMLToSvg,
   recolorSvg,
+  PT_TO_PX,
 } from '@silurus/ooxml-core';
 import type { MathNode } from '@silurus/ooxml-core';
 import { intendedSingleLinePx } from './font-metrics.js';
@@ -23,9 +24,6 @@ const HIGHLIGHT_COLORS: Record<string, string> = {
   darkYellow: '#808000', darkGray: '#808080', lightGray: '#C0C0C0',
   black: '#000000', white: '#FFFFFF',
 };
-
-// 1pt = 96/72 CSS px at screen
-const PT_TO_PX = 96 / 72;
 
 // ── Math (OMML) rendering via MathJax ───────────────────────────────────────
 // Each equation is converted OMML AST -> MathML -> MathJax SVG, then rasterized to

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1347,8 +1347,9 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
     // Ruby annotation rides with the WHOLE base text (typically 1-2 chars).
     // Splitting on word boundaries would lose the association, so attach
     // the annotation only to the first emitted segment.
-    const ruby = (base as DocxTextRun).ruby
-      ? { text: (base as DocxTextRun).ruby!.text, fontSizePt: (base as DocxTextRun).ruby!.fontSizePt }
+    const baseRuby = (base as DocxTextRun).ruby;
+    const ruby = baseRuby
+      ? { text: baseRuby.text, fontSizePt: baseRuby.fontSizePt }
       : undefined;
     const revision = (base as DocxTextRun).revision;
     let firstSeg = true;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -2,7 +2,7 @@
 
 import type { MathNode } from '@silurus/ooxml-core';
 
-export interface Document {
+export interface DocxDocumentModel {
   section: SectionProps;
   body: BodyElement[];
   headers: HeadersFooters;
@@ -473,7 +473,7 @@ export type WorkerRequest =
   | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number };
 
 export type WorkerResponse =
-  | { type: 'parsed'; id: number; document: Document }
+  | { type: 'parsed'; id: number; document: DocxDocumentModel }
   | { type: 'error'; id: number; message: string };
 
 // ===== Public API types =====

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -22,7 +22,7 @@ export interface Document {
   fontFamilyClasses?: Record<string, string>;
   /** ECMA-376 §17.13.5 — flat list of `<w:ins>` / `<w:del>` events in the
    *  body. Each entry carries author / date / text. The renderer marks
-   *  runs inline via {@link TextRun.revision}; this array is primarily for
+   *  runs inline via {@link DocxTextRun.revision}; this array is primarily for
    *  tooling (MCP, agents, change-summary panels). */
   revisions?: DocRevision[];
   /** ECMA-376 §17.13.4 — `word/comments.xml`. Each comment carries id,
@@ -190,7 +190,7 @@ export interface NumberingInfo {
 }
 
 export type DocRun =
-  | { type: 'text' } & TextRun
+  | { type: 'text' } & DocxTextRun
   | { type: 'image' } & ImageRun
   | { type: 'break'; breakType: 'line' | 'page' | 'column' }
   | { type: 'field' } & FieldRun
@@ -312,7 +312,7 @@ export interface FieldRun {
   highlight?: string | null;
 }
 
-export interface TextRun {
+export interface DocxTextRun {
   text: string;
   bold: boolean;
   italic: boolean;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -470,11 +470,11 @@ export interface CellBorders {
 
 export type WorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; data: ArrayBuffer; maxZipEntryBytes?: number };
+  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number };
 
 export type WorkerResponse =
-  | { type: 'parsed'; document: Document }
-  | { type: 'error'; message: string };
+  | { type: 'parsed'; id: number; document: Document }
+  | { type: 'error'; id: number; message: string };
 
 // ===== Public API types =====
 

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -10,6 +10,10 @@ export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
    * browser's native text selection works on document content.
    */
   enableTextSelection?: boolean;
+  /** Called when a page finishes rendering. */
+  onPageChange?: (index: number, total: number) => void;
+  /** Called on parse or render errors. */
+  onError?: (err: Error) => void;
 }
 
 export class DocxViewer {
@@ -50,13 +54,29 @@ export class DocxViewer {
     }
   }
 
+  /**
+   * Load a DOCX from URL or ArrayBuffer and render the first page.
+   *
+   * Error contract (shared by all three viewers): on failure, if an `onError`
+   * callback was provided it is invoked and `load` resolves normally; if not,
+   * the error is rethrown so it is never silently swallowed.
+   */
   async load(source: string | ArrayBuffer): Promise<void> {
-    this._doc = await DocxDocument.load(source, {
-      useGoogleFonts: this._opts.useGoogleFonts,
-      maxZipEntryBytes: this._opts.maxZipEntryBytes,
-    });
-    this._currentPage = 0;
-    await this._render();
+    try {
+      this._doc = await DocxDocument.load(source, {
+        useGoogleFonts: this._opts.useGoogleFonts,
+        maxZipEntryBytes: this._opts.maxZipEntryBytes,
+      });
+      this._currentPage = 0;
+      await this._render();
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      if (this._opts.onError) {
+        this._opts.onError(e);
+        return;
+      }
+      throw e;
+    }
   }
 
   get pageCount(): number {
@@ -65,6 +85,11 @@ export class DocxViewer {
 
   get currentPage(): number {
     return this._currentPage;
+  }
+
+  /** The underlying <canvas> element. */
+  get canvasElement(): HTMLCanvasElement {
+    return this._canvas;
   }
 
   async goToPage(index: number): Promise<void> {
@@ -77,18 +102,25 @@ export class DocxViewer {
   async nextPage(): Promise<void> { await this.goToPage(this._currentPage + 1); }
   async prevPage(): Promise<void> { await this.goToPage(this._currentPage - 1); }
 
+  /** Terminate the parser worker and release resources. */
+  destroy(): void {
+    this._doc?.destroy();
+    this._doc = null;
+    this._wrapper.remove();
+  }
+
   private async _render(): Promise<void> {
     if (!this._doc) return;
     const runs: DocxTextRunInfo[] = [];
     const onTextRun = this._textLayer ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
     await this._doc.renderPage(this._canvas, this._currentPage, { ...this._opts, onTextRun });
     if (this._textLayer) {
-      this._buildTextLayer(runs);
+      this._buildTextLayer(this._textLayer, runs);
     }
+    this._opts.onPageChange?.(this._currentPage, this.pageCount);
   }
 
-  private _buildTextLayer(runs: DocxTextRunInfo[]): void {
-    const layer = this._textLayer!;
+  private _buildTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {
     layer.innerHTML = '';
     layer.style.width = `${this._canvas.style.width || this._canvas.width + 'px'}`;
     layer.style.height = `${this._canvas.style.height || this._canvas.height + 'px'}`;

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -1,17 +1,8 @@
 import init, { parse_docx } from './wasm/docx_parser.js';
+import { decodeDataUrl } from '@silurus/ooxml-core';
 import type { WorkerRequest, WorkerResponse } from './types';
 
 let initPromise: Promise<unknown> | null = null;
-
-function decodeDataUrl(url: string): ArrayBuffer | null {
-  if (!url.startsWith('data:')) return null;
-  const comma = url.indexOf(',');
-  if (comma === -1) return null;
-  const binary = atob(url.slice(comma + 1));
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes.buffer;
-}
 
 self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;
@@ -21,6 +12,9 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
     return;
   }
 
+  // Echo the correlation id so the client routes the response to the right
+  // pending promise (id correlation, not response-type matching).
+  const id = req.id;
   try {
     await initPromise;
     if (req.type === 'parse') {
@@ -31,11 +25,11 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       const json = parse_docx(new Uint8Array(req.data), maxBytes);
       const document = JSON.parse(json);
       if (document.error) throw new Error(`Parse error: ${document.error}`);
-      const res: WorkerResponse = { type: 'parsed', document };
+      const res: WorkerResponse = { type: 'parsed', id, document };
       self.postMessage(res);
     }
   } catch (err) {
-    const res: WorkerResponse = { type: 'error', message: String(err) };
+    const res: WorkerResponse = { type: 'error', id, message: String(err) };
     self.postMessage(res);
   }
 };

--- a/packages/docx/tsconfig.json
+++ b/packages/docx/tsconfig.json
@@ -1,19 +1,16 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "declaration": true,
-    "composite": true,
     "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "paths": {
+      "@silurus/ooxml-core": ["../core/src/index.ts"],
+      "@silurus/ooxml-core/*": ["../core/src/*"]
+    }
   },
   "include": ["src"],
-  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"]
+  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"],
+  "references": [{ "path": "../core" }]
 }

--- a/packages/node/src/docx.ts
+++ b/packages/node/src/docx.ts
@@ -1,4 +1,4 @@
-import type { Document } from '@silurus/ooxml-docx';
+import type { DocxDocumentModel } from '@silurus/ooxml-docx';
 // @ts-ignore — wasm-pack generated JS without a d.ts entry for the bare module path
 import * as docxWasm from '../../docx/src/wasm/docx_parser.js';
 import { loadWasmModule, resolveWasm } from './wasm-loader.ts';
@@ -12,14 +12,14 @@ function ensureInit(): void {
   initialized = true;
 }
 
-/** Parse a `.docx` archive in Node and return the same `Document` model the
+/** Parse a `.docx` archive in Node and return the same `DocxDocumentModel` the
  *  browser path produces. */
-export function parseDocx(buffer: ArrayBuffer | Uint8Array | Buffer): Document {
+export function parseDocx(buffer: ArrayBuffer | Uint8Array | Buffer): DocxDocumentModel {
   ensureInit();
   const bytes =
     buffer instanceof Uint8Array
       ? buffer
       : new Uint8Array(buffer as ArrayBuffer);
   const json = (docxWasm as unknown as { parse_docx: (b: Uint8Array) => string }).parse_docx(bytes);
-  return JSON.parse(json) as Document;
+  return JSON.parse(json) as DocxDocumentModel;
 }

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { buildViewerUI } from './PptxViewer.stories';
 import { PptxPresentation } from './presentation';
 import { PptxViewer } from './viewer';
-import type { TextRunInfo } from './renderer';
+import type { PptxTextRunInfo } from './renderer';
 
 type DemoArgs = { width: number };
 type LayoutArgs = Record<string, never>;
@@ -40,7 +40,7 @@ function makeStatus(root: HTMLElement): HTMLDivElement {
   return s;
 }
 
-function buildPptxTextLayer(layer: HTMLDivElement, runs: TextRunInfo[], cssWidth: number, cssHeight: number): void {
+function buildPptxTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
   layer.innerHTML = '';
   layer.style.width = `${cssWidth}px`;
   layer.style.height = `${cssHeight}px`;
@@ -111,7 +111,7 @@ export const ScrollView: LayoutStory = {
           slideWrapper.appendChild(textLayer);
           scroller.appendChild(slideWrapper);
 
-          const runs: TextRunInfo[] = [];
+          const runs: PptxTextRunInfo[] = [];
           await pres.renderSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
           buildPptxTextLayer(textLayer, runs, widthPx, cssHeight);
         }

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -1,6 +1,6 @@
 export { PptxViewer, type PptxViewerOptions } from './viewer';
 export { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
-export { renderSlide, type RenderOptions, type TextRunInfo, type TextRunCallback } from './renderer';
+export { renderSlide, type RenderOptions, type PptxTextRunInfo, type TextRunCallback } from './renderer';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Presentation,

--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -1,8 +1,8 @@
 import type { MediaElement, Slide } from './types';
 import { drawPlayBadge } from './media-chrome';
 import { tabularDigitWidth, tabularTextWidth, drawTabularText } from './tabular-text';
+import { EMU_PER_PX } from '@silurus/ooxml-core';
 
-const EMU_PER_PX = 9525;
 const emuToPx = (v: number, scale: number) => (v / EMU_PER_PX) * scale;
 
 interface MediaState {

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -25,18 +25,9 @@ const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
 };
 
-/** Options for {@link PptxPresentation.load}. Extends the shared
- *  `LoadOptions` shape from `@silurus/ooxml-core`. */
-export interface LoadOptions extends CoreLoadOptions {
-  /**
-   * Override the per-entry ZIP decompression cap (bytes). Defaults to
-   * 512 MiB — matches `MAX_ZIP_ENTRY_BYTES` in the Rust parser. Raising
-   * this past 4 GiB requires a 64-bit WASM build; lowering it makes the
-   * loader reject otherwise-legitimate large media decks. Zero or
-   * negative values fall back to the default.
-   */
-  maxZipEntryBytes?: number;
-}
+/** Options for {@link PptxPresentation.load}. The shared load-options type
+ *  from `@silurus/ooxml-core` (`useGoogleFonts`, `maxZipEntryBytes`). */
+export type LoadOptions = CoreLoadOptions;
 
 /** Options for rendering a single slide onto a canvas. */
 export interface RenderSlideOptions {

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -101,11 +101,9 @@ export class PptxPresentation {
       buffer = source;
     }
     await pres._parse(buffer, opts.maxZipEntryBytes);
-    if (opts.useGoogleFonts) {
-      await preloadGoogleFonts(
-        [pres._presentation!.majorFont, pres._presentation!.minorFont],
-        PPTX_GOOGLE_FONTS,
-      );
+    const parsed = pres._presentation;
+    if (opts.useGoogleFonts && parsed) {
+      await preloadGoogleFonts([parsed.majorFont, parsed.minorFont], PPTX_GOOGLE_FONTS);
     }
     return pres;
   }

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1,7 +1,12 @@
 import type { MediaElement, Presentation, WorkerRequest, WorkerResponse } from './types';
 import { renderSlide, type TextRunCallback } from './renderer';
 import { createPresentationHandle, type PresentationHandle } from './presentation-handle';
-import { preloadGoogleFonts, type FontPreloadEntry, type LoadOptions as CoreLoadOptions } from '@silurus/ooxml-core';
+import {
+  preloadGoogleFonts,
+  WorkerBridge,
+  type FontPreloadEntry,
+  type LoadOptions as CoreLoadOptions,
+} from '@silurus/ooxml-core';
 import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/pptx_parser_bg.wasm?url';
 
@@ -66,68 +71,28 @@ export interface RenderSlideOptions {
  */
 export class PptxPresentation {
   private readonly _worker: Worker;
+  private readonly _bridge: WorkerBridge<WorkerResponse>;
   private _presentation: Presentation | null = null;
-  private _pendingParseCallbacks = new Map<
-    number,
-    { resolve: (p: Presentation) => void; reject: (e: Error) => void }
-  >();
-  private _pendingMediaCallbacks = new Map<
-    number,
-    { resolve: (b: ArrayBuffer) => void; reject: (e: Error) => void }
-  >();
   private _mediaCache = new Map<string, Promise<Blob>>();
-  private _nextId = 1;
   private _workerReady = false;
   private _workerReadyCallbacks: Array<() => void> = [];
 
   private constructor() {
     this._worker = new InlineWorker();
+    this._bridge = new WorkerBridge<WorkerResponse>(this._worker, {
+      // The init `ready` handshake carries no id; everything else does.
+      correlate: (msg) => ('id' in msg ? msg.id : undefined),
+      toError: (msg) => (msg.kind === 'error' ? msg.message : undefined),
+      onUnsolicited: (msg) => {
+        if (msg.kind === 'ready') {
+          this._workerReady = true;
+          for (const cb of this._workerReadyCallbacks) cb();
+          this._workerReadyCallbacks = [];
+        }
+      },
+    });
     const wasmUrl = new URL(wasmAssetUrl, location.href).href;
-    this._worker.postMessage({ kind: 'init', wasmUrl } satisfies WorkerRequest);
-
-    this._worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
-      const msg = e.data;
-
-      if (msg.kind === 'ready') {
-        this._workerReady = true;
-        for (const cb of this._workerReadyCallbacks) cb();
-        this._workerReadyCallbacks = [];
-        return;
-      }
-
-      if (msg.kind === 'parsed') {
-        const cb = this._pendingParseCallbacks.get(msg.id);
-        if (cb) {
-          this._pendingParseCallbacks.delete(msg.id);
-          cb.resolve(msg.presentation);
-        }
-        return;
-      }
-
-      if (msg.kind === 'mediaExtracted') {
-        const cb = this._pendingMediaCallbacks.get(msg.id);
-        if (cb) {
-          this._pendingMediaCallbacks.delete(msg.id);
-          cb.resolve(msg.bytes);
-        }
-        return;
-      }
-
-      if (msg.kind === 'error') {
-        const err = new Error(msg.message);
-        const parseCb = this._pendingParseCallbacks.get(msg.id);
-        if (parseCb) {
-          this._pendingParseCallbacks.delete(msg.id);
-          parseCb.reject(err);
-          return;
-        }
-        const mediaCb = this._pendingMediaCallbacks.get(msg.id);
-        if (mediaCb) {
-          this._pendingMediaCallbacks.delete(msg.id);
-          mediaCb.reject(err);
-        }
-      }
-    };
+    this._bridge.post({ kind: 'init', wasmUrl } satisfies WorkerRequest);
   }
 
   /** Parse a PPTX from URL or ArrayBuffer. */
@@ -161,12 +126,11 @@ export class PptxPresentation {
 
   private async _parse(buffer: ArrayBuffer, maxZipEntryBytes?: number): Promise<void> {
     await this._waitForWorker();
-    const id = this._nextId++;
-    const presentation = await new Promise<Presentation>((resolve, reject) => {
-      this._pendingParseCallbacks.set(id, { resolve, reject });
-      this._worker.postMessage({ kind: 'parse', id, buffer, maxZipEntryBytes } satisfies WorkerRequest, [buffer]);
-    });
-    this._presentation = presentation;
+    const res = await this._bridge.request(
+      (id) => ({ kind: 'parse', id, buffer, maxZipEntryBytes }) satisfies WorkerRequest,
+      [buffer],
+    );
+    this._presentation = (res as Extract<WorkerResponse, { kind: 'parsed' }>).presentation;
   }
 
   /** Total number of slides in the loaded presentation. */
@@ -218,11 +182,10 @@ export class PptxPresentation {
     const mimeType = this._findMimeTypeForPath(mediaPath);
     const p = (async () => {
       await this._waitForWorker();
-      const id = this._nextId++;
-      const bytes = await new Promise<ArrayBuffer>((resolve, reject) => {
-        this._pendingMediaCallbacks.set(id, { resolve, reject });
-        this._worker.postMessage({ kind: 'extractMedia', id, path: mediaPath } satisfies WorkerRequest);
-      });
+      const res = await this._bridge.request(
+        (id) => ({ kind: 'extractMedia', id, path: mediaPath }) satisfies WorkerRequest,
+      );
+      const bytes = (res as Extract<WorkerResponse, { kind: 'mediaExtracted' }>).bytes;
       return new Blob([bytes], { type: mimeType });
     })();
     this._mediaCache.set(mediaPath, p);
@@ -274,7 +237,7 @@ export class PptxPresentation {
 
   /** Terminate the worker and release all resources. */
   destroy(): void {
-    this._worker.terminate();
+    this._bridge.terminate();
     this._presentation = null;
     this._mediaCache.clear();
   }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -42,7 +42,7 @@ export interface RenderContext {
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
-export interface TextRunInfo {
+export interface PptxTextRunInfo {
   text: string;
   /** X position in CSS px, relative to the shape's top-left corner. */
   inShapeX: number;
@@ -73,7 +73,7 @@ export interface TextRunInfo {
   textBodyRotation?: number;
 }
 
-export type TextRunCallback = (run: TextRunInfo) => void;
+export type TextRunCallback = (run: PptxTextRunInfo) => void;
 
 /**
  * Convert EMU to canvas pixels.

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -26,12 +26,10 @@ import {
   drawStar,
   drawPolygon,
   ooxmlArcTo,
+  EMU_PER_PT as PT_TO_EMU,
 } from '@silurus/ooxml-core';
 import { drawPlayBadge } from './media-chrome';
 import { renderPresetShape, hasPreset, getConnectorAnchors } from './preset-shape';
-
-/** EMU per point (OOXML: 1 pt = 12700 EMU). Used to scale font sizes with the canvas. */
-const PT_TO_EMU = 12700;
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -2031,8 +2029,8 @@ export async function renderSlide(
       await renderMedia(ctx, el, scale, opts.fetchMedia, opts.skipMediaControls);
     } else if (el.type === 'chart') {
       // OOXML: 1pt = 12700 EMU. The slide renderer's `scale` is px-per-EMU,
-      // so 12700 * scale gives pixels-per-point at the current display size.
-      const chartPtToPx = 12700 * scale;
+      // so PT_TO_EMU * scale gives pixels-per-point at the current display size.
+      const chartPtToPx = PT_TO_EMU * scale;
       renderChart(
         ctx,
         {

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -80,7 +80,13 @@ export class PptxViewer {
     }
   }
 
-  /** Load a PPTX from URL or ArrayBuffer and render the first slide. */
+  /**
+   * Load a PPTX from URL or ArrayBuffer and render the first slide.
+   *
+   * Error contract (shared by all three viewers): on failure, if an `onError`
+   * callback was provided it is invoked and `load` resolves normally; if not,
+   * the error is rethrown so it is never silently swallowed.
+   */
   async load(source: string | ArrayBuffer): Promise<void> {
     try {
       this.engine = await PptxPresentation.load(source, {
@@ -91,7 +97,10 @@ export class PptxViewer {
       await this.renderCurrentSlide();
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
-      this.opts.onError?.(e);
+      if (this.opts.onError) {
+        this.opts.onError(e);
+        return;
+      }
       throw e;
     }
   }

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -1,4 +1,4 @@
-import type { RenderOptions, TextRunInfo } from './renderer';
+import type { RenderOptions, PptxTextRunInfo } from './renderer';
 import { PptxPresentation } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
 
@@ -139,8 +139,8 @@ export class PptxViewer {
     this.handle?.dispose();
     this.handle = null;
 
-    const runs: TextRunInfo[] = [];
-    const onTextRun = this.textLayer ? (r: TextRunInfo) => runs.push(r) : undefined;
+    const runs: PptxTextRunInfo[] = [];
+    const onTextRun = this.textLayer ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
 
     try {
       if (this.opts.enableMediaPlayback) {
@@ -161,7 +161,7 @@ export class PptxViewer {
     }
   }
 
-  private _buildTextLayer(runs: TextRunInfo[], cssWidth: number, cssHeight: number): void {
+  private _buildTextLayer(runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
     const layer = this.textLayer!;
     layer.innerHTML = '';
     layer.style.width = `${cssWidth}px`;

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -157,12 +157,11 @@ export class PptxViewer {
     }
 
     if (this.textLayer) {
-      this._buildTextLayer(runs, targetWidth, cssHeight);
+      this._buildTextLayer(this.textLayer, runs, targetWidth, cssHeight);
     }
   }
 
-  private _buildTextLayer(runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
-    const layer = this.textLayer!;
+  private _buildTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
     layer.innerHTML = '';
     layer.style.width = `${cssWidth}px`;
     layer.style.height = `${cssHeight}px`;

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -18,7 +18,7 @@ declare function acquireVsCodeApi(): {
 
 import { XlsxViewer, type CellRange } from '@silurus/ooxml-xlsx';
 import { DocxDocument, type DocxTextRunInfo } from '@silurus/ooxml-docx';
-import { PptxPresentation, type TextRunInfo } from '@silurus/ooxml-pptx';
+import { PptxPresentation, type PptxTextRunInfo } from '@silurus/ooxml-pptx';
 
 const vscodeApi = acquireVsCodeApi();
 const fileType = __OOXML_FILE_TYPE__;
@@ -149,7 +149,7 @@ async function initDocx(buffer: ArrayBuffer): Promise<void> {
 
 function buildPptxTextLayer(
   layer: HTMLDivElement,
-  runs: TextRunInfo[],
+  runs: PptxTextRunInfo[],
   cssWidth: number,
   cssHeight: number,
 ): void {
@@ -211,7 +211,7 @@ async function initPptx(buffer: ArrayBuffer): Promise<void> {
     wrapper.append(canvas, textLayer);
     stack.appendChild(wrapper);
 
-    const runs: TextRunInfo[] = [];
+    const runs: PptxTextRunInfo[] = [];
     await pres.presentSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
     buildPptxTextLayer(textLayer, runs, widthPx, cssHeight);
   }

--- a/packages/xlsx/index.html
+++ b/packages/xlsx/index.html
@@ -66,13 +66,13 @@
     const sheetSelect = document.getElementById('sheetSelect');
     const status = document.getElementById('status');
 
-    const wb = new XlsxWorkbook();
+    let wb = null;
     let loaded = false;
 
     async function loadFile(source) {
       status.textContent = 'Loading…';
       try {
-        await wb.load(source);
+        wb = await XlsxWorkbook.load(source);
         loaded = true;
         sheetSelect.innerHTML = '';
         wb.sheetNames.forEach((name, i) => {

--- a/packages/xlsx/src/conditional-format.ts
+++ b/packages/xlsx/src/conditional-format.ts
@@ -1,4 +1,4 @@
-import type { Worksheet, Cell, CellRange, CfStop, CfValue, Dxf, CfRule, Fill, Border, DefinedName } from './types.js';
+import type { Worksheet, Cell, CellRange, CfStop, CfValue, Dxf, CfRule, CellFill, Border, DefinedName } from './types.js';
 import { evalFormulaToBool } from './formula.js';
 
 // ────────────────────────────────────────────────────────────────
@@ -27,7 +27,7 @@ export interface CfContext {
 }
 
 export interface CfResult {
-  fill?: Fill;
+  fill?: CellFill;
   fontColor?: string;
   fontBold?: boolean;
   fontItalic?: boolean;

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -1,4 +1,4 @@
-export { XlsxWorkbook } from './workbook.js';
+export { XlsxWorkbook, type LoadOptions } from './workbook.js';
 export { XlsxViewer } from './viewer.js';
 export type { XlsxViewerOptions, CellAddress, CellRange, SelectionMode } from './viewer.js';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
@@ -10,8 +10,8 @@ export type {
   Cell,
   CellValue,
   Styles,
-  Font,
-  Fill,
+  CellFont,
+  CellFill,
   Border,
   BorderEdge,
   CellXf,
@@ -20,5 +20,5 @@ export type {
   ParsedWorkbook,
   ViewportRange,
   RenderViewportOptions,
-  TextRunInfo,
+  XlsxTextRunInfo,
 } from './types.js';

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type {
-  Worksheet, Styles, Cell, CellValue, Font, Fill, Border, BorderEdge, CellXf,
-  ViewportRange, RenderViewportOptions, TextRunInfo,
+  Worksheet, Styles, Cell, CellValue, CellFont, CellFill, Border, BorderEdge, CellXf,
+  ViewportRange, RenderViewportOptions, XlsxTextRunInfo,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
@@ -379,7 +379,7 @@ function hatchPattern(
  */
 function paintCellPatternFill(
   ctx: CanvasRenderingContext2D,
-  fill: Fill,
+  fill: CellFill,
   x: number, y: number, w: number, h: number,
 ): boolean {
   if (fill.gradient && fill.gradient.stops.length > 0) {
@@ -501,7 +501,7 @@ function blendHex(fgHex: string, bgHex: string, fgCoverage: number): string {
   return `rgb(${r},${g},${b})`;
 }
 
-function buildFont(font: Font, cs = 1): string {
+function buildFont(font: CellFont, cs = 1): string {
   const style = font.italic ? 'italic ' : '';
   const weight = font.bold ? 'bold ' : '';
   const sizePx = Math.max(1, Math.round(font.size * PT_TO_PX * cs));
@@ -541,7 +541,7 @@ function drawTextDecoLine(
  * size/color/name fall back to the base when omitted. A run with no
  * <rPr> (run.font undefined) inherits the base entirely.
  */
-function applyRunFont(base: Font, run: Run): Font {
+function applyRunFont(base: CellFont, run: Run): CellFont {
   const rf = run.font;
   if (!rf) return base;
   return {
@@ -557,12 +557,12 @@ function applyRunFont(base: Font, run: Run): Font {
   };
 }
 
-function resolveXf(styles: Styles, styleIndex: number): { font: Font; fill: Fill; border: Border; xf: CellXf } {
+function resolveXf(styles: Styles, styleIndex: number): { font: CellFont; fill: CellFill; border: Border; xf: CellXf } {
   const xf: CellXf = styles.cellXfs[styleIndex] ?? styles.cellXfs[0] ?? {
     fontId: 0, fillId: 0, borderId: 0, numFmtId: 0, alignH: null, alignV: null, wrapText: false,
   };
-  const font: Font = styles.fonts[xf.fontId] ?? { bold: false, italic: false, underline: false, strike: false, size: DEFAULT_FONT_SIZE, color: null, name: null };
-  const fill: Fill = styles.fills[xf.fillId] ?? { patternType: 'none', fgColor: null, bgColor: null };
+  const font: CellFont = styles.fonts[xf.fontId] ?? { bold: false, italic: false, underline: false, strike: false, size: DEFAULT_FONT_SIZE, color: null, name: null };
+  const fill: CellFill = styles.fills[xf.fillId] ?? { patternType: 'none', fgColor: null, bgColor: null };
   const border: Border = styles.borders[xf.borderId] ?? { left: null, right: null, top: null, bottom: null };
   return { font, fill, border, xf };
 }
@@ -641,7 +641,7 @@ function wrapParagraphLines(ctx: CanvasRenderingContext2D, paragraph: string, ma
 
 interface RichSeg {
   text: string;
-  font: Font;
+  font: CellFont;
   width: number; // px
 }
 
@@ -662,7 +662,7 @@ interface RichLine {
 function layoutRichTextLines(
   ctx: CanvasRenderingContext2D,
   runs: Run[],
-  baseFont: Font,
+  baseFont: CellFont,
   cs: number,
   maxWidth: number,
 ): RichLine[] {
@@ -677,7 +677,7 @@ function layoutRichTextLines(
     cur = []; curW = 0; curMaxSize = 0;
   };
 
-  const push = (text: string, font: Font) => {
+  const push = (text: string, font: CellFont) => {
     if (!text) return;
     ctx.font = buildFont(font, cs);
     const w = ctx.measureText(text).width;
@@ -775,7 +775,7 @@ interface RenderContext {
    *  (ECMA-376 §18.3.1.13). Used by `colWidthToPx` to convert character-
    *  unit column widths into pixels. */
   mdw: number;
-  onTextRun?: (info: TextRunInfo) => void;
+  onTextRun?: (info: XlsxTextRunInfo) => void;
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -1083,7 +1083,7 @@ function renderQuadrant(
     const effectiveItalic = font.italic || !!cf.fontItalic;
     const effectiveUnderline = font.underline || !!cf.fontUnderline;
     const effectiveStrike = font.strike || !!cf.fontStrike;
-    const fontForDraw: Font = (
+    const fontForDraw: CellFont = (
       effectiveBold !== font.bold || effectiveItalic !== font.italic ||
       effectiveUnderline !== font.underline || effectiveStrike !== font.strike
     ) ? { ...font, bold: effectiveBold, italic: effectiveItalic, underline: effectiveUnderline, strike: effectiveStrike }
@@ -1384,7 +1384,7 @@ function renderQuadrant(
       const effectiveItalic = font.italic || !!cf.fontItalic;
       const effectiveUnderline = font.underline || !!cf.fontUnderline;
       const effectiveStrike = font.strike || !!cf.fontStrike;
-      const fontForDraw: Font = (
+      const fontForDraw: CellFont = (
         effectiveBold !== font.bold || effectiveItalic !== font.italic ||
         effectiveUnderline !== font.underline || effectiveStrike !== font.strike
       )
@@ -1764,7 +1764,7 @@ function renderQuadrant(
         let vaYShift = 0;
         if (cellVertAlign === 'superscript') vaYShift = -Math.round(baseSizePxOrig * 0.35);
         else if (cellVertAlign === 'subscript') vaYShift = Math.round(baseSizePxOrig * 0.10);
-        const drawFont: Font = cellVertAlign
+        const drawFont: CellFont = cellVertAlign
           ? { ...fontForDraw, size: fontForDraw.size * 0.65 }
           : fontForDraw;
         if (cellVertAlign) {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { renderChart, renderSparkline, type ChartModel, type SparklineModel } from '@silurus/ooxml-core';
+import { renderChart, renderSparkline, PT_TO_PX, EMU_PER_PX, type ChartModel, type SparklineModel } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -28,10 +28,6 @@ const DEFAULT_FONT_SIZE = 11;
 // so the spec-correct value depends on which font and point size that style
 // resolves to (e.g. Meiryo UI 10 pt yields MDW ≈ 6 px).
 const MDW_FALLBACK = 8;
-/** Standard pt → CSS px conversion at 96 DPI. ECMA-376 §18.4.11 (font sz),
- * §18.8.5 (border width margins, etc.) all express their dimensions in
- * points. Multiply by this constant to obtain the display pixel value. */
-const PT_TO_PX = 4 / 3;
 
 export const HEADER_W = 50;
 export const HEADER_H = 22;
@@ -2296,7 +2292,6 @@ function renderHeaders(
 // ────────────────────────────────────────────────────────────────
 // Image anchors  (ECMA-376 §20.5, <xdr:twoCellAnchor>)
 // ────────────────────────────────────────────────────────────────
-const EMU_PER_PX = 9525;
 
 /** Sum scaled column widths for cols 1..n-1 (sheet-space X of col n in scaled px). */
 function sheetXForCol(
@@ -3124,7 +3119,7 @@ function renderCharts(
 
     // XLSX natural rendering is device-px at 96 DPI where 1pt = 4/3 px. Scale
     // that by `cs` so OOXML-specified font sizes (title/axes) scale with zoom.
-    const ptToPx = (4 / 3) * cs;
+    const ptToPx = PT_TO_PX * cs;
     renderChart(ctx, adaptChartData(anchor.chart), { x: cx, y: cy, w: cw, h: ch }, ptToPx);
     ctx.restore();
   }

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -629,8 +629,8 @@ export interface NumFmt {
 }
 
 export interface Styles {
-  fonts: Font[];
-  fills: Fill[];
+  fonts: CellFont[];
+  fills: CellFill[];
   borders: Border[];
   cellXfs: CellXf[];
   numFmts: NumFmt[];
@@ -638,8 +638,8 @@ export interface Styles {
 }
 
 export interface Dxf {
-  font: Font | null;
-  fill: Fill | null;
+  font: CellFont | null;
+  fill: CellFill | null;
   border: Border | null;
   /** Number format override from the dxf (ECMA-376 §18.8.17). When a
    *  conditional-formatting rule matches, this numFmt replaces the cell's own
@@ -648,7 +648,7 @@ export interface Dxf {
   numFmt?: NumFmt | null;
 }
 
-export interface Font {
+export interface CellFont {
   bold: boolean;
   italic: boolean;
   underline: boolean;
@@ -662,7 +662,7 @@ export interface Font {
   vertAlign?: 'superscript' | 'subscript';
 }
 
-export interface Fill {
+export interface CellFill {
   patternType: string;
   fgColor: string | null;
   bgColor: string | null;
@@ -735,7 +735,7 @@ export interface ViewportRange {
 }
 
 /** Emitted once per cell that has text, with the cell's canvas-pixel bounds. */
-export interface TextRunInfo {
+export interface XlsxTextRunInfo {
   text: string;
   /** Canvas CSS-pixel x of the cell's top-left corner. */
   x: number;
@@ -764,7 +764,7 @@ export interface RenderViewportOptions {
   /** Pre-loaded Image elements keyed by their dataUrl (for ImageAnchor rendering). */
   loadedImages?: Map<string, HTMLImageElement>;
   /** Called once per cell that contains text, with canvas-pixel position and cell address. */
-  onTextRun?: (info: TextRunInfo) => void;
+  onTextRun?: (info: XlsxTextRunInfo) => void;
   /** Highlighted row range for selected row headers (1-indexed inclusive).
    *  `strong: true` → light blue + blue border (rows / cols / all selection modes).
    *  `strong: false` → slightly darker grey (cells selection mode). */

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -775,10 +775,17 @@ export interface RenderViewportOptions {
 
 export type WorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; data: ArrayBuffer; maxZipEntryBytes?: number }
-  | { type: 'parseSheet'; data: ArrayBuffer; sheetIndex: number; sheetName: string; maxZipEntryBytes?: number };
+  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number }
+  | {
+      type: 'parseSheet';
+      id: number;
+      data: ArrayBuffer;
+      sheetIndex: number;
+      sheetName: string;
+      maxZipEntryBytes?: number;
+    };
 
 export type WorkerResponse =
-  | { type: 'parsed'; workbook: ParsedWorkbook }
-  | { type: 'parsedSheet'; worksheet: Worksheet }
-  | { type: 'error'; message: string };
+  | { type: 'parsed'; id: number; workbook: ParsedWorkbook }
+  | { type: 'parsedSheet'; id: number; worksheet: Worksheet }
+  | { type: 'error'; id: number; message: string };

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -264,6 +264,13 @@ export class XlsxViewer {
     this.setupSelectionEvents();
   }
 
+  /**
+   * Load an XLSX from URL or ArrayBuffer and render the first sheet.
+   *
+   * Error contract (shared by all three viewers): on failure, if an `onError`
+   * callback was provided it is invoked and `load` resolves normally; if not,
+   * the error is rethrown so it is never silently swallowed.
+   */
   async load(source: string | ArrayBuffer): Promise<void> {
     try {
       this.wb = await XlsxWorkbook.load(source, {
@@ -274,7 +281,12 @@ export class XlsxViewer {
       this.opts.onReady?.(this.wb.sheetNames);
       await this.showSheet(0);
     } catch (err) {
-      this.opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+      const e = err instanceof Error ? err : new Error(String(err));
+      if (this.opts.onError) {
+        this.opts.onError(e);
+        return;
+      }
+      throw e;
     }
   }
 
@@ -1176,6 +1188,11 @@ export class XlsxViewer {
 
   get sheetNames(): string[] {
     return this.wb?.sheetNames ?? [];
+  }
+
+  /** The underlying <canvas> element the grid is drawn on. */
+  get canvasElement(): HTMLCanvasElement {
+    return this.canvas;
   }
 
   destroy(): void {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -311,6 +311,34 @@ export class XlsxViewer {
     this.opts.onSheetChange?.(index, this.workbook.sheetNames[index] ?? '');
   }
 
+  /** 0-based index of the currently displayed sheet. */
+  get sheetIndex(): number {
+    return this.currentSheet;
+  }
+
+  /** Total number of sheets in the loaded workbook. */
+  get sheetCount(): number {
+    return this.wb?.sheetCount ?? 0;
+  }
+
+  /**
+   * Navigate to a sheet by index, clamped to range. Canonical navigation verb
+   * matching {@link PptxViewer.goToSlide} / {@link DocxViewer.goToPage};
+   * {@link showSheet} is the lower-level form that assumes a valid index.
+   */
+  async goToSheet(index: number): Promise<void> {
+    if (this.sheetCount === 0) return;
+    await this.showSheet(Math.max(0, Math.min(index, this.sheetCount - 1)));
+  }
+
+  async nextSheet(): Promise<void> {
+    await this.goToSheet(this.currentSheet + 1);
+  }
+
+  async prevSheet(): Promise<void> {
+    await this.goToSheet(this.currentSheet - 1);
+  }
+
   /** Returns the cell at canvas-client coordinates, or null if outside the cell grid. */
   getCellAt(clientX: number, clientY: number): CellAddress | null {
     const ws = this.currentWorksheet;

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -127,7 +127,7 @@ function getSheetAxes(ws: Worksheet, mdw: number): SheetAxes {
 }
 
 export class XlsxViewer {
-  private wb: XlsxWorkbook;
+  private wb: XlsxWorkbook | null = null;
   private canvas: HTMLCanvasElement;
   private canvasArea: HTMLDivElement;
   private scrollHost: HTMLDivElement;
@@ -160,7 +160,6 @@ export class XlsxViewer {
 
   constructor(container: HTMLElement, opts: XlsxViewerOptions = {}) {
     this.opts = opts;
-    this.wb = new XlsxWorkbook();
 
     const wrapper = document.createElement('div');
     wrapper.style.cssText =
@@ -267,7 +266,7 @@ export class XlsxViewer {
 
   async load(source: string | ArrayBuffer): Promise<void> {
     try {
-      await this.wb.load(source, {
+      this.wb = await XlsxWorkbook.load(source, {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
       });
@@ -279,6 +278,12 @@ export class XlsxViewer {
     }
   }
 
+  /** The loaded workbook, or throws if {@link load} has not completed. */
+  private get workbook(): XlsxWorkbook {
+    if (!this.wb) throw new Error('Workbook not loaded');
+    return this.wb;
+  }
+
   async showSheet(index: number): Promise<void> {
     this.currentSheet = index;
     this.scrollHost.scrollLeft = 0;
@@ -288,10 +293,10 @@ export class XlsxViewer {
     this.selectionMode = 'cells';
     this.updateSelectionOverlay();
     this.updateTabActive(index);
-    this.currentWorksheet = await this.wb.getWorksheet(index);
+    this.currentWorksheet = await this.workbook.getWorksheet(index);
     this.updateSpacerSize(this.currentWorksheet);
     await this.renderCurrentSheet();
-    this.opts.onSheetChange?.(index, this.wb.sheetNames[index] ?? '');
+    this.opts.onSheetChange?.(index, this.workbook.sheetNames[index] ?? '');
   }
 
   /** Returns the cell at canvas-client coordinates, or null if outside the cell grid. */
@@ -809,8 +814,8 @@ export class XlsxViewer {
   private buildTabs(): void {
     this.tabStrip.innerHTML = '';
     this.tabs = [];
-    this.tabColors = this.wb.tabColors;
-    this.wb.sheetNames.forEach((name, i) => {
+    this.tabColors = this.workbook.tabColors;
+    this.workbook.sheetNames.forEach((name, i) => {
       const btn = document.createElement('button');
       btn.textContent = name;
       btn.title = name;
@@ -1119,7 +1124,7 @@ export class XlsxViewer {
 
     const { selectedRowRange, selectedColRange } = this.computeHeaderHighlight();
 
-    await this.wb.renderViewport(this.canvas, this.currentSheet, viewport, {
+    await this.workbook.renderViewport(this.canvas, this.currentSheet, viewport, {
       width: w,
       height: h,
       dpr,
@@ -1170,7 +1175,7 @@ export class XlsxViewer {
   }
 
   get sheetNames(): string[] {
-    return this.wb.sheetNames;
+    return this.wb?.sheetNames ?? [];
   }
 
   destroy(): void {
@@ -1178,6 +1183,6 @@ export class XlsxViewer {
     if (this.keydownHandler) {
       document.removeEventListener('keydown', this.keydownHandler);
     }
-    this.wb.destroy();
+    this.wb?.destroy();
   }
 }

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -27,17 +27,9 @@ const XLSX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   },
 };
 
-/** Options for {@link XlsxWorkbook.load}. Extends the shared
- *  `LoadOptions` shape from `@silurus/ooxml-core`. */
-export interface LoadOptions extends CoreLoadOptions {
-  /**
-   * Override the per-entry ZIP decompression cap (bytes) used by the
-   * zip-bomb guard in the Rust parser. Defaults to 512 MiB. Applies to both
-   * the initial workbook parse and per-sheet parse. Zero / negative values
-   * fall back to the default.
-   */
-  maxZipEntryBytes?: number;
-}
+/** Options for {@link XlsxWorkbook.load}. The shared load-options type from
+ *  `@silurus/ooxml-core` (`useGoogleFonts`, `maxZipEntryBytes`). */
+export type LoadOptions = CoreLoadOptions;
 
 export class XlsxWorkbook {
   private worker: Worker;

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -1,6 +1,11 @@
 import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/xlsx_parser_bg.wasm?url';
-import { preloadGoogleFonts, type FontPreloadEntry, type LoadOptions as CoreLoadOptions } from '@silurus/ooxml-core';
+import {
+  preloadGoogleFonts,
+  WorkerBridge,
+  type FontPreloadEntry,
+  type LoadOptions as CoreLoadOptions,
+} from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, WorkerResponse } from './types.js';
 import { renderViewport } from './renderer.js';
 
@@ -36,6 +41,7 @@ export interface LoadOptions extends CoreLoadOptions {
 
 export class XlsxWorkbook {
   private worker: Worker;
+  private bridge: WorkerBridge<WorkerResponse>;
   private parsedWorkbook: ParsedWorkbook | null = null;
   private sheetCache = new Map<number, Worksheet>();
   /** Cache of loaded images keyed by their data URL. Shared across sheets. */
@@ -43,24 +49,41 @@ export class XlsxWorkbook {
   private rawData: ArrayBuffer | null = null;
   private maxZipEntryBytes: number | undefined;
 
-  constructor() {
+  private constructor() {
     this.worker = new InlineWorker();
+    this.bridge = new WorkerBridge<WorkerResponse>(this.worker, {
+      correlate: (res) => res.id,
+      toError: (res) => (res.type === 'error' ? res.message : undefined),
+    });
     const wasmUrl = new URL(wasmAssetUrl, location.href).href;
-    this.worker.postMessage({ type: 'init', wasmUrl });
+    this.bridge.post({ type: 'init', wasmUrl });
   }
 
-  async load(source: string | ArrayBuffer, opts: LoadOptions = {}): Promise<void> {
-    const data =
-      typeof source === 'string'
-        ? await fetch(source).then((r) => r.arrayBuffer())
-        : source;
+  /** Parse an XLSX from a URL or ArrayBuffer. */
+  static async load(source: string | ArrayBuffer, opts: LoadOptions = {}): Promise<XlsxWorkbook> {
+    const wb = new XlsxWorkbook();
+    await wb._load(source, opts);
+    return wb;
+  }
+
+  private async _load(source: string | ArrayBuffer, opts: LoadOptions = {}): Promise<void> {
+    let data: ArrayBuffer;
+    if (typeof source === 'string') {
+      const res = await fetch(source);
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
+      data = await res.arrayBuffer();
+    } else {
+      data = source;
+    }
     this.rawData = data;
     this.maxZipEntryBytes = opts.maxZipEntryBytes;
-    this.parsedWorkbook = await this.sendMessage({
+    const parsed = await this.bridge.request((id) => ({
       type: 'parse',
+      id,
       data: data.slice(0),
       maxZipEntryBytes: this.maxZipEntryBytes,
-    }) as ParsedWorkbook;
+    }));
+    this.parsedWorkbook = (parsed as Extract<WorkerResponse, { type: 'parsed' }>).workbook;
     if (opts.useGoogleFonts) {
       // Walk every styled font in the workbook and queue Google Fonts
       // substitutes for any Office faces (Calibri → Carlito, Cambria →
@@ -89,22 +112,24 @@ export class XlsxWorkbook {
   }
 
   async getWorksheet(sheetIndex: number): Promise<Worksheet> {
-    if (this.sheetCache.has(sheetIndex)) {
-      return this.sheetCache.get(sheetIndex)!;
-    }
+    const cached = this.sheetCache.get(sheetIndex);
+    if (cached) return cached;
     if (!this.parsedWorkbook || !this.rawData) {
       throw new Error('Workbook not loaded');
     }
+    const rawData = this.rawData;
     const sheetMeta = this.parsedWorkbook.workbook.sheets[sheetIndex];
     if (!sheetMeta) throw new Error(`Sheet index ${sheetIndex} out of range`);
 
-    const ws = await this.sendMessage({
+    const res = await this.bridge.request((id) => ({
       type: 'parseSheet',
-      data: this.rawData.slice(0),
+      id,
+      data: rawData.slice(0),
       sheetIndex,
       sheetName: sheetMeta.name,
       maxZipEntryBytes: this.maxZipEntryBytes,
-    }) as Worksheet;
+    }));
+    const ws = (res as Extract<WorkerResponse, { type: 'parsedSheet' }>).worksheet;
     this.sheetCache.set(sheetIndex, ws);
     return ws;
   }
@@ -188,23 +213,6 @@ export class XlsxWorkbook {
   }
 
   destroy(): void {
-    this.worker.terminate();
-  }
-
-  private sendMessage(req: object): Promise<ParsedWorkbook | Worksheet> {
-    return new Promise((resolve, reject) => {
-      const handler = (e: MessageEvent<WorkerResponse>) => {
-        this.worker.removeEventListener('message', handler);
-        if (e.data.type === 'error') {
-          reject(new Error(e.data.message));
-        } else if (e.data.type === 'parsed') {
-          resolve(e.data.workbook);
-        } else if (e.data.type === 'parsedSheet') {
-          resolve(e.data.worksheet);
-        }
-      };
-      this.worker.addEventListener('message', handler);
-      this.worker.postMessage(req);
-    });
+    this.bridge.terminate();
   }
 }

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -1,17 +1,8 @@
 import init, { parse_xlsx, parse_sheet } from './wasm/xlsx_parser.js';
+import { decodeDataUrl } from '@silurus/ooxml-core';
 import type { WorkerRequest, WorkerResponse } from './types.js';
 
 let initPromise: Promise<unknown> | null = null;
-
-function decodeDataUrl(url: string): ArrayBuffer | null {
-  if (!url.startsWith('data:')) return null;
-  const comma = url.indexOf(',');
-  if (comma === -1) return null;
-  const binary = atob(url.slice(comma + 1));
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes.buffer;
-}
 
 self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;
@@ -21,6 +12,9 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
     return;
   }
 
+  // Every non-init request carries a correlation id that must be echoed back so
+  // the client can route the response to the right pending promise.
+  const id = req.id;
   try {
     await initPromise;
     if (req.type === 'parse') {
@@ -30,7 +24,7 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
           : undefined;
       const json = parse_xlsx(new Uint8Array(req.data), maxBytes);
       const workbook = JSON.parse(json);
-      const res: WorkerResponse = { type: 'parsed', workbook };
+      const res: WorkerResponse = { type: 'parsed', id, workbook };
       self.postMessage(res);
     } else if (req.type === 'parseSheet') {
       const maxBytes =
@@ -39,11 +33,11 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
           : undefined;
       const json = parse_sheet(new Uint8Array(req.data), req.sheetIndex, req.sheetName, maxBytes);
       const worksheet = JSON.parse(json);
-      const res: WorkerResponse = { type: 'parsedSheet', worksheet };
+      const res: WorkerResponse = { type: 'parsedSheet', id, worksheet };
       self.postMessage(res);
     }
   } catch (err) {
-    const res: WorkerResponse = { type: 'error', message: String(err) };
+    const res: WorkerResponse = { type: 'error', id, message: String(err) };
     self.postMessage(res);
   }
 };

--- a/packages/xlsx/tests/visual/fixture.html
+++ b/packages/xlsx/tests/visual/fixture.html
@@ -32,8 +32,7 @@
   canvas.style.height = height + 'px';
 
   try {
-    const wb = new XlsxWorkbook();
-    await wb.load('/' + file);
+    const wb = await XlsxWorkbook.load('/' + file);
     const idx = Math.max(0, Math.min(sheet, wb.sheetNames.length - 1));
     await wb.renderViewport(canvas, idx, { row, col, rows, cols }, { width, height, dpr: 1 });
     document.body.dataset.status = 'ready';


### PR DESCRIPTION
## Summary

v1.0 に向けた API/設計の一貫性監査で洗い出した不統一・設計の歪みをまとめて解消する。外部 API はここで凍結される前提で、後から直すと breaking change になる項目を優先的に対応した。各コミットは独立した論理単位（merge commit 前提、squash 不可）。

## 対応した項目

**A. リリースブロッカー級のバグ**
- **Worker レスポンスの取り違え/ハング** (`fix(core)`): xlsx/docx は応答を `type` だけで突き合わせる one-shot リスナーで、並行リクエスト時に別呼び出しのデータで resolve したり未知 type で永久 pending になっていた。pptx と同じ **request-id 相関**へ統一。protocol 非依存の共有 `WorkerBridge`（+9 unit tests）を core に新設し3パッケージを載せ替え、重複していた `decodeDataUrl` も core へ集約。

**B. 公開 API の不統一（凍結前に必須）**
- `XlsxWorkbook` を `private constructor + static load()` へ（pptx/docx と統一。旧 `new + load()` は壊れる別系統だった）。
- `DocxViewer.destroy()` 追加（worker リーク修正）、`onError`/`onPageChange` 追加。
- `load()` のエラー契約を3 viewer で統一: **onError があれば呼んで resolve、無ければ rethrow**（従来 pptx=rethrow / xlsx=握り潰し / docx=未処理）。
- 同名異義の公開型を解消: `LoadOptions` を core 1 本に集約（`maxZipEntryBytes` を core へ）、xlsx `Fill`/`Font`→`CellFill`/`CellFont`、`TextRunInfo`→`Pptx`/`Xlsx`/`Docx` prefix、docx `TextRun`→`DocxTextRun`、docx データ型 `Document`→`DocxDocumentModel`（DOM グローバルの shadow 解消）。
- `XlsxViewer` に `goToSheet`/`nextSheet`/`prevSheet`/`sheetIndex`/`sheetCount`、各 viewer に `canvasElement` を追加（ナビ動詞・アクセサの整合）。

**C. 横断インフラの集約**
- pt→px・EMU 定数の4通りの綴りを `core/units.ts`（`PT_TO_PX`/`EMU_PER_*`）に一元化。

**D. 片付け**
- core/index.ts を `export *` から明示 export へ、docx tsconfig を base 継承へ、残存の非 null assertion `!` を除去。

## 検証

- `pnpm typecheck` ✅ / `pnpm test` ✅ (71 passed, WorkerBridge の 9 件含む) / `pnpm lint` ✅
- VRT: **pptx 69/69 pass**、**docx 19/19 pass**。xlsx は demo の match% が base と完全一致＝**描画中立**を確認（worker 移行・単位統一でピクセル変化なし）。
- Storybook 実描画で pptx サムネイル並行描画・docx 複数ページ・xlsx 高速シート切替（並行 parseSheet）を確認。

## 既知の事項（本 PR 対象外）
- xlsx demo sample-1 sheet 1/2 の VRT が fidelity 閾値(20%)を超過しているのは **base(release/0.44.0) でも同じ既存状態**で、本 PR の変更とは無関係（参照画像は方針により未更新）。
- 見送った項目（リスク/工数のため follow-up 推奨）: pptx `renderSlide` の OffscreenCanvas 対応（renderer が offsetWidth/window 依存）、font-metrics の3実装統合（docx 行高比 / xlsx MDW / pptx fallback は別概念で安易な共通化は不適）、`.js` import 拡張子の全面統一（現行 bundler resolution では無害なため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
