### PR TITLE
fix(docx): trHeight hRule="auto" is content-driven, not a floor (§17.4.80)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1918,7 +1918,15 @@ function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt:
       rowHs.push(row.rowHeight);
       continue;
     }
-    let rowH = row.rowHeight != null ? row.rowHeight : 10;
+    // ECMA-376 §17.4.80 / §17.18.37 (ST_HeightRule):
+    //   auto (default)  — height is content-driven; the trHeight val is ignored
+    //                     ("with no predetermined minimum or maximum size"). val
+    //                     is only an advisory layout cache Word may emit.
+    //   atLeast         — val is a lower bound the content can exceed.
+    // So only atLeast uses val as a floor; auto falls back to the minimum row
+    // height (10pt) like a row with no trHeight at all.
+    let rowH =
+      row.rowHeight != null && row.rowHeightRule === 'atLeast' ? row.rowHeight : 10;
     let ci = 0;
     for (const cell of row.cells) {
       const span = Math.min(cell.colSpan, colWidths.length - ci);
@@ -6015,26 +6023,28 @@ function renderTable(table: DocTable, state: RenderState): void {
   state.y = y;
 }
 
-function calculateRowHeight(
+export function calculateRowHeight(
   row: DocTableRow,
   table: DocTable,
   colWidths: number[],
   scale: number,
   state: RenderState,
 ): number {
-  // ECMA-376 §17.4.80:
-  //   exact   — honor w:trHeight verbatim, clip overflow.
-  //   atLeast / auto (default) — w:trHeight is a lower bound that content
-  //                               can exceed. In practice Word treats the
-  //                               default `auto` like `atLeast` when a value
-  //                               is present: it preserves the saved layout
-  //                               height even though the spec text describes
-  //                               auto as content-driven. Resume / cover
-  //                               templates rely on this — their row heights
-  //                               (trHeight=1872, 2448, 1152 …) shape the
-  //                               whole page composition.
+  // ECMA-376 §17.4.80 / §17.18.37 (ST_HeightRule):
+  //   exact   — height is exactly w:trHeight/@val; overflow is clipped.
+  //   atLeast — w:trHeight/@val is a lower bound; content can expand the row.
+  //   auto    — height is determined entirely by the content; the @val is
+  //             ignored ("with no predetermined minimum or maximum size").
+  //             @val on an auto row is only an advisory layout cache Word may
+  //             write back, never a floor. (auto is also the default when
+  //             @hRule is omitted.)
+  // Only atLeast contributes a val-derived floor; auto and the no-trHeight case
+  // fall back to the minimum row height.
   if (row.rowHeight != null && row.rowHeightRule === 'exact') return row.rowHeight * scale;
-  const minH = row.rowHeight != null ? row.rowHeight * scale : 10 * scale;
+  const minH =
+    row.rowHeight != null && row.rowHeightRule === 'atLeast'
+      ? row.rowHeight * scale
+      : 10 * scale;
 
   let maxH = minH;
   let ci = 0;

--- a/packages/docx/src/table-row-height.test.ts
+++ b/packages/docx/src/table-row-height.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRowHeight } from './renderer.js';
+import type { DocTable, DocTableRow, DocTableCell } from './types.js';
+
+// ECMA-376 §17.4.80 (trHeight) + §17.18.37 (ST_HeightRule): the @hRule attribute
+// decides how w:trHeight/@val constrains the row height.
+//   exact   — height is exactly @val (overflow clipped).
+//   atLeast — @val is a lower bound; content can expand the row.
+//   auto    — height is content-driven; @val is IGNORED ("with no predetermined
+//             minimum or maximum size"). It is only an advisory layout cache.
+//
+// These tests pin the floor logic with empty cells: with no content, the cell's
+// content height is just its (here zero) margins, so the row height is governed
+// entirely by the trHeight rule. calculateRowHeight only measures cell content
+// when a cell carries any (measureCellElementHeight), so empty cells let us
+// exercise the rule branch without a real measuring context — the `state` is
+// never dereferenced for empty cells.
+
+const EMPTY_STATE = {} as unknown as Parameters<typeof calculateRowHeight>[4];
+
+function emptyCell(): DocTableCell {
+  return {
+    content: [],
+    colSpan: 1,
+    vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null },
+    background: null,
+    vAlign: 'top',
+    widthPt: null,
+  } as unknown as DocTableCell;
+}
+
+function rowWith(rowHeight: number | null, rule: string): DocTableRow {
+  return {
+    cells: [emptyCell()],
+    rowHeight,
+    rowHeightRule: rule,
+    isHeader: false,
+  } as unknown as DocTableRow;
+}
+
+function table(): DocTable {
+  return {
+    colWidths: [100],
+    rows: [],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+  } as unknown as DocTable;
+}
+
+describe('calculateRowHeight — ST_HeightRule (§17.4.80 / §17.18.37)', () => {
+  const COLS = [100];
+  const SCALE = 2; // px == 2 * pt, to confirm scale is applied
+  const t = table();
+
+  it('exact — height is exactly @val regardless of (here empty) content', () => {
+    const h = calculateRowHeight(rowWith(600, 'exact'), t, COLS, SCALE, EMPTY_STATE);
+    expect(h).toBe(600 * SCALE);
+  });
+
+  it('atLeast — @val is a lower bound; empty content cannot shrink below it', () => {
+    const h = calculateRowHeight(rowWith(600, 'atLeast'), t, COLS, SCALE, EMPTY_STATE);
+    expect(h).toBe(600 * SCALE);
+  });
+
+  it('auto — @val is IGNORED; height collapses to the content (empty ⇒ minimum)', () => {
+    // The advisory cached val (600) must NOT act as a floor under auto. With no
+    // content the row falls back to the 10pt minimum, not 600pt.
+    const h = calculateRowHeight(rowWith(600, 'auto'), t, COLS, SCALE, EMPTY_STATE);
+    expect(h).toBe(10 * SCALE);
+    expect(h).not.toBe(600 * SCALE);
+  });
+
+  it('auto with no trHeight — same as auto with a cached val (content-driven)', () => {
+    const h = calculateRowHeight(rowWith(null, 'auto'), t, COLS, SCALE, EMPTY_STATE);
+    expect(h).toBe(10 * SCALE);
+  });
+
+  it('atLeast with no @val — falls back to the minimum (val null ⇒ no floor)', () => {
+    const h = calculateRowHeight(rowWith(null, 'atLeast'), t, COLS, SCALE, EMPTY_STATE);
+    expect(h).toBe(10 * SCALE);
+  });
+});


### PR DESCRIPTION
## Summary
calibre `sample-11.docx` page 4 — the outer 2×2 nested table rows rendered too tall (~54pt from `trHeight val="1079"`) instead of the content-tight ~34pt Word shows. The renderer used `val` as a lower bound even for `hRule="auto"`.

Per ECMA-376 §17.4.80 (`trHeight`) / §17.18.37 (`ST_HeightRule`): **`auto`** (the default) sizes the row from its content with no predetermined minimum — the cached `val` is advisory only. `atLeast` = floor; `exact` = clip.

Both paths fixed: `computeTableRowHeights` (pagination) and `calculateRowHeight` (draw) now floor on `val` only for `atLeast`; `exact` still clips; **`auto` ignores `val` and is content-driven**. The prior "Word preserves saved layout height" heuristic comment is replaced with the spec-accurate one.

## Verification
- TS typecheck clean; 169 unit tests (5 new `table-row-height.test.ts`: exact/atLeast/auto/auto-no-val/atLeast-no-val).
- **VRT 21/21 pass, no regression** — no covered sample inflated an empty row via `auto`+`val`, so the change moves purely toward the Word PDF ground truth.
- Visual: page 4 — outer nested-table rows collapse to content height, matching the Word PDF.

Part of the sample-11 fidelity series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)