### PR TITLE
refactor(core): hoist default scheme-slot color map to ooxml-common

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -470,14 +470,10 @@ impl ThemeColors {
     }
 
     fn resolve(&self, scheme_name: &str) -> Option<String> {
-        // "bg1"/"bg2"/"tx1"/"tx2" map onto lt1/lt2/dk1/dk2 per spec
-        let key = match scheme_name {
-            "bg1" => "lt1",
-            "bg2" => "lt2",
-            "tx1" => "dk1",
-            "tx2" => "dk2",
-            other => other,
-        };
+        // bg1/bg2/tx1/tx2 map onto lt1/lt2/dk1/dk2 per the default §19.3.1.6
+        // clrMap; raw slot names (and accents/hlink) pass through unchanged.
+        // Canonical table: ooxml_common::color::SCHEME_DEFAULT_SLOTS.
+        let key = ooxml_common::color::default_scheme_slot(scheme_name);
         self.map.get(key).cloned()
     }
 

--- a/packages/ooxml-common/src/color.rs
+++ b/packages/ooxml-common/src/color.rs
@@ -13,6 +13,57 @@
 
 use roxmltree::Node;
 
+/// Default DrawingML logical-color → theme scheme-slot mapping
+/// (ECMA-376 §19.3.1.6 `clrMap` / CT_ColorMapping, with the standard
+/// PowerPoint default attribute values).
+///
+/// A theme's `<a:clrScheme>` stores twelve named slots — `dk1`, `lt1`, `dk2`,
+/// `lt2`, `accent1`..`accent6`, `hlink`, `folHlink`. Documents reference colors
+/// by *logical* name (`bg1`, `tx1`, `bg2`, `tx2`, the accents, and the two
+/// hyperlink names) and a `clrMap` indirection layer resolves each logical name
+/// to a slot. When no explicit `clrMap` override is present the default mapping
+/// applies:
+///
+/// - `bg1` → `lt1`, `tx1` → `dk1` (background 1 is the light slot, text 1 the
+///   dark slot)
+/// - `bg2` → `lt2`, `tx2` → `dk2`
+/// - `accent1`..`accent6`, `hlink`, `folHlink` map to the identically named slot
+///
+/// This is the single source of truth for that default table. Each parser keeps
+/// its own *resolution* (storage layout and per-app tint), but the logical→slot
+/// names live here. See also [`default_scheme_slot`] for a lookup that also
+/// accepts a raw slot name and returns it unchanged.
+pub const SCHEME_DEFAULT_SLOTS: &[(&str, &str)] = &[
+    ("bg1", "lt1"),
+    ("tx1", "dk1"),
+    ("bg2", "lt2"),
+    ("tx2", "dk2"),
+    ("accent1", "accent1"),
+    ("accent2", "accent2"),
+    ("accent3", "accent3"),
+    ("accent4", "accent4"),
+    ("accent5", "accent5"),
+    ("accent6", "accent6"),
+    ("hlink", "hlink"),
+    ("folHlink", "folHlink"),
+];
+
+/// Resolve a DrawingML color name to its default theme scheme slot
+/// (ECMA-376 §19.3.1.6, default `clrMap`).
+///
+/// Logical names listed in [`SCHEME_DEFAULT_SLOTS`] (`bg1`/`tx1`/`bg2`/`tx2`)
+/// map to their slot; every other input — including the raw slot names
+/// (`dk1`, `lt1`, …), the accents and the hyperlink names — is returned
+/// unchanged. This mirrors how a parser walks a `schemeClr@val` that may carry
+/// either a logical name *or* a slot name and wants the underlying slot.
+pub fn default_scheme_slot(name: &str) -> &str {
+    SCHEME_DEFAULT_SLOTS
+        .iter()
+        .find(|(logical, _)| *logical == name)
+        .map(|(_, slot)| *slot)
+        .unwrap_or(name)
+}
+
 /// Selects the formula applied to `<a:tint val>` modifiers. The OOXML spec
 /// is consistent (val = retained input), but the two desktop apps render
 /// templates differently in practice — see ECMA-376 §20.1.2.3.34 and the
@@ -248,4 +299,49 @@ pub fn hls_to_rgb(h: f64, l: f64, s: f64) -> (f64, f64, f64) {
         hue2rgb(p, q, h),
         hue2rgb(p, q, h - 1.0 / 3.0),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the default §19.3.1.6 logical→slot table so the three parsers that
+    /// consume it can't drift. The twelve pairs are exactly the PowerPoint
+    /// default `clrMap`.
+    #[test]
+    fn scheme_default_slots_match_spec() {
+        assert_eq!(
+            SCHEME_DEFAULT_SLOTS,
+            &[
+                ("bg1", "lt1"),
+                ("tx1", "dk1"),
+                ("bg2", "lt2"),
+                ("tx2", "dk2"),
+                ("accent1", "accent1"),
+                ("accent2", "accent2"),
+                ("accent3", "accent3"),
+                ("accent4", "accent4"),
+                ("accent5", "accent5"),
+                ("accent6", "accent6"),
+                ("hlink", "hlink"),
+                ("folHlink", "folHlink"),
+            ]
+        );
+    }
+
+    #[test]
+    fn default_scheme_slot_maps_logicals_and_passes_through_slots() {
+        // Logical names resolve to their slot.
+        assert_eq!(default_scheme_slot("bg1"), "lt1");
+        assert_eq!(default_scheme_slot("tx1"), "dk1");
+        assert_eq!(default_scheme_slot("bg2"), "lt2");
+        assert_eq!(default_scheme_slot("tx2"), "dk2");
+        // Raw slot names and accents/hyperlinks pass through unchanged.
+        assert_eq!(default_scheme_slot("dk1"), "dk1");
+        assert_eq!(default_scheme_slot("lt1"), "lt1");
+        assert_eq!(default_scheme_slot("accent3"), "accent3");
+        assert_eq!(default_scheme_slot("hlink"), "hlink");
+        // Unknown input is returned verbatim (caller decides what to do).
+        assert_eq!(default_scheme_slot("phClr"), "phClr");
+    }
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2014,20 +2014,9 @@ fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
 /// attribute is absent: bg1=lt1, tx1=dk1, bg2=lt2, tx2=dk2, accentN identity,
 /// hlink/folHlink identity. Shared by `<p:clrMap>` (§19.3.1.6) and
 /// `<a:overrideClrMapping>` (§20.1.6.8), which carry the identical attribute set.
-const CLR_MAP_LOGICALS: &[(&str, &str)] = &[
-    ("bg1", "lt1"),
-    ("tx1", "dk1"),
-    ("bg2", "lt2"),
-    ("tx2", "dk2"),
-    ("accent1", "accent1"),
-    ("accent2", "accent2"),
-    ("accent3", "accent3"),
-    ("accent4", "accent4"),
-    ("accent5", "accent5"),
-    ("accent6", "accent6"),
-    ("hlink", "hlink"),
-    ("folHlink", "folHlink"),
-];
+/// Aliases `ooxml_common::color::SCHEME_DEFAULT_SLOTS` so the default §19.3.1.6
+/// table lives in exactly one place across the workspace.
+const CLR_MAP_LOGICALS: &[(&str, &str)] = ooxml_common::color::SCHEME_DEFAULT_SLOTS;
 
 /// Read the 12 `CT_ColorMapping` attributes (§19.3.1.6) from `node` into an owned
 /// `{logical → slot}` map. Works for both `<p:clrMap>` and
@@ -2171,15 +2160,16 @@ fn parse_color_node_tint(
                     let hex = hex.clone();
                     return Some(xform(&hex, c));
                 }
+                // Canonical logical→slot fallback, per the default §19.3.1.6
+                // clrMap (shared table: ooxml_common::color::SCHEME_DEFAULT_SLOTS).
+                // The helper also passes raw slot names (dk1/lt1/…) and accents
+                // through unchanged.
                 let canonical: &str = match scheme_name.as_str() {
-                    "tx1" | "dk1" => "dk1",
-                    "tx2" | "dk2" => "dk2",
-                    "bg1" | "lt1" => "lt1",
-                    "bg2" | "lt2" => "lt2",
                     // phClr = "placeholder color" (inherits from layout).
-                    // Approximate as the primary dark text color.
+                    // Approximate as the primary dark text color. Not part of
+                    // §19.3.1.6, so it stays a local special case.
                     "phClr" => "dk1",
-                    other => other,
+                    other => ooxml_common::color::default_scheme_slot(other),
                 };
                 let base_hex = theme.get(canonical)?.clone();
                 return Some(xform(&base_hex, c));

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -406,6 +406,9 @@ pub(crate) fn resolve_color_attrs(
     //   0=lt1, 1=dk1, 2=lt2, 3=dk2, 4..11 unchanged.
     // This is a well-known interoperability quirk (see Open-XML-SDK issue #46
     // and ECMA-376 §22.1.2.7 where "index values of 0 and 1 are swapped").
+    // This is an index→index remap, not a logical→slot-name mapping, so the
+    // shared ooxml_common::color::SCHEME_DEFAULT_SLOTS table (the canonical
+    // §19.3.1.6 logical→slot names) does not apply here; this stays local.
     if let Some(theme_str) = theme {
         if let Ok(idx) = theme_str.parse::<usize>() {
             let mapped = match idx {
@@ -1644,6 +1647,15 @@ pub(crate) fn resolve_fill_color(
         }
         if tag == "schemeClr" {
             if let Some(v) = n.attribute("val") {
+                // ooxml_common::color::SCHEME_DEFAULT_SLOTS is the canonical
+                // logical→slot-NAME table (§19.3.1.6). xlsx instead maps the
+                // logical/slot name straight to a numeric INDEX into the theme
+                // color Vec (raw clrScheme order: dk1=0, lt1=1, dk2=2, lt2=3,
+                // accent1..6=4..9, hlink=10, folHlink=11). Routing through the
+                // shared name→name table would add an indirection without
+                // changing the result, so this stays local. (Note: the cell
+                // @theme path below applies the §22.1.2.7 dk1↔lt1 / dk2↔lt2
+                // index swap; this drawing path indexes the array directly.)
                 let idx = match v {
                     "dk1" | "tx1" => Some(0),
                     "lt1" | "bg1" => Some(1),


### PR DESCRIPTION
## Goal

Establish one source of truth for the default DrawingML logical→scheme-slot color mapping (ECMA-376 §19.3.1.6: `bg1`→`lt1`, `tx1`→`dk1`, `bg2`→`lt2`, `tx2`→`dk2`, `accentN`/`hlink`/`folHlink` identity), which was duplicated across the three parsers (flagged during the #474 review). A spec correction to the default table should land once, not four times.

## Changes

- **ooxml-common** (`src/color.rs`): add `pub const SCHEME_DEFAULT_SLOTS: &[(&str,&str)]` (the 12-pair table) and a `default_scheme_slot(name)` helper that maps a logical name to its slot and passes raw slot names / accents / hyperlinks through unchanged. Two unit tests pin the table and the helper.
- **pptx** (`parser/src/lib.rs`): `CLR_MAP_LOGICALS` now **aliases** `SCHEME_DEFAULT_SLOTS` (no more literal copy); the `parse_color_node_tint` canonical fallback uses `default_scheme_slot` (keeping `phClr` as a local approximation — it is not part of §19.3.1.6).
- **docx** (`parser/src/parser.rs`): `ThemeColors::resolve` uses `default_scheme_slot`.
- **xlsx** (`parser/src/lib.rs`): **left local, by design**, with comments explaining why. Its two maps resolve a logical/slot name to a **numeric index** into the theme color `Vec` and apply the Excel `dk1↔lt1` / `dk2↔lt2` index swap (§22.1.2.7) — a different representation that the name→slot table does not fit. Forcing it through the shared table would add indirection without changing results and risk obscuring the quirk.

`ooxml-common`'s per-crate `ColorResolver` design is intentionally unchanged — scheme *resolution* stays per-crate (storage `HashMap` vs `Vec`; Word vs PowerPoint tint); only the default-slot **constant** is shared.

## No behavior change

Every parser's existing tests pass with **identical counts** — docx 43, pptx 70, xlsx 50, mcp-server 41 — the only delta is +2 new `ooxml-common` tests (35 → 37). All three CI gates green locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)