### PR TITLE
fix(pptx): scope Arabic Noto fallback to Arabic-script faces (Latin no longer serif)

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -443,10 +443,30 @@ const OFFICE_FONT_SUBSTITUTE: Record<string, string> = {
   'univers next arabic': 'Noto Sans Arabic',
 };
 
-/** Generic Arabic fallbacks appended to every named-font canvas stack (before
- *  the CSS generic) so Arabic-script glyphs in an unmapped family still resolve
- *  to a real Arabic web font when `useGoogleFonts` is on. */
+/** Generic Arabic fallbacks appended to an Arabic-script font's canvas stack
+ *  (before the CSS generic) so Arabic glyphs in an Arabic-targeted family that
+ *  the host lacks still resolve to a real Arabic web font when `useGoogleFonts`
+ *  is on. */
 const ARABIC_FALLBACKS = '"Noto Naskh Arabic", "Noto Sans Arabic"';
+
+/**
+ * True when `family` names an Arabic-script face. Only such faces get the Noto
+ * Arabic web fonts appended to their canvas stack.
+ *
+ * These fallback faces (esp. Noto Naskh Arabic) also carry serif-style *Latin*
+ * glyphs, so appending them to every font stack made Latin text in an
+ * uninstalled Latin/CJK face (e.g. a Japanese gothic carrying "About us") fall
+ * into the serif Naskh face instead of degrading to the sans-serif generic.
+ * Gating on Arabic-script faces keeps RTL decks (Amiri, Sakkal Majalla, …)
+ * correct while letting Latin/CJK text degrade to the right generic.
+ */
+function isArabicScriptFace(family: string): boolean {
+  // Faces we explicitly substitute to a Noto Arabic web font are Arabic-script.
+  if (OFFICE_FONT_SUBSTITUTE[family.toLowerCase()]?.includes('Arabic')) return true;
+  const l = family.toLowerCase();
+  // Common Arabic-script family-name markers (Latin transliterations + Arabic).
+  return /arabic|naskh|kufi|nastaliq|amiri|scheherazade|lateef|aldhabi|urdu|farsi|العرب|[؀-ۿ]/.test(l);
+}
 
 function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string, rc: RenderContext): string {
   const style  = italic ? 'italic ' : '';
@@ -455,12 +475,14 @@ function buildFont(bold: boolean, italic: boolean, sizePx: number, family: strin
   if (CSS_GENERIC_FAMILIES.has(normalized)) {
     return `${style}${weight}${sizePx}px ${normalized}`;
   }
-  // Named font + (metric-compatible substitute, if an Office face) + generic
-  // Arabic web fonts + inferred generic fallback, so browsers degrade
-  // consistently when the exact typeface is not installed.
+  // Named font + (metric-compatible substitute, if an Office face) + Arabic web
+  // fonts (only for Arabic-script faces — see isArabicScriptFace) + inferred
+  // generic fallback, so browsers degrade consistently when the exact typeface
+  // is not installed.
   const sub = OFFICE_FONT_SUBSTITUTE[normalized.toLowerCase()];
   const subPart = sub ? `"${sub}", ` : '';
-  return `${style}${weight}${sizePx}px "${normalized}", ${subPart}${ARABIC_FALLBACKS}, ${genericFallback(normalized)}`;
+  const arabicPart = isArabicScriptFace(normalized) ? `${ARABIC_FALLBACKS}, ` : '';
+  return `${style}${weight}${sizePx}px "${normalized}", ${subPart}${arabicPart}${genericFallback(normalized)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Latin text in `private/sample-1.pptx` slide 2 (heading **About us**, the **RakuRakuEC** in "プロダクト概要 - RakuRakuEC") regressed from sans-serif to **serif** within the RTL merge window. PowerPoint renders these sans-serif.

## Root cause

Commit `f272a77` (feat(pptx): wire Arabic Noto fallback web fonts under useGoogleFonts, PR #369) changed `buildFont` in `packages/pptx/src/renderer.ts:463` to append `"Noto Naskh Arabic", "Noto Sans Arabic"` to **every** named-font canvas stack:

```
`… "${normalized}", ${subPart}${ARABIC_FALLBACKS}, ${genericFallback(normalized)}`
```

Both runs use `<a:latin typeface="+mn-ea"/>`, which resolves to the deck's theme minor font `FOT-筑紫A丸ゴシック Std B` (a Japanese gothic, not installed on most hosts). Canvas font fallback is per-glyph: with the JP font absent, the Latin glyphs match the next available stack entry — **Noto Naskh Arabic**, whose Latin glyphs are serif-style — instead of falling through to the trailing `sans-serif` generic.

## Fix

Gate the Arabic fallback on a new `isArabicScriptFace()` check. Only Arabic-script faces — those substituted to a Noto Arabic web font, or whose name marks Arabic script (`arabic`/`naskh`/`kufi`/`amiri`/… or Arabic-range characters) — get the Noto Arabic faces appended. Latin/CJK faces degrade to their inferred generic. Arabic decks keep the fallback (`sample-10`: Amiri, Sakkal Majalla).

## Evidence (canvas `measureText`, Noto Naskh loaded as `useGoogleFonts:true` does)

| Text | Stack | Before | After |
|------|-------|-------:|------:|
| `About us` | JP-gothic stack | **402.24px** (= Noto-Naskh-only, serif) | **378.94px** (= `sans-serif` generic) |
| `مرحبا` | Amiri stack | resolves to Noto Naskh | resolves to Noto Naskh (unchanged) |

## VRT

Full pptx VRT: **69/69 pass, every slide byte-identical before and after** (incl. sample-1 slide 2 = 95.7%, all demo slides unchanged). The VRT host has neither the JP face nor the Noto Arabic web fonts installed (`useGoogleFonts` is off in the fixture), so the regression is not pixel-visible in VRT either way — the glyph-width probe above exercises the exact user-facing condition. No demo slide regresses.

## Gates

- `npx vitest run packages/pptx` — 9 passed
- `pnpm exec tsc --noEmit` (packages/pptx) — clean
- Full pptx Playwright VRT — 69 passed, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)