### PR TITLE
chore(release): 0.47.0 — ESM-only distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.47.0 — 2026-06-04
+
+Packaging: **ESM-only distribution.**
+
+- The published `@silurus/ooxml` bundle inlines a large math-typesetting engine;
+  emitting a duplicate CommonJS copy of every chunk roughly doubled the package.
+  We now ship **`.mjs` only** (no `.cjs`), halving the package: unpacked
+  22.3 MB → 11.3 MB, tarball 8.4 MB → 4.3 MB.
+- **Breaking** for `require('@silurus/ooxml/…')` (CommonJS) consumers — use an
+  `import` instead. Every modern bundler (Vite / webpack / Rollup / esbuild /
+  Next) and Node ≥ 20 consume ESM, and the documented examples already use
+  `import`.
+
 ## 0.46.0 — 2026-06-04
 
 PowerPoint equation rendering, and a new shared math font.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",
@@ -36,22 +36,18 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
       "types": "./dist/types/index.d.ts"
     },
     "./docx": {
       "import": "./dist/docx.mjs",
-      "require": "./dist/docx.cjs",
       "types": "./dist/types/docx.d.ts"
     },
     "./xlsx": {
       "import": "./dist/xlsx.mjs",
-      "require": "./dist/xlsx.cjs",
       "types": "./dist/types/xlsx.d.ts"
     },
     "./pptx": {
       "import": "./dist/pptx.mjs",
-      "require": "./dist/pptx.cjs",
       "types": "./dist/types/pptx.d.ts"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,8 +31,12 @@ export default defineConfig({
         xlsx:  resolve(__dirname, 'src/xlsx.ts'),
         docx:  resolve(__dirname, 'src/docx.ts'),
       },
-      formats: ['es', 'cjs'],
-      fileName: (format, name) => `${name}.${format === 'es' ? 'mjs' : 'cjs'}`,
+      // ESM-only: the published bundle inlines a large math engine; emitting a
+      // duplicate CJS copy of every chunk roughly doubled the package size.
+      // Every modern bundler (Vite / webpack / Rollup / esbuild / Next) and
+      // Node ≥ 20 consume ESM, so we ship `.mjs` only.
+      formats: ['es'],
+      fileName: (_format, name) => `${name}.mjs`,
     },
     rollupOptions: {
       output: { assetFileNames: '[name][extname]' },


### PR DESCRIPTION
## 0.47.0 — ESM-only (package size halved)

The published `@silurus/ooxml` bundle inlines a large math-typesetting engine (MathJax + STIX Two Math, baked in for offline use). Vite's lib mode base64-inlines that asset, and emitting a **duplicate CommonJS copy** of every chunk roughly doubled the package.

**Fix: ship `.mjs` only.**

| | before | after |
|---|---|---|
| unpacked | 22.3 MB | **11.3 MB** |
| tarball (download) | 8.4 MB | **4.3 MB** |

### Changes
- `vite.config.ts`: lib `formats: ['es']`.
- `package.json` `exports`: drop the `require` (cjs) conditions (keep `import` + `types`).
- Version bump: all 8 packages → 0.47.0; CHANGELOG entry.

### Breaking
- `require('@silurus/ooxml/…')` (CommonJS) no longer resolves — use `import`. Every modern bundler (Vite / webpack / Rollup / esbuild / Next) and Node ≥ 20 consume ESM, and the documented examples already use `import`.

Verified: build emits `.mjs` only (single shared `mathjax` chunk, no cjs duplicate), entries + types intact, 71 tests pass.

Merge with `--merge`, then tag `v0.47.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)