### PR TITLE
ci: bump GitHub Actions off the deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -42,11 +42,11 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,9 +27,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -66,7 +66,7 @@ jobs:
           echo "ooxml.silurus.dev" > site/dist/CNAME
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site/dist
 
@@ -79,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # ── Rust toolchain (for building WASM parsers) ─────────────────────────
       - name: Install Rust toolchain
@@ -40,10 +40,10 @@ jobs:
 
       # ── Node / pnpm ────────────────────────────────────────────────────────
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -71,7 +71,7 @@ jobs:
         run: pnpm exec vsce package --no-dependencies --out ooxml-viewer.vsix
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ooxml-viewer-vsix
           path: packages/vscode-extension/ooxml-viewer.vsix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # ── Rust toolchain ──────────────────────────────────────────────────────
       - name: Install Rust toolchain
@@ -35,11 +35,11 @@ jobs:
 
       # ── Node / pnpm ─────────────────────────────────────────────────────────
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         # version is read from packageManager field in package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -59,7 +59,7 @@ jobs:
             asset: ooxml-mcp-server-x86_64-pc-windows-msvc.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -109,7 +109,7 @@ jobs:
           cat "${{ matrix.asset }}.sha256"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.asset }}
           path: staging/*
@@ -132,7 +132,7 @@ jobs:
             echo "name=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Why

CI emits the Node.js 20 deprecation warning. GitHub forces Node 20 actions onto Node 24 on **2026-06-16** and removes the Node 20 runtime on **2026-09-16**.

## What

Bump every action that still ran on Node 20 to the first major that ships a Node 24 runtime:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v5** |
| `actions/setup-node` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v5** |
| `actions/download-artifact` | v4 | **v5** |
| `pnpm/action-setup` | v4 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `actions/upload-pages-artifact` | v3 | **v4** (inner upload-artifact → Node 24) |

Pinned to the **minimum** major that resolves the warning rather than the latest, to avoid unnecessary breaking changes.

## Breaking changes — verified non-impacting here

- **setup-node v5** auto-caching: moot, every job sets `cache: 'pnpm'` explicitly.
- **download-artifact v5** path change: only affects single-artifact-by-id downloads; `release-mcp-server.yml` downloads all with `merge-multiple: true`.
- **upload-pages-artifact v4** drops dotfiles: irrelevant for the built static site (Astro + Storybook).

`dtolnay/rust-toolchain` and `Swatinem/rust-cache` are composite/non-Node actions, so untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)