### PR TITLE
fix(docx): raise note reference numbers as true superscript

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1794,7 +1794,10 @@ fn parse_run_inner(
                     background: fmt.background.clone(),
                     // Force superscript regardless of the run's original
                     // vertAlign so reference markers appear above the line.
-                    vert_align: Some("superscript".to_string()),
+                    // NOTE: the model value is "super" (see the styles.rs
+                    // w:vertAlign mapping) — the renderer only raises the
+                    // baseline for that exact token.
+                    vert_align: Some("super".to_string()),
                     hyperlink: hyperlink.clone(),
                     all_caps,
                     small_caps,
@@ -4509,7 +4512,10 @@ mod footnote_tests {
         let nr = run.note_ref.as_ref().expect("note_ref set");
         assert_eq!(nr.kind, "footnote");
         assert_eq!(nr.id, "3");
-        assert_eq!(run.vert_align.as_deref(), Some("superscript"));
+        // Model value is "super" (the styles.rs mapping of w:vertAlign
+        // val="superscript"), NOT the raw XML token — the renderer raises
+        // the baseline only for "super".
+        assert_eq!(run.vert_align.as_deref(), Some("super"));
     }
 
     /// ECMA-376 §17.11.16 — the in-note `<w:footnoteRef>` placeholder is tagged


### PR DESCRIPTION
User-reported: footnote numbers rendered like subscript (small, at the baseline) where Word shows superscript.

Root cause: the shared noteRef path (#401) hard-coded `vert_align: "superscript"` — the raw XML token — while the model contract (styles.rs mapping of `w:vertAlign`, §17.3.2.42) and the renderer's baseline-raise comparison use `"super"`. The renderer's size reduction keys on truthiness but the raise compares exact tokens, so the number shrank without rising. Affects both the in-body marker and the in-note leading number.

- TDD: corrected the existing unit-test expectation first (Red), then the one-token fix (Green); 33 cargo tests pass
- Visual: footnote number now renders raised (¹ On forest age …), matching the Word PDF
- docx VRT 19/19 green (page-5 diff vs the committed demo ref is the 24 raised pixels — within threshold; happy to refresh that ref on instruction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)