### PR TITLE
feat(xlsx): cell comments (incl. threaded) + data-validation model & list dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,8 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | **Advanced** | Conditional formatting (`cellIs`, `colorScale`, `dataBar`, `iconSet`, `top10`, `aboveAverage`) | ✅ |
 | | Slicers (static, Office 2010 extension) | ✅ |
 | | Pivot tables | ❌ Not planned |
-| | Data validation / comments | ❌ Not planned |
+| | Cell comments / notes (classic `xl/commentsN.xml` + Office-365 threaded comments — red triangle indicator + author / text via the worksheet model) | ✅ |
+| | Data validation (rules via the worksheet model; `list`-type dropdown arrow on the selected cell — display only) | ✅ |
 | **Interaction** | Cell selection (single / range / row / column / all) | ✅ |
 | | Excel-style row / column header highlight on selection | ✅ |
 | | Shift+click to extend, Ctrl+C to copy as TSV | ✅ |

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1247,32 +1247,147 @@ fn load_sheet_comments(
         return Vec::new();
     };
 
-    // Accept both plain ("/comments") and threaded ("/threadedComment") relTypes
-    // but prefer the classic comments file — threaded comments live in a
-    // separate namespace and are an extension.
-    let mut comments_target: Option<String> = None;
+    // A sheet may carry classic notes (`/comments`, ECMA-376 §18.7) and/or
+    // Office-365 threaded comments (`/threadedComment`, MS extension). Excel
+    // writes a back-compat `xl/commentsN.xml` alongside every threaded comment,
+    // so the classic file is preferred when present (it already includes the
+    // threaded text). Only when there is no classic file do we fall back to the
+    // threaded part — which is the case for files authored by tools that emit
+    // threaded comments exclusively.
+    let mut classic_target: Option<String> = None;
+    let mut threaded_target: Option<String> = None;
     for rel in rels_doc
         .root_element()
         .children()
         .filter(|n| n.is_element())
     {
         let rel_type = rel.attribute("Type").unwrap_or("");
+        let Some(t) = rel.attribute("Target") else {
+            continue;
+        };
         if rel_type.ends_with("/comments") {
-            if let Some(t) = rel.attribute("Target") {
-                comments_target = Some(t.to_string());
-                break;
+            classic_target.get_or_insert_with(|| t.to_string());
+        } else if rel_type.ends_with("/threadedComment") {
+            threaded_target.get_or_insert_with(|| t.to_string());
+        }
+    }
+
+    if let Some(target) = classic_target {
+        let comments_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+        if let Ok(comments_xml) = read_zip_entry(archive, &comments_path) {
+            return parse_comments_xml(&comments_xml);
+        }
+    }
+
+    if let Some(target) = threaded_target {
+        let tc_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
+        if let Ok(tc_xml) = read_zip_entry(archive, &tc_path) {
+            let persons = load_persons(archive);
+            return parse_threaded_comments_xml(&tc_xml, &persons);
+        }
+    }
+
+    Vec::new()
+}
+
+/// Load `personId` → display-name map from `xl/persons/person*.xml`
+/// (Office-365 threaded-comment authors, MS-XLSX schema
+/// `…/office/spreadsheetml/2018/threadedcomments`). `<person displayName id/>`.
+/// Returns an empty map when no persons part exists.
+fn load_persons(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> HashMap<String, String> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    // Persons live under xl/persons/ by convention; collect every part there so
+    // we don't depend on the exact file name (person.xml vs person1.xml).
+    let person_paths: Vec<String> = (0..archive.len())
+        .filter_map(|i| archive.by_index(i).ok().map(|f| f.name().to_string()))
+        .filter(|n| n.starts_with("xl/persons/") && n.ends_with(".xml"))
+        .collect();
+    for path in person_paths {
+        let Ok(xml) = read_zip_entry(archive, &path) else {
+            continue;
+        };
+        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+            continue;
+        };
+        for p in doc
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "person")
+        {
+            if let (Some(id), Some(name)) = (p.attribute("id"), p.attribute("displayName")) {
+                out.insert(id.to_string(), name.to_string());
             }
         }
     }
-    let Some(target) = comments_target else {
-        return Vec::new();
-    };
+    out
+}
 
-    let comments_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-    let Ok(comments_xml) = read_zip_entry(archive, &comments_path) else {
+/// Parse `xl/threadedComments/threadedCommentN.xml` (MS-XLSX threaded comments,
+/// schema `…/office/spreadsheetml/2018/threadedcomments`). Each
+/// `<threadedComment ref personId>` carries a `<text>`; `personId` resolves to a
+/// display name via the `persons` map. Multiple comments on the same cell (a
+/// thread of replies) are joined into one body, mirroring how the classic
+/// back-compat file flattens a thread. Returns one `XlsxComment` per cell that
+/// has at least one threaded comment.
+fn parse_threaded_comments_xml(
+    tc_xml: &str,
+    persons: &HashMap<String, String>,
+) -> Vec<XlsxComment> {
+    let Ok(doc) = roxmltree::Document::parse(tc_xml) else {
         return Vec::new();
     };
-    let Ok(comments_doc) = roxmltree::Document::parse(&comments_xml) else {
+    // Preserve document order of first appearance per cell ref.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_ref: HashMap<String, (Option<String>, String)> = HashMap::new();
+    for node in doc
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "threadedComment")
+    {
+        let Some(cell_ref) = node.attribute("ref") else {
+            continue;
+        };
+        let author = node
+            .attribute("personId")
+            .and_then(|id| persons.get(id).cloned())
+            .filter(|s| !s.is_empty());
+        let text = node
+            .children()
+            .find(|c| c.is_element() && c.tag_name().name() == "text")
+            .and_then(|t| t.text())
+            .unwrap_or("")
+            .to_string();
+        let entry = by_ref.entry(cell_ref.to_string()).or_insert_with(|| {
+            order.push(cell_ref.to_string());
+            (None, String::new())
+        });
+        // First comment in the thread sets the author; replies are appended.
+        if entry.0.is_none() {
+            entry.0 = author;
+        }
+        if !entry.1.is_empty() {
+            entry.1.push('\n');
+        }
+        entry.1.push_str(&text);
+    }
+    order
+        .into_iter()
+        .map(|cell_ref| {
+            let (author, text) = by_ref.remove(&cell_ref).unwrap();
+            XlsxComment {
+                cell_ref,
+                author,
+                text,
+            }
+        })
+        .collect()
+}
+
+/// Parse a `xl/commentsN.xml` document (ECMA-376 §18.7) into structured
+/// `XlsxComment`s. Resolves `@authorId` against the `<authors>` block and joins
+/// every `<text>/<r>/<t>` run into plain text (rich-text formatting dropped).
+/// Returns an empty vec on malformed XML. Split out from `load_sheet_comments`
+/// so the parse path is unit-testable without a ZIP archive.
+fn parse_comments_xml(comments_xml: &str) -> Vec<XlsxComment> {
+    let Ok(comments_doc) = roxmltree::Document::parse(comments_xml) else {
         return Vec::new();
     };
 
@@ -2179,5 +2294,181 @@ mod conditional_format_tests {
             }
             other => panic!("expected one AboveAverage rule, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod data_validation_tests {
+    use super::parse_worksheet;
+    use crate::types::DataValidation;
+
+    const NS: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    fn parse_dvs(dv_xml: &str) -> Vec<DataValidation> {
+        let xml = format!(r#"<worksheet xmlns="{NS}"><sheetData/>{dv_xml}</worksheet>"#);
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        ws.data_validations
+    }
+
+    /// ECMA-376 §18.3.1.33 — a `list` rule captures type, sqref and the
+    /// `<formula1>` literal list. `allowBlank="1"` is honored.
+    #[test]
+    fn list_validation_captures_formula_and_sqref() {
+        let dvs = parse_dvs(
+            r#"<dataValidations count="1"><dataValidation sqref="B2:B5" type="list" allowBlank="1"><formula1>"Pending,Shipped,Delivered"</formula1></dataValidation></dataValidations>"#,
+        );
+        assert_eq!(dvs.len(), 1, "one rule parsed");
+        let dv = &dvs[0];
+        assert_eq!(dv.sqref, "B2:B5");
+        assert_eq!(dv.validation_type.as_deref(), Some("list"));
+        assert_eq!(dv.formula1.as_deref(), Some("\"Pending,Shipped,Delivered\""));
+        assert!(dv.allow_blank, "allowBlank=\"1\" → true");
+    }
+
+    /// A `whole`/`between` rule keeps both operands and the operator.
+    #[test]
+    fn whole_between_keeps_both_operands() {
+        let dvs = parse_dvs(
+            r#"<dataValidations count="1"><dataValidation sqref="C2:C5" type="whole" operator="between"><formula1>1</formula1><formula2>100</formula2></dataValidation></dataValidations>"#,
+        );
+        let dv = &dvs[0];
+        assert_eq!(dv.validation_type.as_deref(), Some("whole"));
+        assert_eq!(dv.operator.as_deref(), Some("between"));
+        assert_eq!(dv.formula1.as_deref(), Some("1"));
+        assert_eq!(dv.formula2.as_deref(), Some("100"));
+        assert!(!dv.allow_blank, "absent allowBlank → false");
+    }
+
+    /// A rule without a `@sqref` is dropped (nothing to anchor it to).
+    #[test]
+    fn rule_without_sqref_is_skipped() {
+        let dvs = parse_dvs(
+            r#"<dataValidations count="1"><dataValidation type="list"><formula1>"A,B"</formula1></dataValidation></dataValidations>"#,
+        );
+        assert!(dvs.is_empty(), "missing sqref → rule dropped");
+    }
+
+    /// Multiple rules in one block are all captured, preserving order.
+    #[test]
+    fn multiple_rules_preserved() {
+        let dvs = parse_dvs(
+            r#"<dataValidations count="2"><dataValidation sqref="B2:B5" type="list"><formula1>"A,B"</formula1></dataValidation><dataValidation sqref="C2:C5" type="whole" operator="between"><formula1>1</formula1><formula2>9</formula2></dataValidation></dataValidations>"#,
+        );
+        assert_eq!(dvs.len(), 2);
+        assert_eq!(dvs[0].sqref, "B2:B5");
+        assert_eq!(dvs[1].sqref, "C2:C5");
+    }
+
+    /// Absent `<dataValidations>` yields an empty vec (no panic).
+    #[test]
+    fn absent_block_yields_empty() {
+        let dvs = parse_dvs("");
+        assert!(dvs.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod comment_tests {
+    use super::parse_comments_xml;
+
+    const NS: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    /// ECMA-376 §18.7 — each `<comment>` yields its cell ref, the author
+    /// resolved from `@authorId`, and the joined `<t>` text.
+    #[test]
+    fn resolves_ref_author_and_text() {
+        let xml = format!(
+            r#"<comments xmlns="{NS}"><authors><author>Reviewer</author><author>Ops Team</author></authors><commentList><comment ref="B1" authorId="0"><text><t>Set the order status.</t></text></comment><comment ref="C3" authorId="1"><text><t>Verify qty.</t></text></comment></commentList></comments>"#
+        );
+        let cs = parse_comments_xml(&xml);
+        assert_eq!(cs.len(), 2);
+        assert_eq!(cs[0].cell_ref, "B1");
+        assert_eq!(cs[0].author.as_deref(), Some("Reviewer"));
+        assert_eq!(cs[0].text, "Set the order status.");
+        assert_eq!(cs[1].cell_ref, "C3");
+        assert_eq!(cs[1].author.as_deref(), Some("Ops Team"));
+    }
+
+    /// Multiple `<r><t>` runs in one comment are concatenated into plain text.
+    #[test]
+    fn joins_multiple_runs() {
+        let xml = format!(
+            r#"<comments xmlns="{NS}"><authors><author>A</author></authors><commentList><comment ref="A1" authorId="0"><text><r><t>Hello </t></r><r><t>world</t></r></text></comment></commentList></comments>"#
+        );
+        let cs = parse_comments_xml(&xml);
+        assert_eq!(cs[0].text, "Hello world");
+    }
+
+    /// An out-of-range or absent `@authorId` leaves the author as None.
+    #[test]
+    fn missing_author_is_none() {
+        let xml = format!(
+            r#"<comments xmlns="{NS}"><authors><author>A</author></authors><commentList><comment ref="A1" authorId="9"><text><t>orphan</t></text></comment></commentList></comments>"#
+        );
+        let cs = parse_comments_xml(&xml);
+        assert_eq!(cs.len(), 1);
+        assert_eq!(cs[0].author, None, "authorId out of range → None");
+        assert_eq!(cs[0].text, "orphan");
+    }
+
+    /// Malformed XML returns an empty vec instead of panicking.
+    #[test]
+    fn malformed_xml_yields_empty() {
+        assert!(parse_comments_xml("<comments><not closed").is_empty());
+    }
+}
+
+#[cfg(test)]
+mod threaded_comment_tests {
+    use super::parse_threaded_comments_xml;
+    use std::collections::HashMap;
+
+    const TC_NS: &str = "http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments";
+
+    fn persons() -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("{p1}".to_string(), "Reviewer".to_string());
+        m.insert("{p2}".to_string(), "Ops Team".to_string());
+        m
+    }
+
+    /// MS-XLSX threaded comments — each `<threadedComment>` yields its cell ref,
+    /// the author resolved from `personId`, and the `<text>` body.
+    #[test]
+    fn resolves_ref_person_and_text() {
+        let xml = format!(
+            r#"<ThreadedComments xmlns="{TC_NS}"><threadedComment ref="B1" personId="{{p1}}" id="a"><text>Set the status.</text></threadedComment><threadedComment ref="C3" personId="{{p2}}" id="b"><text>Verify qty.</text></threadedComment></ThreadedComments>"#
+        );
+        let cs = parse_threaded_comments_xml(&xml, &persons());
+        assert_eq!(cs.len(), 2);
+        assert_eq!(cs[0].cell_ref, "B1");
+        assert_eq!(cs[0].author.as_deref(), Some("Reviewer"));
+        assert_eq!(cs[0].text, "Set the status.");
+        assert_eq!(cs[1].author.as_deref(), Some("Ops Team"));
+    }
+
+    /// A thread of replies on one cell is flattened into a single comment body,
+    /// keeping the original author.
+    #[test]
+    fn replies_collapse_into_one_thread() {
+        let xml = format!(
+            r#"<ThreadedComments xmlns="{TC_NS}"><threadedComment ref="A1" personId="{{p1}}" id="a"><text>Question?</text></threadedComment><threadedComment ref="A1" personId="{{p2}}" id="b" parentId="a"><text>Answer.</text></threadedComment></ThreadedComments>"#
+        );
+        let cs = parse_threaded_comments_xml(&xml, &persons());
+        assert_eq!(cs.len(), 1, "one comment per cell");
+        assert_eq!(cs[0].cell_ref, "A1");
+        assert_eq!(cs[0].author.as_deref(), Some("Reviewer"), "first author kept");
+        assert_eq!(cs[0].text, "Question?\nAnswer.");
+    }
+
+    /// An unknown `personId` leaves the author as None (no persons part).
+    #[test]
+    fn unknown_person_is_none() {
+        let xml = format!(
+            r#"<ThreadedComments xmlns="{TC_NS}"><threadedComment ref="A1" personId="{{zzz}}" id="a"><text>hi</text></threadedComment></ThreadedComments>"#
+        );
+        let cs = parse_threaded_comments_xml(&xml, &HashMap::new());
+        assert_eq!(cs[0].author, None);
+        assert_eq!(cs[0].text, "hi");
     }
 }

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2321,7 +2321,10 @@ mod data_validation_tests {
         let dv = &dvs[0];
         assert_eq!(dv.sqref, "B2:B5");
         assert_eq!(dv.validation_type.as_deref(), Some("list"));
-        assert_eq!(dv.formula1.as_deref(), Some("\"Pending,Shipped,Delivered\""));
+        assert_eq!(
+            dv.formula1.as_deref(),
+            Some("\"Pending,Shipped,Delivered\"")
+        );
         assert!(dv.allow_blank, "allowBlank=\"1\" → true");
     }
 
@@ -2457,7 +2460,11 @@ mod threaded_comment_tests {
         let cs = parse_threaded_comments_xml(&xml, &persons());
         assert_eq!(cs.len(), 1, "one comment per cell");
         assert_eq!(cs[0].cell_ref, "A1");
-        assert_eq!(cs[0].author.as_deref(), Some("Reviewer"), "first author kept");
+        assert_eq!(
+            cs[0].author.as_deref(),
+            Some("Reviewer"),
+            "first author kept"
+        );
         assert_eq!(cs[0].text, "Question?\nAnswer.");
     }
 

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -274,19 +274,25 @@ pub struct TableColumnInfo {
     pub totals_row_dxf_id: Option<u32>,
 }
 
-/// One `<comment>` from xl/commentsN.xml (ECMA-376 §18.7). `text` is the
-/// joined plain text of every `<r><t>` run; rich-text formatting is dropped.
+/// One cell comment. Sourced from the classic notes file `xl/commentsN.xml`
+/// (ECMA-376 §18.7) when present, otherwise from the Office-365 threaded
+/// comments part `xl/threadedComments/threadedCommentN.xml` (MS-XLSX schema
+/// `…/office/spreadsheetml/2018/threadedcomments`, `personId` resolved against
+/// `xl/persons/person*.xml`). `text` is the joined plain text — every `<r><t>`
+/// run for classic notes, every reply in the thread (newline-joined) for
+/// threaded comments; rich-text formatting is dropped.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct XlsxComment {
     /// A1-style cell reference (`@ref` on the comment element).
     pub cell_ref: String,
-    /// Resolved author name from the parent `<authors>` block (`@authorId`
-    /// indexes into that list). `None` when the workbook omits authors or
-    /// the `authorId` is out of range.
+    /// Resolved author name. For classic notes this is the `<authors>` entry
+    /// indexed by `@authorId`; for threaded comments it is the `<person>`
+    /// `displayName` matching `@personId`. `None` when unresolved / absent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
-    /// Concatenated plain text of every text run.
+    /// Concatenated plain text (every run for classic; every threaded reply,
+    /// newline-joined, for threaded).
     pub text: String,
 }
 

--- a/packages/xlsx/src/data-validation.test.ts
+++ b/packages/xlsx/src/data-validation.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { cellInSqref, findListValidationAt } from './data-validation.js';
+import type { DataValidation } from './types.js';
+
+describe('cellInSqref — ECMA-376 §18.3.1.33 @sqref matching', () => {
+  it('matches a single-cell sqref', () => {
+    expect(cellInSqref('B2', 2, 2)).toBe(true);
+    expect(cellInSqref('B2', 2, 3)).toBe(false);
+  });
+
+  it('matches a rectangular range', () => {
+    // C3:E6 → rows 3-6, cols 3-5
+    expect(cellInSqref('C3:E6', 3, 3)).toBe(true);
+    expect(cellInSqref('C3:E6', 6, 5)).toBe(true);
+    expect(cellInSqref('C3:E6', 4, 4)).toBe(true);
+    expect(cellInSqref('C3:E6', 2, 3)).toBe(false); // row above
+    expect(cellInSqref('C3:E6', 3, 6)).toBe(false); // col right
+  });
+
+  it('handles a reversed range (Excel writes from active corner)', () => {
+    expect(cellInSqref('E6:C3', 4, 4)).toBe(true);
+  });
+
+  it('matches across a space-separated multi-range sqref', () => {
+    const sq = 'A1 C3:D4 F10';
+    expect(cellInSqref(sq, 1, 1)).toBe(true);
+    expect(cellInSqref(sq, 3, 4)).toBe(true);
+    expect(cellInSqref(sq, 10, 6)).toBe(true);
+    expect(cellInSqref(sq, 5, 5)).toBe(false);
+  });
+
+  it('returns false for malformed sqref tokens without throwing', () => {
+    expect(cellInSqref('', 1, 1)).toBe(false);
+    expect(cellInSqref('not-a-ref', 1, 1)).toBe(false);
+  });
+});
+
+describe('findListValidationAt — list-type dropdown gating', () => {
+  const listDv: DataValidation = {
+    sqref: 'B2:B10',
+    validationType: 'list',
+    formula1: '"Yes,No,Maybe"',
+  };
+  const wholeDv: DataValidation = {
+    sqref: 'C2:C10',
+    validationType: 'whole',
+    operator: 'between',
+    formula1: '1',
+    formula2: '100',
+  };
+
+  it('returns the list rule when the cell is inside its sqref', () => {
+    expect(findListValidationAt([wholeDv, listDv], 5, 2)).toBe(listDv);
+  });
+
+  it('ignores non-list validation types (no dropdown for whole/decimal/etc.)', () => {
+    expect(findListValidationAt([wholeDv], 5, 3)).toBeNull();
+  });
+
+  it('returns null when the cell is outside every list rule', () => {
+    expect(findListValidationAt([listDv], 11, 2)).toBeNull();
+    expect(findListValidationAt([listDv], 5, 3)).toBeNull();
+  });
+
+  it('returns null for an empty / undefined rule set', () => {
+    expect(findListValidationAt([], 1, 1)).toBeNull();
+    expect(findListValidationAt(undefined, 1, 1)).toBeNull();
+  });
+});

--- a/packages/xlsx/src/data-validation.ts
+++ b/packages/xlsx/src/data-validation.ts
@@ -1,0 +1,62 @@
+import type { DataValidation } from './types.js';
+
+/** Parse an A1-style cell reference ("A1", "B12", "AA3") to 1-based row/col.
+ *  Strips `$` absolute markers. Returns null on malformed input. */
+function parseA1(ref: string): { row: number; col: number } | null {
+  const m = /^\$?([A-Z]+)\$?(\d+)$/.exec(ref.trim());
+  if (!m) return null;
+  const letters = m[1];
+  let col = 0;
+  for (let i = 0; i < letters.length; i++) {
+    col = col * 26 + (letters.charCodeAt(i) - 64);
+  }
+  return { row: parseInt(m[2], 10), col };
+}
+
+/**
+ * Test whether a 1-based (row, col) cell falls inside a `@sqref` (ECMA-376
+ * §18.3.1.33). `sqref` is a space-separated list of A1 ranges ("A1",
+ * "C3:E6"); ranges may be written from any corner (Excel emits them anchored
+ * at the active cell, so the start corner can be below/right of the end).
+ */
+export function cellInSqref(sqref: string, row: number, col: number): boolean {
+  if (!sqref) return false;
+  for (const token of sqref.split(/\s+/)) {
+    if (!token) continue;
+    const [a, b] = token.split(':');
+    const start = parseA1(a);
+    if (!start) continue;
+    if (!b) {
+      if (start.row === row && start.col === col) return true;
+      continue;
+    }
+    const end = parseA1(b);
+    if (!end) continue;
+    const r1 = Math.min(start.row, end.row);
+    const r2 = Math.max(start.row, end.row);
+    const c1 = Math.min(start.col, end.col);
+    const c2 = Math.max(start.col, end.col);
+    if (row >= r1 && row <= r2 && col >= c1 && col <= c2) return true;
+  }
+  return false;
+}
+
+/**
+ * Find the first `list`-type data-validation rule whose `@sqref` covers the
+ * given 1-based cell, or null. Only `list` rules drive the dropdown arrow —
+ * Excel shows the in-cell dropdown button exclusively for list validation
+ * (ECMA-376 §18.3.1.33, `ST_DataValidationType` value `list`); whole / decimal
+ * / date / textLength / custom rules have no dropdown.
+ */
+export function findListValidationAt(
+  validations: DataValidation[] | undefined,
+  row: number,
+  col: number,
+): DataValidation | null {
+  if (!validations) return null;
+  for (const dv of validations) {
+    if (dv.validationType !== 'list') continue;
+    if (cellInSqref(dv.sqref, row, col)) return dv;
+  }
+  return null;
+}

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -37,6 +37,10 @@ export type {
   // Workbook-level metadata.
   DefinedName,
   Hyperlink,
+  // Cell comments / notes (reachable via Worksheet.comments).
+  XlsxComment,
+  // Data validation rules (reachable via Worksheet.dataValidations).
+  DataValidation,
   // Excel tables (reachable via Worksheet.tables).
   TableInfo,
   TableColumnInfo,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -57,6 +57,17 @@ export interface Worksheet {
   /** A1-style cell refs of commented cells (ECMA-376 §18.7.3). Rendered as a
    *  small red triangle in each cell's top-right corner. */
   commentRefs?: string[];
+  /** Full-fidelity comment bodies (cell ref + author + plain text) for every
+   *  `<comment>` in `xl/commentsN.xml` (ECMA-376 §18.7). Parallel to
+   *  {@link commentRefs} (one entry per ref). Consume this to read the note
+   *  text; the renderer only uses {@link commentRefs} for the red indicator.
+   *  Hover popups are out of scope (TODO). */
+  comments?: XlsxComment[];
+  /** Data-validation rules on this sheet (ECMA-376 §18.3.1.32–33). Exposed for
+   *  tooling. The viewer draws a list-dropdown arrow on the active cell when the
+   *  selection intersects a `list`-type rule's `sqref` (display only — opening
+   *  the list / picking a value is out of scope for a viewer). */
+  dataValidations?: DataValidation[];
   /** Defined names in scope for this sheet (ECMA-376 §18.2.5). Used by
    *  conditional-formatting `expression` rules that call named ranges
    *  (e.g. `task_start`, `today`). */
@@ -199,6 +210,46 @@ export interface TableColumnInfo {
 export interface DefinedName {
   name: string;
   formula: string;
+}
+
+/** One cell comment. Sourced from the classic notes file `xl/commentsN.xml`
+ *  (ECMA-376 §18.7) when present, otherwise from the Office-365 threaded
+ *  comments part `xl/threadedComments/` (MS-XLSX schema
+ *  `…/spreadsheetml/2018/threadedcomments`, `personId` resolved via
+ *  `xl/persons/`). `text` is the joined plain text — every `<r><t>` run for
+ *  classic notes, every reply in the thread (newline-joined) for threaded
+ *  comments; rich-text formatting is dropped. 1:1 with the Rust `XlsxComment`
+ *  (serde camelCase). */
+export interface XlsxComment {
+  /** A1-style cell reference (`@ref` on the comment element). */
+  cellRef: string;
+  /** Resolved author name — the `<authors>` entry (classic) or the `<person>`
+   *  `displayName` (threaded). Absent when unresolved. */
+  author?: string;
+  /** Concatenated plain text of every run / threaded reply. */
+  text: string;
+}
+
+/** One `<dataValidation>` rule (ECMA-376 §18.3.1.33). `type` is the constraint
+ *  class (`list` | `whole` | `decimal` | `date` | `time` | `textLength` |
+ *  `custom`); `operator` qualifies it (`between` | `notBetween` | `equal` | …).
+ *  `formula1` / `formula2` are the operands (for `list`, `formula1` is the
+ *  comma-separated literal list or a range/named reference). 1:1 with the Rust
+ *  `DataValidation` (serde camelCase). */
+export interface DataValidation {
+  /** Affected cell ranges, verbatim from `@sqref` (space-separated A1 refs). */
+  sqref: string;
+  /** Constraint class. Absent means the spec default (`none`, no constraint). */
+  validationType?: string;
+  operator?: string;
+  formula1?: string;
+  formula2?: string;
+  /** `@allowBlank` — empty input is permitted. */
+  allowBlank?: boolean;
+  promptTitle?: string;
+  prompt?: string;
+  errorTitle?: string;
+  errorMessage?: string;
 }
 
 // ─── Chart types ─────────────────────────────────────────────────────────────

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -2,6 +2,7 @@ import { XlsxWorkbook } from './workbook.js';
 import type { ViewportRange, Worksheet } from './types.js';
 import type { MathRenderer } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
+import { findListValidationAt } from './data-validation.js';
 
 const TAB_BAR_H = 30;
 // Gap between adjacent sheet tabs. The first tab also gets this much leading
@@ -836,6 +837,61 @@ export class XlsxViewer {
       `box-sizing:border-box;border:2px solid #1a73e8;` +
       `background:rgba(26,115,232,0.08);pointer-events:none;`;
     this.selectionOverlay.appendChild(box);
+
+    // List data-validation dropdown arrow (ECMA-376 §18.3.1.33). Excel shows an
+    // in-cell dropdown button only while the cell is *selected* and only for
+    // `list`-type rules — so it is drawn here (selection overlay) rather than in
+    // the canvas renderer. Display only: clicking it does nothing, since opening
+    // the list / picking a value is out of scope for a read-only viewer (TODO:
+    // surface the choices on click once an interaction model is defined).
+    this.maybeDrawValidationDropdown();
+  }
+
+  /** Draw the Excel list-validation dropdown button just outside the
+   *  bottom-right corner of the *active* cell when that cell is covered by a
+   *  `list` data-validation rule. Anchored to the single active cell (not the
+   *  whole range) to mirror Excel, which attaches the button to the active
+   *  cell of the selection. */
+  private maybeDrawValidationDropdown(): void {
+    if (this.selectionMode !== 'cells') return;
+    const ws = this.currentWorksheet;
+    const active = this.activeCell;
+    if (!ws || !active) return;
+    const dv = findListValidationAt(ws.dataValidations, active.row, active.col);
+    if (!dv) return;
+
+    const rect = this.getCellRect(active.row, active.col);
+    if (!rect) return;
+
+    // Excel's dropdown button is a fixed square sized to the cell height,
+    // clamped to a sensible range so it stays usable at small zoom and doesn't
+    // dominate tall rows. The arrow glyph is centered inside.
+    const cs = this.opts.cellScale ?? 1;
+    const headerW = Math.round(HEADER_W * cs);
+    const headerH = Math.round(HEADER_H * cs);
+    const side = Math.max(14, Math.min(rect.h, 22 * cs));
+    // Button sits flush to the right of the cell, top-aligned with it.
+    const btnLogicalX = rect.x + rect.w;
+    const btnY = rect.y;
+    // Cull when the active cell (hence its button) is scrolled behind the
+    // fixed headers.
+    if (btnLogicalX + side <= headerW || btnY + side <= headerH) return;
+
+    const screenLeft = this.screenX(btnLogicalX, side);
+
+    const btn = document.createElement('div');
+    btn.setAttribute('data-xlsx-validation-dropdown', '');
+    btn.style.cssText =
+      `position:absolute;` +
+      `left:${screenLeft}px;top:${btnY}px;width:${side}px;height:${side}px;` +
+      `box-sizing:border-box;display:flex;align-items:center;justify-content:center;` +
+      // Match Excel's grey button chrome; non-interactive (display only).
+      `background:#f0f0f0;border:1px solid #7f7f7f;pointer-events:none;`;
+    const arrow = Math.max(4, Math.round(side * 0.42));
+    btn.innerHTML =
+      `<svg width="${arrow}" height="${arrow}" viewBox="0 0 10 6" aria-hidden="true">` +
+      `<path d="M0 0 L10 0 L5 6 Z" fill="#333"/></svg>`;
+    this.selectionOverlay.appendChild(btn);
   }
 
   private applyPointerSelection(clientX: number, clientY: number, shiftKey: boolean, pointerId: number, allowDrag: boolean): void {


### PR DESCRIPTION
## Summary

Completes the xlsx **cell comments / notes** and **data validation** features (display + model exposure), per the approved scope.

### Cell comments / notes (ECMA-376 §18.7)
- Surfaced the full comment model in TypeScript: `Worksheet.comments: XlsxComment[]` (`cellRef` / `author` / `text`), parallel to the existing `commentRefs`. Both `XlsxComment` and `DataValidation` are now exported from the barrel (export-completeness guard satisfied).
- The renderer already drew the **red triangle indicator** for commented cells (`commentRefs` → `commentCells` → `drawCommentMarker`); this PR exposes the bodies/authors via the worksheet model. Hover popups remain out of scope (TODO in code).
- **Threaded comments (Office 365)** are now parsed as a fallback: `load_sheet_comments` prefers the classic `/comments` rel, then falls back to the `/threadedComment` rel (MS-XLSX schema `…/spreadsheetml/2018/threadedcomments`). `parse_threaded_comments_xml` reads each `<threadedComment ref personId>`, collapses a reply thread on one cell into a single newline-joined body, and resolves `personId` → display name via `load_persons` (`xl/persons/person*.xml`). Previously a threaded-only file (no back-compat classic part) surfaced nothing.

### Data validation (ECMA-376 §18.3.1.32–33)
- `Worksheet.dataValidations: DataValidation[]` exposed in TS (sqref / type / operator / formula1-2 / allowBlank / prompt / error).
- **List dropdown indicator**: when the active cell is inside a `list`-type rule's `sqref`, the viewer draws Excel's in-cell dropdown arrow just outside the cell's right edge — **display only**, shown only on selection and only for list rules. Integrated into `updateSelectionOverlay` so it tracks scroll / zoom / RTL. New pure helpers `cellInSqref` / `findListValidationAt` (`data-validation.ts`). Opening the list / picking a value is out of scope.

### README
"Data validation / comments — ❌ Not planned" split into two ✅ rows with honest scope wording.

## Verification
- Parser: `cargo test` 39 passed (new `comment_tests`, `threaded_comment_tests`, `data_validation_tests`); `cargo clippy --all-targets -- -D warnings` clean.
- TS: `tsc --build` clean; vitest 82 xlsx tests passed (new `data-validation.test.ts`); `ast-grep scan` clean.
- VRT (fidelity): `demo/sample-1` 5/5 sheets 100% match — no regression.
- Manual: openpyxl fixture with comments on B1/C3 + list validation on B2:B5 + whole-number on C2:C5. Red triangles render on B1/C3; the dropdown arrow appears on selected B2 and **not** on the whole-number column. Synthetic threaded-only fixture verified to surface refs + authors + text after the fallback. (Fixtures kept local / gitignored, not committed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)