### PR TITLE
fix(docx): honor trHeight val on auto rows; collapse spacing in measure path

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1949,21 +1949,28 @@ function splitParagraphAcrossPages(
  *  renderer's row sizing (exact / atLeast / auto + vMerge span distribution,
  *  ECMA-376 §17.4.80, §17.4.85) via the shared {@link resolveTableRowHeights}
  *  skeleton. Works in pt (scale 1); the cell measurer is the paginator's
- *  float-aware `estimateParagraphHeight` cursor-walk. */
+ *  float-aware `estimateParagraphHeight` cursor-walk. Adjacent paragraphs inside
+ *  a cell collapse spacing the same way `renderCellContent` does (ECMA-376
+ *  §17.3.1.33 contextualSpacing + spaceAfter/spaceBefore overlap = max not sum),
+ *  so the measured height matches the painted height. Without this, a cell
+ *  containing a nested table followed by a paragraph with `spaceBefore` would
+ *  measure taller than it paints, leaving a gap below the nested table. */
 function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt: number): number[] {
   const colWidths = resolveColumnWidths(table, contentWPt, state);
   return resolveTableRowHeights(table, colWidths, 1, (cell, cellW) => {
     const cm = effCellMargins(cell, table);
     const innerW = Math.max(1, cellW - cm.left - cm.right);
-    let ch = cm.top + cm.bottom;
-    for (const ce of cell.content) {
+    // pt-space: estimateParagraphHeight emits the full spaceBefore (its
+    // suppressSpaceBefore flag is for page-break continuations, not intra-cell
+    // collapse), so sumCellContentHeight folds in contextualSuppressed
+    // (§17.3.1.33) and the prevSpaceAfter/spaceBefore overlap to match the
+    // paint pass's renderCellContent.
+    return cm.top + cm.bottom + sumCellContentHeight(cell.content, (ce) => {
       if (ce.type === 'paragraph') {
-        ch += estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
-      } else if (ce.type === 'table') {
-        ch += estimateTableHeight(state, ce as unknown as DocTable, innerW);
+        return estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
       }
-    }
-    return ch;
+      return estimateTableHeight(state, ce as unknown as DocTable, innerW);
+    }, 1);
   });
 }
 
@@ -2323,6 +2330,62 @@ function renderBodyElement(el: BodyElement, state: RenderState): void {
 
 function contextualSuppressed(prev: DocParagraph | null, curr: DocParagraph): boolean {
   return !!(prev?.contextualSpacing && curr.contextualSpacing && prev.styleId && prev.styleId === curr.styleId);
+}
+
+/**
+ * Sum the heights of a cell's content elements with paragraph spacing collapsed
+ * the same way `renderCellContent` paints them, so a cell measured for row
+ * sizing equals the height it actually paints. Two collapse rules apply
+ * (mirroring the paint pass):
+ *
+ *   - ECMA-376 §17.3.1.33 `<w:contextualSpacing>`: a paragraph whose
+ *     contextualSpacing toggle matches the previous paragraph's AND shares its
+ *     styleId emits zero spaceBefore (the toggle suppresses spacing between
+ *     same-style siblings).
+ *   - Adjacent-paragraph spacing OVERLAP: the gap between two paragraphs is
+ *     `max(prevSpaceAfter, currSpaceBefore)`, not their sum. We subtract the
+ *     overlap `min(prevSpaceAfter, effBefore)` so a 12pt space-after followed
+ *     by a 12pt space-before contributes 12pt of gap, not 24pt.
+ *
+ * A nested table (CellElement other than paragraph) resets the
+ * prev-paragraph context — the next paragraph after a table spaces from a
+ * fresh baseline, exactly as `renderCellContent` does.
+ *
+ * `perElementHeight(elem)` returns each element's full measured height: for a
+ * paragraph it must include its full `spaceBefore` (no contextual or overlap
+ * adjustment) so this helper can subtract the collapse correctly; for a nested
+ * table it is the table's own total height. `spaceScale` converts spec spacing
+ * (pt) into the same units as `perElementHeight` returns (1 for pt; the device
+ * scale for px); the subtracted collapse therefore lands in matching units.
+ *
+ * Exported for unit tests (table-spacing-collapse.test).
+ */
+export function sumCellContentHeight(
+  content: CellElement[],
+  perElementHeight: (el: CellElement) => number,
+  spaceScale: number,
+): number {
+  let h = 0;
+  let prevPara: DocParagraph | null = null;
+  let prevSpaceAfter = 0;
+  for (const ce of content) {
+    if (ce.type === 'paragraph') {
+      const para = ce as unknown as DocParagraph;
+      const suppress = contextualSuppressed(prevPara, para);
+      const effBefore = suppress ? 0 : para.spaceBefore;
+      const overlap = Math.min(prevSpaceAfter, effBefore);
+      h += perElementHeight(ce)
+        - (suppress ? para.spaceBefore : 0) * spaceScale
+        - overlap * spaceScale;
+      prevPara = para;
+      prevSpaceAfter = para.spaceAfter;
+    } else {
+      h += perElementHeight(ce);
+      prevPara = null;
+      prevSpaceAfter = 0;
+    }
+  }
+  return h;
 }
 
 /** ECMA-376 §17.6.4 `<w:cols w:sep="1">` — draw a thin vertical rule centred in
@@ -5374,8 +5437,11 @@ function computeTableLayout(
 
 /** Content height (px, at `scale`) of a table cell laid out at total width
  *  `cellW`: cell top/bottom margins plus each content element measured at the
- *  paint pass's `measureCellElementHeight`. Shared by the per-row skeleton (via
- *  computeTableLayout) and the exported {@link calculateRowHeight}. */
+ *  paint pass's `measureCellElementHeight`. Adjacent paragraphs inside the cell
+ *  collapse spacing the same way `renderCellContent` does (ECMA-376 §17.3.1.33
+ *  contextualSpacing + spaceAfter/spaceBefore overlap = max not sum), so the
+ *  measured height matches the painted height. Shared by the per-row skeleton
+ *  (via computeTableLayout) and the exported {@link calculateRowHeight}. */
 function measureCellContentHeightPx(
   cell: DocTableCell,
   table: DocTable,
@@ -5385,11 +5451,15 @@ function measureCellContentHeightPx(
 ): number {
   const cm = effCellMargins(cell, table);
   const contentW = cellW - (cm.left + cm.right) * scale;
-  let h = (cm.top + cm.bottom) * scale;
-  for (const ce of cell.content) {
-    h += measureCellElementHeight(state, ce, contentW, scale);
-  }
-  return h;
+  // measureCellElementHeight always includes paragraph spaceBefore+spaceAfter;
+  // sumCellContentHeight folds in contextualSuppressed (§17.3.1.33) and the
+  // prevSpaceAfter/spaceBefore overlap collapse to match the paint pass's
+  // renderCellContent. Spacing is converted from pt to px with `scale`.
+  return (cm.top + cm.bottom) * scale + sumCellContentHeight(
+    cell.content,
+    (ce) => measureCellElementHeight(state, ce, contentW, scale),
+    scale,
+  );
 }
 
 /** Draw all rows of a table whose grid origin is `tableX` (px) and whose top is

--- a/packages/docx/src/table-geometry.ts
+++ b/packages/docx/src/table-geometry.ts
@@ -68,9 +68,19 @@ export type MeasureCellContentHeight = (cell: DocTableCell, cellWidth: number) =
  *       exact   — height is exactly `w:trHeight/@val` (× `scale`); overflow is
  *                 clipped by the caller.
  *       atLeast — `@val` (× `scale`) is a lower bound; content can grow the row.
- *       auto    — `@val` is IGNORED ("no predetermined minimum or maximum size",
- *                 advisory layout cache only); the row falls back to the
- *                 `MIN_ROW_HEIGHT_PT` floor. Same as a row with no `w:trHeight`.
+ *       auto    — by the literal text of §17.4.80, `@val` is IGNORED ("no
+ *                 predetermined minimum or maximum size", advisory layout cache
+ *                 only). However, Word's own output PDFs show `@val` being
+ *                 honored as a LOWER BOUND (atLeast-equivalent) when `hRule` is
+ *                 omitted and `@val` is present: e.g. sample-11.docx's December
+ *                 2007 calendar emits `<w:trHeight w:val="576"/>` (hRule
+ *                 omitted; spec default = auto) and Word lays each row out at
+ *                 ~43.2 pt = 576 / 20, matching `@val` as a floor (pdftotext
+ *                 -bbox measures 343.536−300.336 = 43.2 pt). XML inspection
+ *                 confirms no other height information exists, so `@val` is the
+ *                 only signal that produces Word's geometry. We deliberately
+ *                 deviate from the §17.4.80 literal to follow Word's behavior.
+ *                 With `@val` absent, auto falls back to `MIN_ROW_HEIGHT_PT`.
  *   - gridSpan: a cell's width is the sum of the `cell.colSpan` columns it
  *     anchors (clamped to the remaining columns).
  *   - ECMA-376 §17.4.85 (vMerge): a `vMerge=restart` cell's content occupies the
@@ -88,9 +98,12 @@ export type MeasureCellContentHeight = (cell: DocTableCell, cellWidth: number) =
  * Height of ONE row (ECMA-376 §17.4.80 / §17.18.37 ST_HeightRule + gridSpan),
  * EXCLUDING the §17.4.85 vMerge span extension (the caller / the table-level
  * resolver applies that in a post-pass). `exact` returns exactly `@val × scale`;
- * `atLeast` floors at `@val × scale`; `auto` / no-`@val` floors at
- * `MIN_ROW_HEIGHT_PT × scale`. A `vMerge=restart` cell is excluded (its content
- * is distributed across the span, not absorbed by its first row) and a
+ * `atLeast` floors at `@val × scale`; `auto` with `@val` present also floors at
+ * `@val × scale` (intentional Word-compatible deviation from the §17.4.80
+ * literal "ignored" — see the resolver docstring above for the rationale and
+ * the sample-11.docx December calendar evidence). `auto` with no `@val` floors
+ * at `MIN_ROW_HEIGHT_PT × scale`. A `vMerge=restart` cell is excluded (its
+ * content is distributed across the span, not absorbed by its first row) and a
  * `vMerge=continue` cell renders no content. This is the single source of the
  * trHeight rule, shared by {@link resolveTableRowHeights} and the exported
  * `calculateRowHeight`.
@@ -102,8 +115,14 @@ export function resolveSingleRowHeight(
   measureCellContentHeight: MeasureCellContentHeight,
 ): number {
   if (row.rowHeight != null && row.rowHeightRule === 'exact') return row.rowHeight * scale;
+  // §17.4.80 literal says `auto` ignores `@val`. Word's output PDFs disagree:
+  // when `hRule` is omitted and `@val` is present, Word treats `@val` as a
+  // lower bound (atLeast-equivalent). Deliberate deviation to match Word —
+  // ground truth is the Word output PDF (sample-11.docx calendar measured at
+  // 43.2 pt = `@val` 576 / 20). With `@val` absent, auto still collapses to
+  // the implementation-defined minimum.
   let rowH =
-    row.rowHeight != null && row.rowHeightRule === 'atLeast'
+    row.rowHeight != null && (row.rowHeightRule === 'atLeast' || row.rowHeightRule === 'auto')
       ? row.rowHeight * scale
       : MIN_ROW_HEIGHT_PT * scale;
 

--- a/packages/docx/src/table-row-height.test.ts
+++ b/packages/docx/src/table-row-height.test.ts
@@ -6,8 +6,17 @@ import type { DocTable, DocTableRow, DocTableCell } from './types.js';
 // decides how w:trHeight/@val constrains the row height.
 //   exact   — height is exactly @val (overflow clipped).
 //   atLeast — @val is a lower bound; content can expand the row.
-//   auto    — height is content-driven; @val is IGNORED ("with no predetermined
-//             minimum or maximum size"). It is only an advisory layout cache.
+//   auto    — per the §17.4.80 literal, @val is IGNORED ("no predetermined
+//             minimum or maximum size", advisory layout cache only). Word's
+//             output PDFs, however, treat @val as a LOWER BOUND (same as
+//             atLeast) when hRule is omitted and @val is present — e.g.
+//             sample-11.docx's December 2007 calendar emits trHeight w:val=576
+//             (no hRule, spec default = auto) and Word renders each row at
+//             ~43.2 pt = 576 / 20, matching @val as a floor (pdftotext -bbox
+//             measurement). XML inspection confirms no other height signal
+//             exists. We deliberately deviate from the §17.4.80 literal to
+//             match Word's behavior; @val absent still falls back to the
+//             implementation-defined minimum.
 //
 // These tests pin the floor logic with empty cells: with no content, the cell's
 // content height is just its (here zero) margins, so the row height is governed
@@ -67,15 +76,17 @@ describe('calculateRowHeight — ST_HeightRule (§17.4.80 / §17.18.37)', () => 
     expect(h).toBe(600 * SCALE);
   });
 
-  it('auto — @val is IGNORED; height collapses to the content (empty ⇒ minimum)', () => {
-    // The advisory cached val (600) must NOT act as a floor under auto. With no
-    // content the row falls back to the 10pt minimum, not 600pt.
+  // Word-compatible deviation from the §17.4.80 literal: with hRule omitted
+  // (spec default = auto) and @val present, Word honors @val as a lower bound.
+  // Ground truth is the Word output PDF — sample-11.docx's December calendar
+  // measures 43.2 pt per row = trHeight @val 576 / 20. See the resolveSingleRowHeight
+  // docstring (table-geometry.ts) for the full rationale.
+  it('auto with @val — @val is honored as a lower bound (Word-compatible)', () => {
     const h = calculateRowHeight(rowWith(600, 'auto'), t, COLS, SCALE, EMPTY_STATE);
-    expect(h).toBe(10 * SCALE);
-    expect(h).not.toBe(600 * SCALE);
+    expect(h).toBe(600 * SCALE);
   });
 
-  it('auto with no trHeight — same as auto with a cached val (content-driven)', () => {
+  it('auto with no @val — falls back to the implementation-defined minimum', () => {
     const h = calculateRowHeight(rowWith(null, 'auto'), t, COLS, SCALE, EMPTY_STATE);
     expect(h).toBe(10 * SCALE);
   });

--- a/packages/docx/src/table-spacing-collapse.test.ts
+++ b/packages/docx/src/table-spacing-collapse.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { sumCellContentHeight } from './renderer.js';
+import type { CellElement, DocParagraph } from './types.js';
+
+// `sumCellContentHeight` is the shared measure-side spacing-collapse helper
+// that mirrors `renderCellContent`'s paint-side spacing rules:
+//   * ECMA-376 §17.3.1.33 contextualSpacing (same styleId siblings suppress
+//     spaceBefore between them).
+//   * Adjacent-paragraph spacing OVERLAP: the gap between two paragraphs is
+//     max(prevSpaceAfter, currSpaceBefore), not their sum.
+// Both rules were applied in the paint loop (`renderCellContent`) but the
+// measurement paths (`measureCellContentHeightPx`, `computeTableRowHeights`)
+// previously summed `spaceBefore + spaceAfter` per element unconditionally, so a
+// cell measured taller than it painted — leaving an unexplained gap below a
+// nested table whose trailing empty paragraph carried `w:spaceBefore`.
+
+function para(opts: Partial<DocParagraph> = {}): CellElement {
+  return {
+    type: 'paragraph',
+    runs: [],
+    spaceBefore: 0,
+    spaceAfter: 0,
+    contextualSpacing: false,
+    styleId: null,
+    ...opts,
+  } as unknown as CellElement;
+}
+
+function tbl(): CellElement {
+  return { type: 'table' } as unknown as CellElement;
+}
+
+// In each case the per-element height returns the paragraph's "intrinsic + full
+// spacing" measurement — i.e. exactly what measureCellElementHeight and
+// estimateParagraphHeight return without contextual or overlap collapse.
+const fullHeight = (intrinsic: number) => (ce: CellElement): number => {
+  if (ce.type === 'paragraph') {
+    const p = ce as unknown as DocParagraph;
+    return intrinsic + p.spaceBefore + p.spaceAfter;
+  }
+  // Nested table — caller supplies its own height (10 in these tests).
+  return 10;
+};
+
+describe('sumCellContentHeight — spacing collapse mirrors renderCellContent', () => {
+  it('a single paragraph contributes intrinsic + spaceBefore + spaceAfter', () => {
+    const content = [para({ spaceBefore: 6, spaceAfter: 8 })];
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(20 + 6 + 8);
+  });
+
+  it('between two paragraphs the gap is max(prevAfter, currBefore), not the sum', () => {
+    const content = [
+      para({ spaceAfter: 12 }),
+      para({ spaceBefore: 12 }),
+    ];
+    // Without collapse: 20 + 12 + 20 + 12 = 64.
+    // With  collapse: gap = max(12,12) = 12, total = 20 + 12 + 20 = 52.
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(52);
+  });
+
+  it('asymmetric spacing collapses to the larger of the two', () => {
+    const content = [
+      para({ spaceAfter: 4 }),
+      para({ spaceBefore: 10 }),
+    ];
+    // gap = max(4, 10) = 10, total = 20 + 10 + 20 = 50.
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(50);
+  });
+
+  it('contextualSpacing across siblings of the same style suppresses spaceBefore (§17.3.1.33)', () => {
+    const content = [
+      para({ styleId: 'ListBullet', contextualSpacing: true, spaceAfter: 0 }),
+      para({ styleId: 'ListBullet', contextualSpacing: true, spaceBefore: 8 }),
+    ];
+    // 2nd paragraph's spaceBefore is suppressed: 20 + 0 + 20 + 0 = 40
+    // (no spaceBefore for the suppressed paragraph, no overlap to subtract).
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(40);
+  });
+
+  it('contextualSpacing does NOT apply across different styles', () => {
+    const content = [
+      para({ styleId: 'ListBullet', contextualSpacing: true, spaceAfter: 4 }),
+      para({ styleId: 'Body', contextualSpacing: true, spaceBefore: 10 }),
+    ];
+    // Different styleIds → no §17.3.1.33 suppression; falls back to overlap.
+    // gap = max(4, 10) = 10, total = 20 + 10 + 20 = 50.
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(50);
+  });
+
+  it('a nested table resets the prev-paragraph context (no overlap across the table)', () => {
+    const content = [
+      para({ spaceAfter: 12 }),
+      tbl(),                          // intrinsic 10, ends spacing context
+      para({ spaceBefore: 12 }),
+    ];
+    // 1st para 20 + 12 (its spaceAfter is NOT collapsed against the table —
+    // table reset is the paint-pass model)
+    // + table 10
+    // + 2nd para 20 + 12 (full spaceBefore, no prev paragraph to overlap with)
+    // = 74.
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(74);
+  });
+
+  it('scales spacing in px units (spaceScale = device scale)', () => {
+    const content = [
+      para({ spaceAfter: 12 }),
+      para({ spaceBefore: 12 }),
+    ];
+    // perElementHeight returns px directly (intrinsic 40 + spacing × 2);
+    // sumCellContentHeight subtracts the overlap in matching px (12 × 2 = 24).
+    const perEl = (ce: CellElement): number => {
+      if (ce.type === 'paragraph') {
+        const p = ce as unknown as DocParagraph;
+        return 40 + (p.spaceBefore + p.spaceAfter) * 2;
+      }
+      return 20;
+    };
+    // Without collapse: 40 + 12*2 + 40 + 12*2 = 128.
+    // With  collapse: 40 + 12*2 + 40 = 104.
+    expect(sumCellContentHeight(content, perEl, 2)).toBe(104);
+  });
+});


### PR DESCRIPTION
## Summary

Two table-rendering fixes for `sample-11.docx`, both grounded in **Word output PDF** measurements + ECMA-376.

### 1. `trHeight val` honored as a lower bound on `auto` rows (intentional §17.4.80 deviation)

The §17.4.80 literal says `auto` IGNORES `<w:trHeight w:val>` (advisory cache only). The Word output PDFs disagree: when `hRule` is omitted (spec default = `auto`) and `@val` is present, Word treats `@val` as a **lower bound** (`atLeast`-equivalent).

`sample-11.docx` emits the December 2007 calendar rows as `<w:trHeight w:val="576"/>` (no `hRule`). XML inspection shows no other height signal exists, yet Word's PDF lays each row out at ~43.2 pt = 576 / 20 (pdftotext `-bbox` measures 343.536 − 300.336 = 43.2 pt). The header row carries `w:val="810"` and renders ~40.5 pt the same way.

`resolveSingleRowHeight` (`packages/docx/src/table-geometry.ts`) now treats `rowHeightRule === 'auto'` the same as `'atLeast'` when `rowHeight != null`. `auto` with no `@val` still collapses to `MIN_ROW_HEIGHT_PT`. `exact` / `atLeast` are unchanged. Both the function docstring and the in-body comment explicitly record the **deliberate deviation** from the §17.4.80 literal and cite the Word output PDF measurement as the ground truth.

### 2. Measurement-path spacing collapse (§17.3.1.33 + adjacent overlap)

`renderCellContent` (paint pass) collapses adjacent paragraph spacing two ways:
- `contextualSuppressed` (ECMA-376 §17.3.1.33): same-style siblings with the toggle suppress spaceBefore.
- Spacing overlap: gap = `max(prevSpaceAfter, currSpaceBefore)`, not the sum (subtract `min(prevSpaceAfter, effBefore)`).

The two measurement paths (`measureCellContentHeightPx` for paint-side row layout, the per-cell measurer in `computeTableRowHeights` for the paginator) were summing `spaceBefore + spaceAfter` per element unconditionally. measure > paint by the overlap, so the row box grew taller than the painted content — visible on sample-11 as an unexplained gap below a nested table whose trailing empty paragraph carried `w:spaceBefore`.

Extracted the spacing-collapse rules into one pure helper `sumCellContentHeight(content, perElementHeight, spaceScale)` and routed both measurement paths through it. The helper takes a per-element measurer (pt for the paginator's `estimateParagraphHeight`, px for the paint-side `measureCellElementHeight`) and a matching spacing scale, so one body of logic mirrors `renderCellContent` exactly.

## Tests

- **`table-row-height.test.ts`**: replaced the "auto with @val IGNORED" case with the Word-compatible expectation (@val honored as a lower bound). Comment explicitly notes the deliberate §17.4.80 deviation and the sample-11.docx measurement.
- **`table-spacing-collapse.test.ts` (new)**: seven unit tests for `sumCellContentHeight`:
  - single-paragraph baseline,
  - two-paragraph symmetric overlap (12+12 → 12 gap, not 24),
  - asymmetric overlap (max wins),
  - `contextualSpacing` matching siblings suppresses spaceBefore (§17.3.1.33),
  - `contextualSpacing` across different styles does NOT suppress,
  - nested-table resets the prev-paragraph context,
  - px-unit scaling.

## Verification

- `pnpm vitest run packages/docx/` — 216/216 pass.
- `pnpm vitest run` (root) — 859/859 pass, 16 skipped (unchanged from main).
- `pnpm typecheck` (root) — clean.
- `pnpm --filter @silurus/ooxml-docx vrt` — 8/8 demo refs pass (the 13 failing cases are `private/sample-*` 404s; those samples aren't in the repo and are unaffected by this change).
- No Rust changes.

## Test plan

- [x] `pnpm vitest run packages/docx/` — green.
- [x] `pnpm vitest run` (root) — green.
- [x] `pnpm typecheck` (root) — green.
- [x] `pnpm --filter @silurus/ooxml-docx vrt` — public demo refs unchanged.
- [ ] Local visual check of sample-11 December calendar rows + nested-table outer row (private; not in CI).