### PR TITLE
feat(docx): floating tables (w:tblpPr §17.4.58 / w:tblOverlap §17.4.59)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4163,6 +4163,37 @@ fn parse_table(
     // per-cell left/right borders when this is set.
     let bidi_visual = tbl_pr.and_then(|p| bool_prop(p, "bidiVisual"));
 
+    // ECMA-376 §17.4.57 `<w:tblpPr>` — floating-table position. Its presence
+    // makes the table float (out of flow). twips_to_pt accepts a leading '-'
+    // (Rust f64 parsing handles signed strings), so tblpX/tblpY (signed twips)
+    // round-trip correctly.
+    let tblp_pr = tbl_pr.and_then(|p| child_w(p, "tblpPr")).map(|n| TblpPr {
+        left_from_text: attr_w(n, "leftFromText")
+            .map(|v| twips_to_pt(&v))
+            .unwrap_or(0.0),
+        right_from_text: attr_w(n, "rightFromText")
+            .map(|v| twips_to_pt(&v))
+            .unwrap_or(0.0),
+        top_from_text: attr_w(n, "topFromText")
+            .map(|v| twips_to_pt(&v))
+            .unwrap_or(0.0),
+        bottom_from_text: attr_w(n, "bottomFromText")
+            .map(|v| twips_to_pt(&v))
+            .unwrap_or(0.0),
+        horz_anchor: attr_w(n, "horzAnchor").unwrap_or_else(|| "page".to_string()),
+        vert_anchor: attr_w(n, "vertAnchor").unwrap_or_else(|| "page".to_string()),
+        tblp_x: attr_w(n, "tblpX").map(|v| twips_to_pt(&v)).unwrap_or(0.0),
+        tblp_y: attr_w(n, "tblpY").map(|v| twips_to_pt(&v)).unwrap_or(0.0),
+        tblp_x_spec: attr_w(n, "tblpXSpec"),
+        tblp_y_spec: attr_w(n, "tblpYSpec"),
+    });
+
+    // ECMA-376 §17.4.56 `<w:tblOverlap w:val>` — "never" | "overlap" (default
+    // "overlap"). Only meaningful when the table is floating.
+    let overlap = tbl_pr
+        .and_then(|p| child_w(p, "tblOverlap"))
+        .and_then(|n| attr_w(n, "val"));
+
     DocTable {
         col_widths,
         rows,
@@ -4176,6 +4207,8 @@ fn parse_table(
         width_pt: tbl_w_pt,
         width_pct: tbl_w_pct,
         bidi_visual,
+        tblp_pr,
+        overlap,
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1135,6 +1135,40 @@ pub enum BreakType {
 
 // ===== Table =====
 
+/// ECMA-376 §17.4.57 `<w:tblpPr>` — floating-table positioning. Its mere
+/// presence in `<w:tblPr>` makes the table FLOAT (out of the main text flow,
+/// absolutely positioned by its top-left corner). All attributes are optional.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TblpPr {
+    /// §17.4.57 leftFromText/rightFromText/topFromText/bottomFromText
+    /// (ST_TwipsMeasure): minimum distance to wrapping text (dist padding), pt.
+    /// Default 0.
+    pub left_from_text: f64,
+    pub right_from_text: f64,
+    pub top_from_text: f64,
+    pub bottom_from_text: f64,
+    /// §17.4.57 horzAnchor (ST_HAnchor {text,margin,page}). Default "page".
+    pub horz_anchor: String,
+    /// §17.4.57 vertAnchor (ST_VAnchor {text,margin,page}). Default "page".
+    pub vert_anchor: String,
+    /// §17.4.57 tblpX/tblpY (ST_SignedTwipsMeasure): absolute signed offset from
+    /// the horz/vert anchor edge, pt. Default 0. Ignored when the corresponding
+    /// `*Spec` is present.
+    pub tblp_x: f64,
+    pub tblp_y: f64,
+    /// §17.4.57 tblpXSpec (ST_XAlign {left,center,right,inside,outside}).
+    /// Supersedes tblpX when present. None ⇒ use the absolute offset tblpX.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tblp_x_spec: Option<String>,
+    /// §17.4.57 tblpYSpec (ST_YAlign {inline,top,center,bottom,inside,outside}).
+    /// Supersedes tblpY when present, UNLESS vertAnchor="text" (relative vertical
+    /// positioning is not allowed there ⇒ tblpYSpec is ignored, fall back to
+    /// tblpY). None ⇒ use the absolute offset tblpY.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tblp_y_spec: Option<String>,
+}
+
 #[derive(Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DocTable {
@@ -1171,6 +1205,17 @@ pub struct DocTable {
     /// left/right borders accordingly.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bidi_visual: Option<bool>,
+    /// ECMA-376 §17.4.57 `<w:tblpPr>` — when present the table is FLOATING
+    /// (absolutely positioned, out of the main text flow). None ⇒ an ordinary
+    /// block table.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tblp_pr: Option<TblpPr>,
+    /// ECMA-376 §17.4.56 `<w:tblOverlap w:val>` (ST_TblOverlap {never,overlap}).
+    /// "never" ⇒ the floating table must be repositioned to avoid overlapping
+    /// other floats. Default "overlap" (omitted ⇒ overlap allowed). Ignored when
+    /// the table is not floating (no `tblp_pr`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub overlap: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]

--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { computeFloatTableBox, registerTableFloat, floatTableWrapSide } from './renderer.js';
+import type { FloatTableBox } from './renderer.js';
+import type { TblpPr } from './types.js';
+import type { FloatRect } from './float-layout.js';
+
+// Table-driven geometry assertions for floating tables (ECMA-376 §17.4.57
+// `<w:tblpPr>` / §17.4.56 `<w:tblOverlap>`). The VRT does not cover the
+// floating-table sample (private/sample-11 is not in the VRT suite), so these
+// pin the placement math AND the FloatRect that registerTableFloat emits
+// (xLeft/xRight/yTop/yBottom/mode/side), which resolveLineFloatWindow consumes
+// to wrap the surrounding body text.
+//
+// Geometry is exercised at scale=1 so px == pt. A representative page:
+//   pageWidth=600, margins L/R/T/B = 100/100/72/72 ⇒ content band [100,500].
+//   A single column is modeled as contentX=100, contentW=400; hAnchor="text"
+//   snaps to it (the #513 column-relative contract).
+
+interface MinState {
+  scale: number;
+  contentX: number;
+  contentW: number;
+  marginLeft: number;
+  marginRight: number;
+  marginTop: number;
+  marginBottom: number;
+  pageWidth: number;
+  pageH: number;
+  floats: FloatRect[];
+  floatParaSeq: number;
+}
+
+function makeState(over: Partial<MinState> = {}): MinState {
+  return {
+    scale: 1,
+    contentX: 100,
+    contentW: 400,
+    marginLeft: 100,
+    marginRight: 100,
+    marginTop: 72,
+    marginBottom: 72,
+    pageWidth: 600,
+    pageH: 800,
+    floats: [],
+    floatParaSeq: 0,
+    ...over,
+  };
+}
+
+// Full TblpPr with the spec defaults; tests override only the axis under test.
+function tblp(over: Partial<TblpPr> = {}): TblpPr {
+  return {
+    leftFromText: 0,
+    rightFromText: 0,
+    topFromText: 0,
+    bottomFromText: 0,
+    horzAnchor: 'page',
+    vertAnchor: 'page',
+    tblpX: 0,
+    tblpY: 0,
+    ...over,
+  };
+}
+
+// Cast helpers: the geometry fns read only the MinState subset of RenderState.
+const box = (tp: TblpPr, st: MinState, paraTop: number, w: number, h: number): FloatTableBox =>
+  computeFloatTableBox(tp, st as never, paraTop, w, h);
+const registerFloat = (
+  b: FloatTableBox,
+  tp: TblpPr,
+  st: MinState,
+  side: string,
+  allowOverlap: boolean,
+): void => registerTableFloat(b, tp, st as never, side, allowOverlap);
+const wrapSide = (b: FloatTableBox, st: MinState): string =>
+  floatTableWrapSide(b, st as never);
+
+describe('floating table geometry (§17.4.57) — horizontal placement', () => {
+  it('horzAnchor="page", tblpX=0 ⇒ table at the physical page left edge', () => {
+    const st = makeState();
+    const b = box(tblp({ horzAnchor: 'page', tblpX: 0 }), st, 300, 150, 60);
+    expect(b.x).toBe(0); // page left + 0
+    expect(b.w).toBe(150);
+    expect(b.h).toBe(60);
+  });
+
+  it('horzAnchor="page", tblpX signed offset is added (signed twips round-trip)', () => {
+    const st = makeState();
+    expect(box(tblp({ horzAnchor: 'page', tblpX: 36 }), st, 300, 150, 60).x).toBe(36);
+    expect(box(tblp({ horzAnchor: 'page', tblpX: -20 }), st, 300, 150, 60).x).toBe(-20);
+  });
+
+  it('horzAnchor="margin", tblpX anchors against the page content margin', () => {
+    const st = makeState();
+    const b = box(tblp({ horzAnchor: 'margin', tblpX: 10 }), st, 300, 150, 60);
+    expect(b.x).toBe(100 + 10); // marginLeft + tblpX
+  });
+
+  it('horzAnchor="text", tblpX anchors against the COLUMN band (contentX, #513)', () => {
+    const st = makeState({ contentX: 250, contentW: 200 }); // a right-hand column
+    const b = box(tblp({ horzAnchor: 'text', tblpX: 10 }), st, 300, 80, 40);
+    expect(b.x).toBe(250 + 10); // column left + tblpX
+  });
+
+  it('tblpXSpec="left" / "inside" snap to the band left, superseding tblpX', () => {
+    const st = makeState();
+    for (const spec of ['left', 'inside']) {
+      const b = box(tblp({ horzAnchor: 'text', tblpX: 999, tblpXSpec: spec }), st, 300, 100, 40);
+      expect(b.x, spec).toBe(100); // contentX, tblpX ignored
+    }
+  });
+
+  it('tblpXSpec="center" centers the table in the band, superseding tblpX', () => {
+    const st = makeState(); // text band [100,500], width 400
+    const b = box(tblp({ horzAnchor: 'text', tblpX: 999, tblpXSpec: 'center' }), st, 300, 100, 40);
+    expect(b.x).toBe(100 + (400 - 100) / 2);
+  });
+
+  it('tblpXSpec="right" / "outside" right-align the table in the band', () => {
+    const st = makeState();
+    for (const spec of ['right', 'outside']) {
+      const b = box(tblp({ horzAnchor: 'text', tblpXSpec: spec }), st, 300, 100, 40);
+      expect(b.x, spec).toBe(500 - 100); // band right − tableW
+    }
+  });
+});
+
+describe('floating table geometry (§17.4.57) — vertical placement', () => {
+  it('vertAnchor="text", tblpY ⇒ table top at the anchor paragraph top + tblpY', () => {
+    const st = makeState();
+    const b = box(tblp({ vertAnchor: 'text', tblpY: 1 }), st, 300, 150, 60);
+    expect(b.y).toBe(300 + 1); // paraTop + tblpY
+  });
+
+  it('vertAnchor="margin", tblpY anchors against the top content margin', () => {
+    const st = makeState();
+    const b = box(tblp({ vertAnchor: 'margin', tblpY: 5 }), st, 300, 150, 60);
+    expect(b.y).toBe(72 + 5); // marginTop + tblpY
+  });
+
+  it('vertAnchor="page", tblpY anchors against the physical page top', () => {
+    const st = makeState();
+    const b = box(tblp({ vertAnchor: 'page', tblpY: 5 }), st, 300, 150, 60);
+    expect(b.y).toBe(0 + 5); // page top + tblpY
+  });
+
+  it('vertAnchor="text" IGNORES tblpYSpec (relative vertical not allowed) → tblpY', () => {
+    const st = makeState();
+    // tblpYSpec="center" would otherwise center; with vertAnchor="text" it is
+    // ignored and the absolute tblpY offset is used instead (§17.4.57).
+    const b = box(tblp({ vertAnchor: 'text', tblpY: 7, tblpYSpec: 'center' }), st, 300, 150, 60);
+    expect(b.y).toBe(300 + 7);
+  });
+
+  it('vertAnchor="margin" + tblpYSpec="bottom" bottom-aligns on the page, superseding tblpY', () => {
+    const st = makeState();
+    const b = box(tblp({ vertAnchor: 'margin', tblpY: 999, tblpYSpec: 'bottom' }), st, 300, 150, 60);
+    expect(b.y).toBe((800 - 72) - 60); // (pageH − marginBottom) − tableH
+  });
+
+  it('vertAnchor="margin" + tblpYSpec="center" centers vertically, superseding tblpY', () => {
+    const st = makeState();
+    const b = box(tblp({ vertAnchor: 'margin', tblpY: 999, tblpYSpec: 'center' }), st, 300, 150, 60);
+    expect(b.y).toBe(72 + (800 - 60) / 2 - 72); // vy + (pageH−h)/2 − marginTop
+  });
+});
+
+describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
+  it('registers a square wrap float padded by the *FromText dist values', () => {
+    const st = makeState();
+    const tp = tblp({ horzAnchor: 'page', leftFromText: 5, rightFromText: 9, topFromText: 3, bottomFromText: 7 });
+    const b = box(tp, st, 300, 150, 60);
+    registerFloat(b, tp, st, 'right', true);
+    expect(st.floats).toHaveLength(1);
+    const f = st.floats[0];
+    expect(f.mode).toBe('square');
+    expect(f.side).toBe('right');
+    expect(f.imageKey).toBe(''); // non-image float (table painted directly)
+    expect(f.drawn).toBe(true);
+    expect(f.xLeft).toBe(0 - 5); // box.x − leftFromText
+    expect(f.xRight).toBe(0 + 150 + 9); // box.x + tableW + rightFromText
+    expect(f.yTop).toBe(b.y - 3);
+    expect(f.yBottom).toBe(b.y + 60 + 7);
+    expect(f.distLeft).toBe(5);
+    expect(f.distRight).toBe(9);
+  });
+
+  it('a degenerate (zero-area) box registers no float', () => {
+    const st = makeState();
+    const tp = tblp();
+    registerFloat({ x: 0, y: 0, w: 0, h: 0 }, tp, st, 'right', true);
+    expect(st.floats).toHaveLength(0);
+  });
+
+  it('overlap="never" (allowOverlap=false) re-seats the new float off a blocker', () => {
+    // Pre-seat a blocking float [0,200]×[300,360] from another paragraph.
+    const st = makeState({
+      floatParaSeq: 1,
+      floats: [{
+        mode: 'square', imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
+        xLeft: 0, xRight: 200, yTop: 300, yBottom: 360, side: 'bothSides',
+        distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0, drawn: true,
+      }],
+    });
+    // A new floating table at page-left x=0 overlapping the blocker; never ⇒ avoid.
+    const tp = tblp({ horzAnchor: 'page', tblpX: 0, vertAnchor: 'page', tblpY: 320 });
+    const b = box(tp, st, 0, 100, 20); // box at (0,320), overlaps the blocker
+    registerFloat(b, tp, st, 'right', /* allowOverlap */ false);
+    const f = st.floats[st.floats.length - 1];
+    // resolveFloatOverlap re-seats it to the right of the blocker's right edge.
+    expect(f.xLeft).toBeGreaterThanOrEqual(200);
+  });
+});
+
+describe('floating table — sample-11 case (§17.4.57)', () => {
+  // <w:tblpPr w:rightFromText="187" w:bottomFromText="72" w:vertAnchor="text"
+  //           w:tblpY="1"/> + <w:tblOverlap w:val="never"/>. No horzAnchor ⇒
+  // page; no tblpX ⇒ 0 ⇒ the table sits at the page's left vertical edge.
+  // rightFromText 187 twip → 9.35 pt; bottomFromText 72 twip → 3.6 pt.
+  const RIGHT_FROM_TEXT = 187 / 20; // 9.35 pt
+  const BOTTOM_FROM_TEXT = 72 / 20; // 3.6 pt
+
+  it('floats at page-left (x=0), text wraps on the RIGHT, right dist padding present', () => {
+    const st = makeState();
+    const tp = tblp({
+      rightFromText: RIGHT_FROM_TEXT,
+      bottomFromText: BOTTOM_FROM_TEXT,
+      horzAnchor: 'page', // default
+      vertAnchor: 'text',
+      tblpX: 0,
+      tblpY: 1,
+    });
+    // A small ITEM/NEEDED table, say 120 wide × 50 tall, anchored at paraTop=300.
+    const tableW = 120;
+    const b = box(tp, st, 300, tableW, 50);
+    expect(b.x).toBe(0); // page left
+    expect(b.y).toBe(300 + 1); // vAnchor=text ⇒ paraTop + tblpY
+
+    // side from the column band [100,500]: the float's right edge (x+w = 120) is
+    // left of the column centre (300) ⇒ float on the LEFT ⇒ text wraps RIGHT.
+    const side = wrapSide(b, st);
+    expect(side).toBe('right'); // text sits to the RIGHT of the float
+
+    registerFloat(b, tp, st, side, /* overlap="never" ⇒ */ false);
+    const f = st.floats[0];
+    expect(f.side).toBe('right');
+    expect(f.xRight).toBe(0 + tableW + RIGHT_FROM_TEXT); // right edge includes the dist padding
+    expect(f.yBottom).toBe(b.y + 50 + BOTTOM_FROM_TEXT);
+  });
+});
+
+describe('floating table wrap side (§17.4.57) from the column band', () => {
+  const st = makeState(); // column band [100, 500], centre 300
+
+  it('float whose right edge is left-of-centre ⇒ text wraps RIGHT', () => {
+    expect(wrapSide({ x: 0, y: 0, w: 120, h: 50 }, st)).toBe('right');
+  });
+
+  it('float whose left edge is right-of-centre ⇒ text wraps LEFT', () => {
+    expect(wrapSide({ x: 350, y: 0, w: 120, h: 50 }, st)).toBe('left');
+  });
+
+  it('float straddling the column centre ⇒ bothSides', () => {
+    expect(wrapSide({ x: 200, y: 0, w: 200, h: 50 }, st)).toBe('bothSides');
+  });
+});

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -40,6 +40,7 @@ export type {
   DocxRunBorder,
   // Table model (reachable via BodyElement table variant).
   DocTable,
+  TblpPr,
   DocTableRow,
   DocTableCell,
   CellElement,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, DocNote, NumberingInfo, ColumnGeom, FramePr,
+  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
@@ -1430,6 +1430,40 @@ export function computePages(
       prevSpaceAfter = para.spaceAfter;
     } else if (el.type === 'table') {
       const tbl = el as unknown as DocTable;
+
+      // ECMA-376 §17.4.57 `<w:tblpPr>`: a floating table is positioned OUT OF
+      // FLOW (like a frame paragraph, §17.3.1.11). It does NOT advance the page
+      // cursor and is not split. Register its wrap float on the measureState so
+      // following paragraphs estimate around it, then emit it onto the current
+      // page (the renderer draws it absolutely). prevPara/spaceAfter are left
+      // untouched so the following paragraph spaces against the paragraph BEFORE
+      // the table.
+      //
+      // ヒューリスティック、§17.4.57 TODO: floating table page-fit is Word runtime
+      // behavior, not spec-defined. Minimal: keep on current page (no break /
+      // relocation across pages here; only the in-page wrap band is modeled).
+      if (tbl.tblpPr) {
+        // KNOWN LIMITATION (#513): measureState.contentX/contentW stay at the
+        // full content band here (they are not re-pointed per newspaper column
+        // the way renderBodyElements does for the paint pass). So for a
+        // horzAnchor="text" floating table inside a MULTI-COLUMN section the
+        // paginator estimates its wrap band against the full band while the
+        // renderer paints it in the owning column — measure and paint diverge.
+        // Harmless for single-column / page|margin-anchored tables (the common
+        // case, incl. sample-11). Threading per-column geometry into the measure
+        // pass (shared with the frame branch) is tracked as a follow-up.
+        // measureState.scale is 1, so colW() (pt) equals the px content width
+        // computeTableLayout expects (it re-divides by scale internally).
+        const cW = colW() * measureState.scale;
+        const layout = computeTableLayout(tbl, cW, measureState);
+        const tableH = layout.rowHeights.reduce((s, x) => s + x, 0);
+        const box = computeFloatTableBox(tbl.tblpPr, measureState, measureState.y, layout.tableW, tableH);
+        const side = floatTableWrapSide(box, measureState);
+        registerTableFloat(box, tbl.tblpPr, measureState, side, tbl.overlap !== 'never');
+        pushTagged(el as PaginatedBodyElement);
+        continue;
+      }
+
       // Tables in a multi-column section are sized to the column width, not the
       // full content band.
       const rowHs = computeTableRowHeights(measureState, tbl, colW());
@@ -2392,9 +2426,17 @@ function renderBodyElements(
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;
     } else if (el.type === 'table') {
-      renderTable(el as unknown as DocTable, state);
-      prevPara = null;
-      prevSpaceAfter = 0;
+      const tbl = el as unknown as DocTable;
+      // A floating table (ECMA-376 §17.4.57 `<w:tblpPr>`) is out of flow: it is
+      // drawn absolutely by renderFloatTable and adds no flow height, so leave
+      // prevPara/spaceAfter untouched (the following content spaces against the
+      // paragraph BEFORE the table, exactly like a frame paragraph). A block
+      // table resets them (it ends the previous spacing context).
+      renderTable(tbl, state);
+      if (!tbl.tblpPr) {
+        prevPara = null;
+        prevSpaceAfter = 0;
+      }
     }
   }
 }
@@ -2556,6 +2598,16 @@ export interface FrameBox {
   exRight: number;
   exTop: number;
   exBottom: number;
+}
+
+/** Resolved top-left placement (canvas px) of a floating table (`<w:tblpPr>`,
+ *  ECMA-376 §17.4.57). `w`/`h` are the rendered table extent (sum of column
+ *  widths × row heights). Exported for unit tests only — not package API. */
+export interface FloatTableBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
 }
 
 /**
@@ -2840,6 +2892,171 @@ export function registerFrameFloat(box: FrameBox, fp: FramePr, state: RenderStat
     drawn: true, // painted by renderFrameParagraph; deferred path must skip it.
   };
   state.floats.push(rect);
+}
+
+// ===== Floating tables (ECMA-376 §17.4.57 w:tblpPr / §17.4.56 w:tblOverlap) =====
+
+/**
+ * Resolve a floating table's top-left placement (canvas px) from its
+ * `<w:tblpPr>` (ECMA-376 §17.4.57). `tableW`/`tableH` are the already-laid-out
+ * table extent in px. The anchor / alignment semantics line up 1:1 with a
+ * `<w:framePr>` text frame (horzAnchor↔hAnchor, vertAnchor↔vAnchor,
+ * tblpXSpec↔xAlign, tblpYSpec↔yAlign, tblpX/tblpY↔x/y), so this mirrors
+ * {@link computeFrameBox}'s placement math exactly — `frameXContainer` /
+ * `frameYContainer` give the same per-anchor bands (text→column band,
+ * margin→page content margin, page→physical edges), which is the #513
+ * column-integrity guarantee.
+ *
+ * Exported for unit tests only (the float-table-geometry table) — not package API.
+ */
+export function computeFloatTableBox(
+  tp: TblpPr,
+  state: RenderState,
+  paraTop: number,
+  tableW: number,
+  tableH: number,
+): FloatTableBox {
+  const sc = state.scale;
+  const hx = frameXContainer(tp.horzAnchor, state);
+  const vy = frameYContainer(tp.vertAnchor, paraTop, state);
+
+  // Horizontal: tblpXSpec (ST_XAlign) supersedes the absolute tblpX offset
+  // (§17.4.57). Mirrors computeFrameBox's xAlign handling.
+  let x: number;
+  if (tp.tblpXSpec) {
+    switch (tp.tblpXSpec) {
+      case 'center':
+        x = hx.left + (hx.right - hx.left - tableW) / 2;
+        break;
+      case 'right':
+      case 'outside':
+        x = hx.right - tableW;
+        break;
+      case 'left':
+      case 'inside':
+      default:
+        x = hx.left;
+        break;
+    }
+  } else {
+    // §17.4.57 tblpX: absolute signed offset from the horzAnchor left edge.
+    x = hx.left + tp.tblpX * sc;
+  }
+
+  // Vertical: tblpYSpec (ST_YAlign) supersedes the absolute tblpY offset
+  // (§17.4.57) — EXCEPT when vertAnchor="text", where relative vertical
+  // positioning is not allowed and tblpYSpec is ignored (fall back to tblpY).
+  // Mirrors computeFrameBox's yAlign handling (ignored when vAnchor="text").
+  let y: number;
+  if (tp.tblpYSpec && tp.vertAnchor !== 'text') {
+    switch (tp.tblpYSpec) {
+      case 'center':
+        y = vy + (state.pageH - tableH) / 2 - state.marginTop * sc;
+        break;
+      case 'bottom':
+      case 'outside':
+        y = (state.pageH - state.marginBottom * sc) - tableH;
+        break;
+      case 'top':
+      case 'inside':
+      case 'inline':
+      default:
+        y = vy;
+        break;
+    }
+  } else {
+    y = vy + tp.tblpY * sc;
+  }
+
+  return { x, y, w: tableW, h: tableH };
+}
+
+/**
+ * Push the wrap-exclusion FloatRect for a resolved floating-table box onto
+ * `state.floats` so following body text flows around the table (§17.4.57). The
+ * exclusion is the table box padded by the *FromText dist values. Overlap
+ * avoidance (§17.4.56) runs FIRST (mirroring registerShapeFloat: resolve x/y,
+ * THEN build the exclusion from the resolved x/y) with allowOverlap =
+ * `table.overlap !== 'never'` (default true ⇒ overlap permitted).
+ *
+ * `side` (which side text wraps on) is computed by the caller from the resolved
+ * box vs the column band: the table sits to one side and text fills the other
+ * (§17.4.57). The x-range is built from the box (which for horzAnchor="text" is
+ * column-relative via frameXContainer), so resolveLineFloatWindow only
+ * constrains the matching column (#513), consistent with registerFrameFloat.
+ *
+ * Exported for unit tests only (the float-table-geometry table) — not package API.
+ */
+export function registerTableFloat(
+  box: FloatTableBox,
+  tp: TblpPr,
+  state: RenderState,
+  side: string,
+  allowOverlap: boolean,
+): void {
+  if (box.w <= 0 || box.h <= 0) return;
+  const sc = state.scale;
+  const dl = tp.leftFromText * sc;
+  const dr = tp.rightFromText * sc;
+  const dt = tp.topFromText * sc;
+  const db = tp.bottomFromText * sc;
+  const paraId = state.floatParaSeq++;
+
+  // §17.4.56: resolve overlap against already-registered page floats before
+  // fixing the exclusion rect. allowOverlap=false (tblOverlap="never") forces
+  // avoidance of ALL floats; allowOverlap=true only avoids OTHER paragraphs'
+  // floats (the implementation-defined scope documented on resolveFloatOverlap).
+  const resolved = resolveFloatOverlap(
+    box.x, box.y, box.w, box.h, dl, dr, dt, db, paraId, allowOverlap,
+    state.pageWidth * state.scale, state.floats,
+  );
+  const px = resolved.x;
+  const py = resolved.y;
+
+  const rect: FloatRect = {
+    mode: 'square',
+    imageKey: '', // non-image float: the table is painted by renderFloatTable.
+    imageX: px,
+    imageY: py,
+    imageW: box.w,
+    imageH: box.h,
+    xLeft: px - dl,
+    xRight: px + box.w + dr,
+    yTop: py - dt,
+    yBottom: py + box.h + db,
+    side,
+    distLeft: dl,
+    distRight: dr,
+    distTop: dt,
+    distBottom: db,
+    paraId,
+    drawn: true, // painted by renderFloatTable; deferred image path must skip it.
+  };
+  state.floats.push(rect);
+}
+
+/**
+ * §17.4.57 — which side the body text wraps on, from the resolved float box vs
+ * the current COLUMN band [contentX, contentX+contentW]. A floating table sits
+ * to ONE side of the column and text fills the OTHER:
+ *   - float's right edge at/left-of the column centre ⇒ float on the LEFT ⇒
+ *     text wraps on the RIGHT (side='right').
+ *   - float's left edge at/right-of the column centre ⇒ float on the RIGHT ⇒
+ *     text wraps on the LEFT (side='left').
+ *   - otherwise the float straddles the centre ⇒ 'bothSides' (resolveLineFloat-
+ *     Window then takes the widest free gap on either flank).
+ * Coordinates are page-absolute px; the comparison is against the column band so
+ * a per-column floating table wraps within its own column (#513).
+ *
+ * Exported for unit tests only (the float-table-geometry table) — not package API.
+ */
+export function floatTableWrapSide(box: FloatTableBox, state: RenderState): string {
+  const colLeft = state.contentX;
+  const colRight = state.contentX + state.contentW;
+  const center = (colLeft + colRight) / 2;
+  if (box.x + box.w <= center) return 'right';
+  if (box.x >= center) return 'left';
+  return 'bothSides';
 }
 
 /**
@@ -5556,26 +5773,24 @@ function registerShapeFloat(
 
 // ===== Table rendering =====
 
-function renderTable(table: DocTable, state: RenderState): void {
-  const { ctx, scale, contentX, contentW, dryRun } = state;
-
+/** Per-column widths (px), total table width (px), and per-row heights (px,
+ *  with the §17.4.85 vMerge-span extension applied) for a table laid out in a
+ *  content band `contentWPx` wide. Shared by the block ({@link renderTable}) and
+ *  floating ({@link renderFloatTable}) paths so both size the table identically. */
+function computeTableLayout(
+  table: DocTable,
+  contentWPx: number,
+  state: RenderState,
+): { colWidths: number[]; tableW: number; rowHeights: number[] } {
+  const { scale } = state;
   // Resolve column widths in pt (autofit by preferred widths, or fixed grid),
   // already scaled to fit the available content width, then convert to px.
-  const colWidths = resolveColumnWidths(table, contentW / scale, state).map((w) => w * scale);
-
-  // Horizontal table alignment on the page (w:tblPr/w:jc).
+  const colWidths = resolveColumnWidths(table, contentWPx / scale, state).map((w) => w * scale);
   const tableW = colWidths.reduce((s, w) => s + w, 0);
-  const tableX =
-    table.jc === 'center'
-      ? contentX + Math.max(0, (contentW - tableW) / 2)
-      : table.jc === 'right'
-        ? contentX + Math.max(0, contentW - tableW)
-        : contentX;
 
   const rowHeights: number[] = [];
   for (const row of table.rows) {
-    const rowH = calculateRowHeight(row, table, colWidths, scale, state);
-    rowHeights.push(rowH);
+    rowHeights.push(calculateRowHeight(row, table, colWidths, scale, state));
   }
 
   // ECMA-376 §17.4.85: extend each vMerge span's last row when the restart
@@ -5600,6 +5815,24 @@ function renderTable(table: DocTable, state: RenderState): void {
     }
   }
 
+  return { colWidths, tableW, rowHeights };
+}
+
+/** Draw all rows of a table whose grid origin is `tableX` (px) and whose top is
+ *  `startY` (px), returning the Y just past the last row. Shared by the block
+ *  and floating paths. Honors bidiVisual, vMerge span heights, and exact-row
+ *  clipping exactly as the original inline loop did. In dryRun, measures cell
+ *  content instead of drawing. */
+function drawTableRows(
+  table: DocTable,
+  colWidths: number[],
+  tableW: number,
+  rowHeights: number[],
+  tableX: number,
+  startY: number,
+  state: RenderState,
+): number {
+  const { scale, dryRun } = state;
   // ECMA-376 §17.4.1 `<w:bidiVisual>`: lay the grid columns right-to-left, so
   // logical column 0 sits at the table's RIGHT edge and indices advance
   // leftward. We mirror by POSITION arithmetic (not canvas transform): a cell
@@ -5610,7 +5843,7 @@ function renderTable(table: DocTable, state: RenderState): void {
   // from logical column offset to a physical x flips.
   const mirror = table.bidiVisual === true;
 
-  let y = state.y;
+  let y = startY;
   for (let ri = 0; ri < table.rows.length; ri++) {
     const row = table.rows[ri];
     const rowH = rowHeights[ri];
@@ -5653,6 +5886,74 @@ function renderTable(table: DocTable, state: RenderState): void {
 
     y += rowH;
   }
+  return y;
+}
+
+/**
+ * Render a FLOATING table (ECMA-376 §17.4.57 `<w:tblpPr>`). Like a `<w:framePr>`
+ * frame, it is OUT OF FLOW: drawn at an absolute (anchor-relative) position and
+ * consuming ZERO flow height, so the following content begins where the table's
+ * anchor paragraph sat. A wrap-exclusion FloatRect is registered (§17.4.57
+ * *FromText padding, §17.4.56 overlap) so the body text flows around it.
+ *
+ * Mirrors {@link renderFrameParagraph}: save contentX/contentW/y, redirect the
+ * flow geometry to the resolved box, draw the rows, then RESTORE the in-flow
+ * state.y (the float adds no flow height). In dryRun the rows are not drawn but
+ * the float is still registered so wrap estimates see the band.
+ */
+function renderFloatTable(table: DocTable, state: RenderState): void {
+  const tp = table.tblpPr!;
+  const inFlowY = state.y;
+  const savedX = state.contentX;
+  const savedW = state.contentW;
+
+  // Lay the table out in its anchor column's content band, then place its box.
+  // tableW is the ACTUAL rendered width (sum of column widths), so the FloatRect
+  // exclusion matches the painted table exactly (#513 column integrity: for
+  // horzAnchor="text" the box.x derives from the column band via
+  // frameXContainer, so the wrap stays inside this column).
+  const { colWidths, tableW, rowHeights } = computeTableLayout(table, state.contentW, state);
+  const tableH = rowHeights.reduce((s, h) => s + h, 0);
+  const box = computeFloatTableBox(tp, state, inFlowY, tableW, tableH);
+  const side = floatTableWrapSide(box, state);
+
+  // Redirect the flow geometry to the float box and draw the rows there. The
+  // table is positioned absolutely; its grid origin is box.x (no jc — a floating
+  // table's position is dictated entirely by tblpPr, §17.4.57).
+  state.contentX = box.x;
+  state.contentW = tableW;
+  drawTableRows(table, colWidths, tableW, rowHeights, box.x, box.y, state);
+  state.contentX = savedX;
+  state.contentW = savedW;
+
+  // Restore the in-flow cursor: a floating table consumes NO body flow height
+  // (§17.4.57 — out of flow), so the following content spaces as if it weren't
+  // here. (renderFrameParagraph does the same for a frame.)
+  state.y = inFlowY;
+
+  registerTableFloat(box, tp, state, side, table.overlap !== 'never');
+}
+
+function renderTable(table: DocTable, state: RenderState): void {
+  // ECMA-376 §17.4.57: a `<w:tblpPr>` table floats — divert to the out-of-flow
+  // path before the normal block layout (which would advance state.y).
+  if (table.tblpPr) {
+    renderFloatTable(table, state);
+    return;
+  }
+
+  const { contentX, contentW } = state;
+  const { colWidths, tableW, rowHeights } = computeTableLayout(table, contentW, state);
+
+  // Horizontal table alignment on the page (w:tblPr/w:jc).
+  const tableX =
+    table.jc === 'center'
+      ? contentX + Math.max(0, (contentW - tableW) / 2)
+      : table.jc === 'right'
+        ? contentX + Math.max(0, contentW - tableW)
+        : contentX;
+
+  const y = drawTableRows(table, colWidths, tableW, rowHeights, tableX, state.y, state);
 
   state.y = y;
 }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -763,6 +763,33 @@ export interface ImageRun {
 
 // ===== Table =====
 
+/**
+ * ECMA-376 §17.4.57 `<w:tblpPr>` — floating-table positioning. Present in
+ * `<w:tblPr>` ⇒ the table FLOATS (out of the main text flow, absolutely
+ * positioned by its top-left corner). All fields are optional in the source.
+ */
+export interface TblpPr {
+  /** §17.4.57 minimum distance to wrapping text (dist padding), pt. Default 0. */
+  leftFromText: number;
+  rightFromText: number;
+  topFromText: number;
+  bottomFromText: number;
+  /** §17.4.57 ST_HAnchor {text,margin,page}. Default 'page'. */
+  horzAnchor: 'text' | 'margin' | 'page' | string;
+  /** §17.4.57 ST_VAnchor {text,margin,page}. Default 'page'. */
+  vertAnchor: 'text' | 'margin' | 'page' | string;
+  /** §17.4.57 absolute signed offset from the horz/vert anchor edge, pt.
+   *  Default 0. Ignored when the matching `*Spec` is present. */
+  tblpX: number;
+  tblpY: number;
+  /** §17.4.57 ST_XAlign {left,center,right,inside,outside}. Supersedes tblpX. */
+  tblpXSpec?: 'left' | 'center' | 'right' | 'inside' | 'outside' | string;
+  /** §17.4.57 ST_YAlign {inline,top,center,bottom,inside,outside}. Supersedes
+   *  tblpY, UNLESS vertAnchor='text' (relative vertical positioning is not
+   *  allowed there ⇒ tblpYSpec is ignored, fall back to tblpY). */
+  tblpYSpec?: 'inline' | 'top' | 'center' | 'bottom' | 'inside' | 'outside' | string;
+}
+
 export interface DocTable {
   colWidths: number[];  // pt
   rows: DocTableRow[];
@@ -789,6 +816,13 @@ export interface DocTable {
    * is placed rightmost, and flips per-cell left/right borders accordingly.
    */
   bidiVisual?: boolean;
+  /** ECMA-376 §17.4.57 `<w:tblpPr>` — when present the table is FLOATING
+   *  (absolutely positioned, out of the main text flow). Absent ⇒ block table. */
+  tblpPr?: TblpPr;
+  /** ECMA-376 §17.4.56 `<w:tblOverlap w:val>` — 'never' | 'overlap'. 'never' ⇒
+   *  the floating table must be repositioned to avoid overlapping other floats.
+   *  Default 'overlap' (omitted ⇒ overlap allowed). Ignored when not floating. */
+  overlap?: string;
 }
 
 export interface TableBorders {


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 3 — the green ITEM/NEEDED table should **float left with the body text wrapping to its right**; `<w:tblpPr>` (floating-table positioning) was unimplemented, so it rendered as a full-width block.

- **Parser**: `TblpPr` (`*FromText` distances, `horzAnchor`/`vertAnchor` [text/margin/page], `tblpX`/`tblpY` + `tblpXSpec`/`tblpYSpec`) and `tblOverlap` on `DocTable`. TS model mirrors it.
- **Renderer**: a tblpPr table is diverted to `renderFloatTable` — `computeFloatTableBox` places it (mirroring `computeFrameBox`; the `*Spec` alignments supersede absolute `tblpX`/`tblpY`), `registerTableFloat` pushes a square `FloatRect` padded by `*FromText` (`resolveFloatOverlap` honours `overlap="never"`), cells draw at absolute coords without advancing the flow. Following lines wrap via the existing `resolveLineFloatWindow`. `renderTable` is split into shared `computeTableLayout`/`drawTableRows`.
- **Column integrity (§17.6.4)**: the exclusion x-range comes from the anchor column band (`frameXContainer`, shared with frames), so a floating table in a multi-column section only constrains its own column.

## Verification
- Rust fmt/clippy clean, 97 cargo tests; WASM rebuilt.
- TS typecheck clean; **39 geometry tests** (20 new `float-table-geometry.test.ts`).
- **VRT 21/21 pass** — non-floating tables untouched (the divert is gated on `tblp_pr`).
- Visual: page 3 — ITEM/NEEDED table floats left, "Tables in Word can vary…" wraps to its right, matching the Word PDF. (Also shows PR #518's conditional formatting: City-or-Town banding + College teal header.)

## Notes
- Paginator keep-on-page for a page-overflowing float is a documented `TODO(§17.4.58)` heuristic (Word runtime behaviour, not pinned by ECMA-376).
- Known limitation (pre-existing, flagged): the measure pass doesn't thread per-column `contentX/contentW`; irrelevant for sample-11 (single column, horzAnchor=page).

Completes the original 4 sample-11 features (inline, table style, dropcap, floating table); fidelity series continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)