### PR TITLE
chore(release): 0.59.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.59.3 — 2026-06-14
+
+Patch: shrink the published bundle ~36% by inlining each parser's WASM only once.
+
+- **build**: each parser's WASM was inlined as a base64 data URL twice per format
+  — once for the main thread (the canonical `?url` import, posted to the worker)
+  and again inside every worker bundle, because the wasm-bindgen glue's
+  `new URL('*_bg.wasm', import.meta.url)` fallback was inlined by vite-plugin-wasm
+  even though workers always init from the URL the main thread passes. Setting
+  `omit-default-module-path` in each parser's wasm-pack metadata regenerates the
+  glue without that fallback, so the duplicate copies disappear naturally in the
+  build. `dist` drops from 12.69 MB to 8.06 MB; the VS Code extension webview
+  shrinks too. No API or behavior change — WASM is still delivered as an inline
+  data URL (zero-config), and the glue `init()` is internal (never part of the
+  public API; every caller already passes an explicit module).
+
 ## 0.59.2 — 2026-06-14
 
 Patch: shrink the VS Code extension bundle.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.59.2",
+  "version": "0.59.3",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release. Shrinks the published bundle ~36%.

- **build** ([#443](https://github.com/yukiyokotani/office-open-xml-viewer/pull/443)): set `omit-default-module-path` in each parser's wasm-pack metadata so the wasm-bindgen glue is generated without the `new URL('*_bg.wasm', import.meta.url)` fallback. That fallback was being inlined into every worker bundle as a dead second copy of the WASM (the workers always init from the URL the main thread passes). `dist`: **12.69 MB → 8.06 MB**; the VS Code extension webview shrinks too.
- No API or behavior change — WASM stays an inline data URL (zero-config); `init()` is internal.
- Bump all 8 `package.json` to 0.59.3; CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)