### PR TITLE
feat(core,pptx): support a:tile blipFill backgrounds (§20.1.8.58)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export type {
   TextOutline,
   TextRun,
   TextRunData,
+  TileInfo,
 } from './types/common';
 export type {
   ChartDataLabelOverride,

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -63,16 +63,48 @@ export interface FillRect {
 }
 
 /**
+ * ECMA-376 §20.1.8.58 (CT_TileInfoProperties) — tiled blip-fill placement.
+ * The blip repeats at its native size (scaled by sx/sy) across the fill box.
+ * Mutually exclusive with {@link ImageFill.fillRect} (the `stretch` mode).
+ */
+export interface TileInfo {
+  /** Horizontal offset of the first tile, in EMU (`tx`). Default 0. */
+  tx: number;
+  /** Vertical offset of the first tile, in EMU (`ty`). Default 0. */
+  ty: number;
+  /** Horizontal tile scale as a fraction (`sx` / 100000). Default 1.0. */
+  sx: number;
+  /** Vertical tile scale as a fraction (`sy` / 100000). Default 1.0. */
+  sy: number;
+  /** Mirror mode: `'none' | 'x' | 'y' | 'xy'` (`flip`). Default `'none'`. */
+  flip: string;
+  /**
+   * Anchor corner the tile grid registers against:
+   * `tl|t|tr|l|ctr|r|bl|b|br` (`algn`). Default `'tl'`.
+   */
+  algn: string;
+}
+
+/**
  * Image fill — ECMA-376 §20.1.8.14 (CT_BlipFillProperties). The embedded blip
- * is resolved to a base64 data URL at parse time. Only the `stretch` fill-mode
- * (§20.1.8.58) is modelled; `tile` is not yet supported.
+ * is resolved to a base64 data URL at parse time. Both fill-modes are modelled
+ * and mutually exclusive: `stretch` (§20.1.8.56) carries {@link ImageFill.fillRect};
+ * `tile` (§20.1.8.58) carries {@link ImageFill.tile}.
  */
 export interface ImageFill {
   fillType: 'image';
   /** `data:<mime>;base64,…` of the embedded blip. */
   dataUrl: string;
-  /** `<a:stretch><a:fillRect>` insets. Absent → fills the whole box. */
+  /**
+   * `<a:stretch><a:fillRect>` insets. Absent → fills the whole box (or the
+   * fill is tiled — see {@link ImageFill.tile}).
+   */
   fillRect?: FillRect;
+  /**
+   * `<a:tile>` descriptor. Present only when the blipFill is tiled; mutually
+   * exclusive with {@link ImageFill.fillRect}.
+   */
+  tile?: TileInfo;
   /** `a:blip > a:alphaModFix@amt` as a fraction (0.0–1.0). Absent = opaque. */
   alpha?: number;
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1073,6 +1073,53 @@ fn parse_fill_rect(stretch: roxmltree::Node<'_, '_>) -> Option<FillRect> {
     }
 }
 
+/// Parse `<a:tile tx ty sx sy flip algn>` (ECMA-376 §20.1.8.58 CT_TileInfoProperties).
+///
+/// - `tx` / `ty`: ST_Coordinate offset of the first tile, in EMU. Default 0.
+/// - `sx` / `sy`: ST_Percentage scale of the tile (1000ths of a percent →
+///   `/100000` gives a fraction). Absent → `1.0` (100% = native blip size).
+/// - `flip`: ST_TileFlipMode (none|x|y|xy). Default "none".
+/// - `algn`: ST_RectAlignment (tl|t|tr|l|ctr|r|bl|b|br) — the anchor corner the
+///   tile grid is registered against. The schema gives no default; PowerPoint
+///   treats an absent `algn` as "tl" (the first tile sits at the box origin
+///   plus tx/ty). We carry it verbatim and default to "tl".
+fn parse_tile(tile: roxmltree::Node<'_, '_>) -> TileInfo {
+    let scale = |name: &str| -> f64 {
+        attr(&tile, name)
+            .and_then(|v| v.parse::<f64>().ok())
+            .map(|v| v / 100_000.0)
+            .unwrap_or(1.0)
+    };
+    TileInfo {
+        tx: attr_i64(&tile, "tx").unwrap_or(0),
+        ty: attr_i64(&tile, "ty").unwrap_or(0),
+        sx: scale("sx"),
+        sy: scale("sy"),
+        flip: attr(&tile, "flip").unwrap_or_else(|| "none".to_owned()),
+        algn: attr(&tile, "algn").unwrap_or_else(|| "tl".to_owned()),
+    }
+}
+
+/// ECMA-376 §20.1.8.58 (CT_TileInfoProperties) — tiled blip-fill placement.
+/// Mutually exclusive with `stretch` inside a single `a:blipFill`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct TileInfo {
+    /// Horizontal offset of the first tile, EMU (`tx`). Default 0.
+    tx: i64,
+    /// Vertical offset of the first tile, EMU (`ty`). Default 0.
+    ty: i64,
+    /// Horizontal tile scale as a fraction (`sx` / 100000). Default 1.0.
+    sx: f64,
+    /// Vertical tile scale as a fraction (`sy` / 100000). Default 1.0.
+    sy: f64,
+    /// Mirror mode: "none" | "x" | "y" | "xy" (`flip`). Default "none".
+    flip: String,
+    /// Anchor corner the tile grid registers against: tl|t|tr|l|ctr|r|bl|b|br
+    /// (`algn`). Default "tl".
+    algn: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 struct GradStop {
@@ -1174,18 +1221,24 @@ enum Fill {
         preset: String,
     },
     /// Image fill — ECMA-376 §20.1.8.14 `a:blipFill`. The referenced blip is
-    /// resolved to a base64 data URL at parse time. Only the `stretch`
-    /// fill-mode (§20.1.8.58) is modelled; the `tile` mode (§20.1.8.32) is not
-    /// implemented (see `parse_blip_fill`).
+    /// resolved to a base64 data URL at parse time. Both fill-modes are
+    /// modelled and mutually exclusive: `stretch` (§20.1.8.56) carries a
+    /// `fill_rect`; `tile` (§20.1.8.58) carries a `tile` descriptor (see
+    /// `parse_blip_fill`).
     #[serde(rename_all = "camelCase")]
     Image {
         /// `data:<mime>;base64,…` of the embedded blip.
         data_url: String,
         /// `<a:stretch><a:fillRect>` (§20.1.8.30 CT_RelativeRect). Edge insets
         /// as fractions of the fill region; negative values overscan past the
-        /// bounding box. `None` when stretch has no fillRect (= full box).
+        /// bounding box. `None` when stretch has no fillRect (= full box) or
+        /// the fill-mode is `tile`.
         #[serde(skip_serializing_if = "Option::is_none")]
         fill_rect: Option<FillRect>,
+        /// `<a:tile>` (§20.1.8.58). `Some` only when the blipFill is tiled;
+        /// mutually exclusive with `fill_rect`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tile: Option<TileInfo>,
         /// `a:blip > a:alphaModFix@amt` as a fraction (0.0–1.0). None = opaque.
         #[serde(skip_serializing_if = "Option::is_none")]
         alpha: Option<f64>,
@@ -2053,27 +2106,36 @@ fn parse_fill(node: roxmltree::Node<'_, '_>, theme: &HashMap<String, String>) ->
 /// closure maps the `<a:blip r:embed>` rId to a base64 data URL using the
 /// caller's rels + zip (each inheritance level resolves against its own part).
 ///
-/// Only the `stretch` fill-mode (§20.1.8.58) is honoured: its `fillRect`
-/// (§20.1.8.30) is captured so the renderer can place the (possibly
-/// overscanned) image. The `tile` fill-mode (§20.1.8.32) is **not implemented**
-/// — a tile-only blipFill returns None so callers keep their existing
-/// solid/bgRef fallback rather than mis-rendering a tiled image as stretched.
+/// Both fill-modes are honoured and mutually exclusive:
+/// - `stretch` (§20.1.8.56): the `fillRect` (§20.1.8.30) is captured so the
+///   renderer can place the (possibly overscanned) image into the box.
+/// - `tile` (§20.1.8.58): the tile offset/scale/flip/align descriptor is
+///   captured so the renderer can repeat the blip at its native (scaled) size.
+///
+/// When neither child is present the blip defaults to full-box placement
+/// (stretch with no fillRect).
 fn parse_blip_fill<F: FnMut(&str) -> Option<String>>(
     blip_fill: roxmltree::Node<'_, '_>,
     resolve_blip: &mut F,
 ) -> Option<Fill> {
     let r_id = child(blip_fill, "blip").and_then(|b| attr_r(&b, "embed"))?;
     let data_url = resolve_blip(&r_id)?;
-    // tile mode is unsupported; only proceed for stretch (or no explicit mode,
-    // which defaults to stretch-like full-box placement).
-    if child(blip_fill, "tile").is_some() {
-        return None;
+    let alpha = parse_blip_alpha(blip_fill);
+    // §20.1.8.58 tile takes precedence when present (stretch/tile are an
+    // either-or choice in CT_BlipFillProperties).
+    if let Some(tile_node) = child(blip_fill, "tile") {
+        return Some(Fill::Image {
+            data_url,
+            fill_rect: None,
+            tile: Some(parse_tile(tile_node)),
+            alpha,
+        });
     }
     let fill_rect = child(blip_fill, "stretch").and_then(parse_fill_rect);
-    let alpha = parse_blip_alpha(blip_fill);
     Some(Fill::Image {
         data_url,
         fill_rect,
+        tile: None,
         alpha,
     })
 }
@@ -8369,6 +8431,7 @@ mod tests {
             Fill::Image {
                 data_url,
                 fill_rect,
+                tile,
                 alpha,
             } => {
                 assert_eq!(data_url, "data:image/jpeg;base64,QUJD");
@@ -8376,16 +8439,56 @@ mod tests {
                 assert!((fr.t - (-0.09)).abs() < 1e-9, "t={}", fr.t);
                 assert!((fr.b - (-0.09)).abs() < 1e-9, "b={}", fr.b);
                 assert!(is_zero_f64(&fr.l) && is_zero_f64(&fr.r));
+                assert!(tile.is_none(), "stretch fill must not carry tile");
                 assert!((alpha.expect("alpha") - 0.8).abs() < 1e-6);
             }
             other => panic!("expected Fill::Image, got {other:?}"),
         }
     }
 
-    /// A `bgPr > blipFill` whose fill-mode is `tile` is unsupported: it must NOT
-    /// produce a `Fill::Image` (so callers keep their solid/bgRef fallback).
+    /// ECMA-376 §20.1.8.14 + §20.1.8.58 — a `bgPr > blipFill` with `<a:tile>`
+    /// parses into `Fill::Image` carrying a `TileInfo` (and no `fillRect`).
+    /// tx/ty stay EMU, sx/sy convert ST_Percentage → fraction, flip/algn pass
+    /// through verbatim.
     #[test]
-    fn test_parse_background_blip_fill_tile_unsupported() {
+    fn test_parse_background_blip_fill_tile() {
+        let xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <p:bg><p:bgPr>
+                <a:blipFill>
+                    <a:blip r:embed="rId2"/>
+                    <a:tile tx="457200" ty="-228600" sx="50000" sy="75000" flip="xy" algn="ctr"/>
+                </a:blipFill>
+            </p:bgPr></p:bg>
+        </p:cSld>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::new();
+        let mut resolve =
+            |_: &str| -> Option<String> { Some("data:image/png;base64,QQ==".to_owned()) };
+        let fill = parse_background(doc.root_element(), &theme, &mut resolve)
+            .expect("tiled blip background should resolve to Fill::Image");
+        match fill {
+            Fill::Image {
+                fill_rect, tile, ..
+            } => {
+                assert!(fill_rect.is_none(), "tile fill must not carry fillRect");
+                let t = tile.expect("tile should be present");
+                assert_eq!(t.tx, 457_200);
+                assert_eq!(t.ty, -228_600);
+                assert!((t.sx - 0.5).abs() < 1e-9, "sx={}", t.sx);
+                assert!((t.sy - 0.75).abs() < 1e-9, "sy={}", t.sy);
+                assert_eq!(t.flip, "xy");
+                assert_eq!(t.algn, "ctr");
+            }
+            other => panic!("expected Fill::Image, got {other:?}"),
+        }
+    }
+
+    /// §20.1.8.58 defaults: a bare `<a:tile/>` yields tx/ty=0, sx/sy=1.0
+    /// (100% native size), flip="none", algn="tl".
+    #[test]
+    fn test_parse_background_blip_fill_tile_defaults() {
         let xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
                               xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
                               xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
@@ -8397,8 +8500,20 @@ mod tests {
         let theme = HashMap::new();
         let mut resolve =
             |_: &str| -> Option<String> { Some("data:image/png;base64,QQ==".to_owned()) };
-        // No solidFill fallback inside bgPr → overall None (caller falls through).
-        assert!(parse_background(doc.root_element(), &theme, &mut resolve).is_none());
+        let fill = parse_background(doc.root_element(), &theme, &mut resolve)
+            .expect("bare tile should still resolve to Fill::Image");
+        match fill {
+            Fill::Image { tile, .. } => {
+                let t = tile.expect("tile should be present");
+                assert_eq!(t.tx, 0);
+                assert_eq!(t.ty, 0);
+                assert!((t.sx - 1.0).abs() < 1e-9);
+                assert!((t.sy - 1.0).abs() < 1e-9);
+                assert_eq!(t.flip, "none");
+                assert_eq!(t.algn, "tl");
+            }
+            other => panic!("expected Fill::Image, got {other:?}"),
+        }
     }
 
     /// ECMA-376 §21.1.2.3.16 — underline_style carries non-default underline

--- a/packages/pptx/public/private/_gen_bg_tile.py
+++ b/packages/pptx/public/private/_gen_bg_tile.py
@@ -1,0 +1,126 @@
+"""Generate pptx files whose slide background is a *tiled* blipFill.
+
+ECMA-376 §20.1.8.14 (a:blipFill) + §20.1.8.58 (a:tile). python-pptx has no API
+for a background blipFill, so we:
+  1. add the tile image as a *picture* on the slide (this registers the image
+     part + a slide relationship we can reuse), then delete the picture shape,
+  2. hand-assemble <p:bg><p:bgPr><a:blipFill>…<a:tile/> referencing that rId.
+
+The tile image is an asymmetric "F"-like glyph on a coloured ground so that the
+mirror cadence of flip="x"/"y"/"xy" and the algn anchor are visually obvious.
+
+Run: python3 _gen_bg_tile.py
+Outputs (gitignored — public/private/ is local-only):
+  bg-tile-basic.pptx   — 3 slides: no-flip / flip=x / flip=xy
+  bg-tile-algn.pptx    — algn variants (tl / ctr / br) with a scaled tile
+"""
+import io
+from pptx import Presentation
+from pptx.util import Inches, Emu
+from pptx.oxml.ns import qn
+from lxml import etree
+from PIL import Image, ImageDraw
+
+# ---------------------------------------------------------------------------
+# Build a small, deliberately asymmetric tile bitmap (64x48 px).
+# ---------------------------------------------------------------------------
+def make_tile_png() -> bytes:
+    w, h = 64, 48
+    img = Image.new("RGB", (w, h), (235, 200, 60))  # gold ground
+    d = ImageDraw.Draw(img)
+    # An "F" glyph: vertical bar + two horizontal arms (top + middle).
+    blue = (25, 110, 202)
+    d.rectangle([10, 6, 20, 42], fill=blue)      # vertical stem
+    d.rectangle([10, 6, 48, 16], fill=blue)      # top arm (full width)
+    d.rectangle([10, 22, 38, 30], fill=blue)     # middle arm (shorter)
+    # corner dot marks the tile's top-left for orientation
+    d.ellipse([2, 2, 8, 8], fill=(192, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+TILE_PNG = make_tile_png()
+A = "http://schemas.openxmlformats.org/drawingml/2006/main"
+R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+
+def embed_tile_rid(slide) -> str:
+    """Register the tile image as a slide relationship; return its rId.
+
+    We add then immediately remove a picture so python-pptx wires up the image
+    part + relationship for us (the rId stays valid for the bg blipFill).
+    """
+    pic = slide.shapes.add_picture(io.BytesIO(TILE_PNG), Inches(0), Inches(0),
+                                   width=Inches(1), height=Inches(0.75))
+    rid = pic._element.blipFill.find(qn("a:blip")).get(qn("r:embed"))
+    # remove the visible picture; the relationship + part remain
+    pic._element.getparent().remove(pic._element)
+    return rid
+
+
+def set_tile_background(slide, rid, *, tx=0, ty=0, sx=None, sy=None,
+                        flip="none", algn=None):
+    """Insert <p:bg> with a tiled blipFill into the slide's cSld."""
+    cSld = slide._element.find(qn("p:cSld"))
+    # remove any existing bg
+    for old in cSld.findall(qn("p:bg")):
+        cSld.remove(old)
+    bg = etree.SubElement(cSld, qn("p:bg"))
+    # cSld children are ordered: bg must come first.
+    cSld.remove(bg)
+    cSld.insert(0, bg)
+    bgPr = etree.SubElement(bg, qn("p:bgPr"))
+    blipFill = etree.SubElement(bgPr, qn("a:blipFill"))
+    blip = etree.SubElement(blipFill, qn("a:blip"))
+    blip.set(qn("r:embed"), rid)
+    tile = etree.SubElement(blipFill, qn("a:tile"))
+    if tx:
+        tile.set("tx", str(int(tx)))
+    if ty:
+        tile.set("ty", str(int(ty)))
+    if sx is not None:
+        tile.set("sx", str(int(sx)))
+    if sy is not None:
+        tile.set("sy", str(int(sy)))
+    tile.set("flip", flip)
+    if algn:
+        tile.set("algn", algn)
+    # bgPr requires an effectLst (or effectDag) sibling per CT_BackgroundProperties
+    etree.SubElement(bgPr, qn("a:effectLst"))
+
+
+def new_prs():
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    return prs
+
+
+# ---------------------------------------------------------------------------
+# File 1 — flip cadence: none / x / xy
+# ---------------------------------------------------------------------------
+prs = new_prs()
+blank = prs.slide_layouts[6]
+for flip in ("none", "x", "xy"):
+    s = prs.slides.add_slide(blank)
+    rid = embed_tile_rid(s)
+    set_tile_background(s, rid, flip=flip)
+prs.save("bg-tile-basic.pptx")
+print("wrote bg-tile-basic.pptx (flip none / x / xy)")
+
+# ---------------------------------------------------------------------------
+# File 2 — algn anchors with a 50% scaled tile + a tx/ty offset slide
+# ---------------------------------------------------------------------------
+prs = new_prs()
+blank = prs.slide_layouts[6]
+for algn in ("tl", "ctr", "br"):
+    s = prs.slides.add_slide(blank)
+    rid = embed_tile_rid(s)
+    set_tile_background(s, rid, sx=50000, sy=50000, algn=algn)
+# extra slide: tx/ty offset (1 inch right, 0.5 inch down) at native size
+s = prs.slides.add_slide(blank)
+rid = embed_tile_rid(s)
+set_tile_background(s, rid, tx=Emu(Inches(1)), ty=Emu(Inches(0.5)), algn="tl")
+prs.save("bg-tile-algn.pptx")
+print("wrote bg-tile-algn.pptx (algn tl / ctr / br + tx/ty)")

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -35,6 +35,7 @@ export type {
   GradientStop,
   ImageFill,
   FillRect,
+  TileInfo,
   Stroke,
   // Effect types (reachable via ShapeElement.shadow / .glow / …).
   Shadow,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -6,6 +6,7 @@ import type {
   MediaElement,
   TableElement,
   Fill,
+  TileInfo,
   Stroke,
   TextBody,
   Paragraph,
@@ -852,38 +853,44 @@ async function renderBackground(
   ctx: CanvasRenderingContext2D,
   fill: Fill | null,
   canvasW: number,
-  canvasH: number
+  canvasH: number,
+  scale: number,
 ) {
-  // ECMA-376 §20.1.8.14 — image (blipFill) background. Decode the embedded blip
-  // and stretch it into the destination rect derived from the §20.1.8.30
-  // fillRect insets. Paint an opaque white base first so a partially
-  // transparent image (alphaModFix) composites over white, and so a decode
-  // failure still leaves a defined background.
+  // ECMA-376 §20.1.8.14 — image (blipFill) background. Paint an opaque white
+  // base first so a partially transparent image (alphaModFix) composites over
+  // white, and so a decode failure still leaves a defined background.
   if (fill && fill.fillType === 'image') {
     ctx.fillStyle = '#FFFFFF';
     ctx.fillRect(0, 0, canvasW, canvasH);
     try {
       const bitmap = await getCachedBitmap(fill.dataUrl);
-      // fillRect edges are fractions of the fill region; negative = overscan.
-      // ECMA-376 §20.1.8.30: l/t are left/top insets, r/b are right/bottom
-      // insets, so the destination spans [l, 1-r] × [t, 1-b] of the box.
-      const fr = fill.fillRect ?? {};
-      const l = fr.l ?? 0;
-      const t = fr.t ?? 0;
-      const r = fr.r ?? 0;
-      const b = fr.b ?? 0;
-      const dx = l * canvasW;
-      const dy = t * canvasH;
-      const dw = canvasW * (1 - l - r);
-      const dh = canvasH * (1 - t - b);
       ctx.save();
-      // Clip to the slide rectangle so overscan (negative insets) is cropped at
-      // the slide edge rather than spilling onto neighbouring content.
+      // Clip to the slide rectangle so overscan (negative insets) or tile
+      // bleed is cropped at the slide edge rather than spilling onto
+      // neighbouring content.
       ctx.beginPath();
       ctx.rect(0, 0, canvasW, canvasH);
       ctx.clip();
       if (fill.alpha != null) ctx.globalAlpha = fill.alpha;
-      ctx.drawImage(bitmap, dx, dy, dw, dh);
+      if (fill.tile) {
+        // §20.1.8.58 — tiled placement: repeat the blip at its native size.
+        paintTiledBackground(ctx, bitmap, fill.tile, canvasW, canvasH, scale);
+      } else {
+        // §20.1.8.56 stretch into the destination rect from the §20.1.8.30
+        // fillRect insets. l/t are left/top insets, r/b are right/bottom
+        // insets, so the destination spans [l, 1-r] × [t, 1-b] of the box;
+        // negative edges overscan past the box.
+        const fr = fill.fillRect ?? {};
+        const l = fr.l ?? 0;
+        const t = fr.t ?? 0;
+        const r = fr.r ?? 0;
+        const b = fr.b ?? 0;
+        const dx = l * canvasW;
+        const dy = t * canvasH;
+        const dw = canvasW * (1 - l - r);
+        const dh = canvasH * (1 - t - b);
+        ctx.drawImage(bitmap, dx, dy, dw, dh);
+      }
       ctx.restore();
     } catch {
       // Decode failed — the white base painted above remains as the fallback.
@@ -893,6 +900,127 @@ async function renderBackground(
   const bg = resolveShapeFill(fill, ctx, 0, 0, canvasW, canvasH);
   ctx.fillStyle = bg ?? '#FFFFFF';
   ctx.fillRect(0, 0, canvasW, canvasH);
+}
+
+/**
+ * EMU per pixel at 96 DPI. A blip's intrinsic pixel size is interpreted at
+ * 96 DPI to get its native EMU size, matching how PowerPoint sizes a tile.
+ * 914400 EMU / inch ÷ 96 px / inch = 9525 EMU / px.
+ */
+const EMU_PER_PX_96 = 9525;
+
+/**
+ * Compute the anchor (origin) of the first tile inside the fill box for a
+ * given §20.1.8.41 ST_RectAlignment value. The returned point is where the
+ * tile grid is registered; tx/ty then shift it further. The pattern is then
+ * phase-shifted so a tile edge passes through this anchor.
+ *
+ * - `tl` → box origin (0,0); the first tile's top-left sits at the box origin.
+ * - `ctr` → box centre; a tile is centred in the box.
+ * - `br` → box bottom-right corner; a tile's bottom-right sits there.
+ * etc. The anchor is expressed as the position (px) of the tile's top-left
+ * for the corresponding alignment, before tx/ty.
+ */
+export function tileAnchorOffset(
+  algn: string,
+  boxW: number,
+  boxH: number,
+  tileW: number,
+  tileH: number,
+): { ax: number; ay: number } {
+  // Horizontal: tl/l/bl = left, t/ctr/b = centre, tr/r/br = right.
+  let ax: number;
+  if (algn === 't' || algn === 'ctr' || algn === 'b') {
+    ax = (boxW - tileW) / 2;
+  } else if (algn === 'tr' || algn === 'r' || algn === 'br') {
+    ax = boxW - tileW;
+  } else {
+    ax = 0; // tl, l, bl (and any unknown) anchor left.
+  }
+  // Vertical: tl/t/tr = top, l/ctr/r = middle, bl/b/br = bottom.
+  let ay: number;
+  if (algn === 'l' || algn === 'ctr' || algn === 'r') {
+    ay = (boxH - tileH) / 2;
+  } else if (algn === 'bl' || algn === 'b' || algn === 'br') {
+    ay = boxH - tileH;
+  } else {
+    ay = 0; // tl, t, tr (and any unknown) anchor top.
+  }
+  return { ax, ay };
+}
+
+/**
+ * Paint a tiled blip background (ECMA-376 §20.1.8.58 CT_TileInfoProperties).
+ *
+ * The blip repeats at its native pixel size (interpreted at 96 DPI → EMU)
+ * scaled by sx/sy and the slide `scale`. `flip` mirrors alternate tiles, which
+ * we pre-compose into a 2×2 "super-tile" so a plain `repeat` pattern reproduces
+ * the mirror cadence. `algn` registers the grid against a box corner/edge and
+ * tx/ty add a further EMU offset. The whole pattern is phase-shifted via a
+ * `DOMMatrix` translate on the pattern transform.
+ *
+ * The caller has already clipped to the slide box and set globalAlpha.
+ */
+function paintTiledBackground(
+  ctx: CanvasRenderingContext2D,
+  bitmap: ImageBitmap,
+  tile: TileInfo,
+  canvasW: number,
+  canvasH: number,
+  scale: number,
+): void {
+  // Native tile size in slide px: image px → EMU @96dpi → × sx/sy → × scale.
+  const tileW = bitmap.width * EMU_PER_PX_96 * tile.sx * scale;
+  const tileH = bitmap.height * EMU_PER_PX_96 * tile.sy * scale;
+  if (!(tileW > 0) || !(tileH > 0)) return;
+
+  const flipX = tile.flip === 'x' || tile.flip === 'xy';
+  const flipY = tile.flip === 'y' || tile.flip === 'xy';
+
+  // Build the repeating cell. Without flip it is one tile; with flip it is a
+  // 2×2 block whose neighbours are mirrored, so the seam between repeats is a
+  // mirror line (PowerPoint's tile-flip behaviour).
+  const cellW = tileW * (flipX ? 2 : 1);
+  const cellH = tileH * (flipY ? 2 : 1);
+  const aux = createAuxCanvas(cellW, cellH);
+  if (!aux) return;
+  const actx = aux.getContext('2d') as CanvasRenderingContext2D | null;
+  if (!actx) return;
+
+  const drawCell = (cx: number, cy: number, mx: boolean, my: boolean) => {
+    actx.save();
+    actx.translate(cx + (mx ? tileW : 0), cy + (my ? tileH : 0));
+    actx.scale(mx ? -1 : 1, my ? -1 : 1);
+    actx.drawImage(bitmap, 0, 0, tileW, tileH);
+    actx.restore();
+  };
+  // Top-left tile is always un-mirrored; mirror the X/Y neighbours.
+  drawCell(0, 0, false, false);
+  if (flipX) drawCell(tileW, 0, true, false);
+  if (flipY) drawCell(0, tileH, false, true);
+  if (flipX && flipY) drawCell(tileW, tileH, true, true);
+
+  const pattern = ctx.createPattern(aux as unknown as CanvasImageSource, 'repeat');
+  if (!pattern) return;
+
+  // Phase: register the grid against the alignment anchor, then add tx/ty.
+  const { ax, ay } = tileAnchorOffset(tile.algn, canvasW, canvasH, tileW, tileH);
+  const px = ax + emuToPx(tile.tx, scale);
+  const py = ay + emuToPx(tile.ty, scale);
+  // `setTransform` exists where DOMMatrix is available (browser + skia-canvas).
+  // The translate aligns a cell origin with (px, py); `repeat` covers the box.
+  if (typeof pattern.setTransform === 'function' && typeof DOMMatrix !== 'undefined') {
+    pattern.setTransform(new DOMMatrix().translateSelf(px, py));
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, canvasW, canvasH);
+  } else {
+    // Fallback: bake the phase into the fill origin by translating the context.
+    ctx.save();
+    ctx.translate(px, py);
+    ctx.fillStyle = pattern;
+    ctx.fillRect(-px, -py, canvasW, canvasH);
+    ctx.restore();
+  }
 }
 
 function applyShadow(ctx: CanvasRenderingContext2D, shadow: Shadow | null, scale: number) {
@@ -2873,7 +3001,7 @@ export async function renderSlide(
     themeHlinkColor: opts.hlinkColor ?? null,
   };
 
-  await renderBackground(ctx, slide.background, canvasW, canvasH);
+  await renderBackground(ctx, slide.background, canvasW, canvasH, scale);
   if (superseded()) return canvas;
 
   // Pre-rasterize any equations so the synchronous text layout can place them.

--- a/packages/pptx/src/tile-fill.test.ts
+++ b/packages/pptx/src/tile-fill.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { tileAnchorOffset } from './renderer';
+
+/**
+ * ECMA-376 §20.1.8.58 (CT_TileInfoProperties) `algn` + §20.1.8.41
+ * (ST_RectAlignment). The tile grid registers against a corner / edge / centre
+ * of the fill box; `tileAnchorOffset` returns the top-left position (px) of the
+ * tile that sits at that anchor, before the tx/ty offset is added.
+ *
+ * Box 100×100, tile 40×30 — distinct W/H so axis mix-ups surface.
+ */
+describe('tileAnchorOffset — §20.1.8.41 ST_RectAlignment', () => {
+  const W = 100;
+  const H = 100;
+  const TW = 40;
+  const TH = 30;
+
+  // Horizontal: left = 0, centre = (W-TW)/2 = 30, right = W-TW = 60.
+  // Vertical:   top  = 0, middle = (H-TH)/2 = 35, bottom = H-TH = 70.
+  const cases: Array<[string, number, number]> = [
+    ['tl', 0, 0],
+    ['t', 30, 0],
+    ['tr', 60, 0],
+    ['l', 0, 35],
+    ['ctr', 30, 35],
+    ['r', 60, 35],
+    ['bl', 0, 70],
+    ['b', 30, 70],
+    ['br', 60, 70],
+  ];
+
+  for (const [algn, ax, ay] of cases) {
+    it(`algn="${algn}" anchors at (${ax}, ${ay})`, () => {
+      const got = tileAnchorOffset(algn, W, H, TW, TH);
+      expect(got.ax).toBeCloseTo(ax, 6);
+      expect(got.ay).toBeCloseTo(ay, 6);
+    });
+  }
+
+  it('defaults an unknown algn to top-left (tl)', () => {
+    // §20.1.8.58 gives no schema default; PowerPoint treats absent/unknown as
+    // tl, which the parser already normalises to "tl".
+    expect(tileAnchorOffset('???', W, H, TW, TH)).toEqual({ ax: 0, ay: 0 });
+  });
+});

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -1,7 +1,7 @@
 // ===== Shared types re-exported from @silurus/ooxml-core =====
 export type {
   PathCmd,
-  Fill, SolidFill, NoFill, GradientFill, GradientStop, ImageFill, FillRect,
+  Fill, SolidFill, NoFill, GradientFill, GradientStop, ImageFill, FillRect, TileInfo,
   Shadow,
   Glow,
   SoftEdge,


### PR DESCRIPTION
## Summary

PR #402 implemented blipFill backgrounds for the **stretch** fill-mode only; a tile-only blipFill fell back to `None`. This implements the **tile** fill-mode (ECMA-376 §20.1.8.58 `a:tile` / CT_TileInfoProperties) for slide backgrounds.

## Parser

- New `TileInfo { tx, ty (EMU), sx, sy (fraction), flip, algn }` + `parse_tile` with documented defaults (`0/0/1.0/1.0/none/tl`).
- `Fill::Image` gains `tile: Option<TileInfo>`, mutually exclusive with `fill_rect`. `parse_blip_fill` emits `tile` when `<a:tile>` is present, else the stretch path. The old "tile unsupported → None" guard is removed.

## Types

`TileInfo` + `ImageFill.tile?` added to `@silurus/ooxml-core` and re-exported through the pptx barrel (export-completeness reachable via `ImageFill`).

## Renderer

`renderBackground` splits stretch vs tile. `paintTiledBackground`:
- tile px = `bitmap.{w,h} × 9525 (EMU/px @96dpi) × s{x,y} × scale`
- `flip` → pre-composed **2×2 mirror super-tile** (top-left un-mirrored; X/Y/XY neighbours mirrored via `translate` + `scale(-1)`), so a plain `repeat` pattern reproduces the mirror cadence
- `algn` registers the grid against the box corner/edge/centre (§20.1.8.41); `tx`/`ty` add an EMU offset
- phase applied via `pattern.setTransform(DOMMatrix.translate(px,py))`, with a `ctx.translate` fallback where DOMMatrix is absent

## Shape / picture blipFill — follow-up (not in this PR)

Tile `Fill::Image` is produced only for backgrounds. Shape image fills take other paths that don't model tile today: `<p:pic>` → `PictureElement` (stretch-into-box + srcRect), and `<p:sp>` spPr `<a:blipFill>` is ignored by `parse_fill`. Extending those is a materially larger change and is left as a TODO.

## Tests / verification

- Parser: tile + defaults cases; stretch test asserts `tile.is_none()`. `cargo test` 49 passed, `clippy -D warnings` + `fmt` clean.
- `tileAnchorOffset` unit test covers all nine ST_RectAlignment anchors. `pnpm test` 274 passed, `pnpm typecheck` clean.
- pptx **demo VRT green** (sample-1, 9 slides; match% unchanged).
- Hand-assembled tiled-background fixtures (gitignored) rendered with skia-canvas and visually verified: no-flip uniform grid, flip=x back-to-back columns, flip=xy 2×2 kaleidoscope, ctr-anchored half-size grid centred, tx/ty phase shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)