### PR TITLE
chore(release): 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.49.0 — 2026-06-04
+
+Packaging: **the math engine is now opt-in.** ⚠️ Breaking change.
+
+- The MathJax + STIX Two Math engine (~3 MB) was statically imported by the
+  docx/pptx renderers, so every consumer shipped it in their initial bundle even
+  with no equations. It now lives behind a separate entry point,
+  `@silurus/ooxml/math`, exposing a named `math` engine. Pass it to a viewer to
+  render equations; omit it and a bundler tree-shakes the ~3 MB away entirely.
+
+  ```ts
+  import { DocxViewer } from '@silurus/ooxml/docx';
+  import { math } from '@silurus/ooxml/math';
+  new DocxViewer(canvas, { math });
+  ```
+
+  Works for `PptxViewer` and the headless `DocxDocument` / `PptxPresentation`
+  APIs (all take `math` in their options). xlsx never references the engine.
+- **Migration**: equations in docx/pptx no longer render automatically — add the
+  `@silurus/ooxml/math` import and pass `math`. No change needed if you don't use
+  equations (and you no longer pay the ~3 MB for them).
+- Docs site: the "Try yours" page enables equation rendering; the pptx
+  master-detail demo's large preview now fills its pane.
+- Repo hygiene: internal design/plan/dev-note docs (`docs/superpowers/`,
+  `docs/dev-notes/`) are no longer tracked.
+
 ## 0.48.1 — 2026-06-04
 
 Docs: correct the README "Bundle size note" — the package became ESM-only in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
## 0.49.0 — opt-in math engine

Headline: the MathJax + STIX Two Math engine (~3 MB) is now an **opt-in, tree-shakeable** entry point (`@silurus/ooxml/math`) instead of being statically bundled into the docx/pptx renderers.

```ts
import { DocxViewer } from '@silurus/ooxml/docx';
import { math } from '@silurus/ooxml/math';
new DocxViewer(canvas, { math });
```

### ⚠️ Breaking change
Equations in docx/pptx no longer render automatically. Import `{ math }` from `@silurus/ooxml/math` and pass it as the viewer/load `math` option. No change (and no ~3 MB cost) if you don't use equations.

### Included since 0.48.1
- Math opt-in engine (#341) — DI via a named `math` export; verified the engine asset lands only in `math.mjs` and docx/pptx exclude it; equation fidelity confirmed on sample-8.
- "Try yours" docs page renders equations (#341).
- pptx master-detail large preview fills its pane (#342).
- Internal design/plan/dev-note docs untracked (#343).

### Release bookkeeping
- Version bump to 0.49.0 across root + packages/{core,pptx,xlsx,docx,markdown,node,vscode-extension} (8 files).
- CHANGELOG 0.49.0 section with migration note.
- README already carries the "Rendering equations" section + corrected bundle-size note; site api-reference documents the `math` option (incl. PptxPresentation.renderSlide). Verified README integrity (bundle-size note, named-import examples, feature table, no stale patterns).
- Screenshots (`docs/images/*.png`) unchanged — the feature doesn't alter the existing non-equation demo samples.

Tag `v0.49.0` after merge triggers npm publish, VS Code Marketplace publish, Pages deploy, and MCP binary release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)