### PR TITLE
chore(release): 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.53.0 — 2026-06-09
+
+pptx:
+
+- **Table styles now apply cell fill, text colour and bold from `tcStyle` /
+  `tcTxStyle`.** The cell fill is wrapped in `<a:fill>` (ECMA-376 §20.1.4.2.27),
+  which the parser skipped, so `wholeTbl` / `firstRow` / banding fills never
+  resolved (transparent cells); and `<a:tcTxStyle>` (per-role default colour and
+  `b="on"` bold) was ignored, so header text rendered black/non-bold. Table
+  `<a:tint>` now uses the literal ECMA-376 §20.1.2.3.34 formula (a 20% band is a
+  near-white wash) instead of the SmartArt linear lerp. Built-in "Medium Style 1
+  - Accent 2" tables now match PowerPoint (orange header + white bold text,
+  light-pink banding).
+- **List bullets are inherited from the layout / master `lstStyle`.** Paragraphs
+  with no explicit `<a:buChar>`/`<a:buAutoNum>` now resolve their marker from the
+  per-level bullet cascade (master `bodyStyle`, layout placeholder lstStyles) by
+  `lvl` (§19.7.10 / §21.1.2.4), with the matching hanging-indent metrics — body
+  placeholders that previously rendered with no bullets now show the master `•`
+  or a layout auto-number.
+- **Line arrowheads enlarged to match PowerPoint.** The sm/med/lg width/length
+  multipliers were ~half PowerPoint's size (§20.1.10.32/.33 define the steps only
+  as relative); a lg/lg triangle now measures ≈8× line width, matching the PDF.
+- **Stale slide renders are cancelled to stop canvas ghosting.** `renderSlide`
+  is async (it awaits image/equation decode), so navigating faster than a render
+  completes interleaved multiple slides onto one canvas. A per-canvas render
+  token now makes superseded renders bail, so the latest slide always wins.
+
 ## 0.52.0 — 2026-06-09
 
 pptx:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.53.0 — pptx rendering-fidelity fixes (found by comparing sample-9 against its PowerPoint PDF export).

### pptx
- Table styles apply cell fill, text colour and bold from `tcStyle` / `tcTxStyle`; table `<a:tint>` uses the literal ECMA-376 wash (#359).
- List bullets are inherited from the layout / master `lstStyle` with hanging-indent metrics (#360).
- Line arrowheads enlarged to match PowerPoint (#360).
- Stale slide renders are cancelled to stop canvas ghosting on rapid navigation (#361).

Version bump across all 8 packages; CHANGELOG updated. These are accuracy fixes to already-supported features, so the Feature Support table, site API reference, and README screenshots (the demo title slide is unaffected) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)