### PR TITLE
fix(fonts): preload only the script fonts the document actually uses

### DIFF
--- a/packages/core/src/fonts/scripts.test.ts
+++ b/packages/core/src/fonts/scripts.test.ts
@@ -6,7 +6,18 @@ import {
   NON_CJK_SERIF_FALLBACKS,
   SCRIPT_GOOGLE_FONTS,
   SCRIPT_PRELOAD_NAMES,
+  scriptPreloadNamesForText,
 } from './scripts.js';
+
+/** Lower-case every name and assert it is resolvable in the preload URL map. */
+function assertResolvable(names: string[]): void {
+  for (const n of names) {
+    expect(
+      SCRIPT_GOOGLE_FONTS[n.toLowerCase()],
+      `${n} missing from SCRIPT_GOOGLE_FONTS`,
+    ).toBeDefined();
+  }
+}
 
 describe('classifyCjkFont — Office font name → CJK language', () => {
   it('classifies Korean faces (Malgun Gothic, Batang, Gulim, Dotum, 돋움)', () => {
@@ -116,5 +127,120 @@ describe('SCRIPT_GOOGLE_FONTS / SCRIPT_PRELOAD_NAMES', () => {
     expect(SCRIPT_GOOGLE_FONTS['noto sans devanagari']).toBeDefined();
     expect(SCRIPT_GOOGLE_FONTS['noto sans hebrew']).toBeDefined();
     expect(SCRIPT_GOOGLE_FONTS['noto serif hebrew']).toBeDefined();
+  });
+});
+
+describe('scriptPreloadNamesForText — script-aware preload set from document text', () => {
+  it('returns nothing for empty / no text', () => {
+    expect(scriptPreloadNamesForText([], null)).toEqual([]);
+    expect(scriptPreloadNamesForText([''], null)).toEqual([]);
+  });
+
+  it('returns ZERO CJK/script names for pure Latin (ASCII + Latin-1)', () => {
+    const out = scriptPreloadNamesForText(['Hello, World!', 'café résumé'], null);
+    expect(out).toEqual([]);
+  });
+
+  it('detects Japanese (Hiragana/Katakana) → Noto Sans/Serif JP', () => {
+    const out = scriptPreloadNamesForText(['こんにちは カタカナ'], null);
+    expect(out).toEqual(['Noto Sans JP', 'Noto Serif JP']);
+    assertResolvable(out);
+  });
+
+  it('detects Korean (Hangul) → Noto Sans/Serif KR', () => {
+    const out = scriptPreloadNamesForText(['안녕하세요'], null);
+    expect(out).toEqual(['Noto Sans KR', 'Noto Serif KR']);
+    assertResolvable(out);
+  });
+
+  it('Han only with cjkLang hint sc → uses the hint', () => {
+    const out = scriptPreloadNamesForText(['汉字测试'], 'sc');
+    expect(out).toEqual(['Noto Sans SC', 'Noto Serif SC']);
+  });
+
+  it('Han only with no hint → defaults to jp', () => {
+    const out = scriptPreloadNamesForText(['漢字'], null);
+    expect(out).toEqual(['Noto Sans JP', 'Noto Serif JP']);
+  });
+
+  it('Han + Hangul → Hangul sets kr; Han resolves to the kr face (no JP emitted)', () => {
+    const out = scriptPreloadNamesForText(['한국어 漢字'], 'jp');
+    expect(out).toEqual(['Noto Sans KR', 'Noto Serif KR']);
+  });
+
+  it('Han + Kana → Kana sets jp even with sc hint', () => {
+    const out = scriptPreloadNamesForText(['ひらがな 漢字'], 'sc');
+    expect(out).toEqual(['Noto Sans JP', 'Noto Serif JP']);
+  });
+
+  it('Hangul + Kana → both KR and JP faces', () => {
+    const out = scriptPreloadNamesForText(['한국 ひらがな'], null);
+    expect(out).toContain('Noto Sans KR');
+    expect(out).toContain('Noto Serif KR');
+    expect(out).toContain('Noto Sans JP');
+    expect(out).toContain('Noto Serif JP');
+    assertResolvable(out);
+  });
+
+  it('detects Arabic → Noto Naskh Arabic + Noto Sans Arabic', () => {
+    const out = scriptPreloadNamesForText(['مرحبا بالعالم'], null);
+    expect(out).toContain('Noto Naskh Arabic');
+    expect(out).toContain('Noto Sans Arabic');
+  });
+
+  it('detects Thai → Noto Sans Thai', () => {
+    const out = scriptPreloadNamesForText(['สวัสดี'], null);
+    expect(out).toEqual(['Noto Sans Thai']);
+    assertResolvable(out);
+  });
+
+  it('detects Hebrew → Noto Sans/Serif Hebrew', () => {
+    const out = scriptPreloadNamesForText(['שלום עולם'], null);
+    expect(out).toContain('Noto Sans Hebrew');
+    expect(out).toContain('Noto Serif Hebrew');
+    assertResolvable(out);
+  });
+
+  it('detects Devanagari → Noto Sans Devanagari', () => {
+    const out = scriptPreloadNamesForText(['नमस्ते'], null);
+    expect(out).toEqual(['Noto Sans Devanagari']);
+    assertResolvable(out);
+  });
+
+  it('detects Cyrillic → Noto Sans/Serif (which cover Cyrillic)', () => {
+    const out = scriptPreloadNamesForText(['Привет мир'], null);
+    expect(out).toEqual(['Noto Sans', 'Noto Serif']);
+    assertResolvable(out);
+  });
+
+  it('detects Greek → Noto Sans/Serif', () => {
+    const out = scriptPreloadNamesForText(['Γειά σου'], null);
+    expect(out).toEqual(['Noto Sans', 'Noto Serif']);
+  });
+
+  it('mixed CJK (Japanese) + Arabic + Cyrillic', () => {
+    const out = scriptPreloadNamesForText(['日本語 العربية Кириллица'], null);
+    expect(out).toContain('Noto Sans JP');
+    expect(out).toContain('Noto Serif JP');
+    expect(out).toContain('Noto Naskh Arabic');
+    expect(out).toContain('Noto Sans Arabic');
+    expect(out).toContain('Noto Sans');
+    expect(out).toContain('Noto Serif');
+  });
+
+  it('handles astral Han (U+20000+) via codePointAt', () => {
+    const out = scriptPreloadNamesForText(['\u{20089}'], null);
+    expect(out).toEqual(['Noto Sans JP', 'Noto Serif JP']);
+  });
+
+  it('is deterministic: same text yields the same set regardless of chunking', () => {
+    const a = scriptPreloadNamesForText(['日本語 العربية'], null);
+    const b = scriptPreloadNamesForText(['日本', '語 ', 'العربية'], null);
+    expect([...a].sort()).toEqual([...b].sort());
+  });
+
+  it('every returned name is resolvable in SCRIPT_GOOGLE_FONTS (CJK + Cyrillic + scripts)', () => {
+    const out = scriptPreloadNamesForText(['漢字 Привет สวัสดี नमस्ते שלום'], null);
+    assertResolvable(out);
   });
 });

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -194,3 +194,152 @@ export const SCRIPT_PRELOAD_NAMES: string[] = [
   'Noto Sans Devanagari', 'Noto Sans Thai',
   'Noto Sans Hebrew', 'Noto Serif Hebrew',
 ];
+
+/**
+ * Decide WHICH of the script Noto families above actually need force-loading for
+ * a document, by scanning its rendered text for the Unicode scripts that require
+ * a script-specific web font.
+ *
+ * Why scan the text rather than always preload {@link SCRIPT_PRELOAD_NAMES}: the
+ * CJK Noto families have no `text=` subset (the full multi-MB family is fetched),
+ * so eagerly loading all eight CJK faces for a pure-Latin document blocks first
+ * paint on megabytes of fonts that will never paint a glyph. We force-load only
+ * the families whose script appears in the text. The renderer still APPENDS the
+ * full Noto fallback chain to the canvas font stack — preloading is purely about
+ * which faces are fetched up front before first paint; an un-preloaded face that
+ * later proves needed simply loads lazily via the FontFaceSet on its first use.
+ *
+ * Detection is by objective Unicode block membership (no name/heuristic guessing
+ * — see root CLAUDE.md). Ranges scanned per codepoint:
+ *   - Hangul     U+1100–11FF (Jamo), U+3130–318F (Compat Jamo), U+AC00–D7AF
+ *                (Syllables)                                   → CJK, lang 'kr'
+ *   - Hira/Kana  U+3040–30FF                                   → CJK, lang 'jp'
+ *   - Han        U+3400–4DBF, U+4E00–9FFF, U+F900–FAFF,
+ *                U+20000–2FA1F (via codePointAt)               → CJK, shared
+ *   - Arabic     U+0600–06FF, U+0750–077F, U+08A0–08FF,
+ *                U+FB50–FDFF, U+FE70–FEFF      → 'Noto Naskh Arabic','Noto Sans Arabic'
+ *   - Thai       U+0E00–0E7F                  → 'Noto Sans Thai'
+ *   - Hebrew     U+0590–05FF, U+FB1D–FB4F      → 'Noto Sans Hebrew','Noto Serif Hebrew'
+ *   - Devanagari U+0900–097F                   → 'Noto Sans Devanagari'
+ *   - Cyrillic   U+0400–04FF / Greek U+0370–03FF → 'Noto Sans','Noto Serif'
+ *                (the un-suffixed Latin Notos embed these)
+ *   - Basic Latin / Latin-1 / everything else  → nothing
+ *
+ * CJK language resolution: a Hangul codepoint forces 'kr' and a Kana codepoint
+ * forces 'jp' (those scripts are language-exclusive); shared Han codepoints adopt
+ * the document's `cjkLang` hint (derived by the caller from the theme font via
+ * {@link classifyCjkFont}), defaulting to 'jp' when no hint and no Hangul/Kana is
+ * present. For each detected CJK language BOTH the Sans and Serif face are
+ * emitted (the renderer may pick either depending on the run's serif-ness). When
+ * multiple CJK languages appear (e.g. Hangul + Kana), each contributes its pair.
+ *
+ * Note the Arabic names are NOT keys of {@link SCRIPT_GOOGLE_FONTS} — they live
+ * in each package's own `*_GOOGLE_FONTS` map (which also spreads SCRIPT_GOOGLE_FONTS),
+ * mirroring the unconditional Arabic preload entries the callers already queue.
+ *
+ * The result is a deduplicated, deterministically-ordered array, so the
+ * main-thread `load()` and the render worker — given the same parsed model —
+ * derive an IDENTICAL preload set (required for worker/main pixel equivalence).
+ */
+export function scriptPreloadNamesForText(
+  text: Iterable<string>,
+  cjkLang: CjkLang | null,
+): string[] {
+  let hasHan = false;
+  let hasHangul = false;
+  let hasKana = false;
+  let hasArabic = false;
+  let hasThai = false;
+  let hasHebrew = false;
+  let hasDevanagari = false;
+  let hasCyrGreek = false;
+
+  // Every script category found → can stop scanning further codepoints.
+  const allFound = (): boolean =>
+    (hasHan && hasHangul && hasKana) &&
+    hasArabic &&
+    hasThai &&
+    hasHebrew &&
+    hasDevanagari &&
+    hasCyrGreek;
+
+  outer: for (const chunk of text) {
+    if (!chunk) continue;
+    for (const ch of chunk) {
+      const cp = ch.codePointAt(0);
+      if (cp === undefined) continue;
+
+      // Fast path: ASCII / Latin-1 / Latin Extended need no script font.
+      if (cp <= 0x024f) continue;
+
+      if (
+        (cp >= 0x1100 && cp <= 0x11ff) ||
+        (cp >= 0x3130 && cp <= 0x318f) ||
+        (cp >= 0xac00 && cp <= 0xd7af)
+      ) {
+        hasHangul = true;
+      } else if (cp >= 0x3040 && cp <= 0x30ff) {
+        hasKana = true;
+      } else if (
+        (cp >= 0x3400 && cp <= 0x4dbf) ||
+        (cp >= 0x4e00 && cp <= 0x9fff) ||
+        (cp >= 0xf900 && cp <= 0xfaff) ||
+        (cp >= 0x20000 && cp <= 0x2fa1f)
+      ) {
+        hasHan = true;
+      } else if (
+        (cp >= 0x0600 && cp <= 0x06ff) ||
+        (cp >= 0x0750 && cp <= 0x077f) ||
+        (cp >= 0x08a0 && cp <= 0x08ff) ||
+        (cp >= 0xfb50 && cp <= 0xfdff) ||
+        (cp >= 0xfe70 && cp <= 0xfeff)
+      ) {
+        hasArabic = true;
+      } else if (cp >= 0x0e00 && cp <= 0x0e7f) {
+        hasThai = true;
+      } else if (
+        (cp >= 0x0590 && cp <= 0x05ff) ||
+        (cp >= 0xfb1d && cp <= 0xfb4f)
+      ) {
+        hasHebrew = true;
+      } else if (cp >= 0x0900 && cp <= 0x097f) {
+        hasDevanagari = true;
+      } else if (
+        (cp >= 0x0400 && cp <= 0x04ff) ||
+        (cp >= 0x0370 && cp <= 0x03ff)
+      ) {
+        hasCyrGreek = true;
+      }
+
+      if (allFound()) break outer;
+    }
+  }
+
+  const names: string[] = [];
+
+  // CJK: each detected language contributes its Sans+Serif pair. Hangul → 'kr',
+  // Kana → 'jp', shared Han → the language hint (or 'jp' default) UNLESS Hangul
+  // or Kana already pinned a CJK language, in which case Han resolves to one of
+  // those faces and needs no extra family.
+  const cjkLangs = new Set<CjkLang>();
+  if (hasHangul) cjkLangs.add('kr');
+  if (hasKana) cjkLangs.add('jp');
+  if (hasHan && cjkLangs.size === 0) {
+    cjkLangs.add(cjkLang ?? 'jp');
+  }
+  // Stable order: kr, sc, tc, jp.
+  for (const lang of ['kr', 'sc', 'tc', 'jp'] as const) {
+    if (cjkLangs.has(lang)) {
+      const suffix = { kr: 'KR', sc: 'SC', tc: 'TC', jp: 'JP' }[lang];
+      names.push(`Noto Sans ${suffix}`, `Noto Serif ${suffix}`);
+    }
+  }
+
+  if (hasCyrGreek) names.push('Noto Sans', 'Noto Serif');
+  if (hasArabic) names.push('Noto Naskh Arabic', 'Noto Sans Arabic');
+  if (hasThai) names.push('Noto Sans Thai');
+  if (hasHebrew) names.push('Noto Sans Hebrew', 'Noto Serif Hebrew');
+  if (hasDevanagari) names.push('Noto Sans Devanagari');
+
+  return names;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export {
   NON_CJK_SERIF_FALLBACKS,
   SCRIPT_GOOGLE_FONTS,
   SCRIPT_PRELOAD_NAMES,
+  scriptPreloadNamesForText,
   type CjkLang,
   type FontVariant,
 } from './fonts/scripts';

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -91,7 +91,7 @@ export class DocxDocument {
     );
     if (mode === 'main' && opts.useGoogleFonts && doc._document) {
       await preloadGoogleFonts(
-        docxFontPreloadNames(doc._document.majorFont, doc._document.minorFont),
+        docxFontPreloadNames(doc._document),
         DOCX_GOOGLE_FONTS,
       );
     }

--- a/packages/docx/src/google-fonts.test.ts
+++ b/packages/docx/src/google-fonts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { docxFontPreloadNames } from './google-fonts.js';
+import type { DocxDocumentModel } from './types.js';
+
+/** Build a minimal model whose body is a single paragraph with one text run. */
+function docWith(text: string, major = 'Calibri', minor = 'Calibri'): DocxDocumentModel {
+  return {
+    section: {} as DocxDocumentModel['section'],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    majorFont: major,
+    minorFont: minor,
+    body: [
+      {
+        type: 'paragraph',
+        runs: [{ type: 'text', text } as never],
+      } as never,
+    ],
+  } as DocxDocumentModel;
+}
+
+describe('docxFontPreloadNames — script-aware preload', () => {
+  it('pure-Latin doc preloads ONLY the theme fonts (no CJK / script faces)', () => {
+    const names = docxFontPreloadNames(docWith('Hello, world.'));
+    expect(names).toEqual(['Calibri', 'Calibri']);
+    // The expensive CJK faces must NOT be queued for a Latin document.
+    expect(names).not.toContain('Noto Sans JP');
+    expect(names).not.toContain('Noto Sans KR');
+    expect(names).not.toContain('Noto Naskh Arabic');
+  });
+
+  it('Japanese doc preloads the JP Noto faces', () => {
+    const names = docxFontPreloadNames(docWith('こんにちは世界'));
+    expect(names).toContain('Noto Sans JP');
+    expect(names).toContain('Noto Serif JP');
+    expect(names).not.toContain('Noto Sans KR');
+  });
+
+  it('Han with a Korean theme font uses the kr lang hint', () => {
+    const names = docxFontPreloadNames(docWith('漢字', 'Malgun Gothic', 'Malgun Gothic'));
+    expect(names).toContain('Noto Sans KR');
+    expect(names).not.toContain('Noto Sans JP');
+  });
+
+  it('is deterministic — same model yields the same set (main == worker)', () => {
+    const doc = docWith('日本語 العربية');
+    expect(docxFontPreloadNames(doc)).toEqual(docxFontPreloadNames(doc));
+  });
+});

--- a/packages/docx/src/google-fonts.ts
+++ b/packages/docx/src/google-fonts.ts
@@ -1,4 +1,15 @@
-import { SCRIPT_GOOGLE_FONTS, SCRIPT_PRELOAD_NAMES, type FontPreloadEntry } from '@silurus/ooxml-core';
+import {
+  classifyCjkFont,
+  scriptPreloadNamesForText,
+  SCRIPT_GOOGLE_FONTS,
+  type FontPreloadEntry,
+} from '@silurus/ooxml-core';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocTable,
+  DocxDocumentModel,
+} from './types.js';
 
 /** Theme-referenced typefaces commonly used by DOCX templates. Mirrors the
  *  PPTX map — these are the well-known free webfont alternatives Microsoft
@@ -44,21 +55,67 @@ export const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   ...SCRIPT_GOOGLE_FONTS,
 };
 
+/** Yield every rendered text string in the document model so the preload step
+ *  can detect which scripts are actually present. Walks the body, headers /
+ *  footers, footnotes / endnotes and nested tables (text-only). Comments are
+ *  not painted on the page, so they are excluded. */
+function* docxTextRuns(doc: DocxDocumentModel): Generator<string> {
+  const fromRuns = function* (runs: DocParagraph['runs']): Generator<string> {
+    for (const r of runs) {
+      if (r.type === 'text') yield r.text;
+      else if (r.type === 'field') yield r.fallbackText;
+      else if (r.type === 'shape') {
+        for (const t of r.textBlocks ?? []) yield t.text;
+      }
+    }
+  };
+  const walk = function* (el: BodyElement): Generator<string> {
+    if ('runs' in el) yield* fromRuns((el as DocParagraph).runs);
+    if ('rows' in el) {
+      for (const row of (el as DocTable).rows) {
+        for (const cell of row.cells) {
+          for (const child of cell.content) yield* walk(child as BodyElement);
+        }
+      }
+    }
+  };
+  const walkBody = function* (body: BodyElement[] | undefined): Generator<string> {
+    for (const el of body ?? []) yield* walk(el);
+  };
+
+  yield* walkBody(doc.body);
+  for (const hf of [doc.headers, doc.footers]) {
+    for (const which of [hf?.default, hf?.first, hf?.even]) {
+      yield* walkBody(which?.body);
+    }
+  }
+  for (const note of [...(doc.footnotes ?? []), ...(doc.endnotes ?? [])]) {
+    yield* walkBody(note.content);
+  }
+}
+
 /**
  * The font-family names to preload for a document: the theme major/minor fonts,
- * the generic Arabic fallbacks, and every script Noto face. The renderer's font
- * fallback chains end with those Noto faces, so they must be loaded for any
- * Arabic/CJK/Cyrillic/Thai/Devanagari/Hebrew glyph that falls through the chain
- * to resolve to a real web font instead of an OS face or tofu.
+ * plus only the script-fallback Noto faces whose script the document's TEXT
+ * actually contains ({@link scriptPreloadNamesForText}). The renderer's font
+ * fallback chains still END with the full Noto set, but eagerly fetching the
+ * multi-MB CJK families for a document that has no CJK glyphs would block first
+ * paint for nothing; an un-preloaded face loads lazily if it ever proves needed.
  *
  * Single source of truth shared by the main-thread `load()` and the render
- * worker, so both modes preload an identical set — worker/main rendering must
- * stay pixel-equivalent. (Fonts must also be loaded before pagination, which
- * measures text; both callers await this before paginating.)
+ * worker. Both derive the set from the SAME parsed {@link DocxDocumentModel}, so
+ * they preload an identical set — worker/main rendering must stay
+ * pixel-equivalent. (Fonts must also be loaded before pagination, which measures
+ * text; both callers await this before paginating.)
  */
 export function docxFontPreloadNames(
-  majorFont: string | null | undefined,
-  minorFont: string | null | undefined,
+  doc: DocxDocumentModel,
 ): (string | null | undefined)[] {
-  return [majorFont, minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic', ...SCRIPT_PRELOAD_NAMES];
+  const cjkLang =
+    classifyCjkFont(doc.majorFont) ?? classifyCjkFont(doc.minorFont) ?? null;
+  return [
+    doc.majorFont,
+    doc.minorFont,
+    ...scriptPreloadNamesForText(docxTextRuns(doc), cjkLang),
+  ];
 }

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -42,7 +42,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         // Pagination measures text, so fonts must land BEFORE computePages —
         // same ordering the main-mode load() guarantees.
         await preloadGoogleFonts(
-          docxFontPreloadNames(doc.majorFont, doc.minorFont),
+          docxFontPreloadNames(doc),
           DOCX_GOOGLE_FONTS,
         );
       }

--- a/packages/pptx/src/google-fonts.ts
+++ b/packages/pptx/src/google-fonts.ts
@@ -1,4 +1,11 @@
-import { SCRIPT_GOOGLE_FONTS, SCRIPT_PRELOAD_NAMES, type FontPreloadEntry } from '@silurus/ooxml-core';
+import {
+  classifyCjkFont,
+  scriptPreloadNamesForText,
+  SCRIPT_GOOGLE_FONTS,
+  type FontPreloadEntry,
+  type TextBody,
+} from '@silurus/ooxml-core';
+import type { Presentation, SlideElement } from './types';
 
 /** Theme-referenced typefaces commonly used by PPTX templates. Keys are
  *  lower-cased family names. Entries that substitute a metric-compatible
@@ -48,20 +55,57 @@ export const PPTX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   ...SCRIPT_GOOGLE_FONTS,
 };
 
+/** Yield every painted text string in a text body (paragraph runs). */
+function* textBodyRuns(body: TextBody | null | undefined): Generator<string> {
+  for (const p of body?.paragraphs ?? []) {
+    for (const r of p.runs) {
+      if (r.type === 'text') yield r.text;
+    }
+  }
+}
+
+/** Yield every rendered text string in the presentation: shape text, table
+ *  cell text and chart labels across all slides. Speaker notes and comments are
+ *  not painted on the slide, so they are excluded (the renderer ignores them). */
+function* pptxTextRuns(pres: Presentation): Generator<string> {
+  for (const slide of pres.slides) {
+    for (const el of slide.elements as SlideElement[]) {
+      if (el.type === 'shape') {
+        yield* textBodyRuns(el.textBody);
+      } else if (el.type === 'table') {
+        for (const row of el.rows) {
+          for (const cell of row.cells) yield* textBodyRuns(cell.textBody);
+        }
+      } else if (el.type === 'chart') {
+        if (el.title) yield el.title;
+        for (const c of el.categories) yield c;
+        for (const s of el.series) if (s.name) yield s.name;
+      }
+    }
+  }
+}
+
 /**
  * The font-family names to preload for a presentation: the theme major/minor
- * fonts, the generic Arabic fallbacks, and every script Noto face. The renderer's
- * canvas font stack ends with those fallbacks, so they must be loaded for any
- * Arabic/CJK/Cyrillic/Thai/Devanagari/Hebrew glyph that falls through the stack
- * to resolve to a real web font instead of an OS face or tofu.
+ * fonts, plus only the script-fallback Noto faces whose script the slide TEXT
+ * actually contains ({@link scriptPreloadNamesForText}). The renderer's canvas
+ * font stack still ends with the full Noto set, but eagerly fetching the
+ * multi-MB CJK families for a deck with no CJK glyphs would block first paint
+ * for nothing; an un-preloaded face loads lazily if it ever proves needed.
  *
  * Single source of truth shared by the main-thread `load()` and the render
- * worker, so both modes preload an identical set — worker/main rendering must
- * stay pixel-equivalent.
+ * worker. Both derive the set from the SAME parsed {@link Presentation}, so both
+ * modes preload an identical set — worker/main rendering must stay
+ * pixel-equivalent.
  */
 export function pptxFontPreloadNames(
-  majorFont: string | null | undefined,
-  minorFont: string | null | undefined,
+  pres: Presentation,
 ): (string | null | undefined)[] {
-  return [majorFont, minorFont, 'Noto Naskh Arabic', 'Noto Sans Arabic', ...SCRIPT_PRELOAD_NAMES];
+  const cjkLang =
+    classifyCjkFont(pres.majorFont) ?? classifyCjkFont(pres.minorFont) ?? null;
+  return [
+    pres.majorFont,
+    pres.minorFont,
+    ...scriptPreloadNamesForText(pptxTextRuns(pres), cjkLang),
+  ];
 }

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -145,9 +145,8 @@ export class PptxPresentation {
       mode === 'worker' ? !!opts.useGoogleFonts : false,
     );
     if (mode === 'main' && opts.useGoogleFonts && pres._presentation) {
-      const parsed = pres._presentation;
       await preloadGoogleFonts(
-        pptxFontPreloadNames(parsed.majorFont, parsed.minorFont),
+        pptxFontPreloadNames(pres._presentation),
         PPTX_GOOGLE_FONTS,
       );
     }

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -73,7 +73,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         // Kick the preload now so it overlaps with main-thread work; renders
         // await `fontsLoaded` so text never rasterizes with fallback metrics.
         fontsLoaded = preloadGoogleFonts(
-          pptxFontPreloadNames(pres.majorFont, pres.minorFont),
+          pptxFontPreloadNames(pres),
           PPTX_GOOGLE_FONTS,
         );
       }

--- a/packages/xlsx/src/google-fonts.ts
+++ b/packages/xlsx/src/google-fonts.ts
@@ -1,5 +1,11 @@
-import { SCRIPT_GOOGLE_FONTS, SCRIPT_PRELOAD_NAMES, type FontPreloadEntry } from '@silurus/ooxml-core';
-import type { Styles } from './types.js';
+import {
+  classifyCjkFont,
+  scriptPreloadNamesForText,
+  SCRIPT_GOOGLE_FONTS,
+  type CjkLang,
+  type FontPreloadEntry,
+} from '@silurus/ooxml-core';
+import type { ParsedWorkbook } from './types.js';
 
 /** Office font name → metric-compatible Google Fonts substitute. These are
  *  the well-known pairings Microsoft and Google both publish and ship on
@@ -44,26 +50,48 @@ export const XLSX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   ...SCRIPT_GOOGLE_FONTS,
 };
 
+/** Yield every textual cell value carried by the parsed workbook: the shared
+ *  string table (`text` plus rich-text `runs[].text`). This is the bulk of a
+ *  workbook's painted text and is present in BOTH main and worker at parse time
+ *  (sheets parse lazily, but the shared string table is workbook-level).
+ *  Numbers / dates carry no script-specific glyphs, so they are irrelevant. */
+function* xlsxTextRuns(wb: ParsedWorkbook | undefined): Generator<string> {
+  for (const s of wb?.sharedStrings ?? []) {
+    if (s.runs && s.runs.length > 0) {
+      for (const r of s.runs) yield r.text;
+    } else {
+      yield s.text;
+    }
+  }
+}
+
 /**
- * The font-family names to preload for a workbook: every styled cell font, the
- * generic Arabic fallbacks, and every script Noto face. Office faces map to
+ * The font-family names to preload for a workbook: every styled cell font, plus
+ * only the script-fallback Noto faces whose script the workbook's TEXT actually
+ * contains ({@link scriptPreloadNamesForText}). Office faces map to
  * metric-compatible substitutes (Calibri → Carlito, Cambria → Caladea); the
- * renderer's default chain ends with the Noto faces, so they must be loaded for
- * any Arabic/CJK/Cyrillic/Thai/Devanagari/Hebrew glyph that falls through to
- * resolve to a real web font instead of an OS face or tofu. A workbook using
- * only system fonts (no map entries) still produces zero network requests.
+ * renderer's default chain still ends with the full Noto set, but eagerly
+ * fetching the multi-MB CJK families for a workbook that has no CJK glyphs would
+ * block first paint for nothing; an un-preloaded face loads lazily if it ever
+ * proves needed. A workbook using only system fonts (no map entries) still
+ * produces zero network requests.
  *
  * Single source of truth shared by the main-thread `_load()` and the render
- * worker, so both modes preload an identical set — worker/main rendering must
- * stay pixel-equivalent.
+ * worker. Both derive the set from the SAME parsed {@link ParsedWorkbook}, so
+ * both modes preload an identical set — worker/main rendering must stay
+ * pixel-equivalent.
  */
-export function xlsxFontPreloadNames(styles: Styles | undefined): Set<string> {
+export function xlsxFontPreloadNames(wb: ParsedWorkbook | undefined): Set<string> {
   const names = new Set<string>();
-  for (const f of styles?.fonts ?? []) {
-    if (f.name) names.add(f.name);
+  let cjkLang: CjkLang | null = null;
+  for (const f of wb?.styles?.fonts ?? []) {
+    if (f.name) {
+      names.add(f.name);
+      cjkLang ??= classifyCjkFont(f.name);
+    }
   }
-  names.add('Noto Naskh Arabic');
-  names.add('Noto Sans Arabic');
-  for (const n of SCRIPT_PRELOAD_NAMES) names.add(n);
+  for (const n of scriptPreloadNamesForText(xlsxTextRuns(wb), cjkLang)) {
+    names.add(n);
+  }
   return names;
 }

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -68,7 +68,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         // every styled font name, plus the generic Arabic fallbacks. Fonts must
         // land before rendering (which measures text), so we keep the promise
         // and await it in the renderViewport handler.
-        fontsLoaded = preloadGoogleFonts(xlsxFontPreloadNames(workbook.styles), XLSX_GOOGLE_FONTS);
+        fontsLoaded = preloadGoogleFonts(xlsxFontPreloadNames(workbook), XLSX_GOOGLE_FONTS);
       }
       post({ type: 'parsed', id, workbook });
       return;

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -120,7 +120,7 @@ export class XlsxWorkbook {
     this.parsedWorkbook = (parsed as Extract<WorkerResponse, { type: 'parsed' }>).workbook;
     if (this._mode === 'main' && opts.useGoogleFonts) {
       await preloadGoogleFonts(
-        xlsxFontPreloadNames(this.parsedWorkbook.styles),
+        xlsxFontPreloadNames(this.parsedWorkbook),
         XLSX_GOOGLE_FONTS,
       );
     }


### PR DESCRIPTION
## Problem
With `useGoogleFonts: true`, every docx/pptx/xlsx `load()` force-downloaded a fixed set of ~16 script-fallback Noto families **before first paint** — including all 8 CJK families (Noto Sans/Serif KR/SC/TC/JP), requested with no `text=` subset so the **full multi-MB families** download — regardless of whether the document contained any of those scripts. Because `load()` awaits `preloadGoogleFonts`, a pure-Latin document showed a **blank viewer** until every CJK font finished downloading.

This was masked until 0.59.0: the [#436](https://github.com/yukiyokotani/office-open-xml-viewer/pull/436) preload fix made `.load()` actually fire (before it, multi-word `FontFace.family` quoting meant it silently never ran). So 0.59.0 turned a no-op into an eager full-CJK download. The official site (all demos `useGoogleFonts:true`) showed a clearly detectable blank before first paint.

## Fix
Detect the scripts actually present in the parsed document's **text** (Unicode-block ranges, early-exit scan) and preload only the matching Noto families. Latin-only → none. The named/theme fonts are unchanged.

`scriptPreloadNamesForText(text, cjkLang)` (core, pure) maps detected scripts → Noto family names:
Hangul→KR, Kana→JP, Han→lang hint, Arabic/Thai/Hebrew/Devanagari→their Notos, Cyrillic/Greek→Noto Sans/Serif, ASCII/Latin→none.

Both the main-thread `load()` and the render worker derive the set from the **same parsed model**, so worker/main rendering stays pixel-equivalent.

## Before / after (`*FontPreloadNames` output)
- Pure-Latin docx (Calibri theme): `["Calibri","Calibri", ...16 script families]` → **`["Calibri","Calibri"]`** (0 script families, 0 CJK)
- Japanese docx: → `["Calibri","Calibri","Noto Sans JP","Noto Serif JP"]` (CJK still correct)

## Verification
- `pnpm typecheck` clean; `pnpm vitest run` → **449 passed** (incl. 23 new tests).
- `pnpm build:wasm` + pptx **worker-equivalence VRT → 3/3 slides 0.000% diff** (main == worker preload set).
- Live (Storybook docx Examples demo, Latin): **zero `fonts.googleapis.com`/`gstatic` requests, zero CJK FontFaces registered/loaded** (was ~16 css2 fetches + multi-MB CJK before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)