### PR TITLE
fix(xlsx): Latin serif cell fonts render serif, not sans (unify serif/sans classifier in core)

### DIFF
--- a/packages/core/src/fonts/scripts.test.ts
+++ b/packages/core/src/fonts/scripts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyCjkFont,
+  classifyFontGeneric,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,
@@ -71,6 +72,60 @@ describe('classifyCjkFont — Office font name → CJK language', () => {
   it('is case-insensitive for Latin transliterations', () => {
     expect(classifyCjkFont('simsun')).toBe('sc');
     expect(classifyCjkFont('MALGUN GOTHIC')).toBe('kr');
+  });
+});
+
+describe('classifyFontGeneric — font name → CSS generic class', () => {
+  it('classifies Latin serif faces as serif', () => {
+    expect(classifyFontGeneric('Century')).toBe('serif');
+    expect(classifyFontGeneric('Garamond')).toBe('serif');
+    expect(classifyFontGeneric('Times New Roman')).toBe('serif');
+    expect(classifyFontGeneric('Cambria')).toBe('serif');
+    expect(classifyFontGeneric('Georgia')).toBe('serif');
+    expect(classifyFontGeneric('Palatino')).toBe('serif');
+    expect(classifyFontGeneric('Didot')).toBe('serif');
+    expect(classifyFontGeneric('Bodoni')).toBe('serif');
+    expect(classifyFontGeneric('Playfair Display')).toBe('serif');
+    expect(classifyFontGeneric('Source Serif Pro')).toBe('serif');
+    expect(classifyFontGeneric('Noto Serif')).toBe('serif');
+  });
+
+  it('classifies CJK serif (song/ming/kai/fangsong) faces as serif', () => {
+    expect(classifyFontGeneric('SimSun')).toBe('serif');
+    expect(classifyFontGeneric('PMingLiU')).toBe('serif');
+    expect(classifyFontGeneric('MS Mincho')).toBe('serif');
+    expect(classifyFontGeneric('游明朝')).toBe('serif');
+    expect(classifyFontGeneric('Batang')).toBe('serif');
+    expect(classifyFontGeneric('KaiTi')).toBe('serif');
+    expect(classifyFontGeneric('FangSong')).toBe('serif');
+    expect(classifyFontGeneric('宋体')).toBe('serif');
+  });
+
+  it('classifies sans faces as sans', () => {
+    expect(classifyFontGeneric('Calibri')).toBe('sans');
+    expect(classifyFontGeneric('Arial')).toBe('sans');
+    expect(classifyFontGeneric('Verdana')).toBe('sans');
+    expect(classifyFontGeneric('Yu Gothic')).toBe('sans');
+    expect(classifyFontGeneric('Meiryo')).toBe('sans');
+    expect(classifyFontGeneric('Microsoft YaHei')).toBe('sans');
+    expect(classifyFontGeneric('Malgun Gothic')).toBe('sans');
+    expect(classifyFontGeneric('SimHei')).toBe('sans');
+  });
+
+  it('classifies monospace faces as mono', () => {
+    expect(classifyFontGeneric('Consolas')).toBe('mono');
+    expect(classifyFontGeneric('Courier New')).toBe('mono');
+    expect(classifyFontGeneric('Cascadia Mono')).toBe('mono');
+  });
+
+  it('returns sans for nullish / empty input', () => {
+    expect(classifyFontGeneric(null)).toBe('sans');
+    expect(classifyFontGeneric(undefined)).toBe('sans');
+    expect(classifyFontGeneric('')).toBe('sans');
+  });
+
+  it('regression guard: Century is serif (was misclassified as sans)', () => {
+    expect(classifyFontGeneric('Century')).toBe('serif');
   });
 });
 

--- a/packages/core/src/fonts/scripts.test.ts
+++ b/packages/core/src/fonts/scripts.test.ts
@@ -127,6 +127,20 @@ describe('classifyFontGeneric — font name → CSS generic class', () => {
   it('regression guard: Century is serif (was misclassified as sans)', () => {
     expect(classifyFontGeneric('Century')).toBe('serif');
   });
+
+  it('disambiguates substring collisions: Century Gothic / Source Sans are SANS', () => {
+    // "Century Gothic" is a geometric SANS face that shares the "century" token
+    // with the serif Century family — it must NOT be classified serif.
+    expect(classifyFontGeneric('Century Gothic')).toBe('sans');
+    expect(classifyFontGeneric('CenturyGothic')).toBe('sans');
+    // …but the rest of the Century family stays serif.
+    expect(classifyFontGeneric('Century Schoolbook')).toBe('serif');
+    expect(classifyFontGeneric('New Century Schoolbook')).toBe('serif');
+    // "Source Serif" leads with the explicit "source serif" token, so the sans
+    // sibling does not leak into serif.
+    expect(classifyFontGeneric('Source Sans Pro')).toBe('sans');
+    expect(classifyFontGeneric('Source Serif Pro')).toBe('serif');
+  });
 });
 
 describe('cjkFallbackChain — language-specific Noto CJK ordering', () => {

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -104,6 +104,43 @@ export function classifyCjkFont(family: string | null | undefined): CjkLang | nu
   return null;
 }
 
+/** CSS generic class of a font face, inferred from its name. */
+export type FontGenericClass = 'serif' | 'sans' | 'mono';
+
+/**
+ * Classify a font *name* into a CSS generic class (serif / sans / monospace).
+ * SINGLE SOURCE OF TRUTH for the serif/sans name heuristic shared by the docx,
+ * pptx and xlsx renderers (collapsing three previously-duplicated regexes).
+ *
+ * This is the NAME-pattern fallback only. A caller that has authoritative class
+ * data — Word's word/fontTable.xml `<w:family>` §17.8.3.10 (roman/swiss/modern)
+ * — MUST consult that first and use this only for faces absent from the table or
+ * marked "auto". The token set is the union of the renderers' prior regexes; no
+ * new name guessing is introduced.
+ *
+ * - mono : mono / courier / consolas / 等幅 …
+ * - serif: Latin serifs (Times, Cambria/Caladea, Georgia, Garamond, Century,
+ *          Palatino, Didot, Bodoni, Playfair, "… Serif", roman) AND CJK
+ *          song/ming/kai/fangsong faces (SimSun 宋 / Batang / PMingLiU 細明 /
+ *          KaiTi 楷 / FangSong 仿宋 / *Mincho 明朝) — so the per-language Noto CJK
+ *          fallback picks its serif variant.
+ * - sans : everything else (gothic, hei, kaku, round, grotesk, …).
+ */
+export function classifyFontGeneric(family: string | null | undefined): FontGenericClass {
+  if (!family) return 'sans';
+  const l = family.toLowerCase();
+  if (/mono|courier|consolas|等幅|gothic_m/.test(l)) return 'mono';
+  if (
+    /roman|times|cambria|caladea|georgia|garamond|century|palatino|didot|bodoni|playfair|source serif|noto serif|min\s*cho|明朝体|明朝|song|sung|simsun|nsimsun|batang|gungsuh|ming\s*liu|mingliu|pmingliu|fang\s*song|fangsong|kai\s*ti|kaiti|simkai|simfang|stsong|stkaiti|stfangsong|stzhongsong|新細明|細明|宋体|楷体|楷體|仿宋|標楷|游明朝|ＭＳ 明朝|ms mincho|yu mincho|hiragino mincho|ヒラギノ明朝/.test(
+      l,
+    ) ||
+    /新細明體|細明體|宋体|明朝|楷体|楷體|仿宋|標楷體|游明朝|ＭＳ 明朝/.test(family)
+  ) {
+    return 'serif';
+  }
+  return 'sans';
+}
+
 /**
  * Ordered Noto CJK family names for a given language, primary face first so the
  * browser resolves shared Han glyphs to that language's shapes. The other three

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -109,14 +109,19 @@ export type FontGenericClass = 'serif' | 'sans' | 'mono';
 
 /**
  * Classify a font *name* into a CSS generic class (serif / sans / monospace).
- * SINGLE SOURCE OF TRUTH for the serif/sans name heuristic shared by the docx,
- * pptx and xlsx renderers (collapsing three previously-duplicated regexes).
+ * The shared serif/sans name heuristic for the pptx and xlsx renderers, which
+ * both now route through it (collapsing their two duplicated regexes into one).
+ * docx is NOT yet wired in: its name classifier layers word/fontTable.xml
+ * `<w:family>` priority and Arabic-companion handling on top, and its Latin-first
+ * fallback ordering is still on an unmerged branch — routing docx through here is
+ * a deferred follow-up (it becomes the third caller, completing the unification).
  *
  * This is the NAME-pattern fallback only. A caller that has authoritative class
  * data — Word's word/fontTable.xml `<w:family>` §17.8.3.10 (roman/swiss/modern)
  * — MUST consult that first and use this only for faces absent from the table or
- * marked "auto". The token set is the union of the renderers' prior regexes; no
- * new name guessing is introduced.
+ * marked "auto". The token set is the union of all three renderers' prior regexes
+ * (docx included, so the future docx migration loses no coverage); no new name
+ * guessing is introduced.
  *
  * - mono : mono / courier / consolas / 等幅 …
  * - serif: Latin serifs (Times, Cambria/Caladea, Georgia, Garamond, Century,

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -130,8 +130,13 @@ export function classifyFontGeneric(family: string | null | undefined): FontGene
   if (!family) return 'sans';
   const l = family.toLowerCase();
   if (/mono|courier|consolas|等幅|gothic_m/.test(l)) return 'mono';
+  // `century(?!\s*gothic)` keeps the serif Century family (Century, Century
+  // Schoolbook, …) but excludes the geometric SANS "Century Gothic" — the one
+  // union token where a serif name collides with a real sans face. (The
+  // authoritative split is the §17.8.3.10 <w:family> class the caller checks
+  // first; this only refines the name-pattern fallback.)
   if (
-    /roman|times|cambria|caladea|georgia|garamond|century|palatino|didot|bodoni|playfair|source serif|noto serif|min\s*cho|明朝体|明朝|song|sung|simsun|nsimsun|batang|gungsuh|ming\s*liu|mingliu|pmingliu|fang\s*song|fangsong|kai\s*ti|kaiti|simkai|simfang|stsong|stkaiti|stfangsong|stzhongsong|新細明|細明|宋体|楷体|楷體|仿宋|標楷|游明朝|ＭＳ 明朝|ms mincho|yu mincho|hiragino mincho|ヒラギノ明朝/.test(
+    /roman|times|cambria|caladea|georgia|garamond|century(?!\s*gothic)|palatino|didot|bodoni|playfair|source serif|noto serif|min\s*cho|明朝体|明朝|song|sung|simsun|nsimsun|batang|gungsuh|ming\s*liu|mingliu|pmingliu|fang\s*song|fangsong|kai\s*ti|kaiti|simkai|simfang|stsong|stkaiti|stfangsong|stzhongsong|新細明|細明|宋体|楷体|楷體|仿宋|標楷|游明朝|ＭＳ 明朝|ms mincho|yu mincho|hiragino mincho|ヒラギノ明朝/.test(
       l,
     ) ||
     /新細明體|細明體|宋体|明朝|楷体|楷體|仿宋|標楷體|游明朝|ＭＳ 明朝/.test(family)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export type { LoadOptions } from './types/load-options';
 export { preloadGoogleFonts, type FontPreloadEntry } from './fonts/preload';
 export {
   classifyCjkFont,
+  classifyFontGeneric,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,
@@ -49,6 +50,7 @@ export {
   SCRIPT_PRELOAD_NAMES,
   scriptPreloadNamesForText,
   type CjkLang,
+  type FontGenericClass,
   type FontVariant,
 } from './fonts/scripts';
 export { renderChart } from './chart/renderer';

--- a/packages/pptx/src/font-stack.test.ts
+++ b/packages/pptx/src/font-stack.test.ts
@@ -63,3 +63,18 @@ describe('cssFontStack — non-CJK scripts appended to Latin faces', () => {
     expect(stack.endsWith('serif')).toBe(true);
   });
 });
+
+describe('cssFontStack — serif/sans generic classification (core classifier)', () => {
+  it('Cambria degrades to a serif (latent pptx fix — was sans-serif)', () => {
+    const stack = cssFontStack('Cambria');
+    expect(stack.endsWith('serif')).toBe(true);
+    expect(stack.endsWith('sans-serif')).toBe(false);
+    // Cambria's metric-compatible substitute is appended (OFFICE_FONT_SUBSTITUTE).
+    expect(stack).toContain('"Caladea"');
+  });
+
+  it('regression: Calibri stays sans, Times New Roman stays serif', () => {
+    expect(cssFontStack('Calibri').endsWith('sans-serif')).toBe(true);
+    expect(cssFontStack('Times New Roman').endsWith('serif')).toBe(true);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -53,6 +53,7 @@ import {
   isHTMLCanvas,
   defaultDpr,
   classifyCjkFont,
+  classifyFontGeneric,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,
@@ -500,22 +501,12 @@ const CSS_GENERIC_FAMILIES = new Set([
   'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui',
 ]);
 
-/** Infer a CSS generic fallback from a named font so missing fonts degrade consistently. */
+/** Infer a CSS generic fallback from a named font so missing fonts degrade
+ *  consistently. Delegates the serif/sans/mono decision to the shared core
+ *  classifier (single source of truth); maps it to the CSS generic keyword. */
 function genericFallback(family: string): string {
-  const l = family.toLowerCase();
-  if (/mono|courier|consolas|等幅|gothic_m/.test(l)) return 'monospace';
-  // Serif: mincho (Japanese serif), roman, times, garamond, etc., plus CJK
-  // song/ming/kai (serif) faces — SimSun(宋)/Batang/PMingLiU(細明)/KaiTi(楷)/
-  // FangSong(仿宋) — so their Noto CJK fallback picks the serif variant.
-  if (
-    /mincho|明朝|roman|times|garamond|georgia|palatino|century|didot|song|sung|simsun|nsimsun|batang|gungsuh|mingliu|pmingliu|fangsong|kaiti|simkai|simfang|stsong|stkaiti|新細明|細明|宋体|楷体|楷體|仿宋|標楷|游明朝/.test(
-      l,
-    ) ||
-    /新細明體|細明體|宋体|楷体|楷體|仿宋|標楷體|游明朝/.test(family)
-  )
-    return 'serif';
-  // Everything else (gothic, kaku, round, rounded, sans, grotesk, …) → sans-serif
-  return 'sans-serif';
+  const g = classifyFontGeneric(family);
+  return g === 'mono' ? 'monospace' : g === 'serif' ? 'serif' : 'sans-serif';
 }
 
 /**

--- a/packages/xlsx/src/font-stack.test.ts
+++ b/packages/xlsx/src/font-stack.test.ts
@@ -49,7 +49,48 @@ describe('fontStackFor — CJK language-specific Noto ordering', () => {
     expect(tail).toContain('"Calibri"');
   });
 
-  it('non-CJK named face falls back to the default chain', () => {
-    expect(cssTailFor('Times New Roman')).toBe(fontStackFor(null));
+  it('non-CJK SANS named face falls back to the default sans chain', () => {
+    expect(cssTailFor('Arial')).toBe(fontStackFor(null));
+  });
+});
+
+describe('cssTailFor / fontStackFor — Latin serif & mono (bug fix)', () => {
+  it('a Latin serif the host lacks (Century) degrades to a serif, not sans', () => {
+    const tail = cssTailFor('Century');
+    expect(tail.endsWith('serif')).toBe(true);
+    expect(tail.endsWith('sans-serif')).toBe(false);
+    // Office serif (Cambria) and its metric clone (Caladea) lead the serif default.
+    expect(tail).toContain('"Cambria"');
+    expect(tail).toContain('"Caladea"');
+    // Pure Latin serif — no CJK Noto face should lead the chain.
+    expect(tail.startsWith('"Noto Serif')).toBe(false);
+    expect(tail.startsWith('"Noto Sans')).toBe(false);
+  });
+
+  it('fontStackFor leads with the named serif face then the serif default', () => {
+    expect(fontStackFor('Century')).toBe(`"Century", ${cssTailFor('Century')}`);
+    expect(fontStackFor('Century').startsWith('"Century", "Cambria"')).toBe(true);
+  });
+
+  it('other Latin serifs (Garamond, Times New Roman) also end in serif', () => {
+    expect(cssTailFor('Garamond').endsWith('serif')).toBe(true);
+    expect(cssTailFor('Times New Roman').endsWith('serif')).toBe(true);
+  });
+
+  it('a monospaced face the host lacks (Consolas) degrades to monospace', () => {
+    expect(cssTailFor('Consolas').endsWith('monospace')).toBe(true);
+  });
+
+  it('regression: a Latin sans face / unnamed cell still ends in sans-serif', () => {
+    expect(cssTailFor('Arial').endsWith('sans-serif')).toBe(true);
+    expect(fontStackFor(null).endsWith('sans-serif')).toBe(true);
+    expect(fontStackFor('Arial').startsWith('"Arial", "Calibri", "Carlito"')).toBe(true);
+  });
+
+  it('regression: CJK serif/sans ordering unchanged', () => {
+    expect(cssTailFor('SimSun').startsWith('"Noto Serif SC"')).toBe(true);
+    expect(cssTailFor('SimSun').endsWith('serif')).toBe(true);
+    expect(cssTailFor('Microsoft YaHei').startsWith('"Noto Sans SC"')).toBe(true);
+    expect(cssTailFor('Microsoft YaHei').endsWith('sans-serif')).toBe(true);
   });
 });

--- a/packages/xlsx/src/font-stack.test.ts
+++ b/packages/xlsx/src/font-stack.test.ts
@@ -85,6 +85,10 @@ describe('cssTailFor / fontStackFor — Latin serif & mono (bug fix)', () => {
     expect(cssTailFor('Arial').endsWith('sans-serif')).toBe(true);
     expect(fontStackFor(null).endsWith('sans-serif')).toBe(true);
     expect(fontStackFor('Arial').startsWith('"Arial", "Calibri", "Carlito"')).toBe(true);
+    // "Century Gothic" is SANS despite the "century" token — must not regress to
+    // the serif default just because the serif Century family does.
+    expect(cssTailFor('Century Gothic').endsWith('sans-serif')).toBe(true);
+    expect(cssTailFor('Century Gothic')).toBe(fontStackFor(null));
   });
 
   it('regression: CJK serif/sans ordering unchanged', () => {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -37,33 +37,45 @@ const NON_CJK_SANS_TAIL = NON_CJK_SANS_FALLBACKS.map((n) => `"${n}"`).join(', ')
 const NON_CJK_SERIF_TAIL = NON_CJK_SERIF_FALLBACKS.map((n) => `"${n}"`).join(', ');
 const DEFAULT_FONT_FAMILY =
   `"Calibri", "Carlito", "Cambria", "Caladea", Arial, "Noto Naskh Arabic", "Noto Sans Arabic", ${NON_CJK_SANS_TAIL}, sans-serif`;
-
-/** Markers of a CJK *serif* (song/ming/kai/fangsong) cell face — Noto CJK then
- *  uses its serif variant. Verified against the Office default font set. */
-function isCjkSerifName(l: string): boolean {
-  return /song|sung|simsun|nsimsun|batang|gungsuh|mincho|mingliu|pmingliu|fangsong|kaiti|simkai|simfang|stsong|stkaiti|新細明|細明|宋体|明朝|楷体|楷體|仿宋|標楷|游明朝/.test(
-    l,
-  );
-}
+// Serif counterpart of DEFAULT_FONT_FAMILY. A Latin *serif* cell font the host
+// lacks (Century, Garamond, …) must degrade to a serif — Excel renders such a
+// cell with a serif, not the sans default. Cambria is Office's serif; Caladea is
+// its metric-compatible clone (loaded opt-in via useGoogleFonts), then web-safe
+// serifs, ending in the `serif` generic.
+const DEFAULT_SERIF_FONT_FAMILY =
+  `"Cambria", "Caladea", "Times New Roman", "Liberation Serif", "Noto Naskh Arabic", "Noto Sans Arabic", ${NON_CJK_SERIF_TAIL}, serif`;
+// Monospace counterpart: a monospaced cell font the host lacks degrades to a
+// monospace generic rather than the proportional sans default.
+const DEFAULT_MONO_FONT_FAMILY = `"Courier New", "Liberation Mono", monospace`;
 
 /**
  * CSS font-family TAIL (everything after the cell's named face) for an xlsx
  * cell. For a CJK cell font the matching Noto CJK leads (so shared Han glyphs
  * take the document language's shapes; see core/fonts/scripts.ts), followed by
- * the standard Latin/Arabic/non-CJK fallbacks. Non-CJK or unnamed cells get the
- * historical {@link DEFAULT_FONT_FAMILY}. Exported for unit testing.
+ * the standard Latin/Arabic/non-CJK fallbacks. A non-CJK cell font picks the
+ * default chain by its generic class ({@link classifyFontGeneric}) so a Latin
+ * serif/mono face the host lacks degrades to the matching generic. Exported for
+ * unit testing.
  */
 export function cssTailFor(name: string | null | undefined): string {
   const cjk = name ? classifyCjkFont(name) : null;
-  if (!cjk) return DEFAULT_FONT_FAMILY;
-  const serif = isCjkSerifName((name ?? '').toLowerCase());
+  const generic = classifyFontGeneric(name); // 'serif' | 'sans' | 'mono'
+  if (!cjk) {
+    // Non-CJK (Latin) cell font: choose the default chain by generic class so a
+    // Latin serif/mono face the host lacks degrades to the matching generic
+    // (Excel renders serif/mono, not the sans default).
+    if (generic === 'serif') return DEFAULT_SERIF_FONT_FAMILY;
+    if (generic === 'mono') return DEFAULT_MONO_FONT_FAMILY;
+    return DEFAULT_FONT_FAMILY;
+  }
+  const serif = generic === 'serif';
   const cjkPart = cjkFallbackChain(cjk, serif ? 'serif' : 'sans')
     .map((n) => `"${n}"`)
     .join(', ');
   const tail = serif ? NON_CJK_SERIF_TAIL : NON_CJK_SANS_TAIL;
-  const generic = serif ? 'serif' : 'sans-serif';
+  const genericKeyword = serif ? 'serif' : 'sans-serif';
   // CJK Noto leads, then Latin/metric substitutes, Arabic, non-CJK scripts.
-  return `${cjkPart}, "Calibri", "Carlito", "Cambria", "Caladea", Arial, "Noto Naskh Arabic", "Noto Sans Arabic", ${tail}, ${generic}`;
+  return `${cjkPart}, "Calibri", "Carlito", "Cambria", "Caladea", Arial, "Noto Naskh Arabic", "Noto Sans Arabic", ${tail}, ${genericKeyword}`;
 }
 
 /** Full CSS font-family list for a cell font name (named face first). */


### PR DESCRIPTION
## Problem

The XLSX renderer rendered a Latin **serif** cell font the host lacks (e.g. `Century`, `Garamond`, `Times New Roman`) as **sans-serif**. `cssTailFor` only detected *CJK* serif faces (`isCjkSerifName`); any non-CJK name fell through to `DEFAULT_FONT_FAMILY`, which ends in `sans-serif`. So a cell Excel renders with a serif came out sans for us.

Root cause was **three drifted serif/sans regexes**, one per renderer, each with different gaps:
- **pptx** `genericFallback` — fairly complete, but missing `cambria`/`caladea` (Cambria → sans, latent).
- **docx** `isSerif`/`isCjkSerif` — missing `century`/`palatino`/`didot` (relies on `fontTable` §17.8.3.10 for those).
- **xlsx** `isCjkSerifName` — **no Latin-serif detection at all** (the bug).

## Fix

Collapse the serif/sans/mono name heuristic into a single core source of truth — `classifyFontGeneric()` in `packages/core/src/fonts/scripts.ts` — and route pptx + xlsx through it.

- **core**: add `classifyFontGeneric(name) → 'serif' | 'sans' | 'mono'` + `FontGenericClass`. The token set is the **union** of the three prior regexes (no new name-guessing); it is the §17.8.3.10 *name-pattern fallback only* — callers that have `<w:family>` data consult that first.
- **pptx**: `genericFallback` delegates to the core classifier (also fixes the latent Cambria → sans miss).
- **xlsx**: delete `isCjkSerifName`; add `DEFAULT_SERIF_FONT_FAMILY` / `DEFAULT_MONO_FONT_FAMILY`; `cssTailFor` selects the default chain by generic class, so a Latin serif/mono cell font degrades to the matching generic. **← the bug fix.**

### Scope: docx deferred (intentional)
docx keeps its own `serifTail`/`sansTail` for now — its Latin-first fallback fix is on an unmerged branch (`feature/docx-sample10-multicolumn`). Routing docx through the shared classifier is a clean follow-up once that lands, to avoid a stacked PR / conflict. This PR collapses 2 of the 3 regexes; docx is the third.

## Independent review finding (addressed)
A reviewer caught that `century` also matches the geometric **sans** "Century Gothic" — unifying surfaced it in xlsx. Narrowed to `century(?!\s*gothic)` so the serif Century family stays serif while Century Gothic resolves to sans (commit 2), with tests pinning the split.

## Verification
- Full monorepo vitest: **632 passed / 17 skipped, 0 failed**.
- Type-check: core clean; pptx clean; xlsx clean except the pre-existing gitignored-WASM `TS2307` in `worker.ts`/`render-worker.ts` (unrelated, files untouched, handled by CI build ordering).
- No Rust touched. VRT not run (local-only); changes are correctness-improving (actual serif fonts → serif).

> Merge with `--merge` or `--rebase` (no squash), per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)