### PR TITLE
fix: snap-based crispOffset + xlsx coverage (review fixes for #505)

### DIFF
--- a/packages/core/src/canvas/crisp.ts
+++ b/packages/core/src/canvas/crisp.ts
@@ -2,24 +2,27 @@
  * Crisp-line rasterization helper shared by the docx / xlsx / pptx renderers.
  *
  * All three renderers draw in *logical* pixels under `ctx.scale(dpr, dpr)`, so a
- * thin axis-aligned stroke placed on an integer coordinate can straddle two
- * device rows (each at 50% coverage) and render blurry. Nudging the coordinate
- * by half a device pixel centers an odd-device-width stroke on a single device
- * row, which renders crisp.
- */
-
-/**
- * The offset to add to an integer-aligned coordinate so an axis-aligned stroke of
- * `logicalWidth` logical px renders crisp under `ctx.scale(dpr, dpr)`.
+ * thin axis-aligned stroke can land between device rows and render blurry (its
+ * ink spread across two rows at partial coverage). `crispOffset` returns the
+ * delta to add to an axis-aligned stroke's coordinate so it snaps onto the
+ * nearest crisp device position.
  *
- * `ctx.scale(dpr, dpr)` maps the stroke width to `round(logicalWidth * dpr)`
- * device px. An ODD device width must sit on a pixel *midpoint* (offset `0.5/dpr`)
- * to land on one device row; an EVEN device width is already crisp on the integer
- * coordinate and must NOT be nudged (offset `0`), or it straddles and blurs.
+ * Given the stroke's logical `coord` (the x of a vertical line / the y of a
+ * horizontal line) and `logicalWidth`, the device-space width is
+ * `round(logicalWidth * dpr)`. An ODD device width must sit on a pixel *midpoint*
+ * to occupy a single device row; an EVEN device width must sit on an integer
+ * device boundary. We snap `coord` to the nearest such position and return the
+ * (sub-pixel) delta — so the result is correct whether `coord` is integer- or
+ * fractional-aligned, and is `0` for an even width already on the boundary.
  *
  * Only meaningful for axis-aligned (horizontal / vertical) strokes — diagonals,
  * arbitrary paths and glyph outlines cannot be pixel-aligned this way.
  */
-export function crispOffset(logicalWidth: number, dpr: number): number {
-  return Math.round(logicalWidth * dpr) % 2 === 1 ? 0.5 / dpr : 0;
+export function crispOffset(coord: number, logicalWidth: number, dpr: number): number {
+  // Target fractional part (in device px) of the stroke's center: 0.5 for odd
+  // device widths (pixel midpoint), 0 for even (pixel boundary).
+  const target = Math.round(logicalWidth * dpr) % 2 === 1 ? 0.5 : 0;
+  const deviceCoord = coord * dpr;
+  const snapped = Math.round(deviceCoord - target) + target;
+  return snapped / dpr - coord;
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -646,11 +646,11 @@ function drawPageFootnotes(
   ctx.strokeStyle = baseState.defaultColor;
   const ruleLw = Math.max(1, Math.round(0.5 * scale));
   ctx.lineWidth = ruleLw;
-  // Crispness nudge (see crispOffset): a horizontal rule on an integer y needs a
-  // half-device-pixel offset only when its device width is odd. The previous
-  // hardcoded `+ 0.5` was a logical-px offset that only happened to be crisp at
-  // dpr=1 and blurred at dpr>1; crispOffset makes it device-correct at any dpr.
-  const ruleNudge = crispOffset(ruleLw, baseState.dpr);
+  // Crispness nudge (see crispOffset): a horizontal rule snaps onto the nearest
+  // crisp device row from its own y. The previous hardcoded `+ 0.5` was a
+  // logical-px offset that only happened to be crisp at dpr=1 and blurred at
+  // dpr>1; crispOffset makes it device-correct at any dpr and fractional y.
+  const ruleNudge = crispOffset(ruleY, ruleLw, baseState.dpr);
   ctx.beginPath();
   ctx.moveTo(leftX, ruleY + ruleNudge);
   ctx.lineTo(leftX + (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale / 3, ruleY + ruleNudge);
@@ -699,9 +699,10 @@ function drawEndnotes(
   const ruleLw = Math.max(1, Math.round(0.5 * scale));
   ctx.lineWidth = ruleLw;
   // Crispness nudge (see crispOffset): device-correct replacement for the old
-  // hardcoded logical `+ 0.5`, which only rendered crisp at dpr=1.
-  const ruleNudge = crispOffset(ruleLw, bodyState.dpr);
+  // hardcoded logical `+ 0.5`, which only rendered crisp at dpr=1. Snap from the
+  // rule's own y so it stays crisp at any dpr and fractional position.
   const ruleY = Math.round(y);
+  const ruleNudge = crispOffset(ruleY, ruleLw, bodyState.dpr);
   ctx.beginPath();
   ctx.moveTo(leftX, ruleY + ruleNudge);
   ctx.lineTo(leftX + (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale / 3, ruleY + ruleNudge);
@@ -2509,9 +2510,9 @@ function renderParagraph(
         const lineColor = revColor ?? (s.color ? `#${s.color}` : defaultColor);
         const lineW = Math.max(0.5, effSizePx * 0.05);
         // Crispness nudge (see crispOffset): underline / strike-through are
-        // horizontal strokes; an odd device-width one lands crisp on a single
-        // device row only when offset by half a device pixel in Y.
-        const lineNudge = crispOffset(lineW, state.dpr);
+        // horizontal strokes; each snaps onto the nearest crisp device row from
+        // its own y (an odd device-width one would otherwise straddle two rows).
+        // Compute the offset per line because each stroke sits at a different y.
         // Underline / strike run the full stretched glyph span (natural glyph
         // width + the internal justification pitch).
         const textW = ctx.measureText(s.text).width + internalStretch;
@@ -2522,22 +2523,26 @@ function renderParagraph(
         if (s.underline || isInsertion) {
           ctx.strokeStyle = lineColor;
           ctx.lineWidth = lineW;
-          const uy = baseline + yOffset + effSizePx * 0.12 + lineNudge;
+          const uyRaw = baseline + yOffset + effSizePx * 0.12;
+          const uy = uyRaw + crispOffset(uyRaw, lineW, state.dpr);
           ctx.beginPath(); ctx.moveTo(x, uy); ctx.lineTo(x + textW, uy); ctx.stroke();
         }
 
         if (s.strikethrough || isDeletion) {
           ctx.strokeStyle = lineColor;
           ctx.lineWidth = lineW;
-          const sy = baseline + yOffset - effSizePx * 0.3 + lineNudge;
+          const syRaw = baseline + yOffset - effSizePx * 0.3;
+          const sy = syRaw + crispOffset(syRaw, lineW, state.dpr);
           ctx.beginPath(); ctx.moveTo(x, sy); ctx.lineTo(x + textW, sy); ctx.stroke();
         }
 
         if (s.doubleStrikethrough) {
           ctx.strokeStyle = lineColor;
           ctx.lineWidth = lineW;
-          const sy1 = baseline + yOffset - effSizePx * 0.35 + lineNudge;
-          const sy2 = baseline + yOffset - effSizePx * 0.22 + lineNudge;
+          const sy1Raw = baseline + yOffset - effSizePx * 0.35;
+          const sy2Raw = baseline + yOffset - effSizePx * 0.22;
+          const sy1 = sy1Raw + crispOffset(sy1Raw, lineW, state.dpr);
+          const sy2 = sy2Raw + crispOffset(sy2Raw, lineW, state.dpr);
           ctx.beginPath(); ctx.moveTo(x, sy1); ctx.lineTo(x + textW, sy1); ctx.stroke();
           ctx.beginPath(); ctx.moveTo(x, sy2); ctx.lineTo(x + textW, sy2); ctx.stroke();
         }
@@ -4522,16 +4527,15 @@ function drawBorderLine(
   const lw = Math.max(0.5, spec.width * scale);
   ctx.lineWidth = lw;
   // Crispness nudge (see crispOffset): a thin (odd device-width) axis-aligned
-  // stroke on an integer coordinate straddles two device rows and blurs; nudging
-  // it by half a device pixel perpendicular to the line centers it on one row.
-  // Cell / paragraph borders are always horizontal (y1===y2) or vertical
-  // (x1===x2) — never diagonal — so the orientation is read directly from the
-  // endpoints. An even device width gets 0 (already crisp on the integer edge).
+  // stroke straddles two device rows and blurs; nudging it perpendicular to the
+  // line snaps it onto the nearest crisp device position. Cell / paragraph
+  // borders are always horizontal (y1===y2) or vertical (x1===x2) — never
+  // diagonal — so the orientation is read directly from the endpoints, and the
+  // snap delta is derived from the line's own coordinate (fractional-safe).
   const horizontal = y1 === y2;
   const vertical = x1 === x2;
-  const nudge = horizontal || vertical ? crispOffset(lw, dpr) : 0;
-  const dpx = vertical ? nudge : 0;
-  const dpy = horizontal ? nudge : 0;
+  const dpx = vertical ? crispOffset(x1, lw, dpr) : 0;
+  const dpy = horizontal ? crispOffset(y1, lw, dpr) : 0;
   ctx.beginPath();
   ctx.moveTo(x1 + dpx, y1 + dpy);
   ctx.lineTo(x2 + dpx, y2 + dpy);

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -84,9 +84,11 @@ export interface RenderContext {
    * `ctx.scale(dpr, dpr)` in the top render fn). Threaded so axis-aligned
    * thin line strokes (table grid borders, text underline / strike-through)
    * can apply {@link crispOffset} and render crisp on a DPR=1 display.
-   * Defaults to 1 (no nudge) when unset.
+   * Always set — `renderSlide` populates it from the real dpr; the in-module
+   * default literals use 1. Required so the crisp-line call sites need no
+   * `?? 1` fallback (aligns with docx's required `RenderState.dpr`).
    */
-  dpr?: number;
+  dpr: number;
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -206,11 +208,12 @@ function drawUnderline(
   const lineW = heavy ? baseLineW * 1.8 : baseLineW;
   const y = baseline + Math.max(2, lineW);
   // Crispness nudge (see crispOffset): a horizontal underline whose device-pixel
-  // width is odd straddles two device rows on a DPR=1 display (blurry). Shifting
-  // the line's y by half a device px centers an odd-width stroke on one device
-  // row → crisp. Applied to the straight / dbl / dashed branches only; the wavy
-  // variant is not axis-aligned per pixel, so it deliberately omits the offset.
-  const crispY = crispOffset(lineW, dpr);
+  // width is odd straddles two device rows on a DPR=1 display (blurry). Snapping
+  // the line's y onto the nearest crisp device position centers an odd-width
+  // stroke on one device row → crisp. Applied to the straight / dbl / dashed
+  // branches only; the wavy variant is not axis-aligned per pixel, so it
+  // deliberately omits the offset.
+  const crispY = crispOffset(y, lineW, dpr);
   ctx.strokeStyle = color;
   ctx.lineWidth = lineW;
   ctx.setLineDash([]);
@@ -261,11 +264,14 @@ function drawUnderline(
 
   if (style === 'dbl') {
     const offset = lineW * 1.4;
+    // Two parallel rules straddling y; snap each onto its own crisp device row.
+    const y1 = y - offset / 2;
+    const y2 = y + offset / 2;
     ctx.beginPath();
-    ctx.moveTo(x, y - offset / 2 + crispY);
-    ctx.lineTo(x + width, y - offset / 2 + crispY);
-    ctx.moveTo(x, y + offset / 2 + crispY);
-    ctx.lineTo(x + width, y + offset / 2 + crispY);
+    ctx.moveTo(x, y1 + crispOffset(y1, lineW, dpr));
+    ctx.lineTo(x + width, y1 + crispOffset(y1, lineW, dpr));
+    ctx.moveTo(x, y2 + crispOffset(y2, lineW, dpr));
+    ctx.lineTo(x + width, y2 + crispOffset(y2, lineW, dpr));
     ctx.stroke();
     return;
   }
@@ -702,7 +708,7 @@ export function layoutParagraph(
   defaultItalic: boolean = false,
   fontScale: number = 1.0,
   slideNumber?: number,
-  rc: RenderContext = { themeMajorFont: null, themeMinorFont: null },
+  rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
   let currentLine: LayoutLine = { segments: [] };
@@ -1311,7 +1317,7 @@ function presetTextRect(
   }
 }
 
-function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: number, themeDefaultColor = '#000000', slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null }, onTextRun?: TextRunCallback) {
+function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: number, themeDefaultColor = '#000000', slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }, onTextRun?: TextRunCallback) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
   const w = emuToPx(el.width, scale);
@@ -1864,7 +1870,7 @@ function renderTextBody(
   shapeFlipV = false,
   themeDefaultColor = '#000000',
   slideNumber?: number,
-  rc: RenderContext = { themeMajorFont: null, themeMinorFont: null },
+  rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
   onTextRun?: TextRunCallback,
   measureOnly = false,
 ): number | void {
@@ -2518,7 +2524,7 @@ function renderTextBody(
       }
 
       if (seg.underline) {
-        drawUnderline(ctx, penX, segBaseline, segW + jext, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle, rc.dpr ?? 1);
+        drawUnderline(ctx, penX, segBaseline, segW + jext, seg.sizePx, seg.underlineColor ?? seg.color, seg.underlineStyle, rc.dpr);
       }
 
       if (seg.strikethrough) {
@@ -2526,27 +2532,29 @@ function renderTextBody(
         ctx.strokeStyle = seg.color;
         ctx.lineWidth = lineW;
         ctx.setLineDash([]);
-        // Crispness nudge (see crispOffset): the strike is a horizontal stroke,
-        // so an odd device-pixel width is centered on one device row by shifting
-        // y half a device px at DPR=1 (otherwise it straddles two rows → blurry).
-        const crispY = crispOffset(lineW, rc.dpr ?? 1);
+        // Crispness nudge (see crispOffset): the strike is a horizontal stroke;
+        // an odd device-pixel width is centered on one device row by snapping its
+        // y onto the nearest crisp device position (otherwise it straddles two
+        // rows → blurry). Snap each line from its own y.
+        const yMid = segBaseline - seg.sizePx * 0.32;
         if (seg.strikeDouble) {
           // Two parallel lines straddling the standard strike position,
           // separated by ~ 1.5× the line weight (visually distinct yet
           // staying inside the glyph's central band).
           const offset = lineW * 0.9;
-          const yMid = segBaseline - seg.sizePx * 0.32 + crispY;
+          const yUp = yMid - offset;
+          const yDn = yMid + offset;
           ctx.beginPath();
-          ctx.moveTo(penX, yMid - offset);
-          ctx.lineTo(penX + segW + jext, yMid - offset);
-          ctx.moveTo(penX, yMid + offset);
-          ctx.lineTo(penX + segW + jext, yMid + offset);
+          ctx.moveTo(penX, yUp + crispOffset(yUp, lineW, rc.dpr));
+          ctx.lineTo(penX + segW + jext, yUp + crispOffset(yUp, lineW, rc.dpr));
+          ctx.moveTo(penX, yDn + crispOffset(yDn, lineW, rc.dpr));
+          ctx.lineTo(penX + segW + jext, yDn + crispOffset(yDn, lineW, rc.dpr));
           ctx.stroke();
         } else {
-          const yMid = segBaseline - seg.sizePx * 0.32 + crispY;
+          const sy = yMid + crispOffset(yMid, lineW, rc.dpr);
           ctx.beginPath();
-          ctx.moveTo(penX, yMid);
-          ctx.lineTo(penX + segW + jext, yMid);
+          ctx.moveTo(penX, sy);
+          ctx.lineTo(penX + segW + jext, sy);
           ctx.stroke();
         }
       }
@@ -3602,7 +3610,7 @@ function applyStroke(ctx: CanvasRenderingContext2D, stroke: Stroke | null, scale
 
 // ─── Table rendering ─────────────────────────────────────────────────────────
 
-function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: number, slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null }) {
+function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: number, slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }) {
   const x0 = emuToPx(el.x, scale);
   const y0 = emuToPx(el.y, scale);
 
@@ -3737,17 +3745,18 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
       // Borders
       // Crispness nudge (see crispOffset): an axis-aligned thin grid line whose
       // device-pixel width is odd straddles two device rows/cols on a DPR=1
-      // display (each ~50% ink → blurry). Offsetting the integer cell edge by
-      // half a device pixel perpendicular to the line centers an odd-width
+      // display (each ~50% ink → blurry). Snapping the cell edge perpendicular
+      // to the line onto the nearest crisp device position centers an odd-width
       // stroke on one device row/col → crisp. `applyStroke` sets ctx.lineWidth
-      // to the logical width, so we read it back to pick the right offset.
-      // Horizontal edges (T/B) shift Y; vertical edges (L/R) shift X. Diagonals
-      // can't be pixel-aligned this way, so they are left untouched.
-      const dpr = rc.dpr ?? 1;
+      // to the logical width, so we read it back to pick the right offset, and
+      // the snap delta is derived from the edge's own coordinate (fractional-
+      // safe). Horizontal edges (T/B) shift Y from their y; vertical edges (L/R)
+      // shift X from their x. Diagonals can't be pixel-aligned, so untouched.
+      const dpr = rc.dpr;
       ctx.save();
       if (cell.borderT) {
         applyStroke(ctx, cell.borderT, scale);
-        const dy = crispOffset(ctx.lineWidth, dpr);
+        const dy = crispOffset(rowY, ctx.lineWidth, dpr);
         ctx.beginPath();
         ctx.moveTo(colX, rowY + dy);
         ctx.lineTo(colX + cellW, rowY + dy);
@@ -3755,7 +3764,7 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
       }
       if (cell.borderB) {
         applyStroke(ctx, cell.borderB, scale);
-        const dy = crispOffset(ctx.lineWidth, dpr);
+        const dy = crispOffset(rowY + cellH, ctx.lineWidth, dpr);
         ctx.beginPath();
         ctx.moveTo(colX, rowY + cellH + dy);
         ctx.lineTo(colX + cellW, rowY + cellH + dy);
@@ -3763,7 +3772,7 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
       }
       if (cell.borderL) {
         applyStroke(ctx, cell.borderL, scale);
-        const dx = crispOffset(ctx.lineWidth, dpr);
+        const dx = crispOffset(colX, ctx.lineWidth, dpr);
         ctx.beginPath();
         ctx.moveTo(colX + dx, rowY);
         ctx.lineTo(colX + dx, rowY + cellH);
@@ -3771,7 +3780,7 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
       }
       if (cell.borderR) {
         applyStroke(ctx, cell.borderR, scale);
-        const dx = crispOffset(ctx.lineWidth, dpr);
+        const dx = crispOffset(colX + cellW, ctx.lineWidth, dpr);
         ctx.beginPath();
         ctx.moveTo(colX + cellW + dx, rowY);
         ctx.lineTo(colX + cellW + dx, rowY + cellH);

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -592,16 +592,23 @@ function drawTextDecoLine(
   ctx: CanvasRenderingContext2D,
   x1: number, x2: number, y: number,
   color: string, double: boolean,
+  dpr = 1,
 ): void {
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 0.5;
   ctx.beginPath();
+  // crispOffset snaps each horizontal stroke onto the device pixel grid so the
+  // 0.5-px rule renders crisp at any dpr (matches docx/pptx underline/strike).
   if (double) {
-    ctx.moveTo(x1, y - 1); ctx.lineTo(x2, y - 1);
-    ctx.moveTo(x1, y + 1); ctx.lineTo(x2, y + 1);
+    const yUp = y - 1, yDn = y + 1;
+    const yu = yUp + crispOffset(yUp, 0.5, dpr);
+    const yd = yDn + crispOffset(yDn, 0.5, dpr);
+    ctx.moveTo(x1, yu); ctx.lineTo(x2, yu);
+    ctx.moveTo(x1, yd); ctx.lineTo(x2, yd);
   } else {
-    ctx.moveTo(x1, y); ctx.lineTo(x2, y);
+    const ys = y + crispOffset(y, 0.5, dpr);
+    ctx.moveTo(x1, ys); ctx.lineTo(x2, ys);
   }
   ctx.stroke();
   ctx.restore();
@@ -1580,28 +1587,32 @@ function renderQuadrant(
       }
 
       // Grid lines – draw only right + bottom edges once per cell (avoids double-drawing at
-      // shared cell boundaries). Half-device-pixel offset (0.5/dpr) aligns each line to the
-      // device pixel grid so we get a crisp 1-device-pixel result.
+      // shared cell boundaries). crispOffset snaps each line onto the device
+      // pixel grid so we get a crisp 1-device-pixel result at any dpr (a fixed
+      // 0.5/dpr offset blurs at even device widths, e.g. dpr=3).
       // Skipped when the sheet has `<sheetView showGridLines="0">` (View →
       // Gridlines unchecked; ECMA-376 §18.3.1.83).
       if (rc.worksheet.showGridlines !== false) {
-        const hp = 0.5 / dpr;
         ctx.strokeStyle = '#d0d0d0';
         ctx.lineWidth = 0.5;
         ctx.beginPath();
         if (!suppressRightGridCol.has(ci)) {
-          ctx.moveTo(cx + cellW + hp, cy);        // right edge
-          ctx.lineTo(cx + cellW + hp, cy + cellH);
+          const rx = cx + cellW + crispOffset(cx + cellW, 0.5, dpr);  // right edge
+          ctx.moveTo(rx, cy);
+          ctx.lineTo(rx, cy + cellH);
         }
-        ctx.moveTo(cx, cy + cellH + hp);           // bottom edge
-        ctx.lineTo(cx + cellW, cy + cellH + hp);
+        const by = cy + cellH + crispOffset(cy + cellH, 0.5, dpr);    // bottom edge
+        ctx.moveTo(cx, by);
+        ctx.lineTo(cx + cellW, by);
         if (ri === 0) {                            // top edge for first row
-          ctx.moveTo(cx, cy + hp);
-          ctx.lineTo(cx + cellW, cy + hp);
+          const ty = cy + crispOffset(cy, 0.5, dpr);
+          ctx.moveTo(cx, ty);
+          ctx.lineTo(cx + cellW, ty);
         }
         if (ci === 0) {                            // left edge for first column
-          ctx.moveTo(cx + hp, cy);
-          ctx.lineTo(cx + hp, cy + cellH);
+          const lx = cx + crispOffset(cx, 0.5, dpr);
+          ctx.moveTo(lx, cy);
+          ctx.lineTo(lx, cy + cellH);
         }
         ctx.stroke();
       }
@@ -1683,11 +1694,14 @@ function renderQuadrant(
           ctx.strokeStyle = overlay.color;
           ctx.lineWidth = overlay.lineWidth;
           ctx.beginPath();
+          // perimeter inset (-hp) kept literal: snapping could push it outside
+          // the cell's bottom edge; dpr>=3 edge accepted
           ctx.moveTo(cx, cy + cellH - hp);
           ctx.lineTo(cx + cellW, cy + cellH - hp);
           if (overlay.topEdge) {
-            ctx.moveTo(cx, cy + hp);
-            ctx.lineTo(cx + cellW, cy + hp);
+            const ty = cy + crispOffset(cy, overlay.lineWidth, dpr);
+            ctx.moveTo(cx, ty);
+            ctx.lineTo(cx + cellW, ty);
           }
           ctx.stroke();
         }
@@ -2010,13 +2024,14 @@ function renderQuadrant(
             if (seg.font.underline) {
               const stroke = segColor ? hexToRgba(segColor) : '#000000';
               const dbl = seg.font.underlineStyle === 'double' || seg.font.underlineStyle === 'doubleAccounting';
-              drawTextDecoLine(ctx, xx, xx + seg.width, yy + rSizePx + 1, stroke, dbl);
+              drawTextDecoLine(ctx, xx, xx + seg.width, yy + rSizePx + 1, stroke, dbl, dpr);
             }
             if (seg.font.strike) {
               ctx.save();
               ctx.strokeStyle = segColor ? hexToRgba(segColor) : '#000000';
               ctx.lineWidth = 0.5;
-              const sy2 = yy + Math.round(rSizePx * 0.5);
+              const sy2base = yy + Math.round(rSizePx * 0.5);
+              const sy2 = sy2base + crispOffset(sy2base, 0.5, dpr);
               ctx.beginPath(); ctx.moveTo(xx, sy2); ctx.lineTo(xx + seg.width, sy2); ctx.stroke();
               ctx.restore();
             }
@@ -2102,7 +2117,7 @@ function renderQuadrant(
                 : cy + cellH - paddingY + 1;
             const uy = uyBase + yShift;
             const stroke = runColor ? hexToRgba(runColor) : '#000000';
-            drawTextDecoLine(ctx, runX, runX + runWidths[i], uy, stroke, rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting');
+            drawTextDecoLine(ctx, runX, runX + runWidths[i], uy, stroke, rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting', dpr);
           }
           if (rf.strike) {
             const syBase = alignV === 'top'
@@ -2110,7 +2125,7 @@ function renderQuadrant(
               : alignV === 'center'
                 ? cy + cellH / 2
                 : cy + cellH - paddingY - Math.round(rSizePx * 0.35);
-            const sy = syBase + yShift;
+            const sy = syBase + yShift + crispOffset(syBase + yShift, 0.5, dpr);
             ctx.save();
             ctx.strokeStyle = runColor ? hexToRgba(runColor) : '#000000';
             ctx.lineWidth = 0.5;
@@ -2161,16 +2176,17 @@ function renderQuadrant(
               : cy + cellH - paddingY + 1) + vaYShift;
           const stroke = hyperlinkUrl ? '#0563C1' : (textColor ? hexToRgba(textColor) : '#000000');
           const dbl = fontForDraw.underlineStyle === 'double' || fontForDraw.underlineStyle === 'doubleAccounting';
-          drawTextDecoLine(ctx, ux, ux + tW, uy, stroke, dbl);
+          drawTextDecoLine(ctx, ux, ux + tW, uy, stroke, dbl, dpr);
         }
         if (fontForDraw.strike) {
           const { x: sx, width: tW } = overlayX();
           // Strike line sits roughly at the x-height mid-line (~45% up from baseline)
-          const sy = (alignV === 'top'
+          const syBase = (alignV === 'top'
             ? cy + paddingY + Math.round(sizePx * 0.5)
             : alignV === 'center'
               ? cy + cellH / 2
               : cy + cellH - paddingY - Math.round(sizePx * 0.35)) + vaYShift;
+          const sy = syBase + crispOffset(syBase, 0.5, dpr);
           ctx.save();
           ctx.strokeStyle = textColor ? hexToRgba(textColor) : '#000000';
           ctx.lineWidth = 0.5;
@@ -2488,22 +2504,22 @@ export function renderViewport(
   // band (which now anchors at the right). The horizontal divider is
   // unaffected by the x-mirror but its row-header end moves to the right.
   const rtl = worksheet.rightToLeft === true;
-  // Half-device-pixel offset so the 0.5-px divider lands crisp on the device
-  // grid (same convention as gridlines/headers). At dpr=1 this is +0.5; the
-  // previous hardcoded +0.5 was a *logical* px and blurred at dpr>1.
-  const hp = 0.5 / dpr;
+  // crispOffset snaps the 0.5-px divider onto the device grid (same convention
+  // as gridlines/headers). A fixed 0.5/dpr offset blurred at even device
+  // widths (e.g. dpr=3).
   if (freezeRows > 0) {
     ctx.save();
     ctx.strokeStyle = FREEZE_LINE_COLOR;
     ctx.lineWidth = 0.5;
     ctx.beginPath();
+    const dy = scrollAreaY + crispOffset(scrollAreaY, 0.5, dpr);
     if (rtl) {
       // cell area is [0, canvasW - hw]
-      ctx.moveTo(0, scrollAreaY + hp);
-      ctx.lineTo(canvasW - hw, scrollAreaY + hp);
+      ctx.moveTo(0, dy);
+      ctx.lineTo(canvasW - hw, dy);
     } else {
-      ctx.moveTo(hw, scrollAreaY + hp);
-      ctx.lineTo(canvasW, scrollAreaY + hp);
+      ctx.moveTo(hw, dy);
+      ctx.lineTo(canvasW, dy);
     }
     ctx.stroke();
     ctx.restore();
@@ -2516,7 +2532,8 @@ export function renderViewport(
     // Divider sits between the frozen band and the scroll band. In LTR that
     // is at scrollAreaX = hw + frozenW; mirrored that becomes
     // canvasW - scrollAreaX.
-    const dividerX = rtl ? canvasW - scrollAreaX + hp : scrollAreaX + hp;
+    const dividerBase = rtl ? canvasW - scrollAreaX : scrollAreaX;
+    const dividerX = dividerBase + crispOffset(dividerBase, 0.5, dpr);
     ctx.moveTo(dividerX, hh);
     ctx.lineTo(dividerX, canvasH);
     ctx.stroke();
@@ -2583,8 +2600,12 @@ function renderHeaders(
   ctx.strokeStyle = HEADER_BORDER;
   ctx.lineWidth = 0.5;
   ctx.beginPath();
-  ctx.moveTo(cornerX + hp, 0); ctx.lineTo(cornerX + hp, hh);          // left
-  ctx.moveTo(cornerX, hp); ctx.lineTo(cornerX + hw, hp);              // top
+  const cornerL = cornerX + crispOffset(cornerX, 0.5, dpr);
+  const cornerT = crispOffset(0, 0.5, dpr);
+  ctx.moveTo(cornerL, 0); ctx.lineTo(cornerL, hh);                    // left
+  ctx.moveTo(cornerX, cornerT); ctx.lineTo(cornerX + hw, cornerT);    // top
+  // perimeter inset (-hp) kept literal: snapping could push it outside the
+  // header box; dpr>=3 edge accepted
   ctx.moveTo(cornerX + hw - hp, 0); ctx.lineTo(cornerX + hw - hp, hh);  // right
   ctx.moveTo(cornerX, hh - hp); ctx.lineTo(cornerX + hw, hh - hp);    // bottom
   ctx.stroke();
@@ -2608,9 +2629,11 @@ function renderHeaders(
     ctx.strokeStyle = colBorder(col);
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(cx + hp, 0);          ctx.lineTo(cx + hp, hh);        // left = column boundary (aligns with data grid at +hp)
-    ctx.moveTo(cx, hh - hp);          ctx.lineTo(cx + cw, hh - hp);  // bottom (strip perimeter, inset)
-    ctx.moveTo(cx, hp);               ctx.lineTo(cx + cw, hp);        // top (strip perimeter)
+    const colSepX = cx + crispOffset(cx, 0.5, dpr);  // column boundary, aligns with data grid
+    const colTopY = crispOffset(0, 0.5, dpr);
+    ctx.moveTo(colSepX, 0);           ctx.lineTo(colSepX, hh);       // left = column boundary (aligns with data grid)
+    ctx.moveTo(cx, hh - hp);          ctx.lineTo(cx + cw, hh - hp);  // bottom (strip perimeter, inset -hp kept literal)
+    ctx.moveTo(cx, colTopY);          ctx.lineTo(cx + cw, colTopY);  // top (strip perimeter)
     ctx.stroke();
     ctx.fillStyle = HEADER_TEXT;
     ctx.textAlign = 'center';
@@ -2634,9 +2657,11 @@ function renderHeaders(
     ctx.strokeStyle = rowBorder(row);
     ctx.lineWidth = 0.5;
     ctx.beginPath();
-    ctx.moveTo(rx + hw - hp, cy);  ctx.lineTo(rx + hw - hp, cy + ch);   // right (strip perimeter, inset)
-    ctx.moveTo(rx, cy + hp);       ctx.lineTo(rx + hw, cy + hp);         // top = row boundary (aligns with data grid at +hp)
-    ctx.moveTo(rx + hp, cy);       ctx.lineTo(rx + hp, cy + ch);         // left (strip perimeter)
+    const rowSepY = cy + crispOffset(cy, 0.5, dpr);   // row boundary, aligns with data grid
+    const rowLeftX = rx + crispOffset(rx, 0.5, dpr);
+    ctx.moveTo(rx + hw - hp, cy);  ctx.lineTo(rx + hw - hp, cy + ch);   // right (strip perimeter, inset -hp kept literal)
+    ctx.moveTo(rx, rowSepY);       ctx.lineTo(rx + hw, rowSepY);         // top = row boundary (aligns with data grid)
+    ctx.moveTo(rowLeftX, cy);      ctx.lineTo(rowLeftX, cy + ch);        // left (strip perimeter)
     ctx.stroke();
     ctx.fillStyle = HEADER_TEXT;
     ctx.textBaseline = 'middle';
@@ -3506,13 +3531,13 @@ function renderBorder(
     ctx.lineWidth = lw;
     const dash = borderStyleDash(edge.style);
     ctx.setLineDash(dash);
-    // Crispness nudge (see crispOffset): an odd device-width stroke is centered
-    // on a pixel midpoint so it renders crisp instead of bleeding across two
-    // rows; an even device width is already crisp on the integer cell edge and
-    // gets 0. Diagonals can't be pixel-aligned, so no offset.
-    const crispNudge = kind !== 'd' ? crispOffset(lw, dpr) : 0;
-    const dpx = kind === 'v' ? crispNudge : 0;
-    const dpy = kind === 'h' ? crispNudge : 0;
+    // Crispness snap (see crispOffset): snap the stroke to the nearest crisp
+    // device position derived from its own coordinate — the x of a vertical
+    // edge, the y of a horizontal edge. An odd device-width stroke lands on a
+    // pixel midpoint; an even device width snaps to an integer boundary (0 when
+    // already aligned). Diagonals can't be pixel-aligned, so no offset.
+    const dpx = kind === 'v' ? crispOffset(x1, lw, dpr) : 0;
+    const dpy = kind === 'h' ? crispOffset(y1, lw, dpr) : 0;
     ctx.moveTo(x1 + dpx, y1 + dpy);
     ctx.lineTo(x2 + dpx, y2 + dpy);
     ctx.stroke();


### PR DESCRIPTION
## Summary

An independent multi-agent review of #505 (dimensions: spec-first / single-responsibility / no-duplicate-logic / docx-xlsx-pptx consistency) surfaced real issues. This PR fixes the correctness ones.

## core — correctness

`crispOffset(logicalWidth, dpr)` → `crispOffset(coord, logicalWidth, dpr)`.

The old helper returned a fixed `+0.5/dpr` meant to be added to an integer coordinate. But docx/pptx table and text coordinates are fractional, where a blind `+0.5/dpr` can push a line further from a crisp device position. It now snaps `coord` to the nearest crisp device position (pixel midpoint for an odd device width, boundary for even) and returns the sub-pixel delta — correct for integer and fractional coords, and 0 for an even device width already on the boundary (which also fixes a dpr>=3 blur the fixed offset caused).

## xlsx — coverage gaps the review found

- Route the hand-rolled `+0.5/dpr` outset lines through `crispOffset`: gridlines, the table-style accent overlay, freeze-pane dividers, and the inter-cell header separators. These blurred at even device widths (e.g. dpr=3).
- Add crisp handling to text underline / strike-through (was missing in xlsx while docx/pptx already had it).
- The `-hp` inset perimeter edges (corner / header box) are kept literal — snapping could push them outside the filled box (noted inline).

## docx / pptx

- Migrate every `crispOffset` call site to the coord-based signature (so fractional table/text positions snap correctly).
- pptx: `RenderContext.dpr` made required (was optional with scattered `?? 1`), aligning with docx's required `RenderState.dpr`.

## Verification (device pixels, not eyeballed)

- All 6 device-pixel probes green: dpr=1 → a single near-black device row; dpr=2 → a clean 2-device-row band (no over-correction).
- typecheck 0 for core / xlsx / docx / pptx / node.
- Full suite: 632 pass. The only 2 failures are pre-existing, CI-skipped pptx image-extraction tests, unrelated to this change (confirmed by reverting these edits).

## Deferred (quality only, no correctness impact)

- Extract shared probe-test utilities (`probe-utils.ts`) — the three `*-crisp.probe.test.ts` files duplicate ~120 lines of pixel-measurement scaffolding.
- Trim the verbose per-call-site comments now that the rationale lives in `crispOffset`'s JSDoc.

Merge with `--merge` (no squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
