### PR TITLE
chore(release): 0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.60.0 — 2026-06-14
+
+Minor: docx floating-object layout (overlap avoidance, below-float line flow)
+plus grouped-drawing and shape-fill fixes.
+
+### docx
+
+- Floating-object layout: reposition overlapping floats per `allowOverlap`
+  (ECMA-376 §20.4.2.3 mandates it for `allowOverlap="false"`; cross-paragraph
+  avoidance for the `"true"` default is Word-parity), flow captions/lines and
+  empty / anchor-only paragraph-mark rows (§17.3.1.29) below full-width floats
+  (§20.4.2.16/.17), and move a paragraph-anchored float that overflows the page
+  bottom to the next page — so side-by-side photos and their captions render
+  like Word.
+- Shape fidelity: honor an explicit `<a:noFill/>` over the shape style's
+  `fillRef` (§20.1.8.44), keep degenerate line connectors (`prstGeom="line"`
+  with a zero extent, §20.1.9.18), and compose nested `<wpg:grpSp>` group
+  transforms recursively for both shapes and grouped images (§20.1.7.5/.6).
+- Emit the paragraph-mark line for anchor-only paragraphs so consecutive
+  image-only paragraphs no longer collapse onto each other (fixes shifted
+  figure captions).
+
+### xlsx
+
+- Keep merged-cell text rendered when the cell's top-left anchor scrolls out of
+  view, by wrapping it in the off-screen-anchor pre-pass.
+
+### docs
+
+- Drop the retired shields.io VS Code Marketplace badges from the README.
+
 ## 0.59.3 — 2026-06-14
 
 Patch: shrink the published bundle ~36% by inlining each parser's WASM only once.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.59.3",
+  "version": "0.60.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.59.3",
+  "version": "0.60.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.59.3",
+  "version": "0.60.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.59.3",
+  "version": "0.60.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.59.3",
+  "version": "0.60.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.59.3",
+  "version": "0.60.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.59.3",
+  "version": "0.60.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.59.3",
+  "version": "0.60.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.60.0 (minor).

Bumps all 8 package versions to 0.60.0 and adds the CHANGELOG entry. No README screenshot / Feature Support / API-reference changes were needed: the changes are docx/xlsx rendering-accuracy and layout fixes to already-supported features (no new public API, no new format support), and the README screenshots depict content (single-image demo doc, pptx, xlsx) unaffected by the float-layout work (demo VRT stays 100%).

## Highlights (see CHANGELOG.md for detail)

- **docx floating-object layout**: overlap avoidance per `allowOverlap` (§20.4.2.3), captions/lines and empty/anchor-only mark rows flow below full-width floats (§20.4.2.16/.17, §17.3.1.29), page-break for a float overflowing the page bottom.
- **docx shape fidelity**: explicit `<a:noFill/>` over style `fillRef` (§20.1.8.44), degenerate line connectors kept (§20.1.9.18), nested `<wpg:grpSp>` transforms composed for shapes and grouped images (§20.1.7.5/.6).
- **docx**: paragraph-mark line for anchor-only paragraphs (fixes shifted captions).
- **xlsx**: merged-cell text stays rendered when its top-left anchor scrolls off-screen.
- **docs**: removed retired VS Code Marketplace badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)