### PR TITLE
chore(release): 0.60.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.60.1 — 2026-06-15
+
+Patch: docx shape rendering now goes through the shared spec-driven preset
+engine, with connector arrow heads and dash patterns.
+
+### docx
+
+- Route `<a:prstGeom>` shapes through core's `renderPresetShape` engine
+  (presets.json, 186 ECMA-376 geometries) instead of the legacy
+  `buildShapePath` switch. This recovers 37 preset families that previously
+  fell back to a plain rectangle — actionButton (×18), callout2/3 and the
+  border/accent callout variants, gear6/9, leftCircularArrow,
+  leftRightCircularArrow, leftRightRibbon, lineInv, nonIsoscelesTrapezoid,
+  swooshArrow, corner/plaque/squareTabs, flowchartOfflineStorage/Or,
+  upDownArrowCallout, chartPlus/Star/X. `arc` keeps its bespoke fallback and
+  `custGeom` still uses `buildCustomPath` (PR #450).
+- Root cause of the rectangle fallback: core `buildShapePath` matched preset
+  names case-sensitively, but docx passed the raw camelCase `presetGeometry`
+  — now matched via `toLowerCase()`.
+- Connector line ends: parse and render `<a:ln>` `headEnd` / `tailEnd` arrow
+  decorations (§20.1.8.3) and `prstDash` dash patterns (§20.1.8.48); the
+  shared `drawArrowHead` helper moved from the pptx renderer into
+  `@silurus/ooxml-core`.
+- Export the `LineEnd` type from the docx public entry point (reachable from
+  `DocxDocument` via `ShapeRun.headEnd` / `tailEnd`).
+
 ## 0.60.0 — 2026-06-14
 
 Minor: docx floating-object layout (overlap avoidance, below-float line flow)

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Right-to-left table column order (`w:bidiVisual`, §17.4.1) | ✅ |
 | | Math equations (OMML `m:oMath` / `m:oMathPara`, rendered via MathJax — opt-in `@silurus/ooxml/math`) | ✅ |
 | | Images (inline and anchored, with text wrap) | ✅ |
-| | Text boxes / drawing shapes | ✅ |
+| | Text boxes / drawing shapes (`wps:txbx`, `a:prstGeom` — 186 preset geometries via the shared engine; connector arrow heads `headEnd` / `tailEnd` (§20.1.8.3) and `prstDash` dash patterns (§20.1.8.48)) | ✅ |
 | | WMF / EMF metafile images (legacy vector) | ❌ Not planned |
 | **Advanced** | Footnotes — reference markers + bottom-of-page bodies with separator rule, numbered (`w:footnoteReference` / `w:footnoteRef`, §17.11) | ✅ |
 | | Endnotes — reference markers + bodies at document end (`w:endnoteReference`, §17.11) | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release **0.60.1**.

## Highlights (docx)

- Route `<a:prstGeom>` shapes through core's spec-driven `renderPresetShape` engine (186 ECMA-376 geometries) instead of the legacy `buildShapePath` switch — recovering **37 preset families** that previously rendered as plain rectangles (actionButton ×18, callout2/3 + border/accent variants, gear6/9, circular arrows, ribbons, tabs, flowchart shapes, chart symbols).
- Connector line ends: `<a:ln>` `headEnd` / `tailEnd` arrow heads (§20.1.8.3) and `prstDash` dash patterns (§20.1.8.48). `drawArrowHead` moved into `@silurus/ooxml-core`.
- Root-cause fix: core `buildShapePath` now matches preset names case-insensitively (docx passes raw camelCase).
- Export `LineEnd` type from the docx public entry point.

Ships the work merged in [#450](https://github.com/yukiyokotani/office-open-xml-viewer/pull/450).

## Release checklist

- [x] CHANGELOG `0.60.1` section
- [x] All 8 `package.json` bumped to `0.60.1`
- [x] README docx drawing-shapes row updated (preset engine, arrow heads, prstDash)
- [x] README consistency verified (ESM-only, no stale CJS/require, no stale version refs)
- [x] Screenshots: not re-shot (fidelity-only patch; per maintainer decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)