### PR TITLE
fix(pptx): cancel stale slide renders to prevent canvas ghosting

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2194,6 +2194,16 @@ export async function renderSlide(
   opts: RenderOptions = {},
   onTextRun?: TextRunCallback,
 ): Promise<HTMLCanvasElement | OffscreenCanvas> {
+  // Cancellation guard. renderSlide is async (it awaits image / equation decode),
+  // so rapid navigation can start a newer render of the SAME canvas before this
+  // one finishes. Both would `canvas.width = …` (clear) and then draw, and their
+  // draws interleave at the await points — ghosting multiple slides together.
+  // Stamp a per-canvas token; once a newer render supersedes us, stop drawing at
+  // the next await so only the latest render's output survives.
+  const tokenHost = canvas as unknown as { __pptxRenderToken?: number };
+  const myToken = (tokenHost.__pptxRenderToken = (tokenHost.__pptxRenderToken ?? 0) + 1);
+  const superseded = () => tokenHost.__pptxRenderToken !== myToken;
+
   const targetWidth = opts.width ?? ((canvas instanceof HTMLCanvasElement ? canvas.offsetWidth : 0) || 960);
   const scale = targetWidth / slideWidth;
   const canvasW = Math.round(targetWidth);
@@ -2228,6 +2238,7 @@ export async function renderSlide(
   // Requires the opt-in `math` engine (RenderOptions.math); without it,
   // equations are skipped and the engine asset never enters the bundle.
   if (opts.math) await prepareSlideMath(slide, opts.math);
+  if (superseded()) return canvas;
 
   const themeDefaultColor = opts.defaultTextColor
     ? `#${opts.defaultTextColor}`
@@ -2235,6 +2246,9 @@ export async function renderSlide(
 
   const slideNumber = slide.slideNumber;
   for (const el of slide.elements) {
+    // A newer render of this canvas started while we awaited an image/equation —
+    // stop so we don't paint this (now stale) slide over the newer one.
+    if (superseded()) return canvas;
     if (el.type === 'shape') {
       renderShape(ctx, el, scale, themeDefaultColor, slideNumber, rc, onTextRun);
     } else if (el.type === 'picture') {


### PR DESCRIPTION
## Problem

Navigating slides faster than a render completes paints several slides on top of each other (ghosting). Reproduced by firing rapid `Next` clicks: slides 2–9 overlapped into one garbled frame.

## Root cause

`renderSlide` is async — it `await`s image (`renderPicture`) and equation (`prepareSlideMath`) decoding. A second render of the **same canvas** can start before the first finishes (rapid next/prev, key-repeat, programmatic jumps). Both do `canvas.width = …` (which clears) and then draw, and their draw passes interleave at the await points, so the older render keeps painting after the newer one cleared — multiple slides stack.

`PptxViewer.goToSlide` → `renderCurrentSlide` has no serialization, so the **public viewer** is affected, not only the Storybook helper. Real users only hit it at faster-than-render navigation, but it's a genuine concurrency gap.

## Fix

Per-canvas render token: each `renderSlide` stamps `canvas.__pptxRenderToken`; a newer render bumps it, and an older render bails at the next await (after math prep, and at the top of the element loop) rather than drawing its now-stale slide. The latest render always wins. Localized to `renderSlide`, so every caller (viewer, harness, direct API) benefits.

## Verification

- Repro before fix: 8 rapid `Next` clicks → 8 slides ghosted together.
- After fix: same 8 rapid clicks → only slide 9 renders, cleanly.
- Typecheck passes.

Note: the `enableMediaPlayback` path (`presentSlide`) is separate and not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)