### PR TITLE
fix(docx): honor wp:align on anchored images (§20.4.3.1)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2246,6 +2246,9 @@ fn parse_inline_drawing(
             // Inline image: not a float, so the overlap constraint is moot.
             // Carry the spec no-constraint value (true).
             allow_overlap: true,
+            // Inline images have no wp:align (positionH/V is anchor-only).
+            anchor_x_align: None,
+            anchor_y_align: None,
         })];
     }
 
@@ -2385,6 +2388,12 @@ fn parse_inline_drawing(
         dist_right: anchor_meta.dist_right,
         wrap_side: anchor_meta.wrap_side.clone(),
         allow_overlap: anchor_meta.allow_overlap,
+        // ECMA-376 §20.4.3.1 wp:align (positionH/V). Mirrors the ShapeRun
+        // `apply_pos_meta` path so a `<wp:align>center</wp:align>` anchor image
+        // is centered within its relativeFrom container instead of pinned to
+        // the discarded posOffset. `None` falls back to the offset path.
+        anchor_x_align: x_align.clone(),
+        anchor_y_align: y_align.clone(),
     })]
 }
 
@@ -2792,6 +2801,16 @@ fn parse_group_pic(
         dist_right: anchor_meta.dist_right,
         wrap_side: anchor_meta.wrap_side.clone(),
         allow_overlap: anchor_meta.allow_overlap,
+        // wgp child images are positioned by the group transform chain:
+        // anchor_x_pt / anchor_y_pt already carry the full page-absolute
+        // position (group page offset + the child's scaled in-group offset).
+        // The wgp ShapeRun path differs — it leaves the within-group offset in
+        // anchor_x_pt and lets resolveShapeBox center the GROUP via
+        // groupWidthPt — but ImageRun carries no group dimensions, so honoring
+        // align here would double-count the offset. Leave align unset; group
+        // align (if any) is already baked into anchor_x_pt by parse_wgp_images.
+        anchor_x_align: None,
+        anchor_y_align: None,
     })
 }
 
@@ -5795,6 +5814,8 @@ mod svg_blip_tests {
             dist_right: 0.0,
             wrap_side: None,
             allow_overlap: true,
+            anchor_x_align: None,
+            anchor_y_align: None,
         };
         let json = serde_json::to_string(&run).expect("serialize");
         assert!(

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1037,6 +1037,18 @@ pub struct ImageRun {
     /// `false` mandates the renderer reposition the object to prevent any overlap.
     /// Inline images carry true (the no-constraint value).
     pub allow_overlap: bool,
+    /// ECMA-376 §20.4.3.1 wp:align (positionH/wp:align). When present the
+    /// renderer centers / left-aligns / right-aligns the image within the
+    /// container indicated by `anchor_x_from_margin`. Values: "left",
+    /// "center", "right" (others fall back to "left"). Mirrors
+    /// `ShapeRun::anchor_x_align`. `None` for inline images and offset-based
+    /// anchors.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_x_align: Option<String>,
+    /// Vertical equivalent of anchor_x_align (positionV/wp:align).
+    /// Values: "top", "center", "bottom".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_y_align: Option<String>,
 }
 
 fn is_zero_f64(v: &f64) -> bool {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4935,15 +4935,30 @@ function resolveAnchorBox(
   paraBaseY: number,
 ): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } {
   const scale = state.scale;
+  const w = img.widthPt * scale;
+  const h = img.heightPt * scale;
+  // ECMA-376 §20.4.3.1 wp:align — when positionH/V carry <wp:align>, the
+  // renderer aligns the image within its relativeFrom container instead of
+  // using the (discarded) posOffset. Mirrors resolveShapeBox (the ShapeRun
+  // equivalent): we route X/Y through resolveAnchorX/Y with the image's own
+  // box size as the align size. ImageRun carries neither a raw relativeFrom
+  // string nor pctPos/sizeRel, so those args are null and the boolean
+  // anchorXFromMargin / anchorYFromPara hints pick page-vs-margin containers
+  // (xContainer/yContainer). When align is absent, resolveAnchorX/Y fall back
+  // to the same offset path this function used previously.
+  const x = resolveAnchorX(
+    img.anchorXAlign, img.anchorXFromMargin ?? false, img.anchorXPt ?? 0, w, state,
+    null, null, null,
+  );
+  const y = resolveAnchorY(
+    img.anchorYAlign, img.anchorYFromPara ?? false, img.anchorYPt ?? 0, h, paraBaseY, state,
+    null, null, null,
+  );
   return {
-    x: img.anchorXFromMargin
-      ? (state.marginLeft + (img.anchorXPt ?? 0)) * scale
-      : (img.anchorXPt ?? 0) * scale,
-    y: img.anchorYFromPara
-      ? paraBaseY + (img.anchorYPt ?? 0) * scale
-      : (img.anchorYPt ?? 0) * scale,
-    w: img.widthPt * scale,
-    h: img.heightPt * scale,
+    x,
+    y,
+    w,
+    h,
     dl: (img.distLeft   ?? 0) * scale,
     dr: (img.distRight  ?? 0) * scale,
     dt: (img.distTop    ?? 0) * scale,

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -705,6 +705,14 @@ export interface ImageRun {
    * reposition the object to prevent any overlap.
    */
   allowOverlap?: boolean;
+  /** ECMA-376 §20.4.3.1 wp:align horizontal: "left" | "center" | "right" |
+   *  "inside" | "outside". When set the renderer aligns the image inside the
+   *  container indicated by `anchorXFromMargin` and ignores `anchorXPt`.
+   *  Mirrors {@link ShapeRun.anchorXAlign}. Absent for inline images and
+   *  offset-based anchors. */
+  anchorXAlign?: string | null;
+  /** Vertical equivalent of anchorXAlign: "top" | "center" | "bottom". */
+  anchorYAlign?: string | null;
 }
 
 // ===== Table =====


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 7 — the "centered green dot" rendered flush-left because anchored **images** discarded `<wp:align>`, while anchored **shapes** honored it.

`ImageRun` now carries `anchor_x_align` / `anchor_y_align`, mirroring `ShapeRun` end-to-end:
- Parser already extracted the align tokens (`parse_anchor_pos_h/v`); the single-blip anchor path now forwards them to `ImageRun`.
- `resolveAnchorBox` routes X/Y through the same `resolveAnchorX` / `resolveAnchorY` helpers `resolveShapeBox` uses (§20.4.3.1 `wp:align`).
- align-absent anchors are byte-identical to before (the blue side arrows use `posOffset`, unaffected).
- wgp group-child images keep `align=None` (their anchor offset is already page-absolute; honoring align would double-count).

## Verification
- Rust: fmt/clippy clean, 92 tests pass; WASM rebuilt.
- TS typecheck clean.
- VRT: 21/21 pass (no regression on existing anchor-image samples).
- Visual: rendered page 7 — green dot now horizontally centered, matching the Word PDF.

Part of the sample-11 fidelity series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)