### PR TITLE
feat(docx): floating-object overlap avoidance and below-float line flow

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1940,6 +1940,9 @@ fn parse_inline_drawing(
             dist_left: 0.0,
             dist_right: 0.0,
             wrap_side: None,
+            // Inline image: not a float, so the overlap constraint is moot.
+            // Carry the spec no-constraint value (true).
+            allow_overlap: true,
         })];
     }
 
@@ -2080,10 +2083,11 @@ fn parse_inline_drawing(
         dist_left: anchor_meta.dist_left,
         dist_right: anchor_meta.dist_right,
         wrap_side: anchor_meta.wrap_side.clone(),
+        allow_overlap: anchor_meta.allow_overlap,
     })]
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 struct AnchorMeta {
     wrap_mode: Option<String>,
     wrap_side: Option<String>,
@@ -2091,6 +2095,28 @@ struct AnchorMeta {
     dist_bottom: f64,
     dist_left: f64,
     dist_right: f64,
+    /// ECMA-376 §20.4.2.3 `wp:anchor/@allowOverlap` — whether this floating
+    /// object may overlap other floating objects. Spec default is **true**
+    /// (the attribute is optional). `false` mandates the object be repositioned
+    /// to prevent overlap. We implement `Default` by hand so the spec default of
+    /// `true` is preserved everywhere `AnchorMeta::default()` is used (a derived
+    /// `Default` would wrongly yield `false`).
+    allow_overlap: bool,
+}
+
+impl Default for AnchorMeta {
+    fn default() -> Self {
+        AnchorMeta {
+            wrap_mode: None,
+            wrap_side: None,
+            dist_top: 0.0,
+            dist_bottom: 0.0,
+            dist_left: 0.0,
+            dist_right: 0.0,
+            // §20.4.2.3: omitted @allowOverlap ⇒ true.
+            allow_overlap: true,
+        }
+    }
 }
 
 /// Parse wrap element and dist* padding from a wp:anchor container.
@@ -2100,6 +2126,13 @@ fn parse_anchor_wrap(container: &roxmltree::Node) -> AnchorMeta {
     let dist_bottom = container.attribute("distB").map(to_pt).unwrap_or(0.0);
     let dist_left = container.attribute("distL").map(to_pt).unwrap_or(0.0);
     let dist_right = container.attribute("distR").map(to_pt).unwrap_or(0.0);
+
+    // ECMA-376 §20.4.2.3 `wp:anchor/@allowOverlap`: "1"/"true" ⇒ true,
+    // "0"/"false" ⇒ false, omitted ⇒ true (spec default).
+    let allow_overlap = container
+        .attribute("allowOverlap")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(true);
 
     let mut wrap_mode: Option<String> = None;
     let mut wrap_side: Option<String> = None;
@@ -2141,6 +2174,7 @@ fn parse_anchor_wrap(container: &roxmltree::Node) -> AnchorMeta {
         dist_bottom,
         dist_left,
         dist_right,
+        allow_overlap,
     }
 }
 
@@ -2454,6 +2488,7 @@ fn parse_group_pic(
         dist_left: anchor_meta.dist_left,
         dist_right: anchor_meta.dist_right,
         wrap_side: anchor_meta.wrap_side.clone(),
+        allow_overlap: anchor_meta.allow_overlap,
     })
 }
 
@@ -4221,6 +4256,50 @@ mod wgp_image_tests {
             "anchor_y_pt = {}",
             img.anchor_y_pt
         );
+    }
+}
+
+#[cfg(test)]
+mod allow_overlap_tests {
+    use super::*;
+
+    fn meta(anchor_attrs: &str) -> AnchorMeta {
+        let xml = format!(
+            r#"<wp:anchor xmlns:wp="urn:wp" {attrs}>
+                 <wp:wrapSquare wrapText="bothSides"/>
+               </wp:anchor>"#,
+            attrs = anchor_attrs
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        parse_anchor_wrap(&doc.root_element())
+    }
+
+    // ECMA-376 §20.4.2.3 — @allowOverlap is optional; when omitted the object
+    // MAY overlap (default true).
+    #[test]
+    fn omitted_allow_overlap_defaults_true() {
+        assert!(meta("").allow_overlap);
+    }
+
+    // §20.4.2.3 — allowOverlap="0" / "false" forbids overlap (false).
+    #[test]
+    fn allow_overlap_false_is_false() {
+        assert!(!meta(r#"allowOverlap="0""#).allow_overlap);
+        assert!(!meta(r#"allowOverlap="false""#).allow_overlap);
+    }
+
+    // §20.4.2.3 — allowOverlap="1" / "true" permits overlap (true).
+    #[test]
+    fn allow_overlap_true_is_true() {
+        assert!(meta(r#"allowOverlap="1""#).allow_overlap);
+        assert!(meta(r#"allowOverlap="true""#).allow_overlap);
+    }
+
+    // The hand-written Default must preserve the spec default of true so any
+    // AnchorMeta::default() (e.g. group images without an anchor) is correct.
+    #[test]
+    fn default_anchor_meta_allows_overlap() {
+        assert!(AnchorMeta::default().allow_overlap);
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -755,6 +755,11 @@ pub struct ImageRun {
     /// Defaults to "bothSides" (equivalent).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wrap_side: Option<String>,
+    /// ECMA-376 §20.4.2.3 `wp:anchor/@allowOverlap` — whether this floating
+    /// object may overlap other floats. Spec default is true (attribute optional);
+    /// `false` mandates the renderer reposition the object to prevent any overlap.
+    /// Inline images carry true (the no-constraint value).
+    pub allow_overlap: bool,
 }
 
 fn is_zero_f64(v: &f64) -> bool {

--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -1,0 +1,309 @@
+// Float-wrap geometry for DOCX anchor images (ECMA-376 §20.4.2.x).
+//
+// Pure layout math: given the floats active on a page (as FloatRect exclusion
+// boxes) it answers "where may this line sit?" and "where must this new float
+// be re-seated to avoid a clash?". No canvas/drawing or document-model deps, so
+// it can be unit-reasoned and shared by the renderer and the paginator.
+//
+// IMPORTANT: which parts of the behavior here are ECMA-376-mandated vs
+// implementation-defined (Word-mimicking) HEURISTICS is documented inline on
+// resolveFloatOverlap and resolveLineFloatWindow. Do not "tighten" the
+// heuristics toward a specific sample — see packages/docx/CLAUDE.md.
+
+/** Anchor image float that affects text wrap on the current page. */
+export interface FloatRect {
+  mode: 'square' | 'topAndBottom';
+  /** Hex key of the image bitmap (used to defer drawing until final Y is known). */
+  imageKey: string;
+  /** Absolute canvas X of the image box (without dist padding). */
+  imageX: number;
+  imageY: number;
+  imageW: number;
+  imageH: number;
+  /** Padded exclusion rectangle for text wrap. */
+  xLeft: number;
+  xRight: number;
+  yTop: number;
+  yBottom: number;
+  /** wrapText: "bothSides" | "left" | "right" | "largest" (only square uses this). */
+  side: string;
+  /** dist* padding (px) — needed when displacing a float to keep its exclusion
+   *  padding when re-seating next to a blocking float (ECMA-376 §20.4.2.x). */
+  distLeft: number;
+  distRight: number;
+  distTop: number;
+  distBottom: number;
+  /** Identifier of the anchoring paragraph. Used only by the implementation-
+   *  defined (HEURISTIC) overlap avoidance under allowOverlap=true: floats with
+   *  the SAME paraId never displace each other, different-paragraph floats do.
+   *  ECMA-376 does not define this scoping; it mirrors Word/LibreOffice. See
+   *  resolveFloatOverlap. */
+  paraId: number;
+  /** true once the image itself has been drawn (drawn after its paragraph lays out). */
+  drawn: boolean;
+}
+
+/** A horizontal interval [l, r] in absolute canvas px. */
+export interface Gap {
+  l: number;
+  r: number;
+}
+
+// ── Float-layout tolerances (px) ──────────────────────────────────────────────
+// Sub-pixel slack used so floating-point coordinate noise (margin/anchor/dist
+// arithmetic at the current scale) doesn't read as a real overlap or a real gap.
+
+/** Overlap epsilon: two exclusion rects must overlap by MORE than this to count
+ *  as intersecting, so coincident/touching edges (and FP noise) are not a clash. */
+export const FLOAT_OVERLAP_EPS = 0.01;
+
+/** Slack added to the page-right edge when testing whether a displaced float
+ *  still fits horizontally — a float ending within this many px of the page edge
+ *  is treated as fitting (it would otherwise be pushed down by FP rounding).
+ *  Looser than FLOAT_OVERLAP_EPS because it guards a half-pixel rounding of a
+ *  full-width displacement, not an edge-touch test. */
+export const FLOAT_PAGE_RIGHT_SLACK = 0.5;
+
+/** Minimum width (px) a free side-gap must have to hold a line start. Floors the
+ *  required-width probe so a zero-width probe (an empty line with no content yet)
+ *  still rejects sub-pixel slivers between full-width floats. */
+export const MIN_LINE_GAP = 1;
+
+export function isWrapFloat(mode?: string): boolean {
+  return mode === 'square' || mode === 'topAndBottom' || mode === 'tight' || mode === 'through';
+}
+
+/** Two exclusion rects intersect (strict overlap, touching edges allowed). */
+export function rectsOverlap(
+  aL: number, aR: number, aT: number, aB: number,
+  bL: number, bR: number, bT: number, bB: number,
+): boolean {
+  return aL < bR - FLOAT_OVERLAP_EPS && aR > bL + FLOAT_OVERLAP_EPS &&
+    aT < bB - FLOAT_OVERLAP_EPS && aB > bT + FLOAT_OVERLAP_EPS;
+}
+
+/**
+ * Widest free horizontal interval within [left, right] after removing the
+ * `blocked` spans. Returns null when nothing is free. Factored out of
+ * resolveLineFloatWindow so the caller holds a properly-typed Gap (the previous
+ * inline closure form forced TS to narrow `best` to never, requiring casts).
+ */
+export function widestFreeGap(blocked: Gap[], left: number, right: number): Gap | null {
+  const spans = blocked.slice().sort((a, b) => a.l - b.l);
+  let cursor = left;
+  let best: Gap | null = null;
+  const consider = (l: number, r: number): void => {
+    // Adopt only when strictly wider than the current best (0 when none yet),
+    // so a zero/negative-width gap never becomes `best`. Matches the prior inline
+    // form `r - l > (best ? best.r - best.l : 0)`.
+    if (r - l > (best ? best.r - best.l : 0)) best = { l, r };
+  };
+  for (const b of spans) {
+    if (b.l > cursor) consider(cursor, Math.min(b.l, right));
+    cursor = Math.max(cursor, Math.min(b.r, right));
+    if (cursor >= right) break;
+  }
+  if (cursor < right) consider(cursor, right);
+  return best;
+}
+
+/**
+ * Resolve where a single line box may sit relative to the page's active floats.
+ *
+ * Given the line's intended top Y and the minimum horizontal width it needs to
+ * be placeable (`requiredWidth` — the width of its first atomic token, or, for
+ * an empty paragraph-mark line, one em of the mark font), this returns the Y at
+ * which the line actually starts plus the horizontal sub-window it may use.
+ *
+ * Two ECMA-376 wrap rules are applied, in order:
+ *   1. topAndBottom floats (§20.4.2.16): a line intersecting one is pushed below
+ *      it — text never sits beside a topAndBottom object.
+ *   2. square floats (§20.4.2.17): text wraps around the float's rect + dist
+ *      padding. When several squares cover a row we take the WIDEST free
+ *      horizontal gap. If no gap is wide enough for `requiredWidth` the line
+ *      cannot sit here at all and flows below the obstruction (advance to the
+ *      lowest blocking float bottom and re-evaluate). The square/topAndBottom
+ *      geometry itself is spec-defined; but routing empty / anchor-only
+ *      paragraph-mark lines through this with `requiredWidth` = one em (so they
+ *      drop below a full-width float band) is an implementation-defined
+ *      HEURISTIC (see resolveEmptyMarkTop): ECMA-376 does not require a
+ *      float-free row for a paragraph mark — only `<w:br w:clear>` (§17.18.3)
+ *      mandates flowing onto a float-free region.
+ */
+export function resolveLineFloatWindow(
+  topY: number,
+  requiredWidth: number,
+  probeH: number,
+  paraX: number,
+  maxWidth: number,
+  floats: FloatRect[],
+): { topY: number; xOffset: number; maxWidth: number } {
+  // 1. Keep pushing past any topAndBottom block we sit inside.
+  //
+  // ASSUMPTION (M3): step 1 runs ONCE, before the square sweep, and is not
+  // re-checked after a square push in step 2. This relies on "no topAndBottom
+  // float sits below a square float in the same column band." topAndBottom
+  // objects span the full content width (ECMA-376 §20.4.2.16) and are normally
+  // anchored above/below the square-wrapped region, so the square push in step 2
+  // lands in float-free space below the band. If a document ever places a
+  // topAndBottom strictly below a square the pushed line could clip into it; the
+  // spec-correct fix is to make steps 1+2 a single fixpoint loop. Left as a
+  // documented assumption here to preserve current behavior (no observed sample
+  // exercises the inverted ordering).
+  for (let guard = 0; guard < 16; guard++) {
+    const lineBot = topY + probeH;
+    let skip: number | null = null;
+    for (const f of floats) {
+      if (f.mode !== 'topAndBottom') continue;
+      if (lineBot > f.yTop && topY < f.yBottom) {
+        skip = skip === null ? f.yBottom : Math.max(skip, f.yBottom);
+      }
+    }
+    if (skip === null) break;
+    topY = skip;
+  }
+
+  // 2. Horizontal constraint from square floats.
+  const paraXLeft = paraX;
+  const paraXRight = paraX + maxWidth;
+  // A gap must fit the line's first atomic token to be usable. Floor so a
+  // zero-width probe (no content yet) still rejects sub-pixel slivers.
+  const usableGap = Math.max(requiredWidth, MIN_LINE_GAP);
+  let xOffset = 0;
+  let lineMaxWidth = maxWidth;
+  for (let guard = 0; guard < 64; guard++) {
+    const lineBot = topY + probeH;
+    const blocked: { l: number; r: number }[] = [];
+    const intersecting: FloatRect[] = [];
+    for (const f of floats) {
+      if (f.mode !== 'square') continue;
+      if (lineBot <= f.yTop || topY >= f.yBottom) continue;
+      intersecting.push(f);
+      switch (f.side) {
+        // Text may sit only on the LEFT of the float ⇒ everything from the
+        // float's left edge to the column right is unavailable.
+        case 'left':  blocked.push({ l: f.xLeft, r: paraXRight }); break;
+        // Text may sit only on the RIGHT ⇒ column left .. float right blocked.
+        case 'right': blocked.push({ l: paraXLeft, r: f.xRight }); break;
+        case 'largest':
+        case 'bothSides':
+        default:      blocked.push({ l: f.xLeft, r: f.xRight }); break;
+      }
+    }
+    if (intersecting.length === 0) {
+      xOffset = 0;
+      lineMaxWidth = maxWidth;
+      break;
+    }
+    // Widest free horizontal gap between the blocked spans across the column.
+    const best = widestFreeGap(blocked, paraXLeft, paraXRight);
+    if (best && best.r - best.l >= usableGap) {
+      xOffset = Math.max(0, best.l - paraXLeft);
+      lineMaxWidth = Math.min(maxWidth - xOffset, best.r - best.l);
+      if (lineMaxWidth < 0) lineMaxWidth = 0;
+      break;
+    }
+
+    // No usable gap on this row: the intersecting floats cover the whole column
+    // width here. The line must clear them all — advance to the LOWEST blocking
+    // float bottom (max yBottom) so it sits centred below the band rather than
+    // squeezed into a side sliver beside a still-active float.
+    const nextY = Math.max(...intersecting.map((f) => f.yBottom));
+    if (nextY <= topY) {
+      // Degenerate guard (shouldn't happen): keep full width to avoid a stall.
+      xOffset = 0;
+      lineMaxWidth = maxWidth;
+      break;
+    }
+    topY = nextY;
+  }
+  return { topY, xOffset, maxWidth: lineMaxWidth };
+}
+
+/**
+ * Multi-float collision resolution for a NEW wrap float, against floats already
+ * registered on the page.
+ *
+ * What ECMA-376 actually mandates here is narrow. Part 1 §20.4.2.3
+ * (wp:anchor/@allowOverlap) says an object that "cannot overlap other DrawingML
+ * object … shall be repositioned when displayed to prevent this overlap" — i.e.
+ * allowOverlap="false" REQUIRES repositioning. allowOverlap="true" (the default
+ * when omitted, §20.4.2.3) only *permits* overlap; the spec is silent on whether
+ * a renderer may avoid it. So:
+ *   - allowOverlap === false → spec-mandated avoidance of ALL other floats.
+ *   - allowOverlap === true  → implementation-defined avoidance of floats
+ *     anchored in OTHER paragraphs only.
+ *
+ * EVERYTHING ELSE in this function is implementation-defined — ECMA-376 Part 1
+ * does NOT specify it. This is a HEURISTIC chosen to match Word's observed
+ * layout (e.g. sample-9 figure 9), not a spec requirement:
+ *   - the move DIRECTION (right first, then down),
+ *   - WHICH float moves (the later/document-order float is the "new" one),
+ *   - the "same-paragraph floats never displace each other" gate (the paraId
+ *     scoping under allowOverlap=true above),
+ *   - and the move AMOUNT. Note the dist* padding reused below is, per
+ *     §20.4.2.3/§20.4.2.17, the minimum distance between the float and *text*
+ *     (wrapSquare geometry) — it is NOT spec-defined as a float-to-float gap.
+ *     Using it to seat one float beside another is our own choice.
+ *
+ * If the §20.4.2.3 "shall be repositioned" requirement is ever satisfiable in
+ * more than one way, the particular re-seating below remains a Word-mimicking
+ * heuristic; keep it as such until a spec-grounded placement rule is found.
+ *
+ * We re-seat horizontally to the right of the blocking float(s) first (margins
+ * may be used — Word lets a displaced float sit in the page margin), and only
+ * fall back to a vertical push when no horizontal room remains.
+ *
+ * Coordinates are page-absolute px. (x,y) is the image box origin (no dist).
+ * `pageRight` is the page width in px; `floats` is the page's active float set.
+ */
+export function resolveFloatOverlap(
+  x: number, y: number, w: number, h: number,
+  dl: number, dr: number, dt: number, db: number,
+  paraId: number, allowOverlap: boolean,
+  pageRight: number, floats: FloatRect[],
+): { x: number; y: number } {
+  for (let guard = 0; guard < 16; guard++) {
+    const exL = x - dl, exR = x + w + dr, exT = y - dt, exB = y + h + db;
+    // Blocking floats whose exclusion rects intersect ours. When the moving
+    // float forbids overlap (§20.4.2.3 allowOverlap="false") EVERY intersecting
+    // float blocks; otherwise only floats from OTHER paragraphs block (Word
+    // de-facto cross-paragraph avoidance).
+    const blockers = floats.filter(
+      (f) => (allowOverlap ? f.paraId !== paraId : true) &&
+        rectsOverlap(exL, exR, exT, exB, f.xLeft, f.xRight, f.yTop, f.yBottom),
+    );
+    if (blockers.length === 0) return { x, y };
+
+    // Horizontal: re-seat just right of the right-most blocker. Setting our
+    // left exclusion edge (x - dl) flush against the blocker's right exclusion
+    // edge means x = maxRight + dl (gap = blocker.distRight + our distLeft).
+    const maxRight = Math.max(...blockers.map((f) => f.xRight));
+    const newX = maxRight + dl;
+    if (newX + w + dr <= pageRight + FLOAT_PAGE_RIGHT_SLACK) {
+      x = newX;
+      continue; // re-check against all other-paragraph floats
+    }
+
+    // No horizontal room: push below the lowest blocker (smallest displacement
+    // that clears them). Our top exclusion edge (y - dt) flush with the
+    // blocker's bottom exclusion edge ⇒ y = maxBottom + dt.
+    const maxBottom = Math.max(...blockers.map((f) => f.yBottom));
+    y = maxBottom + dt;
+  }
+  return { x, y };
+}
+
+/** If y is inside a topAndBottom float, return the float bottom; otherwise return y. */
+export function skipPastTopAndBottom(y: number, floats: FloatRect[]): number {
+  for (let guard = 0; guard < 16; guard++) {
+    let next = y;
+    for (const f of floats) {
+      if (f.mode !== 'topAndBottom') continue;
+      if (y >= f.yTop && y < f.yBottom) next = Math.max(next, f.yBottom);
+    }
+    if (next === y) return y;
+    y = next;
+  }
+  return y;
+}

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3491,19 +3491,16 @@ function renderAnchorImages(
     if (isWrapFloat(img.wrapMode)) continue;  // drawn as a float
     const bmp = state.images.get(imageKey(img.dataUrl, img.colorReplaceFrom));
     if (!bmp) continue;
-    const w = img.widthPt * state.scale;
-    const h = img.heightPt * state.scale;
 
-    // Resolve X: margin-relative offsets need section.marginLeft added
-    const pageX = img.anchorXFromMargin
-      ? (state.marginLeft + (img.anchorXPt ?? 0)) * state.scale
-      : (img.anchorXPt ?? 0) * state.scale;
-
-    // Resolve Y: paragraph-relative offsets use the paragraph's top Y in canvas px
-    const pageY = img.anchorYFromPara
-      ? paragraphTopPx + (img.anchorYPt ?? 0) * state.scale
-      : (img.anchorYPt ?? 0) * state.scale;
-
+    // wrapNone images anchor against the paragraph's pre-spaceBefore top
+    // (paragraphTopPx). Shared box resolution with the float path. By design the
+    // box-resolution is symmetric but the overlap handling is NOT: wrap floats
+    // (registerAnchorFloats) build an exclusion rect and run resolveFloatOverlap,
+    // whereas wrapNone images carry no exclusion rect — they are positioned
+    // directly in the paragraph flow (ECMA-376 wrapNone, §20.4.2.x: the object
+    // does not displace text and is not displaced by other floats), so dist* is
+    // unused here.
+    const { x: pageX, y: pageY, w, h } = resolveAnchorBox(img, state, paragraphTopPx);
     state.ctx.drawImage(bmp, pageX, pageY, w, h);
   }
 }
@@ -3898,6 +3895,41 @@ function resolveFloatOverlap(
   return { x, y };
 }
 
+/**
+ * Resolve an anchor image's page-space box origin and dist* padding (px), shared
+ * by registerAnchorFloats (wrap floats) and renderAnchorImages (wrapNone images).
+ *
+ * X: margin-relative offsets add section.marginLeft (ECMA-376 §20.4.3.4
+ * relativeFrom="margin"); otherwise anchorXPt is already page-absolute.
+ * Y: paragraph-relative offsets add `paraBaseY`; otherwise page-absolute. The
+ * caller supplies `paraBaseY` because the two consumers anchor against different
+ * paragraph references — wrap floats use the post-spaceBefore textAreaTop, while
+ * wrapNone images use the pre-spaceBefore paragraph top (see the
+ * anchoredFloatBottomOffset note in the paginator). This is the box origin BEFORE
+ * any overlap displacement; resolveFloatOverlap runs on top of it for floats.
+ */
+function resolveAnchorBox(
+  img: ImageRun,
+  state: RenderState,
+  paraBaseY: number,
+): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } {
+  const scale = state.scale;
+  return {
+    x: img.anchorXFromMargin
+      ? (state.marginLeft + (img.anchorXPt ?? 0)) * scale
+      : (img.anchorXPt ?? 0) * scale,
+    y: img.anchorYFromPara
+      ? paraBaseY + (img.anchorYPt ?? 0) * scale
+      : (img.anchorYPt ?? 0) * scale,
+    w: img.widthPt * scale,
+    h: img.heightPt * scale,
+    dl: (img.distLeft   ?? 0) * scale,
+    dr: (img.distRight  ?? 0) * scale,
+    dt: (img.distTop    ?? 0) * scale,
+    db: (img.distBottom ?? 0) * scale,
+  };
+}
+
 /** Register floats from a paragraph's anchor images and draw the image bitmap immediately. */
 function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphAnchorY: number): void {
   // One id per registerAnchorFloats call ⇒ one id per paragraph. Floats sharing
@@ -3913,19 +3945,11 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
     const mode: 'square' | 'topAndBottom' =
       img.wrapMode === 'topAndBottom' ? 'topAndBottom' : 'square';
 
-    const scale = state.scale;
-    const w = img.widthPt * scale;
-    const h = img.heightPt * scale;
-    let pageX = img.anchorXFromMargin
-      ? (state.marginLeft + (img.anchorXPt ?? 0)) * scale
-      : (img.anchorXPt ?? 0) * scale;
-    let pageY = img.anchorYFromPara
-      ? paragraphAnchorY + (img.anchorYPt ?? 0) * scale
-      : (img.anchorYPt ?? 0) * scale;
-    const dt = (img.distTop    ?? 0) * scale;
-    const db = (img.distBottom ?? 0) * scale;
-    const dl = (img.distLeft   ?? 0) * scale;
-    const dr = (img.distRight  ?? 0) * scale;
+    // Wrap floats anchor against the post-spaceBefore textAreaTop (paragraphAnchorY).
+    const box = resolveAnchorBox(img, state, paragraphAnchorY);
+    const { w, h, dl, dr, dt, db } = box;
+    let pageX = box.x;
+    let pageY = box.y;
 
     // Overlap avoidance. Spec-mandated part: allowOverlap="false" (ECMA-376
     // §20.4.2.3) REQUIRES repositioning to prevent overlap; "true"/omitted only

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1048,6 +1048,7 @@ function estimateParagraphHeight(
       floats: state.floats,
       lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0),
       pageH: state.pageH,
+      markEmPx: paragraphMarkEmPx(para, 1),
     } : undefined;
     const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku);
     if (lines.length === 0) {
@@ -1138,6 +1139,7 @@ function splitParagraphAcrossPages(
     floats: measureState.floats,
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0),
     pageH: measureState.pageH,
+    markEmPx: paragraphMarkEmPx(para, 1),
   } : undefined;
   const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku);
   if (lines.length === 0) {
@@ -1768,7 +1770,7 @@ function renderParagraph(
     // Required width for an empty mark line: one em of the mark font (HEURISTIC,
     // see above — not a spec-defined threshold). A side gap narrower than this is
     // treated as unable to hold the line start, so the line flows below.
-    const markEm = getDefaultFontSize(para) * scale;
+    const markEm = paragraphMarkEmPx(para, scale);
     const probeH = 10 * scale;
     const win = resolveLineFloatWindow(
       textAreaTopY, markEm, probeH, paraX, paraW, state.floats,
@@ -1806,6 +1808,7 @@ function renderParagraph(
     floats: state.floats,
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0),
     pageH: state.pageH,
+    markEmPx: paragraphMarkEmPx(para, scale),
   } : undefined;
 
   const lines = layoutLines(ctx, segments, paraW, firstLineX - paraX, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku);
@@ -2289,6 +2292,11 @@ interface WrapLayoutCtx {
   lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number) => number;
   /** Hard cap on Y to keep layout from running past the page. */
   pageH: number;
+  /** Paragraph-mark em width (px), from paragraphMarkEmPx(para). Shared with
+   *  resolveEmptyMarkTop so an empty / anchor-only mark line that has no
+   *  trailing-break font of its own falls below a float band on the SAME
+   *  threshold the empty-paragraph path uses. */
+  markEmPx: number;
 }
 
 /**
@@ -3094,10 +3102,15 @@ function layoutLines(
     // below the float.
     const q = queue.find((s) => !('lineBreak' in s) && !('dataUrl' in s && s.anchor));
     if (!q) {
-      // Empty/paragraph-mark line: reserve one em of the paragraph font so a
-      // sub-glyph gap is rejected and the mark line drops below the floats.
-      const fs = trailingBreakFontSize ?? (segs[0] && 'fontSize' in segs[0] ? segs[0].fontSize : 10);
-      return fs * scale;
+      // Empty/paragraph-mark line: reserve one em so a sub-glyph gap is rejected
+      // and the mark line drops below the floats. A trailing `<w:br/>` carries
+      // its own (line-local) font size; otherwise use the shared paragraph-mark
+      // em (paragraphMarkEmPx, threaded via wrapCtx) so this fallback agrees with
+      // resolveEmptyMarkTop. Outside a float context the result is unused
+      // (startLine no-ops), so fall back to the legacy estimate.
+      if (trailingBreakFontSize !== null) return trailingBreakFontSize * scale;
+      if (wrapCtx) return wrapCtx.markEmPx;
+      return (segs[0] && 'fontSize' in segs[0] ? segs[0].fontSize : 10) * scale;
     }
     if ('isTab' in q) return q.measuredWidth || 0;
     if ('dataUrl' in q) return q.widthPt * scale;
@@ -4604,6 +4617,16 @@ function getDefaultFontSize(para: DocParagraph): number {
   }
   if (typeof para.defaultFontSize === 'number') return para.defaultFontSize;
   return 10; // pt fallback
+}
+
+/** Width (px) of the paragraph-mark "em" — the smallest horizontal gap a
+ *  float-bordered empty / anchor-only paragraph-mark line is allowed to sit in
+ *  before it flows below the float band. Single source of truth shared by the
+ *  empty-mark float-window probe (resolveEmptyMarkTop) and the layoutLines
+ *  empty-line fallback, so the two paths agree on what "one em of the mark
+ *  font" means. HEURISTIC threshold (see resolveEmptyMarkTop), not spec. */
+function paragraphMarkEmPx(para: DocParagraph, scale: number): number {
+  return getDefaultFontSize(para) * scale;
 }
 
 /** First text/field run's font family — used to size empty paragraphs whose

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -711,9 +711,12 @@ export function computePages(
   // registerAnchorFloats/WrapLayoutCtx anchor relative to where we actually
   // are on the page. Anchor floats are registered on the measureState as
   // paragraphs are processed and cleared when we flip to a new page, exactly
-  // like the real renderer does.
+  // like the real renderer does. floatParaSeq is reset together with floats so
+  // the paraId採番 matches the renderer, which starts each page at 0 (a fresh
+  // RenderState per page in renderDocumentToCanvas).
   measureState.y = section.marginTop;
   measureState.floats = [];
+  measureState.floatParaSeq = 0;
   // Footnote ids already reserved on the current page (so a paragraph that
   // references the same note twice doesn't double-count, and the renderer draws
   // each note once). Reset on every page flip.
@@ -733,6 +736,7 @@ export function computePages(
       prevSpaceAfter = 0;
       measureState.y = section.marginTop;
       measureState.floats = [];
+      measureState.floatParaSeq = 0;
       startPageBookkeeping();
     }
   };
@@ -796,6 +800,7 @@ export function computePages(
       prevSpaceAfter = 0;
       measureState.y = section.marginTop;
       measureState.floats = [];
+      measureState.floatParaSeq = 0;
       startPageBookkeeping();
       // ECMA-376 §17.18.79 ST_SectionMark: oddPage / evenPage breaks pad
       // with a blank page when the new section would otherwise start on the
@@ -884,9 +889,13 @@ export function computePages(
       const breakForFloat = y > 0 && floatOverflowsHere && floatFitsFresh;
       if ((y > 0 && y + needed > effContentH()) || breakForFloat) {
         newPage();
-        // newPage() cleared measureState.floats; re-register this paragraph's
-        // anchor floats against the new page's top so wrap-around estimates for
-        // this and later paragraphs see them at the correct (post-break) Y.
+        // newPage() cleared measureState.floats AND reset floatParaSeq to 0, so
+        // this is a REPLACE of the earlier register at the top of the loop (whose
+        // floats were just discarded), not an augment: this paragraph is now the
+        // first registrant on the fresh page and gets paraId 0 — exactly matching
+        // the renderer, which re-registers it from a fresh per-page state. The
+        // re-anchoring against the new page top keeps wrap-around estimates for
+        // this and later paragraphs at the correct (post-break) Y.
         registerAnchorFloats(para, measureState, measureState.y + effectiveBefore);
         // The references move to the new page; nothing was reserved there yet,
         // so the separator region still applies to the first footnote.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1697,6 +1697,69 @@ function mathJcToEdge(jc: string): AlignEdge {
   }
 }
 
+/**
+ * Render a paragraph that produces NO inline lines — either literally empty
+ * (no segments) or anchor-only (its only content is wrap floats, drawn
+ * separately). Per ECMA-376 §17.3.1.29 such a paragraph still emits ONE
+ * paragraph-mark line box; this advances `state.y` past it, draws its shading /
+ * borders, and lays its wrapNone anchor images at the (possibly float-flowed)
+ * paragraph base.
+ *
+ * Shared by renderParagraph's `segments.length === 0` and `lines.length === 0`
+ * branches (previously duplicated verbatim). The anchor-only branch's
+ * slice-boundary guards (spaceAfter only on the final slice, anchor images only
+ * on the first) are parameterized via `markCtx.totalLines` / `lineSlice`; for
+ * the literally-empty branch `lineSlice` is always undefined (empty paragraphs
+ * are never sliced), so those guards reduce to the unconditional behavior it had.
+ */
+function renderEmptyMarkParagraph(
+  para: DocParagraph,
+  state: RenderState,
+  markCtx: {
+    grid: DocGridCtx;
+    paraHasRuby: boolean;
+    contentX: number;
+    indLeft: number;
+    paraW: number;
+    textAreaTopY: number;
+    paragraphStartY: number;
+    /** Flowed top of the mark line (output of resolveEmptyMarkTop). */
+    markTop: number;
+    /** Total laid-out line count (0 here); used by the slice guards. */
+    totalLines: number;
+    lineSlice?: { start: number; end: number };
+  },
+): void {
+  const { ctx, scale, dryRun } = state;
+  const { grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY,
+    paragraphStartY, markTop, totalLines, lineSlice } = markCtx;
+  // Displacement applied by the float-flow (0 when the mark fits where it is).
+  const flowShift = Math.max(0, markTop - textAreaTopY);
+  if (markTop > state.y) state.y = markTop;
+  const markRectTop = state.y;
+  const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby);
+  if (para.shading && !dryRun) {
+    ctx.fillStyle = `#${para.shading}`;
+    ctx.fillRect(contentX + indLeft, markRectTop, paraW, emptyH);
+  }
+  state.y += emptyH;
+  if (para.borders && !dryRun) {
+    drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale);
+  }
+  // Only the slice covering the FINAL line emits spaceAfter. With no inline
+  // lines there is a single slice, so this is the whole paragraph.
+  const isFinalSlice = !lineSlice || lineSlice.end >= totalLines;
+  if (isFinalSlice) state.y += para.spaceAfter * scale;
+  // wrapNone anchor images anchor relative to the paragraph (ayFromPara); when
+  // the mark line flowed below a float band the paragraph (and its wrapNone
+  // image) drops by the same amount, so shift the anchor base by flowShift while
+  // keeping the un-flowed base (paragraphStartY) otherwise unchanged. Only the
+  // first slice draws them (a continuation slice already did on its page).
+  if (!lineSlice || lineSlice.start === 0) {
+    renderAnchorImages(para, state, paragraphStartY + flowShift);
+  }
+}
+
 function renderParagraph(
   para: DocParagraph,
   state: RenderState,
@@ -1779,26 +1842,12 @@ function renderParagraph(
   };
 
   if (segments.length === 0) {
-    const markTop = resolveEmptyMarkTop();
-    // Displacement applied by the float-flow (0 when the mark fits where it is).
-    const flowShift = Math.max(0, markTop - textAreaTopY);
-    if (markTop > state.y) state.y = markTop;
-    const markRectTop = state.y;
-    const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby);
-    if (para.shading && !dryRun) {
-      ctx.fillStyle = `#${para.shading}`;
-      ctx.fillRect(contentX + indLeft, markRectTop, paraW, emptyH);
-    }
-    state.y += emptyH;
-    if (para.borders && !dryRun) {
-      drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale);
-    }
-    state.y += para.spaceAfter * scale;
-    // wrapNone anchor images anchor relative to the paragraph (ayFromPara); when
-    // the mark line flowed below a float band the paragraph (and its wrapNone
-    // image) drops by the same amount, so shift the anchor base by flowShift
-    // while keeping the un-flowed base (paragraphStartY) otherwise unchanged.
-    renderAnchorImages(para, state, paragraphStartY + flowShift);
+    // Literally-empty paragraph: one paragraph-mark line box, no inline content
+    // and (by construction in the paginator) never sliced.
+    renderEmptyMarkParagraph(para, state, {
+      grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY, paragraphStartY,
+      markTop: resolveEmptyMarkTop(), totalLines: 0, lineSlice: undefined,
+    });
     return;
   }
 
@@ -1823,27 +1872,14 @@ function renderParagraph(
   // renderAnchorImages on their own absolute-position path, so this only adds the
   // in-flow paragraph-mark advance (no double counting, no double draw).
   if (lines.length === 0) {
-    // Same float-flow as the literally-empty path: an anchor-only paragraph's
-    // mark line (and any wrapNone image it anchors) flows below a float band it
-    // cannot sit beside.
-    const markTop = resolveEmptyMarkTop();
-    const flowShift = Math.max(0, markTop - textAreaTopY);
-    if (markTop > state.y) state.y = markTop;
-    const markRectTop = state.y;
-    const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby);
-    if (para.shading && !dryRun) {
-      ctx.fillStyle = `#${para.shading}`;
-      ctx.fillRect(contentX + indLeft, markRectTop, paraW, emptyH);
-    }
-    state.y += emptyH;
-    if (para.borders && !dryRun) {
-      drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale);
-    }
-    const isFinalSlice = !lineSlice || lineSlice.end >= lines.length;
-    if (isFinalSlice) state.y += para.spaceAfter * scale;
-    if (!lineSlice || lineSlice.start === 0) {
-      renderAnchorImages(para, state, paragraphStartY + flowShift);
-    }
+    // Anchor-only paragraph: same content-less mark line as the literally-empty
+    // path (the anchor floats themselves are drawn separately). Slice guards
+    // honor a paginator-split slice (spaceAfter on the final slice, anchor
+    // images on the first).
+    renderEmptyMarkParagraph(para, state, {
+      grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY, paragraphStartY,
+      markTop: resolveEmptyMarkTop(), totalLines: lines.length, lineSlice,
+    });
     return;
   }
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2923,6 +2923,17 @@ function resolveLineFloatWindow(
   floats: FloatRect[],
 ): { topY: number; xOffset: number; maxWidth: number } {
   // 1. Keep pushing past any topAndBottom block we sit inside.
+  //
+  // ASSUMPTION (M3): step 1 runs ONCE, before the square sweep, and is not
+  // re-checked after a square push in step 2. This relies on "no topAndBottom
+  // float sits below a square float in the same column band." topAndBottom
+  // objects span the full content width (ECMA-376 §20.4.2.16) and are normally
+  // anchored above/below the square-wrapped region, so the square push in step 2
+  // lands in float-free space below the band. If a document ever places a
+  // topAndBottom strictly below a square the pushed line could clip into it; the
+  // spec-correct fix is to make steps 1+2 a single fixpoint loop. Left as a
+  // documented assumption here to preserve current behavior (no observed sample
+  // exercises the inverted ordering).
   for (let guard = 0; guard < 16; guard++) {
     const lineBot = topY + probeH;
     let skip: number | null = null;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -130,6 +130,16 @@ interface FloatRect {
   yBottom: number;
   /** wrapText: "bothSides" | "left" | "right" | "largest" (only square uses this). */
   side: string;
+  /** dist* padding (px) — needed when displacing a float to keep its exclusion
+   *  padding when re-seating next to a blocking float (ECMA-376 §20.4.2.x). */
+  distLeft: number;
+  distRight: number;
+  distTop: number;
+  distBottom: number;
+  /** Identifier of the anchoring paragraph. Floats with the SAME paraId belong
+   *  to one paragraph and never displace each other; different-paragraph floats
+   *  are subject to de-facto overlap avoidance (Word/LibreOffice). */
+  paraId: number;
   /** true once the image itself has been drawn (drawn after its paragraph lays out). */
   drawn: boolean;
 }
@@ -162,6 +172,11 @@ interface RenderState {
   pageWidth: number;
   /** Active anchor-image floats that constrain text layout on the current page. */
   floats: FloatRect[];
+  /** Monotonic counter assigning a unique id to each registerAnchorFloats call,
+   *  i.e. one id per paragraph. Used to scope float overlap avoidance to
+   *  DIFFERENT paragraphs (floats from the same paragraph never displace each
+   *  other). */
+  floatParaSeq: number;
   /** ECMA-376 §17.6.5 docGrid (type + pitch), applied to auto line spacing. */
   docGrid: DocGridCtx;
   /** ECMA-376 §17.8.3.10 — font→family map from word/fontTable.xml. Used by
@@ -407,6 +422,7 @@ export async function renderDocumentToCanvas(
     marginBottom: sec.marginBottom,
     pageWidth: sec.pageWidth,
     floats: [],
+    floatParaSeq: 0,
     docGrid: { type: sec.docGridType ?? null, linePitchPt: sec.docGridLinePitch ?? null },
     fontFamilyClasses: doc.fontFamilyClasses ?? {},
     kinsoku,
@@ -984,6 +1000,7 @@ function buildMeasureState(
     marginBottom: section.marginBottom,
     pageWidth: section.pageWidth,
     floats: [],
+    floatParaSeq: 0,
     docGrid: { type: section.docGridType ?? null, linePitchPt: section.docGridLinePitch ?? null },
     fontFamilyClasses,
     kinsoku,
@@ -2788,12 +2805,19 @@ function layoutLines(
   let lineXOffset = 0;
   let currentLineTopY = wrapCtx?.startPageY ?? 0;
 
-  // Compute wrap constraints for a new line about to start. Mutates lineXOffset/lineMaxWidth/currentLineTopY.
-  const startLine = (): void => {
+  // Compute wrap constraints for a new line about to start. Mutates
+  // lineXOffset/lineMaxWidth/currentLineTopY. `minWidth` is the smallest width
+  // the upcoming line must have to be placeable here (the width of its first
+  // atomic token, or the paragraph-mark em for an empty line); a free gap
+  // narrower than this is treated as unusable and the line is sent below the
+  // intervening float(s) — the ECMA-376 wrap rule that text which cannot fit
+  // beside a floating object flows past it.
+  const startLine = (minWidth: number = 0): void => {
     lineXOffset = 0;
     lineMaxWidth = maxWidth;
     if (!wrapCtx) return;
-    // Probe height: the smallest plausible line height; good enough for float intersection check.
+    // Small fixed probe height for float intersection (matches the historical
+    // wrap behaviour for the topAndBottom skip and horizontal-gap scan).
     const probeH = 10 * scale;
     // Keep pushing past any topAndBottom block we sit inside.
     for (let guard = 0; guard < 16; guard++) {
@@ -2808,38 +2832,91 @@ function layoutLines(
       if (skip === null) break;
       currentLineTopY = skip;
     }
-    // Now compute horizontal constraint from square floats.
+    // Horizontal constraint from square floats. A line can be split into
+    // several free segments by floats; ECMA-376 §20.4.2.17 (wrapSquare) defines
+    // text wrapping around a single float's rect + dist padding, but when
+    // multiple floats cover a row we
+    // must pick a free horizontal gap that the line can use. We compute the
+    // open sub-intervals of [paraXLeft, paraXRight] and take the WIDEST. If the
+    // floats leave NO usable gap (e.g. two full-width side-by-side images that
+    // together span the whole column), the line cannot sit here at all: we send
+    // it down to the nearest float bottom and re-evaluate, which is the wrap
+    // spec's "flow below the obstruction" behaviour. Without this, a fully
+    // blocked line (and following empty/caption lines) would render INSIDE the
+    // float band.
     const paraXLeft = wrapCtx.paraX;
     const paraXRight = wrapCtx.paraX + maxWidth;
-    let left = paraXLeft;
-    let right = paraXRight;
-    const lineBot = currentLineTopY + probeH;
-    for (const f of wrapCtx.floats) {
-      if (f.mode !== 'square') continue;
-      if (lineBot <= f.yTop || currentLineTopY >= f.yBottom) continue;
-      // Decide which side text should flow on. "left"/"right" refer to the side TEXT occupies.
-      const spaceLeft = f.xLeft - paraXLeft;
-      const spaceRight = paraXRight - f.xRight;
-      let textOnLeft: boolean;
-      switch (f.side) {
-        case 'left':    textOnLeft = true;  break;
-        case 'right':   textOnLeft = false; break;
-        case 'largest':
-        case 'bothSides':
-        default:        textOnLeft = spaceLeft >= spaceRight; break;
+    // A gap must fit the line's first atomic token to be usable. Floor at 1px so
+    // a zero-width probe (no content yet) still rejects sub-pixel slivers.
+    const usableGap = Math.max(minWidth, 1);
+    for (let guard = 0; guard < 64; guard++) {
+      const lineBot = currentLineTopY + probeH;
+      // Collect square floats intersecting this Y band and the X interval they
+      // block (depends on wrapText side: the float plus, for one-sided wrap,
+      // the column edge on the forbidden side).
+      const blocked: { l: number; r: number }[] = [];
+      const intersecting: FloatRect[] = [];
+      for (const f of wrapCtx.floats) {
+        if (f.mode !== 'square') continue;
+        if (lineBot <= f.yTop || currentLineTopY >= f.yBottom) continue;
+        intersecting.push(f);
+        switch (f.side) {
+          // Text may sit only on the LEFT of the float ⇒ everything from the
+          // float's left edge to the column right is unavailable.
+          case 'left':  blocked.push({ l: f.xLeft, r: paraXRight }); break;
+          // Text may sit only on the RIGHT ⇒ column left .. float right blocked.
+          case 'right': blocked.push({ l: paraXLeft, r: f.xRight }); break;
+          case 'largest':
+          case 'bothSides':
+          default:      blocked.push({ l: f.xLeft, r: f.xRight }); break;
+        }
       }
-      if (textOnLeft) {
-        if (f.xLeft < right) right = Math.max(left, f.xLeft);
-      } else {
-        if (f.xRight > left) left = Math.min(right, f.xRight);
+      if (intersecting.length === 0) {
+        lineXOffset = 0;
+        lineMaxWidth = maxWidth;
+        break;
       }
+      // Sweep [paraXLeft, paraXRight] removing blocked spans; collect free gaps.
+      blocked.sort((a, b) => a.l - b.l);
+      let cursor = paraXLeft;
+      let best: { l: number; r: number } | null = null;
+      const consider = (l: number, r: number) => {
+        if (r - l > (best ? best.r - best.l : 0)) best = { l, r };
+      };
+      for (const b of blocked) {
+        if (b.l > cursor) consider(cursor, Math.min(b.l, paraXRight));
+        cursor = Math.max(cursor, Math.min(b.r, paraXRight));
+        if (cursor >= paraXRight) break;
+      }
+      if (cursor < paraXRight) consider(cursor, paraXRight);
+
+      if (best && (best as { l: number; r: number }).r - (best as { l: number; r: number }).l >= usableGap) {
+        const seg = best as { l: number; r: number };
+        lineXOffset = Math.max(0, seg.l - paraXLeft);
+        lineMaxWidth = Math.min(maxWidth - lineXOffset, seg.r - seg.l);
+        if (lineMaxWidth < 0) lineMaxWidth = 0;
+        break;
+      }
+
+      // No usable gap on this row: the intersecting floats cover the whole
+      // column width here (otherwise a gap would have been found above). The
+      // line therefore cannot sit beside ANY of them, so it must clear them all
+      // — advance to the LOWEST blocking float bottom (max yBottom). Dropping
+      // only to the nearest bottom would leave the line squeezed into a side gap
+      // beside a still-active float (placing a full-width caption off-centre
+      // under one image); clearing all the full-width floats at once puts it
+      // centred below the band, matching Word. (Partial-width floats never reach
+      // this branch because they leave a usable side gap above.)
+      const nextY = Math.max(...intersecting.map((f) => f.yBottom));
+      if (nextY <= currentLineTopY) {
+        // Degenerate guard (shouldn't happen): keep full width to avoid a stall.
+        lineXOffset = 0;
+        lineMaxWidth = maxWidth;
+        break;
+      }
+      currentLineTopY = nextY;
     }
-    const eff = Math.max(0, right - left);
-    lineXOffset = Math.max(0, left - paraXLeft);
-    lineMaxWidth = Math.min(maxWidth - lineXOffset, eff);
-    if (lineMaxWidth < 0) lineMaxWidth = 0;
   };
-  startLine();
 
   const availW = () => lineMaxWidth - (isFirst ? firstIndent : 0);
 
@@ -2878,7 +2955,7 @@ function layoutLines(
     lineIntendedSingle = 0;
     lineHasRuby = false;
     isFirst = false;
-    startLine();
+    startLine(requiredLineWidth());
   };
 
   const addToLine = (
@@ -2924,11 +3001,47 @@ function layoutLines(
   // Use an explicit queue so CJK split-tails can be re-queued
   const queue: LayoutSeg[] = [...segs];
 
+  // Smallest width the NEXT line must have to be placeable beside a float: the
+  // width of its first atomic token. For text we measure the first wrap unit
+  // (CJK: one grapheme — kinsoku may force more, but one char is the floor;
+  // Latin: up to the first space). For an image/math the whole object. An empty
+  // line (no remaining content) still reserves the paragraph-mark em so a
+  // sliver gap between full-width floats does not "fit" it. Used by startLine to
+  // decide whether to wrap in a gap or send the line below the floats.
+  const requiredLineWidth = (): number => {
+    // First inline token that actually occupies width on the line. Anchor-image
+    // segments are floats (drawn separately, measuredWidth 0) and lineBreaks
+    // carry no width, so skip them — otherwise the float's own width would be
+    // mistaken for the line's required width and wrongly push every wrap line
+    // below the float.
+    const q = queue.find((s) => !('lineBreak' in s) && !('dataUrl' in s && s.anchor));
+    if (!q) {
+      // Empty/paragraph-mark line: reserve one em of the paragraph font so a
+      // sub-glyph gap is rejected and the mark line drops below the floats.
+      const fs = trailingBreakFontSize ?? (segs[0] && 'fontSize' in segs[0] ? segs[0].fontSize : 10);
+      return fs * scale;
+    }
+    if ('isTab' in q) return q.measuredWidth || 0;
+    if ('dataUrl' in q) return q.widthPt * scale;
+    if ('mathNodes' in q) return q.measuredWidth || 0;
+    const ts = q as LayoutTextSeg;
+    // First wrap unit: leading run up to the first space (Latin word) or the
+    // first character (CJK / no space). Whichever is shorter bounds the floor.
+    const sp = ts.text.indexOf(' ');
+    const head = sp > 0 ? ts.text.slice(0, sp) : ts.text;
+    const firstChar = [...head][0] ?? '';
+    const probe = { ...ts, text: firstChar };
+    return measureText(probe).width;
+  };
+
   // A `<w:br/>` always starts a new line (§17.3.3.1) — when it is the LAST
   // content of the paragraph that new line is an EMPTY line that still
   // occupies one line height (Word reserves it; visible e.g. as extra table
   // row height). Track the trailing break so it can be flushed after the loop.
   let trailingBreakFontSize: number | null = null;
+
+  // Establish the first line's wrap window now that the content queue exists.
+  startLine(requiredLineWidth());
 
   while (queue.length > 0) {
     const seg = queue.shift()!;
@@ -3576,8 +3689,76 @@ function isWrapFloat(mode?: string): boolean {
   return mode === 'square' || mode === 'topAndBottom' || mode === 'tight' || mode === 'through';
 }
 
+/** Two exclusion rects intersect (strict overlap, touching edges allowed). */
+function rectsOverlap(
+  aL: number, aR: number, aT: number, aB: number,
+  bL: number, bR: number, bT: number, bB: number,
+): boolean {
+  const EPS = 0.01;
+  return aL < bR - EPS && aR > bL + EPS && aT < bB - EPS && aB > bT + EPS;
+}
+
+/**
+ * De-facto multi-float collision resolution for a NEW wrap float, against
+ * floats already registered on the page that belong to OTHER paragraphs.
+ *
+ * Per ECMA-376 Part 1 §20.4.2.3 (wp:anchor/@allowOverlap): an object that
+ * "cannot overlap other DrawingML object … shall be repositioned when displayed
+ * to prevent this overlap" — i.e. allowOverlap="false" MANDATES repositioning,
+ * while allowOverlap="true" only *permits* overlap (it does not require it, nor
+ * does it forbid the renderer from avoiding it). Word and LibreOffice keep
+ * floats anchored in different paragraphs from overlapping regardless — for
+ * allowOverlap="false" that is spec-mandated, and for the common allowOverlap=
+ * "true" case (e.g. sample-9 figure 9) it is a spec-permitted layout policy we
+ * mirror to match the reference rendering. Single-float wrap geometry and the
+ * dist* padding reused below are defined by §20.4.2.17 (wrapSquare).
+ *
+ * We re-seat horizontally to the right of the blocking float(s) first (margins
+ * may be used — Word lets a displaced float sit in the page margin), and only
+ * fall back to a vertical push when no horizontal room remains.
+ *
+ * Coordinates are page-absolute px. (x,y) is the image box origin (no dist).
+ */
+function resolveFloatOverlap(
+  x: number, y: number, w: number, h: number,
+  dl: number, dr: number, dt: number, db: number,
+  paraId: number, state: RenderState,
+): { x: number; y: number } {
+  const pageRight = state.pageWidth * state.scale;
+  for (let guard = 0; guard < 16; guard++) {
+    const exL = x - dl, exR = x + w + dr, exT = y - dt, exB = y + h + db;
+    // Blocking floats: different paragraph, exclusion rects intersect.
+    const blockers = state.floats.filter(
+      (f) => f.paraId !== paraId &&
+        rectsOverlap(exL, exR, exT, exB, f.xLeft, f.xRight, f.yTop, f.yBottom),
+    );
+    if (blockers.length === 0) return { x, y };
+
+    // Horizontal: re-seat just right of the right-most blocker. Setting our
+    // left exclusion edge (x - dl) flush against the blocker's right exclusion
+    // edge means x = maxRight + dl (gap = blocker.distRight + our distLeft).
+    const maxRight = Math.max(...blockers.map((f) => f.xRight));
+    const newX = maxRight + dl;
+    if (newX + w + dr <= pageRight + 0.5) {
+      x = newX;
+      continue; // re-check against all other-paragraph floats
+    }
+
+    // No horizontal room: push below the lowest blocker (smallest displacement
+    // that clears them). Our top exclusion edge (y - dt) flush with the
+    // blocker's bottom exclusion edge ⇒ y = maxBottom + dt.
+    const maxBottom = Math.max(...blockers.map((f) => f.yBottom));
+    y = maxBottom + dt;
+  }
+  return { x, y };
+}
+
 /** Register floats from a paragraph's anchor images and draw the image bitmap immediately. */
 function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphAnchorY: number): void {
+  // One id per registerAnchorFloats call ⇒ one id per paragraph. Floats sharing
+  // a paraId (e.g. two side-by-side photos in one paragraph) never displace each
+  // other; floats from different paragraphs do (de-facto overlap avoidance).
+  const paraId = state.floatParaSeq++;
   for (const run of para.runs) {
     if (run.type !== 'image') continue;
     const img = run as unknown as ImageRun;
@@ -3590,16 +3771,30 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
     const scale = state.scale;
     const w = img.widthPt * scale;
     const h = img.heightPt * scale;
-    const pageX = img.anchorXFromMargin
+    let pageX = img.anchorXFromMargin
       ? (state.marginLeft + (img.anchorXPt ?? 0)) * scale
       : (img.anchorXPt ?? 0) * scale;
-    const pageY = img.anchorYFromPara
+    let pageY = img.anchorYFromPara
       ? paragraphAnchorY + (img.anchorYPt ?? 0) * scale
       : (img.anchorYPt ?? 0) * scale;
     const dt = (img.distTop    ?? 0) * scale;
     const db = (img.distBottom ?? 0) * scale;
     const dl = (img.distLeft   ?? 0) * scale;
     const dr = (img.distRight  ?? 0) * scale;
+
+    // Overlap avoidance (ECMA-376 §20.4.2.3 allowOverlap: "false" mandates
+    // repositioning to prevent overlap; "true" only permits it). Word/LibreOffice
+    // keep floats anchored in different paragraphs from overlapping — the later
+    // (document-order) float is displaced. We resolve against already-registered
+    // floats from OTHER paragraphs — first horizontally (re-seat to the right of
+    // the blockers, honoring dist padding), then, if that runs off the page,
+    // vertically. (allowOverlap is not yet surfaced by the parser, so this fires
+    // for every different-paragraph overlap; all current samples are "true".)
+    const resolved = resolveFloatOverlap(
+      pageX, pageY, w, h, dl, dr, dt, db, paraId, state,
+    );
+    pageX = resolved.x;
+    pageY = resolved.y;
 
     const key = imageKey(img.dataUrl, img.colorReplaceFrom);
     const rect: FloatRect = {
@@ -3614,6 +3809,11 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
       yTop: pageY - dt,
       yBottom: pageY + h + db,
       side: img.wrapSide ?? 'bothSides',
+      distLeft: dl,
+      distRight: dr,
+      distTop: dt,
+      distBottom: db,
+      paraId,
       drawn: false,
     };
     state.floats.push(rect);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1738,18 +1738,48 @@ function renderParagraph(
   const paraHasRuby = paragraphHasRuby(para);
   const grid = paraGrid(para, state);
 
+  // A paragraph with no inline content (literally empty, or anchor-only) still
+  // produces ONE paragraph-mark line box (ECMA-376 §17.3.1.29). That line box
+  // is subject to the same float-wrap rules as text: if it cannot fit beside the
+  // page's active floats it flows below them (§20.4.2.16/.17). Without this an
+  // empty paragraph mark wedges into a sub-em sliver beside a full-width float
+  // band and the following paragraphs (and any wrapNone image those paragraphs
+  // anchor) stay pinned inside the band. We resolve the mark line's flowed top
+  // here and use it for the mark advance, the shading/border rect, and the
+  // paragraph-relative base of any wrapNone anchor image drawn below.
+  const resolveEmptyMarkTop = (): number => {
+    if (state.floats.length === 0) return textAreaTopY;
+    // Required width for an empty mark line: one em of the mark font. A side gap
+    // narrower than this cannot hold the line start, so the line flows below.
+    const markEm = getDefaultFontSize(para) * scale;
+    const probeH = 10 * scale;
+    const win = resolveLineFloatWindow(
+      textAreaTopY, markEm, probeH, paraX, paraW, state.floats,
+    );
+    return win.topY;
+  };
+
   if (segments.length === 0) {
+    const markTop = resolveEmptyMarkTop();
+    // Displacement applied by the float-flow (0 when the mark fits where it is).
+    const flowShift = Math.max(0, markTop - textAreaTopY);
+    if (markTop > state.y) state.y = markTop;
+    const markRectTop = state.y;
     const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby);
     if (para.shading && !dryRun) {
       ctx.fillStyle = `#${para.shading}`;
-      ctx.fillRect(contentX + indLeft, textAreaTopY, paraW, emptyH);
+      ctx.fillRect(contentX + indLeft, markRectTop, paraW, emptyH);
     }
     state.y += emptyH;
     if (para.borders && !dryRun) {
-      drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, emptyH, para.borders, scale);
+      drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale);
     }
     state.y += para.spaceAfter * scale;
-    renderAnchorImages(para, state, paragraphStartY);
+    // wrapNone anchor images anchor relative to the paragraph (ayFromPara); when
+    // the mark line flowed below a float band the paragraph (and its wrapNone
+    // image) drops by the same amount, so shift the anchor base by flowShift
+    // while keeping the un-flowed base (paragraphStartY) otherwise unchanged.
+    renderAnchorImages(para, state, paragraphStartY + flowShift);
     return;
   }
 
@@ -1773,19 +1803,26 @@ function renderParagraph(
   // renderAnchorImages on their own absolute-position path, so this only adds the
   // in-flow paragraph-mark advance (no double counting, no double draw).
   if (lines.length === 0) {
+    // Same float-flow as the literally-empty path: an anchor-only paragraph's
+    // mark line (and any wrapNone image it anchors) flows below a float band it
+    // cannot sit beside.
+    const markTop = resolveEmptyMarkTop();
+    const flowShift = Math.max(0, markTop - textAreaTopY);
+    if (markTop > state.y) state.y = markTop;
+    const markRectTop = state.y;
     const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby);
     if (para.shading && !dryRun) {
       ctx.fillStyle = `#${para.shading}`;
-      ctx.fillRect(contentX + indLeft, textAreaTopY, paraW, emptyH);
+      ctx.fillRect(contentX + indLeft, markRectTop, paraW, emptyH);
     }
     state.y += emptyH;
     if (para.borders && !dryRun) {
-      drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, emptyH, para.borders, scale);
+      drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale);
     }
     const isFinalSlice = !lineSlice || lineSlice.end >= lines.length;
     if (isFinalSlice) state.y += para.spaceAfter * scale;
     if (!lineSlice || lineSlice.start === 0) {
-      renderAnchorImages(para, state, paragraphStartY);
+      renderAnchorImages(para, state, paragraphStartY + flowShift);
     }
     return;
   }
@@ -2762,6 +2799,119 @@ function splitTextForLayout(text: string): string[] {
   return result.length ? result : [text];
 }
 
+/**
+ * Resolve where a single line box may sit relative to the page's active floats.
+ *
+ * Given the line's intended top Y and the minimum horizontal width it needs to
+ * be placeable (`requiredWidth` — the width of its first atomic token, or, for
+ * an empty paragraph-mark line, one em of the mark font), this returns the Y at
+ * which the line actually starts plus the horizontal sub-window it may use.
+ *
+ * Two ECMA-376 wrap rules are applied, in order:
+ *   1. topAndBottom floats (§20.4.2.16): a line intersecting one is pushed below
+ *      it — text never sits beside a topAndBottom object.
+ *   2. square floats (§20.4.2.17): text wraps around the float's rect + dist
+ *      padding. When several squares cover a row we take the WIDEST free
+ *      horizontal gap. If no gap is wide enough for `requiredWidth` the line
+ *      cannot sit here at all and flows below the obstruction (advance to the
+ *      lowest blocking float bottom and re-evaluate). This is the same "flow
+ *      below the obstruction" behaviour used for wrapped text; routing empty /
+ *      anchor-only paragraph-mark lines through it makes those lines (and the
+ *      paragraphs that follow them) drop below a full-width float band instead
+ *      of rendering inside it.
+ */
+function resolveLineFloatWindow(
+  topY: number,
+  requiredWidth: number,
+  probeH: number,
+  paraX: number,
+  maxWidth: number,
+  floats: FloatRect[],
+): { topY: number; xOffset: number; maxWidth: number } {
+  // 1. Keep pushing past any topAndBottom block we sit inside.
+  for (let guard = 0; guard < 16; guard++) {
+    const lineBot = topY + probeH;
+    let skip: number | null = null;
+    for (const f of floats) {
+      if (f.mode !== 'topAndBottom') continue;
+      if (lineBot > f.yTop && topY < f.yBottom) {
+        skip = skip === null ? f.yBottom : Math.max(skip, f.yBottom);
+      }
+    }
+    if (skip === null) break;
+    topY = skip;
+  }
+
+  // 2. Horizontal constraint from square floats.
+  const paraXLeft = paraX;
+  const paraXRight = paraX + maxWidth;
+  // A gap must fit the line's first atomic token to be usable. Floor at 1px so a
+  // zero-width probe (no content yet) still rejects sub-pixel slivers.
+  const usableGap = Math.max(requiredWidth, 1);
+  let xOffset = 0;
+  let lineMaxWidth = maxWidth;
+  for (let guard = 0; guard < 64; guard++) {
+    const lineBot = topY + probeH;
+    const blocked: { l: number; r: number }[] = [];
+    const intersecting: FloatRect[] = [];
+    for (const f of floats) {
+      if (f.mode !== 'square') continue;
+      if (lineBot <= f.yTop || topY >= f.yBottom) continue;
+      intersecting.push(f);
+      switch (f.side) {
+        // Text may sit only on the LEFT of the float ⇒ everything from the
+        // float's left edge to the column right is unavailable.
+        case 'left':  blocked.push({ l: f.xLeft, r: paraXRight }); break;
+        // Text may sit only on the RIGHT ⇒ column left .. float right blocked.
+        case 'right': blocked.push({ l: paraXLeft, r: f.xRight }); break;
+        case 'largest':
+        case 'bothSides':
+        default:      blocked.push({ l: f.xLeft, r: f.xRight }); break;
+      }
+    }
+    if (intersecting.length === 0) {
+      xOffset = 0;
+      lineMaxWidth = maxWidth;
+      break;
+    }
+    // Sweep [paraXLeft, paraXRight] removing blocked spans; collect free gaps.
+    blocked.sort((a, b) => a.l - b.l);
+    let cursor = paraXLeft;
+    let best: { l: number; r: number } | null = null;
+    const consider = (l: number, r: number) => {
+      if (r - l > (best ? best.r - best.l : 0)) best = { l, r };
+    };
+    for (const b of blocked) {
+      if (b.l > cursor) consider(cursor, Math.min(b.l, paraXRight));
+      cursor = Math.max(cursor, Math.min(b.r, paraXRight));
+      if (cursor >= paraXRight) break;
+    }
+    if (cursor < paraXRight) consider(cursor, paraXRight);
+
+    if (best && (best as { l: number; r: number }).r - (best as { l: number; r: number }).l >= usableGap) {
+      const seg = best as { l: number; r: number };
+      xOffset = Math.max(0, seg.l - paraXLeft);
+      lineMaxWidth = Math.min(maxWidth - xOffset, seg.r - seg.l);
+      if (lineMaxWidth < 0) lineMaxWidth = 0;
+      break;
+    }
+
+    // No usable gap on this row: the intersecting floats cover the whole column
+    // width here. The line must clear them all — advance to the LOWEST blocking
+    // float bottom (max yBottom) so it sits centred below the band rather than
+    // squeezed into a side sliver beside a still-active float.
+    const nextY = Math.max(...intersecting.map((f) => f.yBottom));
+    if (nextY <= topY) {
+      // Degenerate guard (shouldn't happen): keep full width to avoid a stall.
+      xOffset = 0;
+      lineMaxWidth = maxWidth;
+      break;
+    }
+    topY = nextY;
+  }
+  return { topY, xOffset, maxWidth: lineMaxWidth };
+}
+
 function layoutLines(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   segs: LayoutSeg[],
@@ -2819,103 +2969,12 @@ function layoutLines(
     // Small fixed probe height for float intersection (matches the historical
     // wrap behaviour for the topAndBottom skip and horizontal-gap scan).
     const probeH = 10 * scale;
-    // Keep pushing past any topAndBottom block we sit inside.
-    for (let guard = 0; guard < 16; guard++) {
-      const lineBot = currentLineTopY + probeH;
-      let skip: number | null = null;
-      for (const f of wrapCtx.floats) {
-        if (f.mode !== 'topAndBottom') continue;
-        if (lineBot > f.yTop && currentLineTopY < f.yBottom) {
-          skip = skip === null ? f.yBottom : Math.max(skip, f.yBottom);
-        }
-      }
-      if (skip === null) break;
-      currentLineTopY = skip;
-    }
-    // Horizontal constraint from square floats. A line can be split into
-    // several free segments by floats; ECMA-376 §20.4.2.17 (wrapSquare) defines
-    // text wrapping around a single float's rect + dist padding, but when
-    // multiple floats cover a row we
-    // must pick a free horizontal gap that the line can use. We compute the
-    // open sub-intervals of [paraXLeft, paraXRight] and take the WIDEST. If the
-    // floats leave NO usable gap (e.g. two full-width side-by-side images that
-    // together span the whole column), the line cannot sit here at all: we send
-    // it down to the nearest float bottom and re-evaluate, which is the wrap
-    // spec's "flow below the obstruction" behaviour. Without this, a fully
-    // blocked line (and following empty/caption lines) would render INSIDE the
-    // float band.
-    const paraXLeft = wrapCtx.paraX;
-    const paraXRight = wrapCtx.paraX + maxWidth;
-    // A gap must fit the line's first atomic token to be usable. Floor at 1px so
-    // a zero-width probe (no content yet) still rejects sub-pixel slivers.
-    const usableGap = Math.max(minWidth, 1);
-    for (let guard = 0; guard < 64; guard++) {
-      const lineBot = currentLineTopY + probeH;
-      // Collect square floats intersecting this Y band and the X interval they
-      // block (depends on wrapText side: the float plus, for one-sided wrap,
-      // the column edge on the forbidden side).
-      const blocked: { l: number; r: number }[] = [];
-      const intersecting: FloatRect[] = [];
-      for (const f of wrapCtx.floats) {
-        if (f.mode !== 'square') continue;
-        if (lineBot <= f.yTop || currentLineTopY >= f.yBottom) continue;
-        intersecting.push(f);
-        switch (f.side) {
-          // Text may sit only on the LEFT of the float ⇒ everything from the
-          // float's left edge to the column right is unavailable.
-          case 'left':  blocked.push({ l: f.xLeft, r: paraXRight }); break;
-          // Text may sit only on the RIGHT ⇒ column left .. float right blocked.
-          case 'right': blocked.push({ l: paraXLeft, r: f.xRight }); break;
-          case 'largest':
-          case 'bothSides':
-          default:      blocked.push({ l: f.xLeft, r: f.xRight }); break;
-        }
-      }
-      if (intersecting.length === 0) {
-        lineXOffset = 0;
-        lineMaxWidth = maxWidth;
-        break;
-      }
-      // Sweep [paraXLeft, paraXRight] removing blocked spans; collect free gaps.
-      blocked.sort((a, b) => a.l - b.l);
-      let cursor = paraXLeft;
-      let best: { l: number; r: number } | null = null;
-      const consider = (l: number, r: number) => {
-        if (r - l > (best ? best.r - best.l : 0)) best = { l, r };
-      };
-      for (const b of blocked) {
-        if (b.l > cursor) consider(cursor, Math.min(b.l, paraXRight));
-        cursor = Math.max(cursor, Math.min(b.r, paraXRight));
-        if (cursor >= paraXRight) break;
-      }
-      if (cursor < paraXRight) consider(cursor, paraXRight);
-
-      if (best && (best as { l: number; r: number }).r - (best as { l: number; r: number }).l >= usableGap) {
-        const seg = best as { l: number; r: number };
-        lineXOffset = Math.max(0, seg.l - paraXLeft);
-        lineMaxWidth = Math.min(maxWidth - lineXOffset, seg.r - seg.l);
-        if (lineMaxWidth < 0) lineMaxWidth = 0;
-        break;
-      }
-
-      // No usable gap on this row: the intersecting floats cover the whole
-      // column width here (otherwise a gap would have been found above). The
-      // line therefore cannot sit beside ANY of them, so it must clear them all
-      // — advance to the LOWEST blocking float bottom (max yBottom). Dropping
-      // only to the nearest bottom would leave the line squeezed into a side gap
-      // beside a still-active float (placing a full-width caption off-centre
-      // under one image); clearing all the full-width floats at once puts it
-      // centred below the band, matching Word. (Partial-width floats never reach
-      // this branch because they leave a usable side gap above.)
-      const nextY = Math.max(...intersecting.map((f) => f.yBottom));
-      if (nextY <= currentLineTopY) {
-        // Degenerate guard (shouldn't happen): keep full width to avoid a stall.
-        lineXOffset = 0;
-        lineMaxWidth = maxWidth;
-        break;
-      }
-      currentLineTopY = nextY;
-    }
+    const win = resolveLineFloatWindow(
+      currentLineTopY, minWidth, probeH, wrapCtx.paraX, maxWidth, wrapCtx.floats,
+    );
+    currentLineTopY = win.topY;
+    lineXOffset = win.xOffset;
+    lineMaxWidth = win.maxWidth;
   };
 
   const availW = () => lineMaxWidth - (isFirst ? firstIndent : 0);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2860,6 +2860,37 @@ function splitTextForLayout(text: string): string[] {
   return result.length ? result : [text];
 }
 
+/** A horizontal interval [l, r] in absolute canvas px. */
+interface Gap {
+  l: number;
+  r: number;
+}
+
+/**
+ * Widest free horizontal interval within [left, right] after removing the
+ * `blocked` spans. Returns null when nothing is free. Factored out of
+ * resolveLineFloatWindow so the caller holds a properly-typed Gap (the previous
+ * inline closure form forced TS to narrow `best` to never, requiring casts).
+ */
+function widestFreeGap(blocked: Gap[], left: number, right: number): Gap | null {
+  const spans = blocked.slice().sort((a, b) => a.l - b.l);
+  let cursor = left;
+  let best: Gap | null = null;
+  const consider = (l: number, r: number): void => {
+    // Adopt only when strictly wider than the current best (0 when none yet),
+    // so a zero/negative-width gap never becomes `best`. Matches the prior inline
+    // form `r - l > (best ? best.r - best.l : 0)`.
+    if (r - l > (best ? best.r - best.l : 0)) best = { l, r };
+  };
+  for (const b of spans) {
+    if (b.l > cursor) consider(cursor, Math.min(b.l, right));
+    cursor = Math.max(cursor, Math.min(b.r, right));
+    if (cursor >= right) break;
+  }
+  if (cursor < right) consider(cursor, right);
+  return best;
+}
+
 /**
  * Resolve where a single line box may sit relative to the page's active floats.
  *
@@ -2908,9 +2939,9 @@ function resolveLineFloatWindow(
   // 2. Horizontal constraint from square floats.
   const paraXLeft = paraX;
   const paraXRight = paraX + maxWidth;
-  // A gap must fit the line's first atomic token to be usable. Floor at 1px so a
+  // A gap must fit the line's first atomic token to be usable. Floor so a
   // zero-width probe (no content yet) still rejects sub-pixel slivers.
-  const usableGap = Math.max(requiredWidth, 1);
+  const usableGap = Math.max(requiredWidth, MIN_LINE_GAP);
   let xOffset = 0;
   let lineMaxWidth = maxWidth;
   for (let guard = 0; guard < 64; guard++) {
@@ -2937,24 +2968,11 @@ function resolveLineFloatWindow(
       lineMaxWidth = maxWidth;
       break;
     }
-    // Sweep [paraXLeft, paraXRight] removing blocked spans; collect free gaps.
-    blocked.sort((a, b) => a.l - b.l);
-    let cursor = paraXLeft;
-    let best: { l: number; r: number } | null = null;
-    const consider = (l: number, r: number) => {
-      if (r - l > (best ? best.r - best.l : 0)) best = { l, r };
-    };
-    for (const b of blocked) {
-      if (b.l > cursor) consider(cursor, Math.min(b.l, paraXRight));
-      cursor = Math.max(cursor, Math.min(b.r, paraXRight));
-      if (cursor >= paraXRight) break;
-    }
-    if (cursor < paraXRight) consider(cursor, paraXRight);
-
-    if (best && (best as { l: number; r: number }).r - (best as { l: number; r: number }).l >= usableGap) {
-      const seg = best as { l: number; r: number };
-      xOffset = Math.max(0, seg.l - paraXLeft);
-      lineMaxWidth = Math.min(maxWidth - xOffset, seg.r - seg.l);
+    // Widest free horizontal gap between the blocked spans across the column.
+    const best = widestFreeGap(blocked, paraXLeft, paraXRight);
+    if (best && best.r - best.l >= usableGap) {
+      xOffset = Math.max(0, best.l - paraXLeft);
+      lineMaxWidth = Math.min(maxWidth - xOffset, best.r - best.l);
       if (lineMaxWidth < 0) lineMaxWidth = 0;
       break;
     }
@@ -3813,13 +3831,33 @@ function isWrapFloat(mode?: string): boolean {
   return mode === 'square' || mode === 'topAndBottom' || mode === 'tight' || mode === 'through';
 }
 
+// ── Float-layout tolerances (px) ──────────────────────────────────────────────
+// Sub-pixel slack used so floating-point coordinate noise (margin/anchor/dist
+// arithmetic at the current scale) doesn't read as a real overlap or a real gap.
+
+/** Overlap epsilon: two exclusion rects must overlap by MORE than this to count
+ *  as intersecting, so coincident/touching edges (and FP noise) are not a clash. */
+const FLOAT_OVERLAP_EPS = 0.01;
+
+/** Slack added to the page-right edge when testing whether a displaced float
+ *  still fits horizontally — a float ending within this many px of the page edge
+ *  is treated as fitting (it would otherwise be pushed down by FP rounding).
+ *  Looser than FLOAT_OVERLAP_EPS because it guards a half-pixel rounding of a
+ *  full-width displacement, not an edge-touch test. */
+const FLOAT_PAGE_RIGHT_SLACK = 0.5;
+
+/** Minimum width (px) a free side-gap must have to hold a line start. Floors the
+ *  required-width probe so a zero-width probe (an empty line with no content yet)
+ *  still rejects sub-pixel slivers between full-width floats. */
+const MIN_LINE_GAP = 1;
+
 /** Two exclusion rects intersect (strict overlap, touching edges allowed). */
 function rectsOverlap(
   aL: number, aR: number, aT: number, aB: number,
   bL: number, bR: number, bT: number, bB: number,
 ): boolean {
-  const EPS = 0.01;
-  return aL < bR - EPS && aR > bL + EPS && aT < bB - EPS && aB > bT + EPS;
+  return aL < bR - FLOAT_OVERLAP_EPS && aR > bL + FLOAT_OVERLAP_EPS &&
+    aT < bB - FLOAT_OVERLAP_EPS && aB > bT + FLOAT_OVERLAP_EPS;
 }
 
 /**
@@ -3881,7 +3919,7 @@ function resolveFloatOverlap(
     // edge means x = maxRight + dl (gap = blocker.distRight + our distLeft).
     const maxRight = Math.max(...blockers.map((f) => f.xRight));
     const newX = maxRight + dl;
-    if (newX + w + dr <= pageRight + 0.5) {
+    if (newX + w + dr <= pageRight + FLOAT_PAGE_RIGHT_SLACK) {
       x = newX;
       continue; // re-check against all other-paragraph floats
     }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -28,6 +28,13 @@ import {
   type AlignEdge,
   type LineVisualOrder,
 } from './bidi-line.js';
+import {
+  type FloatRect,
+  isWrapFloat,
+  resolveLineFloatWindow,
+  resolveFloatOverlap,
+  skipPastTopAndBottom,
+} from './float-layout.js';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -111,39 +118,6 @@ export async function prepareMathRuns(body: BodyElement[], math: MathRenderer): 
       // Conversion failure: leave the equation unrendered (zero-size) rather than throw.
     }
   }
-}
-
-/** Anchor image float that affects text wrap on the current page. */
-interface FloatRect {
-  mode: 'square' | 'topAndBottom';
-  /** Hex key of the image bitmap (used to defer drawing until final Y is known). */
-  imageKey: string;
-  /** Absolute canvas X of the image box (without dist padding). */
-  imageX: number;
-  imageY: number;
-  imageW: number;
-  imageH: number;
-  /** Padded exclusion rectangle for text wrap. */
-  xLeft: number;
-  xRight: number;
-  yTop: number;
-  yBottom: number;
-  /** wrapText: "bothSides" | "left" | "right" | "largest" (only square uses this). */
-  side: string;
-  /** dist* padding (px) — needed when displacing a float to keep its exclusion
-   *  padding when re-seating next to a blocking float (ECMA-376 §20.4.2.x). */
-  distLeft: number;
-  distRight: number;
-  distTop: number;
-  distBottom: number;
-  /** Identifier of the anchoring paragraph. Used only by the implementation-
-   *  defined (HEURISTIC) overlap avoidance under allowOverlap=true: floats with
-   *  the SAME paraId never displace each other, different-paragraph floats do.
-   *  ECMA-376 does not define this scoping; it mirrors Word/LibreOffice. See
-   *  resolveFloatOverlap. */
-  paraId: number;
-  /** true once the image itself has been drawn (drawn after its paragraph lays out). */
-  drawn: boolean;
 }
 
 interface RenderState {
@@ -2860,150 +2834,6 @@ function splitTextForLayout(text: string): string[] {
   return result.length ? result : [text];
 }
 
-/** A horizontal interval [l, r] in absolute canvas px. */
-interface Gap {
-  l: number;
-  r: number;
-}
-
-/**
- * Widest free horizontal interval within [left, right] after removing the
- * `blocked` spans. Returns null when nothing is free. Factored out of
- * resolveLineFloatWindow so the caller holds a properly-typed Gap (the previous
- * inline closure form forced TS to narrow `best` to never, requiring casts).
- */
-function widestFreeGap(blocked: Gap[], left: number, right: number): Gap | null {
-  const spans = blocked.slice().sort((a, b) => a.l - b.l);
-  let cursor = left;
-  let best: Gap | null = null;
-  const consider = (l: number, r: number): void => {
-    // Adopt only when strictly wider than the current best (0 when none yet),
-    // so a zero/negative-width gap never becomes `best`. Matches the prior inline
-    // form `r - l > (best ? best.r - best.l : 0)`.
-    if (r - l > (best ? best.r - best.l : 0)) best = { l, r };
-  };
-  for (const b of spans) {
-    if (b.l > cursor) consider(cursor, Math.min(b.l, right));
-    cursor = Math.max(cursor, Math.min(b.r, right));
-    if (cursor >= right) break;
-  }
-  if (cursor < right) consider(cursor, right);
-  return best;
-}
-
-/**
- * Resolve where a single line box may sit relative to the page's active floats.
- *
- * Given the line's intended top Y and the minimum horizontal width it needs to
- * be placeable (`requiredWidth` — the width of its first atomic token, or, for
- * an empty paragraph-mark line, one em of the mark font), this returns the Y at
- * which the line actually starts plus the horizontal sub-window it may use.
- *
- * Two ECMA-376 wrap rules are applied, in order:
- *   1. topAndBottom floats (§20.4.2.16): a line intersecting one is pushed below
- *      it — text never sits beside a topAndBottom object.
- *   2. square floats (§20.4.2.17): text wraps around the float's rect + dist
- *      padding. When several squares cover a row we take the WIDEST free
- *      horizontal gap. If no gap is wide enough for `requiredWidth` the line
- *      cannot sit here at all and flows below the obstruction (advance to the
- *      lowest blocking float bottom and re-evaluate). The square/topAndBottom
- *      geometry itself is spec-defined; but routing empty / anchor-only
- *      paragraph-mark lines through this with `requiredWidth` = one em (so they
- *      drop below a full-width float band) is an implementation-defined
- *      HEURISTIC (see resolveEmptyMarkTop): ECMA-376 does not require a
- *      float-free row for a paragraph mark — only `<w:br w:clear>` (§17.18.3)
- *      mandates flowing onto a float-free region.
- */
-function resolveLineFloatWindow(
-  topY: number,
-  requiredWidth: number,
-  probeH: number,
-  paraX: number,
-  maxWidth: number,
-  floats: FloatRect[],
-): { topY: number; xOffset: number; maxWidth: number } {
-  // 1. Keep pushing past any topAndBottom block we sit inside.
-  //
-  // ASSUMPTION (M3): step 1 runs ONCE, before the square sweep, and is not
-  // re-checked after a square push in step 2. This relies on "no topAndBottom
-  // float sits below a square float in the same column band." topAndBottom
-  // objects span the full content width (ECMA-376 §20.4.2.16) and are normally
-  // anchored above/below the square-wrapped region, so the square push in step 2
-  // lands in float-free space below the band. If a document ever places a
-  // topAndBottom strictly below a square the pushed line could clip into it; the
-  // spec-correct fix is to make steps 1+2 a single fixpoint loop. Left as a
-  // documented assumption here to preserve current behavior (no observed sample
-  // exercises the inverted ordering).
-  for (let guard = 0; guard < 16; guard++) {
-    const lineBot = topY + probeH;
-    let skip: number | null = null;
-    for (const f of floats) {
-      if (f.mode !== 'topAndBottom') continue;
-      if (lineBot > f.yTop && topY < f.yBottom) {
-        skip = skip === null ? f.yBottom : Math.max(skip, f.yBottom);
-      }
-    }
-    if (skip === null) break;
-    topY = skip;
-  }
-
-  // 2. Horizontal constraint from square floats.
-  const paraXLeft = paraX;
-  const paraXRight = paraX + maxWidth;
-  // A gap must fit the line's first atomic token to be usable. Floor so a
-  // zero-width probe (no content yet) still rejects sub-pixel slivers.
-  const usableGap = Math.max(requiredWidth, MIN_LINE_GAP);
-  let xOffset = 0;
-  let lineMaxWidth = maxWidth;
-  for (let guard = 0; guard < 64; guard++) {
-    const lineBot = topY + probeH;
-    const blocked: { l: number; r: number }[] = [];
-    const intersecting: FloatRect[] = [];
-    for (const f of floats) {
-      if (f.mode !== 'square') continue;
-      if (lineBot <= f.yTop || topY >= f.yBottom) continue;
-      intersecting.push(f);
-      switch (f.side) {
-        // Text may sit only on the LEFT of the float ⇒ everything from the
-        // float's left edge to the column right is unavailable.
-        case 'left':  blocked.push({ l: f.xLeft, r: paraXRight }); break;
-        // Text may sit only on the RIGHT ⇒ column left .. float right blocked.
-        case 'right': blocked.push({ l: paraXLeft, r: f.xRight }); break;
-        case 'largest':
-        case 'bothSides':
-        default:      blocked.push({ l: f.xLeft, r: f.xRight }); break;
-      }
-    }
-    if (intersecting.length === 0) {
-      xOffset = 0;
-      lineMaxWidth = maxWidth;
-      break;
-    }
-    // Widest free horizontal gap between the blocked spans across the column.
-    const best = widestFreeGap(blocked, paraXLeft, paraXRight);
-    if (best && best.r - best.l >= usableGap) {
-      xOffset = Math.max(0, best.l - paraXLeft);
-      lineMaxWidth = Math.min(maxWidth - xOffset, best.r - best.l);
-      if (lineMaxWidth < 0) lineMaxWidth = 0;
-      break;
-    }
-
-    // No usable gap on this row: the intersecting floats cover the whole column
-    // width here. The line must clear them all — advance to the LOWEST blocking
-    // float bottom (max yBottom) so it sits centred below the band rather than
-    // squeezed into a side sliver beside a still-active float.
-    const nextY = Math.max(...intersecting.map((f) => f.yBottom));
-    if (nextY <= topY) {
-      // Degenerate guard (shouldn't happen): keep full width to avoid a stall.
-      xOffset = 0;
-      lineMaxWidth = maxWidth;
-      break;
-    }
-    topY = nextY;
-  }
-  return { topY, xOffset, maxWidth: lineMaxWidth };
-}
-
 function layoutLines(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   segs: LayoutSeg[],
@@ -3838,112 +3668,6 @@ function renderShapeText(
   ctx.direction = 'ltr'; // reset for subsequent draws
 }
 
-function isWrapFloat(mode?: string): boolean {
-  return mode === 'square' || mode === 'topAndBottom' || mode === 'tight' || mode === 'through';
-}
-
-// ── Float-layout tolerances (px) ──────────────────────────────────────────────
-// Sub-pixel slack used so floating-point coordinate noise (margin/anchor/dist
-// arithmetic at the current scale) doesn't read as a real overlap or a real gap.
-
-/** Overlap epsilon: two exclusion rects must overlap by MORE than this to count
- *  as intersecting, so coincident/touching edges (and FP noise) are not a clash. */
-const FLOAT_OVERLAP_EPS = 0.01;
-
-/** Slack added to the page-right edge when testing whether a displaced float
- *  still fits horizontally — a float ending within this many px of the page edge
- *  is treated as fitting (it would otherwise be pushed down by FP rounding).
- *  Looser than FLOAT_OVERLAP_EPS because it guards a half-pixel rounding of a
- *  full-width displacement, not an edge-touch test. */
-const FLOAT_PAGE_RIGHT_SLACK = 0.5;
-
-/** Minimum width (px) a free side-gap must have to hold a line start. Floors the
- *  required-width probe so a zero-width probe (an empty line with no content yet)
- *  still rejects sub-pixel slivers between full-width floats. */
-const MIN_LINE_GAP = 1;
-
-/** Two exclusion rects intersect (strict overlap, touching edges allowed). */
-function rectsOverlap(
-  aL: number, aR: number, aT: number, aB: number,
-  bL: number, bR: number, bT: number, bB: number,
-): boolean {
-  return aL < bR - FLOAT_OVERLAP_EPS && aR > bL + FLOAT_OVERLAP_EPS &&
-    aT < bB - FLOAT_OVERLAP_EPS && aB > bT + FLOAT_OVERLAP_EPS;
-}
-
-/**
- * Multi-float collision resolution for a NEW wrap float, against floats already
- * registered on the page.
- *
- * What ECMA-376 actually mandates here is narrow. Part 1 §20.4.2.3
- * (wp:anchor/@allowOverlap) says an object that "cannot overlap other DrawingML
- * object … shall be repositioned when displayed to prevent this overlap" — i.e.
- * allowOverlap="false" REQUIRES repositioning. allowOverlap="true" (the default
- * when omitted, §20.4.2.3) only *permits* overlap; the spec is silent on whether
- * a renderer may avoid it. So:
- *   - allowOverlap === false → spec-mandated avoidance of ALL other floats.
- *   - allowOverlap === true  → implementation-defined avoidance of floats
- *     anchored in OTHER paragraphs only.
- *
- * EVERYTHING ELSE in this function is implementation-defined — ECMA-376 Part 1
- * does NOT specify it. This is a HEURISTIC chosen to match Word's observed
- * layout (e.g. sample-9 figure 9), not a spec requirement:
- *   - the move DIRECTION (right first, then down),
- *   - WHICH float moves (the later/document-order float is the "new" one),
- *   - the "same-paragraph floats never displace each other" gate (the paraId
- *     scoping under allowOverlap=true above),
- *   - and the move AMOUNT. Note the dist* padding reused below is, per
- *     §20.4.2.3/§20.4.2.17, the minimum distance between the float and *text*
- *     (wrapSquare geometry) — it is NOT spec-defined as a float-to-float gap.
- *     Using it to seat one float beside another is our own choice.
- *
- * If the §20.4.2.3 "shall be repositioned" requirement is ever satisfiable in
- * more than one way, the particular re-seating below remains a Word-mimicking
- * heuristic; keep it as such until a spec-grounded placement rule is found.
- *
- * We re-seat horizontally to the right of the blocking float(s) first (margins
- * may be used — Word lets a displaced float sit in the page margin), and only
- * fall back to a vertical push when no horizontal room remains.
- *
- * Coordinates are page-absolute px. (x,y) is the image box origin (no dist).
- */
-function resolveFloatOverlap(
-  x: number, y: number, w: number, h: number,
-  dl: number, dr: number, dt: number, db: number,
-  paraId: number, allowOverlap: boolean, state: RenderState,
-): { x: number; y: number } {
-  const pageRight = state.pageWidth * state.scale;
-  for (let guard = 0; guard < 16; guard++) {
-    const exL = x - dl, exR = x + w + dr, exT = y - dt, exB = y + h + db;
-    // Blocking floats whose exclusion rects intersect ours. When the moving
-    // float forbids overlap (§20.4.2.3 allowOverlap="false") EVERY intersecting
-    // float blocks; otherwise only floats from OTHER paragraphs block (Word
-    // de-facto cross-paragraph avoidance).
-    const blockers = state.floats.filter(
-      (f) => (allowOverlap ? f.paraId !== paraId : true) &&
-        rectsOverlap(exL, exR, exT, exB, f.xLeft, f.xRight, f.yTop, f.yBottom),
-    );
-    if (blockers.length === 0) return { x, y };
-
-    // Horizontal: re-seat just right of the right-most blocker. Setting our
-    // left exclusion edge (x - dl) flush against the blocker's right exclusion
-    // edge means x = maxRight + dl (gap = blocker.distRight + our distLeft).
-    const maxRight = Math.max(...blockers.map((f) => f.xRight));
-    const newX = maxRight + dl;
-    if (newX + w + dr <= pageRight + FLOAT_PAGE_RIGHT_SLACK) {
-      x = newX;
-      continue; // re-check against all other-paragraph floats
-    }
-
-    // No horizontal room: push below the lowest blocker (smallest displacement
-    // that clears them). Our top exclusion edge (y - dt) flush with the
-    // blocker's bottom exclusion edge ⇒ y = maxBottom + dt.
-    const maxBottom = Math.max(...blockers.map((f) => f.yBottom));
-    y = maxBottom + dt;
-  }
-  return { x, y };
-}
-
 /**
  * Resolve an anchor image's page-space box origin and dist* padding (px), shared
  * by registerAnchorFloats (wrap floats) and renderAnchorImages (wrapNone images).
@@ -4009,7 +3733,8 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
     // padding as the float-to-float gap. See resolveFloatOverlap header.
     const allowOverlap = img.allowOverlap ?? true;
     const resolved = resolveFloatOverlap(
-      pageX, pageY, w, h, dl, dr, dt, db, paraId, allowOverlap, state,
+      pageX, pageY, w, h, dl, dr, dt, db, paraId, allowOverlap,
+      state.pageWidth * state.scale, state.floats,
     );
     pageX = resolved.x;
     pageY = resolved.y;
@@ -4042,20 +3767,6 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
       rect.drawn = true;
     }
   }
-}
-
-/** If y is inside a topAndBottom float, return the float bottom; otherwise return y. */
-function skipPastTopAndBottom(y: number, floats: FloatRect[]): number {
-  for (let guard = 0; guard < 16; guard++) {
-    let next = y;
-    for (const f of floats) {
-      if (f.mode !== 'topAndBottom') continue;
-      if (y >= f.yTop && y < f.yBottom) next = Math.max(next, f.yBottom);
-    }
-    if (next === y) return y;
-    y = next;
-  }
-  return y;
 }
 
 // ===== Table rendering =====

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3706,12 +3706,20 @@ function rectsOverlap(
  * "cannot overlap other DrawingML object … shall be repositioned when displayed
  * to prevent this overlap" — i.e. allowOverlap="false" MANDATES repositioning,
  * while allowOverlap="true" only *permits* overlap (it does not require it, nor
- * does it forbid the renderer from avoiding it). Word and LibreOffice keep
- * floats anchored in different paragraphs from overlapping regardless — for
- * allowOverlap="false" that is spec-mandated, and for the common allowOverlap=
- * "true" case (e.g. sample-9 figure 9) it is a spec-permitted layout policy we
- * mirror to match the reference rendering. Single-float wrap geometry and the
- * dist* padding reused below are defined by §20.4.2.17 (wrapSquare).
+ * does it forbid the renderer from avoiding it). The default when the attribute
+ * is omitted is true (§20.4.2.3).
+ *
+ * The blocker set depends on the *moving* float's own allowOverlap:
+ *   - allowOverlap === false → spec-mandated avoidance of ALL other floats
+ *     (every intersecting float blocks, regardless of which paragraph it is
+ *     anchored in).
+ *   - allowOverlap === true → only avoid floats anchored in OTHER paragraphs.
+ *     This is the Word/LibreOffice de-facto behavior we mirror (e.g. sample-9
+ *     figure 9): same-paragraph floats may overlap, cross-paragraph floats are
+ *     kept apart. It is a spec-permitted layout policy, not a requirement.
+ *
+ * Single-float wrap geometry and the dist* padding reused below are defined by
+ * §20.4.2.17 (wrapSquare).
  *
  * We re-seat horizontally to the right of the blocking float(s) first (margins
  * may be used — Word lets a displaced float sit in the page margin), and only
@@ -3722,14 +3730,17 @@ function rectsOverlap(
 function resolveFloatOverlap(
   x: number, y: number, w: number, h: number,
   dl: number, dr: number, dt: number, db: number,
-  paraId: number, state: RenderState,
+  paraId: number, allowOverlap: boolean, state: RenderState,
 ): { x: number; y: number } {
   const pageRight = state.pageWidth * state.scale;
   for (let guard = 0; guard < 16; guard++) {
     const exL = x - dl, exR = x + w + dr, exT = y - dt, exB = y + h + db;
-    // Blocking floats: different paragraph, exclusion rects intersect.
+    // Blocking floats whose exclusion rects intersect ours. When the moving
+    // float forbids overlap (§20.4.2.3 allowOverlap="false") EVERY intersecting
+    // float blocks; otherwise only floats from OTHER paragraphs block (Word
+    // de-facto cross-paragraph avoidance).
     const blockers = state.floats.filter(
-      (f) => f.paraId !== paraId &&
+      (f) => (allowOverlap ? f.paraId !== paraId : true) &&
         rectsOverlap(exL, exR, exT, exB, f.xLeft, f.xRight, f.yTop, f.yBottom),
     );
     if (blockers.length === 0) return { x, y };
@@ -3783,15 +3794,15 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
     const dr = (img.distRight  ?? 0) * scale;
 
     // Overlap avoidance (ECMA-376 §20.4.2.3 allowOverlap: "false" mandates
-    // repositioning to prevent overlap; "true" only permits it). Word/LibreOffice
-    // keep floats anchored in different paragraphs from overlapping — the later
-    // (document-order) float is displaced. We resolve against already-registered
-    // floats from OTHER paragraphs — first horizontally (re-seat to the right of
-    // the blockers, honoring dist padding), then, if that runs off the page,
-    // vertically. (allowOverlap is not yet surfaced by the parser, so this fires
-    // for every different-paragraph overlap; all current samples are "true".)
+    // repositioning to prevent overlap; "true"/omitted only permits it). The
+    // later (document-order) float is displaced. When allowOverlap is false we
+    // avoid ALL registered floats (spec-mandated); when true we avoid only
+    // floats anchored in OTHER paragraphs (Word de-facto behavior). Resolution
+    // re-seats horizontally first (to the right of the blockers, honoring dist
+    // padding), then vertically if that runs off the page. Default true per spec.
+    const allowOverlap = img.allowOverlap ?? true;
     const resolved = resolveFloatOverlap(
-      pageX, pageY, w, h, dl, dr, dt, db, paraId, state,
+      pageX, pageY, w, h, dl, dr, dt, db, paraId, allowOverlap, state,
     );
     pageX = resolved.x;
     pageY = resolved.y;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -136,9 +136,11 @@ interface FloatRect {
   distRight: number;
   distTop: number;
   distBottom: number;
-  /** Identifier of the anchoring paragraph. Floats with the SAME paraId belong
-   *  to one paragraph and never displace each other; different-paragraph floats
-   *  are subject to de-facto overlap avoidance (Word/LibreOffice). */
+  /** Identifier of the anchoring paragraph. Used only by the implementation-
+   *  defined (HEURISTIC) overlap avoidance under allowOverlap=true: floats with
+   *  the SAME paraId never displace each other, different-paragraph floats do.
+   *  ECMA-376 does not define this scoping; it mirrors Word/LibreOffice. See
+   *  resolveFloatOverlap. */
   paraId: number;
   /** true once the image itself has been drawn (drawn after its paragraph lays out). */
   drawn: boolean;
@@ -173,9 +175,9 @@ interface RenderState {
   /** Active anchor-image floats that constrain text layout on the current page. */
   floats: FloatRect[];
   /** Monotonic counter assigning a unique id to each registerAnchorFloats call,
-   *  i.e. one id per paragraph. Used to scope float overlap avoidance to
-   *  DIFFERENT paragraphs (floats from the same paragraph never displace each
-   *  other). */
+   *  i.e. one id per paragraph per page. Used only to scope the implementation-
+   *  defined (HEURISTIC) overlap avoidance to DIFFERENT paragraphs. Reset to 0
+   *  on every page flip so measure and render assign matching paraIds. */
   floatParaSeq: number;
   /** ECMA-376 §17.6.5 docGrid (type + pitch), applied to auto line spacing. */
   docGrid: DocGridCtx;
@@ -1739,18 +1741,24 @@ function renderParagraph(
   const grid = paraGrid(para, state);
 
   // A paragraph with no inline content (literally empty, or anchor-only) still
-  // produces ONE paragraph-mark line box (ECMA-376 §17.3.1.29). That line box
-  // is subject to the same float-wrap rules as text: if it cannot fit beside the
-  // page's active floats it flows below them (§20.4.2.16/.17). Without this an
-  // empty paragraph mark wedges into a sub-em sliver beside a full-width float
-  // band and the following paragraphs (and any wrapNone image those paragraphs
-  // anchor) stay pinned inside the band. We resolve the mark line's flowed top
-  // here and use it for the mark advance, the shading/border rect, and the
+  // produces ONE paragraph-mark line box (ECMA-376 §17.3.1.29 regulates only the
+  // existence of that line; the horizontal wrap geometry around a square float is
+  // §20.4.2.17). The behavior below — firing an automatic "flow the mark line
+  // below the float band when it cannot sit beside it" displacement, and using
+  // ONE EM of the mark font as the width the gap must hold — is NOT specified by
+  // ECMA-376 Part 1. It is an implementation-defined HEURISTIC chosen to match
+  // Word: the only spec-mandated flow of a line onto a float-free region is the
+  // explicit `<w:br w:clear>` of §17.18.3, which is not what fires here. Without
+  // this heuristic an empty paragraph mark wedges into a sub-em sliver beside a
+  // full-width float band and the following paragraphs (and any wrapNone image
+  // they anchor) stay pinned inside the band. We resolve the mark line's flowed
+  // top here and use it for the mark advance, the shading/border rect, and the
   // paragraph-relative base of any wrapNone anchor image drawn below.
   const resolveEmptyMarkTop = (): number => {
     if (state.floats.length === 0) return textAreaTopY;
-    // Required width for an empty mark line: one em of the mark font. A side gap
-    // narrower than this cannot hold the line start, so the line flows below.
+    // Required width for an empty mark line: one em of the mark font (HEURISTIC,
+    // see above — not a spec-defined threshold). A side gap narrower than this is
+    // treated as unable to hold the line start, so the line flows below.
     const markEm = getDefaultFontSize(para) * scale;
     const probeH = 10 * scale;
     const win = resolveLineFloatWindow(
@@ -2814,11 +2822,13 @@ function splitTextForLayout(text: string): string[] {
  *      padding. When several squares cover a row we take the WIDEST free
  *      horizontal gap. If no gap is wide enough for `requiredWidth` the line
  *      cannot sit here at all and flows below the obstruction (advance to the
- *      lowest blocking float bottom and re-evaluate). This is the same "flow
- *      below the obstruction" behaviour used for wrapped text; routing empty /
- *      anchor-only paragraph-mark lines through it makes those lines (and the
- *      paragraphs that follow them) drop below a full-width float band instead
- *      of rendering inside it.
+ *      lowest blocking float bottom and re-evaluate). The square/topAndBottom
+ *      geometry itself is spec-defined; but routing empty / anchor-only
+ *      paragraph-mark lines through this with `requiredWidth` = one em (so they
+ *      drop below a full-width float band) is an implementation-defined
+ *      HEURISTIC (see resolveEmptyMarkTop): ECMA-376 does not require a
+ *      float-free row for a paragraph mark — only `<w:br w:clear>` (§17.18.3)
+ *      mandates flowing onto a float-free region.
  */
 function resolveLineFloatWindow(
   topY: number,
@@ -3758,27 +3768,34 @@ function rectsOverlap(
 }
 
 /**
- * De-facto multi-float collision resolution for a NEW wrap float, against
- * floats already registered on the page that belong to OTHER paragraphs.
+ * Multi-float collision resolution for a NEW wrap float, against floats already
+ * registered on the page.
  *
- * Per ECMA-376 Part 1 §20.4.2.3 (wp:anchor/@allowOverlap): an object that
- * "cannot overlap other DrawingML object … shall be repositioned when displayed
- * to prevent this overlap" — i.e. allowOverlap="false" MANDATES repositioning,
- * while allowOverlap="true" only *permits* overlap (it does not require it, nor
- * does it forbid the renderer from avoiding it). The default when the attribute
- * is omitted is true (§20.4.2.3).
+ * What ECMA-376 actually mandates here is narrow. Part 1 §20.4.2.3
+ * (wp:anchor/@allowOverlap) says an object that "cannot overlap other DrawingML
+ * object … shall be repositioned when displayed to prevent this overlap" — i.e.
+ * allowOverlap="false" REQUIRES repositioning. allowOverlap="true" (the default
+ * when omitted, §20.4.2.3) only *permits* overlap; the spec is silent on whether
+ * a renderer may avoid it. So:
+ *   - allowOverlap === false → spec-mandated avoidance of ALL other floats.
+ *   - allowOverlap === true  → implementation-defined avoidance of floats
+ *     anchored in OTHER paragraphs only.
  *
- * The blocker set depends on the *moving* float's own allowOverlap:
- *   - allowOverlap === false → spec-mandated avoidance of ALL other floats
- *     (every intersecting float blocks, regardless of which paragraph it is
- *     anchored in).
- *   - allowOverlap === true → only avoid floats anchored in OTHER paragraphs.
- *     This is the Word/LibreOffice de-facto behavior we mirror (e.g. sample-9
- *     figure 9): same-paragraph floats may overlap, cross-paragraph floats are
- *     kept apart. It is a spec-permitted layout policy, not a requirement.
+ * EVERYTHING ELSE in this function is implementation-defined — ECMA-376 Part 1
+ * does NOT specify it. This is a HEURISTIC chosen to match Word's observed
+ * layout (e.g. sample-9 figure 9), not a spec requirement:
+ *   - the move DIRECTION (right first, then down),
+ *   - WHICH float moves (the later/document-order float is the "new" one),
+ *   - the "same-paragraph floats never displace each other" gate (the paraId
+ *     scoping under allowOverlap=true above),
+ *   - and the move AMOUNT. Note the dist* padding reused below is, per
+ *     §20.4.2.3/§20.4.2.17, the minimum distance between the float and *text*
+ *     (wrapSquare geometry) — it is NOT spec-defined as a float-to-float gap.
+ *     Using it to seat one float beside another is our own choice.
  *
- * Single-float wrap geometry and the dist* padding reused below are defined by
- * §20.4.2.17 (wrapSquare).
+ * If the §20.4.2.3 "shall be repositioned" requirement is ever satisfiable in
+ * more than one way, the particular re-seating below remains a Word-mimicking
+ * heuristic; keep it as such until a spec-grounded placement rule is found.
  *
  * We re-seat horizontally to the right of the blocking float(s) first (margins
  * may be used — Word lets a displaced float sit in the page margin), and only
@@ -3852,13 +3869,13 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
     const dl = (img.distLeft   ?? 0) * scale;
     const dr = (img.distRight  ?? 0) * scale;
 
-    // Overlap avoidance (ECMA-376 §20.4.2.3 allowOverlap: "false" mandates
-    // repositioning to prevent overlap; "true"/omitted only permits it). The
-    // later (document-order) float is displaced. When allowOverlap is false we
-    // avoid ALL registered floats (spec-mandated); when true we avoid only
-    // floats anchored in OTHER paragraphs (Word de-facto behavior). Resolution
-    // re-seats horizontally first (to the right of the blockers, honoring dist
-    // padding), then vertically if that runs off the page. Default true per spec.
+    // Overlap avoidance. Spec-mandated part: allowOverlap="false" (ECMA-376
+    // §20.4.2.3) REQUIRES repositioning to prevent overlap; "true"/omitted only
+    // permits overlap. Default true per §20.4.2.3.
+    // Implementation-defined (HEURISTIC, Word-mimicking, no ECMA-376 basis):
+    // displacing the later document-order float, the "other paragraphs only"
+    // gate under allowOverlap=true, and the right-then-down re-seat using dist
+    // padding as the float-to-float gap. See resolveFloatOverlap header.
     const allowOverlap = img.allowOverlap ?? true;
     const resolved = resolveFloatOverlap(
       pageX, pageY, w, h, dl, dr, dt, db, paraId, allowOverlap, state,

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -498,6 +498,13 @@ export interface ImageRun {
   distRight?: number;
   /** wrapText attribute: "bothSides" | "left" | "right" | "largest". */
   wrapSide?: string;
+  /**
+   * ECMA-376 §20.4.2.3 `wp:anchor/@allowOverlap` — whether this floating object
+   * may overlap other floats. Spec default is true (the attribute is optional);
+   * absent/undefined is treated as true. `false` mandates the renderer
+   * reposition the object to prevent any overlap.
+   */
+  allowOverlap?: boolean;
 }
 
 // ===== Table =====


### PR DESCRIPTION
Implements docx floating-object layout so multi-photo + caption figures in sample-9 match the Word-exported PDF (figures 2/3/4/7/8/9), and audits exactly which behavior is ECMA-376-mandated vs. implementation-defined.

## Behavior

- **(A) Flow lines below full-width floats** (§20.4.2.16/.17): when two side-by-side wrapSquare images span the column, the following caption/heading/empty lines flow below the band instead of rendering inside it. Generalized the wrap window from a single left/right gap to the widest free sub-interval, dropping below when none fits.
- **(B) Float overlap avoidance**: floats that would overlap are re-seated (right, then down). Honors `allowOverlap` per **§20.4.2.3** — `false` mandates repositioning; `true` is avoided only across paragraphs (Word parity).
- **allowOverlap extraction**: parser now surfaces `wp:anchor/@allowOverlap` (default `true` per §20.4.2.3) through to the renderer, with a hand-written `Default` and a dedicated Rust test module.
- **Empty / anchor-only paragraph mark lines** (§17.3.1.29) participate in the same float-wrap, so a `wrapNone` image anchored in a later paragraph (sample-9 figure 2's third photo) drops below the band with its paragraph, and the author's spacer paragraphs push the caption below it.

## Spec audit (ECMA-376 Part 1, local `spec/`)

Searched the spec exhaustively for an overlap-resolution algorithm. ECMA-376 specifies only the *no-overlap constraint* (`allowOverlap="false"` → "shall be repositioned"; same for `suppressOverlap`, `tblOverlap`) and the *lateral wrap shapes* — it never specifies the **direction, amount, which object moves, or document-order dependence** of the resolution, nor an automatic "flow below the float" trigger (only `<w:br clear>`, §17.18.3), nor a minimum line width. Real Word overlap behavior is driven by Part 4 transitional compat flags that Part 1 omits.

Code comments were rewritten to separate the spec-mandated parts from the **implementation-defined heuristics** (move direction/amount/which-moves, the same-paragraph gate, the empty-mark auto-flow and its 1-em width), per the repo's "label short-term heuristics" rule.

## Design

Pure float-wrap geometry (`FloatRect`/`Gap`, tolerances, `rectsOverlap`, `widestFreeGap`, `resolveLineFloatWindow`, `resolveFloatOverlap`, `skipPastTopAndBottom`) extracted into a dependency-free `float-layout.ts`. De-duplicated the empty/anchor-only mark paths (`renderEmptyMarkParagraph`), unified the paragraph-mark em (`paragraphMarkEmPx`) and anchor box resolution (`resolveAnchorBox`), named the tolerance constants, and fixed a measure/render `floatParaSeq` reset inconsistency.

## Verification

docx VRT 21/21 (demo/sample-1 all pages 100%, private samples at baseline), typecheck clean, Rust tests + clippy clean. sample-9 figures verified against the PDF; every refactor commit confirmed 0 diff pixels across all 11 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
