### PR TITLE
refactor(core): share value-axis scaling helper

### DIFF
--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { niceStep, niceAxisMax, niceAxisMin } from './axis-scale.js';
+import { niceStep, niceAxisMax, niceAxisMin, valueAxisScale } from './axis-scale.js';
 
 describe('niceStep', () => {
   it('picks 1/2/5 × 10ⁿ for ~5 gridlines', () => {
@@ -42,5 +42,38 @@ describe('niceAxisMin', () => {
   });
   it('data exactly on a gridline drops one extra step', () => {
     expect(niceAxisMin(-20, 10)).toBe(-30);
+  });
+});
+
+describe('valueAxisScale (one niceStep drives min, max and gridline step)', () => {
+  it('positive data anchored at 0 (bar/area/radar style)', () => {
+    // step = niceStep(41-0) = niceStep(41) = 10; min = 0; max = niceAxisMax(41,10,0) = 50
+    expect(valueAxisScale(0, 41)).toEqual({ min: 0, max: 50, step: 10 });
+  });
+  it('negative data floors the min and widens the max with the niced min', () => {
+    // step = niceStep(100-(-15)) = niceStep(115) = 20;
+    // min = niceAxisMin(-15,20) = -20; max = niceAxisMax(100,20,-20) = ceil((100+6)/20)*20 = 120
+    expect(valueAxisScale(-15, 100)).toEqual({ min: -20, max: 120, step: 20 });
+  });
+  it('explicit min/max override the computed bounds (step still from data range)', () => {
+    // step = niceStep(41-0) = 10; explicit min -5, max 60 win
+    expect(valueAxisScale(0, 41, -5, 60)).toEqual({ min: -5, max: 60, step: 10 });
+  });
+  it('a null explicit bound falls back to the auto value', () => {
+    expect(valueAxisScale(0, 41, null, 60)).toEqual({ min: 0, max: 60, step: 10 });
+    expect(valueAxisScale(0, 41, -5, null)).toEqual({ min: -5, max: 50, step: 10 });
+  });
+  it('data 3.5 → max 4 with step 0.5 (fine-grained positive range)', () => {
+    // step = niceStep(3.5) = 0.5; min = 0; max = niceAxisMax(3.5,0.5,0):
+    //   3.5 + 3.5/20 = 3.675 → ceil(3.675/0.5)*0.5 = 4
+    expect(valueAxisScale(0, 3.5)).toEqual({ min: 0, max: 4, step: 0.5 });
+  });
+  it('data 0.1129 → max 0.12 with step 0.02 (sub-unit range)', () => {
+    // step = niceStep(0.1129) = 0.02; min = 0;
+    //   0.1129 + 0.1129/20 = 0.118545 → ceil(0.118545/0.02)*0.02 = 0.12
+    const { min, max, step } = valueAxisScale(0, 0.1129);
+    expect(min).toBe(0);
+    expect(step).toBeCloseTo(0.02, 12);
+    expect(max).toBeCloseTo(0.12, 12);
   });
 });

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -38,3 +38,17 @@ export function niceAxisMin(dataMin: number, step: number): number {
   const ax = Math.floor(dataMin / step) * step;
   return Math.abs(ax - dataMin) < step * 1e-9 ? ax - step : ax;
 }
+
+/** Excel-style auto value-axis bounds + major unit. ONE `niceStep` (of the data
+ *  range) drives the rounded min, max AND the gridline step, so they can never
+ *  desync. Explicit `<c:valAx><c:scaling><c:min/max>` wins. The auto major unit
+ *  is Excel-proprietary (not in ECMA-376); niceStep approximates it. */
+export function valueAxisScale(
+  dataMin: number, dataMax: number,
+  explicitMin?: number | null, explicitMax?: number | null,
+): { min: number; max: number; step: number } {
+  const step = niceStep(dataMax - dataMin);
+  const min = explicitMin ?? niceAxisMin(dataMin, step);
+  const max = explicitMax ?? niceAxisMax(dataMax, step, min);
+  return { min, max, step };
+}

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -4,7 +4,7 @@
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
 import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
-import { niceStep, niceAxisMax, niceAxisMin } from './axis-scale.js';
+import { niceStep, valueAxisScale } from './axis-scale.js';
 import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
 import { hexToRgba } from '../shape/paint.js';
 import { EMU_PER_PT, PT_TO_PX } from '../units.js';
@@ -578,8 +578,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   if (chart.valMax != null) dataMax = chart.valMax;
   if (dataMax === 0) dataMax = 1;
 
-  const step  = niceStep(dataMax);
-  const axMax = chart.valMax ?? niceAxisMax(dataMax, step);
+  // Bar/column anchors the value axis at 0; ignore the returned min.
+  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax);
 
   const gridColor = '#e0e0e0';
   const steps = Math.round(axMax / step);
@@ -877,9 +877,7 @@ function renderLineChart(
   else if (dataMax < 0) dataMax = 0;
   if (dataMax === dataMin) dataMax = dataMin + 1;
 
-  const step  = niceStep(dataMax - dataMin);
-  const axMin = chart.valMin ?? niceAxisMin(dataMin, step);
-  const axMax = chart.valMax ?? niceAxisMax(dataMax, step);
+  const { min: axMin, max: axMax, step } = valueAxisScale(dataMin, dataMax, chart.valMin, chart.valMax);
   const range = axMax - axMin; if (range === 0) return;
 
   const toY = (v: number) => py0 + ph - ((v - axMin) / range) * ph;
@@ -1025,8 +1023,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   }
   if (chart.valMax != null) dataMax = chart.valMax;
   if (dataMax === 0) dataMax = 1;
-  const step  = niceStep(dataMax);
-  const axMax = chart.valMax ?? niceAxisMax(dataMax, step);
+  // Area anchors the value axis at 0; ignore the returned min.
+  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax);
 
   const toX = (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
   const toY = (v: number) => py0 + ph - (v / axMax) * ph;
@@ -1215,8 +1213,8 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
   for (const s of chart.series) for (const v of s.values) dataMax = Math.max(dataMax, v ?? 0);
   if (chart.valMax != null) dataMax = chart.valMax;
   if (dataMax === 0) dataMax = 1;
-  const step  = niceStep(dataMax);
-  const axMax = chart.valMax ?? niceAxisMax(dataMax, step);
+  // Radar anchors the value axis at 0; ignore the returned min.
+  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax);
 
   const angle0 = -Math.PI / 2;
   const spoke  = (i: number) => angle0 + (i / n) * Math.PI * 2;
@@ -1413,20 +1411,19 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   else if (yMin > 0) yMin = 0;
   if (chart.valMax != null) yMax = chart.valMax;
   // Auto value (Y) axis: ONE major unit (the "nice" step) drives both the
-  // rounded maximum and the gridlines — identical to bar/line/area. niceAxisMax
+  // rounded bounds and the gridlines — identical to bar/line/area. niceAxisMax
   // adds ~5% headroom above the data max and rounds up to that step, so the top
   // point sits below the top gridline (data 3.5 → step 0.5, max 4 → 0,.5,…,4;
   // 0.1129 → step 0.02, max 0.12). The step is taken from the DATA range and
-  // reused for the gridline loop below — recomputing it on the rounded range
-  // would wrongly coarsen it (niceStep(4)=1 vs the 0.5 Excel uses for 0–4).
-  // Explicit <c:valAx><c:scaling> wins. NB: the auto major unit is not specified
-  // by ECMA-376 (Excel-proprietary); niceStep approximates it and may differ
-  // from Excel by one step on some ranges.
-  const yAxisStep = niceStep(yMax - yMin);
-  if (yAxisStep > 0) {
-    if (chart.valMin == null) yMin = niceAxisMin(yMin, yAxisStep);
-    if (chart.valMax == null) yMax = niceAxisMax(yMax, yAxisStep, yMin);
-  }
+  // reused for the gridline loop below. The post-anchor yMin (which already had
+  // chart.valMin and the >0→0 anchor applied above) is the data extent; passing
+  // chart.valMin/valMax as the explicit args reproduces the prior `?? niceAxis…`
+  // behavior exactly. Explicit <c:valAx><c:scaling> wins. NB: the auto major
+  // unit is not specified by ECMA-376 (Excel-proprietary); niceStep approximates
+  // it and may differ from Excel by one step on some ranges.
+  const { min: niceYMin, max: niceYMax, step: yAxisStep } =
+    valueAxisScale(yMin, yMax, chart.valMin, chart.valMax);
+  yMin = niceYMin; yMax = niceYMax;
   if (chart.catAxisMin != null) xMin = chart.catAxisMin;
   if (chart.catAxisMax != null) xMax = chart.catAxisMax;
   // Excel snaps auto-derived axis bounds outward to a multiple of the
@@ -1448,10 +1445,9 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   if (!chart.valAxisHidden) {
     const yTickFontPx = Math.max(8, Math.min(11, ph / 20));
     ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${yTickFontPx}px sans-serif`;
-    const yStep = yAxisStep;
-    const ySteps = Math.round((yMax - yMin) / yStep) + 1;
+    const ySteps = Math.round((yMax - yMin) / yAxisStep) + 1;
     for (let si = 0; si < ySteps; si++) {
-      const v = yMin + si * yStep; if (v > yMax + yStep * 0.01) break;
+      const v = yMin + si * yAxisStep; if (v > yMax + yAxisStep * 0.01) break;
       const gy = toY(v);
       ctx.strokeStyle = '#e0e0e0'; ctx.lineWidth = 0.5;
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();


### PR DESCRIPTION
## What

Extracts a single `valueAxisScale(dataMin, dataMax, explicitMin?, explicitMax?)` helper in `packages/core/src/chart/axis-scale.ts` and repoints all five value-axis chart renderers (`renderBarChart`, `renderLineChart`, `renderAreaChart`, the radar variant, `renderScatterChart`) in `packages/core/src/chart/renderer.ts` to use it.

One `niceStep` (of the data range) now drives the rounded min, the rounded max, **and** the gridline step, so they can never desync. Explicit `<c:valAx><c:scaling><c:min/max>` still wins via the `explicit ?? auto` fallback.

Each renderer keeps its own data-extent scan; only the nice-scaling tail is shared:
- **bar / area / radar** — pass `dataMin = 0` (they anchor the value axis at 0) and ignore the returned `min`.
- **line** — pass scanned `dataMin`/`dataMax` + `chart.valMin`/`valMax`.
- **scatter** — keep the existing `>0 → 0` anchor and explicit-extent lines that compute the pre-nice `yMin`/`yMax`, feed them through the helper, and drop the local `yStep` indirection.

## Why

The five renderers each repeated the same incantation (`niceStep` on the data range, then `niceAxisMin`/`niceAxisMax` on the rounded bounds). Centralizing removes the duplication and the desync risk, and gives the math its own unit tests.

## Sole behavioral delta

Byte-identical to the prior code for **bar/area/radar** (`dataMin = 0`), **scatter** (already called `niceAxisMax` 3-arg), and **line charts with non-negative data**.

The **only** intended change: **line charts whose data goes negative**. The old line code called the 2-arg `niceAxisMax(dataMax, step)` (so `dataMin` defaulted to `0`); the helper calls `niceAxisMax(dataMax, step, nicedMin)` with the niced negative min, giving slightly more headroom — which is **more** faithful to `niceAxisMax`'s documented `(Ymax − Ymin)/20` algorithm. (For non-negative data `niceAxisMin` returns `0`, so the niced min passed in is `0` and the two forms coincide — hence no change for positive line charts.)

## Verification

- `pnpm --filter @silurus/ooxml-core typecheck` — clean.
- `vitest run packages/core/src/chart/axis-scale.test.ts` — 15 passed, incl. 6 new `valueAxisScale` cases (positive/anchored-at-0, negative, explicit override, null-fallback, `3.5 → {4, step 0.5}`, `0.1129 → {0.12, step 0.02}`).
- **Same-machine before/after demo-render diff** (stash → render origin/main → pop → render working tree → pixelmatch), avoiding cross-machine text-render noise: **0 diff pixels across all 14 committed demo charts** — xlsx `demo/sample-1` sheets 1–5 (bar, line, line, radar) and pptx `demo/sample-1` slides 1–9 (incl. a line chart). All three demo line charts have non-negative value-series data (xlsx: dataMin 2015; pptx: explicit min=60/max=72), so the line-negative-data path is not exercised by any demo — confirming the refactor is a no-op for committed demos. `UPDATE_REFS` was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)