### PR TITLE
fix(docx): reserve a full line box for inline math (not just glyph ink)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1859,10 +1859,20 @@ function layoutLines(
       const asc = render.ascentEm * emPx;
       const desc = render.descentEm * emPx;
       seg.measuredWidth = w;
+      // Ink extents (from the MathJax SVG viewBox) position the rasterized
+      // glyph relative to the baseline when drawing.
       seg.mathAscent = asc;
       seg.mathDescent = desc;
+      // …but the LINE BOX must reserve at least a normal single line for the
+      // run's font size. A short equation — e.g. a lone "−" — has near-zero ink
+      // height; using that as the line height would collapse the line (and the
+      // table row) and pin the glyph to the very top of the cell. Floor to the
+      // font's natural ascent/descent so math occupies a full line like text
+      // does (tall math — fractions, big operators — keeps its larger ink box).
+      const lineAsc = Math.max(asc, emPx * 0.8);
+      const lineDesc = Math.max(desc, emPx * 0.2);
       if (currentLine.length > 0 && currentWidth + w > availW()) flush();
-      addToLine(seg, w, seg.fontSize, asc, desc);
+      addToLine(seg, w, seg.fontSize, lineAsc, lineDesc);
       continue;
     }
 


### PR DESCRIPTION
## Problem

In docx tables (and inline), a math run's line-box ascent/descent were taken straight from the **MathJax SVG ink extents**. For a short equation — a lone "−", a single operator — the ink height is near zero, so the line (and its table row) collapsed and the glyph was pinned to the very top of the cell. (Reported on `sample-6.docx`: "looks like only the height of '−' (almost none) is taken".)

Text runs already avoid this by using stable **font** metrics, not per-glyph ink.

## Fix

Floor the math line box to the run font's natural ascent/descent (0.8 / 0.2 em) while keeping the SVG ink extents for positioning the rasterized glyph relative to the baseline. Tall math (fractions, big operators, stretchy braces) still drives a larger line box via its real ink extents.

`sample-6.docx` has **243 inline-math runs inside table cells**, many of them single short symbols that previously collapsed.

## Verification

- typecheck ✓
- Rendered sample-6 in the docx viewer: the "Common symbols with shortcuts" table (the one with the lone "−"), the Accents table, and the Stretchy-symbols table now render every math glyph at normal size in normal-height rows — no collapse — matching `sample-6.pdf`.

## Note

This is the height-measurement fix the user diagnosed. Vertical *centering* of cell content stays top-aligned per the earlier decision (the document carries no `w:vAlign`; ECMA-376 default is top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)