### PR TITLE
fix(core/docx/pptx): crisp axis-aligned lines at DPR=1 (shared crispOffset)

### DIFF
--- a/packages/core/src/canvas/crisp.ts
+++ b/packages/core/src/canvas/crisp.ts
@@ -1,0 +1,25 @@
+/**
+ * Crisp-line rasterization helper shared by the docx / xlsx / pptx renderers.
+ *
+ * All three renderers draw in *logical* pixels under `ctx.scale(dpr, dpr)`, so a
+ * thin axis-aligned stroke placed on an integer coordinate can straddle two
+ * device rows (each at 50% coverage) and render blurry. Nudging the coordinate
+ * by half a device pixel centers an odd-device-width stroke on a single device
+ * row, which renders crisp.
+ */
+
+/**
+ * The offset to add to an integer-aligned coordinate so an axis-aligned stroke of
+ * `logicalWidth` logical px renders crisp under `ctx.scale(dpr, dpr)`.
+ *
+ * `ctx.scale(dpr, dpr)` maps the stroke width to `round(logicalWidth * dpr)`
+ * device px. An ODD device width must sit on a pixel *midpoint* (offset `0.5/dpr`)
+ * to land on one device row; an EVEN device width is already crisp on the integer
+ * coordinate and must NOT be nudged (offset `0`), or it straddles and blurs.
+ *
+ * Only meaningful for axis-aligned (horizontal / vertical) strokes — diagonals,
+ * arbitrary paths and glyph outlines cannot be pixel-aligned this way.
+ */
+export function crispOffset(logicalWidth: number, dpr: number): number {
+  return Math.round(logicalWidth * dpr) % 2 === 1 ? 0.5 / dpr : 0;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,7 @@ export {
 export type { MathNode, MathFormula, MathStyle } from './types/math';
 export { EMU_PER_INCH, EMU_PER_PT, EMU_PER_PX, PT_TO_PX } from './units';
 export { isHTMLCanvas, defaultDpr } from './canvas/env';
+export { crispOffset } from './canvas/crisp';
 export {
   WorkerBridge,
   type WorkerLike,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -17,6 +17,7 @@ import {
   getConnectorAnchors,
   mathToMathML,
   recolorSvg,
+  crispOffset,
   PT_TO_PX,
   resolveBaseDirection,
   isHTMLCanvas,
@@ -140,6 +141,10 @@ export async function prepareMathRuns(body: BodyElement[], math: MathRenderer): 
 interface RenderState {
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   scale: number;    // px per pt
+  /** Device-pixel ratio the canvas was scaled by (`ctx.scale(dpr, dpr)`). Used to
+   *  compute the crisp-line offset (see crispOffset) so thin axis-aligned strokes
+   *  land on a single device row instead of straddling two. */
+  dpr: number;
   contentX: number; // left of content area (px)
   contentW: number; // width of content area (px)
   y: number;        // current Y cursor (px)
@@ -513,6 +518,7 @@ export async function renderDocumentToCanvas(
   const baseState: RenderState = {
     ctx,
     scale,
+    dpr,
     contentX: sec.marginLeft * scale,
     contentW: (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale,
     y: sec.marginTop * scale,
@@ -638,10 +644,16 @@ function drawPageFootnotes(
   const ctx = baseState.ctx;
   ctx.save();
   ctx.strokeStyle = baseState.defaultColor;
-  ctx.lineWidth = Math.max(1, Math.round(0.5 * scale));
+  const ruleLw = Math.max(1, Math.round(0.5 * scale));
+  ctx.lineWidth = ruleLw;
+  // Crispness nudge (see crispOffset): a horizontal rule on an integer y needs a
+  // half-device-pixel offset only when its device width is odd. The previous
+  // hardcoded `+ 0.5` was a logical-px offset that only happened to be crisp at
+  // dpr=1 and blurred at dpr>1; crispOffset makes it device-correct at any dpr.
+  const ruleNudge = crispOffset(ruleLw, baseState.dpr);
   ctx.beginPath();
-  ctx.moveTo(leftX, ruleY + 0.5);
-  ctx.lineTo(leftX + (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale / 3, ruleY + 0.5);
+  ctx.moveTo(leftX, ruleY + ruleNudge);
+  ctx.lineTo(leftX + (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale / 3, ruleY + ruleNudge);
   ctx.stroke();
   ctx.restore();
 
@@ -684,10 +696,15 @@ function drawEndnotes(
   const leftX = sec.marginLeft * scale;
   ctx.save();
   ctx.strokeStyle = bodyState.defaultColor;
-  ctx.lineWidth = Math.max(1, Math.round(0.5 * scale));
+  const ruleLw = Math.max(1, Math.round(0.5 * scale));
+  ctx.lineWidth = ruleLw;
+  // Crispness nudge (see crispOffset): device-correct replacement for the old
+  // hardcoded logical `+ 0.5`, which only rendered crisp at dpr=1.
+  const ruleNudge = crispOffset(ruleLw, bodyState.dpr);
+  const ruleY = Math.round(y);
   ctx.beginPath();
-  ctx.moveTo(leftX, Math.round(y) + 0.5);
-  ctx.lineTo(leftX + (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale / 3, Math.round(y) + 0.5);
+  ctx.moveTo(leftX, ruleY + ruleNudge);
+  ctx.lineTo(leftX + (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale / 3, ruleY + ruleNudge);
   ctx.stroke();
   ctx.restore();
 
@@ -1122,6 +1139,7 @@ function buildMeasureState(
   return {
     ctx,
     scale: 1,
+    dpr: 1,
     contentX: 0,
     contentW: section.pageWidth - section.marginLeft - section.marginRight,
     y: 0,
@@ -1995,7 +2013,7 @@ function renderEmptyMarkParagraph(
   }
   state.y += emptyH;
   if (para.borders && !dryRun) {
-    drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale);
+    drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale, state.dpr);
   }
   // Only the slice covering the FINAL line emits spaceAfter. With no inline
   // lines there is a single slice, so this is the whole paragraph.
@@ -2490,6 +2508,10 @@ function renderParagraph(
 
         const lineColor = revColor ?? (s.color ? `#${s.color}` : defaultColor);
         const lineW = Math.max(0.5, effSizePx * 0.05);
+        // Crispness nudge (see crispOffset): underline / strike-through are
+        // horizontal strokes; an odd device-width one lands crisp on a single
+        // device row only when offset by half a device pixel in Y.
+        const lineNudge = crispOffset(lineW, state.dpr);
         // Underline / strike run the full stretched glyph span (natural glyph
         // width + the internal justification pitch).
         const textW = ctx.measureText(s.text).width + internalStretch;
@@ -2500,22 +2522,22 @@ function renderParagraph(
         if (s.underline || isInsertion) {
           ctx.strokeStyle = lineColor;
           ctx.lineWidth = lineW;
-          const uy = baseline + yOffset + effSizePx * 0.12;
+          const uy = baseline + yOffset + effSizePx * 0.12 + lineNudge;
           ctx.beginPath(); ctx.moveTo(x, uy); ctx.lineTo(x + textW, uy); ctx.stroke();
         }
 
         if (s.strikethrough || isDeletion) {
           ctx.strokeStyle = lineColor;
           ctx.lineWidth = lineW;
-          const sy = baseline + yOffset - effSizePx * 0.3;
+          const sy = baseline + yOffset - effSizePx * 0.3 + lineNudge;
           ctx.beginPath(); ctx.moveTo(x, sy); ctx.lineTo(x + textW, sy); ctx.stroke();
         }
 
         if (s.doubleStrikethrough) {
           ctx.strokeStyle = lineColor;
           ctx.lineWidth = lineW;
-          const sy1 = baseline + yOffset - effSizePx * 0.35;
-          const sy2 = baseline + yOffset - effSizePx * 0.22;
+          const sy1 = baseline + yOffset - effSizePx * 0.35 + lineNudge;
+          const sy2 = baseline + yOffset - effSizePx * 0.22 + lineNudge;
           ctx.beginPath(); ctx.moveTo(x, sy1); ctx.lineTo(x + textW, sy1); ctx.stroke();
           ctx.beginPath(); ctx.moveTo(x, sy2); ctx.lineTo(x + textW, sy2); ctx.stroke();
         }
@@ -2538,7 +2560,7 @@ function renderParagraph(
 
   if (para.borders && !dryRun) {
     const textH = state.y - textAreaTopY;
-    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale);
+    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale, state.dpr);
   }
 
   // spaceAfter is paragraph-level; only emit it on the slice that covers
@@ -4360,7 +4382,7 @@ function renderCell(
     ctx.fillRect(x, y, w, h);
   }
 
-  drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale, mirror);
+  drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale, mirror, state.dpr);
 
   const cm = effCellMargins(cell, table);
   const mt = cm.top * scale;
@@ -4472,6 +4494,7 @@ function drawCellBorders(
   table: TableBorders,
   scale: number,
   mirror = false,
+  dpr = 1,
 ): void {
   const top = cell.top ?? table.top;
   const bottom = cell.bottom ?? table.bottom;
@@ -4481,10 +4504,10 @@ function drawCellBorders(
   const left = mirror ? (cell.right ?? table.right) : (cell.left ?? table.left);
   const right = mirror ? (cell.left ?? table.left) : (cell.right ?? table.right);
 
-  if (top && top.style !== 'none') drawBorderLine(ctx, x, y, x + w, y, top, scale);
-  if (bottom && bottom.style !== 'none') drawBorderLine(ctx, x, y + h, x + w, y + h, bottom, scale);
-  if (left && left.style !== 'none') drawBorderLine(ctx, x, y, x, y + h, left, scale);
-  if (right && right.style !== 'none') drawBorderLine(ctx, x + w, y, x + w, y + h, right, scale);
+  if (top && top.style !== 'none') drawBorderLine(ctx, x, y, x + w, y, top, scale, dpr);
+  if (bottom && bottom.style !== 'none') drawBorderLine(ctx, x, y + h, x + w, y + h, bottom, scale, dpr);
+  if (left && left.style !== 'none') drawBorderLine(ctx, x, y, x, y + h, left, scale, dpr);
+  if (right && right.style !== 'none') drawBorderLine(ctx, x + w, y, x + w, y + h, right, scale, dpr);
 }
 
 function drawBorderLine(
@@ -4492,13 +4515,26 @@ function drawBorderLine(
   x1: number, y1: number, x2: number, y2: number,
   spec: BorderSpec,
   scale: number,
+  dpr = 1,
 ): void {
   ctx.save();
   ctx.strokeStyle = spec.color ? `#${spec.color}` : '#000000';
-  ctx.lineWidth = Math.max(0.5, spec.width * scale);
+  const lw = Math.max(0.5, spec.width * scale);
+  ctx.lineWidth = lw;
+  // Crispness nudge (see crispOffset): a thin (odd device-width) axis-aligned
+  // stroke on an integer coordinate straddles two device rows and blurs; nudging
+  // it by half a device pixel perpendicular to the line centers it on one row.
+  // Cell / paragraph borders are always horizontal (y1===y2) or vertical
+  // (x1===x2) — never diagonal — so the orientation is read directly from the
+  // endpoints. An even device width gets 0 (already crisp on the integer edge).
+  const horizontal = y1 === y2;
+  const vertical = x1 === x2;
+  const nudge = horizontal || vertical ? crispOffset(lw, dpr) : 0;
+  const dpx = vertical ? nudge : 0;
+  const dpy = horizontal ? nudge : 0;
   ctx.beginPath();
-  ctx.moveTo(x1, y1);
-  ctx.lineTo(x2, y2);
+  ctx.moveTo(x1 + dpx, y1 + dpy);
+  ctx.lineTo(x2 + dpx, y2 + dpy);
   ctx.stroke();
   ctx.restore();
 }
@@ -4508,11 +4544,12 @@ function drawParaBorders(
   x: number, y: number, w: number, h: number,
   borders: ParagraphBorders,
   scale: number,
+  dpr = 1,
 ): void {
   const drawEdge = (edge: ParaBorderEdge | null, x1: number, y1: number, x2: number, y2: number) => {
     if (!edge || edge.style === 'none') return;
     const spec: BorderSpec = { width: edge.width, color: edge.color, style: edge.style };
-    drawBorderLine(ctx, x1, y1, x2, y2, spec, scale);
+    drawBorderLine(ctx, x1, y1, x2, y2, spec, scale, dpr);
   };
   const sp = (edge: ParaBorderEdge | null) => (edge?.space ?? 0) * scale;
   drawEdge(borders.top,    x, y - sp(borders.top),         x + w, y - sp(borders.top));

--- a/packages/node/src/docx-border-crisp.probe.test.ts
+++ b/packages/node/src/docx-border-crisp.probe.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Device-pixel crispness probe for the docx border / rule fix.
+ *
+ * Background: on a DPR=1 monitor a thin (1 logical px) axis-aligned docx stroke —
+ * a table-cell border, a paragraph border, or a footnote/endnote separator rule —
+ * rendered blurry (~2 device rows at ~50% ink each) instead of Word's crisp 1px.
+ * Root cause: `renderDocumentToCanvas` applies `ctx.scale(dpr,dpr)`, so drawing is
+ * in logical px; a `lineWidth=1` stroke at an INTEGER y has its span `[y-0.5,
+ * y+0.5]` in device space → it straddles two device rows (each ~50% ink →
+ * antialiased blur). The fix nudges the coordinate by `crispOffset(lw, dpr)`
+ * (= `0.5/dpr` only when the device-pixel width is odd) perpendicular to the line,
+ * centering odd-width strokes on a single device row (crisp).
+ *
+ * This test MEASURES device pixels (not eyeballs). The committed demo/sample-1.docx
+ * has no cleanly isolatable thin horizontal border, so — mirroring the xlsx probe
+ * (xlsx-border-crisp.probe.test.ts) — this probe INJECTS one synthetic paragraph
+ * carrying a thin PURE-BLACK bottom border (#000000) at the top of the parsed body,
+ * renders at dpr=1, and reads the vertical luminance profile across that border.
+ * The document is rendered at `width = pageWidth` (scale = 1 px/pt) and the border
+ * width is 1 pt, so `drawBorderLine`'s `Math.max(0.5, width*scale)` resolves to
+ * lineWidth = 1 logical px → device width 1 (odd) at dpr=1 and 2 (even) at dpr=2.
+ *
+ * This committed test asserts the FIXED state (crisp single near-black device row
+ * at dpr=1; clean 2-device-row band at dpr=2). It fails against the pre-fix
+ * renderer, so it is a genuine regression guard — not a tautology.
+ *
+ * CI-safe: skia-canvas ships a native binding CI omits, and docx.ts statically
+ * imports gitignored WASM glue, so the suite is gated with
+ * `describe.skipIf(!skia || !docxMod)` — both loaded via caught dynamic import.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import type { DocxDocumentModel, DocParagraph, BodyElement } from '@silurus/ooxml-docx';
+
+const skia = await import('skia-canvas').catch(() => null);
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+
+// docx.ts statically imports the gitignored WASM glue (docx_parser.js). In CI
+// `pnpm test` runs BEFORE `pnpm build:wasm`, so a static import here would fail at
+// collection; load it dynamically and skip when absent — same gate as skia.
+const docxMod = await import('./docx.ts').catch(() => null);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed for border probe');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const SAMPLE = resolve(ROOT, 'packages/docx/public/demo/sample-1.docx');
+// Load the renderer from source by absolute path. The @silurus/ooxml-docx package
+// ships no built entry (source-only in the monorepo), so importing the package
+// specifier at runtime fails to resolve — mirror the xlsx probe, which imports
+// render-orchestrator.ts directly by path (the type-only import above still uses
+// the package specifier, resolved by TS for typecheck and erased at runtime).
+const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
+const rendererMod = await import(RENDERER_PATH).catch(() => null);
+// Opt-in diagnostics: set PROBE_OUT to a directory to dump the full render plus
+// an 8x crop of the measured border. Null by default → the test writes no files.
+const OUT_DIR = process.env.PROBE_OUT ?? null;
+
+function lum(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/** Parse the sample and splice a single empty paragraph carrying a thin
+ *  pure-black BOTTOM border at the top of the body. Rendered at scale = 1 px/pt,
+ *  the 1 pt border resolves to lineWidth = 1 logical px (Math.max(0.5, 1*1)). */
+function buildInjected(): DocxDocumentModel {
+  if (!docxMod) throw new Error('docx WASM unavailable (run pnpm build:wasm)');
+  const { parseDocx } = docxMod;
+  const buf = readFileSync(SAMPLE);
+  const doc = parseDocx(buf);
+
+  // A standalone paragraph with no runs, no shading, and ONLY a thin black
+  // bottom border (space 0 so it sits at the bottom of the empty mark line).
+  // Surrounded by blank paragraphs to guarantee a white region above & below.
+  const blank = (): BodyElement =>
+    ({
+      type: 'paragraph',
+      alignment: 'left',
+      indentLeft: 0,
+      indentRight: 0,
+      indentFirst: 0,
+      spaceBefore: 0,
+      spaceAfter: 6,
+      lineSpacing: null,
+      numbering: null,
+      tabStops: [],
+      runs: [],
+      borders: null,
+    }) as unknown as BodyElement;
+
+  const bordered: BodyElement = {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 6,
+    spaceAfter: 6,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: [],
+    borders: {
+      top: null,
+      bottom: { style: 'single', color: '000000', width: 1, space: 0 },
+      left: null,
+      right: null,
+      between: null,
+    },
+  } as unknown as DocParagraph as unknown as BodyElement;
+
+  // Replace the body with ONLY the injected paragraphs. The parse still exercises
+  // the real WASM parser (and gives a real `section`), but rendering a tiny body
+  // keeps the probe fast and the injected border guaranteed-isolated in white
+  // (no surrounding content, images, or shading to interfere). Headers/footers /
+  // notes are dropped for the same reason.
+  doc.body = [blank(), bordered, blank()];
+  doc.headers = { default: null, first: null, even: null };
+  doc.footers = { default: null, first: null, even: null };
+  doc.footnotes = [];
+  doc.endnotes = [];
+  return doc;
+}
+
+async function renderInjected(dpr: number): Promise<{
+  data: Uint8ClampedArray;
+  w: number;
+  h: number;
+  canvas: InstanceType<typeof Canvas>;
+}> {
+  const doc = buildInjected();
+  const { renderDocumentToCanvas } = rendererMod as {
+    renderDocumentToCanvas: (
+      doc: DocxDocumentModel,
+      canvas: unknown,
+      pageIndex: number,
+      opts: { dpr: number; width: number },
+    ) => Promise<void>;
+  };
+  // Render at scale = 1 px/pt so the 1 pt border = lineWidth 1 logical px.
+  const widthPx = doc.section.pageWidth; // pt → px at scale 1
+  const heightPx = doc.section.pageHeight;
+  const canvas = new Canvas(Math.round(widthPx * dpr), Math.round(heightPx * dpr));
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr, width: widthPx });
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const w = canvas.width;
+  const h = canvas.height;
+  const img = ctx.getImageData(0, 0, w, h);
+  return { data: img.data, w, h, canvas };
+}
+
+/** Locate the injected thin horizontal border: the dark (greyscale, near-neutral)
+ *  horizontal run that is ISOLATED in white (white ~3*dpr px above AND below).
+ *  Works for BOTH the crisp AFTER case (a single pure-black row, L≈0) and the
+ *  blurry BEFORE case (two adjacent mid-grey rows, L≈128 each, ink split 50/50).
+ *  The injected paragraph is the FIRST body content, so the topmost qualifying
+ *  isolated dark run is the injected border. */
+function findInjectedBlackBorder(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  dpr: number,
+): { x: number; y: number; runLen: number } {
+  const isDarkNeutral = (i: number): boolean => {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const L = lum(r, g, b);
+    const spread = Math.max(r, g, b) - Math.min(r, g, b);
+    return L < 170 && spread < 24;
+  };
+  const isLight = (i: number): boolean =>
+    lum(data[i], data[i + 1], data[i + 2]) > 200;
+  const minRun = Math.round(60 * dpr); // border spans most of the content width
+  const gap = 3 * dpr;
+  // Scan top-to-bottom and return the FIRST isolated dark horizontal run (the
+  // injected paragraph is the first body element, above all real content).
+  for (let y = gap; y < h - gap; y++) {
+    let cur = 0;
+    let curStart = -1;
+    let found: { x: number; y: number; runLen: number } | null = null;
+    for (let x = 0; x <= w; x++) {
+      const i = (y * w + x) * 4;
+      const dark = x < w && isDarkNeutral(i);
+      if (dark) {
+        if (curStart < 0) curStart = x;
+        cur++;
+      } else {
+        if (cur >= minRun) {
+          const mx = curStart + Math.floor(cur / 2);
+          const aboveWhite = isLight(((y - gap) * w + mx) * 4);
+          const belowWhite = isLight(((y + gap) * w + mx) * 4);
+          if (aboveWhite && belowWhite) {
+            found = { x: mx, y, runLen: cur };
+            break;
+          }
+        }
+        cur = 0;
+        curStart = -1;
+      }
+    }
+    if (found) return found;
+  }
+  return { x: -1, y: -1, runLen: 0 };
+}
+
+function vProfile(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  x: number,
+  y: number,
+  span = 3,
+): { ys: number[]; L: number[] } {
+  const ys: number[] = [];
+  const L: number[] = [];
+  for (let dy = -span; dy <= span; dy++) {
+    const yy = y + dy;
+    ys.push(yy);
+    if (yy < 0 || yy >= h) {
+      L.push(NaN);
+      continue;
+    }
+    const i = (yy * w + x) * 4;
+    L.push(lum(data[i], data[i + 1], data[i + 2]));
+  }
+  return { ys, L };
+}
+
+/** Recenter on the darkest row within ±r so a 2-row blurry band reports
+ *  symmetrically around its center of mass. */
+function darkestNear(
+  data: Uint8ClampedArray,
+  w: number,
+  x: number,
+  y: number,
+  r = 2,
+): number {
+  let cy = y;
+  let best = Infinity;
+  for (let dy = -r; dy <= r; dy++) {
+    const i = ((y + dy) * w + x) * 4;
+    const L = lum(data[i], data[i + 1], data[i + 2]);
+    if (L < best) {
+      best = L;
+      cy = y + dy;
+    }
+  }
+  return cy;
+}
+
+function saveZoomCrop(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  cx: number,
+  cy: number,
+  outPath: string,
+): void {
+  const CROP = 24;
+  const ZOOM = 8;
+  const half = CROP / 2;
+  const x0 = Math.max(0, Math.min(w - CROP, cx - half));
+  const y0 = Math.max(0, Math.min(h - CROP, cy - half));
+  const out = new Canvas(CROP * ZOOM, CROP * ZOOM);
+  const octx = out.getContext('2d') as unknown as CanvasRenderingContext2D;
+  for (let yy = 0; yy < CROP; yy++) {
+    for (let xx = 0; xx < CROP; xx++) {
+      const i = ((y0 + yy) * w + (x0 + xx)) * 4;
+      octx.fillStyle = `rgb(${data[i]},${data[i + 1]},${data[i + 2]})`;
+      octx.fillRect(xx * ZOOM, yy * ZOOM, ZOOM, ZOOM);
+    }
+  }
+  const png = (
+    out as unknown as { toBufferSync?: (f: string) => Buffer }
+  ).toBufferSync?.('png');
+  if (png) writeFileSync(outPath, png);
+}
+
+function savePng(canvas: InstanceType<typeof Canvas>, outPath: string): void {
+  const png = (
+    canvas as unknown as { toBufferSync?: (f: string) => Buffer }
+  ).toBufferSync?.('png');
+  if (png) writeFileSync(outPath, png);
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)(
+  'docx border crispness (device-pixel probe)',
+  () => {
+    it('injected thin black horizontal border at dpr=1 collapses to one near-black device row', async () => {
+      const { data, w, h, canvas } = await renderInjected(1);
+
+      const hit = findInjectedBlackBorder(data, w, h, 1);
+      expect(hit.x).toBeGreaterThanOrEqual(0);
+
+      const cy = darkestNear(data, w, hit.x, hit.y, 2);
+      const { ys, L } = vProfile(data, w, h, hit.x, cy, 3);
+      const finite = L.filter((v) => !Number.isNaN(v));
+      const minLum = Math.min(...finite);
+      const darkRowCount = finite.filter((v) => v < 160).length;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `\n[PROBE dpr=1] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+          ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
+          `\n  minLum=${minLum.toFixed(1)} darkRowCount(<160)=${darkRowCount}`,
+      );
+
+      if (OUT_DIR) {
+        mkdirSync(OUT_DIR, { recursive: true });
+        savePng(canvas, resolve(OUT_DIR, 'docx-border-after.png'));
+        saveZoomCrop(data, w, h, hit.x, cy, resolve(OUT_DIR, 'docx-crop-after-8x.png'));
+      }
+
+      // A thin (1 device px) black border must collapse to one near-black row.
+      expect(minLum).toBeLessThan(80);
+      expect(darkRowCount).toBe(1);
+    }, 30000);
+
+    it('dpr=2 sanity: thin border = even device width → clean 2-row band (no over-correction)', async () => {
+      const { data, w, h } = await renderInjected(2);
+
+      const hit = findInjectedBlackBorder(data, w, h, 2);
+      expect(hit.x).toBeGreaterThanOrEqual(0);
+
+      const cy = darkestNear(data, w, hit.x, hit.y, 3);
+      const { ys, L } = vProfile(data, w, h, hit.x, cy, 3);
+      const finite = L.filter((v) => !Number.isNaN(v));
+      const darkRowCount = finite.filter((v) => v < 160).length;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `\n[PROBE dpr=2] injected border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+          ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
+          `\n  darkRowCount(<160)=${darkRowCount}`,
+      );
+
+      // deviceW=2 (even) → no offset → a clean 2-device-row band, NOT 3.
+      expect(darkRowCount).toBeLessThanOrEqual(2);
+    }, 30000);
+  },
+);

--- a/packages/node/src/pptx-line-crisp.probe.test.ts
+++ b/packages/node/src/pptx-line-crisp.probe.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Device-pixel crispness probe for the pptx axis-aligned thin-line fix.
+ *
+ * Background: on a DPR=1 monitor pptx table cell borders (and text underline /
+ * strike-through) rendered blurry (~2 device rows at ~50% ink each) instead of
+ * PowerPoint's crisp 1px. Root cause: `renderSlide` applies `ctx.scale(dpr,dpr)`,
+ * so drawing is in logical px; a `lineWidth=1` stroke at an INTEGER y has its
+ * span `[y-0.5, y+0.5]` in device space → it straddles two device rows (each
+ * ~50% ink → antialiased blur). The fix (renderer.ts `renderTable` /
+ * `drawUnderline` / strike-through) adds a half-device-pixel offset
+ * `crispOffset(lw, dpr) = 0.5/dpr` ONLY when the device-pixel width is odd,
+ * centering odd-width strokes on a single device row (crisp).
+ *
+ * This test MEASURES device pixels (not eyeballs). It builds a synthetic
+ * Presentation in memory (no .pptx file, no WASM parse) containing a single
+ * table cell carrying a thin PURE-BLACK bottom border (1 logical px) on the
+ * default white background, renders it through `renderSlideNode` at dpr=1 and
+ * dpr=2, and reads the vertical luminance profile across that border. Pure black
+ * on white is unambiguous, and the cell's geometry is chosen so the border's
+ * bottom edge lands on an INTEGER device-y at dpr=1 (the worst case: an integer
+ * coordinate straddles two rows without the fix).
+ *
+ * This committed test asserts the FIXED state (crisp single near-black device
+ * row at dpr=1; clean 2-device-row band at dpr=2). It fails against the pre-fix
+ * renderer, so it is a genuine regression guard — not a tautology.
+ *
+ * CI-safe: skia-canvas ships a native binding CI omits, so the suite is gated
+ * with `describe.skipIf(!skia)`. The render helper (`./render.ts`) and the pptx
+ * renderer it dynamically imports do NOT statically import WASM, but to stay
+ * future-proof the render module is itself loaded via a caught dynamic import and
+ * gated too.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Presentation, Slide, TableElement, Stroke } from '@silurus/ooxml-pptx';
+
+const skia = await import('skia-canvas').catch(() => null);
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+
+// `./render.ts` does not statically import WASM today, but load it via a caught
+// dynamic import (and gate on it) so the suite never fails at collection if that
+// ever changes.
+const renderMod = await import('./render.ts').catch(() => null);
+
+const EMU_PER_PX = 9525; // 96 dpi → 1 logical px
+
+// Slide / table geometry, all in EMU so logical px == EMU / EMU_PER_PX when the
+// render width matches the slide's px width.
+const SLIDE_W_PX = 960;
+const SLIDE_H_PX = 540;
+const TABLE_X_PX = 100;
+const TABLE_Y_PX = 100;
+const COL_W_PX = 200;
+const ROW_H_PX = 80;
+// Bottom edge of the single cell, in logical px: integer 180. At dpr=1 the
+// device row is 180 (worst case — straddles two rows without the fix); at dpr=2
+// it is 360 (even device width → clean 2-row band, no over-correction).
+const BORDER_Y_PX = TABLE_Y_PX + ROW_H_PX; // 180
+
+function lum(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/** A single-cell table whose only inked edge is a thin pure-black bottom
+ *  border (1 logical px), on the default white slide background. */
+function buildTableSlide(): Presentation {
+  const blackThin: Stroke = { color: '#000000', width: EMU_PER_PX }; // 1 logical px
+  const cell = {
+    textBody: null,
+    fill: null,
+    borderL: null,
+    borderR: null,
+    borderT: null,
+    borderB: blackThin,
+    gridSpan: 1,
+    rowSpan: 1,
+    hMerge: false,
+    vMerge: false,
+  };
+  const table: TableElement = {
+    type: 'table',
+    x: TABLE_X_PX * EMU_PER_PX,
+    y: TABLE_Y_PX * EMU_PER_PX,
+    width: COL_W_PX * EMU_PER_PX,
+    height: ROW_H_PX * EMU_PER_PX,
+    cols: [COL_W_PX * EMU_PER_PX],
+    rows: [{ height: ROW_H_PX * EMU_PER_PX, cells: [cell] }],
+  };
+  const slide: Slide = {
+    index: 0,
+    slideNumber: 1,
+    background: null, // → white
+    elements: [table],
+  };
+  return {
+    slideWidth: SLIDE_W_PX * EMU_PER_PX,
+    slideHeight: SLIDE_H_PX * EMU_PER_PX,
+    slides: [slide],
+    defaultTextColor: null,
+    majorFont: null,
+    minorFont: null,
+  };
+}
+
+async function renderTableSlide(
+  dpr: number,
+): Promise<{ data: Uint8ClampedArray; w: number; h: number; canvas: InstanceType<typeof Canvas> }> {
+  if (!renderMod) throw new Error('render module unavailable');
+  const { renderSlideNode } = renderMod;
+  const canvas = new Canvas(Math.round(SLIDE_W_PX * dpr), Math.round(SLIDE_H_PX * dpr));
+  await renderSlideNode(
+    canvas as unknown as Parameters<typeof renderSlideNode>[0],
+    buildTableSlide(),
+    0,
+    { width: SLIDE_W_PX, dpr },
+  );
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const w = canvas.width;
+  const h = canvas.height;
+  const img = ctx.getImageData(0, 0, w, h);
+  return { data: img.data, w, h, canvas };
+}
+
+/** Locate the injected thin black bottom border: the only dark, near-neutral
+ *  horizontal run isolated in white (white a few px above AND below). Works for
+ *  BOTH the crisp AFTER case (one pure-black row, L≈0) and the blurry BEFORE
+ *  case (two adjacent mid-grey rows, L≈128 each, ink split 50/50). */
+function findBlackHLine(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  dpr: number,
+): { x: number; y: number; runLen: number } {
+  const isDarkNeutral = (i: number): boolean => {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const L = lum(r, g, b);
+    const spread = Math.max(r, g, b) - Math.min(r, g, b);
+    return L < 170 && spread < 24;
+  };
+  const isLight = (i: number): boolean =>
+    lum(data[i], data[i + 1], data[i + 2]) > 200;
+  const minRun = Math.round(120 * dpr); // 200-px-wide cell → ~200*dpr px run
+  const gap = Math.round(4 * dpr);
+  let best = { x: -1, y: -1, runLen: 0 };
+  for (let y = gap; y < h - gap; y++) {
+    let cur = 0;
+    let curStart = -1;
+    for (let x = 0; x <= w; x++) {
+      const i = (y * w + x) * 4;
+      const dark = x < w && isDarkNeutral(i);
+      if (dark) {
+        if (curStart < 0) curStart = x;
+        cur++;
+      } else {
+        if (cur >= minRun) {
+          const mx = curStart + Math.floor(cur / 2);
+          const aboveWhite = isLight(((y - gap) * w + mx) * 4);
+          const belowWhite = isLight(((y + gap) * w + mx) * 4);
+          if (aboveWhite && belowWhite && cur > best.runLen) {
+            best = { x: mx, y, runLen: cur };
+          }
+        }
+        cur = 0;
+        curStart = -1;
+      }
+    }
+  }
+  return best;
+}
+
+function vProfile(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  x: number,
+  y: number,
+  span = 3,
+): { ys: number[]; L: number[] } {
+  const ys: number[] = [];
+  const L: number[] = [];
+  for (let dy = -span; dy <= span; dy++) {
+    const yy = y + dy;
+    ys.push(yy);
+    if (yy < 0 || yy >= h) {
+      L.push(NaN);
+      continue;
+    }
+    const i = (yy * w + x) * 4;
+    L.push(lum(data[i], data[i + 1], data[i + 2]));
+  }
+  return { ys, L };
+}
+
+/** Recenter on the darkest row within ±r so a 2-row blurry band reports
+ *  symmetrically around its center of mass. */
+function darkestNear(
+  data: Uint8ClampedArray,
+  w: number,
+  x: number,
+  y: number,
+  r = 2,
+): number {
+  let cy = y;
+  let best = Infinity;
+  for (let dy = -r; dy <= r; dy++) {
+    const i = ((y + dy) * w + x) * 4;
+    const L = lum(data[i], data[i + 1], data[i + 2]);
+    if (L < best) {
+      best = L;
+      cy = y + dy;
+    }
+  }
+  return cy;
+}
+
+describe.skipIf(!skia || !renderMod)('pptx line crispness (device-pixel probe)', () => {
+  it('thin black table border at dpr=1 collapses to one near-black device row', async () => {
+    const { data, w, h } = await renderTableSlide(1);
+
+    const hit = findBlackHLine(data, w, h, 1);
+    expect(hit.x).toBeGreaterThanOrEqual(0);
+
+    const cy = darkestNear(data, w, hit.x, hit.y, 2);
+    const { ys, L } = vProfile(data, w, h, hit.x, cy, 3);
+    const finite = L.filter((v) => !Number.isNaN(v));
+    const minLum = Math.min(...finite);
+    const darkRowCount = finite.filter((v) => v < 160).length;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[PROBE dpr=1] border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+        ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
+        `\n  minLum=${minLum.toFixed(1)} darkRowCount(<160)=${darkRowCount}`,
+    );
+
+    // A thin (1 device px) black border must collapse to one near-black row.
+    expect(minLum).toBeLessThan(80);
+    expect(darkRowCount).toBe(1);
+  });
+
+  it('dpr=2 sanity: thin border = even device width → clean 2-row band (no over-correction)', async () => {
+    const { data, w, h } = await renderTableSlide(2);
+
+    const hit = findBlackHLine(data, w, h, 2);
+    expect(hit.x).toBeGreaterThanOrEqual(0);
+
+    const cy = darkestNear(data, w, hit.x, hit.y, 3);
+    const { ys, L } = vProfile(data, w, h, hit.x, cy, 4);
+    const finite = L.filter((v) => !Number.isNaN(v));
+    const darkRowCount = finite.filter((v) => v < 160).length;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[PROBE dpr=2] border @ (x=${hit.x}, y=${cy}) runLen=${hit.runLen}\n` +
+        ys.map((yy, k) => `  y=${yy} L=${L[k].toFixed(1)}`).join('\n') +
+        `\n  darkRowCount(<160)=${darkRowCount}`,
+    );
+
+    // deviceW=2 (even) → no offset → a clean 2-device-row band, NOT 3.
+    expect(darkRowCount).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -19,6 +19,7 @@ import type {
 } from './types';
 import {
   renderChart,
+  crispOffset,
   buildCustomPath as buildCustomPathCore,
   hexToRgba as hexToRgbaCore,
   resolveFill as resolveFillCore,
@@ -78,6 +79,14 @@ export interface RenderContext {
   themeMinorFont: string | null;
   /** Theme hyperlink colour as a 6-char hex (no leading #), or null. */
   themeHlinkColor?: string | null;
+  /**
+   * Device-pixel ratio the slide is being drawn at (the `dpr` passed to
+   * `ctx.scale(dpr, dpr)` in the top render fn). Threaded so axis-aligned
+   * thin line strokes (table grid borders, text underline / strike-through)
+   * can apply {@link crispOffset} and render crisp on a DPR=1 display.
+   * Defaults to 1 (no nudge) when unset.
+   */
+  dpr?: number;
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -190,11 +199,18 @@ function drawUnderline(
   sizePx: number,
   color: string,
   style: string | undefined,
+  dpr = 1,
 ): void {
   const baseLineW = Math.max(1, sizePx * 0.05);
   const heavy = style?.endsWith('Heavy') ?? false;
   const lineW = heavy ? baseLineW * 1.8 : baseLineW;
   const y = baseline + Math.max(2, lineW);
+  // Crispness nudge (see crispOffset): a horizontal underline whose device-pixel
+  // width is odd straddles two device rows on a DPR=1 display (blurry). Shifting
+  // the line's y by half a device px centers an odd-width stroke on one device
+  // row → crisp. Applied to the straight / dbl / dashed branches only; the wavy
+  // variant is not axis-aligned per pixel, so it deliberately omits the offset.
+  const crispY = crispOffset(lineW, dpr);
   ctx.strokeStyle = color;
   ctx.lineWidth = lineW;
   ctx.setLineDash([]);
@@ -246,18 +262,18 @@ function drawUnderline(
   if (style === 'dbl') {
     const offset = lineW * 1.4;
     ctx.beginPath();
-    ctx.moveTo(x, y - offset / 2);
-    ctx.lineTo(x + width, y - offset / 2);
-    ctx.moveTo(x, y + offset / 2);
-    ctx.lineTo(x + width, y + offset / 2);
+    ctx.moveTo(x, y - offset / 2 + crispY);
+    ctx.lineTo(x + width, y - offset / 2 + crispY);
+    ctx.moveTo(x, y + offset / 2 + crispY);
+    ctx.lineTo(x + width, y + offset / 2 + crispY);
     ctx.stroke();
     return;
   }
 
   ctx.setLineDash(dashFor(style ?? 'sng').map((v) => v * lineW));
   ctx.beginPath();
-  ctx.moveTo(x, y);
-  ctx.lineTo(x + width, y);
+  ctx.moveTo(x, y + crispY);
+  ctx.lineTo(x + width, y + crispY);
   ctx.stroke();
   ctx.setLineDash([]);
 }
@@ -2502,7 +2518,7 @@ function renderTextBody(
       }
 
       if (seg.underline) {
-        drawUnderline(ctx, penX, segBaseline, segW + jext, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle);
+        drawUnderline(ctx, penX, segBaseline, segW + jext, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle, rc.dpr ?? 1);
       }
 
       if (seg.strikethrough) {
@@ -2510,12 +2526,16 @@ function renderTextBody(
         ctx.strokeStyle = seg.color;
         ctx.lineWidth = lineW;
         ctx.setLineDash([]);
+        // Crispness nudge (see crispOffset): the strike is a horizontal stroke,
+        // so an odd device-pixel width is centered on one device row by shifting
+        // y half a device px at DPR=1 (otherwise it straddles two rows → blurry).
+        const crispY = crispOffset(lineW, rc.dpr ?? 1);
         if (seg.strikeDouble) {
           // Two parallel lines straddling the standard strike position,
           // separated by ~ 1.5× the line weight (visually distinct yet
           // staying inside the glyph's central band).
           const offset = lineW * 0.9;
-          const yMid = segBaseline - seg.sizePx * 0.32;
+          const yMid = segBaseline - seg.sizePx * 0.32 + crispY;
           ctx.beginPath();
           ctx.moveTo(penX, yMid - offset);
           ctx.lineTo(penX + segW + jext, yMid - offset);
@@ -2523,9 +2543,10 @@ function renderTextBody(
           ctx.lineTo(penX + segW + jext, yMid + offset);
           ctx.stroke();
         } else {
+          const yMid = segBaseline - seg.sizePx * 0.32 + crispY;
           ctx.beginPath();
-          ctx.moveTo(penX, segBaseline - seg.sizePx * 0.32);
-          ctx.lineTo(penX + segW + jext, segBaseline - seg.sizePx * 0.32);
+          ctx.moveTo(penX, yMid);
+          ctx.lineTo(penX + segW + jext, yMid);
           ctx.stroke();
         }
       }
@@ -3714,33 +3735,46 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
       }
 
       // Borders
+      // Crispness nudge (see crispOffset): an axis-aligned thin grid line whose
+      // device-pixel width is odd straddles two device rows/cols on a DPR=1
+      // display (each ~50% ink → blurry). Offsetting the integer cell edge by
+      // half a device pixel perpendicular to the line centers an odd-width
+      // stroke on one device row/col → crisp. `applyStroke` sets ctx.lineWidth
+      // to the logical width, so we read it back to pick the right offset.
+      // Horizontal edges (T/B) shift Y; vertical edges (L/R) shift X. Diagonals
+      // can't be pixel-aligned this way, so they are left untouched.
+      const dpr = rc.dpr ?? 1;
       ctx.save();
       if (cell.borderT) {
         applyStroke(ctx, cell.borderT, scale);
+        const dy = crispOffset(ctx.lineWidth, dpr);
         ctx.beginPath();
-        ctx.moveTo(colX, rowY);
-        ctx.lineTo(colX + cellW, rowY);
+        ctx.moveTo(colX, rowY + dy);
+        ctx.lineTo(colX + cellW, rowY + dy);
         ctx.stroke();
       }
       if (cell.borderB) {
         applyStroke(ctx, cell.borderB, scale);
+        const dy = crispOffset(ctx.lineWidth, dpr);
         ctx.beginPath();
-        ctx.moveTo(colX, rowY + cellH);
-        ctx.lineTo(colX + cellW, rowY + cellH);
+        ctx.moveTo(colX, rowY + cellH + dy);
+        ctx.lineTo(colX + cellW, rowY + cellH + dy);
         ctx.stroke();
       }
       if (cell.borderL) {
         applyStroke(ctx, cell.borderL, scale);
+        const dx = crispOffset(ctx.lineWidth, dpr);
         ctx.beginPath();
-        ctx.moveTo(colX, rowY);
-        ctx.lineTo(colX, rowY + cellH);
+        ctx.moveTo(colX + dx, rowY);
+        ctx.lineTo(colX + dx, rowY + cellH);
         ctx.stroke();
       }
       if (cell.borderR) {
         applyStroke(ctx, cell.borderR, scale);
+        const dx = crispOffset(ctx.lineWidth, dpr);
         ctx.beginPath();
-        ctx.moveTo(colX + cellW, rowY);
-        ctx.lineTo(colX + cellW, rowY + cellH);
+        ctx.moveTo(colX + cellW + dx, rowY);
+        ctx.lineTo(colX + cellW + dx, rowY + cellH);
         ctx.stroke();
       }
       // Diagonal borders: top-left→bottom-right and bottom-left→top-right
@@ -3823,6 +3857,7 @@ export async function renderSlide(
     themeMajorFont: opts.majorFont ?? null,
     themeMinorFont: opts.minorFont ?? null,
     themeHlinkColor: opts.hlinkColor ?? null,
+    dpr,
   };
 
   await renderBackground(ctx, slide.background, canvasW, canvasH, scale, opts.fetchImage);

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -3518,16 +3518,6 @@ function renderBorder(
     ctx.stroke();
     ctx.setLineDash([]);
   }
-}
-
-/** Half-device-pixel nudge that keeps an axis-aligned stroke of `logicalWidth`
- *  logical px crisp. ctx.scale(dpr,dpr) maps the width to round(logicalWidth*dpr)
- *  device px; an ODD device width must sit on a pixel *midpoint* (offset 0.5/dpr)
- *  to render as a single sharp row, while an EVEN device width is already crisp
- *  on the integer coordinate (offset 0 — nudging it would straddle two rows and
- *  blur). Returns the coordinate offset to add to an integer-aligned edge. */
-function crispOffset(logicalWidth: number, dpr: number): number {
-  return Math.round(logicalWidth * dpr) % 2 === 1 ? 0.5 / dpr : 0;
 }
 
 function borderStyleWidth(style: string): number {


### PR DESCRIPTION
## Summary

Follow-up to the 0.64.3 xlsx border-crispness fix. Hoist the DPR=1 crisp-line offset into `@silurus/ooxml-core` and apply it to **docx** and **pptx**, which had the same latent blur — thin axis-aligned 1-logical-px strokes drawn on integer coordinates straddle two device rows at dpr=1.

### core
- New `crispOffset(logicalWidth, dpr)` in `packages/core/src/canvas/crisp.ts` (odd device width → `0.5/dpr`, else `0`). xlsx now imports it; the file-local copy is removed (single source of truth).

### docx
- Applied to cell / paragraph borders (`drawBorderLine`), footnote/endnote separator rules (replacing a hardcoded logical `+0.5` that blurred at dpr>1), and underline / strike-through. `dpr` threaded via `RenderState`.

### pptx
- Applied to table cell grid borders (`renderTable`) and text underline / strike-through (`drawUnderline`). `dpr` threaded via `RenderContext`.

Diagonals, path-based shape outlines, glyph outlines, and the wavy underline are deliberately left untouched (not pixel-alignable).

### Verification (device pixels, not eyeballed)
Headless node + skia probes, before → after:

| | dpr=1 before | dpr=1 after | dpr=2 after |
|---|---|---|---|
| xlsx | 2 rows (L=128 ea.) | **1 row (L=0)** | 2 rows (clean) |
| docx | 2 rows (L=128 ea.) | **1 row (L=0)** | 2 rows (clean) |
| pptx | 2 rows (L=128 ea.) | **1 row (L=0)** | 2 rows (clean) |

New committed regression guards: `packages/node/src/{docx-border-crisp,pptx-line-crisp}.probe.test.ts` (skia/WASM-gated via caught dynamic imports — CI-safe; verified they skip cleanly with skia+WASM absent). Full suite: 632 pass; the only 2 failures are **pre-existing**, CI-skipped pptx image-extraction tests unrelated to this change (confirmed by reverting these edits). Typecheck green for core/xlsx/docx/pptx/node.

Merge with `--merge` (no squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)