### PR TITLE
fix: three site-reported issues (xlsx tab scroll, Try-yours control size, hero copy)

### DIFF
--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -937,7 +937,22 @@ export class XlsxViewer {
     this.tabs.forEach((btn, i) => {
       btn.style.cssText = this.tabStyle(i === index, this.tabColors[i]);
     });
-    this.tabs[index]?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    // Keep the active tab visible by scrolling the tab strip HORIZONTALLY only.
+    // `scrollIntoView` walks every scrollable ancestor, so it also scrolls the
+    // page vertically — on first load that jumped the whole page down to the
+    // tab bar (the active sheet is set during load). Adjust the strip's
+    // scrollLeft directly so the page never moves.
+    const tab = this.tabs[index];
+    if (tab) {
+      const strip = this.tabStrip;
+      const tabRect = tab.getBoundingClientRect();
+      const stripRect = strip.getBoundingClientRect();
+      if (tabRect.left < stripRect.left) {
+        strip.scrollLeft -= stripRect.left - tabRect.left;
+      } else if (tabRect.right > stripRect.right) {
+        strip.scrollLeft += tabRect.right - stripRect.right;
+      }
+    }
   }
 
   private tabStyle(active: boolean, tabColor?: string | null): string {

--- a/site/src/layouts/FormatPage.astro
+++ b/site/src/layouts/FormatPage.astro
@@ -10,6 +10,7 @@ interface Props {
 }
 const { format, name, ext, tagline, color } = Astro.props;
 const title = `${name} (${ext}) — @silurus/ooxml`;
+const fileNoun = { docx: 'Word document', xlsx: 'Excel workbook', pptx: 'PowerPoint deck' }[format];
 ---
 <Base title={title}>
   <Nav active={format} />
@@ -20,8 +21,8 @@ const title = `${name} (${ext}) — @silurus/ooxml`;
       <p class="eyebrow"><span class="fp-dot"></span> {name}</p>
       <h1 class="fp-title">{tagline}</h1>
       <p class="fp-lead">
-        Every demo below is the real library rendering <code>{`sample-1${ext}`}</code> live in your
-        browser — and the exact code that produces it. The same patterns power the Storybook stories.
+        Every demo below is the real library rendering a sample {fileNoun} (<code>{ext}</code>) live in
+        your browser — and the exact code that produces it. The same patterns power the Storybook stories.
       </p>
     </div>
   </header>

--- a/site/src/lib/try.ts
+++ b/site/src/lib/try.ts
@@ -12,6 +12,13 @@ const math = { loadMathJax, mathMLToSvg };
 
 const DPR = () => Math.min(typeof window !== 'undefined' ? window.devicePixelRatio : 1, 2);
 
+// Render slides at the width they actually display at (`.lv-page` max-width),
+// not larger. Rendering bigger than the display only shrinks the interactive
+// media controls (drawn at fixed px in canvas space) when the canvas is
+// CSS-downscaled to fit — making them look tiny next to the slide. dpr keeps
+// the backing store crisp on HiDPI.
+const SLIDE_W = 880;
+
 type SlideHandle = Awaited<ReturnType<PptxPresentation['presentSlide']>>;
 
 // Disposes the previous render's live resources (interactive slide handles +
@@ -58,7 +65,7 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
       c.className = 'lv-page';
       c.dataset.slide = String(i);
       sc.appendChild(c);
-      await deck.renderSlide(c, i, { width: 1280, dpr: DPR(), math });
+      await deck.renderSlide(c, i, { width: SLIDE_W, dpr: DPR(), math });
       canvases.push(c);
     }
 
@@ -79,7 +86,7 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
             if (handles.has(idx) || pending.has(idx)) continue;
             pending.add(idx);
             deck
-              .presentSlide(c, idx, { width: 1280, dpr: DPR(), math })
+              .presentSlide(c, idx, { width: SLIDE_W, dpr: DPR(), math })
               .then((h) => {
                 pending.delete(idx);
                 if (visible.has(idx)) handles.set(idx, h);


### PR DESCRIPTION
Three issues reported on the docs site:

### 1. `fix(xlsx)` — activating a sheet tab scrolled the whole page
`updateTabActive` used `tab.scrollIntoView({ block:'nearest', inline:'nearest' })` to keep the active tab visible in the horizontal strip — but `scrollIntoView` scrolls *every* scrollable ancestor, including the document. On `/xlsx` (viewer below the fold) the active sheet is set during load, so the page jumped down on open. Now scrolls the strip's `scrollLeft` directly (horizontal only). **Library fix** — benefits any `XlsxViewer` consumer. Verified: `/xlsx` loads with `scrollY === 0` and the viewer fully rendered (10 tabs).

### 2. `fix(site)` — Try-yours media controls looked tiny
Slides rendered at CSS width 1280 but `.lv-page` caps display at 880 → canvas downscaled ~0.69×, shrinking the fixed-px playback controls. Storybook renders at ≈display width (≈1:1), hence the mismatch. Now renders at 880; dpr keeps it crisp. Measured backing/display ratio 2.91 → 2.0; slide display size unchanged.

### 3. `docs(site)` — cryptic "sample-1.xlsx" copy
The hero said "rendering `sample-1.xlsx`" — meaningless to visitors. Now "a sample Excel workbook (.xlsx)" (per-format noun).

`astro build` passes; all three verified live on the dev server.

Note: the site auto-deploys on `v*` tags; a manual Pages redeploy (workflow_dispatch) can publish #1–3 without a release once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)