### PR TITLE
fix(pptx): bevel/scene3d offscreen clips centre-aligned borders (slide-6 ring cut)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,7 +76,7 @@ export {
   type Scene3dQuad,
   type Vec2,
 } from './shape/scene3d-camera';
-export { drawProjected } from './shape/scene3d-draw';
+export { drawProjected, expandProjectedQuad } from './shape/scene3d-draw';
 // DrawingML 3D bevel shading (Phase B). ECMA-376 §20.1.5.12 (sp3d) /
 // §20.1.5.3 (bevel) / §20.1.10.9 (ST_BevelPresetType) / §20.1.5.9 (lightRig).
 export {

--- a/packages/core/src/shape/scene3d-draw.ts
+++ b/packages/core/src/shape/scene3d-draw.ts
@@ -388,6 +388,46 @@ function affineScale(m: Affine): number {
   return Math.sqrt(Math.abs(m[0] * m[3] - m[1] * m[2])) || 1;
 }
 
+/**
+ * Extrapolate a projected quad outward through the SAME projective map that
+ * produced it. `corners` is the image of the unit square (TL,TR,BR,BL order, as
+ * returned by `computeScene3dQuad`); the result is the image of the rectangle
+ * [-fx, 1+fx] × [-fy, 1+fy] under that homography.
+ *
+ * Used to grow a shape's offscreen by an edge margin (for the centre-aligned
+ * border's outer half, the outside-aligned contour, and the extrusion sweep —
+ * all of which extend past the shape's bounding box) WITHOUT re-deriving the
+ * camera quad at the padded size: `computeScene3dQuad` re-fits its projection
+ * to the box it is given, so calling it with a padded box would change the
+ * geometry instead of just extending it. Extrapolating the existing quad keeps
+ * the body's projection bit-identical and maps the margin consistently.
+ *
+ * Returns null when the quad is degenerate or the extrapolated corner would
+ * cross the projection horizon (homography denominator ≤ 0) — callers should
+ * then fall back to the unpadded quad.
+ */
+export function expandProjectedQuad(
+  corners: [Vec2, Vec2, Vec2, Vec2],
+  fx: number,
+  fy: number,
+): [Vec2, Vec2, Vec2, Vec2] | null {
+  const h = unitSquareToQuad(corners[0], corners[1], corners[2], corners[3]);
+  if (!h) return null;
+  const uv: Array<[number, number]> = [
+    [-fx, -fy],
+    [1 + fx, -fy],
+    [1 + fx, 1 + fy],
+    [-fx, 1 + fy],
+  ];
+  const out: Vec2[] = [];
+  for (const [u, v] of uv) {
+    const w = h[6] * u + h[7] * v + h[8];
+    if (!(w > 1e-9)) return null;
+    out.push(applyH(h, u, v));
+  }
+  return out as [Vec2, Vec2, Vec2, Vec2];
+}
+
 let fallbackWarned = false;
 /**
  * Warn (once per process) that scene3d warp fell back to the non-supersampled

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -40,6 +40,7 @@ import {
   computeScene3dQuad,
   isScene3dNonIdentity,
   drawProjected,
+  expandProjectedQuad,
   createAuxCanvas,
   applyBevelShading,
   applyExtrusion,
@@ -1193,7 +1194,18 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
         // No onTextRun → the projected text is not selectable (see the note).
         renderShape(octx, localEl, scale, themeDefaultColor, slideNumber, rc, undefined);
       },
-      { bevels, extrusion: extrusion ?? undefined },
+      {
+        bevels,
+        extrusion: extrusion ?? undefined,
+        // Edge margin so the centre-aligned stroke's outer half and the
+        // extrusion sweep aren't clipped by the box-sized offscreen (see
+        // Project3dOpts.edgePadCss).
+        edgePadCss:
+          (el.stroke ? (el.stroke.width * scale) / 2 : 0) +
+          (el.sp3d?.contourW ? el.sp3d.contourW * scale : 0) +
+          (extrusion ? Math.hypot(extrusion.offsetX, extrusion.offsetY) / ctxDevScale : 0) +
+          2,
+      },
     );
     if (ok) {
       ctx.restore();
@@ -2367,12 +2379,26 @@ interface Project3dOpts {
   /** Extrusion side-wall to bake in before the bevel (§20.1.5.12 extrusionH). */
   extrusion?: ExtrusionInput;
   /**
-   * Paint edges (a:ln border + sp3d contour) into the offscreen AFTER the bevel
-   * shading but in the same local rect. Kept separate from `paintBody` so the
-   * bevel reads the body silhouette's alpha without the outside-aligned contour
-   * stroke contaminating the distance transform.
+   * Paint edges that sit OUTSIDE the beveled front face (the sp3d contour, an
+   * outside-aligned rim of the extruded side edge) into the offscreen AFTER the
+   * bevel shading, in the same local rect. The a:ln border belongs to the front
+   * face itself — PowerPoint's bevel lights the framed picture as one surface —
+   * so the border is painted inside `paintBody`, BEFORE the bevel, and only the
+   * contour goes here (it must not contaminate the lip's distance transform).
    */
   paintEdges?: (octx: CanvasRenderingContext2D, ox: number, oy: number, ow: number, oh: number) => void;
+  /**
+   * Margin (CSS px) added on every side of the offscreen around the shape's
+   * w×h box. The box alone CLIPS everything a shape legitimately paints past
+   * it: the outer half of the centre-aligned a:ln border, the outside-aligned
+   * contour, and the extrusion sweep. For a silhouette that touches its box
+   * (an inscribed ellipse touches it at all four apices) that clip cuts the
+   * rim along the straight box edge — the "sliced ellipse" slide-6 bug. The
+   * margin also keeps the silhouette away from the offscreen border so the
+   * bevel's distance transform (which treats out-of-bounds as background)
+   * measures the true silhouette distance instead of the canvas edge.
+   */
+  edgePadCss?: number;
 }
 
 function projectScene3dPaint(
@@ -2391,16 +2417,34 @@ function projectScene3dPaint(
   const tf = target.getTransform();
   const det = Math.abs(tf.a * tf.d - tf.b * tf.c);
   const devScale = det > 0 ? Math.sqrt(det) : 1;
-  const ow = Math.max(1, Math.ceil(w * devScale));
-  const oh = Math.max(1, Math.ceil(h * devScale));
+
+  // Edge margin (see Project3dOpts.edgePadCss). Quantised to whole device px so
+  // the body lands on the same pixel grid as the unpadded layout, then mapped
+  // onto the destination by extrapolating the camera quad through its own
+  // homography (computeScene3dQuad re-fits to the box it is given, so it must
+  // NOT be called with the padded size). Degenerate extrapolation → pad 0.
+  let padDev = Math.max(0, Math.ceil((opts.edgePadCss ?? 0) * devScale));
+  const quad = computeScene3dQuad(camera, w, h);
+  let quadCorners = quad.corners;
+  if (padDev > 0) {
+    const padCss = padDev / devScale;
+    const expanded = expandProjectedQuad(quad.corners, padCss / w, padCss / h);
+    if (expanded) quadCorners = expanded;
+    else padDev = 0;
+  }
+  const padCss = padDev / devScale;
+
+  const ow = Math.max(1, Math.ceil(w * devScale) + 2 * padDev);
+  const oh = Math.max(1, Math.ceil(h * devScale) + 2 * padDev);
   const aux = createAuxCanvas(ow, oh);
   if (!aux) return false;
   const octx = aux.getContext('2d') as CanvasRenderingContext2D | null;
   if (!octx) return false;
 
-  // Paint the body into the offscreen with the origin at (0,0); scale device px.
+  // Paint the body into the offscreen with the origin at (pad,pad); device px.
   octx.save();
   octx.scale(devScale, devScale);
+  octx.translate(padCss, padCss);
   paintBody(octx, 0, 0, w, h);
   octx.restore();
 
@@ -2414,17 +2458,19 @@ function projectScene3dPaint(
     for (const bevel of opts.bevels) applyBevelShading(octx, bevel);
   }
 
-  // Edges (border + contour) on top of the beveled body, still pre-projection.
+  // Post-bevel edges (the contour rim) on top of the beveled body, still
+  // pre-projection. The a:ln border is painted inside paintBody (see
+  // Project3dOpts.paintEdges).
   if (opts.paintEdges) {
     octx.save();
     octx.scale(devScale, devScale);
+    octx.translate(padCss, padCss);
     opts.paintEdges(octx, 0, 0, w, h);
     octx.restore();
   }
 
-  // Project the w×h box and offset the quad to the element's (x,y).
-  const quad = computeScene3dQuad(camera, w, h);
-  const corners = quad.corners.map((c) => ({ x: x + c.x, y: y + c.y })) as [
+  // Offset the (possibly pad-expanded) quad to the element's (x,y).
+  const corners = quadCorners.map((c) => ({ x: x + c.x, y: y + c.y })) as [
     Vec2,
     Vec2,
     Vec2,
@@ -2439,8 +2485,16 @@ function projectScene3dPaint(
 /**
  * Bake bevel shading + edges into a body that is NOT camera-projected (identity
  * camera, e.g. orthographicFront). Renders the body to a device-px offscreen,
- * shades the bevel, paints the edges, then blits the offscreen back at (x,y).
- * Falls back to false (caller paints flat) when no offscreen is available.
+ * shades the bevel, paints the post-bevel edges (contour), then blits the
+ * offscreen back at (x,y). Falls back to false (caller paints flat) when no
+ * offscreen is available.
+ *
+ * `edgePadCss` grows the offscreen by a margin on every side (same rationale
+ * as Project3dOpts.edgePadCss): without it the box-sized offscreen clips the
+ * outer half of the centre-aligned border wherever the silhouette touches its
+ * bounding box, and the bevel's distance transform reads the offscreen border
+ * as the silhouette edge there — both showed up as the straight-cut rim on the
+ * slide-6 ellipse apices.
  */
 function paintBeveledFlat(
   target: CanvasRenderingContext2D,
@@ -2451,13 +2505,17 @@ function paintBeveledFlat(
   bevels: BevelInput[],
   paintBody: (octx: CanvasRenderingContext2D, ox: number, oy: number, ow: number, oh: number) => void,
   paintEdges?: (octx: CanvasRenderingContext2D, ox: number, oy: number, ow: number, oh: number) => void,
+  edgePadCss = 0,
 ): boolean {
   if (w <= 0 || h <= 0 || bevels.length === 0) return false;
   const tf = target.getTransform();
   const det = Math.abs(tf.a * tf.d - tf.b * tf.c);
   const devScale = det > 0 ? Math.sqrt(det) : 1;
-  const ow = Math.max(1, Math.ceil(w * devScale));
-  const oh = Math.max(1, Math.ceil(h * devScale));
+  // Whole-device-px margin so the body stays on the unpadded pixel grid.
+  const padDev = Math.max(0, Math.ceil(edgePadCss * devScale));
+  const padCss = padDev / devScale;
+  const ow = Math.max(1, Math.ceil(w * devScale) + 2 * padDev);
+  const oh = Math.max(1, Math.ceil(h * devScale) + 2 * padDev);
   const aux = createAuxCanvas(ow, oh);
   if (!aux) return false;
   const octx = aux.getContext('2d') as CanvasRenderingContext2D | null;
@@ -2465,17 +2523,26 @@ function paintBeveledFlat(
 
   octx.save();
   octx.scale(devScale, devScale);
+  octx.translate(padCss, padCss);
   paintBody(octx, 0, 0, w, h);
   octx.restore();
   for (const bevel of bevels) applyBevelShading(octx, bevel);
   if (paintEdges) {
     octx.save();
     octx.scale(devScale, devScale);
+    octx.translate(padCss, padCss);
     paintEdges(octx, 0, 0, w, h);
     octx.restore();
   }
-  // Blit the device-px offscreen back into target's CSS-px space at (x,y).
-  target.drawImage(aux as unknown as CanvasImageSource, x, y, w, h);
+  // Blit the device-px offscreen back into target's CSS-px space, 1:1 in
+  // device pixels, with the margin hanging past (x,y) on every side.
+  target.drawImage(
+    aux as unknown as CanvasImageSource,
+    x - padCss,
+    y - padCss,
+    ow / devScale,
+    oh / devScale,
+  );
   return true;
 }
 
@@ -2619,16 +2686,24 @@ async function renderPicture(
     // homography and effectLst (reflection / soft edge) re-paints them too —
     // matching PowerPoint, which applies the 3D transform and effects to the
     // framed picture as a whole.
-    const strokePictureEdges = (
+    //
+    // The two edges are split because they sit on OPPOSITE sides of the bevel
+    // shading: the a:ln border is part of the FRONT FACE (PowerPoint's bevel
+    // lip lights the framed picture as one surface — sample-11.pdf p6 shows
+    // the lit shelf and dark rim crease ON the beige border), so it is painted
+    // before applyBevelShading; the contour approximates the extruded side
+    // edge OUTSIDE the front face and must stay out of the lip's distance
+    // transform, so it is painted after.
+    const strokeLnBorder = (
       target: CanvasRenderingContext2D,
       ox: number,
       oy: number,
       ow: number,
       oh: number,
     ): void => {
-      // 1) a:ln picture border (ECMA-376 §20.1.2.2.24). Centre-aligned stroke,
-      //    the Canvas default — PowerPoint draws the picture frame straddling
-      //    the silhouette edge.
+      // a:ln picture border (ECMA-376 §20.1.2.2.24). Centre-aligned stroke,
+      // the Canvas default — PowerPoint draws the picture frame straddling
+      // the silhouette edge.
       if (el.stroke) {
         target.save();
         applyStroke(target, el.stroke, scale);
@@ -2636,7 +2711,15 @@ async function renderPicture(
         target.stroke();
         target.restore();
       }
-      // 2) sp3d contour edge (ECMA-376 §20.1.5.12 `contourW` / `<a:contourClr>`).
+    };
+    const strokeContourEdge = (
+      target: CanvasRenderingContext2D,
+      ox: number,
+      oy: number,
+      ow: number,
+      oh: number,
+    ): void => {
+      // sp3d contour edge (ECMA-376 §20.1.5.12 `contourW` / `<a:contourClr>`).
       //    The spec's contour is the extruded 3D edge surface lit by the scene's
       //    light rig. We draw a FLAT approximation: a uniform-width outline in
       //    the contour colour, with no per-edge light-rig response. (The bevel
@@ -2674,7 +2757,7 @@ async function renderPicture(
     // camera actually transforms the shape; identity/front cameras fall through
     // to the normal flat draw (but sp3d bevel/extrusion still apply via the flat
     // path below). sp3d bevel/extrusion shading is wired in just after this; the
-    // contour edge is the flat approximation in strokePictureEdges.
+    // contour edge is the flat approximation in strokeContourEdge.
     const scene3d = el.scene3d && isScene3dNonIdentity(el.scene3d.camera) ? el.scene3d : null;
 
     // Paint JUST the (clipped, optionally cropped) bitmap body at a local rect —
@@ -2709,7 +2792,23 @@ async function renderPicture(
       oh: number,
     ): void => {
       paintBitmapBodyAt(target, ox, oy, ow, oh);
-      strokePictureEdges(target, ox, oy, ow, oh);
+      strokeLnBorder(target, ox, oy, ow, oh);
+      strokeContourEdge(target, ox, oy, ow, oh);
+    };
+
+    // Front face for the bevel paths: the clipped bitmap PLUS its a:ln border.
+    // The bevel's distance transform then starts at the border's outer edge and
+    // its lit/shadowed lip shades the border itself, matching PowerPoint (and
+    // the p:sp path, whose recursive body render also includes the stroke).
+    const paintFaceAt = (
+      target: CanvasRenderingContext2D,
+      ox: number,
+      oy: number,
+      ow: number,
+      oh: number,
+    ): void => {
+      paintBitmapBodyAt(target, ox, oy, ow, oh);
+      strokeLnBorder(target, ox, oy, ow, oh);
     };
 
     // ── sp3d bevel (ECMA-376 §20.1.5.12 bevelT/bevelB, Phase B). Device-px lip
@@ -2733,6 +2832,18 @@ async function renderPicture(
       ? buildExtrusion(el.sp3d as Sp3dLike | undefined, scene3d.camera, w, h, scale, ctxDevScale)
       : null;
 
+    // Offscreen edge margin (CSS px) for the bevel/scene3d paths: everything a
+    // picture legitimately paints OUTSIDE its w×h box. Half the centre-aligned
+    // border, the outside-aligned contour, the extrusion's screen sweep, plus
+    // 2 px so the silhouette's antialiasing never touches the offscreen border
+    // (the bevel EDT treats that border as background). See edgePadCss docs.
+    const strokeHalfCss = el.stroke ? (el.stroke.width * scale) / 2 : 0;
+    const contourCss = el.sp3d?.contourW ? el.sp3d.contourW * scale : 0;
+    const extrusionCss = extrusion
+      ? Math.hypot(extrusion.offsetX, extrusion.offsetY) / ctxDevScale
+      : 0;
+    const edgePadCss = strokeHalfCss + contourCss + extrusionCss + 2;
+
     // Draw the (clipped, optionally cropped) bitmap into a target context. This
     // is the picture "body" that the effect helpers re-paint onto aux canvases,
     // so reflections/soft edges mirror the real image rather than a flat shape.
@@ -2743,15 +2854,26 @@ async function renderPicture(
     // camera) so it tracks the silhouette and the projection.
     const paintImage = (target: CanvasRenderingContext2D): void => {
       if (scene3d) {
-        const ok = projectScene3dPaint(target, scene3d.camera, x, y, w, h, paintBitmapBodyAt, {
+        const ok = projectScene3dPaint(target, scene3d.camera, x, y, w, h, paintFaceAt, {
           bevels,
           extrusion: extrusion ?? undefined,
-          paintEdges: strokePictureEdges,
+          paintEdges: strokeContourEdge,
+          edgePadCss,
         });
         if (ok) return;
         // Headless fallback: draw flat (no bevel).
       } else if (bevels.length > 0) {
-        const ok = paintBeveledFlat(target, x, y, w, h, bevels, paintBitmapBodyAt, strokePictureEdges);
+        const ok = paintBeveledFlat(
+          target,
+          x,
+          y,
+          w,
+          h,
+          bevels,
+          paintFaceAt,
+          strokeContourEdge,
+          edgePadCss,
+        );
         if (ok) return;
       }
       paintImageAt(target, x, y, w, h);

--- a/packages/pptx/tests/visual/bevel-ring.spec.ts
+++ b/packages/pptx/tests/visual/bevel-ring.spec.ts
@@ -8,141 +8,201 @@ import { dirname, join } from 'node:path';
  * tilted-ellipse photo with a 15 pt a:ln beige border, bevelT hardEdge,
  * extrusionH and outerShdw under a perspectiveFront camera).
  *
- * History: across sessions the ellipse rim regressed into a "white band" — a
- * pure-white stripe sitting in the outer half of the ring, making the
- * silhouette read as cut off against the white slide. The merged bevel
- * band-geometry / lip-azimuth PRs cured it; this spec LOCKS the cure in.
+ * History: across sessions the ellipse rim regressed into a "cut" look — the
+ * outer part of the ring went missing at the four apices, so the silhouette
+ * read as sliced off by straight lines against the white slide. Root cause:
+ * `paintBeveledFlat` / `projectScene3dPaint` rasterised the body + edges into
+ * an offscreen EXACTLY the size of the shape's bounding box, so the outer half
+ * of the centre-aligned 15 pt border (and the bevel band's shading near the
+ * box edge) was clipped wherever the ellipse touches its box — i.e. at every
+ * apex. The defect exists at every scale but its pixel size grows with the
+ * render scale, which is why small-canvas verifications kept missing it.
  *
- * Ground truth (sample-11.pdf p6): the ring is a CONTINUOUS pale-beige band on
- * every apex — a soft outer shadow outside it, then opaque beige, then the
- * photo, with NO white interruption and no saturated-white lit lip.
+ * Ground truth (sample-11.pdf p6): the ring is a CONTINUOUS pale-beige band of
+ * the FULL border width on every apex — a soft outer shadow outside it, then
+ * the bevel-lit beige band straddling the silhouette, then the photo, with NO
+ * white interruption, no straight cut, and no saturated-white lit lip.
  *
  * The .pptx is private (never committed). Like the other private-sample specs
  * this one SKIPS when the fixture is absent so a clean checkout stays green.
  * It asserts pixel structure from the live canvas, not a reference image.
+ *
+ * The check runs at several render scales (width × deviceScaleFactor) because
+ * the original regression was scale-dependent in visibility: dpr1/1280 hides a
+ * 10 px loss inside the shadow falloff, dpr2 makes it a visible cut.
  */
+
+const SAMPLE = 'private/sample-11';
+const SLIDE_INDEX = 5; // PDF p6, 0-based
+
+// EMU geometry of the deck (ppt/presentation.xml sldSz) and the ring border
+// (slide6.xml a:ln w="190500" = 15 pt). Used to derive the expected band width
+// in device px at each scale.
+const SLIDE_W_EMU = 12192000;
+const STROKE_W_EMU = 190500;
+
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'public',
+  `${SAMPLE}.pptx`,
+);
+
+/** width = viewer render width (CSS px), dpr = deviceScaleFactor. */
+const SCALES: Array<{ width: number; dpr: number }> = [
+  { width: 1280, dpr: 1 }, // the VRT default
+  { width: 1280, dpr: 2 }, // HiDPI at the same layout width
+  { width: 960, dpr: 2 },  // the Storybook card scale the user reproduced at
+];
+
 test.describe('pptx slide-6 sp3d bevel ring', () => {
-  const SAMPLE = 'private/sample-11';
-  const SLIDE_INDEX = 5; // PDF p6, 0-based
+  for (const { width, dpr } of SCALES) {
+    test(`full-width continuous beige band on every apex (width=${width}, dpr=${dpr})`, async ({
+      browser,
+    }, testInfo) => {
+      testInfo.skip(!existsSync(fixturePath), `${SAMPLE}.pptx not present (private sample)`);
 
-  const fixturePath = join(
-    dirname(fileURLToPath(import.meta.url)),
-    '..',
-    '..',
-    'public',
-    `${SAMPLE}.pptx`,
-  );
-
-  test('the ring is a continuous beige band on every apex — no white cut, no blown lit lip', async ({
-    page,
-  }, testInfo) => {
-    testInfo.skip(!existsSync(fixturePath), `${SAMPLE}.pptx not present (private sample)`);
-
-    await page.goto(`/tests/visual/fixture.html?pptx=${SAMPLE}&slide=${SLIDE_INDEX}`);
-    await page.waitForFunction(
-      () =>
-        document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
-      { timeout: 30_000 },
-    );
-    const status = await page.evaluate(() => document.body.dataset.status);
-    if (status === 'error') {
-      const msg = await page.evaluate(() => document.body.dataset.errorMessage ?? '');
-      throw new Error(`Fixture error: ${msg}`);
-    }
-    await page.waitForTimeout(200);
-
-    // Sample the four apex cross-sections off the live canvas and classify each
-    // ray's pixels into page-white / beige-rim / photo. The acceptance
-    // contract: walking from the page into the photo we cross a CONTINUOUS
-    // beige run wide enough to read as the ring with ZERO white pixels in the
-    // rim region, and the rim never saturates (luma < 250).
-    //
-    // The ring is the 15 pt = 190500 EMU centre-aligned a:ln border (the bevel
-    // lip sits under it). After antialiasing toward the photo and the outer
-    // shadow the PURE-beige run measures ~11 device px at deviceScaleFactor 1
-    // (cw 1280) and ~40 px at dpr 2; sample-11.pdf p6 rasterised to matching
-    // width shows the same band. The floor is DPR-aware (fraction of canvas
-    // width) with an 8 px absolute minimum — low enough to tolerate the AA at
-    // these narrow apices, high enough to fail hard if the ring collapses to a
-    // thin line or is split by a white stripe (the regression we guard).
-    const result = await page.evaluate(() => {
-      const canvas = document.querySelector('canvas') as HTMLCanvasElement;
-      const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-      const cw = canvas.width;
-      const ch = canvas.height;
-      const minRim = Math.max(8, Math.round(cw * 0.006));
-      const D = ctx.getImageData(0, 0, cw, ch).data;
-      const at = (x: number, y: number): [number, number, number] => {
-        const o = (Math.round(y) * cw + Math.round(x)) * 4;
-        return [D[o], D[o + 1], D[o + 2]];
-      };
-      const isWhite = (r: number, g: number, b: number) => r >= 250 && g >= 250 && b >= 250;
-      const isPhoto = (r: number, g: number, b: number) => b > 95 && b > r + 25 && b > g + 15;
-      const isBeige = (r: number, g: number, b: number) =>
-        r > 150 && g > 150 && b > 130 && Math.abs(r - g) < 30 && r > b && !isWhite(r, g, b);
-
-      function analyze(name: string, x0: number, y0: number, dx: number, dy: number) {
-        let x = x0;
-        let y = y0;
-        // Skip leading page white.
-        while (x >= 0 && y >= 0 && x < cw && y < ch) {
-          const [r, g, b] = at(x, y);
-          if (!isWhite(r, g, b)) break;
-          x += dx;
-          y += dy;
+      const context = await browser.newContext({
+        viewport: { width: 1400, height: 1100 },
+        deviceScaleFactor: dpr,
+      });
+      const page = await context.newPage();
+      try {
+        await page.goto(
+          `/tests/visual/fixture.html?pptx=${SAMPLE}&slide=${SLIDE_INDEX}&width=${width}`,
+        );
+        await page.waitForFunction(
+          () =>
+            document.body.dataset.status === 'ready' ||
+            document.body.dataset.status === 'error',
+          { timeout: 30_000 },
+        );
+        const status = await page.evaluate(() => document.body.dataset.status);
+        if (status === 'error') {
+          const msg = await page.evaluate(() => document.body.dataset.errorMessage ?? '');
+          throw new Error(`Fixture error: ${msg}`);
         }
-        // March through the rim until the photo, tracking white intrusions and
-        // the longest beige run + its brightest pixel.
-        let whiteInRim = 0;
-        let beigeRun = 0;
-        let bestBeigeRun = 0;
-        let beigeMax = 0;
-        for (let i = 0; i < Math.max(cw, ch); i++) {
-          if (x < 0 || y < 0 || x >= cw || y >= ch) break;
-          const [r, g, b] = at(x, y);
-          if (isPhoto(r, g, b)) break;
-          if (isWhite(r, g, b)) whiteInRim++;
-          if (isBeige(r, g, b)) {
-            beigeRun++;
-            bestBeigeRun = Math.max(bestBeigeRun, beigeRun);
-            beigeMax = Math.max(beigeMax, 0.299 * r + 0.587 * g + 0.114 * b);
-          } else {
-            beigeRun = 0;
-          }
-          x += dx;
-          y += dy;
+        await page.waitForTimeout(200);
+
+        // Sample the four apex cross-sections off the live canvas and classify
+        // each ray's pixels into page-white / warm-rim / photo. Acceptance
+        // contract, per the PDF ground truth:
+        //   1. ZERO white pixels inside the rim (no white cut band);
+        //   2. a CONTINUOUS warm-toned run of (almost) the FULL border width —
+        //      the centre-aligned 15 pt stroke must not lose its outer half to
+        //      the offscreen box clip at the apices;
+        //   3. the rim (including the bevel-lit lip) stays below page white.
+        //
+        // The rim classifier is HUE-based (warm: r ≥ b, near-neutral r vs g),
+        // not brightness-based: the bevel lip legitimately brightens the lit
+        // side and darkens the shadowed side of the beige border, and the
+        // exact shading level is a light-rig calibration concern (tracked
+        // separately — our threePt rig currently lacks the fill light and the
+        // <a:rot rev> rotation, so the bottom lip runs darker than the PDF).
+        // What this spec locks is the band's WIDTH and CONTINUITY, which is
+        // what the offscreen box clip destroyed.
+        //
+        // The floor is 0.8 × the border's device-px width: the missing ~0.2
+        // allows the antialiased blend into the outer shadow and the photo.
+        // The pre-fix renders measure ~0.5 × (half the band clipped), so the
+        // floor separates the two states with margin on both sides.
+        const result = await page.evaluate(
+          ({ slideWEmu, strokeWEmu }) => {
+            const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+            const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+            const cw = canvas.width;
+            const ch = canvas.height;
+            const strokePx = (strokeWEmu / slideWEmu) * cw;
+            const minRim = Math.max(8, Math.round(strokePx * 0.8));
+            const D = ctx.getImageData(0, 0, cw, ch).data;
+            const at = (x: number, y: number): [number, number, number] => {
+              const o = (Math.round(y) * cw + Math.round(x)) * 4;
+              return [D[o], D[o + 1], D[o + 2]];
+            };
+            const isWhite = (r: number, g: number, b: number) =>
+              r >= 250 && g >= 250 && b >= 250;
+            const isPhoto = (r: number, g: number, b: number) =>
+              b > 95 && b > r + 25 && b > g + 15;
+            // Warm rim tone: the C8C6BD border under any bevel lighting (lit
+            // ~+25% through shadowed ~-30%), excluding the page white, the
+            // neutral shadow greys (r === b) and the blue photo.
+            const isRim = (r: number, g: number, b: number) =>
+              r > 120 && g > 110 && b > 100 && Math.abs(r - g) < 30 && r > b && !isWhite(r, g, b);
+
+            function analyze(name: string, x0: number, y0: number, dx: number, dy: number) {
+              let x = x0;
+              let y = y0;
+              // Skip leading page white.
+              while (x >= 0 && y >= 0 && x < cw && y < ch) {
+                const [r, g, b] = at(x, y);
+                if (!isWhite(r, g, b)) break;
+                x += dx;
+                y += dy;
+              }
+              // March through the rim until the photo, tracking white
+              // intrusions and the longest beige run + its brightest pixel.
+              // The march is bounded to a few border-widths so a ray that
+              // enters dark photo content (the bottom caption) cannot wander
+              // deep into the bitmap and pick up unrelated beige runs.
+              let whiteInRim = 0;
+              let rimRun = 0;
+              let bestRimRun = 0;
+              let rimMax = 0;
+              const maxMarch = Math.ceil(strokePx * 6);
+              for (let i = 0; i < maxMarch; i++) {
+                if (x < 0 || y < 0 || x >= cw || y >= ch) break;
+                const [r, g, b] = at(x, y);
+                if (isPhoto(r, g, b)) break;
+                if (isWhite(r, g, b)) whiteInRim++;
+                if (isRim(r, g, b)) {
+                  rimRun++;
+                  bestRimRun = Math.max(bestRimRun, rimRun);
+                  rimMax = Math.max(rimMax, 0.299 * r + 0.587 * g + 0.114 * b);
+                } else {
+                  rimRun = 0;
+                }
+                x += dx;
+                y += dy;
+              }
+              return { name, whiteInRim, bestRimRun, rimMax: Math.round(rimMax) };
+            }
+
+            const cx = Math.round(cw / 2);
+            const cy = Math.round(ch / 2);
+            return {
+              minRim,
+              strokePx: Math.round(strokePx),
+              cw,
+              sections: [
+                analyze('TOP', cx, 0, 0, 1),
+                analyze('BOTTOM', cx, ch - 1, 0, -1),
+                analyze('LEFT', 0, cy, 1, 0),
+                analyze('RIGHT', cw - 1, cy, -1, 0),
+              ],
+            };
+          },
+          { slideWEmu: SLIDE_W_EMU, strokeWEmu: STROKE_W_EMU },
+        );
+
+        console.log(
+          `slide-6 ring (canvas ${result.cw}px, stroke ${result.strokePx}px, minRim ${result.minRim}px):`,
+          JSON.stringify(result.sections),
+        );
+        for (const r of result.sections) {
+          // 1) No white band inside the rim.
+          expect(r.whiteInRim, `${r.name}: white pixels inside the ring`).toBe(0);
+          // 2) A continuous beige band of (almost) the full border width.
+          expect(
+            r.bestRimRun,
+            `${r.name}: continuous beige run (>= ${result.minRim} of ${result.strokePx} device px)`,
+          ).toBeGreaterThanOrEqual(result.minRim);
+          // 3) The rim (incl. any lit lip) stays a clear step below page white.
+          expect(r.rimMax, `${r.name}: rim brightness must stay below white`).toBeLessThan(250);
         }
-        return { name, whiteInRim, bestBeigeRun, beigeMax: Math.round(beigeMax) };
+      } finally {
+        await context.close();
       }
-
-      const cx = Math.round(cw / 2);
-      const cy = Math.round(ch / 2);
-      return {
-        minRim,
-        cw,
-        sections: [
-          analyze('TOP', cx, 0, 0, 1),
-          analyze('BOTTOM', cx, ch - 1, 0, -1),
-          analyze('LEFT', 0, cy, 1, 0),
-          analyze('RIGHT', cw - 1, cy, -1, 0),
-        ],
-      };
     });
-
-    console.log(
-      `slide-6 ring (canvas ${result.cw}px, minRim ${result.minRim}px):`,
-      JSON.stringify(result.sections),
-    );
-    for (const r of result.sections) {
-      // 1) No white band inside the rim (this is the regression we guard).
-      expect(r.whiteInRim, `${r.name}: white pixels inside the ring`).toBe(0);
-      // 2) A continuous beige band wide enough to read as the ring.
-      expect(
-        r.bestBeigeRun,
-        `${r.name}: continuous beige run (>= ${result.minRim} device px)`,
-      ).toBeGreaterThanOrEqual(result.minRim);
-      // 3) The rim (incl. any lit lip) stays a clear step below page white.
-      expect(r.beigeMax, `${r.name}: rim brightness must stay below white`).toBeLessThan(250);
-    }
-  });
+  }
 });

--- a/packages/pptx/tests/visual/fixture.html
+++ b/packages/pptx/tests/visual/fixture.html
@@ -26,10 +26,13 @@
     const params   = new URLSearchParams(location.search);
     const slideIdx = Math.max(0, parseInt(params.get('slide') ?? '0', 10));
     const pptxName = params.get('pptx') ?? 'sample';
+    // Optional render width override (CSS px), e.g. ?width=960 — used by the
+    // scale-parameterised specs; the default matches the reference images.
+    const width    = Math.max(1, parseInt(params.get('width') ?? '1280', 10));
 
     const canvas = document.getElementById('canvas');
     const viewer = new PptxViewer(canvas, {
-      width: 1280,
+      width,
       onError: (err) => {
         document.body.dataset.status = 'error';
         document.body.dataset.errorMessage = err.message;


### PR DESCRIPTION
## Problem

`private/sample-11` slide 6 (ellipse photo, 15 pt `a:ln` beige border, `bevelT` hardEdge, `outerShdw`): the ring looked **sliced off by straight lines at its top/bottom/left/right** since the bevel work landed in #410. Seven attempts (#410–#419) chased shading models; the cut persisted and reproduced "only at certain scales".

## Root cause (two, both scale-independent — visibility grows with scale)

1. **Offscreen box clip.** `paintBeveledFlat` / `projectScene3dPaint` rasterise the body+edges into an offscreen sized exactly to the shape's bounding box. The outer half of the centre-aligned border extends past that box, and an inscribed ellipse touches its box at all four apices — so the border's outer half was cut along the straight box edge there. The bevel's distance transform also treated the offscreen border as the silhouette edge, flattening the lip shading near each apex.
   Measured at 1920 device px: the band rendered 14 px starting exactly at the bbox edge, vs the PDF's full ~22–30 px band straddling the silhouette.
2. **Border painted after the bevel.** The picture path shaded the bevel on the bare bitmap and then drew the border flat on top. The PDF ground truth (p6) shows the bevel lighting the border itself (dark rim crease → lit shelf → photo). The `p:sp` path already bevels its bordered body; the picture path now matches.

Why every previous check missed it: the node/skia harness has no `OffscreenCanvas`, so `createAuxCanvas` returns null and the renderer **silently falls back to the flat, un-beveled draw with a full-width border** — the bug cannot reproduce there; and at dpr1 the missing 10 px hid inside the shadow falloff. The earlier "white band inside the rim" measurement turned out to be page white between the card edge and the shadow falloff.

## Fix

- Grow the bevel/scene3d offscreen by an edge margin (border half-width + `contourW` + extrusion offset + 2 css px) and blit back 1:1 in device px.
- Extend the scene3d destination quad through its own homography with the new `expandProjectedQuad` core helper (`computeScene3dQuad` re-fits to the box it is given, so it must not be called with a padded size).
- Paint the `a:ln` border into the front face **before** `applyBevelShading`; keep the sp3d contour post-bevel so it cannot contaminate the lip's distance transform.

## Test (TDD)

`bevel-ring.spec.ts` now runs at (width, dpr) = (1280,1), (1280,2), (960,2) and requires a continuous warm-toned band ≥ 0.8× the border's device-px width on every apex. Pre-fix it measures ~0.5× (red at all three scales); post-fix 1.0× (green). `fixture.html` gained a `?width=` override for this.

Apex cross-sections at 1920 px, before → after → PDF:
| | before | after | PDF p6 |
|---|---|---|---|
| TOP band | 14 px, flat, starts at bbox edge | 30 px, bevel-lit | ~22 px visible, bevel-lit |
| LEFT/RIGHT | 14–15 px | 31–33 px | ~23 px visible |

## Verification

- `playwright test bevel-ring`: 3/3 green (red on parent commit).
- Full pptx VRT: 72/72 pass.
- Workspace vitest 357/357, `tsc --build` + package typechecks, `ast-grep scan` clean.
- Slide 3 (the #410 calibration card, no border) visually unchanged apart from its contour no longer being box-clipped.

## Known remaining gap (intentionally out of scope)

The threePt light rig has no fill light and `<a:rot rev>` (slide 6 carries rev=320°) is not parsed, so the bottom lip renders darker (−29 % vs face) than the PDF (+3 %). PDF reference values are recorded in the spec comments and local dev notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)