### PR TITLE
fix(pptx): serialize PathCmd::ArcTo angle fields as camelCase (stAng/swAng)

### DIFF
--- a/packages/core/src/shape/custGeom.test.ts
+++ b/packages/core/src/shape/custGeom.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import type { PathCmd } from '../types/common';
+import { buildCustomPath } from './custGeom';
+
+/**
+ * Records the canvas calls `buildCustomPath` makes so we can assert on the arc
+ * geometry without a real canvas. `ellipse` captures its full argument list,
+ * which is where the serde naming bug surfaced: when the parser emitted the arc
+ * angles in snake_case (`st_ang`/`sw_ang`) the TS reader (`cmd.stAng`/
+ * `cmd.swAng`) saw `undefined`, so `(undefined * Math.PI) / 180` made every
+ * derived `ellipse` argument `NaN`.
+ */
+function makeRecorder(): {
+  ctx: CanvasRenderingContext2D;
+  ellipseCalls: number[][];
+  moveTos: Array<{ x: number; y: number }>;
+} {
+  const ellipseCalls: number[][] = [];
+  const moveTos: Array<{ x: number; y: number }> = [];
+  const ctx = {
+    beginPath() {},
+    closePath() {},
+    moveTo(x: number, y: number) {
+      moveTos.push({ x, y });
+    },
+    lineTo() {},
+    bezierCurveTo() {},
+    ellipse(
+      cx: number,
+      cy: number,
+      rx: number,
+      ry: number,
+      rot: number,
+      start: number,
+      end: number,
+      counterclockwise?: boolean,
+    ) {
+      ellipseCalls.push([cx, cy, rx, ry, rot, start, end, counterclockwise ? 1 : 0]);
+    },
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, ellipseCalls, moveTos };
+}
+
+describe('buildCustomPath — arcTo', () => {
+  // A 90° arc whose angle fields use the camelCase keys the (fixed) parser now
+  // emits and the TS PathCmd type declares.
+  const arcPath: PathCmd[][] = [
+    [
+      { cmd: 'moveTo', x: 1, y: 0 },
+      { cmd: 'arcTo', wr: 0.5, hr: 0.5, stAng: 0, swAng: 90 },
+    ],
+  ];
+
+  it('emits an ellipse with all-finite arguments (no NaN)', () => {
+    const { ctx, ellipseCalls } = makeRecorder();
+    buildCustomPath(ctx, arcPath, 0, 0, 100, 100);
+
+    expect(ellipseCalls).toHaveLength(1);
+    const args = ellipseCalls[0];
+    for (const [i, v] of args.entries()) {
+      expect(Number.isFinite(v), `ellipse arg #${i} must be finite, got ${v}`).toBe(true);
+      expect(Number.isNaN(v), `ellipse arg #${i} must not be NaN`).toBe(false);
+    }
+  });
+
+  it('places the ellipse centre by back-calculating from the pen and stAng', () => {
+    const { ctx, ellipseCalls } = makeRecorder();
+    buildCustomPath(ctx, arcPath, 0, 0, 100, 100);
+
+    // rw = 0.5*100 = 50, rh = 0.5*100 = 50. Pen after moveTo(1,0) is at
+    // (0 + 1*100, 0 + 0*100) = (100, 0). stAng = 0 →
+    // cx = penAbsX - rw*cos(0) = 100 - 50 = 50; cy = penAbsY - rh*sin(0) = 0.
+    const [cx, cy, rx, ry, , start, end] = ellipseCalls[0];
+    expect(cx).toBeCloseTo(50, 9);
+    expect(cy).toBeCloseTo(0, 9);
+    expect(rx).toBeCloseTo(50, 9);
+    expect(ry).toBeCloseTo(50, 9);
+    expect(start).toBeCloseTo(0, 9); // stAng in radians
+    expect(end).toBeCloseTo(Math.PI / 2, 9); // stAng + swAng
+  });
+
+  it('guards the regression: snake_case angle keys would produce NaN', () => {
+    // This is the *pre-fix* shape the buggy parser serialized: the angles live
+    // under snake_case keys, so the camelCase reads are undefined → NaN. We
+    // assert the failure mode explicitly so a regression to snake_case is
+    // caught by the renderer-side contract too, not just the parser test.
+    const buggy = [
+      [
+        { cmd: 'moveTo', x: 1, y: 0 },
+        // Intentionally wrong keys (st_ang/sw_ang) cast through the PathCmd type.
+        { cmd: 'arcTo', wr: 0.5, hr: 0.5, st_ang: 0, sw_ang: 90 },
+      ],
+    ] as unknown as PathCmd[][];
+    const { ctx, ellipseCalls } = makeRecorder();
+    buildCustomPath(ctx, buggy, 0, 0, 100, 100);
+
+    expect(ellipseCalls).toHaveLength(1);
+    // start/end (indices 5,6) are derived from the missing angles → NaN.
+    expect(Number.isNaN(ellipseCalls[0][5])).toBe(true);
+    expect(Number.isNaN(ellipseCalls[0][6])).toBe(true);
+  });
+});

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1386,6 +1386,16 @@ enum PathCmd {
         y: f64,
     },
     /// Elliptical arc (all angles in degrees)
+    ///
+    /// The enum-level `#[serde(tag = ..., rename_all = "camelCase")]` renames the
+    /// variant *tag* (`ArcTo` → `arcTo`) but NOT the variant's struct fields, so
+    /// a per-variant `rename_all` is required for the multi-word fields. Without
+    /// it the JSON carried `st_ang`/`sw_ang`, while the TS `PathCmd`
+    /// (core/src/types/common.ts) reads `stAng`/`swAng` — the mismatch left the
+    /// angles `undefined`, producing `NaN` coordinates and a missing arc. This
+    /// mirrors the per-variant `rename_all` already used by `Fill`, `Bullet`,
+    /// and `TextRun`.
+    #[serde(rename_all = "camelCase")]
     ArcTo {
         wr: f64,
         hr: f64,
@@ -11932,5 +11942,89 @@ mod tests {
         assert_eq!(c.title_font_bold, Some(true));
         assert_eq!(c.cat_axis_font_bold, Some(true));
         assert_eq!(c.val_axis_font_bold, Some(false));
+    }
+
+    /// Regression for the `PathCmd::ArcTo` serde naming bug: the enum-level
+    /// `#[serde(tag = "cmd", rename_all = "camelCase")]` renames only the variant
+    /// tag, not the struct-variant fields, so `st_ang`/`sw_ang` serialized in
+    /// snake_case. The TS `PathCmd` (core/src/types/common.ts) reads `stAng`/
+    /// `swAng`, so the angles came back `undefined` → `NaN` coordinates and the
+    /// arc (plus everything after it) vanished. A non-degenerate arc (positive
+    /// `wR`/`hR`) is essential: a degenerate arc short-circuits before the
+    /// angles are read, which is why the original arrow sample (degenerate arcs
+    /// only) never surfaced this.
+    #[test]
+    fn arcto_serializes_angle_fields_as_camel_case() {
+        // 90° arc: swAng = 90 * 60000 = 5400000 in OOXML 60000ths of a degree.
+        let xml = r#"<custGeom xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <pathLst>
+    <path w="100" h="100">
+      <moveTo><pt x="100" y="50"/></moveTo>
+      <arcTo wR="50" hR="50" stAng="0" swAng="5400000"/>
+    </path>
+  </pathLst>
+</custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let subpaths = parse_cust_geom(doc.root_element());
+        let json = serde_json::to_string(&subpaths).expect("custGeom should serialize");
+
+        // The two camelCase keys the TS renderer reads must be present…
+        assert!(
+            json.contains("\"stAng\""),
+            "ArcTo must serialize stAng (camelCase); got: {json}"
+        );
+        assert!(
+            json.contains("\"swAng\""),
+            "ArcTo must serialize swAng (camelCase); got: {json}"
+        );
+        // …and the buggy snake_case keys must be gone.
+        assert!(
+            !json.contains("\"st_ang\""),
+            "ArcTo must not emit snake_case st_ang; got: {json}"
+        );
+        assert!(
+            !json.contains("\"sw_ang\""),
+            "ArcTo must not emit snake_case sw_ang; got: {json}"
+        );
+    }
+
+    /// Full value-level round-trip through the serde tag + camelCase fields:
+    /// re-deserializing the serialized JSON must reproduce the angle values,
+    /// proving the rename is symmetric (Serialize + Deserialize both use the
+    /// camelCase keys) and the 60000ths→degrees conversion is intact.
+    #[test]
+    fn arcto_round_trips_angles_through_camel_case_json() {
+        let xml = r#"<custGeom xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <pathLst>
+    <path w="200" h="100">
+      <moveTo><pt x="200" y="50"/></moveTo>
+      <arcTo wR="100" hR="50" stAng="2700000" swAng="-5400000"/>
+    </path>
+  </pathLst>
+</custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let subpaths = parse_cust_geom(doc.root_element());
+        let json = serde_json::to_string(&subpaths).unwrap();
+        let back: Vec<Vec<PathCmd>> =
+            serde_json::from_str(&json).expect("camelCase JSON must deserialize back");
+        let arc = back[0]
+            .iter()
+            .find(|c| matches!(c, PathCmd::ArcTo { .. }))
+            .expect("arc command should be present");
+        match arc {
+            PathCmd::ArcTo {
+                wr,
+                hr,
+                st_ang,
+                sw_ang,
+            } => {
+                // wR/hR normalised by path w/h; angles converted from 60000ths.
+                assert!((wr - 0.5).abs() < 1e-9, "wr = {wr}"); // 100/200
+                assert!((hr - 0.5).abs() < 1e-9, "hr = {hr}"); // 50/100
+                assert!((st_ang - 45.0).abs() < 1e-9, "st_ang = {st_ang}"); // 2700000/60000
+                assert!((sw_ang + 90.0).abs() < 1e-9, "sw_ang = {sw_ang}"); // -5400000/60000
+            }
+            _ => unreachable!(),
+        }
     }
 }


### PR DESCRIPTION
## Problem

A `<a:custGeom>` (freeform) shape containing a **non-degenerate** elliptical arc (`<a:arcTo>` with `wR`/`hR` > 0) rendered with `NaN` coordinates and silently disappeared.

The `PathCmd` enum (`packages/pptx/parser/src/lib.rs`) is internally tagged:

```rust
#[serde(tag = "cmd", rename_all = "camelCase")]
enum PathCmd { … ArcTo { wr, hr, st_ang, sw_ang }, … }
```

`#[serde(rename_all = "camelCase")]` renames the variant **tag** (`ArcTo` → `arcTo`) but **not** the struct-variant fields, so `st_ang`/`sw_ang` serialized in snake_case. The TS contract reads camelCase:

- `packages/core/src/types/common.ts` — `PathCmd = … | { cmd: 'arcTo'; wr; hr; stAng; swAng }`
- `packages/core/src/shape/custGeom.ts` (`buildCustomPath`) reads `cmd.stAng` / `cmd.swAng`
- `packages/core/src/shape/custgeom-endpoints.ts` reads the same

At runtime the JSON had `st_ang`/`sw_ang`, so `cmd.stAng` was `undefined`, `(undefined * Math.PI) / 180` produced `NaN`, and the arc — plus every command after it, since the pen position also went `NaN` — failed to render.

### Why it went unnoticed
- `wr`/`hr` were unaffected (their Rust field names have no underscore).
- The degenerate-arc guard (`wr <= 0 || hr <= 0`) short-circuits **before** the angles are read, so the existing custGeom arrow sample (which only used degenerate `wR=0`/`hR=0` arcs) never exercised the angle path.
- The custGeom arrow feature merged in #487 has the **same latent break** for any non-degenerate arc.

## Fix

Add a per-variant `#[serde(rename_all = "camelCase")]` to `ArcTo`, matching the pattern already used by `Fill`, `Bullet`, and `TextRun`. One line; future-proof against new multi-word fields on the variant.

```rust
#[serde(rename_all = "camelCase")]
ArcTo { wr: f64, hr: f64, st_ang: f64, sw_ang: f64 },
```

## Verification

- **Pre-fix (real `parse_cust_geom` path):** `{"cmd":"arcTo","wr":0.5,"hr":0.5,"st_ang":0.0,"sw_ang":90.0}` → TS reads `undefined` → `NaN`.
- **Post-fix:** `{"cmd":"arcTo","wr":0.5,"hr":0.5,"stAng":0.0,"swAng":90.0}`.
- **Headless pixel render** (skia-canvas via `renderSlideNode`) of a generated deck with a quarter-disc wedge (90° arc) and a half-ellipse ribbon (180° arc):
  - fixed (camelCase): `red=6685, blue=11934` — both arcs render.
  - snake_case (pre-fix simulation): `red=0, blue=0` — both arcs vanish.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test` (78 passed incl. 2 new).
- Full TS suite: 594 passed (65 files). `@silurus/ooxml-core` typecheck clean. ast-grep test lint clean.
- pptx VRT (demo): 12/12 green (the `private/sample-*` 404s are the redistribution-prohibited samples absent from the repo, per CLAUDE.md — local-only).

### Tests added
- `arcto_serializes_angle_fields_as_camel_case` (parser) — asserts JSON has `stAng`/`swAng`, not `st_ang`/`sw_ang`.
- `arcto_round_trips_angles_through_camel_case_json` (parser) — symmetric ser/de + 60000ths→degrees conversion.
- `packages/core/src/shape/custGeom.test.ts` — `buildCustomPath` arc emits all-finite `ctx.ellipse` args; guard test reproduces the NaN failure mode from snake_case keys.

## docx / xlsx: same bug present (NOT touched here — separate sessions own those packages)

Both have the identical defect and should be fixed in their own PRs:

- **docx** — `packages/docx/parser/src/types.rs` `PathCmd` (`tag = "cmd"`, no per-variant `rename_all`) emits `st_ang`/`sw_ang`. `packages/docx/src/renderer.ts` routes custGeom through core's `buildCustomPath`, which reads `stAng`/`swAng`. **Affected — non-degenerate arcs render as NaN.**
- **xlsx** — `packages/xlsx/parser/src/types.rs` `PathCmd` (`tag = "op"`, no per-variant `rename_all`) emits `st_ang`/`sw_ang`. The xlsx renderer (`packages/xlsx/src/renderer.ts`, its own inline path walker, divides angles by 60000) reads `cmd.stAng`/`cmd.swAng`. **Affected — non-degenerate arcs render as NaN.** (Note: xlsx passes raw 60000ths and divides in the renderer, unlike pptx/docx which pre-divide in the parser; the field-name mismatch is the same.)

The same one-line per-variant `rename_all` fix applies to both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)