### PR TITLE
ci(rust): add fmt/clippy/test quality gate (v1.0 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Rust quality gate for the parser workspace. Runs without the (gitignored,
+  # redistribution-prohibited) sample files: the sample-dependent parser tests
+  # skip themselves when the fixtures are absent.
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -1,21 +1,21 @@
 use wasm_bindgen::prelude::*;
 
-mod types;
-mod xml_util;
-mod styles;
-mod numbering;
-mod parser;
 mod markdown;
 mod math;
+mod numbering;
+mod parser;
+mod styles;
+mod types;
+mod xml_util;
 
 #[wasm_bindgen]
 pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> String {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     match parser::parse(data) {
-        Ok(doc) => serde_json::to_string(&doc).unwrap_or_else(|e| {
-            format!("{{\"error\":\"{}\"}}", e)
-        }),
+        Ok(doc) => {
+            serde_json::to_string(&doc).unwrap_or_else(|e| format!("{{\"error\":\"{}\"}}", e))
+        }
         Err(e) => format!("{{\"error\":\"{}\"}}", e),
     }
 }
@@ -34,8 +34,7 @@ pub fn docx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result
 /// Native equivalent of `parse_docx` for use from the MCP server.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_docx_native(data: &[u8]) -> Result<String, String> {
-    parser::parse(data)
-        .and_then(|doc| serde_json::to_string(&doc).map_err(|e| e.to_string()))
+    parser::parse(data).and_then(|doc| serde_json::to_string(&doc).map_err(|e| e.to_string()))
 }
 
 /// Parse a docx and project the result to GitHub-flavoured markdown:

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -1,16 +1,16 @@
-use std::collections::HashMap;
-use roxmltree::Document as XmlDoc;
 use crate::xml_util::*;
+use roxmltree::Document as XmlDoc;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct LevelDef {
-    pub format: String,  // "decimal" | "bullet" | etc.
-    pub text: String,    // lvlText val, e.g. "%1." or "•"
-    pub indent_left: f64,   // pt — w:ind@left ≡ logical START indent (§17.3.1.12)
+    pub format: String,   // "decimal" | "bullet" | etc.
+    pub text: String,     // lvlText val, e.g. "%1." or "•"
+    pub indent_left: f64, // pt — w:ind@left ≡ logical START indent (§17.3.1.12)
     /// pt — w:ind@right ≡ logical END indent (Part 4 §14.11.2). RTL list levels
     /// carry their indent here (the renderer maps it to the physical left side).
     pub indent_right: Option<f64>,
-    pub tab: f64,            // pt
+    pub tab: f64, // pt
     pub start: u32,
 }
 
@@ -50,7 +50,9 @@ impl NumberingMap {
 
         // Parse abstractNum definitions
         for abs_node in children_w(root, "abstractNum") {
-            let Some(abs_id_s) = attr_w(abs_node, "abstractNumId") else { continue };
+            let Some(abs_id_s) = attr_w(abs_node, "abstractNumId") else {
+                continue;
+            };
             let abs_id: u32 = abs_id_s.parse().unwrap_or(0);
             let mut levels = vec![];
             for lvl_node in children_w(abs_node, "lvl") {
@@ -84,24 +86,38 @@ impl NumberingMap {
                     .and_then(|i| attr_w(i, "hanging").or_else(|| attr_w(i, "firstLine")))
                     .map(|v| twips_to_pt(&v))
                     .unwrap_or(36.0);
-                levels.push(LevelDef { format, text, indent_left, indent_right, tab, start });
+                levels.push(LevelDef {
+                    format,
+                    text,
+                    indent_left,
+                    indent_right,
+                    tab,
+                    start,
+                });
             }
             map.abstract_nums.insert(abs_id, levels);
         }
 
         // Parse num → abstractNum
         for num_node in children_w(root, "num") {
-            let Some(num_id_s) = attr_w(num_node, "numId") else { continue };
+            let Some(num_id_s) = attr_w(num_node, "numId") else {
+                continue;
+            };
             let num_id: u32 = num_id_s.parse().unwrap_or(0);
-            if let Some(abs_ref) = child_w(num_node, "abstractNumId").and_then(|n| attr_w(n, "val")) {
+            if let Some(abs_ref) = child_w(num_node, "abstractNumId").and_then(|n| attr_w(n, "val"))
+            {
                 let abs_id: u32 = abs_ref.parse().unwrap_or(0);
                 map.num_to_abstract.insert(num_id, abs_id);
             }
             // Level overrides
             let mut overrides = HashMap::new();
             for lvl_ov in children_w(num_node, "lvlOverride") {
-                let ilvl: u32 = attr_w(lvl_ov, "ilvl").and_then(|v| v.parse().ok()).unwrap_or(0);
-                if let Some(start_ov) = child_w(lvl_ov, "startOverride").and_then(|n| attr_w(n, "val")) {
+                let ilvl: u32 = attr_w(lvl_ov, "ilvl")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                if let Some(start_ov) =
+                    child_w(lvl_ov, "startOverride").and_then(|n| attr_w(n, "val"))
+                {
                     overrides.insert(ilvl, start_ov.parse().unwrap_or(1));
                 }
             }
@@ -135,7 +151,9 @@ impl NumberingMap {
 
         // Reset deeper levels
         let keys: Vec<u32> = entry.keys().copied().filter(|&l| l > level).collect();
-        for k in keys { entry.remove(&k); }
+        for k in keys {
+            entry.remove(&k);
+        }
 
         // Ensure levels from 0 to level-1 are initialized
         for (lvl, &start) in starts.iter().enumerate().take(level as usize) {
@@ -150,7 +168,9 @@ impl NumberingMap {
 
     /// Resolve the display text for a counter value in the given level.
     pub fn resolve_text(&self, num_id: u32, level: u32, counter: u32) -> String {
-        let Some(lvl) = self.get_level(num_id, level) else { return format!("{}.", counter) };
+        let Some(lvl) = self.get_level(num_id, level) else {
+            return format!("{}.", counter);
+        };
 
         let formatted = format_counter(counter, &lvl.format);
 
@@ -182,12 +202,28 @@ fn format_counter(n: u32, format: &str) -> String {
 }
 
 fn to_roman(n: u32) -> String {
-    let vals = [(1000,"M"),(900,"CM"),(500,"D"),(400,"CD"),(100,"C"),(90,"XC"),
-                (50,"L"),(40,"XL"),(10,"X"),(9,"IX"),(5,"V"),(4,"IV"),(1,"I")];
+    let vals = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ];
     let mut n = n;
     let mut s = String::new();
     for (v, r) in &vals {
-        while n >= *v { s.push_str(r); n -= v; }
+        while n >= *v {
+            s.push_str(r);
+            n -= v;
+        }
     }
     s
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -687,20 +687,18 @@ fn parse_body_elements(
                 let tbl = parse_table(child, style_map, num_map, media_map, rel_map, theme);
                 body.push(BodyElement::Table(tbl));
             }
-            "sectPr" => {
-                // Mid-body loose sectPr (rare) would behave like a page break.
-                // The final body-level sectPr only defines section settings — skip it.
-                if Some(child.id()) != body_level_sect_id {
-                    match read_section_break_type(child).as_deref() {
-                        Some("continuous") => {}
-                        Some("oddPage") => body.push(BodyElement::PageBreak {
-                            parity: Some("odd".to_string()),
-                        }),
-                        Some("evenPage") => body.push(BodyElement::PageBreak {
-                            parity: Some("even".to_string()),
-                        }),
-                        _ => body.push(BodyElement::PageBreak { parity: None }),
-                    }
+            // Mid-body loose sectPr (rare) behaves like a page break. The
+            // final body-level sectPr only defines section settings — skip it.
+            "sectPr" if Some(child.id()) != body_level_sect_id => {
+                match read_section_break_type(child).as_deref() {
+                    Some("continuous") => {}
+                    Some("oddPage") => body.push(BodyElement::PageBreak {
+                        parity: Some("odd".to_string()),
+                    }),
+                    Some("evenPage") => body.push(BodyElement::PageBreak {
+                        parity: Some("even".to_string()),
+                    }),
+                    _ => body.push(BodyElement::PageBreak { parity: None }),
                 }
             }
             _ => {}

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -107,8 +107,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
 
     let sect_pr = body_node
         .children()
-        .filter(|n| n.is_element())
-        .last()
+        .rfind(|n| n.is_element())
         .filter(|n| n.tag_name().name() == "sectPr");
 
     let (section, refs) = parse_section(sect_pr, &rel_map);
@@ -710,6 +709,10 @@ fn parse_body_elements(
     body
 }
 
+// Short-lived intermediate consumed immediately by the caller into BodyElement;
+// boxing the Para variant would add a heap allocation per paragraph on the hot
+// parse path with no real memory benefit for a transient `Vec<ParaPiece>`.
+#[allow(clippy::large_enum_variant)]
 enum ParaPiece {
     Para(DocParagraph),
     PageBreak,
@@ -1215,6 +1218,10 @@ struct FieldState {
     substitute: bool,
 }
 
+// Threads the immutable parse context (style/media/rel maps, theme) plus the
+// running output buffer and revision state through the paragraph walk; grouping
+// these into a context struct would only relocate the same fields.
+#[allow(clippy::too_many_arguments)]
 fn parse_para_content(
     node: roxmltree::Node,
     base_run: &RunFmt,
@@ -1334,6 +1341,9 @@ fn parse_para_content(
     }
 }
 
+// Same parse-context threading as parse_para_content, with the additional
+// hyperlink/field state carried per run.
+#[allow(clippy::too_many_arguments)]
 fn handle_run_in_para(
     r_node: roxmltree::Node,
     base_run: &RunFmt,
@@ -1474,7 +1484,6 @@ fn make_field_run(instr: &str, fmt: &RunFmt, fallback: &str, theme: &ThemeColors
 
 fn classify_field(instr: &str) -> String {
     let token = instr
-        .trim()
         .split_whitespace()
         .next()
         .unwrap_or("")
@@ -1486,6 +1495,8 @@ fn classify_field(instr: &str) -> String {
     }
 }
 
+// Same parse-context threading as handle_run_in_para.
+#[allow(clippy::too_many_arguments)]
 fn parse_run_inner(
     node: roxmltree::Node,
     base_run: &RunFmt,
@@ -2395,6 +2406,10 @@ fn parse_wgp_shapes(
 /// from group child coord space to page EMU; `group_off_pt_*` are the group origin
 /// on the page (in pt) so the shape's off.x/off.y (in child coord space) can be
 /// translated to page-relative pt. For a standalone wsp (no wgp), pass sx=sy=1, group_off=0.
+// Carries the accumulated anchor/group coordinate transform (offsets, scale,
+// relative-from flags, z-order) needed to place a wsp shape in page space;
+// these are interdependent transform parameters, not an arbitrary bag.
+#[allow(clippy::too_many_arguments)]
 fn parse_wsp_shape(
     wsp: roxmltree::Node,
     theme: &ThemeColors,
@@ -4333,7 +4348,7 @@ mod rtl_tests {
             })
             .unwrap();
         // `w:b` sets the non-CS bold…
-        assert_eq!(run.bold, true, "w:b sets non-CS bold");
+        assert!(run.bold, "w:b sets non-CS bold");
         // …and `w:bCs` is absent, so the parser leaves the CS bold axis None.
         // The renderer mirrors it from `bold` (boldCs ?? bold) per the PDF-
         // verified sample-7 page-1 behaviour; that fallback lives in renderer.ts.

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,14 +1,16 @@
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use roxmltree::Document as XmlDoc;
 use std::collections::HashMap;
 use std::io::Read;
 use zip::ZipArchive;
-use roxmltree::Document as XmlDoc;
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as B64;
 
-use crate::xml_util::*;
-use crate::types::*;
-use crate::styles::{StyleMap, parse_para_fmt, parse_run_fmt, ParaFmt, RunFmt, CondFmt, RawTblBorders, EdgeBorder};
 use crate::numbering::NumberingMap;
+use crate::styles::{
+    parse_para_fmt, parse_run_fmt, CondFmt, EdgeBorder, ParaFmt, RawTblBorders, RunFmt, StyleMap,
+};
+use crate::types::*;
+use crate::xml_util::*;
 
 const DEFAULT_FONT_SIZE: f64 = 10.0; // pt fallback
 
@@ -26,21 +28,32 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     let cursor = std::io::Cursor::new(data);
     let mut zip = ZipArchive::new(cursor).map_err(|e| e.to_string())?;
 
-    let rels_xml = read_zip_entry(&mut zip, "word/_rels/document.xml.rels")
-        .unwrap_or_default();
+    let rels_xml = read_zip_entry(&mut zip, "word/_rels/document.xml.rels").unwrap_or_default();
     let rel_map = parse_rels(&rels_xml);
 
     // Styles are referenced from the document relationships (Target may be
     // "styles.xml" or "styles2.xml"). Fall back to "word/styles.xml" for old files.
     let styles_path = find_rel_target(&rels_xml, "styles")
-        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .map(|t| {
+            if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            }
+        })
         .unwrap_or_else(|| "word/styles.xml".to_string());
     let style_map = read_zip_entry(&mut zip, &styles_path)
         .map(|s| StyleMap::parse(&s))
         .unwrap_or_else(|_| StyleMap::parse(""));
 
     let numbering_path = find_rel_target(&rels_xml, "numbering")
-        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .map(|t| {
+            if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            }
+        })
         .unwrap_or_else(|| "word/numbering.xml".to_string());
     let mut num_map = read_zip_entry(&mut zip, &numbering_path)
         .map(|s| NumberingMap::parse(&s))
@@ -50,15 +63,27 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     // to word/<target> and parse the clrScheme.
     let mut theme = find_rel_target(&rels_xml, "theme")
         .map(|t| {
-            let p = if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) };
-            read_zip_entry(&mut zip, &p).map(|s| ThemeColors::parse(&s)).unwrap_or_default()
+            let p = if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            };
+            read_zip_entry(&mut zip, &p)
+                .map(|s| ThemeColors::parse(&s))
+                .unwrap_or_default()
         })
         .unwrap_or_default();
 
     // §17.15.1.88 w:themeFontLang — when the theme leaves a cs typeface empty,
     // the settings' bidi language decides the actual complex-script face.
     let settings_path = find_rel_target(&rels_xml, "settings")
-        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .map(|t| {
+            if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            }
+        })
         .unwrap_or_else(|| "word/settings.xml".to_string());
     let mut document_settings: Option<crate::types::DocumentSettings> = None;
     if let Ok(settings_xml) = read_zip_entry(&mut zip, &settings_path) {
@@ -74,22 +99,45 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     let doc_xml = read_zip_entry(&mut zip, "word/document.xml")?;
     let xml_doc = XmlDoc::parse(&doc_xml).map_err(|e| e.to_string())?;
 
-    let body_node = xml_doc.root_element()
+    let body_node = xml_doc
+        .root_element()
         .descendants()
         .find(|n| n.tag_name().name() == "body")
         .ok_or("No body element")?;
 
-    let sect_pr = body_node.children()
+    let sect_pr = body_node
+        .children()
         .filter(|n| n.is_element())
         .last()
         .filter(|n| n.tag_name().name() == "sectPr");
 
     let (section, refs) = parse_section(sect_pr, &rel_map);
 
-    let body = parse_body_elements(body_node, &style_map, &mut num_map, &media_map, &rel_map, &theme);
+    let body = parse_body_elements(
+        body_node,
+        &style_map,
+        &mut num_map,
+        &media_map,
+        &rel_map,
+        &theme,
+    );
 
-    let headers = load_header_footer_set(&mut zip, &refs.headers, "hdr", &style_map, &mut num_map, &theme);
-    let footers = load_header_footer_set(&mut zip, &refs.footers, "ftr", &style_map, &mut num_map, &theme);
+    let headers = load_header_footer_set(
+        &mut zip,
+        &refs.headers,
+        "hdr",
+        &style_map,
+        &mut num_map,
+        &theme,
+    );
+    let footers = load_header_footer_set(
+        &mut zip,
+        &refs.footers,
+        "ftr",
+        &style_map,
+        &mut num_map,
+        &theme,
+    );
 
     let major_font = theme.theme_font("major", "latin");
     let minor_font = theme.theme_font("minor", "latin");
@@ -98,7 +146,13 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     // Resolve via relationship (Type ending in "/fontTable"); fall back to
     // "word/fontTable.xml" for documents that omit the relationship.
     let font_table_path = find_rel_target(&rels_xml, "fontTable")
-        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .map(|t| {
+            if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            }
+        })
         .unwrap_or_else(|| "word/fontTable.xml".to_string());
     let font_family_classes = read_zip_entry(&mut zip, &font_table_path)
         .map(|s| parse_font_table(&s))
@@ -111,24 +165,51 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     let revisions = collect_revisions(body_node);
 
     let comments = find_rel_target(&rels_xml, "comments")
-        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .map(|t| {
+            if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            }
+        })
         .and_then(|p| read_zip_entry(&mut zip, &p).ok())
         .map(|xml| parse_comments(&xml))
         .unwrap_or_default();
     let footnotes = find_rel_target(&rels_xml, "footnotes")
-        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .map(|t| {
+            if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            }
+        })
         .and_then(|p| read_zip_entry(&mut zip, &p).ok())
         .map(|xml| parse_notes(&xml, "footnote"))
         .unwrap_or_default();
     let endnotes = find_rel_target(&rels_xml, "endnotes")
-        .map(|t| if t.starts_with('/') { t.trim_start_matches('/').to_string() } else { format!("word/{}", t) })
+        .map(|t| {
+            if t.starts_with('/') {
+                t.trim_start_matches('/').to_string()
+            } else {
+                format!("word/{}", t)
+            }
+        })
         .and_then(|p| read_zip_entry(&mut zip, &p).ok())
         .map(|xml| parse_notes(&xml, "endnote"))
         .unwrap_or_default();
 
     Ok(Document {
-        section, body, headers, footers, major_font, minor_font, font_family_classes,
-        revisions, comments, footnotes, endnotes,
+        section,
+        body,
+        headers,
+        footers,
+        major_font,
+        minor_font,
+        font_family_classes,
+        revisions,
+        comments,
+        footnotes,
+        endnotes,
         settings: document_settings,
     })
 }
@@ -178,19 +259,53 @@ fn collect_revisions(body: roxmltree::Node) -> Vec<crate::types::DocxRevision> {
 
 /// Parse word/comments.xml into a flat list of `<w:comment>` entries.
 fn parse_comments(xml: &str) -> Vec<crate::types::DocxComment> {
-    let Ok(doc) = roxmltree::Document::parse(xml) else { return Vec::new(); };
+    let Ok(doc) = roxmltree::Document::parse(xml) else {
+        return Vec::new();
+    };
     let mut out = Vec::new();
-    for c in doc.descendants().filter(|n| n.is_element() && n.tag_name().name() == "comment") {
-        let id = c.attributes().find(|a| a.name() == "id").map(|a| a.value().to_string()).unwrap_or_default();
-        if id.is_empty() { continue }
-        let author = c.attributes().find(|a| a.name() == "author").map(|a| a.value().to_string()).filter(|s| !s.is_empty());
-        let initials = c.attributes().find(|a| a.name() == "initials").map(|a| a.value().to_string()).filter(|s| !s.is_empty());
-        let date = c.attributes().find(|a| a.name() == "date").map(|a| a.value().to_string()).filter(|s| !s.is_empty());
-        let mut text = String::new();
-        for t in c.descendants().filter(|n| n.is_element() && n.tag_name().name() == "t") {
-            if let Some(s) = t.text() { text.push_str(s); }
+    for c in doc
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "comment")
+    {
+        let id = c
+            .attributes()
+            .find(|a| a.name() == "id")
+            .map(|a| a.value().to_string())
+            .unwrap_or_default();
+        if id.is_empty() {
+            continue;
         }
-        out.push(crate::types::DocxComment { id, author, initials, date, text });
+        let author = c
+            .attributes()
+            .find(|a| a.name() == "author")
+            .map(|a| a.value().to_string())
+            .filter(|s| !s.is_empty());
+        let initials = c
+            .attributes()
+            .find(|a| a.name() == "initials")
+            .map(|a| a.value().to_string())
+            .filter(|s| !s.is_empty());
+        let date = c
+            .attributes()
+            .find(|a| a.name() == "date")
+            .map(|a| a.value().to_string())
+            .filter(|s| !s.is_empty());
+        let mut text = String::new();
+        for t in c
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "t")
+        {
+            if let Some(s) = t.text() {
+                text.push_str(s);
+            }
+        }
+        out.push(crate::types::DocxComment {
+            id,
+            author,
+            initials,
+            date,
+            text,
+        });
     }
     out
 }
@@ -199,14 +314,30 @@ fn parse_comments(xml: &str) -> Vec<crate::types::DocxComment> {
 /// reserved entries (id="-1" separator, id="0" continuation separator)
 /// per ECMA-376 §17.11.10.
 fn parse_notes(xml: &str, element_name: &str) -> Vec<crate::types::DocxNote> {
-    let Ok(doc) = roxmltree::Document::parse(xml) else { return Vec::new(); };
+    let Ok(doc) = roxmltree::Document::parse(xml) else {
+        return Vec::new();
+    };
     let mut out = Vec::new();
-    for n in doc.descendants().filter(|n| n.is_element() && n.tag_name().name() == element_name) {
-        let id = n.attributes().find(|a| a.name() == "id").map(|a| a.value().to_string()).unwrap_or_default();
-        if id.is_empty() || id == "-1" || id == "0" { continue }
+    for n in doc
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == element_name)
+    {
+        let id = n
+            .attributes()
+            .find(|a| a.name() == "id")
+            .map(|a| a.value().to_string())
+            .unwrap_or_default();
+        if id.is_empty() || id == "-1" || id == "0" {
+            continue;
+        }
         let mut text = String::new();
-        for t in n.descendants().filter(|t| t.is_element() && t.tag_name().name() == "t") {
-            if let Some(s) = t.text() { text.push_str(s); }
+        for t in n
+            .descendants()
+            .filter(|t| t.is_element() && t.tag_name().name() == "t")
+        {
+            if let Some(s) = t.text() {
+                text.push_str(s);
+            }
         }
         out.push(crate::types::DocxNote { id, text });
     }
@@ -234,9 +365,21 @@ impl ThemeColors {
         let mut map: HashMap<String, String> = HashMap::new();
         let mut fonts: HashMap<String, String> = HashMap::new();
         let theme_xml = Some(xml.to_string());
-        let doc = match XmlDoc::parse(xml) { Ok(d) => d, Err(_) => return Self { map, fonts, theme_xml } };
+        let doc = match XmlDoc::parse(xml) {
+            Ok(d) => d,
+            Err(_) => {
+                return Self {
+                    map,
+                    fonts,
+                    theme_xml,
+                }
+            }
+        };
         let root = doc.root_element();
-        if let Some(scheme) = root.descendants().find(|n| n.is_element() && n.tag_name().name() == "clrScheme") {
+        if let Some(scheme) = root
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "clrScheme")
+        {
             for child in scheme.children().filter(|n| n.is_element()) {
                 let name = child.tag_name().name().to_string();
                 let hex = child.children().filter(|n| n.is_element()).find_map(|n| {
@@ -246,19 +389,31 @@ impl ThemeColors {
                         _ => None,
                     }
                 });
-                if let Some(h) = hex { map.insert(name, h); }
+                if let Some(h) = hex {
+                    map.insert(name, h);
+                }
             }
         }
-        if let Some(font_scheme) = root.descendants().find(|n| n.is_element() && n.tag_name().name() == "fontScheme") {
+        if let Some(font_scheme) = root
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "fontScheme")
+        {
             for group_name in &["majorFont", "minorFont"] {
-                let prefix = if *group_name == "majorFont" { "major" } else { "minor" };
-                if let Some(group) = font_scheme.children().find(|n| n.is_element() && n.tag_name().name() == *group_name) {
+                let prefix = if *group_name == "majorFont" {
+                    "major"
+                } else {
+                    "minor"
+                };
+                if let Some(group) = font_scheme
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == *group_name)
+                {
                     for child in group.children().filter(|n| n.is_element()) {
                         let typ = match child.tag_name().name() {
                             "latin" => Some("latin"),
-                            "ea"    => Some("ea"),
-                            "cs"    => Some("cs"),
-                            _       => None,
+                            "ea" => Some("ea"),
+                            "cs" => Some("cs"),
+                            _ => None,
                         };
                         if let Some(t) = typ {
                             if let Some(face) = child.attribute("typeface") {
@@ -271,7 +426,11 @@ impl ThemeColors {
                 }
             }
         }
-        Self { map, fonts, theme_xml }
+        Self {
+            map,
+            fonts,
+            theme_xml,
+        }
     }
 
     fn resolve(&self, scheme_name: &str) -> Option<String> {
@@ -312,7 +471,11 @@ impl ThemeColors {
     /// against sample-7.pdf: the no-rFonts table cells embed ArialMT while
     /// explicit-rFonts runs embed Sakkal Majalla).
     pub fn fill_default_cs_font(&mut self, bidi_lang: &str) {
-        let primary = bidi_lang.split('-').next().unwrap_or("").to_ascii_lowercase();
+        let primary = bidi_lang
+            .split('-')
+            .next()
+            .unwrap_or("")
+            .to_ascii_lowercase();
         let default = match primary.as_str() {
             "ar" | "he" => "Arial",
             _ => return,
@@ -329,11 +492,11 @@ impl ThemeColors {
     pub fn resolve_font(&self, theme_ref: &str) -> Option<String> {
         let (group, axis) = match theme_ref {
             "minorHAnsi" | "minorAscii" => ("minor", "latin"),
-            "minorBidi"                 => ("minor", "cs"),
-            "minorEastAsia"             => ("minor", "ea"),
+            "minorBidi" => ("minor", "cs"),
+            "minorEastAsia" => ("minor", "ea"),
             "majorHAnsi" | "majorAscii" => ("major", "latin"),
-            "majorBidi"                 => ("major", "cs"),
-            "majorEastAsia"             => ("major", "ea"),
+            "majorBidi" => ("major", "cs"),
+            "majorEastAsia" => ("major", "ea"),
             _ => return None,
         };
         self.fonts.get(&format!("{group}/{axis}")).cloned()
@@ -343,7 +506,8 @@ impl ThemeColors {
 /// Extract `<w:themeFontLang w:bidi="…"/>` from word/settings.xml (§17.15.1.88).
 fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
     let doc = XmlDoc::parse(settings_xml).ok()?;
-    let node = doc.root_element()
+    let node = doc
+        .root_element()
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "themeFontLang")?;
     attr_w(node, "bidi").filter(|s| !s.is_empty())
@@ -372,13 +536,20 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
     let collect = |tag: &str| -> Option<String> {
         let mut found = false;
         let mut acc = String::new();
-        for node in root.children().filter(|n| n.is_element() && n.tag_name().name() == tag) {
+        for node in root
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == tag)
+        {
             found = true;
             if let Some(val) = attr_w(node, "val") {
                 acc.push_str(&val);
             }
         }
-        if found { Some(acc) } else { None }
+        if found {
+            Some(acc)
+        } else {
+            None
+        }
     };
     let no_line_breaks_before = collect("noLineBreaksBefore");
     let no_line_breaks_after = collect("noLineBreaksAfter");
@@ -394,9 +565,15 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
 }
 
 fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
-    if rels_xml.is_empty() { return None; }
+    if rels_xml.is_empty() {
+        return None;
+    }
     let doc = XmlDoc::parse(rels_xml).ok()?;
-    for rel in doc.root_element().children().filter(|n| n.tag_name().name() == "Relationship") {
+    for rel in doc
+        .root_element()
+        .children()
+        .filter(|n| n.tag_name().name() == "Relationship")
+    {
         if let (Some(ty), Some(target)) = (rel.attribute("Type"), rel.attribute("Target")) {
             if ty.ends_with(&format!("/{}", type_suffix)) {
                 return Some(target.to_string());
@@ -416,15 +593,23 @@ fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
 /// as `auto`.
 fn parse_font_table(xml: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
-    let Ok(doc) = XmlDoc::parse(xml) else { return map };
+    let Ok(doc) = XmlDoc::parse(xml) else {
+        return map;
+    };
     let w_ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
-    for font in doc.root_element()
-        .descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "font" && n.tag_name().namespace() == Some(w_ns))
-    {
-        let Some(name) = font.attribute((w_ns, "name")) else { continue };
-        let family = font.children()
-            .find(|n| n.is_element() && n.tag_name().name() == "family" && n.tag_name().namespace() == Some(w_ns))
+    for font in doc.root_element().descendants().filter(|n| {
+        n.is_element() && n.tag_name().name() == "font" && n.tag_name().namespace() == Some(w_ns)
+    }) {
+        let Some(name) = font.attribute((w_ns, "name")) else {
+            continue;
+        };
+        let family = font
+            .children()
+            .find(|n| {
+                n.is_element()
+                    && n.tag_name().name() == "family"
+                    && n.tag_name().namespace() == Some(w_ns)
+            })
             .and_then(|n| n.attribute((w_ns, "val")));
         if let Some(f) = family {
             map.insert(name.to_string(), f.to_string());
@@ -455,11 +640,15 @@ fn parse_body_elements(
     for child in body_children {
         match child.tag_name().name() {
             "p" => {
-                let result = parse_paragraph(child, style_map, num_map, media_map, rel_map, theme, None);
-                let is_page_break_only = result.runs.len() == 1 && matches!(
-                    result.runs[0],
-                    DocRun::Break { break_type: BreakType::Page }
-                );
+                let result =
+                    parse_paragraph(child, style_map, num_map, media_map, rel_map, theme, None);
+                let is_page_break_only = result.runs.len() == 1
+                    && matches!(
+                        result.runs[0],
+                        DocRun::Break {
+                            break_type: BreakType::Page
+                        }
+                    );
                 if is_page_break_only {
                     body.push(BodyElement::PageBreak { parity: None });
                     continue;
@@ -481,11 +670,16 @@ fn parse_body_elements(
                 //   - "continuous" → no page break
                 //   - "nextPage" / missing → plain page break
                 //   - "oddPage" / "evenPage" → page break + parity padding
-                if let Some(sect_pr) = child_w(child, "pPr").and_then(|ppr| child_w(ppr, "sectPr")) {
+                if let Some(sect_pr) = child_w(child, "pPr").and_then(|ppr| child_w(ppr, "sectPr"))
+                {
                     match read_section_break_type(sect_pr).as_deref() {
                         Some("continuous") => { /* no page break */ }
-                        Some("oddPage") => body.push(BodyElement::PageBreak { parity: Some("odd".to_string()) }),
-                        Some("evenPage") => body.push(BodyElement::PageBreak { parity: Some("even".to_string()) }),
+                        Some("oddPage") => body.push(BodyElement::PageBreak {
+                            parity: Some("odd".to_string()),
+                        }),
+                        Some("evenPage") => body.push(BodyElement::PageBreak {
+                            parity: Some("even".to_string()),
+                        }),
                         _ => body.push(BodyElement::PageBreak { parity: None }),
                     }
                 }
@@ -500,8 +694,12 @@ fn parse_body_elements(
                 if Some(child.id()) != body_level_sect_id {
                     match read_section_break_type(child).as_deref() {
                         Some("continuous") => {}
-                        Some("oddPage") => body.push(BodyElement::PageBreak { parity: Some("odd".to_string()) }),
-                        Some("evenPage") => body.push(BodyElement::PageBreak { parity: Some("even".to_string()) }),
+                        Some("oddPage") => body.push(BodyElement::PageBreak {
+                            parity: Some("odd".to_string()),
+                        }),
+                        Some("evenPage") => body.push(BodyElement::PageBreak {
+                            parity: Some("even".to_string()),
+                        }),
                         _ => body.push(BodyElement::PageBreak { parity: None }),
                     }
                 }
@@ -549,12 +747,26 @@ fn split_para_on_page_breaks(para: DocParagraph) -> Vec<ParaPiece> {
     // have since absorbed: with this gate gone, private/sample-5 — 66 ruby runs,
     // 5 lastRenderedPageBreak hints, 7 pages — is byte-identical and still
     // matches its Word export.)
-    let is_break_run = |r: &DocRun| matches!(r, DocRun::Break { break_type: BreakType::Page });
+    let is_break_run = |r: &DocRun| {
+        matches!(
+            r,
+            DocRun::Break {
+                break_type: BreakType::Page
+            }
+        )
+    };
     let has_break = para.runs.iter().any(is_break_run);
     if !has_break {
         // Strip the (ignored) RenderedPage runs so they don't pollute layout.
         let mut p = para;
-        p.runs.retain(|r| !matches!(r, DocRun::Break { break_type: BreakType::RenderedPage }));
+        p.runs.retain(|r| {
+            !matches!(
+                r,
+                DocRun::Break {
+                    break_type: BreakType::RenderedPage
+                }
+            )
+        });
         return vec![ParaPiece::Para(p)];
     }
 
@@ -562,16 +774,22 @@ fn split_para_on_page_breaks(para: DocParagraph) -> Vec<ParaPiece> {
     let mut chunks: Vec<Vec<DocRun>> = vec![Vec::new()];
     for run in para.runs.iter().cloned() {
         match &run {
-            DocRun::Break { break_type: BreakType::Page } => chunks.push(Vec::new()),
-            DocRun::Break { break_type: BreakType::RenderedPage } => { /* ignored hint */ }
+            DocRun::Break {
+                break_type: BreakType::Page,
+            } => chunks.push(Vec::new()),
+            DocRun::Break {
+                break_type: BreakType::RenderedPage,
+            } => { /* ignored hint */ }
             _ => chunks.last_mut().unwrap().push(run),
         }
     }
 
     let has_visible = |runs: &Vec<DocRun>| {
-        runs.iter().any(|r| matches!(r,
+        runs.iter().any(|r| {
+            matches!(r,
             DocRun::Text(t) if !t.text.trim().is_empty())
-            || matches!(r, DocRun::Field(_) | DocRun::Image(_) | DocRun::Shape(_)))
+                || matches!(r, DocRun::Field(_) | DocRun::Image(_) | DocRun::Shape(_))
+        })
     };
 
     // Drop trailing chunks that carry no visible content too — this
@@ -638,10 +856,15 @@ fn load_media_map(
                 format!("{}{}", base_dir, target)
             };
             if let Ok(bytes) = read_zip_bytes(zip, &path) {
-                let mime = if path.ends_with(".png") { "image/png" }
-                    else if path.ends_with(".jpg") || path.ends_with(".jpeg") { "image/jpeg" }
-                    else if path.ends_with(".gif") { "image/gif" }
-                    else { "image/png" };
+                let mime = if path.ends_with(".png") {
+                    "image/png"
+                } else if path.ends_with(".jpg") || path.ends_with(".jpeg") {
+                    "image/jpeg"
+                } else if path.ends_with(".gif") {
+                    "image/gif"
+                } else {
+                    "image/png"
+                };
                 let b64 = B64.encode(&bytes);
                 media_map.insert(rid.clone(), format!("data:{};base64,{}", mime, b64));
             }
@@ -677,11 +900,22 @@ fn load_header_footer_set(
             Ok(d) => d,
             Err(_) => continue,
         };
-        let Some(root) = xml_doc.root_element().descendants().find(|n| n.tag_name().name() == root_tag) else {
+        let Some(root) = xml_doc
+            .root_element()
+            .descendants()
+            .find(|n| n.tag_name().name() == root_tag)
+        else {
             continue;
         };
 
-        let body = parse_body_elements(root, style_map, num_map, &local_media_map, &local_rel_map, theme);
+        let body = parse_body_elements(
+            root,
+            style_map,
+            num_map,
+            &local_media_map,
+            &local_rel_map,
+            theme,
+        );
         let hf = HeaderFooter { body };
         match kind.as_str() {
             "first" => out.first = Some(hf),
@@ -692,7 +926,10 @@ fn load_header_footer_set(
     out
 }
 
-fn parse_section(sect_pr: Option<roxmltree::Node>, rel_map: &HashMap<String, String>) -> (SectionProps, SectionRefs) {
+fn parse_section(
+    sect_pr: Option<roxmltree::Node>,
+    rel_map: &HashMap<String, String>,
+) -> (SectionProps, SectionRefs) {
     let default = SectionProps {
         page_width: 612.0,
         page_height: 792.0,
@@ -708,20 +945,38 @@ fn parse_section(sect_pr: Option<roxmltree::Node>, rel_map: &HashMap<String, Str
         doc_grid_line_pitch: None,
     };
 
-    let Some(sp) = sect_pr else { return (default, SectionRefs::default()) };
+    let Some(sp) = sect_pr else {
+        return (default, SectionRefs::default());
+    };
 
     let mut props = default;
     if let Some(pg_sz) = child_w(sp, "pgSz") {
-        if let Some(w) = attr_w(pg_sz, "w") { props.page_width = twips_to_pt(&w); }
-        if let Some(h) = attr_w(pg_sz, "h") { props.page_height = twips_to_pt(&h); }
+        if let Some(w) = attr_w(pg_sz, "w") {
+            props.page_width = twips_to_pt(&w);
+        }
+        if let Some(h) = attr_w(pg_sz, "h") {
+            props.page_height = twips_to_pt(&h);
+        }
     }
     if let Some(pg_mar) = child_w(sp, "pgMar") {
-        if let Some(v) = attr_w(pg_mar, "top") { props.margin_top = twips_to_pt(&v); }
-        if let Some(v) = attr_w(pg_mar, "right") { props.margin_right = twips_to_pt(&v); }
-        if let Some(v) = attr_w(pg_mar, "bottom") { props.margin_bottom = twips_to_pt(&v); }
-        if let Some(v) = attr_w(pg_mar, "left") { props.margin_left = twips_to_pt(&v); }
-        if let Some(v) = attr_w(pg_mar, "header") { props.header_distance = twips_to_pt(&v); }
-        if let Some(v) = attr_w(pg_mar, "footer") { props.footer_distance = twips_to_pt(&v); }
+        if let Some(v) = attr_w(pg_mar, "top") {
+            props.margin_top = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "right") {
+            props.margin_right = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "bottom") {
+            props.margin_bottom = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "left") {
+            props.margin_left = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "header") {
+            props.header_distance = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "footer") {
+            props.footer_distance = twips_to_pt(&v);
+        }
     }
     props.title_page = child_w(sp, "titlePg").is_some();
 
@@ -746,13 +1001,18 @@ fn parse_section(sect_pr: Option<roxmltree::Node>, rel_map: &HashMap<String, Str
     let mut refs = SectionRefs::default();
     for child in sp.children().filter(|n| n.is_element()) {
         let local = child.tag_name().name();
-        if local != "headerReference" && local != "footerReference" { continue; }
+        if local != "headerReference" && local != "footerReference" {
+            continue;
+        }
         let kind = attr_w(child, "type").unwrap_or_else(|| "default".to_string());
-        let rid = child.attribute((R_NS, "id"))
+        let rid = child
+            .attribute((R_NS, "id"))
             .or_else(|| child.attribute("id"))
             .map(|s| s.to_string());
         let Some(rid) = rid else { continue };
-        let Some(target) = rel_map.get(&rid) else { continue };
+        let Some(target) = rel_map.get(&rid) else {
+            continue;
+        };
         let target = target.trim_start_matches('/').to_string();
         if local == "headerReference" {
             refs.headers.insert(kind, target);
@@ -781,7 +1041,8 @@ fn parse_paragraph(
         .and_then(|s| attr_w(s, "val"));
 
     // Resolve base formatting from style
-    let (mut base_para, mut base_run) = style_map.resolve_para(explicit_style_id.as_deref(), table_style_id);
+    let (mut base_para, mut base_run) =
+        style_map.resolve_para(explicit_style_id.as_deref(), table_style_id);
 
     // Apply direct paragraph formatting overrides
     if let Some(ppr) = ppr_node {
@@ -794,59 +1055,100 @@ fn parse_paragraph(
         }
     }
 
-    let mut alignment = base_para.alignment.as_deref().map(normalize_align).unwrap_or("left").to_string();
+    let mut alignment = base_para
+        .alignment
+        .as_deref()
+        .map(normalize_align)
+        .unwrap_or("left")
+        .to_string();
     let alignment_explicit = base_para.alignment.is_some();
     let indent_right = base_para.indent_right.unwrap_or(0.0);
     let space_before = base_para.space_before.unwrap_or(0.0);
     let space_after = base_para.space_after.unwrap_or(0.0);
     let line_spacing = base_para.line_spacing_val.map(|v| LineSpacing {
         value: v,
-        rule: base_para.line_spacing_rule.clone().unwrap_or_else(|| "auto".to_string()),
+        rule: base_para
+            .line_spacing_rule
+            .clone()
+            .unwrap_or_else(|| "auto".to_string()),
         explicit: base_para.line_spacing_explicit.unwrap_or(false),
     });
 
     // Numbering — extract level data before advancing counter (avoids borrow conflict)
-    let numbering = if let (Some(num_id), Some(num_level)) = (base_para.num_id, base_para.num_level) {
+    let numbering = if let (Some(num_id), Some(num_level)) = (base_para.num_id, base_para.num_level)
+    {
         if num_id != 0 {
-            let (format, ind_left, tab) = num_map.get_level(num_id, num_level)
+            let (format, ind_left, tab) = num_map
+                .get_level(num_id, num_level)
                 .map(|l| (l.format.clone(), l.indent_left, l.tab))
                 .unwrap_or_else(|| ("decimal".to_string(), 36.0, 18.0));
             let counter = num_map.advance(num_id, num_level);
             let text = num_map.resolve_text(num_id, num_level, counter);
-            Some(NumberingInfo { num_id, level: num_level, format, text, indent_left: ind_left, tab })
-        } else { None }
-    } else { None };
+            Some(NumberingInfo {
+                num_id,
+                level: num_level,
+                format,
+                text,
+                indent_left: ind_left,
+                tab,
+            })
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     // Numbering level's pPr/ind overrides the paragraph style's indent
     let (indent_left, indent_first) = if let Some(ref num) = numbering {
-        num_map.get_level(num.num_id, num.level)
+        num_map
+            .get_level(num.num_id, num.level)
             .map(|l| (l.indent_left, -l.tab))
-            .unwrap_or((base_para.indent_left.unwrap_or(0.0), base_para.indent_first.unwrap_or(0.0)))
+            .unwrap_or((
+                base_para.indent_left.unwrap_or(0.0),
+                base_para.indent_first.unwrap_or(0.0),
+            ))
     } else {
-        (base_para.indent_left.unwrap_or(0.0), base_para.indent_first.unwrap_or(0.0))
+        (
+            base_para.indent_left.unwrap_or(0.0),
+            base_para.indent_first.unwrap_or(0.0),
+        )
     };
     // Same for the end-side indent (w:ind@right ≡ end): an RTL list level
     // defines its indent there (e.g. w:right="720" w:hanging="360").
-    let indent_right = numbering.as_ref()
+    let indent_right = numbering
+        .as_ref()
         .and_then(|num| num_map.get_level(num.num_id, num.level))
         .and_then(|l| l.indent_right)
         .unwrap_or(indent_right);
 
     // Parse runs
     let mut runs = vec![];
-    parse_para_content(node, &base_run, style_map, media_map, rel_map, theme, &mut runs, None);
+    parse_para_content(
+        node, &base_run, style_map, media_map, rel_map, theme, &mut runs, None,
+    );
 
     // OMML display equations (m:oMathPara) are center-justified by default (§22.1.2.88
     // m:jc). When the paragraph has no explicit alignment, centering the block math
     // matches Word.
     if !alignment_explicit
-        && runs.iter().any(|r| matches!(r, DocRun::Math { display: true, .. }))
+        && runs
+            .iter()
+            .any(|r| matches!(r, DocRun::Math { display: true, .. }))
     {
         alignment = "center".to_string();
     }
 
-    let tab_stops = base_para.tab_stops.clone().unwrap_or_default().into_iter()
-        .map(|(pos, alignment, leader)| TabStop { pos, alignment, leader })
+    let tab_stops = base_para
+        .tab_stops
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(pos, alignment, leader)| TabStop {
+            pos,
+            alignment,
+            leader,
+        })
         .collect();
 
     DocParagraph {
@@ -867,7 +1169,9 @@ fn parse_paragraph(
         // when styles.xml doesn't spell it out — demoted heading paragraphs
         // (outlineLvl 0..8) are pinned to the next paragraph so the heading
         // never orphans at page bottom. Honor an explicit false to opt out.
-        keep_next: base_para.keep_next.unwrap_or_else(|| base_para.outline_level.is_some()),
+        keep_next: base_para
+            .keep_next
+            .unwrap_or_else(|| base_para.outline_level.is_some()),
         keep_lines: base_para.keep_lines.unwrap_or(false),
         // ECMA-376 §17.3.1.44: widowControl defaults to true when absent.
         widow_control: base_para.widow_control.unwrap_or(true),
@@ -884,7 +1188,8 @@ fn parse_paragraph(
         // Resolve the paragraph's default font the same way runs do (ascii
         // first, then eastAsia, through theme refs) so empty paragraphs can be
         // sized with the intended font's line metrics.
-        default_font_family: theme.resolve_font_ref(base_run.font_family_ascii.clone())
+        default_font_family: theme
+            .resolve_font_ref(base_run.font_family_ascii.clone())
             .or_else(|| theme.resolve_font_ref(base_run.font_family_east_asia.clone())),
         outline_level: base_para.outline_level,
         // ECMA-376 §17.3.1.6 — RTL paragraph flag resolved through the style
@@ -925,15 +1230,31 @@ fn parse_para_content(
     for child in element_children_flat(node) {
         match child.tag_name().name() {
             "r" => {
-                handle_run_in_para(child, base_run, style_map, media_map, theme, runs, &mut field, None, revision);
+                handle_run_in_para(
+                    child, base_run, style_map, media_map, theme, runs, &mut field, None, revision,
+                );
             }
             "hyperlink" => {
                 // Resolve URL from r:id via relationships
-                let href = child.attribute((R_NS, "id"))
+                let href = child
+                    .attribute((R_NS, "id"))
                     .or_else(|| child.attribute("id"))
                     .and_then(|rid| rel_map.get(rid).cloned());
-                for r in child.children().filter(|n| n.is_element() && n.tag_name().name() == "r") {
-                    handle_run_in_para(r, base_run, style_map, media_map, theme, runs, &mut field, Some(href.clone()), revision);
+                for r in child
+                    .children()
+                    .filter(|n| n.is_element() && n.tag_name().name() == "r")
+                {
+                    handle_run_in_para(
+                        r,
+                        base_run,
+                        style_map,
+                        media_map,
+                        theme,
+                        runs,
+                        &mut field,
+                        Some(href.clone()),
+                        revision,
+                    );
                 }
             }
             "ins" | "del" => {
@@ -941,22 +1262,40 @@ fn parse_para_content(
                 // every descendant run so the renderer can paint tracked
                 // changes inline. Nested ins/del isn't legal per spec; the
                 // inner block wins if it occurs anyway.
-                let kind = if child.tag_name().name() == "ins" { "insertion" } else { "deletion" };
+                let kind = if child.tag_name().name() == "ins" {
+                    "insertion"
+                } else {
+                    "deletion"
+                };
                 let inner = RunRevision {
                     kind: kind.to_string(),
                     author: attr_w(child, "author"),
                     date: attr_w(child, "date"),
                 };
-                parse_para_content(child, base_run, style_map, media_map, rel_map, theme, runs, Some(&inner));
+                parse_para_content(
+                    child,
+                    base_run,
+                    style_map,
+                    media_map,
+                    rel_map,
+                    theme,
+                    runs,
+                    Some(&inner),
+                );
             }
             "smartTag" => {
-                parse_para_content(child, base_run, style_map, media_map, rel_map, theme, runs, revision);
+                parse_para_content(
+                    child, base_run, style_map, media_map, rel_map, theme, runs, revision,
+                );
             }
             "fldSimple" => {
                 let instr = attr_w(child, "instr").unwrap_or_default();
                 // Collect formatting from the first contained run (if any)
                 let mut fmt = base_run.clone();
-                if let Some(r) = child.children().find(|n| n.is_element() && n.tag_name().name() == "r") {
+                if let Some(r) = child
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "r")
+                {
                     if let Some(rpr) = child_w(r, "rPr") {
                         apply_direct_run(&mut fmt, &parse_run_fmt(rpr));
                     }
@@ -1047,7 +1386,12 @@ fn handle_run_in_para(
             "end" => {
                 if field.active && field.substitute {
                     let fmt = field.fmt.clone().unwrap_or_else(|| base_run.clone());
-                    runs.push(make_field_run(&field.instruction, &fmt, &field.fallback, theme));
+                    runs.push(make_field_run(
+                        &field.instruction,
+                        &fmt,
+                        &field.fallback,
+                        theme,
+                    ));
                 }
                 *field = FieldState::default();
             }
@@ -1074,7 +1418,10 @@ fn handle_run_in_para(
 
     if field.active && field.substitute {
         // Cached result of a recomputed field (PAGE/NUMPAGES) — swallow it.
-        for c in r_node.children().filter(|n| n.is_element() && n.tag_name().name() == "t") {
+        for c in r_node
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "t")
+        {
             if let Some(t) = c.text() {
                 field.fallback.push_str(t);
             }
@@ -1084,7 +1431,9 @@ fn handle_run_in_para(
     // field.active && past_separate && !substitute → fall through and render the result.
 
     // Normal run
-    parse_run_inner(r_node, base_run, style_map, media_map, theme, runs, link_href, revision);
+    parse_run_inner(
+        r_node, base_run, style_map, media_map, theme, runs, link_href, revision,
+    );
 }
 
 fn extract_text_from_runs(node: roxmltree::Node) -> String {
@@ -1124,7 +1473,12 @@ fn make_field_run(instr: &str, fmt: &RunFmt, fallback: &str, theme: &ThemeColors
 }
 
 fn classify_field(instr: &str) -> String {
-    let token = instr.trim().split_whitespace().next().unwrap_or("").to_ascii_uppercase();
+    let token = instr
+        .trim()
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
     match token.as_str() {
         "PAGE" => "page".to_string(),
         "NUMPAGES" => "numPages".to_string(),
@@ -1159,7 +1513,9 @@ fn parse_run_inner(
     }
 
     // Skip hidden runs entirely
-    if fmt.vanish.unwrap_or(false) { return; }
+    if fmt.vanish.unwrap_or(false) {
+        return;
+    }
 
     // External links (URL) vs internal-document links (anchor: TOC entries,
     // cross-references). Word renders internal links as plain body text — NOT with
@@ -1274,11 +1630,14 @@ fn parse_run_inner(
                 }));
             }
             "br" => {
-                let break_type = attr_w(child, "type").as_deref().map(|v| match v {
-                    "page" => BreakType::Page,
-                    "column" => BreakType::Column,
-                    _ => BreakType::Line,
-                }).unwrap_or(BreakType::Line);
+                let break_type = attr_w(child, "type")
+                    .as_deref()
+                    .map(|v| match v {
+                        "page" => BreakType::Page,
+                        "column" => BreakType::Column,
+                        _ => BreakType::Line,
+                    })
+                    .unwrap_or(BreakType::Line);
                 runs.push(DocRun::Break { break_type });
             }
             "lastRenderedPageBreak" => {
@@ -1287,7 +1646,9 @@ fn parse_run_inner(
                 // it as a separate `RenderedPage` break type so the
                 // paragraph splitter can decide whether to honor it
                 // (currently: only inside ruby-bearing paragraphs).
-                runs.push(DocRun::Break { break_type: BreakType::RenderedPage });
+                runs.push(DocRun::Break {
+                    break_type: BreakType::RenderedPage,
+                });
             }
             "ruby" => {
                 // ECMA-376 §17.3.3.25 w:ruby — phonetic guide (furigana).
@@ -1310,14 +1671,29 @@ fn parse_run_inner(
                     .map(|hp| hp / 2.0) // half-points → points
                     .unwrap_or_else(|| fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE) / 2.0);
                 let ruby = if !rt_text.is_empty() {
-                    Some(RubyAnnotation { text: rt_text, font_size_pt: rt_size_pt })
+                    Some(RubyAnnotation {
+                        text: rt_text,
+                        font_size_pt: rt_size_pt,
+                    })
                 } else {
                     None
                 };
                 if let Some(rb) = child_w(child, "rubyBase") {
                     let before = runs.len();
-                    for inner in rb.children().filter(|n| n.is_element() && n.tag_name().name() == "r") {
-                        parse_run_inner(inner, &fmt, style_map, media_map, theme, runs, link_href.clone(), revision);
+                    for inner in rb
+                        .children()
+                        .filter(|n| n.is_element() && n.tag_name().name() == "r")
+                    {
+                        parse_run_inner(
+                            inner,
+                            &fmt,
+                            style_map,
+                            media_map,
+                            theme,
+                            runs,
+                            link_href.clone(),
+                            revision,
+                        );
                     }
                     // Attach ruby to the FIRST text run produced from rubyBase
                     // (typical case is a single base run carrying one or two
@@ -1413,7 +1789,10 @@ fn parse_inline_drawing(
             Some(c) => c,
             None => return vec![],
         };
-        let extent = match container.children().find(|n| n.tag_name().name() == "extent") {
+        let extent = match container
+            .children()
+            .find(|n| n.tag_name().name() == "extent")
+        {
             Some(e) => e,
             None => return vec![],
         };
@@ -1429,7 +1808,10 @@ fn parse_inline_drawing(
             Some(b) => b,
             None => return vec![],
         };
-        let r_id = match blip.attribute((R_NS, "embed")).or_else(|| blip.attribute("r:embed")) {
+        let r_id = match blip
+            .attribute((R_NS, "embed"))
+            .or_else(|| blip.attribute("r:embed"))
+        {
             Some(r) => r,
             None => return vec![],
         };
@@ -1464,13 +1846,16 @@ fn parse_inline_drawing(
 
     // Parse positionH / positionV with relativeFrom
     let (pos_x, x_from_margin, x_align) = parse_anchor_pos_h(&container);
-    let (pos_y, y_from_para,   y_align) = parse_anchor_pos_v(&container);
+    let (pos_y, y_from_para, y_align) = parse_anchor_pos_v(&container);
     let (pct_h, pct_v, rel_h, rel_v) = parse_anchor_pct_pos(&container);
     let (size_w_pct, size_h_pct, size_w_rel, size_h_rel) = parse_anchor_size_rel(&container);
     let anchor_meta = parse_anchor_wrap(&container);
 
     // behindDoc="1" flag — renderer uses this to draw shapes before text
-    let behind_doc = container.attribute("behindDoc").map(|v| v == "1" || v == "true").unwrap_or(false);
+    let behind_doc = container
+        .attribute("behindDoc")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
 
     let apply_pos_meta = |shp: &mut ShapeRun| {
         shp.anchor_x_align = x_align.clone();
@@ -1486,12 +1871,31 @@ fn parse_inline_drawing(
     };
 
     // Check for wgp (Word Graphics Group) — expands to multiple per-element entries
-    if let Some(wgp) = container.descendants().find(|n| n.tag_name().name() == "wgp") {
+    if let Some(wgp) = container
+        .descendants()
+        .find(|n| n.tag_name().name() == "wgp")
+    {
         let mut out: Vec<DocRun> = Vec::new();
-        for img in parse_wgp_images(wgp, media_map, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta) {
+        for img in parse_wgp_images(
+            wgp,
+            media_map,
+            pos_x,
+            x_from_margin,
+            pos_y,
+            y_from_para,
+            &anchor_meta,
+        ) {
             out.push(DocRun::Image(img));
         }
-        for mut shp in parse_wgp_shapes(wgp, theme, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta) {
+        for mut shp in parse_wgp_shapes(
+            wgp,
+            theme,
+            pos_x,
+            x_from_margin,
+            pos_y,
+            y_from_para,
+            &anchor_meta,
+        ) {
             shp.behind_doc = behind_doc;
             apply_pos_meta(&mut shp);
             out.push(DocRun::Shape(shp));
@@ -1500,8 +1904,24 @@ fn parse_inline_drawing(
     }
 
     // wps:wsp directly under the anchor (no wgp wrapper)
-    if let Some(wsp) = container.descendants().find(|n| n.tag_name().name() == "wsp") {
-        if let Some(mut shp) = parse_wsp_shape(wsp, theme, pos_x, x_from_margin, pos_y, y_from_para, &anchor_meta, 1.0, 1.0, 0.0, 0.0, 0) {
+    if let Some(wsp) = container
+        .descendants()
+        .find(|n| n.tag_name().name() == "wsp")
+    {
+        if let Some(mut shp) = parse_wsp_shape(
+            wsp,
+            theme,
+            pos_x,
+            x_from_margin,
+            pos_y,
+            y_from_para,
+            &anchor_meta,
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0,
+        ) {
             shp.behind_doc = behind_doc;
             apply_pos_meta(&mut shp);
             return vec![DocRun::Shape(shp)];
@@ -1509,7 +1929,10 @@ fn parse_inline_drawing(
     }
 
     // Regular single-blip anchor
-    let extent = match container.children().find(|n| n.tag_name().name() == "extent") {
+    let extent = match container
+        .children()
+        .find(|n| n.tag_name().name() == "extent")
+    {
         Some(e) => e,
         None => return vec![],
     };
@@ -1525,7 +1948,10 @@ fn parse_inline_drawing(
         Some(b) => b,
         None => return vec![],
     };
-    let r_id = match blip.attribute((R_NS, "embed")).or_else(|| blip.attribute("r:embed")) {
+    let r_id = match blip
+        .attribute((R_NS, "embed"))
+        .or_else(|| blip.attribute("r:embed"))
+    {
         Some(r) => r,
         None => return vec![],
     };
@@ -1576,16 +2002,41 @@ fn parse_anchor_wrap(container: &roxmltree::Node) -> AnchorMeta {
     for child in container.children().filter(|n| n.is_element()) {
         let name = child.tag_name().name();
         match name {
-            "wrapSquare"       => { wrap_mode = Some("square".into());       wrap_side = child.attribute("wrapText").map(|s| s.to_string()); break; }
-            "wrapTopAndBottom" => { wrap_mode = Some("topAndBottom".into()); break; }
-            "wrapNone"         => { wrap_mode = Some("none".into());         break; }
-            "wrapTight"        => { wrap_mode = Some("tight".into());        wrap_side = child.attribute("wrapText").map(|s| s.to_string()); break; }
-            "wrapThrough"      => { wrap_mode = Some("through".into());      wrap_side = child.attribute("wrapText").map(|s| s.to_string()); break; }
+            "wrapSquare" => {
+                wrap_mode = Some("square".into());
+                wrap_side = child.attribute("wrapText").map(|s| s.to_string());
+                break;
+            }
+            "wrapTopAndBottom" => {
+                wrap_mode = Some("topAndBottom".into());
+                break;
+            }
+            "wrapNone" => {
+                wrap_mode = Some("none".into());
+                break;
+            }
+            "wrapTight" => {
+                wrap_mode = Some("tight".into());
+                wrap_side = child.attribute("wrapText").map(|s| s.to_string());
+                break;
+            }
+            "wrapThrough" => {
+                wrap_mode = Some("through".into());
+                wrap_side = child.attribute("wrapText").map(|s| s.to_string());
+                break;
+            }
             _ => {}
         }
     }
 
-    AnchorMeta { wrap_mode, wrap_side, dist_top, dist_bottom, dist_left, dist_right }
+    AnchorMeta {
+        wrap_mode,
+        wrap_side,
+        dist_top,
+        dist_bottom,
+        dist_left,
+        dist_right,
+    }
 }
 
 /// Parse positionH — returns (posOffset_pt, needs_margin_offset).
@@ -1602,9 +2053,15 @@ fn find_position_node<'a, 'i>(
     if let Some(n) = container.children().find(|n| n.tag_name().name() == name) {
         return Some(n);
     }
-    for ac in container.children().filter(|n| n.tag_name().name() == "AlternateContent") {
+    for ac in container
+        .children()
+        .filter(|n| n.tag_name().name() == "AlternateContent")
+    {
         if let Some(choice) = ac.children().find(|n| n.tag_name().name() == "Choice") {
-            if let Some(n) = choice.descendants().find(|n| n.is_element() && n.tag_name().name() == name) {
+            if let Some(n) = choice
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == name)
+            {
                 return Some(n);
             }
         }
@@ -1618,7 +2075,8 @@ fn parse_anchor_pos_h(container: &roxmltree::Node) -> (f64, bool, Option<String>
         None => return (0.0, false, None),
     };
     let rel = pos.attribute("relativeFrom").unwrap_or("page");
-    let offset = pos.children()
+    let offset = pos
+        .children()
         .find(|n| n.tag_name().name() == "posOffset")
         .and_then(|n| n.text())
         .and_then(|t| t.parse::<f64>().ok())
@@ -1626,7 +2084,8 @@ fn parse_anchor_pos_h(container: &roxmltree::Node) -> (f64, bool, Option<String>
         .unwrap_or(0.0);
     // ECMA-376 §20.4.3.1: <wp:align>left|center|right</wp:align> takes
     // precedence over posOffset when both are present.
-    let align = pos.children()
+    let align = pos
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "align")
         .and_then(|n| n.text())
         .map(|s| s.trim().to_string())
@@ -1642,13 +2101,15 @@ fn parse_anchor_pos_v(container: &roxmltree::Node) -> (f64, bool, Option<String>
         None => return (0.0, false, None),
     };
     let rel = pos.attribute("relativeFrom").unwrap_or("page");
-    let offset = pos.children()
+    let offset = pos
+        .children()
         .find(|n| n.tag_name().name() == "posOffset")
         .and_then(|n| n.text())
         .and_then(|t| t.parse::<f64>().ok())
         .map(|emu| emu / 12700.0)
         .unwrap_or(0.0);
-    let align = pos.children()
+    let align = pos
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "align")
         .and_then(|n| n.text())
         .map(|s| s.trim().to_string())
@@ -1698,7 +2159,9 @@ fn parse_anchor_size_rel(
     container: &roxmltree::Node,
 ) -> (Option<f64>, Option<f64>, Option<String>, Option<String>) {
     let read = |outer_tag: &str, inner_tag: &str| -> (Option<f64>, Option<String>) {
-        let node = container.children().find(|n| n.tag_name().name() == outer_tag);
+        let node = container
+            .children()
+            .find(|n| n.tag_name().name() == outer_tag);
         let pct = node
             .and_then(|n| {
                 n.descendants()
@@ -1747,19 +2210,40 @@ fn parse_wgp_images(
             Some(e) => e,
             None => continue,
         };
-        let ox = off.attribute("x").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 12700.0;
-        let oy = off.attribute("y").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 12700.0;
-        let cx = ext.attribute("cx").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 12700.0;
-        let cy = ext.attribute("cy").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 12700.0;
+        let ox = off
+            .attribute("x")
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 12700.0;
+        let oy = off
+            .attribute("y")
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 12700.0;
+        let cx = ext
+            .attribute("cx")
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 12700.0;
+        let cy = ext
+            .attribute("cy")
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 12700.0;
 
-        if cx <= 0.0 || cy <= 0.0 { continue; }
+        if cx <= 0.0 || cy <= 0.0 {
+            continue;
+        }
 
         // Find the blip inside this pic
         let blip = match pic.descendants().find(|n| n.tag_name().name() == "blip") {
             Some(b) => b,
             None => continue,
         };
-        let r_id = match blip.attribute((R_NS, "embed")).or_else(|| blip.attribute("r:embed")) {
+        let r_id = match blip
+            .attribute((R_NS, "embed"))
+            .or_else(|| blip.attribute("r:embed"))
+        {
             Some(r) => r,
             None => continue,
         };
@@ -1770,7 +2254,8 @@ fn parse_wgp_images(
 
         // Parse a:clrChange if present — used to make a specific color transparent.
         // clrFrom specifies the source color; clrTo with alpha=0 means replace with transparent.
-        let color_replace_from = blip.children()
+        let color_replace_from = blip
+            .children()
             .find(|n| n.tag_name().name() == "clrChange")
             .and_then(|cc| cc.children().find(|n| n.tag_name().name() == "clrFrom"))
             .and_then(|cf| cf.children().find(|n| n.tag_name().name() == "srgbClr"))
@@ -1810,30 +2295,62 @@ fn parse_wgp_shapes(
     anchor_meta: &AnchorMeta,
 ) -> Vec<ShapeRun> {
     // Read group transform: off/ext (page-relative) vs chOff/chExt (child coord space).
-    let grp_xfrm = wgp.descendants()
+    let grp_xfrm = wgp
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "grpSpPr")
-        .and_then(|gsp| gsp.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm"));
+        .and_then(|gsp| {
+            gsp.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "xfrm")
+        });
     let (off_x, off_y, ext_cx, ext_cy, ch_off_x, ch_off_y, ch_ext_cx, ch_ext_cy) = grp_xfrm
         .map(|x| {
-            let off = x.children().find(|n| n.is_element() && n.tag_name().name() == "off");
-            let ext = x.children().find(|n| n.is_element() && n.tag_name().name() == "ext");
-            let ch_off = x.children().find(|n| n.is_element() && n.tag_name().name() == "chOff");
-            let ch_ext = x.children().find(|n| n.is_element() && n.tag_name().name() == "chExt");
+            let off = x
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "off");
+            let ext = x
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "ext");
+            let ch_off = x
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "chOff");
+            let ch_ext = x
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "chExt");
             (
-                off.and_then(|o| o.attribute("x").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
-                off.and_then(|o| o.attribute("y").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
-                ext.and_then(|e| e.attribute("cx").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
-                ext.and_then(|e| e.attribute("cy").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
-                ch_off.and_then(|o| o.attribute("x").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
-                ch_off.and_then(|o| o.attribute("y").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
-                ch_ext.and_then(|e| e.attribute("cx").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
-                ch_ext.and_then(|e| e.attribute("cy").and_then(|v| v.parse::<f64>().ok())).unwrap_or(0.0),
+                off.and_then(|o| o.attribute("x").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
+                off.and_then(|o| o.attribute("y").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
+                ext.and_then(|e| e.attribute("cx").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
+                ext.and_then(|e| e.attribute("cy").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
+                ch_off
+                    .and_then(|o| o.attribute("x").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
+                ch_off
+                    .and_then(|o| o.attribute("y").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
+                ch_ext
+                    .and_then(|e| e.attribute("cx").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
+                ch_ext
+                    .and_then(|e| e.attribute("cy").and_then(|v| v.parse::<f64>().ok()))
+                    .unwrap_or(0.0),
             )
         })
         .unwrap_or((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 
-    let sx = if ch_ext_cx > 0.0 && ext_cx > 0.0 { ext_cx / ch_ext_cx } else { 1.0 };
-    let sy = if ch_ext_cy > 0.0 && ext_cy > 0.0 { ext_cy / ch_ext_cy } else { 1.0 };
+    let sx = if ch_ext_cx > 0.0 && ext_cx > 0.0 {
+        ext_cx / ch_ext_cx
+    } else {
+        1.0
+    };
+    let sy = if ch_ext_cy > 0.0 && ext_cy > 0.0 {
+        ext_cy / ch_ext_cy
+    } else {
+        1.0
+    };
     // Page-relative offset of the group origin, in EMU. ch_off is subtracted
     // because child coordinates are measured relative to chOff.
     let group_page_off_x_emu = off_x - ch_off_x * sx;
@@ -1847,14 +2364,23 @@ fn parse_wgp_shapes(
     let group_h_pt = (if ext_cy > 0.0 { ext_cy } else { ch_ext_cy }) / 12700.0;
 
     let mut results = Vec::new();
-    for (idx, wsp) in wgp.descendants().filter(|n| n.is_element() && n.tag_name().name() == "wsp").enumerate() {
+    for (idx, wsp) in wgp
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "wsp")
+        .enumerate()
+    {
         if let Some(mut shape) = parse_wsp_shape(
-            wsp, theme,
-            anchor_pos_x, x_from_margin,
-            anchor_pos_y, y_from_para,
+            wsp,
+            theme,
+            anchor_pos_x,
+            x_from_margin,
+            anchor_pos_y,
+            y_from_para,
             anchor_meta,
-            sx, sy,
-            group_page_off_x_emu / 12700.0, group_page_off_y_emu / 12700.0,
+            sx,
+            sy,
+            group_page_off_x_emu / 12700.0,
+            group_page_off_y_emu / 12700.0,
             idx as u32,
         ) {
             shape.group_width_pt = Some(group_w_pt);
@@ -1883,16 +2409,27 @@ fn parse_wsp_shape(
     group_off_pt_y: f64,
     z_order: u32,
 ) -> Option<ShapeRun> {
-    let sp_pr = wsp.children().find(|n| n.is_element() && n.tag_name().name() == "spPr")?;
-    let xfrm = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm")?;
-    let off = xfrm.children().find(|n| n.is_element() && n.tag_name().name() == "off")?;
-    let ext = xfrm.children().find(|n| n.is_element() && n.tag_name().name() == "ext")?;
+    let sp_pr = wsp
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "spPr")?;
+    let xfrm = sp_pr
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "xfrm")?;
+    let off = xfrm
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "off")?;
+    let ext = xfrm
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "ext")?;
     let ox = off.attribute("x").and_then(|v| v.parse::<f64>().ok())?;
     let oy = off.attribute("y").and_then(|v| v.parse::<f64>().ok())?;
     let cx = ext.attribute("cx").and_then(|v| v.parse::<f64>().ok())?;
     let cy = ext.attribute("cy").and_then(|v| v.parse::<f64>().ok())?;
-    if cx <= 0.0 || cy <= 0.0 { return None; }
-    let rotation = xfrm.attribute("rot")
+    if cx <= 0.0 || cy <= 0.0 {
+        return None;
+    }
+    let rotation = xfrm
+        .attribute("rot")
         .and_then(|v| v.parse::<f64>().ok())
         .map(|r| r / 60000.0) // OOXML rotation: 60000ths of a degree
         .unwrap_or(0.0);
@@ -1902,7 +2439,9 @@ fn parse_wsp_shape(
     let anchor_x_pt = anchor_pos_x + group_off_pt_x + ox * sx / 12700.0;
     let anchor_y_pt = anchor_pos_y + group_off_pt_y + oy * sy / 12700.0;
 
-    let cust_geom = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "custGeom");
+    let cust_geom = sp_pr
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "custGeom");
     let (subpaths, preset_geometry, adj_values) = if let Some(cg) = cust_geom {
         (parse_custom_geometry(cg), None, Vec::new())
     } else {
@@ -1920,7 +2459,10 @@ fn parse_wsp_shape(
             .unwrap_or("rect")
             .to_string();
         let adj_values = prst_node
-            .and_then(|p| p.children().find(|n| n.is_element() && n.tag_name().name() == "avLst"))
+            .and_then(|p| {
+                p.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "avLst")
+            })
             .map(|av| {
                 av.children()
                     .filter(|n| n.is_element() && n.tag_name().name() == "gd")
@@ -1934,7 +2476,9 @@ fn parse_wsp_shape(
             .unwrap_or_default();
         (Vec::new(), Some(prst), adj_values)
     };
-    if subpaths.is_empty() && preset_geometry.is_none() { return None; }
+    if subpaths.is_empty() && preset_geometry.is_none() {
+        return None;
+    }
 
     // Direct fills on spPr take priority over wps:style/fillRef. ECMA-376
     // §20.1.4.1.30: when no direct fill is set, the shape's appearance comes
@@ -1943,18 +2487,30 @@ fn parse_wsp_shape(
     let fill = parse_shape_fill(sp_pr, theme).or_else(|| {
         wsp.children()
             .find(|n| n.is_element() && n.tag_name().name() == "style")
-            .and_then(|st| st.children().find(|n| n.is_element() && n.tag_name().name() == "fillRef"))
+            .and_then(|st| {
+                st.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "fillRef")
+            })
             .and_then(|fr| resolve_fill_ref(fr, theme))
     });
-    let (stroke, stroke_width) = sp_pr.children()
+    let (stroke, stroke_width) = sp_pr
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "ln")
         .map(|ln| {
-            let has_no_fill = ln.children().any(|n| n.is_element() && n.tag_name().name() == "noFill");
-            if has_no_fill { return (None, 0.0); }
-            let color = ln.children()
+            let has_no_fill = ln
+                .children()
+                .any(|n| n.is_element() && n.tag_name().name() == "noFill");
+            if has_no_fill {
+                return (None, 0.0);
+            }
+            let color = ln
+                .children()
                 .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
                 .and_then(|sf| resolve_color_element(sf, theme));
-            let w_emu = ln.attribute("w").and_then(|v| v.parse::<f64>().ok()).unwrap_or(9525.0);
+            let w_emu = ln
+                .attribute("w")
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or(9525.0);
             (color, w_emu / 12700.0)
         })
         .unwrap_or((None, 0.0));
@@ -2005,21 +2561,40 @@ fn parse_shape_text_body(
     wsp: roxmltree::Node,
     theme: &ThemeColors,
 ) -> (Vec<ShapeText>, Option<String>, f64, f64, f64, f64) {
-    let txbx = wsp.children().find(|n| n.is_element() && n.tag_name().name() == "txbx");
-    let body_pr = wsp.children().find(|n| n.is_element() && n.tag_name().name() == "bodyPr");
+    let txbx = wsp
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "txbx");
+    let body_pr = wsp
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "bodyPr");
 
     let anchor = body_pr
         .and_then(|b| b.attribute("anchor"))
         .map(|s| s.to_string());
     let emu_to_pt = |v: &str| v.parse::<f64>().ok().map(|e| e / 12700.0).unwrap_or(0.0);
     // ECMA-376 §21.1.2.1.1 defaults: lIns=rIns=91440 EMU, tIns=bIns=45720 EMU
-    let l = body_pr.and_then(|b| b.attribute("lIns")).map(emu_to_pt).unwrap_or(91440.0 / 12700.0);
-    let t = body_pr.and_then(|b| b.attribute("tIns")).map(emu_to_pt).unwrap_or(45720.0 / 12700.0);
-    let r = body_pr.and_then(|b| b.attribute("rIns")).map(emu_to_pt).unwrap_or(91440.0 / 12700.0);
-    let b = body_pr.and_then(|b| b.attribute("bIns")).map(emu_to_pt).unwrap_or(45720.0 / 12700.0);
+    let l = body_pr
+        .and_then(|b| b.attribute("lIns"))
+        .map(emu_to_pt)
+        .unwrap_or(91440.0 / 12700.0);
+    let t = body_pr
+        .and_then(|b| b.attribute("tIns"))
+        .map(emu_to_pt)
+        .unwrap_or(45720.0 / 12700.0);
+    let r = body_pr
+        .and_then(|b| b.attribute("rIns"))
+        .map(emu_to_pt)
+        .unwrap_or(91440.0 / 12700.0);
+    let b = body_pr
+        .and_then(|b| b.attribute("bIns"))
+        .map(emu_to_pt)
+        .unwrap_or(45720.0 / 12700.0);
 
     let blocks: Vec<ShapeText> = txbx
-        .and_then(|t| t.children().find(|n| n.is_element() && n.tag_name().name() == "txbxContent"))
+        .and_then(|t| {
+            t.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "txbxContent")
+        })
         .map(|content| {
             children_w_flat(content, "p")
                 .into_iter()
@@ -2036,17 +2611,25 @@ fn parse_shape_text_body(
 fn extract_simple_paragraph_text(p: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeText> {
     let mut text = String::new();
     let mut first_rpr: Option<roxmltree::Node> = None;
-    for r in p.descendants().filter(|n| n.is_element() && n.tag_name().name() == "r") {
+    for r in p
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "r")
+    {
         if first_rpr.is_none() {
             first_rpr = child_w(r, "rPr");
         }
-        for t in r.descendants().filter(|n| n.is_element() && n.tag_name().name() == "t") {
+        for t in r
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "t")
+        {
             if let Some(text_node) = t.text() {
                 text.push_str(text_node);
             }
         }
     }
-    if text.is_empty() { return None; }
+    if text.is_empty() {
+        return None;
+    }
 
     let alignment = child_w(p, "pPr")
         .and_then(|ppr| child_w(ppr, "jc"))
@@ -2058,7 +2641,8 @@ fn extract_simple_paragraph_text(p: roxmltree::Node, theme: &ThemeColors) -> Opt
         (
             fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE),
             fmt.color.clone(),
-            theme.resolve_font_ref(fmt.font_family_ascii.clone())
+            theme
+                .resolve_font_ref(fmt.font_family_ascii.clone())
                 .or_else(|| theme.resolve_font_ref(fmt.font_family_east_asia.clone())),
             fmt.bold.unwrap_or(false),
             fmt.italic.unwrap_or(false),
@@ -2093,8 +2677,7 @@ fn extract_simple_paragraph_text(p: roxmltree::Node, theme: &ThemeColors) -> Opt
 fn parse_vml_pict(pict: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeRun> {
     // v:shape / v:rect / v:roundrect — any VML shape element with geometry.
     let shape = pict.descendants().find(|n| {
-        n.is_element()
-            && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
+        n.is_element() && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
     })?;
 
     // CSS-like `style`: "position:relative;width:300pt;height:60pt;…"
@@ -2216,20 +2799,21 @@ fn parse_shape_fill(sp_pr: roxmltree::Node, theme: &ThemeColors) -> Option<Shape
 /// indirectly as `fillRef idx="1003"` with the actual color and gradient
 /// parameters living in the theme part. Without this lookup, the shape ends
 /// up with no fill and the cover panel renders blank.
-fn resolve_fill_ref(
-    fill_ref: roxmltree::Node,
-    theme: &ThemeColors,
-) -> Option<ShapeFill> {
+fn resolve_fill_ref(fill_ref: roxmltree::Node, theme: &ThemeColors) -> Option<ShapeFill> {
     let idx: u32 = fill_ref.attribute("idx")?.parse().ok()?;
-    if idx == 0 { return None; }
-    let scheme_clr = fill_ref.children()
+    if idx == 0 {
+        return None;
+    }
+    let scheme_clr = fill_ref
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "schemeClr")
         .and_then(|n| n.attribute("val"))
         .unwrap_or("dk1");
 
     let xml = theme.theme_xml.as_ref()?;
     let doc = XmlDoc::parse(xml).ok()?;
-    let fmt = doc.root_element()
+    let fmt = doc
+        .root_element()
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "fmtScheme")?;
     // ECMA-376 §20.1.4.1.30: fillRef idx is 1-indexed.
@@ -2240,14 +2824,14 @@ fn resolve_fill_ref(
     } else {
         ("fillStyleLst", (idx - 1) as usize)
     };
-    let lst = fmt.children().find(|n| n.is_element() && n.tag_name().name() == lst_name)?;
+    let lst = fmt
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == lst_name)?;
     let entry = lst.children().filter(|n| n.is_element()).nth(local_idx)?;
 
     match entry.tag_name().name() {
-        "solidFill" => {
-            resolve_color_element_with_phclr(entry, theme, scheme_clr)
-                .map(|c| ShapeFill::Solid { color: c })
-        }
+        "solidFill" => resolve_color_element_with_phclr(entry, theme, scheme_clr)
+            .map(|c| ShapeFill::Solid { color: c }),
         "gradFill" => parse_grad_fill_phclr(entry, theme, scheme_clr),
         // blipFill / pattFill recipes aren't supported yet — fall back to no fill.
         _ => None,
@@ -2263,44 +2847,87 @@ fn parse_grad_fill_phclr(
     theme: &ThemeColors,
     ph_clr: &str,
 ) -> Option<ShapeFill> {
-    let gs_lst = node.children().find(|n| n.is_element() && n.tag_name().name() == "gsLst")?;
+    let gs_lst = node
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "gsLst")?;
     let mut stops: Vec<GradientStop> = Vec::new();
-    for gs in gs_lst.children().filter(|n| n.is_element() && n.tag_name().name() == "gs") {
-        let pos = gs.attribute("pos").and_then(|v| v.parse::<f64>().ok()).map(|p| p / 100000.0).unwrap_or(0.0);
+    for gs in gs_lst
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "gs")
+    {
+        let pos = gs
+            .attribute("pos")
+            .and_then(|v| v.parse::<f64>().ok())
+            .map(|p| p / 100000.0)
+            .unwrap_or(0.0);
         if let Some(color) = resolve_color_element_with_phclr(gs, theme, ph_clr) {
-            stops.push(GradientStop { position: pos, color });
+            stops.push(GradientStop {
+                position: pos,
+                color,
+            });
         }
     }
-    if stops.is_empty() { return None; }
+    if stops.is_empty() {
+        return None;
+    }
 
     // Linear direction (a:lin ang = "60000"ths of a degree)
-    let (angle, grad_type) = if let Some(lin) = node.children().find(|n| n.is_element() && n.tag_name().name() == "lin") {
-        let ang = lin.attribute("ang").and_then(|v| v.parse::<f64>().ok()).map(|a| a / 60000.0).unwrap_or(0.0);
+    let (angle, grad_type) = if let Some(lin) = node
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "lin")
+    {
+        let ang = lin
+            .attribute("ang")
+            .and_then(|v| v.parse::<f64>().ok())
+            .map(|a| a / 60000.0)
+            .unwrap_or(0.0);
         (ang, "linear".to_string())
-    } else if node.children().any(|n| n.is_element() && n.tag_name().name() == "path") {
+    } else if node
+        .children()
+        .any(|n| n.is_element() && n.tag_name().name() == "path")
+    {
         (0.0, "radial".to_string())
     } else {
         (0.0, "linear".to_string())
     };
 
-    Some(ShapeFill::Gradient { stops, angle, grad_type })
+    Some(ShapeFill::Gradient {
+        stops,
+        angle,
+        grad_type,
+    })
 }
 
 /// Parse <a:custGeom><a:pathLst><a:path w="W" h="H">...</a:path></a:pathLst>.
 /// Path coords inside each <a:path> are absolute within W×H; normalize to [0,1].
 fn parse_custom_geometry(cust_geom: roxmltree::Node) -> Vec<Vec<PathCmd>> {
-    let Some(path_lst) = cust_geom.children().find(|n| n.is_element() && n.tag_name().name() == "pathLst") else {
+    let Some(path_lst) = cust_geom
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "pathLst")
+    else {
         return vec![];
     };
     let mut subpaths: Vec<Vec<PathCmd>> = Vec::new();
-    for path in path_lst.children().filter(|n| n.is_element() && n.tag_name().name() == "path") {
-        let pw = path.attribute("w").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0);
-        let ph = path.attribute("h").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0);
-        if pw <= 0.0 || ph <= 0.0 { continue; }
+    for path in path_lst
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "path")
+    {
+        let pw = path
+            .attribute("w")
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0);
+        let ph = path
+            .attribute("h")
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0);
+        if pw <= 0.0 || ph <= 0.0 {
+            continue;
+        }
         let mut cmds: Vec<PathCmd> = Vec::new();
         for cmd in path.children().filter(|n| n.is_element()) {
             let name = cmd.tag_name().name();
-            let pts: Vec<(f64, f64)> = cmd.children()
+            let pts: Vec<(f64, f64)> = cmd
+                .children()
                 .filter(|n| n.is_element() && n.tag_name().name() == "pt")
                 .filter_map(|p| {
                     let x = p.attribute("x").and_then(|v| v.parse::<f64>().ok())?;
@@ -2309,29 +2936,63 @@ fn parse_custom_geometry(cust_geom: roxmltree::Node) -> Vec<Vec<PathCmd>> {
                 })
                 .collect();
             match name {
-                "moveTo" => { if let Some(p) = pts.first() { cmds.push(PathCmd::MoveTo { x: p.0, y: p.1 }); } }
-                "lnTo" => { if let Some(p) = pts.first() { cmds.push(PathCmd::LineTo { x: p.0, y: p.1 }); } }
+                "moveTo" => {
+                    if let Some(p) = pts.first() {
+                        cmds.push(PathCmd::MoveTo { x: p.0, y: p.1 });
+                    }
+                }
+                "lnTo" => {
+                    if let Some(p) = pts.first() {
+                        cmds.push(PathCmd::LineTo { x: p.0, y: p.1 });
+                    }
+                }
                 "cubicBezTo" => {
                     if pts.len() >= 3 {
                         cmds.push(PathCmd::CubicBezTo {
-                            x1: pts[0].0, y1: pts[0].1,
-                            x2: pts[1].0, y2: pts[1].1,
-                            x:  pts[2].0, y:  pts[2].1,
+                            x1: pts[0].0,
+                            y1: pts[0].1,
+                            x2: pts[1].0,
+                            y2: pts[1].1,
+                            x: pts[2].0,
+                            y: pts[2].1,
                         });
                     }
                 }
                 "arcTo" => {
-                    let wr = cmd.attribute("wR").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / pw;
-                    let hr = cmd.attribute("hR").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / ph;
-                    let st_ang = cmd.attribute("stAng").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 60000.0;
-                    let sw_ang = cmd.attribute("swAng").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 60000.0;
-                    cmds.push(PathCmd::ArcTo { wr, hr, st_ang, sw_ang });
+                    let wr = cmd
+                        .attribute("wR")
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .unwrap_or(0.0)
+                        / pw;
+                    let hr = cmd
+                        .attribute("hR")
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .unwrap_or(0.0)
+                        / ph;
+                    let st_ang = cmd
+                        .attribute("stAng")
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .unwrap_or(0.0)
+                        / 60000.0;
+                    let sw_ang = cmd
+                        .attribute("swAng")
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .unwrap_or(0.0)
+                        / 60000.0;
+                    cmds.push(PathCmd::ArcTo {
+                        wr,
+                        hr,
+                        st_ang,
+                        sw_ang,
+                    });
                 }
                 "close" => cmds.push(PathCmd::Close),
                 _ => {}
             }
         }
-        if !cmds.is_empty() { subpaths.push(cmds); }
+        if !cmds.is_empty() {
+            subpaths.push(cmds);
+        }
     }
     subpaths
 }
@@ -2357,10 +3018,16 @@ fn resolve_color_element_with_phclr(
             "srgbClr" => c.attribute("val").map(|v| v.to_uppercase()),
             "schemeClr" => {
                 let raw_name = c.attribute("val")?;
-                let name = if raw_name == "phClr" && !ph_clr.is_empty() { ph_clr } else { raw_name };
+                let name = if raw_name == "phClr" && !ph_clr.is_empty() {
+                    ph_clr
+                } else {
+                    raw_name
+                };
                 theme.resolve(name)
             }
-            "sysClr" => c.attribute("lastClr").map(|v| v.to_uppercase())
+            "sysClr" => c
+                .attribute("lastClr")
+                .map(|v| v.to_uppercase())
                 .or_else(|| c.attribute("val").map(|v| v.to_uppercase())),
             _ => None,
         };
@@ -2405,12 +3072,14 @@ fn parse_table(
         .and_then(|s| attr_w(s, "val"));
 
     // Column widths from tblGrid
-    let col_widths: Vec<f64> = tbl_grid.map(|g| {
-        children_w(g, "gridCol")
-            .iter()
-            .map(|c| attr_w(*c, "w").map(|v| twips_to_pt(&v)).unwrap_or(72.0))
-            .collect()
-    }).unwrap_or_default();
+    let col_widths: Vec<f64> = tbl_grid
+        .map(|g| {
+            children_w(g, "gridCol")
+                .iter()
+                .map(|c| attr_w(*c, "w").map(|v| twips_to_pt(&v)).unwrap_or(72.0))
+                .collect()
+        })
+        .unwrap_or_default();
 
     // Resolve the table style's cell/border formatting (shading, banding, borders,
     // vAlign) — these live in styles.xml, not inline (§17.7.6). tblLook selects which
@@ -2426,7 +3095,8 @@ fn parse_table(
 
     // Table borders: inline tblBorders win; otherwise the table style's borders
     // (so styles like "Table Grid" show their gridlines).
-    let mut borders = tbl_pr.and_then(|p| child_w(p, "tblBorders"))
+    let mut borders = tbl_pr
+        .and_then(|p| child_w(p, "tblBorders"))
         .map(|b| parse_table_borders(b))
         .unwrap_or_default();
     apply_style_borders(&mut borders, &tstyle.borders);
@@ -2434,12 +3104,26 @@ fn parse_table(
     // Cell margins
     let (cm_top, cm_bot, cm_left, cm_right) = tbl_pr
         .and_then(|p| child_w(p, "tblCellMar"))
-        .map(|m| (
-            child_w(m, "top").and_then(|n| attr_w(n, "w")).map(|v| twips_to_pt(&v)).unwrap_or(0.0),
-            child_w(m, "bottom").and_then(|n| attr_w(n, "w")).map(|v| twips_to_pt(&v)).unwrap_or(0.0),
-            child_w(m, "left").and_then(|n| attr_w(n, "w")).map(|v| twips_to_pt(&v)).unwrap_or(3.6),
-            child_w(m, "right").and_then(|n| attr_w(n, "w")).map(|v| twips_to_pt(&v)).unwrap_or(3.6),
-        ))
+        .map(|m| {
+            (
+                child_w(m, "top")
+                    .and_then(|n| attr_w(n, "w"))
+                    .map(|v| twips_to_pt(&v))
+                    .unwrap_or(0.0),
+                child_w(m, "bottom")
+                    .and_then(|n| attr_w(n, "w"))
+                    .map(|v| twips_to_pt(&v))
+                    .unwrap_or(0.0),
+                child_w(m, "left")
+                    .and_then(|n| attr_w(n, "w"))
+                    .map(|v| twips_to_pt(&v))
+                    .unwrap_or(3.6),
+                child_w(m, "right")
+                    .and_then(|n| attr_w(n, "w"))
+                    .map(|v| twips_to_pt(&v))
+                    .unwrap_or(3.6),
+            )
+        })
         .unwrap_or((0.0, 0.0, 3.6, 3.6));
 
     let mut rows = vec![];
@@ -2451,7 +3135,15 @@ fn parse_table(
                 .and_then(|p| child_w(p, "cnfStyle"))
                 .and_then(|c| attr_w(c, "val")),
         );
-        let row = parse_table_row(tr_node, style_map, num_map, media_map, rel_map, theme, table_style_id.as_deref());
+        let row = parse_table_row(
+            tr_node,
+            style_map,
+            num_map,
+            media_map,
+            rel_map,
+            theme,
+            table_style_id.as_deref(),
+        );
         rows.push(row);
     }
 
@@ -2473,13 +3165,26 @@ fn parse_table(
         } else if r == 0 && first_row_styled {
             Some("firstRow".to_string())
         } else if h_band {
-            let bi = if first_row_styled { r as i64 - 1 } else { r as i64 };
-            Some(if bi % 2 == 0 { "band1Horz" } else { "band2Horz" }.to_string())
+            let bi = if first_row_styled {
+                r as i64 - 1
+            } else {
+                r as i64
+            };
+            Some(
+                if bi % 2 == 0 {
+                    "band1Horz"
+                } else {
+                    "band2Horz"
+                }
+                .to_string(),
+            )
         } else {
             None
         };
         let cond: Option<&CondFmt> = cond_name.as_deref().and_then(|n| tstyle.cond.get(n));
-        let row_shd = cond.and_then(|c| c.shd.clone()).or_else(|| tstyle.cell_shd.clone());
+        let row_shd = cond
+            .and_then(|c| c.shd.clone())
+            .or_else(|| tstyle.cell_shd.clone());
         for cell in row.cells.iter_mut() {
             if cell.background.is_none() {
                 cell.background = row_shd.clone();
@@ -2511,8 +3216,16 @@ fn parse_table(
         .map(|w| {
             let wtype = attr_w(w, "type").unwrap_or_else(|| "dxa".to_string());
             match wtype.as_str() {
-                "dxa" => (attr_w(w, "w").map(|v| twips_to_pt(&v)).filter(|v| *v > 0.0), None),
-                "pct" => (None, attr_w(w, "w").and_then(|v| v.parse::<f64>().ok()).filter(|v| *v > 0.0)),
+                "dxa" => (
+                    attr_w(w, "w").map(|v| twips_to_pt(&v)).filter(|v| *v > 0.0),
+                    None,
+                ),
+                "pct" => (
+                    None,
+                    attr_w(w, "w")
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .filter(|v| *v > 0.0),
+                ),
                 _ => (None, None),
             }
         })
@@ -2560,11 +3273,24 @@ fn parse_table_row(
 
     let mut cells = vec![];
     for tc_node in children_w_flat(node, "tc") {
-        let cell = parse_table_cell(tc_node, style_map, num_map, media_map, rel_map, theme, table_style_id);
+        let cell = parse_table_cell(
+            tc_node,
+            style_map,
+            num_map,
+            media_map,
+            rel_map,
+            theme,
+            table_style_id,
+        );
         cells.push(cell);
     }
 
-    DocTableRow { cells, row_height, row_height_rule, is_header }
+    DocTableRow {
+        cells,
+        row_height,
+        row_height_rule,
+        is_header,
+    }
 }
 
 fn parse_table_cell(
@@ -2587,21 +3313,24 @@ fn parse_table_cell(
     // ECMA-376 §17.4.85: ST_Merge default is "continue", so a <w:vMerge/>
     // element with no val attribute means the cell continues the merged
     // region from the row above. Only val="restart" begins a new merge.
-    let v_merge = tc_pr.and_then(|p| child_w(p, "vMerge")).map(|m| {
-        attr_w(m, "val").map(|v| v == "restart").unwrap_or(false)
-    });
+    let v_merge = tc_pr
+        .and_then(|p| child_w(p, "vMerge"))
+        .map(|m| attr_w(m, "val").map(|v| v == "restart").unwrap_or(false));
 
-    let borders = tc_pr.and_then(|p| child_w(p, "tcBorders"))
+    let borders = tc_pr
+        .and_then(|p| child_w(p, "tcBorders"))
         .map(|b| parse_cell_borders(b))
         .unwrap_or_default();
 
-    let background = tc_pr.and_then(|p| child_w(p, "shd"))
+    let background = tc_pr
+        .and_then(|p| child_w(p, "shd"))
         .and_then(|s| attr_w(s, "fill"))
         .filter(|f| f != "auto" && f.len() == 6)
         .map(|f| f.to_lowercase());
 
     // Empty = not set inline; parse_table fills it from the table style (else "top").
-    let v_align = tc_pr.and_then(|p| child_w(p, "vAlign"))
+    let v_align = tc_pr
+        .and_then(|p| child_w(p, "vAlign"))
         .and_then(|v| attr_w(v, "val"))
         .unwrap_or_default();
 
@@ -2627,10 +3356,12 @@ fn parse_table_cell(
     // when present, overrides the table-level `<w:tblCellMar>` default; absent
     // edges stay None so the renderer falls back to the table default.
     let tc_mar = tc_pr.and_then(|p| child_w(p, "tcMar"));
-    let edge_mar = |name: &str| tc_mar
-        .and_then(|m| child_w(m, name))
-        .and_then(|n| attr_w(n, "w"))
-        .map(|v| twips_to_pt(&v));
+    let edge_mar = |name: &str| {
+        tc_mar
+            .and_then(|m| child_w(m, name))
+            .and_then(|n| attr_w(n, "w"))
+            .map(|v| twips_to_pt(&v))
+    };
     let margin_top = edge_mar("top");
     let margin_bottom = edge_mar("bottom");
     let margin_left = edge_mar("left");
@@ -2641,19 +3372,35 @@ fn parse_table_cell(
     let mut content: Vec<CellElement> = vec![];
     for child in element_children_flat(node) {
         match child.tag_name().name() {
-            "p" => content.push(CellElement::Paragraph(
-                parse_paragraph(child, style_map, num_map, media_map, rel_map, theme, table_style_id)
-            )),
-            "tbl" => content.push(CellElement::Table(
-                parse_table(child, style_map, num_map, media_map, rel_map, theme)
-            )),
+            "p" => content.push(CellElement::Paragraph(parse_paragraph(
+                child,
+                style_map,
+                num_map,
+                media_map,
+                rel_map,
+                theme,
+                table_style_id,
+            ))),
+            "tbl" => content.push(CellElement::Table(parse_table(
+                child, style_map, num_map, media_map, rel_map, theme,
+            ))),
             _ => {}
         }
     }
 
     DocTableCell {
-        content, col_span, v_merge, borders, background, v_align, width_pt, width_pct,
-        margin_top, margin_bottom, margin_left, margin_right,
+        content,
+        col_span,
+        v_merge,
+        borders,
+        background,
+        v_align,
+        width_pt,
+        width_pct,
+        margin_top,
+        margin_bottom,
+        margin_left,
+        margin_right,
     }
 }
 
@@ -2667,8 +3414,12 @@ fn parse_table_borders(node: roxmltree::Node) -> TableBorders {
     TableBorders {
         top: child_w(node, "top").map(parse_border_spec),
         bottom: child_w(node, "bottom").map(parse_border_spec),
-        left: child_w(node, "left").or_else(|| child_w(node, "start")).map(parse_border_spec),
-        right: child_w(node, "right").or_else(|| child_w(node, "end")).map(parse_border_spec),
+        left: child_w(node, "left")
+            .or_else(|| child_w(node, "start"))
+            .map(parse_border_spec),
+        right: child_w(node, "right")
+            .or_else(|| child_w(node, "end"))
+            .map(parse_border_spec),
         inside_h: child_w(node, "insideH").map(parse_border_spec),
         inside_v: child_w(node, "insideV").map(parse_border_spec),
     }
@@ -2681,8 +3432,12 @@ fn parse_cell_borders(node: roxmltree::Node) -> CellBorders {
     CellBorders {
         top: child_w(node, "top").map(parse_border_spec),
         bottom: child_w(node, "bottom").map(parse_border_spec),
-        left: child_w(node, "left").or_else(|| child_w(node, "start")).map(parse_border_spec),
-        right: child_w(node, "right").or_else(|| child_w(node, "end")).map(parse_border_spec),
+        left: child_w(node, "left")
+            .or_else(|| child_w(node, "start"))
+            .map(parse_border_spec),
+        right: child_w(node, "right")
+            .or_else(|| child_w(node, "end"))
+            .map(parse_border_spec),
     }
 }
 
@@ -2712,21 +3467,65 @@ fn apply_style_borders(dst: &mut TableBorders, src: &RawTblBorders) {
         color: e.color.clone(),
         style: e.style.clone(),
     };
-    if dst.top.is_none() { if let Some(e) = &src.top { if usable(e) { dst.top = Some(conv(e)); } } }
-    if dst.bottom.is_none() { if let Some(e) = &src.bottom { if usable(e) { dst.bottom = Some(conv(e)); } } }
-    if dst.left.is_none() { if let Some(e) = &src.left { if usable(e) { dst.left = Some(conv(e)); } } }
-    if dst.right.is_none() { if let Some(e) = &src.right { if usable(e) { dst.right = Some(conv(e)); } } }
-    if dst.inside_h.is_none() { if let Some(e) = &src.inside_h { if usable(e) { dst.inside_h = Some(conv(e)); } } }
-    if dst.inside_v.is_none() { if let Some(e) = &src.inside_v { if usable(e) { dst.inside_v = Some(conv(e)); } } }
+    if dst.top.is_none() {
+        if let Some(e) = &src.top {
+            if usable(e) {
+                dst.top = Some(conv(e));
+            }
+        }
+    }
+    if dst.bottom.is_none() {
+        if let Some(e) = &src.bottom {
+            if usable(e) {
+                dst.bottom = Some(conv(e));
+            }
+        }
+    }
+    if dst.left.is_none() {
+        if let Some(e) = &src.left {
+            if usable(e) {
+                dst.left = Some(conv(e));
+            }
+        }
+    }
+    if dst.right.is_none() {
+        if let Some(e) = &src.right {
+            if usable(e) {
+                dst.right = Some(conv(e));
+            }
+        }
+    }
+    if dst.inside_h.is_none() {
+        if let Some(e) = &src.inside_h {
+            if usable(e) {
+                dst.inside_h = Some(conv(e));
+            }
+        }
+    }
+    if dst.inside_v.is_none() {
+        if let Some(e) = &src.inside_v {
+            if usable(e) {
+                dst.inside_v = Some(conv(e));
+            }
+        }
+    }
 }
 
 fn parse_border_spec(node: roxmltree::Node) -> BorderSpec {
     let style = attr_w(node, "val").unwrap_or_else(|| "none".to_string());
-    let width = attr_w(node, "sz").map(|v| {
-        v.parse::<f64>().unwrap_or(4.0) / 8.0  // eighth-points → pt
-    }).unwrap_or(0.5);
-    let color = attr_w(node, "color").filter(|c| c != "auto").map(|c| c.to_lowercase());
-    BorderSpec { width, color, style }
+    let width = attr_w(node, "sz")
+        .map(|v| {
+            v.parse::<f64>().unwrap_or(4.0) / 8.0 // eighth-points → pt
+        })
+        .unwrap_or(0.5);
+    let color = attr_w(node, "color")
+        .filter(|c| c != "auto")
+        .map(|c| c.to_lowercase());
+    BorderSpec {
+        width,
+        color,
+        style,
+    }
 }
 
 // ===== Helpers =====
@@ -2747,39 +3546,99 @@ fn normalize_align(s: &str) -> &str {
 }
 
 fn apply_direct_para(base: &mut ParaFmt, direct: &ParaFmt) {
-    if direct.alignment.is_some() { base.alignment = direct.alignment.clone(); }
-    if direct.indent_left.is_some() { base.indent_left = direct.indent_left; }
-    if direct.indent_right.is_some() { base.indent_right = direct.indent_right; }
-    if direct.indent_first.is_some() { base.indent_first = direct.indent_first; }
-    if direct.space_before.is_some() { base.space_before = direct.space_before; }
-    if direct.space_after.is_some() { base.space_after = direct.space_after; }
-    if direct.line_spacing_val.is_some() { base.line_spacing_val = direct.line_spacing_val; }
-    if direct.line_spacing_rule.is_some() { base.line_spacing_rule = direct.line_spacing_rule.clone(); }
-    if direct.line_spacing_explicit.is_some() { base.line_spacing_explicit = direct.line_spacing_explicit; }
-    if direct.outline_level.is_some() { base.outline_level = direct.outline_level; }
-    if direct.num_id.is_some() { base.num_id = direct.num_id; }
-    if direct.num_level.is_some() { base.num_level = direct.num_level; }
-    if direct.tab_stops.is_some() { base.tab_stops = direct.tab_stops.clone(); }
-    if direct.bidi.is_some() { base.bidi = direct.bidi; }
+    if direct.alignment.is_some() {
+        base.alignment = direct.alignment.clone();
+    }
+    if direct.indent_left.is_some() {
+        base.indent_left = direct.indent_left;
+    }
+    if direct.indent_right.is_some() {
+        base.indent_right = direct.indent_right;
+    }
+    if direct.indent_first.is_some() {
+        base.indent_first = direct.indent_first;
+    }
+    if direct.space_before.is_some() {
+        base.space_before = direct.space_before;
+    }
+    if direct.space_after.is_some() {
+        base.space_after = direct.space_after;
+    }
+    if direct.line_spacing_val.is_some() {
+        base.line_spacing_val = direct.line_spacing_val;
+    }
+    if direct.line_spacing_rule.is_some() {
+        base.line_spacing_rule = direct.line_spacing_rule.clone();
+    }
+    if direct.line_spacing_explicit.is_some() {
+        base.line_spacing_explicit = direct.line_spacing_explicit;
+    }
+    if direct.outline_level.is_some() {
+        base.outline_level = direct.outline_level;
+    }
+    if direct.num_id.is_some() {
+        base.num_id = direct.num_id;
+    }
+    if direct.num_level.is_some() {
+        base.num_level = direct.num_level;
+    }
+    if direct.tab_stops.is_some() {
+        base.tab_stops = direct.tab_stops.clone();
+    }
+    if direct.bidi.is_some() {
+        base.bidi = direct.bidi;
+    }
 }
 
 fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
-    if direct.bold.is_some() { base.bold = direct.bold; }
-    if direct.italic.is_some() { base.italic = direct.italic; }
-    if direct.underline.is_some() { base.underline = direct.underline; }
-    if direct.strikethrough.is_some() { base.strikethrough = direct.strikethrough; }
-    if direct.font_size.is_some() { base.font_size = direct.font_size; }
-    if direct.color.is_some() { base.color = direct.color.clone(); }
-    if direct.font_family_ascii.is_some() { base.font_family_ascii = direct.font_family_ascii.clone(); }
-    if direct.font_family_east_asia.is_some() { base.font_family_east_asia = direct.font_family_east_asia.clone(); }
-    if direct.background.is_some() { base.background = direct.background.clone(); }
-    if direct.vert_align.is_some() { base.vert_align = direct.vert_align.clone(); }
-    if direct.rtl.is_some() { base.rtl = direct.rtl; }
-    if direct.cs_toggle.is_some() { base.cs_toggle = direct.cs_toggle; }
-    if direct.font_family_cs.is_some() { base.font_family_cs = direct.font_family_cs.clone(); }
-    if direct.bold_cs.is_some() { base.bold_cs = direct.bold_cs; }
-    if direct.italic_cs.is_some() { base.italic_cs = direct.italic_cs; }
-    if direct.lang_bidi.is_some() { base.lang_bidi = direct.lang_bidi.clone(); }
+    if direct.bold.is_some() {
+        base.bold = direct.bold;
+    }
+    if direct.italic.is_some() {
+        base.italic = direct.italic;
+    }
+    if direct.underline.is_some() {
+        base.underline = direct.underline;
+    }
+    if direct.strikethrough.is_some() {
+        base.strikethrough = direct.strikethrough;
+    }
+    if direct.font_size.is_some() {
+        base.font_size = direct.font_size;
+    }
+    if direct.color.is_some() {
+        base.color = direct.color.clone();
+    }
+    if direct.font_family_ascii.is_some() {
+        base.font_family_ascii = direct.font_family_ascii.clone();
+    }
+    if direct.font_family_east_asia.is_some() {
+        base.font_family_east_asia = direct.font_family_east_asia.clone();
+    }
+    if direct.background.is_some() {
+        base.background = direct.background.clone();
+    }
+    if direct.vert_align.is_some() {
+        base.vert_align = direct.vert_align.clone();
+    }
+    if direct.rtl.is_some() {
+        base.rtl = direct.rtl;
+    }
+    if direct.cs_toggle.is_some() {
+        base.cs_toggle = direct.cs_toggle;
+    }
+    if direct.font_family_cs.is_some() {
+        base.font_family_cs = direct.font_family_cs.clone();
+    }
+    if direct.bold_cs.is_some() {
+        base.bold_cs = direct.bold_cs;
+    }
+    if direct.italic_cs.is_some() {
+        base.italic_cs = direct.italic_cs;
+    }
+    if direct.lang_bidi.is_some() {
+        base.lang_bidi = direct.lang_bidi.clone();
+    }
 
     // Complex-script font size: a directly-applied `w:sz` without an
     // accompanying `w:szCs` mirrors into the cs size (ECMA-376 §17.3.2.18 —
@@ -2798,9 +3657,18 @@ fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
 
 fn parse_rels(xml: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
-    if xml.is_empty() { return map; }
-    let doc = match XmlDoc::parse(xml) { Ok(d) => d, Err(_) => return map };
-    for rel in doc.root_element().children().filter(|n| n.tag_name().name() == "Relationship") {
+    if xml.is_empty() {
+        return map;
+    }
+    let doc = match XmlDoc::parse(xml) {
+        Ok(d) => d,
+        Err(_) => return map,
+    };
+    for rel in doc
+        .root_element()
+        .children()
+        .filter(|n| n.tag_name().name() == "Relationship")
+    {
         if let (Some(id), Some(target)) = (rel.attribute("Id"), rel.attribute("Target")) {
             map.insert(id.to_string(), target.to_string());
         }
@@ -2815,7 +3683,11 @@ fn read_zip_entry(zip: &mut Zip, path: &str) -> Result<String, String> {
         return Err(format!("{}: exceeds size limit", path));
     }
     let mut s = String::new();
-    entry.by_ref().take(max).read_to_string(&mut s).map_err(|e| e.to_string())?;
+    entry
+        .by_ref()
+        .take(max)
+        .read_to_string(&mut s)
+        .map_err(|e| e.to_string())?;
     Ok(s)
 }
 
@@ -2826,7 +3698,11 @@ fn read_zip_bytes(zip: &mut Zip, path: &str) -> Result<Vec<u8>, String> {
         return Err(format!("{}: exceeds size limit", path));
     }
     let mut buf = vec![];
-    entry.by_ref().take(max).read_to_end(&mut buf).map_err(|e| e.to_string())?;
+    entry
+        .by_ref()
+        .take(max)
+        .read_to_end(&mut buf)
+        .map_err(|e| e.to_string())?;
     Ok(buf)
 }
 
@@ -2928,14 +3804,27 @@ mod cs_toggle_tests {
             r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{body_inner}</w:body></w:document>"#
         );
         let doc = XmlDoc::parse(&xml).unwrap();
-        let body = doc.root_element().descendants().find(|n| n.tag_name().name() == "body").unwrap();
+        let body = doc
+            .root_element()
+            .descendants()
+            .find(|n| n.tag_name().name() == "body")
+            .unwrap();
         let style_map = StyleMap::parse("");
         let mut num_map = NumberingMap::default();
-        let elems = parse_body_elements(body, &style_map, &mut num_map, &HashMap::new(), &HashMap::new(), &ThemeColors::default());
+        let elems = parse_body_elements(
+            body,
+            &style_map,
+            &mut num_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+        );
         for e in elems {
             if let BodyElement::Paragraph(p) = e {
                 for r in p.runs {
-                    if let DocRun::Text(t) = r { return t; }
+                    if let DocRun::Text(t) = r {
+                        return t;
+                    }
                 }
             }
         }
@@ -2952,7 +3841,8 @@ mod cs_toggle_tests {
     #[test]
     fn rfonts_cs_attribute_does_not_set_the_toggle() {
         // rFonts@cs is only a font SLOT (§17.3.2.26) — it must not force cs.
-        let run = run_of(r#"<w:p><w:r><w:rPr><w:rFonts w:cs="Arial"/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
+        let run =
+            run_of(r#"<w:p><w:r><w:rPr><w:rFonts w:cs="Arial"/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
         assert_eq!(run.cs, None);
         assert_eq!(run.font_family_cs.as_deref(), Some("Arial"));
     }
@@ -2973,7 +3863,11 @@ mod theme_cs_tests {
             <a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>
           </a:fontScheme></a:themeElements></a:theme>"#;
         let mut theme = ThemeColors::parse(theme_xml);
-        assert_eq!(theme.resolve_font("minorBidi"), None, "empty cs typeface is unset");
+        assert_eq!(
+            theme.resolve_font("minorBidi"),
+            None,
+            "empty cs typeface is unset"
+        );
         theme.fill_default_cs_font("ar-SA");
         assert_eq!(theme.resolve_font("minorBidi").as_deref(), Some("Arial"));
         assert_eq!(theme.resolve_font("majorBidi").as_deref(), Some("Arial"));
@@ -2989,12 +3883,17 @@ mod theme_cs_tests {
           </a:fontScheme></a:themeElements></a:theme>"#;
         let mut theme = ThemeColors::parse(theme_xml);
         theme.fill_default_cs_font("ar-SA");
-        assert_eq!(theme.resolve_font("minorBidi").as_deref(), Some("Sakkal Majalla"));
+        assert_eq!(
+            theme.resolve_font("minorBidi").as_deref(),
+            Some("Sakkal Majalla")
+        );
     }
 
     #[test]
     fn non_rtl_bidi_lang_adds_no_default() {
-        let mut theme = ThemeColors::parse("<a:theme xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"/>");
+        let mut theme = ThemeColors::parse(
+            "<a:theme xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"/>",
+        );
         theme.fill_default_cs_font("en-US");
         assert_eq!(theme.resolve_font("minorBidi"), None);
     }
@@ -3003,7 +3902,10 @@ mod theme_cs_tests {
     fn theme_font_lang_bidi_is_extracted_from_settings() {
         let settings = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
           <w:themeFontLang w:val="en-AE" w:bidi="ar-SA"/></w:settings>"#;
-        assert_eq!(parse_theme_font_bidi_lang(settings).as_deref(), Some("ar-SA"));
+        assert_eq!(
+            parse_theme_font_bidi_lang(settings).as_deref(),
+            Some("ar-SA")
+        );
         let none = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>"#;
         assert_eq!(parse_theme_font_bidi_lang(none), None);
     }
@@ -3079,7 +3981,14 @@ mod rtl_tests {
         let media_map: HashMap<String, String> = HashMap::new();
         let rel_map: HashMap<String, String> = HashMap::new();
         let theme = ThemeColors::default();
-        parse_body_elements(body_node, &style_map, &mut num_map, &media_map, &rel_map, &theme)
+        parse_body_elements(
+            body_node,
+            &style_map,
+            &mut num_map,
+            &media_map,
+            &rel_map,
+            &theme,
+        )
     }
 
     /// ECMA-376 §17.3.1.6 w:bidi, §17.3.2.30 w:rtl, §17.3.2.26 w:rFonts@cs,
@@ -3108,27 +4017,49 @@ mod rtl_tests {
         );
 
         // Paragraph w:bidi
-        let para = body.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => Some(p),
-            _ => None,
-        }).expect("paragraph present");
+        let para = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => Some(p),
+                _ => None,
+            })
+            .expect("paragraph present");
         assert_eq!(para.bidi, Some(true), "w:bidi should set paragraph.bidi");
 
         // Run w:rtl + w:cs + w:szCs
-        let run = para.runs.iter().find_map(|r| match r {
-            DocRun::Text(t) => Some(t),
-            _ => None,
-        }).expect("text run present");
+        let run = para
+            .runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Text(t) => Some(t),
+                _ => None,
+            })
+            .expect("text run present");
         assert_eq!(run.rtl, Some(true), "w:rtl should set run.rtl");
-        assert_eq!(run.font_family_cs.as_deref(), Some("Arial"), "w:rFonts@cs → run.fontFamilyCs");
-        assert_eq!(run.font_size_cs, Some(14.0), "w:szCs val=28 half-pts → 14pt run.fontSizeCs");
+        assert_eq!(
+            run.font_family_cs.as_deref(),
+            Some("Arial"),
+            "w:rFonts@cs → run.fontFamilyCs"
+        );
+        assert_eq!(
+            run.font_size_cs,
+            Some(14.0),
+            "w:szCs val=28 half-pts → 14pt run.fontSizeCs"
+        );
 
         // Table w:bidiVisual
-        let tbl = body.iter().find_map(|e| match e {
-            BodyElement::Table(t) => Some(t),
-            _ => None,
-        }).expect("table present");
-        assert_eq!(tbl.bidi_visual, Some(true), "w:bidiVisual should set table.bidiVisual");
+        let tbl = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("table present");
+        assert_eq!(
+            tbl.bidi_visual,
+            Some(true),
+            "w:bidiVisual should set table.bidiVisual"
+        );
     }
 
     /// On-off toggles honor an explicit `w:val="0"` (off), per §17.3.2.22, so
@@ -3138,15 +4069,22 @@ mod rtl_tests {
         let body = body_from(
             r#"<w:p><w:pPr><w:bidi w:val="0"/></w:pPr><w:r><w:rPr><w:rtl w:val="false"/></w:rPr><w:t>a</w:t></w:r></w:p>"#,
         );
-        let para = body.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => Some(p),
-            _ => None,
-        }).unwrap();
+        let para = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => Some(p),
+                _ => None,
+            })
+            .unwrap();
         assert_eq!(para.bidi, Some(false));
-        let run = para.runs.iter().find_map(|r| match r {
-            DocRun::Text(t) => Some(t),
-            _ => None,
-        }).unwrap();
+        let run = para
+            .runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Text(t) => Some(t),
+                _ => None,
+            })
+            .unwrap();
         assert_eq!(run.rtl, Some(false));
     }
 
@@ -3161,13 +4099,16 @@ mod rtl_tests {
         let body = body_from(
             r#"<w:p><w:r><w:rPr><w:b/><w:sz w:val="36"/></w:rPr><w:t>نبذة</w:t></w:r></w:p>"#,
         );
-        let run = body.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
-                DocRun::Text(t) => Some(t),
+        let run = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Text(t) => Some(t),
+                    _ => None,
+                }),
                 _ => None,
-            }),
-            _ => None,
-        }).expect("text run present");
+            })
+            .expect("text run present");
         assert_eq!(run.font_size, 18.0, "sz=36 half-pts → 18pt");
         assert_eq!(
             run.font_size_cs,
@@ -3179,15 +4120,22 @@ mod rtl_tests {
         let body2 = body_from(
             r#"<w:p><w:r><w:rPr><w:sz w:val="36"/><w:szCs w:val="24"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
         );
-        let run2 = body2.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
-                DocRun::Text(t) => Some(t),
+        let run2 = body2
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Text(t) => Some(t),
+                    _ => None,
+                }),
                 _ => None,
-            }),
-            _ => None,
-        }).unwrap();
+            })
+            .unwrap();
         assert_eq!(run2.font_size, 18.0);
-        assert_eq!(run2.font_size_cs, Some(12.0), "explicit szCs wins over sz mirroring");
+        assert_eq!(
+            run2.font_size_cs,
+            Some(12.0),
+            "explicit szCs wins over sz mirroring"
+        );
     }
 
     /// ECMA-376 §17.3.2.3 w:bCs, §17.3.2.17 w:iCs, §17.3.2.20 w:lang/@w:bidi —
@@ -3199,13 +4147,16 @@ mod rtl_tests {
             r#"<w:p><w:r><w:rPr><w:rtl/><w:bCs/><w:iCs/>
               <w:lang w:val="en-AE" w:bidi="ae-AR"/></w:rPr><w:t>28-02-2026</w:t></w:r></w:p>"#,
         );
-        let run = body.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
-                DocRun::Text(t) => Some(t),
+        let run = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Text(t) => Some(t),
+                    _ => None,
+                }),
                 _ => None,
-            }),
-            _ => None,
-        }).expect("text run present");
+            })
+            .expect("text run present");
         assert_eq!(run.bold_cs, Some(true), "w:bCs → run.boldCs");
         assert_eq!(run.italic_cs, Some(true), "w:iCs → run.italicCs");
         assert_eq!(
@@ -3234,14 +4185,21 @@ mod rtl_tests {
               </v:shape>
             </w:pict></w:r></w:p>"##,
         );
-        let para = body.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => Some(p),
-            _ => None,
-        }).expect("paragraph present");
-        let shape = para.runs.iter().find_map(|r| match r {
-            DocRun::Shape(s) => Some(s),
-            _ => None,
-        }).expect("VML pict should produce a ShapeRun");
+        let para = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => Some(p),
+                _ => None,
+            })
+            .expect("paragraph present");
+        let shape = para
+            .runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Shape(s) => Some(s),
+                _ => None,
+            })
+            .expect("VML pict should produce a ShapeRun");
 
         assert_eq!(shape.width_pt, 300.0, "width from CSS style");
         assert_eq!(shape.height_pt, 60.0, "height from CSS style");
@@ -3282,13 +4240,24 @@ mod rtl_tests {
             </w:tbl>
             "#,
         );
-        let tbl = body.iter().find_map(|e| match e {
-            BodyElement::Table(t) => Some(t),
-            _ => None,
-        }).expect("table present");
+        let tbl = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("table present");
         let cell = &tbl.rows[0].cells[0];
-        let left = cell.borders.left.as_ref().expect("w:start should map to cell.left");
-        let right = cell.borders.right.as_ref().expect("w:end should map to cell.right");
+        let left = cell
+            .borders
+            .left
+            .as_ref()
+            .expect("w:start should map to cell.left");
+        let right = cell
+            .borders
+            .right
+            .as_ref()
+            .expect("w:end should map to cell.right");
         assert_eq!(left.color.as_deref(), Some("d9d9d9"), "start color → left");
         assert_eq!(left.style, "single");
         assert_eq!(right.color.as_deref(), Some("d9d9d9"), "end color → right");
@@ -3316,12 +4285,21 @@ mod rtl_tests {
             </w:tbl>
             "#,
         );
-        let tbl = body.iter().find_map(|e| match e {
-            BodyElement::Table(t) => Some(t),
-            _ => None,
-        }).expect("table present");
-        assert!(tbl.borders.left.is_some(), "w:start should map to tblBorders.left");
-        assert!(tbl.borders.right.is_some(), "w:end should map to tblBorders.right");
+        let tbl = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("table present");
+        assert!(
+            tbl.borders.left.is_some(),
+            "w:start should map to tblBorders.left"
+        );
+        assert!(
+            tbl.borders.right.is_some(),
+            "w:end should map to tblBorders.right"
+        );
     }
 
     /// ECMA-376 §17.3.2.4 w:bCs / §17.3.2.6 w:iCs are INDEPENDENT toggles from
@@ -3339,21 +4317,34 @@ mod rtl_tests {
                 <w:t>28-02-2026</w:t>
             </w:r></w:p>"#,
         );
-        let para = body.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => Some(p),
-            _ => None,
-        }).unwrap();
-        let run = para.runs.iter().find_map(|r| match r {
-            DocRun::Text(t) => Some(t),
-            _ => None,
-        }).unwrap();
+        let para = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => Some(p),
+                _ => None,
+            })
+            .unwrap();
+        let run = para
+            .runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Text(t) => Some(t),
+                _ => None,
+            })
+            .unwrap();
         // `w:b` sets the non-CS bold…
         assert_eq!(run.bold, true, "w:b sets non-CS bold");
         // …and `w:bCs` is absent, so the parser leaves the CS bold axis None.
         // The renderer mirrors it from `bold` (boldCs ?? bold) per the PDF-
         // verified sample-7 page-1 behaviour; that fallback lives in renderer.ts.
-        assert_eq!(run.bold_cs, None, "absent w:bCs stays None at the parser level");
-        assert_eq!(run.italic_cs, None, "absent w:iCs stays None at the parser level");
+        assert_eq!(
+            run.bold_cs, None,
+            "absent w:bCs stays None at the parser level"
+        );
+        assert_eq!(
+            run.italic_cs, None,
+            "absent w:iCs stays None at the parser level"
+        );
     }
 
     /// An explicit `w:bCs` / `w:iCs` is surfaced on its own axis (and honors the
@@ -3366,15 +4357,26 @@ mod rtl_tests {
                 <w:t>عربي</w:t>
             </w:r></w:p>"#,
         );
-        let para = body.iter().find_map(|e| match e {
-            BodyElement::Paragraph(p) => Some(p),
-            _ => None,
-        }).unwrap();
-        let run = para.runs.iter().find_map(|r| match r {
-            DocRun::Text(t) => Some(t),
-            _ => None,
-        }).unwrap();
+        let para = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::Paragraph(p) => Some(p),
+                _ => None,
+            })
+            .unwrap();
+        let run = para
+            .runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Text(t) => Some(t),
+                _ => None,
+            })
+            .unwrap();
         assert_eq!(run.bold_cs, Some(true), "w:bCs sets the CS bold axis");
-        assert_eq!(run.italic_cs, Some(false), "w:iCs val=0 turns CS italic off");
+        assert_eq!(
+            run.italic_cs,
+            Some(false),
+            "w:iCs val=0 turns CS italic off"
+        );
     }
 }

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -82,7 +82,6 @@ pub struct ParaFmt {
     pub tab_stops: Option<Vec<(f64, String, String)>>,
     /// merged run defaults from pPr/rPr
     pub run: RunFmt,
-    pub based_on: Option<String>,
     /// Paragraph background hex color (w:shd fill on paragraph)
     pub shading: Option<String>,
     /// Force page break before paragraph (w:pageBreakBefore)
@@ -715,11 +714,12 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
 }
 
 pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
-    let mut fmt = RunFmt::default();
-
-    fmt.bold = bool_prop(rpr, "b");
-    fmt.italic = bool_prop(rpr, "i");
-    fmt.strikethrough = bool_prop(rpr, "strike");
+    let mut fmt = RunFmt {
+        bold: bool_prop(rpr, "b"),
+        italic: bool_prop(rpr, "i"),
+        strikethrough: bool_prop(rpr, "strike"),
+        ..Default::default()
+    };
 
     // Underline
     if let Some(u) = child_w(rpr, "u") {

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use roxmltree::Document as XmlDoc;
 use crate::xml_util::*;
+use roxmltree::Document as XmlDoc;
+use std::collections::HashMap;
 
 /// Resolved run (character) formatting.
 #[derive(Debug, Clone, Default)]
@@ -9,11 +9,11 @@ pub struct RunFmt {
     pub italic: Option<bool>,
     pub underline: Option<bool>,
     pub strikethrough: Option<bool>,
-    pub font_size: Option<f64>,       // pt
-    pub color: Option<String>,        // hex 6
+    pub font_size: Option<f64>, // pt
+    pub color: Option<String>,  // hex 6
     pub font_family_ascii: Option<String>,
     pub font_family_east_asia: Option<String>,
-    pub background: Option<String>,   // hex 6
+    pub background: Option<String>, // hex 6
     /// "super" | "sub" — mapped from w:vertAlign val="superscript|subscript"
     pub vert_align: Option<String>,
     /// All caps (w:caps)
@@ -62,11 +62,11 @@ pub struct RunFmt {
 #[derive(Debug, Clone, Default)]
 pub struct ParaFmt {
     pub alignment: Option<String>,
-    pub indent_left: Option<f64>,     // pt
-    pub indent_right: Option<f64>,    // pt
-    pub indent_first: Option<f64>,    // pt
-    pub space_before: Option<f64>,    // pt
-    pub space_after: Option<f64>,     // pt
+    pub indent_left: Option<f64>,  // pt
+    pub indent_right: Option<f64>, // pt
+    pub indent_first: Option<f64>, // pt
+    pub space_before: Option<f64>, // pt
+    pub space_after: Option<f64>,  // pt
     pub line_spacing_val: Option<f64>,
     pub line_spacing_rule: Option<String>,
     /// True when `w:spacing/@w:line` was declared on the paragraph's own pPr
@@ -204,22 +204,25 @@ impl StyleMap {
         let mut default_para_style_id: Option<String> = None;
         let mut table_styles: HashMap<String, TableStyleDef> = HashMap::new();
         for style_node in children_w(root, "style") {
-            let Some(style_id) = attr_w(style_node, "styleId") else { continue };
+            let Some(style_id) = attr_w(style_node, "styleId") else {
+                continue;
+            };
             let style_type = attr_w(style_node, "type").unwrap_or_default();
-            if style_type != "paragraph"
-                && style_type != "character"
-                && style_type != "table" { continue; }
+            if style_type != "paragraph" && style_type != "character" && style_type != "table" {
+                continue;
+            }
 
-            if style_type == "paragraph"
-                && attr_w(style_node, "default").as_deref() == Some("1")
-            {
+            if style_type == "paragraph" && attr_w(style_node, "default").as_deref() == Some("1") {
                 default_para_style_id = Some(style_id.clone());
             }
 
             let based_on = child_w(style_node, "basedOn").and_then(|n| attr_w(n, "val"));
 
             if style_type == "table" {
-                table_styles.insert(style_id.clone(), parse_tbl_style_def(style_node, based_on.clone()));
+                table_styles.insert(
+                    style_id.clone(),
+                    parse_tbl_style_def(style_node, based_on.clone()),
+                );
             }
 
             let para = if let Some(ppr) = child_w(style_node, "pPr") {
@@ -234,10 +237,23 @@ impl StyleMap {
                 RunFmt::default()
             };
 
-            styles.insert(style_id, StyleDef { para, run, based_on });
+            styles.insert(
+                style_id,
+                StyleDef {
+                    para,
+                    run,
+                    based_on,
+                },
+            );
         }
 
-        StyleMap { styles, table_styles, defaults_para, defaults_run, default_para_style_id }
+        StyleMap {
+            styles,
+            table_styles,
+            defaults_para,
+            defaults_run,
+            default_para_style_id,
+        }
     }
 
     fn empty() -> Self {
@@ -259,18 +275,29 @@ impl StyleMap {
         while let Some(def) = cur {
             chain.push(def);
             guard += 1;
-            if guard > 16 { break; }
-            cur = def.based_on.as_deref().and_then(|b| self.table_styles.get(b));
+            if guard > 16 {
+                break;
+            }
+            cur = def
+                .based_on
+                .as_deref()
+                .and_then(|b| self.table_styles.get(b));
         }
         // Merge from base (end of chain) to derived (front).
         let mut out = TableStyleDef::default();
         for def in chain.into_iter().rev() {
             merge_raw_borders(&mut out.borders, &def.borders);
-            if def.cell_shd.is_some() { out.cell_shd = def.cell_shd.clone(); }
-            if def.cell_valign.is_some() { out.cell_valign = def.cell_valign.clone(); }
+            if def.cell_shd.is_some() {
+                out.cell_shd = def.cell_shd.clone();
+            }
+            if def.cell_valign.is_some() {
+                out.cell_valign = def.cell_valign.clone();
+            }
             for (k, v) in &def.cond {
                 let slot = out.cond.entry(k.clone()).or_default();
-                if v.shd.is_some() { slot.shd = v.shd.clone(); }
+                if v.shd.is_some() {
+                    slot.shd = v.shd.clone();
+                }
                 merge_raw_borders(&mut slot.borders, &v.borders);
             }
         }
@@ -342,50 +369,132 @@ impl StyleMap {
 }
 
 fn apply_para(dst: &mut ParaFmt, src: &ParaFmt) {
-    if src.alignment.is_some() { dst.alignment = src.alignment.clone(); }
-    if src.indent_left.is_some() { dst.indent_left = src.indent_left; }
-    if src.indent_right.is_some() { dst.indent_right = src.indent_right; }
-    if src.indent_first.is_some() { dst.indent_first = src.indent_first; }
-    if src.space_before.is_some() { dst.space_before = src.space_before; }
-    if src.space_after.is_some() { dst.space_after = src.space_after; }
-    if src.line_spacing_val.is_some() { dst.line_spacing_val = src.line_spacing_val; }
-    if src.line_spacing_rule.is_some() { dst.line_spacing_rule = src.line_spacing_rule.clone(); }
-    if src.line_spacing_explicit.is_some() { dst.line_spacing_explicit = src.line_spacing_explicit; }
-    if src.num_id.is_some() { dst.num_id = src.num_id; }
-    if src.num_level.is_some() { dst.num_level = src.num_level; }
-    if src.tab_stops.is_some() { dst.tab_stops = src.tab_stops.clone(); }
-    if src.shading.is_some() { dst.shading = src.shading.clone(); }
-    if src.page_break_before.is_some() { dst.page_break_before = src.page_break_before; }
-    if src.contextual_spacing.is_some() { dst.contextual_spacing = src.contextual_spacing; }
-    if src.keep_next.is_some() { dst.keep_next = src.keep_next; }
-    if src.outline_level.is_some() { dst.outline_level = src.outline_level; }
-    if src.keep_lines.is_some() { dst.keep_lines = src.keep_lines; }
-    if src.widow_control.is_some() { dst.widow_control = src.widow_control; }
-    if src.para_borders.is_some() { dst.para_borders = src.para_borders.clone(); }
-    if src.bidi.is_some() { dst.bidi = src.bidi; }
+    if src.alignment.is_some() {
+        dst.alignment = src.alignment.clone();
+    }
+    if src.indent_left.is_some() {
+        dst.indent_left = src.indent_left;
+    }
+    if src.indent_right.is_some() {
+        dst.indent_right = src.indent_right;
+    }
+    if src.indent_first.is_some() {
+        dst.indent_first = src.indent_first;
+    }
+    if src.space_before.is_some() {
+        dst.space_before = src.space_before;
+    }
+    if src.space_after.is_some() {
+        dst.space_after = src.space_after;
+    }
+    if src.line_spacing_val.is_some() {
+        dst.line_spacing_val = src.line_spacing_val;
+    }
+    if src.line_spacing_rule.is_some() {
+        dst.line_spacing_rule = src.line_spacing_rule.clone();
+    }
+    if src.line_spacing_explicit.is_some() {
+        dst.line_spacing_explicit = src.line_spacing_explicit;
+    }
+    if src.num_id.is_some() {
+        dst.num_id = src.num_id;
+    }
+    if src.num_level.is_some() {
+        dst.num_level = src.num_level;
+    }
+    if src.tab_stops.is_some() {
+        dst.tab_stops = src.tab_stops.clone();
+    }
+    if src.shading.is_some() {
+        dst.shading = src.shading.clone();
+    }
+    if src.page_break_before.is_some() {
+        dst.page_break_before = src.page_break_before;
+    }
+    if src.contextual_spacing.is_some() {
+        dst.contextual_spacing = src.contextual_spacing;
+    }
+    if src.keep_next.is_some() {
+        dst.keep_next = src.keep_next;
+    }
+    if src.outline_level.is_some() {
+        dst.outline_level = src.outline_level;
+    }
+    if src.keep_lines.is_some() {
+        dst.keep_lines = src.keep_lines;
+    }
+    if src.widow_control.is_some() {
+        dst.widow_control = src.widow_control;
+    }
+    if src.para_borders.is_some() {
+        dst.para_borders = src.para_borders.clone();
+    }
+    if src.bidi.is_some() {
+        dst.bidi = src.bidi;
+    }
 }
 
 fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
-    if src.bold.is_some() { dst.bold = src.bold; }
-    if src.italic.is_some() { dst.italic = src.italic; }
-    if src.underline.is_some() { dst.underline = src.underline; }
-    if src.strikethrough.is_some() { dst.strikethrough = src.strikethrough; }
-    if src.font_size.is_some() { dst.font_size = src.font_size; }
-    if src.color.is_some() { dst.color = src.color.clone(); }
-    if src.font_family_ascii.is_some() { dst.font_family_ascii = src.font_family_ascii.clone(); }
-    if src.font_family_east_asia.is_some() { dst.font_family_east_asia = src.font_family_east_asia.clone(); }
-    if src.background.is_some() { dst.background = src.background.clone(); }
-    if src.vert_align.is_some() { dst.vert_align = src.vert_align.clone(); }
-    if src.all_caps.is_some() { dst.all_caps = src.all_caps; }
-    if src.small_caps.is_some() { dst.small_caps = src.small_caps; }
-    if src.dstrike.is_some() { dst.dstrike = src.dstrike; }
-    if src.vanish.is_some() { dst.vanish = src.vanish; }
-    if src.highlight.is_some() { dst.highlight = src.highlight.clone(); }
-    if src.rtl.is_some() { dst.rtl = src.rtl; }
-    if src.font_family_cs.is_some() { dst.font_family_cs = src.font_family_cs.clone(); }
-    if src.bold_cs.is_some() { dst.bold_cs = src.bold_cs; }
-    if src.italic_cs.is_some() { dst.italic_cs = src.italic_cs; }
-    if src.lang_bidi.is_some() { dst.lang_bidi = src.lang_bidi.clone(); }
+    if src.bold.is_some() {
+        dst.bold = src.bold;
+    }
+    if src.italic.is_some() {
+        dst.italic = src.italic;
+    }
+    if src.underline.is_some() {
+        dst.underline = src.underline;
+    }
+    if src.strikethrough.is_some() {
+        dst.strikethrough = src.strikethrough;
+    }
+    if src.font_size.is_some() {
+        dst.font_size = src.font_size;
+    }
+    if src.color.is_some() {
+        dst.color = src.color.clone();
+    }
+    if src.font_family_ascii.is_some() {
+        dst.font_family_ascii = src.font_family_ascii.clone();
+    }
+    if src.font_family_east_asia.is_some() {
+        dst.font_family_east_asia = src.font_family_east_asia.clone();
+    }
+    if src.background.is_some() {
+        dst.background = src.background.clone();
+    }
+    if src.vert_align.is_some() {
+        dst.vert_align = src.vert_align.clone();
+    }
+    if src.all_caps.is_some() {
+        dst.all_caps = src.all_caps;
+    }
+    if src.small_caps.is_some() {
+        dst.small_caps = src.small_caps;
+    }
+    if src.dstrike.is_some() {
+        dst.dstrike = src.dstrike;
+    }
+    if src.vanish.is_some() {
+        dst.vanish = src.vanish;
+    }
+    if src.highlight.is_some() {
+        dst.highlight = src.highlight.clone();
+    }
+    if src.rtl.is_some() {
+        dst.rtl = src.rtl;
+    }
+    if src.font_family_cs.is_some() {
+        dst.font_family_cs = src.font_family_cs.clone();
+    }
+    if src.bold_cs.is_some() {
+        dst.bold_cs = src.bold_cs;
+    }
+    if src.italic_cs.is_some() {
+        dst.italic_cs = src.italic_cs;
+    }
+    if src.lang_bidi.is_some() {
+        dst.lang_bidi = src.lang_bidi.clone();
+    }
 
     // Complex-script font size resolution (ECMA-376 §17.3.2.18). Word treats a
     // directly-applied `w:sz` as also setting the complex-script size UNLESS the
@@ -420,8 +529,12 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
 
     // Spacing
     if let Some(sp) = child_w(ppr, "spacing") {
-        if let Some(v) = attr_w(sp, "before") { fmt.space_before = Some(twips_to_pt(&v)); }
-        if let Some(v) = attr_w(sp, "after") { fmt.space_after = Some(twips_to_pt(&v)); }
+        if let Some(v) = attr_w(sp, "before") {
+            fmt.space_before = Some(twips_to_pt(&v));
+        }
+        if let Some(v) = attr_w(sp, "after") {
+            fmt.space_after = Some(twips_to_pt(&v));
+        }
         if let Some(v) = attr_w(sp, "line") {
             let rule = attr_w(sp, "lineRule").unwrap_or_else(|| "auto".to_string());
             let raw: f64 = v.parse().unwrap_or(240.0);
@@ -436,9 +549,9 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
             // the section enables a line grid, which is where those oversized
             // values are actually authored.
             let (val, effective_rule) = match rule.as_str() {
-                "exact"   => (raw / 20.0, "exact".to_string()),
+                "exact" => (raw / 20.0, "exact".to_string()),
                 "atLeast" => (raw / 20.0, "atLeast".to_string()),
-                _         => (raw / 240.0, "auto".to_string()),
+                _ => (raw / 240.0, "auto".to_string()),
             };
             fmt.line_spacing_val = Some(val);
             fmt.line_spacing_rule = Some(effective_rule);
@@ -451,13 +564,25 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
     // identical; use either if present, with start/end taking precedence when
     // both appear (logical wins for bidi correctness).
     if let Some(ind) = child_w(ppr, "ind") {
-        if let Some(v) = attr_w(ind, "left")  { fmt.indent_left  = Some(twips_to_pt(&v)); }
-        if let Some(v) = attr_w(ind, "start") { fmt.indent_left  = Some(twips_to_pt(&v)); }
-        if let Some(v) = attr_w(ind, "right") { fmt.indent_right = Some(twips_to_pt(&v)); }
-        if let Some(v) = attr_w(ind, "end")   { fmt.indent_right = Some(twips_to_pt(&v)); }
-        if let Some(v) = attr_w(ind, "firstLine") { fmt.indent_first = Some(twips_to_pt(&v)); }
+        if let Some(v) = attr_w(ind, "left") {
+            fmt.indent_left = Some(twips_to_pt(&v));
+        }
+        if let Some(v) = attr_w(ind, "start") {
+            fmt.indent_left = Some(twips_to_pt(&v));
+        }
+        if let Some(v) = attr_w(ind, "right") {
+            fmt.indent_right = Some(twips_to_pt(&v));
+        }
+        if let Some(v) = attr_w(ind, "end") {
+            fmt.indent_right = Some(twips_to_pt(&v));
+        }
+        if let Some(v) = attr_w(ind, "firstLine") {
+            fmt.indent_first = Some(twips_to_pt(&v));
+        }
         // hanging overrides firstLine per §17.3.1.12 when both are present.
-        if let Some(v) = attr_w(ind, "hanging")   { fmt.indent_first = Some(-twips_to_pt(&v)); }
+        if let Some(v) = attr_w(ind, "hanging") {
+            fmt.indent_first = Some(-twips_to_pt(&v));
+        }
     }
 
     // Numbering
@@ -478,7 +603,9 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
         for t in children_w(tabs_node, "tab") {
             let val = attr_w(t, "val").unwrap_or_else(|| "left".to_string());
             // val="clear" removes an inherited tab — MVP: skip (no tab to emit)
-            if val == "clear" { continue; }
+            if val == "clear" {
+                continue;
+            }
             let pos = match attr_w(t, "pos").map(|s| twips_to_pt(&s)) {
                 Some(p) => p,
                 None => continue,
@@ -535,18 +662,22 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
     if let Some(lvl) = child_w(ppr, "outlineLvl") {
         if let Some(v) = attr_w(lvl, "val") {
             if let Ok(n) = v.parse::<u32>() {
-                if n <= 8 { fmt.outline_level = Some(n); }
+                if n <= 8 {
+                    fmt.outline_level = Some(n);
+                }
             }
         }
     }
 
     // Paragraph borders (pBdr)
     if let Some(pbdr) = child_w(ppr, "pBdr") {
-        use crate::types::{ParagraphBorders, ParaBorderEdge};
+        use crate::types::{ParaBorderEdge, ParagraphBorders};
         let parse_edge = |name: &str| -> Option<ParaBorderEdge> {
             let node = child_w(pbdr, name)?;
             let style = attr_w(node, "val").unwrap_or_else(|| "none".to_string());
-            if style == "none" || style == "nil" { return None; }
+            if style == "none" || style == "nil" {
+                return None;
+            }
             let width = attr_w(node, "sz")
                 .and_then(|s| s.parse::<f64>().ok())
                 .map(|v| v / 8.0)
@@ -557,7 +688,12 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
             let color = attr_w(node, "color")
                 .filter(|c| c != "auto")
                 .map(|c| c.to_lowercase());
-            Some(ParaBorderEdge { style, color, width, space })
+            Some(ParaBorderEdge {
+                style,
+                color,
+                width,
+                space,
+            })
         };
         let borders = ParagraphBorders {
             top: parse_edge("top"),
@@ -566,7 +702,11 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
             right: parse_edge("right"),
             between: parse_edge("between"),
         };
-        if borders.top.is_some() || borders.bottom.is_some() || borders.left.is_some() || borders.right.is_some() {
+        if borders.top.is_some()
+            || borders.bottom.is_some()
+            || borders.left.is_some()
+            || borders.right.is_some()
+        {
             fmt.para_borders = Some(borders);
         }
     }
@@ -649,17 +789,17 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // precedence over theme refs per spec.
     if let Some(rf) = child_w(rpr, "rFonts") {
         let direct_ascii = attr_w(rf, "ascii").or_else(|| attr_w(rf, "hAnsi"));
-        let theme_ascii  = attr_w(rf, "asciiTheme").or_else(|| attr_w(rf, "hAnsiTheme"));
+        let theme_ascii = attr_w(rf, "asciiTheme").or_else(|| attr_w(rf, "hAnsiTheme"));
         fmt.font_family_ascii = direct_ascii.or_else(|| theme_ascii.map(|t| format!("@theme:{t}")));
 
         let direct_ea = attr_w(rf, "eastAsia");
-        let theme_ea  = attr_w(rf, "eastAsiaTheme");
+        let theme_ea = attr_w(rf, "eastAsiaTheme");
         fmt.font_family_east_asia = direct_ea.or_else(|| theme_ea.map(|t| format!("@theme:{t}")));
 
         // Complex-script typeface (§17.3.2.26 @cs / @cstheme). Same direct-wins
         // rule and "@theme:<ref>" marker convention as the other axes.
         let direct_cs = attr_w(rf, "cs");
-        let theme_cs  = attr_w(rf, "cstheme");
+        let theme_cs = attr_w(rf, "cstheme");
         fmt.font_family_cs = direct_cs.or_else(|| theme_cs.map(|t| format!("@theme:{t}")));
     }
 
@@ -722,8 +862,14 @@ fn parse_edge_border(node: roxmltree::Node) -> EdgeBorder {
         .and_then(|v| v.parse::<f64>().ok())
         .map(|v| v / 8.0)
         .unwrap_or(0.5);
-    let color = attr_w(node, "color").filter(|c| c != "auto").map(|c| c.to_lowercase());
-    EdgeBorder { width, color, style }
+    let color = attr_w(node, "color")
+        .filter(|c| c != "auto")
+        .map(|c| c.to_lowercase());
+    EdgeBorder {
+        width,
+        color,
+        style,
+    }
 }
 
 fn parse_raw_tbl_borders(node: roxmltree::Node) -> RawTblBorders {
@@ -744,16 +890,31 @@ fn parse_raw_tbl_borders(node: roxmltree::Node) -> RawTblBorders {
 }
 
 fn merge_raw_borders(dst: &mut RawTblBorders, src: &RawTblBorders) {
-    if src.top.is_some() { dst.top = src.top.clone(); }
-    if src.bottom.is_some() { dst.bottom = src.bottom.clone(); }
-    if src.left.is_some() { dst.left = src.left.clone(); }
-    if src.right.is_some() { dst.right = src.right.clone(); }
-    if src.inside_h.is_some() { dst.inside_h = src.inside_h.clone(); }
-    if src.inside_v.is_some() { dst.inside_v = src.inside_v.clone(); }
+    if src.top.is_some() {
+        dst.top = src.top.clone();
+    }
+    if src.bottom.is_some() {
+        dst.bottom = src.bottom.clone();
+    }
+    if src.left.is_some() {
+        dst.left = src.left.clone();
+    }
+    if src.right.is_some() {
+        dst.right = src.right.clone();
+    }
+    if src.inside_h.is_some() {
+        dst.inside_h = src.inside_h.clone();
+    }
+    if src.inside_v.is_some() {
+        dst.inside_v = src.inside_v.clone();
+    }
 }
 
 fn parse_tbl_style_def(style_node: roxmltree::Node, based_on: Option<String>) -> TableStyleDef {
-    let mut def = TableStyleDef { based_on, ..Default::default() };
+    let mut def = TableStyleDef {
+        based_on,
+        ..Default::default()
+    };
     if let Some(tbl_pr) = child_w(style_node, "tblPr") {
         if let Some(borders) = child_w(tbl_pr, "tblBorders") {
             def.borders = parse_raw_tbl_borders(borders);
@@ -764,7 +925,9 @@ fn parse_tbl_style_def(style_node: roxmltree::Node, based_on: Option<String>) ->
         def.cell_valign = child_w(tc_pr, "vAlign").and_then(|v| attr_w(v, "val"));
     }
     for sp in children_w(style_node, "tblStylePr") {
-        let Some(typ) = attr_w(sp, "type") else { continue };
+        let Some(typ) = attr_w(sp, "type") else {
+            continue;
+        };
         let mut cf = CondFmt::default();
         if let Some(tc_pr) = child_w(sp, "tcPr") {
             cf.shd = shd_fill(tc_pr);

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -320,7 +320,9 @@ pub enum DocRun {
     /// side reads `breakType`. Re-apply camelCase at the variant level so
     /// the JSON tag matches.
     #[serde(rename_all = "camelCase")]
-    Break { break_type: BreakType },
+    Break {
+        break_type: BreakType,
+    },
     Field(FieldRun),
     Shape(ShapeRun),
     /// An OMML equation (`m:oMath`). `display` = block (`m:oMathPara`).
@@ -458,7 +460,9 @@ pub struct ShapeRun {
 #[derive(Serialize, Debug, Clone)]
 #[serde(tag = "fillType", rename_all = "camelCase")]
 pub enum ShapeFill {
-    Solid { color: String },
+    Solid {
+        color: String,
+    },
     #[serde(rename_all = "camelCase")]
     Gradient {
         stops: Vec<GradientStop>,
@@ -483,10 +487,28 @@ pub struct GradientStop {
 #[derive(Serialize, Debug, Clone)]
 #[serde(tag = "cmd", rename_all = "camelCase")]
 pub enum PathCmd {
-    MoveTo { x: f64, y: f64 },
-    LineTo { x: f64, y: f64 },
-    CubicBezTo { x1: f64, y1: f64, x2: f64, y2: f64, x: f64, y: f64 },
-    ArcTo { wr: f64, hr: f64, st_ang: f64, sw_ang: f64 },
+    MoveTo {
+        x: f64,
+        y: f64,
+    },
+    LineTo {
+        x: f64,
+        y: f64,
+    },
+    CubicBezTo {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        x: f64,
+        y: f64,
+    },
+    ArcTo {
+        wr: f64,
+        hr: f64,
+        st_ang: f64,
+        sw_ang: f64,
+    },
     Close,
 }
 
@@ -687,7 +709,9 @@ pub struct ImageRun {
     pub wrap_side: Option<String>,
 }
 
-fn is_zero_f64(v: &f64) -> bool { *v == 0.0 }
+fn is_zero_f64(v: &f64) -> bool {
+    *v == 0.0
+}
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/packages/docx/parser/src/xml_util.rs
+++ b/packages/docx/parser/src/xml_util.rs
@@ -1,15 +1,7 @@
-use roxmltree::{Document, Node};
+use roxmltree::Node;
 
 pub const W_NS: &str = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
-pub const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
 pub const R_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-pub const WP_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing";
-pub const PIC_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/picture";
-
-/// Find first child with given local name in any namespace.
-pub fn child<'a, 'input>(node: Node<'a, 'input>, name: &str) -> Option<Node<'a, 'input>> {
-    node.children().find(|n| n.tag_name().name() == name)
-}
 
 /// Find first child in w: namespace.
 pub fn child_w<'a, 'input>(node: Node<'a, 'input>, name: &str) -> Option<Node<'a, 'input>> {
@@ -57,13 +49,6 @@ pub fn attr_w(node: Node, name: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Get attribute in any namespace matching local name.
-pub fn attr<'a>(node: Node<'a, '_>, ns: &str, name: &str) -> Option<String> {
-    node.attribute((ns, name))
-        .or_else(|| node.attribute(name))
-        .map(|s| s.to_string())
-}
-
 /// Parse twips (1/20 pt) string to f64 pt.
 pub fn twips_to_pt(s: &str) -> f64 {
     s.parse::<f64>().unwrap_or(0.0) / 20.0
@@ -74,11 +59,6 @@ pub fn half_pt_to_pt(s: &str) -> f64 {
     s.parse::<f64>().unwrap_or(0.0) / 2.0
 }
 
-/// Parse EMU string to f64 pt.
-pub fn emu_to_pt(s: &str) -> f64 {
-    s.parse::<f64>().unwrap_or(0.0) / 12700.0
-}
-
 /// Parse a ST_OnOff-style toggle child element. ECMA-376 §17.3.2.22 allows
 /// "true"/"false"/"1"/"0"/"on"/"off" (and absent val attribute = true).
 /// Returns None if the element itself is absent so the caller can distinguish
@@ -86,17 +66,8 @@ pub fn emu_to_pt(s: &str) -> f64 {
 pub fn bool_prop(node: Node, tag: &str) -> Option<bool> {
     let child = child_w(node, tag)?;
     let val = attr_w(child, "val");
-    Some(match val.as_deref() {
-        Some("0") | Some("false") | Some("off") => false,
-        _ => true,
-    })
-}
-
-pub fn find_root_element<'a, 'input>(
-    doc: &'a Document<'input>,
-    tag: &str,
-) -> Option<Node<'a, 'input>> {
-    doc.root_element()
-        .descendants()
-        .find(|n| n.tag_name().name() == tag)
+    Some(!matches!(
+        val.as_deref(),
+        Some("0") | Some("false") | Some("off")
+    ))
 }

--- a/packages/docx/parser/src/xml_util.rs
+++ b/packages/docx/parser/src/xml_util.rs
@@ -92,7 +92,10 @@ pub fn bool_prop(node: Node, tag: &str) -> Option<bool> {
     })
 }
 
-pub fn find_root_element<'a, 'input>(doc: &'a Document<'input>, tag: &str) -> Option<Node<'a, 'input>> {
+pub fn find_root_element<'a, 'input>(
+    doc: &'a Document<'input>,
+    tag: &str,
+) -> Option<Node<'a, 'input>> {
     doc.root_element()
         .descendants()
         .find(|n| n.tag_name().name() == tag)

--- a/packages/mcp-server/src/main.rs
+++ b/packages/mcp-server/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{ServiceExt, transport::stdio};
+use rmcp::{transport::stdio, ServiceExt};
 use tracing_subscriber::{self, EnvFilter};
 
 mod server;

--- a/packages/mcp-server/src/server.rs
+++ b/packages/mcp-server/src/server.rs
@@ -1,16 +1,10 @@
 use rmcp::{
-    ServerHandler,
     handler::server::router::tool::ToolRouter,
     handler::server::wrapper::Parameters,
     model::{ServerCapabilities, ServerInfo},
-    tool, tool_handler, tool_router,
+    tool, tool_handler, tool_router, ServerHandler,
 };
 
-use crate::tools::{
-    docx::DocxTools,
-    pptx::PptxTools,
-    xlsx::XlsxTools,
-};
 use crate::tools::docx::{
     DocxImagesParam, DocxIndexParam, DocxPathParam, DocxSearchParam, DocxTableIndexParam,
 };
@@ -22,6 +16,7 @@ use crate::tools::xlsx::{
     XlsxCellRangeParam, XlsxChartIndexParam, XlsxOptSheetParam, XlsxPathParam, XlsxSearchParam,
     XlsxSheetParam,
 };
+use crate::tools::{docx::DocxTools, pptx::PptxTools, xlsx::XlsxTools};
 
 #[derive(Clone)]
 pub struct OoxmlServer {
@@ -39,226 +34,358 @@ impl OoxmlServer {
 
     // ── xlsx tools ────────────────────────────────────────────────────────────
 
-    #[tool(description = "Convert an XLSX file to GitHub-flavoured markdown — text-focused projection. One `## SheetName` per sheet followed by a pipe table of cached cell values. Use when an agent needs to *read* spreadsheet content efficiently", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Convert an XLSX file to GitHub-flavoured markdown — text-focused projection. One `## SheetName` per sheet followed by a pipe table of cached cell values. Use when an agent needs to *read* spreadsheet content efficiently",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_to_markdown(&self, Parameters(p): Parameters<XlsxPathParam>) -> String {
         XlsxTools::xlsx_to_markdown(Parameters(p))
     }
 
-    #[tool(description = "Parse an XLSX file and return workbook overview including sheet names and IDs", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Parse an XLSX file and return workbook overview including sheet names and IDs",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_parse(&self, Parameters(p): Parameters<XlsxPathParam>) -> String {
         XlsxTools::xlsx_parse(Parameters(p))
     }
 
-    #[tool(description = "Return only the list of sheet names from an XLSX file", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return only the list of sheet names from an XLSX file",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_sheet_names(&self, Parameters(p): Parameters<XlsxPathParam>) -> String {
         XlsxTools::xlsx_get_sheet_names(Parameters(p))
     }
 
-    #[tool(description = "Return the dimensions (max row and column) of a worksheet", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return the dimensions (max row and column) of a worksheet",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_sheet_dimensions(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
         XlsxTools::xlsx_get_sheet_dimensions(Parameters(p))
     }
 
-    #[tool(description = "Return cell values and formulas for a given range (e.g. \"A1:C10\") in a worksheet", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return cell values and formulas for a given range (e.g. \"A1:C10\") in a worksheet",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_cell_range(&self, Parameters(p): Parameters<XlsxCellRangeParam>) -> String {
         XlsxTools::xlsx_get_cell_range(Parameters(p))
     }
 
-    #[tool(description = "Return all cells that contain formulas in a worksheet", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return all cells that contain formulas in a worksheet",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_formulas(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
         XlsxTools::xlsx_get_formulas(Parameters(p))
     }
 
-    #[tool(description = "Search for a substring in cell values and formulas across one or all sheets of an XLSX file", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Search for a substring in cell values and formulas across one or all sheets of an XLSX file",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_search_cells(&self, Parameters(p): Parameters<XlsxSearchParam>) -> String {
         XlsxTools::xlsx_search_cells(Parameters(p))
     }
 
-    #[tool(description = "List charts on a worksheet (or all sheets if `sheet` is omitted). Returns a summary per chart: anchor cell range, chart type, title, axes, legend, and a series outline (without numeric values)", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List charts on a worksheet (or all sheets if `sheet` is omitted). Returns a summary per chart: anchor cell range, chart type, title, axes, legend, and a series outline (without numeric values)",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_charts(&self, Parameters(p): Parameters<XlsxOptSheetParam>) -> String {
         XlsxTools::xlsx_get_charts(Parameters(p))
     }
 
-    #[tool(description = "Return one chart's full series data (categories and per-point values) for drill-down. `chartIndex` matches the index from `xlsx_get_charts` for the same sheet", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return one chart's full series data (categories and per-point values) for drill-down. `chartIndex` matches the index from `xlsx_get_charts` for the same sheet",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_chart_series(&self, Parameters(p): Parameters<XlsxChartIndexParam>) -> String {
         XlsxTools::xlsx_get_chart_series(Parameters(p))
     }
 
-    #[tool(description = "Return all defined names (named ranges) visible in the workbook", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return all defined names (named ranges) visible in the workbook",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_named_ranges(&self, Parameters(p): Parameters<XlsxPathParam>) -> String {
         XlsxTools::xlsx_get_named_ranges(Parameters(p))
     }
 
-    #[tool(description = "List Excel Tables (Ctrl+T tables, ECMA-376 §18.5) on a sheet or across all sheets", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List Excel Tables (Ctrl+T tables, ECMA-376 §18.5) on a sheet or across all sheets",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_tables(&self, Parameters(p): Parameters<XlsxOptSheetParam>) -> String {
         XlsxTools::xlsx_get_tables(Parameters(p))
     }
 
-    #[tool(description = "Return all merged cell ranges on a worksheet as A1 strings", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return all merged cell ranges on a worksheet as A1 strings",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_merged_cells(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
         XlsxTools::xlsx_get_merged_cells(Parameters(p))
     }
 
-    #[tool(description = "Return conditional formatting rules on a worksheet (CellIs, Expression, ColorScale, DataBar, Top10, AboveAverage, IconSet, Other)", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return conditional formatting rules on a worksheet (CellIs, Expression, ColorScale, DataBar, Top10, AboveAverage, IconSet, Other)",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_conditional_formats(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
         XlsxTools::xlsx_get_conditional_formats(Parameters(p))
     }
 
-    #[tool(description = "Return per-sheet layout: explicit column widths, row heights, freeze panes, gridline visibility, default sizes, and tab color", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return per-sheet layout: explicit column widths, row heights, freeze panes, gridline visibility, default sizes, and tab color",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_sheet_layout(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
         XlsxTools::xlsx_get_sheet_layout(Parameters(p))
     }
 
-    #[tool(description = "Return all `<dataValidation>` rules on a worksheet (ECMA-376 §18.3.1.32)", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return all `<dataValidation>` rules on a worksheet (ECMA-376 §18.3.1.32)",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_data_validations(&self, Parameters(p): Parameters<XlsxSheetParam>) -> String {
         XlsxTools::xlsx_get_data_validations(Parameters(p))
     }
 
-    #[tool(description = "Return all comments (text + resolved author) on a worksheet, or across every sheet when `sheet` is omitted", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return all comments (text + resolved author) on a worksheet, or across every sheet when `sheet` is omitted",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn xlsx_get_comments(&self, Parameters(p): Parameters<XlsxOptSheetParam>) -> String {
         XlsxTools::xlsx_get_comments(Parameters(p))
     }
 
     // ── docx tools ────────────────────────────────────────────────────────────
 
-    #[tool(description = "Convert a DOCX file to GitHub-flavoured markdown — text-focused projection. Headings, paragraphs, bullet/numbered lists, tables, footnotes, comments, with bold/italic/strikethrough/hyperlinks preserved. Use when an agent needs to *read* the document content efficiently", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Convert a DOCX file to GitHub-flavoured markdown — text-focused projection. Headings, paragraphs, bullet/numbered lists, tables, footnotes, comments, with bold/italic/strikethrough/hyperlinks preserved. Use when an agent needs to *read* the document content efficiently",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_to_markdown(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_to_markdown(Parameters(p))
     }
 
-    #[tool(description = "Extract all plain text from a DOCX file", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Extract all plain text from a DOCX file",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_extract_text(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_extract_text(Parameters(p))
     }
 
-    #[tool(description = "Return the document structure (paragraphs and tables) of a DOCX file", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return the document structure (paragraphs and tables) of a DOCX file",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_structure(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_structure(Parameters(p))
     }
 
-    #[tool(description = "Return all tables from a DOCX file with their cell contents", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return all tables from a DOCX file with their cell contents",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_tables(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_tables(Parameters(p))
     }
 
-    #[tool(description = "Search for a substring in all paragraph and table text of a DOCX file; returns matching excerpts with their position", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Search for a substring in all paragraph and table text of a DOCX file; returns matching excerpts with their position",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_search_text(&self, Parameters(p): Parameters<DocxSearchParam>) -> String {
         DocxTools::docx_search_text(Parameters(p))
     }
 
-    #[tool(description = "Return one body element's full detail (paragraph or table) including run-level formatting, indents, spacing, numbering, and tab stops", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return one body element's full detail (paragraph or table) including run-level formatting, indents, spacing, numbering, and tab stops",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_paragraph(&self, Parameters(p): Parameters<DocxIndexParam>) -> String {
         DocxTools::docx_get_paragraph(Parameters(p))
     }
 
-    #[tool(description = "Return the document's section properties (page size/margins/docGrid) along with default/first/even header and footer body elements", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return the document's section properties (page size/margins/docGrid) along with default/first/even header and footer body elements",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_sections(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_sections(Parameters(p))
     }
 
-    #[tool(description = "Return one table's full detail by index, including cell content, colSpan/vMerge, borders, shading, and row heights", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return one table's full detail by index, including cell content, colSpan/vMerge, borders, shading, and row heights",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_table(&self, Parameters(p): Parameters<DocxTableIndexParam>) -> String {
         DocxTools::docx_get_table(Parameters(p))
     }
 
-    #[tool(description = "List all images in the document. Set `includeDataUrl=true` to also receive the inline base64 image bytes (large)", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List all images in the document. Set `includeDataUrl=true` to also receive the inline base64 image bytes (large)",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_images(&self, Parameters(p): Parameters<DocxImagesParam>) -> String {
         DocxTools::docx_get_images(Parameters(p))
     }
 
-    #[tool(description = "List all drawn shapes embedded in paragraphs. Returns each shape's preset geometry, fill, stroke, dimensions, anchor offsets, rotation, and embedded text blocks", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List all drawn shapes embedded in paragraphs. Returns each shape's preset geometry, fill, stroke, dimensions, anchor offsets, rotation, and embedded text blocks",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_shapes(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_shapes(Parameters(p))
     }
 
-    #[tool(description = "Return the heading outline of the document built from each paragraph's resolved `outlineLevel`", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return the heading outline of the document built from each paragraph's resolved `outlineLevel`",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_outline(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_outline(Parameters(p))
     }
 
-    #[tool(description = "List all comments from word/comments.xml: id, author, initials, date, plain text", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List all comments from word/comments.xml: id, author, initials, date, plain text",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_comments(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_comments(Parameters(p))
     }
 
-    #[tool(description = "List footnote and endnote bodies from word/footnotes.xml and word/endnotes.xml", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List footnote and endnote bodies from word/footnotes.xml and word/endnotes.xml",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_footnotes(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_footnotes(Parameters(p))
     }
 
-    #[tool(description = "List all track-changes events (insertions and deletions) with author, date, and text", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List all track-changes events (insertions and deletions) with author, date, and text",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn docx_get_revisions(&self, Parameters(p): Parameters<DocxPathParam>) -> String {
         DocxTools::docx_get_revisions(Parameters(p))
     }
 
     // ── pptx tools ────────────────────────────────────────────────────────────
 
-    #[tool(description = "Return the number of slides and each slide's title from a PPTX file", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return the number of slides and each slide's title from a PPTX file",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_slides(&self, Parameters(p): Parameters<PptxPathParam>) -> String {
         PptxTools::pptx_get_slides(Parameters(p))
     }
 
-    #[tool(description = "Extract plain text from a PPTX file; optionally filter to a single slide by 0-based index", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Extract plain text from a PPTX file; optionally filter to a single slide by 0-based index",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_extract_text(&self, Parameters(p): Parameters<PptxTextParam>) -> String {
         PptxTools::pptx_extract_text(Parameters(p))
     }
 
-    #[tool(description = "Return the structure (elements with position, size, text) of a single slide", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return the structure (elements with position, size, text) of a single slide",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_slide_structure(&self, Parameters(p): Parameters<PptxSlideParam>) -> String {
         PptxTools::pptx_get_slide_structure(Parameters(p))
     }
 
-    #[tool(description = "Search for a substring across all text in a PPTX file; returns matching slide numbers and the text snippets that matched", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Search for a substring across all text in a PPTX file; returns matching slide numbers and the text snippets that matched",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_search_text(&self, Parameters(p): Parameters<PptxSearchParam>) -> String {
         PptxTools::pptx_search_text(Parameters(p))
     }
 
-    #[tool(description = "Return one shape's full detail by slide and shape index. Includes geometry name, position/size, rotation/flip, fill, stroke (with arrow ends), adjustment values, effects, and text body", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return one shape's full detail by slide and shape index. Includes geometry name, position/size, rotation/flip, fill, stroke (with arrow ends), adjustment values, effects, and text body",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_shape(&self, Parameters(p): Parameters<PptxShapeParam>) -> String {
         PptxTools::pptx_get_shape(Parameters(p))
     }
 
-    #[tool(description = "Return one shape's text body in detail: paragraphs with alignment, list level, bullets, and per-run formatting", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return one shape's text body in detail: paragraphs with alignment, list level, bullets, and per-run formatting",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_shape_text(&self, Parameters(p): Parameters<PptxShapeParam>) -> String {
         PptxTools::pptx_get_shape_text(Parameters(p))
     }
 
-    #[tool(description = "List all charts on a slide (or every slide). Each entry exposes type, position, title, categories, and series", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List all charts on a slide (or every slide). Each entry exposes type, position, title, categories, and series",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_charts(&self, Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         PptxTools::pptx_get_charts(Parameters(p))
     }
 
-    #[tool(description = "List all tables on a slide (or every slide), including column widths, row heights, and per-cell content with merge information", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List all tables on a slide (or every slide), including column widths, row heights, and per-cell content with merge information",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_tables(&self, Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         PptxTools::pptx_get_tables(Parameters(p))
     }
 
-    #[tool(description = "List all picture elements on a slide (or every slide). Returns metadata only by default; pass `includeDataUrl=true` to include the inline base64 bytes", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "List all picture elements on a slide (or every slide). Returns metadata only by default; pass `includeDataUrl=true` to include the inline base64 bytes",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_pictures(&self, Parameters(p): Parameters<PptxPicturesParam>) -> String {
         PptxTools::pptx_get_pictures(Parameters(p))
     }
 
-    #[tool(description = "Return presentation-level metadata: slide width/height (EMU), slide count, default text color, theme major/minor fonts, and hyperlink colors", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return presentation-level metadata: slide width/height (EMU), slide count, default text color, theme major/minor fonts, and hyperlink colors",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_presentation_meta(&self, Parameters(p): Parameters<PptxPathParam>) -> String {
         PptxTools::pptx_get_presentation_meta(Parameters(p))
     }
 
-    #[tool(description = "Convert a PPTX file to GitHub-flavoured markdown — text-focused projection. Discards geometry/fills/strokes/effects, keeps titles, bullets, tables, chart summaries, notes, and comments. Use when an agent needs to *read* a deck efficiently (10-30× token reduction vs. structured tools)", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Convert a PPTX file to GitHub-flavoured markdown — text-focused projection. Discards geometry/fills/strokes/effects, keeps titles, bullets, tables, chart summaries, notes, and comments. Use when an agent needs to *read* a deck efficiently (10-30× token reduction vs. structured tools)",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_to_markdown(&self, Parameters(p): Parameters<PptxPathParam>) -> String {
         PptxTools::pptx_to_markdown(Parameters(p))
     }
 
-    #[tool(description = "Return speaker-notes text for one or all slides", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return speaker-notes text for one or all slides",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_notes(&self, Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         PptxTools::pptx_get_notes(Parameters(p))
     }
 
-    #[tool(description = "Return legacy slide comments with text, author, and date", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Return legacy slide comments with text, author, and date",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_comments(&self, Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         PptxTools::pptx_get_comments(Parameters(p))
     }
 
-    #[tool(description = "Infer geometric relations between shapes on a slide: connector hookups (with arrow direction when stroke ends are arrows), containment, overlap, and axis-aligned alignment groups. Detection is purely spatial — see `confidence: \"inferred\"` on each emitted relation", annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false))]
+    #[tool(
+        description = "Infer geometric relations between shapes on a slide: connector hookups (with arrow direction when stroke ends are arrows), containment, overlap, and axis-aligned alignment groups. Detection is purely spatial — see `confidence: \"inferred\"` on each emitted relation",
+        annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
+    )]
     fn pptx_get_shape_relations(&self, Parameters(p): Parameters<PptxRelationsParam>) -> String {
         PptxTools::pptx_get_shape_relations(Parameters(p))
     }
@@ -267,10 +394,6 @@ impl OoxmlServer {
 #[tool_handler]
 impl ServerHandler for OoxmlServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
-            ServerCapabilities::builder()
-                .enable_tools()
-                .build(),
-        )
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
     }
 }

--- a/packages/mcp-server/src/tools/docx.rs
+++ b/packages/mcp-server/src/tools/docx.rs
@@ -116,10 +116,7 @@ fn body_structure(body: &[Value]) -> Vec<Value> {
                 })
             }
             "table" => {
-                let rows = el["rows"]
-                    .as_array()
-                    .map(|r| r.len())
-                    .unwrap_or(0);
+                let rows = el["rows"].as_array().map(|r| r.len()).unwrap_or(0);
                 let cols = el["rows"]
                     .as_array()
                     .and_then(|r| r.first())
@@ -142,7 +139,9 @@ fn body_structure(body: &[Value]) -> Vec<Value> {
 pub struct DocxTools;
 
 impl DocxTools {
-    #[tool(description = "Convert a DOCX file to GitHub-flavoured markdown. Preserves textual structure (headings from outlineLevel, paragraphs, bullet/numbered lists, tables, footnotes, comments) and rich-text formatting (bold/italic/strikethrough/hyperlinks). Discards positioning, section properties, font metrics, drawing shapes, and headers/footers. Designed for agents that need to *read* the document content efficiently — typical 10×+ token reduction vs. the structured JSON tools. Lossy by design: when you need precise layout or styling, fall back to `docx_get_structure` / `docx_get_paragraph`")]
+    #[tool(
+        description = "Convert a DOCX file to GitHub-flavoured markdown. Preserves textual structure (headings from outlineLevel, paragraphs, bullet/numbered lists, tables, footnotes, comments) and rich-text formatting (bold/italic/strikethrough/hyperlinks). Discards positioning, section properties, font metrics, drawing shapes, and headers/footers. Designed for agents that need to *read* the document content efficiently — typical 10×+ token reduction vs. the structured JSON tools. Lossy by design: when you need precise layout or styling, fall back to `docx_get_structure` / `docx_get_paragraph`"
+    )]
     pub fn docx_to_markdown(Parameters(p): Parameters<DocxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -224,9 +223,7 @@ impl DocxTools {
                                             .iter()
                                             .map(|cell| {
                                                 let mut text = String::new();
-                                                if let Some(paras) =
-                                                    cell["paragraphs"].as_array()
-                                                {
+                                                if let Some(paras) = cell["paragraphs"].as_array() {
                                                     for p in paras {
                                                         collect_run_texts(&p["runs"], &mut text);
                                                     }
@@ -247,7 +244,9 @@ impl DocxTools {
         serde_json::to_string(&tables).unwrap_or_else(|e| format!("Error: {}", e))
     }
 
-    #[tool(description = "Search for a substring in all paragraph and table text of a DOCX file; returns matching excerpts with their position")]
+    #[tool(
+        description = "Search for a substring in all paragraph and table text of a DOCX file; returns matching excerpts with their position"
+    )]
     pub fn docx_search_text(Parameters(p): Parameters<DocxSearchParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -316,7 +315,9 @@ impl DocxTools {
         .to_string()
     }
 
-    #[tool(description = "Return one body element's full detail (paragraph or table) including run-level formatting (bold/italic/color/font/hyperlink), indents, spacing, numbering, and tab stops. `index` is into the document body list (matches `docx_get_structure`)")]
+    #[tool(
+        description = "Return one body element's full detail (paragraph or table) including run-level formatting (bold/italic/color/font/hyperlink), indents, spacing, numbering, and tab stops. `index` is into the document body list (matches `docx_get_structure`)"
+    )]
     pub fn docx_get_paragraph(Parameters(p): Parameters<DocxIndexParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -348,7 +349,9 @@ impl DocxTools {
         out.to_string()
     }
 
-    #[tool(description = "Return the document's section properties (page size/margins/docGrid) along with default/first/even header and footer body elements")]
+    #[tool(
+        description = "Return the document's section properties (page size/margins/docGrid) along with default/first/even header and footer body elements"
+    )]
     pub fn docx_get_sections(Parameters(p): Parameters<DocxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -372,7 +375,9 @@ impl DocxTools {
         .to_string()
     }
 
-    #[tool(description = "Return one table's full detail by index, including cell content, colSpan/vMerge, borders, shading, and row heights. Use this for deeper inspection than `docx_get_tables`")]
+    #[tool(
+        description = "Return one table's full detail by index, including cell content, colSpan/vMerge, borders, shading, and row heights. Use this for deeper inspection than `docx_get_tables`"
+    )]
     pub fn docx_get_table(Parameters(p): Parameters<DocxTableIndexParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -401,7 +406,10 @@ impl DocxTools {
         let (body_index, table) = match found {
             Some(t) => t,
             None => {
-                let total = body.iter().filter(|e| e["type"].as_str() == Some("table")).count();
+                let total = body
+                    .iter()
+                    .filter(|e| e["type"].as_str() == Some("table"))
+                    .count();
                 return format!(
                     "Error: table index {} out of range (total tables: {})",
                     p.table_index, total
@@ -416,7 +424,9 @@ impl DocxTools {
         .to_string()
     }
 
-    #[tool(description = "List all images in the document. Each entry carries the paragraph index, anchor mode, wrap settings, and dimensions. Set `includeDataUrl=true` to also receive the inline base64 image bytes (large)")]
+    #[tool(
+        description = "List all images in the document. Each entry carries the paragraph index, anchor mode, wrap settings, and dimensions. Set `includeDataUrl=true` to also receive the inline base64 image bytes (large)"
+    )]
     pub fn docx_get_images(Parameters(p): Parameters<DocxImagesParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -436,7 +446,9 @@ impl DocxTools {
             if element["type"].as_str() != Some("paragraph") {
                 continue;
             }
-            let Some(runs) = element["runs"].as_array() else { continue };
+            let Some(runs) = element["runs"].as_array() else {
+                continue;
+            };
             for (run_idx, run) in runs.iter().enumerate() {
                 if run["type"].as_str() != Some("image") {
                     continue;
@@ -462,7 +474,9 @@ impl DocxTools {
         serde_json::json!({ "images": images }).to_string()
     }
 
-    #[tool(description = "List all drawn shapes embedded in paragraphs (wps:wsp inside wp:anchor). Returns each shape's preset geometry, fill, stroke, dimensions, anchor offsets, rotation, and embedded text blocks")]
+    #[tool(
+        description = "List all drawn shapes embedded in paragraphs (wps:wsp inside wp:anchor). Returns each shape's preset geometry, fill, stroke, dimensions, anchor offsets, rotation, and embedded text blocks"
+    )]
     pub fn docx_get_shapes(Parameters(p): Parameters<DocxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -482,7 +496,9 @@ impl DocxTools {
             if element["type"].as_str() != Some("paragraph") {
                 continue;
             }
-            let Some(runs) = element["runs"].as_array() else { continue };
+            let Some(runs) = element["runs"].as_array() else {
+                continue;
+            };
             for (run_idx, run) in runs.iter().enumerate() {
                 if run["type"].as_str() != Some("shape") {
                     continue;
@@ -509,7 +525,9 @@ impl DocxTools {
         serde_json::json!({ "shapes": shapes }).to_string()
     }
 
-    #[tool(description = "Return the heading outline of the document. Each entry has the body index, outlineLevel (0-8), styleId, and visible text. Levels come from the parser's resolved `outlineLevel` (style chain + direct pPr) — useful for building TOCs without parsing styleId strings")]
+    #[tool(
+        description = "Return the heading outline of the document. Each entry has the body index, outlineLevel (0-8), styleId, and visible text. Levels come from the parser's resolved `outlineLevel` (style chain + direct pPr) — useful for building TOCs without parsing styleId strings"
+    )]
     pub fn docx_get_outline(Parameters(p): Parameters<DocxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -526,8 +544,12 @@ impl DocxTools {
         let body = doc["body"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
         let mut outline: Vec<Value> = Vec::new();
         for (idx, el) in body.iter().enumerate() {
-            if el["type"].as_str() != Some("paragraph") { continue }
-            let Some(level) = el["outlineLevel"].as_u64() else { continue };
+            if el["type"].as_str() != Some("paragraph") {
+                continue;
+            }
+            let Some(level) = el["outlineLevel"].as_u64() else {
+                continue;
+            };
             let mut text = String::new();
             collect_run_texts(&el["runs"], &mut text);
             outline.push(serde_json::json!({
@@ -540,7 +562,9 @@ impl DocxTools {
         serde_json::json!({ "outline": outline }).to_string()
     }
 
-    #[tool(description = "List all `<w:comment>` entries from word/comments.xml: id, author, initials, date, plain text. Empty when the document has no comments part")]
+    #[tool(
+        description = "List all `<w:comment>` entries from word/comments.xml: id, author, initials, date, plain text. Empty when the document has no comments part"
+    )]
     pub fn docx_get_comments(Parameters(p): Parameters<DocxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -554,10 +578,13 @@ impl DocxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        serde_json::json!({ "comments": doc["comments"].as_array().cloned().unwrap_or_default() }).to_string()
+        serde_json::json!({ "comments": doc["comments"].as_array().cloned().unwrap_or_default() })
+            .to_string()
     }
 
-    #[tool(description = "List footnote and endnote bodies from word/footnotes.xml and word/endnotes.xml. Each entry has the id (matches `<w:footnoteReference w:id>` in body) and concatenated plain text")]
+    #[tool(
+        description = "List footnote and endnote bodies from word/footnotes.xml and word/endnotes.xml. Each entry has the id (matches `<w:footnoteReference w:id>` in body) and concatenated plain text"
+    )]
     pub fn docx_get_footnotes(Parameters(p): Parameters<DocxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -578,7 +605,9 @@ impl DocxTools {
         .to_string()
     }
 
-    #[tool(description = "Return all track-changes events found in the body: insertions and deletions with author, date, and the text. Empty when the document has no tracked changes")]
+    #[tool(
+        description = "Return all track-changes events found in the body: insertions and deletions with author, date, and the text. Empty when the document has no tracked changes"
+    )]
     pub fn docx_get_revisions(Parameters(p): Parameters<DocxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -592,7 +621,8 @@ impl DocxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        serde_json::json!({ "revisions": doc["revisions"].as_array().cloned().unwrap_or_default() }).to_string()
+        serde_json::json!({ "revisions": doc["revisions"].as_array().cloned().unwrap_or_default() })
+            .to_string()
     }
 }
 
@@ -682,7 +712,10 @@ mod sample_tests {
             include_data_url: false,
         }));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
-        assert!(v["images"].as_array().is_some(), "missing 'images' array: {out}");
+        assert!(
+            v["images"].as_array().is_some(),
+            "missing 'images' array: {out}"
+        );
     }
 
     #[test]
@@ -746,6 +779,9 @@ mod sample_tests {
             path,
             index: 999_999,
         }));
-        assert!(out.starts_with("Error:"), "expected out-of-range error, got: {out}");
+        assert!(
+            out.starts_with("Error:"),
+            "expected out-of-range error, got: {out}"
+        );
     }
 }

--- a/packages/mcp-server/src/tools/pptx.rs
+++ b/packages/mcp-server/src/tools/pptx.rs
@@ -245,6 +245,10 @@ fn slide_structure(slide: &Value) -> Value {
 
 // ─── Spatial geometry helpers (used by `pptx_get_shape_relations`) ───────────
 
+/// A named alignment axis: its label plus an accessor extracting the edge/center
+/// coordinate (EMU) used to group shapes that share that axis.
+type AlignmentAxis = (&'static str, fn(&Bbox) -> i64);
+
 /// EMU values are i64 in the parser output. Bounding box in EMU.
 #[derive(Debug, Clone, Copy)]
 struct Bbox {
@@ -1219,11 +1223,10 @@ impl PptxTools {
             if outer_conn {
                 continue;
             }
-            for j in 0..bboxes.len() {
+            for (j, &(idx_inner, inner_bb, inner_conn)) in bboxes.iter().enumerate() {
                 if i == j {
                     continue;
                 }
-                let (idx_inner, inner_bb, inner_conn) = bboxes[j];
                 if inner_conn {
                     continue;
                 }
@@ -1243,8 +1246,7 @@ impl PptxTools {
             if a_conn {
                 continue;
             }
-            for j in (i + 1)..bboxes.len() {
-                let (idx_b, b_bb, b_conn) = bboxes[j];
+            for &(idx_b, b_bb, b_conn) in bboxes.iter().skip(i + 1) {
                 if b_conn {
                     continue;
                 }
@@ -1270,7 +1272,7 @@ impl PptxTools {
             .map(|(i, b, _)| (*i, *b))
             .collect();
 
-        let alignment_axes: [(&str, fn(&Bbox) -> i64); 3] = [
+        let alignment_axes: [AlignmentAxis; 3] = [
             ("top", |b| b.y),
             ("center", |b| b.cy()),
             ("bottom", |b| b.bottom()),
@@ -1278,7 +1280,7 @@ impl PptxTools {
         for (axis, get_y) in alignment_axes {
             push_alignment_groups(&real, "alignH", axis, get_y, tol, &mut relations);
         }
-        let alignment_axes_v: [(&str, fn(&Bbox) -> i64); 3] = [
+        let alignment_axes_v: [AlignmentAxis; 3] = [
             ("left", |b| b.x),
             ("center", |b| b.cx()),
             ("right", |b| b.right()),

--- a/packages/mcp-server/src/tools/pptx.rs
+++ b/packages/mcp-server/src/tools/pptx.rs
@@ -138,20 +138,30 @@ fn slide_title(slide: &Value) -> Option<String> {
 
     // First pass: prefer the explicit title placeholder.
     for el in elements {
-        if el["type"].as_str() != Some("shape") { continue }
-        let Some(ph) = el["placeholderType"].as_str() else { continue };
+        if el["type"].as_str() != Some("shape") {
+            continue;
+        }
+        let Some(ph) = el["placeholderType"].as_str() else {
+            continue;
+        };
         if ph == "title" || ph == "ctrTitle" {
             let trimmed = read_text(el);
-            if !trimmed.is_empty() { return Some(trimmed); }
+            if !trimmed.is_empty() {
+                return Some(trimmed);
+            }
         }
     }
 
     // Fallback: first non-empty shape text. Same heuristic the previous
     // implementation used; kept for slides without a title placeholder.
     for el in elements {
-        if el["type"].as_str() != Some("shape") { continue }
+        if el["type"].as_str() != Some("shape") {
+            continue;
+        }
         let trimmed = read_text(el);
-        if !trimmed.is_empty() { return Some(trimmed); }
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
     }
     None
 }
@@ -253,10 +263,18 @@ impl Bbox {
         Some(Bbox { x, y, w, h })
     }
 
-    fn right(&self) -> i64 { self.x + self.w }
-    fn bottom(&self) -> i64 { self.y + self.h }
-    fn cx(&self) -> i64 { self.x + self.w / 2 }
-    fn cy(&self) -> i64 { self.y + self.h / 2 }
+    fn right(&self) -> i64 {
+        self.x + self.w
+    }
+    fn bottom(&self) -> i64 {
+        self.y + self.h
+    }
+    fn cx(&self) -> i64 {
+        self.x + self.w / 2
+    }
+    fn cy(&self) -> i64 {
+        self.y + self.h / 2
+    }
 
     /// Intersection-over-union with another bbox. Returns 0.0 when either box
     /// has zero area or they don't overlap.
@@ -272,7 +290,11 @@ impl Bbox {
         let a = (self.w as f64) * (self.h as f64);
         let b = (other.w as f64) * (other.h as f64);
         let union = a + b - inter;
-        if union <= 0.0 { 0.0 } else { inter / union }
+        if union <= 0.0 {
+            0.0
+        } else {
+            inter / union
+        }
     }
 
     /// True when `self` fully contains `other`, allowing `tol` EMU of slack
@@ -298,15 +320,15 @@ fn is_connector(geometry: &str) -> bool {
     matches!(
         geometry,
         "line"
-        | "straightConnector1"
-        | "bentConnector2"
-        | "bentConnector3"
-        | "bentConnector4"
-        | "bentConnector5"
-        | "curvedConnector2"
-        | "curvedConnector3"
-        | "curvedConnector4"
-        | "curvedConnector5"
+            | "straightConnector1"
+            | "bentConnector2"
+            | "bentConnector3"
+            | "bentConnector4"
+            | "bentConnector5"
+            | "curvedConnector2"
+            | "curvedConnector3"
+            | "curvedConnector4"
+            | "curvedConnector5"
     )
 }
 
@@ -325,22 +347,31 @@ fn arrow_is_directional(arrow: &Value) -> bool {
 /// further than `tol` from every side.
 fn point_on_shape(point: (i64, i64), bbox: &Bbox, tol: i64) -> Option<&'static str> {
     let (px, py) = point;
-    if px < bbox.x - tol
-        || px > bbox.right() + tol
-        || py < bbox.y - tol
-        || py > bbox.bottom() + tol
+    if px < bbox.x - tol || px > bbox.right() + tol || py < bbox.y - tol || py > bbox.bottom() + tol
     {
         return None;
     }
     let candidates: [(&'static str, i64); 8] = [
         ("topLeft", (px - bbox.x).abs() + (py - bbox.y).abs()),
         ("topRight", (px - bbox.right()).abs() + (py - bbox.y).abs()),
-        ("bottomLeft", (px - bbox.x).abs() + (py - bbox.bottom()).abs()),
-        ("bottomRight", (px - bbox.right()).abs() + (py - bbox.bottom()).abs()),
+        (
+            "bottomLeft",
+            (px - bbox.x).abs() + (py - bbox.bottom()).abs(),
+        ),
+        (
+            "bottomRight",
+            (px - bbox.right()).abs() + (py - bbox.bottom()).abs(),
+        ),
         ("top", (py - bbox.y).abs() + (px - bbox.cx()).abs() / 4),
-        ("bottom", (py - bbox.bottom()).abs() + (px - bbox.cx()).abs() / 4),
+        (
+            "bottom",
+            (py - bbox.bottom()).abs() + (px - bbox.cx()).abs() / 4,
+        ),
         ("left", (px - bbox.x).abs() + (py - bbox.cy()).abs() / 4),
-        ("right", (px - bbox.right()).abs() + (py - bbox.cy()).abs() / 4),
+        (
+            "right",
+            (px - bbox.right()).abs() + (py - bbox.cy()).abs() / 4,
+        ),
     ];
     let best = candidates.iter().min_by_key(|(_, d)| *d)?;
     Some(best.0)
@@ -452,7 +483,7 @@ mod relations_tests {
     fn nearest_shape_skips_self_and_connectors() {
         let shapes = vec![
             (0usize, b(0, 0, 100, 100), false),
-            (1, b(100, 0, 50, 50), true),  // connector
+            (1, b(100, 0, 50, 50), true), // connector
             (2, b(150, 0, 100, 100), false),
         ];
         // Point at the right edge of shape 0
@@ -483,7 +514,10 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let summary: Vec<Value> = slides
             .iter()
             .map(|s| {
@@ -501,7 +535,9 @@ impl PptxTools {
         .to_string()
     }
 
-    #[tool(description = "Extract plain text from a PPTX file; optionally filter to a single slide by 0-based index")]
+    #[tool(
+        description = "Extract plain text from a PPTX file; optionally filter to a single slide by 0-based index"
+    )]
     pub fn pptx_extract_text(Parameters(p): Parameters<PptxTextParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -515,7 +551,10 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
 
         if let Some(idx) = p.slide_index {
             let slide = match slides.get(idx) {
@@ -540,7 +579,9 @@ impl PptxTools {
         out
     }
 
-    #[tool(description = "Return the structure (elements with position, size, text) of a single slide")]
+    #[tool(
+        description = "Return the structure (elements with position, size, text) of a single slide"
+    )]
     pub fn pptx_get_slide_structure(Parameters(p): Parameters<PptxSlideParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -554,7 +595,10 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let slide = match slides.get(p.slide_index) {
             Some(s) => s,
             None => {
@@ -568,7 +612,9 @@ impl PptxTools {
         serde_json::to_string(&slide_structure(slide)).unwrap_or_else(|e| format!("Error: {}", e))
     }
 
-    #[tool(description = "Search for a substring across all text in a PPTX file; returns matching slide numbers and the text snippets that matched")]
+    #[tool(
+        description = "Search for a substring across all text in a PPTX file; returns matching slide numbers and the text snippets that matched"
+    )]
     pub fn pptx_search_text(Parameters(p): Parameters<PptxSearchParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -582,7 +628,10 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let query_lower = p.query.to_lowercase();
         let mut matches: Vec<Value> = Vec::new();
 
@@ -645,7 +694,9 @@ impl PptxTools {
         .to_string()
     }
 
-    #[tool(description = "Return one shape's full detail by slide and shape index. `shapeIndex` matches the element index in `pptx_get_slide_structure`. Includes geometry name, position/size, rotation/flip, fill, stroke (with arrow ends), adjustment values, effects (shadow/glow/etc.), and the text body when present")]
+    #[tool(
+        description = "Return one shape's full detail by slide and shape index. `shapeIndex` matches the element index in `pptx_get_slide_structure`. Includes geometry name, position/size, rotation/flip, fill, stroke (with arrow ends), adjustment values, effects (shadow/glow/etc.), and the text body when present"
+    )]
     pub fn pptx_get_shape(Parameters(p): Parameters<PptxShapeParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -659,23 +710,31 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let slide = match slides.get(p.slide_index) {
             Some(s) => s,
             None => {
                 return format!(
                     "Error: slide index {} out of range (total: {})",
-                    p.slide_index, slides.len()
+                    p.slide_index,
+                    slides.len()
                 )
             }
         };
-        let elements = slide["elements"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let elements = slide["elements"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let element = match elements.get(p.shape_index) {
             Some(e) => e,
             None => {
                 return format!(
                     "Error: shape index {} out of range (slide elements: {})",
-                    p.shape_index, elements.len()
+                    p.shape_index,
+                    elements.len()
                 )
             }
         };
@@ -687,7 +746,9 @@ impl PptxTools {
         out.to_string()
     }
 
-    #[tool(description = "Return one shape's text body in detail: paragraphs with alignment, list level, bullets, and per-run formatting (text/bold/italic/size/color/font/hyperlink)")]
+    #[tool(
+        description = "Return one shape's text body in detail: paragraphs with alignment, list level, bullets, and per-run formatting (text/bold/italic/size/color/font/hyperlink)"
+    )]
     pub fn pptx_get_shape_text(Parameters(p): Parameters<PptxShapeParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -701,23 +762,31 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let slide = match slides.get(p.slide_index) {
             Some(s) => s,
             None => {
                 return format!(
                     "Error: slide index {} out of range (total: {})",
-                    p.slide_index, slides.len()
+                    p.slide_index,
+                    slides.len()
                 )
             }
         };
-        let elements = slide["elements"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let elements = slide["elements"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let element = match elements.get(p.shape_index) {
             Some(e) => e,
             None => {
                 return format!(
                     "Error: shape index {} out of range (slide elements: {})",
-                    p.shape_index, elements.len()
+                    p.shape_index,
+                    elements.len()
                 )
             }
         };
@@ -730,7 +799,9 @@ impl PptxTools {
         .to_string()
     }
 
-    #[tool(description = "List all charts on a slide (or every slide when `slideIndex` is omitted). Each entry exposes type, position, title, categories, and series (with values)")]
+    #[tool(
+        description = "List all charts on a slide (or every slide when `slideIndex` is omitted). Each entry exposes type, position, title, categories, and series (with values)"
+    )]
     pub fn pptx_get_charts(Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -744,15 +815,24 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let mut charts: Vec<Value> = Vec::new();
         for (slide_idx, slide) in slides.iter().enumerate() {
             if let Some(filter) = p.slide_index {
-                if slide_idx != filter { continue; }
+                if slide_idx != filter {
+                    continue;
+                }
             }
-            let Some(elements) = slide["elements"].as_array() else { continue };
+            let Some(elements) = slide["elements"].as_array() else {
+                continue;
+            };
             for (shape_idx, el) in elements.iter().enumerate() {
-                if el["type"].as_str() != Some("chart") { continue }
+                if el["type"].as_str() != Some("chart") {
+                    continue;
+                }
                 charts.push(serde_json::json!({
                     "slideIndex": slide_idx,
                     "shapeIndex": shape_idx,
@@ -773,7 +853,9 @@ impl PptxTools {
         serde_json::json!({ "charts": charts }).to_string()
     }
 
-    #[tool(description = "List all tables on a slide (or every slide when `slideIndex` is omitted). Each entry includes column widths, row heights, and per-cell content (textBody) plus colSpan/rowSpan/merge information")]
+    #[tool(
+        description = "List all tables on a slide (or every slide when `slideIndex` is omitted). Each entry includes column widths, row heights, and per-cell content (textBody) plus colSpan/rowSpan/merge information"
+    )]
     pub fn pptx_get_tables(Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -787,15 +869,24 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let mut tables: Vec<Value> = Vec::new();
         for (slide_idx, slide) in slides.iter().enumerate() {
             if let Some(filter) = p.slide_index {
-                if slide_idx != filter { continue; }
+                if slide_idx != filter {
+                    continue;
+                }
             }
-            let Some(elements) = slide["elements"].as_array() else { continue };
+            let Some(elements) = slide["elements"].as_array() else {
+                continue;
+            };
             for (shape_idx, el) in elements.iter().enumerate() {
-                if el["type"].as_str() != Some("table") { continue }
+                if el["type"].as_str() != Some("table") {
+                    continue;
+                }
                 tables.push(serde_json::json!({
                     "slideIndex": slide_idx,
                     "shapeIndex": shape_idx,
@@ -811,7 +902,9 @@ impl PptxTools {
         serde_json::json!({ "tables": tables }).to_string()
     }
 
-    #[tool(description = "List all picture elements on a slide (or every slide when `slideIndex` is omitted). Returns metadata only by default; pass `includeDataUrl=true` to include the inline base64 bytes")]
+    #[tool(
+        description = "List all picture elements on a slide (or every slide when `slideIndex` is omitted). Returns metadata only by default; pass `includeDataUrl=true` to include the inline base64 bytes"
+    )]
     pub fn pptx_get_pictures(Parameters(p): Parameters<PptxPicturesParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -825,15 +918,24 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let mut pictures: Vec<Value> = Vec::new();
         for (slide_idx, slide) in slides.iter().enumerate() {
             if let Some(filter) = p.slide_index {
-                if slide_idx != filter { continue; }
+                if slide_idx != filter {
+                    continue;
+                }
             }
-            let Some(elements) = slide["elements"].as_array() else { continue };
+            let Some(elements) = slide["elements"].as_array() else {
+                continue;
+            };
             for (shape_idx, el) in elements.iter().enumerate() {
-                if el["type"].as_str() != Some("picture") { continue }
+                if el["type"].as_str() != Some("picture") {
+                    continue;
+                }
                 let mut entry = serde_json::json!({
                     "slideIndex": slide_idx,
                     "shapeIndex": shape_idx,
@@ -856,7 +958,9 @@ impl PptxTools {
         serde_json::json!({ "pictures": pictures }).to_string()
     }
 
-    #[tool(description = "Return presentation-level metadata: slide width/height (EMU), default text color, theme major/minor fonts, and hyperlink colors")]
+    #[tool(
+        description = "Return presentation-level metadata: slide width/height (EMU), default text color, theme major/minor fonts, and hyperlink colors"
+    )]
     pub fn pptx_get_presentation_meta(Parameters(p): Parameters<PptxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -884,7 +988,9 @@ impl PptxTools {
         .to_string()
     }
 
-    #[tool(description = "Convert a PPTX file to GitHub-flavoured markdown. Preserves textual structure (titles, bullets at correct nesting, tables, chart summaries, speaker notes, comments) and discards presentation details (geometry, fills, strokes, theme inheritance, positions). Designed for agents that need to *read* a deck efficiently — typical 10-30× token reduction vs. `pptx_get_slides` / `pptx_extract_text`. Lossy by design: when you need precise layout or styling, fall back to the structured tools (`pptx_get_shape`, `pptx_get_slide_structure`, etc.)")]
+    #[tool(
+        description = "Convert a PPTX file to GitHub-flavoured markdown. Preserves textual structure (titles, bullets at correct nesting, tables, chart summaries, speaker notes, comments) and discards presentation details (geometry, fills, strokes, theme inheritance, positions). Designed for agents that need to *read* a deck efficiently — typical 10-30× token reduction vs. `pptx_get_slides` / `pptx_extract_text`. Lossy by design: when you need precise layout or styling, fall back to the structured tools (`pptx_get_shape`, `pptx_get_slide_structure`, etc.)"
+    )]
     pub fn pptx_to_markdown(Parameters(p): Parameters<PptxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -896,7 +1002,9 @@ impl PptxTools {
         }
     }
 
-    #[tool(description = "Return speaker-notes text for one or all slides. Each entry: { slideIndex, slideNumber, notes }. Slides without a notesSlide part are omitted")]
+    #[tool(
+        description = "Return speaker-notes text for one or all slides. Each entry: { slideIndex, slideNumber, notes }. Slides without a notesSlide part are omitted"
+    )]
     pub fn pptx_get_notes(Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -910,13 +1018,20 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let mut notes: Vec<Value> = Vec::new();
         for (slide_idx, slide) in slides.iter().enumerate() {
             if let Some(filter) = p.slide_index {
-                if slide_idx != filter { continue }
+                if slide_idx != filter {
+                    continue;
+                }
             }
-            let Some(text) = slide["notes"].as_str() else { continue };
+            let Some(text) = slide["notes"].as_str() else {
+                continue;
+            };
             notes.push(serde_json::json!({
                 "slideIndex": slide_idx,
                 "slideNumber": slide["slideNumber"],
@@ -926,7 +1041,9 @@ impl PptxTools {
         serde_json::json!({ "notes": notes }).to_string()
     }
 
-    #[tool(description = "Return legacy (non-threaded) slide comments. Each entry: { slideIndex, slideNumber, author?, date?, text }. Office365 modern threaded comments are not yet supported")]
+    #[tool(
+        description = "Return legacy (non-threaded) slide comments. Each entry: { slideIndex, slideNumber, author?, date?, text }. Office365 modern threaded comments are not yet supported"
+    )]
     pub fn pptx_get_comments(Parameters(p): Parameters<PptxOptSlideParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -940,13 +1057,20 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let mut comments: Vec<Value> = Vec::new();
         for (slide_idx, slide) in slides.iter().enumerate() {
             if let Some(filter) = p.slide_index {
-                if slide_idx != filter { continue }
+                if slide_idx != filter {
+                    continue;
+                }
             }
-            let Some(arr) = slide["comments"].as_array() else { continue };
+            let Some(arr) = slide["comments"].as_array() else {
+                continue;
+            };
             for c in arr {
                 comments.push(serde_json::json!({
                     "slideIndex": slide_idx,
@@ -960,7 +1084,9 @@ impl PptxTools {
         serde_json::json!({ "comments": comments }).to_string()
     }
 
-    #[tool(description = "Infer geometric relations between shapes on a slide: connector hookups (with arrow direction when stroke ends are arrows), containment, overlap, axis-aligned alignment groups, and equal distribution. Detection is purely spatial — `confidence: \"inferred\"` flags this — until the parser exposes ECMA-376 §20.5.2.2 stCxn/endCxn references")]
+    #[tool(
+        description = "Infer geometric relations between shapes on a slide: connector hookups (with arrow direction when stroke ends are arrows), containment, overlap, axis-aligned alignment groups, and equal distribution. Detection is purely spatial — `confidence: \"inferred\"` flags this — until the parser exposes ECMA-376 §20.5.2.2 stCxn/endCxn references"
+    )]
     pub fn pptx_get_shape_relations(Parameters(p): Parameters<PptxRelationsParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -974,17 +1100,24 @@ impl PptxTools {
             Ok(v) => v,
             Err(e) => return format!("Error: {}", e),
         };
-        let slides = pres["slides"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let slides = pres["slides"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
         let slide = match slides.get(p.slide_index) {
             Some(s) => s,
             None => {
                 return format!(
                     "Error: slide index {} out of range (total: {})",
-                    p.slide_index, slides.len()
+                    p.slide_index,
+                    slides.len()
                 )
             }
         };
-        let elements = slide["elements"].as_array().map(|s| s.as_slice()).unwrap_or(&[]);
+        let elements = slide["elements"]
+            .as_array()
+            .map(|s| s.as_slice())
+            .unwrap_or(&[]);
 
         let tol: i64 = p.tolerance_emu.unwrap_or(50_000).max(0);
 
@@ -993,7 +1126,9 @@ impl PptxTools {
         let mut shape_summaries: Vec<Value> = Vec::with_capacity(elements.len());
         let mut bboxes: Vec<(usize, Bbox, bool)> = Vec::with_capacity(elements.len());
         for (idx, el) in elements.iter().enumerate() {
-            let Some(bbox) = Bbox::from_element(el) else { continue };
+            let Some(bbox) = Bbox::from_element(el) else {
+                continue;
+            };
             let geometry = el["geometry"].as_str().unwrap_or("");
             let is_conn = el["type"].as_str() == Some("shape") && is_connector(geometry);
             // Pull a one-line text snippet for reader convenience.
@@ -1024,11 +1159,19 @@ impl PptxTools {
 
         // ── Connections (connector → resolved endpoints) ──────────────────
         for (idx, bbox, is_conn) in &bboxes {
-            if !*is_conn { continue }
+            if !*is_conn {
+                continue;
+            }
             let element = &elements[*idx];
             let stroke = &element["stroke"];
-            let head_arrow = stroke.get("headEnd").map(arrow_is_directional).unwrap_or(false);
-            let tail_arrow = stroke.get("tailEnd").map(arrow_is_directional).unwrap_or(false);
+            let head_arrow = stroke
+                .get("headEnd")
+                .map(arrow_is_directional)
+                .unwrap_or(false);
+            let tail_arrow = stroke
+                .get("tailEnd")
+                .map(arrow_is_directional)
+                .unwrap_or(false);
 
             let endpoints = line_endpoints(bbox);
             let head_target = nearest_shape_to_point(endpoints[0].1, &bboxes, *idx, tol);
@@ -1073,11 +1216,17 @@ impl PptxTools {
         // ── Contains (real shapes only — connectors don't "contain") ──────
         for i in 0..bboxes.len() {
             let (idx_outer, outer_bb, outer_conn) = bboxes[i];
-            if outer_conn { continue }
+            if outer_conn {
+                continue;
+            }
             for j in 0..bboxes.len() {
-                if i == j { continue }
+                if i == j {
+                    continue;
+                }
                 let (idx_inner, inner_bb, inner_conn) = bboxes[j];
-                if inner_conn { continue }
+                if inner_conn {
+                    continue;
+                }
                 if outer_bb.contains(&inner_bb, tol) {
                     relations.push(serde_json::json!({
                         "kind": "contains",
@@ -1091,11 +1240,17 @@ impl PptxTools {
         // ── Overlap (excluding contains) ──────────────────────────────────
         for i in 0..bboxes.len() {
             let (idx_a, a_bb, a_conn) = bboxes[i];
-            if a_conn { continue }
+            if a_conn {
+                continue;
+            }
             for j in (i + 1)..bboxes.len() {
                 let (idx_b, b_bb, b_conn) = bboxes[j];
-                if b_conn { continue }
-                if a_bb.contains(&b_bb, tol) || b_bb.contains(&a_bb, tol) { continue }
+                if b_conn {
+                    continue;
+                }
+                if a_bb.contains(&b_bb, tol) || b_bb.contains(&a_bb, tol) {
+                    continue;
+                }
                 let iou = a_bb.iou(&b_bb);
                 if iou > 0.0 {
                     relations.push(serde_json::json!({
@@ -1210,8 +1365,14 @@ mod sample_tests {
         }
         let out = PptxTools::pptx_get_presentation_meta(pp(&path));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
-        assert!(v["slideWidth"].as_i64().unwrap_or(0) > 0, "slideWidth should be > 0");
-        assert!(v["slideHeight"].as_i64().unwrap_or(0) > 0, "slideHeight should be > 0");
+        assert!(
+            v["slideWidth"].as_i64().unwrap_or(0) > 0,
+            "slideWidth should be > 0"
+        );
+        assert!(
+            v["slideHeight"].as_i64().unwrap_or(0) > 0,
+            "slideHeight should be > 0"
+        );
     }
 
     #[test]
@@ -1226,8 +1387,14 @@ mod sample_tests {
             tolerance_emu: None,
         }));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
-        assert!(v["shapes"].as_array().is_some(), "missing 'shapes' array: {out}");
-        assert!(v["relations"].as_array().is_some(), "missing 'relations' array: {out}");
+        assert!(
+            v["shapes"].as_array().is_some(),
+            "missing 'shapes' array: {out}"
+        );
+        assert!(
+            v["relations"].as_array().is_some(),
+            "missing 'relations' array: {out}"
+        );
         assert_eq!(v["slideIndex"].as_u64(), Some(0));
     }
 
@@ -1259,7 +1426,10 @@ mod sample_tests {
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
         let pics = v["pictures"].as_array().expect("missing 'pictures'");
         for p in pics {
-            assert!(p.get("dataUrl").is_none(), "dataUrl should be omitted by default");
+            assert!(
+                p.get("dataUrl").is_none(),
+                "dataUrl should be omitted by default"
+            );
         }
     }
 
@@ -1358,11 +1528,18 @@ mod sample_tests {
         let out = PptxTools::pptx_to_markdown(pp(&path));
         assert!(!out.starts_with("Error:"), "errored: {out}");
         // Slide titles should appear as level-1 headings.
-        assert!(out.contains("# STATE OF THE FOREST"), "missing slide-1 heading: {}", &out[..200.min(out.len())]);
+        assert!(
+            out.contains("# STATE OF THE FOREST"),
+            "missing slide-1 heading: {}",
+            &out[..200.min(out.len())]
+        );
         // Slide separator between slides.
         assert!(out.contains("\n---\n"), "missing slide separator");
         // Bold/italic markers from rich-text runs should be preserved.
-        assert!(out.contains("**3.4%**") || out.contains("**+3.4%**"), "missing bold marker");
+        assert!(
+            out.contains("**3.4%**") || out.contains("**+3.4%**"),
+            "missing bold marker"
+        );
         // Tables → pipe rows.
         assert!(out.contains("| Taxon |"), "biodiversity table missing");
         // Chart → markdown summary.
@@ -1394,7 +1571,10 @@ mod sample_tests {
             slide_index: None,
         }));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
-        assert!(v["comments"].as_array().is_some(), "missing 'comments' array");
+        assert!(
+            v["comments"].as_array().is_some(),
+            "missing 'comments' array"
+        );
     }
 
     #[test]
@@ -1408,6 +1588,9 @@ mod sample_tests {
             slide_index: 0,
             shape_index: 999_999,
         }));
-        assert!(out.starts_with("Error:"), "expected out-of-range error, got: {out}");
+        assert!(
+            out.starts_with("Error:"),
+            "expected out-of-range error, got: {out}"
+        );
     }
 }

--- a/packages/mcp-server/src/tools/xlsx.rs
+++ b/packages/mcp-server/src/tools/xlsx.rs
@@ -124,7 +124,10 @@ fn col_to_letter(mut col: u32) -> String {
 
 /// Resolves which sheets to operate on. When `identifier` is `Some`, returns a
 /// single-element vec; when `None`, returns every sheet in workbook order.
-fn target_sheets(workbook_json: &str, identifier: Option<&str>) -> Result<Vec<(u32, String)>, String> {
+fn target_sheets(
+    workbook_json: &str,
+    identifier: Option<&str>,
+) -> Result<Vec<(u32, String)>, String> {
     if let Some(id) = identifier {
         return resolve_sheet(workbook_json, id).map(|r| vec![r]);
     }
@@ -183,7 +186,13 @@ fn cell_display(cell: &Value) -> String {
         // serde from the variant's inner field name).
         "bool" => val["bool"]
             .as_bool()
-            .map(|b| if b { "TRUE".to_string() } else { "FALSE".to_string() })
+            .map(|b| {
+                if b {
+                    "TRUE".to_string()
+                } else {
+                    "FALSE".to_string()
+                }
+            })
             .unwrap_or_default(),
         "error" => val["error"].as_str().unwrap_or("#ERR").to_string(),
         _ => String::new(),
@@ -195,7 +204,9 @@ fn cell_display(cell: &Value) -> String {
 pub struct XlsxTools;
 
 impl XlsxTools {
-    #[tool(description = "Convert an XLSX file to GitHub-flavoured markdown — one `## SheetName` per sheet, followed by a pipe table of the cells' cached display values. Merged-cell continuation cells render empty. Formula cells show the cached result, not the formula text (use `xlsx_get_formulas` if you need the formulas). Designed for agents that need to *read* spreadsheet content efficiently. Lossy by design: drops styling, conditional formatting, charts, sparklines, drawings. For precise structure use the structured tools (`xlsx_get_cell_range`, `xlsx_get_sheet_layout`, etc.)")]
+    #[tool(
+        description = "Convert an XLSX file to GitHub-flavoured markdown — one `## SheetName` per sheet, followed by a pipe table of the cells' cached display values. Merged-cell continuation cells render empty. Formula cells show the cached result, not the formula text (use `xlsx_get_formulas` if you need the formulas). Designed for agents that need to *read* spreadsheet content efficiently. Lossy by design: drops styling, conditional formatting, charts, sparklines, drawings. For precise structure use the structured tools (`xlsx_get_cell_range`, `xlsx_get_sheet_layout`, etc.)"
+    )]
     pub fn xlsx_to_markdown(Parameters(p): Parameters<XlsxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -207,7 +218,9 @@ impl XlsxTools {
         }
     }
 
-    #[tool(description = "Parse an XLSX file and return workbook overview including sheet names and IDs")]
+    #[tool(
+        description = "Parse an XLSX file and return workbook overview including sheet names and IDs"
+    )]
     pub fn xlsx_parse(Parameters(p): Parameters<XlsxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -235,12 +248,7 @@ impl XlsxTools {
         };
         let names: Vec<&str> = wb["sheets"]
             .as_array()
-            .map(|sheets| {
-                sheets
-                    .iter()
-                    .filter_map(|s| s["name"].as_str())
-                    .collect()
-            })
+            .map(|sheets| sheets.iter().filter_map(|s| s["name"].as_str()).collect())
             .unwrap_or_default();
         serde_json::to_string(&names).unwrap_or_else(|e| format!("Error: {}", e))
     }
@@ -296,7 +304,9 @@ impl XlsxTools {
         .to_string()
     }
 
-    #[tool(description = "Return cell values and formulas for a given range (e.g. \"A1:C10\") in a worksheet")]
+    #[tool(
+        description = "Return cell values and formulas for a given range (e.g. \"A1:C10\") in a worksheet"
+    )]
     pub fn xlsx_get_cell_range(Parameters(p): Parameters<XlsxCellRangeParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -424,7 +434,9 @@ impl XlsxTools {
         .to_string()
     }
 
-    #[tool(description = "Search for a substring in cell values and formulas across one or all sheets of an XLSX file")]
+    #[tool(
+        description = "Search for a substring in cell values and formulas across one or all sheets of an XLSX file"
+    )]
     pub fn xlsx_search_cells(Parameters(p): Parameters<XlsxSearchParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -505,7 +517,9 @@ impl XlsxTools {
         .to_string()
     }
 
-    #[tool(description = "List charts on a worksheet (or all sheets if `sheet` is omitted). Returns a summary per chart: anchor cell range, chart type, title, axes, legend, and a series outline (without numeric values)")]
+    #[tool(
+        description = "List charts on a worksheet (or all sheets if `sheet` is omitted). Returns a summary per chart: anchor cell range, chart type, title, axes, legend, and a series outline (without numeric values)"
+    )]
     pub fn xlsx_get_charts(Parameters(p): Parameters<XlsxOptSheetParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -530,7 +544,9 @@ impl XlsxTools {
                 Ok(v) => v,
                 Err(e) => return format!("Error: {}", e),
             };
-            let Some(charts) = ws["charts"].as_array() else { continue };
+            let Some(charts) = ws["charts"].as_array() else {
+                continue;
+            };
             for (chart_idx, anchor) in charts.iter().enumerate() {
                 let chart = &anchor["chart"];
                 let series_outline: Vec<Value> = chart["series"]
@@ -538,7 +554,8 @@ impl XlsxTools {
                     .map(|arr| {
                         arr.iter()
                             .map(|s| {
-                                let value_count = s["values"].as_array().map(|a| a.len()).unwrap_or(0);
+                                let value_count =
+                                    s["values"].as_array().map(|a| a.len()).unwrap_or(0);
                                 serde_json::json!({
                                     "name": s["name"],
                                     "type": s["seriesType"],
@@ -587,7 +604,9 @@ impl XlsxTools {
         serde_json::json!({ "charts": all_charts }).to_string()
     }
 
-    #[tool(description = "Return one chart's full series data (categories and per-point values) for drill-down. `chartIndex` matches the index from `xlsx_get_charts` for the same sheet")]
+    #[tool(
+        description = "Return one chart's full series data (categories and per-point values) for drill-down. `chartIndex` matches the index from `xlsx_get_charts` for the same sheet"
+    )]
     pub fn xlsx_get_chart_series(Parameters(p): Parameters<XlsxChartIndexParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -653,7 +672,9 @@ impl XlsxTools {
         .to_string()
     }
 
-    #[tool(description = "Return all defined names (named ranges) visible in the workbook. Includes workbook-global names plus each sheet's local names; duplicates across sheets are merged")]
+    #[tool(
+        description = "Return all defined names (named ranges) visible in the workbook. Includes workbook-global names plus each sheet's local names; duplicates across sheets are merged"
+    )]
     pub fn xlsx_get_named_ranges(Parameters(p): Parameters<XlsxPathParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -679,7 +700,9 @@ impl XlsxTools {
                 Ok(v) => v,
                 Err(e) => return format!("Error: {}", e),
             };
-            let Some(names) = ws["definedNames"].as_array() else { continue };
+            let Some(names) = ws["definedNames"].as_array() else {
+                continue;
+            };
             for dn in names {
                 let n = dn["name"].as_str().unwrap_or("").to_string();
                 let f = dn["formula"].as_str().unwrap_or("").to_string();
@@ -701,7 +724,9 @@ impl XlsxTools {
         serde_json::json!({ "definedNames": defined_names }).to_string()
     }
 
-    #[tool(description = "List Excel Tables (Ctrl+T tables, ECMA-376 §18.5) on a sheet or across all sheets. Returns each table's range, style, header/totals row counts")]
+    #[tool(
+        description = "List Excel Tables (Ctrl+T tables, ECMA-376 §18.5) on a sheet or across all sheets. Returns each table's range, style, header/totals row counts"
+    )]
     pub fn xlsx_get_tables(Parameters(p): Parameters<XlsxOptSheetParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -726,7 +751,9 @@ impl XlsxTools {
                 Ok(v) => v,
                 Err(e) => return format!("Error: {}", e),
             };
-            let Some(arr) = ws["tables"].as_array() else { continue };
+            let Some(arr) = ws["tables"].as_array() else {
+                continue;
+            };
             for t in arr {
                 tables.push(serde_json::json!({
                     "sheet": name,
@@ -742,7 +769,9 @@ impl XlsxTools {
         serde_json::json!({ "tables": tables }).to_string()
     }
 
-    #[tool(description = "Return all merged cell ranges on a worksheet as A1 strings (e.g. \"A1:B2\")")]
+    #[tool(
+        description = "Return all merged cell ranges on a worksheet as A1 strings (e.g. \"A1:B2\")"
+    )]
     pub fn xlsx_get_merged_cells(Parameters(p): Parameters<XlsxSheetParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -771,7 +800,9 @@ impl XlsxTools {
         serde_json::json!({ "sheet": name, "merges": merges }).to_string()
     }
 
-    #[tool(description = "Return conditional formatting rules on a worksheet. Each entry has the affected ranges (sqref) and the rule body (CellIs, Expression, ColorScale, DataBar, Top10, AboveAverage, IconSet, Other)")]
+    #[tool(
+        description = "Return conditional formatting rules on a worksheet. Each entry has the affected ranges (sqref) and the rule body (CellIs, Expression, ColorScale, DataBar, Top10, AboveAverage, IconSet, Other)"
+    )]
     pub fn xlsx_get_conditional_formats(Parameters(p): Parameters<XlsxSheetParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -815,7 +846,9 @@ impl XlsxTools {
         serde_json::json!({ "sheet": name, "formats": formats }).to_string()
     }
 
-    #[tool(description = "Return all `<dataValidation>` rules on a worksheet: affected ranges, type, operator, formulas, and the optional prompt / error messages")]
+    #[tool(
+        description = "Return all `<dataValidation>` rules on a worksheet: affected ranges, type, operator, formulas, and the optional prompt / error messages"
+    )]
     pub fn xlsx_get_data_validations(Parameters(p): Parameters<XlsxSheetParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -844,7 +877,9 @@ impl XlsxTools {
         .to_string()
     }
 
-    #[tool(description = "Return all comments on a worksheet (or all sheets if `sheet` is omitted) with full text and resolved author. Each entry: { sheet, cellRef, author?, text }")]
+    #[tool(
+        description = "Return all comments on a worksheet (or all sheets if `sheet` is omitted) with full text and resolved author. Each entry: { sheet, cellRef, author?, text }"
+    )]
     pub fn xlsx_get_comments(Parameters(p): Parameters<XlsxOptSheetParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -869,7 +904,9 @@ impl XlsxTools {
                 Ok(v) => v,
                 Err(e) => return format!("Error: {}", e),
             };
-            let Some(comments) = ws["comments"].as_array() else { continue };
+            let Some(comments) = ws["comments"].as_array() else {
+                continue;
+            };
             for c in comments {
                 all_comments.push(serde_json::json!({
                     "sheet": name,
@@ -882,7 +919,9 @@ impl XlsxTools {
         serde_json::json!({ "comments": all_comments }).to_string()
     }
 
-    #[tool(description = "Return per-sheet layout: explicit column widths, row heights, freeze panes, gridline visibility, default sizes, and tab color")]
+    #[tool(
+        description = "Return per-sheet layout: explicit column widths, row heights, freeze panes, gridline visibility, default sizes, and tab color"
+    )]
     pub fn xlsx_get_sheet_layout(Parameters(p): Parameters<XlsxSheetParam>) -> String {
         let data = match read_file(&p.path) {
             Ok(d) => d,
@@ -915,7 +954,9 @@ impl XlsxTools {
                 .collect();
             entries.sort_by_key(|(k, _)| *k);
             for (col, width) in entries {
-                cols.push(serde_json::json!({ "col": col, "width": width, "letter": col_to_letter(col) }));
+                cols.push(
+                    serde_json::json!({ "col": col, "width": width, "letter": col_to_letter(col) }),
+                );
             }
         }
         let mut rows: Vec<Value> = Vec::new();
@@ -968,7 +1009,11 @@ mod sample_tests {
         }
         let out = XlsxTools::xlsx_to_markdown(pp(&path));
         assert!(!out.starts_with("Error:"), "errored: {out}");
-        assert!(out.contains("## "), "missing sheet heading: {}", &out[..200.min(out.len())]);
+        assert!(
+            out.contains("## "),
+            "missing sheet heading: {}",
+            &out[..200.min(out.len())]
+        );
         assert!(out.contains("|"), "no pipe table emitted");
     }
 
@@ -980,7 +1025,10 @@ mod sample_tests {
         }
         let out = XlsxTools::xlsx_parse(pp(&path));
         let v: Value = serde_json::from_str(&out).expect("xlsx_parse must return JSON");
-        assert!(v["sheets"].as_array().is_some(), "missing 'sheets' array: {out}");
+        assert!(
+            v["sheets"].as_array().is_some(),
+            "missing 'sheets' array: {out}"
+        );
     }
 
     #[test]
@@ -992,7 +1040,10 @@ mod sample_tests {
         let out = XlsxTools::xlsx_get_sheet_names(pp(&path));
         let v: Value = serde_json::from_str(&out).expect("must return JSON array");
         let arr = v.as_array().expect("must be JSON array");
-        assert!(!arr.is_empty(), "sample-1.xlsx should have at least one sheet");
+        assert!(
+            !arr.is_empty(),
+            "sample-1.xlsx should have at least one sheet"
+        );
     }
 
     #[test]
@@ -1006,7 +1057,10 @@ mod sample_tests {
             sheet: None,
         }));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
-        assert!(v["charts"].as_array().is_some(), "missing 'charts' array: {out}");
+        assert!(
+            v["charts"].as_array().is_some(),
+            "missing 'charts' array: {out}"
+        );
     }
 
     #[test]
@@ -1017,7 +1071,10 @@ mod sample_tests {
         }
         let out = XlsxTools::xlsx_get_named_ranges(pp(&path));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
-        assert!(v["definedNames"].as_array().is_some(), "missing 'definedNames'");
+        assert!(
+            v["definedNames"].as_array().is_some(),
+            "missing 'definedNames'"
+        );
     }
 
     #[test]
@@ -1061,7 +1118,10 @@ mod sample_tests {
             sheet: "0".into(),
         }));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
-        assert!(v["validations"].as_array().is_some(), "missing 'validations'");
+        assert!(
+            v["validations"].as_array().is_some(),
+            "missing 'validations'"
+        );
     }
 
     #[test]
@@ -1070,10 +1130,7 @@ mod sample_tests {
         if !std::path::Path::new(&path).exists() {
             return;
         }
-        let out = XlsxTools::xlsx_get_comments(Parameters(XlsxOptSheetParam {
-            path,
-            sheet: None,
-        }));
+        let out = XlsxTools::xlsx_get_comments(Parameters(XlsxOptSheetParam { path, sheet: None }));
         let v: Value = serde_json::from_str(&out).expect("must return JSON");
         assert!(v["comments"].as_array().is_some(), "missing 'comments'");
     }

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -33,7 +33,9 @@ use roxmltree::Node;
 
 /// Find a direct child of `parent` whose local name is `name`.
 fn child<'a, 'i>(parent: Node<'a, 'i>, name: &str) -> Option<Node<'a, 'i>> {
-    parent.children().find(|n| n.is_element() && n.tag_name().name() == name)
+    parent
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == name)
 }
 
 /// Theme-aware color resolution for chart text-color helpers.
@@ -66,11 +68,14 @@ pub fn extract_legend(root: Node) -> (bool, Option<String>) {
     // The legend can sit anywhere inside `<c:chart>` but in practice it's a
     // direct child of `<c:chart>`. Use descendants to be tolerant of either
     // structure — there's only one `<c:legend>` element per chart.
-    let legend = root.descendants()
+    let legend = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "legend");
     let show = legend.is_some();
     let pos = legend.and_then(|ln| {
-        child(ln, "legendPos").and_then(|p| p.attribute("val")).map(|s| s.to_string())
+        child(ln, "legendPos")
+            .and_then(|p| p.attribute("val"))
+            .map(|s| s.to_string())
     });
     (show, pos)
 }
@@ -79,10 +84,12 @@ pub fn extract_legend(root: Node) -> (bool, Option<String>) {
 /// §21.2.2.25). Returns `(gap%, overlap%)`. Defaults to (None, None) when
 /// the file relies on Office's defaults (gap 150, overlap 0).
 pub fn extract_bar_gap_overlap(root: Node) -> (Option<i32>, Option<i32>) {
-    let gap = root.descendants()
+    let gap = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "gapWidth")
         .and_then(|n| n.attribute("val").and_then(|v| v.parse::<i32>().ok()));
-    let ov = root.descendants()
+    let ov = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "overlap")
         .and_then(|n| n.attribute("val").and_then(|v| v.parse::<i32>().ok()));
     (gap, ov)
@@ -94,7 +101,9 @@ pub fn extract_data_label_position(root: Node) -> Option<String> {
     root.descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
         .find_map(|dlbls| {
-            child(dlbls, "dLblPos").and_then(|n| n.attribute("val")).map(|s| s.to_string())
+            child(dlbls, "dLblPos")
+                .and_then(|n| n.attribute("val"))
+                .map(|s| s.to_string())
         })
 }
 
@@ -160,9 +169,13 @@ pub fn extract_axis_tick_mark(axis_node: Node, name: &str) -> Option<String> {
 pub fn extract_axis_tick_label_size(axis_node: Node) -> Option<i32> {
     let txpr = child(axis_node, "txPr")?;
     txpr.descendants().find_map(|n| {
-        if !n.is_element() { return None; }
+        if !n.is_element() {
+            return None;
+        }
         let tag = n.tag_name().name();
-        if tag != "defRPr" && tag != "rPr" { return None; }
+        if tag != "defRPr" && tag != "rPr" {
+            return None;
+        }
         n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
     })
 }
@@ -174,12 +187,18 @@ pub fn extract_data_label_font_size(root: Node) -> Option<i32> {
     root.descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
         .find_map(|dl| {
-            child(dl, "txPr").and_then(|tx| tx.descendants().find_map(|n| {
-                if !n.is_element() { return None; }
-                let tag = n.tag_name().name();
-                if tag != "defRPr" && tag != "rPr" { return None; }
-                n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
-            }))
+            child(dl, "txPr").and_then(|tx| {
+                tx.descendants().find_map(|n| {
+                    if !n.is_element() {
+                        return None;
+                    }
+                    let tag = n.tag_name().name();
+                    if tag != "defRPr" && tag != "rPr" {
+                        return None;
+                    }
+                    n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
+                })
+            })
         })
 }
 
@@ -197,10 +216,17 @@ pub fn extract_data_label_font_size(root: Node) -> Option<i32> {
 /// sibling `<c:dLbls><c:spPr><a:solidFill>` (the label *background*
 /// fill, distinct from the text color) can't shadow the answer.
 pub fn extract_data_label_font_color(root: Node, resolver: &dyn ColorResolver) -> Option<String> {
-    for dlbls in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "dLbls") {
-        let Some(txpr) = child(dlbls, "txPr") else { continue; };
+    for dlbls in root
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+    {
+        let Some(txpr) = child(dlbls, "txPr") else {
+            continue;
+        };
         for desc in txpr.descendants().filter(|n| n.is_element()) {
-            if desc.tag_name().name() != "solidFill" { continue; }
+            if desc.tag_name().name() != "solidFill" {
+                continue;
+            }
             if let Some(c) = resolver.resolve_solid_fill(desc) {
                 return Some(c);
             }
@@ -215,10 +241,15 @@ pub fn extract_data_label_font_color(root: Node, resolver: &dyn ColorResolver) -
 /// that ECMA-376 §21.2.2.* / §21.1.2.2.* uses to color the axis tick labels
 /// (e.g. PowerPoint's "category labels in gray"). Scoped to `<c:txPr>` so the
 /// sibling `<c:spPr>` axis-line fill can't shadow the answer.
-pub fn extract_axis_tick_label_color(axis_node: Node, resolver: &dyn ColorResolver) -> Option<String> {
+pub fn extract_axis_tick_label_color(
+    axis_node: Node,
+    resolver: &dyn ColorResolver,
+) -> Option<String> {
     let txpr = child(axis_node, "txPr")?;
     for desc in txpr.descendants().filter(|n| n.is_element()) {
-        if desc.tag_name().name() != "solidFill" { continue; }
+        if desc.tag_name().name() != "solidFill" {
+            continue;
+        }
         if let Some(c) = resolver.resolve_solid_fill(desc) {
             return Some(c);
         }
@@ -240,8 +271,12 @@ pub fn extract_axis_line_style(
     axis_node: Node,
     resolver: &dyn ColorResolver,
 ) -> (Option<String>, Option<u32>, bool) {
-    let Some(sp_pr) = child(axis_node, "spPr") else { return (None, None, false); };
-    let Some(ln) = child(sp_pr, "ln") else { return (None, None, false); };
+    let Some(sp_pr) = child(axis_node, "spPr") else {
+        return (None, None, false);
+    };
+    let Some(ln) = child(sp_pr, "ln") else {
+        return (None, None, false);
+    };
     let width = ln.attribute("w").and_then(|v| v.parse::<u32>().ok());
     let no_fill = child(ln, "noFill").is_some();
     let color = child(ln, "solidFill").and_then(|sf| resolver.resolve_solid_fill(sf));
@@ -259,13 +294,26 @@ pub fn extract_axis_line_style(
 pub fn extract_chartex_axis_hidden(root: Node) -> (bool, bool) {
     let mut cat_hidden = false;
     let mut val_hidden = false;
-    for ax in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "axis") {
+    for ax in root
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "axis")
+    {
         let hidden = ax.attribute("hidden").map(|v| v == "1").unwrap_or(false);
-        if !hidden { continue; }
-        let is_val = ax.children().any(|c| c.is_element() && c.tag_name().name() == "valScaling");
-        let is_cat = ax.children().any(|c| c.is_element() && c.tag_name().name() == "catScaling");
-        if is_val { val_hidden = true; }
-        if is_cat { cat_hidden = true; }
+        if !hidden {
+            continue;
+        }
+        let is_val = ax
+            .children()
+            .any(|c| c.is_element() && c.tag_name().name() == "valScaling");
+        let is_cat = ax
+            .children()
+            .any(|c| c.is_element() && c.tag_name().name() == "catScaling");
+        if is_val {
+            val_hidden = true;
+        }
+        if is_cat {
+            cat_hidden = true;
+        }
     }
     (cat_hidden, val_hidden)
 }
@@ -301,7 +349,8 @@ mod tests {
 
     #[test]
     fn bar_gap_overlap_default_to_none() {
-        let xml = r#"<c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
+        let xml =
+            r#"<c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
         let d = root_of(xml);
         assert_eq!(extract_bar_gap_overlap(d.root_element()), (None, None));
     }
@@ -313,7 +362,10 @@ mod tests {
             <c:overlap val="100"/>
         </c:barChart>"#;
         let d = root_of(xml);
-        assert_eq!(extract_bar_gap_overlap(d.root_element()), (Some(50), Some(100)));
+        assert_eq!(
+            extract_bar_gap_overlap(d.root_element()),
+            (Some(50), Some(100))
+        );
     }
 
     #[test]
@@ -322,15 +374,26 @@ mod tests {
             <c:plotArea><c:dLbls><c:dLblPos val="ctr"/></c:dLbls></c:plotArea>
         </c:chart>"#;
         let d = root_of(xml);
-        assert_eq!(extract_data_label_position(d.root_element()).as_deref(), Some("ctr"));
+        assert_eq!(
+            extract_data_label_position(d.root_element()).as_deref(),
+            Some("ctr")
+        );
     }
 
     #[test]
     fn axis_delete_truthy_variants() {
-        for (val, expect) in [("1", true), ("0", false), ("true", true), ("false", false), ("True", true)] {
-            let xml = format!(r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        for (val, expect) in [
+            ("1", true),
+            ("0", false),
+            ("true", true),
+            ("false", false),
+            ("True", true),
+        ] {
+            let xml = format!(
+                r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:delete val="{val}"/>
-            </c:valAx>"#);
+            </c:valAx>"#
+            );
             let d = root_of(&xml);
             assert_eq!(axis_is_deleted(d.root_element()), expect, "val={val}");
         }
@@ -349,7 +412,10 @@ mod tests {
             <c:scaling><c:max val="2500"/><c:min val="0"/></c:scaling>
         </c:valAx>"#;
         let d = root_of(xml);
-        assert_eq!(extract_axis_min_max(d.root_element()), (Some(0.0), Some(2500.0)));
+        assert_eq!(
+            extract_axis_min_max(d.root_element()),
+            (Some(0.0), Some(2500.0))
+        );
     }
 
     #[test]
@@ -367,7 +433,10 @@ mod tests {
             <c:numFmt formatCode="0.0%"/>
         </c:valAx>"#;
         let d = root_of(xml);
-        assert_eq!(extract_axis_format_code(d.root_element()).as_deref(), Some("0.0%"));
+        assert_eq!(
+            extract_axis_format_code(d.root_element()).as_deref(),
+            Some("0.0%")
+        );
     }
 
     /// Test resolver: returns the schemeClr@val verbatim, or the srgbClr@val
@@ -413,7 +482,10 @@ mod tests {
         </c:chart>"#;
         let d = root_of(xml);
         let got = extract_data_label_font_color(d.root_element(), &StubResolver);
-        assert!(got.is_none(), "spPr fill must not leak into the font color: got {got:?}");
+        assert!(
+            got.is_none(),
+            "spPr fill must not leak into the font color: got {got:?}"
+        );
     }
 
     #[test]
@@ -484,7 +556,10 @@ mod tests {
     fn axis_line_style_absent() {
         let xml = r#"<c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
         let d = root_of(xml);
-        assert_eq!(extract_axis_line_style(d.root_element(), &StubResolver), (None, None, false));
+        assert_eq!(
+            extract_axis_line_style(d.root_element(), &StubResolver),
+            (None, None, false)
+        );
     }
 
     #[test]

--- a/packages/ooxml-common/src/color.rs
+++ b/packages/ooxml-common/src/color.rs
@@ -61,43 +61,61 @@ pub fn apply_color_transforms(hex: &str, node: Node, tint_mode: TintMode) -> Str
                 let val = attr_pct(&t, "val", 100_000.0);
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb(h, (l * val).min(1.0), s);
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
             "lumOff" => {
                 let val = attr_pct(&t, "val", 0.0);
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb(h, (l + val).clamp(0.0, 1.0), s);
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
             "satMod" => {
                 let val = attr_pct(&t, "val", 100_000.0);
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb(h, l, (s * val).clamp(0.0, 1.0));
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
             "satOff" => {
                 let val = attr_pct(&t, "val", 0.0);
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb(h, l, (s + val).clamp(0.0, 1.0));
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
             "hueMod" => {
                 let val = attr_pct(&t, "val", 100_000.0);
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb((h * val).rem_euclid(1.0), l, s);
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
             "hueOff" => {
                 // hueOff is in 60000ths of a degree per ECMA-376 §20.1.2.3.16.
-                let val_deg = t.attribute("val").and_then(|v| v.parse::<f64>().ok()).unwrap_or(0.0) / 60_000.0;
+                let val_deg = t
+                    .attribute("val")
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .unwrap_or(0.0)
+                    / 60_000.0;
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb((h + val_deg / 360.0).rem_euclid(1.0), l, s);
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
             "shade" => {
                 // ECMA-376 §20.1.2.3.31: result = val·input + (1-val)·black.
                 let val = attr_pct(&t, "val", 100_000.0);
-                rf *= val; gf *= val; bf *= val;
+                rf *= val;
+                gf *= val;
+                bf *= val;
             }
             "tint" => {
                 let val = attr_pct(&t, "val", 0.0);
@@ -154,12 +172,20 @@ pub fn apply_color_transforms(hex: &str, node: Node, tint_mode: TintMode) -> Str
 
 /// sRGB → linear light. IEC 61966-2-1 transfer function.
 pub fn srgb_to_linear(c: f64) -> f64 {
-    if c <= 0.04045 { c / 12.92 } else { ((c + 0.055) / 1.055).powf(2.4) }
+    if c <= 0.04045 {
+        c / 12.92
+    } else {
+        ((c + 0.055) / 1.055).powf(2.4)
+    }
 }
 
 /// Linear light → sRGB.
 pub fn linear_to_srgb(c: f64) -> f64 {
-    if c <= 0.0031308 { 12.92 * c } else { 1.055 * c.powf(1.0 / 2.4) - 0.055 }
+    if c <= 0.0031308 {
+        12.92 * c
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    }
 }
 
 /// RGB → HLS conversion (lightness in the middle, matches Python's colorsys).
@@ -172,7 +198,11 @@ pub fn rgb_to_hls(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
     if d < 1e-10 {
         return (0.0, l, 0.0);
     }
-    let s = if l > 0.5 { d / (2.0 - max - min) } else { d / (max + min) };
+    let s = if l > 0.5 {
+        d / (2.0 - max - min)
+    } else {
+        d / (max + min)
+    };
     let h = if (max - r).abs() < 1e-10 {
         (g - b) / d + if g < b { 6.0 } else { 0.0 }
     } else if (max - g).abs() < 1e-10 {
@@ -190,14 +220,28 @@ pub fn hls_to_rgb(h: f64, l: f64, s: f64) -> (f64, f64, f64) {
         return (l, l, l);
     }
     fn hue2rgb(p: f64, q: f64, mut t: f64) -> f64 {
-        if t < 0.0 { t += 1.0; }
-        if t > 1.0 { t -= 1.0; }
-        if t < 1.0 / 6.0 { return p + (q - p) * 6.0 * t; }
-        if t < 0.5        { return q; }
-        if t < 2.0 / 3.0  { return p + (q - p) * (2.0 / 3.0 - t) * 6.0; }
+        if t < 0.0 {
+            t += 1.0;
+        }
+        if t > 1.0 {
+            t -= 1.0;
+        }
+        if t < 1.0 / 6.0 {
+            return p + (q - p) * 6.0 * t;
+        }
+        if t < 0.5 {
+            return q;
+        }
+        if t < 2.0 / 3.0 {
+            return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+        }
         p
     }
-    let q = if l < 0.5 { l * (1.0 + s) } else { l + s - l * s };
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
     let p = 2.0 * l - q;
     (
         hue2rgb(p, q, h + 1.0 / 3.0),

--- a/packages/ooxml-common/src/math.rs
+++ b/packages/ooxml-common/src/math.rs
@@ -521,7 +521,7 @@ mod tests {
         }
         // no stray '&' leaks into text
         let json = serde_json::to_string(&nodes).unwrap();
-        assert!(!json.contains('&') || json.contains("\\u0026") == false);
+        assert!(!json.contains('&') || !json.contains("\\u0026"));
     }
 
     #[test]

--- a/packages/ooxml-common/src/math.rs
+++ b/packages/ooxml-common/src/math.rs
@@ -209,23 +209,37 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                     .and_then(|p| mval(p, "pos"))
                     .unwrap_or_else(|| "bot".to_string());
                 let chr = pr.and_then(|p| mval(p, "chr")).unwrap_or_else(|| {
-                    if pos == "top" { "\u{23DE}".to_string() } else { "\u{23DF}".to_string() }
+                    if pos == "top" {
+                        "\u{23DE}".to_string()
+                    } else {
+                        "\u{23DF}".to_string()
+                    }
                 });
-                out.push(MathNode::GroupChr { chr, pos, base: nodes_in(child, "e") });
+                out.push(MathNode::GroupChr {
+                    chr,
+                    pos,
+                    base: nodes_in(child, "e"),
+                });
             }
             "bar" => {
                 let pr = mchild(child, "barPr");
                 let pos = pr
                     .and_then(|p| mval(p, "pos"))
                     .unwrap_or_else(|| "top".to_string());
-                out.push(MathNode::Bar { pos, base: nodes_in(child, "e") });
+                out.push(MathNode::Bar {
+                    pos,
+                    base: nodes_in(child, "e"),
+                });
             }
             "acc" => {
                 let pr = mchild(child, "accPr");
                 let chr = pr
                     .and_then(|p| mval(p, "chr"))
                     .unwrap_or_else(|| "\u{0302}".to_string());
-                out.push(MathNode::Accent { chr, base: nodes_in(child, "e") });
+                out.push(MathNode::Accent {
+                    chr,
+                    base: nodes_in(child, "e"),
+                });
             }
             "func" => out.push(MathNode::Func {
                 name: nodes_in(child, "fName"),
@@ -266,13 +280,19 @@ pub fn nodes_to_text(nodes: &[MathNode]) -> String {
                 s.push('^');
                 s.push_str(&nodes_to_text(sup));
             }
-            MathNode::Nary { op, sub, sup, body, .. } => {
+            MathNode::Nary {
+                op, sub, sup, body, ..
+            } => {
                 s.push_str(op);
                 s.push_str(&nodes_to_text(sub));
                 s.push_str(&nodes_to_text(sup));
                 s.push_str(&nodes_to_text(body));
             }
-            MathNode::Delimiter { beg_char, end_char, items } => {
+            MathNode::Delimiter {
+                beg_char,
+                end_char,
+                items,
+            } => {
                 s.push_str(beg_char);
                 for (i, it) in items.iter().enumerate() {
                     if i > 0 {
@@ -345,7 +365,10 @@ fn parse_matrix(el: Node) -> MathNode {
             .collect();
         rows.push(cells);
     }
-    MathNode::Array { rows, align: "center".to_string() }
+    MathNode::Array {
+        rows,
+        align: "center".to_string(),
+    }
 }
 
 /// `m:eqArr` -> array where each `m:e` is a row, split into cells at `&` alignment marks.
@@ -357,7 +380,10 @@ fn parse_eqarr(el: Node) -> MathNode {
     {
         rows.push(split_align_cells(parse_omath_nodes(e)));
     }
-    MathNode::Array { rows, align: "eq".to_string() }
+    MathNode::Array {
+        rows,
+        align: "eq".to_string(),
+    }
 }
 
 /// Split a row's nodes into alignment cells at run-text `&` markers.
@@ -396,7 +422,10 @@ fn nodes_in(parent: Node, name: &str) -> Vec<MathNode> {
 /// Concatenate all `m:t` text under a math run.
 fn run_text(r: Node) -> String {
     let mut s = String::new();
-    for t in r.children().filter(|n| n.is_element() && n.tag_name().name() == "t") {
+    for t in r
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "t")
+    {
         for tn in t.children() {
             if let Some(txt) = tn.text() {
                 s.push_str(txt);
@@ -465,7 +494,10 @@ mod tests {
         let nodes = parse(&xml);
         let json = serde_json::to_string(&nodes).unwrap();
         assert!(json.contains(r#""kind":"nary""#), "json: {json}");
-        assert!(json.contains(r#""op":"∑""#) || json.contains("∑"), "json: {json}");
+        assert!(
+            json.contains(r#""op":"∑""#) || json.contains("∑"),
+            "json: {json}"
+        );
     }
 
     #[test]

--- a/packages/pptx/parser/examples/dump.rs
+++ b/packages/pptx/parser/examples/dump.rs
@@ -1,47 +1,75 @@
 fn main() {
-    let path = std::env::args().nth(1)
+    let path = std::env::args()
+        .nth(1)
         .unwrap_or_else(|| "/Users/yokotani/開発/office-open-xml-viewer/public/sample.pptx".into());
     let data = std::fs::read(&path).expect("read pptx");
-    
+
     // Call the library's internal logic via the public WASM function
-    // (We can't call parse_pptx directly since it's wasm_bindgen, but we can 
+    // (We can't call parse_pptx directly since it's wasm_bindgen, but we can
     //  replicate the core logic inline here for testing)
-    
+
     use std::io::{Cursor, Read};
     let cursor = Cursor::new(data.as_slice());
     let mut zip = zip::ZipArchive::new(cursor).unwrap();
-    
+
     let pres_xml = {
         let mut f = zip.by_name("ppt/presentation.xml").unwrap();
-        let mut s = String::new(); f.read_to_string(&mut s).unwrap(); s
+        let mut s = String::new();
+        f.read_to_string(&mut s).unwrap();
+        s
     };
     let pres_doc = roxmltree::Document::parse(&pres_xml).unwrap();
     let root = pres_doc.root_element();
-    
+
     // Find sldIdLst
-    let sld_id_lst = root.descendants().find(|n| n.is_element() && n.tag_name().name() == "sldIdLst");
+    let sld_id_lst = root
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "sldIdLst");
     println!("sldIdLst found: {}", sld_id_lst.is_some());
-    
+
     if let Some(lst) = sld_id_lst {
         for sld in lst.children().filter(|n| n.is_element()) {
             println!("  sldId attrs:");
             for a in sld.attributes() {
-                println!("    name={} ns={:?} val={}", a.name(), a.namespace(), a.value());
+                println!(
+                    "    name={} ns={:?} val={}",
+                    a.name(),
+                    a.namespace(),
+                    a.value()
+                );
             }
         }
     }
-    
+
     let pres_rels = {
         let mut f = zip.by_name("ppt/_rels/presentation.xml.rels").unwrap();
-        let mut s = String::new(); f.read_to_string(&mut s).unwrap(); s
+        let mut s = String::new();
+        f.read_to_string(&mut s).unwrap();
+        s
     };
     let rels_doc = roxmltree::Document::parse(&pres_rels).unwrap();
     println!("\nPresentation rels:");
-    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
-        let id = rel.attributes().find(|a| a.name() == "Id" && a.namespace().is_none()).map(|a| a.value());
-        let target = rel.attributes().find(|a| a.name() == "Target" && a.namespace().is_none()).map(|a| a.value());
-        let typ = rel.attributes().find(|a| a.name() == "Type" && a.namespace().is_none()).map(|a| a.value());
-        if typ.map(|t| t.contains("/slide\"") || t.ends_with("/slide")).unwrap_or(false) {
+    for rel in rels_doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element())
+    {
+        let id = rel
+            .attributes()
+            .find(|a| a.name() == "Id" && a.namespace().is_none())
+            .map(|a| a.value());
+        let target = rel
+            .attributes()
+            .find(|a| a.name() == "Target" && a.namespace().is_none())
+            .map(|a| a.value());
+        let typ = rel
+            .attributes()
+            .find(|a| a.name() == "Type" && a.namespace().is_none())
+            .map(|a| a.value());
+        if typ
+            .map(|t| t.contains("/slide\"") || t.ends_with("/slide"))
+            .unwrap_or(false)
+        {
             println!("  id={:?} target={:?}", id, target);
         }
     }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -7416,23 +7416,25 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Local-only sample (redistribution-prohibited, gitignored). Tests that
+    // depend on it must skip gracefully on a clean checkout / in CI where the
+    // file is absent. See packages/pptx/public/private/.
+    const LOCAL_SAMPLE_2: &str = "../public/private/sample-2.pptx";
+
     #[test]
     fn test_parse_chartex() {
-        let xml = std::fs::read_to_string("../public/sample-2.pptx")
-            .ok()
-            .and_then(|_| None::<String>)
-            .unwrap_or_else(|| {
-                // read from zip directly
-                let data = std::fs::read("../public/sample-2.pptx").unwrap();
-                let cursor = std::io::Cursor::new(data.as_slice());
-                let mut zip = zip::ZipArchive::new(cursor).unwrap();
-                let mut s = String::new();
-                zip.by_name("ppt/charts/chartEx1.xml")
-                    .unwrap()
-                    .read_to_string(&mut s)
-                    .unwrap();
-                s
-            });
+        let Ok(data) = std::fs::read(LOCAL_SAMPLE_2) else {
+            eprintln!("skipping test_parse_chartex: local sample not found");
+            return;
+        };
+        let cursor = std::io::Cursor::new(data.as_slice());
+        let mut zip = zip::ZipArchive::new(cursor).unwrap();
+        let mut xml = String::new();
+        zip.by_name("ppt/charts/chartEx1.xml")
+            .unwrap()
+            .read_to_string(&mut xml)
+            .unwrap();
         let theme = HashMap::new();
         let result = parse_chartex(&xml, &theme);
         println!("parse_chartex result: {:?}", result.is_some());
@@ -7450,7 +7452,10 @@ mod tests {
 
     #[test]
     fn test_slide8_chart_rid() {
-        let data = std::fs::read("../public/sample-2.pptx").unwrap();
+        let Ok(data) = std::fs::read(LOCAL_SAMPLE_2) else {
+            eprintln!("skipping test_slide8_chart_rid: local sample not found");
+            return;
+        };
         let cursor = std::io::Cursor::new(data.as_slice());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         let mut slide_xml = String::new();
@@ -7495,7 +7500,10 @@ mod tests {
 
     #[test]
     fn test_slide8_full_parse() {
-        let data = std::fs::read("../public/sample-2.pptx").unwrap();
+        let Ok(data) = std::fs::read(LOCAL_SAMPLE_2) else {
+            eprintln!("skipping test_slide8_full_parse: local sample not found");
+            return;
+        };
         let pres = parse_presentation(&data).unwrap();
         let slide = &pres.slides[7]; // 0-indexed, slide 8
         println!("Slide 8 elements: {}", slide.elements.len());
@@ -7517,7 +7525,10 @@ mod tests {
 
     #[test]
     fn test_slide8_chartex_pipeline() {
-        let data = std::fs::read("../public/sample-2.pptx").unwrap();
+        let Ok(data) = std::fs::read(LOCAL_SAMPLE_2) else {
+            eprintln!("skipping test_slide8_chartex_pipeline: local sample not found");
+            return;
+        };
         let cursor = std::io::Cursor::new(data.as_slice());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
 

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -41,7 +41,6 @@ pub fn pptx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result
 }
 
 /// Native equivalent of `parse_pptx` for use from the MCP server.
-
 pub fn parse_pptx_native(data: &[u8]) -> Result<String, String> {
     let presentation = parse_presentation(data).map_err(|e| e.to_string())?;
     serde_json::to_string(&presentation).map_err(|e| e.to_string())
@@ -53,7 +52,6 @@ pub fn parse_pptx_native(data: &[u8]) -> Result<String, String> {
 /// strokes, effects, theme inheritance details). Designed for AI agents that
 /// need to read content efficiently — typical 10-30× token reduction vs. the
 /// raw JSON of `parse_pptx_native`.
-
 pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
     let pres = parse_presentation(data).map_err(|e| e.to_string())?;
     let mut out = String::new();
@@ -274,7 +272,6 @@ fn render_runs_md(runs: &[TextRun]) -> String {
 /// body text contains so much punctuation that aggressive escaping makes the
 /// output noisier than the structure it's trying to expose. Pipe is handled
 /// separately in `render_table_cell_md` since it only matters inside tables.
-
 fn escape_inline_md(s: &str) -> String {
     s.replace('\\', "\\\\")
         .replace('*', "\\*")
@@ -438,6 +435,11 @@ struct PptxComment {
     text: String,
 }
 
+// serde-facing parser output enum; the variant sizes follow the OOXML element
+// model. Boxing the large Shape variant would change the JSON serialization
+// shape only cosmetically while complicating 30+ construction/match sites, for
+// no real benefit on this parse-once-then-serialize type.
+#[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum SlideElement {
@@ -1193,6 +1195,10 @@ struct Paragraph {
     runs: Vec<TextRun>,
 }
 
+// serde-facing parser output enum; same rationale as SlideElement — the Text
+// variant is the common case and boxing it would add an allocation per run with
+// no meaningful gain on this parse-once-then-serialize type.
+#[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum TextRun {
@@ -1729,18 +1735,6 @@ fn parse_color_node_tint(
         }
     }
     None
-}
-
-/// PowerPoint's interpretation of OOXML color modifiers. Wraps the shared
-/// `ooxml_common::color::apply_color_transforms` with TintMode::PowerPointLinear
-/// — `tint` is applied as a `lerp(input, white, val)` in linear sRGB.
-/// Verified against PDF exports of SmartArt accent recolors.
-fn apply_color_transforms(hex: &str, node: roxmltree::Node<'_, '_>) -> String {
-    ooxml_common::color::apply_color_transforms(
-        hex,
-        node,
-        ooxml_common::color::TintMode::PowerPointLinear,
-    )
 }
 
 fn preset_color(name: &str) -> Option<String> {
@@ -3036,7 +3030,7 @@ fn parse_master_level_bullets(
 
 /// Parse default bold/italic from master txStyles (titleStyle / bodyStyle / otherStyle)
 /// > lvl1pPr > defRPr @b and @i. Keyed by ph_type.
-/// Only populated when the attribute is explicitly present on the master.
+/// > Only populated when the attribute is explicitly present on the master.
 fn parse_master_txstyle_bold_italic(
     master_xml: &str,
 ) -> (
@@ -3096,8 +3090,8 @@ fn parse_master_txstyle_bold_italic(
 
 /// Parse default text color from master txStyles (titleStyle/bodyStyle/otherStyle)
 /// > lvl1pPr > defRPr > solidFill, and from per-placeholder shapes in the master spTree's
-/// txBody > lstStyle > lvl1pPr > defRPr > solidFill. Keyed by ph_type.
-/// Shape-level lstStyle takes priority over txStyles generic defaults.
+/// > txBody > lstStyle > lvl1pPr > defRPr > solidFill. Keyed by ph_type.
+/// > Shape-level lstStyle takes priority over txStyles generic defaults.
 fn parse_master_txstyle_color(
     master_xml: &str,
     theme: &HashMap<String, String>,
@@ -3235,6 +3229,10 @@ fn parse_master_transforms(master_xml: &str) -> HashMap<String, Transform> {
     map
 }
 
+// Seeds layout placeholders from the master's per-type defaults (transforms,
+// alignment, spacing) before overlaying the layout's own placeholder props; the
+// many maps are the master inheritance sources, threaded through as-is.
+#[allow(clippy::too_many_arguments)]
 fn parse_layout_placeholders(
     layout_xml: &str,
     master_font_sizes: &HashMap<String, f64>,
@@ -3251,12 +3249,14 @@ fn parse_layout_placeholders(
     layout_rels: &HashMap<String, String>,
     zip: &mut PptxZip<'_>,
 ) -> LayoutPlaceholders {
-    let mut lph = LayoutPlaceholders::default();
-    lph.master_by_type = master_transforms.clone();
-    lph.by_type_master_alignment = master_alignments.clone();
-    lph.by_type_master_space_before = master_space_before.clone();
-    lph.by_type_master_space_after = master_space_after.clone();
-    lph.by_type_master_line_spacing = master_line_spacing.clone();
+    let mut lph = LayoutPlaceholders {
+        master_by_type: master_transforms.clone(),
+        by_type_master_alignment: master_alignments.clone(),
+        by_type_master_space_before: master_space_before.clone(),
+        by_type_master_space_after: master_space_after.clone(),
+        by_type_master_line_spacing: master_line_spacing.clone(),
+        ..Default::default()
+    };
     let doc = match roxmltree::Document::parse(layout_xml) {
         Ok(d) => d,
         Err(_) => return lph,
@@ -3503,6 +3503,10 @@ enum ShapeKind {
     Sp,
 }
 
+// Carries the resolved master/layout/placeholder inheritance context (theme,
+// rels, inherited font size, default alignment/spacing, level styles) that text
+// runs need; these are inheritance inputs, not an arbitrary parameter bag.
+#[allow(clippy::too_many_arguments)]
 fn parse_text_body(
     tx_body: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
@@ -3810,6 +3814,8 @@ fn push_math_runs(
     }
 }
 
+// Same inherited paragraph/run context as parse_text_body, scoped to one <a:p>.
+#[allow(clippy::too_many_arguments)]
 fn parse_paragraph(
     p_node: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
@@ -3871,7 +3877,7 @@ fn parse_paragraph(
     let mar_r = p_pr.and_then(|n| attr_i64(&n, "marR")).unwrap_or(0);
     let indent = p_pr
         .and_then(|n| attr_i64(&n, "indent"))
-        .unwrap_or_else(|| if has_bullet { -342900 } else { 0 });
+        .unwrap_or(if has_bullet { -342900 } else { 0 });
 
     let space_before = p_pr
         .and_then(|n| {
@@ -4409,7 +4415,7 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             cat.descendants()
                 .find(|n| n.is_element() && is_pt_container(n.tag_name().name()))
         })
-        .map(|cache| collect_pt_strings(cache))
+        .map(&collect_pt_strings)
         .unwrap_or_default();
 
     let pt_count = categories.len().max(1);
@@ -4461,8 +4467,7 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             } else {
                 None
             };
-            let series_categories: Option<Vec<String>> =
-                x_cache.map(|cache| collect_pt_strings(cache));
+            let series_categories: Option<Vec<String>> = x_cache.map(&collect_pt_strings);
 
             // Y values: scatter/bubble use `<c:yVal>`, everything else uses `<c:val>`.
             // Restrict the descendant walk to the matching tag so a sibling `<c:xVal>`
@@ -4647,8 +4652,8 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     let show_data_labels = root
         .descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
-        .any(|dLbls| {
-            dLbls.children().any(|c| {
+        .any(|d_lbls| {
+            d_lbls.children().any(|c| {
                 c.is_element()
                     && c.tag_name().name() == "showVal"
                     && attr(&c, "val").as_deref() == Some("1")
@@ -5777,14 +5782,17 @@ fn parse_table_styles_xml(
         let style_id = style_id.to_string();
         let mut def = TableStyleDef::default();
 
-        let parse_tc_style = |role: roxmltree::Node<'_, '_>| -> (
+        // (fill, inside-horizontal, inside-vertical, diagonal/unused, outer-horizontal,
+        // outer-vertical) borders for one table-style role (ECMA-376 §20.1.4.2.27).
+        type TcStyle = (
             Option<Fill>,
             Option<Stroke>,
             Option<Stroke>,
             Option<Stroke>,
             Option<Stroke>,
             Option<Stroke>,
-        ) {
+        );
+        let parse_tc_style = |role: roxmltree::Node<'_, '_>| -> TcStyle {
             let tc_style = match child(role, "tcStyle") {
                 Some(n) => n,
                 None => return (None, None, None, None, None, None),
@@ -6262,6 +6270,11 @@ fn parse_table_cell(
 //  Slide parser
 // ===========================
 
+// Threads the full master+layout inheritance context (per-type font sizes,
+// bullets, anchors, transforms, alignments, spacing, bold/italic/caps/color
+// maps) plus zip/theme into one slide parse; this is the inheritance chain
+// ECMA-376 requires, not an arbitrary parameter bag.
+#[allow(clippy::too_many_arguments)]
 fn parse_slide(
     xml: &str,
     layout_xml: Option<&str>,
@@ -6503,6 +6516,9 @@ fn load_pptx_comments(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> 
     out
 }
 
+// Recurses the shape tree carrying placeholder/layout context, theme, rels,
+// smartart drawings, the zip, the output buffer and inherited group fill.
+#[allow(clippy::too_many_arguments)]
 fn parse_sp_tree_node(
     node: roxmltree::Node<'_, '_>,
     lph: &LayoutPlaceholders,
@@ -7249,12 +7265,12 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
 
     let master_font_sizes: HashMap<String, f64> = master_xml_opt
         .as_deref()
-        .map(|xml| parse_master_font_sizes(xml))
+        .map(parse_master_font_sizes)
         .unwrap_or_default();
 
     let master_level_font_sizes: HashMap<String, LevelFontSizes> = master_xml_opt
         .as_deref()
-        .map(|xml| parse_master_level_font_sizes(xml))
+        .map(parse_master_level_font_sizes)
         .unwrap_or_default();
 
     let master_level_bullets: HashMap<String, LevelBullets> = master_xml_opt
@@ -7264,17 +7280,17 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
 
     let master_anchors: HashMap<String, String> = master_xml_opt
         .as_deref()
-        .map(|xml| parse_master_anchors(xml))
+        .map(parse_master_anchors)
         .unwrap_or_default();
 
     let master_transforms: HashMap<String, Transform> = master_xml_opt
         .as_deref()
-        .map(|xml| parse_master_transforms(xml))
+        .map(parse_master_transforms)
         .unwrap_or_default();
 
     let master_alignments: HashMap<String, String> = master_xml_opt
         .as_deref()
-        .map(|xml| parse_master_alignments(xml))
+        .map(parse_master_alignments)
         .unwrap_or_default();
 
     let (master_space_before, master_space_after, master_line_spacing): (
@@ -7283,7 +7299,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         HashMap<String, f64>,
     ) = master_xml_opt
         .as_deref()
-        .map(|xml| parse_master_txstyle_spacing(xml))
+        .map(parse_master_txstyle_spacing)
         .unwrap_or_default();
 
     let (master_bold, master_italic, master_caps): (
@@ -7292,7 +7308,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         HashMap<String, String>,
     ) = master_xml_opt
         .as_deref()
-        .map(|xml| parse_master_txstyle_bold_italic(xml))
+        .map(parse_master_txstyle_bold_italic)
         .unwrap_or_default();
 
     let master_color: HashMap<String, String> = master_xml_opt
@@ -7321,7 +7337,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         let slide_path = format!("ppt/{rel_target}");
         let slide_file = rel_target
             .split('/')
-            .last()
+            .next_back()
             .unwrap_or("slide.xml")
             .to_owned();
         let rels_path = format!("ppt/slides/_rels/{slide_file}.rels");
@@ -7343,7 +7359,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         let layout_rels = layout_path
             .as_deref()
             .and_then(|path| {
-                let file = path.split('/').last().unwrap_or("layout.xml");
+                let file = path.split('/').next_back().unwrap_or("layout.xml");
                 let rels_p = format!("ppt/slideLayouts/_rels/{file}.rels");
                 read_zip_str(&mut zip, &rels_p).ok()
             })

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -71,7 +71,6 @@ pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
 //  serialization used by the viewer. Lossy by design.
 // ───────────────────────────────────────────────────────────────────────────
 
-
 fn render_slide_md(slide: &Slide, out: &mut String) {
     use std::fmt::Write as _;
     let title = slide_title_md(slide);
@@ -99,7 +98,6 @@ fn render_slide_md(slide: &Slide, out: &mut String) {
     }
 }
 
-
 fn slide_title_md(slide: &Slide) -> Option<String> {
     for el in &slide.elements {
         if let SlideElement::Shape(s) = el {
@@ -117,7 +115,6 @@ fn slide_title_md(slide: &Slide) -> Option<String> {
     None
 }
 
-
 fn shape_text_plain(s: &ShapeElement) -> Option<String> {
     let tb = s.text_body.as_ref()?;
     let mut buf = String::new();
@@ -130,9 +127,12 @@ fn shape_text_plain(s: &ShapeElement) -> Option<String> {
         buf.push(' ');
     }
     let trimmed = buf.trim().to_string();
-    if trimmed.is_empty() { None } else { Some(trimmed) }
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
-
 
 fn render_element_md(el: &SlideElement, out: &mut String) {
     match el {
@@ -160,7 +160,6 @@ fn render_element_md(el: &SlideElement, out: &mut String) {
     }
 }
 
-
 fn render_shape_md(s: &ShapeElement, out: &mut String) {
     let Some(tb) = &s.text_body else { return };
     if tb.paragraphs.is_empty() {
@@ -171,21 +170,18 @@ fn render_shape_md(s: &ShapeElement, out: &mut String) {
     // as bulleted, mirroring what PowerPoint draws. Free text boxes default to
     // plain paragraphs.
     let ph = s.placeholder_type.as_deref().unwrap_or("");
-    let inherit_means_bullet =
-        matches!(ph, "body" | "subTitle" | "obj" | "tx" | "ftr" | "hdr");
+    let inherit_means_bullet = matches!(ph, "body" | "subTitle" | "obj" | "tx" | "ftr" | "hdr");
     for para in &tb.paragraphs {
         render_paragraph_md(para, inherit_means_bullet, out);
     }
     out.push('\n');
 }
 
-
 enum ParaKind {
     Plain,
     Bullet,
     Number,
 }
-
 
 fn paragraph_kind(b: &Bullet, inherit_means_bullet: bool) -> ParaKind {
     match b {
@@ -201,7 +197,6 @@ fn paragraph_kind(b: &Bullet, inherit_means_bullet: bool) -> ParaKind {
         }
     }
 }
-
 
 fn render_paragraph_md(para: &Paragraph, inherit_means_bullet: bool, out: &mut String) {
     use std::fmt::Write as _;
@@ -227,7 +222,6 @@ fn render_paragraph_md(para: &Paragraph, inherit_means_bullet: bool, out: &mut S
         }
     }
 }
-
 
 fn render_runs_md(runs: &[TextRun]) -> String {
     let mut out = String::new();
@@ -288,7 +282,6 @@ fn escape_inline_md(s: &str) -> String {
         .replace('`', "\\`")
 }
 
-
 fn render_table_md(t: &TableElement, out: &mut String) {
     use std::fmt::Write as _;
     if t.rows.is_empty() {
@@ -308,7 +301,6 @@ fn render_table_md(t: &TableElement, out: &mut String) {
     }
     out.push('\n');
 }
-
 
 fn render_table_cell_md(cell: &TableCell) -> String {
     // Continuation cells of a merge carry no content — leave empty so the row
@@ -332,7 +324,6 @@ fn render_table_cell_md(cell: &TableCell) -> String {
     }
     buf.trim().replace('|', "\\|")
 }
-
 
 fn render_chart_md(c: &ChartElement, out: &mut String) {
     use std::fmt::Write as _;
@@ -359,7 +350,11 @@ fn render_chart_md(c: &ChartElement, out: &mut String) {
 /// pptx zip archive. Used by the main thread to materialize media blobs for
 /// interactive playback without re-parsing the whole file.
 #[wasm_bindgen]
-pub fn extract_media(data: &[u8], path: &str, max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
+pub fn extract_media(
+    data: &[u8],
+    path: &str,
+    max_zip_entry_bytes: Option<u64>,
+) -> Result<Vec<u8>, JsValue> {
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let max = ooxml_common::zip::current_max();
     let cursor = Cursor::new(data);
@@ -495,7 +490,10 @@ struct ChartSeriesData {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct ChartElement {
-    x: i64, y: i64, width: i64, height: i64,
+    x: i64,
+    y: i64,
+    width: i64,
+    height: i64,
     chart_type: String,
     title: Option<String>,
     categories: Vec<String>,
@@ -624,7 +622,10 @@ struct ChartManualLayout {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct TableElement {
-    x: i64, y: i64, width: i64, height: i64,
+    x: i64,
+    y: i64,
+    width: i64,
+    height: i64,
     /// Column widths in EMU
     cols: Vec<i64>,
     rows: Vec<TableRow>,
@@ -814,7 +815,9 @@ struct SrcRect {
     b: f64,
 }
 
-fn is_zero_f64(v: &f64) -> bool { v.abs() < 1e-9 }
+fn is_zero_f64(v: &f64) -> bool {
+    v.abs() < 1e-9
+}
 
 /// ECMA-376 §19.3.1.17/18 a:audioFile / a:videoFile and the
 /// p14:media extension (embed attribute).
@@ -850,7 +853,11 @@ fn parse_blip_alpha(blip_fill: roxmltree::Node<'_, '_>) -> Option<f64> {
     let amf = child(blip, "alphaModFix")?;
     let amt: f64 = attr(&amf, "amt")?.parse().ok()?;
     let frac = amt / 100_000.0;
-    if frac >= 0.9999 { None } else { Some(frac.max(0.0)) }
+    if frac >= 0.9999 {
+        None
+    } else {
+        Some(frac.max(0.0))
+    }
 }
 
 /// Parse `<a:srcRect l t r b>` from a `<p:blipFill>` (or `<a:blipFill>`) node.
@@ -863,8 +870,14 @@ fn parse_src_rect(blip_fill: roxmltree::Node<'_, '_>) -> Option<SrcRect> {
             .map(|v| v / 100_000.0)
             .unwrap_or(0.0)
     };
-    let rect = SrcRect { l: read("l"), t: read("t"), r: read("r"), b: read("b") };
-    if is_zero_f64(&rect.l) && is_zero_f64(&rect.t) && is_zero_f64(&rect.r) && is_zero_f64(&rect.b) {
+    let rect = SrcRect {
+        l: read("l"),
+        t: read("t"),
+        r: read("r"),
+        b: read("b"),
+    };
+    if is_zero_f64(&rect.l) && is_zero_f64(&rect.t) && is_zero_f64(&rect.r) && is_zero_f64(&rect.b)
+    {
         None
     } else {
         Some(rect)
@@ -949,7 +962,9 @@ struct Reflection {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "fillType", rename_all = "camelCase")]
 enum Fill {
-    Solid { color: String },
+    Solid {
+        color: String,
+    },
     None,
     #[serde(rename_all = "camelCase")]
     Gradient {
@@ -1010,12 +1025,30 @@ struct Stroke {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "cmd", rename_all = "camelCase")]
 enum PathCmd {
-    MoveTo { x: f64, y: f64 },
-    LineTo { x: f64, y: f64 },
+    MoveTo {
+        x: f64,
+        y: f64,
+    },
+    LineTo {
+        x: f64,
+        y: f64,
+    },
     /// Cubic Bézier: two control points + endpoint
-    CubicBezTo { x1: f64, y1: f64, x2: f64, y2: f64, x: f64, y: f64 },
+    CubicBezTo {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        x: f64,
+        y: f64,
+    },
     /// Elliptical arc (all angles in degrees)
-    ArcTo { wr: f64, hr: f64, st_ang: f64, sw_ang: f64 },
+    ArcTo {
+        wr: f64,
+        hr: f64,
+        st_ang: f64,
+        sw_ang: f64,
+    },
     Close,
 }
 
@@ -1068,10 +1101,18 @@ struct TextBody {
     rtl_col: bool,
 }
 
-fn one_u32() -> u32 { 1 }
-fn is_one(n: &u32) -> bool { *n == 1 }
-fn is_zero_i64(n: &i64) -> bool { *n == 0 }
-fn is_false(b: &bool) -> bool { !*b }
+fn one_u32() -> u32 {
+    1
+}
+fn is_one(n: &u32) -> bool {
+    *n == 1
+}
+fn is_zero_i64(n: &i64) -> bool {
+    *n == 0
+}
+fn is_false(b: &bool) -> bool {
+    !*b
+}
 
 /// Line spacing specification
 #[derive(Serialize, Deserialize, Debug)]
@@ -1285,43 +1326,40 @@ fn read_zip_bytes(zip: &mut PptxZip<'_>, path: &str) -> Option<Vec<u8>> {
 /// Resolved fills and borders extracted from a single <a:tblStyle> definition.
 #[derive(Debug, Clone, Default)]
 struct TableStyleDef {
-    whole_fill:        Option<Fill>,
-    whole_inside_h:    Option<Stroke>,
-    whole_inside_v:    Option<Stroke>,
+    whole_fill: Option<Fill>,
+    whole_inside_h: Option<Stroke>,
+    whole_inside_v: Option<Stroke>,
     /// Outer top/bottom edge border (from wholeTbl tcBdr top/bottom)
-    whole_outer_h:     Option<Stroke>,
+    whole_outer_h: Option<Stroke>,
     /// Outer left/right edge border (from wholeTbl tcBdr left/right)
-    whole_outer_v:     Option<Stroke>,
-    band1h_fill:       Option<Fill>,
-    band2h_fill:       Option<Fill>,
-    first_row_fill:    Option<Fill>,
+    whole_outer_v: Option<Stroke>,
+    band1h_fill: Option<Fill>,
+    band2h_fill: Option<Fill>,
+    first_row_fill: Option<Fill>,
     first_row_border_b: Option<Stroke>,
-    last_row_fill:     Option<Fill>,
-    first_col_fill:    Option<Fill>,
-    last_col_fill:     Option<Fill>,
+    last_row_fill: Option<Fill>,
+    first_col_fill: Option<Fill>,
+    last_col_fill: Option<Fill>,
     /// Default text colour per role, from `<a:tcTxStyle>` (schemeClr/srgbClr).
     /// e.g. wholeTbl → dk1, firstRow header → lt1 (white). Hex, no `#`.
-    whole_text_color:     Option<String>,
+    whole_text_color: Option<String>,
     first_row_text_color: Option<String>,
-    last_row_text_color:  Option<String>,
+    last_row_text_color: Option<String>,
     first_col_text_color: Option<String>,
-    last_col_text_color:  Option<String>,
+    last_col_text_color: Option<String>,
     /// Default bold per role, from `<a:tcTxStyle b="on">` (ECMA-376 §20.1.4.2.28).
     /// e.g. a firstRow header is commonly bold.
-    first_row_bold:       Option<bool>,
-    last_row_bold:        Option<bool>,
-    first_col_bold:       Option<bool>,
-    last_col_bold:        Option<bool>,
+    first_row_bold: Option<bool>,
+    last_row_bold: Option<bool>,
+    first_col_bold: Option<bool>,
+    last_col_bold: Option<bool>,
 }
 
 // ===========================
 //  XML helpers (roxmltree)
 // ===========================
 
-fn child<'a, 'i>(
-    node: roxmltree::Node<'a, 'i>,
-    local: &str,
-) -> Option<roxmltree::Node<'a, 'i>> {
+fn child<'a, 'i>(node: roxmltree::Node<'a, 'i>, local: &str) -> Option<roxmltree::Node<'a, 'i>> {
     node.children()
         .find(|n| n.is_element() && n.tag_name().name() == local)
 }
@@ -1335,8 +1373,7 @@ fn children_vec<'a, 'i>(
         .collect()
 }
 
-const R_NS: &str =
-    "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+const R_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
 fn attr(node: &roxmltree::Node<'_, '_>, local: &str) -> Option<String> {
     node.attributes()
@@ -1381,10 +1418,7 @@ fn parse_rels(xml: &str) -> HashMap<String, String> {
 /// Pair diagramData rels with diagramDrawing rels in a slide's rels XML by filename
 /// number (data1.xml ↔ drawing1.xml, data2.xml ↔ drawing2.xml, ...), then load each
 /// drawing XML from the zip. Returns dm_rid → drawing_xml_content.
-fn build_smartart_drawings(
-    rels_xml: &str,
-    zip: &mut PptxZip<'_>,
-) -> HashMap<String, String> {
+fn build_smartart_drawings(rels_xml: &str, zip: &mut PptxZip<'_>) -> HashMap<String, String> {
     let mut result: HashMap<String, String> = HashMap::new();
     let doc = match roxmltree::Document::parse(rels_xml) {
         Ok(d) => d,
@@ -1406,12 +1440,20 @@ fn build_smartart_drawings(
     fn trailing_num(target: &str) -> Option<u32> {
         let file = target.rsplit('/').next().unwrap_or("");
         let stem = file.split('.').next().unwrap_or("");
-        let digits: String = stem.chars().rev().take_while(|c| c.is_ascii_digit()).collect();
+        let digits: String = stem
+            .chars()
+            .rev()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
         digits.chars().rev().collect::<String>().parse().ok()
     }
     for (rid, data_target) in data_rels {
-        let Some(num) = trailing_num(&data_target) else { continue };
-        let drawing_target = drawing_targets.iter().find(|t| trailing_num(t) == Some(num));
+        let Some(num) = trailing_num(&data_target) else {
+            continue;
+        };
+        let drawing_target = drawing_targets
+            .iter()
+            .find(|t| trailing_num(t) == Some(num));
         if let Some(dt) = drawing_target {
             let drawing_path = resolve_path("ppt/slides", dt);
             if let Ok(xml) = read_zip_str(zip, &drawing_path) {
@@ -1440,7 +1482,9 @@ fn resolve_path(base_dir: &str, target: &str) -> String {
     let mut parts: Vec<&str> = base_dir.split('/').collect();
     for seg in target.split('/') {
         match seg {
-            ".." => { parts.pop(); }
+            ".." => {
+                parts.pop();
+            }
             "." | "" => {}
             s => parts.push(s),
         }
@@ -1476,9 +1520,9 @@ fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
         for c in slot.children().filter(|n| n.is_element()) {
             let hex = match c.tag_name().name() {
                 "srgbClr" => attr(&c, "val"),
-                "sysClr"  => attr(&c, "lastClr"),
+                "sysClr" => attr(&c, "lastClr"),
                 "prstClr" => preset_color(attr(&c, "val").unwrap_or_default().as_str()),
-                _         => None,
+                _ => None,
             };
             if let Some(h) = hex {
                 map.insert(name, h);
@@ -1490,11 +1534,16 @@ fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
     // Parse fmtScheme > lnStyleLst so lnRef idx="N" can resolve to the theme's
     // canonical stroke width (9525 is wrong; theme defines 12700 / 19050 / 25400).
     // Stored under "+lnRef-1", "+lnRef-2", "+lnRef-3".
-    if let Some(fmt_scheme) = root.descendants()
+    if let Some(fmt_scheme) = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "fmtScheme")
     {
         if let Some(ln_style_lst) = child(fmt_scheme, "lnStyleLst") {
-            for (i, ln) in ln_style_lst.children().filter(|n| n.is_element() && n.tag_name().name() == "ln").enumerate() {
+            for (i, ln) in ln_style_lst
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "ln")
+                .enumerate()
+            {
                 if let Some(w) = attr(&ln, "w") {
                     map.insert(format!("+lnRef-{}", i + 1), w);
                 }
@@ -1504,7 +1553,8 @@ fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
 
     // Parse font scheme: majorFont (+mj-lt, +mj-ea, +mj-cs) and minorFont (+mn-lt, +mn-ea, +mn-cs)
     // Store as special keys in the theme map so the renderer can resolve +mj-lt → actual typeface.
-    if let Some(font_scheme) = root.descendants()
+    if let Some(font_scheme) = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "fontScheme")
     {
         let pairs: &[(&str, &[&str])] = &[
@@ -1515,8 +1565,8 @@ fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
         for (element_name, keys) in pairs {
             if let Some(font_node) = child(font_scheme, element_name) {
                 for (script, key) in scripts.iter().zip(keys.iter()) {
-                    if let Some(typeface) = child(font_node, script)
-                        .and_then(|n| attr(&n, "typeface"))
+                    if let Some(typeface) =
+                        child(font_node, script).and_then(|n| attr(&n, "typeface"))
                     {
                         if !typeface.is_empty() {
                             map.insert(key.to_string(), typeface.to_string());
@@ -1539,28 +1589,52 @@ fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
     // the bodyPr attributes (and the autoFit child element) into namespaced
     // theme keys so `parse_text_body` can fall back through them without
     // changing function signatures.
-    if let Some(obj_defaults) = root.descendants()
+    if let Some(obj_defaults) = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "objectDefaults")
     {
         let read_def = |def_name: &str, key_prefix: &str, map: &mut HashMap<String, String>| {
-            let Some(def) = child(obj_defaults, def_name) else { return; };
-            let Some(body_pr) = child(def, "bodyPr") else { return; };
+            let Some(def) = child(obj_defaults, def_name) else {
+                return;
+            };
+            let Some(body_pr) = child(def, "bodyPr") else {
+                return;
+            };
             // Plain attributes — copy verbatim; consumers parse the strings.
-            for attr_name in ["wrap", "anchor", "anchorCtr", "vert", "rtlCol",
-                              "lIns", "rIns", "tIns", "bIns",
-                              "numCol", "spcCol",
-                              "vertOverflow", "horzOverflow", "spcFirstLastPara",
-                              "rot", "upright", "fromWordArt", "forceAA",
-                              "compatLnSpc"] {
+            for attr_name in [
+                "wrap",
+                "anchor",
+                "anchorCtr",
+                "vert",
+                "rtlCol",
+                "lIns",
+                "rIns",
+                "tIns",
+                "bIns",
+                "numCol",
+                "spcCol",
+                "vertOverflow",
+                "horzOverflow",
+                "spcFirstLastPara",
+                "rot",
+                "upright",
+                "fromWordArt",
+                "forceAA",
+                "compatLnSpc",
+            ] {
                 if let Some(v) = attr(&body_pr, attr_name) {
                     map.insert(format!("{key_prefix}-bodyPr-{attr_name}"), v);
                 }
             }
             // Auto-fit is a child element, not an attribute. Encode as
             // `{prefix}-autoFit` → "sp" | "norm" | "none".
-            let auto_fit = if child(body_pr, "spAutoFit").is_some() { "sp" }
-                else if child(body_pr, "normAutofit").is_some() { "norm" }
-                else { "none" };
+            let auto_fit = if child(body_pr, "spAutoFit").is_some() {
+                "sp"
+            } else if child(body_pr, "normAutofit").is_some() {
+                "norm"
+            } else {
+                "none"
+            };
             // Only record when explicit; "none" is the spec default and
             // recording it would make every consumer see `Some("none")` even
             // for themes that didn't say anything.
@@ -1621,15 +1695,16 @@ fn parse_color_node_tint(
     theme: &HashMap<String, String>,
     tint_mode: ooxml_common::color::TintMode,
 ) -> Option<String> {
-    let xform = |hex: &str, c: roxmltree::Node<'_, '_>|
-        ooxml_common::color::apply_color_transforms(hex, c, tint_mode);
+    let xform = |hex: &str, c: roxmltree::Node<'_, '_>| {
+        ooxml_common::color::apply_color_transforms(hex, c, tint_mode)
+    };
     for c in node.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
             "srgbClr" => {
                 let hex = attr(&c, "val")?;
                 return Some(xform(&hex, c));
             }
-            "sysClr"  => {
+            "sysClr" => {
                 let hex = attr(&c, "lastClr")?;
                 return Some(xform(&hex, c));
             }
@@ -1638,14 +1713,14 @@ fn parse_color_node_tint(
                 let scheme_name = attr(&c, "val")?;
                 // OOXML semantic aliases → canonical theme slot names
                 let canonical: &str = match scheme_name.as_str() {
-                    "tx1" | "dk1"   => "dk1",
-                    "tx2" | "dk2"   => "dk2",
-                    "bg1" | "lt1"   => "lt1",
-                    "bg2" | "lt2"   => "lt2",
+                    "tx1" | "dk1" => "dk1",
+                    "tx2" | "dk2" => "dk2",
+                    "bg1" | "lt1" => "lt1",
+                    "bg2" | "lt2" => "lt2",
                     // phClr = "placeholder color" (inherits from layout).
                     // Approximate as the primary dark text color.
-                    "phClr"         => "dk1",
-                    other           => other,
+                    "phClr" => "dk1",
+                    other => other,
                 };
                 let base_hex = theme.get(canonical)?.clone();
                 return Some(xform(&base_hex, c));
@@ -1670,17 +1745,17 @@ fn apply_color_transforms(hex: &str, node: roxmltree::Node<'_, '_>) -> String {
 
 fn preset_color(name: &str) -> Option<String> {
     let hex = match name {
-        "black"                  => "000000",
-        "white"                  => "FFFFFF",
-        "red"                    => "FF0000",
-        "green"                  => "008000",
-        "blue"                   => "0000FF",
-        "yellow"                 => "FFFF00",
-        "cyan"                   => "00FFFF",
-        "magenta"                => "FF00FF",
-        "orange"                 => "FFA500",
-        "gray"   | "grey"        => "808080",
-        "darkGray"  | "darkGrey"  => "404040",
+        "black" => "000000",
+        "white" => "FFFFFF",
+        "red" => "FF0000",
+        "green" => "008000",
+        "blue" => "0000FF",
+        "yellow" => "FFFF00",
+        "cyan" => "00FFFF",
+        "magenta" => "FF00FF",
+        "orange" => "FFA500",
+        "gray" | "grey" => "808080",
+        "darkGray" | "darkGrey" => "404040",
         "lightGray" | "lightGrey" => "D3D3D3",
         _ => return None,
     };
@@ -1691,10 +1766,7 @@ fn preset_color(name: &str) -> Option<String> {
 //  Fill / Stroke parsing
 // ===========================
 
-fn parse_fill(
-    node: roxmltree::Node<'_, '_>,
-    theme: &HashMap<String, String>,
-) -> Option<Fill> {
+fn parse_fill(node: roxmltree::Node<'_, '_>, theme: &HashMap<String, String>) -> Option<Fill> {
     for c in node.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
             "solidFill" => {
@@ -1736,7 +1808,9 @@ fn parse_fill(
                     // No valid stops — continue scanning other fill elements
                 } else {
                     stops.sort_by(|a, b| {
-                        a.position.partial_cmp(&b.position).unwrap_or(std::cmp::Ordering::Equal)
+                        a.position
+                            .partial_cmp(&b.position)
+                            .unwrap_or(std::cmp::Ordering::Equal)
                     });
                     let (grad_type, angle) = if let Some(lin) = child(c, "lin") {
                         // OOXML ang: 60000ths of degree, 0 = left→right, 5400000 = top→bottom
@@ -1747,7 +1821,11 @@ fn parse_fill(
                     } else {
                         ("linear".to_owned(), 0.0)
                     };
-                    return Some(Fill::Gradient { stops, angle, grad_type });
+                    return Some(Fill::Gradient {
+                        stops,
+                        angle,
+                        grad_type,
+                    });
                 }
             }
             _ => {}
@@ -1758,8 +1836,8 @@ fn parse_fill(
 
 fn parse_arrow_end(node: roxmltree::Node<'_, '_>) -> ArrowEnd {
     let kind = attr(&node, "type").unwrap_or_else(|| "none".to_owned());
-    let w    = attr(&node, "w").unwrap_or_else(|| "med".to_owned());
-    let len  = attr(&node, "len").unwrap_or_else(|| "med".to_owned());
+    let w = attr(&node, "w").unwrap_or_else(|| "med".to_owned());
+    let len = attr(&node, "len").unwrap_or_else(|| "med".to_owned());
     ArrowEnd { kind, w, len }
 }
 
@@ -1771,8 +1849,7 @@ fn parse_stroke(
         return None;
     }
     let width = attr_i64(&ln_node, "w").unwrap_or(9525);
-    let color = child(ln_node, "solidFill")
-        .and_then(|n| parse_color_node(n, theme))?;
+    let color = child(ln_node, "solidFill").and_then(|n| parse_color_node(n, theme))?;
     let dash_style = child(ln_node, "prstDash")
         .and_then(|n| attr(&n, "val"))
         .filter(|v| v != "solid");
@@ -1786,7 +1863,14 @@ fn parse_stroke(
     // ECMA-376 §20.1.8.42 ST_CompoundLine. Default "sng" stays absent so the
     // renderer keeps its single-stroke fast path.
     let cmpd = attr(&ln_node, "cmpd").filter(|v| v != "sng");
-    Some(Stroke { color, width, dash_style, head_end, tail_end, cmpd })
+    Some(Stroke {
+        color,
+        width,
+        dash_style,
+        head_end,
+        tail_end,
+        cmpd,
+    })
 }
 
 // ===========================
@@ -1829,7 +1913,13 @@ fn parse_shadow_node(
         (color_str, 1.0)
     };
 
-    Some(Shadow { color, alpha, blur, dist, dir })
+    Some(Shadow {
+        color,
+        alpha,
+        blur,
+        dist,
+        dir,
+    })
 }
 
 /// Parse spPr > effectLst > glow into a Glow effect — ECMA-376 §20.1.8.17
@@ -1847,7 +1937,11 @@ fn parse_glow(
     } else {
         (color_str, 1.0)
     };
-    Some(Glow { color, alpha, radius })
+    Some(Glow {
+        color,
+        alpha,
+        radius,
+    })
 }
 
 /// Parse spPr > effectLst > softEdge into a SoftEdge — ECMA-376 §20.1.8.31.
@@ -1869,11 +1963,11 @@ fn parse_reflection(effect_lst: roxmltree::Node<'_, '_>) -> Option<Reflection> {
         blur: attr_i64(&r, "blurRad").unwrap_or(0),
         dist: attr_i64(&r, "dist").unwrap_or(0),
         dir: attr_f64(&r, "dir").unwrap_or(0.0) / 60_000.0,
-        st_a:   pct("stA",   1.0),
+        st_a: pct("stA", 1.0),
         st_pos: pct("stPos", 0.0),
-        end_a:  pct("endA",  0.0),
+        end_a: pct("endA", 0.0),
         end_pos: pct("endPos", 1.0),
-        sx: pct("sx",  1.0),
+        sx: pct("sx", 1.0),
         sy: pct("sy", -1.0),
     })
 }
@@ -1883,11 +1977,7 @@ fn parse_reflection(effect_lst: roxmltree::Node<'_, '_>) -> Option<Reflection> {
 // ===========================
 
 /// Parse a single path command node; coordinates are normalised to [0,1].
-fn parse_path_cmd(
-    cmd_node: roxmltree::Node<'_, '_>,
-    path_w: f64,
-    path_h: f64,
-) -> Option<PathCmd> {
+fn parse_path_cmd(cmd_node: roxmltree::Node<'_, '_>, path_w: f64, path_h: f64) -> Option<PathCmd> {
     match cmd_node.tag_name().name() {
         "moveTo" => {
             let pt = child(cmd_node, "pt")?;
@@ -1903,22 +1993,36 @@ fn parse_path_cmd(
         }
         "cubicBezTo" => {
             let pts: Vec<_> = children_vec(cmd_node, "pt");
-            if pts.len() < 3 { return None; }
+            if pts.len() < 3 {
+                return None;
+            }
             let x1 = attr_f64(&pts[0], "x")? / path_w;
             let y1 = attr_f64(&pts[0], "y")? / path_h;
             let x2 = attr_f64(&pts[1], "x")? / path_w;
             let y2 = attr_f64(&pts[1], "y")? / path_h;
-            let x  = attr_f64(&pts[2], "x")? / path_w;
-            let y  = attr_f64(&pts[2], "y")? / path_h;
-            Some(PathCmd::CubicBezTo { x1, y1, x2, y2, x, y })
+            let x = attr_f64(&pts[2], "x")? / path_w;
+            let y = attr_f64(&pts[2], "y")? / path_h;
+            Some(PathCmd::CubicBezTo {
+                x1,
+                y1,
+                x2,
+                y2,
+                x,
+                y,
+            })
         }
         "arcTo" => {
             // wR/hR are radii in path-local units; stAng/swAng in 60000ths of a degree
-            let wr     = attr_f64(&cmd_node, "wR").unwrap_or(0.0) / path_w;
-            let hr     = attr_f64(&cmd_node, "hR").unwrap_or(0.0) / path_h;
+            let wr = attr_f64(&cmd_node, "wR").unwrap_or(0.0) / path_w;
+            let hr = attr_f64(&cmd_node, "hR").unwrap_or(0.0) / path_h;
             let st_ang = attr_f64(&cmd_node, "stAng").unwrap_or(0.0) / 60000.0;
             let sw_ang = attr_f64(&cmd_node, "swAng").unwrap_or(0.0) / 60000.0;
-            Some(PathCmd::ArcTo { wr, hr, st_ang, sw_ang })
+            Some(PathCmd::ArcTo {
+                wr,
+                hr,
+                st_ang,
+                sw_ang,
+            })
         }
         "close" => Some(PathCmd::Close),
         _ => None,
@@ -1964,17 +2068,23 @@ struct Transform {
 }
 
 fn parse_xfrm(xfrm: roxmltree::Node<'_, '_>) -> Transform {
-    let rot    = attr_f64(&xfrm, "rot").unwrap_or(0.0) / 60000.0;
-    let flip_h = attr(&xfrm, "flipH").map(|v| v == "1" || v == "true").unwrap_or(false);
-    let flip_v = attr(&xfrm, "flipV").map(|v| v == "1" || v == "true").unwrap_or(false);
+    let rot = attr_f64(&xfrm, "rot").unwrap_or(0.0) / 60000.0;
+    let flip_h = attr(&xfrm, "flipH")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    let flip_v = attr(&xfrm, "flipV")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
     let off = child(xfrm, "off");
     let ext = child(xfrm, "ext");
     Transform {
-        x:  off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
-        y:  off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
+        x: off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
+        y: off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
         cx: ext.and_then(|n| attr_i64(&n, "cx")).unwrap_or(0),
         cy: ext.and_then(|n| attr_i64(&n, "cy")).unwrap_or(0),
-        rot, flip_h, flip_v,
+        rot,
+        flip_h,
+        flip_v,
     }
 }
 
@@ -1984,10 +2094,14 @@ fn parse_xfrm(xfrm: roxmltree::Node<'_, '_>) -> Transform {
 
 #[derive(Clone, Debug, Default)]
 struct GroupTransform {
-    x: i64, y: i64,
-    cx: i64, cy: i64,
-    ch_x: i64, ch_y: i64,
-    ch_cx: i64, ch_cy: i64,
+    x: i64,
+    y: i64,
+    cx: i64,
+    cy: i64,
+    ch_x: i64,
+    ch_y: i64,
+    ch_cx: i64,
+    ch_cy: i64,
     flip_h: bool,
     flip_v: bool,
     /// Group rotation in degrees, clockwise
@@ -1996,8 +2110,16 @@ struct GroupTransform {
 
 impl GroupTransform {
     fn apply_to_transform(&self, t: Transform) -> Transform {
-        let sx = if self.ch_cx != 0 { self.cx as f64 / self.ch_cx as f64 } else { 1.0 };
-        let sy = if self.ch_cy != 0 { self.cy as f64 / self.ch_cy as f64 } else { 1.0 };
+        let sx = if self.ch_cx != 0 {
+            self.cx as f64 / self.ch_cx as f64
+        } else {
+            1.0
+        };
+        let sy = if self.ch_cy != 0 {
+            self.cy as f64 / self.ch_cy as f64
+        } else {
+            1.0
+        };
         // If the group is flipped, mirror child positions in child coordinate space
         // before applying the normal scale+translate.
         // Mirror formula: new_left = (ch_x + ch_cx) - (t.x - ch_x) - t.cx
@@ -2033,7 +2155,10 @@ impl GroupTransform {
             // Clockwise rotation in screen coords (y-axis down): x' = x*cos - y*sin, y' = x*sin + y*cos
             let dx_new = dx * cos_r - dy * sin_r;
             let dy_new = dx * sin_r + dy * cos_r;
-            (group_cx + dx_new - new_cx as f64 / 2.0, group_cy + dy_new - new_cy as f64 / 2.0)
+            (
+                group_cx + dx_new - new_cx as f64 / 2.0,
+                group_cy + dy_new - new_cy as f64 / 2.0,
+            )
         } else {
             (new_x, new_y)
         };
@@ -2043,8 +2168,8 @@ impl GroupTransform {
         // GF (group net flip) = flip_h XOR flip_v.
         let gf = self.flip_h ^ self.flip_v;
         Transform {
-            x:  final_x.round() as i64,
-            y:  final_y.round() as i64,
+            x: final_x.round() as i64,
+            y: final_y.round() as i64,
             cx: new_cx,
             cy: new_cy,
             rot: self.rot + if gf { -t.rot } else { t.rot },
@@ -2058,24 +2183,61 @@ impl GroupTransform {
 fn apply_group_transform_to_element(el: &mut SlideElement, gt: &GroupTransform) {
     match el {
         SlideElement::Shape(s) => {
-            let t = Transform { x: s.x, y: s.y, cx: s.width, cy: s.height, rot: s.rotation, flip_h: s.flip_h, flip_v: s.flip_v };
+            let t = Transform {
+                x: s.x,
+                y: s.y,
+                cx: s.width,
+                cy: s.height,
+                rot: s.rotation,
+                flip_h: s.flip_h,
+                flip_v: s.flip_v,
+            };
             let nt = gt.apply_to_transform(t);
-            s.x = nt.x; s.y = nt.y; s.width = nt.cx; s.height = nt.cy;
-            s.rotation = nt.rot; s.flip_h = nt.flip_h; s.flip_v = nt.flip_v;
+            s.x = nt.x;
+            s.y = nt.y;
+            s.width = nt.cx;
+            s.height = nt.cy;
+            s.rotation = nt.rot;
+            s.flip_h = nt.flip_h;
+            s.flip_v = nt.flip_v;
             // Transform the explicit text frame in lock-step. It is axis-aligned
             // in local coords; pass rot=0/flip=false so it only translates+scales
             // (SmartArt drawings that carry txXfrm are not nested in rotated groups).
             if let Some(tr) = &mut s.text_rect {
-                let tt = Transform { x: tr.x, y: tr.y, cx: tr.width, cy: tr.height, rot: 0.0, flip_h: false, flip_v: false };
+                let tt = Transform {
+                    x: tr.x,
+                    y: tr.y,
+                    cx: tr.width,
+                    cy: tr.height,
+                    rot: 0.0,
+                    flip_h: false,
+                    flip_v: false,
+                };
                 let ntt = gt.apply_to_transform(tt);
-                tr.x = ntt.x; tr.y = ntt.y; tr.width = ntt.cx; tr.height = ntt.cy;
+                tr.x = ntt.x;
+                tr.y = ntt.y;
+                tr.width = ntt.cx;
+                tr.height = ntt.cy;
             }
         }
         SlideElement::Picture(p) => {
-            let t = Transform { x: p.x, y: p.y, cx: p.width, cy: p.height, rot: p.rotation, flip_h: p.flip_h, flip_v: p.flip_v };
+            let t = Transform {
+                x: p.x,
+                y: p.y,
+                cx: p.width,
+                cy: p.height,
+                rot: p.rotation,
+                flip_h: p.flip_h,
+                flip_v: p.flip_v,
+            };
             let nt = gt.apply_to_transform(t);
-            p.x = nt.x; p.y = nt.y; p.width = nt.cx; p.height = nt.cy;
-            p.rotation = nt.rot; p.flip_h = nt.flip_h; p.flip_v = nt.flip_v;
+            p.x = nt.x;
+            p.y = nt.y;
+            p.width = nt.cx;
+            p.height = nt.cy;
+            p.rotation = nt.rot;
+            p.flip_h = nt.flip_h;
+            p.flip_v = nt.flip_v;
         }
         SlideElement::Table(tbl) => {
             // If the table has no xfrm (zero dimensions), it fills the group's child space.
@@ -2084,9 +2246,20 @@ fn apply_group_transform_to_element(el: &mut SlideElement, gt: &GroupTransform) 
             } else {
                 (tbl.x, tbl.y, tbl.width, tbl.height)
             };
-            let t = Transform { x: ex, y: ey, cx: ecx, cy: ecy, rot: 0.0, flip_h: false, flip_v: false };
+            let t = Transform {
+                x: ex,
+                y: ey,
+                cx: ecx,
+                cy: ecy,
+                rot: 0.0,
+                flip_h: false,
+                flip_v: false,
+            };
             let nt = gt.apply_to_transform(t);
-            tbl.x = nt.x; tbl.y = nt.y; tbl.width = nt.cx; tbl.height = nt.cy;
+            tbl.x = nt.x;
+            tbl.y = nt.y;
+            tbl.width = nt.cx;
+            tbl.height = nt.cy;
         }
         SlideElement::Chart(chart) => {
             // If the chart graphicFrame has no xfrm (zero dimensions), it fills the group's child space.
@@ -2095,14 +2268,36 @@ fn apply_group_transform_to_element(el: &mut SlideElement, gt: &GroupTransform) 
             } else {
                 (chart.x, chart.y, chart.width, chart.height)
             };
-            let t = Transform { x: ex, y: ey, cx: ecx, cy: ecy, rot: 0.0, flip_h: false, flip_v: false };
+            let t = Transform {
+                x: ex,
+                y: ey,
+                cx: ecx,
+                cy: ecy,
+                rot: 0.0,
+                flip_h: false,
+                flip_v: false,
+            };
             let nt = gt.apply_to_transform(t);
-            chart.x = nt.x; chart.y = nt.y; chart.width = nt.cx; chart.height = nt.cy;
+            chart.x = nt.x;
+            chart.y = nt.y;
+            chart.width = nt.cx;
+            chart.height = nt.cy;
         }
         SlideElement::Media(m) => {
-            let t = Transform { x: m.x, y: m.y, cx: m.width, cy: m.height, rot: 0.0, flip_h: false, flip_v: false };
+            let t = Transform {
+                x: m.x,
+                y: m.y,
+                cx: m.width,
+                cy: m.height,
+                rot: 0.0,
+                flip_h: false,
+                flip_v: false,
+            };
             let nt = gt.apply_to_transform(t);
-            m.x = nt.x; m.y = nt.y; m.width = nt.cx; m.height = nt.cy;
+            m.x = nt.x;
+            m.y = nt.y;
+            m.width = nt.cx;
+            m.height = nt.cy;
         }
     }
 }
@@ -2114,24 +2309,24 @@ fn apply_group_transform_to_element(el: &mut SlideElement, gt: &GroupTransform) 
 /// Keyed first by idx (integer), then by type string.
 #[derive(Default)]
 struct LayoutPlaceholders {
-    by_idx:  HashMap<u32, Transform>,
+    by_idx: HashMap<u32, Transform>,
     by_type: HashMap<String, Transform>,
     /// Fallback transforms from slide master (by ph_type), used when layout has no xfrm
     master_by_type: HashMap<String, Transform>,
     /// Default font size (pt) per placeholder idx, from layout/master lstStyle
-    by_idx_font_size:  HashMap<u32, f64>,
+    by_idx_font_size: HashMap<u32, f64>,
     /// Default font size (pt) per placeholder type, from layout/master lstStyle
     by_type_font_size: HashMap<String, f64>,
     /// Per-list-level default font sizes (pt) per placeholder idx — index 0..=8
     /// maps to lvl1pPr..lvl9pPr (ECMA-376 §21.1.2.4). Lets nested bullets shrink
     /// per level (e.g. body 28pt → lvl2 24pt → lvl3 20pt) instead of all using
     /// the level-1 size. None per level where the style chain doesn't specify it.
-    by_idx_level_sizes:  HashMap<u32, LevelFontSizes>,
+    by_idx_level_sizes: HashMap<u32, LevelFontSizes>,
     /// Per-list-level default font sizes (pt) per placeholder type.
     by_type_level_sizes: HashMap<String, LevelFontSizes>,
     /// Per-list-level inherited bullet (buChar/buAutoNum/buNone) per placeholder
     /// idx — what a paragraph with no explicit bullet inherits (ECMA-376 §19.7.10).
-    by_idx_level_bullets:  HashMap<u32, LevelBullets>,
+    by_idx_level_bullets: HashMap<u32, LevelBullets>,
     /// Per-list-level inherited bullet per placeholder type.
     by_type_level_bullets: HashMap<String, LevelBullets>,
     /// Default bold per placeholder type, from layout lstStyle defRPr b attribute
@@ -2197,7 +2392,11 @@ impl LayoutPlaceholders {
             .and_then(|i| self.by_idx.get(&i))
             .or_else(|| self.by_type.get(ph_type))
             .or_else(|| {
-                if ph_type == "body" { self.by_type.get("") } else { None }
+                if ph_type == "body" {
+                    self.by_type.get("")
+                } else {
+                    None
+                }
             })
             .or_else(|| self.master_by_type.get(ph_type))
     }
@@ -2208,8 +2407,13 @@ impl LayoutPlaceholders {
         if let Some(i) = ph_idx {
             return self.by_idx_font_size.get(&i).copied();
         }
-        self.by_type_font_size.get(ph_type).copied()
-            .or_else(|| if ph_type == "body" { self.by_type_font_size.get("").copied() } else { None })
+        self.by_type_font_size.get(ph_type).copied().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_font_size.get("").copied()
+            } else {
+                None
+            }
+        })
     }
 
     /// Per-list-level inherited default font sizes (lvl1..lvl9). Same idx-strict
@@ -2217,10 +2421,22 @@ impl LayoutPlaceholders {
     /// per-level styling.
     fn lookup_level_font_sizes(&self, ph_type: &str, ph_idx: Option<u32>) -> LevelFontSizes {
         if let Some(i) = ph_idx {
-            return self.by_idx_level_sizes.get(&i).copied().unwrap_or([None; 9]);
+            return self
+                .by_idx_level_sizes
+                .get(&i)
+                .copied()
+                .unwrap_or([None; 9]);
         }
-        self.by_type_level_sizes.get(ph_type).copied()
-            .or_else(|| if ph_type == "body" { self.by_type_level_sizes.get("").copied() } else { None })
+        self.by_type_level_sizes
+            .get(ph_type)
+            .copied()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_level_sizes.get("").copied()
+                } else {
+                    None
+                }
+            })
             .unwrap_or([None; 9])
     }
 
@@ -2228,57 +2444,131 @@ impl LayoutPlaceholders {
     /// `lookup_level_font_sizes`. All-None when the placeholder inherits no bullet.
     fn lookup_level_bullets(&self, ph_type: &str, ph_idx: Option<u32>) -> LevelBullets {
         if let Some(i) = ph_idx {
-            return self.by_idx_level_bullets.get(&i).cloned().unwrap_or_else(empty_level_bullets);
+            return self
+                .by_idx_level_bullets
+                .get(&i)
+                .cloned()
+                .unwrap_or_else(empty_level_bullets);
         }
-        self.by_type_level_bullets.get(ph_type).cloned()
-            .or_else(|| if ph_type == "body" { self.by_type_level_bullets.get("").cloned() } else { None })
+        self.by_type_level_bullets
+            .get(ph_type)
+            .cloned()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_level_bullets.get("").cloned()
+                } else {
+                    None
+                }
+            })
             .unwrap_or_else(empty_level_bullets)
     }
 
     /// Look up inherited bold for this placeholder type.
     fn lookup_bold(&self, ph_type: &str) -> Option<bool> {
-        self.by_type_bold.get(ph_type).copied()
-            .or_else(|| if ph_type == "body" { self.by_type_bold.get("").copied() } else { None })
+        self.by_type_bold.get(ph_type).copied().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_bold.get("").copied()
+            } else {
+                None
+            }
+        })
     }
 
     /// Look up inherited italic for this placeholder type.
     fn lookup_italic(&self, ph_type: &str) -> Option<bool> {
-        self.by_type_italic.get(ph_type).copied()
-            .or_else(|| if ph_type == "body" { self.by_type_italic.get("").copied() } else { None })
+        self.by_type_italic.get(ph_type).copied().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_italic.get("").copied()
+            } else {
+                None
+            }
+        })
     }
 
     /// Look up inherited caps ("all"/"small") for this placeholder type.
     fn lookup_caps(&self, ph_type: &str) -> Option<String> {
-        self.by_type_caps.get(ph_type).cloned()
-            .or_else(|| if ph_type == "body" { self.by_type_caps.get("").cloned() } else { None })
+        self.by_type_caps.get(ph_type).cloned().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_caps.get("").cloned()
+            } else {
+                None
+            }
+        })
     }
 
     /// Look up inherited vertical anchor for this placeholder type.
     fn lookup_anchor(&self, ph_type: &str) -> Option<String> {
-        self.by_type_anchor.get(ph_type).cloned()
-            .or_else(|| if ph_type == "body" { self.by_type_anchor.get("").cloned() } else { None })
+        self.by_type_anchor.get(ph_type).cloned().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_anchor.get("").cloned()
+            } else {
+                None
+            }
+        })
     }
 
     /// Look up inherited paragraph alignment for this placeholder type.
     fn lookup_alignment(&self, ph_type: &str) -> Option<String> {
-        self.by_type_alignment.get(ph_type).cloned()
-            .or_else(|| if ph_type == "body" { self.by_type_alignment.get("").cloned() } else { None })
+        self.by_type_alignment
+            .get(ph_type)
+            .cloned()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_alignment.get("").cloned()
+                } else {
+                    None
+                }
+            })
             .or_else(|| self.by_type_master_alignment.get(ph_type).cloned())
-            .or_else(|| if ph_type == "body" { self.by_type_master_alignment.get("").cloned() } else { None })
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_master_alignment.get("").cloned()
+                } else {
+                    None
+                }
+            })
     }
 
     fn lookup_space_before(&self, ph_type: &str) -> Option<i64> {
-        self.by_type_space_before.get(ph_type).copied()
-            .or_else(|| if ph_type == "body" { self.by_type_space_before.get("").copied() } else { None })
+        self.by_type_space_before
+            .get(ph_type)
+            .copied()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_space_before.get("").copied()
+                } else {
+                    None
+                }
+            })
             .or_else(|| self.by_type_master_space_before.get(ph_type).copied())
-            .or_else(|| if ph_type == "body" { self.by_type_master_space_before.get("").copied() } else { None })
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_master_space_before.get("").copied()
+                } else {
+                    None
+                }
+            })
     }
 
     fn lookup_space_after(&self, ph_type: &str) -> Option<i64> {
-        self.by_type_space_after.get(ph_type).copied()
-            .or_else(|| if ph_type == "body" { self.by_type_space_after.get("").copied() } else { None })
+        self.by_type_space_after
+            .get(ph_type)
+            .copied()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_space_after.get("").copied()
+                } else {
+                    None
+                }
+            })
             .or_else(|| self.by_type_master_space_after.get(ph_type).copied())
-            .or_else(|| if ph_type == "body" { self.by_type_master_space_after.get("").copied() } else { None })
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_master_space_after.get("").copied()
+                } else {
+                    None
+                }
+            })
     }
 
     /// Look up inherited blipFill from the layout placeholder spPr. Used when a slide
@@ -2298,8 +2588,13 @@ impl LayoutPlaceholders {
         if let Some(i) = ph_idx {
             return self.by_idx_stroke.get(&i).cloned();
         }
-        self.by_type_stroke.get(ph_type).cloned()
-            .or_else(|| if ph_type == "body" { self.by_type_stroke.get("").cloned() } else { None })
+        self.by_type_stroke.get(ph_type).cloned().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_stroke.get("").cloned()
+            } else {
+                None
+            }
+        })
     }
 
     /// Look up inherited default text color for this placeholder (layout then master fallback).
@@ -2322,13 +2617,32 @@ impl LayoutPlaceholders {
                 return Some(c.clone());
             }
             // Layout idx had no colour → fall through to the master type-keyed default.
-            return self.by_type_master_color.get(ph_type).cloned()
-                .or_else(|| if ph_type == "body" { self.by_type_master_color.get("").cloned() } else { None });
+            return self.by_type_master_color.get(ph_type).cloned().or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_master_color.get("").cloned()
+                } else {
+                    None
+                }
+            });
         }
-        self.by_type_color.get(ph_type).cloned()
-            .or_else(|| if ph_type == "body" { self.by_type_color.get("").cloned() } else { None })
+        self.by_type_color
+            .get(ph_type)
+            .cloned()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_color.get("").cloned()
+                } else {
+                    None
+                }
+            })
             .or_else(|| self.by_type_master_color.get(ph_type).cloned())
-            .or_else(|| if ph_type == "body" { self.by_type_master_color.get("").cloned() } else { None })
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_master_color.get("").cloned()
+                } else {
+                    None
+                }
+            })
     }
 
     /// Look up the inherited shape fill from the layout placeholder's `<p:spPr>`.
@@ -2353,8 +2667,13 @@ impl LayoutPlaceholders {
         if let Some(i) = ph_idx {
             return self.by_idx_fill.get(&i).cloned();
         }
-        self.by_type_fill.get(ph_type).cloned()
-            .or_else(|| if ph_type == "body" { self.by_type_fill.get("").cloned() } else { None })
+        self.by_type_fill.get(ph_type).cloned().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_fill.get("").cloned()
+            } else {
+                None
+            }
+        })
     }
 
     /// Look up inherited line spacing (spcPct val, e.g. 90000 = 90%) for this placeholder.
@@ -2363,10 +2682,24 @@ impl LayoutPlaceholders {
         if let Some(i) = ph_idx {
             return self.by_idx_line_spacing.get(&i).copied();
         }
-        self.by_type_line_spacing.get(ph_type).copied()
-            .or_else(|| if ph_type == "body" { self.by_type_line_spacing.get("").copied() } else { None })
+        self.by_type_line_spacing
+            .get(ph_type)
+            .copied()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_line_spacing.get("").copied()
+                } else {
+                    None
+                }
+            })
             .or_else(|| self.by_type_master_line_spacing.get(ph_type).copied())
-            .or_else(|| if ph_type == "body" { self.by_type_master_line_spacing.get("").copied() } else { None })
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_master_line_spacing.get("").copied()
+                } else {
+                    None
+                }
+            })
     }
 }
 
@@ -2390,7 +2723,8 @@ fn read_level_font_sizes(list_style: roxmltree::Node<'_, '_>) -> LevelFontSizes 
     let mut out: LevelFontSizes = [None; 9];
     for (lvl, slot) in out.iter_mut().enumerate() {
         let tag = format!("lvl{}pPr", lvl + 1);
-        *slot = list_style.children()
+        *slot = list_style
+            .children()
             .find(|n| n.is_element() && n.tag_name().name() == tag)
             .and_then(|lp| child(lp, "defRPr"))
             .and_then(|rp| attr_f64(&rp, "sz"))
@@ -2401,16 +2735,22 @@ fn read_level_font_sizes(list_style: roxmltree::Node<'_, '_>) -> LevelFontSizes 
 
 /// Per-level default font sizes from a txBody's own `<a:lstStyle>`.
 fn extract_level_font_sizes(tx_body: roxmltree::Node<'_, '_>) -> LevelFontSizes {
-    child(tx_body, "lstStyle").map(read_level_font_sizes).unwrap_or([None; 9])
+    child(tx_body, "lstStyle")
+        .map(read_level_font_sizes)
+        .unwrap_or([None; 9])
 }
 
 /// True when any level carries a size (avoids storing all-None arrays).
-fn has_any_level_size(s: &LevelFontSizes) -> bool { s.iter().any(|v| v.is_some()) }
+fn has_any_level_size(s: &LevelFontSizes) -> bool {
+    s.iter().any(|v| v.is_some())
+}
 
 /// Per-edge merge: `primary[lvl]` wins, else `fallback[lvl]`.
 fn merge_level_sizes(primary: &LevelFontSizes, fallback: &LevelFontSizes) -> LevelFontSizes {
     let mut out: LevelFontSizes = [None; 9];
-    for lvl in 0..9 { out[lvl] = primary[lvl].or(fallback[lvl]); }
+    for lvl in 0..9 {
+        out[lvl] = primary[lvl].or(fallback[lvl]);
+    }
     out
 }
 
@@ -2419,19 +2759,27 @@ fn merge_level_sizes(primary: &LevelFontSizes, fallback: &LevelFontSizes) -> Lev
 /// (so the value is still inherited from a lower-priority style tier).
 type LevelBullets = [Option<Bullet>; 9];
 
-fn empty_level_bullets() -> LevelBullets { std::array::from_fn(|_| None) }
+fn empty_level_bullets() -> LevelBullets {
+    std::array::from_fn(|_| None)
+}
 
 /// True when any level carries an explicit bullet (avoids storing all-None arrays).
-fn has_any_level_bullet(s: &LevelBullets) -> bool { s.iter().any(|v| v.is_some()) }
+fn has_any_level_bullet(s: &LevelBullets) -> bool {
+    s.iter().any(|v| v.is_some())
+}
 
 /// Read `<a:lvlNpPr>` bullets for levels 1..9 from a node holding `<a:lvlNpPr>`
 /// children (a txBody `<a:lstStyle>` or a master `<p:txStyles>` style node).
 /// A level resolves to `Some` only when it explicitly sets `buChar`/`buAutoNum`/
 /// `buNone`; an absent bullet element stays `None` so lower tiers can supply it.
-fn read_level_bullets(list_style: roxmltree::Node<'_, '_>, theme: &HashMap<String, String>) -> LevelBullets {
+fn read_level_bullets(
+    list_style: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+) -> LevelBullets {
     std::array::from_fn(|lvl| {
         let tag = format!("lvl{}pPr", lvl + 1);
-        list_style.children()
+        list_style
+            .children()
             .find(|n| n.is_element() && n.tag_name().name() == tag)
             .and_then(|lp| match parse_bullet(Some(lp), theme) {
                 Bullet::Inherit => None,
@@ -2441,8 +2789,13 @@ fn read_level_bullets(list_style: roxmltree::Node<'_, '_>, theme: &HashMap<Strin
 }
 
 /// Per-level bullets from a txBody's own `<a:lstStyle>`.
-fn extract_level_bullets(tx_body: roxmltree::Node<'_, '_>, theme: &HashMap<String, String>) -> LevelBullets {
-    child(tx_body, "lstStyle").map(|ls| read_level_bullets(ls, theme)).unwrap_or_else(empty_level_bullets)
+fn extract_level_bullets(
+    tx_body: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+) -> LevelBullets {
+    child(tx_body, "lstStyle")
+        .map(|ls| read_level_bullets(ls, theme))
+        .unwrap_or_else(empty_level_bullets)
 }
 
 /// Per-edge merge: `primary[lvl]` wins, else `fallback[lvl]`.
@@ -2459,8 +2812,12 @@ fn parse_master_anchors(master_xml: &str) -> HashMap<String, String> {
     };
     let root = doc.root_element();
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
-        for sp in sp_tree.children().filter(|n| n.is_element() && n.tag_name().name() == "sp") {
-            let ph_node = sp.descendants()
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            let ph_node = sp
+                .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "ph");
             if let Some(ph) = ph_node {
                 let ph_type = attr(&ph, "type").unwrap_or_default();
@@ -2485,8 +2842,12 @@ fn parse_master_alignments(master_xml: &str) -> HashMap<String, String> {
     };
     let root = doc.root_element();
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
-        for sp in sp_tree.children().filter(|n| n.is_element() && n.tag_name().name() == "sp") {
-            let ph_node = sp.descendants()
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            let ph_node = sp
+                .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "ph");
             if let Some(ph) = ph_node {
                 let ph_type = attr(&ph, "type").unwrap_or_default();
@@ -2516,8 +2877,12 @@ fn parse_master_font_sizes(master_xml: &str) -> HashMap<String, f64> {
 
     // Scan master spTree placeholder shapes first — per-shape lstStyle is more specific
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
-        for sp in sp_tree.children().filter(|n| n.is_element() && n.tag_name().name() == "sp") {
-            let ph_node = sp.descendants()
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            let ph_node = sp
+                .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "ph");
             if let Some(ph) = ph_node {
                 let ph_type = attr(&ph, "type").unwrap_or_default();
@@ -2533,9 +2898,9 @@ fn parse_master_font_sizes(master_xml: &str) -> HashMap<String, f64> {
     // p:txStyles > a:titleStyle / a:bodyStyle / a:otherStyle as fallback
     if let Some(tx_styles) = child(root, "txStyles") {
         let style_ph_map: &[(&str, &[&str])] = &[
-            ("titleStyle",  &["title", "ctrTitle"]),
-            ("bodyStyle",   &["body", "subTitle", "obj", ""]),
-            ("otherStyle",  &["dt", "ftr", "sldNum"]),
+            ("titleStyle", &["title", "ctrTitle"]),
+            ("bodyStyle", &["body", "subTitle", "obj", ""]),
+            ("otherStyle", &["dt", "ftr", "sldNum"]),
         ];
         for (style_name, ph_types) in style_ph_map {
             let sz = child(tx_styles, style_name)
@@ -2568,12 +2933,20 @@ fn parse_master_level_font_sizes(master_xml: &str) -> HashMap<String, LevelFontS
 
     // Per-shape lstStyle first (more specific).
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
-        for sp in sp_tree.children().filter(|n| n.is_element() && n.tag_name().name() == "sp") {
-            if let Some(ph) = sp.descendants().find(|n| n.is_element() && n.tag_name().name() == "ph") {
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            if let Some(ph) = sp
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "ph")
+            {
                 let ph_type = attr(&ph, "type").unwrap_or_default();
                 if let Some(tx_body) = child(sp, "txBody") {
                     let sizes = extract_level_font_sizes(tx_body);
-                    if has_any_level_size(&sizes) { map.entry(ph_type).or_insert(sizes); }
+                    if has_any_level_size(&sizes) {
+                        map.entry(ph_type).or_insert(sizes);
+                    }
                 }
             }
         }
@@ -2582,9 +2955,9 @@ fn parse_master_level_font_sizes(master_xml: &str) -> HashMap<String, LevelFontS
     // txStyles fallback.
     if let Some(tx_styles) = child(root, "txStyles") {
         let style_ph_map: &[(&str, &[&str])] = &[
-            ("titleStyle",  &["title", "ctrTitle"]),
-            ("bodyStyle",   &["body", "subTitle", "obj", ""]),
-            ("otherStyle",  &["dt", "ftr", "sldNum"]),
+            ("titleStyle", &["title", "ctrTitle"]),
+            ("bodyStyle", &["body", "subTitle", "obj", ""]),
+            ("otherStyle", &["dt", "ftr", "sldNum"]),
         ];
         for (style_name, ph_types) in style_ph_map {
             if let Some(style_node) = child(tx_styles, style_name) {
@@ -2606,7 +2979,10 @@ fn parse_master_level_font_sizes(master_xml: &str) -> HashMap<String, LevelFontS
 /// the `bodyStyle` `<a:lvlNpPr>` bullets) is what a slide body paragraph with no
 /// explicit bullet inherits (ECMA-376 §19.7.10 / §21.1.2.4). Per-shape lstStyle
 /// wins over the generic txStyles.
-fn parse_master_level_bullets(master_xml: &str, theme: &HashMap<String, String>) -> HashMap<String, LevelBullets> {
+fn parse_master_level_bullets(
+    master_xml: &str,
+    theme: &HashMap<String, String>,
+) -> HashMap<String, LevelBullets> {
     let mut map: HashMap<String, LevelBullets> = HashMap::new();
     let doc = match roxmltree::Document::parse(master_xml) {
         Ok(d) => d,
@@ -2616,12 +2992,20 @@ fn parse_master_level_bullets(master_xml: &str, theme: &HashMap<String, String>)
 
     // Per-shape lstStyle first (more specific).
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
-        for sp in sp_tree.children().filter(|n| n.is_element() && n.tag_name().name() == "sp") {
-            if let Some(ph) = sp.descendants().find(|n| n.is_element() && n.tag_name().name() == "ph") {
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            if let Some(ph) = sp
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "ph")
+            {
                 let ph_type = attr(&ph, "type").unwrap_or_default();
                 if let Some(tx_body) = child(sp, "txBody") {
                     let bullets = extract_level_bullets(tx_body, theme);
-                    if has_any_level_bullet(&bullets) { map.entry(ph_type).or_insert(bullets); }
+                    if has_any_level_bullet(&bullets) {
+                        map.entry(ph_type).or_insert(bullets);
+                    }
                 }
             }
         }
@@ -2630,16 +3014,17 @@ fn parse_master_level_bullets(master_xml: &str, theme: &HashMap<String, String>)
     // txStyles fallback.
     if let Some(tx_styles) = child(root, "txStyles") {
         let style_ph_map: &[(&str, &[&str])] = &[
-            ("titleStyle",  &["title", "ctrTitle"]),
-            ("bodyStyle",   &["body", "subTitle", "obj", ""]),
-            ("otherStyle",  &["dt", "ftr", "sldNum"]),
+            ("titleStyle", &["title", "ctrTitle"]),
+            ("bodyStyle", &["body", "subTitle", "obj", ""]),
+            ("otherStyle", &["dt", "ftr", "sldNum"]),
         ];
         for (style_name, ph_types) in style_ph_map {
             if let Some(style_node) = child(tx_styles, style_name) {
                 let bullets = read_level_bullets(style_node, theme);
                 if has_any_level_bullet(&bullets) {
                     for ph_type in *ph_types {
-                        map.entry(ph_type.to_string()).or_insert_with(|| bullets.clone());
+                        map.entry(ph_type.to_string())
+                            .or_insert_with(|| bullets.clone());
                     }
                 }
             }
@@ -2652,7 +3037,13 @@ fn parse_master_level_bullets(master_xml: &str, theme: &HashMap<String, String>)
 /// Parse default bold/italic from master txStyles (titleStyle / bodyStyle / otherStyle)
 /// > lvl1pPr > defRPr @b and @i. Keyed by ph_type.
 /// Only populated when the attribute is explicitly present on the master.
-fn parse_master_txstyle_bold_italic(master_xml: &str) -> (HashMap<String, bool>, HashMap<String, bool>, HashMap<String, String>) {
+fn parse_master_txstyle_bold_italic(
+    master_xml: &str,
+) -> (
+    HashMap<String, bool>,
+    HashMap<String, bool>,
+    HashMap<String, String>,
+) {
     let mut bold_map: HashMap<String, bool> = HashMap::new();
     let mut italic_map: HashMap<String, bool> = HashMap::new();
     // ECMA-376 §21.1.2.3.13 cap="all"/"small" on the master txStyles defRPr —
@@ -2663,27 +3054,41 @@ fn parse_master_txstyle_bold_italic(master_xml: &str) -> (HashMap<String, bool>,
         Err(_) => return (bold_map, italic_map, caps_map),
     };
     let root = doc.root_element();
-    let Some(tx_styles) = child(root, "txStyles") else { return (bold_map, italic_map, caps_map); };
+    let Some(tx_styles) = child(root, "txStyles") else {
+        return (bold_map, italic_map, caps_map);
+    };
     let style_ph_map: &[(&str, &[&str])] = &[
-        ("titleStyle",  &["title", "ctrTitle"]),
-        ("bodyStyle",   &["body", "subTitle", "obj", ""]),
-        ("otherStyle",  &["dt", "ftr", "sldNum"]),
+        ("titleStyle", &["title", "ctrTitle"]),
+        ("bodyStyle", &["body", "subTitle", "obj", ""]),
+        ("otherStyle", &["dt", "ftr", "sldNum"]),
     ];
     for (style_name, ph_types) in style_ph_map {
         let def_rpr = child(tx_styles, style_name)
             .and_then(|sn| child(sn, "lvl1pPr"))
             .and_then(|lp| child(lp, "defRPr"));
-        let b = def_rpr.and_then(|rp| attr(&rp, "b")).map(|v| v == "1" || v == "true");
-        let i = def_rpr.and_then(|rp| attr(&rp, "i")).map(|v| v == "1" || v == "true");
-        let c = def_rpr.and_then(|rp| attr(&rp, "cap")).filter(|v| v == "all" || v == "small");
+        let b = def_rpr
+            .and_then(|rp| attr(&rp, "b"))
+            .map(|v| v == "1" || v == "true");
+        let i = def_rpr
+            .and_then(|rp| attr(&rp, "i"))
+            .map(|v| v == "1" || v == "true");
+        let c = def_rpr
+            .and_then(|rp| attr(&rp, "cap"))
+            .filter(|v| v == "all" || v == "small");
         if let Some(bv) = b {
-            for t in *ph_types { bold_map.entry(t.to_string()).or_insert(bv); }
+            for t in *ph_types {
+                bold_map.entry(t.to_string()).or_insert(bv);
+            }
         }
         if let Some(iv) = i {
-            for t in *ph_types { italic_map.entry(t.to_string()).or_insert(iv); }
+            for t in *ph_types {
+                italic_map.entry(t.to_string()).or_insert(iv);
+            }
         }
         if let Some(cv) = c {
-            for t in *ph_types { caps_map.entry(t.to_string()).or_insert(cv.clone()); }
+            for t in *ph_types {
+                caps_map.entry(t.to_string()).or_insert(cv.clone());
+            }
         }
     }
     (bold_map, italic_map, caps_map)
@@ -2706,8 +3111,13 @@ fn parse_master_txstyle_color(
 
     // Scan master spTree placeholder shapes first — per-shape lstStyle is more specific.
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
-        for sp in sp_tree.children().filter(|n| n.is_element() && n.tag_name().name() == "sp") {
-            let ph_node = sp.descendants().find(|n| n.is_element() && n.tag_name().name() == "ph");
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            let ph_node = sp
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "ph");
             if let Some(ph) = ph_node {
                 let ph_type = attr(&ph, "type").unwrap_or_default();
                 if let Some(color) = child(sp, "txBody")
@@ -2726,9 +3136,9 @@ fn parse_master_txstyle_color(
     // Fall back to p:txStyles > titleStyle/bodyStyle/otherStyle > lvl1pPr > defRPr > solidFill.
     if let Some(tx_styles) = child(root, "txStyles") {
         let style_ph_map: &[(&str, &[&str])] = &[
-            ("titleStyle",  &["title", "ctrTitle"]),
-            ("bodyStyle",   &["body", "subTitle", "obj", ""]),
-            ("otherStyle",  &["dt", "ftr", "sldNum"]),
+            ("titleStyle", &["title", "ctrTitle"]),
+            ("bodyStyle", &["body", "subTitle", "obj", ""]),
+            ("otherStyle", &["dt", "ftr", "sldNum"]),
         ];
         for (style_name, ph_types) in style_ph_map {
             if let Some(color) = child(tx_styles, style_name)
@@ -2753,10 +3163,16 @@ fn parse_master_txstyle_color(
 /// Note: line_spacing_map is intentionally NOT populated. Inheriting txStyles lnSpc hurts VRT
 /// scores because our font substitutes (sans-serif) have different em-square metrics than the
 /// original Aptos font, so applying the master's 120% line spacing over-expands text layout.
-fn parse_master_txstyle_spacing(master_xml: &str) -> (HashMap<String, i64>, HashMap<String, i64>, HashMap<String, f64>) {
+fn parse_master_txstyle_spacing(
+    master_xml: &str,
+) -> (
+    HashMap<String, i64>,
+    HashMap<String, i64>,
+    HashMap<String, f64>,
+) {
     let mut before_map: HashMap<String, i64> = HashMap::new();
-    let mut after_map:  HashMap<String, i64> = HashMap::new();
-    let line_map:       HashMap<String, f64> = HashMap::new(); // intentionally not populated
+    let mut after_map: HashMap<String, i64> = HashMap::new();
+    let line_map: HashMap<String, f64> = HashMap::new(); // intentionally not populated
     let doc = match roxmltree::Document::parse(master_xml) {
         Ok(d) => d,
         Err(_) => return (before_map, after_map, line_map),
@@ -2767,15 +3183,17 @@ fn parse_master_txstyle_spacing(master_xml: &str) -> (HashMap<String, i64>, Hash
         None => return (before_map, after_map, line_map),
     };
     let style_ph_map: &[(&str, &[&str])] = &[
-        ("titleStyle",  &["title", "ctrTitle"]),
-        ("bodyStyle",   &["body", "subTitle", "obj", ""]),
-        ("otherStyle",  &["dt", "ftr", "sldNum"]),
+        ("titleStyle", &["title", "ctrTitle"]),
+        ("bodyStyle", &["body", "subTitle", "obj", ""]),
+        ("otherStyle", &["dt", "ftr", "sldNum"]),
     ];
     for (style_name, ph_types) in style_ph_map {
         let lvl1 = child(tx_styles, style_name).and_then(|sn| child(sn, "lvl1pPr"));
-        let spc_before = lvl1.and_then(|lp| child(lp, "spcBef"))
+        let spc_before = lvl1
+            .and_then(|lp| child(lp, "spcBef"))
             .and_then(|s| child(s, "spcPts").and_then(|n| attr_i64(&n, "val")));
-        let spc_after = lvl1.and_then(|lp| child(lp, "spcAft"))
+        let spc_after = lvl1
+            .and_then(|lp| child(lp, "spcAft"))
             .and_then(|s| child(s, "spcPts").and_then(|n| attr_i64(&n, "val")));
         if let Some(v) = spc_before {
             for ph_type in *ph_types {
@@ -2799,8 +3217,12 @@ fn parse_master_transforms(master_xml: &str) -> HashMap<String, Transform> {
     };
     let root = doc.root_element();
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
-        for sp in sp_tree.children().filter(|n| n.is_element() && n.tag_name().name() == "sp") {
-            let ph_node = sp.descendants()
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            let ph_node = sp
+                .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "ph");
             if let Some(ph) = ph_node {
                 let ph_type = attr(&ph, "type").unwrap_or_default();
@@ -2813,7 +3235,22 @@ fn parse_master_transforms(master_xml: &str) -> HashMap<String, Transform> {
     map
 }
 
-fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<String, f64>, master_level_font_sizes: &HashMap<String, LevelFontSizes>, master_level_bullets: &HashMap<String, LevelBullets>, master_anchors: &HashMap<String, String>, master_transforms: &HashMap<String, Transform>, master_alignments: &HashMap<String, String>, master_space_before: &HashMap<String, i64>, master_space_after: &HashMap<String, i64>, master_line_spacing: &HashMap<String, f64>, theme: &HashMap<String, String>, layout_dir: &str, layout_rels: &HashMap<String, String>, zip: &mut PptxZip<'_>) -> LayoutPlaceholders {
+fn parse_layout_placeholders(
+    layout_xml: &str,
+    master_font_sizes: &HashMap<String, f64>,
+    master_level_font_sizes: &HashMap<String, LevelFontSizes>,
+    master_level_bullets: &HashMap<String, LevelBullets>,
+    master_anchors: &HashMap<String, String>,
+    master_transforms: &HashMap<String, Transform>,
+    master_alignments: &HashMap<String, String>,
+    master_space_before: &HashMap<String, i64>,
+    master_space_after: &HashMap<String, i64>,
+    master_line_spacing: &HashMap<String, f64>,
+    theme: &HashMap<String, String>,
+    layout_dir: &str,
+    layout_rels: &HashMap<String, String>,
+    zip: &mut PptxZip<'_>,
+) -> LayoutPlaceholders {
     let mut lph = LayoutPlaceholders::default();
     lph.master_by_type = master_transforms.clone();
     lph.by_type_master_alignment = master_alignments.clone();
@@ -2852,9 +3289,11 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
         let layout_lvl1_ppr: Option<roxmltree::Node<'_, '_>> = child(sp, "txBody")
             .and_then(|tb| child(tb, "lstStyle"))
             .and_then(|ls| child(ls, "lvl1pPr"));
-        let layout_def_rpr: Option<roxmltree::Node<'_, '_>> = layout_lvl1_ppr
-            .and_then(|lp| child(lp, "defRPr"));
-        let layout_font_size = layout_def_rpr.and_then(|rp| attr_f64(&rp, "sz")).map(|v| v / 100.0);
+        let layout_def_rpr: Option<roxmltree::Node<'_, '_>> =
+            layout_lvl1_ppr.and_then(|lp| child(lp, "defRPr"));
+        let layout_font_size = layout_def_rpr
+            .and_then(|rp| attr_f64(&rp, "sz"))
+            .map(|v| v / 100.0);
         // Per-level sizes from the layout placeholder's own lstStyle (all
         // lvlNpPr), used to give nested bullets their shrinking sizes.
         let layout_level_sizes: LevelFontSizes = child(sp, "txBody")
@@ -2864,9 +3303,15 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
         let layout_level_bullets: LevelBullets = child(sp, "txBody")
             .map(|tb| extract_level_bullets(tb, theme))
             .unwrap_or_else(empty_level_bullets);
-        let layout_bold   = layout_def_rpr.and_then(|rp| attr(&rp, "b")).map(|v| v == "1" || v == "true");
-        let layout_italic = layout_def_rpr.and_then(|rp| attr(&rp, "i")).map(|v| v == "1" || v == "true");
-        let layout_caps   = layout_def_rpr.and_then(|rp| attr(&rp, "cap")).filter(|v| v == "all" || v == "small");
+        let layout_bold = layout_def_rpr
+            .and_then(|rp| attr(&rp, "b"))
+            .map(|v| v == "1" || v == "true");
+        let layout_italic = layout_def_rpr
+            .and_then(|rp| attr(&rp, "i"))
+            .map(|v| v == "1" || v == "true");
+        let layout_caps = layout_def_rpr
+            .and_then(|rp| attr(&rp, "cap"))
+            .filter(|v| v == "all" || v == "small");
         let layout_color: Option<String> = layout_def_rpr
             .and_then(|rp| child(rp, "solidFill"))
             .and_then(|sf| parse_color_node(sf, theme));
@@ -2894,8 +3339,7 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
             .map(|a| a.to_string());
 
         // Layout spPr > ln stroke (real visible border, not edit-mode indicator when solidFill is present)
-        let layout_stroke: Option<Stroke> = child(sp_pr, "ln")
-            .and_then(|n| parse_stroke(n, theme));
+        let layout_stroke: Option<Stroke> = child(sp_pr, "ln").and_then(|n| parse_stroke(n, theme));
 
         // Layout spPr fill (solidFill / noFill / gradFill / pattFill). The
         // slide-level placeholder shape inherits this when its own `<p:spPr>` is
@@ -2906,20 +3350,19 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
 
         // Layout spPr > blipFill → image that bleeds through when the slide's
         // matching placeholder has no own blipFill (picture placeholder inheritance).
-        let layout_blip_fill: Option<InheritedBlipFill> = child(sp_pr, "blipFill")
-            .and_then(|bf| {
-                let rid = child(bf, "blip").and_then(|b| attr_r(&b, "embed"))?;
-                let rel_target = layout_rels.get(&rid)?;
-                let image_path = resolve_path(layout_dir, rel_target);
-                let bytes = read_zip_bytes(zip, &image_path)?;
-                let mime = mime_from_ext(&image_path);
-                let data_url = format!("data:{mime};base64,{}", B64.encode(&bytes));
-                Some(InheritedBlipFill {
-                    data_url,
-                    src_rect: parse_src_rect(bf),
-                    alpha: parse_blip_alpha(bf),
-                })
-            });
+        let layout_blip_fill: Option<InheritedBlipFill> = child(sp_pr, "blipFill").and_then(|bf| {
+            let rid = child(bf, "blip").and_then(|b| attr_r(&b, "embed"))?;
+            let rel_target = layout_rels.get(&rid)?;
+            let image_path = resolve_path(layout_dir, rel_target);
+            let bytes = read_zip_bytes(zip, &image_path)?;
+            let mime = mime_from_ext(&image_path);
+            let data_url = format!("data:{mime};base64,{}", B64.encode(&bytes));
+            Some(InheritedBlipFill {
+                data_url,
+                src_rect: parse_src_rect(bf),
+                alpha: parse_blip_alpha(bf),
+            })
+        });
 
         if let Some(ph) = ph_node {
             let ph_type = attr(&ph, "type").unwrap_or_default();
@@ -2930,8 +3373,7 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
                     lph.by_idx.entry(idx).or_insert_with(|| t.clone());
                 }
                 // Prefer layout font size; fall back to master
-                let fs = layout_font_size
-                    .or_else(|| master_font_sizes.get(&ph_type).copied());
+                let fs = layout_font_size.or_else(|| master_font_sizes.get(&ph_type).copied());
                 if let Some(fs) = fs {
                     lph.by_idx_font_size.entry(idx).or_insert(fs);
                 }
@@ -2968,8 +3410,8 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
                     lph.by_idx_fill.entry(idx).or_insert(f.clone());
                 }
             }
-            let effective_fs = layout_font_size
-                .or_else(|| master_font_sizes.get(&ph_type).copied());
+            let effective_fs =
+                layout_font_size.or_else(|| master_font_sizes.get(&ph_type).copied());
             if let Some(fs) = effective_fs {
                 lph.by_type_font_size.entry(ph_type.clone()).or_insert(fs);
             }
@@ -2978,7 +3420,9 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
                 master_level_font_sizes.get(&ph_type).unwrap_or(&[None; 9]),
             );
             if has_any_level_size(&type_level_sizes) {
-                lph.by_type_level_sizes.entry(ph_type.clone()).or_insert(type_level_sizes);
+                lph.by_type_level_sizes
+                    .entry(ph_type.clone())
+                    .or_insert(type_level_sizes);
             }
             let empty_bul_t = empty_level_bullets();
             let type_level_bullets = merge_level_bullets(
@@ -2986,7 +3430,9 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
                 master_level_bullets.get(&ph_type).unwrap_or(&empty_bul_t),
             );
             if has_any_level_bullet(&type_level_bullets) {
-                lph.by_type_level_bullets.entry(ph_type.clone()).or_insert(type_level_bullets);
+                lph.by_type_level_bullets
+                    .entry(ph_type.clone())
+                    .or_insert(type_level_bullets);
             }
             if let Some(b) = layout_bold {
                 lph.by_type_bold.entry(ph_type.clone()).or_insert(b);
@@ -3007,10 +3453,13 @@ fn parse_layout_placeholders(layout_xml: &str, master_font_sizes: &HashMap<Strin
                 lph.by_type_space_after.entry(ph_type.clone()).or_insert(v);
             }
             if let Some(ls) = layout_line_spacing {
-                lph.by_type_line_spacing.entry(ph_type.clone()).or_insert(ls);
+                lph.by_type_line_spacing
+                    .entry(ph_type.clone())
+                    .or_insert(ls);
             }
             // Anchor: layout bodyPr > fall back to master anchor map
-            let effective_anchor = layout_anchor.clone()
+            let effective_anchor = layout_anchor
+                .clone()
                 .or_else(|| master_anchors.get(&ph_type).cloned());
             if let Some(a) = effective_anchor {
                 lph.by_type_anchor.entry(ph_type.clone()).or_insert(a);
@@ -3080,19 +3529,18 @@ fn parse_text_body(
     // instead of what the theme author intended.
     // Shape-kind-aware lookup: text boxes consult txDef, regular shapes spDef.
     // Cross-fall is intentionally NOT done — see ShapeKind doc.
-    let def_prefix = match shape_kind { ShapeKind::Tx => "+txDef", ShapeKind::Sp => "+spDef" };
-    let theme_default_str = |key: &str| -> Option<String> {
-        theme.get(&format!("{def_prefix}-bodyPr-{key}")).cloned()
+    let def_prefix = match shape_kind {
+        ShapeKind::Tx => "+txDef",
+        ShapeKind::Sp => "+spDef",
     };
-    let theme_default_i64 = |key: &str| -> Option<i64> {
-        theme_default_str(key).and_then(|v| v.parse::<i64>().ok())
-    };
-    let theme_default_u32 = |key: &str| -> Option<u32> {
-        theme_default_str(key).and_then(|v| v.parse::<u32>().ok())
-    };
-    let theme_auto_fit = || -> Option<String> {
-        theme.get(&format!("{def_prefix}-autoFit")).cloned()
-    };
+    let theme_default_str =
+        |key: &str| -> Option<String> { theme.get(&format!("{def_prefix}-bodyPr-{key}")).cloned() };
+    let theme_default_i64 =
+        |key: &str| -> Option<i64> { theme_default_str(key).and_then(|v| v.parse::<i64>().ok()) };
+    let theme_default_u32 =
+        |key: &str| -> Option<u32> { theme_default_str(key).and_then(|v| v.parse::<u32>().ok()) };
+    let theme_auto_fit =
+        || -> Option<String> { theme.get(&format!("{def_prefix}-autoFit")).cloned() };
 
     let vertical_anchor = body_pr
         .and_then(|n| attr(&n, "anchor"))
@@ -3102,22 +3550,28 @@ fn parse_text_body(
         .unwrap_or_else(|| "t".into());
     // Text insets (EMU). OOXML defaults: lIns=rIns=91440, tIns=bIns=45720.
     // Shape attribute → theme objectDefaults → spec default.
-    let l_ins = body_pr.and_then(|n| attr_i64(&n, "lIns"))
+    let l_ins = body_pr
+        .and_then(|n| attr_i64(&n, "lIns"))
         .or_else(|| theme_default_i64("lIns"))
         .unwrap_or(91_440);
-    let r_ins = body_pr.and_then(|n| attr_i64(&n, "rIns"))
+    let r_ins = body_pr
+        .and_then(|n| attr_i64(&n, "rIns"))
         .or_else(|| theme_default_i64("rIns"))
         .unwrap_or(91_440);
-    let t_ins = body_pr.and_then(|n| attr_i64(&n, "tIns"))
+    let t_ins = body_pr
+        .and_then(|n| attr_i64(&n, "tIns"))
         .or_else(|| theme_default_i64("tIns"))
         .unwrap_or(45_720);
-    let b_ins = body_pr.and_then(|n| attr_i64(&n, "bIns"))
+    let b_ins = body_pr
+        .and_then(|n| attr_i64(&n, "bIns"))
         .or_else(|| theme_default_i64("bIns"))
         .unwrap_or(45_720);
-    let wrap = body_pr.and_then(|n| attr(&n, "wrap"))
+    let wrap = body_pr
+        .and_then(|n| attr(&n, "wrap"))
         .or_else(|| theme_default_str("wrap"))
         .unwrap_or_else(|| "square".into());
-    let vert = body_pr.and_then(|n| attr(&n, "vert"))
+    let vert = body_pr
+        .and_then(|n| attr(&n, "vert"))
         .or_else(|| theme_default_str("vert"))
         .unwrap_or_else(|| "horz".into());
     // Auto-fit child element (spAutoFit / normAutofit). When the shape's own
@@ -3128,15 +3582,17 @@ fn parse_text_body(
     let mut font_scale: Option<f64> = None;
     let mut ln_spc_reduction: Option<f64> = None;
     let auto_fit = if let Some(n) = body_pr {
-        if child(n, "spAutoFit").is_some() { "sp".to_owned() }
+        if child(n, "spAutoFit").is_some() {
+            "sp".to_owned()
+        }
         // OOXML uses lowercase 'f': normAutofit (not normAutoFit).
         else if let Some(na) = child(n, "normAutofit") {
             font_scale = attr_f64(&na, "fontScale").map(|v| v / 100000.0);
             ln_spc_reduction = attr_f64(&na, "lnSpcReduction").map(|v| v / 100000.0);
             "norm".to_owned()
-        }
-        else if child(n, "noAutofit").is_some() { "none".to_owned() }
-        else {
+        } else if child(n, "noAutofit").is_some() {
+            "none".to_owned()
+        } else {
             // bodyPr present but no autofit child — fall back to theme.
             theme_auto_fit().unwrap_or_else(|| "none".to_owned())
         }
@@ -3167,10 +3623,10 @@ fn parse_text_body(
         .unwrap_or(false);
 
     // Own lstStyle > lvl1pPr, then fall back to layout/master inherited values
-    let own_lvl1_ppr = child(tx_body, "lstStyle")
-        .and_then(|ls| child(ls, "lvl1pPr"));
+    let own_lvl1_ppr = child(tx_body, "lstStyle").and_then(|ls| child(ls, "lvl1pPr"));
     let own_def_rpr = own_lvl1_ppr.and_then(|lp| child(lp, "defRPr"));
-    let default_font_size = own_def_rpr.and_then(|rp| attr_f64(&rp, "sz"))
+    let default_font_size = own_def_rpr
+        .and_then(|rp| attr_f64(&rp, "sz"))
         .map(|v| v / 100.0)
         .or(inherited_font_size);
     // Effective per-list-level default sizes: this shape's own lstStyle wins per
@@ -3184,10 +3640,12 @@ fn parse_text_body(
     let own_level_bullets = extract_level_bullets(tx_body, theme);
     let effective_level_bullets = merge_level_bullets(&own_level_bullets, inherited_level_bullets);
     let default_bold = own_def_rpr
-        .and_then(|rp| attr(&rp, "b")).map(|v| v == "1" || v == "true")
+        .and_then(|rp| attr(&rp, "b"))
+        .map(|v| v == "1" || v == "true")
         .or(inherited_bold);
     let default_italic = own_def_rpr
-        .and_then(|rp| attr(&rp, "i")).map(|v| v == "1" || v == "true")
+        .and_then(|rp| attr(&rp, "i"))
+        .map(|v| v == "1" || v == "true")
         .or(inherited_italic);
     // Own lstStyle > lvl1pPr > algn overrides inherited alignment
     let body_default_alignment = own_lvl1_ppr
@@ -3205,7 +3663,7 @@ fn parse_text_body(
         .and_then(|s| child(s, "spcPts"))
         .and_then(|s| attr_i64(&s, "val"));
     let body_default_space_before = own_lvl1_spcbef.or(inherited_space_before);
-    let body_default_space_after  = own_lvl1_spcaft.or(inherited_space_after);
+    let body_default_space_after = own_lvl1_spcaft.or(inherited_space_after);
 
     // Own lstStyle > lvl1pPr > lnSpc overrides inherited line spacing
     let own_lvl1_line_spacing: Option<f64> = own_lvl1_ppr
@@ -3216,7 +3674,19 @@ fn parse_text_body(
 
     let mut paragraphs: Vec<Paragraph> = children_vec(tx_body, "p")
         .into_iter()
-        .map(|p| parse_paragraph(p, theme, rels, body_default_alignment.as_deref(), body_default_space_before, body_default_space_after, body_default_line_spacing, &effective_level_sizes, &effective_level_bullets))
+        .map(|p| {
+            parse_paragraph(
+                p,
+                theme,
+                rels,
+                body_default_alignment.as_deref(),
+                body_default_space_before,
+                body_default_space_after,
+                body_default_line_spacing,
+                &effective_level_sizes,
+                &effective_level_bullets,
+            )
+        })
         .collect();
 
     // ECMA-376 §21.1.2.3.13 cap: a run inherits cap="all"/"small" from the
@@ -3232,13 +3702,33 @@ fn parse_text_body(
         for para in &mut paragraphs {
             for run in &mut para.runs {
                 if let TextRun::Text(t) = run {
-                    if t.caps.is_none() { t.caps = Some(bc.clone()); }
+                    if t.caps.is_none() {
+                        t.caps = Some(bc.clone());
+                    }
                 }
             }
         }
     }
 
-    TextBody { vertical_anchor, paragraphs, default_font_size, default_bold, default_italic, l_ins, r_ins, t_ins, b_ins, wrap, vert, auto_fit, font_scale, ln_spc_reduction, num_col, spc_col, rtl_col }
+    TextBody {
+        vertical_anchor,
+        paragraphs,
+        default_font_size,
+        default_bold,
+        default_italic,
+        l_ins,
+        r_ins,
+        t_ins,
+        b_ins,
+        wrap,
+        vert,
+        auto_fit,
+        font_scale,
+        ln_spc_reduction,
+        num_col,
+        spc_col,
+        rtl_col,
+    }
 }
 
 /// Walk `node` for OMML math and push a `TextRun::Math` for each equation,
@@ -3337,21 +3827,29 @@ fn parse_paragraph(
     // and the paragraph has no explicit `algn`, the implicit default flips
     // from "l" to "r" (matches PowerPoint's behaviour for Arabic / Hebrew
     // slides where users typically don't author an explicit alignment).
-    let rtl = p_pr.and_then(|n| attr(&n, "rtl"))
+    let rtl = p_pr
+        .and_then(|n| attr(&n, "rtl"))
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
 
     // Paragraph's own algn → body/layout/master default → "r" if rtl, else "l"
-    let alignment = p_pr.and_then(|n| attr(&n, "algn"))
+    let alignment = p_pr
+        .and_then(|n| attr(&n, "algn"))
         .map(|a| a.to_string())
         .or_else(|| body_default_alignment.map(|a| a.to_string()))
         .unwrap_or_else(|| if rtl { "r".into() } else { "l".into() });
-    let lvl: u32   = p_pr.and_then(|n| attr(&n, "lvl")).and_then(|v| v.parse().ok()).unwrap_or(0);
+    let lvl: u32 = p_pr
+        .and_then(|n| attr(&n, "lvl"))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
 
     // Effective bullet: the paragraph's own `<a:buChar>`/`<a:buAutoNum>`/`<a:buNone>`,
     // else the inherited per-level bullet for this placeholder (ECMA-376 §19.7.10).
     let bullet = match parse_bullet(p_pr, theme) {
-        Bullet::Inherit => level_bullets.get(lvl as usize).and_then(|o| o.clone()).unwrap_or(Bullet::Inherit),
+        Bullet::Inherit => level_bullets
+            .get(lvl as usize)
+            .and_then(|o| o.clone())
+            .unwrap_or(Bullet::Inherit),
         b => b,
     };
     // A paragraph is a list item (and gets a hanging indent) when its effective
@@ -3370,28 +3868,38 @@ fn parse_paragraph(
             lvl as i64 * 457200
         }
     });
-    let mar_r  = p_pr.and_then(|n| attr_i64(&n, "marR")).unwrap_or(0);
-    let indent = p_pr.and_then(|n| attr_i64(&n, "indent")).unwrap_or_else(|| {
-        if has_bullet { -342900 } else { 0 }
-    });
+    let mar_r = p_pr.and_then(|n| attr_i64(&n, "marR")).unwrap_or(0);
+    let indent = p_pr
+        .and_then(|n| attr_i64(&n, "indent"))
+        .unwrap_or_else(|| if has_bullet { -342900 } else { 0 });
 
-    let space_before = p_pr.and_then(|n| {
-        child(n, "spcBef").and_then(|s| child(s, "spcPts")).and_then(|s| attr_i64(&s, "val"))
-    }).or(body_default_space_before);
-    let space_after = p_pr.and_then(|n| {
-        child(n, "spcAft").and_then(|s| child(s, "spcPts")).and_then(|s| attr_i64(&s, "val"))
-    }).or(body_default_space_after);
+    let space_before = p_pr
+        .and_then(|n| {
+            child(n, "spcBef")
+                .and_then(|s| child(s, "spcPts"))
+                .and_then(|s| attr_i64(&s, "val"))
+        })
+        .or(body_default_space_before);
+    let space_after = p_pr
+        .and_then(|n| {
+            child(n, "spcAft")
+                .and_then(|s| child(s, "spcPts"))
+                .and_then(|s| attr_i64(&s, "val"))
+        })
+        .or(body_default_space_after);
 
-    let space_line = p_pr.and_then(|n| {
-        let spc = child(n, "lnSpc")?;
-        if let Some(pct) = child(spc, "spcPct") {
-            attr_f64(&pct, "val").map(|v| SpaceLine::Pct { val: v })
-        } else {
-            child(spc, "spcPts")
-                .and_then(|pts| attr_f64(&pts, "val"))
-                .map(|v| SpaceLine::Pts { val: v / 100.0 }) // hundredths of pt → pt
-        }
-    }).or_else(|| body_default_line_spacing.map(|v| SpaceLine::Pct { val: v }));
+    let space_line = p_pr
+        .and_then(|n| {
+            let spc = child(n, "lnSpc")?;
+            if let Some(pct) = child(spc, "spcPct") {
+                attr_f64(&pct, "val").map(|v| SpaceLine::Pct { val: v })
+            } else {
+                child(spc, "spcPts")
+                    .and_then(|pts| attr_f64(&pts, "val"))
+                    .map(|v| SpaceLine::Pts { val: v / 100.0 }) // hundredths of pt → pt
+            }
+        })
+        .or_else(|| body_default_line_spacing.map(|v| SpaceLine::Pct { val: v }));
 
     // Tab stops from pPr > tabLst
     let tab_stops: Vec<TabStop> = p_pr
@@ -3401,7 +3909,7 @@ fn parse_paragraph(
                 .children()
                 .filter(|n| n.is_element() && n.tag_name().name() == "tab")
                 .filter_map(|tab| {
-                    let pos  = attr_i64(&tab, "pos")?;
+                    let pos = attr_i64(&tab, "pos")?;
                     let algn = attr(&tab, "algn").unwrap_or_else(|| "l".into());
                     Some(TabStop { pos, algn })
                 })
@@ -3410,12 +3918,20 @@ fn parse_paragraph(
         .unwrap_or_default();
 
     // Paragraph-level default run properties (pPr > defRPr)
-    let def_rpr        = p_pr.and_then(|n| child(n, "defRPr"));
-    let def_font_size  = def_rpr.and_then(|n| attr_f64(&n, "sz")).map(|v| v / 100.0);
-    let def_color      = def_rpr.and_then(|n| child(n, "solidFill")).and_then(|n| parse_color_node(n, theme));
-    let def_bold       = def_rpr.and_then(|n| attr(&n, "b")).map(|v| v == "1" || v == "true");
-    let def_italic     = def_rpr.and_then(|n| attr(&n, "i")).map(|v| v == "1" || v == "true");
-    let def_font_family = def_rpr.and_then(|n| child(n, "latin")).and_then(|n| attr(&n, "typeface"))
+    let def_rpr = p_pr.and_then(|n| child(n, "defRPr"));
+    let def_font_size = def_rpr.and_then(|n| attr_f64(&n, "sz")).map(|v| v / 100.0);
+    let def_color = def_rpr
+        .and_then(|n| child(n, "solidFill"))
+        .and_then(|n| parse_color_node(n, theme));
+    let def_bold = def_rpr
+        .and_then(|n| attr(&n, "b"))
+        .map(|v| v == "1" || v == "true");
+    let def_italic = def_rpr
+        .and_then(|n| attr(&n, "i"))
+        .map(|v| v == "1" || v == "true");
+    let def_font_family = def_rpr
+        .and_then(|n| child(n, "latin"))
+        .and_then(|n| attr(&n, "typeface"))
         .map(|tf| resolve_theme_typeface(&tf, theme));
 
     let mut runs = Vec::new();
@@ -3438,13 +3954,24 @@ fn parse_paragraph(
             // Field elements (e.g. slide number, date): parse like a run but tag the field type
             "fld" => {
                 let fld_type = attr(&node, "type").unwrap_or_default().to_string();
-                let text = child(node, "t").and_then(|t| t.text()).unwrap_or("").to_string();
+                let text = child(node, "t")
+                    .and_then(|t| t.text())
+                    .unwrap_or("")
+                    .to_string();
                 let r_pr = child(node, "rPr");
                 let font_size = r_pr.and_then(|n| attr_f64(&n, "sz")).map(|v| v / 100.0);
-                let color = r_pr.and_then(|n| child(n, "solidFill")).and_then(|n| parse_color_node(n, theme));
-                let bold = r_pr.and_then(|n| attr(&n, "b")).map(|v| v == "1" || v == "true");
-                let italic = r_pr.and_then(|n| attr(&n, "i")).map(|v| v == "1" || v == "true");
-                let font_family = r_pr.and_then(|n| child(n, "latin")).and_then(|n| attr(&n, "typeface"))
+                let color = r_pr
+                    .and_then(|n| child(n, "solidFill"))
+                    .and_then(|n| parse_color_node(n, theme));
+                let bold = r_pr
+                    .and_then(|n| attr(&n, "b"))
+                    .map(|v| v == "1" || v == "true");
+                let italic = r_pr
+                    .and_then(|n| attr(&n, "i"))
+                    .map(|v| v == "1" || v == "true");
+                let font_family = r_pr
+                    .and_then(|n| child(n, "latin"))
+                    .and_then(|n| attr(&n, "typeface"))
                     .map(|tf| resolve_theme_typeface(&tf, theme));
                 runs.push(TextRun::Text(TextRunData {
                     text,
@@ -3462,7 +3989,11 @@ fn parse_paragraph(
                     baseline: None,
                     caps: None,
                     letter_spacing: None,
-                    field_type: if fld_type == "slidenum" { Some("slidenum".to_string()) } else { None },
+                    field_type: if fld_type == "slidenum" {
+                        Some("slidenum".to_string())
+                    } else {
+                        None
+                    },
                     hyperlink: None,
                     shadow: None,
                     outline: None,
@@ -3491,22 +4022,31 @@ fn parse_paragraph(
         .or_else(|| level_font_sizes.get(lvl as usize).copied().flatten());
 
     Paragraph {
-        alignment, mar_l, mar_r, indent,
-        space_before, space_after, space_line,
-        lvl, bullet,
-        def_font_size, def_color, def_bold, def_italic, def_font_family,
-        tab_stops, rtl, runs,
+        alignment,
+        mar_l,
+        mar_r,
+        indent,
+        space_before,
+        space_after,
+        space_line,
+        lvl,
+        bullet,
+        def_font_size,
+        def_color,
+        def_bold,
+        def_italic,
+        def_font_family,
+        tab_stops,
+        rtl,
+        runs,
     }
 }
 
 /// Parse bullet specification from pPr node.
-fn parse_bullet(
-    p_pr: Option<roxmltree::Node<'_, '_>>,
-    theme: &HashMap<String, String>,
-) -> Bullet {
+fn parse_bullet(p_pr: Option<roxmltree::Node<'_, '_>>, theme: &HashMap<String, String>) -> Bullet {
     let p_pr = match p_pr {
         Some(n) => n,
-        None    => return Bullet::Inherit,
+        None => return Bullet::Inherit,
     };
 
     // Explicit "no bullet"
@@ -3522,9 +4062,15 @@ fn parse_bullet(
         let size_pct = child(p_pr, "buSzPct")
             .and_then(|n| attr_f64(&n, "val"))
             .map(|v| v / 1000.0);
-        let font_family = child(p_pr, "buFont").and_then(|n| attr(&n, "typeface"))
+        let font_family = child(p_pr, "buFont")
+            .and_then(|n| attr(&n, "typeface"))
             .map(|tf| resolve_theme_typeface(&tf, theme));
-        return Bullet::Char { ch, color, size_pct, font_family };
+        return Bullet::Char {
+            ch,
+            color,
+            size_pct,
+            font_family,
+        };
     }
 
     // Auto-numbered bullet
@@ -3544,76 +4090,105 @@ fn parse_run(
     rels: &HashMap<String, String>,
 ) -> Option<TextRunData> {
     let t_node = child(r_node, "t")?;
-    let text  = t_node.text().unwrap_or("").to_owned();
-    let r_pr  = child(r_node, "rPr");
+    let text = t_node.text().unwrap_or("").to_owned();
+    let r_pr = child(r_node, "rPr");
 
     // Attribute with rPr → defRPr fallback; None means "not set" (inherit from body/layout defaults)
-    let bold = r_pr.and_then(|n| attr(&n, "b"))
+    let bold = r_pr
+        .and_then(|n| attr(&n, "b"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "b")))
         .map(|v| v == "1" || v == "true");
-    let italic = r_pr.and_then(|n| attr(&n, "i"))
+    let italic = r_pr
+        .and_then(|n| attr(&n, "i"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "i")))
         .map(|v| v == "1" || v == "true");
     // ECMA-376 §21.1.2.3.16 — underline style enum: none/sng/dbl/heavy/dotted/
     // dash/dashLong/dotDash/dotDotDash/wavy plus *Heavy variants. Carry the
     // exact value through for the renderer to dispatch on; the bool stays
     // true for any non-"none" value so existing code paths keep working.
-    let underline_attr = r_pr.and_then(|n| attr(&n, "u"))
+    let underline_attr = r_pr
+        .and_then(|n| attr(&n, "u"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "u")));
-    let underline = underline_attr.as_deref().map(|v| v != "none").unwrap_or(false);
+    let underline = underline_attr
+        .as_deref()
+        .map(|v| v != "none")
+        .unwrap_or(false);
     let underline_style = underline_attr.filter(|v| v != "none" && v != "sng");
 
     // ECMA-376 §21.1.2.3.20 — uFill specifies a per-underline colour that
     // overrides the text colour. uFillTx (or absence) means "follow text".
-    let underline_color = r_pr.and_then(|n| child(n, "uFill"))
+    let underline_color = r_pr
+        .and_then(|n| child(n, "uFill"))
         .or_else(|| def_rpr.and_then(|n| child(n, "uFill")))
         .and_then(|n| child(n, "solidFill"))
         .and_then(|n| parse_color_node(n, theme));
 
     // strikethrough: "sngStrike" or "dblStrike" → true; double tracked separately
-    let strike_attr = r_pr.and_then(|n| attr(&n, "strike"))
+    let strike_attr = r_pr
+        .and_then(|n| attr(&n, "strike"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "strike")));
-    let strikethrough = strike_attr.as_deref().map(|v| v == "sngStrike" || v == "dblStrike").unwrap_or(false);
+    let strikethrough = strike_attr
+        .as_deref()
+        .map(|v| v == "sngStrike" || v == "dblStrike")
+        .unwrap_or(false);
     let strike_double = strike_attr.as_deref() == Some("dblStrike");
 
     // ECMA-376 §21.1.2.3.13 ST_TextCapsType: "none" | "small" | "all". Treat
     // "none" as not set (no transform) so the field stays absent in JSON.
-    let caps = r_pr.and_then(|n| attr(&n, "cap"))
+    let caps = r_pr
+        .and_then(|n| attr(&n, "cap"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "cap")))
         .filter(|v| v == "small" || v == "all");
 
     // ECMA-376 §21.1.2.3.5 rPr @spc — letter spacing in 100ths of a point.
     // Negative values are valid (tightening). Non-zero only.
-    let letter_spacing = r_pr.and_then(|n| attr_f64(&n, "spc"))
+    let letter_spacing = r_pr
+        .and_then(|n| attr_f64(&n, "spc"))
         .or_else(|| def_rpr.and_then(|n| attr_f64(&n, "spc")))
         .map(|v| v / 100.0)
         .filter(|v| v.abs() > f64::EPSILON);
 
     // sz in hundredths of a point
-    let font_size = r_pr.and_then(|n| attr_f64(&n, "sz"))
+    let font_size = r_pr
+        .and_then(|n| attr_f64(&n, "sz"))
         .or_else(|| def_rpr.and_then(|n| attr_f64(&n, "sz")))
         .map(|v| v / 100.0);
 
-    let color = r_pr.and_then(|n| child(n, "solidFill"))
+    let color = r_pr
+        .and_then(|n| child(n, "solidFill"))
         .and_then(|n| parse_color_node(n, theme))
         .or_else(|| {
-            def_rpr.and_then(|n| child(n, "solidFill"))
-                   .and_then(|n| parse_color_node(n, theme))
+            def_rpr
+                .and_then(|n| child(n, "solidFill"))
+                .and_then(|n| parse_color_node(n, theme))
         });
 
-    let font_family = r_pr.and_then(|n| child(n, "latin")).and_then(|n| attr(&n, "typeface"))
-        .or_else(|| def_rpr.and_then(|n| child(n, "latin")).and_then(|n| attr(&n, "typeface")))
+    let font_family = r_pr
+        .and_then(|n| child(n, "latin"))
+        .and_then(|n| attr(&n, "typeface"))
+        .or_else(|| {
+            def_rpr
+                .and_then(|n| child(n, "latin"))
+                .and_then(|n| attr(&n, "typeface"))
+        })
         .map(|tf| resolve_theme_typeface(&tf, theme));
     // ECMA-376 §21.1.2.3.7 — <a:ea typeface="..."/> sets a separate font for
     // East Asian glyphs (CJK). Defaults to the theme's +mn-ea slot when the
     // run doesn't specify one explicitly.
-    let font_family_ea = r_pr.and_then(|n| child(n, "ea")).and_then(|n| attr(&n, "typeface"))
-        .or_else(|| def_rpr.and_then(|n| child(n, "ea")).and_then(|n| attr(&n, "typeface")))
+    let font_family_ea = r_pr
+        .and_then(|n| child(n, "ea"))
+        .and_then(|n| attr(&n, "typeface"))
+        .or_else(|| {
+            def_rpr
+                .and_then(|n| child(n, "ea"))
+                .and_then(|n| attr(&n, "typeface"))
+        })
         .map(|tf| resolve_theme_typeface(&tf, theme))
         .filter(|tf| !tf.is_empty());
 
     // baseline in thousandths of a point; 30000=superscript, -25000=subscript (OOXML typical)
-    let baseline = r_pr.and_then(|n| attr(&n, "baseline"))
+    let baseline = r_pr
+        .and_then(|n| attr(&n, "baseline"))
         .and_then(|v| v.parse::<i32>().ok())
         .filter(|&v| v != 0);
 
@@ -3628,14 +4203,16 @@ fn parse_run(
     // ECMA-376 §20.1.8.45 — `<a:rPr><a:effectLst><a:outerShdw>` glyph drop
     // shadow. Reuse the shape-level outerShdw reader so parse semantics
     // stay identical (blurRad, dist, dir, color + alphaModFix).
-    let shadow = r_pr.and_then(|n| child(n, "effectLst"))
+    let shadow = r_pr
+        .and_then(|n| child(n, "effectLst"))
         .and_then(|el| parse_shadow(el, theme));
 
     // ECMA-376 §20.1.2.2.24 (CT_TextOutlineEffect) — `<a:rPr><a:ln w="..">`
     // strokes each glyph outline. `<a:noFill>` inside the ln means "no
     // visible outline" — skip in that case so the renderer doesn't draw a
     // black box around every glyph. Pull color from solidFill if present.
-    let outline = r_pr.and_then(|n| child(n, "ln"))
+    let outline = r_pr
+        .and_then(|n| child(n, "ln"))
         .filter(|ln| child(*ln, "noFill").is_none())
         .map(|ln| TextOutline {
             width: attr_i64(&ln, "w").unwrap_or(0),
@@ -3643,12 +4220,25 @@ fn parse_run(
         });
 
     Some(TextRunData {
-        text, bold, italic, underline, underline_style, underline_color,
-        strikethrough, strike_double,
-        font_size, color, font_family, font_family_ea, baseline,
-        caps, letter_spacing,
-        field_type: None, hyperlink,
-        shadow, outline,
+        text,
+        bold,
+        italic,
+        underline,
+        underline_style,
+        underline_color,
+        strikethrough,
+        strike_double,
+        font_size,
+        color,
+        font_family,
+        font_family_ea,
+        baseline,
+        caps,
+        letter_spacing,
+        field_type: None,
+        hyperlink,
+        shadow,
+        outline,
     })
 }
 
@@ -3662,27 +4252,32 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     let root = doc.root_element();
 
     // Determine chart type by finding the first recognized chart element
-    let find_chart = |name: &str| root.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == name);
+    let find_chart = |name: &str| {
+        root.descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == name)
+    };
 
     let chart_type = if let Some(bc) = find_chart("barChart") {
-        let grouping = bc.children()
+        let grouping = bc
+            .children()
             .find(|c| c.is_element() && c.tag_name().name() == "grouping")
             .and_then(|n| attr(&n, "val"))
             .unwrap_or_else(|| "clustered".into());
-        let bar_dir = bc.children()
+        let bar_dir = bc
+            .children()
             .find(|c| c.is_element() && c.tag_name().name() == "barDir")
             .and_then(|n| attr(&n, "val"))
             .unwrap_or_else(|| "col".into());
         let horizontal = bar_dir == "bar";
         match (grouping.as_str(), horizontal) {
             ("stacked" | "percentStacked", false) => "stackedBar".to_string(),
-            ("stacked" | "percentStacked", true)  => "stackedBarH".to_string(),
+            ("stacked" | "percentStacked", true) => "stackedBarH".to_string(),
             (_, false) => "clusteredBar".to_string(),
-            (_, true)  => "clusteredBarH".to_string(),
+            (_, true) => "clusteredBarH".to_string(),
         }
     } else if let Some(lc) = find_chart("lineChart") {
-        let grouping = lc.children()
+        let grouping = lc
+            .children()
             .find(|c| c.is_element() && c.tag_name().name() == "grouping")
             .and_then(|n| attr(&n, "val"))
             .unwrap_or_else(|| "standard".into());
@@ -3696,7 +4291,8 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     } else if find_chart("doughnutChart").is_some() {
         "doughnut".to_string()
     } else if let Some(ac) = find_chart("areaChart") {
-        let grouping = ac.children()
+        let grouping = ac
+            .children()
             .find(|c| c.is_element() && c.tag_name().name() == "grouping")
             .and_then(|n| attr(&n, "val"))
             .unwrap_or_else(|| "standard".into());
@@ -3715,49 +4311,72 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     };
 
     // Title text
-    let title_node_opt = root.descendants()
+    let title_node_opt = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "title");
     let title = title_node_opt.and_then(|title_node| {
-        let texts: Vec<String> = title_node.descendants()
+        let texts: Vec<String> = title_node
+            .descendants()
             .filter(|n| n.is_element() && n.tag_name().name() == "t")
             .filter_map(|n| n.text().map(|t| t.to_string()))
             .collect();
-        if texts.is_empty() { None } else { Some(texts.join("")) }
+        if texts.is_empty() {
+            None
+        } else {
+            Some(texts.join(""))
+        }
     });
     // Title font size in hundredths of a point — taken from the first
     // defRPr@sz or rPr@sz we find inside the title. ECMA-376 uses hpt for size.
-    let title_font_size_hpt = title_node_opt
-        .and_then(|t| t.descendants().find_map(|n| {
-            if !n.is_element() { return None; }
+    let title_font_size_hpt = title_node_opt.and_then(|t| {
+        t.descendants().find_map(|n| {
+            if !n.is_element() {
+                return None;
+            }
             let tag = n.tag_name().name();
-            if tag != "defRPr" && tag != "rPr" { return None; }
+            if tag != "defRPr" && tag != "rPr" {
+                return None;
+            }
             attr(&n, "sz").and_then(|v| v.parse::<i32>().ok())
-        }));
+        })
+    });
 
     // val axis max / min and visibility — shared helpers in ooxml-common
     // so xlsx & pptx stay in sync (`<c:scaling><c:min|max val>` and
     // `<c:delete val>` ECMA-376 §21.2.2.40 / §21.2.2.43).
-    let val_ax = root.descendants()
+    let val_ax = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "valAx");
-    let cat_ax = root.descendants()
+    let cat_ax = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "catAx");
     let (val_min, val_max) = val_ax
         .map(ooxml_common::chart::extract_axis_min_max)
         .unwrap_or((None, None));
-    let val_axis_hidden = val_ax.map(ooxml_common::chart::axis_is_deleted).unwrap_or(false);
-    let cat_axis_hidden = cat_ax.map(ooxml_common::chart::axis_is_deleted).unwrap_or(false);
+    let val_axis_hidden = val_ax
+        .map(ooxml_common::chart::axis_is_deleted)
+        .unwrap_or(false);
+    let cat_axis_hidden = cat_ax
+        .map(ooxml_common::chart::axis_is_deleted)
+        .unwrap_or(false);
 
     // Series
-    let plot_area = root.descendants()
+    let plot_area = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "plotArea")?;
 
     // Plot area background: <c:plotArea><c:spPr><a:solidFill>
-    let plot_area_bg = plot_area.children()
+    let plot_area_bg = plot_area
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "spPr")
-        .and_then(|sp| sp.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
+        .and_then(|sp| {
+            sp.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+        })
         .and_then(|fill| parse_color_node(fill, theme));
 
-    let ser_nodes: Vec<_> = plot_area.descendants()
+    let ser_nodes: Vec<_> = plot_area
+        .descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "ser")
         .collect();
 
@@ -3767,18 +4386,21 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
 
     // Helper: collect <c:pt> values from a cache node (strCache or numCache)
     let collect_pt_strings = |cache: roxmltree::Node<'_, '_>| -> Vec<String> {
-        cache.children()
+        cache
+            .children()
             .filter(|n| n.is_element() && n.tag_name().name() == "pt")
-            .filter_map(|pt| pt.children().find(|n| n.is_element() && n.tag_name().name() == "v"))
+            .filter_map(|pt| {
+                pt.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "v")
+            })
             .filter_map(|v| v.text().map(|t| t.to_string()))
             .collect()
     };
 
     // ECMA-376 §21.2.2: category data may be in a *Cache (backing a *Ref) or a *Lit (inline literal).
     // Accept strCache/numCache (external refs with cached values) AND strLit/numLit (inline literals).
-    let is_pt_container = |name: &str| {
-        matches!(name, "strCache" | "numCache" | "strLit" | "numLit")
-    };
+    let is_pt_container =
+        |name: &str| matches!(name, "strCache" | "numCache" | "strLit" | "numLit");
 
     let categories: Vec<String> = ser_nodes[0]
         .children()
@@ -3794,161 +4416,253 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
 
     let is_scatter_like = chart_type == "scatter" || chart_type == "bubble";
 
-    let series: Vec<ChartSeriesData> = ser_nodes.iter().map(|ser| {
-        // Series name from <c:tx>  (can be strRef/strCache, strLit, or a bare <c:v>)
-        let name = ser.children()
-            .find(|n| n.is_element() && n.tag_name().name() == "tx")
-            .and_then(|tx| {
-                // Preferred: first pt > v inside any cache/lit container
-                tx.descendants()
-                    .find(|n| n.is_element() && is_pt_container(n.tag_name().name()))
-                    .and_then(|cache| {
-                        cache.children()
-                            .find(|n| n.is_element() && n.tag_name().name() == "pt")
-                            .and_then(|pt| pt.children().find(|n| n.is_element() && n.tag_name().name() == "v"))
-                            .and_then(|v| v.text().map(|t| t.to_string()))
+    let series: Vec<ChartSeriesData> = ser_nodes
+        .iter()
+        .map(|ser| {
+            // Series name from <c:tx>  (can be strRef/strCache, strLit, or a bare <c:v>)
+            let name = ser
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "tx")
+                .and_then(|tx| {
+                    // Preferred: first pt > v inside any cache/lit container
+                    tx.descendants()
+                        .find(|n| n.is_element() && is_pt_container(n.tag_name().name()))
+                        .and_then(|cache| {
+                            cache
+                                .children()
+                                .find(|n| n.is_element() && n.tag_name().name() == "pt")
+                                .and_then(|pt| {
+                                    pt.children()
+                                        .find(|n| n.is_element() && n.tag_name().name() == "v")
+                                })
+                                .and_then(|v| v.text().map(|t| t.to_string()))
+                        })
+                        // Fallback: <c:tx><c:v>Name</c:v></c:tx>
+                        .or_else(|| {
+                            tx.children()
+                                .find(|n| n.is_element() && n.tag_name().name() == "v")
+                                .and_then(|v| v.text().map(|t| t.to_string()))
+                        })
+                })
+                .unwrap_or_default();
+
+            // Per-series X values for scatter/bubble: ECMA-376 §21.2.2.43 puts numeric
+            // X data in `<c:xVal>` (with its own numCache / numLit) instead of the
+            // shared `<c:cat>`. Read it as strings so the core ChartSeries.categories
+            // field can stay string-typed (renderScatterChart parses each entry back
+            // to a float).
+            let x_cache = if is_scatter_like {
+                ser.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "xVal")
+                    .and_then(|x| {
+                        x.descendants()
+                            .find(|n| n.is_element() && is_pt_container(n.tag_name().name()))
                     })
-                    // Fallback: <c:tx><c:v>Name</c:v></c:tx>
-                    .or_else(|| tx.children()
-                        .find(|n| n.is_element() && n.tag_name().name() == "v")
-                        .and_then(|v| v.text().map(|t| t.to_string())))
-            })
-            .unwrap_or_default();
+            } else {
+                None
+            };
+            let series_categories: Option<Vec<String>> =
+                x_cache.map(|cache| collect_pt_strings(cache));
 
-        // Per-series X values for scatter/bubble: ECMA-376 §21.2.2.43 puts numeric
-        // X data in `<c:xVal>` (with its own numCache / numLit) instead of the
-        // shared `<c:cat>`. Read it as strings so the core ChartSeries.categories
-        // field can stay string-typed (renderScatterChart parses each entry back
-        // to a float).
-        let x_cache = if is_scatter_like {
-            ser.children()
-                .find(|n| n.is_element() && n.tag_name().name() == "xVal")
-                .and_then(|x| x.descendants().find(|n| n.is_element() && is_pt_container(n.tag_name().name())))
-        } else { None };
-        let series_categories: Option<Vec<String>> = x_cache.map(|cache| collect_pt_strings(cache));
+            // Y values: scatter/bubble use `<c:yVal>`, everything else uses `<c:val>`.
+            // Restrict the descendant walk to the matching tag so a sibling `<c:xVal>`
+            // (also a numCache) can't be picked up as the Y series.
+            let val_cache = if is_scatter_like {
+                ser.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "yVal")
+                    .and_then(|y| {
+                        y.descendants().find(|n| {
+                            n.is_element()
+                                && (n.tag_name().name() == "numCache"
+                                    || n.tag_name().name() == "numLit")
+                        })
+                    })
+            } else {
+                ser.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "val")
+                    .and_then(|v| {
+                        v.descendants().find(|n| {
+                            n.is_element()
+                                && (n.tag_name().name() == "numCache"
+                                    || n.tag_name().name() == "numLit")
+                        })
+                    })
+            };
 
-        // Y values: scatter/bubble use `<c:yVal>`, everything else uses `<c:val>`.
-        // Restrict the descendant walk to the matching tag so a sibling `<c:xVal>`
-        // (also a numCache) can't be picked up as the Y series.
-        let val_cache = if is_scatter_like {
-            ser.children()
-                .find(|n| n.is_element() && n.tag_name().name() == "yVal")
-                .and_then(|y| y.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")))
-        } else {
-            ser.children()
-                .find(|n| n.is_element() && n.tag_name().name() == "val")
-                .and_then(|v| v.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")))
-        };
+            // For scatter/bubble the point count comes from this series' xVal (each
+            // series can have a different point count). For other charts it's the
+            // shared category count.
+            let series_pt_count = if is_scatter_like {
+                series_categories
+                    .as_ref()
+                    .map(|c| c.len())
+                    .unwrap_or(0)
+                    .max(1)
+            } else {
+                pt_count
+            };
 
-        // For scatter/bubble the point count comes from this series' xVal (each
-        // series can have a different point count). For other charts it's the
-        // shared category count.
-        let series_pt_count = if is_scatter_like {
-            series_categories.as_ref().map(|c| c.len()).unwrap_or(0).max(1)
-        } else { pt_count };
-
-        let mut values: Vec<Option<f64>> = vec![None; series_pt_count];
-        if let Some(cache) = val_cache {
-            for pt in cache.children().filter(|n| n.is_element() && n.tag_name().name() == "pt") {
-                let idx: usize = attr(&pt, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                let val: Option<f64> = pt.children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "v")
-                    .and_then(|v| v.text())
-                    .and_then(|t| t.parse().ok());
-                if idx < values.len() {
-                    values[idx] = val;
-                }
-            }
-        }
-
-        // Bubble per-point sizes (ECMA-376 §21.2.2.4 `<c:bubbleSize>`).
-        // Only meaningful for bubble charts; scatter / others ignore.
-        let bubble_sizes: Option<Vec<Option<f64>>> = if chart_type == "bubble" {
-            let bub_cache = ser.children()
-                .find(|n| n.is_element() && n.tag_name().name() == "bubbleSize")
-                .and_then(|b| b.descendants().find(|n| n.is_element() && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")));
-            bub_cache.map(|cache| {
-                let mut sizes: Vec<Option<f64>> = vec![None; series_pt_count];
-                for pt in cache.children().filter(|n| n.is_element() && n.tag_name().name() == "pt") {
+            let mut values: Vec<Option<f64>> = vec![None; series_pt_count];
+            if let Some(cache) = val_cache {
+                for pt in cache
+                    .children()
+                    .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+                {
                     let idx: usize = attr(&pt, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                    let val: Option<f64> = pt.children()
+                    let val: Option<f64> = pt
+                        .children()
                         .find(|n| n.is_element() && n.tag_name().name() == "v")
                         .and_then(|v| v.text())
                         .and_then(|t| t.parse().ok());
-                    if idx < sizes.len() { sizes[idx] = val; }
+                    if idx < values.len() {
+                        values[idx] = val;
+                    }
                 }
-                sizes
-            })
-        } else { None };
+            }
 
-        // Series color from spPr > solidFill (bar/area/pie) or spPr > ln > solidFill (line)
-        let color = ser.children()
-            .find(|n| n.is_element() && n.tag_name().name() == "spPr")
-            .and_then(|sp| {
-                sp.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill")
-                    .or_else(|| sp.children()
-                        .find(|n| n.is_element() && n.tag_name().name() == "ln")
-                        .and_then(|ln| ln.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill")))
-            })
-            .and_then(|fill| parse_color_node(fill, theme));
+            // Bubble per-point sizes (ECMA-376 §21.2.2.4 `<c:bubbleSize>`).
+            // Only meaningful for bubble charts; scatter / others ignore.
+            let bubble_sizes: Option<Vec<Option<f64>>> = if chart_type == "bubble" {
+                let bub_cache = ser
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "bubbleSize")
+                    .and_then(|b| {
+                        b.descendants().find(|n| {
+                            n.is_element()
+                                && (n.tag_name().name() == "numCache"
+                                    || n.tag_name().name() == "numLit")
+                        })
+                    });
+                bub_cache.map(|cache| {
+                    let mut sizes: Vec<Option<f64>> = vec![None; series_pt_count];
+                    for pt in cache
+                        .children()
+                        .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+                    {
+                        let idx: usize = attr(&pt, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
+                        let val: Option<f64> = pt
+                            .children()
+                            .find(|n| n.is_element() && n.tag_name().name() == "v")
+                            .and_then(|v| v.text())
+                            .and_then(|t| t.parse().ok());
+                        if idx < sizes.len() {
+                            sizes[idx] = val;
+                        }
+                    }
+                    sizes
+                })
+            } else {
+                None
+            };
 
-        // Per-data-point colors from <c:dPt> (important for pie charts)
-        let data_point_colors: Vec<Option<String>> = (0..series_pt_count).map(|i| {
-            ser.children()
-                .filter(|n| n.is_element() && n.tag_name().name() == "dPt")
-                .find(|dpt| attr(dpt, "idx").and_then(|v| v.parse::<usize>().ok()) == Some(i))
-                .and_then(|dpt| dpt.descendants().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
-                .and_then(|fill| parse_color_node(fill, theme))
-        }).collect();
+            // Series color from spPr > solidFill (bar/area/pie) or spPr > ln > solidFill (line)
+            let color = ser
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "spPr")
+                .and_then(|sp| {
+                    sp.children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+                        .or_else(|| {
+                            sp.children()
+                                .find(|n| n.is_element() && n.tag_name().name() == "ln")
+                                .and_then(|ln| {
+                                    ln.children().find(|n| {
+                                        n.is_element() && n.tag_name().name() == "solidFill"
+                                    })
+                                })
+                        })
+                })
+                .and_then(|fill| parse_color_node(fill, theme));
 
-        let has_dpt_colors = data_point_colors.iter().any(|c| c.is_some());
+            // Per-data-point colors from <c:dPt> (important for pie charts)
+            let data_point_colors: Vec<Option<String>> = (0..series_pt_count)
+                .map(|i| {
+                    ser.children()
+                        .filter(|n| n.is_element() && n.tag_name().name() == "dPt")
+                        .find(|dpt| {
+                            attr(dpt, "idx").and_then(|v| v.parse::<usize>().ok()) == Some(i)
+                        })
+                        .and_then(|dpt| {
+                            dpt.descendants()
+                                .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+                        })
+                        .and_then(|fill| parse_color_node(fill, theme))
+                })
+                .collect();
 
-        // Series value number format from `<c:val>…<c:numCache><c:formatCode>`.
-        // Used for data labels when `<c:dLbls>` carries no explicit `<c:numFmt>`
-        // (ECMA-376 §21.2.2.121). "General" means "no format" → drop it so the
-        // renderer's default integer/decimal formatter takes over.
-        let val_format_code = val_cache
-            .and_then(|cache| cache.children()
-                .find(|n| n.is_element() && n.tag_name().name() == "formatCode")
-                .and_then(|fc| fc.text().map(|t| t.to_string())))
-            .filter(|s| !s.is_empty() && s != "General");
+            let has_dpt_colors = data_point_colors.iter().any(|c| c.is_some());
 
-        // Series-level data-label text colour from `<c:dLbls><c:txPr>…solidFill`.
-        // Scoped to this `<c:ser>` (not chart-root) so stacked-bar segments keep
-        // their independent label colours (white on dark fill, black on light).
-        let label_color = ser.children()
-            .find(|n| n.is_element() && n.tag_name().name() == "dLbls")
-            .and_then(|dlbls| dlbls.children().find(|n| n.is_element() && n.tag_name().name() == "txPr"))
-            .and_then(|txpr| txpr.descendants().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
-            .and_then(|fill| parse_color_node(fill, theme));
+            // Series value number format from `<c:val>…<c:numCache><c:formatCode>`.
+            // Used for data labels when `<c:dLbls>` carries no explicit `<c:numFmt>`
+            // (ECMA-376 §21.2.2.121). "General" means "no format" → drop it so the
+            // renderer's default integer/decimal formatter takes over.
+            let val_format_code = val_cache
+                .and_then(|cache| {
+                    cache
+                        .children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "formatCode")
+                        .and_then(|fc| fc.text().map(|t| t.to_string()))
+                })
+                .filter(|s| !s.is_empty() && s != "General");
 
-        ChartSeriesData {
-            name, values, color,
-            data_point_colors: if has_dpt_colors { Some(data_point_colors) } else { None },
-            // Legacy `<c:chart>` per-point label colors are extracted via
-            // `<c:dLbls><c:dLbl idx>` — not yet wired here; chartEx is the only
-            // path that needs it for sample-2's waterfall.
-            data_label_colors: None,
-            categories: series_categories,
-            bubble_sizes,
-            val_format_code,
-            label_color,
-        }
-    }).collect();
+            // Series-level data-label text colour from `<c:dLbls><c:txPr>…solidFill`.
+            // Scoped to this `<c:ser>` (not chart-root) so stacked-bar segments keep
+            // their independent label colours (white on dark fill, black on light).
+            let label_color = ser
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "dLbls")
+                .and_then(|dlbls| {
+                    dlbls
+                        .children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "txPr")
+                })
+                .and_then(|txpr| {
+                    txpr.descendants()
+                        .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+                })
+                .and_then(|fill| parse_color_node(fill, theme));
+
+            ChartSeriesData {
+                name,
+                values,
+                color,
+                data_point_colors: if has_dpt_colors {
+                    Some(data_point_colors)
+                } else {
+                    None
+                },
+                // Legacy `<c:chart>` per-point label colors are extracted via
+                // `<c:dLbls><c:dLbl idx>` — not yet wired here; chartEx is the only
+                // path that needs it for sample-2's waterfall.
+                data_label_colors: None,
+                categories: series_categories,
+                bubble_sizes,
+                val_format_code,
+                label_color,
+            }
+        })
+        .collect();
 
     // Check if data labels (showVal) are enabled — at chart level or in any series
-    let show_data_labels = root.descendants()
+    let show_data_labels = root
+        .descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
         .any(|dLbls| {
-            dLbls.children()
-                .any(|c| c.is_element() && c.tag_name().name() == "showVal"
-                    && attr(&c, "val").as_deref() == Some("1"))
+            dLbls.children().any(|c| {
+                c.is_element()
+                    && c.tag_name().name() == "showVal"
+                    && attr(&c, "val").as_deref() == Some("1")
+            })
         });
 
     // Outer chartSpace spPr: we want the child of chartSpace (not plotArea).
-    let chart_bg = root.children()
+    let chart_bg = root
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "spPr")
-        .and_then(|sp| sp.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
+        .and_then(|sp| {
+            sp.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+        })
         .and_then(|fill| parse_color_node(fill, theme));
 
     // <c:legend> + <c:legendPos val> — shared helper.
@@ -3957,9 +4671,13 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     // ECMA-376 §21.2.2.35: `<c:crossBetween>` lives on the VALUE axis (not cat),
     // and describes whether value gridlines land between or on category ticks.
     // Default is "between" (categories inset by half a step each side).
-    let cat_axis_cross_between = root.descendants()
+    let cat_axis_cross_between = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "valAx")
-        .and_then(|ax| ax.children().find(|n| n.is_element() && n.tag_name().name() == "crossBetween"))
+        .and_then(|ax| {
+            ax.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "crossBetween")
+        })
         .and_then(|n| attr(&n, "val"))
         .unwrap_or_else(|| "between".to_string());
 
@@ -3989,20 +4707,23 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     // ColorResolver wrapper around `parse_color_node` so the
     // ECMA-376 §21.2.2.16 dLbls > txPr > solidFill walk lives in one place.
     let resolver = PptxColorResolver { theme };
-    let data_label_font_color =
-        ooxml_common::chart::extract_data_label_font_color(root, &resolver);
+    let data_label_font_color = ooxml_common::chart::extract_data_label_font_color(root, &resolver);
 
     // Axis tick-label text color + axis-line style (color / width / noFill).
     // ECMA-376 §21.2.2.* — `<c:catAx|valAx><c:txPr>…<a:solidFill>` colors the
     // tick labels and `<c:spPr><a:ln>` styles the axis rule. Shared helpers so
     // the gray "2025年3月期" category labels and the light-gray category-axis
     // line in sample-2 slide-16's horizontal bar chart resolve the same way.
-    let cat_axis_font_color = cat_ax.and_then(|n| ooxml_common::chart::extract_axis_tick_label_color(n, &resolver));
-    let val_axis_font_color = val_ax.and_then(|n| ooxml_common::chart::extract_axis_tick_label_color(n, &resolver));
-    let (cat_axis_line_color, cat_axis_line_width_emu, cat_axis_line_hidden) =
-        cat_ax.map(|n| ooxml_common::chart::extract_axis_line_style(n, &resolver)).unwrap_or((None, None, false));
-    let (val_axis_line_color, val_axis_line_width_emu, val_axis_line_hidden) =
-        val_ax.map(|n| ooxml_common::chart::extract_axis_line_style(n, &resolver)).unwrap_or((None, None, false));
+    let cat_axis_font_color =
+        cat_ax.and_then(|n| ooxml_common::chart::extract_axis_tick_label_color(n, &resolver));
+    let val_axis_font_color =
+        val_ax.and_then(|n| ooxml_common::chart::extract_axis_tick_label_color(n, &resolver));
+    let (cat_axis_line_color, cat_axis_line_width_emu, cat_axis_line_hidden) = cat_ax
+        .map(|n| ooxml_common::chart::extract_axis_line_style(n, &resolver))
+        .unwrap_or((None, None, false));
+    let (val_axis_line_color, val_axis_line_width_emu, val_axis_line_hidden) = val_ax
+        .map(|n| ooxml_common::chart::extract_axis_line_style(n, &resolver))
+        .unwrap_or((None, None, false));
 
     // `<c:valAx><c:numFmt formatCode>` — value-axis tick label number format.
     let val_axis_format_code = val_ax.and_then(ooxml_common::chart::extract_axis_format_code);
@@ -4012,9 +4733,14 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
     // this to keep its horizontal bar chart from spilling into the side
     // annotation column. We parse the same shape xlsx already exposes
     // (xMode, yMode, layoutTarget, x, y, w?, h?).
-    let plot_area_manual_layout = plot_area.children()
+    let plot_area_manual_layout = plot_area
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "layout")
-        .and_then(|layout| layout.children().find(|n| n.is_element() && n.tag_name().name() == "manualLayout"))
+        .and_then(|layout| {
+            layout
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "manualLayout")
+        })
         .map(|ml| {
             let mut x_mode = "edge".to_string();
             let mut y_mode = "edge".to_string();
@@ -4026,29 +4752,65 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
             for ch in ml.children().filter(|n| n.is_element()) {
                 let val_str = attr(&ch, "val");
                 match ch.tag_name().name() {
-                    "xMode" => { if let Some(v) = val_str { x_mode = v; } }
-                    "yMode" => { if let Some(v) = val_str { y_mode = v; } }
-                    "layoutTarget" => { layout_target = val_str; }
-                    "x" => { if let Some(v) = val_str.and_then(|s| s.parse::<f64>().ok()) { x = v; } }
-                    "y" => { if let Some(v) = val_str.and_then(|s| s.parse::<f64>().ok()) { y = v; } }
-                    "w" => { w = val_str.and_then(|s| s.parse::<f64>().ok()); }
-                    "h" => { h = val_str.and_then(|s| s.parse::<f64>().ok()); }
+                    "xMode" => {
+                        if let Some(v) = val_str {
+                            x_mode = v;
+                        }
+                    }
+                    "yMode" => {
+                        if let Some(v) = val_str {
+                            y_mode = v;
+                        }
+                    }
+                    "layoutTarget" => {
+                        layout_target = val_str;
+                    }
+                    "x" => {
+                        if let Some(v) = val_str.and_then(|s| s.parse::<f64>().ok()) {
+                            x = v;
+                        }
+                    }
+                    "y" => {
+                        if let Some(v) = val_str.and_then(|s| s.parse::<f64>().ok()) {
+                            y = v;
+                        }
+                    }
+                    "w" => {
+                        w = val_str.and_then(|s| s.parse::<f64>().ok());
+                    }
+                    "h" => {
+                        h = val_str.and_then(|s| s.parse::<f64>().ok());
+                    }
                     _ => {}
                 }
             }
-            ChartManualLayout { x_mode, y_mode, layout_target, x, y, w, h }
+            ChartManualLayout {
+                x_mode,
+                y_mode,
+                layout_target,
+                x,
+                y,
+                w,
+                h,
+            }
         });
 
     // `<c:scatterChart><c:scatterStyle val>` — ECMA-376 §21.2.2.42. Lives
     // directly under scatterChart, so a plot_area descendant walk is enough.
     let scatter_style = if chart_type == "scatter" {
-        plot_area.descendants()
+        plot_area
+            .descendants()
             .find(|n| n.is_element() && n.tag_name().name() == "scatterStyle")
             .and_then(|n| attr(&n, "val"))
-    } else { None };
+    } else {
+        None
+    };
 
     Some(ChartElement {
-        x: 0, y: 0, width: 0, height: 0,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
         chart_type,
         title,
         categories,
@@ -4095,16 +4857,24 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
     let root = doc.root_element();
 
     // Chart type from series layoutId attribute
-    let series_node = root.descendants()
+    let series_node = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "series")?;
     let layout_id = attr(&series_node, "layoutId").unwrap_or_default();
     let chart_type = layout_id; // "waterfall", "treemap", etc.
 
     // Categories from chartData > data > strDim[@type="cat"] > lvl > pt
-    let categories: Vec<String> = root.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "strDim"
-            && attr(n, "type").as_deref() == Some("cat"))
-        .and_then(|dim| dim.descendants().find(|n| n.is_element() && n.tag_name().name() == "lvl"))
+    let categories: Vec<String> = root
+        .descendants()
+        .find(|n| {
+            n.is_element()
+                && n.tag_name().name() == "strDim"
+                && attr(n, "type").as_deref() == Some("cat")
+        })
+        .and_then(|dim| {
+            dim.descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "lvl")
+        })
         .map(|lvl| {
             lvl.children()
                 .filter(|n| n.is_element() && n.tag_name().name() == "pt")
@@ -4116,13 +4886,21 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
     let pt_count = categories.len().max(1);
 
     // Values from chartData > data > numDim[@type="val"] > lvl > pt
-    let raw_values: Vec<Option<f64>> = root.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "numDim"
-            && attr(n, "type").as_deref() == Some("val"))
-        .and_then(|dim| dim.descendants().find(|n| n.is_element() && n.tag_name().name() == "lvl"))
+    let raw_values: Vec<Option<f64>> = root
+        .descendants()
+        .find(|n| {
+            n.is_element()
+                && n.tag_name().name() == "numDim"
+                && attr(n, "type").as_deref() == Some("val")
+        })
+        .and_then(|dim| {
+            dim.descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "lvl")
+        })
         .map(|lvl| {
             let mut vals: Vec<Option<f64>> = vec![None; pt_count];
-            for (i, pt) in lvl.children()
+            for (i, pt) in lvl
+                .children()
                 .filter(|n| n.is_element() && n.tag_name().name() == "pt")
                 .enumerate()
             {
@@ -4136,10 +4914,14 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
 
     // Subtotal indices (idx=0 is always implicit; add from cx:subtotals)
     let mut subtotal_indices: Vec<u32> = vec![0];
-    if let Some(subtotals_node) = series_node.descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "subtotals") {
-        for idx_node in subtotals_node.children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "idx") {
+    if let Some(subtotals_node) = series_node
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "subtotals")
+    {
+        for idx_node in subtotals_node
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "idx")
+        {
             if let Some(v) = attr(&idx_node, "val").and_then(|v| v.parse::<u32>().ok()) {
                 if v != 0 {
                     subtotal_indices.push(v);
@@ -4149,9 +4931,13 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
     }
 
     // Series color (first dataPt or series spPr)
-    let color = series_node.children()
+    let color = series_node
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "spPr")
-        .and_then(|sp| sp.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill"))
+        .and_then(|sp| {
+            sp.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+        })
         .and_then(|fill| parse_color_node(fill, theme));
 
     // Per-idx data-label colors. ChartEx writes `<cx:dataLabels>` with
@@ -4161,18 +4947,28 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
     // positive-bar labels stay tx1 (black).
     let mut data_label_colors_vec: Vec<Option<String>> = vec![None; raw_values.len().max(1)];
     let mut has_per_label_color = false;
-    for dl in series_node.descendants()
+    for dl in series_node
+        .descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "dataLabel")
     {
-        let Some(idx) = attr(&dl, "idx").and_then(|v| v.parse::<usize>().ok()) else { continue; };
-        if idx >= data_label_colors_vec.len() { continue; }
+        let Some(idx) = attr(&dl, "idx").and_then(|v| v.parse::<usize>().ok()) else {
+            continue;
+        };
+        if idx >= data_label_colors_vec.len() {
+            continue;
+        }
         // First `<a:solidFill>` inside the per-idx <cx:txPr>.
-        let txpr = match dl.children().find(|n| n.is_element() && n.tag_name().name() == "txPr") {
+        let txpr = match dl
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "txPr")
+        {
             Some(n) => n,
             None => continue,
         };
         for desc in txpr.descendants().filter(|n| n.is_element()) {
-            if desc.tag_name().name() != "solidFill" { continue; }
+            if desc.tag_name().name() != "solidFill" {
+                continue;
+            }
             if let Some(c) = parse_color_node(desc, theme) {
                 data_label_colors_vec[idx] = Some(c);
                 has_per_label_color = true;
@@ -4186,7 +4982,11 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
         values: raw_values,
         color,
         data_point_colors: None,
-        data_label_colors: if has_per_label_color { Some(data_label_colors_vec) } else { None },
+        data_label_colors: if has_per_label_color {
+            Some(data_label_colors_vec)
+        } else {
+            None
+        },
         categories: None,
         bubble_sizes: None,
         val_format_code: None,
@@ -4204,14 +5004,18 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
     // shared renderer's `barW = catGap / (1 + gapWidth/100)` formula works
     // uniformly across chart types. Default 1.5 (= legacy 150%) per PowerPoint
     // when the attribute is omitted.
-    let bar_gap_width = root.descendants()
+    let bar_gap_width = root
+        .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "catScaling")
         .and_then(|n| attr(&n, "gapWidth"))
         .and_then(|v| v.parse::<f64>().ok())
         .map(|frac| (frac * 100.0).round() as i32);
 
     Some(ChartElement {
-        x: 0, y: 0, width: 0, height: 0,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
         chart_type,
         title: None,
         categories,
@@ -4261,23 +5065,59 @@ fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElem
 fn default_placeholder_transform(ph_type: &str) -> Transform {
     match ph_type {
         "title" | "ctrTitle" => Transform {
-            x: 457200,   y: 274638,   cx: 8229600, cy: 1143000, rot: 0.0, flip_h: false, flip_v: false,
+            x: 457200,
+            y: 274638,
+            cx: 8229600,
+            cy: 1143000,
+            rot: 0.0,
+            flip_h: false,
+            flip_v: false,
         },
         "subTitle" => Transform {
-            x: 457200,   y: 1600200,  cx: 8229600, cy: 899160,  rot: 0.0, flip_h: false, flip_v: false,
+            x: 457200,
+            y: 1600200,
+            cx: 8229600,
+            cy: 899160,
+            rot: 0.0,
+            flip_h: false,
+            flip_v: false,
         },
         "dt" => Transform {
-            x: 0,        y: 6261600,  cx: 2286000, cy: 596900,  rot: 0.0, flip_h: false, flip_v: false,
+            x: 0,
+            y: 6261600,
+            cx: 2286000,
+            cy: 596900,
+            rot: 0.0,
+            flip_h: false,
+            flip_v: false,
         },
         "ftr" => Transform {
-            x: 2972400,  y: 6261600,  cx: 3086100, cy: 596900,  rot: 0.0, flip_h: false, flip_v: false,
+            x: 2972400,
+            y: 6261600,
+            cx: 3086100,
+            cy: 596900,
+            rot: 0.0,
+            flip_h: false,
+            flip_v: false,
         },
         "sldNum" => Transform {
-            x: 6629400,  y: 6261600,  cx: 2057400, cy: 596900,  rot: 0.0, flip_h: false, flip_v: false,
+            x: 6629400,
+            y: 6261600,
+            cx: 2057400,
+            cy: 596900,
+            rot: 0.0,
+            flip_h: false,
+            flip_v: false,
         },
         // "body" and everything else: full-width content area below title
         _ => Transform {
-            x: 457200,   y: 1600200,  cx: 8229600, cy: 4525963, rot: 0.0, flip_h: false, flip_v: false,
+            x: 457200,
+            y: 1600200,
+            cx: 8229600,
+            cy: 4525963,
+            rot: 0.0,
+            flip_h: false,
+            flip_v: false,
         },
     }
 }
@@ -4387,13 +5227,25 @@ fn parse_shape(
     // cy=0 means "auto-height" for body-text shapes, but connector-type
     // geometries (line, *Connector*) legitimately use cy=0 to represent
     // a perfectly horizontal segment — don't inflate their height.
-    let is_connector_geom = matches!(geometry.as_str(),
-        "line" | "straightConnector1"
-        | "bentConnector2" | "bentConnector3" | "bentConnector4" | "bentConnector5"
-        | "curvedConnector2" | "curvedConnector3" | "curvedConnector4" | "curvedConnector5"
+    let is_connector_geom = matches!(
+        geometry.as_str(),
+        "line"
+            | "straightConnector1"
+            | "bentConnector2"
+            | "bentConnector3"
+            | "bentConnector4"
+            | "bentConnector5"
+            | "curvedConnector2"
+            | "curvedConnector3"
+            | "curvedConnector4"
+            | "curvedConnector5"
     );
     let cy = if t.cy == 0 && !is_connector_geom {
-        if is_bottom_anchor { 0_i64 } else { 2_000_000_i64 }
+        if is_bottom_anchor {
+            0_i64
+        } else {
+            2_000_000_i64
+        }
     } else {
         t.cy
     };
@@ -4408,7 +5260,11 @@ fn parse_shape(
     };
     let av_node = prst_geom_node.and_then(|n| child(n, "avLst"));
     let gd_nodes: Vec<_> = av_node
-        .map(|av| av.children().filter(|n| n.is_element() && n.tag_name().name() == "gd").collect())
+        .map(|av| {
+            av.children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "gd")
+                .collect()
+        })
         .unwrap_or_default();
     // First gd = adj (match by name "adj" or "adj1", fallback to position 0)
     let adj: Option<f64> = gd_nodes
@@ -4461,35 +5317,40 @@ fn parse_shape(
     let style_node = child(sp_node, "style");
 
     // fillRef idx=0 → explicit no-fill; idx>0 → use referenced color as solid fill
-    let style_fill: Option<Fill> = style_node
-        .and_then(|s| child(s, "fillRef"))
-        .and_then(|fr| {
-            let idx: u32 = attr(&fr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
-            if idx == 0 {
-                Some(Fill::None)
-            } else {
-                parse_color_node(fr, theme).map(|c| Fill::Solid { color: c })
-            }
-        });
+    let style_fill: Option<Fill> = style_node.and_then(|s| child(s, "fillRef")).and_then(|fr| {
+        let idx: u32 = attr(&fr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
+        if idx == 0 {
+            Some(Fill::None)
+        } else {
+            parse_color_node(fr, theme).map(|c| Fill::Solid { color: c })
+        }
+    });
 
     // lnRef idx=0 → no line; idx>0 → resolve width from theme's fmtScheme >
     // lnStyleLst (stored as "+lnRef-N") and color from the ref's own solidFill.
     // Falling back to 9525 under-weights idx>=2 strokes (Office default theme
     // idx=2 is 19050 EMU = 1.5pt, idx=3 is 25400 EMU = 2pt).
-    let style_stroke: Option<Stroke> = style_node
-        .and_then(|s| child(s, "lnRef"))
-        .and_then(|lr| {
-            let idx: u32 = attr(&lr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
-            if idx == 0 { None } else {
-                parse_color_node(lr, theme).map(|c| {
-                    let width = theme
-                        .get(&format!("+lnRef-{}", idx))
-                        .and_then(|s| s.parse::<i64>().ok())
-                        .unwrap_or(9525);
-                    Stroke { color: c, width, dash_style: None, head_end: None, tail_end: None, cmpd: None }
-                })
-            }
-        });
+    let style_stroke: Option<Stroke> = style_node.and_then(|s| child(s, "lnRef")).and_then(|lr| {
+        let idx: u32 = attr(&lr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
+        if idx == 0 {
+            None
+        } else {
+            parse_color_node(lr, theme).map(|c| {
+                let width = theme
+                    .get(&format!("+lnRef-{}", idx))
+                    .and_then(|s| s.parse::<i64>().ok())
+                    .unwrap_or(9525);
+                Stroke {
+                    color: c,
+                    width,
+                    dash_style: None,
+                    head_end: None,
+                    tail_end: None,
+                    cmpd: None,
+                }
+            })
+        }
+    });
 
     // fontRef → default text color for this shape.
     // Fall back to layout/master placeholder inherited color (lstStyle > lvl1pPr > defRPr
@@ -4529,7 +5390,9 @@ fn parse_shape(
     // spPr stroke: if ln element is present, respect it (even if noFill → None);
     // otherwise fall back to layout placeholder stroke, then style stroke.
     let stroke = if sp_pr.and_then(|p| child(p, "ln")).is_some() {
-        sp_pr.and_then(|p| child(p, "ln")).and_then(|n| parse_stroke(n, theme))
+        sp_pr
+            .and_then(|p| child(p, "ln"))
+            .and_then(|n| parse_stroke(n, theme))
     } else if ph_node.is_some() {
         lph.lookup_stroke(&ph_type, ph_idx).or(style_stroke)
     } else {
@@ -4537,8 +5400,17 @@ fn parse_shape(
     };
 
     // Inherited defaults from layout/master for this placeholder type/idx
-    let (inherited_font_size, inherited_bold, inherited_italic, inherited_caps, inherited_anchor, inherited_alignment,
-         inherited_space_before, inherited_space_after, inherited_line_spacing) = if ph_node.is_some() {
+    let (
+        inherited_font_size,
+        inherited_bold,
+        inherited_italic,
+        inherited_caps,
+        inherited_anchor,
+        inherited_alignment,
+        inherited_space_before,
+        inherited_space_after,
+        inherited_line_spacing,
+    ) = if ph_node.is_some() {
         (
             lph.lookup_font_size(&ph_type, ph_idx),
             lph.lookup_bold(&ph_type),
@@ -4567,7 +5439,11 @@ fn parse_shape(
         .and_then(|n| attr(&n, "txBox"))
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-    let shape_kind = if is_text_box { ShapeKind::Tx } else { ShapeKind::Sp };
+    let shape_kind = if is_text_box {
+        ShapeKind::Tx
+    } else {
+        ShapeKind::Sp
+    };
     // Per-level bullets a paragraph inherits when it declares no explicit one
     // (ECMA-376 §19.7.10): the layout/master placeholder cascade for this slot.
     let inherited_level_bullets: LevelBullets = if ph_node.is_some() {
@@ -4575,8 +5451,25 @@ fn parse_shape(
     } else {
         empty_level_bullets()
     };
-    let text_body = child(sp_node, "txBody")
-        .map(|n| parse_text_body(n, theme, rels, inherited_font_size, inherited_level_font_sizes, &inherited_level_bullets, inherited_bold, inherited_italic, inherited_caps.clone(), inherited_anchor, inherited_alignment, inherited_space_before, inherited_space_after, inherited_line_spacing, shape_kind));
+    let text_body = child(sp_node, "txBody").map(|n| {
+        parse_text_body(
+            n,
+            theme,
+            rels,
+            inherited_font_size,
+            inherited_level_font_sizes,
+            &inherited_level_bullets,
+            inherited_bold,
+            inherited_italic,
+            inherited_caps.clone(),
+            inherited_anchor,
+            inherited_alignment,
+            inherited_space_before,
+            inherited_space_after,
+            inherited_line_spacing,
+            shape_kind,
+        )
+    });
 
     // Effects from spPr > effectLst (outerShdw / innerShdw / glow / softEdge /
     // reflection are independent siblings — ECMA-376 §20.1.8.16). Pull each.
@@ -4588,11 +5481,32 @@ fn parse_shape(
     let reflection = effect_lst.and_then(parse_reflection);
 
     Some(ShapeElement {
-        x: t.x, y: t.y, width: t.cx, height: cy,
-        rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
-        geometry, fill, stroke, text_body, default_text_color, cust_geom,
-        adj, adj2, adj3, adj4, adj5, adj6, adj7, adj8,
-        shadow, inner_shadow, glow, soft_edge, reflection,
+        x: t.x,
+        y: t.y,
+        width: t.cx,
+        height: cy,
+        rotation: t.rot,
+        flip_h: t.flip_h,
+        flip_v: t.flip_v,
+        geometry,
+        fill,
+        stroke,
+        text_body,
+        default_text_color,
+        cust_geom,
+        adj,
+        adj2,
+        adj3,
+        adj4,
+        adj5,
+        adj6,
+        adj7,
+        adj8,
+        shadow,
+        inner_shadow,
+        glow,
+        soft_edge,
+        reflection,
         id: cnv_id,
         name: cnv_name,
         placeholder_type: placeholder_type_out,
@@ -4636,9 +5550,15 @@ fn parse_picture(
     let cust_geom = child(sp_pr, "custGeom").map(parse_cust_geom);
 
     Some(PictureElement {
-        x: t.x, y: t.y, width: t.cx, height: t.cy,
-        rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
-        data_url, clip_adjust: None,
+        x: t.x,
+        y: t.y,
+        width: t.cx,
+        height: t.cy,
+        rotation: t.rot,
+        flip_h: t.flip_h,
+        flip_v: t.flip_v,
+        data_url,
+        clip_adjust: None,
         src_rect: parse_src_rect(blip_fill),
         alpha: parse_blip_alpha(blip_fill),
         cust_geom,
@@ -4663,23 +5583,29 @@ fn png_size_from_data_url(data_url: &str) -> Option<(u32, u32)> {
 const EMU_PER_PX_96DPI: i64 = 9525;
 
 fn mime_from_ext(path: &str) -> &'static str {
-    match path.rsplit('.').next().unwrap_or("").to_ascii_lowercase().as_str() {
-        "png"  => "image/png",
+    match path
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "png" => "image/png",
         "jpg" | "jpeg" => "image/jpeg",
-        "gif"  => "image/gif",
-        "bmp"  => "image/bmp",
-        "svg"  => "image/svg+xml",
+        "gif" => "image/gif",
+        "bmp" => "image/bmp",
+        "svg" => "image/svg+xml",
         "webp" => "image/webp",
-        "mp3"  => "audio/mpeg",
-        "m4a"  => "audio/mp4",
-        "wav"  => "audio/wav",
-        "aac"  => "audio/aac",
+        "mp3" => "audio/mpeg",
+        "m4a" => "audio/mp4",
+        "wav" => "audio/wav",
+        "aac" => "audio/aac",
         "ogg" | "oga" => "audio/ogg",
-        "mp4"  => "video/mp4",
-        "mov"  => "video/quicktime",
+        "mp4" => "video/mp4",
+        "mov" => "video/quicktime",
         "webm" => "video/webm",
-        "ogv"  => "video/ogg",
-        _      => "application/octet-stream",
+        "ogv" => "video/ogg",
+        _ => "application/octet-stream",
     }
 }
 
@@ -4699,11 +5625,17 @@ fn parse_media(
     let (media_kind, media_rid) = nv_pr
         .children()
         .find_map(|n| {
-            if !n.is_element() { return None; }
+            if !n.is_element() {
+                return None;
+            }
             let name = n.tag_name().name();
             if name == "videoFile" || name == "audioFile" {
                 let rid = attr_r(&n, "link").or_else(|| attr_r(&n, "embed"))?;
-                let kind = if name == "videoFile" { "video" } else { "audio" };
+                let kind = if name == "videoFile" {
+                    "video"
+                } else {
+                    "audio"
+                };
                 Some((kind, rid))
             } else {
                 None
@@ -4712,14 +5644,19 @@ fn parse_media(
         .or_else(|| {
             // p14:media lives inside p:extLst > p:ext
             let ext_lst = child(nv_pr, "extLst")?;
-            ext_lst.children().filter(|c| c.is_element()).find_map(|ext| {
-                ext.children().filter(|c| c.is_element()).find_map(|m| {
-                    if m.tag_name().name() != "media" { return None; }
-                    let rid = attr_r(&m, "link").or_else(|| attr_r(&m, "embed"))?;
-                    // ext has no way to say audio vs video by itself; decide from file ext
-                    Some(("", rid))
+            ext_lst
+                .children()
+                .filter(|c| c.is_element())
+                .find_map(|ext| {
+                    ext.children().filter(|c| c.is_element()).find_map(|m| {
+                        if m.tag_name().name() != "media" {
+                            return None;
+                        }
+                        let rid = attr_r(&m, "link").or_else(|| attr_r(&m, "embed"))?;
+                        // ext has no way to say audio vs video by itself; decide from file ext
+                        Some(("", rid))
+                    })
                 })
-            })
         })?;
 
     let rel_target = rels.get(&media_rid)?;
@@ -4741,7 +5678,9 @@ fn parse_media(
     let sp_pr = child(pic_node, "spPr")?;
     let xfrm_node = child(sp_pr, "xfrm")?;
     let t = parse_xfrm(xfrm_node);
-    if t.cx == 0 || t.cy == 0 { return None; }
+    if t.cx == 0 || t.cy == 0 {
+        return None;
+    }
 
     // Poster image (from blipFill). Optional — the renderer falls back to a
     // solid fill when the poster is absent or still loading. We emit just the
@@ -4758,7 +5697,10 @@ fn parse_media(
     .unwrap_or_default();
 
     Some(MediaElement {
-        x: t.x, y: t.y, width: t.cx, height: t.cy,
+        x: t.x,
+        y: t.y,
+        width: t.cx,
+        height: t.cy,
         media_kind,
         poster_path,
         poster_mime_type,
@@ -4804,7 +5746,7 @@ fn parse_table_style_fill(
     use ooxml_common::color::TintMode::WordLiteral;
     for c in fill_wrapper.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
-            "noFill"    => return Some(Fill::None),
+            "noFill" => return Some(Fill::None),
             "solidFill" => {
                 return parse_color_node_tint(c, theme, WordLiteral)
                     .map(|color| Fill::Solid { color });
@@ -4816,21 +5758,36 @@ fn parse_table_style_fill(
 }
 
 /// Parse ppt/tableStyles.xml into a map of styleId → TableStyleDef.
-fn parse_table_styles_xml(xml: &str, theme: &HashMap<String, String>) -> HashMap<String, TableStyleDef> {
+fn parse_table_styles_xml(
+    xml: &str,
+    theme: &HashMap<String, String>,
+) -> HashMap<String, TableStyleDef> {
     let mut map = HashMap::new();
-    let Ok(doc) = roxmltree::Document::parse(xml) else { return map; };
+    let Ok(doc) = roxmltree::Document::parse(xml) else {
+        return map;
+    };
     let root = doc.root_element();
-    for style_node in root.children().filter(|n| n.is_element() && n.tag_name().name() == "tblStyle") {
-        let Some(style_id) = attr(&style_node, "styleId") else { continue };
+    for style_node in root
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "tblStyle")
+    {
+        let Some(style_id) = attr(&style_node, "styleId") else {
+            continue;
+        };
         let style_id = style_id.to_string();
         let mut def = TableStyleDef::default();
 
-        let parse_tc_style = |role: roxmltree::Node<'_, '_>|
-            -> (Option<Fill>, Option<Stroke>, Option<Stroke>, Option<Stroke>, Option<Stroke>, Option<Stroke>)
-        {
+        let parse_tc_style = |role: roxmltree::Node<'_, '_>| -> (
+            Option<Fill>,
+            Option<Stroke>,
+            Option<Stroke>,
+            Option<Stroke>,
+            Option<Stroke>,
+            Option<Stroke>,
+        ) {
             let tc_style = match child(role, "tcStyle") {
                 Some(n) => n,
-                None    => return (None, None, None, None, None, None),
+                None => return (None, None, None, None, None, None),
             };
             // ECMA-376 §20.1.4.2.27 — the cell fill is wrapped in `<a:fill>`
             // (CT_FillProperties), so descend into it before reading the actual
@@ -4838,13 +5795,15 @@ fn parse_table_styles_xml(xml: &str, theme: &HashMap<String, String>) -> HashMap
             let fill = child(tc_style, "fill")
                 .and_then(|f| parse_table_style_fill(f, theme))
                 .or_else(|| {
-                child(tc_style, "fillRef").and_then(|fr| {
-                    let idx: u32 = attr(&fr, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                    if idx == 0 { Some(Fill::None) } else {
-                        parse_color_node(fr, theme).map(|c| Fill::Solid { color: c })
-                    }
-                })
-            });
+                    child(tc_style, "fillRef").and_then(|fr| {
+                        let idx: u32 = attr(&fr, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
+                        if idx == 0 {
+                            Some(Fill::None)
+                        } else {
+                            parse_color_node(fr, theme).map(|c| Fill::Solid { color: c })
+                        }
+                    })
+                });
             let tc_bdr = child(tc_style, "tcBdr");
             let parse_side = |side: &str| -> Option<Stroke> {
                 let side_node = tc_bdr.and_then(|b| child(b, side))?;
@@ -4854,19 +5813,34 @@ fn parse_table_styles_xml(xml: &str, theme: &HashMap<String, String>) -> HashMap
                 }
                 // <a:lnRef idx="N">: use standard themed width + provided color
                 if let Some(ln_ref) = child(side_node, "lnRef") {
-                    let idx: u32 = attr(&ln_ref, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                    if idx == 0 { return None; }
+                    let idx: u32 = attr(&ln_ref, "idx")
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+                    if idx == 0 {
+                        return None;
+                    }
                     let color = parse_color_node(ln_ref, theme)?;
-                    let width: i64 = match idx { 1 => 6350, 2 => 12700, _ => 19050 };
-                    return Some(Stroke { color, width, dash_style: None, head_end: None, tail_end: None, cmpd: None });
+                    let width: i64 = match idx {
+                        1 => 6350,
+                        2 => 12700,
+                        _ => 19050,
+                    };
+                    return Some(Stroke {
+                        color,
+                        width,
+                        dash_style: None,
+                        head_end: None,
+                        tail_end: None,
+                        cmpd: None,
+                    });
                 }
                 None
             };
             let inside_h = parse_side("insideH");
             let inside_v = parse_side("insideV");
             let border_b = parse_side("bottom");
-            let outer_h  = parse_side("top");
-            let outer_v  = parse_side("left");
+            let outer_h = parse_side("top");
+            let outer_v = parse_side("left");
             (fill, inside_h, inside_v, border_b, outer_h, outer_v)
         };
 
@@ -4888,8 +5862,8 @@ fn parse_table_styles_xml(xml: &str, theme: &HashMap<String, String>) -> HashMap
             def.whole_fill = fill;
             def.whole_inside_h = ih;
             def.whole_inside_v = iv;
-            def.whole_outer_h  = oh;
-            def.whole_outer_v  = ov;
+            def.whole_outer_h = oh;
+            def.whole_outer_v = ov;
             def.whole_text_color = parse_tc_tx_color(whole);
         }
         if let Some(band) = child(style_node, "band1H") {
@@ -4945,24 +5919,29 @@ fn parse_table(
         .and_then(|n| n.text())
         .map(|s| s.to_string());
     let flag = |attr_name: &str| -> bool {
-        tbl_pr.and_then(|n| attr(&n, attr_name))
-            .map(|v| v == "1" || v == "true").unwrap_or(false)
+        tbl_pr
+            .and_then(|n| attr(&n, attr_name))
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false)
     };
     let first_row = flag("firstRow");
-    let last_row  = flag("lastRow");
+    let last_row = flag("lastRow");
     // ECMA-376 §21.1.3.13 (a:tblPr@rtl): right-to-left table layout.
     let rtl = flag("rtl");
-    let band_row  = flag("bandRow");
+    let band_row = flag("bandRow");
     let first_col = flag("firstCol");
-    let last_col  = flag("lastCol");
+    let last_col = flag("lastCol");
 
     // Load style definitions once
     let table_styles_xml = read_zip_str(zip, "ppt/tableStyles.xml").ok();
-    let table_styles = table_styles_xml.as_deref()
+    let table_styles = table_styles_xml
+        .as_deref()
         .map(|xml| parse_table_styles_xml(xml, theme))
         .unwrap_or_default();
     let style_owned: Option<TableStyleDef> = style_id.as_deref().and_then(|id| {
-        table_styles.get(id).cloned()
+        table_styles
+            .get(id)
+            .cloned()
             .or_else(|| table_style_presets::lookup_builtin_table_style(id, theme))
     });
     let style = style_owned.as_ref();
@@ -5006,23 +5985,33 @@ fn parse_table(
                     let band_ri = ri.saturating_sub(if first_row { 1 } else { 0 });
                     if !(first_row && ri == 0) {
                         if band_ri % 2 == 0 {
-                            if let Some(f) = s.band1h_fill.clone() { effective_fill = Some(f); }
+                            if let Some(f) = s.band1h_fill.clone() {
+                                effective_fill = Some(f);
+                            }
                         } else if let Some(f) = s.band2h_fill.clone() {
                             effective_fill = Some(f);
                         }
                     }
                 }
                 if first_row && ri == 0 {
-                    if let Some(f) = s.first_row_fill.clone() { effective_fill = Some(f); }
+                    if let Some(f) = s.first_row_fill.clone() {
+                        effective_fill = Some(f);
+                    }
                 }
                 if last_row && ri == last_row_idx {
-                    if let Some(f) = s.last_row_fill.clone() { effective_fill = Some(f); }
+                    if let Some(f) = s.last_row_fill.clone() {
+                        effective_fill = Some(f);
+                    }
                 }
                 if first_col && ci == 0 {
-                    if let Some(f) = s.first_col_fill.clone() { effective_fill = Some(f); }
+                    if let Some(f) = s.first_col_fill.clone() {
+                        effective_fill = Some(f);
+                    }
                 }
                 if last_col && ci == last_col_idx {
-                    if let Some(f) = s.last_col_fill.clone() { effective_fill = Some(f); }
+                    if let Some(f) = s.last_col_fill.clone() {
+                        effective_fill = Some(f);
+                    }
                 }
                 // Cell's own tcPr fill wins
                 if cell.fill.is_none() {
@@ -5035,16 +6024,24 @@ fn parse_table(
                 // explicit colour still wins later, at render time.
                 let mut effective_text = s.whole_text_color.clone();
                 if first_row && ri == 0 {
-                    if let Some(c) = s.first_row_text_color.clone() { effective_text = Some(c); }
+                    if let Some(c) = s.first_row_text_color.clone() {
+                        effective_text = Some(c);
+                    }
                 }
                 if last_row && ri == last_row_idx {
-                    if let Some(c) = s.last_row_text_color.clone() { effective_text = Some(c); }
+                    if let Some(c) = s.last_row_text_color.clone() {
+                        effective_text = Some(c);
+                    }
                 }
                 if first_col && ci == 0 {
-                    if let Some(c) = s.first_col_text_color.clone() { effective_text = Some(c); }
+                    if let Some(c) = s.first_col_text_color.clone() {
+                        effective_text = Some(c);
+                    }
                 }
                 if last_col && ci == last_col_idx {
-                    if let Some(c) = s.last_col_text_color.clone() { effective_text = Some(c); }
+                    if let Some(c) = s.last_col_text_color.clone() {
+                        effective_text = Some(c);
+                    }
                 }
                 if cell.text_color.is_none() {
                     cell.text_color = effective_text;
@@ -5053,12 +6050,22 @@ fn parse_table(
                 // ── Bold cascade (style `<a:tcTxStyle b="on">`, role-keyed) ──
                 // Applied as the cell text body's default bold; a run's own @b wins.
                 let mut effective_bold: Option<bool> = None;
-                if first_row && ri == 0 { effective_bold = effective_bold.or(s.first_row_bold); }
-                if last_row && ri == last_row_idx { effective_bold = effective_bold.or(s.last_row_bold); }
-                if first_col && ci == 0 { effective_bold = effective_bold.or(s.first_col_bold); }
-                if last_col && ci == last_col_idx { effective_bold = effective_bold.or(s.last_col_bold); }
+                if first_row && ri == 0 {
+                    effective_bold = effective_bold.or(s.first_row_bold);
+                }
+                if last_row && ri == last_row_idx {
+                    effective_bold = effective_bold.or(s.last_row_bold);
+                }
+                if first_col && ci == 0 {
+                    effective_bold = effective_bold.or(s.first_col_bold);
+                }
+                if last_col && ci == last_col_idx {
+                    effective_bold = effective_bold.or(s.last_col_bold);
+                }
                 if let (Some(b), Some(tb)) = (effective_bold, cell.text_body.as_mut()) {
-                    if tb.default_bold.is_none() { tb.default_bold = Some(b); }
+                    if tb.default_bold.is_none() {
+                        tb.default_bold = Some(b);
+                    }
                 }
 
                 // ── Border cascade (style provides inside and outer borders) ──
@@ -5077,7 +6084,9 @@ fn parse_table(
                 // Inner bottom separator; firstRow gets its own bottom definition
                 if cell.border_b.is_none() {
                     if first_row && ri == 0 {
-                        cell.border_b = s.first_row_border_b.clone()
+                        cell.border_b = s
+                            .first_row_border_b
+                            .clone()
                             .or_else(|| s.whole_inside_h.clone());
                     } else if ri < last_row_idx {
                         cell.border_b = s.whole_inside_h.clone();
@@ -5102,10 +6111,19 @@ fn parse_table(
             } else {
                 // ── Fallback for built-in styles not defined in tableStyles.xml ──
                 // Approximate "Medium Style 2": accent1 header fill + thin outer box + row separators.
-                let thin = Stroke { color: "A0A096".to_string(), width: 9525, dash_style: None, head_end: None, tail_end: None, cmpd: None };
+                let thin = Stroke {
+                    color: "A0A096".to_string(),
+                    width: 9525,
+                    dash_style: None,
+                    head_end: None,
+                    tail_end: None,
+                    cmpd: None,
+                };
                 if cell.fill.is_none() && first_row && ri == 0 {
                     if let Some(color) = theme.get("accent1") {
-                        cell.fill = Some(Fill::Solid { color: color.clone() });
+                        cell.fill = Some(Fill::Solid {
+                            color: color.clone(),
+                        });
                     }
                 }
                 // Outer top
@@ -5133,8 +6151,13 @@ fn parse_table(
     }
 
     Some(TableElement {
-        x: t.x, y: t.y, width: t.cx, height: t.cy,
-        cols, rows, rtl,
+        x: t.x,
+        y: t.y,
+        width: t.cx,
+        height: t.cy,
+        cols,
+        rows,
+        rtl,
     })
 }
 
@@ -5159,31 +6182,79 @@ fn parse_table_cell(
 ) -> TableCell {
     let tc_pr = child(tc, "tcPr");
     // tcPr > anchor controls vertical text alignment within the cell
-    let anchor = tc_pr.and_then(|n| attr(&n, "anchor")).map(|a| a.to_string());
-    let text_body = child(tc, "txBody").map(|n| parse_text_body(n, theme, rels, None, [None; 9], &empty_level_bullets(), None, None, None, anchor, None, None, None, None, ShapeKind::Sp));
+    let anchor = tc_pr
+        .and_then(|n| attr(&n, "anchor"))
+        .map(|a| a.to_string());
+    let text_body = child(tc, "txBody").map(|n| {
+        parse_text_body(
+            n,
+            theme,
+            rels,
+            None,
+            [None; 9],
+            &empty_level_bullets(),
+            None,
+            None,
+            None,
+            anchor,
+            None,
+            None,
+            None,
+            None,
+            ShapeKind::Sp,
+        )
+    });
 
     let fill = tc_pr.and_then(|n| parse_fill(n, theme));
 
-    let border_l = tc_pr.and_then(|n| child(n, "lnL")).and_then(|n| parse_stroke(n, theme));
-    let border_r = tc_pr.and_then(|n| child(n, "lnR")).and_then(|n| parse_stroke(n, theme));
-    let border_t = tc_pr.and_then(|n| child(n, "lnT")).and_then(|n| parse_stroke(n, theme));
-    let border_b = tc_pr.and_then(|n| child(n, "lnB")).and_then(|n| parse_stroke(n, theme));
+    let border_l = tc_pr
+        .and_then(|n| child(n, "lnL"))
+        .and_then(|n| parse_stroke(n, theme));
+    let border_r = tc_pr
+        .and_then(|n| child(n, "lnR"))
+        .and_then(|n| parse_stroke(n, theme));
+    let border_t = tc_pr
+        .and_then(|n| child(n, "lnT"))
+        .and_then(|n| parse_stroke(n, theme));
+    let border_b = tc_pr
+        .and_then(|n| child(n, "lnB"))
+        .and_then(|n| parse_stroke(n, theme));
     // Diagonal borders: lnTlToBr (top-left→bottom-right) and lnBlToTr (bottom-left→top-right)
     // These are CT_LineProperties elements (same structure as lnL/lnR/lnT/lnB)
-    let diagonal_tl = tc_pr.and_then(|n| child(n, "lnTlToBr")).and_then(|n| parse_stroke(n, theme));
-    let diagonal_tr = tc_pr.and_then(|n| child(n, "lnBlToTr")).and_then(|n| parse_stroke(n, theme));
+    let diagonal_tl = tc_pr
+        .and_then(|n| child(n, "lnTlToBr"))
+        .and_then(|n| parse_stroke(n, theme));
+    let diagonal_tr = tc_pr
+        .and_then(|n| child(n, "lnBlToTr"))
+        .and_then(|n| parse_stroke(n, theme));
 
-    let grid_span: u32 = attr(&tc, "gridSpan").and_then(|v| v.parse().ok()).unwrap_or(1);
-    let row_span: u32  = attr(&tc, "rowSpan").and_then(|v| v.parse().ok()).unwrap_or(1);
-    let h_merge = attr(&tc, "hMerge").map(|v| v == "1" || v == "true").unwrap_or(false);
-    let v_merge = attr(&tc, "vMerge").map(|v| v == "1" || v == "true").unwrap_or(false);
+    let grid_span: u32 = attr(&tc, "gridSpan")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let row_span: u32 = attr(&tc, "rowSpan")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let h_merge = attr(&tc, "hMerge")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    let v_merge = attr(&tc, "vMerge")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
 
     TableCell {
-        text_body, fill,
+        text_body,
+        fill,
         text_color: None,
-        border_l, border_r, border_t, border_b,
-        diagonal_tl, diagonal_tr,
-        grid_span, row_span, h_merge, v_merge,
+        border_l,
+        border_r,
+        border_t,
+        border_b,
+        diagonal_tl,
+        diagonal_tr,
+        grid_span,
+        row_span,
+        h_merge,
+        v_merge,
     }
 }
 
@@ -5217,7 +6288,22 @@ fn parse_slide(
     theme: &HashMap<String, String>,
 ) -> Result<Slide, Box<dyn std::error::Error>> {
     let mut lph = match layout_xml {
-        Some(x) => parse_layout_placeholders(x, master_font_sizes, master_level_font_sizes, master_level_bullets, master_anchors, master_transforms, master_alignments, master_space_before, master_space_after, master_line_spacing, theme, layout_dir, layout_rels, zip),
+        Some(x) => parse_layout_placeholders(
+            x,
+            master_font_sizes,
+            master_level_font_sizes,
+            master_level_bullets,
+            master_anchors,
+            master_transforms,
+            master_alignments,
+            master_space_before,
+            master_space_after,
+            master_line_spacing,
+            theme,
+            layout_dir,
+            layout_rels,
+            zip,
+        ),
         None => LayoutPlaceholders::default(),
     };
     // Fall back to master txStyles defRPr @b/@i when the layout did not specify
@@ -5233,7 +6319,9 @@ fn parse_slide(
         lph.by_type_caps.entry(t.clone()).or_insert(c.clone());
     }
     for (t, c) in master_color.iter() {
-        lph.by_type_master_color.entry(t.clone()).or_insert(c.clone());
+        lph.by_type_master_color
+            .entry(t.clone())
+            .or_insert(c.clone());
     }
 
     let doc = roxmltree::Document::parse(xml)?;
@@ -5246,8 +6334,7 @@ fn parse_slide(
         .or_else(|| {
             layout_xml.and_then(|lx| {
                 let doc2 = roxmltree::Document::parse(lx).ok()?;
-                child(doc2.root_element(), "cSld")
-                    .and_then(|n| parse_background(n, theme))
+                child(doc2.root_element(), "cSld").and_then(|n| parse_background(n, theme))
             })
         })
         .or(master_bg);
@@ -5269,8 +6356,14 @@ fn parse_slide(
                 let empty_lph = LayoutPlaceholders::default();
                 for node in lsp_tree.children().filter(|n| n.is_element()) {
                     parse_sp_tree_node(
-                        node, &empty_lph, layout_dir, layout_rels, smartart_drawings,
-                        zip, theme, &mut elements,
+                        node,
+                        &empty_lph,
+                        layout_dir,
+                        layout_rels,
+                        smartart_drawings,
+                        zip,
+                        theme,
+                        &mut elements,
                         true, // skip placeholder shapes
                         None, // no inherited group fill at top level
                     );
@@ -5281,14 +6374,32 @@ fn parse_slide(
 
     // ── Slide shapes ─────────────────────────────────────────────────────
     for node in sp_tree.children().filter(|n| n.is_element()) {
-        parse_sp_tree_node(node, &lph, slide_dir, rels, smartart_drawings, zip, theme, &mut elements, false, None);
+        parse_sp_tree_node(
+            node,
+            &lph,
+            slide_dir,
+            rels,
+            smartart_drawings,
+            zip,
+            theme,
+            &mut elements,
+            false,
+            None,
+        );
     }
 
     // ── Notes slide & comments (Phase 2 surfacing only — no rendering) ────
     let notes = load_notes_slide(zip, rels);
     let comments = load_pptx_comments(zip, rels);
 
-    Ok(Slide { index, slide_number: index + 1, background, elements, notes, comments })
+    Ok(Slide {
+        index,
+        slide_number: index + 1,
+        background,
+        elements,
+        notes,
+        comments,
+    })
 }
 
 /// Resolve the slide's `notesSlide` relationship, read the notes part, and
@@ -5311,7 +6422,9 @@ fn load_notes_slide(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> Op
     let mut buf = String::new();
     let mut prev_was_text = false;
     for n in doc.descendants() {
-        if !n.is_element() { continue }
+        if !n.is_element() {
+            continue;
+        }
         let name = n.tag_name().name();
         if name == "p" && prev_was_text {
             buf.push('\n');
@@ -5325,28 +6438,41 @@ fn load_notes_slide(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> Op
         }
     }
     let trimmed = buf.trim();
-    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// Resolve and parse the slide's `comments` relationship (legacy
 /// `<p:cmLst>` format). Modern threaded comments live in a different
 /// namespace and are not yet supported.
 fn load_pptx_comments(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> Vec<PptxComment> {
-    let Some(target) = rels.values().find(|t| t.contains("comments/")) else { return Vec::new(); };
+    let Some(target) = rels.values().find(|t| t.contains("comments/")) else {
+        return Vec::new();
+    };
     let path = if target.starts_with('/') {
         target.trim_start_matches('/').to_string()
     } else {
         resolve_path("ppt/slides", target)
     };
-    let Ok(xml) = read_zip_str(zip, &path) else { return Vec::new(); };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else { return Vec::new(); };
+    let Ok(xml) = read_zip_str(zip, &path) else {
+        return Vec::new();
+    };
+    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        return Vec::new();
+    };
 
     // commentAuthors.xml is a top-level part — look it up directly.
     let author_xml = read_zip_str(zip, "ppt/commentAuthors.xml").ok();
     let mut authors: HashMap<String, String> = HashMap::new();
     if let Some(ax) = author_xml {
         if let Ok(adoc) = roxmltree::Document::parse(&ax) {
-            for a in adoc.descendants().filter(|n| n.is_element() && n.tag_name().name() == "cmAuthor") {
+            for a in adoc
+                .descendants()
+                .filter(|n| n.is_element() && n.tag_name().name() == "cmAuthor")
+            {
                 let id = a.attribute("id").unwrap_or("").to_string();
                 let name = a.attribute("name").unwrap_or("").to_string();
                 if !id.is_empty() && !name.is_empty() {
@@ -5357,10 +6483,16 @@ fn load_pptx_comments(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> 
     }
 
     let mut out = Vec::new();
-    for cm in doc.descendants().filter(|n| n.is_element() && n.tag_name().name() == "cm") {
+    for cm in doc
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "cm")
+    {
         let author_id = cm.attribute("authorId").unwrap_or("");
         let author = authors.get(author_id).cloned();
-        let date = cm.attribute("dt").map(String::from).filter(|s| !s.is_empty());
+        let date = cm
+            .attribute("dt")
+            .map(String::from)
+            .filter(|s| !s.is_empty());
         let text = cm
             .children()
             .find(|n| n.is_element() && n.tag_name().name() == "text")
@@ -5410,14 +6542,23 @@ fn parse_sp_tree_node(
                                     .and_then(|pg| child(pg, "avLst"))
                                     .and_then(|avlst| avlst.children().find(|n| n.is_element()))
                                     .and_then(|gd| attr(&gd, "fmla"))
-                                    .and_then(|fmla| fmla.strip_prefix("val ").and_then(|v| v.parse::<i64>().ok()));
+                                    .and_then(|fmla| {
+                                        fmla.strip_prefix("val ")
+                                            .and_then(|v| v.parse::<i64>().ok())
+                                    });
                                 let cust_geom = sp_pr_node
                                     .and_then(|p| child(p, "custGeom"))
                                     .map(parse_cust_geom);
                                 out.push(SlideElement::Picture(PictureElement {
-                                    x: t.x, y: t.y, width: t.cx, height: t.cy,
-                                    rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
-                                    data_url, clip_adjust,
+                                    x: t.x,
+                                    y: t.y,
+                                    width: t.cx,
+                                    height: t.cy,
+                                    rotation: t.rot,
+                                    flip_h: t.flip_h,
+                                    flip_v: t.flip_v,
+                                    data_url,
+                                    clip_adjust,
                                     src_rect: blip_fill_node.and_then(parse_src_rect),
                                     alpha: blip_fill_node.and_then(parse_blip_alpha),
                                     cust_geom,
@@ -5432,19 +6573,27 @@ fn parse_sp_tree_node(
             // look up an inherited blipFill from the layout placeholder. Transform
             // comes from the slide's xfrm when present, otherwise from the layout.
             if blip_rid.is_none() {
-                if let Some(ph) = node.descendants().find(|n| n.is_element() && n.tag_name().name() == "ph") {
+                if let Some(ph) = node
+                    .descendants()
+                    .find(|n| n.is_element() && n.tag_name().name() == "ph")
+                {
                     let ph_type = attr(&ph, "type").unwrap_or_else(|| "body".into());
                     let ph_idx: Option<u32> = attr(&ph, "idx").and_then(|v| v.parse().ok());
                     if let Some(bf) = lph.lookup_blip_fill(&ph_type, ph_idx) {
                         let slide_xfrm = sp_pr_node.and_then(|p| child(p, "xfrm")).map(parse_xfrm);
-                        let t = slide_xfrm
-                            .or_else(|| lph.lookup(&ph_type, ph_idx).cloned());
+                        let t = slide_xfrm.or_else(|| lph.lookup(&ph_type, ph_idx).cloned());
                         if let Some(t) = t {
                             if t.cx > 0 && t.cy > 0 {
                                 out.push(SlideElement::Picture(PictureElement {
-                                    x: t.x, y: t.y, width: t.cx, height: t.cy,
-                                    rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
-                                    data_url: bf.data_url, clip_adjust: None,
+                                    x: t.x,
+                                    y: t.y,
+                                    width: t.cx,
+                                    height: t.cy,
+                                    rotation: t.rot,
+                                    flip_h: t.flip_h,
+                                    flip_v: t.flip_v,
+                                    data_url: bf.data_url,
+                                    clip_adjust: None,
                                     src_rect: bf.src_rect,
                                     alpha: bf.alpha,
                                     cust_geom: None,
@@ -5466,7 +6615,8 @@ fn parse_sp_tree_node(
                 out.push(SlideElement::Picture(pic));
             } else {
                 // Placeholder pic: no xfrm in spPr — position comes from layout by_idx
-                let ph_idx = node.descendants()
+                let ph_idx = node
+                    .descendants()
                     .find(|n| n.is_element() && n.tag_name().name() == "ph")
                     .and_then(|ph| attr(&ph, "idx"))
                     .and_then(|s| s.parse::<u32>().ok());
@@ -5481,11 +6631,18 @@ fn parse_sp_tree_node(
                                 let image_path = resolve_path(slide_dir, rel_target);
                                 if let Some(image_bytes) = read_zip_bytes(zip, &image_path) {
                                     let mime = mime_from_ext(&image_path);
-                                    let data_url = format!("data:{mime};base64,{}", B64.encode(&image_bytes));
+                                    let data_url =
+                                        format!("data:{mime};base64,{}", B64.encode(&image_bytes));
                                     out.push(SlideElement::Picture(PictureElement {
-                                        x: t.x, y: t.y, width: t.cx, height: t.cy,
-                                        rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
-                                        data_url, clip_adjust: None,
+                                        x: t.x,
+                                        y: t.y,
+                                        width: t.cx,
+                                        height: t.cy,
+                                        rotation: t.rot,
+                                        flip_h: t.flip_h,
+                                        flip_v: t.flip_v,
+                                        data_url,
+                                        clip_adjust: None,
                                         src_rect: blip_fill.and_then(parse_src_rect),
                                         alpha: blip_fill.and_then(parse_blip_alpha),
                                         cust_geom: None,
@@ -5503,26 +6660,51 @@ fn parse_sp_tree_node(
             // nothing (Choice contains an element we don't render, like contentPart),
             // fall back to Fallback which usually carries a rasterized p:pic alternative.
             let before = out.len();
-            let choice_node = node.children()
+            let choice_node = node
+                .children()
                 .find(|n| n.is_element() && n.tag_name().name() == "Choice");
             // Choice contains p:contentPart → ink/handwriting. PowerPoint renders the
             // InkML directly; the Fallback PNG is a low-resolution rasterization at
             // the stroke's actual pixel extent. For empty/single-tap strokes the PNG
             // is only a few pixels and should not be stretched to the bounding box.
             let is_ink_fallback = choice_node.is_some_and(|c| {
-                c.descendants().any(|n| n.is_element() && n.tag_name().name() == "contentPart")
+                c.descendants()
+                    .any(|n| n.is_element() && n.tag_name().name() == "contentPart")
             });
             if let Some(choice_node) = choice_node {
                 for child_node in choice_node.children().filter(|n| n.is_element()) {
-                    parse_sp_tree_node(child_node, lph, slide_dir, rels, smartart_drawings, zip, theme, out, skip_placeholders, group_fill);
+                    parse_sp_tree_node(
+                        child_node,
+                        lph,
+                        slide_dir,
+                        rels,
+                        smartart_drawings,
+                        zip,
+                        theme,
+                        out,
+                        skip_placeholders,
+                        group_fill,
+                    );
                 }
             }
             if out.len() == before {
-                if let Some(fallback_node) = node.children()
+                if let Some(fallback_node) = node
+                    .children()
                     .find(|n| n.is_element() && n.tag_name().name() == "Fallback")
                 {
                     for child_node in fallback_node.children().filter(|n| n.is_element()) {
-                        parse_sp_tree_node(child_node, lph, slide_dir, rels, smartart_drawings, zip, theme, out, skip_placeholders, group_fill);
+                        parse_sp_tree_node(
+                            child_node,
+                            lph,
+                            slide_dir,
+                            rels,
+                            smartart_drawings,
+                            zip,
+                            theme,
+                            out,
+                            skip_placeholders,
+                            group_fill,
+                        );
                     }
                 }
                 if is_ink_fallback {
@@ -5533,7 +6715,8 @@ fn parse_sp_tree_node(
                     // matches the box keep their existing extent.
                     for el in &mut out[before..] {
                         if let SlideElement::Picture(p) = el {
-                            if let Some((nat_w_px, nat_h_px)) = png_size_from_data_url(&p.data_url) {
+                            if let Some((nat_w_px, nat_h_px)) = png_size_from_data_url(&p.data_url)
+                            {
                                 let nat_w = (nat_w_px as i64) * EMU_PER_PX_96DPI;
                                 let nat_h = (nat_h_px as i64) * EMU_PER_PX_96DPI;
                                 if nat_w < p.width && nat_h < p.height {
@@ -5565,7 +6748,8 @@ fn parse_sp_tree_node(
 
             // SmartArt: render the PowerPoint-prebaked fallback drawing1.xml when present.
             // Layout-engine reconstruction is not implemented; we rely on the cached dsp:spTree.
-            if let Some(gd) = node.descendants()
+            if let Some(gd) = node
+                .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "graphicData")
             {
                 let uri = attr(&gd, "uri").unwrap_or_default();
@@ -5582,11 +6766,14 @@ fn parse_sp_tree_node(
             }
 
             // Chart
-            if let Some(gd) = node.descendants()
-                .find(|n| n.is_element() && n.tag_name().name() == "graphicData") {
+            if let Some(gd) = node
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "graphicData")
+            {
                 let uri = attr(&gd, "uri").unwrap_or_default();
                 // Both <c:chart> and <cx:chart> share the local name "chart"
-                let chart_rid = gd.descendants()
+                let chart_rid = gd
+                    .descendants()
                     .find(|n| n.is_element() && n.tag_name().name() == "chart")
                     .and_then(|n| attr_r(&n, "id"));
                 if let Some(rid) = chart_rid {
@@ -5599,8 +6786,10 @@ fn parse_sp_tree_node(
                                 parse_legacy_chart(&chart_xml, theme)
                             };
                             if let Some(mut chart) = chart_opt {
-                                chart.x = t.x; chart.y = t.y;
-                                chart.width = t.cx; chart.height = t.cy;
+                                chart.x = t.x;
+                                chart.y = t.y;
+                                chart.width = t.cx;
+                                chart.height = t.cy;
                                 out.push(SlideElement::Chart(chart));
                             }
                         }
@@ -5610,24 +6799,27 @@ fn parse_sp_tree_node(
         }
         "grpSp" => {
             let grp_sp_pr = child(node, "grpSpPr");
-            let gt: Option<GroupTransform> = grp_sp_pr
-                .and_then(|pr| child(pr, "xfrm"))
-                .map(|xfrm| {
-                    let off    = child(xfrm, "off");
-                    let ext    = child(xfrm, "ext");
+            let gt: Option<GroupTransform> =
+                grp_sp_pr.and_then(|pr| child(pr, "xfrm")).map(|xfrm| {
+                    let off = child(xfrm, "off");
+                    let ext = child(xfrm, "ext");
                     let ch_off = child(xfrm, "chOff");
                     let ch_ext = child(xfrm, "chExt");
                     GroupTransform {
-                        x:     off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
-                        y:     off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
-                        cx:    ext.and_then(|n| attr_i64(&n, "cx")).unwrap_or(0),
-                        cy:    ext.and_then(|n| attr_i64(&n, "cy")).unwrap_or(0),
-                        ch_x:  ch_off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
-                        ch_y:  ch_off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
+                        x: off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
+                        y: off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
+                        cx: ext.and_then(|n| attr_i64(&n, "cx")).unwrap_or(0),
+                        cy: ext.and_then(|n| attr_i64(&n, "cy")).unwrap_or(0),
+                        ch_x: ch_off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
+                        ch_y: ch_off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
                         ch_cx: ch_ext.and_then(|n| attr_i64(&n, "cx")).unwrap_or(0),
                         ch_cy: ch_ext.and_then(|n| attr_i64(&n, "cy")).unwrap_or(0),
-                        flip_h: attr(&xfrm, "flipH").map(|v| v == "1" || v == "true").unwrap_or(false),
-                        flip_v: attr(&xfrm, "flipV").map(|v| v == "1" || v == "true").unwrap_or(false),
+                        flip_h: attr(&xfrm, "flipH")
+                            .map(|v| v == "1" || v == "true")
+                            .unwrap_or(false),
+                        flip_v: attr(&xfrm, "flipV")
+                            .map(|v| v == "1" || v == "true")
+                            .unwrap_or(false),
                         rot: attr_f64(&xfrm, "rot").unwrap_or(0.0) / 60000.0,
                     }
                 });
@@ -5649,8 +6841,16 @@ fn parse_sp_tree_node(
             let start = out.len();
             for child_node in node.children().filter(|n| n.is_element()) {
                 parse_sp_tree_node(
-                    child_node, lph, slide_dir, rels, smartart_drawings, zip, theme, out,
-                    skip_placeholders, child_group_fill.as_ref(),
+                    child_node,
+                    lph,
+                    slide_dir,
+                    rels,
+                    smartart_drawings,
+                    zip,
+                    theme,
+                    out,
+                    skip_placeholders,
+                    child_group_fill.as_ref(),
                 );
             }
             if let Some(gt) = gt {
@@ -5706,7 +6906,9 @@ fn parse_smartart_drawing(
         Err(_) => return,
     };
     let root = doc.root_element();
-    let Some(sp_tree) = child(root, "spTree") else { return };
+    let Some(sp_tree) = child(root, "spTree") else {
+        return;
+    };
 
     let empty_lph = LayoutPlaceholders::default();
 
@@ -5737,24 +6939,27 @@ fn parse_smartart_drawing(
                 // Recursively render a group by collecting its children into a temp buffer
                 // and applying the group's xfrm, mirroring the grpSp branch in parse_sp_tree_node.
                 let grp_sp_pr = child(node, "grpSpPr");
-                let gt: Option<GroupTransform> = grp_sp_pr
-                    .and_then(|pr| child(pr, "xfrm"))
-                    .map(|xfrm| {
+                let gt: Option<GroupTransform> =
+                    grp_sp_pr.and_then(|pr| child(pr, "xfrm")).map(|xfrm| {
                         let off = child(xfrm, "off");
                         let ext = child(xfrm, "ext");
                         let ch_off = child(xfrm, "chOff");
                         let ch_ext = child(xfrm, "chExt");
                         GroupTransform {
-                            x:     off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
-                            y:     off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
-                            cx:    ext.and_then(|n| attr_i64(&n, "cx")).unwrap_or(0),
-                            cy:    ext.and_then(|n| attr_i64(&n, "cy")).unwrap_or(0),
-                            ch_x:  ch_off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
-                            ch_y:  ch_off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
+                            x: off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
+                            y: off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
+                            cx: ext.and_then(|n| attr_i64(&n, "cx")).unwrap_or(0),
+                            cy: ext.and_then(|n| attr_i64(&n, "cy")).unwrap_or(0),
+                            ch_x: ch_off.and_then(|n| attr_i64(&n, "x")).unwrap_or(0),
+                            ch_y: ch_off.and_then(|n| attr_i64(&n, "y")).unwrap_or(0),
                             ch_cx: ch_ext.and_then(|n| attr_i64(&n, "cx")).unwrap_or(0),
                             ch_cy: ch_ext.and_then(|n| attr_i64(&n, "cy")).unwrap_or(0),
-                            flip_h: attr(&xfrm, "flipH").map(|v| v == "1" || v == "true").unwrap_or(false),
-                            flip_v: attr(&xfrm, "flipV").map(|v| v == "1" || v == "true").unwrap_or(false),
+                            flip_h: attr(&xfrm, "flipH")
+                                .map(|v| v == "1" || v == "true")
+                                .unwrap_or(false),
+                            flip_v: attr(&xfrm, "flipV")
+                                .map(|v| v == "1" || v == "true")
+                                .unwrap_or(false),
                             rot: attr_f64(&xfrm, "rot").unwrap_or(0.0) / 60000.0,
                         }
                     });
@@ -5763,7 +6968,9 @@ fn parse_smartart_drawing(
                 for child_node in node.children().filter(|n| n.is_element()) {
                     match child_node.tag_name().name() {
                         "sp" => {
-                            if let Some(mut shape) = parse_shape(child_node, &empty_lph, theme, &empty_rels, None) {
+                            if let Some(mut shape) =
+                                parse_shape(child_node, &empty_lph, theme, &empty_rels, None)
+                            {
                                 shape.text_rect = parse_tx_xfrm(child_node);
                                 out.push(SlideElement::Shape(shape));
                             }
@@ -5794,11 +7001,30 @@ fn parse_smartart_drawing(
 
 fn offset_slide_element(el: &mut SlideElement, dx: i64, dy: i64) {
     match el {
-        SlideElement::Shape(s)   => { s.x += dx; s.y += dy; if let Some(tr) = &mut s.text_rect { tr.x += dx; tr.y += dy; } }
-        SlideElement::Picture(p) => { p.x += dx; p.y += dy; }
-        SlideElement::Table(t)   => { t.x += dx; t.y += dy; }
-        SlideElement::Chart(c)   => { c.x += dx; c.y += dy; }
-        SlideElement::Media(m)   => { m.x += dx; m.y += dy; }
+        SlideElement::Shape(s) => {
+            s.x += dx;
+            s.y += dy;
+            if let Some(tr) = &mut s.text_rect {
+                tr.x += dx;
+                tr.y += dy;
+            }
+        }
+        SlideElement::Picture(p) => {
+            p.x += dx;
+            p.y += dy;
+        }
+        SlideElement::Table(t) => {
+            t.x += dx;
+            t.y += dy;
+        }
+        SlideElement::Chart(c) => {
+            c.x += dx;
+            c.y += dy;
+        }
+        SlideElement::Media(m) => {
+            m.x += dx;
+            m.y += dy;
+        }
     }
 }
 
@@ -5819,20 +7045,27 @@ fn parse_connector(
     // theme fmtScheme lnStyleLst entry N (1-based). We look up the canonical
     // width from the theme map ("+lnRef-N") rather than hardcoding 9525.
     let style_node = child(node, "style");
-    let style_stroke: Option<Stroke> = style_node
-        .and_then(|s| child(s, "lnRef"))
-        .and_then(|lr| {
-            let idx: u32 = attr(&lr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
-            if idx == 0 { None } else {
-                parse_color_node(lr, theme).map(|c| {
-                    let width = theme
-                        .get(&format!("+lnRef-{}", idx))
-                        .and_then(|s| s.parse::<i64>().ok())
-                        .unwrap_or(9525);
-                    Stroke { color: c, width, dash_style: None, head_end: None, tail_end: None, cmpd: None }
-                })
-            }
-        });
+    let style_stroke: Option<Stroke> = style_node.and_then(|s| child(s, "lnRef")).and_then(|lr| {
+        let idx: u32 = attr(&lr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
+        if idx == 0 {
+            None
+        } else {
+            parse_color_node(lr, theme).map(|c| {
+                let width = theme
+                    .get(&format!("+lnRef-{}", idx))
+                    .and_then(|s| s.parse::<i64>().ok())
+                    .unwrap_or(9525);
+                Stroke {
+                    color: c,
+                    width,
+                    dash_style: None,
+                    head_end: None,
+                    tail_end: None,
+                    cmpd: None,
+                }
+            })
+        }
+    });
 
     // Merge <a:ln> attributes onto style_stroke: <a:ln> commonly contains only
     // arrow ends (headEnd/tailEnd) while the color/width come from lnRef.
@@ -5850,16 +7083,24 @@ fn parse_connector(
                 let ln_dash = child(ln, "prstDash")
                     .and_then(|n| attr(&n, "val"))
                     .filter(|v| v != "solid");
-                let ln_head = child(ln, "headEnd").map(parse_arrow_end).filter(|a| a.kind != "none");
-                let ln_tail = child(ln, "tailEnd").map(parse_arrow_end).filter(|a| a.kind != "none");
+                let ln_head = child(ln, "headEnd")
+                    .map(parse_arrow_end)
+                    .filter(|a| a.kind != "none");
+                let ln_tail = child(ln, "tailEnd")
+                    .map(parse_arrow_end)
+                    .filter(|a| a.kind != "none");
                 let ln_cmpd = attr(&ln, "cmpd").filter(|v| v != "sng");
                 match (ln_color, style_stroke) {
                     (Some(c), base) => Some(Stroke {
                         color: c,
-                        width: ln_width.unwrap_or_else(|| base.as_ref().map(|s| s.width).unwrap_or(9525)),
-                        dash_style: ln_dash.or_else(|| base.as_ref().and_then(|s| s.dash_style.clone())),
-                        head_end: ln_head.or_else(|| base.as_ref().and_then(|s| s.head_end.clone())),
-                        tail_end: ln_tail.or_else(|| base.as_ref().and_then(|s| s.tail_end.clone())),
+                        width: ln_width
+                            .unwrap_or_else(|| base.as_ref().map(|s| s.width).unwrap_or(9525)),
+                        dash_style: ln_dash
+                            .or_else(|| base.as_ref().and_then(|s| s.dash_style.clone())),
+                        head_end: ln_head
+                            .or_else(|| base.as_ref().and_then(|s| s.head_end.clone())),
+                        tail_end: ln_tail
+                            .or_else(|| base.as_ref().and_then(|s| s.tail_end.clone())),
                         cmpd: ln_cmpd.or_else(|| base.as_ref().and_then(|s| s.cmpd.clone())),
                     }),
                     (None, Some(base)) => Some(Stroke {
@@ -5876,8 +7117,7 @@ fn parse_connector(
         }
     };
 
-    let shadow = child(sp_pr, "effectLst")
-        .and_then(|n| parse_shadow(n, theme));
+    let shadow = child(sp_pr, "effectLst").and_then(|n| parse_shadow(n, theme));
 
     let cy = if t.cy == 0 { 1 } else { t.cy };
 
@@ -5897,7 +7137,11 @@ fn parse_connector(
     };
     let av_node = prst_geom_node.and_then(|n| child(n, "avLst"));
     let gd_nodes: Vec<_> = av_node
-        .map(|av| av.children().filter(|n| n.is_element() && n.tag_name().name() == "gd").collect())
+        .map(|av| {
+            av.children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "gd")
+                .collect()
+        })
         .unwrap_or_default();
     let adj: Option<f64> = gd_nodes
         .iter()
@@ -5921,8 +7165,13 @@ fn parse_connector(
         .and_then(|n| parse_gd_val(*n));
 
     Some(ShapeElement {
-        x: t.x, y: t.y, width: t.cx, height: cy,
-        rotation: t.rot, flip_h: t.flip_h, flip_v: t.flip_v,
+        x: t.x,
+        y: t.y,
+        width: t.cx,
+        height: cy,
+        rotation: t.rot,
+        flip_h: t.flip_h,
+        flip_v: t.flip_v,
         geometry,
         fill: None,
         stroke,
@@ -5964,7 +7213,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
     let pres_root = pres_doc.root_element();
 
     let sld_sz = child(pres_root, "sldSz");
-    let slide_width  = sld_sz.and_then(|n| attr_i64(&n, "cx")).unwrap_or(9_144_000);
+    let slide_width = sld_sz.and_then(|n| attr_i64(&n, "cx")).unwrap_or(9_144_000);
     let slide_height = sld_sz.and_then(|n| attr_i64(&n, "cy")).unwrap_or(6_858_000);
 
     // Ordered slide rIds
@@ -5995,8 +7244,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
 
     let master_bg: Option<Fill> = master_xml_opt.as_deref().and_then(|master_xml| {
         let doc = roxmltree::Document::parse(master_xml).ok()?;
-        child(doc.root_element(), "cSld")
-            .and_then(|n| parse_background(n, &theme))
+        child(doc.root_element(), "cSld").and_then(|n| parse_background(n, &theme))
     });
 
     let master_font_sizes: HashMap<String, f64> = master_xml_opt
@@ -6029,12 +7277,20 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         .map(|xml| parse_master_alignments(xml))
         .unwrap_or_default();
 
-    let (master_space_before, master_space_after, master_line_spacing): (HashMap<String, i64>, HashMap<String, i64>, HashMap<String, f64>) = master_xml_opt
+    let (master_space_before, master_space_after, master_line_spacing): (
+        HashMap<String, i64>,
+        HashMap<String, i64>,
+        HashMap<String, f64>,
+    ) = master_xml_opt
         .as_deref()
         .map(|xml| parse_master_txstyle_spacing(xml))
         .unwrap_or_default();
 
-    let (master_bold, master_italic, master_caps): (HashMap<String, bool>, HashMap<String, bool>, HashMap<String, String>) = master_xml_opt
+    let (master_bold, master_italic, master_caps): (
+        HashMap<String, bool>,
+        HashMap<String, bool>,
+        HashMap<String, String>,
+    ) = master_xml_opt
         .as_deref()
         .map(|xml| parse_master_txstyle_bold_italic(xml))
         .unwrap_or_default();
@@ -6063,7 +7319,11 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
             None => continue,
         };
         let slide_path = format!("ppt/{rel_target}");
-        let slide_file = rel_target.split('/').last().unwrap_or("slide.xml").to_owned();
+        let slide_file = rel_target
+            .split('/')
+            .last()
+            .unwrap_or("slide.xml")
+            .to_owned();
         let rels_path = format!("ppt/slides/_rels/{slide_file}.rels");
 
         let slide_xml = read_zip_str(&mut zip, &slide_path)?;
@@ -6075,11 +7335,13 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         let layout_path = find_rel_target_by_type(&slide_rels_xml, "/slideLayout")
             .map(|target| resolve_path("ppt/slides", &target));
 
-        let layout_xml = layout_path.as_deref()
+        let layout_xml = layout_path
+            .as_deref()
             .and_then(|path| read_zip_str(&mut zip, path).ok());
 
         // Layout rels (for resolving images inside the layout)
-        let layout_rels = layout_path.as_deref()
+        let layout_rels = layout_path
+            .as_deref()
             .and_then(|path| {
                 let file = path.split('/').last().unwrap_or("layout.xml");
                 let rels_p = format!("ppt/slideLayouts/_rels/{file}.rels");
@@ -6094,8 +7356,13 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
             .unwrap_or_else(|| "ppt/slideLayouts".to_owned());
 
         raw_slides.push(SlideRaw {
-            index: idx, slide_xml, slide_rels, smartart_drawings,
-            layout_xml, layout_rels, layout_dir,
+            index: idx,
+            slide_xml,
+            slide_rels,
+            smartart_drawings,
+            layout_xml,
+            layout_rels,
+            layout_dir,
         });
     }
 
@@ -6134,7 +7401,16 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
     let minor_font = theme.get("+mn-lt").cloned();
     let hlink_color = theme.get("hlink").cloned();
     let fol_hlink_color = theme.get("folHlink").cloned();
-    Ok(Presentation { slide_width, slide_height, slides, default_text_color, major_font, minor_font, hlink_color, fol_hlink_color })
+    Ok(Presentation {
+        slide_width,
+        slide_height,
+        slides,
+        default_text_color,
+        major_font,
+        minor_font,
+        hlink_color,
+        fol_hlink_color,
+    })
 }
 
 #[cfg(test)]
@@ -6142,7 +7418,8 @@ mod tests {
     use super::*;
     #[test]
     fn test_parse_chartex() {
-        let xml = std::fs::read_to_string("../public/sample-2.pptx").ok()
+        let xml = std::fs::read_to_string("../public/sample-2.pptx")
+            .ok()
             .and_then(|_| None::<String>)
             .unwrap_or_else(|| {
                 // read from zip directly
@@ -6150,7 +7427,10 @@ mod tests {
                 let cursor = std::io::Cursor::new(data.as_slice());
                 let mut zip = zip::ZipArchive::new(cursor).unwrap();
                 let mut s = String::new();
-                zip.by_name("ppt/charts/chartEx1.xml").unwrap().read_to_string(&mut s).unwrap();
+                zip.by_name("ppt/charts/chartEx1.xml")
+                    .unwrap()
+                    .read_to_string(&mut s)
+                    .unwrap();
                 s
             });
         let theme = HashMap::new();
@@ -6174,20 +7454,37 @@ mod tests {
         let cursor = std::io::Cursor::new(data.as_slice());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         let mut slide_xml = String::new();
-        zip.by_name("ppt/slides/slide8.xml").unwrap().read_to_string(&mut slide_xml).unwrap();
-        
+        zip.by_name("ppt/slides/slide8.xml")
+            .unwrap()
+            .read_to_string(&mut slide_xml)
+            .unwrap();
+
         let doc = roxmltree::Document::parse(&slide_xml).unwrap();
         let root = doc.root_element();
-        
-        for gf in root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "graphicFrame") {
+
+        for gf in root
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "graphicFrame")
+        {
             println!("Found graphicFrame");
-            if let Some(gd) = gf.descendants().find(|n| n.is_element() && n.tag_name().name() == "graphicData") {
+            if let Some(gd) = gf
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "graphicData")
+            {
                 let uri = attr(&gd, "uri").unwrap_or_default();
                 println!("  graphicData uri: {}", uri);
-                if let Some(chart_node) = gd.descendants().find(|n| n.is_element() && n.tag_name().name() == "chart") {
+                if let Some(chart_node) = gd
+                    .descendants()
+                    .find(|n| n.is_element() && n.tag_name().name() == "chart")
+                {
                     println!("  chart node found, tag: {:?}", chart_node.tag_name());
                     for a in chart_node.attributes() {
-                        println!("  attr: name={} ns={:?} val={}", a.name(), a.namespace(), a.value());
+                        println!(
+                            "  attr: name={} ns={:?} val={}",
+                            a.name(),
+                            a.namespace(),
+                            a.value()
+                        );
                     }
                     let rid = attr_r(&chart_node, "id");
                     println!("  attr_r id: {:?}", rid);
@@ -6204,7 +7501,12 @@ mod tests {
         println!("Slide 8 elements: {}", slide.elements.len());
         for (i, el) in slide.elements.iter().enumerate() {
             match el {
-                SlideElement::Chart(c) => println!("  [{}] CHART type={} cats={}", i, c.chart_type, c.categories.len()),
+                SlideElement::Chart(c) => println!(
+                    "  [{}] CHART type={} cats={}",
+                    i,
+                    c.chart_type,
+                    c.categories.len()
+                ),
                 SlideElement::Shape(s) => println!("  [{}] shape x={}", i, s.x),
                 SlideElement::Table(_) => println!("  [{}] table", i),
                 SlideElement::Picture(_) => println!("  [{}] picture", i),
@@ -6218,18 +7520,21 @@ mod tests {
         let data = std::fs::read("../public/sample-2.pptx").unwrap();
         let cursor = std::io::Cursor::new(data.as_slice());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
-        
+
         let mut rels_xml = String::new();
-        zip.by_name("ppt/slides/_rels/slide8.xml.rels").unwrap().read_to_string(&mut rels_xml).unwrap();
+        zip.by_name("ppt/slides/_rels/slide8.xml.rels")
+            .unwrap()
+            .read_to_string(&mut rels_xml)
+            .unwrap();
         let rels = parse_rels(&rels_xml);
         println!("rels: {:?}", rels);
-        
+
         let chart_path = resolve_path("ppt/slides", "../charts/chartEx1.xml");
         println!("chart_path: {}", chart_path);
-        
+
         let result = read_zip_str(&mut zip, &chart_path);
         println!("read_zip_str ok: {}", result.is_ok());
-        
+
         if let Ok(chart_xml) = result {
             let theme = HashMap::new();
             let r = parse_chartex(&chart_xml, &theme);
@@ -6349,7 +7654,11 @@ mod tests {
     fn test_parse_run_caps_attribute() {
         let theme = HashMap::new();
         let rels = HashMap::new();
-        let cases = [("all", Some("all")), ("small", Some("small")), ("none", None)];
+        let cases = [
+            ("all", Some("all")),
+            ("small", Some("small")),
+            ("none", None),
+        ];
         for (val, expected) in cases {
             let xml = format!(
                 r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr cap="{val}"/><t>x</t></r>"#
@@ -6405,13 +7714,13 @@ mod tests {
         let theme = HashMap::new();
         let rels = HashMap::new();
         let cases: &[(&str, bool, Option<&str>)] = &[
-            ("none",    false, None),
-            ("sng",     true,  None),
-            ("dbl",     true,  Some("dbl")),
-            ("heavy",   true,  Some("heavy")),
-            ("dotted",  true,  Some("dotted")),
-            ("wavy",    true,  Some("wavy")),
-            ("dashLong",true,  Some("dashLong")),
+            ("none", false, None),
+            ("sng", true, None),
+            ("dbl", true, Some("dbl")),
+            ("heavy", true, Some("heavy")),
+            ("dotted", true, Some("dotted")),
+            ("wavy", true, Some("wavy")),
+            ("dashLong", true, Some("dashLong")),
         ];
         for (val, expected_bool, expected_style) in cases {
             let xml = format!(
@@ -6435,7 +7744,13 @@ mod tests {
         let with_ufill = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr u="sng"><uFill><solidFill><srgbClr val="FF0000"/></solidFill></uFill></rPr><t>x</t></r>"#;
         let doc = roxmltree::Document::parse(with_ufill).unwrap();
         let r = parse_run(doc.root_element(), None, &theme, &rels).unwrap();
-        assert_eq!(r.underline_color.as_deref().map(str::to_uppercase).as_deref(), Some("FF0000"));
+        assert_eq!(
+            r.underline_color
+                .as_deref()
+                .map(str::to_uppercase)
+                .as_deref(),
+            Some("FF0000")
+        );
 
         let with_ufilltx = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr u="sng"><uFillTx/></rPr><t>x</t></r>"#;
         let doc = roxmltree::Document::parse(with_ufilltx).unwrap();
@@ -6555,8 +7870,8 @@ mod tests {
         assert_eq!(body[0], Some(28.0)); // lvl1 → level 0
         assert_eq!(body[1], Some(24.0)); // lvl2 → level 1
         assert_eq!(body[2], Some(20.0)); // lvl3 → level 2
-        assert_eq!(body[3], None);       // unspecified
-        // body style also keys the empty placeholder type and "obj".
+        assert_eq!(body[3], None); // unspecified
+                                   // body style also keys the empty placeholder type and "obj".
         assert_eq!(m.get("").unwrap()[2], Some(20.0));
         // title style is captured separately.
         assert_eq!(m.get("title").unwrap()[0], Some(44.0));
@@ -6591,19 +7906,34 @@ mod tests {
         }
         assert!(body[2].is_none(), "lvl3 unspecified");
         // body style also keys the empty placeholder type and "obj".
-        assert!(matches!(m.get("").and_then(|b| b[0].clone()), Some(Bullet::Char { .. })));
-        assert!(matches!(m.get("obj").and_then(|b| b[0].clone()), Some(Bullet::Char { .. })));
+        assert!(matches!(
+            m.get("").and_then(|b| b[0].clone()),
+            Some(Bullet::Char { .. })
+        ));
+        assert!(matches!(
+            m.get("obj").and_then(|b| b[0].clone()),
+            Some(Bullet::Char { .. })
+        ));
         // titleStyle's explicit buNone is captured (so titles don't inherit a bullet).
-        assert!(matches!(m.get("title").and_then(|b| b[0].clone()), Some(Bullet::None)));
+        assert!(matches!(
+            m.get("title").and_then(|b| b[0].clone()),
+            Some(Bullet::None)
+        ));
     }
 
     #[test]
     fn merge_level_sizes_prefers_primary_per_edge() {
         let primary: LevelFontSizes = {
-            let mut a = [None; 9]; a[1] = Some(28.0); a
+            let mut a = [None; 9];
+            a[1] = Some(28.0);
+            a
         };
         let fallback: LevelFontSizes = {
-            let mut a = [None; 9]; a[0] = Some(32.0); a[1] = Some(24.0); a[2] = Some(20.0); a
+            let mut a = [None; 9];
+            a[0] = Some(32.0);
+            a[1] = Some(24.0);
+            a[2] = Some(20.0);
+            a
         };
         let merged = merge_level_sizes(&primary, &fallback);
         assert_eq!(merged[0], Some(32.0)); // only fallback
@@ -6644,7 +7974,12 @@ mod tests {
         push_math_runs(ac, Some(18.0), &theme, &mut runs);
         assert_eq!(runs.len(), 1, "exactly one math run, fallback ignored");
         match &runs[0] {
-            TextRun::Math { display, nodes, font_size, .. } => {
+            TextRun::Math {
+                display,
+                nodes,
+                font_size,
+                ..
+            } => {
                 assert!(*display, "oMathPara → display math");
                 assert_eq!(*font_size, Some(18.0));
                 assert_eq!(nodes_to_text(nodes), "x");
@@ -6674,10 +8009,19 @@ mod tests {
         push_math_runs(doc.root_element(), None, &theme, &mut runs);
         assert_eq!(runs.len(), 1);
         match &runs[0] {
-            TextRun::Math { display, font_size, nodes, color } => {
+            TextRun::Math {
+                display,
+                font_size,
+                nodes,
+                color,
+            } => {
                 assert!(!*display, "bare a14:m with m:oMath → inline");
                 assert_eq!(*font_size, Some(28.0), "size read from math run rPr sz");
-                assert_eq!(color.as_deref(), Some("7030A0"), "colour read from math run rPr solidFill");
+                assert_eq!(
+                    color.as_deref(),
+                    Some("7030A0"),
+                    "colour read from math run rPr solidFill"
+                );
                 assert_eq!(nodes_to_text(nodes), "n");
             }
             other => panic!("expected math run, got {other:?}"),
@@ -6697,8 +8041,10 @@ mod tests {
     fn idx_placeholder_inherits_master_txstyle_color() {
         let mut lph = LayoutPlaceholders::default();
         // Master bodyStyle resolves to white and is keyed by type (incl. "" and "body").
-        lph.by_type_master_color.insert("body".to_string(), "FFFFFF".to_string());
-        lph.by_type_master_color.insert("".to_string(), "FFFFFF".to_string());
+        lph.by_type_master_color
+            .insert("body".to_string(), "FFFFFF".to_string());
+        lph.by_type_master_color
+            .insert("".to_string(), "FFFFFF".to_string());
 
         // Layout idx=35 placeholder declared size only → no by_idx_color entry.
         assert_eq!(
@@ -6724,9 +8070,11 @@ mod tests {
     /// white header text was ignored (tcTxStyle was never read).
     #[test]
     fn table_style_resolves_fill_wrapper_and_tctxstyle_colour() {
-        let theme: HashMap<String, String> = [
-            ("dk1", "000000"), ("lt1", "FFFFFF"), ("accent2", "B83903"),
-        ].iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+        let theme: HashMap<String, String> =
+            [("dk1", "000000"), ("lt1", "FFFFFF"), ("accent2", "B83903")]
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
 
         let xml = r#"<a:tblStyleLst xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
           <a:tblStyle styleId="{TEST}" styleName="Medium Style 1 - Accent 2">
@@ -6769,25 +8117,43 @@ mod tests {
             Some(Fill::Solid { color }) => Some(color.clone()),
             _ => None,
         };
-        assert_eq!(solid(&def.whole_fill).as_deref(), Some("FFFFFF"),
-            "wholeTbl fill should be lt1 white");
-        assert_eq!(solid(&def.first_row_fill).as_deref(), Some("B83903"),
-            "firstRow header fill should be accent2 orange");
+        assert_eq!(
+            solid(&def.whole_fill).as_deref(),
+            Some("FFFFFF"),
+            "wholeTbl fill should be lt1 white"
+        );
+        assert_eq!(
+            solid(&def.first_row_fill).as_deref(),
+            Some("B83903"),
+            "firstRow header fill should be accent2 orange"
+        );
         // band1H = accent2 + `<a:tint val="20000">`. Table styles use the literal
         // ECMA-376 tint (val·input + (1-val)·white), giving a near-white wash —
         // NOT the saturated linear-lerp. 0.2·B83903 + 0.8·white = F1D7CD.
-        assert_eq!(solid(&def.band1h_fill).as_deref(), Some("F1D7CD"),
-            "band1H tint should be the literal near-white wash, not a saturated lerp");
+        assert_eq!(
+            solid(&def.band1h_fill).as_deref(),
+            Some("F1D7CD"),
+            "band1H tint should be the literal near-white wash, not a saturated lerp"
+        );
 
         // Text colours from tcTxStyle.
-        assert_eq!(def.whole_text_color.as_deref(), Some("000000"),
-            "wholeTbl text colour should be dk1 black");
-        assert_eq!(def.first_row_text_color.as_deref(), Some("FFFFFF"),
-            "firstRow header text colour should be lt1 white");
+        assert_eq!(
+            def.whole_text_color.as_deref(),
+            Some("000000"),
+            "wholeTbl text colour should be dk1 black"
+        );
+        assert_eq!(
+            def.first_row_text_color.as_deref(),
+            Some("FFFFFF"),
+            "firstRow header text colour should be lt1 white"
+        );
 
         // firstRow `<a:tcTxStyle b="on">` → bold header.
-        assert_eq!(def.first_row_bold, Some(true),
-            "firstRow header should be bold from tcTxStyle b=on");
+        assert_eq!(
+            def.first_row_bold,
+            Some(true),
+            "firstRow header should be bold from tcTxStyle b=on"
+        );
     }
 
     /// ECMA-376 §21.1.2.1.1 — `<a:bodyPr rtlCol="1">` lays out a multi-column
@@ -6804,9 +8170,20 @@ mod tests {
             );
             let doc = roxmltree::Document::parse(&xml).unwrap();
             parse_text_body(
-                doc.root_element(), &theme, &rels,
-                None, [None; 9], &empty_level_bullets(),
-                None, None, None, None, None, None, None, None,
+                doc.root_element(),
+                &theme,
+                &rels,
+                None,
+                [None; 9],
+                &empty_level_bullets(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
                 ShapeKind::Sp,
             )
         };
@@ -6821,15 +8198,24 @@ mod tests {
 
         // Absent attribute → false (spec default).
         let tb_absent = parse(r#"<bodyPr numCol="2"/>"#);
-        assert!(!tb_absent.rtl_col, "absent rtlCol should yield rtl_col=false");
+        assert!(
+            !tb_absent.rtl_col,
+            "absent rtlCol should yield rtl_col=false"
+        );
 
         // false is omitted from the serialized JSON.
         let json = serde_json::to_string(&tb_absent).unwrap();
-        assert!(!json.contains("rtlCol"), "rtl_col=false must be omitted from JSON; got {json}");
+        assert!(
+            !json.contains("rtlCol"),
+            "rtl_col=false must be omitted from JSON; got {json}"
+        );
 
         // rtlCol="1" appears under the camelCase key "rtlCol".
         let json_true = serde_json::to_string(&tb).unwrap();
-        assert!(json_true.contains("\"rtlCol\":true"), "expected rtlCol:true in JSON; got {json_true}");
+        assert!(
+            json_true.contains("\"rtlCol\":true"),
+            "expected rtlCol:true in JSON; got {json_true}"
+        );
     }
 
     /// ECMA-376 §21.1.3.13 (`a:tblPr@rtl`): a right-to-left table sets `rtl=true`
@@ -6854,11 +8240,20 @@ mod tests {
                 r#"<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">{tbl_xml}</root>"#
             );
             let doc = roxmltree::Document::parse(&xml).unwrap();
-            let tbl = doc.root_element()
+            let tbl = doc
+                .root_element()
                 .children()
                 .find(|n| n.is_element() && n.tag_name().name() == "tbl")
                 .unwrap();
-            let t = Transform { x: 0, y: 0, cx: 100, cy: 100, rot: 0.0, flip_h: false, flip_v: false };
+            let t = Transform {
+                x: 0,
+                y: 0,
+                cx: 100,
+                cy: 100,
+                rot: 0.0,
+                flip_h: false,
+                flip_v: false,
+            };
             let theme: HashMap<String, String> = HashMap::new();
             let rels: HashMap<String, String> = HashMap::new();
             let bytes = empty_zip();
@@ -6874,7 +8269,10 @@ mod tests {
         );
         assert!(t_rtl.rtl, "rtl=\"1\" should yield rtl=true");
         let json = serde_json::to_string(&t_rtl).unwrap();
-        assert!(json.contains("\"rtl\":true"), "expected rtl:true in JSON; got {json}");
+        assert!(
+            json.contains("\"rtl\":true"),
+            "expected rtl:true in JSON; got {json}"
+        );
 
         // Absent tblPr@rtl → false, omitted from JSON.
         let t_ltr = parse_tbl(
@@ -6883,6 +8281,9 @@ mod tests {
         );
         assert!(!t_ltr.rtl, "absent rtl should yield rtl=false");
         let json_ltr = serde_json::to_string(&t_ltr).unwrap();
-        assert!(!json_ltr.contains("\"rtl\""), "rtl=false must be omitted; got {json_ltr}");
+        assert!(
+            !json_ltr.contains("\"rtl\""),
+            "rtl=false must be omitted; got {json_ltr}"
+        );
     }
 }

--- a/packages/pptx/parser/src/table_style_presets.rs
+++ b/packages/pptx/parser/src/table_style_presets.rs
@@ -21,7 +21,11 @@ fn rgb_to_hls(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
     if d < 1e-10 {
         return (0.0, l, 0.0);
     }
-    let s = if l < 0.5 { d / (max + min) } else { d / (2.0 - max - min) };
+    let s = if l < 0.5 {
+        d / (max + min)
+    } else {
+        d / (2.0 - max - min)
+    };
     let h = if (r - max).abs() < 1e-10 {
         (g - b) / d + if g < b { 6.0 } else { 0.0 }
     } else if (g - max).abs() < 1e-10 {
@@ -34,31 +38,56 @@ fn rgb_to_hls(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
 
 fn hue_to_rgb(p: f64, q: f64, t: f64) -> f64 {
     let t = t.rem_euclid(1.0);
-    if t < 1.0 / 6.0 { p + (q - p) * 6.0 * t }
-    else if t < 1.0 / 2.0 { q }
-    else if t < 2.0 / 3.0 { p + (q - p) * (2.0 / 3.0 - t) * 6.0 }
-    else { p }
+    if t < 1.0 / 6.0 {
+        p + (q - p) * 6.0 * t
+    } else if t < 1.0 / 2.0 {
+        q
+    } else if t < 2.0 / 3.0 {
+        p + (q - p) * (2.0 / 3.0 - t) * 6.0
+    } else {
+        p
+    }
 }
 
 fn hls_to_rgb(h: f64, l: f64, s: f64) -> (f64, f64, f64) {
-    if s < 1e-10 { return (l, l, l); }
-    let q = if l < 0.5 { l * (1.0 + s) } else { l + s - l * s };
+    if s < 1e-10 {
+        return (l, l, l);
+    }
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
     let p = 2.0 * l - q;
-    (hue_to_rgb(p, q, h + 1.0 / 3.0), hue_to_rgb(p, q, h), hue_to_rgb(p, q, h - 1.0 / 3.0))
+    (
+        hue_to_rgb(p, q, h + 1.0 / 3.0),
+        hue_to_rgb(p, q, h),
+        hue_to_rgb(p, q, h - 1.0 / 3.0),
+    )
 }
 
 fn srgb_to_linear(c: f64) -> f64 {
-    if c <= 0.04045 { c / 12.92 } else { ((c + 0.055) / 1.055).powf(2.4) }
+    if c <= 0.04045 {
+        c / 12.92
+    } else {
+        ((c + 0.055) / 1.055).powf(2.4)
+    }
 }
 
 fn linear_to_srgb(c: f64) -> f64 {
-    if c <= 0.0031308 { 12.92 * c } else { 1.055 * c.powf(1.0 / 2.4) - 0.055 }
+    if c <= 0.0031308 {
+        12.92 * c
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    }
 }
 
 /// Apply a sequence of (name, val) color transforms to a hex color.
 /// val uses OOXML units (100_000 = 100%).
 pub(crate) fn apply_transforms(hex: &str, transforms: &[(&str, i64)]) -> String {
-    if hex.len() < 6 { return hex.to_owned(); }
+    if hex.len() < 6 {
+        return hex.to_owned();
+    }
     let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
     let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
     let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
@@ -72,14 +101,22 @@ pub(crate) fn apply_transforms(hex: &str, transforms: &[(&str, i64)]) -> String 
             "lumMod" => {
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb(h, (l * v).min(1.0), s);
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
             "lumOff" => {
                 let (h, l, s) = rgb_to_hls(rf, gf, bf);
                 let (nr, ng, nb) = hls_to_rgb(h, (l + v).clamp(0.0, 1.0), s);
-                rf = nr; gf = ng; bf = nb;
+                rf = nr;
+                gf = ng;
+                bf = nb;
             }
-            "shade" => { rf *= v; gf *= v; bf *= v; }
+            "shade" => {
+                rf *= v;
+                gf *= v;
+                bf *= v;
+            }
             "tint" => {
                 let lr = srgb_to_linear(rf);
                 let lg = srgb_to_linear(gf);
@@ -88,7 +125,9 @@ pub(crate) fn apply_transforms(hex: &str, transforms: &[(&str, i64)]) -> String 
                 gf = linear_to_srgb((lg + (1.0 - lg) * v).clamp(0.0, 1.0));
                 bf = linear_to_srgb((lb + (1.0 - lb) * v).clamp(0.0, 1.0));
             }
-            "alpha" => { alpha = v; }
+            "alpha" => {
+                alpha = v;
+            }
             _ => {}
         }
     }
@@ -106,7 +145,9 @@ pub(crate) fn apply_transforms(hex: &str, transforms: &[(&str, i64)]) -> String 
 // ── Theme color helpers ──────────────────────────────────────────────────────
 
 fn accent(theme: &HashMap<String, String>, idx: Option<u8>) -> Option<String> {
-    let key = idx.map(|n| format!("accent{n}")).unwrap_or_else(|| "dk1".into());
+    let key = idx
+        .map(|n| format!("accent{n}"))
+        .unwrap_or_else(|| "dk1".into());
     theme.get(&key).cloned()
 }
 
@@ -119,17 +160,28 @@ fn dk1(theme: &HashMap<String, String>) -> Option<String> {
 }
 
 fn solid(color: &str) -> Fill {
-    Fill::Solid { color: color.to_owned() }
+    Fill::Solid {
+        color: color.to_owned(),
+    }
 }
 
 fn stroke(color: &str) -> Stroke {
-    Stroke { color: color.to_owned(), width: 12700, dash_style: None, head_end: None, tail_end: None, cmpd: None }
+    Stroke {
+        color: color.to_owned(),
+        width: 12700,
+        dash_style: None,
+        head_end: None,
+        tail_end: None,
+        cmpd: None,
+    }
 }
 
 // ── Family generators ────────────────────────────────────────────────────────
 
 fn themed_style_1(theme: &HashMap<String, String>, accent_idx: Option<u8>) -> TableStyleDef {
-    let Some(a) = accent(theme, accent_idx) else { return TableStyleDef::default(); };
+    let Some(a) = accent(theme, accent_idx) else {
+        return TableStyleDef::default();
+    };
     let lt = lt1(theme).unwrap_or_else(|| "FFFFFF".into());
     let border = Some(stroke(&a));
     let first_row_fill = Some(solid(&a));
@@ -351,7 +403,10 @@ fn dark_style_2(theme: &HashMap<String, String>, accent_idx: Option<u8>) -> Tabl
         Some(5) => "accent6",
         _ => "dk1",
     };
-    let first_row_hex = theme.get(first_row_key).cloned().unwrap_or_else(|| dk.clone());
+    let first_row_hex = theme
+        .get(first_row_key)
+        .cloned()
+        .unwrap_or_else(|| dk.clone());
     let whole_color = apply_transforms(&a, &[("tint", 20000)]);
     let band1h_color = apply_transforms(&a, &[("tint", 40000)]);
     let last_row_color = apply_transforms(&a, &[("tint", 20000)]);
@@ -384,90 +439,386 @@ enum Family {
 // (GUID, family, accent_index: 0=no accent/dk1, 1-6=accent1-6)
 const CATALOG: &[(&str, Family, u8)] = &[
     // Themed Style 1
-    ("{2D5ABB26-0587-4C30-8999-92F81FD0307C}", Family::ThemedStyle1, 0),
-    ("{3C2FFA5D-87B4-456A-9821-1D502468CF0F}", Family::ThemedStyle1, 1),
-    ("{284E427A-3D55-4303-BF80-6455036E1DE7}", Family::ThemedStyle1, 2),
-    ("{69C7853C-536D-4A76-A0AE-DD22124D55A5}", Family::ThemedStyle1, 3),
-    ("{775DCB02-9BB8-47FD-8907-85C794F793BA}", Family::ThemedStyle1, 4),
-    ("{35758FB7-9AC5-4552-8A53-C91805E547FA}", Family::ThemedStyle1, 5),
-    ("{08FB837D-C827-4EFA-A057-4D05807E0F7C}", Family::ThemedStyle1, 6),
+    (
+        "{2D5ABB26-0587-4C30-8999-92F81FD0307C}",
+        Family::ThemedStyle1,
+        0,
+    ),
+    (
+        "{3C2FFA5D-87B4-456A-9821-1D502468CF0F}",
+        Family::ThemedStyle1,
+        1,
+    ),
+    (
+        "{284E427A-3D55-4303-BF80-6455036E1DE7}",
+        Family::ThemedStyle1,
+        2,
+    ),
+    (
+        "{69C7853C-536D-4A76-A0AE-DD22124D55A5}",
+        Family::ThemedStyle1,
+        3,
+    ),
+    (
+        "{775DCB02-9BB8-47FD-8907-85C794F793BA}",
+        Family::ThemedStyle1,
+        4,
+    ),
+    (
+        "{35758FB7-9AC5-4552-8A53-C91805E547FA}",
+        Family::ThemedStyle1,
+        5,
+    ),
+    (
+        "{08FB837D-C827-4EFA-A057-4D05807E0F7C}",
+        Family::ThemedStyle1,
+        6,
+    ),
     // Themed Style 2
-    ("{5940675A-B579-460E-94D1-54222C63F5DA}", Family::ThemedStyle2, 0),
-    ("{D113A9D2-9D6B-4929-AA2D-F23B5EE8CBE7}", Family::ThemedStyle2, 1),
-    ("{18603FDC-E32A-4AB5-989C-0864C3EAD2B8}", Family::ThemedStyle2, 2),
-    ("{306799F8-075E-4A3A-A7F6-7FBC6576F1A4}", Family::ThemedStyle2, 3),
-    ("{E269D01E-BC32-4049-B463-5C60D7B0CCD2}", Family::ThemedStyle2, 4),
-    ("{327F97BB-C833-4FB7-BDE5-3F7075034690}", Family::ThemedStyle2, 5),
-    ("{638B1855-1B75-4FBE-930C-398BA8C253C6}", Family::ThemedStyle2, 6),
+    (
+        "{5940675A-B579-460E-94D1-54222C63F5DA}",
+        Family::ThemedStyle2,
+        0,
+    ),
+    (
+        "{D113A9D2-9D6B-4929-AA2D-F23B5EE8CBE7}",
+        Family::ThemedStyle2,
+        1,
+    ),
+    (
+        "{18603FDC-E32A-4AB5-989C-0864C3EAD2B8}",
+        Family::ThemedStyle2,
+        2,
+    ),
+    (
+        "{306799F8-075E-4A3A-A7F6-7FBC6576F1A4}",
+        Family::ThemedStyle2,
+        3,
+    ),
+    (
+        "{E269D01E-BC32-4049-B463-5C60D7B0CCD2}",
+        Family::ThemedStyle2,
+        4,
+    ),
+    (
+        "{327F97BB-C833-4FB7-BDE5-3F7075034690}",
+        Family::ThemedStyle2,
+        5,
+    ),
+    (
+        "{638B1855-1B75-4FBE-930C-398BA8C253C6}",
+        Family::ThemedStyle2,
+        6,
+    ),
     // Light Style 1
-    ("{9D7B26C5-4107-4FEC-AEDC-1716B250A1EF}", Family::LightStyle1, 0),
-    ("{3B4B98B0-60AC-42C2-AFA5-B58CD77FA1E5}", Family::LightStyle1, 1),
-    ("{0E3FDE45-AF77-4B5C-9715-49D594BDF05E}", Family::LightStyle1, 2),
-    ("{C083E6E3-FA7D-4D7B-A595-EF9225AFEA82}", Family::LightStyle1, 3),
-    ("{D27102A9-8310-4765-A935-A1911B00CA55}", Family::LightStyle1, 4),
-    ("{5FD0F851-EC5A-4D38-B0AD-8093EC10F338}", Family::LightStyle1, 5),
-    ("{68D230F3-CF80-4859-8CE7-A43EE81993B5}", Family::LightStyle1, 6),
+    (
+        "{9D7B26C5-4107-4FEC-AEDC-1716B250A1EF}",
+        Family::LightStyle1,
+        0,
+    ),
+    (
+        "{3B4B98B0-60AC-42C2-AFA5-B58CD77FA1E5}",
+        Family::LightStyle1,
+        1,
+    ),
+    (
+        "{0E3FDE45-AF77-4B5C-9715-49D594BDF05E}",
+        Family::LightStyle1,
+        2,
+    ),
+    (
+        "{C083E6E3-FA7D-4D7B-A595-EF9225AFEA82}",
+        Family::LightStyle1,
+        3,
+    ),
+    (
+        "{D27102A9-8310-4765-A935-A1911B00CA55}",
+        Family::LightStyle1,
+        4,
+    ),
+    (
+        "{5FD0F851-EC5A-4D38-B0AD-8093EC10F338}",
+        Family::LightStyle1,
+        5,
+    ),
+    (
+        "{68D230F3-CF80-4859-8CE7-A43EE81993B5}",
+        Family::LightStyle1,
+        6,
+    ),
     // Light Style 2
-    ("{7E9639D4-E3E2-4D34-9284-5A2195B3D0D7}", Family::LightStyle2, 0),
-    ("{69012ECD-51FC-41F1-AA8D-1B2483CD663E}", Family::LightStyle2, 1),
-    ("{72833802-FEF1-4C79-8D5D-14CF1EAF98D9}", Family::LightStyle2, 2),
-    ("{F2DE63D5-997A-4646-A377-4702673A728D}", Family::LightStyle2, 3),
-    ("{17292A2E-F333-43FB-9621-5CBBE7FDCDCB}", Family::LightStyle2, 4),
-    ("{5A111915-BE36-4E01-A7E5-04B1672EAD32}", Family::LightStyle2, 5),
-    ("{912C8C85-51F0-491E-9774-3900AFEF0FD7}", Family::LightStyle2, 6),
+    (
+        "{7E9639D4-E3E2-4D34-9284-5A2195B3D0D7}",
+        Family::LightStyle2,
+        0,
+    ),
+    (
+        "{69012ECD-51FC-41F1-AA8D-1B2483CD663E}",
+        Family::LightStyle2,
+        1,
+    ),
+    (
+        "{72833802-FEF1-4C79-8D5D-14CF1EAF98D9}",
+        Family::LightStyle2,
+        2,
+    ),
+    (
+        "{F2DE63D5-997A-4646-A377-4702673A728D}",
+        Family::LightStyle2,
+        3,
+    ),
+    (
+        "{17292A2E-F333-43FB-9621-5CBBE7FDCDCB}",
+        Family::LightStyle2,
+        4,
+    ),
+    (
+        "{5A111915-BE36-4E01-A7E5-04B1672EAD32}",
+        Family::LightStyle2,
+        5,
+    ),
+    (
+        "{912C8C85-51F0-491E-9774-3900AFEF0FD7}",
+        Family::LightStyle2,
+        6,
+    ),
     // Light Style 3
-    ("{616DA210-FB5B-4158-B5E0-FEB733F419BA}", Family::LightStyle3, 0),
-    ("{BC89EF96-8CEA-46FF-86C4-4CE0E7609802}", Family::LightStyle3, 1),
-    ("{5DA37D80-6434-44D0-A028-1B22A696006F}", Family::LightStyle3, 2),
-    ("{8799B23B-EC83-4686-B30A-512413B5E67A}", Family::LightStyle3, 3),
-    ("{ED083AE6-46FA-4A59-8FB0-9F97EB10719F}", Family::LightStyle3, 4),
-    ("{BDBED569-4797-4DF1-A0F4-6AAB3CD982D8}", Family::LightStyle3, 5),
-    ("{E8B1032C-EA38-4F05-BA0D-38AFFFC7BED3}", Family::LightStyle3, 6),
+    (
+        "{616DA210-FB5B-4158-B5E0-FEB733F419BA}",
+        Family::LightStyle3,
+        0,
+    ),
+    (
+        "{BC89EF96-8CEA-46FF-86C4-4CE0E7609802}",
+        Family::LightStyle3,
+        1,
+    ),
+    (
+        "{5DA37D80-6434-44D0-A028-1B22A696006F}",
+        Family::LightStyle3,
+        2,
+    ),
+    (
+        "{8799B23B-EC83-4686-B30A-512413B5E67A}",
+        Family::LightStyle3,
+        3,
+    ),
+    (
+        "{ED083AE6-46FA-4A59-8FB0-9F97EB10719F}",
+        Family::LightStyle3,
+        4,
+    ),
+    (
+        "{BDBED569-4797-4DF1-A0F4-6AAB3CD982D8}",
+        Family::LightStyle3,
+        5,
+    ),
+    (
+        "{E8B1032C-EA38-4F05-BA0D-38AFFFC7BED3}",
+        Family::LightStyle3,
+        6,
+    ),
     // Medium Style 1
-    ("{793D81CF-94F2-401A-BA57-92F5A7B2D0C5}", Family::MediumStyle1, 0),
-    ("{B301B821-A1FF-4177-AEE7-76D212191A09}", Family::MediumStyle1, 1),
-    ("{9DCAF9ED-07DC-4A11-8D7F-57B35C25682E}", Family::MediumStyle1, 2),
-    ("{1FECB4D8-DB02-4DC6-A0A2-4F2EBAE1DC90}", Family::MediumStyle1, 3),
-    ("{1E171933-4619-4E11-9A3F-F7608DF75F80}", Family::MediumStyle1, 4),
-    ("{FABFCF23-3B69-468F-B69F-88F6DE6A72F2}", Family::MediumStyle1, 5),
-    ("{10A1B5D5-9B99-4C35-A422-299274C87663}", Family::MediumStyle1, 6),
+    (
+        "{793D81CF-94F2-401A-BA57-92F5A7B2D0C5}",
+        Family::MediumStyle1,
+        0,
+    ),
+    (
+        "{B301B821-A1FF-4177-AEE7-76D212191A09}",
+        Family::MediumStyle1,
+        1,
+    ),
+    (
+        "{9DCAF9ED-07DC-4A11-8D7F-57B35C25682E}",
+        Family::MediumStyle1,
+        2,
+    ),
+    (
+        "{1FECB4D8-DB02-4DC6-A0A2-4F2EBAE1DC90}",
+        Family::MediumStyle1,
+        3,
+    ),
+    (
+        "{1E171933-4619-4E11-9A3F-F7608DF75F80}",
+        Family::MediumStyle1,
+        4,
+    ),
+    (
+        "{FABFCF23-3B69-468F-B69F-88F6DE6A72F2}",
+        Family::MediumStyle1,
+        5,
+    ),
+    (
+        "{10A1B5D5-9B99-4C35-A422-299274C87663}",
+        Family::MediumStyle1,
+        6,
+    ),
     // Medium Style 2
-    ("{073A0DAA-6AF3-43AB-8588-CEC1D06C72B9}", Family::MediumStyle2, 0),
-    ("{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}", Family::MediumStyle2, 1),
-    ("{21E4AEA4-8DFA-4A89-87EB-49C32662AFE0}", Family::MediumStyle2, 2),
-    ("{F5AB1C69-6EDB-4FF4-983F-18BD219EF322}", Family::MediumStyle2, 3),
-    ("{00A15C55-8517-42AA-B614-E9B94910E393}", Family::MediumStyle2, 4),
-    ("{7DF18680-E054-41AD-8BC1-D1AEF772440D}", Family::MediumStyle2, 5),
-    ("{93296810-A885-4BE3-A3E7-6D5BEEA58F35}", Family::MediumStyle2, 6),
+    (
+        "{073A0DAA-6AF3-43AB-8588-CEC1D06C72B9}",
+        Family::MediumStyle2,
+        0,
+    ),
+    (
+        "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}",
+        Family::MediumStyle2,
+        1,
+    ),
+    (
+        "{21E4AEA4-8DFA-4A89-87EB-49C32662AFE0}",
+        Family::MediumStyle2,
+        2,
+    ),
+    (
+        "{F5AB1C69-6EDB-4FF4-983F-18BD219EF322}",
+        Family::MediumStyle2,
+        3,
+    ),
+    (
+        "{00A15C55-8517-42AA-B614-E9B94910E393}",
+        Family::MediumStyle2,
+        4,
+    ),
+    (
+        "{7DF18680-E054-41AD-8BC1-D1AEF772440D}",
+        Family::MediumStyle2,
+        5,
+    ),
+    (
+        "{93296810-A885-4BE3-A3E7-6D5BEEA58F35}",
+        Family::MediumStyle2,
+        6,
+    ),
     // Medium Style 3
-    ("{8EC20E35-A176-4012-BC5E-935CFFF8708E}", Family::MediumStyle3, 0),
-    ("{6E25E649-3F16-4E02-A733-19D2CDBF48F0}", Family::MediumStyle3, 1),
-    ("{85BE263C-DBD7-4A20-BB59-AAB30ACAA65A}", Family::MediumStyle3, 2),
-    ("{EB344D84-9AFB-497E-A393-DC336BA19D2E}", Family::MediumStyle3, 3),
-    ("{EB9631B5-78F2-41C9-869B-9F39066F8104}", Family::MediumStyle3, 4),
-    ("{74C1A8A3-306A-4EB7-A6B1-4F7E0EB9C5D6}", Family::MediumStyle3, 5),
-    ("{2A488322-F2BA-4B5B-9748-0D474271808F}", Family::MediumStyle3, 6),
+    (
+        "{8EC20E35-A176-4012-BC5E-935CFFF8708E}",
+        Family::MediumStyle3,
+        0,
+    ),
+    (
+        "{6E25E649-3F16-4E02-A733-19D2CDBF48F0}",
+        Family::MediumStyle3,
+        1,
+    ),
+    (
+        "{85BE263C-DBD7-4A20-BB59-AAB30ACAA65A}",
+        Family::MediumStyle3,
+        2,
+    ),
+    (
+        "{EB344D84-9AFB-497E-A393-DC336BA19D2E}",
+        Family::MediumStyle3,
+        3,
+    ),
+    (
+        "{EB9631B5-78F2-41C9-869B-9F39066F8104}",
+        Family::MediumStyle3,
+        4,
+    ),
+    (
+        "{74C1A8A3-306A-4EB7-A6B1-4F7E0EB9C5D6}",
+        Family::MediumStyle3,
+        5,
+    ),
+    (
+        "{2A488322-F2BA-4B5B-9748-0D474271808F}",
+        Family::MediumStyle3,
+        6,
+    ),
     // Medium Style 4
-    ("{D7AC3CCA-C797-4891-BE02-D94E43425B78}", Family::MediumStyle4, 0),
-    ("{69CF1AB2-1976-4502-BF36-3FF5EA218861}", Family::MediumStyle4, 1),
-    ("{8A107856-5554-42FB-B03E-39F5DBC370BA}", Family::MediumStyle4, 2),
-    ("{0505E3EF-67EA-436B-97B2-0124C06EBD24}", Family::MediumStyle4, 3),
-    ("{C4B1156A-380E-4F78-BDF5-A606A8083BF9}", Family::MediumStyle4, 4),
-    ("{22838BEF-8BB2-4498-84A7-C5851F593DF1}", Family::MediumStyle4, 5),
-    ("{16D9F66E-5EB9-4882-86FB-DCBF35E3C3E4}", Family::MediumStyle4, 6),
+    (
+        "{D7AC3CCA-C797-4891-BE02-D94E43425B78}",
+        Family::MediumStyle4,
+        0,
+    ),
+    (
+        "{69CF1AB2-1976-4502-BF36-3FF5EA218861}",
+        Family::MediumStyle4,
+        1,
+    ),
+    (
+        "{8A107856-5554-42FB-B03E-39F5DBC370BA}",
+        Family::MediumStyle4,
+        2,
+    ),
+    (
+        "{0505E3EF-67EA-436B-97B2-0124C06EBD24}",
+        Family::MediumStyle4,
+        3,
+    ),
+    (
+        "{C4B1156A-380E-4F78-BDF5-A606A8083BF9}",
+        Family::MediumStyle4,
+        4,
+    ),
+    (
+        "{22838BEF-8BB2-4498-84A7-C5851F593DF1}",
+        Family::MediumStyle4,
+        5,
+    ),
+    (
+        "{16D9F66E-5EB9-4882-86FB-DCBF35E3C3E4}",
+        Family::MediumStyle4,
+        6,
+    ),
     // Dark Style 1
-    ("{E8034E78-7F5D-4C2E-B375-FC64B27BC917}", Family::DarkStyle1, 0),
-    ("{125E5076-3810-47DD-B79F-674D7AD40C01}", Family::DarkStyle1, 1),
-    ("{37CE84F3-28C3-443E-9E96-99CF82512B78}", Family::DarkStyle1, 2),
-    ("{D03447BB-5D67-496B-8E87-E561075AD55C}", Family::DarkStyle1, 3),
-    ("{E929F9F4-4A8F-4326-A1B4-22849713DDAB}", Family::DarkStyle1, 4),
-    ("{8FD4443E-F989-4FC4-A0C8-D5A2AF1F390B}", Family::DarkStyle1, 5),
-    ("{AF606853-7671-496A-8E4F-DF71F8EC918B}", Family::DarkStyle1, 6),
+    (
+        "{E8034E78-7F5D-4C2E-B375-FC64B27BC917}",
+        Family::DarkStyle1,
+        0,
+    ),
+    (
+        "{125E5076-3810-47DD-B79F-674D7AD40C01}",
+        Family::DarkStyle1,
+        1,
+    ),
+    (
+        "{37CE84F3-28C3-443E-9E96-99CF82512B78}",
+        Family::DarkStyle1,
+        2,
+    ),
+    (
+        "{D03447BB-5D67-496B-8E87-E561075AD55C}",
+        Family::DarkStyle1,
+        3,
+    ),
+    (
+        "{E929F9F4-4A8F-4326-A1B4-22849713DDAB}",
+        Family::DarkStyle1,
+        4,
+    ),
+    (
+        "{8FD4443E-F989-4FC4-A0C8-D5A2AF1F390B}",
+        Family::DarkStyle1,
+        5,
+    ),
+    (
+        "{AF606853-7671-496A-8E4F-DF71F8EC918B}",
+        Family::DarkStyle1,
+        6,
+    ),
     // Dark Style 2
-    ("{5202B0CA-FC54-4496-8BCA-5EF66A818D29}", Family::DarkStyle2, 0),
-    ("{0660B408-B3CF-4A94-85FC-2B1E0A45F4A2}", Family::DarkStyle2, 1),
-    ("{91EBBBCC-DAD2-459C-BE2E-F6DE35CF9A28}", Family::DarkStyle2, 3),
-    ("{46F890A9-2807-4EBB-B81D-B2AA78EC7F39}", Family::DarkStyle2, 5),
+    (
+        "{5202B0CA-FC54-4496-8BCA-5EF66A818D29}",
+        Family::DarkStyle2,
+        0,
+    ),
+    (
+        "{0660B408-B3CF-4A94-85FC-2B1E0A45F4A2}",
+        Family::DarkStyle2,
+        1,
+    ),
+    (
+        "{91EBBBCC-DAD2-459C-BE2E-F6DE35CF9A28}",
+        Family::DarkStyle2,
+        3,
+    ),
+    (
+        "{46F890A9-2807-4EBB-B81D-B2AA78EC7F39}",
+        Family::DarkStyle2,
+        5,
+    ),
 ];
 
 // ── Public entry point ───────────────────────────────────────────────────────
@@ -477,18 +828,22 @@ pub fn lookup_builtin_table_style(
     theme: &HashMap<String, String>,
 ) -> Option<TableStyleDef> {
     let (_, family, accent_u8) = CATALOG.iter().find(|(g, _, _)| *g == guid)?;
-    let accent_idx = if *accent_u8 == 0 { None } else { Some(*accent_u8) };
+    let accent_idx = if *accent_u8 == 0 {
+        None
+    } else {
+        Some(*accent_u8)
+    };
     Some(match family {
-        Family::ThemedStyle1  => themed_style_1(theme, accent_idx),
-        Family::ThemedStyle2  => themed_style_2(theme, accent_idx),
-        Family::LightStyle1   => light_style_1(theme, accent_idx),
-        Family::LightStyle2   => light_style_2(theme, accent_idx),
-        Family::LightStyle3   => light_style_3(theme, accent_idx),
-        Family::MediumStyle1  => medium_style_1(theme, accent_idx),
-        Family::MediumStyle2  => medium_style_2(theme, accent_idx),
-        Family::MediumStyle3  => medium_style_3(theme, accent_idx),
-        Family::MediumStyle4  => medium_style_4(theme, accent_idx),
-        Family::DarkStyle1    => dark_style_1(theme, accent_idx),
-        Family::DarkStyle2    => dark_style_2(theme, accent_idx),
+        Family::ThemedStyle1 => themed_style_1(theme, accent_idx),
+        Family::ThemedStyle2 => themed_style_2(theme, accent_idx),
+        Family::LightStyle1 => light_style_1(theme, accent_idx),
+        Family::LightStyle2 => light_style_2(theme, accent_idx),
+        Family::LightStyle3 => light_style_3(theme, accent_idx),
+        Family::MediumStyle1 => medium_style_1(theme, accent_idx),
+        Family::MediumStyle2 => medium_style_2(theme, accent_idx),
+        Family::MediumStyle3 => medium_style_3(theme, accent_idx),
+        Family::MediumStyle4 => medium_style_4(theme, accent_idx),
+        Family::DarkStyle1 => dark_style_1(theme, accent_idx),
+        Family::DarkStyle2 => dark_style_2(theme, accent_idx),
     })
 }

--- a/packages/xlsx/parser/Cargo.toml
+++ b/packages/xlsx/parser/Cargo.toml
@@ -15,7 +15,3 @@ roxmltree = { workspace = true }
 base64 = { workspace = true }
 console_error_panic_hook = { workspace = true }
 ooxml-common = { workspace = true }
-
-[profile.release]
-opt-level = "s"
-lto = true

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -599,13 +599,11 @@ pub(crate) fn parse_chart_xml(
                                     data_label_position = d.attribute("val").map(|s| s.to_string());
                                 }
                             }
-                            "numFmt" => {
-                                if data_label_format_code.is_none() {
-                                    data_label_format_code = d
-                                        .attribute("formatCode")
-                                        .map(|s| s.to_string())
-                                        .filter(|s| !s.is_empty() && s != "General");
-                                }
+                            "numFmt" if data_label_format_code.is_none() => {
+                                data_label_format_code = d
+                                    .attribute("formatCode")
+                                    .map(|s| s.to_string())
+                                    .filter(|s| !s.is_empty() && s != "General");
                             }
                             // txPr (data-label text color) is now resolved
                             // up front via ooxml_common::chart::extract_data_label_font_color.
@@ -659,13 +657,11 @@ pub(crate) fn parse_chart_xml(
                                 data_label_position = d.attribute("val").map(|s| s.to_string());
                             }
                         }
-                        "numFmt" => {
-                            if data_label_format_code.is_none() {
-                                data_label_format_code = d
-                                    .attribute("formatCode")
-                                    .map(|s| s.to_string())
-                                    .filter(|s| !s.is_empty() && s != "General");
-                            }
+                        "numFmt" if data_label_format_code.is_none() => {
+                            data_label_format_code = d
+                                .attribute("formatCode")
+                                .map(|s| s.to_string())
+                                .filter(|s| !s.is_empty() && s != "General");
                         }
                         // txPr (data-label text color) handled by the
                         // shared helper before this loop runs.

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1362,9 +1362,9 @@ pub(crate) fn resolve_scheme_color(name: &str, theme_colors: &[String]) -> Optio
 /// this widens it to combine multiple transforms.
 pub(crate) fn apply_color_transforms(base_hex: &str, color_el: &roxmltree::Node) -> String {
     let cleaned = base_hex.trim_start_matches('#');
-    let r = u8::from_str_radix(&cleaned.get(0..2).unwrap_or("00"), 16).unwrap_or(0);
-    let g = u8::from_str_radix(&cleaned.get(2..4).unwrap_or("00"), 16).unwrap_or(0);
-    let b = u8::from_str_radix(&cleaned.get(4..6).unwrap_or("00"), 16).unwrap_or(0);
+    let r = u8::from_str_radix(cleaned.get(0..2).unwrap_or("00"), 16).unwrap_or(0);
+    let g = u8::from_str_radix(cleaned.get(2..4).unwrap_or("00"), 16).unwrap_or(0);
+    let b = u8::from_str_radix(cleaned.get(4..6).unwrap_or("00"), 16).unwrap_or(0);
     let mut rf = r as f64 / 255.0;
     let mut gf = g as f64 / 255.0;
     let mut bf = b as f64 / 255.0;
@@ -1401,7 +1401,7 @@ pub(crate) fn apply_color_transforms(base_hex: &str, color_el: &roxmltree::Node)
             _ => {}
         }
     }
-    let clamp = |v: f64| -> u8 { (v.max(0.0).min(1.0) * 255.0).round() as u8 };
+    let clamp = |v: f64| -> u8 { (v.clamp(0.0, 1.0) * 255.0).round() as u8 };
     format!("{:02X}{:02X}{:02X}", clamp(rf), clamp(gf), clamp(bf))
 }
 
@@ -1761,9 +1761,7 @@ pub(crate) fn parse_error_bars(
                     let vals = extract_num_block(&side, c_ns, n_points);
                     if !vals.is_empty() {
                         let len = vals.len().min(target.len());
-                        for i in 0..len {
-                            target[i] = vals[i];
-                        }
+                        target[..len].copy_from_slice(&vals[..len]);
                     }
                 }
             }

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
-use crate::{resolve_fill_color, read_zip_entry, resolve_zip_path, parse_rels_map};
-use std::io::Cursor;
+use crate::{parse_rels_map, read_zip_entry, resolve_fill_color, resolve_zip_path};
 use std::collections::HashMap;
+use std::io::Cursor;
 
 /// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse
 /// its drawing(s) for chart anchors (`<xdr:graphicFrame>` elements).
@@ -23,29 +23,41 @@ pub(crate) fn load_sheet_charts(
 
     // Collect all drawing relationship targets
     let mut drawing_targets: Vec<String> = Vec::new();
-    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+    for rel in rels_doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element())
+    {
         if rel.attribute("Type").unwrap_or("").ends_with("/drawing") {
             if let Some(t) = rel.attribute("Target") {
                 drawing_targets.push(t.to_string());
             }
         }
     }
-    if drawing_targets.is_empty() { return Vec::new(); }
+    if drawing_targets.is_empty() {
+        return Vec::new();
+    }
 
     let mut all_charts: Vec<ChartAnchor> = Vec::new();
     let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
-    let a_ns   = "http://schemas.openxmlformats.org/drawingml/2006/main";
-    let c_ns   = "http://schemas.openxmlformats.org/drawingml/2006/chart";
-    let r_ns   = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    let c_ns = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
     for target in drawing_targets {
         // Resolve drawing path relative to the sheet directory
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
-        let Ok(draw_doc) = roxmltree::Document::parse(&drawing_xml) else { continue; };
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+            continue;
+        };
+        let Ok(draw_doc) = roxmltree::Document::parse(&drawing_xml) else {
+            continue;
+        };
 
         // Load drawing rels (to resolve chart rIds)
-        let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else { continue; };
+        let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else {
+            continue;
+        };
         let drawing_rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
         let drawing_rels = read_zip_entry(archive, &drawing_rels_path)
             .ok()
@@ -53,35 +65,53 @@ pub(crate) fn load_sheet_charts(
             .unwrap_or_default();
 
         // Iterate over twoCellAnchor elements
-        for anchor in draw_doc.root_element().children().filter(|n| n.is_element()) {
+        for anchor in draw_doc
+            .root_element()
+            .children()
+            .filter(|n| n.is_element())
+        {
             if anchor.tag_name().name() != "twoCellAnchor"
                 || anchor.tag_name().namespace() != Some(xdr_ns)
             {
                 continue;
             }
 
-            let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) = (0u32, 0i64, 0u32, 0i64);
-            let (mut to_col,   mut to_col_off,   mut to_row,   mut to_row_off)   = (0u32, 0i64, 0u32, 0i64);
+            let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) =
+                (0u32, 0i64, 0u32, 0i64);
+            let (mut to_col, mut to_col_off, mut to_row, mut to_row_off) = (0u32, 0i64, 0u32, 0i64);
             let mut chart_rid: Option<String> = None;
 
             for child in anchor.children() {
-                if !child.is_element() { continue; }
+                if !child.is_element() {
+                    continue;
+                }
                 match child.tag_name().name() {
                     "from" | "to" => {
                         let is_from = child.tag_name().name() == "from";
-                        let mut col: u32 = 0; let mut col_off: i64 = 0;
-                        let mut row: u32 = 0; let mut row_off: i64 = 0;
+                        let mut col: u32 = 0;
+                        let mut col_off: i64 = 0;
+                        let mut row: u32 = 0;
+                        let mut row_off: i64 = 0;
                         for c in child.children() {
                             match (c.tag_name().name(), c.text()) {
-                                ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                                ("col", Some(t)) => col = t.trim().parse().unwrap_or(0),
                                 ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
-                                ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                                ("row", Some(t)) => row = t.trim().parse().unwrap_or(0),
                                 ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
                                 _ => {}
                             }
                         }
-                        if is_from { from_col = col; from_col_off = col_off; from_row = row; from_row_off = row_off; }
-                        else       { to_col   = col; to_col_off   = col_off; to_row   = row; to_row_off   = row_off; }
+                        if is_from {
+                            from_col = col;
+                            from_col_off = col_off;
+                            from_row = row;
+                            from_row_off = row_off;
+                        } else {
+                            to_col = col;
+                            to_col_off = col_off;
+                            to_row = row;
+                            to_row_off = row_off;
+                        }
                     }
                     "graphicFrame" => {
                         // Look for a:graphic/a:graphicData/c:chart[@r:id]
@@ -89,7 +119,8 @@ pub(crate) fn load_sheet_charts(
                             if gf_child.tag_name().name() == "chart"
                                 && gf_child.tag_name().namespace() == Some(c_ns)
                             {
-                                if let Some(rid) = gf_child.attributes()
+                                if let Some(rid) = gf_child
+                                    .attributes()
                                     .find(|a| a.name() == "id" && a.namespace() == Some(r_ns))
                                     .map(|a| a.value().to_string())
                                 {
@@ -102,15 +133,29 @@ pub(crate) fn load_sheet_charts(
                 }
             }
 
-            let Some(rid) = chart_rid else { continue; };
-            let Some(chart_target) = drawing_rels.get(&rid) else { continue; };
+            let Some(rid) = chart_rid else {
+                continue;
+            };
+            let Some(chart_target) = drawing_rels.get(&rid) else {
+                continue;
+            };
             let chart_path = resolve_zip_path(drawing_dir, chart_target);
-            let Ok(chart_xml) = read_zip_entry(archive, &chart_path) else { continue; };
-            let Some(chart_data) = parse_chart_xml(&chart_xml, c_ns, a_ns, theme_colors) else { continue; };
+            let Ok(chart_xml) = read_zip_entry(archive, &chart_path) else {
+                continue;
+            };
+            let Some(chart_data) = parse_chart_xml(&chart_xml, c_ns, a_ns, theme_colors) else {
+                continue;
+            };
 
             all_charts.push(ChartAnchor {
-                from_col, from_col_off, from_row, from_row_off,
-                to_col,   to_col_off,   to_row,   to_row_off,
+                from_col,
+                from_col_off,
+                from_row,
+                from_row_off,
+                to_col,
+                to_col_off,
+                to_row,
+                to_row_off,
                 chart: chart_data,
             });
         }
@@ -121,11 +166,17 @@ pub(crate) fn load_sheet_charts(
 // ─── Chart XML parser ────────────────────────────────────────────────────────
 
 /// Parse a `xl/charts/chartN.xml` file into a `ChartData`.
-pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &[String]) -> Option<ChartData> {
+pub(crate) fn parse_chart_xml(
+    xml: &str,
+    c_ns: &str,
+    a_ns: &str,
+    theme_colors: &[String],
+) -> Option<ChartData> {
     let doc = roxmltree::Document::parse(xml).ok()?;
 
     // Find c:chart root element
-    let chart_root = doc.descendants()
+    let chart_root = doc
+        .descendants()
         .find(|n| n.tag_name().name() == "chart" && n.tag_name().namespace() == Some(c_ns))?;
 
     // Parse optional title
@@ -141,7 +192,8 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
     // ECMA-376 §21.2.2.10 — both parts come from the shared ooxml-common helper
     // so pptx & xlsx stay in lockstep.
     let (show_legend, legend_pos) = ooxml_common::chart::extract_legend(chart_root);
-    let legend_node = chart_root.children()
+    let legend_node = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "legend" && n.tag_name().namespace() == Some(c_ns));
     // Legend <c:layout><c:manualLayout> (ECMA-376 §21.2.2.31) — when present,
     // gives explicit x/y/w/h fractions of the chart space. Used by the Excel
@@ -149,17 +201,25 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
     // left half of the chart. We just collect the raw fractions here; the
     // renderer decides whether to honor `edge` vs `factor` placement.
     let legend_manual_layout = legend_node.and_then(|ln| {
-        let layout = ln.children()
+        let layout = ln
+            .children()
             .find(|n| n.tag_name().name() == "layout" && n.tag_name().namespace() == Some(c_ns))?;
-        let manual = layout.children()
-            .find(|n| n.tag_name().name() == "manualLayout" && n.tag_name().namespace() == Some(c_ns))?;
-        let val = |tag: &str| manual.children()
-            .find(|n| n.tag_name().name() == tag && n.tag_name().namespace() == Some(c_ns))
-            .and_then(|n| n.attribute("val").and_then(|v| v.parse::<f64>().ok()));
-        let mode = |tag: &str| manual.children()
-            .find(|n| n.tag_name().name() == tag && n.tag_name().namespace() == Some(c_ns))
-            .and_then(|n| n.attribute("val").map(|v| v.to_string()))
-            .unwrap_or_else(|| "edge".to_string());
+        let manual = layout.children().find(|n| {
+            n.tag_name().name() == "manualLayout" && n.tag_name().namespace() == Some(c_ns)
+        })?;
+        let val = |tag: &str| {
+            manual
+                .children()
+                .find(|n| n.tag_name().name() == tag && n.tag_name().namespace() == Some(c_ns))
+                .and_then(|n| n.attribute("val").and_then(|v| v.parse::<f64>().ok()))
+        };
+        let mode = |tag: &str| {
+            manual
+                .children()
+                .find(|n| n.tag_name().name() == tag && n.tag_name().namespace() == Some(c_ns))
+                .and_then(|n| n.attribute("val").map(|v| v.to_string()))
+                .unwrap_or_else(|| "edge".to_string())
+        };
         Some(LegendManualLayout {
             x_mode: mode("xMode"),
             y_mode: mode("yMode"),
@@ -177,18 +237,26 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
     // the theme just like series fills. When the element is absent we leave
     // `chart_bg` unset and tell the adapter to use the default opaque white
     // via `has_chart_sp_pr=false`.
-    let chart_space_root = doc.descendants()
+    let chart_space_root = doc
+        .descendants()
         .find(|n| n.tag_name().name() == "chartSpace" && n.tag_name().namespace() == Some(c_ns));
-    let chart_sp_pr = chart_space_root.and_then(|cs| cs.children()
-        .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns)));
+    let chart_sp_pr = chart_space_root.and_then(|cs| {
+        cs.children()
+            .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns))
+    });
     let has_chart_sp_pr = chart_sp_pr.is_some();
     let chart_bg = chart_sp_pr.and_then(|sp| {
         // Walk direct children: noFill → None, solidFill → resolved color.
         let mut resolved: Option<String> = None;
         for ch in sp.children().filter(|n| n.is_element()) {
             match ch.tag_name().name() {
-                "noFill"    => { return None; }
-                "solidFill" => { resolved = resolve_fill_color(&ch, theme_colors); break; }
+                "noFill" => {
+                    return None;
+                }
+                "solidFill" => {
+                    resolved = resolve_fill_color(&ch, theme_colors);
+                    break;
+                }
                 _ => {}
             }
         }
@@ -196,21 +264,27 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
     });
 
     // `<c:title><c:layout><c:manualLayout>` (ECMA-376 §21.2.2.27).
-    let title_manual_layout = chart_root.children()
+    let title_manual_layout = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))
-        .and_then(|t| t.children().find(|n| n.tag_name().name() == "layout" && n.tag_name().namespace() == Some(c_ns)))
+        .and_then(|t| {
+            t.children()
+                .find(|n| n.tag_name().name() == "layout" && n.tag_name().namespace() == Some(c_ns))
+        })
         .and_then(|l| extract_manual_layout(&l, c_ns));
 
     // Find c:plotArea
-    let plot_area = chart_root.children()
+    let plot_area = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "plotArea" && n.tag_name().namespace() == Some(c_ns))?;
-    let plot_area_manual_layout = plot_area.children()
+    let plot_area_manual_layout = plot_area
+        .children()
         .find(|n| n.tag_name().name() == "layout" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|l| extract_manual_layout(&l, c_ns));
 
     let mut primary_type = String::new();
-    let mut bar_dir      = "col".to_string();
-    let mut grouping     = "clustered".to_string();
+    let mut bar_dir = "col".to_string();
+    let mut grouping = "clustered".to_string();
     // `grouping` is recorded only from the first non-line chart-type element that
     // explicitly sets it. In combo charts (e.g. `<c:barChart grouping="stacked">`
     // followed by `<c:lineChart grouping="standard">`) the lineChart's grouping
@@ -265,19 +339,23 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
 
     // Recognised chart-type element names → our internal type strings
     let type_map: &[(&str, &str)] = &[
-        ("barChart",      "bar"),
-        ("lineChart",     "line"),
-        ("areaChart",     "area"),
-        ("pieChart",      "pie"),
+        ("barChart", "bar"),
+        ("lineChart", "line"),
+        ("areaChart", "area"),
+        ("pieChart", "pie"),
         ("doughnutChart", "doughnut"),
-        ("radarChart",    "radar"),
-        ("scatterChart",  "scatter"),
-        ("bubbleChart",   "scatter"), // treat bubble as scatter
+        ("radarChart", "radar"),
+        ("scatterChart", "scatter"),
+        ("bubbleChart", "scatter"), // treat bubble as scatter
     ];
 
     for child in plot_area.children() {
-        if !child.is_element() { continue; }
-        if child.tag_name().namespace() != Some(c_ns) { continue; }
+        if !child.is_element() {
+            continue;
+        }
+        if child.tag_name().namespace() != Some(c_ns) {
+            continue;
+        }
         let elem_name = child.tag_name().name();
 
         // Axis title + tick label font size extraction (ECMA-376 §21.2.2.17
@@ -298,24 +376,42 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                 }
                 if cat_axis_line_color.is_none() || cat_axis_line_width_emu.is_none() {
                     let (col, w) = extract_axis_line_style(&child, c_ns, theme_colors);
-                    if cat_axis_line_color.is_none() { cat_axis_line_color = col; }
-                    if cat_axis_line_width_emu.is_none() { cat_axis_line_width_emu = w; }
+                    if cat_axis_line_color.is_none() {
+                        cat_axis_line_color = col;
+                    }
+                    if cat_axis_line_width_emu.is_none() {
+                        cat_axis_line_width_emu = w;
+                    }
                 }
                 if cat_axis_major_tick_mark.is_none() {
-                    cat_axis_major_tick_mark = extract_axis_tick_mark(&child, c_ns, "majorTickMark");
+                    cat_axis_major_tick_mark =
+                        extract_axis_tick_mark(&child, c_ns, "majorTickMark");
                 }
                 if cat_axis_minor_tick_mark.is_none() {
-                    cat_axis_minor_tick_mark = extract_axis_tick_mark(&child, c_ns, "minorTickMark");
+                    cat_axis_minor_tick_mark =
+                        extract_axis_tick_mark(&child, c_ns, "minorTickMark");
                 }
                 if let Some((mn, mx)) = extract_axis_scaling(&child, c_ns) {
-                    if cat_axis_min.is_none() { cat_axis_min = mn; }
-                    if cat_axis_max.is_none() { cat_axis_max = mx; }
+                    if cat_axis_min.is_none() {
+                        cat_axis_min = mn;
+                    }
+                    if cat_axis_max.is_none() {
+                        cat_axis_max = mx;
+                    }
                 }
                 let (cr, cra) = extract_axis_crosses(&child, c_ns);
-                if cat_axis_crosses.is_none() { cat_axis_crosses = cr; }
-                if cat_axis_crosses_at.is_none() { cat_axis_crosses_at = cra; }
-                if axis_is_deleted(&child, c_ns) { cat_axis_hidden = true; }
-                if axis_line_is_hidden(&child, c_ns) { cat_axis_line_hidden = true; }
+                if cat_axis_crosses.is_none() {
+                    cat_axis_crosses = cr;
+                }
+                if cat_axis_crosses_at.is_none() {
+                    cat_axis_crosses_at = cra;
+                }
+                if axis_is_deleted(&child, c_ns) {
+                    cat_axis_hidden = true;
+                }
+                if axis_line_is_hidden(&child, c_ns) {
+                    cat_axis_line_hidden = true;
+                }
                 continue;
             }
             "valAx" => {
@@ -323,8 +419,11 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                 // by `<c:axPos val>` — `b`(bottom)/`t`(top) → X axis, `l`/`r`
                 // → Y axis. For non-scatter charts the first valAx hit is
                 // always Y.
-                let ax_pos = child.children()
-                    .find(|n| n.tag_name().name() == "axPos" && n.tag_name().namespace() == Some(c_ns))
+                let ax_pos = child
+                    .children()
+                    .find(|n| {
+                        n.tag_name().name() == "axPos" && n.tag_name().namespace() == Some(c_ns)
+                    })
                     .and_then(|n| n.attribute("val"))
                     .unwrap_or("");
                 let is_x_axis = matches!(ax_pos, "b" | "t");
@@ -333,8 +432,12 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                         cat_axis_format_code = extract_axis_format_code(&child, c_ns);
                     }
                     if let Some((mn, mx)) = extract_axis_scaling(&child, c_ns) {
-                        if cat_axis_min.is_none() { cat_axis_min = mn; }
-                        if cat_axis_max.is_none() { cat_axis_max = mx; }
+                        if cat_axis_min.is_none() {
+                            cat_axis_min = mn;
+                        }
+                        if cat_axis_max.is_none() {
+                            cat_axis_max = mx;
+                        }
                     }
                     if cat_axis_font_size_hpt.is_none() {
                         cat_axis_font_size_hpt = extract_axis_tick_label_size(&child, c_ns, a_ns);
@@ -344,20 +447,34 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                     }
                     if cat_axis_line_color.is_none() || cat_axis_line_width_emu.is_none() {
                         let (col, w) = extract_axis_line_style(&child, c_ns, theme_colors);
-                        if cat_axis_line_color.is_none() { cat_axis_line_color = col; }
-                        if cat_axis_line_width_emu.is_none() { cat_axis_line_width_emu = w; }
+                        if cat_axis_line_color.is_none() {
+                            cat_axis_line_color = col;
+                        }
+                        if cat_axis_line_width_emu.is_none() {
+                            cat_axis_line_width_emu = w;
+                        }
                     }
                     if cat_axis_major_tick_mark.is_none() {
-                        cat_axis_major_tick_mark = extract_axis_tick_mark(&child, c_ns, "majorTickMark");
+                        cat_axis_major_tick_mark =
+                            extract_axis_tick_mark(&child, c_ns, "majorTickMark");
                     }
                     if cat_axis_minor_tick_mark.is_none() {
-                        cat_axis_minor_tick_mark = extract_axis_tick_mark(&child, c_ns, "minorTickMark");
+                        cat_axis_minor_tick_mark =
+                            extract_axis_tick_mark(&child, c_ns, "minorTickMark");
                     }
                     let (cr, cra) = extract_axis_crosses(&child, c_ns);
-                    if cat_axis_crosses.is_none() { cat_axis_crosses = cr; }
-                    if cat_axis_crosses_at.is_none() { cat_axis_crosses_at = cra; }
-                    if axis_is_deleted(&child, c_ns) { cat_axis_hidden = true; }
-                    if axis_line_is_hidden(&child, c_ns) { cat_axis_line_hidden = true; }
+                    if cat_axis_crosses.is_none() {
+                        cat_axis_crosses = cr;
+                    }
+                    if cat_axis_crosses_at.is_none() {
+                        cat_axis_crosses_at = cra;
+                    }
+                    if axis_is_deleted(&child, c_ns) {
+                        cat_axis_hidden = true;
+                    }
+                    if axis_line_is_hidden(&child, c_ns) {
+                        cat_axis_line_hidden = true;
+                    }
                 } else {
                     if val_axis_title.is_none() {
                         val_axis_title = extract_chart_title(&child, c_ns, a_ns);
@@ -372,25 +489,43 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                         val_axis_font_bold = extract_axis_tick_label_bold(&child, c_ns);
                     }
                     if let Some((mn, mx)) = extract_axis_scaling(&child, c_ns) {
-                        if val_axis_min.is_none() { val_axis_min = mn; }
-                        if val_axis_max.is_none() { val_axis_max = mx; }
+                        if val_axis_min.is_none() {
+                            val_axis_min = mn;
+                        }
+                        if val_axis_max.is_none() {
+                            val_axis_max = mx;
+                        }
                     }
                     let (cr, cra) = extract_axis_crosses(&child, c_ns);
-                    if val_axis_crosses.is_none() { val_axis_crosses = cr; }
-                    if val_axis_crosses_at.is_none() { val_axis_crosses_at = cra; }
+                    if val_axis_crosses.is_none() {
+                        val_axis_crosses = cr;
+                    }
+                    if val_axis_crosses_at.is_none() {
+                        val_axis_crosses_at = cra;
+                    }
                     if val_axis_line_color.is_none() || val_axis_line_width_emu.is_none() {
                         let (col, w) = extract_axis_line_style(&child, c_ns, theme_colors);
-                        if val_axis_line_color.is_none() { val_axis_line_color = col; }
-                        if val_axis_line_width_emu.is_none() { val_axis_line_width_emu = w; }
+                        if val_axis_line_color.is_none() {
+                            val_axis_line_color = col;
+                        }
+                        if val_axis_line_width_emu.is_none() {
+                            val_axis_line_width_emu = w;
+                        }
                     }
                     if val_axis_major_tick_mark.is_none() {
-                        val_axis_major_tick_mark = extract_axis_tick_mark(&child, c_ns, "majorTickMark");
+                        val_axis_major_tick_mark =
+                            extract_axis_tick_mark(&child, c_ns, "majorTickMark");
                     }
                     if val_axis_minor_tick_mark.is_none() {
-                        val_axis_minor_tick_mark = extract_axis_tick_mark(&child, c_ns, "minorTickMark");
+                        val_axis_minor_tick_mark =
+                            extract_axis_tick_mark(&child, c_ns, "minorTickMark");
                     }
-                    if axis_is_deleted(&child, c_ns) { val_axis_hidden = true; }
-                    if axis_line_is_hidden(&child, c_ns) { val_axis_line_hidden = true; }
+                    if axis_is_deleted(&child, c_ns) {
+                        val_axis_hidden = true;
+                    }
+                    if axis_line_is_hidden(&child, c_ns) {
+                        val_axis_line_hidden = true;
+                    }
                 }
                 continue;
             }
@@ -412,15 +547,20 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
         let mut chart_marker_default = false;
         for attr_node in child.children().filter(|n| n.is_element()) {
             match attr_node.tag_name().name() {
-                "barDir"   => { bar_dir  = attr_node.attribute("val").unwrap_or("col").to_string(); }
+                "barDir" => {
+                    bar_dir = attr_node.attribute("val").unwrap_or("col").to_string();
+                }
                 "grouping" => {
-                    let val = attr_node.attribute("val").unwrap_or("clustered").to_string();
+                    let val = attr_node
+                        .attribute("val")
+                        .unwrap_or("clustered")
+                        .to_string();
                     if !grouping_locked && ser_type != "line" {
                         grouping = val;
                         grouping_locked = true;
                     }
                 }
-                "marker"   => {
+                "marker" => {
                     chart_marker_default = attr_node.attribute("val").unwrap_or("0") != "0";
                 }
                 "gapWidth" => {
@@ -430,7 +570,7 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                         bar_gap_width = attr_node.attribute("val").and_then(|v| v.parse().ok());
                     }
                 }
-                "overlap"  => {
+                "overlap" => {
                     // ECMA-376 §21.2.2.25 — signed percent of bar width for the
                     // overlap within a cluster (negative = gap).
                     if bar_overlap.is_none() {
@@ -446,7 +586,7 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                         radar_style = attr_node.attribute("val").map(|s| s.to_string());
                     }
                 }
-                "dLbls"    => {
+                "dLbls" => {
                     for d in attr_node.children().filter(|n| n.is_element()) {
                         match d.tag_name().name() {
                             "showVal" | "showPercent" => {
@@ -461,7 +601,8 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                             }
                             "numFmt" => {
                                 if data_label_format_code.is_none() {
-                                    data_label_format_code = d.attribute("formatCode")
+                                    data_label_format_code = d
+                                        .attribute("formatCode")
                                         .map(|s| s.to_string())
                                         .filter(|s| !s.is_empty() && s != "General");
                                 }
@@ -477,10 +618,16 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
         }
 
         // Parse series
-        for ser_node in child.children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "ser" && n.tag_name().namespace() == Some(c_ns))
-        {
-            let s = parse_chart_series(&ser_node, c_ns, ser_type, chart_marker_default, theme_colors);
+        for ser_node in child.children().filter(|n| {
+            n.is_element() && n.tag_name().name() == "ser" && n.tag_name().namespace() == Some(c_ns)
+        }) {
+            let s = parse_chart_series(
+                &ser_node,
+                c_ns,
+                ser_type,
+                chart_marker_default,
+                theme_colors,
+            );
             if shared_categories.is_empty() && !s.categories.is_empty() {
                 shared_categories = s.categories.clone();
             }
@@ -495,11 +642,11 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
             // the default-color/position/format travels when Excel emits
             // `<c:dLblPos val="inBase"/>` + `<c:txPr>` per series rather
             // than on the chart.
-            if let Some(ser_dlbls) = ser_node.children()
-                .find(|n| n.is_element()
+            if let Some(ser_dlbls) = ser_node.children().find(|n| {
+                n.is_element()
                     && n.tag_name().name() == "dLbls"
-                    && n.tag_name().namespace() == Some(c_ns))
-            {
+                    && n.tag_name().namespace() == Some(c_ns)
+            }) {
                 for d in ser_dlbls.children().filter(|n| n.is_element()) {
                     match d.tag_name().name() {
                         "showVal" | "showPercent" => {
@@ -514,7 +661,8 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
                         }
                         "numFmt" => {
                             if data_label_format_code.is_none() {
-                                data_label_format_code = d.attribute("formatCode")
+                                data_label_format_code = d
+                                    .attribute("formatCode")
                                     .map(|s| s.to_string())
                                     .filter(|s| !s.is_empty() && s != "General");
                             }
@@ -528,7 +676,9 @@ pub(crate) fn parse_chart_xml(xml: &str, c_ns: &str, a_ns: &str, theme_colors: &
         }
     }
 
-    if primary_type.is_empty() { return None; }
+    if primary_type.is_empty() {
+        return None;
+    }
 
     // Fill in categories for series that have none (mixed charts share categories)
     for s in &mut all_series {
@@ -607,7 +757,11 @@ pub(crate) fn extract_axis_format_code(axis_node: &roxmltree::Node, _c_ns: &str)
 
 /// `<c:catAx|valAx><c:majorTickMark val>` / `<c:minorTickMark val>` —
 /// `none` / `out` / `in` / `cross` (ECMA-376 §21.2.2.49 ST_TickMark).
-pub(crate) fn extract_axis_tick_mark(axis_node: &roxmltree::Node, _c_ns: &str, name: &str) -> Option<String> {
+pub(crate) fn extract_axis_tick_mark(
+    axis_node: &roxmltree::Node,
+    _c_ns: &str,
+    name: &str,
+) -> Option<String> {
     ooxml_common::chart::extract_axis_tick_mark(*axis_node, name)
 }
 
@@ -618,10 +772,15 @@ pub(crate) fn extract_axis_line_style(
     c_ns: &str,
     theme_colors: &[String],
 ) -> (Option<String>, Option<u32>) {
-    let Some(sp_pr) = axis_node.children()
+    let Some(sp_pr) = axis_node
+        .children()
         .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns))
-    else { return (None, None); };
-    let Some(ln) = sp_pr.children().find(|n| n.tag_name().name() == "ln") else { return (None, None); };
+    else {
+        return (None, None);
+    };
+    let Some(ln) = sp_pr.children().find(|n| n.tag_name().name() == "ln") else {
+        return (None, None);
+    };
     let width = ln.attribute("w").and_then(|v| v.parse::<u32>().ok());
     let color = extract_solid_fill_in_drawingml(&ln, theme_colors);
     (color, width)
@@ -633,22 +792,37 @@ pub(crate) fn extract_axis_line_style(
 /// Growth" uses this on `<c:valAx>` to keep the Y-axis numbers visible
 /// while suppressing the vertical rule.
 pub(crate) fn axis_line_is_hidden(axis_node: &roxmltree::Node, c_ns: &str) -> bool {
-    let Some(sp_pr) = axis_node.children()
+    let Some(sp_pr) = axis_node
+        .children()
         .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns))
-    else { return false; };
-    let Some(ln) = sp_pr.children().find(|n| n.tag_name().name() == "ln") else { return false; };
-    ln.children().any(|n| n.is_element() && n.tag_name().name() == "noFill")
+    else {
+        return false;
+    };
+    let Some(ln) = sp_pr.children().find(|n| n.tag_name().name() == "ln") else {
+        return false;
+    };
+    ln.children()
+        .any(|n| n.is_element() && n.tag_name().name() == "noFill")
 }
 
 /// `<c:catAx|valAx><c:txPr>...defRPr@b>` — bold flag for axis tick labels.
-pub(crate) fn extract_axis_tick_label_bold(axis_node: &roxmltree::Node, c_ns: &str) -> Option<bool> {
-    let txpr = axis_node.children()
+pub(crate) fn extract_axis_tick_label_bold(
+    axis_node: &roxmltree::Node,
+    c_ns: &str,
+) -> Option<bool> {
+    let txpr = axis_node
+        .children()
         .find(|n| n.tag_name().name() == "txPr" && n.tag_name().namespace() == Some(c_ns))?;
     txpr.descendants().find_map(|n| {
-        if !n.is_element() { return None; }
+        if !n.is_element() {
+            return None;
+        }
         let tag = n.tag_name().name();
-        if tag != "defRPr" && tag != "rPr" { return None; }
-        n.attribute("b").map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        if tag != "defRPr" && tag != "rPr" {
+            return None;
+        }
+        n.attribute("b")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
     })
 }
 
@@ -656,12 +830,17 @@ pub(crate) fn extract_axis_tick_label_bold(axis_node: &roxmltree::Node, c_ns: &s
 /// along its perpendicular axis. `crosses` is a string ("autoZero" |
 /// "min" | "max"); `crossesAt` is an explicit numeric override that
 /// takes precedence at render time.
-pub(crate) fn extract_axis_crosses(axis_node: &roxmltree::Node, c_ns: &str) -> (Option<String>, Option<f64>) {
-    let crosses = axis_node.children()
+pub(crate) fn extract_axis_crosses(
+    axis_node: &roxmltree::Node,
+    c_ns: &str,
+) -> (Option<String>, Option<f64>) {
+    let crosses = axis_node
+        .children()
         .find(|n| n.tag_name().name() == "crosses" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .map(|s| s.to_string());
-    let crosses_at = axis_node.children()
+    let crosses_at = axis_node
+        .children()
         .find(|n| n.tag_name().name() == "crossesAt" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .and_then(|v| v.parse::<f64>().ok());
@@ -672,9 +851,16 @@ pub(crate) fn extract_axis_crosses(axis_node: &roxmltree::Node, c_ns: &str) -> (
 /// `(min, max)` where each is `None` if the axis didn't override that bound.
 /// Returns `None` only when neither bound is set (matches the prior xlsx
 /// callsite shape `if let Some((mn, mx)) = …`).
-pub(crate) fn extract_axis_scaling(axis_node: &roxmltree::Node, _c_ns: &str) -> Option<(Option<f64>, Option<f64>)> {
+pub(crate) fn extract_axis_scaling(
+    axis_node: &roxmltree::Node,
+    _c_ns: &str,
+) -> Option<(Option<f64>, Option<f64>)> {
     let (mn, mx) = ooxml_common::chart::extract_axis_min_max(*axis_node);
-    if mn.is_some() || mx.is_some() { Some((mn, mx)) } else { None }
+    if mn.is_some() || mx.is_some() {
+        Some((mn, mx))
+    } else {
+        None
+    }
 }
 
 /// `<c:catAx|valAx><c:delete val="1"/>` — true when the axis is hidden
@@ -686,9 +872,13 @@ pub(crate) fn axis_is_deleted(axis_node: &roxmltree::Node, _c_ns: &str) -> bool 
 /// Extract a `<c:layout><c:manualLayout>` block. The given `layout_node` is
 /// `<c:layout>` (parent of `<c:manualLayout>`). Returns None when the layout
 /// is auto (no `manualLayout` child).
-pub(crate) fn extract_manual_layout(layout_node: &roxmltree::Node, c_ns: &str) -> Option<ManualLayout> {
-    let ml = layout_node.children()
-        .find(|n| n.tag_name().name() == "manualLayout" && n.tag_name().namespace() == Some(c_ns))?;
+pub(crate) fn extract_manual_layout(
+    layout_node: &roxmltree::Node,
+    c_ns: &str,
+) -> Option<ManualLayout> {
+    let ml = layout_node.children().find(|n| {
+        n.tag_name().name() == "manualLayout" && n.tag_name().namespace() == Some(c_ns)
+    })?;
     let mut x_mode = "edge".to_string();
     let mut y_mode = "edge".to_string();
     let mut layout_target: Option<String> = None;
@@ -696,39 +886,87 @@ pub(crate) fn extract_manual_layout(layout_node: &roxmltree::Node, c_ns: &str) -
     let mut y = 0.0_f64;
     let mut w: Option<f64> = None;
     let mut h: Option<f64> = None;
-    for ch in ml.children().filter(|n| n.is_element() && n.tag_name().namespace() == Some(c_ns)) {
+    for ch in ml
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().namespace() == Some(c_ns))
+    {
         let val = ch.attribute("val").map(|s| s.to_string());
         match ch.tag_name().name() {
-            "xMode" => { if let Some(v) = val { x_mode = v; } }
-            "yMode" => { if let Some(v) = val { y_mode = v; } }
-            "layoutTarget" => { layout_target = val; }
-            "x" => { if let Some(v) = ch.attribute("val").and_then(|s| s.parse::<f64>().ok()) { x = v; } }
-            "y" => { if let Some(v) = ch.attribute("val").and_then(|s| s.parse::<f64>().ok()) { y = v; } }
-            "w" => { w = ch.attribute("val").and_then(|s| s.parse::<f64>().ok()); }
-            "h" => { h = ch.attribute("val").and_then(|s| s.parse::<f64>().ok()); }
+            "xMode" => {
+                if let Some(v) = val {
+                    x_mode = v;
+                }
+            }
+            "yMode" => {
+                if let Some(v) = val {
+                    y_mode = v;
+                }
+            }
+            "layoutTarget" => {
+                layout_target = val;
+            }
+            "x" => {
+                if let Some(v) = ch.attribute("val").and_then(|s| s.parse::<f64>().ok()) {
+                    x = v;
+                }
+            }
+            "y" => {
+                if let Some(v) = ch.attribute("val").and_then(|s| s.parse::<f64>().ok()) {
+                    y = v;
+                }
+            }
+            "w" => {
+                w = ch.attribute("val").and_then(|s| s.parse::<f64>().ok());
+            }
+            "h" => {
+                h = ch.attribute("val").and_then(|s| s.parse::<f64>().ok());
+            }
             _ => {}
         }
     }
-    Some(ManualLayout { x_mode, y_mode, layout_target, x, y, w, h })
+    Some(ManualLayout {
+        x_mode,
+        y_mode,
+        layout_target,
+        x,
+        y,
+        w,
+        h,
+    })
 }
 
 /// Extract a category/value axis tick-label font size (hundredths of a point)
 /// from the first `a:defRPr@sz` (or `a:rPr@sz`) inside the axis' `c:txPr`.
 /// ECMA-376 §21.2.2.17 — `<c:txPr>` controls tick label text properties.
-pub(crate) fn extract_axis_tick_label_size(axis_node: &roxmltree::Node, _c_ns: &str, _a_ns: &str) -> Option<i32> {
+pub(crate) fn extract_axis_tick_label_size(
+    axis_node: &roxmltree::Node,
+    _c_ns: &str,
+    _a_ns: &str,
+) -> Option<i32> {
     ooxml_common::chart::extract_axis_tick_label_size(*axis_node)
 }
 
 /// Extract the chart title's font size (hundredths of a point) from the first
 /// `a:defRPr@sz` or `a:rPr@sz` found under `c:title`. Returns None when absent.
-pub(crate) fn extract_chart_title_size(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<i32> {
-    let title_node = chart_root.children()
+pub(crate) fn extract_chart_title_size(
+    chart_root: &roxmltree::Node,
+    c_ns: &str,
+    a_ns: &str,
+) -> Option<i32> {
+    let title_node = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
     title_node.descendants().find_map(|n| {
-        if !n.is_element() { return None; }
-        if n.tag_name().namespace() != Some(a_ns) { return None; }
+        if !n.is_element() {
+            return None;
+        }
+        if n.tag_name().namespace() != Some(a_ns) {
+            return None;
+        }
         let tag = n.tag_name().name();
-        if tag != "defRPr" && tag != "rPr" { return None; }
+        if tag != "defRPr" && tag != "rPr" {
+            return None;
+        }
         n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
     })
 }
@@ -736,15 +974,27 @@ pub(crate) fn extract_chart_title_size(chart_root: &roxmltree::Node, c_ns: &str,
 /// Extract chart title bold flag from the first `a:defRPr@b` / `a:rPr@b`
 /// inside `c:title`. Returns None when not specified (renderer treats as
 /// not bold).
-pub(crate) fn extract_chart_title_bold(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<bool> {
-    let title_node = chart_root.children()
+pub(crate) fn extract_chart_title_bold(
+    chart_root: &roxmltree::Node,
+    c_ns: &str,
+    a_ns: &str,
+) -> Option<bool> {
+    let title_node = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
     title_node.descendants().find_map(|n| {
-        if !n.is_element() { return None; }
-        if n.tag_name().namespace() != Some(a_ns) { return None; }
+        if !n.is_element() {
+            return None;
+        }
+        if n.tag_name().namespace() != Some(a_ns) {
+            return None;
+        }
         let tag = n.tag_name().name();
-        if tag != "defRPr" && tag != "rPr" { return None; }
-        n.attribute("b").map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        if tag != "defRPr" && tag != "rPr" {
+            return None;
+        }
+        n.attribute("b")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
     })
 }
 
@@ -752,50 +1002,88 @@ pub(crate) fn extract_chart_title_bold(chart_root: &roxmltree::Node, c_ns: &str,
 /// `a:solidFill/a:srgbClr@val` inside `c:title`. Only srgb is resolved here —
 /// scheme colors would require the workbook theme, which isn't wired through
 /// to chart parsing yet.
-pub(crate) fn extract_chart_title_color(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<String> {
-    let title_node = chart_root.children()
+pub(crate) fn extract_chart_title_color(
+    chart_root: &roxmltree::Node,
+    c_ns: &str,
+    a_ns: &str,
+) -> Option<String> {
+    let title_node = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
     title_node.descendants().find_map(|n| {
-        if !n.is_element() { return None; }
-        if n.tag_name().namespace() != Some(a_ns) { return None; }
-        if n.tag_name().name() != "srgbClr" { return None; }
+        if !n.is_element() {
+            return None;
+        }
+        if n.tag_name().namespace() != Some(a_ns) {
+            return None;
+        }
+        if n.tag_name().name() != "srgbClr" {
+            return None;
+        }
         // Skip srgbClr nodes that aren't inside a solidFill (e.g. a gradient stop).
-        let parent_is_solid = n.parent()
+        let parent_is_solid = n
+            .parent()
             .map(|p| p.tag_name().name() == "solidFill" && p.tag_name().namespace() == Some(a_ns))
             .unwrap_or(false);
-        if !parent_is_solid { return None; }
+        if !parent_is_solid {
+            return None;
+        }
         n.attribute("val").map(|s| s.to_string())
     })
 }
 
 /// Extract the chart title's font family from the first `a:latin@typeface`
 /// descendant of `c:title` (ECMA-376 DrawingML §20.1.4.2.24).
-pub(crate) fn extract_chart_title_face(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<String> {
-    let title_node = chart_root.children()
+pub(crate) fn extract_chart_title_face(
+    chart_root: &roxmltree::Node,
+    c_ns: &str,
+    a_ns: &str,
+) -> Option<String> {
+    let title_node = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
     title_node.descendants().find_map(|n| {
-        if !n.is_element() { return None; }
-        if n.tag_name().namespace() != Some(a_ns) { return None; }
-        if n.tag_name().name() != "latin" { return None; }
+        if !n.is_element() {
+            return None;
+        }
+        if n.tag_name().namespace() != Some(a_ns) {
+            return None;
+        }
+        if n.tag_name().name() != "latin" {
+            return None;
+        }
         n.attribute("typeface").map(|s| s.to_string())
     })
 }
 
 /// Extract plain text from `c:chart/c:title`.
-pub(crate) fn extract_chart_title(chart_root: &roxmltree::Node, c_ns: &str, a_ns: &str) -> Option<String> {
-    let title_node = chart_root.children()
+pub(crate) fn extract_chart_title(
+    chart_root: &roxmltree::Node,
+    c_ns: &str,
+    a_ns: &str,
+) -> Option<String> {
+    let title_node = chart_root
+        .children()
         .find(|n| n.tag_name().name() == "title" && n.tag_name().namespace() == Some(c_ns))?;
     // c:title/c:tx/c:rich/a:p/a:r/a:t  or  c:title/c:tx/c:strRef/c:strCache/c:pt/c:v
     let mut text = String::new();
     for node in title_node.descendants() {
         if node.tag_name().name() == "t" && node.tag_name().namespace() == Some(a_ns) {
-            if let Some(t) = node.text() { text.push_str(t); }
+            if let Some(t) = node.text() {
+                text.push_str(t);
+            }
         }
         if node.tag_name().name() == "v" && node.tag_name().namespace() == Some(c_ns) {
-            if let Some(t) = node.text() { text.push_str(t); }
+            if let Some(t) = node.text() {
+                text.push_str(t);
+            }
         }
     }
-    if text.is_empty() { None } else { Some(text) }
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
 }
 
 /// Parse one `<c:ser>` element.
@@ -822,8 +1110,12 @@ impl ooxml_common::chart::ColorResolver for XlsxColorResolver<'_> {
 }
 /// Series fill color from `<c:ser><c:spPr><a:solidFill>`. Returns None when
 /// the series has no direct `<c:spPr>` or its fill isn't a recognised solid.
-pub(crate) fn resolve_series_color(ser_node: &roxmltree::Node, theme_colors: &[String]) -> Option<String> {
-    let sp_pr = ser_node.children()
+pub(crate) fn resolve_series_color(
+    ser_node: &roxmltree::Node,
+    theme_colors: &[String],
+) -> Option<String> {
+    let sp_pr = ser_node
+        .children()
         .find(|n| n.is_element() && n.tag_name().name() == "spPr")?;
     // Line / scatter / radar series carry their color on `<a:ln><a:solidFill>`
     // (the series IS the stroke), not on `<a:solidFill>` directly under spPr.
@@ -837,7 +1129,9 @@ pub(crate) fn resolve_series_color(ser_node: &roxmltree::Node, theme_colors: &[S
     if let Some(c) = resolve_fill_color(&sp_pr, theme_colors) {
         return Some(c);
     }
-    let ln = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "ln")?;
+    let ln = sp_pr
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "ln")?;
     resolve_fill_color(&ln, theme_colors)
 }
 
@@ -854,7 +1148,8 @@ pub(crate) fn parse_chart_series(
     // uses for default color selection. When absent, fall back to 0 so we
     // still produce a deterministic palette pick. `<c:order>` is the display
     // order (legend / stacking) and is intentionally ignored for coloring.
-    let idx: usize = node.children()
+    let idx: usize = node
+        .children()
         .find(|n| n.tag_name().name() == "idx" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .and_then(|v| v.parse::<usize>().ok())
@@ -862,7 +1157,8 @@ pub(crate) fn parse_chart_series(
 
     // `<c:order val>` (ECMA-376 §21.2.2.28) — series display order. Used for
     // stacking and legend ordering. Defaults to 0.
-    let order: usize = node.children()
+    let order: usize = node
+        .children()
         .find(|n| n.tag_name().name() == "order" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .and_then(|v| v.parse::<usize>().ok())
@@ -870,20 +1166,28 @@ pub(crate) fn parse_chart_series(
 
     // For scatter: xVal → categories (as strings), yVal → values
     // For others:  cat  → categories,             val  → values
-    let (cat_tag, val_tag) = if ser_type == "scatter" { ("xVal", "yVal") } else { ("cat", "val") };
+    let (cat_tag, val_tag) = if ser_type == "scatter" {
+        ("xVal", "yVal")
+    } else {
+        ("cat", "val")
+    };
 
     let categories = collect_str_cache(node, c_ns, cat_tag);
-    let values     = collect_num_cache(node, c_ns, val_tag);
+    let values = collect_num_cache(node, c_ns, val_tag);
     // `<c:val><c:numRef><c:numCache><c:formatCode>` (ECMA-376 §21.2.2.37)
     // preserves the Excel number format Excel stamped onto the cached values
     // at save time; absent "General" codes return None so the renderer can
     // fall back cleanly.
-    let val_format_code = node.children()
+    let val_format_code = node
+        .children()
         .find(|n| n.tag_name().name() == val_tag && n.tag_name().namespace() == Some(c_ns))
-        .and_then(|val_node| val_node.descendants()
-            .find(|n| n.is_element()
-                && n.tag_name().name() == "formatCode"
-                && n.tag_name().namespace() == Some(c_ns)))
+        .and_then(|val_node| {
+            val_node.descendants().find(|n| {
+                n.is_element()
+                    && n.tag_name().name() == "formatCode"
+                    && n.tag_name().namespace() == Some(c_ns)
+            })
+        })
         .and_then(|n| n.text().map(|s| s.to_string()))
         .filter(|s| !s.is_empty() && s != "General");
 
@@ -895,23 +1199,26 @@ pub(crate) fn parse_chart_series(
     // `<c:idx>`. That's the rule behind "first series = green, second = red"
     // when the theme's accent1/accent2 are green/red. We inline that
     // resolution here so the renderer doesn't need theme access.
-    let color = resolve_series_color(node, theme_colors)
-        .or_else(|| {
-            // Theme order in `theme_colors`: dk1@0, lt1@1, dk2@2, lt2@3, accent1@4 … accent6@9.
-            theme_colors.get(4 + (idx % 6)).map(|c| c.trim_start_matches('#').to_lowercase())
-        });
+    let color = resolve_series_color(node, theme_colors).or_else(|| {
+        // Theme order in `theme_colors`: dk1@0, lt1@1, dk2@2, lt2@3, accent1@4 … accent6@9.
+        theme_colors
+            .get(4 + (idx % 6))
+            .map(|c| c.trim_start_matches('#').to_lowercase())
+    });
 
     // Marker visibility (ECMA-376 §21.2.2.32 — c:marker/c:symbol default is
     // "none"). A per-series <c:marker><c:symbol> overrides; otherwise fall
     // back to the chart-type-level <c:lineChart><c:marker val> flag. Scatter
     // charts default to visible markers even without an explicit flag.
-    let marker_node = node.children()
+    let marker_node = node
+        .children()
         .find(|n| n.tag_name().name() == "marker" && n.tag_name().namespace() == Some(c_ns));
-    let (marker_symbol, marker_size, marker_fill, marker_line) = parse_marker_block(marker_node, c_ns, theme_colors);
+    let (marker_symbol, marker_size, marker_fill, marker_line) =
+        parse_marker_block(marker_node, c_ns, theme_colors);
     let show_marker = match (&marker_symbol, ser_type) {
-        (Some(sym), _)   => sym != "none",
+        (Some(sym), _) => sym != "none",
         (None, "scatter") => true,
-        _                 => chart_marker_default,
+        _ => chart_marker_default,
     };
 
     // Per-series data-label text color from `<c:ser><c:dLbls><c:txPr>…solidFill`.
@@ -930,7 +1237,8 @@ pub(crate) fn parse_chart_series(
     // CELLRANGE field placeholders against this at parse time so the
     // renderer just receives plain strings.
     let dlbl_range_cache = collect_dlbl_range_cache(node, c_ns);
-    let (series_data_labels, data_label_overrides) = parse_data_labels(node, c_ns, theme_colors, &dlbl_range_cache);
+    let (series_data_labels, data_label_overrides) =
+        parse_data_labels(node, c_ns, theme_colors, &dlbl_range_cache);
     let err_bars = parse_error_bars(node, c_ns, &values, theme_colors);
 
     ChartSeries {
@@ -962,16 +1270,21 @@ pub(crate) fn parse_marker_block(
     c_ns: &str,
     theme_colors: &[String],
 ) -> (Option<String>, Option<u32>, Option<String>, Option<String>) {
-    let Some(mk) = marker_node else { return (None, None, None, None); };
-    let symbol = mk.children()
+    let Some(mk) = marker_node else {
+        return (None, None, None, None);
+    };
+    let symbol = mk
+        .children()
         .find(|n| n.tag_name().name() == "symbol" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .map(|s| s.to_string());
-    let size = mk.children()
+    let size = mk
+        .children()
         .find(|n| n.tag_name().name() == "size" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .and_then(|v| v.parse::<u32>().ok());
-    let sp_pr = mk.children()
+    let sp_pr = mk
+        .children()
         .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns));
     let fill = sp_pr.and_then(|p| extract_solid_fill_in_drawingml(&p, theme_colors));
     let line = sp_pr.and_then(|p| {
@@ -990,7 +1303,10 @@ pub(crate) fn extract_solid_fill_in_drawingml(
     parent: &roxmltree::Node,
     theme_colors: &[String],
 ) -> Option<String> {
-    for fill in parent.children().filter(|n| n.is_element() && n.tag_name().name() == "solidFill") {
+    for fill in parent
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "solidFill")
+    {
         for clr in fill.children().filter(|n| n.is_element()) {
             match clr.tag_name().name() {
                 "srgbClr" => {
@@ -1024,12 +1340,19 @@ pub(crate) fn resolve_scheme_color(name: &str, theme_colors: &[String]) -> Optio
         "lt1" | "bg1" | "tx2" => 1,
         "dk2" => 2,
         "lt2" => 3,
-        "accent1" => 4, "accent2" => 5, "accent3" => 6,
-        "accent4" => 7, "accent5" => 8, "accent6" => 9,
-        "hlink" => 10, "folHlink" => 11,
+        "accent1" => 4,
+        "accent2" => 5,
+        "accent3" => 6,
+        "accent4" => 7,
+        "accent5" => 8,
+        "accent6" => 9,
+        "hlink" => 10,
+        "folHlink" => 11,
         _ => return None,
     };
-    theme_colors.get(idx).map(|s| s.trim_start_matches('#').to_string())
+    theme_colors
+        .get(idx)
+        .map(|s| s.trim_start_matches('#').to_string())
 }
 
 /// Apply DrawingML color transforms (`lumMod`/`lumOff`/`tint`/`shade`/
@@ -1046,22 +1369,33 @@ pub(crate) fn apply_color_transforms(base_hex: &str, color_el: &roxmltree::Node)
     let mut gf = g as f64 / 255.0;
     let mut bf = b as f64 / 255.0;
     for child in color_el.children().filter(|n| n.is_element()) {
-        let pct = child.attribute("val")
+        let pct = child
+            .attribute("val")
             .and_then(|v| v.parse::<f64>().ok())
             .map(|v| v / 100000.0);
         let Some(p) = pct else { continue };
         match child.tag_name().name() {
-            "lumMod"  => { rf *= p; gf *= p; bf *= p; }
-            "lumOff"  => { rf += p; gf += p; bf += p; }
-            "tint"    => {
+            "lumMod" => {
+                rf *= p;
+                gf *= p;
+                bf *= p;
+            }
+            "lumOff" => {
+                rf += p;
+                gf += p;
+                bf += p;
+            }
+            "tint" => {
                 // ECMA-376: lighten toward 1.0 by `p` (0..1).
                 rf = rf + (1.0 - rf) * p;
                 gf = gf + (1.0 - gf) * p;
                 bf = bf + (1.0 - bf) * p;
             }
-            "shade"   => {
+            "shade" => {
                 // Darken toward 0 by `1 - p`.
-                rf *= p; gf *= p; bf *= p;
+                rf *= p;
+                gf *= p;
+                bf *= p;
             }
             // alpha is dropped — we render opaque.
             _ => {}
@@ -1080,20 +1414,31 @@ pub(crate) fn parse_data_point_overrides(
     theme_colors: &[String],
 ) -> Vec<DataPointOverride> {
     let mut result = Vec::new();
-    for dpt in ser_node.children().filter(|n| n.is_element() && n.tag_name().name() == "dPt" && n.tag_name().namespace() == Some(c_ns)) {
-        let idx = dpt.children()
+    for dpt in ser_node.children().filter(|n| {
+        n.is_element() && n.tag_name().name() == "dPt" && n.tag_name().namespace() == Some(c_ns)
+    }) {
+        let idx = dpt
+            .children()
             .find(|n| n.tag_name().name() == "idx" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(0);
-        let sp_pr = dpt.children()
+        let sp_pr = dpt
+            .children()
             .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns));
         let color = sp_pr.and_then(|p| extract_solid_fill_in_drawingml(&p, theme_colors));
-        let mk = dpt.children()
+        let mk = dpt
+            .children()
             .find(|n| n.tag_name().name() == "marker" && n.tag_name().namespace() == Some(c_ns));
-        let (marker_symbol, marker_size, marker_fill, marker_line) = parse_marker_block(mk, c_ns, theme_colors);
+        let (marker_symbol, marker_size, marker_fill, marker_line) =
+            parse_marker_block(mk, c_ns, theme_colors);
         result.push(DataPointOverride {
-            idx, color, marker_symbol, marker_size, marker_fill, marker_line,
+            idx,
+            color,
+            marker_symbol,
+            marker_size,
+            marker_fill,
+            marker_line,
         });
     }
     result
@@ -1102,16 +1447,41 @@ pub(crate) fn parse_data_point_overrides(
 /// Resolve `<c:ser><c:extLst><c:ext><c15:datalabelsRange>` cache: index →
 /// label text. Used to substitute `<a:fld type="CELLRANGE">` placeholders.
 /// Returns indices in 0..ptCount; missing entries are empty strings.
-pub(crate) fn collect_dlbl_range_cache(ser_node: &roxmltree::Node, c_ns: &str) -> HashMap<u32, String> {
+pub(crate) fn collect_dlbl_range_cache(
+    ser_node: &roxmltree::Node,
+    c_ns: &str,
+) -> HashMap<u32, String> {
     let mut map: HashMap<u32, String> = HashMap::new();
-    let Some(ext_lst) = ser_node.children().find(|n| n.tag_name().name() == "extLst" && n.tag_name().namespace() == Some(c_ns)) else { return map; };
-    for ext in ext_lst.children().filter(|n| n.is_element() && n.tag_name().name() == "ext" && n.tag_name().namespace() == Some(c_ns)) {
-        for range in ext.descendants().filter(|n| n.is_element() && n.tag_name().name() == "datalabelsRange") {
-            for cache in range.children().filter(|n| n.is_element() && n.tag_name().name() == "dlblRangeCache") {
-                for pt in cache.children().filter(|n| n.is_element() && n.tag_name().name() == "pt" && n.tag_name().namespace() == Some(c_ns)) {
-                    let Some(idx) = pt.attribute("idx").and_then(|v| v.parse::<u32>().ok()) else { continue };
-                    let v = pt.children()
-                        .find(|n| n.tag_name().name() == "v" && n.tag_name().namespace() == Some(c_ns))
+    let Some(ext_lst) = ser_node
+        .children()
+        .find(|n| n.tag_name().name() == "extLst" && n.tag_name().namespace() == Some(c_ns))
+    else {
+        return map;
+    };
+    for ext in ext_lst.children().filter(|n| {
+        n.is_element() && n.tag_name().name() == "ext" && n.tag_name().namespace() == Some(c_ns)
+    }) {
+        for range in ext
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "datalabelsRange")
+        {
+            for cache in range
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "dlblRangeCache")
+            {
+                for pt in cache.children().filter(|n| {
+                    n.is_element()
+                        && n.tag_name().name() == "pt"
+                        && n.tag_name().namespace() == Some(c_ns)
+                }) {
+                    let Some(idx) = pt.attribute("idx").and_then(|v| v.parse::<u32>().ok()) else {
+                        continue;
+                    };
+                    let v = pt
+                        .children()
+                        .find(|n| {
+                            n.tag_name().name() == "v" && n.tag_name().namespace() == Some(c_ns)
+                        })
                         .and_then(|n| n.text())
                         .unwrap_or("")
                         .to_string();
@@ -1133,27 +1503,38 @@ pub(crate) fn flatten_rich_text(
 ) -> String {
     let mut out = String::new();
     let mut first_para = true;
-    for p in rich_root.descendants().filter(|n| n.is_element() && n.tag_name().name() == "p") {
-        if !first_para { out.push('\n'); }
+    for p in rich_root
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "p")
+    {
+        if !first_para {
+            out.push('\n');
+        }
         first_para = false;
         for child in p.children().filter(|n| n.is_element()) {
             match child.tag_name().name() {
                 "r" => {
                     if let Some(t) = child.children().find(|n| n.tag_name().name() == "t") {
-                        if let Some(s) = t.text() { out.push_str(s); }
+                        if let Some(s) = t.text() {
+                            out.push_str(s);
+                        }
                     }
                 }
                 "fld" => {
                     let typ = child.attribute("type").unwrap_or("");
                     if typ == "CELLRANGE" {
-                        if let Some(s) = cellrange_cache { out.push_str(s); }
+                        if let Some(s) = cellrange_cache {
+                            out.push_str(s);
+                        }
                     } else {
                         // VALUE/SERIESNAME/CATEGORYNAME field placeholders are
                         // resolved by the renderer using the series data, since
                         // they don't need cell-range expansion. We embed a marker
                         // so the renderer can recognise them.
                         if let Some(t) = child.children().find(|n| n.tag_name().name() == "t") {
-                            if let Some(s) = t.text() { out.push_str(s); }
+                            if let Some(s) = t.text() {
+                                out.push_str(s);
+                            }
                         }
                     }
                 }
@@ -1171,9 +1552,12 @@ pub(crate) fn parse_data_labels(
     theme_colors: &[String],
     cellrange_cache: &HashMap<u32, String>,
 ) -> (Option<SeriesDataLabels>, Vec<DataLabelOverride>) {
-    let Some(d_lbls) = ser_node.children()
+    let Some(d_lbls) = ser_node
+        .children()
         .find(|n| n.tag_name().name() == "dLbls" && n.tag_name().namespace() == Some(c_ns))
-    else { return (None, Vec::new()); };
+    else {
+        return (None, Vec::new());
+    };
 
     let bool_attr = |n: &roxmltree::Node, name: &str| {
         n.children()
@@ -1183,34 +1567,45 @@ pub(crate) fn parse_data_labels(
             .unwrap_or(false)
     };
 
-    let position = d_lbls.children()
+    let position = d_lbls
+        .children()
         .find(|n| n.tag_name().name() == "dLblPos" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .map(|s| s.to_string());
-    let format_code = d_lbls.children()
+    let format_code = d_lbls
+        .children()
         .find(|n| n.tag_name().name() == "numFmt" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("formatCode"))
         .map(|s| s.to_string());
-    let font_color = d_lbls.children()
+    let font_color = d_lbls
+        .children()
         .find(|n| n.tag_name().name() == "txPr" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|tx| {
             tx.descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "defRPr")
                 .and_then(|def| extract_solid_fill_in_drawingml(&def, theme_colors))
         });
-    let font_bold_default = d_lbls.children()
+    let font_bold_default = d_lbls
+        .children()
         .find(|n| n.tag_name().name() == "txPr" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|tx| {
             tx.descendants()
-                .find(|n| n.is_element() && (n.tag_name().name() == "defRPr" || n.tag_name().name() == "rPr"))
+                .find(|n| {
+                    n.is_element()
+                        && (n.tag_name().name() == "defRPr" || n.tag_name().name() == "rPr")
+                })
                 .and_then(|n| n.attribute("b"))
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         });
-    let font_size_default = d_lbls.children()
+    let font_size_default = d_lbls
+        .children()
         .find(|n| n.tag_name().name() == "txPr" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|tx| {
             tx.descendants()
-                .find(|n| n.is_element() && (n.tag_name().name() == "defRPr" || n.tag_name().name() == "rPr"))
+                .find(|n| {
+                    n.is_element()
+                        && (n.tag_name().name() == "defRPr" || n.tag_name().name() == "rPr")
+                })
                 .and_then(|n| n.attribute("sz"))
                 .and_then(|v| v.parse::<i32>().ok())
         });
@@ -1228,20 +1623,25 @@ pub(crate) fn parse_data_labels(
     };
 
     let mut overrides = Vec::new();
-    for dl in d_lbls.children().filter(|n| n.is_element() && n.tag_name().name() == "dLbl" && n.tag_name().namespace() == Some(c_ns)) {
-        let idx = dl.children()
+    for dl in d_lbls.children().filter(|n| {
+        n.is_element() && n.tag_name().name() == "dLbl" && n.tag_name().namespace() == Some(c_ns)
+    }) {
+        let idx = dl
+            .children()
             .find(|n| n.tag_name().name() == "idx" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(0);
         // <c:delete val="1"/> — the user explicitly removed this point's
         // label. Render as empty text so the renderer skips it.
-        let deleted = dl.children()
+        let deleted = dl
+            .children()
             .find(|n| n.tag_name().name() == "delete" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        let pos = dl.children()
+        let pos = dl
+            .children()
             .find(|n| n.tag_name().name() == "dLblPos" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .map(|s| s.to_string());
@@ -1253,29 +1653,42 @@ pub(crate) fn parse_data_labels(
             // Without `<c:tx>` the override is metadata-only (e.g. only a
             // position change); show the cellrange cache value when
             // available, else empty.
-            let tx = dl.children()
+            let tx = dl
+                .children()
                 .find(|n| n.tag_name().name() == "tx" && n.tag_name().namespace() == Some(c_ns));
             match tx {
                 Some(tx_node) => flatten_rich_text(&tx_node, cache_for_idx),
                 None => cache_for_idx.unwrap_or("").to_string(),
             }
         };
-        let font_color = dl.children()
+        let font_color = dl
+            .children()
             .find(|n| n.tag_name().name() == "txPr" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|tx| {
                 tx.descendants()
                     .find(|n| n.is_element() && n.tag_name().name() == "defRPr")
                     .and_then(|def| extract_solid_fill_in_drawingml(&def, theme_colors))
             });
-        let font_size_hpt = dl.descendants()
+        let font_size_hpt = dl
+            .descendants()
             .find(|n| n.is_element() && n.tag_name().name() == "defRPr")
             .and_then(|def| def.attribute("sz"))
             .and_then(|v| v.parse::<i32>().ok());
-        let font_bold = dl.descendants()
-            .find(|n| n.is_element() && (n.tag_name().name() == "defRPr" || n.tag_name().name() == "rPr"))
+        let font_bold = dl
+            .descendants()
+            .find(|n| {
+                n.is_element() && (n.tag_name().name() == "defRPr" || n.tag_name().name() == "rPr")
+            })
             .and_then(|def| def.attribute("b"))
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"));
-        overrides.push(DataLabelOverride { idx, text, position: pos, font_color, font_size_hpt, font_bold });
+        overrides.push(DataLabelOverride {
+            idx,
+            text,
+            position: pos,
+            font_color,
+            font_size_hpt,
+            font_bold,
+        });
     }
 
     let any_default = series_defaults.show_val
@@ -1287,7 +1700,11 @@ pub(crate) fn parse_data_labels(
         || series_defaults.format_code.is_some()
         || series_defaults.font_bold.is_some()
         || series_defaults.font_size_hpt.is_some();
-    let series_out = if any_default { Some(series_defaults) } else { None };
+    let series_out = if any_default {
+        Some(series_defaults)
+    } else {
+        None
+    };
     (series_out, overrides)
 }
 
@@ -1301,23 +1718,29 @@ pub(crate) fn parse_error_bars(
     theme_colors: &[String],
 ) -> Vec<ErrBars> {
     let mut result = Vec::new();
-    for eb in ser_node.children().filter(|n| n.is_element() && n.tag_name().name() == "errBars" && n.tag_name().namespace() == Some(c_ns)) {
-        let dir = eb.children()
+    for eb in ser_node.children().filter(|n| {
+        n.is_element() && n.tag_name().name() == "errBars" && n.tag_name().namespace() == Some(c_ns)
+    }) {
+        let dir = eb
+            .children()
             .find(|n| n.tag_name().name() == "errDir" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .unwrap_or("y")
             .to_string();
-        let bar_type = eb.children()
+        let bar_type = eb
+            .children()
             .find(|n| n.tag_name().name() == "errBarType" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .unwrap_or("both")
             .to_string();
-        let val_type = eb.children()
+        let val_type = eb
+            .children()
             .find(|n| n.tag_name().name() == "errValType" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .unwrap_or("fixedVal")
             .to_string();
-        let no_end_cap = eb.children()
+        let no_end_cap = eb
+            .children()
             .find(|n| n.tag_name().name() == "noEndCap" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -1330,17 +1753,26 @@ pub(crate) fn parse_error_bars(
         match val_type.as_str() {
             "cust" => {
                 for (slot, target) in [("plus", &mut plus), ("minus", &mut minus)] {
-                    let Some(side) = eb.children().find(|n| n.tag_name().name() == slot && n.tag_name().namespace() == Some(c_ns)) else { continue };
+                    let Some(side) = eb.children().find(|n| {
+                        n.tag_name().name() == slot && n.tag_name().namespace() == Some(c_ns)
+                    }) else {
+                        continue;
+                    };
                     let vals = extract_num_block(&side, c_ns, n_points);
                     if !vals.is_empty() {
                         let len = vals.len().min(target.len());
-                        for i in 0..len { target[i] = vals[i]; }
+                        for i in 0..len {
+                            target[i] = vals[i];
+                        }
                     }
                 }
             }
             "fixedVal" => {
-                let v = eb.children()
-                    .find(|n| n.tag_name().name() == "val" && n.tag_name().namespace() == Some(c_ns))
+                let v = eb
+                    .children()
+                    .find(|n| {
+                        n.tag_name().name() == "val" && n.tag_name().namespace() == Some(c_ns)
+                    })
                     .and_then(|n| n.attribute("val"))
                     .and_then(|s| s.parse::<f64>().ok())
                     .unwrap_or(0.0);
@@ -1351,15 +1783,19 @@ pub(crate) fn parse_error_bars(
             }
             "percentage" => {
                 // Each point's bar = abs(value) * pct/100.
-                let pct = eb.children()
-                    .find(|n| n.tag_name().name() == "val" && n.tag_name().namespace() == Some(c_ns))
+                let pct = eb
+                    .children()
+                    .find(|n| {
+                        n.tag_name().name() == "val" && n.tag_name().namespace() == Some(c_ns)
+                    })
                     .and_then(|n| n.attribute("val"))
                     .and_then(|s| s.parse::<f64>().ok())
                     .unwrap_or(0.0);
                 for (i, v) in series_values.iter().enumerate() {
                     if let Some(val) = v {
                         let d = val.abs() * pct / 100.0;
-                        plus[i] = Some(d); minus[i] = Some(d);
+                        plus[i] = Some(d);
+                        minus[i] = Some(d);
                     }
                 }
             }
@@ -1367,26 +1803,34 @@ pub(crate) fn parse_error_bars(
                 let nums: Vec<f64> = series_values.iter().filter_map(|v| *v).collect();
                 if !nums.is_empty() {
                     let mean = nums.iter().sum::<f64>() / nums.len() as f64;
-                    let var = nums.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / nums.len() as f64;
+                    let var =
+                        nums.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / nums.len() as f64;
                     let std = var.sqrt();
-                    let mult = eb.children()
-                        .find(|n| n.tag_name().name() == "val" && n.tag_name().namespace() == Some(c_ns))
+                    let mult = eb
+                        .children()
+                        .find(|n| {
+                            n.tag_name().name() == "val" && n.tag_name().namespace() == Some(c_ns)
+                        })
                         .and_then(|n| n.attribute("val"))
                         .and_then(|s| s.parse::<f64>().ok())
                         .unwrap_or(1.0);
                     let sample = if val_type == "stdErr" {
                         std / (nums.len() as f64).sqrt()
-                    } else { std };
+                    } else {
+                        std
+                    };
                     let delta = sample * mult;
                     for i in 0..n_points {
-                        plus[i] = Some(delta); minus[i] = Some(delta);
+                        plus[i] = Some(delta);
+                        minus[i] = Some(delta);
                     }
                 }
             }
             _ => {}
         }
 
-        let sp_pr = eb.children()
+        let sp_pr = eb
+            .children()
             .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(c_ns));
         let color = sp_pr.and_then(|p| {
             let ln = p.children().find(|n| n.tag_name().name() == "ln");
@@ -1406,10 +1850,14 @@ pub(crate) fn parse_error_bars(
             .map(|s| s.to_string());
 
         result.push(ErrBars {
-            dir, bar_type,
-            plus, minus,
+            dir,
+            bar_type,
+            plus,
+            minus,
             no_end_cap,
-            color, line_width_emu, dash,
+            color,
+            line_width_emu,
+            dash,
         });
     }
     result
@@ -1418,26 +1866,42 @@ pub(crate) fn parse_error_bars(
 /// Read a `<c:numRef><c:numCache>` or `<c:numLit>` block under `parent` and
 /// return per-point values keyed by `<c:pt idx>`. Length is at least
 /// `expected_len` (padded with None).
-pub(crate) fn extract_num_block(parent: &roxmltree::Node, c_ns: &str, expected_len: usize) -> Vec<Option<f64>> {
-    let cache = parent.descendants()
-        .find(|n| n.is_element()
+pub(crate) fn extract_num_block(
+    parent: &roxmltree::Node,
+    c_ns: &str,
+    expected_len: usize,
+) -> Vec<Option<f64>> {
+    let cache = parent.descendants().find(|n| {
+        n.is_element()
             && (n.tag_name().name() == "numCache" || n.tag_name().name() == "numLit")
-            && n.tag_name().namespace() == Some(c_ns));
-    let Some(cache) = cache else { return Vec::new(); };
-    let pt_count: usize = cache.children()
+            && n.tag_name().namespace() == Some(c_ns)
+    });
+    let Some(cache) = cache else {
+        return Vec::new();
+    };
+    let pt_count: usize = cache
+        .children()
         .find(|n| n.tag_name().name() == "ptCount" && n.tag_name().namespace() == Some(c_ns))
         .and_then(|n| n.attribute("val"))
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(expected_len);
     let len = pt_count.max(expected_len);
     let mut values: Vec<Option<f64>> = vec![None; len];
-    for pt in cache.children().filter(|n| n.tag_name().name() == "pt" && n.tag_name().namespace() == Some(c_ns)) {
-        let Some(idx) = pt.attribute("idx").and_then(|v| v.parse::<usize>().ok()) else { continue };
-        let v = pt.children()
+    for pt in cache
+        .children()
+        .filter(|n| n.tag_name().name() == "pt" && n.tag_name().namespace() == Some(c_ns))
+    {
+        let Some(idx) = pt.attribute("idx").and_then(|v| v.parse::<usize>().ok()) else {
+            continue;
+        };
+        let v = pt
+            .children()
             .find(|n| n.tag_name().name() == "v" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.text())
             .and_then(|s| s.trim().parse::<f64>().ok());
-        if idx < values.len() { values[idx] = v; }
+        if idx < values.len() {
+            values[idx] = v;
+        }
     }
     values
 }
@@ -1446,11 +1910,16 @@ pub(crate) fn extract_num_block(parent: &roxmltree::Node, c_ns: &str, expected_l
 pub(crate) fn extract_series_name(node: &roxmltree::Node, c_ns: &str) -> String {
     // c:tx/c:strRef/c:strCache/c:pt[@idx=0]/c:v
     // or c:tx/c:v
-    if let Some(tx) = node.children().find(|n| n.tag_name().name() == "tx" && n.tag_name().namespace() == Some(c_ns)) {
+    if let Some(tx) = node
+        .children()
+        .find(|n| n.tag_name().name() == "tx" && n.tag_name().namespace() == Some(c_ns))
+    {
         for desc in tx.descendants() {
             if desc.tag_name().name() == "v" && desc.tag_name().namespace() == Some(c_ns) {
                 if let Some(t) = desc.text() {
-                    if !t.is_empty() { return t.to_string(); }
+                    if !t.is_empty() {
+                        return t.to_string();
+                    }
                 }
             }
         }
@@ -1461,29 +1930,44 @@ pub(crate) fn extract_series_name(node: &roxmltree::Node, c_ns: &str) -> String 
 /// Collect string values from a cache child element (e.g. `<c:cat>` or `<c:xVal>`).
 /// Reads `c:strRef/c:strCache`, `c:multiLvlStrRef/c:multiLvlStrCache`, or
 /// `c:numRef/c:numCache` (formats numbers as strings).
-pub(crate) fn collect_str_cache(ser_node: &roxmltree::Node, c_ns: &str, child_tag: &str) -> Vec<String> {
-    let Some(child) = ser_node.children()
+pub(crate) fn collect_str_cache(
+    ser_node: &roxmltree::Node,
+    c_ns: &str,
+    child_tag: &str,
+) -> Vec<String> {
+    let Some(child) = ser_node
+        .children()
         .find(|n| n.tag_name().name() == child_tag && n.tag_name().namespace() == Some(c_ns))
-    else { return Vec::new(); };
+    else {
+        return Vec::new();
+    };
 
     // Multi-level categories: use only the first (innermost) lvl to get primary labels.
-    if let Some(multi_cache) = child.descendants()
-        .find(|n| n.tag_name().name() == "multiLvlStrCache" && n.tag_name().namespace() == Some(c_ns))
-    {
-        let pt_count: usize = multi_cache.children()
+    if let Some(multi_cache) = child.descendants().find(|n| {
+        n.tag_name().name() == "multiLvlStrCache" && n.tag_name().namespace() == Some(c_ns)
+    }) {
+        let pt_count: usize = multi_cache
+            .children()
             .find(|n| n.tag_name().name() == "ptCount" && n.tag_name().namespace() == Some(c_ns))
             .and_then(|n| n.attribute("val"))
             .and_then(|v| v.parse().ok())
             .unwrap_or(0);
-        if let Some(first_lvl) = multi_cache.children()
+        if let Some(first_lvl) = multi_cache
+            .children()
             .find(|n| n.tag_name().name() == "lvl" && n.tag_name().namespace() == Some(c_ns))
         {
             let mut pts: Vec<(usize, String)> = Vec::new();
-            for pt in first_lvl.children()
-                .filter(|n| n.is_element() && n.tag_name().name() == "pt" && n.tag_name().namespace() == Some(c_ns))
-            {
-                let idx: usize = pt.attribute("idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                let val = pt.children()
+            for pt in first_lvl.children().filter(|n| {
+                n.is_element()
+                    && n.tag_name().name() == "pt"
+                    && n.tag_name().namespace() == Some(c_ns)
+            }) {
+                let idx: usize = pt
+                    .attribute("idx")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let val = pt
+                    .children()
                     .find(|n| n.tag_name().name() == "v")
                     .and_then(|n| n.text())
                     .unwrap_or("")
@@ -1493,7 +1977,9 @@ pub(crate) fn collect_str_cache(ser_node: &roxmltree::Node, c_ns: &str, child_ta
             let len = pt_count.max(pts.iter().map(|(i, _)| i + 1).max().unwrap_or(0));
             let mut result = vec![String::new(); len];
             for (idx, val) in pts {
-                if idx < result.len() { result[idx] = val; }
+                if idx < result.len() {
+                    result[idx] = val;
+                }
             }
             return result;
         }
@@ -1505,11 +1991,18 @@ pub(crate) fn collect_str_cache(ser_node: &roxmltree::Node, c_ns: &str, child_ta
     for desc in child.descendants() {
         match desc.tag_name().name() {
             "ptCount" if desc.tag_name().namespace() == Some(c_ns) => {
-                pt_count = desc.attribute("val").and_then(|v| v.parse().ok()).unwrap_or(0);
+                pt_count = desc
+                    .attribute("val")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
             }
             "pt" if desc.tag_name().namespace() == Some(c_ns) => {
-                let idx: usize = desc.attribute("idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                let val = desc.children()
+                let idx: usize = desc
+                    .attribute("idx")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let val = desc
+                    .children()
                     .find(|n| n.tag_name().name() == "v")
                     .and_then(|n| n.text())
                     .unwrap_or("")
@@ -1519,30 +2012,48 @@ pub(crate) fn collect_str_cache(ser_node: &roxmltree::Node, c_ns: &str, child_ta
             _ => {}
         }
     }
-    if pt_count == 0 { pt_count = pts.len(); }
+    if pt_count == 0 {
+        pt_count = pts.len();
+    }
     let mut result = vec![String::new(); pt_count];
     for (idx, val) in pts {
-        if idx < result.len() { result[idx] = val; }
+        if idx < result.len() {
+            result[idx] = val;
+        }
     }
     result
 }
 
 /// Collect numeric values from a cache child element (e.g. `<c:val>` or `<c:yVal>`).
-pub(crate) fn collect_num_cache(ser_node: &roxmltree::Node, c_ns: &str, child_tag: &str) -> Vec<Option<f64>> {
-    let Some(child) = ser_node.children()
+pub(crate) fn collect_num_cache(
+    ser_node: &roxmltree::Node,
+    c_ns: &str,
+    child_tag: &str,
+) -> Vec<Option<f64>> {
+    let Some(child) = ser_node
+        .children()
         .find(|n| n.tag_name().name() == child_tag && n.tag_name().namespace() == Some(c_ns))
-    else { return Vec::new(); };
+    else {
+        return Vec::new();
+    };
 
     let mut pt_count: usize = 0;
     let mut pts: Vec<(usize, f64)> = Vec::new();
     for desc in child.descendants() {
         match desc.tag_name().name() {
             "ptCount" if desc.tag_name().namespace() == Some(c_ns) => {
-                pt_count = desc.attribute("val").and_then(|v| v.parse().ok()).unwrap_or(0);
+                pt_count = desc
+                    .attribute("val")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
             }
             "pt" if desc.tag_name().namespace() == Some(c_ns) => {
-                let idx: usize = desc.attribute("idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                if let Some(v) = desc.children()
+                let idx: usize = desc
+                    .attribute("idx")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                if let Some(v) = desc
+                    .children()
                     .find(|n| n.tag_name().name() == "v")
                     .and_then(|n| n.text())
                     .and_then(|t| t.parse::<f64>().ok())
@@ -1553,14 +2064,17 @@ pub(crate) fn collect_num_cache(ser_node: &roxmltree::Node, c_ns: &str, child_ta
             _ => {}
         }
     }
-    if pt_count == 0 { pt_count = pts.len(); }
+    if pt_count == 0 {
+        pt_count = pts.len();
+    }
     let mut result: Vec<Option<f64>> = vec![None; pt_count];
     for (idx, val) in pts {
-        if idx < result.len() { result[idx] = Some(val); }
+        if idx < result.len() {
+            result[idx] = Some(val);
+        }
     }
     result
 }
-
 
 #[cfg(test)]
 mod label_color_tests {
@@ -1583,16 +2097,24 @@ mod label_color_tests {
                    <c:pt idx="0"><c:v>1</c:v></c:pt>
                  </c:numCache></c:numRef></c:val>
                </c:ser>"#,
-            c = C_NS, s = scheme
+            c = C_NS,
+            s = scheme
         )
     }
 
     // Theme order: dk1@0, lt1@1, dk2@2, lt2@3, accent1@4 …
     fn theme() -> Vec<String> {
         vec![
-            "111111".into(), "fefefe".into(), "222222".into(), "eeeeee".into(),
-            "aa0000".into(), "00aa00".into(), "0000aa".into(),
-            "aaaa00".into(), "00aaaa".into(), "aa00aa".into(),
+            "111111".into(),
+            "fefefe".into(),
+            "222222".into(),
+            "eeeeee".into(),
+            "aa0000".into(),
+            "00aa00".into(),
+            "0000aa".into(),
+            "aaaa00".into(),
+            "00aaaa".into(),
+            "aa00aa".into(),
         ]
     }
 

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -626,6 +626,11 @@ pub(crate) fn parse_sp_geom(sp_pr: &roxmltree::Node) -> Option<ShapeGeom> {
 /// Recursively walk an `xdr:grpSp` / `xdr:sp` tree, chaining coordinate
 /// transforms, and push leaf shapes (normalized to [0,1] of `root_ext`) into
 /// `out`.
+// The arguments are the running coordinate-transform state threaded through the
+// recursion (root offset/extent, accumulated scale/translation, theme + rels);
+// bundling them into a struct would only move the same fields elsewhere without
+// improving clarity.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn collect_shapes(
     node: &roxmltree::Node,
     root_off_x: f64,

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{read_zip_entry, read_zip_bytes, resolve_zip_path, parse_rels_map, mime_from_ext};
+use crate::{mime_from_ext, parse_rels_map, read_zip_bytes, read_zip_entry, resolve_zip_path};
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -27,8 +27,9 @@ pub(crate) fn parse_drawing_anchors(
         {
             continue;
         }
-        let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) = (0u32, 0i64, 0u32, 0i64);
-        let (mut to_col,   mut to_col_off,   mut to_row,   mut to_row_off)   = (0u32, 0i64, 0u32, 0i64);
+        let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) =
+            (0u32, 0i64, 0u32, 0i64);
+        let (mut to_col, mut to_col_off, mut to_row, mut to_row_off) = (0u32, 0i64, 0u32, 0i64);
         let mut pic_rid: Option<String> = None;
         let mut native_ext_cx: i64 = 0;
         let mut native_ext_cy: i64 = 0;
@@ -39,7 +40,9 @@ pub(crate) fn parse_drawing_anchors(
         let edit_as = anchor.attribute("editAs").map(|s| s.to_string());
 
         for child in anchor.children() {
-            if !child.is_element() { continue; }
+            if !child.is_element() {
+                continue;
+            }
             match child.tag_name().name() {
                 "from" | "to" => {
                     let is_from = child.tag_name().name() == "from";
@@ -49,41 +52,51 @@ pub(crate) fn parse_drawing_anchors(
                     let mut row_off: i64 = 0;
                     for c in child.children() {
                         match (c.tag_name().name(), c.text()) {
-                            ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                            ("col", Some(t)) => col = t.trim().parse().unwrap_or(0),
                             ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
-                            ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                            ("row", Some(t)) => row = t.trim().parse().unwrap_or(0),
                             ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
                             _ => {}
                         }
                     }
                     if is_from {
-                        from_col = col; from_col_off = col_off; from_row = row; from_row_off = row_off;
+                        from_col = col;
+                        from_col_off = col_off;
+                        from_row = row;
+                        from_row_off = row_off;
                     } else {
-                        to_col = col; to_col_off = col_off; to_row = row; to_row_off = row_off;
+                        to_col = col;
+                        to_col_off = col_off;
+                        to_row = row;
+                        to_row_off = row_off;
                     }
                 }
                 "pic" => {
                     // <xdr:pic><xdr:blipFill><a:blip r:embed="rId1"/></xdr:blipFill></xdr:pic>
-                    let blip_fill = child.children()
-                        .find(|n| n.tag_name().name() == "blipFill" && n.tag_name().namespace() == Some(xdr_ns));
+                    let blip_fill = child.children().find(|n| {
+                        n.tag_name().name() == "blipFill"
+                            && n.tag_name().namespace() == Some(xdr_ns)
+                    });
                     if let Some(bf) = blip_fill {
-                        let blip = bf.children()
-                            .find(|n| n.tag_name().name() == "blip" && n.tag_name().namespace() == Some(a_ns));
+                        let blip = bf.children().find(|n| {
+                            n.tag_name().name() == "blip" && n.tag_name().namespace() == Some(a_ns)
+                        });
                         if let Some(b) = blip {
                             // r:embed attribute
-                            pic_rid = b.attributes()
+                            pic_rid = b
+                                .attributes()
                                 .find(|a| a.name() == "embed" && a.namespace() == Some(r_ns))
                                 .map(|a| a.value().to_string());
                         }
                     }
                     // <xdr:pic><xdr:spPr><a:xfrm><a:ext cx cy>: the picture's
                     // own saved EMU extent. Authoritative when editAs="oneCell".
-                    if let Some(sp_pr) = child.children()
-                        .find(|n| n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(xdr_ns))
-                    {
-                        if let Some(xfrm_n) = sp_pr.children()
-                            .find(|n| n.tag_name().name() == "xfrm" && n.tag_name().namespace() == Some(a_ns))
-                        {
+                    if let Some(sp_pr) = child.children().find(|n| {
+                        n.tag_name().name() == "spPr" && n.tag_name().namespace() == Some(xdr_ns)
+                    }) {
+                        if let Some(xfrm_n) = sp_pr.children().find(|n| {
+                            n.tag_name().name() == "xfrm" && n.tag_name().namespace() == Some(a_ns)
+                        }) {
                             if let Some(xfrm) = parse_xfrm(&xfrm_n) {
                                 native_ext_cx = xfrm.ext_x as i64;
                                 native_ext_cy = xfrm.ext_y as i64;
@@ -95,16 +108,28 @@ pub(crate) fn parse_drawing_anchors(
             }
         }
 
-        let Some(rid) = pic_rid else { continue; };
-        let Some(target) = drawing_rels.get(&rid) else { continue; };
+        let Some(rid) = pic_rid else {
+            continue;
+        };
+        let Some(target) = drawing_rels.get(&rid) else {
+            continue;
+        };
         let media_path = resolve_zip_path(drawing_dir, target);
-        let Some(bytes) = read_zip_bytes(archive, &media_path) else { continue; };
+        let Some(bytes) = read_zip_bytes(archive, &media_path) else {
+            continue;
+        };
         let mime = mime_from_ext(&media_path);
         let data_url = format!("data:{mime};base64,{}", B64.encode(&bytes));
 
         anchors.push(ImageAnchor {
-            from_col, from_col_off, from_row, from_row_off,
-            to_col, to_col_off, to_row, to_row_off,
+            from_col,
+            from_col_off,
+            from_row,
+            from_row_off,
+            to_col,
+            to_col_off,
+            to_row,
+            to_row_off,
             edit_as,
             native_ext_cx,
             native_ext_cy,
@@ -129,10 +154,14 @@ pub(crate) fn parse_drawing_anchors(
 
 #[derive(Clone, Copy)]
 pub(crate) struct Xfrm {
-    off_x: f64, off_y: f64,
-    ext_x: f64, ext_y: f64,
-    ch_off_x: f64, ch_off_y: f64,
-    ch_ext_x: f64, ch_ext_y: f64,
+    off_x: f64,
+    off_y: f64,
+    ext_x: f64,
+    ext_y: f64,
+    ch_off_x: f64,
+    ch_off_y: f64,
+    ch_ext_x: f64,
+    ch_ext_y: f64,
     has_ch: bool,
 }
 
@@ -150,8 +179,14 @@ pub(crate) fn parse_xfrm(xfrm_node: &roxmltree::Node) -> Option<Xfrm> {
                 off.1 = c.attribute("y").and_then(|s| s.parse().ok()).unwrap_or(0.0);
             }
             "ext" => {
-                ext.0 = c.attribute("cx").and_then(|s| s.parse().ok()).unwrap_or(0.0);
-                ext.1 = c.attribute("cy").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                ext.0 = c
+                    .attribute("cx")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
+                ext.1 = c
+                    .attribute("cy")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
                 has_ext = true;
             }
             "chOff" => {
@@ -160,18 +195,29 @@ pub(crate) fn parse_xfrm(xfrm_node: &roxmltree::Node) -> Option<Xfrm> {
                 has_ch = true;
             }
             "chExt" => {
-                ch_ext.0 = c.attribute("cx").and_then(|s| s.parse().ok()).unwrap_or(0.0);
-                ch_ext.1 = c.attribute("cy").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                ch_ext.0 = c
+                    .attribute("cx")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
+                ch_ext.1 = c
+                    .attribute("cy")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
                 has_ch = true;
             }
             _ => {}
         }
     }
-    if !has_ext { return None; }
+    if !has_ext {
+        return None;
+    }
     Some(Xfrm {
-        off_x: off.0, off_y: off.1,
-        ext_x: ext.0, ext_y: ext.1,
-        ch_off_x: ch_off.0, ch_off_y: ch_off.1,
+        off_x: off.0,
+        off_y: off.1,
+        ext_x: ext.0,
+        ext_y: ext.1,
+        ch_off_x: ch_off.0,
+        ch_off_y: ch_off.1,
         ch_ext_x: if ch_ext.0 == 0.0 { ext.0 } else { ch_ext.0 },
         ch_ext_y: if ch_ext.1 == 0.0 { ext.1 } else { ch_ext.1 },
         has_ch,
@@ -193,7 +239,10 @@ fn apply_clr_mods(base_with_hash: &str, clr_node: &roxmltree::Node) -> String {
     format!("#{}", out.to_uppercase())
 }
 
-pub(crate) fn parse_solid_fill(fill_node: &roxmltree::Node, theme_colors: &[String]) -> Option<String> {
+pub(crate) fn parse_solid_fill(
+    fill_node: &roxmltree::Node,
+    theme_colors: &[String],
+) -> Option<String> {
     for c in fill_node.children() {
         match c.tag_name().name() {
             "srgbClr" => {
@@ -214,18 +263,18 @@ pub(crate) fn parse_solid_fill(fill_node: &roxmltree::Node, theme_colors: &[Stri
                 // here had dk1/lt1 and dk2/lt2 swapped which darkened
                 // shapes that painted "lt1" (the sheet paper colour).
                 let idx = match v {
-                    "dk1" | "tx1"    => Some(0),
-                    "lt1" | "bg1"    => Some(1),
-                    "dk2" | "tx2"    => Some(2),
-                    "lt2" | "bg2"    => Some(3),
-                    "accent1"        => Some(4),
-                    "accent2"        => Some(5),
-                    "accent3"        => Some(6),
-                    "accent4"        => Some(7),
-                    "accent5"        => Some(8),
-                    "accent6"        => Some(9),
-                    "hlink"          => Some(10),
-                    "folHlink"       => Some(11),
+                    "dk1" | "tx1" => Some(0),
+                    "lt1" | "bg1" => Some(1),
+                    "dk2" | "tx2" => Some(2),
+                    "lt2" | "bg2" => Some(3),
+                    "accent1" => Some(4),
+                    "accent2" => Some(5),
+                    "accent3" => Some(6),
+                    "accent4" => Some(7),
+                    "accent5" => Some(8),
+                    "accent6" => Some(9),
+                    "hlink" => Some(10),
+                    "folHlink" => Some(11),
                     _ => None,
                 };
                 return idx
@@ -241,44 +290,87 @@ pub(crate) fn parse_solid_fill(fill_node: &roxmltree::Node, theme_colors: &[Stri
 /// Parse a single custGeom path element. Each path has its own coordinate
 /// system (`a:path/@w`, `@h`) that the renderer scales to the shape's rect.
 pub(crate) fn parse_custom_path(path_node: &roxmltree::Node) -> PathInfo {
-    let w: f64 = path_node.attribute("w").and_then(|s| s.parse().ok()).unwrap_or(0.0);
-    let h: f64 = path_node.attribute("h").and_then(|s| s.parse().ok()).unwrap_or(0.0);
+    let w: f64 = path_node
+        .attribute("w")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.0);
+    let h: f64 = path_node
+        .attribute("h")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.0);
     let mut commands: Vec<PathCmd> = Vec::new();
     for cmd in path_node.children().filter(|n| n.is_element()) {
         let name = cmd.tag_name().name();
         // Collect `<a:pt x=.. y=..>` points in order.
-        let pts: Vec<(f64, f64)> = cmd.children()
+        let pts: Vec<(f64, f64)> = cmd
+            .children()
             .filter(|n| n.is_element() && n.tag_name().name() == "pt")
-            .map(|n| (
-                n.attribute("x").and_then(|s| s.parse().ok()).unwrap_or(0.0),
-                n.attribute("y").and_then(|s| s.parse().ok()).unwrap_or(0.0),
-            ))
+            .map(|n| {
+                (
+                    n.attribute("x").and_then(|s| s.parse().ok()).unwrap_or(0.0),
+                    n.attribute("y").and_then(|s| s.parse().ok()).unwrap_or(0.0),
+                )
+            })
             .collect();
         match name {
-            "moveTo"       => if let Some(p) = pts.first() { commands.push(PathCmd::MoveTo { x: p.0, y: p.1 }); },
-            "lnTo"         => if let Some(p) = pts.first() { commands.push(PathCmd::LineTo { x: p.0, y: p.1 }); },
-            "cubicBezTo"   => if pts.len() >= 3 {
-                commands.push(PathCmd::CubicBezTo {
-                    x1: pts[0].0, y1: pts[0].1,
-                    x2: pts[1].0, y2: pts[1].1,
-                    x3: pts[2].0, y3: pts[2].1,
-                });
-            },
-            "quadBezTo"    => if pts.len() >= 2 {
-                commands.push(PathCmd::QuadBezTo {
-                    x1: pts[0].0, y1: pts[0].1,
-                    x2: pts[1].0, y2: pts[1].1,
-                });
-            },
-            "close"        => commands.push(PathCmd::Close),
+            "moveTo" => {
+                if let Some(p) = pts.first() {
+                    commands.push(PathCmd::MoveTo { x: p.0, y: p.1 });
+                }
+            }
+            "lnTo" => {
+                if let Some(p) = pts.first() {
+                    commands.push(PathCmd::LineTo { x: p.0, y: p.1 });
+                }
+            }
+            "cubicBezTo" => {
+                if pts.len() >= 3 {
+                    commands.push(PathCmd::CubicBezTo {
+                        x1: pts[0].0,
+                        y1: pts[0].1,
+                        x2: pts[1].0,
+                        y2: pts[1].1,
+                        x3: pts[2].0,
+                        y3: pts[2].1,
+                    });
+                }
+            }
+            "quadBezTo" => {
+                if pts.len() >= 2 {
+                    commands.push(PathCmd::QuadBezTo {
+                        x1: pts[0].0,
+                        y1: pts[0].1,
+                        x2: pts[1].0,
+                        y2: pts[1].1,
+                    });
+                }
+            }
+            "close" => commands.push(PathCmd::Close),
             "arcTo" => {
                 // ECMA-376 §20.1.9.3: `wR`/`hR` in path-coord units;
                 // `stAng`/`swAng` in 60000ths of a degree.
-                let wr:     f64 = cmd.attribute("wR").and_then(|s| s.parse().ok()).unwrap_or(0.0);
-                let hr:     f64 = cmd.attribute("hR").and_then(|s| s.parse().ok()).unwrap_or(0.0);
-                let st_ang: f64 = cmd.attribute("stAng").and_then(|s| s.parse().ok()).unwrap_or(0.0);
-                let sw_ang: f64 = cmd.attribute("swAng").and_then(|s| s.parse().ok()).unwrap_or(0.0);
-                commands.push(PathCmd::ArcTo { wr, hr, st_ang, sw_ang });
+                let wr: f64 = cmd
+                    .attribute("wR")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
+                let hr: f64 = cmd
+                    .attribute("hR")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
+                let st_ang: f64 = cmd
+                    .attribute("stAng")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
+                let sw_ang: f64 = cmd
+                    .attribute("swAng")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
+                commands.push(PathCmd::ArcTo {
+                    wr,
+                    hr,
+                    st_ang,
+                    sw_ang,
+                });
             }
             _ => {}
         }
@@ -386,15 +478,22 @@ fn push_math_runs_shape(
     }
 }
 
-pub(crate) fn parse_tx_body(tx_body: &roxmltree::Node, theme_colors: &[String]) -> Option<ShapeText> {
+pub(crate) fn parse_tx_body(
+    tx_body: &roxmltree::Node,
+    theme_colors: &[String],
+) -> Option<ShapeText> {
     let mut anchor = String::from("t");
     let mut wrap = String::from("square");
     let mut paragraphs: Vec<ShapeParagraph> = Vec::new();
     for c in tx_body.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
             "bodyPr" => {
-                if let Some(a) = c.attribute("anchor") { anchor = a.to_string(); }
-                if let Some(w) = c.attribute("wrap") { wrap = w.to_string(); }
+                if let Some(a) = c.attribute("anchor") {
+                    anchor = a.to_string();
+                }
+                if let Some(w) = c.attribute("wrap") {
+                    wrap = w.to_string();
+                }
             }
             "p" => {
                 let mut align = String::from("l");
@@ -403,10 +502,15 @@ pub(crate) fn parse_tx_body(tx_body: &roxmltree::Node, theme_colors: &[String]) 
                 for pc in c.children().filter(|n| n.is_element()) {
                     match pc.tag_name().name() {
                         "pPr" => {
-                            if let Some(a) = pc.attribute("algn") { align = a.to_string(); }
+                            if let Some(a) = pc.attribute("algn") {
+                                align = a.to_string();
+                            }
                             // ECMA-376 §21.1.2.2.7 `<a:pPr@rtl>` — right-to-left
                             // paragraph. Default false (left-to-right).
-                            rtl = pc.attribute("rtl").map(|v| v == "1" || v == "true").unwrap_or(false);
+                            rtl = pc
+                                .attribute("rtl")
+                                .map(|v| v == "1" || v == "true")
+                                .unwrap_or(false);
                         }
                         "r" => {
                             // Run text + run-level formatting.
@@ -420,8 +524,10 @@ pub(crate) fn parse_tx_body(tx_body: &roxmltree::Node, theme_colors: &[String]) 
                                 match rc.tag_name().name() {
                                     "rPr" => {
                                         bold = rc.attribute("b").map(|v| v == "1").unwrap_or(false);
-                                        italic = rc.attribute("i").map(|v| v == "1").unwrap_or(false);
-                                        size = rc.attribute("sz")
+                                        italic =
+                                            rc.attribute("i").map(|v| v == "1").unwrap_or(false);
+                                        size = rc
+                                            .attribute("sz")
                                             .and_then(|s| s.parse::<f64>().ok())
                                             .map(|v| v / 100.0)
                                             .unwrap_or(0.0);
@@ -431,20 +537,30 @@ pub(crate) fn parse_tx_body(tx_body: &roxmltree::Node, theme_colors: &[String]) 
                                                     color = parse_solid_fill(&rpc, theme_colors);
                                                 }
                                                 "latin" => {
-                                                    font_face = rpc.attribute("typeface").map(String::from);
+                                                    font_face =
+                                                        rpc.attribute("typeface").map(String::from);
                                                 }
                                                 _ => {}
                                             }
                                         }
                                     }
                                     "t" => {
-                                        if let Some(t) = rc.text() { text.push_str(t); }
+                                        if let Some(t) = rc.text() {
+                                            text.push_str(t);
+                                        }
                                     }
                                     _ => {}
                                 }
                             }
                             if !text.is_empty() {
-                                runs.push(ShapeTextRun::Text { text, bold, italic, size, color, font_face });
+                                runs.push(ShapeTextRun::Text {
+                                    text,
+                                    bold,
+                                    italic,
+                                    size,
+                                    color,
+                                    font_face,
+                                });
                             }
                         }
                         "br" => {
@@ -467,8 +583,14 @@ pub(crate) fn parse_tx_body(tx_body: &roxmltree::Node, theme_colors: &[String]) 
             _ => {}
         }
     }
-    if paragraphs.is_empty() { None } else {
-        Some(ShapeText { anchor, wrap, paragraphs })
+    if paragraphs.is_empty() {
+        None
+    } else {
+        Some(ShapeText {
+            anchor,
+            wrap,
+            paragraphs,
+        })
     }
 }
 
@@ -482,8 +604,14 @@ pub(crate) fn parse_sp_geom(sp_pr: &roxmltree::Node) -> Option<ShapeGeom> {
             }
             "custGeom" => {
                 let mut paths: Vec<PathInfo> = Vec::new();
-                for pl in c.children().filter(|n| n.is_element() && n.tag_name().name() == "pathLst") {
-                    for p in pl.children().filter(|n| n.is_element() && n.tag_name().name() == "path") {
+                for pl in c
+                    .children()
+                    .filter(|n| n.is_element() && n.tag_name().name() == "pathLst")
+                {
+                    for p in pl
+                        .children()
+                        .filter(|n| n.is_element() && n.tag_name().name() == "path")
+                    {
                         paths.push(parse_custom_path(&p));
                     }
                 }
@@ -500,11 +628,15 @@ pub(crate) fn parse_sp_geom(sp_pr: &roxmltree::Node) -> Option<ShapeGeom> {
 /// `out`.
 pub(crate) fn collect_shapes(
     node: &roxmltree::Node,
-    root_off_x: f64, root_off_y: f64,
-    root_ext_x: f64, root_ext_y: f64,
+    root_off_x: f64,
+    root_off_y: f64,
+    root_ext_x: f64,
+    root_ext_y: f64,
     // transform from current local coords into root (top-level grpSp) coords
-    scale_x: f64, scale_y: f64,
-    trans_x: f64, trans_y: f64,
+    scale_x: f64,
+    scale_y: f64,
+    trans_x: f64,
+    trans_y: f64,
     theme_colors: &[String],
     rid_urls: &HashMap<String, String>,
     out: &mut Vec<ShapeInfo>,
@@ -513,9 +645,14 @@ pub(crate) fn collect_shapes(
         let tag = child.tag_name().name();
         if tag == "grpSp" {
             // Nested grpSp: compose the transform by the group's own xfrm.
-            let grp_sp_pr = child.children().find(|n| n.is_element() && n.tag_name().name() == "grpSpPr");
+            let grp_sp_pr = child
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "grpSpPr");
             let xfrm = grp_sp_pr
-                .and_then(|n| n.children().find(|c| c.is_element() && c.tag_name().name() == "xfrm"))
+                .and_then(|n| {
+                    n.children()
+                        .find(|c| c.is_element() && c.tag_name().name() == "xfrm")
+                })
                 .as_ref()
                 .and_then(parse_xfrm);
             let (sx, sy, tx, ty) = if let Some(x) = xfrm {
@@ -532,23 +669,50 @@ pub(crate) fn collect_shapes(
                     )
                 } else {
                     // No child coord system: treat as identity mapping inside the group.
-                    (scale_x, scale_y,
-                     trans_x + scale_x * x.off_x,
-                     trans_y + scale_y * x.off_y)
+                    (
+                        scale_x,
+                        scale_y,
+                        trans_x + scale_x * x.off_x,
+                        trans_y + scale_y * x.off_y,
+                    )
                 }
             } else {
                 (scale_x, scale_y, trans_x, trans_y)
             };
-            collect_shapes(&child, root_off_x, root_off_y, root_ext_x, root_ext_y,
-                           sx, sy, tx, ty, theme_colors, rid_urls, out);
+            collect_shapes(
+                &child,
+                root_off_x,
+                root_off_y,
+                root_ext_x,
+                root_ext_y,
+                sx,
+                sy,
+                tx,
+                ty,
+                theme_colors,
+                rid_urls,
+                out,
+            );
         } else if tag == "sp" {
-            let sp_pr = child.children().find(|n| n.is_element() && n.tag_name().name() == "spPr");
-            let Some(sp_pr) = sp_pr else { continue; };
-            let xfrm_node = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm");
-            let Some(xfrm_n) = xfrm_node else { continue; };
-            let Some(xfrm) = parse_xfrm(&xfrm_n) else { continue; };
-            let rot_raw: f64 = xfrm_n.attribute("rot")
-                .and_then(|s| s.parse().ok()).unwrap_or(0.0);
+            let sp_pr = child
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "spPr");
+            let Some(sp_pr) = sp_pr else {
+                continue;
+            };
+            let xfrm_node = sp_pr
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "xfrm");
+            let Some(xfrm_n) = xfrm_node else {
+                continue;
+            };
+            let Some(xfrm) = parse_xfrm(&xfrm_n) else {
+                continue;
+            };
+            let rot_raw: f64 = xfrm_n
+                .attribute("rot")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0);
 
             // Shape rect in root coords
             let root_x = trans_x + scale_x * xfrm.off_x;
@@ -557,31 +721,44 @@ pub(crate) fn collect_shapes(
             let root_h = scale_y * xfrm.ext_y;
 
             // Normalize to [0,1] of root ext
-            if root_ext_x == 0.0 || root_ext_y == 0.0 { continue; }
+            if root_ext_x == 0.0 || root_ext_y == 0.0 {
+                continue;
+            }
             let nx = (root_x - root_off_x) / root_ext_x;
             let ny = (root_y - root_off_y) / root_ext_y;
             let nw = root_w / root_ext_x;
             let nh = root_h / root_ext_y;
 
             let geom = parse_sp_geom(&sp_pr);
-            let Some(geom) = geom else { continue; };
+            let Some(geom) = geom else {
+                continue;
+            };
 
             // Fill
             let mut fill_color: Option<String> = None;
             let mut has_no_fill = false;
             for c in sp_pr.children().filter(|n| n.is_element()) {
                 match c.tag_name().name() {
-                    "solidFill" => { fill_color = parse_solid_fill(&c, theme_colors); }
-                    "noFill"    => { has_no_fill = true; }
+                    "solidFill" => {
+                        fill_color = parse_solid_fill(&c, theme_colors);
+                    }
+                    "noFill" => {
+                        has_no_fill = true;
+                    }
                     _ => {}
                 }
             }
-            if has_no_fill { fill_color = None; }
+            if has_no_fill {
+                fill_color = None;
+            }
 
             // Stroke (line)
             let mut stroke_color: Option<String> = None;
             let mut stroke_width: i64 = 0;
-            if let Some(ln) = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "ln") {
+            if let Some(ln) = sp_pr
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "ln")
+            {
                 let w_attr = ln.attribute("w");
                 stroke_width = w_attr.and_then(|s| s.parse().ok()).unwrap_or(0);
                 for c in ln.children().filter(|n| n.is_element()) {
@@ -608,13 +785,22 @@ pub(crate) fn collect_shapes(
             // and rely on the style's fillRef + fontRef pair (e.g. accent1
             // background + lt1 white text). We resolve scheme colors here
             // against the workbook theme and apply them as fallbacks.
-            let style_node = child.children()
+            let style_node = child
+                .children()
                 .find(|n| n.is_element() && n.tag_name().name() == "style");
-            let style_fill = style_node.as_ref()
-                .and_then(|s| s.children().find(|n| n.is_element() && n.tag_name().name() == "fillRef"))
+            let style_fill = style_node
+                .as_ref()
+                .and_then(|s| {
+                    s.children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "fillRef")
+                })
                 .and_then(|n| parse_solid_fill(&n, theme_colors));
-            let style_text_color = style_node.as_ref()
-                .and_then(|s| s.children().find(|n| n.is_element() && n.tag_name().name() == "fontRef"))
+            let style_text_color = style_node
+                .as_ref()
+                .and_then(|s| {
+                    s.children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "fontRef")
+                })
                 .and_then(|n| parse_solid_fill(&n, theme_colors));
             if fill_color.is_none() && !has_no_fill {
                 fill_color = style_fill;
@@ -642,7 +828,10 @@ pub(crate) fn collect_shapes(
             }
 
             out.push(ShapeInfo {
-                x: nx, y: ny, w: nw, h: nh,
+                x: nx,
+                y: ny,
+                w: nw,
+                h: nh,
                 rot: rot_raw / 60000.0,
                 fill_color,
                 stroke_color,
@@ -654,45 +843,71 @@ pub(crate) fn collect_shapes(
             // `<xdr:pic>` leaf inside a group (ECMA-376 §20.5.2.17). The image
             // binary is resolved via the drawing's .rels file; `rid_urls` maps
             // each r:id to its pre-encoded `data:<mime>;base64,…` URL.
-            let sp_pr = child.children().find(|n| n.is_element() && n.tag_name().name() == "spPr");
-            let Some(sp_pr) = sp_pr else { continue; };
-            let xfrm_node = sp_pr.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm");
-            let Some(xfrm_n) = xfrm_node else { continue; };
-            let Some(xfrm) = parse_xfrm(&xfrm_n) else { continue; };
-            let rot_raw: f64 = xfrm_n.attribute("rot")
-                .and_then(|s| s.parse().ok()).unwrap_or(0.0);
+            let sp_pr = child
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "spPr");
+            let Some(sp_pr) = sp_pr else {
+                continue;
+            };
+            let xfrm_node = sp_pr
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "xfrm");
+            let Some(xfrm_n) = xfrm_node else {
+                continue;
+            };
+            let Some(xfrm) = parse_xfrm(&xfrm_n) else {
+                continue;
+            };
+            let rot_raw: f64 = xfrm_n
+                .attribute("rot")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0);
 
             // Resolve <a:blip r:embed="rIdN"/>. The r:embed attribute lives in
             // the relationships namespace, not the drawingml namespace.
             let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-            let pic_rid = child.descendants()
+            let pic_rid = child
+                .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "blip")
                 .and_then(|b| {
                     b.attributes()
                         .find(|a| a.name() == "embed" && a.namespace() == Some(r_ns))
                         .map(|a| a.value().to_string())
                 });
-            let Some(rid) = pic_rid else { continue; };
-            let Some(data_url) = rid_urls.get(&rid) else { continue; };
+            let Some(rid) = pic_rid else {
+                continue;
+            };
+            let Some(data_url) = rid_urls.get(&rid) else {
+                continue;
+            };
 
             let root_x = trans_x + scale_x * xfrm.off_x;
             let root_y = trans_y + scale_y * xfrm.off_y;
             let root_w = scale_x * xfrm.ext_x;
             let root_h = scale_y * xfrm.ext_y;
-            if root_ext_x == 0.0 || root_ext_y == 0.0 { continue; }
+            if root_ext_x == 0.0 || root_ext_y == 0.0 {
+                continue;
+            }
             let nx = (root_x - root_off_x) / root_ext_x;
             let ny = (root_y - root_off_y) / root_ext_y;
             let nw = root_w / root_ext_x;
             let nh = root_h / root_ext_y;
-            if nw <= 0.0 || nh <= 0.0 { continue; }
+            if nw <= 0.0 || nh <= 0.0 {
+                continue;
+            }
 
             out.push(ShapeInfo {
-                x: nx, y: ny, w: nw, h: nh,
+                x: nx,
+                y: ny,
+                w: nw,
+                h: nh,
                 rot: rot_raw / 60000.0,
                 fill_color: None,
                 stroke_color: None,
                 stroke_width: 0,
-                geom: ShapeGeom::Image { data_url: data_url.clone() },
+                geom: ShapeGeom::Image {
+                    data_url: data_url.clone(),
+                },
                 text: None,
             });
         }
@@ -705,7 +920,9 @@ pub(crate) fn parse_shape_anchors(
     theme_colors: &[String],
     rid_urls: &HashMap<String, String>,
 ) -> Vec<ShapeAnchor> {
-    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else { return Vec::new(); };
+    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
+        return Vec::new();
+    };
     let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
     let mut anchors: Vec<ShapeAnchor> = Vec::new();
 
@@ -716,11 +933,15 @@ pub(crate) fn parse_shape_anchors(
         // size). Excel authors equation text boxes as oneCellAnchor, so we must
         // accept both or those shapes (and their math) are silently dropped.
         if (anchor_tag != "twoCellAnchor" && anchor_tag != "oneCellAnchor")
-            || anchor.tag_name().namespace() != Some(xdr_ns) { continue; }
+            || anchor.tag_name().namespace() != Some(xdr_ns)
+        {
+            continue;
+        }
 
         // Parse from/to anchor rect (shared between grpSp and stand-alone sp paths)
-        let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) = (0u32, 0i64, 0u32, 0i64);
-        let (mut to_col,   mut to_col_off,   mut to_row,   mut to_row_off)   = (0u32, 0i64, 0u32, 0i64);
+        let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) =
+            (0u32, 0i64, 0u32, 0i64);
+        let (mut to_col, mut to_col_off, mut to_row, mut to_row_off) = (0u32, 0i64, 0u32, 0i64);
         // ECMA-376 §20.5.2.33 `twoCellAnchor@editAs` — see ImageAnchor parsing
         // path for semantics. `"oneCell"` instructs the renderer to preserve
         // the group's saved EMU size instead of resizing with the cell rect.
@@ -737,24 +958,34 @@ pub(crate) fn parse_shape_anchors(
         let native_ext_cx: i64;
         let native_ext_cy: i64;
         for c in anchor.children() {
-            if !c.is_element() { continue; }
+            if !c.is_element() {
+                continue;
+            }
             if c.tag_name().name() == "from" || c.tag_name().name() == "to" {
                 let is_from = c.tag_name().name() == "from";
-                let mut col: u32 = 0; let mut col_off: i64 = 0;
-                let mut row: u32 = 0; let mut row_off: i64 = 0;
+                let mut col: u32 = 0;
+                let mut col_off: i64 = 0;
+                let mut row: u32 = 0;
+                let mut row_off: i64 = 0;
                 for cc in c.children() {
                     match (cc.tag_name().name(), cc.text()) {
-                        ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                        ("col", Some(t)) => col = t.trim().parse().unwrap_or(0),
                         ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
-                        ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                        ("row", Some(t)) => row = t.trim().parse().unwrap_or(0),
                         ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
                         _ => {}
                     }
                 }
                 if is_from {
-                    from_col = col; from_col_off = col_off; from_row = row; from_row_off = row_off;
+                    from_col = col;
+                    from_col_off = col_off;
+                    from_row = row;
+                    from_row_off = row_off;
                 } else {
-                    to_col = col; to_col_off = col_off; to_row = row; to_row_off = row_off;
+                    to_col = col;
+                    to_col_off = col_off;
+                    to_row = row;
+                    to_row_off = row_off;
                 }
             }
         }
@@ -782,14 +1013,26 @@ pub(crate) fn parse_shape_anchors(
         //       to define the anchor's drawing-coord system; the stand-alone
         //       path treats the shape as filling 100 % of the anchor rect.
         let mut shapes: Vec<ShapeInfo> = Vec::new();
-        if let Some(grp) = content.children().find(|n| n.is_element() && n.tag_name().name() == "grpSp") {
-            let grp_sp_pr = grp.children().find(|n| n.is_element() && n.tag_name().name() == "grpSpPr");
+        if let Some(grp) = content
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "grpSp")
+        {
+            let grp_sp_pr = grp
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "grpSpPr");
             let xfrm = grp_sp_pr
-                .and_then(|n| n.children().find(|c| c.is_element() && c.tag_name().name() == "xfrm"))
+                .and_then(|n| {
+                    n.children()
+                        .find(|c| c.is_element() && c.tag_name().name() == "xfrm")
+                })
                 .as_ref()
                 .and_then(parse_xfrm);
-            let Some(root) = xfrm else { continue; };
-            if !root.has_ch || root.ch_ext_x == 0.0 || root.ch_ext_y == 0.0 { continue; }
+            let Some(root) = xfrm else {
+                continue;
+            };
+            if !root.has_ch || root.ch_ext_x == 0.0 || root.ch_ext_y == 0.0 {
+                continue;
+            }
 
             // Top-level grpSp ext is the group's saved on-sheet EMU size —
             // authoritative when editAs="oneCell".
@@ -802,34 +1045,80 @@ pub(crate) fn parse_shape_anchors(
             let tx = root.off_x - root.ch_off_x * csx;
             let ty = root.off_y - root.ch_off_y * csy;
 
-            collect_shapes(&grp, root.off_x, root.off_y, root.ext_x, root.ext_y,
-                           csx, csy, tx, ty, theme_colors, rid_urls, &mut shapes);
-        } else if let Some(sp) = content.children().find(|n| n.is_element() && (n.tag_name().name() == "sp" || n.tag_name().name() == "pic")) {
+            collect_shapes(
+                &grp,
+                root.off_x,
+                root.off_y,
+                root.ext_x,
+                root.ext_y,
+                csx,
+                csy,
+                tx,
+                ty,
+                theme_colors,
+                rid_urls,
+                &mut shapes,
+            );
+        } else if let Some(sp) = content.children().find(|n| {
+            n.is_element() && (n.tag_name().name() == "sp" || n.tag_name().name() == "pic")
+        }) {
             // Stand-alone sp/pic: the shape's own xfrm gives its absolute EMU
             // rect, but for our rendering pipeline the anchor's from/to
             // already defines the on-sheet rect, and the leaf occupies it
             // 100 %. Build a synthetic root coord-system whose origin matches
             // the shape's xfrm so collect_shapes normalizes the leaf to (0,0)
             // (1,1).
-            let sp_pr = sp.children().find(|n| n.is_element() && n.tag_name().name() == "spPr");
-            let Some(sp_pr_node) = sp_pr else { continue; };
-            let xfrm_node = sp_pr_node.children().find(|n| n.is_element() && n.tag_name().name() == "xfrm");
-            let Some(xfrm_n) = xfrm_node else { continue; };
-            let Some(xfrm) = parse_xfrm(&xfrm_n) else { continue; };
-            if xfrm.ext_x == 0.0 || xfrm.ext_y == 0.0 { continue; }
+            let sp_pr = sp
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "spPr");
+            let Some(sp_pr_node) = sp_pr else {
+                continue;
+            };
+            let xfrm_node = sp_pr_node
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "xfrm");
+            let Some(xfrm_n) = xfrm_node else {
+                continue;
+            };
+            let Some(xfrm) = parse_xfrm(&xfrm_n) else {
+                continue;
+            };
+            if xfrm.ext_x == 0.0 || xfrm.ext_y == 0.0 {
+                continue;
+            }
             native_ext_cx = xfrm.ext_x as i64;
             native_ext_cy = xfrm.ext_y as i64;
-            collect_shapes(&content, xfrm.off_x, xfrm.off_y, xfrm.ext_x, xfrm.ext_y,
-                           1.0, 1.0, 0.0, 0.0, theme_colors, rid_urls, &mut shapes);
+            collect_shapes(
+                &content,
+                xfrm.off_x,
+                xfrm.off_y,
+                xfrm.ext_x,
+                xfrm.ext_y,
+                1.0,
+                1.0,
+                0.0,
+                0.0,
+                theme_colors,
+                rid_urls,
+                &mut shapes,
+            );
         } else {
             continue;
         }
 
-        if shapes.is_empty() { continue; }
+        if shapes.is_empty() {
+            continue;
+        }
 
         anchors.push(ShapeAnchor {
-            from_col, from_col_off, from_row, from_row_off,
-            to_col, to_col_off, to_row, to_row_off,
+            from_col,
+            from_col_off,
+            from_row,
+            from_row_off,
+            to_col,
+            to_col_off,
+            to_row,
+            to_row_off,
             edit_as,
             native_ext_cx,
             native_ext_cy,
@@ -844,20 +1133,34 @@ pub(crate) fn load_sheet_shape_groups(
     sheet_path: &str,
     theme_colors: &[String],
 ) -> Vec<ShapeAnchor> {
-    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
+        return Vec::new();
+    };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else { return Vec::new(); };
-    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else { return Vec::new(); };
+    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+        return Vec::new();
+    };
+    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+        return Vec::new();
+    };
     let mut drawing_targets: Vec<String> = Vec::new();
-    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+    for rel in rels_doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element())
+    {
         if rel.attribute("Type").unwrap_or("").ends_with("/drawing") {
-            if let Some(t) = rel.attribute("Target") { drawing_targets.push(t.to_string()); }
+            if let Some(t) = rel.attribute("Target") {
+                drawing_targets.push(t.to_string());
+            }
         }
     }
     let mut all: Vec<ShapeAnchor> = Vec::new();
     for target in drawing_targets {
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+            continue;
+        };
         let rid_urls = build_drawing_rid_urls(archive, &drawing_path);
         all.extend(parse_shape_anchors(&drawing_xml, theme_colors, &rid_urls));
     }
@@ -885,9 +1188,12 @@ pub(crate) fn build_drawing_rid_urls(
     let mut result: HashMap<String, String> = HashMap::new();
     for (rid, target) in rels {
         let lower = target.to_lowercase();
-        if !(lower.ends_with(".png") || lower.ends_with(".jpg")
-            || lower.ends_with(".jpeg") || lower.ends_with(".gif")
-            || lower.ends_with(".bmp")  || lower.ends_with(".webp"))
+        if !(lower.ends_with(".png")
+            || lower.ends_with(".jpg")
+            || lower.ends_with(".jpeg")
+            || lower.ends_with(".gif")
+            || lower.ends_with(".bmp")
+            || lower.ends_with(".webp"))
         {
             continue;
         }
@@ -920,7 +1226,11 @@ pub(crate) fn load_sheet_images(
         return Vec::new();
     };
     let mut drawing_targets: Vec<String> = Vec::new();
-    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+    for rel in rels_doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element())
+    {
         let rel_type = rel.attribute("Type").unwrap_or("");
         if rel_type.ends_with("/drawing") {
             if let Some(t) = rel.attribute("Target") {
@@ -928,16 +1238,22 @@ pub(crate) fn load_sheet_images(
             }
         }
     }
-    if drawing_targets.is_empty() { return Vec::new(); }
+    if drawing_targets.is_empty() {
+        return Vec::new();
+    }
 
     let mut all_anchors: Vec<ImageAnchor> = Vec::new();
     for target in drawing_targets {
         // sheet_dir is "worksheets", target typically "../drawings/drawing1.xml"
         // base dir for the drawing = "xl/worksheets" + "../drawings" → "xl/drawings"
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+            continue;
+        };
         // Drawing rels:  xl/drawings/_rels/drawing1.xml.rels
-        let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else { continue; };
+        let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else {
+            continue;
+        };
         let drawing_rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
         let drawing_rels = read_zip_entry(archive, &drawing_rels_path)
             .ok()
@@ -1015,10 +1331,19 @@ mod math_tests {
         let runs = &text.paragraphs[0].runs;
         assert_eq!(runs.len(), 1);
         match &runs[0] {
-            ShapeTextRun::Math { display, font_size, color, nodes } => {
+            ShapeTextRun::Math {
+                display,
+                font_size,
+                color,
+                nodes,
+            } => {
                 assert!(!*display, "bare a14:m + m:oMath → inline");
                 assert_eq!(*font_size, Some(28.0), "size from math run rPr sz/100");
-                assert_eq!(color.as_deref(), Some("#7030A0"), "colour from math run rPr solidFill (xlsx #-prefixed convention)");
+                assert_eq!(
+                    color.as_deref(),
+                    Some("#7030A0"),
+                    "colour from math run rPr solidFill (xlsx #-prefixed convention)"
+                );
                 assert_eq!(nodes_to_text(nodes), "n");
             }
             other => panic!("expected Math run, got {other:?}"),
@@ -1084,4 +1409,3 @@ mod math_tests {
         assert!(!text.paragraphs[0].rtl, "absent @rtl → rtl false");
     }
 }
-

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -461,20 +461,21 @@ fn parse_defined_names_for_sheet(doc: &roxmltree::Document, sheet_index: u32) ->
 fn resolve_sheet_path(doc: &roxmltree::Document, r_id: &str) -> Option<String> {
     let ns = "http://schemas.openxmlformats.org/package/2006/relationships";
     for node in doc.descendants() {
-        if node.tag_name().name() == "Relationship" && node.tag_name().namespace() == Some(ns) {
-            if node.attribute("Id") == Some(r_id) {
-                let target = node.attribute("Target")?;
-                // ECMA-376 / Open Packaging Conventions: Target may be a
-                // package-absolute path (`/xl/worksheets/sheet1.xml`, used
-                // by openpyxl and some online tools) or a path relative to
-                // the .rels file's parent (`worksheets/sheet1.xml`, the
-                // common Office-saved form). Callers prepend `xl/` to the
-                // returned value, so strip a leading `/xl/` to convert
-                // absolute paths into the relative form they expect.
-                let t = target.strip_prefix('/').unwrap_or(target);
-                let t = t.strip_prefix("xl/").unwrap_or(t);
-                return Some(t.to_string());
-            }
+        if node.tag_name().name() == "Relationship"
+            && node.tag_name().namespace() == Some(ns)
+            && node.attribute("Id") == Some(r_id)
+        {
+            let target = node.attribute("Target")?;
+            // ECMA-376 / Open Packaging Conventions: Target may be a
+            // package-absolute path (`/xl/worksheets/sheet1.xml`, used
+            // by openpyxl and some online tools) or a path relative to
+            // the .rels file's parent (`worksheets/sheet1.xml`, the
+            // common Office-saved form). Callers prepend `xl/` to the
+            // returned value, so strip a leading `/xl/` to convert
+            // absolute paths into the relative form they expect.
+            let t = target.strip_prefix('/').unwrap_or(target);
+            let t = t.strip_prefix("xl/").unwrap_or(t);
+            return Some(t.to_string());
         }
     }
     None
@@ -586,12 +587,15 @@ fn parse_si_node(node: &roxmltree::Node, ns: &str, theme_colors: &[String]) -> S
         runs: if has_runs { Some(runs) } else { None },
     }
 }
+/// `(row, col, relationship id)` triples for cell hyperlinks pending rels resolution.
+type HyperlinkRids = Vec<(u32, u32, String)>;
+
 fn parse_worksheet(
     xml: &str,
     shared_strings: &[SharedString],
     theme_colors: &[String],
     name: &str,
-) -> Result<(Worksheet, Vec<(u32, u32, String)>), String> {
+) -> Result<(Worksheet, HyperlinkRids), String> {
     let doc = roxmltree::Document::parse(xml).map_err(|e| e.to_string())?;
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
@@ -615,7 +619,7 @@ fn parse_worksheet(
     let mut right_to_left = false;
     let mut tab_color: Option<String> = None;
     let mut auto_filter: Option<CellRange> = None;
-    let mut hyperlink_rids: Vec<(u32, u32, String)> = Vec::new();
+    let mut hyperlink_rids: HyperlinkRids = Vec::new();
 
     // Pre-scan worksheet-level extLst for x14:dataBar extension attributes.
     // Excel 2010+ stores the `gradient` flag on `<x14:dataBar>` inside
@@ -896,10 +900,7 @@ fn parse_worksheet(
                 });
             }
             "conditionalFormatting" if node.tag_name().namespace() == Some(ns) => {
-                let sqref = node
-                    .attribute("sqref")
-                    .map(|s| parse_sqref(s))
-                    .unwrap_or_default();
+                let sqref = node.attribute("sqref").map(parse_sqref).unwrap_or_default();
                 let mut rules: Vec<CfRule> = Vec::new();
                 for cf in node.children() {
                     if cf.tag_name().name() != "cfRule" {
@@ -1380,7 +1381,7 @@ fn parse_data_validations(ws_root: roxmltree::Node<'_, '_>) -> Vec<DataValidatio
 fn load_hyperlinks(
     archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
     sheet_path: &str,
-    hyperlink_rids: Vec<(u32, u32, String)>,
+    hyperlink_rids: HyperlinkRids,
 ) -> Vec<Hyperlink> {
     if hyperlink_rids.is_empty() {
         return Vec::new();
@@ -1859,7 +1860,6 @@ pub(crate) fn parse_cell_ref(r: &str) -> (u32, u32) {
 
 /// Returns workbook overview (sheet names and metadata) as JSON.
 /// Native equivalent of `parse_xlsx` for use from the MCP server.
-
 pub fn parse_workbook_native(data: &[u8]) -> Result<String, String> {
     parse_xlsx_inner(data)
         .and_then(|wb| serde_json::to_string(&wb.workbook).map_err(|e| e.to_string()))
@@ -1879,7 +1879,6 @@ pub fn xlsx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result
 /// cached `<v>` so formula formulas show their results, not the formula text.
 /// Designed for AI agents that need to read the spreadsheet content
 /// efficiently — drops styling, formatting, charts, sparklines, drawings.
-
 pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
     to_markdown_impl(data)
 }
@@ -1906,7 +1905,6 @@ fn to_markdown_impl(data: &[u8]) -> Result<String, String> {
 
 /// Parses a single worksheet by 0-based index and returns it as JSON.
 /// Native equivalent of `parse_sheet` for use from the MCP server.
-
 pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<String, String> {
     let cursor = Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1,7 +1,6 @@
-use wasm_bindgen::prelude::*;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
-
+use wasm_bindgen::prelude::*;
 
 mod markdown;
 
@@ -18,18 +17,25 @@ use slicer::*;
 mod table;
 use table::*;
 
-
 // Excel built-in indexed color palette (indices 0-63)
 // Standard Excel 2003 color palette
 const INDEXED_COLORS: &[&str] = &[
-    "#000000", "#FFFFFF", "#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF", "#00FFFF", // 0-7
-    "#000000", "#FFFFFF", "#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF", "#00FFFF", // 8-15
-    "#800000", "#008000", "#000080", "#808000", "#800080", "#008080", "#C0C0C0", "#808080", // 16-23
-    "#9999FF", "#993366", "#FFFFCC", "#CCFFFF", "#660066", "#FF8080", "#0066CC", "#CCCCFF", // 24-31
-    "#000080", "#FF00FF", "#FFFF00", "#00FFFF", "#800080", "#800000", "#008080", "#0000FF", // 32-39
-    "#00CCFF", "#CCFFFF", "#CCFFCC", "#FFFF99", "#99CCFF", "#FF99CC", "#CC99FF", "#FFCC99", // 40-47
-    "#3366FF", "#33CCCC", "#99CC00", "#FFCC00", "#FF9900", "#FF6600", "#666699", "#969696", // 48-55
-    "#003366", "#339966", "#003300", "#333300", "#993300", "#993366", "#333399", "#333333", // 56-63
+    "#000000", "#FFFFFF", "#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF",
+    "#00FFFF", // 0-7
+    "#000000", "#FFFFFF", "#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF",
+    "#00FFFF", // 8-15
+    "#800000", "#008000", "#000080", "#808000", "#800080", "#008080", "#C0C0C0",
+    "#808080", // 16-23
+    "#9999FF", "#993366", "#FFFFCC", "#CCFFFF", "#660066", "#FF8080", "#0066CC",
+    "#CCCCFF", // 24-31
+    "#000080", "#FF00FF", "#FFFF00", "#00FFFF", "#800080", "#800000", "#008080",
+    "#0000FF", // 32-39
+    "#00CCFF", "#CCFFFF", "#CCFFCC", "#FFFF99", "#99CCFF", "#FF99CC", "#CC99FF",
+    "#FFCC99", // 40-47
+    "#3366FF", "#33CCCC", "#99CC00", "#FFCC00", "#FF9900", "#FF6600", "#666699",
+    "#969696", // 48-55
+    "#003366", "#339966", "#003300", "#333300", "#993300", "#993366", "#333399",
+    "#333333", // 56-63
 ];
 
 #[wasm_bindgen]
@@ -42,7 +48,12 @@ pub fn parse_xlsx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Strin
 }
 
 #[wasm_bindgen]
-pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str, max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
+pub fn parse_sheet(
+    data: &[u8],
+    sheet_index: u32,
+    name: &str,
+    max_zip_entry_bytes: Option<u64>,
+) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let cursor = Cursor::new(data);
@@ -65,8 +76,9 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str, max_zip_entry_byte
     let theme_colors = parse_theme_colors(&mut archive);
     let shared_strings = read_shared_strings(&mut archive, &theme_colors);
     let sheet_xml = read_zip_entry(&mut archive, &format!("xl/{}", sheet_path))?;
-    let (mut ws, hyperlink_rids) = parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
-        .map_err(|e| e.to_string())?;
+    let (mut ws, hyperlink_rids) =
+        parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
+            .map_err(|e| e.to_string())?;
 
     // Attach any drawing-anchored images and charts for this sheet
     ws.images = load_sheet_images(&mut archive, &sheet_path);
@@ -78,7 +90,8 @@ pub fn parse_sheet(data: &[u8], sheet_index: u32, name: &str, max_zip_entry_byte
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
     ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
     ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
-    ws.sparkline_groups = load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
+    ws.sparkline_groups =
+        load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
     let (df_family, df_size) = parse_default_font(&mut archive);
     ws.default_font_family = df_family;
     ws.default_font_size = df_size;
@@ -107,9 +120,13 @@ fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
     if let Ok(rels_xml) = read_zip_entry(&mut archive, "xl/_rels/workbook.xml.rels") {
         if let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) {
             for sheet in sheets.iter_mut() {
-                let Some(path) = resolve_sheet_path(&rels_doc, &sheet.r_id) else { continue; };
+                let Some(path) = resolve_sheet_path(&rels_doc, &sheet.r_id) else {
+                    continue;
+                };
                 let Ok(head) = read_zip_entry_head(&mut archive, &format!("xl/{}", path), 16_384)
-                else { continue; };
+                else {
+                    continue;
+                };
                 sheet.tab_color = extract_tab_color_from_head(&head, &theme_colors);
             }
         }
@@ -135,7 +152,10 @@ fn read_zip_entry_head(
         .by_name(name)
         .map_err(|e| format!("entry '{}' not found: {}", name, e))?;
     let mut buf = Vec::new();
-    file.by_ref().take(max_bytes).read_to_end(&mut buf).map_err(|e| e.to_string())?;
+    file.by_ref()
+        .take(max_bytes)
+        .read_to_end(&mut buf)
+        .map_err(|e| e.to_string())?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
@@ -168,7 +188,10 @@ fn extract_tab_color_from_head(head: &str, theme_colors: &[String]) -> Option<St
     )
 }
 
-pub(crate) fn read_zip_entry(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, name: &str) -> Result<String, String> {
+pub(crate) fn read_zip_entry(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    name: &str,
+) -> Result<String, String> {
     let max = ooxml_common::zip::current_max();
     let mut file = archive
         .by_name(name)
@@ -177,7 +200,10 @@ pub(crate) fn read_zip_entry(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, name:
         return Err(format!("entry '{}' exceeds size limit", name));
     }
     let mut buf = String::new();
-    file.by_ref().take(max).read_to_string(&mut buf).map_err(|e| e.to_string())?;
+    file.by_ref()
+        .take(max)
+        .read_to_string(&mut buf)
+        .map_err(|e| e.to_string())?;
     Ok(buf)
 }
 
@@ -196,17 +222,21 @@ fn parse_theme_colors(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<Strin
     for node in doc.descendants() {
         if node.tag_name().name() == "clrScheme" && node.tag_name().namespace() == Some(a_ns) {
             for child in node.children() {
-                if !child.is_element() { continue; }
+                if !child.is_element() {
+                    continue;
+                }
                 // Each child is a color slot; its first child element holds the actual color
                 for color_node in child.children() {
-                    if !color_node.is_element() { continue; }
+                    if !color_node.is_element() {
+                        continue;
+                    }
                     let hex = match color_node.tag_name().name() {
-                        "srgbClr" => {
-                            color_node.attribute("val").map(|v| format!("#{}", v.to_uppercase()))
-                        }
-                        "sysClr" => {
-                            color_node.attribute("lastClr").map(|v| format!("#{}", v.to_uppercase()))
-                        }
+                        "srgbClr" => color_node
+                            .attribute("val")
+                            .map(|v| format!("#{}", v.to_uppercase())),
+                        "sysClr" => color_node
+                            .attribute("lastClr")
+                            .map(|v| format!("#{}", v.to_uppercase())),
                         _ => None,
                     };
                     if let Some(h) = hex {
@@ -225,7 +255,9 @@ fn parse_theme_colors(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<Strin
 /// tint > 0: lighten; tint < 0: darken.
 fn apply_tint(hex: &str, tint: f64) -> String {
     let hex = hex.trim_start_matches('#');
-    if hex.len() < 6 { return format!("#{}", hex); }
+    if hex.len() < 6 {
+        return format!("#{}", hex);
+    }
     let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0) as f64 / 255.0;
     let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0) as f64 / 255.0;
     let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0) as f64 / 255.0;
@@ -261,14 +293,23 @@ fn apply_tint(hex: &str, tint: f64) -> String {
 
     // HLS → RGB
     let (nr, ng, nb) = hls_to_rgb(h, new_l, s);
-    format!("#{:02X}{:02X}{:02X}", (nr * 255.0).round() as u8, (ng * 255.0).round() as u8, (nb * 255.0).round() as u8)
+    format!(
+        "#{:02X}{:02X}{:02X}",
+        (nr * 255.0).round() as u8,
+        (ng * 255.0).round() as u8,
+        (nb * 255.0).round() as u8
+    )
 }
 
 fn hls_to_rgb(h: f64, l: f64, s: f64) -> (f64, f64, f64) {
     if s == 0.0 {
         return (l, l, l);
     }
-    let q = if l < 0.5 { l * (1.0 + s) } else { l + s - l * s };
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
     let p = 2.0 * l - q;
     let r = hue_to_rgb(p, q, h + 1.0 / 3.0);
     let g = hue_to_rgb(p, q, h);
@@ -277,11 +318,21 @@ fn hls_to_rgb(h: f64, l: f64, s: f64) -> (f64, f64, f64) {
 }
 
 fn hue_to_rgb(p: f64, q: f64, mut t: f64) -> f64 {
-    if t < 0.0 { t += 1.0; }
-    if t > 1.0 { t -= 1.0; }
-    if t < 1.0 / 6.0 { return p + (q - p) * 6.0 * t; }
-    if t < 1.0 / 2.0 { return q; }
-    if t < 2.0 / 3.0 { return p + (q - p) * (2.0 / 3.0 - t) * 6.0; }
+    if t < 0.0 {
+        t += 1.0;
+    }
+    if t > 1.0 {
+        t -= 1.0;
+    }
+    if t < 1.0 / 6.0 {
+        return p + (q - p) * 6.0 * t;
+    }
+    if t < 1.0 / 2.0 {
+        return q;
+    }
+    if t < 2.0 / 3.0 {
+        return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+    }
     p
 }
 
@@ -369,11 +420,13 @@ fn parse_workbook_sheets(doc: &roxmltree::Document) -> Vec<SheetMeta> {
                 .attribute("sheetId")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(1);
-            let r_id = node
-                .attribute((r_ns, "id"))
-                .unwrap_or("")
-                .to_string();
-            sheets.push(SheetMeta { name, sheet_id, r_id, tab_color: None });
+            let r_id = node.attribute((r_ns, "id")).unwrap_or("").to_string();
+            sheets.push(SheetMeta {
+                name,
+                sheet_id,
+                r_id,
+                tab_color: None,
+            });
         }
     }
     sheets
@@ -390,8 +443,15 @@ fn parse_defined_names_for_sheet(doc: &roxmltree::Document, sheet_index: u32) ->
             continue;
         }
         let local: Option<u32> = node.attribute("localSheetId").and_then(|s| s.parse().ok());
-        if let Some(l) = local { if l != sheet_index { continue; } }
-        let name = match node.attribute("name") { Some(n) => n.to_string(), None => continue };
+        if let Some(l) = local {
+            if l != sheet_index {
+                continue;
+            }
+        }
+        let name = match node.attribute("name") {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
         let formula = node.text().unwrap_or("").to_string();
         names.push(DefinedName { name, formula });
     }
@@ -443,16 +503,14 @@ fn read_shared_strings(
 /// Parse a `<si>` (shared) or `<is>` (inline) node into a SharedString.
 /// The node may contain direct `<t>` text (plain) and/or multiple `<r>`
 /// runs with per-run `<rPr>` font properties.
-fn parse_si_node(
-    node: &roxmltree::Node,
-    ns: &str,
-    theme_colors: &[String],
-) -> SharedString {
+fn parse_si_node(node: &roxmltree::Node, ns: &str, theme_colors: &[String]) -> SharedString {
     let mut text = String::new();
     let mut runs: Vec<Run> = Vec::new();
     let mut has_runs = false;
     for child in node.children() {
-        if !child.is_element() { continue; }
+        if !child.is_element() {
+            continue;
+        }
         match child.tag_name().name() {
             "t" if child.tag_name().namespace() == Some(ns) => {
                 if let Some(s) = child.text() {
@@ -515,7 +573,10 @@ fn parse_si_node(
                     }
                 }
                 text.push_str(&run_text);
-                runs.push(Run { text: run_text, font: run_font });
+                runs.push(Run {
+                    text: run_text,
+                    font: run_font,
+                });
             }
             _ => {}
         }
@@ -564,9 +625,17 @@ fn parse_worksheet(
     // (§2.6.3). Build a GUID → gradient map so cfRule parsing can look up
     // the override.
     let mut x14_databar_gradient: HashMap<String, bool> = HashMap::new();
-    for x14_rule in doc.descendants().filter(|n| n.tag_name().name() == "cfRule" && n.attribute("type") == Some("dataBar")) {
-        let Some(id) = x14_rule.attribute("id") else { continue };
-        for bar in x14_rule.children().filter(|n| n.tag_name().name() == "dataBar") {
+    for x14_rule in doc
+        .descendants()
+        .filter(|n| n.tag_name().name() == "cfRule" && n.attribute("type") == Some("dataBar"))
+    {
+        let Some(id) = x14_rule.attribute("id") else {
+            continue;
+        };
+        for bar in x14_rule
+            .children()
+            .filter(|n| n.tag_name().name() == "dataBar")
+        {
             if let Some(g) = bar.attribute("gradient") {
                 x14_databar_gradient.insert(id.to_string(), !(g == "0" || g == "false"));
             }
@@ -579,22 +648,49 @@ fn parse_worksheet(
     // and cfvo values inside `<xm:f>` children instead of `val` attributes.
     // The sqref for x14 CF rules lives in a `<xm:sqref>` sibling.
     let mut x14_icon_formats: Vec<ConditionalFormat> = Vec::new();
-    for x14_cf in doc.descendants().filter(|n| n.tag_name().name() == "conditionalFormatting" && n.tag_name().namespace().map(|u| u.contains("/spreadsheetml/2009/9")).unwrap_or(false)) {
-        let sqref: Vec<CellRange> = x14_cf.children()
+    for x14_cf in doc.descendants().filter(|n| {
+        n.tag_name().name() == "conditionalFormatting"
+            && n.tag_name()
+                .namespace()
+                .map(|u| u.contains("/spreadsheetml/2009/9"))
+                .unwrap_or(false)
+    }) {
+        let sqref: Vec<CellRange> = x14_cf
+            .children()
             .find(|n| n.tag_name().name() == "sqref")
             .and_then(|n| n.text())
             .map(parse_sqref)
             .unwrap_or_default();
-        if sqref.is_empty() { continue; }
+        if sqref.is_empty() {
+            continue;
+        }
         let mut rules: Vec<CfRule> = Vec::new();
-        for x14_rule in x14_cf.children().filter(|n| n.tag_name().name() == "cfRule" && n.attribute("type") == Some("iconSet")) {
-            let priority: i32 = x14_rule.attribute("priority").and_then(|s| s.parse().ok()).unwrap_or(0);
-            let Some(icon_node) = x14_rule.children().find(|n| n.tag_name().name() == "iconSet") else { continue };
-            let custom = icon_node.attribute("custom").map(|v| v == "1" || v == "true").unwrap_or(false);
-            let icon_set_name = icon_node.attribute("iconSet")
+        for x14_rule in x14_cf
+            .children()
+            .filter(|n| n.tag_name().name() == "cfRule" && n.attribute("type") == Some("iconSet"))
+        {
+            let priority: i32 = x14_rule
+                .attribute("priority")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            let Some(icon_node) = x14_rule
+                .children()
+                .find(|n| n.tag_name().name() == "iconSet")
+            else {
+                continue;
+            };
+            let custom = icon_node
+                .attribute("custom")
+                .map(|v| v == "1" || v == "true")
+                .unwrap_or(false);
+            let icon_set_name = icon_node
+                .attribute("iconSet")
                 .unwrap_or(if custom { "" } else { "3TrafficLights1" })
                 .to_string();
-            let reverse = icon_node.attribute("reverse").map(|v| v == "1" || v == "true").unwrap_or(false);
+            let reverse = icon_node
+                .attribute("reverse")
+                .map(|v| v == "1" || v == "true")
+                .unwrap_or(false);
             let mut cfvos: Vec<CfValue> = Vec::new();
             let mut custom_icons: Vec<CfIcon> = Vec::new();
             for ch in icon_node.children().filter(|n| n.is_element()) {
@@ -602,7 +698,8 @@ fn parse_worksheet(
                     "cfvo" => {
                         let kind = ch.attribute("type").unwrap_or("percent").to_string();
                         // x14:cfvo stores the value in `<xm:f>` child; attribute val fallback.
-                        let value = ch.children()
+                        let value = ch
+                            .children()
                             .find(|n| n.tag_name().name() == "f")
                             .and_then(|n| n.text())
                             .map(|s| s.to_string())
@@ -611,8 +708,14 @@ fn parse_worksheet(
                     }
                     "cfIcon" => {
                         let set = ch.attribute("iconSet").unwrap_or("NoIcons").to_string();
-                        let id = ch.attribute("iconId").and_then(|s| s.parse().ok()).unwrap_or(0);
-                        custom_icons.push(CfIcon { icon_set: set, icon_id: id });
+                        let id = ch
+                            .attribute("iconId")
+                            .and_then(|s| s.parse().ok())
+                            .unwrap_or(0);
+                        custom_icons.push(CfIcon {
+                            icon_set: set,
+                            icon_id: id,
+                        });
                     }
                     _ => {}
                 }
@@ -633,7 +736,10 @@ fn parse_worksheet(
     for node in doc.descendants() {
         match node.tag_name().name() {
             "sheetFormatPr" if node.tag_name().namespace() == Some(ns) => {
-                if let Some(v) = node.attribute("defaultColWidth").and_then(|s| s.parse().ok()) {
+                if let Some(v) = node
+                    .attribute("defaultColWidth")
+                    .and_then(|s| s.parse().ok())
+                {
                     default_col_width = v;
                 }
                 // ECMA-376 §18.3.1.81 `defaultRowHeight` is the workbook
@@ -653,15 +759,25 @@ fn parse_worksheet(
                 let custom = attr_bool(&node, "customWidth").unwrap_or(false);
                 let hidden = attr_bool(&node, "hidden").unwrap_or(false);
                 // Only record widths for custom-widthed columns OR hidden columns
-                if !custom && !hidden { continue; }
-                let min: u32 = node.attribute("min").and_then(|s| s.parse().ok()).unwrap_or(1);
-                let max: u32 = node.attribute("max").and_then(|s| s.parse().ok()).unwrap_or(1);
+                if !custom && !hidden {
+                    continue;
+                }
+                let min: u32 = node
+                    .attribute("min")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(1);
+                let max: u32 = node
+                    .attribute("max")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(1);
                 // Cap range to avoid storing 16K entries for max=16384 ranges
                 let max = max.min(min + 255);
                 let width: f64 = if hidden {
                     0.0
                 } else {
-                    node.attribute("width").and_then(|s| s.parse().ok()).unwrap_or(default_col_width)
+                    node.attribute("width")
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(default_col_width)
                 };
                 for c in min..=max {
                     col_widths.insert(c, width);
@@ -683,21 +799,36 @@ fn parse_worksheet(
                     auto_filter = if parts.len() == 2 {
                         let (left, top) = parse_cell_ref(parts[0]);
                         let (right, bottom) = parse_cell_ref(parts[1]);
-                        Some(CellRange { top, left, bottom, right })
+                        Some(CellRange {
+                            top,
+                            left,
+                            bottom,
+                            right,
+                        })
                     } else {
                         let (col, row) = parse_cell_ref(parts[0]);
-                        Some(CellRange { top: row, left: col, bottom: row, right: col })
+                        Some(CellRange {
+                            top: row,
+                            left: col,
+                            bottom: row,
+                            right: col,
+                        })
                     };
                 }
             }
             "hyperlinks" if node.tag_name().namespace() == Some(ns) => {
                 for hl in node.children() {
-                    if !hl.is_element() || hl.tag_name().name() != "hyperlink" { continue; }
-                    let Some(ref_str) = hl.attribute("ref") else { continue };
+                    if !hl.is_element() || hl.tag_name().name() != "hyperlink" {
+                        continue;
+                    }
+                    let Some(ref_str) = hl.attribute("ref") else {
+                        continue;
+                    };
                     // Only first cell of ref range
                     let ref_single = ref_str.split(':').next().unwrap_or(ref_str);
                     let (col, row) = parse_cell_ref(ref_single);
-                    if let Some(rid) = hl.attributes()
+                    if let Some(rid) = hl
+                        .attributes()
                         .find(|a| a.name() == "id" && a.namespace() == Some(r_ns))
                         .map(|a| a.value().to_string())
                     {
@@ -708,11 +839,13 @@ fn parse_worksheet(
             "pane" if node.tag_name().namespace() == Some(ns) => {
                 let state = node.attribute("state").unwrap_or("");
                 if state == "frozen" || state == "frozenSplit" {
-                    freeze_rows = node.attribute("ySplit")
+                    freeze_rows = node
+                        .attribute("ySplit")
                         .and_then(|s| s.parse::<f64>().ok())
                         .map(|v| v as u32)
                         .unwrap_or(0);
-                    freeze_cols = node.attribute("xSplit")
+                    freeze_cols = node
+                        .attribute("xSplit")
                         .and_then(|s| s.parse::<f64>().ok())
                         .map(|v| v as u32)
                         .unwrap_or(0);
@@ -724,12 +857,20 @@ fn parse_worksheet(
                     if parts.len() == 2 {
                         let (left, top) = parse_cell_ref(parts[0]);
                         let (right, bottom) = parse_cell_ref(parts[1]);
-                        merge_cells.push(MergeCell { top, left, bottom, right });
+                        merge_cells.push(MergeCell {
+                            top,
+                            left,
+                            bottom,
+                            right,
+                        });
                     }
                 }
             }
             "row" if node.tag_name().namespace() == Some(ns) => {
-                let row_idx: u32 = node.attribute("r").and_then(|s| s.parse().ok()).unwrap_or(0);
+                let row_idx: u32 = node
+                    .attribute("r")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
                 let hidden = attr_bool(&node, "hidden").unwrap_or(false);
                 // ECMA-376 §18.3.1.73 `<row>@ht` is the row height in points.
                 // Gating the value on `@customHeight="1"` (0.37.0) was too
@@ -748,45 +889,66 @@ fn parse_worksheet(
                     row_heights.insert(row_idx, h);
                 }
                 let cells = parse_row_cells(&node, shared_strings, theme_colors, ns);
-                rows.push(Row { index: row_idx, height, cells });
+                rows.push(Row {
+                    index: row_idx,
+                    height,
+                    cells,
+                });
             }
             "conditionalFormatting" if node.tag_name().namespace() == Some(ns) => {
-                let sqref = node.attribute("sqref")
+                let sqref = node
+                    .attribute("sqref")
                     .map(|s| parse_sqref(s))
                     .unwrap_or_default();
                 let mut rules: Vec<CfRule> = Vec::new();
                 for cf in node.children() {
-                    if cf.tag_name().name() != "cfRule" { continue; }
+                    if cf.tag_name().name() != "cfRule" {
+                        continue;
+                    }
                     let kind = cf.attribute("type").unwrap_or("").to_string();
-                    let priority: i32 = cf.attribute("priority").and_then(|s| s.parse().ok()).unwrap_or(0);
+                    let priority: i32 = cf
+                        .attribute("priority")
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0);
                     let dxf_id: Option<u32> = cf.attribute("dxfId").and_then(|s| s.parse().ok());
                     match kind.as_str() {
                         "cellIs" => {
                             let operator = cf.attribute("operator").unwrap_or("equal").to_string();
-                            let formulas: Vec<String> = cf.children()
+                            let formulas: Vec<String> = cf
+                                .children()
                                 .filter(|n| n.tag_name().name() == "formula")
                                 .filter_map(|n| n.text().map(|s| s.to_string()))
                                 .collect();
-                            rules.push(CfRule::CellIs { operator, formulas, dxf_id, priority });
+                            rules.push(CfRule::CellIs {
+                                operator,
+                                formulas,
+                                dxf_id,
+                                priority,
+                            });
                         }
-                        "expression"
-                        | "containsBlanks" | "notContainsBlanks"
-                        | "containsText" | "notContainsText"
-                        | "beginsWith" | "endsWith"
-                        | "containsErrors" | "notContainsErrors" => {
+                        "expression" | "containsBlanks" | "notContainsBlanks" | "containsText"
+                        | "notContainsText" | "beginsWith" | "endsWith" | "containsErrors"
+                        | "notContainsErrors" => {
                             // For `containsBlanks`/`notContainsBlanks`/`containsText` etc.,
                             // Excel serializes an equivalent boolean formula (e.g.
                             // `LEN(TRIM(C8))>0`) as the rule's `<formula>` child
                             // (ECMA-376 §18.3.1.10). Evaluate as an expression rule.
-                            let formula = cf.children()
+                            let formula = cf
+                                .children()
                                 .find(|n| n.tag_name().name() == "formula")
                                 .and_then(|n| n.text())
                                 .unwrap_or("")
                                 .to_string();
-                            let stop_if_true = cf.attribute("stopIfTrue")
+                            let stop_if_true = cf
+                                .attribute("stopIfTrue")
                                 .map(|v| v == "1" || v == "true")
                                 .unwrap_or(false);
-                            rules.push(CfRule::Expression { formula, dxf_id, priority, stop_if_true });
+                            rules.push(CfRule::Expression {
+                                formula,
+                                dxf_id,
+                                priority,
+                                stop_if_true,
+                            });
                         }
                         "colorScale" => {
                             let scale = cf.children().find(|n| n.tag_name().name() == "colorScale");
@@ -797,22 +959,35 @@ fn parse_worksheet(
                                     match child.tag_name().name() {
                                         "cfvo" => {
                                             stop_values.push((
-                                                child.attribute("type").unwrap_or("num").to_string(),
+                                                child
+                                                    .attribute("type")
+                                                    .unwrap_or("num")
+                                                    .to_string(),
                                                 child.attribute("val").map(|s| s.to_string()),
                                             ));
                                         }
                                         "color" => {
-                                            stop_colors.push(parse_color(&child, theme_colors).unwrap_or_else(|| "#FFFFFF".to_string()));
+                                            stop_colors.push(
+                                                parse_color(&child, theme_colors)
+                                                    .unwrap_or_else(|| "#FFFFFF".to_string()),
+                                            );
                                         }
                                         _ => {}
                                     }
                                 }
                             }
-                            let stops: Vec<CfStop> = stop_values.into_iter().enumerate().map(|(i, (kind, value))| CfStop {
-                                kind,
-                                value,
-                                color: stop_colors.get(i).cloned().unwrap_or_else(|| "#FFFFFF".to_string()),
-                            }).collect();
+                            let stops: Vec<CfStop> = stop_values
+                                .into_iter()
+                                .enumerate()
+                                .map(|(i, (kind, value))| CfStop {
+                                    kind,
+                                    value,
+                                    color: stop_colors
+                                        .get(i)
+                                        .cloned()
+                                        .unwrap_or_else(|| "#FFFFFF".to_string()),
+                                })
+                                .collect();
                             rules.push(CfRule::ColorScale { stops, priority });
                         }
                         "dataBar" => {
@@ -824,12 +999,17 @@ fn parse_worksheet(
                                     match child.tag_name().name() {
                                         "cfvo" => {
                                             cfvos.push((
-                                                child.attribute("type").unwrap_or("min").to_string(),
+                                                child
+                                                    .attribute("type")
+                                                    .unwrap_or("min")
+                                                    .to_string(),
                                                 child.attribute("val").map(|s| s.to_string()),
                                             ));
                                         }
                                         "color" => {
-                                            if let Some(c) = parse_color(&child, theme_colors) { color = c; }
+                                            if let Some(c) = parse_color(&child, theme_colors) {
+                                                color = c;
+                                            }
                                         }
                                         _ => {}
                                     }
@@ -842,9 +1022,15 @@ fn parse_worksheet(
                             // `<x14:id>{GUID}</x14:id>` contained in this
                             // cfRule's own extLst.
                             let mut gradient = true;
-                            'gradient_lookup: for ext_list in cf.children().filter(|n| n.tag_name().name() == "extLst") {
-                                for ext in ext_list.children().filter(|n| n.tag_name().name() == "ext") {
-                                    for id_node in ext.descendants().filter(|n| n.tag_name().name() == "id") {
+                            'gradient_lookup: for ext_list in
+                                cf.children().filter(|n| n.tag_name().name() == "extLst")
+                            {
+                                for ext in
+                                    ext_list.children().filter(|n| n.tag_name().name() == "ext")
+                                {
+                                    for id_node in
+                                        ext.descendants().filter(|n| n.tag_name().name() == "id")
+                                    {
                                         if let Some(guid) = id_node.text() {
                                             if let Some(&g) = x14_databar_gradient.get(guid) {
                                                 gradient = g;
@@ -854,7 +1040,10 @@ fn parse_worksheet(
                                     }
                                     // Fallback: some files embed <x14:dataBar>
                                     // directly in the cfRule's extLst.
-                                    for x14_bar in ext.descendants().filter(|n| n.tag_name().name() == "dataBar") {
+                                    for x14_bar in ext
+                                        .descendants()
+                                        .filter(|n| n.tag_name().name() == "dataBar")
+                                    {
                                         if let Some(g) = x14_bar.attribute("gradient") {
                                             gradient = !(g == "0" || g == "false");
                                             break 'gradient_lookup;
@@ -862,24 +1051,69 @@ fn parse_worksheet(
                                     }
                                 }
                             }
-                            let min = cfvos.first().map(|(k, v)| CfValue { kind: k.clone(), value: v.clone() })
-                                .unwrap_or(CfValue { kind: "min".into(), value: None });
-                            let max = cfvos.get(1).map(|(k, v)| CfValue { kind: k.clone(), value: v.clone() })
-                                .unwrap_or(CfValue { kind: "max".into(), value: None });
-                            rules.push(CfRule::DataBar { color, min, max, priority, gradient });
+                            let min = cfvos
+                                .first()
+                                .map(|(k, v)| CfValue {
+                                    kind: k.clone(),
+                                    value: v.clone(),
+                                })
+                                .unwrap_or(CfValue {
+                                    kind: "min".into(),
+                                    value: None,
+                                });
+                            let max = cfvos
+                                .get(1)
+                                .map(|(k, v)| CfValue {
+                                    kind: k.clone(),
+                                    value: v.clone(),
+                                })
+                                .unwrap_or(CfValue {
+                                    kind: "max".into(),
+                                    value: None,
+                                });
+                            rules.push(CfRule::DataBar {
+                                color,
+                                min,
+                                max,
+                                priority,
+                                gradient,
+                            });
                         }
                         "top10" => {
-                            let top = !cf.attribute("bottom").map(|v| v == "1" || v == "true").unwrap_or(false);
-                            let percent = cf.attribute("percent").map(|v| v == "1" || v == "true").unwrap_or(false);
-                            let rank = cf.attribute("rank").and_then(|s| s.parse().ok()).unwrap_or(10);
-                            rules.push(CfRule::Top10 { top, percent, rank, dxf_id, priority });
+                            let top = !cf
+                                .attribute("bottom")
+                                .map(|v| v == "1" || v == "true")
+                                .unwrap_or(false);
+                            let percent = cf
+                                .attribute("percent")
+                                .map(|v| v == "1" || v == "true")
+                                .unwrap_or(false);
+                            let rank = cf
+                                .attribute("rank")
+                                .and_then(|s| s.parse().ok())
+                                .unwrap_or(10);
+                            rules.push(CfRule::Top10 {
+                                top,
+                                percent,
+                                rank,
+                                dxf_id,
+                                priority,
+                            });
                         }
                         "aboveAverage" => {
-                            let above_average = cf.attribute("aboveAverage").map(|v| v != "0").unwrap_or(true);
-                            rules.push(CfRule::AboveAverage { above_average, dxf_id, priority });
+                            let above_average = cf
+                                .attribute("aboveAverage")
+                                .map(|v| v != "0")
+                                .unwrap_or(true);
+                            rules.push(CfRule::AboveAverage {
+                                above_average,
+                                dxf_id,
+                                priority,
+                            });
                         }
                         "iconSet" => {
-                            let icon_set_node = cf.children().find(|n| n.tag_name().name() == "iconSet");
+                            let icon_set_node =
+                                cf.children().find(|n| n.tag_name().name() == "iconSet");
                             let icon_set = icon_set_node
                                 .and_then(|n| n.attribute("iconSet"))
                                 .unwrap_or("3TrafficLights1")
@@ -889,19 +1123,32 @@ fn parse_worksheet(
                                 .map(|v| v == "1" || v == "true")
                                 .unwrap_or(false);
                             let cfvos: Vec<CfValue> = icon_set_node
-                                .map(|n| n.children()
-                                    .filter(|c| c.is_element() && c.tag_name().name() == "cfvo")
-                                    .map(|c| CfValue {
-                                        kind: c.attribute("type").unwrap_or("percent").to_string(),
-                                        value: c.attribute("val").map(|s| s.to_string()),
-                                    })
-                                    .collect()
-                                )
+                                .map(|n| {
+                                    n.children()
+                                        .filter(|c| c.is_element() && c.tag_name().name() == "cfvo")
+                                        .map(|c| CfValue {
+                                            kind: c
+                                                .attribute("type")
+                                                .unwrap_or("percent")
+                                                .to_string(),
+                                            value: c.attribute("val").map(|s| s.to_string()),
+                                        })
+                                        .collect()
+                                })
                                 .unwrap_or_default();
-                            rules.push(CfRule::IconSet { icon_set, cfvos, reverse, priority, custom_icons: None });
+                            rules.push(CfRule::IconSet {
+                                icon_set,
+                                cfvos,
+                                reverse,
+                                priority,
+                                custom_icons: None,
+                            });
                         }
                         other => {
-                            rules.push(CfRule::Other { kind: other.to_string(), priority });
+                            rules.push(CfRule::Other {
+                                kind: other.to_string(),
+                                priority,
+                            });
                         }
                     }
                 }
@@ -915,36 +1162,39 @@ fn parse_worksheet(
 
     let data_validations = parse_data_validations(doc.root_element());
 
-    Ok((Worksheet {
-        name: name.to_string(),
-        rows,
-        col_widths,
-        row_heights,
-        default_col_width,
-        default_row_height,
-        merge_cells,
-        freeze_rows,
-        freeze_cols,
-        conditional_formats,
-        images: Vec::new(),
-        charts: Vec::new(),
-        shape_groups: Vec::new(),
-        show_zeros,
-        show_gridlines,
-        right_to_left,
-        tab_color,
-        auto_filter,
-        hyperlinks: Vec::new(),
-        comment_refs: Vec::new(),
-        comments: Vec::new(),
-        data_validations,
-        defined_names: Vec::new(),
-        tables: Vec::new(),
-        slicers: Vec::new(),
-        sparkline_groups: Vec::new(),
-        default_font_family: None,
-        default_font_size: None,
-    }, hyperlink_rids))
+    Ok((
+        Worksheet {
+            name: name.to_string(),
+            rows,
+            col_widths,
+            row_heights,
+            default_col_width,
+            default_row_height,
+            merge_cells,
+            freeze_rows,
+            freeze_cols,
+            conditional_formats,
+            images: Vec::new(),
+            charts: Vec::new(),
+            shape_groups: Vec::new(),
+            show_zeros,
+            show_gridlines,
+            right_to_left,
+            tab_color,
+            auto_filter,
+            hyperlinks: Vec::new(),
+            comment_refs: Vec::new(),
+            comments: Vec::new(),
+            data_validations,
+            defined_names: Vec::new(),
+            tables: Vec::new(),
+            slicers: Vec::new(),
+            sparkline_groups: Vec::new(),
+            default_font_family: None,
+            default_font_size: None,
+        },
+        hyperlink_rids,
+    ))
 }
 
 /// Parse a .rels file into rId → Target map.
@@ -972,16 +1222,26 @@ fn load_sheet_comments(
     archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
     sheet_path: &str,
 ) -> Vec<XlsxComment> {
-    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
+        return Vec::new();
+    };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else { return Vec::new(); };
-    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else { return Vec::new(); };
+    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+        return Vec::new();
+    };
+    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else {
+        return Vec::new();
+    };
 
     // Accept both plain ("/comments") and threaded ("/threadedComment") relTypes
     // but prefer the classic comments file — threaded comments live in a
     // separate namespace and are an extension.
     let mut comments_target: Option<String> = None;
-    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+    for rel in rels_doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element())
+    {
         let rel_type = rel.attribute("Type").unwrap_or("");
         if rel_type.ends_with("/comments") {
             if let Some(t) = rel.attribute("Target") {
@@ -990,11 +1250,17 @@ fn load_sheet_comments(
             }
         }
     }
-    let Some(target) = comments_target else { return Vec::new(); };
+    let Some(target) = comments_target else {
+        return Vec::new();
+    };
 
     let comments_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-    let Ok(comments_xml) = read_zip_entry(archive, &comments_path) else { return Vec::new(); };
-    let Ok(comments_doc) = roxmltree::Document::parse(&comments_xml) else { return Vec::new(); };
+    let Ok(comments_xml) = read_zip_entry(archive, &comments_path) else {
+        return Vec::new();
+    };
+    let Ok(comments_doc) = roxmltree::Document::parse(&comments_xml) else {
+        return Vec::new();
+    };
 
     // Resolve <authors><author>…</author></authors> — `authorId` indexes here.
     let authors: Vec<String> = comments_doc
@@ -1010,18 +1276,27 @@ fn load_sheet_comments(
 
     let mut comments: Vec<XlsxComment> = Vec::new();
     for node in comments_doc.descendants() {
-        if node.tag_name().name() != "comment" || !node.is_element() { continue }
-        let Some(cell_ref) = node.attribute("ref") else { continue };
+        if node.tag_name().name() != "comment" || !node.is_element() {
+            continue;
+        }
+        let Some(cell_ref) = node.attribute("ref") else {
+            continue;
+        };
         let author = node
             .attribute("authorId")
             .and_then(|s| s.parse::<usize>().ok())
             .and_then(|i| authors.get(i).cloned())
             .filter(|s| !s.is_empty());
         let mut text = String::new();
-        if let Some(t_node) = node.children().find(|c| c.is_element() && c.tag_name().name() == "text") {
+        if let Some(t_node) = node
+            .children()
+            .find(|c| c.is_element() && c.tag_name().name() == "text")
+        {
             for r in t_node.descendants() {
                 if r.is_element() && r.tag_name().name() == "t" {
-                    if let Some(s) = r.text() { text.push_str(s); }
+                    if let Some(s) = r.text() {
+                        text.push_str(s);
+                    }
                 }
             }
         }
@@ -1038,19 +1313,42 @@ fn load_sheet_comments(
 /// XML root. Returns an empty vec when the element is absent.
 fn parse_data_validations(ws_root: roxmltree::Node<'_, '_>) -> Vec<DataValidation> {
     let mut out: Vec<DataValidation> = Vec::new();
-    let Some(dvs) = ws_root.children().find(|n| n.is_element() && n.tag_name().name() == "dataValidations") else {
+    let Some(dvs) = ws_root
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "dataValidations")
+    else {
         return out;
     };
-    for dv in dvs.children().filter(|n| n.is_element() && n.tag_name().name() == "dataValidation") {
+    for dv in dvs
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dataValidation")
+    {
         let sqref = dv.attribute("sqref").unwrap_or("").to_string();
-        if sqref.is_empty() { continue }
+        if sqref.is_empty() {
+            continue;
+        }
         let validation_type = dv.attribute("type").map(String::from);
         let operator = dv.attribute("operator").map(String::from);
-        let allow_blank = dv.attribute("allowBlank").map(|v| v == "1" || v.eq_ignore_ascii_case("true")).unwrap_or(false);
-        let prompt_title = dv.attribute("promptTitle").map(String::from).filter(|s| !s.is_empty());
-        let prompt = dv.attribute("prompt").map(String::from).filter(|s| !s.is_empty());
-        let error_title = dv.attribute("errorTitle").map(String::from).filter(|s| !s.is_empty());
-        let error_message = dv.attribute("error").map(String::from).filter(|s| !s.is_empty());
+        let allow_blank = dv
+            .attribute("allowBlank")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let prompt_title = dv
+            .attribute("promptTitle")
+            .map(String::from)
+            .filter(|s| !s.is_empty());
+        let prompt = dv
+            .attribute("prompt")
+            .map(String::from)
+            .filter(|s| !s.is_empty());
+        let error_title = dv
+            .attribute("errorTitle")
+            .map(String::from)
+            .filter(|s| !s.is_empty());
+        let error_message = dv
+            .attribute("error")
+            .map(String::from)
+            .filter(|s| !s.is_empty());
 
         let mut formula1: Option<String> = None;
         let mut formula2: Option<String> = None;
@@ -1078,27 +1376,38 @@ fn parse_data_validations(ws_root: roxmltree::Node<'_, '_>) -> Vec<DataValidatio
     out
 }
 
-
 /// Resolve hyperlink rIds to URLs from the sheet rels file.
 fn load_hyperlinks(
     archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
     sheet_path: &str,
     hyperlink_rids: Vec<(u32, u32, String)>,
 ) -> Vec<Hyperlink> {
-    if hyperlink_rids.is_empty() { return Vec::new(); }
-    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    if hyperlink_rids.is_empty() {
+        return Vec::new();
+    }
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
+        return Vec::new();
+    };
     let rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
     let rels = read_zip_entry(archive, &rels_path)
         .ok()
         .map(|xml| parse_rels_map(&xml))
         .unwrap_or_default();
-    hyperlink_rids.into_iter().map(|(col, row, rid)| Hyperlink {
-        col, row, url: rels.get(&rid).cloned(),
-    }).collect()
+    hyperlink_rids
+        .into_iter()
+        .map(|(col, row, rid)| Hyperlink {
+            col,
+            row,
+            url: rels.get(&rid).cloned(),
+        })
+        .collect()
 }
 
 /// Read a binary file from the zip.
-pub(crate) fn read_zip_bytes(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, path: &str) -> Option<Vec<u8>> {
+pub(crate) fn read_zip_bytes(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    path: &str,
+) -> Option<Vec<u8>> {
     let max = ooxml_common::zip::current_max();
     let mut file = archive.by_name(path).ok()?;
     if file.size() > max {
@@ -1114,7 +1423,9 @@ pub(crate) fn resolve_zip_path(base_dir: &str, target: &str) -> String {
     let mut parts: Vec<&str> = base_dir.split('/').filter(|s| !s.is_empty()).collect();
     for seg in target.split('/') {
         match seg {
-            ".." => { parts.pop(); }
+            ".." => {
+                parts.pop();
+            }
             "." | "" => {}
             s => parts.push(s),
         }
@@ -1123,17 +1434,26 @@ pub(crate) fn resolve_zip_path(base_dir: &str, target: &str) -> String {
 }
 
 pub(crate) fn mime_from_ext(path: &str) -> &'static str {
-    match path.rsplit('.').next().unwrap_or("").to_ascii_lowercase().as_str() {
-        "png"  => "image/png",
+    match path
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "png" => "image/png",
         "jpg" | "jpeg" => "image/jpeg",
-        "gif"  => "image/gif",
-        "bmp"  => "image/bmp",
+        "gif" => "image/gif",
+        "bmp" => "image/bmp",
         "webp" => "image/webp",
-        _      => "application/octet-stream",
+        _ => "application/octet-stream",
     }
 }
 
-pub(crate) fn resolve_fill_color(fill_node: &roxmltree::Node, theme_colors: &[String]) -> Option<String> {
+pub(crate) fn resolve_fill_color(
+    fill_node: &roxmltree::Node,
+    theme_colors: &[String],
+) -> Option<String> {
     // Accept either a `<a:solidFill>` directly or a `<c:spPr>` whose first
     // fill-ish child is `<a:solidFill>`. Looking at *direct* children (not
     // descendants) is intentional — chart series often carry label/axis text
@@ -1141,7 +1461,9 @@ pub(crate) fn resolve_fill_color(fill_node: &roxmltree::Node, theme_colors: &[St
     let solid = if fill_node.tag_name().name() == "solidFill" {
         Some(*fill_node)
     } else {
-        fill_node.children().find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+        fill_node
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
     }?;
     for n in solid.children().filter(|n| n.is_element()) {
         let tag = n.tag_name().name();
@@ -1153,17 +1475,17 @@ pub(crate) fn resolve_fill_color(fill_node: &roxmltree::Node, theme_colors: &[St
         if tag == "schemeClr" {
             if let Some(v) = n.attribute("val") {
                 let idx = match v {
-                    "dk1"  | "tx1" => Some(0),
-                    "lt1"  | "bg1" => Some(1),
-                    "dk2"  | "tx2" => Some(2),
-                    "lt2"  | "bg2" => Some(3),
+                    "dk1" | "tx1" => Some(0),
+                    "lt1" | "bg1" => Some(1),
+                    "dk2" | "tx2" => Some(2),
+                    "lt2" | "bg2" => Some(3),
                     "accent1" => Some(4),
                     "accent2" => Some(5),
                     "accent3" => Some(6),
                     "accent4" => Some(7),
                     "accent5" => Some(8),
                     "accent6" => Some(9),
-                    "hlink"    => Some(10),
+                    "hlink" => Some(10),
                     "folHlink" => Some(11),
                     _ => None,
                 };
@@ -1179,16 +1501,28 @@ pub(crate) fn resolve_fill_color(fill_node: &roxmltree::Node, theme_colors: &[St
 }
 
 fn parse_sqref(s: &str) -> Vec<CellRange> {
-    s.split_whitespace().map(|range_str| {
-        if let Some((a, b)) = range_str.split_once(':') {
-            let (left, top) = parse_cell_ref(a);
-            let (right, bottom) = parse_cell_ref(b);
-            CellRange { top, left, bottom, right }
-        } else {
-            let (col, row) = parse_cell_ref(range_str);
-            CellRange { top: row, left: col, bottom: row, right: col }
-        }
-    }).collect()
+    s.split_whitespace()
+        .map(|range_str| {
+            if let Some((a, b)) = range_str.split_once(':') {
+                let (left, top) = parse_cell_ref(a);
+                let (right, bottom) = parse_cell_ref(b);
+                CellRange {
+                    top,
+                    left,
+                    bottom,
+                    right,
+                }
+            } else {
+                let (col, row) = parse_cell_ref(range_str);
+                CellRange {
+                    top: row,
+                    left: col,
+                    bottom: row,
+                    right: col,
+                }
+            }
+        })
+        .collect()
 }
 
 /// Split an `<xm:f>` reference like `Sheet1!A1:A10` or `'My Sheet'!$B$3:$B$8`
@@ -1197,7 +1531,9 @@ fn parse_sqref(s: &str) -> Vec<CellRange> {
 /// "same sheet" by callers.
 fn split_sheet_ref(s: &str) -> (Option<String>, String) {
     let s = s.trim();
-    let Some(bang) = s.rfind('!') else { return (None, s.to_string()); };
+    let Some(bang) = s.rfind('!') else {
+        return (None, s.to_string());
+    };
     let mut sheet = s[..bang].to_string();
     // Strip absolute-ref dollars from the range part.
     let range = s[bang + 1..].replace('$', "");
@@ -1218,11 +1554,18 @@ fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> 
     let total = ((range.bottom - range.top + 1) as usize)
         .saturating_mul((range.right - range.left + 1) as usize);
     let mut values: Vec<Option<f64>> = vec![None; total];
-    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else { return values; };
+    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else {
+        return values;
+    };
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     let row_span = (range.right - range.left + 1) as usize;
-    for c in doc.descendants().filter(|n| n.tag_name().name() == "c" && n.tag_name().namespace() == Some(ns)) {
-        let Some(r_attr) = c.attribute("r") else { continue };
+    for c in doc
+        .descendants()
+        .filter(|n| n.tag_name().name() == "c" && n.tag_name().namespace() == Some(ns))
+    {
+        let Some(r_attr) = c.attribute("r") else {
+            continue;
+        };
         let (col, row) = parse_cell_ref(r_attr);
         if row < range.top || row > range.bottom || col < range.left || col > range.right {
             continue;
@@ -1230,8 +1573,11 @@ fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> 
         // Only honor numeric / formula-numeric cells. `t` of "s" / "str" /
         // "inlineStr" / "b" / "e" all map to None for sparkline values.
         let t = c.attribute("t").unwrap_or("");
-        if matches!(t, "s" | "str" | "inlineStr" | "b" | "e") { continue; }
-        let v = c.children()
+        if matches!(t, "s" | "str" | "inlineStr" | "b" | "e") {
+            continue;
+        }
+        let v = c
+            .children()
             .find(|n| n.tag_name().name() == "v" && n.tag_name().namespace() == Some(ns))
             .and_then(|n| n.text())
             .and_then(|s| s.trim().parse::<f64>().ok());
@@ -1256,7 +1602,9 @@ fn load_sheet_sparklines(
     rels_doc: &roxmltree::Document,
     theme_colors: &[String],
 ) -> Vec<SparklineGroup> {
-    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else { return Vec::new(); };
+    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else {
+        return Vec::new();
+    };
     let mut groups: Vec<SparklineGroup> = Vec::new();
     // Cache: sheet name → loaded XML. Saves re-reading when many sparklines
     // reference the same source sheet (typical: one "data" sheet feeds many
@@ -1273,10 +1621,13 @@ fn load_sheet_sparklines(
         n.attribute(key).and_then(|v| v.parse::<f64>().ok())
     };
 
-    for group_node in doc.descendants().filter(|n| n.tag_name().name() == "sparklineGroup") {
+    for group_node in doc
+        .descendants()
+        .filter(|n| n.tag_name().name() == "sparklineGroup")
+    {
         let kind = match group_node.attribute("type").unwrap_or("line") {
             "column" => SparklineType::Column,
-            "stacked" => SparklineType::Stem,  // historical alias
+            "stacked" => SparklineType::Stem, // historical alias
             "stem" => SparklineType::Stem,
             // ECMA-376 lists `line` and a planned `stairStep`; treat unknown
             // types as line (closest visual fallback).
@@ -1284,28 +1635,41 @@ fn load_sheet_sparklines(
         };
 
         let resolve_color = |child_name: &str| -> Option<String> {
-            group_node.children()
+            group_node
+                .children()
                 .find(|n| n.is_element() && n.tag_name().name() == child_name)
                 .and_then(|n| parse_color(&n, theme_colors))
         };
 
         let mut sparklines: Vec<Sparkline> = Vec::new();
         // <x14:sparklines> is the wrapper; <x14:sparkline> are the children.
-        for sparklines_node in group_node.children().filter(|n| n.is_element() && n.tag_name().name() == "sparklines") {
-            for sl in sparklines_node.children().filter(|n| n.is_element() && n.tag_name().name() == "sparkline") {
-                let f_text = sl.children()
+        for sparklines_node in group_node
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sparklines")
+        {
+            for sl in sparklines_node
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "sparkline")
+            {
+                let f_text = sl
+                    .children()
                     .find(|n| n.is_element() && n.tag_name().name() == "f")
                     .and_then(|n| n.text())
                     .unwrap_or("");
-                let sqref_text = sl.children()
+                let sqref_text = sl
+                    .children()
                     .find(|n| n.is_element() && n.tag_name().name() == "sqref")
                     .and_then(|n| n.text())
                     .unwrap_or("");
-                if f_text.is_empty() || sqref_text.is_empty() { continue; }
+                if f_text.is_empty() || sqref_text.is_empty() {
+                    continue;
+                }
                 let (col, row) = parse_cell_ref(sqref_text.trim());
                 let (source_sheet, range_str) = split_sheet_ref(f_text);
                 let ranges = parse_sqref(&range_str);
-                let Some(range) = ranges.into_iter().next() else { continue };
+                let Some(range) = ranges.into_iter().next() else {
+                    continue;
+                };
 
                 // Look up source sheet XML (cross-sheet ref). When the ref
                 // has no sheet qualifier, fall back to the *current* sheet
@@ -1313,7 +1677,8 @@ fn load_sheet_sparklines(
                 let source_xml: Option<&str> = match source_sheet {
                     Some(name) => {
                         if !xml_cache.contains_key(&name) {
-                            let path = sheets.iter()
+                            let path = sheets
+                                .iter()
                                 .find(|s| s.name == name)
                                 .and_then(|s| resolve_sheet_path(rels_doc, &s.r_id))
                                 .map(|p| format!("xl/{}", p));
@@ -1341,9 +1706,18 @@ fn load_sheet_sparklines(
             last: parse_bool_attr(&group_node, "last", false),
             negative: parse_bool_attr(&group_node, "negative", false),
             display_x_axis: parse_bool_attr(&group_node, "displayXAxis", false),
-            display_empty_cells_as: group_node.attribute("displayEmptyCellsAs").unwrap_or("gap").to_string(),
-            min_axis_type: group_node.attribute("minAxisType").unwrap_or("individual").to_string(),
-            max_axis_type: group_node.attribute("maxAxisType").unwrap_or("individual").to_string(),
+            display_empty_cells_as: group_node
+                .attribute("displayEmptyCellsAs")
+                .unwrap_or("gap")
+                .to_string(),
+            min_axis_type: group_node
+                .attribute("minAxisType")
+                .unwrap_or("individual")
+                .to_string(),
+            max_axis_type: group_node
+                .attribute("maxAxisType")
+                .unwrap_or("individual")
+                .to_string(),
             manual_min: parse_f64_attr(&group_node, "manualMin"),
             manual_max: parse_f64_attr(&group_node, "manualMax"),
             line_weight: parse_f64_attr(&group_node, "lineWeight").unwrap_or(0.75),
@@ -1375,7 +1749,10 @@ fn parse_row_cells(
         let cell_ref = c_node.attribute("r").unwrap_or("A1").to_string();
         let (col, row) = parse_cell_ref(&cell_ref);
         let cell_type = c_node.attribute("t").unwrap_or("");
-        let style_index: u32 = c_node.attribute("s").and_then(|s| s.parse().ok()).unwrap_or(0);
+        let style_index: u32 = c_node
+            .attribute("s")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
 
         // Inline string: <c t="inlineStr"><is>...</is></c>
         let is_node = c_node.children().find(|n| n.tag_name().name() == "is");
@@ -1400,7 +1777,10 @@ fn parse_row_cells(
             match is_node {
                 Some(is) => {
                     let ss = parse_si_node(&is, ns, theme_colors);
-                    CellValue::Text { text: ss.text, runs: ss.runs }
+                    CellValue::Text {
+                        text: ss.text,
+                        runs: ss.runs,
+                    }
                 }
                 None => CellValue::Empty,
             }
@@ -1411,25 +1791,46 @@ fn parse_row_cells(
                 "s" => {
                     let idx: usize = v_text.parse().unwrap_or(0);
                     if let Some(ss) = shared_strings.get(idx) {
-                        CellValue::Text { text: ss.text.clone(), runs: ss.runs.clone() }
+                        CellValue::Text {
+                            text: ss.text.clone(),
+                            runs: ss.runs.clone(),
+                        }
                     } else {
-                        CellValue::Text { text: String::new(), runs: None }
+                        CellValue::Text {
+                            text: String::new(),
+                            runs: None,
+                        }
                     }
                 }
-                "str" => CellValue::Text { text: v_text, runs: None },
-                "b" => CellValue::Bool { bool: v_text == "1" || v_text == "true" },
+                "str" => CellValue::Text {
+                    text: v_text,
+                    runs: None,
+                },
+                "b" => CellValue::Bool {
+                    bool: v_text == "1" || v_text == "true",
+                },
                 "e" => CellValue::Error { error: v_text },
                 _ => {
                     if let Ok(n) = v_text.parse::<f64>() {
                         CellValue::Number { number: n }
                     } else {
-                        CellValue::Text { text: v_text, runs: None }
+                        CellValue::Text {
+                            text: v_text,
+                            runs: None,
+                        }
                     }
                 }
             }
         };
 
-        cells.push(Cell { col, row, col_ref: cell_ref, value, style_index, formula });
+        cells.push(Cell {
+            col,
+            row,
+            col_ref: cell_ref,
+            value,
+            style_index,
+            formula,
+        });
     }
     cells
 }
@@ -1438,18 +1839,16 @@ fn parse_row_cells(
 /// Accepts `1`/`true`/`on` as true and `0`/`false`/`off` as false (case-insensitive).
 /// Returns `None` when the attribute is absent so callers can apply their own default.
 pub(crate) fn attr_bool(node: &roxmltree::Node, name: &str) -> Option<bool> {
-    node.attribute(name).map(|v| {
-        matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "on"
-        )
-    })
+    node.attribute(name)
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on"))
 }
 
 pub(crate) fn parse_cell_ref(r: &str) -> (u32, u32) {
     let col_str: String = r.chars().take_while(|c| c.is_ascii_alphabetic()).collect();
     let row_str: String = r.chars().skip_while(|c| c.is_ascii_alphabetic()).collect();
-    let col = col_str.chars().fold(0u32, |acc, c| acc * 26 + (c as u32 - 'A' as u32 + 1));
+    let col = col_str
+        .chars()
+        .fold(0u32, |acc, c| acc * 26 + (c as u32 - 'A' as u32 + 1));
     let row = row_str.parse().unwrap_or(1);
     (col, row)
 }
@@ -1496,10 +1895,8 @@ fn to_markdown_impl(data: &[u8]) -> Result<String, String> {
 
     let mut out = String::new();
     for (idx, sheet_meta) in sheets.iter().enumerate() {
-        let sheet_json =
-            parse_sheet_native(data, idx as u32, &sheet_meta.name).map_err(|e| {
-                format!("sheet '{}' (#{}) parse failed: {}", sheet_meta.name, idx, e)
-            })?;
+        let sheet_json = parse_sheet_native(data, idx as u32, &sheet_meta.name)
+            .map_err(|e| format!("sheet '{}' (#{}) parse failed: {}", sheet_meta.name, idx, e))?;
         let sheet: serde_json::Value =
             serde_json::from_str(&sheet_json).map_err(|e| e.to_string())?;
         markdown::render_sheet(&sheet, &mut out);
@@ -1543,7 +1940,8 @@ pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<S
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
     ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
     ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
-    ws.sparkline_groups = load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
+    ws.sparkline_groups =
+        load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
     let (df_family, df_size) = parse_default_font(&mut archive);
     ws.default_font_family = df_family;
     ws.default_font_size = df_size;
@@ -1556,8 +1954,8 @@ mod tab_color_tests {
     use super::extract_tab_color_from_head;
 
     const THEME: &[&str] = &[
-        "#000000", "#FFFFFF", "#44546A", "#E7E6E6", "#4472C4", "#ED7D31",
-        "#A5A5A5", "#FFC000", "#5B9BD5", "#70AD47", "#0563C1", "#954F72",
+        "#000000", "#FFFFFF", "#44546A", "#E7E6E6", "#4472C4", "#ED7D31", "#A5A5A5", "#FFC000",
+        "#5B9BD5", "#70AD47", "#0563C1", "#954F72",
     ];
 
     fn theme() -> Vec<String> {
@@ -1567,7 +1965,10 @@ mod tab_color_tests {
     #[test]
     fn tab_color_rgb() {
         let head = r#"<?xml version="1.0"?><worksheet><sheetPr><tabColor rgb="FFFF0000"/></sheetPr><dimension ref="A1"/><sheetData>"#;
-        assert_eq!(extract_tab_color_from_head(head, &theme()).as_deref(), Some("#FF0000"));
+        assert_eq!(
+            extract_tab_color_from_head(head, &theme()).as_deref(),
+            Some("#FF0000")
+        );
     }
 
     #[test]
@@ -1577,7 +1978,11 @@ mod tab_color_tests {
         let head = r#"<worksheet><sheetPr codeName="S1"><tabColor theme="4" tint="-0.249977111117893"/></sheetPr><sheetData/></worksheet>"#;
         let got = extract_tab_color_from_head(head, &theme());
         assert!(got.is_some(), "theme tab color should resolve");
-        assert_ne!(got.as_deref(), Some("#4472C4"), "tint should darken the base");
+        assert_ne!(
+            got.as_deref(),
+            Some("#4472C4"),
+            "tint should darken the base"
+        );
     }
 
     #[test]
@@ -1589,7 +1994,8 @@ mod tab_color_tests {
     #[test]
     fn tab_color_not_searched_past_sheetdata() {
         // A stray "tabColor" token inside the body must not be misread.
-        let head = r#"<worksheet><sheetPr/><sheetData><c><is><t>tabColor rgb="00FF00"</t></is></c>"#;
+        let head =
+            r#"<worksheet><sheetPr/><sheetData><c><is><t>tabColor rgb="00FF00"</t></is></c>"#;
         assert_eq!(extract_tab_color_from_head(head, &theme()), None);
     }
 }
@@ -1618,7 +2024,10 @@ mod sheet_view_tests {
             r#"<worksheet xmlns="{NS}"><sheetViews><sheetView workbookViewId="0"/></sheetViews><sheetData/></worksheet>"#
         );
         let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
-        assert!(!ws.right_to_left, "absent @rightToLeft → right_to_left false");
+        assert!(
+            !ws.right_to_left,
+            "absent @rightToLeft → right_to_left false"
+        );
     }
 
     /// ECMA-376 §22.9.2.7 `ST_Boolean` allows `true`/`false` as well as `1`/`0`.

--- a/packages/xlsx/parser/src/markdown.rs
+++ b/packages/xlsx/parser/src/markdown.rs
@@ -111,11 +111,7 @@ pub(crate) fn render_sheet(sheet: &Value, out: &mut String) {
 
 fn write_table_row(out: &mut String, row: &[String], n_cols: usize) {
     let cells: Vec<String> = (0..n_cols)
-        .map(|i| {
-            row.get(i)
-                .map(|s| escape_cell(s))
-                .unwrap_or_default()
-        })
+        .map(|i| row.get(i).map(|s| escape_cell(s)).unwrap_or_default())
         .collect();
     let _ = writeln!(out, "| {} |", cells.join(" | "));
 }
@@ -140,7 +136,13 @@ fn cell_display(cell: &Value) -> String {
             .unwrap_or_default(),
         "bool" => value["bool"]
             .as_bool()
-            .map(|b| if b { "TRUE".to_string() } else { "FALSE".to_string() })
+            .map(|b| {
+                if b {
+                    "TRUE".to_string()
+                } else {
+                    "FALSE".to_string()
+                }
+            })
             .unwrap_or_default(),
         "error" => value["error"].as_str().unwrap_or("#ERR").to_string(),
         _ => String::new(),
@@ -156,11 +158,12 @@ fn format_number(n: f64) -> String {
     // round-trips through XML as 702.5999999999999). Trim trailing zeros so
     // 702.6 doesn't render as 702.6000000000.
     let s = format!("{n:.10}");
-    let trimmed = s
-        .trim_end_matches('0')
-        .trim_end_matches('.')
-        .to_string();
-    if trimmed.is_empty() { "0".to_string() } else { trimmed }
+    let trimmed = s.trim_end_matches('0').trim_end_matches('.').to_string();
+    if trimmed.is_empty() {
+        "0".to_string()
+    } else {
+        trimmed
+    }
 }
 
 /// Returns the set of (row, col) coordinates that are continuation cells of a

--- a/packages/xlsx/parser/src/slicer.rs
+++ b/packages/xlsx/parser/src/slicer.rs
@@ -42,15 +42,24 @@ pub(crate) fn load_all_pivot_cache_fields(
         .filter(|n| n.starts_with("xl/pivotCache/pivotCacheDefinition") && n.ends_with(".xml"))
         .collect();
     for name in names {
-        let Ok(xml) = read_zip_entry(archive, &name) else { continue; };
-        let Ok(doc) = roxmltree::Document::parse(&xml) else { continue; };
+        let Ok(xml) = read_zip_entry(archive, &name) else {
+            continue;
+        };
+        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+            continue;
+        };
         for field in doc.descendants() {
-            if field.tag_name().name() != "cacheField"
-                || field.tag_name().namespace() != Some(ns)
-            { continue; }
-            let Some(field_name) = field.attribute("name") else { continue; };
+            if field.tag_name().name() != "cacheField" || field.tag_name().namespace() != Some(ns) {
+                continue;
+            }
+            let Some(field_name) = field.attribute("name") else {
+                continue;
+            };
             let mut items: Vec<String> = Vec::new();
-            for shared in field.children().filter(|n| n.is_element() && n.tag_name().name() == "sharedItems") {
+            for shared in field
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "sharedItems")
+            {
                 for item in shared.children().filter(|n| n.is_element()) {
                     match item.tag_name().name() {
                         "s" => items.push(item.attribute("v").unwrap_or("").to_string()),
@@ -82,15 +91,28 @@ pub(crate) fn load_all_slicer_caches(
         .filter(|n| n.starts_with("xl/slicerCaches/slicerCache") && n.ends_with(".xml"))
         .collect();
     for path in names {
-        let Ok(xml) = read_zip_entry(archive, &path) else { continue; };
-        let Ok(doc) = roxmltree::Document::parse(&xml) else { continue; };
+        let Ok(xml) = read_zip_entry(archive, &path) else {
+            continue;
+        };
+        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+            continue;
+        };
         let root = doc.root_element();
         let cache_name = root.attribute("name").unwrap_or("").to_string();
         let source_name = root.attribute("sourceName").unwrap_or("").to_string();
         let mut items: Vec<(u32, bool)> = Vec::new();
-        for tabular in doc.descendants().filter(|n| n.is_element() && n.tag_name().name() == "tabular") {
-            for i_el in tabular.descendants().filter(|n| n.is_element() && n.tag_name().name() == "i") {
-                let x: u32 = i_el.attribute("x").and_then(|v| v.parse().ok()).unwrap_or(0);
+        for tabular in doc
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "tabular")
+        {
+            for i_el in tabular
+                .descendants()
+                .filter(|n| n.is_element() && n.tag_name().name() == "i")
+            {
+                let x: u32 = i_el
+                    .attribute("x")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
                 // `s` defaults to "1" (selected) when absent — ECMA-376
                 // extension schema for slicer caches.
                 let selected = i_el.attribute("s").map(|v| v != "0").unwrap_or(true);
@@ -114,8 +136,13 @@ pub(crate) struct SlicerDef {
 
 pub(crate) fn parse_slicers_xml(xml: &str) -> HashMap<String, SlicerDef> {
     let mut out: HashMap<String, SlicerDef> = HashMap::new();
-    let Ok(doc) = roxmltree::Document::parse(xml) else { return out; };
-    for slicer in doc.descendants().filter(|n| n.is_element() && n.tag_name().name() == "slicer") {
+    let Ok(doc) = roxmltree::Document::parse(xml) else {
+        return out;
+    };
+    for slicer in doc
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "slicer")
+    {
         let name = slicer.attribute("name").unwrap_or("").to_string();
         let caption = slicer.attribute("caption").unwrap_or("").to_string();
         let cache = slicer.attribute("cache").unwrap_or("").to_string();
@@ -144,9 +171,15 @@ pub(crate) fn load_sheet_slicers(
     // 1. Collect slicer-definition and drawing targets from the sheet rels.
     let mut drawing_targets: Vec<String> = Vec::new();
     let mut slicer_targets: Vec<String> = Vec::new();
-    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+    for rel in rels_doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element())
+    {
         let rel_type = rel.attribute("Type").unwrap_or("");
-        let Some(target) = rel.attribute("Target") else { continue; };
+        let Some(target) = rel.attribute("Target") else {
+            continue;
+        };
         if rel_type.ends_with("/drawing") {
             drawing_targets.push(target.to_string());
         } else if rel_type.ends_with("/slicer") {
@@ -162,12 +195,16 @@ pub(crate) fn load_sheet_slicers(
     let mut slicer_defs: HashMap<String, SlicerDef> = HashMap::new();
     for target in &slicer_targets {
         let slicer_path = resolve_zip_path(&format!("xl/{}", sheet_dir), target);
-        let Ok(xml) = read_zip_entry(archive, &slicer_path) else { continue; };
+        let Ok(xml) = read_zip_entry(archive, &slicer_path) else {
+            continue;
+        };
         for (k, v) in parse_slicers_xml(&xml) {
             slicer_defs.insert(k, v);
         }
     }
-    if slicer_defs.is_empty() { return Vec::new(); }
+    if slicer_defs.is_empty() {
+        return Vec::new();
+    }
 
     // 3. Resolve caches (and their backing pivot fields) once.
     let slicer_caches = load_all_slicer_caches(archive);
@@ -177,8 +214,15 @@ pub(crate) fn load_sheet_slicers(
     let mut out: Vec<SlicerAnchor> = Vec::new();
     for target in drawing_targets {
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else { continue; };
-        out.extend(parse_slicer_anchors(&drawing_xml, &slicer_defs, &slicer_caches, &pivot_fields));
+        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+            continue;
+        };
+        out.extend(parse_slicer_anchors(
+            &drawing_xml,
+            &slicer_defs,
+            &slicer_caches,
+            &pivot_fields,
+        ));
     }
     out
 }
@@ -200,28 +244,35 @@ pub(crate) fn parse_slicer_anchors(
     for anchor in doc.descendants() {
         if anchor.tag_name().name() != "twoCellAnchor"
             || anchor.tag_name().namespace() != Some(xdr_ns)
-        { continue; }
+        {
+            continue;
+        }
 
         // Anchor rect.
         let mut from = (0u32, 0i64, 0u32, 0i64);
-        let mut to   = (0u32, 0i64, 0u32, 0i64);
+        let mut to = (0u32, 0i64, 0u32, 0i64);
         for child in anchor.children().filter(|n| n.is_element()) {
             match child.tag_name().name() {
                 "from" | "to" => {
                     let is_from = child.tag_name().name() == "from";
-                    let mut col: u32 = 0; let mut col_off: i64 = 0;
-                    let mut row: u32 = 0; let mut row_off: i64 = 0;
+                    let mut col: u32 = 0;
+                    let mut col_off: i64 = 0;
+                    let mut row: u32 = 0;
+                    let mut row_off: i64 = 0;
                     for c in child.children() {
                         match (c.tag_name().name(), c.text()) {
-                            ("col",    Some(t)) => col     = t.trim().parse().unwrap_or(0),
+                            ("col", Some(t)) => col = t.trim().parse().unwrap_or(0),
                             ("colOff", Some(t)) => col_off = t.trim().parse().unwrap_or(0),
-                            ("row",    Some(t)) => row     = t.trim().parse().unwrap_or(0),
+                            ("row", Some(t)) => row = t.trim().parse().unwrap_or(0),
                             ("rowOff", Some(t)) => row_off = t.trim().parse().unwrap_or(0),
                             _ => {}
                         }
                     }
-                    if is_from { from = (col, col_off, row, row_off); }
-                    else       { to   = (col, col_off, row, row_off); }
+                    if is_from {
+                        from = (col, col_off, row, row_off);
+                    } else {
+                        to = (col, col_off, row, row_off);
+                    }
                 }
                 _ => {}
             }
@@ -230,8 +281,13 @@ pub(crate) fn parse_slicer_anchors(
         // Slicers live inside `<mc:AlternateContent><mc:Choice>` — descend
         // until we find a `<xdr:graphicFrame>` whose graphicData uri is the
         // 2010 slicer namespace, then harvest the graphicFrame's cNvPr name.
-        let Some(frame_name) = anchor.descendants()
-            .filter(|n| n.is_element() && n.tag_name().name() == "Choice" && n.tag_name().namespace() == Some(mc_ns))
+        let Some(frame_name) = anchor
+            .descendants()
+            .filter(|n| {
+                n.is_element()
+                    && n.tag_name().name() == "Choice"
+                    && n.tag_name().namespace() == Some(mc_ns)
+            })
             .flat_map(|choice| choice.descendants())
             .find_map(|n| {
                 if n.is_element()
@@ -241,30 +297,48 @@ pub(crate) fn parse_slicer_anchors(
                     // graphicData → ancestor graphicFrame → nvGraphicFramePr → cNvPr
                     let mut p = n.parent();
                     while let Some(pp) = p {
-                        if pp.tag_name().name() == "graphicFrame" { break; }
+                        if pp.tag_name().name() == "graphicFrame" {
+                            break;
+                        }
                         p = pp.parent();
                     }
                     let frame = p?;
-                    let cnvpr = frame.descendants()
+                    let cnvpr = frame
+                        .descendants()
                         .find(|d| d.is_element() && d.tag_name().name() == "cNvPr")?;
                     cnvpr.attribute("name").map(|s| s.to_string())
-                } else { None }
-            }) else { continue };
+                } else {
+                    None
+                }
+            })
+        else {
+            continue;
+        };
 
-        let Some(slicer_def) = slicer_defs.get(&frame_name) else { continue; };
+        let Some(slicer_def) = slicer_defs.get(&frame_name) else {
+            continue;
+        };
 
         // Resolve items via cache → pivot field; fall back to an empty list
         // if any link is broken (still renders the header and box).
-        let items: Vec<SlicerItem> = slicer_caches.get(&slicer_def.cache)
+        let items: Vec<SlicerItem> = slicer_caches
+            .get(&slicer_def.cache)
             .map(|cache| {
                 let field_items = pivot_fields.by_name.get(&cache.source_name);
-                cache.items.iter().map(|(x, selected)| {
-                    let name = field_items
-                        .and_then(|list| list.get(*x as usize))
-                        .cloned()
-                        .unwrap_or_default();
-                    SlicerItem { name, selected: *selected }
-                }).collect()
+                cache
+                    .items
+                    .iter()
+                    .map(|(x, selected)| {
+                        let name = field_items
+                            .and_then(|list| list.get(*x as usize))
+                            .cloned()
+                            .unwrap_or_default();
+                        SlicerItem {
+                            name,
+                            selected: *selected,
+                        }
+                    })
+                    .collect()
             })
             .unwrap_or_default();
 
@@ -275,8 +349,14 @@ pub(crate) fn parse_slicer_anchors(
         };
 
         out.push(SlicerAnchor {
-            from_col: from.0, from_col_off: from.1, from_row: from.2, from_row_off: from.3,
-            to_col:   to.0,   to_col_off:   to.1,   to_row:   to.2,   to_row_off:   to.3,
+            from_col: from.0,
+            from_col_off: from.1,
+            from_row: from.2,
+            from_row_off: from.3,
+            to_col: to.0,
+            to_col_off: to.1,
+            to_row: to.2,
+            to_row_off: to.3,
             caption,
             items,
         });
@@ -285,5 +365,3 @@ pub(crate) fn parse_slicer_anchors(
 }
 
 // ─── Chart loading ──────────────────────────────────────────────────────────
-
-

--- a/packages/xlsx/parser/src/styles.rs
+++ b/packages/xlsx/parser/src/styles.rs
@@ -2,28 +2,43 @@ use crate::types::*;
 use crate::{parse_color, read_zip_entry};
 use std::io::Cursor;
 
-
 /// Resolve the workbook's Normal-style font (family name + point size) by
 /// following `<cellStyleXfs>[0].fontId` → `<fonts>[fontId]`. Returns `(None,
 /// None)` if `xl/styles.xml` is missing or malformed. The renderer uses this
 /// to compute the Max Digit Width for column-width pixel conversion
 /// (ECMA-376 §18.3.1.13).
-pub(crate) fn parse_default_font(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> (Option<String>, Option<f64>) {
-    let Ok(xml) = read_zip_entry(archive, "xl/styles.xml") else { return (None, None); };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else { return (None, None); };
+pub(crate) fn parse_default_font(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+) -> (Option<String>, Option<f64>) {
+    let Ok(xml) = read_zip_entry(archive, "xl/styles.xml") else {
+        return (None, None);
+    };
+    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        return (None, None);
+    };
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     let mut font_id: usize = 0;
     for n in doc.descendants() {
         if n.tag_name().name() == "cellStyleXfs" && n.tag_name().namespace() == Some(ns) {
-            if let Some(xf) = n.children().find(|c| c.is_element() && c.tag_name().name() == "xf") {
-                font_id = xf.attribute("fontId").and_then(|s| s.parse().ok()).unwrap_or(0);
+            if let Some(xf) = n
+                .children()
+                .find(|c| c.is_element() && c.tag_name().name() == "xf")
+            {
+                font_id = xf
+                    .attribute("fontId")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
             }
             break;
         }
     }
     for fonts_node in doc.descendants() {
-        if fonts_node.tag_name().name() != "fonts" || fonts_node.tag_name().namespace() != Some(ns) { continue; }
-        if let Some(font_node) = fonts_node.children()
+        if fonts_node.tag_name().name() != "fonts" || fonts_node.tag_name().namespace() != Some(ns)
+        {
+            continue;
+        }
+        if let Some(font_node) = fonts_node
+            .children()
             .filter(|c| c.is_element() && c.tag_name().name() == "font")
             .nth(font_id)
         {
@@ -32,7 +47,7 @@ pub(crate) fn parse_default_font(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -
             for child in font_node.children() {
                 match child.tag_name().name() {
                     "name" => name = child.attribute("val").map(|s| s.to_string()),
-                    "sz"   => sz = child.attribute("val").and_then(|s| s.parse().ok()),
+                    "sz" => sz = child.attribute("val").and_then(|s| s.parse().ok()),
                     _ => {}
                 }
             }
@@ -43,7 +58,10 @@ pub(crate) fn parse_default_font(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -
     (None, None)
 }
 
-pub(crate) fn parse_styles(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, theme_colors: &[String]) -> Result<Styles, String> {
+pub(crate) fn parse_styles(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    theme_colors: &[String],
+) -> Result<Styles, String> {
     let xml = read_zip_entry(archive, "xl/styles.xml")?;
     let doc = roxmltree::Document::parse(&xml).map_err(|e| e.to_string())?;
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
@@ -55,7 +73,14 @@ pub(crate) fn parse_styles(archive: &mut zip::ZipArchive<Cursor<&[u8]>>, theme_c
     let cell_xfs = parse_cell_xfs(&doc, ns);
     let dxfs = parse_dxfs(&doc, ns, theme_colors);
 
-    Ok(Styles { fonts, fills, borders, cell_xfs, num_fmts, dxfs })
+    Ok(Styles {
+        fonts,
+        fills,
+        borders,
+        cell_xfs,
+        num_fmts,
+        dxfs,
+    })
 }
 
 pub(crate) fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> Vec<Dxf> {
@@ -65,12 +90,17 @@ pub(crate) fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[St
             continue;
         }
         for dxf_node in dxfs_node.children() {
-            if dxf_node.tag_name().name() != "dxf" { continue; }
+            if dxf_node.tag_name().name() != "dxf" {
+                continue;
+            }
             let mut d = Dxf::default();
             for child in dxf_node.children() {
                 match child.tag_name().name() {
                     "font" => {
-                        let mut f = Font { size: 11.0, ..Default::default() };
+                        let mut f = Font {
+                            size: 11.0,
+                            ..Default::default()
+                        };
                         for fc in child.children() {
                             match fc.tag_name().name() {
                                 "b" => f.bold = parse_st_on_off(&fc),
@@ -93,7 +123,9 @@ pub(crate) fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[St
                                     }
                                 }
                                 "sz" => {
-                                    if let Some(v) = fc.attribute("val").and_then(|s| s.parse().ok()) {
+                                    if let Some(v) =
+                                        fc.attribute("val").and_then(|s| s.parse().ok())
+                                    {
                                         f.size = v;
                                     }
                                 }
@@ -112,11 +144,16 @@ pub(crate) fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[St
                         let mut f = Fill::default();
                         for pf in child.children() {
                             if pf.tag_name().name() == "patternFill" {
-                                f.pattern_type = pf.attribute("patternType").unwrap_or("solid").to_string();
+                                f.pattern_type =
+                                    pf.attribute("patternType").unwrap_or("solid").to_string();
                                 for color_node in pf.children() {
                                     match color_node.tag_name().name() {
-                                        "fgColor" => f.fg_color = parse_color(&color_node, theme_colors),
-                                        "bgColor" => f.bg_color = parse_color(&color_node, theme_colors),
+                                        "fgColor" => {
+                                            f.fg_color = parse_color(&color_node, theme_colors)
+                                        }
+                                        "bgColor" => {
+                                            f.bg_color = parse_color(&color_node, theme_colors)
+                                        }
                                         _ => {}
                                     }
                                 }
@@ -132,8 +169,12 @@ pub(crate) fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[St
                         let mut b = Border::default();
                         for edge_node in child.children() {
                             let style = edge_node.attribute("style").unwrap_or("").to_string();
-                            if style.is_empty() { continue; }
-                            let color = edge_node.children().find(|c| c.is_element())
+                            if style.is_empty() {
+                                continue;
+                            }
+                            let color = edge_node
+                                .children()
+                                .find(|c| c.is_element())
                                 .and_then(|c| parse_color(&c, theme_colors));
                             let edge = Some(BorderEdge { style, color });
                             match edge_node.tag_name().name() {
@@ -142,18 +183,22 @@ pub(crate) fn parse_dxfs(doc: &roxmltree::Document, ns: &str, theme_colors: &[St
                                 "top" => b.top = edge,
                                 "bottom" => b.bottom = edge,
                                 "horizontal" => b.horizontal = edge,
-                                "vertical"   => b.vertical   = edge,
+                                "vertical" => b.vertical = edge,
                                 _ => {}
                             }
                         }
                         d.border = Some(b);
                     }
                     "numFmt" => {
-                        let num_fmt_id = child.attribute("numFmtId")
-                            .and_then(|v| v.parse().ok()).unwrap_or(0);
-                        let format_code = child.attribute("formatCode")
-                            .unwrap_or("").to_string();
-                        d.num_fmt = Some(NumFmt { num_fmt_id, format_code });
+                        let num_fmt_id = child
+                            .attribute("numFmtId")
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(0);
+                        let format_code = child.attribute("formatCode").unwrap_or("").to_string();
+                        d.num_fmt = Some(NumFmt {
+                            num_fmt_id,
+                            format_code,
+                        });
                     }
                     _ => {}
                 }
@@ -170,10 +215,18 @@ pub(crate) fn parse_num_fmts(doc: &roxmltree::Document, ns: &str) -> Vec<NumFmt>
     for node in doc.descendants() {
         if node.tag_name().name() == "numFmts" && node.tag_name().namespace() == Some(ns) {
             for child in node.children() {
-                if child.tag_name().name() != "numFmt" { continue; }
-                let num_fmt_id = child.attribute("numFmtId").and_then(|v| v.parse().ok()).unwrap_or(0);
+                if child.tag_name().name() != "numFmt" {
+                    continue;
+                }
+                let num_fmt_id = child
+                    .attribute("numFmtId")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
                 let format_code = child.attribute("formatCode").unwrap_or("").to_string();
-                fmts.push(NumFmt { num_fmt_id, format_code });
+                fmts.push(NumFmt {
+                    num_fmt_id,
+                    format_code,
+                });
             }
             break;
         }
@@ -193,13 +246,23 @@ pub(crate) fn parse_st_on_off(node: &roxmltree::Node) -> bool {
     }
 }
 
-pub(crate) fn parse_fonts(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> Vec<Font> {
+pub(crate) fn parse_fonts(
+    doc: &roxmltree::Document,
+    ns: &str,
+    theme_colors: &[String],
+) -> Vec<Font> {
     let mut fonts = Vec::new();
     for fonts_node in doc.descendants() {
-        if fonts_node.tag_name().name() == "fonts" && fonts_node.tag_name().namespace() == Some(ns) {
+        if fonts_node.tag_name().name() == "fonts" && fonts_node.tag_name().namespace() == Some(ns)
+        {
             for font_node in fonts_node.children() {
-                if font_node.tag_name().name() != "font" { continue; }
-                let mut f = Font { size: 11.0, ..Default::default() };
+                if font_node.tag_name().name() != "font" {
+                    continue;
+                }
+                let mut f = Font {
+                    size: 11.0,
+                    ..Default::default()
+                };
                 for child in font_node.children() {
                     match child.tag_name().name() {
                         "b" => f.bold = parse_st_on_off(&child),
@@ -243,21 +306,33 @@ pub(crate) fn parse_fonts(doc: &roxmltree::Document, ns: &str, theme_colors: &[S
     fonts
 }
 
-pub(crate) fn parse_fills(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> Vec<Fill> {
+pub(crate) fn parse_fills(
+    doc: &roxmltree::Document,
+    ns: &str,
+    theme_colors: &[String],
+) -> Vec<Fill> {
     let mut fills = Vec::new();
     for fills_node in doc.descendants() {
-        if fills_node.tag_name().name() == "fills" && fills_node.tag_name().namespace() == Some(ns) {
+        if fills_node.tag_name().name() == "fills" && fills_node.tag_name().namespace() == Some(ns)
+        {
             for fill_node in fills_node.children() {
-                if fill_node.tag_name().name() != "fill" { continue; }
+                if fill_node.tag_name().name() != "fill" {
+                    continue;
+                }
                 let mut f = Fill::default();
                 for pf in fill_node.children() {
                     match pf.tag_name().name() {
                         "patternFill" => {
-                            f.pattern_type = pf.attribute("patternType").unwrap_or("none").to_string();
+                            f.pattern_type =
+                                pf.attribute("patternType").unwrap_or("none").to_string();
                             for color_node in pf.children() {
                                 match color_node.tag_name().name() {
-                                    "fgColor" => f.fg_color = parse_color(&color_node, theme_colors),
-                                    "bgColor" => f.bg_color = parse_color(&color_node, theme_colors),
+                                    "fgColor" => {
+                                        f.fg_color = parse_color(&color_node, theme_colors)
+                                    }
+                                    "bgColor" => {
+                                        f.bg_color = parse_color(&color_node, theme_colors)
+                                    }
                                     _ => {}
                                 }
                             }
@@ -267,26 +342,53 @@ pub(crate) fn parse_fills(doc: &roxmltree::Document, ns: &str, theme_colors: &[S
                             // `degree`, path uses top/bottom/left/right as a relative
                             // bounding box; children <stop position="n"><color/></stop>.
                             let gtype = pf.attribute("type").unwrap_or("linear").to_string();
-                            let degree = pf.attribute("degree").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
-                            let left   = pf.attribute("left").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
-                            let right  = pf.attribute("right").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
-                            let top    = pf.attribute("top").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
-                            let bottom = pf.attribute("bottom").and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
-                            let mut stops: Vec<GradientStopSpec> = pf.children()
+                            let degree = pf
+                                .attribute("degree")
+                                .and_then(|s| s.parse::<f64>().ok())
+                                .unwrap_or(0.0);
+                            let left = pf
+                                .attribute("left")
+                                .and_then(|s| s.parse::<f64>().ok())
+                                .unwrap_or(0.0);
+                            let right = pf
+                                .attribute("right")
+                                .and_then(|s| s.parse::<f64>().ok())
+                                .unwrap_or(0.0);
+                            let top = pf
+                                .attribute("top")
+                                .and_then(|s| s.parse::<f64>().ok())
+                                .unwrap_or(0.0);
+                            let bottom = pf
+                                .attribute("bottom")
+                                .and_then(|s| s.parse::<f64>().ok())
+                                .unwrap_or(0.0);
+                            let mut stops: Vec<GradientStopSpec> = pf
+                                .children()
                                 .filter(|n| n.is_element() && n.tag_name().name() == "stop")
                                 .filter_map(|stop| {
-                                    let position = stop.attribute("position").and_then(|s| s.parse::<f64>().ok())?;
-                                    let color_node = stop.children().find(|c| c.is_element() && c.tag_name().name() == "color")?;
+                                    let position = stop
+                                        .attribute("position")
+                                        .and_then(|s| s.parse::<f64>().ok())?;
+                                    let color_node = stop.children().find(|c| {
+                                        c.is_element() && c.tag_name().name() == "color"
+                                    })?;
                                     let color = parse_color(&color_node, theme_colors)?;
                                     Some(GradientStopSpec { position, color })
                                 })
                                 .collect();
-                            stops.sort_by(|a, b| a.position.partial_cmp(&b.position).unwrap_or(std::cmp::Ordering::Equal));
+                            stops.sort_by(|a, b| {
+                                a.position
+                                    .partial_cmp(&b.position)
+                                    .unwrap_or(std::cmp::Ordering::Equal)
+                            });
                             if !stops.is_empty() {
                                 f.gradient = Some(GradientFillSpec {
                                     gradient_type: gtype,
                                     degree,
-                                    left, right, top, bottom,
+                                    left,
+                                    right,
+                                    top,
+                                    bottom,
                                     stops,
                                 });
                             }
@@ -302,30 +404,55 @@ pub(crate) fn parse_fills(doc: &roxmltree::Document, ns: &str, theme_colors: &[S
     fills
 }
 
-pub(crate) fn parse_borders(doc: &roxmltree::Document, ns: &str, theme_colors: &[String]) -> Vec<Border> {
+pub(crate) fn parse_borders(
+    doc: &roxmltree::Document,
+    ns: &str,
+    theme_colors: &[String],
+) -> Vec<Border> {
     let mut borders = Vec::new();
     for borders_node in doc.descendants() {
-        if borders_node.tag_name().name() == "borders" && borders_node.tag_name().namespace() == Some(ns) {
+        if borders_node.tag_name().name() == "borders"
+            && borders_node.tag_name().namespace() == Some(ns)
+        {
             for border_node in borders_node.children() {
-                if border_node.tag_name().name() != "border" { continue; }
-                let has_diag_up = border_node.attribute("diagonalUp").map(|v| v == "1" || v == "true").unwrap_or(false);
-                let has_diag_down = border_node.attribute("diagonalDown").map(|v| v == "1" || v == "true").unwrap_or(false);
+                if border_node.tag_name().name() != "border" {
+                    continue;
+                }
+                let has_diag_up = border_node
+                    .attribute("diagonalUp")
+                    .map(|v| v == "1" || v == "true")
+                    .unwrap_or(false);
+                let has_diag_down = border_node
+                    .attribute("diagonalDown")
+                    .map(|v| v == "1" || v == "true")
+                    .unwrap_or(false);
                 let mut b = Border::default();
                 let mut diag_edge: Option<BorderEdge> = None;
                 for edge_node in border_node.children() {
                     let style = edge_node.attribute("style").unwrap_or("").to_string();
-                    let color = edge_node.children().find(|c| c.is_element()).and_then(|c| parse_color(&c, theme_colors));
+                    let color = edge_node
+                        .children()
+                        .find(|c| c.is_element())
+                        .and_then(|c| parse_color(&c, theme_colors));
                     match edge_node.tag_name().name() {
                         "left" if !style.is_empty() => b.left = Some(BorderEdge { style, color }),
                         "right" if !style.is_empty() => b.right = Some(BorderEdge { style, color }),
                         "top" if !style.is_empty() => b.top = Some(BorderEdge { style, color }),
-                        "bottom" if !style.is_empty() => b.bottom = Some(BorderEdge { style, color }),
-                        "diagonal" if !style.is_empty() => diag_edge = Some(BorderEdge { style, color }),
+                        "bottom" if !style.is_empty() => {
+                            b.bottom = Some(BorderEdge { style, color })
+                        }
+                        "diagonal" if !style.is_empty() => {
+                            diag_edge = Some(BorderEdge { style, color })
+                        }
                         _ => {}
                     }
                 }
-                if has_diag_up { b.diagonal_up = diag_edge.clone(); }
-                if has_diag_down { b.diagonal_down = diag_edge; }
+                if has_diag_up {
+                    b.diagonal_up = diag_edge.clone();
+                }
+                if has_diag_down {
+                    b.diagonal_down = diag_edge;
+                }
                 borders.push(b);
             }
             break;
@@ -339,11 +466,25 @@ pub(crate) fn parse_cell_xfs(doc: &roxmltree::Document, ns: &str) -> Vec<CellXf>
     for xfs_node in doc.descendants() {
         if xfs_node.tag_name().name() == "cellXfs" && xfs_node.tag_name().namespace() == Some(ns) {
             for xf_node in xfs_node.children() {
-                if xf_node.tag_name().name() != "xf" { continue; }
-                let font_id = xf_node.attribute("fontId").and_then(|v| v.parse().ok()).unwrap_or(0);
-                let fill_id = xf_node.attribute("fillId").and_then(|v| v.parse().ok()).unwrap_or(0);
-                let border_id = xf_node.attribute("borderId").and_then(|v| v.parse().ok()).unwrap_or(0);
-                let num_fmt_id = xf_node.attribute("numFmtId").and_then(|v| v.parse().ok()).unwrap_or(0);
+                if xf_node.tag_name().name() != "xf" {
+                    continue;
+                }
+                let font_id = xf_node
+                    .attribute("fontId")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let fill_id = xf_node
+                    .attribute("fillId")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let border_id = xf_node
+                    .attribute("borderId")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let num_fmt_id = xf_node
+                    .attribute("numFmtId")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
                 let mut align_h = None;
                 let mut align_v = None;
                 let mut wrap_text = false;
@@ -355,18 +496,44 @@ pub(crate) fn parse_cell_xfs(doc: &roxmltree::Document, ns: &str) -> Vec<CellXf>
                     if child.tag_name().name() == "alignment" {
                         align_h = child.attribute("horizontal").map(|s| s.to_string());
                         align_v = child.attribute("vertical").map(|s| s.to_string());
-                        wrap_text = child.attribute("wrapText").map(|v| v == "1" || v == "true").unwrap_or(false);
-                        indent = child.attribute("indent").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
-                        text_rotation = child.attribute("textRotation").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
-                        shrink_to_fit = child.attribute("shrinkToFit").map(|v| v == "1" || v == "true").unwrap_or(false);
-                        reading_order = child.attribute("readingOrder").and_then(|s| s.parse::<u32>().ok()).filter(|&v| v > 0);
+                        wrap_text = child
+                            .attribute("wrapText")
+                            .map(|v| v == "1" || v == "true")
+                            .unwrap_or(false);
+                        indent = child
+                            .attribute("indent")
+                            .and_then(|s| s.parse::<u32>().ok())
+                            .filter(|&v| v > 0);
+                        text_rotation = child
+                            .attribute("textRotation")
+                            .and_then(|s| s.parse::<u32>().ok())
+                            .filter(|&v| v > 0);
+                        shrink_to_fit = child
+                            .attribute("shrinkToFit")
+                            .map(|v| v == "1" || v == "true")
+                            .unwrap_or(false);
+                        reading_order = child
+                            .attribute("readingOrder")
+                            .and_then(|s| s.parse::<u32>().ok())
+                            .filter(|&v| v > 0);
                     }
                 }
-                xfs.push(CellXf { font_id, fill_id, border_id, num_fmt_id, align_h, align_v, wrap_text, indent, text_rotation, shrink_to_fit, reading_order });
+                xfs.push(CellXf {
+                    font_id,
+                    fill_id,
+                    border_id,
+                    num_fmt_id,
+                    align_h,
+                    align_v,
+                    wrap_text,
+                    indent,
+                    text_rotation,
+                    shrink_to_fit,
+                    reading_order,
+                });
             }
             break;
         }
     }
     xfs
 }
-

--- a/packages/xlsx/parser/src/table.rs
+++ b/packages/xlsx/parser/src/table.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{read_zip_entry, resolve_zip_path, parse_cell_ref};
+use crate::{parse_cell_ref, read_zip_entry, resolve_zip_path};
 use std::io::Cursor;
 
 /// Parse `xl/tables/tableN.xml` files referenced from the sheet rels and
@@ -29,23 +29,39 @@ pub(crate) struct TableStyleElements {
 
 /// Parse `<tableStyles><tableStyle name="…"><tableStyleElement type="…" dxfId="…"/>`
 /// into a lookup keyed by table-style name.
-pub(crate) fn parse_table_styles_map(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> std::collections::HashMap<String, TableStyleElements> {
+pub(crate) fn parse_table_styles_map(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+) -> std::collections::HashMap<String, TableStyleElements> {
     use std::collections::HashMap;
     let mut map: HashMap<String, TableStyleElements> = HashMap::new();
-    let Ok(xml) = read_zip_entry(archive, "xl/styles.xml") else { return map; };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else { return map; };
+    let Ok(xml) = read_zip_entry(archive, "xl/styles.xml") else {
+        return map;
+    };
+    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        return map;
+    };
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     for n in doc.descendants() {
-        if n.tag_name().name() != "tableStyles" || n.tag_name().namespace() != Some(ns) { continue; }
-        for ts in n.children().filter(|c| c.is_element() && c.tag_name().name() == "tableStyle") {
-            let Some(name) = ts.attribute("name") else { continue; };
+        if n.tag_name().name() != "tableStyles" || n.tag_name().namespace() != Some(ns) {
+            continue;
+        }
+        for ts in n
+            .children()
+            .filter(|c| c.is_element() && c.tag_name().name() == "tableStyle")
+        {
+            let Some(name) = ts.attribute("name") else {
+                continue;
+            };
             let mut elems = TableStyleElements::default();
-            for el in ts.children().filter(|c| c.is_element() && c.tag_name().name() == "tableStyleElement") {
+            for el in ts
+                .children()
+                .filter(|c| c.is_element() && c.tag_name().name() == "tableStyleElement")
+            {
                 let t = el.attribute("type").unwrap_or("");
                 let dxf: Option<u32> = el.attribute("dxfId").and_then(|s| s.parse().ok());
                 match t {
                     "wholeTable" => elems.whole_table = dxf,
-                    "headerRow"  => elems.header_row = dxf,
+                    "headerRow" => elems.header_row = dxf,
                     _ => {}
                 }
             }
@@ -57,13 +73,23 @@ pub(crate) fn parse_table_styles_map(archive: &mut zip::ZipArchive<Cursor<&[u8]>
 
 pub(crate) fn resolve_table_style_accent(style_name: &str, theme_colors: &[String]) -> String {
     let fallback = "#808080".to_string();
-    let Some(rest) = style_name.strip_prefix("TableStyle") else { return fallback; };
+    let Some(rest) = style_name.strip_prefix("TableStyle") else {
+        return fallback;
+    };
     let digits_start = rest.find(|c: char| c.is_ascii_digit());
-    let Some(start) = digits_start else { return fallback; };
-    let Ok(n) = rest[start..].parse::<u32>() else { return fallback; };
-    if n == 0 { return fallback; }
+    let Some(start) = digits_start else {
+        return fallback;
+    };
+    let Ok(n) = rest[start..].parse::<u32>() else {
+        return fallback;
+    };
+    if n == 0 {
+        return fallback;
+    }
     let slot = ((n - 1) % 7) as usize;
-    if slot == 0 { return fallback; }
+    if slot == 0 {
+        return fallback;
+    }
     theme_colors.get(3 + slot).cloned().unwrap_or(fallback)
 }
 
@@ -73,13 +99,23 @@ pub(crate) fn load_sheet_tables(
     theme_colors: &[String],
 ) -> Vec<TableInfo> {
     let custom_styles = parse_table_styles_map(archive);
-    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else { return Vec::new(); };
+    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
+        return Vec::new();
+    };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else { return Vec::new(); };
-    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else { return Vec::new(); };
+    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+        return Vec::new();
+    };
+    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else {
+        return Vec::new();
+    };
 
     let mut table_targets: Vec<String> = Vec::new();
-    for rel in rels_doc.root_element().children().filter(|n| n.is_element()) {
+    for rel in rels_doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element())
+    {
         if rel.attribute("Type").unwrap_or("").ends_with("/table") {
             if let Some(t) = rel.attribute("Target") {
                 table_targets.push(t.to_string());
@@ -90,26 +126,46 @@ pub(crate) fn load_sheet_tables(
     let mut tables: Vec<TableInfo> = Vec::new();
     for target in table_targets {
         let table_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(xml) = read_zip_entry(archive, &table_path) else { continue; };
-        let Ok(doc) = roxmltree::Document::parse(&xml) else { continue; };
+        let Ok(xml) = read_zip_entry(archive, &table_path) else {
+            continue;
+        };
+        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+            continue;
+        };
         let root = doc.root_element();
-        let Some(ref_attr) = root.attribute("ref") else { continue };
+        let Some(ref_attr) = root.attribute("ref") else {
+            continue;
+        };
         let parts: Vec<&str> = ref_attr.split(':').collect();
         let range = if parts.len() == 2 {
             let (left, top) = parse_cell_ref(parts[0]);
             let (right, bottom) = parse_cell_ref(parts[1]);
-            CellRange { top, left, bottom, right }
+            CellRange {
+                top,
+                left,
+                bottom,
+                right,
+            }
         } else {
             let (col, row) = parse_cell_ref(parts[0]);
-            CellRange { top: row, left: col, bottom: row, right: col }
+            CellRange {
+                top: row,
+                left: col,
+                bottom: row,
+                right: col,
+            }
         };
-        let header_row_count: u32 = root.attribute("headerRowCount")
+        let header_row_count: u32 = root
+            .attribute("headerRowCount")
             .and_then(|s| s.parse().ok())
             .unwrap_or(1);
-        let totals_row_count: u32 = root.attribute("totalsRowCount")
+        let totals_row_count: u32 = root
+            .attribute("totalsRowCount")
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
-        let style_info = root.children().find(|n| n.tag_name().name() == "tableStyleInfo");
+        let style_info = root
+            .children()
+            .find(|n| n.tag_name().name() == "tableStyleInfo");
         // ECMA-376 §18.5.1.4: when `name` is absent the table has "None" style —
         // no visual table formatting. Default to "" rather than a named style so
         // the renderer can skip table-style overlay for these cells.
@@ -117,16 +173,21 @@ pub(crate) fn load_sheet_tables(
             .and_then(|n| n.attribute("name"))
             .unwrap_or("")
             .to_string();
-        let bool_attr = |n: &roxmltree::Node, key: &str| n.attribute(key).map(|v| v == "1" || v == "true").unwrap_or(false);
-        let (show_row_stripes, show_column_stripes, show_first_column, show_last_column) = match style_info {
-            Some(n) => (
-                bool_attr(&n, "showRowStripes"),
-                bool_attr(&n, "showColumnStripes"),
-                bool_attr(&n, "showFirstColumn"),
-                bool_attr(&n, "showLastColumn"),
-            ),
-            None => (false, false, false, false),
+        let bool_attr = |n: &roxmltree::Node, key: &str| {
+            n.attribute(key)
+                .map(|v| v == "1" || v == "true")
+                .unwrap_or(false)
         };
+        let (show_row_stripes, show_column_stripes, show_first_column, show_last_column) =
+            match style_info {
+                Some(n) => (
+                    bool_attr(&n, "showRowStripes"),
+                    bool_attr(&n, "showColumnStripes"),
+                    bool_attr(&n, "showFirstColumn"),
+                    bool_attr(&n, "showLastColumn"),
+                ),
+                None => (false, false, false, false),
+            };
         let accent_color = resolve_table_style_accent(&style_name, theme_colors);
         let (whole_table_dxf, header_row_dxf) = match custom_styles.get(&style_name) {
             Some(e) => (e.whole_table, e.header_row),
@@ -140,7 +201,7 @@ pub(crate) fn load_sheet_tables(
             .descendants()
             .filter(|n| n.is_element() && n.tag_name().name() == "tableColumn")
             .map(|tc| TableColumnInfo {
-                data_dxf_id:       tc.attribute("dataDxfId").and_then(|s| s.parse().ok()),
+                data_dxf_id: tc.attribute("dataDxfId").and_then(|s| s.parse().ok()),
                 header_row_dxf_id: tc.attribute("headerRowDxfId").and_then(|s| s.parse().ok()),
                 totals_row_dxf_id: tc.attribute("totalsRowDxfId").and_then(|s| s.parse().ok()),
             })

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -890,14 +890,37 @@ pub struct PathInfo {
 #[derive(Debug, Serialize)]
 #[serde(tag = "op", rename_all = "camelCase")]
 pub enum PathCmd {
-    MoveTo { x: f64, y: f64 },
-    LineTo { x: f64, y: f64 },
-    CubicBezTo { x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64 },
-    QuadBezTo { x1: f64, y1: f64, x2: f64, y2: f64 },
+    MoveTo {
+        x: f64,
+        y: f64,
+    },
+    LineTo {
+        x: f64,
+        y: f64,
+    },
+    CubicBezTo {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        x3: f64,
+        y3: f64,
+    },
+    QuadBezTo {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+    },
     /// ECMA-376 §20.1.9.3 `a:arcTo`. `stAng`/`swAng` are in 60000ths of a
     /// degree. The start point is the current pen position; the ellipse
     /// center is derived so the pen lies on the ellipse at `stAng`.
-    ArcTo { wr: f64, hr: f64, st_ang: f64, sw_ang: f64 },
+    ArcTo {
+        wr: f64,
+        hr: f64,
+        st_ang: f64,
+        sw_ang: f64,
+    },
     Close,
 }
 
@@ -983,17 +1006,43 @@ pub struct ConditionalFormat {
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum CfRule {
     #[serde(rename_all = "camelCase")]
-    CellIs { operator: String, formulas: Vec<String>, dxf_id: Option<u32>, priority: i32 },
+    CellIs {
+        operator: String,
+        formulas: Vec<String>,
+        dxf_id: Option<u32>,
+        priority: i32,
+    },
     #[serde(rename_all = "camelCase")]
-    Expression { formula: String, dxf_id: Option<u32>, priority: i32, stop_if_true: bool },
+    Expression {
+        formula: String,
+        dxf_id: Option<u32>,
+        priority: i32,
+        stop_if_true: bool,
+    },
     #[serde(rename_all = "camelCase")]
     ColorScale { stops: Vec<CfStop>, priority: i32 },
     #[serde(rename_all = "camelCase")]
-    DataBar { color: String, min: CfValue, max: CfValue, priority: i32, gradient: bool },
+    DataBar {
+        color: String,
+        min: CfValue,
+        max: CfValue,
+        priority: i32,
+        gradient: bool,
+    },
     #[serde(rename_all = "camelCase")]
-    Top10 { top: bool, percent: bool, rank: u32, dxf_id: Option<u32>, priority: i32 },
+    Top10 {
+        top: bool,
+        percent: bool,
+        rank: u32,
+        dxf_id: Option<u32>,
+        priority: i32,
+    },
     #[serde(rename_all = "camelCase")]
-    AboveAverage { above_average: bool, dxf_id: Option<u32>, priority: i32 },
+    AboveAverage {
+        above_average: bool,
+        dxf_id: Option<u32>,
+        priority: i32,
+    },
     #[serde(rename_all = "camelCase")]
     IconSet {
         icon_set: String,
@@ -1071,9 +1120,15 @@ pub enum CellValue {
         #[serde(skip_serializing_if = "Option::is_none")]
         runs: Option<Vec<Run>>,
     },
-    Number { number: f64 },
-    Bool { bool: bool },
-    Error { error: String },
+    Number {
+        number: f64,
+    },
+    Bool {
+        bool: bool,
+    },
+    Error {
+        error: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Default)]


### PR DESCRIPTION
## Summary

v1.0 release prep, Phase 2: stand up a Rust CI quality gate for the parser workspace and bring the workspace to a green `cargo fmt` / `clippy -D warnings` / `test` state.

### 1. `cargo fmt`
- `style: apply rustfmt across workspace` — pure formatting, no behavioral change.

### 2. Sample-dependent tests skip cleanly
- The pptx `chartEx` / slide-8 tests read `sample-2.pptx`, a gitignored, redistribution-prohibited local fixture. They previously `unwrap()`-ed the read and panicked on a clean checkout / in CI.
- Now point at the real path (`../public/private/sample-2.pptx`) via a shared `LOCAL_SAMPLE_2` const and `eprintln!("skipping <test>: local sample not found")` + early-return when absent. With the fixture present locally they run their full assertions as before.
- docx/xlsx/ooxml-common parsers have no sample-file reads in tests (verified by grep).

### 3. Clippy warnings resolved (workspace now `-D warnings` clean)
- **Deletions (genuinely dead):** 7 unused docx `xml_util` items (`A_NS`/`WP_NS`/`PIC_NS`, `child`, `attr`, `emu_to_pt`, `find_root_element`) + unused `Document` import; the never-read `ParaFmt::based_on` field; the unused local `apply_color_transforms` wrapper in pptx (call sites use `ooxml_common::color::apply_color_transforms` directly).
- **Mechanical fixes:** `bool_comparison`, `manual_clamp`, `manual_memcpy`, `needless_range_loop` ×2, `empty_line_after_doc_comments` ×6, `field_reassign_with_default` ×2, `assert_eq!(_, true)` → `assert!`, non-snake-case `dLbls` → `d_lbls`, `Iterator::last`/`next_back` → `rfind`/`next_back`, redundant closures and doc-quote `>` markers (via `cargo clippy --fix`).
- **Type aliases for `type_complexity`:** `HyperlinkRids` (xlsx), `AlignmentAxis` (mcp-server), `TcStyle` (pptx).
- **`#[allow]` with explanatory comments (behavior-preserving, refactor not worthwhile):**
  - `too_many_arguments` ×10 — parser functions threading the ECMA-376 master/layout inheritance context (xlsx `collect_shapes`; docx `parse_para_content`/`handle_run_in_para`/`parse_run_inner`/`parse_wsp_shape`; pptx `parse_text_body`/`parse_paragraph`/`parse_slide`/`parse_sp_tree_node`/`parse_layout_placeholders`).
  - `large_enum_variant` ×3 — short-lived docx `ParaPiece`; serde-facing pptx `SlideElement`/`TextRun` output enums (boxing would only cosmetically change JSON serialization while complicating 30+/15 sites).
- Also dropped a redundant `[profile.release]` from `xlsx/parser/Cargo.toml` (ignored for non-root members; clears a cargo warning).
- No behavioral changes anywhere.

### 4. CI Rust gate
New `rust` job in `.github/workflows/ci.yml`:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- stable toolchain with rustfmt + clippy components (no wasm target needed for native tests), `Swatinem/rust-cache@v2` for cargo caching.

### Verification (run locally in a sample-free worktree)
- `cargo fmt --all --check` → exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo test --workspace` → exit 0 (sample-dependent pptx tests print their skip log and pass)
- `pnpm install && pnpm typecheck` (with WASM artifacts copied in) → all packages green; Rust changes do not affect TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)