### PR TITLE
feat(docx): Japanese kinsoku line breaking (ECMA-376 §17.15.1.58–.60)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -60,10 +60,12 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     let settings_path = find_rel_target(&rels_xml, "settings")
         .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
         .unwrap_or_else(|| "word/settings.xml".to_string());
+    let mut document_settings: Option<crate::types::DocumentSettings> = None;
     if let Ok(settings_xml) = read_zip_entry(&mut zip, &settings_path) {
         if let Some(lang) = parse_theme_font_bidi_lang(&settings_xml) {
             theme.fill_default_cs_font(&lang);
         }
+        document_settings = parse_document_settings(&settings_xml);
     }
     let theme = theme;
 
@@ -127,6 +129,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     Ok(Document {
         section, body, headers, footers, major_font, minor_font, font_family_classes,
         revisions, comments, footnotes, endnotes,
+        settings: document_settings,
     })
 }
 
@@ -344,6 +347,50 @@ fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "themeFontLang")?;
     attr_w(node, "bidi").filter(|s| !s.is_empty())
+}
+
+/// Parse the typography settings the renderer needs from `word/settings.xml`.
+///
+/// - §17.15.1.58 `w:kinsoku` — East-Asian line-breaking toggle (ST_OnOff;
+///   absence means ON, which the renderer assumes, so we only surface an
+///   explicit `Some(false)`/`Some(true)`).
+/// - §17.15.1.60 `w:noLineBreaksBefore` / §17.15.1.59 `w:noLineBreaksAfter` —
+///   custom 行頭/行末禁則 character sets. The spec says `w:val` "specifies the
+///   set of characters", i.e. a present element REPLACES the application
+///   default set. A document may emit one element per `w:lang`; we concatenate
+///   the `w:val` strings into one set (the renderer is language-agnostic here
+///   and applies the union to its single CJK break path).
+///
+/// Returns `None` when none of these elements are present, so the renderer
+/// falls back to its built-in Japanese defaults with kinsoku ON.
+fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentSettings> {
+    let doc = XmlDoc::parse(settings_xml).ok()?;
+    let root = doc.root_element();
+
+    let kinsoku = bool_prop(root, "kinsoku");
+
+    let collect = |tag: &str| -> Option<String> {
+        let mut found = false;
+        let mut acc = String::new();
+        for node in root.children().filter(|n| n.is_element() && n.tag_name().name() == tag) {
+            found = true;
+            if let Some(val) = attr_w(node, "val") {
+                acc.push_str(&val);
+            }
+        }
+        if found { Some(acc) } else { None }
+    };
+    let no_line_breaks_before = collect("noLineBreaksBefore");
+    let no_line_breaks_after = collect("noLineBreaksAfter");
+
+    if kinsoku.is_none() && no_line_breaks_before.is_none() && no_line_breaks_after.is_none() {
+        return None;
+    }
+    Some(crate::types::DocumentSettings {
+        kinsoku,
+        no_line_breaks_before,
+        no_line_breaks_after,
+    })
 }
 
 fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
@@ -2959,6 +3006,52 @@ mod theme_cs_tests {
         assert_eq!(parse_theme_font_bidi_lang(settings).as_deref(), Some("ar-SA"));
         let none = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>"#;
         assert_eq!(parse_theme_font_bidi_lang(none), None);
+    }
+
+    #[test]
+    fn document_settings_absent_when_no_kinsoku_elements() {
+        // §17.15.1.58 default kinsoku=ON ⇒ no element ⇒ None (renderer defaults).
+        let xml = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:themeFontLang w:val="ja-JP"/></w:settings>"#;
+        assert!(parse_document_settings(xml).is_none());
+    }
+
+    #[test]
+    fn document_settings_kinsoku_off_is_surfaced() {
+        // §17.15.1.58 explicit w:val="0" disables kinsoku.
+        let xml = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:kinsoku w:val="0"/></w:settings>"#;
+        let s = parse_document_settings(xml).expect("settings present");
+        assert_eq!(s.kinsoku, Some(false));
+        assert_eq!(s.no_line_breaks_before, None);
+        assert_eq!(s.no_line_breaks_after, None);
+    }
+
+    #[test]
+    fn document_settings_kinsoku_on_explicit() {
+        let xml = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:kinsoku w:val="1"/></w:settings>"#;
+        assert_eq!(parse_document_settings(xml).unwrap().kinsoku, Some(true));
+    }
+
+    #[test]
+    fn document_settings_custom_no_line_breaks_replace_default() {
+        // §17.15.1.59/.60 — custom sets surfaced verbatim (renderer replaces).
+        let xml = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:noLineBreaksBefore w:lang="ja-JP" w:val="、。"/>
+          <w:noLineBreaksAfter w:lang="ja-JP" w:val="（「"/></w:settings>"#;
+        let s = parse_document_settings(xml).unwrap();
+        assert_eq!(s.no_line_breaks_before.as_deref(), Some("、。"));
+        assert_eq!(s.no_line_breaks_after.as_deref(), Some("（「"));
+    }
+
+    #[test]
+    fn document_settings_multiple_lang_no_line_breaks_concatenated() {
+        let xml = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:noLineBreaksBefore w:lang="ja-JP" w:val="、"/>
+          <w:noLineBreaksBefore w:lang="zh-CN" w:val="。"/></w:settings>"#;
+        let s = parse_document_settings(xml).unwrap();
+        assert_eq!(s.no_line_breaks_before.as_deref(), Some("、。"));
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -47,6 +47,33 @@ pub struct Document {
     /// `footnotes`.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub endnotes: Vec<DocxNote>,
+    /// ECMA-376 §17.15.1.* — document-wide compatibility / typography settings
+    /// from `word/settings.xml`. Currently the Japanese line-breaking (kinsoku)
+    /// configuration. `None` when settings.xml carries none of these elements
+    /// (the renderer then uses spec defaults: kinsoku ON).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<DocumentSettings>,
+}
+
+/// Document-wide settings surfaced from `word/settings.xml`. Only the
+/// typography settings the renderer needs are extracted.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentSettings {
+    /// §17.15.1.58 `w:kinsoku` — East-Asian line-breaking toggle. `None` means
+    /// the element is absent; the spec default is ON, so the renderer treats
+    /// `None` and `Some(true)` identically. `Some(false)` disables kinsoku.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kinsoku: Option<bool>,
+    /// §17.15.1.60 `w:noLineBreaksBefore@w:val` — custom set of characters that
+    /// cannot begin a line (行頭禁則). When present it REPLACES the application
+    /// default set. Multiple per-`w:lang` elements are concatenated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_line_breaks_before: Option<String>,
+    /// §17.15.1.59 `w:noLineBreaksAfter@w:val` — custom set of characters that
+    /// cannot end a line (行末禁則). Replaces the default when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_line_breaks_after: Option<String>,
 }
 
 /// Single track-changes event extracted from a body `<w:ins>` / `<w:del>`.

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -8,7 +8,7 @@ import {
   type MathRenderer,
 } from '@silurus/ooxml-core';
 import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerResponse } from './types';
-import { computePages, renderDocumentToCanvas, documentHasMath, prepareMathRuns } from './renderer';
+import { computePages, renderDocumentToCanvas, documentHasMath, prepareMathRuns, resolveKinsokuRules } from './renderer';
 
 /** Theme-referenced typefaces commonly used by DOCX templates. Mirrors the
  *  PPTX map — these are the well-known free webfont alternatives Microsoft
@@ -142,7 +142,16 @@ export class DocxDocument {
       this._pages = [this._document.body];
       return this._pages;
     }
-    this._pages = computePages(this._document.body, this._document.section, ctx);
+    // Pagination must use the same fontFamilyClasses + kinsoku rules as the
+    // render path, otherwise line-break decisions (and thus page breaks)
+    // diverge between measurement and paint. ECMA-376 §17.15.1.58–.60.
+    this._pages = computePages(
+      this._document.body,
+      this._document.section,
+      ctx,
+      this._document.fontFamilyClasses ?? {},
+      resolveKinsokuRules(this._document.settings),
+    );
     return this._pages;
   }
 

--- a/packages/docx/src/kinsoku.test.ts
+++ b/packages/docx/src/kinsoku.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  kinsokuAdjustedSplit,
+  resolveKinsokuRules,
+  DEFAULT_KINSOKU_RULES,
+} from './renderer.js';
+
+// ECMA-376 §17.15.1.58–.60 Japanese line-breaking (kinsoku) tests.
+//
+// kinsokuAdjustedSplit operates on an array of single code points and a
+// proposed split index `splitAt`: chars[0..splitAt) stay on the current line
+// (head), chars[splitAt..] overflow to the next line (tail). It retracts the
+// split leftwards so the tail never begins with a 行頭禁則 char and the head
+// never ends with a 行末禁則 char.
+
+const cp = (s: string): string[] => [...s];
+
+describe('kinsokuAdjustedSplit — line-start-forbidden (行頭禁則 / 追い出し)', () => {
+  it('pulls the preceding char down so a line never begins with 、', () => {
+    // "あいの、うえ" with a natural break that would put 、 at the tail start.
+    // chars: あ(0) い(1) の(2) 、(3) う(4) え(5)
+    // raw break after の (splitAt=3) → tail = "、うえ" begins with 、(forbidden).
+    const chars = cp('あいの、うえ');
+    const adjusted = kinsokuAdjustedSplit(chars, 3, DEFAULT_KINSOKU_RULES);
+    // Retract one: split=2 → head="あい", tail="の、うえ" begins with の (legal).
+    expect(adjusted).toBe(2);
+    expect(chars.slice(0, adjusted).join('')).toBe('あい');
+    expect(chars.slice(adjusted).join('')).toBe('の、うえ');
+  });
+
+  it('never begins a line with 。', () => {
+    // raw break before 。 ⇒ retract.
+    const chars = cp('簡潔に。説明');
+    // chars: 簡(0)潔(1)に(2)。(3)説(4)明(5); break at 3 → tail begins 。
+    const adjusted = kinsokuAdjustedSplit(chars, 3, DEFAULT_KINSOKU_RULES);
+    expect(adjusted).toBe(2);
+    expect(chars.slice(adjusted).join('').startsWith('。')).toBe(false);
+  });
+
+  it('retracts past consecutive forbidden chars', () => {
+    // "あ、。い" break at 1 → tail "、。い" forbidden; but break is already 1.
+    // Use break at 3: あ(0)、(1)。(2)い(3) — tail "い" legal already.
+    // Construct a case where two forbidden chars are at the tail head:
+    // break at 2 → tail "。い" forbidden → retract to 1 → tail "、。い" forbidden
+    // → retract to 0... but minSplit default 1 floors at 1; still forbidden →
+    // fall back to original split (2).
+    const chars = cp('あ、。い');
+    const adjusted = kinsokuAdjustedSplit(chars, 2, DEFAULT_KINSOKU_RULES);
+    // floor reached while still illegal → unrestricted fallback.
+    expect(adjusted).toBe(2);
+  });
+});
+
+describe('kinsokuAdjustedSplit — line-end-forbidden (行末禁則)', () => {
+  it('does not leave an opening bracket 「 as the last char of a line', () => {
+    // あい「うえ: break at 3 → head "あい「" ends with 「 (forbidden at line end).
+    const chars = cp('あい「うえ');
+    const adjusted = kinsokuAdjustedSplit(chars, 3, DEFAULT_KINSOKU_RULES);
+    // retract to 2 → head "あい", tail "「うえ" (legal: 「 may begin a line).
+    expect(adjusted).toBe(2);
+    expect(chars.slice(0, adjusted).join('').endsWith('「')).toBe(false);
+  });
+
+  it('does not leave （ as the last char of a line', () => {
+    const chars = cp('テスト（内容');
+    // テ(0)ス(1)ト(2)（(3)内(4)容(5); break at 4 → head ends with （.
+    const adjusted = kinsokuAdjustedSplit(chars, 4, DEFAULT_KINSOKU_RULES);
+    expect(adjusted).toBe(3);
+    expect(chars.slice(0, adjusted).join('').endsWith('（')).toBe(false);
+  });
+});
+
+describe('kinsokuAdjustedSplit — bounds & no-op cases', () => {
+  it('returns splitAt unchanged at the head edge (splitAt<=0)', () => {
+    expect(kinsokuAdjustedSplit(cp('、あい'), 0, DEFAULT_KINSOKU_RULES)).toBe(0);
+  });
+
+  it('returns splitAt unchanged at the tail edge (splitAt>=len)', () => {
+    const chars = cp('あいう');
+    expect(kinsokuAdjustedSplit(chars, 3, DEFAULT_KINSOKU_RULES)).toBe(3);
+  });
+
+  it('leaves a legal split untouched', () => {
+    const chars = cp('あいうえお');
+    expect(kinsokuAdjustedSplit(chars, 2, DEFAULT_KINSOKU_RULES)).toBe(2);
+  });
+
+  it('pathological all-forbidden run falls back without hanging', () => {
+    // Every tail-start is forbidden; must terminate and return the input split.
+    const chars = cp('、。、。、。');
+    const adjusted = kinsokuAdjustedSplit(chars, 3, DEFAULT_KINSOKU_RULES);
+    expect(adjusted).toBe(3); // unrestricted fallback, no infinite loop
+  });
+
+  it('allows retraction to an empty head when minSplit=0 (line already has content)', () => {
+    // chars: の(0)、(1)あ(2); break at 1 → tail "、あ" forbidden → retract to 0.
+    const chars = cp('の、あ');
+    const adjusted = kinsokuAdjustedSplit(chars, 1, DEFAULT_KINSOKU_RULES, 0);
+    expect(adjusted).toBe(0); // whole run pushed to next line (追い出し)
+  });
+});
+
+describe('resolveKinsokuRules — §17.15.1.58 toggle', () => {
+  it('defaults kinsoku to ON when settings absent', () => {
+    expect(resolveKinsokuRules().enabled).toBe(true);
+    expect(resolveKinsokuRules(undefined).enabled).toBe(true);
+    expect(resolveKinsokuRules({}).enabled).toBe(true);
+  });
+
+  it('kinsoku=false (w:val="0") disables', () => {
+    const rules = resolveKinsokuRules({ kinsoku: false });
+    expect(rules.enabled).toBe(false);
+    // When disabled, the split is never adjusted.
+    expect(kinsokuAdjustedSplit(cp('あいの、うえ'), 3, rules)).toBe(3);
+  });
+
+  it('default sets include the reported start-forbidden chars', () => {
+    const rules = resolveKinsokuRules();
+    for (const ch of '、。」）') {
+      expect(rules.lineStartForbidden.has(ch.codePointAt(0)!)).toBe(true);
+    }
+  });
+
+  it('default sets include the reported end-forbidden chars', () => {
+    const rules = resolveKinsokuRules();
+    for (const ch of '「（《') {
+      expect(rules.lineEndForbidden.has(ch.codePointAt(0)!)).toBe(true);
+    }
+  });
+});
+
+describe('resolveKinsokuRules — §17.15.1.59/.60 custom sets REPLACE defaults', () => {
+  it('custom noLineBreaksBefore replaces the default start set', () => {
+    const rules = resolveKinsokuRules({ noLineBreaksBefore: '〇' });
+    // The custom char is now start-forbidden...
+    expect(rules.lineStartForbidden.has('〇'.codePointAt(0)!)).toBe(true);
+    // ...and the default 、 is NO LONGER forbidden (replaced, not extended).
+    expect(rules.lineStartForbidden.has('、'.codePointAt(0)!)).toBe(false);
+    // So a break leaving 、 at line start is now legal (not retracted).
+    expect(kinsokuAdjustedSplit(cp('あいの、うえ'), 3, rules)).toBe(3);
+    // But a break leaving 〇 at line start IS retracted.
+    expect(kinsokuAdjustedSplit(cp('あい〇うえ'), 2, rules)).toBe(1);
+  });
+
+  it('custom noLineBreaksAfter replaces the default end set', () => {
+    const rules = resolveKinsokuRules({ noLineBreaksAfter: '＠' });
+    expect(rules.lineEndForbidden.has('＠'.codePointAt(0)!)).toBe(true);
+    expect(rules.lineEndForbidden.has('「'.codePointAt(0)!)).toBe(false);
+  });
+
+  it('empty custom set is a legitimate replacement (disables that direction)', () => {
+    const rules = resolveKinsokuRules({ noLineBreaksBefore: '' });
+    expect(rules.lineStartForbidden.size).toBe(0);
+    expect(kinsokuAdjustedSplit(cp('あいの、うえ'), 3, rules)).toBe(3);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -160,6 +160,10 @@ interface RenderState {
   /** ECMA-376 §17.8.3.10 — font→family map from word/fontTable.xml. Used by
    *  resolveFontFamily as the authoritative source of serif/sans-serif classification. */
   fontFamilyClasses: Record<string, string>;
+  /** ECMA-376 §17.15.1.58–.60 — resolved Japanese line-breaking rules
+   *  (kinsoku enabled flag + line-start/line-end forbidden character sets).
+   *  Default is the application's Japanese kinsoku table with kinsoku ON. */
+  kinsoku: KinsokuRules;
   /** Callback for building a transparent text selection overlay. */
   onTextRun?: (run: DocxTextRunInfo) => void;
   /** When false, runs tagged with a `revision` render without the
@@ -347,7 +351,8 @@ export async function renderDocumentToCanvas(
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(0, 0, cssWidth, cssHeight);
 
-  const pages = opts.prebuiltPages ?? computePages(doc.body, sec, ctx, doc.fontFamilyClasses ?? {});
+  const kinsoku = resolveKinsokuRules(doc.settings);
+  const pages = opts.prebuiltPages ?? computePages(doc.body, sec, ctx, doc.fontFamilyClasses ?? {}, kinsoku);
   const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
   const elements = pages[pageIndex] ?? pages[0] ?? [];
 
@@ -373,6 +378,7 @@ export async function renderDocumentToCanvas(
     floats: [],
     docGrid: { type: sec.docGridType ?? null, linePitchPt: sec.docGridLinePitch ?? null },
     fontFamilyClasses: doc.fontFamilyClasses ?? {},
+    kinsoku,
     onTextRun: opts.onTextRun,
     showTrackChanges: opts.showTrackChanges ?? true,
   };
@@ -405,10 +411,11 @@ export function computePages(
   section: SectionProps,
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   fontFamilyClasses: Record<string, string> = {},
+  kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
 ): PaginatedBodyElement[][] {
   const contentH = section.pageHeight - section.marginTop - section.marginBottom;
   const contentW = section.pageWidth - section.marginLeft - section.marginRight;
-  const measureState = buildMeasureState(ctx, section, fontFamilyClasses);
+  const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku);
 
   const pages: PaginatedBodyElement[][] = [[]];
   let y = 0;
@@ -563,6 +570,7 @@ function buildMeasureState(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   section: SectionProps,
   fontFamilyClasses: Record<string, string> = {},
+  kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
 ): RenderState {
   return {
     ctx,
@@ -584,6 +592,7 @@ function buildMeasureState(
     floats: [],
     docGrid: { type: section.docGridType ?? null, linePitchPt: section.docGridLinePitch ?? null },
     fontFamilyClasses,
+    kinsoku,
     showTrackChanges: false,
   };
 }
@@ -619,7 +628,7 @@ function estimateParagraphHeight(
       lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, state.docGrid, paraHasRuby, is ?? 0),
       pageH: state.pageH,
     } : undefined;
-    const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft);
+    const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku);
     if (paraHasRuby) {
       // Word uses the same line height for every line in a ruby paragraph,
       // snapped to an integer docGrid pitch.
@@ -697,7 +706,7 @@ function splitParagraphAcrossPages(
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0),
     pageH: measureState.pageH,
   } : undefined;
-  const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft);
+  const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku);
   const paraHasRuby = paragraphHasRuby(para);
 
   const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby, l.intendedSingle);
@@ -1303,7 +1312,7 @@ function renderParagraph(
     pageH: state.pageH,
   } : undefined;
 
-  const lines = layoutLines(ctx, segments, paraW, firstLineX - paraX, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft);
+  const lines = layoutLines(ctx, segments, paraW, firstLineX - paraX, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku);
 
   // For paragraphs that carry any ruby annotation, Word renders every line
   // at the SAME height. Per the user's note: when the section's docGrid is
@@ -1942,6 +1951,162 @@ function fitCJKPrefix(
   return chars.slice(0, lo).join('');
 }
 
+/* ------------------------------------------------------------------ *
+ * Japanese line-breaking (kinsoku shori / 禁則処理)
+ *
+ * ECMA-376 §17.15.1.58 `w:kinsoku` is a document-wide on/off toggle for
+ * "East Asian typography line-breaking rules". Its default, when the
+ * element is absent from settings.xml, is TRUE (the toggle is a
+ * ST_OnOff whose absence Word treats as enabled for kinsoku). So a doc
+ * with no <w:kinsoku> still gets Japanese line breaking — which is what
+ * Word does and what users see.
+ *
+ * §17.15.1.59 `w:noLineBreaksAfter` / §17.15.1.60 `w:noLineBreaksBefore`
+ * let a document override the character set used by the kinsoku engine
+ * for a given language (`w:lang`):
+ *   - noLineBreaksBefore (§.60): characters that "cannot begin a line"
+ *     (行頭禁則 — line-start-forbidden).
+ *   - noLineBreaksAfter  (§.59): characters that "cannot end a line"
+ *     (行末禁則 — line-end-forbidden).
+ * The spec states the `w:val` "specifies the set of characters" — it is
+ * the COMPLETE set, so a present override REPLACES the application's
+ * default set for that language (it does not extend it). When the
+ * element is absent the application's own default set is used. We
+ * implement replace-vs-default exactly per that wording.
+ *
+ * The default sets below are Word's documented Japanese kinsoku tables
+ * (Tools ▸ Options ▸ Typography ▸ "Use default kinsoku rules"). They
+ * coincide with JIS X 4051 §6.1 (行頭禁則文字 / 行末禁則文字). We encode
+ * them as two flat string constants (data, not scattered conditionals);
+ * membership is a Set lookup.
+ *
+ * Word applies kinsoku only to East-Asian wrapping (the per-character
+ * break path). Pure-Latin word wrap is untouched: these sets contain no
+ * ASCII letters/space, and the Latin path never consults them.
+ * ------------------------------------------------------------------ */
+
+/** §17.15.1.60 default 行頭禁則 — characters that may NOT begin a line.
+ *  Closing brackets/quotes, mid/end punctuation, small kana, prolonged
+ *  sound mark, iteration marks, and their halfwidth forms. */
+const KINSOKU_DEFAULT_LINE_START_FORBIDDEN =
+  // closing brackets / quotes (fullwidth)
+  '”’）〕］｝〉》」』】〙〗〟｠»' +
+  // mid / end punctuation (fullwidth)
+  '、。，．・：；／？！‐ー゠–〜～' +
+  // small kana
+  'ぁぃぅぇぉっゃゅょゎゕゖ' +
+  'ァィゥェォッャュョヮヵヶ' +
+  'ㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ' +
+  // iteration / sound marks
+  '々〻ゝゞヽヾ゛゜' +
+  // misc trailing symbols
+  '％‰℃°′″' +
+  // halfwidth forms (cannot start a line either)
+  '｡｣､･ｰﾞﾟ' +
+  '!),.:;?]}｠';
+
+/** §17.15.1.59 default 行末禁則 — characters that may NOT end a line.
+ *  Opening brackets / quotes and currency/lead symbols. */
+const KINSOKU_DEFAULT_LINE_END_FORBIDDEN =
+  // opening brackets / quotes (fullwidth)
+  '“‘（〔［｛〈《「『【〘〖〝｟«' +
+  // currency / lead symbols
+  '＄￥＃￡￠' +
+  // halfwidth opening forms
+  '([{｟';
+
+/** Resolved kinsoku configuration for a document.
+ *  `enabled` reflects §17.15.1.58; the two sets are §.60 / §.59 (custom
+ *  sets replace the defaults — see resolveKinsokuRules). */
+export interface KinsokuRules {
+  enabled: boolean;
+  /** Code points forbidden at line START (行頭禁則). */
+  lineStartForbidden: Set<number>;
+  /** Code points forbidden at line END (行末禁則). */
+  lineEndForbidden: Set<number>;
+}
+
+function codePointSet(text: string): Set<number> {
+  const out = new Set<number>();
+  for (const ch of text) out.add(ch.codePointAt(0)!);
+  return out;
+}
+
+/** Build the active {@link KinsokuRules} from the document settings.
+ *  - `enabled` defaults to TRUE when undefined (§17.15.1.58 default).
+ *  - A non-undefined custom set REPLACES the default for that direction
+ *    (§17.15.1.59 / §.60 "specifies the set of characters"). An empty
+ *    string is a legitimate replacement that disables that direction.
+ */
+export function resolveKinsokuRules(settings?: {
+  kinsoku?: boolean;
+  noLineBreaksBefore?: string;
+  noLineBreaksAfter?: string;
+}): KinsokuRules {
+  return {
+    enabled: settings?.kinsoku !== false,
+    lineStartForbidden: codePointSet(
+      settings?.noLineBreaksBefore ?? KINSOKU_DEFAULT_LINE_START_FORBIDDEN,
+    ),
+    lineEndForbidden: codePointSet(
+      settings?.noLineBreaksAfter ?? KINSOKU_DEFAULT_LINE_END_FORBIDDEN,
+    ),
+  };
+}
+
+/** The default Japanese kinsoku rules (no document overrides). */
+export const DEFAULT_KINSOKU_RULES: KinsokuRules = resolveKinsokuRules();
+
+/**
+ * Adjust a CJK line-break position so it does not violate kinsoku.
+ *
+ * Given a line being split into `head = chars[0..splitAt)` (stays on the
+ * current line) and `tail = chars[splitAt..]` (overflows to the next),
+ * return the largest legal `splitAt' <= splitAt` such that:
+ *   1. `tail'[0]` is not line-START-forbidden (行頭禁則 追い出し — the
+ *      offending char and any preceding forbidden chars are pulled down
+ *      onto the next line), AND
+ *   2. `head'[last]` is not line-END-forbidden (push a dangling opener
+ *      to the next line).
+ *
+ * Retraction is bounded: we never retract below `minSplit` (default 1,
+ * so at least one code point always stays on a non-empty line and we
+ * keep forward progress). If no legal split exists within that bound
+ * (pathological run of forbidden chars), the original `splitAt` is
+ * returned unchanged — Word likewise lets an over-long forbidden run
+ * overflow rather than loop forever.
+ *
+ * `chars` must be an array of single code points (e.g. `[...text]`).
+ */
+export function kinsokuAdjustedSplit(
+  chars: string[],
+  splitAt: number,
+  rules: KinsokuRules,
+  minSplit = 1,
+): number {
+  if (!rules.enabled) return splitAt;
+  if (splitAt <= 0 || splitAt >= chars.length) return splitAt;
+
+  const startForbidden = (i: number): boolean =>
+    i < chars.length && rules.lineStartForbidden.has(chars[i].codePointAt(0)!);
+  const endForbidden = (i: number): boolean =>
+    i >= 0 && rules.lineEndForbidden.has(chars[i].codePointAt(0)!);
+
+  let s = splitAt;
+  // Retract while the tail begins with a start-forbidden char OR the head
+  // ends with an end-forbidden char. Each retraction moves one code point
+  // from the head onto the tail (追い出し). Bounded by minSplit.
+  while (s > minSplit && (startForbidden(s) || endForbidden(s - 1))) {
+    s--;
+  }
+  // If we hit the floor and it is still illegal, no legal break exists in
+  // range — fall back to the unrestricted split (never empty, never hang).
+  if (s <= minSplit && (startForbidden(s) || endForbidden(s - 1))) {
+    return splitAt;
+  }
+  return s;
+}
+
 /**
  * Split a text run into layout-segment strings.
  * Each segment is an atomic unit for word-level fitting; CJK overflow is handled in layoutLines.
@@ -2098,6 +2263,9 @@ function layoutLines(
   // Paragraph left-indent in px. Tab-stop positions are measured from the text
   // margin (ECMA-376 §17.3.1.37), but layout is paraX-relative, so subtract this.
   tabOriginPx: number = 0,
+  // ECMA-376 §17.15.1.58–.60 Japanese line-breaking rules. Default kinsoku is
+  // ON; the CJK overflow path retracts the break to a kinsoku-legal position.
+  kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
   let currentLine: (LayoutTextSeg | LayoutImageSeg | LayoutMathSeg | LayoutTabSeg)[] = [];
@@ -2447,7 +2615,19 @@ function layoutLines(
       // CJK overflow: split at the maximum prefix that fits, re-queue the tail
       const available = availW() - currentWidth;
       ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
-      const prefix = available > 0 ? fitCJKPrefix(ctx, s.text, available) : '';
+      const rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available) : '';
+      // Apply kinsoku to the break position: retract leftwards so the tail
+      // never begins with a 行頭禁則 char and the head never ends with a
+      // 行末禁則 char (ECMA-376 §17.15.1.58–.60). When the current line
+      // already has content, retracting to an empty prefix is allowed — the
+      // whole run moves to the next (fresh) line, which is Word's 追い出し.
+      // When the line is empty we keep at least one char (minSplit=1) so we
+      // never lose forward progress.
+      const allChars = [...s.text];
+      const rawSplit = [...rawPrefix].length;
+      const minSplit = currentLine.length > 0 ? 0 : 1;
+      const split = kinsokuAdjustedSplit(allChars, rawSplit, kinsoku, minSplit);
+      const prefix = allChars.slice(0, split).join('');
       if (prefix.length > 0) {
         const pm = ctx.measureText(prefix);
         const headSeg: LayoutTextSeg = { ...s, text: prefix, measuredWidth: pm.width };
@@ -3146,7 +3326,7 @@ function measureParaHeight(
     const { asc, desc } = emptyLineNaturalPx(fs, scale);
     return lineBoxHeight(para.lineSpacing, asc, desc, scale, state.docGrid, paraHasRuby, emptyIntendedSinglePx(para, scale));
   }
-  const lines = layoutLines(state.ctx, segs, maxWidth, 0, scale, para.tabStops, undefined, state.fontFamilyClasses);
+  const lines = layoutLines(state.ctx, segs, maxWidth, 0, scale, para.tabStops, undefined, state.fontFamilyClasses, 0, state.kinsoku);
   return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, state.docGrid, paraHasRuby, l.intendedSingle), 0);
 }
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -34,6 +34,24 @@ export interface DocxDocumentModel {
   /** ECMA-376 §17.11.4 — `word/endnotes.xml` (id + text). Same shape as
    *  `footnotes`. */
   endnotes?: DocNote[];
+  /** ECMA-376 §17.15.1.* — document-wide compatibility / typography settings
+   *  from `word/settings.xml`. Currently carries the Japanese line-breaking
+   *  (kinsoku) configuration. Absent when settings.xml has no relevant
+   *  elements (the renderer then uses spec defaults: kinsoku ON). */
+  settings?: DocSettings;
+}
+
+export interface DocSettings {
+  /** §17.15.1.58 `w:kinsoku` — East-Asian line-breaking toggle. `undefined`
+   *  means the element is absent; the spec default is ON (treated as `true`). */
+  kinsoku?: boolean;
+  /** §17.15.1.60 `w:noLineBreaksBefore@w:val` — custom set of characters that
+   *  cannot begin a line (行頭禁則). When present it REPLACES the application
+   *  default set. Word's per-`w:lang` sets are merged into one string. */
+  noLineBreaksBefore?: string;
+  /** §17.15.1.59 `w:noLineBreaksAfter@w:val` — custom set of characters that
+   *  cannot end a line (行末禁則). Replaces the default when present. */
+  noLineBreaksAfter?: string;
 }
 
 export interface DocRevision {


### PR DESCRIPTION
## Summary

Implements Japanese **kinsoku shori (禁則処理)** in the DOCX renderer. Word never starts a line with closing punctuation / brackets / small kana (行頭禁則) nor ends a line with an opening bracket (行末禁則); instead it pulls the preceding character down onto the next line (追い出し). Our CJK wrap path previously broke between *any* two CJK characters, so:

- `private/sample-5` page 3 began lines with `、` / `。`
- `private/sample-3` page 1 (middle column) began a line with `。簡潔に説明します。`

both diverging from the Word reference PDFs the user flagged.

## Spec basis

- **§17.15.1.58 `w:kinsoku`** — East-Asian line-breaking toggle. ST_OnOff; **default ON** when the element is absent (sample-3 / sample-5 carry no kinsoku elements, verified — so the default applies).
- **§17.15.1.60 `w:noLineBreaksBefore`** / **§17.15.1.59 `w:noLineBreaksAfter`** — custom 行頭/行末禁則 sets. The spec says `w:val` *"specifies the set of characters"*, i.e. a present element **REPLACES** the application default for that direction (not extend). When absent, the application's Japanese defaults apply.

Default sets are Word's documented Japanese kinsoku tables (coincide with JIS X 4051 §6.1), encoded as two flat string constants with provenance in a comment — structured as data, not scattered conditionals.

## Implementation

- **Parser (Rust)** — `parse_document_settings` reads `w:kinsoku` / `w:noLineBreaksBefore` / `w:noLineBreaksAfter` from `word/settings.xml`, surfaced on the `Document` model as `settings` (`DocumentSettings`). Multiple per-`w:lang` custom elements are concatenated.
- **Renderer (TS)** — `kinsokuAdjustedSplit` retracts the CJK break position leftwards until the tail no longer begins with a start-forbidden char and the head no longer ends with an end-forbidden char. Retraction is **bounded** (`minSplit`): a pathological all-forbidden run falls back to the unrestricted break — never loops, never emits an empty line that loses progress. `resolveKinsokuRules` applies the §.58 default (ON), the `w:val="0"` disable, and the §.59/.60 replace-vs-default semantics.
- **Pagination** — `_getPages` now passes the same `fontFamilyClasses` + kinsoku rules as the paint path, so line-break (and page-break) decisions don't diverge between measure and render.
- **Latin word-wrap unchanged** — the forbidden sets contain no ASCII letters/space and the Latin path never consults them.

## Before / after VRT (vs Word reference PNGs)

| Page | Before | After | Δ |
|---|---|---|---|
| private/sample-3 p1 | 91.9 | 91.9 | 0 |
| private/sample-3 p2 | 91.4 | 91.4 | 0 |
| private/sample-3 p3 | 91.1 | 91.1 | 0 |
| private/sample-5 p2 | 95.4 | 95.4 | 0 |
| **private/sample-5 p3** | **94.8** | **95.1** | **+0.3** |
| private/sample-5 p5 | 93.0 | 93.1 | +0.1 |
| all other pages | — | — | identical |
| demo/sample-1 (6 pages) | 100/100/99.3/100/100/100 | same | 0 |

No page regressed. demo VRT stays **6/6**.

(sample-3's pixel score is unchanged because the corrected break shifts only one character and is dwarfed by other cell-level divergences vs Word; the line-start *correctness* is confirmed below.)

## Fixed line starts (verified via `onTextRun` probe + Word reference PNG)

sample-5 p3, kinsoku **OFF** → lines began with the forbidden `、`:
- `、仕方がないわと云った。`
- `、そこに、写ってる…`

kinsoku **ON** (this PR) → the preceding char is pulled down (追い出し), matching the Word reference exactly:
- `の、仕方がないわと云った。`
- `ら、そこに、写ってる…`

## Tests

- **vitest 61/61** — 17 new tests in `kinsoku.test.ts` (start/end retraction, bounds, pathological fallback, §.58 toggle, §.59/.60 custom-set replacement, empty-set replacement).
- **cargo 28/28** — 5 new `parse_document_settings` tests (absent → None, kinsoku off/on, custom sets, multi-lang concat).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)