### PR TITLE
fix(docx): tblOverlap=never scopes to other floating tables only (§17.4.56)

### DIFF
--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -12,6 +12,13 @@
 
 /** Anchor image float that affects text wrap on the current page. */
 export interface FloatRect {
+  /** What kind of object reserved this float. Used to scope overlap avoidance:
+   *  ECMA-376 §17.4.56 (tblOverlap="never") only forbids a floating table from
+   *  overlapping OTHER FLOATING TABLES — not DrawingML anchors (§20.4.2.3) or
+   *  text frames. resolveFloatOverlap reads this to limit a never-overlap
+   *  table's blockers to kind==='table'. 'shape' = DrawingML wp:anchor shape,
+   *  'frame' = <w:framePr> text frame; both also cover anchor images. */
+  kind: 'table' | 'shape' | 'frame';
   mode: 'square' | 'topAndBottom';
   /** Hex key of the image bitmap (used to defer drawing until final Y is known). */
   imageKey: string;
@@ -224,13 +231,23 @@ export function resolveLineFloatWindow(
  * Multi-float collision resolution for a NEW wrap float, against floats already
  * registered on the page.
  *
- * What ECMA-376 actually mandates here is narrow. Part 1 §20.4.2.3
- * (wp:anchor/@allowOverlap) says an object that "cannot overlap other DrawingML
- * object … shall be repositioned when displayed to prevent this overlap" — i.e.
- * allowOverlap="false" REQUIRES repositioning. allowOverlap="true" (the default
- * when omitted, §20.4.2.3) only *permits* overlap; the spec is silent on whether
- * a renderer may avoid it. So:
- *   - allowOverlap === false → spec-mandated avoidance of ALL other floats.
+ * What ECMA-376 actually mandates here is narrow, and the mandate differs by
+ * what kind of object forbids overlap:
+ *   - A DrawingML anchor with @allowOverlap="false" (Part 1 §20.4.2.3): an
+ *     object that "cannot overlap other DrawingML object … shall be
+ *     repositioned when displayed to prevent this overlap" — i.e. it must avoid
+ *     OTHER DRAWINGML OBJECTS. (We never pass allowOverlap=false for shapes/
+ *     images today; the default is "true", which only *permits* overlap.)
+ *   - A floating table with <w:tblOverlap w:val="never"/> (§17.4.56): the table
+ *     "cannot overlap with OTHER FLOATING TABLES in the document." It does NOT
+ *     mandate avoiding DrawingML anchors (§20.4.2.3) or text frames — those keep
+ *     their own §20.4.2.3 behavior. So a never-overlap table must only avoid
+ *     blockers with kind==='table'.
+ * allowOverlap="true"/omitted (the default, §20.4.2.3 / §17.4.56) only *permits*
+ * overlap; the spec is silent on whether a renderer may avoid it. So:
+ *   - allowOverlap === false → spec-mandated avoidance. Scoped by `kind`: a
+ *     table avoids only other tables (§17.4.56); any other kind would avoid all
+ *     (§20.4.2.3) — not currently exercised, see above.
  *   - allowOverlap === true  → implementation-defined avoidance of floats
  *     anchored in OTHER paragraphs only.
  *
@@ -261,16 +278,23 @@ export function resolveFloatOverlap(
   x: number, y: number, w: number, h: number,
   dl: number, dr: number, dt: number, db: number,
   paraId: number, allowOverlap: boolean,
+  kind: FloatRect['kind'],
   pageRight: number, floats: FloatRect[],
 ): { x: number; y: number } {
   for (let guard = 0; guard < 16; guard++) {
     const exL = x - dl, exR = x + w + dr, exT = y - dt, exB = y + h + db;
-    // Blocking floats whose exclusion rects intersect ours. When the moving
-    // float forbids overlap (§20.4.2.3 allowOverlap="false") EVERY intersecting
-    // float blocks; otherwise only floats from OTHER paragraphs block (Word
-    // de-facto cross-paragraph avoidance).
+    // Which already-registered floats block the moving float:
+    //   - allowOverlap === false (spec-mandated avoidance): scope by the moving
+    //     float's kind. A floating table with tblOverlap="never" (§17.4.56) may
+    //     only overlap-avoid OTHER FLOATING TABLES, so it blocks on kind==='table'
+    //     alone; DrawingML anchors / frames keep their own §20.4.2.3 placement.
+    //     Any other kind would avoid all intersecting floats (§20.4.2.3), but no
+    //     caller passes allowOverlap=false for non-tables today.
+    //   - allowOverlap === true (Word de-facto cross-paragraph avoidance): only
+    //     floats anchored in OTHER paragraphs block, regardless of kind.
     const blockers = floats.filter(
-      (f) => (allowOverlap ? f.paraId !== paraId : true) &&
+      (f) =>
+        (allowOverlap ? f.paraId !== paraId : kind !== 'table' || f.kind === 'table') &&
         rectsOverlap(exL, exR, exT, exB, f.xLeft, f.xRight, f.yTop, f.yBottom),
     );
     if (blockers.length === 0) return { x, y };

--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -196,12 +196,12 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
     expect(st.floats).toHaveLength(0);
   });
 
-  it('overlap="never" (allowOverlap=false) re-seats the new float off a blocker', () => {
-    // Pre-seat a blocking float [0,200]×[300,360] from another paragraph.
+  it('overlap="never" (allowOverlap=false) re-seats the new float off another table', () => {
+    // Pre-seat a blocking FLOATING TABLE [0,200]×[300,360] from another paragraph.
     const st = makeState({
       floatParaSeq: 1,
       floats: [{
-        mode: 'square', imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
+        kind: 'table', mode: 'square', imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
         xLeft: 0, xRight: 200, yTop: 300, yBottom: 360, side: 'bothSides',
         distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0, drawn: true,
       }],
@@ -213,6 +213,50 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
     const f = st.floats[st.floats.length - 1];
     // resolveFloatOverlap re-seats it to the right of the blocker's right edge.
     expect(f.xLeft).toBeGreaterThanOrEqual(200);
+  });
+
+  // §17.4.56 scope: a floating table with <w:tblOverlap w:val="never"/> must
+  // only avoid OTHER FLOATING TABLES. DrawingML anchors (§20.4.2.3) and text
+  // frames keep their own placement — a never-overlap table does NOT re-seat off
+  // them. These pin that scoping via FloatRect.kind.
+  describe('overlap="never" scopes to other floating tables only (§17.4.56)', () => {
+    // A blocker occupying [0,200]×[300,360], anchored in another paragraph,
+    // parameterized by kind so we can assert table-vs-non-table behavior.
+    const blocker = (kind: FloatRect['kind']): FloatRect => ({
+      kind, mode: 'square', imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
+      xLeft: 0, xRight: 200, yTop: 300, yBottom: 360, side: 'bothSides',
+      distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0, drawn: true,
+    });
+    // A never-overlap floating table seated at page-left x=0, overlapping [0,200].
+    const seatNeverTable = (blockers: FloatRect[]): FloatRect => {
+      const st = makeState({ floatParaSeq: 1, floats: blockers });
+      const tp = tblp({ horzAnchor: 'page', tblpX: 0, vertAnchor: 'page', tblpY: 320 });
+      const b = box(tp, st, 0, 100, 20); // box at (0,320), overlaps [0,200]
+      registerFloat(b, tp, st, 'right', /* allowOverlap (never) */ false);
+      return st.floats[st.floats.length - 1];
+    };
+
+    it('does NOT re-seat off a DrawingML shape/image float (stays at x=0)', () => {
+      const f = seatNeverTable([blocker('shape')]);
+      expect(f.xLeft).toBe(0); // overlap permitted: §17.4.56 ignores non-tables
+    });
+
+    it('does NOT re-seat off a text-frame float (stays at x=0)', () => {
+      const f = seatNeverTable([blocker('frame')]);
+      expect(f.xLeft).toBe(0);
+    });
+
+    it('DOES re-seat off another floating-table float', () => {
+      const f = seatNeverTable([blocker('table')]);
+      expect(f.xLeft).toBeGreaterThanOrEqual(200); // avoids the other table
+    });
+
+    it('avoids only the table blocker when a shape and a table both overlap', () => {
+      // shape at [0,200], table at [0,200] (same band, different paragraphs):
+      // the table re-seats past the TABLE's right edge, ignoring the shape.
+      const f = seatNeverTable([blocker('shape'), blocker('table')]);
+      expect(f.xLeft).toBeGreaterThanOrEqual(200);
+    });
   });
 });
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2955,6 +2955,9 @@ interface PushFloatOpts {
   dr: number;
   dt: number;
   db: number;
+  /** What reserved this float — scopes overlap avoidance (§17.4.56). See
+   *  {@link FloatRect.kind}. */
+  kind: FloatRect['kind'];
   mode: 'square' | 'topAndBottom';
   side: string;
   imageKey: string;
@@ -2964,8 +2967,9 @@ interface PushFloatOpts {
    *  false (frame floats) the box is used as-is. */
   avoidOverlap: boolean;
   /** allowOverlap arg passed to resolveFloatOverlap when avoidOverlap is true
-   *  (true ⇒ only avoid OTHER paragraphs' floats; false ⇒ avoid ALL). Ignored
-   *  when avoidOverlap is false. */
+   *  (true ⇒ only avoid OTHER paragraphs' floats; false ⇒ spec-mandated
+   *  avoidance, scoped by `kind`: a table avoids only other tables, §17.4.56).
+   *  Ignored when avoidOverlap is false. */
   allowOverlap?: boolean;
 }
 
@@ -2984,12 +2988,13 @@ function pushFloatRect(state: RenderState, o: PushFloatOpts): FloatRect {
   if (o.avoidOverlap) {
     const resolved = resolveFloatOverlap(
       px, py, o.w, o.h, o.dl, o.dr, o.dt, o.db, o.paraId, o.allowOverlap ?? true,
-      state.pageWidth * state.scale, state.floats,
+      o.kind, state.pageWidth * state.scale, state.floats,
     );
     px = resolved.x;
     py = resolved.y;
   }
   const rect: FloatRect = {
+    kind: o.kind,
     mode: o.mode,
     imageKey: o.imageKey,
     imageX: px,
@@ -3049,6 +3054,7 @@ export function registerFrameFloat(box: FrameBox, fp: FramePr, state: RenderStat
     dr: box.exRight - (box.x + box.w),
     dt: box.y - box.exTop,
     db: box.exBottom - (box.y + box.h),
+    kind: 'frame',
     mode,
     // A drop cap sits at the column's left edge, so text wraps only to its
     // RIGHT. A generic frame may sit anywhere, so text wraps on both sides
@@ -3155,14 +3161,18 @@ export function registerTableFloat(
 
   // §17.4.56: resolve overlap against already-registered page floats before
   // fixing the exclusion rect. allowOverlap=false (tblOverlap="never") forces
-  // avoidance of ALL floats; allowOverlap=true only avoids OTHER paragraphs'
-  // floats (the implementation-defined scope documented on resolveFloatOverlap).
+  // avoidance of OTHER FLOATING TABLES only — §17.4.56 scopes "never" to other
+  // floating tables, NOT DrawingML anchors (§20.4.2.3) or text frames. The
+  // kind==='table' tag below makes resolveFloatOverlap limit blockers to tables.
+  // allowOverlap=true only avoids OTHER paragraphs' floats (the implementation-
+  // defined scope documented on resolveFloatOverlap).
   pushFloatRect(state, {
     x: box.x,
     y: box.y,
     w: box.w,
     h: box.h,
     dl, dr, dt, db,
+    kind: 'table',
     mode: 'square',
     side,
     imageKey: '', // non-image float: the table is painted by renderFloatTable.
@@ -5880,6 +5890,7 @@ function registerImageFloat(
     x: box.x,
     y: box.y,
     w, h, dl, dr, dt, db,
+    kind: 'shape', // DrawingML anchor (§20.4.2.3); not a floating table.
     mode,
     side: img.wrapSide ?? 'bothSides',
     imageKey: key,
@@ -5933,6 +5944,7 @@ function registerShapeFloat(
   // here — but running it keeps multi-float behavior identical to images.
   pushFloatRect(state, {
     x, y, w, h, dl, dr, dt, db,
+    kind: 'shape', // DrawingML wp:anchor shape (§20.4.2.3); not a floating table.
     mode,
     side: shape.wrapSide ?? 'bothSides',
     imageKey: '',


### PR DESCRIPTION
## Problem

`registerTableFloat` passed `allowOverlap = (tbl.overlap !== 'never')` to `resolveFloatOverlap`. With `allowOverlap=false` (i.e. `<w:tblOverlap w:val="never"/>`), the resolver treated **every** intersecting float as a blocker — DrawingML images/shapes (§20.4.2.3) and text frames included — and re-seated the table off all of them.

## Spec basis (ECMA-376 §17.4.56)

> "This element specifies whether the current table shall allow **other floating tables** to overlap its extents… The `tblOverlap` element with a value of `never` specifies that the specified table cannot overlap with **other floating tables** in the document."

`tblOverlap="never"` is scoped to **other floating tables only**. It does not mandate avoiding DrawingML anchors (§20.4.2.3) or `<w:framePr>` text frames; those keep their own placement.

## Change

- Add a `kind: 'table' | 'shape' | 'frame'` discriminator to `FloatRect` (`float-layout.ts`). Each `register*Float` site sets it: table → `'table'`, frame → `'frame'`, anchor image / wp:anchor shape → `'shape'`.
- `resolveFloatOverlap` now takes the moving float's `kind`. When `allowOverlap === false` (spec-mandated avoidance), a `kind==='table'` mover blocks **only** on `kind==='table'` floats. The `allowOverlap === true` cross-paragraph heuristic and all shape/frame §20.4.2.3 behavior are unchanged.
- Fix the misleading comment in `registerTableFloat` (was "forces avoidance of ALL floats") to reflect the §17.4.56 scope.

## Tests (TDD)

Added a `§17.4.56 scoping` describe block to `float-table-geometry.test.ts`:
- never-overlap table does **not** re-seat off a `shape` float (stays at `x=0`)
- never-overlap table does **not** re-seat off a `frame` float (stays at `x=0`)
- never-overlap table **does** re-seat off another `table` float
- with a `shape` + `table` both overlapping, the table avoids only the table

Verified Red (2 failing) against the pre-fix filter, then Green after the fix. The pre-existing `overlap="never" … re-seats` test now tags its blocker as `kind:'table'` to stay meaningful.

## Verification

- docx vitest: 189 unit tests pass (185 → 189; +4 new), 0 regressions. (The 2 `tests/visual/*.spec.ts` "failures" are pre-existing — vitest globs Playwright VRT specs it can't run; identical on the clean base.)
- `tsc --build`: docx surface typechecks clean (remaining `Cannot find module './wasm/*_parser.js'` errors are gitignored WASM artifacts not built in the worktree, identical on the clean base).
- VRT not run (local-only); behavior changes only the rare never-overlap-table + mixed-float case, no VRT reference impact expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)