### PR TITLE
feat(rtl): renderer integration — docx/pptx/xlsx (PR2-4 consolidation)

### DIFF
--- a/packages/core/src/fonts/preload.test.ts
+++ b/packages/core/src/fonts/preload.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { preloadGoogleFonts, type FontPreloadEntry } from './preload.js';
+
+// Minimal DOM/FontFaceSet doubles so the loader's promise ordering can be
+// asserted in the node test environment (no jsdom). We model the two failure
+// modes the real flicker came from: (1) the stylesheet <link> registering its
+// FontFace entries asynchronously, and (2) face.load() settling later than the
+// loader used to wait. The loader must not resolve until BOTH have settled.
+
+interface FakeFace {
+  family: string;
+  loaded: boolean;
+  resolveLoad: () => void;
+  load: () => Promise<void>;
+}
+
+function makeFace(family: string): FakeFace {
+  let resolve!: () => void;
+  const p = new Promise<void>((r) => (resolve = r));
+  const face: FakeFace = {
+    family,
+    loaded: false,
+    resolveLoad: () => {
+      face.loaded = true;
+      resolve();
+    },
+    load: () => p,
+  };
+  return face;
+}
+
+const ORIG = {
+  document: (globalThis as Record<string, unknown>).document,
+};
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).document = ORIG.document;
+  vi.restoreAllMocks();
+});
+
+const MAP: Record<string, FontPreloadEntry> = {
+  carlito: { url: 'https://fonts.example/carlito.css', loadFamily: 'Carlito' },
+};
+
+function installFakeDom(faces: FakeFace[]) {
+  const linkListeners: Record<string, (() => void)[]> = {};
+  let appendedLink: Record<string, unknown> | null = null;
+
+  const link: Record<string, unknown> = {
+    rel: '',
+    href: '',
+    sheet: null, // not yet parsed
+    addEventListener: (ev: string, cb: () => void) => {
+      (linkListeners[ev] ??= []).push(cb);
+    },
+    removeEventListener: () => {},
+  };
+
+  const doc = {
+    querySelector: () => null,
+    createElement: () => link,
+    head: { appendChild: (l: Record<string, unknown>) => (appendedLink = l) },
+    fonts: faces as unknown as Iterable<FakeFace> & { ready: Promise<unknown> },
+  };
+  (doc.fonts as unknown as { ready: Promise<unknown> }).ready = Promise.resolve();
+  (globalThis as Record<string, unknown>).document = doc;
+
+  return {
+    fireLinkLoad: () => {
+      (linkListeners['load'] ?? []).forEach((cb) => cb());
+    },
+    get appendedLink() {
+      return appendedLink;
+    },
+  };
+}
+
+describe('preloadGoogleFonts', () => {
+  it('does not resolve until the stylesheet loads AND every face.load() settles', async () => {
+    const face = makeFace('Carlito');
+    const dom = installFakeDom([face]);
+
+    let settled = false;
+    const p = preloadGoogleFonts(['Calibri'], { calibri: MAP.carlito }).then(() => {
+      settled = true;
+    });
+
+    // Give microtasks a chance; must still be pending (link not loaded yet).
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    // Stylesheet parses → FontFace entries registered, but face still loading.
+    dom.fireLinkLoad();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(face.loaded).toBe(false);
+
+    // Face finishes downloading → loader resolves.
+    face.resolveLoad();
+    await p;
+    expect(settled).toBe(true);
+    expect(face.loaded).toBe(true);
+  });
+
+  it('returns immediately when no requested family is in the map', async () => {
+    installFakeDom([]);
+    await expect(
+      preloadGoogleFonts(['Totally Unknown Face'], MAP),
+    ).resolves.toBeUndefined();
+  });
+
+  it('is a no-op without a document (SSR / worker)', async () => {
+    (globalThis as Record<string, unknown>).document = undefined;
+    await expect(preloadGoogleFonts(['Calibri'], MAP)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -25,9 +25,40 @@ export interface FontPreloadEntry {
   loadFamily?: string;
 }
 
-const PRELOAD_TIMEOUT_MS = 3000;
-const REGISTRATION_POLL_MS = 20;
-const REGISTRATION_POLL_ATTEMPTS = 25;
+/**
+ * Hard ceiling so a wedged network (the stylesheet `<link>` never firing
+ * load/error, or a `FontFace.load()` that never settles) cannot hang the
+ * caller forever. This is a SAFETY NET, not the normal exit: on a reachable
+ * network every awaited promise settles well within it, so first paint is
+ * deterministic. It is intentionally generous — the previous 3 s timeout RACED
+ * the font loads and could resolve while faces were still downloading, which is
+ * exactly the cold-cache flicker this function must prevent.
+ */
+const HARD_CEILING_MS = 15000;
+
+/** Resolve when the stylesheet `<link>` has finished loading (load or error),
+ *  so the FontFace entries it defines are registered in `document.fonts`.
+ *  Resolves immediately for a `<link>` that already loaded. */
+function linkLoaded(link: HTMLLinkElement): Promise<void> {
+  // A stylesheet that is already applied exposes its `sheet`; treat as loaded.
+  if (link.sheet) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const done = () => {
+      link.removeEventListener('load', done);
+      link.removeEventListener('error', done);
+      resolve();
+    };
+    link.addEventListener('load', done);
+    link.addEventListener('error', done);
+  });
+}
+
+function withCeiling<T>(p: Promise<T>): Promise<T | void> {
+  return Promise.race([
+    p,
+    new Promise<void>((resolve) => setTimeout(resolve, HARD_CEILING_MS)),
+  ]);
+}
 
 export async function preloadGoogleFonts(
   fontNames: Iterable<string | null | undefined>,
@@ -37,6 +68,7 @@ export async function preloadGoogleFonts(
 
   const seen = new Set<string>();
   const targetFamilies = new Set<string>();
+  const linkPromises: Promise<void>[] = [];
 
   for (const name of fontNames) {
     if (!name) continue;
@@ -46,37 +78,43 @@ export async function preloadGoogleFonts(
     const entry = map[key];
     if (!entry) continue;
 
-    if (!document.querySelector(`link[href="${entry.url}"]`)) {
+    let link = document.querySelector<HTMLLinkElement>(`link[href="${entry.url}"]`);
+    if (!link) {
       try {
-        const link = document.createElement('link');
+        link = document.createElement('link');
         link.rel = 'stylesheet';
         link.href = entry.url;
         document.head.appendChild(link);
       } catch {
         // Network or DOM error — silently skip; renderer falls back to system.
+        link = null;
       }
     }
+    // Wait for the stylesheet to actually parse so its FontFace entries are
+    // registered before we enumerate `document.fonts`. The previous version
+    // polled for ~500 ms and gave up loading NOTHING on a slow/cold network,
+    // so the next (warm) reload rendered with different fonts — the flicker.
+    if (link) linkPromises.push(linkLoaded(link));
 
     targetFamilies.add((entry.loadFamily ?? name).toLowerCase());
   }
 
   if (targetFamilies.size === 0) return;
 
-  // After a fresh `<link>` append, FontFaceSet briefly reports zero matching
-  // FontFace entries while the stylesheet parses. Poll for up to ~500 ms.
-  let registered: FontFace[] = [];
-  for (let i = 0; i < REGISTRATION_POLL_ATTEMPTS; i++) {
-    registered = [...document.fonts].filter((f) =>
-      targetFamilies.has(f.family.toLowerCase()),
-    );
-    if (registered.length > 0) break;
-    await new Promise<void>((r) => setTimeout(r, REGISTRATION_POLL_MS));
-  }
+  // 1) Wait for every stylesheet to register its FontFace entries.
+  await withCeiling(Promise.allSettled(linkPromises));
 
-  await Promise.race([
+  // 2) Force-load every matching FontFace and AWAIT them all — no timeout race
+  //    that could resolve mid-download. `face.load()` is required because
+  //    canvas rendering never puts glyphs in the DOM, so unicode-range gating
+  //    would otherwise leave the faces `unloaded` and the first paint would use
+  //    a system fallback, shifting once a later interaction re-rasterized.
+  const registered = [...document.fonts].filter((f) =>
+    targetFamilies.has(f.family.toLowerCase()),
+  );
+  await withCeiling(
     Promise.allSettled(registered.map((f) => f.load())).then(() =>
       document.fonts.ready,
     ),
-    new Promise<void>((resolve) => setTimeout(resolve, PRELOAD_TIMEOUT_MS)),
-  ]);
+  );
 }

--- a/packages/core/src/text/bidi/engine.ts
+++ b/packages/core/src/text/bidi/engine.ts
@@ -4,17 +4,25 @@
 // getMirroredCharacter) without touching renderers or `toVisualSegments`,
 // which sit ABOVE this seam.
 
-import type { BaseDirection, BidiLevels } from './types.js';
+import type { BaseDirection, BidiClass, BidiLevels } from './types.js';
 import { createUax9Engine } from './uax9/index.js';
 
 export interface BidiEngine {
   /**
    * UAX#9 P2-P3 + X..I rules. Returns the resolved embedding level per code
    * unit and the paragraph base level. Mirrors bidi-js `getEmbeddingLevels`.
+   *
+   * `classOverride` is an optional UAX#9 §4.3 HL1 higher-level-protocol hook:
+   * a per-CODE-UNIT array (indexed identically to `text`; surrogate-pair halves
+   * share one entry on the leading unit, trailing unit ignored) whose non-null
+   * entries replace the assigned Bidi_Class of that code point before the
+   * algorithm runs. Used e.g. to classify European digits as AN in Arabic
+   * complex-script context (Word behaviour). Omit it to run pure UAX#9.
    */
   computeLevels(
     text: string,
     base: BaseDirection,
+    classOverride?: ReadonlyArray<BidiClass | null | undefined>,
   ): { levels: BidiLevels; paragraphLevel: number };
 
   /**

--- a/packages/core/src/text/bidi/uax9/index.ts
+++ b/packages/core/src/text/bidi/uax9/index.ts
@@ -4,34 +4,44 @@
 // core to the string / code-unit surface renderers use.
 
 import type { BidiEngine } from '../engine.js';
-import type { BaseDirection, BidiLevels } from '../types.js';
+import type { BaseDirection, BidiClass, BidiLevels } from '../types.js';
 import { mirror as mirrorGlyph } from '../char-data.js';
 import { resolveLevels, reorderByLevels, REMOVED } from './rules.js';
 
 /** Code-unit sentinel for code units removed by rule X9 (REMOVED maps here). */
 const REMOVED_UNIT = 255;
 
-/** Decode a UTF-16 string into code points + how many code units each occupies. */
-function decode(text: string): { cps: number[]; units: number[] } {
+/** Decode a UTF-16 string into code points, their code-unit widths, and the
+ *  code-unit offset at which each code point begins. */
+function decode(text: string): { cps: number[]; units: number[]; starts: number[] } {
   const cps: number[] = [];
   const units: number[] = [];
+  const starts: number[] = [];
   for (let i = 0; i < text.length; ) {
     const cp = text.codePointAt(i)!;
     const len = cp > 0xffff ? 2 : 1;
     cps.push(cp);
     units.push(len);
+    starts.push(i);
     i += len;
   }
-  return { cps, units };
+  return { cps, units, starts };
 }
 
 class Uax9Engine implements BidiEngine {
   computeLevels(
     text: string,
     base: BaseDirection,
+    classOverride?: ReadonlyArray<BidiClass | null | undefined>,
   ): { levels: BidiLevels; paragraphLevel: number } {
-    const { cps, units } = decode(text);
-    const { levels: cpLevels, paragraphLevel } = resolveLevels(cps, base);
+    const { cps, units, starts } = decode(text);
+    // Collapse the per-code-UNIT override the renderer supplies into the
+    // per-code-POINT space the rule engine works in (read it at the code
+    // point's leading unit). Skipped entirely when no override is passed.
+    const cpOverride = classOverride
+      ? cps.map((_, i) => classOverride[starts[i]] ?? null)
+      : undefined;
+    const { levels: cpLevels, paragraphLevel } = resolveLevels(cps, base, cpOverride);
 
     // Expand per-code-point levels back to per-code-unit (both surrogate halves
     // share the level), mapping the REMOVED sentinel to 255.

--- a/packages/core/src/text/bidi/uax9/rules.ts
+++ b/packages/core/src/text/bidi/uax9/rules.ts
@@ -435,10 +435,19 @@ function resolveSequence(
 export function resolveLevels(
   cps: number[],
   base: BaseDirection,
+  classOverride?: ReadonlyArray<BidiClass | null | undefined>,
 ): { levels: number[]; paragraphLevel: number } {
   const n = cps.length;
   const origTypes: BidiClass[] = new Array(n);
-  for (let i = 0; i < n; i++) origTypes[i] = bidiClass(cps[i]);
+  // UAX#9 §4.3 HL1 higher-level protocol: a caller may override the assigned
+  // Bidi_Class of selected code points BEFORE the algorithm runs (e.g. Word
+  // classifying European digits as AN inside Arabic-language complex-script
+  // context — see W2). The pure algorithm is unchanged when `classOverride` is
+  // absent, so the UAX#9 conformance suite (which passes no override) still
+  // drives `resolveLevels` exactly as the standard specifies.
+  for (let i = 0; i < n; i++) {
+    origTypes[i] = classOverride?.[i] ?? bidiClass(cps[i]);
+  }
 
   const paragraphLevel =
     base === 'rtl' ? 1 : base === 'ltr' ? 0 : firstStrongLevel(origTypes, 0, n);

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -6,7 +6,10 @@ use crate::xml_util::*;
 pub struct LevelDef {
     pub format: String,  // "decimal" | "bullet" | etc.
     pub text: String,    // lvlText val, e.g. "%1." or "•"
-    pub indent_left: f64,   // pt
+    pub indent_left: f64,   // pt — w:ind@left ≡ logical START indent (§17.3.1.12)
+    /// pt — w:ind@right ≡ logical END indent (Part 4 §14.11.2). RTL list levels
+    /// carry their indent here (the renderer maps it to the physical left side).
+    pub indent_right: Option<f64>,
     pub tab: f64,            // pt
     pub start: u32,
 }
@@ -17,6 +20,7 @@ impl Default for LevelDef {
             format: "decimal".to_string(),
             text: "%1.".to_string(),
             indent_left: 36.0,
+            indent_right: None,
             tab: 36.0,
             start: 1,
         }
@@ -60,17 +64,27 @@ impl NumberingMap {
                 let text = child_w(lvl_node, "lvlText")
                     .and_then(|n| attr_w(n, "val"))
                     .unwrap_or_else(|| "%1.".to_string());
-                let indent_left = child_w(lvl_node, "pPr")
-                    .and_then(|p| child_w(p, "ind"))
+                let ind_node = child_w(lvl_node, "pPr").and_then(|p| child_w(p, "ind"));
+                // When the level defines a w:ind, a missing @left means "no
+                // start indent from this source" (an RTL level carries its
+                // indent in @right ≡ end instead); the per-level depth default
+                // applies only when no w:ind exists at all.
+                let indent_left = ind_node
                     .and_then(|i| attr_w(i, "left"))
                     .map(|v| twips_to_pt(&v))
-                    .unwrap_or(720.0 / 20.0 * (levels.len() as f64 + 1.0));
-                let tab = child_w(lvl_node, "pPr")
-                    .and_then(|p| child_w(p, "ind"))
+                    .unwrap_or(if ind_node.is_some() {
+                        0.0
+                    } else {
+                        720.0 / 20.0 * (levels.len() as f64 + 1.0)
+                    });
+                let indent_right = ind_node
+                    .and_then(|i| attr_w(i, "right"))
+                    .map(|v| twips_to_pt(&v));
+                let tab = ind_node
                     .and_then(|i| attr_w(i, "hanging").or_else(|| attr_w(i, "firstLine")))
                     .map(|v| twips_to_pt(&v))
                     .unwrap_or(36.0);
-                levels.push(LevelDef { format, text, indent_left, tab, start });
+                levels.push(LevelDef { format, text, indent_left, indent_right, tab, start });
             }
             map.abstract_nums.insert(abs_id, levels);
         }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -739,6 +739,12 @@ fn parse_paragraph(
     } else {
         (base_para.indent_left.unwrap_or(0.0), base_para.indent_first.unwrap_or(0.0))
     };
+    // Same for the end-side indent (w:ind@right ≡ end): an RTL list level
+    // defines its indent there (e.g. w:right="720" w:hanging="360").
+    let indent_right = numbering.as_ref()
+        .and_then(|num| num_map.get_level(num.num_id, num.level))
+        .and_then(|l| l.indent_right)
+        .unwrap_or(indent_right);
 
     // Parse runs
     let mut runs = vec![];

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1106,6 +1106,12 @@ fn parse_run_inner(
     let rtl = fmt.rtl;
     let font_family_cs = theme.resolve_font_ref(fmt.font_family_cs.clone());
     let font_size_cs = fmt.font_size_cs;
+    // Complex-script bold / italic (ECMA-376 §17.3.2.3 / §17.3.2.17) and the
+    // complex-script language tag (§17.3.2.20). Recorded so the renderer can
+    // route cs-classified content to cs formatting and decide AN digit ordering.
+    let bold_cs = fmt.bold_cs;
+    let italic_cs = fmt.italic_cs;
+    let lang_bidi = fmt.lang_bidi.clone();
 
     for child in node.children().filter(|n| n.is_element()) {
         match child.tag_name().name() {
@@ -1137,6 +1143,9 @@ fn parse_run_inner(
                         rtl,
                         font_family_cs: font_family_cs.clone(),
                         font_size_cs,
+                        bold_cs,
+                        italic_cs,
+                        lang_bidi: lang_bidi.clone(),
                     }));
                 }
             }
@@ -1164,6 +1173,9 @@ fn parse_run_inner(
                     rtl,
                     font_family_cs: font_family_cs.clone(),
                     font_size_cs,
+                    bold_cs,
+                    italic_cs,
+                    lang_bidi: lang_bidi.clone(),
                 }));
             }
             "br" => {
@@ -1260,6 +1272,9 @@ fn parse_run_inner(
                     rtl,
                     font_family_cs: font_family_cs.clone(),
                     font_size_cs,
+                    bold_cs,
+                    italic_cs,
+                    lang_bidi: lang_bidi.clone(),
                 }));
             }
             "AlternateContent" => {
@@ -2639,7 +2654,23 @@ fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
     if direct.vert_align.is_some() { base.vert_align = direct.vert_align.clone(); }
     if direct.rtl.is_some() { base.rtl = direct.rtl; }
     if direct.font_family_cs.is_some() { base.font_family_cs = direct.font_family_cs.clone(); }
-    if direct.font_size_cs.is_some() { base.font_size_cs = direct.font_size_cs; }
+    if direct.bold_cs.is_some() { base.bold_cs = direct.bold_cs; }
+    if direct.italic_cs.is_some() { base.italic_cs = direct.italic_cs; }
+    if direct.lang_bidi.is_some() { base.lang_bidi = direct.lang_bidi.clone(); }
+
+    // Complex-script font size: a directly-applied `w:sz` without an
+    // accompanying `w:szCs` mirrors into the cs size (ECMA-376 §17.3.2.18 —
+    // see `styles::apply_run` for the full rationale). An explicit `w:szCs`
+    // always wins; otherwise inherited-only szCs is carried unchanged.
+    if direct.font_size_cs_set_here {
+        base.font_size_cs = direct.font_size_cs;
+    } else if direct.font_size_set_here {
+        base.font_size_cs = direct.font_size;
+    } else if direct.font_size_cs.is_some() {
+        base.font_size_cs = direct.font_size_cs;
+    }
+    base.font_size_set_here = false;
+    base.font_size_cs_set_here = false;
 }
 
 fn parse_rels(xml: &str) -> HashMap<String, String> {
@@ -2769,6 +2800,71 @@ mod rtl_tests {
             _ => None,
         }).unwrap();
         assert_eq!(run.rtl, Some(false));
+    }
+
+    /// ECMA-376 §17.3.2.18: a directly-applied `w:sz` with NO accompanying
+    /// `w:szCs` mirrors into the complex-script size (Word draws Arabic in a
+    /// run that only sets `w:sz` at that size — sample-7's underlined title sets
+    /// sz=36 / no szCs and renders the Arabic at 18pt). An explicit `w:szCs`
+    /// still wins independently.
+    #[test]
+    fn direct_sz_without_szcs_mirrors_into_cs_size() {
+        // sz=36 (18pt), no szCs -> font_size_cs == font_size == 18.
+        let body = body_from(
+            r#"<w:p><w:r><w:rPr><w:b/><w:sz w:val="36"/></w:rPr><w:t>نبذة</w:t></w:r></w:p>"#,
+        );
+        let run = body.iter().find_map(|e| match e {
+            BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                DocRun::Text(t) => Some(t),
+                _ => None,
+            }),
+            _ => None,
+        }).expect("text run present");
+        assert_eq!(run.font_size, 18.0, "sz=36 half-pts → 18pt");
+        assert_eq!(
+            run.font_size_cs,
+            Some(18.0),
+            "sz without szCs mirrors into the complex-script size (§17.3.2.18)"
+        );
+
+        // sz=36 AND szCs=24 -> cs size honors the explicit szCs (12pt).
+        let body2 = body_from(
+            r#"<w:p><w:r><w:rPr><w:sz w:val="36"/><w:szCs w:val="24"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+        );
+        let run2 = body2.iter().find_map(|e| match e {
+            BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                DocRun::Text(t) => Some(t),
+                _ => None,
+            }),
+            _ => None,
+        }).unwrap();
+        assert_eq!(run2.font_size, 18.0);
+        assert_eq!(run2.font_size_cs, Some(12.0), "explicit szCs wins over sz mirroring");
+    }
+
+    /// ECMA-376 §17.3.2.3 w:bCs, §17.3.2.17 w:iCs, §17.3.2.20 w:lang/@w:bidi —
+    /// complex-script bold/italic toggles and the RTL language tag (lower-cased)
+    /// are surfaced on the run model for the renderer's cs-formatting path.
+    #[test]
+    fn complex_script_bold_italic_and_lang_bidi_are_extracted() {
+        let body = body_from(
+            r#"<w:p><w:r><w:rPr><w:rtl/><w:bCs/><w:iCs/>
+              <w:lang w:val="en-AE" w:bidi="ae-AR"/></w:rPr><w:t>28-02-2026</w:t></w:r></w:p>"#,
+        );
+        let run = body.iter().find_map(|e| match e {
+            BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                DocRun::Text(t) => Some(t),
+                _ => None,
+            }),
+            _ => None,
+        }).expect("text run present");
+        assert_eq!(run.bold_cs, Some(true), "w:bCs → run.boldCs");
+        assert_eq!(run.italic_cs, Some(true), "w:iCs → run.italicCs");
+        assert_eq!(
+            run.lang_bidi.as_deref(),
+            Some("ae-ar"),
+            "w:lang@w:bidi lower-cased → run.langBidi"
+        );
     }
 
     /// Legacy VML text box (ECMA-376 Part 4 §14.1): `<w:pict>` with a

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1274,6 +1274,16 @@ fn parse_run_inner(
                     }
                 }
             }
+            "pict" => {
+                // Legacy VML drawing (ECMA-376 Part 4 §14.1): <w:pict> wraps a
+                // <v:shape>/<v:rect>/<v:roundrect> with optional <v:textbox>.
+                // Word still emits these for simple text boxes. We surface the
+                // shape's fill/stroke/size and its txbxContent as a ShapeRun so
+                // the existing shape renderer draws the panel + RTL body text.
+                if let Some(shp) = parse_vml_pict(child, theme) {
+                    runs.push(DocRun::Shape(shp));
+                }
+            }
             _ => {}
         }
     }
@@ -1954,6 +1964,118 @@ fn extract_simple_paragraph_text(p: roxmltree::Node, theme: &ThemeColors) -> Opt
         bold,
         italic,
         alignment: normalize_align(&alignment).to_string(),
+    })
+}
+
+/// Parse a legacy VML `<w:pict>` text box (ECMA-376 Part 4 §14.1) into a
+/// ShapeRun. Handles the common Word-emitted form:
+///   <w:pict><v:shape type="#_x0000_t202"
+///       style="…width:300pt;height:60pt…" fillcolor="#fdf2d0"
+///       strokecolor="#c0a000">
+///     <v:textbox><w:txbxContent>…</w:txbxContent></v:textbox>
+///   </v:shape></w:pict>
+/// Size comes from the CSS-like `style` attribute (width/height in pt), fill
+/// and stroke from `fillcolor`/`strokecolor`. The shape is anchored to the
+/// paragraph's leading (top-left) corner — VML `position:relative` text boxes
+/// flow with their anchor paragraph, which Word places at the left margin just
+/// below the preceding content.
+fn parse_vml_pict(pict: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeRun> {
+    // v:shape / v:rect / v:roundrect — any VML shape element with geometry.
+    let shape = pict.descendants().find(|n| {
+        n.is_element()
+            && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
+    })?;
+
+    // CSS-like `style`: "position:relative;width:300pt;height:60pt;…"
+    let style = shape.attribute("style").unwrap_or("");
+    let css_pt = |prop: &str| -> Option<f64> {
+        for decl in style.split(';') {
+            let mut kv = decl.splitn(2, ':');
+            let k = kv.next()?.trim();
+            let v = kv.next()?.trim();
+            if k.eq_ignore_ascii_case(prop) {
+                // strip a trailing "pt" unit; VML lengths default to pt here.
+                let num = v.trim_end_matches("pt").trim();
+                return num.parse::<f64>().ok();
+            }
+        }
+        None
+    };
+    let width_pt = css_pt("width").unwrap_or(0.0);
+    let height_pt = css_pt("height").unwrap_or(0.0);
+    if width_pt <= 0.0 || height_pt <= 0.0 {
+        return None;
+    }
+
+    // VML colors: `fillcolor` / `strokecolor` are "#rrggbb" (or named); we keep
+    // the 6-hex form the renderer expects (no leading '#').
+    let hex6 = |c: &str| -> Option<String> {
+        let s = c.trim().trim_start_matches('#');
+        if s.len() == 6 && s.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            Some(s.to_ascii_lowercase())
+        } else {
+            None
+        }
+    };
+    let fill = shape
+        .attribute("fillcolor")
+        .and_then(hex6)
+        .map(|color| ShapeFill::Solid { color });
+    let stroke = shape.attribute("strokecolor").and_then(hex6);
+    // VML default stroke weight is 0.75pt when a stroke color is present and no
+    // explicit weight is given (Part 4 §14.1.2.21 strokeweight default).
+    let stroke_width = if stroke.is_some() {
+        shape
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "stroke")
+            .and_then(|n| n.attribute("weight"))
+            .and_then(|w| w.trim_end_matches("pt").trim().parse::<f64>().ok())
+            .or_else(|| {
+                shape
+                    .attribute("strokeweight")
+                    .and_then(|w| w.trim_end_matches("pt").trim().parse::<f64>().ok())
+            })
+            .unwrap_or(0.75)
+    } else {
+        0.0
+    };
+
+    // Body text from <v:textbox><w:txbxContent>.
+    let text_blocks: Vec<ShapeText> = shape
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "txbxContent")
+        .map(|content| {
+            children_w_flat(content, "p")
+                .into_iter()
+                .filter_map(|p| extract_simple_paragraph_text(p, theme))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(ShapeRun {
+        width_pt,
+        height_pt,
+        anchor_x_pt: 0.0,
+        anchor_y_pt: 0.0,
+        anchor_x_from_margin: true,
+        anchor_y_from_para: true,
+        behind_doc: false,
+        z_order: 0,
+        subpaths: Vec::new(),
+        preset_geometry: Some("rect".to_string()),
+        adj_values: Vec::new(),
+        fill,
+        stroke,
+        stroke_width,
+        rotation: 0.0,
+        // VML t202 text-box default insets are the OOXML defaults (§21.1.2.1.1).
+        text_blocks,
+        text_anchor: None,
+        text_inset_l: 91440.0 / 12700.0,
+        text_inset_t: 45720.0 / 12700.0,
+        text_inset_r: 91440.0 / 12700.0,
+        text_inset_b: 45720.0 / 12700.0,
+        ..Default::default()
     })
 }
 
@@ -2638,5 +2760,47 @@ mod rtl_tests {
             _ => None,
         }).unwrap();
         assert_eq!(run.rtl, Some(false));
+    }
+
+    /// Legacy VML text box (ECMA-376 Part 4 §14.1): `<w:pict>` with a
+    /// `<v:shape type="#_x0000_t202">` surfaces as a ShapeRun carrying the
+    /// fill/stroke from the VML attributes, the size from the CSS `style`, and
+    /// the `<w:txbxContent>` body text — so the renderer draws the yellow box.
+    #[test]
+    fn vml_pict_textbox_becomes_a_shape_run() {
+        let body = body_from(
+            r##"<w:p><w:r><w:pict xmlns:v="urn:schemas-microsoft-com:vml">
+              <v:shape id="tb1" type="#_x0000_t202"
+                  style="position:relative;width:300pt;height:60pt"
+                  fillcolor="#fdf2d0" strokecolor="#c0a000">
+                <v:textbox><w:txbxContent>
+                  <w:p><w:pPr><w:bidi/><w:jc w:val="right"/></w:pPr>
+                    <w:r><w:rPr><w:rtl/></w:rPr><w:t>مربع نص 2025</w:t></w:r>
+                  </w:p>
+                </w:txbxContent></v:textbox>
+              </v:shape>
+            </w:pict></w:r></w:p>"##,
+        );
+        let para = body.iter().find_map(|e| match e {
+            BodyElement::Paragraph(p) => Some(p),
+            _ => None,
+        }).expect("paragraph present");
+        let shape = para.runs.iter().find_map(|r| match r {
+            DocRun::Shape(s) => Some(s),
+            _ => None,
+        }).expect("VML pict should produce a ShapeRun");
+
+        assert_eq!(shape.width_pt, 300.0, "width from CSS style");
+        assert_eq!(shape.height_pt, 60.0, "height from CSS style");
+        assert_eq!(shape.preset_geometry.as_deref(), Some("rect"));
+        match &shape.fill {
+            Some(ShapeFill::Solid { color }) => assert_eq!(color, "fdf2d0"),
+            other => panic!("expected solid fdf2d0 fill, got {other:?}"),
+        }
+        assert_eq!(shape.stroke.as_deref(), Some("c0a000"));
+        assert!(shape.stroke_width > 0.0, "stroke present ⇒ visible weight");
+        assert_eq!(shape.text_blocks.len(), 1, "one body paragraph");
+        assert_eq!(shape.text_blocks[0].text, "مربع نص 2025");
+        assert_eq!(shape.text_blocks[0].alignment, "right");
     }
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2521,22 +2521,31 @@ fn parse_table_cell(
 }
 
 fn parse_table_borders(node: roxmltree::Node) -> TableBorders {
+    // ECMA-376 §17.4.* tblBorders: the vertical edges may be given either as the
+    // legacy physical names (w:left/w:right) or as the logical edges
+    // (w:start/w:end, §17.4.66-67). Prefer the physical name when both are
+    // present, else fall back to the logical alias. The renderer handles
+    // visual mirroring for bidiVisual tables via its `mirror` flag, so at
+    // parse time start→left and end→right unconditionally.
     TableBorders {
         top: child_w(node, "top").map(parse_border_spec),
         bottom: child_w(node, "bottom").map(parse_border_spec),
-        left: child_w(node, "left").map(parse_border_spec),
-        right: child_w(node, "right").map(parse_border_spec),
+        left: child_w(node, "left").or_else(|| child_w(node, "start")).map(parse_border_spec),
+        right: child_w(node, "right").or_else(|| child_w(node, "end")).map(parse_border_spec),
         inside_h: child_w(node, "insideH").map(parse_border_spec),
         inside_v: child_w(node, "insideV").map(parse_border_spec),
     }
 }
 
 fn parse_cell_borders(node: roxmltree::Node) -> CellBorders {
+    // ECMA-376 §17.4.* tcBorders: same logical/physical edge aliasing as
+    // tblBorders. w:start/w:end (§17.4.66-67) are the logical vertical edges;
+    // w:left/w:right the physical names. Prefer physical, fall back to logical.
     CellBorders {
         top: child_w(node, "top").map(parse_border_spec),
         bottom: child_w(node, "bottom").map(parse_border_spec),
-        left: child_w(node, "left").map(parse_border_spec),
-        right: child_w(node, "right").map(parse_border_spec),
+        left: child_w(node, "left").or_else(|| child_w(node, "start")).map(parse_border_spec),
+        right: child_w(node, "right").or_else(|| child_w(node, "end")).map(parse_border_spec),
     }
 }
 
@@ -2802,5 +2811,72 @@ mod rtl_tests {
         assert_eq!(shape.text_blocks.len(), 1, "one body paragraph");
         assert_eq!(shape.text_blocks[0].text, "مربع نص 2025");
         assert_eq!(shape.text_blocks[0].alignment, "right");
+    }
+
+    /// ECMA-376 §17.4.* w:tcBorders with only the logical vertical edges
+    /// (w:start/w:end, §17.4.66-67) must still yield left/right border specs.
+    /// RTL/bidi-aware authoring tools emit start/end instead of left/right;
+    /// the parser maps start→left, end→right (the renderer handles visual
+    /// mirroring for bidiVisual tables).
+    #[test]
+    fn tc_borders_start_end_map_to_left_right() {
+        let body = body_from(
+            r#"
+            <w:tbl>
+              <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+              <w:tr><w:tc>
+                <w:tcPr>
+                  <w:tcBorders>
+                    <w:start w:sz="1" w:val="single" w:color="D9D9D9"/>
+                    <w:top w:sz="1" w:val="single" w:color="D9D9D9"/>
+                    <w:end w:sz="1" w:val="single" w:color="D9D9D9"/>
+                    <w:bottom w:sz="1" w:val="single" w:color="D9D9D9"/>
+                  </w:tcBorders>
+                </w:tcPr>
+                <w:p><w:r><w:t>x</w:t></w:r></w:p>
+              </w:tc></w:tr>
+            </w:tbl>
+            "#,
+        );
+        let tbl = body.iter().find_map(|e| match e {
+            BodyElement::Table(t) => Some(t),
+            _ => None,
+        }).expect("table present");
+        let cell = &tbl.rows[0].cells[0];
+        let left = cell.borders.left.as_ref().expect("w:start should map to cell.left");
+        let right = cell.borders.right.as_ref().expect("w:end should map to cell.right");
+        assert_eq!(left.color.as_deref(), Some("d9d9d9"), "start color → left");
+        assert_eq!(left.style, "single");
+        assert_eq!(right.color.as_deref(), Some("d9d9d9"), "end color → right");
+        assert_eq!(right.style, "single");
+        // top/bottom (literal physical names) still parsed.
+        assert!(cell.borders.top.is_some());
+        assert!(cell.borders.bottom.is_some());
+    }
+
+    /// ECMA-376 §17.4.* w:tblBorders: a table-level w:start/w:end likewise
+    /// maps to the physical left/right edges.
+    #[test]
+    fn tbl_borders_start_end_map_to_left_right() {
+        let body = body_from(
+            r#"
+            <w:tbl>
+              <w:tblPr>
+                <w:tblBorders>
+                  <w:start w:sz="4" w:val="single" w:color="000000"/>
+                  <w:end w:sz="4" w:val="single" w:color="000000"/>
+                </w:tblBorders>
+              </w:tblPr>
+              <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+              <w:tr><w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr>
+            </w:tbl>
+            "#,
+        );
+        let tbl = body.iter().find_map(|e| match e {
+            BodyElement::Table(t) => Some(t),
+            _ => None,
+        }).expect("table present");
+        assert!(tbl.borders.left.is_some(), "w:start should map to tblBorders.left");
+        assert!(tbl.borders.right.is_some(), "w:end should map to tblBorders.right");
     }
 }

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -37,6 +37,22 @@ pub struct RunFmt {
     /// ECMA-376 §17.3.2.18 w:szCs/@w:val — complex-script font size in pt
     /// (converted from half-points, same units as `font_size`).
     pub font_size_cs: Option<f64>,
+    /// True when `w:sz` was set at THIS level (direct rPr or a named style),
+    /// regardless of whether `w:szCs` was also set. Word resolves the
+    /// complex-script size by mirroring a directly-applied `w:sz` when no
+    /// `w:szCs` accompanies it at the same level (a directly-set Latin size
+    /// shadows an inherited complex-script size); §17.3.2.38 / §17.3.2.18.
+    pub font_size_set_here: bool,
+    /// True when `w:szCs` was set at THIS level. Lets the merge mirror an
+    /// unaccompanied `w:sz` into `font_size_cs` (see `apply_run`).
+    pub font_size_cs_set_here: bool,
+    /// ECMA-376 §17.3.2.3 w:bCs — complex-script bold toggle.
+    pub bold_cs: Option<bool>,
+    /// ECMA-376 §17.3.2.17 w:iCs — complex-script italic toggle.
+    pub italic_cs: Option<bool>,
+    /// ECMA-376 §17.3.2.20 w:lang/@w:bidi — complex-script (RTL) language tag,
+    /// lower-cased (e.g. "ar-sa", "ae-ar"). Drives Word's AN digit ordering.
+    pub lang_bidi: Option<String>,
 }
 
 /// Resolved paragraph formatting.
@@ -364,7 +380,31 @@ fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.highlight.is_some() { dst.highlight = src.highlight.clone(); }
     if src.rtl.is_some() { dst.rtl = src.rtl; }
     if src.font_family_cs.is_some() { dst.font_family_cs = src.font_family_cs.clone(); }
-    if src.font_size_cs.is_some() { dst.font_size_cs = src.font_size_cs; }
+    if src.bold_cs.is_some() { dst.bold_cs = src.bold_cs; }
+    if src.italic_cs.is_some() { dst.italic_cs = src.italic_cs; }
+    if src.lang_bidi.is_some() { dst.lang_bidi = src.lang_bidi.clone(); }
+
+    // Complex-script font size resolution (ECMA-376 §17.3.2.18). Word treats a
+    // directly-applied `w:sz` as also setting the complex-script size UNLESS the
+    // same level supplies its own `w:szCs`: a run/style that sets only `w:sz`
+    // renders its Arabic/Hebrew text at that size too (e.g. sample-7's underlined
+    // title sets sz=36 with no szCs and Word draws the Arabic at 18pt, not at the
+    // inherited docDefaults szCs=11pt). So at a level that sets sz-without-szCs,
+    // the Latin size shadows the inherited cs size; an explicit szCs always wins.
+    if src.font_size_cs_set_here {
+        dst.font_size_cs = src.font_size_cs;
+    } else if src.font_size_set_here {
+        dst.font_size_cs = src.font_size;
+    } else if src.font_size_cs.is_some() {
+        // Inherited-only szCs (no sz/szCs literally on this level): carry it.
+        dst.font_size_cs = src.font_size_cs;
+    }
+    // OR-propagate the "set here" markers. `apply_run` may be used to fold a
+    // whole (rStyle) sub-chain into a single RunFmt that is later re-applied via
+    // `apply_direct_run`; carrying these flags forward lets that later merge see
+    // that the sub-chain set sz/szCs and apply the same mirroring rule.
+    dst.font_size_set_here |= src.font_size_set_here;
+    dst.font_size_cs_set_here |= src.font_size_cs_set_here;
 }
 
 pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
@@ -558,6 +598,28 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     if let Some(sz_cs) = child_w(rpr, "szCs") {
         if let Some(v) = attr_w(sz_cs, "val") {
             fmt.font_size_cs = Some(half_pt_to_pt(&v));
+        }
+    }
+
+    // Record which of w:sz / w:szCs were set AT THIS LEVEL so the style-chain
+    // merge can mirror a directly-applied Latin size into the complex-script
+    // size when no szCs accompanies it (Word's behaviour — §17.3.2.18). Use the
+    // literal child presence (not the sz/szCs fallback above, which conflates
+    // them).
+    fmt.font_size_set_here = child_w(rpr, "sz").is_some();
+    fmt.font_size_cs_set_here = child_w(rpr, "szCs").is_some();
+
+    // Complex-script bold / italic toggles (ECMA-376 §17.3.2.3 / §17.3.2.17).
+    fmt.bold_cs = bool_prop(rpr, "bCs");
+    fmt.italic_cs = bool_prop(rpr, "iCs");
+
+    // Complex-script language tag (ECMA-376 §17.3.2.20 w:lang/@w:bidi). Lower-
+    // cased; its primary subtag later decides European-digit AN classification.
+    if let Some(lang) = child_w(rpr, "lang") {
+        if let Some(bidi) = attr_w(lang, "bidi") {
+            if !bidi.is_empty() {
+                fmt.lang_bidi = Some(bidi.to_lowercase());
+            }
         }
     }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -549,6 +549,20 @@ pub struct TextRun {
     /// units as `font_size`). `None` when unspecified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size_cs: Option<f64>,
+    /// ECMA-376 §17.3.2.3 `<w:bCs>` — complex-script bold toggle. `None` when
+    /// unspecified (renderer falls back to `bold`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bold_cs: Option<bool>,
+    /// ECMA-376 §17.3.2.17 `<w:iCs>` — complex-script italic toggle. `None`
+    /// when unspecified (renderer falls back to `italic`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub italic_cs: Option<bool>,
+    /// ECMA-376 §17.3.2.20 `<w:lang w:bidi>` — the complex-script (RTL) language
+    /// tag, lower-cased (e.g. "ar-sa", "ae-ar", "he-il"). Used to decide whether
+    /// European digits in a complex-script run are classified as AN (Word's
+    /// Arabic/Hebrew digit ordering). `None` when unspecified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lang_bidi: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/bidi-line.test.ts
+++ b/packages/docx/src/bidi-line.test.ts
@@ -120,4 +120,38 @@ describe('computeLineVisualOrder', () => {
     const { order } = computeLineVisualOrder([{ text: 'שלום ' }, {}, { text: 'טוב' }], true);
     expect(order).toEqual([2, 1, 0]);
   });
+
+  it('orders an AN-classified date to Word ordering (2026-02-28)', () => {
+    // sample-7 date cell: logical "28-02-2026" in an Arabic complex-script run
+    // (w:rtl, w:lang w:bidi="ae-AR"). The renderer pre-splits it into digit-
+    // group / separator segments and tags each with `digitsAsAN`. Under the
+    // RTL cell base, classifying the European digits as AN reorders the groups
+    // to Word's "2026-02-28" (UAX#9 §4.3 HL1 higher-level protocol).
+    const segs = [
+      { text: '28', rtl: true, digitsAsAN: true },
+      { text: '-', rtl: true, digitsAsAN: true },
+      { text: '02', rtl: true, digitsAsAN: true },
+      { text: '-', rtl: true, digitsAsAN: true },
+      { text: '2026', rtl: true, digitsAsAN: true },
+    ];
+    const { order } = computeLineVisualOrder(segs, true);
+    // Visual L→R: 2026 - 02 - 28  →  logical indices [4,3,2,1,0].
+    const visual = order.map((i) => segs[i].text).join('');
+    expect(visual).toBe('2026-02-28');
+  });
+
+  it('leaves a date as logical order when digits are NOT AN-classified (pure UAX#9 EN)', () => {
+    // Same split, base RTL, but without the digitsAsAN flag: European digits
+    // stay EN, all at the even embedded level, so the groups keep logical order.
+    const segs = [
+      { text: '28', rtl: true },
+      { text: '-', rtl: true },
+      { text: '02', rtl: true },
+      { text: '-', rtl: true },
+      { text: '2026', rtl: true },
+    ];
+    const { order } = computeLineVisualOrder(segs, true);
+    const visual = order.map((i) => segs[i].text).join('');
+    expect(visual).toBe('28-02-2026');
+  });
 });

--- a/packages/docx/src/bidi-line.test.ts
+++ b/packages/docx/src/bidi-line.test.ts
@@ -85,6 +85,27 @@ describe('computeLineVisualOrder', () => {
     expect(rtl).toEqual([true, true]);
   });
 
+  it('keeps a trailing non-rtl numeric run leftmost in a base-RTL title (§17.3.2.30)', () => {
+    // sample-7 title "المشاريع لعام 2026": three runs, the Arabic ones carry
+    // w:rtl, "2026" does not, in a base-RTL (w:bidi) paragraph. Word renders
+    // "2026" at the LEFT (logically last in the RTL line). A w:rtl run that
+    // already has strong-RTL content must NOT be over-embedded above the base.
+    const { order, rtl } = computeLineVisualOrder(
+      [
+        { text: 'المشاريع ', rtl: true },
+        { text: 'لعام ', rtl: true },
+        { text: '2026', rtl: false },
+      ],
+      true,
+    );
+    // `order` is logical indices in visual LEFT→RIGHT order, so the LEFTMOST
+    // segment is order[0] (cf. the pure-RTL case where order=[1,0] puts the
+    // logically-last word leftmost).
+    expect(order).toEqual([2, 1, 0]);
+    expect(order[0]).toBe(2); // "2026" visually leftmost
+    expect(rtl[2]).toBe(false);
+  });
+
   it('keeps the LTR fast path byte-identical when no rtl marks and no strong-RTL', () => {
     const { order, rtl } = computeLineVisualOrder(
       [{ text: '1. ' }, { text: 'item' }],

--- a/packages/docx/src/bidi-line.test.ts
+++ b/packages/docx/src/bidi-line.test.ts
@@ -16,6 +16,20 @@ describe('segmentsHaveRtl', () => {
   });
 });
 
+  it('keeps LTR word order for English text in rtl-marked runs', () => {
+    // w:rtl on a run of pure Latin (e.g. "first leader name" in sample-7's
+    // signature block): the RLE embedding must NOT reverse the words — only
+    // weak/neutral content (digits, punctuation) takes the RTL embedding.
+    const segs = [
+      { text: 'first ', rtl: true },
+      { text: 'leader ', rtl: true },
+      { text: 'name', rtl: true },
+    ];
+    const { order, rtl } = computeLineVisualOrder(segs, false);
+    expect(order).toEqual([0, 1, 2]);
+    expect(rtl).toEqual([false, false, false]);
+  });
+
 describe('resolveAlignEdge', () => {
   it('resolves logical start/end against base direction', () => {
     expect(resolveAlignEdge(undefined, false)).toBe('left');

--- a/packages/docx/src/bidi-line.test.ts
+++ b/packages/docx/src/bidi-line.test.ts
@@ -19,8 +19,12 @@ describe('resolveAlignEdge', () => {
     expect(resolveAlignEdge('end', false)).toBe('right');
     expect(resolveAlignEdge('center', true)).toBe('center');
     expect(resolveAlignEdge('both', true)).toBe('justify');
-    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
-    expect(resolveAlignEdge('right', true)).toBe('right');
+    // Transitional left/right are "semantically equivalent to start/end"
+    // (ECMA-376 Part 4 §14.11.2) — logical, so they flip under an RTL base.
+    expect(resolveAlignEdge('left', true)).toBe('right');
+    expect(resolveAlignEdge('right', true)).toBe('left');
+    expect(resolveAlignEdge('left', false)).toBe('left');
+    expect(resolveAlignEdge('right', false)).toBe('right');
   });
 });
 

--- a/packages/docx/src/bidi-line.test.ts
+++ b/packages/docx/src/bidi-line.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { segmentsHaveRtl, computeLineVisualOrder, resolveAlignEdge } from './bidi-line.js';
+
+describe('segmentsHaveRtl', () => {
+  it('detects Arabic/Hebrew, ignores Latin and objects', () => {
+    expect(segmentsHaveRtl([{ text: 'Hello world' }])).toBe(false);
+    expect(segmentsHaveRtl([{ text: 'price 99' }, {}])).toBe(false); // object seg has no text
+    expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
+    expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
+  });
+});
+
+describe('resolveAlignEdge', () => {
+  it('resolves logical start/end against base direction', () => {
+    expect(resolveAlignEdge(undefined, false)).toBe('left');
+    expect(resolveAlignEdge(undefined, true)).toBe('right');
+    expect(resolveAlignEdge('start', true)).toBe('right');
+    expect(resolveAlignEdge('end', true)).toBe('left');
+    expect(resolveAlignEdge('end', false)).toBe('right');
+    expect(resolveAlignEdge('center', true)).toBe('center');
+    expect(resolveAlignEdge('both', true)).toBe('justify');
+    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
+    expect(resolveAlignEdge('right', true)).toBe('right');
+  });
+});
+
+describe('computeLineVisualOrder', () => {
+  it('keeps pure-LTR segments in logical order', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'Hello ' }, { text: 'world' }], false);
+    expect(order).toEqual([0, 1]);
+    expect(rtl).toEqual([false, false]);
+  });
+
+  it('reverses pure-RTL segments and marks them RTL', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'שלום ' }, { text: 'עולם' }], true);
+    expect(order).toEqual([1, 0]); // last word is visually leftmost
+    expect(rtl).toEqual([true, true]);
+  });
+
+  it('orders an embedded LTR run inside an RTL line', () => {
+    // logical: Hebrew, Latin, Hebrew (base RTL) -> visual L→R: [2,1,0]
+    const { order, rtl } = computeLineVisualOrder(
+      [{ text: 'שלום ' }, { text: 'world ' }, { text: 'טוב' }],
+      true,
+    );
+    expect(order).toEqual([2, 1, 0]);
+    expect(rtl[1]).toBe(false); // the Latin segment is LTR
+    expect(rtl[0]).toBe(true);
+    expect(rtl[2]).toBe(true);
+  });
+
+  it('places a neutral object by surrounding direction', () => {
+    // object between two Hebrew words, base RTL -> object stays in RTL flow
+    const { order } = computeLineVisualOrder([{ text: 'שלום ' }, {}, { text: 'טוב' }], true);
+    expect(order).toEqual([2, 1, 0]);
+  });
+});

--- a/packages/docx/src/bidi-line.test.ts
+++ b/packages/docx/src/bidi-line.test.ts
@@ -8,6 +8,12 @@ describe('segmentsHaveRtl', () => {
     expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
     expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
   });
+
+  it('detects a run-level rtl mark even on neutral-only text', () => {
+    // "1. " has no strong-RTL char, but the run carries <w:rtl> (§17.3.2.30).
+    expect(segmentsHaveRtl([{ text: '1. ', rtl: true }])).toBe(true);
+    expect(segmentsHaveRtl([{ text: '1. ' }])).toBe(false);
+  });
 });
 
 describe('resolveAlignEdge', () => {
@@ -51,6 +57,27 @@ describe('computeLineVisualOrder', () => {
     expect(rtl[1]).toBe(false); // the Latin segment is LTR
     expect(rtl[0]).toBe(true);
     expect(rtl[2]).toBe(true);
+  });
+
+  it('resolves a leading-digit run-level rtl run with digits at the trailing (right) end', () => {
+    // "1. " + Hebrew, both run-level rtl, base LTR (no w:bidi). Per §17.3.2.30
+    // the digits must embed RTL, so visually the Hebrew is leftmost and the
+    // "1. " (read RTL → ".1") sits at the right end.
+    const { order, rtl } = computeLineVisualOrder(
+      [{ text: '1. ', rtl: true }, { text: 'תוכן', rtl: true }],
+      false,
+    );
+    expect(order).toEqual([1, 0]); // Hebrew visually left, "1." visually right
+    expect(rtl).toEqual([true, true]);
+  });
+
+  it('keeps the LTR fast path byte-identical when no rtl marks and no strong-RTL', () => {
+    const { order, rtl } = computeLineVisualOrder(
+      [{ text: '1. ' }, { text: 'item' }],
+      false,
+    );
+    expect(order).toEqual([0, 1]);
+    expect(rtl).toEqual([false, false]);
   });
 
   it('places a neutral object by surrounding direction', () => {

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -10,7 +10,7 @@
 // resolved direction. Inline objects (image / math / tab) participate as a
 // single neutral object-replacement character.
 
-import { getDefaultBidiEngine } from '@silurus/ooxml-core';
+import { getDefaultBidiEngine, type BidiClass } from '@silurus/ooxml-core';
 
 /** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
  *  Arabic presentation forms. Used only as a cheap gate to decide whether a
@@ -31,6 +31,12 @@ const segText = (s: unknown): string | undefined => {
 
 /** Does this segment carry a run-level `<w:rtl>` (ECMA-376 §17.3.2.30)? */
 const segRtl = (s: unknown): boolean => (s as { rtl?: unknown }).rtl === true;
+
+/** Should this segment's European digits be classified AN (Word's Arabic
+ *  complex-script digit ordering)? Set by the renderer from `w:lang w:bidi`
+ *  (§17.3.2.20). See {@link computeLineVisualOrder}. */
+const segDigitsAsAN = (s: unknown): boolean =>
+  (s as { digitsAsAN?: unknown }).digitsAsAN === true;
 
 /**
  * Cheap gate: does this run of segments need the bidi pass? True when any
@@ -92,6 +98,11 @@ export function computeLineVisualOrder(
   let full = '';
   const segStart: number[] = new Array(n);
   const segEnd: number[] = new Array(n);
+  // UAX#9 §4.3 HL1 per-code-unit Bidi_Class override (see engine.computeLevels).
+  // We mark European digits inside `digitsAsAN` segments as AN so a logical
+  // "28-02-2026" reorders to Word's "2026-02-28" under an RTL base. `undefined`
+  // until any segment opts in, so the pure algorithm runs for ordinary lines.
+  let classOverride: (BidiClass | null)[] | undefined;
   for (let i = 0; i < n; i++) {
     const t = segText(segments[i]) ?? '';
     // Only wrap a w:rtl run that has NO strong-RTL char of its own: a run with
@@ -104,10 +115,25 @@ export function computeLineVisualOrder(
     full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
     segEnd[i] = full.length;
     if (isRtl) full += PDF;
+
+    if (segDigitsAsAN(segments[i]) && t.length > 0) {
+      if (!classOverride) classOverride = new Array(0);
+      // Extend lazily to the current length, then tag each European digit AN.
+      while (classOverride.length < full.length) classOverride.push(null);
+      for (let k = segStart[i]; k < segEnd[i]; k++) {
+        const c = full.charCodeAt(k);
+        if (c >= 0x30 && c <= 0x39) classOverride[k] = 'AN';
+      }
+    }
   }
+  if (classOverride) while (classOverride.length < full.length) classOverride.push(null);
 
   const engine = getDefaultBidiEngine();
-  const { levels, paragraphLevel } = engine.computeLevels(full, baseRtl ? 'rtl' : 'ltr');
+  const { levels, paragraphLevel } = engine.computeLevels(
+    full,
+    baseRtl ? 'rtl' : 'ltr',
+    classOverride,
+  );
 
   // Ordering level = the RESOLVED level of the segment's first real code unit.
   // No level forcing for rtl-marked segments: inside their RLE…PDF embedding,

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -65,11 +65,16 @@ const PDF = '‬'; // POP DIRECTIONAL FORMATTING
  * practice because they are space-split); Canvas resolves any residual
  * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
  *
- * Segments flagged `rtl` (run-level `<w:rtl>`, §17.3.2.30) are wrapped in
- * RLE…PDF so their weak/neutral characters resolve against an RTL embedding,
- * while their strong-Latin content keeps its even (LTR) resolved level — i.e.
- * a literal "1. " list prefix mirrors to ".1" at the trailing edge as Word
- * does, but English words in an rtl-marked run keep their LTR word order.
+ * A run-level `<w:rtl>` (§17.3.2.30) gives the run a strong-RTL context for
+ * its OWN weak/neutral characters; it must NOT raise the run's embedding level
+ * relative to the paragraph base. We therefore only RLE…PDF-wrap a w:rtl run
+ * when it carries NO strong-RTL character of its own: a purely neutral/numeric
+ * run (e.g. a literal "1. " list prefix) needs the wrap to resolve RTL, but a
+ * run that already contains strong Arabic/Hebrew is RTL by content — wrapping
+ * it would over-embed it (level base+2) above sibling LTR/numeric runs at the
+ * base level, stranding e.g. a trailing "2026" on the wrong side of an
+ * otherwise-RTL line. Strong-Latin content always keeps its even (LTR) level,
+ * so English words in an rtl-marked run keep their LTR word order either way.
  */
 export function computeLineVisualOrder(
   segments: readonly unknown[],
@@ -89,7 +94,11 @@ export function computeLineVisualOrder(
   const segEnd: number[] = new Array(n);
   for (let i = 0; i < n; i++) {
     const t = segText(segments[i]) ?? '';
-    const isRtl = segRtl(segments[i]);
+    // Only wrap a w:rtl run that has NO strong-RTL char of its own: a run with
+    // strong Arabic/Hebrew is already RTL by content, so an RLE embedding would
+    // over-raise its level above sibling base-level runs (the 2026-on-the-wrong-
+    // side bug). A neutral/numeric w:rtl run still needs the wrap to resolve RTL.
+    const isRtl = segRtl(segments[i]) && !RTL_GATE.test(t);
     if (isRtl) full += RLE;
     segStart[i] = full.length;
     full += t.length > 0 ? t : OBJECT_PLACEHOLDER;

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -66,9 +66,10 @@ const PDF = '‬'; // POP DIRECTIONAL FORMATTING
  * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
  *
  * Segments flagged `rtl` (run-level `<w:rtl>`, §17.3.2.30) are wrapped in
- * RLE…PDF and assigned the RTL embedding level directly, so a run whose text is
- * purely neutral/numeric (e.g. a literal "1. " list prefix) still embeds and
- * mirrors right-to-left as Word does.
+ * RLE…PDF so their weak/neutral characters resolve against an RTL embedding,
+ * while their strong-Latin content keeps its even (LTR) resolved level — i.e.
+ * a literal "1. " list prefix mirrors to ".1" at the trailing edge as Word
+ * does, but English words in an rtl-marked run keep their LTR word order.
  */
 export function computeLineVisualOrder(
   segments: readonly unknown[],
@@ -85,42 +86,57 @@ export function computeLineVisualOrder(
   // from the content, not the formatting control.
   let full = '';
   const segStart: number[] = new Array(n);
+  const segEnd: number[] = new Array(n);
   for (let i = 0; i < n; i++) {
     const t = segText(segments[i]) ?? '';
     const isRtl = segRtl(segments[i]);
     if (isRtl) full += RLE;
     segStart[i] = full.length;
     full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
+    segEnd[i] = full.length;
     if (isRtl) full += PDF;
   }
 
   const engine = getDefaultBidiEngine();
   const { levels, paragraphLevel } = engine.computeLevels(full, baseRtl ? 'rtl' : 'ltr');
 
-  // Embedding level established by a top-level RLE = smallest odd level above
-  // the paragraph level (UAX#9 X2). A run-level `<w:rtl>` segment draws RTL by
-  // definition (§17.3.2.30), so it takes this odd level directly — without it,
-  // a digits-only run (European Number) would resolve to an even level and be
-  // drawn LTR even though Word mirrors it ("1. " → ".1") at the trailing edge.
-  const rtlEmbedLevel = paragraphLevel | 1;
-
+  // Ordering level = the RESOLVED level of the segment's first real code unit.
+  // No level forcing for rtl-marked segments: inside their RLE…PDF embedding,
+  // Latin letters legitimately resolve to the even embedded level (so English
+  // words in an rtl-marked run keep their mutual LTR order, as Word renders
+  // them), while digits/neutrals resolve per UAX#9 against the RTL embedding.
+  //
+  // Direction hint = "does the segment contain ANY odd-level unit". A
+  // digits-with-punctuation slice like "1. " inside an RTL embedding has its
+  // "." resolve to the odd embedding level, so the slice draws with
+  // ctx.direction rtl and Canvas mirrors it to ".1" exactly as Word does —
+  // whereas a pure-Latin slice is all-even and keeps its LTR rendering.
   const segLevels = new Uint8Array(n);
+  const rtl: boolean[] = new Array(n);
   for (let i = 0; i < n; i++) {
-    if (segRtl(segments[i])) {
-      segLevels[i] = rtlEmbedLevel;
-      continue;
-    }
     const lvl = levels[segStart[i]];
     // 255 = removed by X9 (no glyph); fall back to the paragraph level.
     segLevels[i] = lvl === 255 ? paragraphLevel : lvl;
+    // Scan excludes the segment's TRAILING whitespace: an inter-word space's
+    // level is seam context (N2 gives it the embedding level between
+    // opposite-direction neighbours), not segment content — only the content
+    // decides whether the slice must mirror.
+    let scanEnd = segEnd[i];
+    while (scanEnd > segStart[i] && full[scanEnd - 1] === ' ') scanEnd--;
+    let anyOdd = false;
+    for (let k = segStart[i]; k < scanEnd; k++) {
+      const l = levels[k];
+      if (l !== 255 && (l & 1) === 1) {
+        anyOdd = true;
+        break;
+      }
+    }
+    rtl[i] = anyOdd;
   }
 
   const order = engine.reorderVisual(segLevels, 0, n);
-  const rtl: boolean[] = new Array(n);
-  for (let i = 0; i < n; i++) rtl[i] = (segLevels[i] & 1) === 1;
   return { order, rtl };
 }
-
 /** Physical edge a line aligns to, resolving logical start/end against base direction. */
 export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
 

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -1,0 +1,110 @@
+// Per-line bidi ordering for the docx renderer.
+//
+// `buildSegments` splits runs into space-delimited word pieces, so Arabic
+// joining never crosses a segment boundary. That lets us reorder at SEGMENT
+// granularity (1:1 with the laid-out segments — every per-segment property is
+// preserved) using the shared UAX#9 engine, and let Canvas shape/mirror each
+// segment internally when it is drawn with `ctx.direction` set to the segment's
+// resolved direction. Inline objects (image / math / tab) participate as a
+// single neutral object-replacement character.
+
+import { getDefaultBidiEngine } from '@silurus/ooxml-core';
+
+/** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
+ *  Arabic presentation forms. Used only as a cheap gate to decide whether a
+ *  line needs the (exact) bidi pass at all — never for ordering itself. */
+const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+
+/** A laid-out segment as seen here: only its optional text matters for bidi.
+ *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
+ *  math / tab members carry no `text`) assigns cleanly. */
+const segText = (s: unknown): string | undefined => {
+  const t = (s as { text?: unknown }).text;
+  return typeof t === 'string' ? t : undefined;
+};
+
+/** Cheap test: does this run of segments contain any strong-RTL character? */
+export function segmentsHaveRtl(segments: readonly unknown[]): boolean {
+  for (const s of segments) {
+    const t = segText(s);
+    if (t !== undefined && RTL_GATE.test(t)) return true;
+  }
+  return false;
+}
+
+export interface LineVisualOrder {
+  /** Logical segment indices in visual (left-to-right) order. */
+  order: number[];
+  /** Per-LOGICAL-index resolved direction (true = RTL) for `ctx.direction`. */
+  rtl: boolean[];
+}
+
+const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON)
+
+/**
+ * Compute the visual draw order of a line's segments under `baseRtl`. Text
+ * segments contribute their text; non-text segments contribute one neutral
+ * placeholder so they take the surrounding direction. Each segment is assigned
+ * the embedding level of its first code unit (segments are single-script in
+ * practice because they are space-split); Canvas resolves any residual
+ * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
+ */
+export function computeLineVisualOrder(
+  segments: readonly unknown[],
+  baseRtl: boolean,
+): LineVisualOrder {
+  const n = segments.length;
+  if (n === 0) return { order: [], rtl: [] };
+
+  let full = '';
+  const segStart: number[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    segStart[i] = full.length;
+    const t = segText(segments[i]) ?? '';
+    full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
+  }
+
+  const engine = getDefaultBidiEngine();
+  const { levels, paragraphLevel } = engine.computeLevels(full, baseRtl ? 'rtl' : 'ltr');
+
+  const segLevels = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const lvl = levels[segStart[i]];
+    // 255 = removed by X9 (no glyph); fall back to the paragraph level.
+    segLevels[i] = lvl === 255 ? paragraphLevel : lvl;
+  }
+
+  const order = engine.reorderVisual(segLevels, 0, n);
+  const rtl: boolean[] = new Array(n);
+  for (let i = 0; i < n; i++) rtl[i] = (segLevels[i] & 1) === 1;
+  return { order, rtl };
+}
+
+/** Physical edge a line aligns to, resolving logical start/end against base direction. */
+export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
+
+/**
+ * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
+ * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
+ * an unset alignment defaults to the leading (logical-start) edge.
+ */
+export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
+  switch (alignment) {
+    case 'center':
+      return 'center';
+    case 'both':
+    case 'justify':
+    case 'distribute':
+      return 'justify';
+    case 'left':
+      return 'left';
+    case 'right':
+      return 'right';
+    case 'end':
+      return baseRtl ? 'left' : 'right';
+    case 'start':
+    case undefined:
+    default:
+      return baseRtl ? 'right' : 'left';
+  }
+}

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -1,7 +1,9 @@
 // Per-line bidi ordering for the docx renderer.
 //
-// `buildSegments` splits runs into space-delimited word pieces, so Arabic
-// joining never crosses a segment boundary. That lets us reorder at SEGMENT
+// `buildSegments` splits each run's text into space-delimited word pieces, so
+// WITHIN a run Arabic joining never crosses a segment boundary (a mid-word
+// run split — e.g. one letter bolded — still seams at the run boundary; that
+// pre-existing limitation is tracked for Phase 4). That lets us reorder at SEGMENT
 // granularity (1:1 with the laid-out segments — every per-segment property is
 // preserved) using the shared UAX#9 engine, and let Canvas shape/mirror each
 // segment internally when it is drawn with `ctx.direction` set to the segment's
@@ -13,7 +15,11 @@ import { getDefaultBidiEngine } from '@silurus/ooxml-core';
 /** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
  *  Arabic presentation forms. Used only as a cheap gate to decide whether a
  *  line needs the (exact) bidi pass at all — never for ordering itself. */
-const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+const RTL_GATE =
+  // strong-RTL blocks incl. presentation forms, Plane-1 RTL blocks
+  // (Phoenician..Old Hungarian U+10800-10FFF; Mende Kikakui/Adlam/Arabic
+  // Math U+1E800-1EFFF), and RTL-implicating controls (RLM/RLE/RLO/RLI).
+  /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF\u200F\u202B\u202E\u2067]|[\u{10800}-\u{10FFF}\u{1E800}-\u{1EFFF}]/u;
 
 /** A laid-out segment as seen here: only its optional text matters for bidi.
  *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
@@ -85,8 +91,11 @@ export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
 
 /**
  * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
- * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
- * an unset alignment defaults to the leading (logical-start) edge.
+ * ALL edge values are logical in WordprocessingML: `start`/`end` by definition
+ * (§17.18.44), and the transitional `left`/`right` are defined as
+ * "semantically equivalent to start/end" (ECMA-376 Part 4 §14.11.2) — so every
+ * edge flips under an RTL base. An unset alignment defaults to the leading
+ * (logical-start) edge.
  */
 export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
   switch (alignment) {
@@ -96,13 +105,11 @@ export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean
     case 'justify':
     case 'distribute':
       return 'justify';
-    case 'left':
-      return 'left';
-    case 'right':
-      return 'right';
     case 'end':
+    case 'right':
       return baseRtl ? 'left' : 'right';
     case 'start':
+    case 'left':
     case undefined:
     default:
       return baseRtl ? 'right' : 'left';

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -29,9 +29,17 @@ const segText = (s: unknown): string | undefined => {
   return typeof t === 'string' ? t : undefined;
 };
 
-/** Cheap test: does this run of segments contain any strong-RTL character? */
+/** Does this segment carry a run-level `<w:rtl>` (ECMA-376 §17.3.2.30)? */
+const segRtl = (s: unknown): boolean => (s as { rtl?: unknown }).rtl === true;
+
+/**
+ * Cheap gate: does this run of segments need the bidi pass? True when any
+ * segment contains a strong-RTL character OR carries a run-level `<w:rtl>`
+ * mark (§17.3.2.30 — e.g. a digits-only run that must resolve RTL).
+ */
 export function segmentsHaveRtl(segments: readonly unknown[]): boolean {
   for (const s of segments) {
+    if (segRtl(s)) return true;
     const t = segText(s);
     if (t !== undefined && RTL_GATE.test(t)) return true;
   }
@@ -46,6 +54,8 @@ export interface LineVisualOrder {
 }
 
 const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON)
+const RLE = '‫'; // RIGHT-TO-LEFT EMBEDDING
+const PDF = '‬'; // POP DIRECTIONAL FORMATTING
 
 /**
  * Compute the visual draw order of a line's segments under `baseRtl`. Text
@@ -54,6 +64,11 @@ const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON
  * the embedding level of its first code unit (segments are single-script in
  * practice because they are space-split); Canvas resolves any residual
  * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
+ *
+ * Segments flagged `rtl` (run-level `<w:rtl>`, §17.3.2.30) are wrapped in
+ * RLE…PDF and assigned the RTL embedding level directly, so a run whose text is
+ * purely neutral/numeric (e.g. a literal "1. " list prefix) still embeds and
+ * mirrors right-to-left as Word does.
  */
 export function computeLineVisualOrder(
   segments: readonly unknown[],
@@ -62,19 +77,39 @@ export function computeLineVisualOrder(
   const n = segments.length;
   if (n === 0) return { order: [], rtl: [] };
 
+  // Concatenate every segment into one logical string for the bidi algorithm.
+  // A run-level `<w:rtl>` segment (§17.3.2.30) is wrapped in RLE…PDF so that its
+  // neutral/weak characters (e.g. leading Western digits in "1. ") resolve to an
+  // RTL embedding, matching Word. `segStart[i]` points at the segment's FIRST
+  // REAL code unit (skipping the injected RLE) so the per-segment level is read
+  // from the content, not the formatting control.
   let full = '';
   const segStart: number[] = new Array(n);
   for (let i = 0; i < n; i++) {
-    segStart[i] = full.length;
     const t = segText(segments[i]) ?? '';
+    const isRtl = segRtl(segments[i]);
+    if (isRtl) full += RLE;
+    segStart[i] = full.length;
     full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
+    if (isRtl) full += PDF;
   }
 
   const engine = getDefaultBidiEngine();
   const { levels, paragraphLevel } = engine.computeLevels(full, baseRtl ? 'rtl' : 'ltr');
 
+  // Embedding level established by a top-level RLE = smallest odd level above
+  // the paragraph level (UAX#9 X2). A run-level `<w:rtl>` segment draws RTL by
+  // definition (§17.3.2.30), so it takes this odd level directly — without it,
+  // a digits-only run (European Number) would resolve to an even level and be
+  // drawn LTR even though Word mirrors it ("1. " → ".1") at the trailing edge.
+  const rtlEmbedLevel = paragraphLevel | 1;
+
   const segLevels = new Uint8Array(n);
   for (let i = 0; i < n; i++) {
+    if (segRtl(segments[i])) {
+      segLevels[i] = rtlEmbedLevel;
+      continue;
+    }
     const lvl = levels[segStart[i]];
     // 255 = removed by X9 (no glyph); fall back to the paragraph level.
     segLevels[i] = lvl === 255 ? paragraphLevel : lvl;

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -15,6 +15,11 @@ import { computePages, renderDocumentToCanvas, documentHasMath, prepareMathRuns 
  *  Office templates pull from. Substitutes that diverge from the requested
  *  family name (Calibri → Carlito, Cambria → Caladea) include
  *  `loadFamily` so the FontFaceSet load is driven against the substitute. */
+const NOTO_NASKH_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic:wght@400;700&display=swap';
+const NOTO_SANS_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@400;700&display=swap';
+
 const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'calibri':           { url: 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Carlito' },
   'cambria':           { url: 'https://fonts.googleapis.com/css2?family=Caladea:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Caladea' },
@@ -27,6 +32,21 @@ const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'poppins':           { url: 'https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'raleway':           { url: 'https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
+  // Common Arabic-script faces that hosts rarely ship. Map them to Noto
+  // substitutes so RTL documents (e.g. sample-7, which requests Sakkal Majalla
+  // / Univers Next Arabic) render with a real web font instead of an oversized
+  // OS fallback. "Naskh" covers traditional serif-like Arabic faces; "Sans"
+  // covers the modern geometric ones.
+  'sakkal majalla':      { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'traditional arabic':  { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'simplified arabic':   { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'arabic typesetting':  { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'univers next arabic': { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
+  // Self-referencing entries so the generic Arabic fallback fonts (appended to
+  // the renderer's font chain) are themselves loaded whenever useGoogleFonts
+  // is enabled — see `load`, which always queues these names.
+  'noto naskh arabic':   { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'noto sans arabic':    { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
 };
 
 /** Options for {@link DocxDocument.load}. Extends the shared load-options type
@@ -69,8 +89,16 @@ export class DocxDocument {
     }
     await doc._parse(buffer, opts.maxZipEntryBytes);
     if (opts.useGoogleFonts) {
+      // Always load the generic Arabic fallbacks so any Arabic-script run gets
+      // a real web font even when its named family is unmapped (the renderer's
+      // font fallback chains end with these two Noto faces).
       await preloadGoogleFonts(
-        [doc._document?.majorFont, doc._document?.minorFont],
+        [
+          doc._document?.majorFont,
+          doc._document?.minorFont,
+          'Noto Naskh Arabic',
+          'Noto Sans Arabic',
+        ],
         DOCX_GOOGLE_FONTS,
       );
     }

--- a/packages/docx/src/font-family.test.ts
+++ b/packages/docx/src/font-family.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeFontFamily } from './renderer.js';
+
+describe('normalizeFontFamily — Arabic substitute fonts', () => {
+  it('puts the Arabic substitute first so Latin/digits resolve from the same family as Arabic', () => {
+    // Sakkal Majalla is family="auto" in fontTable; the run carries both
+    // Arabic glyphs and Latin/digits. The Arabic substitute must lead the chain
+    // (before any CJK sans face) so Latin/digits don't leak to Noto Sans JP.
+    const chain = normalizeFontFamily('Sakkal Majalla');
+    expect(chain.startsWith('"Sakkal Majalla", "Noto Naskh Arabic"')).toBe(true);
+    // No CJK sans face before the Arabic substitute.
+    const naskhIdx = chain.indexOf('Noto Naskh Arabic');
+    const cjkIdx = chain.indexOf('Noto Sans JP');
+    expect(naskhIdx).toBeGreaterThan(0);
+    expect(naskhIdx).toBeLessThan(cjkIdx);
+  });
+
+  it('routes traditional Naskh faces to a serif Latin companion', () => {
+    // Word's PDF export of sample-7 renders Sakkal Majalla's Latin with serifs,
+    // so a serif Latin generic precedes the sans generics.
+    const chain = normalizeFontFamily('Traditional Arabic');
+    expect(chain).toContain('"Noto Serif"');
+    expect(chain.endsWith('serif')).toBe(true);
+    expect(chain.indexOf('Noto Serif')).toBeLessThan(chain.indexOf('Noto Sans JP'));
+  });
+
+  it('keys off the family, not a hardcoded string — case-insensitive', () => {
+    expect(normalizeFontFamily('sakkal majalla').startsWith('"sakkal majalla", "Noto Naskh Arabic"')).toBe(true);
+  });
+
+  it('routes geometric Arabic faces (Univers Next Arabic) to a sans chain', () => {
+    const chain = normalizeFontFamily('Univers Next Arabic');
+    expect(chain.startsWith('"Univers Next Arabic", "Noto Sans Arabic"')).toBe(true);
+    expect(chain.endsWith('sans-serif')).toBe(true);
+  });
+
+  it('leaves pure-Latin fonts unchanged (sans default chain)', () => {
+    expect(normalizeFontFamily('Arial')).toBe(
+      '"Arial", "Noto Sans JP", "Hiragino Sans", "Meiryo", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif',
+    );
+  });
+
+  it('leaves serif Latin fonts unchanged', () => {
+    expect(normalizeFontFamily('Times New Roman')).toBe(
+      '"Times New Roman", "Yu Mincho", "YuMincho", "Hiragino Mincho ProN", "MS Mincho", "Noto Serif JP", "Noto Serif", "Noto Naskh Arabic", "Noto Sans Arabic", serif',
+    );
+  });
+});

--- a/packages/docx/src/font-metrics.test.ts
+++ b/packages/docx/src/font-metrics.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { fontWinLineHeightRatio, intendedSingleLinePx } from './font-metrics.js';
+import { fontWinLineHeightRatio, intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 
 describe('fontWinLineHeightRatio', () => {
   it('returns Meiryo / Meiryo UI win line-height ratio (≈1.60 em)', () => {
     expect(fontWinLineHeightRatio('Meiryo UI')).toBe(1.6);
     expect(fontWinLineHeightRatio('Meiryo')).toBe(1.6);
     expect(fontWinLineHeightRatio('メイリオ')).toBe(1.6);
+  });
+  it('returns Sakkal Majalla win line-height ratio (1.3965 em, from OS/2)', () => {
+    // unitsPerEm 2048, usWinAscent 1810 + usWinDescent 1050 = 2860 → 1.3965.
+    expect(fontWinLineHeightRatio('Sakkal Majalla')).toBeCloseTo(2860 / 2048, 5);
+    expect(fontWinLineHeightRatio('sakkal majalla')).toBeCloseTo(2860 / 2048, 5);
   });
   it('is case-insensitive', () => {
     expect(fontWinLineHeightRatio('meiryo ui')).toBe(1.6);
@@ -33,5 +38,27 @@ describe('intendedSingleLinePx', () => {
   it('returns 0 (no-op sentinel) for untabled fonts', () => {
     expect(intendedSingleLinePx('Arial', 96)).toBe(0);
     expect(intendedSingleLinePx(null, 96)).toBe(0);
+  });
+});
+
+describe('correctLineMetrics', () => {
+  it('returns the document font win ascent/descent for tabled fonts', () => {
+    // Sakkal Majalla at em = 12 px: asc = 1810/2048 × 12, desc = 1050/2048 × 12.
+    // The substitute's (over-large) measured metrics are replaced, not scaled.
+    const r = correctLineMetrics('Sakkal Majalla', 12, /*substituteAsc*/ 18, /*substituteDesc*/ 8);
+    expect(r.ascent).toBeCloseTo((1810 / 2048) * 12, 5);
+    expect(r.descent).toBeCloseTo((1050 / 2048) * 12, 5);
+    // Total equals the win line-height ratio × em (here ~16.76 px, well under
+    // the substitute's 26 px), which is what fixes the over-measured cell box.
+    expect(r.ascent + r.descent).toBeCloseTo((2860 / 2048) * 12, 5);
+  });
+  it('preserves Meiryo total at exactly 1.60 em with the OS/2 split', () => {
+    const r = correctLineMetrics('Meiryo UI', 18, 14, 4);
+    expect(r.ascent + r.descent).toBeCloseTo(1.6 * 18, 5);
+    expect(r.ascent / (r.ascent + r.descent)).toBeCloseTo(2210 / 3269, 5);
+  });
+  it('passes through measured metrics unchanged for untabled fonts', () => {
+    const r = correctLineMetrics('Arial', 12, 11, 3);
+    expect(r).toEqual({ ascent: 11, descent: 3 });
   });
 });

--- a/packages/docx/src/font-metrics.ts
+++ b/packages/docx/src/font-metrics.ts
@@ -13,34 +13,93 @@
 // Our renderer normally derives the single-line height from the Canvas
 // `fontBoundingBoxAscent + fontBoundingBoxDescent` of the font the browser
 // actually used. That is correct when the document's font is installed, but
-// when it is substituted the fallback's metrics can be far smaller than the
-// intended font's — and for fonts with large win-metrics (Japanese UI fonts
-// especially) the gap is big enough to overlap lines and accumulate vertical
-// drift down the page.
+// when it is substituted the fallback's metrics can differ from the intended
+// font's — in EITHER direction — by enough to break line spacing, vertical
+// centering, and pagination:
 //
-// `Meiryo` / `Meiryo UI` are the canonical example: their win line height is
-// ≈1.60 em (unitsPerEm 2048, usWinAscent+usWinDescent ≈ 3269), while the
-// macOS/Chromium fallback (`Hiragino Sans`) reports only ≈1.0 em from
-// `fontBoundingBox`. A 48 pt Meiryo title with `line="168"` (0.7×) therefore
-// renders at 0.7 × 1.60 × 48 ≈ 53.8 pt in Word but collapses to ≈34 pt with
-// the fallback metric, overlapping the lines.
+//   * Fallback TALLER than the document font: the substitute's design line box
+//     overstates Word's line height. The lines spread out, and in a fixed-size
+//     box (e.g. a `w:trHeight hRule="exact"` table row with `w:vAlign="center"`,
+//     §17.4.81 / §17.4.84) the over-measured content height pushes the centered
+//     text above the true center. `Sakkal Majalla` substituted by `Noto Naskh
+//     Arabic` is the canonical example (see below).
+//   * Fallback SHORTER than the document font: the substitute understates Word's
+//     line height, so lines overlap and vertical drift accumulates down the
+//     page. `Meiryo` / `Meiryo UI` is the canonical example.
 //
-// This table provides the intended font's win line-height ratio so the line
-// box can be sized as Word would, independent of which fallback ends up
-// drawing the glyphs. Only fonts whose ratio is verified from real metrics
-// belong here — never a value tuned to make one sample look right. Latin
-// fonts are intentionally absent: their win ratio (~1.15–1.22 em) is close to
-// what the browser fallback already reports, so the correction is negligible.
+// Both are the same defect: the line box must follow the DOCUMENT font's design
+// line height, not the substitute's. On Windows (Word's PDF-export target) that
+// design line height is `(usWinAscent + usWinDescent) / unitsPerEm` from the
+// OS/2 table whenever the font does not set the USE_TYPO_METRICS fsSelection
+// bit (bit 7); both fonts below clear that bit, so the win metric is what Word
+// uses.
+//
+// Examples:
+//   * `Meiryo` / `Meiryo UI` — unitsPerEm 2048, usWinAscent 2210 +
+//     usWinDescent 1059 ≈ 3269 → 1.596 em. The macOS/Chromium fallback
+//     (`Hiragino Sans`) reports only ≈1.0 em from `fontBoundingBox`. A 48 pt
+//     Meiryo title with `line="168"` (0.7×) renders at 0.7 × 1.60 × 48 ≈
+//     53.8 pt in Word but collapses to ≈34 pt with the fallback metric.
+//   * `Sakkal Majalla` — unitsPerEm 2048, usWinAscent 1810 + usWinDescent
+//     1050 = 2860 → 1.3965 em (extracted directly from the installed
+//     `Sakkal Majalla Regular.ttf`, version 5.01; USE_TYPO_METRICS bit clear,
+//     so Word uses the win metric). The Google-Fonts substitute `Noto Naskh
+//     Arabic` reports a far larger ≈2.2 em line box (winAscent ≈1.535 em +
+//     winDescent ≈0.665 em) from `fontBoundingBox`. In sample-7's page-2 table
+//     header (12 pt, `w:trHeight` 350 twips hRule="exact" → 17.5 pt row,
+//     `w:vAlign="center"`) the substitute's 2.2 × 12 = 26.4 pt content box
+//     centers to (17.5 − 26.4)/2 = −4.4 pt, pushing the white header text above
+//     the band top; Word fits the 1.3965 × 12 ≈ 16.8 pt box inside the row with
+//     visible top/bottom gaps.
+//
+// This table provides the intended font's win ascent and descent ratios
+// (`usWinAscent / unitsPerEm` and `usWinDescent / unitsPerEm`) so the line box
+// can be sized — and the baseline placed within it — as Word would, independent
+// of which fallback ends up drawing the glyphs. Carrying ascent and descent
+// separately (rather than only their sum) matters when the substitute's
+// ascent:descent split differs from the document font's: using the substitute's
+// split would mis-place the baseline inside an otherwise correctly sized box,
+// shifting vertically-centered text off center. Only fonts whose metrics are
+// verified from real OS/2 data belong here — never a value tuned to make one
+// sample look right. Latin fonts are intentionally absent: their win ratio
+// (~1.15–1.22 em) is close to what the browser fallback already reports, so the
+// correction is negligible.
 
-/** A known font's win line-height ratio: `(usWinAscent + usWinDescent) /
- *  unitsPerEm`. Keyed by a normalized (lowercased) family name. */
-const WIN_LINE_HEIGHT_RATIO: ReadonlyArray<readonly [test: (n: string) => boolean, ratio: number]> = [
-  // Meiryo / Meiryo UI — unitsPerEm 2048, usWinAscent 2210 + usWinDescent 1059
-  // ≈ 3269 → 1.596. Cross-checked against the sample-3 reference PDF: the 48 pt
-  // Title (`line="168"` = 0.7×) measures 53.8 pt cap-top to cap-top
-  // → singleLine = 53.8 / 0.7 / 48 = 1.60 em.
-  [(n) => n.includes('meiryo') || n.includes('メイリオ'), 1.6],
+interface WinMetric {
+  /** `usWinAscent / unitsPerEm`. */ asc: number;
+  /** `usWinDescent / unitsPerEm`. */ desc: number;
+}
+
+/** A known font's win metrics. Keyed by a normalized (lowercased) name test. */
+const WIN_METRICS: ReadonlyArray<readonly [test: (n: string) => boolean, m: WinMetric]> = [
+  // Meiryo / Meiryo UI — unitsPerEm 2048, usWinAscent 2210, usWinDescent 1059
+  // → raw sum 3269/2048 = 1.5962. Cross-checked against the sample-3 reference
+  // PDF: the 48 pt Title (`line="168"` = 0.7×) measures 53.8 pt cap-top to
+  // cap-top → singleLine = 53.8 / 0.7 / 48 = 1.60 em, so the sum is pinned to
+  // exactly 1.60 (its long-standing cross-checked value); the ascent:descent
+  // split keeps the OS/2 proportion (2210:1059).
+  [
+    (n) => n.includes('meiryo') || n.includes('メイリオ'),
+    { asc: 1.6 * (2210 / 3269), desc: 1.6 * (1059 / 3269) },
+  ],
+  // Sakkal Majalla — unitsPerEm 2048, usWinAscent 1810, usWinDescent 1050
+  // → asc 0.8838, desc 0.5127, sum = 1.3965. Extracted directly from the
+  // installed `Sakkal Majalla Regular.ttf` (version 5.01, © 2008 Microsoft) via
+  // fontTools OS/2: USE_TYPO_METRICS bit (fsSelection bit 7) is clear, so Word
+  // uses the win metric. The Google-Fonts substitute (Noto Naskh Arabic)
+  // reports ≈2.2 em from fontBoundingBox with a more ascent-heavy split, so
+  // without this both the line box and the baseline position are wrong.
+  [(n) => n.includes('sakkal majalla') || n.includes('majalla'), { asc: 1810 / 2048, desc: 1050 / 2048 }],
 ];
+
+function lookupWinMetric(family: string | null | undefined): WinMetric | null {
+  if (!family) return null;
+  const n = family.toLowerCase();
+  for (const [test, m] of WIN_METRICS) {
+    if (test(n)) return m;
+  }
+  return null;
+}
 
 /**
  * Win line-height ratio (`(usWinAscent+usWinDescent)/unitsPerEm`) for a
@@ -48,12 +107,8 @@ const WIN_LINE_HEIGHT_RATIO: ReadonlyArray<readonly [test: (n: string) => boolea
  * caller should then fall back to the substituted font's Canvas metrics).
  */
 export function fontWinLineHeightRatio(family: string | null | undefined): number | null {
-  if (!family) return null;
-  const n = family.toLowerCase();
-  for (const [test, ratio] of WIN_LINE_HEIGHT_RATIO) {
-    if (test(n)) return ratio;
-  }
-  return null;
+  const m = lookupWinMetric(family);
+  return m === null ? null : m.asc + m.desc;
 }
 
 /**
@@ -65,4 +120,34 @@ export function fontWinLineHeightRatio(family: string | null | undefined): numbe
 export function intendedSingleLinePx(family: string | null | undefined, emPx: number): number {
   const ratio = fontWinLineHeightRatio(family);
   return ratio === null ? 0 : ratio * emPx;
+}
+
+/**
+ * Correct a substitute font's measured Canvas `fontBoundingBox` ascent/descent
+ * to the DOCUMENT font's design line box, so both the rendered line height AND
+ * the baseline position within it match Word regardless of which fallback drew
+ * the glyphs.
+ *
+ * When `family` is in the win-metric table the returned ascent/descent are the
+ * document font's `usWinAscent / unitsPerEm × emPx` and
+ * `usWinDescent / unitsPerEm × emPx` — i.e. the intended line box with the
+ * intended baseline split, not the substitute's. This both RAISES boxes for
+ * substitutes that understate the document font (Meiryo via Hiragino) and
+ * SHRINKS boxes for substitutes that overstate it (Sakkal Majalla via Noto
+ * Naskh Arabic, §17.4.81 / §17.4.84 cell centering). Using the document font's
+ * own ascent:descent split keeps vertically-centered text on center even when
+ * the substitute's split differs. When `family` is not in the table, the
+ * measured metrics are returned unchanged. The `ascentPx`/`descentPx` arguments
+ * are unused for tabled fonts but kept so callers can pass the substitute
+ * metrics uniformly.
+ */
+export function correctLineMetrics(
+  family: string | null | undefined,
+  emPx: number,
+  ascentPx: number,
+  descentPx: number,
+): { ascent: number; descent: number } {
+  const m = lookupWinMetric(family);
+  if (m === null) return { ascent: ascentPx, descent: descentPx };
+  return { ascent: m.asc * emPx, descent: m.desc * emPx };
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1395,6 +1395,11 @@ interface LayoutTextSeg {
    *  When true the segment's text is treated as a strong-RTL embedding in the
    *  per-line bidi pass (so leading digits / neutrals resolve RTL). */
   rtl?: boolean;
+  /** UAX#9 §4.3 HL1 / Word behaviour: classify this segment's European digits
+   *  (U+0030–0039) as Arabic-Number (AN) in the per-line bidi pass, so a date
+   *  like "28-02-2026" in an Arabic complex-script run reorders to "2026-02-28"
+   *  exactly as Word renders it (ECMA-376 §17.3.2.20 w:lang w:bidi). */
+  digitsAsAN?: boolean;
 }
 
 /**
@@ -1492,18 +1497,41 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
       ? { text: baseRuby.text, fontSizePt: baseRuby.fontSizePt }
       : undefined;
     const revision = (base as DocxTextRun).revision;
-    const rtl = (base as DocxTextRun).rtl === true ? true : undefined;
+    const r = base as DocxTextRun;
+    const rtl = r.rtl === true ? true : undefined;
+
+    // ECMA-376 §17.3.2.26 content classification. A run with `w:rtl` (§17.3.2.30)
+    // or an explicit complex-script font (`w:rFonts w:cs`) applies complex-script
+    // formatting to ALL of its characters; otherwise each character is routed by
+    // its Unicode block (Arabic/Hebrew/... → cs; Latin/digits/CJK → ascii/hAnsi).
+    const forceCs = r.rtl === true || r.fontFamilyCs != null;
+
+    // Complex-script (cs) formatting sources, each falling back to its Latin
+    // counterpart when the cs-specific property is absent (the parser already
+    // resolves szCs through the full style chain, mirroring a directly-set
+    // `w:sz` per §17.3.2.18; bCs/iCs per §17.3.2.3/§17.3.2.17).
+    const csFontSize = r.fontSizeCs ?? base.fontSize;
+    const csFontFamily = r.fontFamilyCs ?? base.fontFamily;
+    const csBold = r.boldCs ?? base.bold;
+    const csItalic = r.italicCs ?? base.italic;
+
+    // Word classifies European digits in an Arabic/Hebrew complex-script run as
+    // AN (§17.3.2.20 w:lang w:bidi): use the bidi language's primary subtag when
+    // present, else fall back to the run being rtl-marked.
+    const digitsAsAN =
+      (forceCs || r.rtl === true) && isRtlBidiLang(r.langBidi, r.rtl === true);
+
     let firstSeg = true;
-    for (const word of splitTextForLayout(displayText)) {
+    const emit = (word: string, cs: boolean) => {
       segs.push({
         text: word,
-        bold: base.bold,
-        italic: base.italic,
+        bold: cs ? csBold : base.bold,
+        italic: cs ? csItalic : base.italic,
         underline: base.underline,
         strikethrough: base.strikethrough,
-        fontSize: base.fontSize,
+        fontSize: cs ? csFontSize : base.fontSize,
         color: base.color,
-        fontFamily: base.fontFamily,
+        fontFamily: cs ? csFontFamily : base.fontFamily,
         vertAlign,
         measuredWidth: 0,
         smallCaps: base.smallCaps ?? false,
@@ -1512,8 +1540,29 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         ruby: firstSeg ? ruby : undefined,
         revision,
         rtl,
+        digitsAsAN: digitsAsAN ? true : undefined,
       });
       firstSeg = false;
+    };
+
+    for (const word of splitTextForLayout(displayText)) {
+      if (forceCs) {
+        // When the run's digits are AN-classified, split a token into maximal
+        // digit-groups and the surrounding separators so the per-line bidi pass
+        // (which reorders at SEGMENT granularity) can place the groups in Word's
+        // order — e.g. "28-02-2026" → segments [28][-][02][-][2026] reordered to
+        // 2026-02-28. Canvas only reorders WITHIN a fillText using EN semantics,
+        // so a single-segment date would otherwise stay 28-02-2026.
+        if (digitsAsAN) {
+          for (const slice of splitDigitGroups(word)) emit(slice, true);
+        } else {
+          emit(word, true);
+        }
+      } else {
+        // Mixed Arabic+Latin word (no w:rtl / w:cs): split at script boundaries
+        // so each side gets its own (cs vs Latin) size and typeface.
+        for (const slice of splitByComplexScript(word)) emit(slice.text, slice.cs);
+      }
     }
   };
 
@@ -1630,6 +1679,133 @@ function fitCJKPrefix(
  * Split a text run into layout-segment strings.
  * Each segment is an atomic unit for word-level fitting; CJK overflow is handled in layoutLines.
  */
+/** RTL primary language subtags (ISO 639) whose complex-script context makes
+ *  Word classify European digits as Arabic-Number (AN). */
+const RTL_PRIMARY_SUBTAGS = new Set([
+  'ar', // Arabic
+  'fa', // Persian
+  'ur', // Urdu
+  'he', 'iw', // Hebrew (iw = legacy code)
+  'yi', 'ji', // Yiddish
+  'ps', // Pashto
+  'sd', // Sindhi
+  'ug', // Uyghur
+  'dv', // Divehi
+  'syr', // Syriac
+  'ckb', // Central Kurdish (Sorani)
+]);
+
+/**
+ * Decide whether a `w:lang w:bidi` tag (§17.3.2.20) designates an RTL
+ * complex-script language, so the run's European digits are classified AN
+ * (Word's date ordering). The tag's primary subtag (before the first '-') is
+ * matched against {@link RTL_PRIMARY_SUBTAGS}. When the tag is absent OR a
+ * malformed/unknown value (e.g. the "ae-AR" seen in real-world files), fall
+ * back to whether the run is explicitly rtl-marked — `w:rtl` already asserts
+ * the run is complex-script RTL content.
+ */
+function isRtlBidiLang(langBidi: string | undefined, runIsRtl: boolean): boolean {
+  if (langBidi) {
+    const primary = langBidi.split('-')[0].toLowerCase();
+    if (RTL_PRIMARY_SUBTAGS.has(primary)) return true;
+  }
+  return runIsRtl;
+}
+
+/**
+ * ECMA-376 §17.3.2.26 (rFonts) content classification — does this code point
+ * belong to the COMPLEX-SCRIPT (`cs`) category? Word routes such characters to
+ * the run's complex-script formatting (`w:szCs` / `w:rFonts w:cs` / `w:bCs` /
+ * `w:iCs`) instead of the Latin (`ascii`/`hAnsi`) formatting. The ranges are
+ * the Unicode blocks Word treats as complex script: Hebrew, Arabic (incl.
+ * supplements / extended / presentation forms), Syriac, Thaana, NKo,
+ * Samaritan, Mandaic, and the Arabic-math / extended Plane-1 blocks. Latin,
+ * digits (EN), punctuation and CJK are NOT cs.
+ */
+function isComplexScriptCodePoint(cp: number): boolean {
+  return (
+    (cp >= 0x0590 && cp <= 0x05ff) || // Hebrew
+    (cp >= 0x0600 && cp <= 0x06ff) || // Arabic
+    (cp >= 0x0700 && cp <= 0x074f) || // Syriac
+    (cp >= 0x0750 && cp <= 0x077f) || // Arabic Supplement
+    (cp >= 0x0780 && cp <= 0x07bf) || // Thaana
+    (cp >= 0x07c0 && cp <= 0x07ff) || // NKo
+    (cp >= 0x0800 && cp <= 0x083f) || // Samaritan
+    (cp >= 0x0840 && cp <= 0x085f) || // Mandaic
+    (cp >= 0x0860 && cp <= 0x08ff) || // Syriac Supp. / Arabic Extended-A/B
+    (cp >= 0xfb1d && cp <= 0xfb4f) || // Hebrew presentation forms
+    (cp >= 0xfb50 && cp <= 0xfdff) || // Arabic Presentation Forms-A
+    (cp >= 0xfe70 && cp <= 0xfeff) || // Arabic Presentation Forms-B
+    (cp >= 0x10800 && cp <= 0x10fff) || // Plane-1 RTL blocks
+    (cp >= 0x1e800 && cp <= 0x1efff)    // Mende/Adlam/Arabic Math
+  );
+}
+
+/**
+ * Split `text` into maximal runs that are uniformly complex-script or not, per
+ * §17.3.2.26 per-character classification. Returns `[{text, cs}]` in logical
+ * order. Used only when a run has NO explicit `w:rtl`/`w:cs` (which would force
+ * the whole run to cs); otherwise the caller treats the entire piece as cs.
+ *
+ * Digits / spaces / punctuation (neutral, non-cs) attach to the PRECEDING slice
+ * so a number embedded in Arabic ("نص 12 نص") does not fragment the word into
+ * extra segments — Word keeps such weak/neutral characters with the script they
+ * border. A leading neutral run takes the first strong slice's class.
+ */
+function splitByComplexScript(text: string): { text: string; cs: boolean }[] {
+  const out: { text: string; cs: boolean }[] = [];
+  let curCs: boolean | null = null;
+  let buf = '';
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) as number;
+    // Neutral (non-letter) characters do not switch the active class; they ride
+    // with whatever script is currently open (or the next one if none yet).
+    const isLetter = /\p{L}/u.test(ch);
+    if (!isLetter) {
+      buf += ch;
+      continue;
+    }
+    const cs = isComplexScriptCodePoint(cp);
+    if (curCs === null) {
+      curCs = cs;
+      buf += ch;
+    } else if (cs === curCs) {
+      buf += ch;
+    } else {
+      out.push({ text: buf, cs: curCs });
+      curCs = cs;
+      buf = ch;
+    }
+  }
+  if (buf.length > 0) out.push({ text: buf, cs: curCs ?? false });
+  return out;
+}
+
+/**
+ * Split a token into maximal runs of European digits (U+0030–0039) versus
+ * everything else, so a date / number in an AN-classified Arabic run can be
+ * reordered group-by-group by the per-line bidi pass (which works at segment
+ * granularity). "28-02-2026" → ["28","-","02","-","2026"].
+ */
+function splitDigitGroups(text: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let bufDigit: boolean | null = null;
+  for (const ch of text) {
+    const c = ch.charCodeAt(0);
+    const isDigit = c >= 0x30 && c <= 0x39;
+    if (bufDigit === null || isDigit === bufDigit) {
+      buf += ch;
+    } else {
+      out.push(buf);
+      buf = ch;
+    }
+    bufDigit = isDigit;
+  }
+  if (buf.length > 0) out.push(buf);
+  return out.length ? out : [text];
+}
+
 function splitTextForLayout(text: string): string[] {
   const result: string[] = [];
   let i = 0;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1010,8 +1010,12 @@ function renderParagraph(
 
   const textAreaTopY = state.y;
 
-  const indLeft = para.indentLeft * scale;
-  const indRight = para.indentRight * scale;
+  // ECMA-376 §17.3.1.12 w:ind — the transitional left/right attributes are
+  // logical start/end (Part 4 §14.11.2). In a bidi paragraph the start side is
+  // the physical RIGHT, so the two indents swap physical sides here.
+  const baseRtl = para.bidi === true;
+  const indLeft = (baseRtl ? para.indentRight : para.indentLeft) * scale;
+  const indRight = (baseRtl ? para.indentLeft : para.indentRight) * scale;
   const indFirst = para.indentFirst * scale;
 
   // Numbering prefix (indent is already baked into para.indentLeft / para.indentFirst)
@@ -1107,8 +1111,8 @@ function renderParagraph(
   // (ECMA-376 §17.3.1.6). We engage the (exact) bidi pass only when the base is
   // RTL or the line actually contains strong-RTL characters, so pure-LTR
   // paragraphs keep their byte-identical fast path. `alignEdge` resolves
-  // logical start/end against the base direction.
-  const baseRtl = para.bidi === true;
+  // logical start/end against the base direction. (`baseRtl` is declared with
+  // the indent swap above.)
   const paraNeedsBidi = baseRtl || segmentsHaveRtl(segments);
   const alignEdge = resolveAlignEdge(para.alignment, baseRtl);
 
@@ -1141,27 +1145,11 @@ function renderParagraph(
     // Per-line X range (may be narrower than paraW when wrapping around floats).
     const lineLeft = paraX + line.xOffset;
     const lineAvailW = line.availWidth;
-    let x = firstLine ? lineLeft + indFirst : lineLeft;
-
-    if (firstLine && numPrefix && !dryRun) {
-      const numFontSize = getDefaultFontSize(para) * scale;
-      ctx.font = `${numFontSize}px sans-serif`;
-      ctx.fillStyle = defaultColor;
-      if (baseRtl) {
-        // RTL list: the marker hangs in the right gutter; its right edge mirrors
-        // the LTR position (firstLineX - numTab) about the line's right edge.
-        const prevAlign = ctx.textAlign;
-        const prevDir = ctx.direction;
-        ctx.textAlign = 'left';
-        ctx.direction = 'rtl';
-        const markerW = ctx.measureText(para.numbering!.text).width;
-        ctx.fillText(para.numbering!.text, lineLeft + lineAvailW + numTab - markerW, baseline);
-        ctx.textAlign = prevAlign;
-        ctx.direction = prevDir;
-      } else {
-        ctx.fillText(para.numbering!.text, x - numTab, baseline);
-      }
-    }
+    // First-line indent shifts the START edge: physical left for LTR; for RTL
+    // the start is the right edge, so it narrows/widens the line's available
+    // width instead of moving x (effAvailW below).
+    let x = firstLine && !baseRtl ? lineLeft + indFirst : lineLeft;
+    const effAvailW = baseRtl && firstLine ? lineAvailW - indFirst : lineAvailW;
 
     // Visual draw order. Under bidi we reorder the line's segments per UAX#9
     // (rule L2) and draw each with ctx.direction matching its resolved
@@ -1180,7 +1168,7 @@ function renderParagraph(
     const lastDrawnSi = visual ? visual.order[segCount - 1] : segCount - 1;
 
     const lineWidth = line.segments.reduce((s, seg) => s + seg.measuredWidth, 0);
-    const lineSlack = lineAvailW - (x - lineLeft) - lineWidth;
+    const lineSlack = effAvailW - (x - lineLeft) - lineWidth;
     const applyJustify = isJustified && (!isLastLine || stretchLastLine);
     let alignOffset = 0;
     if (alignEdge === 'right') {
@@ -1195,6 +1183,29 @@ function renderParagraph(
     }
     // 'left' and stretched 'justify' keep alignOffset 0.
     x += alignOffset;
+
+    if (firstLine && numPrefix && !dryRun) {
+      const numFontSize = getDefaultFontSize(para) * scale;
+      ctx.font = `${numFontSize}px sans-serif`;
+      ctx.fillStyle = defaultColor;
+      if (baseRtl) {
+        // The RTL list marker is laid out INLINE at the line's start (right)
+        // edge: its right edge sits numTab (w:hanging) to the right of the
+        // text's start edge, mirroring the LTR `firstLineX - numTab` anchor,
+        // and it follows the text through jc alignment (sample-8 PDF ground
+        // truth: marker right edge = aligned text right edge + hanging).
+        const prevAlign = ctx.textAlign;
+        const prevDir = ctx.direction;
+        ctx.textAlign = 'left';
+        ctx.direction = 'rtl';
+        const markerW = ctx.measureText(para.numbering!.text).width;
+        ctx.fillText(para.numbering!.text, x + lineWidth + numTab - markerW, baseline);
+        ctx.textAlign = prevAlign;
+        ctx.direction = prevDir;
+      } else {
+        ctx.fillText(para.numbering!.text, lineLeft + indFirst - numTab, baseline);
+      }
+    }
 
     // Inter-word adjustment per whitespace char on this line. Positive slack
     // (lineWidth < availW) expands spaces to fill; negative slack (lineWidth >
@@ -1213,7 +1224,7 @@ function renderParagraph(
         if (si === lastDrawnSi) continue;
         if ('text' in seg) totalTrailingSpaces += countTrailingSpaces((seg as LayoutTextSeg).text);
       }
-      const slack = lineAvailW - (x - lineLeft) - lineWidth;
+      const slack = effAvailW - (x - lineLeft) - lineWidth;
       if (totalTrailingSpaces > 0) {
         extraPerSpace = slack / totalTrailingSpaces;
         // Don't compress past zero-width spaces — limit compression to at most

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2888,6 +2888,39 @@ function buildFont(
   return `${s} ${w} ${sizePx}px ${f}`;
 }
 
+/** Arabic-script faces that hosts rarely ship; we substitute them with Noto
+ *  Naskh/Sans Arabic web fonts (see DOCX_GOOGLE_FONTS in document.ts — this
+ *  list MUST mirror the Arabic entries there). A run whose font is one of these
+ *  contains BOTH Arabic and Latin/digit glyphs that Word renders from the same
+ *  single face, so the fallback chain must keep both scripts stylistically
+ *  consistent (Arabic substitute first, serif Latin companion before the sans
+ *  generics) rather than letting Latin/digits leak to a CJK sans face. */
+const ARABIC_SUBSTITUTE_FONTS = new Set([
+  'sakkal majalla',
+  'traditional arabic',
+  'simplified arabic',
+  'arabic typesetting',
+  'univers next arabic',
+  'noto naskh arabic',
+  'noto sans arabic',
+]);
+
+/** Naskh-style traditional Arabic faces ship a serif Latin companion; the
+ *  geometric/modern ones pair with a sans Latin. Drives whether an Arabic-font
+ *  run's Latin+digits route to Noto Naskh Arabic (serif-like) or Noto Sans
+ *  Arabic, and which Latin serif/sans companion follows. */
+const NASKH_SERIF_ARABIC_FONTS = new Set([
+  'sakkal majalla',
+  'traditional arabic',
+  'simplified arabic',
+  'arabic typesetting',
+  'noto naskh arabic',
+]);
+
+function isArabicSubstituteFont(family: string): boolean {
+  return ARABIC_SUBSTITUTE_FONTS.has(family.toLowerCase());
+}
+
 /** Resolve a requested font-family name to a CSS font-family string with
  *  appropriate fallback chain.
  *
@@ -2902,7 +2935,7 @@ function buildFont(
  *     where fontTable says "auto"). Retained as a safety net for theme fonts
  *     and system fonts that OOXML docs do not list in fontTable.xml.
  */
-function normalizeFontFamily(
+export function normalizeFontFamily(
   family: string | null,
   fontFamilyClasses: Record<string, string> = {},
 ): string {
@@ -2911,6 +2944,33 @@ function normalizeFontFamily(
   const escape = (s: string) => s.replace(/"/g, '\\"');
   const head = `"${escape(family)}"`;
   const lower = family.toLowerCase();
+
+  // 0) Arabic-script faces substituted by Noto Naskh/Sans Arabic. A single
+  //    Sakkal Majalla / Traditional Arabic run carries Arabic glyphs AND
+  //    Latin letters/digits; Word draws both from that one face. The browser
+  //    resolves each glyph against the chain in order, so the Arabic substitute
+  //    MUST come first — otherwise the Latin/digit glyphs are grabbed by the
+  //    first chain member that has them (e.g. the CJK "Noto Sans JP"), and
+  //    Latin/digits render in a different, sans face than the Arabic. Keeping
+  //    the Arabic substitute first makes Arabic+Latin+digits all resolve from
+  //    one family, matching Word's single-face rendering.
+  //
+  //    Latin companion: traditional Naskh faces (Sakkal Majalla, Traditional
+  //    Arabic, …) ship a SERIF Latin companion — Word's PDF export of sample-7
+  //    renders the Latin "first leader name" with bracketed serifs and the
+  //    "2026" digits as serif figures. Noto Naskh Arabic, our substitute, also
+  //    ships a serif Latin face (verified: its Latin glyphs carry bracketed
+  //    serifs and closely match the PDF), so placing it first gives Latin+digits
+  //    a serif look consistent with the Arabic — matching Word. "Noto Serif" is
+  //    kept as a serif safety net for the rare case Noto Naskh Arabic is
+  //    unavailable, so Latin still falls to a serif rather than the CJK sans.
+  //    Geometric Arabic faces (Univers Next Arabic) pair with a sans Latin.
+  if (isArabicSubstituteFont(family)) {
+    if (NASKH_SERIF_ARABIC_FONTS.has(lower)) {
+      return `${head}, "Noto Naskh Arabic", "Noto Sans Arabic", "Noto Serif", "Noto Sans JP", "Hiragino Sans", serif`;
+    }
+    return `${head}, "Noto Sans Arabic", "Noto Naskh Arabic", "Noto Sans JP", "Hiragino Sans", sans-serif`;
+  }
 
   // 1) Authoritative classification from word/fontTable.xml §17.8.3.10.
   const tableClass = fontFamilyClasses[family];

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2541,6 +2541,16 @@ function renderTable(table: DocTable, state: RenderState): void {
     }
   }
 
+  // ECMA-376 §17.4.1 `<w:bidiVisual>`: lay the grid columns right-to-left, so
+  // logical column 0 sits at the table's RIGHT edge and indices advance
+  // leftward. We mirror by POSITION arithmetic (not canvas transform): a cell
+  // spanning [ci, ci+span) gets physical left x = tableX + tableW − (offset of
+  // its right grid edge). Cell borders are mirrored too — a cell's logical
+  // left/right border specs swap physical sides (its "start" edge is on the
+  // right). gridSpan still consumes the same logical columns; only the mapping
+  // from logical column offset to a physical x flips.
+  const mirror = table.bidiVisual === true;
+
   let y = state.y;
   for (let ri = 0; ri < table.rows.length; ri++) {
     const row = table.rows[ri];
@@ -2551,6 +2561,11 @@ function renderTable(table: DocTable, state: RenderState): void {
     for (const cell of row.cells) {
       const span = Math.min(cell.colSpan, colWidths.length - ci);
       const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
+      // Physical left edge of this cell. LTR: cumulative from the left (`x`).
+      // bidiVisual: place so logical column 0 is rightmost — the cell's left
+      // edge is the table's right edge minus the offset of its trailing grid
+      // line (sum of widths up to and including this span).
+      const leadX = mirror ? tableX + tableW - (x - tableX) - cellW : x;
 
       if (cell.vMerge === false) {
         // continue cell — content is rendered by its restart partner.
@@ -2563,7 +2578,7 @@ function renderTable(table: DocTable, state: RenderState): void {
           drawH = 0;
           for (let rj = ri; rj <= endRi; rj++) drawH += rowHeights[rj];
         }
-        if (!dryRun) renderCell(cell, table, x, y, cellW, drawH, state);
+        if (!dryRun) renderCell(cell, table, leadX, y, cellW, drawH, state, mirror);
         else measureCellContent(cell, table, cellW, scale, state);
       }
 
@@ -2727,6 +2742,7 @@ function renderCell(
   w: number,
   h: number,
   state: RenderState,
+  mirror = false,
 ): void {
   const { ctx, scale } = state;
 
@@ -2735,7 +2751,7 @@ function renderCell(
     ctx.fillRect(x, y, w, h);
   }
 
-  drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale);
+  drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale, mirror);
 
   const cm = effCellMargins(cell, table);
   const mt = cm.top * scale;
@@ -2820,11 +2836,15 @@ function drawCellBorders(
   cell: CellBorders,
   table: TableBorders,
   scale: number,
+  mirror = false,
 ): void {
   const top = cell.top ?? table.top;
   const bottom = cell.bottom ?? table.bottom;
-  const left = cell.left ?? table.left;
-  const right = cell.right ?? table.right;
+  // ECMA-376 §17.4.1: under bidiVisual the columns are visually reversed, so a
+  // cell's logical left (start) border is drawn on its physical right edge and
+  // vice versa. Borders are owned by the cell, so swap which spec each side uses.
+  const left = mirror ? (cell.right ?? table.right) : (cell.left ?? table.left);
+  const right = mirror ? (cell.left ?? table.left) : (cell.right ?? table.right);
 
   if (top && top.style !== 'none') drawBorderLine(ctx, x, y, x + w, y, top, scale);
   if (bottom && bottom.style !== 'none') drawBorderLine(ctx, x, y + h, x + w, y + h, bottom, scale);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2906,7 +2906,7 @@ function normalizeFontFamily(
   family: string | null,
   fontFamilyClasses: Record<string, string> = {},
 ): string {
-  if (!family) return '"Noto Sans JP", "Hiragino Sans", "Meiryo", sans-serif';
+  if (!family) return '"Noto Sans JP", "Hiragino Sans", "Meiryo", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif';
 
   const escape = (s: string) => s.replace(/"/g, '\\"');
   const head = `"${escape(family)}"`;
@@ -2917,9 +2917,9 @@ function normalizeFontFamily(
   if (tableClass && tableClass !== 'auto') {
     switch (tableClass) {
       case 'roman':
-        return `${head}, "Yu Mincho", "YuMincho", "Hiragino Mincho ProN", "MS Mincho", "Noto Serif JP", "Noto Serif", serif`;
+        return `${head}, "Yu Mincho", "YuMincho", "Hiragino Mincho ProN", "MS Mincho", "Noto Serif JP", "Noto Serif", "Noto Naskh Arabic", "Noto Sans Arabic", serif`;
       case 'swiss':
-        return `${head}, "Noto Sans JP", "Hiragino Sans", "Meiryo", sans-serif`;
+        return `${head}, "Noto Sans JP", "Hiragino Sans", "Meiryo", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif`;
       case 'modern':
         return `${head}, "Courier New", monospace`;
       default:
@@ -2951,22 +2951,22 @@ function normalizeFontFamily(
     family.includes('Noto Serif');
 
   if (isSerif) {
-    return `${head}, "Yu Mincho", "YuMincho", "Hiragino Mincho ProN", "MS Mincho", "Noto Serif JP", "Noto Serif", serif`;
+    return `${head}, "Yu Mincho", "YuMincho", "Hiragino Mincho ProN", "MS Mincho", "Noto Serif JP", "Noto Serif", "Noto Naskh Arabic", "Noto Sans Arabic", serif`;
   }
 
   if (lower.includes('meiryo') || family.includes('メイリオ')) {
-    return `${head}, "Meiryo UI", "Meiryo", "Noto Sans JP", "Hiragino Sans", sans-serif`;
+    return `${head}, "Meiryo UI", "Meiryo", "Noto Sans JP", "Hiragino Sans", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif`;
   }
   if (family.includes('游ゴシック') || /\byu\s*gothic\b/i.test(family) || lower.includes('yugothic')) {
-    return `${head}, "Yu Gothic", "YuGothic", "Noto Sans JP", "Hiragino Sans", sans-serif`;
+    return `${head}, "Yu Gothic", "YuGothic", "Noto Sans JP", "Hiragino Sans", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif`;
   }
   if (lower.includes('ipa')) {
-    return `${head}, "IPAexGothic", "Noto Sans JP", "Hiragino Sans", sans-serif`;
+    return `${head}, "IPAexGothic", "Noto Sans JP", "Hiragino Sans", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif`;
   }
   if (lower.includes('segoe')) {
-    return `${head}, "Segoe UI", sans-serif`;
+    return `${head}, "Segoe UI", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif`;
   }
-  return `${head}, "Noto Sans JP", "Hiragino Sans", "Meiryo", sans-serif`;
+  return `${head}, "Noto Sans JP", "Hiragino Sans", "Meiryo", "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif`;
 }
 
 function getDefaultFontSize(para: DocParagraph): number {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -11,6 +11,7 @@ import {
   mathToMathML,
   recolorSvg,
   PT_TO_PX,
+  resolveBaseDirection,
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import { intendedSingleLinePx } from './font-metrics.js';
@@ -2378,11 +2379,19 @@ function renderShapeText(
     const fontPx = block.fontSizePt * scale;
     ctx.font = buildFont(block.bold ?? false, block.italic ?? false, fontPx, block.fontFamily ?? null, fontFamilyClasses);
     ctx.fillStyle = block.color ? `#${block.color}` : '#000000';
+    // The whole block is drawn in one fillText, so Canvas applies UAX#9 over
+    // the full string; we only set the base direction (for neutral resolution)
+    // and resolve alignment. No explicit shape-paragraph rtl flag exists, so
+    // derive the base direction from the content (first-strong).
+    const baseRtl = resolveBaseDirection(undefined, block.text) === 'rtl';
+    const edge = resolveAlignEdge(block.alignment, baseRtl);
+    ctx.textAlign = 'left';
+    ctx.direction = baseRtl ? 'rtl' : 'ltr';
     const m = ctx.measureText(block.text);
     let tx = innerX;
-    if (block.alignment === 'center' || block.alignment === 'distribute') {
+    if (edge === 'center') {
       tx = innerX + Math.max(0, (innerW - m.width) / 2);
-    } else if (block.alignment === 'right' || block.alignment === 'end') {
+    } else if (edge === 'right') {
       tx = innerX + Math.max(0, innerW - m.width);
     }
     // Baseline = cursorY + ascent (approx 0.85 of font size for default fonts).
@@ -2390,6 +2399,7 @@ function renderShapeText(
     ctx.fillText(block.text, tx, baseline);
     cursorY += lineHeights[i];
   }
+  ctx.direction = 'ltr'; // reset for subsequent draws
 }
 
 function isWrapFloat(mode?: string): boolean {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1163,15 +1163,37 @@ function renderParagraph(
       }
     }
 
+    // Visual draw order. Under bidi we reorder the line's segments per UAX#9
+    // (rule L2) and draw each with ctx.direction matching its resolved
+    // direction; ctx.textAlign stays physical 'left' so x is always the
+    // segment's left edge. The LTR fast path is untouched (visual === null).
+    // Computed before justification so the stretch bookkeeping below can use
+    // the same (visual) domain as the draw loop.
+    const visual: LineVisualOrder | null = paraNeedsBidi
+      ? computeLineVisualOrder(line.segments, baseRtl)
+      : null;
+    if (paraNeedsBidi) ctx.textAlign = 'left';
+    const segCount = line.segments.length;
+    // The segment whose trailing spaces sit at the line's PHYSICAL end (no
+    // stretch there): the visually-last segment. Equals the logical last in
+    // the LTR fast path.
+    const lastDrawnSi = visual ? visual.order[segCount - 1] : segCount - 1;
+
     const lineWidth = line.segments.reduce((s, seg) => s + seg.measuredWidth, 0);
     const lineSlack = lineAvailW - (x - lineLeft) - lineWidth;
+    const applyJustify = isJustified && (!isLastLine || stretchLastLine);
     let alignOffset = 0;
     if (alignEdge === 'right') {
       alignOffset = lineSlack;
     } else if (alignEdge === 'center') {
       alignOffset = lineSlack / 2;
+    } else if (alignEdge === 'justify' && baseRtl && !applyJustify) {
+      // The unstretched (last) line of a justified RTL paragraph aligns to the
+      // leading edge — the RIGHT margin (§17.18.44 `both`: last line is
+      // start-aligned). LTR keeps alignOffset 0 as before.
+      alignOffset = lineSlack;
     }
-    // 'left' and 'justify' keep alignOffset 0 (justify expands inter-word space).
+    // 'left' and stretched 'justify' keep alignOffset 0.
     x += alignOffset;
 
     // Inter-word adjustment per whitespace char on this line. Positive slack
@@ -1182,12 +1204,13 @@ function renderParagraph(
     // space, and is only applied when the line is a candidate for justification
     // (jc=both/distribute, not the last line unless distribute).
     let extraPerSpace = 0;
-    const applyJustify = isJustified && (!isLastLine || stretchLastLine);
     if (applyJustify) {
       let totalTrailingSpaces = 0;
-      for (let si = 0; si < line.segments.length; si++) {
+      for (let si = 0; si < segCount; si++) {
         const seg = line.segments[si];
-        if (si === line.segments.length - 1) break; // trailing spaces on final seg don't stretch
+        // Trailing spaces on the visually-final segment don't stretch (they sit
+        // at the physical line end) — same domain as the draw-loop skip below.
+        if (si === lastDrawnSi) continue;
         if ('text' in seg) totalTrailingSpaces += countTrailingSpaces((seg as LayoutTextSeg).text);
       }
       const slack = lineAvailW - (x - lineLeft) - lineWidth;
@@ -1200,15 +1223,6 @@ function renderParagraph(
       }
     }
 
-    // Visual draw order. Under bidi we reorder the line's segments per UAX#9
-    // (rule L2) and draw each with ctx.direction matching its resolved
-    // direction; ctx.textAlign stays physical 'left' so x is always the
-    // segment's left edge. The LTR fast path is untouched (visual === null).
-    const visual: LineVisualOrder | null = paraNeedsBidi
-      ? computeLineVisualOrder(line.segments, baseRtl)
-      : null;
-    if (paraNeedsBidi) ctx.textAlign = 'left';
-    const segCount = line.segments.length;
     for (let vi = 0; vi < segCount; vi++) {
       const si = visual ? visual.order[vi] : vi;
       const seg = line.segments[si];
@@ -2384,7 +2398,12 @@ function renderShapeText(
     // and resolve alignment. No explicit shape-paragraph rtl flag exists, so
     // derive the base direction from the content (first-strong).
     const baseRtl = resolveBaseDirection(undefined, block.text) === 'rtl';
-    const edge = resolveAlignEdge(block.alignment, baseRtl);
+    // Shape text draws one line per block with no inter-word stretching, so
+    // 'distribute' keeps its pre-bidi approximation (centered) rather than the
+    // justify edge resolveAlignEdge reports for paragraphs.
+    const edge = block.alignment === 'distribute'
+      ? 'center'
+      : resolveAlignEdge(block.alignment, baseRtl);
     ctx.textAlign = 'left';
     ctx.direction = baseRtl ? 'rtl' : 'ltr';
     const m = ctx.measureText(block.text);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -14,6 +14,12 @@ import {
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import { intendedSingleLinePx } from './font-metrics.js';
+import {
+  segmentsHaveRtl,
+  computeLineVisualOrder,
+  resolveAlignEdge,
+  type LineVisualOrder,
+} from './bidi-line.js';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -1096,6 +1102,15 @@ function renderParagraph(
     return c;
   };
 
+  // Bidirectional text. The paragraph's base direction comes from w:bidi
+  // (ECMA-376 §17.3.1.6). We engage the (exact) bidi pass only when the base is
+  // RTL or the line actually contains strong-RTL characters, so pure-LTR
+  // paragraphs keep their byte-identical fast path. `alignEdge` resolves
+  // logical start/end against the base direction.
+  const baseRtl = para.bidi === true;
+  const paraNeedsBidi = baseRtl || segmentsHaveRtl(segments);
+  const alignEdge = resolveAlignEdge(para.alignment, baseRtl);
+
   // Slice bounds — when the paginator split this paragraph across pages,
   // only render lines in [sliceStart, sliceEnd). The first line we paint
   // resets state.y baseline so the slice begins at the page's content top.
@@ -1131,16 +1146,31 @@ function renderParagraph(
       const numFontSize = getDefaultFontSize(para) * scale;
       ctx.font = `${numFontSize}px sans-serif`;
       ctx.fillStyle = defaultColor;
-      ctx.fillText(para.numbering!.text, x - numTab, baseline);
+      if (baseRtl) {
+        // RTL list: the marker hangs in the right gutter; its right edge mirrors
+        // the LTR position (firstLineX - numTab) about the line's right edge.
+        const prevAlign = ctx.textAlign;
+        const prevDir = ctx.direction;
+        ctx.textAlign = 'left';
+        ctx.direction = 'rtl';
+        const markerW = ctx.measureText(para.numbering!.text).width;
+        ctx.fillText(para.numbering!.text, lineLeft + lineAvailW + numTab - markerW, baseline);
+        ctx.textAlign = prevAlign;
+        ctx.direction = prevDir;
+      } else {
+        ctx.fillText(para.numbering!.text, x - numTab, baseline);
+      }
     }
 
     const lineWidth = line.segments.reduce((s, seg) => s + seg.measuredWidth, 0);
+    const lineSlack = lineAvailW - (x - lineLeft) - lineWidth;
     let alignOffset = 0;
-    if (para.alignment === 'right' || para.alignment === 'end') {
-      alignOffset = lineAvailW - (x - lineLeft) - lineWidth;
-    } else if (para.alignment === 'center') {
-      alignOffset = (lineAvailW - (x - lineLeft) - lineWidth) / 2;
+    if (alignEdge === 'right') {
+      alignOffset = lineSlack;
+    } else if (alignEdge === 'center') {
+      alignOffset = lineSlack / 2;
     }
+    // 'left' and 'justify' keep alignOffset 0 (justify expands inter-word space).
     x += alignOffset;
 
     // Inter-word adjustment per whitespace char on this line. Positive slack
@@ -1169,9 +1199,20 @@ function renderParagraph(
       }
     }
 
-    for (let si = 0; si < line.segments.length; si++) {
+    // Visual draw order. Under bidi we reorder the line's segments per UAX#9
+    // (rule L2) and draw each with ctx.direction matching its resolved
+    // direction; ctx.textAlign stays physical 'left' so x is always the
+    // segment's left edge. The LTR fast path is untouched (visual === null).
+    const visual: LineVisualOrder | null = paraNeedsBidi
+      ? computeLineVisualOrder(line.segments, baseRtl)
+      : null;
+    if (paraNeedsBidi) ctx.textAlign = 'left';
+    const segCount = line.segments.length;
+    for (let vi = 0; vi < segCount; vi++) {
+      const si = visual ? visual.order[vi] : vi;
       const seg = line.segments[si];
-      const isLastSeg = si === line.segments.length - 1;
+      const isLastSeg = vi === segCount - 1;
+      if (visual) ctx.direction = visual.rtl[si] ? 'rtl' : 'ltr';
       if ('isTab' in seg) {
         // Tabs render as blank space, optionally filled with a leader (TOC dots etc.).
         if (!dryRun && seg.leader && seg.leader !== 'none' && seg.measuredWidth > 1) {
@@ -1292,6 +1333,7 @@ function renderParagraph(
         if (trailing > 0) x += trailing * extraPerSpace;
       }
     }
+    if (paraNeedsBidi) ctx.direction = 'ltr'; // reset for subsequent draws
 
     state.y += lineH;
   }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1391,6 +1391,10 @@ interface LayoutTextSeg {
   ruby?: { text: string; fontSizePt: number };
   /** Track-changes revision attached to this run (insertion / deletion). */
   revision?: { kind: 'insertion' | 'deletion' | string; author?: string };
+  /** ECMA-376 §17.3.2.30 `<w:rtl>` — run carries right-to-left characteristics.
+   *  When true the segment's text is treated as a strong-RTL embedding in the
+   *  per-line bidi pass (so leading digits / neutrals resolve RTL). */
+  rtl?: boolean;
 }
 
 /**
@@ -1488,6 +1492,7 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
       ? { text: baseRuby.text, fontSizePt: baseRuby.fontSizePt }
       : undefined;
     const revision = (base as DocxTextRun).revision;
+    const rtl = (base as DocxTextRun).rtl === true ? true : undefined;
     let firstSeg = true;
     for (const word of splitTextForLayout(displayText)) {
       segs.push({
@@ -1506,6 +1511,7 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         highlight: base.highlight ?? null,
         ruby: firstSeg ? ruby : undefined,
         revision,
+        rtl,
       });
       firstSeg = false;
     }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -14,7 +14,7 @@ import {
   resolveBaseDirection,
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
-import { intendedSingleLinePx } from './font-metrics.js';
+import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import {
   segmentsHaveRtl,
   computeLineVisualOrder,
@@ -2134,8 +2134,15 @@ function layoutLines(
     const h = s.fontSize;
     // Prefer font-metric ascent/descent (stable per font+size) so baselines and
     // line boxes do not jitter based on the specific characters on each line.
-    let asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? s.fontSize * scale * 0.8;
-    const desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? s.fontSize * scale * 0.2;
+    // When the document font is substituted by one with different vertical
+    // metrics, rescale to the document font's design line box so the line
+    // height (and thus baseline centering, row auto-heights, cell vAlign
+    // §17.4.84, and pagination) match Word — see font-metrics.ts.
+    const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? s.fontSize * scale * 0.8;
+    const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? s.fontSize * scale * 0.2;
+    const corrected = correctLineMetrics(s.fontFamily, effectiveFontPx(s), rawAsc, rawDesc);
+    let asc = corrected.ascent;
+    const desc = corrected.descent;
     // Ruby annotation: small text rendered above the base. Reserve ascent
     // room for the rt glyphs (ECMA-376 §17.3.3.25). The actual line spacing
     // in docGrid sections is set further down by the paragraph-wide
@@ -2765,7 +2772,13 @@ function renderTable(table: DocTable, state: RenderState): void {
           drawH = 0;
           for (let rj = ri; rj <= endRi; rj++) drawH += rowHeights[rj];
         }
-        if (!dryRun) renderCell(cell, table, leadX, y, cellW, drawH, state, mirror);
+        // ECMA-376 §17.4.81: an exact row height is honored verbatim and
+        // content taller than the row is clipped to the row box (Word clips;
+        // we would otherwise overflow into neighboring rows). A vMerge=restart
+        // cell spans multiple rows, so it is never governed by a single row's
+        // exact height — only single-row cells clip.
+        const clipExact = row.rowHeightRule === 'exact' && cell.vMerge !== true;
+        if (!dryRun) renderCell(cell, table, leadX, y, cellW, drawH, state, mirror, clipExact);
         else measureCellContent(cell, table, cellW, scale, state);
       }
 
@@ -2930,6 +2943,7 @@ function renderCell(
   h: number,
   state: RenderState,
   mirror = false,
+  clipExact = false,
 ): void {
   const { ctx, scale } = state;
 
@@ -2969,13 +2983,39 @@ function renderCell(
     // rendering of resume "bar chart" cells. Skip a single trailing empty
     // paragraph after a non-paragraph block.
     const visibleContent = trimTrailingStructuralMarker(cell.content);
-    const contentH = visibleContent.reduce(
+    let contentH = visibleContent.reduce(
       (s, ce) => s + measureCellElementHeight(cellState, ce, w - ml - mr, scale), 0);
+    // Word collapses the LAST paragraph's space-after against the cell's bottom
+    // content boundary when vertically aligning. That trailing spacing produces
+    // no ink (nothing follows it inside the cell), so including it in the
+    // centered block height lifts the visible text above true center. Word
+    // centers the line box alone: a header cell whose paragraph carries an 8 pt
+    // space-after still centers the ~16.8 pt line box, not 24.8 pt. This mirrors
+    // how block space-after collapses at a container edge (ECMA-376 §17.3.1.33
+    // describes spacing between paragraphs, not at the frame boundary). The
+    // render path already adds this space-after after the final line where it
+    // has no visual effect, so trimming it here only fixes the measurement.
+    // Spacing BETWEEN two paragraphs inside the cell is left intact.
+    const lastEl = visibleContent[visibleContent.length - 1];
+    if (lastEl && lastEl.type === 'paragraph') {
+      contentH -= (lastEl as unknown as DocParagraph).spaceAfter * scale;
+    }
     if (cell.vAlign === 'center') cellState.y = y + (h - contentH) / 2;
     else cellState.y = y + h - contentH - mb;
   }
 
-  renderCellContent(cell.content, cellState);
+  if (clipExact) {
+    // ECMA-376 §17.4.81: clip content to the exact row box so taller content
+    // does not bleed into adjacent rows (Word's behavior for hRule="exact").
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(x, y, w, h);
+    ctx.clip();
+    renderCellContent(cell.content, cellState);
+    ctx.restore();
+  } else {
+    renderCellContent(cell.content, cellState);
+  }
 }
 
 /** Drop a trailing empty paragraph that follows a non-paragraph block (nested

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -354,6 +354,13 @@ export interface DocxTextRun {
   /** ECMA-376 §17.3.2.18 `<w:szCs>` — complex-script font size in pt
    *  (same units as `fontSize`). */
   fontSizeCs?: number;
+  /** ECMA-376 §17.3.2.3 `<w:bCs>` — complex-script bold toggle. */
+  boldCs?: boolean;
+  /** ECMA-376 §17.3.2.17 `<w:iCs>` — complex-script italic toggle. */
+  italicCs?: boolean;
+  /** ECMA-376 §17.3.2.20 `<w:lang w:bidi>` — complex-script (RTL) language tag,
+   *  lower-cased (e.g. "ar-sa", "ae-ar"). Drives Word's AN digit ordering. */
+  langBidi?: string;
 }
 
 export interface RunRevision {

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -628,6 +628,10 @@ struct TableElement {
     /// Column widths in EMU
     cols: Vec<i64>,
     rows: Vec<TableRow>,
+    /// `<a:tblPr rtl="1">` (ECMA-376 §21.1.3.13): right-to-left table —
+    /// column 0 renders at the right edge. Skipped when false/absent.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    rtl: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -4946,6 +4950,8 @@ fn parse_table(
     };
     let first_row = flag("firstRow");
     let last_row  = flag("lastRow");
+    // ECMA-376 §21.1.3.13 (a:tblPr@rtl): right-to-left table layout.
+    let rtl = flag("rtl");
     let band_row  = flag("bandRow");
     let first_col = flag("firstCol");
     let last_col  = flag("lastCol");
@@ -5128,7 +5134,7 @@ fn parse_table(
 
     Some(TableElement {
         x: t.x, y: t.y, width: t.cx, height: t.cy,
-        cols, rows,
+        cols, rows, rtl,
     })
 }
 
@@ -6824,5 +6830,59 @@ mod tests {
         // rtlCol="1" appears under the camelCase key "rtlCol".
         let json_true = serde_json::to_string(&tb).unwrap();
         assert!(json_true.contains("\"rtlCol\":true"), "expected rtlCol:true in JSON; got {json_true}");
+    }
+
+    /// ECMA-376 §21.1.3.13 (`a:tblPr@rtl`): a right-to-left table sets `rtl=true`
+    /// so the renderer can place column 0 at the right edge. Absent/false must be
+    /// omitted from the serialized JSON (TableElement.rtl is optional in TS).
+    #[test]
+    fn table_rtl_attribute_parses() {
+        // An empty in-memory zip is enough: parse_table only reads
+        // ppt/tableStyles.xml (absent → no style cascade) and the tbl node.
+        fn empty_zip() -> Vec<u8> {
+            let mut buf = Vec::new();
+            {
+                let cursor = Cursor::new(&mut buf);
+                let writer = zip::ZipWriter::new(cursor);
+                writer.finish().unwrap();
+            }
+            buf
+        }
+
+        fn parse_tbl(tbl_xml: &str) -> TableElement {
+            let xml = format!(
+                r#"<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">{tbl_xml}</root>"#
+            );
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let tbl = doc.root_element()
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "tbl")
+                .unwrap();
+            let t = Transform { x: 0, y: 0, cx: 100, cy: 100, rot: 0.0, flip_h: false, flip_v: false };
+            let theme: HashMap<String, String> = HashMap::new();
+            let rels: HashMap<String, String> = HashMap::new();
+            let bytes = empty_zip();
+            let cursor = Cursor::new(bytes.as_slice());
+            let mut zip = zip::ZipArchive::new(cursor).unwrap();
+            parse_table(tbl, &t, &theme, &rels, &mut zip).unwrap()
+        }
+
+        // rtl="1" → rtl=true, serialized.
+        let t_rtl = parse_tbl(
+            r#"<a:tbl><a:tblPr rtl="1"/><a:tblGrid><a:gridCol w="100"/></a:tblGrid>
+               <a:tr h="0"><a:tc><a:txBody/></a:tc></a:tr></a:tbl>"#,
+        );
+        assert!(t_rtl.rtl, "rtl=\"1\" should yield rtl=true");
+        let json = serde_json::to_string(&t_rtl).unwrap();
+        assert!(json.contains("\"rtl\":true"), "expected rtl:true in JSON; got {json}");
+
+        // Absent tblPr@rtl → false, omitted from JSON.
+        let t_ltr = parse_tbl(
+            r#"<a:tbl><a:tblPr/><a:tblGrid><a:gridCol w="100"/></a:tblGrid>
+               <a:tr h="0"><a:tc><a:txBody/></a:tc></a:tr></a:tbl>"#,
+        );
+        assert!(!t_ltr.rtl, "absent rtl should yield rtl=false");
+        let json_ltr = serde_json::to_string(&t_ltr).unwrap();
+        assert!(!json_ltr.contains("\"rtl\""), "rtl=false must be omitted; got {json_ltr}");
     }
 }

--- a/packages/pptx/src/bidi-line.test.ts
+++ b/packages/pptx/src/bidi-line.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { segmentsHaveRtl, computeLineVisualOrder, resolveAlignEdge } from './bidi-line.js';
+import { segmentsHaveRtl, computeLineVisualOrder } from './bidi-line.js';
 
 describe('segmentsHaveRtl', () => {
   it('detects Arabic/Hebrew, ignores Latin and objects', () => {
@@ -7,20 +7,6 @@ describe('segmentsHaveRtl', () => {
     expect(segmentsHaveRtl([{ text: 'price 99' }, {}])).toBe(false); // object seg has no text
     expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
     expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
-  });
-});
-
-describe('resolveAlignEdge', () => {
-  it('resolves logical start/end against base direction', () => {
-    expect(resolveAlignEdge(undefined, false)).toBe('left');
-    expect(resolveAlignEdge(undefined, true)).toBe('right');
-    expect(resolveAlignEdge('start', true)).toBe('right');
-    expect(resolveAlignEdge('end', true)).toBe('left');
-    expect(resolveAlignEdge('end', false)).toBe('right');
-    expect(resolveAlignEdge('center', true)).toBe('center');
-    expect(resolveAlignEdge('both', true)).toBe('justify');
-    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
-    expect(resolveAlignEdge('right', true)).toBe('right');
   });
 });
 

--- a/packages/pptx/src/bidi-line.test.ts
+++ b/packages/pptx/src/bidi-line.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { segmentsHaveRtl, computeLineVisualOrder, resolveAlignEdge } from './bidi-line.js';
+
+describe('segmentsHaveRtl', () => {
+  it('detects Arabic/Hebrew, ignores Latin and objects', () => {
+    expect(segmentsHaveRtl([{ text: 'Hello world' }])).toBe(false);
+    expect(segmentsHaveRtl([{ text: 'price 99' }, {}])).toBe(false); // object seg has no text
+    expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
+    expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
+  });
+});
+
+describe('resolveAlignEdge', () => {
+  it('resolves logical start/end against base direction', () => {
+    expect(resolveAlignEdge(undefined, false)).toBe('left');
+    expect(resolveAlignEdge(undefined, true)).toBe('right');
+    expect(resolveAlignEdge('start', true)).toBe('right');
+    expect(resolveAlignEdge('end', true)).toBe('left');
+    expect(resolveAlignEdge('end', false)).toBe('right');
+    expect(resolveAlignEdge('center', true)).toBe('center');
+    expect(resolveAlignEdge('both', true)).toBe('justify');
+    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
+    expect(resolveAlignEdge('right', true)).toBe('right');
+  });
+});
+
+describe('computeLineVisualOrder', () => {
+  it('keeps pure-LTR segments in logical order', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'Hello ' }, { text: 'world' }], false);
+    expect(order).toEqual([0, 1]);
+    expect(rtl).toEqual([false, false]);
+  });
+
+  it('reverses pure-RTL segments and marks them RTL', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'שלום ' }, { text: 'עולם' }], true);
+    expect(order).toEqual([1, 0]); // last word is visually leftmost
+    expect(rtl).toEqual([true, true]);
+  });
+
+  it('orders an embedded LTR run inside an RTL line', () => {
+    // logical: Hebrew, Latin, Hebrew (base RTL) -> visual L→R: [2,1,0]
+    const { order, rtl } = computeLineVisualOrder(
+      [{ text: 'שלום ' }, { text: 'world ' }, { text: 'טוב' }],
+      true,
+    );
+    expect(order).toEqual([2, 1, 0]);
+    expect(rtl[1]).toBe(false); // the Latin segment is LTR
+    expect(rtl[0]).toBe(true);
+    expect(rtl[2]).toBe(true);
+  });
+
+  it('places a neutral object by surrounding direction', () => {
+    // object between two Hebrew words, base RTL -> object stays in RTL flow
+    const { order } = computeLineVisualOrder([{ text: 'שלום ' }, {}, { text: 'טוב' }], true);
+    expect(order).toEqual([2, 1, 0]);
+  });
+});

--- a/packages/pptx/src/bidi-line.ts
+++ b/packages/pptx/src/bidi-line.ts
@@ -14,7 +14,10 @@ import { getDefaultBidiEngine } from '@silurus/ooxml-core';
 /** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
  *  Arabic presentation forms. Used only as a cheap gate to decide whether a
  *  line needs the (exact) bidi pass at all — never for ordering itself. */
-const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+const RTL_GATE =
+  // strong-RTL blocks incl. presentation forms, Plane-1 RTL blocks, and
+  // RTL-implicating controls (RLM/RLE/RLO/RLI).
+  /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF\u200F\u202B\u202E\u2067]|[\u{10800}-\u{10FFF}\u{1E800}-\u{1EFFF}]/u;
 
 /** A laid-out segment as seen here: only its optional text matters for bidi.
  *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
@@ -46,9 +49,12 @@ const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON
  * Compute the visual draw order of a line's segments under `baseRtl`. Text
  * segments contribute their text; non-text segments contribute one neutral
  * placeholder so they take the surrounding direction. Each segment is assigned
- * the embedding level of its first code unit (segments are single-script in
- * practice because they are space-split); Canvas resolves any residual
- * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
+ * the embedding level of its first code unit. pptx segments are style-merged
+ * (not word-split), so a single-style segment CAN span a direction boundary;
+ * its internal order is still resolved correctly by Canvas (whole segment in
+ * one fillText with the matching `ctx.direction`), while its position among
+ * neighbours uses the first-unit level — a documented approximation, exact
+ * splitting at level boundaries is tracked as a follow-up.
  */
 export function computeLineVisualOrder(
   segments: readonly unknown[],
@@ -81,31 +87,3 @@ export function computeLineVisualOrder(
   return { order, rtl };
 }
 
-/** Physical edge a line aligns to, resolving logical start/end against base direction. */
-export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
-
-/**
- * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
- * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
- * an unset alignment defaults to the leading (logical-start) edge.
- */
-export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
-  switch (alignment) {
-    case 'center':
-      return 'center';
-    case 'both':
-    case 'justify':
-    case 'distribute':
-      return 'justify';
-    case 'left':
-      return 'left';
-    case 'right':
-      return 'right';
-    case 'end':
-      return baseRtl ? 'left' : 'right';
-    case 'start':
-    case undefined:
-    default:
-      return baseRtl ? 'right' : 'left';
-  }
-}

--- a/packages/pptx/src/bidi-line.ts
+++ b/packages/pptx/src/bidi-line.ts
@@ -1,0 +1,111 @@
+// Per-line bidi ordering for the pptx renderer.
+//
+// Lines are laid out as a list of style/word segments. We reorder at SEGMENT
+// granularity (1:1 with the laid-out segments — every per-segment property is
+// preserved) using the shared UAX#9 engine (rule L2), and let Canvas
+// shape/mirror each segment internally when it is drawn with `ctx.direction`
+// set to the segment's resolved direction. The whole segment string is drawn in
+// one fillText, so Canvas resolves any residual intra-segment bidi. Inline
+// objects (math / image) participate as a single neutral object-replacement
+// character.
+
+import { getDefaultBidiEngine } from '@silurus/ooxml-core';
+
+/** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
+ *  Arabic presentation forms. Used only as a cheap gate to decide whether a
+ *  line needs the (exact) bidi pass at all — never for ordering itself. */
+const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+
+/** A laid-out segment as seen here: only its optional text matters for bidi.
+ *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
+ *  math / tab members carry no `text`) assigns cleanly. */
+const segText = (s: unknown): string | undefined => {
+  const t = (s as { text?: unknown }).text;
+  return typeof t === 'string' ? t : undefined;
+};
+
+/** Cheap test: does this run of segments contain any strong-RTL character? */
+export function segmentsHaveRtl(segments: readonly unknown[]): boolean {
+  for (const s of segments) {
+    const t = segText(s);
+    if (t !== undefined && RTL_GATE.test(t)) return true;
+  }
+  return false;
+}
+
+export interface LineVisualOrder {
+  /** Logical segment indices in visual (left-to-right) order. */
+  order: number[];
+  /** Per-LOGICAL-index resolved direction (true = RTL) for `ctx.direction`. */
+  rtl: boolean[];
+}
+
+const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON)
+
+/**
+ * Compute the visual draw order of a line's segments under `baseRtl`. Text
+ * segments contribute their text; non-text segments contribute one neutral
+ * placeholder so they take the surrounding direction. Each segment is assigned
+ * the embedding level of its first code unit (segments are single-script in
+ * practice because they are space-split); Canvas resolves any residual
+ * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
+ */
+export function computeLineVisualOrder(
+  segments: readonly unknown[],
+  baseRtl: boolean,
+): LineVisualOrder {
+  const n = segments.length;
+  if (n === 0) return { order: [], rtl: [] };
+
+  let full = '';
+  const segStart: number[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    segStart[i] = full.length;
+    const t = segText(segments[i]) ?? '';
+    full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
+  }
+
+  const engine = getDefaultBidiEngine();
+  const { levels, paragraphLevel } = engine.computeLevels(full, baseRtl ? 'rtl' : 'ltr');
+
+  const segLevels = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const lvl = levels[segStart[i]];
+    // 255 = removed by X9 (no glyph); fall back to the paragraph level.
+    segLevels[i] = lvl === 255 ? paragraphLevel : lvl;
+  }
+
+  const order = engine.reorderVisual(segLevels, 0, n);
+  const rtl: boolean[] = new Array(n);
+  for (let i = 0; i < n; i++) rtl[i] = (segLevels[i] & 1) === 1;
+  return { order, rtl };
+}
+
+/** Physical edge a line aligns to, resolving logical start/end against base direction. */
+export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
+
+/**
+ * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
+ * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
+ * an unset alignment defaults to the leading (logical-start) edge.
+ */
+export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
+  switch (alignment) {
+    case 'center':
+      return 'center';
+    case 'both':
+    case 'justify':
+    case 'distribute':
+      return 'justify';
+    case 'left':
+      return 'left';
+    case 'right':
+      return 'right';
+    case 'end':
+      return baseRtl ? 'left' : 'right';
+    case 'start':
+    case undefined:
+    default:
+      return baseRtl ? 'right' : 'left';
+  }
+}

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -18,6 +18,11 @@ import wasmAssetUrl from './wasm/pptx_parser_bg.wasm?url';
  *  substitute into the canvas font stack so missing Office fonts degrade to a
  *  same-width webfont instead of a wider system serif/sans. The remaining
  *  entries omit `loadFamily` because Google Fonts ships the same family name. */
+const NOTO_NASKH_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic:wght@400;700&display=swap';
+const NOTO_SANS_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@400;700&display=swap';
+
 const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'calibri':           { url: 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Carlito' },
   'calibri light':     { url: 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Carlito' },
@@ -32,6 +37,21 @@ const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'poppins':           { url: 'https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'raleway':           { url: 'https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
+  // Common Arabic-script faces that hosts rarely ship. Map them to Noto
+  // substitutes so RTL slides (e.g. sample-10, which requests Sakkal Majalla /
+  // Univers Next Arabic) render with a real web font instead of an oversized
+  // OS fallback. "Naskh" covers traditional serif-like Arabic faces; "Sans"
+  // covers the modern geometric ones.
+  'sakkal majalla':      { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'traditional arabic':  { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'simplified arabic':   { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'arabic typesetting':  { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'univers next arabic': { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
+  // Self-referencing entries so the generic Arabic fallback fonts (appended to
+  // the renderer's font stack) are themselves loaded whenever useGoogleFonts is
+  // enabled — see `load`, which always queues these names.
+  'noto naskh arabic':   { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'noto sans arabic':    { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
 };
 
 /** Options for {@link PptxPresentation.load}. The shared load-options type
@@ -117,7 +137,13 @@ export class PptxPresentation {
     await pres._parse(buffer, opts.maxZipEntryBytes);
     const parsed = pres._presentation;
     if (opts.useGoogleFonts && parsed) {
-      await preloadGoogleFonts([parsed.majorFont, parsed.minorFont], PPTX_GOOGLE_FONTS);
+      // Always load the generic Arabic fallbacks so any Arabic-script run gets
+      // a real web font even when its named family is unmapped (the renderer's
+      // canvas font stack ends with these two Noto faces).
+      await preloadGoogleFonts(
+        [parsed.majorFont, parsed.minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic'],
+        PPTX_GOOGLE_FONTS,
+      );
     }
     return pres;
   }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1561,7 +1561,10 @@ function renderTextBody(
     }
     cursorY += topGapPx;
     entriesInCol++;
-    const xShift = colIdx * colWidthShift;
+    // §21.1.2.1.1 bodyPr@rtlCol: columns fill right-to-left — mirror the
+    // visual column index. LTR bodies (rtlCol false/absent) are unchanged.
+    const visCol = body.rtlCol ? numCol - 1 - colIdx : colIdx;
+    const xShift = visCol * colWidthShift;
     const textX = entry.textX + xShift;
     const bulletX = entry.bulletX + xShift;
     const textMaxW = entry.textMaxW;
@@ -1603,8 +1606,8 @@ function renderTextBody(
       if (paraNeedsBidi && baseRtl) {
         const prevDir = ctx.direction;
         ctx.direction = 'rtl';
-        const bw = ctx.measureText(bulletLabel).width;
-        ctx.fillText(bulletLabel, textX + textMaxW + (textX - bulletX) - bw, baseline);
+        const bulletW = ctx.measureText(bulletLabel).width;
+        ctx.fillText(bulletLabel, textX + textMaxW + (textX - bulletX) - bulletW, baseline);
         ctx.direction = prevDir;
       } else {
         ctx.fillText(bulletLabel, bulletX, baseline);
@@ -1672,14 +1675,21 @@ function renderTextBody(
       if (ls > 0 && seg.text.length > 1 && !segRtl) {
         // Draw glyph-by-glyph so each character advance is `measure + ls`.
         // Matches OOXML rPr @spc semantics — extra space added to each
-        // character's advance, including after the last one. Skipped for RTL
-        // segments: per-glyph advance would break Arabic cursive joining, so we
-        // draw the whole shaped segment in one fillText instead.
+        // character's advance, including after the last one.
         let cx = penX;
         for (const ch of seg.text) {
           ctx.fillText(ch, cx, segBaseline);
           cx += ctx.measureText(ch).width + ls;
         }
+      } else if (ls > 0 && seg.text.length > 1) {
+        // RTL segment with rPr @spc: per-glyph advance would break Arabic
+        // cursive joining, so distribute the spacing via canvas letterSpacing
+        // and draw the whole shaped segment in one fillText. The painted width
+        // then matches the segW advance below (baseW + ls per character).
+        const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+        try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
+        ctx.fillText(seg.text, penX, segBaseline);
+        try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
       } else {
         ctx.fillText(seg.text, penX, segBaseline);
       }
@@ -1704,6 +1714,11 @@ function renderTextBody(
             ctx.strokeText(ch, cx, segBaseline);
             cx += ctx.measureText(ch).width + ls;
           }
+        } else if (ls > 0 && seg.text.length > 1) {
+          const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+          try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
+          ctx.strokeText(seg.text, penX, segBaseline);
+          try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
         } else {
           ctx.strokeText(seg.text, penX, segBaseline);
         }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1161,7 +1161,8 @@ function renderTextBody(
   slideNumber?: number,
   rc: RenderContext = { themeMajorFont: null, themeMinorFont: null },
   onTextRun?: TextRunCallback,
-) {
+  measureOnly = false,
+): number | void {
   // Vertical text: rotate rendering context so text flows top-to-bottom.
   // "vert" and "eaVert" both approximate to 90° clockwise rotation.
   // "vert270" rotates 270° (= 90° counterclockwise).
@@ -1200,6 +1201,11 @@ function renderTextBody(
         })
       : undefined;
 
+    if (measureOnly) {
+      // The rotated sub-frame's content height runs along the original width
+      // axis; for a table row the vertical extent is the original box width.
+      return bw;
+    }
     ctx.save();
     ctx.translate(cx, cy);
     ctx.rotate(isVert270 ? -Math.PI / 2 : Math.PI / 2);
@@ -1472,6 +1478,13 @@ function renderTextBody(
         ({ allLines, totalHeight } = buildLayout(lo));
       }
     }
+  }
+
+  // ── measure-only: return the content height the text body needs ─────────
+  // Used by renderTable to grow rows to fit their tallest cell (ECMA-376
+  // §21.1.3.18: a:tr@h is a minimum). Returns padding + laid-out text height.
+  if (measureOnly) {
+    return tPad + totalHeight + bPad;
   }
 
   // ── anchor="b" with bh=0: auto-height growing upward from by ────────────
@@ -2132,34 +2145,119 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
   const x0 = emuToPx(el.x, scale);
   const y0 = emuToPx(el.y, scale);
 
-  // Convert col widths and row heights to pixels
+  // Convert col widths to pixels.
   const colWidths = el.cols.map(c => emuToPx(c, scale));
+  const numCols = colWidths.length;
+
+  // Spanned width starting at column `ci` for `span` columns.
+  const spannedWidth = (ci: number, span: number): number => {
+    let w = 0;
+    for (let s = 0; s < span; s++) w += colWidths[ci + s] ?? 0;
+    return w;
+  };
+
+  // ── Row heights: ECMA-376 §21.1.3.18 (a:tr@h) is a MINIMUM ────────────────
+  // PowerPoint grows a row to fit its tallest cell's laid-out text (like
+  // Word's "at least" line rule). A literal h=0 therefore becomes
+  // content-driven. We measure each cell's text body at its spanned width
+  // (reusing the same renderTextBody machinery via measureOnly) and take
+  // max(tr@h, tallest single-row cell content). A rowSpan cell distributes
+  // its content height across the rows it covers so it doesn't inflate the
+  // first row.
   const rowHeights = el.rows.map(r => emuToPx(r.height, scale));
 
-  let rowY = y0;
+  // First pass: single-row (rowSpan ≤ 1) cells set their own row's minimum.
   for (let ri = 0; ri < el.rows.length; ri++) {
     const row = el.rows[ri];
-    const rowH = rowHeights[ri];
-    let colX = x0;
+    for (let ci = 0; ci < row.cells.length; ci++) {
+      const cell = row.cells[ci];
+      if (cell.hMerge || cell.vMerge) continue;
+      if ((cell.rowSpan || 1) > 1) continue;
+      if (!cell.textBody) continue;
+      const cellW = spannedWidth(ci, cell.gridSpan || 1);
+      const needed = (renderTextBody(
+        ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
+        '#000000', slideNumber, rc, undefined, true,
+      ) as number) || 0;
+      if (needed > rowHeights[ri]) rowHeights[ri] = needed;
+    }
+  }
+
+  // Second pass: rowSpan cells. If the content needs more than the sum of the
+  // rows it spans, distribute the deficit across those rows so the merged area
+  // grows without inflating any single row beyond what its own content needs.
+  for (let ri = 0; ri < el.rows.length; ri++) {
+    const row = el.rows[ri];
+    for (let ci = 0; ci < row.cells.length; ci++) {
+      const cell = row.cells[ci];
+      if (cell.hMerge || cell.vMerge) continue;
+      const span = cell.rowSpan || 1;
+      if (span <= 1 || !cell.textBody) continue;
+      const cellW = spannedWidth(ci, cell.gridSpan || 1);
+      const needed = (renderTextBody(
+        ctx, cell.textBody, 0, 0, cellW, 0, scale, null, 0, false, false,
+        '#000000', slideNumber, rc, undefined, true,
+      ) as number) || 0;
+      let have = 0;
+      for (let s = 0; s < span && ri + s < rowHeights.length; s++) have += rowHeights[ri + s];
+      if (needed > have) {
+        const extra = (needed - have) / span;
+        for (let s = 0; s < span && ri + s < rowHeights.length; s++) rowHeights[ri + s] += extra;
+      }
+    }
+  }
+
+  // ── Column x-positions ────────────────────────────────────────────────────
+  // ECMA-376 §21.1.3.13 (a:tblPr@rtl): a right-to-left table places column 0
+  // at the right edge, columns advancing leftward. We precompute the left
+  // pixel edge of each column so RTL is a coordinate flip (no ctx.scale(-1,1)
+  // which would mirror text and borders).
+  const tableW = colWidths.reduce((a, b) => a + b, 0);
+  const colLeft: number[] = new Array(numCols);
+  if (el.rtl) {
+    let right = x0 + tableW;
+    for (let ci = 0; ci < numCols; ci++) {
+      right -= colWidths[ci];
+      colLeft[ci] = right;
+    }
+  } else {
+    let left = x0;
+    for (let ci = 0; ci < numCols; ci++) {
+      colLeft[ci] = left;
+      left += colWidths[ci];
+    }
+  }
+
+  // Left pixel edge of a cell spanning columns [ci, ci+span). Under RTL the
+  // span grows leftward, so the merged cell's left edge is the leftmost column.
+  const spannedLeft = (ci: number, span: number): number =>
+    el.rtl ? colLeft[ci + span - 1] : colLeft[ci];
+
+  const rowTop: number[] = new Array(el.rows.length);
+  {
+    let y = y0;
+    for (let ri = 0; ri < el.rows.length; ri++) { rowTop[ri] = y; y += rowHeights[ri]; }
+  }
+
+  for (let ri = 0; ri < el.rows.length; ri++) {
+    const row = el.rows[ri];
+    const rowY = rowTop[ri];
 
     for (let ci = 0; ci < row.cells.length; ci++) {
       const cell = row.cells[ci];
 
       // Merged cells that are continuations: skip drawing
       if (cell.hMerge || cell.vMerge) {
-        colX += colWidths[ci] ?? 0;
         continue;
       }
 
       // Cell size: span multiple columns/rows
-      let cellW = 0;
-      for (let span = 0; span < (cell.gridSpan || 1); span++) {
-        cellW += colWidths[ci + span] ?? 0;
-      }
+      const cellW = spannedWidth(ci, cell.gridSpan || 1);
       let cellH = 0;
       for (let span = 0; span < (cell.rowSpan || 1); span++) {
         cellH += rowHeights[ri + span] ?? 0;
       }
+      const colX = spannedLeft(ci, cell.gridSpan || 1);
 
       // Fill
       const fillColor = resolveFill(cell.fill);
@@ -2221,10 +2319,7 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
         ctx.stroke();
       }
       ctx.restore();
-
-      colX += colWidths[ci] ?? 0;
     }
-    rowY += rowH;
   }
 }
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -431,7 +431,22 @@ const OFFICE_FONT_SUBSTITUTE: Record<string, string> = {
   'calibri light': 'Carlito',
   'cambria': 'Caladea',
   'cambria math': 'Caladea',
+  // Common Arabic-script faces that hosts rarely ship. Map them to Noto
+  // substitutes so RTL slides (e.g. sample-10, which requests Sakkal Majalla /
+  // Univers Next Arabic) render with a real web font instead of an oversized
+  // OS fallback. "Naskh" covers traditional serif-like Arabic faces; "Sans"
+  // covers the modern geometric ones.
+  'sakkal majalla': 'Noto Naskh Arabic',
+  'traditional arabic': 'Noto Naskh Arabic',
+  'simplified arabic': 'Noto Naskh Arabic',
+  'arabic typesetting': 'Noto Naskh Arabic',
+  'univers next arabic': 'Noto Sans Arabic',
 };
+
+/** Generic Arabic fallbacks appended to every named-font canvas stack (before
+ *  the CSS generic) so Arabic-script glyphs in an unmapped family still resolve
+ *  to a real Arabic web font when `useGoogleFonts` is on. */
+const ARABIC_FALLBACKS = '"Noto Naskh Arabic", "Noto Sans Arabic"';
 
 function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string, rc: RenderContext): string {
   const style  = italic ? 'italic ' : '';
@@ -440,12 +455,12 @@ function buildFont(bold: boolean, italic: boolean, sizePx: number, family: strin
   if (CSS_GENERIC_FAMILIES.has(normalized)) {
     return `${style}${weight}${sizePx}px ${normalized}`;
   }
-  // Named font + (metric-compatible substitute, if an Office face) + inferred
-  // generic fallback, so browsers degrade consistently when the exact typeface
-  // is not installed.
+  // Named font + (metric-compatible substitute, if an Office face) + generic
+  // Arabic web fonts + inferred generic fallback, so browsers degrade
+  // consistently when the exact typeface is not installed.
   const sub = OFFICE_FONT_SUBSTITUTE[normalized.toLowerCase()];
   const subPart = sub ? `"${sub}", ` : '';
-  return `${style}${weight}${sizePx}px "${normalized}", ${subPart}${genericFallback(normalized)}`;
+  return `${style}${weight}${sizePx}px "${normalized}", ${subPart}${ARABIC_FALLBACKS}, ${genericFallback(normalized)}`;
 }
 
 /**

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -33,6 +33,11 @@ import {
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import { drawPlayBadge } from './media-chrome';
 import { renderPresetShape, hasPreset, getConnectorAnchors } from './preset-shape';
+import {
+  segmentsHaveRtl,
+  computeLineVisualOrder,
+  type LineVisualOrder,
+} from './bidi-line';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -1561,6 +1566,12 @@ function renderTextBody(
     const bulletX = entry.bulletX + xShift;
     const textMaxW = entry.textMaxW;
 
+    // Bidi: base direction from a:pPr@rtl (the parser already flips the default
+    // alignment l→r for rtl paragraphs). Engage only when the base is RTL or a
+    // line carries strong-RTL characters, so LTR slides keep their exact path.
+    const baseRtl = entry.para.rtl === true;
+    const paraNeedsBidi = baseRtl || segmentsHaveRtl(line.segments);
+
     // Measure line for alignment AND baseline ascent in one pass.
     // actualBoundingBoxAscent gives the real font ascent for the rendered glyphs,
     // replacing the 0.8×lineHeight heuristic that over-estimates for CJK and
@@ -1583,11 +1594,21 @@ function renderTextBody(
     }
     const baseline = cursorY + maxAscent;
 
-    // Draw bullet
+    // Draw bullet. Under RTL the bullet hangs in the right gutter: mirror its
+    // LTR offset (textX − bulletX, i.e. the bullet→text gap) about the text
+    // column's right edge.
     if (bulletLabel) {
       ctx.font = bulletFont;
       ctx.fillStyle = bulletColor;
-      ctx.fillText(bulletLabel, bulletX, baseline);
+      if (paraNeedsBidi && baseRtl) {
+        const prevDir = ctx.direction;
+        ctx.direction = 'rtl';
+        const bw = ctx.measureText(bulletLabel).width;
+        ctx.fillText(bulletLabel, textX + textMaxW + (textX - bulletX) - bw, baseline);
+        ctx.direction = prevDir;
+      } else {
+        ctx.fillText(bulletLabel, bulletX, baseline);
+      }
     }
 
     const effectiveTextX = textX + textXOffset;
@@ -1600,7 +1621,18 @@ function renderTextBody(
       penX = effectiveTextX;
     }
 
-    for (const seg of line.segments) {
+    // Visual draw order: under bidi, reorder segments per UAX#9 (rule L2) and
+    // draw each with ctx.direction matching its resolved direction. textAlign
+    // is already 'left', so penX stays the segment's left edge.
+    const visual: LineVisualOrder | null = paraNeedsBidi
+      ? computeLineVisualOrder(line.segments, baseRtl)
+      : null;
+    const segCount = line.segments.length;
+    for (let vi = 0; vi < segCount; vi++) {
+      const li = visual ? visual.order[vi] : vi;
+      const seg = line.segments[li];
+      const segRtl = visual ? visual.rtl[li] : false;
+      if (paraNeedsBidi) ctx.direction = segRtl ? 'rtl' : 'ltr';
       // ── Equation segment: draw the cached image instead of text ──────────
       if (seg.math) {
         const render = mathRenders.get(seg.math.nodes);
@@ -1637,10 +1669,12 @@ function renderTextBody(
         ctx.shadowOffsetY = Math.sin(dirRad) * dist;
       }
 
-      if (ls > 0 && seg.text.length > 1) {
+      if (ls > 0 && seg.text.length > 1 && !segRtl) {
         // Draw glyph-by-glyph so each character advance is `measure + ls`.
         // Matches OOXML rPr @spc semantics — extra space added to each
-        // character's advance, including after the last one.
+        // character's advance, including after the last one. Skipped for RTL
+        // segments: per-glyph advance would break Arabic cursive joining, so we
+        // draw the whole shaped segment in one fillText instead.
         let cx = penX;
         for (const ch of seg.text) {
           ctx.fillText(ch, cx, segBaseline);
@@ -1664,7 +1698,7 @@ function renderTextBody(
         ctx.lineWidth = Math.max(0.5, emuToPx(segOutline.width, scale));
         ctx.strokeStyle = segOutline.color ? `#${segOutline.color}` : seg.color;
         ctx.lineJoin = 'round';
-        if (ls > 0 && seg.text.length > 1) {
+        if (ls > 0 && seg.text.length > 1 && !segRtl) {
           let cx = penX;
           for (const ch of seg.text) {
             ctx.strokeText(ch, cx, segBaseline);
@@ -1728,6 +1762,7 @@ function renderTextBody(
 
       penX += segW;
     }
+    if (paraNeedsBidi) ctx.direction = 'ltr'; // reset before tab-stop / next line
 
     // ── Tab-stop segments (right-aligned or centred at tab stop position) ──
     if (line.tabStop && line.tabStop.segments.length > 0) {

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -148,6 +148,8 @@ export interface TableElement {
   /** Column widths in EMU */
   cols: number[];
   rows: TableRow[];
+  /** `<a:tblPr rtl="1">` (ECMA-376 §21.1.3.13): right-to-left table — column 0 at the right edge. */
+  rtl?: boolean;
 }
 
 export interface TableRow {

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -650,8 +650,8 @@ fn parse_worksheet(
                 }
             }
             "col" if node.tag_name().namespace() == Some(ns) => {
-                let custom = node.attribute("customWidth").map(|v| v == "1").unwrap_or(false);
-                let hidden = node.attribute("hidden").map(|v| v == "1").unwrap_or(false);
+                let custom = attr_bool(&node, "customWidth").unwrap_or(false);
+                let hidden = attr_bool(&node, "hidden").unwrap_or(false);
                 // Only record widths for custom-widthed columns OR hidden columns
                 if !custom && !hidden { continue; }
                 let min: u32 = node.attribute("min").and_then(|s| s.parse().ok()).unwrap_or(1);
@@ -668,11 +668,11 @@ fn parse_worksheet(
                 }
             }
             "sheetView" if node.tag_name().namespace() == Some(ns) => {
-                show_zeros = node.attribute("showZeros").map(|v| v != "0").unwrap_or(true);
-                show_gridlines = node.attribute("showGridLines").map(|v| v != "0").unwrap_or(true);
+                show_zeros = attr_bool(&node, "showZeros").unwrap_or(true);
+                show_gridlines = attr_bool(&node, "showGridLines").unwrap_or(true);
                 // ECMA-376 §18.3.1.87 `rightToLeft` — mirrors the whole grid so
                 // column A is on the right. Default false (left-to-right).
-                right_to_left = node.attribute("rightToLeft").map(|v| v == "1" || v == "true").unwrap_or(false);
+                right_to_left = attr_bool(&node, "rightToLeft").unwrap_or(false);
             }
             "tabColor" if node.tag_name().namespace() == Some(ns) => {
                 tab_color = parse_color(&node, theme_colors);
@@ -730,7 +730,7 @@ fn parse_worksheet(
             }
             "row" if node.tag_name().namespace() == Some(ns) => {
                 let row_idx: u32 = node.attribute("r").and_then(|s| s.parse().ok()).unwrap_or(0);
-                let hidden = node.attribute("hidden").map(|v| v == "1").unwrap_or(false);
+                let hidden = attr_bool(&node, "hidden").unwrap_or(false);
                 // ECMA-376 §18.3.1.73 `<row>@ht` is the row height in points.
                 // Gating the value on `@customHeight="1"` (0.37.0) was too
                 // strict — `demo/sample-1` sheets 2-5 store `ht="36.95"` on
@@ -1434,6 +1434,18 @@ fn parse_row_cells(
     cells
 }
 
+/// Parse an `ST_Boolean` (ECMA-376 §22.9.2.7, xsd:boolean) attribute value.
+/// Accepts `1`/`true`/`on` as true and `0`/`false`/`off` as false (case-insensitive).
+/// Returns `None` when the attribute is absent so callers can apply their own default.
+pub(crate) fn attr_bool(node: &roxmltree::Node, name: &str) -> Option<bool> {
+    node.attribute(name).map(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "on"
+        )
+    })
+}
+
 pub(crate) fn parse_cell_ref(r: &str) -> (u32, u32) {
     let col_str: String = r.chars().take_while(|c| c.is_ascii_alphabetic()).collect();
     let row_str: String = r.chars().skip_while(|c| c.is_ascii_alphabetic()).collect();
@@ -1607,5 +1619,32 @@ mod sheet_view_tests {
         );
         let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
         assert!(!ws.right_to_left, "absent @rightToLeft → right_to_left false");
+    }
+
+    /// ECMA-376 §22.9.2.7 `ST_Boolean` allows `true`/`false` as well as `1`/`0`.
+    /// LibreOffice writes `<col customWidth="true" .../>`; the parser must honor
+    /// the recorded width instead of skipping the `<col>` (which would leave the
+    /// column at `defaultColWidth`).
+    #[test]
+    fn col_custom_width_accepts_true_literal() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols><col customWidth="true" min="1" max="1" width="22"/></cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        assert_eq!(
+            ws.col_widths.get(&1).copied(),
+            Some(22.0),
+            "customWidth=\"true\" → width 22 recorded for column 1"
+        );
+    }
+
+    /// `customWidth="1"` (Excel's spelling) must keep working after the helper change.
+    #[test]
+    fn col_custom_width_accepts_one_literal() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols><col customWidth="1" min="2" max="2" width="10"/></cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        assert_eq!(ws.col_widths.get(&2).copied(), Some(10.0));
     }
 }

--- a/packages/xlsx/src/bidi-line.test.ts
+++ b/packages/xlsx/src/bidi-line.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  segmentsHaveRtl,
+  computeLineVisualOrder,
+  resolveAlignEdge,
+  cellBaseRtl,
+} from './bidi-line.js';
+
+describe('cellBaseRtl', () => {
+  it('honors explicit readingOrder', () => {
+    expect(cellBaseRtl(2, 'Hello')).toBe(true); // 2 = RTL
+    expect(cellBaseRtl(1, 'مرحبا')).toBe(false); // 1 = LTR
+  });
+  it('uses first-strong for Context (0) / absent', () => {
+    expect(cellBaseRtl(0, 'مرحبا')).toBe(true);
+    expect(cellBaseRtl(0, 'Hello')).toBe(false);
+    expect(cellBaseRtl(undefined, 'منتج alpha')).toBe(true);
+    expect(cellBaseRtl(undefined, '1234')).toBe(false);
+  });
+});
+
+describe('segmentsHaveRtl', () => {
+  it('detects Arabic/Hebrew, ignores Latin and objects', () => {
+    expect(segmentsHaveRtl([{ text: 'Hello world' }])).toBe(false);
+    expect(segmentsHaveRtl([{ text: 'price 99' }, {}])).toBe(false); // object seg has no text
+    expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
+    expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
+  });
+});
+
+describe('resolveAlignEdge', () => {
+  it('resolves logical start/end against base direction', () => {
+    expect(resolveAlignEdge(undefined, false)).toBe('left');
+    expect(resolveAlignEdge(undefined, true)).toBe('right');
+    expect(resolveAlignEdge('start', true)).toBe('right');
+    expect(resolveAlignEdge('end', true)).toBe('left');
+    expect(resolveAlignEdge('end', false)).toBe('right');
+    expect(resolveAlignEdge('center', true)).toBe('center');
+    expect(resolveAlignEdge('both', true)).toBe('justify');
+    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
+    expect(resolveAlignEdge('right', true)).toBe('right');
+  });
+});
+
+describe('computeLineVisualOrder', () => {
+  it('keeps pure-LTR segments in logical order', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'Hello ' }, { text: 'world' }], false);
+    expect(order).toEqual([0, 1]);
+    expect(rtl).toEqual([false, false]);
+  });
+
+  it('reverses pure-RTL segments and marks them RTL', () => {
+    const { order, rtl } = computeLineVisualOrder([{ text: 'שלום ' }, { text: 'עולם' }], true);
+    expect(order).toEqual([1, 0]); // last word is visually leftmost
+    expect(rtl).toEqual([true, true]);
+  });
+
+  it('orders an embedded LTR run inside an RTL line', () => {
+    // logical: Hebrew, Latin, Hebrew (base RTL) -> visual L→R: [2,1,0]
+    const { order, rtl } = computeLineVisualOrder(
+      [{ text: 'שלום ' }, { text: 'world ' }, { text: 'טוב' }],
+      true,
+    );
+    expect(order).toEqual([2, 1, 0]);
+    expect(rtl[1]).toBe(false); // the Latin segment is LTR
+    expect(rtl[0]).toBe(true);
+    expect(rtl[2]).toBe(true);
+  });
+
+  it('places a neutral object by surrounding direction', () => {
+    // object between two Hebrew words, base RTL -> object stays in RTL flow
+    const { order } = computeLineVisualOrder([{ text: 'שלום ' }, {}, { text: 'טוב' }], true);
+    expect(order).toEqual([2, 1, 0]);
+  });
+});

--- a/packages/xlsx/src/bidi-line.test.ts
+++ b/packages/xlsx/src/bidi-line.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  segmentsHaveRtl,
-  computeLineVisualOrder,
-  resolveAlignEdge,
-  cellBaseRtl,
-} from './bidi-line.js';
+import { segmentsHaveRtl, computeLineVisualOrder, cellBaseRtl } from './bidi-line.js';
 
 describe('cellBaseRtl', () => {
   it('honors explicit readingOrder', () => {
@@ -25,20 +20,6 @@ describe('segmentsHaveRtl', () => {
     expect(segmentsHaveRtl([{ text: 'price 99' }, {}])).toBe(false); // object seg has no text
     expect(segmentsHaveRtl([{ text: 'مرحبا' }])).toBe(true);
     expect(segmentsHaveRtl([{ text: 'abc ' }, { text: 'שלום' }])).toBe(true);
-  });
-});
-
-describe('resolveAlignEdge', () => {
-  it('resolves logical start/end against base direction', () => {
-    expect(resolveAlignEdge(undefined, false)).toBe('left');
-    expect(resolveAlignEdge(undefined, true)).toBe('right');
-    expect(resolveAlignEdge('start', true)).toBe('right');
-    expect(resolveAlignEdge('end', true)).toBe('left');
-    expect(resolveAlignEdge('end', false)).toBe('right');
-    expect(resolveAlignEdge('center', true)).toBe('center');
-    expect(resolveAlignEdge('both', true)).toBe('justify');
-    expect(resolveAlignEdge('left', true)).toBe('left'); // physical stays physical
-    expect(resolveAlignEdge('right', true)).toBe('right');
   });
 });
 

--- a/packages/xlsx/src/bidi-line.ts
+++ b/packages/xlsx/src/bidi-line.ts
@@ -22,7 +22,10 @@ export function cellBaseRtl(readingOrder: number | undefined, text: string): boo
 /** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
  *  Arabic presentation forms. Used only as a cheap gate to decide whether a
  *  line needs the (exact) bidi pass at all — never for ordering itself. */
-const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+const RTL_GATE =
+  // strong-RTL blocks incl. presentation forms, Plane-1 RTL blocks, and
+  // RTL-implicating controls (RLM/RLE/RLO/RLI).
+  /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF\u200F\u202B\u202E\u2067]|[\u{10800}-\u{10FFF}\u{1E800}-\u{1EFFF}]/u;
 
 /** A laid-out segment as seen here: only its optional text matters for bidi.
  *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
@@ -89,31 +92,3 @@ export function computeLineVisualOrder(
   return { order, rtl };
 }
 
-/** Physical edge a line aligns to, resolving logical start/end against base direction. */
-export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
-
-/**
- * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
- * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
- * an unset alignment defaults to the leading (logical-start) edge.
- */
-export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
-  switch (alignment) {
-    case 'center':
-      return 'center';
-    case 'both':
-    case 'justify':
-    case 'distribute':
-      return 'justify';
-    case 'left':
-      return 'left';
-    case 'right':
-      return 'right';
-    case 'end':
-      return baseRtl ? 'left' : 'right';
-    case 'start':
-    case undefined:
-    default:
-      return baseRtl ? 'right' : 'left';
-  }
-}

--- a/packages/xlsx/src/bidi-line.ts
+++ b/packages/xlsx/src/bidi-line.ts
@@ -1,0 +1,119 @@
+// Per-line bidi ordering for the xlsx renderer (rich-text cell runs).
+//
+// We reorder a cell line's rich-text runs at SEGMENT granularity (1:1 with the
+// runs — every per-run font/colour property is preserved) using the shared
+// UAX#9 engine (rule L2), and let Canvas shape each run internally when it is
+// drawn with `ctx.direction` set to the run's resolved direction. The whole run
+// string is drawn in one fillText, so Canvas resolves any residual
+// intra-run bidi.
+
+import { getDefaultBidiEngine, resolveBaseDirection } from '@silurus/ooxml-core';
+
+/**
+ * Resolve a cell's base direction from its xf @readingOrder
+ * (ECMA-376 §18.8.1: 1 = LTR, 2 = RTL, 0/absent = Context → UAX#9 first-strong).
+ */
+export function cellBaseRtl(readingOrder: number | undefined, text: string): boolean {
+  if (readingOrder === 2) return true;
+  if (readingOrder === 1) return false;
+  return resolveBaseDirection(undefined, text) === 'rtl';
+}
+
+/** Strong-RTL scripts (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, …) +
+ *  Arabic presentation forms. Used only as a cheap gate to decide whether a
+ *  line needs the (exact) bidi pass at all — never for ordering itself. */
+const RTL_GATE = /[֐-ࣿיִ-﷿ﹰ-﻿]|[\u{10800}-\u{10FFF}]/u;
+
+/** A laid-out segment as seen here: only its optional text matters for bidi.
+ *  Typed as `unknown` element so the renderer's LayoutSeg union (whose image /
+ *  math / tab members carry no `text`) assigns cleanly. */
+const segText = (s: unknown): string | undefined => {
+  const t = (s as { text?: unknown }).text;
+  return typeof t === 'string' ? t : undefined;
+};
+
+/** Cheap test: does this run of segments contain any strong-RTL character? */
+export function segmentsHaveRtl(segments: readonly unknown[]): boolean {
+  for (const s of segments) {
+    const t = segText(s);
+    if (t !== undefined && RTL_GATE.test(t)) return true;
+  }
+  return false;
+}
+
+export interface LineVisualOrder {
+  /** Logical segment indices in visual (left-to-right) order. */
+  order: number[];
+  /** Per-LOGICAL-index resolved direction (true = RTL) for `ctx.direction`. */
+  rtl: boolean[];
+}
+
+const OBJECT_PLACEHOLDER = '￼'; // OBJECT REPLACEMENT CHARACTER (bidi class ON)
+
+/**
+ * Compute the visual draw order of a line's segments under `baseRtl`. Text
+ * segments contribute their text; non-text segments contribute one neutral
+ * placeholder so they take the surrounding direction. Each segment is assigned
+ * the embedding level of its first code unit (segments are single-script in
+ * practice because they are space-split); Canvas resolves any residual
+ * intra-segment bidi when the slice is drawn with the matching `ctx.direction`.
+ */
+export function computeLineVisualOrder(
+  segments: readonly unknown[],
+  baseRtl: boolean,
+): LineVisualOrder {
+  const n = segments.length;
+  if (n === 0) return { order: [], rtl: [] };
+
+  let full = '';
+  const segStart: number[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    segStart[i] = full.length;
+    const t = segText(segments[i]) ?? '';
+    full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
+  }
+
+  const engine = getDefaultBidiEngine();
+  const { levels, paragraphLevel } = engine.computeLevels(full, baseRtl ? 'rtl' : 'ltr');
+
+  const segLevels = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const lvl = levels[segStart[i]];
+    // 255 = removed by X9 (no glyph); fall back to the paragraph level.
+    segLevels[i] = lvl === 255 ? paragraphLevel : lvl;
+  }
+
+  const order = engine.reorderVisual(segLevels, 0, n);
+  const rtl: boolean[] = new Array(n);
+  for (let i = 0; i < n; i++) rtl[i] = (segLevels[i] & 1) === 1;
+  return { order, rtl };
+}
+
+/** Physical edge a line aligns to, resolving logical start/end against base direction. */
+export type AlignEdge = 'left' | 'right' | 'center' | 'justify';
+
+/**
+ * Resolve a paragraph's `w:jc` value (and base direction) to a physical edge.
+ * `start`/`end` are logical (flip under RTL); `left`/`right` are physical;
+ * an unset alignment defaults to the leading (logical-start) edge.
+ */
+export function resolveAlignEdge(alignment: string | undefined, baseRtl: boolean): AlignEdge {
+  switch (alignment) {
+    case 'center':
+      return 'center';
+    case 'both':
+    case 'justify':
+    case 'distribute':
+      return 'justify';
+    case 'left':
+      return 'left';
+    case 'right':
+      return 'right';
+    case 'end':
+      return baseRtl ? 'left' : 'right';
+    case 'start':
+    case undefined:
+    default:
+      return baseRtl ? 'right' : 'left';
+  }
+}

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -19,7 +19,14 @@ import { computeLineVisualOrder, cellBaseRtl, segmentsHaveRtl } from './bidi-lin
 // true })`. Listing it in the cascade means: Calibri (Windows / Office)
 // → Carlito (loaded webfont) → Arial → sans-serif. Caladea is the same
 // for Cambria.
-const DEFAULT_FONT_FAMILY = '"Calibri", "Carlito", "Cambria", "Caladea", Arial, sans-serif';
+// The two trailing Noto Arabic faces are generic Arabic-script fallbacks:
+// when the primary Latin faces (Calibri / Carlito / Arial) lack a requested
+// glyph, the browser advances down the cascade per-glyph, so any Arabic
+// codepoint resolves to a real web font (loaded by `XlsxWorkbook.load`'s
+// useGoogleFonts path) instead of an oversized OS Arabic face. Latin glyphs
+// still bind to the earlier faces, so Latin rendering is unchanged.
+const DEFAULT_FONT_FAMILY =
+  '"Calibri", "Carlito", "Cambria", "Caladea", Arial, "Noto Naskh Arabic", "Noto Sans Arabic", sans-serif';
 const DEFAULT_FONT_SIZE = 11;
 // Fallback Max Digit Width of the Normal-style font when the workbook's
 // default font isn't known. Calibri 11 pt at 96 DPI ≈ 8 px (Canvas2D
@@ -1227,17 +1234,31 @@ function renderQuadrant(
       // - directional hatches (dark/light Horizontal/Vertical/Down/Up/Grid/
       //   Trellis): render via a small repeating tile using createPattern so
       //   the hatch actually shows, rather than approximating as a blend.
+      // Whether this cell painted an opaque fill over its rect. The
+      // neighbour-edge inherit below (which redraws the shared boundary line
+      // the left/above cell already drew) is only needed to repair a line
+      // that *this* cell's fill over-painted. An empty, fill-less cell paints
+      // nothing over the boundary, so inheriting the neighbour's edge there is
+      // a pure double-draw — invisible in LTR (it lands on the same pixel the
+      // neighbour drew) but in an RTL mirror (ECMA-376 §18.3.1.87) the cell's
+      // own "left" maps to its *screen-left* edge, away from the neighbour,
+      // producing a spurious vertical line Excel never draws (sample-29 E1).
+      let paintedFill = false;
       if (paintCellPatternFill(ctx, effectiveFill, cx, cy, cellW, cellH)) {
         // own fill painted; tableStyle fallbacks intentionally skipped
+        paintedFill = true;
       } else if (tableStyle && tableStyle.isHeader && tsDxfHeader?.fill?.fgColor) {
         ctx.fillStyle = hexToRgba(tsDxfHeader.fill.fgColor);
         ctx.fillRect(cx, cy, cellW, cellH);
+        paintedFill = true;
       } else if (tableStyle && !tableStyle.isHeader && !tableStyle.isTotals && tsDxfWhole?.fill?.fgColor) {
         ctx.fillStyle = hexToRgba(tsDxfWhole.fill.fgColor);
         ctx.fillRect(cx, cy, cellW, cellH);
+        paintedFill = true;
       } else if (tableStyle && tableStyle.isBanded) {
         ctx.fillStyle = stripeColorFor(tableStyle.accent);
         ctx.fillRect(cx, cy, cellW, cellH);
+        paintedFill = true;
       }
 
       // Comment indicator triangle — drawn above fill but below borders so
@@ -1319,7 +1340,7 @@ function renderQuadrant(
       // inherit picks the visually dominant style instead of always favouring
       // the lower cell's own.
       const aboveCell = cellMap.get(`${rowIndex - 1}:${colIndex}`);
-      const aboveBottom = aboveCell
+      const aboveBottom = paintedFill && aboveCell
         ? resolveXf(styles, aboveCell.styleIndex).border.bottom
         : null;
       let invertedTop = false;
@@ -1334,7 +1355,7 @@ function renderQuadrant(
         invertedTop = picked === aboveBottom && before !== aboveBottom;
       }
       let invertedLeft = false;
-      if (!suppressLeftGridCol.has(ci)) {
+      if (paintedFill && !suppressLeftGridCol.has(ci)) {
         // Skip the inherit when the left edge was deliberately suppressed for
         // a centerContinuous run (ECMA-376 §18.18.40) — otherwise the
         // neighbour's xf.right re-introduces the internal vertical that we

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -773,6 +773,17 @@ interface RenderContext {
    *  unit column widths into pixels. */
   mdw: number;
   onTextRun?: (info: XlsxTextRunInfo) => void;
+  /** Sheet-level right-to-left grid mirror (ECMA-376 §18.3.1.87
+   *  `<sheetView rightToLeft>`). When true the whole grid is mirrored:
+   *  column A sits at the right edge, columns flow right-to-left, and the
+   *  row-number header strip sits on the right of the canvas. Implemented
+   *  by remapping each cell's canvas x to `canvasW - cx - cellW` (mirror
+   *  about the cell-area band) — glyphs themselves are NOT flipped, and
+   *  cell-level left/right alignment stays physical (Excel behavior). */
+  rtl: boolean;
+  /** Logical canvas width (device-independent px). Needed by the RTL
+   *  mirror; identical to the value the top-level render fn computes. */
+  canvasW: number;
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -991,6 +1002,16 @@ function renderQuadrant(
   const numCols = colWidths.length;
   const numRows = rowHeights.length;
 
+  // RTL grid mirror (ECMA-376 §18.3.1.87). Maps a left-anchored cell rect
+  // [x, x+w] to its mirror [canvasW - x - w, canvasW - x] within the
+  // cell-area band. Because the LTR cell area is [hw, canvasW] and the RTL
+  // cell area is [0, canvasW - hw] (header strip moves to the right), the
+  // transform for any cell/quadrant collapses to `canvasW - x - w`. Applied
+  // to every column x (so fills, borders, gridlines, text positions, merge
+  // spans and the clip rect all mirror) while leaving glyphs un-flipped and
+  // cell-level left/right alignment physical.
+  const mirrorX = (x: number, w: number): number => rc.rtl ? rc.canvasW - x - w : x;
+
   // Canvas x for each column
   const colXs: number[] = [];
   let x = -pixOffsetX;
@@ -1009,7 +1030,7 @@ function renderQuadrant(
 
   ctx.save();
   ctx.beginPath();
-  ctx.rect(clipX, clipY, clipW, clipH);
+  ctx.rect(mirrorX(clipX, clipW), clipY, clipW, clipH);
   ctx.clip();
 
   // Deferred text drawing. Excel renders cell text on top of *all* cell
@@ -1057,6 +1078,7 @@ function renderQuadrant(
     }
 
     const cW = info.totalW, cH = info.totalH;
+    aCx = mirrorX(aCx, cW);
     const key = `${aRow}:${aCol}`;
     const cell = rc.cellMap.get(key);
     const { font, fill, border, xf } = resolveXf(styles, cell?.styleIndex ?? 0);
@@ -1170,9 +1192,11 @@ function renderQuadrant(
 
     for (let ci = 0; ci < numCols; ci++) {
       const colIndex = startCol + ci;
-      const cx = originX + colXs[ci];
+      const ltrCx = originX + colXs[ci];
       const cw = colWidths[ci];
-      if (cx + cw <= clipX || cx >= clipX + clipW) continue;
+      // Cull against the (un-mirrored) clip band — visibility is preserved
+      // by the mirror, so the LTR test is correct for both directions.
+      if (ltrCx + cw <= clipX || ltrCx >= clipX + clipW) continue;
 
       const key = `${rowIndex}:${colIndex}`;
       if (mergeSkipSet.has(key)) continue;
@@ -1180,6 +1204,9 @@ function renderQuadrant(
       const mergeInfo = mergeAnchorMap.get(key);
       const cellW = mergeInfo ? mergeInfo.totalW : cw;
       const cellH = mergeInfo ? mergeInfo.totalH : ch;
+      // Mirror the cell's canvas x for RTL. Uses the *full* drawn width
+      // (merge span included) so the rect lands at the correct mirror band.
+      const cx = mirrorX(ltrCx, cellW);
 
       const cell = cellMap.get(key);
       const styleIndex = cell?.styleIndex ?? 0;
@@ -2034,6 +2061,8 @@ export function renderViewport(
     sparklineMap,
     mdw,
     onTextRun: opts.onTextRun,
+    rtl: worksheet.rightToLeft === true,
+    canvasW,
   };
 
   // Canvas areas for each quadrant
@@ -2137,16 +2166,27 @@ export function renderViewport(
     hw, hh, cs, dpr,
     opts.selectedRowRange ?? null,
     opts.selectedColRange ?? null,
+    worksheet.rightToLeft === true,
   );
 
   // ── Freeze pane separator lines ──────────────────────────────
+  // RTL mirrors the vertical freeze divider to the left edge of the frozen
+  // band (which now anchors at the right). The horizontal divider is
+  // unaffected by the x-mirror but its row-header end moves to the right.
+  const rtl = worksheet.rightToLeft === true;
   if (freezeRows > 0) {
     ctx.save();
     ctx.strokeStyle = FREEZE_LINE_COLOR;
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(hw, scrollAreaY + 0.5);
-    ctx.lineTo(canvasW, scrollAreaY + 0.5);
+    if (rtl) {
+      // cell area is [0, canvasW - hw]
+      ctx.moveTo(0, scrollAreaY + 0.5);
+      ctx.lineTo(canvasW - hw, scrollAreaY + 0.5);
+    } else {
+      ctx.moveTo(hw, scrollAreaY + 0.5);
+      ctx.lineTo(canvasW, scrollAreaY + 0.5);
+    }
     ctx.stroke();
     ctx.restore();
   }
@@ -2155,8 +2195,12 @@ export function renderViewport(
     ctx.strokeStyle = FREEZE_LINE_COLOR;
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(scrollAreaX + 0.5, hh);
-    ctx.lineTo(scrollAreaX + 0.5, canvasH);
+    // Divider sits between the frozen band and the scroll band. In LTR that
+    // is at scrollAreaX = hw + frozenW; mirrored that becomes
+    // canvasW - scrollAreaX.
+    const dividerX = rtl ? canvasW - scrollAreaX + 0.5 : scrollAreaX + 0.5;
+    ctx.moveTo(dividerX, hh);
+    ctx.lineTo(dividerX, canvasH);
     ctx.stroke();
     ctx.restore();
   }
@@ -2177,6 +2221,7 @@ function renderHeaders(
   hw: number, hh: number, cs: number, dpr: number,
   selectedRowRange: { start: number; end: number; strong: boolean } | null,
   selectedColRange: { start: number; end: number; strong: boolean } | null,
+  rtl: boolean,
 ): void {
   const HEADER_BG = '#f8f9fa';
   const HEADER_BG_SUBTLE = '#e8eaed';
@@ -2207,16 +2252,23 @@ function renderHeaders(
   const scrollAreaY = hh + frozenH;
   const hp = 0.5 / dpr;  // half device-pixel offset for 1dp crisp lines
 
+  // RTL grid mirror (ECMA-376 §18.3.1.87). The cell-area band mirrors about
+  // canvasW: a left-anchored col-header rect [x, x+w] maps to its mirror.
+  // The corner box and the row-number strip move from the left edge
+  // ([0, hw]) to the right edge ([canvasW - hw, canvasW]).
+  const mirrorX = (x: number, w: number): number => rtl ? canvasW - x - w : x;
+  const cornerX = rtl ? canvasW - hw : 0;  // x-origin of the corner / row-header strip
+
   // Corner – draw all 4 edges (standalone box)
   ctx.fillStyle = HEADER_BG;
-  ctx.fillRect(0, 0, hw, hh);
+  ctx.fillRect(cornerX, 0, hw, hh);
   ctx.strokeStyle = HEADER_BORDER;
   ctx.lineWidth = 0.5;
   ctx.beginPath();
-  ctx.moveTo(hp, 0); ctx.lineTo(hp, hh);          // left  (outward — canvas edge)
-  ctx.moveTo(0, hp); ctx.lineTo(hw, hp);            // top   (outward — canvas edge)
-  ctx.moveTo(hw - hp, 0); ctx.lineTo(hw - hp, hh);  // right  (inset — aligns with row-header right)
-  ctx.moveTo(0, hh - hp); ctx.lineTo(hw, hh - hp);  // bottom (inset — aligns with col-header bottom)
+  ctx.moveTo(cornerX + hp, 0); ctx.lineTo(cornerX + hp, hh);          // left
+  ctx.moveTo(cornerX, hp); ctx.lineTo(cornerX + hw, hp);              // top
+  ctx.moveTo(cornerX + hw - hp, 0); ctx.lineTo(cornerX + hw - hp, hh);  // right
+  ctx.moveTo(cornerX, hh - hp); ctx.lineTo(cornerX + hw, hh - hp);    // bottom
   ctx.stroke();
 
   ctx.font = HEADER_FONT;
@@ -2225,7 +2277,8 @@ function renderHeaders(
   // Helper: draw one column header cell.
   // Borders are drawn INSET (-hp) so that the next cell's fillRect (which starts at cx+cw)
   // never overwrites the current cell's right/bottom border line.
-  const drawColHeader = (col: number, cx: number, cw: number) => {
+  const drawColHeader = (col: number, ltrCx: number, cw: number) => {
+    const cx = mirrorX(ltrCx, cw);
     ctx.fillStyle = colBg(col);
     ctx.fillRect(cx, 0, cw, hh);
     ctx.strokeStyle = colBorder(col);
@@ -2244,26 +2297,35 @@ function renderHeaders(
   // Helper: draw one row header cell.
   // Borders drawn inset so adjacent cell's fill never overwrites them.
   const drawRowHeader = (row: number, cy: number, ch: number) => {
+    const rx = cornerX;  // left edge of the row-header strip (mirrors to the right in RTL)
     ctx.fillStyle = rowBg(row);
-    ctx.fillRect(0, cy, hw, ch);
+    ctx.fillRect(rx, cy, hw, ch);
     ctx.strokeStyle = rowBorder(row);
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(hw - hp, cy);  ctx.lineTo(hw - hp, cy + ch);   // right (inset)
-    ctx.moveTo(0, cy + ch - hp); ctx.lineTo(hw, cy + ch - hp); // bottom (inset)
-    ctx.moveTo(hp, cy);       ctx.lineTo(hp, cy + ch);          // left
+    ctx.moveTo(rx + hw - hp, cy);  ctx.lineTo(rx + hw - hp, cy + ch);   // right (inset)
+    ctx.moveTo(rx, cy + ch - hp); ctx.lineTo(rx + hw, cy + ch - hp);    // bottom (inset)
+    ctx.moveTo(rx + hp, cy);       ctx.lineTo(rx + hp, cy + ch);         // left
     ctx.stroke();
     ctx.fillStyle = HEADER_TEXT;
-    ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
-    ctx.fillText(String(row), hw - Math.max(2, Math.round(4 * cs)), cy + ch / 2);
+    const pad = Math.max(2, Math.round(4 * cs));
+    if (rtl) {
+      // Strip is on the right; the grid sits to its left, so anchor the
+      // number toward the grid-facing (left) edge.
+      ctx.textAlign = 'left';
+      ctx.fillText(String(row), rx + pad, cy + ch / 2);
+    } else {
+      ctx.textAlign = 'right';
+      ctx.fillText(String(row), rx + hw - pad, cy + ch / 2);
+    }
   };
 
   // Frozen col headers (no h-scroll, fixed positions)
   if (frozenColWidths.length > 0) {
     ctx.save();
     ctx.beginPath();
-    ctx.rect(hw, 0, frozenW, hh);
+    ctx.rect(mirrorX(hw, frozenW), 0, frozenW, hh);
     ctx.clip();
     let cx = hw;
     for (let ci = 0; ci < frozenColWidths.length; ci++) {
@@ -2276,7 +2338,7 @@ function renderHeaders(
   // Scrollable col headers
   ctx.save();
   ctx.beginPath();
-  ctx.rect(scrollAreaX, 0, canvasW - scrollAreaX, hh);
+  ctx.rect(mirrorX(scrollAreaX, canvasW - scrollAreaX), 0, canvasW - scrollAreaX, hh);
   ctx.clip();
   let cx = scrollAreaX - scrollOffsetX;
   for (let ci = 0; ci < scrollColWidths.length; ci++) {
@@ -2292,7 +2354,7 @@ function renderHeaders(
   if (frozenRowHeights.length > 0) {
     ctx.save();
     ctx.beginPath();
-    ctx.rect(0, hh, hw, frozenH);
+    ctx.rect(cornerX, hh, hw, frozenH);
     ctx.clip();
     let cy = hh;
     for (let ri = 0; ri < frozenRowHeights.length; ri++) {
@@ -2305,7 +2367,7 @@ function renderHeaders(
   // Scrollable row headers
   ctx.save();
   ctx.beginPath();
-  ctx.rect(0, scrollAreaY, hw, canvasH - scrollAreaY);
+  ctx.rect(cornerX, scrollAreaY, hw, canvasH - scrollAreaY);
   ctx.clip();
   let cy = scrollAreaY - scrollOffsetY;
   for (let ri = 0; ri < scrollRowHeights.length; ri++) {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -8,6 +8,7 @@ import { renderChart, renderSparkline, PT_TO_PX, EMU_PER_PX, mathToMathML, recol
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
+import { computeLineVisualOrder, cellBaseRtl } from './bidi-line.js';
 
 // Default font stack. Calibri is the workbook default font in Excel; on
 // systems without Office (macOS / Linux) the browser would otherwise fall
@@ -1639,6 +1640,9 @@ function renderQuadrant(
         else yy = cy + cellH - totalH - paddingY;
         ctx.textAlign = 'left';
         ctx.textBaseline = 'top';
+        // Bidi base direction for the cell (xf @readingOrder / first-strong).
+        const wrapBaseRtl = cellBaseRtl(xf.readingOrder, runs.map(r => r.text).join(''));
+        const dctxW = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
         for (const line of rLines) {
           const lineH = Math.round(line.maxFontSize * PT_TO_PX * 1.2);
           const totalW = line.segments.reduce((s, seg) => s + seg.width, 0);
@@ -1646,7 +1650,12 @@ function renderQuadrant(
           if (alignH === 'right') xx = cx + cellW - paddingX - totalW;
           else if (alignH === 'center') xx = cx + cellW / 2 - totalW / 2;
           else xx = cx + leftPad;
-          for (const seg of line.segments) {
+          // Draw the line's segments in visual order (rule L2).
+          const wvis = computeLineVisualOrder(line.segments, wrapBaseRtl);
+          for (let vi = 0; vi < line.segments.length; vi++) {
+            const li2 = wvis.order[vi];
+            const seg = line.segments[li2];
+            try { dctxW.direction = wvis.rtl[li2] ? 'rtl' : 'ltr'; } catch { /* ignore */ }
             ctx.font = buildFont(seg.font, cs);
             const segColor = cf.fontColor ?? seg.font.color;
             ctx.fillStyle = segColor ? hexToRgba(segColor) : '#000000';
@@ -1669,6 +1678,7 @@ function renderQuadrant(
           }
           yy += lineH;
         }
+        try { dctxW.direction = 'ltr'; } catch { /* ignore */ } // reset for next cell
       } else if (xf.wrapText) {
         const lines = wrapTextLines(ctx, text, cellW - leftPad - paddingX);
         const lineH = Math.round(font.size * PT_TO_PX * 1.2);
@@ -1709,8 +1719,17 @@ function renderQuadrant(
         if (alignV === 'top') { ctx.textBaseline = 'top'; textY = cy + paddingY; }
         else if (alignV === 'center') { ctx.textBaseline = 'middle'; textY = cy + cellH / 2; }
         else { ctx.textBaseline = 'bottom'; textY = cy + cellH - paddingY; }
+        // Bidi: draw the runs in visual order (UAX#9 rule L2) under the cell's
+        // base direction (xf @readingOrder, or first-strong for Context), each
+        // with ctx.direction set so Canvas shapes/orders it internally. The
+        // x-budget (totalWidth/startX) is order-independent.
+        const richBaseRtl = cellBaseRtl(xf.readingOrder, runs.map(r => r.text).join(''));
+        const richVis = computeLineVisualOrder(runs, richBaseRtl);
+        const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
         let runX = startX;
-        for (let i = 0; i < runs.length; i++) {
+        for (let vi = 0; vi < runs.length; vi++) {
+          const i = richVis.order[vi];
+          try { dctx.direction = richVis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ }
           const rf = drawRunFonts[i];
           const baseRf = baseRunFonts[i];
           ctx.font = buildFont(rf, cs);
@@ -1750,6 +1769,7 @@ function renderQuadrant(
           }
           runX += runWidths[i];
         }
+        try { dctx.direction = 'ltr'; } catch { /* ignore */ } // reset for next cell
       } else {
         // ECMA-376 §18.4.6 — cell-level super/subscript: render the glyphs at
         // ~65% size, shifted off the baseline so the cell still reads at the

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -8,7 +8,7 @@ import { renderChart, renderSparkline, PT_TO_PX, EMU_PER_PX, mathToMathML, recol
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
-import { computeLineVisualOrder, cellBaseRtl } from './bidi-line.js';
+import { computeLineVisualOrder, cellBaseRtl, segmentsHaveRtl } from './bidi-line.js';
 
 // Default font stack. Calibri is the workbook default font in Excel; on
 // systems without Office (macOS / Linux) the browser would otherwise fall
@@ -1618,11 +1618,14 @@ function renderQuadrant(
       if (letterSpacingPx > 0) {
         try { (ctx as CanvasRenderingContext2D & { letterSpacing: string }).letterSpacing = `${letterSpacingPx}px`; } catch { /* ignore */ }
       }
-      if (xf.readingOrder === 2) {
-        try { (ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' }).direction = 'rtl'; } catch { /* ignore */ }
-      } else if (xf.readingOrder === 1) {
-        try { (ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' }).direction = 'ltr'; } catch { /* ignore */ }
-      }
+      // §18.8.1 readingOrder: 1 = LTR, 2 = RTL, 0/absent = Context (first
+      // strong character decides). Always set the direction explicitly — the
+      // previous explicit-only ladder leaked the prior cell's direction into
+      // Context cells.
+      try {
+        (ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' }).direction =
+          cellBaseRtl(xf.readingOrder, text) ? 'rtl' : 'ltr';
+      } catch { /* ignore */ }
 
       // Rich text: draw each run with its own font. Only supported for the
       // non-wrap path (wrap with mixed fonts is significantly more complex).
@@ -1641,7 +1644,9 @@ function renderQuadrant(
         ctx.textAlign = 'left';
         ctx.textBaseline = 'top';
         // Bidi base direction for the cell (xf @readingOrder / first-strong).
-        const wrapBaseRtl = cellBaseRtl(xf.readingOrder, runs.map(r => r.text).join(''));
+        // Gated so pure-LTR cells keep the exact pre-bidi path.
+        const wrapNeedsBidi = xf.readingOrder === 2 || segmentsHaveRtl(runs);
+        const wrapBaseRtl = wrapNeedsBidi && cellBaseRtl(xf.readingOrder, runs.map(r => r.text).join(''));
         const dctxW = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
         for (const line of rLines) {
           const lineH = Math.round(line.maxFontSize * PT_TO_PX * 1.2);
@@ -1651,11 +1656,11 @@ function renderQuadrant(
           else if (alignH === 'center') xx = cx + cellW / 2 - totalW / 2;
           else xx = cx + leftPad;
           // Draw the line's segments in visual order (rule L2).
-          const wvis = computeLineVisualOrder(line.segments, wrapBaseRtl);
+          const wvis = wrapNeedsBidi ? computeLineVisualOrder(line.segments, wrapBaseRtl) : null;
           for (let vi = 0; vi < line.segments.length; vi++) {
-            const li2 = wvis.order[vi];
+            const li2 = wvis ? wvis.order[vi] : vi;
             const seg = line.segments[li2];
-            try { dctxW.direction = wvis.rtl[li2] ? 'rtl' : 'ltr'; } catch { /* ignore */ }
+            if (wvis) { try { dctxW.direction = wvis.rtl[li2] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
             ctx.font = buildFont(seg.font, cs);
             const segColor = cf.fontColor ?? seg.font.color;
             ctx.fillStyle = segColor ? hexToRgba(segColor) : '#000000';
@@ -1678,7 +1683,8 @@ function renderQuadrant(
           }
           yy += lineH;
         }
-        try { dctxW.direction = 'ltr'; } catch { /* ignore */ } // reset for next cell
+        // Defensive reset (the per-cell ctx.restore() also restores direction).
+        if (wrapNeedsBidi) { try { dctxW.direction = 'ltr'; } catch { /* ignore */ } }
       } else if (xf.wrapText) {
         const lines = wrapTextLines(ctx, text, cellW - leftPad - paddingX);
         const lineH = Math.round(font.size * PT_TO_PX * 1.2);
@@ -1722,14 +1728,17 @@ function renderQuadrant(
         // Bidi: draw the runs in visual order (UAX#9 rule L2) under the cell's
         // base direction (xf @readingOrder, or first-strong for Context), each
         // with ctx.direction set so Canvas shapes/orders it internally. The
-        // x-budget (totalWidth/startX) is order-independent.
-        const richBaseRtl = cellBaseRtl(xf.readingOrder, runs.map(r => r.text).join(''));
-        const richVis = computeLineVisualOrder(runs, richBaseRtl);
+        // x-budget (totalWidth/startX) is order-independent. Gated so pure-LTR
+        // cells keep the exact pre-bidi path (no per-repaint UAX#9 cost).
+        const richNeedsBidi = xf.readingOrder === 2 || segmentsHaveRtl(runs);
+        const richVis = richNeedsBidi
+          ? computeLineVisualOrder(runs, cellBaseRtl(xf.readingOrder, runs.map(r => r.text).join('')))
+          : null;
         const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
         let runX = startX;
         for (let vi = 0; vi < runs.length; vi++) {
-          const i = richVis.order[vi];
-          try { dctx.direction = richVis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ }
+          const i = richVis ? richVis.order[vi] : vi;
+          if (richVis) { try { dctx.direction = richVis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
           const rf = drawRunFonts[i];
           const baseRf = baseRunFonts[i];
           ctx.font = buildFont(rf, cs);
@@ -1769,7 +1778,8 @@ function renderQuadrant(
           }
           runX += runWidths[i];
         }
-        try { dctx.direction = 'ltr'; } catch { /* ignore */ } // reset for next cell
+        // Defensive reset (the per-cell ctx.restore() also restores direction).
+        if (richVis) { try { dctx.direction = 'ltr'; } catch { /* ignore */ } }
       } else {
         // ECMA-376 §18.4.6 — cell-level super/subscript: render the glyphs at
         // ~65% size, shifted off the baseline so the cell still reads at the

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -308,7 +308,6 @@ export class XlsxViewer {
 
   async showSheet(index: number): Promise<void> {
     this.currentSheet = index;
-    this.scrollHost.scrollLeft = 0;
     this.scrollHost.scrollTop = 0;
     this.anchorCell = null;
     this.activeCell = null;
@@ -317,8 +316,50 @@ export class XlsxViewer {
     this.updateTabActive(index);
     this.currentWorksheet = await this.workbook.getWorksheet(index);
     this.updateSpacerSize(this.currentWorksheet);
+    // Reset the horizontal scroll origin to the natural START of the sheet.
+    // For RTL sheets the start column (col A) lives at the RIGHT, which means
+    // the native scrollbar thumb must sit at its right end (max scrollLeft);
+    // for LTR sheets the start is scrollLeft=0. updateSpacerSize must run first
+    // so scrollWidth reflects the new sheet before we read the max offset.
+    this.resetHorizontalScroll();
     await this.renderCurrentSheet();
     this.opts.onSheetChange?.(index, this.workbook.sheetNames[index] ?? '');
+  }
+
+  /** True when the current sheet's grid is laid out right-to-left. */
+  private get isRtl(): boolean {
+    return this.currentWorksheet?.rightToLeft === true;
+  }
+
+  /** Maximum horizontal scroll offset the native scroll host allows (≥ 0). */
+  private get maxScrollLeft(): number {
+    return Math.max(0, this.scrollHost.scrollWidth - this.scrollHost.clientWidth);
+  }
+
+  /**
+   * The logical horizontal scroll position used to find the start-of-sheet
+   * (col A) edge, in *scaled* CSS pixels — the same unit as
+   * `scrollHost.scrollLeft`. The renderer always lays the grid out LTR and then
+   * mirrors it (ECMA-376 §18.3.1.87), so the viewer must hand it a position
+   * where 0 = the START of the sheet (col A) and increasing values reveal later
+   * columns.
+   *
+   * For LTR that is exactly the native `scrollLeft`. For RTL the sheet starts at
+   * the RIGHT, so the native scrollbar runs the opposite way: thumb fully right
+   * (`scrollLeft = maxScrollLeft`) is the start, thumb left is the far columns.
+   * Inverting here makes wheel/trackpad follow the finger and aligns the
+   * thumb↔page mapping with Excel, without depending on browser-specific RTL
+   * `scrollLeft` sign conventions.
+   */
+  private get effectiveScrollLeft(): number {
+    const raw = this.scrollHost.scrollLeft;
+    return this.isRtl ? this.maxScrollLeft - raw : raw;
+  }
+
+  /** Park the scrollbar at the sheet's natural start: scrollLeft=0 for LTR,
+   *  the right end for RTL (so col A shows first). */
+  private resetHorizontalScroll(): void {
+    this.scrollHost.scrollLeft = this.isRtl ? this.maxScrollLeft : 0;
   }
 
   /** 0-based index of the currently displayed sheet. */
@@ -415,7 +456,7 @@ export class XlsxViewer {
       }
       if (col === -1) return null;
     } else {
-      const contentX = innerX - frozenW + this.scrollHost.scrollLeft / cs;
+      const contentX = innerX - frozenW + this.effectiveScrollLeft / cs;
       col = -1;
       let acc = 0;
       for (let c = freezeCols + 1; c <= 16384; c++) {
@@ -461,7 +502,7 @@ export class XlsxViewer {
       const scrollAreaX = sp(HEADER_W) + frozenW;
 
       // Mirror renderCurrentSheet's startCol / offsetX search (binary search).
-      const logicalScrollX = this.scrollHost.scrollLeft / cs;
+      const logicalScrollX = this.effectiveScrollLeft / cs;
       const colAxis = getSheetAxes(ws, mdw).col;
       const { index: startCol, partial: offsetX } =
         colAxis.indexAt(logicalScrollX + colAxis.offsetOf(freezeCols + 1));
@@ -577,7 +618,7 @@ export class XlsxViewer {
       }
       return null;
     }
-    const contentX = innerX - frozenW + this.scrollHost.scrollLeft / cs;
+    const contentX = innerX - frozenW + this.effectiveScrollLeft / cs;
     let acc = 0;
     for (let c = freezeCols + 1; c <= 16384; c++) {
       acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws));
@@ -1086,7 +1127,18 @@ export class XlsxViewer {
     // The tab-nav block spans the row-header width, which scales with the cells.
     this.navGroup.style.width = `${Math.round(HEADER_W * next)}px`;
 
-    if (this.currentWorksheet) this.updateSpacerSize(this.currentWorksheet);
+    if (this.currentWorksheet) {
+      // Preserve the START-anchored effective scroll position across the zoom.
+      // The spacer (scrollWidth) is re-sized below, which changes maxScrollLeft;
+      // for RTL the native scrollLeft is the inverse of the effective position,
+      // so we must re-derive scrollLeft from the preserved effective value or
+      // the view would jump toward the start on every zoom step.
+      const prevEffective = this.effectiveScrollLeft;
+      this.updateSpacerSize(this.currentWorksheet);
+      if (this.isRtl) {
+        this.scrollHost.scrollLeft = Math.max(0, this.maxScrollLeft - prevEffective);
+      }
+    }
     void this.renderCurrentSheet();
     this.updateSelectionOverlay();
     this.updateNavButtons();
@@ -1152,8 +1204,10 @@ export class XlsxViewer {
     }
 
     // DOM scrollLeft/scrollTop are in scaled (physical) CSS pixels.
-    // Convert to logical pixels for cell-finding by dividing by cs.
-    const logicalScrollX = this.scrollHost.scrollLeft / cs;
+    // Convert to logical pixels for cell-finding by dividing by cs. For RTL
+    // sheets effectiveScrollLeft inverts the native scrollLeft so that 0 = col A
+    // at the (mirrored) right edge — see the getter for the rationale.
+    const logicalScrollX = this.effectiveScrollLeft / cs;
     const logicalScrollY = this.scrollHost.scrollTop / cs;
 
     // Find startCol / startRow in logical pixel space (binary search over the

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -17,6 +17,11 @@ import { renderViewport, prepareWorksheetMath, worksheetHasUncachedMath } from '
  *  that lacks the Office face keeps text width measurements close to
  *  Excel's. The substitute font-family differs from the requested name, so
  *  `loadFamily` redirects FontFaceSet loading appropriately. */
+const NOTO_NASKH_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic:wght@400;700&display=swap';
+const NOTO_SANS_ARABIC_URL =
+  'https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@400;700&display=swap';
+
 const XLSX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'calibri': {
     url: 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap',
@@ -26,6 +31,21 @@ const XLSX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
     url: 'https://fonts.googleapis.com/css2?family=Caladea:ital,wght@0,400;0,700;1,400;1,700&display=swap',
     loadFamily: 'Caladea',
   },
+  // Common Arabic-script faces that hosts rarely ship. Map them to Noto
+  // substitutes so RTL workbooks (e.g. the LibreOffice-authored sample-29,
+  // which requests Sakkal Majalla / Univers Next Arabic) render with a real
+  // web font instead of an oversized OS fallback. "Naskh" covers traditional
+  // serif-like Arabic faces; "Sans" covers the modern geometric ones.
+  'sakkal majalla': { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'traditional arabic': { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'simplified arabic': { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'arabic typesetting': { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'univers next arabic': { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
+  // Self-referencing entries so the generic Arabic fallback fonts (appended to
+  // the renderer's font chain) are themselves loaded whenever useGoogleFonts
+  // is enabled — see `_load`, which always queues these names.
+  'noto naskh arabic': { url: NOTO_NASKH_ARABIC_URL, loadFamily: 'Noto Naskh Arabic' },
+  'noto sans arabic': { url: NOTO_SANS_ARABIC_URL, loadFamily: 'Noto Sans Arabic' },
 };
 
 /** Options for {@link XlsxWorkbook.load}. The shared load-options type from
@@ -91,6 +111,11 @@ export class XlsxWorkbook {
       for (const f of this.parsedWorkbook.styles?.fonts ?? []) {
         if (f.name) names.add(f.name);
       }
+      // Always load the generic Arabic fallbacks so any Arabic-script cell
+      // gets a real web font even when its named family is unmapped (the
+      // renderer's DEFAULT_FONT_FAMILY chain ends with these two Noto faces).
+      names.add('Noto Naskh Arabic');
+      names.add('Noto Sans Arabic');
       await preloadGoogleFonts(names, XLSX_GOOGLE_FONTS);
     }
   }


### PR DESCRIPTION
## Summary

The RTL series (issue #366) was staged as a stack of renderer PRs — #368 (docx renderer RTL), #369 (pptx), #370 (xlsx) — that were merged into `feature/rtl-core` instead of into `main`. This PR delivers all three renderer integrations to `main`, resolving the overlaps with the work that landed on `main` in the meantime: #371 (zero-line-spacing), #372 (table autofit), #373 (marker cleanup), and #374 (rtl docx follow-ups).

All merge conflicts were in the docx package. They are resolved in favor of the spec-faithful complex-script implementation, while keeping #374's genuine improvements.

## Conflict resolution

**`packages/docx/src/renderer.ts`**
- Keep HEAD's per-segment complex-script logic in `buildSegments`: `forceCs`, `csFontSize`/`csFontFamily`/`csBold`/`csItalic` (each falling back to its Latin counterpart), `digitsAsAN` (+ `splitDigitGroups`), and `splitByComplexScript` mixed-script splitting, plus the per-segment `rtl` flag.
- **Revert #374's `effectiveRunStyle()` simplification.** That run-level helper dropped `forceCs`, `digitsAsAN`, mixed-script splitting and the per-segment `rtl` flag — regressing Word-style date reordering (28-02-2026 → 2026-02-28), `szCs` sizing of Arabic in non-rtl runs, and run-level RTL bidi. The function and both its call sites are removed; the `cellMinContentPt` measurement path now inlines the same cs-axis resolution as `buildSegments`.
- **Keep #374's column min-width fix** (`cellMinContentPt` / `resolveColumnWidths`: autofit columns never fall below the widest atomic token; gridSpan min distribution). It coexists with HEAD's `renderTable` `bidiVisual` mirroring.

**`packages/docx/parser/src/{parser.rs, styles.rs, types.rs}`**
- Keep HEAD's `bCs`/`iCs` + `lang_bidi` (`w:lang/@w:bidi`) parsing and the §17.3.2.18 `szCs` mirroring through the full style chain (a directly-set `w:sz` with no accompanying `w:szCs` mirrors into the cs size).
- Drop main's duplicate `bCs`/`iCs` fields/parsing where they overlap.
- Keep BOTH sides' tests (17 parser tests pass).

## cs-bold semantics (PDF-verified)

The complex-script bold fallback **mirrors** the non-cs axis: `csBold = boldCs ?? base.bold` — NOT #374's `boldCs ?? false`. Ground truth: sample-7 page-1 heading runs carry `w:b` WITHOUT `w:bCs` and render **bold** in Word. The parser still surfaces `bold_cs == None` when `w:bCs` is absent; the mirror happens in the renderer. The main-side parser test was adapted to the mirror semantics with a comment explaining the PDF-verified behavior.

## Verification

- `cargo test` (docx parser): 17/17 pass
- `vitest` docx + core: 105/105 pass
- `vitest` pptx + xlsx (RTL renderers untouched by this merge): 41/41 pass
- `tsc --noEmit`: docx and core both clean
- docx demo VRT: 6/6 pass
- sample-7 page 1: list markers ".1"/".2" each on one bold visual line (the digit/dot split bug did NOT reproduce); matches the PDF
- sample-7 page 2: dates "2026-02-28" etc. each on one line, columns aligned to PDF boundaries, header band white text vertically centered and bold, data-cell Arabic same face as header

🤖 Generated with [Claude Code](https://claude.com/claude-code)