### PR TITLE
fix(core): symbol-font — distinguish Wingdings 2/3, drop dead alias, restore pencil/scissors

### DIFF
--- a/packages/core/src/fonts/symbol-font.test.ts
+++ b/packages/core/src/fonts/symbol-font.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  SYMBOL_FONT_MAP,
   SYMBOL_MAP,
-  WINGDINGS_MAP,
   symbolFontToUnicode,
   isSymbolFontFamily,
   symbolTextToUnicodeSegments,
@@ -87,24 +85,44 @@ describe('symbolFontToUnicode', () => {
     expect(symbolFontToUnicode(ch(0x21), 'Symbol')).toBe(ch(0x21));
   });
 
-  it('matches "wingdings" case-insensitively and as a substring', () => {
+  it('matches exactly "wingdings" (case-insensitive, trimmed) for the Wingdings table', () => {
     expect(symbolFontToUnicode(ch(0xf0a7), 'WINGDINGS')).toBe('▪');
-    expect(symbolFontToUnicode(ch(0xf0a7), 'Wingdings 2')).toBe('▪');
+    expect(symbolFontToUnicode(ch(0xf0a7), '  Wingdings  ')).toBe('▪');
+  });
+
+  // Wingdings 2 / 3 and Webdings use DIFFERENT private encodings than Wingdings 1,
+  // so they must NOT be looked up in the Wingdings 1 table (WINGDINGS_MAP) — doing
+  // so produces a *wrong* glyph. They are unmapped (passthrough) so the real font
+  // draws the intended glyph if installed; better the bare PUA point than tofu of a
+  // wrong glyph.
+  it('does NOT map Wingdings 2 / Wingdings 3 / Webdings through the Wingdings 1 table', () => {
+    expect(symbolFontToUnicode(ch(0xa7), 'Wingdings 2')).toBe(ch(0xa7));
+    expect(symbolFontToUnicode(ch(0xf0a7), 'Wingdings 2')).toBe(ch(0xf0a7));
+    expect(symbolFontToUnicode(ch(0xa7), 'Wingdings 3')).toBe(ch(0xa7));
+    expect(symbolFontToUnicode(ch(0xa7), 'Webdings')).toBe(ch(0xa7));
+    // Wingdings 1 itself still resolves the same code point to the square bullet.
+    expect(symbolFontToUnicode(ch(0xa7), 'Wingdings')).toBe('▪');
   });
 
   // Pencil/scissors/faces are Wingdings glyphs only. In Symbol, 0x21 is "!" and
   // 0x22 is "∀" — so these dingbats must NOT leak across the font gate.
   it('keeps Wingdings dingbats out of the Symbol table', () => {
     expect(SYMBOL_MAP[0x21]).toBeUndefined();
+    expect(SYMBOL_MAP[0x22]).toBeUndefined();
     expect(SYMBOL_MAP[0x24]).toBeUndefined();
+    expect(symbolFontToUnicode(ch(0x21), 'Symbol')).toBe(ch(0x21));
+    expect(symbolFontToUnicode(ch(0x22), 'Symbol')).toBe(ch(0x22));
     expect(symbolFontToUnicode(ch(0x24), 'Symbol')).toBe(ch(0x24));
   });
 
-  // The deprecated shared alias still resolves Wingdings markers (it aliases the
-  // Wingdings table) so any legacy importer keeps working.
-  it('keeps the deprecated SYMBOL_FONT_MAP alias pointing at Wingdings', () => {
-    expect(SYMBOL_FONT_MAP).toBe(WINGDINGS_MAP);
-    expect(SYMBOL_FONT_MAP[0xa7]).toBe('▪');
+  // Wingdings 0x21 "pencil" → U+270F PENCIL, 0x22 "scissors" → U+2702 BLACK
+  // SCISSORS — both faithful BMP dingbats that render in ordinary fallback fonts.
+  // (bare + PUA-shifted form.)
+  it('maps the Wingdings pencil (0x21) and scissors (0x22) to BMP dingbats', () => {
+    expect(symbolFontToUnicode(ch(0x21), 'Wingdings')).toBe('✏');
+    expect(symbolFontToUnicode(ch(0xf021), 'Wingdings')).toBe('✏');
+    expect(symbolFontToUnicode(ch(0x22), 'Wingdings')).toBe('✂');
+    expect(symbolFontToUnicode(ch(0xf022), 'Wingdings')).toBe('✂');
   });
 });
 
@@ -146,12 +164,12 @@ describe('symbolTextToUnicodeSegments', () => {
   });
 
   it('splits at mapped/unmapped boundaries so each run is single-font', () => {
-    // 0x21 "!" has no Wingdings entry (passthrough), 0xF0A7 maps to ▪.
-    const segs = symbolTextToUnicodeSegments(ch(0x21) + ch(0xf0a7) + ch(0x22), 'Wingdings');
+    // 0x41 'A' / 0x42 'B' have no Wingdings entry (passthrough); 0xF0A7 maps to ▪.
+    const segs = symbolTextToUnicodeSegments(ch(0x41) + ch(0xf0a7) + ch(0x42), 'Wingdings');
     expect(segs).toEqual([
-      { text: ch(0x21), mapped: false },
+      { text: ch(0x41), mapped: false },
       { text: '▪', mapped: true },
-      { text: ch(0x22), mapped: false },
+      { text: ch(0x42), mapped: false },
     ]);
   });
 

--- a/packages/core/src/fonts/symbol-font.ts
+++ b/packages/core/src/fonts/symbol-font.ts
@@ -97,6 +97,16 @@ export const SYMBOL_MAP: Record<number, string> = {
  * U+1F55x) are OMITTED — passthrough, since the bare PUA point is no worse.
  */
 export const WINGDINGS_MAP: Record<number, string> = {
+  // 0x21 "pencil" → U+270F PENCIL; 0x22 "scissors" → U+2702 BLACK SCISSORS. Both
+  // are faithful BMP dingbats that render in any ordinary fallback font (unlike
+  // the Unicode-7.0 canonical unifications U+1F589 / U+2702, where the pencil is
+  // an astral PUA-adjacent glyph). The Dingbats ✏/✂ are the semantically exact
+  // glyphs, so this is a faithful substitution, not a guess.
+  // 0x23 is the SECOND Wingdings scissors variant ("scissorscutting"); its only
+  // distinct faithful target (U+2701/U+2703) is an obscure half-blade scissors
+  // that tofus in most fonts and is easily confused with 0x22, so it is left as
+  // passthrough rather than mapped to a near-duplicate ✂.
+  0x21: '✏', 0x22: '✂',
   // 0x24 "readingglasses" → U+1F453 EYEGLASSES. Astral with no BMP equivalent;
   // unlike the omitted clock/hand dingbats we DO map it because U+1F453 is the
   // semantically exact glyph — it renders in an emoji-capable fallback and is
@@ -125,16 +135,6 @@ export const WINGDINGS_MAP: Record<number, string> = {
   0xe3: '↖', 0xe4: '↗', 0xe5: '↙', 0xe6: '↘',
 };
 
-/**
- * Backwards-compatible alias. Historically a single `SYMBOL_FONT_MAP` was
- * exported; it leaned toward the Wingdings repertoire. New code should select
- * {@link SYMBOL_MAP} / {@link WINGDINGS_MAP} explicitly via
- * {@link symbolFontToUnicode}.
- *
- * @deprecated Use {@link symbolFontToUnicode} (it picks the right font table).
- */
-export const SYMBOL_FONT_MAP: Record<number, string> = WINGDINGS_MAP;
-
 /** Add the PUA-shifted (0xF000 + code) variant for every entry in `base`. */
 function withPua(base: Record<number, string>): Record<number, string> {
   const out: Record<number, string> = {};
@@ -152,14 +152,23 @@ const WINGDINGS_LOOKUP = withPua(WINGDINGS_MAP);
 /**
  * Normalize a single Symbol/Wingdings code point to its Unicode equivalent.
  *
- * The lookup table is chosen by `fontFamily`: an exact "symbol" selects the
- * Adobe Symbol encoding ({@link SYMBOL_MAP}); any family containing "wingdings"
- * selects the Wingdings cmap ({@link WINGDINGS_MAP}). Both the bare code point
- * (0xA7, 0xB7, …) and its PUA-shifted form (0xF0A7, 0xF0B7, …) resolve.
+ * The lookup table is chosen by `fontFamily` via a TRIMMED EXACT match (case-
+ * insensitive): exactly "symbol" selects the Adobe Symbol encoding
+ * ({@link SYMBOL_MAP}); exactly "wingdings" selects the Wingdings 1 cmap
+ * ({@link WINGDINGS_MAP}). Both the bare code point (0xA7, 0xB7, …) and its
+ * PUA-shifted form (0xF0A7, 0xF0B7, …) resolve.
  *
- * Returns `char` unchanged when `fontFamily` is null/undefined, is not a symbol
- * font, or has no mapping in the selected table (passthrough — better the bare
- * code point than a wrong glyph).
+ * "Wingdings 2", "Wingdings 3" and "Webdings" use DIFFERENT private encodings —
+ * the same code point is a different glyph than in Wingdings 1 — so they are
+ * deliberately NOT matched and pass through unchanged (we have no table for
+ * them). Routing them through the Wingdings 1 table would emit a *wrong* glyph;
+ * passthrough lets the real font draw the intended glyph when installed, and a
+ * bare PUA point is no worse than a wrong substitution. Add a dedicated table if
+ * those repertoires are ever needed.
+ *
+ * Returns `char` unchanged when `fontFamily` is null/undefined, is not one of the
+ * two mapped families, or has no mapping in the selected table (passthrough —
+ * better the bare code point than a wrong glyph).
  *
  * @param char       the marker/run character as stored in the OOXML (often a
  *                   PUA code point such as U+F0B7)
@@ -170,12 +179,13 @@ export function symbolFontToUnicode(
   fontFamily: string | null | undefined,
 ): string {
   if (!fontFamily) return char;
-  const lower = fontFamily.toLowerCase();
-  const table = lower.includes('wingdings')
-    ? WINGDINGS_LOOKUP
-    : lower === 'symbol'
-      ? SYMBOL_LOOKUP
-      : null;
+  const lower = fontFamily.trim().toLowerCase();
+  const table =
+    lower === 'wingdings'
+      ? WINGDINGS_LOOKUP
+      : lower === 'symbol'
+        ? SYMBOL_LOOKUP
+        : null;
   if (!table) return char;
   const code = char.charCodeAt(0);
   return table[code] ?? char;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,7 +55,6 @@ export {
   type FontVariant,
 } from './fonts/scripts';
 export {
-  SYMBOL_FONT_MAP,
   SYMBOL_MAP,
   WINGDINGS_MAP,
   symbolFontToUnicode,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1813,7 +1813,7 @@ export function resolveBulletLabel(
   if (para.bullet.type === 'char') {
     // Reset counters when switching to char bullets.
     autoNumCounters.clear();
-    return hasContent ? symbolFontToUnicode(para.bullet.char, para.bullet.fontFamily ?? '') : '';
+    return hasContent ? symbolFontToUnicode(para.bullet.char, para.bullet.fontFamily ?? null) : '';
   }
   if (para.bullet.type === 'autoNum') {
     if (!hasContent) return '';


### PR DESCRIPTION
## Summary

Tightens the Symbol/Wingdings font-encoding → Unicode normalization in `packages/core/src/fonts/symbol-font.ts`.

### S-7 — Wingdings 2/3 (and Webdings) were mis-glyphed
`symbolFontToUnicode` selected the **Wingdings 1** table for *any* family containing `"wingdings"` (`lower.includes('wingdings')`). "Wingdings 2" / "Wingdings 3" use **different private encodings**, so the same code point is a different glyph — routing them through the Wingdings 1 cmap produced a *wrong* glyph (e.g. `0xA7` → `▪`). Webdings similarly leaked through the gate.

Fix: table selection is now a **trimmed exact match** (case-insensitive): `"symbol"` → `SYMBOL_MAP`, `"wingdings"` → `WINGDINGS_MAP`. Wingdings 2/3 and Webdings pass through unchanged, so the real font draws the intended glyph when installed (a bare PUA point is no worse than a wrong substitution). `isSymbolFontFamily`'s gate is intentionally left unchanged (`Wingdings 2` still returns `true`) so the renderers still enter the symbol path and keep the native font for those runs.

### S-8 — dead `SYMBOL_FONT_MAP` alias removed
The deprecated `SYMBOL_FONT_MAP` (= `WINGDINGS_MAP`) export and its `core/index.ts` re-export are removed. `grep -rn SYMBOL_FONT_MAP packages/*/src` confirmed no docx/pptx/xlsx references — only core's own definition, re-export, and a unit test (all removed/updated).

### M-1 — restore pencil / scissors
Added `0x21 "pencil" → U+270F ✏` and `0x22 "scissors" → U+2702 ✂` to `WINGDINGS_MAP` — both faithful BMP dingbats that render in ordinary fallback fonts. `0x23` (the second Wingdings scissors variant) is left as **passthrough**: its only distinct faithful target (U+2701/U+2703) is an obscure half-blade scissors that tofus in most fonts and is easily confused with `0x22`, so mapping it would be a near-duplicate guess.

### NICE — argument unification
`pptx` `resolveBulletLabel` now passes `?? null` to `symbolFontToUnicode` (matching docx `renderer.ts`); behaviour-preserving since the function already accepts `string | null | undefined`.

## Verification
- `vitest` core suite: **385 passed** (symbol-font: 19, incl. new Red→Green cases for S-7 and M-1)
- `vitest` docx + pptx: **286 passed**
- root `tsc --build` (core/pptx/xlsx/docx project refs): **exit 0**; markdown / node / vscode-extension typecheck: **Done**
- `ast-grep scan`: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)