### PR TITLE
fix(core,pptx): scope decoded-image caches per document, not by zip path

### DIFF
--- a/packages/core/src/image/svg-image-by-path.test.ts
+++ b/packages/core/src/image/svg-image-by-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { getCachedSvgImageByPath } from './svg-image-by-path';
+import { getCachedSvgImageByPath, dropSvgImageCache } from './svg-image-by-path';
 
 describe('getCachedSvgImageByPath', () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -36,6 +36,42 @@ describe('getCachedSvgImageByPath', () => {
     // Second call must RETRY (cache self-evicted), not return a cached rejection.
     await expect(getCachedSvgImageByPath('p.svg', fetchImage)).rejects.toThrow();
     expect(fetchImage).toHaveBeenCalledTimes(2);
+  });
+
+  it('namespaces the cache by fetchImage — same zip path from two documents does not cross-contaminate', async () => {
+    vi.stubGlobal('URL', { createObjectURL: () => 'blob:x', revokeObjectURL: () => {} });
+    class FakeImg { onload: (() => void) | null = null; onerror: (() => void) | null = null;
+      set src(_v: string) { queueMicrotask(() => this.onload && this.onload()); } }
+    vi.stubGlobal('Image', FakeImg);
+    // Two different documents reference the SAME internal zip path. Their byte
+    // sources (fetchImage closures) differ — the cache must not serve doc A's
+    // decoded SVG for doc B's request.
+    const fetchA = vi.fn(async () => new Blob(['<svg/>'], { type: 'image/svg+xml' }));
+    const fetchB = vi.fn(async () => new Blob(['<svg/>'], { type: 'image/svg+xml' }));
+    const a = await getCachedSvgImageByPath('word/media/image1.svg', fetchA);
+    const b = await getCachedSvgImageByPath('word/media/image1.svg', fetchB);
+    expect(fetchA).toHaveBeenCalledTimes(1);
+    expect(fetchB).toHaveBeenCalledTimes(1); // B must consult its OWN source, not hit A's cache
+    expect(a).not.toBe(b); // distinct decoded images
+    // Within one document, the path still dedupes.
+    const a2 = await getCachedSvgImageByPath('word/media/image1.svg', fetchA);
+    expect(a2).toBe(a);
+    expect(fetchA).toHaveBeenCalledTimes(1);
+  });
+
+  it('dropSvgImageCache revokes every object URL for a fetchImage and lets it re-decode', async () => {
+    let revoked = 0;
+    vi.stubGlobal('URL', { createObjectURL: () => 'blob:x', revokeObjectURL: () => { revoked++; } });
+    class FakeImg { onload: (() => void) | null = null; onerror: (() => void) | null = null;
+      set src(_v: string) { queueMicrotask(() => this.onload && this.onload()); } }
+    vi.stubGlobal('Image', FakeImg);
+    const fetchImage = vi.fn(async () => new Blob(['<svg/>'], { type: 'image/svg+xml' }));
+    await getCachedSvgImageByPath('a.svg', fetchImage);
+    await getCachedSvgImageByPath('b.svg', fetchImage);
+    dropSvgImageCache(fetchImage); // e.g. on Document.destroy()
+    expect(revoked).toBe(2); // both live object URLs released
+    await getCachedSvgImageByPath('a.svg', fetchImage);
+    expect(fetchImage).toHaveBeenCalledTimes(3); // cache cleared → fresh decode
   });
 
   it('awaits img.decode() before resolving when available', async () => {

--- a/packages/core/src/image/svg-image-by-path.ts
+++ b/packages/core/src/image/svg-image-by-path.ts
@@ -1,59 +1,84 @@
 // Decoder for embedded SVG images (Microsoft's `asvg:svgBlip` extension,
 // MS-ODRAWXML) used by the docx, pptx and xlsx renderers, for the lazy,
-// byte-on-demand image pipeline. The cache keys on the embedded zip path
-// (e.g. "word/media/image1.svg") and pulls the bytes lazily via a caller-
+// byte-on-demand image pipeline. The bytes are pulled lazily via a caller-
 // supplied `fetchImage(path, mimeType)` — mirroring the pptx audio/video
 // extraction pattern. The fetched bytes are wrapped in an object URL that this
 // module owns and revokes on drop (unlike a `data:` URL, an object URL is a
 // live handle that leaks if never released).
 //
+// The cache is keyed FIRST by the document's `fetchImage` closure, then by the
+// embedded zip path. Two different documents reuse the same internal paths
+// (e.g. both have "word/media/image1.svg"), so the path alone is NOT a unique
+// key — the byte source is. Keying by `fetchImage` (one stable closure per
+// document instance) keeps document A's decoded SVG from being served for
+// document B's identically-named blip. The outer WeakMap also lets a document's
+// whole image cache be reclaimed with the document.
+//
 // SVG is decoded via an `<img>` element rather than `createImageBitmap`,
 // because `createImageBitmap` cannot rasterize SVG in every browser. The Promise
 // is cached so concurrent first-renders dedupe; an HTMLImageElement holds no GPU
 // resource, so a drop only needs to forget the entry and revoke its object URL.
-// Bounded LRU.
+// Bounded LRU per document.
 
-const svgByPathCache = new Map<string, Promise<HTMLImageElement>>();
-const urlByPath = new Map<string, string>(); // object URL owned per path
+type FetchImage = (path: string, mimeType: string) => Promise<Blob>;
+
+/** Per-document decode state: the LRU of decoded `<img>` promises and the
+ *  object URL owned for each path (kept in lockstep so drop revokes both). */
+interface DocCache {
+  imgs: Map<string, Promise<HTMLImageElement>>;
+  urls: Map<string, string>;
+}
+
+const byFetch = new WeakMap<FetchImage, DocCache>();
 const MAX = 256;
 
-// Drop a path: forget the cached promise and revoke its object URL together, so
-// the URL lifecycle has a single owner whether the drop is by LRU eviction or by
-// decode failure. Co-locating forget+revoke is what keeps a failed decode from
-// leaking its handle.
-function dropEntry(path: string): void {
-  svgByPathCache.delete(path);
-  const url = urlByPath.get(path);
+function docCacheFor(fetchImage: FetchImage): DocCache {
+  let dc = byFetch.get(fetchImage);
+  if (!dc) {
+    dc = { imgs: new Map(), urls: new Map() };
+    byFetch.set(fetchImage, dc);
+  }
+  return dc;
+}
+
+// Drop a path within one document: forget the cached promise and revoke its
+// object URL together, so the URL lifecycle has a single owner whether the drop
+// is by LRU eviction or by decode failure. Co-locating forget+revoke is what
+// keeps a failed decode from leaking its handle.
+function dropEntry(dc: DocCache, path: string): void {
+  dc.imgs.delete(path);
+  const url = dc.urls.get(path);
   if (url) {
     URL.revokeObjectURL(url);
-    urlByPath.delete(path);
+    dc.urls.delete(path);
   }
 }
 
 /**
- * Decode the SVG at `svgImagePath` to an `HTMLImageElement`, cached by path.
- * The bytes are fetched lazily through `fetchImage(path, mimeType)`; the
- * resulting object URL is owned by this module and revoked when the entry is
- * dropped. The returned image is drawable with `ctx.drawImage` exactly like an
- * ImageBitmap. Rejects (and self-evicts, so the next call retries fresh) if the
- * SVG fails to load — callers should fall back to a raster representation on
- * rejection.
+ * Decode the SVG at `svgImagePath` to an `HTMLImageElement`, cached per
+ * document (keyed by `fetchImage`) then by path. The bytes are fetched lazily
+ * through `fetchImage(path, mimeType)`; the resulting object URL is owned by
+ * this module and revoked when the entry is dropped. The returned image is
+ * drawable with `ctx.drawImage` exactly like an ImageBitmap. Rejects (and
+ * self-evicts, so the next call retries fresh) if the SVG fails to load —
+ * callers should fall back to a raster representation on rejection.
  */
 export function getCachedSvgImageByPath(
   svgImagePath: string,
-  fetchImage: (path: string, mimeType: string) => Promise<Blob>,
+  fetchImage: FetchImage,
 ): Promise<HTMLImageElement> {
-  const hit = svgByPathCache.get(svgImagePath);
+  const dc = docCacheFor(fetchImage);
+  const hit = dc.imgs.get(svgImagePath);
   if (hit) {
     // Refresh LRU position.
-    svgByPathCache.delete(svgImagePath);
-    svgByPathCache.set(svgImagePath, hit);
+    dc.imgs.delete(svgImagePath);
+    dc.imgs.set(svgImagePath, hit);
     return hit;
   }
   const p = (async () => {
     const blob = await fetchImage(svgImagePath, 'image/svg+xml');
     const url = URL.createObjectURL(blob);
-    urlByPath.set(svgImagePath, url);
+    dc.urls.set(svgImagePath, url);
     const img = new Image();
     await new Promise<void>((resolve, reject) => {
       img.onload = () => {
@@ -75,11 +100,26 @@ export function getCachedSvgImageByPath(
     return img;
   })();
   // Don't poison the cache on a transient fetch/decode failure; revoke the URL too.
-  p.catch(() => dropEntry(svgImagePath));
-  svgByPathCache.set(svgImagePath, p);
-  if (svgByPathCache.size > MAX) {
-    const oldest = svgByPathCache.keys().next().value as string;
-    dropEntry(oldest);
+  p.catch(() => dropEntry(dc, svgImagePath));
+  dc.imgs.set(svgImagePath, p);
+  if (dc.imgs.size > MAX) {
+    const oldest = dc.imgs.keys().next().value as string;
+    dropEntry(dc, oldest);
   }
   return p;
+}
+
+/**
+ * Release every decoded SVG and its object URL for one document's `fetchImage`,
+ * then forget the document. Call from the owning viewer's `destroy()` so the
+ * live object URLs are revoked promptly rather than waiting for GC. A no-op when
+ * the document never decoded an SVG.
+ */
+export function dropSvgImageCache(fetchImage: FetchImage): void {
+  const dc = byFetch.get(fetchImage);
+  if (!dc) return;
+  for (const url of dc.urls.values()) URL.revokeObjectURL(url);
+  dc.urls.clear();
+  dc.imgs.clear();
+  byFetch.delete(fetchImage);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,7 +66,7 @@ export { drawArrowHead } from './shape/arrow';
 // three renderers to prefer the vector original over the raster fallback.
 // Path-keyed for the lazy byte-on-demand pipeline: fetches SVG bytes via a
 // caller-supplied fetchImage(path, mimeType) and owns the object-URL lifecycle.
-export { getCachedSvgImageByPath } from './image/svg-image-by-path';
+export { getCachedSvgImageByPath, dropSvgImageCache } from './image/svg-image-by-path';
 // ECMA-376 §20.1.9 spec-driven preset geometry engine (presets.json from
 // presetShapeDefinitions.xml). Coexists with the legacy hand-rolled
 // `buildShapePath` above, which the pptx renderer still uses as a silhouette /

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -4,6 +4,7 @@ import {
   preloadGoogleFonts,
   WorkerBridge,
   defaultDpr,
+  dropSvgImageCache,
   type LoadOptions as CoreLoadOptions,
   type MathRenderer,
 } from '@silurus/ooxml-core';
@@ -45,6 +46,12 @@ export class DocxDocument {
   private _worker: Worker;
   private _bridge: WorkerBridge<WorkerResponse | RenderWorkerResponse>;
   private _imageCache = new Map<string, Promise<Blob>>();
+  /** One stable closure per instance: core's path-keyed SVG cache namespaces on
+   *  this identity, so two open documents never swap a shared zip path (e.g.
+   *  word/media/image1.svg). Reusing one reference also lets the SVG cache hit
+   *  across page renders. */
+  private readonly _fetchImage = (path: string, mime: string): Promise<Blob> =>
+    this.getImage(path, mime);
 
   private constructor(worker: Worker, mode: 'main' | 'worker') {
     this._worker = worker;
@@ -131,6 +138,9 @@ export class DocxDocument {
     this._meta = null;
     this._pages = null;
     this._imageCache.clear();
+    // Revoke this document's decoded-SVG object URLs (raster bitmaps are decoded
+    // into a per-render-local map, so they have no module cache to drop).
+    dropSvgImageCache(this._fetchImage);
   }
 
   /**
@@ -231,7 +241,7 @@ export class DocxDocument {
       prebuiltPages: pages,
       // Lazy image bytes: the renderer fetches each embedded blip on demand by
       // zip path (decoded only when drawn) instead of reading inlined base64.
-      fetchImage: (path, mime) => this.getImage(path, mime),
+      fetchImage: this._fetchImage,
     });
   }
 

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1,5 +1,5 @@
 import type { MediaElement, Presentation, WorkerRequest, WorkerResponse } from './types';
-import { renderSlide, type TextRunCallback } from './renderer';
+import { renderSlide, dropImageBitmapCache, type TextRunCallback } from './renderer';
 import { createPresentationHandle, type PresentationHandle } from './presentation-handle';
 import { selectNotes } from './notes';
 import {
@@ -7,6 +7,7 @@ import {
   WorkerBridge,
   defaultDpr,
   isHTMLCanvas,
+  dropSvgImageCache,
   type LoadOptions as CoreLoadOptions,
   type MathRenderer,
 } from '@silurus/ooxml-core';
@@ -84,6 +85,12 @@ export class PptxPresentation {
   private _meta: PresentationMeta | null = null;
   private _mediaCache = new Map<string, Promise<Blob>>();
   private _imageCache = new Map<string, Promise<Blob>>();
+  /** One stable closure per instance: the decoded-bitmap and SVG caches key on
+   *  this identity to scope decodes per deck (so two open decks never swap
+   *  images for a shared zip path like ppt/media/image1.png). Reusing the same
+   *  reference across every render also lets those caches hit across slides. */
+  private readonly _fetchImage = (path: string, mime: string): Promise<Blob> =>
+    this.getImage(path, mime);
   private _workerReady = false;
   private _workerReadyCallbacks: Array<() => void> = [];
   /** Opt-in OMML equation engine, injected once at {@link load}. Every
@@ -245,7 +252,7 @@ export class PptxPresentation {
         minorFont: this._presentation.minorFont,
         hlinkColor: this._presentation.hlinkColor ?? null,
         fetchMedia: (path) => this.getMedia(path),
-        fetchImage: (path, mime) => this.getImage(path, mime),
+        fetchImage: this._fetchImage,
         skipMediaControls: opts.skipMediaControls,
         math: this._math,
       },
@@ -397,7 +404,7 @@ export class PptxPresentation {
       dpr,
       slideWidthEmu: this.slideWidth,
       fetchMedia: (path) => this.getMedia(path),
-      fetchImage: (path, mime) => this.getImage(path, mime),
+      fetchImage: this._fetchImage,
       drawBase,
     });
   }
@@ -409,5 +416,9 @@ export class PptxPresentation {
     this._meta = null;
     this._mediaCache.clear();
     this._imageCache.clear();
+    // Release this deck's decoded raster bitmaps (GPU-backed) and SVG object
+    // URLs promptly; both caches are keyed by `_fetchImage`.
+    dropImageBitmapCache(this._fetchImage);
+    dropSvgImageCache(this._fetchImage);
   }
 }

--- a/packages/pptx/src/renderer.image.test.ts
+++ b/packages/pptx/src/renderer.image.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getCachedBitmap } from './renderer';
+import { getCachedBitmap, dropImageBitmapCache } from './renderer';
 
 /**
  * Raster blips decode through `getCachedBitmap`, which now keys its LRU by zip
@@ -37,5 +37,39 @@ describe('getCachedBitmap (lazy image bytes)', () => {
     const path = 'ppt/media/getcachedbitmap-b.jpeg';
     await getCachedBitmap(path, 'image/jpeg', fetchImage);
     expect(fetchImage).toHaveBeenCalledWith(path, 'image/jpeg');
+  });
+
+  it('namespaces the cache by fetchImage — two decks sharing a zip path decode independently', async () => {
+    // Different .pptx files reuse the SAME internal paths (ppt/media/image1.png).
+    // Opening deck B after deck A must NOT paint deck A's bytes for deck B: the
+    // decoded-bitmap cache has to be scoped per byte source, not by path alone.
+    const path = 'ppt/media/image1.png';
+    const fetchA = vi.fn(async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }));
+    const fetchB = vi.fn(async (_p: string, mime: string) => new Blob([new Uint8Array([2])], { type: mime }));
+    await getCachedBitmap(path, 'image/png', fetchA);
+    await getCachedBitmap(path, 'image/png', fetchB);
+    expect(fetchA).toHaveBeenCalledTimes(1);
+    expect(fetchB).toHaveBeenCalledTimes(1); // deck B must consult its own source
+    expect((globalThis.createImageBitmap as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2);
+    // Within one deck the path still dedupes across draws.
+    await getCachedBitmap(path, 'image/png', fetchA);
+    expect(fetchA).toHaveBeenCalledTimes(1);
+  });
+
+  it('dropImageBitmapCache closes a deck\'s bitmaps and lets it re-decode', async () => {
+    const closes: number[] = [];
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (_blob: Blob) => ({ width: 1, height: 1, close: () => closes.push(1) }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (_p: string, mime: string) => new Blob([new Uint8Array([3])], { type: mime }));
+    await getCachedBitmap('ppt/media/drop-a.png', 'image/png', fetchImage);
+    await getCachedBitmap('ppt/media/drop-b.png', 'image/png', fetchImage);
+    dropImageBitmapCache(fetchImage); // e.g. on Presentation.destroy()
+    // Both decoded bitmaps were closed to release their GPU backing.
+    await Promise.resolve();
+    expect(closes.length).toBe(2);
+    await getCachedBitmap('ppt/media/drop-a.png', 'image/png', fetchImage);
+    expect(fetchImage).toHaveBeenCalledTimes(3); // cache cleared → fresh decode
   });
 });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2568,9 +2568,26 @@ function renderTextBody(
 // ImageBitmap is expensive, and the same picture is re-decoded on every render
 // (each scroll / resize / interaction). Cache the decode — the Promise, so
 // concurrent first-renders dedupe — and reuse it. Bounded FIFO so a long
-// session or many decks can't grow without limit.
+// session can't grow without limit.
+//
+// Keyed FIRST by the deck's `fetchImage` closure, then by zip path. Different
+// .pptx files reuse the same internal paths (ppt/media/image1.png), so a
+// module-global path→bitmap map would paint deck A's image for deck B's
+// identically-named blip when both are open on the main thread. The WeakMap
+// scopes the cache per byte source (one stable closure per Presentation) and
+// lets a deck's bitmaps be reclaimed with it.
+type FetchImage = (path: string, mime: string) => Promise<Blob>;
 const IMAGE_BITMAP_CACHE_MAX = 256;
-const imageBitmapCache = new Map<string, Promise<ImageBitmap>>();
+const bitmapCacheByFetch = new WeakMap<FetchImage, Map<string, Promise<ImageBitmap>>>();
+
+function bitmapCacheFor(fetchImage: FetchImage): Map<string, Promise<ImageBitmap>> {
+  let cache = bitmapCacheByFetch.get(fetchImage);
+  if (!cache) {
+    cache = new Map();
+    bitmapCacheByFetch.set(fetchImage, cache);
+  }
+  return cache;
+}
 
 
 /** Local view of the parsed `<a:sp3d>` (1:1 with the Sp3d TS type). */
@@ -2879,26 +2896,41 @@ function paintBeveledFlat(
 export function getCachedBitmap(
   imagePath: string,
   mimeType: string,
-  fetchImage: (path: string, mime: string) => Promise<Blob>,
+  fetchImage: FetchImage,
 ): Promise<ImageBitmap> {
-  const existing = imageBitmapCache.get(imagePath);
+  const cache = bitmapCacheFor(fetchImage);
+  const existing = cache.get(imagePath);
   if (existing) {
     // Refresh LRU position.
-    imageBitmapCache.delete(imagePath);
-    imageBitmapCache.set(imagePath, existing);
+    cache.delete(imagePath);
+    cache.set(imagePath, existing);
     return existing;
   }
   const p = fetchImage(imagePath, mimeType).then((b) => createImageBitmap(b));
   // Don't poison the cache on a transient decode failure.
-  p.catch(() => imageBitmapCache.delete(imagePath));
-  imageBitmapCache.set(imagePath, p);
-  if (imageBitmapCache.size > IMAGE_BITMAP_CACHE_MAX) {
-    const oldestKey = imageBitmapCache.keys().next().value as string;
-    const oldest = imageBitmapCache.get(oldestKey);
-    imageBitmapCache.delete(oldestKey);
+  p.catch(() => cache.delete(imagePath));
+  cache.set(imagePath, p);
+  if (cache.size > IMAGE_BITMAP_CACHE_MAX) {
+    const oldestKey = cache.keys().next().value as string;
+    const oldest = cache.get(oldestKey);
+    cache.delete(oldestKey);
     oldest?.then((b) => b.close()).catch(() => {});
   }
   return p;
+}
+
+/**
+ * Close every decoded bitmap for one deck's `fetchImage` and forget the deck.
+ * Call from {@link PptxPresentation.destroy} so GPU-backed ImageBitmaps are
+ * released promptly rather than waiting for GC. A no-op when the deck decoded no
+ * raster blips.
+ */
+export function dropImageBitmapCache(fetchImage: FetchImage): void {
+  const cache = bitmapCacheByFetch.get(fetchImage);
+  if (!cache) return;
+  for (const p of cache.values()) p.then((b) => b.close()).catch(() => {});
+  cache.clear();
+  bitmapCacheByFetch.delete(fetchImage);
 }
 
 /** Poster bitmaps decoded once per media element; renderSlide's prefetch pass

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -4,6 +4,7 @@ import {
   preloadGoogleFonts,
   WorkerBridge,
   defaultDpr,
+  dropSvgImageCache,
   type LoadOptions as CoreLoadOptions,
   type MathRenderer,
 } from '@silurus/ooxml-core';
@@ -49,6 +50,12 @@ export class XlsxWorkbook {
    *  `_imageCache`; kept separate from {@link XlsxWorkbook.imageCache} (decoded
    *  sources) so each layer dedupes independently. */
   private imageBlobCache = new Map<string, Promise<Blob>>();
+  /** One stable closure per instance: core's path-keyed SVG cache namespaces on
+   *  this identity, so two open workbooks never swap a shared zip path (e.g.
+   *  xl/media/image1.svg). Reusing one reference also lets the SVG cache hit
+   *  across viewport renders. */
+  private readonly _fetchImage = (path: string, mime: string): Promise<Blob> =>
+    this.getImage(path, mime);
   private rawData: ArrayBuffer | null = null;
   private maxZipEntryBytes: number | undefined;
   /** Opt-in OMML equation engine, injected once at {@link load}. Every
@@ -272,7 +279,7 @@ export class XlsxWorkbook {
       viewport,
       // Supply the lazy byte loader so the orchestrator can decode embedded
       // images on demand; an explicit caller-provided fetchImage still wins.
-      { fetchImage: (path, mime) => this.getImage(path, mime), ...opts },
+      { fetchImage: this._fetchImage, ...opts },
     );
   }
 
@@ -313,6 +320,9 @@ export class XlsxWorkbook {
     this.sheetCache.clear();
     this.imageCache.clear();
     this.imageBlobCache.clear();
+    // Revoke this workbook's decoded-SVG object URLs (raster sources live in the
+    // per-instance imageCache cleared above).
+    dropSvgImageCache(this._fetchImage);
     this.rawData = null;
   }
 }


### PR DESCRIPTION
## Problem

Reported: opening `sample-12.pptx` and then `sample-11.pptx` shows **sample-12's images in place of sample-11's** (and the reverse with the opposite order).

## Root cause

The lazy-image pipeline (#492) re-keyed the decoded-image caches by **zip path** (e.g. `ppt/media/image1.png`). Different OOXML files reuse the same internal paths, so the **module-global** caches collided across documents rendered on the main thread:

- `packages/pptx/src/renderer.ts` — `imageBitmapCache` (module-global, key = path) → pptx raster blips collide. **This is the reported symptom.**
- `packages/core/src/image/svg-image-by-path.ts` — `getCachedSvgImageByPath` (module-global, key = path) → SVG blips collide for **all three** packages.

`PptxPresentation._imageCache` (the *bytes* cache) was already per-instance and correct; the *decoded* cache was the shared one. The old `data:`-URL key was content-addressed, so it never collided. docx raster (per-render-local map) and xlsx raster (per-instance `imageCache`) were already correctly scoped. Worker mode was unaffected (each instance owns its worker → its own module realm); the collision was **main-mode only** (the default the viewers use).

## Fix

Key both caches by the document's `fetchImage` closure **first**, then by path. One stable `_fetchImage` closure per viewer instance ⇒ distinct documents are distinct cache namespaces and can never cross-contaminate; the outer `WeakMap` also lets a document's images be reclaimed with it.

- core: `getCachedSvgImageByPath` → `WeakMap<fetchImage, …>`, new `dropSvgImageCache`
- pptx: `getCachedBitmap` → `WeakMap<fetchImage, …>`, new `dropImageBitmapCache`
- pptx/docx/xlsx: stabilize a per-instance `_fetchImage`; call the drop helpers from `destroy()` to release GPU bitmaps + object URLs promptly (addresses the memory-cleanup half of the report)

## Tests

- Regression tests reproduce the exact collision (two `fetchImage` closures, one shared path) for both the core SVG helper and the pptx bitmap cache, plus cover the destroy-time drop. Both were **red before / green after**.
- Full suite green: 608 tests, typecheck clean.
- **End-to-end in Storybook**: rendered `sample-12` then switched to `sample-11` **in the same module realm** (iframe not reloaded — verified via a surviving marker). The resulting canvas is **pixel-identical** (fingerprint `555321442`) to a fresh `sample-11`, and does **not** match `sample-12` (`1781177722`). Before the fix this is exactly where the swap occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)