### PR TITLE
fix(vscode): render OMML equations in the webview

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./types": "./src/types/common.ts"
+    "./types": "./src/types/common.ts",
+    "./mathjax-stix2": "./assets/mathjax-stix2.js"
   },
   "scripts": {
     "build": "tsc --build",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -127,6 +127,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
+    "@silurus/ooxml-core": "workspace:*",
     "@silurus/ooxml-docx": "workspace:*",
     "@silurus/ooxml-xlsx": "workspace:*",
     "@silurus/ooxml-pptx": "workspace:*"

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -19,6 +19,24 @@ declare function acquireVsCodeApi(): {
 import { XlsxViewer, type CellRange } from '@silurus/ooxml-xlsx';
 import { DocxDocument, type DocxTextRunInfo } from '@silurus/ooxml-docx';
 import { PptxPresentation, type PptxTextRunInfo } from '@silurus/ooxml-pptx';
+import { svgExtents } from '@silurus/ooxml-core';
+// Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
+// into the webview and sets globalThis.__ooxmlStix2. The library renders OMML
+// equations only when handed a `math` engine; its built-in engine loads lazily
+// by injecting a <script>, which this webview's nonce CSP blocks — so we bundle
+// the engine inline instead and pass the adapter below to the viewers.
+import '@silurus/ooxml-core/mathjax-stix2';
+
+const math = {
+  loadMathJax: async (): Promise<void> => {
+    /* engine bundled by the import above; globalThis.__ooxmlStix2 is set */
+  },
+  mathMLToSvg: async (mathml: string) => {
+    if (!__ooxmlStix2) throw new Error('Math engine failed to initialize');
+    const svg = __ooxmlStix2.mathml2svg(mathml);
+    return { svg, ...svgExtents(svg) };
+  },
+};
 
 const vscodeApi = acquireVsCodeApi();
 const fileType = __OOXML_FILE_TYPE__;
@@ -115,7 +133,7 @@ function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): voi
 }
 
 async function initDocx(buffer: ArrayBuffer): Promise<void> {
-  const doc = await DocxDocument.load(buffer);
+  const doc = await DocxDocument.load(buffer, { math });
 
   const stack = document.createElement('div');
   stack.className = 'page-stack';
@@ -212,7 +230,7 @@ async function initPptx(buffer: ArrayBuffer): Promise<void> {
     stack.appendChild(wrapper);
 
     const runs: PptxTextRunInfo[] = [];
-    await pres.presentSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
+    await pres.presentSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r), math });
     buildPptxTextLayer(textLayer, runs, widthPx, cssHeight);
   }
 

--- a/packages/vscode-extension/src/webview/engine.d.ts
+++ b/packages/vscode-extension/src/webview/engine.d.ts
@@ -1,0 +1,11 @@
+// The prebuilt MathJax + STIX Two Math engine is a self-contained IIFE asset
+// (no exports) that sets `globalThis.__ooxmlStix2` when evaluated. We import it
+// for its side effect so esbuild bundles it into the webview (the library's
+// normal lazy <script> injection is blocked by the webview's nonce CSP).
+declare module '@silurus/ooxml-core/mathjax-stix2';
+
+interface Stix2Engine {
+  mathml2svg(mathml: string): string;
+}
+// eslint-disable-next-line no-var
+declare var __ooxmlStix2: Stix2Engine | undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
 
   packages/vscode-extension:
     dependencies:
+      '@silurus/ooxml-core':
+        specifier: workspace:*
+        version: link:../core
       '@silurus/ooxml-docx':
         specifier: workspace:*
         version: link:../docx


### PR DESCRIPTION
## Why math didn't render in the VS Code extension

1. **Not opt-in-wired** — since 0.49.0 the math engine is opt-in; `DocxDocument.load` / `PptxPresentation.presentSlide` need a `math` engine passed, which the webview bootstrap didn't do.
2. **CSP blocks the lazy loader** — the library's engine loads by injecting a `<script>`, but the webview CSP is `script-src 'nonce-…' 'wasm-unsafe-eval'`, so an un-nonced injected script is blocked. Passing the built-in engine alone wouldn't help.

## Fix

Bundle the self-contained MathJax + STIX Two Math engine **into the webview** via a new `@silurus/ooxml-core/mathjax-stix2` side-effect import. It sets `globalThis.__ooxmlStix2` when `webview.js` runs (which loads under the page nonce) — no `<script>` injection, CSP-safe. A small `MathRenderer` adapter (reads the global + `svgExtents`) is passed to both viewers.

- **core**: export `./mathjax-stix2` → the prebuilt engine asset. core is `private`; no root entry imports this, so the **published npm library is unaffected**.
- **vscode-extension**: add `@silurus/ooxml-core` dep; ambient decl for the side-effect import; pass `math` to docx `load` and pptx `presentSlide`.

## Verification

- typecheck ✓, lint ✓.
- Built `webview.js` contains the engine's `globalThis.__ooxmlStix2=` assignment **and** the adapter read — no `<script>` injection. Single engine copy (~8 MB webview.js; was ~20 MB before I rebuilt the stale sub-package dists, which CI rebuilds anyway).
- The publish workflow runs `pnpm -r --filter "@silurus/*" build` before bundling, so the extension picks up the post-0.49.0 opt-in renderers.

> In-editor (F5 / installed .vsix) confirmation of rendered equations is recommended as a final check — I verified at the build/bundle level since I can't drive VS Code here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)