### PR TITLE
chore(release): 0.64.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.64.1 — 2026-06-18
+
+Patch. Fixes glyph overlap on justified CJK lines containing punctuation adjacent to Latin text in both docx and pptx.
+
+- **docx / pptx**: `both`/`distribute` (docx §17.18.44) and `just`/`dist` (pptx §20.1.10.59) justification now anchor each sliced CJK piece to the whole-string cumulative advance, preserving the browser's contextual 約物半角 half-width collapse. Previously, summing isolated piece advances overran the segment box and painted the following run on top of the trailing CJK glyph. (PR #497)
+- **core**: `justifiedPiecePositions` / `JustifiedPiece` promoted to `@silurus/ooxml-core` so both docx and pptx renderers share the same helper.
+
 ## 0.64.0 — 2026-06-17
 
 Minor. Two headline changes plus several rendering features. **(1)** Embedded SVG

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release for the CJK justified-text glyph overlap fix (PR #497).

## Changes
- **docx + pptx**: anchor justified CJK pieces to whole-string advance (§17.18.44 / §20.1.10.59) — fixes glyph overlap at CJK→Latin boundary caused by 約物半角 measurement drift
- **core**: promote `justifiedPiecePositions` / `JustifiedPiece` to `@silurus/ooxml-core`
- Version bump: 0.64.0 → 0.64.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)