### PR TITLE
chore(release): 0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,60 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
-## 0.58.0 — 2026-06-12
+## 0.59.0 — 2026-06-14
+
+The off-main-thread release: an opt-in `mode: 'worker'` that parses **and**
+renders pptx / docx / xlsx entirely inside a Web Worker, returning each frame as
+a transferable `ImageBitmap` so document rendering never blocks the UI thread.
+Plus a broader script→Noto font-fallback chain under `useGoogleFonts`, and a fix
+that makes that web-font preload actually load multi-word families.
+
+core:
+
+- `mode: 'worker'` plumbing shared across all three formats: worker-safe render
+  guards (`isHTMLCanvas` / `defaultDpr`), a FontFaceSet-agnostic Google Fonts
+  preloader that works off `self.fonts` in a worker, and per-format render
+  workers that keep the parsed model worker-side (#427).
+- Shared script→Noto fallback definitions — CJK (KR/SC/TC/JP, ordered by the
+  document's language), Cyrillic, Thai, Devanagari and Hebrew — appended to the
+  canvas font stack under `useGoogleFonts` so non-Latin runs resolve to a real
+  web font instead of tofu (#426).
+- Fix: `preloadGoogleFonts` loaded nothing for multi-word families. It
+  re-selected which faces to load by matching `FontFace.family`, but Chrome
+  serializes a multi-word family back with quotes (`"Nunito Sans"`), so the
+  match found nothing and the font silently never loaded (worker text then fell
+  back to a default face, changing line wrapping). It now loads the FontFace
+  objects it created by reference (#436).
+- Centralized each format's font-preload name collection so main-thread and
+  worker modes always preload an identical set (#428).
+
+pptx / docx / xlsx:
+
+- Headless `mode: 'worker'` with `renderSlideToBitmap` / `renderPageToBitmap` /
+  `renderViewportToBitmap` (both modes; worker mode runs off the main thread).
+  docx paginates worker-side; xlsx parses sheets on demand in the worker.
+  Equations require `mode: 'main'` (#427).
+- `mode: 'worker'` on the interactive `PptxViewer` / `DocxViewer` / `XlsxViewer`
+  too: the whole viewer — scroll, sheet tabs, frozen panes, zoom, sheet
+  switching, media playback — renders off the main thread, painting worker
+  bitmaps via a `bitmaprenderer` context. xlsx cell selection still works
+  (geometry-based); the pptx/docx text-selection overlay is unavailable in
+  worker mode (`onTextRun` can't cross the worker boundary) (#432).
+- pptx: worker-mode `presentSlide` composites main-thread video over a
+  worker-rendered base; concurrent picture/poster bitmap prefetch shaves the
+  serial-await latency off first paint (#427).
+- xlsx: anchored images decode via `createImageBitmap` and pattern-fill tiles
+  build on `OffscreenCanvas`, so the render path is worker-safe (#427).
+
+docx:
+
+- Honor `m:oMathParaPr/m:jc` for display-math cell layout (§22.1.2.88) (#431).
+
+pptx:
+
+- Don't draw bullet / number markers on empty paragraphs (#425).
+
+
 
 The sp3d release: full DrawingML 3-D shape shading — bevels, extrusion side
 walls, and a calibrated light rig — layered on the scene3d camera from 0.57.0.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release **0.59.0** — the off-main-thread release.

## Highlights
- **`mode: 'worker'`** across pptx / docx / xlsx: parse **and** render entirely in a Web Worker, returning each frame as a transferable `ImageBitmap` so rendering never blocks the UI. Available on the headless engines (`render*ToBitmap`) **and** the interactive Viewers (the whole viewer — scroll, sheet tabs, zoom, media — renders off-thread).
- **Script→Noto font fallback** under `useGoogleFonts`: CJK / Cyrillic / Thai / Devanagari / Hebrew (#426).
- **Fix**: `preloadGoogleFonts` never loaded multi-word web fonts (Chrome quotes `FontFace.family`); now loads by reference (#436).
- docx display-math cell justification `m:jc` (#431); pptx empty-paragraph bullet suppression (#425).

## Release checklist
- Version bumped to 0.59.0 across all 8 package.json files.
- CHANGELOG updated.
- README / site api-reference already document worker mode + script fallbacks (synced during the feature work).
- README screenshots **not** retaken: main-mode rendering is unchanged this cycle (worker output is pixel-identical to main; font fallbacks affect non-Latin only, not the representative samples).

Verification: `pnpm -r typecheck` clean; pptx/docx/xlsx VRT all pass; worker/main equivalence bit-identical.

Merge with `--merge` (no squash); tag `v0.59.0` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)