### PR TITLE
chore(release): 0.60.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.60.2 — 2026-06-15
+
+Patch: docx connector arrow-head correctness.
+
+### docx
+
+- Honor shape `<a:xfrm flipH/flipV>` (§20.1.7.6). docx previously dropped flip
+  entirely, so a near-horizontal `straightConnector1` kept the right line but
+  swapped its start/end — drawing the arrow head on the wrong tip. Flip is now
+  parsed and applied as a canvas transform composed with rotation, mirroring
+  the pptx renderer (sample-9 figure 1 leader arrows now match Word).
+- Gate connector arrow-head drawing on line/connector geometry instead of any
+  preset. `getConnectorAnchors` resolves `path[0]` of any preset, so a filled
+  shape carrying an `<a:ln>` head/tail end could otherwise get spurious arrow
+  heads at its first subpath's endpoints.
+
 ## 0.60.1 — 2026-06-15
 
 Patch: docx shape rendering now goes through the shared spec-driven preset

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.60.1",
+  "version": "0.60.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release **0.60.2** — docx connector arrow-head correctness.

## Highlights (docx)

- **Honor shape `<a:xfrm flipH/flipV>` (§20.1.7.6).** docx previously dropped flip entirely, so a near-horizontal `straightConnector1` kept the right line but swapped its start/end — drawing the arrow head on the wrong tip. Flip is now parsed and applied as a canvas transform composed with rotation, mirroring the pptx renderer. ([#453](https://github.com/yukiyokotani/office-open-xml-viewer/pull/453))
- **Gate connector arrow heads on line geometry**, not any preset — `getConnectorAnchors` resolves `path[0]` of any preset, so a filled shape with an `<a:ln>` head/tail end could otherwise get spurious arrow heads. ([#452](https://github.com/yukiyokotani/office-open-xml-viewer/pull/452))

## Release checklist

- [x] CHANGELOG `0.60.2` section
- [x] All 8 `package.json` bumped to `0.60.2`
- [x] README: no feature-table change (fidelity-only patch; rationale in CHANGELOG)
- [x] README consistency verified (unchanged since 0.60.1)
- [x] Screenshots: not re-shot (fidelity-only patch; per maintainer decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)