### PR TITLE
fix(core): scale chart axis-line widths by ptToPx (match chart border)

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -626,8 +626,14 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // default (gridlines stand in), so only draw it when the file specifies one.
   const catLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#aaa';
   const valLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#aaa';
-  const catLineW = chart.catAxisLineWidthEmu ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) : 1;
-  const valLineW = chart.valAxisLineWidthEmu ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) : 1;
+  // Axis line weights from `<c:*Ax><c:spPr><a:ln@w>` (EMU). `ctx.lineWidth`
+  // is in CANVAS pixels, so the point width must be multiplied by `ptToPx`
+  // (px-per-point at the display scale: ~1.333 for xlsx 96dpi, ~1.05 for
+  // pptx) — exactly like the chart-border code in renderChart. Without it the
+  // rule is under-scaled on HiDPI/zoomed canvases. The `: 1` fallback (no
+  // explicit `@w`) stays a 1px hairline.
+  const catLineW = chart.catAxisLineWidthEmu ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
+  const valLineW = chart.valAxisLineWidthEmu ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
   const strokeAxis = (x1: number, y1: number, x2: number, y2: number, color: string, lw: number): void => {
     ctx.strokeStyle = color; ctx.lineWidth = lw;
     ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
@@ -1438,7 +1444,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
       const yAxisLineWidth = chart.valAxisLineWidthEmu
-        ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) : undefined;
+        ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx : undefined;
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, yAxisLineColor, yAxisLineWidth);
     }
   }
@@ -1474,7 +1480,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.save();
     ctx.strokeStyle = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#888';
     ctx.lineWidth = chart.catAxisLineWidthEmu
-      ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT)
+      ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx
       : 1;
     ctx.lineCap = 'butt';
     ctx.beginPath(); ctx.moveTo(px0, xAxisY); ctx.lineTo(px0 + pw, xAxisY); ctx.stroke();
@@ -1484,7 +1490,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.save();
     ctx.strokeStyle = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#888';
     ctx.lineWidth = chart.valAxisLineWidthEmu
-      ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT)
+      ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx
       : 1;
     ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
     ctx.restore();
@@ -1509,7 +1515,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode), gx, xAxisY + 4);
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
       const xAxisLineWidth = chart.catAxisLineWidthEmu
-        ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) : undefined;
+        ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx : undefined;
       drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, xAxisLineWidth);
     }
   }


### PR DESCRIPTION
## Bug

Chart **axis-line** and **tick-mark** widths in `packages/core/src/chart/renderer.ts` converted EMU→points and assigned the result straight to `ctx.lineWidth` (which is in **canvas pixels**) **without** multiplying by `ptToPx`. On HiDPI/zoomed canvases this under-scales the axis rule: xlsx renders at `ptToPx = PT_TO_PX * cs ≈ 1.333` (96 dpi, `1pt = 4/3 px`), pptx ≈ 1.05. A `<c:catAx><c:spPr><a:ln w="9525">` (0.75 pt) line therefore drew at 0.75 px instead of the correct 1.0 px.

The chart-**border** code in the same file (`renderChart`, ~L2152) already does it correctly:

```ts
ctx.lineWidth = chart.chartBorderWidthEmu
  ? Math.max(0.5, chart.chartBorderWidthEmu / EMU_PER_PT) * ptToPx
  : 1;
```

## Fix

Bring every axis-line / tick-mark width onto the same `* ptToPx` convention. The only two render functions that read `*AxisLineWidthEmu` are `renderBarChart` and `renderScatterChart` (both take `ptToPx` as a param); all five sites are fixed:

- `renderBarChart`: `catLineW`, `valLineW` (axis lines) — + explanatory comment on the convention.
- `renderScatterChart`: cat-axis line, val-axis line, and the cat/val **major tick-mark** widths passed to `drawAxisTick`.

The `: 1` fallback (no explicit `<a:ln w>`) intentionally **stays a 1 px hairline** — only the explicit-EMU branch is scaled. Line/area/radar/pie axis code uses hardcoded stroke widths and does not consume `*AxisLineWidthEmu`, so it is unaffected.

## Inert for default-width charts

The change only alters output for charts that declare an explicit `<c:catAx|valAx><c:spPr><a:ln w="…">` (or explicit tick-mark widths) **and** only at `ptToPx ≠ 1`. Default-width charts (no explicit `@w`) hit the `: 1` hairline branch and are byte-for-byte unchanged.

## VRT impact (references are user-gated — not updated here)

VRT is local-only; only `demo/*` references are committed (`private/*` are gitignored). I scanned the committed chart samples and inspected the **runtime** chart models the xlsx renderer feeds to `renderChart`:

- **`demo/sample-1.xlsx`** — declares `<a:ln w="9525">` (0.75 pt) on every axis, but the visible charts at the default sheet view are **line** (sheet "Carbon & Growth", ×2) and **radar** (sheet "Biodiversity Index"), which route through `renderLineChart` / `renderRadarChart` — both **untouched** and neither reads `*AxisLineWidthEmu`. The one **bar** chart ("Species Analysis") that *would* route through `renderBarChart` is anchored off the default scroll viewport, so `renderChart` is never invoked for it. Net: **no committed reference image changes.**
- **`demo/sample-1.pptx`** — a single **line** chart → `renderLineChart` (untouched) → **no change.**

Verified by rendering `demo/sample-1.xlsx` sheets through the VRT fixture before vs after the patch: the exported canvases were **byte-identical** (md5 match), consistent with the patched paths (bar/scatter) not being exercised by any committed reference. Runtime probe confirmed the visible charts report `type=line`/`type=radar` with `ptToPx=1.3333`.

`private/*` samples that *do* declare explicit axis widths (e.g. sample-16/17/18/26/9 xlsx, sample-2 pptx, where bar/scatter axes are visible) may shift by up to ~+0.25 px on the affected axis line; those references are gitignored and **user-gated** — not regenerated in this PR.

## Verification

- `pnpm --filter @silurus/ooxml-core typecheck` — clean (exit 0).
- Code matches the chart-border `* ptToPx` convention exactly; the change is a single multiplicative factor on the explicit-EMU branch.