### PR TITLE
chore(release): 0.48.1 — fix README bundle-size note (ESM-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.48.1 — 2026-06-04
+
+Docs: correct the README "Bundle size note" — the package became ESM-only in
+0.47.0, so the note no longer describes a CJS output or "single module format"
+tree-shaking; it now reflects the ESM-only bundle and the shared, lazily-loaded
+math engine.
+
 ## 0.48.0 — 2026-06-04
 
 Packaging: **smaller math engine.**

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pnpm add @silurus/ooxml
 
 > **Bundler note**: this package embeds `.wasm` files. With Vite add [`vite-plugin-wasm`](https://github.com/Menci/vite-plugin-wasm); with webpack use [`experiments.asyncWebAssembly`](https://webpack.js.org/configuration/experiments/).
 
-> **Bundle size note**: npm's *Unpacked Size* figure sums ES (`.mjs`) and CJS (`.cjs`) outputs for all three formats. The size that actually lands in your app is much smaller — import only the format you need (e.g. `@silurus/ooxml/pptx`) and your bundler picks a single module format, so tree-shaking drops the other two formats entirely.
+> **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked Size* sums all three format bundles plus the statically-bundled math engine (MathJax + STIX Two Math, ~3 MB) used to render OOXML equations. What actually lands in your app is much smaller — import only the format you need (e.g. `@silurus/ooxml/pptx`), and the math engine is a shared chunk loaded lazily, only when a document contains equations (docx / pptx). It is tree-shaken away entirely for xlsx.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
## 0.48.1 — docs patch

The README **Bundle size note** was stale after 0.47.0 made the package ESM-only — it still claimed npm's *Unpacked Size* "sums ES (`.mjs`) and CJS (`.cjs`) outputs" and that tree-shaking "drops the other two module formats". There is no CJS output anymore.

Rewritten to reflect:
- ESM-only (`.mjs`) distribution.
- Unpacked size = the three format bundles + the statically-bundled math engine (MathJax + STIX Two Math, ~3 MB).
- The math engine is a shared chunk, loaded lazily only when a document has equations (docx/pptx), and tree-shaken away entirely for xlsx.

Republished (version bump → 0.48.1) so the npm README reflects the correction. Verified the rest of the README (Quick Start uses `import`, Feature Support has the pptx Math row, no stale CJS/version claims).

Merge with `--merge`, then tag `v0.48.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)