### PR TITLE
fix(docx): cancel stale page renders to prevent canvas ghosting

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -343,6 +343,19 @@ export async function renderDocumentToCanvas(
   pageIndex: number,
   opts: RenderDocumentOptions = {},
 ): Promise<void> {
+  // Cancellation guard. renderDocumentToCanvas is async (it awaits image decode
+  // via preloadImages), so rapid page navigation can start a newer render of the
+  // SAME canvas before this one finishes. Both clear the canvas (`canvas.width =
+  // …` + a white fillRect) up front and then draw their page AFTER the await —
+  // so the clears run first and the draws accumulate, ghosting several pages on
+  // top of each other. Stamp a per-canvas token; once a newer render supersedes
+  // us, stop at the next await so only the latest render's output survives.
+  // (Mirrors the pptx renderSlide guard; the worker path renders each page on a
+  // fresh OffscreenCanvas, so the token is a no-op there.)
+  const tokenHost = canvas as unknown as { __docxRenderToken?: number };
+  const myToken = (tokenHost.__docxRenderToken = (tokenHost.__docxRenderToken ?? 0) + 1);
+  const superseded = () => tokenHost.__docxRenderToken !== myToken;
+
   const sec = doc.section;
   const dpr = opts.dpr ?? defaultDpr();
   const cssWidth = opts.width ?? sec.pageWidth * PT_TO_PX;
@@ -370,6 +383,9 @@ export async function renderDocumentToCanvas(
   const elements = pages[pageIndex] ?? pages[0] ?? [];
 
   const images = await preloadImages(doc);
+  // A newer render of this canvas started while we awaited image decode — stop
+  // so we don't paint this (now stale) page over the newer one.
+  if (superseded()) return;
 
   // ECMA-376 §17.11: map each note id to its 1-based display number so the
   // reference markers (and the in-note footnoteRef placeholder) show the


### PR DESCRIPTION
## Problem

On the showcase site's docx **"Single viewer with navigation"** demo, rapid page-flipping (fast next/prev) ghosts several pages on top of each other.

`renderDocumentToCanvas` is async — it awaits image decode via `preloadImages` — so navigating faster than a render completes starts a second render of the **same** canvas before the first finishes. Both clear the canvas (`canvas.width = …` + a white `fillRect`) up front and then draw their page **after** the await, so the clears run first and the draws accumulate:

```
clear(A) → clear(B) → draw(A: page N) → draw(B: page M)   // N and M overlap
```

`DocxViewer.goToPage` has no serialization, so the public `DocxDocument.renderPage` API is affected too — not just the site/Storybook harness. This is the same mechanism the pptx renderer was fixed for in #361; docx never got the equivalent guard.

## Fix

Stamp a per-canvas render token at the top of `renderDocumentToCanvas`; a newer render bumps it, and an older render bails at the next await (after `preloadImages`) instead of drawing its now-stale page over the newer one. The latest render always wins. Mirrors the pptx `renderSlide` guard.

- Worker path renders each page on a fresh `OffscreenCanvas`, so the token is a no-op there (and the visible canvas is updated atomically via `transferFromImageBitmap`).
- xlsx is already safe: `renderViewport` clears and draws synchronously, with no await between.

## Verification

- **Before**: 3 synchronous `Next` clicks on the docx Demo story → status "Page 4/6" but the canvas shows page 1 title/body/image/table ghosted together.
- **After**: same input → page 4 only, clean (pixel-identical to slow sequential navigation).
- pptx Demo (Next ×4 synchronous) → single clean slide (existing #361 guard holds).
- xlsx Demo (4 sheet tabs switched in one tick) → last sheet only, no overlap.
- `tsc` clean; docx unit tests 74/74 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)