### PR TITLE
fix(docx): honor shape flipH/flipV (connector arrow-head direction)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2782,6 +2782,9 @@ fn parse_wsp_shape(
         .and_then(|v| v.parse::<f64>().ok())
         .map(|r| r / 60000.0) // OOXML rotation: 60000ths of a degree
         .unwrap_or(0.0);
+    // §20.1.7.6 a:xfrm flipH/flipV — "1"/"true" mirror the shape.
+    let flip_h = matches!(xfrm.attribute("flipH"), Some("1") | Some("true"));
+    let flip_v = matches!(xfrm.attribute("flipV"), Some("1") | Some("true"));
 
     let width_pt = cx * sx / 12700.0;
     let height_pt = cy * sy / 12700.0;
@@ -2920,6 +2923,8 @@ fn parse_wsp_shape(
         head_end,
         tail_end,
         rotation,
+        flip_h,
+        flip_v,
         wrap_mode: anchor_meta.wrap_mode.clone(),
         text_blocks,
         text_anchor,

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -484,6 +484,14 @@ pub struct ShapeRun {
     /// rotation in degrees (clockwise).
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub rotation: f64,
+    /// Horizontal flip (`<a:xfrm flipH="1">`, §20.1.7.6). Mirrors the shape
+    /// about its vertical centre line — also swaps a connector's start/end so
+    /// arrow heads land on the correct tip.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub flip_h: bool,
+    /// Vertical flip (`<a:xfrm flipV="1">`, §20.1.7.6).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub flip_v: bool,
     /// Text blocks from <wps:txbx><w:txbxContent> — text rendered INSIDE the
     /// shape's bounding box (ECMA-376 §17.3.4.7). Each block is one paragraph
     /// reduced to plain text + the first run's formatting; advanced layout

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3588,10 +3588,18 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
   );
 
   const rot = shape.rotation ?? 0;
+  const flipH = shape.flipH ?? false;
+  const flipV = shape.flipV ?? false;
   ctx.save();
-  if (rot !== 0) {
+  // §20.1.7.6 — rotate then mirror about the shape centre, matching the pptx
+  // renderer. Applying flip via the canvas transform keeps the body path, the
+  // connector arrow-head position, and its direction consistent (a flipped
+  // connector swaps which tip carries the head/tail end).
+  if (rot !== 0 || flipH || flipV) {
     ctx.translate(x + w / 2, y + h / 2);
-    ctx.rotate((rot * Math.PI) / 180);
+    if (rot !== 0) ctx.rotate((rot * Math.PI) / 180);
+    if (flipH) ctx.scale(-1, 1);
+    if (flipV) ctx.scale(1, -1);
     ctx.translate(-(x + w / 2), -(y + h / 2));
   }
   // Dispatch to the shared spec-driven preset engine when the geometry is a

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -329,6 +329,10 @@ export interface ShapeRun {
   /** `<a:ln><a:tailEnd>` line-end decoration (ECMA-376 §20.1.8.3). */
   tailEnd?: LineEnd | null;
   rotation?: number;
+  /** `<a:xfrm flipH>` (§20.1.7.6) — mirror about the vertical centre line. */
+  flipH?: boolean;
+  /** `<a:xfrm flipV>` (§20.1.7.6) — mirror about the horizontal centre line. */
+  flipV?: boolean;
   wrapMode?: string | null;
   /** Text rendered INSIDE the shape's bounding box (`<wps:txbx><w:txbxContent>`). */
   textBlocks?: ShapeText[];


### PR DESCRIPTION
## Problem

A reversed arrow head was reported in sample-9 figure 1: one connector's arrow tip was on the wrong end.

Root cause: **docx dropped a shape's `<a:xfrm flipH/flipV>` entirely.** `ShapeRun` carried only `rotation` — the parser never read flip, and the renderer never applied it. For a near-horizontal `straightConnector1`, ignoring `flipH` leaves the **line looking the same** but **swaps its logical start/end**, so the `tailEnd` / `headEnd` arrow head lands on the wrong tip.

## Fix (ECMA-376 §20.1.7.6)

- **parser** — read `flipH` / `flipV` from the shape `a:xfrm`.
- **types** (Rust + TS) — add `flip_h` / `flip_v` (`flipH` / `flipV`) to `ShapeRun`.
- **renderer** — apply flip as a canvas transform composed with rotation (translate to centre → rotate → `scale(-1,1)`/`scale(1,-1)` → translate back), mirroring the pptx renderer. Doing it via the transform keeps the body path, the connector arrow-head **position**, and its **direction** all consistent.

## Verification

- typecheck pass, docx VRT 21/21, clippy clean, WASM rebuilt.
- sample-9 figure 1: all three leader-line arrows (定規 / クリップ / スリット) now point into their target objects, matching the Word PDF (p3) — verified visually.

Follows [#450](https://github.com/yukiyokotani/office-open-xml-viewer/pull/450) / [#452](https://github.com/yukiyokotani/office-open-xml-viewer/pull/452).

🤖 Generated with [Claude Code](https://claude.com/claude-code)