### PR TITLE
fix(pptx): render a:sym symbol-font runs (Wingdings arrows) instead of tofu

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -327,6 +327,13 @@ export interface TextRunData {
    * present; absent means CJK falls back to fontFamily.
    */
   fontFamilyEa?: string;
+  /**
+   * Symbol font family from rPr > a:sym (ECMA-376 §21.1.2.3.10), resolved
+   * through the theme. PowerPoint stores symbol-font glyphs as Private-Use
+   * codepoints U+F020–U+F0FF; the renderer uses this font to resolve them.
+   * Absent means no symbol font was declared.
+   */
+  fontFamilySym?: string;
   /** Baseline shift in thousandths of a point. Positive = superscript, negative = subscript. */
   baseline?: number;
   /**

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1528,6 +1528,11 @@ struct TextRunData {
     /// ECMA-376 §21.1.2.3.7 (CT_TextFont, ea variant).
     #[serde(skip_serializing_if = "Option::is_none")]
     font_family_ea: Option<String>,
+    /// Symbol font family from rPr > sym (resolved through the theme).
+    /// Renderer uses this for symbol-range PUA glyphs (U+F0xx).
+    /// ECMA-376 §21.1.2.3.10 (CT_TextFont, sym variant).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_family_sym: Option<String>,
     /// Baseline shift in thousandths of a point. Positive = superscript, negative = subscript.
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline: Option<i32>,
@@ -4402,6 +4407,7 @@ fn parse_paragraph(
                     color,
                     font_family,
                     font_family_ea: None,
+                    font_family_sym: None,
                     baseline: None,
                     caps: None,
                     letter_spacing: None,
@@ -4602,6 +4608,19 @@ fn parse_run(
         .map(|tf| resolve_theme_typeface(&tf, theme))
         .filter(|tf| !tf.is_empty());
 
+    // ECMA-376 §21.1.2.3.10 — <a:sym typeface="..."/> sets the font used for
+    // symbol characters. PowerPoint stores those as PUA codepoints (U+F0xx).
+    let font_family_sym = r_pr
+        .and_then(|n| child(n, "sym"))
+        .and_then(|n| attr(&n, "typeface"))
+        .or_else(|| {
+            def_rpr
+                .and_then(|n| child(n, "sym"))
+                .and_then(|n| attr(&n, "typeface"))
+        })
+        .map(|tf| resolve_theme_typeface(&tf, theme))
+        .filter(|tf| !tf.is_empty());
+
     // baseline in thousandths of a point; 30000=superscript, -25000=subscript (OOXML typical)
     let baseline = r_pr
         .and_then(|n| attr(&n, "baseline"))
@@ -4648,6 +4667,7 @@ fn parse_run(
         color,
         font_family,
         font_family_ea,
+        font_family_sym,
         baseline,
         caps,
         letter_spacing,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -400,6 +400,13 @@ const WINGDINGS_MAP: Record<number, string> = {
   0x76: '✔', 0xFC: '✓', 0xFB: '✗', 0xFE: '■',
   0xA7: '▪', 0xB7: '•', 0xB8: '◦', 0xB9: '–',
   0xF0A7: '▪', 0xF0B7: '•',
+  // Wingdings barb2 arrow block — glyph names verified against the Wingdings
+  // cmap (0xDF=barb2left … 0xE6=barb2se). Mapped to Unicode arrows so they
+  // render in any font even when Wingdings is unavailable.
+  0xDF: '←', 0xE0: '→', 0xE1: '↑', 0xE2: '↓',
+  0xE3: '↖', 0xE4: '↗', 0xE5: '↙', 0xE6: '↘',
+  0xF0DF: '←', 0xF0E0: '→', 0xF0E1: '↑', 0xF0E2: '↓',
+  0xF0E3: '↖', 0xF0E4: '↗', 0xF0E5: '↙', 0xF0E6: '↘',
 };
 
 function applySymbolFont(char: string, fontFamily: string): string {
@@ -755,6 +762,10 @@ function layoutParagraph(
     const familyEa = run.fontFamilyEa
       ? normalizeFontFamily(run.fontFamilyEa, rc)
       : null;
+    // Symbol font (rPr > a:sym) — used for Private-Use symbol glyphs (U+F0xx).
+    const familySym = run.fontFamilySym
+      ? normalizeFontFamily(run.fontFamilySym, rc)
+      : null;
     // Hyperlink runs without an explicit colour pick up the theme hlink colour
     // (ECMA-376 §20.1.2.3.5 — hyperlinks inherit theme hyperlink slot).
     let color: string;
@@ -841,6 +852,35 @@ function layoutParagraph(
       // If already in tab mode, collect all text into tabStop.segments (no wrap)
       if (tabActive) {
         push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
+        continue;
+      }
+
+      // ── Symbol-font characters (Wingdings/Webdings/Symbol) ───────────────
+      // PowerPoint stores symbol glyphs as Private-Use codepoints U+F020–U+F0FF
+      // and picks the font via rPr > a:sym (ECMA-376 §21.1.2.3.10). Map the
+      // known ones to Unicode equivalents so they render reliably regardless of
+      // whether the symbol font is installed; fall back to the real symbol font
+      // for unmapped glyphs.
+      const SYMBOL_PUA_RE = /[-]/;
+      if (SYMBOL_PUA_RE.test(token) && (familySym || /wingding|webding|symbol/i.test(family))) {
+        const symName = familySym ?? family;
+        for (const ch of token) {
+          let drawCh = ch;
+          let chFont = font;
+          if (SYMBOL_PUA_RE.test(ch)) {
+            const mapped = applySymbolFont(ch, symName);
+            if (mapped !== ch) {
+              drawCh = mapped;
+              chFont = buildFont(isBold, isItalic, sizePx, 'sans-serif', rc);
+            } else {
+              chFont = buildFont(isBold, isItalic, sizePx, symName, rc);
+            }
+          }
+          ctx.font = chFont;
+          const chW = ctx.measureText(drawCh).width;
+          if (lineW + chW > maxWidthPx && lineW > 0) newLine();
+          push(drawCh, chFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
+        }
         continue;
       }
 


### PR DESCRIPTION
## Problem
private/sample-8 slide-16 rendered its left arrows as missing-glyph boxes (tofu, □).

## Root cause
The arrow is character **U+F0DF** = Wingdings glyph `barb2left`. PowerPoint stores symbol-font glyphs in the Private-Use Area (`0xF000 + original byte`) and selects the font via `<a:sym typeface="Wingdings"/>`, **not** `<a:latin>`. The pptx parser read `latin`/`ea` but **dropped `a:sym`**, so the run inherited the body font (Arial), which has no glyph at U+F0DF → tofu. (Wingdings on macOS has only a symbol cmap (3,0) and no Unicode cmap, so direct font rendering is environment-fragile anyway.)

## Fix (ECMA-376 §21.1.2.3.10, mirrors the existing `fontFamilyEa` slot)
- **core**: add `fontFamilySym?` to the shared `TextRunData` contract type.
- **pptx parser**: parse `<a:sym typeface>` into `font_family_sym` (theme-resolved).
- **pptx renderer**: route Private-Use symbol chars (U+F020–U+F0FF) through the existing `applySymbolFont`/`WINGDINGS_MAP` path, extended with the Wingdings barb2 arrow block (`← → ↑ ↓ ↖ ↗ ↙ ↘`). Mapped glyphs render reliably in any font; unmapped ones fall back to the real symbol font.

General fix for Wingdings/Symbol symbol runs in body text — not a slide-16-specific patch.

## Verification
- slide-16 now shows the three left arrows correctly (manually rendered & inspected).
- VRT regression: private sample-1–6 + demo unchanged (the symbol path only fires on tokens containing U+F020–U+F0FF).
- `cargo test` 49 passed; tsc + ast-grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)