### PR TITLE
fix(docx): page-3 table fidelity — float anchor, conditional borders, double line

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4476,6 +4476,12 @@ fn parse_table(
             .map(|v| twips_to_pt(&v))
             .unwrap_or(0.0),
         horz_anchor: attr_w(n, "horzAnchor").unwrap_or_else(|| "page".to_string()),
+        // §17.4.57: did the source give ANY horizontal positioning hint? If not,
+        // the spec-literal default (page edge) and Word's actual placement (text/
+        // column left) diverge; the renderer resolves that via this flag.
+        horz_specified: attr_w(n, "horzAnchor").is_some()
+            || attr_w(n, "tblpX").is_some()
+            || attr_w(n, "tblpXSpec").is_some(),
         vert_anchor: attr_w(n, "vertAnchor").unwrap_or_else(|| "page".to_string()),
         tblp_x: attr_w(n, "tblpX").map(|v| twips_to_pt(&v)).unwrap_or(0.0),
         tblp_y: attr_w(n, "tblpY").map(|v| twips_to_pt(&v)).unwrap_or(0.0),
@@ -4583,10 +4589,19 @@ fn parse_table_cell(
         .and_then(|p| child_w(p, "vMerge"))
         .map(|m| attr_w(m, "val").map(|v| v == "restart").unwrap_or(false));
 
-    let borders = tc_pr
+    // ECMA-376 §17.4.34 (tcBorders) + §17.7.6 (conditional formatting): a cell's
+    // effective borders are its inline `w:tcBorders` layered OVER the resolved
+    // conditional table-style borders (firstRow/lastRow/band*/corner). Without
+    // this the header underline and the `insideH/insideV w:val="nil"` that styles
+    // like Medium List 2 / Medium Shading 2 use to suppress data-row gridlines
+    // are silently dropped. Inline edges win per-edge; conditional fills the rest.
+    let mut borders = tc_pr
         .and_then(|p| child_w(p, "tcBorders"))
         .map(|b| parse_cell_borders(b))
         .unwrap_or_default();
+    if let Some(c) = cond {
+        apply_cond_cell_borders(&mut borders, &c.borders);
+    }
 
     let background = tc_pr
         .and_then(|p| child_w(p, "shd"))
@@ -4702,6 +4717,8 @@ fn parse_cell_borders(node: roxmltree::Node) -> CellBorders {
     // ECMA-376 §17.4.* tcBorders: same logical/physical edge aliasing as
     // tblBorders. w:start/w:end (§17.4.66-67) are the logical vertical edges;
     // w:left/w:right the physical names. Prefer physical, fall back to logical.
+    // insideH/insideV (§17.4.34) are kept so a conditional tcBorders with
+    // `insideH w:val="nil"` (banded data rows) reaches the renderer.
     CellBorders {
         top: child_w(node, "top").map(parse_border_spec),
         bottom: child_w(node, "bottom").map(parse_border_spec),
@@ -4711,6 +4728,49 @@ fn parse_cell_borders(node: roxmltree::Node) -> CellBorders {
         right: child_w(node, "right")
             .or_else(|| child_w(node, "end"))
             .map(parse_border_spec),
+        inside_h: child_w(node, "insideH").map(parse_border_spec),
+        inside_v: child_w(node, "insideV").map(parse_border_spec),
+    }
+}
+
+/// Convert one table-style border edge ([`EdgeBorder`]) into the serialized
+/// [`BorderSpec`] used by cell/table borders. `nil`/`none` styles are preserved
+/// verbatim (the renderer treats both as "no border") so a conditional
+/// `insideH w:val="nil"` can suppress the table-level interior gridline.
+fn edge_to_border_spec(e: &EdgeBorder) -> BorderSpec {
+    BorderSpec {
+        width: e.width,
+        color: e.color.clone(),
+        style: e.style.clone(),
+    }
+}
+
+/// Fold a conditional table-style block's borders (§17.7.6 `w:tblStylePr` →
+/// `w:tcBorders`, already merged across the matching condition layers) UNDER a
+/// cell's inline `w:tcBorders`. Inline edges win per-edge (§17.4 direct cell
+/// formatting beats the style); an edge the cell did not set inline is taken
+/// from the conditional block. This is how a Medium List 2 data cell picks up
+/// `insideH w:val="nil"` (suppressing the banded gridline) while still letting an
+/// inline tcBorders override on a specific cell. Edges absent from both stay
+/// `None` so the renderer falls back to the table-level inside/outside spec.
+fn apply_cond_cell_borders(dst: &mut CellBorders, src: &RawTblBorders) {
+    if dst.top.is_none() {
+        dst.top = src.top.as_ref().map(edge_to_border_spec);
+    }
+    if dst.bottom.is_none() {
+        dst.bottom = src.bottom.as_ref().map(edge_to_border_spec);
+    }
+    if dst.left.is_none() {
+        dst.left = src.left.as_ref().map(edge_to_border_spec);
+    }
+    if dst.right.is_none() {
+        dst.right = src.right.as_ref().map(edge_to_border_spec);
+    }
+    if dst.inside_h.is_none() {
+        dst.inside_h = src.inside_h.as_ref().map(edge_to_border_spec);
+    }
+    if dst.inside_v.is_none() {
+        dst.inside_v = src.inside_v.as_ref().map(edge_to_border_spec);
     }
 }
 
@@ -8004,5 +8064,134 @@ mod numbering_marker_font_tests {
             cell_text_color(&t.rows[0].cells[1]).as_deref(),
             Some("bbb222")
         );
+    }
+
+    // ---- Conditional cell borders fold into cell.borders (§17.4.34 + §17.7.6) ----
+
+    /// A Medium List 2-like table style: whole-table outer borders only (no
+    /// insideH/insideV), a firstRow that underlines the header (bottom=single)
+    /// AND suppresses interior gridlines (insideH/insideV=nil), and a band1Horz
+    /// data condition that suppresses interior gridlines (insideH=nil). This is
+    /// exactly the structure that made calibre sample-11's blue/teal data rows
+    /// show phantom horizontal rules before the conditional borders were folded.
+    fn banded_border_styles() -> StyleMap {
+        StyleMap::parse(&format!(
+            r#"<w:styles xmlns:w="{ns}">
+                <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:rPr/></w:style>
+                <w:style w:type="table" w:styleId="ML2">
+                    <w:tblPr>
+                        <w:tblBorders>
+                            <w:top w:val="single" w:sz="8" w:color="4F81BD"/>
+                            <w:left w:val="single" w:sz="8" w:color="4F81BD"/>
+                            <w:bottom w:val="single" w:sz="8" w:color="4F81BD"/>
+                            <w:right w:val="single" w:sz="8" w:color="4F81BD"/>
+                        </w:tblBorders>
+                    </w:tblPr>
+                    <w:tblStylePr w:type="firstRow">
+                        <w:tcPr><w:tcBorders>
+                            <w:top w:val="nil"/>
+                            <w:left w:val="nil"/>
+                            <w:bottom w:val="single" w:sz="24" w:color="4F81BD"/>
+                            <w:right w:val="nil"/>
+                            <w:insideH w:val="nil"/>
+                            <w:insideV w:val="nil"/>
+                        </w:tcBorders></w:tcPr>
+                    </w:tblStylePr>
+                    <w:tblStylePr w:type="band1Horz">
+                        <w:tcPr><w:tcBorders>
+                            <w:top w:val="nil"/>
+                            <w:bottom w:val="nil"/>
+                            <w:insideH w:val="nil"/>
+                            <w:insideV w:val="nil"/>
+                        </w:tcBorders></w:tcPr>
+                    </w:tblStylePr>
+                </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        ))
+    }
+
+    #[test]
+    fn cond_firstrow_underline_folds_into_cell_bottom() {
+        // tblLook 0020 = firstRow on (0x0020). Row 0 = header.
+        let t = parse_tbl_styled(
+            r#"<w:tblPr><w:tblStyle w:val="ML2"/>
+                 <w:tblLook w:val="0020"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+               <w:tr><w:tc><w:p><w:r><w:t>Head</w:t></w:r></w:p></w:tc></w:tr>
+               <w:tr><w:tc><w:p><w:r><w:t>Data</w:t></w:r></w:p></w:tc></w:tr>"#,
+            &banded_border_styles(),
+        );
+        // Header cell: firstRow conditional bottom=single sz24 must reach cell.bottom.
+        let head = &t.rows[0].cells[0].borders;
+        let bottom = head.bottom.as_ref().expect("firstRow bottom folded in");
+        assert_eq!(bottom.style, "single");
+        assert!((bottom.width - 3.0).abs() < 1e-9, "sz=24 eighths → 3 pt");
+        assert_eq!(bottom.color.as_deref(), Some("4f81bd"));
+        // firstRow also sets top/left/right = nil ⇒ explicit "no border" on the cell
+        // (so the renderer suppresses them rather than falling back to table.top).
+        assert_eq!(head.top.as_ref().map(|b| b.style.as_str()), Some("nil"));
+        // …and insideH=nil so an interior gridline inside the header span is off.
+        assert_eq!(
+            head.inside_h.as_ref().map(|b| b.style.as_str()),
+            Some("nil")
+        );
+    }
+
+    #[test]
+    fn cond_band_insideh_nil_folds_into_cell_inside_h() {
+        // firstRow + horizontal banding on (0x0020 firstRow, banding default-on).
+        // The style's firstRow carries NO shd ⇒ first_row_styled is false ⇒ the
+        // banding parity is bi=r: even body rows (r=2,4,…) are band1Horz, odd
+        // body rows band2Horz. Row 2 (D2) therefore lands on band1Horz, the only
+        // banded condition this style defines (mirroring Medium List 2, which
+        // styles band1 rows and leaves band2 rows unbanded white).
+        let t = parse_tbl_styled(
+            r#"<w:tblPr><w:tblStyle w:val="ML2"/>
+                 <w:tblLook w:val="0020"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+               <w:tr><w:tc><w:p><w:r><w:t>Head</w:t></w:r></w:p></w:tc></w:tr>
+               <w:tr><w:tc><w:p><w:r><w:t>D1</w:t></w:r></w:p></w:tc></w:tr>
+               <w:tr><w:tc><w:p><w:r><w:t>D2</w:t></w:r></w:p></w:tc></w:tr>"#,
+            &banded_border_styles(),
+        );
+        // The band1Horz data row must carry insideH=nil so the renderer draws NO
+        // interior horizontal gridline between data rows.
+        let data = &t.rows[2].cells[0].borders;
+        assert_eq!(
+            data.inside_h.as_ref().map(|b| b.style.as_str()),
+            Some("nil"),
+            "band1Horz insideH=nil must fold into the data cell"
+        );
+        // top/bottom on the data cell are nil too (band1Horz top/bottom=nil).
+        assert_eq!(data.top.as_ref().map(|b| b.style.as_str()), Some("nil"));
+        assert_eq!(data.bottom.as_ref().map(|b| b.style.as_str()), Some("nil"));
+    }
+
+    #[test]
+    fn inline_tcborders_win_over_conditional() {
+        // A cell whose inline tcBorders set bottom=double must keep double even
+        // though the firstRow conditional would set bottom=single (inline wins,
+        // §17.4 direct cell formatting beats the style). Edges the cell did NOT
+        // set inline still come from the conditional (insideH=nil here).
+        let t = parse_tbl_styled(
+            r#"<w:tblPr><w:tblStyle w:val="ML2"/>
+                 <w:tblLook w:val="0020"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+               <w:tr><w:tc>
+                 <w:tcPr><w:tcBorders><w:bottom w:val="double" w:sz="6" w:color="FF0000"/></w:tcBorders></w:tcPr>
+                 <w:p><w:r><w:t>Head</w:t></w:r></w:p>
+               </w:tc></w:tr>"#,
+            &banded_border_styles(),
+        );
+        let b = &t.rows[0].cells[0].borders;
+        let bottom = b.bottom.as_ref().expect("inline bottom kept");
+        assert_eq!(
+            bottom.style, "double",
+            "inline tcBorders override conditional"
+        );
+        assert_eq!(bottom.color.as_deref(), Some("ff0000"));
+        // The cell left no insideH inline ⇒ it comes from the firstRow condition (nil).
+        assert_eq!(b.inside_h.as_ref().map(|x| x.style.as_str()), Some("nil"));
     }
 }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1164,6 +1164,13 @@ pub struct TblpPr {
     pub bottom_from_text: f64,
     /// §17.4.57 horzAnchor (ST_HAnchor {text,margin,page}). Default "page".
     pub horz_anchor: String,
+    /// True iff the source `<w:tblpPr>` carried ANY horizontal positioning hint
+    /// (horzAnchor, tblpX, or tblpXSpec). When false, NO horizontal position was
+    /// given. ECMA-376's literal default would then be horzAnchor="page" +
+    /// tblpX=0 (the page edge), but Word anchors such an auto-converted floating
+    /// table at the anchor paragraph's text/column left instead. The renderer
+    /// uses this flag to apply that Word-runtime placement (documented there).
+    pub horz_specified: bool,
     /// §17.4.57 vertAnchor (ST_VAnchor {text,margin,page}). Default "page".
     pub vert_anchor: String,
     /// §17.4.57 tblpX/tblpY (ST_SignedTwipsMeasure): absolute signed offset from
@@ -1318,4 +1325,14 @@ pub struct CellBorders {
     pub bottom: Option<BorderSpec>,
     pub left: Option<BorderSpec>,
     pub right: Option<BorderSpec>,
+    /// ECMA-376 §17.4.34 (tcBorders w:insideH/w:insideV): the interior
+    /// horizontal/vertical borders a cell contributes. A conditional table-style
+    /// block (`w:tblStylePr`) commonly sets these to `nil` to suppress the
+    /// gridlines on banded data rows (e.g. Medium List 2 / Medium Shading 2). We
+    /// keep them as part of the cell so the conditional formatting (§17.7.6),
+    /// folded in at parse time, can override the table-level insideH/insideV on a
+    /// per-cell basis. `None` = unset (renderer falls back to the table inside
+    /// spec); a `Some` with style "nil"/"none" = an explicit "no interior border".
+    pub inside_h: Option<BorderSpec>,
+    pub inside_v: Option<BorderSpec>,
 }

--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -48,6 +48,9 @@ function makeState(over: Partial<MinState> = {}): MinState {
 }
 
 // Full TblpPr with the spec defaults; tests override only the axis under test.
+// The factory sets horzAnchor:'page' (an explicit horizontal hint), so
+// horzSpecified defaults to true; the "no horizontal spec at all" case is
+// exercised by overriding horzSpecified:false (see the sample-11 case).
 function tblp(over: Partial<TblpPr> = {}): TblpPr {
   return {
     leftFromText: 0,
@@ -55,6 +58,7 @@ function tblp(over: Partial<TblpPr> = {}): TblpPr {
     topFromText: 0,
     bottomFromText: 0,
     horzAnchor: 'page',
+    horzSpecified: true,
     vertAnchor: 'page',
     tblpX: 0,
     tblpY: 0,
@@ -214,18 +218,22 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
 
 describe('floating table — sample-11 case (§17.4.57)', () => {
   // <w:tblpPr w:rightFromText="187" w:bottomFromText="72" w:vertAnchor="text"
-  //           w:tblpY="1"/> + <w:tblOverlap w:val="never"/>. No horzAnchor ⇒
-  // page; no tblpX ⇒ 0 ⇒ the table sits at the page's left vertical edge.
+  //           w:tblpY="1"/> + <w:tblOverlap w:val="never"/>. NO horzAnchor, NO
+  // tblpX, NO tblpXSpec ⇒ horzSpecified=false. The spec-literal default would be
+  // horzAnchor="page" + tblpX=0 (page edge), but Word anchors such a table at the
+  // anchor paragraph's text/column LEFT (contentX), not the page edge — matching
+  // the calibre PDF where the ITEM/NEEDED table aligns with the body column.
   // rightFromText 187 twip → 9.35 pt; bottomFromText 72 twip → 3.6 pt.
   const RIGHT_FROM_TEXT = 187 / 20; // 9.35 pt
   const BOTTOM_FROM_TEXT = 72 / 20; // 3.6 pt
 
-  it('floats at page-left (x=0), text wraps on the RIGHT, right dist padding present', () => {
-    const st = makeState();
+  it('no horizontal spec ⇒ anchors at the text/column left (NOT the page edge)', () => {
+    const st = makeState(); // column band [100, 500]
     const tp = tblp({
       rightFromText: RIGHT_FROM_TEXT,
       bottomFromText: BOTTOM_FROM_TEXT,
-      horzAnchor: 'page', // default
+      horzAnchor: 'page', // defaulted token, but…
+      horzSpecified: false, // …no horizontal hint was present in the source
       vertAnchor: 'text',
       tblpX: 0,
       tblpY: 1,
@@ -233,19 +241,26 @@ describe('floating table — sample-11 case (§17.4.57)', () => {
     // A small ITEM/NEEDED table, say 120 wide × 50 tall, anchored at paraTop=300.
     const tableW = 120;
     const b = box(tp, st, 300, tableW, 50);
-    expect(b.x).toBe(0); // page left
+    expect(b.x).toBe(100); // text/column left (contentX), NOT page-left 0
     expect(b.y).toBe(300 + 1); // vAnchor=text ⇒ paraTop + tblpY
 
-    // side from the column band [100,500]: the float's right edge (x+w = 120) is
-    // left of the column centre (300) ⇒ float on the LEFT ⇒ text wraps RIGHT.
+    // side from the column band [100,500]: the float's right edge (100+120=220)
+    // is left of the column centre (300) ⇒ float on the LEFT ⇒ text wraps RIGHT.
     const side = wrapSide(b, st);
     expect(side).toBe('right'); // text sits to the RIGHT of the float
 
     registerFloat(b, tp, st, side, /* overlap="never" ⇒ */ false);
     const f = st.floats[0];
     expect(f.side).toBe('right');
-    expect(f.xRight).toBe(0 + tableW + RIGHT_FROM_TEXT); // right edge includes the dist padding
+    expect(f.xRight).toBe(100 + tableW + RIGHT_FROM_TEXT); // right edge includes the dist padding
     expect(f.yBottom).toBe(b.y + 50 + BOTTOM_FROM_TEXT);
+  });
+
+  it('explicit horzAnchor="page" + tblpX=0 still pins to the page edge', () => {
+    const st = makeState();
+    // When the source DOES specify a horizontal anchor, honor the spec literally.
+    const b = box(tblp({ horzAnchor: 'page', horzSpecified: true, tblpX: 0 }), st, 300, 120, 50);
+    expect(b.x).toBe(0); // page left edge
   });
 });
 

--- a/packages/docx/src/measure-column-geometry.test.ts
+++ b/packages/docx/src/measure-column-geometry.test.ts
@@ -101,6 +101,7 @@ function tblp(over: Partial<TblpPr> = {}): TblpPr {
     topFromText: 0,
     bottomFromText: 0,
     horzAnchor: 'text',
+    horzSpecified: true,
     vertAnchor: 'text',
     tblpX: 0,
     tblpY: 0,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2981,7 +2981,18 @@ export function computeFloatTableBox(
   tableH: number,
 ): FloatTableBox {
   const sc = state.scale;
-  const hx = frameXContainer(tp.horzAnchor, state);
+  // §17.4.57 + §17.18.35: horzAnchor's literal default is "page", which would
+  // pin a floating table to the physical page edge (left margin). But when the
+  // source `<w:tblpPr>` gave NO horizontal positioning at all (no horzAnchor, no
+  // tblpX, no tblpXSpec), Word anchors the table at the anchor paragraph's text/
+  // column left — the in-flow position it was converted from — NOT the page edge.
+  // (Word runtime behavior; the spec-literal page default does not match Word
+  // here. See calibre sample-11 p.3 "ITEM/NEEDED" float.) We force the text band
+  // for that case so the table aligns with the body column, then let tblpX=0
+  // place it at that band's left.
+  const hx = tp.horzSpecified
+    ? frameXContainer(tp.horzAnchor, state)
+    : frameXContainer('text', state);
   const vy = frameYContainer(tp.vertAnchor, paraTop, state);
 
   // Horizontal: tblpXSpec (ST_XAlign) supersedes the absolute tblpX offset
@@ -5980,18 +5991,31 @@ function drawTableRows(
         // ECMA-376 §17.4.85: a vMerge=restart cell visually occupies the full
         // merged span; use the sum of row heights for its render box.
         let drawH = rowH;
+        let lastRowOfCell = ri;
         if (cell.vMerge === true) {
           const endRi = findMergeEndRow(table, ri, ci);
+          lastRowOfCell = endRi;
           drawH = 0;
           for (let rj = ri; rj <= endRi; rj++) drawH += rowHeights[rj];
         }
+        // ECMA-376 §17.4.34/§17.4.39: classify which physical edges of this cell
+        // are the table's OUTER edges (vs. interior gridlines) from its grid
+        // position so drawCellBorders can pick table.top/bottom/left/right vs.
+        // table.insideH/insideV. `leftCol`/`rightCol` are the LOGICAL columns
+        // (gridSpan-aware); the renderer flips them for bidiVisual via `mirror`.
+        const edges: CellEdgeFlags = {
+          topRow: ri === 0,
+          bottomRow: lastRowOfCell === table.rows.length - 1,
+          leftCol: ci === 0,
+          rightCol: ci + span === colWidths.length,
+        };
         // ECMA-376 §17.4.81: an exact row height is honored verbatim and
         // content taller than the row is clipped to the row box (Word clips;
         // we would otherwise overflow into neighboring rows). A vMerge=restart
         // cell spans multiple rows, so it is never governed by a single row's
         // exact height — only single-row cells clip.
         const clipExact = row.rowHeightRule === 'exact' && cell.vMerge !== true;
-        if (!dryRun) renderCell(cell, table, leadX, y, cellW, drawH, state, mirror, clipExact);
+        if (!dryRun) renderCell(cell, table, leadX, y, cellW, drawH, state, edges, mirror, clipExact);
         else measureCellContent(cell, table, cellW, scale, state);
       }
 
@@ -6226,6 +6250,7 @@ function renderCell(
   w: number,
   h: number,
   state: RenderState,
+  edges: CellEdgeFlags,
   mirror = false,
   clipExact = false,
 ): void {
@@ -6236,7 +6261,7 @@ function renderCell(
     ctx.fillRect(x, y, w, h);
   }
 
-  drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale, mirror, state.dpr);
+  drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale, edges, mirror, state.dpr);
 
   const cm = effCellMargins(cell, table);
   const mt = cm.top * scale;
@@ -6341,27 +6366,107 @@ function renderCellContent(content: CellElement[], state: RenderState): void {
   }
 }
 
+/** Which grid edges of the table this cell touches, so {@link drawCellBorders}
+ *  can pick the OUTER (table.top/bottom/left/right) vs the INNER
+ *  (table.insideH/insideV) spec per physical edge (ECMA-376 §17.4.34/§17.4.39). */
+interface CellEdgeFlags {
+  topRow: boolean;     // cell sits in the table's first row → its top is the table outer top
+  bottomRow: boolean;  // cell's bottom edge is the table outer bottom (vMerge-span aware)
+  leftCol: boolean;    // cell's left edge is the table outer left
+  rightCol: boolean;   // cell's right edge is the table outer right
+}
+
+/** Resolve a `nil`/`none` border to "no ink". A `null` means "not set" — the
+ *  caller already substituted a fallback before reaching here. */
+function paintable(b: BorderSpec | null): BorderSpec | null {
+  if (!b) return null;
+  if (b.style === 'none' || b.style === 'nil') return null;
+  return b;
+}
+
 function drawCellBorders(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   x: number, y: number, w: number, h: number,
   cell: CellBorders,
   table: TableBorders,
   scale: number,
+  edges: CellEdgeFlags,
   mirror = false,
   dpr = 1,
 ): void {
-  const top = cell.top ?? table.top;
-  const bottom = cell.bottom ?? table.bottom;
+  // ECMA-376 §17.4.34/§17.4.39: a cell's TOP/BOTTOM use the table OUTER border
+  // (top/bottom) only on the table's outermost rows; an interior horizontal
+  // gridline uses table.insideH. Likewise LEFT/RIGHT use the outer left/right
+  // only on the outermost columns, interior verticals use table.insideV.
+  // Per-edge precedence (§17.4 + §17.7.6): the cell's own explicit edge (which
+  // already folds the conditional firstRow/lastRow/band tcBorders at parse time)
+  // wins; for an interior edge the cell's insideH/insideV is consulted before the
+  // table inside spec; the table outer spec is the last resort on outer edges.
+  //
+  // TODO(border-conflict §17.4.39): true adjacent-cell border conflict
+  // resolution (larger width / style-rank wins, ties broken by color, then by
+  // top-then-left ownership) is NOT implemented. Each cell paints its own four
+  // edges, so an interior gridline is drawn once by each of the two adjacent
+  // cells; for matching specs this is visually identical, and `nil` on either
+  // side still suppresses that side's stroke. When the two sides disagree the
+  // later-painted cell currently wins rather than the spec's max-width rule.
+  const horiz = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
+    paintable(own ?? (outer ? table.top : (cell.insideH ?? table.insideH)));
+  const horizB = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
+    paintable(own ?? (outer ? table.bottom : (cell.insideH ?? table.insideH)));
+  const vert = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
+    paintable(own ?? (outer ? table.left : (cell.insideV ?? table.insideV)));
+  const vertR = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
+    paintable(own ?? (outer ? table.right : (cell.insideV ?? table.insideV)));
+
+  const top = horiz(cell.top, edges.topRow);
+  const bottom = horizB(cell.bottom, edges.bottomRow);
   // ECMA-376 §17.4.1: under bidiVisual the columns are visually reversed, so a
   // cell's logical left (start) border is drawn on its physical right edge and
-  // vice versa. Borders are owned by the cell, so swap which spec each side uses.
-  const left = mirror ? (cell.right ?? table.right) : (cell.left ?? table.left);
-  const right = mirror ? (cell.left ?? table.left) : (cell.right ?? table.right);
+  // vice versa. Borders are owned by the cell, so swap which spec each side uses,
+  // AND swap which outer edge / inside-fallback applies (the start column's outer
+  // edge is the physical right under bidiVisual).
+  const left = mirror
+    ? vertR(cell.right, edges.rightCol)
+    : vert(cell.left, edges.leftCol);
+  const right = mirror
+    ? vert(cell.left, edges.leftCol)
+    : vertR(cell.right, edges.rightCol);
 
-  if (top && top.style !== 'none') drawBorderLine(ctx, x, y, x + w, y, top, scale, dpr);
-  if (bottom && bottom.style !== 'none') drawBorderLine(ctx, x, y + h, x + w, y + h, bottom, scale, dpr);
-  if (left && left.style !== 'none') drawBorderLine(ctx, x, y, x, y + h, left, scale, dpr);
-  if (right && right.style !== 'none') drawBorderLine(ctx, x + w, y, x + w, y + h, right, scale, dpr);
+  if (top) drawBorderLine(ctx, x, y, x + w, y, top, scale, dpr);
+  if (bottom) drawBorderLine(ctx, x, y + h, x + w, y + h, bottom, scale, dpr);
+  if (left) drawBorderLine(ctx, x, y, x, y + h, left, scale, dpr);
+  if (right) drawBorderLine(ctx, x + w, y, x + w, y + h, right, scale, dpr);
+}
+
+/** Stroke one crisp axis-aligned segment. `perp` shifts the whole line
+ *  perpendicular to its direction (px, pre-crisp-snap) — used to place the two
+ *  rails of a `double` border on either side of the nominal edge. */
+function strokeCrispSegment(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  x1: number, y1: number, x2: number, y2: number,
+  lw: number,
+  dpr: number,
+  perp: number,
+): void {
+  ctx.lineWidth = lw;
+  // Crispness nudge (see crispOffset): a thin (odd device-width) axis-aligned
+  // stroke straddles two device rows and blurs; nudging it perpendicular to the
+  // line snaps it onto the nearest crisp device position. Cell / paragraph
+  // borders are always horizontal (y1===y2) or vertical (x1===x2) — never
+  // diagonal — so the orientation is read directly from the endpoints, and the
+  // snap delta is derived from the line's own coordinate (fractional-safe).
+  const horizontal = y1 === y2;
+  const vertical = x1 === x2;
+  // `perp` runs along x for a horizontal line, along y for a vertical line.
+  const ox = (horizontal ? 0 : perp);
+  const oy = (horizontal ? perp : 0);
+  const dpx = vertical ? crispOffset(x1 + ox, lw, dpr) : 0;
+  const dpy = horizontal ? crispOffset(y1 + oy, lw, dpr) : 0;
+  ctx.beginPath();
+  ctx.moveTo(x1 + ox + dpx, y1 + oy + dpy);
+  ctx.lineTo(x2 + ox + dpx, y2 + oy + dpy);
+  ctx.stroke();
 }
 
 function drawBorderLine(
@@ -6374,21 +6479,22 @@ function drawBorderLine(
   ctx.save();
   ctx.strokeStyle = spec.color ? `#${spec.color}` : '#000000';
   const lw = Math.max(0.5, spec.width * scale);
-  ctx.lineWidth = lw;
-  // Crispness nudge (see crispOffset): a thin (odd device-width) axis-aligned
-  // stroke straddles two device rows and blurs; nudging it perpendicular to the
-  // line snaps it onto the nearest crisp device position. Cell / paragraph
-  // borders are always horizontal (y1===y2) or vertical (x1===x2) — never
-  // diagonal — so the orientation is read directly from the endpoints, and the
-  // snap delta is derived from the line's own coordinate (fractional-safe).
-  const horizontal = y1 === y2;
-  const vertical = x1 === x2;
-  const dpx = vertical ? crispOffset(x1, lw, dpr) : 0;
-  const dpy = horizontal ? crispOffset(y1, lw, dpr) : 0;
-  ctx.beginPath();
-  ctx.moveTo(x1 + dpx, y1 + dpy);
-  ctx.lineTo(x2 + dpx, y2 + dpy);
-  ctx.stroke();
+
+  if (spec.style === 'double') {
+    // ECMA-376 §17.18.2 ST_Border "double": a double line around the object.
+    // The standard does not normatively define the rail/gap geometry, so this
+    // matches Word's rendering — three equal bands across the nominal width
+    // (line / gap / line), each rail = sz/3, gap = sz/3, the pair centered on
+    // the edge. (Word's own UI labels `sz` as the total double-border width.)
+    const railW = Math.max(0.5, lw / 3);
+    const offset = (lw - railW) / 2; // rail centers sit ±offset from the edge
+    strokeCrispSegment(ctx, x1, y1, x2, y2, railW, dpr, -offset);
+    strokeCrispSegment(ctx, x1, y1, x2, y2, railW, dpr, offset);
+    ctx.restore();
+    return;
+  }
+
+  strokeCrispSegment(ctx, x1, y1, x2, y2, lw, dpr, 0);
   ctx.restore();
 }
 

--- a/packages/docx/src/table-row-height.test.ts
+++ b/packages/docx/src/table-row-height.test.ts
@@ -23,7 +23,7 @@ function emptyCell(): DocTableCell {
     content: [],
     colSpan: 1,
     vMerge: null,
-    borders: { top: null, bottom: null, left: null, right: null },
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
     background: null,
     vAlign: 'top',
     widthPt: null,

--- a/packages/docx/src/table-split.test.ts
+++ b/packages/docx/src/table-split.test.ts
@@ -11,7 +11,7 @@ function row(opts: { isHeader?: boolean; vMergeContinue?: boolean } = {}): DocTa
         content: [],
         colSpan: 1,
         vMerge: opts.vMergeContinue ? false : null,
-        borders: { top: null, bottom: null, left: null, right: null },
+        borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
         background: null,
         vAlign: 'top',
         widthPt: null,

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -786,6 +786,12 @@ export interface TblpPr {
   bottomFromText: number;
   /** §17.4.57 ST_HAnchor {text,margin,page}. Default 'page'. */
   horzAnchor: 'text' | 'margin' | 'page' | string;
+  /** True iff the source `<w:tblpPr>` carried ANY horizontal positioning hint
+   *  (horzAnchor, tblpX, or tblpXSpec). When false, no horizontal position was
+   *  given: ECMA-376's literal default is the page edge, but Word places such a
+   *  table at the anchor paragraph's text/column left. computeFloatTableBox uses
+   *  this flag to apply that Word-runtime placement. */
+  horzSpecified: boolean;
   /** §17.4.57 ST_VAnchor {text,margin,page}. Default 'page'. */
   vertAnchor: 'text' | 'margin' | 'page' | string;
   /** §17.4.57 absolute signed offset from the horz/vert anchor edge, pt.
@@ -892,6 +898,14 @@ export interface CellBorders {
   bottom: BorderSpec | null;
   left: BorderSpec | null;
   right: BorderSpec | null;
+  /** ECMA-376 §17.4.34 (tcBorders w:insideH/w:insideV): the interior
+   *  horizontal/vertical border this cell contributes. Folded from the cell's
+   *  inline tcBorders OVER the resolved conditional table-style borders (§17.7.6)
+   *  at parse time. `null` = unset (the renderer falls back to the table-level
+   *  insideH/insideV); a spec with style "nil"/"none" = an explicit "no interior
+   *  border" (e.g. banded data rows in Medium List 2 / Medium Shading 2). */
+  insideH: BorderSpec | null;
+  insideV: BorderSpec | null;
 }
 
 // ===== Worker message protocol =====


### PR DESCRIPTION
Three sample-11 page-3 table bugs reported against the Word PDF:

### 1. Floating table spilled into the left margin
The green ITEM/NEEDED table's `tblpPr` specifies only vertical position (`vertAnchor`/`tblpY`) with **no `horzAnchor`/`tblpX`/`tblpXSpec`**. `horzAnchor`'s spec-literal default is `page` → page edge, but **Word anchors a float with no horizontal hint at the anchor paragraph's text/column left**. `TblpPr` gains `horz_specified` (any of horzAnchor/tblpX/tblpXSpec present); `computeFloatTableBox` forces the `text` column band (`state.contentX`) when false. An explicit `horzAnchor="page"` still pins to the page edge (regression test). Documented as Word-runtime behavior (§17.4.57).

### 2. Phantom horizontal gridlines on banded data rows
Both styles define **no whole-table `insideH`** and set `insideH`/`insideV="nil"` in every conditional, yet we drew a rule under every row. Two causes:
- **(a) parser**: `parse_table_cell` ignored the conditional `CondFmt.borders`, so the firstRow underline / band `insideH=nil` never reached the cell. `apply_cond_cell_borders` now folds them under the inline `tcBorders` (inline wins per edge; `nil`/`none` preserved).
- **(b) renderer**: `drawCellBorders` used the **outer** `table.top/bottom/left/right` for every edge. It is now grid-position aware (`CellEdgeFlags`): interior edges use `cell.insideH/V ?? table.insideH/V`, only the perimeter uses the outer borders.
- Precedence: inline tcBorders > conditional > insideH/V > outer.

### 3. Total-row top drawn as a thick single line instead of double
The lastRow conditional sets `top=double`; `drawBorderLine` now renders `style="double"` as two parallel rails (each `sz/3`, gap `sz/3`) per §17.18.2.

## Verification
- Rust fmt/clippy clean, **124 cargo tests** (3 new: firstRow-underline fold, band1Horz insideH=nil fold, inline-wins-over-conditional); WASM rebuilt.
- TS typecheck clean; docx vitest 39 (float-geometry test updated to column-left + a new explicit-page-anchor guard; CellBorders fixtures gain insideH/insideV).
- **VRT 21/21 pass** — existing TableGrid borders (sample-3/4/5) unchanged.
- Visual: page 3 — green table at the body column left; blue & teal data rows with no interior horizontal rules; teal Total-row top a double line. Matches the Word PDF.

## Known limitation
`drawCellBorders` carries a `TODO(§17.4.39)`: true adjacent-cell border-conflict resolution (max-width/style-rank) is not implemented — each cell paints its own edges, later-painted wins when two sides disagree. Not exercised by these tables (interior edges are uniformly nil or table-level). Dashed/dotted ST_Border styles still render solid (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)