### PR TITLE
fix(core): scale-invariant bevel lip azimuth from a blurred coverage gradient

### DIFF
--- a/packages/core/src/shape/bevel-shading.test.ts
+++ b/packages/core/src/shape/bevel-shading.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   bevelHeightProfile,
   edt1d,
+  gaussianBlur,
   computeBevelNormals,
   shadePixel,
+  shadeParamsFor,
   lightDirFromRig,
   applyBevelShading,
   applyExtrusion,
@@ -151,7 +153,7 @@ describe('shadePixel (Lambert + weak specular)', () => {
   });
 });
 
-describe('computeBevelNormals (finite-difference of height field)', () => {
+describe('computeBevelNormals (distance-driven tilt, coverage-gradient azimuth)', () => {
   it('produces (0,0,1) on the flat interior and tilted normals on the band', () => {
     // 7x7 filled square, bevel width 2. Interior pixels (far from edge) flat;
     // band pixels tilt outward.
@@ -205,117 +207,98 @@ function ellipseAlpha(W: number, H: number, ss = 4): Uint8ClampedArray {
   return a;
 }
 
-describe('computeBevelNormals — smooth lip on a curved silhouette (anti-facet)', () => {
-  // REGRESSION (PR #410): a wide hardEdge bevel on an ellipse produced a faceted
-  // (polygonal) lip because the per-pixel finite-difference gradient of the EDT
-  // height field is piecewise-constant — each band pixel's distance is dominated
-  // by ONE nearest boundary sample, so ∇d snaps to the Voronoi-cell direction of
-  // the silhouette's sampled rim. The lip normal must instead track the
-  // *macroscopic* silhouette direction so a circle reads as a circle, not an
-  // N-gon. We assert that the in-plane normal azimuth varies MONOTONICALLY and
-  // SMOOTHLY around the ring, with no large angular jumps between neighbouring
-  // boundary samples (a facet shows up as a long run of identical azimuths broken
-  // by a sudden kink).
-  it('in-plane normal azimuth rotates smoothly around a wide-band ellipse', () => {
-    const W = 240;
-    const H = 320;
-    const band = 40; // wide band — the regime where faceting was visible
-    const alpha = ellipseAlpha(W, H);
-    const { normals, bandMask } = computeBevelNormals(alpha, W, H, band, 'hardEdge', band / 2);
-
-    // Walk a ring near the OUTER rim (just inside the silhouette) sampling the
-    // in-plane normal azimuth at many angles; it should rotate ~once around 2π.
-    const cx = W / 2;
-    const cy = H / 2;
-    const rx = W / 2 - 1;
-    const ry = H / 2 - 1;
-    // Sample along the band MIDLINE (~band/2 inside the rim) where the lip faces
-    // the camera at its steepest and where the facets were most visible. The very
-    // outermost 1-2 px are the anti-aliased rim fringe (sub-pixel coverage noise),
-    // which is not a facet, so we measure inside it.
-    const inset = band / 2;
-    const azimuths: number[] = [];
-    for (let deg = 0; deg < 360; deg += 1) {
-      const ang = (deg * Math.PI) / 180;
-      const ex = Math.cos(ang) * (rx - inset);
-      const ey = Math.sin(ang) * (ry - inset);
-      const x = Math.round(cx + ex);
-      const y = Math.round(cy + ey);
-      if (x < 0 || y < 0 || x >= W || y >= H) continue;
-      const i = y * W + x;
-      if (!bandMask[i]) continue;
-      const nx = normals[i * 3];
-      const ny = normals[i * 3 + 1];
-      if (Math.hypot(nx, ny) < 1e-3) continue;
-      azimuths.push(Math.atan2(ny, nx));
+/**
+ * Anti-aliased annulus (ring) coverage: outer ellipse minus a concentric inner
+ * ellipse. A wide bevel band reaching toward the ring's medial axis is the
+ * worst case for the OLD EDT-gradient azimuth (the nearest-feature flips across
+ * the medial ridge). Used by the scale-sweep below to prove the coverage-gradient
+ * azimuth tracks a SINGLE rim smoothly even on a thin ring at every scale.
+ */
+function ringAlpha(W: number, H: number, thickFrac: number, ss = 4): Uint8ClampedArray {
+  const a = new Uint8ClampedArray(W * H);
+  const cx = W / 2;
+  const cy = H / 2;
+  const rx = W / 2 - 1;
+  const ry = H / 2 - 1;
+  const irx = rx * (1 - thickFrac);
+  const iry = ry * (1 - thickFrac);
+  for (let y = 0; y < H; y++)
+    for (let x = 0; x < W; x++) {
+      let cnt = 0;
+      for (let sy = 0; sy < ss; sy++)
+        for (let sx = 0; sx < ss; sx++) {
+          const px = x + (sx + 0.5) / ss - 0.5;
+          const py = y + (sy + 0.5) / ss - 0.5;
+          const outer = ((px - cx) / rx) ** 2 + ((py - cy) / ry) ** 2 <= 1;
+          const inner = ((px - cx) / irx) ** 2 + ((py - cy) / iry) ** 2 <= 1;
+          if (outer && !inner) cnt++;
+        }
+      a[y * W + x] = Math.round((255 * cnt) / (ss * ss));
     }
-    expect(azimuths.length).toBeGreaterThan(300);
+  return a;
+}
 
-    // Unwrap and measure the largest jump between consecutive samples. For a
-    // smooth lip the azimuth advances by ~(2π / N) ≈ 0.017 rad per degree-step;
-    // a facet would hold one azimuth for many steps then jump by a big angle.
-    // Allow up to ~12° (0.21 rad) between adjacent 1° samples — generous enough
-    // for the rim discretisation yet far below the >30° jumps the facets caused.
-    let maxJump = 0;
-    for (let i = 1; i < azimuths.length; i++) {
-      let d = azimuths[i] - azimuths[i - 1];
-      while (d > Math.PI) d -= 2 * Math.PI;
-      while (d < -Math.PI) d += 2 * Math.PI;
-      maxJump = Math.max(maxJump, Math.abs(d));
+describe('gaussianBlur (3-box cascade, zero-padded)', () => {
+  it('smooths a step and falls off across a clipped (canvas-edge) boundary', () => {
+    // A solid block touching the left edge: coverage 1 for x<W/2, 0 otherwise.
+    const W = 32;
+    const H = 4;
+    const src = new Float64Array(W * H);
+    for (let y = 0; y < H; y++) for (let x = 0; x < W / 2; x++) src[y * W + x] = 1;
+    const out = gaussianBlur(src, W, H, 4);
+    // Monotonic falloff across the interior step (x from W/2-4 to W/2+4).
+    const row = 1 * W;
+    for (let x = W / 2 - 3; x < W / 2 + 3; x++) {
+      expect(out[row + x]).toBeGreaterThan(out[row + x + 1]);
     }
-    expect(maxJump).toBeLessThan(0.21);
-
-    // And the azimuth must make ~one full turn (net rotation ≈ 2π), i.e. the lip
-    // faces radially outward all the way round — not collapse onto a few facet
-    // directions.
-    let net = 0;
-    for (let i = 1; i < azimuths.length; i++) {
-      let d = azimuths[i] - azimuths[i - 1];
-      while (d > Math.PI) d -= 2 * Math.PI;
-      while (d < -Math.PI) d += 2 * Math.PI;
-      net += d;
-    }
-    expect(Math.abs(Math.abs(net) - 2 * Math.PI)).toBeLessThan(0.5);
+    // Zero padding (NOT clamp-to-edge): the solid block flush with x=0 falls off
+    // toward the left border, so the value AT the border is below the interior
+    // plateau — this is what gives a clipped silhouette an outward ∇C lip.
+    expect(out[row + 0]).toBeLessThan(out[row + 4]);
   });
+});
 
-  // REGRESSION (high-DPR facet, this PR): the size-dependent bevel bug has now
-  // slipped through THREE times, each time at a larger raster scale:
-  //   1. PR #410 mesh cracks — grew with shape size.
-  //   2. PR #413 lip facets — grew with band width (devScale ≤ 2 fixed).
-  //   3. THIS PR — the lit/shadow-terminator facet on sample-11 slide 6 at
-  //      deviceScaleFactor 4, where the hardEdge band is ~128 px deep (4× the
-  //      ~32 px of devScale 1). #413's height-field blur smooths the gradient
-  //      MAGNITUDE but not its DIRECTION; on a linear (hardEdge) profile the
-  //      gradient azimuth still snaps to EDT Voronoi cells, and the screen-blend
-  //      highlight amplifies that into a visible chord. The fix low-passes the
-  //      in-plane normal DIRECTION over a band-proportional radius.
-  // This case mirrors the real geometry at devScale 4 (large ellipse, band 128).
-  // It is RED before the direction-smoothing fix (azimuth holds across a Voronoi
-  // cell then jumps) and GREEN after. The deep-band sampling (inset = band·0.7)
-  // is where the terminator sits and where the chord was visible.
-  it('lip azimuth stays smooth at the real high-DPR body scale (1590×2014, band 128)', () => {
-    // Match sample-11 slide 6's BODY offscreen at deviceScaleFactor 4 exactly:
-    // the diagnostic build logged w=1590 h=2014 bandPx=128 (hardEdge). At that
-    // scale the per-pixel EDT-gradient azimuth holds across each Voronoi cell then
-    // jumps — and the lit/shadow terminator (amplified by the screen-blend
-    // highlight) renders those jumps as the visible chord. Stage 1's height blur
-    // does NOT remove it (the hardEdge profile is ~linear, so its gradient
-    // *direction* still snaps); stage 2's tangential normal-direction blur does.
-    const W = 1590;
-    const H = 2014;
-    const band = 128;
-    const alpha = ellipseAlpha(W, H);
+describe('computeBevelNormals — scale-invariant azimuth (issue #410→#413→#415→here)', () => {
+  // DECISIVE SCALE SWEEP. The bevel facet bug has now slipped through THREE times,
+  // each time at a LARGER raster scale, because every prior fix was a post-filter
+  // on the EDT gradient whose radius was a fraction of the (growing) band:
+  //   1. #410 mesh cracks — grew with shape size.
+  //   2. #413 height-field blur — fixed devScale ≤ 2, regressed at 4.
+  //   3. #415 tangential normal blur (radius 0.25·band, gated ≥24px) — fixed
+  //      devScale 4, REGRESSED at devScale 8 (the user's real DPR-8 render).
+  // Each prior test pinned a SINGLE scale (e.g. #415 asserted band=128 / devScale 4
+  // only), so the next larger scale walked straight through. This suite instead
+  // PARAMETRISES devScale ∈ {1,2,4,8} and asserts ONE scale-independent threshold
+  // for every scale, so a regression at any DPR fails here.
+  //
+  // The redesign sources the lip AZIMUTH from ∇(Gaussian-blurred coverage), which
+  // is analytically C^∞ at every scale (no EDT Voronoi structure enters the
+  // direction), so smoothness is invariant — and in fact IMPROVES with scale.
+  // Measured ceilings (production code): ellipse & ring max 1-step azimuth jump
+  // ≤ 0.0094 rad at devScale 1, shrinking to ≤ 0.0030 at devScale 8; highlight
+  // luminance 2nd-difference ≤ 0.0011 → ≤ 0.0002. For comparison the RAW EDT
+  // gradient (pre-patch) jumps 0.12–0.24 rad — a 7°–13° chord — at all scales.
+  // A single ceiling of 0.02 rad / 0.003 lum sits well above the redesign at
+  // every scale yet an order of magnitude below the raw facet.
+  const DEV_SCALES = [1, 2, 4, 8];
+  // sample-11 slide 6 body offscreen at devScale 1 ≈ 397×503 px, hardEdge band 32.
+  const BASE = { W: 397, H: 503, band: 32 };
+  const AZ_JUMP_MAX = 0.02; // rad, scale-independent
+  const LUM_2ND_DIFF_MAX = 0.003; // scale-independent
+
+  function ringAzimuthAndHighlight(alpha: Uint8ClampedArray, W: number, H: number, band: number) {
     const { normals, bandMask } = computeBevelNormals(alpha, W, H, band, 'hardEdge', band / 2);
-
+    const params = shadeParamsFor('matte', lightDirFromRig('threePt', 't'));
+    const faceFactor = shadePixel({ x: 0, y: 0, z: 1 }, params) || 1;
     const cx = W / 2;
     const cy = H / 2;
     const rx = W / 2 - 1;
     const ry = H / 2 - 1;
-    // Sample at the band midline (inset = band/2), where the lit/shadow terminator
-    // sits and the chord was visible. 0.1° steps so a chord spanning several
-    // degrees registers as a run of equal azimuths broken by a sudden jump.
-    const inset = band * 0.5;
-    const azimuths: number[] = [];
+    const inset = band * 0.5; // band midline, where the lit/shadow terminator sits
+    const az: number[] = [];
+    const lum: number[] = [];
+    // 0.1° steps so a chord spanning several degrees registers as a run of equal
+    // azimuths broken by a sudden jump.
     for (let deg = 0; deg < 360; deg += 0.1) {
       const ang = (deg * Math.PI) / 180;
       const x = Math.round(cx + Math.cos(ang) * (rx - inset));
@@ -325,24 +308,73 @@ describe('computeBevelNormals — smooth lip on a curved silhouette (anti-facet)
       if (!bandMask[i]) continue;
       const nx = normals[i * 3];
       const ny = normals[i * 3 + 1];
+      const nz = normals[i * 3 + 2];
       if (Math.hypot(nx, ny) < 1e-3) continue;
-      azimuths.push(Math.atan2(ny, nx));
+      az.push(Math.atan2(ny, nx));
+      lum.push(shadePixel({ x: nx, y: ny, z: nz }, params) / faceFactor);
     }
-    expect(azimuths.length).toBeGreaterThan(3000);
-
-    // Largest single-step azimuth jump. Measured: without stage-2 smoothing the
-    // un-regularised field peaks at ~0.016 rad/step (the Voronoi-cell jumps);
-    // with it the azimuth advances continuously at ~0.004 rad/step. A ceiling of
-    // 0.010 rad sits cleanly between the two, so this is RED before the fix and
-    // GREEN after, at the exact scale that regressed.
     let maxJump = 0;
-    for (let i = 1; i < azimuths.length; i++) {
-      let d = azimuths[i] - azimuths[i - 1];
+    let net = 0;
+    for (let i = 1; i < az.length; i++) {
+      let d = az[i] - az[i - 1];
       while (d > Math.PI) d -= 2 * Math.PI;
       while (d < -Math.PI) d += 2 * Math.PI;
       maxJump = Math.max(maxJump, Math.abs(d));
+      net += d;
     }
-    expect(maxJump).toBeLessThan(0.01);
+    let maxLum2 = 0;
+    for (let i = 2; i < lum.length; i++) {
+      maxLum2 = Math.max(maxLum2, Math.abs(lum[i] - 2 * lum[i - 1] + lum[i - 2]));
+    }
+    return { maxJump, maxLum2, net, n: az.length };
+  }
+
+  for (const ds of DEV_SCALES) {
+    const W = BASE.W * ds;
+    const H = BASE.H * ds;
+    const band = BASE.band * ds;
+
+    it(`ellipse lip is smooth at devScale ${ds} (band ${band}px)`, () => {
+      const r = ringAzimuthAndHighlight(ellipseAlpha(W, H), W, H, band);
+      expect(r.n).toBeGreaterThan(3000);
+      // (a) no facet: largest single-step azimuth jump under the shared ceiling.
+      expect(r.maxJump).toBeLessThan(AZ_JUMP_MAX);
+      // (b) highlight has no chorded kink: tangential 2nd-difference bounded.
+      expect(r.maxLum2).toBeLessThan(LUM_2ND_DIFF_MAX);
+      // (c) the azimuth makes one full turn — it tracks the rim, not a few facets.
+      expect(Math.abs(Math.abs(r.net) - 2 * Math.PI)).toBeLessThan(0.5);
+    });
+
+    it(`thin-ring lip is smooth at devScale ${ds} (band ${band}px)`, () => {
+      // A ring whose band reaches toward the medial axis — the medial-ridge case
+      // that breaks an EDT-nearest-feature azimuth. The coverage σ (0.25·band) is
+      // small enough to stay local to the OUTER rim, so it stays smooth.
+      const r = ringAzimuthAndHighlight(ringAlpha(W, H, 0.18), W, H, band);
+      expect(r.n).toBeGreaterThan(3000);
+      expect(r.maxJump).toBeLessThan(AZ_JUMP_MAX);
+      expect(r.maxLum2).toBeLessThan(LUM_2ND_DIFF_MAX);
+      expect(Math.abs(Math.abs(r.net) - 2 * Math.PI)).toBeLessThan(0.5);
+    });
+  }
+
+  it('smoothness does NOT degrade as scale grows (the property prior patches lacked)', () => {
+    // The defining scale-invariance assertion: the max azimuth jump at devScale 8
+    // must be NO WORSE than at devScale 1. Every prior EDT-gradient patch had the
+    // opposite behaviour (smooth at the tuned scale, faceted above it); this would
+    // be RED for all of them and is GREEN for the coverage-gradient azimuth.
+    const small = ringAzimuthAndHighlight(
+      ellipseAlpha(BASE.W * 1, BASE.H * 1),
+      BASE.W * 1,
+      BASE.H * 1,
+      BASE.band * 1,
+    );
+    const large = ringAzimuthAndHighlight(
+      ellipseAlpha(BASE.W * 8, BASE.H * 8),
+      BASE.W * 8,
+      BASE.H * 8,
+      BASE.band * 8,
+    );
+    expect(large.maxJump).toBeLessThanOrEqual(small.maxJump + 1e-6);
   });
 });
 

--- a/packages/core/src/shape/bevel-shading.ts
+++ b/packages/core/src/shape/bevel-shading.ts
@@ -19,9 +19,13 @@
  *      surface height in [0,1]: 0 at the rim (d=0), 1 once `d ≥ w` (the flat top).
  *      `circle` is a quarter-circle (rounded lip), `hardEdge` a linear chamfer,
  *      etc. (§20.1.10.9).
- *   3. The surface normal is the finite-difference gradient of that height field
- *      (n = normalize(-∂h/∂x, -∂h/∂y, 1)). On the flat interior the gradient is
- *      zero → n = (0,0,1); on the lip it tilts outward toward the rim.
+ *   3. The surface normal combines two INDEPENDENT sources (the scale-invariant
+ *      redesign — see `computeBevelNormals`): its TILT MAGNITUDE comes from the
+ *      profile's local slope at the exact EDT distance, and its in-plane AZIMUTH
+ *      comes from the gradient of a Gaussian-blurred coverage field. Distance is
+ *      exact; direction is analytically smooth at every raster scale. On the flat
+ *      interior the tilt is zero → n = (0,0,1); on the lip it tilts outward toward
+ *      the rim along the silhouette's macroscopic normal.
  *   4. Lambert diffuse + a weak specular term against the light-rig direction
  *      give a per-pixel brightness factor, applied as a multiply/screen over the
  *      already-painted body.
@@ -150,6 +154,105 @@ export function edt1d(f: ArrayLike<number>): Float64Array {
 }
 
 /**
+ * Box sizes whose 3-fold convolution approximates a Gaussian of std-dev `sigma`
+ * (Wells 1986, "Efficient synthesis of Gaussian filters by cascaded uniform
+ * filters"). Three equal-radius box blurs already give a good Gaussian; mixing two
+ * adjacent odd widths (`wl` and `wl+2`) matches the target variance more exactly.
+ * Returns `n` odd box widths. Used by `gaussianBlur` below.
+ */
+function boxSizesForGaussian(sigma: number, n = 3): number[] {
+  if (sigma <= 0) return new Array(n).fill(1);
+  const wIdeal = Math.sqrt((12 * sigma * sigma) / n + 1);
+  let wl = Math.floor(wIdeal);
+  if (wl % 2 === 0) wl--;
+  const wu = wl + 2;
+  const mIdeal =
+    (12 * sigma * sigma - n * wl * wl - 4 * n * wl - 3 * n) / (-4 * wl - 4);
+  const m = Math.round(mIdeal);
+  const sizes: number[] = [];
+  for (let i = 0; i < n; i++) sizes.push(i < m ? wl : wu);
+  return sizes;
+}
+
+/**
+ * One separable box-blur pass with ZERO padding (out-of-bounds treated as 0).
+ * `horizontal` selects the axis. Uses a running sum so cost is O(N) independent
+ * of the radius.
+ *
+ * Zero padding (NOT clamp-to-edge) is the correct boundary condition for a COVERAGE
+ * field: a silhouette flush with the canvas edge has transparent (coverage 0) just
+ * outside the bounds, so the blurred coverage falls off across that edge and ∇C
+ * points outward there — exactly as `distanceToEdge` folds in the out-of-bounds
+ * transparent region for the EDT. Clamp-to-edge would instead make the field flat
+ * at the border, giving a zero gradient and no lip along a clipped edge.
+ */
+function boxBlurPass(
+  src: Float64Array,
+  dst: Float64Array,
+  w: number,
+  h: number,
+  r: number,
+  horizontal: boolean,
+): void {
+  const norm = 1 / (2 * r + 1);
+  if (horizontal) {
+    for (let y = 0; y < h; y++) {
+      const row = y * w;
+      // Seed the window [−r, r]: indices < 0 contribute 0 (zero padding).
+      let acc = 0;
+      for (let k = 0; k <= r; k++) if (k < w) acc += src[row + k];
+      for (let x = 0; x < w; x++) {
+        dst[row + x] = acc * norm;
+        const ai = x + r + 1;
+        const si = x - r;
+        if (ai < w) acc += src[row + ai];
+        if (si >= 0) acc -= src[row + si];
+      }
+    }
+  } else {
+    for (let x = 0; x < w; x++) {
+      let acc = 0;
+      for (let k = 0; k <= r; k++) if (k < h) acc += src[k * w + x];
+      for (let y = 0; y < h; y++) {
+        dst[y * w + x] = acc * norm;
+        const ai = y + r + 1;
+        const si = y - r;
+        if (ai < h) acc += src[ai * w + x];
+        if (si >= 0) acc -= src[si * w + x];
+      }
+    }
+  }
+}
+
+/**
+ * Approximate Gaussian blur of std-dev `sigma` over a scalar field, via three
+ * cascaded separable box blurs (zero-padded). O(N) total, independent of sigma.
+ *
+ * This is the SAME code path in every environment (browser, OffscreenCanvas,
+ * node/skia headless), so the bevel azimuth never depends on `ctx.filter='blur'`
+ * — whose support and exact kernel differ across canvas backends. The blur is run
+ * on the in-memory coverage field, not on a canvas, so it is fully unit-testable.
+ */
+export function gaussianBlur(
+  src: ArrayLike<number>,
+  w: number,
+  h: number,
+  sigma: number,
+): Float64Array {
+  const a = Float64Array.from(src as ArrayLike<number> & Iterable<number>);
+  if (sigma <= 0 || w <= 0 || h <= 0) return a;
+  const scratch = new Float64Array(w * h);
+  // Each box does a horizontal pass into `scratch`, then a vertical pass back into
+  // `a`, so the result always lands in `a` (no buffer swap to track).
+  for (const size of boxSizesForGaussian(sigma, 3)) {
+    const r = Math.max(1, (size - 1) / 2);
+    boxBlurPass(a, scratch, w, h, r, true);
+    boxBlurPass(scratch, a, w, h, r, false);
+  }
+  return a;
+}
+
+/**
  * Exact 2-D Euclidean distance (in px) from every pixel to the nearest pixel
  * whose alpha is below `threshold` (i.e. the boundary of the silhouette). The
  * region OUTSIDE the image bounds is also treated as below-threshold, so a
@@ -209,6 +312,9 @@ export function distanceToEdge(
   return f;
 }
 
+/** Fraction of the band width used as the coverage-blur σ. See COVERAGE_SIGMA. */
+const COVERAGE_SIGMA_FRACTION = 0.25;
+
 /**
  * Compute per-pixel surface normals for the bevel lip of a silhouette.
  *
@@ -223,6 +329,48 @@ export function distanceToEdge(
  * Returns `normals` (W·H·3 floats, unit vectors, +Z toward viewer) and
  * `bandMask` (W·H of 0/1; 1 where the pixel is inside the shape and within the
  * bevel band, i.e. where shading should be applied).
+ *
+ * ## Scale-invariant azimuth (this redesign — issue lineage #410→#413→#415→here)
+ *
+ * The lip normal has two parts that we derive from two INDEPENDENT, decoupled
+ * sources so each is correct on its own terms:
+ *
+ *   • TILT MAGNITUDE (how steeply the lip rises) — from the cross-section profile's
+ *     local slope at the EXACT EDT distance `d`. Distance is the geometrically
+ *     meaningful quantity for the height (a `circle` lip at d=band/2 is at a precise
+ *     height), and the EDT gives it exactly. This is what the PDF-calibrated slide-3
+ *     brightness curve depends on, so it is preserved bit-for-bit in spirit.
+ *
+ *   • IN-PLANE AZIMUTH (which way the lip faces) — from the gradient of a Gaussian-
+ *     blurred COVERAGE field `C = G_σ * alpha`, σ = 0.25·bandPx. This is the load-
+ *     bearing change. `∇C = (∇G_σ) * alpha` is a convolution with the smooth kernel
+ *     ∇G_σ, so C ∈ C^∞ regardless of how the silhouette was rasterised: the azimuth
+ *     field rotates continuously around any smooth boundary, with a per-step turn
+ *     bounded only by the silhouette's curvature. Because σ scales with the band and
+ *     the geometry scales with devScale TOGETHER, the smoothness is identical at
+ *     every raster scale — it is scale-invariant by construction.
+ *
+ * ### Why this finally fixes the size-dependent facet (and the patches didn't)
+ *
+ * The OLD method took BOTH parts from the finite-difference gradient of the EDT
+ * height field. But ∇(distance-to-point-set) is piecewise-constant: each band
+ * pixel's nearest boundary sample dominates, so the gradient DIRECTION snaps to
+ * that sample's Voronoi-cell direction, chording the lip into facets. The screen-
+ * blend highlight amplifies the chord at the lit/shadow terminator. Both prior
+ * fixes were post-filters on that same broken field:
+ *   - #413: box-blur the scalar height → smooths gradient MAGNITUDE, not direction
+ *     (fixed devScale ≤ 2 only).
+ *   - #415: tangential low-pass of the normal VECTOR over radius 0.25·bandPx, gated
+ *     at bandPx ≥ 24 → fixed devScale 4, REGRESSED at devScale 8.
+ * Every band-proportional blur radius chases a moving target: the Voronoi cell's
+ * angular width depends on radial distance from the rim, which grows with the band,
+ * so a large enough band always re-opens the chord. Sourcing the azimuth from ∇C
+ * removes the Voronoi structure at the SOURCE — there is no discrete cell field
+ * left to facet — so no gate and no post-blur are needed at any scale.
+ *
+ * The coverage blur is O(N) (three cascaded box passes, running-sum, independent of
+ * σ), runs once per bevel on the device offscreen — the same order as the EDT it
+ * sits beside, and cheaper than the two post-filter passes it replaces.
  */
 export function computeBevelNormals(
   alpha: ArrayLike<number>,
@@ -234,83 +382,69 @@ export function computeBevelNormals(
 ): { normals: Float32Array; bandMask: Uint8Array } {
   const normals = new Float32Array(w * h * 3);
   const bandMask = new Uint8Array(w * h);
+  if (w <= 0 || h <= 0) return { normals, bandMask };
   const dist = distanceToEdge(alpha, w, h);
   const profile = bevelHeightProfile(prst, bandPx);
-
-  // Height field: profile(d) scaled by the bevel's height/width aspect. A height
-  // of `heightPx` over a band of `bandPx` means the lip rises heightPx px over
-  // bandPx px of run, so the surface-space gradient scale is heightPx/bandPx.
-  const heightScale = bandPx > 0 ? heightPx / bandPx : 0;
-
-  // Dense height field over the whole mask: profile(d)·heightScale·bandPx inside
-  // the silhouette, 0 (ground) outside. Materialising it lets us regularise the
-  // gradient (below) before differencing, instead of sampling it per-neighbour.
   const inside = (x: number, y: number) => (alpha[y * w + x] ?? 0) >= 128;
-  const height = new Float64Array(w * h);
-  for (let i = 0; i < w * h; i++) {
-    height[i] = (alpha[i] ?? 0) >= 128 ? profile(dist[i]) * heightScale * bandPx : 0;
-  }
 
-  // ── Anti-facet smoothing of the height field ──────────────────────────────
-  // The EDT `dist` is exact, but its *gradient* is piecewise-constant: every
-  // band pixel's distance is dominated by ONE nearest boundary sample, so ∇d (and
-  // hence the lip normal) snaps to that sample's Voronoi-cell direction. On a
-  // curved silhouette (e.g. an ellipse) this turns the lip into flat chords — a
-  // visible polygonal facet whose coarseness grows with the band width (the wider
-  // the band, the larger the cells). A bevel lip is geometrically a smooth ruled
-  // surface swept along the silhouette, so its normal must follow the silhouette's
-  // *macroscopic* direction, not the per-pixel nearest-sample direction.
-  //
-  // We recover that by box-blurring the height field over a radius proportional to
-  // the band width before differencing. The radius is NOT an empirical fudge: it
-  // is the only length scale in the problem — averaging ∇h over a neighbourhood a
-  // small fraction of the band removes the sub-pixel Voronoi noise while staying
-  // far more local than the band itself, so the iso-contours (band mask) and the
-  // calibrated brightness curve along the lip are unchanged (the profile is ~linear
-  // across a few px, so a symmetric blur preserves its value). `dist`/`bandMask`
-  // stay exact — only the gradient used for the normal is regularised.
-  //
-  // Cost vs. a "full-resolution exact" alternative: the EDT is already exact and
-  // full-res (Felzenszwalb O(N) per pass). The faceting is intrinsic to sampling
-  // ∇(distance-to-point-set), so a higher-res EDT would NOT remove it — only push
-  // the cells smaller. A band-scaled separable box blur is O(N) (two passes,
-  // running-sum) and adds a constant factor to a step we already pay, which is why
-  // it is preferred over, say, re-deriving the analytic silhouette normal.
-  const blurR = Math.max(1, Math.round(bandPx * 0.12));
-  const sm = boxBlurClampedInside(height, alpha, w, h, blurR);
+  // Height-field aspect scale: the lip rises `heightPx` over `bandPx` of run, so a
+  // unit of profile change maps to heightScale·bandPx of surface height (the same
+  // mapping the old height field used — preserves the calibrated tilt magnitude).
+  const heightScale = bandPx > 0 ? heightPx / bandPx : 0;
+  const tiltScale = heightScale * bandPx;
 
-  const heightSmooth = (x: number, y: number): number => sm[y * w + x];
+  // ── Azimuth source: gradient of a Gaussian-blurred coverage field ──────────
+  // Blur the raw coverage (alpha/255) by σ ∝ band. σ is a quarter of the band: a
+  // fraction of the bevel's OWN length scale, large enough to wash out the per-
+  // pixel Voronoi noise yet small enough to stay local to a single rim (a larger σ
+  // would blur the inner and outer rims of a thin ring together and flip the
+  // azimuth at the medial axis). See COVERAGE_SIGMA_FRACTION.
+  const coverage = new Float64Array(w * h);
+  for (let i = 0; i < w * h; i++) coverage[i] = (alpha[i] ?? 0) / 255;
+  const sigma = Math.max(1, bandPx * COVERAGE_SIGMA_FRACTION);
+  const C = gaussianBlur(coverage, w, h, sigma);
+
+  // Local profile slope dh/dd at distance d (per px), via a centred 1px difference
+  // of the profile. Drives the lip's tilt magnitude; the height stays distance-exact.
+  const slopeAt = (d: number): number => {
+    const a = profile(Math.max(0, d - 0.5));
+    const b = profile(d + 0.5);
+    return b - a; // change in profile over 1 px of distance
+  };
 
   for (let y = 0; y < h; y++) {
     for (let x = 0; x < w; x++) {
       const i = y * w + x;
       if (!inside(x, y)) {
-        // Outside the silhouette: flat ground normal, no shading.
-        normals[i * 3 + 2] = 1;
+        normals[i * 3 + 2] = 1; // flat ground outside the silhouette
         continue;
       }
       const d = dist[i];
       const inBand = d > 0 && d < bandPx;
       bandMask[i] = inBand ? 1 : 0;
       if (!inBand) {
-        // Flat top of the shape (or right at the rim) — face the viewer.
-        normals[i * 3 + 2] = 1;
+        normals[i * 3 + 2] = 1; // flat top of the shape
         continue;
       }
-      // Central finite difference of the SMOOTHED height field. Clamp neighbours
-      // that step outside the silhouette to the current pixel's height so the lip
-      // gradient is measured against the rim, not against ground level beyond.
-      const hC = heightSmooth(x, y);
-      const hL = x > 0 && inside(x - 1, y) ? heightSmooth(x - 1, y) : hC;
-      const hR = x < w - 1 && inside(x + 1, y) ? heightSmooth(x + 1, y) : hC;
-      const hU = y > 0 && inside(x, y - 1) ? heightSmooth(x, y - 1) : hC;
-      const hD = y < h - 1 && inside(x, y + 1) ? heightSmooth(x, y + 1) : hC;
-      // Gradient (∂h/∂x, ∂h/∂y) via central difference (px units cancel: 2px run).
-      const dhdx = (hR - hL) / 2;
-      const dhdy = (hD - hU) / 2;
-      // Surface normal of z=h(x,y): n = normalize(-dh/dx, -dh/dy, 1).
-      let nx = -dhdx;
-      let ny = -dhdy;
+      // Outward azimuth = −∇C/|∇C| (coverage decreases toward the rim, so the
+      // negative gradient points outward, along the silhouette's outward normal).
+      const xl = x > 0 ? x - 1 : x;
+      const xr = x < w - 1 ? x + 1 : x;
+      const yu = y > 0 ? y - 1 : y;
+      const yd = y < h - 1 ? y + 1 : y;
+      const gx = (C[y * w + xr] - C[y * w + xl]) / (xr - xl || 1);
+      const gy = (C[yd * w + x] - C[yu * w + x]) / (yd - yu || 1);
+      const gm = Math.hypot(gx, gy);
+      let ax = 0;
+      let ay = 0;
+      if (gm > 1e-9) {
+        ax = -gx / gm;
+        ay = -gy / gm;
+      }
+      // Tilt magnitude from the exact-distance profile slope; azimuth from ∇C.
+      const s = slopeAt(d) * tiltScale;
+      let nx = s * ax;
+      let ny = s * ay;
       let nz = 1;
       const m = Math.hypot(nx, ny, nz) || 1;
       nx /= m;
@@ -321,183 +455,7 @@ export function computeBevelNormals(
       normals[i * 3 + 2] = nz;
     }
   }
-  // ── Anti-facet stage 2: regularise the in-plane normal DIRECTION ───────────
-  // Stage 1 (the height-field box blur above) smooths the gradient MAGNITUDE and
-  // removes the facet for narrow bands (≤ ~32 px / devScale ≤ 2). But for a wide
-  // band on a strongly-curved silhouette — sample-11 slide 6 at high DPR, where
-  // the hardEdge band is ~128 px deep — the facet returns on the lit/shadow
-  // terminator. Root cause: the height field of a `hardEdge` (linear) profile is
-  // ~linear in `dist`, so its gradient *direction* (the lip azimuth) still flips
-  // sharply across the EDT's Voronoi-cell boundaries; a blur of the scalar height
-  // barely rotates that gradient. The screen-blend highlight (lit lip → white,
-  // SCREEN_GAIN) is a high-contrast operator that amplifies tiny azimuth jitter
-  // at the terminator into a visible bright chord. The shadow (plain multiply)
-  // and the un-modulated band do not show it — only the lit highlight does
-  // (confirmed by ablation: bevel off → smooth; lit-only → faceted; flat → smooth).
-  //
-  // The geometrically correct regulariser is therefore a *direct* low-pass of the
-  // in-plane normal VECTOR (nx, ny) — the azimuth itself — over a tangential
-  // neighbourhood proportional to the band. The Voronoi cell's tangential extent
-  // grows with the band depth, so the only intrinsic length scale is the band
-  // width; a radius of ~0.25·bandPx spans several cells at every devScale,
-  // collapsing the chorded azimuth onto the silhouette's macroscopic direction
-  // while leaving the lip's rise (height) and the band mask exact. (0.12·bandPx —
-  // the stage-1 fraction — still leaves a faint chord at 128 px; 0.25 clears it
-  // with margin.) Separable, masked to band pixels, O(N·r); paid once per bevel
-  // on the device offscreen, like stage 1.
-  //
-  // GATE — only for bands wide enough to actually facet. The Voronoi facet is
-  // invisible until the band is many px deep: at devScale ≤ ~1 the band is a
-  // handful of px (sample-11 slide 3's circle bevel is ~11 px) and stage 1 alone
-  // already reads as smooth. Running stage 2 there would low-pass the few-px lip
-  // and perturb the PDF-CALIBRATED slide-3 shading for no visible gain. We
-  // therefore engage stage 2 only when `bandPx ≥ 24` — comfortably above slide-3
-  // (≈11 px, left exactly as #410/#413 calibrated it) and below the facet's onset
-  // band (slide 6 is 32 px at devScale 1, 64/96/128 px at devScale 2/3/4, all
-  // smoothed). This is the only data-dependent constant; it is a *visibility*
-  // gate, not a per-sample fudge, and is documented as such per CLAUDE.md.
-  const FACET_MIN_BAND_PX = 24;
-  if (bandPx >= FACET_MIN_BAND_PX) {
-    const normalBlurR = Math.max(1, Math.round(bandPx * 0.25));
-    smoothNormalsTangential(normals, bandMask, w, h, normalBlurR);
-  }
   return { normals, bandMask };
-}
-
-/**
- * Separable box blur of the in-plane normal components (nx, ny) over band pixels
- * only, then re-normalise (recovering nz from the unit-length constraint). This
- * regularises the lip AZIMUTH along the silhouette — see the "Anti-facet stage 2"
- * note in computeBevelNormals for why direction (not just height magnitude) must
- * be smoothed to kill the high-DPR terminator facet. Out-of-band taps are skipped
- * so the smoothing is purely tangential and never averages the flat interior /
- * exterior into the lip. O(N·r), r small (≈ 0.25·bandPx).
- */
-function smoothNormalsTangential(
-  normals: Float32Array,
-  bandMask: Uint8Array,
-  w: number,
-  h: number,
-  r: number,
-): void {
-  const nx = new Float64Array(w * h);
-  const ny = new Float64Array(w * h);
-  for (let i = 0; i < w * h; i++) {
-    nx[i] = normals[i * 3];
-    ny[i] = normals[i * 3 + 1];
-  }
-  const tmpX = new Float64Array(w * h);
-  const tmpY = new Float64Array(w * h);
-  // Horizontal.
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) {
-      const i = y * w + x;
-      if (!bandMask[i]) { tmpX[i] = nx[i]; tmpY[i] = ny[i]; continue; }
-      let sx = 0, sy = 0, n = 0;
-      for (let k = -r; k <= r; k++) {
-        const xx = x + k;
-        if (xx < 0 || xx >= w) continue;
-        const j = y * w + xx;
-        if (!bandMask[j]) continue;
-        sx += nx[j]; sy += ny[j]; n++;
-      }
-      tmpX[i] = n ? sx / n : nx[i];
-      tmpY[i] = n ? sy / n : ny[i];
-    }
-  }
-  // Vertical + re-normalise.
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) {
-      const i = y * w + x;
-      if (!bandMask[i]) continue;
-      let sx = 0, sy = 0, n = 0;
-      for (let k = -r; k <= r; k++) {
-        const yy = y + k;
-        if (yy < 0 || yy >= h) continue;
-        const j = yy * w + x;
-        if (!bandMask[j]) continue;
-        sx += tmpX[j]; sy += tmpY[j]; n++;
-      }
-      const ax = n ? sx / n : nx[i];
-      const ay = n ? sy / n : ny[i];
-      const m = Math.hypot(ax, ay, 1) || 1;
-      normals[i * 3] = ax / m;
-      normals[i * 3 + 1] = ay / m;
-      normals[i * 3 + 2] = 1 / m;
-    }
-  }
-}
-
-/**
- * Separable box blur of a height field, with samples that fall OUTSIDE the
- * silhouette (alpha < 128) skipped rather than averaged in as ground level.
- *
- * Why skip instead of clamp-to-zero: averaging in the exterior ground (h=0) near
- * the rim would pull the smoothed height down and bias the gradient inward,
- * weakening the lip exactly at the rim where the shading matters most. Skipping
- * out-of-silhouette taps keeps the smoothing a pure *tangential* regulariser of
- * the lip surface — it averages along the band, not across the rim into the void.
- *
- * O(N·r) here (a plain windowed mean, not a running sum) because the per-tap
- * inside test makes a constant-time sliding sum awkward; r is small (≈ band·0.12,
- * a handful of px) so this stays well within the EDT's own cost. The blur runs
- * once per bevel, on the device-resolution offscreen, so it is paid only for
- * shapes that actually carry an sp3d bevel.
- */
-function boxBlurClampedInside(
-  src: Float64Array,
-  alpha: ArrayLike<number>,
-  w: number,
-  h: number,
-  r: number,
-): Float64Array {
-  const tmp = new Float64Array(w * h);
-  const out = new Float64Array(w * h);
-  const isInside = (idx: number) => (alpha[idx] ?? 0) >= 128;
-  // Horizontal pass.
-  for (let y = 0; y < h; y++) {
-    const row = y * w;
-    for (let x = 0; x < w; x++) {
-      const i = row + x;
-      if (!isInside(i)) {
-        tmp[i] = 0;
-        continue;
-      }
-      let s = 0;
-      let n = 0;
-      for (let k = -r; k <= r; k++) {
-        const xx = x + k;
-        if (xx < 0 || xx >= w) continue;
-        const j = row + xx;
-        if (!isInside(j)) continue;
-        s += src[j];
-        n++;
-      }
-      tmp[i] = n > 0 ? s / n : src[i];
-    }
-  }
-  // Vertical pass.
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) {
-      const i = y * w + x;
-      if (!isInside(i)) {
-        out[i] = 0;
-        continue;
-      }
-      let s = 0;
-      let n = 0;
-      for (let k = -r; k <= r; k++) {
-        const yy = y + k;
-        if (yy < 0 || yy >= h) continue;
-        const j = yy * w + x;
-        if (!isInside(j)) continue;
-        s += tmp[j];
-        n++;
-      }
-      out[i] = n > 0 ? s / n : tmp[i];
-    }
-  }
-  return out;
 }
 
 // ── Light rig ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The sp3d bevel facet bug has now slipped through **four** times (#410 → #413 → #415 → here), each at a larger raster scale. #415 fixed devScale 4 but **regressed at devScale 8** — the user's real DPR-8 render shows a straight chord on the bevel ring shoulder (sample-11 slide 6).

Every prior fix was a post-filter on the EDT height-field gradient whose smoothing radius was a fraction of the band. Because the EDT Voronoi cell's angular width grows with the band, a large enough band always re-opens the chord. This PR is a **method change, not another patch.**

## Root cause

The lip normal took *both* its tilt and its azimuth from the finite-difference gradient of the EDT height field. `∇(distance-to-point-set)` is piecewise-constant — each band pixel's nearest boundary sample dominates, so the gradient *direction* snaps to that sample's Voronoi-cell direction, chording a curved lip into facets. The screen-blend highlight amplifies the chord at the lit/shadow terminator.

## Fix: decouple distance (tilt) from a smooth azimuth

- **Tilt magnitude** — still from the cross-section profile's slope at the **exact EDT distance**. The PDF-calibrated slide-3 brightness depends only on this, so it is preserved.
- **In-plane azimuth** — from `∇C`, where `C = G_σ * alpha` is the Gaussian-blurred coverage field (σ = 0.25·band). `∇C = (∇G_σ) * alpha` is a convolution with a smooth kernel, so `C ∈ C^∞` regardless of rasterisation: the azimuth field is analytically smooth at **every** scale, with no Voronoi structure. σ and the geometry scale with devScale together, so smoothness is **scale-invariant by construction** — and in fact improves with DPR.

Both anti-facet patch stages (height-field blur, tangential normal-direction blur) and the `bandPx ≥ 24` gate are **removed**. The coverage blur is a 3-box-cascade Gaussian (zero-padded, running-sum, O(N) independent of σ), the same code path in browser and node/skia — the bevel no longer depends on `ctx.filter='blur'`.

## Why this is scale-invariant (the property prior patches lacked)

| devScale | band px | max 1-step azimuth jump (ellipse / ring) |
|---|---|---|
| 1 | 32  | 0.0094 |
| 2 | 64  | 0.0047 |
| 4 | 128 | 0.0039 |
| 8 | 256 | 0.0030 |

Raw EDT gradient (pre-patch) jumps **0.12–0.24 rad** at all scales. The new method **gets smoother as scale grows** — the inverse of every prior patch.

## Verification

- **Decisive unit test**: parametrises devScale ∈ {1,2,4,8} (ellipse + thin ring) with a single scale-independent threshold for both the azimuth jump and the highlight-luminance 2nd-difference, plus an explicit "smoothness does not degrade with scale" assertion. Replaces the #415 DPR-4-only test (whose single-scale pin let the next scale walk through — documented in test comments).
- **Visual**: slide 6 captured at DPR {2,4,8}. The DPR-8 shoulder/inner-rim arc is smooth; A/B against the old renderer shows the chord is gone.
- **slide-3 calibration invariance**: OLD vs NEW (DPR 2) = **0.00% pixels differ** (threshold 0.2), luma histogram L1 = 0.0054. The calibrated `circle` bevel is untouched.
- **VRT**: 69/69 pptx tests green (demo + private sample 1-6).
- `pnpm test` 337/337, core typecheck, ast-grep lint all green.
- **Perf**: ~5× faster at devScale 8 (old O(N·r) blurs grew with the band; new path is O(N) flat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)