### PR TITLE
fix(docx): keep 字下げ indent fixed under justification & apply kinsoku across runs

### DIFF
--- a/packages/docx/src/kinsoku.test.ts
+++ b/packages/docx/src/kinsoku.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   kinsokuAdjustedSplit,
+  crossRunKinsokuRetract,
   resolveKinsokuRules,
   DEFAULT_KINSOKU_RULES,
 } from './renderer.js';
@@ -152,5 +153,48 @@ describe('resolveKinsokuRules — §17.15.1.59/.60 custom sets REPLACE defaults'
     const rules = resolveKinsokuRules({ noLineBreaksBefore: '' });
     expect(rules.lineStartForbidden.size).toBe(0);
     expect(kinsokuAdjustedSplit(cp('あいの、うえ'), 3, rules)).toBe(3);
+  });
+});
+
+describe('crossRunKinsokuRetract — cross-run 行頭禁則 (追い出し across segments)', () => {
+  const R = DEFAULT_KINSOKU_RULES;
+
+  it('pulls the last grapheme down so the next line does not begin with 、', () => {
+    // current line last segment "…を表", overflowing run begins "、". Pull 表.
+    expect(crossRunKinsokuRetract(cp('を表'), R, 0)).toBe(1);
+  });
+
+  it('does not retract below minKeep (single-char-only segment stays put)', () => {
+    // last segment is "5" alone and is the line's only segment → minKeep 1.
+    expect(crossRunKinsokuRetract(cp('5'), R, 1)).toBe(0);
+  });
+
+  it('may empty a non-final segment (minKeep 0) — pulls its single char', () => {
+    expect(crossRunKinsokuRetract(cp('5'), R, 0)).toBe(1);
+  });
+
+  it('never orphans a whitespace at the next line start — pulls more', () => {
+    // last chars "A " → k=1 would put a space at line start; pull "A " (k=2).
+    expect(crossRunKinsokuRetract(cp('A '), R, 0)).toBe(2);
+  });
+
+  it('keeps pulling past a char that is itself line-start-forbidden', () => {
+    // last char 。 is start-forbidden → leading with it just moves the problem;
+    // pull "あ。" so あ leads the next line.
+    expect(crossRunKinsokuRetract(cp('あ。'), R, 0)).toBe(2);
+  });
+
+  it('does not leave the current line ending on a line-end-forbidden opener', () => {
+    // retracting just "x" would dangle 「 at the current line end → pull "「x".
+    expect(crossRunKinsokuRetract(cp('「x'), R, 0)).toBe(2);
+  });
+
+  it('returns 0 when kinsoku is disabled', () => {
+    expect(crossRunKinsokuRetract(cp('を表'), resolveKinsokuRules({ kinsoku: false }), 0)).toBe(0);
+  });
+
+  it('returns 0 when no legal non-whitespace retraction exists within minKeep', () => {
+    // only a trailing space available and minKeep forbids pulling the rest.
+    expect(crossRunKinsokuRetract(cp('X '), R, 1)).toBe(0);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2230,13 +2230,27 @@ function renderParagraph(
     // space, and is only applied when the line is a candidate for justification
     // (jc=both/distribute, not the last line unless distribute).
     let extraPerSpace = 0;
+    // First content segment in reading order. Leading-whitespace segments before
+    // it (a paragraph's 字下げ indent) are NOT stretched by justification — Word
+    // keeps the indent fixed and distributes slack only across the line content
+    // (§17.18.44). Only meaningful for LTR: under bidi the logical-leading
+    // segment is not the visually-leading one, so leave the skip off (0) there.
+    let firstContentSi = 0;
     if (applyJustify) {
+      if (!paraNeedsBidi) {
+        for (let i = 0; i < segCount; i++) {
+          const seg = line.segments[i];
+          if (!('text' in seg) || /\S/.test((seg as LayoutTextSeg).text)) { firstContentSi = i; break; }
+        }
+      }
       let totalTrailingSpaces = 0;
       for (let si = 0; si < segCount; si++) {
         const seg = line.segments[si];
         // Trailing spaces on the visually-final segment don't stretch (they sit
         // at the physical line end) — same domain as the draw-loop skip below.
         if (si === lastDrawnSi) continue;
+        // Leading 字下げ whitespace is not an inter-word gap — don't stretch it.
+        if (si < firstContentSi) continue;
         if ('text' in seg) totalTrailingSpaces += countTrailingSpaces((seg as LayoutTextSeg).text);
       }
       const slack = effAvailW - (x - lineLeft) - lineWidth;
@@ -2368,8 +2382,9 @@ function renderParagraph(
       x += s.measuredWidth;
       // Inter-word justification slack (applied AFTER the segment so the next
       // segment starts at a shifted baseline). Skip on the final segment —
-      // trailing spaces at line end don't participate in stretching.
-      if (extraPerSpace > 0 && !isLastSeg) {
+      // trailing spaces at line end don't participate in stretching — and on the
+      // leading 字下げ whitespace (si < firstContentSi), which stays fixed.
+      if (extraPerSpace > 0 && !isLastSeg && si >= firstContentSi) {
         const trailing = countTrailingSpaces(s.text);
         if (trailing > 0) x += trailing * extraPerSpace;
       }
@@ -2895,6 +2910,45 @@ export function kinsokuAdjustedSplit(
     return splitAt;
   }
   return s;
+}
+
+/**
+ * Cross-run 行頭禁則 (追い出し) helper. `kinsokuAdjustedSplit` only retracts
+ * WITHIN the run being wrapped; when a line-start-forbidden char is the FIRST
+ * code point of its run, the preceding character lives in an earlier segment on
+ * the current line, so the offending char would be orphaned at the next line's
+ * start. Given the current line's last text segment's code points (`lastChars`)
+ * and that the overflowing run begins with a 行頭禁則 char, decide how many
+ * trailing graphemes of `lastChars` to pull down so they lead the next line
+ * ahead of that run.
+ *
+ * Returns the count k (≥1) to retract, or 0 to leave the line as-is (fall back).
+ * Mirrors `kinsokuAdjustedSplit`'s bounded loop and re-validation: the pulled-down
+ * graphemes must (1) start with a non-whitespace char that is itself NOT
+ * line-start-forbidden (else the violation just moves), and (2) leave the
+ * current line ending on a char that is NOT line-end-forbidden. `minKeep` is the
+ * fewest code points that must remain on the current line (0 when other segments
+ * precede this one, 1 when it is the only segment — never empty the line).
+ *
+ * ECMA-376 §17.3.1.16 (kinsoku toggle + default forbidden sets); §17.15.1.58/.59
+ * (`noLineBreaksAfter` / `noLineBreaksBefore` custom sets).
+ */
+export function crossRunKinsokuRetract(
+  lastChars: string[],
+  rules: KinsokuRules,
+  minKeep: number,
+): number {
+  if (!rules.enabled) return 0;
+  const maxRetract = lastChars.length - minKeep;
+  for (let k = 1; k <= maxRetract; k++) {
+    const lead = lastChars[lastChars.length - k]; // becomes the next line's start
+    if (/\s/.test(lead)) continue; // never orphan a whitespace at the line start
+    if (rules.lineStartForbidden.has(lead.codePointAt(0)!)) continue; // still illegal — pull more
+    const end = lastChars[lastChars.length - k - 1]; // new current-line end (may be undefined)
+    if (end && rules.lineEndForbidden.has(end.codePointAt(0)!)) continue; // would dangle an opener
+    return k;
+  }
+  return 0;
 }
 
 /**
@@ -3435,9 +3489,40 @@ function layoutLines(
         const tail = s.text.slice(prefix.length);
         if (tail) queue.unshift({ ...s, text: tail, measuredWidth: 0 });
       } else if (currentLine.length > 0) {
-        // No prefix fits but line has content — flush and retry on a fresh line
+        // No prefix of `s` fits. If `s` would lead the next line with a 行頭禁則
+        // char, kinsokuAdjustedSplit can't fix it from within `s` (the offending
+        // char is its first); pull trailing graphemes of the current line's last
+        // text segment down so they lead the next line ahead of `s` — cross-run
+        // 追い出し (§17.3.1.16). See crossRunKinsokuRetract for the bounded,
+        // re-validating, whitespace-guarded retraction count.
+        let retracted: LayoutTextSeg | null = null;
+        const sFirstCp = s.text.codePointAt(0);
+        const lastSeg = currentLine[currentLine.length - 1];
+        if (sFirstCp !== undefined && kinsoku.lineStartForbidden.has(sFirstCp) && 'text' in lastSeg) {
+          const lastText = lastSeg as LayoutTextSeg;
+          const chars = [...lastText.text];
+          const minKeep = currentLine.length > 1 ? 0 : 1;
+          const k = crossRunKinsokuRetract(chars, kinsoku, minKeep);
+          if (k > 0) {
+            const headText = chars.slice(0, chars.length - k).join('');
+            const tailText = chars.slice(chars.length - k).join('');
+            retracted = { ...lastText, text: tailText, measuredWidth: measureText({ ...lastText, text: tailText }).width };
+            if (headText) {
+              const headW = measureText({ ...lastText, text: headText }).width;
+              currentWidth -= lastText.measuredWidth - headW;
+              currentLine[currentLine.length - 1] = { ...lastText, text: headText, measuredWidth: headW };
+            } else {
+              // Whole last segment moves down. Line metrics (ascent/descent) are
+              // not recomputed; the retracted graphemes share the line's font in
+              // practice, so the flushed box height is unaffected.
+              currentWidth -= lastText.measuredWidth;
+              currentLine.pop();
+            }
+          }
+        }
         flush();
         queue.unshift(s);
+        if (retracted) queue.unshift(retracted);
       } else {
         // Empty line and not even one char fits — force-fit one char to guarantee progress
         const firstChar = [...s.text][0] ?? '';


### PR DESCRIPTION
Two Japanese line-layout defects, reported on `private/sample-9.docx`.

## 1. Justification stretched the leading 字下げ indent

A justified paragraph (Normal here is `jc="both"`) whose first line starts with a leading **ASCII** space — the common 全角＋半角 `"　 "` 字下げ — handed that space *all* of the line's justification slack. A CJK line has no other ASCII inter-word gaps, so the single leading space absorbed the entire slack and the first character was pushed ~1 character too far right.

> 「プラスチックケースをハサミを用いて…」の行頭が字下げされすぎ。Word では全角スペース＋半角スペース分だけ。

**Root cause:** `renderParagraph`'s justification distributes slack per trailing ASCII space, including the leading-indent space.
**Fix:** compute the first content segment of each line and skip leading-whitespace segments when both *counting* and *applying* inter-word stretch (ECMA-376 §17.18.44 — the indent is not an inter-word stretch point). Measured: the first glyph moves from x≈117 back to x≈100.8 = `paraX + 　 + space`, exactly the indent width.

## 2. Kinsoku (行頭禁則) not applied across run boundaries

`「…の測定結果を表5、…」` wrapped with the `、` orphaned at the **start** of the next line.

> 禁則処理が甘い。Word では「表5、」が2行目に来るように改行されます。

Kinsoku **is** spec-defined (ECMA-376 §17.15.1.58–.60; default ON when `<w:kinsoku>` is absent) and implemented via `kinsokuAdjustedSplit`. But that helper only retracts *within the segment being wrapped*. In this run the text is split `…を表` / `5` / `、溶液…`, so when the `、`-leading run can't fit even one char, it was flushed whole — leaving `、` at the line head.

**Fix:** in the CJK-overflow path, when a run would lead the next line with a 行頭禁則 char and no prefix fits, pull the last grapheme of the current line down to join it — cross-run 追い出し — when the current line ends in a text segment and retracting leaves it non-empty. Result: `…を表` / `5、溶液…` (the `、` is no longer orphaned).

## Scope / safety

Both triggers are narrow (leading **ASCII** space under justify; an orphaned 行頭禁則 char at a run boundary). Plain CJK 字下げ that uses only `　` (U+3000) is untouched (`countTrailingSpaces` only counts U+0020), and ordinary paragraphs are unchanged. **LTR/CJK only — RTL list geometry is left alone.**

## Verification

- sample-9: first glyph now flush after `　`+space; `…を表` / `5、…` break (kinsoku-legal).
- **docx VRT 21/21**, byte-identical to pre-change on every corpus sample (demo Word-export refs still 0-pixel). The buggy cases aren't in the VRT corpus (all non-leading-space / non-orphan), so coverage is via manual render — same corpus gap noted for lists.
- `tsc --noEmit` clean; docx unit tests 83/83.

No reference images updated.

## Not included

`private/sample-8.docx` RTL bullets are slightly misaligned because the RTL marker is placed at `text_right_edge + hanging` (per-line text width) instead of a fixed start-edge anchor. A correct fix needs RTL list start-alignment rework and is higher-risk; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)