### PR TITLE
chore(release): 0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.50.0 — 2026-06-04
+
+docx:
+
+- **Tables split across pages.** A table taller than the page was paginated as
+  one atomic block and clipped at the bottom margin; it now splits row by row
+  (ECMA-376 table pagination). Breaks land only on vMerge-safe boundaries
+  (§17.4.85) and leading `w:tblHeader` rows (§17.4.78) repeat at the top of each
+  continuation page.
+- **Inline math reserves a full line box.** A math run's line height was taken
+  from the MathJax SVG ink extents, so a short equation (a lone "−", a single
+  operator) collapsed its line — and its table row — to near-zero and pinned the
+  glyph to the top of the cell. The line box is now floored to the run font's
+  natural ascent/descent (tall math keeps its larger ink box).
+
+xlsx:
+
+- Activating a sheet tab no longer scrolls the page. `XlsxViewer` kept the
+  active tab visible with `scrollIntoView`, which also scrolled every ancestor
+  (including the document); it now scrolls the tab strip horizontally only.
+
+Docs site:
+
+- "Try yours" renders pptx with interactive audio/video playback (only on-screen
+  slides hold a live handle). Its slides render at display width so the media
+  controls aren't shrunk. The per-format hero copy no longer references the
+  cryptic "sample-1.xlsx".
+
 ## 0.49.0 — 2026-06-04
 
 Packaging: **the math engine is now opt-in.** ⚠️ Breaking change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
## 0.50.0

Bug-fix + correctness release on top of 0.49.0.

### docx
- **Tables split across pages** — a table taller than the page was clipped at the bottom margin; it now splits row by row (ECMA-376), breaking only on vMerge-safe boundaries and repeating `w:tblHeader` rows on continuation pages. (#346)
- **Inline math reserves a full line box** — a short equation (lone "−", single operator) collapsed its line/row to the glyph's ink height; the line box is now floored to the run font's natural metrics. (#348)

### xlsx
- Activating a sheet tab no longer scrolls the page (`scrollIntoView` → horizontal-only strip scroll). (#347)

### Docs site
- "Try yours" interactive audio/video playback + correct control sizing; friendlier hero copy (no more "sample-1.xlsx"). (#345, #347)

### Bookkeeping
- Version bump to 0.50.0 across all 8 packages.
- CHANGELOG 0.50.0 added.
- README verified (bundle-size note, named-import examples, no stale patterns) — no public-API changes this release, so no README/api-reference edits needed.
- Screenshots unchanged (these fixes don't affect the representative README images).

Tag `v0.50.0` after merge → npm publish, VS Code Marketplace, Pages deploy, MCP binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)