### PR TITLE
fix(pptx): render arrowheads on custom-geometry (freeform/curve) lines

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,11 @@ export {
 export { renderChart } from './chart/renderer';
 export { autoResize, type AutoResizeOptions } from './autoResize';
 export { buildCustomPath } from './shape/custGeom';
+export {
+  getCustGeomEndpoints,
+  type CustGeomEndpoint,
+  type CustGeomEndpoints,
+} from './shape/custgeom-endpoints';
 export { hexToRgba, resolveFill, applyStroke } from './shape/paint';
 export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/preset';
 export { drawArrowHead } from './shape/arrow';

--- a/packages/core/src/shape/custgeom-endpoints.test.ts
+++ b/packages/core/src/shape/custgeom-endpoints.test.ts
@@ -194,4 +194,117 @@ describe('getCustGeomEndpoints', () => {
       expect(end?.y).toBe(1);
     });
   });
+
+  describe('degenerate arc (wr<=0 || hr<=0) matches buildCustomPath skip', () => {
+    // buildCustomPath skips a degenerate arc entirely (`if (rw<=0||rh<=0) break;`)
+    // WITHOUT advancing the pen — so the next drawn command starts from the pen
+    // position *before* the arc, and a degenerate arc never contributes geometry.
+    // The endpoint extractor must follow the same pen traversal, otherwise the
+    // computed end point / closed-judgment diverge from what is actually drawn.
+
+    /**
+     * Reference pen walk mirroring buildCustomPath (in normalised space): a
+     * degenerate arc is a no-op. Returns the final pen point, or null if the
+     * sub-path never started.
+     */
+    function refTerminal(cmds: PathCmd[]): { x: number; y: number } | null {
+      let px = 0;
+      let py = 0;
+      let started = false;
+      for (const cmd of cmds) {
+        switch (cmd.cmd) {
+          case 'moveTo':
+            px = cmd.x; py = cmd.y; started = true;
+            break;
+          case 'lineTo':
+          case 'cubicBezTo':
+            px = cmd.x; py = cmd.y;
+            break;
+          case 'arcTo': {
+            if (cmd.wr <= 0 || cmd.hr <= 0) break; // degenerate: pen unchanged
+            const stRad = (cmd.stAng * Math.PI) / 180;
+            const endRad = stRad + (cmd.swAng * Math.PI) / 180;
+            const cx = px - cmd.wr * Math.cos(stRad);
+            const cy = py - cmd.hr * Math.sin(stRad);
+            px = cx + cmd.wr * Math.cos(endRad);
+            py = cy + cmd.hr * Math.sin(endRad);
+            break;
+          }
+          case 'close':
+            break;
+        }
+      }
+      return started ? { x: px, y: py } : null;
+    }
+
+    it('degenerate arc before the final segment does not shift the end point or tangent', () => {
+      // moveTo(0,0) -> arcTo(wr=0,...) [skipped] -> lineTo(0.5,0.5).
+      // The line is drawn from (0,0) (pen unchanged by the no-op arc), so the
+      // end point is (0.5,0.5) and the outward tangent is (0.5,0.5)-(0,0).
+      const cmds: PathCmd[] = [
+        { cmd: 'moveTo', x: 0, y: 0 },
+        { cmd: 'arcTo', wr: 0, hr: 0.3, stAng: 0, swAng: 90 },
+        { cmd: 'lineTo', x: 0.5, y: 0.5 },
+      ];
+      const { end } = getCustGeomEndpoints([cmds]);
+      const ref = refTerminal(cmds);
+      expect(end?.x).toBeCloseTo(ref!.x, 12);
+      expect(end?.y).toBeCloseTo(ref!.y, 12);
+      // If the arc had (buggily) advanced the pen to (0,0.3), the tangent would
+      // be (0.5,0.2); the correct skip yields (0.5,0.5).
+      expect(angleNear(angleOf(end), Math.atan2(0.5, 0.5))).toBe(true);
+    });
+
+    it('hr<=0 degenerate arc is also a no-op (skip uses wr<=0 || hr<=0)', () => {
+      // Same shape but the *width* radius is valid and the *height* radius is 0.
+      const cmds: PathCmd[] = [
+        { cmd: 'moveTo', x: 0.1, y: 0.1 },
+        { cmd: 'arcTo', wr: 0.4, hr: 0, stAng: 0, swAng: 90 },
+        { cmd: 'lineTo', x: 0.7, y: 0.5 },
+      ];
+      const { end } = getCustGeomEndpoints([cmds]);
+      const ref = refTerminal(cmds);
+      expect(end?.x).toBeCloseTo(ref!.x, 12);
+      expect(end?.y).toBeCloseTo(ref!.y, 12);
+      // Tangent of the line drawn from the unchanged pen (0.1,0.1) to (0.7,0.5).
+      expect(angleNear(angleOf(end), Math.atan2(0.5 - 0.1, 0.7 - 0.1))).toBe(true);
+    });
+
+    it('implicit closure is preserved across a degenerate arc (terminal == start)', () => {
+      // The no-op arc must not move the pen, so the path still returns exactly to
+      // its start and is detected as closed -> both arrowheads suppressed. With a
+      // buggy traversal the arc would shift the terminal and break the closure.
+      const cmds: PathCmd[] = [
+        { cmd: 'moveTo', x: 0.2, y: 0.2 },
+        { cmd: 'lineTo', x: 0.8, y: 0.2 },
+        { cmd: 'lineTo', x: 0.8, y: 0.8 },
+        { cmd: 'arcTo', wr: 0, hr: 0, stAng: 45, swAng: 120 },
+        { cmd: 'lineTo', x: 0.2, y: 0.2 },
+      ];
+      const ref = refTerminal(cmds);
+      expect(ref).not.toBeNull();
+      expect(near(ref!.x, 0.2, 1e-12)).toBe(true);
+      expect(near(ref!.y, 0.2, 1e-12)).toBe(true);
+      const { start, end } = getCustGeomEndpoints([cmds]);
+      expect(start).toBeNull();
+      expect(end).toBeNull();
+    });
+
+    it('a degenerate arc as the last drawn command contributes no movement (null end)', () => {
+      // moveTo -> lineTo -> arcTo(degenerate). buildCustomPath draws only the
+      // line and the arc adds nothing, so the no-op arc yields no outward tangent
+      // and therefore no end decoration (consistent with the skip semantics).
+      const cmds: PathCmd[] = [
+        { cmd: 'moveTo', x: 0.2, y: 0.2 },
+        { cmd: 'lineTo', x: 0.6, y: 0.4 },
+        { cmd: 'arcTo', wr: 0.3, hr: 0, stAng: 0, swAng: 90 },
+      ];
+      // The visible path still terminates where the line ended (pen unchanged).
+      const ref = refTerminal(cmds);
+      expect(near(ref!.x, 0.6, 1e-12)).toBe(true);
+      expect(near(ref!.y, 0.4, 1e-12)).toBe(true);
+      const { end } = getCustGeomEndpoints([cmds]);
+      expect(end).toBeNull();
+    });
+  });
 });

--- a/packages/core/src/shape/custgeom-endpoints.test.ts
+++ b/packages/core/src/shape/custgeom-endpoints.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import type { PathCmd } from '../types/common';
+import { getCustGeomEndpoints, type CustGeomEndpoint } from './custgeom-endpoints';
+
+/** atan2 of a returned endpoint's normalised tangent, rounded for comparison. */
+function angleOf(e: CustGeomEndpoint | null): number {
+  if (!e) throw new Error('expected endpoint, got null');
+  return Math.atan2(e.dy, e.dx);
+}
+
+function near(a: number, b: number, eps = 1e-9): boolean {
+  return Math.abs(a - b) <= eps;
+}
+
+/** Compare two angles as directions, treating +π and -π (and 2π wraps) as equal. */
+function angleNear(a: number, b: number, eps = 1e-9): boolean {
+  let d = a - b;
+  while (d > Math.PI) d -= 2 * Math.PI;
+  while (d < -Math.PI) d += 2 * Math.PI;
+  return Math.abs(d) <= eps;
+}
+
+describe('getCustGeomEndpoints', () => {
+  it('returns null/null for empty input', () => {
+    expect(getCustGeomEndpoints([])).toEqual({ start: null, end: null });
+    expect(getCustGeomEndpoints([[]])).toEqual({ start: null, end: null });
+  });
+
+  describe('lineTo terminal', () => {
+    // moveTo(0,0) -> lineTo(1,1): an open diagonal.
+    const path: PathCmd[][] = [[
+      { cmd: 'moveTo', x: 0, y: 0 },
+      { cmd: 'lineTo', x: 1, y: 1 },
+    ]];
+
+    it('start sits at the first moveTo point', () => {
+      const { start } = getCustGeomEndpoints(path);
+      expect(start?.x).toBe(0);
+      expect(start?.y).toBe(0);
+    });
+
+    it('start tangent points OUTWARD (away from the next point)', () => {
+      // First drawn segment direction is (1,1); outward = reverse = (-1,-1).
+      const { start } = getCustGeomEndpoints(path);
+      expect(angleNear(angleOf(start), Math.atan2(-1, -1))).toBe(true);
+    });
+
+    it('end sits at the last lineTo point', () => {
+      const { end } = getCustGeomEndpoints(path);
+      expect(end?.x).toBe(1);
+      expect(end?.y).toBe(1);
+    });
+
+    it('end tangent points along the incoming segment (outward)', () => {
+      // Travel direction into the end is (1,1); outward at the tail is the same.
+      const { end } = getCustGeomEndpoints(path);
+      expect(angleNear(angleOf(end), Math.atan2(1, 1))).toBe(true);
+    });
+  });
+
+  describe('cubicBezTo terminal', () => {
+    it('end tangent uses control point (x2,y2) -> end vector', () => {
+      // moveTo(0,0) -> C (0.2,0) (0.8,0.2) (1,1). End tangent = (1-0.8, 1-0.2)=(0.2,0.8).
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0, y: 0 },
+        { cmd: 'cubicBezTo', x1: 0.2, y1: 0, x2: 0.8, y2: 0.2, x: 1, y: 1 },
+      ]];
+      const { end } = getCustGeomEndpoints(path);
+      expect(end?.x).toBe(1);
+      expect(end?.y).toBe(1);
+      expect(angleNear(angleOf(end), Math.atan2(0.8, 0.2))).toBe(true);
+    });
+
+    it('start tangent uses moveTo -> control point (x1,y1) vector, reversed', () => {
+      // First drawn cmd is the cubic; start tangent forward = (x1,y1)-(0,0)=(0.2,0).
+      // Outward (head) = reversed = (-0.2, 0).
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0, y: 0 },
+        { cmd: 'cubicBezTo', x1: 0.2, y1: 0, x2: 0.8, y2: 0.2, x: 1, y: 1 },
+      ]];
+      const { start } = getCustGeomEndpoints(path);
+      expect(angleNear(angleOf(start), Math.atan2(0, -0.2))).toBe(true);
+    });
+
+    it('degenerate (x2==x && y2==y): falls back to (x1,y1) -> end', () => {
+      // C (0.1,0.3) (1,1) (1,1): control2 == end, so use (x1,y1)->end = (0.9,0.7).
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0, y: 0 },
+        { cmd: 'cubicBezTo', x1: 0.1, y1: 0.3, x2: 1, y2: 1, x: 1, y: 1 },
+      ]];
+      const { end } = getCustGeomEndpoints(path);
+      expect(angleNear(angleOf(end), Math.atan2(1 - 0.3, 1 - 0.1))).toBe(true);
+    });
+
+    it('fully degenerate (both controls == end): falls back to start -> end', () => {
+      // moveTo(0.2,0.2) -> C (1,1) (1,1) (1,1): use prevPoint(0.2,0.2)->end(1,1).
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0.2, y: 0.2 },
+        { cmd: 'cubicBezTo', x1: 1, y1: 1, x2: 1, y2: 1, x: 1, y: 1 },
+      ]];
+      const { end } = getCustGeomEndpoints(path);
+      expect(angleNear(angleOf(end), Math.atan2(0.8, 0.8))).toBe(true);
+    });
+  });
+
+  describe('arcTo terminal', () => {
+    // moveTo at the 3 o'clock point of a unit-ish ellipse, sweep +90deg (CW in
+    // screen coords where +y is down). Pen starts at stAng=0.
+    // center = pen - (wr*cos0, hr*sin0) = (0.5,0.5) - (0.4,0) = (0.1,0.5).
+    // end at stAng+sw = 90deg: (0.1 + 0.4*cos90, 0.5 + 0.3*sin90) = (0.1, 0.8).
+    it('positive sweep: end point and outward tangent are analytic', () => {
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0.5, y: 0.5 },
+        { cmd: 'arcTo', wr: 0.4, hr: 0.3, stAng: 0, swAng: 90 },
+      ]];
+      const { end } = getCustGeomEndpoints(path);
+      expect(near(end!.x, 0.1, 1e-9)).toBe(true);
+      expect(near(end!.y, 0.8, 1e-9)).toBe(true);
+      // Tangent of (cx+wr cos t, cy+hr sin t) is (-wr sin t, hr cos t); for
+      // sw>0 travel is increasing t, so outward tangent at t=90deg:
+      // (-0.4*sin90, 0.3*cos90) = (-0.4, 0).
+      expect(angleNear(angleOf(end), Math.atan2(0, -0.4))).toBe(true);
+    });
+
+    it('negative sweep flips the direction of travel', () => {
+      // Same geometry, sweep -90deg. end at t=-90deg:
+      // (0.1 + 0.4*cos(-90), 0.5 + 0.3*sin(-90)) = (0.1, 0.2).
+      // For sw<0 travel is decreasing t, outward tangent = -(-wr sin t, hr cos t)
+      // at t=-90deg: -(-0.4*sin(-90), 0.3*cos(-90)) = -((0.4),(0)) = (-0.4, 0).
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0.5, y: 0.5 },
+        { cmd: 'arcTo', wr: 0.4, hr: 0.3, stAng: 0, swAng: -90 },
+      ]];
+      const { end } = getCustGeomEndpoints(path);
+      expect(near(end!.x, 0.1, 1e-9)).toBe(true);
+      expect(near(end!.y, 0.2, 1e-9)).toBe(true);
+      expect(angleNear(angleOf(end), Math.atan2(0, -0.4))).toBe(true);
+    });
+  });
+
+  describe('multiple subpaths', () => {
+    it('start comes from the first subpath, end from the last', () => {
+      const path: PathCmd[][] = [
+        [ { cmd: 'moveTo', x: 0, y: 0 }, { cmd: 'lineTo', x: 0.3, y: 0 } ],
+        [ { cmd: 'moveTo', x: 0.6, y: 0.6 }, { cmd: 'lineTo', x: 1, y: 1 } ],
+      ];
+      const { start, end } = getCustGeomEndpoints(path);
+      expect(start?.x).toBe(0);
+      expect(start?.y).toBe(0);
+      expect(end?.x).toBe(1);
+      expect(end?.y).toBe(1);
+    });
+  });
+
+  describe('closed paths produce no endpoints', () => {
+    it('explicit close suppresses both arrowheads', () => {
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0, y: 0 },
+        { cmd: 'lineTo', x: 1, y: 0 },
+        { cmd: 'lineTo', x: 1, y: 1 },
+        { cmd: 'close' },
+      ]];
+      expect(getCustGeomEndpoints(path)).toEqual({ start: null, end: null });
+    });
+
+    it('implicit closure (last point == first point) suppresses arrowheads', () => {
+      const path: PathCmd[][] = [[
+        { cmd: 'moveTo', x: 0.25, y: 0.25 },
+        { cmd: 'lineTo', x: 0.75, y: 0.25 },
+        { cmd: 'lineTo', x: 0.75, y: 0.75 },
+        { cmd: 'lineTo', x: 0.25, y: 0.25 },
+      ]];
+      const { start, end } = getCustGeomEndpoints(path);
+      expect(start).toBeNull();
+      expect(end).toBeNull();
+    });
+
+    it('a closed FIRST subpath suppresses only the start; an open LAST keeps the end', () => {
+      const path: PathCmd[][] = [
+        [ // closed triangle
+          { cmd: 'moveTo', x: 0, y: 0 },
+          { cmd: 'lineTo', x: 0.2, y: 0 },
+          { cmd: 'lineTo', x: 0.1, y: 0.2 },
+          { cmd: 'close' },
+        ],
+        [ // open line
+          { cmd: 'moveTo', x: 0.5, y: 0.5 },
+          { cmd: 'lineTo', x: 1, y: 1 },
+        ],
+      ];
+      const { start, end } = getCustGeomEndpoints(path);
+      expect(start).toBeNull();
+      expect(end?.x).toBe(1);
+      expect(end?.y).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/shape/custgeom-endpoints.ts
+++ b/packages/core/src/shape/custgeom-endpoints.ts
@@ -93,17 +93,52 @@ function startForwardTangent(
 }
 
 /**
+ * Advance the pen across one command, returning the new pen position. This is
+ * the single source of truth for pen traversal and mirrors `buildCustomPath`
+ * **exactly** — in particular a degenerate arc (`wr<=0 || hr<=0`) is a no-op
+ * that leaves the pen unchanged (buildCustomPath does `break` before advancing
+ * the pen), so the next drawn command starts from the pre-arc point.
+ *
+ * `close` and any non-drawing command leave the pen where it is.
+ */
+function advancePen(px: number, py: number, cmd: PathCmd): { x: number; y: number } {
+  switch (cmd.cmd) {
+    case 'moveTo':
+    case 'lineTo':
+    case 'cubicBezTo':
+      return { x: cmd.x, y: cmd.y };
+    case 'arcTo': {
+      // Same degenerate guard as buildCustomPath (`rw<=0 || rh<=0`, with w,h>0
+      // this reduces to wr<=0 || hr<=0): skip the arc and keep the pen put.
+      if (cmd.wr <= 0 || cmd.hr <= 0) return { x: px, y: py };
+      const stRad = (cmd.stAng * Math.PI) / 180;
+      const endRad = stRad + (cmd.swAng * Math.PI) / 180;
+      // Centre back-calculated from the pen at stAng (matches buildCustomPath):
+      // cx = penX - wr cos(stAng); end = (cx + wr cos(endRad), cy + hr sin(endRad)).
+      const cx = px - cmd.wr * Math.cos(stRad);
+      const cy = py - cmd.hr * Math.sin(stRad);
+      return { x: cx + cmd.wr * Math.cos(endRad), y: cy + cmd.hr * Math.sin(endRad) };
+    }
+    default:
+      return { x: px, y: py };
+  }
+}
+
+/**
  * Forward tangent (direction of travel) **arriving** at the end of a drawn
- * command, given the point `(prevX, prevY)` it started from.
+ * command, given the point `(prevX, prevY)` it started from. The end point is
+ * computed via {@link advancePen} so it always agrees with buildCustomPath's
+ * traversal (a degenerate arc contributes no movement and no tangent).
  */
 function endForwardTangent(
   prevX: number,
   prevY: number,
   cmd: PathCmd,
 ): { dx: number; dy: number; x: number; y: number } {
+  const { x, y } = advancePen(prevX, prevY, cmd);
   switch (cmd.cmd) {
     case 'lineTo':
-      return { dx: cmd.x - prevX, dy: cmd.y - prevY, x: cmd.x, y: cmd.y };
+      return { dx: cmd.x - prevX, dy: cmd.y - prevY, x, y };
     case 'cubicBezTo': {
       // Tangent at t=1 points from the second control point to the end.
       let dx = cmd.x - cmd.x2;
@@ -118,25 +153,21 @@ function endForwardTangent(
         dx = cmd.x - prevX;
         dy = cmd.y - prevY;
       }
-      return { dx, dy, x: cmd.x, y: cmd.y };
+      return { dx, dy, x, y };
     }
     case 'arcTo': {
+      // A degenerate arc draws nothing (advancePen kept the pen put), so it has
+      // no outward tangent — matching buildCustomPath, which skips it entirely.
+      if (cmd.wr <= 0 || cmd.hr <= 0) return { dx: 0, dy: 0, x, y };
       const stRad = (cmd.stAng * Math.PI) / 180;
-      const swRad = (cmd.swAng * Math.PI) / 180;
-      const endRad = stRad + swRad;
-      // Centre back-calculated from the pen at stAng (matches buildCustomPath):
-      // cx = penX - wr cos(stAng); end = (cx + wr cos(endRad), cy + hr sin(endRad)).
-      const cxOff = -cmd.wr * Math.cos(stRad); // centre relative to prev point
-      const cyOff = -cmd.hr * Math.sin(stRad);
-      const ex = prevX + cxOff + cmd.wr * Math.cos(endRad);
-      const ey = prevY + cyOff + cmd.hr * Math.sin(endRad);
+      const endRad = stRad + (cmd.swAng * Math.PI) / 180;
       const dir = cmd.swAng < 0 ? -1 : 1;
       const dx = -cmd.wr * Math.sin(endRad) * dir;
       const dy = cmd.hr * Math.cos(endRad) * dir;
-      return { dx, dy, x: ex, y: ey };
+      return { dx, dy, x, y };
     }
     default:
-      return { dx: 0, dy: 0, x: prevX, y: prevY };
+      return { dx: 0, dy: 0, x, y };
   }
 }
 
@@ -146,26 +177,8 @@ function terminalPoint(cmds: PathCmd[]): { x: number; y: number } | null {
   let py = 0;
   let started = false;
   for (const cmd of cmds) {
-    switch (cmd.cmd) {
-      case 'moveTo':
-        px = cmd.x; py = cmd.y; started = true;
-        break;
-      case 'lineTo':
-      case 'cubicBezTo':
-        px = cmd.x; py = cmd.y;
-        break;
-      case 'arcTo': {
-        const stRad = (cmd.stAng * Math.PI) / 180;
-        const endRad = stRad + (cmd.swAng * Math.PI) / 180;
-        const cx = px - cmd.wr * Math.cos(stRad);
-        const cy = py - cmd.hr * Math.sin(stRad);
-        px = cx + cmd.wr * Math.cos(endRad);
-        py = cy + cmd.hr * Math.sin(endRad);
-        break;
-      }
-      case 'close':
-        break;
-    }
+    if (cmd.cmd === 'moveTo') started = true;
+    ({ x: px, y: py } = advancePen(px, py, cmd));
   }
   return started ? { x: px, y: py } : null;
 }
@@ -195,6 +208,23 @@ function isClosed(cmds: PathCmd[]): boolean {
  *
  * An end belonging to a **closed** sub-path returns `null` (no arrow head), which
  * matches PowerPoint: line-end decorations only apply to open paths.
+ *
+ * Relationship to {@link getConnectorAnchors} (preset-geometry/index.ts): that
+ * helper serves the *preset* connector/callout geometries (`straightConnector1`,
+ * `bentConnector*`, `curvedConnector*`, …). It evaluates a preset's guide
+ * formulas and returns tip points + tangent **angles already in device space**,
+ * and it only walks `m`/`l`/`C` commands (presets never emit `arcTo`). This
+ * helper is its custom-geometry counterpart: it consumes the *raw* normalised
+ * `<a:custGeom>` sub-paths (free-form / curve shapes), handles `arcTo`, and
+ * returns the tangent as a **normalised direction vector** so the caller can
+ * scale it for an anisotropic box before taking `atan2`. The two are kept
+ * separate on purpose — they take different inputs and different coordinate
+ * spaces, so merging them would only add branching.
+ *
+ * Currently the only consumer is the pptx renderer (free-form / curve lines with
+ * `<a:ln><a:headEnd|tailEnd>`). When docx / xlsx grow free-form line-end arrow
+ * support they are expected to share this helper rather than re-deriving the
+ * endpoints, which is why it lives in `@silurus/ooxml-core`.
  *
  * @param subpaths Normalised (`[0,1]`) custGeom sub-paths.
  */
@@ -230,25 +260,7 @@ export function getCustGeomEndpoints(subpaths: PathCmd[][]): CustGeomEndpoints {
     }
     if (lastDrawIdx >= 0) {
       for (let i = 0; i < lastDrawIdx; i++) {
-        const cmd = lastSub[i];
-        switch (cmd.cmd) {
-          case 'moveTo':
-          case 'lineTo':
-          case 'cubicBezTo':
-            px = cmd.x; py = cmd.y;
-            break;
-          case 'arcTo': {
-            const stRad = (cmd.stAng * Math.PI) / 180;
-            const endRad = stRad + (cmd.swAng * Math.PI) / 180;
-            const cx = px - cmd.wr * Math.cos(stRad);
-            const cy = py - cmd.hr * Math.sin(stRad);
-            px = cx + cmd.wr * Math.cos(endRad);
-            py = cy + cmd.hr * Math.sin(endRad);
-            break;
-          }
-          case 'close':
-            break;
-        }
+        ({ x: px, y: py } = advancePen(px, py, lastSub[i]));
       }
       const t = endForwardTangent(px, py, lastSub[lastDrawIdx]);
       if (Math.abs(t.dx) > EPS || Math.abs(t.dy) > EPS) {

--- a/packages/core/src/shape/custgeom-endpoints.ts
+++ b/packages/core/src/shape/custgeom-endpoints.ts
@@ -1,0 +1,261 @@
+import type { PathCmd } from '../types/common';
+
+/**
+ * An endpoint of a custom-geometry path, used to place a line-end decoration
+ * (arrow head) on a freeform / curved line.
+ *
+ * Coordinates `(x, y)` are in the same **normalised** [0,1] space as the
+ * incoming {@link PathCmd}s (relative to the shape bounding box). `(dx, dy)` is
+ * the **outward** tangent direction at that endpoint, also expressed in
+ * normalised space — i.e. it points *away* from the line so an arrow head drawn
+ * along it faces outward (head at the start, tail at the end).
+ *
+ * The tangent is returned as a raw direction vector rather than a baked angle
+ * because the shape may be scaled anisotropically (w ≠ h). The caller scales the
+ * vector by the box dimensions — `atan2(dy·h, dx·w)` — to obtain the device-space
+ * orientation. {@link CustGeomEndpoint.angle} provides the isotropic angle
+ * (`atan2(dy, dx)`) for convenience / testing.
+ */
+export interface CustGeomEndpoint {
+  /** Normalised x in [0,1]. */
+  x: number;
+  /** Normalised y in [0,1]. */
+  y: number;
+  /** Outward tangent x-component (normalised space). */
+  dx: number;
+  /** Outward tangent y-component (normalised space). */
+  dy: number;
+  /** Isotropic outward angle in radians (`atan2(dy, dx)`). */
+  angle: number;
+}
+
+/** Two endpoints may be `null` independently (closed end ⇒ no arrow head). */
+export interface CustGeomEndpoints {
+  start: CustGeomEndpoint | null;
+  end: CustGeomEndpoint | null;
+}
+
+const EPS = 1e-9;
+
+function isDrawCmd(cmd: PathCmd): boolean {
+  return cmd.cmd === 'lineTo' || cmd.cmd === 'cubicBezTo' || cmd.cmd === 'arcTo';
+}
+
+function makeEndpoint(x: number, y: number, dx: number, dy: number): CustGeomEndpoint {
+  // Normalise signed zero so the tangent (and any atan2 derived from it) is
+  // canonical: `atan2(-0, -k)` is -π while `atan2(0, -k)` is +π — same
+  // direction, but the negative zero leaks an arbitrary sign into the angle.
+  const ndx = dx === 0 ? 0 : dx;
+  const ndy = dy === 0 ? 0 : dy;
+  return { x, y, dx: ndx, dy: ndy, angle: Math.atan2(ndy, ndx) };
+}
+
+/**
+ * Forward tangent (direction of travel) at the **start** of a sub-path, i.e.
+ * leaving `(penX, penY)` along the first drawn command `cmd`.
+ */
+function startForwardTangent(
+  penX: number,
+  penY: number,
+  cmd: PathCmd,
+): { dx: number; dy: number } {
+  switch (cmd.cmd) {
+    case 'lineTo':
+      return { dx: cmd.x - penX, dy: cmd.y - penY };
+    case 'cubicBezTo': {
+      // Tangent at t=0 of a cubic Bézier points toward the first control point.
+      let dx = cmd.x1 - penX;
+      let dy = cmd.y1 - penY;
+      if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
+        // Degenerate first control point: fall back to the second, then the end.
+        dx = cmd.x2 - penX;
+        dy = cmd.y2 - penY;
+      }
+      if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
+        dx = cmd.x - penX;
+        dy = cmd.y - penY;
+      }
+      return { dx, dy };
+    }
+    case 'arcTo': {
+      // Ellipse: P(t) = (cx + wr cos t, cy + hr sin t), with the pen at t=stAng
+      // (matches buildCustomPath). Tangent dP/dt = (-wr sin t, hr cos t); for
+      // sweep>0 travel increases t, for sweep<0 it decreases t.
+      const stRad = (cmd.stAng * Math.PI) / 180;
+      const dir = cmd.swAng < 0 ? -1 : 1;
+      const dx = -cmd.wr * Math.sin(stRad) * dir;
+      const dy = cmd.hr * Math.cos(stRad) * dir;
+      return { dx, dy };
+    }
+    default:
+      return { dx: 0, dy: 0 };
+  }
+}
+
+/**
+ * Forward tangent (direction of travel) **arriving** at the end of a drawn
+ * command, given the point `(prevX, prevY)` it started from.
+ */
+function endForwardTangent(
+  prevX: number,
+  prevY: number,
+  cmd: PathCmd,
+): { dx: number; dy: number; x: number; y: number } {
+  switch (cmd.cmd) {
+    case 'lineTo':
+      return { dx: cmd.x - prevX, dy: cmd.y - prevY, x: cmd.x, y: cmd.y };
+    case 'cubicBezTo': {
+      // Tangent at t=1 points from the second control point to the end.
+      let dx = cmd.x - cmd.x2;
+      let dy = cmd.y - cmd.y2;
+      if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
+        // Degenerate: second control coincides with the end → use first control.
+        dx = cmd.x - cmd.x1;
+        dy = cmd.y - cmd.y1;
+      }
+      if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
+        // Fully degenerate → chord from the previous point to the end.
+        dx = cmd.x - prevX;
+        dy = cmd.y - prevY;
+      }
+      return { dx, dy, x: cmd.x, y: cmd.y };
+    }
+    case 'arcTo': {
+      const stRad = (cmd.stAng * Math.PI) / 180;
+      const swRad = (cmd.swAng * Math.PI) / 180;
+      const endRad = stRad + swRad;
+      // Centre back-calculated from the pen at stAng (matches buildCustomPath):
+      // cx = penX - wr cos(stAng); end = (cx + wr cos(endRad), cy + hr sin(endRad)).
+      const cxOff = -cmd.wr * Math.cos(stRad); // centre relative to prev point
+      const cyOff = -cmd.hr * Math.sin(stRad);
+      const ex = prevX + cxOff + cmd.wr * Math.cos(endRad);
+      const ey = prevY + cyOff + cmd.hr * Math.sin(endRad);
+      const dir = cmd.swAng < 0 ? -1 : 1;
+      const dx = -cmd.wr * Math.sin(endRad) * dir;
+      const dy = cmd.hr * Math.cos(endRad) * dir;
+      return { dx, dy, x: ex, y: ey };
+    }
+    default:
+      return { dx: 0, dy: 0, x: prevX, y: prevY };
+  }
+}
+
+/** Track the pen position across one sub-path to find its final terminal point. */
+function terminalPoint(cmds: PathCmd[]): { x: number; y: number } | null {
+  let px = 0;
+  let py = 0;
+  let started = false;
+  for (const cmd of cmds) {
+    switch (cmd.cmd) {
+      case 'moveTo':
+        px = cmd.x; py = cmd.y; started = true;
+        break;
+      case 'lineTo':
+      case 'cubicBezTo':
+        px = cmd.x; py = cmd.y;
+        break;
+      case 'arcTo': {
+        const stRad = (cmd.stAng * Math.PI) / 180;
+        const endRad = stRad + (cmd.swAng * Math.PI) / 180;
+        const cx = px - cmd.wr * Math.cos(stRad);
+        const cy = py - cmd.hr * Math.sin(stRad);
+        px = cx + cmd.wr * Math.cos(endRad);
+        py = cy + cmd.hr * Math.sin(endRad);
+        break;
+      }
+      case 'close':
+        break;
+    }
+  }
+  return started ? { x: px, y: py } : null;
+}
+
+/** Does this sub-path form a closed loop (explicit `close` or terminal ≈ start)? */
+function isClosed(cmds: PathCmd[]): boolean {
+  if (cmds.some((c) => c.cmd === 'close')) return true;
+  const first = cmds.find((c) => c.cmd === 'moveTo') as
+    | Extract<PathCmd, { cmd: 'moveTo' }>
+    | undefined;
+  if (!first) return false;
+  const term = terminalPoint(cmds);
+  if (!term) return false;
+  // Only a path that actually draws something can be an implicit loop.
+  const hasDraw = cmds.some(isDrawCmd);
+  if (!hasDraw) return false;
+  return Math.abs(term.x - first.x) < EPS && Math.abs(term.y - first.y) < EPS;
+}
+
+/**
+ * Extract the start and end decoration points of a custom-geometry path.
+ *
+ * - `start` = the very first `moveTo` of the first sub-path. Its tangent is the
+ *   **reverse** of the direction leaving that point (so a head faces outward).
+ * - `end`   = the terminal point of the last drawn command of the last sub-path.
+ *   Its tangent is the direction of travel arriving there (already outward).
+ *
+ * An end belonging to a **closed** sub-path returns `null` (no arrow head), which
+ * matches PowerPoint: line-end decorations only apply to open paths.
+ *
+ * @param subpaths Normalised (`[0,1]`) custGeom sub-paths.
+ */
+export function getCustGeomEndpoints(subpaths: PathCmd[][]): CustGeomEndpoints {
+  const result: CustGeomEndpoints = { start: null, end: null };
+  if (!subpaths || subpaths.length === 0) return result;
+
+  // ── start: first sub-path's opening moveTo + first drawn command ──────────
+  const firstSub = subpaths[0];
+  if (firstSub && firstSub.length > 0 && !isClosed(firstSub)) {
+    const mv = firstSub.find((c) => c.cmd === 'moveTo') as
+      | Extract<PathCmd, { cmd: 'moveTo' }>
+      | undefined;
+    const firstDraw = firstSub.find(isDrawCmd);
+    if (mv && firstDraw) {
+      const fwd = startForwardTangent(mv.x, mv.y, firstDraw);
+      if (Math.abs(fwd.dx) > EPS || Math.abs(fwd.dy) > EPS) {
+        // Outward (head) tangent is the reverse of the travel direction.
+        result.start = makeEndpoint(mv.x, mv.y, -fwd.dx, -fwd.dy);
+      }
+    }
+  }
+
+  // ── end: last sub-path's final drawn command ─────────────────────────────
+  const lastSub = subpaths[subpaths.length - 1];
+  if (lastSub && lastSub.length > 0 && !isClosed(lastSub)) {
+    // Replay the pen to the point just before the last drawn command.
+    let px = 0;
+    let py = 0;
+    let lastDrawIdx = -1;
+    for (let i = 0; i < lastSub.length; i++) {
+      if (isDrawCmd(lastSub[i])) lastDrawIdx = i;
+    }
+    if (lastDrawIdx >= 0) {
+      for (let i = 0; i < lastDrawIdx; i++) {
+        const cmd = lastSub[i];
+        switch (cmd.cmd) {
+          case 'moveTo':
+          case 'lineTo':
+          case 'cubicBezTo':
+            px = cmd.x; py = cmd.y;
+            break;
+          case 'arcTo': {
+            const stRad = (cmd.stAng * Math.PI) / 180;
+            const endRad = stRad + (cmd.swAng * Math.PI) / 180;
+            const cx = px - cmd.wr * Math.cos(stRad);
+            const cy = py - cmd.hr * Math.sin(stRad);
+            px = cx + cmd.wr * Math.cos(endRad);
+            py = cy + cmd.hr * Math.sin(endRad);
+            break;
+          }
+          case 'close':
+            break;
+        }
+      }
+      const t = endForwardTangent(px, py, lastSub[lastDrawIdx]);
+      if (Math.abs(t.dx) > EPS || Math.abs(t.dy) > EPS) {
+        result.end = makeEndpoint(t.x, t.y, t.dx, t.dy);
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -37,6 +37,7 @@ import {
   hasPreset,
   buildPresetGeometryPath,
   getConnectorAnchors,
+  getCustGeomEndpoints,
   drawArrowHead,
   computeScene3dQuad,
   isScene3dNonIdentity,
@@ -1567,6 +1568,35 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     }
     if (el.stroke.headEnd) {
       drawArrowHead(ctx, attX, attY, headAngle, el.stroke.headEnd, el.stroke, scale);
+    }
+  } else if (
+    el.stroke &&
+    el.custGeom &&
+    el.custGeom.length > 0 &&
+    ((el.stroke.headEnd && el.stroke.headEnd.type !== 'none') ||
+      (el.stroke.tailEnd && el.stroke.tailEnd.type !== 'none'))
+  ) {
+    // Freeform / curve (custGeom) lines also carry `<a:ln><a:headEnd|tailEnd>`.
+    // The connector/callout branches above only cover preset geometries, so a
+    // custGeom path's arrow heads were dropped. Extract the open path's two
+    // terminal points + outward tangents and decorate them like a connector.
+    // Endpoints on a *closed* sub-path are returned as null (PowerPoint draws no
+    // line-end decoration on a closed contour).
+    const { start, end } = getCustGeomEndpoints(el.custGeom);
+    // The endpoint tangent is expressed in normalised (0..1) space; convert to
+    // device space accounting for anisotropic scaling (w ≠ h) before atan2 so
+    // the arrow head orientation is correct on non-square boxes.
+    if (start && el.stroke.headEnd && el.stroke.headEnd.type !== 'none') {
+      const sx = x + start.x * w;
+      const sy = y + start.y * h;
+      const sAngle = Math.atan2(start.dy * h, start.dx * w);
+      drawArrowHead(ctx, sx, sy, sAngle, el.stroke.headEnd, el.stroke, scale);
+    }
+    if (end && el.stroke.tailEnd && el.stroke.tailEnd.type !== 'none') {
+      const ex = x + end.x * w;
+      const ey = y + end.y * h;
+      const eAngle = Math.atan2(end.dy * h, end.dx * w);
+      drawArrowHead(ctx, ex, ey, eAngle, el.stroke.tailEnd, el.stroke, scale);
     }
   }
 


### PR DESCRIPTION
## Problem

Arrow-head decorations (`a:ln > a:headEnd` / `a:tailEnd`, ECMA-376 §20.1.8.3) were drawn only for the **connector** preset family and the **callout1** family. A line drawn as **custom geometry** (`a:custGeom` — the freeform / curve / scribble tools) carries the same `a:ln` decorations, but the renderer's arrow-head dispatch (`renderer.ts`, the `if (CONNECTOR_GEOMS) … else if (CALLOUT1_GEOMS) …` chain) had **no `custGeom` branch**. The parser already exposed `headEnd` / `tailEnd` on the stroke, so the information was present but silently dropped at draw time.

## Cause

No `custGeom` case in the arrow-head dispatch in `packages/pptx/src/renderer.ts`. The custGeom path was built and stroked, but its endpoints were never decorated.

## Changes

- **`packages/core/src/shape/custgeom-endpoints.ts`** (new): `getCustGeomEndpoints(PathCmd[][])` returns the `start` / `end` decoration points and their **outward** tangents for a custom-geometry path (normalised 0..1 space).
  - `start` = first sub-path's opening `moveTo`; tangent reversed so the head faces outward.
  - `end` = terminal point of the last drawn command of the last sub-path; tangent = direction of travel arriving there.
  - `lineTo` / `cubicBezTo` / `arcTo` tangents computed **analytically**. Cubic degenerate-control fallbacks: `control2→end`, then `control1→end`, then chord. Arc end tangent derived from the **same ellipse parametrisation `buildCustomPath()` uses**, with the `swAng` sign selecting the travel direction.
  - A **closed** sub-path (explicit `close`, or terminal ≈ start within ε) yields a `null` endpoint → no decoration, matching PowerPoint.
  - The tangent is returned as a raw direction vector `(dx, dy)` (not a baked angle) so the caller can correct for **anisotropic scaling** (`w ≠ h`) before `atan2`. Signed zero is normalised so angles are canonical.
- **`packages/core/src/index.ts`**: export `getCustGeomEndpoints`.
- **`packages/pptx/src/renderer.ts`**: add the `custGeom` branch after the callout1 branch — extract endpoints, map normalised coords through the shape box, scale tangents by `(w, h)` before `atan2`, and draw `headEnd` at the start / `tailEnd` at the end via the existing `drawArrowHead()`. `"none"` ends and `null` endpoints are skipped.

No parser or type changes (both already modelled `headEnd` / `tailEnd`). No heuristics or empirical constants — all geometry is analytic.

## Verification

**Unit tests** (`custgeom-endpoints.test.ts`, 15 cases, all green): every command type, normal + degenerate cubics, both arc sweep signs, multi-sub-path start/end selection, and closed-path suppression (explicit `close`, implicit closure, and closed-first/open-last).

**Headless render** (skia-canvas, via `renderSlideNode`) on a generated sample (open polyline, open cubic curve, closed triangle — all with `headEnd`/`tailEnd` requested). Before/after coloured-pixel counts in boxes centred on each endpoint:

| shape | endpoint | before | after | Δ |
|---|---|---|---|---|
| polyline | start | 341 | 549 | **+208** |
| polyline | end | 344 | 550 | **+206** |
| curve | start | 347 | 555 | **+208** |
| curve | end | 345 | 547 | **+202** |
| closed triangle | apex | 670 | 670 | **0** |

Filled arrow heads appear on both open lines (both ends) and **none** on the closed path. Orientations are visibly correct, including the curve's tangent-following heads.

**Regression**: `demo/sample-1` VRT — 12/12 pass (match 97–100%, within existing thresholds). `core` vitest — 287/287 pass. ast-grep clean. (`private/*` VRT samples are local-only and absent in CI/worktree, so they 404 regardless of this change.)

## Not done

PDF ground-truth comparison against PowerPoint's own rendering is **not** performed here — the user will provide a PowerPoint-exported PDF later for pixel-level fidelity confirmation. This PR establishes that the arrow heads render with correct placement/orientation; the exact head proportions reuse the shared `drawArrowHead` calibration already used by connectors.