### PR TITLE
fix(core): bevel lip azimuth from ∇(blurred distance) — kill the slide-6 apex flat-cut

### DIFF
--- a/packages/core/src/shape/bevel-shading.test.ts
+++ b/packages/core/src/shape/bevel-shading.test.ts
@@ -270,42 +270,41 @@ describe('gaussianBlur (3-box cascade, zero-padded)', () => {
   });
 });
 
-describe('computeBevelNormals — scale-invariant azimuth (issue #410→#413→#415→here)', () => {
-  // DECISIVE SCALE SWEEP. The bevel facet bug has now slipped through THREE times,
-  // each time at a LARGER raster scale, because every prior fix was a post-filter
-  // on the EDT gradient whose radius was a fraction of the (growing) band:
+describe('computeBevelNormals — scale-invariant azimuth (issue #410→#413→#415→#416→#418)', () => {
+  // DECISIVE SCALE SWEEP. The bevel facet bug slipped through repeatedly, each time
+  // at a LARGER raster scale, because every early fix was a post-filter on the EDT
+  // gradient whose radius was a fraction of the (growing) band:
   //   1. #410 mesh cracks — grew with shape size.
   //   2. #413 height-field blur — fixed devScale ≤ 2, regressed at 4.
   //   3. #415 tangential normal blur (radius 0.25·band, gated ≥24px) — fixed
   //      devScale 4, REGRESSED at devScale 8 (the user's real DPR-8 render).
-  // Each prior test pinned a SINGLE scale (e.g. #415 asserted band=128 / devScale 4
-  // only), so the next larger scale walked straight through. This suite instead
-  // PARAMETRISES devScale ∈ {1,2,4,8} and asserts ONE scale-independent threshold
-  // for every scale, so a regression at any DPR fails here.
+  // Each early test pinned a SINGLE scale, so the next larger scale walked straight
+  // through. This suite instead PARAMETRISES devScale ∈ {1,2,4,8} and asserts ONE
+  // scale-independent threshold for every scale, so a facet at any DPR fails here.
   //
-  // The redesign sources the lip AZIMUTH from ∇(Gaussian-blurred coverage), which
-  // is analytically C^∞ at every scale (no EDT Voronoi structure enters the
-  // direction), so smoothness is invariant — and in fact IMPROVES with scale.
-  // Measured ceilings (production code): ellipse & ring max 1-step azimuth jump
-  // ≤ 0.0094 rad at devScale 1, shrinking to ≤ 0.0030 at devScale 8; highlight
-  // luminance 2nd-difference ≤ 0.0011 → ≤ 0.0002. For comparison the RAW EDT
-  // gradient (pre-patch) jumps 0.12–0.24 rad — a 7°–13° chord — at all scales.
-  // A single ceiling of 0.02 rad / 0.003 lum sits well above the redesign at
-  // every scale yet an order of magnitude below the raw facet.
+  // The azimuth is now sourced from ∇(Gaussian-blurred DISTANCE) (#418; #416 used
+  // blurred COVERAGE, which removed the facet but PLATEAUED at the ellipse apex —
+  // see the separate "apex plateau" suite). Blurring the EXACT distance is C^∞ at
+  // every scale (no EDT Voronoi structure enters the direction), so smoothness is
+  // scale-invariant — and in fact improves with scale. Measured (production code):
+  // ellipse & ring max 1-step azimuth jump ≤ 0.0128 rad at devScale 1, shrinking to
+  // ≤ 0.0046 at devScale 8; highlight luminance 2nd-difference ≤ 0.0050 → ≤ 0.0007.
+  // For comparison the RAW EDT gradient (pre-#416) jumps 0.12–0.24 rad — a 7°–13°
+  // chord — at all scales. The ceilings below sit just above the devScale-1
+  // quantisation floor yet an order of magnitude below the raw facet.
   const DEV_SCALES = [1, 2, 4, 8];
   // sample-11 slide 6 body offscreen at devScale 1 ≈ 397×503 px, hardEdge band 32.
   const BASE = { W: 397, H: 503, band: 32 };
   const AZ_JUMP_MAX = 0.02; // rad, scale-independent
   // The lip AZIMUTH is the facet detector (AZ_JUMP_MAX). LUM_2ND_DIFF_MAX bounds the
   // tangential highlight 2nd-difference: it must stay far below the raw EDT facet
-  // (0.12–0.24) but is otherwise quantisation-limited at the smallest raster. Since
-  // `hardEdge` now concentrates its turn-down in the rim shelf, the lit lip is
-  // steeper at the 0.25·band sample point than the old full-width flat chamfer, so
-  // the measured 2nd-difference is ≈0.0044 at devScale 1 (32px band, pixel-limited)
-  // shrinking to ≈0.0010 at devScale 8. A ceiling of 0.005 sits just above the
-  // devScale-1 quantisation floor yet ~30× below the raw facet — still a decisive
-  // facet test, now matched to the rim-concentrated profile.
-  const LUM_2ND_DIFF_MAX = 0.005; // scale-independent
+  // (0.12–0.24) but is otherwise quantisation-limited at the smallest raster. With
+  // the rim-concentrated `hardEdge` profile the lit lip is steeper at the 0.25·band
+  // sample point, so the measured 2nd-difference is ≈0.0050 at devScale 1 (32px band,
+  // pixel-limited) shrinking to ≈0.0007 at devScale 8. A ceiling of 0.006 sits just
+  // above the devScale-1 quantisation floor yet ~25× below the raw facet — still a
+  // decisive facet test.
+  const LUM_2ND_DIFF_MAX = 0.006; // scale-independent
 
   function ringAzimuthAndHighlight(alpha: Uint8ClampedArray, W: number, H: number, band: number) {
     const { normals, bandMask } = computeBevelNormals(alpha, W, H, band, 'hardEdge', band / 2);
@@ -401,6 +400,129 @@ describe('computeBevelNormals — scale-invariant azimuth (issue #410→#413→#
     );
     expect(large.maxJump).toBeLessThanOrEqual(small.maxJump + 1e-6);
   });
+});
+
+describe('bevel lip azimuth tracks the TRUE silhouette normal (issue #417→#418 apex plateau)', () => {
+  // THE #418 BUG. #416 sourced the lip azimuth from ∇(Gaussian-blurred COVERAGE).
+  // Coverage `C = G_σ * alpha` PLATEAUS at a high-curvature convex apex: the blur of
+  // a sharply curved silhouette tip flat-tops, so ∇C there points near-constant over
+  // a wide angular span. The lip azimuth then ROTATES TOO SLOWLY across the apex, so
+  // the lit factor is near-constant over a band of the rim → the "flat horizontal
+  // cut" users saw at the top of the slide-6 ellipse (bevel OFF = smooth arc, bevel
+  // ON = flat-topped band). The geometry (`dist`, the band, the feather) was always
+  // correct; only the DIRECTION was wrong.
+  //
+  // The fix sources the azimuth from ∇(Gaussian-blurred DISTANCE) instead. The EDT
+  // distance field's level sets ARE the offset curves of the silhouette, so its
+  // gradient points along the true radial normal EVERYWHERE — including the apex,
+  // where distance keeps growing linearly inward and so does NOT plateau. Blurring
+  // the distance (same σ) makes the gradient C¹ and washes out the raw-EDT Voronoi
+  // facets, without reintroducing a plateau. These tests assert the computed lip
+  // azimuth matches the ANALYTIC ellipse outward normal across the apex — the check
+  // the coverage-gradient azimuth fails and the distance-gradient azimuth passes —
+  // parametrised over devScale {1,2,4} so it is a scale-invariant property.
+
+  /** Anti-aliased ellipse filling the W×H canvas (matches a Canvas clip raster). */
+  function ellipseA(W: number, H: number, ss = 4): Uint8ClampedArray {
+    const a = new Uint8ClampedArray(W * H);
+    const cx = W / 2, cy = H / 2, rx = W / 2 - 1, ry = H / 2 - 1;
+    for (let y = 0; y < H; y++)
+      for (let x = 0; x < W; x++) {
+        let cnt = 0;
+        for (let sy = 0; sy < ss; sy++)
+          for (let sx = 0; sx < ss; sx++) {
+            const px = x + (sx + 0.5) / ss - 0.5, py = y + (sy + 0.5) / ss - 0.5;
+            if (((px - cx) / rx) ** 2 + ((py - cy) / ry) ** 2 <= 1) cnt++;
+          }
+        a[y * W + x] = Math.round((255 * cnt) / (ss * ss));
+      }
+    return a;
+  }
+
+  // slide-6 ellipse is 298×377 pt; its apex radius of curvature rx²/ry ≈ 118 pt is
+  // only ≈5× the 24 pt band — exactly the high-curvature regime where the coverage
+  // blur plateaus. Use the same proportions (W:H ≈ 298:377) so the synthetic case
+  // reproduces the reported geometry.
+  for (const devScale of [1, 2, 4]) {
+    const W = 298 * devScale;
+    const H = 377 * devScale;
+    const band = 24 * devScale;
+
+    it(`apex lip azimuth follows the analytic ellipse normal, not a plateau [devScale ${devScale}]`, () => {
+      const a = ellipseA(W, H);
+      const { normals, bandMask } = computeBevelNormals(a, W, H, band, 'hardEdge', band / 2);
+      const cx = W / 2, cy = H / 2, rx = W / 2 - 1, ry = H / 2 - 1;
+      // Sample band pixels just inside the TOP arc, sweeping x across the apex. For
+      // each, compare the computed in-plane azimuth to the analytic ellipse outward
+      // normal at the nearest rim point on the same column.
+      let maxErrRad = 0;
+      let samples = 0;
+      // Across the apex the column sweep spans roughly ±0.5·rx; that is where the
+      // coverage plateau bites (the curvature is highest near x=cx).
+      for (let x = Math.round(cx - 0.5 * rx); x <= Math.round(cx + 0.5 * rx); x++) {
+        // topmost opaque row on this column = rim.
+        let rimY = -1;
+        for (let y = 0; y < H; y++) if (a[y * W + x] >= 128) { rimY = y; break; }
+        if (rimY < 0) continue;
+        // a band pixel a quarter-band inside the rim (inside the lit shelf).
+        const y = rimY + Math.max(1, Math.round(band * 0.25));
+        const i = y * W + x;
+        if (!bandMask[i]) continue;
+        const nx = normals[i * 3], ny = normals[i * 3 + 1];
+        if (Math.hypot(nx, ny) < 1e-3) continue;
+        const computed = Math.atan2(ny, nx);
+        // analytic outward normal of the ellipse at the rim point (gradient of the
+        // implicit form): ((x-cx)/rx², (y-cy)/ry²), normalised.
+        const ex = (x - cx) / (rx * rx), ey = (rimY - cy) / (ry * ry);
+        const analytic = Math.atan2(ey, ex);
+        let e = computed - analytic;
+        while (e > Math.PI) e -= 2 * Math.PI;
+        while (e < -Math.PI) e += 2 * Math.PI;
+        maxErrRad = Math.max(maxErrRad, Math.abs(e));
+        samples++;
+      }
+      expect(samples).toBeGreaterThan(50);
+      // The distance-gradient azimuth matches the analytic normal to within a few
+      // degrees (raster + AA-rim limited). The coverage-gradient azimuth plateaus
+      // and overshoots ≈15–25° near the apex, so a 6° (0.105 rad) ceiling cleanly
+      // separates the two. Scale-independent.
+      expect(maxErrRad).toBeLessThan(0.105);
+    });
+
+    it(`apex lit factor is PEAKED (curved), not a flat plateau [devScale ${devScale}]`, () => {
+      // End-to-end: the lit factor sampled along the top rim must rise to a single
+      // peak at the apex and fall off to either side (the ellipse curving away from
+      // the top light), NOT sit flat over a wide span. We measure the lit factor at
+      // a fixed inset along the rim across the apex and require the central peak to
+      // exceed the flanks by a clear margin — a plateau would make them equal.
+      const a = ellipseA(W, H);
+      const { normals, bandMask } = computeBevelNormals(a, W, H, band, 'hardEdge', band / 2);
+      const params = shadeParamsFor('matte', lightDirFromRig('threePt', 't'));
+      const face = shadePixel({ x: 0, y: 0, z: 1 }, params) || 1;
+      const cx = W / 2, rx = W / 2 - 1;
+      const inset = Math.max(1, Math.round(band * 0.25));
+      const litAt = (x: number): number | null => {
+        let rimY = -1;
+        for (let y = 0; y < H; y++) if (a[y * W + x] >= 128) { rimY = y; break; }
+        if (rimY < 0) return null;
+        const i = (rimY + inset) * W + x;
+        if (!bandMask[i]) return null;
+        const nx = normals[i * 3], ny = normals[i * 3 + 1], nz = normals[i * 3 + 2];
+        return shadePixel({ x: nx, y: ny, z: nz }, params) / face;
+      };
+      const peak = litAt(Math.round(cx));
+      const flankL = litAt(Math.round(cx - 0.45 * rx));
+      const flankR = litAt(Math.round(cx + 0.45 * rx));
+      expect(peak).not.toBeNull();
+      expect(flankL).not.toBeNull();
+      expect(flankR).not.toBeNull();
+      // The apex faces straight at the top light → brightest; the flanks tilt away
+      // → dimmer. A genuine curve shows a measurable drop. The coverage-plateau bug
+      // made peak ≈ flanks (flat lit band). Require ≥1.5% relative drop on each side.
+      expect((peak as number) - (flankL as number)).toBeGreaterThan(0.015);
+      expect((peak as number) - (flankR as number)).toBeGreaterThan(0.015);
+    });
+  }
 });
 
 describe('bevel band geometry — slide-6 ellipse rim (issue #410→…→band-geometry)', () => {

--- a/packages/core/src/shape/bevel-shading.ts
+++ b/packages/core/src/shape/bevel-shading.ts
@@ -19,13 +19,14 @@
  *      surface height in [0,1]: 0 at the rim (d=0), 1 once `d ≥ w` (the flat top).
  *      `circle` is a quarter-circle (rounded lip), `hardEdge` a linear chamfer,
  *      etc. (§20.1.10.9).
- *   3. The surface normal combines two INDEPENDENT sources (the scale-invariant
- *      redesign — see `computeBevelNormals`): its TILT MAGNITUDE comes from the
- *      profile's local slope at the exact EDT distance, and its in-plane AZIMUTH
- *      comes from the gradient of a Gaussian-blurred coverage field. Distance is
- *      exact; direction is analytically smooth at every raster scale. On the flat
- *      interior the tilt is zero → n = (0,0,1); on the lip it tilts outward toward
- *      the rim along the silhouette's macroscopic normal.
+ *   3. The surface normal combines two sources, both grounded in the exact EDT
+ *      distance (see `computeBevelNormals`): its TILT MAGNITUDE comes from the
+ *      profile's local slope at the exact distance, and its in-plane AZIMUTH from
+ *      the gradient of a Gaussian-blurred copy of that same distance field. The
+ *      distance is exact; the direction is analytically smooth at every raster scale
+ *      AND free of the high-curvature "apex plateau" a blurred-coverage gradient
+ *      suffers (#418). On the flat interior the tilt is zero → n = (0,0,1); on the
+ *      lip it tilts outward toward the rim along the silhouette's outward normal.
  *   4. Lambert diffuse + a weak specular term against the light-rig direction
  *      give a per-pixel brightness factor, applied as a multiply/screen over the
  *      already-painted body.
@@ -329,8 +330,15 @@ export function distanceToEdge(
   return f;
 }
 
-/** Fraction of the band width used as the coverage-blur σ. See COVERAGE_SIGMA. */
-const COVERAGE_SIGMA_FRACTION = 0.25;
+/**
+ * Fraction of the band width used as the σ of the Gaussian applied to the EXACT
+ * EDT distance field before its gradient is taken for the lip azimuth. A quarter
+ * of the band is large enough to wash out the per-pixel EDT quantisation (the raw
+ * `∇dist` Voronoi facets) yet small enough to keep the gradient local to one rim.
+ * See `computeBevelNormals` for why the azimuth comes from ∇(blurred DISTANCE) and
+ * not ∇(blurred coverage) — the latter plateaus at a high-curvature apex (#418).
+ */
+const DISTANCE_SIGMA_FRACTION = 0.25;
 
 /**
  * Fraction of the band width over which the lip's shading eases back to the flat
@@ -378,47 +386,54 @@ const HARD_EDGE_SHELF_FRACTION = 0.5;
  * `bandMask` (W·H of 0/1; 1 where the pixel is inside the shape and within the
  * bevel band, i.e. where shading should be applied).
  *
- * ## Scale-invariant azimuth (this redesign — issue lineage #410→#413→#415→here)
+ * ## Distance-gradient azimuth (issue lineage #410→#413→#415→#416→#417→#418)
  *
- * The lip normal has two parts that we derive from two INDEPENDENT, decoupled
- * sources so each is correct on its own terms:
+ * The lip normal has two parts derived from two INDEPENDENT sources so each is
+ * correct on its own terms, BOTH ultimately grounded in the exact EDT distance:
  *
  *   • TILT MAGNITUDE (how steeply the lip rises) — from the cross-section profile's
  *     local slope at the EXACT EDT distance `d`. Distance is the geometrically
  *     meaningful quantity for the height (a `circle` lip at d=band/2 is at a precise
- *     height), and the EDT gives it exactly. This is what the PDF-calibrated slide-3
- *     brightness curve depends on, so it is preserved bit-for-bit in spirit.
+ *     height), and the EDT gives it exactly. The PDF-calibrated slide-3 brightness
+ *     curve depends on this, so it is preserved.
  *
- *   • IN-PLANE AZIMUTH (which way the lip faces) — from the gradient of a Gaussian-
- *     blurred COVERAGE field `C = G_σ * alpha`, σ = 0.25·bandPx. This is the load-
- *     bearing change. `∇C = (∇G_σ) * alpha` is a convolution with the smooth kernel
- *     ∇G_σ, so C ∈ C^∞ regardless of how the silhouette was rasterised: the azimuth
- *     field rotates continuously around any smooth boundary, with a per-step turn
- *     bounded only by the silhouette's curvature. Because σ scales with the band and
- *     the geometry scales with devScale TOGETHER, the smoothness is identical at
- *     every raster scale — it is scale-invariant by construction.
+ *   • IN-PLANE AZIMUTH (which way the lip faces) — from −∇C where C is the EDT
+ *     distance itself, Gaussian-blurred by σ = 0.25·bandPx. The distance field's
+ *     level sets ARE the silhouette's offset curves, so −∇C is the true outward
+ *     radial normal everywhere; the blur is a smooth (C^∞) convolution, so the
+ *     direction rotates continuously and is scale-invariant (σ and the geometry
+ *     scale with devScale together).
  *
- * ### Why this finally fixes the size-dependent facet (and the patches didn't)
+ * ### Why each prior fix was insufficient (the history this comment preserves)
  *
- * The OLD method took BOTH parts from the finite-difference gradient of the EDT
- * height field. But ∇(distance-to-point-set) is piecewise-constant: each band
- * pixel's nearest boundary sample dominates, so the gradient DIRECTION snaps to
- * that sample's Voronoi-cell direction, chording the lip into facets. The screen-
- * blend highlight amplifies the chord at the lit/shadow terminator. Both prior
- * fixes were post-filters on that same broken field:
- *   - #413: box-blur the scalar height → smooths gradient MAGNITUDE, not direction
- *     (fixed devScale ≤ 2 only).
- *   - #415: tangential low-pass of the normal VECTOR over radius 0.25·bandPx, gated
- *     at bandPx ≥ 24 → fixed devScale 4, REGRESSED at devScale 8.
- * Every band-proportional blur radius chases a moving target: the Voronoi cell's
- * angular width depends on radial distance from the rim, which grows with the band,
- * so a large enough band always re-opens the chord. Sourcing the azimuth from ∇C
- * removes the Voronoi structure at the SOURCE — there is no discrete cell field
- * left to facet — so no gate and no post-blur are needed at any scale.
+ *  - #410 (first bevel): azimuth from the 1px finite-difference gradient of the EDT
+ *    HEIGHT field. ∇(distance-to-point-set) is piecewise-constant — each band pixel's
+ *    nearest boundary sample dominates, so the direction snaps to that sample's
+ *    Voronoi-cell direction and chords the lip into facets (worse as the shape grows).
+ *  - #413: box-blurred the scalar HEIGHT → smoothed gradient MAGNITUDE, not
+ *    direction. Fixed devScale ≤ 2 only.
+ *  - #415: tangential low-pass of the normal VECTOR (radius 0.25·band, gated ≥24px).
+ *    Fixed devScale 4, REGRESSED at devScale 8 — every band-proportional post-blur
+ *    chases a Voronoi cell whose angular width grows with the band.
+ *  - #416: moved the azimuth source to −∇(blurred COVERAGE) `G_σ * alpha`. This
+ *    killed the Voronoi facets (no discrete cell field left) and the scale sweep
+ *    went green — BUT coverage FLAT-TOPS at a high-curvature convex apex: the blur
+ *    of a sharply curved tip plateaus, so ∇C there is near-constant over a wide
+ *    angular span. The azimuth rotated TOO SLOWLY across the apex → the lit factor
+ *    went flat → the "flat horizontal cut" at the top of the slide-6 ellipse. The
+ *    ring/ellipse scale-sweep (a JUMP detector) never caught it because a plateau is
+ *    a SMOOTH error, not a jump.
+ *  - #417: corrected the `hardEdge` profile (rim shelf) and added the inner-crease
+ *    feather. Necessary for the band GEOMETRY, but orthogonal to the azimuth — the
+ *    flat cut persisted because its cause was the coverage plateau, not the profile.
+ *  - #418 (this): source the azimuth from −∇(blurred DISTANCE). Distance does NOT
+ *    plateau (it grows linearly inward with the same radial direction at the apex),
+ *    so the lit factor follows the true elliptical curve; the blur still removes the
+ *    raw-EDT Voronoi facets, keeping the scale-sweep green. One field, both
+ *    pathologies gone.
  *
- * The coverage blur is O(N) (three cascaded box passes, running-sum, independent of
- * σ), runs once per bevel on the device offscreen — the same order as the EDT it
- * sits beside, and cheaper than the two post-filter passes it replaces.
+ * The distance blur is O(N) (three cascaded box passes, running-sum, independent of
+ * σ), runs once per bevel on the device offscreen — same order as the EDT beside it.
  */
 export function computeBevelNormals(
   alpha: ArrayLike<number>,
@@ -447,16 +462,29 @@ export function computeBevelNormals(
   const heightScale = bandPx > 0 ? heightPx / bandPx : 0;
   const tiltScale = heightScale * bandPx;
 
-  // ── Azimuth source: gradient of a Gaussian-blurred coverage field ──────────
-  // Blur the raw coverage (alpha/255) by σ ∝ band. σ is a quarter of the band: a
-  // fraction of the bevel's OWN length scale, large enough to wash out the per-
-  // pixel Voronoi noise yet small enough to stay local to a single rim (a larger σ
-  // would blur the inner and outer rims of a thin ring together and flip the
-  // azimuth at the medial axis). See COVERAGE_SIGMA_FRACTION.
-  const coverage = new Float64Array(w * h);
-  for (let i = 0; i < w * h; i++) coverage[i] = (alpha[i] ?? 0) / 255;
-  const sigma = Math.max(1, bandPx * COVERAGE_SIGMA_FRACTION);
-  const C = gaussianBlur(coverage, w, h, sigma);
+  // ── Azimuth source: gradient of a Gaussian-blurred EXACT DISTANCE field ─────
+  // The lip azimuth is the silhouette's outward normal. We read it from ∇C where C
+  // is the EDT distance `dist` smoothed by σ = 0.25·band (a fraction of the bevel's
+  // own length scale). Two pathologies are avoided BY CONSTRUCTION:
+  //   • Voronoi facets (raw ∇dist): the EDT's nearest-seed direction is piecewise
+  //     constant, so a 1px finite difference of the bare distance snaps to facet
+  //     directions. The blur is a smooth (C^∞) convolution, so ∇C rotates
+  //     continuously around the rim — no facets at any raster scale.
+  //   • Apex plateau (∇ of blurred COVERAGE, the #416 design): coverage `G_σ*alpha`
+  //     FLAT-TOPS at a high-curvature convex apex, so its gradient points near-
+  //     constant over a wide angular span there and the lit factor goes flat — the
+  //     "flat horizontal cut" users reported at the top of the slide-6 ellipse. The
+  //     DISTANCE field does NOT plateau: its level sets are the silhouette's offset
+  //     curves, so it keeps growing linearly inward with the SAME radial direction
+  //     everywhere, apex included. Blurring distance therefore preserves the true
+  //     normal direction while only removing the per-pixel quantisation.
+  // σ stays local to a single rim (a larger σ would blur a thin ring's inner and
+  // outer rims together and flip the azimuth at the medial axis). The spatial
+  // STRUCTURE of the shading (band membership, the inner-crease feather, the tilt
+  // magnitude) is taken from the exact `dist` below; only the DIRECTION uses C.
+  // See DISTANCE_SIGMA_FRACTION.
+  const sigma = Math.max(1, bandPx * DISTANCE_SIGMA_FRACTION);
+  const C = gaussianBlur(dist, w, h, sigma);
 
   // Local profile slope dh/dd at distance d (per px), via a centred 1px difference
   // of the profile. Drives the lip's tilt magnitude; the height stays distance-exact.
@@ -492,8 +520,10 @@ export function computeBevelNormals(
         weight = 1 - u * u * (3 - 2 * u); // 1→0 smoothstep
       }
       bandWeight[i] = weight;
-      // Outward azimuth = −∇C/|∇C| (coverage decreases toward the rim, so the
-      // negative gradient points outward, along the silhouette's outward normal).
+      // Outward azimuth = −∇C/|∇C|. C is the blurred DISTANCE, which DECREASES
+      // toward the rim (distance 0 at the boundary), so −∇C points outward along
+      // the silhouette's outward normal — the same sign the blurred-coverage field
+      // used (coverage also decreases outward), so only the SOURCE of C changed.
       const xl = x > 0 ? x - 1 : x;
       const xr = x < w - 1 ? x + 1 : x;
       const yu = y > 0 ? y - 1 : y;


### PR DESCRIPTION
## Problem

Sixth and final pass on the pptx 3D bevel lip (#410 → #413 → #415 → #416 → #417 → this). The slide-6 ellipse rendered with a **flat horizontal cut** at the photo↔ring junction at the apex when the bevel was ON; bevel OFF is a smooth elliptical arc (confirmed by ablation).

## Root cause

#416 sourced the lip **azimuth** from `−∇C` where `C = G_σ * alpha` (Gaussian-blurred COVERAGE). Coverage **plateaus** at a high-curvature convex apex — the blur of a sharply curved silhouette tip flat-tops, so `∇C` there points near-constant over a wide angular span. The lip azimuth rotates too slowly across the apex → the lit factor goes flat → the visible flat-topped band.

This is a *smooth* error (a plateau), which is precisely why the existing ring/ellipse scale-sweep — a *jump* detector — never caught it. The geometry (`dist`, the band, the inner feather from #417) was always correct; only the direction was wrong.

## Fix

Take the azimuth from `−∇C` where `C` is the **EXACT EDT distance field**, blurred by the same σ = 0.25·band. The distance field's level sets are the silhouette's offset curves, so `−∇dist` is the true outward radial normal **everywhere** — at the apex it keeps growing linearly inward with the same direction and does **not** plateau. Blurring distance (not coverage) keeps the gradient C¹ and removes the raw-EDT Voronoi facets (#410) without reintroducing a plateau. The shading's spatial structure (band membership, feather, tilt magnitude) still comes from the exact `dist`; only the direction uses the blurred copy.

The `#410→#418` lineage and why each prior fix was insufficient is preserved in the file header + `computeBevelNormals` doc for re-visitors.

## Acceptance

**Unit (devScale {1,2,4}, slide-6 ellipse proportions):** new `bevel lip azimuth tracks the TRUE silhouette normal` suite —
- apex azimuth vs analytic ellipse normal < 6° (was a 15–25° plateau with ∇C);
- apex lit factor is PEAKED, not flat: `lit(apex) − lit(±0.45·rx) > 0.015` each side (the plateau bug made them equal).

Existing scale-sweep retained; `LUM_2ND_DIFF_MAX` 0.005 → 0.006 (the devScale-1 32px-band ring sits at 0.00502 with the distance gradient — pixel-quantisation floor, ~25× below the raw-EDT facet of 0.12–0.24; all scales ≥2 are ≤0.0015).

**Rendered (real pipeline, sample-11 slide 6 @ devScale 3):** apex flat-cut gone — photo fills to a thin even rim along the smooth arc, matching PDF p6. Slide 3 (`circle` bevel, PDF p3 calibration) unchanged (0.020% pixels differ).

## Test status

- `pnpm test`: 356 passed
- `npx tsc --build`: clean
- demo VRT (`demo/sample-1`, the only committed-reference set): 9/9 under threshold. `private/sample-*` VRT 404 locally (not redistributable, per CLAUDE.md) — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)