### PR TITLE
refactor(core): move isComplexScriptCodePoint to core (shared §17.3.2.26 cs predicate)

### DIFF
--- a/packages/core/src/fonts/scripts.test.ts
+++ b/packages/core/src/fonts/scripts.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyCjkFont,
   classifyFontGeneric,
+  isComplexScriptCodePoint,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,
@@ -309,7 +310,28 @@ describe('scriptPreloadNamesForText — script-aware preload set from document t
   });
 
   it('every returned name is resolvable in SCRIPT_GOOGLE_FONTS (CJK + Cyrillic + scripts)', () => {
-    const out = scriptPreloadNamesForText(['漢字 Привет สวัสดี नमस्ते שלום'], null);
+    const out = scriptPreloadNamesForText(['漢字 Привет สวัสดी नमस्ते שלום'], null);
     assertResolvable(out);
+  });
+});
+
+describe('isComplexScriptCodePoint — §17.3.2.26 cs-axis blocks', () => {
+  const cp = (s: string) => s.codePointAt(0) as number;
+  it('classifies RTL/complex scripts as complex', () => {
+    expect(isComplexScriptCodePoint(cp('א'))).toBe(true); // Hebrew U+05D0
+    expect(isComplexScriptCodePoint(cp('ع'))).toBe(true); // Arabic U+0639
+    expect(isComplexScriptCodePoint(cp('ܐ'))).toBe(true); // Syriac U+0710
+    expect(isComplexScriptCodePoint(cp('ޱ'))).toBe(true); // Thaana U+07B1
+    expect(isComplexScriptCodePoint(0xfdf2)).toBe(true); // Arabic Presentation Forms-A
+    expect(isComplexScriptCodePoint(0xfe8e)).toBe(true); // Arabic Presentation Forms-B
+    expect(isComplexScriptCodePoint(0x1ee00)).toBe(true); // Arabic Math (Plane-1)
+  });
+  it('classifies Latin / digits / punctuation / CJK as NOT complex', () => {
+    expect(isComplexScriptCodePoint(cp('A'))).toBe(false);
+    expect(isComplexScriptCodePoint(cp('5'))).toBe(false);
+    expect(isComplexScriptCodePoint(cp('.'))).toBe(false);
+    expect(isComplexScriptCodePoint(cp('あ'))).toBe(false); // Hiragana
+    expect(isComplexScriptCodePoint(cp('漢'))).toBe(false); // Han
+    expect(isComplexScriptCodePoint(cp('가'))).toBe(false); // Hangul
   });
 });

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -152,6 +152,39 @@ export function classifyFontGeneric(family: string | null | undefined): FontGene
 }
 
 /**
+ * True when a code point belongs to a complex-script (RTL/`cs`) Unicode block —
+ * Hebrew, Arabic (incl. supplements / extended / presentation forms), Syriac,
+ * Thaana, NKo, Samaritan, Mandaic, and the Plane-1 RTL / Arabic-math blocks.
+ * Single source of truth for ECMA-376 §17.3.2.26's per-character complex-script
+ * (`cs`) font-axis split: Word routes such characters to the run's cs formatting
+ * (`w:szCs`/`w:rFonts w:cs`/`w:bCs`/`w:iCs`) instead of the Latin (`ascii`/
+ * `hAnsi`) formatting. Latin, European digits, punctuation and CJK are NOT cs.
+ *
+ * Distinct from {@link scriptPreloadNamesForText}'s ranges, which decide WHICH
+ * Noto web font to load (Arabic vs Hebrew separately, only the scripts we ship)
+ * — a narrower, different-purpose set. This is the broad "is this a cs-axis
+ * glyph" predicate, exported so any renderer can apply the same split.
+ */
+export function isComplexScriptCodePoint(cp: number): boolean {
+  return (
+    (cp >= 0x0590 && cp <= 0x05ff) || // Hebrew
+    (cp >= 0x0600 && cp <= 0x06ff) || // Arabic
+    (cp >= 0x0700 && cp <= 0x074f) || // Syriac
+    (cp >= 0x0750 && cp <= 0x077f) || // Arabic Supplement
+    (cp >= 0x0780 && cp <= 0x07bf) || // Thaana
+    (cp >= 0x07c0 && cp <= 0x07ff) || // NKo
+    (cp >= 0x0800 && cp <= 0x083f) || // Samaritan
+    (cp >= 0x0840 && cp <= 0x085f) || // Mandaic
+    (cp >= 0x0860 && cp <= 0x08ff) || // Syriac Supp. / Arabic Extended-A/B
+    (cp >= 0xfb1d && cp <= 0xfb4f) || // Hebrew presentation forms
+    (cp >= 0xfb50 && cp <= 0xfdff) || // Arabic Presentation Forms-A
+    (cp >= 0xfe70 && cp <= 0xfeff) || // Arabic Presentation Forms-B
+    (cp >= 0x10800 && cp <= 0x10fff) || // Plane-1 RTL blocks
+    (cp >= 0x1e800 && cp <= 0x1efff)    // Mende/Adlam/Arabic Math
+  );
+}
+
+/**
  * Ordered Noto CJK family names for a given language, primary face first so the
  * browser resolves shared Han glyphs to that language's shapes. The other three
  * follow as a last-resort so a codepoint absent from the primary face does not

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export { preloadGoogleFonts, type FontPreloadEntry } from './fonts/preload';
 export {
   classifyCjkFont,
   classifyFontGeneric,
+  isComplexScriptCodePoint,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
   NON_CJK_SERIF_FALLBACKS,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -32,6 +32,7 @@ import {
   crossRunKinsokuRetract,
   isCjkBreakChar,
   classifyFontGeneric,
+  isComplexScriptCodePoint,
   decodeRasterOrMetafile,
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer, KinsokuRules } from '@silurus/ooxml-core';
@@ -3316,35 +3317,6 @@ function isRtlBidiLang(langBidi: string | undefined, runIsRtl: boolean): boolean
     if (RTL_PRIMARY_SUBTAGS.has(primary)) return true;
   }
   return runIsRtl;
-}
-
-/**
- * ECMA-376 §17.3.2.26 (rFonts) content classification — does this code point
- * belong to the COMPLEX-SCRIPT (`cs`) category? Word routes such characters to
- * the run's complex-script formatting (`w:szCs` / `w:rFonts w:cs` / `w:bCs` /
- * `w:iCs`) instead of the Latin (`ascii`/`hAnsi`) formatting. The ranges are
- * the Unicode blocks Word treats as complex script: Hebrew, Arabic (incl.
- * supplements / extended / presentation forms), Syriac, Thaana, NKo,
- * Samaritan, Mandaic, and the Arabic-math / extended Plane-1 blocks. Latin,
- * digits (EN), punctuation and CJK are NOT cs.
- */
-function isComplexScriptCodePoint(cp: number): boolean {
-  return (
-    (cp >= 0x0590 && cp <= 0x05ff) || // Hebrew
-    (cp >= 0x0600 && cp <= 0x06ff) || // Arabic
-    (cp >= 0x0700 && cp <= 0x074f) || // Syriac
-    (cp >= 0x0750 && cp <= 0x077f) || // Arabic Supplement
-    (cp >= 0x0780 && cp <= 0x07bf) || // Thaana
-    (cp >= 0x07c0 && cp <= 0x07ff) || // NKo
-    (cp >= 0x0800 && cp <= 0x083f) || // Samaritan
-    (cp >= 0x0840 && cp <= 0x085f) || // Mandaic
-    (cp >= 0x0860 && cp <= 0x08ff) || // Syriac Supp. / Arabic Extended-A/B
-    (cp >= 0xfb1d && cp <= 0xfb4f) || // Hebrew presentation forms
-    (cp >= 0xfb50 && cp <= 0xfdff) || // Arabic Presentation Forms-A
-    (cp >= 0xfe70 && cp <= 0xfeff) || // Arabic Presentation Forms-B
-    (cp >= 0x10800 && cp <= 0x10fff) || // Plane-1 RTL blocks
-    (cp >= 0x1e800 && cp <= 0x1efff)    // Mende/Adlam/Arabic Math
-  );
 }
 
 /**


### PR DESCRIPTION
The Arabic/Hebrew/Syriac/… complex-script range table for the §17.3.2.26 per-character `cs` font-axis split lived privately in the docx renderer. This moves it to **core** (beside `classifyCjkFont`/`classifyFontGeneric`) as the single source of truth and routes docx through it — the optional cleanup noted after the docx↔core unification (#511), done now while it's fresh.

## Changes
- **core**: add + export `isComplexScriptCodePoint(cp)`. Its doc-comment notes it is **distinct** from `scriptPreloadNamesForText` (which decides *which Noto web font to load* — Arabic vs Hebrew separately, only the scripts we ship — a narrower, different-purpose set).
- **docx**: import from core, delete the local copy (`renderer.ts`).
- **test**: core unit test for the cs-axis ranges (Hebrew/Arabic/Syriac/Thaana/presentation-forms/Arabic-math → complex; Latin/digit/punct/CJK → not).

## Notes
- Pure refactor — the ranges are moved verbatim, so docx behavior is unchanged (`splitByComplexScript` now calls the core predicate).
- Used only by docx today (the `cs` axis is WordprocessingML); exporting it makes the shared script knowledge reusable, consistent with the other core font helpers.

## Verification
- `tsc --build` clean; `vitest packages/core packages/docx` **473 pass** (incl. 2 new core tests). No parser/Rust change.

> Merge with `--merge` (no squash), per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)