### PR TITLE
chore(release): 0.64.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.64.2 — 2026-06-18
+
+Patch. PowerPoint text-rendering fidelity fixes — placeholder alignment now resolves through the slide master, letter spacing counts whole code points, and CJK justification shares the docx code path.
+
+- **pptx**: Placeholder paragraph alignment now inherits through the slide master's `<p:txStyles>` (`titleStyle`/`bodyStyle`/`otherStyle` `@algn`) and matches the layout placeholder by `idx`, so a master-defined alignment is no longer dropped to the `"l"` default nor overridden by an unrelated typeless placeholder's centering. Adds an idx-aware `lookup_alignment` and folds the master `txStyles` alignment into the inheritance chain (ECMA-376 §19.3.1.36 idx matching; §19.3.1.52 → §19.3.1.49/.5/.35). (PR #501)
+- **pptx**: Letter spacing (`spc`) is applied per Unicode code point instead of per UTF-16 code unit, so runs containing astral characters (emoji, rare CJK) are spaced correctly. (PR #500)
+- **pptx / core**: pptx CJK justification (`just`/`dist`, §20.1.10.59) now runs through the same shared `@silurus/ooxml-core` helper as docx, eliminating the last divergent justify path. (PR #499)
+- **site**: The showcase "Try yours" page prewarms the docx/xlsx/pptx WASM engines on an idle tick for a faster first parse, and the homepage browser-tab title now reads "Office Open XML Viewer". (PR #502)
+
 ## 0.64.1 — 2026-06-18
 
 Patch. Fixes glyph overlap on justified CJK lines containing punctuation adjacent to Latin text in both docx and pptx.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.64.2 (patch) — PowerPoint text-rendering fidelity fixes + showcase-site tweaks.

## Included (since v0.64.1)
- **pptx** — placeholder paragraph alignment resolves through the slide master `<p:txStyles>` and matches the layout placeholder by `idx`; closes a cross-placeholder centering leak ([#501](https://github.com/yukiyokotani/office-open-xml-viewer/pull/501)).
- **pptx** — letter spacing counted per Unicode code point, not UTF-16 code unit ([#500](https://github.com/yukiyokotani/office-open-xml-viewer/pull/500)).
- **pptx / core** — pptx CJK justification unified onto the shared docx code path ([#499](https://github.com/yukiyokotani/office-open-xml-viewer/pull/499)).
- **site** — Try-page WASM hot-standby (prewarm) + homepage tab title ([#502](https://github.com/yukiyokotani/office-open-xml-viewer/pull/502)).

## Release chores
- CHANGELOG: 0.64.2 section added.
- All 8 package versions bumped 0.64.1 → 0.64.2.
- Feature Support table / API reference: unchanged (accuracy fixes only, no new format feature or public API change).
- README screenshots: verified unchanged — `demo/sample-1` renders identically (VRT 99.7%) and the hero samples contain no CJK/astral content affected by these fixes, so `docs/images` are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)