### PR TITLE
fix(storybook): match docx Examples width to pptx (consistent loading area)

### DIFF
--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -17,7 +17,9 @@ const meta: Meta<DemoArgs> = {
       description: 'Canvas render width (px) — used by the Demo story',
     },
   },
-  args: { width: 700 },
+  // Match the pptx Examples width so the loading placeholder (and the rendered
+  // document) are the same size across the Demo / Offscreen stories.
+  args: { width: 960 },
 };
 export default meta;
 


### PR DESCRIPTION
The docx `Demo` / `Offscreen` stories rendered at width **700** while pptx used **960**, so the gray loading placeholder (the `#f0f0f0` container behind the spinner) — and the rendered document — were a **different size** between the two. It's most noticeable during the worker-mode cold load, where the gray box is on screen for a moment.

Both containers already share identical CSS (`max-width:100%`, `min-height:120px`, same border/background); the only difference was the `args.width` default. Aligning docx's Examples width to **960** (within its 400–1200 range) makes the loading area and the rendered output match pptx across both the Demo and Offscreen stories.

Verified in Storybook: at the same viewport the docx and pptx loading containers now measure the same width.

Do not squash-merge (repo policy): use `--merge` or `--rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)