### PR TITLE
fix(docx): honor m:oMathParaPr/m:jc for display-math cell layout

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -14,6 +14,9 @@ use crate::xml_util::*;
 
 const DEFAULT_FONT_SIZE: f64 = 10.0; // pt fallback
 
+/// OMML (math) namespace — ECMA-376 §22.
+const M_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/math";
+
 type Zip<'a> = ZipArchive<std::io::Cursor<&'a [u8]>>;
 
 /// Section-level header/footer references collected from sectPr.
@@ -587,13 +590,33 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
     let no_line_breaks_before = collect("noLineBreaksBefore");
     let no_line_breaks_after = collect("noLineBreaksAfter");
 
-    if kinsoku.is_none() && no_line_breaks_before.is_none() && no_line_breaks_after.is_none() {
+    // ECMA-376 §22.1.2.30 `m:mathPr/m:defJc@m:val` — document-wide default math
+    // justification (math namespace, bare `val` fallback).
+    let math_def_jc = root
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "mathPr")
+        .and_then(|mp| {
+            mp.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "defJc")
+        })
+        .and_then(|jc| {
+            jc.attribute((M_NS, "val"))
+                .or_else(|| jc.attribute("val"))
+                .map(|s| s.to_string())
+        });
+
+    if kinsoku.is_none()
+        && no_line_breaks_before.is_none()
+        && no_line_breaks_after.is_none()
+        && math_def_jc.is_none()
+    {
         return None;
     }
     Some(crate::types::DocumentSettings {
         kinsoku,
         no_line_breaks_before,
         no_line_breaks_after,
+        math_def_jc,
     })
 }
 
@@ -1090,13 +1113,12 @@ fn parse_paragraph(
         }
     }
 
-    let mut alignment = base_para
+    let alignment = base_para
         .alignment
         .as_deref()
         .map(normalize_align)
         .unwrap_or("left")
         .to_string();
-    let alignment_explicit = base_para.alignment.is_some();
     let indent_right = base_para.indent_right.unwrap_or(0.0);
     let space_before = base_para.space_before.unwrap_or(0.0);
     let space_after = base_para.space_after.unwrap_or(0.0);
@@ -1163,16 +1185,12 @@ fn parse_paragraph(
         node, &base_run, style_map, media_map, rel_map, theme, &mut runs, None,
     );
 
-    // OMML display equations (m:oMathPara) are center-justified by default (§22.1.2.88
-    // m:jc). When the paragraph has no explicit alignment, centering the block math
-    // matches Word.
-    if !alignment_explicit
-        && runs
-            .iter()
-            .any(|r| matches!(r, DocRun::Math { display: true, .. }))
-    {
-        alignment = "center".to_string();
-    }
+    // NOTE: We do NOT force display-math paragraphs to center here. The math
+    // block's justification (ECMA-376 §22.1.2.88 `m:jc` / §22.1.2.30 `m:defJc`)
+    // is a concept independent of the paragraph's text `w:jc`; it is resolved by
+    // the renderer from the per-instance `jc` on the Math run and the document
+    // default `mathDefJc` (spec default `centerGroup`). The paragraph alignment
+    // stays its natural text value (e.g. Tabletext = left).
 
     let tab_stops = base_para
         .tab_stops
@@ -1353,11 +1371,28 @@ fn parse_para_content(
                         nodes,
                         display: false,
                         font_size: base_run.font_size.unwrap_or(DEFAULT_FONT_SIZE),
+                        jc: None,
                     });
                 }
             }
             "oMathPara" => {
                 // A block math paragraph wraps one or more m:oMath children.
+                // ECMA-376 §22.1.2.88 — `m:oMathParaPr/m:jc@m:val` (math namespace,
+                // bare `val` fallback) is the per-instance justification of the
+                // display equation. Document-default (`m:defJc`) resolution is the
+                // renderer's job; we only surface the explicit per-instance value.
+                let para_jc = child
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "oMathParaPr")
+                    .and_then(|pr| {
+                        pr.children()
+                            .find(|n| n.is_element() && n.tag_name().name() == "jc")
+                    })
+                    .and_then(|jc| {
+                        jc.attribute((M_NS, "val"))
+                            .or_else(|| jc.attribute("val"))
+                            .map(|s| s.to_string())
+                    });
                 for om in child
                     .children()
                     .filter(|n| n.is_element() && n.tag_name().name() == "oMath")
@@ -1368,6 +1403,7 @@ fn parse_para_content(
                             nodes,
                             display: true,
                             font_size: base_run.font_size.unwrap_or(DEFAULT_FONT_SIZE),
+                            jc: para_jc.clone(),
                         });
                     }
                 }
@@ -3869,6 +3905,104 @@ mod tests {
         );
         assert_eq!(t.width_pt, None);
         assert_eq!(t.width_pct, None);
+    }
+}
+
+#[cfg(test)]
+mod math_jc_tests {
+    use super::*;
+    use crate::xml_util::W_NS;
+
+    const M_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/math";
+
+    /// Build a `<w:p>` declaring both the w and m namespaces and run it through
+    /// `parse_paragraph`, analogous to `parse_tbl` above.
+    fn parse_p(inner: &str) -> DocParagraph {
+        let xml = format!(
+            r#"<w:p xmlns:w="{w}" xmlns:m="{m}">{inner}</w:p>"#,
+            w = W_NS,
+            m = M_NS
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let style_map = StyleMap::parse("");
+        let mut num_map = NumberingMap::default();
+        let media: HashMap<String, String> = HashMap::new();
+        let rels: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+        parse_paragraph(
+            doc.root_element(),
+            &style_map,
+            &mut num_map,
+            &media,
+            &rels,
+            &theme,
+            None,
+        )
+    }
+
+    fn first_math_jc(p: &DocParagraph) -> Option<&Option<String>> {
+        p.runs.iter().find_map(|r| match r {
+            DocRun::Math { jc, .. } => Some(jc),
+            _ => None,
+        })
+    }
+
+    // ECMA-376 §22.1.2.88 `m:jc` — the per-instance justification on
+    // `m:oMathPara/m:oMathParaPr` reaches the display Math run.
+    #[test]
+    fn omathpara_jc_left_sets_run_jc() {
+        let p = parse_p(
+            r#"<m:oMathPara><m:oMathParaPr><m:jc m:val="left"/></m:oMathParaPr>
+               <m:oMath><m:r><m:t>α</m:t></m:r></m:oMath></m:oMathPara>"#,
+        );
+        assert_eq!(first_math_jc(&p), Some(&Some("left".to_string())));
+    }
+
+    // ECMA-376 §22.1.2.88 — absent `m:oMathParaPr` ⇒ no per-instance jc; the
+    // document default (`m:defJc`) resolution is left to the renderer.
+    #[test]
+    fn omathpara_without_jc_is_none() {
+        let p = parse_p(r#"<m:oMathPara><m:oMath><m:r><m:t>α</m:t></m:r></m:oMath></m:oMathPara>"#);
+        assert_eq!(first_math_jc(&p), Some(&None));
+    }
+
+    // ECMA-376 §22.1.2.77 `m:oMath` — inline math carries no oMathPara jc.
+    #[test]
+    fn inline_omath_jc_is_none() {
+        let p = parse_p(r#"<m:oMath><m:r><m:t>α</m:t></m:r></m:oMath>"#);
+        assert_eq!(first_math_jc(&p), Some(&None));
+    }
+
+    // ECMA-376 §22.1.2.30 `m:defJc` — document-wide default math justification in
+    // `word/settings.xml` `m:mathPr` surfaces as `math_def_jc`; absent ⇒ None.
+    #[test]
+    fn settings_defjc_surfaces() {
+        let xml = format!(
+            r#"<w:settings xmlns:w="{w}" xmlns:m="{m}">
+                 <m:mathPr><m:defJc m:val="centerGroup"/></m:mathPr>
+               </w:settings>"#,
+            w = W_NS,
+            m = M_NS
+        );
+        let s = parse_document_settings(&xml).expect("settings present (defJc)");
+        assert_eq!(s.math_def_jc.as_deref(), Some("centerGroup"));
+
+        let empty = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>"#;
+        assert!(parse_document_settings(empty).is_none());
+    }
+
+    // ECMA-376 §22.1.2.88 + §17.3.1.13 `w:jc` — a display-math paragraph with no
+    // explicit text alignment must keep its natural text alignment ("left" for
+    // a Tabletext-styled cell). The math block's own justification is handled by
+    // the renderer via `m:jc`/`m:defJc`, NOT by force-centering the paragraph.
+    #[test]
+    fn display_math_para_alignment_not_forced_center() {
+        // No w:jc in pPr ⇒ natural default is "left"; oMathPara present.
+        let p = parse_p(
+            r#"<m:oMathPara><m:oMathParaPr><m:jc m:val="left"/></m:oMathParaPr>
+               <m:oMath><m:r><m:t>α</m:t></m:r></m:oMath></m:oMathPara>"#,
+        );
+        assert_eq!(p.alignment, "left");
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -74,6 +74,11 @@ pub struct DocumentSettings {
     /// cannot end a line (行末禁則). Replaces the default when present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_line_breaks_after: Option<String>,
+    /// §22.1.2.30 `m:mathPr/m:defJc@m:val` — document-wide default math
+    /// justification (ST_Jc math). `None` when absent; the renderer then falls
+    /// back to the spec default `centerGroup`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub math_def_jc: Option<String>,
 }
 
 /// Single track-changes event extracted from a body `<w:ins>` / `<w:del>`.
@@ -347,6 +352,12 @@ pub enum DocRun {
         display: bool,
         /// Resolved paragraph font size (pt) so the equation matches surrounding text.
         font_size: f64,
+        /// ECMA-376 §22.1.2.88 `m:oMathPara/m:oMathParaPr/m:jc` — per-instance
+        /// justification of a display equation (ST_Jc math: left|right|center|
+        /// centerGroup). Only set for display math; inline `m:oMath` is `None`.
+        /// Document-default (`m:defJc`) resolution is left to the renderer.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        jc: Option<String>,
     },
 }
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -25,6 +25,7 @@ import {
   segmentsHaveRtl,
   computeLineVisualOrder,
   resolveAlignEdge,
+  type AlignEdge,
   type LineVisualOrder,
 } from './bidi-line.js';
 
@@ -170,6 +171,11 @@ interface RenderState {
    *  (kinsoku enabled flag + line-start/line-end forbidden character sets).
    *  Default is the application's Japanese kinsoku table with kinsoku ON. */
   kinsoku: KinsokuRules;
+  /** ECMA-376 §22.1.2.30 `m:mathPr/m:defJc` — document-wide default math
+   *  justification (ST_Jc math). `undefined` ⇒ spec default `centerGroup`.
+   *  Threaded from `doc.settings.mathDefJc` like `kinsoku`; consumed by the
+   *  per-line alignment step for single display-math lines. */
+  mathDefJc?: string;
   /** Callback for building a transparent text selection overlay. */
   onTextRun?: (run: DocxTextRunInfo) => void;
   /** When false, runs tagged with a `revision` render without the
@@ -404,6 +410,7 @@ export async function renderDocumentToCanvas(
     docGrid: { type: sec.docGridType ?? null, linePitchPt: sec.docGridLinePitch ?? null },
     fontFamilyClasses: doc.fontFamilyClasses ?? {},
     kinsoku,
+    mathDefJc: doc.settings?.mathDefJc,
     onTextRun: opts.onTextRun,
     showTrackChanges: opts.showTrackChanges ?? true,
     noteNumbers,
@@ -1587,6 +1594,27 @@ function renderParaList(paras: DocParagraph[], state: RenderState): void {
 
 // ===== Paragraph rendering =====
 
+/**
+ * Map an ST_Jc (math) value to a physical alignment edge for a display
+ * equation. ECMA-376 §22.1.2.88: `left`→left, `right`→right, `center` and
+ * `centerGroup`→center (for a single equation centerGroup is identical to
+ * center; the group-block distinction is out of scope — see spec YAGNI). The
+ * math jc is an absolute position within the block, not a logical start/end, so
+ * it is NOT flipped by the paragraph base direction.
+ */
+function mathJcToEdge(jc: string): AlignEdge {
+  switch (jc) {
+    case 'left':
+      return 'left';
+    case 'right':
+      return 'right';
+    case 'center':
+    case 'centerGroup':
+    default:
+      return 'center';
+  }
+}
+
 function renderParagraph(
   para: DocParagraph,
   state: RenderState,
@@ -1775,11 +1803,26 @@ function renderParagraph(
     const lineSlack = effAvailW - (x - lineLeft) - lineWidth;
     const applyJustify = isJustified && (!isLastLine || stretchLastLine);
     let alignOffset = 0;
-    if (alignEdge === 'right') {
+    // ECMA-376 §22.1.2.88 `m:jc` / §22.1.2.30 `m:defJc` — a display equation's
+    // justification is independent of the paragraph's text alignment. When this
+    // line is exactly one display-math segment, resolve its effective math jc
+    // (per-instance → document default → spec default `centerGroup`) and use it
+    // for THIS line only, overriding the paragraph alignEdge.
+    const onlyMathSeg =
+      line.segments.length === 1 &&
+      'mathNodes' in line.segments[0] &&
+      (line.segments[0] as LayoutMathSeg).display
+        ? (line.segments[0] as LayoutMathSeg)
+        : null;
+    const mathEdge = onlyMathSeg
+      ? mathJcToEdge(onlyMathSeg.jc ?? state.mathDefJc ?? 'centerGroup')
+      : null;
+    const effEdge = mathEdge ?? alignEdge;
+    if (effEdge === 'right') {
       alignOffset = lineSlack;
-    } else if (alignEdge === 'center') {
+    } else if (effEdge === 'center') {
       alignOffset = lineSlack / 2;
-    } else if (alignEdge === 'justify' && baseRtl && !applyJustify) {
+    } else if (effEdge === 'justify' && baseRtl && !applyJustify) {
       // The unstretched (last) line of a justified RTL paragraph aligns to the
       // leading edge — the RIGHT margin (§17.18.44 `both`: last line is
       // start-aligned). LTR keeps alignOffset 0 as before.
@@ -2054,6 +2097,10 @@ interface LayoutMathSeg {
   /** px ascent/descent of the laid-out box at scale, cached during measurement. */
   mathAscent: number;
   mathDescent: number;
+  /** ECMA-376 §22.1.2.88 `m:oMathPara/m:jc` — per-instance justification of a
+   *  display equation (ST_Jc math). `undefined` for inline math; the renderer
+   *  resolves the document default (`mathDefJc`, spec default `centerGroup`). */
+  jc?: string;
 }
 
 /** Sentinel that forces a new line when encountered in layoutLines. */
@@ -2259,6 +2306,7 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         measuredWidth: 0,
         mathAscent: 0,
         mathDescent: 0,
+        jc: run.jc,
       });
     }
   }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -52,6 +52,10 @@ export interface DocSettings {
   /** §17.15.1.59 `w:noLineBreaksAfter@w:val` — custom set of characters that
    *  cannot end a line (行末禁則). Replaces the default when present. */
   noLineBreaksAfter?: string;
+  /** §22.1.2.30 `m:mathPr/m:defJc@m:val` — document-wide default math
+   *  justification (ST_Jc math: left|right|center|centerGroup). `undefined`
+   *  ⇒ the renderer uses the spec default `centerGroup`. */
+  mathDefJc?: string;
 }
 
 export interface DocRevision {
@@ -254,7 +258,7 @@ export type DocRun =
   | { type: 'break'; breakType: 'line' | 'page' | 'column' }
   | { type: 'field' } & FieldRun
   | { type: 'shape' } & ShapeRun
-  | { type: 'math'; nodes: MathNode[]; display: boolean; fontSize: number };
+  | { type: 'math'; nodes: MathNode[]; display: boolean; fontSize: number; jc?: string };
 
 export type PathCmd =
   | { cmd: 'moveTo'; x: number; y: number }


### PR DESCRIPTION
## Problem

Display-math paragraphs (`<m:oMathPara>`) inside table cells were always rendered **center-aligned**. In `sample-6.docx`'s "Appendix: Alphabets / Greek" table, the single Greek-letter cells (α, β, Α, Σ, …) carry an explicit `<m:oMathParaPr><m:jc m:val="left"/>` yet rendered centered instead of left, diverging from Word.

### Root cause
1. The parser's `oMathPara` branch dropped `m:oMathParaPr/m:jc` entirely.
2. A heuristic blanket-set `alignment = "center"` for any paragraph containing a display-math run with no explicit `w:jc`.

The `" or "` cells (ε/ϵ, σ/ς) used *inline* `<m:oMath>` + text and happened to be left-aligned by inheriting the `Tabletext` (left) paragraph default.

## Fix (ECMA-376 §22.1.2.88 / §22.1.2.30)

Treat math-paragraph justification (`m:jc`) as a concept distinct from text-paragraph `w:jc`, resolved as: per-instance `m:oMathParaPr/m:jc` → document `settings.xml m:mathPr/m:defJc` (default `centerGroup`) → `centerGroup`.

- **parser**: read `m:oMathParaPr/m:jc` onto `DocRun::Math.jc` (display only); surface `m:defJc` as `DocumentSettings.math_def_jc`; **remove the force-center heuristic** so paragraph alignment keeps its natural value.
- **renderer**: carry `jc` on `LayoutMathSeg` and `mathDefJc` on `RenderState` (threaded like resolved kinsoku); for a line that is a single display-math segment, resolve `seg.jc ?? mathDefJc ?? 'centerGroup'` and align that line by it, overriding the paragraph edge for that line only.
- **TS types**: `jc?` on the math run; `mathDefJc?` on `DocSettings`.

Bare display-math with no per-instance `m:jc` still centers via `defJc=centerGroup`.

## Verification

- **Rust unit tests (TDD)**: 5 new tests RED→GREEN (per-instance jc, absent jc, inline jc, defJc surfacing, heuristic-removal alignment); 38 total pass.
- **WASM build / TS typecheck**: clean.
- **VRT**: no regression on committed references (demo/sample-1, worker-equivalence).
- **Visual vs Word PDF (sample-6)**: (a) α/Α cells now left-aligned; (b) bare display-math δ example still centered — both match `sample-6.pdf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)