### PR TITLE
refactor(core): extract shared justified-line slack kernel

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -155,3 +155,10 @@ export {
   crossRunKinsokuRetract,
 } from './text/kinsoku';
 export { isCjkBreakChar } from './text/cjk-ranges';
+export {
+  distributeLineSlack,
+  type DistributeSeg,
+  type DistributeResult,
+  type DistributeOptions,
+  type SegStretch,
+} from './text/line-distribute';

--- a/packages/core/src/text/line-distribute.test.ts
+++ b/packages/core/src/text/line-distribute.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest';
+import { distributeLineSlack } from './line-distribute.js';
+import type { DistributeSeg, DistributeResult } from './line-distribute.js';
+
+// distributeLineSlack is the shared "fill the line" kernel behind WordprocessingML
+// §17.18.44 (`both`/`distribute`) and DrawingML §20.1.10.59 (`just`/`dist`). Given
+// a line's segments (logical order) and its slack, it returns per-segment split
+// points + a trailing-gap flag and the per-gap px. Both gap families participate:
+// inter-word whitespace AND inter-CJK boundaries (either side a CJK / ideographic
+// glyph). The Word PDF for private/sample-9 pins the CJK case: a wrapped pure-CJK
+// `both` line with zero ASCII spaces still fills to the right margin (xMax 523.0pt
+// via pdftotext -bbox), only possible by widening inter-CJK boundaries.
+//
+// These tests exercise the kernel directly with its default (WordprocessingML)
+// predicates AND with the injected predicates the pptx adapter supplies.
+
+const seg = (text?: string): DistributeSeg => ({ text });
+
+/** Total px the kernel will add across the whole line = Σ over segments of
+ *  (internal gaps + trailing gap) × perGap. Must equal `slack` so the final
+ *  glyph lands on the right margin. */
+function totalStretch(r: DistributeResult): number {
+  let gaps = 0;
+  for (const s of r.perSeg.values()) {
+    gaps += s.splitBefore.length + (s.trailingGap ? 1 : 0);
+  }
+  return gaps * r.perGap;
+}
+
+describe('distributeLineSlack — pure CJK (the bug)', () => {
+  // A pure-CJK phrase is ONE segment with no ASCII spaces. A space-only model
+  // produces zero stretch; the kernel must open every inter-CJK boundary.
+  it('opens an inter-CJK gap at every interior boundary of a single CJK segment', () => {
+    const segs = [seg('観察することで')]; // 7 code points → 6 interior boundaries
+    const r = distributeLineSlack(segs, 60, { firstContentSi: 0, lastDrawnSi: 1 });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(s.trailingGap).toBe(false);
+    expect(r!.perGap).toBeCloseTo(60 / 6, 6);
+    expect(totalStretch(r!)).toBeCloseTo(60, 6);
+  });
+
+  it('returns null for a single CJK glyph (no interior boundary)', () => {
+    expect(distributeLineSlack([seg('観')], 40, { firstContentSi: 0, lastDrawnSi: 1 })).toBeNull();
+  });
+});
+
+describe('distributeLineSlack — default options', () => {
+  // firstContentSi defaults to 0, lastDrawnSi to segments.length-1, isGapChar to
+  // core.isCjkBreakChar, isWhitespace to U+0020||U+3000. Omitting opts entirely
+  // must behave like the explicit WordprocessingML-expansion form.
+  it('omitting opts uses 0 / length-1 / CJK / ASCII+ideographic-space defaults', () => {
+    const segs = [seg('観察'), seg('結果')];
+    const withDefaults = distributeLineSlack(segs, 18);
+    const explicit = distributeLineSlack(segs, 18, {
+      firstContentSi: 0,
+      lastDrawnSi: 1,
+    });
+    expect(withDefaults).not.toBeNull();
+    expect(explicit).not.toBeNull();
+    expect(withDefaults!.perGap).toBeCloseTo(explicit!.perGap, 9);
+    expect(withDefaults!.perSeg.get(0)).toEqual(explicit!.perSeg.get(0));
+    expect(withDefaults!.perSeg.has(1)).toBe(false);
+  });
+});
+
+describe('distributeLineSlack — Latin justify is unchanged (regression guard)', () => {
+  it('stretches only inter-word ASCII spaces, never inside a Latin word', () => {
+    const segs = [seg('the '), seg('quick')];
+    const r = distributeLineSlack(segs, 20, { firstContentSi: 0, lastDrawnSi: 1 });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([]); // no intra-word split
+    expect(s.trailingGap).toBe(true); // the inter-word space after "the "
+    expect(r!.perSeg.has(1)).toBe(false); // final segment opens no gap
+    expect(r!.perGap).toBeCloseTo(20, 6);
+    expect(totalStretch(r!)).toBeCloseTo(20, 6);
+  });
+
+  it('distributes across multiple inter-word spaces equally', () => {
+    const segs = [seg('the '), seg('lazy '), seg('dog')];
+    const r = distributeLineSlack(segs, 30, { firstContentSi: 0, lastDrawnSi: 2 });
+    expect(r).not.toBeNull();
+    expect(r!.perGap).toBeCloseTo(15, 6);
+    expect(r!.perSeg.get(0)!.trailingGap).toBe(true);
+    expect(r!.perSeg.get(1)!.trailingGap).toBe(true);
+    expect(totalStretch(r!)).toBeCloseTo(30, 6);
+  });
+
+  it('never splits a long single Latin word (no gaps → null)', () => {
+    expect(
+      distributeLineSlack([seg('supercalifragilistic')], 50, { firstContentSi: 0, lastDrawnSi: 1 }),
+    ).toBeNull();
+  });
+});
+
+describe('distributeLineSlack — mixed Latin + CJK', () => {
+  it('opens gaps at inter-CJK boundaries and at the Latin/CJK boundary', () => {
+    // "BZ反応" — 4 code points: B Z 反 応. B|Z Latin → no gap; Z|反 (CJK right) and
+    // 反|応 (both CJK) → gaps. A single content segment uses lastDrawnSi past the
+    // end (1) so the segment is NOT the "visually-last" one and may open gaps.
+    const segs = [seg('BZ反応')];
+    const r = distributeLineSlack(segs, 24, { firstContentSi: 0, lastDrawnSi: 1 });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([2, 3]);
+    expect(s.trailingGap).toBe(false);
+    expect(r!.perGap).toBeCloseTo(12, 6);
+  });
+
+  it('does not open a gap between two Latin letters even next to CJK', () => {
+    // "反BZ応": 反(0) B(1) Z(2) 応(3). 反|B and Z|応 are gaps; B|Z is not.
+    const segs = [seg('反BZ応')];
+    const r = distributeLineSlack(segs, 20, { firstContentSi: 0, lastDrawnSi: 1 });
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([1, 3]);
+  });
+});
+
+describe('distributeLineSlack — leading 字下げ indent stays fixed', () => {
+  it('does not stretch a leading whitespace segment before firstContentSi', () => {
+    const segs = [seg('　'), seg('観察する'), seg('結果')];
+    const r = distributeLineSlack(segs, 30, { firstContentSi: 1, lastDrawnSi: 2 });
+    expect(r).not.toBeNull();
+    expect(r!.perSeg.has(0)).toBe(false); // indent segment never stretched
+    expect(r!.perSeg.has(2)).toBe(false); // final segment opens no gap
+    const s = r!.perSeg.get(1)!;
+    expect(s.splitBefore).toEqual([1, 2, 3]);
+    expect(s.trailingGap).toBe(true);
+    expect(r!.perGap).toBeCloseTo(7.5, 6); // 30 / 4
+    expect(totalStretch(r!)).toBeCloseTo(30, 6);
+  });
+
+  it('skips a leading ideographic space at the START of the content segment', () => {
+    const segs = [seg('　観察'), seg('結果')];
+    const r = distributeLineSlack(segs, 16, { firstContentSi: 0, lastDrawnSi: 1 });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([2]);
+    expect(s.trailingGap).toBe(true);
+    expect(totalStretch(r!)).toBeCloseTo(16, 6);
+  });
+
+  it('treats an interior ideographic space as a single inter-word gap', () => {
+    const segs = [seg('観　察結')];
+    const r = distributeLineSlack(segs, 10, { firstContentSi: 0, lastDrawnSi: 1 });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([2, 3]);
+    expect(r!.perGap).toBeCloseTo(5, 6); // 10 / 2
+  });
+});
+
+describe('distributeLineSlack — final segment opens no gap, Σgaps == slack', () => {
+  it('opens no gap WITHIN the final segment but does widen the boundary into it', () => {
+    const segs = [seg('観察'), seg('結果')];
+    const r = distributeLineSlack(segs, 18, { firstContentSi: 0, lastDrawnSi: 1 });
+    expect(r).not.toBeNull();
+    expect(r!.perSeg.has(1)).toBe(false);
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([1]); // 観|察 internal
+    expect(s.trailingGap).toBe(true); // 察|結 boundary into the final segment
+    expect(r!.perGap).toBeCloseTo(9, 6); // 18 / 2 gaps
+    expect(totalStretch(r!)).toBeCloseTo(18, 6);
+  });
+
+  it('Σgaps equals slack for a mixed multi-segment line', () => {
+    const segs = [seg('図 '), seg('観察する'), seg('こと')];
+    const r = distributeLineSlack(segs, 40, { firstContentSi: 0, lastDrawnSi: 2 });
+    expect(r).not.toBeNull();
+    expect(totalStretch(r!)).toBeCloseTo(40, 6);
+  });
+});
+
+describe('distributeLineSlack — negative slack (compression)', () => {
+  it('compresses gaps with a negative perGap, clamped to minPerGap', () => {
+    const segs = [seg('観察することで')]; // 6 interior gaps
+    const r = distributeLineSlack(segs, -60, { firstContentSi: 0, lastDrawnSi: 1, minPerGap: -4 });
+    expect(r).not.toBeNull();
+    expect(r!.perGap).toBe(-4);
+  });
+
+  it('applies an unclamped negative perGap when within the cap', () => {
+    const segs = [seg('観察することで')];
+    const r = distributeLineSlack(segs, -12, { firstContentSi: 0, lastDrawnSi: 1, minPerGap: -10 });
+    expect(r!.perGap).toBeCloseTo(-2, 6); // -12/6 = -2, above the -10 floor
+  });
+
+  it('returns null when |slack| is below the 0.5px noise floor', () => {
+    expect(distributeLineSlack([seg('観察')], 0.3, { firstContentSi: 0, lastDrawnSi: 1 })).toBeNull();
+    expect(distributeLineSlack([seg('観察')], -0.4, { firstContentSi: 0, lastDrawnSi: 1 })).toBeNull();
+  });
+
+  it('with isGapChar=()=>false, compresses only spaces and leaves CJK boundaries alone', () => {
+    // The docx COMPRESSION path: slack < 0 → only spaces stretch, no glyph overlap.
+    const segs = [seg('図 '), seg('観察'), seg('end')];
+    const r = distributeLineSlack(segs, -10, {
+      firstContentSi: 0,
+      lastDrawnSi: 2,
+      isGapChar: () => false,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.perSeg.get(0)!.trailingGap).toBe(true);
+    expect(r!.perSeg.has(1)).toBe(false);
+    expect(r!.perGap).toBeCloseTo(-10, 6); // one gap absorbs all the (negative) slack
+  });
+
+  it('with isGapChar=()=>false, returns null for a space-free CJK line', () => {
+    expect(
+      distributeLineSlack([seg('観察することで')], -30, {
+        firstContentSi: 0,
+        lastDrawnSi: 1,
+        isGapChar: () => false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('distributeLineSlack — non-text atoms', () => {
+  it('opens a CJK gap against an inline atom edge but not inside it', () => {
+    const segs: DistributeSeg[] = [{}, seg('観察'), seg('end')];
+    const r = distributeLineSlack(segs, 30, { firstContentSi: 0, lastDrawnSi: 2 });
+    expect(r).not.toBeNull();
+    expect(r!.perSeg.get(0)!.trailingGap).toBe(true);
+    expect(r!.perSeg.get(0)!.splitBefore).toEqual([]);
+    expect(r!.perSeg.get(1)!.splitBefore).toEqual([1]);
+    expect(totalStretch(r!)).toBeCloseTo(30, 6);
+  });
+});
+
+describe('distributeLineSlack — bidi (visually-last segment ≠ logical-last)', () => {
+  // lastDrawnSi = the VISUALLY-last segment's LOGICAL index. The exclusion must be
+  // an EXACT match, not `>=`: for a pure-RTL line lastDrawnSi is the logical-FIRST
+  // segment (0), so `>=` would suppress every segment → total 0 → null. #483.
+  it('justifies when the fixed (visually-last) segment is the logical first (RTL)', () => {
+    const segs = [seg('a '), seg('b '), seg('c')];
+    const r = distributeLineSlack(segs, 30, { firstContentSi: 0, lastDrawnSi: 0 });
+    expect(r).not.toBeNull(); // was null under the `>=` regression
+    expect(r!.perSeg.has(0)).toBe(false); // the visually-last segment opens no gap
+    expect(r!.perSeg.get(1)!.trailingGap).toBe(true);
+    expect(totalStretch(r!)).toBeCloseTo(30, 6);
+  });
+});
+
+describe('distributeLineSlack — injected whitespace predicate (pptx parity)', () => {
+  // PowerPoint treats every JS `\s` char as inter-word whitespace, wider than the
+  // WordprocessingML default (U+0020 || U+3000). The kernel must classify by the
+  // injected predicate, so e.g. a TAB becomes an inter-word gap under pptx but a
+  // CJK-or-nothing boundary under the default.
+  const pptxWs = (cp: number): boolean => /\s/.test(String.fromCodePoint(cp));
+
+  it('a TAB is an inter-word gap under the pptx predicate', () => {
+    // "a\tb" + "c" → a(off0) \t(off1) b(off2) | c. Under pptxWs the tab is the
+    // only whitespace → exactly one gap, after it (interior: off1 → split before
+    // off2). The b|c boundary is Latin/Latin and NOT whitespace, so it opens no
+    // gap; the only stretch is the tab.
+    const segs = [seg('a\tb'), seg('c')];
+    const r = distributeLineSlack(segs, 12, {
+      firstContentSi: 0,
+      lastDrawnSi: 1,
+      isWhitespace: pptxWs,
+    });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([2]); // split before b (after the tab)
+    expect(s.trailingGap).toBe(false); // b|c is Latin/Latin → not a gap
+    expect(r!.perGap).toBeCloseTo(12, 6); // single gap absorbs all the slack
+    expect(r!.perSeg.has(1)).toBe(false);
+  });
+
+  it('the default whitespace predicate does NOT treat a TAB as a gap', () => {
+    // Same input under defaults: \t is not whitespace and not CJK, so a|\t, \t|b
+    // and b|c are all Latin/control boundaries → no gap anywhere → null. (Word
+    // never sees a bare \t as a justify opportunity; pptx does.)
+    const segs = [seg('a\tb'), seg('c')];
+    const r = distributeLineSlack(segs, 12, { firstContentSi: 0, lastDrawnSi: 1 });
+    expect(r).toBeNull();
+  });
+});

--- a/packages/core/src/text/line-distribute.ts
+++ b/packages/core/src/text/line-distribute.ts
@@ -81,7 +81,10 @@ export interface DistributeOptions {
    *  gap. Default `segments.length - 1`. The match is EXACT, not `>=`: under
    *  bidi this is the visually-last segment's LOGICAL index, which is not the
    *  maximum si, so `>=` would wrongly suppress every logically-later segment
-   *  (a pure-RTL line would skip the whole line → no justification). */
+   *  (a pure-RTL line would skip the whole line → no justification). Pass a value
+   *  ≥ segments.length (e.g. `segments.length`) to exclude NO segment: the pptx
+   *  adapter does this because it draws every segment in one loop and relies on
+   *  the content-span trim to suppress only the final glyph's gap. */
   lastDrawnSi?: number;
   /** Lower bound on a (negative) `perGap` when compressing (slack < 0), so a
    *  compression never eats more than a capped amount per gap. Default

--- a/packages/core/src/text/line-distribute.ts
+++ b/packages/core/src/text/line-distribute.ts
@@ -1,0 +1,237 @@
+// Shared "fill the line" slack distributor for justified text — the single gap
+// model behind WordprocessingML §17.18.44 (`both`/`distribute`) and DrawingML
+// §20.1.10.59 (`just`/`dist`). Given a laid-out line's segments (logical order)
+// and its slack, it reports — per segment — where each gap falls and the per-gap
+// px, so a renderer can slice the glyph drawing and advance the pen.
+//
+// ── Why one kernel for both formats ─────────────────────────────────────────
+// Word and PowerPoint reach the SAME gap selection: a stretch opportunity is an
+// inter-word space OR an inter-CJK boundary (either side a CJK / ideographic
+// glyph), evaluated across the whole line's code-point stream — boundaries are
+// tested across segment edges too, so a colour change mid-phrase doesn't swallow
+// a gap. They differ only in policy the CALLER owns and which this kernel does
+// NOT encode:
+//   • last-line policy (Word `both` / PowerPoint `just` leave the final line
+//     natural; `distribute` / `dist` fill it). The caller decides whether to
+//     call the kernel for a given line — the kernel just stretches whatever line
+//     it is handed.
+//   • the whitespace predicate. PowerPoint treats every JS `\s` char as an
+//     inter-word space; Word counts only U+0020 and U+3000. Each caller injects
+//     its own `isWhitespace` so the kernel reproduces that format's behaviour.
+//   • the gap predicate. EXPANSION opens inter-CJK boundaries (`isGapChar` =
+//     core.isCjkBreakChar); a COMPRESSION path that may shrink spaces but must
+//     not overlap ideographs injects `isGapChar: () => false`.
+//
+// Why a per-segment / per-character model: layout merges adjacent same-style
+// tokens into ONE segment, so a CJK phrase like "観察することで" is a single
+// segment with no internal spaces — its inter-CJK gaps fall INSIDE the segment,
+// between code points. The kernel walks the line's whole code-point stream and
+// reports, per segment, the interior split offsets and a trailing-edge flag.
+//
+// This file is format-agnostic: no ECMA-376 §-specific policy lives here, only
+// the gap geometry both renderers share. See packages/pptx/src/text-justify.ts
+// and packages/docx/src/text-distribute.ts for the format adapters.
+
+import { isCjkBreakChar } from './cjk-ranges.js';
+
+/** A laid-out segment as the distributor sees it. Only the optional text matters;
+ *  an undefined `text` marks a non-text inline atom (image / math / tab) — one
+ *  opaque unit bearing no stretch of its own, though a CJK neighbour can still
+ *  open a gap against its edge (the atom counts as a non-CJK, non-space unit). */
+export interface DistributeSeg {
+  text?: string;
+}
+
+/** Per-text-segment instructions for applying the line's slack.
+ *
+ *  `splitBefore` lists the code-point offsets (1..len-1, counted in code points,
+ *  NOT UTF-16 units) at which an INTERNAL gap falls — the glyphs before the
+ *  offset are drawn, the pen advances by `perGap`, then drawing resumes.
+ *  `trailingGap` marks that the boundary AFTER this segment's last code point
+ *  (the inter-segment boundary) is a stretch opportunity. */
+export interface SegStretch {
+  /** Code-point offsets inside the segment after which to insert `perGap`. */
+  splitBefore: number[];
+  /** Whether to advance `perGap` after the whole segment (inter-segment gap). */
+  trailingGap: boolean;
+  /** px added strictly INSIDE the segment = splitBefore.length * perGap.
+   *  Decorations (highlight / underline / strike / ruby centring / onTextRun
+   *  width) should span measuredWidth + internalStretch. */
+  internalStretch: number;
+}
+
+/** Result of distributing a line's slack across its gap opportunities. */
+export interface DistributeResult {
+  /** px added at each gap (negative when the line is compressed). */
+  perGap: number;
+  /** Per-segment stretch, keyed by the segment's index in `segments`. Segments
+   *  with no gap (and non-text atoms) are absent. */
+  perSeg: Map<number, SegStretch>;
+}
+
+/** Tuning for {@link distributeLineSlack}; every field is optional and defaults
+ *  to the WordprocessingML expansion behaviour. */
+export interface DistributeOptions {
+  /** Index of the first segment holding non-whitespace content; earlier
+   *  (leading-indent / 字下げ whitespace) segments are fixed and never open a
+   *  gap. Default 0 (no skip — e.g. under bidi, or for callers with no indent
+   *  concept). */
+  firstContentSi?: number;
+  /** Index of the VISUALLY-final segment; it and the boundary into it open no
+   *  gap. Default `segments.length - 1`. The match is EXACT, not `>=`: under
+   *  bidi this is the visually-last segment's LOGICAL index, which is not the
+   *  maximum si, so `>=` would wrongly suppress every logically-later segment
+   *  (a pure-RTL line would skip the whole line → no justification). */
+  lastDrawnSi?: number;
+  /** Lower bound on a (negative) `perGap` when compressing (slack < 0), so a
+   *  compression never eats more than a capped amount per gap. Default
+   *  -Infinity (uncapped). Ignored when slack >= 0. */
+  minPerGap?: number;
+  /** A boundary between two non-space code points opens an inter-CJK gap when
+   *  EITHER side satisfies this predicate. Default core.isCjkBreakChar (open a
+   *  gap when either side is a CJK / ideographic glyph). Pass `() => false` for
+   *  a compression path that must not overlap ideographs (only spaces stretch). */
+  isGapChar?: (cp: number) => boolean;
+  /** Classifies a code point as inter-word whitespace: it becomes ONE gap and is
+   *  never treated as a CJK boundary. Default `cp === 0x20 || cp === 0x3000`
+   *  (the WordprocessingML set). PowerPoint injects a wider JS-`\s` predicate.
+   *  Whitespace is classified FIRST, so an ideographic space is one inter-word
+   *  gap and never reaches `isGapChar`. */
+  isWhitespace?: (cp: number) => boolean;
+}
+
+/** Default inter-word whitespace (WordprocessingML): ASCII space + ideographic
+ *  space. */
+const defaultIsWhitespace = (cp: number): boolean => cp === 0x20 || cp === 0x3000;
+
+/**
+ * Distribute `slack` px equally across a justified line's gap opportunities
+ * (inter-word spaces AND, by default, inter-CJK boundaries).
+ *
+ * A gap is opened AFTER a code point whose owning segment is eligible to OPEN a
+ * gap (its index is in `[firstContentSi, segments.length)` and is NOT
+ * `lastDrawnSi`). The LEFT side of every gap is thus eligible, while the gap's
+ * right side may be the first code point of the final segment — so a 2-token
+ * line "the quick" widens the space before "quick", and a CJK line split into
+ * [観察][結果] widens the 察|結 boundary. The final segment opens no gap of its
+ * own and is never split internally, but the boundary INTO it stretches like any
+ * other; all slack lands to the final glyph's left, which reaches the margin
+ * (Σgaps == slack). Leading whitespace before the first content unit and the gap
+ * after the last content unit never stretch.
+ *
+ * @param segments The line's segments in LOGICAL (reading) order.
+ * @param slack    availWidth - naturalWidth, px. >0 stretches; <0 compresses.
+ * @param opts     See {@link DistributeOptions}; omitted fields take the
+ *                 WordprocessingML-expansion defaults.
+ * @returns The distribution, or `null` when nothing stretches (no eligible gap,
+ *          or |slack| below the 0.5px noise floor).
+ */
+export function distributeLineSlack<T extends DistributeSeg>(
+  segments: readonly T[],
+  slack: number,
+  opts: DistributeOptions = {},
+): DistributeResult | null {
+  if (Math.abs(slack) <= 0.5) return null;
+
+  const firstContentSi = opts.firstContentSi ?? 0;
+  const lastDrawnSi = opts.lastDrawnSi ?? segments.length - 1;
+  const minPerGap = opts.minPerGap ?? -Infinity;
+  const isGapChar = opts.isGapChar ?? isCjkBreakChar;
+  const isWhitespace = opts.isWhitespace ?? defaultIsWhitespace;
+
+  // Flatten the eligible segments to a code-point stream. Segments before
+  // `firstContentSi` (leading indent) are skipped; the rest — INCLUDING the
+  // final segment — are flattened, because a gap may have its RIGHT side in the
+  // final segment even though its left side may not be. Each unit carries its
+  // owning segment, the code-point offset within that segment, the code point,
+  // and an inter-word-whitespace flag. Non-text atoms become one unit with
+  // cp=undefined.
+  type Unit = { si: number; off: number; cp?: number; ws: boolean };
+  const units: Unit[] = [];
+  for (let si = firstContentSi; si < segments.length; si++) {
+    const seg = segments[si];
+    if (seg === undefined) continue;
+    if (seg.text === undefined) {
+      units.push({ si, off: 0, ws: false });
+      continue;
+    }
+    let off = 0;
+    for (const ch of seg.text) {
+      const cp = ch.codePointAt(0)!;
+      units.push({ si, off, cp, ws: isWhitespace(cp) });
+      off++;
+    }
+  }
+
+  // Content span: the first and last NON-whitespace units. Leading/trailing
+  // spaces never stretch, and a single content unit has no interior gap.
+  let first = -1;
+  let last = -1;
+  for (let k = 0; k < units.length; k++) {
+    if (!units[k].ws) {
+      if (first === -1) first = k;
+      last = k;
+    }
+  }
+  if (first === -1 || first === last) return null;
+
+  // Mark a gap AFTER unit k, for first <= k < last, when k's owning segment is
+  // eligible to OPEN a gap (its si is not lastDrawnSi — the visually-last
+  // segment opens none and is never split, but the boundary INTO it still
+  // stretches). Whitespace → one inter-word gap (each space stretches).
+  // Non-space → an inter-CJK gap only when the boundary to the next NON-space
+  // unit satisfies `isGapChar` on either side; a boundary INTO whitespace is
+  // already counted by that whitespace, so it is not double-counted.
+  const gapAfter = new Array<boolean>(units.length).fill(false);
+  let total = 0;
+  for (let k = first; k < last; k++) {
+    const u = units[k];
+    if (u.si === lastDrawnSi) continue; // the visually-last segment opens no gap
+    if (u.ws) {
+      gapAfter[k] = true;
+      total++;
+      continue;
+    }
+    const nx = units[k + 1];
+    if (nx.ws) continue; // counted by that space when we reach it
+    const lc = u.cp;
+    const rc = nx.cp;
+    if (
+      (lc !== undefined && isGapChar(lc)) ||
+      (rc !== undefined && isGapChar(rc))
+    ) {
+      gapAfter[k] = true;
+      total++;
+    }
+  }
+  if (total === 0) return null;
+
+  let perGap = slack / total;
+  if (slack < 0 && perGap < minPerGap) perGap = minPerGap;
+
+  // Per-segment code-point length, to tell an internal gap (off < len-1) from the
+  // trailing inter-segment gap (off === len-1).
+  const segLen = new Map<number, number>();
+  for (const u of units) {
+    if (u.cp !== undefined) segLen.set(u.si, (segLen.get(u.si) ?? 0) + 1);
+  }
+
+  const perSeg = new Map<number, SegStretch>();
+  for (let k = 0; k < units.length; k++) {
+    if (!gapAfter[k]) continue;
+    const u = units[k];
+    let s = perSeg.get(u.si);
+    if (!s) {
+      s = { splitBefore: [], trailingGap: false, internalStretch: 0 };
+      perSeg.set(u.si, s);
+    }
+    const len = segLen.get(u.si) ?? 0;
+    if (u.cp === undefined || u.off === len - 1) {
+      s.trailingGap = true; // inter-segment boundary
+    } else {
+      s.splitBefore.push(u.off + 1); // split BEFORE code point off+1
+      s.internalStretch += perGap;
+    }
+  }
+  return { perGap, perSeg };
+}

--- a/packages/docx/src/text-distribute.test.ts
+++ b/packages/docx/src/text-distribute.test.ts
@@ -2,23 +2,18 @@ import { describe, it, expect } from 'vitest';
 import { distributeLineSlack } from './text-distribute.js';
 import type { DistributeSeg, DistributeResult } from './text-distribute.js';
 
-// ECMA-376 §17.18.44 ST_Jc: `both` and `distribute` fill a line to the margin by
-// adding equal slack at every gap opportunity. The clause "both affects only
-// inter-word spacing, not inter-character within a word" is LATIN-scoped — in CJK
-// each ideograph is its own word, so inter-CJK boundaries are inter-word gaps.
-// The Word PDF for private/sample-9 confirms it: a wrapped pure-CJK `both` line
-// with zero ASCII spaces still fills to the right margin (xMax 523.0pt via
-// pdftotext -bbox), which is only possible by widening inter-CJK boundaries.
-//
-// distributeLineSlack is the pure kernel: given a line's segments (logical order),
-// its slack, and the fixed-edge indices the renderer already computes, it returns
-// per-segment split points + a trailing-gap flag and the per-gap px.
+// text-distribute.ts is now a thin POSITIONAL adapter over the shared kernel
+// `@silurus/ooxml-core` → distributeLineSlack. The exhaustive gap-geometry tests
+// live with the kernel (packages/core/src/text/line-distribute.test.ts). These
+// tests pin the docx adapter contract the renderer depends on: the positional
+// argument order, the includeCJK → compression mapping, the leading-indent skip,
+// the bidi exact-match exclusion, and the §17.18.44 pure-CJK fill — i.e. that the
+// docx-specific wiring (whitespace = U+0020/U+3000, includeCJK = slack > 0) is
+// preserved across the extraction.
 
 const seg = (text?: string): DistributeSeg => ({ text });
 
-/** Total px the kernel will add across the whole line = Σ over segments of
- *  (internal gaps + trailing gap) × perGap. Must equal `slack` so the final
- *  glyph lands on the right margin. */
+/** Σ over segments of (internal gaps + trailing gap) × perGap; must equal slack. */
 function totalStretch(r: DistributeResult): number {
   let gaps = 0;
   for (const s of r.perSeg.values()) {
@@ -27,231 +22,73 @@ function totalStretch(r: DistributeResult): number {
   return gaps * r.perGap;
 }
 
-describe('distributeLineSlack — pure CJK (the bug)', () => {
-  // A pure-CJK phrase is ONE segment with no ASCII spaces. The old space-only
-  // model produced zero stretch; the kernel must open every inter-CJK boundary.
-  it('opens an inter-CJK gap at every interior boundary of a single CJK segment', () => {
-    const segs = [seg('観察することで')]; // 7 code points → 6 interior boundaries
-    const r = distributeLineSlack(segs, 60, 0, 1);
-    expect(r).not.toBeNull();
-    const s = r!.perSeg.get(0)!;
-    // 6 boundaries, all internal (single segment, no trailing gap since the final
-    // segment is excluded — here there IS no later segment, so the segment is the
-    // only eligible one and its last boundary is interior).
-    expect(s.splitBefore).toEqual([1, 2, 3, 4, 5, 6]);
-    expect(s.trailingGap).toBe(false);
-    expect(r!.perGap).toBeCloseTo(60 / 6, 6);
-    expect(totalStretch(r!)).toBeCloseTo(60, 6);
-  });
-
-  it('returns null for a single CJK glyph (no interior boundary)', () => {
-    expect(distributeLineSlack([seg('観')], 40, 0, 1)).toBeNull();
-  });
-});
-
-describe('distributeLineSlack — Latin justify is unchanged (regression guard)', () => {
-  it('stretches only inter-word ASCII spaces, never inside a Latin word', () => {
-    // Two tokens "the " and "quick". The only gap is the space after "the " —
-    // its left side (seg 0) is eligible and its right side is the final segment.
-    // No split lands inside "the" or "quick".
-    const segs = [seg('the '), seg('quick')];
-    const r = distributeLineSlack(segs, 20, 0, 1);
-    expect(r).not.toBeNull();
-    const s = r!.perSeg.get(0)!;
-    expect(s.splitBefore).toEqual([]); // no intra-word split
-    expect(s.trailingGap).toBe(true); // the inter-word space after "the "
-    expect(r!.perSeg.has(1)).toBe(false); // final segment opens no gap
-    expect(r!.perGap).toBeCloseTo(20, 6);
-    expect(totalStretch(r!)).toBeCloseTo(20, 6);
-  });
-
-  it('distributes across multiple inter-word spaces equally', () => {
-    // Three tokens; "the " and "lazy " are eligible (final "dog" excluded). Two
-    // trailing spaces → two gaps.
-    const segs = [seg('the '), seg('lazy '), seg('dog')];
-    const r = distributeLineSlack(segs, 30, 0, 2);
-    expect(r).not.toBeNull();
-    expect(r!.perGap).toBeCloseTo(15, 6);
-    expect(r!.perSeg.get(0)!.trailingGap).toBe(true);
-    expect(r!.perSeg.get(1)!.trailingGap).toBe(true);
-    expect(totalStretch(r!)).toBeCloseTo(30, 6);
-  });
-
-  it('never splits a long single Latin word (no gaps → null)', () => {
-    expect(distributeLineSlack([seg('supercalifragilistic')], 50, 0, 1)).toBeNull();
-  });
-});
-
-describe('distributeLineSlack — mixed Latin + CJK', () => {
-  // Mirrors private/sample-9 para#16: Latin word then CJK, no spaces inside CJK.
-  it('opens gaps at inter-CJK boundaries and at the Latin/CJK boundary', () => {
-    // One segment "BZ反応" — 4 code points: B Z 反 応.
-    //   B|Z : both Latin → NOT a gap.
-    //   Z|反 : right side CJK → gap (split before index 3, the 反).
-    //   反|応 : both CJK → gap (split before index 4? no — that's interior, before 応).
-    const segs = [seg('BZ反応')];
-    const r = distributeLineSlack(segs, 24, 0, 1);
-    expect(r).not.toBeNull();
-    const s = r!.perSeg.get(0)!;
-    // Gaps after Z (offset 1 → split before 2) and after 反 (offset 2 → split before 3).
-    expect(s.splitBefore).toEqual([2, 3]);
-    expect(s.trailingGap).toBe(false);
-    expect(r!.perGap).toBeCloseTo(12, 6);
-  });
-
-  it('does not open a gap between two Latin letters even next to CJK', () => {
-    // "反BZ応" code points: 反(0) B(1) Z(2) 応(3).
-    //   反|B → CJK left → gap after offset 0 → split before index 1.
-    //   B|Z → Latin-Latin → no gap.
-    //   Z|応 → CJK right → gap after offset 2 → split before index 3.
-    const segs = [seg('反BZ応')];
-    const r = distributeLineSlack(segs, 20, 0, 1);
-    const s = r!.perSeg.get(0)!;
-    expect(s.splitBefore).toEqual([1, 3]); // none after B (the Latin-Latin pair)
-  });
-});
-
-describe('distributeLineSlack — leading 字下げ indent stays fixed', () => {
-  it('does not stretch a leading whitespace segment before firstContentSi', () => {
-    // seg 0 = ideographic-space indent (fixed), seg 1 = CJK content, seg 2 = final.
+describe('text-distribute adapter — positional signature', () => {
+  it('forwards (segs, slack, firstContentSi, lastDrawnSi) positionally', () => {
+    // [indent][観察する][結果]: firstContentSi=1 skips the indent, lastDrawnSi=2 is
+    // the final segment (opens no gap). Verifies the positional args reach the
+    // kernel in the right slots.
     const segs = [seg('　'), seg('観察する'), seg('結果')];
-    // firstContentSi = 1 (indent skipped), lastDrawnSi = 2 (final opens no gap).
     const r = distributeLineSlack(segs, 30, 1, 2);
     expect(r).not.toBeNull();
-    expect(r!.perSeg.has(0)).toBe(false); // indent segment never stretched
+    expect(r!.perSeg.has(0)).toBe(false); // indent fixed
     expect(r!.perSeg.has(2)).toBe(false); // final segment opens no gap
     const s = r!.perSeg.get(1)!;
-    // "観察する" = 4 cp: 観|察, 察|す, す|る are internal; る|結 is the boundary
-    // into the final segment (trailing). 4 gaps total.
     expect(s.splitBefore).toEqual([1, 2, 3]);
     expect(s.trailingGap).toBe(true);
-    expect(r!.perGap).toBeCloseTo(7.5, 6); // 30 / 4
+    expect(r!.perGap).toBeCloseTo(7.5, 6);
     expect(totalStretch(r!)).toBeCloseTo(30, 6);
   });
 
-  it('skips a leading ideographic space at the START of the content segment', () => {
-    // sample-9 para#16 shape: a U+3000 indent fused into the content segment.
-    // The leading 　 must NOT open a gap; the first stretchable boundary is
-    // inside the CJK content after it.
-    const segs = [seg('　観察'), seg('結果')];
-    const r = distributeLineSlack(segs, 16, 0, 1);
+  it('§17.18.44: fills a wrapped pure-CJK line via inter-CJK pitch (expansion default)', () => {
+    // A pure-CJK phrase is ONE segment with no ASCII spaces; the default
+    // (includeCJK omitted = true) opens every interior boundary so the line fills.
+    const segs = [seg('観察することで')]; // 7 cp → 6 interior gaps
+    const r = distributeLineSlack(segs, 60, 0, 1);
     expect(r).not.toBeNull();
-    const s = r!.perSeg.get(0)!;
-    // code points: 　(0) 観(1) 察(2). Leading 　 is trimmed from the content
-    // span, so no gap after offset 0; gap 観|察 (after offset 1 → split before 2)
-    // and 察|結 (after offset 2 = last → trailing into final).
-    expect(s.splitBefore).toEqual([2]);
-    expect(s.trailingGap).toBe(true);
-    expect(totalStretch(r!)).toBeCloseTo(16, 6);
-  });
-
-  it('treats an interior ideographic space as a single inter-word gap', () => {
-    // "観　察" → 観(0) 　(1) 察(2). The 　 is one inter-word gap (after offset 1),
-    // NOT two CJK boundaries around it. 観|　 is a boundary into whitespace
-    // (counted by the space), so only one gap.
-    const segs = [seg('観　察結')];
-    const r = distributeLineSlack(segs, 10, 0, 1);
-    expect(r).not.toBeNull();
-    const s = r!.perSeg.get(0)!;
-    // gaps: after 　(offset 1 → split before 2, the inter-word gap) and 察|結
-    // (offset 2 → split before 3). 観|　 is NOT a gap.
-    expect(s.splitBefore).toEqual([2, 3]);
-    expect(r!.perGap).toBeCloseTo(5, 6); // 10 / 2
+    expect(r!.perSeg.get(0)!.splitBefore).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(r!.perGap).toBeCloseTo(10, 6);
   });
 });
 
-describe('distributeLineSlack — final segment opens no gap, Σgaps == slack', () => {
-  it('opens no gap WITHIN the final segment but does widen the boundary into it', () => {
-    // [観察][結果], justify. The 4 CJK chars spread as 観 _ 察 _ 結 _ 果: three
-    // equal gaps, 果 on the margin. Two of those gaps belong to seg 0 (観|察
-    // internal, 察|結 trailing-into-final); none belong to seg 1.
-    const segs = [seg('観察'), seg('結果')];
-    const r = distributeLineSlack(segs, 18, 0, 1);
-    expect(r).not.toBeNull();
-    expect(r!.perSeg.has(1)).toBe(false); // final segment opens no gap, never split
-    const s = r!.perSeg.get(0)!;
-    expect(s.splitBefore).toEqual([1]); // 観|察 internal
-    expect(s.trailingGap).toBe(true); // 察|結 boundary into the final segment
-    expect(r!.perGap).toBeCloseTo(9, 6); // 18 / 2 gaps
-    expect(totalStretch(r!)).toBeCloseTo(18, 6); // 果 still reaches the margin
-  });
-
-  it('Σgaps equals slack for a mixed multi-segment line', () => {
-    const segs = [seg('図 '), seg('観察する'), seg('こと')];
-    const r = distributeLineSlack(segs, 40, 0, 2);
-    expect(r).not.toBeNull();
-    expect(totalStretch(r!)).toBeCloseTo(40, 6);
-  });
-});
-
-describe('distributeLineSlack — negative slack (compression)', () => {
-  it('compresses gaps with a negative perGap, clamped to minPerGap', () => {
-    const segs = [seg('観察することで')]; // 6 interior gaps
-    // slack -60 → perGap -10, but clamp at -4 → perGap -4.
-    const r = distributeLineSlack(segs, -60, 0, 1, -4);
-    expect(r).not.toBeNull();
-    expect(r!.perGap).toBe(-4);
-  });
-
-  it('applies an unclamped negative perGap when within the cap', () => {
-    const segs = [seg('観察することで')];
-    const r = distributeLineSlack(segs, -12, 0, 1, -10);
-    expect(r!.perGap).toBeCloseTo(-2, 6); // -12/6 = -2, above the -10 floor
-  });
-
-  it('returns null when |slack| is below the 0.5px noise floor', () => {
-    expect(distributeLineSlack([seg('観察')], 0.3, 0, 1)).toBeNull();
-    expect(distributeLineSlack([seg('観察')], -0.4, 0, 1)).toBeNull();
-  });
-
-  it('with includeCJK=false, compresses only spaces and leaves CJK boundaries alone', () => {
-    // Mixed line, negative slack: only the inter-word space gap participates; the
-    // inter-CJK boundary is NOT compressed (no glyph overlap). This is the
-    // renderer's compression path (slack < 0 → includeCJK=false).
+describe('text-distribute adapter — includeCJK compression mapping', () => {
+  it('includeCJK=false compresses spaces only, never overlaps ideographs', () => {
+    // The docx compression path (slack < 0 → includeCJK = false). Only the inter-
+    // word space participates; the inter-CJK boundary is left alone.
     const segs = [seg('図 '), seg('観察'), seg('end')];
     const r = distributeLineSlack(segs, -10, 0, 2, -Infinity, false);
     expect(r).not.toBeNull();
-    // Only the space after "図 " (trailing gap of seg 0). 観|察 NOT opened.
-    expect(r!.perSeg.get(0)!.trailingGap).toBe(true);
-    expect(r!.perSeg.has(1)).toBe(false);
-    expect(r!.perGap).toBeCloseTo(-10, 6); // one gap absorbs all the (negative) slack
+    expect(r!.perSeg.get(0)!.trailingGap).toBe(true); // the space after "図 "
+    expect(r!.perSeg.has(1)).toBe(false); // 観|察 NOT opened
+    expect(r!.perGap).toBeCloseTo(-10, 6);
   });
 
-  it('with includeCJK=false, returns null for a space-free CJK line', () => {
-    // No spaces → no compressible gap → null (the renderer then leaves the line
-    // natural, overflowing by the small canvas-vs-Word bias, as before for CJK).
+  it('includeCJK=false returns null for a space-free CJK line (nothing to compress)', () => {
     expect(distributeLineSlack([seg('観察することで')], -30, 0, 1, -Infinity, false)).toBeNull();
   });
+
+  it('clamps a compressing perGap to minPerGap', () => {
+    const segs = [seg('観察することで')]; // 6 interior gaps, expansion
+    const r = distributeLineSlack(segs, -60, 0, 1, -4);
+    expect(r!.perGap).toBe(-4); // -60/6 = -10, clamped up to the -4 floor
+  });
 });
 
-describe('distributeLineSlack — non-text atoms', () => {
-  it('opens a CJK gap against an inline atom edge but not inside it', () => {
-    // seg 0 = image atom, seg 1 = CJK, seg 2 = final. atom|観 → CJK right → gap.
-    const segs: DistributeSeg[] = [{}, seg('観察'), seg('end')];
-    const r = distributeLineSlack(segs, 30, 0, 2);
+describe('text-distribute adapter — bidi exact-match exclusion (#483)', () => {
+  it('justifies a pure-RTL line where the visually-last segment is the logical first', () => {
+    // lastDrawnSi = logical-first (0). The exclusion is an EXACT match, not `>=`,
+    // so segs 1 and 2 still distribute; `>=` would have skipped the whole line.
+    const segs = [seg('a '), seg('b '), seg('c')];
+    const r = distributeLineSlack(segs, 30, 0, 0);
     expect(r).not.toBeNull();
-    // atom gets a trailing gap (boundary atom|観), CJK seg gets one interior gap (観|察).
-    expect(r!.perSeg.get(0)!.trailingGap).toBe(true);
-    expect(r!.perSeg.get(0)!.splitBefore).toEqual([]);
-    expect(r!.perSeg.get(1)!.splitBefore).toEqual([1]);
+    expect(r!.perSeg.has(0)).toBe(false);
+    expect(r!.perSeg.get(1)!.trailingGap).toBe(true);
     expect(totalStretch(r!)).toBeCloseTo(30, 6);
   });
 });
 
-describe('distributeLineSlack — bidi (visually-last segment ≠ logical-last)', () => {
-  // The renderer passes lastDrawnSi = the VISUALLY-last segment's LOGICAL index
-  // (visual.order[segCount-1]); under RTL that is NOT the maximum si. The
-  // exclusion must be an EXACT match, not `>=`: for a pure-RTL line lastDrawnSi
-  // is the logical-FIRST segment (0), so `>=` would suppress every segment →
-  // total 0 → null → the line renders unjustified. This guards that regression.
-  it('justifies when the fixed (visually-last) segment is the logical first (RTL)', () => {
-    // Three word-segments drawn right-to-left: logical seg 0 sits at the physical
-    // (right) end, so it opens no gap; segs 1 and 2 still distribute the slack.
-    const segs = [seg('a '), seg('b '), seg('c')];
-    const r = distributeLineSlack(segs, 30, 0, /* lastDrawnSi = logical-first */ 0);
-    expect(r).not.toBeNull(); // was null under the `>=` regression
-    expect(r!.perSeg.has(0)).toBe(false); // the visually-last segment opens no gap
-    expect(r!.perSeg.get(1)!.trailingGap).toBe(true); // its inter-word space stretches
-    expect(totalStretch(r!)).toBeCloseTo(30, 6);
+describe('text-distribute adapter — noise floor', () => {
+  it('returns null when |slack| is below 0.5px', () => {
+    expect(distributeLineSlack([seg('観察')], 0.3, 0, 1)).toBeNull();
+    expect(distributeLineSlack([seg('観察')], -0.4, 0, 1)).toBeNull();
   });
 });

--- a/packages/docx/src/text-distribute.ts
+++ b/packages/docx/src/text-distribute.ts
@@ -24,224 +24,83 @@
 // boundaries; it does NOT widen the boundary between two Latin letters of one
 // word.
 //
-// In this kernel `both` and `distribute` select the same gap opportunities and
-// differ only in the last line: `both` leaves the paragraph's final line natural,
-// `distribute` fills it too. NOTE: per spec `distribute` should additionally add
-// pitch between Latin letters within a word ("all characters on the line"); that
+// `both` and `distribute` select the same gap opportunities and differ only in
+// the last line: `both` leaves the paragraph's final line natural, `distribute`
+// fills it too — a policy the RENDERER owns (it decides whether to call this for
+// a given line). NOTE: per spec `distribute` should additionally add pitch
+// between Latin letters within a word ("all characters on the line"); that
 // pure-Latin refinement is unimplemented (rare, and it needs a Word ground truth)
 // and is tracked as a follow-up — CJK content, this kernel's target, is
-// unaffected. (The renderer decides whether to call this kernel
-// for a given line; the kernel just stretches whatever line it is handed.) This
-// mirrors the pptx text-justify kernel — see packages/pptx/src/text-justify.ts —
-// which reached the same gap model from the PowerPoint PDFs.
+// unaffected.
+//
+// The gap geometry itself lives in the shared kernel
+// `@silurus/ooxml-core` → `distributeLineSlack` (packages/core/src/text/
+// line-distribute.ts), which the pptx justifier shares too. This module is a thin
+// docx adapter: it keeps the renderer's positional call shape and injects docx's
+// whitespace predicate (U+0020 / U+3000, the core default) and the
+// expansion-vs-compression gap rule (compression touches spaces only, never
+// overlaps ideographs).
 //
 // Why a per-segment / per-character model: docx layout splits a paragraph into
 // segments at spaces and style boundaries (splitTextForLayout), so a CJK phrase
 // like "観察することで" is ONE segment with no internal spaces. Its inter-CJK
-// gaps fall INSIDE the segment, between code points — the old "advance after
-// trailing ASCII spaces only" model could never open them. This kernel walks the
-// line's whole code-point stream (boundaries evaluated across segment edges, so a
-// colour change mid-phrase doesn't swallow a gap) and reports, per segment, where
-// each gap falls: internal split points (to slice the glyph drawing) and a
-// trailing-edge flag (the inter-segment boundary). The renderer applies `perGap`
-// at each.
+// gaps fall INSIDE the segment, between code points. The kernel walks the line's
+// whole code-point stream and reports, per segment, where each gap falls:
+// internal split points (to slice the glyph drawing) and a trailing-edge flag
+// (the inter-segment boundary). The renderer applies `perGap` at each.
 
-import { isCjkBreakChar } from '@silurus/ooxml-core';
+import {
+  distributeLineSlack as distributeLineSlackCore,
+  type DistributeResult,
+} from '@silurus/ooxml-core';
 
-// A boundary between two non-space code points is a CJK stretch opportunity when
-// either side is a CJK / ideographic glyph, tested via the shared
-// core.isCjkBreakChar (the single CJK-range source across pptx/docx/xlsx). NOTE:
-// U+3000 (ideographic space) is inside that predicate's range, but the gap walker
-// classifies whitespace FIRST (see isJustifyWhitespace), so an ideographic space
-// becomes one inter-word gap and never reaches the CJK test.
-
-/** Whitespace that participates as an INTER-WORD gap: the ASCII space (U+0020)
- *  and the ideographic space (U+3000). Both are stretched as one gap each, like
- *  any inter-word space, rather than as CJK boundaries around them. (JS `\s`
- *  matches U+3000 too, so this stays consistent with the renderer's `/\S/`
- *  leading-indent detection.) */
-const isJustifyWhitespace = (cp: number): boolean => cp === 0x20 || cp === 0x3000;
-
-/** A laid-out segment as the distributor sees it. Only the optional text matters;
- *  an undefined `text` marks a non-text inline atom (image / math / tab) — one
- *  opaque unit bearing no stretch of its own, though a CJK neighbour can still
- *  open a gap against its edge (the atom counts as a non-CJK, non-space unit). */
-export interface DistributeSeg {
-  text?: string;
-}
-
-/** Per-text-segment instructions for applying the line's slack.
- *
- *  `splitBefore` lists the code-point offsets (1..len-1, counted in code points,
- *  NOT UTF-16 units) at which an INTERNAL gap falls — the glyphs before the
- *  offset are drawn, the pen advances by `perGap`, then drawing resumes.
- *  `trailingGap` marks that the boundary AFTER this segment's last code point
- *  (the inter-segment boundary) is a stretch opportunity. */
-export interface SegStretch {
-  /** Code-point offsets inside the segment after which to insert `perGap`. */
-  splitBefore: number[];
-  /** Whether to advance `perGap` after the whole segment (inter-segment gap). */
-  trailingGap: boolean;
-  /** px added strictly INSIDE the segment = splitBefore.length * perGap.
-   *  Decorations (highlight / underline / strike / ruby centring / onTextRun
-   *  width) should span measuredWidth + internalStretch. */
-  internalStretch: number;
-}
-
-/** Result of distributing a line's slack across its gap opportunities. */
-export interface DistributeResult {
-  /** px added at each gap (negative when the line is compressed). */
-  perGap: number;
-  /** Per-segment stretch, keyed by the segment's index in `segments`. Segments
-   *  with no gap (and non-text atoms) are absent. */
-  perSeg: Map<number, SegStretch>;
-}
+// Re-export the shared shapes so the renderer keeps importing them from here.
+export type {
+  DistributeSeg,
+  DistributeResult,
+  SegStretch,
+} from '@silurus/ooxml-core';
 
 /**
- * Distribute `slack` px equally across a justified line's gap opportunities
- * (inter-word ASCII spaces AND inter-CJK boundaries), per ECMA-376 §17.18.44.
+ * Distribute `slack` px across a justified line's gap opportunities (inter-word
+ * spaces AND, for expansion, inter-CJK boundaries), per ECMA-376 §17.18.44.
  *
- * A gap is opened AFTER a code point whose owning segment is in
- * `[firstContentSi, lastDrawnSi)` — i.e. the LEFT side of every gap is eligible,
- * while the gap's right side may be the first code point of the final segment (so
- * a 2-token line "the quick" still widens the space before "quick", and a CJK
- * line split into [観察][結果] still widens the 察|結 boundary). The final segment
- * thus opens no gap of its own and is never split internally, but the boundary
- * INTO it stretches like any other — all slack lands to the final glyph's left,
- * which reaches the margin (Σgaps == slack). Also excluded, matching the
- * renderer's pre-existing rules:
- *   - segments before `firstContentSi` (a paragraph's 字下げ leading-indent
- *     whitespace) stay fixed;
- *   - leading whitespace before the first content unit, and the gap after the
- *     last content unit, never stretch.
+ * Thin positional adapter over the shared `distributeLineSlack` kernel; see
+ * {@link DistributeResult} and the core docs for the gap model. docx's
+ * whitespace set is U+0020 / U+3000 — exactly the kernel default — so no
+ * whitespace predicate is injected.
  *
  * @param segments       The line's segments in LOGICAL (reading) order.
  * @param slack          availWidth - naturalWidth, px. >0 stretches; <0 compresses.
  * @param firstContentSi Index of the first segment holding non-whitespace content;
- *                       earlier (leading-indent) whitespace segments are fixed.
- *                       Pass 0 to disable the skip (e.g. under bidi).
+ *                       earlier (leading-indent / 字下げ) whitespace segments are
+ *                       fixed. Pass 0 to disable the skip (e.g. under bidi).
  * @param lastDrawnSi    Index of the visually-final segment; it and the boundary
- *                       into it get no gap.
- * @param minPerGap      Lower bound on a (negative) `perGap` when compressing
- *                       (slack < 0), so we never eat more than a capped amount per
- *                       gap. Ignored when slack >= 0.
+ *                       into it get no gap (EXACT match, not `>=`, for bidi).
+ * @param minPerGap      Lower bound on a (negative) `perGap` when compressing.
+ *                       Ignored when slack >= 0.
  * @param includeCJK     When true (default), inter-CJK boundaries open gaps too
- *                       (the §17.18.44 "additional character pitch shall be added"
- *                       behaviour, used for EXPANSION). When false, only inter-word
- *                       spaces open gaps — used for COMPRESSION (negative slack),
- *                       where shrinking a space glyph is legitimate but overlapping
- *                       two ideographs is not, so the renderer passes
- *                       includeCJK = slack > 0.
- * @returns The distribution, or `null` when nothing stretches (no eligible gap,
- *          or |slack| below the 0.5px noise floor).
+ *                       (EXPANSION). When false, only inter-word spaces open gaps
+ *                       — used for COMPRESSION (negative slack), where shrinking a
+ *                       space is legitimate but overlapping two ideographs is not,
+ *                       so the renderer passes includeCJK = slack > 0.
+ * @returns The distribution, or `null` when nothing stretches.
  */
 export function distributeLineSlack(
-  segments: readonly DistributeSeg[],
+  segments: readonly { text?: string }[],
   slack: number,
   firstContentSi: number,
   lastDrawnSi: number,
   minPerGap = -Infinity,
   includeCJK = true,
 ): DistributeResult | null {
-  if (Math.abs(slack) <= 0.5) return null;
-
-  // Flatten the eligible segments to a code-point stream. Segments before
-  // `firstContentSi` (leading 字下げ indent) are skipped; the rest — INCLUDING
-  // the final segment — are flattened, because a gap may have its RIGHT side in
-  // the final segment even though its left side may not be. Each unit carries its
-  // owning segment, the code-point offset within that segment, the code point,
-  // and an inter-word-whitespace flag (ASCII + ideographic space; see
-  // isJustifyWhitespace). Non-text atoms become one unit with cp=undefined.
-  type Unit = { si: number; off: number; cp?: number; ws: boolean };
-  const units: Unit[] = [];
-  for (let si = firstContentSi; si < segments.length; si++) {
-    const seg = segments[si];
-    if (seg === undefined) continue;
-    if (seg.text === undefined) {
-      units.push({ si, off: 0, ws: false });
-      continue;
-    }
-    let off = 0;
-    for (const ch of seg.text) {
-      const cp = ch.codePointAt(0)!;
-      units.push({ si, off, cp, ws: isJustifyWhitespace(cp) });
-      off++;
-    }
-  }
-
-  // Content span: the first and last NON-whitespace units. Leading/trailing
-  // spaces never stretch, and a single content unit has no interior gap.
-  let first = -1;
-  let last = -1;
-  for (let k = 0; k < units.length; k++) {
-    if (!units[k].ws) {
-      if (first === -1) first = k;
-      last = k;
-    }
-  }
-  if (first === -1 || first === last) return null;
-
-  // Mark a gap AFTER unit k, for first <= k < last, when k's owning segment is
-  // eligible to OPEN a gap (its si is not lastDrawnSi — the visually-last segment
-  // opens none and is never split, but the boundary INTO it still stretches).
-  // The match must be EXACT, not `>=`: under bidi lastDrawnSi is the visually-last
-  // segment's LOGICAL index, which is not the maximum si, so `>=` would wrongly
-  // suppress every logically-later segment (for a pure-RTL line that skips the
-  // whole line → no justification). Whitespace → one inter-word gap (Word
-  // stretches each space). Non-space → an inter-CJK gap only when the boundary to
-  // the next NON-space unit touches a CJK glyph; a boundary INTO whitespace is
-  // already counted by that whitespace, so it is not double-counted.
-  const gapAfter = new Array<boolean>(units.length).fill(false);
-  let total = 0;
-  for (let k = first; k < last; k++) {
-    const u = units[k];
-    if (u.si === lastDrawnSi) continue; // the visually-last segment opens no gap
-    if (u.ws) {
-      gapAfter[k] = true;
-      total++;
-      continue;
-    }
-    if (!includeCJK) continue; // compression path: only spaces open gaps
-    const nx = units[k + 1];
-    if (nx.ws) continue; // counted by that space when we reach it
-    const lc = u.cp;
-    const rc = nx.cp;
-    if (
-      (lc !== undefined && isCjkBreakChar(lc)) ||
-      (rc !== undefined && isCjkBreakChar(rc))
-    ) {
-      gapAfter[k] = true;
-      total++;
-    }
-  }
-  if (total === 0) return null;
-
-  let perGap = slack / total;
-  if (slack < 0 && perGap < minPerGap) perGap = minPerGap;
-
-  // Per-segment code-point length, to tell an internal gap (off < len-1) from the
-  // trailing inter-segment gap (off === len-1).
-  const segLen = new Map<number, number>();
-  for (const u of units) {
-    if (u.cp !== undefined) segLen.set(u.si, (segLen.get(u.si) ?? 0) + 1);
-  }
-
-  const perSeg = new Map<number, SegStretch>();
-  for (let k = 0; k < units.length; k++) {
-    if (!gapAfter[k]) continue;
-    const u = units[k];
-    let s = perSeg.get(u.si);
-    if (!s) {
-      s = { splitBefore: [], trailingGap: false, internalStretch: 0 };
-      perSeg.set(u.si, s);
-    }
-    const len = segLen.get(u.si) ?? 0;
-    if (u.cp === undefined || u.off === len - 1) {
-      s.trailingGap = true; // inter-segment boundary
-    } else {
-      s.splitBefore.push(u.off + 1); // split BEFORE code point off+1
-      s.internalStretch += perGap;
-    }
-  }
-  return { perGap, perSeg };
+  return distributeLineSlackCore(segments, slack, {
+    firstContentSi,
+    lastDrawnSi,
+    minPerGap,
+    // Compression (includeCJK=false) opens spaces only; never widen an inter-CJK
+    // boundary, which would overlap ideographs. The kernel default isGapChar
+    // (core.isCjkBreakChar) handles expansion.
+    ...(includeCJK ? {} : { isGapChar: () => false }),
+  });
 }

--- a/packages/pptx/src/text-justify.test.ts
+++ b/packages/pptx/src/text-justify.test.ts
@@ -124,6 +124,34 @@ describe('justifyLine', () => {
     ]);
   });
 
+  it('emits an empty-text segment (inline OMML equation) so it is still drawn', () => {
+    // In pptx an inline equation is a segment with text==='' (plus a `math`
+    // field), NOT text===undefined. The pre-extraction justifyLine accumulated
+    // glyphs into a buffer and pushed only NON-empty buffers, so it silently
+    // DROPPED the equation from a justified line (not drawn, pen not advanced →
+    // trailing text overlapped the gap). The shared-kernel adapter emits every
+    // text-bearing segment, so the equation survives with jext 0 and all fields
+    // (here `tag`, in production `math`) preserved; the gap distribution among
+    // the real glyphs is unchanged (the empty segment contributes no units).
+    const r = justifyLine<Seg>(
+      [
+        { text: '日', tag: 'a' },
+        { text: '', tag: 'math' },
+        { text: '本', tag: 'b' },
+      ],
+      120,
+      60,
+      'just',
+      false,
+    );
+    expect(r).not.toBeNull();
+    expect(r!.map((p) => [p.text, +p.jext.toFixed(3), p.tag])).toEqual([
+      ['日', 60, 'a'],
+      ['', 0, 'math'],
+      ['本', 0, 'b'],
+    ]);
+  });
+
   it('the jext advances sum to the slack (line reaches availWidth)', () => {
     const r = justifyLine<Seg>([{ text: 'Hello world foo bar' }], 300, 120, 'just', false);
     const sum = r!.reduce((a, p) => a + p.jext, 0);

--- a/packages/pptx/src/text-justify.test.ts
+++ b/packages/pptx/src/text-justify.test.ts
@@ -87,6 +87,32 @@ describe('justifyLine', () => {
     ]);
   });
 
+  it('opens gaps INSIDE the final segment too (CJK boundary inside the last run)', () => {
+    // [日本][語学], 4 glyphs. PowerPoint widens every inter-CJK boundary except
+    // after the last glyph — INCLUDING 語|学, which lives inside the final
+    // segment. Only the final glyph's gap is suppressed (the content-span trim),
+    // not the whole final segment. Pins that the adapter excludes no segment by
+    // index (lastDrawnSi sentinel = segments.length), so the second run is still
+    // split at 語|学; a `length-1` exclusion would wrongly leave 語学 unsplit.
+    const r = justifyLine<Seg>(
+      [
+        { text: '日本', tag: 'a' },
+        { text: '語学', tag: 'b' },
+      ],
+      150,
+      60,
+      'just',
+      false,
+    );
+    expect(r).not.toBeNull();
+    expect(r!.map((p) => [p.text, +p.jext.toFixed(3), p.tag])).toEqual([
+      ['日', 30, 'a'],
+      ['本', 30, 'a'],
+      ['語', 30, 'b'],
+      ['学', 0, 'b'],
+    ]);
+  });
+
   it('an inline object (text===undefined) is one unit and can take a gap', () => {
     const r = justifyLine<Seg>([{ text: '日' }, {}, { text: '本' }], 100, 60, 'just', false);
     // gaps after 日 and after the object → perGap = 40/2 = 20

--- a/packages/pptx/src/text-justify.ts
+++ b/packages/pptx/src/text-justify.ts
@@ -49,16 +49,15 @@
 // sum to the whole-line `naturalWidth` passed in, and the painted line lands on
 // `availWidth` without measurement drift.
 
-import { distributeLineSlack, isCjkBreakChar } from '@silurus/ooxml-core';
+import { distributeLineSlack, isCjkBreakChar, type DistributeSeg } from '@silurus/ooxml-core';
 
-/** A laid-out segment as seen by the justifier. Only the optional text matters;
- *  an undefined `text` marks an inline object (math / image), which is one
- *  opaque unit that bears no stretch of its own (a CJK neighbour can still open
- *  a gap against it). The generic `T` lets the renderer pass its full LayoutSeg
- *  and get pieces that keep every style field, plus `jext`. */
-export interface JustifySeg {
-  text?: string;
-}
+/** A laid-out segment as seen by the justifier: structurally the shared core
+ *  `DistributeSeg`, aliased (not re-declared) so there is a single structural
+ *  source. Only the optional `text` matters; an undefined `text` marks an inline
+ *  object that bears no stretch of its own (a CJK neighbour can still open a gap
+ *  against it). The generic `T` lets the renderer pass its full LayoutSeg and
+ *  get pieces that keep every style field, plus `jext`. */
+export type JustifySeg = DistributeSeg;
 
 export type JustifyMode = 'just' | 'dist';
 

--- a/packages/pptx/src/text-justify.ts
+++ b/packages/pptx/src/text-justify.ts
@@ -21,6 +21,14 @@
 // only; no length threshold is invented for other short lines (the spec gives
 // no metric, and a guess would be a heuristic).
 //
+// The gap geometry itself lives in the shared kernel
+// `@silurus/ooxml-core` → `distributeLineSlack` (packages/core/src/text/
+// line-distribute.ts), shared with the docx justifier. This module is a thin
+// pptx adapter: it owns the DrawingML last-line policy and the slack threshold,
+// injects PowerPoint's whitespace predicate (every JS `\s` char is an inter-word
+// space — wider than Word's U+0020/U+3000 set), and re-expresses the kernel's
+// per-segment result as the renderer's draw pieces.
+//
 // Why character-level, not segment-level: the layout merges adjacent
 // same-style tokens into ONE segment (see layoutParagraph's `push`/`sameMeta`),
 // so a plain paragraph line is usually a single segment holding the whole
@@ -41,15 +49,7 @@
 // sum to the whole-line `naturalWidth` passed in, and the painted line lands on
 // `availWidth` without measurement drift.
 
-import { isCjkBreakChar } from '@silurus/ooxml-core';
-
-/** A boundary is a stretch opportunity when either side is a CJK / ideographic
- *  glyph (see core's `isCjkBreakChar` for the canonical ranges). U+3000
- *  (ideographic space) is classified as whitespace below, so it never reaches
- *  this test — which is why sharing the wrap-side predicate (it includes U+3000)
- *  is safe here: a U+3000 unit is stretched as an inter-word gap, never reaching
- *  the CJK test, so it is never double-counted. */
-const isCjk = (ch: string): boolean => isCjkBreakChar(ch.codePointAt(0) ?? 0);
+import { distributeLineSlack, isCjkBreakChar } from '@silurus/ooxml-core';
 
 /** A laid-out segment as seen by the justifier. Only the optional text matters;
  *  an undefined `text` marks an inline object (math / image), which is one
@@ -62,7 +62,12 @@ export interface JustifySeg {
 
 export type JustifyMode = 'just' | 'dist';
 
-const isWsChar = (ch: string): boolean => /\s/.test(ch);
+/** PowerPoint counts EVERY JS-`\s` code point as an inter-word space (\t, \n, the
+ *  ideographic space U+3000, …), wider than Word's U+0020/U+3000 set. Injected
+ *  into the shared kernel so the pptx gap selection is unchanged by the
+ *  extraction. (U+3000 is whitespace here, so it is stretched as one inter-word
+ *  gap and never reaches the CJK predicate — never double-counted.) */
+const isWsCp = (cp: number): boolean => /\s/.test(String.fromCodePoint(cp));
 
 /**
  * Split one laid-out line into draw pieces that fill `availWidth` when each
@@ -92,78 +97,48 @@ export function justifyLine<T extends JustifySeg>(
   const slack = availWidth - naturalWidth;
   if (slack <= 0.5) return null;
 
-  // Flatten to a unit stream: each code point of a text segment is a unit; an
-  // inline object is a single (non-char, non-ws) unit.
-  type Unit = { ch?: string; ws: boolean };
-  const units: Unit[] = [];
-  for (const seg of segments) {
-    if (seg.text === undefined) {
-      units.push({ ws: false });
-    } else {
-      for (const ch of seg.text) units.push({ ch, ws: isWsChar(ch) });
-    }
-  }
+  // Shared gap selection. pptx justifies from the line start (no leading-indent
+  // skip), opens inter-CJK boundaries (expansion), and uses PowerPoint's wide
+  // whitespace predicate. It does NOT exclude any segment by index: the final
+  // glyph's gap is already suppressed by the kernel's content-span trim (the
+  // boundary AFTER the last non-whitespace unit opens no gap), so unlike docx —
+  // which draws its final segment separately and excludes it — pptx must let
+  // gaps open across EVERY segment boundary, including inside the last segment.
+  // `lastDrawnSi = segments.length` is therefore a sentinel that matches no real
+  // segment, reproducing the original code-point walk exactly.
+  const dist = distributeLineSlack(segments, slack, {
+    firstContentSi: 0,
+    lastDrawnSi: segments.length,
+    isGapChar: isCjkBreakChar,
+    isWhitespace: isWsCp,
+  });
+  if (!dist) return null;
 
-  // Content span: leading/trailing whitespace must not stretch, and a single
-  // content unit (one word / one glyph) has no inner gap.
-  let first = -1;
-  let last = -1;
-  for (let k = 0; k < units.length; k++) {
-    if (!units[k].ws) {
-      if (first === -1) first = k;
-      last = k;
-    }
-  }
-  if (first === -1 || first === last) return null;
+  const { perGap, perSeg } = dist;
 
-  // Mark the gap AFTER each qualifying unit. Whitespace → inter-word (one gap
-  // per space, Word stretches each). Non-whitespace → an inter-CJK gap only
-  // when the boundary to the next NON-whitespace unit touches a CJK glyph; a
-  // boundary into whitespace is already counted by that whitespace, so it is
-  // never double-counted here.
-  const gapAfter = new Array<boolean>(units.length).fill(false);
-  let total = 0;
-  for (let k = first; k < last; k++) {
-    const u = units[k];
-    if (u.ws) {
-      gapAfter[k] = true;
-      total++;
-    } else {
-      const nx = units[k + 1];
-      if (!nx.ws) {
-        const lc = u.ch;
-        const rc = nx.ch;
-        if ((lc !== undefined && isCjk(lc)) || (rc !== undefined && isCjk(rc))) {
-          gapAfter[k] = true;
-          total++;
-        }
-      }
-    }
-  }
-  if (total === 0) return null; // e.g. a single long Latin word that wrapped alone
-
-  const perGap = slack / total;
-
-  // Re-walk the SAME unit order, splitting each segment at gap positions.
+  // Re-express the per-segment stretch as the renderer's draw pieces. For each
+  // segment: an inline object is one piece (a trailing gap → jext = perGap);
+  // a text segment is sliced at the kernel's interior split offsets, each piece
+  // before a split advancing perGap, and the final piece advancing perGap iff
+  // the boundary AFTER the segment is a gap (trailingGap). This matches the old
+  // code-point walk exactly — Σ jext == slack, final glyph reaches availWidth.
   const out: (T & { jext: number })[] = [];
-  let k = 0;
-  for (const seg of segments) {
+  for (let si = 0; si < segments.length; si++) {
+    const seg = segments[si];
+    const s = perSeg.get(si);
     if (seg.text === undefined) {
-      out.push({ ...seg, jext: gapAfter[k] ? perGap : 0 });
-      k++;
+      out.push({ ...seg, jext: s?.trailingGap ? perGap : 0 });
       continue;
     }
-    let buf = '';
-    for (const ch of seg.text) {
-      buf += ch;
-      const g = gapAfter[k];
-      k++;
-      if (g) {
-        out.push({ ...seg, text: buf, jext: perGap });
-        buf = '';
-      }
+    const cps = [...seg.text]; // code points (handles surrogate pairs)
+    const splits = s?.splitBefore ?? [];
+    let from = 0;
+    for (const cut of splits) {
+      out.push({ ...seg, text: cps.slice(from, cut).join(''), jext: perGap });
+      from = cut;
     }
-    if (buf !== '') out.push({ ...seg, text: buf, jext: 0 });
+    // Final piece of this segment: trailingGap → perGap, else 0.
+    out.push({ ...seg, text: cps.slice(from).join(''), jext: s?.trailingGap ? perGap : 0 });
   }
   return out;
 }


### PR DESCRIPTION
## What

Extracts the justified-line slack distributor that pptx and docx had duplicated (~175 overlapping lines, ~75% of each kernel) into a single shared primitive in `@silurus/ooxml-core`. **Behavior-preserving — no pixel change.**

## Why

PR #481 (pptx `justifyLine`) and #483 (docx `distributeLineSlack`) independently implemented the same gap model: flatten the line to code points → content span → mark a gap at each inter-word space / inter-CJK boundary → `perGap = slack / total`. Two copies, two mirror-image test suites. With both on main, this is the inflection point to converge them.

## How

- **New `packages/core/src/text/line-distribute.ts`** → `distributeLineSlack(segments, slack, opts?)` (beside `kinsoku/` and `bidi/`), exported from `@silurus/ooxml-core`. Format-agnostic: returns the per-segment gap geometry (`{ splitBefore, trailingGap, internalStretch }` + `perGap`); no ECMA-376 policy lives here. Policy is injected via opts:
  - `isWhitespace` — PowerPoint counts every JS `\s`; Word counts only U+0020/U+3000. Each adapter injects its own.
  - `isGapChar` — `core.isCjkBreakChar` for expansion; `() => false` for docx's compression path.
  - `firstContentSi` / `lastDrawnSi` / `minPerGap` — leading-indent skip, the (exact-match, bidi-safe) final-segment exclusion, and the compression floor.
- **docx** `text-distribute.ts` → thin positional adapter over the core kernel; renderer untouched (same call, `SegStretch` re-exported from core). 247 → 106 lines.
- **pptx** `text-justify.ts` → thin adapter; `justifyLine` keeps its exact `(T & { jext })[]` signature and draw-piece output. It owns the DrawingML last-line policy + `slack <= 0.5` floor, injects PowerPoint's `\s` whitespace, and re-expresses the kernel's per-seg result as draw pieces. 169 → 144 lines.

### Subtlety worth noting (pinned by a test)

pptx and docx exclude the final segment differently. docx draws its visually-last segment separately and excludes it (`lastDrawnSi = visual.order[last]`, exact-match for bidi). pptx draws every segment in one loop, so it must let gaps open inside the last segment too — the final glyph is already suppressed by the kernel's content-span trim. The adapter passes `lastDrawnSi = segments.length` (a sentinel matching no real segment). A new pptx test pins the multi-glyph-final-segment case so this isn't "simplified" back to `length - 1` (which broke 10 tests).

## Verification (behavior-preserving)

- `vitest run`: **550 passed, 0 failed**. Justify subset: core 22 + pptx 16 + docx 8 = 46. The original 16 pptx + 19 docx kernel cases pass verbatim (the docx kernel cases moved to the core suite; docx keeps adapter-contract tests).
- `tsc --build` clean; `ast-grep scan` clean.
- **VRT: no pixel diffs** — docx demo 8/8, pptx demo 12/12 (private-sample 404s are gitignored absent files, not diffs).

## Scope

Only `packages/{core,pptx,docx}` touched; xlsx and `core/src/fonts/scripts.ts` (a separate font-selection predicate) untouched. Pre-existing follow-up carried over (out of scope): `distribute`'s pure-Latin intra-word pitch (§17.18.44 "all characters") remains unimplemented — CJK unaffected, needs a Word ground truth.

Merge with `--merge` / `--rebase` (no squash, per repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
