### PR TITLE
feat(docx): faithful shape preset rendering — arrow heads, dashes, and shared preset engine

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export { autoResize, type AutoResizeOptions } from './autoResize';
 export { buildCustomPath } from './shape/custGeom';
 export { hexToRgba, resolveFill, applyStroke } from './shape/paint';
 export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/preset';
+export { drawArrowHead } from './shape/arrow';
 // ECMA-376 §20.1.9 spec-driven preset geometry engine (presets.json from
 // presetShapeDefinitions.xml). Coexists with the legacy hand-rolled
 // `buildShapePath` above, which the pptx renderer still uses as a silhouette /

--- a/packages/core/src/shape/arrow.ts
+++ b/packages/core/src/shape/arrow.ts
@@ -1,0 +1,73 @@
+import type { ArrowEnd, Stroke } from '../types/common';
+import { hexToRgba } from './paint';
+
+/**
+ * Draw a DrawingML line-end decoration (arrow head) at `(tipX, tipY)`,
+ * oriented along `angle` radians (0 = pointing right, +x axis).
+ *
+ * ECMA-376 §20.1.8.3 (CT_LineEndProperties) / §20.1.10.33 (ST_LineEndType:
+ * none / triangle / stealth / diamond / oval / arrow) / §20.1.10.31–.32
+ * (ST_LineEndWidth / ST_LineEndLength: sm / med / lg). The spec only names
+ * the w/len steps as *relative* sizes, not exact ratios — the multiples of
+ * line width below are calibrated against PowerPoint's rendering and shared
+ * between the pptx and docx renderers so connector arrows look identical.
+ *
+ * `scale` is the EMU → device-px factor (same convention as core's
+ * `applyStroke`, where stroke width in px is `stroke.width * scale`).
+ */
+export function drawArrowHead(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  angle: number,
+  arrowEnd: ArrowEnd,
+  stroke: Stroke,
+  scale: number,
+): void {
+  if (arrowEnd.type === 'none') return;
+  const lw = Math.max(0.5, stroke.width * scale);
+  const wMul = arrowEnd.w === 'sm' ? 4 : arrowEnd.w === 'lg' ? 8 : 6;
+  const lMul = arrowEnd.len === 'sm' ? 4 : arrowEnd.len === 'lg' ? 8 : 6;
+  const halfW = (lw * wMul) / 2;
+  const len = lw * lMul;
+  const color = hexToRgba(stroke.color);
+
+  ctx.save();
+  ctx.translate(tipX, tipY);
+  ctx.rotate(angle);
+  ctx.fillStyle = color;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = lw;
+  ctx.setLineDash([]);
+  ctx.beginPath();
+  switch (arrowEnd.type) {
+    case 'triangle':
+    case 'stealth':
+      ctx.moveTo(0, 0);
+      ctx.lineTo(-len, -halfW);
+      ctx.lineTo(-len, halfW);
+      ctx.closePath();
+      ctx.fill();
+      break;
+    case 'arrow':
+      ctx.moveTo(0, 0);
+      ctx.lineTo(-len, -halfW);
+      ctx.moveTo(0, 0);
+      ctx.lineTo(-len, halfW);
+      ctx.stroke();
+      break;
+    case 'diamond':
+      ctx.moveTo(0, 0);
+      ctx.lineTo(-len / 2, -halfW);
+      ctx.lineTo(-len, 0);
+      ctx.lineTo(-len / 2, halfW);
+      ctx.closePath();
+      ctx.fill();
+      break;
+    case 'oval':
+      ctx.ellipse(-len / 2, 0, len / 2, halfW, 0, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+  }
+  ctx.restore();
+}

--- a/packages/core/src/shape/preset.ts
+++ b/packages/core/src/shape/preset.ts
@@ -110,7 +110,13 @@ export function buildShapePath(
   const cx = x + w / 2;
   const cy = y + h / 2;
 
-  switch (geom) {
+  // OOXML preset names are camelCase (e.g. `straightConnector1`, `roundRect`,
+  // `rtTriangle`), but every `case` below is lowercase. Normalize here so the
+  // catalog is matched case-insensitively — otherwise camelCase presets fall
+  // through to the `default` plain-rect branch. (The pptx renderer already
+  // lower-cases at its call site; this makes the function correct for every
+  // caller, e.g. the docx renderer which passes the raw `prst` value.)
+  switch (geom.toLowerCase()) {
     // ── Ellipses ──────────────────────────────────────────────────────────────
     case 'ellipse':
     case 'oval':

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1873,7 +1873,7 @@ fn parse_run_inner(
                 // shape's fill/stroke/size and its txbxContent as a ShapeRun so
                 // the existing shape renderer draws the panel + RTL body text.
                 if let Some(shp) = parse_vml_pict(child, theme) {
-                    runs.push(DocRun::Shape(shp));
+                    runs.push(DocRun::Shape(Box::new(shp)));
                 }
             }
             _ => {}
@@ -2006,7 +2006,7 @@ fn parse_inline_drawing(
         ) {
             shp.behind_doc = behind_doc;
             apply_pos_meta(&mut shp);
-            out.push(DocRun::Shape(shp));
+            out.push(DocRun::Shape(Box::new(shp)));
         }
         return out;
     }
@@ -2032,7 +2032,7 @@ fn parse_inline_drawing(
         ) {
             shp.behind_doc = behind_doc;
             apply_pos_meta(&mut shp);
-            return vec![DocRun::Shape(shp)];
+            return vec![DocRun::Shape(Box::new(shp))];
         }
     }
 
@@ -2847,9 +2847,10 @@ fn parse_wsp_shape(
             })
             .and_then(|fr| resolve_fill_ref(fr, theme)),
     };
-    let (stroke, stroke_width) = sp_pr
+    let ln_node = sp_pr
         .children()
-        .find(|n| n.is_element() && n.tag_name().name() == "ln")
+        .find(|n| n.is_element() && n.tag_name().name() == "ln");
+    let (stroke, stroke_width) = ln_node
         .map(|ln| {
             let has_no_fill = ln
                 .children()
@@ -2868,6 +2869,32 @@ fn parse_wsp_shape(
             (color, w_emu / 12700.0)
         })
         .unwrap_or((None, 0.0));
+    // ECMA-376 §20.1.8.48 prstDash and §20.1.8.3 head/tail line-end decorations.
+    let stroke_dash = ln_node.and_then(|ln| {
+        ln.children()
+            .find(|n| n.is_element() && n.tag_name().name() == "prstDash")
+            .and_then(|d| d.attribute("val"))
+            .map(|v| v.to_string())
+    });
+    let parse_line_end = |name: &str| -> Option<LineEnd> {
+        let ln = ln_node?;
+        let end = ln
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == name)?;
+        // CT_LineEndProperties: type defaults to "none"; w/len default to "med"
+        // (ECMA-376 §20.1.8.3 — absent w/len means the medium step).
+        let ty = end.attribute("type").unwrap_or("none");
+        if ty == "none" {
+            return None;
+        }
+        Some(LineEnd {
+            r#type: ty.to_string(),
+            w: end.attribute("w").unwrap_or("med").to_string(),
+            len: end.attribute("len").unwrap_or("med").to_string(),
+        })
+    };
+    let head_end = parse_line_end("headEnd");
+    let tail_end = parse_line_end("tailEnd");
 
     // Shape body text: <wps:txbx><w:txbxContent>...</w:txbxContent></wps:txbx>
     // and the bodyPr (insets / vertical anchor).
@@ -2889,6 +2916,9 @@ fn parse_wsp_shape(
         fill,
         stroke,
         stroke_width,
+        stroke_dash,
+        head_end,
+        tail_end,
         rotation,
         wrap_mode: anchor_meta.wrap_mode.clone(),
         text_blocks,

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -344,7 +344,10 @@ pub enum DocRun {
         break_type: BreakType,
     },
     Field(FieldRun),
-    Shape(ShapeRun),
+    // Boxed: ShapeRun is by far the largest Run variant; boxing keeps the
+    // enum compact (clippy::large_enum_variant). Serde flattens the Box, so
+    // the JSON tag/shape is unchanged.
+    Shape(Box<ShapeRun>),
     /// An OMML equation (`m:oMath`). `display` = block (`m:oMathPara`).
     #[serde(rename_all = "camelCase")]
     Math {
@@ -359,6 +362,20 @@ pub enum DocRun {
         #[serde(skip_serializing_if = "Option::is_none")]
         jc: Option<String>,
     },
+}
+
+/// A DrawingML line-end decoration (arrow head). ECMA-376 §20.1.8.3
+/// (CT_LineEndProperties): `type` ∈ none/triangle/stealth/diamond/oval/arrow,
+/// `w`/`len` ∈ sm/med/lg. Maps 1:1 to core's `ArrowEnd`.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LineEnd {
+    /// ST_LineEndType (§20.1.10.33).
+    pub r#type: String,
+    /// ST_LineEndWidth (§20.1.10.32). Absent in source ⇒ "med".
+    pub w: String,
+    /// ST_LineEndLength (§20.1.10.31). Absent in source ⇒ "med".
+    pub len: String,
 }
 
 /// A drawn shape (wps:wsp inside wp:anchor). Positioned like an anchor image
@@ -455,6 +472,15 @@ pub struct ShapeRun {
     /// stroke width in pt.
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub stroke_width: f64,
+    /// `<a:ln><a:prstDash val>` (ECMA-376 §20.1.8.48). None ⇒ solid.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stroke_dash: Option<String>,
+    /// `<a:ln><a:headEnd>` decoration (line start). None ⇒ no head.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_end: Option<LineEnd>,
+    /// `<a:ln><a:tailEnd>` decoration (line end). None ⇒ no tail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tail_end: Option<LineEnd>,
     /// rotation in degrees (clockwise).
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub rotation: f64,

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -41,5 +41,6 @@ export type {
   // Shape geometry / fill sub-types.
   PathCmd,
   GradientStop,
+  LineEnd,
 } from './types';
 export type { DocxTextRunInfo } from './renderer';

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3,11 +3,15 @@ import type {
   DocRun, DocxTextRun, ImageRun, ShapeRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, SectionProps, DocNote,
 } from './types';
+import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
   buildCustomPath,
   buildShapePath,
   hexToRgba,
   resolveFill,
+  applyStroke,
+  drawArrowHead,
+  getConnectorAnchors,
   mathToMathML,
   recolorSvg,
   PT_TO_PX,
@@ -3510,6 +3514,15 @@ function resolveAnchorY(
   }
 }
 
+/** Convert a parsed docx LineEnd into core's ArrowEnd. Returns undefined when
+ *  absent so the Stroke field stays unset. */
+function lineEndToArrowEnd(
+  end: ShapeRun['headEnd'],
+): ArrowEnd | undefined {
+  if (!end) return undefined;
+  return { type: end.type, w: end.w, len: end.len };
+}
+
 function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: number): void {
   const { ctx, scale } = state;
   // ECMA-376 §20.4.2.18: when wp14:sizeRelH/sizeRelV is present it overrides
@@ -3603,9 +3616,36 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     ctx.fill();
   }
   if (shape.stroke && (shape.strokeWidth ?? 0) > 0) {
-    ctx.strokeStyle = hexToRgba(shape.stroke);
-    ctx.lineWidth = Math.max(0.5, (shape.strokeWidth ?? 0) * scale);
+    // Build a core Stroke so dash / line-end handling matches the pptx path.
+    // `width` is in pt and `scale` is px/pt, so `width * scale` is px — the
+    // same convention core's applyStroke / drawArrowHead expect.
+    const coreStroke: Stroke = {
+      color: shape.stroke,
+      width: shape.strokeWidth ?? 0,
+      dashStyle: shape.strokeDash ?? undefined,
+      headEnd: lineEndToArrowEnd(shape.headEnd),
+      tailEnd: lineEndToArrowEnd(shape.tailEnd),
+    };
+    applyStroke(ctx as CanvasRenderingContext2D, coreStroke, scale);
     ctx.stroke();
+    // Line-end decorations (ECMA-376 §20.1.8.3). Only connector/line presets
+    // expose head/tail tips with a well-defined tangent; for those we place the
+    // arrow heads at the path endpoints with the path's outgoing direction.
+    if ((coreStroke.headEnd || coreStroke.tailEnd) && shape.presetGeometry) {
+      const anchors = getConnectorAnchors(
+        shape.presetGeometry, x, y, w, h,
+        shape.adjValues ?? [],
+      );
+      if (anchors) {
+        ctx.setLineDash([]);
+        if (coreStroke.tailEnd) {
+          drawArrowHead(ctx as CanvasRenderingContext2D, anchors.end.x, anchors.end.y, anchors.end.angle, coreStroke.tailEnd, coreStroke, scale);
+        }
+        if (coreStroke.headEnd) {
+          drawArrowHead(ctx as CanvasRenderingContext2D, anchors.start.x, anchors.start.y, anchors.start.angle, coreStroke.headEnd, coreStroke, scale);
+        }
+      }
+    }
   }
   ctx.restore();
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7,6 +7,8 @@ import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
   buildCustomPath,
   buildShapePath,
+  renderPresetShape,
+  hasPreset,
   hexToRgba,
   resolveFill,
   applyStroke,
@@ -3592,58 +3594,88 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     ctx.rotate((rot * Math.PI) / 180);
     ctx.translate(-(x + w / 2), -(y + h / 2));
   }
-  ctx.beginPath();
-  if (shape.presetGeometry) {
-    // OOXML <a:prstGeom> — delegate to core's buildShapePath which has the
-    // full preset shape catalog (rect / ellipse / triangles / arrows /
-    // callouts / ribbons / flowchart / …) shared with the pptx renderer.
-    const adj = shape.adjValues ?? [];
-    buildShapePath(
+  // Dispatch to the shared spec-driven preset engine when the geometry is a
+  // known <a:prstGeom> preset, mirroring the pptx renderer. `arc` keeps its
+  // bespoke buildShapePath fallback (fill semantics differ); custGeom (no
+  // presetGeometry, subpaths only) likewise falls through to buildCustomPath.
+  const geom = shape.presetGeometry?.toLowerCase() ?? '';
+  const usePresetEngine =
+    !!shape.presetGeometry && geom !== 'arc' && hasPreset(geom);
+
+  const adj = shape.adjValues ?? [];
+  const fillStyle = resolveFill(shape.fill, ctx as CanvasRenderingContext2D, x, y, w, h);
+
+  // Build a core Stroke so dash / line-end handling matches the pptx path.
+  // `width` is in pt and `scale` is px/pt, so `width * scale` is px — the
+  // same convention core's applyStroke / drawArrowHead expect.
+  const coreStroke: Stroke | null =
+    shape.stroke && (shape.strokeWidth ?? 0) > 0
+      ? {
+          color: shape.stroke,
+          width: shape.strokeWidth ?? 0,
+          dashStyle: shape.strokeDash ?? undefined,
+          headEnd: lineEndToArrowEnd(shape.headEnd),
+          tailEnd: lineEndToArrowEnd(shape.tailEnd),
+        }
+      : null;
+  const strokeCb = coreStroke
+    ? () => {
+        applyStroke(ctx as CanvasRenderingContext2D, coreStroke, scale);
+        ctx.stroke();
+      }
+    : null;
+
+  if (usePresetEngine) {
+    renderPresetShape(
       ctx as CanvasRenderingContext2D,
-      shape.presetGeometry,
-      x, y, w, h,
-      adj[0] ?? null,
-      adj[1] ?? null,
-      adj[2] ?? null,
-      adj[3] ?? null,
+      geom, x, y, w, h,
+      [
+        adj[0] ?? null, adj[1] ?? null, adj[2] ?? null, adj[3] ?? null,
+        adj[4] ?? null, adj[5] ?? null, adj[6] ?? null, adj[7] ?? null,
+      ],
+      fillStyle, strokeCb,
+      // docx shapes carry no shadow state, so the clear-shadow hook is a no-op.
+      () => {},
     );
   } else {
-    buildCustomPath(ctx as CanvasRenderingContext2D, shape.subpaths, x, y, w, h);
-  }
-  const fillStyle = resolveFill(shape.fill, ctx as CanvasRenderingContext2D, x, y, w, h);
-  if (fillStyle) {
-    ctx.fillStyle = fillStyle;
-    ctx.fill();
-  }
-  if (shape.stroke && (shape.strokeWidth ?? 0) > 0) {
-    // Build a core Stroke so dash / line-end handling matches the pptx path.
-    // `width` is in pt and `scale` is px/pt, so `width * scale` is px — the
-    // same convention core's applyStroke / drawArrowHead expect.
-    const coreStroke: Stroke = {
-      color: shape.stroke,
-      width: shape.strokeWidth ?? 0,
-      dashStyle: shape.strokeDash ?? undefined,
-      headEnd: lineEndToArrowEnd(shape.headEnd),
-      tailEnd: lineEndToArrowEnd(shape.tailEnd),
-    };
-    applyStroke(ctx as CanvasRenderingContext2D, coreStroke, scale);
-    ctx.stroke();
-    // Line-end decorations (ECMA-376 §20.1.8.3). Only connector/line presets
-    // expose head/tail tips with a well-defined tangent; for those we place the
-    // arrow heads at the path endpoints with the path's outgoing direction.
-    if ((coreStroke.headEnd || coreStroke.tailEnd) && shape.presetGeometry) {
-      const anchors = getConnectorAnchors(
-        shape.presetGeometry, x, y, w, h,
-        shape.adjValues ?? [],
+    ctx.beginPath();
+    if (shape.presetGeometry) {
+      buildShapePath(
+        ctx as CanvasRenderingContext2D,
+        shape.presetGeometry,
+        x, y, w, h,
+        adj[0] ?? null,
+        adj[1] ?? null,
+        adj[2] ?? null,
+        adj[3] ?? null,
       );
-      if (anchors) {
-        ctx.setLineDash([]);
-        if (coreStroke.tailEnd) {
-          drawArrowHead(ctx as CanvasRenderingContext2D, anchors.end.x, anchors.end.y, anchors.end.angle, coreStroke.tailEnd, coreStroke, scale);
-        }
-        if (coreStroke.headEnd) {
-          drawArrowHead(ctx as CanvasRenderingContext2D, anchors.start.x, anchors.start.y, anchors.start.angle, coreStroke.headEnd, coreStroke, scale);
-        }
+    } else {
+      buildCustomPath(ctx as CanvasRenderingContext2D, shape.subpaths, x, y, w, h);
+    }
+    if (fillStyle) {
+      ctx.fillStyle = fillStyle;
+      ctx.fill();
+    }
+    if (strokeCb) strokeCb();
+  }
+
+  // Line-end decorations (ECMA-376 §20.1.8.3). Only connector/line presets
+  // expose head/tail tips with a well-defined tangent; for those we place the
+  // arrow heads at the path endpoints with the path's outgoing direction. The
+  // preset engine does not draw connector arrow heads, so this runs whether or
+  // not the body went through it.
+  if (coreStroke && (coreStroke.headEnd || coreStroke.tailEnd) && shape.presetGeometry) {
+    const anchors = getConnectorAnchors(
+      shape.presetGeometry, x, y, w, h,
+      shape.adjValues ?? [],
+    );
+    if (anchors) {
+      ctx.setLineDash([]);
+      if (coreStroke.tailEnd) {
+        drawArrowHead(ctx as CanvasRenderingContext2D, anchors.end.x, anchors.end.y, anchors.end.angle, coreStroke.tailEnd, coreStroke, scale);
+      }
+      if (coreStroke.headEnd) {
+        drawArrowHead(ctx as CanvasRenderingContext2D, anchors.start.x, anchors.start.y, anchors.start.angle, coreStroke.headEnd, coreStroke, scale);
       }
     }
   }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -322,6 +322,12 @@ export interface ShapeRun {
   fill: ShapeFill | null;
   stroke: string | null;
   strokeWidth?: number;
+  /** `<a:ln><a:prstDash val>` — ECMA-376 §20.1.8.48. Absent = solid. */
+  strokeDash?: string | null;
+  /** `<a:ln><a:headEnd>` line-start decoration (ECMA-376 §20.1.8.3). */
+  headEnd?: LineEnd | null;
+  /** `<a:ln><a:tailEnd>` line-end decoration (ECMA-376 §20.1.8.3). */
+  tailEnd?: LineEnd | null;
   rotation?: number;
   wrapMode?: string | null;
   /** Text rendered INSIDE the shape's bounding box (`<wps:txbx><w:txbxContent>`). */
@@ -332,6 +338,17 @@ export interface ShapeRun {
   textInsetT?: number;  // pt
   textInsetR?: number;  // pt
   textInsetB?: number;  // pt
+}
+
+/** DrawingML line-end (arrow head). ECMA-376 §20.1.8.3 CT_LineEndProperties.
+ *  Maps 1:1 to core's `ArrowEnd`. */
+export interface LineEnd {
+  /** "triangle" | "stealth" | "diamond" | "oval" | "arrow" (never "none"). */
+  type: string;
+  /** Width step: "sm" | "med" | "lg". */
+  w: string;
+  /** Length step: "sm" | "med" | "lg". */
+  len: string;
 }
 
 export interface ShapeText {

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -37,6 +37,7 @@ import {
   hasPreset,
   buildPresetGeometryPath,
   getConnectorAnchors,
+  drawArrowHead,
   computeScene3dQuad,
   isScene3dNonIdentity,
   drawProjected,
@@ -3225,68 +3226,6 @@ function drawCompoundLine(
     ctx.moveTo(start.x + ox, start.y + oy);
     ctx.lineTo(end.x + ox, end.y + oy);
     ctx.stroke();
-  }
-  ctx.restore();
-}
-
-/** Draw an arrowhead at `tip` pointing in `angle` radians (0 = right). */
-function drawArrowHead(
-  ctx: CanvasRenderingContext2D,
-  tipX: number,
-  tipY: number,
-  angle: number,
-  arrowEnd: { type: string; w: string; len: string },
-  stroke: Stroke,
-  scale: number,
-): void {
-  if (arrowEnd.type === 'none') return;
-  const lw = Math.max(0.5, emuToPx(stroke.width, scale));
-  // Arrowhead size is implementation-defined: ECMA-376 §20.1.10.32/.33 only name
-  // the w/len steps (sm/med/lg) as "relative", not exact ratios. These multiples
-  // of line width are calibrated to PowerPoint's rendering (verified against the
-  // sample-9 SmartArt timeline PDF, a lg/lg triangle on a 1pt line ≈ 8× wide).
-  const wMul = arrowEnd.w   === 'sm' ? 4 : arrowEnd.w   === 'lg' ? 8 : 6;
-  const lMul = arrowEnd.len === 'sm' ? 4 : arrowEnd.len === 'lg' ? 8 : 6;
-  const halfW = lw * wMul / 2;
-  const len   = lw * lMul;
-  const color = hexToRgba(stroke.color);
-
-  ctx.save();
-  ctx.translate(tipX, tipY);
-  ctx.rotate(angle);
-  ctx.fillStyle   = color;
-  ctx.strokeStyle = color;
-  ctx.lineWidth   = lw;
-  ctx.setLineDash([]);
-  ctx.beginPath();
-  switch (arrowEnd.type) {
-    case 'triangle':
-    case 'stealth':
-      ctx.moveTo(0, 0);
-      ctx.lineTo(-len, -halfW);
-      ctx.lineTo(-len,  halfW);
-      ctx.closePath();
-      ctx.fill();
-      break;
-    case 'arrow':
-      ctx.moveTo(0, 0);
-      ctx.lineTo(-len, -halfW);
-      ctx.moveTo(0, 0);
-      ctx.lineTo(-len,  halfW);
-      ctx.stroke();
-      break;
-    case 'diamond':
-      ctx.moveTo(0, 0);
-      ctx.lineTo(-len / 2, -halfW);
-      ctx.lineTo(-len, 0);
-      ctx.lineTo(-len / 2,  halfW);
-      ctx.closePath();
-      ctx.fill();
-      break;
-    case 'oval':
-      ctx.ellipse(-len / 2, 0, len / 2, halfW, 0, 0, Math.PI * 2);
-      ctx.fill();
-      break;
   }
   ctx.restore();
 }


### PR DESCRIPTION
## Summary

Fixes DOCX shape rendering so `<a:prstGeom>` presets draw their true silhouette instead of falling back to a plain rectangle, and adds connector line-end decorations.

The root cause: core `buildShapePath` matched preset names with a **lowercase-only** `switch`, but DOCX passed the raw camelCase `presetGeometry` value, so every camelCase preset (`straightConnector1`, `roundRect`, `rtTriangle`, `leftArrow`, …) fell through to `ctx.rect()`. PPTX was unaffected because it lowercases at the call site.

## Commits

1. **fix(core)** — `buildShapePath` now matches `switch(geom.toLowerCase())`, so DOCX's camelCase presets resolve correctly.
2. **refactor(core)** — move `drawArrowHead` from the pptx renderer into shared `core/src/shape/arrow.ts` (behavior unchanged; pptx imports it).
3. **feat(docx/parser)** — extract `<a:ln>` `headEnd`/`tailEnd` (§20.1.8.3) and `prstDash` (§20.1.8.48); add `LineEnd` to `types.rs`.
4. **feat(docx)** — `renderAnchorShape` builds a core `Stroke` and draws arrow heads / dashes on connector presets via `getConnectorAnchors` → `drawArrowHead`.
5. **feat(docx)** — route shape presets through the shared spec-driven `renderPresetShape` engine (the same one pptx uses), recovering **37 preset families** that previously rendered as rectangles (actionButton ×18, callout2/3 + border/accent variants, gear6/9, circular arrows, ribbons, tabs, flowchart shapes, chart symbols, …). `arc` keeps its bespoke fallback; `custGeom` falls through to `buildCustomPath`.

## Verification

- docx VRT **21/21**, pptx VRT **75/75** (pptx untouched).
- typecheck (core/docx/pptx), `cargo test` 43/43, clippy clean.
- sample-9 figure 1's three arrows (`straightConnector1`, now engine-routed) verified visually: line + arrow head intact, matches Word PDF p3, no rect regression.

## Out of scope (follow-up issues)

- group `rot`/`flipH`/`flipV` dropped in parser; group-nested `pic` missed.
- line cap/join (§20.1.8.35), gradient/pattern line fill, custGeom `quadBezTo` (§20.1.9.22), shape-text wrap/autofit/vertical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)