### PR TITLE
chore(release): 0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.61.0 — 2026-06-15
+
+Minor: docx pagination fidelity — floating-object displacement, line-level page
+breaks with widow/orphan control, and document-grid line heights — plus shared
+arc shape rendering.
+
+### docx
+
+- Account for floating-object vertical displacement in pagination. Body text
+  pushed below a full-width anchor-float band (ECMA-376 §20.4.2.x) now consumes
+  page space in the paginator exactly as it does in the renderer, so a paragraph
+  no longer spills past the bottom margin and is clipped (sample-9 page 4). (#457)
+- Split an overflowing paragraph at a line boundary instead of relocating it
+  whole, honoring `keepLines` (§17.3.1.14) and `widowControl` (§17.3.1.44 — keep
+  ≥2 lines together across a page break). Replaces a `h > ½ page` heuristic that
+  suppressed ordinary line-level breaks. (#457)
+- Round document-grid line heights up to whole grid cells for East Asian lines
+  (§17.6.5 / §17.3.1.32): a CJK line taller than the pitch reserves two cells; a
+  Latin line keeps its natural height. Fixes compressed CJK title blocks that
+  cascaded every page boundary off Word. (#458)
+
+### shapes (docx + pptx)
+
+- Render the `arc` preset through the shared preset engine so docx and pptx draw
+  it identically, and gate connector arrow heads on line geometry. (#455)
+
 ## 0.60.2 — 2026-06-15
 
 Patch: docx connector arrow-head correctness.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.60.2",
+  "version": "0.61.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.60.2",
+  "version": "0.61.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.60.2",
+  "version": "0.61.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.60.2",
+  "version": "0.61.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.60.2",
+  "version": "0.61.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.60.2",
+  "version": "0.61.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.60.2",
+  "version": "0.61.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.60.2",
+  "version": "0.61.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.61.0 — docx pagination fidelity + shared arc rendering.

Bundles the already-merged docx pagination work (#457, #458) and the arc shape fix
(#455) into a release: version bump (8 packages → 0.61.0) and CHANGELOG.

### docx (#457, #458)
- Floating-object vertical displacement is now counted in pagination, so content
  no longer overflows the bottom margin and clips (sample-9 page 4).
- Paragraphs split at line boundaries (keepLines §17.3.1.14, widowControl
  §17.3.1.44) instead of a `h > ½ page` heuristic.
- Document-grid line heights round to whole cells for East Asian lines
  (§17.6.5 / §17.3.1.32); Latin lines keep natural height.

### shapes (#455)
- `arc` renders through the shared docx/pptx preset engine; connector arrow heads
  gated on line geometry.

No public API change (no site/api-reference update). README hero screenshots
unchanged (docx hero = demo/sample-1, a Latin doc — VRT 100%; pptx/xlsx heroes
unaffected). Feature table rows for docGrid / widowControl were already ✅
(precision improvement only). VRT 21/21; 83 docx unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)