### PR TITLE
refactor(fonts): centralize per-format font-preload name collection

### DIFF
--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -4,13 +4,12 @@ import {
   preloadGoogleFonts,
   WorkerBridge,
   defaultDpr,
-  SCRIPT_PRELOAD_NAMES,
   type LoadOptions as CoreLoadOptions,
   type MathRenderer,
 } from '@silurus/ooxml-core';
 import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerRequest, WorkerResponse, DocComment, DocNote } from './types';
 import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument } from './renderer';
-import { DOCX_GOOGLE_FONTS } from './google-fonts';
+import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import type {
   DocumentMeta,
   RenderWorkerRequest,
@@ -91,20 +90,8 @@ export class DocxDocument {
       mode === 'worker' ? !!opts.useGoogleFonts : false,
     );
     if (mode === 'main' && opts.useGoogleFonts && doc._document) {
-      // Always load the generic Arabic fallbacks so any Arabic-script run gets
-      // a real web font even when its named family is unmapped (the renderer's
-      // font fallback chains end with these two Noto faces).
       await preloadGoogleFonts(
-        [
-          doc._document.majorFont,
-          doc._document.minorFont,
-          'Noto Naskh Arabic',
-          'Noto Sans Arabic',
-          // Always queue every script Noto face so a glyph that falls through
-          // the chain (CJK / Cyrillic / Thai / Devanagari / Hebrew) resolves to
-          // a real web font even when no document font maps to it by name.
-          ...SCRIPT_PRELOAD_NAMES,
-        ],
+        docxFontPreloadNames(doc._document.majorFont, doc._document.minorFont),
         DOCX_GOOGLE_FONTS,
       );
     }

--- a/packages/docx/src/google-fonts.ts
+++ b/packages/docx/src/google-fonts.ts
@@ -1,4 +1,4 @@
-import { SCRIPT_GOOGLE_FONTS, type FontPreloadEntry } from '@silurus/ooxml-core';
+import { SCRIPT_GOOGLE_FONTS, SCRIPT_PRELOAD_NAMES, type FontPreloadEntry } from '@silurus/ooxml-core';
 
 /** Theme-referenced typefaces commonly used by DOCX templates. Mirrors the
  *  PPTX map — these are the well-known free webfont alternatives Microsoft
@@ -43,3 +43,22 @@ export const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   // loaded only when useGoogleFonts is on — no binaries ship in the bundle.
   ...SCRIPT_GOOGLE_FONTS,
 };
+
+/**
+ * The font-family names to preload for a document: the theme major/minor fonts,
+ * the generic Arabic fallbacks, and every script Noto face. The renderer's font
+ * fallback chains end with those Noto faces, so they must be loaded for any
+ * Arabic/CJK/Cyrillic/Thai/Devanagari/Hebrew glyph that falls through the chain
+ * to resolve to a real web font instead of an OS face or tofu.
+ *
+ * Single source of truth shared by the main-thread `load()` and the render
+ * worker, so both modes preload an identical set — worker/main rendering must
+ * stay pixel-equivalent. (Fonts must also be loaded before pagination, which
+ * measures text; both callers await this before paginating.)
+ */
+export function docxFontPreloadNames(
+  majorFont: string | null | undefined,
+  minorFont: string | null | undefined,
+): (string | null | undefined)[] {
+  return [majorFont, minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic', ...SCRIPT_PRELOAD_NAMES];
+}

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -8,10 +8,10 @@
  * Single-document contract: the proxy issues one `parse` and then renders.
  */
 import init, { parse_docx } from './wasm/docx_parser.js';
-import { decodeDataUrl, preloadGoogleFonts, SCRIPT_PRELOAD_NAMES } from '@silurus/ooxml-core';
+import { decodeDataUrl, preloadGoogleFonts } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
 import { paginateDocument, renderDocumentToCanvas } from './renderer';
-import { DOCX_GOOGLE_FONTS } from './google-fonts';
+import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import type { RenderWorkerRequest, RenderWorkerResponse, DocumentMeta } from './worker-protocol';
 
 let initPromise: Promise<unknown> | null = null;
@@ -42,7 +42,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         // Pagination measures text, so fonts must land BEFORE computePages —
         // same ordering the main-mode load() guarantees.
         await preloadGoogleFonts(
-          [doc.majorFont, doc.minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic', ...SCRIPT_PRELOAD_NAMES],
+          docxFontPreloadNames(doc.majorFont, doc.minorFont),
           DOCX_GOOGLE_FONTS,
         );
       }

--- a/packages/pptx/src/google-fonts.ts
+++ b/packages/pptx/src/google-fonts.ts
@@ -1,4 +1,4 @@
-import { SCRIPT_GOOGLE_FONTS, type FontPreloadEntry } from '@silurus/ooxml-core';
+import { SCRIPT_GOOGLE_FONTS, SCRIPT_PRELOAD_NAMES, type FontPreloadEntry } from '@silurus/ooxml-core';
 
 /** Theme-referenced typefaces commonly used by PPTX templates. Keys are
  *  lower-cased family names. Entries that substitute a metric-compatible
@@ -47,3 +47,21 @@ export const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   // loaded only when useGoogleFonts is on — no binaries ship in the bundle.
   ...SCRIPT_GOOGLE_FONTS,
 };
+
+/**
+ * The font-family names to preload for a presentation: the theme major/minor
+ * fonts, the generic Arabic fallbacks, and every script Noto face. The renderer's
+ * canvas font stack ends with those fallbacks, so they must be loaded for any
+ * Arabic/CJK/Cyrillic/Thai/Devanagari/Hebrew glyph that falls through the stack
+ * to resolve to a real web font instead of an OS face or tofu.
+ *
+ * Single source of truth shared by the main-thread `load()` and the render
+ * worker, so both modes preload an identical set — worker/main rendering must
+ * stay pixel-equivalent.
+ */
+export function pptxFontPreloadNames(
+  majorFont: string | null | undefined,
+  minorFont: string | null | undefined,
+): (string | null | undefined)[] {
+  return [majorFont, minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic', ...SCRIPT_PRELOAD_NAMES];
+}

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -7,11 +7,10 @@ import {
   WorkerBridge,
   defaultDpr,
   isHTMLCanvas,
-  SCRIPT_PRELOAD_NAMES,
   type LoadOptions as CoreLoadOptions,
   type MathRenderer,
 } from '@silurus/ooxml-core';
-import { PPTX_GOOGLE_FONTS } from './google-fonts';
+import { PPTX_GOOGLE_FONTS, pptxFontPreloadNames } from './google-fonts';
 import { findMimeTypeForPath } from './media-mime';
 import type {
   PresentationMeta,
@@ -147,20 +146,8 @@ export class PptxPresentation {
     );
     if (mode === 'main' && opts.useGoogleFonts && pres._presentation) {
       const parsed = pres._presentation;
-      // Always load the generic Arabic fallbacks so any Arabic-script run gets
-      // a real web font even when its named family is unmapped (the renderer's
-      // canvas font stack ends with these two Noto faces).
       await preloadGoogleFonts(
-        [
-          parsed.majorFont,
-          parsed.minorFont,
-          'Noto Naskh Arabic',
-          'Noto Sans Arabic',
-          // Always queue every script Noto face so a glyph falling through the
-          // stack (CJK / Cyrillic / Thai / Devanagari / Hebrew) resolves to a
-          // real web font even when no slide font maps to it by name.
-          ...SCRIPT_PRELOAD_NAMES,
-        ],
+        pptxFontPreloadNames(parsed.majorFont, parsed.minorFont),
         PPTX_GOOGLE_FONTS,
       );
     }

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -14,8 +14,8 @@ import init, { parse_pptx, extract_media } from './wasm/pptx_parser.js';
 import { renderSlide } from './renderer';
 import { selectNotes } from './notes';
 import { findMimeTypeForPath } from './media-mime';
-import { PPTX_GOOGLE_FONTS } from './google-fonts';
-import { preloadGoogleFonts, decodeDataUrl, SCRIPT_PRELOAD_NAMES } from '@silurus/ooxml-core';
+import { PPTX_GOOGLE_FONTS, pptxFontPreloadNames } from './google-fonts';
+import { preloadGoogleFonts, decodeDataUrl } from '@silurus/ooxml-core';
 import type { RenderWorkerRequest, RenderWorkerResponse, PresentationMeta } from './worker-protocol';
 
 let ready = false;
@@ -73,7 +73,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         // Kick the preload now so it overlaps with main-thread work; renders
         // await `fontsLoaded` so text never rasterizes with fallback metrics.
         fontsLoaded = preloadGoogleFonts(
-          [pres.majorFont, pres.minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic', ...SCRIPT_PRELOAD_NAMES],
+          pptxFontPreloadNames(pres.majorFont, pres.minorFont),
           PPTX_GOOGLE_FONTS,
         );
       }

--- a/packages/xlsx/src/google-fonts.ts
+++ b/packages/xlsx/src/google-fonts.ts
@@ -1,4 +1,5 @@
-import { SCRIPT_GOOGLE_FONTS, type FontPreloadEntry } from '@silurus/ooxml-core';
+import { SCRIPT_GOOGLE_FONTS, SCRIPT_PRELOAD_NAMES, type FontPreloadEntry } from '@silurus/ooxml-core';
+import type { Styles } from './types.js';
 
 /** Office font name → metric-compatible Google Fonts substitute. These are
  *  the well-known pairings Microsoft and Google both publish and ship on
@@ -42,3 +43,27 @@ export const XLSX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   // appended to the default chain. Loaded only when useGoogleFonts is on.
   ...SCRIPT_GOOGLE_FONTS,
 };
+
+/**
+ * The font-family names to preload for a workbook: every styled cell font, the
+ * generic Arabic fallbacks, and every script Noto face. Office faces map to
+ * metric-compatible substitutes (Calibri → Carlito, Cambria → Caladea); the
+ * renderer's default chain ends with the Noto faces, so they must be loaded for
+ * any Arabic/CJK/Cyrillic/Thai/Devanagari/Hebrew glyph that falls through to
+ * resolve to a real web font instead of an OS face or tofu. A workbook using
+ * only system fonts (no map entries) still produces zero network requests.
+ *
+ * Single source of truth shared by the main-thread `_load()` and the render
+ * worker, so both modes preload an identical set — worker/main rendering must
+ * stay pixel-equivalent.
+ */
+export function xlsxFontPreloadNames(styles: Styles | undefined): Set<string> {
+  const names = new Set<string>();
+  for (const f of styles?.fonts ?? []) {
+    if (f.name) names.add(f.name);
+  }
+  names.add('Noto Naskh Arabic');
+  names.add('Noto Sans Arabic');
+  for (const n of SCRIPT_PRELOAD_NAMES) names.add(n);
+  return names;
+}

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -10,9 +10,9 @@
  * stale sheets / images.
  */
 import init, { parse_xlsx, parse_sheet } from './wasm/xlsx_parser.js';
-import { decodeDataUrl, preloadGoogleFonts, SCRIPT_PRELOAD_NAMES } from '@silurus/ooxml-core';
+import { decodeDataUrl, preloadGoogleFonts } from '@silurus/ooxml-core';
 import { renderWorksheetViewport } from './render-orchestrator.js';
-import { XLSX_GOOGLE_FONTS } from './google-fonts.js';
+import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import type { ParsedWorkbook, Worksheet } from './types.js';
 import type { RenderWorkerRequest, RenderWorkerResponse } from './worker-protocol.js';
 
@@ -68,14 +68,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         // every styled font name, plus the generic Arabic fallbacks. Fonts must
         // land before rendering (which measures text), so we keep the promise
         // and await it in the renderViewport handler.
-        const names = new Set<string>();
-        for (const f of workbook.styles?.fonts ?? []) {
-          if (f.name) names.add(f.name);
-        }
-        names.add('Noto Naskh Arabic');
-        names.add('Noto Sans Arabic');
-        for (const n of SCRIPT_PRELOAD_NAMES) names.add(n);
-        fontsLoaded = preloadGoogleFonts(names, XLSX_GOOGLE_FONTS);
+        fontsLoaded = preloadGoogleFonts(xlsxFontPreloadNames(workbook.styles), XLSX_GOOGLE_FONTS);
       }
       post({ type: 'parsed', id, workbook });
       return;

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -4,13 +4,12 @@ import {
   preloadGoogleFonts,
   WorkerBridge,
   defaultDpr,
-  SCRIPT_PRELOAD_NAMES,
   type LoadOptions as CoreLoadOptions,
   type MathRenderer,
 } from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, WorkerRequest, WorkerResponse, Cell } from './types.js';
 import { renderWorksheetViewport } from './render-orchestrator.js';
-import { XLSX_GOOGLE_FONTS } from './google-fonts.js';
+import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { formatCellValue } from './number-format.js';
 import {
   parseListFormula,
@@ -120,24 +119,10 @@ export class XlsxWorkbook {
     // sheetNames / tabColors / resolveValidationList keep working.
     this.parsedWorkbook = (parsed as Extract<WorkerResponse, { type: 'parsed' }>).workbook;
     if (this._mode === 'main' && opts.useGoogleFonts) {
-      // Walk every styled font in the workbook and queue Google Fonts
-      // substitutes for any Office faces (Calibri → Carlito, Cambria →
-      // Caladea). Documents that use only system fonts produce zero
-      // network requests.
-      const names = new Set<string>();
-      for (const f of this.parsedWorkbook.styles?.fonts ?? []) {
-        if (f.name) names.add(f.name);
-      }
-      // Always load the generic Arabic fallbacks so any Arabic-script cell
-      // gets a real web font even when its named family is unmapped (the
-      // renderer's DEFAULT_FONT_FAMILY chain ends with these two Noto faces).
-      names.add('Noto Naskh Arabic');
-      names.add('Noto Sans Arabic');
-      // Always queue every script Noto face so a glyph falling through the
-      // chain (CJK / Cyrillic / Thai / Devanagari / Hebrew) resolves to a real
-      // web font even when no cell font maps to it by name.
-      for (const n of SCRIPT_PRELOAD_NAMES) names.add(n);
-      await preloadGoogleFonts(names, XLSX_GOOGLE_FONTS);
+      await preloadGoogleFonts(
+        xlsxFontPreloadNames(this.parsedWorkbook.styles),
+        XLSX_GOOGLE_FONTS,
+      );
     }
   }
 


### PR DESCRIPTION
## Why

Follow-up cleanup from the worker-rendering merge (#427). Integrating the script→Noto font-fallback feature (#426) left each format's "which font names to preload" list **duplicated** between its main-thread `load()` and its render worker — and #426's `...SCRIPT_PRELOAD_NAMES` had to be added to both copies by hand. A future fallback addition to only one copy would silently desync worker-mode vs main-mode rendering (only the demo-sample equivalence tests would catch it, and only for the scripts those samples happen to use).

## What

Extract one collector per format, colocated with its `*_GOOGLE_FONTS` map in `google-fonts.ts` — making that module the single source of truth for what the format preloads:

- `pptxFontPreloadNames(major, minor)` / `docxFontPreloadNames(major, minor)` → theme major/minor + Arabic fallbacks + script Noto faces.
- `xlsxFontPreloadNames(styles)` → every styled cell font + Arabic fallbacks + script Noto faces.

`load()` (main mode) and `render-worker.ts` (worker mode) now call the same function in all three packages, so worker/main font parity is **structural** rather than hand-maintained. 6 inline collections → 3 shared helpers.

## No behavior change

The collected set is identical; this only removes the duplication.

- worker/main equivalence: pptx 0.000 / 0.506 / 0.000 %, docx 0.000 / 0.000 %, xlsx 0.000 / 0.000 % (unchanged)
- pptx VRT 75 passed (main-mode non-regression), unit 425 passed, `pnpm -r typecheck` clean.

Do not squash-merge (repo policy): use `--merge` or `--rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)