### PR TITLE
feat(docx): dashed/dotted ST_Border styles in drawBorderLine (§17.18.2)

### DIFF
--- a/packages/docx/src/border-dash.test.ts
+++ b/packages/docx/src/border-dash.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { borderDashPattern } from './renderer.js';
+
+// ECMA-376 §17.18.2 ST_Border dash/dot families. Patterns are in units of the
+// stroked width `lw` (px); a dot = 1·lw, a dash = 3·lw, gaps = 2·lw (1·lw for
+// the small-gap variant). lw=2 here so the numbers read clearly.
+describe('borderDashPattern (ST_Border §17.18.2)', () => {
+  const lw = 2;
+
+  it('maps the dashed/dotted family to width-scaled patterns', () => {
+    expect(borderDashPattern('dotted', lw)).toEqual([2, 4]);
+    expect(borderDashPattern('dashed', lw)).toEqual([6, 4]);
+    expect(borderDashPattern('dashSmallGap', lw)).toEqual([6, 2]);
+    expect(borderDashPattern('dotDash', lw)).toEqual([2, 4, 6, 4]);
+    expect(borderDashPattern('dotDotDash', lw)).toEqual([2, 4, 2, 4, 6, 4]);
+    // dashDotStroked (thin/thick alternation) is approximated as dotDash.
+    expect(borderDashPattern('dashDotStroked', lw)).toEqual([2, 4, 6, 4]);
+  });
+
+  it('scales the pattern with the border width', () => {
+    expect(borderDashPattern('dashed', 1)).toEqual([3, 2]);
+    expect(borderDashPattern('dashed', 4)).toEqual([12, 8]);
+  });
+
+  // Solid / continuous styles (and the separately-handled double) get no dash
+  // pattern → an empty array → a continuous stroke.
+  it('returns an empty pattern for solid / non-dash styles', () => {
+    for (const s of ['single', 'thick', 'triple', 'double', 'wave', 'none', 'nil', 'inset']) {
+      expect(borderDashPattern(s, lw)).toEqual([]);
+    }
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6469,6 +6469,38 @@ function strokeCrispSegment(
   ctx.stroke();
 }
 
+/**
+ * ECMA-376 §17.18.2 ST_Border dash/dot families → a `setLineDash` pattern,
+ * expressed in units of the stroked width `lw` (px) so the dashes scale with the
+ * border thickness. The standard gives no normative pixel geometry, so these are
+ * Word-like approximations: a "dot" is one `lw` square, a "dash" three `lw`, gaps
+ * two `lw` (one for the small-gap variant). The ctx is already `scale(dpr,dpr)`d,
+ * so `lw`-relative lengths render crisply at any dpr (matching the single/double
+ * paths). Returns `[]` for solid styles (single/thick/triple/wave/…), which then
+ * stroke as a continuous line.
+ *
+ * `dashDotStroked` (alternating thin/thick strokes) cannot be expressed with a
+ * single `setLineDash`, so it is approximated as `dotDash`; noted, not exact.
+ */
+export function borderDashPattern(style: string, lw: number): number[] {
+  switch (style) {
+    case 'dotted':
+      return [lw, lw * 2];
+    case 'dashed':
+      return [lw * 3, lw * 2];
+    case 'dashSmallGap':
+      return [lw * 3, lw];
+    case 'dotDash':
+      return [lw, lw * 2, lw * 3, lw * 2];
+    case 'dotDotDash':
+      return [lw, lw * 2, lw, lw * 2, lw * 3, lw * 2];
+    case 'dashDotStroked':
+      return [lw, lw * 2, lw * 3, lw * 2];
+    default:
+      return [];
+  }
+}
+
 function drawBorderLine(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   x1: number, y1: number, x2: number, y2: number,
@@ -6494,6 +6526,10 @@ function drawBorderLine(
     return;
   }
 
+  // Dashed/dotted ST_Border families (§17.18.2). setLineDash is reset by the
+  // ctx.restore() below. Solid styles get an empty pattern → continuous line.
+  const dash = borderDashPattern(spec.style, lw);
+  if (dash.length) ctx.setLineDash(dash);
   strokeCrispSegment(ctx, x1, y1, x2, y2, lw, dpr, 0);
   ctx.restore();
 }


### PR DESCRIPTION
## Summary
`drawBorderLine` handled only `single` / `none` / `double` (the last added in [#531](https://github.com/yokotani/office-open-xml-viewer/pull/531)); the **dashed/dotted family** (`dashed`, `dotted`, `dotDash`, `dotDotDash`, `dashSmallGap`, `dashDotStroked`) fell through to a solid line.

New `borderDashPattern(style, lw)` maps those ST_Border values (§17.18.2) to a `setLineDash` pattern in units of the stroked width `lw` (dot = 1·lw, dash = 3·lw, gaps = 2·lw / 1·lw for the small-gap variant), so dashes scale with the border thickness. The ctx is already `scale(dpr,dpr)`d, so `lw`-relative lengths stay crisp at any dpr (matching the single/double paths). The pattern is set before the single `strokeCrispSegment` and reset by the existing `ctx.restore()`.

- **`double` is untouched** (already correct).
- `dashDotStroked`'s thin/thick alternation can't be expressed via a single `setLineDash`, so it's approximated as `dotDash` (documented, not exact).
- Solid styles (`single`/`thick`/`triple`/`wave`/…) return an empty pattern → continuous line, so existing borders are unchanged.

## Verification
- TS typecheck clean; new `border-dash.test.ts` (3 tests: the family→pattern map, width-scaling, and solid/double/none → empty).
- **VRT 21/21 pass** — no existing sample uses a dashed/dotted border, and solid/double are byte-identical.

The ST_Border enum was cross-checked against §17.18.2 in the bundled spec. Follow-up flagged during the #531 table-border work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)