### PR TITLE
feat: unify embedded SVG (asvg:svgBlip) across docx/pptx/xlsx (0.64.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.64.0 — 2026-06-17
+
+Minor: embedded SVG images (Microsoft `asvg:svgBlip` extension, MS-ODRAWXML) now
+render across Word and Excel as well as PowerPoint, through shared blip helpers
+in `@silurus/ooxml-core` and the common Rust crate. PowerPoint additionally
+renders pictures that carry *only* the svgBlip (no raster fallback).
+
+### Shared
+
+- New `ooxml_common::blip` Rust helpers (`svg_blip_rid`, `blip_embed_rid`,
+  `mime_from_ext`) and a shared `getCachedSvgImage` decoder in
+  `@silurus/ooxml-core`, replacing three divergent `mime_from_ext` copies and the
+  previously pptx-only svgBlip logic. `.svg` parts map to `image/svg+xml`
+  everywhere; all three renderers prefer the vector original and fall back to the
+  raster on decode failure.
+
+### pptx
+
+- Render pictures whose `<a:blip>` carries only the `asvg:svgBlip` extension with
+  no raster `r:embed` (e.g. icons inserted as pure SVG) instead of dropping them.
+- An SVG picture with an `a:srcRect` crop no longer routes the SVG through
+  `createImageBitmap` (which cannot rasterize SVG in every browser); it decodes
+  via the shared `<img>` path.
+
+### docx
+
+- Honor the `asvg:svgBlip` extension on inline, anchored and grouped pictures:
+  draw the vector original, fall back to the raster. `.svg` parts are no longer
+  mislabeled `image/png`. (§20.1.8.13 + MS-ODRAWXML SVG extension)
+
+### xlsx
+
+- Honor the `asvg:svgBlip` extension on `xdr:twoCellAnchor` and grouped pictures;
+  `.svg` media parts are no longer excluded from collection.
+
 ## 0.63.0 — 2026-06-17
 
 Minor: Japanese line breaking (kinsoku) and justified-text alignment shared

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Right-to-left table column order (`w:bidiVisual`, §17.4.1) | ✅ |
 | | Math equations (OMML `m:oMath` / `m:oMathPara`, rendered via MathJax — opt-in `@silurus/ooxml/math`) | ✅ |
 | | Images (inline and anchored, with text wrap) | ✅ |
+| | SVG images (`asvg:svgBlip` MS-2016 extension — vector drawn from the embedded `.svg`, raster fallback) | ✅ |
 | | Text boxes / drawing shapes (`wps:txbx`, `a:prstGeom` — 186 preset geometries via the shared engine; connector arrow heads `headEnd` / `tailEnd` (§20.1.8.3) and `prstDash` dash patterns (§20.1.8.48)) | ✅ |
 | | WMF / EMF metafile images (legacy vector) | ❌ Not planned |
 | **Advanced** | Footnotes — reference markers + bottom-of-page bodies with separator rule, numbered (`w:footnoteReference` / `w:footnoteRef`, §17.11) | ✅ |
@@ -496,6 +497,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Row / column sizing (custom widths and heights) | ✅ |
 | | Hidden rows / columns | ✅ |
 | **Elements** | Images (`<xdr:twoCellAnchor>`) | ✅ |
+| | SVG images (`asvg:svgBlip` MS-2016 extension — vector drawn from the embedded `.svg`, raster fallback) | ✅ |
 | | Drawing shapes / text boxes (`xdr:sp`, `xdr:txBody` — 186 preset geometries via the shared engine, with `avLst` adjust handles) | ✅ |
 | | Math equations in shapes (OMML `m:oMath` / `m:oMathPara` in `xdr:txBody`, incl. `a14:m` / `mc:AlternateContent`; rendered via MathJax — opt-in `@silurus/ooxml/math`) | ✅ |
 | | Charts (bar, line, area, pie, doughnut, radar, scatter / bubble) | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/src/image/svg-image.ts
+++ b/packages/core/src/image/svg-image.ts
@@ -1,0 +1,57 @@
+// Shared decoder for embedded SVG images (Microsoft's `asvg:svgBlip` extension,
+// MS-ODRAWXML) used by the docx, pptx and xlsx renderers. The parsers surface
+// the vector original as a `data:image/svg+xml;base64,…` URL on the element's
+// `svgDataUrl`; this decodes it to a drawable `HTMLImageElement`.
+//
+// SVG is decoded via an `<img>` element rather than `createImageBitmap`, because
+// `createImageBitmap` cannot rasterize SVG in every browser. The same picture is
+// re-drawn on every render (scroll / resize / interaction), so the decoded image
+// is cached — the Promise, so concurrent first-renders dedupe. Unlike an
+// ImageBitmap, an HTMLImageElement holds no GPU resource that must be released,
+// so eviction just drops the entry (nothing to `.close()`). Bounded FIFO.
+
+const SVG_IMAGE_CACHE_MAX = 256;
+const svgImageCache = new Map<string, Promise<HTMLImageElement>>();
+
+/**
+ * Decode a `data:image/svg+xml;base64,…` URL to an `HTMLImageElement`, cached by
+ * URL. The returned image is drawable with `ctx.drawImage` exactly like an
+ * ImageBitmap; both expose numeric `.width`/`.height`. Rejects if the SVG fails
+ * to load — callers should fall back to the raster `dataUrl` on rejection.
+ */
+export function getCachedSvgImage(dataUrl: string): Promise<HTMLImageElement> {
+  const existing = svgImageCache.get(dataUrl);
+  if (existing) {
+    // Refresh LRU position.
+    svgImageCache.delete(dataUrl);
+    svgImageCache.set(dataUrl, existing);
+    return existing;
+  }
+  const p = new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      // `decode()` guarantees the bitmap is ready before the first draw, so the
+      // synchronous paint pass never draws an undecoded image. Fall back to the
+      // already-fired load event if decode() is unavailable / rejects.
+      if (typeof img.decode === 'function') {
+        img
+          .decode()
+          .then(() => resolve(img))
+          .catch(() => resolve(img));
+      } else {
+        resolve(img);
+      }
+    };
+    img.onerror = () => reject(new Error('SVG image failed to load'));
+    img.src = dataUrl;
+  });
+  // Don't poison the cache on a transient decode failure.
+  p.catch(() => svgImageCache.delete(dataUrl));
+  svgImageCache.set(dataUrl, p);
+  if (svgImageCache.size > SVG_IMAGE_CACHE_MAX) {
+    // HTMLImageElement holds no GPU handle — just drop the oldest entry.
+    const oldestKey = svgImageCache.keys().next().value as string;
+    svgImageCache.delete(oldestKey);
+  }
+  return p;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,9 @@ export { buildCustomPath } from './shape/custGeom';
 export { hexToRgba, resolveFill, applyStroke } from './shape/paint';
 export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/preset';
 export { drawArrowHead } from './shape/arrow';
+// Shared embedded-SVG decoder (Microsoft asvg:svgBlip extension) — used by all
+// three renderers to prefer the vector original over the raster fallback.
+export { getCachedSvgImage } from './image/svg-image';
 // ECMA-376 §20.1.9 spec-driven preset geometry engine (presets.json from
 // presetShapeDefinitions.xml). Coexists with the legacy hand-rolled
 // `buildShapePath` above, which the pptx renderer still uses as a silhouette /

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,5 +1,6 @@
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
+use ooxml_common::blip::{blip_embed_rid, mime_from_ext, svg_blip_rid};
 use roxmltree::Document as XmlDoc;
 use std::collections::HashMap;
 use std::io::Read;
@@ -914,15 +915,11 @@ fn load_media_map(
                 format!("{}{}", base_dir, target)
             };
             if let Ok(bytes) = read_zip_bytes(zip, &path) {
-                let mime = if path.ends_with(".png") {
-                    "image/png"
-                } else if path.ends_with(".jpg") || path.ends_with(".jpeg") {
-                    "image/jpeg"
-                } else if path.ends_with(".gif") {
-                    "image/gif"
-                } else {
-                    "image/png"
-                };
+                // Shared mime table (the single source of truth) — notably the
+                // only place `.svg` ⇒ `image/svg+xml` is decided. The previous
+                // inline map defaulted every non-png/jpg/gif part (including
+                // `.svg`) to `image/png`, so embedded SVG icons were mislabeled.
+                let mime = mime_from_ext(&path);
                 let b64 = B64.encode(&bytes);
                 media_map.insert(rid.clone(), format!("data:{};base64,{}", mime, b64));
             }
@@ -1882,6 +1879,32 @@ fn parse_run_inner(
     }
 }
 
+/// Resolve a DrawingML `<a:blip>`'s drawable source(s) against the document's
+/// media map (rId → `data:<mime>;base64,…`). Returns `(data_url, svg_data_url)`:
+///
+/// - `svg_data_url` is the Microsoft 2016 SVG extension target
+///   (`<a:extLst><asvg:svgBlip r:embed>`, MS-ODRAWXML) when present, else `None`.
+/// - `data_url` is the raster fallback (`<a:blip r:embed>`) when present, else it
+///   falls back to the SVG itself so an svg-only picture (no raster `r:embed`,
+///   e.g. an icon inserted as a pure SVG) is still drawable.
+///
+/// Returns `None` only when NEITHER source resolves (the element is then
+/// dropped, matching the previous raster-only behavior). `blip_embed_rid` /
+/// `svg_blip_rid` come from `ooxml_common::blip`, shared with pptx/xlsx.
+fn resolve_blip_urls(
+    blip: roxmltree::Node,
+    media_map: &HashMap<String, String>,
+) -> Option<(String, Option<String>)> {
+    let svg_data_url = svg_blip_rid(blip).and_then(|rid| media_map.get(&rid).cloned());
+    let raster_data_url = blip_embed_rid(&blip).and_then(|rid| media_map.get(&rid).cloned());
+    let data_url = match (raster_data_url, svg_data_url.as_ref()) {
+        (Some(raster), _) => raster,
+        (None, Some(svg)) => svg.clone(),
+        (None, None) => return None,
+    };
+    Some((data_url, svg_data_url))
+}
+
 fn parse_inline_drawing(
     node: roxmltree::Node,
     media_map: &HashMap<String, String>,
@@ -1914,19 +1937,19 @@ fn parse_inline_drawing(
             Some(b) => b,
             None => return vec![],
         };
-        let r_id = match blip
-            .attribute((R_NS, "embed"))
-            .or_else(|| blip.attribute("r:embed"))
-        {
-            Some(r) => r,
-            None => return vec![],
-        };
-        let data_url = match media_map.get(r_id) {
-            Some(u) => u.clone(),
+        // Microsoft 2016 SVG extension (MS-ODRAWXML): the vector original rides
+        // inside `<a:blip><a:extLst><asvg:svgBlip r:embed>`, while `<a:blip
+        // r:embed>` carries a raster (PNG/JPEG) *fallback* for SVG-incapable
+        // clients. Prefer the vector; fall back to the raster so an svg-only
+        // picture is never dropped. `data_url` keeps the raster when present,
+        // else the SVG itself; drop the element only if NEITHER resolves.
+        let (data_url, svg_data_url) = match resolve_blip_urls(blip, media_map) {
+            Some(urls) => urls,
             None => return vec![],
         };
         return vec![DocRun::Image(ImageRun {
             data_url,
+            svg_data_url,
             width_pt: cx / 12700.0,
             height_pt: cy / 12700.0,
             anchor: false,
@@ -2057,19 +2080,16 @@ fn parse_inline_drawing(
         Some(b) => b,
         None => return vec![],
     };
-    let r_id = match blip
-        .attribute((R_NS, "embed"))
-        .or_else(|| blip.attribute("r:embed"))
-    {
-        Some(r) => r,
-        None => return vec![],
-    };
-    let data_url = match media_map.get(r_id) {
-        Some(u) => u.clone(),
+    // Microsoft 2016 SVG extension (see parse_inline_drawing): prefer the vector
+    // original, keep the raster as the `data_url` fallback, and never drop an
+    // svg-only picture.
+    let (data_url, svg_data_url) = match resolve_blip_urls(blip, media_map) {
+        Some(urls) => urls,
         None => return vec![],
     };
     vec![DocRun::Image(ImageRun {
         data_url,
+        svg_data_url,
         width_pt: cx / 12700.0,
         height_pt: cy / 12700.0,
         anchor: true,
@@ -2457,10 +2477,10 @@ fn parse_group_pic(
 
     // Find the blip inside this pic.
     let blip = pic.descendants().find(|n| n.tag_name().name() == "blip")?;
-    let r_id = blip
-        .attribute((R_NS, "embed"))
-        .or_else(|| blip.attribute("r:embed"))?;
-    let data_url = media_map.get(r_id)?.clone();
+    // Microsoft 2016 SVG extension (see parse_inline_drawing): prefer the vector
+    // original, keep the raster as the `data_url` fallback, and never drop an
+    // svg-only picture.
+    let (data_url, svg_data_url) = resolve_blip_urls(blip, media_map)?;
 
     // Parse a:clrChange if present — used to make a specific color transparent.
     // clrFrom specifies the source color; clrTo with alpha=0 means replace with transparent.
@@ -2473,6 +2493,7 @@ fn parse_group_pic(
 
     Some(ImageRun {
         data_url,
+        svg_data_url,
         width_pt: cx * xform.scale_x / 12700.0,
         height_pt: cy * xform.scale_y / 12700.0,
         anchor: true,
@@ -5130,5 +5151,289 @@ mod footnote_tests {
     fn snap_to_grid_absent_is_none() {
         let p = first_para(r#"<w:p><w:r><w:t>x</w:t></w:r></w:p>"#);
         assert_eq!(p.snap_to_grid, None);
+    }
+}
+
+// ── Microsoft `asvg:svgBlip` extension (MS-ODRAWXML) ──────────────────────
+//
+// Mirrors pptx's svg-blip parser tests, adapted to docx's blip resolution
+// (`resolve_blip_urls` against a media map of rId → data URL) and to the
+// inline-drawing parse entry. Covers: raster + svgBlip both present, svgBlip
+// only (no raster `r:embed`, must still parse), and a plain raster blip
+// (svg_data_url stays None). The end-to-end test also exercises the
+// `load_media_map` mime fix (`.svg` ⇒ image/svg+xml, previously image/png).
+#[cfg(test)]
+mod svg_blip_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    const SVG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="#0a0"/></svg>"##;
+
+    /// 1×1 transparent PNG (smallest valid PNG), for the raster-fallback cases.
+    const PNG_1X1: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x62, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    /// Parse a standalone `<a:blip>` document into its root element so
+    /// `resolve_blip_urls` can be driven directly with a hand-built media map.
+    fn blip_doc(blip_xml: &str) -> XmlDoc<'_> {
+        XmlDoc::parse(blip_xml).unwrap()
+    }
+
+    /// A blip carrying a PNG fallback plus an `asvg:svgBlip` extension must
+    /// surface the SVG on `svg_data_url` while keeping the PNG as `data_url`.
+    /// The svgBlip uses a different prefix (asvg:) on purpose — matching is by
+    /// namespace-local name, so the prefix must not matter.
+    #[test]
+    fn resolve_blip_urls_prefers_svg_keeps_raster_fallback() {
+        let doc = blip_doc(
+            r#"<a:blip xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                 xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                 xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="rIdPng">
+                 <a:extLst>
+                   <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip r:embed="rIdSvg"/></a:ext>
+                 </a:extLst>
+               </a:blip>"#,
+        );
+        let mut media_map = HashMap::new();
+        media_map.insert(
+            "rIdPng".to_string(),
+            format!("data:image/png;base64,{}", B64.encode(PNG_1X1)),
+        );
+        media_map.insert(
+            "rIdSvg".to_string(),
+            format!("data:image/svg+xml;base64,{}", B64.encode(SVG)),
+        );
+
+        let (data_url, svg_data_url) =
+            resolve_blip_urls(doc.root_element(), &media_map).expect("both URLs resolve");
+        // PNG fallback preserved on data_url (regression-safe).
+        assert!(
+            data_url.starts_with("data:image/png;base64,"),
+            "data_url must remain the PNG fallback; got {}",
+            &data_url[..data_url.len().min(40)]
+        );
+        // The SVG body is surfaced separately as an image/svg+xml data URL.
+        let svg_url = svg_data_url.expect("svg_data_url must be Some when an svgBlip is present");
+        assert!(
+            svg_url.starts_with("data:image/svg+xml;base64,"),
+            "svg_data_url must be a base64 image/svg+xml data URL; got {}",
+            &svg_url[..svg_url.len().min(40)]
+        );
+        let decoded = B64
+            .decode(svg_url.strip_prefix("data:image/svg+xml;base64,").unwrap())
+            .expect("svg_data_url payload must be valid base64");
+        assert_eq!(
+            decoded, SVG,
+            "decoded svg_data_url must equal the .svg part"
+        );
+    }
+
+    /// A blip whose only image is the `asvg:svgBlip` extension — no raster
+    /// `r:embed` fallback at all (an icon inserted as a pure SVG, as in pptx
+    /// sample-12) — must still resolve: `svg_data_url` carries the SVG and
+    /// `data_url` falls back to the same SVG so the element is never dropped.
+    #[test]
+    fn resolve_blip_urls_svg_only_falls_back_data_url_to_svg() {
+        let doc = blip_doc(
+            r#"<a:blip xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                 xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                 xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main">
+                 <a:extLst>
+                   <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip r:embed="rIdSvg"/></a:ext>
+                 </a:extLst>
+               </a:blip>"#,
+        );
+        let svg_url = format!("data:image/svg+xml;base64,{}", B64.encode(SVG));
+        let mut media_map = HashMap::new();
+        media_map.insert("rIdSvg".to_string(), svg_url.clone());
+
+        let (data_url, svg_data_url) = resolve_blip_urls(doc.root_element(), &media_map)
+            .expect("svgBlip-only blip must still resolve");
+        assert_eq!(
+            svg_data_url.as_deref(),
+            Some(svg_url.as_str()),
+            "svg_data_url must be the SVG"
+        );
+        assert_eq!(
+            data_url, svg_url,
+            "data_url must fall back to the SVG when no raster blip is embedded"
+        );
+    }
+
+    /// A plain raster blip (no svgBlip extension) must leave `svg_data_url`
+    /// None and keep the raster on `data_url` — guards the new branch against
+    /// firing spuriously.
+    #[test]
+    fn resolve_blip_urls_plain_raster_has_no_svg() {
+        let doc = blip_doc(
+            r#"<a:blip xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                 xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:embed="rIdPng"/>"#,
+        );
+        let mut media_map = HashMap::new();
+        media_map.insert(
+            "rIdPng".to_string(),
+            format!("data:image/png;base64,{}", B64.encode(PNG_1X1)),
+        );
+        let (data_url, svg_data_url) =
+            resolve_blip_urls(doc.root_element(), &media_map).expect("raster resolves");
+        assert!(data_url.starts_with("data:image/png;base64,"));
+        assert!(
+            svg_data_url.is_none(),
+            "svg_data_url must be None without an svgBlip extension"
+        );
+    }
+
+    /// A blip with neither a raster `r:embed` nor a resolvable svgBlip drops
+    /// the element (returns None), matching the prior raster-only behavior.
+    #[test]
+    fn resolve_blip_urls_none_when_nothing_resolves() {
+        let doc = blip_doc(
+            r#"<a:blip xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                 xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:embed="rIdMissing"/>"#,
+        );
+        assert!(resolve_blip_urls(doc.root_element(), &HashMap::new()).is_none());
+    }
+
+    /// Build a minimal `.docx` zip with the given `word/document.xml` body, a
+    /// rels part mapping the two media rIds, and the PNG + SVG media parts.
+    fn build_docx_with_media(body_inner: &str) -> Vec<u8> {
+        use zip::write::SimpleFileOptions;
+        let document_xml = format!(
+            r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{body_inner}</w:body></w:document>"#
+        );
+        let rels_xml = r#"<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPng" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+  <Relationship Id="rIdSvg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image2.svg"/>
+</Relationships>"#;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            let mut put = |name: &str, bytes: &[u8]| {
+                use std::io::Write;
+                zw.start_file(name, opts).unwrap();
+                zw.write_all(bytes).unwrap();
+            };
+            put("word/document.xml", document_xml.as_bytes());
+            put("word/_rels/document.xml.rels", rels_xml.as_bytes());
+            put("word/media/image1.png", PNG_1X1);
+            put("word/media/image2.svg", SVG);
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    /// End-to-end through `parse()`: an inline `<w:drawing>` whose `<a:blip>`
+    /// carries ONLY an `asvg:svgBlip` (no raster `r:embed`) must still produce
+    /// an `ImageRun`, with the SVG on both `svg_data_url` and (as the fallback)
+    /// `data_url`. Also pins the `load_media_map` mime fix: the `.svg` part is
+    /// labeled `image/svg+xml`, not `image/png`.
+    #[test]
+    fn inline_drawing_with_svg_blip_and_no_raster_still_parses() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+             xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill>
+          <a:blip>
+            <a:extLst>
+              <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip r:embed="rIdSvg"/></a:ext>
+            </a:extLst>
+          </a:blip>
+        </pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx_with_media(body);
+        let doc = parse(&data).expect("parse must succeed");
+        let img = doc
+            .body
+            .iter()
+            .find_map(|el| match el {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Image(im) => Some(im),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("an inline svg-only image must parse");
+
+        let svg_url = img
+            .svg_data_url
+            .as_deref()
+            .expect("svg_data_url must be Some for an svgBlip-only picture");
+        assert!(
+            svg_url.starts_with("data:image/svg+xml;base64,"),
+            "svg part must be labeled image/svg+xml (load_media_map mime fix); got {}",
+            &svg_url[..svg_url.len().min(40)]
+        );
+        assert!(
+            img.data_url.starts_with("data:image/svg+xml;base64,"),
+            "data_url must fall back to the SVG when no raster blip is embedded; got {}",
+            &img.data_url[..img.data_url.len().min(40)]
+        );
+        // 304800 EMU / 12700 = 24pt.
+        assert!((img.width_pt - 24.0).abs() < 1e-6);
+    }
+
+    /// End-to-end: an inline `<a:blip r:embed>` with a raster fallback AND an
+    /// svgBlip extension keeps the PNG on `data_url` and the SVG on
+    /// `svg_data_url` (the renderer prefers the vector, falling back on decode
+    /// failure).
+    #[test]
+    fn inline_drawing_with_raster_and_svg_blip_emits_both() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+             xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill>
+          <a:blip r:embed="rIdPng">
+            <a:extLst>
+              <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip r:embed="rIdSvg"/></a:ext>
+            </a:extLst>
+          </a:blip>
+        </pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx_with_media(body);
+        let doc = parse(&data).expect("parse must succeed");
+        let img = doc
+            .body
+            .iter()
+            .find_map(|el| match el {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Image(im) => Some(im),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("an inline image must parse");
+        assert!(
+            img.data_url.starts_with("data:image/png;base64,"),
+            "data_url must be the PNG fallback when a raster r:embed is present"
+        );
+        assert!(
+            img.svg_data_url
+                .as_deref()
+                .is_some_and(|u| u.starts_with("data:image/svg+xml;base64,")),
+            "svg_data_url must carry the vector original"
+        );
     }
 }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -749,8 +749,14 @@ pub struct ShapeText {
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageRun {
-    /// data:<mime>;base64,...
+    /// data:<mime>;base64,... — the raster fallback (PNG/JPEG) of the blip, or
+    /// the SVG itself when the blip embeds no raster `r:embed`. Always drawable.
     pub data_url: String,
+    /// Vector original from the Microsoft `asvg:svgBlip` extension (MS-ODRAWXML),
+    /// as a `data:image/svg+xml;base64,…` URL. When present the renderer prefers
+    /// it over `data_url` (the raster fallback). `None` for a plain raster blip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svg_data_url: Option<String>,
     /// pt
     pub width_pt: f64,
     /// pt

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9,6 +9,7 @@ import {
   buildShapePath,
   renderPresetShape,
   hasPreset,
+  getCachedSvgImage,
   hexToRgba,
   resolveFill,
   applyStroke,
@@ -147,8 +148,9 @@ interface RenderState {
   pageIndex: number;
   /** total page count in the document */
   totalPages: number;
-  /** preloaded image bitmaps keyed by dataUrl */
-  images: Map<string, ImageBitmap>;
+  /** preloaded drawable images keyed by dataUrl (raster ImageBitmap or, for an
+   *  `asvg:svgBlip` vector original, an HTMLImageElement) */
+  images: Map<string, DecodedImage>;
   /** when true, layout is performed but nothing is drawn (used for header/footer height measurement) */
   dryRun: boolean;
   /** section left margin in pt — used to convert margin-relative anchor X to page-absolute */
@@ -239,8 +241,25 @@ export interface RenderDocumentOptions {
 
 // ===== Image preloading =====
 
+/**
+ * A decoded, drawable image. Raster blips decode to an `ImageBitmap`
+ * (createImageBitmap); the Microsoft `asvg:svgBlip` vector original decodes to
+ * an `HTMLImageElement` (via core's `getCachedSvgImage`, since
+ * `createImageBitmap` cannot rasterize SVG in every browser). Both are valid
+ * `ctx.drawImage` sources with numeric `.width`/`.height`, so every draw site is
+ * identical regardless of which kind was decoded.
+ */
+type DecodedImage = ImageBitmap | HTMLImageElement;
+
 interface ImagePair {
+  /** Raster fallback (or the SVG itself when no raster blip is embedded). */
   url: string;
+  /**
+   * Vector original from the `asvg:svgBlip` extension, when present. Preferred
+   * over `url`; the decoded image is still stored under `url`'s key so draw
+   * sites (which look up by `dataUrl`) find it unchanged.
+   */
+  svgUrl?: string;
   colorReplaceFrom?: string;
 }
 
@@ -280,7 +299,12 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
       if (run.type === 'image') {
         const img = run as unknown as ImageRun;
         const key = imageKey(img.dataUrl, img.colorReplaceFrom);
-        if (!seen.has(key)) seen.set(key, { url: img.dataUrl, colorReplaceFrom: img.colorReplaceFrom });
+        if (!seen.has(key))
+          seen.set(key, {
+            url: img.dataUrl,
+            svgUrl: img.svgDataUrl,
+            colorReplaceFrom: img.colorReplaceFrom,
+          });
       }
     }
   };
@@ -334,24 +358,60 @@ async function applyColorReplacement(bmp: ImageBitmap, colorHex: string): Promis
   return createImageBitmap(offscreen);
 }
 
-async function preloadImages(doc: DocxDocumentModel): Promise<Map<string, ImageBitmap>> {
+/**
+ * Decode a raster blip URL to an `ImageBitmap`, applying an `a:clrChange`
+ * (`colorReplaceFrom`) make-transparent pass when requested.
+ */
+async function decodeRaster(
+  url: string,
+  colorReplaceFrom?: string,
+): Promise<ImageBitmap> {
+  const res = await fetch(url);
+  const blob = await res.blob();
+  let bmp = await createImageBitmap(blob);
+  if (colorReplaceFrom) {
+    bmp = await applyColorReplacement(bmp, colorReplaceFrom);
+  }
+  return bmp;
+}
+
+async function preloadImages(doc: DocxDocumentModel): Promise<Map<string, DecodedImage>> {
   const pairs = collectImagePairs(doc);
   const entries = await Promise.all(
-    pairs.map(async (pair): Promise<[string, ImageBitmap] | null> => {
+    pairs.map(async (pair): Promise<[string, DecodedImage] | null> => {
+      // Unified svgBlip selection (shared with pptx/xlsx). The decoded image is
+      // keyed by the raster `url` (== element `dataUrl`) regardless of which
+      // source we picked, so every draw site finds it via imageKey(dataUrl, …)
+      // unchanged.
+      const dataIsSvg = pair.url.startsWith('data:image/svg+xml');
       try {
-        const res = await fetch(pair.url);
-        const blob = await res.blob();
-        let bmp = await createImageBitmap(blob);
-        if (pair.colorReplaceFrom) {
-          bmp = await applyColorReplacement(bmp, pair.colorReplaceFrom);
+        let img: DecodedImage;
+        if (pair.svgUrl != null) {
+          // Prefer the vector original (Microsoft `asvg:svgBlip` extension);
+          // fall back to the raster on any SVG decode failure. docx images have
+          // no srcRect crop, so the vector is always preferred when present.
+          try {
+            img = await getCachedSvgImage(pair.svgUrl);
+          } catch {
+            img = dataIsSvg
+              ? await getCachedSvgImage(pair.url)
+              : await decodeRaster(pair.url, pair.colorReplaceFrom);
+          }
+        } else if (dataIsSvg) {
+          // svg-only picture (no svgDataUrl surfaced — e.g. a non-svgBlip `.svg`
+          // part): `createImageBitmap` can't rasterize SVG, so decode through
+          // the <img>-based SVG path.
+          img = await getCachedSvgImage(pair.url);
+        } else {
+          img = await decodeRaster(pair.url, pair.colorReplaceFrom);
         }
-        return [imageKey(pair.url, pair.colorReplaceFrom), bmp];
+        return [imageKey(pair.url, pair.colorReplaceFrom), img];
       } catch {
         return null;
       }
     }),
   );
-  return new Map(entries.filter((e): e is [string, ImageBitmap] => e !== null));
+  return new Map(entries.filter((e): e is [string, DecodedImage] => e !== null));
 }
 
 // ===== Main entry =====
@@ -3439,7 +3499,7 @@ function renderInlineImage(
   x: number,
   baseline: number,
   scale: number,
-  images: Map<string, ImageBitmap>,
+  images: Map<string, DecodedImage>,
 ): void {
   // Anchor images are skipped during layout (measuredWidth=0, not added to line.segments)
   // and are drawn later by renderAnchorImages — so this function only handles inline images.

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -481,7 +481,18 @@ export interface RubyAnnotation {
 }
 
 export interface ImageRun {
+  /**
+   * `data:<mime>;base64,…` — the raster fallback (PNG/JPEG), or the SVG itself
+   * when no raster blip is embedded. Always drawable.
+   */
   dataUrl: string;
+  /**
+   * Vector original from the Microsoft `asvg:svgBlip` extension (MS-ODRAWXML),
+   * as a `data:image/svg+xml;base64,…` URL. When present the renderer prefers it
+   * over `dataUrl` (the raster fallback); `dataUrl` is the SVG itself when no
+   * raster blip is embedded. Absent for a plain raster image.
+   */
+  svgDataUrl?: string;
   widthPt: number;
   heightPt: number;
   /** true = wp:anchor (absolute positioned), false/undefined = wp:inline (flows with text) */

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/ooxml-common/src/blip.rs
+++ b/packages/ooxml-common/src/blip.rs
@@ -1,0 +1,145 @@
+//! Shared DrawingML blip helpers used by the docx, pptx and xlsx parsers.
+//!
+//! Every OOXML host references embedded media through the same DrawingML
+//! `<a:blip>` element (ECMA-376 §20.1.8.13). A blip's raster image rides in its
+//! `@r:embed` relationship; when the picture is a vector graphic, Microsoft's
+//! 2016 SVG extension (MS-ODRAWXML) nests an `<asvg:svgBlip r:embed="…">` inside
+//! the blip's `<a:extLst>`, and the raster `@r:embed` becomes a *fallback* for
+//! SVG-incapable clients. These helpers were previously re-implemented (or, for
+//! the SVG extension, only implemented in pptx) per parser; sharing them keeps
+//! the three formats' blip handling identical.
+
+use roxmltree::Node;
+
+/// Relationships namespace (`r:`) — where a blip's `embed` / `link` rIds live.
+pub const R_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+/// Microsoft 2016 SVG extension URI (MS-ODRAWXML). An `<a:blip>` wrapping a
+/// vector image carries `<a:extLst><a:ext uri="{96DAC541-…}"><asvg:svgBlip
+/// r:embed="…"/></a:ext></a:extLst>`.
+pub const SVG_BLIP_EXT_URI: &str = "{96DAC541-7B7A-43D3-8B79-37D633B846F1}";
+
+/// Resolve a blip-like node's `r:embed` relationship id (the raster image, or
+/// an `svgBlip`'s vector target). Reads the `embed` attribute in the
+/// relationships namespace, tolerating the literal `r:embed` form some producers
+/// emit without binding the namespace.
+pub fn blip_embed_rid(node: &Node<'_, '_>) -> Option<String> {
+    node.attribute((R_NS, "embed"))
+        .or_else(|| node.attribute("r:embed"))
+        .map(str::to_string)
+}
+
+/// Resolve the relationship id of the vector original from an `<a:blip>`'s
+/// `asvg:svgBlip` extension. Matching is by namespace-local element name
+/// (`svgBlip`), so the producer's prefix (`asvg:` etc.) does not matter. Returns
+/// `None` when the blip carries no svgBlip extension (the common, raster-only
+/// case).
+pub fn svg_blip_rid(blip: Node<'_, '_>) -> Option<String> {
+    blip.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "extLst")?
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "ext")
+        .find_map(|ext| {
+            ext.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "svgBlip")
+        })
+        .and_then(|svg_blip| blip_embed_rid(&svg_blip))
+}
+
+/// Map a part name / path extension to its MIME type, covering the image, audio
+/// and video parts OOXML blips reference. Unknown extensions fall back to
+/// `application/octet-stream`. This is the single source of truth for all three
+/// parsers — notably it is the only place `svg` ⇒ `image/svg+xml` is decided.
+pub fn mime_from_ext(path: &str) -> &'static str {
+    match path
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "bmp" => "image/bmp",
+        "svg" => "image/svg+xml",
+        "webp" => "image/webp",
+        "mp3" => "audio/mpeg",
+        "m4a" => "audio/mp4",
+        "wav" => "audio/wav",
+        "aac" => "audio/aac",
+        "wma" => "audio/x-ms-wma",
+        "flac" => "audio/flac",
+        "ogg" | "oga" => "audio/ogg",
+        "mp4" | "m4v" => "video/mp4",
+        "mov" | "qt" => "video/quicktime",
+        "avi" => "video/x-msvideo",
+        "wmv" => "video/x-ms-wmv",
+        "mpg" | "mpeg" => "video/mpeg",
+        "3gp" => "video/3gpp",
+        "mkv" => "video/x-matroska",
+        "webm" => "video/webm",
+        "ogv" => "video/ogg",
+        _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roxmltree::Document;
+
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    const ASVG_NS: &str = "http://schemas.microsoft.com/office/drawing/2016/SVG/main";
+
+    #[test]
+    fn svg_blip_rid_reads_extension_regardless_of_prefix() {
+        // The svgBlip uses a different prefix (asvg:) on purpose: matching is by
+        // namespace-local name, so the prefix must not matter.
+        let xml = format!(
+            r#"<a:blip xmlns:a="{A_NS}" xmlns:r="{R_NS}" xmlns:asvg="{ASVG_NS}" r:embed="rIdPng">
+                 <a:extLst>
+                   <a:ext uri="{SVG_BLIP_EXT_URI}"><asvg:svgBlip r:embed="rIdSvg"/></a:ext>
+                 </a:extLst>
+               </a:blip>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        let blip = doc.root_element();
+        assert_eq!(blip_embed_rid(&blip).as_deref(), Some("rIdPng"));
+        assert_eq!(svg_blip_rid(blip).as_deref(), Some("rIdSvg"));
+    }
+
+    #[test]
+    fn svg_blip_only_has_no_raster_embed() {
+        // sample-12 shape: the blip has no r:embed at all, only the svgBlip ext.
+        let xml = format!(
+            r#"<a:blip xmlns:a="{A_NS}" xmlns:r="{R_NS}" xmlns:asvg="{ASVG_NS}">
+                 <a:extLst>
+                   <a:ext uri="{SVG_BLIP_EXT_URI}"><asvg:svgBlip r:embed="rIdSvg"/></a:ext>
+                 </a:extLst>
+               </a:blip>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        let blip = doc.root_element();
+        assert_eq!(blip_embed_rid(&blip), None);
+        assert_eq!(svg_blip_rid(blip).as_deref(), Some("rIdSvg"));
+    }
+
+    #[test]
+    fn plain_blip_has_no_svg() {
+        let xml = format!(r#"<a:blip xmlns:a="{A_NS}" xmlns:r="{R_NS}" r:embed="rId1"/>"#);
+        let doc = Document::parse(&xml).unwrap();
+        let blip = doc.root_element();
+        assert_eq!(blip_embed_rid(&blip).as_deref(), Some("rId1"));
+        assert_eq!(svg_blip_rid(blip), None);
+    }
+
+    #[test]
+    fn mime_table_covers_svg_and_common_rasters() {
+        assert_eq!(mime_from_ext("../media/image2.svg"), "image/svg+xml");
+        assert_eq!(mime_from_ext("a/b/image1.PNG"), "image/png");
+        assert_eq!(mime_from_ext("x.jpeg"), "image/jpeg");
+        assert_eq!(mime_from_ext("x.webp"), "image/webp");
+        assert_eq!(mime_from_ext("noext"), "application/octet-stream");
+    }
+}

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -6,6 +6,7 @@
 //! schema-specific (DocParagraph, ShapeRun, Slide, etc.) stays in the
 //! consuming crate.
 
+pub mod blip;
 pub mod chart;
 pub mod color;
 pub mod math;

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1,4 +1,5 @@
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ooxml_common::blip::{mime_from_ext, svg_blip_rid};
 use ooxml_common::math::{nodes_to_text, parse_omath_nodes, MathNode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -950,6 +951,10 @@ struct PictureElement {
     rotation: f64,
     flip_h: bool,
     flip_v: bool,
+    /// The raster image from the blip's own `r:embed` (PNG/JPEG). When the
+    /// picture is a pure SVG with no raster `r:embed` (only the svgBlip
+    /// extension below), this falls back to the SVG data URL so the element is
+    /// always drawable; `svg_data_url` then holds the same vector source.
     data_url: String,
     /// Microsoft 2016 SVG extension (`<a:blip><a:extLst><a:ext
     /// uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip r:embed>`):
@@ -6376,14 +6381,7 @@ fn svg_blip_data_url(
     rels: &HashMap<String, String>,
     zip: &mut PptxZip<'_>,
 ) -> Option<String> {
-    let svg_blip = child(blip, "extLst")?
-        .children()
-        .filter(|n| n.is_element() && n.tag_name().name() == "ext")
-        .find_map(|ext| {
-            ext.children()
-                .find(|n| n.is_element() && n.tag_name().name() == "svgBlip")
-        })?;
-    let svg_rid = attr_r(&svg_blip, "embed")?;
+    let svg_rid = svg_blip_rid(blip)?;
     let svg_target = rels.get(&svg_rid)?;
     let svg_path = resolve_path(slide_dir, svg_target);
     let svg_bytes = read_zip_bytes(zip, &svg_path)?;
@@ -6410,19 +6408,35 @@ fn parse_picture(
 
     let blip_fill = child(pic_node, "blipFill")?;
     let blip = child(blip_fill, "blip")?;
-    let r_id = attr_r(&blip, "embed")?;
 
-    let rel_target = rels.get(&r_id)?;
-    let image_path = resolve_path(slide_dir, rel_target);
-
-    let image_bytes = read_zip_bytes(zip, &image_path)?;
-    let mime = mime_from_ext(&image_path);
-    let data_url = format!("data:{mime};base64,{}", B64.encode(&image_bytes));
-
-    // Microsoft 2016 SVG extension: the PNG above is only the fallback; the real
-    // vector image rides inside `<a:blip><a:extLst>`. Surface it separately so
-    // the renderer can prefer the SVG and fall back to the PNG on decode error.
+    // Microsoft 2016 SVG extension: the real vector image rides inside
+    // `<a:blip><a:extLst>`, while `<a:blip r:embed>` carries a raster (PNG/JPEG)
+    // *fallback* for SVG-incapable clients. Resolve the SVG first so a picture
+    // that carries ONLY the svgBlip — with no raster `r:embed`, e.g. an icon
+    // inserted as a pure SVG — still parses instead of being dropped. Surfaced
+    // separately so the renderer can prefer the vector original and fall back to
+    // the raster on decode error.
     let svg_data_url = svg_blip_data_url(blip, slide_dir, rels, zip);
+
+    // Raster blip (`<a:blip r:embed>` → PNG/JPEG data URL). Optional: a pure-SVG
+    // picture omits it, so this is no longer a hard requirement for the element.
+    let raster_data_url = (|| -> Option<String> {
+        let r_id = attr_r(&blip, "embed")?;
+        let rel_target = rels.get(&r_id)?;
+        let image_path = resolve_path(slide_dir, rel_target);
+        let image_bytes = read_zip_bytes(zip, &image_path)?;
+        let mime = mime_from_ext(&image_path);
+        Some(format!("data:{mime};base64,{}", B64.encode(&image_bytes)))
+    })();
+
+    // A picture needs at least one drawable source. Keep the raster as `data_url`
+    // (the renderer's srcRect / SVG-decode-failure fallback path); when no raster
+    // is embedded, fall back to the SVG itself so the element is always drawable.
+    let data_url = match (raster_data_url, svg_data_url.as_ref()) {
+        (Some(raster), _) => raster,
+        (None, Some(svg)) => svg.clone(),
+        (None, None) => return None,
+    };
 
     // ECMA-376 §20.1.9.8 — `<p:pic>` may carry `<a:custGeom>` inside `<p:spPr>`,
     // in which case the bitmap is clipped to that custom path (e.g. a laptop
@@ -6488,40 +6502,6 @@ fn png_size_from_data_url(data_url: &str) -> Option<(u32, u32)> {
 
 /// EMU per CSS pixel at PowerPoint's default 96 DPI (914400 EMU/inch ÷ 96).
 const EMU_PER_PX_96DPI: i64 = 9525;
-
-fn mime_from_ext(path: &str) -> &'static str {
-    match path
-        .rsplit('.')
-        .next()
-        .unwrap_or("")
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "bmp" => "image/bmp",
-        "svg" => "image/svg+xml",
-        "webp" => "image/webp",
-        "mp3" => "audio/mpeg",
-        "m4a" => "audio/mp4",
-        "wav" => "audio/wav",
-        "aac" => "audio/aac",
-        "wma" => "audio/x-ms-wma",
-        "flac" => "audio/flac",
-        "ogg" | "oga" => "audio/ogg",
-        "mp4" | "m4v" => "video/mp4",
-        "mov" | "qt" => "video/quicktime",
-        "avi" => "video/x-msvideo",
-        "wmv" => "video/x-ms-wmv",
-        "mpg" | "mpeg" => "video/mpeg",
-        "3gp" => "video/3gpp",
-        "mkv" => "video/x-matroska",
-        "webm" => "video/webm",
-        "ogv" => "video/ogg",
-        _ => "application/octet-stream",
-    }
-}
 
 /// If a `p:pic` declares an `a:audioFile` / `a:videoFile` in its `nvPr`
 /// (or the newer `p14:media` extension), emit a `MediaElement` with the
@@ -10713,6 +10693,78 @@ mod tests {
         assert!(
             pic.svg_data_url.is_none(),
             "svg_data_url must be None without an svgBlip extension"
+        );
+    }
+
+    /// A `<p:pic>` whose `<a:blip>` carries ONLY the `asvg:svgBlip` extension —
+    /// no raster `r:embed` fallback at all (an icon inserted as a pure SVG, as
+    /// in sample-12) — must still parse. Previously the mandatory raster embed
+    /// (`attr_r(&blip, "embed")?`) made `parse_picture` return None, so the whole
+    /// picture was silently dropped and the SVG never rendered.
+    #[test]
+    fn picture_with_only_svg_blip_and_no_raster_embed_still_parses() {
+        const SVG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="#0a0"/></svg>"##;
+
+        // The `<a:blip>` has NO r:embed attribute — the image is referenced only
+        // through the svgBlip extension.
+        let pic_xml = r#"<p:pic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+  xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main">
+  <p:nvPicPr><p:cNvPr id="4" name="SvgOnly"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+  <p:blipFill>
+    <a:blip>
+      <a:extLst>
+        <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">
+          <asvg:svgBlip r:embed="rIdSvg"/>
+        </a:ext>
+      </a:extLst>
+    </a:blip>
+    <a:stretch><a:fillRect/></a:stretch>
+  </p:blipFill>
+  <p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300000" cy="300000"/></a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+</p:pic>"#;
+
+        let doc = roxmltree::Document::parse(pic_xml).unwrap();
+        let pic_node = doc.root_element();
+
+        let mut rels = HashMap::new();
+        rels.insert("rIdSvg".to_string(), "../media/image2.svg".to_string());
+
+        let theme = HashMap::new();
+        // Only the .svg part is referenced; the PNG arg is unused here.
+        let data = build_blip_media_zip(b"", SVG);
+        let cursor = Cursor::new(data.as_slice());
+        let mut zip = zip::ZipArchive::new(cursor).unwrap();
+
+        let pic = parse_picture(pic_node, "ppt/slides", &rels, &theme, &mut zip)
+            .expect("parse_picture must succeed for an svgBlip-only picture (sample-12 case)");
+
+        // The SVG body is surfaced on svg_data_url so the renderer prefers it.
+        let svg_url = pic
+            .svg_data_url
+            .as_deref()
+            .expect("svg_data_url must be Some for an svgBlip-only picture");
+        assert!(
+            svg_url.starts_with("data:image/svg+xml;base64,"),
+            "svg_data_url must be a base64 image/svg+xml data URL; got {}",
+            &svg_url[..svg_url.len().min(40)]
+        );
+
+        // With no raster blip, data_url falls back to the SVG itself so the
+        // element is always drawable (rather than being dropped or empty).
+        assert!(
+            pic.data_url.starts_with("data:image/svg+xml;base64,"),
+            "data_url must fall back to the SVG when no raster blip is embedded; got {}",
+            &pic.data_url[..pic.data_url.len().min(40)]
+        );
+        let decoded = B64
+            .decode(svg_url.strip_prefix("data:image/svg+xml;base64,").unwrap())
+            .expect("svg_data_url payload must be valid base64");
+        assert_eq!(
+            decoded, SVG,
+            "decoded svg_data_url must equal the .svg part"
         );
     }
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -56,6 +56,7 @@ import {
   NON_CJK_SERIF_FALLBACKS,
   DEFAULT_KINSOKU_RULES,
   isCjkBreakChar,
+  getCachedSvgImage,
 } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
@@ -2483,15 +2484,6 @@ function renderTextBody(
 const IMAGE_BITMAP_CACHE_MAX = 256;
 const imageBitmapCache = new Map<string, Promise<ImageBitmap>>();
 
-// Decoded-SVG cache keyed by the `data:image/svg+xml;base64,…` URL. SVG
-// pictures (Microsoft's svgBlip extension) are decoded via an <img> element
-// (createImageBitmap cannot rasterize SVG in every browser), and the same
-// picture is re-drawn on every render. Cache the decoded HTMLImageElement
-// (the Promise, so concurrent first-renders dedupe). Unlike ImageBitmap, an
-// HTMLImageElement holds no GPU resource that must be released, so eviction
-// just drops the entry — there is nothing to `.close()`. Bounded FIFO.
-const SVG_IMAGE_CACHE_MAX = 256;
-const svgImageCache = new Map<string, Promise<HTMLImageElement>>();
 
 /** Local view of the parsed `<a:sp3d>` (1:1 with the Sp3d TS type). */
 interface Sp3dLike {
@@ -2811,48 +2803,6 @@ function getCachedBitmap(dataUrl: string): Promise<ImageBitmap> {
   return p;
 }
 
-/**
- * Decode a `data:image/svg+xml;base64,…` URL to an HTMLImageElement, cached by
- * URL. Used for pictures that carry Microsoft's svgBlip extension so the vector
- * original is drawn instead of the rasterized PNG fallback. Rejects (so callers
- * can fall back to the PNG) if the SVG fails to load. The returned image is
- * drawable with `ctx.drawImage` exactly like an ImageBitmap; it must NOT be
- * `.close()`d (only ImageBitmaps own a releasable resource).
- */
-function getCachedSvgImage(dataUrl: string): Promise<HTMLImageElement> {
-  const existing = svgImageCache.get(dataUrl);
-  if (existing) {
-    // Refresh LRU position.
-    svgImageCache.delete(dataUrl);
-    svgImageCache.set(dataUrl, existing);
-    return existing;
-  }
-  const p = new Promise<HTMLImageElement>((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => {
-      // `decode()` guarantees the bitmap is ready before the first draw, so the
-      // synchronous paint pass never draws an undecoded image. Fall back to the
-      // already-fired load event if decode() is unavailable / rejects.
-      if (typeof img.decode === 'function') {
-        img.decode().then(() => resolve(img)).catch(() => resolve(img));
-      } else {
-        resolve(img);
-      }
-    };
-    img.onerror = () => reject(new Error('SVG image failed to load'));
-    img.src = dataUrl;
-  });
-  // Don't poison the cache on a transient decode failure.
-  p.catch(() => svgImageCache.delete(dataUrl));
-  svgImageCache.set(dataUrl, p);
-  if (svgImageCache.size > SVG_IMAGE_CACHE_MAX) {
-    // HTMLImageElement holds no GPU handle — just drop the oldest entry.
-    const oldestKey = svgImageCache.keys().next().value as string;
-    svgImageCache.delete(oldestKey);
-  }
-  return p;
-}
-
 /** Poster bitmaps decoded once per media element; renderSlide's prefetch pass
  *  warms this so the sequential draw loop never waits on the network. Keyed by
  *  element identity (not posterPath), so the bitmap releases when the slide
@@ -2888,22 +2838,34 @@ async function renderPicture(
     // two drawable sources — both expose numeric .width/.height (used for the
     // srcRect crop below) and both are valid `ctx.drawImage` sources, so every
     // downstream path stays unchanged.
+    // `dataUrl` is normally a raster (PNG/JPEG), but for a pure-SVG picture with
+    // no raster blip it is the SVG itself — and `createImageBitmap` (getCachedBitmap)
+    // cannot rasterize SVG in every browser, so such a `dataUrl` must also go
+    // through the <img>-based SVG decoder.
+    const dataIsSvg = el.dataUrl.startsWith('data:image/svg+xml');
     let bitmap: ImageBitmap | HTMLImageElement;
     if (el.svgDataUrl != null && !el.srcRect) {
-      // No crop: prefer the vector original. With an a:srcRect crop, fall back
-      // to the PNG instead — the crop math below multiplies fractional srcRect
-      // edges by the source's pixel dims, and an SVG HTMLImageElement that
-      // declares only a viewBox (no intrinsic width/height) reports the
-      // 300×150 default rather than its logical size, so a 9-arg drawImage with
-      // a source rect samples the wrong basis (and Chromium draws nothing). The
-      // PNG fallback (el.dataUrl, always populated alongside svgDataUrl) has
-      // exact pixel dims that make the ECMA-376 §20.1.8.55 fractional crop
-      // well-defined and drawable.
+      // No crop: prefer the vector original. With an a:srcRect crop we skip this
+      // branch — the crop math below multiplies fractional srcRect edges by the
+      // source's pixel dims, and an SVG HTMLImageElement that declares only a
+      // viewBox (no intrinsic width/height) reports the 300×150 default rather
+      // than its logical size, so a 9-arg drawImage with a source rect samples
+      // the wrong basis. When a real raster exists it has exact pixel dims that
+      // make the ECMA-376 §20.1.8.55 fractional crop well-defined (handled in
+      // the final branch); when only the SVG exists the `dataIsSvg` branch below
+      // still draws it (uncropped is the overwhelmingly common case for icons).
       try {
         bitmap = await getCachedSvgImage(el.svgDataUrl);
       } catch {
-        bitmap = await getCachedBitmap(el.dataUrl);
+        bitmap = dataIsSvg
+          ? await getCachedSvgImage(el.dataUrl)
+          : await getCachedBitmap(el.dataUrl);
       }
+    } else if (dataIsSvg) {
+      // SVG-only picture (here either because it has a crop, or — defensively —
+      // because no svgDataUrl was surfaced): decode through the SVG path since
+      // createImageBitmap can't.
+      bitmap = await getCachedSvgImage(el.dataUrl);
     } else {
       bitmap = await getCachedBitmap(el.dataUrl);
     }
@@ -3724,8 +3686,11 @@ export async function renderSlide(
       // (The draw path still falls back to getCachedBitmap on SVG decode
       // failure, so the PNG stays cold only in that rare case.)
       const p = el as PictureElement;
+      const pDataIsSvg = p.dataUrl.startsWith('data:image/svg+xml');
       if (p.svgDataUrl != null && !p.srcRect) {
         void getCachedSvgImage(p.svgDataUrl).catch(() => undefined);
+      } else if (pDataIsSvg) {
+        void getCachedSvgImage(p.dataUrl).catch(() => undefined);
       } else {
         void getCachedBitmap(p.dataUrl).catch(() => undefined);
       }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1,6 +1,12 @@
 use crate::types::*;
-use crate::{mime_from_ext, parse_rels_map, read_zip_bytes, read_zip_entry, resolve_zip_path};
+use crate::{parse_rels_map, read_zip_bytes, read_zip_entry, resolve_zip_path};
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+// Shared DrawingML blip helpers (ECMA-376 §20.1.8.13 + Microsoft 2016 SVG
+// extension, MS-ODRAWXML). `mime_from_ext` is the single source of truth for
+// `.svg ⇒ image/svg+xml`; `svg_blip_rid` resolves the vector original nested in
+// a blip's `<a:extLst>`. Replaces xlsx's former local `mime_from_ext` (a strict
+// subset that lacked the `svg` arm and so dropped SVG parts).
+use ooxml_common::blip::{blip_embed_rid, mime_from_ext, svg_blip_rid};
 use std::collections::HashMap;
 use std::io::Cursor;
 
@@ -18,7 +24,6 @@ pub(crate) fn parse_drawing_anchors(
     };
     let xdr_ns = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
     let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
-    let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
     let mut anchors: Vec<ImageAnchor> = Vec::new();
 
     for anchor in doc.descendants() {
@@ -31,6 +36,10 @@ pub(crate) fn parse_drawing_anchors(
             (0u32, 0i64, 0u32, 0i64);
         let (mut to_col, mut to_col_off, mut to_row, mut to_row_off) = (0u32, 0i64, 0u32, 0i64);
         let mut pic_rid: Option<String> = None;
+        // Microsoft 2016 SVG extension (MS-ODRAWXML): the blip's vector original,
+        // nested in `<a:blip><a:extLst>`. The raster `r:embed` (pic_rid) is only a
+        // fallback for SVG-incapable clients.
+        let mut svg_rid: Option<String> = None;
         let mut native_ext_cx: i64 = 0;
         let mut native_ext_cy: i64 = 0;
         // ECMA-376 §20.5.2.33 `twoCellAnchor@editAs`. Possible values:
@@ -82,11 +91,12 @@ pub(crate) fn parse_drawing_anchors(
                             n.tag_name().name() == "blip" && n.tag_name().namespace() == Some(a_ns)
                         });
                         if let Some(b) = blip {
-                            // r:embed attribute
-                            pic_rid = b
-                                .attributes()
-                                .find(|a| a.name() == "embed" && a.namespace() == Some(r_ns))
-                                .map(|a| a.value().to_string());
+                            // Raster fallback (`<a:blip r:embed>`); tolerate the
+                            // literal `r:embed` form via the shared helper.
+                            pic_rid = blip_embed_rid(&b);
+                            // Vector original (`<asvg:svgBlip r:embed>` inside the
+                            // blip's `<a:extLst>`), matched by namespace-local name.
+                            svg_rid = svg_blip_rid(b);
                         }
                     }
                     // <xdr:pic><xdr:spPr><a:xfrm><a:ext cx cy>: the picture's
@@ -108,18 +118,31 @@ pub(crate) fn parse_drawing_anchors(
             }
         }
 
-        let Some(rid) = pic_rid else {
-            continue;
+        // Resolve a blip rId → media bytes → `data:<mime>;base64,…`. Shared by the
+        // raster fallback and the SVG original so both go through the single
+        // `mime_from_ext` table.
+        let mut resolve = |rid: &str| -> Option<String> {
+            let target = drawing_rels.get(rid)?;
+            let media_path = resolve_zip_path(drawing_dir, target);
+            let bytes = read_zip_bytes(archive, &media_path)?;
+            let mime = mime_from_ext(&media_path);
+            Some(format!("data:{mime};base64,{}", B64.encode(&bytes)))
         };
-        let Some(target) = drawing_rels.get(&rid) else {
-            continue;
+
+        // Vector original first (so an svg-only picture is never dropped); raster
+        // fallback second.
+        let svg_data_url = svg_rid.as_deref().and_then(&mut resolve);
+        let raster_data_url = pic_rid.as_deref().and_then(&mut resolve);
+
+        // A picture needs at least one drawable source. Prefer the raster as
+        // `data_url` (Excel's compatibility fallback); when no raster is embedded,
+        // fall back to the SVG itself so the element is always drawable. Drop only
+        // when neither resolves. ECMA-376 §20.1.8.13 + MS-ODRAWXML svgBlip.
+        let data_url = match (raster_data_url, svg_data_url.as_ref()) {
+            (Some(raster), _) => raster,
+            (None, Some(svg)) => svg.clone(),
+            (None, None) => continue,
         };
-        let media_path = resolve_zip_path(drawing_dir, target);
-        let Some(bytes) = read_zip_bytes(archive, &media_path) else {
-            continue;
-        };
-        let mime = mime_from_ext(&media_path);
-        let data_url = format!("data:{mime};base64,{}", B64.encode(&bytes));
 
         anchors.push(ImageAnchor {
             from_col,
@@ -134,6 +157,7 @@ pub(crate) fn parse_drawing_anchors(
             native_ext_cx,
             native_ext_cy,
             data_url,
+            svg_data_url,
         });
     }
     anchors
@@ -964,22 +988,26 @@ pub(crate) fn collect_shapes(
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0.0);
 
-            // Resolve <a:blip r:embed="rIdN"/>. The r:embed attribute lives in
-            // the relationships namespace, not the drawingml namespace.
-            let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-            let pic_rid = child
+            // Resolve `<a:blip>`. The raster fallback rides in `r:embed`; the
+            // vector original (Microsoft 2016 svgBlip extension, MS-ODRAWXML) is
+            // nested in `<a:blip><a:extLst>`. `rid_urls` maps every media rId
+            // (raster *and* svg) to its pre-encoded `data:<mime>;base64,…` URL.
+            let blip = child
                 .descendants()
-                .find(|n| n.is_element() && n.tag_name().name() == "blip")
-                .and_then(|b| {
-                    b.attributes()
-                        .find(|a| a.name() == "embed" && a.namespace() == Some(r_ns))
-                        .map(|a| a.value().to_string())
-                });
-            let Some(rid) = pic_rid else {
-                continue;
-            };
-            let Some(data_url) = rid_urls.get(&rid) else {
-                continue;
+                .find(|n| n.is_element() && n.tag_name().name() == "blip");
+            let pic_rid = blip.as_ref().and_then(blip_embed_rid);
+            let svg_rid = blip.and_then(svg_blip_rid);
+
+            let svg_data_url = svg_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
+            let raster_data_url = pic_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
+
+            // Prefer the raster as `data_url`; fall back to the SVG when no raster
+            // is embedded so an svg-only leaf is never dropped. Drop only when
+            // neither resolves. ECMA-376 §20.1.8.13 + MS-ODRAWXML svgBlip.
+            let data_url = match (raster_data_url, svg_data_url.as_ref()) {
+                (Some(raster), _) => raster,
+                (None, Some(svg)) => svg.clone(),
+                (None, None) => continue,
             };
 
             let root_x = trans_x + scale_x * xfrm.off_x;
@@ -1007,7 +1035,8 @@ pub(crate) fn collect_shapes(
                 stroke_color: None,
                 stroke_width: 0,
                 geom: ShapeGeom::Image {
-                    data_url: data_url.clone(),
+                    data_url,
+                    svg_data_url,
                 },
                 text: None,
             });
@@ -1299,12 +1328,16 @@ pub(crate) fn build_drawing_rid_urls(
     let mut result: HashMap<String, String> = HashMap::new();
     for (rid, target) in rels {
         let lower = target.to_lowercase();
+        // `.svg` is included so the Microsoft svgBlip extension's vector original
+        // is collected (it was previously excluded, dropping svg-only pictures);
+        // its `image/svg+xml` mime comes from the shared `mime_from_ext`.
         if !(lower.ends_with(".png")
             || lower.ends_with(".jpg")
             || lower.ends_with(".jpeg")
             || lower.ends_with(".gif")
             || lower.ends_with(".bmp")
-            || lower.ends_with(".webp"))
+            || lower.ends_with(".webp")
+            || lower.ends_with(".svg"))
         {
             continue;
         }
@@ -1686,5 +1719,178 @@ mod geom_tests {
             ShapeGeom::Preset { adj, .. } => assert_eq!(adj, vec![Some(16667.0)]),
             other => panic!("expected Preset, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod blip_svg_tests {
+    // Microsoft 2016 SVG extension (MS-ODRAWXML) on a `<xdr:pic>` blip: the real
+    // vector image rides in `<a:blip><a:extLst><a:ext
+    // uri="{96DAC541-…}"><asvg:svgBlip r:embed>`, while `<a:blip r:embed>` is a
+    // PNG/JPEG *fallback* (which may be absent for a pure-SVG insert). The parser
+    // must keep emitting the raster fallback as `data_url` (regression-safe) while
+    // additionally surfacing the SVG body in `svg_data_url`, and must never drop a
+    // picture that carries only the svgBlip. Mirrors the pptx parser tests.
+    use super::*;
+
+    // 1×1 transparent PNG (smallest valid PNG).
+    const PNG_1X1: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x62, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+    const SVG: &[u8] =
+        br##"<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2"><rect width="2" height="2" fill="#0a0"/></svg>"##;
+
+    /// Build a tiny zip with the two media parts a `<xdr:pic>` blip references
+    /// (a PNG fallback and an SVG body) under `xl/media/`, so
+    /// `parse_drawing_anchors` can be driven with a hand-rolled rels map.
+    fn build_media_zip(png: &[u8], svg: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let mut buf = Vec::new();
+        {
+            let cursor = Cursor::new(&mut buf);
+            let mut zw = zip::ZipWriter::new(cursor);
+            let opts = SimpleFileOptions::default();
+            zw.start_file("xl/media/image1.png", opts).unwrap();
+            zw.write_all(png).unwrap();
+            zw.start_file("xl/media/image2.svg", opts).unwrap();
+            zw.write_all(svg).unwrap();
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    /// `<xdr:wsDr>` wrapping a single `twoCellAnchor` picture whose `<a:blip>`
+    /// inner XML is supplied by the caller (so each test varies only the blip).
+    fn drawing_xml(blip_inner: &str) -> String {
+        format!(
+            r#"<xdr:wsDr
+  xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main">
+  <xdr:twoCellAnchor editAs="oneCell">
+    <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+    <xdr:to><xdr:col>3</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>5</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+    <xdr:pic>
+      <xdr:nvPicPr><xdr:cNvPr id="2" name="P"/><xdr:cNvPicPr/></xdr:nvPicPr>
+      <xdr:blipFill>{blip_inner}<a:stretch><a:fillRect/></a:stretch></xdr:blipFill>
+      <xdr:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="300000" cy="300000"/></a:xfrm>
+        <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr>
+    </xdr:pic>
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>
+</xdr:wsDr>"#
+        )
+    }
+
+    fn parse_one(blip_inner: &str, rels: &HashMap<String, String>) -> ImageAnchor {
+        let xml = drawing_xml(blip_inner);
+        let data = build_media_zip(PNG_1X1, SVG);
+        let cursor = Cursor::new(data.as_slice());
+        let mut archive = zip::ZipArchive::new(cursor).unwrap();
+        let anchors = parse_drawing_anchors(&xml, rels, "xl/drawings", &mut archive);
+        assert_eq!(anchors.len(), 1, "exactly one picture anchor expected");
+        anchors.into_iter().next().unwrap()
+    }
+
+    /// A `<xdr:pic>` carrying a PNG fallback blip plus an `asvg:svgBlip` extension
+    /// must yield both the PNG `data_url` and the SVG `svg_data_url`. The svgBlip
+    /// uses a different prefix (asvg:) on purpose — matching is by namespace-local
+    /// name, so the prefix must not matter.
+    #[test]
+    fn picture_with_svg_blip_extension_emits_both_urls() {
+        let blip = r#"<a:blip r:embed="rIdPng">
+          <a:extLst>
+            <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">
+              <asvg:svgBlip r:embed="rIdSvg"/>
+            </a:ext>
+          </a:extLst>
+        </a:blip>"#;
+        let mut rels = HashMap::new();
+        rels.insert("rIdPng".to_string(), "../media/image1.png".to_string());
+        rels.insert("rIdSvg".to_string(), "../media/image2.svg".to_string());
+
+        let anchor = parse_one(blip, &rels);
+
+        // PNG fallback is preserved on data_url (regression-safe).
+        assert!(
+            anchor.data_url.starts_with("data:image/png;base64,"),
+            "data_url must remain the PNG fallback; got {}",
+            &anchor.data_url[..anchor.data_url.len().min(40)]
+        );
+        // The SVG body is surfaced separately as an image/svg+xml data URL …
+        let svg_url = anchor
+            .svg_data_url
+            .as_deref()
+            .expect("svg_data_url must be Some when an svgBlip extension is present");
+        assert!(
+            svg_url.starts_with("data:image/svg+xml;base64,"),
+            "svg_data_url must be a base64 image/svg+xml data URL; got {}",
+            &svg_url[..svg_url.len().min(40)]
+        );
+        // … and it must decode back to the original SVG bytes.
+        let decoded = B64
+            .decode(svg_url.strip_prefix("data:image/svg+xml;base64,").unwrap())
+            .expect("svg_data_url payload must be valid base64");
+        assert_eq!(
+            decoded, SVG,
+            "decoded svg_data_url must equal the .svg part"
+        );
+    }
+
+    /// A `<xdr:pic>` whose `<a:blip>` carries ONLY the `asvg:svgBlip` extension —
+    /// no raster `r:embed` fallback (an icon inserted as a pure SVG) — must still
+    /// parse. Previously the media filter excluded `.svg` and the resolution
+    /// required a raster embed, so the whole picture was silently dropped.
+    #[test]
+    fn picture_with_only_svg_blip_and_no_raster_embed_still_parses() {
+        let blip = r#"<a:blip>
+          <a:extLst>
+            <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">
+              <asvg:svgBlip r:embed="rIdSvg"/>
+            </a:ext>
+          </a:extLst>
+        </a:blip>"#;
+        let mut rels = HashMap::new();
+        rels.insert("rIdSvg".to_string(), "../media/image2.svg".to_string());
+
+        let anchor = parse_one(blip, &rels);
+
+        // With no raster embed, data_url falls back to the SVG itself so the
+        // element is always drawable …
+        assert!(
+            anchor.data_url.starts_with("data:image/svg+xml;base64,"),
+            "data_url must fall back to the SVG when no raster is embedded; got {}",
+            &anchor.data_url[..anchor.data_url.len().min(40)]
+        );
+        // … and svg_data_url carries the same vector source.
+        let svg_url = anchor
+            .svg_data_url
+            .as_deref()
+            .expect("svg_data_url must be Some for a pure-SVG picture");
+        assert!(svg_url.starts_with("data:image/svg+xml;base64,"));
+        assert_eq!(svg_url, anchor.data_url);
+    }
+
+    /// A plain `<xdr:pic>` with no svgBlip extension must leave `svg_data_url`
+    /// as None (and still emit the PNG data_url) — guards against the new branch
+    /// firing spuriously.
+    #[test]
+    fn picture_without_svg_blip_has_no_svg_url() {
+        let blip = r#"<a:blip r:embed="rIdPng"/>"#;
+        let mut rels = HashMap::new();
+        rels.insert("rIdPng".to_string(), "../media/image1.png".to_string());
+
+        let anchor = parse_one(blip, &rels);
+        assert!(anchor.data_url.starts_with("data:image/png;base64,"));
+        assert!(
+            anchor.svg_data_url.is_none(),
+            "svg_data_url must be None without an svgBlip extension"
+        );
     }
 }

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1606,23 +1606,6 @@ pub(crate) fn resolve_zip_path(base_dir: &str, target: &str) -> String {
     parts.join("/")
 }
 
-pub(crate) fn mime_from_ext(path: &str) -> &'static str {
-    match path
-        .rsplit('.')
-        .next()
-        .unwrap_or("")
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "bmp" => "image/bmp",
-        "webp" => "image/webp",
-        _ => "application/octet-stream",
-    }
-}
-
 pub(crate) fn resolve_fill_color(
     fill_node: &roxmltree::Node,
     theme_colors: &[String],

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -942,11 +942,19 @@ pub enum ShapeGeom {
     },
     /// Freeform path geometry (ECMA-376 §20.1.9.2 `a:custGeom`).
     Custom { paths: Vec<PathInfo> },
-    /// Bitmap image leaf inside a `<xdr:grpSp>` tree (ECMA-376 §20.5.2.17).
-    /// `data_url` is a `data:<mime>;base64,…` URL produced from the drawing's
-    /// relationship target (png/jpg/gif/…).
+    /// Bitmap (or vector) image leaf inside a `<xdr:grpSp>` tree (ECMA-376
+    /// §20.5.2.17). `data_url` is a `data:<mime>;base64,…` URL produced from the
+    /// drawing's relationship target (png/jpg/gif/svg/…) — the blip's raster
+    /// `r:embed` fallback, or the SVG itself when no raster is embedded.
+    /// `svg_data_url` carries the Microsoft svgBlip extension's vector original
+    /// (`data:image/svg+xml;base64,…`) when present, so the renderer can prefer
+    /// it and fall back to `data_url` on a decode failure. `None` otherwise.
     #[serde(rename_all = "camelCase")]
-    Image { data_url: String },
+    Image {
+        data_url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        svg_data_url: Option<String>,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -1054,8 +1062,18 @@ pub struct ImageAnchor {
     /// `editAs == "oneCell"`. 0 = absent / use from/to rect.
     pub native_ext_cx: i64,
     pub native_ext_cy: i64,
-    /// Data URL: "data:image/png;base64,..."
+    /// Raster data URL ("data:image/png;base64,…"). The blip's own `r:embed`
+    /// fallback when an svgBlip extension is present; otherwise the only source.
+    /// Falls back to the SVG itself when the picture has no raster `r:embed`
+    /// (an icon inserted as a pure SVG), so the element is always drawable.
     pub data_url: String,
+    /// Microsoft 2016 SVG extension (`<a:blip><a:extLst><a:ext
+    /// uri="{96DAC541-…}"><asvg:svgBlip r:embed>`, MS-ODRAWXML): the vector
+    /// *original*, serialized as a `data:image/svg+xml;base64,…` URL so the
+    /// renderer can prefer it and fall back to `data_url` on a decode failure.
+    /// `None` when the picture carries no svgBlip extension (the common case).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svg_data_url: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -1,6 +1,38 @@
-import { defaultDpr, isHTMLCanvas, type MathRenderer } from '@silurus/ooxml-core';
+import { defaultDpr, isHTMLCanvas, getCachedSvgImage, type MathRenderer } from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions } from './types.js';
 import { renderViewport, prepareWorksheetMath, worksheetHasUncachedMath } from './renderer.js';
+
+/** Decode one image element to a drawable `CanvasImageSource`, preferring the
+ *  Microsoft svgBlip vector original (MS-ODRAWXML). Unified across the top-level
+ *  twoCellAnchor picture (`ImageAnchor`) and the `<xdr:grpSp>` leaf
+ *  (`ShapeGeom` image) — both carry a raster `dataUrl` fallback plus an optional
+ *  `svgDataUrl`. xlsx images have no `a:srcRect` crop, so the vector branch
+ *  always applies when an svgBlip is present (cf. the contract's `!srcRect`
+ *  gate). SVG decodes through `getCachedSvgImage` (an `<img>`) because
+ *  `createImageBitmap` cannot rasterize SVG in every browser. */
+async function decodeImageSource(
+  dataUrl: string,
+  svgDataUrl?: string,
+): Promise<CanvasImageSource> {
+  const decodeRaster = async (url: string): Promise<CanvasImageSource> =>
+    createImageBitmap(await (await fetch(url)).blob());
+  const dataIsSvg = dataUrl.startsWith('data:image/svg+xml');
+  if (svgDataUrl != null) {
+    // Prefer the vector original; fall back to the raster fallback on decode
+    // failure (or, when `dataUrl` is itself the SVG, the SVG decoder again).
+    try {
+      return await getCachedSvgImage(svgDataUrl);
+    } catch {
+      return dataIsSvg ? getCachedSvgImage(dataUrl) : decodeRaster(dataUrl);
+    }
+  }
+  if (dataIsSvg) {
+    // svg-only picture with no separate `svgDataUrl` field (defensive): the
+    // raster decoder (createImageBitmap) can't rasterize SVG.
+    return getCachedSvgImage(dataUrl);
+  }
+  return decodeRaster(dataUrl);
+}
 
 export interface RenderDeps {
   ws: Worksheet;
@@ -34,29 +66,32 @@ export async function renderWorksheetViewport(
   // every scroll frame. By awaiting first (and only when there's something
   // uncached), the whole resize+draw runs synchronously in a single tick and
   // the old frame stays visible until the new one is ready.
-  const uncached: string[] = [];
+  // The cache is keyed by `dataUrl` (the renderer's lookup key); the decoded
+  // source may come from `svgDataUrl` (preferred) instead. De-dup by `dataUrl`.
+  const uncached = new Map<string, string | undefined>();
   if (ws.images) {
     for (const img of ws.images) {
-      if (!imageCache.has(img.dataUrl)) uncached.push(img.dataUrl);
+      if (!imageCache.has(img.dataUrl)) uncached.set(img.dataUrl, img.svgDataUrl);
     }
   }
   if (ws.shapeGroups) {
     for (const grp of ws.shapeGroups) {
       for (const shape of grp.shapes) {
         if (shape.geom.type === 'image' && !imageCache.has(shape.geom.dataUrl)) {
-          uncached.push(shape.geom.dataUrl);
+          uncached.set(shape.geom.dataUrl, shape.geom.svgDataUrl);
         }
       }
     }
   }
-  if (uncached.length > 0) {
+  if (uncached.size > 0) {
     await Promise.all(
-      uncached.map(async (url) => {
-        const blob = await (await fetch(url)).blob();
-        const bmp = await createImageBitmap(blob);
-        imageCache.set(url, bmp);
+      [...uncached].map(async ([dataUrl, svgDataUrl]) => {
+        // Swallow per-image failures so one broken picture doesn't sink the grid.
+        try {
+          imageCache.set(dataUrl, await decodeImageSource(dataUrl, svgDataUrl));
+        } catch { /* leave uncached; renderer skips a missing source */ }
       }),
-    ).catch(() => { /* swallow image failures so the grid still renders */ });
+    );
   }
 
   // ── Step 1b: Pre-rasterize equations in shapes BEFORE the canvas resize,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -595,10 +595,19 @@ export type ShapeGeom =
       adj?: (number | null)[];
     }
   | { type: 'custom'; paths: PathInfo[] }
-  /** Bitmap picture leaf inside a `<xdr:grpSp>`. `dataUrl` is a pre-encoded
-   *  `data:<mime>;base64,…` produced by the Rust parser from the drawing's
-   *  relationship target. */
-  | { type: 'image'; dataUrl: string };
+  /** Bitmap (or vector) picture leaf inside a `<xdr:grpSp>`. `dataUrl` is a
+   *  pre-encoded `data:<mime>;base64,…` produced by the Rust parser from the
+   *  drawing's relationship target — the blip's raster `r:embed` fallback, or
+   *  the SVG itself when no raster is embedded. */
+  | {
+      type: 'image';
+      dataUrl: string;
+      /** Vector original from the Microsoft `asvg:svgBlip` extension
+       *  (MS-ODRAWXML), as a `data:image/svg+xml;base64,…` URL. Prefer this over
+       *  `dataUrl` (the raster fallback, or the SVG itself when no raster blip is
+       *  embedded). Absent when the picture carries no svgBlip extension. */
+      svgDataUrl?: string;
+    };
 
 export interface PathInfo {
   w: number;
@@ -638,8 +647,15 @@ export interface ImageAnchor {
    *  size. Authoritative when `editAs === "oneCell"`. 0 = unavailable. */
   nativeExtCx: number;
   nativeExtCy: number;
-  /** Data URL (data:image/png;base64,...) */
+  /** Raster data URL (data:image/png;base64,...). The blip's own `r:embed`
+   *  fallback when an svgBlip extension is present; otherwise the only source.
+   *  Falls back to the SVG itself when the picture has no raster `r:embed`. */
   dataUrl: string;
+  /** Vector original from the Microsoft `asvg:svgBlip` extension (MS-ODRAWXML),
+   *  as a `data:image/svg+xml;base64,…` URL. `dataUrl` is the raster fallback,
+   *  or the SVG itself when no raster blip is embedded. Absent when the picture
+   *  carries no svgBlip extension. */
+  svgDataUrl?: string;
 }
 
 export interface CellRange {

--- a/site/src/components/Capabilities.astro
+++ b/site/src/components/Capabilities.astro
@@ -5,7 +5,7 @@ const cols = [
     items: [
       'Headers / footers, section breaks',
       'Tables — borders, fills, merges',
-      'Images, inline & anchored with text wrap',
+      'Images & SVG, inline & anchored with text wrap',
       'Ruby / furigana, sub/superscript',
       'Line grid (docGrid), spacing rules',
       'Lists, paragraph & table styles',
@@ -24,7 +24,7 @@ const cols = [
       'Merged cells, frozen panes, kinsoku cell wrap',
       'Cell comments, list data validation',
       'Selection, TSV copy, zoom slider',
-      'Images, drawing shapes, slicers',
+      'Images & SVG, drawing shapes, slicers',
       'Math equations (OMML, STIX Two Math)',
     ],
   },


### PR DESCRIPTION
## Summary

Brings embedded **SVG image** support (Microsoft `asvg:svgBlip` extension, MS-ODRAWXML — the vector original beside a raster fallback inside `<a:blip><a:extLst>`) to parity across **docx, pptx and xlsx**, behind one shared implementation.

Originally this started as a pptx fix: `private/sample-12.pptx`'s SVG icon never rendered because `parse_picture` required a raster `<a:blip r:embed>` and dropped any `<p:pic>` carrying only the svgBlip. Reviewing for cross-package consistency surfaced that **docx ignored the extension entirely** (and mislabeled `.svg` parts as `image/png`) and **xlsx excluded `.svg` media parts**, so the work was unified.

## What changed

- **`ooxml-common` (Rust, new `blip` module):** `svg_blip_rid`, `blip_embed_rid`, `mime_from_ext` — one source of truth for the svgBlip walk and `.svg ⇒ image/svg+xml`. Replaces 3 divergent `mime_from_ext` copies + the pptx-only svgBlip logic.
- **`@silurus/ooxml-core` (TS):** shared `getCachedSvgImage` (`<img>`-based decode+cache; `createImageBitmap` can't rasterize SVG in every browser).
- **pptx:** render svgBlip-only pictures (the original bug); refactor onto the shared helpers; an SVG + `a:srcRect` no longer feeds the SVG to `createImageBitmap`.
- **docx / xlsx:** parse `svgDataUrl` on every picture site; renderer prefers the vector and falls back to the raster on decode failure; docx `.svg` mime fixed; xlsx `.svg` parts collected.

Unified contract (identical in all three): parser emits `(dataUrl, svgDataUrl?)` — `dataUrl` is the raster, or the SVG itself when no raster blip exists (so the element is never dropped); renderer prefers `svgDataUrl`, falls back to the raster.

## Review findings addressed
- Independent review #1 (pptx): the SVG + `srcRect` → `createImageBitmap` hole is fixed; `data_url` doc comments corrected.
- Independent review #2 (cross-package): drove the shared-helper design so docx/xlsx reach parity rather than diverging.
- **Out of scope (tracked follow-up):** `parse_blip_fill` shape/background fills still ignore svgBlip in all three; worker-mode (`mode:'worker'`) can't decode svg-only pictures because `getCachedSvgImage` uses `new Image()` (main-thread mode is unaffected; consistent across packages).

## Verification (all green)
- Rust workspace: pptx 72 / docx 49 / xlsx 53 / ooxml-common 41 / mcp 41; `fmt` + `clippy -D warnings` clean.
- TS: `pnpm typecheck` green; `vitest` 558/558.
- VRT (pptx/docx/xlsx): all green, **no `demo/*` regression**, reference images untouched.
- Visual: pptx `sample-12` SVG icon now renders (confirmed in Storybook).

## Release
Bundled release commit bumps all packages to **0.64.0** with CHANGELOG + README/site capability rows. Merge with `--merge` (no squash, per repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)