### PR TITLE
fix(docx): round docGrid line heights to whole cells for East Asian lines

### DIFF
--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -42,3 +42,36 @@ describe('lineBoxHeight — degenerate zero line spacing', () => {
     expect(lineBoxHeight(null, 12, 3, 1, undefined)).toBe(15);
   });
 });
+
+// ECMA-376 §17.6.5 / §17.3.1.32 only define docGrid line height for natural <=
+// pitch. Word's runtime behaviour for taller lines (verified via pdftotext -bbox
+// of the sample-9 Word PDF: a 20pt CJK title on a 20pt pitch is 40px = 2 cells)
+// rounds East Asian lines UP to whole grid cells, while Latin-only lines keep
+// their natural height above a one-cell floor (demo/sample-1's 18pt heading on
+// an 18pt pitch stays ~natural, not 2 cells). The `eastAsian` flag gates it.
+describe('lineBoxHeight — docGrid line-cell rounding (East Asian vs Latin)', () => {
+  const grid20 = { type: 'lines', linePitchPt: 20 } as const;
+
+  it('rounds an East Asian line taller than the pitch UP to whole cells', () => {
+    // glyph natural 22px > 20px pitch → ceil(22/20) = 2 cells = 40px.
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20, false, 0, true)).toBe(40);
+  });
+  it('keeps a Latin line at natural height (one-cell floor), NOT rounded to 2 cells', () => {
+    // Same 22px natural, Latin → max(22, 20) = 22px (Word does not cell-round it).
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20, false, 0, false)).toBe(22);
+  });
+  it('puts a short East Asian line in a single cell (natural <= pitch)', () => {
+    // glyph natural 13px <= 20px pitch → ceil(13/20) = 1 cell = 20px.
+    expect(lineBoxHeight(null, 10.4, 2.6, 1, grid20, false, 0, true)).toBe(20);
+  });
+  it('rounds an East Asian line over two pitches up to three cells', () => {
+    // glyph natural 41px → ceil(41/20) = 3 cells = 60px.
+    expect(lineBoxHeight(null, 32.8, 8.2, 1, grid20, false, 0, true)).toBe(60);
+  });
+  it('does not cell-round when no docGrid is active (East Asian, off grid)', () => {
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, undefined, false, 0, true)).toBe(22);
+  });
+  it('defaults to Latin (no cell rounding) when the flag is omitted', () => {
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20)).toBe(22);
+  });
+});

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { computePages } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxTextRun, SectionProps, PaginatedBodyElement } from './types';
+
+// Unit tests for computePages pagination behaviour that the renderer-path VRT
+// (local-only, private samples) cannot guard in CI. A deterministic stub canvas
+// makes line wrapping and line heights predictable: glyph advance = charCount ×
+// fontPx, and the font box = 0.8/0.2 em (so a single line is exactly fontPx tall
+// with no spacing/grid). CJK characters break between any two glyphs, so a run of
+// N of them wraps to ceil(N / charsPerLine) lines.
+
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, fillText() {}, strokeText() {}, beginPath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fillRect() {}, drawImage() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1, textAlign: 'left' as CanvasTextAlign,
+    direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function section(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 200, pageHeight: 140,
+    marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    ...overrides,
+  };
+}
+
+function textRun(text: string, fontSize: number): DocRun {
+  const run: DocxTextRun = {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+  return { type: 'text', ...run } as DocRun;
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function para(opts: { text?: string; fontSize?: number; widowControl?: boolean } = {}): BodyElement {
+  const fontSize = opts.fontSize ?? 20;
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: opts.text ? [textRun(opts.text, fontSize)] : [],
+    defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
+    widowControl: opts.widowControl,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+const sliceOf = (el: PaginatedBodyElement) =>
+  (el as { lineSlice?: { start: number; end: number } }).lineSlice;
+
+describe('computePages — empty-paragraph relocation (C2: §17.3.1.29)', () => {
+  it('moves an unsplittable mark-only paragraph to the next page instead of overflowing the bottom margin', () => {
+    // content height = 140 - 40 = 100; each empty mark = 20px → exactly 5 per page.
+    const body = Array.from({ length: 7 }, () => para()); // 7 empty paragraphs
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages.length).toBe(2);
+    expect(pages[0].length).toBe(5); // page 1 fills exactly
+    expect(pages[1].length).toBe(2); // overflow relocated, NOT clipped onto page 1
+    // no page holds more than its 5-line capacity (would mean an overflow)
+    for (const p of pages) expect(p.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('computePages — line-boundary splitting + widowControl (C1: §17.3.1.44)', () => {
+  // contentW = 160, glyph advance = fontPx; at 20px → 8 chars/line. 48 chars → 6 lines.
+  // content height = 100 → 5 lines (100px) fit per page.
+  const sixLineText = 'あ'.repeat(48);
+
+  it('avoids a widow: a single trailing line is not stranded on the next page (default widowControl on)', () => {
+    const pages = computePages([para({ text: sixLineText })], section(), makeCtx());
+    expect(pages.length).toBe(2);
+    // Greedy fit is 5 lines on page 1; widowControl pulls one down so ≥2 carry over.
+    expect(sliceOf(pages[0][0])).toEqual({ start: 0, end: 4 });
+    expect(sliceOf(pages[1][0])).toEqual({ start: 4, end: 6 });
+  });
+
+  it('honors w:widowControl="off": the trailing single line is allowed (matches sample-9)', () => {
+    const pages = computePages([para({ text: sixLineText, widowControl: false })], section(), makeCtx());
+    expect(pages.length).toBe(2);
+    expect(sliceOf(pages[0][0])).toEqual({ start: 0, end: 5 }); // greedy 5 lines
+    expect(sliceOf(pages[1][0])).toEqual({ start: 5, end: 6 }); // lone widow line allowed
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -161,6 +161,10 @@ interface RenderState {
   floatParaSeq: number;
   /** ECMA-376 §17.6.5 docGrid (type + pitch), applied to auto line spacing. */
   docGrid: DocGridCtx;
+  /** True when the document body contains East Asian text. Gates docGrid line-
+   *  cell rounding of empty / anchor-only paragraph marks (see
+   *  paragraphMarkLineHeight), which carry no text to classify themselves. */
+  docEastAsian: boolean;
   /** ECMA-376 §17.8.3.10 — font→family map from word/fontTable.xml. Used by
    *  resolveFontFamily as the authoritative source of serif/sans-serif classification. */
   fontFamilyClasses: Record<string, string>;
@@ -402,6 +406,7 @@ export async function renderDocumentToCanvas(
   for (const [id, n] of footnoteNums) noteNumbers.set(`footnote:${id}`, n);
   for (const [id, n] of endnoteNums) noteNumbers.set(`endnote:${id}`, n);
 
+  const docEA = documentHasEastAsian(doc.body);
   const baseState: RenderState = {
     ctx,
     scale,
@@ -422,6 +427,7 @@ export async function renderDocumentToCanvas(
     floats: [],
     floatParaSeq: 0,
     docGrid: { type: sec.docGridType ?? null, linePitchPt: sec.docGridLinePitch ?? null },
+    docEastAsian: docEA,
     fontFamilyClasses: doc.fontFamilyClasses ?? {},
     kinsoku,
     mathDefJc: doc.settings?.mathDefJc,
@@ -469,8 +475,9 @@ function measureNoteBlockForDraw(
   sec: SectionProps,
   fontFamilyClasses: Record<string, string>,
   kinsoku: KinsokuRules,
+  docEastAsian: boolean,
 ): { total: number; trailingSpaceAfter: number } {
-  const measure = buildMeasureState(ctx, sec, fontFamilyClasses, kinsoku);
+  const measure = buildMeasureState(ctx, sec, fontFamilyClasses, kinsoku, docEastAsian);
   const contentWPt = sec.pageWidth - sec.marginLeft - sec.marginRight;
   return measureFootnoteBlockPt(note, measure, contentWPt);
 }
@@ -513,7 +520,7 @@ function drawPageFootnotes(
   for (const id of ids) {
     const note = noteById.get(id);
     if (!note) continue;
-    const m = measureNoteBlockForDraw(note, baseState.ctx, sec, baseState.fontFamilyClasses, baseState.kinsoku);
+    const m = measureNoteBlockForDraw(note, baseState.ctx, sec, baseState.fontFamilyClasses, baseState.kinsoku, baseState.docEastAsian);
     totalPt += m.total;
     lastTrailingPt = m.trailingSpaceAfter;
   }
@@ -688,7 +695,7 @@ export function computePages(
 ): PaginatedBodyElement[][] {
   const fullContentH = section.pageHeight - section.marginTop - section.marginBottom;
   const contentW = section.pageWidth - section.marginLeft - section.marginRight;
-  const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku);
+  const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body));
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
   // Per-page reserved footnote height (pt). Index 0 = first page. Grows as
@@ -1007,6 +1014,7 @@ function buildMeasureState(
   section: SectionProps,
   fontFamilyClasses: Record<string, string> = {},
   kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
+  docEastAsian = false,
 ): RenderState {
   return {
     ctx,
@@ -1028,6 +1036,7 @@ function buildMeasureState(
     floats: [],
     floatParaSeq: 0,
     docGrid: { type: section.docGridType ?? null, linePitchPt: section.docGridLinePitch ?? null },
+    docEastAsian,
     fontFamilyClasses,
     kinsoku,
     showTrackChanges: false,
@@ -1083,7 +1092,7 @@ function estimateParagraphHeight(
       const win = resolveLineFloatWindow(cursor, paragraphMarkEmPx(para, 1), 10, paraX, paraW, state.floats);
       if (win.topY > cursor) cursor = win.topY;
     }
-    cursor += paragraphMarkLineHeight(para, 1, grid, paraHasRuby);
+    cursor += paragraphMarkLineHeight(para, 1, grid, paraHasRuby, state.docEastAsian, state.ctx, state.fontFamilyClasses);
   };
   if (segs.length === 0) {
     flowMarkLine();
@@ -1095,7 +1104,7 @@ function estimateParagraphHeight(
       startPageY: cursor,
       paraX,
       floats: state.floats,
-      lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0),
+      lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0, paragraphIsEastAsian(para)),
       pageH: state.pageH,
       markEmPx: paragraphMarkEmPx(para, 1),
     } : undefined;
@@ -1108,7 +1117,7 @@ function estimateParagraphHeight(
       // Word uses the same line height for every line in a ruby paragraph,
       // snapped to an integer docGrid pitch.
       const uniform = snapParaLineToGrid(
-        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, true, l.intendedSingle))),
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, true, l.intendedSingle, paragraphIsEastAsian(para)))),
         grid,
         1,
       );
@@ -1119,7 +1128,7 @@ function estimateParagraphHeight(
     } else {
       for (const l of lines) {
         if (l.topY !== undefined && l.topY > cursor) cursor = l.topY;
-        cursor += lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, false, l.intendedSingle);
+        cursor += lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, false, l.intendedSingle, paragraphIsEastAsian(para));
       }
     }
   }
@@ -1147,6 +1156,45 @@ function snapParaLineToGrid(h: number, grid: DocGridCtx | undefined, scale: numb
 function paragraphHasRuby(para: DocParagraph): boolean {
   for (const run of para.runs) {
     if (run.type === 'text' && (run as unknown as DocxTextRun).ruby) return true;
+  }
+  return false;
+}
+
+/** Code points whose presence marks a line as East Asian for docGrid line-cell
+ *  rounding: CJK symbols/punctuation, Hiragana, Katakana, CJK Unified +
+ *  Extension A, compatibility ideographs, Hangul, and fullwidth forms. Content
+ *  test only — not a font-name heuristic (cf. packages/docx/CLAUDE.md). */
+const EAST_ASIAN_RE =
+  /[ᄀ-ᇿ⺀-⿟　-〿぀-ヿ㄰-㆏㐀-䶿一-鿿ꥠ-꥿가-퟿豈-﫿＀-￯]/u;
+
+/** ECMA-376 §17.6.5 docGrid line-cell rounding (see lineBoxHeight) applies to
+ *  East Asian lines. A paragraph counts as East Asian when any of its text runs
+ *  carries East Asian characters. (Empty / anchor-only paragraphs carry no text;
+ *  their mark line is handled separately by paragraphMarkLineHeight.) */
+function paragraphIsEastAsian(para: DocParagraph): boolean {
+  for (const run of para.runs) {
+    if (run.type === 'text' && EAST_ASIAN_RE.test((run as unknown as DocxTextRun).text)) return true;
+  }
+  return false;
+}
+
+/** Whether the document body contains any East Asian text. An empty / anchor-
+ *  only paragraph mark carries no text to classify, so its docGrid cell rounding
+ *  (paragraphMarkLineHeight) is gated on this document-level signal: in an East
+ *  Asian document the paragraph default is an East Asian font and its mark snaps
+ *  to whole grid cells; a purely Latin document (e.g. demo/sample-1) keeps the
+ *  natural single-cell mark. Recurses into table cells. */
+function documentHasEastAsian(body: BodyElement[]): boolean {
+  for (const el of body) {
+    if (el.type === 'paragraph') {
+      if (paragraphIsEastAsian(el as unknown as DocParagraph)) return true;
+    } else if (el.type === 'table') {
+      for (const row of (el as unknown as DocTable).rows) {
+        for (const cell of row.cells) {
+          if (documentHasEastAsian(cell.content)) return true;
+        }
+      }
+    }
   }
   return false;
 }
@@ -1214,7 +1262,7 @@ function splitParagraphAcrossPages(
     startPageY: measureState.y,
     paraX,
     floats: measureState.floats,
-    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0),
+    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0, paragraphIsEastAsian(para)),
     pageH: measureState.pageH,
     markEmPx: paragraphMarkEmPx(para, 1),
   } : undefined;
@@ -1226,7 +1274,7 @@ function splitParagraphAcrossPages(
   }
   const paraHasRuby = paragraphHasRuby(para);
 
-  const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby, l.intendedSingle);
+  const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby, l.intendedSingle, paragraphIsEastAsian(para));
   const uniformH = paraHasRuby
     ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), measureState.docGrid, 1)
     : 0;
@@ -1837,7 +1885,7 @@ function renderEmptyMarkParagraph(
   const flowShift = Math.max(0, markTop - textAreaTopY);
   if (markTop > state.y) state.y = markTop;
   const markRectTop = state.y;
-  const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby);
+  const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby, state.docEastAsian, ctx, state.fontFamilyClasses);
   if (para.shading && !dryRun) {
     ctx.fillStyle = `#${para.shading}`;
     ctx.fillRect(contentX + indLeft, markRectTop, paraW, emptyH);
@@ -1955,7 +2003,7 @@ function renderParagraph(
     startPageY: state.y,
     paraX,
     floats: state.floats,
-    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0),
+    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0, paragraphIsEastAsian(para)),
     pageH: state.pageH,
     markEmPx: paragraphMarkEmPx(para, scale),
   } : undefined;
@@ -1993,7 +2041,7 @@ function renderParagraph(
   // else just the max natural.
   const uniformLineH = paraHasRuby
     ? snapParaLineToGrid(
-        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle))),
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, paragraphIsEastAsian(para)))),
         grid,
         scale,
       )
@@ -2001,7 +2049,7 @@ function renderParagraph(
   const lineHForLine = (l: typeof lines[number]): number =>
     paraHasRuby
       ? uniformLineH
-      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle);
+      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, paragraphIsEastAsian(para));
 
   if (para.shading && !dryRun) {
     const totalTextH = lines.reduce((s, l) => s + lineHForLine(l), 0);
@@ -4168,10 +4216,10 @@ function measureParaHeight(
   if (segs.length === 0) {
     const fs = getDefaultFontSize(para);
     const { asc, desc } = emptyLineNaturalPx(fs, scale);
-    return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSinglePx(para, scale));
+    return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSinglePx(para, scale), paragraphIsEastAsian(para));
   }
   const lines = layoutLines(state.ctx, segs, maxWidth, 0, scale, para.tabStops, undefined, state.fontFamilyClasses, 0, state.kinsoku);
-  return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle), 0);
+  return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle, paragraphIsEastAsian(para)), 0);
 }
 
 /** Effective cell margins (pt). Per-cell `<w:tcMar>` overrides (ECMA-376
@@ -4719,6 +4767,7 @@ export function lineBoxHeight(
   grid?: DocGridCtx,
   hasRuby?: boolean,
   intendedSinglePx = 0,
+  eastAsian = false,
 ): number {
   const glyphNatural = ascentPx + descentPx;
   // For `auto`/single spacing the multiplier applies to the intended font's
@@ -4748,12 +4797,23 @@ export function lineBoxHeight(
   // the rt reserve in buildSegments is set generously enough. So the
   // ruby-aware logic now lives entirely in the segment-level ascent
   // reservation, and lineBoxHeight stays format-agnostic.
+  // A single-spaced line on a docGrid snaps to whole grid CELLS in East Asian
+  // text: Word rounds its height UP to the next pitch multiple, so a line taller
+  // than one pitch reserves two (or more). sample-9 (pdftotext -bbox of the Word
+  // PDF): a 20pt CJK title on a 20pt pitch is 40px = 2 cells; an 11pt body is
+  // 20px = 1 cell. A Latin-only line is NOT cell-rounded — it keeps its natural
+  // height above a one-cell floor (demo/sample-1: an 18pt heading on an 18pt
+  // pitch stays ~20.7px, not 36). ECMA-376 Part 1 only defines the natural ≤
+  // pitch case (§17.6.5 / §17.3.1.32); the East-Asian cell rounding for taller
+  // lines is Word runtime behaviour, so it is gated on the line's script.
+  const gridSingleCell = (): number => eastAsian
+    ? Math.max(pitchPx, Math.ceil(glyphNatural / pitchPx) * pitchPx)
+    : Math.max(glyphNatural, pitchPx);
   const inheritedOnly = ls !== null && ls.explicit !== true;
   if (!ls) {
     // No explicit spacing → single line. Use the intended single-line height
-    // (`natural`) off-grid; on-grid, snap to the pitch with the glyph extent
-    // as the overflow floor (the grid, not the font metric, governs height).
-    return hasGrid ? Math.max(glyphNatural, pitchPx) : natural;
+    // (`natural`) off-grid; on-grid, snap per gridSingleCell.
+    return hasGrid ? gridSingleCell() : natural;
   }
   // A zero/negative `w:line` is degenerate input whose behavior ECMA-376
   // §17.3.1.33 does not define (read literally, an `exact` line of 0 would
@@ -4770,11 +4830,11 @@ export function lineBoxHeight(
   // mode; applying the same fallback to a degenerate auto multiplier <= 0 is
   // the analogous non-collapsing reading.)
   if ((ls.rule === 'exact' || ls.rule === 'auto') && ls.value <= 0) {
-    return hasGrid ? Math.max(glyphNatural, pitchPx) : natural;
+    return hasGrid ? gridSingleCell() : natural;
   }
   if (ls.rule === 'auto') {
     if (hasGrid) {
-      if (inheritedOnly) return Math.max(glyphNatural, pitchPx);
+      if (inheritedOnly) return gridSingleCell();
       return Math.max(glyphNatural, pitchPx * ls.value);
     }
     return natural * ls.value;
@@ -4803,8 +4863,28 @@ function paragraphMarkLineHeight(
   scale: number,
   grid: DocGridCtx | undefined,
   paraHasRuby: boolean,
+  eastAsian = false,
+  ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  fontFamilyClasses: Record<string, string> = {},
 ): number {
   const fs = getDefaultFontSize(para);
-  const { asc, desc } = emptyLineNaturalPx(fs, scale);
-  return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSinglePx(para, scale));
+  let asc: number;
+  let desc: number;
+  if (eastAsian && ctx) {
+    // East Asian document: the empty paragraph-mark line follows the real East
+    // Asian font box so docGrid cell rounding (lineBoxHeight) reserves whole
+    // cells — a 20pt mark on a 20pt pitch → 2 cells (40px), matching Word's title
+    // pages. The synthetic 0.8/0.2 ≈ 1em fallback measures exactly one pitch and
+    // would round down to a single cell. fontBoundingBox is font-wide, so any
+    // East Asian glyph probes it.
+    const prevFont = ctx.font;
+    ctx.font = buildFont(false, false, fs * scale, getDefaultFontFamily(para), fontFamilyClasses);
+    const m = ctx.measureText('あ');
+    asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fs * scale * 0.8;
+    desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fs * scale * 0.2;
+    ctx.font = prevFont;
+  } else {
+    ({ asc, desc } = emptyLineNaturalPx(fs, scale));
+  }
+  return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSinglePx(para, scale), eastAsian);
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1044,6 +1044,13 @@ function estimateParagraphHeight(
   const indLeft = para.indentLeft;
   const indRight = para.indentRight;
   const paraW = Math.max(1, contentWPt - indLeft - indRight);
+  // Float-wrap windows are evaluated at the paragraph's content left edge =
+  // contentX + physical left indent, matching renderParagraph. The left/right
+  // indents swap to physical sides in a bidi paragraph (§17.3.1.12 / Part 4
+  // §14.11.2), so use the bidi-resolved left indent; otherwise an indented / RTL
+  // paragraph wrapping a square float would measure the gap at the wrong X and
+  // diverge from the paint pass.
+  const paraX = paraXPt + (para.bidi === true ? indRight : indLeft);
   const segs = buildSegments(para.runs, state);
   // Word renders ruby paragraphs with consistent line spacing — every line
   // in a paragraph that carries ANY furigana snaps to the same pitch
@@ -1073,7 +1080,7 @@ function estimateParagraphHeight(
     // Empty / anchor-only paragraph: one paragraph-mark line box, flowed below a
     // full-width float band exactly like renderEmptyMarkParagraph.
     if (hasFloats) {
-      const win = resolveLineFloatWindow(cursor, paragraphMarkEmPx(para, 1), 10, paraXPt, paraW, state.floats);
+      const win = resolveLineFloatWindow(cursor, paragraphMarkEmPx(para, 1), 10, paraX, paraW, state.floats);
       if (win.topY > cursor) cursor = win.topY;
     }
     cursor += paragraphMarkLineHeight(para, 1, grid, paraHasRuby);
@@ -1086,7 +1093,7 @@ function estimateParagraphHeight(
     // and line count agree with the paint pass.
     const wrapCtx: WrapLayoutCtx | undefined = hasFloats ? {
       startPageY: cursor,
-      paraX: paraXPt,
+      paraX,
       floats: state.floats,
       lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0),
       pageH: state.pageH,
@@ -1175,15 +1182,37 @@ function splitParagraphAcrossPages(
   const indLeft = para.indentLeft;
   const indRight = para.indentRight;
   const paraW = Math.max(1, contentWPt - indLeft - indRight);
+  // Mirror renderParagraph's paragraph-content left edge: contentX + the
+  // physical left indent (ECMA-376 §17.3.1.12; the left/right indents swap to
+  // physical sides in a bidi paragraph, Part 4 §14.11.2). Using the bare margin
+  // here would evaluate square-float wrap windows at the wrong X for indented /
+  // RTL paragraphs, re-introducing a paginate/render disagreement.
+  const physLeftInd = para.bidi === true ? indRight : indLeft;
+  const paraX = marginLeftPt + physLeftInd;
+  // A paragraph with no layoutable inline lines (literally empty, or only
+  // wrap-float anchors) is a single paragraph-mark line (§17.3.1.29) that cannot
+  // be split. If it doesn't fit in the space left on this page, relocate it
+  // whole to the next page — matching the wholesale break the paginator applies
+  // to unsplittable paragraphs — instead of letting the mark overflow the bottom
+  // margin (which the prior unconditional break never allowed).
+  const placeMarkOnly = (): { endY: number } => {
+    let markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
+    let top = initialY;
+    if (initialY > 0 && initialY + markH - para.spaceAfter > contentH) {
+      newPage();
+      top = 0;
+      markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
+    }
+    pages[pages.length - 1].push(para as PaginatedBodyElement);
+    return { endY: top + markH };
+  };
   const segs = buildSegments(para.runs, measureState);
   if (segs.length === 0) {
-    // No layoutable content — treat as a single empty line, fits or pushes.
-    pages[pages.length - 1].push(para as PaginatedBodyElement);
-    return { endY: initialY + estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt) };
+    return placeMarkOnly();
   }
   const wrapCtx: WrapLayoutCtx | undefined = measureState.floats.length > 0 ? {
     startPageY: measureState.y,
-    paraX: marginLeftPt,
+    paraX,
     floats: measureState.floats,
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0),
     pageH: measureState.pageH,
@@ -1191,11 +1220,9 @@ function splitParagraphAcrossPages(
   } : undefined;
   const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku);
   if (lines.length === 0) {
-    // Anchor-only paragraph: no inline lines to split, but the paragraph mark
-    // still occupies one line (§17.3.1.29). Emit it as a single unit, matching
-    // the literal-empty branch above so the renderer's one-line advance agrees.
-    pages[pages.length - 1].push(para as PaginatedBodyElement);
-    return { endY: initialY + estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt) };
+    // Anchor-only paragraph: no inline lines, but the paragraph mark still
+    // occupies one (possibly relocated) line (§17.3.1.29).
+    return placeMarkOnly();
   }
   const paraHasRuby = paragraphHasRuby(para);
 
@@ -1236,6 +1263,31 @@ function splitParagraphAcrossPages(
       // First page, first line doesn't fit — force-emit it and let it overflow.
       lastFitting = firstFitting + 1;
       usedH += lineHeights[firstFitting];
+    }
+    // ECMA-376 §17.3.1.44 widowControl (default ON): keep at least two lines of
+    // the paragraph together across a page break — never strand a single trailing
+    // line on a later page (widow) nor a single leading line at a page bottom
+    // (orphan). Skipped when w:widowControl is explicitly off
+    // (para.widowControl === false). Only applies when lines actually carry over
+    // (lastFitting < lines.length); the final slice can legally be one line.
+    if (para.widowControl !== false && lastFitting < lines.length) {
+      // Widow: this slice would leave exactly one line for a later page. Pull one
+      // line down with it so ≥2 carry over — provided this slice keeps ≥1 line.
+      if (lines.length - lastFitting === 1 && lastFitting - firstFitting >= 2) {
+        lastFitting--;
+        usedH -= lineHeights[lastFitting];
+      }
+      // Orphan: the paragraph's first line would sit alone at this page's bottom
+      // (more lines follow). Relocate the paragraph start to the next page so it
+      // begins with ≥2 lines — only when there is room above to break from
+      // (cursorY > 0); a lone line at a fresh page top cannot be helped. Also
+      // catches the case the widow pull above just reduced to a single line.
+      if (firstFitting === 0 && lastFitting - firstFitting === 1 && cursorY > 0) {
+        newPage();
+        cursorY = 0;
+        isFirstSliceOnPage = true;
+        continue;
+      }
     }
     const isFinalSlice = lastFitting === lines.length;
     if (isFinalSlice) usedH += spaceAfter;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -883,7 +883,19 @@ export function computePages(
       const floatOverflowsHere = floatBottomOff > 0 && y + floatBottomOff > effContentH();
       const floatFitsFresh = floatBottomOff > 0 && floatBottomOff <= effContentH();
       const breakForFloat = y > 0 && floatOverflowsHere && floatFitsFresh;
-      if ((y > 0 && y + needed > effContentH()) || breakForFloat) {
+      // Does the content (+ keepNext look-ahead + newly-referenced footnote
+      // bodies) overflow the space left on this page? spaceAfter is trailing
+      // whitespace allowed to spill past the bottom margin, so it is excluded.
+      const overflowsHere = y > 0 && y + needed > effContentH();
+      // Relocate the WHOLE paragraph to a fresh page (rather than splitting its
+      // lines) only when it must stay intact AND would then fit: keepLines
+      // (§17.3.1.14 — all lines on one page), keepNext (§17.3.1.15 — stay with
+      // the next block), or a footnote it carries (§17.11 — keep the body with
+      // its reference). An ordinary paragraph is NOT relocated just for spilling
+      // past the bottom; it is split at a line boundary by the path below
+      // (Word's default behaviour). A keep-on-page float forces relocation too.
+      const keepIntact = para.keepLines || needNext > 0 || addReservePt > 0;
+      if (breakForFloat || (overflowsHere && keepIntact && needed <= effContentH())) {
         newPage();
         // newPage() cleared measureState.floats AND reset floatParaSeq to 0, so
         // this is a REPLACE of the earlier register at the top of the loop (whose
@@ -898,13 +910,20 @@ export function computePages(
         if (haveFootnotes && newRefIds.length > 0) addReservePt = sumReserve(newRefIds);
       }
 
-      // ECMA-376 doesn't say "paragraphs must fit on one page" — Word
-      // splits long paragraphs at line boundaries. If the paragraph is
-      // taller than the remaining content area, walk the laid-out lines
-      // and emit one PaginatedBodyElement slice per page.
+      // ECMA-376 places no "a paragraph must fit on one page" requirement — Word
+      // splits a paragraph at line boundaries whenever its content doesn't fit in
+      // the space left on the page. Walk the laid-out lines and emit one slice
+      // per page. The old `&& h > pageContentH * 0.5` guard (split only
+      // paragraphs taller than half a page) was a heuristic that suppressed every
+      // ordinary line-level break: a body/list paragraph that didn't fit was
+      // neither split nor (in the default case) relocated, so it overflowed and
+      // was clipped (sample-9 page-4). Gate on splittability instead — keepLines
+      // (§17.3.1.14) forbids splitting unless the paragraph cannot fit on any
+      // page (taller than the full content height), where it must split anyway.
       const pageContentH = effContentH();
       const remainingH = pageContentH - y;
-      if (h > remainingH && h > pageContentH * 0.5) {
+      const splittable = !para.keepLines || h > pageContentH;
+      if (fitHeight > remainingH && splittable) {
         const placed = splitParagraphAcrossPages(
           measureState, para, contentW, suppressBefore, section.marginLeft,
           y, pageContentH, pages,
@@ -1031,15 +1050,42 @@ function estimateParagraphHeight(
   // multiple, otherwise mixed-ruby paragraphs jitter and pagination drifts.
   const paraHasRuby = paragraphHasRuby(para);
   const grid = paraGrid(para, state);
-  let textH: number;
+  // Mirror renderParagraph's vertical advancement EXACTLY so the paginator's
+  // page-fill tracker matches where the renderer actually draws each line. With
+  // anchor floats active a paragraph's text (and even an empty paragraph mark)
+  // is pushed BELOW the float band (ECMA-376 §20.4.2.x; resolveLineFloatWindow /
+  // skipPastTopAndBottom), and that vertical displacement — not just the line
+  // heights — consumes page space. The previous estimate summed only the line
+  // heights, so the paginator under-counted full-width-float pages and packed
+  // far too much onto them (sample-9 page-4: the photo block displaced the body
+  // text, but the paginator ignored the gap and let the bullet list spill past
+  // the bottom margin). Reproduce the renderer's cursor walk:
+  //   spaceBefore → skipPastTopAndBottom → per line: max(topY) then += lineH
+  //   (empty/anchor-only: flow the mark line below the band) → spaceAfter.
+  // When no floats are active skipPastTopAndBottom is a no-op and no line carries
+  // a topY, so this collapses to spaceBefore + Σ lineHeights + spaceAfter — the
+  // exact previous value, leaving float-free documents unchanged.
+  const hasFloats = state.floats.length > 0;
+  const startY = state.y;
+  let cursor = startY + (suppressSpaceBefore ? 0 : para.spaceBefore);
+  if (hasFloats) cursor = skipPastTopAndBottom(cursor, state.floats);
+  const flowMarkLine = (): void => {
+    // Empty / anchor-only paragraph: one paragraph-mark line box, flowed below a
+    // full-width float band exactly like renderEmptyMarkParagraph.
+    if (hasFloats) {
+      const win = resolveLineFloatWindow(cursor, paragraphMarkEmPx(para, 1), 10, paraXPt, paraW, state.floats);
+      if (win.topY > cursor) cursor = win.topY;
+    }
+    cursor += paragraphMarkLineHeight(para, 1, grid, paraHasRuby);
+  };
   if (segs.length === 0) {
-    textH = paragraphMarkLineHeight(para, 1, grid, paraHasRuby);
+    flowMarkLine();
   } else {
-    // When anchor-image floats are active on the current page the paragraph
-    // wraps around them, adding lines compared to a full-width layout. Use
-    // the same WrapLayoutCtx the renderer uses so estimate and render agree.
-    const wrapCtx: WrapLayoutCtx | undefined = state.floats.length > 0 ? {
-      startPageY: state.y,
+    // Same WrapLayoutCtx the renderer uses (startPageY is the post-spaceBefore,
+    // post-skip top — matching renderParagraph) so the laid-out line `topY`s
+    // and line count agree with the paint pass.
+    const wrapCtx: WrapLayoutCtx | undefined = hasFloats ? {
+      startPageY: cursor,
       paraX: paraXPt,
       floats: state.floats,
       lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0),
@@ -1048,10 +1094,9 @@ function estimateParagraphHeight(
     } : undefined;
     const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku);
     if (lines.length === 0) {
-      // Anchor-only paragraph: layoutLines placed no inline content but the
-      // paragraph mark still occupies one line (§17.3.1.29) — mirror the
-      // renderer so pagination math agrees.
-      textH = paragraphMarkLineHeight(para, 1, grid, paraHasRuby);
+      // Anchor-only paragraph: no inline content, but the paragraph mark still
+      // occupies one (possibly flowed) line (§17.3.1.29).
+      flowMarkLine();
     } else if (paraHasRuby) {
       // Word uses the same line height for every line in a ruby paragraph,
       // snapped to an integer docGrid pitch.
@@ -1060,12 +1105,19 @@ function estimateParagraphHeight(
         grid,
         1,
       );
-      textH = uniform * lines.length;
+      for (const l of lines) {
+        if (l.topY !== undefined && l.topY > cursor) cursor = l.topY;
+        cursor += uniform;
+      }
     } else {
-      textH = lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, false, l.intendedSingle), 0);
+      for (const l of lines) {
+        if (l.topY !== undefined && l.topY > cursor) cursor = l.topY;
+        cursor += lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, false, l.intendedSingle);
+      }
     }
   }
-  return textH + (suppressSpaceBefore ? 0 : para.spaceBefore) + para.spaceAfter;
+  cursor += para.spaceAfter;
+  return cursor - startY;
 }
 
 /** Snap a paragraph's uniform line height up to an integer multiple of the


### PR DESCRIPTION
> **Stacked on #457** (the float-displacement pagination fix). This branch is based on it; merge #457 first, then this PR's diff reduces to the docGrid commit (`26f1998`). The docGrid change depends on #457's `estimateParagraphHeight` rewrite, so it cannot be rebased onto `main` independently until #457 lands.

## Problem

In a document grid (`w:docGrid w:type="lines"`), a line taller than the grid pitch must reserve **whole grid cells**. `pdftotext -bbox` of the sample-9 Word PDF proves it: a **20pt CJK title on a 20pt `linePitch` is 40px = 2 cells**, while an 11pt body is 20px = 1 cell. `lineBoxHeight` instead used `max(natural, pitch)`, capping the CJK title at ~1 cell. That halved sample-9's title block, so the body started a page early and **every page boundary cascaded off Word** (page-2 began mid-table instead of at "2. 実験方法").

A Latin-only line is **not** cell-rounded — it keeps its natural height above a one-cell floor (demo/sample-1's 18pt heading on an 18pt pitch stays ~natural, not 36px). A naïve `ceil` on every grid line regresses it, so the rounding must be gated on the line's script.

## Spec basis

ECMA-376 Part 1 defines docGrid line height only for `natural ≤ pitch` (§17.6.5 / §17.3.1.32 — "add pitch up to one cell"). The cell rounding for taller **East Asian** lines is **Word runtime behaviour**, not in Part 1; implementing it was approved as a separate task per `packages/docx/CLAUDE.md`'s "reverse-engineering Word runtime needs approval" rule. The rule was derived from `-bbox` measurements of both a CJK doc (sample-9 → 2 cells) and a Latin doc (demo/sample-1 → natural), not curve-fit to one sample.

## Change

- `lineBoxHeight` gains an `eastAsian` flag: East Asian → `ceil(glyphNatural / pitch) * pitch`; Latin → `max(glyphNatural, pitch)` (unchanged). Canvas glyph metrics suffice (CJK 20pt ~22px → 2 cells, 11pt ~13px → 1 cell) — **no font-metrics entry, no sample-specific constant**.
- Text lines classify via `paragraphIsEastAsian(para)` — a CJK **content** test (Unicode ranges), not a font-name heuristic.
- Empty / anchor-only marks carry no text, so their rounding is gated on a document-level `docEastAsian` signal threaded through `RenderState`, and the mark height is measured from the real East Asian font box so it rounds to the right cell count. **Latin documents (`docEastAsian=false`) are byte-for-byte unchanged.**

## Result

sample-9's title block now matches Word: **page-2 starts "2. 実験方法", page-3 starts the 表2 body table** (was page-2 starting mid-table) — a large step toward Word's pagination.

## Known residual (separate, pre-existing — NOT this change)

A 1–2 paragraph offset remains on later pages. Root cause is a **line-WRAPPING width** difference, not line height: the 1.目的 intro wraps to **3 lines in our render vs Word's 2**, so a trailing blank line spills to the next page and the boundary drifts. That is the known substituted-font char-width residual (`±1–2px/line`), independent of the docGrid line-height behaviour fixed here.

## Verification

- VRT 21/21 unchanged (demo/sample-1 100%, all private samples unchanged)
- 83 unit tests pass — adds `lineBoxHeight` East-Asian cell-rounding cases (CJK ceil, Latin max, short-line single cell, >2-cell, off-grid, default-Latin)
- typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)