### PR TITLE
feat(viewers): add mode:'worker' to all three Viewers (offscreen rendering)

### DIFF
--- a/packages/docx/src/DocxViewer.stories.ts
+++ b/packages/docx/src/DocxViewer.stories.ts
@@ -31,6 +31,7 @@ type Story = StoryObj<Args>;
 export function buildViewerUI(
   args: Args,
   autoLoadUrl?: string,
+  extra?: { mode?: 'main' | 'worker' },
 ): { root: HTMLElement; doc: DocxDocument | null } {
   const root = document.createElement('div');
   root.style.cssText = 'font-family:sans-serif;padding:16px;';
@@ -69,6 +70,7 @@ export function buildViewerUI(
     enableTextSelection: true,
     useGoogleFonts: true,
     math,
+    ...extra,
   });
 
   const updateNav = () => {

--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -34,72 +34,10 @@ export const Demo: DemoStory = {
 
 export const Offscreen: DemoStory = {
   name: 'Offscreen — Web Worker rendering (demo.docx)',
+  // The single-viewer Demo, rendered entirely in a Web Worker (mode: 'worker').
+  // Identical UX — only the pixels are produced off the main thread.
   render(args) {
-    const root = document.createElement('div');
-    root.style.cssText = 'font-family:sans-serif;padding:16px;';
-    const heading = document.createElement('h3');
-    heading.textContent = 'Offscreen — parsed and rendered in a Web Worker';
-    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
-    root.appendChild(heading);
-    const status = makeStatus(root);
-
-    const bar = document.createElement('div');
-    bar.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:8px;';
-    const prev = document.createElement('button');
-    prev.textContent = '‹ Prev';
-    const next = document.createElement('button');
-    next.textContent = 'Next ›';
-    const label = document.createElement('span');
-    label.style.cssText = 'font-size:13px;color:#444;min-width:96px;text-align:center;';
-    bar.append(prev, label, next);
-    root.appendChild(bar);
-
-    // mode: 'worker' returns each page as an ImageBitmap; the main thread only
-    // paints it through a `bitmaprenderer` context (which consumes the bitmap).
-    // The canvas stays hidden until the first frame paints — worker init + WASM
-    // + font preload take a moment on cold load, and a pre-sized empty frame
-    // would show at the wrong dimensions and jump once the real bitmap arrives.
-    const { canvas, ctx, setBusy, reveal } = makeOffscreenStage(root);
-
-    const dpr = window.devicePixelRatio || 1;
-    let docu: DocxDocument | null = null;
-    let index = 0;
-    let busy = false;
-
-    const paint = async () => {
-      if (!docu || busy) return;
-      busy = true;
-      prev.disabled = next.disabled = true;
-      setBusy(true);
-      status.textContent = `Rendering page ${index + 1} in a Web Worker…`;
-      try {
-        const bmp = await docu.renderPageToBitmap(index, { width: args.width, dpr });
-        canvas.width = bmp.width;
-        canvas.height = bmp.height;
-        canvas.style.width = `${Math.round(bmp.width / dpr)}px`;
-        canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
-        ctx.transferFromImageBitmap(bmp);
-        reveal();
-        label.textContent = `Page ${index + 1} / ${docu.pageCount}`;
-        status.textContent = 'Rendered off the main thread — the UI never blocked.';
-      } finally {
-        busy = false;
-        setBusy(false);
-        prev.disabled = index === 0;
-        next.disabled = !docu || index >= docu.pageCount - 1;
-      }
-    };
-
-    prev.addEventListener('click', () => { if (index > 0) { index--; void paint(); } });
-    next.addEventListener('click', () => { if (docu && index < docu.pageCount - 1) { index++; void paint(); } });
-
-    DocxDocument.load(SAMPLE_URL, { mode: 'worker', useGoogleFonts: true })
-      .then((d) => { docu = d; return paint(); })
-      .catch((e: Error) => {
-        status.textContent = `Error: ${e.message}`;
-        status.style.color = 'red';
-      });
-
+    const { root } = buildViewerUI(args, SAMPLE_URL, { mode: 'worker' });
     return root;
   },
 };
@@ -110,48 +48,6 @@ function makeStatus(root: HTMLElement): HTMLDivElement {
   s.textContent = 'Loading…';
   root.appendChild(s);
   return s;
-}
-
-/** A render stage for the Offscreen story: a centred area with an indeterminate
- *  spinner overlay and a `bitmaprenderer` canvas that stays hidden until the
- *  first frame is painted (so no wrong-sized empty frame flashes during the
- *  cold-load delay). `setBusy` toggles the spinner; `reveal` shows the canvas. */
-function makeOffscreenStage(root: HTMLElement): {
-  canvas: HTMLCanvasElement;
-  ctx: ImageBitmapRenderingContext;
-  setBusy: (busy: boolean) => void;
-  reveal: () => void;
-} {
-  if (!document.getElementById('ooxml-offscreen-spin-kf')) {
-    const style = document.createElement('style');
-    style.id = 'ooxml-offscreen-spin-kf';
-    style.textContent = '@keyframes ooxml-offscreen-spin{to{transform:rotate(360deg)}}';
-    document.head.appendChild(style);
-  }
-  const stage = document.createElement('div');
-  stage.style.cssText =
-    'position:relative;min-height:200px;display:flex;align-items:flex-start;justify-content:center;';
-  const canvas = document.createElement('canvas');
-  canvas.style.cssText = 'display:none;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
-  const spinWrap = document.createElement('div');
-  // Visible from mount so the spinner covers the slow cold load (worker init +
-  // WASM + parse), not just the per-frame render; hidden after the first paint.
-  spinWrap.style.cssText =
-    'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;pointer-events:none;';
-  const spinner = document.createElement('div');
-  spinner.style.cssText =
-    'width:36px;height:36px;border:4px solid rgba(0,0,0,0.12);border-top-color:#0366d6;' +
-    'border-radius:50%;animation:ooxml-offscreen-spin 0.8s linear infinite;';
-  spinWrap.appendChild(spinner);
-  stage.append(canvas, spinWrap);
-  root.appendChild(stage);
-  const ctx = canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext;
-  return {
-    canvas,
-    ctx,
-    setBusy: (busy: boolean) => { spinWrap.style.display = busy ? 'flex' : 'none'; },
-    reveal: () => { canvas.style.display = 'block'; },
-  };
 }
 
 function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -23,10 +23,17 @@ export class DocxViewer {
   private _wrapper: HTMLDivElement;
   private _textLayer: HTMLDivElement | null = null;
   private _opts: DocxViewerOptions;
+  private readonly _mode: 'main' | 'worker';
+  /** The canvas's bitmaprenderer context, used only in worker mode (a canvas
+   *  holds one context type for its lifetime; the main-mode 2d render path is
+   *  never used on the same canvas). */
+  private _bitmapCtx: ImageBitmapRenderingContext | null = null;
+  private _warnedNoTextSelection = false;
 
   constructor(canvas: HTMLCanvasElement, opts: DocxViewerOptions = {}) {
     this._canvas = canvas;
     this._opts = opts;
+    this._mode = opts.mode ?? 'main';
 
     // Wrap canvas in a positioned container for the optional text layer overlay
     const parent = canvas.parentElement;
@@ -44,6 +51,12 @@ export class DocxViewer {
       parent.insertBefore(this._wrapper, canvas);
     }
     this._wrapper.appendChild(canvas);
+
+    // Worker mode paints worker-produced bitmaps via a bitmaprenderer context,
+    // grabbed once (a canvas holds one context type for its lifetime).
+    if (this._mode === 'worker') {
+      this._bitmapCtx = canvas.getContext('bitmaprenderer');
+    }
 
     if (opts.enableTextSelection) {
       this._textLayer = document.createElement('div');
@@ -67,6 +80,7 @@ export class DocxViewer {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         math: this._opts.math,
+        mode: this._mode,
       });
       this._currentPage = 0;
       await this._render();
@@ -112,11 +126,39 @@ export class DocxViewer {
 
   private async _render(): Promise<void> {
     if (!this._doc) return;
-    const runs: DocxTextRunInfo[] = [];
-    const onTextRun = this._textLayer ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
-    await this._doc.renderPage(this._canvas, this._currentPage, { ...this._opts, onTextRun });
-    if (this._textLayer) {
-      this._buildTextLayer(this._textLayer, runs);
+    const isWorker = this._mode === 'worker';
+    // In worker mode rendering happens off the main thread, so the onTextRun
+    // callback can't fire — the text-selection overlay is unavailable.
+    if (isWorker && this._textLayer && !this._warnedNoTextSelection) {
+      this._warnedNoTextSelection = true;
+      console.warn(
+        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
+      );
+    }
+    if (isWorker) {
+      const dpr = this._opts.dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+      // Only serializable render options may cross to the worker — spreading the
+      // full viewer opts would postMessage non-cloneable values (the math
+      // engine, callbacks, container element) and throw a DataCloneError.
+      const bmp = await this._doc.renderPageToBitmap(this._currentPage, {
+        width: this._opts.width,
+        dpr: this._opts.dpr,
+        showTrackChanges: this._opts.showTrackChanges,
+      });
+      this._canvas.width = bmp.width;
+      this._canvas.height = bmp.height;
+      // The bitmap is sized in device px; mirror the main renderer by setting
+      // the CSS size to the logical (÷dpr) dimensions so it isn't 2× on HiDPI.
+      this._canvas.style.width = `${Math.round(bmp.width / dpr)}px`;
+      this._canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
+      this._bitmapCtx?.transferFromImageBitmap(bmp);
+    } else {
+      const runs: DocxTextRunInfo[] = [];
+      const onTextRun = this._textLayer ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
+      await this._doc.renderPage(this._canvas, this._currentPage, { ...this._opts, onTextRun });
+      if (this._textLayer) {
+        this._buildTextLayer(this._textLayer, runs);
+      }
     }
     this._opts.onPageChange?.(this._currentPage, this.pageCount);
   }

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -34,72 +34,10 @@ export const Demo: DemoStory = {
 
 export const Offscreen: DemoStory = {
   name: 'Offscreen — Web Worker rendering (demo.pptx)',
+  // The single-viewer Demo, rendered entirely in a Web Worker (mode: 'worker').
+  // Identical UX — only the pixels are produced off the main thread.
   render(args) {
-    const root = document.createElement('div');
-    root.style.cssText = 'font-family:sans-serif;padding:16px;';
-    const heading = document.createElement('h3');
-    heading.textContent = 'Offscreen — parsed and rendered in a Web Worker';
-    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
-    root.appendChild(heading);
-    const status = makeStatus(root);
-
-    const bar = document.createElement('div');
-    bar.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:8px;';
-    const prev = document.createElement('button');
-    prev.textContent = '‹ Prev';
-    const next = document.createElement('button');
-    next.textContent = 'Next ›';
-    const label = document.createElement('span');
-    label.style.cssText = 'font-size:13px;color:#444;min-width:96px;text-align:center;';
-    bar.append(prev, label, next);
-    root.appendChild(bar);
-
-    // mode: 'worker' returns each slide as an ImageBitmap; the main thread only
-    // paints it through a `bitmaprenderer` context (which consumes the bitmap).
-    // The canvas stays hidden until the first frame paints — worker init + WASM
-    // + font preload take a moment on cold load, and a pre-sized empty frame
-    // would show at the wrong dimensions and jump once the real bitmap arrives.
-    const { canvas, ctx, setBusy, reveal } = makeOffscreenStage(root);
-
-    const dpr = window.devicePixelRatio || 1;
-    let pres: PptxPresentation | null = null;
-    let index = 0;
-    let busy = false;
-
-    const paint = async () => {
-      if (!pres || busy) return;
-      busy = true;
-      prev.disabled = next.disabled = true;
-      setBusy(true);
-      status.textContent = `Rendering slide ${index + 1} in a Web Worker…`;
-      try {
-        const bmp = await pres.renderSlideToBitmap(index, { width: args.width, dpr });
-        canvas.width = bmp.width;
-        canvas.height = bmp.height;
-        canvas.style.width = `${Math.round(bmp.width / dpr)}px`;
-        canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
-        ctx.transferFromImageBitmap(bmp);
-        reveal();
-        label.textContent = `Slide ${index + 1} / ${pres.slideCount}`;
-        status.textContent = 'Rendered off the main thread — the UI never blocked.';
-      } finally {
-        busy = false;
-        setBusy(false);
-        prev.disabled = index === 0;
-        next.disabled = !pres || index >= pres.slideCount - 1;
-      }
-    };
-
-    prev.addEventListener('click', () => { if (index > 0) { index--; void paint(); } });
-    next.addEventListener('click', () => { if (pres && index < pres.slideCount - 1) { index++; void paint(); } });
-
-    PptxPresentation.load(SAMPLE_URL, { mode: 'worker', useGoogleFonts: true })
-      .then((p) => { pres = p; return paint(); })
-      .catch((e: Error) => {
-        status.textContent = `Error: ${e.message}`;
-        status.style.color = 'red';
-      });
-
+    const { root } = buildViewerUI(args, SAMPLE_URL, { mode: 'worker' });
     return root;
   },
 };
@@ -110,48 +48,6 @@ function makeStatus(root: HTMLElement): HTMLDivElement {
   s.textContent = 'Loading…';
   root.appendChild(s);
   return s;
-}
-
-/** A render stage for the Offscreen story: a centred area with an indeterminate
- *  spinner overlay and a `bitmaprenderer` canvas that stays hidden until the
- *  first frame is painted (so no wrong-sized empty frame flashes during the
- *  cold-load delay). `setBusy` toggles the spinner; `reveal` shows the canvas. */
-function makeOffscreenStage(root: HTMLElement): {
-  canvas: HTMLCanvasElement;
-  ctx: ImageBitmapRenderingContext;
-  setBusy: (busy: boolean) => void;
-  reveal: () => void;
-} {
-  if (!document.getElementById('ooxml-offscreen-spin-kf')) {
-    const style = document.createElement('style');
-    style.id = 'ooxml-offscreen-spin-kf';
-    style.textContent = '@keyframes ooxml-offscreen-spin{to{transform:rotate(360deg)}}';
-    document.head.appendChild(style);
-  }
-  const stage = document.createElement('div');
-  stage.style.cssText =
-    'position:relative;min-height:200px;display:flex;align-items:flex-start;justify-content:center;';
-  const canvas = document.createElement('canvas');
-  canvas.style.cssText = 'display:none;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
-  const spinWrap = document.createElement('div');
-  // Visible from mount so the spinner covers the slow cold load (worker init +
-  // WASM + parse), not just the per-frame render; hidden after the first paint.
-  spinWrap.style.cssText =
-    'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;pointer-events:none;';
-  const spinner = document.createElement('div');
-  spinner.style.cssText =
-    'width:36px;height:36px;border:4px solid rgba(0,0,0,0.12);border-top-color:#0366d6;' +
-    'border-radius:50%;animation:ooxml-offscreen-spin 0.8s linear infinite;';
-  spinWrap.appendChild(spinner);
-  stage.append(canvas, spinWrap);
-  root.appendChild(stage);
-  const ctx = canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext;
-  return {
-    canvas,
-    ctx,
-    setBusy: (busy: boolean) => { spinWrap.style.display = busy ? 'flex' : 'none'; },
-    reveal: () => { canvas.style.display = 'block'; },
-  };
 }
 
 function buildPptxTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -29,7 +29,8 @@ type Story = StoryObj<Args>;
 // ---------------------------------------------------------------------------
 export function buildViewerUI(
   args: Args,
-  autoLoadUrl?: string
+  autoLoadUrl?: string,
+  extra?: { mode?: 'main' | 'worker' }
 ): { root: HTMLElement; viewer: PptxViewer } {
   const root = document.createElement('div');
   root.style.cssText = 'font-family:sans-serif;padding:16px;';
@@ -76,6 +77,7 @@ export function buildViewerUI(
       nextBtn.disabled = idx === total - 1;
     },
     onError: (err) => { status.textContent = `Error: ${err.message}`; },
+    ...extra,
   });
 
   prevBtn.addEventListener('click', () => viewer.prevSlide());

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -40,10 +40,17 @@ export class PptxViewer {
   private readonly opts: PptxViewerOptions;
   private currentSlide = 0;
   private handle: PresentationHandle | null = null;
+  private readonly _mode: 'main' | 'worker';
+  /** The canvas's bitmaprenderer context, used only by the static worker-mode
+   *  render path. The media-playback path keeps a 2d context (via presentSlide),
+   *  so this is obtained only when worker mode renders without media playback. */
+  private _bitmapCtx: ImageBitmapRenderingContext | null = null;
+  private _warnedNoTextSelection = false;
 
   constructor(canvas: HTMLCanvasElement, opts: PptxViewerOptions = {}) {
     this.opts = opts;
     this.canvas = canvas;
+    this._mode = opts.mode ?? 'main';
 
     const parent = canvas.parentElement;
     this.wrapper = document.createElement('div');
@@ -58,6 +65,14 @@ export class PptxViewer {
     if (!canvas.style.display) canvas.style.display = 'block';
     if (parent) parent.insertBefore(this.wrapper, canvas);
     this.wrapper.appendChild(canvas);
+
+    // Static worker-mode rendering paints worker-produced bitmaps via a
+    // bitmaprenderer context (grabbed once — a canvas holds one context type for
+    // its lifetime). The media-playback path uses presentSlide, which keeps a 2d
+    // context, so skip bitmaprenderer there.
+    if (this._mode === 'worker' && !opts.enableMediaPlayback) {
+      this._bitmapCtx = canvas.getContext('bitmaprenderer');
+    }
 
     if (opts.enableTextSelection) {
       this.textLayer = document.createElement('div');
@@ -81,6 +96,7 @@ export class PptxViewer {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         math: this.opts.math,
+        mode: this._mode,
       });
       this.currentSlide = 0;
       await this.renderCurrentSlide();
@@ -138,15 +154,31 @@ export class PptxViewer {
     this.handle?.destroy();
     this.handle = null;
 
+    const isWorker = this._mode === 'worker';
+    // In worker mode rendering happens off the main thread, so the onTextRun
+    // callback can't fire — the text-selection overlay is unavailable.
+    if (isWorker && this.textLayer && !this._warnedNoTextSelection) {
+      this._warnedNoTextSelection = true;
+      console.warn(
+        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
+      );
+    }
     const runs: PptxTextRunInfo[] = [];
-    const onTextRun = this.textLayer ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    const onTextRun = !isWorker && this.textLayer ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
 
     try {
       if (this.opts.enableMediaPlayback) {
+        // presentSlide supports both modes (worker: base off-thread, video
+        // overlay composited on the main thread).
         this.handle = await this.engine.presentSlide(this.canvas, this.currentSlide, {
           width: targetWidth,
           dpr,
         });
+      } else if (isWorker) {
+        const bmp = await this.engine.renderSlideToBitmap(this.currentSlide, { width: targetWidth, dpr });
+        this.canvas.width = bmp.width;
+        this.canvas.height = bmp.height;
+        this._bitmapCtx?.transferFromImageBitmap(bmp);
       } else {
         await this.engine.renderSlide(this.canvas, this.currentSlide, { width: targetWidth, dpr, onTextRun });
       }
@@ -155,7 +187,7 @@ export class PptxViewer {
       this.opts.onError?.(err instanceof Error ? err : new Error(String(err)));
     }
 
-    if (this.textLayer) {
+    if (this.textLayer && !isWorker) {
       this._buildTextLayer(this.textLayer, runs, targetWidth, cssHeight);
     }
   }

--- a/packages/xlsx/src/Examples.stories.ts
+++ b/packages/xlsx/src/Examples.stories.ts
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { buildViewerUI } from './XlsxViewer.stories';
-import { XlsxWorkbook } from './workbook';
 
 type Args = { scale: number };
 
@@ -26,130 +25,14 @@ export const Demo: Story = {
 };
 
 const SAMPLE_URL = `${import.meta.env.BASE_URL}xlsx/demo/sample-1.xlsx`;
-// Fixed CSS viewport for the offscreen demo: there is no DOM element to measure
-// in a worker, so renderViewportToBitmap requires explicit width/height.
-const VIEW = { row: 1, col: 1, rows: 40, cols: 12 };
-const VIEW_W = 960;
-const VIEW_H = 600;
 
 export const Offscreen: Story = {
   name: 'Offscreen — Web Worker rendering (demo.xlsx)',
+  // The single-viewer Demo, rendered entirely in a Web Worker (mode: 'worker').
+  // Identical UX — scroll, sheet tabs, cell selection — only the pixels are
+  // produced off the main thread.
   render(args) {
-    const root = document.createElement('div');
-    root.style.cssText = 'font-family:sans-serif;padding:16px;';
-    const heading = document.createElement('h3');
-    heading.textContent = 'Offscreen — parsed and rendered in a Web Worker';
-    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
-    root.appendChild(heading);
-    const status = document.createElement('div');
-    status.style.cssText = 'color:#666;font-size:13px;margin-bottom:8px;min-height:18px;';
-    status.textContent = 'Loading…';
-    root.appendChild(status);
-
-    const bar = document.createElement('div');
-    bar.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:8px;';
-    const prev = document.createElement('button');
-    prev.textContent = '‹ Prev';
-    const next = document.createElement('button');
-    next.textContent = 'Next ›';
-    const label = document.createElement('span');
-    label.style.cssText = 'font-size:13px;color:#444;min-width:140px;text-align:center;';
-    bar.append(prev, label, next);
-    root.appendChild(bar);
-
-    // mode: 'worker' returns the sheet viewport as an ImageBitmap; the main
-    // thread only paints it through a `bitmaprenderer` context. The canvas
-    // stays hidden until the first frame paints — worker init + WASM + font
-    // preload take a moment on cold load, and a pre-sized empty frame would
-    // show at the wrong dimensions and jump once the real bitmap arrives.
-    const { canvas, ctx, setBusy, reveal } = makeOffscreenStage(root);
-
-    const dpr = window.devicePixelRatio || 1;
-    let wb: XlsxWorkbook | null = null;
-    let index = 0;
-    let busy = false;
-
-    const paint = async () => {
-      if (!wb || busy) return;
-      busy = true;
-      prev.disabled = next.disabled = true;
-      setBusy(true);
-      status.textContent = `Rendering "${wb.sheetNames[index]}" in a Web Worker…`;
-      try {
-        const bmp = await wb.renderViewportToBitmap(index, VIEW, {
-          width: VIEW_W,
-          height: VIEW_H,
-          dpr,
-          cellScale: args.scale,
-        });
-        canvas.width = bmp.width;
-        canvas.height = bmp.height;
-        canvas.style.width = `${Math.round(bmp.width / dpr)}px`;
-        canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
-        ctx.transferFromImageBitmap(bmp);
-        reveal();
-        label.textContent = `${wb.sheetNames[index]} (${index + 1} / ${wb.sheetCount})`;
-        status.textContent = 'Rendered off the main thread — the UI never blocked.';
-      } finally {
-        busy = false;
-        setBusy(false);
-        prev.disabled = index === 0;
-        next.disabled = !wb || index >= wb.sheetCount - 1;
-      }
-    };
-
-    prev.addEventListener('click', () => { if (index > 0) { index--; void paint(); } });
-    next.addEventListener('click', () => { if (wb && index < wb.sheetCount - 1) { index++; void paint(); } });
-
-    XlsxWorkbook.load(SAMPLE_URL, { mode: 'worker', useGoogleFonts: true })
-      .then((w) => { wb = w; return paint(); })
-      .catch((e: Error) => {
-        status.textContent = `Error: ${e.message}`;
-        status.style.color = 'red';
-      });
-
+    const { root } = buildViewerUI(args, SAMPLE_URL, { mode: 'worker' });
     return root;
   },
 };
-
-/** A render stage for the Offscreen story: a centred area with an indeterminate
- *  spinner overlay and a `bitmaprenderer` canvas that stays hidden until the
- *  first frame is painted (so no wrong-sized empty frame flashes during the
- *  cold-load delay). `setBusy` toggles the spinner; `reveal` shows the canvas. */
-function makeOffscreenStage(root: HTMLElement): {
-  canvas: HTMLCanvasElement;
-  ctx: ImageBitmapRenderingContext;
-  setBusy: (busy: boolean) => void;
-  reveal: () => void;
-} {
-  if (!document.getElementById('ooxml-offscreen-spin-kf')) {
-    const style = document.createElement('style');
-    style.id = 'ooxml-offscreen-spin-kf';
-    style.textContent = '@keyframes ooxml-offscreen-spin{to{transform:rotate(360deg)}}';
-    document.head.appendChild(style);
-  }
-  const stage = document.createElement('div');
-  stage.style.cssText =
-    'position:relative;min-height:200px;display:flex;align-items:flex-start;justify-content:center;';
-  const canvas = document.createElement('canvas');
-  canvas.style.cssText = 'display:none;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.2);';
-  const spinWrap = document.createElement('div');
-  // Visible from mount so the spinner covers the slow cold load (worker init +
-  // WASM + parse), not just the per-frame render; hidden after the first paint.
-  spinWrap.style.cssText =
-    'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;pointer-events:none;';
-  const spinner = document.createElement('div');
-  spinner.style.cssText =
-    'width:36px;height:36px;border:4px solid rgba(0,0,0,0.12);border-top-color:#0366d6;' +
-    'border-radius:50%;animation:ooxml-offscreen-spin 0.8s linear infinite;';
-  spinWrap.appendChild(spinner);
-  stage.append(canvas, spinWrap);
-  root.appendChild(stage);
-  const ctx = canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext;
-  return {
-    canvas,
-    ctx,
-    setBusy: (busy: boolean) => { spinWrap.style.display = busy ? 'flex' : 'none'; },
-    reveal: () => { canvas.style.display = 'block'; },
-  };
-}

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -31,6 +31,7 @@ type Story = StoryObj<Args>;
 export function buildViewerUI(
   args: Args,
   autoLoadUrl?: string,
+  extra?: { mode?: 'main' | 'worker' },
 ): { root: HTMLElement; viewer: XlsxViewer } {
   const root = document.createElement('div');
   root.style.cssText = 'width:100%;height:100vh;display:flex;flex-direction:column;overflow:hidden;font-family:sans-serif;box-sizing:border-box;';
@@ -57,6 +58,7 @@ export function buildViewerUI(
       status.textContent = `Sheet ${idx + 1} / ${total}: ${sheetNames[idx] ?? ''}`;
     },
     onError: (err) => { status.textContent = `Error: ${err.message}`; },
+    ...extra,
   });
 
   if (autoLoadUrl) {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -78,6 +78,15 @@ export interface XlsxViewerOptions {
    * dependency-injection contract as the docx/pptx viewers.
    */
   math?: MathRenderer;
+  /**
+   * `'main'` (default): parse in a worker, render on the main thread. `'worker'`:
+   * parse AND render entirely inside the worker and paint the returned
+   * ImageBitmap onto the viewer's canvas, so document rendering never blocks the
+   * UI thread. All interaction (scroll, sheet tabs, frozen panes, zoom, cell
+   * selection) is unchanged. Requires `Worker` + `OffscreenCanvas`. Equations
+   * require `'main'` (the math engine cannot cross the worker boundary).
+   */
+  mode?: 'main' | 'worker';
 }
 
 export interface CellAddress {
@@ -185,6 +194,12 @@ export class XlsxViewer {
   private currentSheet = 0;
   private currentWorksheet: Worksheet | null = null;
   private opts: XlsxViewerOptions;
+  /** 'main' renders on this thread; 'worker' paints worker-produced bitmaps. */
+  private readonly _mode: 'main' | 'worker';
+  /** The canvas's bitmaprenderer context, used only in worker mode. A canvas
+   *  holds one context type for its lifetime, so this is obtained once and the
+   *  main-mode 2d render path is never used on the same canvas. */
+  private _bitmapCtx: ImageBitmapRenderingContext | null = null;
   private resizeObserver: ResizeObserver | null = null;
   /**
    * Start-anchored horizontal scroll position (the {@link effectiveScrollLeft}
@@ -244,6 +259,7 @@ export class XlsxViewer {
 
   constructor(container: HTMLElement, opts: XlsxViewerOptions = {}) {
     this.opts = opts;
+    this._mode = opts.mode ?? 'main';
 
     const wrapper = document.createElement('div');
     wrapper.style.cssText =
@@ -255,6 +271,11 @@ export class XlsxViewer {
 
     this.canvas = document.createElement('canvas');
     this.canvas.style.cssText = `position:absolute;top:0;left:0;z-index:0;display:block;`;
+    // Worker mode paints worker-produced bitmaps; grab the bitmaprenderer
+    // context once (a canvas can hold only one context type for its lifetime).
+    if (this._mode === 'worker') {
+      this._bitmapCtx = this.canvas.getContext('bitmaprenderer');
+    }
 
     // Selection overlay: sits above canvas, below scrollHost (z-index 0.5 via fractional z not possible,
     // use pointer-events:none so scrollHost still receives events)
@@ -413,6 +434,7 @@ export class XlsxViewer {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         math: this.opts.math,
+        mode: this._mode,
       });
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
@@ -1793,7 +1815,7 @@ export class XlsxViewer {
 
     const { selectedRowRange, selectedColRange } = this.computeHeaderHighlight();
 
-    await this.workbook.renderViewport(this.canvas, this.currentSheet, viewport, {
+    const renderOpts = {
       width: w,
       height: h,
       dpr,
@@ -1804,7 +1826,20 @@ export class XlsxViewer {
       freezeCols,
       selectedRowRange,
       selectedColRange,
-    });
+    };
+
+    if (this._mode === 'worker') {
+      // Render the viewport off the main thread and paint the returned bitmap.
+      // The selection overlay (geometry-based, from getCellRect) is unaffected.
+      const bmp = await this.workbook.renderViewportToBitmap(this.currentSheet, viewport, renderOpts);
+      this.canvas.width = bmp.width;
+      this.canvas.height = bmp.height;
+      this.canvas.style.width = `${w}px`;
+      this.canvas.style.height = `${h}px`;
+      this._bitmapCtx?.transferFromImageBitmap(bmp);
+    } else {
+      await this.workbook.renderViewport(this.canvas, this.currentSheet, viewport, renderOpts);
+    }
   }
 
   private computeHeaderHighlight(): {

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -25,6 +25,7 @@ const GFONTS = { name: 'useGoogleFonts', type: 'boolean', def: 'false', desc: 'L
 const DPR = { name: 'dpr', type: 'number', def: 'devicePixelRatio', desc: 'Device pixel ratio for the backing store (crispness on HiDPI).' };
 const MATH = { name: 'math', type: 'MathRenderer', def: 'undefined', desc: 'Opt-in OMML equation engine (MathJax + STIX Two Math, ~4 MB). Import it from the separate @silurus/ooxml/math entry — `import { math } from "@silurus/ooxml/math"` — and pass it to render equations. Omit it and equations are skipped — the engine tree-shakes away entirely.' };
 const MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "'main' parses in a worker and renders on the main thread (default). 'worker' parses AND renders entirely inside the worker; the main thread only paints the ImageBitmap returned by the render*ToBitmap method via a `bitmaprenderer` context. Requires Worker + OffscreenCanvas. The canvas-target render methods are unavailable in 'worker' mode, and equations require 'main'." };
+const VIEWER_MODE = { name: 'mode', type: "'main' | 'worker'", def: "'main'", desc: "'main' renders on the main thread (default). 'worker' renders the whole viewer off the main thread — every frame is produced in a Web Worker and painted via a `bitmaprenderer` context — so document rendering never blocks the UI. Scroll, sheet tabs, zoom and (xlsx) cell selection are unchanged. Requires Worker + OffscreenCanvas. The pptx/docx text-selection overlay is unavailable in 'worker' mode (onTextRun can't cross the worker boundary), and equations require 'main'." };
 
 export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
   pptx: [
@@ -40,6 +41,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'enableMediaPlayback', type: 'boolean', def: 'false', desc: 'Make embedded audio/video interactive (the viewer draws its own play chrome).' },
         ZIP,
         MATH,
+        VIEWER_MODE,
         { name: 'onSlideChange', type: '(index: number, total: number) => void', desc: 'Called after a slide finishes rendering.' },
         { name: 'onError', type: '(err: Error) => void', desc: 'Called on parse or render errors.' },
       ],
@@ -85,6 +87,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'showTrackChanges', type: 'boolean', desc: 'Render tracked insertions/deletions with author colours.' },
         ZIP,
         MATH,
+        VIEWER_MODE,
         { name: 'onPageChange', type: '(index: number, total: number) => void', desc: 'Called after a page finishes rendering.' },
         { name: 'onError', type: '(err: Error) => void', desc: 'Called on parse or render errors.' },
       ],
@@ -125,6 +128,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         GFONTS,
         ZIP,
         MATH,
+        VIEWER_MODE,
         { name: 'onReady', type: '(sheetNames: string[]) => void', desc: 'Called once the workbook is parsed.' },
         { name: 'onSheetChange', type: '(index: number, total: number) => void', desc: 'Called when the active sheet changes; `total` is the sheet count. Read the name via `sheetNames[index]`.' },
         { name: 'onSelectionChange', type: '(sel: CellRange | null) => void', desc: 'Called when the selected range changes; null clears it.' },


### PR DESCRIPTION
## What

Extends `mode: 'worker'` — already supported by the headless engines — to the interactive **Viewer** classes (`PptxViewer` / `DocxViewer` / `XlsxViewer`). In worker mode the whole viewer renders off the main thread: every frame is produced in a Web Worker and painted onto the viewer's canvas via a `bitmaprenderer` context, so document rendering never blocks the UI. **All interaction is unchanged** — scroll, sheet tabs, frozen panes, zoom, sheet switching, media playback.

This makes the Storybook **Offscreen** demos the *real* single-viewer demos rendered off-thread: `buildViewerUI({ mode: 'worker' })`. (Supersedes the bespoke navigator/spinner UI from #430.)

## How (contained per viewer)

Each viewer change is localized to three points:
1. pass `mode` to the headless `load()`;
2. grab a `bitmaprenderer` context once in worker mode (a canvas holds one context type for its lifetime; the media-playback path keeps a 2d context via `presentSlide`, which already supports worker mode);
3. at the single render call, branch to `render*ToBitmap` → `transferFromImageBitmap`.

All scroll/selection/tab geometry stays on the main thread off the metadata / `Worksheet` model, which works in worker mode (`getWorksheet` round-trips through the worker).

## Limitation (documented)

The pptx/docx **text-selection overlay** is built from `onTextRun` callbacks fired during main-thread rendering — these can't cross the worker boundary, so the overlay is skipped in worker mode (one `console.warn`). **xlsx cell selection is geometry-based (`getCellRect`) and works in worker mode.** The site API reference documents the new viewer `mode` option and this limitation.

A DataCloneError footgun was avoided: only serializable render options are forwarded to the worker (spreading the full viewer opts would postMessage the math engine / callbacks / container element).

## Verification

Storybook (port 6007), all three Offscreen stories rendering the real viewer in worker mode:
- **xlsx** — scrollable grid with row/col headers, sheet tabs (Dashboard / Forest Inventory / …), zoom slider, cell selection; sheet switching works.
- **pptx** — Slide 1→2 navigation, 960×540 @dpr2.
- **docx** — 6 pages, 700×990.

No console errors. `pnpm -r typecheck` clean across all packages.

Spec: `docs/superpowers/specs/2026-06-13-viewer-worker-mode-design.md` (local-only).

Do not squash-merge (repo policy): use `--merge` or `--rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)