### PR TITLE
fix(docx): treat exact/auto line spacing of 0 as single line (table row collapse)

### DIFF
--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -5,8 +5,10 @@ import type { LineSpacing } from './types.js';
 // Regression: some generators emit <w:spacing w:line="0" w:lineRule="exact"/> on
 // table cells (e.g. private/sample-7.docx). A literal exact-0 line collapsed every
 // line to 0px, so table rows fell back to the 10px minimum and cell content
-// overlapped. Word ignores a zero line value and uses single spacing; lineBoxHeight
-// must do the same (ECMA-376 §17.3.1.33).
+// overlapped. ECMA-376 §17.3.1.33 leaves a zero line undefined; Word's native
+// model ([MS-DOC] LSPD) cannot represent an exact 0 (exact = negative dyaLine)
+// and resolves a non-negative dyaLine as max(dyaLine, single spacing) — so 0
+// means exactly single spacing. lineBoxHeight must do the same.
 
 const exact = (value: number): LineSpacing => ({ value, rule: 'exact', explicit: true });
 const auto = (value: number): LineSpacing => ({ value, rule: 'auto', explicit: true });

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { lineBoxHeight } from './renderer.js';
+import type { LineSpacing } from './types.js';
+
+// Regression: some generators emit <w:spacing w:line="0" w:lineRule="exact"/> on
+// table cells (e.g. private/sample-7.docx). A literal exact-0 line collapsed every
+// line to 0px, so table rows fell back to the 10px minimum and cell content
+// overlapped. Word ignores a zero line value and uses single spacing; lineBoxHeight
+// must do the same (ECMA-376 §17.3.1.33).
+
+const exact = (value: number): LineSpacing => ({ value, rule: 'exact', explicit: true });
+const auto = (value: number): LineSpacing => ({ value, rule: 'auto', explicit: true });
+
+describe('lineBoxHeight — degenerate zero line spacing', () => {
+  // ascent 12 + descent 3 = 15px natural single-line height (no grid).
+  it('treats exact line=0 as single spacing (natural), not 0', () => {
+    expect(lineBoxHeight(exact(0), 12, 3, 1, undefined)).toBe(15);
+  });
+  it('treats auto value=0 as single spacing (natural), not 0', () => {
+    expect(lineBoxHeight(auto(0), 12, 3, 1, undefined)).toBe(15);
+  });
+  it('still honors a positive exact line value', () => {
+    expect(lineBoxHeight(exact(240), 12, 3, 1, undefined)).toBe(240);
+  });
+  it('still applies the auto multiplier for a positive value', () => {
+    expect(lineBoxHeight(auto(2), 12, 3, 1, undefined)).toBe(30); // natural 15 × 2
+  });
+  it('unspecified spacing is single (natural)', () => {
+    expect(lineBoxHeight(null, 12, 3, 1, undefined)).toBe(15);
+  });
+});

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -22,7 +22,18 @@ describe('lineBoxHeight — degenerate zero line spacing', () => {
     expect(lineBoxHeight(auto(0), 12, 3, 1, undefined)).toBe(15);
   });
   it('still honors a positive exact line value', () => {
-    expect(lineBoxHeight(exact(240), 12, 3, 1, undefined)).toBe(240);
+    // 12pt exact (w:line="240" twips / 20 = 12pt; LineSpacing.value is pt).
+    expect(lineBoxHeight(exact(12), 12, 3, 1, undefined)).toBe(12);
+  });
+  it('treats negative exact/auto values as single spacing too', () => {
+    expect(lineBoxHeight(exact(-5), 12, 3, 1, undefined)).toBe(15);
+    expect(lineBoxHeight(auto(-1), 12, 3, 1, undefined)).toBe(15);
+  });
+  it('snaps a degenerate line to the grid pitch in docGrid sections', () => {
+    // Same fallback as unspecified spacing: on-grid, the pitch governs.
+    expect(
+      lineBoxHeight(exact(0), 12, 3, 1, { type: 'lines', linePitchPt: 18 }),
+    ).toBe(18);
   });
   it('still applies the auto multiplier for a positive value', () => {
     expect(lineBoxHeight(auto(2), 12, 3, 1, undefined)).toBe(30); // natural 15 × 2

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2999,12 +2999,20 @@ export function lineBoxHeight(
     // as the overflow floor (the grid, not the font metric, governs height).
     return hasGrid ? Math.max(glyphNatural, pitchPx) : natural;
   }
-  // ECMA-376 §17.3.1.33: a zero (or negative) `w:line` is degenerate — an
-  // `exact`/`auto` line of 0 would collapse the line to no height. Word ignores
-  // it and falls back to single line spacing instead of clipping the text away.
-  // (Some generators emit `<w:spacing w:line="0" w:lineRule="exact"/>` on table
-  // cells, e.g. sample-7; the Word-exported PDF renders those rows at normal
-  // height.) Treat it like unspecified spacing.
+  // A zero/negative `w:line` is degenerate input whose behavior ECMA-376
+  // §17.3.1.33 does not define (read literally, an `exact` line of 0 would
+  // collapse the line box to no height; some generators emit
+  // `<w:spacing w:line="0" w:lineRule="exact"/>` on table cells, e.g. sample-7).
+  // Word's native model has no such state: per the [MS-DOC] LSPD structure,
+  // "exact" spacing is encoded as a negative dyaLine ("the line spacing, in
+  // twips, is exactly 0x10000 minus dyaLine", so an exact 0 is unrepresentable)
+  // and a non-negative dyaLine in twips mode is "dyaLine or the number of twips
+  // necessary for single spacing, whichever value is greater" — i.e. a stored 0
+  // resolves to exactly single spacing. Word's PDF export of sample-7 confirms
+  // (those rows render at normal single-line height). Match that: treat
+  // exact/auto line <= 0 as single spacing. (LSPD's max() rule is the twips
+  // mode; applying the same fallback to a degenerate auto multiplier <= 0 is
+  // the analogous non-collapsing reading.)
   if ((ls.rule === 'exact' || ls.rule === 'auto') && ls.value <= 0) {
     return hasGrid ? Math.max(glyphNatural, pitchPx) : natural;
   }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2955,7 +2955,7 @@ function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
  *   atLeast → max(natural, value in pt × scale).
  *   null    → natural, or grid pitch if the section defines one.
  */
-function lineBoxHeight(
+export function lineBoxHeight(
   ls: LineSpacing | null,
   ascentPx: number,
   descentPx: number,
@@ -2997,6 +2997,15 @@ function lineBoxHeight(
     // No explicit spacing → single line. Use the intended single-line height
     // (`natural`) off-grid; on-grid, snap to the pitch with the glyph extent
     // as the overflow floor (the grid, not the font metric, governs height).
+    return hasGrid ? Math.max(glyphNatural, pitchPx) : natural;
+  }
+  // ECMA-376 §17.3.1.33: a zero (or negative) `w:line` is degenerate — an
+  // `exact`/`auto` line of 0 would collapse the line to no height. Word ignores
+  // it and falls back to single line spacing instead of clipping the text away.
+  // (Some generators emit `<w:spacing w:line="0" w:lineRule="exact"/>` on table
+  // cells, e.g. sample-7; the Word-exported PDF renders those rows at normal
+  // height.) Treat it like unspecified spacing.
+  if ((ls.rule === 'exact' || ls.rule === 'auto') && ls.value <= 0) {
     return hasGrid ? Math.max(glyphNatural, pitchPx) : natural;
   }
   if (ls.rule === 'auto') {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2954,6 +2954,9 @@ function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
  *   exact   → value in pt, converted to px (ignores font and grid).
  *   atLeast → max(natural, value in pt × scale).
  *   null    → natural, or grid pitch if the section defines one.
+ *
+ * Exported for unit tests only — not part of the package API (not
+ * re-exported from index.ts).
  */
 export function lineBoxHeight(
   ls: LineSpacing | null,

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -171,7 +171,7 @@ export interface TabStop {
 }
 
 export interface LineSpacing {
-  value: number;   // multiplier (auto/atLeast) or pt (exact)
+  value: number;   // multiplier (auto) or pt (exact/atLeast)
   rule: 'auto' | 'exact' | 'atLeast';
   /** True when `w:spacing/@w:line` was set on the paragraph's own pPr or on a
    *  named style (not inherited solely from docDefault). Per ECMA-376 §17.6.5,


### PR DESCRIPTION
Independent of the RTL work — a pre-existing layout bug surfaced while reviewing `private/sample-7.docx` (reproduces on `main`, LTR).

## Symptom
On sample-7 page 2, the 6-column "المراحل التنفيذية الرئيسية" table renders with all cell content (headers, dates, wrapped Arabic) crammed into a thin overlapping band — "table cell sizes wrong / date font size wrong".

## Root cause (systematic-debugging)
Those table cells carry `<w:spacing w:after="0" w:line="0" w:lineRule="exact"/>`. `lineBoxHeight` honored the **exact line of 0** literally and returned `0 * scale = 0`, so every text line had **0 height** → `calculateRowHeight` found no content height → rows fell back to the **10px minimum** → 12pt text from each row overlapped its neighbours. Confirmed by instrumenting the measurement chain (`rowHeights = [17.5, 10, 10, 10, 10]`; per-line height `0`; `lineSpacing = {value:0, rule:'exact'}`).

## Spec basis
- **ECMA-376 §17.3.1.33 does not define a zero `w:line`** — the literal reading (height exactly 0) is the collapse the old code produced.
- **Word's native model cannot represent it**: per [[MS-DOC] LSPD](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-doc/fcdd2b79-9d47-4e0c-b1fd-705aeab88e41), *exact* spacing is encoded as a **negative** `dyaLine` ("the line spacing, in twips, is exactly 0x10000 minus dyaLine" — an exact 0 is unrepresentable), and a **non-negative** `dyaLine` in twips mode is "**dyaLine or the number of twips necessary for single spacing, whichever value is greater**" — i.e. a stored 0 resolves to **exactly single spacing**.
- Word's PDF export of sample-7 confirms: those rows render at normal single-line height.

## Fix
In `lineBoxHeight`, treat an `exact`/`auto` line value ≤ 0 as single line spacing instead of collapsing to 0 (the `auto ≤ 0` case is the analogous non-collapsing reading of the same degenerate input; LSPD's max() rule is the twips mode). Positive values are unchanged. Export `lineBoxHeight` + add a regression test.

## Verification
- New unit test (5 cases) covering exact-0 / auto-0 / positive values / null.
- docx demo VRT: 6/6 unchanged (no LTR regression).
- sample-7 p2 table now lays out with correct row heights, wrapped cell content, and properly-sized dates — matching the PDF structure.

## Known residual (separate, not this bug)
Word *autofits* the column widths (e.g. `#` narrow, اسم المرحلة wide) while we use the uniform `w:tblGrid`, so the date columns are a touch tight. Changing column widths alters every table's rendering and would require re-approving VRT reference images, so it's tracked separately. (The date *order* `28-02-2026` vs `2026-02-28` is a bidi effect handled by the RTL docx PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
