### PR TITLE
feat: v1.0 Phase 1 — API freeze (callback parity, destroy() rename, exhaustive type exports)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./types": "./src/types/common.ts",
+    "./testing": "./src/testing/export-completeness.ts",
     "./mathjax-stix2": "./assets/mathjax-stix2.js"
   },
   "scripts": {

--- a/packages/core/src/testing/export-completeness.ts
+++ b/packages/core/src/testing/export-completeness.ts
@@ -1,0 +1,296 @@
+/**
+ * Export-completeness checker (v1.0 API freeze tooling).
+ *
+ * Uses the TypeScript Compiler API to find public types that are *reachable*
+ * from a package's `index.ts` barrel but are NOT themselves re-exported. The
+ * classic failure this guards against: a union like
+ *
+ *   export type SlideElement = ShapeElement | TableElement | ChartElement;
+ *
+ * is exported, but `TableElement` / `ChartElement` are not — so a consumer can
+ * receive a `SlideElement`, narrow on `el.type === 'table'`, and have no name
+ * for the resulting object.
+ *
+ * The traversal is driven by the *type checker* (not the raw AST), so it
+ * follows only the public type surface:
+ *   - union / intersection constituents,
+ *   - type arguments (e.g. `Array<T>`, `Map<K, V>`, `T | null`),
+ *   - the **public** properties of object types (private / protected class
+ *     members and function-body-local type aliases are invisible to the type
+ *     API and are therefore correctly skipped),
+ *   - call / construct signature parameter and return types.
+ *
+ * It is intentionally conservative: only types *declared inside the same
+ * package* (under the package's `src/` dir) are required to be exported. Types
+ * from `@silurus/ooxml-core` or `lib.dom` (`HTMLCanvasElement`, `Error`, …) are
+ * out of scope.
+ *
+ * This is test-only tooling and is never re-exported from the package barrels,
+ * so it does not enter the published bundle.
+ */
+import ts from 'typescript';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface MissingExport {
+  /** The unexported type's name. */
+  name: string;
+  /** Absolute path of the file that declares it. */
+  declaredIn: string;
+  /** The exported barrel symbol through which it is reachable (diagnostics). */
+  reachableFrom: string[];
+}
+
+export interface CheckOptions {
+  /** Absolute path to the package's `src/index.ts` barrel. */
+  indexPath: string;
+  /**
+   * Absolute path to the package `src/` directory. Only types declared under
+   * this directory are considered "same-package" and therefore required to be
+   * exported. Defaults to `dirname(indexPath)`.
+   */
+  srcDir?: string;
+  /**
+   * Names to ignore even if reachable and unexported (escape hatch for
+   * deliberately-internal helper types). Usually empty.
+   */
+  allowlist?: readonly string[];
+}
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  strict: true,
+  skipLibCheck: true,
+  noEmit: true,
+};
+
+/** Normalise a fs path for cross-platform prefix comparison. */
+function norm(p: string): string {
+  return path.normalize(p).split(path.sep).join('/');
+}
+
+/** True when `file` lives under `dir` (both already normalised). */
+function isUnder(file: string, dir: string): boolean {
+  const f = norm(file);
+  const d = norm(dir).replace(/\/$/, '');
+  return f === d || f.startsWith(d + '/');
+}
+
+/**
+ * Find types reachable from the barrel's exports that are declared in the same
+ * package's `src/` tree but are not themselves exported from the barrel.
+ */
+export function findMissingExports(opts: CheckOptions): MissingExport[] {
+  const indexPath = norm(opts.indexPath);
+  const srcDir = norm(opts.srcDir ?? path.dirname(opts.indexPath));
+  const allow = new Set(opts.allowlist ?? []);
+
+  const program = ts.createProgram([indexPath], COMPILER_OPTIONS);
+  const checker = program.getTypeChecker();
+
+  const indexSource = program.getSourceFile(indexPath);
+  if (!indexSource) throw new Error(`Could not load index source file: ${indexPath}`);
+  const moduleSymbol = checker.getSymbolAtLocation(indexSource);
+  if (!moduleSymbol) throw new Error(`Could not resolve module symbol for: ${indexPath}`);
+
+  const exports = checker.getExportsOfModule(moduleSymbol);
+  const exportedNames = new Set<string>(exports.map((s) => s.getName()));
+
+  const missing = new Map<string, MissingExport>();
+  // Guard against cycles. The checker mints fresh `ts.Type` objects for derived
+  // types (apparent props, `T | null` wrappers), so identity-based Set guarding
+  // does not converge — key on the stable internal numeric type id, with an
+  // object-identity WeakSet fallback for the rare type that lacks an id.
+  const visitedTypeIds = new Set<number>();
+  const visitedTypeObjs = new WeakSet<object>();
+  const MAX_DEPTH = 64;
+
+  function resolveAlias(sym: ts.Symbol): ts.Symbol {
+    return sym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym) : sym;
+  }
+
+  /** Where is a type's naming symbol declared? */
+  type Origin =
+    | { kind: 'in-package'; name: string; file: string }
+    | { kind: 'external' } // named, but declared outside the package src (core, lib.dom, …)
+    | { kind: 'anonymous' }; // inline object literal / union / primitive — no naming symbol
+
+  /**
+   * True for class members that are not part of the public surface: explicit
+   * `private`/`protected` modifiers, ECMAScript `#private` names, or
+   * `@internal`-style underscore-prefixed members are NOT treated as private
+   * here (only real access modifiers / `#` names are). The Compiler API leaks
+   * private members through `getProperties()`, so we must filter them.
+   */
+  function isNonPublicMember(sym: ts.Symbol): boolean {
+    const decls = sym.getDeclarations();
+    if (!decls) return false;
+    for (const d of decls) {
+      const mods = ts.getCombinedModifierFlags(d);
+      if (mods & (ts.ModifierFlags.Private | ts.ModifierFlags.Protected)) return true;
+      // `#private` fields/methods.
+      const nameNode = (d as ts.NamedDeclaration).name;
+      if (nameNode && ts.isPrivateIdentifier(nameNode)) return true;
+    }
+    return false;
+  }
+
+  /** Only these declaration kinds introduce a *named type* in the API surface. */
+  function isTypeDeclaration(d: ts.Declaration): boolean {
+    return (
+      ts.isInterfaceDeclaration(d) ||
+      ts.isTypeAliasDeclaration(d) ||
+      ts.isClassDeclaration(d) ||
+      ts.isEnumDeclaration(d)
+    );
+  }
+
+  function originOf(type: ts.Type): Origin {
+    const sym = type.aliasSymbol ?? type.getSymbol();
+    if (!sym) return { kind: 'anonymous' };
+    if (sym.flags & ts.SymbolFlags.TypeParameter) return { kind: 'anonymous' };
+    const name = sym.getName();
+    if (!name || name === '__type' || name === '__object') return { kind: 'anonymous' };
+    const decls = sym.getDeclarations();
+    if (!decls || decls.length === 0) return { kind: 'external' };
+    // A symbol whose declarations are functions/methods/variables (not a type
+    // declaration) does not name a *type* — it is an anonymous structural type
+    // for our purposes (we still descend into its signature via the caller).
+    const typeDecls = decls.filter(isTypeDeclaration);
+    if (typeDecls.length === 0) return { kind: 'anonymous' };
+    for (const d of typeDecls) {
+      const file = d.getSourceFile().fileName;
+      if (isUnder(file, srcDir)) return { kind: 'in-package', name, file: norm(file) };
+    }
+    return { kind: 'external' };
+  }
+
+  function record(name: string, file: string, root: string): void {
+    const existing = missing.get(name);
+    if (existing) {
+      if (!existing.reachableFrom.includes(root)) existing.reachableFrom.push(root);
+    } else {
+      missing.set(name, { name, declaredIn: file, reachableFrom: [root] });
+    }
+  }
+
+  /** Recurse through a type's public surface, recording in-package types. */
+  function walkType(type: ts.Type, root: string, depth: number): void {
+    if (depth > MAX_DEPTH) return;
+    const id = (type as ts.Type & { id?: number }).id;
+    if (id !== undefined) {
+      if (visitedTypeIds.has(id)) return;
+      visitedTypeIds.add(id);
+    } else {
+      if (visitedTypeObjs.has(type)) return;
+      visitedTypeObjs.add(type);
+    }
+
+    const origin = originOf(type);
+
+    // External named type (core, lib.dom, Node, …): record nothing and DO NOT
+    // descend into its members. This is the critical pruning step — without it
+    // the walk would explore the entire DOM/lib type graph and OOM.
+    if (origin.kind === 'external') {
+      // Type arguments still matter: an external container like `Array<Foo>` or
+      // `Promise<Foo>` may carry an in-package `Foo`. Descend only into those.
+      const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
+      if (typeArgs) for (const ta of typeArgs) walkType(ta, root, depth + 1);
+      return;
+    }
+
+    // In-package named type: check + record if unexported, then keep walking
+    // its structure (it may reach further in-package types).
+    if (origin.kind === 'in-package') {
+      if (!exportedNames.has(origin.name) && !allow.has(origin.name)) {
+        record(origin.name, origin.file, root);
+      }
+    }
+
+    // Union / intersection constituents.
+    if (type.isUnionOrIntersection()) {
+      for (const t of type.types) walkType(t, root, depth + 1);
+    }
+
+    // Type arguments (Array<T>, Map<K,V>, generics on in-package aliases …).
+    const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
+    if (typeArgs && typeArgs.length) {
+      for (const ta of typeArgs) walkType(ta, root, depth + 1);
+    }
+
+    // Own properties — only descend for in-package and anonymous (inline
+    // object-literal) types. NB: the Compiler API's `getProperties()` DOES
+    // include `private`/`protected` class members (privacy is enforced at
+    // check time, not stripped from the symbol table), so they must be
+    // filtered out explicitly — otherwise the walk leaks through a viewer's
+    // private worker bridge into the internal message protocol types.
+    for (const prop of type.getProperties()) {
+      if (isNonPublicMember(prop)) continue;
+      const propDecl = prop.valueDeclaration ?? prop.getDeclarations()?.[0];
+      if (!propDecl) continue;
+      const propType = checker.getTypeOfSymbolAtLocation(prop, propDecl);
+      walkType(propType, root, depth + 1);
+    }
+
+    // Call / construct signatures: parameter and return types.
+    for (const sig of [...type.getCallSignatures(), ...type.getConstructSignatures()]) {
+      for (const p of sig.getParameters()) {
+        const pDecl = p.valueDeclaration ?? p.getDeclarations()?.[0];
+        if (!pDecl) continue;
+        walkType(checker.getTypeOfSymbolAtLocation(p, pDecl), root, depth + 1);
+      }
+      walkType(sig.getReturnType(), root, depth + 1);
+    }
+  }
+
+  for (const exp of exports) {
+    const sym = resolveAlias(exp);
+    const decl = sym.getDeclarations()?.[0];
+    if (!decl) continue;
+    // Use the declared type at its declaration site so type aliases resolve to
+    // their target (unions, object literals, …) and classes/interfaces to their
+    // instance type.
+    const type = checker.getTypeOfSymbolAtLocation(sym, decl);
+    walkType(type, exp.getName(), 0);
+    // For interfaces / type aliases the symbol type above may be the *type* of
+    // a value; also walk the declared type to be safe.
+    const declared = checker.getDeclaredTypeOfSymbol(sym);
+    if (declared) walkType(declared, exp.getName(), 0);
+  }
+
+  return Array.from(missing.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Convenience wrapper for package tests: resolve `index.ts` relative to the
+ * test module's `import.meta.url` so callers don't need `@silurus/ooxml-core`'s
+ * `@types/node` to call `fileURLToPath` themselves. The node-API dependency
+ * lives here in core, which already depends on `@types/node`.
+ *
+ * @param metaUrl     the test file's `import.meta.url`.
+ * @param relIndexPath path to the barrel relative to the test file (default
+ *                     `./index.ts`).
+ */
+export function findMissingExportsFromUrl(
+  metaUrl: string,
+  relIndexPath = './index.ts',
+  extra?: Omit<CheckOptions, 'indexPath'>,
+): MissingExport[] {
+  const indexPath = fileURLToPath(new URL(relIndexPath, metaUrl));
+  return findMissingExports({ indexPath, ...extra });
+}
+
+/**
+ * Convenience: format a readable failure message listing the reachable-but-
+ * unexported types, or '' on success.
+ */
+export function formatMissing(missing: MissingExport[]): string {
+  if (missing.length === 0) return '';
+  const lines = missing.map(
+    (m) =>
+      `  - ${m.name} (declared in ${path.basename(m.declaredIn)}; reachable from ${m.reachableFrom.join(', ')})`,
+  );
+  return `Reachable-but-unexported public types:\n${lines.join('\n')}`;
+}

--- a/packages/docx/src/export-completeness.test.ts
+++ b/packages/docx/src/export-completeness.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { findMissingExportsFromUrl, formatMissing } from '@silurus/ooxml-core/testing';
+
+/**
+ * v1.0 API freeze guard: every public type reachable from the docx barrel must
+ * itself be exported. See `@silurus/ooxml-core/testing` for the algorithm.
+ */
+describe('docx public API export completeness', () => {
+  it('exports every in-package type reachable from index.ts', () => {
+    const missing = findMissingExportsFromUrl(import.meta.url);
+    expect(missing, formatMissing(missing)).toEqual([]);
+  });
+});

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -3,16 +3,40 @@ export { DocxViewer, type DocxViewerOptions } from './viewer';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   DocxDocumentModel,
+  DocSettings,
   SectionProps,
+  HeadersFooters,
+  HeaderFooter,
+  NumberingInfo,
   BodyElement,
   DocParagraph,
   DocRun,
   DocxTextRun,
+  FieldRun,
   ImageRun,
+  ShapeRun,
+  ShapeText,
+  RubyAnnotation,
   RenderPageOptions,
   RunRevision,
   DocRevision,
   DocComment,
   DocNote,
+  // Paragraph / line-spacing sub-types.
+  LineSpacing,
+  TabStop,
+  ParagraphBorders,
+  ParaBorderEdge,
+  // Table model (reachable via BodyElement table variant).
+  DocTable,
+  DocTableRow,
+  DocTableCell,
+  CellElement,
+  TableBorders,
+  CellBorders,
+  BorderSpec,
+  // Shape geometry / fill sub-types.
+  PathCmd,
+  GradientStop,
 } from './types';
 export type { DocxTextRunInfo } from './renderer';

--- a/packages/pptx/src/export-completeness.test.ts
+++ b/packages/pptx/src/export-completeness.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { findMissingExportsFromUrl, formatMissing } from '@silurus/ooxml-core/testing';
+
+/**
+ * v1.0 API freeze guard: every public type reachable from the pptx barrel must
+ * itself be exported. See `@silurus/ooxml-core/testing` for the algorithm.
+ * The canonical regression this catches is the `SlideElement` union whose
+ * `TableElement` / `ChartElement` / `MediaElement` members were unexported.
+ */
+describe('pptx public API export completeness', () => {
+  it('exports every in-package type reachable from index.ts', () => {
+    const missing = findMissingExportsFromUrl(import.meta.url, './index.ts', {
+      // `SlideRenderOptions` is `RenderOptions & { math }`, the *internal*
+      // parameter type of `renderSlide`. The `math` engine is implementation
+      // plumbing that `PptxPresentation` injects; the public-facing option type
+      // is the exported `RenderSlideOptions`, which deliberately omits `math`.
+      // It is therefore intentionally not re-exported.
+      allowlist: ['SlideRenderOptions'],
+    });
+    expect(missing, formatMissing(missing)).toEqual([]);
+  });
+});

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -1,6 +1,7 @@
 export { PptxViewer, type PptxViewerOptions } from './viewer';
 export { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 export { renderSlide, type RenderOptions, type PptxTextRunInfo, type TextRunCallback } from './renderer';
+export type { PresentationHandle } from './presentation-handle';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Presentation,
@@ -8,13 +9,37 @@ export type {
   SlideElement,
   ShapeElement,
   PictureElement,
+  // SlideElement union members — reachable via Slide.elements; exported so a
+  // consumer that narrows on `el.type` has a name for every variant.
+  TableElement,
+  TableRow,
+  TableCell,
+  ChartElement,
+  MediaElement,
+  TextRect,
+  // Fill / stroke variants (reachable via ShapeElement.fill / .stroke etc.).
   Fill,
   SolidFill,
   NoFill,
+  GradientFill,
+  GradientStop,
   Stroke,
+  // Effect types (reachable via ShapeElement.shadow / .glow / …).
+  Shadow,
+  Glow,
+  SoftEdge,
+  Reflection,
+  // Geometry + text run sub-types (reachable via ShapeElement / TextBody).
+  PathCmd,
+  Bullet,
+  SpaceLine,
+  TabStop,
   TextBody,
   Paragraph,
   TextRun,
   TextRunData,
   LineBreak,
+  // Chart model (reachable via ChartElement.series and renderChart).
+  ChartModel,
+  ChartSeries,
 } from './types';

--- a/packages/pptx/src/presentation-handle.test.ts
+++ b/packages/pptx/src/presentation-handle.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import type { PresentationHandle } from './presentation-handle.js';
+
+/**
+ * Compile-time assertions enforced by `pnpm typecheck`. They are erased at
+ * runtime, so the `it(...)` body keeps the file a valid (trivially green)
+ * vitest suite.
+ */
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
+type Expect<T extends true> = T;
+
+/**
+ * v1.0 API freeze: the live-playback handle's teardown method is named
+ * `destroy()`, matching `PptxViewer.destroy()`, `DocxDocument.destroy()`,
+ * `XlsxWorkbook.destroy()` etc. The old `dispose()` name is removed so the
+ * whole public surface uses one teardown verb.
+ */
+type _HasDestroy = Expect<HasKey<PresentationHandle, 'destroy'>>;
+// `dispose` must NOT exist on the handle any more.
+type _NoDispose = Expect<HasKey<PresentationHandle, 'dispose'> extends false ? true : false>;
+
+describe('PresentationHandle teardown method', () => {
+  it('exposes destroy() (renamed from dispose()) for API parity', () => {
+    // Enforced by `pnpm typecheck` via the `_HasDestroy` / `_NoDispose` types.
+    expect(true).toBe(true);
+  });
+});

--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -20,7 +20,13 @@ interface MediaState {
 export interface PresentationHandle {
   play(mediaPath?: string): void;
   pause(mediaPath?: string): void;
-  dispose(): void;
+  /**
+   * Stop the playback RAF loop, detach pointer listeners and release every
+   * media blob URL. Named `destroy()` to match the teardown method on the
+   * viewers/documents (`PptxViewer.destroy()`, `XlsxWorkbook.destroy()`, …)
+   * so the public API uses one consistent teardown verb.
+   */
+  destroy(): void;
 }
 
 export interface PresentOptions {
@@ -40,7 +46,7 @@ export interface PresentOptions {
  * Attach canvas-native playback to a slide. Layers each media element's video
  * frame (via HTMLVideoElement → drawImage) and a self-drawn play/progress
  * overlay on top of the base rendering. Click on a media element to toggle
- * playback. Call dispose() to stop the RAF loop and release blob URLs.
+ * playback. Call destroy() to stop the RAF loop and release blob URLs.
  */
 export async function createPresentationHandle(
   canvas: HTMLCanvasElement,
@@ -254,7 +260,7 @@ export async function createPresentationHandle(
         if (!mediaPath || s.el.mediaPath === mediaPath) s.media.pause();
       }
     },
-    dispose() {
+    destroy() {
       if (disposed) return;
       disposed = true;
       if (rafId !== null) cancelAnimationFrame(rafId);

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -237,9 +237,9 @@ export class PptxPresentation {
 
   /**
    * Render a slide and attach canvas-native playback controls for any
-   * embedded audio/video. Returns a disposable handle that owns the RAF loop,
-   * media elements, and object URLs. Unlike {@link renderSlide}, this method
-   * is stateful — always call `handle.dispose()` when leaving the slide.
+   * embedded audio/video. Returns a {@link PresentationHandle} that owns the
+   * RAF loop, media elements, and object URLs. Unlike {@link renderSlide}, this
+   * method is stateful — always call `handle.destroy()` when leaving the slide.
    */
   async presentSlide(
     canvas: HTMLCanvasElement,

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -125,7 +125,7 @@ export class PptxViewer {
     this.canvas.style.width = `${targetWidth}px`;
     this.canvas.style.height = `${cssHeight}px`;
 
-    this.handle?.dispose();
+    this.handle?.destroy();
     this.handle = null;
 
     const runs: PptxTextRunInfo[] = [];
@@ -197,7 +197,7 @@ export class PptxViewer {
 
   /** Clean up the viewer and terminate the background worker. */
   destroy(): void {
-    this.handle?.dispose();
+    this.handle?.destroy();
     this.handle = null;
     this.engine?.destroy();
     this.wrapper.remove();

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -43,15 +43,18 @@ export function buildViewerUI(
   viewerContainer.style.cssText = 'flex:1;min-height:0;';
   root.appendChild(viewerContainer);
 
+  let sheetNames: string[] = [];
+
   const viewer = new XlsxViewer(viewerContainer, {
     cellScale: args.scale,
     useGoogleFonts: true,
     math,
     onReady: (names) => {
+      sheetNames = names;
       status.textContent = `Loaded — ${names.length} sheet(s)`;
     },
-    onSheetChange: (_idx, name) => {
-      status.textContent = `Sheet: ${name}`;
+    onSheetChange: (idx, total) => {
+      status.textContent = `Sheet ${idx + 1} / ${total}: ${sheetNames[idx] ?? ''}`;
     },
     onError: (err) => { status.textContent = `Error: ${err.message}`; },
   });
@@ -140,6 +143,7 @@ export const FileUpload: Story = {
     root.appendChild(viewerContainer);
 
     let viewer: XlsxViewer | null = null;
+    let sheetNames: string[] = [];
 
     async function loadBuffer(buf: ArrayBuffer) {
       viewer?.destroy();
@@ -148,8 +152,8 @@ export const FileUpload: Story = {
         cellScale: args.scale,
         useGoogleFonts: true,
         math,
-        onReady: (names) => { status.textContent = `${names.length} sheet(s)`; },
-        onSheetChange: (_idx, name) => { status.textContent = `Sheet: ${name}`; },
+        onReady: (names) => { sheetNames = names; status.textContent = `${names.length} sheet(s)`; },
+        onSheetChange: (idx, total) => { status.textContent = `Sheet ${idx + 1} / ${total}: ${sheetNames[idx] ?? ''}`; },
         onError: (err) => { status.textContent = `Error: ${err.message}`; },
       });
       await viewer.load(buf);

--- a/packages/xlsx/src/export-completeness.test.ts
+++ b/packages/xlsx/src/export-completeness.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { findMissingExportsFromUrl, formatMissing } from '@silurus/ooxml-core/testing';
+
+/**
+ * v1.0 API freeze guard: every public type reachable from the xlsx barrel must
+ * itself be exported. See `@silurus/ooxml-core/testing` for the algorithm.
+ */
+describe('xlsx public API export completeness', () => {
+  it('exports every in-package type reachable from index.ts', () => {
+    const missing = findMissingExportsFromUrl(import.meta.url);
+    expect(missing, formatMissing(missing)).toEqual([]);
+  });
+});

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -21,4 +21,49 @@ export type {
   ViewportRange,
   RenderViewportOptions,
   XlsxTextRunInfo,
+  // Rich-text run sub-types (reachable via Cell rich-text values).
+  Run,
+  RunFont,
+  SharedString,
+  // Differential / gradient style sub-types (reachable via Styles).
+  Dxf,
+  GradientFillSpec,
+  // Conditional formatting (reachable via Worksheet.conditionalFormats).
+  ConditionalFormat,
+  CfRule,
+  CfValue,
+  CfStop,
+  CfIcon,
+  // Workbook-level metadata.
+  DefinedName,
+  Hyperlink,
+  // Excel tables (reachable via Worksheet.tables).
+  TableInfo,
+  TableColumnInfo,
+  // Slicers.
+  SlicerAnchor,
+  SlicerItem,
+  // Sparklines (reachable via Worksheet sparkline groups).
+  SparklineGroup,
+  Sparkline,
+  // Drawings / shapes (reachable via Worksheet drawings).
+  ImageAnchor,
+  ChartAnchor,
+  ShapeAnchor,
+  ShapeInfo,
+  ShapeGeom,
+  ShapeText,
+  ShapeParagraph,
+  ShapeTextRun,
+  PathInfo,
+  PathCmd,
+  // Embedded chart model sub-types.
+  ChartData,
+  XlsxChartSeries,
+  SeriesDataLabels,
+  DataLabelOverride,
+  DataPointOverride,
+  ErrBars,
+  ManualLayout,
+  LegendManualLayout,
 } from './types.js';

--- a/packages/xlsx/src/viewer-callbacks.test.ts
+++ b/packages/xlsx/src/viewer-callbacks.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import type { XlsxViewerOptions } from './viewer.js';
+
+/**
+ * Compile-time equality check. `Equal<A, B>` resolves to `true` only when the
+ * two types are mutually assignable AND identical; otherwise `false`. Feeding
+ * the result to `Expect<...>` makes `tsc --build` (run via `pnpm typecheck`)
+ * fail when the assertion is violated. These are erased at runtime, so the
+ * `it(...)` body below also keeps the file as a valid (trivially green) vitest
+ * suite — the real gate is the type checker.
+ */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type SheetCb = NonNullable<XlsxViewerOptions['onSheetChange']>;
+
+/**
+ * Cross-viewer API consistency (v1.0 API freeze): `onSheetChange` must share
+ * the `(index: number, total: number) => void` shape used by the docx
+ * (`onPageChange`) and pptx (`onSlideChange`) viewers, so downstream code can
+ * treat the three viewers uniformly. The second argument is the *total* number
+ * of sheets — NOT the sheet name. Consumers that need the name look it up via
+ * `workbook.sheetNames[index]`.
+ */
+type _AssertSheetCb = Expect<Equal<SheetCb, (index: number, total: number) => void>>;
+
+describe('XlsxViewer onSheetChange signature', () => {
+  it('matches the docx/pptx (index, total) contract', () => {
+    // Enforced by `pnpm typecheck` via the `_AssertSheetCb` type above.
+    // `total` is the sheet count; the name is read from `workbook.sheetNames`.
+    expect(true).toBe(true);
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -21,7 +21,15 @@ export interface XlsxViewerOptions {
   zoomMin?: number;
   zoomMax?: number;
   onReady?: (sheetNames: string[]) => void;
-  onSheetChange?: (index: number, name: string) => void;
+  /**
+   * Called when the active sheet changes, with the new sheet's zero-based
+   * `index` and the `total` number of sheets in the workbook. This mirrors the
+   * docx `onPageChange` and pptx `onSlideChange` contracts so all three viewers
+   * share one callback shape. To get the sheet *name*, look it up by index from
+   * `viewer.sheetNames[index]` (or the `sheetNames` array delivered to
+   * `onReady`).
+   */
+  onSheetChange?: (index: number, total: number) => void;
   onError?: (err: Error) => void;
   /** Called when the selected cell range changes. null means no selection. */
   onSelectionChange?: (selection: CellRange | null) => void;
@@ -323,7 +331,7 @@ export class XlsxViewer {
     // so scrollWidth reflects the new sheet before we read the max offset.
     this.resetHorizontalScroll();
     await this.renderCurrentSheet();
-    this.opts.onSheetChange?.(index, this.workbook.sheetNames[index] ?? '');
+    this.opts.onSheetChange?.(index, this.workbook.sheetNames.length);
   }
 
   /** True when the current sheet's grid is laid out right-to-left. */

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -120,7 +120,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         ZIP,
         MATH,
         { name: 'onReady', type: '(sheetNames: string[]) => void', desc: 'Called once the workbook is parsed.' },
-        { name: 'onSheetChange', type: '(index: number, name: string) => void', desc: 'Called when the active sheet changes.' },
+        { name: 'onSheetChange', type: '(index: number, total: number) => void', desc: 'Called when the active sheet changes; `total` is the sheet count. Read the name via `sheetNames[index]`.' },
         { name: 'onSelectionChange', type: '(sel: CellRange | null) => void', desc: 'Called when the selected range changes; null clears it.' },
         { name: 'onError', type: '(err: Error) => void', desc: 'Called on parse or render errors.' },
       ],

--- a/site/src/lib/try.ts
+++ b/site/src/lib/try.ts
@@ -90,14 +90,14 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
               .then((h) => {
                 pending.delete(idx);
                 if (visible.has(idx)) handles.set(idx, h);
-                else h.dispose(); // scrolled away before it resolved
+                else h.destroy(); // scrolled away before it resolved
               })
               .catch(() => pending.delete(idx));
           } else {
             visible.delete(idx);
             const h = handles.get(idx);
             if (h) {
-              h.dispose(); // stops media + RAF; the static base frame remains
+              h.destroy(); // stops media + RAF; the static base frame remains
               handles.delete(idx);
             }
           }
@@ -108,7 +108,7 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
     canvases.forEach((c) => io.observe(c));
     activeCleanup = () => {
       io.disconnect();
-      handles.forEach((h) => h.dispose());
+      handles.forEach((h) => h.destroy());
       handles.clear();
       pending.clear();
       visible.clear();


### PR DESCRIPTION
## v1.0 Phase 1 — API Freeze

Aligns the public API across the three viewers ahead of the v1.0 freeze: unifies the change callbacks, the teardown verb, and makes every reachable public type exportable (guarded by a compiler-driven test).

### Breaking changes

1. **`XlsxViewer.onSheetChange` signature** — was `(index: number, name: string)`, now `(index: number, total: number)`, matching docx `onPageChange` and pptx `onSlideChange`. The second argument is the **sheet count**, not the name. To get the name, read `viewer.sheetNames[index]` (or the array from `onReady`).
2. **`PresentationHandle.dispose()` → `destroy()`** — the handle returned by `Presentation.presentSlide()` renames its teardown method to `destroy()`, matching `PptxViewer.destroy()` / `XlsxWorkbook.destroy()` / etc.

Migration:
```ts
// xlsx
viewer = new XlsxViewer(container, {
  onReady: (names) => { sheetNames = names; },
  onSheetChange: (index, total) => { /* was (index, name) */
    const name = sheetNames[index];
  },
});

// pptx
const handle = await presentation.presentSlide(canvas, 0);
handle.destroy(); // was handle.dispose()
```

### Additive (non-breaking)

3. **Exhaustive public type exports.** Many types reachable from the public API were never re-exported from the package barrels (most visibly the pptx `SlideElement` union members `TableElement` / `ChartElement` / `MediaElement`). All reachable in-package types are now exported from `index.ts` — see the commit body of `feat(api): export all public types…` for the full per-package list.

4. **Export-completeness guard.** New test-only `@silurus/ooxml-core/testing` helper walks the public type surface (TypeScript Compiler API) from each `index.ts` and fails if any reachable in-package type is unexported. A vitest suite per package (docx/pptx/xlsx) enforces it, so this class of omission can't regress. The walk is type-checker-driven: it follows union/intersection members, type arguments, public object properties and call/construct signatures; it skips `private`/`protected` members and treats core/lib.dom types as external. The helper is never re-exported from the public barrels, so it does not enter the published bundle.

### Verification

- `tsc --build` (core/pptx/docx/xlsx) — green
- `pnpm test` — green (29 files / 179 tests, incl. 5 new)
- `pnpm build` / `pnpm build:packages` — green; confirmed new types land in `dist/types/*.d.ts` and the testing helper does not leak into the public bundle
- `pnpm lint` (ast-grep) — green
- `pnpm typecheck`: the `tsc --build` library portion and markdown/node typechecks are green. The `vscode-extension` webview typecheck fails, but **identically on origin/main** (it resolves `@silurus/ooxml-*` to per-package `dist/index.mjs`, which the build flow ships without an adjacent `dist/types/`, plus pre-existing implicit-`any` params in `bootstrap.ts`). This is a pre-existing environmental issue unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)