### PR TITLE
feat(pptx): render picture effects (effectLst on p:pic)

### DIFF
--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -244,18 +244,23 @@ export function applyReflection(
   c.restore();
 
   // 2. Fade with a vertical alpha gradient over the shape's bbox band.
-  //    Map stPos/endPos (0..1 along the ramp) to the bbox top..bottom.
+  //    ECMA-376 §20.1.8.50: stA/stPos is the alpha at the START of the
+  //    reflection (the edge touching the shape) and endA/endPos the END (the
+  //    far edge). The reflection is mirrored about the bottom edge (step 3), so
+  //    its START maps to the shape's BOTTOM row in this un-mirrored aux and its
+  //    END maps upward toward the top. Build the ramp from the bottom up so the
+  //    opaque stA band sits at `bottom` (→ reflection top after the flip) and
+  //    fades to endA toward `top` — otherwise the visible band lands far below
+  //    the shape (off-canvas for tall pictures) and the reflection disappears.
   c.save();
   c.globalCompositeOperation = 'destination-in';
   const top = bbox.y;
   const bottom = bbox.y + bbox.h;
-  const grad = c.createLinearGradient(0, top, 0, bottom);
+  const grad = c.createLinearGradient(0, bottom, 0, top);
   const stPos = clamp01(reflection.stPos);
   const endPos = clamp01(reflection.endPos);
-  // Guard equal stops (createLinearGradient requires strictly increasing offsets
-  // only loosely, but identical offsets collapse the ramp). stA applies before
-  // stPos, endA after endPos — pad the ends so the band outside [stPos,endPos]
-  // holds the terminal alpha.
+  // Offsets run 0→1 from `bottom` to `top` (the createLinearGradient axis).
+  // stA holds from the bottom edge up to stPos; endA holds from endPos onward.
   grad.addColorStop(0, `rgba(0,0,0,${reflection.stA})`);
   if (stPos > 0) grad.addColorStop(stPos, `rgba(0,0,0,${reflection.stA})`);
   if (endPos < 1 && endPos > stPos) grad.addColorStop(endPos, `rgba(0,0,0,${reflection.endA})`);

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -797,6 +797,23 @@ struct PictureElement {
     /// None when the picture is a plain rectangle.
     #[serde(skip_serializing_if = "Option::is_none")]
     cust_geom: Option<Vec<Vec<PathCmd>>>,
+    /// Drop shadow from spPr > effectLst > outerShdw. ECMA-376 §20.1.8.45.
+    /// `p:spPr` is CT_ShapeProperties for pictures too (§19.3.1.37), so the
+    /// same effects a shape carries apply to images.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shadow: Option<Shadow>,
+    /// Inner (inset) shadow from spPr > effectLst > innerShdw. §20.1.8.40.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inner_shadow: Option<Shadow>,
+    /// Coloured glow halo from spPr > effectLst > glow. §20.1.8.32.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    glow: Option<Glow>,
+    /// Soft (feathered) edge from spPr > effectLst > softEdge. §20.1.8.53.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    soft_edge: Option<SoftEdge>,
+    /// Mirrored reflection from spPr > effectLst > reflection. §20.1.8.50.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reflection: Option<Reflection>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -1964,6 +1981,33 @@ fn parse_reflection(effect_lst: roxmltree::Node<'_, '_>) -> Option<Reflection> {
         sx: pct("sx", 1.0),
         sy: pct("sy", -1.0),
     })
+}
+
+/// Effects pulled from `spPr > effectLst`. The five members are independent
+/// siblings inside `CT_EffectList` — ECMA-376 §20.1.8.16. Used by both shapes
+/// (`p:sp`) and pictures (`p:pic`): `p:spPr` is `CT_ShapeProperties` in both
+/// cases (§19.3.1.37), so `effectLst` applies equally to images.
+struct EffectLst {
+    shadow: Option<Shadow>,
+    inner_shadow: Option<Shadow>,
+    glow: Option<Glow>,
+    soft_edge: Option<SoftEdge>,
+    reflection: Option<Reflection>,
+}
+
+/// Read every `effectLst` child shapes and pictures share. `effect_lst` is the
+/// optional `<a:effectLst>` node; missing nodes yield an all-`None` result.
+fn parse_effect_lst(
+    effect_lst: Option<roxmltree::Node<'_, '_>>,
+    theme: &HashMap<String, String>,
+) -> EffectLst {
+    EffectLst {
+        shadow: effect_lst.and_then(|n| parse_shadow(n, theme)),
+        inner_shadow: effect_lst.and_then(|n| parse_inner_shadow(n, theme)),
+        glow: effect_lst.and_then(|n| parse_glow(n, theme)),
+        soft_edge: effect_lst.and_then(parse_soft_edge),
+        reflection: effect_lst.and_then(parse_reflection),
+    }
 }
 
 // ===========================
@@ -5478,12 +5522,13 @@ fn parse_shape(
 
     // Effects from spPr > effectLst (outerShdw / innerShdw / glow / softEdge /
     // reflection are independent siblings — ECMA-376 §20.1.8.16). Pull each.
-    let effect_lst = sp_pr.and_then(|p| child(p, "effectLst"));
-    let shadow = effect_lst.and_then(|n| parse_shadow(n, theme));
-    let inner_shadow = effect_lst.and_then(|n| parse_inner_shadow(n, theme));
-    let glow = effect_lst.and_then(|n| parse_glow(n, theme));
-    let soft_edge = effect_lst.and_then(parse_soft_edge);
-    let reflection = effect_lst.and_then(parse_reflection);
+    let EffectLst {
+        shadow,
+        inner_shadow,
+        glow,
+        soft_edge,
+        reflection,
+    } = parse_effect_lst(sp_pr.and_then(|p| child(p, "effectLst")), theme);
 
     Some(ShapeElement {
         x: t.x,
@@ -5528,6 +5573,7 @@ fn parse_picture(
     pic_node: roxmltree::Node<'_, '_>,
     slide_dir: &str,
     rels: &HashMap<String, String>,
+    theme: &HashMap<String, String>,
     zip: &mut PptxZip<'_>,
 ) -> Option<PictureElement> {
     let sp_pr = child(pic_node, "spPr")?;
@@ -5554,6 +5600,16 @@ fn parse_picture(
     // build a Path2D and `ctx.clip()` before drawing the image.
     let cust_geom = child(sp_pr, "custGeom").map(parse_cust_geom);
 
+    // §19.3.1.37: p:pic's spPr is CT_ShapeProperties, so effectLst (§20.1.8.16)
+    // applies to images exactly as it does to shapes.
+    let EffectLst {
+        shadow,
+        inner_shadow,
+        glow,
+        soft_edge,
+        reflection,
+    } = parse_effect_lst(child(sp_pr, "effectLst"), theme);
+
     Some(PictureElement {
         x: t.x,
         y: t.y,
@@ -5567,6 +5623,11 @@ fn parse_picture(
         src_rect: parse_src_rect(blip_fill),
         alpha: parse_blip_alpha(blip_fill),
         cust_geom,
+        shadow,
+        inner_shadow,
+        glow,
+        soft_edge,
+        reflection,
     })
 }
 
@@ -6565,6 +6626,18 @@ fn parse_sp_tree_node(
                                 let cust_geom = sp_pr_node
                                     .and_then(|p| child(p, "custGeom"))
                                     .map(parse_cust_geom);
+                                // §20.1.8.16 effectLst applies to a sp painted as
+                                // a picture (blipFill) just like a regular p:pic.
+                                let EffectLst {
+                                    shadow,
+                                    inner_shadow,
+                                    glow,
+                                    soft_edge,
+                                    reflection,
+                                } = parse_effect_lst(
+                                    sp_pr_node.and_then(|p| child(p, "effectLst")),
+                                    theme,
+                                );
                                 out.push(SlideElement::Picture(PictureElement {
                                     x: t.x,
                                     y: t.y,
@@ -6578,6 +6651,11 @@ fn parse_sp_tree_node(
                                     src_rect: blip_fill_node.and_then(parse_src_rect),
                                     alpha: blip_fill_node.and_then(parse_blip_alpha),
                                     cust_geom,
+                                    shadow,
+                                    inner_shadow,
+                                    glow,
+                                    soft_edge,
+                                    reflection,
                                 }));
                                 return;
                             }
@@ -6613,6 +6691,11 @@ fn parse_sp_tree_node(
                                     src_rect: bf.src_rect,
                                     alpha: bf.alpha,
                                     cust_geom: None,
+                                    shadow: None,
+                                    inner_shadow: None,
+                                    glow: None,
+                                    soft_edge: None,
+                                    reflection: None,
                                 }));
                                 return;
                             }
@@ -6627,7 +6710,7 @@ fn parse_sp_tree_node(
         "pic" => {
             if let Some(media) = parse_media(node, slide_dir, rels) {
                 out.push(SlideElement::Media(media));
-            } else if let Some(pic) = parse_picture(node, slide_dir, rels, zip) {
+            } else if let Some(pic) = parse_picture(node, slide_dir, rels, theme, zip) {
                 out.push(SlideElement::Picture(pic));
             } else {
                 // Placeholder pic: no xfrm in spPr — position comes from layout by_idx
@@ -6662,6 +6745,11 @@ fn parse_sp_tree_node(
                                         src_rect: blip_fill.and_then(parse_src_rect),
                                         alpha: blip_fill.and_then(parse_blip_alpha),
                                         cust_geom: None,
+                                        shadow: None,
+                                        inner_shadow: None,
+                                        glow: None,
+                                        soft_edge: None,
+                                        reflection: None,
                                     }));
                                 }
                             }
@@ -7859,6 +7947,64 @@ mod tests {
         assert!((r.sy + 1.0).abs() < 0.01);
         // sx defaults to 1.0 when not specified
         assert!((r.sx - 1.0).abs() < 0.01);
+    }
+
+    /// §19.3.1.37 — a p:pic's spPr is CT_ShapeProperties, so every effectLst
+    /// child (§20.1.8.16) applies to images. parse_effect_lst is the shared
+    /// reader both p:sp and p:pic use; exercise it with the reflection-bearing
+    /// effectLst lifted from sample-11's `図 3` picture.
+    #[test]
+    fn test_pic_effect_lst_resolves_all_effects() {
+        let xml = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <effectLst>
+                <outerShdw blurRad="50800" dist="38100" dir="2700000"><srgbClr val="000000"><alpha val="40000"/></srgbClr></outerShdw>
+                <innerShdw blurRad="63500" dist="50800" dir="5400000"><srgbClr val="111111"/></innerShdw>
+                <glow rad="63500"><srgbClr val="FFCC00"/></glow>
+                <softEdge rad="25400"/>
+                <reflection blurRad="12700" stA="38000" endPos="28000" dist="5000" dir="5400000" sy="-100000" algn="bl" rotWithShape="0"/>
+            </effectLst>
+        </spPr>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::new();
+        let sp_pr = doc.root_element();
+        let eff = parse_effect_lst(child(sp_pr, "effectLst"), &theme);
+
+        let shadow = eff.shadow.expect("outerShdw should resolve");
+        assert_eq!(shadow.blur, 50_800);
+        assert_eq!(shadow.dist, 38_100);
+        assert!((shadow.alpha - 0.4).abs() < 0.01);
+
+        let inner = eff.inner_shadow.expect("innerShdw should resolve");
+        assert_eq!(inner.blur, 63_500);
+
+        let glow = eff.glow.expect("glow should resolve");
+        assert_eq!(glow.radius, 63_500);
+        assert_eq!(glow.color, "FFCC00");
+
+        let soft = eff.soft_edge.expect("softEdge should resolve");
+        assert_eq!(soft.radius, 25_400);
+
+        let r = eff.reflection.expect("reflection should resolve");
+        assert_eq!(r.blur, 12_700);
+        assert_eq!(r.dist, 5_000);
+        assert!((r.dir - 90.0).abs() < 0.001);
+        assert!((r.st_a - 0.38).abs() < 0.01);
+        assert!((r.end_pos - 0.28).abs() < 0.01);
+        assert!((r.sy + 1.0).abs() < 0.01);
+    }
+
+    /// A spPr with no effectLst yields an all-None EffectLst (the common case).
+    #[test]
+    fn test_pic_effect_lst_empty_when_absent() {
+        let xml = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"/>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::new();
+        let eff = parse_effect_lst(child(doc.root_element(), "effectLst"), &theme);
+        assert!(eff.shadow.is_none());
+        assert!(eff.inner_shadow.is_none());
+        assert!(eff.glow.is_none());
+        assert!(eff.soft_edge.is_none());
+        assert!(eff.reflection.is_none());
     }
 
     /// ECMA-376 §20.1.8.42 — `<a:ln cmpd="dbl"/>` should round-trip.

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2028,25 +2028,13 @@ async function renderPicture(
       if (el.flipV) ctx.scale(1, -1);
       ctx.translate(-(x + w / 2), -(y + h / 2));
     }
-    if (el.clipAdjust != null) {
-      const minDim = Math.min(w, h);
-      const r = (el.clipAdjust / 100000) * minDim;
-      ctx.beginPath();
-      ctx.roundRect(x, y, w, h, r);
-      ctx.clip();
-    } else if (el.custGeom && el.custGeom.length > 0) {
-      // ECMA-376 §20.1.9.8: a `<p:pic>` may carry `<a:custGeom>` (the same
-      // path model as a shape) that defines a non-rectangular silhouette.
-      // The bitmap is then trimmed to that path — e.g. the laptop frame on
-      // sample-2 slide-12 keeps the surrounding bezel visible because the
-      // image is clipped to just the screen + body shape.
-      buildCustomPath(ctx, el.custGeom, x, y, w, h);
-      ctx.clip();
-    }
-    // ECMA-376 a:srcRect — draw a sub-rectangle of the source image.
-    // Edge values are fractions of source dims (negative values mean extend past
-    // the image, which in OOXML duplicates edge pixels; we clamp to [0,1]).
+
+    // ── srcRect sub-rectangle (ECMA-376 a:srcRect). Edge values are fractions
+    // of source dims (negative values mean extend past the image, duplicating
+    // edge pixels in OOXML; we clamp to [0,1]). Resolve once so both the live
+    // paint and the effect aux paints share identical crop coordinates.
     const sr = el.srcRect;
+    let crop: { sx: number; sy: number; sw: number; sh: number } | null = null;
     if (sr && (sr.l || sr.t || sr.r || sr.b)) {
       const bw = bitmap.width, bh = bitmap.height;
       const sl = Math.max(0, Math.min(1, sr.l ?? 0));
@@ -2055,12 +2043,118 @@ async function renderPicture(
       const sbB = Math.max(0, Math.min(1, sr.b ?? 0));
       const sx = sl * bw;
       const sy = st * bh;
-      const sw = Math.max(1, bw - sx - srR * bw);
-      const sh = Math.max(1, bh - sy - sbB * bh);
-      ctx.drawImage(bitmap, sx, sy, sw, sh, x, y, w, h);
-    } else {
-      ctx.drawImage(bitmap, x, y, w, h);
+      crop = {
+        sx,
+        sy,
+        sw: Math.max(1, bw - sx - srR * bw),
+        sh: Math.max(1, bh - sy - sbB * bh),
+      };
     }
+
+    // Apply the picture clip (roundRect / custGeom) to an arbitrary target.
+    // ECMA-376 §20.1.9.8: a `<p:pic>` may carry `<a:custGeom>` defining a
+    // non-rectangular silhouette the bitmap is trimmed to (e.g. a laptop frame).
+    const applyClip = (target: CanvasRenderingContext2D): void => {
+      if (el.clipAdjust != null) {
+        const minDim = Math.min(w, h);
+        const r = (el.clipAdjust / 100000) * minDim;
+        target.beginPath();
+        target.roundRect(x, y, w, h, r);
+        target.clip();
+      } else if (el.custGeom && el.custGeom.length > 0) {
+        buildCustomPath(target, el.custGeom, x, y, w, h);
+        target.clip();
+      }
+    };
+
+    // Draw the (clipped, optionally cropped) bitmap into a target context. This
+    // is the picture "body" that the effect helpers re-paint onto aux canvases,
+    // so reflections/soft edges mirror the real image rather than a flat shape.
+    const paintImage = (target: CanvasRenderingContext2D): void => {
+      target.save();
+      applyClip(target);
+      if (crop) {
+        target.drawImage(bitmap, crop.sx, crop.sy, crop.sw, crop.sh, x, y, w, h);
+      } else {
+        target.drawImage(bitmap, x, y, w, h);
+      }
+      target.restore();
+    };
+
+    // Flat opaque silhouette of the clipped picture rectangle, used as the mask
+    // for innerShdw / softEdge. Falls back to the bounding rect when the picture
+    // is a plain rectangle (no clip path).
+    const paintMask = (target: CanvasRenderingContext2D, color: string): void => {
+      target.save();
+      applyClip(target);
+      target.fillStyle = color;
+      target.fillRect(x, y, w, h);
+      target.restore();
+    };
+
+    // ── effectLst (§19.3.1.37 routes p:pic's spPr through CT_ShapeProperties,
+    // so §20.1.8.16 effects apply to images). Same sequence as the p:sp path.
+    const deviceW = (ctx.canvas as { width: number }).width || 0;
+    const deviceH = (ctx.canvas as { height: number }).height || 0;
+    const liveTransform = ctx.getTransform();
+    const det = Math.abs(
+      liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c,
+    );
+    const devScale = det > 0 ? Math.sqrt(det) : 1;
+    const effBBox = { x: x * devScale, y: y * devScale, w: w * devScale, h: h * devScale };
+    const effScale = scale * devScale; // EMU → device px
+    const applyLiveTransform = (c: CanvasRenderingContext2D) => c.setTransform(liveTransform);
+    const haveAux = deviceW > 0 && deviceH > 0;
+
+    // Reflection sits below the picture — paint it first. §20.1.8.50. The aux
+    // paint bakes in the live rotation/flip via setTransform, so the blit runs
+    // at identity.
+    if (el.reflection && haveAux) {
+      ctx.save();
+      ctx.setTransform(new DOMMatrix());
+      applyReflection(
+        ctx,
+        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintImage(c as CanvasRenderingContext2D); },
+        effBBox, el.reflection, effScale, deviceW, deviceH,
+      );
+      ctx.restore();
+    }
+
+    // outerShdw / glow use the single Canvas shadow slot, cast by the image's
+    // own opaque pixels. Outer shadow wins when both are present (as in p:sp).
+    if (el.shadow) applyShadow(ctx, el.shadow, scale);
+    else if (el.glow) applyGlow(ctx, el.glow, scale);
+
+    // softEdge feathers the whole picture, REPLACING the direct body paint
+    // (§20.1.8.53). The shadow/glow set above is carried into the aux paint via
+    // setTransform of the same live context, so it still casts.
+    if (el.softEdge && haveAux) {
+      ctx.save();
+      ctx.setTransform(new DOMMatrix());
+      applySoftEdge(
+        ctx,
+        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintImage(c as CanvasRenderingContext2D); },
+        effBBox, el.softEdge, effScale, deviceW, deviceH,
+        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintMask(c as CanvasRenderingContext2D, '#000'); },
+      );
+      ctx.restore();
+    } else {
+      paintImage(ctx);
+    }
+    if (el.shadow || el.glow) clearShadow(ctx);
+
+    // innerShdw casts inward, on top of the picture (§20.1.8.40).
+    if (el.innerShadow && haveAux) {
+      ctx.save();
+      ctx.setTransform(new DOMMatrix());
+      applyInnerShadow(
+        ctx,
+        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintMask(c as CanvasRenderingContext2D, '#000'); },
+        effBBox, el.innerShadow, effScale, deviceW, deviceH,
+      );
+      ctx.restore();
+    }
+
     ctx.restore();
     // bitmap is owned by getCachedBitmap's cache — do not close it here.
   } catch {

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -294,6 +294,20 @@ export interface PictureElement {
    * trimmed to the laptop / device silhouette declared in the file.
    */
   custGeom?: PathCmd[][] | null;
+  /**
+   * Drop shadow from `spPr > effectLst > outerShdw`. A `p:pic`'s `spPr` is
+   * `CT_ShapeProperties` (ECMA-376 §19.3.1.37), so the same effects shapes
+   * carry apply to images. ECMA-376 §20.1.8.45 (CT_OuterShadowEffect).
+   */
+  shadow?: Shadow;
+  /** Inner (inset) shadow from effectLst > innerShdw. ECMA-376 §20.1.8.40. */
+  innerShadow?: Shadow;
+  /** Coloured glow halo from effectLst > glow. ECMA-376 §20.1.8.32. */
+  glow?: Glow;
+  /** Soft (feathered) edge from effectLst > softEdge. ECMA-376 §20.1.8.53. */
+  softEdge?: SoftEdge;
+  /** Mirrored reflection from effectLst > reflection. ECMA-376 §20.1.8.50. */
+  reflection?: Reflection;
 }
 
 // ===== Worker message protocol =====


### PR DESCRIPTION
## Summary

`private/sample-11.pptx` slide 1 has a picture (`図 3`) with a `reflection` effect that was never drawn: the pptx parser read `spPr > effectLst` only on the **shape** (`p:sp`) path and ignored it entirely for `p:pic`, and `PictureElement` carried no effect fields.

`p:pic`'s `spPr` is `CT_ShapeProperties` (ECMA-376 §19.3.1.37), identical to `p:sp`, so `effectLst` (§20.1.8.16) applies to images exactly as to shapes.

## Changes

**Parser** (`packages/pptx/parser/src/lib.rs`)
- Added a shared `EffectLst` struct + `parse_effect_lst()` reader (outerShdw / innerShdw / glow / softEdge / reflection — §20.1.8.16 siblings), refactored the `p:sp` path onto it.
- `parse_picture` now takes `theme` and populates the five effect fields; the `sp`-as-picture (`blipFill`) path reads its `effectLst` too. Serde names match `ShapeElement`.
- Rust unit tests for the pic effectLst reader (all five effects + empty case).

**TS types** (`packages/pptx/src/types.ts`)
- `PictureElement` += `shadow` / `innerShadow` / `glow` / `softEdge` / `reflection` (§20.1.8.45 / 40 / 32 / 53 / 50). Effect types already exported; export-completeness test passes.

**Renderer** (`packages/pptx/src/renderer.ts`)
- `renderPicture` applies the five effects, reusing core's `applyInnerShadow` / `applySoftEdge` / `applyReflection` and the `p:sp` outerShdw/glow pattern.
- The reflection / softEdge `PaintShape` callbacks **re-draw the clipped bitmap itself** so a mirrored photo reflects the real image (not a flat silhouette); innerShdw / softEdge masks use the clip-path silhouette.
- Effect order follows the `effectLst` sequence (§20.1.8.16): reflection → outerShdw/glow → softEdge → innerShdw. Clip (roundRect / custGeom), rotation and flip compose with effects via the shared live transform.

**core** (`packages/core/src/shape/effects.ts`)
- Fixed `applyReflection`'s alpha gradient orientation: it ran top→bottom, so after the bottom-edge mirror the opaque `stA` band landed at the far edge — off-canvas for tall elements, making the reflection invisible. Now ramps from the shape edge (§20.1.8.50). This also corrects `p:sp` reflections.

## Verification

- Rust unit tests, full TS unit suite (191), `tsc --build`, `cargo clippy -D warnings`, `cargo fmt --check` all green.
- Storybook + Playwright on sample-11 slide 1: the faded mirror now renders below the magazine, opaque at the bottom edge fading downward to transparent (stA 38% → endPos 28%, downward, bottom-left anchor).
- pptx VRT: 9 demo references (sample-1, includes pictures) all pass → no regression on effect-free image rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)