### PR TITLE
docs(pptx): restore 追い出し term in CJK cross-reference comment

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -910,7 +910,7 @@ function layoutParagraph(
         // DEFAULT_KINSOKU_RULES is correct for pptx: PresentationML has no custom
         // forbidden-set element (w:noLineBreaksBefore/After are WordprocessingML-only).
         // docx's analogous CJK path (renderer.ts, fitCJKPrefix) is intentionally
-        // separate: substring binary-search fit + cross-run carry-over. Do not unify them.
+        // separate: substring binary-search fit + cross-run 追い出し. Do not unify them.
         const measured: (MeasuredChar & { font: string })[] = [];
         for (const ch of token) {
           const chFont = CJK_RE.test(ch) ? fontEa : font;


### PR DESCRIPTION
Cosmetic follow-up to #479. The eaLnBrk commit incidentally anglicized one comment (`cross-run 追い出し` → `carry-over`) in `packages/pptx/src/renderer.ts`, leaving it inconsistent with docx (`renderer.ts`) and core (`text/kinsoku/split.ts`), which use `追い出し`. This restores the term. Comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)