### PR TITLE
fix(docx): picture-bullet default size + symbol/picture bullet render tests

### DIFF
--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -74,11 +74,15 @@ pub struct PicBullet {
     pub image_path: String,
     /// MIME type derived from the part extension (e.g. `image/gif`).
     pub mime_type: String,
-    /// Marker width in pt, from the `<v:shape style="width:..">` (default 9pt
-    /// when the style omits a width — the common Word default for bullet shapes).
-    pub width_pt: f64,
-    /// Marker height in pt, from the `<v:shape style="height:..">`.
-    pub height_pt: f64,
+    /// Marker width in pt, from the `<v:shape style="width:..">`. `None` when the
+    /// shape style omits a width — ECMA-376 §17.9.20 derives the picture-bullet
+    /// size from the drawing's own extent and defines no fallback dimension, so we
+    /// surface the absence and let the renderer fall back to the resolved marker
+    /// font size (its single source of truth) rather than inventing a magic pt.
+    pub width_pt: Option<f64>,
+    /// Marker height in pt, from the `<v:shape style="height:..">`. `None` ⇒ see
+    /// {@link PicBullet::width_pt}.
+    pub height_pt: Option<f64>,
 }
 
 impl Default for LevelDef {
@@ -151,16 +155,17 @@ impl NumberingMap {
             let Some(image_path) = media_map.get(rid).cloned() else {
                 continue;
             };
-            // `<v:shape style="width:9pt;height:9pt">` — VML CSS lengths. Word
-            // always emits explicit pt for bullet shapes; default to 9pt (Word's
-            // standard picture-bullet size) when a dimension is absent.
+            // `<v:shape style="width:9pt;height:9pt">` — VML CSS lengths. The
+            // dimension is left as `None` when the style omits it: §17.9.20 has no
+            // default picture-bullet size, so the renderer (not the parser)
+            // resolves the absence against the marker font size.
             let shape_style = pb_node
                 .descendants()
                 .find(|n| n.tag_name().name() == "shape")
                 .and_then(|n| n.attribute("style"))
                 .unwrap_or("");
-            let width_pt = vml_style_len(shape_style, "width").unwrap_or(9.0);
-            let height_pt = vml_style_len(shape_style, "height").unwrap_or(9.0);
+            let width_pt = vml_style_len(shape_style, "width");
+            let height_pt = vml_style_len(shape_style, "height");
             let mime_type = mime_from_ext(&image_path).to_string();
             pic_bullets.insert(
                 id,
@@ -456,8 +461,97 @@ mod tests {
         let pb = lvl.pic_bullet.as_ref().expect("picture bullet resolved");
         assert_eq!(pb.image_path, "word/media/image1.gif");
         assert_eq!(pb.mime_type, "image/gif");
-        assert!((pb.width_pt - 9.0).abs() < 1e-6);
-        assert!((pb.height_pt - 9.0).abs() < 1e-6);
+        assert!((pb.width_pt.expect("width from style") - 9.0).abs() < 1e-6);
+        assert!((pb.height_pt.expect("height from style") - 9.0).abs() < 1e-6);
+    }
+
+    /// §17.9.20 — when the `<v:shape>` style omits width/height, the size is left
+    /// as `None` (no magic 9pt default in the parser). The renderer falls back to
+    /// the resolved marker font size, so the parser must NOT invent a dimension.
+    #[test]
+    fn picture_bullet_without_shape_size_is_none() {
+        const R: &str =
+            "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"";
+        const V: &str = "xmlns:v=\"urn:schemas-microsoft-com:vml\"";
+        let media: HashMap<String, String> =
+            [("rId1".to_string(), "word/media/image1.png".to_string())]
+                .into_iter()
+                .collect();
+        let xml = format!(
+            r#"<w:numbering {W} {R} {V}>
+                 <w:numPicBullet w:numPicBulletId="0">
+                   <w:pict><v:shape id="x">
+                     <v:imagedata r:id="rId1"/>
+                   </v:shape></w:pict>
+                 </w:numPicBullet>
+                 <w:abstractNum w:abstractNumId="8">
+                   <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val=""/>
+                     <w:lvlPicBulletId w:val="0"/></w:lvl>
+                 </w:abstractNum>
+                 <w:num w:numId="3"><w:abstractNumId w:val="8"/></w:num>
+               </w:numbering>"#
+        );
+        let m = NumberingMap::parse(&xml, &media);
+        let pb = m
+            .get_level(3, 0)
+            .unwrap()
+            .pic_bullet
+            .as_ref()
+            .expect("picture bullet resolved");
+        assert_eq!(pb.image_path, "word/media/image1.png");
+        assert_eq!(pb.mime_type, "image/png");
+        assert_eq!(
+            pb.width_pt, None,
+            "no shape width ⇒ None (no magic default)"
+        );
+        assert_eq!(pb.height_pt, None);
+    }
+
+    /// §17.9.20 → §17.9.9 end-to-end resolution chain: a `<w:numPicBullet>` (id N)
+    /// whose `<v:imagedata r:id>` resolves through the numbering part's rels, then
+    /// a level's `<w:lvlPicBulletId w:val="N"/>` picks that bullet up. Confirms the
+    /// id wiring (not just a single happy-path size): a DIFFERENT id is rejected
+    /// and the matching id surfaces the right media path + size.
+    #[test]
+    fn lvl_pic_bullet_id_resolves_matching_num_pic_bullet() {
+        const R: &str =
+            "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"";
+        const V: &str = "xmlns:v=\"urn:schemas-microsoft-com:vml\"";
+        let media: HashMap<String, String> = [
+            ("rId7".to_string(), "word/media/bullet-a.png".to_string()),
+            ("rId8".to_string(), "word/media/bullet-b.gif".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let xml = format!(
+            r#"<w:numbering {W} {R} {V}>
+                 <w:numPicBullet w:numPicBulletId="1">
+                   <w:pict><v:shape style="width:12pt;height:6pt">
+                     <v:imagedata r:id="rId7"/></v:shape></w:pict>
+                 </w:numPicBullet>
+                 <w:numPicBullet w:numPicBulletId="2">
+                   <w:pict><v:shape style="width:8pt;height:8pt">
+                     <v:imagedata r:id="rId8"/></v:shape></w:pict>
+                 </w:numPicBullet>
+                 <w:abstractNum w:abstractNumId="4">
+                   <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val=""/>
+                     <w:lvlPicBulletId w:val="2"/></w:lvl>
+                 </w:abstractNum>
+                 <w:num w:numId="9"><w:abstractNumId w:val="4"/></w:num>
+               </w:numbering>"#
+        );
+        let m = NumberingMap::parse(&xml, &media);
+        let pb = m
+            .get_level(9, 0)
+            .unwrap()
+            .pic_bullet
+            .as_ref()
+            .expect("lvlPicBulletId=2 resolves to numPicBulletId=2");
+        // The level referenced id=2, so it must surface bullet-b (NOT bullet-a).
+        assert_eq!(pb.image_path, "word/media/bullet-b.gif");
+        assert_eq!(pb.mime_type, "image/gif");
+        assert!((pb.width_pt.unwrap() - 8.0).abs() < 1e-6);
+        assert!((pb.height_pt.unwrap() - 8.0).abs() < 1e-6);
     }
 
     /// An unresolvable `r:id` (no matching rel) yields no picture bullet — the

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1430,11 +1430,15 @@ fn parse_paragraph_cond(
                 pic_bullet_width_pt,
                 pic_bullet_height_pt,
             ) = match pic_bullet {
+                // width_pt / height_pt are already Option<f64> (None when the VML
+                // shape style omits the dimension — §17.9.20 defines no default
+                // size, so the renderer resolves the absence against the marker
+                // font), so they flow through unchanged.
                 Some(pb) => (
                     Some(pb.image_path),
                     Some(pb.mime_type),
-                    Some(pb.width_pt),
-                    Some(pb.height_pt),
+                    pb.width_pt,
+                    pb.height_pt,
                 ),
                 None => (None, None, None, None),
             };

--- a/packages/docx/src/numbering-bullet-marker.test.ts
+++ b/packages/docx/src/numbering-bullet-marker.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+  NumberingInfo,
+} from './types';
+
+// docx VRT covers no list paragraphs (every visual sample is numPr=0), so the
+// bullet-marker draw path has no regression net. These end-to-end renderer tests
+// pin two §17.9.x bullet behaviors that have silently regressed before:
+//
+//  1. Symbol/Wingdings glyph bullets (§17.9.6 rPr + §17.3.2.26 rFonts) are stored
+//     as the FONT's own PUA code point (Symbol U+F0B7 = "•", Wingdings U+F0A7 =
+//     "▪"). The renderer must normalize them to the Unicode equivalent so a
+//     fallback face shows the real glyph, never raw tofu (the PUA char).
+//  2. Picture bullets (§17.9.9 lvlPicBulletId → §17.9.20 numPicBullet) draw the
+//     marker as an IMAGE at the hanging-indent anchor, sized from the bullet
+//     drawing's extent and — when the extent is absent — the resolved marker font
+//     size (the S-9 unification: one default, no magic "9pt").
+
+const FONT_CLASSES: Record<string, string> = {
+  'Times New Roman': 'roman',
+};
+
+interface DrawImageCall { bmp: unknown; x: number; y: number; w: number; h: number; }
+
+/** Recording 2D context. Records fillText WITH the active font (markers are drawn
+ *  via fillText, not reported through onTextRun) AND drawImage args (picture
+ *  bullets are drawn via drawImage). Glyph advance = charCount × fontPx. */
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; x: number; font: string }[];
+  drawImageCalls: DrawImageCall[];
+} {
+  let font = '16px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '16');
+  const fillTextCalls: { text: string; x: number; font: string }[] = [];
+  const drawImageCalls: DrawImageCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage(bmp: unknown, x: number, y: number, w: number, h: number) {
+      drawImageCalls.push({ bmp, x, y, w, h });
+    },
+    fillText(text: string, x: number, _y: number) { fillTextCalls.push({ text, x, font }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls, drawImageCalls };
+}
+
+function run(text: string, fontFamily = 'Times New Roman'): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 16, color: null, fontFamily, fontFamilyEastAsia: fontFamily,
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as DocxTextRun;
+}
+
+function bulletDoc(num: NumberingInfo): DocxDocumentModel {
+  const p: DocParagraph = {
+    alignment: 'left',
+    indentLeft: 36, indentRight: 0, indentFirst: -18, // hanging indent (marker in the margin)
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: num, tabStops: [],
+    runs: [{ type: 'text', ...run('body') } as DocParagraph['runs'][number]],
+    defaultFontSize: 16, defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'paragraph', ...p } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: FONT_CLASSES,
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(
+  num: NumberingInfo,
+  fetchImage?: (path: string, mime: string) => Promise<Blob>,
+) {
+  const { canvas, fillTextCalls, drawImageCalls } = makeRecordingCanvas();
+  const runs: DocxTextRunInfo[] = [];
+  await renderDocumentToCanvas(bulletDoc(num), canvas, 0, {
+    dpr: 1,
+    width: 400, // scale = 1 (px per pt)
+    onTextRun: (r) => runs.push(r),
+    fetchImage,
+  });
+  return { runs, fillTextCalls, drawImageCalls };
+}
+
+// A 1×1 transparent GIF — the smallest valid raster the createImageBitmap stub
+// can stand in for. Used as the picture-bullet media part bytes.
+const ONE_BY_ONE_GIF = new Uint8Array([
+  0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00,
+  0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x21, 0xf9, 0x04, 0x01, 0x00, 0x00, 0x00,
+  0x00, 0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02,
+  0x44, 0x01, 0x00, 0x3b,
+]);
+
+describe('symbol/wingdings glyph bullet markers (§17.9.6 rPr + §17.3.2.26 rFonts)', () => {
+  it('draws a Symbol bullet (U+F0B7) as "•", never the raw PUA char', async () => {
+    const num: NumberingInfo = {
+      numId: 1, level: 0, format: 'bullet', text: '',
+      indentLeft: 36, tab: 18, suff: 'tab', fontFamily: 'Symbol',
+    };
+    const { fillTextCalls } = await render(num);
+    const bullet = fillTextCalls.find((c) => c.text === '•');
+    expect(bullet, 'Symbol U+F0B7 normalized to the Unicode bullet').toBeDefined();
+    // The raw private-use code point must NOT reach the canvas (it renders as tofu
+    // in any fallback face).
+    expect(fillTextCalls.some((c) => c.text === '')).toBe(false);
+  });
+
+  it('draws a Wingdings bullet (U+F0A7) as "▪", never the raw PUA char', async () => {
+    const num: NumberingInfo = {
+      numId: 2, level: 0, format: 'bullet', text: '',
+      indentLeft: 36, tab: 18, suff: 'tab', fontFamily: 'Wingdings',
+    };
+    const { fillTextCalls } = await render(num);
+    const sq = fillTextCalls.find((c) => c.text === '▪');
+    expect(sq, 'Wingdings U+F0A7 normalized to the Unicode square').toBeDefined();
+    expect(fillTextCalls.some((c) => c.text === '')).toBe(false);
+  });
+});
+
+describe('picture bullet marker (§17.9.9 lvlPicBulletId → §17.9.20 numPicBullet)', () => {
+  beforeEach(() => {
+    // createImageBitmap doesn't exist in node; stub it to a 4×4 sentinel bitmap
+    // (size is irrelevant — the draw box is driven by the §17.9.20 pt size, not
+    // the bitmap's intrinsic pixels).
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (_src: unknown) => ({ width: 4, height: 4, close: () => {} }) as unknown as ImageBitmap),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  // Marker text is empty for a picture bullet (lvlText is typically ""); the
+  // marker IS the image. No explicit width/height ⇒ the S-9 fallback = resolved
+  // marker font size (16pt here). suff:'space' so the body offset is measured off
+  // the marker width (no tab-stop dependency).
+  const picNum = (): NumberingInfo => ({
+    numId: 3, level: 0, format: 'bullet', text: '',
+    indentLeft: 36, tab: 18, suff: 'space',
+    picBulletImagePath: 'word/media/image1.gif',
+    picBulletMimeType: 'image/gif',
+    // picBulletWidthPt / picBulletHeightPt intentionally omitted (extent absent).
+  });
+
+  async function renderPic(num: NumberingInfo = picNum()) {
+    const fetchImage = vi.fn(
+      async (_path: string, mime: string) => new Blob([ONE_BY_ONE_GIF], { type: mime }),
+    );
+    const out = await render(num, fetchImage);
+    return { ...out, fetchImage };
+  }
+
+  it('(a) draws the bullet image via drawImage at the hanging-indent anchor', async () => {
+    const { drawImageCalls, fetchImage } = await renderPic();
+    expect(fetchImage).toHaveBeenCalledWith('word/media/image1.gif', 'image/gif');
+    expect(drawImageCalls).toHaveLength(1);
+    // LTR marker sits at lineLeft + indFirst = (contentX 0 + indentLeft 36) +
+    // indentFirst(-18) = 18px (the hanging margin = line start − markerW band).
+    expect(drawImageCalls[0].x).toBeCloseTo(18, 5);
+  });
+
+  it('(b) sizes the bullet to the resolved marker font size when the extent is absent (S-9: no magic 9pt)', async () => {
+    const { drawImageCalls } = await renderPic();
+    // 16pt font, scale = 1 px/pt ⇒ 16px box. The pre-S-9 draw default was a magic
+    // 9px; this asserts the unified font-size fallback, NOT 9.
+    expect(drawImageCalls[0].w).toBeCloseTo(16, 5);
+    expect(drawImageCalls[0].h).toBeCloseTo(16, 5);
+    expect(drawImageCalls[0].w).not.toBeCloseTo(9, 1);
+  });
+
+  it('(b2) honors an explicit picBullet extent over the font-size fallback', async () => {
+    const num = { ...picNum(), picBulletWidthPt: 24, picBulletHeightPt: 12 };
+    const { drawImageCalls } = await renderPic(num);
+    expect(drawImageCalls[0].w).toBeCloseTo(24, 5);
+    expect(drawImageCalls[0].h).toBeCloseTo(12, 5);
+  });
+
+  it('(c) advances the body text past the marker (markerW = bullet width)', async () => {
+    const { runs } = await renderPic();
+    const body = runs.find((r) => r.text === 'body');
+    expect(body).toBeDefined();
+    // suff:'space': body x = firstLineX (18) + markerW (16) + one space (16px) = 50.
+    // The key assertion is that the body is pushed RIGHT of the marker band (not
+    // overlapping the bullet at x=18), i.e. ≥ marker end (18 + 16 = 34).
+    expect(body!.x).toBeGreaterThanOrEqual(34);
+    expect(body!.x).toBeCloseTo(50, 5);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -371,13 +371,19 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
   // same decode pipeline (keyed by its zip path) so the marker draw site finds
   // a decoded bitmap.
   const recordPara = (para: DocParagraph) => {
-    const pb = para.numbering?.picBulletImagePath;
-    if (pb) {
+    const num = para.numbering;
+    const pb = num?.picBulletImagePath;
+    if (pb && num) {
+      // Same §17.9.20 size resolution the draw site uses (picBulletSizePt): the
+      // extent if present, else the resolved marker font size. Keeping the two in
+      // lock-step matters for WMF/EMF bullets, where this size drives raster
+      // sharpness — a 0 here would rasterize a vector bullet at zero size.
+      const size = picBulletSizePt(num, para);
       record({
         imagePath: pb,
-        mimeType: para.numbering!.picBulletMimeType ?? '',
-        widthPt: para.numbering!.picBulletWidthPt ?? 0,
-        heightPt: para.numbering!.picBulletHeightPt ?? 0,
+        mimeType: num.picBulletMimeType ?? '',
+        widthPt: size.w,
+        heightPt: size.h,
       });
     }
   };
@@ -3316,9 +3322,11 @@ function renderParagraph(
     if (pbPath) {
       const bmp = state.images.get(imageKey(pbPath));
       if (bmp) {
-        const w = (para.numbering.picBulletWidthPt ?? 9) * scale;
-        const h = (para.numbering.picBulletHeightPt ?? 9) * scale;
-        picBullet = { bmp, w, h };
+        // §17.9.20 — size from the bullet drawing's extent, else the resolved
+        // marker font size (picBulletSizePt is the single source of truth shared
+        // with the collect side; no magic pt default).
+        const size = picBulletSizePt(para.numbering, para);
+        picBullet = { bmp, w: size.w * scale, h: size.h * scale };
       }
     }
     if (suff !== 'tab') {
@@ -6860,6 +6868,22 @@ function getDefaultFontSize(para: DocParagraph): number {
   }
   if (typeof para.defaultFontSize === 'number') return para.defaultFontSize;
   return 10; // pt fallback
+}
+
+/** ECMA-376 §17.9.20 picture-bullet marker size in pt. The size comes from the
+ *  `<w:numPicBullet>` drawing's own extent (parsed into
+ *  `picBulletWidthPt`/`picBulletHeightPt`). The spec defines NO fallback
+ *  dimension, so when the extent is absent the marker is sized to the paragraph's
+ *  resolved marker font size — one source of truth shared by the collect side
+ *  (WMF raster sharpness) and the draw site (the drawImage box), keeping them in
+ *  lock-step. Replaces the former mismatched `?? 0` (collect) / `?? 9` (draw)
+ *  defaults; `9` was a magic pt value not present in §17.9.20. */
+function picBulletSizePt(num: NumberingInfo, para: DocParagraph): { w: number; h: number } {
+  const fallback = getDefaultFontSize(para);
+  return {
+    w: num.picBulletWidthPt ?? fallback,
+    h: num.picBulletHeightPt ?? fallback,
+  };
 }
 
 /** Width (px) of the paragraph-mark "em" — the smallest horizontal gap a


### PR DESCRIPTION
## Summary

Two list-marker fidelity fixes for docx, both grounded in ECMA-376 §17.9.x.

### S-9 — picture-bullet default size unified, magic `9` removed
The renderer resolved the §17.9.20 picture-bullet marker size with **two different defaults for the same optional**:
- collect side (`collectImagePairs`): `picBulletWidthPt ?? 0` — and a `0` here rasterizes a vector (WMF/EMF) bullet at zero size.
- draw site (`drawImage` box): `picBulletWidthPt ?? 9` — `9` is a magic pt value with no basis in §17.9.20, which derives the bullet size from the drawing's own extent and defines **no** fallback dimension.

Both now flow through a single `picBulletSizePt(num, para)`: the extent if present, else the paragraph's **resolved marker font size** (`getDefaultFontSize`). The parser stops inventing a 9pt default as well — `PicBullet.width_pt`/`height_pt` become `Option<f64>` (`None` when the `<v:shape style>` omits the dimension). The JSON contract was already `Option` + `skip_serializing_if`, so an absent extent simply omits the field and the renderer's single fallback handles it.

**Unified default:** the paragraph's resolved marker font size (e.g. 16pt → 16px at scale 1), not 9.

### M-3 — bullet-marker render tests (docx VRT covers no lists)
docx VRT is entirely `numPr=0`, so the bullet draw path had no regression net (the same gap that hid PR #476's hanging bug). Added end-to-end recording-canvas tests (twin of `numbering-marker-font.test.ts`):

- **Symbol bullet** U+F0B7 → `•` and **Wingdings** U+F0A7 → `▪` via `fillText`, never the raw PUA char (§17.9.6 rPr + §17.3.2.26 rFonts).
- **Picture bullet**: drawn via `drawImage` at the hanging-indent anchor; sized to the font-size fallback when the extent is absent (asserts the S-9 value, **not** 9); honors an explicit extent; pushes body text past the marker band.
- **Parser `#[test]`s**: the numPicBullet → lvlPicBulletId → picBulletImagePath chain (id wiring — a different id is rejected) and the no-shape-size → `None` contract.

## Verification
- docx vitest: 23 files / 191 tests pass (incl. 6 new bullet-marker tests)
- cargo fmt + clippy (`-D warnings`) + test: 132 parser tests pass (incl. 4 picBullet tests)
- root `pnpm typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)