### PR TITLE
fix(docx): RTL table follow-ups — column auto-fit by content width + complex-script bold axis

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1106,6 +1106,12 @@ fn parse_run_inner(
     let rtl = fmt.rtl;
     let font_family_cs = theme.resolve_font_ref(fmt.font_family_cs.clone());
     let font_size_cs = fmt.font_size_cs;
+    // Complex-script bold/italic (ECMA-376 §17.3.2.4 / §17.3.2.6). Surfaced as
+    // Option so the renderer can apply them on the CS axis for rtl/cs runs:
+    // `None` ⇒ not set anywhere in the style chain ⇒ not bold/italic for CS
+    // glyphs, regardless of the non-CS `b`/`i`.
+    let bold_cs = fmt.bold_cs;
+    let italic_cs = fmt.italic_cs;
 
     for child in node.children().filter(|n| n.is_element()) {
         match child.tag_name().name() {
@@ -1137,6 +1143,8 @@ fn parse_run_inner(
                         rtl,
                         font_family_cs: font_family_cs.clone(),
                         font_size_cs,
+                        bold_cs,
+                        italic_cs,
                     }));
                 }
             }
@@ -1164,6 +1172,8 @@ fn parse_run_inner(
                     rtl,
                     font_family_cs: font_family_cs.clone(),
                     font_size_cs,
+                    bold_cs,
+                    italic_cs,
                 }));
             }
             "br" => {
@@ -1260,6 +1270,8 @@ fn parse_run_inner(
                     rtl,
                     font_family_cs: font_family_cs.clone(),
                     font_size_cs,
+                    bold_cs,
+                    italic_cs,
                 }));
             }
             "AlternateContent" => {
@@ -2535,6 +2547,8 @@ fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
     if direct.rtl.is_some() { base.rtl = direct.rtl; }
     if direct.font_family_cs.is_some() { base.font_family_cs = direct.font_family_cs.clone(); }
     if direct.font_size_cs.is_some() { base.font_size_cs = direct.font_size_cs; }
+    if direct.bold_cs.is_some() { base.bold_cs = direct.bold_cs; }
+    if direct.italic_cs.is_some() { base.italic_cs = direct.italic_cs; }
 }
 
 fn parse_rels(xml: &str) -> HashMap<String, String> {
@@ -2753,5 +2767,56 @@ mod rtl_tests {
             _ => None,
         }).unwrap();
         assert_eq!(run.rtl, Some(false));
+    }
+
+    /// ECMA-376 §17.3.2.4 w:bCs / §17.3.2.6 w:iCs are INDEPENDENT toggles from
+    /// §17.3.2.3 w:b / §17.3.2.5 w:i. A run that sets only `w:b` (no `w:bCs`)
+    /// must surface `bold_cs == None`, so a complex-script consumer renders it
+    /// non-bold — this is the sample-7 date-cell case where Word draws the
+    /// dates at regular weight despite the run carrying `w:b`.
+    #[test]
+    fn complex_script_bold_is_independent_of_non_cs_bold() {
+        let body = body_from(
+            r#"<w:p><w:r>
+                <w:rPr><w:rtl/><w:cs/><w:b/><w:szCs w:val="24"/></w:rPr>
+                <w:t>28-02-2026</w:t>
+            </w:r></w:p>"#,
+        );
+        let para = body.iter().find_map(|e| match e {
+            BodyElement::Paragraph(p) => Some(p),
+            _ => None,
+        }).unwrap();
+        let run = para.runs.iter().find_map(|r| match r {
+            DocRun::Text(t) => Some(t),
+            _ => None,
+        }).unwrap();
+        // `w:b` sets the non-CS bold…
+        assert_eq!(run.bold, true, "w:b sets non-CS bold");
+        // …but `w:bCs` is absent, so the CS bold axis stays None (inherit/off),
+        // NOT derived from w:b.
+        assert_eq!(run.bold_cs, None, "absent w:bCs must not inherit w:b");
+        assert_eq!(run.italic_cs, None, "absent w:iCs must not inherit w:i");
+    }
+
+    /// An explicit `w:bCs` / `w:iCs` is surfaced on its own axis (and honors the
+    /// `w:val="0"` off form, §17.3.2.22), independent of `w:b`/`w:i`.
+    #[test]
+    fn complex_script_bold_italic_surface_when_present() {
+        let body = body_from(
+            r#"<w:p><w:r>
+                <w:rPr><w:rtl/><w:bCs/><w:iCs w:val="0"/></w:rPr>
+                <w:t>عربي</w:t>
+            </w:r></w:p>"#,
+        );
+        let para = body.iter().find_map(|e| match e {
+            BodyElement::Paragraph(p) => Some(p),
+            _ => None,
+        }).unwrap();
+        let run = para.runs.iter().find_map(|r| match r {
+            DocRun::Text(t) => Some(t),
+            _ => None,
+        }).unwrap();
+        assert_eq!(run.bold_cs, Some(true), "w:bCs sets the CS bold axis");
+        assert_eq!(run.italic_cs, Some(false), "w:iCs val=0 turns CS italic off");
     }
 }

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -37,6 +37,14 @@ pub struct RunFmt {
     /// ECMA-376 §17.3.2.39 w:szCs/@w:val — complex-script font size in pt
     /// (converted from half-points, same units as `font_size`).
     pub font_size_cs: Option<f64>,
+    /// ECMA-376 §17.3.2.4 w:bCs — bold toggle for complex-script text. This is
+    /// an INDEPENDENT toggle from §17.3.2.3 w:b (which applies to non-complex
+    /// text): an absent w:bCs does not inherit `b`'s value but resolves through
+    /// the style chain on its own axis. RTL/complex-script runs take this value.
+    pub bold_cs: Option<bool>,
+    /// ECMA-376 §17.3.2.6 w:iCs — italic toggle for complex-script text.
+    /// Independent of §17.3.2.5 w:i, same as `bold_cs` above.
+    pub italic_cs: Option<bool>,
 }
 
 /// Resolved paragraph formatting.
@@ -365,6 +373,8 @@ fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.rtl.is_some() { dst.rtl = src.rtl; }
     if src.font_family_cs.is_some() { dst.font_family_cs = src.font_family_cs.clone(); }
     if src.font_size_cs.is_some() { dst.font_size_cs = src.font_size_cs; }
+    if src.bold_cs.is_some() { dst.bold_cs = src.bold_cs; }
+    if src.italic_cs.is_some() { dst.italic_cs = src.italic_cs; }
 }
 
 pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
@@ -536,6 +546,11 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
 
     fmt.bold = bool_prop(rpr, "b");
     fmt.italic = bool_prop(rpr, "i");
+    // Complex-script bold/italic toggles (ECMA-376 §17.3.2.4 w:bCs,
+    // §17.3.2.6 w:iCs). Parsed on their own axis — never derived from b/i —
+    // so RTL/complex-script runs resolve weight/slant independently per spec.
+    fmt.bold_cs = bool_prop(rpr, "bCs");
+    fmt.italic_cs = bool_prop(rpr, "iCs");
     fmt.strikethrough = bool_prop(rpr, "strike");
 
     // Underline

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -549,6 +549,17 @@ pub struct TextRun {
     /// units as `font_size`). `None` when unspecified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size_cs: Option<f64>,
+    /// ECMA-376 §17.3.2.4 `<w:bCs>` — bold toggle for complex-script text.
+    /// Independent of `bold` (§17.3.2.3 w:b). `None` when unspecified, in which
+    /// case a complex-script run is NOT bold (the toggle resolved to absent
+    /// through the whole style chain). `false` is meaningful: an explicit
+    /// `<w:bCs w:val="0"/>` turning off an inherited complex-script bold.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bold_cs: Option<bool>,
+    /// ECMA-376 §17.3.2.6 `<w:iCs>` — italic toggle for complex-script text.
+    /// Independent of `italic` (§17.3.2.5 w:i), same semantics as `bold_cs`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub italic_cs: Option<bool>,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -753,7 +753,7 @@ function splitParagraphAcrossPages(
  *  renderer's row sizing (exact / atLeast / auto + vMerge span distribution,
  *  ECMA-376 §17.4.80, §17.4.85). */
 function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt: number): number[] {
-  const colWidths = resolveColumnWidths(table, contentWPt);
+  const colWidths = resolveColumnWidths(table, contentWPt, state);
 
   const rowHs: number[] = [];
   const restartInfo: Array<{ ri: number; ci: number; contentH: number }> = [];
@@ -830,23 +830,141 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
  * then multiplies by the device scale) and `computeTableRowHeights` (which
  * works directly in pt) consume this.
  */
-function resolveColumnWidths(table: DocTable, contentWPt: number): number[] {
+/** Minimum content width (pt) of a single cell: the widest non-breakable token
+ *  across its paragraphs plus the cell's left/right margins. A column can never
+ *  be narrower than this without clipping/wrapping the longest word — Word's
+ *  auto-fit (ECMA-376 §17.4.52) treats it as the column's hard floor when the
+ *  preferred widths overflow, which is why date strings like "2026-02-28" stay
+ *  on one line even though their preferred `tcW` gets squeezed. */
+function cellMinContentPt(cell: DocTableCell, table: DocTable, state: RenderState): number {
+  const { ctx, fontFamilyClasses } = state;
+  let maxTokenPt = 0;
+  const scanPara = (para: DocParagraph): void => {
+    for (const run of para.runs) {
+      if (run.type !== 'text') continue;
+      const t = run as unknown as DocxTextRun & { type: 'text' };
+      if (!t.text) continue;
+      const eff = effectiveRunStyle(t);
+      // Measure in pt-space (font size in pt, scale 1) so the result composes
+      // directly with the pt-based column math.
+      ctx.font = buildFont(eff.bold, eff.italic, eff.fontSize, eff.fontFamily, fontFamilyClasses);
+      // Non-breakable tokens are the same units the line layout treats as
+      // atomic (UAX#14 has no break inside a word or between a digit and an
+      // adjacent hyphen/period). CJK breaks per-glyph, so its min is one glyph.
+      for (const piece of t.text.split('\t')) {
+        for (const token of splitTextForLayout(piece)) {
+          const trimmed = token.replace(/\s+$/u, '');
+          if (!trimmed) continue;
+          const w = hasCJKBreakOpportunity(trimmed)
+            ? Math.max(...[...trimmed].map((ch) => ctx.measureText(ch).width))
+            : ctx.measureText(trimmed).width;
+          if (w > maxTokenPt) maxTokenPt = w;
+        }
+      }
+    }
+  };
+  for (const ce of cell.content) {
+    if (ce.type === 'paragraph') scanPara(ce as unknown as DocParagraph);
+    // Nested tables: their own columns handle min-width; skip here.
+  }
+  if (maxTokenPt === 0) return 0;
+  const cm = effCellMargins(cell, table);
+  return maxTokenPt + cm.left + cm.right;
+}
+
+function resolveColumnWidths(table: DocTable, contentWPt: number, state: RenderState): number[] {
   const n = table.colWidths.length;
   if (n === 0) return [];
 
   const grid = table.colWidths;
+
+  // Per-column minimum content width (pt). Single-column cells set a hard floor;
+  // a gridSpan cell's min is distributed across its columns in proportion to the
+  // tblGrid so a wide spanning cell does not over-inflate any one column.
+  const minW: number[] = new Array(n).fill(0);
+  for (const row of table.rows) {
+    let ci = 0;
+    for (const cell of row.cells) {
+      const span = Math.min(Math.max(cell.colSpan, 1), n - ci);
+      const m = cellMinContentPt(cell, table, state);
+      if (m > 0) {
+        if (span === 1) {
+          if (m > minW[ci]) minW[ci] = m;
+        } else {
+          const spanCols = grid.slice(ci, ci + span);
+          const gridSum = spanCols.reduce((s, w) => s + w, 0);
+          for (let k = 0; k < span; k++) {
+            const share = gridSum > 0 ? spanCols[k] / gridSum : 1 / span;
+            const part = m * share;
+            if (part > minW[ci + k]) minW[ci + k] = part;
+          }
+        }
+      }
+      ci += span;
+    }
+  }
+
+  // Fit a desired-width vector (preferred `tcW`, floored at min content) to the
+  // available width. When the desired total overflows, Word's auto-fit
+  // (ECMA-376 §17.4.52) distributes the available width in proportion to each
+  // column's PREFERRED width — but never below its minimum content width. A
+  // column pinned to its min keeps that width and the leftover space is shared
+  // among the still-shrinkable columns (again proportional to preferred). This
+  // is what makes a date column with a small preferred width settle at exactly
+  // the date string's width (its content min) while a column with a large
+  // preferred width keeps proportionally more, matching Word's PDF layout.
   const fitToContent = (widths: number[]): number[] => {
     const total = widths.reduce((s, w) => s + w, 0);
-    if (total > contentWPt && total > 0) {
-      const s = contentWPt / total;
-      return widths.map((w) => w * s);
+    if (total <= contentWPt || total <= 0) return widths;
+    const minTotal = minW.reduce((s, w) => s + w, 0);
+    if (minTotal >= contentWPt) {
+      // Even the minimums overflow — scale the minimums so the table still
+      // fits (content clips, as Word does when forced narrower than its words).
+      const s = contentWPt / minTotal;
+      return minTotal > 0 ? minW.map((w) => w * s) : widths.map(() => contentWPt / n);
     }
-    return widths;
+    // Iteratively pin columns to their min and redistribute the rest by
+    // preferred-width proportion. Converges in ≤ n passes (each pass pins at
+    // least one new column or finishes). `widths` already encodes the preferred
+    // width (floored at min) per column, used as the distribution weight.
+    const out = widths.slice();
+    const pinned = new Array(n).fill(false);
+    for (let pass = 0; pass < n; pass++) {
+      let free = contentWPt;
+      let weightSum = 0;
+      for (let c = 0; c < n; c++) {
+        if (pinned[c]) free -= out[c];
+        else weightSum += widths[c];
+      }
+      if (weightSum <= 0) break;
+      let pinnedAny = false;
+      for (let c = 0; c < n; c++) {
+        if (pinned[c]) continue;
+        const share = free * (widths[c] / weightSum);
+        if (share < minW[c]) {
+          out[c] = minW[c];
+          pinned[c] = true;
+          pinnedAny = true;
+        } else {
+          out[c] = share;
+        }
+      }
+      if (!pinnedAny) break;
+    }
+    return out;
   };
 
-  // Fixed layout: tblGrid is authoritative (ECMA-376 §17.4.52). Scale to fit.
+  // Fixed layout: tblGrid is authoritative (ECMA-376 §17.4.52) and content is
+  // clipped, never grown — so scale proportionally to fit, ignoring min content
+  // widths (which only govern the autofit branch below).
   if (table.layout === 'fixed') {
-    return fitToContent(grid.slice());
+    const g = grid.slice();
+    const total = g.reduce((s, w) => s + w, 0);
+    if (total > contentWPt && total > 0) {
+      const s = contentWPt / total;
+      return g.map((w) => w * s);
+    }
+    return g;
   }
 
   // Autofit (default): preferred widths drive the column sizes.
@@ -913,8 +1031,11 @@ function resolveColumnWidths(table: DocTable, contentWPt: number): number[] {
     }
   }
 
-  // Columns with no preference anywhere fall back to their tblGrid width.
-  const widths = pref.map((p, c) => (hasPref[c] ? p : grid[c]));
+  // Columns with no preference anywhere fall back to their tblGrid width. A
+  // column's desired width is then floored at its minimum content width: a
+  // preferred `tcW` narrower than the longest unbreakable token cannot actually
+  // be honored (ECMA-376 §17.4.52 — auto layout grows a column to fit content).
+  const widths = pref.map((p, c) => Math.max(hasPref[c] ? p : grid[c], minW[c]));
   return fitToContent(widths);
 }
 
@@ -2573,7 +2694,7 @@ function renderTable(table: DocTable, state: RenderState): void {
 
   // Resolve column widths in pt (autofit by preferred widths, or fixed grid),
   // already scaled to fit the available content width, then convert to px.
-  const colWidths = resolveColumnWidths(table, contentW / scale).map((w) => w * scale);
+  const colWidths = resolveColumnWidths(table, contentW / scale, state).map((w) => w * scale);
 
   // Horizontal table alignment on the page (w:tblPr/w:jc).
   const tableW = colWidths.reduce((s, w) => s + w, 0);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1523,6 +1523,41 @@ interface WrapLayoutCtx {
   pageH: number;
 }
 
+/**
+ * Resolve the formatting axis that actually governs a run's glyphs.
+ *
+ * ECMA-376 §17.3.2.30 `w:rtl` marks a run as complex-script. For such a run the
+ * complex-script properties take effect — §17.3.2.4 `bCs` (bold), §17.3.2.6
+ * `iCs` (italic), §17.3.2.26 `rFonts@cs` (typeface), §17.3.2.39 `szCs` (size) —
+ * instead of the non-CS `b`/`i`/`rFonts@ascii`/`sz`, which apply to
+ * non-complex (Latin/CJK) text. `bCs`/`iCs` are INDEPENDENT toggles: an absent
+ * `bCs` does not inherit `b`'s value, so a complex-script run that carries only
+ * `w:b` renders non-bold. (sample-7's date cells carry `b` without `bCs`, and
+ * Word draws them at regular weight; the header carries both and is bold.)
+ */
+function effectiveRunStyle(base: DocxTextRun | FieldRun): {
+  bold: boolean;
+  italic: boolean;
+  fontFamily: string | null;
+  fontSize: number;
+} {
+  const r = base as DocxTextRun;
+  if (r.rtl === true) {
+    return {
+      bold: r.boldCs ?? false,
+      italic: r.italicCs ?? false,
+      fontFamily: r.fontFamilyCs ?? base.fontFamily,
+      fontSize: r.fontSizeCs ?? base.fontSize,
+    };
+  }
+  return {
+    bold: base.bold,
+    italic: base.italic,
+    fontFamily: base.fontFamily,
+    fontSize: base.fontSize,
+  };
+}
+
 function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
   const segs: LayoutSeg[] = [];
   const pushTextPiece = (
@@ -1539,17 +1574,22 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
       ? { text: baseRuby.text, fontSizePt: baseRuby.fontSizePt }
       : undefined;
     const revision = (base as DocxTextRun).revision;
+    const eff = effectiveRunStyle(base);
+    const effBold = eff.bold;
+    const effItalic = eff.italic;
+    const effFontFamily = eff.fontFamily;
+    const effFontSize = eff.fontSize;
     let firstSeg = true;
     for (const word of splitTextForLayout(displayText)) {
       segs.push({
         text: word,
-        bold: base.bold,
-        italic: base.italic,
+        bold: effBold,
+        italic: effItalic,
         underline: base.underline,
         strikethrough: base.strikethrough,
-        fontSize: base.fontSize,
+        fontSize: effFontSize,
         color: base.color,
-        fontFamily: base.fontFamily,
+        fontFamily: effFontFamily,
         vertAlign,
         measuredWidth: 0,
         smallCaps: base.smallCaps ?? false,

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -354,6 +354,13 @@ export interface DocxTextRun {
   /** ECMA-376 §17.3.2.39 `<w:szCs>` — complex-script font size in pt
    *  (same units as `fontSize`). */
   fontSizeCs?: number;
+  /** ECMA-376 §17.3.2.4 `<w:bCs>` — bold for complex-script text. Independent
+   *  toggle from `bold` (§17.3.2.3 w:b): absent means a complex-script run is
+   *  not bold regardless of `bold`. RTL/complex-script runs use this value. */
+  boldCs?: boolean;
+  /** ECMA-376 §17.3.2.6 `<w:iCs>` — italic for complex-script text.
+   *  Independent toggle from `italic`, same semantics as `boldCs`. */
+  italicCs?: boolean;
 }
 
 export interface RunRevision {


### PR DESCRIPTION
Follow-ups on the sample-7 (Arabic / RTL) DOCX after the RTL + table-autofit
PRs landed on main. Investigated against Word's PDF export as ground truth.

## Issue C — data cells rendered bolder/heavier than Word (now fixed)
**Root cause.** A run marked `w:rtl` is complex-script (ECMA-376 §17.3.2.30); its
weight/slant/typeface/size come from the *complex-script* axis (`w:bCs` §17.3.2.4,
`w:iCs` §17.3.2.6, `w:rFonts@cs` §17.3.2.26, `w:szCs` §17.3.2.39), **not** the
non-CS `w:b`/`w:i`/`w:rFonts@ascii`/`w:sz`. `w:bCs`/`w:iCs` are independent
toggles — an absent `w:bCs` does **not** inherit `w:b`. The parser surfaced
`rtl`/`fontFamilyCs`/`fontSizeCs` but dropped `w:bCs`/`w:iCs`, and the renderer
applied the non-CS axis to every run.

**Fix.** Parse `w:bCs`/`w:iCs` through the full style chain (docDefaults → style →
direct) and surface them; the renderer resolves the cs axis for `rtl` runs via a
new `effectiveRunStyle()`. sample-7 page-2 date cells (`28-02-2026`) carry `w:b`
without `w:bCs`, so Word draws them at regular weight — now matched. The header
carries both `w:b`+`w:bCs` and stays bold (unchanged).

## Issue B — table column widths differed from Word (now fixed)
**Root cause.** `resolveColumnWidths` scaled every autofit column proportionally
to its preferred `w:tcW` with no content floor. The page-2 date columns
(`tcW=2880`, small) were squeezed below the date string's width → dates wrapped
to two lines, while large-preferred empty columns stayed wide.

**Fix.** Implement Word's auto-fit (ECMA-376 §17.4.52): size each column from its
preferred width but never below its **minimum content width** (widest atomic
token — UAX#14 has no break inside a word or between a digit and an adjacent
`-`/`.`). On overflow, distribute proportionally to preferred width while pinning
any column that would fall below its content min, then share the remainder among
the rest. gridSpan cells distribute their min across the spanned columns.

Measured column boundaries (595px page) vs Word PDF — date cols within ~1px:

| col | end-date | start-date | contributing | responsible | name | # |
|-----|---|---|---|---|---|---|
| PDF | 53 | 53 | 102 | 86 | 112 | 9 |
| ours| 52 | 52 | 100 | 80 | 120 | 13 |

(was [~40,~40,…] with dates wrapping before the fix.)

## Issue A — page-1 "1."/"2." markers (already on-line on main; improved here)
The originally-reported stacked-digit artifact does **not** reproduce on current
`main` — the markers already render on the same visual line as their headings.
As a side effect of the Issue-B fix, the heading table's narrow marker cell
(`tcW=100`) now gets its content min, so the markers separate cleanly from the
heading text (gap + same line), matching the PDF's `.1 التأمين الصحي`. The
remaining glyph-level reorder (`.1` vs `1.`) and the date logical-vs-visual order
(`2026-02-28`) are the bidi glyph-reordering step that belongs to the not-yet-
integrated RTL renderer (`toVisualSegments`), out of scope for these follow-ups.

## Gates (all green)
- `npx vitest run packages/docx packages/core` → 79 passed
- `cargo test` (parser) → 12 passed (incl. 2 new bCs/iCs independence tests)
- `tsc --noEmit` in packages/docx and packages/core → clean
- docx demo VRT → 6/6 (page 3's 0.7% diff is pre-existing on main, unchanged)
- Re-rendered sample-7 p1/p2 + sample-8 p1: no regressions (header centered &
  bold, list markers adjacent on-line, date columns one-line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)