### PR TITLE
fix(docx): map Ubuntu theme font to Google Fonts (sample-11 cell wrap)

### DIFF
--- a/packages/docx/src/google-fonts.test.ts
+++ b/packages/docx/src/google-fonts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { docxFontPreloadNames } from './google-fonts.js';
+import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts.js';
 import type { DocxDocumentModel } from './types.js';
 
 /** Build a minimal model whose body is a single paragraph with one text run. */
@@ -45,5 +45,28 @@ describe('docxFontPreloadNames — script-aware preload', () => {
   it('is deterministic — same model yields the same set (main == worker)', () => {
     const doc = docWith('日本語 العربية');
     expect(docxFontPreloadNames(doc)).toEqual(docxFontPreloadNames(doc));
+  });
+});
+
+describe('DOCX_GOOGLE_FONTS — theme typeface coverage', () => {
+  // Templates whose theme minorFont is Ubuntu (e.g. sample-11) emit runs with
+  // family "Ubuntu". Without an explicit mapping the preloader skips the name
+  // and the renderer falls back to a system sans whose metrics are narrower
+  // than Ubuntu's — table cells sized against the Ubuntu width then fail to
+  // wrap where Word would. The map entry resolves Ubuntu against Google Fonts
+  // so the canvas measures glyphs with the actual face.
+  it('resolves Ubuntu to a Google Fonts Ubuntu stylesheet', () => {
+    const entry = DOCX_GOOGLE_FONTS['ubuntu'];
+    expect(entry).toBeDefined();
+    expect(entry.url).toMatch(/^https:\/\/fonts\.googleapis\.com\/css2\?/);
+    expect(entry.url).toMatch(/family=Ubuntu(?:[:&]|$)/);
+    // No loadFamily override — Google Fonts ships the same family name, so
+    // the renderer's canvas font stack can use "Ubuntu" directly.
+    expect(entry.loadFamily).toBeUndefined();
+  });
+
+  it('includes Ubuntu in the preload list when the theme minorFont is Ubuntu', () => {
+    const names = docxFontPreloadNames(docWith('City or Town', 'Calibri', 'Ubuntu'));
+    expect(names).toContain('Ubuntu');
   });
 });

--- a/packages/docx/src/google-fonts.ts
+++ b/packages/docx/src/google-fonts.ts
@@ -33,6 +33,13 @@ export const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   'poppins':           { url: 'https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'raleway':           { url: 'https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   'playfair display':  { url: 'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
+  // Ubuntu (used as the minorFont in some templates, e.g. sample-11). Without
+  // this mapping the renderer falls back to a system sans whose horizontal
+  // metrics are narrower than Ubuntu's, so cells sized for the Ubuntu width
+  // (e.g. table cells with `tcW` measured against the Ubuntu run) wrap
+  // differently from Word — the symptom that motivated this entry was a
+  // table cell expected to break into two lines but staying on one.
+  'ubuntu':            { url: 'https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,400;0,700;1,400;1,700&display=swap' },
   // Common Arabic-script faces that hosts rarely ship. Map them to Noto
   // substitutes so RTL documents (e.g. sample-7, which requests Sakkal Majalla
   // / Univers Next Arabic) render with a real web font instead of an oversized


### PR DESCRIPTION
## Summary

Templates whose theme `minorFont` resolves to **Ubuntu** had no entry in `DOCX_GOOGLE_FONTS`, so the preloader skipped the family and the renderer fell back to a system sans. Ubuntu's glyphs are wider than common system sans defaults, so Word and our renderer disagreed on horizontal metrics — table cells sized with `tcW` (ECMA-376 §17.4.71) against the Ubuntu run width wrapped in Word but stayed on one line for us.

Adding `'ubuntu'` to `DOCX_GOOGLE_FONTS` (Google Fonts ships the family under the requested name, so no `loadFamily` override) lets the canvas measure glyphs with the real face. `layoutLines` then breaks at the same place Word does, automatically — no table or wrap code changes are required.

## Why `<w:noWrap/>` does not save us

The affected cell carries `<w:noWrap/>` (§17.4.29), but per spec `noWrap` only constrains the **autofit minimum width** — it does not suppress line breaks at render time. Honoring `noWrap` would widen the column and make the layout worse, not better.

## Concrete case (Word ground truth)

- Cell: `tcW = 818pct` → 76.55 pt outer / 65.75 pt inner after `tblCellMar`.
- Word (with Ubuntu): "City or Town" measures ~85 pt > 65.75 → 2 lines (`Town` on row 2). Verified against the Word output PDF bounding boxes.
- Us (with sans fallback): measures ~60–62 pt < 65.75 → 1 line.
- After this fix, Ubuntu glyphs measure correctly and we break at the same place.

## Changes

- `packages/docx/src/google-fonts.ts`: add `'ubuntu'` entry to `DOCX_GOOGLE_FONTS`. Same shape as the other self-named Latin web fonts (Open Sans, Roboto, Lato, …).
- `packages/docx/src/google-fonts.test.ts`: assert the entry resolves to a Google Fonts Ubuntu stylesheet, and that `docxFontPreloadNames` includes "Ubuntu" when the theme `minorFont` is Ubuntu.

## Test plan

- [x] `pnpm test` — 854 passed / 16 skipped (88 test files). New tests cover the Ubuntu mapping shape and preload-name inclusion.
- [x] `pnpm typecheck` — `tsc --build` green; downstream typechecks (`markdown`, `node`, `vscode-extension`) green.
- [ ] Local visual check on the affected sample-11 page-2 table. (VRT is local-only per CLAUDE.md.)

## Spec references

- ECMA-376 §17.4.29 — `noWrap` semantics (autofit min-width only, no render-time line-break suppression).
- ECMA-376 §17.4.71 — `tcW` cell width.

Ground truth is the Word output PDF only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)