### PR TITLE
fix(xlsx): serialize ShapeTextRun font fields as camelCase (fontFace/fontSize)

### DIFF
--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1552,6 +1552,81 @@ mod math_tests {
         assert_eq!(text.paragraphs.len(), 1);
         assert!(!text.paragraphs[0].rtl, "absent @rtl → rtl false");
     }
+
+    /// `ShapeTextRun` uses an enum-level `#[serde(tag = "type", rename_all =
+    /// "camelCase")]`, which renames only the variant tags — not the fields. The
+    /// `Text` variant's `font_face` and the `Math` variant's `font_size`
+    /// therefore need per-variant `rename_all` to serialize as the camelCase
+    /// keys the TS renderer reads (`run.fontFace` / `run.fontSize`). This locks
+    /// the JSON contract so the keys never regress to snake_case (which the
+    /// renderer reads as `undefined`). Same bug class as the pptx serde fix
+    /// (PR #489) and the xlsx ArcTo fix (PR #491).
+    #[test]
+    fn serializes_text_run_font_face_as_camel_case() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:p>
+                <a:r>
+                  <a:rPr sz="1400"><a:latin typeface="Calibri"/></a:rPr>
+                  <a:t>hi</a:t>
+                </a:r>
+              </a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        let run = &text.paragraphs[0].runs[0];
+        assert!(
+            matches!(run, ShapeTextRun::Text { .. }),
+            "expected Text run"
+        );
+
+        let v: serde_json::Value = serde_json::to_value(run).unwrap();
+        assert_eq!(v["type"], "text", "tag key is `type`");
+        assert_eq!(
+            v["fontFace"], "Calibri",
+            "font_face must serialize as camelCase `fontFace` (renderer reads run.fontFace)"
+        );
+        assert!(
+            v.get("font_face").is_none(),
+            "snake_case `font_face` must not appear"
+        );
+    }
+
+    /// Companion to the Text-run case: the `Math` variant's `font_size` must
+    /// serialize as `fontSize` (renderer reads `run.fontSize`). Without the
+    /// per-variant `rename_all` the equation falls back to the inherited size.
+    #[test]
+    fn serializes_math_run_font_size_as_camel_case() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:p>
+                <a14:m><m:oMath><m:r>
+                  <a:rPr sz="2800"/>
+                  <m:t>n</m:t>
+                </m:r></m:oMath></a14:m>
+              </a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        let run = &text.paragraphs[0].runs[0];
+        assert!(
+            matches!(run, ShapeTextRun::Math { .. }),
+            "expected Math run"
+        );
+
+        let v: serde_json::Value = serde_json::to_value(run).unwrap();
+        assert_eq!(v["type"], "math", "tag key is `type`");
+        assert_eq!(
+            v["fontSize"], 28.0,
+            "font_size must serialize as camelCase `fontSize` (renderer reads run.fontSize)"
+        );
+        assert!(
+            v.get("font_size").is_none(),
+            "snake_case `font_size` must not appear"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -898,6 +898,14 @@ pub struct ShapeParagraph {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ShapeTextRun {
+    /// The enum-level `rename_all = "camelCase"` (tag = "type") renames only the
+    /// variant tags, not the fields, so the multi-word `font_face` needs a
+    /// per-variant `rename_all` to serialize as the camelCase key the TS
+    /// renderer reads (`renderer.ts`: `run.fontFace`). Without it the key lands
+    /// as snake_case, the renderer reads `undefined`, and the shape text's font
+    /// face is silently ignored (falls back to the default stack). Same root
+    /// cause as the pptx fix in PR #489 / the xlsx ArcTo fix in PR #491.
+    #[serde(rename_all = "camelCase")]
     Text {
         text: String,
         bold: bool,
@@ -914,6 +922,13 @@ pub enum ShapeTextRun {
     /// Soft line break (`<a:br>`).
     Break,
     /// Inline (`display:false`) or block (`display:true`) OMML equation.
+    ///
+    /// Like `Text`, the multi-word `font_size` needs a per-variant
+    /// `rename_all = "camelCase"` so it serializes as `fontSize` (the key the
+    /// renderer reads at `renderer.ts`: `run.fontSize`). Without it the
+    /// snake_case key is read as `undefined` and the equation always falls back
+    /// to the inherited/default size instead of its explicit `rPr@sz`.
+    #[serde(rename_all = "camelCase")]
     Math {
         nodes: Vec<ooxml_common::math::MathNode>,
         display: bool,


### PR DESCRIPTION
## Cause

`ShapeTextRun` (packages/xlsx/parser/src/types.rs) uses an enum-level
`#[serde(tag = "type", rename_all = "camelCase")]`. At the enum level,
`rename_all` renames only the **variant tags**, not the variant **fields**.
So two multi-word fields serialized as snake_case:

- `Text { … font_face: Option<String> }` → `"font_face"`
- `Math { … font_size: Option<f64> }` → `"font_size"`

## Impact

The TS contract (packages/xlsx/src/types.ts:573, :583) declares `fontFace` /
`fontSize`, and the renderer reads them:

- `renderer.ts:3166` → `fontStackFor(run.fontFace)`
- `renderer.ts:3194` → `run.fontSize ?? (lastTextPt || DEFAULT_FONT_SIZE)`

With the keys arriving as snake_case, both read `undefined`:

- shape text's explicit **font face is silently ignored** (falls back to the
  default font stack), and
- inline/block **equations ignore their explicit `rPr@sz`** and always fall
  back to the inherited / default point size.

## Fix

Add a per-variant `#[serde(rename_all = "camelCase")]` to the `Text` and
`Math` variants so the multi-word fields serialize as `fontFace` / `fontSize`.
All other fields are single words (unchanged); the tag key stays `type`. This
mirrors the xlsx `Image` variant, which already carries a per-variant
`rename_all`.

## Same bug class

Identical root cause to the pptx serde fix (**PR #489**) and the xlsx
`PathCmd::ArcTo` serde fix (**PR #491**): an enum-level `rename_all` that does
not reach the variant fields. Discovered by an independent review as a sibling
of #491.

## Tests

- Two Rust regression tests in `drawing.rs` (`math_tests`): parse an
  `<xdr:txBody>` via `parse_tx_body`, serialize the run, and assert the JSON
  carries the tag key `type` and camelCase `fontFace` / `fontSize` — never
  `font_face` / `font_size`.
- Empirically confirmed before/after: pre-fix JSON emitted
  `"font_face":"Calibri"` / `"font_size":28.0`; post-fix emits
  `"fontFace":"Calibri"` / `"fontSize":28.0`.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D
  warnings`, and `cargo test` (55 passed) all green.
- xlsx demo VRT 100% (7/7, diff 0.0%); no references touched. (The demo sample
  has no shape text/math, so VRT confirms no regression but does not exercise
  this path directly — same as the ArcTo fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)