### PR TITLE
fix(xlsx): re-anchor RTL scroll position when the host is resized

### DIFF
--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -163,6 +163,17 @@ export class XlsxViewer {
   private currentWorksheet: Worksheet | null = null;
   private opts: XlsxViewerOptions;
   private resizeObserver: ResizeObserver | null = null;
+  /**
+   * Start-anchored horizontal scroll position (the {@link effectiveScrollLeft}
+   * value last produced by a real user scroll or a programmatic reset), kept
+   * as the source of truth across container size changes. The native
+   * `scrollLeft` cannot serve that role for RTL sheets (ECMA-376 §18.3.1.87):
+   * it is the *inverse* of the start-anchored offset, and the browser clamps
+   * any assignment to 0 while the host is unlaid-out (`display:none` mount —
+   * e.g. a host revealed only after `load()` resolves), which would otherwise
+   * strand the view at the sheet's far end once the host gains its real size.
+   */
+  private effectiveH = 0;
 
   // Selection state
   private anchorCell: CellAddress | null = null;
@@ -266,12 +277,23 @@ export class XlsxViewer {
     container.appendChild(wrapper);
 
     this.scrollHost.addEventListener('scroll', () => {
+      // Track the start-anchored position, but only while the host is laid
+      // out: a hidden host reports clientWidth 0 and fires bogus scroll
+      // events when the browser clamps scrollLeft, which must not overwrite
+      // the last real position.
+      if (this.scrollHost.clientWidth > 0) {
+        this.effectiveH = this.effectiveScrollLeft;
+      }
       this.renderCurrentSheet();
       this.updateSelectionOverlay();
     });
 
-    // Re-render whenever the canvas area changes size
+    // Re-render whenever the canvas area changes size. Re-anchor first: a
+    // size change shifts maxScrollLeft, and for RTL sheets the native
+    // scrollLeft must be re-derived from the start-anchored position or the
+    // view drifts (or, after a hidden mount, stays stranded at the far end).
     this.resizeObserver = new ResizeObserver(() => {
+      this.reanchorHorizontalScroll();
       this.renderCurrentSheet();
       this.updateSelectionOverlay();
       this.updateNavButtons();
@@ -381,7 +403,20 @@ export class XlsxViewer {
   /** Park the scrollbar at the sheet's natural start: scrollLeft=0 for LTR,
    *  the right end for RTL (so col A shows first). */
   private resetHorizontalScroll(): void {
+    this.effectiveH = 0;
     this.scrollHost.scrollLeft = this.isRtl ? this.maxScrollLeft : 0;
+  }
+
+  /** Re-derive the native scrollLeft from the tracked start-anchored
+   *  position after the scroll host's size changes. Only RTL needs this:
+   *  for LTR the native scrollLeft *is* start-anchored and the browser
+   *  already clamps it sensibly on resize. */
+  private reanchorHorizontalScroll(): void {
+    if (!this.isRtl || this.scrollHost.clientWidth === 0) return;
+    const want = Math.max(0, this.maxScrollLeft - this.effectiveH);
+    if (Math.abs(this.scrollHost.scrollLeft - want) > 1) {
+      this.scrollHost.scrollLeft = want;
+    }
   }
 
   /** 0-based index of the currently displayed sheet. */
@@ -1173,6 +1208,7 @@ export class XlsxViewer {
       // the view would jump toward the start on every zoom step.
       const prevEffective = this.effectiveScrollLeft;
       this.updateSpacerSize(this.currentWorksheet);
+      this.effectiveH = prevEffective;
       if (this.isRtl) {
         this.scrollHost.scrollLeft = Math.max(0, this.maxScrollLeft - prevEffective);
       }


### PR DESCRIPTION
## Problem

Opening an RTL sheet (`sheetView rightToLeft`, ECMA-376 §18.3.1.87) through the showcase site's **try** page left the initial view at the top-**left** (the sheet's far end) instead of the top-right where column A lives.

## Root cause

`try.astro` hides the result panel while the file renders and reveals it after `load()` resolves — a legitimate usage pattern. While the scroll host is `display:none`, the browser clamps the RTL park assignment `scrollLeft = maxScrollLeft` to 0, and the `ResizeObserver` only re-rendered on reveal without re-anchoring, stranding the view at the sheet's far end.

## Fix

Track the start-anchored horizontal scroll position as the source of truth (updated on real user scrolls only; clamp-induced scroll events from an unlaid-out host with `clientWidth === 0` are ignored) and re-derive the native `scrollLeft` from it whenever the host's size changes. LTR sheets are unaffected.

## Verification (real user flow via `site dev`, Playwright upload to /try)

- RTL sample-29 without fix: `scrollLeft: 0 / max: 1358` (stranded left — reproduces the report)
- RTL sample-29 with fix: `scrollLeft: 1358 / max: 1358` (parked top-right)
- LTR sample-6: `scrollLeft: 0` (unchanged)
- Visible-mount RTL via Storybook story: parked right (unchanged)
- `pnpm test` 191/191 green, `pnpm typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)