### PR TITLE
fix(docx): per-section newspaper columns (§17.6.4) — regression on sample-5

### DIFF
--- a/packages/docx/parser/src/markdown.rs
+++ b/packages/docx/parser/src/markdown.rs
@@ -51,9 +51,11 @@ fn render_body(body: &[BodyElement], out: &mut String) {
         match el {
             BodyElement::Paragraph(p) => render_paragraph(p, out),
             BodyElement::Table(t) => render_table(t, out),
-            BodyElement::PageBreak { .. } | BodyElement::ColumnBreak => {
-                // Page / column breaks are layout, not content — skip in the
-                // projection.
+            BodyElement::PageBreak { .. }
+            | BodyElement::ColumnBreak
+            | BodyElement::SectionBreak { .. } => {
+                // Page / column / section breaks are layout, not content — skip
+                // in the projection.
             }
         }
     }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -776,42 +776,30 @@ fn parse_body_elements(
                     }
                 }
                 // ECMA-376 §17.6.1: a section break inside pPr defines the
-                // section that ENDS at this paragraph. The break TYPE
-                // (`<w:type w:val>`) controls how the next section starts:
-                //   - "continuous" → no page break
-                //   - "nextPage" / missing → plain page break
-                //   - "oddPage" / "evenPage" → page break + parity padding
+                // section that ENDS at this paragraph. Emit a SectionBreak marker
+                // carrying that section's <w:cols> (§17.6.4) AND its break kind
+                // (ST_SectionMark, §17.18.79) so the renderer can switch the
+                // active column geometry per section — even for a "continuous"
+                // break, which produces no page break but may still change the
+                // column count. (Previously a "continuous" break emitted nothing
+                // and the others emitted a column-less PageBreak, so every
+                // section inherited the body-level section's columns — the bug
+                // this fixes.)
                 if let Some(sect_pr) = child_w(child, "pPr").and_then(|ppr| child_w(ppr, "sectPr"))
                 {
-                    match read_section_break_type(sect_pr).as_deref() {
-                        Some("continuous") => { /* no page break */ }
-                        Some("oddPage") => body.push(BodyElement::PageBreak {
-                            parity: Some("odd".to_string()),
-                        }),
-                        Some("evenPage") => body.push(BodyElement::PageBreak {
-                            parity: Some("even".to_string()),
-                        }),
-                        _ => body.push(BodyElement::PageBreak { parity: None }),
-                    }
+                    body.push(section_break_element(sect_pr));
                 }
             }
             "tbl" => {
                 let tbl = parse_table(child, style_map, num_map, media_map, rel_map, theme);
                 body.push(BodyElement::Table(tbl));
             }
-            // Mid-body loose sectPr (rare) behaves like a page break. The
-            // final body-level sectPr only defines section settings — skip it.
+            // Mid-body loose sectPr (rare) defines the section that ENDS here.
+            // Emit a SectionBreak carrying its columns + break kind (see the
+            // pPr-nested case above). The final body-level sectPr only defines
+            // section settings (surfaced on Document.section) — skip it.
             "sectPr" if Some(child.id()) != body_level_sect_id => {
-                match read_section_break_type(child).as_deref() {
-                    Some("continuous") => {}
-                    Some("oddPage") => body.push(BodyElement::PageBreak {
-                        parity: Some("odd".to_string()),
-                    }),
-                    Some("evenPage") => body.push(BodyElement::PageBreak {
-                        parity: Some("even".to_string()),
-                    }),
-                    _ => body.push(BodyElement::PageBreak { parity: None }),
-                }
+                body.push(section_break_element(child));
             }
             _ => {}
         }
@@ -974,6 +962,29 @@ fn read_section_break_type(sect_pr: roxmltree::Node) -> Option<String> {
         .children()
         .filter(|n| n.is_element() && n.tag_name().name() == "type")
         .find_map(|n| attr_w(n, "val"))
+}
+
+/// Build a `BodyElement::SectionBreak` for a sectPr that ENDS a section
+/// (ECMA-376 §17.6.x). Carries the section's `<w:cols>` (§17.6.4, via
+/// `parse_columns` ⇒ `None` for a single column) and its ST_SectionMark kind
+/// (§17.18.79), normalized: an absent/unknown `<w:type>` ⇒ "nextPage" (the spec
+/// default). `nextColumn` is normalized to "nextPage" — a section-level
+/// nextColumn break is not modeled distinctly (column breaks within a section
+/// come from `<w:br w:type="column"/>` ⇒ `ColumnBreak`); the renderer would
+/// otherwise have no defined column geometry to advance into across a section
+/// boundary.
+fn section_break_element(sect_pr: roxmltree::Node) -> BodyElement {
+    let kind = match read_section_break_type(sect_pr).as_deref() {
+        Some("continuous") => "continuous",
+        Some("oddPage") => "oddPage",
+        Some("evenPage") => "evenPage",
+        _ => "nextPage",
+    }
+    .to_string();
+    BodyElement::SectionBreak {
+        kind,
+        columns: parse_columns(sect_pr),
+    }
 }
 
 /// Build a map of rId → embedded **zip path** (e.g. `word/media/image1.png`) for
@@ -6144,6 +6155,89 @@ mod column_tests {
         assert!(matches!(body[2], BodyElement::Paragraph(_)));
         assert!(matches!(body[3], BodyElement::ColumnBreak));
         assert!(matches!(body[4], BodyElement::Paragraph(_)));
+    }
+
+    /// ECMA-376 §17.6.x — a `<w:sectPr>` carried in a paragraph's `pPr` defines
+    /// the section that ENDS at that paragraph. It must emit a
+    /// `BodyElement::SectionBreak` carrying (a) that section's `<w:cols>`
+    /// (§17.6.4) and (b) its ST_SectionMark kind — NOT a column-less PageBreak.
+    /// This is the per-section-columns fix: previously the columns were dropped
+    /// here and every section inherited the body-level section's columns.
+    #[test]
+    fn ppr_section_break_emits_sectionbreak_with_columns_and_kind() {
+        let body = body_from(
+            r#"<w:p>
+                 <w:pPr>
+                   <w:sectPr>
+                     <w:type w:val="continuous"/>
+                     <w:cols w:num="3" w:space="425"/>
+                   </w:sectPr>
+                 </w:pPr>
+                 <w:r><w:t>sec1 last para</w:t></w:r>
+               </w:p>"#,
+        );
+        // Para("sec1 last para"), SectionBreak { kind: "continuous", cols(3) }.
+        assert_eq!(body.len(), 2);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        match &body[1] {
+            BodyElement::SectionBreak { kind, columns } => {
+                assert_eq!(kind, "continuous");
+                let c = columns.as_ref().expect("num=3 ⇒ multi-column");
+                assert_eq!(c.count, 3);
+            }
+            other => panic!("expected SectionBreak, got {other:?}"),
+        }
+    }
+
+    /// A single-column ending section (`<w:cols>` with no `@w:num` ⇒ §17.6.4
+    /// default of 1 column) carries `columns: None`, and the default break type
+    /// (absent `<w:type>`) normalizes to "nextPage". This is exactly sample-5's
+    /// section 1 → only the FINAL (body-level) section is 2-column.
+    #[test]
+    fn single_column_section_break_has_none_columns_and_nextpage_kind() {
+        let body = body_from(
+            r#"<w:p>
+                 <w:pPr><w:sectPr><w:cols w:space="425"/></w:sectPr></w:pPr>
+                 <w:r><w:t>a</w:t></w:r>
+               </w:p>
+               <w:p><w:r><w:t>final section content</w:t></w:r></w:p>
+               <w:sectPr><w:cols w:num="2" w:space="425"/></w:sectPr>"#,
+        );
+        // Para(a), SectionBreak { kind: nextPage, cols None }, Para(final).
+        // The body-level (2-col) sectPr is the FINAL section, surfaced on
+        // Document.section — NOT emitted as a body element here.
+        assert_eq!(body.len(), 3);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        match &body[1] {
+            BodyElement::SectionBreak { kind, columns } => {
+                assert_eq!(kind, "nextPage");
+                assert!(columns.is_none(), "single-column ⇒ None");
+            }
+            other => panic!("expected SectionBreak, got {other:?}"),
+        }
+        assert!(matches!(body[2], BodyElement::Paragraph(_)));
+    }
+
+    /// A loose mid-body `<w:sectPr>` (not nested in a pPr) is also a section
+    /// boundary and emits a `SectionBreak` carrying its columns + kind.
+    #[test]
+    fn loose_mid_body_sectpr_emits_sectionbreak() {
+        let body = body_from(
+            r#"<w:p><w:r><w:t>a</w:t></w:r></w:p>
+               <w:sectPr><w:type w:val="oddPage"/><w:cols w:space="425"/></w:sectPr>
+               <w:p><w:r><w:t>b</w:t></w:r></w:p>
+               <w:sectPr><w:cols w:num="2"/></w:sectPr>"#,
+        );
+        // Para(a), SectionBreak{ oddPage, None }, Para(b); final body-level
+        // sectPr skipped.
+        assert_eq!(body.len(), 3);
+        match &body[1] {
+            BodyElement::SectionBreak { kind, columns } => {
+                assert_eq!(kind, "oddPage");
+                assert!(columns.is_none());
+            }
+            other => panic!("expected SectionBreak, got {other:?}"),
+        }
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -235,6 +235,34 @@ pub enum BodyElement {
     /// without inspecting runs mid-paragraph. In a single-column section it
     /// behaves like a page break.
     ColumnBreak,
+    /// ECMA-376 §17.6.x — a section boundary in the body. A `<w:sectPr>` carried
+    /// in a paragraph's `pPr` (or a loose mid-body `<w:sectPr>`) defines the
+    /// section that ENDS at that point; the FINAL section is the body-level
+    /// `<w:sectPr>` and is surfaced on `Document.section` instead of here.
+    ///
+    /// `columns` is THAT ending section's `<w:cols>` (§17.6.4), parsed via
+    /// `parse_columns` (so `None` ⇒ a single full-width column — the spec default
+    /// when `@w:num` is absent or 1). `kind` is the section's ST_SectionMark
+    /// (`<w:type w:val>`, §17.18.79) which controls how the NEXT section starts:
+    /// "continuous" ⇒ no page break (the next section's columns begin on the same
+    /// page); "nextPage" (default) ⇒ a plain page break; "oddPage"/"evenPage" ⇒ a
+    /// page break + parity padding.
+    ///
+    /// The renderer switches its active column geometry to the *next* section's
+    /// columns at each marker (each marker carries the columns of the section it
+    /// terminates, so the renderer peeks forward to the next marker to size the
+    /// current section).
+    #[serde(rename_all = "camelCase")]
+    SectionBreak {
+        /// ST_SectionMark token: "continuous" | "nextPage" | "oddPage" |
+        /// "evenPage". Always one of these (the parser normalizes the default to
+        /// "nextPage").
+        kind: String,
+        /// The terminating section's `<w:cols>` (§17.6.4). `None` ⇒ single
+        /// full-width column.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        columns: Option<ColumnsSpec>,
+    },
 }
 
 #[derive(Serialize, Debug, Clone, Default)]

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -123,6 +123,13 @@ const colOf = (el: PaginatedBodyElement) => el.colIndex;
 /** A body-level column break (ECMA-376 §17.3.1.20, hoisted by the parser). */
 const colBreak = (): BodyElement => ({ type: 'columnBreak' } as BodyElement);
 
+/** A body-level section break (ECMA-376 §17.6.x). `columns` is the ENDING
+ *  section's `<w:cols>` (null/undefined ⇒ single full-width column). */
+const sectionBreak = (
+  kind: 'continuous' | 'nextPage' | 'oddPage' | 'evenPage',
+  columns: SectionProps['columns'] = null,
+): BodyElement => ({ type: 'sectionBreak', kind, columns } as BodyElement);
+
 /** Text of a paragraph element (joins its text runs). */
 const textOf = (el: PaginatedBodyElement): string =>
   el.type === 'paragraph'
@@ -395,5 +402,99 @@ describe('computePages — single-column regression (§17.6.4 absent)', () => {
     expect(sliceOf(pages[1][0])).toEqual({ start: 5, end: 6 });
     expect(colOf(pages[0][0]) ?? 0).toBe(0);
     expect(colOf(pages[1][0]) ?? 0).toBe(0);
+  });
+});
+
+describe('computePages — per-section columns (§17.6.4, regression)', () => {
+  // The sample-5 shape: section 1 is single-column (no <w:cols num>), only the
+  // FINAL section is 2-column. Section 1's content MUST lay out in ONE full-width
+  // column — not in the final section's 2-column grid. `section.columns` carries
+  // the FINAL (body-level) section's columns; each mid-body section's columns ride
+  // on its SectionBreak marker (here None ⇒ single column).
+  const colGeomOf = (el: PaginatedBodyElement): { xPt: number; wPt: number }[] | undefined =>
+    (el as { colGeom?: { xPt: number; wPt: number }[] }).colGeom;
+
+  const finalTwoCol = (): SectionProps =>
+    section({ columns: { count: 2, spacePt: 20, equalWidth: true, sep: false, cols: [] } });
+
+  it("section 1 lays out in ONE full-width column even though the FINAL section is 2-col", () => {
+    // 8 CJK chars: full width (160 → 8/line) = 1 line; the buggy 2-col path (70px →
+    // 3/line) would wrap it to 3 lines. Section 1 = this para, ended by a nextPage
+    // SectionBreak (cols None). Final section = one 2-col para.
+    const body: BodyElement[] = [
+      para({ text: 'あ'.repeat(8), fontSize: 20 }),
+      sectionBreak('nextPage', null),
+      para({ text: 'final', fontSize: 20 }),
+    ];
+    const pages = computePages(body, finalTwoCol(), makeCtx());
+    // SectionBreak is consumed (not emitted); section 1 on page 1, final on page 2.
+    expect(pages.length).toBe(2);
+    const sec1Para = pages[0][0];
+    // Full-width single column ⇒ NOT split (still one line) and colGeom length 1.
+    expect(sliceOf(sec1Para)).toBeUndefined();
+    expect(colOf(sec1Para) ?? 0).toBe(0);
+    expect(colGeomOf(sec1Para)).toEqual([{ xPt: 20, wPt: 160 }]);
+    // The FINAL section's paragraph gets the 2-column geometry.
+    const finalPara = pages[1][0];
+    expect(colGeomOf(finalPara)).toEqual([
+      { xPt: 20, wPt: 70 },
+      { xPt: 110, wPt: 70 },
+    ]);
+  });
+
+  it('section 1 fills the full column height (5 lines/page) before paginating, not the half-width 2-col height', () => {
+    // 5 single-line paragraphs fill a full-width column exactly (content height 100
+    // / 20px = 5). All land on page 1, column 0, full-width geometry. Under the bug
+    // they would have been squeezed into 2-col width and the flow would differ.
+    const body: BodyElement[] = [
+      ...Array.from({ length: 5 }, (_, i) => para({ text: `s${i}`, fontSize: 20 })),
+      sectionBreak('nextPage', null),
+      para({ text: 'final', fontSize: 20 }),
+    ];
+    const pages = computePages(body, finalTwoCol(), makeCtx());
+    expect(pages[0]).toHaveLength(5);
+    for (const el of pages[0]) {
+      expect(colOf(el) ?? 0).toBe(0);
+      expect(colGeomOf(el)).toEqual([{ xPt: 20, wPt: 160 }]);
+    }
+  });
+
+  it('a continuous section break keeps both single-column sections on the SAME page, stacked', () => {
+    // Section A (1 para) — continuous → Section B (1 para) on the same page; final
+    // 2-col section gets a nextPage break. Both A and B are single-column full width
+    // and must NOT reset to the page top (B stacks below A).
+    const body: BodyElement[] = [
+      para({ text: 'A', fontSize: 20 }),
+      sectionBreak('continuous', null),
+      para({ text: 'B', fontSize: 20 }),
+      sectionBreak('nextPage', null),
+      para({ text: 'final', fontSize: 20 }),
+    ];
+    const pages = computePages(body, finalTwoCol(), makeCtx());
+    expect(pages.length).toBe(2);
+    // A and B share page 1 (continuous), final on page 2.
+    expect(pages[0].map(textOf)).toEqual(['A', 'B']);
+    expect(pages[1].map(textOf)).toEqual(['final']);
+    for (const el of pages[0]) {
+      expect(colGeomOf(el)).toEqual([{ xPt: 20, wPt: 160 }]);
+    }
+  });
+
+  it('single-section 2-col docs are UNCHANGED (no SectionBreak markers ⇒ whole body uses section.columns)', () => {
+    // Guard: with NO section breaks, columns = section.columns for the whole body,
+    // identical to the pre-fix global-columns behavior (sample-10's case).
+    const body = Array.from({ length: 7 }, (_, i) => para({ text: `p${i}`, fontSize: 20 }));
+    const pages = computePages(body, finalTwoCol(), makeCtx());
+    // 5 fill col0, 2 spill into col1 — one page (the existing newspaper-flow test).
+    expect(pages.length).toBe(1);
+    expect(pages[0].slice(0, 5).map(colOf)).toEqual([0, 0, 0, 0, 0]);
+    expect(pages[0].slice(5).map(colOf)).toEqual([1, 1]);
+    // Every element carries the same 2-col geometry (the body-level section's).
+    for (const el of pages[0]) {
+      expect(colGeomOf(el)).toEqual([
+        { xPt: 20, wPt: 70 },
+        { xPt: 110, wPt: 70 },
+      ]);
+    }
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop, ParagraphBorders, ParaBorderEdge, SectionProps, DocNote, NumberingInfo,
+  TabStop, ParagraphBorders, ParaBorderEdge, SectionProps, DocNote, NumberingInfo, ColumnGeom,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
@@ -623,15 +623,34 @@ export async function renderDocumentToCanvas(
     renderHeaderFooter(footer, footerTopY, baseState);
   }
 
-  // Body. ECMA-376 §17.6.4: lay out body text in the section's newspaper columns
-  // (one full-width column for a single-column section ⇒ unchanged path).
+  // Body. ECMA-376 §17.6.4: lay out body text in EACH section's newspaper columns
+  // (per-section columns). `columns` is the body-level (final) section's geometry,
+  // used as the fallback for elements that carry no per-section `colGeom` (single-
+  // section docs, where it equals the whole-body geometry — unchanged path).
   const columns = computeColumns(sec);
   const bodyState: RenderState = { ...baseState, y: sec.marginTop * scale };
   // Optional column separator rules (`<w:cols w:sep="1">`), drawn before the text
   // so glyphs sit on top. A thin rule is centred in each inter-column gap and
-  // spans the content height.
-  if (sec.columns?.sep && columns.length > 1) {
-    drawColumnSeparators(ctx, columns, sec, scale);
+  // spans the content height. With per-section columns a page can carry more than
+  // one section's geometry (a continuous break), so draw separators for each
+  // DISTINCT multi-column geometry actually present on this page (derived from the
+  // elements' stamped `colGeom`), falling back to the page-level `columns` when an
+  // element carries none. The `sep` flag is the final section's
+  // (`sec.columns?.sep`); threading a per-section sep toggle is unnecessary until a
+  // document mixes differing sep settings across sections sharing a page (rare,
+  // untested — both bundled samples use sep:false).
+  if (sec.columns?.sep) {
+    const seen = new Set<ColumnGeom[]>();
+    const geoms: ColumnGeom[][] = [];
+    for (const el of elements) {
+      const g = (el as PaginatedBodyElement).colGeom ?? columns;
+      if (g.length > 1 && !seen.has(g)) {
+        seen.add(g);
+        geoms.push(g);
+      }
+    }
+    if (geoms.length === 0 && columns.length > 1) geoms.push(columns);
+    for (const g of geoms) drawColumnSeparators(ctx, g, sec, scale);
   }
   renderBodyElements(elements, bodyState, columns);
 
@@ -878,13 +897,11 @@ function footnoteReserveHeightPt(
  * (ECMA-376 §17.11): the footnote bodies occupy the bottom of the text column,
  * so the body must stop short of them.
  */
-/** One newspaper column's page-absolute horizontal geometry (pt). `xPt` is the
- *  column's left edge measured from the page's left edge (i.e. it already
- *  includes `marginLeft`); `wPt` is the column's text width. */
-export interface ColumnGeom {
-  xPt: number;
-  wPt: number;
-}
+// `ColumnGeom` (one newspaper column's page-absolute x/width, pt) is defined in
+// ./types (alongside ColumnsSpec/ColSpec) so it can be referenced from
+// `PaginatedBodyElement` without a renderer↔types import cycle. Re-exported here
+// for callers that import it from the renderer.
+export type { ColumnGeom } from './types';
 
 /**
  * ECMA-376 §17.6.4 — resolve a section's newspaper columns to page-absolute
@@ -947,13 +964,36 @@ export function computePages(
   // footnote references are placed on the current page.
   const footnoteReservePt: number[] = [0];
 
-  // ECMA-376 §17.6.4 newspaper columns. For a single-column section this is one
-  // full-width column, so the loop below behaves exactly as before. `colIndex`
-  // tracks which column we are filling; `colX()`/`colW()` give its page-absolute
-  // left edge and text width (pt). Measurement uses the column width (not the
-  // full content band) and the column's left x as the float-window paraX, so
-  // square floats only constrain the column(s) their x-range intersects.
-  const columns = computeColumns(section);
+  // ECMA-376 §17.6.4 newspaper columns are PER-SECTION. A `<w:sectPr>` carried in
+  // a paragraph's `pPr` (or a loose mid-body one) ends a section; the parser emits
+  // a `SectionBreak` marker carrying THAT section's `<w:cols>`. The FINAL section's
+  // columns live on `section.columns` (the body-level sectPr). So the columns for
+  // the section that STARTS at body index `startIdx` are the `.columns` of the
+  // NEXT `SectionBreak` at/after `startIdx`; if there is none, the body-level
+  // section's columns. A `<w:cols>`-less section (columns == null) ⇒ one full-width
+  // column (computeColumns's single-column path), exactly as before.
+  const sectionColumnsFrom = (startIdx: number): ColumnGeom[] => {
+    for (let j = startIdx; j < body.length; j++) {
+      const e = body[j];
+      if (e.type === 'sectionBreak') {
+        // computeColumns reads only `section.columns` + the page geometry (which
+        // is constant across the body), so resolve this section's cols by
+        // swapping in its ColumnsSpec.
+        return computeColumns({ ...section, columns: e.columns ?? null });
+      }
+    }
+    return computeColumns(section);
+  };
+
+  // The active section's column geometry. Reassigned (a) here for the first
+  // section and (b) at every `SectionBreak` as the flow enters the next section.
+  // `colIndex` tracks which column we are filling; `colX()`/`colW()` give its
+  // page-absolute left edge and text width (pt). Measurement uses the column
+  // width (not the full content band) and the column's left x as the float-window
+  // paraX, so square floats only constrain the column(s) their x-range intersects.
+  // For a single-section document there are no SectionBreak markers, so `columns`
+  // stays `computeColumns(section)` for the whole body — byte-identical to before.
+  let columns = sectionColumnsFrom(0);
   let colIndex = 0;
   const colX = () => columns[colIndex].xPt;
   const colW = () => columns[colIndex].wPt;
@@ -1088,11 +1128,15 @@ export function computePages(
     return 0;
   };
 
-  // Stamp the active newspaper column on an element and push it onto the current
-  // page. For single-column sections colIndex is always 0 (the renderer treats
-  // 0/absent identically), so this is behaviour-neutral there.
+  // Stamp the active newspaper column (index + this section's geometry) on an
+  // element and push it onto the current page. For single-column sections
+  // colIndex is always 0 (the renderer treats 0/absent identically) and colGeom
+  // equals the page-level columns, so this is behaviour-neutral there. colGeom
+  // lets the renderer resolve the right section's column widths when two sections
+  // share a page (a continuous break).
   const pushTagged = (el: PaginatedBodyElement) => {
     el.colIndex = colIndex;
+    el.colGeom = columns;
     pages[pages.length - 1].push(el);
   };
 
@@ -1124,6 +1168,48 @@ export function computePages(
       } else if (el.parity === 'even' && pages.length % 2 === 1) {
         pages.push([]);
         startPageBookkeeping();
+      }
+      continue;
+    }
+    if (el.type === 'sectionBreak') {
+      // ECMA-376 §17.6.x — a section boundary. Switch the active newspaper-column
+      // geometry to the NEXT section (the one starting at i+1) and reset the
+      // column index, then break per the section's ST_SectionMark (§17.18.79).
+      // This is the per-section-columns fix: each section now lays out in its OWN
+      // columns instead of every section inheriting the body-level section's.
+      columns = sectionColumnsFrom(i + 1);
+      colIndex = 0;
+      if (el.kind === 'continuous') {
+        // ECMA-376 §17.18.79 "continuous": NO page break — the next section's
+        // content continues on the SAME page at the CURRENT vertical position
+        // (y is intentionally NOT reset), just in the new section's column 0.
+        // (sample-5's continuous break is 1-col → 1-col, so the two single-column
+        // sections simply stack; full continuous column-balancing for a column-
+        // count change is out of scope per the task.) prevPara is cleared so the
+        // first paragraph of the new section doesn't collapse spacing against the
+        // last paragraph of the previous one. Floats / footnote reserve stay
+        // (page-scoped). measureState.y already tracks the current y.
+        prevPara = null;
+        prevSpaceAfter = 0;
+      } else {
+        // nextPage (default) / oddPage / evenPage: start a new page (mirrors the
+        // pageBreak path, including parity padding). A new page already resets
+        // colIndex to 0 and clears page-scoped floats.
+        pages.push([]);
+        y = 0;
+        prevPara = null;
+        prevSpaceAfter = 0;
+        measureState.y = section.marginTop;
+        measureState.floats = [];
+        measureState.floatParaSeq = 0;
+        startPageBookkeeping();
+        if (el.kind === 'oddPage' && pages.length % 2 === 0) {
+          pages.push([]);
+          startPageBookkeeping();
+        } else if (el.kind === 'evenPage' && pages.length % 2 === 1) {
+          pages.push([]);
+          startPageBookkeeping();
+        }
       }
       continue;
     }
@@ -1263,9 +1349,11 @@ export function computePages(
           y, pageContentH, pages,
           // Overflow during the split advances to the next column first, then a
           // new page (newspaper fill). Each slice is tagged with the column it
-          // landed in via the colIndex thunk.
+          // landed in via the colIndex thunk, plus this section's column geometry
+          // (constant — a paragraph never spans a section boundary).
           () => { nextColumnOrPage(); },
           () => colIndex,
+          columns,
         );
         // After splitting, `y` is the bottom of the last slice in the
         // current column (continues for the LAST slice; intermediate slices
@@ -1313,6 +1401,7 @@ export function computePages(
           tbl, rowHs, y, tableContentH, pages,
           () => { nextColumnOrPage(); },
           () => colIndex,
+          columns,
         );
         y = endY;
         measureState.y = section.marginTop + endY;
@@ -1573,9 +1662,15 @@ function splitParagraphAcrossPages(
    *  slice is tagged with the column it landed in so the renderer flows it in the
    *  right column. Omitted (single-column / direct unit tests) ⇒ no tag. */
   tagColIndex?: () => number,
+  /** ECMA-376 §17.6.4 — the current SECTION's column geometry. A paragraph is
+   *  never split across a section boundary, so this is constant for all slices;
+   *  stamped so the renderer resolves the slice's column against the right
+   *  section. Omitted ⇒ the renderer uses the page-level columns. */
+  colGeom?: ColumnGeom[],
 ): { endY: number } {
   const stamp = (el: PaginatedBodyElement): PaginatedBodyElement => {
     if (tagColIndex) el.colIndex = tagColIndex();
+    if (colGeom) el.colGeom = colGeom;
     return el;
   };
   const indLeft = para.indentLeft;
@@ -2035,6 +2130,10 @@ export function splitTableAcrossPages(
    *  `newPage()`. When provided, each table slice is tagged with its column.
    *  Omitted (single-column / direct unit tests) ⇒ no tag. */
   tagColIndex?: () => number,
+  /** ECMA-376 §17.6.4 — the current SECTION's column geometry (constant across
+   *  the split; a table is never split across a section boundary). Stamped on
+   *  each slice so the renderer resolves its column against the right section. */
+  colGeom?: ColumnGeom[],
 ): number {
   const n = table.rows.length;
   // Leading tblHeader rows repeat on each continuation page.
@@ -2064,6 +2163,7 @@ export function splitTableAcrossPages(
     const sliceRows = isContinuation ? [...headerRows, ...bodyRows] : bodyRows;
     const sliceEl = { ...table, type: 'table', rows: sliceRows } as PaginatedBodyElement;
     if (tagColIndex) sliceEl.colIndex = tagColIndex();
+    if (colGeom) sliceEl.colGeom = colGeom;
     pages[pages.length - 1].push(sliceEl);
 
     y += used;
@@ -2167,33 +2267,59 @@ function drawColumnSeparators(
 function renderBodyElements(
   elements: PaginatedBodyElement[],
   state: RenderState,
-  /** ECMA-376 §17.6.4 — page-absolute column geometry (pt). When provided and
-   *  the page spans multiple columns, the flow is reset to each element's tagged
-   *  column. Omitted (header/footer, single-column) ⇒ the state's existing
-   *  full-width contentX/contentW is used unchanged. */
+  /** ECMA-376 §17.6.4 — page-absolute column geometry (pt) for the page. Used as
+   *  the fallback when an element carries no per-section `colGeom` (header /
+   *  footer, single-column). Omitted ⇒ the state's existing full-width
+   *  contentX/contentW is used unchanged. */
   columns?: ColumnGeom[],
 ): void {
   let prevPara: DocParagraph | null = null;
   let prevSpaceAfter = 0;
-  // The column whose flow `state` is currently set to. Starts at -1 so the first
-  // element always seeds the column (when `columns` drives multi-column layout).
+  // The (geometry, column index) the flow `state` is currently set to. `activeCol`
+  // starts at -1 so the first element always seeds the column. `activeGeom` tracks
+  // the SECTION whose columns are in effect (per-section newspaper columns,
+  // §17.6.4): elements carry their own section's geometry in `colGeom`, so two
+  // sections sharing a page (a continuous break) each resolve their `colIndex`
+  // against the right widths.
   let activeCol = -1;
-  const multiCol = !!columns && columns.length > 1;
+  let activeGeom: ColumnGeom[] | undefined;
   for (const el of elements) {
-    // Reset the flow when this element belongs to a different newspaper column
-    // than the one currently set up (also seeds the first element). Floats are
-    // NOT cleared here — they are page-scoped and the per-page fresh bodyState
-    // already gave a clean set, so a full-width wrapTopAndBottom band still
-    // pushes down every column and square floats keep constraining their columns.
+    // Per-section column geometry: prefer the element's own (stamped by the
+    // paginator), else the page-level columns. A single full-width column (or no
+    // geometry) is the unchanged single-column path.
+    const cols = el.colGeom ?? columns;
+    const multiCol = !!cols && cols.length > 1;
     const elCol = el.colIndex ?? 0;
-    if (multiCol && elCol !== activeCol) {
-      const col = columns[Math.min(elCol, columns.length - 1)];
+    // Switch the flow when this element's section geometry OR its column index
+    // changed (also seeds the first element). Reset the vertical cursor to the
+    // column TOP only when ADVANCING to a higher column within the page (newspaper
+    // fill); a same-or-lower colIndex from a continuous section break continues at
+    // the current y so the new section stacks below the previous one rather than
+    // overprinting it. Floats are NOT cleared here — they are page-scoped and the
+    // per-page fresh bodyState already gave a clean set.
+    if (multiCol && (cols !== activeGeom || elCol !== activeCol)) {
+      const col = cols[Math.min(elCol, cols.length - 1)];
       state.contentX = col.xPt * state.scale;
       state.contentW = col.wPt * state.scale;
-      state.y = state.marginTop * state.scale;
+      if (elCol > activeCol && cols === activeGeom) {
+        state.y = state.marginTop * state.scale;
+      }
       prevPara = null;
       prevSpaceAfter = 0;
       activeCol = elCol;
+      activeGeom = cols;
+    } else if (!multiCol && cols && cols.length === 1 && cols !== activeGeom) {
+      // A single-column SECTION on a multi-section page (e.g. sample-5 sections
+      // 1–4): set the full-width content band for this section. Continue at the
+      // current y (continuous) — only the page-level fresh state / a page break
+      // resets to the top, both handled by the caller.
+      const col = cols[0];
+      state.contentX = col.xPt * state.scale;
+      state.contentW = col.wPt * state.scale;
+      prevPara = null;
+      prevSpaceAfter = 0;
+      activeCol = elCol;
+      activeGeom = cols;
     }
     if (el.type === 'paragraph') {
       const para = el as unknown as DocParagraph;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -168,6 +168,14 @@ export interface ColSpec {
   spacePt: number;
 }
 
+/** ECMA-376 §17.6.4 — a single newspaper column resolved to its page-absolute
+ *  left edge (`xPt`) and text width (`wPt`), in pt. Produced by `computeColumns`
+ *  (in the renderer) from a section's {@link ColumnsSpec} + the page geometry. */
+export interface ColumnGeom {
+  xPt: number;
+  wPt: number;
+}
+
 export type BodyElement =
   | { type: 'paragraph' } & DocParagraph
   | { type: 'table' } & DocTable
@@ -175,7 +183,18 @@ export type BodyElement =
   /** ECMA-376 §17.3.1.20 `<w:br w:type="column"/>` — force the following content
    *  into the next newspaper column (or the next page's first column when
    *  already in the last column). Hoisted to the body level by the parser. */
-  | { type: 'columnBreak' };
+  | { type: 'columnBreak' }
+  /** ECMA-376 §17.6.x — a section boundary in the body. A `<w:sectPr>` carried in
+   *  a paragraph's `pPr` (or a loose mid-body one) defines the section that ENDS
+   *  here; the FINAL section's settings live on {@link DocxDocumentModel.section}.
+   *  `columns` is the ENDING section's `<w:cols>` (§17.6.4; absent ⇒ single
+   *  full-width column — the spec default for `@w:num` 1). `kind` is the
+   *  ST_SectionMark (§17.18.79) controlling how the NEXT section starts:
+   *  "continuous" (same page), "nextPage" (default; page break), "oddPage" /
+   *  "evenPage" (page break + parity padding). The paginator switches its active
+   *  newspaper-column geometry per section at each marker — fixing the regression
+   *  where every section inherited the body-level section's columns. */
+  | { type: 'sectionBreak'; kind: 'continuous' | 'nextPage' | 'oddPage' | 'evenPage' | string; columns?: ColumnsSpec | null };
 
 /** A BodyElement annotated with a line range to render. Set when the
  *  paginator splits a paragraph that doesn't fit on a single page —
@@ -187,6 +206,14 @@ export type BodyElement =
 export type PaginatedBodyElement = BodyElement & {
   lineSlice?: { start: number; end: number };
   colIndex?: number;
+  /** ECMA-376 §17.6.4 — the column geometry of the SECTION this element belongs
+   *  to (per-section newspaper columns). Stamped by the paginator so the renderer
+   *  resolves `colIndex` against the right section's columns even when two
+   *  sections share a page (a "continuous" section break). Absent ⇒ the renderer
+   *  uses the page-level `columns` it was given (single-section / header / footer
+   *  paths), so single-section documents are unaffected. Runtime-only — never
+   *  emitted by the parser. */
+  colGeom?: ColumnGeom[];
 };
 
 export interface DocParagraph {


### PR DESCRIPTION
## Regression
`private/sample-5.docx` is single-column in Word, but we rendered it **entirely 2-column**. Root cause: §17.6.4 newspaper columns are **per-section**, but the model has one `Document.section` (the body-level/final `sectPr`) and the renderer applied its `columns` to the whole document. sample-5's final (body-level) section is `<w:cols w:num="2">` (1 paragraph), so the bulk — section 1's 9 paragraphs, which are 1-column — got 2 columns.

## Fix — columns resolved per section
- **parser**: every mid-body section break now emits `BodyElement::SectionBreak { kind, columns }` carrying that ending section's `<w:cols>` (`parse_columns`; `None` for 1-column), **including `continuous`** breaks (previously dropped entirely). `Document.section.columns` stays the final/body-level section.
- **renderer**: `computePages` resolves the active columns per section via `sectionColumnsFrom` (peek forward to the next `SectionBreak` = the section starting here; body-level when none) and switches at each break — reset `colIndex`; `nextPage`/`oddPage`/`evenPage` page-break (with parity); `continuous` stays on the same page (y not reset), just new column 0. Each placed element is stamped `colGeom` so **measure==draw** and two sections sharing a page use their own widths.

## Single-section unchanged
With no `SectionBreak` markers, `columns` falls straight through to `computeColumns(section)` for the whole body — byte-identical to before. **sample-10 (single-section `num=2`) stays 2-column.**

## Verification
- `cargo test` 87 · `clippy -D warnings` clean · `vitest` 477 (new parser tests + 4 per-section pagination tests) · `tsc --build` clean.
- **Real files**: sample-5 → section 1 lays out in **1 column** (`colGeom.len=1`), only the final 1-paragraph section is 2-col; sample-10 → **2 columns throughout** (`hasSectionBreak=false`).
- Independent review: **merge-ready** (spec-faithful §17.6.4/§17.18.79; single-section provably unchanged; no heuristics).

Known limitation (documented in-code, out of scope): a `continuous` break that *changes column count* mid-page isn't column-balanced (non-crashing); sample-5's continuous break is 1col→1col.

> Merge with `--merge` (no squash), per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)