### PR TITLE
fix(docx): cs formatting is forced by the <w:cs/> toggle, not rFonts@cs

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1149,6 +1149,7 @@ fn parse_run_inner(
     // cs font goes through the same theme-ref resolution as the ascii/eastAsia
     // axes so consumers receive a literal family.
     let rtl = fmt.rtl;
+    let cs_toggle = fmt.cs_toggle;
     let font_family_cs = theme.resolve_font_ref(fmt.font_family_cs.clone());
     let font_size_cs = fmt.font_size_cs;
     // Complex-script bold / italic (ECMA-376 §17.3.2.3 / §17.3.2.17) and the
@@ -1186,6 +1187,7 @@ fn parse_run_inner(
                         ruby: None,
                         revision: revision.cloned(),
                         rtl,
+                        cs: cs_toggle,
                         font_family_cs: font_family_cs.clone(),
                         font_size_cs,
                         bold_cs,
@@ -1216,6 +1218,7 @@ fn parse_run_inner(
                     ruby: None,
                     revision: revision.cloned(),
                     rtl,
+                    cs: cs_toggle,
                     font_family_cs: font_family_cs.clone(),
                     font_size_cs,
                     bold_cs,
@@ -1315,6 +1318,7 @@ fn parse_run_inner(
                     ruby: None,
                     revision: revision.cloned(),
                     rtl,
+                    cs: cs_toggle,
                     font_family_cs: font_family_cs.clone(),
                     font_size_cs,
                     bold_cs,
@@ -2724,6 +2728,7 @@ fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
     if direct.background.is_some() { base.background = direct.background.clone(); }
     if direct.vert_align.is_some() { base.vert_align = direct.vert_align.clone(); }
     if direct.rtl.is_some() { base.rtl = direct.rtl; }
+    if direct.cs_toggle.is_some() { base.cs_toggle = direct.cs_toggle; }
     if direct.font_family_cs.is_some() { base.font_family_cs = direct.font_family_cs.clone(); }
     if direct.bold_cs.is_some() { base.bold_cs = direct.bold_cs; }
     if direct.italic_cs.is_some() { base.italic_cs = direct.italic_cs; }
@@ -2864,6 +2869,45 @@ mod tests {
         );
         assert_eq!(t.width_pt, None);
         assert_eq!(t.width_pct, None);
+    }
+}
+
+#[cfg(test)]
+mod cs_toggle_tests {
+    use super::*;
+
+    fn run_of(body_inner: &str) -> TextRun {
+        let xml = format!(
+            r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{body_inner}</w:body></w:document>"#
+        );
+        let doc = XmlDoc::parse(&xml).unwrap();
+        let body = doc.root_element().descendants().find(|n| n.tag_name().name() == "body").unwrap();
+        let style_map = StyleMap::parse("");
+        let mut num_map = NumberingMap::default();
+        let elems = parse_body_elements(body, &style_map, &mut num_map, &HashMap::new(), &HashMap::new(), &ThemeColors::default());
+        for e in elems {
+            if let BodyElement::Paragraph(p) = e {
+                for r in p.runs {
+                    if let DocRun::Text(t) = r { return t; }
+                }
+            }
+        }
+        panic!("no text run");
+    }
+
+    #[test]
+    fn cs_element_sets_run_cs_toggle() {
+        // §17.3.2.7 <w:cs/> — the complex-script run toggle.
+        let run = run_of(r#"<w:p><w:r><w:rPr><w:cs/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
+        assert_eq!(run.cs, Some(true));
+    }
+
+    #[test]
+    fn rfonts_cs_attribute_does_not_set_the_toggle() {
+        // rFonts@cs is only a font SLOT (§17.3.2.26) — it must not force cs.
+        let run = run_of(r#"<w:p><w:r><w:rPr><w:rFonts w:cs="Arial"/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
+        assert_eq!(run.cs, None);
+        assert_eq!(run.font_family_cs.as_deref(), Some("Arial"));
     }
 }
 

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -30,6 +30,9 @@ pub struct RunFmt {
     /// content. Phase 0 of RTL support only records the flag; alignment /
     /// glyph-order resolution is deferred to a later PR.
     pub rtl: Option<bool>,
+    /// ECMA-376 §17.3.2.7 `<w:cs/>` — treat the run as complex-script,
+    /// applying the cs formatting axis to ALL its characters (§17.3.2.26).
+    pub cs_toggle: Option<bool>,
     /// ECMA-376 §17.3.2.26 w:rFonts/@w:cs — complex-script typeface. Parallel
     /// to `font_family_ascii` / `font_family_east_asia`; carries the same
     /// "@theme:<ref>" marker convention for @cstheme references.
@@ -697,6 +700,9 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
 
     // Complex-script / RTL run (ECMA-376 §17.3.2.30 w:rtl). On-off toggle.
     fmt.rtl = bool_prop(rpr, "rtl");
+    // §17.3.2.7 w:cs — complex-script run toggle (distinct from rFonts@cs,
+    // which is only a font SLOT and must not force cs formatting).
+    fmt.cs_toggle = bool_prop(rpr, "cs");
 
     fmt
 }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -541,6 +541,10 @@ pub struct TextRun {
     /// Phase 0: recorded only; glyph-order resolution is deferred.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtl: Option<bool>,
+    /// ECMA-376 §17.3.2.7 `<w:cs/>` — complex-script run toggle: cs
+    /// formatting applies to ALL characters of the run (§17.3.2.26).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cs: Option<bool>,
     /// ECMA-376 §17.3.2.26 `<w:rFonts w:cs>` — complex-script typeface (theme
     /// references resolved to a literal family). `None` when unspecified.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -852,12 +852,14 @@ function cellMinContentPt(cell: DocTableCell, table: DocTable, state: RenderStat
       const t = run as unknown as DocxTextRun & { type: 'text' };
       if (!t.text) continue;
       // Resolve the complex-script (cs) axis the same way `buildSegments` does
-      // (ECMA-376 §17.3.2.3/§17.3.2.17/§17.3.2.18): a run forcing cs (w:rtl or an
-      // explicit cs font) measures with the cs bold/italic/size/family, each
-      // falling back to its Latin counterpart when absent. We pick the cs axis
-      // for the min-content estimate when the run forces cs so wide Arabic/Hebrew
-      // tokens reserve enough column width; otherwise the Latin axis.
-      const forceCs = t.rtl === true || t.fontFamilyCs != null;
+      // (ECMA-376 §17.3.2.3/§17.3.2.17/§17.3.2.18): a run forcing cs (w:rtl or
+      // the §17.3.2.7 <w:cs/> toggle) measures with the cs bold/italic/size/
+      // family, each falling back to its Latin counterpart when absent. We pick
+      // the cs axis for the min-content estimate when the run forces cs so wide
+      // Arabic/Hebrew tokens reserve enough column width; otherwise the Latin
+      // axis. NOTE rFonts@cs alone is just a font SLOT — it must not force cs
+      // (a Latin heading whose style defines cstheme would wrongly take szCs).
+      const forceCs = t.rtl === true || t.cs === true;
       const effBold = forceCs ? (t.boldCs ?? t.bold) : t.bold;
       const effItalic = forceCs ? (t.italicCs ?? t.italic) : t.italic;
       const effFontSize = forceCs ? (t.fontSizeCs ?? t.fontSize) : t.fontSize;
@@ -1762,11 +1764,14 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
     const r = base as DocxTextRun;
     const rtl = r.rtl === true ? true : undefined;
 
-    // ECMA-376 §17.3.2.26 content classification. A run with `w:rtl` (§17.3.2.30)
-    // or an explicit complex-script font (`w:rFonts w:cs`) applies complex-script
+    // ECMA-376 §17.3.2.26 content classification. A run with `w:rtl`
+    // (§17.3.2.30) or the `<w:cs/>` toggle (§17.3.2.7) applies complex-script
     // formatting to ALL of its characters; otherwise each character is routed by
     // its Unicode block (Arabic/Hebrew/... → cs; Latin/digits/CJK → ascii/hAnsi).
-    const forceCs = r.rtl === true || r.fontFamilyCs != null;
+    // NOTE rFonts@cs (fontFamilyCs) alone is just a font SLOT and must NOT
+    // force cs — e.g. sample-1's Heading1 (Latin) has cstheme + szCs=52 but
+    // renders at w:sz=24; forcing cs blew its size up to 26pt.
+    const forceCs = r.rtl === true || r.cs === true;
 
     // Complex-script (cs) formatting sources, each falling back to its Latin
     // counterpart when the cs-specific property is absent (the parser already

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -348,6 +348,10 @@ export interface DocxTextRun {
    *  `true` = RTL, `false` = explicitly LTR, absent = unspecified.
    *  Phase 0: recorded only; glyph-order resolution is deferred. */
   rtl?: boolean;
+  /** ECMA-376 §17.3.2.7 `<w:cs/>` — complex-script run toggle: cs formatting
+   *  applies to ALL characters of the run (§17.3.2.26). Distinct from
+   *  `rFonts@cs` (`fontFamilyCs`), which is only a font slot. */
+  cs?: boolean;
   /** ECMA-376 §17.3.2.26 `<w:rFonts w:cs>` — complex-script typeface
    *  (theme references resolved to a literal family). */
   fontFamilyCs?: string;


### PR DESCRIPTION
Regression report: private/sample-1's blue Heading1 rendered at the wrong size after the RTL consolidation.

Root cause: `forceCs` keyed on `fontFamilyCs != null`, conflating the `rFonts@cs` font SLOT (populated for plain Latin runs via style-chain `cstheme`) with the `<w:cs/>` complex-script toggle (§17.3.2.7). Heading1 (Latin, `sz=24`, `szCs=52`, `cstheme="majorBidi"`) got forced onto the cs axis → 26pt instead of 12pt.

Fix: parse `<w:cs/>` through the style chain like `w:rtl`, surface as `run.cs`, key `forceCs = rtl || cs` (per §17.3.2.26) in both buildSegments and the autofit min-content path.

Private VRT (vs Word-export references): sample-1 87.4→90.3, sample-2 94.7→95.7, sample-3 90.4→91.3, sample-4 92.1→92.5, sample-5 improvements across pages; demo 6/6 at 100%. RTL sample-7 unaffected (its cs runs carry explicit `<w:cs/>`). cargo 23/23, vitest 110/110, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)