### PR TITLE
chore(pptx): declare missing pngjs runtime devDependency

### DIFF
--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -44,6 +44,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.59.1",
+    "pngjs": "^7.0.0",
     "typescript": "^6.0.2",
     "vite": "^8.0.8",
     "vite-plugin-top-level-await": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.3


### PR DESCRIPTION
## Summary

`packages/pptx/package.json` declared `@types/pngjs` but was **missing the runtime `pngjs` package itself**. The pptx VRT specs import it directly:

- `packages/pptx/tests/visual/visual.spec.ts`
- `packages/pptx/tests/visual/worker-equivalence.spec.ts`

Today this only resolves by **accidental hoisting** from `packages/docx`, which declares `"pngjs": "^7.0.0"`. In an isolated git worktree with a clean `pnpm install`, the pptx VRT fails to start:

```
Error: Cannot find package 'pngjs' imported from .../packages/pptx/tests/visual/visual.spec.ts
```

(Surfaced while running the pptx VRT in an isolated worktree for PR #455.)

## Change

Add `"pngjs": "^7.0.0"` (matching docx) to `packages/pptx` devDependencies + lockfile. Diff is 4 lines (package.json +1, pnpm-lock.yaml +3).

## Verification

In a clean isolated worktree (no hoisting hack), `pnpm --filter @silurus/ooxml-pptx vrt` now **resolves the `pngjs` import** and runs — the test runner starts and the committed `demo/sample-1` cases pass (12 passed). The remaining 60 failures are all `fetch failed: 404` from the gitignored `private/sample-*` files being absent in a fresh worktree, which is expected and unrelated. The `Cannot find package 'pngjs'` startup error is gone.

> Squash merge forbidden per repo policy — use `--merge` or `--rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)