### PR TITLE
fix(docx): gate connector arrow heads on line geometry

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3663,10 +3663,13 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
   // expose head/tail tips with a well-defined tangent; for those we place the
   // arrow heads at the path endpoints with the path's outgoing direction. The
   // preset engine does not draw connector arrow heads, so this runs whether or
-  // not the body went through it.
-  if (coreStroke && (coreStroke.headEnd || coreStroke.tailEnd) && shape.presetGeometry) {
+  // not the body went through it. Gate on `isLineGeom` (mirroring the pptx
+  // renderer's CONNECTOR_GEOMS set): getConnectorAnchors resolves path[0] of
+  // *any* preset, so a filled shape carrying an <a:ln> head/tail end would
+  // otherwise get spurious arrow heads at its first subpath's endpoints.
+  if (coreStroke && (coreStroke.headEnd || coreStroke.tailEnd) && isLineGeom) {
     const anchors = getConnectorAnchors(
-      shape.presetGeometry, x, y, w, h,
+      preset, x, y, w, h,
       shape.adjValues ?? [],
     );
     if (anchors) {


### PR DESCRIPTION
Follow-up to the docx shape preset-engine unification ([#450](https://github.com/yukiyokotani/office-open-xml-viewer/pull/450)), from a design-consistency review against the pptx/xlsx renderers.

## Problem

`renderAnchorShape`'s line-end decoration block guarded on `shape.presetGeometry` (i.e. *any* preset) and assumed `getConnectorAnchors` would return `null` for non-connectors. It does not — `getConnectorAnchors` resolves `path[0]` of any preset and returns its start/end. So a filled shape (rect, star, callout, …) that carries an `<a:ln>` `headEnd`/`tailEnd` would get spurious arrow heads drawn at its first subpath's endpoints.

The pptx renderer avoids this by gating strictly on an explicit `CONNECTOR_GEOMS` set; docx did not have the equivalent gate.

## Fix

Gate the block on the existing `isLineGeom` (`line` / `straightconnector*` / `bentconnector*` / `curvedconnector*`) already computed in the same function — mirroring pptx's `CONNECTOR_GEOMS` intent and matching the block's own comment. No new abstraction.

## Verification

- typecheck pass, docx VRT 21/21.
- sample-9 figure 1 connector arrows (straightConnector1) verified visually — still drawn, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)