### PR TITLE
fix(xlsx): scrollbar-drag selection + theme lnRef shape outlines

### DIFF
--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -700,6 +700,7 @@ pub(crate) fn collect_shapes(
     trans_x: f64,
     trans_y: f64,
     theme_colors: &[String],
+    theme_ln_widths: &[i64],
     rid_urls: &HashMap<String, String>,
     out: &mut Vec<ShapeInfo>,
 ) {
@@ -752,6 +753,7 @@ pub(crate) fn collect_shapes(
                 tx,
                 ty,
                 theme_colors,
+                theme_ln_widths,
                 rid_urls,
                 out,
             );
@@ -817,6 +819,9 @@ pub(crate) fn collect_shapes(
             // Stroke (line)
             let mut stroke_color: Option<String> = None;
             let mut stroke_width: i64 = 0;
+            // An explicit `<a:ln><a:noFill/>` is a hard "no outline" and must
+            // suppress the theme lnRef fallback below.
+            let mut ln_no_stroke = false;
             if let Some(ln) = sp_pr
                 .children()
                 .find(|n| n.is_element() && n.tag_name().name() == "ln")
@@ -826,9 +831,11 @@ pub(crate) fn collect_shapes(
                 for c in ln.children().filter(|n| n.is_element()) {
                     if c.tag_name().name() == "solidFill" {
                         stroke_color = parse_solid_fill(&c, theme_colors);
+                        ln_no_stroke = false;
                     } else if c.tag_name().name() == "noFill" {
                         stroke_color = None;
                         stroke_width = 0;
+                        ln_no_stroke = true;
                     }
                 }
                 // An `<a:ln>` with a fill but no explicit `w` still draws an
@@ -866,6 +873,38 @@ pub(crate) fn collect_shapes(
                 .and_then(|n| parse_solid_fill(&n, theme_colors));
             if fill_color.is_none() && !has_no_fill {
                 fill_color = style_fill;
+            }
+
+            // <a:lnRef> — ECMA-376 §20.1.4.2.19: when `<xdr:spPr>` carries no
+            // explicit `<a:ln>`, the shape's outline comes from the theme's
+            // style matrix: `idx="N"` selects entry N (1-based) of
+            // `fmtScheme > lnStyleLst` for the line WIDTH, and the lnRef's
+            // child color (e.g. `<a:schemeClr val="accent1"/>`) substitutes
+            // the entry's `phClr` placeholder for the line COLOR. This is how
+            // Excel-inserted shapes get their default border, so without it
+            // every default shape renders outline-less. An explicit
+            // `<a:ln>` (including `<a:noFill/>`) always wins.
+            if stroke_color.is_none() && !ln_no_stroke {
+                if let Some(ln_ref) = style_node.as_ref().and_then(|s| {
+                    s.children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "lnRef")
+                }) {
+                    if let Some(c) = parse_solid_fill(&ln_ref, theme_colors) {
+                        stroke_color = Some(c);
+                        let idx: usize = ln_ref
+                            .attribute("idx")
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(0);
+                        // Missing/out-of-range entries fall back to the
+                        // CT_LineProperties default width (§20.1.2.2.24,
+                        // 9525 EMU = 0.75 pt).
+                        stroke_width = if idx >= 1 {
+                            theme_ln_widths.get(idx - 1).copied().unwrap_or(9525)
+                        } else {
+                            9525
+                        };
+                    }
+                }
             }
 
             // Text body (txBox shapes carry visible text inside
@@ -980,6 +1019,7 @@ pub(crate) fn collect_shapes(
 pub(crate) fn parse_shape_anchors(
     drawing_xml: &str,
     theme_colors: &[String],
+    theme_ln_widths: &[i64],
     rid_urls: &HashMap<String, String>,
 ) -> Vec<ShapeAnchor> {
     let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
@@ -1118,6 +1158,7 @@ pub(crate) fn parse_shape_anchors(
                 tx,
                 ty,
                 theme_colors,
+                theme_ln_widths,
                 rid_urls,
                 &mut shapes,
             );
@@ -1161,6 +1202,7 @@ pub(crate) fn parse_shape_anchors(
                 0.0,
                 0.0,
                 theme_colors,
+                theme_ln_widths,
                 rid_urls,
                 &mut shapes,
             );
@@ -1195,6 +1237,8 @@ pub(crate) fn load_sheet_shape_groups(
     sheet_path: &str,
     theme_colors: &[String],
 ) -> Vec<ShapeAnchor> {
+    // Theme line-style widths for <a:lnRef> resolution (§20.1.4.2.19).
+    let theme_ln_widths = crate::parse_theme_ln_widths(archive);
     let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
         return Vec::new();
     };
@@ -1224,7 +1268,12 @@ pub(crate) fn load_sheet_shape_groups(
             continue;
         };
         let rid_urls = build_drawing_rid_urls(archive, &drawing_path);
-        all.extend(parse_shape_anchors(&drawing_xml, theme_colors, &rid_urls));
+        all.extend(parse_shape_anchors(
+            &drawing_xml,
+            theme_colors,
+            &theme_ln_widths,
+            &rid_urls,
+        ));
     }
     all
 }
@@ -1469,6 +1518,94 @@ mod math_tests {
         let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
         assert_eq!(text.paragraphs.len(), 1);
         assert!(!text.paragraphs[0].rtl, "absent @rtl → rtl false");
+    }
+}
+
+#[cfg(test)]
+mod style_lnref_tests {
+    use super::*;
+
+    const NS: &str = r#"xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main""#;
+
+    /// dk1, lt1, dk2, lt2, accent1 — enough slots for schemeClr accent1 (idx 4).
+    fn theme() -> Vec<String> {
+        ["#000000", "#FFFFFF", "#222222", "#EEEEEE", "#4472C4"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn shape_of(sp_pr_inner: &str, style: &str) -> (Option<String>, i64) {
+        let xml = format!(
+            r#"<xdr:wsDr {NS}><xdr:twoCellAnchor>
+              <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+              <xdr:to><xdr:col>4</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>6</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+              <xdr:sp>
+                <xdr:nvSpPr><xdr:cNvPr id="2" name="P"/><xdr:cNvSpPr/></xdr:nvSpPr>
+                <xdr:spPr>
+                  <a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                  <a:prstGeom prst="parallelogram"><a:avLst/></a:prstGeom>
+                  {sp_pr_inner}
+                </xdr:spPr>
+                {style}
+              </xdr:sp>
+              <xdr:clientData/>
+            </xdr:twoCellAnchor></xdr:wsDr>"#
+        );
+        let anchors =
+            parse_shape_anchors(&xml, &theme(), &[6_350, 12_700, 19_050], &HashMap::new());
+        assert_eq!(anchors.len(), 1, "one anchor expected");
+        let s = &anchors[0].shapes[0];
+        (s.stroke_color.clone(), s.stroke_width)
+    }
+
+    /// §20.1.4.2.19 — with no explicit `<a:ln>`, the outline comes from the
+    /// theme style matrix: lnRef idx picks the lnStyleLst width, the lnRef's
+    /// child scheme colour substitutes phClr.
+    #[test]
+    fn lnref_supplies_stroke_when_sppr_has_no_ln() {
+        let (color, width) = shape_of(
+            "",
+            r#"<xdr:style><a:lnRef idx="2"><a:schemeClr val="accent1"/></a:lnRef></xdr:style>"#,
+        );
+        assert_eq!(color.as_deref(), Some("#4472C4"));
+        assert_eq!(width, 12_700);
+    }
+
+    /// An explicit `<a:ln><a:noFill/>` is a hard "no outline" and must beat
+    /// the theme lnRef fallback.
+    #[test]
+    fn explicit_nofill_ln_beats_lnref() {
+        let (color, width) = shape_of(
+            r#"<a:ln><a:noFill/></a:ln>"#,
+            r#"<xdr:style><a:lnRef idx="2"><a:schemeClr val="accent1"/></a:lnRef></xdr:style>"#,
+        );
+        assert!(color.is_none());
+        assert_eq!(width, 0);
+    }
+
+    /// An explicit `<a:ln>` with its own fill/width wins over lnRef.
+    #[test]
+    fn explicit_ln_beats_lnref() {
+        let (color, width) = shape_of(
+            r#"<a:ln w="28575"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:ln>"#,
+            r#"<xdr:style><a:lnRef idx="3"><a:schemeClr val="accent1"/></a:lnRef></xdr:style>"#,
+        );
+        assert_eq!(color.as_deref(), Some("#00FF00"));
+        assert_eq!(width, 28_575);
+    }
+
+    /// lnRef idx out of range (or theme without lnStyleLst) still draws with
+    /// the CT_LineProperties default width (§20.1.2.2.24).
+    #[test]
+    fn lnref_out_of_range_uses_default_width() {
+        let (color, width) = shape_of(
+            "",
+            r#"<xdr:style><a:lnRef idx="9"><a:schemeClr val="accent1"/></a:lnRef></xdr:style>"#,
+        );
+        assert_eq!(color.as_deref(), Some("#4472C4"));
+        assert_eq!(width, 9_525);
     }
 }
 

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -207,6 +207,38 @@ pub(crate) fn read_zip_entry(
     Ok(buf)
 }
 
+/// Theme `fmtScheme > lnStyleLst` line widths (EMU), in declaration order.
+/// A drawing shape's `<a:style><a:lnRef idx="N">` resolves its outline width
+/// from entry N (1-based) of this list (ECMA-376 §20.1.4.2.19); an entry
+/// without an explicit `w` uses the CT_LineProperties default 9525 EMU =
+/// 0.75 pt (§20.1.2.2.24).
+pub(crate) fn parse_theme_ln_widths(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<i64> {
+    let Ok(xml) = read_zip_entry(archive, "xl/theme/theme1.xml") else {
+        return Vec::new();
+    };
+    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        return Vec::new();
+    };
+    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    let mut widths: Vec<i64> = Vec::new();
+    for node in doc.descendants() {
+        if node.tag_name().name() == "lnStyleLst" && node.tag_name().namespace() == Some(a_ns) {
+            for ln in node
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "ln")
+            {
+                widths.push(
+                    ln.attribute("w")
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(9525),
+                );
+            }
+            break;
+        }
+    }
+    widths
+}
+
 fn parse_theme_colors(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<String> {
     let Ok(xml) = read_zip_entry(archive, "xl/theme/theme1.xml") else {
         return Vec::new();

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -182,8 +182,11 @@ export class XlsxViewer {
   private isSelecting = false;
   private selectionOverlay: HTMLDivElement;
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
-  // Pending touch/pen tap: only commit selection on pointerup if movement stays within tap threshold,
-  // so swipe-to-scroll on mobile doesn't change the selected cell.
+  // Deferred selection press: committed on pointerup only if the pointer
+  // neither moved beyond the tap threshold nor caused a scroll. Used for
+  // touch/pen (swipe-to-scroll must not change the cell) and for mouse
+  // presses inside the overlay-scrollbar band (a thumb drag must not select
+  // the cell underneath).
   private pendingTap: { x: number; y: number; shiftKey: boolean; pointerId: number } | null = null;
 
   constructor(container: HTMLElement, opts: XlsxViewerOptions = {}) {
@@ -277,6 +280,10 @@ export class XlsxViewer {
     container.appendChild(wrapper);
 
     this.scrollHost.addEventListener('scroll', () => {
+      // Any scroll cancels a deferred tap: the press that started it was a
+      // scrollbar-thumb drag (overlay scrollbars) or a touch swipe, not a
+      // cell click.
+      this.pendingTap = null;
       // Track the start-anchored position, but only while the host is laid
       // out: a hidden host reports clientWidth 0 and fires bogus scroll
       // events when the browser clamps scrollLeft, which must not overwrite
@@ -905,9 +912,35 @@ export class XlsxViewer {
     this.scrollHost.addEventListener('pointerdown', (e: PointerEvent) => {
       if (e.button !== 0) return;
 
+      // A pointerdown on the native scrollbar must not move the cell
+      // selection — dragging the thumb would otherwise select whatever cell
+      // sits underneath it. Two scrollbar styles need different handling:
+      // classic scrollbars reserve layout space, so the press lands in the
+      // band between the content box (clientWidth/Height) and the border-box
+      // edge and can be rejected exactly; OS overlay scrollbars (macOS
+      // "show when scrolling") float over the content without affecting
+      // client sizes, so a press near a scrollable edge is geometrically
+      // indistinguishable from a cell click. For that case we defer the
+      // selection to pointerup via the pendingTap path and cancel it when a
+      // scroll event arrives first (the press was a thumb drag). A plain
+      // click in the band still selects the cell on release.
+      const hostRect = this.scrollHost.getBoundingClientRect();
+      const localX = e.clientX - hostRect.left - this.scrollHost.clientLeft;
+      const localY = e.clientY - hostRect.top - this.scrollHost.clientTop;
+      if (localX >= this.scrollHost.clientWidth || localY >= this.scrollHost.clientHeight) {
+        return; // classic scrollbar gutter
+      }
+      // Overlay scrollbar hit band (~15 CSS px on macOS / Windows 11).
+      const OVERLAY_SCROLLBAR_BAND = 16;
+      const inOverlayBand =
+        (this.scrollHost.scrollWidth > this.scrollHost.clientWidth &&
+          this.scrollHost.clientHeight - localY <= OVERLAY_SCROLLBAR_BAND) ||
+        (this.scrollHost.scrollHeight > this.scrollHost.clientHeight &&
+          this.scrollHost.clientWidth - localX <= OVERLAY_SCROLLBAR_BAND);
+
       // Touch / pen: defer selection until pointerup so swipe-to-scroll doesn't change the cell.
       // Mouse: select immediately to preserve drag-to-extend behavior.
-      if (e.pointerType !== 'mouse') {
+      if (e.pointerType !== 'mouse' || inOverlayBand) {
         this.pendingTap = { x: e.clientX, y: e.clientY, shiftKey: e.shiftKey, pointerId: e.pointerId };
         return;
       }


### PR DESCRIPTION
Two user-reported xlsx bugs.

## 1. Dragging the horizontal scrollbar moved the cell selection

`pointerdown` on the scroll host fired the selection handler even when the press landed on the native scrollbar. Classic (space-reserving) scrollbars are rejected exactly via the client-box check; OS **overlay** scrollbars float over the content, so a mouse press inside the overlay hit band near a scrollable edge now defers the selection to pointerup — a scroll event in between (= thumb drag) cancels it, while a stationary click in the band still selects the cell on release.

Verified via Playwright on sample-6: band press + drag leaves the selection untouched (pixel-identical screenshots); normal clicks unchanged.

## 2. Bordered parallelogram (any default shape) rendered without its outline

Excel-inserted shapes carry their border via `<xdr:style><a:lnRef idx="N">` (ECMA-376 §20.1.4.2.19): idx selects the `fmtScheme>lnStyleLst` width and the lnRef's child colour substitutes `phClr`. The parser resolved `fillRef`/`fontRef` but dropped `lnRef`. Now resolved, with an explicit `<a:ln>` (incl. `<a:noFill/>`) always winning; theme `lnStyleLst` widths are parsed with the §20.1.2.2.24 default (9525 EMU).

4 new Rust unit tests; pixel-verified against a hand-built Excel-style fixture (border = accent1 shade 50%, width = lnStyleLst idx 2). xlsx VRT 65/65 green (existing samples don't rely on lnRef outlines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)