### PR TITLE
chore(release): 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.52.0 — 2026-06-09
+
+pptx:
+
+- **Placeholder body text now inherits the master `txStyles` colour even when
+  bound by `idx`.** A slide body placeholder bound by `idx` (e.g.
+  `<p:ph idx="35"/>`) whose matching layout shape declared size-but-not-colour
+  rendered black instead of the master `bodyStyle` colour. Colour resolution was
+  idx-strict and returned early on a missing layout-idx colour, never falling
+  through to the master default. The idx-strict rule (ECMA-376 §19.7.16) only
+  applies to the layout tier — it stops a sibling layout placeholder from leaking
+  its colour. The master `txStyles` tier (titleStyle/bodyStyle/otherStyle) is a
+  document-wide default keyed by placeholder *type* (§21.1.2.4 / §19.3.1) and is
+  inherited regardless of `idx`. Fixes white-on-dark body text (master
+  `schemeClr bg1`) rendering black on themed decks.
+
 ## 0.51.0 — 2026-06-09
 
 xlsx:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.52.0.

### pptx
- Placeholder body text now inherits the master `txStyles` colour even when bound by `idx` (#356). Fixes white-on-dark body text (master `schemeClr bg1`) rendering black on themed decks — e.g. an Agenda slide whose body placeholders are `<p:ph idx="35"/>` with no layout-level colour.

Version bump across all 8 packages (root + core/docx/pptx/xlsx/markdown/node/vscode-extension); CHANGELOG updated. No public API changes, so the Feature Support table, site API reference, and README screenshots are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)