### PR TITLE
test(xlsx): conditional-formatting unit tests + pie/doughnut chart rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | **Elements** | Images (`<xdr:twoCellAnchor>`) | ✅ |
 | | Drawing shapes / text boxes (`xdr:sp`, `xdr:txBody` — 186 preset geometries via the shared engine, with `avLst` adjust handles) | ✅ |
 | | Math equations in shapes (OMML `m:oMath` / `m:oMathPara` in `xdr:txBody`, incl. `a14:m` / `mc:AlternateContent`; rendered via MathJax — opt-in `@silurus/ooxml/math`) | ✅ |
-| | Charts (bar, line, area, radar, scatter / bubble) | ✅ |
+| | Charts (bar, line, area, pie, doughnut, radar, scatter / bubble) | ✅ |
 | | Chart markers (circle / square / diamond / triangle / x / plus / star / dot / dash, per-point `<c:dPt>` overrides) | ✅ |
 | | Chart data labels (`<c:dLbl>` per-point with CELLRANGE / VALUE / SERIESNAME / CATEGORYNAME field references, position `l`/`r`/`t`/`b`/`ctr`/`outEnd`) | ✅ |
 | | Chart error bars (`<c:errBars>` X/Y direction, `cust` / `fixedVal` / `stdErr` / `stdDev` / `percentage`, dashed/styled lines) | ✅ |

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -64,13 +64,19 @@ pub(crate) fn load_sheet_charts(
             .map(|xml| parse_rels_map(&xml))
             .unwrap_or_default();
 
-        // Iterate over twoCellAnchor elements
+        // Iterate over chart anchors. Charts may be saved either as a
+        // `<xdr:twoCellAnchor>` (from + to cells — Excel's default) or a
+        // `<xdr:oneCellAnchor>` (from cell + a saved `<xdr:ext cx cy>` EMU
+        // size, ECMA-376 §20.5.2.16). openpyxl and some other writers emit
+        // oneCellAnchor; both must produce a chart.
         for anchor in draw_doc
             .root_element()
             .children()
             .filter(|n| n.is_element())
         {
-            if anchor.tag_name().name() != "twoCellAnchor"
+            let anchor_tag = anchor.tag_name().name();
+            let is_one_cell = anchor_tag == "oneCellAnchor";
+            if (anchor_tag != "twoCellAnchor" && !is_one_cell)
                 || anchor.tag_name().namespace() != Some(xdr_ns)
             {
                 continue;
@@ -79,6 +85,8 @@ pub(crate) fn load_sheet_charts(
             let (mut from_col, mut from_col_off, mut from_row, mut from_row_off) =
                 (0u32, 0i64, 0u32, 0i64);
             let (mut to_col, mut to_col_off, mut to_row, mut to_row_off) = (0u32, 0i64, 0u32, 0i64);
+            // oneCellAnchor size: `<xdr:ext cx cy>` in EMU.
+            let (mut ext_cx, mut ext_cy) = (0i64, 0i64);
             let mut chart_rid: Option<String> = None;
 
             for child in anchor.children() {
@@ -113,6 +121,17 @@ pub(crate) fn load_sheet_charts(
                             to_row_off = row_off;
                         }
                     }
+                    "ext" => {
+                        // oneCellAnchor's `<xdr:ext cx cy>` size in EMU.
+                        ext_cx = child
+                            .attribute("cx")
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(0);
+                        ext_cy = child
+                            .attribute("cy")
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(0);
+                    }
                     "graphicFrame" => {
                         // Look for a:graphic/a:graphicData/c:chart[@r:id]
                         for gf_child in child.descendants() {
@@ -131,6 +150,17 @@ pub(crate) fn load_sheet_charts(
                     }
                     _ => {}
                 }
+            }
+
+            // For a oneCellAnchor the `<to>` corner is absent; the chart's
+            // size is the saved EMU extent (ECMA-376 §20.5.2.16). Encode it as
+            // a `to` corner pinned to the `from` cell plus the extent offset so
+            // the renderer's from/to → pixel math yields exactly `ext` px.
+            if is_one_cell {
+                to_col = from_col;
+                to_row = from_row;
+                to_col_off = from_col_off + ext_cx;
+                to_row_off = from_row_off + ext_cy;
             }
 
             let Some(rid) = chart_rid else {
@@ -2068,6 +2098,83 @@ pub(crate) fn collect_num_cache(
         }
     }
     result
+}
+
+#[cfg(test)]
+mod pie_doughnut_tests {
+    use super::*;
+
+    const C_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    fn theme() -> Vec<String> {
+        vec!["111111".into(); 12]
+    }
+
+    /// A single-series chartSpace whose plotArea holds `chart_elem`
+    /// (`pieChart` or `doughnutChart`). One series, three categories.
+    fn pie_chart_xml(chart_elem: &str) -> String {
+        format!(
+            r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}">
+  <c:chart>
+    <c:title><c:tx><c:rich><a:p><a:r><a:t>Share</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    <c:plotArea>
+      <c:layout/>
+      <c:{ce}>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>Region</c:v></c:pt></c:strCache></c:strRef></c:tx>
+          <c:cat><c:strRef><c:strCache>
+            <c:pt idx="0"><c:v>North</c:v></c:pt>
+            <c:pt idx="1"><c:v>South</c:v></c:pt>
+            <c:pt idx="2"><c:v>East</c:v></c:pt>
+          </c:strCache></c:strRef></c:cat>
+          <c:val><c:numRef><c:numCache>
+            <c:pt idx="0"><c:v>30</c:v></c:pt>
+            <c:pt idx="1"><c:v>50</c:v></c:pt>
+            <c:pt idx="2"><c:v>20</c:v></c:pt>
+          </c:numCache></c:numRef></c:val>
+        </c:ser>
+      </c:{ce}>
+    </c:plotArea>
+    <c:legend><c:legendPos val="r"/></c:legend>
+  </c:chart>
+</c:chartSpace>"#,
+            c = C_NS,
+            a = A_NS,
+            ce = chart_elem,
+        )
+    }
+
+    /// ECMA-376 §21.2.2.141 `<c:pieChart>` → chart_type "pie"; categories and
+    /// the single series' values are carried through unchanged.
+    #[test]
+    fn pie_chart_series_and_categories() {
+        let xml = pie_chart_xml("pieChart");
+        let chart = parse_chart_xml(&xml, C_NS, A_NS, &theme()).expect("pie chart parses");
+        assert_eq!(chart.chart_type, "pie");
+        assert_eq!(chart.title.as_deref(), Some("Share"));
+        assert_eq!(chart.categories, vec!["North", "South", "East"]);
+        assert_eq!(chart.series.len(), 1);
+        assert_eq!(
+            chart.series[0].values,
+            vec![Some(30.0), Some(50.0), Some(20.0)]
+        );
+    }
+
+    /// ECMA-376 §21.2.2.50 `<c:doughnutChart>` → chart_type "doughnut".
+    #[test]
+    fn doughnut_chart_type() {
+        let xml = pie_chart_xml("doughnutChart");
+        let chart = parse_chart_xml(&xml, C_NS, A_NS, &theme()).expect("doughnut chart parses");
+        assert_eq!(chart.chart_type, "doughnut");
+        assert_eq!(chart.categories.len(), 3);
+        assert_eq!(chart.series.len(), 1);
+        assert_eq!(
+            chart.series[0].values,
+            vec![Some(30.0), Some(50.0), Some(20.0)]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1434,7 +1434,16 @@ pub(crate) fn read_zip_bytes(
 
 /// Resolve a relative path ("../media/image1.png") against a base dir ("xl/drawings").
 pub(crate) fn resolve_zip_path(base_dir: &str, target: &str) -> String {
-    let mut parts: Vec<&str> = base_dir.split('/').filter(|s| !s.is_empty()).collect();
+    // An absolute Target (leading "/", e.g. openpyxl's
+    // `/xl/drawings/drawing1.xml`) is package-root-relative and must ignore
+    // `base_dir`; otherwise the base would be prepended, producing a path that
+    // doesn't exist in the archive (ECMA-376 / OPC part names are root-anchored
+    // when they start with "/").
+    let mut parts: Vec<&str> = if target.starts_with('/') {
+        Vec::new()
+    } else {
+        base_dir.split('/').filter(|s| !s.is_empty()).collect()
+    };
     for seg in target.split('/') {
         match seg {
             ".." => {
@@ -2066,6 +2075,38 @@ mod sheet_view_tests {
         );
         let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
         assert_eq!(ws.col_widths.get(&2).copied(), Some(10.0));
+    }
+}
+
+#[cfg(test)]
+mod resolve_zip_path_tests {
+    use super::resolve_zip_path;
+
+    /// A relative Target resolves against the base directory, honoring `..`.
+    #[test]
+    fn relative_target_resolves_against_base() {
+        assert_eq!(
+            resolve_zip_path("xl/worksheets", "../drawings/drawing1.xml"),
+            "xl/drawings/drawing1.xml"
+        );
+        assert_eq!(
+            resolve_zip_path("xl/drawings", "../media/image1.png"),
+            "xl/media/image1.png"
+        );
+    }
+
+    /// An absolute Target (leading "/", as openpyxl writes for drawings) is
+    /// package-root-relative and ignores the base directory.
+    #[test]
+    fn absolute_target_ignores_base() {
+        assert_eq!(
+            resolve_zip_path("xl/worksheets", "/xl/drawings/drawing1.xml"),
+            "xl/drawings/drawing1.xml"
+        );
+        assert_eq!(
+            resolve_zip_path("xl/drawings", "/xl/charts/chart1.xml"),
+            "xl/charts/chart1.xml"
+        );
     }
 }
 

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1106,8 +1106,21 @@ fn parse_worksheet(
                                 .attribute("aboveAverage")
                                 .map(|v| v != "0")
                                 .unwrap_or(true);
+                            // ECMA-376 §18.3.1.10: `equalAverage` (default
+                            // false) and `stdDev` (optional, number of
+                            // standard deviations for the band threshold).
+                            let equal_average = cf
+                                .attribute("equalAverage")
+                                .map(|v| v == "1" || v == "true")
+                                .unwrap_or(false);
+                            let std_dev = cf
+                                .attribute("stdDev")
+                                .and_then(|v| v.parse::<u32>().ok())
+                                .filter(|&n| n > 0);
                             rules.push(CfRule::AboveAverage {
                                 above_average,
+                                equal_average,
+                                std_dev,
                                 dxf_id,
                                 priority,
                             });
@@ -2053,5 +2066,77 @@ mod sheet_view_tests {
         );
         let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
         assert_eq!(ws.col_widths.get(&2).copied(), Some(10.0));
+    }
+}
+
+#[cfg(test)]
+mod conditional_format_tests {
+    use super::parse_worksheet;
+    use crate::types::CfRule;
+
+    const NS: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    fn parse_cf_rules(cf_xml: &str) -> Vec<CfRule> {
+        let xml = format!(r#"<worksheet xmlns="{NS}"><sheetData/>{cf_xml}</worksheet>"#);
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        ws.conditional_formats
+            .into_iter()
+            .flat_map(|cf| cf.rules)
+            .collect()
+    }
+
+    /// ECMA-376 §18.3.1.10: an `aboveAverage` rule with no extra attributes
+    /// defaults to `aboveAverage=true`, `equalAverage=false`, no `stdDev`.
+    #[test]
+    fn above_average_defaults() {
+        let rules = parse_cf_rules(
+            r#"<conditionalFormatting sqref="A1:A5"><cfRule type="aboveAverage" dxfId="0" priority="1"/></conditionalFormatting>"#,
+        );
+        match &rules[..] {
+            [CfRule::AboveAverage {
+                above_average,
+                equal_average,
+                std_dev,
+                ..
+            }] => {
+                assert!(*above_average, "aboveAverage defaults to true");
+                assert!(!*equal_average, "equalAverage defaults to false");
+                assert_eq!(*std_dev, None, "no stdDev by default");
+            }
+            other => panic!("expected one AboveAverage rule, got {other:?}"),
+        }
+    }
+
+    /// `aboveAverage="0"` flips to below-average; `equalAverage="1"` is honored.
+    #[test]
+    fn below_average_with_equal_average() {
+        let rules = parse_cf_rules(
+            r#"<conditionalFormatting sqref="A1:A5"><cfRule type="aboveAverage" aboveAverage="0" equalAverage="1" dxfId="0" priority="1"/></conditionalFormatting>"#,
+        );
+        match &rules[..] {
+            [CfRule::AboveAverage {
+                above_average,
+                equal_average,
+                ..
+            }] => {
+                assert!(!*above_average, "aboveAverage=\"0\" → false");
+                assert!(*equal_average, "equalAverage=\"1\" → true");
+            }
+            other => panic!("expected one AboveAverage rule, got {other:?}"),
+        }
+    }
+
+    /// `stdDev="2"` is captured as a band multiplier (ECMA-376 §18.3.1.10).
+    #[test]
+    fn above_average_std_dev() {
+        let rules = parse_cf_rules(
+            r#"<conditionalFormatting sqref="A1:A5"><cfRule type="aboveAverage" stdDev="2" dxfId="0" priority="1"/></conditionalFormatting>"#,
+        );
+        match &rules[..] {
+            [CfRule::AboveAverage { std_dev, .. }] => {
+                assert_eq!(*std_dev, Some(2), "stdDev=\"2\" captured");
+            }
+            other => panic!("expected one AboveAverage rule, got {other:?}"),
+        }
     }
 }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -1072,6 +1072,15 @@ pub enum CfRule {
     #[serde(rename_all = "camelCase")]
     AboveAverage {
         above_average: bool,
+        /// ECMA-376 §18.3.1.10 `equalAverage`: include cells equal to the
+        /// average in the highlighted set. Default false.
+        #[serde(skip_serializing_if = "std::ops::Not::not")]
+        equal_average: bool,
+        /// ECMA-376 §18.3.1.10 `stdDev`: when present, the threshold becomes
+        /// `mean ± stdDev · σ` (population standard deviation) instead of the
+        /// plain mean. Absent (None) means a simple above/below-average rule.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        std_dev: Option<u32>,
         dxf_id: Option<u32>,
         priority: i32,
     },

--- a/packages/xlsx/src/conditional-format.test.ts
+++ b/packages/xlsx/src/conditional-format.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest';
+import { compileCf, evaluateCf } from './conditional-format.js';
+import type {
+  Worksheet,
+  Cell,
+  CellValue,
+  ConditionalFormat,
+  CfRule,
+  Dxf,
+} from './types.js';
+
+// ────────────────────────────────────────────────────────────────
+// Conditional formatting — unit tests for the pure rule-evaluation
+// layer (compileCf / evaluateCf).
+//
+// These exercise the spec logic (ECMA-376 §18.3.1.10 `<cfRule>`,
+// §18.3.1.11 `<dxf>`) directly, independent of the WASM parser and the
+// Canvas renderer:
+//   - cellIs       — numeric & text comparison operators
+//   - colorScale   — 2-color / 3-color gradient interpolation, min==max
+//   - dataBar      — bar ratio clamping, min==max
+//   - top10        — rank & percent thresholds, top vs bottom
+//   - aboveAverage — mean, equalAverage boundary, stdDev bands
+//   - iconSet      — threshold→icon index assignment, reverse
+// ────────────────────────────────────────────────────────────────
+
+/** Build a numeric cell. */
+function numCell(row: number, col: number, n: number): Cell {
+  return {
+    col,
+    row,
+    colRef: `${String.fromCharCode(65 + col)}${row + 1}`,
+    value: { type: 'number', number: n } as CellValue,
+    styleIndex: 0,
+  };
+}
+
+/** Build a text cell. */
+function textCell(row: number, col: number, t: string): Cell {
+  return {
+    col,
+    row,
+    colRef: `${String.fromCharCode(65 + col)}${row + 1}`,
+    value: { type: 'text', text: t } as CellValue,
+    styleIndex: 0,
+  };
+}
+
+/**
+ * Build a single-column worksheet from a list of numbers (col 0, rows 0..n-1)
+ * plus a list of conditional-format blocks covering that column.
+ */
+function sheetFromColumn(
+  values: number[],
+  cfs: ConditionalFormat[],
+): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: values.map((n, i) => ({ index: i, height: null, cells: [numCell(i, 0, n)] })),
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: cfs,
+    images: [],
+    charts: [],
+  };
+}
+
+function fullColumnSqref(rows: number): { top: number; left: number; bottom: number; right: number } {
+  return { top: 0, left: 0, bottom: rows - 1, right: 0 };
+}
+
+const FILL_RED: Dxf = {
+  font: null,
+  fill: { patternType: 'solid', fgColor: '#FF0000', bgColor: '#FF0000' },
+  border: null,
+};
+
+const FONT_BLUE: Dxf = {
+  font: {
+    bold: false, italic: false, underline: false, strike: false,
+    size: 11, color: '#0000FF', name: null,
+  },
+  fill: null,
+  border: null,
+};
+
+// ─── cellIs (numeric) ────────────────────────────────────────────
+describe('cellIs — numeric operators (ECMA-376 §18.3.1.10)', () => {
+  function evalCellIs(value: number, operator: string, args: string[]): boolean {
+    const rule: CfRule = { type: 'cellIs', operator, formulas: args, dxfId: 0, priority: 1 };
+    const ws = sheetFromColumn([value], [{ sqref: [fullColumnSqref(1)], rules: [rule] }]);
+    const ctx = compileCf(ws);
+    const res = evaluateCf(numCell(0, 0, value), 0, 0, ctx, [FILL_RED]);
+    return res.fill?.fgColor === '#FF0000';
+  }
+
+  it('greaterThan matches strictly greater', () => {
+    expect(evalCellIs(5, 'greaterThan', ['3'])).toBe(true);
+    expect(evalCellIs(3, 'greaterThan', ['3'])).toBe(false);
+  });
+
+  it('greaterThanOrEqual includes the boundary', () => {
+    expect(evalCellIs(3, 'greaterThanOrEqual', ['3'])).toBe(true);
+    expect(evalCellIs(2, 'greaterThanOrEqual', ['3'])).toBe(false);
+  });
+
+  it('lessThan / lessThanOrEqual', () => {
+    expect(evalCellIs(2, 'lessThan', ['3'])).toBe(true);
+    expect(evalCellIs(3, 'lessThan', ['3'])).toBe(false);
+    expect(evalCellIs(3, 'lessThanOrEqual', ['3'])).toBe(true);
+  });
+
+  it('equal / notEqual', () => {
+    expect(evalCellIs(3, 'equal', ['3'])).toBe(true);
+    expect(evalCellIs(3, 'notEqual', ['3'])).toBe(false);
+    expect(evalCellIs(4, 'notEqual', ['3'])).toBe(true);
+  });
+
+  it('between is inclusive of both endpoints', () => {
+    expect(evalCellIs(3, 'between', ['3', '5'])).toBe(true);
+    expect(evalCellIs(5, 'between', ['3', '5'])).toBe(true);
+    expect(evalCellIs(2, 'between', ['3', '5'])).toBe(false);
+    expect(evalCellIs(6, 'between', ['3', '5'])).toBe(false);
+  });
+
+  it('notBetween excludes the closed interval', () => {
+    expect(evalCellIs(2, 'notBetween', ['3', '5'])).toBe(true);
+    expect(evalCellIs(4, 'notBetween', ['3', '5'])).toBe(false);
+  });
+});
+
+// ─── cellIs (text) ───────────────────────────────────────────────
+describe('cellIs — text operators (case-insensitive)', () => {
+  function evalText(value: string, operator: string, args: string[]): boolean {
+    const rule: CfRule = {
+      type: 'cellIs',
+      operator,
+      // quoted string literals as Excel writes them in <formula>
+      formulas: args.map(a => `"${a}"`),
+      dxfId: 0,
+      priority: 1,
+    };
+    const ws: Worksheet = {
+      ...sheetFromColumn([0], [{ sqref: [fullColumnSqref(1)], rules: [rule] }]),
+      rows: [{ index: 0, height: null, cells: [textCell(0, 0, value)] }],
+    };
+    const ctx = compileCf(ws);
+    const res = evaluateCf(textCell(0, 0, value), 0, 0, ctx, [FILL_RED]);
+    return res.fill?.fgColor === '#FF0000';
+  }
+
+  it('equal is case-insensitive', () => {
+    expect(evalText('Apple', 'equal', ['apple'])).toBe(true);
+    expect(evalText('Apple', 'equal', ['pear'])).toBe(false);
+  });
+
+  it('containsText / notContains', () => {
+    expect(evalText('Pineapple', 'containsText', ['apple'])).toBe(true);
+    expect(evalText('Pear', 'notContains', ['apple'])).toBe(true);
+  });
+
+  it('beginsWith / endsWith', () => {
+    expect(evalText('Pineapple', 'beginsWith', ['pine'])).toBe(true);
+    expect(evalText('Pineapple', 'endsWith', ['apple'])).toBe(true);
+    expect(evalText('Pineapple', 'endsWith', ['pine'])).toBe(false);
+  });
+});
+
+// ─── colorScale ──────────────────────────────────────────────────
+describe('colorScale — gradient interpolation (ECMA-376 §18.3.1.16)', () => {
+  function colorAt(value: number, values: number[], rule: CfRule): string | undefined {
+    const ws = sheetFromColumn(values, [{ sqref: [fullColumnSqref(values.length)], rules: [rule] }]);
+    const ctx = compileCf(ws);
+    const res = evaluateCf(numCell(0, 0, value), 0, 0, ctx, []);
+    return res.fill?.fgColor;
+  }
+
+  const twoColor: CfRule = {
+    type: 'colorScale',
+    priority: 1,
+    stops: [
+      { kind: 'min', value: null, color: '#000000' },
+      { kind: 'max', value: null, color: '#FFFFFF' },
+    ],
+  };
+
+  it('2-color: min stop → first color, max stop → last color', () => {
+    expect(colorAt(0, [0, 10], twoColor)).toBe('#000000');
+    expect(colorAt(10, [0, 10], twoColor)).toBe('#FFFFFF');
+  });
+
+  it('2-color: midpoint interpolates halfway (#000000→#FFFFFF = #808080)', () => {
+    expect(colorAt(5, [0, 10], twoColor)).toBe('#808080');
+  });
+
+  it('2-color: value below min / above max clamps to the endpoints', () => {
+    expect(colorAt(-5, [0, 10], twoColor)).toBe('#000000');
+    expect(colorAt(99, [0, 10], twoColor)).toBe('#FFFFFF');
+  });
+
+  it('min==max (all equal) does not divide by zero — returns a stop color', () => {
+    // All samples equal → scaleMin == scaleMax. interpolation t is forced to 0.
+    const color = colorAt(7, [7, 7, 7], twoColor);
+    expect(color).toBe('#000000');
+  });
+
+  const threeColor: CfRule = {
+    type: 'colorScale',
+    priority: 1,
+    stops: [
+      { kind: 'min', value: null, color: '#FF0000' },
+      { kind: 'percentile', value: '50', color: '#FFFF00' },
+      { kind: 'max', value: null, color: '#00FF00' },
+    ],
+  };
+
+  it('3-color: midpoint stop hits the middle color exactly', () => {
+    // values 0..10, 50th percentile of [0,5,10] = 5 → middle color #FFFF00
+    expect(colorAt(5, [0, 5, 10], threeColor)).toBe('#FFFF00');
+  });
+
+  it('3-color: lower band interpolates between first and middle stops', () => {
+    // value 2.5 sits halfway between min(0) and mid(5): #FF0000→#FFFF00 = #FF8000
+    expect(colorAt(2.5, [0, 5, 10], threeColor)).toBe('#FF8000');
+  });
+});
+
+// ─── dataBar ─────────────────────────────────────────────────────
+describe('dataBar — bar ratio (ECMA-376 §18.3.1.28)', () => {
+  function ratioAt(value: number, values: number[]): number | undefined {
+    const rule: CfRule = {
+      type: 'dataBar',
+      color: '#638EC6',
+      min: { kind: 'min', value: null },
+      max: { kind: 'max', value: null },
+      priority: 1,
+      gradient: true,
+    };
+    const ws = sheetFromColumn(values, [{ sqref: [fullColumnSqref(values.length)], rules: [rule] }]);
+    const ctx = compileCf(ws);
+    const res = evaluateCf(numCell(0, 0, value), 0, 0, ctx, []);
+    return res.dataBar?.ratio;
+  }
+
+  it('min → 0, max → 1, midpoint → 0.5', () => {
+    expect(ratioAt(0, [0, 10])).toBe(0);
+    expect(ratioAt(10, [0, 10])).toBe(1);
+    expect(ratioAt(5, [0, 10])).toBe(0.5);
+  });
+
+  it('clamps below-min and above-max into [0,1]', () => {
+    expect(ratioAt(-5, [-5, 0, 10])).toBe(0);
+    expect(ratioAt(10, [0, 5, 10])).toBe(1);
+  });
+
+  it('min==max yields ratio 0 (no division by zero)', () => {
+    expect(ratioAt(5, [5, 5, 5])).toBe(0);
+  });
+});
+
+// ─── top10 ───────────────────────────────────────────────────────
+describe('top10 — rank & percent thresholds (ECMA-376 §18.3.1.10)', () => {
+  function matchesTop10(
+    value: number,
+    values: number[],
+    opts: { top: boolean; percent: boolean; rank: number },
+  ): boolean {
+    const rule: CfRule = { type: 'top10', ...opts, dxfId: 0, priority: 1 };
+    const ws = sheetFromColumn(values, [{ sqref: [fullColumnSqref(values.length)], rules: [rule] }]);
+    const ctx = compileCf(ws);
+    const res = evaluateCf(numCell(0, 0, value), 0, 0, ctx, [FILL_RED]);
+    return res.fill?.fgColor === '#FF0000';
+  }
+
+  const data = [1, 2, 3, 4, 5];
+
+  it('top 2 by rank highlights the two largest', () => {
+    expect(matchesTop10(5, data, { top: true, percent: false, rank: 2 })).toBe(true);
+    expect(matchesTop10(4, data, { top: true, percent: false, rank: 2 })).toBe(true);
+    expect(matchesTop10(3, data, { top: true, percent: false, rank: 2 })).toBe(false);
+  });
+
+  it('bottom 2 by rank highlights the two smallest', () => {
+    expect(matchesTop10(1, data, { top: false, percent: false, rank: 2 })).toBe(true);
+    expect(matchesTop10(2, data, { top: false, percent: false, rank: 2 })).toBe(true);
+    expect(matchesTop10(3, data, { top: false, percent: false, rank: 2 })).toBe(false);
+  });
+
+  it('top 40% selects roughly the top two of five', () => {
+    // percent threshold uses the (1 - rank/100) percentile of the samples.
+    expect(matchesTop10(5, data, { top: true, percent: true, rank: 40 })).toBe(true);
+    expect(matchesTop10(1, data, { top: true, percent: true, rank: 40 })).toBe(false);
+  });
+});
+
+// ─── aboveAverage ────────────────────────────────────────────────
+describe('aboveAverage — mean / stdDev bands (ECMA-376 §18.3.1.10)', () => {
+  function matchesAvg(
+    value: number,
+    values: number[],
+    rule: CfRule,
+  ): boolean {
+    const ws = sheetFromColumn(values, [{ sqref: [fullColumnSqref(values.length)], rules: [rule] }]);
+    const ctx = compileCf(ws);
+    const res = evaluateCf(numCell(0, 0, value), 0, 0, ctx, [FILL_RED]);
+    return res.fill?.fgColor === '#FF0000';
+  }
+
+  const data = [1, 2, 3, 4, 5]; // mean = 3
+
+  it('aboveAverage=true highlights values strictly above the mean', () => {
+    const rule: CfRule = { type: 'aboveAverage', aboveAverage: true, dxfId: 0, priority: 1 };
+    expect(matchesAvg(4, data, rule)).toBe(true);
+    expect(matchesAvg(3, data, rule)).toBe(false);
+    expect(matchesAvg(2, data, rule)).toBe(false);
+  });
+
+  it('aboveAverage=false highlights values strictly below the mean', () => {
+    const rule: CfRule = { type: 'aboveAverage', aboveAverage: false, dxfId: 0, priority: 1 };
+    expect(matchesAvg(2, data, rule)).toBe(true);
+    expect(matchesAvg(3, data, rule)).toBe(false);
+  });
+
+  it('equalAverage=true includes values exactly at the mean', () => {
+    const rule: CfRule = {
+      type: 'aboveAverage', aboveAverage: true, equalAverage: true, dxfId: 0, priority: 1,
+    };
+    expect(matchesAvg(3, data, rule)).toBe(true);
+    expect(matchesAvg(4, data, rule)).toBe(true);
+    expect(matchesAvg(2, data, rule)).toBe(false);
+  });
+
+  it('stdDev=1 above highlights values beyond mean + 1·σ', () => {
+    // population σ of [1..5] = sqrt(2) ≈ 1.414 → threshold ≈ 4.414
+    const rule: CfRule = {
+      type: 'aboveAverage', aboveAverage: true, stdDev: 1, dxfId: 0, priority: 1,
+    };
+    expect(matchesAvg(5, data, rule)).toBe(true);
+    expect(matchesAvg(4, data, rule)).toBe(false);
+  });
+
+  it('stdDev=1 below highlights values beyond mean - 1·σ', () => {
+    const rule: CfRule = {
+      type: 'aboveAverage', aboveAverage: false, stdDev: 1, dxfId: 0, priority: 1,
+    };
+    expect(matchesAvg(1, data, rule)).toBe(true);
+    expect(matchesAvg(2, data, rule)).toBe(false);
+  });
+});
+
+// ─── iconSet ─────────────────────────────────────────────────────
+describe('iconSet — threshold→icon index (ECMA-376 §18.3.1.10)', () => {
+  function iconAt(value: number, values: number[], reverse = false): number | undefined {
+    const rule: CfRule = {
+      type: 'iconSet',
+      iconSet: '3TrafficLights1',
+      // default 3-icon cfvos: 0% / 33% / 67%
+      cfvos: [
+        { kind: 'percent', value: '0' },
+        { kind: 'percent', value: '33' },
+        { kind: 'percent', value: '67' },
+      ],
+      reverse,
+      priority: 1,
+    };
+    const ws = sheetFromColumn(values, [{ sqref: [fullColumnSqref(values.length)], rules: [rule] }]);
+    const ctx = compileCf(ws);
+    const res = evaluateCf(numCell(0, 0, value), 0, 0, ctx, []);
+    return res.iconSet?.index;
+  }
+
+  it('assigns the highest icon for top values, lowest for bottom', () => {
+    // values 0..9: 0% → idx0, 33% (≈3.3) → idx1, 67% (≈6.7) → idx2
+    expect(iconAt(0, [0, 9])).toBe(0);
+    expect(iconAt(9, [0, 9])).toBe(2);
+  });
+
+  it('reverse flips the icon index', () => {
+    expect(iconAt(9, [0, 9], true)).toBe(0);
+    expect(iconAt(0, [0, 9], true)).toBe(2);
+  });
+});
+
+// ─── rule priority / first-match-wins ────────────────────────────
+describe('rule priority — lower number wins per property', () => {
+  it('a higher-priority (lower number) fill rule wins over a later one', () => {
+    const high: CfRule = { type: 'cellIs', operator: 'greaterThan', formulas: ['0'], dxfId: 0, priority: 1 };
+    const low: CfRule = { type: 'cellIs', operator: 'greaterThan', formulas: ['0'], dxfId: 1, priority: 2 };
+    const ws = sheetFromColumn([5], [{ sqref: [fullColumnSqref(1)], rules: [low, high] }]);
+    const ctx = compileCf(ws);
+    const res = evaluateCf(numCell(0, 0, 5), 0, 0, ctx, [FILL_RED, FONT_BLUE]);
+    // priority 1 (FILL_RED via dxfId 0) wins the fill slot
+    expect(res.fill?.fgColor).toBe('#FF0000');
+  });
+});

--- a/packages/xlsx/src/conditional-format.test.ts
+++ b/packages/xlsx/src/conditional-format.test.ts
@@ -173,7 +173,7 @@ describe('cellIs — text operators (case-insensitive)', () => {
 
 // ─── colorScale ──────────────────────────────────────────────────
 describe('colorScale — gradient interpolation (ECMA-376 §18.3.1.16)', () => {
-  function colorAt(value: number, values: number[], rule: CfRule): string | undefined {
+  function colorAt(value: number, values: number[], rule: CfRule): string | null | undefined {
     const ws = sheetFromColumn(values, [{ sqref: [fullColumnSqref(values.length)], rules: [rule] }]);
     const ctx = compileCf(ws);
     const res = evaluateCf(numCell(0, 0, value), 0, 0, ctx, []);

--- a/packages/xlsx/src/conditional-format.ts
+++ b/packages/xlsx/src/conditional-format.ts
@@ -16,6 +16,9 @@ export interface CompiledCfRule {
   top10IsTop?: boolean;
   avgValue?: number;
   avgIsAbove?: boolean;
+  /** Population standard deviation of the sampled range, when the
+   *  aboveAverage rule carries a `stdDev` attribute (ECMA-376 §18.3.1.10). */
+  avgStdDev?: number;
   iconThresholds?: number[];
 }
 
@@ -135,8 +138,16 @@ export function compileCf(worksheet: Worksheet): CfContext {
         }
       } else if (rule.type === 'aboveAverage') {
         if (samples.length > 0) {
-          entry.avgValue = samples.reduce((a, b) => a + b, 0) / samples.length;
+          const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+          entry.avgValue = mean;
           entry.avgIsAbove = rule.aboveAverage;
+          if (rule.stdDev && rule.stdDev > 0) {
+            // ECMA-376 §18.3.1.10: Excel uses the population standard
+            // deviation (divide by N, not N-1) for stdDev bands.
+            const variance =
+              samples.reduce((a, b) => a + (b - mean) * (b - mean), 0) / samples.length;
+            entry.avgStdDev = Math.sqrt(variance);
+          }
         }
       } else if (rule.type === 'iconSet') {
         entry.iconThresholds = rule.cfvos.map(cfv => resolveCfvoValue(cfv, samples));
@@ -307,7 +318,15 @@ export function evaluateCf(cell: Cell | undefined, row: number, col: number, cfC
       if (matches) applyDxfToResult(result, rule.dxfId != null ? dxfs[rule.dxfId] : null);
     } else if (rule.type === 'aboveAverage') {
       if (numVal == null || entry.avgValue == null) continue;
-      const matches = entry.avgIsAbove ? numVal > entry.avgValue : numVal < entry.avgValue;
+      // ECMA-376 §18.3.1.10: with `stdDev=N` the threshold is mean ± N·σ
+      // (population σ); otherwise it is the plain mean. `equalAverage`
+      // includes cells exactly at the threshold in the highlighted set.
+      const band = entry.avgStdDev != null ? entry.avgStdDev * (rule.stdDev ?? 1) : 0;
+      const threshold = entry.avgIsAbove ? entry.avgValue + band : entry.avgValue - band;
+      const eq = rule.equalAverage === true;
+      const matches = entry.avgIsAbove
+        ? (eq ? numVal >= threshold : numVal > threshold)
+        : (eq ? numVal <= threshold : numVal < threshold);
       if (matches) applyDxfToResult(result, rule.dxfId != null ? dxfs[rule.dxfId] : null);
     } else if (rule.type === 'iconSet') {
       if (numVal == null || !entry.iconThresholds?.length) continue;

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -596,7 +596,7 @@ export type CfRule =
   | { type: 'colorScale'; stops: CfStop[]; priority: number }
   | { type: 'dataBar'; color: string; min: CfValue; max: CfValue; priority: number; gradient: boolean }
   | { type: 'top10'; top: boolean; percent: boolean; rank: number; dxfId: number | null; priority: number }
-  | { type: 'aboveAverage'; aboveAverage: boolean; dxfId: number | null; priority: number }
+  | { type: 'aboveAverage'; aboveAverage: boolean; equalAverage?: boolean; stdDev?: number; dxfId: number | null; priority: number }
   | { type: 'iconSet'; iconSet: string; cfvos: CfValue[]; reverse: boolean; priority: number; customIcons?: CfIcon[] }
   | { type: 'other'; kind: string; priority: number };
 


### PR DESCRIPTION
## Summary

xlsx test reinforcement covering two audit findings.

### 1. Conditional formatting unit tests (audit C5)
The CF resolution layer (`compileCf` / `evaluateCf`) was only covered via VRT. Added `packages/xlsx/src/conditional-format.test.ts` (29 cases) exercising every rule type and its boundaries, grounded in ECMA-376 §18.3.1.10 `<cfRule>` / §18.3.1.16 colorScale / §18.3.1.28 dataBar:

- **cellIs** (numeric, all 8 operators incl. `between`/`notBetween` endpoints) + **text** (case-insensitive equal/contains/begins/ends)
- **colorScale** — 2-color min/max/midpoint interpolation, below-min/above-max clamp, **min==max no division-by-zero**; 3-color midpoint exact hit + lower-band interpolation
- **dataBar** — min→0 / max→1 / midpoint→0.5, clamp, **min==max ratio 0**
- **top10** — top-N / bottom-N by rank, percent threshold
- **aboveAverage** — mean, `equalAverage` boundary, **stdDev=1 bands**
- **iconSet** — threshold→index, reverse; rule **priority** first-match-wins

While testing aboveAverage boundaries, found the parser dropped the `equalAverage` and `stdDev` attributes (§18.3.1.10). Fixed spec-faithfully: `CfRule::AboveAverage` now carries `equal_average` + `std_dev`; `compileCf` computes the population standard deviation and `evaluateCf` applies the `mean ± N·σ` band and the equalAverage boundary. 3 Rust parse tests added.

### 2. pie / doughnut charts (audit B2)
The parser already mapped `pieChart`/`doughnutChart` and the renderer routes both to core's `renderPieChart`, but two gaps stopped charts rendering for files written by openpyxl (and other non-Excel writers):

- `load_sheet_charts` only handled `<xdr:twoCellAnchor>`; charts saved as `<xdr:oneCellAnchor>` (from cell + `<xdr:ext cx cy>` EMU size, ECMA-376 §20.5.2.16) were skipped. Now parsed.
- `resolve_zip_path` prepended the base dir to absolute drawing `Target`s (openpyxl writes `/xl/drawings/drawing1.xml`, OPC root-anchored). Absolute targets now ignore the base dir. 2 unit tests added.

Added pie/doughnut chart parse tests and `pie, doughnut` to the README xlsx Charts row. Verified end-to-end in Storybook: pie + doughnut render with correct slice proportions, titles, and legends.

## Verification
- `pnpm test` — 247 passed
- `pnpm typecheck` — clean
- `pnpm lint` (ast-grep) — clean
- `cargo test` (xlsx parser) — 27 passed; `cargo clippy -D warnings` + `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)