### PR TITLE
chore(release): 0.48.0 — trim non-math glyph ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.48.0 — 2026-06-04
+
+Packaging: **smaller math engine.**
+
+- The bundled STIX Two Math font now ships only the math-relevant glyph ranges;
+  non-math ranges (Cyrillic, phonetics, dingbats, accented-Latin variants) are
+  omitted. Math italic variables, Greek, blackboard-bold, script, fraktur,
+  sans-serif/monospace variants, operators, arrows, accents and stretchy
+  delimiters are all retained. Engine asset 4.2 MB → 3.0 MB; package unpacked
+  11.3 MB → 9.6 MB, tarball 4.3 MB → 3.7 MB.
+- Edge case: an equation using a non-Latin/non-math alphabet (e.g. a Cyrillic
+  variable) would now show a missing glyph; such usage is vanishingly rare in
+  OOXML math.
+
 ## 0.47.0 — 2026-06-04
 
 Packaging: **ESM-only distribution.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/build/stix2-entry.mjs
+++ b/packages/core/build/stix2-entry.mjs
@@ -1,11 +1,13 @@
 // Entry for the pre-bundled MathJax v4 + STIX Two Math converter.
 //
 // esbuild bundles this (and only this) into `assets/mathjax-stix2.js`, an
-// opaque, tree-shaken, minified IIFE (~1.7 MB). The renderer loads that asset
+// opaque, tree-shaken, minified IIFE (~3 MB). The renderer loads that asset
 // lazily, so it never bloats non-math viewers and is never re-bundled by the
-// consuming app's bundler. The STIX2 font is baked in statically: every glyph
-// range is imported up-front so `dynamicSetup` marks it loaded → DOM-free,
-// zero network, zero cross-origin (no on-demand range fetches).
+// consuming app's bundler. The STIX2 font is baked in statically: the
+// math-relevant glyph ranges below are imported up-front so `dynamicSetup`
+// marks them loaded → DOM-free, zero network, zero cross-origin (no on-demand
+// range fetches). Non-math ranges (cyrillic, phonetics, dingbats, accented
+// Latin variants) are intentionally omitted to keep the bundle small.
 import { mathjax } from '@mathjax/src/mjs/mathjax.js';
 import { MathML } from '@mathjax/src/mjs/input/mathml.js';
 import { SVG } from '@mathjax/src/mjs/output/svg.js';
@@ -16,19 +18,12 @@ import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/accents-other.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/accents.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/arrows.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/calligraphic.js';
-import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/cyrillic.js';
-import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/dingbats.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/double-struck.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/enclosed.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/fraktur.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/greek.js';
-import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/latin-b.js';
-import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/latin-bi.js';
-import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/latin-i.js';
-import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/latin.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/math.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/monospace.js';
-import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/phonetics.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/sans-serif.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/script.js';
 import '@mathjax/mathjax-stix2-font/mjs/svg/dynamic/shapes.js';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
## 0.48.0 — smaller math engine

The bundled STIX Two Math font shipped all 25 glyph ranges. The non-math ones (Cyrillic, phonetics, dingbats, accented-Latin variants) are never used in OOXML equations, so they're dropped.

| | 0.47.0 | 0.48.0 |
|---|---|---|
| engine asset | 4.2 MB | **3.0 MB** |
| unpacked | 11.3 MB | **9.6 MB** |
| tarball | 4.3 MB | **3.7 MB** |

(Combined with 0.47.0's ESM-only change: 22.3 MB → 9.6 MB unpacked, 8.4 MB → 3.7 MB tarball overall.)

### Retained (verified rendering as `<path>` on sample-8)
math italic variables, Greek, blackboard-bold (ℝ), script/calligraphic (ℒ/𝒞), fraktur (𝔄), sans-serif, monospace, symbols, arrows, accents/overbars, stretchy delimiters/norms, shapes, enclosed, variants. Slide 11 (script + ∀⊆∈⇒ callout) and slide 5 (norms/overbars) render identically — no regressions.

### Edge case
An equation using a non-Latin alphabet as a variable (e.g. a Cyrillic letter) would now show a missing glyph — vanishingly rare in OOXML math.

Merge with `--merge`, then tag `v0.48.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)