### PR TITLE
fix(xlsx,charts): render formatCode "General" as the General number format

### DIFF
--- a/packages/core/src/chart/chart-number-format.test.ts
+++ b/packages/core/src/chart/chart-number-format.test.ts
@@ -45,5 +45,11 @@ describe('formatChartValWithCode — percent & null', () => {
   });
   it('falls back to General when code is null/General', () => {
     expect(formatChartValWithCode(7507, null)).toBe('7507');
+    // "General" is the reserved General-format keyword (ECMA-376 §18.8.30), not a
+    // literal pattern. LibreOffice charts emit <c:numFmt formatCode="General">,
+    // which must render the value — not the literal text "General" (issue #358).
+    expect(formatChartValWithCode(7507, 'General')).toBe('7507');
+    expect(formatChartValWithCode(7507, 'general')).toBe('7507');
+    expect(formatChartValWithCode(0.5, ' General ')).toBe('0.5');
   });
 });

--- a/packages/core/src/chart/chart-number-format.ts
+++ b/packages/core/src/chart/chart-number-format.ts
@@ -25,7 +25,11 @@ export function formatChartVal(v: number): string {
  * or an empty section tells the caller to hide the value.
  */
 export function formatChartValWithCode(v: number, code: string | null | undefined): string {
-  if (!code) return formatChartVal(v);
+  // Absent `code`, or the reserved "General" keyword (ECMA-376 §18.8.30), both
+  // mean the General number format. LibreOffice charts emit
+  // `<c:numFmt formatCode="General">`; tokenizing it as a literal pattern would
+  // render the word "General" instead of the value (issue #358).
+  if (!code || code.trim().toLowerCase() === 'general') return formatChartVal(v);
   // Detect Excel date format codes (m/d/y/h/s tokens outside quotes) and
   // route to the date formatter. Charts use this on the X axis of scatter
   // / time-series charts where the value is a serial date.

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -62,6 +62,22 @@ describe('number formats — literals', () => {
   });
 });
 
+describe('General format code (§18.8.30 / LibreOffice custom numFmt)', () => {
+  // LibreOffice Calc writes a custom numFmt (id ≥ 164) with formatCode="General"
+  // for every saved workbook. "General" is the reserved General-format keyword,
+  // so a cell must render its value — not the literal text "General" (issue #358).
+  it('renders the number for a custom numFmt whose code is "General"', () => {
+    expect(fmt(10, 'General')).toBe('10');
+    expect(fmt(42, 'General')).toBe('42');
+    expect(fmt(3.14, 'General')).toBe('3.14');
+  });
+  it('is case-insensitive and tolerates surrounding whitespace', () => {
+    expect(fmt(10, 'general')).toBe('10');
+    expect(fmt(10, 'GENERAL')).toBe('10');
+    expect(fmt(10, ' General ')).toBe('10');
+  });
+});
+
 describe('non-numeric cells', () => {
   it('passes text through when no 4th section', () => {
     const cell: Cell = { row: 1, col: 1, colRef: 'A1', value: { type: 'text', text: 'hello' }, styleIndex: 0 };

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -368,6 +368,11 @@ function applyFormat(num: number, numFmtId: number, formatCode: string | null): 
   // Built-in date/time numFmtIds (ECMA-376 §18.8.30 table)
   const builtinFmt = BUILTIN_DATE_FMT[numFmtId];
   if (builtinFmt) return formatExcelDateCode(num, builtinFmt);
+  // ECMA-376 §18.8.30: "General" is the reserved General number format regardless
+  // of numFmtId. LibreOffice writes a custom numFmt (id ≥ 164) with
+  // formatCode="General"; tokenizing it as a literal pattern would render the
+  // word "General" instead of the value (issue #358).
+  if (formatCode && formatCode.trim().toLowerCase() === 'general') return String(num);
   if (formatCode) {
     if (isDateFormatCode(formatCode)) return formatExcelDateCode(num, formatCode);
     return applyFormatCode(num, formatCode);


### PR DESCRIPTION
## Summary

Closes #358. A cell (or chart label) whose style references a custom `numFmt` (id ≥ 164) with `formatCode="General"` rendered the literal text **"General"** instead of the value. LibreOffice Calc writes exactly this for every workbook/chart it saves, so every numeric cell and every chart tick in a LibreOffice-authored file showed "General".

Two independent code paths shared the same root cause — both reached the General format only via the *builtin* `numFmtId=0` / `null` code path, so a **custom** `formatCode="General"` was tokenized as a literal pattern:

- `packages/xlsx/src/number-format.ts` — `applyFormat` (the cell path described in the issue)
- `packages/core/src/chart/chart-number-format.ts` — `formatChartValWithCode` (chart axes & data labels; not in the original issue, found during review). Shared by pptx/docx/xlsx charts.

## Fix

ECMA-376 §18.8.30: `"General"` is the reserved General number format **regardless of `numFmtId`**. Normalize a trimmed, case-insensitive `formatCode === "general"` to the General formatter before pattern tokenization, in both formatters. This is spec-faithful (a reserved keyword), not a heuristic — matching Excel, LibreOffice and SheetJS.

- Conditional-format `dxf` `numFmt="General"` is fixed for free (it flows through the same `applyFormat`).
- Text cells were already unaffected (the text-section path passes through unchanged).

## Tests

TDD (Red → Green). Added cell-side cases (value, case-insensitivity, surrounding whitespace) and extended the chart-side `null/General` test — which was named for `"General"` but only ever asserted `null`. Full suite: 77/77 passing; typecheck + ast-grep lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)