### PR TITLE
docs(v1): retire stale RTL Phase 0 comments + core dedup/diagnostics + README bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pnpm add @silurus/ooxml
 
 > **Bundler note**: this package embeds `.wasm` files. With Vite add [`vite-plugin-wasm`](https://github.com/Menci/vite-plugin-wasm); with webpack use [`experiments.asyncWebAssembly`](https://webpack.js.org/configuration/experiments/).
 
-> **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked Size* sums all four entry bundles, including the **opt-in** math engine (MathJax + STIX Two Math, ~3 MB). What actually lands in your app is much smaller — import only the format you need (e.g. `@silurus/ooxml/pptx`). The math engine is a **separate entry** (`@silurus/ooxml/math`): it is bundled **only if you import it and pass it to a viewer** (see [Rendering equations](#rendering-equations)). Viewers that never receive a `math` engine tree-shake the ~3 MB away entirely.
+> **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked Size* sums all four entry bundles, including the **opt-in** math engine (MathJax + STIX Two Math, ~4 MB). What actually lands in your app is much smaller — import only the format you need (e.g. `@silurus/ooxml/pptx`). The math engine is a **separate entry** (`@silurus/ooxml/math`): it is bundled **only if you import it and pass it to a viewer** (see [Rendering equations](#rendering-equations)). Viewers that never receive a `math` engine tree-shake the ~4 MB away entirely.
 
 ---
 
@@ -63,9 +63,9 @@ pptx.nextSlide();
 
 OMML equations (`m:oMath` / `m:oMathPara`) in `.docx`, `.pptx` and `.xlsx` are rendered with
 [MathJax](https://www.mathjax.org/) + [STIX Two Math](https://github.com/stipub/stixfonts).
-That engine is ~3 MB, so it is **opt-in**: import the `math` engine from the separate
+That engine is ~4 MB, so it is **opt-in**: import the `math` engine from the separate
 `@silurus/ooxml/math` entry and pass it to the viewer. Pass it and equations render;
-omit it and the engine is referenced nowhere, so a bundler **tree-shakes the ~3 MB
+omit it and the engine is referenced nowhere, so a bundler **tree-shakes the ~4 MB
 away entirely** (equations are simply skipped). It is fully self-contained: no
 network, no cross-origin requests.
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -6,6 +6,7 @@
 import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
 import { niceStep, niceAxisMax, niceAxisMin } from './axis-scale.js';
 import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
+import { hexToRgba } from '../shape/paint.js';
 import { EMU_PER_PT, PT_TO_PX } from '../units.js';
 
 // ─── Palette + helpers ──────────────────────────────────────────────────────
@@ -24,14 +25,6 @@ function pieSliceColor(idx: number, series: ChartSeries): string {
   const override = series.dataPointColors?.[idx];
   if (override) return `#${override}`;
   return `#${CHART_PALETTE[idx % CHART_PALETTE.length]}`;
-}
-
-function hexToRgba(hex: string, alpha: number): string {
-  const h = hex.startsWith('#') ? hex.slice(1) : hex;
-  const r = parseInt(h.slice(0, 2), 16);
-  const g = parseInt(h.slice(2, 4), 16);
-  const b = parseInt(h.slice(4, 6), 16);
-  return `rgba(${r},${g},${b},${alpha})`;
 }
 
 function drawAxisTitle(

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -69,6 +69,12 @@ export async function preloadGoogleFonts(
   const seen = new Set<string>();
   const targetFamilies = new Set<string>();
   const linkPromises: Promise<void>[] = [];
+  // Families that could not be made available (link injection threw, or every
+  // matching FontFace.load() rejected). Surfaced once at the end via a single
+  // console.warn so a failed web font no longer falls back to a system face
+  // completely silently. The renderer still degrades gracefully — this is
+  // diagnostics only, the return contract stays `Promise<void>`.
+  const failedFamilies = new Set<string>();
 
   for (const name of fontNames) {
     if (!name) continue;
@@ -86,7 +92,9 @@ export async function preloadGoogleFonts(
         link.href = entry.url;
         document.head.appendChild(link);
       } catch {
-        // Network or DOM error — silently skip; renderer falls back to system.
+        // DOM error injecting the stylesheet — record so it is reported, then
+        // skip; renderer falls back to the system font for this family.
+        failedFamilies.add((entry.loadFamily ?? name).toLowerCase());
         link = null;
       }
     }
@@ -113,8 +121,20 @@ export async function preloadGoogleFonts(
     targetFamilies.has(f.family.toLowerCase()),
   );
   await withCeiling(
-    Promise.allSettled(registered.map((f) => f.load())).then(() =>
-      document.fonts.ready,
-    ),
+    Promise.allSettled(registered.map((f) => f.load())).then((results) => {
+      results.forEach((res, i) => {
+        if (res.status === 'rejected') {
+          failedFamilies.add(registered[i].family.toLowerCase());
+        }
+      });
+      return document.fonts.ready;
+    }),
   );
+
+  if (failedFamilies.size > 0) {
+    console.warn(
+      `[ooxml] failed to preload web font(s): ${[...failedFamilies].join(', ')}; ` +
+        `falling back to system fonts (text may shift or differ).`,
+    );
+  }
 }

--- a/packages/core/src/shape/paint.ts
+++ b/packages/core/src/shape/paint.ts
@@ -5,12 +5,14 @@ import { buildPatternBitmap } from './pattern-bitmaps';
  * Convert a 6- or 8-char hex colour to a CSS `rgba()` string.
  * 8-char hex encodes alpha in the last two chars (RRGGBBAA).
  * `alpha` applies to 6-char hex; ignored for 8-char.
+ * A leading `#` is tolerated (`#RRGGBB` and `RRGGBB` both work).
  */
 export function hexToRgba(hex: string, alpha = 1): string {
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  const a = hex.length >= 8 ? parseInt(hex.slice(6, 8), 16) / 255 : alpha;
+  const h = hex.charCodeAt(0) === 35 /* '#' */ ? hex.slice(1) : hex;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  const a = h.length >= 8 ? parseInt(h.slice(6, 8), 16) / 255 : alpha;
   return `rgba(${r},${g},${b},${a})`;
 }
 

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1194,7 +1194,8 @@ fn parse_paragraph(
             .or_else(|| theme.resolve_font_ref(base_run.font_family_east_asia.clone())),
         outline_level: base_para.outline_level,
         // ECMA-376 §17.3.1.6 — RTL paragraph flag resolved through the style
-        // chain + direct pPr. Recorded only in Phase 0.
+        // chain + direct pPr. The renderer reads it as the paragraph base
+        // direction for the UAX#9 reordering and alignment-edge passes.
         bidi: base_para.bidi,
     }
 }
@@ -1557,9 +1558,10 @@ fn parse_run_inner(
     let double_strikethrough = fmt.dstrike.unwrap_or(false);
     let highlight = fmt.highlight.clone();
     // RTL / complex-script properties (ECMA-376 §17.3.2.30 / §17.3.2.26 /
-    // §17.3.2.39). Phase 0: recorded on the run, not yet used for layout. The
-    // cs font goes through the same theme-ref resolution as the ascii/eastAsia
-    // axes so consumers receive a literal family.
+    // §17.3.2.39). The renderer uses `rtl` to drive complex-script shaping and
+    // the UAX#9 reordering / direction-mirroring pass. The cs font goes through
+    // the same theme-ref resolution as the ascii/eastAsia axes so consumers
+    // receive a literal family.
     let rtl = fmt.rtl;
     let cs_toggle = fmt.cs_toggle;
     let font_family_cs = theme.resolve_font_ref(fmt.font_family_cs.clone());
@@ -3245,7 +3247,8 @@ fn parse_table(
         .unwrap_or((None, None));
 
     // ECMA-376 §17.4.1 w:bidiVisual — RTL (visual) column order. On-off toggle.
-    // Phase 0: recorded only; column-order resolution is deferred.
+    // The renderer mirrors the grid (logical column 0 rightmost) and flips
+    // per-cell left/right borders when this is set.
     let bidi_visual = tbl_pr.and_then(|p| bool_prop(p, "bidiVisual"));
 
     DocTable {

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -27,8 +27,9 @@ pub struct RunFmt {
     /// Highlight color name: "yellow" | "cyan" | "green" | ... (w:highlight)
     pub highlight: Option<String>,
     /// ECMA-376 §17.3.2.30 w:rtl — this run contains complex-script (RTL)
-    /// content. Phase 0 of RTL support only records the flag; alignment /
-    /// glyph-order resolution is deferred to a later PR.
+    /// content. Resolved through the style chain onto the run model, where the
+    /// renderer uses it to force complex-script shaping and feed the UAX#9
+    /// reordering / `ctx.direction = 'rtl'` mirroring pass.
     pub rtl: Option<bool>,
     /// ECMA-376 §17.3.2.7 `<w:cs/>` — treat the run as complex-script,
     /// applying the cs formatting axis to ALL its characters (§17.3.2.26).
@@ -102,8 +103,9 @@ pub struct ParaFmt {
     /// code uses this to infer that behavior.
     pub outline_level: Option<u32>,
     /// ECMA-376 §17.3.1.6 w:bidi — right-to-left paragraph (text and column
-    /// order flow RTL). Phase 0 only records the flag; alignment start/end
-    /// resolution is deferred to a later PR.
+    /// order flow RTL). Resolved through the style chain onto the paragraph
+    /// model, where the renderer uses it as the base direction for UAX#9
+    /// reordering, indent swapping, and `w:jc` start/end edge resolution.
     pub bidi: Option<bool>,
 }
 
@@ -649,8 +651,9 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
     fmt.widow_control = bool_prop(ppr, "widowControl");
 
     // bidi — right-to-left paragraph (ECMA-376 §17.3.1.6). On-off toggle:
-    // present (or w:val="1"/"true") = RTL, w:val="0"/"false" = LTR. Phase 0
-    // records the flag only; alignment direction resolution is deferred.
+    // present (or w:val="1"/"true") = RTL, w:val="0"/"false" = LTR. Carried to
+    // the model as the paragraph base direction; the renderer feeds it to the
+    // UAX#9 pass and to start/end alignment-edge resolution.
     fmt.bidi = bool_prop(ppr, "bidi");
 
     // outlineLvl — 0..8 marks this paragraph (or its style) as a heading.

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -236,8 +236,9 @@ pub struct DocParagraph {
     pub outline_level: Option<u32>,
     /// ECMA-376 §17.3.1.6 `<w:bidi>` — right-to-left paragraph. `Some(true)` =
     /// RTL, `Some(false)` = explicitly LTR, `None` = unspecified (inherit).
-    /// Phase 0 of RTL support: recorded only; alignment/column-order resolution
-    /// is deferred to a later PR.
+    /// The renderer consumes this as the paragraph base direction: it seeds the
+    /// UAX#9 reordering pass, swaps the left/right indents, and resolves the
+    /// `w:jc` start/end alignment edges against it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bidi: Option<bool>,
 }
@@ -587,7 +588,9 @@ pub struct TextRun {
     pub revision: Option<RunRevision>,
     /// ECMA-376 §17.3.2.30 `<w:rtl>` — complex-script / right-to-left run.
     /// `Some(true)` = RTL, `Some(false)` = explicitly LTR, `None` = unspecified.
-    /// Phase 0: recorded only; glyph-order resolution is deferred.
+    /// The renderer marks a `Some(true)` run as RTL for the UAX#9 pass (forcing
+    /// complex-script shaping) and draws it with `ctx.direction = 'rtl'` so the
+    /// glyph order is mirrored.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtl: Option<bool>,
     /// ECMA-376 §17.3.2.7 `<w:cs/>` — complex-script run toggle: cs
@@ -760,8 +763,9 @@ pub struct DocTable {
     pub width_pct: Option<f64>,
     /// ECMA-376 §17.4.1 `<w:bidiVisual>` — render columns in right-to-left
     /// (visual) order. `Some(true)` = RTL columns, `Some(false)` = explicitly
-    /// LTR, `None` = unspecified. Phase 0: recorded only; column-order
-    /// resolution is deferred to a later PR.
+    /// LTR, `None` = unspecified. When `Some(true)` the renderer mirrors the
+    /// grid so logical column 0 is placed rightmost and flips the per-cell
+    /// left/right borders accordingly.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bidi_visual: Option<bool>,
 }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -164,8 +164,11 @@ export interface DocParagraph {
   defaultFontFamily?: string | null;
   /**
    * ECMA-376 §17.3.1.6 `<w:bidi>` — right-to-left paragraph. `true` = RTL,
-   * `false` = explicitly LTR, absent = unspecified (inherit). Phase 0 of RTL
-   * support: recorded only; alignment/column-order resolution is deferred.
+   * `false` = explicitly LTR, absent = unspecified (inherit). The renderer uses
+   * this as the paragraph base direction: it seeds the UAX#9 reordering pass
+   * (`computeLineVisualOrder`), swaps the left/right indents, resolves the
+   * `w:jc` start/end edges (`resolveAlignEdge`), and lays out lines from the
+   * right.
    */
   bidi?: boolean;
 }
@@ -363,8 +366,10 @@ export interface DocxTextRun {
    *  tracked changes appear inline. */
   revision?: RunRevision;
   /** ECMA-376 §17.3.2.30 `<w:rtl>` — complex-script / right-to-left run.
-   *  `true` = RTL, `false` = explicitly LTR, absent = unspecified.
-   *  Phase 0: recorded only; glyph-order resolution is deferred. */
+   *  `true` = RTL, `false` = explicitly LTR, absent = unspecified. The renderer
+   *  treats a `true` run as RTL for the UAX#9 pass (it forces complex-script
+   *  shaping and marks the segment so `computeLineVisualOrder` reorders it), and
+   *  draws the slice with `ctx.direction = 'rtl'` so Canvas mirrors the glyphs. */
   rtl?: boolean;
   /** ECMA-376 §17.3.2.7 `<w:cs/>` — complex-script run toggle: cs formatting
    *  applies to ALL characters of the run (§17.3.2.26). Distinct from
@@ -468,8 +473,8 @@ export interface DocTable {
   /**
    * ECMA-376 §17.4.1 `<w:bidiVisual>` — render columns in right-to-left
    * (visual) order. `true` = RTL columns, `false` = explicitly LTR, absent =
-   * unspecified. Phase 0 of RTL support: recorded only; column-order
-   * resolution is deferred.
+   * unspecified. When `true` the renderer mirrors the grid so logical column 0
+   * is placed rightmost, and flips per-cell left/right borders accordingly.
    */
   bidiVisual?: boolean;
 }


### PR DESCRIPTION
v1.0 release audit **Phase 4** (documentation & residue cleanup). Tracks audit items E1 / E2 / E4 / D1 / D2 from `docs/dev-notes/v1.0-release-audit.md`.

## What changed

### 1. Retire stale "RTL Phase 0" comments (docx) — E1
RTL shipped fully in #375 (issue #366), but the `w:bidi` / `w:rtl` / `w:bidiVisual` fields still carried `Phase 0: recorded only; resolution is deferred` across 12 sites. Each comment is **rewritten to the current semantics** (not deleted), describing how the renderer actually consumes the flag:
- `bidi` (§17.3.1.6): paragraph base direction — seeds the UAX#9 reorder pass (`computeLineVisualOrder`), swaps left/right indents, resolves `w:jc` start/end edges (`resolveAlignEdge`), lays lines from the right.
- `rtl` (§17.3.2.30): forces complex-script shaping, marks the segment for reordering, draws with `ctx.direction = 'rtl'` so Canvas mirrors glyphs.
- `bidiVisual` (§17.4.1): mirrors the table grid (logical column 0 rightmost) and flips per-cell left/right borders.

Touched: `packages/docx/src/types.ts`, `parser/src/types.rs`, `parser/src/styles.rs`, `parser/src/parser.rs`. `grep -rn "Phase 0" packages/docx/` → none.

### 2. core quality fixes — D1 / D2
- **D1**: removed the private `hexToRgba` duplicate in `chart/renderer.ts`; folded it into the shared `shape/paint.ts` util (already the public export) by teaching that one to tolerate an optional leading `#`. Chart palette colours are 6-char, so the 8-char-alpha branch never triggers there — behaviour is identical.
- **D2**: `preloadGoogleFonts` no longer swallows every failure silently. Failed families (link-injection throw + rejected `face.load()`) are aggregated and surfaced via a single `console.warn`. Return contract stays `Promise<void>`.

### 3. README bundle-size correction — E4
`vite build` produces `dist/math.mjs` at 4.13 MB (≈3.9 MiB), not the `~3 MB` the README claimed in four places → updated to `~4 MB`. The rest of the release step-3 checklist already matched: ESM-only `.mjs` entries, all examples use ESM `import`, no `require()`/CJS or stale `dispose()`/version strings, and spot-checked Feature Support rows are accurate. The xlsx **Charts** row was intentionally left untouched (pie/doughnut additions are owned by a separate branch).

> TODO.md (gitignored local memo) and `docs/dev-notes/v1.0-phase4-log.md` were refreshed in the working checkout but are not part of this PR (both gitignored).

## Verification
- `tsc --build` ✅
- `vitest run` — 34 files / 218 tests ✅
- `ast-grep scan` — 0 findings ✅
- `cargo fmt --all --check` (docx parser) ✅
- `cargo clippy --all-targets -D warnings` (docx parser) ✅
- `vite build` ✅ (all `.mjs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)