### PR TITLE
feat(pptx): DrawingML 3D camera perspective projection (scene3d, Phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,8 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Inner shadow (`innerShdw`) | ✅ |
 | | Soft edge (`softEdge`) | ✅ |
 | | Reflection (`reflection`) | ✅ |
-| | Bevel / 3D extrusion | ❌ |
+| | 3D camera / perspective projection (`scene3d` camera + `rot`) on pictures | ✅ |
+| | Bevel / 3D extrusion (`sp3d`) | ⚠️ parsed; rendering planned |
 | **Text — characters** | Bold, italic, strikethrough (incl. `dblStrike`) | ✅ |
 | | Underline styles (`sng` / `dbl` / `dotted` / `dash` / `dashLong` / `dotDash` / `dotDotDash` / `wavy` / `wavyDbl` and `*Heavy` variants) | ✅ |
 | | Per-run underline colour (`uFill` / `uFillTx`) | ✅ |

--- a/README.md
+++ b/README.md
@@ -512,13 +512,15 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Dash / dot styles | ✅ |
 | | Arrow heads (`headEnd` / `tailEnd`) | ✅ |
 | | Compound / double lines (`<a:ln cmpd="dbl|thinThick|thickThin|tri">` — straight connectors) | ✅ |
+| | Picture border (`a:ln` on `p:pic`) — stroked along the clip silhouette | ✅ |
 | **Shape effects** | Drop shadow (`outerShdw`) | ✅ |
 | | Glow (`glow` — radius + colour) | ✅ |
 | | Inner shadow (`innerShdw`) | ✅ |
 | | Soft edge (`softEdge`) | ✅ |
 | | Reflection (`reflection`) | ✅ |
 | | 3D camera / perspective projection (`scene3d` camera + `rot`) on pictures | ✅ |
-| | Bevel / 3D extrusion (`sp3d`) | ⚠️ parsed; rendering planned |
+| | 3D contour edge (`sp3d` `contourW` / `contourClr`) on pictures — flat approximation, no bevel shading | ⚠️ |
+| | Bevel / 3D extrusion (`sp3d` `bevelT` / `bevelB` / `extrusionH`) | ⚠️ parsed; rendering planned |
 | **Text — characters** | Bold, italic, strikethrough (incl. `dblStrike`) | ✅ |
 | | Underline styles (`sng` / `dbl` / `dotted` / `dash` / `dashLong` / `dotDash` / `dotDotDash` / `wavy` / `wavyDbl` and `*Heavy` variants) | ✅ |
 | | Per-run underline colour (`uFill` / `uFillTx`) | ✅ |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,18 @@ export {
   type PaintShape,
   type EffectBBox,
 } from './shape/effects';
+// DrawingML 3D camera perspective projection (Phase A — planar homography).
+// ECMA-376 §20.1.5.5 (camera) / §20.1.5.11 (rot). sp3d / lightRig shading is
+// Phase B and not implemented here.
+export {
+  computeScene3dQuad,
+  isScene3dNonIdentity,
+  type CameraInput,
+  type RotInput,
+  type Scene3dQuad,
+  type Vec2,
+} from './shape/scene3d-camera';
+export { drawProjected } from './shape/scene3d-draw';
 export {
   renderSparkline,
   type SparklineKind,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/prese
 export {
   renderPresetShape,
   hasPreset,
+  buildPresetGeometryPath,
   getConnectorAnchors,
 } from './shape/preset-geometry';
 export { type PresetPath } from './shape/preset-geometry/path-executor';

--- a/packages/core/src/shape/__snapshots__/scene3d-camera.test.ts.snap
+++ b/packages/core/src/shape/__snapshots__/scene3d-camera.test.ts.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`computeScene3dQuad > snapshot — sample-11 slide-3 camera (perspectiveRelaxed lat330 lon20 rev347) 1`] = `
+[
+  {
+    "x": 35.62,
+    "y": 102.57,
+  },
+  {
+    "x": 357.71,
+    "y": 0,
+  },
+  {
+    "x": 364.38,
+    "y": 184.46,
+  },
+  {
+    "x": 140.77,
+    "y": 300,
+  },
+]
+`;

--- a/packages/core/src/shape/__snapshots__/scene3d-camera.test.ts.snap
+++ b/packages/core/src/shape/__snapshots__/scene3d-camera.test.ts.snap
@@ -3,20 +3,20 @@
 exports[`computeScene3dQuad > snapshot — sample-11 slide-3 camera (perspectiveRelaxed lat330 lon20 rev347) 1`] = `
 [
   {
-    "x": 35.62,
-    "y": 102.57,
+    "x": 76.51,
+    "y": 23.83,
   },
   {
-    "x": 357.71,
-    "y": 0,
+    "x": 400,
+    "y": 25.48,
   },
   {
-    "x": 364.38,
-    "y": 184.46,
+    "x": 377.39,
+    "y": 276.17,
   },
   {
-    "x": 140.77,
-    "y": 300,
+    "x": 0,
+    "y": 239.31,
   },
 ]
 `;

--- a/packages/core/src/shape/preset-geometry/index.ts
+++ b/packages/core/src/shape/preset-geometry/index.ts
@@ -23,6 +23,40 @@ export function hasPreset(geom: string): boolean {
   return geom.toLowerCase() in PRESETS;
 }
 
+/**
+ * Append a preset geometry's outline to the CURRENT path of `ctx` (no
+ * `beginPath` / `fill` / `stroke` — the caller owns those). Every `<path>` of the
+ * preset is emitted as its own subpath, so the result is suitable for use as a
+ * clip region, a silhouette to stroke, or an even-odd cut-out.
+ *
+ * This is the geometry-only counterpart of {@link renderPresetShape}: it shares
+ * the same evaluator + path executor, so a picture clipped by `<a:prstGeom>`
+ * (ECMA-376 §20.1.9.18 — a picture's preset geometry is its clip silhouette) is
+ * traced by exactly the same code that draws the equivalent `<p:sp>`. Returns
+ * false when the preset name is unknown so the caller can fall back to a rect.
+ *
+ * Note: fill modifiers (`lighten` / `darken`) and multi-path highlight overlays
+ * are irrelevant to a silhouette, so every path is emitted regardless of its
+ * `fill` mode — the union of all subpaths is the shape's outer outline.
+ */
+export function buildPresetGeometryPath(
+  ctx: CanvasRenderingContext2D,
+  geom: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  adj: (number | null | undefined)[] = [],
+): boolean {
+  const def = PRESETS[geom.toLowerCase()];
+  if (!def) return false;
+  const evaluator = createEvaluator({ w, h, adj }, def.adj, def.gd);
+  for (const path of def.paths) {
+    applyPresetPath(ctx, path, evaluator, x, y, w, h);
+  }
+  return true;
+}
+
 // A wedge callout's tail only protrudes when its tip is OUTSIDE the body. When
 // the author drags the tip into the body (e.g. to hide the tail), PowerPoint
 // renders just the base shape — no inward dent. The literal ECMA-376 preset

--- a/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
+++ b/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderPresetShape, hasPreset } from './index';
+import { renderPresetShape, hasPreset, buildPresetGeometryPath } from './index';
 
 /**
  * Records every path vertex the engine emits so we can assert on the resulting
@@ -124,6 +124,46 @@ describe('renderPresetShape (core preset-geometry engine)', () => {
       () => {},
     );
     expect(ok).toBe(false);
+  });
+
+  // buildPresetGeometryPath — the geometry-only entry used for picture clip
+  // silhouettes (ECMA-376 §20.1.9.18). It emits each preset path as a subpath
+  // of the current path with no fill/stroke.
+  describe('buildPresetGeometryPath (picture clip silhouette)', () => {
+    it('builds an ellipse spanning the full box for prst="ellipse"', () => {
+      const { ctx, points } = makeRecorder();
+      const ok = buildPresetGeometryPath(ctx, 'ellipse', 10, 20, 200, 300);
+      expect(ok).toBe(true);
+      // The recorder turns ctx.ellipse into its 4 axis-extreme points. The
+      // ellipse must be inscribed in the bbox: x∈{10,210}, y∈{20,320}, centred.
+      const { xs, ys } = distinct(points);
+      expect(Math.min(...xs)).toBe(10);
+      expect(Math.max(...xs)).toBe(210);
+      expect(Math.min(...ys)).toBe(20);
+      expect(Math.max(...ys)).toBe(320);
+      // The corners of the bbox must NOT be on the path (an ellipse, not a rect).
+      const hasCorner = points.some((p) => Math.round(p.x) === 10 && Math.round(p.y) === 20);
+      expect(hasCorner).toBe(false);
+    });
+
+    it('builds a rounded-rect silhouette whose corner radius tracks the adjust', () => {
+      // roundRect's rounded corners pull the path inward from the box corners by
+      // the radius; a larger adjust → vertices further from the corner.
+      const inset = (adj: number) => {
+        const { ctx, points } = makeRecorder();
+        buildPresetGeometryPath(ctx, 'roundRect', 0, 0, 200, 200, [adj]);
+        // Smallest non-zero x touched along the top edge ≈ corner radius.
+        return Math.min(...points.map((p) => Math.round(p.x)).filter((x) => x > 0));
+      };
+      expect(inset(40000)).toBeGreaterThan(inset(10000));
+    });
+
+    it('returns false for an unknown preset so the caller can fall back to rect', () => {
+      const { ctx, points } = makeRecorder();
+      const ok = buildPresetGeometryPath(ctx, 'totallyMadeUpShape', 0, 0, 10, 10);
+      expect(ok).toBe(false);
+      expect(points.length).toBe(0);
+    });
   });
 
   it('honours an explicit adjust value (parallelogram skew)', () => {

--- a/packages/core/src/shape/scene3d-camera.test.ts
+++ b/packages/core/src/shape/scene3d-camera.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeScene3dQuad,
+  isScene3dNonIdentity,
+  type CameraInput,
+  type Vec2,
+} from './scene3d-camera';
+
+const W = 400;
+const H = 300;
+
+/** Round a Vec2 for readable snapshots / approximate comparisons. */
+function r(p: Vec2, d = 3): { x: number; y: number } {
+  const k = 10 ** d;
+  return { x: Math.round(p.x * k) / k, y: Math.round(p.y * k) / k };
+}
+
+describe('computeScene3dQuad', () => {
+  it('orthographicFront with no rot is the identity rectangle', () => {
+    const cam: CameraInput = { prst: 'orthographicFront' };
+    const q = computeScene3dQuad(cam, W, H);
+    expect(q.isIdentity).toBe(true);
+    expect(q.isAffine).toBe(true);
+    expect(r(q.corners[0])).toEqual({ x: 0, y: 0 });
+    expect(r(q.corners[1])).toEqual({ x: W, y: 0 });
+    expect(r(q.corners[2])).toEqual({ x: W, y: H });
+    expect(r(q.corners[3])).toEqual({ x: 0, y: H });
+  });
+
+  it('orthographicFront with all-zero rot is still identity', () => {
+    const cam: CameraInput = { prst: 'orthographicFront', rot: { lat: 0, lon: 0, rev: 0 } };
+    expect(computeScene3dQuad(cam, W, H).isIdentity).toBe(true);
+    expect(isScene3dNonIdentity(cam)).toBe(false);
+  });
+
+  it('unknown preset falls back to identity (no throw)', () => {
+    const cam: CameraInput = { prst: 'legacyObliqueTopLeft' };
+    const q = computeScene3dQuad(cam, W, H);
+    expect(q.isIdentity).toBe(true);
+  });
+
+  it('lon-only rotation is symmetric about the horizontal centre line', () => {
+    // A pure longitude (Y-axis) turn turns the right edge toward / the left edge
+    // away from the viewer. The left and right edges stay vertical (equal x for
+    // the two corners on each side) and the quad mirrors top↔bottom about the
+    // horizontal centre line; left and right edge HEIGHTS differ (foreshorten).
+    const cam: CameraInput = { prst: 'perspectiveFront', rot: { lat: 0, lon: 25, rev: 0 } };
+    const q = computeScene3dQuad(cam, W, H);
+    expect(q.isAffine).toBe(false);
+    const [tl, tr, br, bl] = q.corners.map((c) => r(c));
+    // Left edge vertical (TL.x == BL.x); right edge vertical (TR.x == BR.x).
+    expect(tl.x).toBeCloseTo(bl.x, 2);
+    expect(tr.x).toBeCloseTo(br.x, 2);
+    // Mirror about the horizontal centre line: TL.y↔BL.y, TR.y↔BR.y.
+    expect(tl.y).toBeCloseTo(H - bl.y, 2);
+    expect(tr.y).toBeCloseTo(H - br.y, 2);
+    // Near edge taller than far edge (perspective foreshortening).
+    const leftH = bl.y - tl.y;
+    const rightH = br.y - tr.y;
+    expect(Math.abs(leftH - rightH)).toBeGreaterThan(1);
+  });
+
+  it('lat-only rotation is symmetric about the vertical centre line', () => {
+    // A pure latitude (X-axis) tilt tips the top edge away / bottom edge toward
+    // the viewer. The top and bottom edges stay horizontal (equal y for the two
+    // corners on each edge) and the quad mirrors left↔right about the vertical
+    // centre line; top and bottom edge WIDTHS differ (foreshorten).
+    const cam: CameraInput = { prst: 'perspectiveFront', rot: { lat: 25, lon: 0, rev: 0 } };
+    const q = computeScene3dQuad(cam, W, H);
+    expect(q.isAffine).toBe(false);
+    const [tl, tr, br, bl] = q.corners.map((c) => r(c));
+    // Top edge horizontal (TL.y == TR.y); bottom edge horizontal (BL.y == BR.y).
+    expect(tl.y).toBeCloseTo(tr.y, 2);
+    expect(bl.y).toBeCloseTo(br.y, 2);
+    // Mirror about the vertical centre line: TL.x↔TR.x, BL.x↔BR.x.
+    expect(tl.x).toBeCloseTo(W - tr.x, 2);
+    expect(bl.x).toBeCloseTo(W - br.x, 2);
+    // Top edge narrower than bottom edge (top recedes from the viewer).
+    const topW = tr.x - tl.x;
+    const botW = br.x - bl.x;
+    expect(topW).toBeLessThan(botW);
+  });
+
+  it('rev-only rotation is a pure in-plane rotation (affine, rigid)', () => {
+    // rev spins the shape in the screen plane: the quad stays a rectangle
+    // (affine), corner-to-corner distances are preserved up to the refit scale,
+    // and it is rotated by -rev (clockwise screen, see sign convention).
+    const cam: CameraInput = { prst: 'orthographicFront', rot: { lat: 0, lon: 0, rev: 30 } };
+    const q = computeScene3dQuad(cam, W, H);
+    expect(q.isAffine).toBe(true);
+    expect(q.isIdentity).toBe(false);
+    // Edge lengths: opposite edges equal, adjacent edges in the original w:h
+    // ratio (rigid rotation preserves the rectangle's proportions).
+    const [tl, tr, br, bl] = q.corners;
+    const top = Math.hypot(tr.x - tl.x, tr.y - tl.y);
+    const right = Math.hypot(br.x - tr.x, br.y - tr.y);
+    const bottom = Math.hypot(br.x - bl.x, br.y - bl.y);
+    const left = Math.hypot(bl.x - tl.x, bl.y - tl.y);
+    expect(top).toBeCloseTo(bottom, 1);
+    expect(left).toBeCloseTo(right, 1);
+    expect(top / right).toBeCloseTo(W / H, 2);
+    // Quad centroid stays at the bbox centre.
+    const cx = (tl.x + tr.x + br.x + bl.x) / 4;
+    const cy = (tl.y + tr.y + br.y + bl.y) / 4;
+    expect(cx).toBeCloseTo(W / 2, 3);
+    expect(cy).toBeCloseTo(H / 2, 3);
+  });
+
+  it('fov override widens the perspective foreshortening', () => {
+    const base: CameraInput = { prst: 'perspectiveFront', rot: { lat: 30, lon: 0, rev: 0 } };
+    const wide: CameraInput = { ...base, fov: 90 };
+    const qb = computeScene3dQuad(base, W, H);
+    const qw = computeScene3dQuad(wide, W, H);
+    // Wider FOV → stronger near/far size difference → bigger top-vs-bottom width gap.
+    const gap = (q: ReturnType<typeof computeScene3dQuad>): number => {
+      const topW = q.corners[1].x - q.corners[0].x;
+      const botW = q.corners[2].x - q.corners[3].x;
+      return Math.abs(topW - botW);
+    };
+    expect(gap(qw)).toBeGreaterThan(gap(qb));
+  });
+
+  it('zoom keeps the quad centred (refit absorbs uniform scale)', () => {
+    // The refit pins the projected quad's bounding-box centre to the element's
+    // bbox centre, so a uniform zoom does not shift the quad.
+    const cam: CameraInput = { prst: 'perspectiveFront', rot: { lat: 20, lon: 10, rev: 0 }, zoom: 2 };
+    const q = computeScene3dQuad(cam, W, H);
+    const xs = q.corners.map((c) => c.x);
+    const ys = q.corners.map((c) => c.y);
+    const bbCx = (Math.min(...xs) + Math.max(...xs)) / 2;
+    const bbCy = (Math.min(...ys) + Math.max(...ys)) / 2;
+    expect(bbCx).toBeCloseTo(W / 2, 3);
+    expect(bbCy).toBeCloseTo(H / 2, 3);
+  });
+
+  it('projected quad fits inside the original bounding box', () => {
+    const cam: CameraInput = { prst: 'perspectiveRelaxed', rot: { lat: 330, lon: 20, rev: 347 } };
+    const q = computeScene3dQuad(cam, W, H);
+    for (const c of q.corners) {
+      expect(c.x).toBeGreaterThanOrEqual(-0.001);
+      expect(c.x).toBeLessThanOrEqual(W + 0.001);
+      expect(c.y).toBeGreaterThanOrEqual(-0.001);
+      expect(c.y).toBeLessThanOrEqual(H + 0.001);
+    }
+  });
+
+  it('snapshot — sample-11 slide-3 camera (perspectiveRelaxed lat330 lon20 rev347)', () => {
+    // The exact camera from sample-11 slide 3, "図 3". lat=330° (=-30° tilt),
+    // lon=20°, rev=347° (=-13° in-plane). Fixed numeric snapshot so future
+    // changes to the camera math are caught.
+    const cam: CameraInput = { prst: 'perspectiveRelaxed', rot: { lat: 330, lon: 20, rev: 347 } };
+    const q = computeScene3dQuad(cam, W, H);
+    expect(q.isAffine).toBe(false);
+    expect(q.corners.map((c) => r(c, 2))).toMatchSnapshot();
+  });
+});

--- a/packages/core/src/shape/scene3d-camera.test.ts
+++ b/packages/core/src/shape/scene3d-camera.test.ts
@@ -39,11 +39,13 @@ describe('computeScene3dQuad', () => {
     expect(q.isIdentity).toBe(true);
   });
 
-  it('lon-only rotation is symmetric about the horizontal centre line', () => {
-    // A pure longitude (Y-axis) turn turns the right edge toward / the left edge
-    // away from the viewer. The left and right edges stay vertical (equal x for
-    // the two corners on each side) and the quad mirrors top↔bottom about the
-    // horizontal centre line; left and right edge HEIGHTS differ (foreshorten).
+  it('lon>0 turns the right edge TOWARD the viewer (right edge nearer/taller)', () => {
+    // A pure longitude (Y-axis) turn. With lon > 0 the right edge comes toward
+    // the viewer and the left edge recedes (file-angle convention — see the
+    // module header). The left and right edges stay vertical (equal x for the
+    // two corners on each side) and the quad mirrors top↔bottom about the
+    // horizontal centre line; the near (right) edge is TALLER than the far (left)
+    // edge by perspective foreshortening.
     const cam: CameraInput = { prst: 'perspectiveFront', rot: { lat: 0, lon: 25, rev: 0 } };
     const q = computeScene3dQuad(cam, W, H);
     expect(q.isAffine).toBe(false);
@@ -54,17 +56,18 @@ describe('computeScene3dQuad', () => {
     // Mirror about the horizontal centre line: TL.y↔BL.y, TR.y↔BR.y.
     expect(tl.y).toBeCloseTo(H - bl.y, 2);
     expect(tr.y).toBeCloseTo(H - br.y, 2);
-    // Near edge taller than far edge (perspective foreshortening).
+    // Right (near) edge taller than left (far) edge.
     const leftH = bl.y - tl.y;
     const rightH = br.y - tr.y;
-    expect(Math.abs(leftH - rightH)).toBeGreaterThan(1);
+    expect(rightH).toBeGreaterThan(leftH + 1);
   });
 
-  it('lat-only rotation is symmetric about the vertical centre line', () => {
-    // A pure latitude (X-axis) tilt tips the top edge away / bottom edge toward
-    // the viewer. The top and bottom edges stay horizontal (equal y for the two
-    // corners on each edge) and the quad mirrors left↔right about the vertical
-    // centre line; top and bottom edge WIDTHS differ (foreshorten).
+  it('lat>0 tips the TOP edge TOWARD the viewer (top edge nearer/wider)', () => {
+    // A pure latitude (X-axis) tilt. With lat > 0 the top edge tips toward the
+    // viewer and the bottom recedes (file-angle convention — see the module
+    // header; sample-11's lat = −30° does the opposite, top recedes). The top and
+    // bottom edges stay horizontal and the quad mirrors left↔right about the
+    // vertical centre line; the near (top) edge is WIDER than the far (bottom).
     const cam: CameraInput = { prst: 'perspectiveFront', rot: { lat: 25, lon: 0, rev: 0 } };
     const q = computeScene3dQuad(cam, W, H);
     expect(q.isAffine).toBe(false);
@@ -75,7 +78,20 @@ describe('computeScene3dQuad', () => {
     // Mirror about the vertical centre line: TL.x↔TR.x, BL.x↔BR.x.
     expect(tl.x).toBeCloseTo(W - tr.x, 2);
     expect(bl.x).toBeCloseTo(W - br.x, 2);
-    // Top edge narrower than bottom edge (top recedes from the viewer).
+    // Top edge WIDER than bottom edge (top nears the viewer).
+    const topW = tr.x - tl.x;
+    const botW = br.x - bl.x;
+    expect(topW).toBeGreaterThan(botW);
+  });
+
+  it('lat<0 (sample-11 slide-3 tilt) makes the TOP edge recede (narrower)', () => {
+    // sample-11 slide 3 supplies lat = 330° (= −30°). The corrected convention
+    // must make the top edge RECEDE here, matching the PDF ground truth
+    // (top/bottom width ratio ≈ 0.82). This is the inverse of the lat>0 case and
+    // is the regression guard for the axis-convention fix.
+    const cam: CameraInput = { prst: 'perspectiveRelaxed', rot: { lat: 330, lon: 0, rev: 0 } };
+    const q = computeScene3dQuad(cam, W, H);
+    const [tl, tr, br, bl] = q.corners;
     const topW = tr.x - tl.x;
     const botW = br.x - bl.x;
     expect(topW).toBeLessThan(botW);
@@ -83,8 +99,8 @@ describe('computeScene3dQuad', () => {
 
   it('rev-only rotation is a pure in-plane rotation (affine, rigid)', () => {
     // rev spins the shape in the screen plane: the quad stays a rectangle
-    // (affine), corner-to-corner distances are preserved up to the refit scale,
-    // and it is rotated by -rev (clockwise screen, see sign convention).
+    // (affine), corner-to-corner distances are preserved up to the refit scale.
+    // rev > 0 rotates COUNTER-CLOCKWISE on screen (file-angle convention).
     const cam: CameraInput = { prst: 'orthographicFront', rot: { lat: 0, lon: 0, rev: 30 } };
     const q = computeScene3dQuad(cam, W, H);
     expect(q.isAffine).toBe(true);
@@ -104,6 +120,9 @@ describe('computeScene3dQuad', () => {
     const cy = (tl.y + tr.y + br.y + bl.y) / 4;
     expect(cx).toBeCloseTo(W / 2, 3);
     expect(cy).toBeCloseTo(H / 2, 3);
+    // Direction: rev > 0 is counter-clockwise on screen, so the top-right corner
+    // rises above the top-left corner (TR.y < TL.y in y-down coords).
+    expect(tr.y).toBeLessThan(tl.y);
   });
 
   it('fov override widens the perspective foreshortening', () => {
@@ -145,12 +164,18 @@ describe('computeScene3dQuad', () => {
   });
 
   it('snapshot — sample-11 slide-3 camera (perspectiveRelaxed lat330 lon20 rev347)', () => {
-    // The exact camera from sample-11 slide 3, "図 3". lat=330° (=-30° tilt),
-    // lon=20°, rev=347° (=-13° in-plane). Fixed numeric snapshot so future
-    // changes to the camera math are caught.
+    // The exact camera from sample-11 slide 3, "図 3". lat=330° (=−30° tilt → top
+    // recedes), lon=20° (right edge nears), rev=347° (=−13° → clockwise in-plane),
+    // fov=26° (calibrated, see scene3d-camera.ts). Fixed numeric snapshot so
+    // future changes to the camera math are caught; the corner positions encode
+    // the corrected axis convention validated against sample-11.pdf page 3.
     const cam: CameraInput = { prst: 'perspectiveRelaxed', rot: { lat: 330, lon: 20, rev: 347 } };
     const q = computeScene3dQuad(cam, W, H);
     expect(q.isAffine).toBe(false);
+    // Top edge narrower than bottom edge (top recedes — the PDF keystone).
+    const topW = q.corners[1].x - q.corners[0].x;
+    const botW = q.corners[2].x - q.corners[3].x;
+    expect(topW).toBeLessThan(botW);
     expect(q.corners.map((c) => r(c, 2))).toMatchSnapshot();
   });
 });

--- a/packages/core/src/shape/scene3d-camera.ts
+++ b/packages/core/src/shape/scene3d-camera.ts
@@ -1,0 +1,355 @@
+/**
+ * DrawingML 3D camera — perspective projection of a planar shape (Phase A).
+ *
+ * ECMA-376 references:
+ *   - §20.1.5.5  `camera` (CT_Camera): prst / fov / zoom / rot.
+ *   - §20.1.5.11 `rot`    (CT_SphereCoords): lat / lon / rev rotation.
+ *   - §20.1.10.47 ST_PresetCameraType: the 62 preset cameras.
+ *
+ * SPEC GAP (documented assumption — see CLAUDE.md "spec fidelity"):
+ * ECMA-376 specifies the camera *model* (rotation order, fov meaning, the
+ * preset enumeration) but gives **no numeric definitions** for the presets —
+ * no base orientation, no per-preset field of view, no near/far. There is no
+ * MS-OI29500 in this repo's spec/ tree either. The numeric constants below are
+ * therefore the de-facto values from the OOXML implementer consensus, i.e. the
+ * orientation/FOV PowerPoint emits and that LibreOffice's `oox` import maps in
+ * oox/source/drawingml/scene3dcontext.cxx + the preset-camera table. They are
+ * flagged here as a derived assumption, not a spec quotation.
+ *
+ * Phase A scope: we model the shape as a flat z=0 rectangle (the picture / 2D
+ * drawing) and compute the 2D homography that maps the un-projected rectangle
+ * to the projected quad. Bevel / extrusion / lightRig shading is Phase B.
+ */
+
+/**
+ * Geometry-only camera inputs the projection math needs. Defined locally so the
+ * core helper has no dependency on the pptx (or any format) type layer; the
+ * pptx `Camera3d` / `Rot3d` are structurally assignable to these. Angles are in
+ * degrees (the parser already converted from 60000ths).
+ */
+export interface CameraInput {
+  /** Preset camera name (`ST_PresetCameraType`). */
+  prst: string;
+  /** Field-of-view override in degrees. Omitted = preset default. */
+  fov?: number;
+  /** Zoom factor as a unit ratio (1.0 = 100%). Omitted = 1.0. */
+  zoom?: number;
+  /** Camera rotation override. Omitted = preset base orientation. */
+  rot?: RotInput;
+}
+
+/** Sphere-coordinate rotation in degrees — ECMA-376 §20.1.5.11. */
+export interface RotInput {
+  lat: number;
+  lon: number;
+  rev: number;
+}
+
+/** A 2D point in the projected (screen) plane, pixels relative to bbox origin. */
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+/** Result of projecting a planar shape through the camera. */
+export interface Scene3dQuad {
+  /**
+   * The four projected corners in CSS pixels, relative to the element's
+   * bounding-box top-left, in order: top-left, top-right, bottom-right,
+   * bottom-left (matching the source rectangle (0,0)-(w,0)-(w,h)-(0,h)).
+   *
+   * The quad is re-centred and scaled to fit the SAME bounding box (w×h) the
+   * un-projected shape occupied, so the renderer can blit a w×h offscreen
+   * bitmap onto it without changing the element's footprint.
+   */
+  corners: [Vec2, Vec2, Vec2, Vec2];
+  /**
+   * True when the projection is (numerically) an affine map — i.e. the four
+   * corners still form a parallelogram. Orthographic / isometric presets and a
+   * pure in-plane `rev` are affine; perspective presets with lat/lon tilt are
+   * not. Callers can take a cheaper single-`setTransform` path when affine.
+   */
+  isAffine: boolean;
+  /**
+   * True when the projection is (numerically) the identity within the bbox —
+   * the renderer should skip projection entirely and draw normally. Happens for
+   * `orthographicFront` with no rot override (or rot all-zero).
+   */
+  isIdentity: boolean;
+}
+
+/** Preset camera kinds that determine the projection math. */
+type ProjectionKind = 'perspective' | 'orthographic';
+
+/**
+ * Per-preset definition: the base camera orientation (applied before the user
+ * `rot` override) and the default field of view in degrees for perspective
+ * presets. Orthographic / isometric presets use parallel projection (fov is
+ * ignored). See the SPEC GAP note above for the source of these numbers.
+ *
+ * Base orientation is expressed as the same lat/lon/rev sphere coordinates the
+ * file uses, in degrees, so it composes with the user rot in one place.
+ */
+interface PresetDef {
+  kind: ProjectionKind;
+  /** Base latitude (X-axis tilt), degrees. */
+  baseLat: number;
+  /** Base longitude (Y-axis turn), degrees. */
+  baseLon: number;
+  /** Base revolution (Z-axis spin), degrees. */
+  baseRev: number;
+  /** Default field of view for perspective presets, degrees. */
+  fovDeg: number;
+}
+
+// Default perspective FOV. PowerPoint's perspective presets cluster around a
+// ~45° vertical field of view; the "relaxed" variants soften it. These match
+// the values LibreOffice oox uses for the corresponding presets.
+const DEFAULT_PERSP_FOV = 45;
+
+/**
+ * Preset camera table. Only the presets we can render in Phase A (planar
+ * homography) are enumerated with their orientation; everything else falls back
+ * to `orthographicFront` (identity) so an unknown/legacy preset never throws.
+ *
+ * Orientation sign convention (object axes): +X right, +Y down, +Z toward the
+ * viewer. `lat` tilts the top toward (-) / away (+) from the viewer, `lon`
+ * turns the right edge toward (+) / away (-) from the viewer, `rev` spins in
+ * the screen plane clockwise (+).
+ */
+const PRESETS: Record<string, PresetDef> = {
+  // ---- Orthographic / front-facing ----
+  orthographicFront: { kind: 'orthographic', baseLat: 0, baseLon: 0, baseRev: 0, fovDeg: 0 },
+
+  // ---- Perspective family (front + heroic + relaxed) ----
+  // perspectiveFront: looking straight on, but with perspective foreshortening.
+  perspectiveFront: { kind: 'perspective', baseLat: 0, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  // perspectiveRelaxed / perspectiveRelaxedModerately: a gentle downward tilt so
+  // the top edge recedes. PowerPoint's "Perspective Relaxed" tips the shape
+  // back ~10–18°; "Moderately" is roughly half that. These are the de-facto
+  // angles (see SPEC GAP). The file-level <a:rot> overrides them when present.
+  perspectiveRelaxed: { kind: 'perspective', baseLat: 0, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  perspectiveRelaxedModerately: { kind: 'perspective', baseLat: 0, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  // perspectiveAbove / perspectiveBelow: camera looks down / up at the shape.
+  perspectiveAbove: { kind: 'perspective', baseLat: 20, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  perspectiveBelow: { kind: 'perspective', baseLat: -20, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  // Left / right facing perspective variants: shape turned about the Y axis.
+  perspectiveLeft: { kind: 'perspective', baseLat: 0, baseLon: -20, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  perspectiveRight: { kind: 'perspective', baseLat: 0, baseLon: 20, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+};
+
+/**
+ * Note on `perspectiveRelaxed` base orientation: the most common authoring path
+ * (and the sample-11 case) supplies an explicit `<a:rot>` that fully defines the
+ * orientation, so the preset's own base tilt is only a fallback. We keep the
+ * base tilt at 0 for the relaxed presets and let the file's rot drive the
+ * orientation; this is the spec-faithful choice because the rot override, when
+ * present, *replaces* the preset rotation (§20.1.5.5: "rotation … overrides …
+ * that further rotate the camera"). When no rot is present we fall back to the
+ * front view rather than inventing an angle we cannot cite.
+ */
+
+/** 3×3 matrix in row-major order. */
+type Mat3 = [number, number, number, number, number, number, number, number, number];
+
+function mul3(a: Mat3, b: Mat3): Mat3 {
+  const r = new Array(9).fill(0) as number[];
+  for (let i = 0; i < 3; i++) {
+    for (let j = 0; j < 3; j++) {
+      let s = 0;
+      for (let k = 0; k < 3; k++) s += a[i * 3 + k] * b[k * 3 + j];
+      r[i * 3 + j] = s;
+    }
+  }
+  return r as Mat3;
+}
+
+function rotX(deg: number): Mat3 {
+  const t = (deg * Math.PI) / 180;
+  const c = Math.cos(t);
+  const s = Math.sin(t);
+  // X-axis rotation (latitude tilt).
+  return [1, 0, 0, 0, c, -s, 0, s, c];
+}
+
+function rotY(deg: number): Mat3 {
+  const t = (deg * Math.PI) / 180;
+  const c = Math.cos(t);
+  const s = Math.sin(t);
+  // Y-axis rotation (longitude turn).
+  return [c, 0, s, 0, 1, 0, -s, 0, c];
+}
+
+function rotZ(deg: number): Mat3 {
+  const t = (deg * Math.PI) / 180;
+  const c = Math.cos(t);
+  const s = Math.sin(t);
+  // Z-axis rotation (revolution / in-plane spin).
+  return [c, -s, 0, s, c, 0, 0, 0, 1];
+}
+
+function applyMat3(m: Mat3, x: number, y: number, z: number): [number, number, number] {
+  return [
+    m[0] * x + m[1] * y + m[2] * z,
+    m[3] * x + m[4] * y + m[5] * z,
+    m[6] * x + m[7] * y + m[8] * z,
+  ];
+}
+
+/**
+ * Compose the full object rotation from a base orientation and an optional file
+ * `rot` override. Per §20.1.5.11 the revolution is applied "about the axis as
+ * the latitude and longitude coordinates", i.e. rev is the last (outermost)
+ * rotation about the resulting view axis. We therefore compose
+ *   R = Rz(rev) · Rx(lat) · Ry(lon).
+ * When an explicit `<a:rot>` is present it supplies lat/lon/rev directly
+ * (replacing the preset base, per the override semantics in §20.1.5.5); when
+ * absent we use the preset's base angles.
+ */
+function buildRotation(preset: PresetDef, rot: RotInput | undefined): Mat3 {
+  const lat = rot ? rot.lat : preset.baseLat;
+  const lon = rot ? rot.lon : preset.baseLon;
+  const rev = rot ? rot.rev : preset.baseRev;
+  return mul3(rotZ(rev), mul3(rotX(lat), rotY(lon)));
+}
+
+/** Look up a preset def, falling back to orthographicFront for unknown names. */
+function presetDef(prst: string): PresetDef {
+  return PRESETS[prst] ?? PRESETS.orthographicFront;
+}
+
+/**
+ * Project a planar shape (the w×h rectangle) through the camera and return the
+ * four projected corners, refit into the original w×h bounding box.
+ *
+ * @param camera  parsed <a:camera> (prst / fov / zoom / rot, angles in degrees).
+ * @param w       shape width in CSS pixels.
+ * @param h       shape height in CSS pixels.
+ */
+export function computeScene3dQuad(camera: CameraInput, w: number, h: number): Scene3dQuad {
+  const def = presetDef(camera.prst);
+  const R = buildRotation(def, camera.rot);
+
+  // Degenerate sizes can't be projected meaningfully.
+  if (w <= 0 || h <= 0) {
+    return {
+      corners: [
+        { x: 0, y: 0 },
+        { x: w, y: 0 },
+        { x: w, y: h },
+        { x: 0, y: h },
+      ],
+      isAffine: true,
+      isIdentity: true,
+    };
+  }
+
+  // Source rectangle corners centred at the origin in shape-local space, with
+  // +X right, +Y down. We work in a unit-ish space (half-extents) so the FOV /
+  // camera distance is independent of pixel size, then rescale at the end.
+  const hw = w / 2;
+  const hh = h / 2;
+  const srcCorners: Array<[number, number]> = [
+    [-hw, -hh], // top-left
+    [hw, -hh], // top-right
+    [hw, hh], // bottom-right
+    [-hw, hh], // bottom-left
+  ];
+
+  const zoom = camera.zoom ?? 1;
+
+  // Camera distance for perspective. The shape's larger half-extent subtends
+  // the full field of view at the camera plane: d = halfMax / tan(fov/2). This
+  // is the standard pinhole relation; it keeps the shape filling the frame
+  // before tilting, matching how PowerPoint frames the un-tilted shape.
+  const halfMax = Math.max(hw, hh);
+  let projected: Array<[number, number]>;
+
+  if (def.kind === 'perspective') {
+    const fovDeg = camera.fov ?? def.fovDeg;
+    const fov = (Math.max(1, Math.min(179, fovDeg)) * Math.PI) / 180;
+    const d = halfMax / Math.tan(fov / 2);
+    projected = srcCorners.map(([sx, sy]) => {
+      const [rx, ry, rz] = applyMat3(R, sx, sy, 0);
+      // Camera at +Z = d looking toward -Z (origin). A point at object-z rz is
+      // at camera-relative depth (d - rz); perspective divide by that depth.
+      const depth = d - rz;
+      // Guard against a corner crossing the camera plane (shouldn't happen for
+      // sane tilts, but clamp to keep the map finite).
+      const safeDepth = Math.abs(depth) < 1e-6 ? 1e-6 * Math.sign(depth || 1) : depth;
+      const f = d / safeDepth;
+      return [rx * f, ry * f] as [number, number];
+    });
+  } else {
+    // Parallel (orthographic / isometric) projection: drop z after rotation.
+    projected = srcCorners.map(([sx, sy]) => {
+      const [rx, ry] = applyMat3(R, sx, sy, 0);
+      return [rx, ry] as [number, number];
+    });
+  }
+
+  // Apply zoom about the centre.
+  projected = projected.map(([px, py]) => [px * zoom, py * zoom] as [number, number]);
+
+  // Refit the projected quad into the original w×h box: scale uniformly so the
+  // quad's bounding box matches w×h, then translate so its centre sits at the
+  // box centre (w/2, h/2). Uniform scale preserves the projected shape's aspect
+  // (we never stretch x and y independently).
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [px, py] of projected) {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  }
+  const projW = maxX - minX || 1;
+  const projH = maxY - minY || 1;
+  const fit = Math.min(w / projW, h / projH);
+  // Centre of the projected quad's bounding box; this is the point we pin to the
+  // element's bbox centre so the projected shape stays inside its footprint.
+  const projCx = (minX + maxX) / 2;
+  const projCy = (minY + maxY) / 2;
+
+  const corners = projected.map(([px, py]) => ({
+    x: w / 2 + (px - projCx) * fit,
+    y: h / 2 + (py - projCy) * fit,
+  })) as [Vec2, Vec2, Vec2, Vec2];
+
+  // Affine test: a quad is a parallelogram iff (C0 + C2) == (C1 + C3) (the
+  // diagonals bisect). Use a relative epsilon vs. the bbox size.
+  const eps = 1e-3 * Math.max(w, h);
+  const sumDiagX = corners[0].x + corners[2].x - (corners[1].x + corners[3].x);
+  const sumDiagY = corners[0].y + corners[2].y - (corners[1].y + corners[3].y);
+  const isAffine = Math.abs(sumDiagX) < eps && Math.abs(sumDiagY) < eps;
+
+  // Identity test: corners within epsilon of the un-projected rectangle.
+  const ref: Array<[number, number]> = [
+    [0, 0],
+    [w, 0],
+    [w, h],
+    [0, h],
+  ];
+  let isIdentity = true;
+  for (let i = 0; i < 4; i++) {
+    if (Math.abs(corners[i].x - ref[i][0]) > eps || Math.abs(corners[i].y - ref[i][1]) > eps) {
+      isIdentity = false;
+      break;
+    }
+  }
+
+  return { corners, isAffine, isIdentity };
+}
+
+/**
+ * True when a scene3d camera will visibly change the shape, i.e. the renderer
+ * should take the projection path. A camera whose preset is unknown/front-facing
+ * with no rot (or an all-zero rot) is the identity and can be skipped.
+ */
+export function isScene3dNonIdentity(camera: CameraInput): boolean {
+  // A 1×1 probe is enough to detect identity vs. projection; the result scales.
+  const { isIdentity } = computeScene3dQuad(camera, 1000, 1000);
+  return !isIdentity;
+}

--- a/packages/core/src/shape/scene3d-camera.ts
+++ b/packages/core/src/shape/scene3d-camera.ts
@@ -102,20 +102,49 @@ interface PresetDef {
   fovDeg: number;
 }
 
-// Default perspective FOV. PowerPoint's perspective presets cluster around a
-// ~45° vertical field of view; the "relaxed" variants soften it. These match
-// the values LibreOffice oox uses for the corresponding presets.
-const DEFAULT_PERSP_FOV = 45;
+// Default perspective FOV for the relaxed presets, in degrees.
+//
+// SPEC GAP (see the file header): ECMA-376 gives no per-preset FOV. This value
+// is CALIBRATED against the PowerPoint-rendered ground truth (sample-11.pdf
+// page 3, `perspectiveRelaxed` + an explicit <a:rot lat="-30" lon="20"
+// rev="-13">). Procedure: rasterise the PDF page at 200 DPI, detect the card's
+// four corners as the pixels extremal along x±y (robust for a convex quad),
+// normalise (centroid-subtract + mean-radius-divide), and minimise the summed
+// per-corner residual over (fov, rotation-sign, depth-sign). The composition
+// Rz(-rev)·Rx(-lat)·Ry(-lon) with depth = d − rz (see `buildRotation`) wins by
+// 5–9× over every other order/sign/depth variant, and its residual bottoms out
+// near **fov ≈ 26°** (top/bottom edge ratio 0.809 vs the PDF's 0.824, left/right
+// 0.927 vs 0.944). 26° is a *narrow* perspective — the earlier 45° vastly
+// over-foreshortened the card. The "relaxed" presets are gentle by design, so a
+// shallow FOV is expected.
+//
+// We have ground truth for `perspectiveRelaxed` only. The remaining perspective
+// presets share the same family/lens scale in PowerPoint's camera rig, so we
+// apply the same 26° default and flag it as a derived assumption; if a future
+// sample supplies a ground truth for another preset, recalibrate that entry.
+const DEFAULT_PERSP_FOV = 26;
 
 /**
  * Preset camera table. Only the presets we can render in Phase A (planar
  * homography) are enumerated with their orientation; everything else falls back
  * to `orthographicFront` (identity) so an unknown/legacy preset never throws.
  *
- * Orientation sign convention (object axes): +X right, +Y down, +Z toward the
- * viewer. `lat` tilts the top toward (-) / away (+) from the viewer, `lon`
- * turns the right edge toward (+) / away (-) from the viewer, `rev` spins in
- * the screen plane clockwise (+).
+ * Orientation sign convention. Object axes: +X right, +Y down, +Z toward the
+ * viewer (depth = d − z, so a corner with larger +z projects larger). The
+ * DrawingML `rot` latitude/longitude/revolution rotate in the OPPOSITE sense to
+ * a textbook right-handed rotation about those axes — `buildRotation` therefore
+ * spins by the NEGATED file angle. In the resulting (file-angle) terms:
+ *   - `lat` > 0 tips the TOP edge TOWARD the viewer (top edge widens / nears);
+ *     `lat` < 0 tips the top AWAY (top edge recedes). sample-11 slide 3 uses
+ *     lat = −30° → top recedes, matching the PDF (top/bottom width ≈ 0.82).
+ *   - `lon` > 0 turns the RIGHT edge TOWARD the viewer (right edge nears / grows
+ *     taller); `lon` < 0 turns the right edge away. sample-11 slide 3 uses
+ *     lon = +20° → right edge nearer, matching the PDF (left/right ≈ 0.94).
+ *   - `rev` > 0 spins the shape COUNTER-CLOCKWISE on screen; `rev` < 0 clockwise.
+ * These directions are calibrated against sample-11.pdf p3 (see DEFAULT_PERSP_FOV)
+ * and verified by the per-axis geometric unit tests. Preset base orientations
+ * below are written as the same file-angle lat/lon/rev so they compose with the
+ * file <a:rot> through one code path.
  */
 const PRESETS: Record<string, PresetDef> = {
   // ---- Orthographic / front-facing ----
@@ -130,10 +159,14 @@ const PRESETS: Record<string, PresetDef> = {
   // angles (see SPEC GAP). The file-level <a:rot> overrides them when present.
   perspectiveRelaxed: { kind: 'perspective', baseLat: 0, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
   perspectiveRelaxedModerately: { kind: 'perspective', baseLat: 0, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
-  // perspectiveAbove / perspectiveBelow: camera looks down / up at the shape.
-  perspectiveAbove: { kind: 'perspective', baseLat: 20, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
-  perspectiveBelow: { kind: 'perspective', baseLat: -20, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  // perspectiveAbove / perspectiveBelow: camera looks down at / up at the shape.
+  // "Above" → the top edge recedes, so lat < 0 in the file-angle convention
+  // documented above (lat < 0 tips the top away); "Below" → top nears, lat > 0.
+  perspectiveAbove: { kind: 'perspective', baseLat: -20, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
+  perspectiveBelow: { kind: 'perspective', baseLat: 20, baseLon: 0, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
   // Left / right facing perspective variants: shape turned about the Y axis.
+  // "Right" shows the right edge nearer (lon > 0); "Left" the left edge nearer
+  // (lon < 0). No ground truth for these — derived from the documented lon sign.
   perspectiveLeft: { kind: 'perspective', baseLat: 0, baseLon: -20, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
   perspectiveRight: { kind: 'perspective', baseLat: 0, baseLon: 20, baseRev: 0, fovDeg: DEFAULT_PERSP_FOV },
 };
@@ -201,7 +234,12 @@ function applyMat3(m: Mat3, x: number, y: number, z: number): [number, number, n
  * `rot` override. Per §20.1.5.11 the revolution is applied "about the axis as
  * the latitude and longitude coordinates", i.e. rev is the last (outermost)
  * rotation about the resulting view axis. We therefore compose
- *   R = Rz(rev) · Rx(lat) · Ry(lon).
+ *   R = Rz(−rev) · Rx(−lat) · Ry(−lon).
+ * The angles are NEGATED: DrawingML's sphere-coordinate rotations spin in the
+ * opposite sense to the textbook right-handed rotX/rotY/rotZ used here (the
+ * y-down screen axis flips the apparent handedness). This negated composition
+ * is the variant that fits the PowerPoint ground truth (sample-11.pdf p3) by
+ * 5–9× over every alternative order/sign — see DEFAULT_PERSP_FOV for the fit.
  * When an explicit `<a:rot>` is present it supplies lat/lon/rev directly
  * (replacing the preset base, per the override semantics in §20.1.5.5); when
  * absent we use the preset's base angles.
@@ -210,7 +248,7 @@ function buildRotation(preset: PresetDef, rot: RotInput | undefined): Mat3 {
   const lat = rot ? rot.lat : preset.baseLat;
   const lon = rot ? rot.lon : preset.baseLon;
   const rev = rot ? rot.rev : preset.baseRev;
-  return mul3(rotZ(rev), mul3(rotX(lat), rotY(lon)));
+  return mul3(rotZ(-rev), mul3(rotX(-lat), rotY(-lon)));
 }
 
 /** Look up a preset def, falling back to orthographicFront for unknown names. */

--- a/packages/core/src/shape/scene3d-draw.test.ts
+++ b/packages/core/src/shape/scene3d-draw.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { drawProjected } from './scene3d-draw';
+import { computeScene3dQuad, type Vec2 } from './scene3d-camera';
+
+/**
+ * Recording 2D context that captures setTransform + drawImage calls so we can
+ * assert the mesh-warp behaviour without a real canvas. drawProjected is pure
+ * geometry + compositing, so the op sequence is the contract under test.
+ */
+class RecordingCtx {
+  transforms: number[][] = [];
+  draws: Array<{ sx: number; sy: number; sw: number; sh: number; dx: number; dy: number; dw: number; dh: number }> = [];
+  clips = 0;
+  savedDepth = 0;
+  maxSavedDepth = 0;
+
+  save(): void {
+    this.savedDepth++;
+    this.maxSavedDepth = Math.max(this.maxSavedDepth, this.savedDepth);
+  }
+  restore(): void {
+    this.savedDepth--;
+  }
+  beginPath(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  closePath(): void {}
+  clip(): void {
+    this.clips++;
+  }
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+    this.transforms.push([a, b, c, d, e, f]);
+  }
+  drawImage(
+    _img: unknown,
+    sx: number,
+    sy: number,
+    sw: number,
+    sh: number,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number,
+  ): void {
+    this.draws.push({ sx, sy, sw, sh, dx, dy, dw, dh });
+  }
+}
+
+function asCtx(c: RecordingCtx): CanvasRenderingContext2D {
+  return c as unknown as CanvasRenderingContext2D;
+}
+
+const fakeImage = {} as CanvasImageSource;
+
+describe('drawProjected', () => {
+  it('draws an identity rectangle as a single un-subdivided affine cell', () => {
+    const ctx = new RecordingCtx();
+    const corners: [Vec2, Vec2, Vec2, Vec2] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 80 },
+      { x: 0, y: 80 },
+    ];
+    drawProjected(fakeImage, asCtx(ctx), 100, 80, corners);
+    // Identity quad has zero perspective error → no subdivision → one cell.
+    expect(ctx.draws.length).toBe(1);
+    expect(ctx.clips).toBe(1);
+    // The single cell's transform should be (approximately) the identity scale.
+    const [a, b, c, d] = ctx.transforms[0];
+    expect(a).toBeCloseTo(1, 3);
+    expect(b).toBeCloseTo(0, 3);
+    expect(c).toBeCloseTo(0, 3);
+    expect(d).toBeCloseTo(1, 3);
+  });
+
+  it('subdivides a perspective quad into many cells (error-driven mesh)', () => {
+    const ctx = new RecordingCtx();
+    // A strongly non-affine quad (foreshortened top edge).
+    const corners: [Vec2, Vec2, Vec2, Vec2] = [
+      { x: 30, y: 0 },
+      { x: 70, y: 0 },
+      { x: 100, y: 80 },
+      { x: 0, y: 80 },
+    ];
+    drawProjected(fakeImage, asCtx(ctx), 100, 80, corners, 0.5);
+    // Must subdivide well past a single cell to hold sub-pixel error.
+    expect(ctx.draws.length).toBeGreaterThan(4);
+  });
+
+  it('finer tolerance produces at least as many cells as a coarser one', () => {
+    const corners: [Vec2, Vec2, Vec2, Vec2] = [
+      { x: 30, y: 0 },
+      { x: 70, y: 0 },
+      { x: 100, y: 80 },
+      { x: 0, y: 80 },
+    ];
+    const coarse = new RecordingCtx();
+    const fine = new RecordingCtx();
+    drawProjected(fakeImage, asCtx(coarse), 100, 80, corners, 2);
+    drawProjected(fakeImage, asCtx(fine), 100, 80, corners, 0.25);
+    expect(fine.draws.length).toBeGreaterThanOrEqual(coarse.draws.length);
+  });
+
+  it('skips a degenerate (zero-area) quad without drawing', () => {
+    const ctx = new RecordingCtx();
+    const corners: [Vec2, Vec2, Vec2, Vec2] = [
+      { x: 10, y: 10 },
+      { x: 10, y: 10 },
+      { x: 10, y: 10 },
+      { x: 10, y: 10 },
+    ];
+    drawProjected(fakeImage, asCtx(ctx), 100, 80, corners);
+    expect(ctx.draws.length).toBe(0);
+  });
+
+  it('end-to-end: projects a camera quad onto cells covering the image', () => {
+    const ctx = new RecordingCtx();
+    const q = computeScene3dQuad(
+      { prst: 'perspectiveRelaxed', rot: { lat: 330, lon: 20, rev: 347 } },
+      200,
+      150,
+    );
+    drawProjected(fakeImage, asCtx(ctx), 200, 150, q.corners);
+    expect(ctx.draws.length).toBeGreaterThan(1);
+    // Every cell samples within the source image bounds (the bleed clamps).
+    for (const d of ctx.draws) {
+      expect(d.sx).toBeGreaterThanOrEqual(-1e-6);
+      expect(d.sy).toBeGreaterThanOrEqual(-1e-6);
+      expect(d.sx + d.sw).toBeLessThanOrEqual(200 + 1e-6);
+      expect(d.sy + d.sh).toBeLessThanOrEqual(150 + 1e-6);
+    }
+  });
+});

--- a/packages/core/src/shape/scene3d-draw.test.ts
+++ b/packages/core/src/shape/scene3d-draw.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { drawProjected } from './scene3d-draw';
 import { computeScene3dQuad, type Vec2 } from './scene3d-camera';
 
@@ -13,6 +13,8 @@ class RecordingCtx {
   clips = 0;
   savedDepth = 0;
   maxSavedDepth = 0;
+  imageSmoothingEnabled = true;
+  imageSmoothingQuality: 'low' | 'medium' | 'high' = 'low';
 
   save(): void {
     this.savedDepth++;
@@ -115,6 +117,88 @@ describe('drawProjected', () => {
     ];
     drawProjected(fakeImage, asCtx(ctx), 100, 80, corners);
     expect(ctx.draws.length).toBe(0);
+  });
+
+  // ── Supersampled path ──────────────────────────────────────────────────────
+  // When an aux canvas IS available (browser / OffscreenCanvas), drawProjected
+  // renders the mesh into an intermediate buffer at 2× device resolution and
+  // blits it down in one pass — this is what dissolves the per-cell seams. We
+  // stub OffscreenCanvas so the node test can exercise that path and assert its
+  // contract: the mesh cells land on the AUX ctx, and dst receives exactly one
+  // downscale drawImage at the identity transform.
+  describe('supersampled path (aux canvas available)', () => {
+    afterEach(() => {
+      // Remove the stub so the other tests keep exercising the fallback path.
+      delete (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas;
+    });
+
+    function installAuxStub(): { dst: RecordingCtx; auxes: RecordingCtx[] } {
+      const auxes: RecordingCtx[] = [];
+      class FakeOffscreen {
+        constructor(
+          public width: number,
+          public height: number,
+        ) {}
+        getContext(): RecordingCtx {
+          const c = new RecordingCtx();
+          auxes.push(c);
+          return c;
+        }
+      }
+      (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas = FakeOffscreen;
+      return { dst: new RecordingCtx(), auxes };
+    }
+
+    it('warps into the aux buffer and blits once onto dst (identity transform)', () => {
+      const { dst, auxes } = installAuxStub();
+      const corners: [Vec2, Vec2, Vec2, Vec2] = [
+        { x: 30, y: 0 },
+        { x: 70, y: 0 },
+        { x: 100, y: 80 },
+        { x: 0, y: 80 },
+      ];
+      drawProjected(fakeImage, asCtx(dst), 100, 80, corners, 0.5);
+
+      // One aux canvas allocated; its ctx carries the mesh cells.
+      expect(auxes.length).toBe(1);
+      expect(auxes[0].draws.length).toBeGreaterThan(4); // perspective → many cells
+      expect(auxes[0].clips).toBe(1); // quad clip on the aux buffer
+
+      // dst receives exactly the single downscale blit, at the identity transform.
+      expect(dst.draws.length).toBe(1);
+      const [a, b, c, d] = dst.transforms[dst.transforms.length - 1];
+      expect([a, b, c, d]).toEqual([1, 0, 0, 1]);
+      // The blit downscales the 2× buffer (sw,sh) into the 1× bbox (dw,dh).
+      const blit = dst.draws[0];
+      expect(blit.sw).toBeCloseTo(blit.dw * 2, 5);
+      expect(blit.sh).toBeCloseTo(blit.dh * 2, 5);
+    });
+
+    it('identity quad warped+blitted-back reproduces the source rect (within 1px)', () => {
+      // Contract for an identity camera: the source rectangle, warped through a
+      // quad equal to its own bounds and blitted back, must land on the same
+      // device rect. We verify the geometry end-to-end through the aux buffer:
+      // the downscale blit covers exactly the source's device bbox.
+      const { dst, auxes } = installAuxStub();
+      // A genuinely rectangular identity quad (source bounds → same bounds).
+      const rect: [Vec2, Vec2, Vec2, Vec2] = [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 80 },
+        { x: 0, y: 80 },
+      ];
+      drawProjected(fakeImage, asCtx(dst), 100, 80, rect, 0.5);
+      expect(auxes.length).toBe(1);
+      // Identity quad → single un-subdivided cell in the aux buffer.
+      expect(auxes[0].draws.length).toBe(1);
+      // Downscale blit back onto dst at identity covers ~the 100×80 source bbox
+      // (plus the 1px AA pad on each side → ≤102×82).
+      const blit = dst.draws[0];
+      expect(blit.dw).toBeGreaterThanOrEqual(100);
+      expect(blit.dw).toBeLessThanOrEqual(103);
+      expect(blit.dh).toBeGreaterThanOrEqual(80);
+      expect(blit.dh).toBeLessThanOrEqual(83);
+    });
   });
 
   it('end-to-end: projects a camera quad onto cells covering the image', () => {

--- a/packages/core/src/shape/scene3d-draw.test.ts
+++ b/packages/core/src/shape/scene3d-draw.test.ts
@@ -25,6 +25,10 @@ class RecordingCtx {
   moveTo(): void {}
   lineTo(): void {}
   closePath(): void {}
+  getTransform(): { a: number; b: number; c: number; d: number; e: number; f: number } {
+    // Identity base transform — the warp composes its cells on top of this.
+    return { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+  }
   clip(): void {
     this.clips++;
   }

--- a/packages/core/src/shape/scene3d-draw.test.ts
+++ b/packages/core/src/shape/scene3d-draw.test.ts
@@ -15,6 +15,12 @@ class RecordingCtx {
   maxSavedDepth = 0;
   imageSmoothingEnabled = true;
   imageSmoothingQuality: 'low' | 'medium' | 'high' = 'low';
+  /** Device scale the live transform reports (DPR). Cells compose on top of it. */
+  deviceScale = 1;
+
+  constructor(deviceScale = 1) {
+    this.deviceScale = deviceScale;
+  }
 
   save(): void {
     this.savedDepth++;
@@ -28,8 +34,8 @@ class RecordingCtx {
   lineTo(): void {}
   closePath(): void {}
   getTransform(): { a: number; b: number; c: number; d: number; e: number; f: number } {
-    // Identity base transform — the warp composes its cells on top of this.
-    return { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+    // Base transform = uniform device scale. The warp composes its cells on top.
+    return { a: this.deviceScale, b: 0, c: 0, d: this.deviceScale, e: 0, f: 0 };
   }
   clip(): void {
     this.clips++;
@@ -199,6 +205,27 @@ describe('drawProjected', () => {
       expect(blit.dh).toBeGreaterThanOrEqual(80);
       expect(blit.dh).toBeLessThanOrEqual(83);
     });
+  });
+
+  it('subdivides FINER at a higher device scale (raster-space error metric)', () => {
+    // Regression for the "white crack grid on large / HiDPI renders": the mesh
+    // density must track the cells' raster resolution, not the CSS corner space.
+    // A perspective quad rendered under a 2× live transform rasterises at 2×
+    // resolution, so its affine cells drift 2× as far in device px — the mesh
+    // must split further to keep adjacent cells overlapping. Measuring the error
+    // in CSS px (the old bug) left it scale-blind, under-subdividing at 2× and
+    // opening transparent seams.
+    const corners: [Vec2, Vec2, Vec2, Vec2] = [
+      { x: 30, y: 0 },
+      { x: 70, y: 0 },
+      { x: 100, y: 80 },
+      { x: 0, y: 80 },
+    ];
+    const at1 = new RecordingCtx(1);
+    const at2 = new RecordingCtx(2);
+    drawProjected(fakeImage, asCtx(at1), 100, 80, corners, 0.5);
+    drawProjected(fakeImage, asCtx(at2), 100, 80, corners, 0.5);
+    expect(at2.draws.length).toBeGreaterThan(at1.draws.length);
   });
 
   it('end-to-end: projects a camera quad onto cells covering the image', () => {

--- a/packages/core/src/shape/scene3d-draw.ts
+++ b/packages/core/src/shape/scene3d-draw.ts
@@ -1,0 +1,255 @@
+/**
+ * Draw a 2D bitmap warped into a projected quad (DrawingML 3D camera, Phase A).
+ *
+ * Canvas 2D has no native perspective (homography) transform — `setTransform`
+ * is affine only. We therefore map the source rectangle onto the destination
+ * quad with a piecewise-affine mesh: the source is split into a grid of cells,
+ * each cell is drawn with its own affine `setTransform` derived from the
+ * homography, and the grid is refined until the affine approximation error of
+ * every cell is below a sub-pixel threshold.
+ *
+ * This works with plain Canvas 2D (and skia-canvas in packages/node) — no
+ * WebGL — per the project's renderer constraints.
+ */
+
+import type { Vec2 } from './scene3d-camera';
+
+type AnyCtx = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+type AnyImage = CanvasImageSource;
+
+/** 3×3 homography in row-major order. */
+type H = [number, number, number, number, number, number, number, number, number];
+
+/**
+ * Solve the homography H that maps the unit square corners
+ *   (0,0) (1,0) (1,1) (0,1)
+ * to the four destination points d0..d3 (same TL,TR,BR,BL order).
+ *
+ * Standard projective mapping of a unit square to a quadrilateral
+ * (Heckbert, "Fundamentals of Texture Mapping and Image Warping", §2.2).
+ * Returns null if the quad is degenerate.
+ */
+function unitSquareToQuad(d0: Vec2, d1: Vec2, d2: Vec2, d3: Vec2): H | null {
+  const x0 = d0.x,
+    y0 = d0.y;
+  const x1 = d1.x,
+    y1 = d1.y;
+  const x2 = d2.x,
+    y2 = d2.y;
+  const x3 = d3.x,
+    y3 = d3.y;
+
+  const dx1 = x1 - x2;
+  const dx2 = x3 - x2;
+  const dx3 = x0 - x1 + x2 - x3;
+  const dy1 = y1 - y2;
+  const dy2 = y3 - y2;
+  const dy3 = y0 - y1 + y2 - y3;
+
+  let a13: number;
+  let a23: number;
+  if (Math.abs(dx3) < 1e-12 && Math.abs(dy3) < 1e-12) {
+    // Affine (parallelogram) case: g = h = 0.
+    a13 = 0;
+    a23 = 0;
+  } else {
+    const den = dx1 * dy2 - dx2 * dy1;
+    if (Math.abs(den) < 1e-12) return null;
+    a13 = (dx3 * dy2 - dx2 * dy3) / den;
+    a23 = (dx1 * dy3 - dx3 * dy1) / den;
+  }
+  const a11 = x1 - x0 + a13 * x1;
+  const a21 = x3 - x0 + a23 * x3;
+  const a31 = x0;
+  const a12 = y1 - y0 + a13 * y1;
+  const a22 = y3 - y0 + a23 * y3;
+  const a32 = y0;
+  // Row-major: [a11 a21 a31; a12 a22 a32; a13 a23 1]
+  return [a11, a21, a31, a12, a22, a32, a13, a23, 1];
+}
+
+/** Apply homography H to a unit-square coordinate (u,v) ∈ [0,1]². */
+function applyH(h: H, u: number, v: number): Vec2 {
+  const w = h[6] * u + h[7] * v + h[8];
+  return {
+    x: (h[0] * u + h[1] * v + h[2]) / w,
+    y: (h[3] * u + h[4] * v + h[5]) / w,
+  };
+}
+
+/**
+ * Draw the affine image of one source cell. Given the source-space rectangle
+ * [sx0,sx1]×[sy0,sy1] and the destination positions of its three corners
+ * (origin p0=TL, pu=TR, pv=BL), compute the affine matrix that sends the source
+ * rect to that parallelogram and `drawImage` the sub-rectangle through it.
+ *
+ * A 0.5px outward bleed on the source sub-rect (and a matching dest expansion)
+ * hides the hairline seams that otherwise appear between mesh cells from
+ * fractional-pixel sampling. The bleed is symmetric so adjacent cells overlap
+ * rather than gap.
+ */
+function drawCell(
+  ctx: AnyCtx,
+  img: AnyImage,
+  imgW: number,
+  imgH: number,
+  sx0: number,
+  sy0: number,
+  sx1: number,
+  sy1: number,
+  p0: Vec2,
+  pu: Vec2,
+  pv: Vec2,
+): void {
+  const sw = sx1 - sx0;
+  const sh = sy1 - sy0;
+  if (sw <= 0 || sh <= 0) return;
+
+  // Destination basis vectors (per unit of source u / v).
+  const ux = (pu.x - p0.x) / sw;
+  const uy = (pu.y - p0.y) / sw;
+  const vx = (pv.x - p0.x) / sh;
+  const vy = (pv.y - p0.y) / sh;
+
+  // Seam-hiding bleed: half a device pixel, expressed in source units along
+  // each axis (so the dest overlap is ~0.5px regardless of the cell's scale).
+  const destLenU = Math.hypot(pu.x - p0.x, pu.y - p0.y) || 1;
+  const destLenV = Math.hypot(pv.x - p0.x, pv.y - p0.y) || 1;
+  const bleedU = (0.5 * sw) / destLenU;
+  const bleedV = (0.5 * sh) / destLenV;
+
+  // Clamp the bled source rect into the image so we never sample outside it.
+  const bx0 = Math.max(0, sx0 - bleedU);
+  const by0 = Math.max(0, sy0 - bleedV);
+  const bx1 = Math.min(imgW, sx1 + bleedU);
+  const by1 = Math.min(imgH, sy1 + bleedV);
+  const bw = bx1 - bx0;
+  const bh = by1 - by0;
+  if (bw <= 0 || bh <= 0) return;
+
+  ctx.save();
+  // setTransform maps source pixel (sx,sy) → dest:
+  //   dest = p0 + (sx - sx0)*u_basis + (sy - sy0)*v_basis
+  // i.e. matrix (a,b,c,d,e,f) with a=ux, b=uy, c=vx, d=vy and translation
+  // chosen so source (sx0,sy0) lands on p0.
+  const e = p0.x - sx0 * ux - sy0 * vx;
+  const f = p0.y - sx0 * uy - sy0 * vy;
+  ctx.setTransform(ux, uy, vx, vy, e, f);
+  ctx.drawImage(img, bx0, by0, bw, bh, bx0, by0, bw, bh);
+  ctx.restore();
+}
+
+/**
+ * Recursively warp source sub-rect [u0,u1]×[v0,v1] (unit-square coords) into the
+ * destination quad described by homography H. A cell is drawn directly when its
+ * centre's affine-vs-homography disagreement is below `tol` device px; otherwise
+ * it is split along its longer axis and recursed. `depth` caps recursion so a
+ * pathological quad can't blow the stack.
+ */
+function warpRecursive(
+  ctx: AnyCtx,
+  img: AnyImage,
+  imgW: number,
+  imgH: number,
+  h: H,
+  u0: number,
+  v0: number,
+  u1: number,
+  v1: number,
+  tol: number,
+  depth: number,
+): void {
+  // Destination corners of this cell.
+  const c00 = applyH(h, u0, v0); // TL
+  const c10 = applyH(h, u1, v0); // TR
+  const c01 = applyH(h, u0, v1); // BL
+  const c11 = applyH(h, u1, v1); // BR
+
+  // Affine prediction of the cell centre (bilinear midpoint of the 4 dest
+  // corners) vs. the true homography position of the centre. Their distance is
+  // the perspective error this cell would incur if drawn as a single affine
+  // parallelogram.
+  const um = (u0 + u1) / 2;
+  const vm = (v0 + v1) / 2;
+  const trueMid = applyH(h, um, vm);
+  const affMid = {
+    x: (c00.x + c10.x + c01.x + c11.x) / 4,
+    y: (c00.y + c10.y + c01.y + c11.y) / 4,
+  };
+  const err = Math.hypot(trueMid.x - affMid.x, trueMid.y - affMid.y);
+
+  if (depth <= 0 || err <= tol) {
+    // Draw as two affine triangles' worth via a single parallelogram derived
+    // from the TL/TR/BL corners. The mesh is fine enough that the BR corner's
+    // residual is within tol, so one affine cell suffices.
+    const sx0 = u0 * imgW;
+    const sy0 = v0 * imgH;
+    const sx1 = u1 * imgW;
+    const sy1 = v1 * imgH;
+    drawCell(ctx, img, imgW, imgH, sx0, sy0, sx1, sy1, c00, c10, c01);
+    return;
+  }
+
+  // Split along the longer source axis to keep cells roughly square.
+  const du = u1 - u0;
+  const dv = v1 - v0;
+  if (du >= dv) {
+    warpRecursive(ctx, img, imgW, imgH, h, u0, v0, um, v1, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, h, um, v0, u1, v1, tol, depth - 1);
+  } else {
+    warpRecursive(ctx, img, imgW, imgH, h, u0, v0, u1, vm, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, h, u0, vm, u1, v1, tol, depth - 1);
+  }
+}
+
+/**
+ * Warp `src` (a `srcW`×`srcH` bitmap, e.g. an offscreen canvas of the shape's
+ * normal 2D rendering) into the destination quad `corners` on `dst`.
+ *
+ * @param corners  destination quad in TL,TR,BR,BL order, in `dst` pixel space.
+ *                 These come from `computeScene3dQuad`, already offset to the
+ *                 element's position by the caller.
+ * @param tol      max affine-approximation error per cell, in device px. The
+ *                 mesh subdivides until every cell is within this. Default 0.5px
+ *                 (sub-pixel — invisible at 1× and most HiDPI ratios). Not a
+ *                 magic cell count: the subdivision is error-driven.
+ */
+export function drawProjected(
+  src: AnyImage,
+  dst: AnyCtx,
+  srcW: number,
+  srcH: number,
+  corners: [Vec2, Vec2, Vec2, Vec2],
+  tol = 0.5,
+): void {
+  if (srcW <= 0 || srcH <= 0) return;
+  // Reject a degenerate (near-zero-area) destination quad. The signed area of
+  // the polygon TL,TR,BR,BL via the shoelace formula; |area| ~ 0 means the quad
+  // collapsed to a line / point and there is nothing to draw.
+  const [p0, p1, p2, p3] = corners;
+  const area =
+    Math.abs(
+      p0.x * p1.y - p1.x * p0.y +
+        p1.x * p2.y - p2.x * p1.y +
+        p2.x * p3.y - p3.x * p2.y +
+        p3.x * p0.y - p0.x * p3.y,
+    ) / 2;
+  if (area < 1e-6) return;
+  const h = unitSquareToQuad(corners[0], corners[1], corners[2], corners[3]);
+  if (!h) return; // degenerate quad — skip rather than draw garbage.
+
+  // Recursion cap: 2^7 = 128 splits per axis is far past sub-pixel for any sane
+  // tilt; the error test almost always stops much sooner.
+  const MAX_DEPTH = 14;
+  dst.save();
+  // Clip to the quad so the bleed overlap can't spill past the projected shape.
+  dst.beginPath();
+  dst.moveTo(corners[0].x, corners[0].y);
+  dst.lineTo(corners[1].x, corners[1].y);
+  dst.lineTo(corners[2].x, corners[2].y);
+  dst.lineTo(corners[3].x, corners[3].y);
+  dst.closePath();
+  dst.clip();
+  warpRecursive(dst, src, srcW, srcH, h, 0, 0, 1, 1, tol, MAX_DEPTH);
+  dst.restore();
+}

--- a/packages/core/src/shape/scene3d-draw.ts
+++ b/packages/core/src/shape/scene3d-draw.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Vec2 } from './scene3d-camera';
+import { createAuxCanvas } from './effects';
 
 type AnyCtx = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 type AnyImage = CanvasImageSource;
@@ -83,13 +84,30 @@ function applyH(h: H, u: number, v: number): Vec2 {
  * (origin p0=TL, pu=TR, pv=BL), compute the affine matrix that sends the source
  * rect to that parallelogram and `drawImage` the sub-rectangle through it.
  *
- * A 0.5px outward bleed on the source sub-rect (and a matching dest expansion)
- * hides the hairline seams that otherwise appear between mesh cells from
- * fractional-pixel sampling. The bleed is symmetric so adjacent cells overlap
- * rather than gap.
+ * Seam-hiding bleed: each cell is `drawImage`'d through `setTransform`, and the
+ * canvas anti-aliases the destination *edge* of that blit over ~1 device pixel
+ * (half a pixel either side of the geometric edge). Where two cells meet, those
+ * partial-alpha AA fringes have to land on each other's OPAQUE interior — if the
+ * overlap is narrower than the fringe, the background shows through the gap and
+ * the seam reads as a lighter line (the grid artefact). We therefore overlap
+ * adjacent cells by `bleedDevPx` *device* pixels on every side: the source
+ * sub-rect is expanded and the dest is expanded by exactly its affine image, so
+ * source and dest stay consistent (no edge-pixel stretching) and the opaque core
+ * of each cell fully covers its neighbour's fringe.
+ *
+ * The overlap must be measured in DEVICE pixels, not CSS pixels: the AA fringe is
+ * a rasteriser artefact and is ~1px wide *after* the device-scale in `base` is
+ * applied. A fixed CSS-px bleed under-covers on HiDPI (the fringe is DPR× wider in
+ * device space). Empirically (browser measurement, gradient source, extreme
+ * foreshortening, DPR 1 and 2) 0.5 device px leaves a residual seam (max Δ≈19–54)
+ * while ≥0.75 device px removes it entirely (max Δ≈0–1); we use 1.0 device px for
+ * headroom. Larger bleeds (tested to 1.5) introduce no sample-mismatch artefact.
  */
 /** A 2D affine transform as the canvas 6-tuple (a,b,c,d,e,f). */
 type Affine = [number, number, number, number, number, number];
+
+/** Overlap between adjacent mesh cells, in device pixels (see drawCell docs). */
+const BLEED_DEVICE_PX = 1.0;
 
 /**
  * Compose two canvas affine transforms: `base ∘ m` (apply m first, then base).
@@ -134,12 +152,17 @@ function drawCell(
   const vx = (pv.x - p0.x) / sh;
   const vy = (pv.y - p0.y) / sh;
 
-  // Seam-hiding bleed: half a device pixel, expressed in source units along
-  // each axis (so the dest overlap is ~0.5px regardless of the cell's scale).
-  const destLenU = Math.hypot(pu.x - p0.x, pu.y - p0.y) || 1;
-  const destLenV = Math.hypot(pv.x - p0.x, pv.y - p0.y) || 1;
-  const bleedU = (0.5 * sw) / destLenU;
-  const bleedV = (0.5 * sh) / destLenV;
+  // Seam-hiding bleed: BLEED_DEVICE_PX device pixels along each dest axis,
+  // expressed in source units. The cell's dest edge lengths (p0→pu, p0→pv) are
+  // in `base`'s pre-image space (CSS px), so multiply by the device scale folded
+  // into `base` to get the edge length in DEVICE px, then make the source bleed
+  // such that the dest overlap is BLEED_DEVICE_PX device px regardless of the
+  // cell's scale or the canvas DPR.
+  const devScale = Math.sqrt(Math.abs(base[0] * base[3] - base[1] * base[2])) || 1;
+  const destLenU = (Math.hypot(pu.x - p0.x, pu.y - p0.y) || 1) * devScale;
+  const destLenV = (Math.hypot(pv.x - p0.x, pv.y - p0.y) || 1) * devScale;
+  const bleedU = (BLEED_DEVICE_PX * sw) / destLenU;
+  const bleedV = (BLEED_DEVICE_PX * sh) / destLenV;
 
   // Clamp the bled source rect into the image so we never sample outside it.
   const bx0 = Math.max(0, sx0 - bleedU);
@@ -238,6 +261,27 @@ function warpRecursive(
  *                 mesh subdivides until every cell is within this. Default 0.5px
  *                 (sub-pixel — invisible at 1× and most HiDPI ratios). Not a
  *                 magic cell count: the subdivision is error-driven.
+ *
+ * ## Seam removal (mesh continuity)
+ * Two artefacts produce a visible grid of cell seams in flat / textured regions:
+ *   (1) the AA fringe of each cell's `drawImage` blit lets the background show
+ *       through where adjacent cells under-overlap — addressed by the per-cell
+ *       device-pixel bleed in `drawCell`;
+ *   (2) for textured sources, neighbouring cells resample the source with
+ *       slightly different filtering across the shared edge, and the bleed band
+ *       is composited twice, leaving a faint line that bleed alone cannot remove.
+ * To kill (2) we render the whole mesh into an intermediate canvas at
+ * `SUPERSAMPLE`× the device resolution of the quad's bounding box, then downscale
+ * it onto `dst` in one high-quality blit. Any residual seam shrinks by the
+ * supersample factor and lands sub-pixel after the box-filter downscale, so it is
+ * no longer resolvable. The silhouette's AA against the slide background is also
+ * produced by the single smooth downscale instead of per-cell edge AA.
+ *
+ * Cost: the intermediate is (bboxW·S)×(bboxH·S) device px (S=2 → 4× the quad's
+ * pixel count) plus one downscale blit. For a typical slide picture (~400×500
+ * device px) that is ~1.6M px of scratch and a sub-millisecond extra blit — only
+ * paid when a shape actually carries a scene3d camera. Falls back to the direct
+ * per-cell draw (bleed only) when no aux canvas is available (headless tests).
  */
 export function drawProjected(
   src: AnyImage,
@@ -266,12 +310,21 @@ export function drawProjected(
   // Recursion cap: 2^14 splits per axis is far past sub-pixel for any sane
   // tilt; the error test almost always stops much sooner.
   const MAX_DEPTH = 14;
-  dst.save();
   // Capture the live transform (DPR scale, the element's rotation/flip). Each
   // cell composes ITS map on top of this so the warp inherits the live
   // coordinate system instead of `setTransform` wiping it to the identity.
   const t = dst.getTransform();
   const base: Affine = [t.a, t.b, t.c, t.d, t.e, t.f];
+
+  // ── Supersampled path ────────────────────────────────────────────────────
+  // Render the mesh into an intermediate buffer at SUPERSAMPLE× the device
+  // resolution of the quad's bounding box, then blit it down in one go.
+  if (drawProjectedSupersampled(src, dst, srcW, srcH, corners, base, h, tol, MAX_DEPTH)) {
+    return;
+  }
+
+  // ── Direct path (fallback when no aux canvas, e.g. headless unit tests) ───
+  dst.save();
   // Clip to the quad so the bleed overlap can't spill past the projected shape.
   // The clip is built under the live transform (corners are in that space), so
   // it matches the cells which also run under the same base transform.
@@ -284,4 +337,111 @@ export function drawProjected(
   dst.clip();
   warpRecursive(dst, src, srcW, srcH, base, h, 0, 0, 1, 1, tol, MAX_DEPTH);
   dst.restore();
+}
+
+/** Supersample factor for the intermediate warp buffer (see drawProjected). */
+const SUPERSAMPLE = 2;
+
+/**
+ * Render the mesh warp into an intermediate canvas at SUPERSAMPLE× the device
+ * resolution of the quad's bounding box, then downscale it onto `dst`. Returns
+ * false (drawing nothing) when no aux canvas can be allocated, so the caller can
+ * fall back to the direct path.
+ */
+function drawProjectedSupersampled(
+  dstSrc: AnyImage,
+  dst: AnyCtx,
+  srcW: number,
+  srcH: number,
+  corners: [Vec2, Vec2, Vec2, Vec2],
+  base: Affine,
+  h: H,
+  tol: number,
+  maxDepth: number,
+): boolean {
+  // Device-space bounding box of the quad (corners are in base's pre-image
+  // space; map them through base to device px to size the intermediate).
+  const dev = corners.map((c) => ({
+    x: base[0] * c.x + base[2] * c.y + base[4],
+    y: base[1] * c.x + base[3] * c.y + base[5],
+  }));
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const d of dev) {
+    if (d.x < minX) minX = d.x;
+    if (d.y < minY) minY = d.y;
+    if (d.x > maxX) maxX = d.x;
+    if (d.y > maxY) maxY = d.y;
+  }
+  // Pad by 1 device px so the silhouette's outermost AA pixel isn't clipped.
+  minX = Math.floor(minX) - 1;
+  minY = Math.floor(minY) - 1;
+  maxX = Math.ceil(maxX) + 1;
+  maxY = Math.ceil(maxY) + 1;
+  const bboxW = maxX - minX;
+  const bboxH = maxY - minY;
+  if (bboxW <= 0 || bboxH <= 0) return false;
+
+  const aux = createAuxCanvas(bboxW * SUPERSAMPLE, bboxH * SUPERSAMPLE);
+  if (!aux) return false;
+  const actx = (aux.getContext('2d') as AnyCtx | null) ?? null;
+  if (!actx) return false;
+
+  // The intermediate maps device px (X,Y) → buffer px via
+  //   buf = (device - bboxMin) * SUPERSAMPLE.
+  // Compose that onto `base` (which maps base-space → device px) so the mesh
+  // cells, which run under `auxBase`, land at SUPERSAMPLE× device resolution.
+  const s = SUPERSAMPLE;
+  const auxBase: Affine = [
+    base[0] * s,
+    base[1] * s,
+    base[2] * s,
+    base[3] * s,
+    (base[4] - minX) * s,
+    (base[5] - minY) * s,
+  ];
+
+  actx.save();
+  // Clip to the quad (in base-space; auxBase carries the device + supersample
+  // scale) so the per-cell bleed can't spill past the projected silhouette.
+  actx.setTransform(auxBase[0], auxBase[1], auxBase[2], auxBase[3], auxBase[4], auxBase[5]);
+  actx.beginPath();
+  actx.moveTo(corners[0].x, corners[0].y);
+  actx.lineTo(corners[1].x, corners[1].y);
+  actx.lineTo(corners[2].x, corners[2].y);
+  actx.lineTo(corners[3].x, corners[3].y);
+  actx.closePath();
+  actx.clip();
+  // Tolerance is in device px; at SUPERSAMPLE× resolution the same visual
+  // tolerance corresponds to S× more buffer px, so subdivide to tol·S there.
+  warpRecursive(actx, dstSrc, srcW, srcH, auxBase, h, 0, 0, 1, 1, tol * s, maxDepth);
+  actx.restore();
+
+  // Blit the intermediate down onto dst. The intermediate covers device-px box
+  // [minX,minY,bboxW,bboxH]; draw it there under the IDENTITY transform (it is
+  // already in device space), with high-quality smoothing for the box-filter
+  // downscale that dissolves any residual seam.
+  dst.save();
+  dst.setTransform(1, 0, 0, 1, 0, 0);
+  const prevSmoothing = dst.imageSmoothingEnabled;
+  const prevQuality = dst.imageSmoothingQuality;
+  dst.imageSmoothingEnabled = true;
+  dst.imageSmoothingQuality = 'high';
+  dst.drawImage(
+    aux as unknown as CanvasImageSource,
+    0,
+    0,
+    bboxW * s,
+    bboxH * s,
+    minX,
+    minY,
+    bboxW,
+    bboxH,
+  );
+  dst.imageSmoothingEnabled = prevSmoothing;
+  dst.imageSmoothingQuality = prevQuality;
+  dst.restore();
+  return true;
 }

--- a/packages/core/src/shape/scene3d-draw.ts
+++ b/packages/core/src/shape/scene3d-draw.ts
@@ -88,11 +88,34 @@ function applyH(h: H, u: number, v: number): Vec2 {
  * fractional-pixel sampling. The bleed is symmetric so adjacent cells overlap
  * rather than gap.
  */
+/** A 2D affine transform as the canvas 6-tuple (a,b,c,d,e,f). */
+type Affine = [number, number, number, number, number, number];
+
+/**
+ * Compose two canvas affine transforms: `base ∘ m` (apply m first, then base).
+ * Matches DOMMatrix.multiply semantics for the 2D 6-tuple form, so the cell
+ * transform stacks ON TOP of the live ctx transform (DPR scale, rotation, flip)
+ * instead of replacing it.
+ */
+function composeAffine(base: Affine, m: Affine): Affine {
+  const [a0, b0, c0, d0, e0, f0] = base;
+  const [a1, b1, c1, d1, e1, f1] = m;
+  return [
+    a0 * a1 + c0 * b1,
+    b0 * a1 + d0 * b1,
+    a0 * c1 + c0 * d1,
+    b0 * c1 + d0 * d1,
+    a0 * e1 + c0 * f1 + e0,
+    b0 * e1 + d0 * f1 + f0,
+  ];
+}
+
 function drawCell(
   ctx: AnyCtx,
   img: AnyImage,
   imgW: number,
   imgH: number,
+  base: Affine,
   sx0: number,
   sy0: number,
   sx1: number,
@@ -128,13 +151,14 @@ function drawCell(
   if (bw <= 0 || bh <= 0) return;
 
   ctx.save();
-  // setTransform maps source pixel (sx,sy) → dest:
+  // The cell maps source pixel (sx,sy) → dest (in the SAME space as the quad
+  // corners, i.e. the caller's CSS-pixel space):
   //   dest = p0 + (sx - sx0)*u_basis + (sy - sy0)*v_basis
-  // i.e. matrix (a,b,c,d,e,f) with a=ux, b=uy, c=vx, d=vy and translation
-  // chosen so source (sx0,sy0) lands on p0.
   const e = p0.x - sx0 * ux - sy0 * vx;
   const f = p0.y - sx0 * uy - sy0 * vy;
-  ctx.setTransform(ux, uy, vx, vy, e, f);
+  // Compose ON TOP of the live transform so DPR / rotation / flip are preserved.
+  const [ca, cb, cc, cd, ce, cf] = composeAffine(base, [ux, uy, vx, vy, e, f]);
+  ctx.setTransform(ca, cb, cc, cd, ce, cf);
   ctx.drawImage(img, bx0, by0, bw, bh, bx0, by0, bw, bh);
   ctx.restore();
 }
@@ -151,6 +175,7 @@ function warpRecursive(
   img: AnyImage,
   imgW: number,
   imgH: number,
+  base: Affine,
   h: H,
   u0: number,
   v0: number,
@@ -186,7 +211,7 @@ function warpRecursive(
     const sy0 = v0 * imgH;
     const sx1 = u1 * imgW;
     const sy1 = v1 * imgH;
-    drawCell(ctx, img, imgW, imgH, sx0, sy0, sx1, sy1, c00, c10, c01);
+    drawCell(ctx, img, imgW, imgH, base, sx0, sy0, sx1, sy1, c00, c10, c01);
     return;
   }
 
@@ -194,11 +219,11 @@ function warpRecursive(
   const du = u1 - u0;
   const dv = v1 - v0;
   if (du >= dv) {
-    warpRecursive(ctx, img, imgW, imgH, h, u0, v0, um, v1, tol, depth - 1);
-    warpRecursive(ctx, img, imgW, imgH, h, um, v0, u1, v1, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, h, u0, v0, um, v1, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, h, um, v0, u1, v1, tol, depth - 1);
   } else {
-    warpRecursive(ctx, img, imgW, imgH, h, u0, v0, u1, vm, tol, depth - 1);
-    warpRecursive(ctx, img, imgW, imgH, h, u0, vm, u1, v1, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, h, u0, v0, u1, vm, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, h, u0, vm, u1, v1, tol, depth - 1);
   }
 }
 
@@ -238,11 +263,18 @@ export function drawProjected(
   const h = unitSquareToQuad(corners[0], corners[1], corners[2], corners[3]);
   if (!h) return; // degenerate quad — skip rather than draw garbage.
 
-  // Recursion cap: 2^7 = 128 splits per axis is far past sub-pixel for any sane
+  // Recursion cap: 2^14 splits per axis is far past sub-pixel for any sane
   // tilt; the error test almost always stops much sooner.
   const MAX_DEPTH = 14;
   dst.save();
+  // Capture the live transform (DPR scale, the element's rotation/flip). Each
+  // cell composes ITS map on top of this so the warp inherits the live
+  // coordinate system instead of `setTransform` wiping it to the identity.
+  const t = dst.getTransform();
+  const base: Affine = [t.a, t.b, t.c, t.d, t.e, t.f];
   // Clip to the quad so the bleed overlap can't spill past the projected shape.
+  // The clip is built under the live transform (corners are in that space), so
+  // it matches the cells which also run under the same base transform.
   dst.beginPath();
   dst.moveTo(corners[0].x, corners[0].y);
   dst.lineTo(corners[1].x, corners[1].y);
@@ -250,6 +282,6 @@ export function drawProjected(
   dst.lineTo(corners[3].x, corners[3].y);
   dst.closePath();
   dst.clip();
-  warpRecursive(dst, src, srcW, srcH, h, 0, 0, 1, 1, tol, MAX_DEPTH);
+  warpRecursive(dst, src, srcW, srcH, base, h, 0, 0, 1, 1, tol, MAX_DEPTH);
   dst.restore();
 }

--- a/packages/core/src/shape/scene3d-draw.ts
+++ b/packages/core/src/shape/scene3d-draw.ts
@@ -95,13 +95,30 @@ function applyH(h: H, u: number, v: number): Vec2 {
  * source and dest stay consistent (no edge-pixel stretching) and the opaque core
  * of each cell fully covers its neighbour's fringe.
  *
- * The overlap must be measured in DEVICE pixels, not CSS pixels: the AA fringe is
- * a rasteriser artefact and is ~1px wide *after* the device-scale in `base` is
- * applied. A fixed CSS-px bleed under-covers on HiDPI (the fringe is DPR× wider in
- * device space). Empirically (browser measurement, gradient source, extreme
- * foreshortening, DPR 1 and 2) 0.5 device px leaves a residual seam (max Δ≈19–54)
- * while ≥0.75 device px removes it entirely (max Δ≈0–1); we use 1.0 device px for
- * headroom. Larger bleeds (tested to 1.5) introduce no sample-mismatch artefact.
+ * The overlap must be measured in the DEVICE pixels of the FINAL `dst` image,
+ * not CSS pixels and not the intermediate buffer's pixels: the AA fringe / gap
+ * the bleed has to cover is a `dst`-rasteriser artefact ~1px wide after the
+ * device scale. A fixed CSS-px bleed under-covers on HiDPI (the fringe is DPR×
+ * wider in device space).
+ *
+ * Crucially the bleed is sized off `bleedDevScale` — the linear scale from the
+ * cell-coordinate space to FINAL `dst` device px — NOT off `base`'s own scale.
+ * In the supersampled path the cells run under `auxBase = base · SUPERSAMPLE`, so
+ * `base`'s scale is SUPERSAMPLE× the dst scale; sizing the bleed off it would
+ * yield only `BLEED_DEVICE_PX / SUPERSAMPLE` device px of overlap after the
+ * downscale (≈0.5 px at S=2 — below the fringe width), which lets the slide
+ * background show through as a grid of fully-transparent cracks. The crack count
+ * grows with the shape's on-screen size because a larger quad subdivides into
+ * more cells, so more interior cell boundaries under-cover. Passing the true
+ * dst-device scale makes the overlap a constant `BLEED_DEVICE_PX` device px of
+ * the final image regardless of the shape's size, the canvas DPR, or the
+ * supersample factor.
+ *
+ * Empirically (browser measurement, gradient source, extreme foreshortening,
+ * DPR 1/2/3, shapes from 280–1400 css px) 0.5 device px leaves transparent
+ * cracks; ≥1.0 device px of FINAL-image overlap removes them entirely. We use
+ * 1.0 device px. Larger bleeds (tested to 1.5) introduce no sample-mismatch
+ * artefact.
  */
 /** A 2D affine transform as the canvas 6-tuple (a,b,c,d,e,f). */
 type Affine = [number, number, number, number, number, number];
@@ -134,6 +151,7 @@ function drawCell(
   imgW: number,
   imgH: number,
   base: Affine,
+  bleedDevScale: number,
   sx0: number,
   sy0: number,
   sx1: number,
@@ -152,15 +170,18 @@ function drawCell(
   const vx = (pv.x - p0.x) / sh;
   const vy = (pv.y - p0.y) / sh;
 
-  // Seam-hiding bleed: BLEED_DEVICE_PX device pixels along each dest axis,
-  // expressed in source units. The cell's dest edge lengths (p0→pu, p0→pv) are
-  // in `base`'s pre-image space (CSS px), so multiply by the device scale folded
-  // into `base` to get the edge length in DEVICE px, then make the source bleed
-  // such that the dest overlap is BLEED_DEVICE_PX device px regardless of the
-  // cell's scale or the canvas DPR.
-  const devScale = Math.sqrt(Math.abs(base[0] * base[3] - base[1] * base[2])) || 1;
-  const destLenU = (Math.hypot(pu.x - p0.x, pu.y - p0.y) || 1) * devScale;
-  const destLenV = (Math.hypot(pv.x - p0.x, pv.y - p0.y) || 1) * devScale;
+  // Seam-hiding bleed: BLEED_DEVICE_PX pixels of the FINAL dst image along each
+  // dest axis, expressed in source units. The cell's dest edge lengths (p0→pu,
+  // p0→pv) are in the cell-coordinate space (the same space as the quad
+  // corners), so multiply by `bleedDevScale` — the scale from that space to
+  // FINAL dst device px — to get the edge length in dst device px, then size the
+  // source bleed so the dest overlap is BLEED_DEVICE_PX dst device px regardless
+  // of the cell's scale, the canvas DPR, or the intermediate supersample factor.
+  // (Deliberately NOT `base`'s scale: in the supersampled path `base` carries the
+  // extra ×SUPERSAMPLE, which would shrink the post-downscale overlap below the
+  // fringe width and reopen the cracks.)
+  const destLenU = (Math.hypot(pu.x - p0.x, pu.y - p0.y) || 1) * bleedDevScale;
+  const destLenV = (Math.hypot(pv.x - p0.x, pv.y - p0.y) || 1) * bleedDevScale;
   const bleedU = (BLEED_DEVICE_PX * sw) / destLenU;
   const bleedV = (BLEED_DEVICE_PX * sh) / destLenV;
 
@@ -189,9 +210,20 @@ function drawCell(
 /**
  * Recursively warp source sub-rect [u0,u1]×[v0,v1] (unit-square coords) into the
  * destination quad described by homography H. A cell is drawn directly when its
- * centre's affine-vs-homography disagreement is below `tol` device px; otherwise
- * it is split along its longer axis and recursed. `depth` caps recursion so a
- * pathological quad can't blow the stack.
+ * affine-vs-homography disagreement is below `tol` of the cells' OWN raster
+ * pixels; otherwise it is split along its longer axis and recursed. `depth` caps
+ * recursion so a pathological quad can't blow the stack.
+ *
+ * The error MUST be measured in the cells' raster space, not the (CSS) corner
+ * space: the cell corners arrive in the live-transform pre-image space, but the
+ * cells actually rasterise under `base`, whose scale is the DPR (direct path) or
+ * DPR·SUPERSAMPLE (intermediate buffer). Comparing a CSS-px residual against a
+ * device-px tolerance under-subdivides as the shape gets larger or the DPR rises,
+ * leaving affine cells whose drift across their shared edge exceeds the seam
+ * bleed — that drift is exactly what opened the grid of transparent cracks on
+ * large / HiDPI renders. Scaling the residual by `base`'s linear scale ties the
+ * mesh density to the actual raster resolution, so the seam stays covered at
+ * every shape size, DPR, and supersample factor.
  */
 function warpRecursive(
   ctx: AnyCtx,
@@ -199,6 +231,7 @@ function warpRecursive(
   imgW: number,
   imgH: number,
   base: Affine,
+  bleedDevScale: number,
   h: H,
   u0: number,
   v0: number,
@@ -216,7 +249,9 @@ function warpRecursive(
   // Affine prediction of the cell centre (bilinear midpoint of the 4 dest
   // corners) vs. the true homography position of the centre. Their distance is
   // the perspective error this cell would incur if drawn as a single affine
-  // parallelogram.
+  // parallelogram. The corners are in the live-transform pre-image space, so
+  // scale the residual by `base`'s linear scale to express it in the cells' own
+  // raster pixels — the space `tol` is defined in (see the doc comment).
   const um = (u0 + u1) / 2;
   const vm = (v0 + v1) / 2;
   const trueMid = applyH(h, um, vm);
@@ -224,7 +259,8 @@ function warpRecursive(
     x: (c00.x + c10.x + c01.x + c11.x) / 4,
     y: (c00.y + c10.y + c01.y + c11.y) / 4,
   };
-  const err = Math.hypot(trueMid.x - affMid.x, trueMid.y - affMid.y);
+  const baseScale = affineScale(base);
+  const err = Math.hypot(trueMid.x - affMid.x, trueMid.y - affMid.y) * baseScale;
 
   if (depth <= 0 || err <= tol) {
     // Draw as two affine triangles' worth via a single parallelogram derived
@@ -234,7 +270,7 @@ function warpRecursive(
     const sy0 = v0 * imgH;
     const sx1 = u1 * imgW;
     const sy1 = v1 * imgH;
-    drawCell(ctx, img, imgW, imgH, base, sx0, sy0, sx1, sy1, c00, c10, c01);
+    drawCell(ctx, img, imgW, imgH, base, bleedDevScale, sx0, sy0, sx1, sy1, c00, c10, c01);
     return;
   }
 
@@ -242,11 +278,11 @@ function warpRecursive(
   const du = u1 - u0;
   const dv = v1 - v0;
   if (du >= dv) {
-    warpRecursive(ctx, img, imgW, imgH, base, h, u0, v0, um, v1, tol, depth - 1);
-    warpRecursive(ctx, img, imgW, imgH, base, h, um, v0, u1, v1, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, bleedDevScale, h, u0, v0, um, v1, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, bleedDevScale, h, um, v0, u1, v1, tol, depth - 1);
   } else {
-    warpRecursive(ctx, img, imgW, imgH, base, h, u0, v0, u1, vm, tol, depth - 1);
-    warpRecursive(ctx, img, imgW, imgH, base, h, u0, vm, u1, v1, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, bleedDevScale, h, u0, v0, u1, vm, tol, depth - 1);
+    warpRecursive(ctx, img, imgW, imgH, base, bleedDevScale, h, u0, vm, u1, v1, tol, depth - 1);
   }
 }
 
@@ -315,13 +351,21 @@ export function drawProjected(
   // coordinate system instead of `setTransform` wiping it to the identity.
   const t = dst.getTransform();
   const base: Affine = [t.a, t.b, t.c, t.d, t.e, t.f];
+  // Linear scale from the live (corner) coordinate space to dst device px.
+  const dstDevScale = affineScale(base);
 
   // ── Supersampled path ────────────────────────────────────────────────────
   // Render the mesh into an intermediate buffer at SUPERSAMPLE× the device
   // resolution of the quad's bounding box, then blit it down in one go.
-  if (drawProjectedSupersampled(src, dst, srcW, srcH, corners, base, h, tol, MAX_DEPTH)) {
+  if (drawProjectedSupersampled(src, dst, srcW, srcH, corners, base, dstDevScale, h, tol, MAX_DEPTH)) {
     return;
   }
+
+  // No aux canvas (e.g. headless unit tests, or a context that refused an
+  // OffscreenCanvas / <canvas>): fall back to drawing the mesh directly onto
+  // dst with per-cell bleed only. This lacks the supersample downscale that
+  // dissolves textured-source seams, so warn once instead of degrading silently.
+  warnFallbackOnce();
 
   // ── Direct path (fallback when no aux canvas, e.g. headless unit tests) ───
   dst.save();
@@ -335,8 +379,31 @@ export function drawProjected(
   dst.lineTo(corners[3].x, corners[3].y);
   dst.closePath();
   dst.clip();
-  warpRecursive(dst, src, srcW, srcH, base, h, 0, 0, 1, 1, tol, MAX_DEPTH);
+  warpRecursive(dst, src, srcW, srcH, base, dstDevScale, h, 0, 0, 1, 1, tol, MAX_DEPTH);
   dst.restore();
+}
+
+/** Uniform linear scale of an affine 6-tuple (√|det|), clamped to ≥ a tiny ε. */
+function affineScale(m: Affine): number {
+  return Math.sqrt(Math.abs(m[0] * m[3] - m[1] * m[2])) || 1;
+}
+
+let fallbackWarned = false;
+/**
+ * Warn (once per process) that scene3d warp fell back to the non-supersampled
+ * direct path because no aux canvas was available. Guarded so a deck with many
+ * 3D shapes doesn't flood the console.
+ */
+function warnFallbackOnce(): void {
+  if (fallbackWarned) return;
+  fallbackWarned = true;
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(
+      '[ooxml] scene3d: no offscreen canvas available — using the direct warp ' +
+        'fallback (per-cell bleed only, no supersample). Textured-source seams ' +
+        'may be faintly visible; the silhouette and geometry are unaffected.',
+    );
+  }
 }
 
 /** Supersample factor for the intermediate warp buffer (see drawProjected). */
@@ -355,6 +422,7 @@ function drawProjectedSupersampled(
   srcH: number,
   corners: [Vec2, Vec2, Vec2, Vec2],
   base: Affine,
+  dstDevScale: number,
   h: H,
   tol: number,
   maxDepth: number,
@@ -416,7 +484,11 @@ function drawProjectedSupersampled(
   actx.clip();
   // Tolerance is in device px; at SUPERSAMPLE× resolution the same visual
   // tolerance corresponds to S× more buffer px, so subdivide to tol·S there.
-  warpRecursive(actx, dstSrc, srcW, srcH, auxBase, h, 0, 0, 1, 1, tol * s, maxDepth);
+  // The bleed, however, is sized off `dstDevScale` (the FINAL dst device scale),
+  // NOT auxBase's scale — auxBase is S× larger, and sizing the bleed off it would
+  // leave only BLEED_DEVICE_PX/S device px of overlap after the downscale, which
+  // reopens the transparent cell-seam cracks at large shape sizes.
+  warpRecursive(actx, dstSrc, srcW, srcH, auxBase, dstDevScale, h, 0, 0, 1, 1, tol * s, maxDepth);
   actx.restore();
 
   // Blit the intermediate down onto dst. The intermediate covers device-px box

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -785,6 +785,11 @@ struct Sp3d {
     #[serde(skip_serializing_if = "is_zero_i64")]
     #[serde(default)]
     contour_w: i64,
+    /// Contour colour (`<a:contourClr>` child, ECMA-376 §20.1.5.12). Resolved
+    /// hex (e.g. "969696"). `None` when absent (the schema default is to reuse
+    /// the shape's line/fill colour, which the renderer does not approximate).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    contour_clr: Option<String>,
     /// Preset surface material (`ST_PresetMaterialType`), default "warmMatte".
     prst_material: String,
     /// Top bevel.
@@ -894,6 +899,13 @@ struct PictureElement {
     flip_h: bool,
     flip_v: bool,
     data_url: String,
+    /// Border line from `<p:pic><p:spPr><a:ln>` (ECMA-376 §20.1.2.2.24
+    /// CT_LineProperties; §19.3.1.37 routes a `p:pic`'s spPr through
+    /// CT_ShapeProperties, so a picture carries the same line as a shape). Same
+    /// model as `ShapeElement.stroke`. `None` when there is no `<a:ln>` or it
+    /// resolves to `<a:noFill/>` (border explicitly suppressed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<Stroke>,
     /// OOXML adj value (0–100000) for roundRect clip; None = plain rectangle
     #[serde(skip_serializing_if = "Option::is_none")]
     clip_adjust: Option<i64>,
@@ -2189,10 +2201,15 @@ fn parse_bevel3d(bevel: roxmltree::Node<'_, '_>) -> Bevel3d {
 /// full but not rendered in Phase A.
 fn parse_sp3d(sppr: roxmltree::Node<'_, '_>) -> Option<Sp3d> {
     let n = child(sppr, "sp3d")?;
+    // contourClr is colour-only here; pass an empty theme map because sp3d
+    // contour colours in practice are srgbClr (no theme lookup needed) and this
+    // parser has the theme threaded only into the line/fill paths.
+    let contour_clr = child(n, "contourClr").and_then(|c| parse_color_node(c, &HashMap::new()));
     Some(Sp3d {
         z: attr_i64(&n, "z").unwrap_or(0),
         extrusion_h: attr_i64(&n, "extrusionH").unwrap_or(0),
         contour_w: attr_i64(&n, "contourW").unwrap_or(0),
+        contour_clr,
         prst_material: attr(&n, "prstMaterial").unwrap_or_else(|| "warmMatte".into()),
         bevel_t: child(n, "bevelT").map(parse_bevel3d),
         bevel_b: child(n, "bevelB").map(parse_bevel3d),
@@ -5822,6 +5839,11 @@ fn parse_picture(
         reflection,
     } = parse_effect_lst(child(sp_pr, "effectLst"), theme);
 
+    // §20.1.2.2.24 — a `p:pic`'s spPr may carry an `<a:ln>` border (e.g. the
+    // white frame of PowerPoint's picture styles). `parse_stroke` returns None
+    // for `<a:noFill/>`, so an explicitly border-less picture stays None.
+    let stroke = child(sp_pr, "ln").and_then(|n| parse_stroke(n, theme));
+
     Some(PictureElement {
         x: t.x,
         y: t.y,
@@ -5831,6 +5853,7 @@ fn parse_picture(
         flip_h: t.flip_h,
         flip_v: t.flip_v,
         data_url,
+        stroke,
         clip_adjust: parse_round_rect_clip_adjust(sp_pr),
         src_rect: parse_src_rect(blip_fill),
         alpha: parse_blip_alpha(blip_fill),
@@ -6843,6 +6866,11 @@ fn parse_sp_tree_node(
                                     sp_pr_node.and_then(|p| child(p, "effectLst")),
                                     theme,
                                 );
+                                // §20.1.2.2.24 — a blipFill-painted sp can carry
+                                // an `<a:ln>` border just like a real p:pic.
+                                let stroke = sp_pr_node
+                                    .and_then(|p| child(p, "ln"))
+                                    .and_then(|n| parse_stroke(n, theme));
                                 out.push(SlideElement::Picture(PictureElement {
                                     x: t.x,
                                     y: t.y,
@@ -6852,6 +6880,7 @@ fn parse_sp_tree_node(
                                     flip_h: t.flip_h,
                                     flip_v: t.flip_v,
                                     data_url,
+                                    stroke,
                                     clip_adjust,
                                     src_rect: blip_fill_node.and_then(parse_src_rect),
                                     alpha: blip_fill_node.and_then(parse_blip_alpha),
@@ -6885,6 +6914,13 @@ fn parse_sp_tree_node(
                         let t = slide_xfrm.or_else(|| lph.lookup(&ph_type, ph_idx).cloned());
                         if let Some(t) = t {
                             if t.cx > 0 && t.cy > 0 {
+                                // §20.1.2.2.24 — honour the slide sp's own `<a:ln>`
+                                // border, falling back to the inherited layout
+                                // placeholder stroke when the slide omits one.
+                                let stroke = match sp_pr_node.and_then(|p| child(p, "ln")) {
+                                    Some(ln) => parse_stroke(ln, theme),
+                                    None => lph.lookup_stroke(&ph_type, ph_idx),
+                                };
                                 out.push(SlideElement::Picture(PictureElement {
                                     x: t.x,
                                     y: t.y,
@@ -6894,6 +6930,7 @@ fn parse_sp_tree_node(
                                     flip_h: t.flip_h,
                                     flip_v: t.flip_v,
                                     data_url: bf.data_url,
+                                    stroke,
                                     clip_adjust: None,
                                     src_rect: bf.src_rect,
                                     alpha: bf.alpha,
@@ -6941,6 +6978,14 @@ fn parse_sp_tree_node(
                                     let mime = mime_from_ext(&image_path);
                                     let data_url =
                                         format!("data:{mime};base64,{}", B64.encode(&image_bytes));
+                                    // §20.1.2.2.24 — placeholder pic border: the
+                                    // p:pic's own `<a:ln>`, else the inherited
+                                    // layout placeholder stroke.
+                                    let stroke =
+                                        match child(node, "spPr").and_then(|p| child(p, "ln")) {
+                                            Some(ln) => parse_stroke(ln, theme),
+                                            None => lph.by_idx_stroke.get(&idx).cloned(),
+                                        };
                                     out.push(SlideElement::Picture(PictureElement {
                                         x: t.x,
                                         y: t.y,
@@ -6950,6 +6995,7 @@ fn parse_sp_tree_node(
                                         flip_h: t.flip_h,
                                         flip_v: t.flip_v,
                                         data_url,
+                                        stroke,
                                         clip_adjust: None,
                                         src_rect: blip_fill.and_then(parse_src_rect),
                                         alpha: blip_fill.and_then(parse_blip_alpha),
@@ -8824,5 +8870,82 @@ mod tests {
         let sppr = parse_sppr_frag(&doc);
         assert!(parse_scene3d(sppr).is_none());
         assert!(parse_sp3d(sppr).is_none());
+    }
+
+    // ===== sp3d contour colour (ECMA-376 §20.1.5.12 contourClr) =====
+
+    #[test]
+    fn test_parse_sp3d_contour_clr_slide3() {
+        // The exact sp3d from sample-11 slide 3: contourW + grey contourClr.
+        let xml = r#"<root
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:spPr>
+            <a:sp3d contourW="6350" prstMaterial="matte">
+              <a:bevelT w="101600" h="101600"/>
+              <a:contourClr><a:srgbClr val="969696"/></a:contourClr>
+            </a:sp3d>
+          </p:spPr>
+        </root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sppr = parse_sppr_frag(&doc);
+        let sp3d = parse_sp3d(sppr).expect("sp3d should parse");
+        assert_eq!(sp3d.contour_w, 6350);
+        assert_eq!(sp3d.contour_clr.as_deref(), Some("969696"));
+        let json = serde_json::to_string(&sp3d).unwrap();
+        assert!(json.contains("\"contourClr\":\"969696\""), "{json}");
+    }
+
+    #[test]
+    fn test_parse_sp3d_contour_clr_absent() {
+        let xml = r#"<root
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:spPr><a:sp3d contourW="6350"/></p:spPr>
+        </root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sppr = parse_sppr_frag(&doc);
+        let sp3d = parse_sp3d(sppr).unwrap();
+        assert!(sp3d.contour_clr.is_none());
+        // Omitted from JSON when absent.
+        let json = serde_json::to_string(&sp3d).unwrap();
+        assert!(!json.contains("contourClr"), "{json}");
+    }
+
+    // ===== picture a:ln stroke (ECMA-376 §20.1.2.2.24, §19.3.1.37) =====
+
+    #[test]
+    fn test_parse_pic_stroke_solid_fill() {
+        // <p:pic>'s spPr > ln with a solidFill → a visible border.
+        let xml = r#"<root
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:spPr>
+            <a:ln w="38100"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></a:ln>
+          </p:spPr>
+        </root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sppr = parse_sppr_frag(&doc);
+        let theme: HashMap<String, String> = HashMap::new();
+        let stroke = child(sppr, "ln")
+            .and_then(|n| parse_stroke(n, &theme))
+            .expect("pic stroke should parse");
+        assert_eq!(stroke.color, "FFFFFF");
+        assert_eq!(stroke.width, 38100);
+    }
+
+    #[test]
+    fn test_parse_pic_stroke_no_fill_is_none() {
+        // sample-11's pic borders are <a:ln><a:noFill/></a:ln> → no border.
+        let xml = r#"<root
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:spPr><a:ln><a:noFill/></a:ln></p:spPr>
+        </root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sppr = parse_sppr_frag(&doc);
+        let theme: HashMap<String, String> = HashMap::new();
+        let stroke = child(sppr, "ln").and_then(|n| parse_stroke(n, &theme));
+        assert!(stroke.is_none());
     }
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -691,6 +691,110 @@ struct TextRect {
     height: i64,
 }
 
+/// DrawingML 3D rotation in sphere coordinates — ECMA-376 §20.1.5.11
+/// (`CT_SphereCoords`). All three angles are stored in **degrees** (the XML
+/// carries 60000ths of a degree; we divide once here). Per the spec, `lat` and
+/// `lon` are latitude/longitude and `rev` is the revolution about the resulting
+/// view axis.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+struct Rot3d {
+    /// Latitude — rotation about the horizontal (X) axis, degrees.
+    lat: f64,
+    /// Longitude — rotation about the vertical (Y) axis, degrees.
+    lon: f64,
+    /// Revolution — in-plane rotation about the view (Z) axis, degrees.
+    rev: f64,
+}
+
+/// `<a:camera>` — ECMA-376 §20.1.5.5 (`CT_Camera`). Defines the camera that
+/// views the 3D scene. `prst` selects one of the 62 preset cameras
+/// (§20.1.10.47); `fov`/`zoom` optionally override the preset.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Camera3d {
+    /// Preset camera name (`ST_PresetCameraType`), e.g. "perspectiveRelaxed".
+    prst: String,
+    /// Field-of-view override in **degrees** (60000ths in XML). None = use the
+    /// preset's default FOV. Only meaningful for perspective presets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fov: Option<f64>,
+    /// Zoom factor as a unit ratio (1.0 = 100%). XML carries an
+    /// `ST_PositivePercentage` (e.g. 100000 = 100%); we divide by 100000.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    zoom: Option<f64>,
+    /// Camera rotation override (`<a:rot>`). None = use the preset's base
+    /// orientation unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rot: Option<Rot3d>,
+}
+
+/// `<a:lightRig>` — ECMA-376 §20.1.5.9 (`CT_LightRig`). Parsed for Phase B
+/// (lighting/bevel shading); the Phase A camera renderer ignores it.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct LightRig {
+    /// Light-rig preset (`ST_LightRigType`), e.g. "threePt".
+    rig: String,
+    /// Light direction (`ST_LightRigDirection`): tl/t/tr/l/r/bl/b/br.
+    dir: String,
+    /// Optional rotation override of the rig.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rot: Option<Rot3d>,
+}
+
+/// `<a:scene3d>` — ECMA-376 §20.1.4.1.41 (`CT_Scene3D`). Holds the camera and
+/// light rig for a shape's 3D scene.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Scene3d {
+    camera: Camera3d,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    light_rig: Option<LightRig>,
+}
+
+/// `<a:bevel>` — ECMA-376 §20.1.5.3 (`CT_Bevel`). Lengths in EMU; `w`/`h`
+/// default to 76200 EMU and `prst` to "circle" per the schema.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Bevel3d {
+    /// Bevel width in EMU.
+    w: i64,
+    /// Bevel height in EMU.
+    h: i64,
+    /// Bevel preset name (`ST_BevelPresetType`).
+    prst: String,
+}
+
+/// `<a:sp3d>` — ECMA-376 §20.1.5.12 (`CT_Shape3D`). Parsed in full but **not
+/// rendered in Phase A** (camera-only). The contour/extrusion/bevel surfaces
+/// are Phase B; the renderer reads only `scene3d` for the perspective
+/// projection.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Sp3d {
+    /// Z position of the shape's front face in EMU (default 0).
+    #[serde(skip_serializing_if = "is_zero_i64")]
+    #[serde(default)]
+    z: i64,
+    /// Extrusion (depth) height in EMU (default 0).
+    #[serde(skip_serializing_if = "is_zero_i64")]
+    #[serde(default)]
+    extrusion_h: i64,
+    /// Contour (outline) width in EMU (default 0).
+    #[serde(skip_serializing_if = "is_zero_i64")]
+    #[serde(default)]
+    contour_w: i64,
+    /// Preset surface material (`ST_PresetMaterialType`), default "warmMatte".
+    prst_material: String,
+    /// Top bevel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bevel_t: Option<Bevel3d>,
+    /// Bottom bevel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bevel_b: Option<Bevel3d>,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct ShapeElement {
@@ -768,6 +872,15 @@ struct ShapeElement {
     /// ordinary shapes (renderer falls back to the preset text rectangle).
     #[serde(skip_serializing_if = "Option::is_none")]
     text_rect: Option<TextRect>,
+    /// `<p:spPr><a:scene3d>` (ECMA-376 §20.1.4.1.41 / §20.1.5.5) — 3D camera
+    /// scene. When the camera is non-identity the renderer projects the shape's
+    /// 2D drawing through the camera homography (Phase A).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scene3d: Option<Scene3d>,
+    /// `<p:spPr><a:sp3d>` (ECMA-376 §20.1.5.12) — 3D shape properties
+    /// (bevel/contour/extrusion). Parsed but not rendered in Phase A.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sp3d: Option<Sp3d>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -814,6 +927,16 @@ struct PictureElement {
     /// Mirrored reflection from spPr > effectLst > reflection. §20.1.8.50.
     #[serde(skip_serializing_if = "Option::is_none")]
     reflection: Option<Reflection>,
+    /// `<p:spPr><a:scene3d>` (ECMA-376 §20.1.4.1.41 / §20.1.5.5). A `p:pic`'s
+    /// `spPr` is `CT_ShapeProperties` (§19.3.1.37), so 3D scenes apply to images
+    /// too. When non-identity, the renderer projects the picture through the
+    /// camera homography (Phase A).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scene3d: Option<Scene3d>,
+    /// `<p:spPr><a:sp3d>` (ECMA-376 §20.1.5.12). Parsed but not rendered in
+    /// Phase A.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sp3d: Option<Sp3d>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -2008,6 +2131,72 @@ fn parse_effect_lst(
         soft_edge: effect_lst.and_then(parse_soft_edge),
         reflection: effect_lst.and_then(parse_reflection),
     }
+}
+
+// ===========================
+//  3D scene parsing (scene3d / sp3d)
+// ===========================
+
+/// Parse `<a:rot>` (`CT_SphereCoords`, ECMA-376 §20.1.5.11). Angles are stored
+/// in the XML as 60000ths of a degree; we convert to degrees. All three
+/// attributes are required by the schema, but we default missing ones to 0 to
+/// stay tolerant of malformed input.
+fn parse_rot3d(rot: roxmltree::Node<'_, '_>) -> Rot3d {
+    let deg = |name: &str| attr_f64(&rot, name).unwrap_or(0.0) / 60_000.0;
+    Rot3d {
+        lat: deg("lat"),
+        lon: deg("lon"),
+        rev: deg("rev"),
+    }
+}
+
+/// Parse `<a:scene3d>` (`CT_Scene3D`, ECMA-376 §20.1.4.1.41). Requires a
+/// `<a:camera>` child (§20.1.5.5); `<a:lightRig>` is optional for our purposes
+/// (Phase A renders the camera only). Returns None when no camera is present.
+fn parse_scene3d(sppr: roxmltree::Node<'_, '_>) -> Option<Scene3d> {
+    let scene = child(sppr, "scene3d")?;
+    let cam = child(scene, "camera")?;
+    let camera = Camera3d {
+        prst: attr(&cam, "prst")?,
+        // §20.1.5.5: fov is an ST_FOVAngle in 60000ths of a degree.
+        fov: attr_f64(&cam, "fov").map(|v| v / 60_000.0),
+        // zoom is an ST_PositivePercentage (100000 = 100%).
+        zoom: attr_f64(&cam, "zoom").map(|v| v / 100_000.0),
+        rot: child(cam, "rot").map(parse_rot3d),
+    };
+    let light_rig = child(scene, "lightRig").and_then(|lr| {
+        Some(LightRig {
+            rig: attr(&lr, "rig")?,
+            dir: attr(&lr, "dir")?,
+            rot: child(lr, "rot").map(parse_rot3d),
+        })
+    });
+    Some(Scene3d { camera, light_rig })
+}
+
+/// Parse `<a:bevel>` (`CT_Bevel`, ECMA-376 §20.1.5.3). `w`/`h` default to
+/// 76200 EMU and `prst` to "circle" per the schema.
+fn parse_bevel3d(bevel: roxmltree::Node<'_, '_>) -> Bevel3d {
+    Bevel3d {
+        w: attr_i64(&bevel, "w").unwrap_or(76_200),
+        h: attr_i64(&bevel, "h").unwrap_or(76_200),
+        prst: attr(&bevel, "prst").unwrap_or_else(|| "circle".into()),
+    }
+}
+
+/// Parse `<a:sp3d>` (`CT_Shape3D`, ECMA-376 §20.1.5.12). Defaults follow the
+/// schema: z=0, extrusionH=0, contourW=0, prstMaterial="warmMatte". Parsed in
+/// full but not rendered in Phase A.
+fn parse_sp3d(sppr: roxmltree::Node<'_, '_>) -> Option<Sp3d> {
+    let n = child(sppr, "sp3d")?;
+    Some(Sp3d {
+        z: attr_i64(&n, "z").unwrap_or(0),
+        extrusion_h: attr_i64(&n, "extrusionH").unwrap_or(0),
+        contour_w: attr_i64(&n, "contourW").unwrap_or(0),
+        prst_material: attr(&n, "prstMaterial").unwrap_or_else(|| "warmMatte".into()),
+        bevel_t: child(n, "bevelT").map(parse_bevel3d),
+        bevel_b: child(n, "bevelB").map(parse_bevel3d),
+    })
 }
 
 // ===========================
@@ -5562,6 +5751,8 @@ fn parse_shape(
         placeholder_type: placeholder_type_out,
         placeholder_idx: ph_idx,
         text_rect: None,
+        scene3d: sp_pr.and_then(parse_scene3d),
+        sp3d: sp_pr.and_then(parse_sp3d),
     })
 }
 
@@ -5649,6 +5840,8 @@ fn parse_picture(
         glow,
         soft_edge,
         reflection,
+        scene3d: parse_scene3d(sp_pr),
+        sp3d: parse_sp3d(sp_pr),
     })
 }
 
@@ -6668,6 +6861,8 @@ fn parse_sp_tree_node(
                                     glow,
                                     soft_edge,
                                     reflection,
+                                    scene3d: sp_pr_node.and_then(parse_scene3d),
+                                    sp3d: sp_pr_node.and_then(parse_sp3d),
                                 }));
                                 return;
                             }
@@ -6708,6 +6903,8 @@ fn parse_sp_tree_node(
                                     glow: None,
                                     soft_edge: None,
                                     reflection: None,
+                                    scene3d: None,
+                                    sp3d: None,
                                 }));
                                 return;
                             }
@@ -6762,6 +6959,8 @@ fn parse_sp_tree_node(
                                         glow: None,
                                         soft_edge: None,
                                         reflection: None,
+                                        scene3d: None,
+                                        sp3d: None,
                                     }));
                                 }
                             }
@@ -7312,6 +7511,8 @@ fn parse_connector(
         placeholder_type: None,
         placeholder_idx: None,
         text_rect: None,
+        scene3d: parse_scene3d(sp_pr),
+        sp3d: parse_sp3d(sp_pr),
     })
 }
 
@@ -8512,5 +8713,116 @@ mod tests {
             !json_ltr.contains("\"rtl\""),
             "rtl=false must be omitted; got {json_ltr}"
         );
+    }
+
+    // ===== scene3d / sp3d parsing (ECMA-376 §20.1.5.5 / §20.1.5.12) =====
+
+    /// Wrap a `<p:spPr>` fragment with the `a:`/`p:` namespaces and return the
+    /// spPr node so parse_scene3d / parse_sp3d can run against it.
+    fn parse_sppr_frag<'a>(doc: &'a roxmltree::Document<'a>) -> roxmltree::Node<'a, 'a> {
+        doc.root_element()
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "spPr")
+            .unwrap()
+    }
+
+    #[test]
+    fn test_parse_scene3d_slide3_fragment() {
+        // The exact scene3d/sp3d from sample-11 slide 3, "図 3".
+        let xml = r#"<root
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:spPr>
+            <a:scene3d>
+              <a:camera prst="perspectiveRelaxed">
+                <a:rot lat="19800000" lon="1200000" rev="20820000"/>
+              </a:camera>
+              <a:lightRig rig="threePt" dir="t"/>
+            </a:scene3d>
+            <a:sp3d contourW="6350" prstMaterial="matte">
+              <a:bevelT w="101600" h="101600"/>
+            </a:sp3d>
+          </p:spPr>
+        </root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sppr = parse_sppr_frag(&doc);
+
+        let scene = parse_scene3d(sppr).expect("scene3d should parse");
+        assert_eq!(scene.camera.prst, "perspectiveRelaxed");
+        let rot = scene.camera.rot.expect("rot present");
+        // 60000ths of a degree → degrees.
+        assert!((rot.lat - 330.0).abs() < 1e-9, "lat = {}", rot.lat);
+        assert!((rot.lon - 20.0).abs() < 1e-9, "lon = {}", rot.lon);
+        assert!((rot.rev - 347.0).abs() < 1e-9, "rev = {}", rot.rev);
+        // No fov/zoom in this file → None.
+        assert!(scene.camera.fov.is_none());
+        assert!(scene.camera.zoom.is_none());
+        let lr = scene.light_rig.as_ref().expect("lightRig present");
+        assert_eq!(lr.rig, "threePt");
+        assert_eq!(lr.dir, "t");
+
+        let sp3d = parse_sp3d(sppr).expect("sp3d should parse");
+        assert_eq!(sp3d.contour_w, 6350);
+        assert_eq!(sp3d.prst_material, "matte");
+        assert_eq!(sp3d.z, 0); // default
+        assert_eq!(sp3d.extrusion_h, 0); // default
+        let bt = sp3d.bevel_t.expect("bevelT present");
+        assert_eq!(bt.w, 101600);
+        assert_eq!(bt.h, 101600);
+        assert_eq!(bt.prst, "circle"); // schema default
+        assert!(sp3d.bevel_b.is_none());
+
+        // camelCase JSON round-trip surfaces the right keys.
+        let json = serde_json::to_string(&scene).unwrap();
+        assert!(json.contains("\"prst\":\"perspectiveRelaxed\""), "{json}");
+        assert!(json.contains("\"lat\":330.0"), "{json}");
+        assert!(json.contains("\"lightRig\""), "{json}");
+    }
+
+    #[test]
+    fn test_parse_camera_fov_zoom_and_defaults() {
+        // fov + zoom present; sp3d with all attributes omitted → schema defaults.
+        let xml = r#"<root
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:spPr>
+            <a:scene3d>
+              <a:camera prst="perspectiveContrastingRightFacing" fov="6900000" zoom="200000"/>
+              <a:lightRig rig="threePt" dir="t"/>
+            </a:scene3d>
+            <a:sp3d/>
+          </p:spPr>
+        </root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sppr = parse_sppr_frag(&doc);
+
+        let scene = parse_scene3d(sppr).unwrap();
+        // fov: 6900000 / 60000 = 115 degrees.
+        assert!((scene.camera.fov.unwrap() - 115.0).abs() < 1e-9);
+        // zoom: 200000 / 100000 = 2.0 (200%).
+        assert!((scene.camera.zoom.unwrap() - 2.0).abs() < 1e-9);
+        // No <a:rot> → None (renderer uses the preset base orientation).
+        assert!(scene.camera.rot.is_none());
+
+        let sp3d = parse_sp3d(sppr).unwrap();
+        assert_eq!(sp3d.z, 0);
+        assert_eq!(sp3d.extrusion_h, 0);
+        assert_eq!(sp3d.contour_w, 0);
+        assert_eq!(sp3d.prst_material, "warmMatte"); // schema default
+        assert!(sp3d.bevel_t.is_none());
+        assert!(sp3d.bevel_b.is_none());
+    }
+
+    #[test]
+    fn test_parse_scene3d_absent_is_none() {
+        let xml = r#"<root
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:spPr><a:prstGeom prst="rect"/></p:spPr>
+        </root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sppr = parse_sppr_frag(&doc);
+        assert!(parse_scene3d(sppr).is_none());
+        assert!(parse_sp3d(sppr).is_none());
     }
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -906,9 +906,18 @@ struct PictureElement {
     /// resolves to `<a:noFill/>` (border explicitly suppressed).
     #[serde(skip_serializing_if = "Option::is_none")]
     stroke: Option<Stroke>,
-    /// OOXML adj value (0–100000) for roundRect clip; None = plain rectangle
+    /// `<p:spPr><a:prstGeom prst="…">` preset name (e.g. "roundRect",
+    /// "ellipse"). ECMA-376 §20.1.9.18: a picture's preset geometry is its clip
+    /// silhouette and the path its border / contour hug. None = plain rectangle
+    /// (prst="rect" or no prstGeom). custGeom takes priority when present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    clip_adjust: Option<i64>,
+    prst_geom: Option<String>,
+    /// Adjust guides from the prstGeom `<a:avLst>` (1/1000-of-a-percent OOXML
+    /// units, in `gd@name` declaration order). Index 0 = adj/adj1, 1 = adj2, …
+    /// Empty / None → the preset's own declared defaults apply. Carried generically
+    /// so any of the 186 presets (not just roundRect) can be reconstructed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prst_adjust: Option<Vec<i64>>,
     /// ECMA-376 §20.1.8.55 a:srcRect — source image crop in 1/100000 fractions of
     /// source width/height. Only serialized when any edge is non-zero.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -5777,25 +5786,43 @@ fn parse_shape(
 //  Picture parsing  (p:pic)
 // ===========================
 
-/// Corner radius for a picture body clipped by `<a:prstGeom prst="roundRect">`
-/// on its spPr (§20.1.9.18 — the preset geometry of a picture acts as its clip
-/// silhouette). Returns the `adj` guide in 1000ths of a percent; when avLst
-/// omits the guide, the roundRect preset's own definition supplies 16667
-/// (OOXML presetShapeDefinitions). Non-roundRect presets are handled by the
-/// shared preset/custGeom paths, not this corner-radius shortcut.
-fn parse_round_rect_clip_adjust(sp_pr: roxmltree::Node<'_, '_>) -> Option<i64> {
-    let pg =
-        child(sp_pr, "prstGeom").filter(|pg| attr(pg, "prst").as_deref() == Some("roundRect"))?;
-    Some(
-        child(pg, "avLst")
-            .and_then(|avlst| avlst.children().find(|n| n.is_element()))
-            .and_then(|gd| attr(&gd, "fmla"))
-            .and_then(|fmla| {
-                fmla.strip_prefix("val ")
-                    .and_then(|v| v.parse::<i64>().ok())
-            })
-            .unwrap_or(16_667),
-    )
+/// Preset clip geometry for a picture body (§20.1.9.18 — the preset geometry of
+/// a `<p:pic>` acts as its clip silhouette and the path its border / contour
+/// hug). Returns the prstGeom `prst` name plus every `<a:avLst><a:gd>` adjust
+/// value in declaration order (1/1000-of-a-percent OOXML units), so any of the
+/// 186 presets — roundRect, ellipse, and the rest — can be reconstructed by the
+/// shared preset-geometry engine on the TS side. The preset's own declared
+/// defaults fill in any omitted guide, so the `adj` Vec may be shorter than the
+/// preset's adjust count (the engine substitutes defaults per index).
+///
+/// `prst="rect"` returns None: a plain rectangle needs no clip path (the bitmap
+/// already fills the bbox), matching the previous behaviour.
+fn parse_pic_prst_geom(sp_pr: roxmltree::Node<'_, '_>) -> (Option<String>, Option<Vec<i64>>) {
+    let pg = match child(sp_pr, "prstGeom") {
+        Some(n) => n,
+        None => return (None, None),
+    };
+    let prst = match attr(&pg, "prst") {
+        Some(p) if p != "rect" => p,
+        _ => return (None, None),
+    };
+    let adjust: Vec<i64> = child(pg, "avLst")
+        .map(|av| {
+            av.children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "gd")
+                .filter_map(|gd| {
+                    attr(&gd, "fmla")
+                        .and_then(|f| f.strip_prefix("val ").and_then(|v| v.parse::<i64>().ok()))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let adjust = if adjust.is_empty() {
+        None
+    } else {
+        Some(adjust)
+    };
+    (Some(prst), adjust)
 }
 
 fn parse_picture(
@@ -5844,6 +5871,7 @@ fn parse_picture(
     // for `<a:noFill/>`, so an explicitly border-less picture stays None.
     let stroke = child(sp_pr, "ln").and_then(|n| parse_stroke(n, theme));
 
+    let (prst_geom, prst_adjust) = parse_pic_prst_geom(sp_pr);
     Some(PictureElement {
         x: t.x,
         y: t.y,
@@ -5854,7 +5882,8 @@ fn parse_picture(
         flip_v: t.flip_v,
         data_url,
         stroke,
-        clip_adjust: parse_round_rect_clip_adjust(sp_pr),
+        prst_geom,
+        prst_adjust,
         src_rect: parse_src_rect(blip_fill),
         alpha: parse_blip_alpha(blip_fill),
         cust_geom,
@@ -6849,8 +6878,10 @@ fn parse_sp_tree_node(
                             if let Some(bytes) = read_zip_bytes(zip, &image_path) {
                                 let mime = mime_from_ext(&image_path);
                                 let data_url = format!("data:{mime};base64,{}", B64.encode(&bytes));
-                                // If the sp has a roundRect preset geometry, record adj for corner clipping
-                                let clip_adjust = sp_pr_node.and_then(parse_round_rect_clip_adjust);
+                                // §20.1.9.18 — the sp's prstGeom (any preset, not
+                                // just roundRect) is the picture's clip silhouette.
+                                let (prst_geom, prst_adjust) =
+                                    sp_pr_node.map(parse_pic_prst_geom).unwrap_or((None, None));
                                 let cust_geom = sp_pr_node
                                     .and_then(|p| child(p, "custGeom"))
                                     .map(parse_cust_geom);
@@ -6881,7 +6912,8 @@ fn parse_sp_tree_node(
                                     flip_v: t.flip_v,
                                     data_url,
                                     stroke,
-                                    clip_adjust,
+                                    prst_geom,
+                                    prst_adjust,
                                     src_rect: blip_fill_node.and_then(parse_src_rect),
                                     alpha: blip_fill_node.and_then(parse_blip_alpha),
                                     cust_geom,
@@ -6931,7 +6963,8 @@ fn parse_sp_tree_node(
                                     flip_v: t.flip_v,
                                     data_url: bf.data_url,
                                     stroke,
-                                    clip_adjust: None,
+                                    prst_geom: None,
+                                    prst_adjust: None,
                                     src_rect: bf.src_rect,
                                     alpha: bf.alpha,
                                     cust_geom: None,
@@ -6996,7 +7029,8 @@ fn parse_sp_tree_node(
                                         flip_v: t.flip_v,
                                         data_url,
                                         stroke,
-                                        clip_adjust: None,
+                                        prst_geom: None,
+                                        prst_adjust: None,
                                         src_rect: blip_fill.and_then(parse_src_rect),
                                         alpha: blip_fill.and_then(parse_blip_alpha),
                                         cust_geom: None,
@@ -8267,45 +8301,76 @@ mod tests {
     }
 
     /// §20.1.9.18 — `<a:prstGeom prst="roundRect">` on a picture's spPr clips
-    /// the bitmap to a rounded rect. An explicit `adj` guide wins.
+    /// the bitmap to a rounded rect. An explicit `adj` guide is carried through;
+    /// the preset default is supplied by the shared engine, not the parser.
     #[test]
-    fn test_pic_round_rect_clip_explicit_adj() {
+    fn test_pic_prst_geom_round_rect_explicit_adj() {
         let xml = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
             <prstGeom prst="roundRect"><avLst><gd name="adj" fmla="val 8594"/></avLst></prstGeom>
         </spPr>"#;
         let doc = roxmltree::Document::parse(xml).unwrap();
         assert_eq!(
-            parse_round_rect_clip_adjust(doc.root_element()),
-            Some(8_594)
+            parse_pic_prst_geom(doc.root_element()),
+            (Some("roundRect".to_owned()), Some(vec![8_594]))
         );
     }
 
-    /// When avLst omits the guide, the roundRect preset's own definition
-    /// supplies `adj = 16667` (OOXML presetShapeDefinitions).
+    /// When avLst omits the guide, the parser carries the name with no adjust;
+    /// the preset's own default (roundRect adj = 16667) is filled in downstream
+    /// by the TS preset-geometry engine, keeping defaults in one place.
     #[test]
-    fn test_pic_round_rect_clip_default_adj() {
+    fn test_pic_prst_geom_round_rect_default_adj() {
         let xml = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
             <prstGeom prst="roundRect"><avLst/></prstGeom>
         </spPr>"#;
         let doc = roxmltree::Document::parse(xml).unwrap();
         assert_eq!(
-            parse_round_rect_clip_adjust(doc.root_element()),
-            Some(16_667)
+            parse_pic_prst_geom(doc.root_element()),
+            (Some("roundRect".to_owned()), None)
         );
     }
 
-    /// A plain rect (or no prstGeom at all) means no corner clipping.
+    /// §20.1.9.18 generalised — a non-roundRect preset (ellipse, empty avLst) is
+    /// now carried generically so the picture clips to that silhouette.
     #[test]
-    fn test_pic_round_rect_clip_absent() {
+    fn test_pic_prst_geom_ellipse() {
+        let xml = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <prstGeom prst="ellipse"><avLst/></prstGeom>
+        </spPr>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        assert_eq!(
+            parse_pic_prst_geom(doc.root_element()),
+            (Some("ellipse".to_owned()), None)
+        );
+    }
+
+    /// Multiple adjust guides are captured in declaration order.
+    #[test]
+    fn test_pic_prst_geom_multi_adj() {
+        let xml = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <prstGeom prst="round2SameRect"><avLst>
+                <gd name="adj1" fmla="val 16667"/><gd name="adj2" fmla="val 0"/>
+            </avLst></prstGeom>
+        </spPr>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        assert_eq!(
+            parse_pic_prst_geom(doc.root_element()),
+            (Some("round2SameRect".to_owned()), Some(vec![16_667, 0]))
+        );
+    }
+
+    /// A plain rect (or no prstGeom at all) means no clip path.
+    #[test]
+    fn test_pic_prst_geom_absent() {
         let rect = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
             <prstGeom prst="rect"><avLst/></prstGeom>
         </spPr>"#;
         let doc = roxmltree::Document::parse(rect).unwrap();
-        assert_eq!(parse_round_rect_clip_adjust(doc.root_element()), None);
+        assert_eq!(parse_pic_prst_geom(doc.root_element()), (None, None));
 
         let bare = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"/>"#;
         let doc = roxmltree::Document::parse(bare).unwrap();
-        assert_eq!(parse_round_rect_clip_adjust(doc.root_element()), None);
+        assert_eq!(parse_pic_prst_geom(doc.root_element()), (None, None));
     }
 
     /// ECMA-376 §20.1.8.42 — `<a:ln cmpd="dbl"/>` should round-trip.

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -17,6 +17,13 @@ export type {
   ChartElement,
   MediaElement,
   TextRect,
+  // 3D scene types (reachable via ShapeElement.scene3d / .sp3d).
+  Scene3d,
+  Camera3d,
+  Rot3d,
+  LightRig,
+  Sp3d,
+  Bevel3d,
   // Fill / stroke variants (reachable via ShapeElement.fill / .stroke etc.).
   Fill,
   SolidFill,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2117,12 +2117,16 @@ async function renderPicture(
       };
     }
 
-    // Apply the picture clip (roundRect / custGeom) at an arbitrary local rect.
-    // ECMA-376 §20.1.9.8: a `<p:pic>` may carry `<a:custGeom>` defining a
-    // non-rectangular silhouette the bitmap is trimmed to (e.g. a laptop frame).
-    // The rect is parameterised so the same clip applies to the live draw
-    // (x,y,w,h) and to the scene3d offscreen (0,0,w,h).
-    const applyClipAt = (
+    // Trace the picture's clip silhouette (roundRect / custGeom / plain rect).
+    // Shared by the clip and the border / contour strokes so the outline always
+    // hugs the exact silhouette the bitmap is trimmed to. ECMA-376 §20.1.9.8:
+    // a `<p:pic>` may carry `<a:custGeom>` (e.g. a laptop frame) or a roundRect
+    // preset clip.
+    //
+    // `...Subpath` appends the silhouette as a fresh subpath of the CURRENT path
+    // (no `beginPath`). Used when combining the silhouette with an enclosing
+    // rect for an even-odd "outside" clip region.
+    const tracePictureSilhouetteSubpath = (
       target: CanvasRenderingContext2D,
       cx: number,
       cy: number,
@@ -2132,12 +2136,99 @@ async function renderPicture(
       if (el.clipAdjust != null) {
         const minDim = Math.min(cw, ch);
         const r = (el.clipAdjust / 100000) * minDim;
-        target.beginPath();
         target.roundRect(cx, cy, cw, ch, r);
-        target.clip();
       } else if (el.custGeom && el.custGeom.length > 0) {
         buildCustomPath(target, el.custGeom, cx, cy, cw, ch);
+      } else {
+        target.rect(cx, cy, cw, ch);
+      }
+    };
+
+    const tracePictureSilhouette = (
+      target: CanvasRenderingContext2D,
+      cx: number,
+      cy: number,
+      cw: number,
+      ch: number,
+    ): void => {
+      target.beginPath();
+      tracePictureSilhouetteSubpath(target, cx, cy, cw, ch);
+    };
+
+    // Apply the picture clip (roundRect / custGeom) at an arbitrary local rect.
+    // The rect is parameterised so the same clip applies to the live draw
+    // (x,y,w,h) and to the scene3d offscreen (0,0,w,h). A plain rectangle needs
+    // no clip (the bitmap already fills the rect), so we only clip when there
+    // is an actual non-rectangular / rounded silhouette.
+    const applyClipAt = (
+      target: CanvasRenderingContext2D,
+      cx: number,
+      cy: number,
+      cw: number,
+      ch: number,
+    ): void => {
+      if (el.clipAdjust != null || (el.custGeom && el.custGeom.length > 0)) {
+        tracePictureSilhouette(target, cx, cy, cw, ch);
         target.clip();
+      }
+    };
+
+    // Stroke the picture's silhouette with the `<a:ln>` border and/or the
+    // `<a:sp3d>` contour edge. Drawn *after* the bitmap inside `paintImageAt`,
+    // so when scene3d is active the strokes are warped through the same camera
+    // homography and effectLst (reflection / soft edge) re-paints them too —
+    // matching PowerPoint, which applies the 3D transform and effects to the
+    // framed picture as a whole.
+    const strokePictureEdges = (
+      target: CanvasRenderingContext2D,
+      ox: number,
+      oy: number,
+      ow: number,
+      oh: number,
+    ): void => {
+      // 1) a:ln picture border (ECMA-376 §20.1.2.2.24). Centre-aligned stroke,
+      //    the Canvas default — PowerPoint draws the picture frame straddling
+      //    the silhouette edge.
+      if (el.stroke) {
+        target.save();
+        applyStroke(target, el.stroke, scale);
+        tracePictureSilhouette(target, ox, oy, ow, oh);
+        target.stroke();
+        target.restore();
+      }
+      // 2) sp3d contour edge (ECMA-376 §20.1.5.12 `contourW` / `<a:contourClr>`).
+      //    The spec's contour is the extruded 3D edge surface lit by the scene's
+      //    light rig. Phase A draws a FLAT approximation: a uniform-width outline
+      //    in the contour colour, with no bevel shading or light-rig response
+      //    (bevelT/bevelB shading remains Phase B — see the Sp3d type doc).
+      //    Position assumption: the contour grows OUTWARD from the front face
+      //    in 3D, so Phase A draws it as an OUTSIDE-aligned stroke (the framed
+      //    edge sits just beyond the picture, not over the image). Canvas has no
+      //    outside-stroke mode, so we (a) clip to the region OUTSIDE the
+      //    silhouette — traced silhouette + an enclosing rect with the even-odd
+      //    rule — then (b) stroke the silhouette at 2× width centred on the
+      //    edge; only the outer half survives the clip. When Phase B implements
+      //    the true 3D extruded edge (with bevel/light-rig shading) it replaces
+      //    this flat band.
+      const sp3d = el.sp3d;
+      if (sp3d && (sp3d.contourW ?? 0) > 0 && sp3d.contourClr) {
+        const wPx = Math.max(0.5, (sp3d.contourW as number) * scale);
+        target.save();
+        // Clip to everything OUTSIDE the silhouette: trace the silhouette plus a
+        // generously enlarged enclosing rect, filled even-odd, so the silhouette
+        // interior is excluded from the clip region.
+        target.beginPath();
+        const pad = wPx * 2 + Math.max(ow, oh);
+        target.rect(ox - pad, oy - pad, ow + 2 * pad, oh + 2 * pad);
+        tracePictureSilhouetteSubpath(target, ox, oy, ow, oh);
+        target.clip('evenodd');
+        target.beginPath();
+        tracePictureSilhouette(target, ox, oy, ow, oh);
+        target.strokeStyle = hexToRgba(sp3d.contourClr);
+        target.lineWidth = wPx * 2;
+        target.setLineDash([]);
+        target.stroke();
+        target.restore();
       }
     };
 
@@ -2165,6 +2256,11 @@ async function renderPicture(
         target.drawImage(bitmap, ox, oy, ow, oh);
       }
       target.restore();
+      // Border (a:ln) and 3D contour edge (sp3d) are stroked AFTER the bitmap so
+      // they sit on top of / around the image, and — because this runs inside
+      // paintImageAt — they ride through the scene3d projection and effectLst
+      // re-paints (reflection / soft edge) along with the picture body.
+      strokePictureEdges(target, ox, oy, ow, oh);
     };
 
     // Draw the (clipped, optionally cropped) bitmap into a target context. This

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -34,6 +34,7 @@ import {
   applyReflection,
   renderPresetShape,
   hasPreset,
+  buildPresetGeometryPath,
   getConnectorAnchors,
   computeScene3dQuad,
   isScene3dNonIdentity,
@@ -2133,12 +2134,26 @@ async function renderPicture(
       cw: number,
       ch: number,
     ): void => {
-      if (el.clipAdjust != null) {
-        const minDim = Math.min(cw, ch);
-        const r = (el.clipAdjust / 100000) * minDim;
-        target.roundRect(cx, cy, cw, ch, r);
-      } else if (el.custGeom && el.custGeom.length > 0) {
+      if (el.custGeom && el.custGeom.length > 0) {
+        // custGeom takes priority over prstGeom (ECMA-376 §20.1.9.8).
         buildCustomPath(target, el.custGeom, cx, cy, cw, ch);
+      } else if (el.prstGeom) {
+        // §20.1.9.18 — the picture's preset geometry is its clip silhouette.
+        // Driven by the shared preset-geometry engine (roundRect, ellipse, and
+        // the other 184 presets), with the avLst adjust handles; the engine
+        // substitutes each preset's declared default for any omitted guide.
+        const ok = buildPresetGeometryPath(
+          target,
+          el.prstGeom,
+          cx,
+          cy,
+          cw,
+          ch,
+          el.prstAdjust ?? [],
+        );
+        // Unknown preset name → fall back to a plain rectangle so the bitmap
+        // still draws (matches the pre-generalisation rect fallback).
+        if (!ok) target.rect(cx, cy, cw, ch);
       } else {
         target.rect(cx, cy, cw, ch);
       }
@@ -2167,7 +2182,7 @@ async function renderPicture(
       cw: number,
       ch: number,
     ): void => {
-      if (el.clipAdjust != null || (el.custGeom && el.custGeom.length > 0)) {
+      if (el.prstGeom || (el.custGeom && el.custGeom.length > 0)) {
         tracePictureSilhouette(target, cx, cy, cw, ch);
         target.clip();
       }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -35,7 +35,12 @@ import {
   renderPresetShape,
   hasPreset,
   getConnectorAnchors,
+  computeScene3dQuad,
+  isScene3dNonIdentity,
+  drawProjected,
+  createAuxCanvas,
 } from '@silurus/ooxml-core';
+import type { CameraInput, Vec2 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import { drawPlayBadge } from './media-chrome';
 import {
@@ -1989,6 +1994,65 @@ function renderTextBody(
 const IMAGE_BITMAP_CACHE_MAX = 256;
 const imageBitmapCache = new Map<string, Promise<ImageBitmap>>();
 
+/**
+ * Project a shape/picture body through a DrawingML 3D camera (scene3d, Phase A).
+ *
+ * ECMA-376 §20.1.5.5: the camera acts in the shape's *local* space, ahead of
+ * the shape's 2D placement. We therefore render the body — normally drawn at
+ * (x,y,w,h) in `target`'s coordinate space — into a separate device-resolution
+ * offscreen canvas sized to the w×h box, then warp that bitmap onto `target`
+ * with `drawProjected` (a piecewise-affine homography). Because `target` already
+ * carries the element's 2D rotation/flip transform when this runs, the
+ * projection composes *inside* that transform, exactly matching "scene3d first,
+ * then the 2D xfrm" ordering.
+ *
+ * `paintBody(octx, ox, oy, ow, oh)` paints the body (clip + fill/stroke/image)
+ * into the offscreen context at the given local rect. Returns true if it
+ * projected, false when no offscreen canvas is available (headless) — callers
+ * then fall back to painting directly.
+ */
+function projectScene3dPaint(
+  target: CanvasRenderingContext2D,
+  camera: CameraInput,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  paintBody: (octx: CanvasRenderingContext2D, ox: number, oy: number, ow: number, oh: number) => void,
+): boolean {
+  if (w <= 0 || h <= 0) return false;
+  // Device scale folded into target's current transform, so the offscreen is
+  // rasterised at the same pixel density as the live canvas (no blur on HiDPI).
+  const tf = target.getTransform();
+  const det = Math.abs(tf.a * tf.d - tf.b * tf.c);
+  const devScale = det > 0 ? Math.sqrt(det) : 1;
+  const ow = Math.max(1, Math.ceil(w * devScale));
+  const oh = Math.max(1, Math.ceil(h * devScale));
+  const aux = createAuxCanvas(ow, oh);
+  if (!aux) return false;
+  const octx = aux.getContext('2d') as CanvasRenderingContext2D | null;
+  if (!octx) return false;
+
+  // Paint the body into the offscreen with the origin at (0,0); scale device px.
+  octx.save();
+  octx.scale(devScale, devScale);
+  paintBody(octx, 0, 0, w, h);
+  octx.restore();
+
+  // Project the w×h box and offset the quad to the element's (x,y).
+  const quad = computeScene3dQuad(camera, w, h);
+  const corners = quad.corners.map((c) => ({ x: x + c.x, y: y + c.y })) as [
+    Vec2,
+    Vec2,
+    Vec2,
+    Vec2,
+  ];
+  // drawProjected runs in target's CSS-px space (the device scale lives in the
+  // target transform), warping the ow×oh offscreen onto the CSS-space quad.
+  drawProjected(aux as unknown as CanvasImageSource, target, ow, oh, corners);
+  return true;
+}
+
 function getCachedBitmap(dataUrl: string): Promise<ImageBitmap> {
   const existing = imageBitmapCache.get(dataUrl);
   if (existing) {
@@ -2053,45 +2117,97 @@ async function renderPicture(
       };
     }
 
-    // Apply the picture clip (roundRect / custGeom) to an arbitrary target.
+    // Apply the picture clip (roundRect / custGeom) at an arbitrary local rect.
     // ECMA-376 §20.1.9.8: a `<p:pic>` may carry `<a:custGeom>` defining a
     // non-rectangular silhouette the bitmap is trimmed to (e.g. a laptop frame).
-    const applyClip = (target: CanvasRenderingContext2D): void => {
+    // The rect is parameterised so the same clip applies to the live draw
+    // (x,y,w,h) and to the scene3d offscreen (0,0,w,h).
+    const applyClipAt = (
+      target: CanvasRenderingContext2D,
+      cx: number,
+      cy: number,
+      cw: number,
+      ch: number,
+    ): void => {
       if (el.clipAdjust != null) {
-        const minDim = Math.min(w, h);
+        const minDim = Math.min(cw, ch);
         const r = (el.clipAdjust / 100000) * minDim;
         target.beginPath();
-        target.roundRect(x, y, w, h, r);
+        target.roundRect(cx, cy, cw, ch, r);
         target.clip();
       } else if (el.custGeom && el.custGeom.length > 0) {
-        buildCustomPath(target, el.custGeom, x, y, w, h);
+        buildCustomPath(target, el.custGeom, cx, cy, cw, ch);
         target.clip();
       }
+    };
+
+    // scene3d (ECMA-376 §20.1.5.5, Phase A camera projection). Active only when
+    // the camera actually transforms the shape; identity/front cameras fall
+    // through to the normal flat draw. sp3d (bevel/contour/extrusion) is parsed
+    // but NOT rendered in Phase A — see the TS Sp3d type doc.
+    const scene3d = el.scene3d && isScene3dNonIdentity(el.scene3d.camera) ? el.scene3d : null;
+
+    // Paint the picture body at an arbitrary local rect (origin-relative when
+    // projecting, absolute otherwise) so it can target either the live ctx or
+    // the scene3d offscreen.
+    const paintImageAt = (
+      target: CanvasRenderingContext2D,
+      ox: number,
+      oy: number,
+      ow: number,
+      oh: number,
+    ): void => {
+      target.save();
+      applyClipAt(target, ox, oy, ow, oh);
+      if (crop) {
+        target.drawImage(bitmap, crop.sx, crop.sy, crop.sw, crop.sh, ox, oy, ow, oh);
+      } else {
+        target.drawImage(bitmap, ox, oy, ow, oh);
+      }
+      target.restore();
     };
 
     // Draw the (clipped, optionally cropped) bitmap into a target context. This
     // is the picture "body" that the effect helpers re-paint onto aux canvases,
     // so reflections/soft edges mirror the real image rather than a flat shape.
+    // When scene3d is active the body is warped through the camera homography
+    // first; effects then composite over the projected result (PowerPoint
+    // applies effects after the 3D transform).
     const paintImage = (target: CanvasRenderingContext2D): void => {
-      target.save();
-      applyClip(target);
-      if (crop) {
-        target.drawImage(bitmap, crop.sx, crop.sy, crop.sw, crop.sh, x, y, w, h);
-      } else {
-        target.drawImage(bitmap, x, y, w, h);
+      if (scene3d) {
+        const ok = projectScene3dPaint(target, scene3d.camera, x, y, w, h, paintImageAt);
+        if (ok) return;
+        // Headless fallback: draw flat.
       }
-      target.restore();
+      paintImageAt(target, x, y, w, h);
     };
 
     // Flat opaque silhouette of the clipped picture rectangle, used as the mask
     // for innerShdw / softEdge. Falls back to the bounding rect when the picture
     // is a plain rectangle (no clip path).
-    const paintMask = (target: CanvasRenderingContext2D, color: string): void => {
+    const paintMaskAt = (
+      target: CanvasRenderingContext2D,
+      color: string,
+      ox: number,
+      oy: number,
+      ow: number,
+      oh: number,
+    ): void => {
       target.save();
-      applyClip(target);
+      applyClipAt(target, ox, oy, ow, oh);
       target.fillStyle = color;
-      target.fillRect(x, y, w, h);
+      target.fillRect(ox, oy, ow, oh);
       target.restore();
+    };
+
+    const paintMask = (target: CanvasRenderingContext2D, color: string): void => {
+      if (scene3d) {
+        const ok = projectScene3dPaint(target, scene3d.camera, x, y, w, h, (octx, ox, oy, ow, oh) =>
+          paintMaskAt(octx, color, ox, oy, ow, oh),
+        );
+        if (ok) return;
+      }
+      paintMaskAt(target, color, x, y, w, h);
     };
 
     // ── effectLst (§19.3.1.37 routes p:pic's spPr through CT_ShapeProperties,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -228,6 +228,11 @@ export interface Sp3d {
   extrusionH?: number;
   /** Contour (outline) width in EMU (default 0). */
   contourW?: number;
+  /** Contour colour (`<a:contourClr>`, ECMA-376 §20.1.5.12) as a hex string
+   *  (e.g. "969696"). Omitted when absent. The renderer draws a flat
+   *  approximation of the 3D contour edge (uniform-width outline, no bevel
+   *  shading) when both `contourW` and `contourClr` are present. */
+  contourClr?: string;
   /** Preset surface material (`ST_PresetMaterialType`), default "warmMatte". */
   prstMaterial: string;
   /** Top bevel. */
@@ -374,6 +379,14 @@ export interface PictureElement {
   flipV: boolean;
   /** Data URL, e.g. "data:image/png;base64,..." */
   dataUrl: string;
+  /**
+   * Border line from `<p:pic><p:spPr><a:ln>` (ECMA-376 §20.1.2.2.24). A
+   * `p:pic`'s spPr is `CT_ShapeProperties` (§19.3.1.37), so a picture carries
+   * the same line model as a shape. `null` when there is no `<a:ln>` or it
+   * resolves to `<a:noFill/>` (border explicitly suppressed). The border is
+   * stroked along the picture's clip silhouette (roundRect / custGeom / rect).
+   */
+  stroke: Stroke | null;
   /** OOXML adj value (0–100000) for roundRect clip, null = plain rectangle */
   clipAdjust: number | null;
   /**

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -387,8 +387,21 @@ export interface PictureElement {
    * stroked along the picture's clip silhouette (roundRect / custGeom / rect).
    */
   stroke: Stroke | null;
-  /** OOXML adj value (0–100000) for roundRect clip, null = plain rectangle */
-  clipAdjust: number | null;
+  /**
+   * `<p:spPr><a:prstGeom prst="…">` preset name (e.g. `"roundRect"`,
+   * `"ellipse"`). ECMA-376 §20.1.9.18: a picture's preset geometry is its clip
+   * silhouette and the path its border / contour hug. Undefined / omitted = a
+   * plain rectangle (`prst="rect"` or no prstGeom). When set, the renderer
+   * builds the silhouette via the shared preset-geometry engine (any of the 186
+   * presets). `custGeom` takes priority when both are present.
+   */
+  prstGeom?: string;
+  /**
+   * Adjust guides from the prstGeom `<a:avLst>` (1/1000-of-a-percent OOXML
+   * units), in `gd@name` declaration order (index 0 = adj/adj1, 1 = adj2, …).
+   * Omitted when avLst is empty — the preset's own declared defaults then apply.
+   */
+  prstAdjust?: number[];
   /**
    * ECMA-376 a:srcRect — source image crop as fractions (0..1) of the source
    * width/height. Omitted when the image is not cropped.

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -129,6 +129,13 @@ export interface ShapeElement {
    *  same space as x/y/width/height). When present the renderer lays text out in
    *  this rectangle instead of the preset/ellipse-derived text rectangle. */
   textRect?: TextRect;
+  /** `<a:scene3d>` 3D camera scene (ECMA-376 §20.1.5.5). When the camera is
+   *  non-identity the renderer projects the shape through the camera
+   *  homography (Phase A). */
+  scene3d?: Scene3d;
+  /** `<a:sp3d>` 3D shape properties (ECMA-376 §20.1.5.12). Parsed but not
+   *  rendered in Phase A. */
+  sp3d?: Sp3d;
 }
 
 /** Absolute text-frame rectangle in EMU (from SmartArt `<dsp:txXfrm>`). */
@@ -137,6 +144,96 @@ export interface TextRect {
   y: number;
   width: number;
   height: number;
+}
+
+// ===== DrawingML 3D scene (scene3d / sp3d) =====
+// 1:1 with the Rust parser's Rot3d / Camera3d / LightRig / Scene3d / Bevel3d /
+// Sp3d. Phase A renders only the camera (perspective homography of the planar
+// shape); sp3d / lightRig are parsed but rendered in Phase B.
+
+/**
+ * 3D rotation in sphere coordinates — ECMA-376 §20.1.5.11 (`CT_SphereCoords`).
+ * Angles are in **degrees** (the XML carries 60000ths of a degree; the parser
+ * divides once). Per the spec, `lat`/`lon` are latitude/longitude and `rev` is
+ * the revolution about the resulting view axis.
+ */
+export interface Rot3d {
+  /** Latitude — rotation about the horizontal (X) axis, degrees. */
+  lat: number;
+  /** Longitude — rotation about the vertical (Y) axis, degrees. */
+  lon: number;
+  /** Revolution — in-plane rotation about the view (Z) axis, degrees. */
+  rev: number;
+}
+
+/**
+ * `<a:camera>` — ECMA-376 §20.1.5.5 (`CT_Camera`). `prst` selects one of the
+ * 62 preset cameras (§20.1.10.47); `fov`/`zoom`/`rot` optionally override it.
+ */
+export interface Camera3d {
+  /** Preset camera name (`ST_PresetCameraType`), e.g. "perspectiveRelaxed". */
+  prst: string;
+  /** Field-of-view override in degrees. Omitted = preset default. */
+  fov?: number;
+  /** Zoom factor as a unit ratio (1.0 = 100%). Omitted = 1.0. */
+  zoom?: number;
+  /** Camera rotation override. Omitted = preset base orientation. */
+  rot?: Rot3d;
+}
+
+/**
+ * `<a:lightRig>` — ECMA-376 §20.1.5.9 (`CT_LightRig`). Parsed for Phase B
+ * (lighting/bevel shading); the Phase A camera renderer ignores it.
+ */
+export interface LightRig {
+  /** Light-rig preset (`ST_LightRigType`), e.g. "threePt". */
+  rig: string;
+  /** Light direction (`ST_LightRigDirection`): tl/t/tr/l/r/bl/b/br. */
+  dir: string;
+  /** Optional rotation override of the rig. */
+  rot?: Rot3d;
+}
+
+/**
+ * `<a:scene3d>` — ECMA-376 §20.1.4.1.41 (`CT_Scene3D`). Camera + light rig for
+ * a shape's 3D scene.
+ */
+export interface Scene3d {
+  camera: Camera3d;
+  lightRig?: LightRig;
+}
+
+/**
+ * `<a:bevel>` — ECMA-376 §20.1.5.3 (`CT_Bevel`). Lengths in EMU; `w`/`h`
+ * default to 76200 EMU and `prst` to "circle".
+ */
+export interface Bevel3d {
+  /** Bevel width in EMU. */
+  w: number;
+  /** Bevel height in EMU. */
+  h: number;
+  /** Bevel preset name (`ST_BevelPresetType`). */
+  prst: string;
+}
+
+/**
+ * `<a:sp3d>` — ECMA-376 §20.1.5.12 (`CT_Shape3D`). Parsed in full but **not
+ * rendered in Phase A** (camera-only). bevel/contour/extrusion are Phase B.
+ * Numeric fields are omitted from JSON when zero.
+ */
+export interface Sp3d {
+  /** Z position of the front face in EMU (default 0). */
+  z?: number;
+  /** Extrusion (depth) height in EMU (default 0). */
+  extrusionH?: number;
+  /** Contour (outline) width in EMU (default 0). */
+  contourW?: number;
+  /** Preset surface material (`ST_PresetMaterialType`), default "warmMatte". */
+  prstMaterial: string;
+  /** Top bevel. */
+  bevelT?: Bevel3d;
+  /** Bottom bevel. */
+  bevelB?: Bevel3d;
 }
 
 export interface TableElement {
@@ -308,6 +405,13 @@ export interface PictureElement {
   softEdge?: SoftEdge;
   /** Mirrored reflection from effectLst > reflection. ECMA-376 §20.1.8.50. */
   reflection?: Reflection;
+  /** `<a:scene3d>` 3D camera scene (ECMA-376 §20.1.5.5). A `p:pic`'s spPr is
+   *  `CT_ShapeProperties`, so 3D scenes apply to images. When non-identity the
+   *  renderer projects the picture through the camera homography (Phase A). */
+  scene3d?: Scene3d;
+  /** `<a:sp3d>` 3D shape properties (ECMA-376 §20.1.5.12). Parsed but not
+   *  rendered in Phase A. */
+  sp3d?: Sp3d;
 }
 
 // ===== Worker message protocol =====


### PR DESCRIPTION
## Summary

Implements **Phase A** of DrawingML `scene3d` support: the 3D **camera perspective projection** of planar shapes (pictures). Bevel / extrusion / lightRig shading is Phase B (parsed only, not drawn).

Target case: `sample-11` slide 3 picture "図 3" — `<a:camera prst="perspectiveRelaxed"><a:rot lat="19800000" lon="1200000" rev="20820000"/></a:camera>` (lat 330° / lon 20° / rev 347°). The roundRect-clipped WIRED cover now tilts in 3D (top edge recedes, ~-13° in-plane, perspective foreshortening) instead of rendering flat.

## What changed

1. **Parser** (`packages/pptx/parser/src/lib.rs`): parse `<a:scene3d>` (camera `prst`/`fov`/`zoom`/`rot{lat,lon,rev}`, `lightRig` `rig`/`dir`) and `<a:sp3d>` (`z`/`extrusionH`/`contourW`/`prstMaterial`, `bevelT`/`bevelB`) onto `ShapeElement` + `PictureElement` (serde camelCase). All paths: `p:sp`, `p:pic`, blipFill-painted `sp`, connectors. Angles 60000ths°→degrees; zoom→ratio; lengths stay EMU. 3 Rust unit tests.
2. **TS types** (`packages/pptx/src/types.ts` + `index.ts`): `Scene3d`/`Camera3d`/`Rot3d`/`LightRig`/`Sp3d`/`Bevel3d`, 1:1 with the parser JSON; exported (export-completeness guard passes).
3. **Core helper** (`packages/core/src/shape/scene3d-camera.ts`, `scene3d-draw.ts`): `computeScene3dQuad` (pure projection math) + `drawProjected` (piecewise-affine mesh warp — Canvas 2D has no native homography). Error-driven subdivision (<0.5px affine error/cell). 15 vitest cases.
4. **Renderer** (`packages/pptx/src/renderer.ts`): project the picture body to an offscreen + warp onto the live ctx; `effectLst` composites over the projected bitmap. Shape (`p:sp`) projection and `sp3d` rendering deferred to Phase B (commented).
5. **README**: Feature Support row for 3D camera projection (✅); `sp3d` flagged ⚠️ parsed/rendering planned.

## Camera model & assumptions

ECMA-376 §20.1.5.5 (camera) / §20.1.5.11 (rot) fix the **model**: `R = Rz(rev)·Rx(lat)·Ry(lon)` on the preset base orientation; perspective via pinhole `d = halfMax/tan(fov/2)`. ECMA-376 has **no numeric preset table** (base orientation / FOV) and there is no MS-OI29500 in `spec/`, so those constants are documented inline as a **derived assumption** (OOXML implementer consensus / LibreOffice `oox`). For sample-11 the file supplies an explicit `<a:rot>`, so the rendered orientation is driven by spec'd file data, not the assumed preset base.

## Verification

- 211 vitest pass; `tsc --build` clean; cargo test (37) / clippy / fmt clean; `build:packages` clean.
- pptx demo VRT (committed `demo/sample-1`, 9 slides) green; non-scene3d path is byte-identical.
- Visual: before = flat roundRect; after = correct 3D tilt, no visible mesh seams. No web-PowerPoint ground truth exists, so final visual sign-off is the maintainer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: picture frame (a:ln border + sp3d contour edge)

After the camera projection landed, the user asked to render the rest of slide 3's picture **frame**. Two distinct features were involved:

### 1. Picture border (`a:ln` on `p:pic`) — general fix

A `p:pic`'s `spPr` is `CT_ShapeProperties` (§19.3.1.37), so a picture carries the same `<a:ln>` line (§20.1.2.2.24) as a shape — but the parser was **dropping it entirely**, so every PowerPoint picture style (white frame, etc.) rendered border-less. The existing `parse_stroke` is now wired into **all four** `p:pic` construction paths (real `p:pic`, blipFill-painted `sp`, inherited-blipFill placeholder, no-xfrm placeholder pic), and `PictureElement` gained `stroke: Option<Stroke>` (TS `Stroke | null`). `<a:noFill/>` resolves to `None`, so `sample-11`'s `<a:ln><a:noFill/></a:ln>` borders stay invisible (correct).

The renderer strokes the picture's **clip silhouette** (roundRect / custGeom / plain rect) with the border, reusing the shape stroke helper (width EMU→px, dash).

### 2. sp3d contour edge (`contourW` / `contourClr`) — slide 3's actual grey "枠"

slide 3's pic carries `<a:sp3d contourW="6350" prstMaterial="matte">…<a:contourClr><a:srgbClr val="969696"/></a:contourClr></a:sp3d>`. Added `contour_clr` to `Sp3d` (§20.1.5.12; `contourW` was already parsed). The renderer draws a **Phase A flat approximation** of the 3D extruded edge: a uniform-width outline in the contour colour, OUTSIDE-aligned (even-odd "outside" clip + 2× centre-stroke). No bevel / light-rig shading (bevelT/bevelB remain Phase B). Assumptions are documented inline with § refs.

Both edges are stroked inside `paintImageAt` **after** the bitmap, so they ride the scene3d homography and `effectLst` (reflection / soft edge) re-paints them with the picture body — same design as the camera path above.

### Verification (follow-up)

- slide 3: perspective projection **and** grey contour rim render together (edge pixels ≈ `rgb(215,215,215)` = `969696` over white; `contourW=6350 EMU ≈ 0.5pt` → a genuinely thin rim).
- slide 1 (`<a:ln><a:noFill/>` + reflection): unchanged, no border.
- Border fixture (a python-pptx pptx, gitignored): plain rect with 6pt red `a:ln` and roundRect with 6pt green `a:ln` both stroke along the exact silhouette.
- Regression: pptx demo VRT (`demo/sample-1`, 9 slides) green. 211 vitest pass; `tsc --build` clean; cargo test (41) / clippy / fmt clean; ast-grep lint clean.
