### PR TITLE
chore(release): 0.64.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.64.3 — 2026-06-21
+
+Patch. Crisp 1-px rendering of Excel grid/border lines at devicePixelRatio = 1, header/data alignment, and toned-down homepage copy.
+
+- **xlsx**: Cell borders now render as a crisp single device row at `devicePixelRatio = 1` instead of an anti-aliased ~2-px band. A thin (1-logical-px) stroke drawn on an integer cell edge straddled two device rows at 50% coverage each; an odd-device-width stroke is now nudged half a device pixel onto a pixel midpoint, while even device widths (e.g. a thin border at dpr=2) are left untouched. Border widths stay in logical px — the orchestrator's `ctx.scale(dpr,dpr)` maps them to device px (ECMA-376 §18.18.3 ST_BorderStyle).
+- **xlsx**: Row- and column-header separators now land on the exact device pixel of the matching data-grid line (they previously sat one device pixel to the left / above at dpr=1), and the freeze-pane divider lines use a device-correct half-pixel offset (they used a hardcoded logical `+0.5` that blurred at `dpr > 1`). The odd-device-width crisp offset is factored into a shared `crispOffset` helper.
+- **site**: Toned down the homepage hero — replaced the "most faithful … on the web" / "pixel-faithful" superlatives with an accurate description and added a brief coverage caveat.
+
 ## 0.64.2 — 2026-06-18
 
 Patch. PowerPoint text-rendering fidelity fixes — placeholder alignment now resolves through the slide master, letter spacing counts whole code points, and CJK justification shares the docx code path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/src/xlsx-border-crisp.probe.test.ts
+++ b/packages/node/src/xlsx-border-crisp.probe.test.ts
@@ -31,7 +31,6 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { parseXlsx, parseSheet } from './xlsx.ts';
 import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
 import type { NodeCanvasFactory } from './render.ts';
 import type {
@@ -45,6 +44,12 @@ import type {
 const skia = await import('skia-canvas').catch(() => null);
 type Skia = typeof import('skia-canvas');
 const { Canvas } = (skia ?? {}) as Skia;
+
+// xlsx.ts statically imports the gitignored WASM glue (xlsx_parser.js). In CI
+// `pnpm test` runs BEFORE `pnpm build:wasm`, so a static import here would fail
+// at collection; load it dynamically and skip when absent — same gate as skia
+// (see source-buffer-image.test.ts).
+const xlsxMod = await import('./xlsx.ts').catch(() => null);
 
 const factory: NodeCanvasFactory = {
   createCanvas: (w, h) =>
@@ -82,6 +87,8 @@ function lum(r: number, g: number, b: number): number {
  *  pure-black BOTTOM border, returning the mutated Worksheet + Styles. The new
  *  border / cellXf are appended (existing indices untouched). */
 function buildInjected(): { ws: Worksheet; styles: Styles } {
+  if (!xlsxMod) throw new Error('xlsx WASM unavailable (run pnpm build:wasm)');
+  const { parseXlsx, parseSheet } = xlsxMod;
   const buf = readFileSync(SAMPLE);
   const parsed = parseXlsx(buf);
   const ws = parseSheet(buf, 0, parsed.workbook.sheets[0].name) as Worksheet;
@@ -307,7 +314,7 @@ function savePng(canvas: InstanceType<typeof Canvas>, outPath: string): void {
   if (png) writeFileSync(outPath, png);
 }
 
-describe.skipIf(!skia)('xlsx border crispness (device-pixel probe)', () => {
+describe.skipIf(!skia || !xlsxMod)('xlsx border crispness (device-pixel probe)', () => {
   it('injected thin black horizontal border at dpr=1 collapses to one near-black device row', async () => {
     const { data, w, h, canvas } = await renderInjected(1);
 

--- a/packages/node/src/xlsx-border-crisp.probe.test.ts
+++ b/packages/node/src/xlsx-border-crisp.probe.test.ts
@@ -20,10 +20,9 @@
  * bottom edge. Pure black (RGB all 0) is unambiguous against the green fill
  * (RGB 27/67/50) and the #d0d0d0 gridline.
  *
- * before/after numbers are produced by an external shell wrapper that swaps the
- * worktree's renderer.ts (pre-fix vs fixed) and points RENDERER_ORCH at the
- * worktree orchestrator. This committed test asserts the AFTER (fixed) state so
- * it is meaningful in CI when skia is present, and skips cleanly when it is not.
+ * This committed test asserts the FIXED state (crisp single near-black device row
+ * at dpr=1; clean 2-device-row band at dpr=2). It fails against the pre-fix
+ * renderer, so it is a genuine regression guard — not a tautology.
  *
  * CI-safe: skia-canvas ships a native binding CI omits, so the suite is gated
  * with `describe.skipIf(!skia)` exactly like render.test.ts.
@@ -32,7 +31,6 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { tmpdir } from 'node:os';
 import { parseXlsx, parseSheet } from './xlsx.ts';
 import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
 import type { NodeCanvasFactory } from './render.ts';
@@ -57,22 +55,13 @@ const factory: NodeCanvasFactory = {
 };
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-// MAIN checkout root (this file lives at <root>/packages/node/src/).
-const MAIN_ROOT = resolve(HERE, '../../..');
-// The render-orchestrator under test. RENDERER_ORCH env overrides the path so a
-// shell wrapper can point this at the WORKTREE's orchestrator (which imports the
-// fixed — or, when swapped, pre-fix — renderer via its relative `./renderer.js`).
-// When unset, defaults to the MAIN checkout's own orchestrator so the committed
-// test runs standalone in CI.
-const ORCH_PATH =
-  process.env.RENDERER_ORCH ??
-  resolve(MAIN_ROOT, 'packages/xlsx/src/render-orchestrator.ts');
-
-const SAMPLE = resolve(MAIN_ROOT, 'packages/xlsx/public/demo/sample-1.xlsx');
-// Diagnostic PNGs land outside the repo (tmpdir) so the committed test never
-// writes tracked files. Override with PROBE_OUT to inspect them elsewhere.
-const OUT_DIR = process.env.PROBE_OUT ?? resolve(tmpdir(), 'xlsx-border-probe');
-const LABEL = process.env.PROBE_LABEL ?? 'after';
+const ROOT = resolve(HERE, '../../..');
+// Render through the package's own orchestrator (which imports renderer.ts).
+const ORCH_PATH = resolve(ROOT, 'packages/xlsx/src/render-orchestrator.ts');
+const SAMPLE = resolve(ROOT, 'packages/xlsx/public/demo/sample-1.xlsx');
+// Opt-in diagnostics: set PROBE_OUT to a directory to dump the full render plus
+// an 8x crop of the measured border. Null by default → the test writes no files.
+const OUT_DIR = process.env.PROBE_OUT ?? null;
 
 const W = 600;
 const H = 400;
@@ -320,7 +309,6 @@ function savePng(canvas: InstanceType<typeof Canvas>, outPath: string): void {
 
 describe.skipIf(!skia)('xlsx border crispness (device-pixel probe)', () => {
   it('injected thin black horizontal border at dpr=1 collapses to one near-black device row', async () => {
-    mkdirSync(OUT_DIR, { recursive: true });
     const { data, w, h, canvas } = await renderInjected(1);
 
     const hit = findInjectedBlackBorder(data, w, h, 1);
@@ -334,25 +322,23 @@ describe.skipIf(!skia)('xlsx border crispness (device-pixel probe)', () => {
 
     // eslint-disable-next-line no-console
     console.log(
-      `\n[PROBE ${LABEL} dpr=1] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+      `\n[PROBE dpr=1] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
         ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
         `\n  minLum=${minLum.toFixed(1)} darkRowCount(<160)=${darkRowCount}`,
     );
 
-    savePng(canvas, resolve(OUT_DIR, `border-${LABEL}.png`));
-    saveZoomCrop(data, w, h, hit.x, cy, resolve(OUT_DIR, `crop-${LABEL}-8x.png`));
-
-    // AFTER (fixed): a thin (1 device px) black border = one near-black device
-    // row. Enforced only when not the explicit BEFORE run so the same file
-    // documents the bug without failing CI on the fix.
-    if (LABEL !== 'before') {
-      expect(minLum).toBeLessThan(80);
-      expect(darkRowCount).toBe(1);
+    if (OUT_DIR) {
+      mkdirSync(OUT_DIR, { recursive: true });
+      savePng(canvas, resolve(OUT_DIR, 'border-after.png'));
+      saveZoomCrop(data, w, h, hit.x, cy, resolve(OUT_DIR, 'crop-after-8x.png'));
     }
+
+    // A thin (1 device px) black border must collapse to one near-black row.
+    expect(minLum).toBeLessThan(80);
+    expect(darkRowCount).toBe(1);
   });
 
   it('dpr=2 sanity: thin border = even device width → clean 2-row band (no over-correction)', async () => {
-    mkdirSync(OUT_DIR, { recursive: true });
     const { data, w, h } = await renderInjected(2);
 
     const hit = findInjectedBlackBorder(data, w, h, 2);
@@ -365,7 +351,7 @@ describe.skipIf(!skia)('xlsx border crispness (device-pixel probe)', () => {
 
     // eslint-disable-next-line no-console
     console.log(
-      `\n[PROBE ${LABEL} dpr=2] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+      `\n[PROBE dpr=2] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
         ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
         `\n  darkRowCount(<160)=${darkRowCount}`,
     );

--- a/packages/node/src/xlsx-border-crisp.probe.test.ts
+++ b/packages/node/src/xlsx-border-crisp.probe.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Device-pixel crispness probe for the xlsx cell-border fix.
+ *
+ * Background: on a DPR=1 monitor xlsx cell borders rendered blurry (~2 device
+ * rows at ~50% ink each) instead of Excel's crisp 1px. Root cause:
+ * `render-orchestrator.ts` applies `ctx.scale(dpr,dpr)`, so drawing is in logical
+ * px; a `lineWidth=1` stroke at an INTEGER y has its span `[y-0.5, y+0.5]` in
+ * device space → it straddles two device rows (each ~50% ink → antialiased blur).
+ * The fix (renderer.ts `renderBorder`) adds a half-device-pixel offset
+ * `hp = 0.5/dpr` ONLY when the device-pixel width is odd, centering odd-width
+ * strokes on a single device row (crisp).
+ *
+ * This test MEASURES device pixels (not eyeballs). demo/sample-1.xlsx's own cell
+ * borders are dark-green (#1B4332, L≈53) and tangled with large solid fills and
+ * 24 merged ranges, so an *isolated* thin horizontal border cannot be located
+ * reliably in it (documented finding — see the diag notes in the task report).
+ * Instead the probe INJECTS one synthetic cell carrying a thin PURE-BLACK bottom
+ * border (#000000) into a guaranteed-white region of the parsed Worksheet model,
+ * renders at dpr=1, and reads the vertical luminance profile across that border's
+ * bottom edge. Pure black (RGB all 0) is unambiguous against the green fill
+ * (RGB 27/67/50) and the #d0d0d0 gridline.
+ *
+ * before/after numbers are produced by an external shell wrapper that swaps the
+ * worktree's renderer.ts (pre-fix vs fixed) and points RENDERER_ORCH at the
+ * worktree orchestrator. This committed test asserts the AFTER (fixed) state so
+ * it is meaningful in CI when skia is present, and skips cleanly when it is not.
+ *
+ * CI-safe: skia-canvas ships a native binding CI omits, so the suite is gated
+ * with `describe.skipIf(!skia)` exactly like render.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parseXlsx, parseSheet } from './xlsx.ts';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import type {
+  Worksheet,
+  Styles,
+  Border,
+  CellXf,
+  ViewportRange,
+} from '@silurus/ooxml-xlsx';
+
+const skia = await import('skia-canvas').catch(() => null);
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed for border probe');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// MAIN checkout root (this file lives at <root>/packages/node/src/).
+const MAIN_ROOT = resolve(HERE, '../../..');
+// The render-orchestrator under test. RENDERER_ORCH env overrides the path so a
+// shell wrapper can point this at the WORKTREE's orchestrator (which imports the
+// fixed — or, when swapped, pre-fix — renderer via its relative `./renderer.js`).
+// When unset, defaults to the MAIN checkout's own orchestrator so the committed
+// test runs standalone in CI.
+const ORCH_PATH =
+  process.env.RENDERER_ORCH ??
+  resolve(MAIN_ROOT, 'packages/xlsx/src/render-orchestrator.ts');
+
+const SAMPLE = resolve(MAIN_ROOT, 'packages/xlsx/public/demo/sample-1.xlsx');
+// Diagnostic PNGs land outside the repo (tmpdir) so the committed test never
+// writes tracked files. Override with PROBE_OUT to inspect them elsewhere.
+const OUT_DIR = process.env.PROBE_OUT ?? resolve(tmpdir(), 'xlsx-border-probe');
+const LABEL = process.env.PROBE_LABEL ?? 'after';
+
+const W = 600;
+const H = 400;
+
+// Injection target: a cell whose BOTTOM edge falls in a guaranteed-white region
+// of the Dashboard sheet (a spacer column, row 6) so the injected thin
+// PURE-BLACK bottom border draws onto white with no fill / gridline / merge
+// interference. Verified empirically: the bottom edge lands at device y≈242
+// (dpr=1) with pure white above and below. We measure that bottom edge.
+const INJ_ROW = 6;
+const INJ_COL = 4;
+
+function lum(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/** Parse the sample and splice in a single cell whose style carries a thin
+ *  pure-black BOTTOM border, returning the mutated Worksheet + Styles. The new
+ *  border / cellXf are appended (existing indices untouched). */
+function buildInjected(): { ws: Worksheet; styles: Styles } {
+  const buf = readFileSync(SAMPLE);
+  const parsed = parseXlsx(buf);
+  const ws = parseSheet(buf, 0, parsed.workbook.sheets[0].name) as Worksheet;
+  const styles = parsed.styles as Styles;
+
+  const newBorder: Border = {
+    left: null,
+    right: null,
+    top: null,
+    bottom: { style: 'thin', color: '#000000' },
+  };
+  styles.borders.push(newBorder);
+  const borderId = styles.borders.length - 1;
+
+  // Clone cellXf[0] but point borderId at our new black-bottom border, with no
+  // fill (fillId 0 = "none") so the cell stays white and only the border draws.
+  const base: CellXf = styles.cellXfs[0] ?? {
+    fontId: 0,
+    fillId: 0,
+    borderId: 0,
+    numFmtId: 0,
+    alignH: null,
+    alignV: null,
+    wrapText: false,
+  };
+  const newXf: CellXf = { ...base, fillId: 0, borderId };
+  styles.cellXfs.push(newXf);
+  const styleIndex = styles.cellXfs.length - 1;
+
+  // Replace (or add) only the target cell, preserving the rest of the row so
+  // the surrounding layout (and thus the white region below the bottom edge) is
+  // unchanged. The injected cell carries fillId 0 (no fill) + the black-bottom
+  // border, so only the bottom edge draws.
+  const injectedCell = {
+    col: INJ_COL,
+    row: INJ_ROW,
+    colRef: `${INJ_COL}`,
+    value: { type: 'empty' as const },
+    styleIndex,
+  };
+  const existing = ws.rows.find((r) => r.index === INJ_ROW);
+  if (existing) {
+    existing.cells = [
+      ...existing.cells.filter((c) => c.col !== INJ_COL),
+      injectedCell,
+    ];
+  } else {
+    ws.rows.push({ index: INJ_ROW, height: null, cells: [injectedCell] });
+    ws.rows.sort((a, b) => a.index - b.index);
+  }
+  return { ws, styles };
+}
+
+async function renderInjected(
+  dpr: number,
+): Promise<{ data: Uint8ClampedArray; w: number; h: number; canvas: InstanceType<typeof Canvas> }> {
+  const { ws, styles } = buildInjected();
+  const { renderWorksheetViewport } = (await import(ORCH_PATH)) as {
+    renderWorksheetViewport: (
+      deps: { ws: Worksheet; styles: Styles; imageCache: Map<string, unknown> },
+      target: unknown,
+      viewport: ViewportRange,
+      opts: { dpr: number; width: number; height: number },
+    ) => Promise<void>;
+  };
+  const canvas = new Canvas(Math.round(W * dpr), Math.round(H * dpr));
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderWorksheetViewport(
+      { ws, styles, imageCache: new Map() },
+      canvas,
+      { row: 1, col: 1, rows: 30, cols: 12 },
+      { dpr, width: W, height: H },
+    );
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const w = canvas.width;
+  const h = canvas.height;
+  const img = ctx.getImageData(0, 0, w, h);
+  return { data: img.data, w, h, canvas };
+}
+
+/** Locate the injected thin horizontal border. The injected border is the only
+ *  dark (greyscale, near-neutral) horizontal run in the canvas that is ISOLATED
+ *  in white (white ~3*dpr px above AND below). This works for BOTH the crisp
+ *  AFTER case (a single pure-black row, L≈0) and the blurry BEFORE case (two
+ *  adjacent mid-grey rows, L≈128 each, ink split 50/50). The white-isolation
+ *  test rejects the tall #1B4332 green fill (which has dark rows but never white
+ *  neighbors) and the grey gridline (#d0d0d0 is too light: L≈208 > the darkness
+ *  gate). "near-neutral" (R≈G≈B) additionally rejects the green fill. */
+function findInjectedBlackBorder(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  dpr: number,
+): { x: number; y: number; runLen: number } {
+  // A dark, near-neutral pixel: low luminance AND R/G/B close together (so the
+  // green fill, RGB 27/67/50 with a 40-wide spread, is excluded even though its
+  // luminance is low). A crisp black row (0/0/0) and a blurry grey row
+  // (128/128/128) both pass.
+  const isDarkNeutral = (i: number): boolean => {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const L = lum(r, g, b);
+    const spread = Math.max(r, g, b) - Math.min(r, g, b);
+    return L < 170 && spread < 24;
+  };
+  const isLight = (i: number): boolean =>
+    lum(data[i], data[i + 1], data[i + 2]) > 200;
+  const minRun = Math.round(16 * dpr); // injected spacer-col cell is ~25 logical px wide
+  const gap = 3 * dpr;
+  let best = { x: -1, y: -1, runLen: 0 };
+  for (let y = gap; y < h - gap; y++) {
+    let cur = 0;
+    let curStart = -1;
+    for (let x = 0; x <= w; x++) {
+      const i = (y * w + x) * 4;
+      const dark = x < w && isDarkNeutral(i);
+      if (dark) {
+        if (curStart < 0) curStart = x;
+        cur++;
+      } else {
+        if (cur >= minRun) {
+          const mx = curStart + Math.floor(cur / 2);
+          // Isolation: a fully-white row exists within `gap` above and below the
+          // band (so a 1- or 2-row band both qualify, but a tall fill does not).
+          const aboveWhite = isLight(((y - gap) * w + mx) * 4);
+          const belowWhite = isLight(((y + gap) * w + mx) * 4);
+          if (aboveWhite && belowWhite && cur > best.runLen) {
+            best = { x: mx, y, runLen: cur };
+          }
+        }
+        cur = 0;
+        curStart = -1;
+      }
+    }
+  }
+  return best;
+}
+
+function vProfile(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  x: number,
+  y: number,
+  span = 3,
+): { ys: number[]; L: number[] } {
+  const ys: number[] = [];
+  const L: number[] = [];
+  for (let dy = -span; dy <= span; dy++) {
+    const yy = y + dy;
+    ys.push(yy);
+    if (yy < 0 || yy >= h) {
+      L.push(NaN);
+      continue;
+    }
+    const i = (yy * w + x) * 4;
+    L.push(lum(data[i], data[i + 1], data[i + 2]));
+  }
+  return { ys, L };
+}
+
+/** Recenter on the darkest row within ±2 so a 2-row blurry band reports
+ *  symmetrically around its center of mass. */
+function darkestNear(
+  data: Uint8ClampedArray,
+  w: number,
+  x: number,
+  y: number,
+  r = 2,
+): number {
+  let cy = y;
+  let best = Infinity;
+  for (let dy = -r; dy <= r; dy++) {
+    const i = ((y + dy) * w + x) * 4;
+    const L = lum(data[i], data[i + 1], data[i + 2]);
+    if (L < best) {
+      best = L;
+      cy = y + dy;
+    }
+  }
+  return cy;
+}
+
+function saveZoomCrop(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  cx: number,
+  cy: number,
+  outPath: string,
+): void {
+  const CROP = 24;
+  const ZOOM = 8;
+  const half = CROP / 2;
+  const x0 = Math.max(0, Math.min(w - CROP, cx - half));
+  const y0 = Math.max(0, Math.min(h - CROP, cy - half));
+  const out = new Canvas(CROP * ZOOM, CROP * ZOOM);
+  const octx = out.getContext('2d') as unknown as CanvasRenderingContext2D;
+  for (let yy = 0; yy < CROP; yy++) {
+    for (let xx = 0; xx < CROP; xx++) {
+      const i = ((y0 + yy) * w + (x0 + xx)) * 4;
+      octx.fillStyle = `rgb(${data[i]},${data[i + 1]},${data[i + 2]})`;
+      octx.fillRect(xx * ZOOM, yy * ZOOM, ZOOM, ZOOM);
+    }
+  }
+  const png = (
+    out as unknown as { toBufferSync?: (f: string) => Buffer }
+  ).toBufferSync?.('png');
+  if (png) writeFileSync(outPath, png);
+}
+
+function savePng(canvas: InstanceType<typeof Canvas>, outPath: string): void {
+  const png = (
+    canvas as unknown as { toBufferSync?: (f: string) => Buffer }
+  ).toBufferSync?.('png');
+  if (png) writeFileSync(outPath, png);
+}
+
+describe.skipIf(!skia)('xlsx border crispness (device-pixel probe)', () => {
+  it('injected thin black horizontal border at dpr=1 collapses to one near-black device row', async () => {
+    mkdirSync(OUT_DIR, { recursive: true });
+    const { data, w, h, canvas } = await renderInjected(1);
+
+    const hit = findInjectedBlackBorder(data, w, h, 1);
+    expect(hit.x).toBeGreaterThanOrEqual(0);
+
+    const cy = darkestNear(data, w, hit.x, hit.y, 2);
+    const { ys, L } = vProfile(data, w, h, hit.x, cy, 3);
+    const finite = L.filter((v) => !Number.isNaN(v));
+    const minLum = Math.min(...finite);
+    const darkRowCount = finite.filter((v) => v < 160).length;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[PROBE ${LABEL} dpr=1] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+        ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
+        `\n  minLum=${minLum.toFixed(1)} darkRowCount(<160)=${darkRowCount}`,
+    );
+
+    savePng(canvas, resolve(OUT_DIR, `border-${LABEL}.png`));
+    saveZoomCrop(data, w, h, hit.x, cy, resolve(OUT_DIR, `crop-${LABEL}-8x.png`));
+
+    // AFTER (fixed): a thin (1 device px) black border = one near-black device
+    // row. Enforced only when not the explicit BEFORE run so the same file
+    // documents the bug without failing CI on the fix.
+    if (LABEL !== 'before') {
+      expect(minLum).toBeLessThan(80);
+      expect(darkRowCount).toBe(1);
+    }
+  });
+
+  it('dpr=2 sanity: thin border = even device width → clean 2-row band (no over-correction)', async () => {
+    mkdirSync(OUT_DIR, { recursive: true });
+    const { data, w, h } = await renderInjected(2);
+
+    const hit = findInjectedBlackBorder(data, w, h, 2);
+    expect(hit.x).toBeGreaterThanOrEqual(0);
+
+    const cy = darkestNear(data, w, hit.x, hit.y, 3);
+    const { ys, L } = vProfile(data, w, h, hit.x, cy, 3);
+    const finite = L.filter((v) => !Number.isNaN(v));
+    const darkRowCount = finite.filter((v) => v < 160).length;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[PROBE ${LABEL} dpr=2] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+        ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
+        `\n  darkRowCount(<160)=${darkRowCount}`,
+    );
+
+    // deviceW=2 (even) → no offset → a clean 2-device-row band, NOT 3.
+    expect(darkRowCount).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2488,6 +2488,10 @@ export function renderViewport(
   // band (which now anchors at the right). The horizontal divider is
   // unaffected by the x-mirror but its row-header end moves to the right.
   const rtl = worksheet.rightToLeft === true;
+  // Half-device-pixel offset so the 0.5-px divider lands crisp on the device
+  // grid (same convention as gridlines/headers). At dpr=1 this is +0.5; the
+  // previous hardcoded +0.5 was a *logical* px and blurred at dpr>1.
+  const hp = 0.5 / dpr;
   if (freezeRows > 0) {
     ctx.save();
     ctx.strokeStyle = FREEZE_LINE_COLOR;
@@ -2495,11 +2499,11 @@ export function renderViewport(
     ctx.beginPath();
     if (rtl) {
       // cell area is [0, canvasW - hw]
-      ctx.moveTo(0, scrollAreaY + 0.5);
-      ctx.lineTo(canvasW - hw, scrollAreaY + 0.5);
+      ctx.moveTo(0, scrollAreaY + hp);
+      ctx.lineTo(canvasW - hw, scrollAreaY + hp);
     } else {
-      ctx.moveTo(hw, scrollAreaY + 0.5);
-      ctx.lineTo(canvasW, scrollAreaY + 0.5);
+      ctx.moveTo(hw, scrollAreaY + hp);
+      ctx.lineTo(canvasW, scrollAreaY + hp);
     }
     ctx.stroke();
     ctx.restore();
@@ -2512,7 +2516,7 @@ export function renderViewport(
     // Divider sits between the frozen band and the scroll band. In LTR that
     // is at scrollAreaX = hw + frozenW; mirrored that becomes
     // canvasW - scrollAreaX.
-    const dividerX = rtl ? canvasW - scrollAreaX + 0.5 : scrollAreaX + 0.5;
+    const dividerX = rtl ? canvasW - scrollAreaX + hp : scrollAreaX + hp;
     ctx.moveTo(dividerX, hh);
     ctx.lineTo(dividerX, canvasH);
     ctx.stroke();
@@ -3418,12 +3422,6 @@ function renderBorder(
   invertedLeft = false,
   dpr = 1,
 ): void {
-  // Half-device-pixel offset used to center odd-device-width strokes on a pixel
-  // midpoint so they render crisp instead of bleeding across two rows. Border
-  // widths themselves stay in *logical* px (NOT divided by dpr): ctx.scale(dpr,
-  // dpr) scales them to device px so a thin border reads as 2 device px at
-  // dpr=2, matching Excel's measured weight. Same offset technique as grid lines.
-  const hp = 0.5 / dpr;
   type EdgeRef = {
     edge: BorderEdge | null | undefined;
     x1: number; y1: number; x2: number; y2: number;
@@ -3504,23 +3502,32 @@ function renderBorder(
     // Logical-px width (thin=1, medium=2, thick=3). ctx.scale(dpr,dpr) scales it
     // to device px, so a thin border is 2 device px at dpr=2 — matching Excel's
     // measured on-screen weight. Do NOT divide by dpr (that halved it to 1 px).
-    ctx.lineWidth = borderStyleWidth(edge.style);
+    const lw = borderStyleWidth(edge.style);
+    ctx.lineWidth = lw;
     const dash = borderStyleDash(edge.style);
     ctx.setLineDash(dash);
-    // Crispness nudge: only a stroke whose *device* width is odd (thin/thick at
-    // dpr=1) needs centering on a pixel midpoint; cell edges sit on integer
-    // device coords so add hp=0.5/dpr. Even device widths (thin → 2 px at dpr=2)
-    // are already crisp on the integer edge and must NOT be nudged, or they
-    // straddle and blur. Diagonals can't be pixel-aligned, so no offset.
-    const deviceW = Math.round(borderStyleWidth(edge.style) * dpr);
-    const off = kind !== 'd' && deviceW % 2 === 1 ? hp : 0;
-    const dpx = kind === 'v' ? off : 0;
-    const dpy = kind === 'h' ? off : 0;
+    // Crispness nudge (see crispOffset): an odd device-width stroke is centered
+    // on a pixel midpoint so it renders crisp instead of bleeding across two
+    // rows; an even device width is already crisp on the integer cell edge and
+    // gets 0. Diagonals can't be pixel-aligned, so no offset.
+    const crispNudge = kind !== 'd' ? crispOffset(lw, dpr) : 0;
+    const dpx = kind === 'v' ? crispNudge : 0;
+    const dpy = kind === 'h' ? crispNudge : 0;
     ctx.moveTo(x1 + dpx, y1 + dpy);
     ctx.lineTo(x2 + dpx, y2 + dpy);
     ctx.stroke();
     ctx.setLineDash([]);
   }
+}
+
+/** Half-device-pixel nudge that keeps an axis-aligned stroke of `logicalWidth`
+ *  logical px crisp. ctx.scale(dpr,dpr) maps the width to round(logicalWidth*dpr)
+ *  device px; an ODD device width must sit on a pixel *midpoint* (offset 0.5/dpr)
+ *  to render as a single sharp row, while an EVEN device width is already crisp
+ *  on the integer coordinate (offset 0 — nudging it would straddle two rows and
+ *  blur). Returns the coordinate offset to add to an integer-aligned edge. */
+function crispOffset(logicalWidth: number, dpr: number): number {
+  return Math.round(logicalWidth * dpr) % 2 === 1 ? 0.5 / dpr : 0;
 }
 
 function borderStyleWidth(style: string): number {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3486,14 +3486,19 @@ function renderBorder(
     }
     ctx.beginPath();
     ctx.strokeStyle = color;
-    ctx.lineWidth = borderStyleWidth(edge.style) / dpr;
+    const deviceW = borderStyleWidth(edge.style);
+    ctx.lineWidth = deviceW / dpr;
     const dash = borderStyleDash(edge.style);
     ctx.setLineDash(dash);
-    // Half-pixel offset aligns horizontal lines to a device-pixel row (y offset)
-    // and vertical lines to a device-pixel column (x offset). Diagonals are
-    // inherently anti-aliased so no offset is applied (dpx=dpy=0 for kind 'd').
-    const dpx = kind === 'v' ? hp : 0;
-    const dpy = kind === 'h' ? hp : 0;
+    // Half-pixel offset only helps ODD device-pixel widths. Cell edges sit on
+    // integer device coordinates (cx/cy are integer CSS px), so a 1- or
+    // 3-device-px line is crisp when its center is nudged to a pixel midpoint
+    // (+hp). An even width (medium = 2 device px) is already crisp centered on
+    // the integer edge — adding hp would straddle three rows and blur it.
+    // Diagonals can't be pixel-aligned, so they take no offset.
+    const off = kind !== 'd' && Math.round(deviceW) % 2 === 1 ? hp : 0;
+    const dpx = kind === 'v' ? off : 0;
+    const dpy = kind === 'h' ? off : 0;
     ctx.moveTo(x1 + dpx, y1 + dpy);
     ctx.lineTo(x2 + dpx, y2 + dpy);
     ctx.stroke();

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2589,8 +2589,14 @@ function renderHeaders(
   ctx.fillStyle = HEADER_TEXT;
 
   // Helper: draw one column header cell.
-  // Borders are drawn INSET (-hp) so that the next cell's fillRect (which starts at cx+cw)
-  // never overwrites the current cell's right/bottom border line.
+  // The inter-column separator is the LEADING (left) edge at +hp, so it lands on
+  // the SAME device pixel as the data grid's vertical column boundary (gridlines
+  // and cell borders draw the shared boundary at cx+hp). Drawing it as this
+  // cell's own left edge — rather than the previous cell's trailing right edge at
+  // cx+cw-hp — both aligns it with the data column line (the strip used to sit 1
+  // device px to the left) AND survives the next cell's fillRect (which starts at
+  // cx+cw and never touches cx+hp), so no separate fill/stroke pass is needed.
+  // The top/bottom lines stay as the header-strip perimeter.
   const drawColHeader = (col: number, ltrCx: number, cw: number) => {
     const cx = mirrorX(ltrCx, cw);
     ctx.fillStyle = colBg(col);
@@ -2598,9 +2604,9 @@ function renderHeaders(
     ctx.strokeStyle = colBorder(col);
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(cx + cw - hp, 0);     ctx.lineTo(cx + cw - hp, hh);  // right (inset)
-    ctx.moveTo(cx, hh - hp);          ctx.lineTo(cx + cw, hh - hp);  // bottom (inset)
-    ctx.moveTo(cx, hp);               ctx.lineTo(cx + cw, hp);        // top
+    ctx.moveTo(cx + hp, 0);          ctx.lineTo(cx + hp, hh);        // left = column boundary (aligns with data grid at +hp)
+    ctx.moveTo(cx, hh - hp);          ctx.lineTo(cx + cw, hh - hp);  // bottom (strip perimeter, inset)
+    ctx.moveTo(cx, hp);               ctx.lineTo(cx + cw, hp);        // top (strip perimeter)
     ctx.stroke();
     ctx.fillStyle = HEADER_TEXT;
     ctx.textAlign = 'center';
@@ -2609,7 +2615,14 @@ function renderHeaders(
   };
 
   // Helper: draw one row header cell.
-  // Borders drawn inset so adjacent cell's fill never overwrites them.
+  // The inter-row separator is the LEADING (top) edge at +hp, so it lands on the
+  // SAME device pixel as the data grid's horizontal row boundary (gridlines and
+  // cell borders draw the shared boundary at cy+hp). Drawing it as this cell's
+  // own top edge — rather than the previous cell's trailing bottom edge at
+  // cy+ch-hp — aligns it with the data row line (the strip used to sit 1 device
+  // px above) AND survives the next cell's fillRect (which starts at cy+ch and
+  // never touches cy+hp), so no separate fill/stroke pass is needed. The
+  // left/right lines stay as the header-strip perimeter.
   const drawRowHeader = (row: number, cy: number, ch: number) => {
     const rx = cornerX;  // left edge of the row-header strip (mirrors to the right in RTL)
     ctx.fillStyle = rowBg(row);
@@ -2617,9 +2630,9 @@ function renderHeaders(
     ctx.strokeStyle = rowBorder(row);
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(rx + hw - hp, cy);  ctx.lineTo(rx + hw - hp, cy + ch);   // right (inset)
-    ctx.moveTo(rx, cy + ch - hp); ctx.lineTo(rx + hw, cy + ch - hp);    // bottom (inset)
-    ctx.moveTo(rx + hp, cy);       ctx.lineTo(rx + hp, cy + ch);         // left
+    ctx.moveTo(rx + hw - hp, cy);  ctx.lineTo(rx + hw - hp, cy + ch);   // right (strip perimeter, inset)
+    ctx.moveTo(rx, cy + hp);       ctx.lineTo(rx + hw, cy + hp);         // top = row boundary (aligns with data grid at +hp)
+    ctx.moveTo(rx + hp, cy);       ctx.lineTo(rx + hp, cy + ch);         // left (strip perimeter)
     ctx.stroke();
     ctx.fillStyle = HEADER_TEXT;
     ctx.textBaseline = 'middle';

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1330,7 +1330,7 @@ function renderQuadrant(
       fillDataBar(ctx, cf.dataBar.color, aCx + bInset, aCy + bInset, bW, cH - bInset * 2, cf.dataBar.gradient);
     }
     const mergedBorder = resolveMergeBorder(border, aRow, aCol, info.right, info.bottom, rc.cellMap, styles);
-    renderBorder(ctx, mergeBorders(mergedBorder, cf.border), aCx, aCy, cW, cH);
+    renderBorder(ctx, mergeBorders(mergedBorder, cf.border), aCx, aCy, cW, cH, false, false, dpr);
 
     if (!cell) continue;
     const text = formatCellValue(cell, styles, cf.numFmt);
@@ -1666,7 +1666,7 @@ function renderQuadrant(
           invertedLeft = picked === leftRight && before !== leftRight;
         }
       }
-      renderBorder(ctx, mergedBorder, cx, cy, cellW, cellH, invertedTop, invertedLeft);
+      renderBorder(ctx, mergedBorder, cx, cy, cellW, cellH, invertedTop, invertedLeft, dpr);
 
       // Excel Table style overlay (ECMA-376 §18.8.83). Custom styles draw only
       // their dxf-defined borders; built-in style names fall back to a
@@ -1677,7 +1677,7 @@ function renderQuadrant(
       if (tableStyle) {
         const overlay = tableOverlayBorder(tableStyle, tsDxfWhole, tsDxfHeader, colIndex);
         if (overlay.kind === 'dxf') {
-          renderBorder(ctx, overlay.border, cx, cy, cellW, cellH);
+          renderBorder(ctx, overlay.border, cx, cy, cellW, cellH, false, false, dpr);
         } else if (overlay.kind === 'accent') {
           const hp = 0.5 / dpr;
           ctx.strokeStyle = overlay.color;
@@ -3403,7 +3403,12 @@ function renderBorder(
    *  Same idea for `invertedLeft` (inherited from the left cell's right). */
   invertedTop = false,
   invertedLeft = false,
+  dpr = 1,
 ): void {
+  // Half-device-pixel offset: aligns the stroke center to a device-pixel row
+  // so that lineWidth=1/dpr renders as a crisp single device pixel rather than
+  // bleeding across two rows at 50 % alpha. Same technique as grid lines.
+  const hp = 0.5 / dpr;
   type EdgeRef = {
     edge: BorderEdge | null | undefined;
     x1: number; y1: number; x2: number; y2: number;
@@ -3435,13 +3440,13 @@ function renderBorder(
       // direction. Excel renders <diagonal style="double"/> the same way it
       // does horizontal/vertical doubles — two thin lines with a small gap.
       ctx.strokeStyle = color;
-      ctx.lineWidth = 1;
+      ctx.lineWidth = 1 / dpr;
       ctx.setLineDash([]);
       const dx = x2 - x1;
       const dy = y2 - y1;
       const len = Math.hypot(dx, dy);
-      // Perpendicular unit vector. ±off shifts the line ~1px to either side.
-      const off = 1;
+      // Perpendicular unit vector. ±off shifts the line ~1 device px to either side.
+      const off = 1 / dpr;
       const px = (-dy / len) * off;
       const py = (dx / len) * off;
       ctx.beginPath();
@@ -3452,9 +3457,9 @@ function renderBorder(
     }
     if (edge.style === 'double' && kind !== 'd') {
       ctx.strokeStyle = color;
-      ctx.lineWidth = 1;
+      ctx.lineWidth = 1 / dpr;
       ctx.setLineDash([]);
-      const off = 1;
+      const off = 1 / dpr;
       ctx.beginPath();
       if (kind === 'h') {
         const isTop = y1 === y;
@@ -3464,15 +3469,15 @@ function renderBorder(
         // (which our fill erased and which we are restoring). Swap which
         // side gets the extension so the restored line is the extended one.
         const swap = isTop && invertedTop;
-        const outerY = isTop ? (swap ? y + off : y - off) : y + h + off;
-        const innerY = isTop ? (swap ? y - off : y + off) : y + h - off;
+        const outerY = (isTop ? (swap ? y + off : y - off) : y + h + off) + hp;
+        const innerY = (isTop ? (swap ? y - off : y + off) : y + h - off) + hp;
         ctx.moveTo(x - off, outerY);   ctx.lineTo(x + w + off, outerY);
         ctx.moveTo(x + off, innerY);   ctx.lineTo(x + w - off, innerY);
       } else {
         const isLeft = x1 === x;
         const swap = isLeft && invertedLeft;
-        const outerX = isLeft ? (swap ? x + off : x - off) : x + w + off;
-        const innerX = isLeft ? (swap ? x - off : x + off) : x + w - off;
+        const outerX = (isLeft ? (swap ? x + off : x - off) : x + w + off) + hp;
+        const innerX = (isLeft ? (swap ? x - off : x + off) : x + w - off) + hp;
         ctx.moveTo(outerX, y - off);   ctx.lineTo(outerX, y + h + off);
         ctx.moveTo(innerX, y + off);   ctx.lineTo(innerX, y + h - off);
       }
@@ -3481,11 +3486,16 @@ function renderBorder(
     }
     ctx.beginPath();
     ctx.strokeStyle = color;
-    ctx.lineWidth = borderStyleWidth(edge.style);
+    ctx.lineWidth = borderStyleWidth(edge.style) / dpr;
     const dash = borderStyleDash(edge.style);
     ctx.setLineDash(dash);
-    ctx.moveTo(x1, y1);
-    ctx.lineTo(x2, y2);
+    // Half-pixel offset aligns horizontal lines to a device-pixel row (y offset)
+    // and vertical lines to a device-pixel column (x offset). Diagonals are
+    // inherently anti-aliased so no offset is applied (dpx=dpy=0 for kind 'd').
+    const dpx = kind === 'v' ? hp : 0;
+    const dpy = kind === 'h' ? hp : 0;
+    ctx.moveTo(x1 + dpx, y1 + dpy);
+    ctx.lineTo(x2 + dpx, y2 + dpy);
     ctx.stroke();
     ctx.setLineDash([]);
   }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3405,9 +3405,11 @@ function renderBorder(
   invertedLeft = false,
   dpr = 1,
 ): void {
-  // Half-device-pixel offset: aligns the stroke center to a device-pixel row
-  // so that lineWidth=1/dpr renders as a crisp single device pixel rather than
-  // bleeding across two rows at 50 % alpha. Same technique as grid lines.
+  // Half-device-pixel offset used to center odd-device-width strokes on a pixel
+  // midpoint so they render crisp instead of bleeding across two rows. Border
+  // widths themselves stay in *logical* px (NOT divided by dpr): ctx.scale(dpr,
+  // dpr) scales them to device px so a thin border reads as 2 device px at
+  // dpr=2, matching Excel's measured weight. Same offset technique as grid lines.
   const hp = 0.5 / dpr;
   type EdgeRef = {
     edge: BorderEdge | null | undefined;
@@ -3440,13 +3442,13 @@ function renderBorder(
       // direction. Excel renders <diagonal style="double"/> the same way it
       // does horizontal/vertical doubles — two thin lines with a small gap.
       ctx.strokeStyle = color;
-      ctx.lineWidth = 1 / dpr;
+      ctx.lineWidth = 1;
       ctx.setLineDash([]);
       const dx = x2 - x1;
       const dy = y2 - y1;
       const len = Math.hypot(dx, dy);
-      // Perpendicular unit vector. ±off shifts the line ~1 device px to either side.
-      const off = 1 / dpr;
+      // Perpendicular unit vector. ±off shifts the line ~1 logical px to either side.
+      const off = 1;
       const px = (-dy / len) * off;
       const py = (dx / len) * off;
       ctx.beginPath();
@@ -3457,9 +3459,9 @@ function renderBorder(
     }
     if (edge.style === 'double' && kind !== 'd') {
       ctx.strokeStyle = color;
-      ctx.lineWidth = 1 / dpr;
+      ctx.lineWidth = 1;
       ctx.setLineDash([]);
-      const off = 1 / dpr;
+      const off = 1;
       ctx.beginPath();
       if (kind === 'h') {
         const isTop = y1 === y;
@@ -3469,15 +3471,15 @@ function renderBorder(
         // (which our fill erased and which we are restoring). Swap which
         // side gets the extension so the restored line is the extended one.
         const swap = isTop && invertedTop;
-        const outerY = (isTop ? (swap ? y + off : y - off) : y + h + off) + hp;
-        const innerY = (isTop ? (swap ? y - off : y + off) : y + h - off) + hp;
+        const outerY = isTop ? (swap ? y + off : y - off) : y + h + off;
+        const innerY = isTop ? (swap ? y - off : y + off) : y + h - off;
         ctx.moveTo(x - off, outerY);   ctx.lineTo(x + w + off, outerY);
         ctx.moveTo(x + off, innerY);   ctx.lineTo(x + w - off, innerY);
       } else {
         const isLeft = x1 === x;
         const swap = isLeft && invertedLeft;
-        const outerX = (isLeft ? (swap ? x + off : x - off) : x + w + off) + hp;
-        const innerX = (isLeft ? (swap ? x - off : x + off) : x + w - off) + hp;
+        const outerX = isLeft ? (swap ? x + off : x - off) : x + w + off;
+        const innerX = isLeft ? (swap ? x - off : x + off) : x + w - off;
         ctx.moveTo(outerX, y - off);   ctx.lineTo(outerX, y + h + off);
         ctx.moveTo(innerX, y + off);   ctx.lineTo(innerX, y + h - off);
       }
@@ -3486,17 +3488,19 @@ function renderBorder(
     }
     ctx.beginPath();
     ctx.strokeStyle = color;
-    const deviceW = borderStyleWidth(edge.style);
-    ctx.lineWidth = deviceW / dpr;
+    // Logical-px width (thin=1, medium=2, thick=3). ctx.scale(dpr,dpr) scales it
+    // to device px, so a thin border is 2 device px at dpr=2 — matching Excel's
+    // measured on-screen weight. Do NOT divide by dpr (that halved it to 1 px).
+    ctx.lineWidth = borderStyleWidth(edge.style);
     const dash = borderStyleDash(edge.style);
     ctx.setLineDash(dash);
-    // Half-pixel offset only helps ODD device-pixel widths. Cell edges sit on
-    // integer device coordinates (cx/cy are integer CSS px), so a 1- or
-    // 3-device-px line is crisp when its center is nudged to a pixel midpoint
-    // (+hp). An even width (medium = 2 device px) is already crisp centered on
-    // the integer edge — adding hp would straddle three rows and blur it.
-    // Diagonals can't be pixel-aligned, so they take no offset.
-    const off = kind !== 'd' && Math.round(deviceW) % 2 === 1 ? hp : 0;
+    // Crispness nudge: only a stroke whose *device* width is odd (thin/thick at
+    // dpr=1) needs centering on a pixel midpoint; cell edges sit on integer
+    // device coords so add hp=0.5/dpr. Even device widths (thin → 2 px at dpr=2)
+    // are already crisp on the integer edge and must NOT be nudged, or they
+    // straddle and blur. Diagonals can't be pixel-aligned, so no offset.
+    const deviceW = Math.round(borderStyleWidth(edge.style) * dpr);
+    const off = kind !== 'd' && deviceW % 2 === 1 ? hp : 0;
     const dpx = kind === 'v' ? off : 0;
     const dpy = kind === 'h' ? off : 0;
     ctx.moveTo(x1 + dpx, y1 + dpy);

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -16,13 +16,14 @@ const base = import.meta.env.BASE_URL;
       <div class="hero-copy">
         <p class="eyebrow">Rust · WebAssembly · Canvas 2D</p>
         <h1 class="hero-title">
-          Pixel-faithful <span class="grad">Office</span> documents,<br />
+          High-fidelity <span class="grad">Office</span> documents,<br />
           rendered in the browser.
         </h1>
         <p class="hero-lead">
           <code>@silurus/ooxml</code> parses <strong>.docx</strong>, <strong>.xlsx</strong> and
           <strong>.pptx</strong> with a Rust/WASM engine and paints them to a Canvas — no server,
-          no native apps, no iframe. The most faithful Office Open XML rendering on the web.
+          no native apps, no iframe. Faithful rendering of a wide range of real-world documents,
+          right in the browser.
         </p>
         <div class="hero-cta">
           <a class="btn btn-primary" href="https://www.npmjs.com/package/@silurus/ooxml">npm install @silurus/ooxml</a>
@@ -68,6 +69,7 @@ const base = import.meta.env.BASE_URL;
       <p class="section-lead">
         A curated slice of what each format supports. The full, exhaustive matrix lives in the
         <a class="inline-link" href="https://github.com/yukiyokotani/office-open-xml-viewer#feature-support">README</a>.
+        Coverage is broad and growing; very complex or unusual documents may still differ from Office in places.
       </p>
       <Capabilities />
     </div>


### PR DESCRIPTION
## Summary

Patch release **0.64.3**. Fixes Excel grid/border line rendering at common display scales and tones down the homepage marketing copy.

### xlsx rendering
- **Crisp 1-px borders at devicePixelRatio = 1.** A thin (1 logical px) cell border drawn on an integer cell edge straddled two device rows at 50% coverage each → a blurry ~2-px band. Odd-device-width strokes are now nudged half a device pixel onto a pixel midpoint; even widths (e.g. a thin border at dpr=2) are untouched. Widths stay logical — the orchestrator's `ctx.scale(dpr,dpr)` maps them to device px (ECMA-376 §18.18.3 ST_BorderStyle).
- **Header ↔ data-grid alignment.** Row/column header separators sat one device pixel left/above the matching data-grid line at dpr=1; they now land on the same pixel. Freeze-pane dividers used a hardcoded logical `+0.5` (blurred at dpr>1) and are now device-correct.
- Factored the odd-device-width crisp offset into a shared `crispOffset` helper.

### Verification (device pixels, not eyeballed)
Headless node + skia at dpr=1/2 on `private/sample-30`:
- Border: blurry 2 device rows (L≈64+57) → crisp 1 row (L=0) at dpr=1; clean 2-row band at dpr=2 (no over-correction).
- Header alignment: header↔data delta went from **+1 px on all 11 column + 25 row boundaries → 0** on every one.
- Committed regression guard: `packages/node/src/xlsx-border-crisp.probe.test.ts` (skia-gated; WASM lazily imported so it stays green in CI's test-before-build:wasm order).

### docs / site
- Toned down the homepage hero (per HN feedback): dropped the "most faithful … on the web" / "pixel-faithful" superlatives in favor of an accurate description, and added a coverage caveat. The spec-first description and the AI-authorship note are unchanged.

Merge with `--merge` (no squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)