### PR TITLE
fix(build): stop publishing sample fixtures and inlining MathJax everywhere

### DIFF
--- a/packages/core/src/math/mathjax.ts
+++ b/packages/core/src/math/mathjax.ts
@@ -1,23 +1,31 @@
 // MathJax turns MathML into an SVG string that the consumer rasterizes onto the canvas.
 //
-// MathJax is loaded lazily AT RUNTIME from a CDN (no npm dependency) so that:
-//   1. bundlers in consuming apps have no bare `mathjax-*` import to resolve, and
-//   2. we use maintained MathJax v4 rather than the frozen/superseded `mathjax-full` v3.
-// Browser-only (it needs a DOM); the load is triggered only when a document actually
-// contains equations. The URL is overridable for self-hosting / offline.
+// The MathJax v3 `mml-svg` component is vendored in this package (../../assets/mathjax),
+// is self-contained (glyph outlines inlined, ZERO runtime network), and is loaded lazily
+// only when a document actually contains equations. Browser-only (it needs a DOM). The
+// URL is overridable via `setMathJaxUrl` for self-hosting / a pinned CDN copy.
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-// Default to the MathJax v4 component bundled with this package (Apache-2.0), resolved
-// to a same-origin asset URL by the consumer's bundler (Vite/webpack/rollup all handle
+// The MathJax v3 component bundled with this package (Apache-2.0) is resolved to a
+// same-origin asset URL by the consumer's bundler (Vite/webpack/rollup all handle
 // `new URL(asset, import.meta.url)`). This makes math a built-in feature with no
 // cross-origin request. `setMathJaxUrl` overrides it (e.g. a CDN or pinned copy).
-let mathJaxUrl: string = new URL('../../assets/mathjax/mml-svg.js', import.meta.url).href;
+//
+// IMPORTANT: the `new URL(...)` lives inside `resolveMathJaxUrl()` rather than at module
+// scope so that bundles which never call into the math pipeline (the pptx/xlsx viewers)
+// tree-shake the whole module out and don't inline the ~2.5MB MathJax asset.
+let mathJaxUrlOverride: string | null = null;
 let mjPromise: Promise<any> | null = null;
+
+function resolveMathJaxUrl(): string {
+  if (mathJaxUrlOverride) return mathJaxUrlOverride;
+  return new URL('../../assets/mathjax/mml-svg.js', import.meta.url).href;
+}
 
 /** Override the MathJax script URL (e.g. a CDN or self-hosted copy). Call before load. */
 export function setMathJaxUrl(url: string): void {
-  mathJaxUrl = url;
+  mathJaxUrlOverride = url;
 }
 
 function loadScript(src: string): Promise<void> {
@@ -51,7 +59,7 @@ async function ensureMathJax(): Promise<any> {
       // No a11y menu / speech-rule worker — keeps it fully offline (no extra fetches).
       options: { ...(w.MathJax?.options || {}), enableMenu: false },
     };
-    await loadScript(mathJaxUrl);
+    await loadScript(resolveMathJaxUrl());
     await w.MathJax.startup.promise;
     return w.MathJax;
   })();

--- a/packages/docx/vite.config.ts
+++ b/packages/docx/vite.config.ts
@@ -9,6 +9,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   root: __dirname,
   plugins: [wasm(), topLevelAwait()],
+  // Don't copy public/ (sample .docx fixtures) into the published dist/.
+  publicDir: false,
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),

--- a/packages/pptx/vite.config.ts
+++ b/packages/pptx/vite.config.ts
@@ -11,6 +11,8 @@ const dirname =
 
 export default defineConfig({
   plugins: [wasm()],
+  // Don't copy public/ (sample .pptx fixtures) into the published dist/.
+  publicDir: false,
   server: {
     fs: {
       // Include monorepo root so node_modules/.pnpm/ fontsource files can be served

--- a/packages/xlsx/vite.config.ts
+++ b/packages/xlsx/vite.config.ts
@@ -12,6 +12,8 @@ const dirname =
 export default defineConfig({
   plugins: [wasm()],
   root: dirname,
+  // Don't copy public/ (sample .xlsx fixtures) into the published dist/.
+  publicDir: false,
   server: { port: 5175, strictPort: true },
   build: {
     lib: {


### PR DESCRIPTION
## Why

Published bundles ballooned to ~25 MB and — worse — leaked non-redistributable sample binaries onto npm.

Two independent causes:

1. **Vite `publicDir` default.** Each viewer's `public/` dir (demo **and** private `.pptx`/`.docx`/`.xlsx` fixtures — ~227 MB for pptx alone) was copied verbatim into `dist/`. This both bloated the packages and shipped files we must not redistribute.
2. **MathJax inlined into every viewer.** `core/src/math/mathjax.ts` resolved the ~2.5 MB bundled MathJax asset with a *module-level* `new URL(...)`. Vite's asset handling then inlined that blob into every bundle re-exporting core — including the non-math pptx/xlsx viewers.

## Fix

- `publicDir: false` on the docx/pptx/xlsx vite configs.
- Move `new URL('../../assets/mathjax/mml-svg.js', import.meta.url)` into a lazily-called `resolveMathJaxUrl()` so non-math bundles tree-shake it out.

## Result (compressed npm tarballs)

| pkg | before | after |
|-----|--------|-------|
| core | 779 KB | 779 KB |
| docx | bloated + samples | **3.0 MB** (bundles offline MathJax, by design) |
| pptx | bloated + samples | **1.47 MB** |
| xlsx | bloated + samples | **1.58 MB** |

MathJax is now present **only** in docx; **no** sample binaries appear in any tarball. `pnpm test` → 71 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)