### PR TITLE
refactor(core): unify duplicated CJK break-range definitions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,3 +154,4 @@ export {
   kinsokuAdjustedSplit,
   crossRunKinsokuRetract,
 } from './text/kinsoku';
+export { isCjkBreakChar } from './text/cjk-ranges';

--- a/packages/core/src/text/cjk-ranges.test.ts
+++ b/packages/core/src/text/cjk-ranges.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { isCjkBreakChar } from './cjk-ranges.js';
+
+describe('isCjkBreakChar', () => {
+  // [code point, expected] — exercises every range edge (low−1, low, high,
+  // high+1) plus the unassigned/Jamo-Extended-B gap above Hangul Syllables.
+  const cases: [number, boolean][] = [
+    [0x2fff, false], // just below U+3000
+    [0x3000, true], // ideographic space (range start)
+    [0x3001, true], // 、 (former pptx-justify start)
+    [0x9fff, true], // CJK Unified Ideographs end
+    [0xa000, false], // just above U+9FFF
+    [0xac00, true], // Hangul Syllables start
+    [0xd7a3, true], // Hangul Syllables end (canonical upper bound)
+    [0xd7a4, false], // unassigned — was wrongly included by the D7AF/D7FF copies
+    [0xd7ff, false], // Hangul Jamo Extended-B — was wrongly included by the D7FF copy
+    [0xf8ff, false], // Private Use Area — just below CJK Compatibility Ideographs
+    [0xf900, true], // CJK Compatibility Ideographs start
+    [0xfaff, true], // CJK Compatibility Ideographs end
+    [0xfb00, false], // just above U+FAFF (Alphabetic Presentation Forms)
+    [0xfeff, false], // BOM / ZWNBSP — below U+FF00
+    [0xff00, true], // Halfwidth/Fullwidth Forms start
+    [0xffef, true], // Halfwidth/Fullwidth Forms end
+    [0xfff0, false], // just above U+FFEF
+  ];
+
+  for (const [cp, expected] of cases) {
+    it(`U+${cp.toString(16).toUpperCase().padStart(4, '0')} → ${expected}`, () => {
+      expect(isCjkBreakChar(cp)).toBe(expected);
+    });
+  }
+});

--- a/packages/core/src/text/cjk-ranges.ts
+++ b/packages/core/src/text/cjk-ranges.ts
@@ -1,0 +1,55 @@
+// Shared classifier for CJK / ideographic code points that permit a line break
+// (and a justification stretch) between adjacent characters, without any
+// intervening whitespace. This is the single source of truth consumed by every
+// renderer; previously the same four ranges were hand-duplicated in
+// packages/{pptx,docx,xlsx} and had drifted (the Hangul upper bound was D7FF in
+// one copy and D7AF in two others — both wrong, see below).
+//
+// ── Canonical ranges ────────────────────────────────────────────────────────
+//   U+3000–U+9FFF  Ideographic space, CJK Symbols & Punctuation, Hiragana,
+//                  Katakana, CJK Unified Ideographs (incl. Extension A and the
+//                  Kangxi/CJK symbol blocks that fall inside this span).
+//   U+AC00–U+D7A3  Hangul Syllables.
+//   U+F900–U+FAFF  CJK Compatibility Ideographs.
+//   U+FF00–U+FFEF  Halfwidth and Fullwidth Forms.
+//
+// ── Why U+D7A3 (not D7AF / D7FF) is the Hangul upper bound ───────────────────
+// The Unicode "Hangul Syllables" block is exactly U+AC00–U+D7A3 (the 11,172
+// precomposed modern syllable blocks). The code points above it are NOT
+// standalone CJK break units and must be excluded:
+//   • U+D7A4–U+D7AF  unassigned (no characters).
+//   • U+D7B0–U+D7FF  "Hangul Jamo Extended-B" — combining/conjoining jamo, i.e.
+//                    pieces that attach to a base syllable. A combining mark is
+//                    never an independent line-break or justification unit, so
+//                    it must stay with its base and is excluded here too.
+// The earlier copies' D7AF (included 12 unassigned code points) and D7FF
+// (additionally swept in all of Jamo Extended-B) were both over-broad; D7A3 is
+// the strict, correct boundary. Behaviour is unchanged for real content: no
+// sample exercises U+D7A4–U+D7FF.
+//
+// ── U+3000 (ideographic space): wrap vs. justify ────────────────────────────
+// U+3000 IS intentionally part of this range. For WRAP/BREAK callers that is
+// required: a line may break around an ideographic space like any other CJK
+// glyph. For JUSTIFY callers it is harmless: a justifier classifies U+3000 as
+// whitespace (it matches /\s/) and stretches it as an inter-word gap BEFORE it
+// would ever reach this predicate, so including U+3000 here never causes a
+// U+3000 unit to be counted a second time as an inter-CJK gap. Renderers can
+// therefore share this one predicate for both purposes. (Historically the pptx
+// justify copy started its range at U+3001 to "exclude" U+3000; that exclusion
+// was redundant for the reason just given, and is dropped here.)
+
+/**
+ * True when `cp` is a CJK / ideographic code point that allows a line break —
+ * and a justification stretch — at the boundary with an adjacent character,
+ * with no intervening whitespace required.
+ *
+ * @param cp A Unicode scalar value (e.g. from `String.prototype.codePointAt`).
+ */
+export function isCjkBreakChar(cp: number): boolean {
+  return (
+    (cp >= 0x3000 && cp <= 0x9fff) || // CJK punctuation/symbols, kana, Unified (incl. Ext-A)
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+    (cp >= 0xff00 && cp <= 0xffef) // Halfwidth/Fullwidth Forms
+  );
+}

--- a/packages/core/src/text/cjk-ranges.ts
+++ b/packages/core/src/text/cjk-ranges.ts
@@ -3,7 +3,7 @@
 // intervening whitespace. This is the single source of truth consumed by every
 // renderer; previously the same four ranges were hand-duplicated in
 // packages/{pptx,docx,xlsx} and had drifted (the Hangul upper bound was D7FF in
-// one copy and D7AF in two others — both wrong, see below).
+// the two pptx copies and D7AF in the docx/xlsx copies — both wrong, see below).
 //
 // ── Canonical ranges ────────────────────────────────────────────────────────
 //   U+3000–U+9FFF  Ideographic space, CJK Symbols & Punctuation, Hiragana,
@@ -18,10 +18,10 @@
 // precomposed modern syllable blocks). The code points above it are NOT
 // standalone CJK break units and must be excluded:
 //   • U+D7A4–U+D7AF  unassigned (no characters).
-//   • U+D7B0–U+D7FF  "Hangul Jamo Extended-B" — combining/conjoining jamo, i.e.
-//                    pieces that attach to a base syllable. A combining mark is
-//                    never an independent line-break or justification unit, so
-//                    it must stay with its base and is excluded here too.
+//   • U+D7B0–U+D7FF  "Hangul Jamo Extended-B" — conjoining jamo (Grapheme_
+//                    Cluster_Break V/T) that compose onto a preceding syllable.
+//                    They are not independent line-break or justification units,
+//                    so they stay with their base and are excluded here too.
 // The earlier copies' D7AF (included 12 unassigned code points) and D7FF
 // (additionally swept in all of Jamo Extended-B) were both over-broad; D7A3 is
 // the strict, correct boundary. Behaviour is unchanged for real content: no

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_KINSOKU_RULES,
   kinsokuAdjustedSplit,
   crossRunKinsokuRetract,
+  isCjkBreakChar,
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer, KinsokuRules } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
@@ -2726,17 +2727,14 @@ function resolveFieldText(f: FieldRun, state: RenderState): string {
   return f.fallbackText;
 }
 
-/** Returns true for code-points that permit line-break between adjacent characters (CJK). */
+/** Returns true when any code point of `text` permits a line break between
+ *  adjacent characters (CJK / ideographic). The canonical ranges live in core's
+ *  {@link isCjkBreakChar} (single source of truth across all renderers). */
 function hasCJKBreakOpportunity(text: string): boolean {
   for (let i = 0; i < text.length; ) {
     const cp = text.codePointAt(i)!;
-    if (
-      (cp >= 0x3000 && cp <= 0x9FFF)  ||
-      (cp >= 0xF900 && cp <= 0xFAFF)  ||
-      (cp >= 0xAC00 && cp <= 0xD7AF)  ||
-      (cp >= 0xFF00 && cp <= 0xFFEF)
-    ) return true;
-    i += cp > 0xFFFF ? 2 : 1;
+    if (isCjkBreakChar(cp)) return true;
+    i += cp > 0xffff ? 2 : 1;
   }
   return false;
 }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -55,6 +55,7 @@ import {
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,
   DEFAULT_KINSOKU_RULES,
+  isCjkBreakChar,
 } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
@@ -617,6 +618,15 @@ function naturalWidthExceedsBbox(
   return false;
 }
 
+/** True when any character of `s` is a CJK / ideographic glyph that allows a
+ *  per-character line break (see core's `isCjkBreakChar` for the ranges). */
+function tokenHasCjk(s: string): boolean {
+  for (const ch of s) {
+    if (isCjkBreakChar(ch.codePointAt(0) ?? 0)) return true;
+  }
+  return false;
+}
+
 function layoutParagraph(
   ctx: CanvasRenderingContext2D,
   para: Paragraph,
@@ -893,8 +903,7 @@ function layoutParagraph(
       // Per-character font dispatch picks `fontEa` for CJK glyphs when the run
       // declared an explicit East Asian typeface (rPr > ea); other characters
       // keep the Latin font so the latin/ea boundary mid-token stays clean.
-      const CJK_RE = /[\u3000-\u9FFF\uAC00-\uD7FF\uF900-\uFAFF\uFF00-\uFFEF]/;
-      const hasCJK = CJK_RE.test(token);
+      const hasCJK = tokenHasCjk(token);
       if (hasCJK) {
         // Measure each grapheme with its per-char font (latin/ea boundary stays
         // clean), then place chars according to a:pPr@eaLnBrk (ECMA-376
@@ -914,7 +923,7 @@ function layoutParagraph(
         // separate: substring binary-search fit + cross-run 追い出し. Do not unify them.
         const measured: (MeasuredChar & { font: string })[] = [];
         for (const ch of token) {
-          const chFont = CJK_RE.test(ch) ? fontEa : font;
+          const chFont = isCjkBreakChar(ch.codePointAt(0) ?? 0) ? fontEa : font;
           ctx.font = chFont;
           measured.push({ ch, w: ctx.measureText(ch).width, font: chFont });
         }

--- a/packages/pptx/src/text-justify.test.ts
+++ b/packages/pptx/src/text-justify.test.ts
@@ -120,4 +120,30 @@ describe('justifyLine', () => {
     const r = justifyLine<Seg>([{ text: '日本語', tag: 'x' }], 120, 60, 'just', false);
     expect(r!.every((p) => p.tag === 'x')).toBe(true);
   });
+
+  // Regression for the CJK-range dedup (isCjkBreakChar now includes U+3000).
+  // U+3000 (ideographic space) is whitespace per /\s/, so it is stretched as a
+  // single inter-word gap and never reaches the CJK predicate. Including U+3000
+  // in the shared predicate must NOT add a second (inter-CJK) gap around it: the
+  // 日→U+3000 boundary takes the boundary-into-whitespace path and contributes
+  // no gap of its own. Output stays exactly one gap on the space.
+  it('U+3000 stretches as one inter-word gap, not double-counted as a CJK gap', () => {
+    const r = justifyLine<Seg>([{ text: '日　本' }], 120, 60, 'just', false);
+    expect(pieces(r)).toEqual([
+      ['日　', 60],
+      ['本', 0],
+    ]);
+  });
+
+  it('U+3000 between CJK glyphs: single stretch point even with neighbours', () => {
+    // 日 本 で  → units: 日, U+3000, 本, で. Only two gaps: the U+3000 space and
+    // the 本|で inter-CJK boundary (the 日|U+3000 boundary adds none). slack 80,
+    // 2 gaps → perGap 40.
+    const r = justifyLine<Seg>([{ text: '日　本で' }], 140, 60, 'just', false);
+    expect(pieces(r)).toEqual([
+      ['日　', 40],
+      ['本', 40],
+      ['で', 0],
+    ]);
+  });
 });

--- a/packages/pptx/src/text-justify.ts
+++ b/packages/pptx/src/text-justify.ts
@@ -41,13 +41,15 @@
 // sum to the whole-line `naturalWidth` passed in, and the painted line lands on
 // `availWidth` without measurement drift.
 
-/** Mirrors the CJK ranges the layout uses to allow a break between adjacent
- *  characters (CJK punctuation & Unified incl. Ext-A, Hangul syllables, CJK
- *  Compatibility Ideographs, and the Halfwidth/Fullwidth forms). A boundary is
- *  a stretch opportunity when either side is one of these glyphs. U+3000
+import { isCjkBreakChar } from '@silurus/ooxml-core';
+
+/** A boundary is a stretch opportunity when either side is a CJK / ideographic
+ *  glyph (see core's `isCjkBreakChar` for the canonical ranges). U+3000
  *  (ideographic space) is classified as whitespace below, so it never reaches
- *  this test. */
-const CJK_RE = /[、-鿿가-퟿豈-﫿＀-￯]/;
+ *  this test — which is why sharing the wrap-side predicate (it includes U+3000)
+ *  is safe here: a U+3000 unit is stretched as an inter-word gap, never reaching
+ *  the CJK test, so it is never double-counted. */
+const isCjk = (ch: string): boolean => isCjkBreakChar(ch.codePointAt(0) ?? 0);
 
 /** A laid-out segment as seen by the justifier. Only the optional text matters;
  *  an undefined `text` marks an inline object (math / image), which is one
@@ -131,7 +133,7 @@ export function justifyLine<T extends JustifySeg>(
       if (!nx.ws) {
         const lc = u.ch;
         const rc = nx.ch;
-        if ((lc !== undefined && CJK_RE.test(lc)) || (rc !== undefined && CJK_RE.test(rc))) {
+        if ((lc !== undefined && isCjk(lc)) || (rc !== undefined && isCjk(rc))) {
           gapAfter[k] = true;
           total++;
         }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -648,15 +648,6 @@ function wrapTextLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: nu
   return lines;
 }
 
-/** Codepoints in the CJK ranges get broken per-character (Excel / JIS X 4051
- *  behaviour). This mirrors the tokenizer in `layoutRichTextLines`. */
-function isCJKCodePoint(cp: number): boolean {
-  return (cp >= 0x3000 && cp <= 0x9FFF)  // CJK punctuation + CJK Unified Ideographs
-      || (cp >= 0xF900 && cp <= 0xFAFF)  // CJK Compatibility Ideographs
-      || (cp >= 0xAC00 && cp <= 0xD7AF)  // Hangul Syllables
-      || (cp >= 0xFF00 && cp <= 0xFFEF); // Halfwidth/Fullwidth
-}
-
 /**
  * Apply Japanese line-breaking (kinsoku, 禁則処理) at a wrap boundary.
  *
@@ -702,7 +693,7 @@ export function wrapParagraphLines(ctx: CanvasRenderingContext2D, paragraph: str
   while (i < paragraph.length) {
     const ch = paragraph[i];
     const cp = ch.codePointAt(0) ?? 0;
-    if (isCJKCodePoint(cp)) {
+    if (isCjkBreakChar(cp)) {
       tokens.push(ch);
       i += cp > 0xFFFF ? 2 : 1;
     } else if (ch === ' ') {
@@ -715,7 +706,7 @@ export function wrapParagraphLines(ctx: CanvasRenderingContext2D, paragraph: str
       while (j < paragraph.length) {
         const c = paragraph[j];
         const p = c.codePointAt(0) ?? 0;
-        if (c === ' ' || isCJKCodePoint(p)) break;
+        if (c === ' ' || isCjkBreakChar(p)) break;
         j += p > 0xFFFF ? 2 : 1;
       }
       tokens.push(paragraph.slice(i, j));

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -831,12 +831,6 @@ export function layoutRichTextLines(
     if (font.size > curMaxSize) curMaxSize = font.size;
   };
 
-  const isCJK = (cp: number) =>
-    (cp >= 0x3000 && cp <= 0x9FFF) ||
-    (cp >= 0xF900 && cp <= 0xFAFF) ||
-    (cp >= 0xAC00 && cp <= 0xD7AF) ||
-    (cp >= 0xFF00 && cp <= 0xFFEF);
-
   for (const run of runs) {
     const font = applyRunFont(baseFont, run);
     // Tokenize: runs of non-space latin, spaces, or individual CJK chars
@@ -848,7 +842,7 @@ export function layoutRichTextLines(
       if (cp === 0x000A) {
         // Explicit newline: force break
         tokens.push('\n'); i += 1;
-      } else if (isCJK(cp)) {
+      } else if (isCjkBreakChar(cp)) {
         tokens.push(ch);
         i += cp > 0xFFFF ? 2 : 1;
       } else if (ch === ' ') {
@@ -861,7 +855,7 @@ export function layoutRichTextLines(
         while (j < run.text.length) {
           const c = run.text[j];
           const p = c.codePointAt(0) ?? 0;
-          if (c === ' ' || c === '\n' || isCJK(p)) break;
+          if (c === ' ' || c === '\n' || isCjkBreakChar(p)) break;
           j += p > 0xFFFF ? 2 : 1;
         }
         tokens.push(run.text.slice(i, j));


### PR DESCRIPTION
## What

Unifies four hand-maintained copies of the CJK / ideographic Unicode break range into a single shared predicate in `@silurus/ooxml-core`.

The same range was duplicated across the renderers and had **drifted**:

| Site | Hangul upper bound |
|---|---|
| `packages/pptx/src/text-justify.ts` (`CJK_RE`) | U+D7FF |
| `packages/pptx/src/renderer.ts` (layout `CJK_RE`) | U+D7FF |
| `packages/docx/src/renderer.ts` (`hasCJKBreakOpportunity`) | U+D7AF |
| `packages/xlsx/src/renderer.ts` (`isCJKCodePoint`) | U+D7AF |

This violated the repo principle that statically-checkable rules belong in shared code, not in prose (the contract was enforced only by a "Mirrors the CJK ranges the layout uses" comment).

## How

- New `packages/core/src/text/cjk-ranges.ts` exports `isCjkBreakChar(cp: number): boolean` (beside the existing `kinsoku/` and `bidi/` text primitives), re-exported from `@silurus/ooxml-core`.
- Canonical ranges: **U+3000–9FFF, U+AC00–D7A3, U+F900–FAFF, U+FF00–FFEF**.
- **Hangul bound U+D7A3** = the exact Hangul Syllables block. U+D7A4–D7AF are unassigned and U+D7B0–D7FF is Hangul Jamo Extended-B (combining jamo); neither should be a standalone break/justify unit, so both the old D7FF and D7AF were over-broad. The three demo samples contain **zero** code points in U+D7A4–D7FF, so the narrowing is behaviour-neutral for the corpus.
- **U+3000** is included (wrap/break callers need it). It is harmless for the justifier: `text-justify.ts` classifies U+3000 as whitespace and consumes it as one inter-word gap *before* the CJK test is reached, so it is never double-counted. Two regression tests pin `justifyLine` output for lines containing U+3000.
- All four sites now call the shared predicate.

## Verification

- `vitest run` (core + pptx + docx + xlsx): **518 passed** (incl. 17 new core boundary tests + 2 new text-justify regression tests).
- `tsc --build`: clean. `pnpm run lint` (ast-grep): clean.
- VRT (`pnpm build:wasm && pnpm vrt`): all **demo-backed** tests green (pptx/docx/xlsx). `private/sample-*` refs are gitignored (absent in a fresh checkout) and out of scope.

## Follow-up

The parallel PR `fix/docx-distribute-cjk` adds `packages/docx/src/text-distribute.ts`, which currently carries its own local `isCJKCodePoint` (it could not import this core predicate because the file did not exist on `main` when it was written). The two PRs merge cleanly (different regions — verified with `git merge-tree`). **After both land, fold `text-distribute.ts`'s `isCJKCodePoint` into `core.isCjkBreakChar`** (~2-line change) so docx has a single CJK source.

Merge with `--merge` / `--rebase` (no squash, per repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
