### PR TITLE
fix(docx): resolveAnchorY handles ST_AlignV inside/outside (§20.4.3.1)

### DIFF
--- a/packages/docx/src/anchor-align.test.ts
+++ b/packages/docx/src/anchor-align.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAnchorY } from './renderer.js';
+
+// resolveAnchorY reads only { scale, marginTop, marginBottom, pageH } of
+// RenderState (via yContainer); cast a minimal stand-in like the other geometry
+// tests. scale=1 so px == pt. pageH=800, top/bottom margins=72 ⇒ the "margin"
+// container band is [72, 728], the "page" band is [0, 800].
+interface MinState {
+  scale: number;
+  marginTop: number;
+  marginBottom: number;
+  pageH: number;
+}
+const state: MinState = { scale: 1, marginTop: 72, marginBottom: 72, pageH: 800 };
+
+// resolveAnchorY(align, fromPara, offsetPt, heightPx, paragraphTopPx, state, relativeFrom)
+const y = (align: string, relativeFrom: string, h = 100): number =>
+  resolveAnchorY(align, false, 0, h, 0, state as never, relativeFrom);
+
+describe('resolveAnchorY — ST_AlignV inside/outside (ECMA-376 §20.4.3.1)', () => {
+  // The page-binding-relative inside/outside degrade to the top/bottom edge of
+  // the container (odd-page approximation), mirroring resolveAnchorX's
+  // inside→left / outside→right.
+  it('inside aligns to the container top edge (= top)', () => {
+    expect(y('inside', 'page')).toBe(0); // page band top
+    expect(y('inside', 'page')).toBe(y('top', 'page'));
+    expect(y('inside', 'margin')).toBe(72); // margin band top
+    expect(y('inside', 'margin')).toBe(y('top', 'margin'));
+  });
+
+  it('outside aligns to the container bottom edge (= bottom)', () => {
+    expect(y('outside', 'page')).toBe(800 - 100); // page band bottom − height
+    expect(y('outside', 'page')).toBe(y('bottom', 'page'));
+    expect(y('outside', 'margin')).toBe(728 - 100); // margin band bottom − height
+    expect(y('outside', 'margin')).toBe(y('bottom', 'margin'));
+  });
+
+  it('still resolves the explicit top/bottom/center cases', () => {
+    expect(y('top', 'page')).toBe(0);
+    expect(y('bottom', 'page')).toBe(700);
+    expect(y('center', 'page')).toBe((800 - 100) / 2);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5067,7 +5067,7 @@ function resolveAnchorX(
   }
 }
 
-function resolveAnchorY(
+export function resolveAnchorY(
   align: string | null | undefined,
   fromPara: boolean,
   offsetPt: number,
@@ -5091,9 +5091,15 @@ function resolveAnchorY(
   const ah = alignHeightPt != null ? alignHeightPt * scale : heightPx;
   switch (align) {
     case 'center': return c.start + (containerH - ah) / 2 + offsetPx;
-    case 'bottom': return c.end - ah + offsetPx;
+    // ECMA-376 §20.4.3.1 ST_AlignV: "inside"/"outside" are page-binding-
+    // relative. Mirroring resolveAnchorX (and the insideMargin/outsideMargin
+    // approximation in yContainer/xContainer): on an odd page the binding edge
+    // is the top, so inside→top edge and outside→bottom edge.
+    case 'bottom':
+    case 'outside': return c.end - ah + offsetPx;
     case 'top':
-    default:       return c.start + offsetPx;
+    case 'inside':
+    default:        return c.start + offsetPx;
   }
 }
 


### PR DESCRIPTION
## Summary
`resolveAnchorY` (shared by anchored shapes and, since [#515](https://github.com/yukiyokotani/office-open-xml-viewer/pull/515), anchored images via `resolveAnchorBox`) handled vertical `<wp:align>` `center`/`top`/`bottom` but let **`inside`/`outside`** fall through to the `default` case → rendered as `top`. Per ECMA-376 §20.4.3.1 (`ST_AlignV`) the valid values are `top|bottom|center|inside|outside`.

Mirrors the horizontal sibling `resolveAnchorX` (which already maps `inside`→left-edge / `outside`→right-edge with the documented odd/even-page approximation, also used by `yContainer`/`xContainer`'s `insideMargin`/`outsideMargin`): **`inside`→container top edge, `outside`→container bottom edge**. No empirical constants — both reuse the existing container-edge arithmetic.

## Verification
- New `anchor-align.test.ts` (3 tests): `inside`→top edge (= `top`), `outside`→bottom edge (= `bottom`), for both the `page` and `margin` containers; plus the existing top/bottom/center cases as a guard. `resolveAnchorY` is exported for the test (consistent with the other geometry helpers).
- TS typecheck clean.
- **VRT 21/21 pass** — purely additive (only the previously-`default` `inside`/`outside` values change; no sample uses vertical inside/outside).

Follow-up from the [#515](https://github.com/yukiyokotani/office-open-xml-viewer/pull/515) review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)