### PR TITLE
fix(node): install OffscreenCanvas shim so bevel/scene3d/effects render

### DIFF
--- a/packages/node/bin/ooxml-thumbnail.mjs
+++ b/packages/node/bin/ooxml-thumbnail.mjs
@@ -74,7 +74,7 @@ if (filePath.toLowerCase().endsWith('.pptx')) {
   const dpr = 2;
   const cssH = Math.round(slideHeight * (width / slideWidth));
   const canvas = factory.createCanvas(width * dpr, cssH * dpr);
-  await renderSlideNode(canvas, presentation, slideIdx, { width, dpr });
+  await renderSlideNode(canvas, presentation, slideIdx, { width, dpr, factory });
   const png = await canvas.toBuffer('png');
   writeFileSync(outPath, png);
   console.log(`Wrote ${outPath} (slide ${slideIdx + 1} / ${presentation.slides.length})`);

--- a/packages/node/src/bevel-render.test.ts
+++ b/packages/node/src/bevel-render.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { Canvas, loadImage } from 'skia-canvas';
+import { renderSlideNode } from './render';
+import type { NodeCanvasFactory } from './render';
+import type { Presentation, Slide, PictureElement } from '@silurus/ooxml-pptx';
+
+/**
+ * Regression test for the Node OffscreenCanvas shim.
+ *
+ * `packages/core/src/shape/effects.ts`'s `createAuxCanvas` needs an
+ * `OffscreenCanvas` (or DOM `document`) to allocate the auxiliary canvas that
+ * the pptx renderer's `paintBeveledFlat` uses to bake sp3d bevel-lip shading.
+ * Under Node neither exists, so without the shim the renderer silently skips
+ * the bevel and blits the flat image. This test renders the SAME synthetic
+ * slide (a solid picture carrying an sp3d `bevelT`) twice — once WITH the shim
+ * (factory passed → bevel shading active) and once WITHOUT (no factory → flat
+ * fallback) — and asserts the rim band differs. If the shim regresses, both
+ * renders match and this fails.
+ */
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) => new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (buf) => loadImage(buf as Buffer) as unknown as ReturnType<NodeCanvasFactory['loadImage']>,
+};
+
+const g = globalThis as unknown as { createImageBitmap?: unknown; OffscreenCanvas?: unknown };
+
+/** Build a small flat-colour PNG as a data URL using skia-canvas. */
+async function flatPngDataUrl(w: number, h: number, color: string): Promise<string> {
+  const c = new Canvas(w, h);
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, w, h);
+  const buf = await c.toBuffer('png');
+  return `data:image/png;base64,${buf.toString('base64')}`;
+}
+
+const EMU_PER_PX = 9525; // 96 dpi
+
+function buildBeveledSlide(dataUrl: string): Presentation {
+  // A 300x300 px picture centred on a 400x400 px slide, with a chunky top
+  // bevel so the lit/shadowed rim is unmistakable.
+  const px = (n: number) => Math.round(n * EMU_PER_PX);
+  const pic: PictureElement = {
+    type: 'picture',
+    x: px(50),
+    y: px(50),
+    width: px(300),
+    height: px(300),
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    dataUrl,
+    stroke: null,
+    sp3d: {
+      prstMaterial: 'warmMatte',
+      // 360000 EMU ≈ 38 px bevel at 1:1; circle lip → strong gradient.
+      bevelT: { w: 360000, h: 360000, prst: 'circle' },
+    },
+  };
+  const slide: Slide = {
+    index: 0,
+    slideNumber: 1,
+    background: null,
+    elements: [pic],
+  };
+  return {
+    slideWidth: px(400),
+    slideHeight: px(400),
+    slides: [slide],
+    defaultTextColor: null,
+    majorFont: null,
+    minorFont: null,
+  };
+}
+
+async function renderToRgba(
+  presentation: Presentation,
+  withShim: boolean,
+): Promise<{ data: Uint8ClampedArray; width: number; height: number }> {
+  const width = 400;
+  const dpr = 1;
+  const canvas = new Canvas(width * dpr, 400 * dpr);
+  // createImageBitmap is always needed to decode the picture's dataUrl.
+  const g2 = globalThis as unknown as { createImageBitmap?: unknown };
+  const prevBitmap = g2.createImageBitmap;
+  g2.createImageBitmap = async (source: Blob | ArrayBuffer | Uint8Array) => {
+    let buf: ArrayBuffer | Uint8Array;
+    if (source instanceof Uint8Array || source instanceof ArrayBuffer) buf = source;
+    else buf = await (source as Blob).arrayBuffer();
+    return loadImage(Buffer.from(buf as ArrayBuffer));
+  };
+  try {
+    await renderSlideNode(
+      canvas as unknown as Parameters<typeof renderSlideNode>[0],
+      presentation,
+      0,
+      { width, dpr, ...(withShim ? { factory } : {}) },
+    );
+  } finally {
+    g2.createImageBitmap = prevBitmap as typeof globalThis.createImageBitmap;
+  }
+  const ctx = canvas.getContext('2d');
+  const img = ctx.getImageData(0, 0, width * dpr, 400 * dpr);
+  return { data: img.data as unknown as Uint8ClampedArray, width: width * dpr, height: 400 * dpr };
+}
+
+describe('node bevel rendering (OffscreenCanvas shim)', () => {
+  it('shim activates sp3d bevel shading — rim pixels differ from the flat fallback', async () => {
+    // Guard: no ambient OffscreenCanvas in the test runtime, so the only way the
+    // bevel can appear is via the shim installed by renderSlideNode(factory).
+    expect(typeof g.OffscreenCanvas).toBe('undefined');
+
+    const dataUrl = await flatPngDataUrl(8, 8, '#808080'); // mid-grey face
+    const presentation = buildBeveledSlide(dataUrl);
+
+    const flat = await renderToRgba(presentation, /* withShim */ false);
+    const beveled = await renderToRgba(presentation, /* withShim */ true);
+
+    // Shim must not leak out of renderSlideNode.
+    expect(typeof g.OffscreenCanvas).toBe('undefined');
+
+    // The picture occupies px (50,50)..(350,350) at dpr=1. Sample a horizontal
+    // band a few px inside the top edge — that's where the top-bevel lip shades
+    // brightest/darkest. Count how many pixels differ from the flat render.
+    const { data: fd, width } = flat;
+    const { data: bd } = beveled;
+    const yBand = 56; // ~6 px below the top edge of the picture
+    let diffCount = 0;
+    let maxDelta = 0;
+    for (let x = 60; x < 340; x++) {
+      const i = (yBand * width + x) * 4;
+      const dr = Math.abs(fd[i] - bd[i]);
+      const dgc = Math.abs(fd[i + 1] - bd[i + 1]);
+      const db = Math.abs(fd[i + 2] - bd[i + 2]);
+      const delta = Math.max(dr, dgc, db);
+      if (delta > 8) diffCount++;
+      if (delta > maxDelta) maxDelta = delta;
+    }
+
+    // Without the shim the flat render fills this band with the flat grey; with
+    // the shim the bevel lip lightens/darkens it. Expect a substantial run of
+    // differing pixels and a clear luminance swing.
+    expect(diffCount).toBeGreaterThan(40);
+    expect(maxDelta).toBeGreaterThan(20);
+  });
+
+  it('without a factory the render is the flat fallback (no aux canvas, no throw)', async () => {
+    const dataUrl = await flatPngDataUrl(8, 8, '#808080');
+    const presentation = buildBeveledSlide(dataUrl);
+    // Two flat renders must be identical (deterministic, no bevel).
+    const a = await renderToRgba(presentation, false);
+    const b = await renderToRgba(presentation, false);
+    let diff = 0;
+    for (let i = 0; i < a.data.length; i++) if (a.data[i] !== b.data[i]) diff++;
+    expect(diff).toBe(0);
+  });
+});

--- a/packages/node/src/bevel-render.test.ts
+++ b/packages/node/src/bevel-render.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { Canvas, loadImage } from 'skia-canvas';
 import { renderSlideNode } from './render';
 import type { NodeCanvasFactory } from './render';
 import type { Presentation, Slide, PictureElement } from '@silurus/ooxml-pptx';
+
+// skia-canvas ships a native binding that CI deliberately omits (VRT and other
+// canvas-backed checks are local-only). Load it dynamically so the suite skips
+// cleanly when the binding is absent instead of failing at module load.
+const skia = await import('skia-canvas').catch(() => null);
+// Non-null aliases for use inside the (skia-gated) test bodies. When `skia` is
+// null the whole suite is skipped via `describe.skipIf`, so these are never
+// dereferenced; the cast keeps the helpers strongly typed without `as any`.
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
 
 /**
  * Regression test for the Node OffscreenCanvas shim.
@@ -18,10 +27,15 @@ import type { Presentation, Slide, PictureElement } from '@silurus/ooxml-pptx';
  * renders match and this fails.
  */
 
-const factory: NodeCanvasFactory = {
-  createCanvas: (w, h) => new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
-  loadImage: (buf) => loadImage(buf as Buffer) as unknown as ReturnType<NodeCanvasFactory['loadImage']>,
-};
+const factory: NodeCanvasFactory | null =
+  Canvas && loadImage
+    ? {
+        createCanvas: (w, h) =>
+          new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+        loadImage: (buf) =>
+          loadImage(buf as Buffer) as unknown as ReturnType<NodeCanvasFactory['loadImage']>,
+      }
+    : null;
 
 const g = globalThis as unknown as { createImageBitmap?: unknown; OffscreenCanvas?: unknown };
 
@@ -95,7 +109,10 @@ async function renderToRgba(
       canvas as unknown as Parameters<typeof renderSlideNode>[0],
       presentation,
       0,
-      { width, dpr, ...(withShim ? { factory } : {}) },
+      // `factory` is non-null whenever this suite runs (it is gated by
+      // describe.skipIf(!skia)); the `&& factory` narrows the nullable type
+      // away so the spread matches renderSlideNode's `factory?` option.
+      { width, dpr, ...(withShim && factory ? { factory } : {}) },
     );
   } finally {
     g2.createImageBitmap = prevBitmap as typeof globalThis.createImageBitmap;
@@ -105,7 +122,7 @@ async function renderToRgba(
   return { data: img.data as unknown as Uint8ClampedArray, width: width * dpr, height: 400 * dpr };
 }
 
-describe('node bevel rendering (OffscreenCanvas shim)', () => {
+describe.skipIf(!skia)('node bevel rendering (OffscreenCanvas shim)', () => {
   it('shim activates sp3d bevel shading — rim pixels differ from the flat fallback', async () => {
     // Guard: no ambient OffscreenCanvas in the test runtime, so the only way the
     // bevel can appear is via the shim installed by renderSlideNode(factory).

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,6 +4,7 @@ export { parseXlsx, parseSheet as parseXlsxSheet, parseXlsxAllSheets } from './x
 export {
   renderSlideNode,
   installImageBitmapShim,
+  installOffscreenCanvasShim,
   type NodeCanvasLike,
   type NodeCanvasFactory,
   type NodeImageLike,

--- a/packages/node/src/render.test.ts
+++ b/packages/node/src/render.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Canvas, loadImage } from 'skia-canvas';
+import { installOffscreenCanvasShim, installImageBitmapShim } from './render';
+import type { NodeCanvasFactory } from './render';
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) => new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (buf) => loadImage(buf as Buffer) as unknown as ReturnType<NodeCanvasFactory['loadImage']>,
+};
+
+const g = globalThis as unknown as { OffscreenCanvas?: unknown };
+
+describe('installOffscreenCanvasShim', () => {
+  afterEach(() => {
+    // Make sure each test cleans up; restore is the responsibility of the test
+    // body, but guard against leakage if an assertion threw.
+    delete g.OffscreenCanvas;
+  });
+
+  it('injects a global OffscreenCanvas backed by the factory', () => {
+    expect(typeof g.OffscreenCanvas).toBe('undefined');
+    const restore = installOffscreenCanvasShim(factory);
+    expect(typeof g.OffscreenCanvas).toBe('function');
+
+    const oc = new (g.OffscreenCanvas as new (w: number, h: number) => unknown)(64, 48) as {
+      width: number;
+      height: number;
+      getContext(k: '2d'): CanvasRenderingContext2D;
+    };
+    expect(oc.width).toBe(64);
+    expect(oc.height).toBe(48);
+    const ctx = oc.getContext('2d');
+    expect(typeof ctx.getImageData).toBe('function');
+    expect(typeof ctx.putImageData).toBe('function');
+    expect(typeof ctx.drawImage).toBe('function');
+
+    restore();
+    expect(typeof g.OffscreenCanvas).toBe('undefined');
+  });
+
+  it('does not overwrite an already-defined global OffscreenCanvas', () => {
+    const sentinel = function PreExisting() {} as unknown;
+    g.OffscreenCanvas = sentinel;
+    const restore = installOffscreenCanvasShim(factory);
+    expect(g.OffscreenCanvas).toBe(sentinel);
+    restore();
+    // restore returns the global to its pre-call value (the sentinel).
+    expect(g.OffscreenCanvas).toBe(sentinel);
+    delete g.OffscreenCanvas;
+  });
+
+  it('shimmed OffscreenCanvas supports a ctx.filter blur pass (feathered edge)', () => {
+    const restore = installOffscreenCanvasShim(factory);
+    const oc = new (g.OffscreenCanvas as new (w: number, h: number) => unknown)(100, 100) as {
+      getContext(k: '2d'): CanvasRenderingContext2D;
+    };
+    const ctx = oc.getContext('2d');
+    ctx.filter = 'blur(6px)';
+    ctx.fillStyle = '#000';
+    ctx.fillRect(40, 40, 20, 20);
+    ctx.filter = 'none';
+    // Just outside the original square edge, blur must leak partial alpha.
+    const outside = ctx.getImageData(33, 50, 1, 1).data;
+    expect(outside[3]).toBeGreaterThan(0);
+    expect(outside[3]).toBeLessThan(255);
+    restore();
+    delete g.OffscreenCanvas;
+  });
+
+  it('shimmed OffscreenCanvas works as a drawImage source onto another canvas', () => {
+    const restore = installOffscreenCanvasShim(factory);
+    const oc = new (g.OffscreenCanvas as new (w: number, h: number) => unknown)(50, 50) as {
+      getContext(k: '2d'): CanvasRenderingContext2D;
+    };
+    const octx = oc.getContext('2d');
+    octx.fillStyle = '#ff0000';
+    octx.fillRect(0, 0, 50, 50);
+
+    const dest = factory.createCanvas(50, 50);
+    const dctx = dest.getContext('2d');
+    dctx.drawImage(oc as unknown as CanvasImageSource, 0, 0);
+    const px = dctx.getImageData(25, 25, 1, 1).data;
+    expect(Array.from(px)).toEqual([255, 0, 0, 255]);
+    restore();
+    delete g.OffscreenCanvas;
+  });
+});
+
+describe('installImageBitmapShim', () => {
+  it('restores the previous global', () => {
+    const gg = globalThis as unknown as { createImageBitmap?: unknown };
+    const before = gg.createImageBitmap;
+    const restore = installImageBitmapShim(factory);
+    expect(typeof gg.createImageBitmap).toBe('function');
+    restore();
+    expect(gg.createImageBitmap).toBe(before);
+  });
+});

--- a/packages/node/src/render.test.ts
+++ b/packages/node/src/render.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { Canvas, loadImage } from 'skia-canvas';
 import { installOffscreenCanvasShim, installImageBitmapShim } from './render';
 import type { NodeCanvasFactory } from './render';
+
+// skia-canvas ships a native binding that CI deliberately omits (it is a
+// peerDependency, not installed by `pnpm install --frozen-lockfile`, and the
+// canvas-backed checks are local-only like the VRT suites). Load it dynamically
+// so these suites skip cleanly when the binding is absent instead of failing
+// the whole run at module load. `describe.skipIf(!skia)` gates every block.
+const skia = await import('skia-canvas').catch(() => null);
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
 
 const factory: NodeCanvasFactory = {
   createCanvas: (w, h) => new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
@@ -10,7 +18,7 @@ const factory: NodeCanvasFactory = {
 
 const g = globalThis as unknown as { OffscreenCanvas?: unknown };
 
-describe('installOffscreenCanvasShim', () => {
+describe.skipIf(!skia)('installOffscreenCanvasShim', () => {
   afterEach(() => {
     // Make sure each test cleans up; restore is the responsibility of the test
     // body, but guard against leakage if an assertion threw.
@@ -86,7 +94,7 @@ describe('installOffscreenCanvasShim', () => {
   });
 });
 
-describe('installImageBitmapShim', () => {
+describe.skipIf(!skia)('installImageBitmapShim', () => {
   it('restores the previous global', () => {
     const gg = globalThis as unknown as { createImageBitmap?: unknown };
     const before = gg.createImageBitmap;

--- a/packages/node/src/render.ts
+++ b/packages/node/src/render.ts
@@ -40,6 +40,65 @@ export interface NodeCanvasFactory {
   loadImage(buffer: ArrayBuffer | Uint8Array | Buffer): Promise<NodeImageLike>;
 }
 
+/**
+ * Polyfill `globalThis.OffscreenCanvas` so the shared rendering primitives can
+ * allocate auxiliary canvases under Node.
+ *
+ * `packages/core/src/shape/effects.ts`'s `createAuxCanvas` probes
+ * `typeof OffscreenCanvas !== 'undefined'` and otherwise `document`. Under Node
+ * neither exists, so it returns `null` and the pptx renderer's beveled-flat
+ * path, scene3d projection, and the inner-shadow / soft-edge / reflection
+ * effects all *silently* degrade to flat output (no rim shading, no 3D warp,
+ * no blur). This shim makes `new OffscreenCanvas(w, h)` allocate a real
+ * skia-canvas (via the user's `factory.createCanvas`), so those paths light up
+ * server-side exactly as they do in the browser.
+ *
+ * `new OffscreenCanvas(w, h)` simply *returns* a backing canvas from
+ * `factory.createCanvas` (a class constructor may return a different object).
+ * Returning the real canvas — rather than a wrapper — matters: the effect
+ * helpers pass the allocated canvas straight to `ctx.drawImage(aux, …)`, and
+ * skia-canvas's `drawImage` only accepts a real `Image`/`Canvas`, rejecting a
+ * forwarding wrapper. The backing canvas already exposes everything
+ * `createAuxCanvas` consumers touch (getContext, getImageData/putImageData,
+ * drawImage as a source, and `ctx.filter = 'blur(Npx)'`); skia-canvas supports
+ * all of them, including the `filter` blur used by the effect helpers.
+ *
+ * If `globalThis.OffscreenCanvas` is already defined (e.g. on a real DOM/worker
+ * runtime, or Node ≥ a future version that ships it) the existing value is left
+ * untouched. The returned function restores the global to its pre-call value.
+ */
+export function installOffscreenCanvasShim(factory: NodeCanvasFactory): () => void {
+  const g = globalThis as unknown as { OffscreenCanvas?: unknown };
+  const prev = g.OffscreenCanvas;
+  const hadOwn = Object.prototype.hasOwnProperty.call(globalThis, 'OffscreenCanvas');
+
+  // Respect a pre-existing implementation — never overwrite a real one.
+  if (typeof prev !== 'undefined') {
+    return () => {
+      /* nothing to restore: we never touched the global */
+    };
+  }
+
+  class OffscreenCanvasShim {
+    constructor(width: number, height: number) {
+      // Return the backing canvas itself (constructors may return another
+      // object). This keeps `aux instanceof <skia Canvas>` true so skia's
+      // `drawImage` accepts it as an image source.
+      return factory.createCanvas(width, height) as unknown as OffscreenCanvasShim;
+    }
+  }
+
+  g.OffscreenCanvas = OffscreenCanvasShim as unknown;
+
+  return () => {
+    if (hadOwn) {
+      g.OffscreenCanvas = prev;
+    } else {
+      delete g.OffscreenCanvas;
+    }
+  };
+}
+
 /** Polyfill `globalThis.createImageBitmap` so the existing renderers can
  *  decode raster pictures. Wires it to the user's `loadImage`. Returns the
  *  previous global (if any) so the caller can restore it. */
@@ -72,12 +131,20 @@ export function installImageBitmapShim(factory: NodeCanvasFactory): () => void {
  *  Note: the underlying browser renderer is `async` and imports Vite-only
  *  worker assets at the top of `presentation.ts`. The Node path bypasses
  *  `PptxPresentation` and `worker.ts` entirely and calls the pure
- *  `renderSlide` function from `@silurus/ooxml-pptx`. */
+ *  `renderSlide` function from `@silurus/ooxml-pptx`.
+ *
+ *  Bevel / scene3d / effects: pass `opts.factory` (the same canvas factory you
+ *  used for {@link installImageBitmapShim}) so this function can install the
+ *  {@link installOffscreenCanvasShim} for the duration of the render. Without a
+ *  factory there is no way to allocate auxiliary canvases, and the renderer's
+ *  beveled-flat path, scene3d projection, and inner-shadow / soft-edge /
+ *  reflection effects silently fall back to flat output. The shim is restored
+ *  before this function returns. */
 export async function renderSlideNode(
   canvas: NodeCanvasLike,
   presentation: Presentation,
   slideIndex: number,
-  opts: { width?: number; dpr?: number } = {},
+  opts: { width?: number; dpr?: number; factory?: NodeCanvasFactory } = {},
 ): Promise<void> {
   // Direct import of the pure renderer module — avoids `presentation.ts`
   // and `viewer.ts`, both of which pull Vite-specific worker / asset
@@ -95,23 +162,33 @@ export async function renderSlideNode(
   if (!slide) throw new Error(`Slide index ${slideIndex} out of range`);
   const width = opts.width ?? 960;
   const dpr = opts.dpr ?? 2;
-  await renderSlide(
-    canvas as unknown as HTMLCanvasElement,
-    slide,
-    presentation.slideWidth,
-    presentation.slideHeight,
-    {
-      width,
-      dpr,
-      defaultTextColor: presentation.defaultTextColor,
-      majorFont: presentation.majorFont,
-      minorFont: presentation.minorFont,
-      hlinkColor: presentation.hlinkColor ?? null,
-      // Node-side renderers don't run media playback, so an empty fetcher
-      // is fine — picture elements with `dataUrl` are handled by the
-      // existing path through createImageBitmap.
-      fetchMedia: async () => new Blob([]),
-      skipMediaControls: true,
-    },
-  );
+  // Light up bevel/scene3d/effects auxiliary-canvas allocation for the render,
+  // then restore the global. No-op restore if a factory was not supplied or an
+  // OffscreenCanvas already exists.
+  const restoreOffscreen = opts.factory
+    ? installOffscreenCanvasShim(opts.factory)
+    : () => {};
+  try {
+    await renderSlide(
+      canvas as unknown as HTMLCanvasElement,
+      slide,
+      presentation.slideWidth,
+      presentation.slideHeight,
+      {
+        width,
+        dpr,
+        defaultTextColor: presentation.defaultTextColor,
+        majorFont: presentation.majorFont,
+        minorFont: presentation.minorFont,
+        hlinkColor: presentation.hlinkColor ?? null,
+        // Node-side renderers don't run media playback, so an empty fetcher
+        // is fine — picture elements with `dataUrl` are handled by the
+        // existing path through createImageBitmap.
+        fetchMedia: async () => new Blob([]),
+        skipMediaControls: true,
+      },
+    );
+  } finally {
+    restoreOffscreen();
+  }
 }


### PR DESCRIPTION
## Problem

`packages/core/src/shape/effects.ts`'s `createAuxCanvas` probes
`typeof OffscreenCanvas !== 'undefined'`, then `document`, and returns `null`
when neither exists. Under Node (the `packages/node` skia-canvas renderer)
both are absent, so the pptx renderer's `paintBeveledFlat`,
`projectScene3dPaint`, and the effect helpers (`applyInnerShadow`,
`applySoftEdge`, `applyReflection`) **silently** fall back to flat output: no
bevel rim shading, no 3D camera warp, no edge blur. Only `drawProjected` had a
`warnFallbackOnce`; the bevel and effect paths warned nothing.

This silent degradation meant the node renderer could not reproduce the
slide-6 sp3d bevel ring, so node-side checks of the ring regression (#420)
were structurally blind to it across several sessions.

## Fix

Add `installOffscreenCanvasShim(factory)`, mirroring the existing
`installImageBitmapShim` pattern. It injects `globalThis.OffscreenCanvas` whose
constructor **returns** a backing skia-canvas from `factory.createCanvas` (a
class constructor may legally return a different object). Returning the real
canvas rather than a forwarding wrapper is required: skia-canvas's `drawImage`
only accepts a real `Image`/`Canvas` and rejects a wrapper, and the effect
helpers pass the aux canvas straight to `ctx.drawImage(aux, …)`.

- Never overwrites a pre-existing `OffscreenCanvas` (real DOM/worker runtime).
- The returned restore fn deletes the shim (or restores the prior value).
- `renderSlideNode` gains an optional `factory` and installs/restores the shim
  around the render; the `ooxml-thumbnail` CLI passes it through so server-side
  thumbnails now render bevels/scene3d/effects.

## skia-canvas API compatibility

Verified against skia-canvas 2.0.2 (the package's peer dep), all OK:

| API | Result |
| --- | --- |
| `new Canvas(w,h)` / `getContext('2d')` | OK |
| `getImageData` / `putImageData` | OK |
| `drawImage(canvas → canvas)` | OK (real Canvas only; wrapper rejected → shim returns the backing Canvas) |
| `ctx.filter = 'blur(Npx)'` | OK — verified to feather edges (alpha bleeds outside the silhouette), so `innerShdw` / `softEdge` / `reflection` blur passes work unchanged |

No degraded API path was needed.

## Before / after — sample-11 slide 6 (the bevel ring), node render @ width=1920, dpr=1

Vertical raw-RGB cross-section through the ring's top apex at x≈860. Without the
shim the warm border band flattens to the bare face level; with the shim the
bevel lip lights it up (the brighter highlight the browser shows).

```
x=860, top apex:
OFF (no shim, flat fallback):  photo[200,198,189] → dark groove[0,34,68] → warm band peaks ~218–222 → photo
ON  (shim, bevel active):      photo[200,198,189] → soft rim ramp[231→200] → dark groove[2,66,127] → warm band peaks ~254 → photo
```

The ON render gains (a) a feathered outer rim ramp and (b) a markedly brighter
bevel-lit highlight (~+35 luma over the flat face) straddling the silhouette —
exactly the "bevel-lit beige band" the browser ground truth (`sample-11.pdf`
p6 / PR #420–#421) shows. Every sampled column (x = 760/860/960/1060/1160)
differs between OFF and ON.

The browser acceptance spec (`packages/pptx/tests/visual/bevel-ring.spec.ts`)
confirms the matching structure at the same scale: at width=1920 the TOP rim is
a continuous 30 px full-width warm band (= the 30 px stroke), zero white
intrusion. The node ON render produces the same full-width warm band on the
apex.

## Tests

- `packages/node/src/render.test.ts` — the shim itself: inject/restore, do not
  overwrite an existing global, `ctx.filter` blur feathers, and the shimmed
  `OffscreenCanvas` works as a `drawImage` source.
- `packages/node/src/bevel-render.test.ts` — synthetic-slide regression. Builds
  a `PictureElement` from a code-generated flat PNG data URL plus `sp3d.bevelT`
  (no committed Office file) and asserts the apex rim band differs with vs
  without the shim, and that two flat renders are byte-identical.

`packages/node` had no prior tests or snapshots, so nothing existing needed
updating. No `tests/visual/references/` image was touched.

## Verification

- `npx vitest run` → 47 files, 367 tests passing.
- `npm run typecheck` → passing.
- `cd packages/pptx && npx playwright test bevel-ring --reporter=list` → 3/3
  passing (browser ground truth unchanged).

## Known behaviour differences / caveats

- The node ON apex highlight peaks ~254 at width=1920/dpr=1, slightly hotter
  than the browser's ~220 at the comparable scale. Cause is the render scale /
  dpr1 vs dpr2 supersample averaging and font substitution, not the bevel math
  — the shading code is shared and identical. The browser spec's `<250` ceiling
  reflects its dpr2 averaging; it is not a contract the node dpr1 path must hit.
- `installOffscreenCanvasShim` is opt-in via the `factory` argument. Callers of
  `renderSlideNode` that do not pass `factory` keep the old flat behaviour (no
  aux canvas), so this is a non-breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
