### PR TITLE
refactor(core): extract autoContrastColor/relativeLuma to core + test run box/shading

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,7 +71,7 @@ export {
   type CustGeomEndpoint,
   type CustGeomEndpoints,
 } from './shape/custgeom-endpoints';
-export { hexToRgba, resolveFill, applyStroke } from './shape/paint';
+export { hexToRgba, relativeLuma, autoContrastColor, resolveFill, applyStroke } from './shape/paint';
 export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/preset';
 export { drawArrowHead } from './shape/arrow';
 // Shared embedded-SVG decoder (Microsoft asvg:svgBlip extension) — used by all

--- a/packages/core/src/shape/paint.test.ts
+++ b/packages/core/src/shape/paint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hexToRgba } from './paint.js';
+import { hexToRgba, relativeLuma, autoContrastColor } from './paint.js';
 
 // hexToRgba is the colour pipeline's exit point: the pptx parser resolves a
 // run's a:highlight (§21.1.2.3.4) to either a 6-char opaque hex or, when an
@@ -27,5 +27,57 @@ describe('hexToRgba', () => {
 
   it('applies the alpha argument only to 6-char hex', () => {
     expect(hexToRgba('FFFF00', 0.5)).toBe('rgba(255,255,0,0.5)');
+  });
+});
+
+// relativeLuma is the Rec.601 perceptual luma used by automatic-contrast text
+// pickers. It shares hexToRgba's hex normalisation: a leading '#' is tolerated
+// and any 8-char alpha byte is ignored.
+describe('relativeLuma (Rec.601)', () => {
+  it('returns 0 for black and 255 for white', () => {
+    expect(relativeLuma('000000')).toBe(0);
+    expect(relativeLuma('FFFFFF')).toBeCloseTo(255);
+  });
+
+  it('weights the channels 0.299 / 0.587 / 0.114', () => {
+    expect(relativeLuma('FF0000')).toBeCloseTo(0.299 * 255);
+    expect(relativeLuma('00FF00')).toBeCloseTo(0.587 * 255);
+    expect(relativeLuma('0000FF')).toBeCloseTo(0.114 * 255);
+  });
+
+  it('tolerates a leading # and ignores the 8-char alpha byte', () => {
+    expect(relativeLuma('#00FF00')).toBeCloseTo(0.587 * 255);
+    // RRGGBBAA — the AA is ignored, same value as the 6-char form.
+    expect(relativeLuma('00FF0080')).toBeCloseTo(0.587 * 255);
+  });
+});
+
+// autoContrastColor implements `w:color="auto"` (ECMA-376 §17.3.2.6) and the
+// generic "pick legible text colour for a background" need shared across
+// renderers. The black/white pick is implementation-defined (no normative
+// algorithm): luma < 128 ⇒ white text, else black; null background ⇒ black.
+describe('autoContrastColor (impl-defined; §17.3.2.6 w:color auto)', () => {
+  it('picks white text on a black background (inverse video)', () => {
+    expect(autoContrastColor('000000')).toBe('#FFFFFF');
+  });
+
+  it('picks black text on a white background', () => {
+    expect(autoContrastColor('ffffff')).toBe('#000000');
+  });
+
+  it('defaults to black text when there is no background (page white)', () => {
+    expect(autoContrastColor(null)).toBe('#000000');
+  });
+
+  it('uses Rec.601 luma — mid green is light enough for black text', () => {
+    // green #00FF00 has luma 0.587*255 ≈ 150 (> 128) ⇒ black text.
+    expect(autoContrastColor('00ff00')).toBe('#000000');
+    // dark blue #0000FF has luma 0.114*255 ≈ 29 (< 128) ⇒ white text.
+    expect(autoContrastColor('0000ff')).toBe('#FFFFFF');
+  });
+
+  it('tolerates a leading # (same normalisation as hexToRgba)', () => {
+    expect(autoContrastColor('#000000')).toBe('#FFFFFF');
+    expect(autoContrastColor('#ffffff')).toBe('#000000');
   });
 });

--- a/packages/core/src/shape/paint.ts
+++ b/packages/core/src/shape/paint.ts
@@ -17,6 +17,33 @@ export function hexToRgba(hex: string, alpha = 1): string {
 }
 
 /**
+ * Rec.601 perceptual luma (`0.299·R + 0.587·G + 0.114·B`) of a colour, on the
+ * 0–255 scale. Accepts a 6- or 8-char hex; a leading `#` is tolerated and the
+ * alpha byte (if present) is ignored, matching {@link hexToRgba}'s hex
+ * normalisation.
+ */
+export function relativeLuma(hex: string): number {
+  const h = hex.charCodeAt(0) === 35 /* '#' */ ? hex.slice(1) : hex;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/**
+ * Pick black or white text for legibility against a background colour. The
+ * mid-gray threshold (128) on the Rec.601 luma splits light vs dark: a dark
+ * background ⇒ white text, otherwise black. `bgHex=null` (no background ⇒ page
+ * white) ⇒ black text. The black/white pick is implementation-defined — no
+ * normative algorithm exists (ECMA-376 §17.3.2.6 `w:color="auto"` only says the
+ * consumer chooses "an appropriate color based on the background").
+ */
+export function autoContrastColor(bgHex: string | null): '#000000' | '#FFFFFF' {
+  if (!bgHex) return '#000000';
+  return relativeLuma(bgHex) < 128 ? '#FFFFFF' : '#000000';
+}
+
+/**
  * Resolve a Fill to a CanvasRenderingContext2D-compatible paint.
  * Gradients require pixel bounds (x, y, w, h) to construct the CanvasGradient.
  * Returns null for noFill.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -11,6 +11,7 @@ import {
   hasPreset,
   getCachedSvgImageByPath,
   hexToRgba,
+  autoContrastColor,
   resolveFill,
   applyStroke,
   drawArrowHead,
@@ -325,30 +326,6 @@ function authorColor(author?: string): string {
     h = Math.imul(h, 0x01000193);
   }
   return TRACK_CHANGE_AUTHOR_PALETTE[Math.abs(h) % TRACK_CHANGE_AUTHOR_PALETTE.length];
-}
-
-/**
- * Automatic text color: pick black or white for legible contrast against the
- * effective background. This black/white resolution is implementation-defined —
- * ECMA-376 specifies no normative algorithm; the `auto` value itself is defined
- * by §17.3.2.6 (w:color) / ST_HexColorAuto §17.18.39. Uses Rec.601 luma; a
- * mid-gray threshold (128) splits light vs dark. `bg=null` ⇒ page white ⇒
- * black text.
- *
- * TODO: the fully-conformant effective background also folds in
- * paragraph-level shading (`<w:pPr><w:shd>`) and table cell shading. The draw
- * loop currently only has the run shading at this point, which covers the
- * inverse-video case (run `w:shd w:fill="000000"`). Paragraph/cell shading
- * should be threaded into `LayoutTextSeg.background` when those backgrounds
- * are dark enough to flip automatic text to white.
- */
-export function autoContrastColor(bgHex: string | null): string {
-  if (!bgHex) return '#000000';
-  const r = parseInt(bgHex.slice(0, 2), 16);
-  const g = parseInt(bgHex.slice(2, 4), 16);
-  const b = parseInt(bgHex.slice(4, 6), 16);
-  const luma = 0.299 * r + 0.587 * g + 0.114 * b;
-  return luma < 128 ? '#FFFFFF' : '#000000';
 }
 
 function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
@@ -3666,10 +3643,41 @@ function renderParagraph(
       distPerGap = dist ? dist.perGap : 0;
     }
 
+    // ECMA-376 §17.3.2.4 (`<w:bdr>`): adjacent runs whose border attribute set
+    // is identical form ONE run-border group and are "rendered within the same
+    // set of borders". Accumulate the group's pixel extent as segments are
+    // drawn left-to-right and stroke a single frame when the group ends (a
+    // segment with a different / absent border, or end of line). Grouping is by
+    // visual adjacency within this line; mixed-direction lines are an edge case
+    // (the spec phrases the group in logical order) left for a follow-up.
+    interface OpenBorderGroup {
+      border: DocxRunBorder;
+      left: number; right: number; top: number; bottom: number;
+    }
+    let borderGroup: OpenBorderGroup | null = null;
+    const flushBorderGroup = () => {
+      if (!borderGroup) return;
+      const g = borderGroup;
+      borderGroup = null;
+      const bw = Math.max(1, g.border.width * scale); // w:sz/8 is in pt
+      const sp = (g.border.space ?? 0) * scale;
+      ctx.strokeStyle = g.border.color ? `#${g.border.color}` : defaultColor;
+      ctx.lineWidth = bw;
+      ctx.strokeRect(
+        g.left - sp,
+        g.top - sp,
+        g.right - g.left + 2 * sp,
+        g.bottom - g.top + 2 * sp,
+      );
+    };
+
     for (let vi = 0; vi < segCount; vi++) {
       const si = visual ? visual.order[vi] : vi;
       const seg = line.segments[si];
       if (visual) ctx.direction = visual.rtl[si] ? 'rtl' : 'ltr';
+      // A non-text segment (tab / inline image / math) breaks run-border
+      // adjacency (§17.3.2.4 groups adjacent *runs*), so close any open frame.
+      if (!('text' in seg)) flushBorderGroup();
       if ('isTab' in seg) {
         // Tabs render as blank space, optionally filled with a leader (TOC dots etc.).
         if (!dryRun && seg.leader && seg.leader !== 'none' && seg.measuredWidth > 1) {
@@ -3730,22 +3738,34 @@ function renderParagraph(
           ctx.fillRect(x, baseline + yOffset - effSizePx * 0.85, spanW, effSizePx * 1.1);
         }
 
-        // ECMA-376 §17.3.2.4 run border (`<w:bdr>`, "box"): stroke a rectangle
-        // around the run, inflated by w:space (pt → px). Drawn after the
-        // background so the box outlines the filled area. The box is drawn per
-        // layout segment; we do not merge consecutive runs that share an
-        // identical bdr into a single frame (Word merges them).
-        if (s.border && s.border.style !== 'none' && s.border.style !== 'nil') {
-          const bw = Math.max(1, s.border.width * scale); // w:sz/8 is in pt
-          const sp = (s.border.space ?? 0) * scale;
-          ctx.strokeStyle = s.border.color ? `#${s.border.color}` : defaultColor;
-          ctx.lineWidth = bw;
-          ctx.strokeRect(
-            x - sp,
-            baseline + yOffset - effSizePx * 0.85 - sp,
-            spanW + 2 * sp,
-            effSizePx * 1.1 + 2 * sp,
-          );
+        // ECMA-376 §17.3.2.4 run border (`<w:bdr>`, "box"): a rectangle around
+        // the run, inflated by w:space (pt → px), drawn after the background so
+        // the box outlines the filled area. Per the spec, adjacent runs sharing
+        // an identical border render within the SAME frame, so instead of
+        // stroking here we extend (or open) the current border group; the frame
+        // is stroked by flushBorderGroup() when the group ends. The box bounds
+        // each segment's glyph box (same rect the shading uses) unioned across
+        // the group, so a mixed-size group still encloses every run.
+        const activeBorder =
+          s.border && s.border.style !== 'none' && s.border.style !== 'nil'
+            ? s.border
+            : null;
+        if (activeBorder) {
+          const segTop = baseline + yOffset - effSizePx * 0.85;
+          const segBottom = segTop + effSizePx * 1.1;
+          if (borderGroup && runBordersEqual(borderGroup.border, activeBorder)) {
+            borderGroup.right = x + spanW;
+            borderGroup.top = Math.min(borderGroup.top, segTop);
+            borderGroup.bottom = Math.max(borderGroup.bottom, segBottom);
+          } else {
+            flushBorderGroup();
+            borderGroup = {
+              border: activeBorder,
+              left: x, right: x + spanW, top: segTop, bottom: segBottom,
+            };
+          }
+        } else {
+          flushBorderGroup();
         }
 
         // Track-changes overlay: paint insertions / deletions in the author's
@@ -3761,9 +3781,16 @@ function renderParagraph(
         } else if (s.color) {
           glyphColor = `#${s.color}`;
         } else if (s.colorAuto) {
-          // Automatic color picks black/white for contrast against the
-          // effective background (run shading > default page white). The
-          // black/white pick is implementation-defined (no normative algorithm).
+          // ECMA-376 §17.3.2.6 (w:color) / ST_HexColorAuto §17.18.39: automatic
+          // color picks black/white for contrast against the effective
+          // background. The black/white pick is implementation-defined (no
+          // normative algorithm) — delegated to core's autoContrastColor.
+          // TODO: the fully-conformant effective background also folds in
+          // paragraph-level shading (`<w:pPr><w:shd>`) and table cell shading.
+          // The draw loop currently only has the run shading at this point,
+          // which covers the inverse-video case (run `w:shd w:fill="000000"`).
+          // Paragraph/cell shading should be threaded into
+          // `LayoutTextSeg.background` when dark enough to flip auto text white.
           glyphColor = autoContrastColor(s.background ?? null);
         } else {
           glyphColor = defaultColor;
@@ -3903,6 +3930,9 @@ function renderParagraph(
       // so the final glyph still lands on the margin (Σgaps == slack).
       if (stretch?.trailingGap) x += distPerGap;
     }
+    // End of line closes any open run-border group: a frame never spans lines
+    // (each line wrap starts a fresh box on the next line).
+    flushBorderGroup();
     if (paraNeedsBidi) ctx.direction = 'ltr'; // reset for subsequent draws
 
     state.y += lineH;
@@ -6594,6 +6624,20 @@ function drawParaBorders(
 }
 
 // ===== Utilities =====
+
+/** ECMA-376 §17.3.2.4 — two `<w:bdr>` borders belong to the same run-border
+ *  group iff their attribute sets are identical. We compare the attributes the
+ *  model carries (style/sz/space/color); themeColor/themeTint/shadow/frame are
+ *  not modelled, so identical themed borders that differ only in unmodelled
+ *  attributes still group (acceptable — the painted frame is identical anyway). */
+function runBordersEqual(a: DocxRunBorder, b: DocxRunBorder): boolean {
+  return (
+    a.style === b.style &&
+    a.width === b.width &&
+    (a.space ?? 0) === (b.space ?? 0) &&
+    (a.color ?? null) === (b.color ?? null)
+  );
+}
 
 function calcEffectiveFontPx(s: LayoutTextSeg, scale: number): number {
   let size = s.fontSize * scale;

--- a/packages/docx/src/run-inline-formatting.test.ts
+++ b/packages/docx/src/run-inline-formatting.test.ts
@@ -1,24 +1,197 @@
 import { describe, it, expect } from 'vitest';
-import { autoContrastColor } from './renderer.js';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  DocxRunBorder,
+  SectionProps,
+} from './types';
 
-describe('autoContrastColor — automatic text color (impl-defined; w:color auto §17.3.2.6)', () => {
-  it('picks white text on a black background (inverse video)', () => {
-    // "Some text in inverse video." — run shading fill #000000 + w:color="auto".
-    expect(autoContrastColor('000000')).toBe('#FFFFFF');
+// End-to-end renderer verification of run-level box (`<w:bdr>` §17.3.2.4) and
+// shading (`<w:shd w:fill>` §17.3.2.32) draw geometry, plus the spec's
+// run-border GROUPING rule: adjacent runs whose border attribute set is
+// identical render within a single frame (§17.3.2.4). These are checked through
+// a recording 2D context that captures every fillRect / strokeRect / fillText
+// in draw order with its geometry and style. (autoContrastColor's unit tests
+// moved to packages/core/src/shape/paint.test.ts when the function was lifted
+// into core.)
+
+type DrawEvent =
+  | { kind: 'fillRect'; x: number; y: number; w: number; h: number; style: string }
+  | { kind: 'strokeRect'; x: number; y: number; w: number; h: number; style: string; lineWidth: number }
+  | { kind: 'fillText'; text: string; x: number };
+
+/** Recording 2D context. Glyph advance = charCount × fontPx; font box 0.8/0.2
+ *  em — the same synthetic metrics the numbering-marker test uses. */
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  events: DrawEvent[];
+} {
+  let font = '16px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '16');
+  const events: DrawEvent[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, setLineDash() {}, drawImage() {}, clearRect() {},
+    arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    fillRect(x: number, y: number, w: number, h: number) {
+      events.push({ kind: 'fillRect', x, y, w, h, style: String(this.fillStyle) });
+    },
+    strokeRect(x: number, y: number, w: number, h: number) {
+      events.push({
+        kind: 'strokeRect', x, y, w, h,
+        style: String(this.strokeStyle), lineWidth: this.lineWidth,
+      });
+    },
+    fillText(text: string, x: number, _y: number) {
+      events.push({ kind: 'fillText', text, x });
+    },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, events };
+}
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 16, color: null, fontFamily: 'Arial', fontFamilyEastAsia: 'Arial',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+    ...extra,
+  };
+}
+
+function paraDoc(runs: DocxTextRun[]): DocxDocumentModel {
+  const p: DocParagraph = {
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: runs.map((r) => ({ type: 'text', ...r }) as DocParagraph['runs'][number]),
+    defaultFontSize: 16, defaultFontFamily: 'Arial',
+    widowControl: false,
+  };
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'paragraph', ...p } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    // Arial → swiss (sans) so the segment stays single-font; not load-bearing
+    // for the rect geometry these tests assert.
+    fontFamilyClasses: { Arial: 'swiss' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(runs: DocxTextRun[]) {
+  const { canvas, events } = makeRecordingCanvas();
+  await renderDocumentToCanvas(paraDoc(runs), canvas, 0, {
+    dpr: 1,
+    width: 400, // scale = 1 (px per pt) so geometry is in pt-equivalent px
+  });
+  return events;
+}
+
+const border = (extra: Partial<DocxRunBorder> = {}): DocxRunBorder => ({
+  style: 'single', color: '0000FF', width: 1, space: 0, ...extra,
+});
+
+describe('run box (w:bdr §17.3.2.4) + shading (w:shd §17.3.2.32) geometry', () => {
+  it('insets the box outside the glyph box by w:space', async () => {
+    // One run carrying BOTH shading (fillRect at the glyph box) and a border
+    // with w:space — the strokeRect must sit `space*scale` OUTSIDE the shading
+    // rect on every side (box bounds = glyph box + space inset). Select the RUN
+    // shading rect by its colour (the first fillRect is the page-white bg).
+    const sp = 4;
+    const events = await render([
+      textRun('AB', { background: '00FF00', border: border({ space: sp }) }),
+    ]);
+    const fill = events.find((e) => e.kind === 'fillRect' && e.style.toUpperCase() === '#00FF00');
+    const stroke = events.find((e) => e.kind === 'strokeRect');
+    expect(fill).toBeDefined();
+    expect(stroke).toBeDefined();
+    if (fill?.kind !== 'fillRect' || stroke?.kind !== 'strokeRect') throw new Error('unreachable');
+    // scale = 1 ⇒ inset = sp px on each side.
+    expect(stroke.x).toBeCloseTo(fill.x - sp);
+    expect(stroke.y).toBeCloseTo(fill.y - sp);
+    expect(stroke.w).toBeCloseTo(fill.w + 2 * sp);
+    expect(stroke.h).toBeCloseTo(fill.h + 2 * sp);
+    // The box is the run's border colour.
+    expect(stroke.style.toUpperCase()).toBe('#0000FF');
   });
 
-  it('picks black text on a white background', () => {
-    expect(autoContrastColor('ffffff')).toBe('#000000');
+  it('merges two adjacent runs with an identical w:bdr into one frame (§17.3.2.4)', async () => {
+    // Two adjacent runs, identical border, no shading. The spec: identical
+    // adjacent borders form one group rendered within a single set of borders.
+    const events = await render([
+      textRun('AB', { border: border() }),
+      textRun('CD', { border: border() }),
+    ]);
+    const strokes = events.filter((e) => e.kind === 'strokeRect');
+    expect(strokes).toHaveLength(1); // ONE frame, not one per run
+    const stroke = strokes[0];
+    if (stroke.kind !== 'strokeRect') throw new Error('unreachable');
+    // The frame spans both runs: width ≈ |AB| + |CD| = 2 chars × 16px × 2 runs.
+    // space = 0 ⇒ no inset. Each char advance is 16px (synthetic metrics).
+    expect(stroke.w).toBeCloseTo(4 * 16);
+    // First glyph of the first run starts at the frame's left edge.
+    const firstText = events.find((e) => e.kind === 'fillText');
+    if (firstText?.kind !== 'fillText') throw new Error('unreachable');
+    expect(stroke.x).toBeCloseTo(firstText.x);
   });
 
-  it('defaults to black text when there is no background (page white)', () => {
-    expect(autoContrastColor(null)).toBe('#000000');
+  it('does NOT merge two adjacent runs whose borders differ (separate frames)', async () => {
+    const events = await render([
+      textRun('AB', { border: border({ color: '0000FF' }) }),
+      textRun('CD', { border: border({ color: 'FF0000' }) }),
+    ]);
+    const strokes = events.filter((e) => e.kind === 'strokeRect');
+    expect(strokes).toHaveLength(2); // different colour ⇒ two groups
   });
 
-  it('uses Rec.601 luma — mid green is light enough for black text', () => {
-    // green #00FF00 has luma 0.587*255 ≈ 150 (> 128) ⇒ black text.
-    expect(autoContrastColor('00ff00')).toBe('#000000');
-    // dark blue #0000FF has luma 0.114*255 ≈ 29 (< 128) ⇒ white text.
-    expect(autoContrastColor('0000ff')).toBe('#FFFFFF');
+  it('paints the shading fillRect behind the text (before the glyphs)', async () => {
+    const events = await render([
+      textRun('AB', { background: 'C0C0C0' }),
+    ]);
+    // Select the RUN shading rect by colour (the page-white bg fillRect runs
+    // first and would otherwise win findIndex).
+    const fillIdx = events.findIndex((e) => e.kind === 'fillRect' && e.style.toUpperCase() === '#C0C0C0');
+    const textIdx = events.findIndex((e) => e.kind === 'fillText' && e.text.includes('A'));
+    expect(fillIdx).toBeGreaterThanOrEqual(0);
+    expect(textIdx).toBeGreaterThanOrEqual(0);
+    // Shading is drawn FIRST so the glyphs sit on top of the fill.
+    expect(fillIdx).toBeLessThan(textIdx);
+    const fill = events[fillIdx];
+    if (fill.kind !== 'fillRect') throw new Error('unreachable');
+    // …in the run's shading colour, at the glyph box.
+    expect(fill.style.toUpperCase()).toBe('#C0C0C0');
+    expect(fill.w).toBeCloseTo(2 * 16); // |AB| = 2 chars × 16px
   });
 });


### PR DESCRIPTION
## M-2 — `autoContrastColor` / `relativeLuma` extracted to core

- Added `relativeLuma(hex)` (Rec.601 `0.299·R + 0.587·G + 0.114·B`) and `autoContrastColor(bgHex): '#000000' | '#FFFFFF'` to `packages/core/src/shape/paint.ts`, both sharing `hexToRgba`'s hex normalisation (leading `#` tolerated, 8-char alpha byte ignored). Exported from `packages/core/src/index.ts`.
- `packages/docx/src/renderer.ts` now imports `autoContrastColor` from core and its local copy is removed. **Behaviour is byte-identical for existing callers** — docx passes a `#`-less 6-hex; same input → same output. The docx-specific TODO about paragraph/cell shading was relocated to the call site.
- Moved the `autoContrastColor` unit tests from `docx/src/run-inline-formatting.test.ts` into `core/src/shape/paint.test.ts`, and added `relativeLuma` coverage.
- luma dedup: no hand-written `0.299` / `0.2126` coefficients existed elsewhere in `packages/core/src` (only in test files, left untouched), so there was nothing further to consolidate.

## S-10 — run box (`w:bdr` §17.3.2.4) / shading (`w:shd` §17.3.2.32) draw geometry tests

Added recording-canvas tests (same pattern as `numbering-marker-font.test.ts`) asserting:
- the box sits `w:space` outside the glyph box on every side;
- a shading `fillRect` is painted in the run colour **before** the glyphs;
- adjacent runs whose `w:bdr` differs stay as separate frames.

### Implementation bug found + fixed
The merge test surfaced a genuine spec gap. The renderer drew **one box per layout segment** and the code comment explicitly admitted it did **not** merge adjacent runs sharing an identical `bdr` (Word does). ECMA-376 §17.3.2.4: identical adjacent borders "shall be considered to be part of the same run border group and rendered within the same set of borders."

Fix: accumulate a run-border group across visually-adjacent same-border segments (compared via a new `runBordersEqual`) and stroke a single frame when the group ends — a different/absent border, a non-text segment (tab/image/math breaks run adjacency), or end of line (a frame never spans wrapped lines). Verified the test fails on the pre-fix per-segment behaviour and passes after.

## Verification
- `vitest` core: 392 passed · docx: 185 passed (577 combined, 54 files)
- root `pnpm typecheck`: green (tsc --build + markdown/node/vscode-extension), after building WASM stubs locally
- VRT not run (local-only); no reference images touched

## Note on merge coordination
`packages/core/src/index.ts` and `packages/docx/src/renderer.ts`'s core-import block are also touched by the symbol-font cleanup PR — **core/index.ts may need a small merge adjustment** there. Edits here were kept local (one line each, near `hexToRgba`).