### PR TITLE
feat(rtl): pptx renderer — intra-line bidi, RTL bullets/shape text (PR3/4)

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -628,6 +628,10 @@ struct TableElement {
     /// Column widths in EMU
     cols: Vec<i64>,
     rows: Vec<TableRow>,
+    /// `<a:tblPr rtl="1">` (ECMA-376 §21.1.3.13): right-to-left table —
+    /// column 0 renders at the right edge. Skipped when false/absent.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    rtl: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -4946,6 +4950,8 @@ fn parse_table(
     };
     let first_row = flag("firstRow");
     let last_row  = flag("lastRow");
+    // ECMA-376 §21.1.3.13 (a:tblPr@rtl): right-to-left table layout.
+    let rtl = flag("rtl");
     let band_row  = flag("bandRow");
     let first_col = flag("firstCol");
     let last_col  = flag("lastCol");
@@ -5128,7 +5134,7 @@ fn parse_table(
 
     Some(TableElement {
         x: t.x, y: t.y, width: t.cx, height: t.cy,
-        cols, rows,
+        cols, rows, rtl,
     })
 }
 
@@ -6824,5 +6830,59 @@ mod tests {
         // rtlCol="1" appears under the camelCase key "rtlCol".
         let json_true = serde_json::to_string(&tb).unwrap();
         assert!(json_true.contains("\"rtlCol\":true"), "expected rtlCol:true in JSON; got {json_true}");
+    }
+
+    /// ECMA-376 §21.1.3.13 (`a:tblPr@rtl`): a right-to-left table sets `rtl=true`
+    /// so the renderer can place column 0 at the right edge. Absent/false must be
+    /// omitted from the serialized JSON (TableElement.rtl is optional in TS).
+    #[test]
+    fn table_rtl_attribute_parses() {
+        // An empty in-memory zip is enough: parse_table only reads
+        // ppt/tableStyles.xml (absent → no style cascade) and the tbl node.
+        fn empty_zip() -> Vec<u8> {
+            let mut buf = Vec::new();
+            {
+                let cursor = Cursor::new(&mut buf);
+                let writer = zip::ZipWriter::new(cursor);
+                writer.finish().unwrap();
+            }
+            buf
+        }
+
+        fn parse_tbl(tbl_xml: &str) -> TableElement {
+            let xml = format!(
+                r#"<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">{tbl_xml}</root>"#
+            );
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let tbl = doc.root_element()
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "tbl")
+                .unwrap();
+            let t = Transform { x: 0, y: 0, cx: 100, cy: 100, rot: 0.0, flip_h: false, flip_v: false };
+            let theme: HashMap<String, String> = HashMap::new();
+            let rels: HashMap<String, String> = HashMap::new();
+            let bytes = empty_zip();
+            let cursor = Cursor::new(bytes.as_slice());
+            let mut zip = zip::ZipArchive::new(cursor).unwrap();
+            parse_table(tbl, &t, &theme, &rels, &mut zip).unwrap()
+        }
+
+        // rtl="1" → rtl=true, serialized.
+        let t_rtl = parse_tbl(
+            r#"<a:tbl><a:tblPr rtl="1"/><a:tblGrid><a:gridCol w="100"/></a:tblGrid>
+               <a:tr h="0"><a:tc><a:txBody/></a:tc></a:tr></a:tbl>"#,
+        );
+        assert!(t_rtl.rtl, "rtl=\"1\" should yield rtl=true");
+        let json = serde_json::to_string(&t_rtl).unwrap();
+        assert!(json.contains("\"rtl\":true"), "expected rtl:true in JSON; got {json}");
+
+        // Absent tblPr@rtl → false, omitted from JSON.
+        let t_ltr = parse_tbl(
+            r#"<a:tbl><a:tblPr/><a:tblGrid><a:gridCol w="100"/></a:tblGrid>
+               <a:tr h="0"><a:tc><a:txBody/></a:tc></a:tr></a:tbl>"#,
+        );
+        assert!(!t_ltr.rtl, "absent rtl should yield rtl=false");
+        let json_ltr = serde_json::to_string(&t_ltr).unwrap();
+        assert!(!json_ltr.contains("\"rtl\""), "rtl=false must be omitted; got {json_ltr}");
     }
 }

--- a/packages/pptx/src/bidi-line.test.ts
+++ b/packages/pptx/src/bidi-line.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { segmentsHaveRtl, computeLineVisualOrder, resolveAlignEdge } from './bidi-line.js';
+import { segmentsHaveRtl, computeLineVisualOrder } from './bidi-line.js';
 
 describe('segmentsHaveRtl', () => {
   it('detects Arabic/Hebrew, ignores Latin and objects', () => {
@@ -7,20 +7,6 @@ describe('segmentsHaveRtl', () => {
     expect(segmentsHaveRtl([{ text: 'price 99' }, {}])).toBe(false); // object seg has no text
     expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
     expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
-  });
-});
-
-describe('resolveAlignEdge', () => {
-  it('resolves logical start/end against base direction', () => {
-    expect(resolveAlignEdge(undefined, false)).toBe('left');
-    expect(resolveAlignEdge(undefined, true)).toBe('right');
-    expect(resolveAlignEdge('start', true)).toBe('right');
-    expect(resolveAlignEdge('end', true)).toBe('left');
-    expect(resolveAlignEdge('end', false)).toBe('right');
-    expect(resolveAlignEdge('center', true)).toBe('center');
-    expect(resolveAlignEdge('both', true)).toBe('justify');
-    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
-    expect(resolveAlignEdge('right', true)).toBe('right');
   });
 });
 

--- a/packages/pptx/src/bidi-line.test.ts
+++ b/packages/pptx/src/bidi-line.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { segmentsHaveRtl, computeLineVisualOrder, resolveAlignEdge } from './bidi-line.js';
+
+describe('segmentsHaveRtl', () => {
+  it('detects Arabic/Hebrew, ignores Latin and objects', () => {
+    expect(segmentsHaveRtl([{ text: 'Hello world' }])).toBe(false);
+    expect(segmentsHaveRtl([{ text: 'price 99' }, {}])).toBe(false); // object seg has no text
+    expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
+    expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
+  });
+});
+
+describe('resolveAlignEdge', () => {
+  it('resolves logical start/end against base direction', () => {
+    expect(resolveAlignEdge(undefined, false)).toBe('left');
+    expect(resolveAlignEdge(undefined, true)).toBe('right');
+    expect(resolveAlignEdge('start', true)).toBe('right');
+    expect(resolveAlignEdge('end', true)).toBe('left');
+    expect(resolveAlignEdge('end', false)).toBe('right');
+    expect(resolveAlignEdge('center', true)).toBe('center');
+    expect(resolveAlignEdge('both', true)).toBe('justify');
+    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
+    expect(resolveAlignEdge('right', true)).toBe('right');
+  });
+});
+
+describe('computeLineVisualOrder', () => {
+  it('keeps pure-LTR segments in logical order', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'Hello ' }, { text: 'world' }], false);
+    expect(order).toEqual([0, 1]);
+    expect(rtl).toEqual([false, false]);
+  });
+
+  it('reverses pure-RTL segments and marks them RTL', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'שלום ' }, { text: 'עולם' }], true);
+    expect(order).toEqual([1, 0]); // last word is visually leftmost
+    expect(rtl).toEqual([true, true]);
+  });
+
+  it('orders an embedded LTR run inside an RTL line', () => {
+    // logical: Hebrew, Latin, Hebrew (base RTL) -> visual L→R: [2,1,0]
+    const { order, rtl } = computeLineVisualOrder(
+      [{ text: 'שלום ' }, { text: 'world ' }, { text: 'טוב' }],
+      true,
+    );
+    expect(order).toEqual([2, 1, 0]);
+    expect(rtl[1]).toBe(false); // the Latin segment is LTR
+    expect(rtl[0]).toBe(true);
+    expect(rtl[2]).toBe(true);
+  });
+
+  it('places a neutral object by surrounding direction', () => {
+    // object between two Hebrew words, base RTL -> object stays in RTL flow
+    const { order } = computeLineVisualOrder([{ text: 'שלום ' }, {}, { text: 'טוב' }], true);
+    expect(order).toEqual([2, 1, 0]);
+  });
+});

--- a/packages/pptx/src/bidi-line.ts
+++ b/packages/pptx/src/bidi-line.ts
@@ -14,7 +14,10 @@ import { getDefaultBidiEngine } from '@silurus/ooxml-core';
 /** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
  *  Arabic presentation forms. Used only as a cheap gate to decide whether a
  *  line needs the (exact) bidi pass at all — never for ordering itself. */
-const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+const RTL_GATE =
+  // strong-RTL blocks incl. presentation forms, Plane-1 RTL blocks, and
+  // RTL-implicating controls (RLM/RLE/RLO/RLI).
+  /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF\u200F\u202B\u202E\u2067]|[\u{10800}-\u{10FFF}\u{1E800}-\u{1EFFF}]/u;
 
 /** A laid-out segment as seen here: only its optional text matters for bidi.
  *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
@@ -46,9 +49,12 @@ const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON
  * Compute the visual draw order of a line's segments under `baseRtl`. Text
  * segments contribute their text; non-text segments contribute one neutral
  * placeholder so they take the surrounding direction. Each segment is assigned
- * the embedding level of its first code unit (segments are single-script in
- * practice because they are space-split); Canvas resolves any residual
- * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
+ * the embedding level of its first code unit. pptx segments are style-merged
+ * (not word-split), so a single-style segment CAN span a direction boundary;
+ * its internal order is still resolved correctly by Canvas (whole segment in
+ * one fillText with the matching `ctx.direction`), while its position among
+ * neighbours uses the first-unit level — a documented approximation, exact
+ * splitting at level boundaries is tracked as a follow-up.
  */
 export function computeLineVisualOrder(
   segments: readonly unknown[],
@@ -81,31 +87,3 @@ export function computeLineVisualOrder(
   return { order, rtl };
 }
 
-/** Physical edge a line aligns to, resolving logical start/end against base direction. */
-export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
-
-/**
- * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
- * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
- * an unset alignment defaults to the leading (logical-start) edge.
- */
-export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
-  switch (alignment) {
-    case 'center':
-      return 'center';
-    case 'both':
-    case 'justify':
-    case 'distribute':
-      return 'justify';
-    case 'left':
-      return 'left';
-    case 'right':
-      return 'right';
-    case 'end':
-      return baseRtl ? 'left' : 'right';
-    case 'start':
-    case undefined:
-    default:
-      return baseRtl ? 'right' : 'left';
-  }
-}

--- a/packages/pptx/src/bidi-line.ts
+++ b/packages/pptx/src/bidi-line.ts
@@ -1,0 +1,111 @@
+// Per-line bidi ordering for the pptx renderer.
+//
+// Lines are laid out as a list of style/word segments. We reorder at SEGMENT
+// granularity (1:1 with the laid-out segments — every per-segment property is
+// preserved) using the shared UAX#9 engine (rule L2), and let Canvas
+// shape/mirror each segment internally when it is drawn with `ctx.direction`
+// set to the segment's resolved direction. The whole segment string is drawn in
+// one fillText, so Canvas resolves any residual intra-segment bidi. Inline
+// objects (math / image) participate as a single neutral object-replacement
+// character.
+
+import { getDefaultBidiEngine } from '@silurus/ooxml-core';
+
+/** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
+ *  Arabic presentation forms. Used only as a cheap gate to decide whether a
+ *  line needs the (exact) bidi pass at all — never for ordering itself. */
+const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+
+/** A laid-out segment as seen here: only its optional text matters for bidi.
+ *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
+ *  math / tab members carry no `text`) assigns cleanly. */
+const segText = (s: unknown): string | undefined => {
+  const t = (s as { text?: unknown }).text;
+  return typeof t === 'string' ? t : undefined;
+};
+
+/** Cheap test: does this run of segments contain any strong-RTL character? */
+export function segmentsHaveRtl(segments: readonly unknown[]): boolean {
+  for (const s of segments) {
+    const t = segText(s);
+    if (t !== undefined && RTL_GATE.test(t)) return true;
+  }
+  return false;
+}
+
+export interface LineVisualOrder {
+  /** Logical segment indices in visual (left-to-right) order. */
+  order: number[];
+  /** Per-LOGICAL-index resolved direction (true = RTL) for `ctx.direction`. */
+  rtl: boolean[];
+}
+
+const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON)
+
+/**
+ * Compute the visual draw order of a line's segments under `baseRtl`. Text
+ * segments contribute their text; non-text segments contribute one neutral
+ * placeholder so they take the surrounding direction. Each segment is assigned
+ * the embedding level of its first code unit (segments are single-script in
+ * practice because they are space-split); Canvas resolves any residual
+ * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
+ */
+export function computeLineVisualOrder(
+  segments: readonly unknown[],
+  baseRtl: boolean,
+): LineVisualOrder {
+  const n = segments.length;
+  if (n === 0) return { order: [], rtl: [] };
+
+  let full = '';
+  const segStart: number[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    segStart[i] = full.length;
+    const t = segText(segments[i]) ?? '';
+    full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
+  }
+
+  const engine = getDefaultBidiEngine();
+  const { levels, paragraphLevel } = engine.computeLevels(full, baseRtl ? 'rtl' : 'ltr');
+
+  const segLevels = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const lvl = levels[segStart[i]];
+    // 255 = removed by X9 (no glyph); fall back to the paragraph level.
+    segLevels[i] = lvl === 255 ? paragraphLevel : lvl;
+  }
+
+  const order = engine.reorderVisual(segLevels, 0, n);
+  const rtl: boolean[] = new Array(n);
+  for (let i = 0; i < n; i++) rtl[i] = (segLevels[i] & 1) === 1;
+  return { order, rtl };
+}
+
+/** Physical edge a line aligns to, resolving logical start/end against base direction. */
+export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
+
+/**
+ * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
+ * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
+ * an unset alignment defaults to the leading (logical-start) edge.
+ */
+export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
+  switch (alignment) {
+    case 'center':
+      return 'center';
+    case 'both':
+    case 'justify':
+    case 'distribute':
+      return 'justify';
+    case 'left':
+      return 'left';
+    case 'right':
+      return 'right';
+    case 'end':
+      return baseRtl ? 'left' : 'right';
+    case 'start':
+    case undefined:
+    default:
+      return baseRtl ? 'right' : 'left';
+  }
+}

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -18,6 +18,11 @@ import wasmAssetUrl from './wasm/pptx_parser_bg.wasm?url';
  *  substitute into the canvas font stack so missing Office fonts degrade to a
  *  same-width webfont instead of a wider system serif/sans. The remaining
  *  entries omit `loadFamily` because Google Fonts ships the same family name. */
+const NOTO_NASKH_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic:wght@400;700&display=swap';
+const NOTO_SANS_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@400;700&display=swap';
+
 const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'calibri':           { url: 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Carlito' },
   'calibri light':     { url: 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Carlito' },
@@ -32,6 +37,21 @@ const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'poppins':           { url: 'https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'raleway':           { url: 'https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
+  // Common Arabic-script faces that hosts rarely ship. Map them to Noto
+  // substitutes so RTL slides (e.g. sample-10, which requests Sakkal Majalla /
+  // Univers Next Arabic) render with a real web font instead of an oversized
+  // OS fallback. "Naskh" covers traditional serif-like Arabic faces; "Sans"
+  // covers the modern geometric ones.
+  'sakkal majalla':      { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'traditional arabic':  { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'simplified arabic':   { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'arabic typesetting':  { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'univers next arabic': { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
+  // Self-referencing entries so the generic Arabic fallback fonts (appended to
+  // the renderer's font stack) are themselves loaded whenever useGoogleFonts is
+  // enabled — see `load`, which always queues these names.
+  'noto naskh arabic':   { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'noto sans arabic':    { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
 };
 
 /** Options for {@link PptxPresentation.load}. The shared load-options type
@@ -117,7 +137,13 @@ export class PptxPresentation {
     await pres._parse(buffer, opts.maxZipEntryBytes);
     const parsed = pres._presentation;
     if (opts.useGoogleFonts && parsed) {
-      await preloadGoogleFonts([parsed.majorFont, parsed.minorFont], PPTX_GOOGLE_FONTS);
+      // Always load the generic Arabic fallbacks so any Arabic-script run gets
+      // a real web font even when its named family is unmapped (the renderer's
+      // canvas font stack ends with these two Noto faces).
+      await preloadGoogleFonts(
+        [parsed.majorFont, parsed.minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic'],
+        PPTX_GOOGLE_FONTS,
+      );
     }
     return pres;
   }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1561,7 +1561,10 @@ function renderTextBody(
     }
     cursorY += topGapPx;
     entriesInCol++;
-    const xShift = colIdx * colWidthShift;
+    // §21.1.2.1.1 bodyPr@rtlCol: columns fill right-to-left — mirror the
+    // visual column index. LTR bodies (rtlCol false/absent) are unchanged.
+    const visCol = body.rtlCol ? numCol - 1 - colIdx : colIdx;
+    const xShift = visCol * colWidthShift;
     const textX = entry.textX + xShift;
     const bulletX = entry.bulletX + xShift;
     const textMaxW = entry.textMaxW;
@@ -1603,8 +1606,8 @@ function renderTextBody(
       if (paraNeedsBidi && baseRtl) {
         const prevDir = ctx.direction;
         ctx.direction = 'rtl';
-        const bw = ctx.measureText(bulletLabel).width;
-        ctx.fillText(bulletLabel, textX + textMaxW + (textX - bulletX) - bw, baseline);
+        const bulletW = ctx.measureText(bulletLabel).width;
+        ctx.fillText(bulletLabel, textX + textMaxW + (textX - bulletX) - bulletW, baseline);
         ctx.direction = prevDir;
       } else {
         ctx.fillText(bulletLabel, bulletX, baseline);
@@ -1672,14 +1675,21 @@ function renderTextBody(
       if (ls > 0 && seg.text.length > 1 && !segRtl) {
         // Draw glyph-by-glyph so each character advance is `measure + ls`.
         // Matches OOXML rPr @spc semantics — extra space added to each
-        // character's advance, including after the last one. Skipped for RTL
-        // segments: per-glyph advance would break Arabic cursive joining, so we
-        // draw the whole shaped segment in one fillText instead.
+        // character's advance, including after the last one.
         let cx = penX;
         for (const ch of seg.text) {
           ctx.fillText(ch, cx, segBaseline);
           cx += ctx.measureText(ch).width + ls;
         }
+      } else if (ls > 0 && seg.text.length > 1) {
+        // RTL segment with rPr @spc: per-glyph advance would break Arabic
+        // cursive joining, so distribute the spacing via canvas letterSpacing
+        // and draw the whole shaped segment in one fillText. The painted width
+        // then matches the segW advance below (baseW + ls per character).
+        const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+        try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
+        ctx.fillText(seg.text, penX, segBaseline);
+        try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
       } else {
         ctx.fillText(seg.text, penX, segBaseline);
       }
@@ -1704,6 +1714,11 @@ function renderTextBody(
             ctx.strokeText(ch, cx, segBaseline);
             cx += ctx.measureText(ch).width + ls;
           }
+        } else if (ls > 0 && seg.text.length > 1) {
+          const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+          try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
+          ctx.strokeText(seg.text, penX, segBaseline);
+          try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
         } else {
           ctx.strokeText(seg.text, penX, segBaseline);
         }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1161,7 +1161,8 @@ function renderTextBody(
   slideNumber?: number,
   rc: RenderContext = { themeMajorFont: null, themeMinorFont: null },
   onTextRun?: TextRunCallback,
-) {
+  measureOnly = false,
+): number | void {
   // Vertical text: rotate rendering context so text flows top-to-bottom.
   // "vert" and "eaVert" both approximate to 90° clockwise rotation.
   // "vert270" rotates 270° (= 90° counterclockwise).
@@ -1200,6 +1201,11 @@ function renderTextBody(
         })
       : undefined;
 
+    if (measureOnly) {
+      // The rotated sub-frame's content height runs along the original width
+      // axis; for a table row the vertical extent is the original box width.
+      return bw;
+    }
     ctx.save();
     ctx.translate(cx, cy);
     ctx.rotate(isVert270 ? -Math.PI / 2 : Math.PI / 2);
@@ -1472,6 +1478,13 @@ function renderTextBody(
         ({ allLines, totalHeight } = buildLayout(lo));
       }
     }
+  }
+
+  // ── measure-only: return the content height the text body needs ─────────
+  // Used by renderTable to grow rows to fit their tallest cell (ECMA-376
+  // §21.1.3.18: a:tr@h is a minimum). Returns padding + laid-out text height.
+  if (measureOnly) {
+    return tPad + totalHeight + bPad;
   }
 
   // ── anchor="b" with bh=0: auto-height growing upward from by ────────────
@@ -2132,34 +2145,119 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
   const x0 = emuToPx(el.x, scale);
   const y0 = emuToPx(el.y, scale);
 
-  // Convert col widths and row heights to pixels
+  // Convert col widths to pixels.
   const colWidths = el.cols.map(c => emuToPx(c, scale));
+  const numCols = colWidths.length;
+
+  // Spanned width starting at column `ci` for `span` columns.
+  const spannedWidth = (ci: number, span: number): number => {
+    let w = 0;
+    for (let s = 0; s < span; s++) w += colWidths[ci + s] ?? 0;
+    return w;
+  };
+
+  // ── Row heights: ECMA-376 §21.1.3.18 (a:tr@h) is a MINIMUM ────────────────
+  // PowerPoint grows a row to fit its tallest cell's laid-out text (like
+  // Word's "at least" line rule). A literal h=0 therefore becomes
+  // content-driven. We measure each cell's text body at its spanned width
+  // (reusing the same renderTextBody machinery via measureOnly) and take
+  // max(tr@h, tallest single-row cell content). A rowSpan cell distributes
+  // its content height across the rows it covers so it doesn't inflate the
+  // first row.
   const rowHeights = el.rows.map(r => emuToPx(r.height, scale));
 
-  let rowY = y0;
+  // First pass: single-row (rowSpan ≤ 1) cells set their own row's minimum.
   for (let ri = 0; ri < el.rows.length; ri++) {
     const row = el.rows[ri];
-    const rowH = rowHeights[ri];
-    let colX = x0;
+    for (let ci = 0; ci < row.cells.length; ci++) {
+      const cell = row.cells[ci];
+      if (cell.hMerge || cell.vMerge) continue;
+      if ((cell.rowSpan || 1) > 1) continue;
+      if (!cell.textBody) continue;
+      const cellW = spannedWidth(ci, cell.gridSpan || 1);
+      const needed = (renderTextBody(
+        ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
+        '#000000', slideNumber, rc, undefined, true,
+      ) as number) || 0;
+      if (needed > rowHeights[ri]) rowHeights[ri] = needed;
+    }
+  }
+
+  // Second pass: rowSpan cells. If the content needs more than the sum of the
+  // rows it spans, distribute the deficit across those rows so the merged area
+  // grows without inflating any single row beyond what its own content needs.
+  for (let ri = 0; ri < el.rows.length; ri++) {
+    const row = el.rows[ri];
+    for (let ci = 0; ci < row.cells.length; ci++) {
+      const cell = row.cells[ci];
+      if (cell.hMerge || cell.vMerge) continue;
+      const span = cell.rowSpan || 1;
+      if (span <= 1 || !cell.textBody) continue;
+      const cellW = spannedWidth(ci, cell.gridSpan || 1);
+      const needed = (renderTextBody(
+        ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
+        '#000000', slideNumber, rc, undefined, true,
+      ) as number) || 0;
+      let have = 0;
+      for (let s = 0; s < span && ri + s < rowHeights.length; s++) have += rowHeights[ri + s];
+      if (needed > have) {
+        const extra = (needed - have) / span;
+        for (let s = 0; s < span && ri + s < rowHeights.length; s++) rowHeights[ri + s] += extra;
+      }
+    }
+  }
+
+  // ── Column x-positions ────────────────────────────────────────────────────
+  // ECMA-376 §21.1.3.13 (a:tblPr@rtl): a right-to-left table places column 0
+  // at the right edge, columns advancing leftward. We precompute the left
+  // pixel edge of each column so RTL is a coordinate flip (no ctx.scale(-1,1)
+  // which would mirror text and borders).
+  const tableW = colWidths.reduce((a, b) => a + b, 0);
+  const colLeft: number[] = new Array(numCols);
+  if (el.rtl) {
+    let right = x0 + tableW;
+    for (let ci = 0; ci < numCols; ci++) {
+      right -= colWidths[ci];
+      colLeft[ci] = right;
+    }
+  } else {
+    let left = x0;
+    for (let ci = 0; ci < numCols; ci++) {
+      colLeft[ci] = left;
+      left += colWidths[ci];
+    }
+  }
+
+  // Left pixel edge of a cell spanning columns [ci, ci+span). Under RTL the
+  // span grows leftward, so the merged cell's left edge is the leftmost column.
+  const spannedLeft = (ci: number, span: number): number =>
+    el.rtl ? colLeft[ci + span - 1] : colLeft[ci];
+
+  const rowTop: number[] = new Array(el.rows.length);
+  {
+    let y = y0;
+    for (let ri = 0; ri < el.rows.length; ri++) { rowTop[ri] = y; y += rowHeights[ri]; }
+  }
+
+  for (let ri = 0; ri < el.rows.length; ri++) {
+    const row = el.rows[ri];
+    const rowY = rowTop[ri];
 
     for (let ci = 0; ci < row.cells.length; ci++) {
       const cell = row.cells[ci];
 
       // Merged cells that are continuations: skip drawing
       if (cell.hMerge || cell.vMerge) {
-        colX += colWidths[ci] ?? 0;
         continue;
       }
 
       // Cell size: span multiple columns/rows
-      let cellW = 0;
-      for (let span = 0; span < (cell.gridSpan || 1); span++) {
-        cellW += colWidths[ci + span] ?? 0;
-      }
+      const cellW = spannedWidth(ci, cell.gridSpan || 1);
       let cellH = 0;
       for (let span = 0; span < (cell.rowSpan || 1); span++) {
         cellH += rowHeights[ri + span] ?? 0;
       }
+      const colX = spannedLeft(ci, cell.gridSpan || 1);
 
       // Fill
       const fillColor = resolveFill(cell.fill);
@@ -2221,10 +2319,7 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
         ctx.stroke();
       }
       ctx.restore();
-
-      colX += colWidths[ci] ?? 0;
     }
-    rowY += rowH;
   }
 }
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -431,7 +431,22 @@ const OFFICE_FONT_SUBSTITUTE: Record<string, string> = {
   'calibri light': 'Carlito',
   'cambria': 'Caladea',
   'cambria math': 'Caladea',
+  // Common Arabic-script faces that hosts rarely ship. Map them to Noto
+  // substitutes so RTL slides (e.g. sample-10, which requests Sakkal Majalla /
+  // Univers Next Arabic) render with a real web font instead of an oversized
+  // OS fallback. "Naskh" covers traditional serif-like Arabic faces; "Sans"
+  // covers the modern geometric ones.
+  'sakkal majalla': 'Noto Naskh Arabic',
+  'traditional arabic': 'Noto Naskh Arabic',
+  'simplified arabic': 'Noto Naskh Arabic',
+  'arabic typesetting': 'Noto Naskh Arabic',
+  'univers next arabic': 'Noto Sans Arabic',
 };
+
+/** Generic Arabic fallbacks appended to every named-font canvas stack (before
+ *  the CSS generic) so Arabic-script glyphs in an unmapped family still resolve
+ *  to a real Arabic web font when `useGoogleFonts` is on. */
+const ARABIC_FALLBACKS = '"Noto Naskh Arabic", "Noto Sans Arabic"';
 
 function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string, rc: RenderContext): string {
   const style  = italic ? 'italic ' : '';
@@ -440,12 +455,12 @@ function buildFont(bold: boolean, italic: boolean, sizePx: number, family: strin
   if (CSS_GENERIC_FAMILIES.has(normalized)) {
     return `${style}${weight}${sizePx}px ${normalized}`;
   }
-  // Named font + (metric-compatible substitute, if an Office face) + inferred
-  // generic fallback, so browsers degrade consistently when the exact typeface
-  // is not installed.
+  // Named font + (metric-compatible substitute, if an Office face) + generic
+  // Arabic web fonts + inferred generic fallback, so browsers degrade
+  // consistently when the exact typeface is not installed.
   const sub = OFFICE_FONT_SUBSTITUTE[normalized.toLowerCase()];
   const subPart = sub ? `"${sub}", ` : '';
-  return `${style}${weight}${sizePx}px "${normalized}", ${subPart}${genericFallback(normalized)}`;
+  return `${style}${weight}${sizePx}px "${normalized}", ${subPart}${ARABIC_FALLBACKS}, ${genericFallback(normalized)}`;
 }
 
 /**

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -33,6 +33,11 @@ import {
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import { drawPlayBadge } from './media-chrome';
 import { renderPresetShape, hasPreset, getConnectorAnchors } from './preset-shape';
+import {
+  segmentsHaveRtl,
+  computeLineVisualOrder,
+  type LineVisualOrder,
+} from './bidi-line';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -1561,6 +1566,12 @@ function renderTextBody(
     const bulletX = entry.bulletX + xShift;
     const textMaxW = entry.textMaxW;
 
+    // Bidi: base direction from a:pPr@rtl (the parser already flips the default
+    // alignment l→r for rtl paragraphs). Engage only when the base is RTL or a
+    // line carries strong-RTL characters, so LTR slides keep their exact path.
+    const baseRtl = entry.para.rtl === true;
+    const paraNeedsBidi = baseRtl || segmentsHaveRtl(line.segments);
+
     // Measure line for alignment AND baseline ascent in one pass.
     // actualBoundingBoxAscent gives the real font ascent for the rendered glyphs,
     // replacing the 0.8×lineHeight heuristic that over-estimates for CJK and
@@ -1583,11 +1594,21 @@ function renderTextBody(
     }
     const baseline = cursorY + maxAscent;
 
-    // Draw bullet
+    // Draw bullet. Under RTL the bullet hangs in the right gutter: mirror its
+    // LTR offset (textX − bulletX, i.e. the bullet→text gap) about the text
+    // column's right edge.
     if (bulletLabel) {
       ctx.font = bulletFont;
       ctx.fillStyle = bulletColor;
-      ctx.fillText(bulletLabel, bulletX, baseline);
+      if (paraNeedsBidi && baseRtl) {
+        const prevDir = ctx.direction;
+        ctx.direction = 'rtl';
+        const bw = ctx.measureText(bulletLabel).width;
+        ctx.fillText(bulletLabel, textX + textMaxW + (textX - bulletX) - bw, baseline);
+        ctx.direction = prevDir;
+      } else {
+        ctx.fillText(bulletLabel, bulletX, baseline);
+      }
     }
 
     const effectiveTextX = textX + textXOffset;
@@ -1600,7 +1621,18 @@ function renderTextBody(
       penX = effectiveTextX;
     }
 
-    for (const seg of line.segments) {
+    // Visual draw order: under bidi, reorder segments per UAX#9 (rule L2) and
+    // draw each with ctx.direction matching its resolved direction. textAlign
+    // is already 'left', so penX stays the segment's left edge.
+    const visual: LineVisualOrder | null = paraNeedsBidi
+      ? computeLineVisualOrder(line.segments, baseRtl)
+      : null;
+    const segCount = line.segments.length;
+    for (let vi = 0; vi < segCount; vi++) {
+      const li = visual ? visual.order[vi] : vi;
+      const seg = line.segments[li];
+      const segRtl = visual ? visual.rtl[li] : false;
+      if (paraNeedsBidi) ctx.direction = segRtl ? 'rtl' : 'ltr';
       // ── Equation segment: draw the cached image instead of text ──────────
       if (seg.math) {
         const render = mathRenders.get(seg.math.nodes);
@@ -1637,10 +1669,12 @@ function renderTextBody(
         ctx.shadowOffsetY = Math.sin(dirRad) * dist;
       }
 
-      if (ls > 0 && seg.text.length > 1) {
+      if (ls > 0 && seg.text.length > 1 && !segRtl) {
         // Draw glyph-by-glyph so each character advance is `measure + ls`.
         // Matches OOXML rPr @spc semantics — extra space added to each
-        // character's advance, including after the last one.
+        // character's advance, including after the last one. Skipped for RTL
+        // segments: per-glyph advance would break Arabic cursive joining, so we
+        // draw the whole shaped segment in one fillText instead.
         let cx = penX;
         for (const ch of seg.text) {
           ctx.fillText(ch, cx, segBaseline);
@@ -1664,7 +1698,7 @@ function renderTextBody(
         ctx.lineWidth = Math.max(0.5, emuToPx(segOutline.width, scale));
         ctx.strokeStyle = segOutline.color ? `#${segOutline.color}` : seg.color;
         ctx.lineJoin = 'round';
-        if (ls > 0 && seg.text.length > 1) {
+        if (ls > 0 && seg.text.length > 1 && !segRtl) {
           let cx = penX;
           for (const ch of seg.text) {
             ctx.strokeText(ch, cx, segBaseline);
@@ -1728,6 +1762,7 @@ function renderTextBody(
 
       penX += segW;
     }
+    if (paraNeedsBidi) ctx.direction = 'ltr'; // reset before tab-stop / next line
 
     // ── Tab-stop segments (right-aligned or centred at tab stop position) ──
     if (line.tabStop && line.tabStop.segments.length > 0) {

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -148,6 +148,8 @@ export interface TableElement {
   /** Column widths in EMU */
   cols: number[];
   rows: TableRow[];
+  /** `<a:tblPr rtl="1">` (ECMA-376 §21.1.3.13): right-to-left table — column 0 at the right edge. */
+  rtl?: boolean;
 }
 
 export interface TableRow {


### PR DESCRIPTION
PR3 of the RTL series (#366). Stacked on `feature/rtl-core` (#367).

Makes the **pptx renderer** consume the core bidi engine in the text-body draw loop: each line's segments are reordered into visual order (UAX#9 rule L2) and drawn with `ctx.direction` set to their resolved direction. Engaged only when the paragraph base is RTL (`a:pPr@rtl`; the parser already flips the default alignment l→r) or a line carries strong-RTL chars, so **LTR slides keep their exact path (demo VRT 9/9 unchanged)**.

- RTL bullets hang in the right gutter.
- The glyph-by-glyph letter-spacing path is **skipped for RTL segments** — per-glyph advance breaks Arabic cursive joining, so the whole shaped segment is drawn in one `fillText`.
- Shape / text-box paragraphs reorder the same way.
- New `bidi-line.ts` + unit tests.

## Verification
- **sample-10 slide 1** (stress test): RTL title, mixed-bidi paragraph with embedded Latin (`shape`, `text-box`) + numbers (`1234.56`, `٧٨٩`), RTL bullets with markers on the right (incl. `English و 42`), and an RTL text-box (`text inside a shape — نص داخل شكل ملوّن`) — all render correctly RTL.
- pptx demo VRT: 9/9, identical (no LTR regression).

## Notes
- `sample-10.pdf` is stale (1 page) vs the current 2-slide `sample-10.pptx`, so verification is by RTL-correctness, not pixel match.
- **slide 2 table** cell content overlaps — present identically in the pre-change baseline, i.e. a pre-existing pptx table column/row sizing bug (not bidi). RTL table column reversal (`rtlCol`) is deferred until that sizing bug is fixed (can't verify against an overlapping baseline). Flagged for follow-up.

No squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)