### PR TITLE
fix(shapes): render arc consistently via the shared preset engine (docx/pptx)

### DIFF
--- a/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
+++ b/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
@@ -180,4 +180,73 @@ describe('renderPresetShape (core preset-geometry engine)', () => {
     const large = slant(50000);
     expect(small).not.toEqual(large);
   });
+
+  // `arc` (ECMA-376 §20.1.10.56 ST_ShapeType "arc"; geometry in
+  // presetShapeDefinitions.xml referenced by §20.1.9.18 <a:prstGeom>) is a
+  // TWO-path shape and the engine must honour each path's own fill/stroke:
+  //   path 0  stroke="false"  → moveTo(x1,y1) arcTo lnTo(hc,vc) close  : FILLED
+  //           pie wedge (arc swept back to the centre), NEVER stroked.
+  //   path 1  fill="none"     → moveTo(x1,y1) arcTo                    : the
+  //           open arc OUTLINE, stroked only, never filled.
+  // This is why a filled arc shows a pie-wedge fill but only the curved edge is
+  // outlined — the two radii are not stroked. A renderer must not collapse this
+  // to a single open path (filling that would auto-close into a chord, not a
+  // pie wedge). These tests pin that behaviour so all three renderers can share
+  // the engine instead of bespoke arc fallbacks.
+  describe('arc — pie-wedge fill + open-arc stroke (§20.1.9.18)', () => {
+    function makeOpRecorder() {
+      const ops: string[] = [];
+      const lineTos: Array<{ x: number; y: number }> = [];
+      const ctx = {
+        beginPath() { ops.push('begin'); },
+        closePath() { ops.push('close'); },
+        moveTo() {},
+        lineTo(x: number, y: number) { ops.push('line'); lineTos.push({ x, y }); },
+        bezierCurveTo() {},
+        quadraticCurveTo() {},
+        ellipse() { ops.push('arc'); },
+        save() {},
+        restore() {},
+        fill() { ops.push('fill'); },
+        stroke() { ops.push('stroke'); },
+        set fillStyle(_v: unknown) {},
+      } as unknown as CanvasRenderingContext2D;
+      return { ctx, ops, lineTos };
+    }
+
+    it('fills exactly one path (the pie wedge, closed to the centre) and strokes exactly one (the open arc)', () => {
+      const { ctx, ops, lineTos } = makeOpRecorder();
+      // Default adjusts: stAng=270°, swAng=90°. Box 200×100 → centre (100,50).
+      const ok = renderPresetShape(
+        ctx, 'arc', 0, 0, 200, 100, [], '#abc', () => ctx.stroke(), () => {},
+      );
+      expect(ok).toBe(true);
+      // One fill (path 0) and one stroke (path 1) — not two of either.
+      expect(ops.filter((o) => o === 'fill')).toHaveLength(1);
+      expect(ops.filter((o) => o === 'stroke')).toHaveLength(1);
+      // The filled path closes back through the shape centre: a pie wedge has a
+      // lnTo the centre (100,50); an open/chord-filled arc never touches it.
+      const touchesCentre = lineTos.some(
+        (p) => Math.round(p.x) === 100 && Math.round(p.y) === 50,
+      );
+      expect(touchesCentre).toBe(true);
+      // That lnTo-to-centre belongs to the FILLED path, before the fill — and
+      // the stroked path (after) has no such lnTo (it is the bare arc).
+      const fillIdx = ops.indexOf('fill');
+      const strokeIdx = ops.indexOf('stroke');
+      expect(ops.slice(0, fillIdx)).toContain('line'); // wedge radius before fill
+      expect(ops.slice(fillIdx + 1)).not.toContain('line'); // open arc only after
+      expect(strokeIdx).toBeGreaterThan(fillIdx);
+    });
+
+    it('with no fill, strokes the open arc and fills nothing (a bare curved line)', () => {
+      const { ctx, ops } = makeOpRecorder();
+      const ok = renderPresetShape(
+        ctx, 'arc', 0, 0, 200, 100, [], null, () => ctx.stroke(), () => {},
+      );
+      expect(ok).toBe(true);
+      expect(ops).not.toContain('fill');
+      expect(ops.filter((o) => o === 'stroke')).toHaveLength(1);
+    });
+  });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3603,12 +3603,18 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     ctx.translate(-(x + w / 2), -(y + h / 2));
   }
   // Dispatch to the shared spec-driven preset engine when the geometry is a
-  // known <a:prstGeom> preset, mirroring the pptx renderer. `arc` keeps its
-  // bespoke buildShapePath fallback (fill semantics differ); custGeom (no
-  // presetGeometry, subpaths only) likewise falls through to buildCustomPath.
+  // known <a:prstGeom> preset, mirroring the pptx renderer. `arc` (ECMA-376
+  // §20.1.10.56 ST_ShapeType "arc") goes through the engine too: its
+  // presetShapeDefinitions geometry is two <path>s — path 0 (stroke="false")
+  // fills the pie wedge (arc + lnTo centre + close) and path 1 (fill="none")
+  // strokes the open arc edge — which the engine honours per-path. The legacy
+  // buildShapePath fallback could only draw the open arc, so filling it
+  // auto-closed into a chord; arc was excluded here to dodge that, but the
+  // engine renders it faithfully now. custGeom (no presetGeometry, subpaths
+  // only) still falls through to buildCustomPath.
   const geom = shape.presetGeometry?.toLowerCase() ?? '';
   const usePresetEngine =
-    !!shape.presetGeometry && geom !== 'arc' && hasPreset(geom);
+    !!shape.presetGeometry && hasPreset(geom);
 
   const adj = shape.adjValues ?? [];
   const fillStyle = resolveFill(shape.fill, ctx as CanvasRenderingContext2D, x, y, w, h);

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1293,10 +1293,15 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
 
   // ── Dispatch to preset engine when possible ────────────────────────────
   // Preference order: custGeom → generic preset engine → legacy switch.
-  // `arc` keeps its bespoke case because its fill semantics (pie-wedge vs
-  // open arc) depend on stroke state in ways the engine doesn't express.
+  // `arc` (ECMA-376 §20.1.10.56 ST_ShapeType "arc") goes through the engine
+  // too: its presetShapeDefinitions geometry is a two-<path> shape — path 0
+  // (stroke="false") fills the pie wedge (arc + lnTo centre + close) and path 1
+  // (fill="none") strokes only the open arc edge. The engine honours those
+  // per-path fill/stroke flags, so arc renders its true pie-wedge fill + open
+  // outline. The legacy buildShapePath could only draw the open arc (filling it
+  // auto-closes into a *chord*), which is why arc used to be excluded here.
   const usePresetEngine =
-    !el.custGeom && geom !== 'arc' && hasPreset(geom);
+    !el.custGeom && hasPreset(geom);
 
   /**
    * Paint the shape's body (fill + stroke) into an arbitrary target context,
@@ -1344,6 +1349,11 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     } else {
       buildShapePath(target, geom, x, y, w, h, el.adj, el.adj2, el.adj3, el.adj4);
     }
+    // Normal arc bodies render through the preset engine above; this legacy
+    // path is only reached for an arc as a custGeom/effect silhouette built by
+    // buildShapePath, which draws the OPEN arc — filling that auto-closes into
+    // a chord, not the pie wedge. So skip the fill for arc here (the engine,
+    // not this branch, owns arc's pie-wedge fill).
     if (tFill && geom !== 'arc') {
       target.fillStyle = tFill;
       if (geom === 'donut' || geom === 'smileyface' || geom === 'frame') {


### PR DESCRIPTION
## Summary

Found during a design review of the docx preset-engine work: the three renderers dispatched `arc` to the shared spec-driven preset engine **inconsistently**. xlsx routed `arc` through `renderPresetShape`; docx and pptx excluded it (`geom !== 'arc'`) and fell back to the legacy `buildShapePath`.

**Investigation result: the engine renders `arc` correctly — the docx/pptx exclusion was stale.**

### ECMA-376 (§20.1.10.56 ST_ShapeType `arc`, geometry via §20.1.9.18 `<a:prstGeom>`)

`arc` is a **two-`<path>`** preset:

| path | attrs | commands | role |
|------|-------|----------|------|
| 0 | `stroke="false"` | `moveTo(x1,y1) → arcTo → lnTo(hc,vc) → close` | **filled pie wedge**, never stroked |
| 1 | `fill="none"` | `moveTo(x1,y1) → arcTo` | **open arc edge**, stroked only, never filled |

So a filled arc shows a pie-wedge fill with only the curved edge outlined (the two radii are *not* stroked). The shared engine already honours each path's per-path fill/stroke flags via `presets.json`, so it renders this faithfully.

The legacy `buildShapePath` (`packages/core/src/shape/preset.ts`) can only draw the **open** ellipse arc. Filling that path auto-closes it into a **chord**, not a pie wedge:
- **docx** previously chord-filled a filled arc (no arc guard in its legacy fill branch).
- **pptx** previously suppressed the fill entirely.

Both are non-spec; the engine is correct.

## Change

- Remove the stale `geom !== 'arc'` exclusion from the `usePresetEngine` gate in **pptx** (`renderer.ts`) and **docx** (`renderer.ts`) so all three renderers share the engine for `arc`. **xlsx unchanged** (already correct).
- Keep + document pptx's legacy fill-guard (`tFill && geom !== 'arc'`): it still applies to the custGeom / effect-silhouette fallback, which genuinely can't express a pie wedge via `buildShapePath`.
- Add characterization tests in `preset-geometry.test.ts` pinning the engine's pie-wedge-fill + open-arc-stroke behaviour.

## Verification

- **Unit**: `@silurus/ooxml-core` vitest — 10/10 pass, including the 2 new arc tests (confirm exactly one filled path closing through the centre + one open stroked path; with no fill, stroke-only).
- **Typecheck**: core / pptx / docx / xlsx clean.
- **VRT** (local, committed `demo/sample-1` only — `private/*` samples are gitignored and absent in a fresh worktree): pptx 12/12, docx 8/8, xlsx 8/8 of the runnable demo tests pass; **zero pixel mismatches**. The change is gated on `geom === 'arc'`, so non-arc rendering is provably unchanged. Reference images were **not** updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)