### PR TITLE
fix(xlsx): keep RTL selection overlay glued to its cell on scroll

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -40,6 +40,32 @@ const MDW_FALLBACK = 8;
 export const HEADER_W = 50;
 export const HEADER_H = 22;
 
+/**
+ * Sheet-level right-to-left horizontal mirror (ECMA-376 §18.3.1.87
+ * `<sheetView rightToLeft>`). The grid is always laid out left-to-right
+ * internally; an RTL sheet is produced by mirroring every horizontal extent
+ * about the canvas width. A left-anchored rect `[x, x + w]` maps to
+ * `[canvasW - x - w, canvasW - x]`.
+ *
+ * Because the LTR layout puts the row-header strip at `[0, HEADER_W]` and the
+ * cell area at `[HEADER_W, canvasW]`, mirroring moves the header strip to the
+ * right edge and the cell area to `[0, canvasW - HEADER_W]`, matching Excel.
+ *
+ * This is the SINGLE source of truth for the RTL x transform. The Canvas
+ * renderer, the selection overlay, and pointer hit-testing must all use it so
+ * that a cell drawn at screen-x is the same cell a click at screen-x resolves
+ * to, at every scroll offset. `canvasW` is the CSS-pixel width of the drawing
+ * surface (`canvasArea.clientWidth`), identical to `ctx.canvas.width / dpr`.
+ *
+ * The transform is an involution: applying it to a screen point recovers the
+ * logical-LTR point (`rtlMirrorX(rtlMirrorX(x, w, W), w, W) === x`), so the
+ * same function serves both cell→px (draw) and px→cell (hit-test, with w = 0
+ * for a point).
+ */
+export function rtlMirrorX(x: number, w: number, canvasW: number): number {
+  return canvasW - x - w;
+}
+
 // Thin line drawn between frozen and scrollable areas
 const FREEZE_LINE_COLOR = '#7a7a7a';
 
@@ -1017,7 +1043,7 @@ function renderQuadrant(
   // to every column x (so fills, borders, gridlines, text positions, merge
   // spans and the clip rect all mirror) while leaving glyphs un-flipped and
   // cell-level left/right alignment physical.
-  const mirrorX = (x: number, w: number): number => rc.rtl ? rc.canvasW - x - w : x;
+  const mirrorX = (x: number, w: number): number => rc.rtl ? rtlMirrorX(x, w, rc.canvasW) : x;
 
   // Canvas x for each column
   const colXs: number[] = [];
@@ -2277,7 +2303,7 @@ function renderHeaders(
   // canvasW: a left-anchored col-header rect [x, x+w] maps to its mirror.
   // The corner box and the row-number strip move from the left edge
   // ([0, hw]) to the right edge ([canvasW - hw, canvasW]).
-  const mirrorX = (x: number, w: number): number => rtl ? canvasW - x - w : x;
+  const mirrorX = (x: number, w: number): number => rtl ? rtlMirrorX(x, w, canvasW) : x;
   const cornerX = rtl ? canvasW - hw : 0;  // x-origin of the corner / row-header strip
 
   // Corner – draw all 4 edges (standalone box)

--- a/packages/xlsx/src/rtl-mirror.test.ts
+++ b/packages/xlsx/src/rtl-mirror.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { rtlMirrorX, HEADER_W } from './renderer.js';
+
+/**
+ * Regression tests for the RTL selection / hit-testing bug (ECMA-376
+ * §18.3.1.87 `<sheetView rightToLeft>`): selecting a cell then scrolling
+ * horizontally made the blue selection frame drift away from its cell, because
+ * the overlay was positioned in the logical-LTR layout while the renderer drew
+ * the cell mirrored about `canvasW`.
+ *
+ * The fix routes the renderer, the selection overlay (cell→px) and pointer
+ * hit-testing (px→cell) through one shared transform, `rtlMirrorX`. These tests
+ * pin the properties that guarantee the overlay tracks its cell at every scroll
+ * offset and that a click resolves to the cell drawn under the cursor.
+ */
+describe('rtlMirrorX', () => {
+  const canvasW = 800;
+
+  it('maps a left-anchored rect to its mirror about canvasW', () => {
+    // LTR rect [x, x+w] -> RTL [canvasW - x - w, canvasW - x].
+    expect(rtlMirrorX(0, 50, canvasW)).toBe(750); // header strip -> right edge
+    expect(rtlMirrorX(50, 100, canvasW)).toBe(650);
+    expect(rtlMirrorX(200, 80, canvasW)).toBe(520);
+  });
+
+  it('moves the row-header strip to the right edge', () => {
+    // LTR header occupies [0, HEADER_W]; mirrored it must sit flush at the
+    // right: [canvasW - HEADER_W, canvasW].
+    expect(rtlMirrorX(0, HEADER_W, canvasW)).toBe(canvasW - HEADER_W);
+  });
+
+  it('is an involution for a point (w = 0): un-mirror recovers the point', () => {
+    for (const sx of [0, 50, 137, 400, 799, canvasW]) {
+      expect(rtlMirrorX(rtlMirrorX(sx, 0, canvasW), 0, canvasW)).toBe(sx);
+    }
+  });
+
+  it('round-trips a rect: mirror then mirror returns the original left edge', () => {
+    for (const [x, w] of [[50, 60], [120, 24], [333, 17]] as const) {
+      const screenLeft = rtlMirrorX(x, w, canvasW);
+      // The inverse maps the screen-left + width band back to the logical left.
+      expect(rtlMirrorX(screenLeft, w, canvasW)).toBe(x);
+    }
+  });
+
+  /**
+   * Core regression: simulate cell→px (overlay) and px→cell (click) using the
+   * SAME transform across several horizontal scroll offsets and assert the
+   * selection rect equals the cell rect at every offset — i.e. the frame stays
+   * glued to its cell while scrolling, in both directions and across the
+   * maxScrollLeft boundary. This is the exact divergence the bug exhibited.
+   */
+  it('keeps the selection rect glued to its cell across scroll offsets', () => {
+    const colW = 64;
+    const maxScrollLeft = 1000;
+
+    // Logical-LTR x of a fixed cell's left edge as a function of the logical
+    // scroll position (header + columns scrolled past). This is the same
+    // formula getCellRect uses (scrollAreaX - scrollOffset + cell offset).
+    const logicalCellX = (logicalScroll: number, cellIndexFromStart: number) =>
+      HEADER_W - logicalScroll + cellIndexFromStart * colW;
+
+    for (const rawScroll of [0, 64, 256, 640, maxScrollLeft]) {
+      // RTL inverts the native scrollbar: effective (logical) scroll = max-raw.
+      const logicalScroll = maxScrollLeft - rawScroll;
+      const cellIndex = 3;
+
+      // cell -> px (overlay): build the LTR rect, then mirror to screen.
+      const ltrX = logicalCellX(logicalScroll, cellIndex);
+      const screenLeft = rtlMirrorX(ltrX, colW, canvasW);
+
+      // px -> cell (hit-test): take a click at the cell's on-screen centre,
+      // un-mirror it back into logical-LTR space, and confirm it lands inside
+      // the same LTR cell band [ltrX, ltrX + colW].
+      const clickScreenX = screenLeft + colW / 2;
+      const clickLogicalX = rtlMirrorX(clickScreenX, 0, canvasW);
+      expect(clickLogicalX).toBeGreaterThanOrEqual(ltrX);
+      expect(clickLogicalX).toBeLessThanOrEqual(ltrX + colW);
+
+      // And the overlay's screen band exactly covers the click point: the rect
+      // the user sees is the rect the click resolves into.
+      expect(clickScreenX).toBeGreaterThanOrEqual(screenLeft);
+      expect(clickScreenX).toBeLessThanOrEqual(screenLeft + colW);
+    }
+  });
+
+  it('selection screen-x moves opposite to the logical-LTR x under RTL', () => {
+    // Scrolling that increases the logical-LTR x of a cell must DECREASE its
+    // on-screen left edge (the grid moves right-to-left). The old code used the
+    // LTR x directly for the overlay, so it moved the wrong way — the bug.
+    const colW = 64;
+    const xA = rtlMirrorX(HEADER_W + 100, colW, canvasW);
+    const xB = rtlMirrorX(HEADER_W + 200, colW, canvasW);
+    expect(xB).toBeLessThan(xA);
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,7 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { ViewportRange, Worksheet } from './types.js';
 import type { MathRenderer } from '@silurus/ooxml-core';
-import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, getMdwForWorksheet } from './renderer.js';
+import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 
 const TAB_BAR_H = 30;
 // Gap between adjacent sheet tabs. The first tab also gets this much leading
@@ -356,6 +356,20 @@ export class XlsxViewer {
     return this.isRtl ? this.maxScrollLeft - raw : raw;
   }
 
+  /**
+   * Map between the logical-LTR x used by all the cell-geometry math and the
+   * on-screen (canvasArea CSS-pixel) x, applying the RTL mirror (ECMA-376
+   * §18.3.1.87) via the same {@link rtlMirrorX} the renderer uses. For LTR this
+   * is the identity. The mirror is an involution, so this one method serves
+   * both cell→px (overlay draw, `w` = cell width) and px→cell (pointer
+   * hit-testing, `w` = 0 for a point) — guaranteeing the overlay sits exactly
+   * where the cell is drawn and a click resolves to that same cell at every
+   * scroll offset. `canvasArea.clientWidth` equals the renderer's `canvasW`.
+   */
+  private screenX(logicalX: number, w: number): number {
+    return this.isRtl ? rtlMirrorX(logicalX, w, this.canvasArea.clientWidth) : logicalX;
+  }
+
   /** Park the scrollbar at the sheet's natural start: scrollLeft=0 for LTR,
    *  the right end for RTL (so col A shows first). */
   private resetHorizontalScroll(): void {
@@ -397,7 +411,11 @@ export class XlsxViewer {
     const cs = this.opts.cellScale ?? 1;
 
     const rect = this.canvasArea.getBoundingClientRect();
-    const lx = (clientX - rect.left) / cs;
+    // Un-mirror the screen x into the logical-LTR layout the geometry below
+    // assumes (header on the left). screenX is an involution, so applying it to
+    // a screen point recovers the logical point; w = 0 for a point. Done in
+    // scaled CSS px (canvasArea space) before converting to logical px.
+    const lx = this.screenX(clientX - rect.left, 0) / cs;
     const ly = (clientY - rect.top) / cs;
 
     if (lx < HEADER_W || ly < HEADER_H) return null;
@@ -563,7 +581,9 @@ export class XlsxViewer {
     if (!ws) return null;
     const cs = this.opts.cellScale ?? 1;
     const rect = this.canvasArea.getBoundingClientRect();
-    const lx = (clientX - rect.left) / cs;
+    // Same RTL un-mirror as getCellAt: map the screen x back to the logical-LTR
+    // layout (row header on the left) before the header math below.
+    const lx = this.screenX(clientX - rect.left, 0) / cs;
     const ly = (clientY - rect.top) / cs;
 
     const inRowHeader = lx < HEADER_W;
@@ -756,10 +776,20 @@ export class XlsxViewer {
     if (selR1 > freezeRows && y < frozenBoundY) { h -= frozenBoundY - y; y = frozenBoundY; }
 
     if (w <= 0 || h <= 0) return;
+
+    // The rect above is in the logical-LTR layout (header on the left), the
+    // same space getCellRect / the all|rows|cols branches use. For an RTL sheet
+    // the renderer mirrors every cell about canvasW (ECMA-376 §18.3.1.87), so
+    // mirror the final [x, x+w] band once with the same transform the renderer
+    // uses. Doing it here — after the LTR clamps — keeps the header/frozen
+    // clamping correct and guarantees the overlay lands exactly on the drawn
+    // cell at every scroll offset (cell→px uses the same map as px→cell above).
+    const screenLeft = this.screenX(x, w);
+
     const box = document.createElement('div');
     box.style.cssText =
       `position:absolute;` +
-      `left:${x}px;top:${y}px;width:${w}px;height:${h}px;` +
+      `left:${screenLeft}px;top:${y}px;width:${w}px;height:${h}px;` +
       `box-sizing:border-box;border:2px solid #1a73e8;` +
       `background:rgba(26,115,232,0.08);pointer-events:none;`;
     this.selectionOverlay.appendChild(box);


### PR DESCRIPTION
## Bug

On an RTL sheet (`sheetView rightToLeft`, ECMA-376 §18.3.1.87), selecting a cell then scrolling horizontally made the blue selection frame fly off to a **different** location than its cell — it did not follow the scroll. The grid itself scrolled correctly (the RTL scroll mapping was already in place); only the selection overlay diverged.

## Root cause

The selection overlay (`getCellRect` → `updateSelectionOverlay`) and pointer hit-testing (`getCellAt` / `getHeaderHit`) computed cell geometry in the **logical-LTR layout** (row header on the left, columns increasing rightward) and used the raw x directly. But the renderer mirrors every cell about `canvasW` for an RTL sheet — `mirrorX(x, w) = canvasW - x - w` — so the cell is *drawn* at the mirrored position. At one scroll offset the LTR x and the mirrored x happen to coincide; as the user scrolls they move in opposite screen directions and diverge increasingly, which is the "flies off" behaviour. Hit-testing had the matching gap: it measured `innerX = lx - HEADER_W` from the left even though under RTL the row-header strip moves to the **right** edge and the cell area is `[0, canvasW - HEADER_W]`.

## Fix

Introduce one shared transform, `rtlMirrorX(x, w, canvasW)`, exported from `renderer.ts` as the single source of truth for the RTL x mirror. The renderer's two inline `mirrorX` helpers now delegate to it, and the viewer applies it at the logical↔screen boundary via a new `screenX()` helper. Because the mirror is an involution, the same function:

- mirrors a logical-LTR cell rect → screen x for the overlay (cell→px), and
- un-mirrors a screen click → logical-LTR x for hit-testing (px→cell),

so a cell drawn at screen-x is exactly the cell a click at screen-x resolves to, at every scroll offset. The viewer keeps all its existing logical-LTR geometry and header/frozen-pane clamping and mirrors once at the end. LTR is the identity → non-RTL sheets are unaffected. No special-casing of "selection only" and no empirical constants.

## Tests

- New `packages/xlsx/src/rtl-mirror.test.ts`: pins `rtlMirrorX` (mirror, header-to-right-edge, involution, rect round-trip) and the core regression — across several scroll offsets it asserts the cell→px overlay band and the px→cell hit-test resolve to the **same** cell, and that the on-screen x moves opposite to the logical-LTR x under RTL (the old wrong direction).
- `npx vitest run packages/xlsx`: 38 passed.
- `pnpm exec tsc --noEmit` (packages/xlsx): clean.
- xlsx demo VRT (`-g demo`): 5/5 at 100% match (LTR unaffected).

## Manual verification

Loaded an RTL sheet (`sheetView rightToLeft`) in a viewer harness, programmatically selected a cell, then scrolled horizontally in both directions and across the `maxScrollLeft` boundary. Before/after screenshots confirm the blue frame stays glued to its cell as the grid moves; at every offset a hit-test at the overlay's centre returns the selected cell. Column-header selection and select-all overlays also land correctly under RTL. An LTR demo sheet behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)