### PR TITLE
perf(pptx): avoid redundant full-size Blob copy of media in presentation handle

### DIFF
--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -76,7 +76,13 @@ export async function createPresentationHandle(
     } catch {
       continue;
     }
-    const typed = new Blob([blob], { type: el.mimeType || blob.type });
+    // getMedia already types the blob in main mode; re-wrapping copies the whole
+    // payload, so only do it when the type is actually missing/wrong (worker mode
+    // returns an untyped blob). This avoids duplicating large media — a 200 MB
+    // embedded video would otherwise be copied just to stamp its MIME type.
+    const desiredType = el.mimeType || blob.type;
+    const typed =
+      blob.type === desiredType ? blob : new Blob([blob], { type: desiredType });
     const url = URL.createObjectURL(typed);
     const media: HTMLVideoElement | HTMLAudioElement = el.mediaKind === 'video'
       ? document.createElement('video')


### PR DESCRIPTION
`createPresentationHandle` unconditionally re-wrapped every media `Blob` in `new Blob([blob], { type })` just to stamp its MIME type, copying the entire payload a second time on the main thread. In **main** mode `getMedia` already returns a correctly-typed `Blob`, so the re-wrap is pure waste; only **worker** mode returns an untyped `Blob` that genuinely needs re-typing. This change re-wraps only when `blob.type` doesn't already match the desired type, skipping the allocation otherwise.

The fix is behavior-preserving: the resulting `Blob`'s `.type` and bytes are identical in every case — it merely avoids the duplicate allocation when the type already matches. It was found while debugging a sample with a ~200 MB embedded video, where navigating to the slide duplicated 200 MB for no reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)