### PR TITLE
refactor(docx): unify table row-height resolution (§17.4.80/.85) into one path

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -76,6 +76,11 @@ import {
   resolveAnchorX,
   resolveAnchorY,
 } from './anchor-geometry.js';
+import {
+  findMergeEndRow,
+  resolveTableRowHeights,
+  resolveSingleRowHeight,
+} from './table-geometry.js';
 import { justifiedPiecePositions } from '@silurus/ooxml-core';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
@@ -1941,65 +1946,24 @@ function splitParagraphAcrossPages(
 
 /** Per-row heights used by both pagination and the height estimate. Mirrors the
  *  renderer's row sizing (exact / atLeast / auto + vMerge span distribution,
- *  ECMA-376 §17.4.80, §17.4.85). */
+ *  ECMA-376 §17.4.80, §17.4.85) via the shared {@link resolveTableRowHeights}
+ *  skeleton. Works in pt (scale 1); the cell measurer is the paginator's
+ *  float-aware `estimateParagraphHeight` cursor-walk. */
 function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt: number): number[] {
   const colWidths = resolveColumnWidths(table, contentWPt, state);
-
-  const rowHs: number[] = [];
-  const restartInfo: Array<{ ri: number; ci: number; contentH: number }> = [];
-
-  for (let ri = 0; ri < table.rows.length; ri++) {
-    const row = table.rows[ri];
-    if (row.rowHeight != null && row.rowHeightRule === 'exact') {
-      rowHs.push(row.rowHeight);
-      continue;
-    }
-    // ECMA-376 §17.4.80 / §17.18.37 (ST_HeightRule):
-    //   auto (default)  — height is content-driven; the trHeight val is ignored
-    //                     ("with no predetermined minimum or maximum size"). val
-    //                     is only an advisory layout cache Word may emit.
-    //   atLeast         — val is a lower bound the content can exceed.
-    // So only atLeast uses val as a floor; auto falls back to the minimum row
-    // height (10pt) like a row with no trHeight at all.
-    let rowH =
-      row.rowHeight != null && row.rowHeightRule === 'atLeast' ? row.rowHeight : 10;
-    let ci = 0;
-    for (const cell of row.cells) {
-      const span = Math.min(cell.colSpan, colWidths.length - ci);
-      const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
-      const cm = effCellMargins(cell, table);
-      const innerW = Math.max(1, cellW - cm.left - cm.right);
-      let ch = cm.top + cm.bottom;
-      for (const ce of cell.content) {
-        if (ce.type === 'paragraph') {
-          ch += estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
-        } else if (ce.type === 'table') {
-          ch += estimateTableHeight(state, ce as unknown as DocTable, innerW);
-        }
+  return resolveTableRowHeights(table, colWidths, 1, (cell, cellW) => {
+    const cm = effCellMargins(cell, table);
+    const innerW = Math.max(1, cellW - cm.left - cm.right);
+    let ch = cm.top + cm.bottom;
+    for (const ce of cell.content) {
+      if (ce.type === 'paragraph') {
+        ch += estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
+      } else if (ce.type === 'table') {
+        ch += estimateTableHeight(state, ce as unknown as DocTable, innerW);
       }
-      // ECMA-376 §17.4.85: vMerge=restart cell content spans the merged region;
-      // do not inflate the first row alone. vMerge=false (continue) renders no
-      // content. Both are deferred to the post-pass below.
-      if (cell.vMerge === true) {
-        restartInfo.push({ ri, ci, contentH: ch });
-      } else if (cell.vMerge !== false) {
-        if (ch > rowH) rowH = ch;
-      }
-      ci += span;
     }
-    rowHs.push(rowH);
-  }
-
-  for (const info of restartInfo) {
-    const endRi = findMergeEndRow(table, info.ri, info.ci);
-    let spanH = 0;
-    for (let rj = info.ri; rj <= endRi; rj++) spanH += rowHs[rj];
-    if (spanH < info.contentH) {
-      rowHs[endRi] += info.contentH - spanH;
-    }
-  }
-
-  return rowHs;
+    return ch;
+  });
 }
 
 function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: number): number {
@@ -2321,29 +2285,6 @@ export function splitTableAcrossPages(
     }
   }
   return y;
-}
-
-/** Find the last row index in a vMerge span starting at (startRi, startCi) —
- *  i.e. walk forward while subsequent rows have a cell at column-start ci with
- *  vMerge=false (continue). ECMA-376 §17.4.85. */
-function findMergeEndRow(table: DocTable, startRi: number, startCi: number): number {
-  let endRi = startRi;
-  for (let rj = startRi + 1; rj < table.rows.length; rj++) {
-    const row = table.rows[rj];
-    let ci = 0;
-    let matched = false;
-    for (const cell of row.cells) {
-      if (ci === startCi) {
-        if (cell.vMerge === false) matched = true;
-        break;
-      }
-      if (ci > startCi) break;
-      ci += cell.colSpan;
-    }
-    if (!matched) break;
-    endRi = rj;
-  }
-  return endRi;
 }
 
 function pickHeaderFooter(
@@ -5419,34 +5360,35 @@ function computeTableLayout(
   const colWidths = resolveColumnWidths(table, contentWPx / scale, state).map((w) => w * scale);
   const tableW = colWidths.reduce((s, w) => s + w, 0);
 
-  const rowHeights: number[] = [];
-  for (const row of table.rows) {
-    rowHeights.push(calculateRowHeight(row, table, colWidths, scale, state));
-  }
-
-  // ECMA-376 §17.4.85: extend each vMerge span's last row when the restart
-  // cell's content exceeds the sum of its rows. calculateRowHeight excluded
-  // restart cells from per-row height to keep the FIRST row from absorbing
-  // all the content of a tall merged cell.
-  for (let ri = 0; ri < table.rows.length; ri++) {
-    let ci = 0;
-    for (const cell of table.rows[ri].cells) {
-      const span = Math.min(cell.colSpan, colWidths.length - ci);
-      if (cell.vMerge === true) {
-        const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
-        const contentH = measureRestartCellContentHeight(cell, table, cellW, scale, state);
-        const endRi = findMergeEndRow(table, ri, ci);
-        let spanH = 0;
-        for (let rj = ri; rj <= endRi; rj++) spanH += rowHeights[rj];
-        if (spanH < contentH) {
-          rowHeights[endRi] += contentH - spanH;
-        }
-      }
-      ci += span;
-    }
-  }
+  // Shared ST_HeightRule + §17.4.85 vMerge-span skeleton (resolveTableRowHeights),
+  // with the paint pass's px cell measurer. The restart-span extension is part of
+  // the skeleton now — calculateRowHeight already excludes restart cells per-row,
+  // and the resolver re-measures them via the same callback to grow the last row.
+  const rowHeights = resolveTableRowHeights(table, colWidths, scale, (cell, cellW) =>
+    measureCellContentHeightPx(cell, table, cellW, scale, state),
+  );
 
   return { colWidths, tableW, rowHeights };
+}
+
+/** Content height (px, at `scale`) of a table cell laid out at total width
+ *  `cellW`: cell top/bottom margins plus each content element measured at the
+ *  paint pass's `measureCellElementHeight`. Shared by the per-row skeleton (via
+ *  computeTableLayout) and the exported {@link calculateRowHeight}. */
+function measureCellContentHeightPx(
+  cell: DocTableCell,
+  table: DocTable,
+  cellW: number,
+  scale: number,
+  state: RenderState,
+): number {
+  const cm = effCellMargins(cell, table);
+  const contentW = cellW - (cm.left + cm.right) * scale;
+  let h = (cm.top + cm.bottom) * scale;
+  for (const ce of cell.content) {
+    h += measureCellElementHeight(state, ce, contentW, scale);
+  }
+  return h;
 }
 
 /** Draw all rows of a table whose grid origin is `tableX` (px) and whose top is
@@ -5602,12 +5544,10 @@ function renderTable(table: DocTable, state: RenderState): void {
   state.y = y;
 }
 
-/** Minimum table-row height (pt) when no `w:trHeight` floor applies — i.e. an
- *  `auto` row, or `atLeast`/`exact` with no `@val`. ECMA-376 leaves the auto
- *  minimum implementation-defined; this is the floor an empty row collapses to
- *  before content (cell margins + measured content) expands it. */
-const MIN_ROW_HEIGHT_PT = 10;
-
+/** Height (px) of a single table row via the shared ST_HeightRule skeleton
+ *  ({@link resolveSingleRowHeight}), with the paint pass's px cell measurer.
+ *  EXCLUDES the §17.4.85 vMerge span extension — `computeTableLayout` applies
+ *  that across the whole table. Exported for unit tests (table-row-height.test). */
 export function calculateRowHeight(
   row: DocTableRow,
   table: DocTable,
@@ -5615,74 +5555,9 @@ export function calculateRowHeight(
   scale: number,
   state: RenderState,
 ): number {
-  // ECMA-376 §17.4.80 / §17.18.37 (ST_HeightRule):
-  //   exact   — height is exactly w:trHeight/@val; overflow is clipped.
-  //   atLeast — w:trHeight/@val is a lower bound; content can expand the row.
-  //   auto    — height is determined entirely by the content; the @val is
-  //             ignored ("with no predetermined minimum or maximum size").
-  //             @val on an auto row is only an advisory layout cache Word may
-  //             write back, never a floor. (auto is also the default when
-  //             @hRule is omitted.)
-  // Only atLeast contributes a val-derived floor; auto and the no-trHeight case
-  // fall back to the minimum row height.
-  if (row.rowHeight != null && row.rowHeightRule === 'exact') return row.rowHeight * scale;
-  const minH =
-    row.rowHeight != null && row.rowHeightRule === 'atLeast'
-      ? row.rowHeight * scale
-      : MIN_ROW_HEIGHT_PT * scale;
-
-  let maxH = minH;
-  let ci = 0;
-  for (const cell of row.cells) {
-    const span = Math.min(cell.colSpan, colWidths.length - ci);
-    const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
-    const cm = effCellMargins(cell, table);
-    const contentW = cellW - (cm.left + cm.right) * scale;
-
-    // ECMA-376 §17.4.85 (w:vMerge): a vMerge=restart cell's content occupies
-    // the entire merged span (this row + following rows whose same column
-    // carries vMerge=continue). Including its content height in THIS row's
-    // height would inflate the first row of the span and push subsequent
-    // content downward — Word distributes the merged-cell content across the
-    // full span instead. We exclude such cells here; the calling code applies
-    // a second pass to extend the span's last row when the merged sum is
-    // shorter than the restart cell's content.
-    if (cell.vMerge === true) {
-      ci += span;
-      continue;
-    }
-    // vMerge=false (continue) cells contain no rendered content.
-    if (cell.vMerge === false) {
-      ci += span;
-      continue;
-    }
-
-    let h = (cm.top + cm.bottom) * scale;
-    for (const ce of cell.content) {
-      h += measureCellElementHeight(state, ce, contentW, scale);
-    }
-    if (h > maxH) maxH = h;
-    ci += span;
-  }
-  return maxH;
-}
-
-/** Measure a vMerge=restart cell's full content height including cell margins.
- *  Used by the pass-2 merge-span extension in renderTable / estimateTableHeight. */
-function measureRestartCellContentHeight(
-  cell: DocTableCell,
-  table: DocTable,
-  cellW: number,
-  scale: number,
-  state: RenderState,
-): number {
-  const cm = effCellMargins(cell, table);
-  const contentW = cellW - (cm.left + cm.right) * scale;
-  let h = (cm.top + cm.bottom) * scale;
-  for (const ce of cell.content) {
-    h += measureCellElementHeight(state, ce, contentW, scale);
-  }
-  return h;
+  return resolveSingleRowHeight(row, colWidths, scale, (cell, cellW) =>
+    measureCellContentHeightPx(cell, table, cellW, scale, state),
+  );
 }
 
 function measureParaHeight(

--- a/packages/docx/src/table-geometry.ts
+++ b/packages/docx/src/table-geometry.ts
@@ -1,0 +1,156 @@
+// Table row-height resolution skeleton (ECMA-376 §17.4.80 `<w:trHeight>` /
+// §17.18.37 ST_HeightRule + §17.4.85 `<w:vMerge>` span extension).
+//
+// The trHeight rule (exact / atLeast / auto), the auto/no-floor minimum, the
+// gridSpan column slicing, and the vMerge restart-span post-pass are pure
+// structural math that does NOT depend on whether the caller works in pt
+// (paginator) or px (paint) units. This module factors that skeleton out of
+// renderer.ts so the rule is expressed once: previously both
+// `computeTableRowHeights` (pt) and `computeTableLayout`/`calculateRowHeight`
+// (px) re-implemented it, and #523 had to patch the identical regression in two
+// places. The two callers still differ in HOW a cell's content height is
+// measured (the paginator's `estimateParagraphHeight` cursor-walk vs the paint
+// pass's `measureParaHeight`); that measurement is supplied as a callback and is
+// deliberately NOT unified here — see the note on `measureCellContentHeight`.
+//
+// Only DocTable/DocTableRow/DocTableCell types are imported (erased at runtime),
+// so there is no import cycle with renderer.ts.
+
+import type { DocTable, DocTableRow, DocTableCell } from './types.js';
+
+/** Minimum table-row height (pt) when no `w:trHeight` floor applies — i.e. an
+ *  `auto` row, or `atLeast`/`exact` with no `@val`. ECMA-376 leaves the auto
+ *  minimum implementation-defined; this is the floor an empty row collapses to
+ *  before content (cell margins + measured content) expands it. */
+export const MIN_ROW_HEIGHT_PT = 10;
+
+/** Last row index covered by the vMerge span that starts at (`startRi`,
+ *  `startCi`). A span continues through following rows whose cell anchored in the
+ *  same grid column carries `vMerge=continue` (ECMA-376 §17.4.85). Pure
+ *  table-structure walk — no geometry. */
+export function findMergeEndRow(table: DocTable, startRi: number, startCi: number): number {
+  let endRi = startRi;
+  for (let rj = startRi + 1; rj < table.rows.length; rj++) {
+    const row = table.rows[rj];
+    let ci = 0;
+    let matched = false;
+    for (const cell of row.cells) {
+      if (ci === startCi) {
+        if (cell.vMerge === false) matched = true;
+        break;
+      }
+      if (ci > startCi) break;
+      ci += cell.colSpan;
+    }
+    if (!matched) break;
+    endRi = rj;
+  }
+  return endRi;
+}
+
+/** Measure the content height (already in the target units — px at `scale`, or
+ *  pt at `scale=1`) of a single cell laid out at the given total cell width
+ *  (`cellWidth`, the summed widths of the grid columns it spans). MUST include
+ *  the cell's top/bottom margins. The two callers pass DIFFERENT measurers — the
+ *  paginator mirrors `renderParagraph`'s float-aware cursor walk
+ *  (`estimateParagraphHeight`); the paint pass uses the lighter `measureParaHeight`
+ *  + explicit spaceBefore/After. They are not equivalent (e.g. an empty East
+ *  Asian paragraph mark on a docGrid rounds to a different cell count), so this
+ *  skeleton keeps each caller's measurer intact rather than choosing one. */
+export type MeasureCellContentHeight = (cell: DocTableCell, cellWidth: number) => number;
+
+/**
+ * Resolve per-row heights for a table whose grid columns have widths
+ * `colWidths` (in the same target units as the measurer returns: px when
+ * `scale` is the device scale, pt when `scale === 1`). Applies, once:
+ *
+ *   - ECMA-376 §17.4.80 / §17.18.37 (ST_HeightRule):
+ *       exact   — height is exactly `w:trHeight/@val` (× `scale`); overflow is
+ *                 clipped by the caller.
+ *       atLeast — `@val` (× `scale`) is a lower bound; content can grow the row.
+ *       auto    — `@val` is IGNORED ("no predetermined minimum or maximum size",
+ *                 advisory layout cache only); the row falls back to the
+ *                 `MIN_ROW_HEIGHT_PT` floor. Same as a row with no `w:trHeight`.
+ *   - gridSpan: a cell's width is the sum of the `cell.colSpan` columns it
+ *     anchors (clamped to the remaining columns).
+ *   - ECMA-376 §17.4.85 (vMerge): a `vMerge=restart` cell's content occupies the
+ *     whole merged span. It is EXCLUDED from its first row's height (so the first
+ *     row is not inflated) and instead a post-pass extends the span's LAST row
+ *     when the restart cell's content exceeds the summed span height.
+ *     `vMerge=continue` cells render no content.
+ *
+ * `measureCellContentHeight` supplies the unit-specific content measurement (see
+ * its type doc). The restart cell is measured through the SAME callback in the
+ * post-pass; the callback must be a pure read of layout state (it is, in both
+ * callers) so re-measuring yields the value the first pass would have computed.
+ */
+/**
+ * Height of ONE row (ECMA-376 §17.4.80 / §17.18.37 ST_HeightRule + gridSpan),
+ * EXCLUDING the §17.4.85 vMerge span extension (the caller / the table-level
+ * resolver applies that in a post-pass). `exact` returns exactly `@val × scale`;
+ * `atLeast` floors at `@val × scale`; `auto` / no-`@val` floors at
+ * `MIN_ROW_HEIGHT_PT × scale`. A `vMerge=restart` cell is excluded (its content
+ * is distributed across the span, not absorbed by its first row) and a
+ * `vMerge=continue` cell renders no content. This is the single source of the
+ * trHeight rule, shared by {@link resolveTableRowHeights} and the exported
+ * `calculateRowHeight`.
+ */
+export function resolveSingleRowHeight(
+  row: DocTableRow,
+  colWidths: number[],
+  scale: number,
+  measureCellContentHeight: MeasureCellContentHeight,
+): number {
+  if (row.rowHeight != null && row.rowHeightRule === 'exact') return row.rowHeight * scale;
+  let rowH =
+    row.rowHeight != null && row.rowHeightRule === 'atLeast'
+      ? row.rowHeight * scale
+      : MIN_ROW_HEIGHT_PT * scale;
+
+  let ci = 0;
+  for (const cell of row.cells) {
+    const span = Math.min(cell.colSpan, colWidths.length - ci);
+    // vMerge=restart cells are sized by the span post-pass; vMerge=continue
+    // cells render no content. Neither raises THIS row's height directly.
+    if (cell.vMerge !== true && cell.vMerge !== false) {
+      const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
+      const ch = measureCellContentHeight(cell, cellW);
+      if (ch > rowH) rowH = ch;
+    }
+    ci += span;
+  }
+  return rowH;
+}
+
+export function resolveTableRowHeights(
+  table: DocTable,
+  colWidths: number[],
+  scale: number,
+  measureCellContentHeight: MeasureCellContentHeight,
+): number[] {
+  const rowHeights = table.rows.map((row) =>
+    resolveSingleRowHeight(row, colWidths, scale, measureCellContentHeight),
+  );
+
+  // §17.4.85 span extension: for each vMerge=restart cell, grow the span's last
+  // row if the restart cell's full content is taller than the summed span rows.
+  for (let ri = 0; ri < table.rows.length; ri++) {
+    let ci = 0;
+    for (const cell of table.rows[ri].cells) {
+      const span = Math.min(cell.colSpan, colWidths.length - ci);
+      if (cell.vMerge === true) {
+        const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
+        const contentH = measureCellContentHeight(cell, cellW);
+        const endRi = findMergeEndRow(table, ri, ci);
+        let spanH = 0;
+        for (let rj = ri; rj <= endRi; rj++) spanH += rowHeights[rj];
+        if (spanH < contentH) {
+          rowHeights[endRi] += contentH - spanH;
+        }
+      }
+      ci += span;
+    }
+  }
+
+  return rowHeights;
+}


### PR DESCRIPTION
## What

Factors the duplicated table **row-height rule skeleton** out of `renderer.ts` into a new `packages/docx/src/table-geometry.ts`, so the ECMA-376 §17.4.80/§17.18.37 ST_HeightRule + §17.4.85 vMerge span logic is expressed **once**.

New module exports:
- `MIN_ROW_HEIGHT_PT` (the auto/no-floor minimum, was duplicated as a literal `10` in the pt path and a named const in the px path)
- `findMergeEndRow` (was a private fn in `renderer.ts`)
- `resolveSingleRowHeight` — per-row exact/atLeast/auto floor + gridSpan slicing + vMerge restart/continue exclusion
- `resolveTableRowHeights` — wraps `resolveSingleRowHeight` over all rows + the §17.4.85 restart-span last-row extension post-pass

Both former call sites now call the shared resolver and supply only their unit-specific cell-content measurer via a callback:
- **pt paginator path** (`computeTableRowHeights`): `scale = 1`, measurer = `estimateParagraphHeight` cursor-walk (unchanged)
- **px paint path** (`computeTableLayout` / exported `calculateRowHeight`): `scale = device`, measurer = the new `measureCellContentHeightPx` wrapping `measureCellElementHeight` (unchanged; this is the old `calculateRowHeight` / `measureRestartCellContentHeight` body, now deduped to one fn)

Net `renderer.ts` −122 lines; `measureRestartCellContentHeight` (which was byte-identical to the px measurer) removed.

## Why this is the right scope — the two CONTENT measurers are NOT equivalent (latent divergence, left untouched)

The task asked to first verify the two row-height implementations are equivalent, and **only** collapse to a single resolver for the parts that genuinely are; where they diverge, report it rather than silently pick a winner.

The **rule skeleton** (trHeight floor, min, gridSpan, vMerge span) IS equivalent modulo `scale` — that is what this PR unifies. But the **per-cell content measurement** is genuinely different and is deliberately kept per-path:

| input | pt path (`estimateParagraphHeight`) | px path (`measureParaHeight` + explicit space) | effect |
|---|---|---|---|
| **empty paragraph mark in an East-Asian doc on a `lines`/`linesAndChars` docGrid** | `paragraphMarkLineHeight(..., state.docEastAsian, ctx)` probes the real EA font box (`measureText('あ')`, fontBoundingBox) → rounds up to whole grid cells (e.g. 20pt mark on 20pt pitch ⇒ 2 cells) | synthetic `emptyLineNaturalPx` 0.8/0.2 ≈ 1em ⇒ rounds **down** to 1 cell | paginator reserves a **taller** empty cell row than the painter draws |
| **first-line indent** | passes `para.indentFirst` to `layoutLines` | passes `0` | wrap/line count can differ when the first line indent changes wrapping |
| **left/right indent** | subtracts `indentLeft`/`indentRight` (bidi-resolved) from the wrap width | uses full inner width | line count can differ for indented cell paragraphs |
| **ruby paragraph** | snaps every line to an integer docGrid pitch (`snapParaLineToGrid`) | no grid snap | ruby cell rows differ |
| **active full-width float band** | adds `skipPastTopAndBottom` / per-line `topY` displacement | ignores floats | (floats rarely active during table measurement, but the codepaths differ) |

These come from two structurally different measurement engines, and "fixing" them requires deciding which matches Word — a spec/Word-runtime adjudication that is **out of scope** here and could change rendering. So this PR does **not** unify them. It only removes the duplicate **rule** logic (the thing #523 had to patch twice), which keeps measure and paint in lock-step for the rule while leaving the measurement divergence exactly as-is.

Note: the paginator already uses BOTH engines today — a *floating* table goes through `computeTableLayout` (px engine) while a *block* table goes through `computeTableRowHeights` (pt engine), and nested tables re-enter the pt engine from within the px path. So the divergence is pre-existing and interleaved; this refactor neither widens nor narrows it.

## Behavior unchanged (verification)

- The per-cell measurement (and thus every row height) is byte-identical to before — each caller keeps its own measurer; only the shared rule wrapper changed.
- `table-row-height.test.ts` and `measure-column-geometry.test.ts` pass **with no expected-value edits**; full docx suite green (**23 files / 195 tests**).
- Root `pnpm typecheck` clean (`tsc --build` + markdown/node/vscode-extension typechecks all pass).
- VRT not run (local-only; behavior-unchanged refactor). The cell-measurement divergence above is unchanged by this PR, so VRT deltas are not expected — but if a reviewer wants belt-and-suspenders, a local `pnpm --filter @silurus/ooxml-docx vrt` on the table samples confirms the row geometry is identical.

## Follow-up (separate task)

The `estimateParagraphHeight` vs `measureParaHeight` measure/paint divergence (esp. the empty East-Asian paragraph-mark grid rounding) is a real latent bug. Reconciling it — likely by routing the paint path's empty-mark/indent/ruby handling through the same primitives as the paginator, after confirming against Word — should be its own change with its own VRT/visual sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)