### PR TITLE
feat(docx): split tables taller than a page across page boundaries

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -530,11 +530,22 @@ export function computePages(
       prevSpaceAfter = para.spaceAfter;
     } else if (el.type === 'table') {
       const tbl = el as unknown as DocTable;
-      const h = estimateTableHeight(measureState, tbl, contentW);
-      if (y + h > contentH) newPage();
-      pages[pages.length - 1].push(el);
-      y += h;
-      measureState.y += h;
+      const rowHs = computeTableRowHeights(measureState, tbl, contentW);
+      const h = rowHs.reduce((s, x) => s + x, 0);
+      if (h > contentH) {
+        // Taller than a full page: split row-by-row so the overflow continues
+        // onto the next page instead of being clipped (ECMA-376 table
+        // pagination). Tables that fit on a page keep the simple place-whole
+        // path below.
+        const endY = splitTableAcrossPages(tbl, rowHs, y, contentH, pages, () => newPage());
+        y = endY;
+        measureState.y = section.marginTop + endY;
+      } else {
+        if (y + h > contentH) newPage();
+        pages[pages.length - 1].push(el);
+        y += h;
+        measureState.y += h;
+      }
       prevPara = null;
     }
   }
@@ -738,7 +749,10 @@ function splitParagraphAcrossPages(
   return { endY: cursorY };
 }
 
-function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: number): number {
+/** Per-row heights used by both pagination and the height estimate. Mirrors the
+ *  renderer's row sizing (exact / atLeast / auto + vMerge span distribution,
+ *  ECMA-376 §17.4.80, §17.4.85). */
+function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt: number): number[] {
   const totalColW = table.colWidths.reduce((s, w) => s + w, 0);
   const colScale = totalColW > contentWPt ? contentWPt / totalColW : 1;
   const colWidths = table.colWidths.map((w) => w * colScale);
@@ -789,7 +803,74 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
     }
   }
 
-  return rowHs.reduce((s, x) => s + x, 0);
+  return rowHs;
+}
+
+function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: number): number {
+  return computeTableRowHeights(state, table, contentWPt).reduce((s, x) => s + x, 0);
+}
+
+/** A page break before row `ri` is unsafe when `ri` continues a vertical merge
+ *  started above (ECMA-376 §17.4.85): splitting there would orphan the merged
+ *  cell's continuation. Such a row carries at least one `vMerge=false` cell. */
+function tableBreakAllowedBefore(table: DocTable, ri: number): boolean {
+  if (ri <= 0) return true;
+  return !table.rows[ri].cells.some((c) => c.vMerge === false);
+}
+
+/**
+ * Split a table that is taller than one page across page boundaries, row by
+ * row (ECMA-376 table pagination). Each page receives a {@link DocTable} slice
+ * holding the rows that fit; `w:tblHeader` rows (§17.4.78) repeat at the top of
+ * every continuation. Breaks land only on vMerge-safe boundaries
+ * ({@link tableBreakAllowedBefore}). Returns the Y offset after the final slice
+ * on the last page.
+ */
+export function splitTableAcrossPages(
+  table: DocTable,
+  rowHs: number[],
+  startY: number,
+  contentH: number,
+  pages: PaginatedBodyElement[][],
+  newPage: () => void,
+): number {
+  const n = table.rows.length;
+  // Leading tblHeader rows repeat on each continuation page.
+  let headerCount = 0;
+  while (headerCount < n && table.rows[headerCount].isHeader) headerCount++;
+  const headerRows = table.rows.slice(0, headerCount);
+  const headerH = rowHs.slice(0, headerCount).reduce((s, h) => s + h, 0);
+
+  let y = startY;
+  let start = 0;
+  let firstSlice = true;
+
+  while (start < n) {
+    const isContinuation = !firstSlice && headerCount > 0 && start >= headerCount;
+    const avail = contentH - y;
+    let used = isContinuation ? headerH : 0;
+    let end = start;
+    // Always place at least one row to guarantee forward progress.
+    while (end < n) {
+      const h = rowHs[end];
+      if (end > start && used + h > avail && tableBreakAllowedBefore(table, end)) break;
+      used += h;
+      end++;
+    }
+
+    const bodyRows = table.rows.slice(start, end);
+    const sliceRows = isContinuation ? [...headerRows, ...bodyRows] : bodyRows;
+    pages[pages.length - 1].push({ ...table, type: 'table', rows: sliceRows } as PaginatedBodyElement);
+
+    y += used;
+    start = end;
+    firstSlice = false;
+    if (start < n) {
+      newPage();
+      y = 0;
+    }
+  }
+  return y;
 }
 
 /** Find the last row index in a vMerge span starting at (startRi, startCi) —

--- a/packages/docx/src/table-split.test.ts
+++ b/packages/docx/src/table-split.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { splitTableAcrossPages } from './renderer.js';
+import type { DocTable, DocTableRow, PaginatedBodyElement } from './types';
+
+// Minimal row/table builders — splitTableAcrossPages only reads rows/cells
+// (vMerge, isHeader) and the precomputed rowHs, never measures.
+function row(opts: { isHeader?: boolean; vMergeContinue?: boolean } = {}): DocTableRow {
+  return {
+    cells: [
+      {
+        content: [],
+        colSpan: 1,
+        vMerge: opts.vMergeContinue ? false : null,
+        borders: { top: null, bottom: null, left: null, right: null },
+        background: null,
+        vAlign: 'top',
+        widthPt: null,
+      },
+    ],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: opts.isHeader ?? false,
+  };
+}
+
+function table(rows: DocTableRow[]): DocTable {
+  return {
+    colWidths: [100],
+    rows,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  };
+}
+
+/** Drive splitTableAcrossPages with a fresh pages array + a newPage that mirrors
+ *  computePages (append an empty page). Returns the resulting pages. */
+function run(t: DocTable, rowHs: number[], startY: number, contentH: number) {
+  const pages: PaginatedBodyElement[][] = [[]];
+  const newPage = () => { pages.push([]); };
+  const endY = splitTableAcrossPages(t, rowHs, startY, contentH, pages, newPage);
+  return { pages, endY };
+}
+
+const rowsOf = (slice: PaginatedBodyElement) => (slice as unknown as DocTable).rows;
+
+describe('splitTableAcrossPages', () => {
+  it('splits a tall table into per-page slices that each fit, preserving all rows in order', () => {
+    const t = table(Array.from({ length: 10 }, () => row()));
+    const rowHs = Array(10).fill(100);
+    const { pages } = run(t, rowHs, 0, 350); // 3 rows (300) fit per 350 page
+
+    // 10 rows → 3 + 3 + 3 + 1 across 4 pages.
+    expect(pages.length).toBe(4);
+    expect(pages.map((p) => rowsOf(p[0]).length)).toEqual([3, 3, 3, 1]);
+    // Every page slice fits within contentH.
+    for (const p of pages) {
+      const h = rowsOf(p[0]).length * 100;
+      expect(h).toBeLessThanOrEqual(350);
+    }
+    // No row lost or duplicated.
+    expect(pages.reduce((s, p) => s + rowsOf(p[0]).length, 0)).toBe(10);
+  });
+
+  it('fills the remaining space on the starting page before breaking', () => {
+    const t = table(Array.from({ length: 6 }, () => row()));
+    const rowHs = Array(6).fill(100);
+    // Start partway down a 350-tall page: only 1 row (100) fits in the 150 left.
+    const { pages } = run(t, rowHs, 200, 350);
+    expect(rowsOf(pages[0][0]).length).toBe(1);
+    expect(pages.length).toBe(3); // 1 + 3 + 2
+    expect(pages.reduce((s, p) => s + rowsOf(p[0]).length, 0)).toBe(6);
+  });
+
+  it('repeats leading tblHeader rows at the top of every continuation page', () => {
+    const header = row({ isHeader: true });
+    const body = Array.from({ length: 8 }, () => row());
+    const t = table([header, ...body]);
+    const rowHs = Array(9).fill(100);
+    const { pages } = run(t, rowHs, 0, 350);
+
+    // First page: header + first body rows. Continuations re-prepend the header.
+    expect(rowsOf(pages[0][0])[0].isHeader).toBe(true);
+    for (let i = 1; i < pages.length; i++) {
+      expect(rowsOf(pages[i][0])[0].isHeader).toBe(true);
+    }
+  });
+
+  it('never breaks before a vMerge continuation row (keeps the merged span together)', () => {
+    // Rows 0..4; row 3 continues a vertical merge started at row 2.
+    const rows = [row(), row(), row(), row({ vMergeContinue: true }), row()];
+    const t = table(rows);
+    const rowHs = Array(5).fill(100);
+    // 350 page would naturally break after row 2 (300) — but the next page would
+    // start at row 3, a vMerge continuation. The break must not orphan it: with
+    // forward-only progress the break still lands on a safe boundary.
+    const { pages } = run(t, rowHs, 0, 350);
+    // Reconstruct the row order across slices (dropping repeated headers — none here).
+    const flat = pages.flatMap((p) => rowsOf(p[0]));
+    expect(flat.length).toBe(5);
+    // For each page boundary, the first row of a continuation slice must not be
+    // a vMerge continuation row.
+    for (let i = 1; i < pages.length; i++) {
+      expect(rowsOf(pages[i][0])[0].vMerge).not.toBe(false);
+    }
+  });
+});

--- a/packages/docx/src/table-split.test.ts
+++ b/packages/docx/src/table-split.test.ts
@@ -99,9 +99,10 @@ describe('splitTableAcrossPages', () => {
     const flat = pages.flatMap((p) => rowsOf(p[0]));
     expect(flat.length).toBe(5);
     // For each page boundary, the first row of a continuation slice must not be
-    // a vMerge continuation row.
+    // a vMerge continuation row (a row carrying any vMerge=false cell).
     for (let i = 1; i < pages.length; i++) {
-      expect(rowsOf(pages[i][0])[0].vMerge).not.toBe(false);
+      const firstRow = rowsOf(pages[i][0])[0];
+      expect(firstRow.cells.some((c) => c.vMerge === false)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## Problem

A docx table was paginated as **one atomic block**: `computePages` measured the whole table, did a single page break if it didn't fit in the remaining space, then placed it. So a table taller than the content area — e.g. `private/sample-6.docx`'s 48-row appendix symbol table — overflowed the bottom margin and the excess was **clipped**. Word instead splits the table at the page boundary and continues on the next page.

## Fix

Teach `computePages` to split such tables **row by row** (ECMA-376 table pagination):

- Each page receives a `DocTable` slice with the rows that fit.
- Breaks land only on **vMerge-safe** boundaries (§17.4.85) — never orphaning a merged cell's continuation.
- Leading `w:tblHeader` rows (§17.4.78) repeat at the top of every continuation page.
- **Scoped**: tables that fit on a page keep the existing place-whole path, so only the previously-clipping case changes — no pagination change for other samples.

Implemented entirely in the paginator by emitting valid `DocTable` slices; the table renderer draws each slice unchanged. Extracted `computeTableRowHeights` (shared by `estimateTableHeight` and the splitter) so row sizing is identical between measurement and the split.

## Verification

- **Unit tests** (`table-split.test.ts`): greedy per-page fit, fill-remaining-space-first, `tblHeader` repetition, vMerge-safe breaks.
- **Visual**: rendered sample-6 in the docx viewer — the appendix symbol table now continues across pages instead of clipping, matching `sample-6.pdf` (the Word-export ground truth). Page count 21 vs the PDF's 20 (minor metric differences); structure matches.
- typecheck ✓, full unit suite 75/75 ✓, ast-grep lint ✓.

## Out of scope (per discussion)

Vertical cell centering in the same tables: the document contains **no `w:vAlign`** anywhere, so ECMA-376's default (top) is what we render — kept as-is intentionally. `w:cantSplit` isn't parsed, but row-boundary splitting already keeps every row whole, satisfying its main effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)