### PR TITLE
feat(pptx): render innerShdw / softEdge / reflection shape effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,9 +514,9 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Compound / double lines (`<a:ln cmpd="dbl|thinThick|thickThin|tri">` — straight connectors) | ✅ |
 | **Shape effects** | Drop shadow (`outerShdw`) | ✅ |
 | | Glow (`glow` — radius + colour) | ✅ |
-| | Inner shadow (`innerShdw` — parsed; rendering follow-up) | ⚠️ |
-| | Soft edge (`softEdge` — parsed; rendering follow-up) | ⚠️ |
-| | Reflection (`reflection` — parsed; rendering follow-up) | ⚠️ |
+| | Inner shadow (`innerShdw`) | ✅ |
+| | Soft edge (`softEdge`) | ✅ |
+| | Reflection (`reflection`) | ✅ |
 | | Bevel / 3D extrusion | ❌ |
 | **Text — characters** | Bold, italic, strikethrough (incl. `dblStrike`) | ✅ |
 | | Underline styles (`sng` / `dbl` / `dotted` / `dash` / `dashLong` / `dotDash` / `dotDotDash` / `wavy` / `wavyDbl` and `*Heavy` variants) | ✅ |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,14 @@ export { buildCustomPath } from './shape/custGeom';
 export { hexToRgba, resolveFill, applyStroke } from './shape/paint';
 export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/preset';
 export {
+  applyInnerShadow,
+  applySoftEdge,
+  applyReflection,
+  createAuxCanvas,
+  type PaintShape,
+  type EffectBBox,
+} from './shape/effects';
+export {
   renderSparkline,
   type SparklineKind,
   type SparklineModel,

--- a/packages/core/src/shape/effects.test.ts
+++ b/packages/core/src/shape/effects.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  applyInnerShadow,
+  applySoftEdge,
+  applyReflection,
+  createAuxCanvas,
+} from './effects';
+import type { Shadow, SoftEdge, Reflection } from '../types/common';
+
+/**
+ * Minimal recording 2D context. Records the ordered sequence of state mutations
+ * and draw calls so we can assert the compositing pipeline each effect builds,
+ * without a real canvas. Effects are pure compositing logic, so the op sequence
+ * is the contract under test (ECMA-376 §20.1.8.40 / .50 / .53).
+ */
+class RecordingCtx {
+  ops: Array<{ op: string; args?: unknown[] }> = [];
+  filter = 'none';
+  globalCompositeOperation = 'source-over';
+  fillStyle: unknown = '#000';
+
+  save() { this.ops.push({ op: 'save' }); }
+  restore() { this.ops.push({ op: 'restore' }); }
+  translate(x: number, y: number) { this.ops.push({ op: 'translate', args: [x, y] }); }
+  scale(x: number, y: number) { this.ops.push({ op: 'scale', args: [x, y] }); }
+  fillRect(...a: number[]) { this.ops.push({ op: 'fillRect', args: a }); }
+  drawImage(...a: unknown[]) { this.ops.push({ op: 'drawImage', args: a }); }
+  createLinearGradient() {
+    this.ops.push({ op: 'createLinearGradient' });
+    const stops: Array<[number, string]> = [];
+    return {
+      stops,
+      addColorStop: (o: number, c: string) => { stops.push([o, c]); },
+    } as unknown as CanvasGradient;
+  }
+  // Setters that the effects toggle are plain fields, captured on read.
+}
+
+/** Install a fake OffscreenCanvas that hands back RecordingCtx instances. */
+function installFakeCanvas(): { auxCtxs: RecordingCtx[] } {
+  const auxCtxs: RecordingCtx[] = [];
+  class FakeOffscreen {
+    width: number;
+    height: number;
+    constructor(w: number, h: number) { this.width = w; this.height = h; }
+    getContext(_kind: string) {
+      const c = new RecordingCtx();
+      auxCtxs.push(c);
+      return c;
+    }
+  }
+  vi.stubGlobal('OffscreenCanvas', FakeOffscreen);
+  return { auxCtxs };
+}
+
+const BBOX = { x: 100, y: 50, w: 200, h: 80 };
+const DEVICE_W = 800;
+const DEVICE_H = 600;
+// scale is px-per-EMU; 1 px == 9525 EMU in DrawingML, but the effect helper just
+// multiplies, so pick a scale where the arithmetic is easy to read.
+const SCALE = 1 / 9525; // 9525 EMU -> 1 px
+
+describe('createAuxCanvas', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns an OffscreenCanvas when available, clamped to >=1 px', () => {
+    installFakeCanvas();
+    const c = createAuxCanvas(0, 0) as { width: number; height: number };
+    expect(c).not.toBeNull();
+    expect(c.width).toBe(1);
+    expect(c.height).toBe(1);
+  });
+
+  it('returns null in a headless environment', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    vi.stubGlobal('document', undefined);
+    expect(createAuxCanvas(10, 10)).toBeNull();
+  });
+});
+
+describe('applyInnerShadow (ECMA-376 §20.1.8.40)', () => {
+  let fake: { auxCtxs: RecordingCtx[] };
+  beforeEach(() => { fake = installFakeCanvas(); });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const shadow: Shadow = { color: '404040', alpha: 0.8, blur: 19050, dist: 9525, dir: 90 };
+
+  it('paints silhouette, carves an offset+blurred copy, clips, then blits', () => {
+    const live = new RecordingCtx();
+    const paint = vi.fn((c: unknown) => { (c as RecordingCtx).ops.push({ op: 'paintShape' }); });
+    applyInnerShadow(live as never, paint as never, BBOX, shadow, SCALE, DEVICE_W, DEVICE_H);
+
+    expect(fake.auxCtxs).toHaveLength(1);
+    const aux = fake.auxCtxs[0];
+    const ops = aux.ops.map(o => o.op);
+    // 3 silhouette paints on the aux canvas: colour fill, destination-out, destination-in.
+    expect(ops.filter(o => o === 'paintShape')).toHaveLength(3);
+    // The blurred offset pass translates by (cos90*dist, sin90*dist) = (0, 1px).
+    const translate = aux.ops.find(o => o.op === 'translate');
+    expect(translate?.args?.[0]).toBeCloseTo(0, 6);
+    expect(translate?.args?.[1]).toBeCloseTo(1, 6); // dist 9525 EMU * scale = 1px, dir=90 -> +y
+    // Result is composited onto the live context exactly once.
+    const liveDraws = live.ops.filter(o => o.op === 'drawImage');
+    expect(liveDraws).toHaveLength(1);
+  });
+
+  it('skips the blur filter when blurRad is 0', () => {
+    const live = new RecordingCtx();
+    const paint = vi.fn();
+    const noBlur: Shadow = { ...shadow, blur: 0 };
+    // Spy on the filter assignments by recording them via a getter/setter proxy
+    // is overkill; instead assert no throw and a single blit (smoke).
+    applyInnerShadow(live as never, paint as never, BBOX, noBlur, SCALE, DEVICE_W, DEVICE_H);
+    expect(live.ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
+  });
+});
+
+describe('applySoftEdge (ECMA-376 §20.1.8.53)', () => {
+  let fake: { auxCtxs: RecordingCtx[] };
+  beforeEach(() => { fake = installFakeCanvas(); });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('paints onto the live context directly when radius is 0 (no feather)', () => {
+    const live = new RecordingCtx();
+    const paint = vi.fn((c: unknown) => { (c as RecordingCtx).ops.push({ op: 'paintShape' }); });
+    const se: SoftEdge = { radius: 0 };
+    applySoftEdge(live as never, paint as never, BBOX, se, SCALE, DEVICE_W, DEVICE_H);
+    // No aux canvas allocated; shape painted straight onto live.
+    expect(fake.auxCtxs).toHaveLength(0);
+    expect(live.ops.some(o => o.op === 'paintShape')).toBe(true);
+    expect(live.ops.some(o => o.op === 'drawImage')).toBe(false);
+  });
+
+  it('feathers via a blurred destination-in mask then blits once', () => {
+    const live = new RecordingCtx();
+    const paint = vi.fn((c: unknown) => { (c as RecordingCtx).ops.push({ op: 'paintShape' }); });
+    const se: SoftEdge = { radius: 28575 }; // 3 px
+    applySoftEdge(live as never, paint as never, BBOX, se, SCALE, DEVICE_W, DEVICE_H);
+    expect(fake.auxCtxs).toHaveLength(1);
+    const aux = fake.auxCtxs[0];
+    // Two silhouette paints on aux: full shape, then blurred mask.
+    expect(aux.ops.filter(o => o.op === 'paintShape')).toHaveLength(2);
+    expect(live.ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
+  });
+});
+
+describe('applyReflection (ECMA-376 §20.1.8.50)', () => {
+  let fake: { auxCtxs: RecordingCtx[] };
+  beforeEach(() => { fake = installFakeCanvas(); });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const reflection: Reflection = {
+    blur: 0, dist: 0, dir: 90,
+    stA: 0.5, stPos: 0, endA: 0, endPos: 0.35,
+    sx: 1, sy: -1,
+  };
+
+  it('paints shape, builds a vertical alpha gradient, mirrors via sy<0, blits', () => {
+    const live = new RecordingCtx();
+    const paint = vi.fn((c: unknown) => { (c as RecordingCtx).ops.push({ op: 'paintShape' }); });
+    applyReflection(live as never, paint as never, BBOX, reflection, SCALE, DEVICE_W, DEVICE_H);
+
+    const aux = fake.auxCtxs[0];
+    expect(aux.ops.some(o => o.op === 'createLinearGradient')).toBe(true);
+    expect(aux.ops.some(o => o.op === 'fillRect')).toBe(true);
+    // The live blit mirrors with scale(sx, sy) where sy<0.
+    const scaleOp = live.ops.find(o => o.op === 'scale');
+    expect(scaleOp?.args).toEqual([1, -1]);
+    expect(live.ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
+  });
+
+  it('anchors the mirror at the shape bottom edge (algn="b") with dist offset', () => {
+    const live = new RecordingCtx();
+    const paint = vi.fn();
+    const withDist: Reflection = { ...reflection, dist: 9525, dir: 90 }; // 1px down
+    applyReflection(live as never, paint as never, BBOX, withDist, SCALE, DEVICE_W, DEVICE_H);
+    const translates = live.ops.filter(o => o.op === 'translate');
+    // First translate moves origin to (bbox.x + offX, bottom + offY).
+    const bottom = BBOX.y + BBOX.h; // 130
+    expect(translates[0].args?.[0]).toBeCloseTo(BBOX.x + 0, 6);
+    expect(translates[0].args?.[1]).toBeCloseTo(bottom + 1, 6);
+  });
+});

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -145,10 +145,14 @@ export function applyInnerShadow(
  * so the perimeter fades to transparent over the feather radius.
  *
  * This helper paints the shape onto an auxiliary canvas, then intersects it with
- * a blurred version of its own silhouette, then blits the feathered result back.
- * Because the mask is the blurred silhouette, the interior (where blur leaves
- * alpha = 1) is untouched and only the edge band fades — matching the spec's
- * "fill is not affected".
+ * a blurred version of its FILLED SILHOUETTE (not the styled body), then blits
+ * the feathered result back. The mask must be the filled silhouette — masking
+ * with a stroked body would `destination-in` only the thin outline ring and
+ * erase the interior. Because the silhouette interior stays alpha = 1 under
+ * blur, only the edge band fades, matching the spec's "fill is not affected".
+ *
+ * `paintMask` paints a flat opaque silhouette (filled path, no stroke). When
+ * omitted, `paintShape` is reused (correct only for unstroked shapes).
  */
 export function applySoftEdge(
   liveCtx: AuxContext,
@@ -158,6 +162,7 @@ export function applySoftEdge(
   scale: number,
   deviceW: number,
   deviceH: number,
+  paintMask?: PaintShape,
 ): void {
   const radius = emuToPx(softEdge.radius, scale);
   if (radius <= 0) {
@@ -177,17 +182,18 @@ export function applySoftEdge(
     return;
   }
 
+  const mask = paintMask ?? paintShape;
+
   // 1. Paint the full shape (fill + stroke) onto the aux canvas.
   paintShape(c);
 
-  // 2. Intersect with a blurred silhouette mask to feather the perimeter.
-  //    A box blur of `radius` px feathers the edge over ~radius px each side;
+  // 2. Intersect with a blurred FILLED silhouette to feather the perimeter.
   //    ECMA gives `rad` as the blur radius directly.
   c.save();
   c.globalCompositeOperation = 'destination-in';
   c.filter = `blur(${radius}px)`;
   c.fillStyle = '#000';
-  paintShape(c);
+  mask(c);
   c.restore();
 
   // 3. Blit the feathered shape back to the live context.

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -92,7 +92,7 @@ function get2d(canvas: AuxCanvas): AuxContext | null {
 export function applyInnerShadow(
   liveCtx: AuxContext,
   paintShape: PaintShape,
-  bbox: EffectBBox,
+  _bbox: EffectBBox,
   shadow: Shadow,
   scale: number,
   deviceW: number,

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -1,0 +1,281 @@
+import type { Shadow, SoftEdge, Reflection } from '../types/common';
+import { hexToRgba } from './paint';
+
+/**
+ * Canvas 2D rendering of the three DrawingML edge/blur effects that the
+ * Canvas shadow primitive (a single offset+blur slot) cannot express:
+ *
+ *   - innerShdw  — ECMA-376 §20.1.8.40 (CT_InnerShadowEffect)
+ *   - softEdge   — ECMA-376 §20.1.8.53 (CT_SoftEdgesEffect)
+ *   - reflection — ECMA-376 §20.1.8.50 (CT_ReflectionEffect)
+ *
+ * Each helper takes a `paintShape` callback that renders the shape's opaque
+ * silhouette (fill + stroke) into a supplied 2D context, positioned in the
+ * SAME device pixel coordinates as the live canvas. The helpers route that
+ * silhouette through one or more auxiliary canvases and `globalCompositeOperation`
+ * / `filter` passes, then blit the result back onto the live context — so the
+ * caller never has to special-case preset vs. custom geometry.
+ *
+ * Coordinates: `bbox` is the shape bounding box in device pixels (already scaled).
+ * Effect radii / distances arrive in EMU and are converted with `scale`.
+ */
+
+export type PaintShape = (ctx: AuxContext) => void;
+
+type AuxCanvas = HTMLCanvasElement | OffscreenCanvas;
+type AuxContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+/** Bounding box of the shape in device pixels (post-scale). */
+export interface EffectBBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * EMU → device px. Mirrors `emuToPx` in the pptx renderer, where `scale` is
+ * px-per-EMU (it already folds in the EMU→px conversion), so this is a bare
+ * multiply. Kept local so the effect helpers have no dependency on the renderer.
+ */
+function emuToPx(emu: number, scale: number): number {
+  return emu * scale;
+}
+
+/**
+ * Allocate an auxiliary canvas. Prefers OffscreenCanvas (no DOM pollution, works
+ * inside a worker); falls back to a detached <canvas>; returns null when neither
+ * is available (e.g. a headless unit-test environment) so callers can no-op.
+ * Dimensions are clamped to >=1 to avoid zero-size canvas errors.
+ */
+export function createAuxCanvas(w: number, h: number): AuxCanvas | null {
+  const cw = Math.max(1, Math.ceil(w));
+  const ch = Math.max(1, Math.ceil(h));
+  if (typeof OffscreenCanvas !== 'undefined') {
+    return new OffscreenCanvas(cw, ch);
+  }
+  if (typeof document !== 'undefined') {
+    const c = document.createElement('canvas');
+    c.width = cw;
+    c.height = ch;
+    return c;
+  }
+  return null;
+}
+
+function get2d(canvas: AuxCanvas): AuxContext | null {
+  // The union return of getContext('2d') across HTMLCanvasElement /
+  // OffscreenCanvas is awkward to type; narrow via unknown.
+  return (canvas.getContext('2d') as AuxContext | null) ?? null;
+}
+
+/**
+ * innerShdw — ECMA-376 §20.1.8.40. "A shadow is applied within the edges of the
+ * object." The shadow colour shows through where the shape's interior is NOT
+ * covered by an offset copy of the shape — i.e. it hugs the inside of the edge
+ * opposite the offset direction.
+ *
+ * Construction (all on an auxiliary canvas the size of the live canvas so the
+ * shadow can bleed up to `blur` px past the silhouette before being clipped):
+ *   1. Paint the silhouette filled with the shadow colour.
+ *   2. `destination-out` an offset + blurred copy of the silhouette. What
+ *      remains is a blurred crescent inside the original edge — the inner shadow.
+ *   3. `destination-in` the (un-offset, un-blurred) silhouette so the shadow is
+ *      clipped to the shape interior.
+ *   4. Blit over the live shape with `source-over` (drawn AFTER the fill).
+ *
+ * Offset uses dir (degrees clockwise from East) and dist (EMU). The shadow is
+ * cast toward `dir`, so the colour collects on the far side — we punch the
+ * offset copy toward `dir` and the surviving colour sits opposite it, matching
+ * PowerPoint's inset shadow.
+ */
+export function applyInnerShadow(
+  liveCtx: AuxContext,
+  paintShape: PaintShape,
+  bbox: EffectBBox,
+  shadow: Shadow,
+  scale: number,
+  deviceW: number,
+  deviceH: number,
+): void {
+  const aux = createAuxCanvas(deviceW, deviceH);
+  if (!aux) return;
+  const c = get2d(aux);
+  if (!c) return;
+
+  const blur = emuToPx(shadow.blur, scale);
+  const dist = emuToPx(shadow.dist, scale);
+  const dirRad = (shadow.dir * Math.PI) / 180;
+  const dx = Math.cos(dirRad) * dist;
+  const dy = Math.sin(dirRad) * dist;
+
+  // 1. Silhouette in the shadow colour.
+  c.save();
+  c.fillStyle = hexToRgba(shadow.color, shadow.alpha);
+  paintShape(c);
+  c.restore();
+
+  // 2. Carve out the offset + blurred copy; the leftover is the inner shadow.
+  c.save();
+  c.globalCompositeOperation = 'destination-out';
+  c.filter = blur > 0 ? `blur(${blur}px)` : 'none';
+  c.translate(dx, dy);
+  c.fillStyle = '#000';
+  paintShape(c);
+  c.restore();
+
+  // 3. Clip the surviving shadow to the shape interior.
+  c.save();
+  c.globalCompositeOperation = 'destination-in';
+  c.filter = 'none';
+  c.fillStyle = '#000';
+  paintShape(c);
+  c.restore();
+
+  // 4. Composite over the live shape.
+  liveCtx.save();
+  liveCtx.drawImage(aux as CanvasImageSource, 0, 0);
+  liveCtx.restore();
+}
+
+/**
+ * softEdge — ECMA-376 §20.1.8.53. "The edges of the shape are blurred, while the
+ * fill is not affected." We feather the shape's alpha by `rad` EMU: build a
+ * blurred silhouette mask and `destination-in` it onto the already-painted shape
+ * so the perimeter fades to transparent over the feather radius.
+ *
+ * This helper paints the shape onto an auxiliary canvas, then intersects it with
+ * a blurred version of its own silhouette, then blits the feathered result back.
+ * Because the mask is the blurred silhouette, the interior (where blur leaves
+ * alpha = 1) is untouched and only the edge band fades — matching the spec's
+ * "fill is not affected".
+ */
+export function applySoftEdge(
+  liveCtx: AuxContext,
+  paintShape: PaintShape,
+  _bbox: EffectBBox,
+  softEdge: SoftEdge,
+  scale: number,
+  deviceW: number,
+  deviceH: number,
+): void {
+  const radius = emuToPx(softEdge.radius, scale);
+  if (radius <= 0) {
+    // No feather: paint straight onto the live context.
+    paintShape(liveCtx);
+    return;
+  }
+
+  const aux = createAuxCanvas(deviceW, deviceH);
+  if (!aux) {
+    paintShape(liveCtx);
+    return;
+  }
+  const c = get2d(aux);
+  if (!c) {
+    paintShape(liveCtx);
+    return;
+  }
+
+  // 1. Paint the full shape (fill + stroke) onto the aux canvas.
+  paintShape(c);
+
+  // 2. Intersect with a blurred silhouette mask to feather the perimeter.
+  //    A box blur of `radius` px feathers the edge over ~radius px each side;
+  //    ECMA gives `rad` as the blur radius directly.
+  c.save();
+  c.globalCompositeOperation = 'destination-in';
+  c.filter = `blur(${radius}px)`;
+  c.fillStyle = '#000';
+  paintShape(c);
+  c.restore();
+
+  // 3. Blit the feathered shape back to the live context.
+  liveCtx.save();
+  liveCtx.drawImage(aux as CanvasImageSource, 0, 0);
+  liveCtx.restore();
+}
+
+/**
+ * reflection — ECMA-376 §20.1.8.50. A mirrored copy of the shape rendered below
+ * it, faded out by a linear alpha gradient.
+ *
+ * Steps:
+ *   1. Paint the shape onto an aux canvas (its own silhouette + fill/stroke).
+ *   2. Apply a vertical alpha gradient via `destination-in`: alpha runs from
+ *      `stA` at `stPos` to `endA` at `endPos` along the (post-mirror top→bottom)
+ *      ramp. With the default fadeDir=5400000 (90°, downward) the ramp is the
+ *      reflection's own vertical axis.
+ *   3. Blit the faded copy onto the live context under a transform that mirrors
+ *      it (sx/sy), offsets it by `dist` along `dir`, and anchors it to the
+ *      shape's bottom edge (algn="b" default).
+ *
+ * Skew (kx/ky), non-bottom alignment, fadeDir != 90°, and rotWithShape are not
+ * carried by the parser model; their spec defaults are assumed (kx=ky=0,
+ * algn="b", fadeDir=90°, rotWithShape=true → reflection shares the shape's
+ * rotation, which the caller's transform already provides).
+ */
+export function applyReflection(
+  liveCtx: AuxContext,
+  paintShape: PaintShape,
+  bbox: EffectBBox,
+  reflection: Reflection,
+  scale: number,
+  deviceW: number,
+  deviceH: number,
+): void {
+  const aux = createAuxCanvas(deviceW, deviceH);
+  if (!aux) return;
+  const c = get2d(aux);
+  if (!c) return;
+
+  const blur = emuToPx(reflection.blur, scale);
+
+  // 1. Paint the shape onto the aux canvas, optionally blurred.
+  c.save();
+  if (blur > 0) c.filter = `blur(${blur}px)`;
+  paintShape(c);
+  c.restore();
+
+  // 2. Fade with a vertical alpha gradient over the shape's bbox band.
+  //    Map stPos/endPos (0..1 along the ramp) to the bbox top..bottom.
+  c.save();
+  c.globalCompositeOperation = 'destination-in';
+  const top = bbox.y;
+  const bottom = bbox.y + bbox.h;
+  const grad = c.createLinearGradient(0, top, 0, bottom);
+  const stPos = clamp01(reflection.stPos);
+  const endPos = clamp01(reflection.endPos);
+  // Guard equal stops (createLinearGradient requires strictly increasing offsets
+  // only loosely, but identical offsets collapse the ramp). stA applies before
+  // stPos, endA after endPos — pad the ends so the band outside [stPos,endPos]
+  // holds the terminal alpha.
+  grad.addColorStop(0, `rgba(0,0,0,${reflection.stA})`);
+  if (stPos > 0) grad.addColorStop(stPos, `rgba(0,0,0,${reflection.stA})`);
+  if (endPos < 1 && endPos > stPos) grad.addColorStop(endPos, `rgba(0,0,0,${reflection.endA})`);
+  grad.addColorStop(1, `rgba(0,0,0,${reflection.endA})`);
+  c.fillStyle = grad;
+  c.fillRect(0, 0, deviceW, deviceH);
+  c.restore();
+
+  // 3. Blit the faded mirror under the shape. Mirror about the shape's bottom
+  //    edge (algn="b"): reflect across y = bottom, then push down by `dist`.
+  const dist = emuToPx(reflection.dist, scale);
+  const dirRad = (reflection.dir * Math.PI) / 180;
+  const offX = Math.cos(dirRad) * dist;
+  const offY = Math.sin(dirRad) * dist;
+
+  liveCtx.save();
+  // Translate to the bottom edge, apply sx/sy scale (sy<0 = mirror), then
+  // translate back. Anchoring at the bottom edge keeps the reflection's top
+  // touching the shape's bottom before `dist` separation.
+  liveCtx.translate(bbox.x + offX, bottom + offY);
+  liveCtx.scale(reflection.sx, reflection.sy);
+  liveCtx.translate(-(bbox.x), -bottom);
+  liveCtx.drawImage(aux as CanvasImageSource, 0, 0);
+  liveCtx.restore();
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1092,6 +1092,8 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     applySoftEdge(
       ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D); },
       effBBox, el.softEdge, effScale, deviceW, deviceH,
+      // Mask is the flat filled silhouette (no stroke) — see applySoftEdge.
+      (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D, '#000'); },
     );
     ctx.restore();
   } else {

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -29,6 +29,9 @@ import {
   EMU_PER_PT as PT_TO_EMU,
   mathToMathML,
   recolorSvg,
+  applyInnerShadow,
+  applySoftEdge,
+  applyReflection,
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import { drawPlayBadge } from './media-chrome';
@@ -978,14 +981,6 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     'callout1', 'bordercallout1', 'accentcallout1', 'accentbordercallout1',
   ]);
 
-  const applyAndStroke = el.stroke
-    ? () => {
-        applyStroke(ctx, el.stroke!, scale);
-        ctx.stroke();
-      }
-    : null;
-  const clearShadowOnce = () => clearShadow(ctx);
-
   // ── Dispatch to preset engine when possible ────────────────────────────
   // Preference order: custGeom → generic preset engine → legacy switch.
   // `arc` keeps its bespoke case because its fill semantics (pie-wedge vs
@@ -993,31 +988,126 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const usePresetEngine =
     !el.custGeom && geom !== 'arc' && hasPreset(geom);
 
-  if (usePresetEngine) {
-    renderPresetShape(
-      ctx, geom, x, y, w, h,
-      [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
-      fillStyle, applyAndStroke, clearShadowOnce,
-    );
-  } else {
-    ctx.beginPath();
+  /**
+   * Paint the shape's body (fill + stroke) into an arbitrary target context,
+   * dispatching through the same preset / custGeom / legacy paths as the live
+   * render. Extracted into a closure so the edge/blur effect helpers
+   * (innerShdw §20.1.8.40, softEdge §20.1.8.53, reflection §20.1.8.50) can
+   * re-paint the shape onto auxiliary canvases.
+   *
+   * `silhouette`: when set, paint a flat opaque silhouette in that colour
+   * (filled path only, no stroke, no gradients) — used by innerShdw to build
+   * its mask. The silhouette honours the same even-odd / preset path topology.
+   */
+  const paintShapeBody = (
+    target: CanvasRenderingContext2D,
+    silhouette?: string,
+  ): void => {
+    const tFill = silhouette ?? fillStyle;
+    const tStroke = silhouette
+      ? null
+      : el.stroke
+        ? () => {
+            applyStroke(target, el.stroke!, scale);
+            target.stroke();
+          }
+        : null;
+    const tClearShadow = () => clearShadow(target);
+
+    if (usePresetEngine && !silhouette) {
+      renderPresetShape(
+        target, geom, x, y, w, h,
+        [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
+        tFill, tStroke, tClearShadow,
+      );
+      return;
+    }
+
+    target.beginPath();
     if (el.custGeom && el.custGeom.length > 0) {
-      buildCustomPath(ctx, el.custGeom, x, y, w, h);
+      buildCustomPath(target, el.custGeom, x, y, w, h);
+    } else if (usePresetEngine) {
+      // Silhouette of a preset shape: build a single filled outline. Preset
+      // path 0 is the body outline (secondary paths are highlights), so the
+      // legacy buildShapePath gives a faithful silhouette of the body.
+      buildShapePath(target, geom, x, y, w, h, el.adj, el.adj2, el.adj3, el.adj4);
     } else {
-      buildShapePath(ctx, geom, x, y, w, h, el.adj, el.adj2, el.adj3, el.adj4);
+      buildShapePath(target, geom, x, y, w, h, el.adj, el.adj2, el.adj3, el.adj4);
     }
-    if (fillStyle && geom !== 'arc') {
-      ctx.fillStyle = fillStyle;
+    if (tFill && geom !== 'arc') {
+      target.fillStyle = tFill;
       if (geom === 'donut' || geom === 'smileyface' || geom === 'frame') {
-        ctx.fill('evenodd');
+        target.fill('evenodd');
       } else {
-        ctx.fill();
+        target.fill();
       }
-      clearShadow(ctx);
+      if (!silhouette) tClearShadow();
     }
-    if (applyAndStroke) {
-      applyAndStroke();
+    if (tStroke) {
+      tStroke();
     }
+  };
+
+  // ── effectLst edge/blur effects (independent siblings, ECMA-376 §20.1.8.25)
+  // Device-pixel canvas extent for the auxiliary effect canvases.
+  const deviceW = (ctx.canvas as { width: number }).width || 0;
+  const deviceH = (ctx.canvas as { height: number }).height || 0;
+  // The effect helpers operate in DEVICE pixels: the aux silhouette is painted
+  // through the live transform (which already folds in devicePixelRatio +
+  // rotation + flip), and the blit happens at identity. So bbox / radii passed
+  // to the helpers must be in device px too. The uniform device scale equals
+  // sqrt(|det|) of the transform's linear part — for scale(dpr)·rot·flip this
+  // is exactly dpr, independent of rotation or mirroring.
+  const liveTransform = ctx.getTransform();
+  const det = Math.abs(liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c);
+  const devScale = det > 0 ? Math.sqrt(det) : 1;
+  const effBBox = { x: x * devScale, y: y * devScale, w: w * devScale, h: h * devScale };
+  const effScale = scale * devScale; // EMU → device px
+  const applyLiveTransform = (c: CanvasRenderingContext2D) => {
+    c.setTransform(liveTransform);
+  };
+
+  // Reflection sits BEHIND/below the shape — draw it first so the body paints
+  // on top. §20.1.8.50. The aux silhouette bakes in the live rotation/flip via
+  // setTransform, and the helper's mirror transform operates in device space,
+  // so the live ctx must blit at identity.
+  if (el.reflection && deviceW > 0 && deviceH > 0) {
+    ctx.save();
+    ctx.setTransform(new DOMMatrix());
+    applyReflection(
+      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D); },
+      effBBox, el.reflection, effScale, deviceW, deviceH,
+    );
+    ctx.restore();
+  }
+
+  // softEdge feathers the whole body, so it REPLACES the direct body paint.
+  // §20.1.8.53. When absent, paint the body normally.
+  if (el.softEdge && deviceW > 0 && deviceH > 0) {
+    // The feathered body is composited in untransformed device space, so reset
+    // the live transform around the blit and re-apply the same transform when
+    // painting the body into the aux canvas.
+    ctx.save();
+    ctx.setTransform(new DOMMatrix());
+    applySoftEdge(
+      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D); },
+      effBBox, el.softEdge, effScale, deviceW, deviceH,
+    );
+    ctx.restore();
+  } else {
+    paintShapeBody(ctx);
+  }
+
+  // innerShdw casts inward, ON TOP of the fill. §20.1.8.40. Composite after the
+  // body. The silhouette callback paints a flat opaque mask.
+  if (el.innerShadow && deviceW > 0 && deviceH > 0) {
+    ctx.save();
+    ctx.setTransform(new DOMMatrix());
+    applyInnerShadow(
+      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D, '#000'); },
+      effBBox, el.innerShadow, effScale, deviceW, deviceH,
+    );
+    ctx.restore();
   }
 
   if (el.stroke && CONNECTOR_GEOMS.has(geom)) {


### PR DESCRIPTION
## Summary

Phase 3 of the v1.0 push: render the three DrawingML shape-level edge/blur effects that were already parsed but not drawn (previously ⚠️ in the Feature Support table).

- **Inner shadow** (`innerShdw`, ECMA-376 §20.1.8.40) — silhouette in the shadow colour, carve an offset+blurred copy via `destination-out`, clip to the interior, composite over the fill.
- **Soft edge** (`softEdge`, §20.1.8.53) — feather the perimeter by intersecting the painted body with a blurred **filled silhouette** mask; the fill is unaffected per spec.
- **Reflection** (`reflection`, §20.1.8.50) — mirrored copy below the shape, faded by a linear `stA→endA` alpha gradient over `stPos→endPos`, mirrored via `sx`/`sy`, offset by `dist` along `dir`, anchored at the bottom edge (`algn="b"`).

New shared module `packages/core/src/shape/effects.ts` exposes the three helpers (plus `createAuxCanvas`). Each takes a `paintShape` silhouette callback so the pptx renderer reuses its preset / custGeom / legacy dispatch (`paintShapeBody`). Effects operate in **device pixels** — DPR + rotation/flip are folded in via the live transform's `sqrt(|det|)`, the aux silhouette is painted through that transform, and the result is blitted at identity. Aux canvases prefer `OffscreenCanvas`.

No parser or WASM change: all three effects were already parsed (with unit tests) upstream.

> Note: the prior type/parser comments cited wrong section numbers (§20.1.8.21 / .27 / .31). The spec prose places these at §20.1.8.40 / .50 / .53; new code uses the correct numbers.

## Verification

- 8 new unit tests for the effect compositing pipeline (`effects.test.ts`); full suite **182/182** green; `tsc --build` green; `ast-grep scan` clean.
- Generated synthetic pptx (python-pptx + raw `effectLst` XML, not committed) covering each effect + combos + stroked roundRect + unstroked ellipse: all render correctly, fill preserved under `softEdge`.
- Rotated-shape sample: inner shadow tracks the rotated edges; reflection rotates with the shape (`rotWithShape` default true).
- VRT `demo/sample-1` (9 slides): 97–100% match, identical to the documented baseline — no regression (sample carries no effects).

Reference images were **not** updated (per repo policy); the new effects only affect shapes that carry these `effectLst` elements, so existing references are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)