### PR TITLE
fix(core): chart legend swatches track per-slice/series colors

### DIFF
--- a/packages/core/src/chart/legend-color.test.ts
+++ b/packages/core/src/chart/legend-color.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import type { ChartSeries } from '../types/chart';
+import { legendEntryColor, CHART_PALETTE } from './renderer.js';
+
+function series(partial: Partial<ChartSeries>): ChartSeries {
+  return { name: '', color: null, values: [], ...partial };
+}
+
+const pal = (i: number) => `#${CHART_PALETTE[i % CHART_PALETTE.length]}`;
+
+describe('legendEntryColor', () => {
+  describe('multi-series chart (bar/line) — one legend entry per series', () => {
+    const s: ChartSeries[] = [
+      series({ name: 'A', color: null }),
+      series({ name: 'B', color: null }),
+      series({ name: 'C', color: null }),
+    ];
+
+    it('falls back to the per-series palette index', () => {
+      expect(legendEntryColor('bar', s, 0)).toBe(pal(0));
+      expect(legendEntryColor('bar', s, 1)).toBe(pal(1));
+      expect(legendEntryColor('bar', s, 2)).toBe(pal(2));
+    });
+
+    it('honors an explicit series color', () => {
+      const withColor: ChartSeries[] = [
+        series({ name: 'A', color: 'FF0000' }),
+        series({ name: 'B', color: null }),
+      ];
+      expect(legendEntryColor('line', withColor, 0)).toBe('#FF0000');
+      expect(legendEntryColor('line', withColor, 1)).toBe(pal(1));
+    });
+  });
+
+  describe('pie / doughnut — one legend entry per category (data point of series[0])', () => {
+    it('uses the per-index palette and matches slice colors, ignoring the series-level color', () => {
+      // Excel sets a series-level solidFill on pie series; that must NOT
+      // collapse every legend swatch to the same color. Each entry uses the
+      // same palette index its slice does.
+      const s: ChartSeries[] = [
+        series({ name: 'Region', color: '4472C4', values: [10, 20, 30] }),
+      ];
+      expect(legendEntryColor('pie', s, 0)).toBe(pal(0));
+      expect(legendEntryColor('pie', s, 1)).toBe(pal(1));
+      expect(legendEntryColor('pie', s, 2)).toBe(pal(2));
+      // Distinct colors, not all the series color.
+      expect(legendEntryColor('pie', s, 0)).not.toBe(legendEntryColor('pie', s, 1));
+    });
+
+    it('honors explicit per-point dPt colors', () => {
+      const s: ChartSeries[] = [
+        series({
+          name: 'Region',
+          color: '4472C4',
+          values: [10, 20, 30],
+          dataPointColors: ['AA0000', null, 'CC0000'],
+        }),
+      ];
+      expect(legendEntryColor('doughnut', s, 0)).toBe('#AA0000');
+      // null inside the array -> palette fallback for that slice
+      expect(legendEntryColor('doughnut', s, 1)).toBe(pal(1));
+      expect(legendEntryColor('doughnut', s, 2)).toBe('#CC0000');
+    });
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -11,7 +11,7 @@ import { EMU_PER_PT, PT_TO_PX } from '../units.js';
 
 // ─── Palette + helpers ──────────────────────────────────────────────────────
 
-const CHART_PALETTE = [
+export const CHART_PALETTE = [
   '4472C4','ED7D31','A9D18E','FF0000','70AD47','4BACC6',
   'FFC000','9E480E','843C0C','636363','255E91','967300',
 ];
@@ -25,6 +25,40 @@ function pieSliceColor(idx: number, series: ChartSeries): string {
   const override = series.dataPointColors?.[idx];
   if (override) return `#${override}`;
   return `#${CHART_PALETTE[idx % CHART_PALETTE.length]}`;
+}
+
+/** Chart types whose legend lists one entry per category (data point of the
+ *  first series) rather than one entry per series. Excel/PowerPoint draw pie
+ *  and doughnut legends this way: each slice gets its own row, colored with
+ *  the slice's color. ECMA-376 §21.2.2.114 (`<c:varyColors>` defaults true for
+ *  pie/doughnut). */
+function legendIsCategoryDriven(chartType: string | undefined): boolean {
+  return chartType === 'pie' || chartType === 'doughnut';
+}
+
+/** Resolve the color for legend entry `entryIndex`, matching the marks the
+ *  plot actually draws.
+ *
+ *  - Category-driven legends (pie / doughnut): the entry maps to data point
+ *    `entryIndex` of the first series, so it must use the *same* resolution as
+ *    {@link pieSliceColor} — explicit per-point `dPt` color, else the palette
+ *    indexed by point. The series-level fill is deliberately ignored: a pie
+ *    series carries a single `<c:spPr>` solidFill that, if honored here, would
+ *    collapse every swatch to one color while the slices stay multi-colored.
+ *  - Series-driven legends (bar / line / area / …): the entry maps to series
+ *    `entryIndex`, so it uses {@link chartColor} — explicit series fill else
+ *    the palette indexed by series. */
+export function legendEntryColor(
+  chartType: string | undefined,
+  series: ChartSeries[],
+  entryIndex: number,
+): string {
+  if (legendIsCategoryDriven(chartType)) {
+    const first = series[0];
+    if (first) return pieSliceColor(entryIndex, first);
+    return `#${CHART_PALETTE[entryIndex % CHART_PALETTE.length]}`;
+  }
+  return chartColor(entryIndex, series[entryIndex]);
 }
 
 function drawAxisTitle(
@@ -92,6 +126,30 @@ function drawLegendSwatch(
   }
 }
 
+/** A single legend row: a label and the color of its swatch. Built so that the
+ *  swatch color is resolved exactly like the mark it represents (slice / bar /
+ *  line). See {@link legendEntryColor}. */
+interface LegendEntry { label: string; color: string }
+
+/** Build the legend entries for a chart. Pie/doughnut legends are
+ *  category-driven (one row per data point of the first series, labeled by
+ *  category); every other chart type is series-driven (one row per series). */
+function buildLegendEntries(series: ChartSeries[], chartType: string | undefined): LegendEntry[] {
+  if (legendIsCategoryDriven(chartType)) {
+    const first = series[0];
+    const n = first ? first.values.length : 0;
+    const cats = first?.categories ?? [];
+    return Array.from({ length: n }, (_, i) => ({
+      label: (cats[i] ?? `Item ${i + 1}`).toString(),
+      color: legendEntryColor(chartType, series, i),
+    }));
+  }
+  return series.map((s, i) => ({
+    label: s.name || `Series ${i + 1}`,
+    color: legendEntryColor(chartType, series, i),
+  }));
+}
+
 function drawLegend(
   ctx: CanvasRenderingContext2D,
   series: ChartSeries[],
@@ -101,35 +159,34 @@ function drawLegend(
 ): void {
   const sw = 10; const gap = 4;
   const swatchStyle = legendSwatchStyle(chartType);
+  const entries = buildLegendEntries(series, chartType);
   if (orient === 'horizontal') {
     // Excel lays a bottom/top legend as a single horizontal row, centered.
     const fontSize = Math.max(9, Math.min(12, lh * 0.7));
     ctx.font = `${fontSize}px sans-serif`;
     ctx.textBaseline = 'middle';
     const itemGap = 12;
-    const labels = series.map((s, i) => s.name || `Series ${i + 1}`);
-    const itemWidths = labels.map((l) => sw + gap + ctx.measureText(l.slice(0, 30)).width);
-    const total = itemWidths.reduce((a, b) => a + b, 0) + itemGap * Math.max(0, series.length - 1);
+    const itemWidths = entries.map((e) => sw + gap + ctx.measureText(e.label.slice(0, 30)).width);
+    const total = itemWidths.reduce((a, b) => a + b, 0) + itemGap * Math.max(0, entries.length - 1);
     let rx = lx + (lw - total) / 2;
     const ry = ly + lh / 2;
-    for (let i = 0; i < series.length; i++) {
-      drawLegendSwatch(ctx, swatchStyle, chartColor(i, series[i]), rx, ry - fontSize / 2, sw, fontSize);
+    for (let i = 0; i < entries.length; i++) {
+      drawLegendSwatch(ctx, swatchStyle, entries[i].color, rx, ry - fontSize / 2, sw, fontSize);
       ctx.fillStyle = '#333'; ctx.textAlign = 'left';
-      ctx.fillText(labels[i].slice(0, 30), rx + sw + gap, ry);
+      ctx.fillText(entries[i].label.slice(0, 30), rx + sw + gap, ry);
       rx += itemWidths[i] + itemGap;
     }
     return;
   }
-  const fontSize = Math.max(9, Math.min(12, lh / (series.length + 1)));
+  const fontSize = Math.max(9, Math.min(12, lh / (entries.length + 1)));
   ctx.font = `${fontSize}px sans-serif`;
   ctx.textBaseline = 'middle';
   const rowH = fontSize + 4;
-  let ry = ly + (lh - rowH * series.length) / 2;
-  for (let i = 0; i < series.length; i++) {
-    drawLegendSwatch(ctx, swatchStyle, chartColor(i, series[i]), lx, ry, sw, fontSize);
+  let ry = ly + (lh - rowH * entries.length) / 2;
+  for (let i = 0; i < entries.length; i++) {
+    drawLegendSwatch(ctx, swatchStyle, entries[i].color, lx, ry, sw, fontSize);
     ctx.fillStyle = '#333'; ctx.textAlign = 'left';
-    const label = series[i].name || `Series ${i + 1}`;
-    ctx.fillText(label.slice(0, 20), lx + sw + gap, ry + fontSize / 2);
+    ctx.fillText(entries[i].label.slice(0, 20), lx + sw + gap, ry + fontSize / 2);
     ry += rowH;
   }
   void lw;
@@ -1025,13 +1082,13 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   }
 
   if (pieLeg) {
-    // Pie legend is category-driven; build a pseudo-series array whose per-
-    // index palette matches the pie's slice colors so the swatches line up.
-    const legendSeries: ChartSeries[] = vals.map((_, i) => ({
-      name: (cats[i] ?? `Item ${i + 1}`).toString(),
-      color: s.dataPointColors?.[i] ?? s.color ?? CHART_PALETTE[i % CHART_PALETTE.length],
-      values: [],
-    }));
+    // Pie/doughnut legends are category-driven: one row per slice, each colored
+    // exactly like its slice (`pieSliceColor`). `buildLegendEntries` derives the
+    // rows from the real series, so pass it through unchanged (with the resolved
+    // category labels attached). The previous pseudo-series collapsed all
+    // swatches to one color because it folded the series-level fill (`s.color`)
+    // into every entry while the slices used the per-index palette.
+    const legendSeries: ChartSeries[] = [{ ...s, categories: cats }];
     const plotLeft = cx2 - pw / 2;
     drawLegendForLayout(
       ctx, { ...chart, series: legendSeries } as ChartModel, pieLeg,


### PR DESCRIPTION
## Problem

In `packages/core/src/chart/renderer.ts`, legend swatches did not track the marks they label. For **pie/doughnut** charts every legend swatch collapsed to the same color (blue) while the slices were correctly multi-colored.

**Root cause:** two divergent color-resolution paths for the same chart. Slices used `pieSliceColor` (`dataPointColors[i] ?? palette[i]`, series-level fill ignored), while the legend built a pseudo-series colored `dataPointColors[i] ?? s.color ?? palette[i]`. Excel emits a series-level `<c:spPr>` solidFill on pie series, so `s.color` was non-null and folded into every legend entry.

## Fix

Single source of truth — a pure function:

```
legendEntryColor(chartType, series, entryIndex)
  pie/doughnut (category-driven): pieSliceColor(i, series[0])      // dPt[i] ?? palette[i]
  otherwise   (series-driven):    chartColor(i, series[i])         // series.color ?? palette[i]
```

- `legendIsCategoryDriven` → true for `pie`/`doughnut` (ECMA-376 §21.2.2.114 `varyColors` defaults true; Excel/PowerPoint draw one legend row per slice).
- `buildLegendEntries` produces `{label, color}` rows; `drawLegend` consumes them in both orientations.
- Pie render path passes the real series through (with resolved category labels) instead of the color-folding pseudo-series.
- bar/line/area legends (one entry per series) keep using the series color — unchanged.
- explicit per-point `dPt` colors are honored in both slice and swatch.

## Tests

- **Unit** (`legend-color.test.ts`, 4 cases): bar palette fallback, explicit series color, pie per-index palette (ignores series fill), pie `dPt` override.
- **Visual**: Playwright harness rendered pie (series fill `4472C4`, 3 distinct slices) + clustered bar (3 series); legend swatches match slices/bars.
- `pnpm typecheck` / `pnpm lint` / full `vitest` (268) green.
- **VRT**: pptx demo/sample-1 9/9 pass; xlsx demo/sample-1 5/5 pass at 100% match, 0 diff. Reference images untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)