### PR TITLE
fix(xlsx): stop synthesizing borders on custom table styles

### DIFF
--- a/packages/xlsx/parser/src/table.rs
+++ b/packages/xlsx/parser/src/table.rs
@@ -17,14 +17,31 @@ use std::io::Cursor;
 /// `theme_colors` is in OOXML natural order — accent1 lives at index 4, so
 /// accent_n is at `theme_colors[3 + n]`. Falls back to a neutral gray when
 /// the style name is unrecognised or the theme is missing accents.
-/// dxf indices for the ECMA-376 §18.8.40 `<tableStyleElement>` roles we care
-/// about. Built-in styles (`TableStyleLight18`, etc.) have no entry in the
-/// file's `<tableStyles>` block and fall through to accent-based rendering;
-/// custom styles (`"Gift Budget"`) reference dxfs from `<dxfs>`.
+/// dxf indices for the ECMA-376 §18.8.83 `<tableStyleElement>` roles we
+/// render. The presence of an entry in the file's `<tableStyles>` block marks
+/// a *custom* style: built-in styles (`TableStyleLight18`, etc.) have no entry
+/// here and fall through to accent-based rendering, whereas custom styles
+/// (`"予算"`, `"交通費"`) reference dxfs from `<dxfs>` and must be drawn from
+/// those dxfs alone — a custom style contributes ONLY what its declared
+/// elements define (§18.5.1.2 tableStyleInfo). If none of its elements carry a
+/// border dxf, Excel draws no table-level border at all.
+///
+/// `ST_TableStyleType` (§18.18.93) defines many element types. We cover the
+/// region-level ones that affect rendering here: wholeTable, headerRow,
+/// totalRow, firstColumn, lastColumn, and the two horizontal banding stripes
+/// (firstRowStripe / secondRowStripe). Vertical banding stripes and the corner
+/// cell types (first/last header/total cell) are out of scope for now.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct TableStyleElements {
     whole_table: Option<u32>,
     header_row: Option<u32>,
+    total_row: Option<u32>,
+    first_column: Option<u32>,
+    last_column: Option<u32>,
+    /// `firstRowStripe` — band1 horizontal stripe dxf (§18.18.93).
+    band1_horizontal: Option<u32>,
+    /// `secondRowStripe` — band2 horizontal stripe dxf.
+    band2_horizontal: Option<u32>,
 }
 
 /// Parse `<tableStyles><tableStyle name="…"><tableStyleElement type="…" dxfId="…"/>`
@@ -59,9 +76,16 @@ pub(crate) fn parse_table_styles_map(
             {
                 let t = el.attribute("type").unwrap_or("");
                 let dxf: Option<u32> = el.attribute("dxfId").and_then(|s| s.parse().ok());
+                // §18.18.93 ST_TableStyleType. firstRowStripe/secondRowStripe
+                // are the horizontal banding stripes (row banding).
                 match t {
                     "wholeTable" => elems.whole_table = dxf,
                     "headerRow" => elems.header_row = dxf,
+                    "totalRow" => elems.total_row = dxf,
+                    "firstColumn" => elems.first_column = dxf,
+                    "lastColumn" => elems.last_column = dxf,
+                    "firstRowStripe" => elems.band1_horizontal = dxf,
+                    "secondRowStripe" => elems.band2_horizontal = dxf,
                     _ => {}
                 }
             }
@@ -189,10 +213,19 @@ pub(crate) fn load_sheet_tables(
                 None => (false, false, false, false),
             };
         let accent_color = resolve_table_style_accent(&style_name, theme_colors);
-        let (whole_table_dxf, header_row_dxf) = match custom_styles.get(&style_name) {
-            Some(e) => (e.whole_table, e.header_row),
-            None => (None, None),
-        };
+        // §18.5.1.2: a style is *custom* iff it is defined in the file's
+        // `<tableStyles>` block. Custom styles render strictly from their
+        // declared element dxfs (no accent approximation); built-in style
+        // names (absent from the block) keep the accent-based fallback.
+        let style_elems = custom_styles.get(&style_name);
+        let is_custom = style_elems.is_some();
+        let whole_table_dxf = style_elems.and_then(|e| e.whole_table);
+        let header_row_dxf = style_elems.and_then(|e| e.header_row);
+        let total_row_dxf = style_elems.and_then(|e| e.total_row);
+        let first_column_dxf = style_elems.and_then(|e| e.first_column);
+        let last_column_dxf = style_elems.and_then(|e| e.last_column);
+        let band1_horizontal_dxf = style_elems.and_then(|e| e.band1_horizontal);
+        let band2_horizontal_dxf = style_elems.and_then(|e| e.band2_horizontal);
         // ECMA-376 §18.5.1.3: each `<tableColumn>` may carry its own
         // `dataDxfId`, `headerRowDxfId`, `totalsRowDxfId`. We collect them in
         // document order so the renderer can index them via
@@ -216,8 +249,14 @@ pub(crate) fn load_sheet_tables(
             show_first_column,
             show_last_column,
             accent_color,
+            is_custom,
             whole_table_dxf,
             header_row_dxf,
+            total_row_dxf,
+            first_column_dxf,
+            last_column_dxf,
+            band1_horizontal_dxf,
+            band2_horizontal_dxf,
             columns,
         });
     }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -212,8 +212,15 @@ pub struct TableInfo {
     /// theme accents (e.g. `TableStyleLight18` → accent3 of theme1.xml). Used
     /// by the renderer to draw banding, header background, and rules.
     pub accent_color: String,
+    /// `true` when `style_name` is defined in the file's `<tableStyles>` block,
+    /// i.e. a *custom* style (ECMA-376 §18.5.1.2). The renderer must draw such
+    /// tables strictly from their declared element dxfs and must NOT apply the
+    /// accent-based approximation (banding, synthesized rules/header) that is
+    /// reserved for built-in style names whose definitions are absent.
+    #[serde(default)]
+    pub is_custom: bool,
     /// Dxf index for the `wholeTable` element of a custom `<tableStyle>`
-    /// (ECMA-376 §18.8.40). When set, its border/fill apply to every cell
+    /// (ECMA-376 §18.8.83). When set, its border/fill apply to every cell
     /// of the table as a base layer. Built-in style names use the renderer's
     /// accent-based fallback, not this field.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -223,6 +230,23 @@ pub struct TableInfo {
     /// vertical separator borders shown between header cells.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub header_row_dxf: Option<u32>,
+    /// Dxf index for the `totalRow` element (ECMA-376 §18.18.93).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_row_dxf: Option<u32>,
+    /// Dxf index for the `firstColumn` element.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_column_dxf: Option<u32>,
+    /// Dxf index for the `lastColumn` element.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_column_dxf: Option<u32>,
+    /// Dxf index for the `firstRowStripe` (band1 horizontal) element — the odd
+    /// banded-row stripe applied when `show_row_stripes` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub band1_horizontal_dxf: Option<u32>,
+    /// Dxf index for the `secondRowStripe` (band2 horizontal) element — the
+    /// even banded-row stripe.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub band2_horizontal_dxf: Option<u32>,
     /// Per-column DXF references (ECMA-376 §18.5.1.3 `tableColumn`). Length
     /// matches the number of `<tableColumn>` children in the table XML, so
     /// `columns[c - range.left]` gives the DXFs for the cell column. The

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -880,14 +880,27 @@ function drawAutoFilterArrow(ctx: CanvasRenderingContext2D, cx: number, cy: numb
 }
 
 // ────────────────────────────────────────────────────────────────
-// Excel Table style overlays (ECMA-376 §18.5)
+// Excel Table style overlays (ECMA-376 §18.5 / §18.8.83)
 // ────────────────────────────────────────────────────────────────
-// We don't ship the full built-in table-style catalog — instead we derive a
-// single "accent" color from the style name and overlay bold header + banded
-// fills + horizontal rules so that `TableStyle*` files render with visible
-// structure rather than as blank ranges.
+// Two distinct paths:
+//
+// 1. CUSTOM styles (defined in the file's `<tableStyles>` block, §18.5.1.2):
+//    rendered strictly from the dxfs of their declared `<tableStyleElement>`s.
+//    A custom style contributes ONLY what its elements define — if none carry
+//    a border, Excel draws no table-level border (the visible structure comes
+//    from theme borders baked into each cell `xf`, which we render separately).
+//    `isCustom` cells therefore never get accent synthesis.
+//
+// 2. BUILT-IN style names (`TableStyleLight18`, …) whose definitions are NOT
+//    in the file. We don't yet ship the preset catalog, so we approximate them
+//    from a single "accent" color: bold header + banded fills + horizontal
+//    rules, so those files render with visible structure rather than blank
+//    ranges. This is an approximation, kept until a real catalog ships
+//    (post-1.0).
 export interface TableCellStyle {
   accent: string;
+  /** `true` for a custom `<tableStyle>` — disables all accent approximation. */
+  isCustom: boolean;
   isHeader: boolean;
   isTotals: boolean;
   /** `true` when this is a banded data row that should get the stripe fill. */
@@ -897,11 +910,20 @@ export interface TableCellStyle {
   isTopEdge: boolean;
   isBottomEdge: boolean;
   /** Dxf for the whole-table element of a custom `<tableStyle>`
-   *  (ECMA-376 §18.8.40). Border/fill apply to every cell as a base layer. */
+   *  (ECMA-376 §18.8.83). Border/fill apply to every cell as a base layer. */
   wholeTableDxf?: number;
   /** Dxf for the header-row element of a custom `<tableStyle>`. Provides
    *  header fill, font color/weight, and vertical separators. */
   headerRowDxf?: number;
+  /** Dxf for the total-row element. */
+  totalRowDxf?: number;
+  /** Dxf for the first-column element (when `showFirstColumn`). */
+  firstColumnDxf?: number;
+  /** Dxf for the last-column element (when `showLastColumn`). */
+  lastColumnDxf?: number;
+  /** Dxf for the stripe (band1=odd, band2=even) that applies to this row when
+   *  `showRowStripes` is set; undefined when this row is not a stripe. */
+  stripeDxf?: number;
 }
 
 function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
@@ -914,6 +936,7 @@ function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
     if (!t.styleName) continue;
     const { top, bottom, left, right } = t.range;
     const accent = t.accentColor || '#808080';
+    const isCustom = !!t.isCustom;
     const hdr = Math.max(0, t.headerRowCount ?? 1);
     const tot = Math.max(0, t.totalsRowCount ?? 0);
     const headerEnd = top + hdr - 1;
@@ -922,9 +945,17 @@ function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
       const isHeader = hdr > 0 && r <= headerEnd;
       const isTotals = tot > 0 && r >= totalsStart;
       const dataIdx = (!isHeader && !isTotals) ? (r - headerEnd - 1) : -1;
+      // Row banding stripes alternate band1 (odd) / band2 (even) over the data
+      // region (§18.18.93). For built-in approximation we only paint the odd
+      // stripe via `isBanded`; for custom styles we pick the matching dxf.
+      const isStripeRow = t.showRowStripes && dataIdx >= 0;
+      const stripeDxf = isStripeRow
+        ? (dataIdx % 2 === 1 ? t.band1HorizontalDxf : t.band2HorizontalDxf)
+        : undefined;
       for (let c = left; c <= right; c++) {
         map.set(`${r}:${c}`, {
           accent,
+          isCustom,
           isHeader,
           isTotals,
           isBanded: t.showRowStripes && dataIdx >= 0 && dataIdx % 2 === 1,
@@ -934,11 +965,77 @@ function buildTableStyleMap(worksheet: Worksheet): Map<string, TableCellStyle> {
           isBottomEdge: r === bottom,
           wholeTableDxf: t.wholeTableDxf,
           headerRowDxf: t.headerRowDxf,
+          totalRowDxf: t.totalRowDxf,
+          firstColumnDxf: t.firstColumnDxf,
+          lastColumnDxf: t.lastColumnDxf,
+          stripeDxf,
         });
       }
     }
   }
   return map;
+}
+
+/**
+ * Result of resolving a table cell's overlay *border* (ECMA-376 §18.8.83).
+ *  - `none`   — draw nothing extra (custom style with no border dxf, or a
+ *               built-in cell that has no rule on this edge).
+ *  - `dxf`    — draw `border` exactly as the resolved dxf defines it.
+ *  - `accent` — built-in approximation only: a synthesized accent-colored rule
+ *               under the cell (plus the table top edge when `topEdge`).
+ */
+export type TableOverlayBorder =
+  | { kind: 'none' }
+  | { kind: 'dxf'; border: Border }
+  | { kind: 'accent'; color: string; lineWidth: number; topEdge: boolean };
+
+/**
+ * Decide the table-style overlay border for one cell.
+ *
+ * `dxfWhole` / `dxfHeader` are the already-resolved dxfs for the cell's
+ * wholeTable / headerRow elements (undefined when the element is absent).
+ * `colIndex` is the cell's column index *within the table* (0 = first column),
+ * used to draw the table's outer-left edge only on the leftmost column.
+ *
+ * Custom styles (`ts.isCustom`) draw only from these dxfs and never synthesize
+ * accent rules: when no border dxf is present they contribute nothing. Built-in
+ * style names keep the accent approximation.
+ */
+export function tableOverlayBorder(
+  ts: TableCellStyle,
+  dxfWhole: Dxf | undefined,
+  dxfHeader: Dxf | undefined,
+  colIndex: number,
+): TableOverlayBorder {
+  const horiz = dxfWhole?.border?.horizontal;
+  const wtTop = dxfWhole?.border?.top;
+  const wtBot = dxfWhole?.border?.bottom;
+  const wtLeft = dxfWhole?.border?.left;
+  const wtRight = dxfWhole?.border?.right;
+  const hdrBot = dxfHeader?.border?.bottom;
+  const hdrTop = dxfHeader?.border?.top;
+  const hasDxfBorder = !!(horiz || wtTop || wtBot || wtLeft || wtRight || hdrBot || hdrTop);
+
+  if (hasDxfBorder) {
+    // Compose per-edge from the table-style hierarchy
+    // (wholeTable < headerRow), §18.8.83. The inner `horizontal` rule fills
+    // top/bottom for interior rows; outer edges come from the table extents.
+    const overlay: Border = { left: null, right: null, top: null, bottom: null };
+    if (ts.isTopEdge) overlay.top = wtTop ?? null;
+    else if (horiz) overlay.top = horiz;
+    if (ts.isHeader && hdrBot) overlay.bottom = hdrBot;
+    else if (ts.isBottomEdge) overlay.bottom = wtBot ?? null;
+    else if (horiz) overlay.bottom = horiz;
+    if (ts.isFirstCol || colIndex === 0) overlay.left = wtLeft ?? null;
+    if (ts.isLastCol) overlay.right = wtRight ?? null;
+    return { kind: 'dxf', border: overlay };
+  }
+
+  // No border dxf. A custom style contributes nothing here (§18.5.1.2):
+  // Excel draws no table-level border, only the theme borders baked into the
+  // cell xf. Built-in names fall through to the accent approximation.
+  if (ts.isCustom) return { kind: 'none' };
+  return { kind: 'accent', color: ts.accent, lineWidth: ts.isHeader ? 1.5 : 1, topEdge: ts.isTopEdge };
 }
 
 /** Flatten the worksheet's parsed `sparklineGroups` into a per-cell render
@@ -1247,13 +1344,29 @@ function renderQuadrant(
       const cf = evaluateCf(cell, rowIndex, colIndex, cfContext, styles.dxfs ?? []);
       const effectiveFill = cf.fill ?? fill;
       const tableStyle = rc.tableStyleMap.get(key);
-      // Custom `<tableStyle>` dxfs (ECMA-376 §18.8.40). When present, they
-      // drive header fill / font color and inter-row borders instead of the
-      // built-in accent fallback.
-      const tsDxfWhole = (tableStyle?.wholeTableDxf != null)
-        ? (styles.dxfs ?? [])[tableStyle.wholeTableDxf] : undefined;
-      const tsDxfHeader = (tableStyle?.headerRowDxf != null)
-        ? (styles.dxfs ?? [])[tableStyle.headerRowDxf] : undefined;
+      // Custom `<tableStyle>` dxfs (ECMA-376 §18.8.83). When present, they
+      // drive fills / font color and borders strictly from the declared
+      // elements — no accent fallback for custom styles.
+      const dxfList = styles.dxfs ?? [];
+      const dxfAt = (i?: number) => (i != null ? dxfList[i] : undefined);
+      const tsDxfWhole = dxfAt(tableStyle?.wholeTableDxf);
+      const tsDxfHeader = dxfAt(tableStyle?.headerRowDxf);
+      const tsDxfTotal = dxfAt(tableStyle?.totalRowDxf);
+      const tsDxfFirstCol = dxfAt(tableStyle?.firstColumnDxf);
+      const tsDxfLastCol = dxfAt(tableStyle?.lastColumnDxf);
+      const tsDxfStripe = dxfAt(tableStyle?.stripeDxf);
+      // Per-cell table fill resolved from the element hierarchy
+      // (§18.8.83: wholeTable < band < column < header/total). The later a
+      // layer appears the higher its precedence; we pick the most specific
+      // fill that defines a fgColor.
+      const tableFillDxf =
+        (tableStyle?.isHeader && tsDxfHeader?.fill?.fgColor) ? tsDxfHeader :
+        (tableStyle?.isTotals && tsDxfTotal?.fill?.fgColor) ? tsDxfTotal :
+        (tableStyle?.isLastCol && tsDxfLastCol?.fill?.fgColor) ? tsDxfLastCol :
+        (tableStyle?.isFirstCol && tsDxfFirstCol?.fill?.fgColor) ? tsDxfFirstCol :
+        (tsDxfStripe?.fill?.fgColor) ? tsDxfStripe :
+        (!tableStyle?.isHeader && !tableStyle?.isTotals && tsDxfWhole?.fill?.fgColor) ? tsDxfWhole :
+        undefined;
 
       // Background fill (base or CF override). ECMA-376 §18.8.22 ST_PatternType.
       // - solid/gray*: blend fgColor with bgColor at the pattern's fg coverage.
@@ -1273,15 +1386,15 @@ function renderQuadrant(
       if (paintCellPatternFill(ctx, effectiveFill, cx, cy, cellW, cellH)) {
         // own fill painted; tableStyle fallbacks intentionally skipped
         paintedFill = true;
-      } else if (tableStyle && tableStyle.isHeader && tsDxfHeader?.fill?.fgColor) {
-        ctx.fillStyle = hexToRgba(tsDxfHeader.fill.fgColor);
+      } else if (tableStyle && tableFillDxf?.fill?.fgColor) {
+        // Custom or built-in: a resolved table-element dxf fill wins.
+        ctx.fillStyle = hexToRgba(tableFillDxf.fill.fgColor);
         ctx.fillRect(cx, cy, cellW, cellH);
         paintedFill = true;
-      } else if (tableStyle && !tableStyle.isHeader && !tableStyle.isTotals && tsDxfWhole?.fill?.fgColor) {
-        ctx.fillStyle = hexToRgba(tsDxfWhole.fill.fgColor);
-        ctx.fillRect(cx, cy, cellW, cellH);
-        paintedFill = true;
-      } else if (tableStyle && tableStyle.isBanded) {
+      } else if (tableStyle && !tableStyle.isCustom && tableStyle.isBanded) {
+        // Accent-tint banding is an approximation for built-in style names
+        // only. Custom styles with no stripe dxf get no banding fill (Excel
+        // draws none — §18.5.1.2).
         ctx.fillStyle = stripeColorFor(tableStyle.accent);
         ctx.fillRect(cx, cy, cellW, cellH);
         paintedFill = true;
@@ -1399,40 +1512,24 @@ function renderQuadrant(
       }
       renderBorder(ctx, mergedBorder, cx, cy, cellW, cellH, invertedTop, invertedLeft);
 
-      // Excel Table style overlay: thin horizontal rules between rows and a
-      // thicker bottom edge under the header row (ECMA-376 §18.5). Drawn on
-      // top of cell borders so an empty-border data cell still shows table
-      // structure. None-style tables produce no entry in `tableStyleMap`
-      // (see `buildTableStyleMap`), so this block is naturally skipped.
+      // Excel Table style overlay (ECMA-376 §18.8.83). Custom styles draw only
+      // their dxf-defined borders; built-in style names fall back to a
+      // synthesized accent rule. Drawn on top of cell borders so an
+      // empty-border data cell still shows the table structure that the style
+      // actually defines. None-style tables produce no entry in
+      // `tableStyleMap` (see `buildTableStyleMap`), so this block is skipped.
       if (tableStyle) {
-        const horiz = tsDxfWhole?.border?.horizontal;
-        const vert  = tsDxfWhole?.border?.vertical;
-        const wtTop = tsDxfWhole?.border?.top;
-        const wtBot = tsDxfWhole?.border?.bottom;
-        const wtLeft = tsDxfWhole?.border?.left;
-        const wtRight = tsDxfWhole?.border?.right;
-        const hdrBot = tsDxfHeader?.border?.bottom;
-        const hdrTop = tsDxfHeader?.border?.top;
-        const hasDxfBorder = !!(horiz || vert || wtTop || wtBot || wtLeft || wtRight || hdrBot || hdrTop);
-        if (hasDxfBorder) {
-          const overlay: Border = { left: null, right: null, top: null, bottom: null };
-          if (tableStyle.isTopEdge) overlay.top = wtTop ?? null;
-          else if (horiz) overlay.top = horiz;
-          if (tableStyle.isHeader && hdrBot) overlay.bottom = hdrBot;
-          else if (tableStyle.isBottomEdge) overlay.bottom = wtBot ?? null;
-          else if (horiz) overlay.bottom = horiz;
-          if (tableStyle.isFirstCol || colIndex === 0) overlay.left = wtLeft ?? null;
-          if (tableStyle.isLastCol) overlay.right = wtRight ?? null;
-          // Outer table left/right edges
-          renderBorder(ctx, overlay, cx, cy, cellW, cellH);
-        } else {
+        const overlay = tableOverlayBorder(tableStyle, tsDxfWhole, tsDxfHeader, colIndex);
+        if (overlay.kind === 'dxf') {
+          renderBorder(ctx, overlay.border, cx, cy, cellW, cellH);
+        } else if (overlay.kind === 'accent') {
           const hp = 0.5 / dpr;
-          ctx.strokeStyle = tableStyle.accent;
-          ctx.lineWidth = tableStyle.isHeader ? 1.5 : 1;
+          ctx.strokeStyle = overlay.color;
+          ctx.lineWidth = overlay.lineWidth;
           ctx.beginPath();
           ctx.moveTo(cx, cy + cellH - hp);
           ctx.lineTo(cx + cellW, cy + cellH - hp);
-          if (tableStyle.isTopEdge) {
+          if (overlay.topEdge) {
             ctx.moveTo(cx, cy + hp);
             ctx.lineTo(cx + cellW, cy + hp);
           }
@@ -1450,7 +1547,23 @@ function renderQuadrant(
       if (!text || (text === '0' && rc.worksheet.showZeros === false)) continue;
 
       textTasks.push(() => {
-      const tableBold = !!(tableStyle && (tableStyle.isHeader || tableStyle.isTotals));
+      // The table-element dxf that applies to this cell's font (header/total/
+      // column/stripe/wholeTable), resolved by the same §18.8.83 hierarchy as
+      // the fill above. Used for both bold and color of custom styles.
+      const tableFontDxf =
+        (tableStyle?.isHeader) ? tsDxfHeader :
+        (tableStyle?.isTotals) ? tsDxfTotal :
+        (tableStyle?.isLastCol && tsDxfLastCol) ? tsDxfLastCol :
+        (tableStyle?.isFirstCol && tsDxfFirstCol) ? tsDxfFirstCol :
+        (tsDxfStripe) ? tsDxfStripe :
+        (tableStyle ? tsDxfWhole : undefined);
+      // Built-in style names: synthesize bold header/total rows (approximation).
+      // Custom styles: bold comes strictly from the element dxf font (§18.5.1.2).
+      const tableBold = tableStyle
+        ? (tableStyle.isCustom
+            ? !!tableFontDxf?.font?.bold
+            : (tableStyle.isHeader || tableStyle.isTotals))
+        : false;
       const effectiveBold = font.bold || !!cf.fontBold || tableBold;
       const effectiveItalic = font.italic || !!cf.fontItalic;
       const effectiveUnderline = font.underline || !!cf.fontUnderline;
@@ -1463,11 +1576,9 @@ function renderQuadrant(
         : font;
       ctx.font = buildFont(fontForDraw, cs);
       const hyperlinkUrl = rc.hyperlinkMap.get(key);
-      // Custom table-style header dxfs can override font color (ECMA-376 §18.8.40).
-      const tableFontColor =
-        (tableStyle?.isHeader && tsDxfHeader?.font?.color) ? tsDxfHeader.font.color :
-        (tableStyle && !tableStyle.isHeader && !tableStyle.isTotals && tsDxfWhole?.font?.color) ? tsDxfWhole.font.color :
-        null;
+      // Table-style element dxfs can override font color (ECMA-376 §18.8.83),
+      // following the same element hierarchy as the fill/bold above.
+      const tableFontColor = tableFontDxf?.font?.color ?? null;
       const textColor = hyperlinkUrl
         ? '#0563C1'
         : (cf.fontColor ?? tableFontColor ?? font.color);

--- a/packages/xlsx/src/table-style.test.ts
+++ b/packages/xlsx/src/table-style.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { tableOverlayBorder, type TableCellStyle } from './renderer.js';
+import type { Dxf } from './types.js';
+
+/**
+ * Regression tests for spurious table borders on *custom* `<tableStyle>`s
+ * (ECMA-376 §18.8.83 / §18.5.1.2).
+ *
+ * A custom style contributes only the dxfs of its declared
+ * `<tableStyleElement>`s. When none of those dxfs define a border, Excel draws
+ * no table-level border at all — the only structure lines come from theme
+ * borders baked into each cell `xf`. The renderer previously synthesized
+ * accent-colored rules in that case (an approximation meant only for built-in
+ * `TableStyle{Light,Medium,Dark}N` styles whose definitions are absent from the
+ * file), which produced gray lines Excel never draws (sample-6 B23:E23 etc.).
+ */
+
+function cell(overrides: Partial<TableCellStyle>): TableCellStyle {
+  return {
+    accent: '#808080',
+    isCustom: false,
+    isHeader: false,
+    isTotals: false,
+    isBanded: false,
+    isFirstCol: false,
+    isLastCol: false,
+    isTopEdge: false,
+    isBottomEdge: false,
+    ...overrides,
+  };
+}
+
+const borderDxf: Dxf = {
+  font: null,
+  fill: null,
+  border: { left: null, right: null, top: null, bottom: { style: 'thin', color: '#000000' } },
+};
+
+describe('tableOverlayBorder', () => {
+  it('custom style with no border dxf draws nothing (no accent synthesis)', () => {
+    // sample-6: custom "交通費" header row, dxf has fill only, no border.
+    const ts = cell({ isCustom: true, isHeader: true, isTopEdge: true });
+    const overlay = tableOverlayBorder(ts, undefined, undefined, 0);
+    expect(overlay.kind).toBe('none');
+  });
+
+  it('custom style with no border dxf on a data row draws nothing', () => {
+    const ts = cell({ isCustom: true, isBanded: true });
+    const overlay = tableOverlayBorder(ts, undefined, undefined, 2);
+    expect(overlay.kind).toBe('none');
+  });
+
+  it('custom style WITH a header-row border dxf draws that border', () => {
+    const ts = cell({ isCustom: true, isHeader: true });
+    const overlay = tableOverlayBorder(ts, undefined, borderDxf, 0);
+    expect(overlay.kind).toBe('dxf');
+    if (overlay.kind === 'dxf') {
+      expect(overlay.border.bottom?.style).toBe('thin');
+    }
+  });
+
+  it('built-in style with no border dxf still synthesizes accent rules', () => {
+    // Built-in TableStyleLight* etc. are not in the file; the accent
+    // approximation must remain until we ship a real preset catalog.
+    const ts = cell({ isCustom: false, isHeader: true, isTopEdge: true, accent: '#4472C4' });
+    const overlay = tableOverlayBorder(ts, undefined, undefined, 0);
+    expect(overlay.kind).toBe('accent');
+    if (overlay.kind === 'accent') {
+      expect(overlay.color).toBe('#4472C4');
+      expect(overlay.topEdge).toBe(true);
+    }
+  });
+});

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -154,13 +154,29 @@ export interface TableInfo {
   /** Accent color resolved by the parser from the built-in style name against
    *  the file's theme accents (e.g. `TableStyleLight18` → accent3). */
   accentColor: string;
+  /** `true` when `styleName` is defined in the file's `<tableStyles>` block,
+   *  i.e. a *custom* style (ECMA-376 §18.5.1.2). The renderer draws such tables
+   *  strictly from their declared element dxfs and must NOT apply the accent
+   *  approximation (banding / synthesized rules / header) reserved for built-in
+   *  style names whose definitions are absent from the file. */
+  isCustom?: boolean;
   /** Dxf index for the `wholeTable` element of a custom `<tableStyle>`
-   *  (ECMA-376 §18.8.40). When set, its border/fill apply to every cell of
+   *  (ECMA-376 §18.8.83). When set, its border/fill apply to every cell of
    *  the table as a base layer. Undefined for built-in style names. */
   wholeTableDxf?: number;
   /** Dxf index for the `headerRow` element of a custom `<tableStyle>` —
    *  provides header background, font color/weight, and vertical separators. */
   headerRowDxf?: number;
+  /** Dxf index for the `totalRow` element (ECMA-376 §18.18.93). */
+  totalRowDxf?: number;
+  /** Dxf index for the `firstColumn` element. */
+  firstColumnDxf?: number;
+  /** Dxf index for the `lastColumn` element. */
+  lastColumnDxf?: number;
+  /** Dxf index for `firstRowStripe` (band1 horizontal) — odd banded-row stripe. */
+  band1HorizontalDxf?: number;
+  /** Dxf index for `secondRowStripe` (band2 horizontal) — even banded-row stripe. */
+  band2HorizontalDxf?: number;
   /** Per-column DXF references (ECMA-376 §18.5.1.3 `tableColumn`). Index by
    *  `cellCol - range.left`. The renderer can use these to apply column-level
    *  overlays for named-style tables; for files where Excel pre-bakes the


### PR DESCRIPTION
## Problem

`private/sample-6.xlsx` renders spurious gray/black borders that Excel does not draw: above/below **B23:E23** (header row of custom table 交通費) and below **B12/D12/E12** (data row of custom table 住居費).

## Root cause

Both tables use **custom** `<tableStyle>`s (予算, 交通費) that declare only `headerRow` / `totalRow` / `firstColumn` dxfs, **none of which define a border** (dxf 158 carries a solid fill `#D0DE4E` + font color only). Per ECMA-376 §18.5.1.2 / §18.8.83 a custom style contributes only what its declared elements define, so Excel draws no table-level border — the faint structure lines come from theme borders baked into each cell `xf` (already rendered).

The renderer's table overlay fell into an **accent-color synthesis** path (`#808080` rule under every row + thick header underline) whenever the resolved dxfs had no border. That path is an approximation reserved for built-in `TableStyle{Light,Medium,Dark}N` names (catalog not shipped), but it was firing for custom styles too.

## Fix (spec-faithful, no heuristics)

**Parser** (`table.rs` / `types.rs`):
- Expand `TableStyleElements` to the 7 region element types: wholeTable, headerRow, totalRow, firstColumn, lastColumn, firstRowStripe(band1), secondRowStripe(band2) — ST_TableStyleType §18.18.93.
- Add `is_custom` (style name present in `<tableStyles>`) + the new element dxf ids to `TableInfo`.

**Renderer** (`renderer.ts` / `types.ts`):
- `TableCellStyle.isCustom`; new pure `tableOverlayBorder()` returning `none` for custom+no-border, `dxf` when a border dxf exists, `accent` only for built-in names.
- Resolve table fill / bold / font color from the element-dxf hierarchy (wholeTable < band < column < header/total, §18.8.83). Accent banding and synthesized bold gated on `!isCustom`.

Built-in style names (e.g. `TableStyleLight18`, sample-8) keep the accent approximation unchanged.

## Verification

- New unit test `table-style.test.ts` for the overlay decision (Red → Green).
- `pnpm typecheck` clean; 42 xlsx unit tests pass; `cargo test -p xlsx-parser` 16 pass.
- Parser on sample-6: all tables `isCustom:true`, referenced dxfs have `border:null` ⇒ overlay returns `none`; dxf 158 fill/font still honored.
- Before/after screenshots confirm the gray accent rules disappear on sample-6; sample-8 (built-in) accent approximation is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)