### PR TITLE
fix(docx): hyperlink appearance from rStyle, not link kind (§17.7.5)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1813,28 +1813,24 @@ fn parse_run_inner(
         return;
     }
 
-    // External links (URL) vs internal-document links (anchor: TOC entries,
-    // cross-references). Word renders internal links as plain body text — NOT with
-    // the Hyperlink style's blue/underline — so strip that styling here.
+    // ECMA-376 §17.16.22 (<w:hyperlink>) defines link *structure* only — the
+    // r:id / w:anchor targets and click behaviour. It carries no visual styling.
+    // A link's blue/underline appearance comes entirely from the run's character
+    // style (typically `rStyle="Hyperlink"`, §17.7.5) plus any direct rPr, which
+    // are already resolved into `fmt` above. So both external (URL) and internal
+    // (anchor: TOC entries, cross-references) links honour the resolved `fmt`
+    // identically; we do not strip styling from internal links nor synthesize
+    // blue/underline for external ones. `is_link` still records link presence so
+    // the renderer can hit-test, and `hyperlink` carries the resolved href.
     let is_link = link_href.is_some();
-    let is_external = matches!(link_href, Some(Some(_)));
-    let is_internal = matches!(link_href, Some(None));
     let hyperlink = link_href.clone().flatten();
-    if is_internal {
-        fmt.color = base_run.color.clone();
-        fmt.underline = base_run.underline;
-    }
 
     let bold = fmt.bold.unwrap_or(false);
     let italic = fmt.italic.unwrap_or(false);
-    let underline = fmt.underline.unwrap_or(false) || is_external;
+    let underline = fmt.underline.unwrap_or(false);
     let strikethrough = fmt.strikethrough.unwrap_or(false);
     let font_size = fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE);
-    let color = if is_external && fmt.color.is_none() {
-        Some("0563c1".to_string())
-    } else {
-        fmt.color.clone()
-    };
+    let color = fmt.color.clone();
     let font_family = theme
         .resolve_font_ref(fmt.font_family_ascii.clone())
         .or_else(|| theme.resolve_font_ref(fmt.font_family_east_asia.clone()));


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 5 — the in-document link "paragraph level formatting" rendered black/no-underline while the external "calibre download page" was blue+underlined. Word renders **both** blue+underlined.

A hyperlink's appearance comes from the run's character style (`rStyle="Hyperlink"`) + direct rPr, **not** from the `<w:hyperlink>` element (§17.16.22 is structural; §17.7.5 governs the style cascade). Two heuristics in `parse_run_inner` violated this and are removed:

- **internal-link strip**: reset the already-resolved Hyperlink style (blue+underline) back to body text — the direct cause of #4.
- **external-link force**: synthesised `0563C1` + underline for unstyled external links.

`underline`/`color` now derive purely from the resolved run formatting; internal and external links render identically.

## Why removing the external force is VRT-safe
Every external link in the covered samples carries a character style whose **`<w:name>` is "Hyperlink"** (supplying underline+color), even where the `styleId` is obfuscated — e.g. demo/sample-1 uses `rStyle="af7"` (name "Hyperlink", `u single`, `color 467886`, then the run's rPr overrides to gray). So the force was redundant, and its `0563C1` was the wrong blue for sample-11 (whose Hyperlink style is `0000FF`).

## Verification
- Rust fmt/clippy clean, 92 unit tests pass; WASM rebuilt.
- TS typecheck clean.
- **VRT 21/21 pass** — demo/sample-1 p1 (the external-link page) = 100% match, confirming the underline now comes from rStyle.
- Visual: page 5 — both links render blue+underline, matching the Word PDF.

Part of the sample-11 fidelity series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)