### PR TITLE
chore(release): 0.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,36 @@ changes that remain compatible with existing API surfaces.
 
 ## 0.64.0 — 2026-06-17
 
-Minor: embedded SVG images (Microsoft `asvg:svgBlip` extension, MS-ODRAWXML) now
-render across Word and Excel as well as PowerPoint, through shared blip helpers
-in `@silurus/ooxml-core` and the common Rust crate. PowerPoint additionally
-renders pictures that carry *only* the svgBlip (no raster fallback).
+Minor. Two headline changes plus several rendering features. **(1)** Embedded SVG
+images (Microsoft `asvg:svgBlip` extension, MS-ODRAWXML) now render across Word
+and Excel as well as PowerPoint, through shared blip helpers in
+`@silurus/ooxml-core` and the common Rust crate; PowerPoint additionally renders
+pictures that carry *only* the svgBlip (no raster fallback). **(2)** Embedded
+images are extracted lazily by zip path instead of being inlined as base64 at
+parse time, cutting the parsed-model payload ~90% on image-heavy files. Also:
+PowerPoint text highlight, custom-geometry arrow heads, and custom-geometry arc
+fixes across all three formats.
 
 ### Shared
 
+- **Lazy, byte-on-demand image pipeline.** Parsers now emit each embedded image's
+  zip path + MIME instead of a base64 `data:` URL, and the renderers fetch the
+  bytes on demand through a `fetchImage(path, mime)` callback (twin of the
+  existing audio/video extraction). New size-guarded
+  `ooxml_common::zip::extract_zip_entry` plus an `extract_image` WASM export per
+  parser. The parsed-model payload drops ~93% (pptx) / ~89% (docx) on
+  image-bearing files. Decoded bitmaps and SVGs are cached **per document** —
+  keyed by byte source, not by zip path, so two open documents that reuse the
+  same internal path (e.g. `ppt/media/image1.png`) never swap images — and are
+  released on `destroy()`.
 - New `ooxml_common::blip` Rust helpers (`svg_blip_rid`, `blip_embed_rid`,
-  `mime_from_ext`) and a shared `getCachedSvgImage` decoder in
+  `mime_from_ext`) and a shared path-keyed `getCachedSvgImageByPath` decoder in
   `@silurus/ooxml-core`, replacing three divergent `mime_from_ext` copies and the
   previously pptx-only svgBlip logic. `.svg` parts map to `image/svg+xml`
   everywhere; all three renderers prefer the vector original and fall back to the
   raster on decode failure.
+- New `highlightBox` core helper: a single source of truth for text-highlight /
+  marker extents, shared by the docx and pptx renderers.
 
 ### pptx
 
@@ -27,17 +44,31 @@ renders pictures that carry *only* the svgBlip (no raster fallback).
 - An SVG picture with an `a:srcRect` crop no longer routes the SVG through
   `createImageBitmap` (which cannot rasterize SVG in every browser); it decodes
   via the shared `<img>` path.
+- Honor `a:highlight` (text highlight / marker) on runs (§21.1.2.3.4).
+- Draw arrow heads on custom-geometry (freeform / curve) lines, not just preset
+  connectors; degenerate arcs are skipped when locating the line endpoints.
 
 ### docx
 
 - Honor the `asvg:svgBlip` extension on inline, anchored and grouped pictures:
   draw the vector original, fall back to the raster. `.svg` parts are no longer
   mislabeled `image/png`. (§20.1.8.13 + MS-ODRAWXML SVG extension)
+- Custom-geometry `ArcTo` angle fields (`stAng` / `swAng`, §20.1.9.3) now
+  deserialize, so arcs in freeform shapes render instead of being dropped.
 
 ### xlsx
 
 - Honor the `asvg:svgBlip` extension on `xdr:twoCellAnchor` and grouped pictures;
   `.svg` media parts are no longer excluded from collection.
+- Custom-geometry `ArcTo` angle fields (`stAng` / `swAng`) and `ShapeTextRun`
+  font fields (`fontFace` / `fontSize`) now serialize as camelCase, fixing
+  dropped shape arcs and unstyled shape text.
+
+### node
+
+- `renderSlideNode` accepts an optional `sourceBuffer`; when supplied, headless
+  renders extract embedded images for real via `makeSourceBufferFetchImage` (the
+  lazy `extract_image` path) instead of skipping them.
 
 ## 0.63.0 — 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Hyperlinks (`hlinkClick` — theme `hlink` colour + auto underline) | ✅ |
 | | Text shadow (`rPr > effectLst > outerShdw`) | ✅ |
 | | Text outline (`rPr > a:ln`) | ✅ |
+| | Text highlight / marker (`a:highlight` — §21.1.2.3.4) | ✅ |
 | | Math equations (OMML `m:oMath` / `m:oMathPara`, incl. `a14:m` / `mc:AlternateContent`; STIX Two Math via MathJax — opt-in `@silurus/ooxml/math`) | ✅ |
 | **Text — paragraphs** | Horizontal alignment (left / center / right / justify) | ✅ |
 | | Vertical anchor (top / center / bottom) | ✅ |


### PR DESCRIPTION
Completes the **0.64.0** release. The version was bumped during the svgBlip prep but never tagged/published — npm is still at **0.63.0** — and the lazy-image pipeline plus several rendering features have since landed on `main` under 0.64.0. This PR expands the CHANGELOG + feature table to cover the full unreleased delta and is the merge that precedes the `v0.64.0` tag.

## What 0.64.0 ships (since 0.63.0)

- **Lazy, byte-on-demand image pipeline** (#492) — parsers emit zip path + MIME; renderers fetch bytes via `fetchImage`; `extract_image` WASM export + shared `extract_zip_entry`. ~93% (pptx) / ~89% (docx) payload cut on image files. Decoded-image cache is now **per document** (keyed by byte source, not zip path).
- **Image-cache cross-document fix** (#494) — opening deck B after deck A no longer paints deck A's image for B's identically-named blip (`ppt/media/image1.png`). Caches drop on `destroy()`.
- **pptx text highlight** `a:highlight` (#488) + **custom-geometry arrow heads** on freeform/curve lines (#487).
- **custGeom `ArcTo` serde fixes** across pptx/docx/xlsx (#489/#490/#491); **xlsx `ShapeTextRun`** font fields (#493).
- **node** `renderSlideNode({ sourceBuffer })` for real headless image extraction.
- Embedded SVG (`asvg:svgBlip`) across docx/xlsx/pptx (already in the 0.64.0 entry).

## Release housekeeping

- Version already `0.64.0` across all 8 packages (no bump).
- README feature table: added pptx text-highlight row; SVG rows + site capabilities were done in the prep commit.
- README consistency verified (ESM-only `.mjs`, no stale version refs, public viewer API unchanged).
- **Screenshots unchanged**: lazy-image is not visually observable and the representative samples don't exercise the new edge-case features (consistent with the 0.64.0 prep commit, which also did not re-take them).

After merge: tag `v0.64.0` → triggers npm publish + VS Code Marketplace publish → GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)