### PR TITLE
feat(docx): paragraph frames & drop caps (w:framePr, §17.3.1.11)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1491,6 +1491,9 @@ fn parse_paragraph_cond(
         // ECMA-376 §17.3.1.32 — when explicitly off, the renderer skips docGrid
         // line snapping for this paragraph (e.g. footnote text).
         snap_to_grid: base_para.snap_to_grid,
+        // ECMA-376 §17.3.1.11 — text-frame / drop-cap properties, resolved
+        // through the style chain. Some ⇒ paragraph is part of a text frame.
+        frame_pr: base_para.frame_pr.clone(),
     }
 }
 
@@ -4526,6 +4529,11 @@ fn apply_direct_para(base: &mut ParaFmt, direct: &ParaFmt) {
     }
     if direct.snap_to_grid.is_some() {
         base.snap_to_grid = direct.snap_to_grid;
+    }
+    // §17.3.1.11: a direct framePr replaces any style-inherited frame whole-sale
+    // (grouped element, not attribute-merged).
+    if direct.frame_pr.is_some() {
+        base.frame_pr = direct.frame_pr.clone();
     }
 }
 

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -126,6 +126,10 @@ pub struct ParaFmt {
     /// "Footnote Text" style sets this off, which is why footnote bodies use
     /// compact natural line height rather than the 18 pt grid pitch.
     pub snap_to_grid: Option<bool>,
+    /// ECMA-376 §17.3.1.11 w:framePr — text-frame / drop-cap properties.
+    /// Resolved through the style chain like other pPr; `Some` ⇒ this paragraph
+    /// is part of a text frame. Boxed to match `DocParagraph::frame_pr`.
+    pub frame_pr: Option<Box<crate::types::FramePr>>,
 }
 
 #[derive(Debug, Default)]
@@ -531,6 +535,12 @@ fn apply_para(dst: &mut ParaFmt, src: &ParaFmt) {
     if src.snap_to_grid.is_some() {
         dst.snap_to_grid = src.snap_to_grid;
     }
+    // §17.3.1.11: framePr is a single grouped element — a later level that
+    // specifies it replaces the whole frame definition (Word does not merge
+    // individual frame attributes across the style chain).
+    if src.frame_pr.is_some() {
+        dst.frame_pr = src.frame_pr.clone();
+    }
 }
 
 fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
@@ -826,6 +836,41 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
         {
             fmt.para_borders = Some(borders);
         }
+    }
+
+    // Text frame / drop cap (ECMA-376 §17.3.1.11 w:framePr). Presence makes the
+    // paragraph part of a text frame; all attributes are optional with the
+    // spec-defined defaults applied here so the renderer never re-derives them.
+    if let Some(fp) = child_w(ppr, "framePr") {
+        use crate::types::FramePr;
+        let twips = |name: &str| attr_w(fp, name).map(|s| twips_to_pt(&s));
+        fmt.frame_pr = Some(Box::new(FramePr {
+            // ST_DropCap default "none" (§17.18.20).
+            drop_cap: attr_w(fp, "dropCap").unwrap_or_else(|| "none".to_string()),
+            // §17.3.1.11 lines default 1.
+            lines: attr_w(fp, "lines")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1),
+            // ST_Wrap default "around" (§17.3.1.11 / §17.18.104).
+            wrap: attr_w(fp, "wrap").unwrap_or_else(|| "around".to_string()),
+            // ST_HAnchor / ST_VAnchor default "page" (§17.3.1.11).
+            h_anchor: attr_w(fp, "hAnchor").unwrap_or_else(|| "page".to_string()),
+            v_anchor: attr_w(fp, "vAnchor").unwrap_or_else(|| "page".to_string()),
+            // ST_HeightRule default "auto" (§17.18.37).
+            h_rule: attr_w(fp, "hRule").unwrap_or_else(|| "auto".to_string()),
+            // hSpace / vSpace default 0 (§17.3.1.11).
+            h_space: twips("hSpace").unwrap_or(0.0),
+            v_space: twips("vSpace").unwrap_or(0.0),
+            // w/h/x/y are kept Option so the renderer can tell "auto" (absent)
+            // from an explicit 0; §17.3.1.11 assumes 0 when consumed.
+            w: twips("w"),
+            h: twips("h"),
+            x: twips("x"),
+            y: twips("y"),
+            // ST_XAlign / ST_YAlign — supersede x/y when present (§17.3.1.11).
+            x_align: attr_w(fp, "xAlign"),
+            y_align: attr_w(fp, "yAlign"),
+        }));
     }
 
     fmt

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -344,6 +344,15 @@ pub struct DocParagraph {
     /// style.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snap_to_grid: Option<bool>,
+    /// ECMA-376 §17.3.1.11 `<w:framePr>` — text-frame / drop-cap properties.
+    /// `Some` ⇒ this paragraph is part of a text frame; the renderer positions
+    /// it as a frame (drop cap or generic frame) and registers a wrap exclusion
+    /// for following body text. `None` ⇒ ordinary in-flow paragraph.
+    /// Boxed (like `numbering`) so `DocParagraph` stays small enough that the
+    /// `BodyElement` / `CellElement` enum variants remain balanced
+    /// (clippy::large_enum_variant); serde flattens the Box, so JSON is unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frame_pr: Option<Box<FramePr>>,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
@@ -412,6 +421,61 @@ pub struct LineSpacing {
     /// snap to one grid pitch per line regardless of the multiplier.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub explicit: bool,
+}
+
+/// ECMA-376 §17.3.1.11 `<w:framePr>` — text-frame / drop-cap properties for a
+/// paragraph. The presence of `framePr` makes the paragraph part of a text
+/// frame; adjacent paragraphs whose attribute sets are identical belong to the
+/// same frame. Lengths are normalized to pt (twip / 20); the raw enum strings
+/// are carried verbatim so the renderer maps them with no re-derivation.
+///
+/// Attribute defaults (per §17.3.1.11):
+///   wrap     → "around"   hRule → "auto"   vRule (implied) → none here
+///   hAnchor  → "page"     vAnchor → "page"
+///   lines    → 1          h/w/x/y → 0
+/// `x`/`y` are ignored when `xAlign`/`yAlign` are set; for a drop cap, `y`/
+/// `yAlign` are ignored entirely and `lines` drives the height.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FramePr {
+    /// ST_DropCap (§17.18.20): "none" | "drop" | "margin". Absent ⇒ "none".
+    pub drop_cap: String,
+    /// §17.3.1.11 `lines` — drop-cap vertical height in anchor lines. Default 1.
+    pub lines: u32,
+    /// ST_Wrap (§17.18.104): "around" | "auto" | "none" | "notBeside" |
+    /// "through" | "tight". Absent ⇒ "around".
+    pub wrap: String,
+    /// ST_HAnchor (§17.18.35): "text"(=column) | "margin" | "page". Default "page".
+    pub h_anchor: String,
+    /// ST_VAnchor (§17.18.100): "text" | "margin" | "page". Default "page".
+    pub v_anchor: String,
+    /// ST_HeightRule (§17.18.37): "auto" | "atLeast" | "exact". Default "auto".
+    pub h_rule: String,
+    /// hSpace — min wrap padding L/R when wrap="around" (pt). Default 0.
+    pub h_space: f64,
+    /// vSpace — min wrap padding top/bottom (pt). Default 0.
+    pub v_space: f64,
+    /// w — exact frame width (pt). 0/absent ⇒ auto (max content line width).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub w: Option<f64>,
+    /// h — frame height (pt). Meaning gated by h_rule. 0/absent ⇒ auto.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub h: Option<f64>,
+    /// x — absolute horizontal offset from h_anchor (pt). Ignored when x_align set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x: Option<f64>,
+    /// y — absolute vertical offset from v_anchor (pt). Ignored when y_align set
+    /// or when this is a drop cap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub y: Option<f64>,
+    /// ST_XAlign (§22.9.2.18): "left" | "center" | "right" | "inside" |
+    /// "outside". Supersedes `x` when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x_align: Option<String>,
+    /// ST_YAlign (§22.9.2.20): "inline" | "top" | "center" | "bottom" |
+    /// "inside" | "outside". Supersedes `y` when present (ignored if v_anchor=text).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub y_align: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { computeFrameBox, registerFrameFloat } from './renderer.js';
+import type { FrameBox } from './renderer.js';
+import type { FramePr } from './types.js';
+import type { FloatRect } from './float-layout.js';
+
+// Table-driven geometry assertions for paragraph frames / drop caps
+// (ECMA-376 §17.3.1.11). The VRT only exercises dropCap="drop" wrap="around"
+// (private/sample-11 page 5), so the other (wrap, dropCap, hAnchor, vAnchor)
+// combinations are pinned here — this is their only regression guard. Each case
+// asserts the resolved FrameBox AND the FloatRect that registerFrameFloat emits
+// (xLeft/xRight/yTop/yBottom/mode/side), which is what resolveLineFloatWindow
+// consumes to wrap the following body text.
+//
+// Geometry is exercised at scale=1 so px == pt. A representative page:
+//   pageWidth=600, margins L/R/T/B = 100/100/72/72  ⇒ content band [100,500].
+//   A multi-column run would set a narrower contentX/contentW; we model a single
+//   column here as contentX=100, contentW=400 and assert hAnchor="text" snaps to
+//   it (the #513 column-relative contract).
+
+interface MinState {
+  scale: number;
+  contentX: number;
+  contentW: number;
+  marginLeft: number;
+  marginRight: number;
+  marginTop: number;
+  marginBottom: number;
+  pageWidth: number;
+  pageH: number;
+  floats: FloatRect[];
+  floatParaSeq: number;
+}
+
+function makeState(over: Partial<MinState> = {}): MinState {
+  return {
+    scale: 1,
+    contentX: 100,
+    contentW: 400,
+    marginLeft: 100,
+    marginRight: 100,
+    marginTop: 72,
+    marginBottom: 72,
+    pageWidth: 600,
+    pageH: 800,
+    floats: [],
+    floatParaSeq: 0,
+    ...over,
+  };
+}
+
+// Full FramePr with the spec defaults; tests override only the axis under test.
+function frame(over: Partial<FramePr> = {}): FramePr {
+  return {
+    dropCap: 'none',
+    lines: 1,
+    wrap: 'around',
+    hAnchor: 'text',
+    vAnchor: 'text',
+    hRule: 'auto',
+    hSpace: 0,
+    vSpace: 0,
+    ...over,
+  };
+}
+
+// Cast helper: computeFrameBox/registerFrameFloat read only the MinState subset
+// of RenderState exercised here.
+const box = (fp: FramePr, st: MinState, paraTop: number, cW: number, cH: number, anchorH: number): FrameBox =>
+  computeFrameBox(fp, st as never, paraTop, cW, cH, anchorH);
+const registerFloat = (b: FrameBox, fp: FramePr, st: MinState): void =>
+  registerFrameFloat(b, fp, st as never);
+
+describe('frame geometry (§17.3.1.11) — drop cap placement', () => {
+  it('dropCap="drop": frame at column left, height = lines × anchor line height', () => {
+    const st = makeState();
+    const fp = frame({ dropCap: 'drop', lines: 3, hAnchor: 'text', vAnchor: 'text' });
+    // paraTop=200 (in-flow Y), measured cap width 42, anchor line height 14.
+    const b = box(fp, st, 200, 42, 50, 14);
+    expect(b.x).toBe(100); // column left (contentX)
+    expect(b.y).toBe(200); // paragraph top (vAnchor="text")
+    expect(b.w).toBe(42); // auto width = measured cap advance
+    expect(b.h).toBe(3 * 14); // lines × anchor line height (y/yAlign ignored)
+  });
+
+  it('dropCap="margin": frame hangs into the left margin (left = band left − width)', () => {
+    const st = makeState();
+    const fp = frame({ dropCap: 'margin', lines: 2, hAnchor: 'text' });
+    const b = box(fp, st, 150, 30, 40, 12);
+    expect(b.x).toBe(100 - 30); // outside the column margin
+    expect(b.w).toBe(30);
+    expect(b.h).toBe(2 * 12);
+  });
+
+  it('drop cap emits a right-side square float (text wraps to the right only)', () => {
+    const st = makeState();
+    const fp = frame({ dropCap: 'drop', lines: 3, wrap: 'around', hSpace: 8 });
+    const b = box(fp, st, 200, 42, 50, 14);
+    registerFloat(b, fp, st);
+    expect(st.floats).toHaveLength(1);
+    const f = st.floats[0];
+    expect(f.mode).toBe('square');
+    expect(f.side).toBe('right');
+    // hSpace=8 pads L/R for wrap="around".
+    expect(f.xLeft).toBe(100 - 8);
+    expect(f.xRight).toBe(100 + 42 + 8);
+    expect(f.yTop).toBe(200);
+    expect(f.yBottom).toBe(200 + 42); // h=3×14, vSpace=0
+  });
+});
+
+describe('frame geometry (§17.3.1.11) — wrap modes', () => {
+  const st0 = () => makeState();
+  const dc = (wrap: FramePr['wrap']) => frame({ dropCap: 'drop', lines: 3, wrap });
+
+  it('wrap="notBeside" → topAndBottom float (text never beside the frame)', () => {
+    const st = st0();
+    const fp = dc('notBeside');
+    const b = box(fp, st, 200, 42, 50, 14);
+    registerFloat(b, fp, st);
+    expect(st.floats).toHaveLength(1);
+    expect(st.floats[0].mode).toBe('topAndBottom');
+  });
+
+  it('wrap="around" and "auto" → square float (auto ≡ around in Word)', () => {
+    for (const w of ['around', 'auto'] as const) {
+      const st = st0();
+      const fp = dc(w);
+      const b = box(fp, st, 200, 42, 50, 14);
+      registerFloat(b, fp, st);
+      expect(st.floats, `wrap=${w}`).toHaveLength(1);
+      expect(st.floats[0].mode, `wrap=${w}`).toBe('square');
+    }
+  });
+
+  it('wrap="tight" and "through" → square float (rectangle, no contour follow)', () => {
+    for (const w of ['tight', 'through'] as const) {
+      const st = st0();
+      const fp = dc(w);
+      const b = box(fp, st, 200, 42, 50, 14);
+      registerFloat(b, fp, st);
+      expect(st.floats, `wrap=${w}`).toHaveLength(1);
+      expect(st.floats[0].mode, `wrap=${w}`).toBe('square');
+    }
+  });
+
+  it('wrap="none" → no float registered (absolute draw only, no exclusion)', () => {
+    const st = st0();
+    const fp = dc('none');
+    const b = box(fp, st, 200, 42, 50, 14);
+    registerFloat(b, fp, st);
+    expect(st.floats).toHaveLength(0);
+  });
+});
+
+describe('frame geometry (§17.3.1.11) — hAnchor / vAnchor containers', () => {
+  // A generic (non-drop-cap) frame at an absolute x/y from each anchor base.
+  it('hAnchor="text" anchors x against the COLUMN band (contentX)', () => {
+    const st = makeState({ contentX: 250, contentW: 200 }); // a right-hand column
+    const fp = frame({ hAnchor: 'text', x: 10 });
+    const b = box(fp, st, 300, 60, 40, 12);
+    expect(b.x).toBe(250 + 10); // column left + x offset
+  });
+
+  it('hAnchor="margin" anchors x against the page content margin', () => {
+    const st = makeState();
+    const fp = frame({ hAnchor: 'margin', x: 10 });
+    const b = box(fp, st, 300, 60, 40, 12);
+    expect(b.x).toBe(100 + 10); // marginLeft + x
+  });
+
+  it('hAnchor="page" anchors x against the physical page edge', () => {
+    const st = makeState();
+    const fp = frame({ hAnchor: 'page', x: 10 });
+    const b = box(fp, st, 300, 60, 40, 12);
+    expect(b.x).toBe(0 + 10); // page left + x
+  });
+
+  it('vAnchor="text" anchors y at the paragraph top', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'text', y: 5 });
+    const b = box(fp, st, 300, 60, 40, 12);
+    expect(b.y).toBe(300 + 5); // paraTop + y (yAlign ignored when vAnchor=text)
+  });
+
+  it('vAnchor="margin" anchors y at the top content margin', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'margin', y: 5 });
+    const b = box(fp, st, 300, 60, 40, 12);
+    expect(b.y).toBe(72 + 5); // marginTop + y
+  });
+
+  it('vAnchor="page" anchors y at the physical page top', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'page', y: 5 });
+    const b = box(fp, st, 300, 60, 40, 12);
+    expect(b.y).toBe(0 + 5); // page top + y
+  });
+});
+
+describe('frame geometry (§17.3.1.11) — generic frame (dropCap="none") sizing', () => {
+  it('hRule="exact" forces the frame height to h regardless of content', () => {
+    const st = makeState();
+    const fp = frame({ hRule: 'exact', h: 30 });
+    const b = box(fp, st, 200, 60, 100, 12); // contentH 100 ignored
+    expect(b.h).toBe(30);
+  });
+
+  it('hRule="atLeast" takes max(h, content height)', () => {
+    const st = makeState();
+    expect(box(frame({ hRule: 'atLeast', h: 30 }), st, 200, 60, 100, 12).h).toBe(100);
+    expect(box(frame({ hRule: 'atLeast', h: 200 }), st, 200, 60, 100, 12).h).toBe(200);
+  });
+
+  it('hRule="auto" uses the content height; explicit w forces exact width', () => {
+    const st = makeState();
+    const b = box(frame({ hRule: 'auto', w: 150 }), st, 200, 60, 80, 12);
+    expect(b.h).toBe(80); // content height
+    expect(b.w).toBe(150); // explicit width supersedes natural content width
+  });
+
+  it('xAlign="center" centers the frame in the hAnchor band, superseding x', () => {
+    const st = makeState(); // text band [100,500], width 400
+    const fp = frame({ hAnchor: 'text', x: 999, xAlign: 'center', w: 100 });
+    const b = box(fp, st, 200, 100, 40, 12);
+    expect(b.x).toBe(100 + (400 - 100) / 2); // centered, x ignored
+  });
+
+  it('xAlign="right" right-aligns the frame in the hAnchor band', () => {
+    const st = makeState();
+    const fp = frame({ hAnchor: 'text', xAlign: 'right', w: 100 });
+    const b = box(fp, st, 200, 100, 40, 12);
+    expect(b.x).toBe(500 - 100); // band right − width
+  });
+
+  it('a generic frame emits a bothSides square float (text wraps either side)', () => {
+    const st = makeState();
+    const fp = frame({ dropCap: 'none', hRule: 'exact', h: 40, w: 120, x: 50 });
+    const b = box(fp, st, 200, 120, 40, 12);
+    registerFloat(b, fp, st);
+    expect(st.floats).toHaveLength(1);
+    expect(st.floats[0].side).toBe('bothSides');
+  });
+});

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -32,6 +32,8 @@ export type {
   NoteRef,
   // Paragraph / line-spacing sub-types.
   LineSpacing,
+  // Text-frame / drop-cap properties (reachable via DocParagraph.framePr).
+  FramePr,
   TabStop,
   ParagraphBorders,
   ParaBorderEdge,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, DocNote, NumberingInfo, ColumnGeom,
+  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, DocNote, NumberingInfo, ColumnGeom, FramePr,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
@@ -1240,6 +1240,27 @@ export function computePages(
     if (el.type === 'paragraph') {
       const para = el as unknown as DocParagraph;
       if (para.pageBreakBefore) newPage();
+
+      // A frame paragraph (ECMA-376 §17.3.1.11) is positioned out of flow: it
+      // does not advance the page cursor and is not split. Register its wrap
+      // float on the measureState so following paragraphs estimate around it,
+      // and emit it onto the current page (the renderer draws it absolutely).
+      // It does NOT advance y / measureState.y and leaves prevPara/spaceAfter
+      // untouched so the following paragraph spaces against the paragraph
+      // BEFORE the frame. (Pagination of a frame that itself overflows the page
+      // bottom — moving the frame + its anchor text together — is Word runtime
+      // behaviour not pinned by ECMA-376; see HEURISTIC note below. We keep the
+      // minimal model: the frame stays with the anchor paragraph because it
+      // adds no height here, so a normal break on the anchor paragraph carries
+      // the wrap band implicitly. TODO(§17.3.1.11): once a self-contained frame
+      // height/keep calc exists, drive an explicit keep-with-anchor here.)
+      if (para.framePr) {
+        const anchorH = frameAnchorLineHeightPx(body as PaginatedBodyElement[], el, measureState);
+        const box = resolveFrameBox(para, measureState, anchorH);
+        registerFrameFloat(box, para.framePr, measureState);
+        pushTagged(el as PaginatedBodyElement);
+        continue;
+      }
       const suppressBefore = contextualSuppressed(prevPara, para);
 
       // Collapse with the previous paragraph's spaceAfter — Word takes
@@ -2348,6 +2369,14 @@ function renderBodyElements(
     if (el.type === 'paragraph') {
       const para = el as unknown as DocParagraph;
       const slice = (el as PaginatedBodyElement).lineSlice;
+      // A frame paragraph (ECMA-376 §17.3.1.11) is positioned out of flow and
+      // does not participate in spacing collapse or pagination splitting. Draw
+      // it absolutely and leave prevPara/spaceAfter untouched so the following
+      // non-frame paragraph spaces against the paragraph BEFORE the frame.
+      if (para.framePr) {
+        renderFrameParagraph(para, state, frameAnchorLineHeightPx(elements, el, state));
+        continue;
+      }
       const suppress = contextualSuppressed(prevPara, para);
       // Collapse spaceAfter+spaceBefore like Word: use max, not sum.
       const effBefore = suppress ? 0 : para.spaceBefore;
@@ -2469,6 +2498,396 @@ function renderEmptyMarkParagraph(
   }
 }
 
+// ===== Text frames & drop caps (ECMA-376 §17.3.1.11) =====
+
+/**
+ * One line height (px) of the anchor (following non-frame) paragraph, used to
+ * size a drop cap by `lines` (§17.3.1.11). The drop cap height equals
+ * `lines` × this. Scans `elements` after the frame element for the first
+ * non-frame paragraph; falls back to the frame paragraph's own single-line
+ * height when none follows (a degenerate trailing frame).
+ */
+function frameAnchorLineHeightPx(
+  elements: PaginatedBodyElement[],
+  frameEl: PaginatedBodyElement,
+  state: RenderState,
+): number {
+  const start = elements.indexOf(frameEl);
+  for (let j = start + 1; j < elements.length; j++) {
+    const e = elements[j];
+    if (e.type !== 'paragraph') continue;
+    const p = e as unknown as DocParagraph;
+    if (p.framePr) continue; // adjacent frame paragraphs are part of the frame
+    return paragraphMarkLineHeight(
+      p,
+      state.scale,
+      paraGrid(p, state),
+      paragraphHasRuby(p),
+      state.docEastAsian,
+      state.ctx,
+      state.fontFamilyClasses,
+    );
+  }
+  const fp = frameEl as unknown as DocParagraph;
+  return paragraphMarkLineHeight(
+    fp,
+    state.scale,
+    paraGrid(fp, state),
+    paragraphHasRuby(fp),
+    state.docEastAsian,
+    state.ctx,
+    state.fontFamilyClasses,
+  );
+}
+
+/** Resolved geometry (canvas px) of a `<w:framePr>` text frame. Exported for
+ *  unit tests only (the table-driven frame-geometry assertions) — not part of
+ *  the package API. */
+export interface FrameBox {
+  /** Drawing origin of the frame content (text area top-left). */
+  x: number;
+  y: number;
+  /** Frame content width / height. */
+  w: number;
+  h: number;
+  /** Padded exclusion rect for the wrap FloatRect (frame + hSpace/vSpace). */
+  exLeft: number;
+  exRight: number;
+  exTop: number;
+  exBottom: number;
+}
+
+/**
+ * Horizontal container band for a frame's hAnchor (ECMA-376 §17.3.1.11 /
+ * §17.18.35). This is a SEPARATE relativeFrom set from DrawingML's
+ * §20.4.3 (so {@link xContainer} is intentionally not reused):
+ *   - "text"   → the COLUMN text margin the anchor paragraph sits in
+ *                (state.contentX..contentX+contentW). This keeps a drop cap
+ *                inside its own newspaper column (#513 per-section columns).
+ *   - "margin" → the page content margin (marginLeft..pageWidth-marginRight).
+ *   - "page"   → the physical page edges (0..pageWidth).
+ * All values in canvas px.
+ */
+function frameXContainer(hAnchor: string, state: RenderState): { left: number; right: number } {
+  const sc = state.scale;
+  switch (hAnchor) {
+    case 'margin':
+      return { left: state.marginLeft * sc, right: (state.pageWidth - state.marginRight) * sc };
+    case 'page':
+      return { left: 0, right: state.pageWidth * sc };
+    case 'text':
+    case 'column':
+    default:
+      // "text" anchors against the current COLUMN band so a frame in a multi-
+      // column section stays inside its column.
+      return { left: state.contentX, right: state.contentX + state.contentW };
+  }
+}
+
+/**
+ * Vertical container origin for a frame's vAnchor (ECMA-376 §17.3.1.11 /
+ * §17.18.100). `paraTop` is the anchor paragraph's text-area top (canvas px).
+ *   - "text"   → the paragraph top (y offsets/relative positions are measured
+ *                from where the frame paragraph sits in the flow).
+ *   - "margin" → the page top content margin.
+ *   - "page"   → the physical page top.
+ */
+function frameYContainer(vAnchor: string, paraTop: number, state: RenderState): number {
+  const sc = state.scale;
+  switch (vAnchor) {
+    case 'margin':
+      return state.marginTop * sc;
+    case 'page':
+      return 0;
+    case 'text':
+    default:
+      return paraTop;
+  }
+}
+
+/**
+ * Resolve a frame's box in canvas px. `paraTop` is the in-flow top of the frame
+ * paragraph (post-spaceBefore). `contentW`/`contentH` are the frame content's
+ * measured natural size (px); `anchorLineHpx` is one line height of the
+ * following non-frame (anchor) paragraph, used to size a drop cap by `lines`.
+ *
+ * Exported for unit tests only (frame-geometry table) — not package API.
+ */
+export function computeFrameBox(
+  fp: FramePr,
+  state: RenderState,
+  paraTop: number,
+  contentW: number,
+  contentH: number,
+  anchorLineHpx: number,
+): FrameBox {
+  const sc = state.scale;
+  const isDropCap = fp.dropCap === 'drop' || fp.dropCap === 'margin';
+
+  const hx = frameXContainer(fp.hAnchor, state);
+  const vy = frameYContainer(fp.vAnchor, paraTop, state);
+
+  // Frame width: explicit `w` (exact) else natural content width (§17.3.1.11 w).
+  const frameW = fp.w != null ? fp.w * sc : contentW;
+
+  // Frame height. For a drop cap the height is `lines` × the anchor paragraph's
+  // line height (§17.3.1.11 lines: "the height of the drop cap is the first N
+  // lines of the anchor paragraph"; y/yAlign are ignored). For a generic frame
+  // hRule gates h: exact = h, atLeast = max(h, content), auto = content.
+  let frameH: number;
+  if (isDropCap) {
+    frameH = Math.max(1, fp.lines) * anchorLineHpx;
+  } else {
+    const hPx = fp.h != null ? fp.h * sc : 0;
+    frameH =
+      fp.hRule === 'exact'
+        ? hPx
+        : fp.hRule === 'atLeast'
+          ? Math.max(hPx, contentH)
+          : contentH;
+  }
+
+  // Horizontal placement.
+  //   dropCap="drop"   → inside the column/text margin (frame at band left).
+  //   dropCap="margin" → outside the margin (frame left = band left − frameW).
+  //   generic frame    → xAlign (left/center/right/inside/outside) supersedes x;
+  //                      else absolute x offset from the hAnchor's left edge.
+  let frameX: number;
+  if (fp.dropCap === 'drop') {
+    frameX = hx.left;
+  } else if (fp.dropCap === 'margin') {
+    frameX = hx.left - frameW;
+  } else if (fp.xAlign) {
+    switch (fp.xAlign) {
+      case 'center':
+        frameX = hx.left + (hx.right - hx.left - frameW) / 2;
+        break;
+      case 'right':
+      case 'outside':
+        frameX = hx.right - frameW;
+        break;
+      case 'left':
+      case 'inside':
+      default:
+        frameX = hx.left;
+        break;
+    }
+  } else {
+    // §17.3.1.11 x: absolute signed offset from the hAnchor left edge.
+    frameX = hx.left + (fp.x != null ? fp.x * sc : 0);
+  }
+
+  // Vertical placement. For a drop cap, y/yAlign are ignored: the cap sits at
+  // the anchor paragraph top (§17.3.1.11 lines). Otherwise yAlign supersedes y
+  // (ignored when vAnchor="text" — relative positioning is not allowed there,
+  // §17.3.1.11 yAlign), else absolute y offset from the vAnchor edge.
+  let frameY: number;
+  if (isDropCap) {
+    frameY = vy;
+  } else if (fp.yAlign && fp.vAnchor !== 'text') {
+    switch (fp.yAlign) {
+      case 'center':
+        frameY = vy + (state.pageH - frameH) / 2 - state.marginTop * sc;
+        break;
+      case 'bottom':
+      case 'outside':
+        frameY = (state.pageH - state.marginBottom * sc) - frameH;
+        break;
+      case 'top':
+      case 'inside':
+      case 'inline':
+      default:
+        frameY = vy;
+        break;
+    }
+  } else {
+    frameY = vy + (fp.y != null ? fp.y * sc : 0);
+  }
+
+  // Exclusion padding: hSpace L/R applies only with wrap="around" (§17.3.1.11
+  // hSpace); vSpace top/bottom always.
+  const hSpacePx = fp.wrap === 'around' || fp.wrap === 'auto' ? fp.hSpace * sc : 0;
+  const vSpacePx = fp.vSpace * sc;
+
+  return {
+    x: frameX,
+    y: frameY,
+    w: frameW,
+    h: frameH,
+    exLeft: frameX - hSpacePx,
+    exRight: frameX + frameW + hSpacePx,
+    exTop: frameY - vSpacePx,
+    exBottom: frameY + frameH + vSpacePx,
+  };
+}
+
+/**
+ * Render a paragraph that is part of a text frame (`para.framePr` set), per
+ * ECMA-376 §17.3.1.11.
+ *
+ * The frame is OUT OF FLOW: it is drawn at an absolute (anchor-relative)
+ * position and does NOT advance the in-flow `state.y`, so the following
+ * non-frame paragraph begins where this paragraph sat. The frame's glyphs are
+ * painted at their own run sizes (a drop cap's big letter is just a large `sz`
+ * run, e.g. sample-11's 58.5 pt "D"). A wrap exclusion FloatRect is registered
+ * (unless wrap="none") so the following body text flows around the frame — the
+ * exclusion x-range is built from the frame's COLUMN-relative band so
+ * resolveLineFloatWindow only constrains the matching column (#513).
+ *
+ * `anchorLineHpx` is one line height of the following non-frame paragraph,
+ * needed to size a drop cap by `lines`. Falls back to the frame paragraph's own
+ * single-line height when there is no following paragraph.
+ */
+/**
+ * Resolve a frame paragraph's box (canvas px) from the current flow geometry.
+ * Lays the frame content out at a wide width to get its natural size, then maps
+ * the framePr anchors/alignment. Shared by the renderer (draw) and the
+ * paginator (wrap estimate) so both see the same band.
+ */
+function resolveFrameBox(
+  para: DocParagraph,
+  state: RenderState,
+  anchorLineHpx: number,
+): FrameBox {
+  const fp = para.framePr!;
+  const { scale } = state;
+  const paraTop = state.y;
+  const grid = paraGrid(para, state);
+  const paraHasRuby = paragraphHasRuby(para);
+  const segments = buildSegments(para.runs, state);
+
+  // Measure the frame's natural content size at a wide width (single-line frame
+  // content stays one line). No floats apply INSIDE the frame; the cap glyph's
+  // own run size drives its extent.
+  const measureW = 100000;
+  const lines =
+    segments.length === 0
+      ? []
+      : layoutLines(
+          state.ctx,
+          segments,
+          measureW,
+          0,
+          scale,
+          para.tabStops,
+          undefined,
+          state.fontFamilyClasses,
+          0,
+          state.kinsoku,
+          gridCharDeltaPx(grid, scale),
+        );
+  const contentW =
+    lines.length === 0
+      ? 0
+      : Math.max(...lines.map((l) => l.segments.reduce((s, sg) => s + sg.measuredWidth, 0)));
+  const contentH = lines.reduce(
+    (s, l) =>
+      s +
+      lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle, paragraphIsEastAsian(para)),
+    0,
+  );
+
+  return computeFrameBox(fp, state, paraTop, contentW, contentH, anchorLineHpx);
+}
+
+/**
+ * Push the wrap-exclusion FloatRect for a resolved frame box onto
+ * `state.floats` so following body text flows around the frame. No-op for
+ * wrap="none" or a degenerate (zero-area) box. Shared by the renderer (after
+ * drawing) and the paginator (so the anchor paragraph's measured height
+ * accounts for the wrap). The exclusion x-range is COLUMN-relative (built in
+ * frameXContainer from state.contentX/contentW for hAnchor="text"), so
+ * resolveLineFloatWindow only constrains the matching column (#513).
+ *
+ * Wrap-mode → FloatRect mapping (ECMA-376 §17.18.104):
+ *   none      → no exclusion (text may overlap; the frame is drawn absolutely
+ *               and following text starts at its normal Y).
+ *   notBeside → topAndBottom (text never sits beside the frame).
+ *   around / auto → square side wrap. "auto" is Word's application-defined
+ *               default, effectively "around" in Word, so treated as around.
+ *   tight / through → a frame is a rectangle, so contour wrapping collapses to
+ *               a square wrap (no contour follow for a rectangular frame).
+ *
+ * Exported for unit tests only (frame-geometry table) — not package API.
+ */
+export function registerFrameFloat(box: FrameBox, fp: FramePr, state: RenderState): void {
+  if (fp.wrap === 'none') return;
+  if (box.w <= 0 || box.h <= 0) return;
+
+  const paraId = state.floatParaSeq++;
+  const mode: 'square' | 'topAndBottom' = fp.wrap === 'notBeside' ? 'topAndBottom' : 'square';
+  const rect: FloatRect = {
+    mode,
+    imageKey: '', // non-image float: the frame is painted above, not deferred.
+    imageX: box.x,
+    imageY: box.y,
+    imageW: box.w,
+    imageH: box.h,
+    xLeft: box.exLeft,
+    xRight: box.exRight,
+    yTop: box.exTop,
+    yBottom: box.exBottom,
+    // A drop cap sits at the column's left edge, so text wraps only to its
+    // RIGHT. A generic frame may sit anywhere, so text wraps on both sides
+    // (resolveLineFloatWindow then takes the widest free gap around it).
+    side: fp.dropCap === 'drop' || fp.dropCap === 'margin' ? 'right' : 'bothSides',
+    distLeft: box.x - box.exLeft,
+    distRight: box.exRight - (box.x + box.w),
+    distTop: box.y - box.exTop,
+    distBottom: box.exBottom - (box.y + box.h),
+    paraId,
+    drawn: true, // painted by renderFrameParagraph; deferred path must skip it.
+  };
+  state.floats.push(rect);
+}
+
+/**
+ * Render a paragraph that is part of a text frame (`para.framePr` set), per
+ * ECMA-376 §17.3.1.11.
+ *
+ * The frame is OUT OF FLOW: it is drawn at an absolute (anchor-relative)
+ * position and does NOT advance the in-flow `state.y`, so the following
+ * non-frame paragraph begins where this paragraph sat. The frame's glyphs are
+ * painted at their own run sizes (a drop cap's big letter is just a large `sz`
+ * run, e.g. sample-11's 58.5 pt "D"). A wrap exclusion is then registered so
+ * following body text flows around the frame.
+ *
+ * `anchorLineHpx` is one line height of the following non-frame paragraph,
+ * needed to size a drop cap by `lines` (§17.3.1.11).
+ */
+function renderFrameParagraph(
+  para: DocParagraph,
+  state: RenderState,
+  anchorLineHpx: number,
+): void {
+  const fp = para.framePr!;
+  // In-flow Y the following paragraph must resume from. The frame is out of
+  // flow; we restore this after drawing so state.y is untouched by the frame.
+  const inFlowY = state.y;
+  const box = resolveFrameBox(para, state, anchorLineHpx);
+
+  // Draw the frame's glyphs by redirecting the flow geometry to the frame box,
+  // then rendering the paragraph through the normal line path. inFrame=true
+  // suppresses anchor-float re-registration and avoids re-entering the frame
+  // dispatch; suppressSpaceBefore=true keeps the cap anchored to the paragraph
+  // top (the frame is positioned absolutely, not in flow).
+  const savedX = state.contentX;
+  const savedW = state.contentW;
+  state.contentX = box.x;
+  state.contentW = Math.max(box.w, box.exRight - box.x);
+  state.y = box.y;
+  renderParagraph(para, state, true, undefined, /* inFrame */ true);
+  state.contentX = savedX;
+  state.contentW = savedW;
+
+  // Restore the in-flow cursor: the frame consumes NO vertical space in the
+  // body flow (§17.3.1.11 — the frame is positioned relative to the next
+  // non-frame paragraph; the frame itself does not advance the flow).
+  state.y = inFlowY;
+
+  registerFrameFloat(box, fp, state);
+}
+
 function renderParagraph(
   para: DocParagraph,
   state: RenderState,
@@ -2476,6 +2895,14 @@ function renderParagraph(
   /** When set, render only `lines[start, end)` of the laid-out paragraph,
    *  used by the paginator to split paragraphs that don't fit on one page. */
   lineSlice?: { start: number; end: number },
+  /** True when this call is the redirected draw of a `<w:framePr>` frame
+   *  paragraph (from {@link renderFrameParagraph}). It suppresses the in-flow
+   *  cursor bookkeeping that the frame path handles itself: anchor-float
+   *  registration is skipped (the frame is the float) and the
+   *  topAndBottom-skip / frame dispatch are bypassed (the geometry is already
+   *  the frame box). Frame dispatch for a non-frame call lives in
+   *  renderBodyElements so it can pass the anchor paragraph's line height. */
+  inFrame = false,
 ): void {
   const { ctx, scale, contentX, contentW, defaultColor, dryRun, fontFamilyClasses } = state;
   // Capture Y before spaceBefore — used for paragraph-relative anchor image positioning
@@ -2483,9 +2910,11 @@ function renderParagraph(
 
   if (!suppressSpaceBefore) state.y += para.spaceBefore * scale;
 
-  // Register anchor floats from this paragraph (must happen after spaceBefore so that
-  // paragraph-relative Y resolves against the textAreaTop, matching Word).
-  registerAnchorFloats(para, state, state.y);
+  // Register anchor floats from this paragraph (must happen after spaceBefore so
+  // that paragraph-relative Y resolves against the textAreaTop, matching Word).
+  // Skipped for the frame-draw recursion: a frame paragraph's wrap exclusion is
+  // its own FloatRect (renderFrameParagraph), not an anchor image/shape float.
+  if (!inFrame) registerAnchorFloats(para, state, state.y);
 
   // behindDoc shapes must render before text so they appear behind it.
   renderAnchorImages(para, state, paragraphStartY, 'behind');
@@ -2498,10 +2927,17 @@ function renderParagraph(
   // ECMA-376 §17.3.1.12 w:ind — the transitional left/right attributes are
   // logical start/end (Part 4 §14.11.2). In a bidi paragraph the start side is
   // the physical RIGHT, so the two indents swap physical sides here.
+  //
+  // A frame paragraph's own body-style indents (e.g. a default first-line indent
+  // inherited from the body style) do NOT apply to the frame content: the frame
+  // box already positions the glyphs from its left edge, and the wrap exclusion
+  // is built from that same left edge (§17.3.1.11). Honoring the indent here
+  // would shift the cap glyph right of the exclusion band and let body text
+  // overlap it, so zero the indents in the frame-draw recursion.
   const baseRtl = para.bidi === true;
-  const indLeft = (baseRtl ? para.indentRight : para.indentLeft) * scale;
-  const indRight = (baseRtl ? para.indentLeft : para.indentRight) * scale;
-  const indFirst = para.indentFirst * scale;
+  const indLeft = inFrame ? 0 : (baseRtl ? para.indentRight : para.indentLeft) * scale;
+  const indRight = inFrame ? 0 : (baseRtl ? para.indentLeft : para.indentRight) * scale;
+  const indFirst = inFrame ? 0 : para.indentFirst * scale;
 
   // Numbering marker. `numMarker` doubles as the "this paragraph has a marker"
   // flag (truthiness); the marker glyph itself is drawn from para.numbering.text.

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -276,6 +276,52 @@ export interface DocParagraph {
    * Text" style, so footnote bodies use compact natural line height.
    */
   snapToGrid?: boolean;
+  /**
+   * ECMA-376 §17.3.1.11 `<w:framePr>` — text-frame / drop-cap properties.
+   * Present ⇒ this paragraph is part of a text frame; the renderer positions it
+   * as a frame (drop cap or generic frame) and registers a wrap exclusion so
+   * following body text flows around it. Absent ⇒ ordinary in-flow paragraph.
+   */
+  framePr?: FramePr;
+}
+
+/**
+ * ECMA-376 §17.3.1.11 `<w:framePr>` — text-frame / drop-cap properties.
+ *
+ * Lengths are pt (parser converts from twips). Per the spec, `x`/`y` are
+ * ignored when `xAlign`/`yAlign` are set, and for a drop cap `y`/`yAlign` are
+ * ignored entirely while `lines` drives the height. `w`/`h`/`x`/`y` are
+ * `undefined` when the attribute was absent (distinct from an explicit 0).
+ */
+export interface FramePr {
+  /** ST_DropCap (§17.18.20): 'none' | 'drop' | 'margin'. Default 'none'. */
+  dropCap: 'none' | 'drop' | 'margin' | string;
+  /** §17.3.1.11 `lines` — drop-cap vertical height in anchor lines. Default 1. */
+  lines: number;
+  /** ST_Wrap (§17.18.104): 'around'|'auto'|'none'|'notBeside'|'through'|'tight'. Default 'around'. */
+  wrap: 'around' | 'auto' | 'none' | 'notBeside' | 'through' | 'tight' | string;
+  /** ST_HAnchor (§17.18.35): 'text'(=column) | 'margin' | 'page'. Default 'page'. */
+  hAnchor: 'text' | 'margin' | 'page' | string;
+  /** ST_VAnchor (§17.18.100): 'text' | 'margin' | 'page'. Default 'page'. */
+  vAnchor: 'text' | 'margin' | 'page' | string;
+  /** ST_HeightRule (§17.18.37): 'auto' | 'atLeast' | 'exact'. Default 'auto'. */
+  hRule: 'auto' | 'atLeast' | 'exact' | string;
+  /** hSpace — min wrap padding L/R when wrap='around' (pt). Default 0. */
+  hSpace: number;
+  /** vSpace — min wrap padding top/bottom (pt). Default 0. */
+  vSpace: number;
+  /** w — exact frame width (pt). Absent ⇒ auto (max content line width). */
+  w?: number;
+  /** h — frame height (pt). Meaning gated by hRule. Absent ⇒ auto. */
+  h?: number;
+  /** x — absolute horizontal offset from hAnchor (pt). Ignored when xAlign set. */
+  x?: number;
+  /** y — absolute vertical offset from vAnchor (pt). Ignored when yAlign set / drop cap. */
+  y?: number;
+  /** ST_XAlign (§22.9.2.18): 'left'|'center'|'right'|'inside'|'outside'. Supersedes x. */
+  xAlign?: 'left' | 'center' | 'right' | 'inside' | 'outside' | string;
+  /** ST_YAlign (§22.9.2.20): 'inline'|'top'|'center'|'bottom'|'inside'|'outside'. Supersedes y. */
+  yAlign?: 'inline' | 'top' | 'center' | 'bottom' | 'inside' | 'outside' | string;
 }
 
 export interface ParagraphBorders {


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 5 "Dropcaps" — the 58.5pt "D" rendered as an oversized inline glyph with no wrap. `<w:framePr>` (§17.3.1.11) was unimplemented across parser/model/renderer/paginator.

- **Parser**: `FramePr` (all §17.3.1.11 attrs, twip→pt, spec defaults) on `DocParagraph`; parsed in `parse_para_fmt`, merged through the style chain + direct pPr. TS model mirrors 1:1.
- **Renderer**: a framed paragraph draws out of flow into a frame box (`computeFrameBox`: drop / margin / generic, hRule sizing, x/yAlign, h/vSpace) and registers a `FloatRect` so following lines wrap via the existing `resolveLineFloatWindow`. `wrap` → float mode (around/auto/tight/through→square, notBeside→topAndBottom, none→no float). `frameXContainer`/`frameYContainer` resolve the text/margin/page anchors (distinct from DrawingML relativeFrom). Drop-cap height = `lines` × following line height; glyph uses the run's own sz.
- **Column integrity (§17.6.4)**: exclusion x-range derives from the active column band (`state.contentX/contentW`), so multi-column sections wrap only the owning column.

## Verification
- Rust fmt/clippy clean, 97 cargo tests; WASM rebuilt.
- TS typecheck clean; **144 vitest** (19 new `frame-geometry.test.ts` table-driven assertions over wrap/dropCap/anchor/hRule/xAlign — the only guard for modes VRT can't reach).
- **VRT 21/21 pass**, no regression (existing samples have no framePr).
- Visual: page 5 — the "D" spans 3 lines and "rop caps are used…" wraps to its right, matching the Word PDF.

## Notes
- Frame content ignores the paragraph's body-style indents (§17.3.1.11 positions content from the frame's own left edge), preventing the cap from drifting into the wrapped text.
- Paginator keep-with-next for a page-edge frame is a documented `TODO(§17.3.1.11)` heuristic (Word runtime behaviour, not pinned by ECMA-376).

Part of the sample-11 fidelity series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)