### PR TITLE
fix(docx): thread wp:positionV/H @relativeFrom through ImageRun (§20.4.3.5/§20.4.3.2)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2487,6 +2487,10 @@ fn parse_inline_drawing(
             // Inline images have no wp:align (positionH/V is anchor-only).
             anchor_x_align: None,
             anchor_y_align: None,
+            // Inline images have no positionH/V at all; relativeFrom is
+            // anchor-only (ECMA-376 §20.4.3.2/§20.4.3.5).
+            anchor_x_relative_from: None,
+            anchor_y_relative_from: None,
         })];
     }
 
@@ -2632,6 +2636,16 @@ fn parse_inline_drawing(
         // the discarded posOffset. `None` falls back to the offset path.
         anchor_x_align: x_align.clone(),
         anchor_y_align: y_align.clone(),
+        // ECMA-376 §20.4.3.2 `<wp:positionH/@relativeFrom>` / §20.4.3.5
+        // `<wp:positionV/@relativeFrom>` — the raw container string
+        // ("page" | "margin" | "topMargin" | "leftMargin" | "paragraph" …).
+        // Mirrors `apply_pos_meta` for ShapeRun. The renderer routes this
+        // through `xContainer` / `yContainer` so e.g. `relativeFrom="margin"`
+        // + `align="top"` pins the image to the body's top content margin
+        // instead of the page top. `None` falls back to the legacy
+        // `anchor_*_from_*` boolean hints.
+        anchor_x_relative_from: rel_h.clone(),
+        anchor_y_relative_from: rel_v.clone(),
     })]
 }
 
@@ -3049,6 +3063,11 @@ fn parse_group_pic(
         // align (if any) is already baked into anchor_x_pt by parse_wgp_images.
         anchor_x_align: None,
         anchor_y_align: None,
+        // For wgp child images, relativeFrom is similarly baked into the
+        // already-page-absolute anchor_*_pt by the group transform chain.
+        // Leave None so the renderer doesn't double-resolve the container.
+        anchor_x_relative_from: None,
+        anchor_y_relative_from: None,
     })
 }
 
@@ -6921,6 +6940,8 @@ mod svg_blip_tests {
             allow_overlap: true,
             anchor_x_align: None,
             anchor_y_align: None,
+            anchor_x_relative_from: None,
+            anchor_y_relative_from: None,
         };
         let json = serde_json::to_string(&run).expect("serialize");
         assert!(
@@ -7149,6 +7170,176 @@ mod svg_blip_tests {
             }
             _ => unreachable!(),
         }
+    }
+}
+
+// ===== ECMA-376 §20.4.3.2 / §20.4.3.5 — wp:positionH/V @relativeFrom on
+// anchor images =====
+//
+// Pins that the parser threads the raw `<wp:positionH>` / `<wp:positionV>`
+// `@relativeFrom` string ("page", "margin", "topMargin", "leftMargin", …) into
+// `ImageRun::anchor_x_relative_from` / `anchor_y_relative_from`. The renderer
+// then routes this through `xContainer` / `yContainer` so e.g.
+// `relativeFrom="margin"` + `<wp:align>top</wp:align>` pins the image to the
+// body's top content margin instead of the page top (the sample-11 "image
+// arrow overflows into the top page margin" bug).
+//
+// `parse_inline_drawing` is private; build the smallest XML that reaches it
+// through `parse()`, matching the pattern used by the svg_blip end-to-end
+// tests above.
+#[cfg(test)]
+mod anchor_image_relative_from_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // Tiny valid PNG (1x1) so resolve_inline_blip's extent+blip contract holds.
+    const PNG_1X1: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    fn build_docx(body_inner: &str) -> Vec<u8> {
+        use zip::write::SimpleFileOptions;
+        let document_xml = format!(
+            r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{body_inner}</w:body></w:document>"#
+        );
+        let rels_xml = r#"<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPng" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>"#;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            let mut put = |name: &str, bytes: &[u8]| {
+                use std::io::Write;
+                zw.start_file(name, opts).unwrap();
+                zw.write_all(bytes).unwrap();
+            };
+            put("word/document.xml", document_xml.as_bytes());
+            put("word/_rels/document.xml.rels", rels_xml.as_bytes());
+            put("word/media/image1.png", PNG_1X1);
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    fn first_image(doc: &Document) -> &ImageRun {
+        doc.body
+            .iter()
+            .find_map(|el| match el {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Image(im) => Some(im),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("expected one anchor image")
+    }
+
+    /// Body XML for an anchor image with the given `<wp:positionH>` and
+    /// `<wp:positionV>` children (relativeFrom + align). Mirrors the shape
+    /// produced by Word for the sample-11 left/right page arrows: `wrap=none`,
+    /// `<wp:align>top</wp:align>`, `relativeFrom="margin"`.
+    fn anchor_body(position_h: &str, position_v: &str) -> String {
+        format!(
+            r#"<w:p><w:r><w:drawing>
+  <wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+             behindDoc="0" distT="0" distB="0" distL="0" distR="0"
+             allowOverlap="1" relativeHeight="1">
+    {position_h}
+    {position_v}
+    <wp:extent cx="304800" cy="304800"/>
+    <wp:wrapNone/>
+    <wp:docPr id="1" name="img"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill><a:blip r:embed="rIdPng"/></pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:anchor>
+</w:drawing></w:r></w:p>"#
+        )
+    }
+
+    /// ECMA-376 §20.4.3.5 — `<wp:positionV relativeFrom="margin"><wp:align>top
+    /// </wp:align></wp:positionV>` must reach `ImageRun.anchor_y_relative_from`
+    /// as the raw "margin" string AND `anchor_y_align="top"`. Without this the
+    /// renderer falls back to relativeFrom=None ⇒ page band, and a "top" image
+    /// lands at Y=0 (inside the page top margin) instead of Y=marginTop.
+    #[test]
+    fn anchor_position_v_margin_top_preserves_relative_from_margin() {
+        let body = anchor_body(
+            r#"<wp:positionH relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionH>"#,
+            r#"<wp:positionV relativeFrom="margin"><wp:align>top</wp:align></wp:positionV>"#,
+        );
+        let data = build_docx(&body);
+        let doc = parse(&data).expect("parse must succeed");
+        let img = first_image(&doc);
+        assert_eq!(
+            img.anchor_y_relative_from.as_deref(),
+            Some("margin"),
+            "raw positionV relativeFrom must reach ImageRun"
+        );
+        assert_eq!(img.anchor_y_align.as_deref(), Some("top"));
+    }
+
+    /// ECMA-376 §20.4.3.2 — same wiring on the horizontal axis. Mirror sanity.
+    #[test]
+    fn anchor_position_h_margin_left_preserves_relative_from_margin() {
+        let body = anchor_body(
+            r#"<wp:positionH relativeFrom="margin"><wp:align>left</wp:align></wp:positionH>"#,
+            r#"<wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>"#,
+        );
+        let data = build_docx(&body);
+        let doc = parse(&data).expect("parse must succeed");
+        let img = first_image(&doc);
+        assert_eq!(img.anchor_x_relative_from.as_deref(), Some("margin"));
+        assert_eq!(img.anchor_x_align.as_deref(), Some("left"));
+    }
+
+    /// `relativeFrom="page"` must round-trip unchanged (the renderer relies on
+    /// the distinction between "page" and "margin" to pick the container).
+    #[test]
+    fn anchor_position_relative_from_page_is_preserved() {
+        let body = anchor_body(
+            r#"<wp:positionH relativeFrom="page"><wp:align>center</wp:align></wp:positionH>"#,
+            r#"<wp:positionV relativeFrom="page"><wp:align>center</wp:align></wp:positionV>"#,
+        );
+        let data = build_docx(&body);
+        let doc = parse(&data).expect("parse must succeed");
+        let img = first_image(&doc);
+        assert_eq!(img.anchor_x_relative_from.as_deref(), Some("page"));
+        assert_eq!(img.anchor_y_relative_from.as_deref(), Some("page"));
+    }
+
+    /// Inline images carry no positionH/V at all — both relativeFrom fields
+    /// must be `None` so the renderer doesn't accidentally re-resolve the
+    /// container for an inline image.
+    #[test]
+    fn inline_image_has_no_relative_from() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill><a:blip r:embed="rIdPng"/></pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx(body);
+        let doc = parse(&data).expect("parse must succeed");
+        let img = first_image(&doc);
+        assert!(img.anchor_x_relative_from.is_none());
+        assert!(img.anchor_y_relative_from.is_none());
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1127,6 +1127,21 @@ pub struct ImageRun {
     /// Values: "top", "center", "bottom".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub anchor_y_align: Option<String>,
+    /// ECMA-376 §20.4.3.2 `<wp:positionH>` / §20.4.3.5 `<wp:positionV>`
+    /// `@relativeFrom` — names the container the offset / align / pctPos
+    /// is measured against (raw spec string: "page", "margin", "paragraph",
+    /// "line", "leftMargin", "rightMargin", "topMargin", "bottomMargin",
+    /// "insideMargin", "outsideMargin", "column", "character"). Mirrors
+    /// `ShapeRun::anchor_x_relative_from` / `anchor_y_relative_from`. The
+    /// renderer routes this to `xContainer` / `yContainer` so e.g.
+    /// `relativeFrom="margin"` + `align="top"` pins the image to the top
+    /// content margin instead of the page top. `None` for inline images and
+    /// for anchors that didn't carry a positionH/V (preserve the legacy
+    /// boolean hints `anchor_x_from_margin` / `anchor_y_from_para`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_x_relative_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_y_relative_from: Option<String>,
 }
 
 fn is_zero_f64(v: &f64) -> bool {

--- a/packages/docx/src/anchor-image-relativefrom.test.ts
+++ b/packages/docx/src/anchor-image-relativefrom.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { __test_resolveAnchorBox, type RenderState } from './renderer.js';
+import type { ImageRun } from './types.js';
+
+// Pin the wiring of `<wp:positionH/V>@relativeFrom` (ECMA-376 §20.4.3.2 /
+// §20.4.3.5) through ImageRun into resolveAnchorBox. The placement math itself
+// is covered by anchor-align.test.ts via resolveAnchorY; this file asserts that
+// `anchorYRelativeFrom` / `anchorXRelativeFrom` reach the geometry helper so
+// e.g. `relativeFrom="margin"` + `align="top"` pins the image to the body's
+// top content margin instead of the page top (Y=0, inside the top margin).
+//
+// resolveAnchorBox reads only { scale, marginLeft/Right/Top/Bottom, pageH,
+// pageWidth } from RenderState; cast a minimal stand-in like anchor-align.test.
+const state = {
+  scale: 1,
+  marginLeft: 96,
+  marginRight: 96,
+  marginTop: 72,
+  marginBottom: 72,
+  pageH: 800,
+  pageWidth: 612,
+} as unknown as RenderState;
+
+const baseImg: ImageRun = {
+  imagePath: 'word/media/image1.png',
+  mimeType: 'image/png',
+  widthPt: 100,
+  heightPt: 60,
+  anchor: true,
+  anchorXPt: 0,
+  anchorYPt: 0,
+  // No "fromMargin" hint — the bug repro path: the relativeFrom string must
+  // do the work on its own.
+  anchorXFromMargin: false,
+  anchorYFromPara: false,
+};
+
+describe('resolveAnchorBox — positionV/@relativeFrom wiring (ECMA-376 §20.4.3.5)', () => {
+  it('relativeFrom="margin" + align="top" pins Y to marginTop (sample-11 image arrow)', () => {
+    // Bug 4a: without anchorYRelativeFrom plumbed through, this image lands at
+    // Y=0 (inside the top page margin). The fix routes the raw "margin"
+    // string into yContainer so resolveAnchorY returns the content-margin top.
+    const img: ImageRun = {
+      ...baseImg,
+      anchorYAlign: 'top',
+      anchorYRelativeFrom: 'margin',
+    };
+    const box = __test_resolveAnchorBox(img, state, 0);
+    expect(box.y).toBe(state.marginTop); // 72, NOT 0
+  });
+
+  it('relativeFrom="page" + align="top" still lands at Y=0 (page band top)', () => {
+    // Sanity: when relativeFrom is page, top alignment hits the page top edge.
+    // Pins that the wire-up doesn't smuggle a margin default in.
+    const img: ImageRun = {
+      ...baseImg,
+      anchorYAlign: 'top',
+      anchorYRelativeFrom: 'page',
+    };
+    expect(__test_resolveAnchorBox(img, state, 0).y).toBe(0);
+  });
+
+  it('absent anchorYRelativeFrom + anchorYFromPara=false ⇒ legacy page-relative offset', () => {
+    // Back-compat: an anchor that omitted positionV (no relativeFrom string,
+    // no fromPara hint) keeps the previous "Y = anchorYPt as page-absolute"
+    // behavior, even with align="top".
+    const img: ImageRun = {
+      ...baseImg,
+      anchorYAlign: 'top',
+      // anchorYRelativeFrom omitted
+    };
+    expect(__test_resolveAnchorBox(img, state, 0).y).toBe(0);
+  });
+});
+
+describe('resolveAnchorBox — positionH/@relativeFrom wiring (ECMA-376 §20.4.3.2)', () => {
+  it('relativeFrom="margin" + align="left" pins X to marginLeft', () => {
+    const img: ImageRun = {
+      ...baseImg,
+      anchorXAlign: 'left',
+      anchorXRelativeFrom: 'margin',
+    };
+    expect(__test_resolveAnchorBox(img, state, 0).x).toBe(state.marginLeft); // 96
+  });
+
+  it('relativeFrom="page" + align="left" lands at X=0', () => {
+    const img: ImageRun = {
+      ...baseImg,
+      anchorXAlign: 'left',
+      anchorXRelativeFrom: 'page',
+    };
+    expect(__test_resolveAnchorBox(img, state, 0).x).toBe(0);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5190,7 +5190,18 @@ export function renderShapeText(
  * wrapNone images use the pre-spaceBefore paragraph top (see the
  * anchoredFloatBottomOffset note in the paginator). This is the box origin BEFORE
  * any overlap displacement; resolveFloatOverlap runs on top of it for floats.
+ *
+ * Exported under a `_test` alias for the anchor-image relativeFrom wiring test
+ * (the public renderer entry points consume the box internally; pin the
+ * positionH/V → xContainer/yContainer plumbing at this seam).
  */
+export const __test_resolveAnchorBox = (
+  img: ImageRun,
+  state: RenderState,
+  paraBaseY: number,
+): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } =>
+  resolveAnchorBox(img, state, paraBaseY);
+
 function resolveAnchorBox(
   img: ImageRun,
   state: RenderState,
@@ -5203,18 +5214,23 @@ function resolveAnchorBox(
   // renderer aligns the image within its relativeFrom container instead of
   // using the (discarded) posOffset. Mirrors resolveShapeBox (the ShapeRun
   // equivalent): we route X/Y through resolveAnchorX/Y with the image's own
-  // box size as the align size. ImageRun carries neither a raw relativeFrom
-  // string nor pctPos/sizeRel, so those args are null and the boolean
-  // anchorXFromMargin / anchorYFromPara hints pick page-vs-margin containers
-  // (xContainer/yContainer). When align is absent, resolveAnchorX/Y fall back
-  // to the same offset path this function used previously.
+  // box size as the align size. The raw §20.4.3.2/§20.4.3.5
+  // `<wp:positionH/V>@relativeFrom` string (e.g. "margin", "topMargin") is
+  // threaded through so xContainer/yContainer pick the correct container.
+  // Without it a `relativeFrom="margin"` + `align="top"` image would degrade
+  // to the page-relative top edge (Y=0 → inside the top margin), which is
+  // exactly the sample-11 misplacement before this wire-up. ImageRun carries
+  // no pctPos/sizeRel, so those args remain null and the legacy boolean
+  // anchorXFromMargin / anchorYFromPara hints still gate page-vs-margin when
+  // no raw relativeFrom is present. When align is absent, resolveAnchorX/Y
+  // fall back to the offset path.
   const x = resolveAnchorX(
     img.anchorXAlign, img.anchorXFromMargin ?? false, img.anchorXPt ?? 0, w, state,
-    null, null, null,
+    img.anchorXRelativeFrom ?? null, null, null,
   );
   const y = resolveAnchorY(
     img.anchorYAlign, img.anchorYFromPara ?? false, img.anchorYPt ?? 0, h, paraBaseY, state,
-    null, null, null,
+    img.anchorYRelativeFrom ?? null, null, null,
   );
   return {
     x,

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -769,6 +769,21 @@ export interface ImageRun {
   anchorXAlign?: string | null;
   /** Vertical equivalent of anchorXAlign: "top" | "center" | "bottom". */
   anchorYAlign?: string | null;
+  /**
+   * ECMA-376 §20.4.3.2 `<wp:positionH/@relativeFrom>` / §20.4.3.5
+   * `<wp:positionV/@relativeFrom>` — names the container the offset / align /
+   * pctPos is measured against. Raw spec string: `"page"`, `"margin"`,
+   * `"paragraph"`, `"line"`, `"leftMargin"`, `"rightMargin"`, `"topMargin"`,
+   * `"bottomMargin"`, `"insideMargin"`, `"outsideMargin"`, `"column"`,
+   * `"character"`. Mirrors {@link ShapeRun.anchorXRelativeFrom} /
+   * {@link ShapeRun.anchorYRelativeFrom}. When present, supersedes the legacy
+   * coarse boolean hints (`anchorXFromMargin` / `anchorYFromPara`) for the
+   * align and pctPos paths so e.g. `relativeFrom="margin"` + `align="top"`
+   * pins the image to the top content margin rather than the page top. Absent
+   * for inline images and for anchors that omitted `<wp:positionH/V>`.
+   */
+  anchorXRelativeFrom?: string | null;
+  anchorYRelativeFrom?: string | null;
 }
 
 // ===== Table =====


### PR DESCRIPTION
## Summary

Anchor images carrying `<wp:positionV relativeFrom=\"margin\"><wp:align>top</wp:align></wp:positionV>` (and the horizontal equivalent) were landing at Y=0 — inside the page top margin — instead of at the body's `marginTop`. The placement math in `resolveAnchorY` already honored the raw `\"margin\"` container string (ECMA-376 §20.4.3.4), but `ImageRun` carried no field for it: the parser only emitted the coarse `anchor_y_from_para` / `anchor_x_from_margin` booleans, and `resolveAnchorBox` passed `null` to the `relativeFrom` arg of `resolveAnchorX/Y`. So the renderer defaulted to the page band and a `top` align resolved to the page top.

`ShapeRun` already had this wiring (`apply_pos_meta` + `resolveShapeBox`). This PR mirrors the same plumbing to `ImageRun`.

## Change

- **parser** (`packages/docx/parser/src/types.rs`): add `anchor_x_relative_from: Option<String>` / `anchor_y_relative_from: Option<String>` to `ImageRun`, mirroring the existing `ShapeRun` fields.
- **parser** (`packages/docx/parser/src/parser.rs`): on the standalone anchor branch, populate the new fields from `rel_h` / `rel_v` (already parsed via `parse_anchor_pct_pos`). Inline images explicitly keep `None` (positionH/V is anchor-only). Grouped images (`parse_group_pic`) also keep `None` because the wgp transform chain already bakes the container offset into `anchor_x_pt` / `anchor_y_pt` — wiring the field there would double-resolve.
- **ts types** (`packages/docx/src/types.ts`): add `anchorXRelativeFrom?: string | null` / `anchorYRelativeFrom?: string | null` to `ImageRun`.
- **renderer** (`packages/docx/src/renderer.ts`): in `resolveAnchorBox`, replace the previous `null, null, null` relativeFrom arg with `img.anchorXRelativeFrom ?? null` / `img.anchorYRelativeFrom ?? null`. `anchor-geometry.ts` is untouched.
- exposed `__test_resolveAnchorBox` so the wiring can be asserted at the seam where the bug lived.

## Tests

- **cargo** (4 new tests in `anchor_image_relative_from_tests`): `positionV/H relativeFrom=\"margin\"` round-trips on both axes; `relativeFrom=\"page\"` is preserved (the renderer needs the distinction); inline images yield `None`. All 139 docx-parser tests green.
- **vitest** (5 new in `anchor-image-relativefrom.test.ts`): pinning `resolveAnchorBox(img, …)` returns `Y=marginTop` for `relativeFrom=\"margin\"+align=\"top\"` (the bug repro), `Y=0` for `relativeFrom=\"page\"+align=\"top\"`, back-compat for the absent-relativeFrom path, and the X-axis mirror. All 214 docx vitest tests green.
- **gates**: root `pnpm typecheck` clean; `cargo fmt`, `clippy --workspace --all-targets -D warnings`, and `cargo test` all green; `pnpm build:wasm` rebuilt cleanly.

## 4b — text wrap between the two arrows

Expected to disappear automatically once 4a is fixed: with the image band moved from `[0, 76.8pt]` (overlapping the top margin) to `[72, 148.8pt]` (inside the body area), `resolveLineFloatWindow` creates the middle window between the left and right floats and body text flows between them. If any residue remains, it will be addressed in a separate PR — no speculative changes here.

## Test plan

- [x] cargo test (4 new + 135 existing) green
- [x] docx vitest (5 new + 209 existing) green
- [x] root pnpm typecheck clean
- [x] cargo fmt + clippy -D warnings green
- [ ] visual re-confirm of sample-11 Images page (requires private sample, deferred)