### PR TITLE
chore(release): 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.62.0 — 2026-06-16
+
+Minor: chart axis titles, borders and value-axis scaling across Excel and
+PowerPoint charts; PowerPoint symbol-font runs; plus soft-edge and
+embedded-media fixes.
+
+### charts (xlsx + pptx)
+
+- Render chart axis titles at their XML font size / weight / colour, anchored in
+  a reserved gutter so they no longer collide with the tick labels, and default
+  axis and chart titles to bold (ECMA-376 ST_Style). Extract the scatter
+  bottom-axis (X) title, which had been dropped for every scatter chart. (#460, #464)
+- Draw a chart-space border when `<c:chartSpace><c:spPr><a:ln>` specifies one,
+  and scale axis-line and border widths by `ptToPx`. (#460, #463)
+- Extend the value axis to Excel's "nice" maximum (a one major-unit margin above
+  the data) and share a single rounding rule for the axis bounds and gridline
+  step across bar / line / area / radar / scatter (`valueAxisScale()`). (#465, #467)
+- Hoist the chart title / axis-title / border extractors into `ooxml-common`,
+  shared by the xlsx and pptx parsers. (#464)
+
+### pptx
+
+- Render `a:sym` symbol-font runs (e.g. Wingdings arrows) instead of tofu. (#462)
+- Stop copying large embedded media a second time when building the playback
+  handle, so navigating to a slide with a ~200 MB embedded video no longer
+  duplicates it on the main thread. (#468)
+
+### core
+
+- Match PowerPoint's soft-edge feather (`softEdge`, §20.1.8.31): build an opaque
+  edge-clamped colour layer and replace its alpha with a blurred silhouette
+  (σ = rad/3), so the perimeter dissolves symmetrically instead of leaving a
+  hard outer step. (#469)
+
+### xlsx
+
+- Scale multi-line cell text line-height and decoration offsets by the cell
+  display scale, so they stay proportional at any zoom. (#466)
+
+### site
+
+- Reset the file input so re-selecting the same file on the “try yours” page
+  re-renders the preview. (#461)
+
 ## 0.61.0 — 2026-06-15
 
 Minor: docx pagination fidelity — floating-object displacement, line-level page

--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Per-run underline colour (`uFill` / `uFillTx`) | ✅ |
 | | Font family, size, color | ✅ |
 | | East Asian font (`rPr > a:ea` — separate typeface for CJK glyphs) | ✅ |
+| | Symbol font runs (`a:sym` — e.g. Wingdings / Webdings glyphs) | ✅ |
 | | Caps transform (`all` / `small`) | ✅ |
 | | Letter spacing (`spc`) | ✅ |
 | | Superscript / subscript | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.62.0 — docs + version bump only (no source changes).

## Summary

- **charts (xlsx + pptx)**: render axis titles at their XML font size/weight/colour in a reserved gutter, default axis/chart titles to bold (ST_Style), extract the scatter X-axis title; draw a chart-space border from `<c:chartSpace><c:spPr><a:ln>` and scale line/border widths by `ptToPx`; extend the value axis to Excel's "nice" maximum with a shared rounding rule across bar/line/area/radar/scatter (`valueAxisScale()`); hoist the title/axis-title/border extractors into `ooxml-common`.
- **pptx**: render `a:sym` symbol-font runs (e.g. Wingdings) instead of tofu; stop duplicating large embedded media on the main thread when building the playback handle.
- **core**: match PowerPoint's `softEdge` feather (§20.1.8.31) — opaque edge-clamped colour layer with a blurred-silhouette alpha (σ = rad/3) so the perimeter dissolves symmetrically.
- **xlsx**: scale multi-line cell line-height and decoration offsets by the cell display scale so they stay proportional at any zoom.
- **site**: reset the file input so re-selecting the same file on the "try yours" page re-renders the preview.

## README / CHANGELOG

- New PowerPoint feature row: Symbol font runs (`a:sym`).
- CHANGELOG 0.62.0 section added; version bumped to 0.62.0 across all 8 packages.

Screenshots unchanged: this release's visual changes don't appear in the hero samples, and re-shooting pptx on this machine risks text-baseline noise.

## Included PRs

#460, #461, #462, #463, #464, #465, #466, #467, #468, #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)