### PR TITLE
chore(release): 0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.50.1 — 2026-06-04
+
+VS Code extension:
+
+- **Equations now render in the webview.** Two causes: since 0.49.0 the math
+  engine is opt-in (the webview wasn't passing a `math` engine), and the
+  engine's lazy `<script>` injection is blocked by the webview's nonce CSP. The
+  extension now bundles the self-contained MathJax + STIX Two Math engine into
+  the webview (sets `globalThis.__ooxmlStix2` on load — no script injection,
+  CSP-safe) and passes a `MathRenderer` adapter to the docx/pptx viewers.
+
+(No functional change to the npm library; version bumped to keep the single
+release series.)
+
 ## 0.50.0 — 2026-06-04
 
 docx:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
## 0.50.1

Patch release: **VS Code extension renders OMML equations again.**

Since 0.49.0 the math engine became opt-in, and the webview both (a) wasn't passing a `math` engine and (b) couldn't load the library's lazy `<script>`-injected engine under its nonce CSP. The extension now bundles the self-contained MathJax + STIX Two Math engine into the webview (sets `globalThis.__ooxmlStix2` on load — CSP-safe) and passes a `MathRenderer` adapter to the docx/pptx viewers. (#350)

No functional change to the npm library; the version is bumped across all packages to keep the single release series. README verified (no stale patterns; no public-API change).

Tag `v0.50.1` after merge → npm publish, **VS Code Marketplace publish** (the fix), Pages deploy, MCP binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)