### PR TITLE
fix(docx): TOC entry bold/italic — webHidden≠vanish & paragraph-mark rPr (§17.3.1.29/.2.44)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1328,17 +1328,31 @@ fn parse_paragraph_cond(
         .and_then(|s| attr_w(s, "val"));
 
     // Resolve base formatting from style (incl. table-style conditional rPr/pPr).
-    let (mut base_para, mut base_run) =
+    let (mut base_para, base_run) =
         style_map.resolve_para_cond(explicit_style_id.as_deref(), table_style_id, cond);
 
-    // Apply direct paragraph formatting overrides
+    // Apply direct paragraph formatting overrides.
+    //
+    // ECMA-376 §17.3.1.29: a paragraph's *direct* `pPr/rPr` is the run formatting
+    // of the PARAGRAPH MARK GLYPH only ("there is no run saved for the paragraph
+    // mark itself"). It is NOT a run default for the paragraph's content — content
+    // runs inherit their formatting from the paragraph style's rPr (§17.7.2), the
+    // character style, and their own direct rPr. So we must NOT fold the direct
+    // pPr/rPr into the content-inheritance `base_run`: doing so let a TOC entry's
+    // paragraph-mark `<w:b w:val="0"/>` / `<w:i w:val="0"/>` strip the TOC1/TOC2
+    // style's bold/italic from the visible entry text, dot leader and page number
+    // (sample-11 p6 ToC, reports #5/#6).
+    //
+    // The mark rPr still matters for an EMPTY paragraph, whose height comes from
+    // the mark glyph. We keep it in a separate `mark_run` used only for the
+    // `default_font_*` (empty-paragraph) metrics below.
+    let mut mark_run = base_run.clone();
     if let Some(ppr) = ppr_node {
         let direct = parse_para_fmt(ppr);
         apply_direct_para(&mut base_para, &direct);
-        // Also merge direct rPr
         if let Some(rpr) = child_w(ppr, "rPr") {
             let direct_run = parse_run_fmt(rpr);
-            apply_direct_run(&mut base_run, &direct_run);
+            apply_direct_run(&mut mark_run, &direct_run);
         }
     }
 
@@ -1516,13 +1530,16 @@ fn parse_paragraph_cond(
             .clone()
             .or_else(|| style_map.default_para_style_id().map(str::to_string))
             .or_else(|| Some("Normal".to_string())),
-        default_font_size: base_run.font_size,
+        // Empty-paragraph metrics come from the paragraph-mark glyph, whose
+        // formatting is the direct `pPr/rPr` (§17.3.1.29) layered over the style
+        // chain — i.e. `mark_run`, not the content `base_run`.
+        default_font_size: mark_run.font_size,
         // Resolve the paragraph's default font the same way runs do (ascii
         // first, then eastAsia, through theme refs) so empty paragraphs can be
         // sized with the intended font's line metrics.
         default_font_family: theme
-            .resolve_font_ref(base_run.font_family_ascii.clone())
-            .or_else(|| theme.resolve_font_ref(base_run.font_family_east_asia.clone())),
+            .resolve_font_ref(mark_run.font_family_ascii.clone())
+            .or_else(|| theme.resolve_font_ref(mark_run.font_family_east_asia.clone())),
         outline_level: base_para.outline_level,
         // ECMA-376 §17.3.1.6 — RTL paragraph flag resolved through the style
         // chain + direct pPr. The renderer reads it as the paragraph base
@@ -4684,6 +4701,9 @@ fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
     if direct.vanish.is_some() {
         base.vanish = direct.vanish;
     }
+    if direct.web_hidden.is_some() {
+        base.web_hidden = direct.web_hidden;
+    }
     if direct.highlight.is_some() {
         base.highlight = direct.highlight.clone();
     }
@@ -5114,6 +5134,127 @@ mod math_jc_tests {
                <m:oMath><m:r><m:t>α</m:t></m:r></m:oMath></m:oMathPara>"#,
         );
         assert_eq!(p.alignment, "left");
+    }
+}
+
+#[cfg(test)]
+mod para_mark_rpr_tests {
+    use super::*;
+    use crate::xml_util::W_NS;
+
+    /// Style map with a paragraph style `Bolded` (basedOn Normal) whose direct
+    /// `<w:rPr>` turns bold on, and `Italicized` whose `<w:rPr>` turns italic on
+    /// — mirroring sample-11's TOC1/TOC2.
+    fn style_map() -> StyleMap {
+        let xml = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal">
+                <w:name w:val="Normal"/>
+              </w:style>
+              <w:style w:type="paragraph" w:styleId="Bolded">
+                <w:name w:val="Bolded"/><w:basedOn w:val="Normal"/>
+                <w:rPr><w:b/></w:rPr>
+              </w:style>
+              <w:style w:type="paragraph" w:styleId="Italicized">
+                <w:name w:val="Italicized"/><w:basedOn w:val="Normal"/>
+                <w:rPr><w:i/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        StyleMap::parse(&xml)
+    }
+
+    fn parse_p(inner: &str, sm: &StyleMap) -> DocParagraph {
+        let xml = format!(r#"<w:p xmlns:w="{w}">{inner}</w:p>"#, w = W_NS);
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let mut num_map = NumberingMap::default();
+        let media: HashMap<String, String> = HashMap::new();
+        let rels: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+        parse_paragraph(
+            doc.root_element(),
+            sm,
+            &mut num_map,
+            &media,
+            &rels,
+            &theme,
+            None,
+        )
+    }
+
+    fn first_text(p: &DocParagraph) -> &TextRun {
+        p.runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Text(t) => Some(t.as_ref()),
+                _ => None,
+            })
+            .expect("a text run")
+    }
+
+    // ECMA-376 §17.3.1.29 + §17.7.2: a paragraph's *direct* `pPr/rPr` formats the
+    // PARAGRAPH MARK GLYPH only — it is NOT a run default for content. A content
+    // run with no own bold toggle must inherit the paragraph style's `<w:b/>`,
+    // even though the paragraph-mark rPr explicitly turns bold OFF. (sample-11 p6
+    // TOC1 report #5: the entry text/leader/page number stay bold.)
+    #[test]
+    fn para_mark_bold_off_does_not_strip_style_bold_from_content() {
+        let sm = style_map();
+        let p = parse_p(
+            r#"<w:pPr><w:pStyle w:val="Bolded"/><w:rPr><w:b w:val="0"/></w:rPr></w:pPr>
+               <w:r><w:t>entry</w:t></w:r>"#,
+            &sm,
+        );
+        assert!(first_text(&p).bold, "content inherits TOC-style bold");
+    }
+
+    // §17.3.1.29 + §17.7.2: same for italic (sample-11 p6 TOC2 report #6).
+    #[test]
+    fn para_mark_italic_off_does_not_strip_style_italic_from_content() {
+        let sm = style_map();
+        let p = parse_p(
+            r#"<w:pPr><w:pStyle w:val="Italicized"/><w:rPr><w:i w:val="0"/></w:rPr></w:pPr>
+               <w:r><w:t>entry</w:t></w:r>"#,
+            &sm,
+        );
+        assert!(first_text(&p).italic, "content inherits TOC-style italic");
+    }
+
+    // §17.3.2.30 — a content run that DIRECTLY sets a toggle still wins; the
+    // paragraph-mark change is irrelevant either way. Guards against a fix that
+    // would instead ignore direct run rPr.
+    #[test]
+    fn direct_run_bold_off_still_wins_over_style() {
+        let sm = style_map();
+        let p = parse_p(
+            r#"<w:pPr><w:pStyle w:val="Bolded"/></w:pPr>
+               <w:r><w:rPr><w:b w:val="0"/></w:rPr><w:t>entry</w:t></w:r>"#,
+            &sm,
+        );
+        assert!(
+            !first_text(&p).bold,
+            "a direct run b=0 overrides the paragraph style bold"
+        );
+    }
+
+    // §17.3.2.44 — a webHidden run (TOC page numbers, dot-leader tabs) renders in
+    // the normal/print view. It must NOT be dropped as if it were §17.3.2.41
+    // vanish. Here the page-number-like run survives parsing.
+    #[test]
+    fn web_hidden_run_survives_in_print_layout() {
+        let sm = style_map();
+        let p = parse_p(
+            r#"<w:pPr><w:pStyle w:val="Bolded"/></w:pPr>
+               <w:r><w:rPr><w:webHidden/></w:rPr><w:t>7</w:t></w:r>"#,
+            &sm,
+        );
+        let t = first_text(&p);
+        assert_eq!(t.text, "7");
+        assert!(
+            t.bold,
+            "the webHidden page number still inherits style bold"
+        );
     }
 }
 

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -31,8 +31,16 @@ pub struct RunFmt {
     pub small_caps: Option<bool>,
     /// Double strikethrough (w:dstrike)
     pub dstrike: Option<bool>,
-    /// Hidden text — run should not be rendered (w:vanish / w:webHidden)
+    /// ECMA-376 §17.3.2.41 w:vanish — "Hidden Text". Hidden in the normal
+    /// (print/page) view this renderer produces, so the parser skips the run.
+    /// This is NOT `webHidden`: vanish hides in all non-web views.
     pub vanish: Option<bool>,
+    /// ECMA-376 §17.3.2.44 w:webHidden — text hidden ONLY when the document is
+    /// shown in *web page view* (§17.18.102). In the normal/print layout we
+    /// render, webHidden text is visible, so it must NOT set `vanish` (doing so
+    /// dropped TOC dot-leader tabs and PAGEREF page numbers, which Word marks
+    /// `<w:webHidden/>`). Preserved here so a future web-view mode can honor it.
+    pub web_hidden: Option<bool>,
     /// Highlight color name: "yellow" | "cyan" | "green" | ... (w:highlight)
     pub highlight: Option<String>,
     /// ECMA-376 §17.3.2.4 `<w:bdr>` — a run-level border drawn as a box around
@@ -594,6 +602,9 @@ fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.vanish.is_some() {
         dst.vanish = src.vanish;
     }
+    if src.web_hidden.is_some() {
+        dst.web_hidden = src.web_hidden;
+    }
     if src.highlight.is_some() {
         dst.highlight = src.highlight.clone();
     }
@@ -1006,8 +1017,13 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // Double strikethrough
     fmt.dstrike = bool_prop(rpr, "dstrike");
 
-    // Hidden text (vanish or webHidden)
-    fmt.vanish = bool_prop(rpr, "vanish").or_else(|| bool_prop(rpr, "webHidden"));
+    // Hidden text. §17.3.2.41 w:vanish hides the run in the normal/print view we
+    // render. §17.3.2.44 w:webHidden hides ONLY in web page view (§17.18.102),
+    // so it is recorded separately and must NOT feed `vanish` — otherwise TOC
+    // dot-leader tabs and PAGEREF page numbers (marked `<w:webHidden/>` by Word)
+    // would be dropped from the rendered page.
+    fmt.vanish = bool_prop(rpr, "vanish");
+    fmt.web_hidden = bool_prop(rpr, "webHidden");
 
     // Highlight
     if let Some(hl) = child_w(rpr, "highlight") {
@@ -1254,6 +1270,72 @@ mod tests {
     fn absent_color_element_stays_none_to_inherit() {
         let fmt = run_fmt_from(r#"<w:b/>"#);
         assert_eq!(fmt.color, None);
+    }
+
+    #[test]
+    fn vanish_hides_run_in_print_layout() {
+        // ECMA-376 §17.3.2.41 w:vanish — "Hidden Text". Hidden in the normal
+        // (print/page) view we render, so it sets the `vanish` flag the parser
+        // uses to skip the run.
+        let fmt = run_fmt_from(r#"<w:vanish/>"#);
+        assert_eq!(fmt.vanish, Some(true));
+        assert_eq!(fmt.web_hidden, None);
+    }
+
+    #[test]
+    fn web_hidden_does_not_vanish_in_print_layout() {
+        // ECMA-376 §17.3.2.44 w:webHidden — text hidden ONLY in *web page view*
+        // (§17.18.102), NOT in the normal/print layout this renderer produces.
+        // Conflating it with §17.3.2.41 w:vanish wrongly dropped TOC page numbers
+        // and dot-leader tab runs (which Word marks `<w:webHidden/>`) from the
+        // rendered page. webHidden must leave `vanish` unset so the run renders;
+        // the flag is preserved separately for a future web-view mode.
+        let fmt = run_fmt_from(r#"<w:webHidden/>"#);
+        assert_eq!(fmt.vanish, None);
+        assert_eq!(fmt.web_hidden, Some(true));
+    }
+
+    /// Minimal styles.xml mirroring sample-11's TOC1 (bold) / TOC2 (italic)
+    /// paragraph styles: both basedOn Normal with the toggle in the style's
+    /// direct `<w:rPr>`.
+    fn toc_style_map() -> StyleMap {
+        let xml = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal">
+                <w:name w:val="Normal"/>
+              </w:style>
+              <w:style w:type="paragraph" w:styleId="TOC1">
+                <w:name w:val="toc 1"/><w:basedOn w:val="Normal"/>
+                <w:rPr><w:b/><w:bCs/><w:sz w:val="20"/></w:rPr>
+              </w:style>
+              <w:style w:type="paragraph" w:styleId="TOC2">
+                <w:name w:val="toc 2"/><w:basedOn w:val="Normal"/>
+                <w:rPr><w:i/><w:iCs/><w:sz w:val="20"/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        StyleMap::parse(&xml)
+    }
+
+    #[test]
+    fn toc1_style_run_base_is_bold() {
+        // ECMA-376 §17.7.4 / §17.7.2: a paragraph style's direct `<w:rPr><w:b/>`
+        // resolves onto the run BASE for every run in a TOC1 paragraph, so the
+        // entry text, dot leader and page number all inherit bold unless a run
+        // overrides it directly. (sample-11 p6 ToC, report #5.)
+        let sm = toc_style_map();
+        let (_para, run) = sm.resolve_para(Some("TOC1"), None);
+        assert_eq!(run.bold, Some(true));
+    }
+
+    #[test]
+    fn toc2_style_run_base_is_italic() {
+        // §17.7.4 / §17.7.2: TOC2's `<w:rPr><w:i/>` resolves onto the run base —
+        // "Inline formatting" etc. inherit italic. (sample-11 p6 ToC, report #6.)
+        let sm = toc_style_map();
+        let (_para, run) = sm.resolve_para(Some("TOC2"), None);
+        assert_eq!(run.italic, Some(true));
     }
 
     // ===== Table style conditional rPr/pPr (§17.7.6 / §17.7.2) =====

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3565,7 +3565,7 @@ function renderParagraph(
       if ('isTab' in seg) {
         // Tabs render as blank space, optionally filled with a leader (TOC dots etc.).
         if (!dryRun && seg.leader && seg.leader !== 'none' && seg.measuredWidth > 1) {
-          drawTabLeader(ctx, seg.leader, x, baseline, seg.measuredWidth, seg.fontSize * scale, defaultColor);
+          drawTabLeader(ctx, seg.leader, x, baseline, seg.measuredWidth, seg.fontSize * scale, defaultColor, seg.bold, seg.italic);
         }
         x += seg.measuredWidth;
         continue;
@@ -3869,6 +3869,11 @@ interface LayoutTabSeg {
   measuredWidth: number;
   /** tab leader to fill the gap (e.g. TOC dot leaders); set during layout. */
   leader?: TabStop['leader'];
+  /** Bold/italic of the run carrying the tab (ECMA-376 §17.3.1.37 — the leader
+   *  characters take the formatting of the tab's run, e.g. a bold TOC1 entry's
+   *  dot leader is bold). Threaded so {@link drawTabLeader} can match the font. */
+  bold?: boolean;
+  italic?: boolean;
 }
 
 interface LayoutImageSeg {
@@ -4104,7 +4109,7 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
       for (let i = 0; i < parts.length; i++) {
         if (parts[i].length > 0) pushTextPiece(parts[i], t, t.vertAlign);
         if (i < parts.length - 1) {
-          segs.push({ isTab: true, fontSize: t.fontSize, measuredWidth: 0 });
+          segs.push({ isTab: true, fontSize: t.fontSize, measuredWidth: 0, bold: t.bold, italic: t.italic });
         }
       }
     } else if (run.type === 'image') {
@@ -4863,6 +4868,8 @@ function drawTabLeader(
   width: number,
   fontPx: number,
   color: string,
+  bold?: boolean,
+  italic?: boolean,
 ): void {
   const ch =
     leader === 'hyphen'
@@ -4873,7 +4880,10 @@ function drawTabLeader(
           ? '·'
           : '.';
   ctx.save();
-  ctx.font = `${fontPx}px serif`;
+  // ECMA-376 §17.3.1.37: the leader fill takes the formatting of the tab's run,
+  // so a bold/italic TOC entry draws a bold/italic dot leader.
+  const style = `${italic ? 'italic ' : ''}${bold ? 'bold ' : ''}`;
+  ctx.font = `${style}${fontPx}px serif`;
   ctx.fillStyle = color;
   const chW = ctx.measureText(ch).width;
   if (chW > 0) {


### PR DESCRIPTION
## What

calibre `sample-11.docx` page 6's table of contents was rendered wrong: TOC1 entries lost their **bold**, TOC2 entries lost their **italic**, and the dot-leader tabs and PAGEREF page numbers were **dropped entirely**. Three spec violations — none specific to TOCs — were behind it.

| # | Bug | Spec |
|---|-----|------|
| A | `webHidden` was treated as `vanish`, so TOC dot-leader tabs and page numbers (which Word marks `<w:webHidden/>`) were skipped | §17.3.2.44 vs §17.3.2.41 / §17.18.102 |
| B | The paragraph's direct `pPr/rPr` was folded into content runs' base formatting; the TOC1/TOC2 mark's `<w:b w:val="0"/>` / `<w:i w:val="0"/>` leaked onto the entry text and stripped the style's bold/italic | §17.3.1.29 (mark glyph only) / §17.7.2 |
| C | The tab leader ignored the run's bold/italic | §17.3.1.37 |

## How

- **A** — parse `w:webHidden` into a separate `web_hidden` field (preserved for a future web-page-view mode); only `w:vanish` skips the run in the print layout.
- **B** — stop folding the direct `pPr/rPr` into the content `base_run`. It now lives in a separate `mark_run` used *only* for empty-paragraph (mark-glyph) `default_font_*` metrics, which stay bit-identical to before. Content runs inherit from the paragraph style rPr per §17.7.2.
- **C** — thread the tab run's `bold`/`italic` through `LayoutTabSeg` into `drawTabLeader`.

No heuristics, no TOC-specific gates — all three are general-rule fixes.

## Verification

- docx VRT **21/21 unchanged** (no regression on covered samples from the global base_run / webHidden changes)
- vitest **169 pass**, `cargo test --lib` **107 pass** (6 new tests: webHidden-survives, vanish-drops, mark-toggle-off doesn't strip style bold/italic, direct run rPr still wins, TOC1/TOC2 base resolves bold/italic)
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -D warnings` clean; root `pnpm typecheck` pass
- Independently reviewed (spec correctness + §17.3.1.29 regression risk): APPROVE, no required changes. Empty-paragraph metrics confirmed preserved; vanish still takes precedence when both flags are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)