### PR TITLE
refactor(core,pptx): unify CJK justify with docx via shared helper

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -173,4 +173,4 @@ export {
   type DistributeOptions,
   type SegStretch,
 } from './text/line-distribute';
-export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-draw';
+export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-positions';

--- a/packages/core/src/text/justify-positions.test.ts
+++ b/packages/core/src/text/justify-positions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { justifiedPiecePositions } from './justify-draw.js';
+import { justifiedPiecePositions } from './justify-positions.js';
 
 // A stub `measure` that models 約物半角: a '.' (stand-in for collapsing
 // punctuation like 。）) advances 6 when it is NOT the first code point of the
@@ -74,5 +74,41 @@ describe('justifiedPiecePositions', () => {
       { text: '観', dx: 0 },
       { text: '察', dx: 15 }, // measure('観')=10 + 1·5
     ]);
+  });
+
+  it('adds letter-spacing × prefix-codepoint-count to each piece offset', () => {
+    // OOXML rPr @spc (§17.3.2.35 docx, §21.1.2.3.7 pptx) widens every code
+    // point's advance by `letterSpacingPx`, including the final one. A split
+    // piece's dx therefore needs `from · letterSpacingPx` on top of the prefix
+    // measure to land on the same x that `fillText(whole)` would draw it at.
+    const cps = [...'a.bc'];
+    const splitBefore = [1, 2, 3];
+    const perGap = 2;
+    const ls = 4;
+    const pieces = justifiedPiecePositions(cps, splitBefore, perGap, measure, ls);
+    expect(pieces.map((p) => p.text)).toEqual(['a', '.', 'b', 'c']);
+    // dx = measure(prefix) + from·ls + gapsSeen·perGap:
+    //   a: 0           + 0·4=0  + 0·2=0  = 0
+    //   .: measure('a')=10  + 1·4=4  + 1·2=2 = 16
+    //   b: measure('a.')=16 + 2·4=8  + 2·2=4 = 28
+    //   c: measure('a.b')=26 + 3·4=12 + 3·2=6 = 44
+    expect(pieces.map((p) => p.dx)).toEqual([0, 16, 28, 44]);
+  });
+
+  it('lands the final glyph exactly on the box including letter-spacing', () => {
+    // box = measure(whole) + cps.length·ls + nGaps·perGap, and the last piece's
+    // own advance also adds the trailing letter-spacing (rPr @spc is per glyph,
+    // including after the last). So the final piece's drawn end must equal
+    // measure(whole) + cps.length·ls + nGaps·perGap.
+    const cps = [...'a.bc'];
+    const splitBefore = [1, 2, 3];
+    const perGap = 2;
+    const ls = 4;
+    const pieces = justifiedPiecePositions(cps, splitBefore, perGap, measure, ls);
+    const last = pieces[pieces.length - 1];
+    const box = measure('a.bc') + cps.length * ls + splitBefore.length * perGap;
+    // Drawn end of the last piece: dx + measure(text) + text.length·ls.
+    const lastEnd = last.dx + measure(last.text) + [...last.text].length * ls;
+    expect(lastEnd).toBe(box); // 44 + 10 + 1·4 = 58, box = 36 + 16 + 6 = 58
   });
 });

--- a/packages/core/src/text/justify-positions.ts
+++ b/packages/core/src/text/justify-positions.ts
@@ -38,18 +38,22 @@ export interface JustifiedPiece {
  * The segment's code points are sliced at `splitBefore` (the same code-point
  * offsets the distribute kernel reported as internal gaps). Each resulting piece
  * is anchored to the whole-string cumulative advance up to its start — via
- * `measure` on the prefix — plus `perGap` for every gap that precedes it. This
- * keeps the drawn glyphs aligned with the segment's `measureText(whole)`-based
- * box (so the final glyph reaches `measure(whole) + splitBefore.length·perGap`
+ * `measure` on the prefix — plus `perGap` for every gap that precedes it, plus
+ * `letterSpacingPx` for every code point that precedes it. This keeps the drawn
+ * glyphs aligned with the segment's `measureText(whole) + ls·n`-based box (so
+ * the final glyph reaches `measure(whole) + ls·n + splitBefore.length·perGap`
  * and the next segment never overlaps), while honouring the contextual CJK
  * metrics baked into `measure`.
  *
- * @param cps        The segment's code points (e.g. `[...seg.text]`).
- * @param splitBefore Ascending code-point offsets (1..len-1) at which internal
- *                    gaps fall; from the distribute kernel.
- * @param perGap     px added at each gap.
- * @param measure    Contextual width of a string — `ctx.measureText(s).width`
- *                   with the segment's font already selected on `ctx`.
+ * @param cps             The segment's code points (e.g. `[...seg.text]`).
+ * @param splitBefore     Ascending code-point offsets (1..len-1) at which
+ *                        internal gaps fall; from the distribute kernel.
+ * @param perGap          px added at each gap.
+ * @param measure         Contextual width of a string — `ctx.measureText(s).width`
+ *                        with the segment's font already selected on `ctx`. Must
+ *                        NOT include letter-spacing (pass that via `letterSpacingPx`).
+ * @param letterSpacingPx px added after each code point's glyph advance
+ *                        (OOXML `rPr @spc` / `w:spacing` semantics). Default 0.
  * @returns One {@link JustifiedPiece} per slice, in draw order.
  */
 export function justifiedPiecePositions(
@@ -57,6 +61,7 @@ export function justifiedPiecePositions(
   splitBefore: readonly number[],
   perGap: number,
   measure: (s: string) => number,
+  letterSpacingPx: number = 0,
 ): JustifiedPiece[] {
   const pieces: JustifiedPiece[] = [];
   let from = 0;
@@ -66,7 +71,10 @@ export function justifiedPiecePositions(
     // NOT the running sum of isolated piece advances — see the module header.
     pieces.push({
       text: cps.slice(from, cut).join(''),
-      dx: measure(cps.slice(0, from).join('')) + gapsSeen * perGap,
+      dx:
+        measure(cps.slice(0, from).join('')) +
+        from * letterSpacingPx +
+        gapsSeen * perGap,
     });
     from = cut;
     gapsSeen++;
@@ -74,7 +82,10 @@ export function justifiedPiecePositions(
   // Final piece: no trailing gap of its own — gapsSeen is not incremented.
   pieces.push({
     text: cps.slice(from).join(''),
-    dx: measure(cps.slice(0, from).join('')) + gapsSeen * perGap,
+    dx:
+      measure(cps.slice(0, from).join('')) +
+      from * letterSpacingPx +
+      gapsSeen * perGap,
   });
   return pieces;
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2435,14 +2435,15 @@ function renderParagraph(
         // offsets and the pen advances `distPerGap` between pieces, so the pitch
         // appears BETWEEN the ideographs rather than bunched at the segment end.
         if (stretch && stretch.splitBefore.length > 0) {
-          // Inter-CJK justification pitch. Anchor each sliced piece to the
-          // WHOLE-string cumulative advance (so the contextual CJK metrics baked
-          // into measureText(whole) = measuredWidth — most visibly 約物半角, the
-          // half-width collapse of （「」。） — are honoured) plus the accumulated
-          // pitch, instead of summing the isolated pieces' advances. That sum
-          // drifts wider than the segment's box and would paint the next run over
-          // this segment's tail (most visible at a CJK→Latin boundary).
-          // See justify-draw.ts.
+          // ECMA-376 §17.18.44 `both`/`distribute` inter-CJK justification pitch.
+          // Anchor each sliced piece to the WHOLE-string cumulative advance (so
+          // the contextual CJK metrics baked into measureText(whole) =
+          // measuredWidth — most visibly 約物半角, the half-width collapse of
+          // （「」。） — are honoured) plus the accumulated pitch, instead of
+          // summing the isolated pieces' advances. That sum drifts wider than
+          // the segment's box and would paint the next run over this segment's
+          // tail (most visible at a CJK→Latin boundary).
+          // See `@silurus/ooxml-core` → text/justify-positions.ts.
           const cps = [...s.text]; // code points (handles surrogate pairs)
           const measure = (str: string): number => ctx.measureText(str).width;
           for (const { text: piece, dx } of justifiedPiecePositions(

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -69,7 +69,8 @@ import {
   type LineVisualOrder,
 } from './bidi-line';
 import { fitCjkLine, type MeasuredChar } from './cjk-wrap.js';
-import { justifyLine, type SplitAnchor } from './text-justify';
+import { justifyLine, type Justified } from './text-justify';
+import { justifiedPiecePositions } from '@silurus/ooxml-core';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -2325,8 +2326,7 @@ function renderTextBody(
     const drawSegs = justifyMode && !paraNeedsBidi && !hasTabStop
       ? justifyLine(line.segments, textMaxW - textXOffset, lineWidth, justifyMode, isLastLine)
       : null;
-    const segs: (LayoutSegment & { jext?: number } & Partial<SplitAnchor>)[] =
-      drawSegs ?? line.segments;
+    const segs: (LayoutSegment & Partial<Justified>)[] = drawSegs ?? line.segments;
 
     // Visual draw order: under bidi, reorder segments per UAX#9 (rule L2) and
     // draw each with ctx.direction matching its resolved direction. textAlign
@@ -2335,9 +2335,6 @@ function renderTextBody(
       ? computeLineVisualOrder(line.segments, baseRtl)
       : null;
     const segCount = segs.length;
-    // Tracks the pen position at the start of the current split segment's first
-    // piece. Used by the anchored-positioning path below to absorb 約物半角 drift.
-    let segOriginX = penX;
     for (let vi = 0; vi < segCount; vi++) {
       const li = visual ? visual.order[vi] : vi;
       const seg = segs[li];
@@ -2349,26 +2346,10 @@ function renderTextBody(
       // the widened gap instead of leaving a hole. The last content piece always
       // has jext 0 (justifyLine never stretches after the final glyph).
       const jext = seg.jext ?? 0;
-
-      // ── Anchored positioning for split CJK segments ───────────────────────
-      // When `justifyLine` splits a segment at inter-CJK gaps, punctuation at
-      // the start of a piece loses its contextual 約物半角 half-width in an
-      // isolated `measureText`, so Σ measure(piece) > measure(whole). We anchor
-      // each piece to `segOriginX + measureText(prefix) + gapsSeen·perGap` to
-      // reproduce the whole-string metrics and avoid drift past `availWidth`.
-      // See `packages/core/src/text/justify-draw.ts` for the invariant proof.
-      const origText = seg._origText;
-      let effectivePenX = penX;
-      if (origText !== undefined) {
-        if (seg._from === 0) segOriginX = penX; // first piece of this segment
-        const ls0 = seg.letterSpacingPx ?? 0;
-        const prefix = [...origText].slice(0, seg._from).join('');
-        effectivePenX =
-          segOriginX +
-          ctx.measureText(prefix).width +
-          (ls0 > 0 ? ls0 * (seg._from ?? 0) : 0) +
-          (seg._gapsSeen ?? 0) * (seg._perGap ?? 0);
-      }
+      const splitBefore = seg.splitBefore;
+      const segPerGap = seg.perGap ?? 0;
+      const internalStretch =
+        splitBefore && splitBefore.length > 0 ? splitBefore.length * segPerGap : 0;
 
       // ── Equation segment: draw the cached image instead of text ──────────
       if (seg.math) {
@@ -2392,12 +2373,14 @@ function renderTextBody(
       const ls = seg.letterSpacingPx ?? 0;
 
       // Run-level text highlight (rPr > a:highlight, ECMA-376 §21.1.2.3.4).
-      // Box advance = glyph measure + letter spacing + justification stretch.
+      // Box advance = glyph measure + letter spacing + justification stretch
+      // (internal CJK pitch + trailing `jext`).
       if (seg.highlight && seg.text) {
         const hlW = ctx.measureText(seg.text).width
           + (ls > 0 ? ls * seg.text.length : 0)
-          + (seg.jext ?? 0);
-        paintHighlight(ctx, effectivePenX, segBaseline, hlW, seg.sizePx, seg.highlight, seg.color);
+          + internalStretch
+          + jext;
+        paintHighlight(ctx, penX, segBaseline, hlW, seg.sizePx, seg.highlight, seg.color);
       }
 
       // Run-level text shadow (rPr > effectLst > outerShdw). Set on the
@@ -2416,26 +2399,48 @@ function renderTextBody(
         ctx.shadowOffsetY = Math.sin(dirRad) * dist;
       }
 
-      if (ls > 0 && seg.text.length > 1 && !segRtl) {
-        // Draw glyph-by-glyph so each character advance is `measure + ls`.
-        // Matches OOXML rPr @spc semantics — extra space added to each
-        // character's advance, including after the last one.
-        let cx = effectivePenX;
-        for (const ch of seg.text) {
-          ctx.fillText(ch, cx, segBaseline);
-          cx += ctx.measureText(ch).width + ls;
+      // Draw `text` at `atX` honouring this segment's letter-spacing / RTL
+      // semantics. Lifted into a closure so the fill and stroke (outline) paths
+      // share it, and so the split-CJK branch below can call it per piece.
+      const drawWithFont = (text: string, atX: number, op: 'fill' | 'stroke'): void => {
+        const paint = op === 'fill' ? ctx.fillText.bind(ctx) : ctx.strokeText.bind(ctx);
+        if (ls > 0 && text.length > 1 && !segRtl) {
+          // Draw glyph-by-glyph so each character advance is `measure + ls`.
+          // Matches OOXML rPr @spc semantics — extra space added to each
+          // character's advance, including after the last one.
+          let cx = atX;
+          for (const ch of text) {
+            paint(ch, cx, segBaseline);
+            cx += ctx.measureText(ch).width + ls;
+          }
+        } else if (ls > 0 && text.length > 1) {
+          // RTL segment with rPr @spc: per-glyph advance would break Arabic
+          // cursive joining, so distribute the spacing via canvas letterSpacing
+          // and draw the whole shaped text in one paint call.
+          const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+          try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
+          paint(text, atX, segBaseline);
+          try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
+        } else {
+          paint(text, atX, segBaseline);
         }
-      } else if (ls > 0 && seg.text.length > 1) {
-        // RTL segment with rPr @spc: per-glyph advance would break Arabic
-        // cursive joining, so distribute the spacing via canvas letterSpacing
-        // and draw the whole shaped segment in one fillText. The painted width
-        // then matches the segW advance below (baseW + ls per character).
-        const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
-        try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
-        ctx.fillText(seg.text, effectivePenX, segBaseline);
-        try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
+      };
+
+      // `splitBefore` is set when justifyLine annotated this segment with
+      // internal CJK gaps. Anchor each piece to the whole-string prefix advance
+      // (via core's `justifiedPiecePositions`) to absorb 約物半角 drift — see
+      // packages/core/src/text/justify-positions.ts for the invariant proof.
+      const measureCb = (s: string): number => ctx.measureText(s).width;
+      const pieces =
+        splitBefore && splitBefore.length > 0
+          ? justifiedPiecePositions([...seg.text], splitBefore, segPerGap, measureCb, ls)
+          : null;
+      if (pieces) {
+        for (const { text: pieceText, dx } of pieces) {
+          drawWithFont(pieceText, penX + dx, 'fill');
+        }
       } else {
-        ctx.fillText(seg.text, effectivePenX, segBaseline);
+        drawWithFont(seg.text, penX, 'fill');
       }
 
       if (segShadow) ctx.restore();
@@ -2452,31 +2457,24 @@ function renderTextBody(
         ctx.lineWidth = Math.max(0.5, emuToPx(segOutline.width, scale));
         ctx.strokeStyle = segOutline.color ? `#${segOutline.color}` : seg.color;
         ctx.lineJoin = 'round';
-        if (ls > 0 && seg.text.length > 1 && !segRtl) {
-          let cx = effectivePenX;
-          for (const ch of seg.text) {
-            ctx.strokeText(ch, cx, segBaseline);
-            cx += ctx.measureText(ch).width + ls;
+        if (pieces) {
+          for (const { text: pieceText, dx } of pieces) {
+            drawWithFont(pieceText, penX + dx, 'stroke');
           }
-        } else if (ls > 0 && seg.text.length > 1) {
-          const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
-          try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
-          ctx.strokeText(seg.text, effectivePenX, segBaseline);
-          try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
         } else {
-          ctx.strokeText(seg.text, effectivePenX, segBaseline);
+          drawWithFont(seg.text, penX, 'stroke');
         }
         ctx.restore();
       }
 
       ctx.font = seg.font;
       const baseW = ctx.measureText(seg.text).width;
-      const segW = baseW + (ls > 0 ? ls * seg.text.length : 0);
+      const segW = baseW + (ls > 0 ? ls * seg.text.length : 0) + internalStretch;
 
       if (onTextRun && seg.text) {
         onTextRun({
           text: seg.text,
-          inShapeX: effectivePenX - bx,
+          inShapeX: penX - bx,
           inShapeY: cursorY - by,
           w: segW + jext,
           h: lineHeight,
@@ -2491,7 +2489,7 @@ function renderTextBody(
       }
 
       if (seg.underline) {
-        drawUnderline(ctx, effectivePenX, segBaseline, segW + jext, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle);
+        drawUnderline(ctx, penX, segBaseline, segW + jext, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle);
       }
 
       if (seg.strikethrough) {
@@ -2506,32 +2504,21 @@ function renderTextBody(
           const offset = lineW * 0.9;
           const yMid = segBaseline - seg.sizePx * 0.32;
           ctx.beginPath();
-          ctx.moveTo(effectivePenX, yMid - offset);
-          ctx.lineTo(effectivePenX + segW + jext, yMid - offset);
-          ctx.moveTo(effectivePenX, yMid + offset);
-          ctx.lineTo(effectivePenX + segW + jext, yMid + offset);
+          ctx.moveTo(penX, yMid - offset);
+          ctx.lineTo(penX + segW + jext, yMid - offset);
+          ctx.moveTo(penX, yMid + offset);
+          ctx.lineTo(penX + segW + jext, yMid + offset);
           ctx.stroke();
         } else {
           ctx.beginPath();
-          ctx.moveTo(effectivePenX, segBaseline - seg.sizePx * 0.32);
-          ctx.lineTo(effectivePenX + segW + jext, segBaseline - seg.sizePx * 0.32);
+          ctx.moveTo(penX, segBaseline - seg.sizePx * 0.32);
+          ctx.lineTo(penX + segW + jext, segBaseline - seg.sizePx * 0.32);
           ctx.stroke();
         }
       }
 
-      if (origText !== undefined) {
-        // Split segment: advance penX only at the last piece, using the whole
-        // original segment's measure to absorb 約物半角 drift.
-        if (seg._isLastInSeg) {
-          const origCps = [...origText];
-          const wholeW = ctx.measureText(origText).width + (ls > 0 ? ls * origCps.length : 0);
-          penX = segOriginX + wholeW + (seg._gapsSeen ?? 0) * (seg._perGap ?? 0) + jext;
-        }
-        // Non-final pieces: penX stays at segOriginX until the last piece sets it.
-      } else {
-        penX += segW;
-        penX += jext;
-      }
+      penX += segW;
+      penX += jext;
     }
     if (paraNeedsBidi) ctx.direction = 'ltr'; // reset before tab-stop / next line
 

--- a/packages/pptx/src/text-justify.test.ts
+++ b/packages/pptx/src/text-justify.test.ts
@@ -5,9 +5,20 @@ import { justifyLine } from './text-justify.js';
 // feed whole strings (not pre-split tokens) — that is the real input shape.
 type Seg = { text?: string; tag?: string };
 
-// Collapse pieces to [text, roundedJext] tuples for compact assertions.
-const pieces = (r: ReturnType<typeof justifyLine<Seg>>) =>
-  r === null ? null : r.map((p) => [p.text, +p.jext.toFixed(3)] as const);
+/**
+ * Collapse each justified segment to a compact tuple for assertions:
+ * `[text, jext, splitBefore?, perGap?]`. splitBefore and perGap are only
+ * included when the segment has internal CJK gaps.
+ */
+const annot = (r: ReturnType<typeof justifyLine<Seg>>) =>
+  r === null
+    ? null
+    : r.map((s) => {
+        const j = +s.jext.toFixed(3);
+        return s.splitBefore && s.splitBefore.length > 0
+          ? ([s.text, j, s.splitBefore, +(s.perGap ?? 0).toFixed(3)] as const)
+          : ([s.text, j] as const);
+      });
 
 describe('justifyLine', () => {
   it("returns null for 'just' on the last line (short sentences stay natural)", () => {
@@ -15,60 +26,45 @@ describe('justifyLine', () => {
   });
 
   it("'dist' justifies even the last line", () => {
+    // 3 CJK glyphs → 2 internal gaps in this single segment; slack 60 → perGap 30.
     const r = justifyLine<Seg>([{ text: '日本語' }], 120, 60, 'dist', true);
-    expect(pieces(r)).toEqual([
-      ['日', 30],
-      ['本', 30],
-      ['語', 0],
-    ]);
+    expect(annot(r)).toEqual([['日本語', 0, [1, 2], 30]]);
   });
 
-  it('pure Latin: widens each inter-word space, splitting after the spaces', () => {
+  it('pure Latin: widens inter-word spaces (kernel splits before the space-following word)', () => {
+    // "Hello world foo": gaps fall before 'w' (code-point 6) and before 'f' (12).
+    // slack 100, 2 gaps → perGap 50, no trailing gap.
     const r = justifyLine<Seg>([{ text: 'Hello world foo' }], 200, 100, 'just', false);
-    expect(pieces(r)).toEqual([
-      ['Hello ', 50],
-      ['world ', 50],
-      ['foo', 0],
-    ]);
+    expect(annot(r)).toEqual([['Hello world foo', 0, [6, 12], 50]]);
   });
 
   it('pure CJK: widens every inter-character gap except after the final glyph', () => {
     const r = justifyLine<Seg>([{ text: '日本語' }], 120, 60, 'just', false);
-    expect(pieces(r)).toEqual([
-      ['日', 30],
-      ['本', 30],
-      ['語', 0],
-    ]);
+    expect(annot(r)).toEqual([['日本語', 0, [1, 2], 30]]);
   });
 
   it('mixed EC市場で: no gap inside the Latin "EC", gaps at C|市, 市|場, 場|で', () => {
+    // 5 code points, 3 gaps inside (after positions 2, 3, 4). slack 30 → perGap 10.
     const r = justifyLine<Seg>([{ text: 'EC市場で' }], 130, 100, 'just', false);
-    expect(pieces(r)).toEqual([
-      ['EC', 10],
-      ['市', 10],
-      ['場', 10],
-      ['で', 0],
-    ]);
+    expect(annot(r)).toEqual([['EC市場で', 0, [2, 3, 4], 10]]);
   });
 
   it('leading 字下げ whitespace stays fixed (no stretch before first content)', () => {
+    // "  日本語": gap after first content boundary (before code-point 3 = 本) and (before 4 = 語).
+    // The leading "  " contributes no gap. slack 30 → perGap 15.
     const r = justifyLine<Seg>([{ text: '  日本語' }], 130, 100, 'just', false);
-    expect(pieces(r)).toEqual([
-      ['  日', 15],
-      ['本', 15],
-      ['語', 0],
-    ]);
+    expect(annot(r)).toEqual([['  日本語', 0, [3, 4], 15]]);
   });
 
   it('trailing whitespace at line end does not stretch', () => {
+    // "日本 ": one gap before 本 (cp 1). slack 40 → perGap 40, no trailing.
     const r = justifyLine<Seg>([{ text: '日本 ' }], 100, 60, 'just', false);
-    expect(pieces(r)).toEqual([
-      ['日', 40],
-      ['本 ', 0],
-    ]);
+    expect(annot(r)).toEqual([['日本 ', 0, [1], 40]]);
   });
 
   it('evaluates CJK boundaries across a style (segment) boundary', () => {
+    // [日本][語]: gaps after 日 (inside seg 1) and after 本 (between seg 1 and seg 2 → trailing).
+    // slack 60, 2 gaps → perGap 30.
     const r = justifyLine<Seg>(
       [
         { text: '日本', tag: 'a' },
@@ -80,10 +76,9 @@ describe('justifyLine', () => {
       false,
     );
     expect(r).not.toBeNull();
-    expect(r!.map((p) => [p.text, +p.jext.toFixed(3), p.tag])).toEqual([
-      ['日', 30, 'a'],
-      ['本', 30, 'a'],
-      ['語', 0, 'b'],
+    expect(r!.map((s) => [s.text, +s.jext.toFixed(3), s.splitBefore ?? null, s.tag])).toEqual([
+      ['日本', 30, [1], 'a'],
+      ['語', 0, null, 'b'],
     ]);
   });
 
@@ -92,8 +87,7 @@ describe('justifyLine', () => {
     // after the last glyph — INCLUDING 語|学, which lives inside the final
     // segment. Only the final glyph's gap is suppressed (the content-span trim),
     // not the whole final segment. Pins that the adapter excludes no segment by
-    // index (lastDrawnSi sentinel = segments.length), so the second run is still
-    // split at 語|学; a `length-1` exclusion would wrongly leave 語学 unsplit.
+    // index (lastDrawnSi sentinel = segments.length).
     const r = justifyLine<Seg>(
       [
         { text: '日本', tag: 'a' },
@@ -105,19 +99,17 @@ describe('justifyLine', () => {
       false,
     );
     expect(r).not.toBeNull();
-    expect(r!.map((p) => [p.text, +p.jext.toFixed(3), p.tag])).toEqual([
-      ['日', 30, 'a'],
-      ['本', 30, 'a'],
-      ['語', 30, 'b'],
-      ['学', 0, 'b'],
+    expect(r!.map((s) => [s.text, +s.jext.toFixed(3), s.splitBefore ?? null, s.tag])).toEqual([
+      ['日本', 30, [1], 'a'],
+      ['語学', 0, [1], 'b'],
     ]);
   });
 
   it('an inline object (text===undefined) is one unit and can take a gap', () => {
-    const r = justifyLine<Seg>([{ text: '日' }, {}, { text: '本' }], 100, 60, 'just', false);
     // gaps after 日 and after the object → perGap = 40/2 = 20
+    const r = justifyLine<Seg>([{ text: '日' }, {}, { text: '本' }], 100, 60, 'just', false);
     expect(r).not.toBeNull();
-    expect(r!.map((p) => [p.text, +p.jext.toFixed(3)])).toEqual([
+    expect(r!.map((s) => [s.text, +s.jext.toFixed(3)])).toEqual([
       ['日', 20],
       [undefined, 20],
       ['本', 0],
@@ -125,14 +117,6 @@ describe('justifyLine', () => {
   });
 
   it('emits an empty-text segment (inline OMML equation) so it is still drawn', () => {
-    // In pptx an inline equation is a segment with text==='' (plus a `math`
-    // field), NOT text===undefined. The pre-extraction justifyLine accumulated
-    // glyphs into a buffer and pushed only NON-empty buffers, so it silently
-    // DROPPED the equation from a justified line (not drawn, pen not advanced →
-    // trailing text overlapped the gap). The shared-kernel adapter emits every
-    // text-bearing segment, so the equation survives with jext 0 and all fields
-    // (here `tag`, in production `math`) preserved; the gap distribution among
-    // the real glyphs is unchanged (the empty segment contributes no units).
     const r = justifyLine<Seg>(
       [
         { text: '日', tag: 'a' },
@@ -145,16 +129,20 @@ describe('justifyLine', () => {
       false,
     );
     expect(r).not.toBeNull();
-    expect(r!.map((p) => [p.text, +p.jext.toFixed(3), p.tag])).toEqual([
+    expect(r!.map((s) => [s.text, +s.jext.toFixed(3), s.tag])).toEqual([
       ['日', 60, 'a'],
       ['', 0, 'math'],
       ['本', 0, 'b'],
     ]);
   });
 
-  it('the jext advances sum to the slack (line reaches availWidth)', () => {
+  it('Σ jext + Σ (perGap × splits) equals slack (line reaches availWidth)', () => {
     const r = justifyLine<Seg>([{ text: 'Hello world foo bar' }], 300, 120, 'just', false);
-    const sum = r!.reduce((a, p) => a + p.jext, 0);
+    expect(r).not.toBeNull();
+    const sum = r!.reduce((acc, s) => {
+      const internal = s.splitBefore && s.perGap ? s.splitBefore.length * s.perGap : 0;
+      return acc + s.jext + internal;
+    }, 0);
     expect(sum).toBeCloseTo(180, 6);
   });
 
@@ -170,34 +158,23 @@ describe('justifyLine', () => {
     expect(justifyLine<Seg>([{ text: '日' }], 200, 20, 'just', false)).toBeNull();
   });
 
-  it('preserves all style fields on every split piece', () => {
+  it('preserves all style fields on every annotated segment', () => {
     const r = justifyLine<Seg>([{ text: '日本語', tag: 'x' }], 120, 60, 'just', false);
-    expect(r!.every((p) => p.tag === 'x')).toBe(true);
+    expect(r!.every((s) => s.tag === 'x')).toBe(true);
   });
 
-  // Regression for the CJK-range dedup (isCjkBreakChar now includes U+3000).
+  // Regression for the CJK-range dedup (isCjkBreakChar includes U+3000).
   // U+3000 (ideographic space) is whitespace per /\s/, so it is stretched as a
-  // single inter-word gap and never reaches the CJK predicate. Including U+3000
-  // in the shared predicate must NOT add a second (inter-CJK) gap around it: the
-  // 日→U+3000 boundary takes the boundary-into-whitespace path and contributes
-  // no gap of its own. Output stays exactly one gap on the space.
+  // single inter-word gap and never reaches the CJK predicate.
   it('U+3000 stretches as one inter-word gap, not double-counted as a CJK gap', () => {
+    // "日　本": one gap before code-point 2 (本). slack 60 → perGap 60.
     const r = justifyLine<Seg>([{ text: '日　本' }], 120, 60, 'just', false);
-    expect(pieces(r)).toEqual([
-      ['日　', 60],
-      ['本', 0],
-    ]);
+    expect(annot(r)).toEqual([['日　本', 0, [2], 60]]);
   });
 
   it('U+3000 between CJK glyphs: single stretch point even with neighbours', () => {
-    // 日 本 で  → units: 日, U+3000, 本, で. Only two gaps: the U+3000 space and
-    // the 本|で inter-CJK boundary (the 日|U+3000 boundary adds none). slack 80,
-    // 2 gaps → perGap 40.
+    // 日　本で: 4 code points, gaps before 本 (cp 2) and before で (cp 3). slack 80 → perGap 40.
     const r = justifyLine<Seg>([{ text: '日　本で' }], 140, 60, 'just', false);
-    expect(pieces(r)).toEqual([
-      ['日　', 40],
-      ['本', 40],
-      ['で', 0],
-    ]);
+    expect(annot(r)).toEqual([['日　本で', 0, [2, 3], 40]]);
   });
 });

--- a/packages/pptx/src/text-justify.ts
+++ b/packages/pptx/src/text-justify.ts
@@ -27,7 +27,7 @@
 // pptx adapter: it owns the DrawingML last-line policy and the slack threshold,
 // injects PowerPoint's whitespace predicate (every JS `\s` char is an inter-word
 // space — wider than Word's U+0020/U+3000 set), and re-expresses the kernel's
-// per-segment result as the renderer's draw pieces.
+// per-segment result as stretch annotations the renderer applies in place.
 //
 // Why character-level, not segment-level: the layout merges adjacent
 // same-style tokens into ONE segment (see layoutParagraph's `push`/`sameMeta`),
@@ -37,20 +37,17 @@
 // in the line's character stream (boundaries are evaluated across segment
 // edges too, so a colour change mid-word doesn't suppress a gap).
 //
-// `justifyLine` returns the line re-expressed as draw pieces: each input
-// segment is split at the gap positions, and every piece carries `jext`, the
-// px to advance AFTER drawing it. The sum of all `jext` equals the slack, so
-// the painted line reaches `availWidth`.
-//
-// IMPORTANT — measurement drift at split boundaries: splitting at an inter-CJK
-// gap can place punctuation (。、）etc.) at the START of a new piece. Measured in
-// isolation that character loses its contextual half-width collapse (約物半角),
-// so `Σ measureText(piece)` runs WIDER than `measureText(whole_segment)`. The
-// renderer therefore uses `justifiedPiecePositions` (from `@silurus/ooxml-core`)
-// for split segments, anchoring each piece to the whole-string prefix advance to
-// avoid the drift that would otherwise push subsequent content past `availWidth`.
-// Split pieces carry `_origText`, `_from`, `_gapsSeen`, `_perGap`, and
-// `_isLastInSeg` to support this anchoring.
+// `justifyLine` annotates each input segment with `jext` (px to advance AFTER
+// the segment when its trailing boundary is a gap) and, when the segment has
+// internal gaps, `splitBefore` (code-point offsets) + `perGap` (px). The
+// renderer draws each segment in place: if `splitBefore` is empty it does one
+// `fillText(seg.text)` and advances by `measureText(seg.text) + jext`; if not,
+// it uses `justifiedPiecePositions` (from `@silurus/ooxml-core`) to anchor each
+// piece to the whole-string prefix advance — required to avoid 約物半角
+// measurement drift, where `Σ measureText(piece)` would exceed
+// `measureText(seg.text)` because isolated punctuation loses its contextual
+// half-width collapse. The sum of all `jext` plus all `perGap × splits` equals
+// the slack, so the painted line reaches `availWidth`.
 
 import { distributeLineSlack, isCjkBreakChar, type DistributeSeg } from '@silurus/ooxml-core';
 
@@ -59,28 +56,27 @@ import { distributeLineSlack, isCjkBreakChar, type DistributeSeg } from '@siluru
  *  source. Only the optional `text` matters; an undefined `text` marks an inline
  *  object that bears no stretch of its own (a CJK neighbour can still open a gap
  *  against it). The generic `T` lets the renderer pass its full LayoutSeg and
- *  get pieces that keep every style field, plus `jext`. */
+ *  get the segment back with `jext` (and optionally `splitBefore`/`perGap`). */
 export type JustifySeg = DistributeSeg;
 
 export type JustifyMode = 'just' | 'dist';
 
-/**
- * Metadata attached to pieces that came from splitting a CJK segment. The
- * renderer uses these to anchor each piece to the whole-string prefix advance
- * (via `justifiedPiecePositions`) instead of summing isolated piece advances,
- * which would lose the contextual 約物半角 collapse and drift past `availWidth`.
- */
-export type SplitAnchor = {
-  /** The original segment's full text (code points joined). */
-  _origText: string;
-  /** Code-point index in `_origText` where this piece starts. */
-  _from: number;
-  /** Number of gap positions before this piece within this segment. */
-  _gapsSeen: number;
-  /** px per gap for this segment (= `jext` of non-final pieces). */
-  _perGap: number;
-  /** True for the last piece of the segment; false for all preceding pieces. */
-  _isLastInSeg: boolean;
+/** Justification annotation added to each segment of a line. The renderer reads
+ *  these to widen the segment's contribution to the line: `jext` advances the
+ *  pen AFTER the segment is drawn; `splitBefore` (when present and non-empty)
+ *  marks internal CJK gaps at which `perGap` px should be inserted within the
+ *  segment's drawn glyphs. */
+export type Justified = {
+  /** px to advance after drawing this segment (0 when its trailing boundary is
+   *  not a gap). */
+  jext: number;
+  /** Ascending code-point offsets at which internal gaps fall inside the
+   *  segment's text. Empty / undefined for inline objects and for segments with
+   *  no interior gaps. */
+  splitBefore?: number[];
+  /** px to insert at each gap inside the segment. Set when `splitBefore` is
+   *  non-empty; undefined otherwise. */
+  perGap?: number;
 };
 
 /** PowerPoint counts EVERY JS-`\s` code point as an inter-word space (\t, \n, the
@@ -91,8 +87,8 @@ export type SplitAnchor = {
 const isWsCp = (cp: number): boolean => /\s/.test(String.fromCodePoint(cp));
 
 /**
- * Split one laid-out line into draw pieces that fill `availWidth` when each
- * piece's `jext` is added to the pen after it is drawn.
+ * Annotate one laid-out line's segments with the stretch (`jext`,
+ * `splitBefore`, `perGap`) needed to fill `availWidth`.
  *
  * @param segments    The line's segments in logical order (LTR only — the
  *                    renderer disables justification under bidi).
@@ -100,9 +96,9 @@ const isWsCp = (cp: number): boolean => /\s/.test(String.fromCodePoint(cp));
  * @param naturalWidth Sum of the segments' natural advance widths, px.
  * @param mode        'just' (last line stays natural) or 'dist' (every line).
  * @param isLastLine  Whether this is the paragraph's final line.
- * @returns The pieces (each a shallow copy of its source segment with sliced
- *          `text` and a `jext` advance), or `null` when no justification
- *          applies (last line under `just`, no slack, no stretchable gap, …).
+ * @returns The same segments (shallow copies) with `jext`/`splitBefore`/`perGap`
+ *          added, or `null` when no justification applies (last line under
+ *          `just`, no slack, no stretchable gap, …).
  */
 export function justifyLine<T extends JustifySeg>(
   segments: readonly T[],
@@ -110,7 +106,7 @@ export function justifyLine<T extends JustifySeg>(
   naturalWidth: number,
   mode: JustifyMode,
   isLastLine: boolean,
-): (T & { jext: number } & Partial<SplitAnchor>)[] | null {
+): (T & Justified)[] | null {
   // `just`/`justLow` leave the paragraph's last line natural.
   if (mode === 'just' && isLastLine) return null;
 
@@ -137,53 +133,20 @@ export function justifyLine<T extends JustifySeg>(
 
   const { perGap, perSeg } = dist;
 
-  // Re-express the per-segment stretch as the renderer's draw pieces. For each
-  // segment: an inline object is one piece (a trailing gap → jext = perGap);
-  // a text segment is sliced at the kernel's interior split offsets, each piece
-  // before a split advancing perGap, and the final piece advancing perGap iff
-  // the boundary AFTER the segment is a gap (trailingGap). Σ jext == slack,
-  // final glyph reaches availWidth.
-  //
-  // Split pieces additionally carry SplitAnchor metadata (_origText, _from,
-  // _gapsSeen, _perGap, _isLastInSeg) so the renderer can use anchored
-  // positioning to avoid the 約物半角 measurement drift described above.
-  const out: (T & { jext: number } & Partial<SplitAnchor>)[] = [];
+  // Annotate each segment in place: `jext` widens the trailing boundary;
+  // `splitBefore`/`perGap` describe the internal gaps. Σ jext + Σ (perGap ×
+  // splits) == slack, so the painted line reaches availWidth.
+  const out: (T & Justified)[] = [];
   for (let si = 0; si < segments.length; si++) {
     const seg = segments[si];
     const s = perSeg.get(si);
-    if (seg.text === undefined) {
-      out.push({ ...seg, jext: s?.trailingGap ? perGap : 0 });
-      continue;
+    const trailing = s?.trailingGap ? perGap : 0;
+    const splits = s?.splitBefore;
+    if (splits && splits.length > 0) {
+      out.push({ ...seg, jext: trailing, splitBefore: [...splits], perGap });
+    } else {
+      out.push({ ...seg, jext: trailing });
     }
-    const cps = [...seg.text]; // code points (handles surrogate pairs)
-    const splits = s?.splitBefore ?? [];
-    const nSplits = splits.length;
-    let from = 0;
-    let gapsSeen = 0;
-    for (const cut of splits) {
-      out.push({
-        ...seg,
-        text: cps.slice(from, cut).join(''),
-        jext: perGap,
-        _origText: seg.text,
-        _from: from,
-        _gapsSeen: gapsSeen,
-        _perGap: perGap,
-        _isLastInSeg: false,
-      });
-      from = cut;
-      gapsSeen++;
-    }
-    // Final piece of this segment: trailingGap → perGap, else 0.
-    const finalJext = s?.trailingGap ? perGap : 0;
-    out.push({
-      ...seg,
-      text: cps.slice(from).join(''),
-      jext: finalJext,
-      ...(nSplits > 0
-        ? { _origText: seg.text, _from: from, _gapsSeen: gapsSeen, _perGap: perGap, _isLastInSeg: true }
-        : {}),
-    });
   }
   return out;
 }


### PR DESCRIPTION
Address review findings on v0.64.1: pptx's CJK justify fix landed with a
parallel implementation path (5 underscore-prefixed `SplitAnchor` fields per
piece, segOriginX / effectivePenX bookkeeping in the renderer), so the core
helper promoted in #497 was effectively unused by pptx. This PR unifies both
formats around one shared helper.

## Changes

- `packages/core/src/text/justify-draw.ts` → `justify-positions.ts` (rename).
  The helper computes positions, not actual draws.
- `justifiedPiecePositions`: accept optional `letterSpacingPx` so callers no
  longer inline the `from · ls` correction. Now models the full OOXML rPr @spc
  semantics (§17.3.2.35 docx, §21.1.2.3.7 pptx).
- `packages/pptx/src/text-justify.ts`: drop `SplitAnchor` (5 fields per piece)
  in favour of a docx-style segment annotation — each segment carries `jext`,
  optional `splitBefore`, and `perGap`. `justifyLine` no longer expands pieces.
- `packages/pptx/src/renderer.ts`: remove `segOriginX`/`effectivePenX`. When
  `seg.splitBefore` is non-empty, call `justifiedPiecePositions` and draw each
  piece at `penX + dx`. Letter-spacing / RTL fill+stroke logic is hoisted into
  a small `drawWithFont` closure so fill and stroke share one body. penX
  advances by `measureText(whole) + ls·n + internalStretch + jext` regardless
  of split state — no special end-of-segment branch.
- `packages/docx/src/renderer.ts`: comment now cites ECMA-376 §17.18.44
  directly and points at the new core path.
- pptx `text-justify.test.ts` rewritten for the new annotation contract; core
  `justify-positions.test.ts` gains two letter-spacing cases that pin the
  `prefix · ls` correction.

## Verification

- 616/616 unit tests pass (vitest)
- docx VRT: 21/21 byte-identical to v0.64.1
- pptx VRT: 75/75 passing (match% within the ±1–2 px noise this machine adds
  to pptx text; not the expected-change axis for this refactor)

## Note

Pure refactor — no rendering behaviour change. Will be bundled into a future
release together with whatever else lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)