### PR TITLE
chore(release): 0.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.59.1 — 2026-06-14
+
+Patch: fix a first-paint regression introduced in 0.59.0. With `useGoogleFonts: true`,
+`load()` force-loaded a fixed set of script-fallback Noto families before first
+paint — including all eight CJK families (Noto Sans/Serif KR/SC/TC/JP) requested
+with no `text=` subset, i.e. the full multi-MB families — regardless of the
+document's content, so a pure-Latin document showed a blank viewer until every
+CJK font downloaded. (The 0.59.0 preload fix unmasked this: before it, `.load()`
+silently never fired.)
+
+- **fonts**: preload only the Noto families whose script the document's text
+  actually contains. A new pure `scriptPreloadNamesForText(text, cjkLang)` scans
+  the parsed model's text by Unicode block (early-exit) — Latin-only documents
+  preload no script fonts at all; CJK/Arabic/Thai/Hebrew/Devanagari documents
+  still preload their faces. The main-thread `load()` and the render worker
+  derive the set from the same parsed model, so worker/main rendering stays
+  pixel-equivalent.
+
 ## 0.59.0 — 2026-06-14
 
 The off-main-thread release: an opt-in `mode: 'worker'` that parses **and**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release. Fixes the 0.59.0 first-paint regression: with `useGoogleFonts: true`, `load()` force-loaded all eight CJK Noto families (full, un-subsetted) plus Arabic/Thai/Hebrew/Devanagari before first paint regardless of document content, blanking the viewer until they downloaded ([#438](https://github.com/yukiyokotani/office-open-xml-viewer/pull/438)).

- Preload only the Noto families the document's text actually needs (Latin-only → none); worker/main stay pixel-equivalent.
- Bump all 8 `package.json` to 0.59.1; CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)