### PR TITLE
feat(docx): table-style conditional & whole-table run/para formatting (§17.7.6)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1274,6 +1274,32 @@ fn parse_paragraph(
     theme: &ThemeColors,
     table_style_id: Option<&str>,
 ) -> DocParagraph {
+    parse_paragraph_cond(
+        node,
+        style_map,
+        num_map,
+        media_map,
+        rel_map,
+        theme,
+        table_style_id,
+        None,
+    )
+}
+
+/// Parse a paragraph, optionally layering a table style's resolved conditional
+/// formatting (§17.7.6, threaded from `parse_table`) as a base below the
+/// paragraph/character styles and direct formatting (§17.7.2 ordering).
+#[allow(clippy::too_many_arguments)]
+fn parse_paragraph_cond(
+    node: roxmltree::Node,
+    style_map: &StyleMap,
+    num_map: &mut NumberingMap,
+    media_map: &HashMap<String, String>,
+    rel_map: &HashMap<String, String>,
+    theme: &ThemeColors,
+    table_style_id: Option<&str>,
+    cond: Option<&CondFmt>,
+) -> DocParagraph {
     // Get style ID from pPr/pStyle. When absent, resolve_para falls back to the
     // paragraph style marked w:default="1" via StyleMap::default_para_style_id.
     let ppr_node = child_w(node, "pPr");
@@ -1281,9 +1307,9 @@ fn parse_paragraph(
         .and_then(|p| child_w(p, "pStyle"))
         .and_then(|s| attr_w(s, "val"));
 
-    // Resolve base formatting from style
+    // Resolve base formatting from style (incl. table-style conditional rPr/pPr).
     let (mut base_para, mut base_run) =
-        style_map.resolve_para(explicit_style_id.as_deref(), table_style_id);
+        style_map.resolve_para_cond(explicit_style_id.as_deref(), table_style_id, cond);
 
     // Apply direct paragraph formatting overrides
     if let Some(ppr) = ppr_node {
@@ -3989,45 +4015,60 @@ fn parse_table(
         })
         .unwrap_or((0.0, 0.0, 3.6, 3.6));
 
-    let mut rows = vec![];
-    let mut row_cnf: Vec<Option<String>> = vec![];
-    for tr_node in children_w_flat(node, "tr") {
-        // §17.4.7 conditional-format bitmask on the row (firstRow/band1Horz/…).
-        row_cnf.push(
-            child_w(tr_node, "trPr")
+    // §17.4.7 conditional-format bitmask on each row (firstRow/band1Horz/…),
+    // captured up front so we can both (a) thread the resolved conditional
+    // rPr/pPr into the cell content as a base layer (§17.7.2), and (b) apply the
+    // conditional cell shading post-hoc below.
+    let tr_nodes: Vec<roxmltree::Node> = children_w_flat(node, "tr");
+    let row_cnf: Vec<Option<String>> = tr_nodes
+        .iter()
+        .map(|tr| {
+            child_w(*tr, "trPr")
                 .and_then(|p| child_w(p, "cnfStyle"))
-                .and_then(|c| attr_w(c, "val")),
-        );
-        let row = parse_table_row(
-            tr_node,
-            style_map,
-            num_map,
-            media_map,
-            rel_map,
-            theme,
-            table_style_id.as_deref(),
-        );
-        rows.push(row);
-    }
+                .and_then(|c| attr_w(c, "val"))
+        })
+        .collect();
 
-    // Apply table-style cell shading + vAlign where the cell didn't set them inline.
-    // Only treat row 0 as a non-banded "first row" when firstRow is enabled AND the
-    // style's firstRow conditional actually carries formatting; an empty firstRow
-    // (like EHC) must NOT shift the banding (Word bands from row 0 → 1st row = band1).
+    // Only treat row 0 as a non-banded "first row" when firstRow is enabled AND
+    // the style's firstRow conditional actually carries shading; an empty
+    // firstRow (like EHC) must NOT shift the banding (Word bands from row 0 →
+    // 1st row = band1). NOTE: this gate uses `shd` deliberately — it governs the
+    // horizontal-banding PARITY for cell shading, not whether firstRow rPr/pPr
+    // applies. The conditional run/paragraph formatting (color, jc, …) is keyed
+    // separately by `firstRow_has_fmt` below so a header row with only a color
+    // (e.g. Calendar 3) still inherits firstRow rPr.
     let first_row_styled = first_row
         && tstyle
             .cond
             .get("firstRow")
             .map(|c| c.shd.is_some())
             .unwrap_or(false);
-    for (r, row) in rows.iter_mut().enumerate() {
-        // Pick the conditional format: the row's explicit cnfStyle wins (§17.4.7);
-        // otherwise fall back to tblLook firstRow + horizontal banding by row parity.
-        let cond_name: Option<String> = if let Some(cnf) = &row_cnf[r] {
+    // firstRow rPr/pPr is honored whenever firstRow is enabled and the style
+    // defines ANY firstRow run/para formatting (independent of shading).
+    let first_row_has_fmt = first_row
+        && tstyle
+            .cond
+            .get("firstRow")
+            .map(|c| c.run.is_some() || c.para.is_some())
+            .unwrap_or(false);
+
+    // Resolve the conditional-format KEY for row `r`. The row's explicit
+    // cnfStyle wins (§17.4.7); otherwise fall back to tblLook firstRow +
+    // horizontal banding by row parity. Used both for content threading (below)
+    // and post-hoc cell shading. Scope note: `cnf_to_cond` only decodes the four
+    // row-level bits (firstRow/lastRow/band1Horz/band2Horz); column-band and
+    // corner conditions (firstCol/lastCol/band*Vert/neCell/…) are NOT resolved
+    // here, so their conditional rPr/pPr (e.g. Calendar 3's firstCol color) is
+    // intentionally unsupported.
+    let cond_name_for = |r: usize| -> Option<String> {
+        if let Some(cnf) = &row_cnf[r] {
             cnf_to_cond(cnf)
-        } else if r == 0 && first_row_styled {
+        } else if r == 0 && (first_row_styled || first_row_has_fmt) {
             Some("firstRow".to_string())
         } else if h_band {
+            // The banding parity offset only shifts when row 0 was consumed as a
+            // SHADED first row; a first row that only carries rPr/pPr (no shd)
+            // still bands from row 0 like Word.
             let bi = if first_row_styled {
                 r as i64 - 1
             } else {
@@ -4043,8 +4084,32 @@ fn parse_table(
             )
         } else {
             None
-        };
-        let cond: Option<&CondFmt> = cond_name.as_deref().and_then(|n| tstyle.cond.get(n));
+        }
+    };
+
+    let mut rows = vec![];
+    for (r, tr_node) in tr_nodes.iter().enumerate() {
+        // §17.7.2: thread the row's resolved conditional rPr/pPr into the cell
+        // content as a BASE layer (below paragraph/character styles + direct
+        // formatting). A first-row band condition gives the calendar header its
+        // 365F91 blue; band rows pick up their banded run color, etc.
+        let cond: Option<&CondFmt> = cond_name_for(r).as_deref().and_then(|n| tstyle.cond.get(n));
+        let row = parse_table_row(
+            *tr_node,
+            style_map,
+            num_map,
+            media_map,
+            rel_map,
+            theme,
+            table_style_id.as_deref(),
+            cond,
+        );
+        rows.push(row);
+    }
+
+    // Apply table-style cell shading + vAlign where the cell didn't set them inline.
+    for (r, row) in rows.iter_mut().enumerate() {
+        let cond: Option<&CondFmt> = cond_name_for(r).as_deref().and_then(|n| tstyle.cond.get(n));
         let row_shd = cond
             .and_then(|c| c.shd.clone())
             .or_else(|| tstyle.cell_shd.clone());
@@ -4115,6 +4180,7 @@ fn parse_table(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn parse_table_row(
     node: roxmltree::Node,
     style_map: &StyleMap,
@@ -4123,6 +4189,9 @@ fn parse_table_row(
     rel_map: &HashMap<String, String>,
     theme: &ThemeColors,
     table_style_id: Option<&str>,
+    // §17.7.6 resolved conditional formatting for this row (firstRow/band*Horz),
+    // threaded into cell content as a base layer below paragraph/char styles.
+    cond: Option<&CondFmt>,
 ) -> DocTableRow {
     let tr_pr = child_w(node, "trPr");
     let tr_height_node = tr_pr.and_then(|p| child_w(p, "trHeight"));
@@ -4145,6 +4214,7 @@ fn parse_table_row(
             rel_map,
             theme,
             table_style_id,
+            cond,
         );
         cells.push(cell);
     }
@@ -4157,6 +4227,7 @@ fn parse_table_row(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn parse_table_cell(
     node: roxmltree::Node,
     style_map: &StyleMap,
@@ -4165,6 +4236,8 @@ fn parse_table_cell(
     rel_map: &HashMap<String, String>,
     theme: &ThemeColors,
     table_style_id: Option<&str>,
+    // §17.7.6 resolved conditional formatting for the owning row.
+    cond: Option<&CondFmt>,
 ) -> DocTableCell {
     let tc_pr = child_w(node, "tcPr");
 
@@ -4236,7 +4309,7 @@ fn parse_table_cell(
     let mut content: Vec<CellElement> = vec![];
     for child in element_children_flat(node) {
         match child.tag_name().name() {
-            "p" => content.push(CellElement::Paragraph(parse_paragraph(
+            "p" => content.push(CellElement::Paragraph(parse_paragraph_cond(
                 child,
                 style_map,
                 num_map,
@@ -4244,7 +4317,10 @@ fn parse_table_cell(
                 rel_map,
                 theme,
                 table_style_id,
+                cond,
             ))),
+            // A nested table resolves its OWN table style + conditional
+            // formatting; the outer cell's `cond` does not propagate into it.
             "tbl" => content.push(CellElement::Table(parse_table(
                 child, style_map, num_map, media_map, rel_map, theme,
             ))),

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -162,6 +162,15 @@ pub struct RawTblBorders {
 pub struct CondFmt {
     pub shd: Option<String>,
     pub borders: RawTblBorders,
+    /// ECMA-376 §17.7.6: the conditional block's `<w:rPr>` — run defaults that
+    /// apply to runs in cells covered by this condition (e.g. Calendar 3's
+    /// firstRow sets `<w:color w:val="365F91"/>` for the "Sun/Mon/…" header).
+    /// Layered as a BASE below paragraph/character styles and direct rPr
+    /// (§17.7.2), so a directly-colored run still wins.
+    pub run: Option<RunFmt>,
+    /// ECMA-376 §17.7.6: the conditional block's `<w:pPr>` — paragraph defaults
+    /// for cells covered by this condition (e.g. firstRow `<w:jc w:val="right"/>`).
+    pub para: Option<ParaFmt>,
 }
 
 /// Table style (`w:style w:type="table"`) cell/border formatting.
@@ -171,6 +180,17 @@ pub struct TableStyleDef {
     pub borders: RawTblBorders,
     pub cell_shd: Option<String>,
     pub cell_valign: Option<String>,
+    /// ECMA-376 §17.7.6: the table style's whole-table `<w:rPr>` — run defaults
+    /// applied to every cell (e.g. Calendar 3's `<w:color w:val="7F7F7F"/>`
+    /// makes day numbers gray). Layered below the conditional `run` but above
+    /// docDefaults (§17.7.2).
+    pub run: Option<RunFmt>,
+    /// ECMA-376 §17.7.6: the table style's whole-table `<w:pPr>` — paragraph
+    /// defaults for every cell (e.g. Calendar 3's `<w:jc w:val="right"/>`).
+    /// "Table Grid"'s line/after spacing is already threaded through
+    /// `StyleMap::styles`; this field carries the table style's pPr for the
+    /// conditional-formatting resolution path used by `resolve_table_cond`.
+    pub para: Option<ParaFmt>,
     /// keyed by w:tblStylePr w:type (firstRow, band1Horz, band2Horz, …).
     pub cond: HashMap<String, CondFmt>,
 }
@@ -317,12 +337,27 @@ impl StyleMap {
             if def.cell_valign.is_some() {
                 out.cell_valign = def.cell_valign.clone();
             }
+            // §17.7.6: a derived table style's whole-table rPr/pPr layers ON TOP
+            // of the base style's. We fold each level into a single accumulated
+            // RunFmt/ParaFmt with the standard merge semantics (later wins).
+            if let Some(r) = &def.run {
+                apply_run(out.run.get_or_insert_with(RunFmt::default), r);
+            }
+            if let Some(p) = &def.para {
+                apply_para(out.para.get_or_insert_with(ParaFmt::default), p);
+            }
             for (k, v) in &def.cond {
                 let slot = out.cond.entry(k.clone()).or_default();
                 if v.shd.is_some() {
                     slot.shd = v.shd.clone();
                 }
                 merge_raw_borders(&mut slot.borders, &v.borders);
+                if let Some(r) = &v.run {
+                    apply_run(slot.run.get_or_insert_with(RunFmt::default), r);
+                }
+                if let Some(p) = &v.para {
+                    apply_para(slot.para.get_or_insert_with(ParaFmt::default), p);
+                }
             }
         }
         out
@@ -337,6 +372,27 @@ impl StyleMap {
         style_id: Option<&str>,
         table_style_id: Option<&str>,
     ) -> (ParaFmt, RunFmt) {
+        self.resolve_para_cond(style_id, table_style_id, None)
+    }
+
+    /// Like [`resolve_para`], but additionally layers a table style's resolved
+    /// conditional formatting (`w:tblStylePr`'s `<w:rPr>`/`<w:pPr>`, §17.7.6)
+    /// onto the cell's base formatting.
+    ///
+    /// ECMA-376 §17.7.2 style-application order (low→high): docDefaults <
+    /// table-style (whole-table) < **table conditional** < numbering <
+    /// paragraph style < character style < direct. So the conditional layer is
+    /// applied AFTER the whole-table table-style chain but BEFORE the paragraph
+    /// style — it is a BASE the paragraph/character styles and direct rPr (which
+    /// the caller applies via `apply_direct_*` on top of the returned values)
+    /// override, never the other way around. This is why a cell whose run
+    /// carries a direct color still wins over a conditional row color.
+    pub fn resolve_para_cond(
+        &self,
+        style_id: Option<&str>,
+        table_style_id: Option<&str>,
+        cond: Option<&CondFmt>,
+    ) -> (ParaFmt, RunFmt) {
         let mut merged_para = ParaFmt::default();
         let mut merged_run = RunFmt::default();
 
@@ -346,9 +402,25 @@ impl StyleMap {
         // Table style pPr applies to every paragraph inside the table, below
         // the paragraph style (§17.7.6). "Table Grid" sets line=240 after=0;
         // without this, cell paragraphs inherit docDefault's M=1.15 spacing
-        // and render ~3pt taller per line than Word.
+        // and render ~3pt taller per line than Word. This step also folds in the
+        // table style's whole-table rPr (e.g. Calendar 3's gray day-number
+        // color) since table styles are indexed in `self.styles`.
         if let Some(tid) = table_style_id {
             self.apply_style_chain(tid, &mut merged_para, &mut merged_run);
+        }
+
+        // §17.7.2: the row/band conditional formatting sits one layer above the
+        // whole-table table style and below the paragraph style. Apply its pPr
+        // then rPr with the standard merge semantics (set values override, unset
+        // inherit) so e.g. firstRow's `<w:color w:val="365F91"/>` colors the
+        // header runs unless a more specific layer overrides it.
+        if let Some(c) = cond {
+            if let Some(p) = &c.para {
+                apply_para(&mut merged_para, p);
+            }
+            if let Some(r) = &c.run {
+                apply_run(&mut merged_run, r);
+            }
         }
 
         // Use explicit pStyle if present, otherwise fall back to the
@@ -998,6 +1070,19 @@ fn parse_tbl_style_def(style_node: roxmltree::Node, based_on: Option<String>) ->
         def.cell_shd = shd_fill(tc_pr);
         def.cell_valign = child_w(tc_pr, "vAlign").and_then(|v| attr_w(v, "val"));
     }
+    // ECMA-376 §17.7.6: a table style's top-level `<w:rPr>`/`<w:pPr>` are
+    // whole-table run/paragraph defaults applied to every cell (e.g. Calendar 3
+    // sets `<w:color w:val="7F7F7F"/>` so day numbers are gray, and `<w:jc
+    // w:val="right"/>` so they right-align). These are also indexed in
+    // `StyleMap::styles` for the resolve_para pPr path, but we keep a copy here
+    // so the conditional-formatting resolution (resolve_table_cond) can layer
+    // them below the conditional rPr/pPr without re-walking the named-style map.
+    if let Some(rpr) = child_w(style_node, "rPr") {
+        def.run = Some(parse_run_fmt(rpr));
+    }
+    if let Some(ppr) = child_w(style_node, "pPr") {
+        def.para = Some(parse_para_fmt(ppr));
+    }
     for sp in children_w(style_node, "tblStylePr") {
         let Some(typ) = attr_w(sp, "type") else {
             continue;
@@ -1013,6 +1098,14 @@ fn parse_tbl_style_def(style_node: roxmltree::Node, based_on: Option<String>) ->
             if let Some(borders) = child_w(tbl_pr, "tblBorders") {
                 merge_raw_borders(&mut cf.borders, &parse_raw_tbl_borders(borders));
             }
+        }
+        // §17.7.6: the conditional block carries its own `<w:rPr>`/`<w:pPr>`
+        // (e.g. firstRow `<w:color w:val="365F91"/>` + `<w:jc w:val="right"/>`).
+        if let Some(rpr) = child_w(sp, "rPr") {
+            cf.run = Some(parse_run_fmt(rpr));
+        }
+        if let Some(ppr) = child_w(sp, "pPr") {
+            cf.para = Some(parse_para_fmt(ppr));
         }
         def.cond.insert(typ, cf);
     }
@@ -1116,5 +1209,126 @@ mod tests {
     fn absent_color_element_stays_none_to_inherit() {
         let fmt = run_fmt_from(r#"<w:b/>"#);
         assert_eq!(fmt.color, None);
+    }
+
+    // ===== Table style conditional rPr/pPr (§17.7.6 / §17.7.2) =====
+
+    /// A minimal styles.xml with a Calendar-3-like table style: a whole-table
+    /// rPr gray color + a firstRow conditional rPr blue color and a firstRow
+    /// pPr right-jc. Mirrors the real Calendar 3 (styleId "Calendar3") subset
+    /// the parser must resolve.
+    fn calendar_style_map() -> StyleMap {
+        let xml = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="table" w:styleId="Calendar3">
+                <w:name w:val="Calendar 3"/>
+                <w:pPr><w:jc w:val="right"/></w:pPr>
+                <w:rPr><w:color w:val="7F7F7F"/></w:rPr>
+                <w:tblStylePr w:type="firstRow">
+                  <w:pPr><w:jc w:val="right"/></w:pPr>
+                  <w:rPr><w:color w:val="365F91"/><w:sz w:val="44"/></w:rPr>
+                </w:tblStylePr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        StyleMap::parse(&xml)
+    }
+
+    #[test]
+    fn table_style_parses_whole_table_and_conditional_run_para() {
+        let sm = calendar_style_map();
+        let def = sm.resolve_table_style("Calendar3");
+        // Whole-table rPr/pPr captured.
+        assert_eq!(def.run.as_ref().unwrap().color.as_deref(), Some("7f7f7f"));
+        assert_eq!(
+            def.para.as_ref().unwrap().alignment.as_deref(),
+            Some("right")
+        );
+        // firstRow conditional rPr/pPr captured.
+        let fr = def.cond.get("firstRow").unwrap();
+        assert_eq!(fr.run.as_ref().unwrap().color.as_deref(), Some("365f91"));
+        assert_eq!(fr.run.as_ref().unwrap().font_size, Some(22.0));
+        assert_eq!(
+            fr.para.as_ref().unwrap().alignment.as_deref(),
+            Some("right")
+        );
+    }
+
+    #[test]
+    fn firstrow_conditional_run_color_is_inherited_by_cell_base() {
+        // §17.7.6 + §17.7.2: a cell paragraph in the firstRow inherits the
+        // conditional rPr color (365F91) as its run BASE — this is the calendar
+        // header "Sun/Mon/…" blue.
+        let sm = calendar_style_map();
+        let cond = {
+            let def = sm.resolve_table_style("Calendar3");
+            def.cond.get("firstRow").cloned()
+        };
+        let (para, run) = sm.resolve_para_cond(None, Some("Calendar3"), cond.as_ref());
+        assert_eq!(run.color.as_deref(), Some("365f91"));
+        // firstRow pPr right-jc also resolves onto the paragraph.
+        assert_eq!(para.alignment.as_deref(), Some("right"));
+    }
+
+    #[test]
+    fn body_row_inherits_whole_table_color_not_conditional() {
+        // A row with no conditional (cond = None) inherits only the whole-table
+        // rPr gray (7F7F7F) — the calendar day numbers — never the firstRow blue.
+        let sm = calendar_style_map();
+        let (_para, run) = sm.resolve_para_cond(None, Some("Calendar3"), None);
+        assert_eq!(run.color.as_deref(), Some("7f7f7f"));
+    }
+
+    #[test]
+    fn direct_run_color_overrides_conditional_base() {
+        // §17.7.2 ordering: the table conditional rPr is a BASE below direct
+        // run formatting. A run that carries its OWN w:color must win over the
+        // firstRow conditional color. We resolve the conditional base, then
+        // layer a direct rPr the way the run walk does (set-value wins).
+        let sm = calendar_style_map();
+        let cond = {
+            let def = sm.resolve_table_style("Calendar3");
+            def.cond.get("firstRow").cloned()
+        };
+        let (_para, base_run) = sm.resolve_para_cond(None, Some("Calendar3"), cond.as_ref());
+        assert_eq!(base_run.color.as_deref(), Some("365f91"));
+
+        // Direct rPr on the run: explicit red. apply_run mirrors the
+        // set-value-wins merge that apply_direct_run performs for the run walk.
+        let mut fmt = base_run.clone();
+        let direct = run_fmt_from(r#"<w:color w:val="FF0000"/>"#);
+        apply_run(&mut fmt, &direct);
+        assert_eq!(
+            fmt.color.as_deref(),
+            Some("ff0000"),
+            "direct run color must override the conditional base"
+        );
+    }
+
+    #[test]
+    fn conditional_run_para_default_to_none_when_absent() {
+        // A table style with no rPr/pPr anywhere yields None — no panics, no
+        // spurious base layer (so cells inherit docDefaults/paragraph style).
+        let xml = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="table" w:styleId="Plain">
+                <w:name w:val="Plain"/>
+                <w:tblStylePr w:type="firstRow">
+                  <w:tcPr><w:shd w:val="clear" w:fill="CCCCCC"/></w:tcPr>
+                </w:tblStylePr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        let sm = StyleMap::parse(&xml);
+        let def = sm.resolve_table_style("Plain");
+        assert!(def.run.is_none());
+        assert!(def.para.is_none());
+        let fr = def.cond.get("firstRow").unwrap();
+        assert!(fr.run.is_none());
+        assert!(fr.para.is_none());
+        // shd still parses (existing behavior unchanged).
+        assert_eq!(fr.shd.as_deref(), Some("cccccc"));
     }
 }


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 4 — the "December 2007" calendar title rendered **black** instead of blue, and the College / ITEM-NEEDED header rows lost their **white bold** text. Table styles' `<w:tblStylePr>` formatting was parsed only for shading/borders; the conditional `<w:rPr>`/`<w:pPr>` (and the style's own whole-table `<w:rPr>`/`<w:pPr>`) were discarded.

- `CondFmt` and `TableStyleDef` now carry `run`/`para`; `parse_tbl_style_def` reads whole-table and per-condition `rPr`/`pPr`.
- The resolved formatting threads into cell content as a **§17.7.2 base layer** (`resolve_para_cond`): below paragraph/character style and direct `rPr`, above docDefaults. A direct run colour still wins (new test `direct_run_color_overrides_conditional_base`).
- The row condition is chosen **before** the cell content is parsed, so it can seed that base.

## Scope
Row conditions (`firstRow`/`lastRow`/`band1Horz`/`band2Horz`) via cnfStyle's four row bits (§17.4.7). **Out of scope** (documented at `cond_name_for`): column-band / corner conditions (`firstCol`/`lastCol`/`band*Vert`/`neCell`…) — `cnf_to_cond` decodes only the four row bits. Consequence: the calendar's Sun/Sat first/last-column blue digits stay gray (their blue comes from `firstCol`/`lastCol` rPr).

## Verification
- Rust fmt/clippy clean, **97 tests** pass (5 new: parse, firstRow inheritance, whole-table body row, direct-colour-overrides-conditional, all-None-when-absent). WASM rebuilt.
- TS typecheck clean (no renderer change — it already draws run colours).
- **VRT 21/21 pass**, no regression.
- Visual: page 4 — "December 2007" blue (365F91), day numbers gray (whole-table 7F7F7F); page 3 — College header white-bold on cyan, ITEM/NEEDED header white-bold on green. All match the Word PDF within the row-condition scope.

Part of the sample-11 fidelity series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)