### PR TITLE
fix(core): kill the hi-DPI bevel-lip terminator facet (anti-facet stage 2)

### DIFF
--- a/packages/core/src/shape/bevel-shading.test.ts
+++ b/packages/core/src/shape/bevel-shading.test.ts
@@ -277,6 +277,73 @@ describe('computeBevelNormals — smooth lip on a curved silhouette (anti-facet)
     }
     expect(Math.abs(Math.abs(net) - 2 * Math.PI)).toBeLessThan(0.5);
   });
+
+  // REGRESSION (high-DPR facet, this PR): the size-dependent bevel bug has now
+  // slipped through THREE times, each time at a larger raster scale:
+  //   1. PR #410 mesh cracks — grew with shape size.
+  //   2. PR #413 lip facets — grew with band width (devScale ≤ 2 fixed).
+  //   3. THIS PR — the lit/shadow-terminator facet on sample-11 slide 6 at
+  //      deviceScaleFactor 4, where the hardEdge band is ~128 px deep (4× the
+  //      ~32 px of devScale 1). #413's height-field blur smooths the gradient
+  //      MAGNITUDE but not its DIRECTION; on a linear (hardEdge) profile the
+  //      gradient azimuth still snaps to EDT Voronoi cells, and the screen-blend
+  //      highlight amplifies that into a visible chord. The fix low-passes the
+  //      in-plane normal DIRECTION over a band-proportional radius.
+  // This case mirrors the real geometry at devScale 4 (large ellipse, band 128).
+  // It is RED before the direction-smoothing fix (azimuth holds across a Voronoi
+  // cell then jumps) and GREEN after. The deep-band sampling (inset = band·0.7)
+  // is where the terminator sits and where the chord was visible.
+  it('lip azimuth stays smooth at the real high-DPR body scale (1590×2014, band 128)', () => {
+    // Match sample-11 slide 6's BODY offscreen at deviceScaleFactor 4 exactly:
+    // the diagnostic build logged w=1590 h=2014 bandPx=128 (hardEdge). At that
+    // scale the per-pixel EDT-gradient azimuth holds across each Voronoi cell then
+    // jumps — and the lit/shadow terminator (amplified by the screen-blend
+    // highlight) renders those jumps as the visible chord. Stage 1's height blur
+    // does NOT remove it (the hardEdge profile is ~linear, so its gradient
+    // *direction* still snaps); stage 2's tangential normal-direction blur does.
+    const W = 1590;
+    const H = 2014;
+    const band = 128;
+    const alpha = ellipseAlpha(W, H);
+    const { normals, bandMask } = computeBevelNormals(alpha, W, H, band, 'hardEdge', band / 2);
+
+    const cx = W / 2;
+    const cy = H / 2;
+    const rx = W / 2 - 1;
+    const ry = H / 2 - 1;
+    // Sample at the band midline (inset = band/2), where the lit/shadow terminator
+    // sits and the chord was visible. 0.1° steps so a chord spanning several
+    // degrees registers as a run of equal azimuths broken by a sudden jump.
+    const inset = band * 0.5;
+    const azimuths: number[] = [];
+    for (let deg = 0; deg < 360; deg += 0.1) {
+      const ang = (deg * Math.PI) / 180;
+      const x = Math.round(cx + Math.cos(ang) * (rx - inset));
+      const y = Math.round(cy + Math.sin(ang) * (ry - inset));
+      if (x < 0 || y < 0 || x >= W || y >= H) continue;
+      const i = y * W + x;
+      if (!bandMask[i]) continue;
+      const nx = normals[i * 3];
+      const ny = normals[i * 3 + 1];
+      if (Math.hypot(nx, ny) < 1e-3) continue;
+      azimuths.push(Math.atan2(ny, nx));
+    }
+    expect(azimuths.length).toBeGreaterThan(3000);
+
+    // Largest single-step azimuth jump. Measured: without stage-2 smoothing the
+    // un-regularised field peaks at ~0.016 rad/step (the Voronoi-cell jumps);
+    // with it the azimuth advances continuously at ~0.004 rad/step. A ceiling of
+    // 0.010 rad sits cleanly between the two, so this is RED before the fix and
+    // GREEN after, at the exact scale that regressed.
+    let maxJump = 0;
+    for (let i = 1; i < azimuths.length; i++) {
+      let d = azimuths[i] - azimuths[i - 1];
+      while (d > Math.PI) d -= 2 * Math.PI;
+      while (d < -Math.PI) d += 2 * Math.PI;
+      maxJump = Math.max(maxJump, Math.abs(d));
+    }
+    expect(maxJump).toBeLessThan(0.01);
+  });
 });
 
 describe('applyExtrusion (side-wall sweep, §20.1.5.12)', () => {

--- a/packages/core/src/shape/bevel-shading.ts
+++ b/packages/core/src/shape/bevel-shading.ts
@@ -321,7 +321,111 @@ export function computeBevelNormals(
       normals[i * 3 + 2] = nz;
     }
   }
+  // ── Anti-facet stage 2: regularise the in-plane normal DIRECTION ───────────
+  // Stage 1 (the height-field box blur above) smooths the gradient MAGNITUDE and
+  // removes the facet for narrow bands (≤ ~32 px / devScale ≤ 2). But for a wide
+  // band on a strongly-curved silhouette — sample-11 slide 6 at high DPR, where
+  // the hardEdge band is ~128 px deep — the facet returns on the lit/shadow
+  // terminator. Root cause: the height field of a `hardEdge` (linear) profile is
+  // ~linear in `dist`, so its gradient *direction* (the lip azimuth) still flips
+  // sharply across the EDT's Voronoi-cell boundaries; a blur of the scalar height
+  // barely rotates that gradient. The screen-blend highlight (lit lip → white,
+  // SCREEN_GAIN) is a high-contrast operator that amplifies tiny azimuth jitter
+  // at the terminator into a visible bright chord. The shadow (plain multiply)
+  // and the un-modulated band do not show it — only the lit highlight does
+  // (confirmed by ablation: bevel off → smooth; lit-only → faceted; flat → smooth).
+  //
+  // The geometrically correct regulariser is therefore a *direct* low-pass of the
+  // in-plane normal VECTOR (nx, ny) — the azimuth itself — over a tangential
+  // neighbourhood proportional to the band. The Voronoi cell's tangential extent
+  // grows with the band depth, so the only intrinsic length scale is the band
+  // width; a radius of ~0.25·bandPx spans several cells at every devScale,
+  // collapsing the chorded azimuth onto the silhouette's macroscopic direction
+  // while leaving the lip's rise (height) and the band mask exact. (0.12·bandPx —
+  // the stage-1 fraction — still leaves a faint chord at 128 px; 0.25 clears it
+  // with margin.) Separable, masked to band pixels, O(N·r); paid once per bevel
+  // on the device offscreen, like stage 1.
+  //
+  // GATE — only for bands wide enough to actually facet. The Voronoi facet is
+  // invisible until the band is many px deep: at devScale ≤ ~1 the band is a
+  // handful of px (sample-11 slide 3's circle bevel is ~11 px) and stage 1 alone
+  // already reads as smooth. Running stage 2 there would low-pass the few-px lip
+  // and perturb the PDF-CALIBRATED slide-3 shading for no visible gain. We
+  // therefore engage stage 2 only when `bandPx ≥ 24` — comfortably above slide-3
+  // (≈11 px, left exactly as #410/#413 calibrated it) and below the facet's onset
+  // band (slide 6 is 32 px at devScale 1, 64/96/128 px at devScale 2/3/4, all
+  // smoothed). This is the only data-dependent constant; it is a *visibility*
+  // gate, not a per-sample fudge, and is documented as such per CLAUDE.md.
+  const FACET_MIN_BAND_PX = 24;
+  if (bandPx >= FACET_MIN_BAND_PX) {
+    const normalBlurR = Math.max(1, Math.round(bandPx * 0.25));
+    smoothNormalsTangential(normals, bandMask, w, h, normalBlurR);
+  }
   return { normals, bandMask };
+}
+
+/**
+ * Separable box blur of the in-plane normal components (nx, ny) over band pixels
+ * only, then re-normalise (recovering nz from the unit-length constraint). This
+ * regularises the lip AZIMUTH along the silhouette — see the "Anti-facet stage 2"
+ * note in computeBevelNormals for why direction (not just height magnitude) must
+ * be smoothed to kill the high-DPR terminator facet. Out-of-band taps are skipped
+ * so the smoothing is purely tangential and never averages the flat interior /
+ * exterior into the lip. O(N·r), r small (≈ 0.25·bandPx).
+ */
+function smoothNormalsTangential(
+  normals: Float32Array,
+  bandMask: Uint8Array,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const nx = new Float64Array(w * h);
+  const ny = new Float64Array(w * h);
+  for (let i = 0; i < w * h; i++) {
+    nx[i] = normals[i * 3];
+    ny[i] = normals[i * 3 + 1];
+  }
+  const tmpX = new Float64Array(w * h);
+  const tmpY = new Float64Array(w * h);
+  // Horizontal.
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = y * w + x;
+      if (!bandMask[i]) { tmpX[i] = nx[i]; tmpY[i] = ny[i]; continue; }
+      let sx = 0, sy = 0, n = 0;
+      for (let k = -r; k <= r; k++) {
+        const xx = x + k;
+        if (xx < 0 || xx >= w) continue;
+        const j = y * w + xx;
+        if (!bandMask[j]) continue;
+        sx += nx[j]; sy += ny[j]; n++;
+      }
+      tmpX[i] = n ? sx / n : nx[i];
+      tmpY[i] = n ? sy / n : ny[i];
+    }
+  }
+  // Vertical + re-normalise.
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = y * w + x;
+      if (!bandMask[i]) continue;
+      let sx = 0, sy = 0, n = 0;
+      for (let k = -r; k <= r; k++) {
+        const yy = y + k;
+        if (yy < 0 || yy >= h) continue;
+        const j = yy * w + x;
+        if (!bandMask[j]) continue;
+        sx += tmpX[j]; sy += tmpY[j]; n++;
+      }
+      const ax = n ? sx / n : nx[i];
+      const ay = n ? sy / n : ny[i];
+      const m = Math.hypot(ax, ay, 1) || 1;
+      normals[i * 3] = ax / m;
+      normals[i * 3 + 1] = ay / m;
+      normals[i * 3 + 2] = 1 / m;
+    }
+  }
 }
 
 /**

--- a/packages/core/src/shape/scene3d-draw.ts
+++ b/packages/core/src/shape/scene3d-draw.ts
@@ -452,8 +452,17 @@ function drawProjectedSupersampled(
   const bboxH = maxY - minY;
   if (bboxW <= 0 || bboxH <= 0) return false;
 
-  const aux = createAuxCanvas(bboxW * SUPERSAMPLE, bboxH * SUPERSAMPLE);
+  const reqW = Math.max(1, Math.ceil(bboxW * SUPERSAMPLE));
+  const reqH = Math.max(1, Math.ceil(bboxH * SUPERSAMPLE));
+  const aux = createAuxCanvas(reqW, reqH);
   if (!aux) return false;
+  // Browsers silently clamp an OffscreenCanvas / <canvas> that exceeds the
+  // max dimension or total-area limit (Chrome ≈ 16384 px / side, ≈ 268 MP),
+  // returning a SMALLER buffer than requested. If we proceeded the mesh would
+  // rasterise into that shrunken buffer and the silhouette would quantise into
+  // chords on upscale. Detect the clamp and fall back to the non-supersampled
+  // direct path (which warps at the live device resolution) instead.
+  if (aux.width !== reqW || aux.height !== reqH) return false;
   const actx = (aux.getContext('2d') as AnyCtx | null) ?? null;
   if (!actx) return false;
 


### PR DESCRIPTION
## Problem

A wide `hardEdge` sp3d bevel on a curved silhouette (sample-11 slide 6: portrait ellipse-clipped photo + perspectiveFront + extrusionH) rendered as a **faceted polygon on the OUTER rim** at high device-scale — Playwright `deviceScaleFactor: 4`, and the user's real Chrome at browser-zoom × DPR. PR #413 had already smoothed the lip for `devScale ≤ 2`, but the facet returned at DPR 3–4.

## Ablation (slide 6 @ DPR4)

| stage off | rim |
|-----------|-----|
| all on | **faceted** (baseline) |
| bevel off | smooth ← bevel is the cause |
| extrusion off | faceted |
| **warp off** | faceted ← scene3d mesh innocent |
| `lit`-only highlight | faceted |
| `shadow`-only / `flat` | smooth |

So the facet lives specifically in the **lit highlight** of the bevel shading. The scene3d warp/mesh and a `createAuxCanvas` size-clamp were ruled out (no clamp fired).

## Root cause

The lip normal's in-plane **direction** (azimuth = −∇`dist` direction) is Voronoi-faceted: each band pixel's EDT distance is dominated by one nearest boundary sample, so ∇`dist` snaps to that cell's direction. For a `hardEdge` (linear) profile the height field is ~linear in `dist`, so PR #413's box blur of the *scalar height* barely rotates the gradient **direction** — the azimuth still flips sharply at cell boundaries. The lit/shadow terminator sits on that azimuth, and the screen-blend highlight (lit lip → white, `SCREEN_GAIN=2`) is a high-contrast operator that amplifies the jitter into a visible bright chord. Band depth — hence the facet — scales with devScale (32→128 px at DPR1→4), which is why #413's band-fraction height blur held at DPR≤2 but not DPR4.

## Fix

**Stage 2:** after building the normals, low-pass the in-plane normal **vector** `(nx,ny)` tangentially over band pixels at radius `round(0.25·bandPx)`, then re-normalise. This regularises the azimuth directly (the band's only intrinsic length scale), collapsing the chorded direction onto the silhouette's macroscopic tangent while leaving the lip rise (height) and band mask exact.

**Gated to `bandPx ≥ 24`** so it engages for the faceting regime (slide 6: 32 px @DPR1 … 128 px @DPR4) but never touches the PDF-calibrated narrow bevels (slide 3 circle ≈ 11 px).

Also hardens `scene3d-draw`: `drawProjectedSupersampled` now falls back to the direct warp path when the browser silently clamps the supersample buffer below the requested size, instead of rasterising into a shrunken buffer (defensive — not this regression's cause, but a latent size-dependent failure mode).

## Smoothness indicator — lip-azimuth max single-step jump (rad), DPR4 body scale (1590×2014, band 128)

| | before (no stage 2) | after |
|---|---|---|
| max azimuth jump | ≈ 0.0164 | ≈ 0.0042 |

## Verification

- New regression unit test (`bevel-shading.test.ts`) at the real DPR4 body scale asserts max azimuth jump `< 0.01` rad — **RED** without stage 2, **GREEN** with it. Deterministic, no browser / private fixture. The comment records the three size-dependent escapes this bug class has made (mesh cracks #410 → lip facet #413 → hi-DPR terminator facet, this PR).
- slide 3 (calibrated circle bevel) and slides 1/4/5 **bit-identical** to `main` (gate excludes them); slide 6 smooth at DPR 1–4 (visually verified).
- `pnpm test` 329 ✓ · `tsc --build` clean · `ast-grep scan` clean · VRT 69/69 slides green (demo + private 1–6).

ECMA-376 §20.1.5.12 (sp3d bevelT/B), §20.1.10.9 (ST_BevelPresetType).

🤖 Generated with [Claude Code](https://claude.com/claude-code)