### PR TITLE
chore(release): 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.54.0 — 2026-06-09
+
+xlsx:
+
+- **A custom `numFmt` with `formatCode="General"` now renders the cell value
+  instead of the literal text "General".** LibreOffice Calc writes a custom
+  numFmt (id ≥ 164) with `formatCode="General"` for every workbook it saves; the
+  formatter only reached the General path via the builtin `numFmtId=0`, so these
+  cells tokenised "General" as a literal pattern and every numeric cell showed the
+  word "General". ECMA-376 §18.8.30 reserves "General" as the General number
+  format regardless of `numFmtId`, so a trimmed, case-insensitive
+  `formatCode === "general"` is now normalised to it (#358).
+
+charts:
+
+- **Chart axis ticks and data labels with an explicit `formatCode="General"` now
+  render the value.** `formatChartValWithCode` only fell back to the General
+  formatter for null/empty codes, so the `<c:numFmt formatCode="General">` that
+  LibreOffice emits on axes and data labels was tokenised as a literal pattern.
+  Shared by pptx/docx/xlsx charts via `@silurus/ooxml-core` (#358).
+
+docs:
+
+- The README "Demo (Storybook)" link is relabelled "Live demo" — it points to the
+  project site (`ooxml.silurus.dev`), not Storybook — and the headless-engine
+  `Examples` reference now links to `/storybook/`, where those stories live.
+
 ## 0.53.0 — 2026-06-09
 
 pptx:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 [![VS Code installs](https://img.shields.io/visual-studio-marketplace/i/silurus.office-open-xml-viewer?label=installs)](https://marketplace.visualstudio.com/items?itemName=silurus.office-open-xml-viewer)
 [![license](https://img.shields.io/npm/l/@silurus/ooxml.svg)](./LICENSE)
 
-**[Demo (Storybook)](https://ooxml.silurus.dev)**
+**[Live demo](https://ooxml.silurus.dev)**
 
 A browser-based viewer for Office Open XML documents that renders to an HTML Canvas element.
 The parsers are written in Rust and compiled to WebAssembly; the renderers use the Canvas 2D API.
-Each format also exposes a headless engine (`DocxDocument` / `XlsxWorkbook` / `PptxPresentation`) that renders into any caller-supplied canvas, so you can compose your own UI — scroll views, thumbnail grids, master-detail panes — instead of being locked into the built-in viewer. See the `Examples` section in [the Storybook demo](https://ooxml.silurus.dev).
+Each format also exposes a headless engine (`DocxDocument` / `XlsxWorkbook` / `PptxPresentation`) that renders into any caller-supplied canvas, so you can compose your own UI — scroll views, thumbnail grids, master-detail panes — instead of being locked into the built-in viewer. See the `Examples` section in [the Storybook demo](https://ooxml.silurus.dev/storybook/).
 
 | DOCX | XLSX | PPTX |
 |:---:|:---:|:---:|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
## 0.54.0

### xlsx / charts
- **Custom `numFmt` with `formatCode="General"` now renders the cell value, not the literal text "General"** (#358). LibreOffice Calc writes a custom numFmt (id ≥ 164) `formatCode="General"` for every saved workbook; the formatter only reached the General path via builtin `numFmtId=0`, so these cells tokenised "General" as a literal pattern. Fixed in both the xlsx cell formatter and the shared chart formatter (`@silurus/ooxml-core`, used by pptx/docx/xlsx charts). ECMA-376 §18.8.30.

### docs
- README "Demo (Storybook)" link relabelled **"Live demo"** — it points to the project site (`ooxml.silurus.dev`), not Storybook. The headless-engine `Examples` reference now links to `/storybook/`, where those stories actually live.

### release
- CHANGELOG `## 0.54.0` section.
- All 8 packages bumped to 0.54.0 (root + core/pptx/xlsx/docx/markdown/node/vscode-extension).

Verified end-to-end: a hand-crafted LibreOffice-style `.xlsx` (numFmt 164 "General", cells `s="0"`) run through the real WASM parser + formatter renders `10/25/7/42` after the fix vs `General` before. Full unit suite 77/77, typecheck + ast-grep lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)