### PR TITLE
feat(docx): picture bullets (w:numPicBullet / w:lvlPicBulletId)

### DIFF
--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -1,7 +1,38 @@
 use crate::styles::{parse_run_fmt, RunFmt};
 use crate::xml_util::*;
+use ooxml_common::blip::mime_from_ext;
 use roxmltree::Document as XmlDoc;
 use std::collections::HashMap;
+
+/// Parse a single VML CSS length (e.g. `width:9pt`) from a `style` attribute
+/// into pt. Supports the units Word emits for picture-bullet shapes: `pt`
+/// (1pt), `in` (72pt), `pc` (12pt), `cm` (28.3465pt), `mm` (2.83465pt). A bare
+/// number with no unit is treated as pt (VML's default user unit for shapes is
+/// the point). Returns `None` when the property is absent or unparseable.
+fn vml_style_len(style: &str, prop: &str) -> Option<f64> {
+    for decl in style.split(';') {
+        let (k, v) = decl.split_once(':')?;
+        if k.trim() != prop {
+            continue;
+        }
+        let v = v.trim();
+        let (num, factor) = if let Some(n) = v.strip_suffix("pt") {
+            (n, 1.0)
+        } else if let Some(n) = v.strip_suffix("in") {
+            (n, 72.0)
+        } else if let Some(n) = v.strip_suffix("pc") {
+            (n, 12.0)
+        } else if let Some(n) = v.strip_suffix("mm") {
+            (n, 2.834_645_7)
+        } else if let Some(n) = v.strip_suffix("cm") {
+            (n, 28.346_457)
+        } else {
+            (v, 1.0)
+        };
+        return num.trim().parse::<f64>().ok().map(|n| n * factor);
+    }
+    None
+}
 
 #[derive(Debug, Clone)]
 pub struct LevelDef {
@@ -24,6 +55,30 @@ pub struct LevelDef {
     /// `<w:rFonts w:hint="eastAsia"/>` (no explicit typeface), in which case every
     /// axis is `None` and the marker simply inherits the paragraph's fonts.
     pub rpr: RunFmt,
+    /// ECMA-376 §17.9.9 `<w:lvlPicBulletId w:val="N"/>` — when present, the
+    /// level's marker is the image defined by the `<w:numPicBullet>` whose
+    /// `numPicBulletId` is N (§17.9.20), drawn in place of `text`. Resolved at
+    /// parse time to the bullet image's zip path (+ MIME + pt size from the
+    /// `<v:shape style>`). `None` ⇒ ordinary text/glyph marker.
+    pub pic_bullet: Option<PicBullet>,
+}
+
+/// ECMA-376 §17.9.20 `<w:numPicBullet>` — an image used as a list marker. The
+/// image is defined by a VML `<w:pict><v:shape><v:imagedata r:id="…"/>` whose
+/// `r:id` resolves through `word/_rels/numbering.xml.rels` to a media part, and
+/// whose `<v:shape style="width:..;height:..">` carries the marker size.
+#[derive(Debug, Clone)]
+pub struct PicBullet {
+    /// Zip path of the bullet image (e.g. `word/media/image1.gif`), resolved
+    /// from the `<v:imagedata r:id>` via the numbering part's relationships.
+    pub image_path: String,
+    /// MIME type derived from the part extension (e.g. `image/gif`).
+    pub mime_type: String,
+    /// Marker width in pt, from the `<v:shape style="width:..">` (default 9pt
+    /// when the style omits a width — the common Word default for bullet shapes).
+    pub width_pt: f64,
+    /// Marker height in pt, from the `<v:shape style="height:..">`.
+    pub height_pt: f64,
 }
 
 impl Default for LevelDef {
@@ -37,6 +92,7 @@ impl Default for LevelDef {
             suff: "tab".to_string(),
             start: 1,
             rpr: RunFmt::default(),
+            pic_bullet: None,
         }
     }
 }
@@ -54,13 +110,68 @@ pub struct NumberingMap {
 }
 
 impl NumberingMap {
-    pub fn parse(xml: &str) -> Self {
+    /// Parse `word/numbering.xml`. `media_map` is the numbering part's own
+    /// relationship table (rId → zip media path, built from
+    /// `word/_rels/numbering.xml.rels`); it is required to resolve the
+    /// `<w:numPicBullet>` images (§17.9.20) — an empty map simply yields no
+    /// picture bullets, leaving levels on their text/glyph markers.
+    pub fn parse(xml: &str, media_map: &HashMap<String, String>) -> Self {
         let mut map = NumberingMap::default();
         let doc = match XmlDoc::parse(xml) {
             Ok(d) => d,
             Err(_) => return map,
         };
         let root = doc.root_element();
+
+        // ECMA-376 §17.9.20 — collect `<w:numPicBullet>` definitions first so
+        // each level's `<w:lvlPicBulletId>` (§17.9.9) can resolve against them.
+        // The bullet image is a VML `<v:shape><v:imagedata r:id>`; the r:id maps
+        // to a media part through the numbering part's rels (`media_map`), and
+        // the `<v:shape style="width:..;height:..">` carries the marker size.
+        let mut pic_bullets: HashMap<u32, PicBullet> = HashMap::new();
+        for pb_node in children_w(root, "numPicBullet") {
+            let Some(id) = attr_w(pb_node, "numPicBulletId").and_then(|v| v.parse::<u32>().ok())
+            else {
+                continue;
+            };
+            let Some(imagedata) = pb_node
+                .descendants()
+                .find(|n| n.tag_name().name() == "imagedata")
+            else {
+                continue;
+            };
+            // `r:id` lives in the relationships namespace; fall back to the
+            // unqualified attribute for defensiveness.
+            let Some(rid) = imagedata
+                .attribute((R_NS, "id"))
+                .or_else(|| imagedata.attribute("id"))
+            else {
+                continue;
+            };
+            let Some(image_path) = media_map.get(rid).cloned() else {
+                continue;
+            };
+            // `<v:shape style="width:9pt;height:9pt">` — VML CSS lengths. Word
+            // always emits explicit pt for bullet shapes; default to 9pt (Word's
+            // standard picture-bullet size) when a dimension is absent.
+            let shape_style = pb_node
+                .descendants()
+                .find(|n| n.tag_name().name() == "shape")
+                .and_then(|n| n.attribute("style"))
+                .unwrap_or("");
+            let width_pt = vml_style_len(shape_style, "width").unwrap_or(9.0);
+            let height_pt = vml_style_len(shape_style, "height").unwrap_or(9.0);
+            let mime_type = mime_from_ext(&image_path).to_string();
+            pic_bullets.insert(
+                id,
+                PicBullet {
+                    image_path,
+                    mime_type,
+                    width_pt,
+                    height_pt,
+                },
+            );
+        }
 
         // Parse abstractNum definitions
         for abs_node in children_w(root, "abstractNum") {
@@ -111,6 +222,12 @@ impl NumberingMap {
                 let rpr = child_w(lvl_node, "rPr")
                     .map(parse_run_fmt)
                     .unwrap_or_default();
+                // §17.9.9 — resolve the level's picture bullet (if any) against
+                // the `<w:numPicBullet>` definitions collected above.
+                let pic_bullet = child_w(lvl_node, "lvlPicBulletId")
+                    .and_then(|n| attr_w(n, "val"))
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .and_then(|id| pic_bullets.get(&id).cloned());
                 levels.push(LevelDef {
                     format,
                     text,
@@ -120,6 +237,7 @@ impl NumberingMap {
                     suff,
                     start,
                     rpr,
+                    pic_bullet,
                 });
             }
             map.abstract_nums.insert(abs_id, levels);
@@ -296,7 +414,75 @@ mod tests {
     const W: &str = "xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"";
 
     fn map(body: &str) -> NumberingMap {
-        NumberingMap::parse(&format!("<w:numbering {W}>{body}</w:numbering>"))
+        NumberingMap::parse(
+            &format!("<w:numbering {W}>{body}</w:numbering>"),
+            &HashMap::new(),
+        )
+    }
+
+    /// §17.9.20 / §17.9.9 — a `<w:numPicBullet>` image resolves through the
+    /// numbering part's rels (`media_map`), and the level's `<w:lvlPicBulletId>`
+    /// picks it up with the `<v:shape style>` size (here width:9pt;height:9pt).
+    #[test]
+    fn picture_bullet_resolves_image_path_and_size() {
+        const R: &str =
+            "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"";
+        const V: &str = "xmlns:v=\"urn:schemas-microsoft-com:vml\"";
+        const O: &str = "xmlns:o=\"urn:schemas-microsoft-com:office:office\"";
+        let media: HashMap<String, String> =
+            [("rId1".to_string(), "word/media/image1.gif".to_string())]
+                .into_iter()
+                .collect();
+        let xml = format!(
+            r#"<w:numbering {W} {R} {V} {O}>
+                 <w:numPicBullet w:numPicBulletId="0">
+                   <w:pict>
+                     <v:shape id="x" style="width:9pt;height:9pt" o:bullet="t">
+                       <v:imagedata r:id="rId1" o:title="BD"/>
+                     </v:shape>
+                   </w:pict>
+                 </w:numPicBullet>
+                 <w:abstractNum w:abstractNumId="8">
+                   <w:lvl w:ilvl="0">
+                     <w:numFmt w:val="bullet"/><w:lvlText w:val=""/>
+                     <w:lvlPicBulletId w:val="0"/>
+                   </w:lvl>
+                 </w:abstractNum>
+                 <w:num w:numId="3"><w:abstractNumId w:val="8"/></w:num>
+               </w:numbering>"#
+        );
+        let m = NumberingMap::parse(&xml, &media);
+        let lvl = m.get_level(3, 0).expect("level 0");
+        let pb = lvl.pic_bullet.as_ref().expect("picture bullet resolved");
+        assert_eq!(pb.image_path, "word/media/image1.gif");
+        assert_eq!(pb.mime_type, "image/gif");
+        assert!((pb.width_pt - 9.0).abs() < 1e-6);
+        assert!((pb.height_pt - 9.0).abs() < 1e-6);
+    }
+
+    /// An unresolvable `r:id` (no matching rel) yields no picture bullet — the
+    /// level falls back to its ordinary text marker.
+    #[test]
+    fn picture_bullet_missing_rel_falls_back() {
+        const R: &str =
+            "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"";
+        const V: &str = "xmlns:v=\"urn:schemas-microsoft-com:vml\"";
+        let xml = format!(
+            r#"<w:numbering {W} {R} {V}>
+                 <w:numPicBullet w:numPicBulletId="0">
+                   <w:pict><v:shape style="width:9pt;height:9pt">
+                     <v:imagedata r:id="rIdX"/>
+                   </v:shape></w:pict>
+                 </w:numPicBullet>
+                 <w:abstractNum w:abstractNumId="8">
+                   <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="o"/>
+                     <w:lvlPicBulletId w:val="0"/></w:lvl>
+                 </w:abstractNum>
+                 <w:num w:numId="3"><w:abstractNumId w:val="8"/></w:num>
+               </w:numbering>"#
+        );
+        let m = NumberingMap::parse(&xml, &HashMap::new());
+        assert!(m.get_level(3, 0).unwrap().pic_bullet.is_none());
     }
 
     /// §17.9.11 — a subsection list (`%1.%2`) whose level 0 is never advanced

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -57,8 +57,28 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             }
         })
         .unwrap_or_else(|| "word/numbering.xml".to_string());
+    // The numbering part has its OWN relationships (`<part>.xml.rels`), needed to
+    // resolve `<w:numPicBullet>` image r:ids (§17.9.26). Resolve them the same
+    // way headers/footers do their per-part media (parse_rels + load_media_map),
+    // derived from the numbering part's stem so a non-default numbering target
+    // (e.g. "numbering2.xml") still finds its sibling rels.
+    let numbering_media_map = {
+        let stem = numbering_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(&numbering_path)
+            .trim_end_matches(".xml");
+        let dir = numbering_path
+            .rsplit_once('/')
+            .map(|(d, _)| d)
+            .unwrap_or("word");
+        let rels_path = format!("{}/_rels/{}.xml.rels", dir, stem);
+        let rels_xml = read_zip_entry(&mut zip, &rels_path).unwrap_or_default();
+        let rel_map = parse_rels(&rels_xml);
+        load_media_map(&mut zip, &rel_map, &format!("{}/", dir))
+    };
     let mut num_map = read_zip_entry(&mut zip, &numbering_path)
-        .map(|s| NumberingMap::parse(&s))
+        .map(|s| NumberingMap::parse(&s, &numbering_media_map))
         .unwrap_or_default();
 
     // Theme is referenced by a relationship with Type ending in "/theme" — resolve
@@ -1351,7 +1371,7 @@ fn parse_paragraph_cond(
             // theme refs. A bare `<w:rFonts w:hint="eastAsia"/>` carries no
             // typeface, so the marker simply inherits the paragraph's ascii (e.g.
             // Times → the auto-number renders serif) and eastAsia (e.g. MS Gothic).
-            let (format, ind_left, tab, suff, marker_ascii, marker_ea) = num_map
+            let (format, ind_left, tab, suff, marker_ascii, marker_ea, pic_bullet) = num_map
                 .get_level(num_id, num_level)
                 .map(|l| {
                     let mut marker_fmt = base_run.clone();
@@ -1363,6 +1383,7 @@ fn parse_paragraph_cond(
                         l.suff.clone(),
                         theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
                         theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
+                        l.pic_bullet.clone(),
                     )
                 })
                 .unwrap_or_else(|| {
@@ -1373,10 +1394,25 @@ fn parse_paragraph_cond(
                         "tab".to_string(),
                         theme.resolve_font_ref(base_run.font_family_ascii.clone()),
                         theme.resolve_font_ref(base_run.font_family_east_asia.clone()),
+                        None,
                     )
                 });
             let counter = num_map.advance(num_id, num_level);
             let text = num_map.resolve_text(num_id, num_level, counter);
+            let (
+                pic_bullet_image_path,
+                pic_bullet_mime_type,
+                pic_bullet_width_pt,
+                pic_bullet_height_pt,
+            ) = match pic_bullet {
+                Some(pb) => (
+                    Some(pb.image_path),
+                    Some(pb.mime_type),
+                    Some(pb.width_pt),
+                    Some(pb.height_pt),
+                ),
+                None => (None, None, None, None),
+            };
             Some(Box::new(NumberingInfo {
                 num_id,
                 level: num_level,
@@ -1387,6 +1423,10 @@ fn parse_paragraph_cond(
                 suff,
                 font_family: marker_ascii,
                 font_family_east_asia: marker_ea,
+                pic_bullet_image_path,
+                pic_bullet_mime_type,
+                pic_bullet_width_pt,
+                pic_bullet_height_pt,
             }))
         } else {
             None
@@ -6808,7 +6848,7 @@ mod numbering_marker_font_tests {
             .find(|n| n.tag_name().name() == "body")
             .unwrap();
         let style_map = StyleMap::parse(&styles_xml());
-        let mut num_map = NumberingMap::parse(&numbering_xml());
+        let mut num_map = NumberingMap::parse(&numbering_xml(), &std::collections::HashMap::new());
         let elems = parse_body_elements(
             body,
             &style_map,

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -506,6 +506,20 @@ pub struct NumberingInfo {
     /// bullet) with this family. `None` ⇒ renderer falls back to `font_family`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub font_family_east_asia: Option<String>,
+    /// ECMA-376 §17.9.9/§17.9.20 — when the level uses a `<w:lvlPicBulletId>`,
+    /// the marker is this image (zip path, e.g. `word/media/image1.gif`) drawn in
+    /// place of `text`. `None` ⇒ ordinary text/glyph marker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pic_bullet_image_path: Option<String>,
+    /// MIME type of {@link pic_bullet_image_path} (e.g. `image/gif`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pic_bullet_mime_type: Option<String>,
+    /// Picture-bullet marker width in pt (from the `<v:shape style="width">`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pic_bullet_width_pt: Option<f64>,
+    /// Picture-bullet marker height in pt (from the `<v:shape style="height">`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pic_bullet_height_pt: Option<f64>,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -363,6 +363,21 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
       existing.heightPt = Math.max(existing.heightPt, pair.heightPt);
     }
   };
+  // ECMA-376 §17.9.9/§17.9.20 — a level's picture-bullet marker is an image
+  // that lives on the paragraph's numbering, not in any run. Feed it into the
+  // same decode pipeline (keyed by its zip path) so the marker draw site finds
+  // a decoded bitmap.
+  const recordPara = (para: DocParagraph) => {
+    const pb = para.numbering?.picBulletImagePath;
+    if (pb) {
+      record({
+        imagePath: pb,
+        mimeType: para.numbering!.picBulletMimeType ?? '',
+        widthPt: para.numbering!.picBulletWidthPt ?? 0,
+        heightPt: para.numbering!.picBulletHeightPt ?? 0,
+      });
+    }
+  };
   const walk = (runs: DocRun[]) => {
     for (const run of runs) {
       if (run.type === 'image') {
@@ -398,13 +413,20 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
     for (const row of tbl.rows)
       for (const cell of row.cells)
         for (const ce of cell.content) {
-          if (ce.type === 'paragraph') walk((ce as unknown as DocParagraph).runs);
-          else if (ce.type === 'table') walkTable(ce as unknown as DocTable);
+          if (ce.type === 'paragraph') {
+            const p = ce as unknown as DocParagraph;
+            recordPara(p);
+            walk(p.runs);
+          } else if (ce.type === 'table') walkTable(ce as unknown as DocTable);
         }
   };
   const walkBody = (body: BodyElement[]) => {
     for (const el of body) {
-      if (el.type === 'paragraph') walk((el as unknown as DocParagraph).runs);
+      if (el.type === 'paragraph') {
+        const p = el as unknown as DocParagraph;
+        recordPara(p);
+        walk(p.runs);
+      }
       if (el.type === 'table') walkTable(el as unknown as DocTable);
     }
   };
@@ -2940,10 +2962,14 @@ function renderParagraph(
   const indRight = inFrame ? 0 : (baseRtl ? para.indentLeft : para.indentRight) * scale;
   const indFirst = inFrame ? 0 : para.indentFirst * scale;
 
-  // Numbering marker. `numMarker` doubles as the "this paragraph has a marker"
-  // flag (truthiness); the marker glyph itself is drawn from para.numbering.text.
+  // Numbering marker. `hasMarker` is the "this paragraph has a marker" flag;
+  // it is true for a text/glyph marker (`numMarker`) AND for a §17.9.9 picture
+  // bullet (whose lvlText is typically empty — `numMarker` would be falsy).
   let numMarker = '';
   let numTab = 0;
+  // §17.9.9/§17.9.20 — when the level uses a picture bullet, this holds its
+  // decoded bitmap + draw size (px); the marker is drawn as an image, not text.
+  let picBullet: { bmp: DecodedImage; w: number; h: number } | null = null;
   // First-line body offset (px) from paraX for an LTR numbered paragraph, set by
   // the §17.9.28 `<w:suff>` that follows the marker:
   //   tab (default) → body advances to the indentLeft tab stop (offset 0),
@@ -2953,17 +2979,34 @@ function renderParagraph(
     numMarker = para.numbering.text;
     numTab = para.numbering.tab * scale;
     const suff = para.numbering.suff || 'tab';
+    const pbPath = para.numbering.picBulletImagePath;
+    if (pbPath) {
+      const bmp = state.images.get(imageKey(pbPath));
+      if (bmp) {
+        const w = (para.numbering.picBulletWidthPt ?? 9) * scale;
+        const h = (para.numbering.picBulletHeightPt ?? 9) * scale;
+        picBullet = { bmp, w, h };
+      }
+    }
     if (suff !== 'tab') {
-      // Measure with the marker's RESOLVED font (§17.3.2.26 + §17.9.6), not a
-      // hardcoded generic — the width must match the draw below so the body
-      // offset is exact for a serif (Times) vs sans (Gothic) marker alike.
-      ctx.font = buildFont(false, false, getDefaultFontSize(para) * scale, markerFontFamily(para.numbering), fontFamilyClasses);
-      const markerW = ctx.measureText(markerDisplayText(para.numbering)).width;
+      // Body-offset width: the picture bullet's own width if present, else the
+      // measured glyph width (§17.3.2.26 + §17.9.6) with the marker's RESOLVED
+      // font — the width must match the draw below so the body offset is exact
+      // for a serif (Times) vs sans (Gothic) marker alike.
+      let markerW: number;
+      if (picBullet) {
+        markerW = picBullet.w;
+      } else {
+        ctx.font = buildFont(false, false, getDefaultFontSize(para) * scale, markerFontFamily(para.numbering), fontFamilyClasses);
+        markerW = ctx.measureText(markerDisplayText(para.numbering)).width;
+      }
       const spaceW = suff === 'space' ? ctx.measureText(' ').width : 0;
       // marker sits at firstLineX (= paraX + indFirst); body starts at its end.
       numBodyOffset = indFirst + markerW + spaceW;
     }
   }
+  // True when the paragraph has any marker to draw (text glyph OR picture bullet).
+  const hasMarker = numMarker !== '' || picBullet !== null;
 
   const paraX = contentX + indLeft;
   const firstLineX = paraX + indFirst;
@@ -3033,7 +3076,7 @@ function renderParagraph(
   // (numBodyOffset, computed above). Non-numbered paragraphs apply the first-line
   // indent (positive firstLine, or a bare negative hanging without a marker) to
   // the body as usual. RTL lists keep their existing start-edge handling.
-  const firstLineIndent = numMarker && !baseRtl ? numBodyOffset : firstLineX - paraX;
+  const firstLineIndent = hasMarker && !baseRtl ? numBodyOffset : firstLineX - paraX;
   const lines = layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, gridCharDeltaPx(grid, scale));
 
   // A paragraph whose only segments are wrap-float anchors (wp:anchor) places no
@@ -3146,7 +3189,7 @@ function renderParagraph(
     // (the indentLeft tab stop for suff=tab → offset 0; the marker end for
     // space/nothing); indFirst only pulls the marker into the hanging margin
     // (drawn below). Non-numbered first lines apply indFirst to the body directly.
-    let x = firstLine && !baseRtl ? (numMarker ? lineLeft + numBodyOffset : lineLeft + indFirst) : lineLeft;
+    let x = firstLine && !baseRtl ? (hasMarker ? lineLeft + numBodyOffset : lineLeft + indFirst) : lineLeft;
     const effAvailW = baseRtl && firstLine ? lineAvailW - indFirst : lineAvailW;
 
     // Visual draw order. Under bidi we reorder the line's segments per UAX#9
@@ -3197,35 +3240,49 @@ function renderParagraph(
     // 'left' and stretched 'justify' keep alignOffset 0.
     x += alignOffset;
 
-    if (firstLine && numMarker && !dryRun) {
-      const numFontSize = getDefaultFontSize(para) * scale;
-      // Draw the marker with its RESOLVED font (§17.3.2.26 + §17.9.6): the
-      // ascii axis for a Latin number (a decimal "1" → Times → serif), the
-      // eastAsia axis for a CJK marker. Replaces the old hardcoded sans-serif,
-      // which forced every number/bullet sans regardless of the heading's font.
-      ctx.font = buildFont(false, false, numFontSize, markerFontFamily(para.numbering!), fontFamilyClasses);
-      ctx.fillStyle = defaultColor;
-      if (baseRtl) {
-        // The RTL list marker is laid out INLINE at the line's start (right)
-        // edge: its right edge sits numTab (w:hanging) to the right of the
-        // text's start edge, mirroring the LTR `firstLineX - numTab` anchor,
-        // and it follows the text through jc alignment (sample-8 PDF ground
-        // truth: marker right edge = aligned text right edge + hanging).
-        const prevAlign = ctx.textAlign;
-        const prevDir = ctx.direction;
-        ctx.textAlign = 'left';
-        ctx.direction = 'rtl';
-        const markerText = markerDisplayText(para.numbering!);
-        const markerW = ctx.measureText(markerText).width;
-        ctx.fillText(markerText, x + lineWidth + numTab - markerW, baseline);
-        ctx.textAlign = prevAlign;
-        ctx.direction = prevDir;
+    if (firstLine && hasMarker && !dryRun) {
+      if (picBullet) {
+        // §17.9.9/§17.9.20 — the marker is an image. It occupies the same
+        // anchor a text marker would (LTR: left edge in the hanging margin;
+        // RTL: right edge numTab past the start edge), and rides the line's jc
+        // alignment via `x`/`lineWidth` exactly like the glyph marker below.
+        // Vertically it bottom-aligns to the baseline (the inline-image
+        // convention, §17.3.3 anchored to the text bottom) so a sub-em bullet
+        // rests on the line like a glyph.
+        const { bmp, w, h } = picBullet;
+        const top = baseline - h;
+        const left = baseRtl ? x + lineWidth + numTab - w : lineLeft + indFirst;
+        ctx.drawImage(bmp, left, top, w, h);
       } else {
-        // Marker sits in the hanging margin at lineLeft + indFirst (= firstLineX
-        // when the line isn't shifted by a float; lineLeft already includes any
-        // float xOffset, so the marker tracks the body that hangs off it). The
-        // body was advanced past the marker above (numBodyOffset).
-        ctx.fillText(markerDisplayText(para.numbering!), lineLeft + indFirst, baseline);
+        const numFontSize = getDefaultFontSize(para) * scale;
+        // Draw the marker with its RESOLVED font (§17.3.2.26 + §17.9.6): the
+        // ascii axis for a Latin number (a decimal "1" → Times → serif), the
+        // eastAsia axis for a CJK marker. Replaces the old hardcoded sans-serif,
+        // which forced every number/bullet sans regardless of the heading's font.
+        ctx.font = buildFont(false, false, numFontSize, markerFontFamily(para.numbering!), fontFamilyClasses);
+        ctx.fillStyle = defaultColor;
+        if (baseRtl) {
+          // The RTL list marker is laid out INLINE at the line's start (right)
+          // edge: its right edge sits numTab (w:hanging) to the right of the
+          // text's start edge, mirroring the LTR `firstLineX - numTab` anchor,
+          // and it follows the text through jc alignment (sample-8 PDF ground
+          // truth: marker right edge = aligned text right edge + hanging).
+          const prevAlign = ctx.textAlign;
+          const prevDir = ctx.direction;
+          ctx.textAlign = 'left';
+          ctx.direction = 'rtl';
+          const markerText = markerDisplayText(para.numbering!);
+          const markerW = ctx.measureText(markerText).width;
+          ctx.fillText(markerText, x + lineWidth + numTab - markerW, baseline);
+          ctx.textAlign = prevAlign;
+          ctx.direction = prevDir;
+        } else {
+          // Marker sits in the hanging margin at lineLeft + indFirst (= firstLineX
+          // when the line isn't shifted by a float; lineLeft already includes any
+          // float xOffset, so the marker tracks the body that hangs off it). The
+          // body was advanced past the marker above (numBodyOffset).
+          ctx.fillText(markerDisplayText(para.numbering!), lineLeft + indFirst, baseline);
+        }
       }
     }
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -392,6 +392,16 @@ export interface NumberingInfo {
    *  this family. Absent ⇒ the renderer falls back to
    *  {@link NumberingInfo.fontFamily}. */
   fontFamilyEastAsia?: string | null;
+  /** ECMA-376 §17.9.9/§17.9.20 — when the level uses a `<w:lvlPicBulletId>`,
+   *  the marker is this image (zip path, e.g. `word/media/image1.gif`), drawn in
+   *  place of {@link NumberingInfo.text}. Absent ⇒ ordinary text/glyph marker. */
+  picBulletImagePath?: string;
+  /** MIME type of {@link NumberingInfo.picBulletImagePath} (e.g. `image/gif`). */
+  picBulletMimeType?: string;
+  /** Picture-bullet marker width in pt (from the `<v:shape style="width">`). */
+  picBulletWidthPt?: number;
+  /** Picture-bullet marker height in pt (from the `<v:shape style="height">`). */
+  picBulletHeightPt?: number;
 }
 
 export type DocRun =


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 8 — "This bullet uses an image as the bullet item" lost its blue image bullet; `<w:numPicBullet>` / `<w:lvlPicBulletId>` were unimplemented.

- **Parser**: `NumberingMap::parse` now takes the numbering part's own media map (resolved from `word/_rels/numbering.xml.rels`, mirroring the per-part rels handling for headers/footers — the bullet `rId` lives there, not in `document.xml.rels`). Collects `<w:numPicBullet>` (VML `<v:imagedata r:id>` → media path, size from `<v:shape style>`) and resolves each level's `<w:lvlPicBulletId>`. The resolved image path + size surface on `NumberingInfo`.
- **Renderer**: `collectImagePairs` preloads the bullet bitmap; the marker draw site paints the image (bottom-aligned to the baseline, hanging margin for LTR / mirrored for RTL) when a level has a picture bullet, else the existing glyph path. A `hasMarker` flag (picture-bullet `lvlText` is empty) drives the indent math.

## Verification
- Rust fmt/clippy clean, **99 cargo tests** (2 new: resolution + missing-rel fallback); WASM rebuilt.
- TS typecheck clean.
- **VRT 21/21 pass** (VRT covers no numbering, so verified visually).
- Visual: page 8 — blue image bullet renders at the row head, matching the Word PDF. The standard 9pt default shape size (Word's) is documented, not a fit-to-sample constant.

sample-11 verified structure: `numPicBulletId=0` → `rId1` → `media/image1.gif` (9pt), referenced by abstractNum 8 ilvl 2.

Part of the sample-11 fidelity series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)