### PR TITLE
fix(docx): serialize PathCmd::ArcTo angle fields as camelCase (stAng/swAng)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5436,4 +5436,85 @@ mod svg_blip_tests {
             "svg_data_url must carry the vector original"
         );
     }
+
+    /// Regression for the `PathCmd::ArcTo` serde naming bug (mirrors pptx #489).
+    /// The enum-level `#[serde(tag = "cmd", rename_all = "camelCase")]` renames
+    /// only the variant tag, not the struct-variant fields, so `st_ang`/`sw_ang`
+    /// serialized in snake_case. The TS `PathCmd` (packages/docx/src/types.ts)
+    /// and core's `buildCustomPath` read `stAng`/`swAng`, so the angles came back
+    /// `undefined` → `NaN` coordinates and the arc (plus everything after it)
+    /// vanished. A non-degenerate arc (positive `wR`/`hR`) is essential: a
+    /// degenerate arc short-circuits before the angles are read, which is why the
+    /// existing degenerate-arc paths never surfaced this.
+    #[test]
+    fn arcto_serializes_angle_fields_as_camel_case() {
+        // 90° arc: swAng = 90 * 60000 = 5400000 in OOXML 60000ths of a degree.
+        let xml = r#"<a:custGeom xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <a:pathLst>
+    <a:path w="100" h="100">
+      <a:moveTo><a:pt x="100" y="50"/></a:moveTo>
+      <a:arcTo wR="50" hR="50" stAng="0" swAng="5400000"/>
+    </a:path>
+  </a:pathLst>
+</a:custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let subpaths = parse_custom_geometry(doc.root_element());
+        let json = serde_json::to_string(&subpaths).expect("custGeom should serialize");
+
+        // The two camelCase keys the TS renderer reads must be present…
+        assert!(
+            json.contains("\"stAng\""),
+            "ArcTo must serialize stAng (camelCase); got: {json}"
+        );
+        assert!(
+            json.contains("\"swAng\""),
+            "ArcTo must serialize swAng (camelCase); got: {json}"
+        );
+        // …and the buggy snake_case keys must be gone.
+        assert!(
+            !json.contains("\"st_ang\""),
+            "ArcTo must not emit snake_case st_ang; got: {json}"
+        );
+        assert!(
+            !json.contains("\"sw_ang\""),
+            "ArcTo must not emit snake_case sw_ang; got: {json}"
+        );
+    }
+
+    /// Value-level check that the parsed `ArcTo` carries the expected numbers:
+    /// `wR`/`hR` normalised by the path's w/h and the angles converted from
+    /// 60000ths of a degree. `PathCmd` derives `Serialize` only, so this asserts
+    /// against the in-memory model rather than round-tripping through JSON.
+    #[test]
+    fn arcto_normalises_radii_and_converts_angles() {
+        let xml = r#"<a:custGeom xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <a:pathLst>
+    <a:path w="200" h="100">
+      <a:moveTo><a:pt x="200" y="50"/></a:moveTo>
+      <a:arcTo wR="100" hR="50" stAng="2700000" swAng="-5400000"/>
+    </a:path>
+  </a:pathLst>
+</a:custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let subpaths = parse_custom_geometry(doc.root_element());
+        let arc = subpaths[0]
+            .iter()
+            .find(|c| matches!(c, PathCmd::ArcTo { .. }))
+            .expect("arc command should be present");
+        match arc {
+            PathCmd::ArcTo {
+                wr,
+                hr,
+                st_ang,
+                sw_ang,
+            } => {
+                // wR/hR normalised by path w/h; angles converted from 60000ths.
+                assert!((wr - 0.5).abs() < 1e-9, "wr = {wr}"); // 100/200
+                assert!((hr - 0.5).abs() < 1e-9, "hr = {hr}"); // 50/100
+                assert!((st_ang - 45.0).abs() < 1e-9, "st_ang = {st_ang}"); // 2700000/60000
+                assert!((sw_ang + 90.0).abs() < 1e-9, "sw_ang = {sw_ang}"); // -5400000/60000
+            }
+            _ => unreachable!(),
+        }
+    }
 }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -566,6 +566,19 @@ pub enum PathCmd {
         x: f64,
         y: f64,
     },
+    /// Elliptical arc (all angles in degrees).
+    ///
+    /// The enum-level `#[serde(tag = ..., rename_all = "camelCase")]` renames the
+    /// variant *tag* (`ArcTo` → `arcTo`) but NOT the variant's struct fields, so
+    /// a per-variant `rename_all` is required for the multi-word fields. Without
+    /// it the JSON carried `st_ang`/`sw_ang`, while the TS `PathCmd`
+    /// (packages/docx/src/types.ts) and core's `buildCustomPath`
+    /// (packages/core/src/shape/custGeom.ts) read `stAng`/`swAng` — the mismatch
+    /// left the angles `undefined`, producing `NaN` coordinates and a missing
+    /// arc. (The degenerate-arc guard `wr<=0||hr<=0` short-circuits before the
+    /// angles are read, so only non-degenerate arcs surface this.) Mirrors the
+    /// pptx fix (#489) and the per-variant `rename_all` used by sibling enums.
+    #[serde(rename_all = "camelCase")]
     ArcTo {
         wr: f64,
         hr: f64,


### PR DESCRIPTION
## Cause

`packages/docx/parser/src/types.rs`'s `PathCmd` enum is internally tagged with `#[serde(tag = "cmd", rename_all = "camelCase")]`. That `rename_all` renames the variant **tag** (`ArcTo` → `arcTo`) but **not** the struct-variant fields, so `ArcTo`'s `st_ang`/`sw_ang` serialized in snake_case.

This is the **same root cause** as the pptx fix in #489.

## Impact

The TS `PathCmd` (`packages/docx/src/types.ts:270`) and core's `buildCustomPath` (`packages/core/src/shape/custGeom.ts`) read `cmd.stAng`/`cmd.swAng`. With snake_case keys those came back `undefined`, `(undefined * Math.PI) / 180` produced `NaN`, and the arc — plus every command after it, since the pen position also went `NaN` — failed to render.

- `wr`/`hr` were unaffected (their Rust field names have no underscore).
- The degenerate-arc guard (`rw <= 0 || rh <= 0`) in `buildCustomPath` short-circuits before the angles are read, so **only non-degenerate** docx custGeom arcs surface this. No shipped docx sample exercised one, so it was latent.

```
Before: {"cmd":"arcTo","wr":0.5,"hr":0.5,"st_ang":0.0,"sw_ang":90.0}
After:  {"cmd":"arcTo","wr":0.5,"hr":0.5,"stAng":0.0,"swAng":90.0}
```

## Fix

Add a per-variant `#[serde(rename_all = "camelCase")]` to `ArcTo`, matching the per-variant `rename_all` pattern already used by sibling structs in this module and by the pptx `PathCmd` (#489). `wr`/`hr` need no change. Future-proof against new multi-word fields on the variant.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test` (docx parser) — 51 passed, 0 failed (49 prior + 2 new)
- docx WASM rebuilt and copied to `packages/docx/src/wasm/` (gitignored, not committed)

New regression tests in `packages/docx/parser/src/parser.rs`:
- `arcto_serializes_angle_fields_as_camel_case` — parses a non-degenerate `<a:arcTo>` through `parse_custom_geometry` and asserts the JSON carries `stAng`/`swAng` and not `st_ang`/`sw_ang` (verified to fail on the pre-fix code: it produced `st_ang`/`sw_ang`).
- `arcto_normalises_radii_and_converts_angles` — asserts the in-memory `ArcTo` carries `wR`/`hR` normalised by path `w`/`h` and angles converted from 60000ths of a degree. (`PathCmd` derives `Serialize` only, so no JSON round-trip — this checks the parsed values directly.)

## Related

Same serde struct-variant field-naming bug as pptx #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)