### PR TITLE
fix(docx): table-style §number citations + band-size + nwCell-less precedence test

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1960,9 +1960,11 @@ fn parse_run_inner(
     let rpr_node = child_w(node, "rPr");
     let mut fmt = base_run.clone();
 
-    // Apply rStyle. ECMA-376 §17.7.5: character styles overlay on top of the
-    // paragraph's run formatting; they must not re-introduce docDefaults or
-    // the default paragraph style — those are already baked into base_run.
+    // Apply rStyle (§17.3.2.29). ECMA-376 §17.7.2 (Style Hierarchy) applies
+    // character styles ON TOP of the paragraph's run formatting (Document
+    // defaults < Table < Numbering < Paragraph < Character < Direct); they must
+    // not re-introduce docDefaults or the default paragraph style — those are
+    // already baked into base_run.
     if let Some(rpr) = rpr_node {
         if let Some(rs) = child_w(rpr, "rStyle").and_then(|n| attr_w(n, "val")) {
             let style_run = style_map.resolve_run_style(&rs);
@@ -1994,7 +1996,7 @@ fn parse_run_inner(
     // ECMA-376 §17.16.22 (<w:hyperlink>) defines link *structure* only — the
     // r:id / w:anchor targets and click behaviour. It carries no visual styling.
     // A link's blue/underline appearance comes entirely from the run's character
-    // style (typically `rStyle="Hyperlink"`, §17.7.5) plus any direct rPr, which
+    // style (typically `rStyle="Hyperlink"`, §17.3.2.29) plus any direct rPr, which
     // are already resolved into `fmt` above. So both external (URL) and internal
     // (anchor: TOC entries, cross-references) links honour the resolved `fmt`
     // identically; we do not strip styling from internal links nor synthesize
@@ -4208,6 +4210,11 @@ fn parse_table(
     // noHBand/noVBand SUPPRESS banding ⇒ banding active = NOT no*Band.
     let h_band = !look_flag("noHBand", 0x0200);
     let v_band = !look_flag("noVBand", 0x0400);
+    // ECMA-376 §17.7.6.7 / §17.7.6.5: rows/columns per band (default 1). With a
+    // band size of N, band1/band2 alternate every N rows/columns rather than
+    // every single one (e.g. size 3 ⇒ band1Horz on rows 1-3, band2Horz on 4-6).
+    let row_band = tstyle.row_band_size.unwrap_or(1);
+    let col_band = tstyle.col_band_size.unwrap_or(1);
 
     // Table borders: inline tblBorders win; otherwise the table style's borders
     // (so styles like "Table Grid" show their gridlines).
@@ -4310,7 +4317,9 @@ fn parse_table(
             } else {
                 r as i64
             };
-            out.push(if bi % 2 == 0 {
+            // §17.7.6.7: group consecutive `row_band` body rows into one band
+            // before alternating band1/band2.
+            out.push(if (bi / row_band as i64) % 2 == 0 {
                 "band1Horz"
             } else {
                 "band2Horz"
@@ -4352,7 +4361,9 @@ fn parse_table(
             // conditional paints nothing yet still shifts vertical banding), gate
             // this on a `first_col_styled` (shd) predicate to match the row side.
             let bi = if first_col { c as i64 - 1 } else { c as i64 };
-            out.push(if bi % 2 == 0 {
+            // §17.7.6.5: group consecutive `col_band` body columns into one band
+            // before alternating band1/band2.
+            out.push(if (bi / col_band as i64) % 2 == 0 {
                 "band1Vert"
             } else {
                 "band2Vert"
@@ -8278,6 +8289,164 @@ mod numbering_marker_font_tests {
         assert_eq!(
             cell_text_color(&t.rows[0].cells[1]).as_deref(),
             Some("bbb222")
+        );
+    }
+
+    // §17.7.6.5 tblStyleColBandSize: a band size >1 groups consecutive columns
+    // into a single vertical band before alternating band1/band2. With
+    // colBandSize=2, columns 0-1 are band1Vert and columns 2-3 are band2Vert
+    // (per the spec example: "band1Vert applied to columns 1 and 2, 5 and 6").
+    // noHBand isolates the vertical axis.
+    #[test]
+    fn vertical_band_size_groups_two_columns() {
+        let styles = StyleMap::parse(&format!(
+            r#"<w:styles xmlns:w="{ns}">
+                <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:rPr/></w:style>
+                <w:style w:type="table" w:styleId="VB2">
+                    <w:tblPr><w:tblStyleColBandSize w:val="2"/></w:tblPr>
+                    <w:tblStylePr w:type="band1Vert"><w:rPr><w:color w:val="aaa111"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="band2Vert"><w:rPr><w:color w:val="bbb222"/></w:rPr></w:tblStylePr>
+                </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        ));
+        // tblLook 0200 = noHBand only; vertical banding stays on by default.
+        let t = parse_tbl_styled(
+            r#"<w:tblPr><w:tblStyle w:val="VB2"/>
+                 <w:tblLook w:val="0200"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="1000"/><w:gridCol w:w="1000"/><w:gridCol w:w="1000"/><w:gridCol w:w="1000"/></w:tblGrid>
+               <w:tr>
+                 <w:tc><w:p><w:r><w:t>C0</w:t></w:r></w:p></w:tc>
+                 <w:tc><w:p><w:r><w:t>C1</w:t></w:r></w:p></w:tc>
+                 <w:tc><w:p><w:r><w:t>C2</w:t></w:r></w:p></w:tc>
+                 <w:tc><w:p><w:r><w:t>C3</w:t></w:r></w:p></w:tc>
+               </w:tr>"#,
+            &styles,
+        );
+        // Columns 0,1 → band1Vert; columns 2,3 → band2Vert.
+        assert_eq!(
+            cell_text_color(&t.rows[0].cells[0]).as_deref(),
+            Some("aaa111"),
+            "col 0 in band1"
+        );
+        assert_eq!(
+            cell_text_color(&t.rows[0].cells[1]).as_deref(),
+            Some("aaa111"),
+            "col 1 in band1"
+        );
+        assert_eq!(
+            cell_text_color(&t.rows[0].cells[2]).as_deref(),
+            Some("bbb222"),
+            "col 2 in band2"
+        );
+        assert_eq!(
+            cell_text_color(&t.rows[0].cells[3]).as_deref(),
+            Some("bbb222"),
+            "col 3 in band2"
+        );
+    }
+
+    // §17.7.6.7 tblStyleRowBandSize: a band size >1 groups consecutive rows into
+    // a single horizontal band before alternating band1/band2. With
+    // rowBandSize=2, rows 0-1 are band1Horz and rows 2-3 are band2Horz. noVBand
+    // isolates the horizontal axis.
+    #[test]
+    fn horizontal_band_size_groups_two_rows() {
+        let styles = StyleMap::parse(&format!(
+            r#"<w:styles xmlns:w="{ns}">
+                <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:rPr/></w:style>
+                <w:style w:type="table" w:styleId="HB2">
+                    <w:tblPr><w:tblStyleRowBandSize w:val="2"/></w:tblPr>
+                    <w:tblStylePr w:type="band1Horz"><w:rPr><w:color w:val="111aaa"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="band2Horz"><w:rPr><w:color w:val="222bbb"/></w:rPr></w:tblStylePr>
+                </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        ));
+        // tblLook 0400 = noVBand only; horizontal banding stays on by default.
+        let t = parse_tbl_styled(
+            r#"<w:tblPr><w:tblStyle w:val="HB2"/>
+                 <w:tblLook w:val="0400"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+               <w:tr><w:tc><w:p><w:r><w:t>R0</w:t></w:r></w:p></w:tc></w:tr>
+               <w:tr><w:tc><w:p><w:r><w:t>R1</w:t></w:r></w:p></w:tc></w:tr>
+               <w:tr><w:tc><w:p><w:r><w:t>R2</w:t></w:r></w:p></w:tc></w:tr>
+               <w:tr><w:tc><w:p><w:r><w:t>R3</w:t></w:r></w:p></w:tc></w:tr>"#,
+            &styles,
+        );
+        // Rows 0,1 → band1Horz; rows 2,3 → band2Horz.
+        assert_eq!(
+            cell_text_color(&t.rows[0].cells[0]).as_deref(),
+            Some("111aaa"),
+            "row 0 in band1"
+        );
+        assert_eq!(
+            cell_text_color(&t.rows[1].cells[0]).as_deref(),
+            Some("111aaa"),
+            "row 1 in band1"
+        );
+        assert_eq!(
+            cell_text_color(&t.rows[2].cells[0]).as_deref(),
+            Some("222bbb"),
+            "row 2 in band2"
+        );
+        assert_eq!(
+            cell_text_color(&t.rows[3].cells[0]).as_deref(),
+            Some("222bbb"),
+            "row 3 in band2"
+        );
+    }
+
+    // D-3 (V-1: Word real-app behavior NOT adjudicated). A 2x2 table whose style
+    // defines firstRow and firstCol in DIFFERENT colors but NO nwCell, with
+    // tblLook firstRow=1 firstColumn=1. The top-left cell is BOTH firstRow and
+    // firstCol; with no nwCell to break the tie, the resolved color reflects the
+    // CURRENT cell_cond layer order (firstRow then firstCol → firstCol wins).
+    // If Word is later confirmed to prefer firstRow here, swap the firstCol/
+    // firstRow ordering in cell_cond's `keys.extend` and update this expected
+    // value. corner_nwcell_overrides_row_and_col already covers the nwCell case.
+    #[test]
+    fn corner_without_nwcell_uses_firstcol_then_firstrow_order() {
+        let styles = StyleMap::parse(&format!(
+            r#"<w:styles xmlns:w="{ns}">
+                <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:rPr/></w:style>
+                <w:style w:type="table" w:styleId="NoCnr">
+                    <w:tblStylePr w:type="firstRow"><w:rPr><w:color w:val="111111"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="firstCol"><w:rPr><w:color w:val="222222"/></w:rPr></w:tblStylePr>
+                </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        ));
+        let t = parse_tbl_styled(
+            r#"<w:tblPr><w:tblStyle w:val="NoCnr"/>
+                 <w:tblLook w:firstRow="1" w:firstColumn="1"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/></w:tblGrid>
+               <w:tr>
+                 <w:tc><w:p><w:r><w:t>NW</w:t></w:r></w:p></w:tc>
+                 <w:tc><w:p><w:r><w:t>NE</w:t></w:r></w:p></w:tc>
+               </w:tr>
+               <w:tr>
+                 <w:tc><w:p><w:r><w:t>SW</w:t></w:r></w:p></w:tc>
+                 <w:tc><w:p><w:r><w:t>SE</w:t></w:r></w:p></w:tc>
+               </w:tr>"#,
+            &styles,
+        );
+        // Top-left (firstRow ∩ firstCol, no nwCell): firstCol layered last → wins.
+        assert_eq!(
+            cell_text_color(&t.rows[0].cells[0]).as_deref(),
+            Some("222222"),
+            "NW = firstCol color (current layer order; V-1 unadjudicated)"
+        );
+        // Sanity anchors: NE is firstRow-only, SW is firstCol-only.
+        assert_eq!(
+            cell_text_color(&t.rows[0].cells[1]).as_deref(),
+            Some("111111"),
+            "NE = firstRow"
+        );
+        assert_eq!(
+            cell_text_color(&t.rows[1].cells[0]).as_deref(),
+            Some("222222"),
+            "SW = firstCol"
         );
     }
 

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -231,6 +231,17 @@ pub struct TableStyleDef {
     /// `StyleMap::styles`; this field carries the table style's pPr for the
     /// conditional-formatting resolution path used by `resolve_table_cond`.
     pub para: Option<ParaFmt>,
+    /// ECMA-376 §17.7.6.7 `<w:tblStyleRowBandSize>`: number of rows per
+    /// horizontal band (band1Horz/band2Horz alternate every N rows). `None`
+    /// means the element was omitted; callers treat that as the spec default 1.
+    /// Kept as `Option` so a derived style that omits it inherits the base
+    /// style's value through `resolve_table_style` instead of resetting to 1.
+    pub row_band_size: Option<usize>,
+    /// ECMA-376 §17.7.6.5 `<w:tblStyleColBandSize>`: number of columns per
+    /// vertical band (band1Vert/band2Vert alternate every N columns). `None` =
+    /// omitted; callers treat that as the spec default 1. See `row_band_size`
+    /// for why this is an `Option`.
+    pub col_band_size: Option<usize>,
     /// keyed by w:tblStylePr w:type (firstRow, band1Horz, band2Horz, …).
     pub cond: HashMap<String, CondFmt>,
 }
@@ -377,6 +388,14 @@ impl StyleMap {
             if def.cell_valign.is_some() {
                 out.cell_valign = def.cell_valign.clone();
             }
+            // §17.7.6.5 / §17.7.6.7: band widths inherit through basedOn — a
+            // derived style that omits them (None) keeps the base value.
+            if def.row_band_size.is_some() {
+                out.row_band_size = def.row_band_size;
+            }
+            if def.col_band_size.is_some() {
+                out.col_band_size = def.col_band_size;
+            }
             // §17.7.6: a derived table style's whole-table rPr/pPr layers ON TOP
             // of the base style's. We fold each level into a single accumulated
             // RunFmt/ParaFmt with the standard merge semantics (later wins).
@@ -487,10 +506,11 @@ impl StyleMap {
         }
     }
 
-    /// Resolve a character style (rStyle) chain WITHOUT prepending docDefaults
-    /// or the default paragraph style. ECMA-376 §17.7.5: rStyle layers ON TOP
-    /// of the paragraph's already-resolved run formatting — pulling docDefaults
-    /// in here would overwrite values the paragraph style legitimately set
+    /// Resolve a character style (rStyle, §17.3.2.29) chain WITHOUT prepending
+    /// docDefaults or the default paragraph style. ECMA-376 §17.7.2 (Style
+    /// Hierarchy) layers character styles ON TOP of the paragraph's
+    /// already-resolved run formatting — pulling docDefaults in here would
+    /// overwrite values the paragraph style legitimately set
     /// (e.g. Normal's Meiryo UI 9pt being clobbered by docDefault Calibri 11pt
     /// for a run that only says `<w:rStyle w:val="PlaceholderText"/>`).
     pub fn resolve_run_style(&self, style_id: &str) -> RunFmt {
@@ -1160,6 +1180,18 @@ fn parse_tbl_style_def(style_node: roxmltree::Node, based_on: Option<String>) ->
         if let Some(borders) = child_w(tbl_pr, "tblBorders") {
             def.borders = parse_raw_tbl_borders(borders);
         }
+        // ECMA-376 §17.7.6.7 / §17.7.6.5: row/column band widths. A value of 0
+        // would make banding ill-defined (division by zero in the parity walk),
+        // so clamp to at least 1. Stored as Some(..) only when present so an
+        // omitting derived style inherits the base via resolve_table_style.
+        def.row_band_size = child_w(tbl_pr, "tblStyleRowBandSize")
+            .and_then(|n| attr_w(n, "val"))
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|n| n.max(1));
+        def.col_band_size = child_w(tbl_pr, "tblStyleColBandSize")
+            .and_then(|n| attr_w(n, "val"))
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|n| n.max(1));
     }
     if let Some(tc_pr) = child_w(style_node, "tcPr") {
         def.cell_shd = shd_fill(tc_pr);


### PR DESCRIPTION
## Summary

Three small, spec-faithful follow-ups in `packages/docx/parser/src` (Rust only — no TS/wasm contract change). All citations verified against ECMA-376 Part 1 (5th ed.).

### S-5 — correct §number citations (comment-only, behavior unchanged)
`parser.rs` (rStyle apply ~L1963, hyperlink-styling comment ~L1997) and `styles.rs` (`resolve_run_style` doc ~L491) cited **§17.7.5** for character-style layering, but §17.7.5 is **Document Defaults**. Verified in the spec and corrected:
- Application/layering order → **§17.7.2 (Style Hierarchy)** (table: "Next, run properties are applied to each run with a specific character style applied. Finally, … direct formatting").
- The rStyle element itself → **§17.3.2.29 (rStyle, Referenced Character Style)** (hierarchy list places "Character styles (this element)" between Paragraph styles and Direct Formatting).

### S-6 — honor band sizes
- Parse `<w:tblStyleRowBandSize>` (**§17.7.6.7**) and `<w:tblStyleColBandSize>` (**§17.7.6.5**) from `<w:tblPr>` in `parse_tbl_style_def`, storing them on `TableStyleDef` as `Option<usize>` (omitted ⇒ spec default 1; `Option` so a derived style that omits them inherits the base value through `resolve_table_style`'s basedOn merge). Values clamped to ≥1.
- Generalize the horizontal/vertical banding parity from `bi % 2` to `(bi / band_size) % 2` in `parse_table`, so a band size N groups N consecutive body rows/columns into one band before alternating band1/band2 (spec example: rowBandSize 3 ⇒ band1Horz on rows 1-3, band2Horz on 4-6).
- Added `#[test] vertical_band_size_groups_two_columns` and `horizontal_band_size_groups_two_rows` (band size 2).
- **V-2 untouched:** the `first_row_styled` (shading) / `first_col` banding-offset gates are left exactly as-is — only the parity divisor changed. Confirmed no gate lines appear in the diff.

### D-3 — nwCell-less corner precedence test
Added `#[test] corner_without_nwcell_uses_firstcol_then_firstrow_order`: a 2x2 table whose style defines firstRow and firstCol in **different** colors but **no nwCell** (tblLook firstRow=1 firstColumn=1). Asserts the **current** `cell_cond` layer order (firstCol layered last → wins the top-left tie) plus firstRow-only / firstCol-only anchors.
- **V-1 (Word real-app behavior NOT adjudicated):** comment documents that if Word is later confirmed to prefer firstRow here, swap the firstCol/firstRow ordering in `cell_cond`'s `keys.extend` and update the expected value. Existing `corner_nwcell_overrides_row_and_col` already covers the nwCell-present case.

## Verification
`cd packages/docx/parser`:
- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (no warnings)
- `cargo test` — **133 passed, 0 failed** (includes the 3 new tests)

VRT not run — VRT is local-only (CI does not run it; the new band-size path is internal parser state with no committed reference coverage). No TS/wasm changes: `TableStyleDef` is an internal parsing struct with no `Serialize` derive, so the JSON contract is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)