### PR TITLE
feat(pptx): justify text alignment (algn just/dist, §20.1.10.59)

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2236,10 +2236,14 @@ function renderTextBody(
       alignment === 'just' || alignment === 'justLow' ? 'just' as const
       : alignment === 'dist' || alignment === 'thaiDist' ? 'dist' as const
       : null;
-    const drawSegs = justifyMode && !paraNeedsBidi
+    // A line broken at a right/centre tab stop keeps its pre-tab text natural:
+    // justifying it would spread that text across the whole column and overlap
+    // the tab-aligned remainder drawn after this loop. Skip justify for it.
+    const hasTabStop = !!line.tabStop && line.tabStop.segments.length > 0;
+    const drawSegs = justifyMode && !paraNeedsBidi && !hasTabStop
       ? justifyLine(line.segments, textMaxW - textXOffset, lineWidth, justifyMode, isLastLine)
       : null;
-    const segs = drawSegs ?? line.segments;
+    const segs: (LayoutSegment & { jext?: number })[] = drawSegs ?? line.segments;
 
     // Visual draw order: under bidi, reorder segments per UAX#9 (rule L2) and
     // draw each with ctx.direction matching its resolved direction. textAlign
@@ -2253,6 +2257,12 @@ function renderTextBody(
       const seg = segs[li];
       const segRtl = visual ? visual.rtl[li] : false;
       if (paraNeedsBidi) ctx.direction = segRtl ? 'rtl' : 'ltr';
+      // Justification advance after this piece (0 when not justifying). Added to
+      // the pen, and folded into the trailing edge of underline / strikethrough
+      // and the reported onTextRun width, so decorations and the text layer span
+      // the widened gap instead of leaving a hole. The last content piece always
+      // has jext 0 (justifyLine never stretches after the final glyph).
+      const jext = seg.jext ?? 0;
       // ── Equation segment: draw the cached image instead of text ──────────
       if (seg.math) {
         const render = mathRenders.get(seg.math.nodes);
@@ -2264,7 +2274,7 @@ function renderTextBody(
           ctx.drawImage(img, penX, top, w, h);
         }
         penX += w;
-        penX += (seg as { jext?: number }).jext ?? 0;
+        penX += jext;
         continue;
       }
       ctx.font = seg.font;
@@ -2352,7 +2362,7 @@ function renderTextBody(
           text: seg.text,
           inShapeX: penX - bx,
           inShapeY: cursorY - by,
-          w: segW,
+          w: segW + jext,
           h: lineHeight,
           fontSize: seg.sizePx,
           font: seg.font,
@@ -2365,7 +2375,7 @@ function renderTextBody(
       }
 
       if (seg.underline) {
-        drawUnderline(ctx, penX, segBaseline, segW, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle);
+        drawUnderline(ctx, penX, segBaseline, segW + jext, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle);
       }
 
       if (seg.strikethrough) {
@@ -2381,20 +2391,20 @@ function renderTextBody(
           const yMid = segBaseline - seg.sizePx * 0.32;
           ctx.beginPath();
           ctx.moveTo(penX, yMid - offset);
-          ctx.lineTo(penX + segW, yMid - offset);
+          ctx.lineTo(penX + segW + jext, yMid - offset);
           ctx.moveTo(penX, yMid + offset);
-          ctx.lineTo(penX + segW, yMid + offset);
+          ctx.lineTo(penX + segW + jext, yMid + offset);
           ctx.stroke();
         } else {
           ctx.beginPath();
           ctx.moveTo(penX, segBaseline - seg.sizePx * 0.32);
-          ctx.lineTo(penX + segW, segBaseline - seg.sizePx * 0.32);
+          ctx.lineTo(penX + segW + jext, segBaseline - seg.sizePx * 0.32);
           ctx.stroke();
         }
       }
 
       penX += segW;
-      penX += (seg as { jext?: number }).jext ?? 0;
+      penX += jext;
     }
     if (paraNeedsBidi) ctx.direction = 'ltr'; // reset before tab-stop / next line
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -65,6 +65,7 @@ import {
   type LineVisualOrder,
 } from './bidi-line';
 import { fitCjkLine, type MeasuredChar } from './cjk-wrap.js';
+import { justifyLine } from './text-justify';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -1859,6 +1860,7 @@ function renderTextBody(
     textX: number;        // canvas X for text
     textMaxW: number;     // max wrap width
     alignment: string;
+    isLastLine: boolean;
     para: Paragraph;
   }
 
@@ -2032,6 +2034,7 @@ function renderTextBody(
         bulletFont, bulletColor, bulletX,
         textX, textMaxW,
         alignment: para.alignment,
+        isLastLine: isLast,
         para,
       });
       totalHeight += linePx + topGap;
@@ -2147,7 +2150,7 @@ function renderTextBody(
   let entriesInCol = 0;
 
   for (const entry of allLines) {
-    const { line, linePx, lineHeight, topGapPx, textXOffset, bulletLabel, bulletFont, bulletColor, alignment } = entry;
+    const { line, linePx, lineHeight, topGapPx, textXOffset, bulletLabel, bulletFont, bulletColor, alignment, isLastLine } = entry;
     // Balanced column advance: when the current column has reached its share
     // of paragraphs, jump to the next one. PowerPoint never breaks a single
     // line across columns and never spills past the last column — anything
@@ -2222,16 +2225,32 @@ function renderTextBody(
       penX = effectiveTextX;
     }
 
+    // Justified alignment (ECMA-376 §20.1.10.59 ST_TextAlignType): just/justLow
+    // fill the column by widening inter-word + inter-CJK gaps with the
+    // paragraph's last line left natural; dist/thaiDist do the same on every
+    // line. Segments are merged by style in layout, so justifyLine splits each
+    // line inside its text at the gaps and returns draw pieces carrying `jext`
+    // (px to advance after each piece). penX already starts at the left edge
+    // (the `else` above). Disabled under bidi (visual≠logical order).
+    const justifyMode =
+      alignment === 'just' || alignment === 'justLow' ? 'just' as const
+      : alignment === 'dist' || alignment === 'thaiDist' ? 'dist' as const
+      : null;
+    const drawSegs = justifyMode && !paraNeedsBidi
+      ? justifyLine(line.segments, textMaxW - textXOffset, lineWidth, justifyMode, isLastLine)
+      : null;
+    const segs = drawSegs ?? line.segments;
+
     // Visual draw order: under bidi, reorder segments per UAX#9 (rule L2) and
     // draw each with ctx.direction matching its resolved direction. textAlign
     // is already 'left', so penX stays the segment's left edge.
     const visual: LineVisualOrder | null = paraNeedsBidi
       ? computeLineVisualOrder(line.segments, baseRtl)
       : null;
-    const segCount = line.segments.length;
+    const segCount = segs.length;
     for (let vi = 0; vi < segCount; vi++) {
       const li = visual ? visual.order[vi] : vi;
-      const seg = line.segments[li];
+      const seg = segs[li];
       const segRtl = visual ? visual.rtl[li] : false;
       if (paraNeedsBidi) ctx.direction = segRtl ? 'rtl' : 'ltr';
       // ── Equation segment: draw the cached image instead of text ──────────
@@ -2245,6 +2264,7 @@ function renderTextBody(
           ctx.drawImage(img, penX, top, w, h);
         }
         penX += w;
+        penX += (seg as { jext?: number }).jext ?? 0;
         continue;
       }
       ctx.font = seg.font;
@@ -2374,6 +2394,7 @@ function renderTextBody(
       }
 
       penX += segW;
+      penX += (seg as { jext?: number }).jext ?? 0;
     }
     if (paraNeedsBidi) ctx.direction = 'ltr'; // reset before tab-stop / next line
 

--- a/packages/pptx/src/text-justify.test.ts
+++ b/packages/pptx/src/text-justify.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { justifyLine } from './text-justify.js';
+
+// A laid-out line is usually ONE merged segment per style run, so the tests
+// feed whole strings (not pre-split tokens) — that is the real input shape.
+type Seg = { text?: string; tag?: string };
+
+// Collapse pieces to [text, roundedJext] tuples for compact assertions.
+const pieces = (r: ReturnType<typeof justifyLine<Seg>>) =>
+  r === null ? null : r.map((p) => [p.text, +p.jext.toFixed(3)] as const);
+
+describe('justifyLine', () => {
+  it("returns null for 'just' on the last line (short sentences stay natural)", () => {
+    expect(justifyLine<Seg>([{ text: '日本語' }], 120, 60, 'just', true)).toBeNull();
+  });
+
+  it("'dist' justifies even the last line", () => {
+    const r = justifyLine<Seg>([{ text: '日本語' }], 120, 60, 'dist', true);
+    expect(pieces(r)).toEqual([
+      ['日', 30],
+      ['本', 30],
+      ['語', 0],
+    ]);
+  });
+
+  it('pure Latin: widens each inter-word space, splitting after the spaces', () => {
+    const r = justifyLine<Seg>([{ text: 'Hello world foo' }], 200, 100, 'just', false);
+    expect(pieces(r)).toEqual([
+      ['Hello ', 50],
+      ['world ', 50],
+      ['foo', 0],
+    ]);
+  });
+
+  it('pure CJK: widens every inter-character gap except after the final glyph', () => {
+    const r = justifyLine<Seg>([{ text: '日本語' }], 120, 60, 'just', false);
+    expect(pieces(r)).toEqual([
+      ['日', 30],
+      ['本', 30],
+      ['語', 0],
+    ]);
+  });
+
+  it('mixed EC市場で: no gap inside the Latin "EC", gaps at C|市, 市|場, 場|で', () => {
+    const r = justifyLine<Seg>([{ text: 'EC市場で' }], 130, 100, 'just', false);
+    expect(pieces(r)).toEqual([
+      ['EC', 10],
+      ['市', 10],
+      ['場', 10],
+      ['で', 0],
+    ]);
+  });
+
+  it('leading 字下げ whitespace stays fixed (no stretch before first content)', () => {
+    const r = justifyLine<Seg>([{ text: '  日本語' }], 130, 100, 'just', false);
+    expect(pieces(r)).toEqual([
+      ['  日', 15],
+      ['本', 15],
+      ['語', 0],
+    ]);
+  });
+
+  it('trailing whitespace at line end does not stretch', () => {
+    const r = justifyLine<Seg>([{ text: '日本 ' }], 100, 60, 'just', false);
+    expect(pieces(r)).toEqual([
+      ['日', 40],
+      ['本 ', 0],
+    ]);
+  });
+
+  it('evaluates CJK boundaries across a style (segment) boundary', () => {
+    const r = justifyLine<Seg>(
+      [
+        { text: '日本', tag: 'a' },
+        { text: '語', tag: 'b' },
+      ],
+      120,
+      60,
+      'just',
+      false,
+    );
+    expect(r).not.toBeNull();
+    expect(r!.map((p) => [p.text, +p.jext.toFixed(3), p.tag])).toEqual([
+      ['日', 30, 'a'],
+      ['本', 30, 'a'],
+      ['語', 0, 'b'],
+    ]);
+  });
+
+  it('an inline object (text===undefined) is one unit and can take a gap', () => {
+    const r = justifyLine<Seg>([{ text: '日' }, {}, { text: '本' }], 100, 60, 'just', false);
+    // gaps after 日 and after the object → perGap = 40/2 = 20
+    expect(r).not.toBeNull();
+    expect(r!.map((p) => [p.text, +p.jext.toFixed(3)])).toEqual([
+      ['日', 20],
+      [undefined, 20],
+      ['本', 0],
+    ]);
+  });
+
+  it('the jext advances sum to the slack (line reaches availWidth)', () => {
+    const r = justifyLine<Seg>([{ text: 'Hello world foo bar' }], 300, 120, 'just', false);
+    const sum = r!.reduce((a, p) => a + p.jext, 0);
+    expect(sum).toBeCloseTo(180, 6);
+  });
+
+  it('returns null when there is no slack to distribute', () => {
+    expect(justifyLine<Seg>([{ text: '日本語' }], 60.2, 60, 'just', false)).toBeNull();
+  });
+
+  it('returns null for a single Latin word (no inner gap)', () => {
+    expect(justifyLine<Seg>([{ text: 'Hello' }], 200, 50, 'just', false)).toBeNull();
+  });
+
+  it('returns null for a single CJK glyph (one content unit)', () => {
+    expect(justifyLine<Seg>([{ text: '日' }], 200, 20, 'just', false)).toBeNull();
+  });
+
+  it('preserves all style fields on every split piece', () => {
+    const r = justifyLine<Seg>([{ text: '日本語', tag: 'x' }], 120, 60, 'just', false);
+    expect(r!.every((p) => p.tag === 'x')).toBe(true);
+  });
+});

--- a/packages/pptx/src/text-justify.ts
+++ b/packages/pptx/src/text-justify.ts
@@ -10,6 +10,17 @@
 // — same distribution, only the kashida/glyph-stretch sophistication differs,
 // which Canvas cannot reproduce — so we treat just≡justLow and dist≡thaiDist.
 //
+// `just` and `dist` use the SAME gap selection (inter-word AND inter-CJK) and
+// differ ONLY in the last line (just: natural, dist: filled). This is
+// intentionally NOT WordprocessingML's ST_Jc model (§17.18.44), where `both`
+// stretches inter-word space only and `distribute` adds inter-character pitch:
+// DrawingML/PowerPoint justifies CJK under `just` too — a pure-CJK `just` line
+// fills to the column edge in PowerPoint (its same-name PDF is the ground truth
+// here; §17.18.44 governs Word, not PowerPoint). The spec's "smart … does not
+// justify sentences which are short" clause is realized as the last-line rule
+// only; no length threshold is invented for other short lines (the spec gives
+// no metric, and a guess would be a heuristic).
+//
 // Why character-level, not segment-level: the layout merges adjacent
 // same-style tokens into ONE segment (see layoutParagraph's `push`/`sameMeta`),
 // so a plain paragraph line is usually a single segment holding the whole
@@ -23,6 +34,12 @@
 // px to advance AFTER drawing it. The renderer simply draws each piece and adds
 // its `jext` — the existing glyph paths are untouched. The sum of all `jext`
 // equals the slack, so the painted line reaches `availWidth`.
+//
+// Splits land only at gap positions (inter-word spaces and inter-CJK
+// boundaries), never inside a Latin word, so a split never cuts a kerning pair
+// or ligature. The per-piece advance widths the renderer re-measures therefore
+// sum to the whole-line `naturalWidth` passed in, and the painted line lands on
+// `availWidth` without measurement drift.
 
 /** Mirrors the CJK ranges the layout uses to allow a break between adjacent
  *  characters (CJK punctuation & Unified incl. Ext-A, Hangul syllables, CJK

--- a/packages/pptx/src/text-justify.ts
+++ b/packages/pptx/src/text-justify.ts
@@ -1,0 +1,150 @@
+// Justified text alignment for the pptx renderer.
+//
+// DrawingML offers four "fill the column" alignments (ECMA-376 §20.1.10.59
+// ST_TextAlignType): `just` and `justLow` justify a line by widening its
+// inter-word and inter-CJK gaps to reach the column width, leaving the
+// paragraph's LAST line natural (the spec notes it "does not justify
+// sentences which are short"); `dist` and `thaiDist` distribute the same way
+// but justify EVERY line, the last included ("Distributes the text words
+// across an entire text line"). justLow/thaiDist are the low-quality variants
+// — same distribution, only the kashida/glyph-stretch sophistication differs,
+// which Canvas cannot reproduce — so we treat just≡justLow and dist≡thaiDist.
+//
+// Why character-level, not segment-level: the layout merges adjacent
+// same-style tokens into ONE segment (see layoutParagraph's `push`/`sameMeta`),
+// so a plain paragraph line is usually a single segment holding the whole
+// string. Justification therefore has to look INSIDE each segment's text: a
+// stretch opportunity is an inter-word space OR an inter-CJK boundary anywhere
+// in the line's character stream (boundaries are evaluated across segment
+// edges too, so a colour change mid-word doesn't suppress a gap).
+//
+// `justifyLine` returns the line re-expressed as draw pieces: each input
+// segment is split at the gap positions, and every piece carries `jext`, the
+// px to advance AFTER drawing it. The renderer simply draws each piece and adds
+// its `jext` — the existing glyph paths are untouched. The sum of all `jext`
+// equals the slack, so the painted line reaches `availWidth`.
+
+/** Mirrors the CJK ranges the layout uses to allow a break between adjacent
+ *  characters (CJK punctuation & Unified incl. Ext-A, Hangul syllables, CJK
+ *  Compatibility Ideographs, and the Halfwidth/Fullwidth forms). A boundary is
+ *  a stretch opportunity when either side is one of these glyphs. U+3000
+ *  (ideographic space) is classified as whitespace below, so it never reaches
+ *  this test. */
+const CJK_RE = /[、-鿿가-퟿豈-﫿＀-￯]/;
+
+/** A laid-out segment as seen by the justifier. Only the optional text matters;
+ *  an undefined `text` marks an inline object (math / image), which is one
+ *  opaque unit that bears no stretch of its own (a CJK neighbour can still open
+ *  a gap against it). The generic `T` lets the renderer pass its full LayoutSeg
+ *  and get pieces that keep every style field, plus `jext`. */
+export interface JustifySeg {
+  text?: string;
+}
+
+export type JustifyMode = 'just' | 'dist';
+
+const isWsChar = (ch: string): boolean => /\s/.test(ch);
+
+/**
+ * Split one laid-out line into draw pieces that fill `availWidth` when each
+ * piece's `jext` is added to the pen after it is drawn.
+ *
+ * @param segments    The line's segments in logical order (LTR only — the
+ *                    renderer disables justification under bidi).
+ * @param availWidth  Content width to fill, px.
+ * @param naturalWidth Sum of the segments' natural advance widths, px.
+ * @param mode        'just' (last line stays natural) or 'dist' (every line).
+ * @param isLastLine  Whether this is the paragraph's final line.
+ * @returns The pieces (each a shallow copy of its source segment with sliced
+ *          `text` and a `jext` advance), or `null` when no justification
+ *          applies (last line under `just`, no slack, no stretchable gap, …).
+ */
+export function justifyLine<T extends JustifySeg>(
+  segments: readonly T[],
+  availWidth: number,
+  naturalWidth: number,
+  mode: JustifyMode,
+  isLastLine: boolean,
+): (T & { jext: number })[] | null {
+  // `just`/`justLow` leave the paragraph's last line natural.
+  if (mode === 'just' && isLastLine) return null;
+
+  // No room to fill (or already overflowing) → nothing to distribute.
+  const slack = availWidth - naturalWidth;
+  if (slack <= 0.5) return null;
+
+  // Flatten to a unit stream: each code point of a text segment is a unit; an
+  // inline object is a single (non-char, non-ws) unit.
+  type Unit = { ch?: string; ws: boolean };
+  const units: Unit[] = [];
+  for (const seg of segments) {
+    if (seg.text === undefined) {
+      units.push({ ws: false });
+    } else {
+      for (const ch of seg.text) units.push({ ch, ws: isWsChar(ch) });
+    }
+  }
+
+  // Content span: leading/trailing whitespace must not stretch, and a single
+  // content unit (one word / one glyph) has no inner gap.
+  let first = -1;
+  let last = -1;
+  for (let k = 0; k < units.length; k++) {
+    if (!units[k].ws) {
+      if (first === -1) first = k;
+      last = k;
+    }
+  }
+  if (first === -1 || first === last) return null;
+
+  // Mark the gap AFTER each qualifying unit. Whitespace → inter-word (one gap
+  // per space, Word stretches each). Non-whitespace → an inter-CJK gap only
+  // when the boundary to the next NON-whitespace unit touches a CJK glyph; a
+  // boundary into whitespace is already counted by that whitespace, so it is
+  // never double-counted here.
+  const gapAfter = new Array<boolean>(units.length).fill(false);
+  let total = 0;
+  for (let k = first; k < last; k++) {
+    const u = units[k];
+    if (u.ws) {
+      gapAfter[k] = true;
+      total++;
+    } else {
+      const nx = units[k + 1];
+      if (!nx.ws) {
+        const lc = u.ch;
+        const rc = nx.ch;
+        if ((lc !== undefined && CJK_RE.test(lc)) || (rc !== undefined && CJK_RE.test(rc))) {
+          gapAfter[k] = true;
+          total++;
+        }
+      }
+    }
+  }
+  if (total === 0) return null; // e.g. a single long Latin word that wrapped alone
+
+  const perGap = slack / total;
+
+  // Re-walk the SAME unit order, splitting each segment at gap positions.
+  const out: (T & { jext: number })[] = [];
+  let k = 0;
+  for (const seg of segments) {
+    if (seg.text === undefined) {
+      out.push({ ...seg, jext: gapAfter[k] ? perGap : 0 });
+      k++;
+      continue;
+    }
+    let buf = '';
+    for (const ch of seg.text) {
+      buf += ch;
+      const g = gapAfter[k];
+      k++;
+      if (g) {
+        out.push({ ...seg, text: buf, jext: perGap });
+        buf = '';
+      }
+    }
+    if (buf !== '') out.push({ ...seg, text: buf, jext: 0 });
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Implements DrawingML justified text alignment in the pptx Canvas renderer. `algn="just"`, `"justLow"`, `"dist"`, `"thaiDist"` (ECMA-376 §20.1.10.59 `ST_TextAlignType`) previously fell through to **left** alignment; they now fill the column width.

- **`just` / `justLow`** — widen inter-word spaces **and** inter-CJK character gaps so each wrapped line reaches the column edge; the paragraph's **last line stays natural** (spec: *"it is smart in the sense that it does not justify sentences which are short"*).
- **`dist` / `thaiDist`** — same distribution, but **every line is justified including the last** (CJK characters spaced across the full width — 均等割り付け). `justLow`/`thaiDist` reuse `just`/`dist` (Canvas can't do kashida/Thai glyph stretch).

## How

New pure kernel `packages/pptx/src/text-justify.ts` → `justifyLine()`. It is **character-level, not segment-level**: the layout merges adjacent same-style tokens into one segment (`push`/`sameMeta`), so a line is usually a single segment holding the whole string. `justifyLine` walks the line's character stream, marks each stretch opportunity (an inter-word space, or an inter-CJK boundary — evaluated across segment edges so a colour change mid-word doesn't suppress a gap), and returns the line re-expressed as **draw pieces**, each split at a gap and carrying `jext` (px to advance after it). Σ`jext` = slack, so the painted line reaches the column width.

Wired into the Pass-2 draw loop with a 6-point hook: the loop iterates the split pieces and adds `jext` after each piece's pen advance. The existing glyph / letterSpacing / outline / shadow / underline paths are **unchanged**. Justification is disabled under bidi (LTR only — visual≠logical order).

No parser/WASM change — `algn` already passes through verbatim.

## Verification

**Unit** — 14 cases on `justifyLine` (pure: Latin, CJK, mixed `EC市場で` keeping "EC" intact, leading 字下げ / trailing whitespace excluded, cross-segment CJK boundary, inline object, slack/last-line guards). Full pptx suite green (76 tests); pptx typecheck clean.

**Against PowerPoint (ground truth)** — a local sample (`private/sample-13.pptx`, gitignored) with four bordered boxes was rendered by our viewer and by PowerPoint (same-name PDF, rasterized @96dpi → identical 1280×720 grid). Per-line **right-edge fill ratio** (pixel-measured, not eyeballed):

| Box | PowerPoint PDF | Ours |
|---|---|---|
| A `just` Latin | 0.998 / 0.998 / **0.418** | 0.991 / 0.991 / **0.419** |
| B `just` 和文 | 0.991 / 0.990 / **0.711** | 0.998 / 1.0 / **0.705** |
| C `dist` 和文 (same text as B) | 0.997 / 0.995 / **0.976** | 0.998 / 1.0 / **0.984** |
| D `just` 混在 | 0.997 / 0.995 / **0.341** | 0.998 / … / **0.34** |

Non-last lines fill (~0.99); `just` last lines stay short; `dist` (box C) stretches its **last** line to full — matching PowerPoint within ~1–2% per line. Line breaks coincide (the same-named §479 kinsoku wrapping).

## Notes

- Branches off latest `main` (incl. the shared-kinsoku-engine refactor, #479/#480). The draw loop was untouched by that refactor, so the hook applies cleanly.
- VRT isn't affected: all committed samples are `l`/`ctr`/`r`, for which `justifyMode` is `null` ⇒ byte-identical draw path.
- Merge with `--merge`/`--rebase` (no squash, per repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)