### PR TITLE
docs(readme): remove retired VS Code Marketplace badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 [![npm version](https://img.shields.io/npm/v/@silurus/ooxml.svg)](https://www.npmjs.com/package/@silurus/ooxml)
 [![npm downloads](https://img.shields.io/npm/dm/@silurus/ooxml.svg)](https://www.npmjs.com/package/@silurus/ooxml)
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/silurus.office-open-xml-viewer?label=VS%20Code&logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=silurus.office-open-xml-viewer)
-[![VS Code installs](https://img.shields.io/visual-studio-marketplace/i/silurus.office-open-xml-viewer?label=installs)](https://marketplace.visualstudio.com/items?itemName=silurus.office-open-xml-viewer)
 [![license](https://img.shields.io/npm/l/@silurus/ooxml.svg)](./LICENSE)
 
 **[Live demo](https://ooxml.silurus.dev)**


### PR DESCRIPTION
The two VS Code Marketplace badges (version `/v/` and installs `/i/`) use the shields.io `visual-studio-marketplace` endpoint, which is now **retired** — it returns a `visual-studio-marketplace: retired badge` placeholder image instead of live version/install data. Both badges therefore display nothing useful.

Removed both lines. The npm version, npm downloads, and license badges are unaffected.

If VS Code badges are wanted again later, a working alternative is the `vsmarketplacebadges.dev` provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)