### PR TITLE
fix(site): re-selecting the same file on /try re-renders the preview

### DIFF
--- a/site/src/pages/try.astro
+++ b/site/src/pages/try.astro
@@ -94,7 +94,16 @@ import Nav from '../components/Nav.astro';
       }
     }
 
-    input.addEventListener('change', () => { const f = input.files?.[0]; if (f) void handle(f); });
+    // Reset the value after capturing the file so re-selecting the SAME file
+    // fires `change` again. Returning to this page via browser back/forward
+    // reloads it but Chromium restores the file input's value to the previously
+    // chosen file; without this reset, re-picking that same file emits no
+    // `change` event and nothing renders.
+    input.addEventListener('change', () => {
+      const f = input.files?.[0];
+      input.value = '';
+      if (f) void handle(f);
+    });
     ['dragenter', 'dragover'].forEach((ev) =>
       dz.addEventListener(ev, (e) => { e.preventDefault(); dz.classList.add('over'); }));
     ['dragleave', 'drop'].forEach((ev) =>


### PR DESCRIPTION
## Bug
On the showcase site: Home → **Try yours** (`/try`) → choose a file → preview renders. Then browser **Back** → Home, browser **Forward** → `/try`, choose the **same file** again → **preview does not render**.

## Root cause (confirmed in a real browser, not assumed)
- The site has no Astro View Transitions, so Forward-nav **fully reloads** `/try` (the module script re-runs) — it is *not* bfcache.
- However Chromium's **form-control state restoration** re-populates the file input's value with the previously chosen file after the reload.
- `try.astro`'s `change` handler never reset `input.value` (only the "Try another →" button did). A file `<input>` fires no `change` when the **same** file is re-picked — so with the value restored to that file, re-picking it emits no `change` and nothing renders.

A discriminating browser test confirmed the viewer/WASM is fully alive (a *different* file renders; clearing the value then re-picking the same file renders) — the only break was the un-reset `input.value`.

## Fix
Reset `input.value = ''` right after capturing the file in the `change` handler, so the same selection always re-fires `change` (and the post-selection away-state value is empty, so history-nav restoration restores an empty input).

```js
input.addEventListener('change', () => {
  const f = input.files?.[0];
  input.value = '';
  if (f) void handle(f);
});
```

## Verification (chromium, Playwright)
- After every selection `#file.value === ''`.
- Same-file `setInputFiles` twice → renders both times (changeCount 1→2; pre-fix the 2nd was a no-op).
- Back/forward flow → restored input value is empty, re-pick renders. No console errors. ✅

Single-file change; client-only; no API/behavior change elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)