### PR TITLE
fix(core): preloadGoogleFonts never loaded multi-word webfonts (load by reference)

### DIFF
--- a/packages/core/src/fonts/preload.test.ts
+++ b/packages/core/src/fonts/preload.test.ts
@@ -52,12 +52,16 @@ interface FakeFace {
   load: () => Promise<FakeFace>;
 }
 
-function installFakes(opts: { failLoad?: boolean } = {}) {
+function installFakes(opts: { failLoad?: boolean; quoteFamily?: boolean } = {}) {
   const added: FakeFace[] = [];
   class FakeFontFace implements FakeFace {
     family: string; source: string; loadCalls = 0;
     constructor(family: string, source: string, public descriptors?: object) {
-      this.family = family; this.source = source;
+      // Chrome serializes a multi-word FontFace.family back WITH quotes
+      // (e.g. `"Nunito Sans"`). quoteFamily reproduces that so the loader is
+      // verified NOT to depend on matching the set by family string.
+      this.family = opts.quoteFamily ? `"${family}"` : family;
+      this.source = source;
     }
     load(): Promise<FakeFace> {
       this.loadCalls++;
@@ -88,6 +92,19 @@ describe('preloadGoogleFonts', () => {
     expect((G.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
     expect(added.map((f) => f.family)).toEqual(['Carlito', 'Carlito']);
     expect(added.every((f) => f.loadCalls === 1)).toBe(true);
+  });
+
+  it('force-loads faces even when FontFace.family serializes with quotes (Chrome multi-word)', async () => {
+    // Regression: the loader must load the FontFace objects it created, not
+    // re-select them from the set by family string. Chrome returns a quoted
+    // `.family` for multi-word names, so a family-string filter matches nothing
+    // and the fonts silently never load (worker OffscreenCanvas falls back).
+    const { added } = installFakes({ quoteFamily: true });
+    G.document = { fonts: { faces: added, add: (f: FakeFace) => added.push(f), [Symbol.iterator]() { return added[Symbol.iterator](); }, ready: Promise.resolve() } };
+    delete G.self;
+    await preloadGoogleFonts(['Calibri'], MAP);
+    expect(added.length).toBe(2);
+    expect(added.every((f) => f.loadCalls === 1)).toBe(true); // loaded despite quoted .family
   });
 
   it('uses self.fonts when document is undefined (worker)', async () => {

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -52,16 +52,17 @@ function withCeiling<T>(p: Promise<T>): Promise<T | void> {
 }
 
 /** In-flight (or completed) fetch-and-register promise per CSS url, keyed by url.
- *  Storing the PROMISE (not just a flag) lets a concurrent caller with the same
- *  url JOIN the first registration instead of seeing a cache hit, skipping
- *  registration, and resolving while the first fetch is still in flight (which
- *  would defeat the first-paint determinism this function exists to provide).
- *  The stored promise ALWAYS resolves: failure handling (recording the failed
- *  families + deleting the entry so a later call can retry) happens inside the
- *  producing call's own logic, so a cache-hit awaiter never throws. An awaiter
- *  that joined a registration which then fails simply proceeds to step 2 and
- *  finds no faces — no worse than the original failure path. */
-const cssRegistrations = new Map<string, Promise<void>>();
+ *  Resolves with the `FontFace` objects this loader added for that stylesheet
+ *  (empty on fetch failure). Storing the PROMISE (not just a flag) lets a
+ *  concurrent caller with the same url JOIN the first registration instead of
+ *  seeing a cache hit, skipping registration, and resolving while the first
+ *  fetch is still in flight (which would defeat the first-paint determinism this
+ *  function exists to provide). It also hands step 2 the exact FontFace
+ *  references to load — see why that matters there. The stored promise ALWAYS
+ *  resolves: failure handling (recording the failed families + deleting the
+ *  entry so a later call can retry) happens inside the producing call's own
+ *  logic, so a cache-hit awaiter never throws. */
+const cssRegistrations = new Map<string, Promise<FontFace[]>>();
 
 /** Test hook — clears the per-context CSS registration cache. */
 export function _resetCssCacheForTests(): void {
@@ -154,10 +155,11 @@ export async function preloadGoogleFonts(
   if (targetFamilies.size === 0) return;
 
   // 1) Fetch each stylesheet once per JS context and register its FontFace
-  //    entries into the active FontFaceSet. Canvas rendering never puts
-  //    glyphs into the DOM, so registration alone is not enough — see (2).
-  await withCeiling(
-    Promise.allSettled(
+  //    entries into the active FontFaceSet, keeping references to the faces we
+  //    add. Canvas rendering never puts glyphs into the DOM, so registration
+  //    alone is not enough — see (2).
+  const faceGroups = await withCeiling(
+    Promise.all(
       [...cssUrls].map((url) => {
         // Cache hit: AWAIT the in-flight registration so concurrent callers join
         // the first fetch rather than racing past it. The stored promise never
@@ -165,18 +167,23 @@ export async function preloadGoogleFonts(
         // just yields no faces in step 2.
         const inFlight = cssRegistrations.get(url);
         if (inFlight) return inFlight;
-        const registration = (async () => {
+        const registration = (async (): Promise<FontFace[]> => {
           try {
             const res = await fetch(url);
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const added: FontFace[] = [];
             for (const f of parseFontFaceRules(await res.text())) {
-              fonts.add(new FontFace(f.family, f.src, f.descriptors));
+              const face = new FontFace(f.family, f.src, f.descriptors);
+              fonts.add(face);
+              added.push(face);
             }
+            return added;
           } catch {
             cssRegistrations.delete(url); // free the slot so a later call retries
             for (const family of urlTargets.get(url) ?? []) {
               failedFamilies.add(family);
             }
+            return [];
           }
         })();
         cssRegistrations.set(url, registration);
@@ -185,16 +192,22 @@ export async function preloadGoogleFonts(
     ),
   );
 
-  // 2) Force-load every matching FontFace and AWAIT them all — no timeout race
+  // 2) Force-load the FontFaces we added and AWAIT them all — no timeout race
   //    that could resolve mid-download. `face.load()` is required because
   //    unicode-range gating would otherwise leave the faces `unloaded` and the
   //    first canvas paint would use a system fallback, shifting once a later
-  //    interaction re-rasterized.
-  const registered = [...fonts].filter((f) => targetFamilies.has(f.family.toLowerCase()));
+  //    interaction re-rasterized. We load the FontFace objects WE created (held
+  //    via cssRegistrations) rather than re-selecting them from the set by
+  //    family name: `FontFace.family` serializes a multi-word name back WITH
+  //    quotes (e.g. `"Nunito Sans"`), so a `family`-string filter silently
+  //    matches nothing and the fonts never load — the bug this avoids.
+  const addedFaces = (Array.isArray(faceGroups) ? faceGroups : []).flat();
   await withCeiling(
-    Promise.allSettled(registered.map((f) => f.load())).then((results) => {
+    Promise.allSettled(addedFaces.map((f) => f.load())).then((results) => {
       results.forEach((res, i) => {
-        if (res.status === 'rejected') failedFamilies.add(registered[i].family.toLowerCase());
+        if (res.status === 'rejected') {
+          failedFamilies.add(addedFaces[i].family.replace(/['"]/g, '').toLowerCase());
+        }
       });
       return fonts.ready;
     }),

--- a/packages/pptx/tests/visual/worker-equivalence.spec.ts
+++ b/packages/pptx/tests/visual/worker-equivalence.spec.ts
@@ -2,17 +2,14 @@ import { test, expect } from '@playwright/test';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
-// Worker mode must produce (near-)identical pixels to main mode: same
-// renderer, same fonts, different thread. Slides 1 and 3 come out
-// bit-identical (0.000%). Slide 2 was observed at ~0.506% in this
-// configuration — sub-pixel text rasterization differing between the
-// main-thread <canvas> and the worker OffscreenCanvas, confined to the
-// smallest body text; the 0.7% bound leaves headroom for AA/font-hinting
-// variance. Per-slide tolerances grant that slack only to the slide that
-// needs it, so the bit-identical slides keep enough sensitivity that even
-// a single dropped small text element (a few tenths of a percent) fails.
+// Worker mode must produce identical pixels to main mode: same renderer, same
+// fonts (the worker loads the same web fonts into its OffscreenCanvas font set),
+// different thread. All three slides come out bit-identical (0.000%); the tiny
+// uniform tolerance only absorbs rare AA/hinting noise and still fails on a
+// dropped element or a font that didn't load in the worker (which would diverge
+// by whole tenths of a percent — that was the symptom before the preload fix).
 const SLIDES = [0, 1, 2];
-const MAX_DIFF_PCT = [0.2, 0.7, 0.2];
+const MAX_DIFF_PCT = [0.1, 0.1, 0.1];
 
 for (const slide of SLIDES) {
   test(`worker mode matches main mode › demo/sample-1 slide ${slide + 1}`, async ({ page }) => {


### PR DESCRIPTION
## Root cause (investigating the worker/main wrap difference)

The user noticed the pptx Demo title **"STATE OF THE FOREST" wraps to 2 lines in main mode but 3 lines in worker (offscreen) mode** at the demo width. Systematic investigation traced it to a **general bug in `preloadGoogleFonts`** (introduced in the FontFaceSet-agnostic rewrite):

`preloadGoogleFonts` created `FontFace` objects from the Google Fonts CSS, added them to the `FontFaceSet`, then chose which to force-load via
`[...fonts].filter(f => targetFamilies.has(f.family.toLowerCase()))`.
But **Chrome serializes a multi-word `FontFace.family` back WITH quotes** (e.g. `"Nunito Sans"`), so that filter matched **nothing** for any multi-word family — `face.load()` was never called, the webfont silently never loaded, and in a worker `self.fonts.ready` then hung until the 15 s ceiling.

This affected **both** render modes, but was masked:
- On the **main thread** by Storybook's `@fontsource` imports / OS-installed fonts (so the font was available anyway).
- In the **worker/main equivalence test** because its fixture has no `@fontsource` — main and worker both fell back to a default face *symmetrically*, so they still matched (0%).

The worker (no `@fontsource`) is the one place nothing masked it → fallback font, wider glyphs, title wraps to 3 lines.

## Conclusion: not a principial limitation

An isolated worker test confirmed an `OffscreenCanvas` **does** honor a `self.fonts` `FontFace` for `measureText`/rendering — so this was purely our bug, not a worker font-isolation limit.

## Fix

Hold references to the `FontFace` objects we create and call `.load()` on **those** directly, so the `.family` serialization quirk is irrelevant (`cssRegistrations` now resolves with the added faces).

## Verification

- worker-vs-main pixel diff for `demo/sample-1` slide 1 dropped to **0.000% at both 960 and 1280** (was 2.77% at 960). The title now wraps identically.
- pptx / docx / xlsx VRT all pass; worker/main equivalence is now **bit-identical on every slide** (tightened the pptx thresholds to `[0.1,0.1,0.1]` and corrected the stale 0.506% comment).
- Added a regression unit test: a fake `FontFace` whose `.family` serializes with quotes — asserts the faces are still loaded. `pnpm -r typecheck` clean, unit 426 pass.

Note: this also fixes main-mode `useGoogleFonts` for any consumer without `@fontsource` — it now actually loads the requested substitutes (Carlito/Caladea/etc.) instead of silently falling back. No reference images changed (the reference VRT fixtures don't pass `useGoogleFonts`).

Do not squash-merge (repo policy): use `--merge` or `--rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)