### PR TITLE
feat(core,docx): map Symbol/Wingdings PUA bullet glyphs to Unicode

### DIFF
--- a/packages/core/src/fonts/symbol-font.test.ts
+++ b/packages/core/src/fonts/symbol-font.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { SYMBOL_FONT_MAP, symbolFontToUnicode } from './symbol-font';
+
+const ch = (code: number): string => String.fromCharCode(code);
+
+describe('symbolFontToUnicode', () => {
+  // The load-bearing case: list bullets. Word serializes a Symbol bullet as the
+  // PUA code point U+F0B7 and a Wingdings square as U+F0A7; both the bare and
+  // PUA-shifted forms must normalize so the marker draws in any fallback face.
+  it('maps Symbol / Wingdings bullet code points (bare + PUA) to Unicode', () => {
+    expect(symbolFontToUnicode(ch(0xf0b7), 'Symbol')).toBe('•');
+    expect(symbolFontToUnicode(ch(0xb7), 'Symbol')).toBe('•');
+    expect(symbolFontToUnicode(ch(0xf0a7), 'Wingdings')).toBe('▪');
+    expect(symbolFontToUnicode(ch(0xa7), 'Wingdings')).toBe('▪');
+  });
+
+  it('maps the Wingdings barb arrow block', () => {
+    expect(symbolFontToUnicode(ch(0xf0e0), 'Wingdings')).toBe('→');
+    expect(symbolFontToUnicode(ch(0xdf), 'Wingdings')).toBe('←');
+  });
+
+  // The gate is keyed on the requested font family, not the character — a normal
+  // body font must never be remapped (a real "·" / "§" / "A" stays itself).
+  it('passes characters through for non-symbol fonts', () => {
+    expect(symbolFontToUnicode(ch(0xb7), 'Calibri')).toBe(ch(0xb7));
+    expect(symbolFontToUnicode(ch(0xa7), 'Times New Roman')).toBe(ch(0xa7));
+    expect(symbolFontToUnicode('A', 'Symbol')).toBe('A');
+  });
+
+  it('passes through when the family is missing or unmapped', () => {
+    expect(symbolFontToUnicode(ch(0xf0b7), null)).toBe(ch(0xf0b7));
+    expect(symbolFontToUnicode(ch(0xf0b7), undefined)).toBe(ch(0xf0b7));
+    // A code point with no entry falls through unchanged rather than guessing.
+    expect(symbolFontToUnicode(ch(0xfe), 'Wingdings')).toBe(ch(0xfe));
+  });
+
+  it('matches "wingdings" case-insensitively and as a substring', () => {
+    expect(symbolFontToUnicode(ch(0xf0a7), 'WINGDINGS')).toBe('▪');
+    expect(symbolFontToUnicode(ch(0xf0a7), 'Wingdings 2')).toBe('▪');
+  });
+
+  // Guard against the ambiguous Symbol-vs-Wingdings code points that were
+  // removed (0x24/0x4B/0x76/0xB8/0xB9/0xFE): they must NOT be in the table.
+  it('omits ambiguous font-specific code points', () => {
+    for (const code of [0x24, 0x4b, 0x76, 0xb8, 0xb9, 0xfe]) {
+      expect(SYMBOL_FONT_MAP[code]).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/src/fonts/symbol-font.ts
+++ b/packages/core/src/fonts/symbol-font.ts
@@ -1,0 +1,83 @@
+/**
+ * Symbol / Wingdings font-encoding → Unicode normalization.
+ *
+ * The classic "Symbol" (§) and "Wingdings" families do NOT use a Unicode cmap:
+ * they ship a private, font-specific encoding where ordinary code points map to
+ * pictographic glyphs (e.g. in Symbol, code point 0xB7 is BULLET "•", not MIDDLE
+ * DOT; in Wingdings, 0xA7 is a small filled square). OOXML stores marker / run
+ * text as the *font's own* code points — and Word commonly emits them in the
+ * Private Use Area (U+F020–U+F0FF), so a Symbol bullet is serialized as U+F0B7
+ * and a Wingdings square as U+F0A7.
+ *
+ * ECMA-376 / ISO-29500 does NOT define these fonts' glyph repertoires:
+ *   - §17.9.x  (numbering level text, `w:lvlText`) and §17.3.2.26 (`w:rPr`
+ *     `w:rFonts`) for docx tell us WHICH font and WHICH code point, but the
+ *     code-point→glyph mapping belongs to the font implementation, not the spec.
+ *   - §21.1.2.3.10 (`a:sym`) for pptx is likewise just a font + char reference.
+ *
+ * When such a marker is drawn in a generic fallback face (the Symbol/Wingdings
+ * font is frequently unavailable, especially on non-Windows hosts), the PUA code
+ * point has no glyph and renders as tofu (□). We normalize the well-known
+ * Symbol/Wingdings code points — both their bare form (0xA7, 0xB7, …) and their
+ * PUA-shifted form (0xF0A7, 0xF0B7, …) — to the equivalent Unicode characters
+ * so the intended glyph (•, ▪, →, …) renders in any fallback font.
+ *
+ * This is a documented font-encoding → Unicode conversion, NOT a per-sample
+ * heuristic: it is keyed solely on the requested font family ("symbol" /
+ * "wingdings") and the font's published code-point repertoire.
+ *
+ * NOTE: This table duplicates `WINGDINGS_MAP` / `applySymbolFont` in
+ * `packages/pptx/src/renderer.ts`. The pptx renderer should later be refactored
+ * to import from here; that change is left for the pptx session because the
+ * branch that introduced this module may not edit `packages/pptx/**`.
+ */
+// Only entries verified against authoritative sources (unicode.org
+// ADOBE/symbol.txt for Symbol; the Wingdings cmap for Wingdings) are listed.
+// The load-bearing markers are the bullets (Symbol 0xB7 "•", Wingdings 0xA7
+// "▪") and the Wingdings barb arrow block; the pencil/scissors/face dingbats
+// below are correct under Wingdings.
+//
+// LIMITATION: this is a single table shared by both fonts, so a code point that
+// means different glyphs in Symbol vs Wingdings (e.g. 0xB8: Symbol "÷",
+// Wingdings a clock face) cannot be disambiguated here. Such ambiguous /
+// font-specific code points are deliberately OMITTED rather than guessed — they
+// fall through unchanged (better tofu than a wrong glyph). Splitting into
+// font-specific SYMBOL_MAP / WINGDINGS_MAP is tracked as a follow-up.
+export const SYMBOL_FONT_MAP: Record<number, string> = {
+  0x21: '✏', 0x22: '✂', 0x23: '✁',
+  0x4A: '☺', 0x4C: '☹',
+  0xFC: '✓', 0xFB: '✗',
+  0xA7: '▪', 0xB7: '•',
+  0xF0A7: '▪', 0xF0B7: '•',
+  // Wingdings barb2 arrow block — glyph names verified against the Wingdings
+  // cmap (0xDF=barb2left … 0xE6=barb2se). Mapped to Unicode arrows so they
+  // render in any font even when Wingdings is unavailable.
+  0xDF: '←', 0xE0: '→', 0xE1: '↑', 0xE2: '↓',
+  0xE3: '↖', 0xE4: '↗', 0xE5: '↙', 0xE6: '↘',
+  0xF0DF: '←', 0xF0E0: '→', 0xF0E1: '↑', 0xF0E2: '↓',
+  0xF0E3: '↖', 0xF0E4: '↗', 0xF0E5: '↙', 0xF0E6: '↘',
+};
+
+/**
+ * Normalize a single Symbol/Wingdings code point to its Unicode equivalent.
+ *
+ * Returns `char` unchanged when `fontFamily` is null/undefined, is not a symbol
+ * font ("symbol" exactly, or any family containing "wingdings"), or has no
+ * mapping in {@link SYMBOL_FONT_MAP}.
+ *
+ * @param char       the marker/run character as stored in the OOXML (often a
+ *                   PUA code point such as U+F0B7)
+ * @param fontFamily the requested font family (ascii / hAnsi axis)
+ */
+export function symbolFontToUnicode(
+  char: string,
+  fontFamily: string | null | undefined,
+): string {
+  if (!fontFamily) return char;
+  const lower = fontFamily.toLowerCase();
+  if (lower.includes('wingdings') || lower === 'symbol') {
+    const code = char.charCodeAt(0);
+    return SYMBOL_FONT_MAP[code] ?? char;
+  }
+  return char;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export {
   type FontGenericClass,
   type FontVariant,
 } from './fonts/scripts';
+export { SYMBOL_FONT_MAP, symbolFontToUnicode } from './fonts/symbol-font';
 export { renderChart } from './chart/renderer';
 export { autoResize, type AutoResizeOptions } from './autoResize';
 export { buildCustomPath } from './shape/custGeom';

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -34,6 +34,7 @@ import {
   classifyFontGeneric,
   isComplexScriptCodePoint,
   decodeRasterOrMetafile,
+  symbolFontToUnicode,
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer, KinsokuRules } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
@@ -2521,7 +2522,7 @@ function renderParagraph(
       // hardcoded generic — the width must match the draw below so the body
       // offset is exact for a serif (Times) vs sans (Gothic) marker alike.
       ctx.font = buildFont(false, false, getDefaultFontSize(para) * scale, markerFontFamily(para.numbering), fontFamilyClasses);
-      const markerW = ctx.measureText(para.numbering.text).width;
+      const markerW = ctx.measureText(markerDisplayText(para.numbering)).width;
       const spaceW = suff === 'space' ? ctx.measureText(' ').width : 0;
       // marker sits at firstLineX (= paraX + indFirst); body starts at its end.
       numBodyOffset = indFirst + markerW + spaceW;
@@ -2778,8 +2779,9 @@ function renderParagraph(
         const prevDir = ctx.direction;
         ctx.textAlign = 'left';
         ctx.direction = 'rtl';
-        const markerW = ctx.measureText(para.numbering!.text).width;
-        ctx.fillText(para.numbering!.text, x + lineWidth + numTab - markerW, baseline);
+        const markerText = markerDisplayText(para.numbering!);
+        const markerW = ctx.measureText(markerText).width;
+        ctx.fillText(markerText, x + lineWidth + numTab - markerW, baseline);
         ctx.textAlign = prevAlign;
         ctx.direction = prevDir;
       } else {
@@ -2787,7 +2789,7 @@ function renderParagraph(
         // when the line isn't shifted by a float; lineLeft already includes any
         // float xOffset, so the marker tracks the body that hangs off it). The
         // body was advanced past the marker above (numBodyOffset).
-        ctx.fillText(para.numbering!.text, lineLeft + indFirst, baseline);
+        ctx.fillText(markerDisplayText(para.numbering!), lineLeft + indFirst, baseline);
       }
     }
 
@@ -5592,6 +5594,17 @@ function markerFontFamily(num: NumberingInfo): string | null {
   const cp = num.text.codePointAt(0) ?? 0;
   const ascii = num.fontFamily ?? null;
   return isCjkBreakChar(cp) ? (num.fontFamilyEastAsia ?? ascii) : ascii;
+}
+
+/** Marker glyph as it should be drawn/measured. Symbol/Wingdings markers
+ *  (§17.9.x `w:lvlText` + §17.3.2.26 `w:rFonts`) store the glyph as the FONT's
+ *  own code point (e.g. Symbol U+F0B7 = "•", Wingdings U+F0A7 = "▪"). Those
+ *  private-encoding code points render as tofu in any fallback face, so we
+ *  normalize them to the Unicode equivalent up front — keyed on the marker's
+ *  requested ascii family, not on the sample. Non-symbol markers (decimals,
+ *  roman, CJK bullets) pass through unchanged. */
+function markerDisplayText(num: NumberingInfo): string {
+  return symbolFontToUnicode(num.text, num.fontFamily ?? null);
 }
 
 /** Arabic-script faces that hosts rarely ship; we substitute them with Noto


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 8 "Bulleted List" — the "One"/"Two" bullets rendered as **tofu (□)**. `numbering.xml` stores the level text as the bullet font's own private-use codepoint (Symbol **U+F0B7** "•", Wingdings **U+F0A7** "▪"); drawing those PUA codepoints in a substitute face (the Symbol/Wingdings faces are absent) produces no glyph.

- New shared core util **`packages/core/src/fonts/symbol-font.ts`** — `symbolFontToUnicode(char, fontFamily)` + `SYMBOL_FONT_MAP` map Symbol/Wingdings codepoints (bare or PUA-shifted `F0xx`) to their Unicode equivalents (`F0B7→•`, `F0A7→▪`, …).
- The docx renderer routes every list-marker measure/draw site (LTR + RTL) through it; marker font classification is unchanged.

### Why core
This is a font-encoding→Unicode mapping shared across docx/pptx/xlsx. **pptx already carries a private `WINGDINGS_MAP`/`applySymbolFont`** — the core util is the single source; a NOTE in the file flags the pptx duplicate for the pptx session to adopt later (this PR doesn't touch pptx). Not a heuristic: keyed only on the requested family ("symbol"/"wingdings") and the font's published repertoire (JSDoc cites §17.9.x, §17.3.2.26, §21.1.2.3.10).

## Verification
- Root `pnpm typecheck` (cross-core, incl. vscode-extension) clean; docx typecheck clean.
- VRT 21/21 pass (no parser change → WASM/cargo skipped). VRT doesn't cover lists, so verified visually.
- Visual: page 8 — "One"/"Two" render a solid black •, the multi-level Wingdings level renders ▪; tofu gone.

Note: the picture bullet ("This bullet uses an image as the bullet item") is a separate gap (`numPicBullet`, follow-up).

Part of the sample-11 fidelity series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)