### PR TITLE
fix(docx): frame/float-table vertical align is vAnchor-relative (§22.9.2.20/§20.4.3.2)

### DIFF
--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -169,6 +169,20 @@ describe('floating table geometry (§17.4.57) — vertical placement', () => {
     expect(b.y).toBe(72 + (728 - 72 - 60) / 2);
   });
 
+  it('vertAnchor="margin" + tblpYSpec="center": ASYMMETRIC margins center in the margin band, NOT the page', () => {
+    // §22.9.2.20: tblpYSpec="center" centers in the margin BAND
+    // [marginTop, pageH−marginBottom], which only equals the page centre when
+    // margins are symmetric. The symmetric case above (marginTop=marginBottom=72)
+    // cannot distinguish "margin band centre" from "page centre"; this asymmetric
+    // case pins the band-relative behaviour.
+    const st = makeState({ marginTop: 40, marginBottom: 120 }); // band [40, 680], height 640
+    const b = box(tblp({ vertAnchor: 'margin', tblpY: 999, tblpYSpec: 'center' }), st, 300, 150, 60);
+    // band centre = marginTop + (pageH − marginTop − marginBottom − h)/2
+    //             = 40 + (800 − 40 − 120 − 60)/2 = 40 + 290 = 330
+    expect(b.y).toBe(40 + (800 - 40 - 120 - 60) / 2); // 330 — NOT page centre (800−60)/2 = 370
+    expect(b.y).not.toBe((800 - 60) / 2); // explicit: this is the band centre, not the page centre
+  });
+
   // §22.9.2.20: ST_YAlign positions relative to the ANCHOR OBJECT (the vertAnchor
   // band), NOT the physical page. For vertAnchor="page" the band is [0, pageH], so
   // center/bottom must NOT carry a margin offset (the pre-band code subtracted

--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -165,7 +165,38 @@ describe('floating table geometry (§17.4.57) — vertical placement', () => {
   it('vertAnchor="margin" + tblpYSpec="center" centers vertically, superseding tblpY', () => {
     const st = makeState();
     const b = box(tblp({ vertAnchor: 'margin', tblpY: 999, tblpYSpec: 'center' }), st, 300, 150, 60);
-    expect(b.y).toBe(72 + (800 - 60) / 2 - 72); // vy + (pageH−h)/2 − marginTop
+    // margin band [72, 728]: start + (end − start − h)/2 = 72 + (728 − 72 − 60)/2
+    expect(b.y).toBe(72 + (728 - 72 - 60) / 2);
+  });
+
+  // §22.9.2.20: ST_YAlign positions relative to the ANCHOR OBJECT (the vertAnchor
+  // band), NOT the physical page. For vertAnchor="page" the band is [0, pageH], so
+  // center/bottom must NOT carry a margin offset (the pre-band code subtracted
+  // marginTop even for page-anchored tables, §17.18.100 page = page edges).
+  it('vertAnchor="page" + tblpYSpec="center" centers over the FULL page (no margin offset)', () => {
+    const st = makeState(); // page band [0, 800]
+    const b = box(tblp({ vertAnchor: 'page', tblpY: 999, tblpYSpec: 'center' }), st, 300, 150, 60);
+    expect(b.y).toBe((800 - 60) / 2); // 370 — NOT (800−60)/2 − marginTop
+  });
+
+  it('vertAnchor="page" + tblpYSpec="bottom" sits flush to the physical page bottom', () => {
+    const st = makeState();
+    const b = box(tblp({ vertAnchor: 'page', tblpY: 999, tblpYSpec: 'bottom' }), st, 300, 150, 60);
+    expect(b.y).toBe(800 - 60); // pageH − tableH (no marginBottom inset)
+  });
+
+  it('vertAnchor="page" + tblpYSpec="outside" sits flush to the physical page bottom', () => {
+    const st = makeState();
+    const b = box(tblp({ vertAnchor: 'page', tblpY: 999, tblpYSpec: 'outside' }), st, 300, 150, 60);
+    expect(b.y).toBe(800 - 60);
+  });
+
+  it('vertAnchor="page" + tblpYSpec="top"/"inside" sits at the page top (band start)', () => {
+    const st = makeState();
+    for (const spec of ['top', 'inside']) {
+      const b = box(tblp({ vertAnchor: 'page', tblpY: 999, tblpYSpec: spec }), st, 300, 150, 60);
+      expect(b.y, spec).toBe(0); // page band start = 0
+    }
   });
 });
 

--- a/packages/docx/src/float-table-geometry.ts
+++ b/packages/docx/src/float-table-geometry.ts
@@ -65,7 +65,10 @@ export function computeFloatTableBox(
   const hx = tp.horzSpecified
     ? frameXContainer(tp.horzAnchor, state)
     : frameXContainer('text', state);
-  const vy = frameYContainer(tp.vertAnchor, paraTop, state);
+  // Vertical band of the vertAnchor (the "anchor object", §22.9.2.20). The
+  // "text" band end uses the table height; tblpYSpec is gated out for "text" so
+  // only band.start (= paraTop) is consumed there.
+  const vBand = frameYContainer(tp.vertAnchor, paraTop, tableH, state);
 
   // Horizontal: tblpXSpec (ST_XAlign) supersedes the absolute tblpX offset
   // (§17.4.57). Mirrors computeFrameBox's xAlign handling.
@@ -83,9 +86,10 @@ export function computeFloatTableBox(
   // Mirrors computeFrameBox's yAlign handling (ignored when vAnchor="text").
   let y: number;
   if (tp.tblpYSpec && tp.vertAnchor !== 'text') {
-    y = resolveAlignedPosV(tp.tblpYSpec, vy, tableH, state);
+    y = resolveAlignedPosV(tp.tblpYSpec, vBand, tableH);
   } else {
-    y = vy + tp.tblpY * sc;
+    // §17.4.57 tblpY: absolute signed offset from the vertAnchor band start.
+    y = vBand.start + tp.tblpY * sc;
   }
 
   return { x, y, w: tableW, h: tableH };

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -198,6 +198,75 @@ describe('frame geometry (§17.3.1.11) — hAnchor / vAnchor containers', () => 
   });
 });
 
+describe('frame geometry (§17.3.1.11 / §22.9.2.20) — yAlign is vAnchor-band relative', () => {
+  // ST_YAlign positions the frame relative to the ANCHOR OBJECT (the vAnchor
+  // band), NOT the physical page (§22.9.2.20: "relative position … relative to
+  // the vertical anchor"). The band per §17.18.100:
+  //   page   → [0, pageH]                       (page edges)
+  //   margin → [marginTop, pageH−marginBottom]  (text margins)
+  //   text   → [paraTop, paraTop+contentH]      (anchor paragraph text extents)
+  // yAlign is ignored for vAnchor="text" (relative positioning not allowed).
+
+  it('vAnchor="margin" + yAlign="center" centers in the MARGIN band, not the page', () => {
+    const st = makeState(); // margin band [72, 728], height 656
+    const fp = frame({ vAnchor: 'margin', yAlign: 'center', hRule: 'exact', h: 60 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    // start + (end − start − h)/2 = 72 + (728 − 72 − 60)/2 = 72 + 298 = 370
+    expect(b.y).toBe(72 + (728 - 72 - 60) / 2);
+  });
+
+  it('vAnchor="margin" + yAlign="bottom" sits flush to the bottom margin', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'margin', yAlign: 'bottom', hRule: 'exact', h: 60 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(728 - 60); // (pageH − marginBottom) − h
+  });
+
+  it('vAnchor="margin" + yAlign="outside" sits flush to the bottom margin', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'margin', yAlign: 'outside', hRule: 'exact', h: 60 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(728 - 60);
+  });
+
+  it('vAnchor="margin" + yAlign="top"/"inside" sits at the margin top (band start)', () => {
+    const st = makeState();
+    for (const ya of ['top', 'inside'] as const) {
+      const fp = frame({ vAnchor: 'margin', yAlign: ya, hRule: 'exact', h: 60 });
+      const b = box(fp, st, 300, 40, 100, 12);
+      expect(b.y, ya).toBe(72); // band start = marginTop
+    }
+  });
+
+  it('vAnchor="page" + yAlign="center" centers over the FULL page (no margin offset)', () => {
+    const st = makeState(); // page band [0, 800]
+    const fp = frame({ vAnchor: 'page', yAlign: 'center', hRule: 'exact', h: 60 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe((800 - 60) / 2); // 370 — NOT (800−60)/2 − marginTop
+  });
+
+  it('vAnchor="page" + yAlign="bottom" sits flush to the physical page bottom', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'page', yAlign: 'bottom', hRule: 'exact', h: 60 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(800 - 60); // pageH − h
+  });
+
+  it('explicit y is measured from the vAnchor band start (margin top)', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'margin', y: 5 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(72 + 5); // band start (marginTop) + y
+  });
+
+  it('yAlign is ignored for vAnchor="text" (relative positioning not allowed)', () => {
+    const st = makeState();
+    const fp = frame({ vAnchor: 'text', yAlign: 'center', y: 7 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(300 + 7); // paraTop + y; yAlign ignored
+  });
+});
+
 describe('frame geometry (§17.3.1.11) — generic frame (dropCap="none") sizing', () => {
   it('hRule="exact" forces the frame height to h regardless of content', () => {
     const st = makeState();

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -215,6 +215,21 @@ describe('frame geometry (§17.3.1.11 / §22.9.2.20) — yAlign is vAnchor-band 
     expect(b.y).toBe(72 + (728 - 72 - 60) / 2);
   });
 
+  it('vAnchor="margin" + yAlign="center": ASYMMETRIC margins center in the margin band, NOT the page', () => {
+    // §22.9.2.20: with vAnchor="margin", yAlign="center" centers in the margin
+    // BAND [marginTop, pageH−marginBottom], which only equals the page centre
+    // when margins are symmetric. The symmetric cases above (marginTop=
+    // marginBottom=72) cannot distinguish "margin band centre" from "page
+    // centre"; this asymmetric case pins the band-relative behaviour.
+    const st = makeState({ marginTop: 40, marginBottom: 120 }); // band [40, 680], height 640
+    const fp = frame({ vAnchor: 'margin', yAlign: 'center', hRule: 'exact', h: 60 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    // band centre = marginTop + (pageH − marginTop − marginBottom − h)/2
+    //             = 40 + (800 − 40 − 120 − 60)/2 = 40 + 290 = 330
+    expect(b.y).toBe(40 + (800 - 40 - 120 - 60) / 2); // 330 — NOT page centre (800−60)/2 = 370
+    expect(b.y).not.toBe((800 - 60) / 2); // explicit: this is the band centre, not the page centre
+  });
+
   it('vAnchor="margin" + yAlign="bottom" sits flush to the bottom margin', () => {
     const st = makeState();
     const fp = frame({ vAnchor: 'margin', yAlign: 'bottom', hRule: 'exact', h: 60 });

--- a/packages/docx/src/frame-geometry.ts
+++ b/packages/docx/src/frame-geometry.ts
@@ -62,23 +62,38 @@ export function frameXContainer(hAnchor: string, state: RenderState): { left: nu
 }
 
 /**
- * Vertical container origin for a frame's vAnchor (ECMA-376 §17.3.1.11 /
- * §17.18.100). `paraTop` is the anchor paragraph's text-area top (canvas px).
- *   - "text"   → the paragraph top (y offsets/relative positions are measured
- *                from where the frame paragraph sits in the flow).
- *   - "margin" → the page top content margin.
- *   - "page"   → the physical page top.
+ * Vertical container band for a frame's vAnchor (ECMA-376 §17.3.1.11 /
+ * §17.18.100). Symmetric with {@link frameXContainer}: ST_YAlign positions the
+ * frame relative to the ANCHOR OBJECT (this band), not the physical page
+ * (§22.9.2.20: "this relative position is specified relative to the vertical
+ * anchor"). All values in canvas px (state.pageH is already px; margins are pt
+ * and scaled here). `paraTop` is the anchor paragraph's text-area top (px) and
+ * `contentH` its frame-content height (px), used only for the "text" band end.
+ *   - "page"   → [0, pageH]: the physical page edges (§17.18.100 page = "the
+ *                location of the edge of the page").
+ *   - "margin" → [marginTop, pageH−marginBottom]: the text margins (§17.18.100
+ *                margin = "the location of the text margin").
+ *   - "text"   → [paraTop, paraTop+contentH]: the anchor paragraph's text
+ *                extents (§17.18.100 text = "the top edge of the text in the
+ *                anchor paragraph"). Relative positioning (yAlign) is not
+ *                allowed for "text" (§17.3.1.11 yAlign), so only `start` is ever
+ *                consumed (as the base for the absolute y offset).
  */
-export function frameYContainer(vAnchor: string, paraTop: number, state: RenderState): number {
+export function frameYContainer(
+  vAnchor: string,
+  paraTop: number,
+  contentH: number,
+  state: RenderState,
+): { start: number; end: number } {
   const sc = state.scale;
   switch (vAnchor) {
     case 'margin':
-      return state.marginTop * sc;
+      return { start: state.marginTop * sc, end: state.pageH - state.marginBottom * sc };
     case 'page':
-      return 0;
+      return { start: 0, end: state.pageH };
     case 'text':
     default:
-      return paraTop;
+      return { start: paraTop, end: paraTop + contentH };
   }
 }
 
@@ -114,31 +129,32 @@ export function resolveAlignedPosH(
 /**
  * Resolve a vertical aligned position (canvas px) for a frame (yAlign,
  * §17.3.1.11) or a floating table (tblpYSpec, §17.4.57). Both use the same
- * ST_YAlign vocabulary, measured against the page box (not the band) per spec:
- *   center           → box centred between the top/bottom content margins
- *   bottom / outside  → box flush to the bottom content margin
- *   top / inside / inline / * → box at the vAnchor origin `vy` (the default)
+ * ST_YAlign vocabulary, measured against the vAnchor BAND `[band.start,
+ * band.end]` (the anchor object, §22.9.2.20) — symmetric with
+ * {@link resolveAlignedPosH}:
+ *   center           → box centred within the band
+ *   bottom / outside  → box flush to the band's end (bottom) edge
+ *   top / inside / inline / * → box flush to the band's start (top) edge (default)
  * Callers gate this on vAnchor!=='text' (relative vertical positioning is not
- * allowed there). Shared by {@link computeFrameBox} and computeFloatTableBox.
+ * allowed there, §17.3.1.11 yAlign). Shared by {@link computeFrameBox} and
+ * computeFloatTableBox.
  */
 export function resolveAlignedPosV(
   spec: string,
-  vy: number,
+  band: { start: number; end: number },
   size: number,
-  state: RenderState,
 ): number {
-  const sc = state.scale;
   switch (spec) {
     case 'center':
-      return vy + (state.pageH - size) / 2 - state.marginTop * sc;
+      return band.start + (band.end - band.start - size) / 2;
     case 'bottom':
     case 'outside':
-      return state.pageH - state.marginBottom * sc - size;
+      return band.end - size;
     case 'top':
     case 'inside':
     case 'inline':
     default:
-      return vy;
+      return band.start;
   }
 }
 
@@ -162,7 +178,10 @@ export function computeFrameBox(
   const isDropCap = fp.dropCap === 'drop' || fp.dropCap === 'margin';
 
   const hx = frameXContainer(fp.hAnchor, state);
-  const vy = frameYContainer(fp.vAnchor, paraTop, state);
+  // Vertical band of the vAnchor (the "anchor object", §22.9.2.20). The "text"
+  // band end uses the frame content height; yAlign is gated out for "text" so
+  // only band.start (= paraTop) is consumed there.
+  const vBand = frameYContainer(fp.vAnchor, paraTop, contentH, state);
 
   // Frame width: explicit `w` (exact) else natural content width (§17.3.1.11 w).
   const frameW = fp.w != null ? fp.w * sc : contentW;
@@ -207,11 +226,12 @@ export function computeFrameBox(
   // §17.3.1.11 yAlign), else absolute y offset from the vAnchor edge.
   let frameY: number;
   if (isDropCap) {
-    frameY = vy;
+    frameY = vBand.start;
   } else if (fp.yAlign && fp.vAnchor !== 'text') {
-    frameY = resolveAlignedPosV(fp.yAlign, vy, frameH, state);
+    frameY = resolveAlignedPosV(fp.yAlign, vBand, frameH);
   } else {
-    frameY = vy + (fp.y != null ? fp.y * sc : 0);
+    // §17.3.1.11 y: absolute signed offset from the vAnchor band start.
+    frameY = vBand.start + (fp.y != null ? fp.y * sc : 0);
   }
 
   // Exclusion padding: hSpace L/R applies only with wrap="around" (§17.3.1.11


### PR DESCRIPTION
## What

Make the **vertical** alignment of paragraph text frames (`<w:framePr>`, §17.3.1.11) and floating tables (`<w:tblpPr>`, §17.4.57) resolve against the **vAnchor band** (the anchor object), symmetric with the already-correct horizontal axis.

## Why (spec)

§22.9.2.20 (ST_YAlign): *"This relative position is specified relative to the vertical anchor specified by the parent object."* The spec example explicitly shows `w:vAnchor="margin" … w:yAlign="center"` centering the frame *"in the center of the anchor object, in this case, the margin"* — not the page. §17.18.100 (ST_VAnchor) defines the bands: `page` = the page edges, `margin` = the text margins, `text` = the top edge of the anchor paragraph's text.

Before this change, `frameXContainer` returned a `{left,right}` band and `resolveAlignedPosH` resolved center/right against it (correct), but `frameYContainer` returned a single origin and `resolveAlignedPosV` computed center/bottom/outside from hard-coded `pageHeight`/`marginTop`/`marginBottom`. So for `vAnchor=page`/`margin`, vertical center/bottom/outside/inside were always **physical-page** relative — the horizontal axis honored the anchor, the vertical axis did not.

## Change

- `frameYContainer(vAnchor, paraTop, contentH, state)` now returns a `{start,end}` band (mirrors `frameXContainer`):
  - `page`   → `[0, pageH]`
  - `margin` → `[marginTop, pageH − marginBottom]`
  - `text`   → `[paraTop, paraTop + contentH]`
- `resolveAlignedPosV(spec, band, size)` is band-relative: `center = start + (end − start − size)/2`, `bottom/outside = end − size`, `top/inside = start`. Absolute `y`/`tblpY` is measured from `band.start` (§17.3.1.11 y / §17.4.57 tblpY).
- `computeFrameBox` and `computeFloatTableBox` route vertical alignment through the band; the hard-coded `pageHeight`/`marginBottom` math is gone.

## Behavior: what changes / what stays

- **Changes:**
  - `vAnchor`/`vertAnchor` = `page` with `center`/`bottom`/`outside`/`inside`: no longer carries a spurious `marginTop`/`marginBottom` offset (e.g. `page` + `center` now centers over the full page).
  - `vAnchor`/`vertAnchor` = `margin` with `center`/`bottom`/`outside`/`inside`: **byte-identical only when margins are symmetric** (`marginTop == marginBottom`), because the band `[marginTop, pageH − marginBottom]` then has the same centre as the page. **With asymmetric margins, `margin` + `center` now centers in the margin *band* instead of the page centre** — this is the §22.9.2.20-correct fix (center "in the center of the anchor object, in this case, the margin"), and a behavior change vs. the pre-band code, which always used the page centre.
- **Unchanged (verified by existing tests):** `text`-anchored and default `top` frames/tables are identical (yAlign/tblpYSpec are gated out for `text`); horizontal placement untouched. The pre-existing margin-anchored tests use symmetric margins (72/72) and stay byte-identical.

## Tests (TDD)

Added band-relative cases to `frame-geometry.test.ts` (vAnchor margin/page × center/bottom/outside/top/inside, explicit-y from band start, text gating) and `float-table-geometry.test.ts` (vertAnchor=page × center/bottom/outside/top/inside). Confirmed Red (5 page-anchor failures) before the implementation, then Green.

Follow-up: added **asymmetric-margin** cases (marginTop=40, marginBottom=120) to both files pinning that `margin` + `center` resolves to the margin *band* centre (`marginTop + (pageH − marginTop − marginBottom − h)/2`), explicitly NOT the page centre. The symmetric (72/72) tests cannot distinguish those two — VRT does not exercise this path, so these units are the only guard for the §22.9.2.20 fix. Full docx unit suite: **209 passed**.

## Verification

- `vitest run` (docx, excl. Playwright VRT specs): 23 files / 209 tests green.
- Root typecheck equivalent: `tsc --build` (core/pptx/xlsx/docx) + markdown/node/vscode-extension `typecheck`, all exit 0 (after `pnpm build:wasm`).
- `ast-grep scan` on changed files: clean.

## VRT impact

VRT is local-only and not run here. Behavior changes **only** for `vAnchor=margin`/`page` vertical center/bottom/outside/inside (and, for `margin`, only under asymmetric margins). If any current VRT sample exercises that path, reference diffs may appear — **reference updates are user-only**; local VRT run recommended. The docx VRT suite covers only `dropCap="drop"` (paraTop/text-anchored), which is unchanged, so a diff is unlikely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
