### PR TITLE
docs: add VS Code Marketplace badge and use Title Case heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
   <img src="docs/images/icon.png" alt="office-open-xml-viewer" width="160" height="160">
 </p>
 
-# office-open-xml-viewer
+# Office Open XML Viewer
 
 [![npm version](https://img.shields.io/npm/v/@silurus/ooxml.svg)](https://www.npmjs.com/package/@silurus/ooxml)
 [![npm downloads](https://img.shields.io/npm/dm/@silurus/ooxml.svg)](https://www.npmjs.com/package/@silurus/ooxml)
+[![VS Code Marketplace](https://vsmarketplacebadges.dev/version/silurus.office-open-xml-viewer.svg)](https://marketplace.visualstudio.com/items?itemName=silurus.office-open-xml-viewer)
 [![license](https://img.shields.io/npm/l/@silurus/ooxml.svg)](./LICENSE)
 
 **[Live demo](https://ooxml.silurus.dev)**


### PR DESCRIPTION
## Summary
- Add a VS Code Marketplace version badge ([vsmarketplacebadges.dev](https://vsmarketplacebadges.dev)) linking to the published `silurus.office-open-xml-viewer` extension.
- Rename the README H1 from `office-open-xml-viewer` to **Office Open XML Viewer** (the proper ECMA-376 / ISO-29500 spec name).

README-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)