### PR TITLE
fix(docx): table border render fidelity — border-collapse paint order + thin double rails

### DIFF
--- a/packages/docx/src/border-double.test.ts
+++ b/packages/docx/src/border-double.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { doubleRailGeometry } from './renderer.js';
+
+// ECMA-376 §17.18.2 ST_Border "double": two parallel lines. The standard leaves
+// the rail/gap PIXEL geometry to the implementation; we render three device-px
+// bands (rail / gap / rail, each ≈ lw/3) with each band floored at one device
+// pixel so a thin double never collapses into a single line. `lw` is the stroked
+// width in px; the canvas is `ctx.scale(dpr,dpr)`-d, so the band is laid out in
+// device pixels (lw·dpr).
+describe('doubleRailGeometry (ST_Border §17.18.2 "double")', () => {
+  // THE regression gate: a thin `double` (e.g. a table "Total" row top at
+  // sz6 ≈ 0.75px) used to render the two rails overlapping with no gap, so it
+  // looked like a single line. For ANY width/dpr the two rails must stay
+  // separated — gapDev ≥ 1 device px — and each rail must paint — railDev ≥ 1.
+  it('always keeps the two rails ≥ 1 device pixel apart (no collapse)', () => {
+    for (const lw of [0.5, 0.75, 1, 1.1, 1.5, 2, 2.25, 3, 4.5, 6, 9]) {
+      for (const dpr of [1, 2, 3]) {
+        const { railDev, gapDev } = doubleRailGeometry(lw, dpr);
+        expect(railDev, `railDev for lw=${lw} dpr=${dpr}`).toBeGreaterThanOrEqual(1);
+        expect(gapDev, `gapDev for lw=${lw} dpr=${dpr}`).toBeGreaterThanOrEqual(1);
+      }
+    }
+  });
+
+  // A thin double (sz6 = 0.75pt) at scale≈1: the case that used to collapse.
+  // The one-device-pixel floor lifts the 0-rounded thirds to a 1/1/1 band.
+  it('floors a thin double to a 1/1/1 device-pixel band', () => {
+    expect(doubleRailGeometry(0.75, 1)).toEqual({ railDev: 1, gapDev: 1, spanDev: 3 });
+    expect(doubleRailGeometry(1.0, 2)).toEqual({ railDev: 1, gapDev: 1, spanDev: 3 });
+    // Even a sub-floor hairline still yields a visible two-line band.
+    expect(doubleRailGeometry(0.5, 1)).toEqual({ railDev: 1, gapDev: 1, spanDev: 3 });
+  });
+
+  // A thick double reduces to the equal line/gap/line thirds (no floor effect).
+  it('reduces to equal thirds for a thick double', () => {
+    expect(doubleRailGeometry(6, 1)).toEqual({ railDev: 2, gapDev: 2, spanDev: 6 });
+    expect(doubleRailGeometry(9, 1)).toEqual({ railDev: 3, gapDev: 3, spanDev: 9 });
+    expect(doubleRailGeometry(3, 2)).toEqual({ railDev: 2, gapDev: 2, spanDev: 6 });
+  });
+
+  // The band is symmetric — rail and gap are the same width at every size — and
+  // spanDev is always 2·railDev + gapDev.
+  it('keeps the band symmetric (rail === gap) and consistent', () => {
+    for (const lw of [0.75, 2.25, 6]) {
+      const { railDev, gapDev, spanDev } = doubleRailGeometry(lw, 2);
+      expect(railDev).toBe(gapDev);
+      expect(spanDev).toBe(2 * railDev + gapDev);
+    }
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5910,6 +5910,25 @@ export function borderDashPattern(style: string, lw: number): number[] {
   return docxBorderDashArray(style, lw);
 }
 
+/**
+ * Device-pixel band layout for an ECMA-376 §17.18.2 `double` border of stroked
+ * width `lw` (px) on a `ctx.scale(dpr,dpr)`-d canvas: three bands — rail / gap /
+ * rail, each ≈ lw/3 — but each FLOORED at one device pixel. The floor is what
+ * stops a thin double (e.g. sz6 ≈ 0.75px) collapsing into a single line: with
+ * `gapDev ≥ 1` the two rails are always separated by at least one device pixel,
+ * and with `railDev ≥ 1` each rail always paints. For thick borders it reduces
+ * to equal thirds. Exported for unit tests only — not part of the package API.
+ */
+export function doubleRailGeometry(lw: number, dpr: number): {
+  railDev: number;
+  gapDev: number;
+  spanDev: number;
+} {
+  const railDev = Math.max(1, Math.round((lw * dpr) / 3));
+  const gapDev = Math.max(1, Math.round((lw * dpr) / 3));
+  return { railDev, gapDev, spanDev: 2 * railDev + gapDev };
+}
+
 function drawBorderLine(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   x1: number, y1: number, x2: number, y2: number,
@@ -5936,9 +5955,7 @@ function drawBorderLine(
     // top of each other and re-collapse the gap. Computing both rails from a
     // single rounded band origin in device space keeps the rail/gap/rail bands
     // whole device pixels, so the gap survives at any sz/scale/dpr.
-    const railDev = Math.max(1, Math.round((lw * dpr) / 3));
-    const gapDev = Math.max(1, Math.round((lw * dpr) / 3));
-    const spanDev = 2 * railDev + gapDev;
+    const { railDev, gapDev, spanDev } = doubleRailGeometry(lw, dpr);
     ctx.fillStyle = ctx.strokeStyle;
     const horizontal = y1 === y2;
     if (horizontal) {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5922,15 +5922,35 @@ function drawBorderLine(
   const lw = Math.max(0.5, spec.width * scale);
 
   if (spec.style === 'double') {
-    // ECMA-376 §17.18.2 ST_Border "double": a double line around the object.
-    // The standard does not normatively define the rail/gap geometry, so this
-    // matches Word's rendering — three equal bands across the nominal width
-    // (line / gap / line), each rail = sz/3, gap = sz/3, the pair centered on
-    // the edge. (Word's own UI labels `sz` as the total double-border width.)
-    const railW = Math.max(0.5, lw / 3);
-    const offset = (lw - railW) / 2; // rail centers sit ±offset from the edge
-    strokeCrispSegment(ctx, x1, y1, x2, y2, railW, dpr, -offset);
-    strokeCrispSegment(ctx, x1, y1, x2, y2, railW, dpr, offset);
+    // ECMA-376 §17.18.2 ST_Border "double": two parallel lines. The standard
+    // leaves the rail/gap PIXEL geometry to the implementation, so this matches
+    // Word — three bands across the nominal width (line / gap / line, each
+    // ≈ lw/3) — but with each band FLOORED at one device pixel so a thin double
+    // (e.g. sz6 ≈ 0.75px) never collapses into a single line. This is a
+    // rendering-legibility floor, NOT a content heuristic; for thick borders it
+    // reduces to the equal line/gap/line thirds.
+    //
+    // Drawn as device-pixel-aligned FILLS rather than two independently
+    // crisp-snapped strokes: `crispOffset` snaps each thin rail to the nearest
+    // device row on its own, which would pull two rails only ~1px apart back on
+    // top of each other and re-collapse the gap. Computing both rails from a
+    // single rounded band origin in device space keeps the rail/gap/rail bands
+    // whole device pixels, so the gap survives at any sz/scale/dpr.
+    const railDev = Math.max(1, Math.round((lw * dpr) / 3));
+    const gapDev = Math.max(1, Math.round((lw * dpr) / 3));
+    const spanDev = 2 * railDev + gapDev;
+    ctx.fillStyle = ctx.strokeStyle;
+    const horizontal = y1 === y2;
+    if (horizontal) {
+      // Centre the band on the edge, snapped to a whole device row.
+      const startDev = Math.round(y1 * dpr - spanDev / 2);
+      ctx.fillRect(x1, startDev / dpr, x2 - x1, railDev / dpr);
+      ctx.fillRect(x1, (startDev + railDev + gapDev) / dpr, x2 - x1, railDev / dpr);
+    } else {
+      const startDev = Math.round(x1 * dpr - spanDev / 2);
+      ctx.fillRect(startDev / dpr, y1, railDev / dpr, y2 - y1);
+      ctx.fillRect((startDev + railDev + gapDev) / dpr, y1, railDev / dpr, y2 - y1);
+    }
     ctx.restore();
     return;
   }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5416,6 +5416,23 @@ function drawTableRows(
   // from logical column offset to a physical x flips.
   const mirror = table.bidiVisual === true;
 
+  // ECMA-376 §17.4.66 (border-collapse): a shared gridline must sit ON TOP of
+  // every cell fill. Painting cell-by-cell (fill→border, per cell) let the next
+  // column's background fill cover the half of the vertical border the previous
+  // column had just drawn; with alternating row banding (e.g. Medium List 2)
+  // this made a shared vertical rule look like its thickness changed row to row.
+  // So walk the grid ONCE to collect every cell's paint box, then paint in TWO
+  // passes: all backgrounds + content first, all borders second.
+  const jobs: Array<{
+    cell: DocTableCell;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    edges: CellEdgeFlags;
+    clipExact: boolean;
+  }> = [];
+
   let y = startY;
   for (let ri = 0; ri < table.rows.length; ri++) {
     const row = table.rows[ri];
@@ -5462,8 +5479,8 @@ function drawTableRows(
         // cell spans multiple rows, so it is never governed by a single row's
         // exact height — only single-row cells clip.
         const clipExact = row.rowHeightRule === 'exact' && cell.vMerge !== true;
-        if (!dryRun) renderCell(cell, table, leadX, y, cellW, drawH, state, edges, mirror, clipExact);
-        else measureCellContent(cell, table, cellW, scale, state);
+        if (dryRun) measureCellContent(cell, table, cellW, scale, state);
+        else jobs.push({ cell, x: leadX, y, w: cellW, h: drawH, edges, clipExact });
       }
 
       x += cellW;
@@ -5471,6 +5488,20 @@ function drawTableRows(
     }
 
     y += rowH;
+  }
+
+  // Pass 1: backgrounds + content. Pass 2: borders, so a border is never
+  // overpainted by a neighbouring cell's fill. `mirror` only swaps which
+  // physical side a logical border maps to, so it is consulted in the border
+  // pass alone.
+  for (const j of jobs) {
+    renderCell(j.cell, table, j.x, j.y, j.w, j.h, state, j.clipExact);
+  }
+  for (const j of jobs) {
+    drawCellBorders(
+      state.ctx, j.x, j.y, j.w, j.h, j.cell.borders, table.borders,
+      scale, j.edges, mirror, state.dpr,
+    );
   }
   return y;
 }
@@ -5636,18 +5667,18 @@ function renderCell(
   w: number,
   h: number,
   state: RenderState,
-  edges: CellEdgeFlags,
-  mirror = false,
   clipExact = false,
 ): void {
   const { ctx, scale } = state;
 
+  // Cell BACKGROUND + content only. Borders are painted in a separate, later
+  // pass by drawTableRows (ECMA-376 §17.4.66 border-collapse): a shared gridline
+  // must sit on top of every cell fill, so no neighbouring cell's background can
+  // occlude the border drawn by the cell on the other side of the gridline.
   if (cell.background) {
     ctx.fillStyle = `#${cell.background}`;
     ctx.fillRect(x, y, w, h);
   }
-
-  drawCellBorders(ctx, x, y, w, h, cell.borders, table.borders, scale, edges, mirror, state.dpr);
 
   const cm = effCellMargins(cell, table);
   const mt = cm.top * scale;


### PR DESCRIPTION
sample-11 page 3 surfaced two renderer-only table-border defects. The parsed model was already correct in both cases; only the canvas paint path was wrong.

## 1. Shared vertical rule looked like its thickness changed row to row
The blue "City or Town" table (`MediumList2-Accent1`, horizontal banding) drew the vertical rule between the label column and the first data column at an uneven thickness, alternating with the row bands.

**Cause:** cells were painted one at a time — background `fillRect` then borders, *per cell* — so the next column's background overpainted the half of the shared vertical border the previous column had just drawn. Only banded rows carried a fill, so only those rows ate into the border → apparent alternating thickness.

**Fix:** walk the grid once to collect each cell's paint box, then paint in **two passes** — all backgrounds + content first, all borders second — so a border is never occluded by a neighbouring cell's fill (ECMA-376 §17.4.66 border-collapse). Applies to every table, not just this one.

## 2. A thin `double` border collapsed into a single line
The teal "College" table's `Total` row top is `double sz=6` (0.75pt) but rendered as one thick line.

**Cause:** the two rails were stroked at ±(lw−railW)/2 with `railW` floored at 0.5px while the offset was not; for a thin double the rails overlapped and `crispOffset` snapped them onto the same device row.

**Fix:** render the double as device-pixel-aligned **fills** from a single rounded band origin — rail / gap / rail, each ≈ lw/3 but floored at one device pixel — so the gap is a whole device pixel and survives at any sz/scale/dpr. Thick borders still reduce to equal thirds. The 1-device-pixel floor is a rendering-legibility minimum; §17.18.2 leaves the rail/gap pixel geometry to the renderer.

## Verification
- Pixel-measured on sample-11 page 3: vertical rule now uniform (122.7 darkness at every row, was alternating); `Total` top now shows two rails + a gap (darkness profile two-peak, was single-peak).
- docx VRT 21/21 unchanged (no diff% regression); 209 docx unit tests pass; root typecheck clean.
- Renderer-only; no parser / WASM / type changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)