### PR TITLE
fix(site): top-align docx master-detail preview so page top is not clipped

### DIFF
--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -168,6 +168,9 @@ function mountMasterDetail(el: HTMLElement, format: Format, url: string): void {
       const select = async (i: number) => {
         cells.forEach((c, k) => c.classList.toggle('active', k === i));
         await viewer.go(i);
+        // Reset scroll so the new page is shown from its top, not wherever the
+        // previous page was scrolled to.
+        detail.scrollTop = 0;
       };
       for (let i = 0; i < doc.count; i++) {
         const cell = document.createElement('div');

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -257,7 +257,7 @@ h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
 .demo-rail-cell { cursor: pointer; border-radius: 5px; outline: 2px solid transparent; transition: outline-color 0.15s; }
 .demo-rail-cell .demo-page { width: 100%; height: auto; }
 .demo-rail-cell.active { outline-color: var(--accent); }
-.demo-detail { flex: 1 1 auto; overflow: auto; padding: 22px; display: flex; justify-content: center; align-items: center; }
+.demo-detail { flex: 1 1 auto; overflow: auto; padding: 22px; display: flex; justify-content: center; align-items: flex-start; }
 .demo-detail .demo-page { width: 100%; max-width: 960px; height: auto; }
 
 /* xlsx full viewer */


### PR DESCRIPTION
## Problem

On the docx detail page (`/docx`), the **Thumbnail rail + large preview** (MasterDetail) demo clipped the top of the document in the large-preview pane. The page header was never visible and there was no way to scroll up to reach it.

## Root cause

`.demo-detail` in `site/src/styles/global.css` used `align-items: center`. The pane is an `overflow: auto` flex container; centering a flex item that is **taller** than the container pushes the item's top *above* the container's content-box top. Since `scrollTop` is clamped at 0, the clipped top is unreachable.

docx pages are tall (portrait), so the canvas overflows and the bug appears. pptx/xlsx large previews are landscape and fit within the 560px pane, so they were unaffected.

The Storybook MasterDetail story (`packages/docx/src/Examples.stories.ts`) already uses `align-items: flex-start` for its detail column and does not have this problem — this PR aligns the site with that correct implementation.

## Fix

- `site/src/styles/global.css`: `.demo-detail` `align-items: center` → `align-items: flex-start`. `justify-content: center` is kept, so horizontal centering of landscape pptx/xlsx previews is preserved.
- `site/src/lib/demos.ts`: `mountMasterDetail()` `select()` now sets `detail.scrollTop = 0` on page switch, so each newly selected page is shown from its top rather than the previous page's scroll offset.

## Verification (browser, Playwright + Chrome, `/docx?all` and `/pptx?all` against a local Astro build)

DOM measurements of the detail pane (`c.top - d.top` = canvas top relative to the pane's top; padding is 22px):

| | align-items | canvas top offset | topClipped | scrollTop after switch |
|---|---|---|---|---|
| docx **before** (`center`, simulated) | center | **-369px** (above visible area, scrollTop locked at 0, cannot scroll up) | **true** | — |
| docx **after** | flex-start | **+22px** (= padding, fully visible) | false | 0 (top shown) |
| pptx **after** | flex-start | +22px | false | 0 |

After the fix, the docx preview renders from the very top (eyebrow → "Beneath the Canopy" heading → byline → body) and scrolls down naturally; switching pages resets to the top. The pptx preview is unchanged (landscape slide fits, top flush). xlsx uses the full `XlsxViewer` (`mountSheet`), not `.demo-detail`, so it is not affected.

docx after:

![docx after](https://github.com/user-attachments/assets/placeholder)

(screenshots captured locally; the DOM metrics above are the load-bearing evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)