### PR TITLE
fix(pptx): don't draw bullet/number markers on empty paragraphs

### DIFF
--- a/packages/pptx/src/empty-bullet.test.ts
+++ b/packages/pptx/src/empty-bullet.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { Paragraph, Bullet, TextRun } from '@silurus/ooxml-core';
+import { paragraphHasRenderableContent, resolveBulletLabel } from './renderer.js';
+
+// Build a minimal Paragraph with the given runs / bullet / level. Only the
+// fields the bullet-resolution logic reads matter; the rest get harmless
+// defaults so we exercise the real code path without a parser.
+function para(runs: TextRun[], bullet: Bullet, lvl = 0): Paragraph {
+  return {
+    alignment: 'l',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl,
+    bullet,
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    runs,
+  };
+}
+
+const text = (t: string): TextRun => ({
+  type: 'text', text: t, bold: null, italic: null, underline: false,
+  strikethrough: false, fontSize: null, color: null, fontFamily: null,
+});
+const brk = (): TextRun => ({ type: 'break' });
+const math = (): TextRun => ({ type: 'math', nodes: [], display: false });
+
+const autoNum = (numType = 'arabicPeriod', startAt: number | null = null): Bullet =>
+  ({ type: 'autoNum', numType, startAt });
+const charBullet = (char = '•'): Bullet =>
+  ({ type: 'char', char, color: null, sizePct: null, fontFamily: null });
+
+describe('paragraphHasRenderableContent', () => {
+  it('is true for a non-empty text run', () => {
+    expect(paragraphHasRenderableContent(para([text('foo')], charBullet()))).toBe(true);
+  });
+
+  it('is false for no runs at all', () => {
+    expect(paragraphHasRenderableContent(para([], charBullet()))).toBe(false);
+  });
+
+  it('is false for a single empty-string text run', () => {
+    expect(paragraphHasRenderableContent(para([text('')], charBullet()))).toBe(false);
+  });
+
+  it('is false for a paragraph that is only a line break', () => {
+    expect(paragraphHasRenderableContent(para([brk()], charBullet()))).toBe(false);
+  });
+
+  it('is true for an equation run even with no text', () => {
+    expect(paragraphHasRenderableContent(para([math()], charBullet()))).toBe(true);
+  });
+
+  it('is true when at least one run has text among empties', () => {
+    expect(paragraphHasRenderableContent(para([text(''), text('x')], charBullet()))).toBe(true);
+  });
+});
+
+describe('resolveBulletLabel — empty paragraphs draw no marker', () => {
+  it('suppresses a char bullet on an empty paragraph', () => {
+    const counters = new Map<number, number>();
+    expect(resolveBulletLabel(para([], charBullet()), counters)).toBe('');
+    expect(resolveBulletLabel(para([brk()], charBullet()), counters)).toBe('');
+  });
+
+  it('suppresses an autoNum marker on an empty paragraph', () => {
+    const counters = new Map<number, number>();
+    expect(resolveBulletLabel(para([], autoNum()), counters)).toBe('');
+  });
+
+  it('still draws a char bullet when the paragraph has text', () => {
+    const counters = new Map<number, number>();
+    expect(resolveBulletLabel(para([text('foo')], charBullet('•')), counters)).toBe('•');
+  });
+});
+
+describe('resolveBulletLabel — autoNum sequencing', () => {
+  it('numbers consecutive non-empty paragraphs 1, 2, 3', () => {
+    const counters = new Map<number, number>();
+    const labels = [
+      resolveBulletLabel(para([text('a')], autoNum()), counters),
+      resolveBulletLabel(para([text('b')], autoNum()), counters),
+      resolveBulletLabel(para([text('c')], autoNum()), counters),
+    ];
+    expect(labels).toEqual(['1.', '2.', '3.']);
+  });
+
+  it('continues the sequence across an empty line (1. / blank / 2.)', () => {
+    const counters = new Map<number, number>();
+    const first = resolveBulletLabel(para([text('foo')], autoNum()), counters);
+    const blank = resolveBulletLabel(para([], autoNum()), counters);
+    const second = resolveBulletLabel(para([text('bar')], autoNum()), counters);
+    expect(first).toBe('1.');
+    expect(blank).toBe('');        // empty line: no number
+    expect(second).toBe('2.');     // sequence continues, NOT 3.
+  });
+
+  it('continues the sequence across a line-break-only paragraph', () => {
+    const counters = new Map<number, number>();
+    const labels = [
+      resolveBulletLabel(para([text('foo')], autoNum()), counters),
+      resolveBulletLabel(para([brk()], autoNum()), counters),
+      resolveBulletLabel(para([text('bar')], autoNum()), counters),
+    ];
+    expect(labels).toEqual(['1.', '', '2.']);
+  });
+
+  it('honours startAt and keeps numbering per level', () => {
+    const counters = new Map<number, number>();
+    expect(resolveBulletLabel(para([text('a')], autoNum('arabicPeriod', 5)), counters)).toBe('5.');
+    expect(resolveBulletLabel(para([text('b')], autoNum('arabicPeriod', 5)), counters)).toBe('6.');
+  });
+
+  it('resets the counter when a non-list paragraph appears between items', () => {
+    const counters = new Map<number, number>();
+    expect(resolveBulletLabel(para([text('a')], autoNum()), counters)).toBe('1.');
+    // a paragraph with no bullet (e.g. a heading) resets the sequence
+    resolveBulletLabel(para([text('heading')], { type: 'none' }), counters);
+    expect(resolveBulletLabel(para([text('b')], autoNum()), counters)).toBe('1.');
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1541,6 +1541,67 @@ function toRoman(n: number): string {
   return result;
 }
 
+/**
+ * True when a paragraph has renderable content — at least one non-empty text
+ * run, or any equation run. Line breaks alone (a paragraph the user created by
+ * pressing Enter on an empty line) do NOT count as content.
+ *
+ * PowerPoint does not draw a bullet/number marker on an empty paragraph and
+ * does not advance an autoNum counter for it (a blank line between "1." and
+ * "2." stays unnumbered and the sequence continues). ECMA-376 §21.1.2.4.x
+ * (CT_Bullet / CT_TextCharBullet / CT_TextAutoNumberBullet) gives no numeric
+ * rule for this, so PowerPoint's behaviour is the reference: suppress the
+ * marker whenever the paragraph carries no real content. This is the plain
+ * "is there content?" test, not a sample-specific heuristic.
+ */
+export function paragraphHasRenderableContent(para: Paragraph): boolean {
+  for (const r of para.runs) {
+    if (r.type === 'text' && r.text !== '') return true;
+    if (r.type === 'math') return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve the bullet/number marker *label string* for a paragraph, mutating
+ * the per-level autoNum counter map as a side effect. Returns '' (= no marker)
+ * for `none`/`inherit` bullets and for empty paragraphs.
+ *
+ * Empty-paragraph handling (PowerPoint reference behaviour, see
+ * `paragraphHasRenderableContent`): when the paragraph has no renderable
+ * content we draw no marker AND do not advance the autoNum counter, so a blank
+ * line between numbered items keeps the sequence going (… "1." / "" / "2." …).
+ *
+ * The counter-reset semantics (clear on char bullets / non-list paragraphs)
+ * are intentionally kept here so the same map walk the renderer relied on is
+ * exercised by the unit tests. Font and colour resolution stay in the renderer
+ * because they depend on canvas/theme context.
+ */
+export function resolveBulletLabel(
+  para: Paragraph,
+  autoNumCounters: Map<number, number>,
+): string {
+  const hasContent = paragraphHasRenderableContent(para);
+  if (para.bullet.type === 'char') {
+    // Reset counters when switching to char bullets.
+    autoNumCounters.clear();
+    return hasContent ? applySymbolFont(para.bullet.char, para.bullet.fontFamily ?? '') : '';
+  }
+  if (para.bullet.type === 'autoNum') {
+    if (!hasContent) return '';
+    const lvl = para.lvl;
+    if (!autoNumCounters.has(lvl)) {
+      autoNumCounters.set(lvl, para.bullet.startAt ?? 1);
+    } else {
+      autoNumCounters.set(lvl, autoNumCounters.get(lvl)! + 1);
+    }
+    return formatAutoNum(autoNumCounters.get(lvl)!, para.bullet.numType);
+  }
+  // none / inherit — not a list paragraph; reset autoNum counters.
+  autoNumCounters.clear();
+  return '';
+}
+
 function renderTextBody(
   ctx: CanvasRenderingContext2D,
   body: TextBody,
@@ -1726,33 +1787,26 @@ function renderTextBody(
     let bulletFont   = buildFont(false, false, bulletBaseSizePx, 'sans-serif', rc);
     let bulletColor  = bulletInheritedColor;
 
+    // Resolve the marker label and advance the autoNum counter. Empty
+    // paragraphs (Enter on a blank line) draw no marker and do not advance the
+    // counter — PowerPoint keeps a blank line between numbered items unnumbered
+    // while continuing the sequence. ECMA-376 §21.1.2.4.x gives no numeric
+    // rule, so PowerPoint's behaviour is the reference (see resolveBulletLabel).
+    bulletLabel = resolveBulletLabel(para, autoNumCounters);
+
     if (para.bullet.type === 'char') {
       const b = para.bullet;
       const bSizePx = b.sizePct != null
         ? bulletBaseSizePx * (b.sizePct / 100)
         : bulletBaseSizePx;
-      bulletLabel = applySymbolFont(b.char, b.fontFamily ?? '');
       // If the char was mapped to a Unicode symbol, use sans-serif for reliable rendering.
       // Otherwise use the specified font (e.g. Wingdings on systems that have it).
       const convertedFamily = bulletLabel !== b.char ? 'sans-serif' : normalizeFontFamily(b.fontFamily ?? null, rc);
       bulletFont  = buildFont(false, false, bSizePx, convertedFamily, rc);
       bulletColor = b.color ? hexToRgba(b.color) : bulletInheritedColor;
-      // Reset counters when switching to char bullets
-      autoNumCounters.clear();
     } else if (para.bullet.type === 'autoNum') {
-      const b = para.bullet;
-      const lvl = para.lvl;
-      if (!autoNumCounters.has(lvl)) {
-        autoNumCounters.set(lvl, b.startAt ?? 1);
-      } else {
-        autoNumCounters.set(lvl, autoNumCounters.get(lvl)! + 1);
-      }
-      bulletLabel = formatAutoNum(autoNumCounters.get(lvl)!, b.numType);
       bulletFont  = buildFont(false, false, bulletBaseSizePx, 'sans-serif', rc);
       bulletColor = bulletInheritedColor;
-    } else {
-      // Not a list paragraph — reset autoNum counters
-      autoNumCounters.clear();
     }
 
     // Text start X and wrap width.


### PR DESCRIPTION
## Problem
The pptx renderer drew a bullet / autoNum marker on **every** list paragraph and advanced the autoNum counter for each one, regardless of whether the paragraph had any text. An empty paragraph (a line the user created by pressing Enter on a blank line) therefore rendered a stray bullet glyph or number and pushed the rest of the numbered sequence off by one.

Example: a list authored as `1. foo` / *(blank line)* / `bar` was rendered as `1. foo` / `2.` *(on the blank line)* / `3. bar`.

## PowerPoint behaviour (reference)
PowerPoint never draws a marker on an empty paragraph and never advances the autoNum counter for it. A blank line between numbered items stays unnumbered while the sequence continues — `1.` / *(blank, no number)* / `2.`. ECMA-376 §21.1.2.4.x (CT_Bullet / CT_TextCharBullet / CT_TextAutoNumberBullet) gives no numeric rule for empty paragraphs, so PowerPoint's runtime behaviour is the reference implementation.

## Fix
`packages/pptx/src/renderer.ts`:
- Added pure exported helper `paragraphHasRenderableContent(para)` — true iff the paragraph has a non-empty text run or any equation run (a lone line break is **not** content).
- Extracted the marker-label resolution + autoNum counter walk into pure exported `resolveBulletLabel(para, autoNumCounters)`. It returns `''` (no marker) and skips the counter advance whenever the paragraph has no renderable content, for both `char` and `autoNum` bullets. Font/colour resolution stays in the renderer (needs canvas/theme context).
- The empty-paragraph test is the plain "is there content?" check — no sample-specific constants or heuristics (per repo policy: spec-faithful over empirical).

## Tests
`packages/pptx/src/empty-bullet.test.ts` (14 cases):
- `paragraphHasRenderableContent`: text / no-runs / empty-string run / break-only / equation / mixed.
- `resolveBulletLabel`: suppresses char + autoNum markers on empty paragraphs; still draws them when the paragraph has text; autoNum sequences `1, 2, 3`; **continues the sequence across a blank line / break-only paragraph** (`1.` / `''` / `2.`, not `3.`); honours `startAt`; resets the counter on a non-list paragraph.

## Verification
- **Synthetic numbered list** (skia render) with a blank middle line renders `1. First` / `2. Second` / *(blank, no number)* / `3. Third` / `4. Fourth` — both behaviours confirmed visually.
- **Real sample** `private/sample-2` slide 13 (a `buChar` list with two empty paragraphs) matches the PowerPoint-export PDF: the blank lines carry no bullet. No pixel regression (its empty bullets already landed in column-overflow space, but the change is verified safe).
- `npx vitest run`: **381 passed**.
- `tsc --build` + markdown/node/vscode typecheck: **clean**.
- pptx VRT (Chrome) — **72/72 passed**, no slide regressed past the 0.5% threshold. References were **not** updated.

## Notes / scope
- No reference images updated; no pptx/pdf committed.
- ECMA-376 has no numeric rule for empty-paragraph markers; this matches PowerPoint's observed behaviour, documented in code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)