### PR TITLE
feat(xlsx): Excel-style hover popup for cell comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | **Advanced** | Conditional formatting (`cellIs`, `colorScale`, `dataBar`, `iconSet`, `top10`, `aboveAverage`) | ✅ |
 | | Slicers (static, Office 2010 extension) | ✅ |
 | | Pivot tables | ❌ Not planned |
-| | Cell comments / notes (classic `xl/commentsN.xml` + Office-365 threaded comments — red triangle indicator + author / text via the worksheet model) | ✅ |
+| | Cell comments / notes (classic `xl/commentsN.xml` + Office-365 threaded comments — red triangle indicator + author / text via the worksheet model, shown in an Excel-style hover popup) | ✅ |
 | | Data validation (rules via the worksheet model; `list`-type dropdown arrow on the selected cell — display only) | ✅ |
 | **Interaction** | Cell selection (single / range / row / column / all) | ✅ |
 | | Excel-style row / column header highlight on selection | ✅ |

--- a/packages/xlsx/src/a1.ts
+++ b/packages/xlsx/src/a1.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared A1-style cell-reference parser (ECMA-376 §18.3.1.95 `ST_CellRef`).
+ * Used by the renderer (comment-indicator placement), data-validation sqref
+ * matching, and the comment hover popup. `$` absolute markers are stripped so
+ * both `"H6"` and `"$H$6"` parse. Returns null on malformed input — parser-side
+ * data is trusted, but callers still guard against junk.
+ */
+export function parseA1(ref: string): { row: number; col: number } | null {
+  const m = /^\$?([A-Z]+)\$?(\d+)$/.exec(ref.trim());
+  if (!m) return null;
+  const letters = m[1];
+  let col = 0;
+  for (let i = 0; i < letters.length; i++) {
+    col = col * 26 + (letters.charCodeAt(i) - 64);
+  }
+  return { row: parseInt(m[2], 10), col };
+}

--- a/packages/xlsx/src/comment-popup.test.ts
+++ b/packages/xlsx/src/comment-popup.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { computeCommentPopupPosition } from './comment-popup.js';
+
+/**
+ * Unit tests for the pure popup-position calculator. The popup follows Excel's
+ * note placement: by default it sits just past the top-right corner of the
+ * commented cell. When it would overflow the viewport it flips to the opposite
+ * side (right→left) and/or clamps to stay fully visible.
+ *
+ * Geometry is in canvasArea CSS-pixel space (the same space getCellRect and the
+ * selection overlay use). For RTL sheets the *cell rect* is already mirrored by
+ * the caller (via screenX), so the default direction is reversed: the popup
+ * opens toward the cell's left so it grows into the sheet body, not off-screen.
+ */
+describe('computeCommentPopupPosition', () => {
+  const GAP = 8; // must match the implementation's cell↔popup gap
+
+  const cell = { x: 100, y: 60, w: 64, h: 20 };
+  const popup = { w: 280, h: 90 };
+  const viewport = { w: 800, h: 600 };
+
+  it('places the popup to the right of the cell, anchored at the cell top (LTR)', () => {
+    const pos = computeCommentPopupPosition({
+      cell,
+      popup,
+      viewport,
+      rtl: false,
+    });
+    // Right of the cell: left = cell.x + cell.w + GAP.
+    expect(pos.left).toBe(cell.x + cell.w + GAP);
+    // Anchored at the cell's top edge.
+    expect(pos.top).toBe(cell.y);
+  });
+
+  it('flips to the left of the cell when the right side overflows (LTR)', () => {
+    // A cell near the right edge: right placement (724 + 8 + 280) overflows 800.
+    const rightCell = { x: 724, y: 60, w: 64, h: 20 };
+    const pos = computeCommentPopupPosition({
+      cell: rightCell,
+      popup,
+      viewport,
+      rtl: false,
+    });
+    // Flipped to the left: left = cell.x - GAP - popup.w.
+    expect(pos.left).toBe(rightCell.x - GAP - popup.w);
+    expect(pos.left).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamps the top so the popup stays inside the bottom edge', () => {
+    // A cell near the bottom: anchoring at cell.y (560) would push the
+    // 90px-tall popup to 650, past the 600px viewport.
+    const bottomCell = { x: 100, y: 560, w: 64, h: 20 };
+    const pos = computeCommentPopupPosition({
+      cell: bottomCell,
+      popup,
+      viewport,
+      rtl: false,
+    });
+    expect(pos.top).toBe(viewport.h - popup.h);
+    expect(pos.top + popup.h).toBeLessThanOrEqual(viewport.h);
+  });
+
+  it('clamps the top so the popup never goes above the viewport', () => {
+    const topCell = { x: 100, y: 2, w: 64, h: 20 };
+    const tallPopup = { w: 280, h: 90 };
+    const pos = computeCommentPopupPosition({
+      cell: topCell,
+      popup: tallPopup,
+      viewport,
+      rtl: false,
+    });
+    expect(pos.top).toBeGreaterThanOrEqual(0);
+  });
+
+  it('opens toward the cell left by default for RTL (cell rect already mirrored)', () => {
+    // For RTL the cell rect is mirrored, so the sheet body lies to the cell's
+    // LEFT. The popup must open left so it grows into the body, not off-screen
+    // past the right edge. Use a cell with room on the left (x large enough).
+    const rtlCell = { x: 500, y: 60, w: 64, h: 20 };
+    const pos = computeCommentPopupPosition({
+      cell: rtlCell,
+      popup,
+      viewport,
+      rtl: true,
+    });
+    expect(pos.left).toBe(rtlCell.x - GAP - popup.w);
+    expect(pos.top).toBe(rtlCell.y);
+  });
+
+  it('flips RTL to the right of the cell when the left side overflows', () => {
+    // A cell near the left edge: left placement (100 - 8 - 280 = -188) overflows.
+    const leftCell = { x: 100, y: 60, w: 64, h: 20 };
+    const pos = computeCommentPopupPosition({
+      cell: leftCell,
+      popup,
+      viewport,
+      rtl: true,
+    });
+    expect(pos.left).toBe(leftCell.x + leftCell.w + GAP);
+    expect(pos.left + popup.w).toBeLessThanOrEqual(viewport.w);
+  });
+
+  it('clamps left into the viewport when neither side fits (very wide popup)', () => {
+    const widePopup = { w: 780, h: 90 };
+    const pos = computeCommentPopupPosition({
+      cell,
+      popup: widePopup,
+      viewport,
+      rtl: false,
+    });
+    expect(pos.left).toBeGreaterThanOrEqual(0);
+    expect(pos.left + widePopup.w).toBeLessThanOrEqual(viewport.w);
+  });
+});

--- a/packages/xlsx/src/comment-popup.ts
+++ b/packages/xlsx/src/comment-popup.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure geometry for the cell-comment hover popup. Kept free of DOM so it can be
+ * unit-tested in isolation; the viewer owns the actual element and feeds it
+ * measured rects.
+ *
+ * Excel shows a comment/note as a small box anchored at the commented cell's
+ * top-right corner, opening toward the sheet body. This calculator reproduces
+ * that placement and adds viewport-aware flipping/clamping so the popup is
+ * always fully visible.
+ *
+ * All coordinates are in canvasArea CSS-pixel space — the same space
+ * `getCellRect` and the selection overlay use. The cell rect is therefore
+ * already RTL-mirrored by the caller (via `screenX`); the `rtl` flag here only
+ * picks the *default* open direction (left for RTL so the popup grows into the
+ * mirrored sheet body rather than off the right edge).
+ */
+
+/** Gap (CSS px) between the cell edge and the popup. */
+export const COMMENT_POPUP_GAP = 8;
+
+export interface CommentPopupGeometry {
+  /** The commented cell's on-screen rect (canvasArea space). */
+  cell: { x: number; y: number; w: number; h: number };
+  /** The popup's measured size. */
+  popup: { w: number; h: number };
+  /** The visible viewport (canvasArea client size). */
+  viewport: { w: number; h: number };
+  /** True when the current sheet is laid out right-to-left. */
+  rtl: boolean;
+}
+
+/**
+ * Compute the top-left position of the popup, in canvasArea CSS pixels.
+ *
+ * Horizontal: prefer the side that opens into the sheet body (right for LTR,
+ * left for RTL). If that side overflows the viewport, flip to the opposite
+ * side. If neither side fits (a popup wider than the room on both sides), clamp
+ * the preferred side into the viewport.
+ *
+ * Vertical: anchor at the cell's top edge, then clamp so the popup stays fully
+ * within [0, viewport.h].
+ */
+export function computeCommentPopupPosition(geo: CommentPopupGeometry): {
+  left: number;
+  top: number;
+} {
+  const { cell, popup, viewport, rtl } = geo;
+  const gap = COMMENT_POPUP_GAP;
+
+  const rightOf = cell.x + cell.w + gap; // popup's left when opening to the right
+  const leftOf = cell.x - gap - popup.w; // popup's left when opening to the left
+
+  const fitsRight = rightOf + popup.w <= viewport.w;
+  const fitsLeft = leftOf >= 0;
+
+  let left: number;
+  if (!rtl) {
+    // LTR: prefer right, flip to left, else clamp.
+    if (fitsRight) left = rightOf;
+    else if (fitsLeft) left = leftOf;
+    else left = rightOf;
+  } else {
+    // RTL: prefer left, flip to right, else clamp.
+    if (fitsLeft) left = leftOf;
+    else if (fitsRight) left = rightOf;
+    else left = leftOf;
+  }
+
+  // Final clamp so a popup wider than the available room on the chosen side is
+  // still pulled fully into view.
+  left = Math.max(0, Math.min(left, viewport.w - popup.w));
+
+  let top = cell.y;
+  top = Math.max(0, Math.min(top, viewport.h - popup.h));
+
+  return { left, top };
+}

--- a/packages/xlsx/src/data-validation.ts
+++ b/packages/xlsx/src/data-validation.ts
@@ -1,17 +1,5 @@
 import type { DataValidation } from './types.js';
-
-/** Parse an A1-style cell reference ("A1", "B12", "AA3") to 1-based row/col.
- *  Strips `$` absolute markers. Returns null on malformed input. */
-function parseA1(ref: string): { row: number; col: number } | null {
-  const m = /^\$?([A-Z]+)\$?(\d+)$/.exec(ref.trim());
-  if (!m) return null;
-  const letters = m[1];
-  let col = 0;
-  for (let i = 0; i < letters.length; i++) {
-    col = col * 26 + (letters.charCodeAt(i) - 64);
-  }
-  return { row: parseInt(m[2], 10), col };
-}
+import { parseA1 } from './a1.js';
 
 /**
  * Test whether a 1-based (row, col) cell falls inside a `@sqref` (ECMA-376

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -9,6 +9,7 @@ import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
 import { computeLineVisualOrder, cellBaseRtl, segmentsHaveRtl } from './bidi-line.js';
+import { parseA1 } from './a1.js';
 
 // Default font stack. Calibri is the workbook default font in Excel; on
 // systems without Office (macOS / Linux) the browser would otherwise fall
@@ -476,22 +477,10 @@ function buildGradientFill(
   return grad;
 }
 
-/**
- * Parse an A1-style cell reference ("A1", "B12", "AA3") to 1-based row/col.
- * Returns null when the input doesn't match the expected shape (parser-side
- * data is trusted, but we still guard against malformed refs).
- */
-function parseA1Ref(ref: string): { row: number; col: number } | null {
-  const m = /^([A-Z]+)(\d+)$/.exec(ref);
-  if (!m) return null;
-  const colLetters = m[1];
-  const row = parseInt(m[2], 10);
-  let col = 0;
-  for (let i = 0; i < colLetters.length; i++) {
-    col = col * 26 + (colLetters.charCodeAt(i) - 64);
-  }
-  return { row, col };
-}
+/** Parse an A1-style cell reference to 1-based row/col. Aliased to the shared
+ *  {@link parseA1} so the renderer, data-validation and the comment popup all
+ *  agree on ref parsing (the shared form also tolerates `$`-absolute markers). */
+const parseA1Ref = parseA1;
 
 /**
  * Draw Excel's comment marker — a small filled triangle in the top-right

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -60,8 +60,8 @@ export interface Worksheet {
   /** Full-fidelity comment bodies (cell ref + author + plain text) for every
    *  `<comment>` in `xl/commentsN.xml` (ECMA-376 §18.7). Parallel to
    *  {@link commentRefs} (one entry per ref). Consume this to read the note
-   *  text; the renderer only uses {@link commentRefs} for the red indicator.
-   *  Hover popups are out of scope (TODO). */
+   *  text; the renderer uses {@link commentRefs} for the red indicator and the
+   *  viewer surfaces these bodies in an Excel-style hover popup. */
   comments?: XlsxComment[];
   /** Data-validation rules on this sheet (ECMA-376 §18.3.1.32–33). Exposed for
    *  tooling. The viewer draws a list-dropdown arrow on the active cell when the

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,8 +1,21 @@
 import { XlsxWorkbook } from './workbook.js';
-import type { ViewportRange, Worksheet } from './types.js';
+import type { ViewportRange, Worksheet, XlsxComment } from './types.js';
 import type { MathRenderer } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
+import { parseA1 } from './a1.js';
+import { computeCommentPopupPosition } from './comment-popup.js';
+
+/** Delay (ms) before a hovered comment popup appears. A short hover dwell
+ *  prevents the popup from flickering while the cursor sweeps across many
+ *  commented cells; ~150ms is the common tooltip-show threshold (responsive yet
+ *  long enough to suppress transient passes). Excel itself uses a comparable
+ *  short hover delay before showing a note. */
+const COMMENT_POPUP_DELAY_MS = 150;
+/** Max width of the comment popup body (CSS px). */
+const COMMENT_POPUP_MAX_W = 280;
+/** Max height before the body scrolls/clips (CSS px). */
+const COMMENT_POPUP_MAX_H = 200;
 
 const TAB_BAR_H = 30;
 // Gap between adjacent sheet tabs. The first tab also gets this much leading
@@ -190,6 +203,19 @@ export class XlsxViewer {
   // the cell underneath).
   private pendingTap: { x: number; y: number; shiftKey: boolean; pointerId: number } | null = null;
 
+  // ─── Comment hover popup (Excel-style note) ───────────────────────────────
+  /** DOM overlay element that shows the hovered cell's comment. Lives in
+   *  canvasArea above the scrollHost; `pointer-events:none` so it never blocks
+   *  cell interaction. */
+  private commentPopup: HTMLDivElement;
+  /** `"row:col"` → comment for the current sheet, rebuilt on every showSheet. */
+  private commentMap = new Map<string, XlsxComment>();
+  /** `"row:col"` of the cell whose popup is currently shown (or pending), so a
+   *  pointermove within the same cell doesn't restart the show timer. */
+  private commentPopupKey: string | null = null;
+  /** Pending show timer (see {@link COMMENT_POPUP_DELAY_MS}). */
+  private commentPopupTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(container: HTMLElement, opts: XlsxViewerOptions = {}) {
     this.opts = opts;
 
@@ -217,9 +243,23 @@ export class XlsxViewer {
     this.spacer.style.cssText = `position:absolute;top:0;left:0;pointer-events:none;`;
     this.scrollHost.appendChild(this.spacer);
 
+    // Comment hover popup. z-index 3 sits above the scrollHost (z-index 2) so
+    // it is visible over the grid; pointer-events:none keeps cell interaction
+    // (selection, scroll) working through it. The zoom slider lives in a
+    // sibling tab-bar flex child, so there is no stacking conflict.
+    this.commentPopup = document.createElement('div');
+    this.commentPopup.style.cssText =
+      `position:absolute;z-index:3;pointer-events:none;display:none;` +
+      `max-width:${COMMENT_POPUP_MAX_W}px;max-height:${COMMENT_POPUP_MAX_H}px;overflow:hidden;` +
+      `box-sizing:border-box;padding:6px 8px;` +
+      `background:#fffbcc;border:1px solid #b8b8a0;` +
+      `box-shadow:1px 2px 5px rgba(0,0,0,0.25);` +
+      `font:12px/1.4 sans-serif;color:#222;white-space:pre-wrap;word-break:break-word;`;
+
     this.canvasArea.appendChild(this.canvas);
     this.canvasArea.appendChild(this.selectionOverlay);
     this.canvasArea.appendChild(this.scrollHost);
+    this.canvasArea.appendChild(this.commentPopup);
 
     const headerW = Math.round(HEADER_W * (this.opts.cellScale ?? 1));
 
@@ -285,6 +325,9 @@ export class XlsxViewer {
       // scrollbar-thumb drag (overlay scrollbars) or a touch swipe, not a
       // cell click.
       this.pendingTap = null;
+      // A comment popup is anchored to a cell's on-screen rect, which moves
+      // under the cursor while scrolling — hide it (Excel does the same).
+      this.hideCommentPopup();
       // Track the start-anchored position, but only while the host is laid
       // out: a hidden host reports clientWidth 0 and fires bogus scroll
       // events when the browser clamps scrollLeft, which must not overwrite
@@ -350,9 +393,11 @@ export class XlsxViewer {
     this.anchorCell = null;
     this.activeCell = null;
     this.selectionMode = 'cells';
+    this.hideCommentPopup();
     this.updateSelectionOverlay();
     this.updateTabActive(index);
     this.currentWorksheet = await this.workbook.getWorksheet(index);
+    this.buildCommentMap(this.currentWorksheet);
     this.updateSpacerSize(this.currentWorksheet);
     // Reset the horizontal scroll origin to the natural START of the sheet.
     // For RTL sheets the start column (col A) lives at the RIGHT, which means
@@ -901,6 +946,88 @@ export class XlsxViewer {
     this.selectionOverlay.appendChild(btn);
   }
 
+  // ─── Comment hover popup ──────────────────────────────────────────────────
+
+  /** Build the `"row:col"` → comment index for the given sheet. Parses each
+   *  `XlsxComment.cellRef` with the shared {@link parseA1}; later refs win on a
+   *  collision (Excel allows at most one note per cell, so this is moot in
+   *  practice). */
+  private buildCommentMap(ws: Worksheet): void {
+    this.commentMap = new Map();
+    for (const c of ws.comments ?? []) {
+      const p = parseA1(c.cellRef);
+      if (p) this.commentMap.set(`${p.row}:${p.col}`, c);
+    }
+  }
+
+  /** Show the popup for the comment on `cell` after the hover dwell, anchored to
+   *  the cell's current on-screen rect. No-op when the cell carries no comment.
+   *  Re-hovering the same cell does not restart the timer. */
+  private scheduleCommentPopup(cell: CellAddress): void {
+    const key = `${cell.row}:${cell.col}`;
+    const comment = this.commentMap.get(key);
+    if (!comment) {
+      this.hideCommentPopup();
+      return;
+    }
+    if (this.commentPopupKey === key) return; // already shown / pending here
+    this.hideCommentPopup();
+    this.commentPopupKey = key;
+    this.commentPopupTimer = setTimeout(() => {
+      this.commentPopupTimer = null;
+      this.renderCommentPopup(cell, comment);
+    }, COMMENT_POPUP_DELAY_MS);
+  }
+
+  /** Immediately render the popup for `comment` anchored to `cell` (used by the
+   *  hover-dwell timer and by touch selection, which has no hover). */
+  private renderCommentPopup(cell: CellAddress, comment: XlsxComment): void {
+    const rect = this.getCellRect(cell.row, cell.col);
+    if (!rect) return;
+
+    // Author on its own bold line (when present), then the body text with
+    // newlines preserved. textContent escapes everything — no HTML injection
+    // from comment text.
+    this.commentPopup.textContent = '';
+    if (comment.author) {
+      const authorEl = document.createElement('div');
+      authorEl.style.cssText = 'font-weight:bold;margin-bottom:2px;';
+      authorEl.textContent = comment.author;
+      this.commentPopup.appendChild(authorEl);
+    }
+    const bodyEl = document.createElement('div');
+    bodyEl.textContent = comment.text;
+    this.commentPopup.appendChild(bodyEl);
+
+    // Anchor to the cell's *screen* rect (RTL already mirrored by screenX), then
+    // run the pure position calc against the popup's measured size. Make it
+    // visible (off-screen) first so offsetWidth/Height reflect the wrapped text.
+    const screenLeft = this.screenX(rect.x, rect.w);
+    this.commentPopup.style.left = '-9999px';
+    this.commentPopup.style.top = '-9999px';
+    this.commentPopup.style.display = 'block';
+
+    const pos = computeCommentPopupPosition({
+      cell: { x: screenLeft, y: rect.y, w: rect.w, h: rect.h },
+      popup: { w: this.commentPopup.offsetWidth, h: this.commentPopup.offsetHeight },
+      viewport: { w: this.canvasArea.clientWidth, h: this.canvasArea.clientHeight },
+      rtl: this.isRtl,
+    });
+    this.commentPopup.style.left = `${pos.left}px`;
+    this.commentPopup.style.top = `${pos.top}px`;
+  }
+
+  /** Hide the popup and cancel any pending show. Called on cell-out, scroll,
+   *  sheet switch and destroy. */
+  private hideCommentPopup(): void {
+    if (this.commentPopupTimer !== null) {
+      clearTimeout(this.commentPopupTimer);
+      this.commentPopupTimer = null;
+    }
+    this.commentPopupKey = null;
+    this.commentPopup.style.display = 'none';
+  }
+
   private applyPointerSelection(clientX: number, clientY: number, shiftKey: boolean, pointerId: number, allowDrag: boolean): void {
     const headerHit = this.getHeaderHit(clientX, clientY);
 
@@ -1014,6 +1141,15 @@ export class XlsxViewer {
         }
       }
 
+      // Comment hover popup (mouse only — touch/pen have no hover, so they get
+      // the popup on selection instead, below). Suppressed while drag-selecting
+      // so the popup doesn't fight the selection rect. A header hover hides it.
+      if (e.pointerType === 'mouse' && !this.isSelecting) {
+        const hovered = this.getCellAt(e.clientX, e.clientY);
+        if (hovered) this.scheduleCommentPopup(hovered);
+        else this.hideCommentPopup();
+      }
+
       if (!this.isSelecting) return;
 
       if (this.selectionMode === 'rows') {
@@ -1043,6 +1179,18 @@ export class XlsxViewer {
         const dy = e.clientY - this.pendingTap.y;
         if (dx * dx + dy * dy <= TAP_SLOP * TAP_SLOP) {
           this.applyPointerSelection(e.clientX, e.clientY, this.pendingTap.shiftKey, e.pointerId, false);
+          // Touch / pen have no hover, so surface the comment popup on a tap
+          // (the active cell after the selection commit). Mouse uses hover.
+          if (e.pointerType !== 'mouse' && this.activeCell) {
+            const key = `${this.activeCell.row}:${this.activeCell.col}`;
+            const comment = this.commentMap.get(key);
+            if (comment) {
+              this.hideCommentPopup();
+              this.renderCommentPopup(this.activeCell, comment);
+            } else {
+              this.hideCommentPopup();
+            }
+          }
         }
         this.pendingTap = null;
       }
@@ -1055,6 +1203,9 @@ export class XlsxViewer {
       }
       this.isSelecting = false;
     });
+
+    // Hide the comment popup when the cursor leaves the grid entirely.
+    this.scrollHost.addEventListener('pointerleave', () => this.hideCommentPopup());
 
     this.keydownHandler = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
@@ -1467,6 +1618,7 @@ export class XlsxViewer {
 
   destroy(): void {
     this.resizeObserver?.disconnect();
+    this.hideCommentPopup();
     if (this.keydownHandler) {
       document.removeEventListener('keydown', this.keydownHandler);
     }


### PR DESCRIPTION
## Summary

Completes the cell-comment/note feature for the XLSX viewer. #399 parsed comments into `Worksheet.comments` and drew the red-triangle indicator, leaving the popup as a TODO; this PR adds the Excel-style hover popup.

- **Hover popup**: hovering a commented cell shows a note box (bold author line + body, newlines preserved, wrapped to `max-width:280px`, clipped at `max-height:200px`) anchored at the cell's top-right corner.
- **DOM overlay** in `canvasArea`, z-index above the scroll host with `pointer-events:none` so it never blocks cell interaction (selection / scroll).
- **Lifecycle**: `pointermove` (mouse) shows it after a 150ms hover dwell (flicker guard); hidden on cell-out, `pointerleave`, scroll, sheet switch and `destroy`. Touch / pen have no hover, so they get the popup on cell selection via the `pointerType` branch.
- **RTL**: position is computed against the cell's screen rect (mirrored through the same `screenX` the selection overlay uses); the popup opens toward the sheet body on both LTR and RTL.

## Position calculation

Extracted to a DOM-free pure function `computeCommentPopupPosition` (`src/comment-popup.ts`) so it can be unit-tested:

- top-right of the cell by default
- flip to the opposite horizontal side when it would overflow
- clamp vertically to stay fully visible
- RTL default direction flipped (cell rect is pre-mirrored by the caller)

7 vitest cases cover: normal, right-edge flip, bottom clamp, top clamp, RTL default, RTL flip, both-sides-overflow clamp.

## Refactor

Consolidated the duplicated A1-ref parsers in `renderer.ts` and `data-validation.ts` into a shared `parseA1` (`src/a1.ts`), reused by the popup's comment-map builder.

## Verification

- `tsc --build` clean; `vitest` 271/271 pass (89 in xlsx).
- xlsx VRT: demo sample green, private samples skipped (reference images gitignored locally). The popup is a hover-only DOM overlay and does not touch the canvas render path, so VRT is unchanged.
- Playwright against `sample-5` (Storybook/vite harness): comment map built (`H6 → "Vertex42.com Templates"`); hover → popup shows; leave / scroll / sheet-switch → hides; non-comment cell → nothing. (`sample-5`'s H6 sits on a hidden width-0 spacer column, so the manual check widened column H at runtime to exercise the real hit-test path on a visible cell.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)