### PR TITLE
fix(xlsx): serialize PathCmd::ArcTo angle fields as camelCase (stAng/swAng)

### DIFF
--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1894,3 +1894,88 @@ mod blip_svg_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod custom_path_arc_tests {
+    use super::*;
+
+    const NS: &str = r#"xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main""#;
+
+    /// `PathCmd`'s enum-level `rename_all = "camelCase"` (tag = "op") renames
+    /// only the variant tags, not the fields. Without a per-variant
+    /// `rename_all`, `ArcTo { st_ang, sw_ang }` serialized as snake_case keys
+    /// `st_ang`/`sw_ang`, which the TS renderer never reads — it reads
+    /// `cmd.stAng`/`cmd.swAng` (`renderer.ts`), so the values came back
+    /// `undefined` → `NaN` and the arc failed to draw. Same root cause as the
+    /// pptx fix in PR #489. This guards the JSON keys the renderer relies on.
+    #[test]
+    fn arc_to_serializes_angle_fields_as_camelcase() {
+        // Non-degenerate arc (wR/hR > 0) — the renderer's degenerate-arc guard
+        // (`if (rx <= 0 || ry <= 0) break;`) short-circuits before the angles
+        // are read, so only non-degenerate arcs surface the missing keys.
+        let xml = format!(
+            r#"<a:path {NS} w="100" h="100">
+                 <a:moveTo><a:pt x="0" y="50"/></a:moveTo>
+                 <a:arcTo wR="50" hR="50" stAng="0" swAng="5400000"/>
+               </a:path>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let path = parse_custom_path(&doc.root_element());
+
+        // The parser keeps angles as raw 60000ths of a degree (the xlsx
+        // convention — the TS renderer divides by 60000). swAng = 5_400_000 =
+        // 90°. wR/hR stay in path-coord units.
+        let arc = path
+            .commands
+            .iter()
+            .find(|c| matches!(c, PathCmd::ArcTo { .. }))
+            .expect("path contains an arcTo command");
+        match arc {
+            PathCmd::ArcTo {
+                wr,
+                hr,
+                st_ang,
+                sw_ang,
+            } => {
+                assert_eq!(*wr, 50.0);
+                assert_eq!(*hr, 50.0);
+                assert_eq!(*st_ang, 0.0);
+                assert_eq!(
+                    *sw_ang, 5_400_000.0,
+                    "raw 60000ths preserved (renderer divides by 60000)"
+                );
+            }
+            other => panic!("expected ArcTo, got {other:?}"),
+        }
+
+        let value = serde_json::to_value(arc).expect("arcTo serializes");
+        let obj = value
+            .as_object()
+            .expect("arcTo serializes to a JSON object");
+
+        // Tag key is "op" (not "cmd"), variant tag is camelCase "arcTo".
+        assert_eq!(
+            obj.get("op").and_then(|v| v.as_str()),
+            Some("arcTo"),
+            "variant tag serializes under key \"op\" as camelCase \"arcTo\""
+        );
+
+        // The angle fields must be camelCase — the TS renderer reads
+        // cmd.stAng / cmd.swAng. snake_case keys here regress the bug.
+        assert!(
+            obj.contains_key("stAng"),
+            "stAng must be camelCase, got keys: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            obj.contains_key("swAng"),
+            "swAng must be camelCase, got keys: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !obj.contains_key("st_ang") && !obj.contains_key("sw_ang"),
+            "snake_case angle keys must not appear (regresses the NaN bug)"
+        );
+        assert_eq!(obj.get("swAng").and_then(|v| v.as_f64()), Some(5_400_000.0));
+    }
+}

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -995,6 +995,15 @@ pub enum PathCmd {
     /// ECMA-376 §20.1.9.3 `a:arcTo`. `stAng`/`swAng` are in 60000ths of a
     /// degree. The start point is the current pen position; the ellipse
     /// center is derived so the pen lies on the ellipse at `stAng`.
+    ///
+    /// The enum-level `rename_all = "camelCase"` (tag = "op") renames only the
+    /// variant tags, not the fields, so `st_ang`/`sw_ang` need a per-variant
+    /// `rename_all` to serialize as the camelCase keys the TS renderer reads
+    /// (`renderer.ts`: `cmd.stAng`/`cmd.swAng`, then `/ 60000`). Without it the
+    /// keys land as snake_case, the renderer reads `undefined` → `NaN`, and the
+    /// arc fails to draw. Same root cause as the pptx fix in PR #489. The raw
+    /// 60000ths convention is unchanged (the renderer does the division).
+    #[serde(rename_all = "camelCase")]
     ArcTo {
         wr: f64,
         hr: f64,


### PR DESCRIPTION
## Summary

xlsx mirror of the pptx serde-naming fix in #489. Custom-geometry (`a:custGeom`) shapes that contain a non-degenerate `a:arcTo` did not render the arc.

## Root cause

`packages/xlsx/parser/src/types.rs` declares the path-command enum as `#[serde(tag = "op", rename_all = "camelCase")]`. `rename_all` renames only the **variant tags**, not the fields, so `ArcTo { wr, hr, st_ang, sw_ang }` serialized the angle fields as snake_case `st_ang`/`sw_ang`.

The xlsx renderer (`packages/xlsx/src/renderer.ts` ~2934) reads `cmd.stAng`/`cmd.swAng` and divides each by `60000`. (xlsx keeps angles as **raw 60000ths of a degree** and the renderer does the division — unlike pptx/docx, which pre-divide in the parser. See `drawing.rs` ~384, which parses `stAng`/`swAng` straight from the XML without scaling.)

With snake_case keys, `cmd.stAng` is `undefined`, so `(undefined / 60000) * (Math.PI / 180)` is `NaN` → the ellipse arc gets `NaN` coordinates and fails to draw. The renderer's degenerate-arc guard `if (rx <= 0 || ry <= 0) break;` short-circuits **before** the angles are read, so only **non-degenerate** arcs (wR/hR > 0) surfaced the bug.

## Impact

Non-degenerate custom-geometry arcs in xlsx drawings silently failed to render. `wr`/`hr` were unaffected (already correct camelCase).

## Fix

Add a per-variant `#[serde(rename_all = "camelCase")]` to the `ArcTo` variant so the angle fields serialize as `stAng`/`swAng`. The **raw-60000ths convention is preserved** — only the field names change; the renderer still performs the `/ 60000`.

## Verification

- New Rust regression test (`drawing.rs` `custom_path_arc_tests::arc_to_serializes_angle_fields_as_camelcase`): parses a non-degenerate `a:arcTo` via `parse_custom_path`, asserts the serialized JSON carries tag key `op` + camelCase `stAng`/`swAng` (never `st_ang`/`sw_ang`), and confirms the parser preserves the raw 60000ths value. Verified failing before the fix, passing after.
- `cargo test` (xlsx parser): 54 passed.
- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- xlsx WASM rebuilt (`wasm-pack build --target web`); `strings` on the binary shows the serialized field set `arcTo … wr hr stAng swAng` (no `st_ang`/`sw_ang`).
- xlsx VRT `demo/sample-1` (committed reference): 7/7 pass at 100% match, no regression. No reference images changed.

Same root cause as #489.