### PR TITLE
fix(site): pptx master-detail large preview fills its pane

### DIFF
--- a/site/src/lib/demo-snippets.ts
+++ b/site/src/lib/demo-snippets.ts
@@ -65,7 +65,7 @@ for (let i = 0; i < doc.${c.count}; i++) {
     masterdetail: `import { ${c.Doc}, ${c.Viewer} } from '@silurus/ooxml/${c.sub}';
 
 // A large preview viewer on the right…
-const viewer = new ${c.Viewer}(detailCanvas, { width: 820, enableTextSelection: true });
+const viewer = new ${c.Viewer}(detailCanvas, { width: 960, enableTextSelection: true });
 
 // …and a thumbnail rail on the left, sharing the same file.
 const [doc] = await Promise.all([

--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -160,7 +160,7 @@ function mountMasterDetail(el: HTMLElement, format: Format, url: string): void {
   el.appendChild(layout);
   const st = status(el, 'Loading…');
 
-  const viewer = makeViewer(format, detailCanvas, 820);
+  const viewer = makeViewer(format, detailCanvas, 960);
   Promise.all([loadDoc(format, url), viewer.load(url)])
     .then(async ([doc]) => {
       st.remove();

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -257,8 +257,8 @@ h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
 .demo-rail-cell { cursor: pointer; border-radius: 5px; outline: 2px solid transparent; transition: outline-color 0.15s; }
 .demo-rail-cell .demo-page { width: 100%; height: auto; }
 .demo-rail-cell.active { outline-color: var(--accent); }
-.demo-detail { flex: 1 1 auto; overflow: auto; padding: 22px; display: flex; justify-content: center; align-items: flex-start; }
-.demo-detail .demo-page { width: 100%; max-width: 640px; height: auto; }
+.demo-detail { flex: 1 1 auto; overflow: auto; padding: 22px; display: flex; justify-content: center; align-items: center; }
+.demo-detail .demo-page { width: 100%; max-width: 960px; height: auto; }
 
 /* xlsx full viewer */
 .demo-xlsx { width: 100%; height: 560px; background: #fff; }


### PR DESCRIPTION
## Problem

On the `/pptx` docs page, the **Thumbnail rail + large preview** (master-detail) demo rendered the large preview slide noticeably smaller than the available preview area.

Measured at a 1280px viewport: the detail pane is ~816px wide × 516px tall, but the slide was capped at **640×360** and top-aligned — leaving ~176px of empty space on the right and ~156px below.

## Fix

- `.demo-detail .demo-page`: `max-width` 640px → **960px** so the slide fills the pane width.
- `.demo-detail`: `align-items` flex-start → **center** so any residual vertical slack is balanced.
- Detail render width 820 → **960** (`mountMasterDetail`) to stay crisp at the larger display size.
- Sync the displayed code snippet's `width` to 960.

After: a 16:9 slide fills the pane **100% × 100%** (verified live at 1280px). Narrower viewports scale down proportionally and stay centered.

Site-only change; unrelated to the math-engine PR (#341).

🤖 Generated with [Claude Code](https://claude.com/claude-code)