### PR TITLE
fix(storybook): xlsx Examples layout:fullscreen — sheet tabs visible without scrolling

### DIFF
--- a/packages/xlsx/src/Examples.stories.ts
+++ b/packages/xlsx/src/Examples.stories.ts
@@ -5,6 +5,11 @@ type Args = { scale: number };
 
 const meta: Meta<Args> = {
   title: 'XlsxViewer/Examples',
+  // The viewer fills the viewport (height:100vh). Storybook's default story
+  // padding would push that past the fold, hiding the bottom sheet-tab bar
+  // behind a scroll. 'fullscreen' removes the padding so 100vh fits exactly and
+  // the tabs stay visible.
+  parameters: { layout: 'fullscreen' },
   argTypes: {
     scale: {
       control: { type: 'range', min: 0.25, max: 2, step: 0.05 },


### PR DESCRIPTION
## Problem

In the xlsx `Demo` / `Offscreen` stories the bottom **sheet-tab bar and zoom slider were hidden behind a scroll** — you had to scroll the preview to reach the sheet tabs.

Cause: the viewer fills the viewport (`height:100vh`), but Storybook wraps the story in `.sb-show-main` with ~16px padding. So the story's `100vh` plus the top+bottom padding totalled `100vh + 32px`, overflowing the iframe by 32px and pushing the bottom tab bar below the fold (measured: viewport 808px, tab-bar bottom 823px).

## Fix

Set `parameters: { layout: 'fullscreen' }` on the xlsx Examples meta — the idiomatic Storybook way to drop the default story padding for full-viewport content. Now `100vh` fits the iframe exactly (measured: viewport 808px, body 808px, no overflow, tab-bar bottom 807px → fully visible, no scroll). Applies to both `Demo` (main mode) and `Offscreen` (worker mode), which share `buildViewerUI`.

Verified in Storybook: the ◀ ▶ Dashboard / Forest Inventory tabs and the zoom slider are visible at the bottom without scrolling.

Do not squash-merge (repo policy): use `--merge` or `--rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)