### PR TITLE
chore(release): 0.59.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.59.2 — 2026-06-14
+
+Patch: shrink the VS Code extension bundle.
+
+- **vscode-extension**: the extension renders on the main thread only, but each
+  viewer package ships a render worker as a dynamically-imported chunk that
+  base64-inlines a second copy of the renderer + WASM. esbuild's `iife` webview
+  output cannot code-split that import into a lazy chunk (as the npm build does),
+  so it inlined ~2 MB of dead worker code. An esbuild plugin now stubs the
+  `render-worker-host` import to a no-op (never reached at runtime here), cutting
+  `webview.js` from 10.6 MB to 8.4 MB raw (4.1 MB → 3.2 MB gzip). No behavior
+  change — worker rendering was never used in the extension.
+
 ## 0.59.1 — 2026-06-14
 
 Patch: fix a first-paint regression introduced in 0.59.0. With `useGoogleFonts: true`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release. Shrinks the VS Code extension bundle.

- **vscode-extension** ([#441](https://github.com/yukiyokotani/office-open-xml-viewer/pull/441)): stub the dead `render-worker-host` import in the esbuild webview build (the extension is main-thread only). `webview.js`: 10.6 MB → 8.4 MB raw, 4.1 MB → 3.2 MB gzip. No behavior change.
- Bump all 8 `package.json` to 0.59.2; CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)