### PR TITLE
refactor(pptx): route symbol-font gate through core isSymbolFontFamily

### DIFF
--- a/packages/core/src/fonts/symbol-font.ts
+++ b/packages/core/src/fonts/symbol-font.ts
@@ -186,13 +186,12 @@ export function symbolFontToUnicode(
  * encodings that {@link symbolFontToUnicode} knows how to normalize — currently
  * exactly "Symbol" and any "Wingdings" family (§17.3.2.26 / §21.1.2.3.10).
  *
- * Intended as the shared "is this a symbol font?" gate so callers don't
- * hand-roll divergent regexes. docx uses it; pptx still has its own broader
- * inline gate (`/wingding|webding|symbol/i`) and is a follow-up to migrate. It
- * deliberately does NOT match "Webdings" (core has no Webdings table yet — a
- * Webdings PUA point would pass the gate only to return unchanged) nor a Latin
- * face like "SymbolMT" (the "symbol" check is exact, not a substring), so a
- * caller wanting either must add it explicitly and accept passthrough.
+ * The shared "is this a symbol font?" gate, used by both docx and pptx so they
+ * don't hand-roll divergent regexes. It deliberately does NOT match "Webdings"
+ * (core has no Webdings table yet — a Webdings PUA point would pass the gate
+ * only to return unchanged) nor a Latin face like "SymbolMT" (the "symbol"
+ * check is exact, not a substring), so a caller wanting either must add it
+ * explicitly and accept passthrough.
  */
 export function isSymbolFontFamily(
   fontFamily: string | null | undefined,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -64,6 +64,7 @@ import {
   decodeRasterOrMetafile,
   highlightBox,
   symbolFontToUnicode,
+  isSymbolFontFamily,
   pptxDashArray,
 } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput } from '@silurus/ooxml-core';
@@ -907,7 +908,13 @@ export function layoutParagraph(
       // whether the symbol font is installed; fall back to the real symbol font
       // for unmapped glyphs.
       const SYMBOL_PUA_RE = /[-]/;
-      if (SYMBOL_PUA_RE.test(token) && (familySym || /wingding|webding|symbol/i.test(family))) {
+      // Gate on core's isSymbolFontFamily (exact "symbol" / any "wingdings";
+      // shared with docx). A familySym (a:sym, §21.1.2.3.10) explicitly names
+      // the run's symbol typeface, so its presence also opens the path.
+      // (Webdings / "SymbolMT" no longer match the family branch — both already
+      // passthrough unchanged since core gates "symbol" exactly and has no
+      // Webdings table, so this is behaviour-preserving.)
+      if (SYMBOL_PUA_RE.test(token) && (familySym != null || isSymbolFontFamily(family))) {
         const symName = familySym ?? family;
         for (const ch of token) {
           let drawCh = ch;


### PR DESCRIPTION
pptx gated its Symbol/Wingdings run normalization on a hand-rolled regex (`/wingding|webding|symbol/i`) while docx ([#534](https://github.com/yokotani/office-open-xml-viewer/pull/534)) uses core's `isSymbolFontFamily`. The two diverged: the regex is a **substring** match that also caught "Webdings" (no core table) and "SymbolMT" (a real Latin face).

The run path now gates on `isSymbolFontFamily(family)` (the explicit `a:sym` `familySym` still opens the path). **Behaviour-preserving**: a Webdings/SymbolMT run already passed through unchanged — core gates `"symbol"` exactly and has no Webdings table, so `symbolFontToUnicode` returned the char as-is and it drew in the same face. Dropping those from the family branch yields the identical visual. The per-char map + sans-fallback-on-hit loop is untouched.

`isSymbolFontFamily`'s docstring is updated: it's now the shared docx+pptx gate.

## Verification
- **pptx VRT 75/75 unchanged** (no reference regenerated, `references/` git-clean).
- docx VRT unaffected (comment-only core change); root `pnpm typecheck` clean.

Completes review finding A1 (the docstring's "single source of truth" is now true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)