### PR TITLE
fix(site): homepage title + Try-page WASM hot-standby

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import '../styles/global.css';
-const { title = 'office-open-xml-viewer', description = 'Browser-based OOXML viewer (docx / xlsx / pptx) — Rust/WASM parser + Canvas renderer.' } = Astro.props;
+const { title = 'Office Open XML Viewer', description = 'Browser-based OOXML viewer (docx / xlsx / pptx) — Rust/WASM parser + Canvas renderer.' } = Astro.props;
 const base = import.meta.env.BASE_URL;
 ---
 <!doctype html>

--- a/site/src/lib/try.ts
+++ b/site/src/lib/try.ts
@@ -126,3 +126,41 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
   }
   return { format: 'docx', units: doc.pageCount, unitLabel: 'page' };
 }
+
+// Hot standby: warm each WASM engine (and the Google Fonts CSS) on an idle tick
+// so the user's first real file parses without paying the cold cost of fetching
+// + compiling the parser binaries. Each `renderFile` spawns a fresh inline
+// worker that re-fetches its `*_parser_bg.wasm`; pre-loading the bundled demo of
+// every format primes the browser's HTTP/code cache for that binary, then the
+// throwaway engines are released. Fire-and-forget, errors swallowed — a failed
+// warm-up just means the first real parse is as slow as before, never broken.
+let warmed = false;
+export function prewarmEngines(): void {
+  if (warmed || typeof window === 'undefined') return;
+  warmed = true;
+  // Respect Data Saver / metered connections — don't spend bandwidth warming.
+  const conn = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection;
+  if (conn?.saveData) return;
+
+  const base = import.meta.env.BASE_URL;
+  const sample = (f: string) => `${base}samples/${f}`.replace(/([^:])\/\/+/g, '$1/');
+
+  const run = (): void => {
+    void PptxPresentation.load(sample('sample-1.pptx'), { useGoogleFonts: true })
+      .then((d) => d.destroy())
+      .catch(() => {});
+    void DocxDocument.load(sample('sample-1.docx'), { useGoogleFonts: true })
+      .then((d) => d.destroy())
+      .catch(() => {});
+    // XlsxViewer needs a container; mount into a detached node never added to the
+    // DOM, then dispose. The parse + one render warms the xlsx WASM engine.
+    const host = document.createElement('div');
+    const v = new XlsxViewer(host, { useGoogleFonts: true });
+    void v.load(sample('sample-1.xlsx')).then(() => v.destroy()).catch(() => v.destroy());
+  };
+
+  const ric = (window as Window & { requestIdleCallback?: (cb: () => void, o?: { timeout: number }) => void })
+    .requestIdleCallback;
+  if (ric) ric(run, { timeout: 2500 });
+  else setTimeout(run, 600);
+}

--- a/site/src/pages/try.astro
+++ b/site/src/pages/try.astro
@@ -63,7 +63,10 @@ import Nav from '../components/Nav.astro';
   </footer>
 
   <script>
-    import { renderFile } from '../lib/try';
+    import { renderFile, prewarmEngines } from '../lib/try';
+    // Hot standby — prime the WASM engines + fonts on idle so the first dropped
+    // file renders without the cold parser-load cost.
+    prewarmEngines();
     const dz = document.getElementById('dropzone') as HTMLLabelElement;
     const input = document.getElementById('file') as HTMLInputElement;
     const status = document.getElementById('status') as HTMLElement;


### PR DESCRIPTION
Two small showcase-site (`site/`, Astro) tweaks.

## 1. Homepage browser-tab title
`Base.astro`'s default title was the repo slug `office-open-xml-viewer`, and the homepage passes no title so it used that verbatim. Set the default to the product name → the home tab and `og:title` now read **Office Open XML Viewer**. Other pages set their own titles (unaffected).

## 2. Try-page hot-standby (prewarm)
The Try page created each parser engine lazily on the first dropped file, so the first parse paid the cold cost of fetching + compiling the docx/xlsx/pptx WASM binaries (and Google Fonts). `prewarmEngines()` now runs on an idle tick: it loads the bundled `sample-1` demo of each format headlessly (XLSX into a detached node), then disposes the throwaway engines — priming the browser's HTTP/code cache so the user's first real file parses immediately. Fire-and-forget, Data-Saver-aware (`navigator.connection.saveData`), all errors swallowed (a failed warm-up is just as slow as before, never broken).

## Verification (browser preview, Astro dev)
- Homepage `<title>` and `og:title` = `Office Open XML Viewer`; Try-page title unchanged; homepage renders correctly.
- On `/try` idle: all three `*_parser_bg.wasm` binaries + the three `sample-1` demos fetched (200), zero console errors, zero failed requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)