### PR TITLE
feat(docx,core): normalize Symbol/Wingdings in inline runs + <w:sym>

### DIFF
--- a/packages/core/src/fonts/symbol-font.test.ts
+++ b/packages/core/src/fonts/symbol-font.test.ts
@@ -4,6 +4,8 @@ import {
   SYMBOL_MAP,
   WINGDINGS_MAP,
   symbolFontToUnicode,
+  isSymbolFontFamily,
+  symbolTextToUnicodeSegments,
 } from './symbol-font';
 
 const ch = (code: number): string => String.fromCharCode(code);
@@ -103,5 +105,65 @@ describe('symbolFontToUnicode', () => {
   it('keeps the deprecated SYMBOL_FONT_MAP alias pointing at Wingdings', () => {
     expect(SYMBOL_FONT_MAP).toBe(WINGDINGS_MAP);
     expect(SYMBOL_FONT_MAP[0xa7]).toBe('▪');
+  });
+});
+
+describe('isSymbolFontFamily', () => {
+  it('matches exactly "symbol" and any "wingdings" family', () => {
+    expect(isSymbolFontFamily('Symbol')).toBe(true);
+    expect(isSymbolFontFamily('SYMBOL')).toBe(true);
+    expect(isSymbolFontFamily('Wingdings')).toBe(true);
+    expect(isSymbolFontFamily('Wingdings 2')).toBe(true);
+  });
+
+  it('does NOT match Webdings (no core table) or ordinary faces', () => {
+    // Webdings is intentionally excluded — core has no Webdings table, so the
+    // gate must not claim it can normalize a Webdings run.
+    expect(isSymbolFontFamily('Webdings')).toBe(false);
+    expect(isSymbolFontFamily('Calibri')).toBe(false);
+    // "Symbol" must be exact, not a substring (e.g. "SymbolMT" is a real Latin
+    // PostScript face), matching symbolFontToUnicode's own gate.
+    expect(isSymbolFontFamily('SymbolMT')).toBe(false);
+    expect(isSymbolFontFamily(null)).toBe(false);
+    expect(isSymbolFontFamily(undefined)).toBe(false);
+  });
+});
+
+describe('symbolTextToUnicodeSegments', () => {
+  it('returns the whole string unmapped for a non-symbol font', () => {
+    expect(symbolTextToUnicodeSegments('abc', 'Calibri')).toEqual([
+      { text: 'abc', mapped: false },
+    ]);
+    expect(symbolTextToUnicodeSegments(ch(0xf0a7), null)).toEqual([
+      { text: ch(0xf0a7), mapped: false },
+    ]);
+  });
+
+  it('maps every Wingdings PUA glyph and flags the run as mapped', () => {
+    // U+F0A7 (square) U+F0E0 (right arrow) → ▪ →
+    const segs = symbolTextToUnicodeSegments(ch(0xf0a7) + ch(0xf0e0), 'Wingdings');
+    expect(segs).toEqual([{ text: '▪→', mapped: true }]);
+  });
+
+  it('splits at mapped/unmapped boundaries so each run is single-font', () => {
+    // 0x21 "!" has no Wingdings entry (passthrough), 0xF0A7 maps to ▪.
+    const segs = symbolTextToUnicodeSegments(ch(0x21) + ch(0xf0a7) + ch(0x22), 'Wingdings');
+    expect(segs).toEqual([
+      { text: ch(0x21), mapped: false },
+      { text: '▪', mapped: true },
+      { text: ch(0x22), mapped: false },
+    ]);
+  });
+
+  it('preserves astral targets by iterating code points', () => {
+    // Wingdings 0x24 → U+1F453 EYEGLASSES (astral). Must survive as one glyph.
+    const segs = symbolTextToUnicodeSegments(ch(0x24), 'Wingdings');
+    expect(segs).toEqual([{ text: '\u{1F453}', mapped: true }]);
+  });
+
+  it('handles the empty string', () => {
+    expect(symbolTextToUnicodeSegments('', 'Wingdings')).toEqual([
+      { text: '', mapped: false },
+    ]);
   });
 });

--- a/packages/core/src/fonts/symbol-font.ts
+++ b/packages/core/src/fonts/symbol-font.ts
@@ -180,3 +180,76 @@ export function symbolFontToUnicode(
   const code = char.charCodeAt(0);
   return table[code] ?? char;
 }
+
+/**
+ * True when `fontFamily` is one of the font-specific (non-Unicode-cmap)
+ * encodings that {@link symbolFontToUnicode} knows how to normalize — currently
+ * exactly "Symbol" and any "Wingdings" family (§17.3.2.26 / §21.1.2.3.10).
+ *
+ * Intended as the shared "is this a symbol font?" gate so callers don't
+ * hand-roll divergent regexes. docx uses it; pptx still has its own broader
+ * inline gate (`/wingding|webding|symbol/i`) and is a follow-up to migrate. It
+ * deliberately does NOT match "Webdings" (core has no Webdings table yet — a
+ * Webdings PUA point would pass the gate only to return unchanged) nor a Latin
+ * face like "SymbolMT" (the "symbol" check is exact, not a substring), so a
+ * caller wanting either must add it explicitly and accept passthrough.
+ */
+export function isSymbolFontFamily(
+  fontFamily: string | null | undefined,
+): boolean {
+  if (!fontFamily) return false;
+  const lower = fontFamily.toLowerCase();
+  return lower === 'symbol' || lower.includes('wingdings');
+}
+
+/** A maximal run of characters sharing a single rendering disposition. */
+export interface SymbolTextSegment {
+  /** The (possibly normalized) text for this run. */
+  text: string;
+  /**
+   * True when at least one character in `text` was mapped from the symbol
+   * font's private encoding to a Unicode equivalent. Such a segment must be
+   * drawn in a generic fallback face (the Symbol/Wingdings font, if present,
+   * would re-interpret the Unicode code point as the WRONG glyph); an unmapped
+   * segment keeps the requested symbol font so an installed Symbol/Wingdings
+   * still draws its native glyph.
+   */
+  mapped: boolean;
+}
+
+/**
+ * String-level companion to {@link symbolFontToUnicode}: normalize every
+ * character of `text` through the font's private encoding and split the result
+ * into maximal same-disposition runs so the caller can switch the draw font at
+ * each mapped/unmapped boundary.
+ *
+ * When `fontFamily` is not a symbol font (per {@link isSymbolFontFamily}), the
+ * whole string is returned as a single `{ text, mapped: false }` segment
+ * unchanged — the caller then needs no special handling. Iterates by code point
+ * so astral targets (e.g. Wingdings 0x24 → U+1F453) survive intact.
+ */
+export function symbolTextToUnicodeSegments(
+  text: string,
+  fontFamily: string | null | undefined,
+): SymbolTextSegment[] {
+  if (!isSymbolFontFamily(fontFamily) || text.length === 0) {
+    return [{ text, mapped: false }];
+  }
+  const out: SymbolTextSegment[] = [];
+  let buf = '';
+  let bufMapped: boolean | null = null;
+  for (const ch of text) {
+    const normalized = symbolFontToUnicode(ch, fontFamily);
+    const mapped = normalized !== ch;
+    if (bufMapped === null || mapped === bufMapped) {
+      bufMapped = mapped;
+      buf += normalized;
+    } else {
+      out.push({ text: buf, mapped: bufMapped });
+      bufMapped = mapped;
+      buf = normalized;
+    }
+  }
+  if (buf.length > 0) out.push({ text: buf, mapped: bufMapped ?? false });
+  return out;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,9 @@ export {
   SYMBOL_MAP,
   WINGDINGS_MAP,
   symbolFontToUnicode,
+  isSymbolFontFamily,
+  symbolTextToUnicodeSegments,
+  type SymbolTextSegment,
 } from './fonts/symbol-font';
 export { renderChart } from './chart/renderer';
 export { autoResize, type AutoResizeOptions } from './autoResize';

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2089,6 +2089,63 @@ fn parse_run_inner(
                     })));
                 }
             }
+            "sym" => {
+                // ECMA-376 §17.3.3.30 <w:sym w:font=".." w:char="F0A7"/> — an
+                // explicit symbol character. `w:char` is the glyph's code point in
+                // the named font's own (private) encoding, written as hex and
+                // commonly PUA-shifted (U+F020–U+F0FF). We emit it as a one-glyph
+                // text run whose font_family is the sym's `w:font` (overriding the
+                // run's ascii axis for this glyph only), so the renderer's
+                // Symbol/Wingdings → Unicode normalization (the same path the body
+                // text and list markers use) maps it to the intended glyph. The
+                // resolved sym font goes through the same theme font-ref resolution
+                // as the rFonts axes. <w:sym> may sit between other text in the run,
+                // so we emit it inline to preserve order.
+                let sym_char = attr_w(child, "char")
+                    .and_then(|v| u32::from_str_radix(v.trim(), 16).ok())
+                    .and_then(char::from_u32);
+                if let Some(c) = sym_char {
+                    let sym_font = theme
+                        .resolve_font_ref(attr_w(child, "font"))
+                        .or_else(|| font_family.clone());
+                    runs.push(DocRun::Text(Box::new(TextRun {
+                        text: c.to_string(),
+                        bold,
+                        italic,
+                        underline,
+                        strikethrough,
+                        font_size,
+                        color: color.clone(),
+                        font_family: sym_font.clone(),
+                        // Keep the eastAsia axis pointed at the sym font too, so a
+                        // glyph that happens to classify as CJK still resolves
+                        // against the symbol font rather than the run's eastAsia
+                        // face. PUA sym chars route to the Latin slot, so the ascii
+                        // axis (`font_family`) is what actually drives rendering.
+                        font_family_east_asia: sym_font,
+                        is_link,
+                        background: fmt.background.clone(),
+                        color_auto,
+                        border: border.clone(),
+                        vert_align: vert_align.clone(),
+                        hyperlink: hyperlink.clone(),
+                        all_caps,
+                        small_caps,
+                        double_strikethrough,
+                        highlight: highlight.clone(),
+                        ruby: None,
+                        revision: revision.cloned(),
+                        rtl,
+                        cs: cs_toggle,
+                        font_family_cs: font_family_cs.clone(),
+                        font_size_cs,
+                        bold_cs,
+                        italic_cs,
+                        lang_bidi: lang_bidi.clone(),
+                        note_ref: None,
+                    })));
+                }
+            }
             "tab" => {
                 // w:tab emits a horizontal tab character; layout handles tab stop alignment.
                 runs.push(DocRun::Text(Box::new(TextRun {
@@ -5707,6 +5764,100 @@ mod math_jc_tests {
                <m:oMath><m:r><m:t>α</m:t></m:r></m:oMath></m:oMathPara>"#,
         );
         assert_eq!(p.alignment, "left");
+    }
+}
+
+#[cfg(test)]
+mod sym_run_tests {
+    use super::*;
+
+    fn parse_p(inner: &str) -> DocParagraph {
+        let xml = format!(
+            r#"<w:p xmlns:w="{w}" xmlns:m="{m}">{inner}</w:p>"#,
+            w = W_NS,
+            m = M_NS
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let style_map = StyleMap::parse("");
+        let mut num_map = NumberingMap::default();
+        let media: HashMap<String, String> = HashMap::new();
+        let rels: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+        let mut field = FieldState::default();
+        parse_paragraph(
+            doc.root_element(),
+            &style_map,
+            &mut num_map,
+            &media,
+            &rels,
+            &theme,
+            None,
+            &mut field,
+        )
+    }
+
+    fn text_runs(p: &DocParagraph) -> Vec<&TextRun> {
+        p.runs
+            .iter()
+            .filter_map(|r| match r {
+                DocRun::Text(t) => Some(t.as_ref()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    // ECMA-376 §17.3.3.30 — <w:sym w:font="Wingdings" w:char="F0A7"/> emits a
+    // one-glyph text run carrying the decoded PUA character (U+F0A7) and the
+    // sym's font on the ascii axis, so the renderer's Symbol/Wingdings → Unicode
+    // normalization can map it. The hex char is parsed as base-16.
+    #[test]
+    fn sym_emits_decoded_char_with_sym_font() {
+        let p = parse_p(r#"<w:r><w:sym w:font="Wingdings" w:char="F0A7"/></w:r>"#);
+        let runs = text_runs(&p);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "\u{F0A7}");
+        assert_eq!(runs[0].font_family.as_deref(), Some("Wingdings"));
+    }
+
+    // The sym font overrides the run's rFonts ascii axis for that glyph only:
+    // surrounding <w:t> text keeps the run font, the <w:sym> takes its own.
+    #[test]
+    fn sym_overrides_run_font_and_preserves_order() {
+        let p = parse_p(
+            r#"<w:r><w:rPr><w:rFonts w:ascii="Calibri"/></w:rPr>
+                 <w:t xml:space="preserve">a</w:t>
+                 <w:sym w:font="Symbol" w:char="F0B7"/>
+                 <w:t xml:space="preserve">b</w:t>
+               </w:r>"#,
+        );
+        let runs = text_runs(&p);
+        // Order preserved: "a", sym glyph, "b".
+        assert_eq!(runs.len(), 3);
+        assert_eq!(runs[0].text, "a");
+        assert_eq!(runs[0].font_family.as_deref(), Some("Calibri"));
+        assert_eq!(runs[1].text, "\u{F0B7}");
+        assert_eq!(runs[1].font_family.as_deref(), Some("Symbol"));
+        assert_eq!(runs[2].text, "b");
+        assert_eq!(runs[2].font_family.as_deref(), Some("Calibri"));
+    }
+
+    // A bare (non-PUA) hex char is decoded the same way (§17.3.3.30 places no
+    // restriction to the PUA): "00B7" → U+00B7 MIDDLE DOT.
+    #[test]
+    fn sym_decodes_bare_codepoint() {
+        let p = parse_p(r#"<w:r><w:sym w:font="Symbol" w:char="00B7"/></w:r>"#);
+        let runs = text_runs(&p);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "\u{00B7}");
+    }
+
+    // A malformed/absent w:char yields no run (no panic) rather than tofu.
+    #[test]
+    fn sym_with_invalid_char_is_skipped() {
+        let p = parse_p(r#"<w:r><w:sym w:font="Wingdings" w:char="ZZZZ"/></w:r>"#);
+        assert!(text_runs(&p).is_empty());
+        let p2 = parse_p(r#"<w:r><w:sym w:font="Wingdings"/></w:r>"#);
+        assert!(text_runs(&p2).is_empty());
     }
 }
 

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -645,9 +645,6 @@ fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     // §17.3.2.7 <w:cs/> — complex-script run toggle. Must mirror
     // apply_direct_run; without this arm a style-chain <w:cs/> (set in a
     // paragraph/character style rPr by parse_run_fmt) is silently dropped.
-    // §17.3.2.7 <w:cs/> — complex-script run toggle. Must mirror
-    // apply_direct_run; without this arm a style-chain <w:cs/> (set in a
-    // paragraph/character style rPr by parse_run_fmt) is silently dropped.
     if src.cs_toggle.is_some() {
         dst.cs_toggle = src.cs_toggle;
     }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -35,6 +35,8 @@ import {
   isComplexScriptCodePoint,
   decodeRasterOrMetafile,
   symbolFontToUnicode,
+  isSymbolFontFamily,
+  symbolTextToUnicodeSegments,
 } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer, KinsokuRules } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
@@ -4130,11 +4132,9 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
     // Latin/digits/neutral (ascii face). Each segment stays SINGLE-FONT — one
     // family for its whole `.text` — so the measure==draw / docGrid char-grid
     // invariant holds and the draw loop needs no per-segment font switching.
-    const emit = (word: string, slot: 'cs' | 'ea' | 'latin') => {
-      const cs = slot === 'cs';
-      const fontFamily = slot === 'cs' ? csFontFamily : slot === 'ea' ? eaFontFamily : base.fontFamily;
+    const pushSeg = (text: string, cs: boolean, fontFamily: string | null) => {
       segs.push({
-        text: word,
+        text,
         bold: cs ? csBold : base.bold,
         italic: cs ? csItalic : base.italic,
         underline: base.underline,
@@ -4156,6 +4156,29 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         digitsAsAN: digitsAsAN ? true : undefined,
       });
       firstSeg = false;
+    };
+    const emit = (word: string, slot: 'cs' | 'ea' | 'latin') => {
+      const cs = slot === 'cs';
+      const fontFamily = slot === 'cs' ? csFontFamily : slot === 'ea' ? eaFontFamily : base.fontFamily;
+      // ECMA-376 §17.3.2.26 + §17.3.3.30: a run whose rFonts axis is Symbol or
+      // Wingdings stores glyphs as the FONT's own (private) code points — Word
+      // commonly in the PUA (U+F020–U+F0FF). Those render as tofu in any
+      // fallback face, so normalize each character to its Unicode equivalent
+      // (core `symbolTextToUnicodeSegments`, the same table the list marker uses
+      // via `symbolFontToUnicode`). The string is split at mapped/unmapped
+      // boundaries: a MAPPED run is drawn in a generic fallback (fontFamily=null
+      // → sans tail with the dingbat glyphs; keeping the symbol family would let
+      // an installed Symbol/Wingdings re-interpret the Unicode code point as the
+      // WRONG glyph), while an UNMAPPED run keeps the symbol family so a host
+      // that ships Symbol/Wingdings still draws its native glyph. Done once at
+      // build time so measure==draw (the seg.text is never transformed later).
+      if (isSymbolFontFamily(fontFamily)) {
+        for (const part of symbolTextToUnicodeSegments(word, fontFamily)) {
+          pushSeg(part.text, cs, part.mapped ? null : fontFamily);
+        }
+        return;
+      }
+      pushSeg(word, cs, fontFamily);
     };
 
     // A non-complex-script slice still mixes scripts at the CJK boundary: emit


### PR DESCRIPTION
docx normalized Symbol/Wingdings PUA codepoints **only on list markers** (`markerDisplayText`), so a **body run** in Wingdings/Symbol with PUA text rendered as **tofu**, and **`<w:sym>`** (§17.3.3.30) was not parsed at all. pptx already normalizes both runs and bullets (review finding A1).

- **core**: `isSymbolFontFamily(family)` — single gate (exact `"symbol"` / any `"wingdings"`; **Webdings excluded** — no core table, documented). `symbolTextToUnicodeSegments(text, family)` — string companion to the single-char `symbolFontToUnicode`: iterates code points (astral targets survive) and returns maximal mapped/unmapped runs so each stays single-font.
- **docx renderer**: `buildSegments`' `emit` splits a symbol-font segment via `symbolTextToUnicodeSegments` — **mapped** pieces drop to the sans fallback chain (which carries the dingbat glyphs; keeping the symbol family would let an installed Symbol/Wingdings re-interpret the Unicode point as the wrong glyph), **unmapped** pieces keep the symbol family. Normalization is once at build, so **measure == draw** (same `seg.text`). Markers untouched (already correct → no double application).
- **docx parser**: `parse_run_inner` handles `<w:sym w:font w:char>` — decodes the hex char, resolves the font like rFonts, emits a one-glyph `TextRun` in document order. Malformed char emits nothing.
- Also removes a duplicated `cs_toggle` comment block in `styles::apply_run` (left by [#533](https://github.com/yokotani/office-open-xml-viewer/pull/533); flagged in its review).

## Verification
- cargo fmt/clippy clean, **130 cargo tests** (+4 `w:sym`); WASM rebuilt.
- **core vitest 18** (+7 for the two new helpers: gate, mapped/unmapped split, astral preservation, Webdings exclusion).
- Root `pnpm typecheck` clean (core touched).
- **docx VRT 21/21** no regression.
- Visual: a synthetic doc with Wingdings/Symbol body runs + inline `<w:sym>` renders `▪→✓●` / `•→` / `a▪b•c`, no tofu; sample-11 markers unchanged.

Webdings is out of scope (core lacks the table); `isSymbolFontFamily` returns false for it → passthrough rather than a wrong normalization. Review finding A1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)