### PR TITLE
fix(docx): inherit tblCellMar from TableNormal style chain (§17.4.41, drop magic 3.6pt)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4204,8 +4204,17 @@ fn parse_table(
     // Resolve the table style's cell/border formatting (shading, banding, borders,
     // vAlign) — these live in styles.xml, not inline (§17.7.6). tblLook selects which
     // conditional formats are active.
-    let tstyle = table_style_id
+    //
+    // ECMA-376 §17.7.4 + §17.4.42: when the table omits `<w:tblStyle>`, the
+    // implicit association is the `<w:style w:type="table" w:default="1">`
+    // (typically "TableNormal" / "Normal Table"). That style's
+    // `<w:tblCellMar>` (and other tblPr defaults) MUST apply, otherwise a
+    // table whose cells rely on TableNormal's 108-twip left/right padding
+    // (the Word convention) renders with the wrong column geometry.
+    let effective_table_style_id = table_style_id
         .as_deref()
+        .or_else(|| style_map.default_table_style_id());
+    let tstyle = effective_table_style_id
         .map(|id| style_map.resolve_table_style(id))
         .unwrap_or_default();
     // ECMA-376 §17.4.49 (w:tblLook). Word writes this either with the modern
@@ -4247,30 +4256,46 @@ fn parse_table(
         .unwrap_or_default();
     apply_style_borders(&mut borders, &tstyle.borders);
 
-    // Cell margins
-    let (cm_top, cm_bot, cm_left, cm_right) = tbl_pr
-        .and_then(|p| child_w(p, "tblCellMar"))
-        .map(|m| {
-            (
-                child_w(m, "top")
-                    .and_then(|n| attr_w(n, "w"))
-                    .map(|v| twips_to_pt(&v))
-                    .unwrap_or(0.0),
-                child_w(m, "bottom")
-                    .and_then(|n| attr_w(n, "w"))
-                    .map(|v| twips_to_pt(&v))
-                    .unwrap_or(0.0),
-                child_w(m, "left")
-                    .and_then(|n| attr_w(n, "w"))
-                    .map(|v| twips_to_pt(&v))
-                    .unwrap_or(3.6),
-                child_w(m, "right")
-                    .and_then(|n| attr_w(n, "w"))
-                    .map(|v| twips_to_pt(&v))
-                    .unwrap_or(3.6),
-            )
-        })
-        .unwrap_or((0.0, 0.0, 3.6, 3.6));
+    // Cell margins. ECMA-376 §17.4.42 (Table Cell Margin Defaults) defines a
+    // strict three-tier inheritance:
+    //   1. Inline `<w:tblPr><w:tblCellMar>` per-edge value wins.
+    //   2. Any edge omitted inline inherits from the associated table style's
+    //      `<w:tblCellMar>` (flattened through basedOn in `resolve_table_style`).
+    //      Per §17.7.4 a table that omits `<w:tblStyle>` is implicitly
+    //      associated with the `w:default="1"` table style (e.g.
+    //      "TableNormal"); we already resolved that into `tstyle` above.
+    //   3. If the style hierarchy never specifies an edge, fall back to the
+    //      spec-mandated default for that edge:
+    //        - §17.4.34 (start) / §17.4.11 (end): 115 twips = 5.75 pt
+    //        - §17.4.5  (bottom) / §17.4.75 (top): 0
+    //
+    // The previous implementation used a magic 3.6 pt fallback for left/right
+    // with no spec basis (a value that also silently overrode TableNormal's
+    // 108-twip inheritance because the code never consulted the style chain).
+    // sample-3's table relies on TableNormal's 5.4 pt left/right padding; the
+    // 3.6 pt default offset every tcMar-absent cell by 1.8 pt per edge.
+    let inline_mar = tbl_pr.and_then(|p| child_w(p, "tblCellMar"));
+    let inline_edge = |name: &str| -> Option<f64> {
+        inline_mar
+            .and_then(|m| child_w(m, name))
+            .filter(|n| attr_w(*n, "type").map(|t| t == "dxa").unwrap_or(true))
+            .and_then(|n| attr_w(n, "w"))
+            .map(|v| twips_to_pt(&v))
+    };
+    // §17.4.34 / §17.4.35: the modern schema uses `start`/`end`; Word also
+    // writes the legacy `left`/`right` aliases. Accept either at every layer.
+    let cm_top = inline_edge("top").or(tstyle.cell_margin_top).unwrap_or(0.0);
+    let cm_bot = inline_edge("bottom")
+        .or(tstyle.cell_margin_bottom)
+        .unwrap_or(0.0);
+    let cm_left = inline_edge("left")
+        .or_else(|| inline_edge("start"))
+        .or(tstyle.cell_margin_left)
+        .unwrap_or(5.75); // §17.4.34: 115 twips when never specified
+    let cm_right = inline_edge("right")
+        .or_else(|| inline_edge("end"))
+        .or(tstyle.cell_margin_right)
+        .unwrap_or(5.75); // §17.4.11: 115 twips when never specified
 
     // §17.4.7/§17.4.8 conditional-format bitmasks. Captured up front so we can
     // both (a) thread each cell's resolved conditional rPr/pPr into its content
@@ -4479,7 +4504,15 @@ fn parse_table(
             media_map,
             rel_map,
             theme,
-            table_style_id.as_deref(),
+            // §17.7.4: the effective style id includes the
+            // `w:default="1"` table style when the document omits
+            // `<w:tblStyle>`. Threading the effective id (rather than the
+            // raw `table_style_id`) ensures cell paragraphs resolve their
+            // pPr/rPr defaults from the same style chain we already used
+            // for tstyle's borders, banding and cell margins. This keeps
+            // the inheritance consistent across all tstyle-derived
+            // attributes.
+            effective_table_style_id,
             &cell_conds,
         );
         rows.push(row);
@@ -5553,6 +5586,119 @@ mod tests {
         // Paragraph-style bold/italic preserved (PR #524).
         assert!(first.bold, "TOC1 bold kept");
         assert!(second.italic, "TOC2 italic kept");
+    }
+
+    // ===== §17.4.42 tblCellMar inheritance =====
+
+    fn parse_tbl_with_styles(body: &str, styles_xml: &str) -> DocTable {
+        let xml = format!(r#"<w:tbl xmlns:w="{ns}">{body}</w:tbl>"#, ns = W_NS);
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let style_map = StyleMap::parse(styles_xml);
+        let mut num_map = NumberingMap::default();
+        let media: HashMap<String, String> = HashMap::new();
+        let rels: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+        parse_table(
+            doc.root_element(),
+            &style_map,
+            &mut num_map,
+            &media,
+            &rels,
+            &theme,
+        )
+    }
+
+    /// sample-3 root cause: a table whose `<w:tblPr>` carries NO
+    /// `<w:tblCellMar>` must inherit per-edge margins from the default table
+    /// style `<w:style w:type="table" w:default="1">` (typically
+    /// "TableNormal"). ECMA-376 §17.4.42 explicitly says an omitted
+    /// `<w:tblCellMar>` inherits from the associated table style; §17.7.4
+    /// makes a `default="1"` table style the implicit association when the
+    /// table omits `<w:tblStyle>`. Word/Office honor this; the previous
+    /// `unwrap_or(3.6)` magic constant ignored the inheritance entirely,
+    /// shifting left/right by 1.8pt per edge.
+    #[test]
+    fn table_inherits_cell_margins_from_default_table_style() {
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="table" w:default="1" w:styleId="TableNormal">
+                <w:tblPr>
+                  <w:tblCellMar>
+                    <w:top w:w="0" w:type="dxa"/>
+                    <w:left w:w="108" w:type="dxa"/>
+                    <w:bottom w:w="0" w:type="dxa"/>
+                    <w:right w:w="108" w:type="dxa"/>
+                  </w:tblCellMar>
+                </w:tblPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        // The table itself omits `<w:tblCellMar>` and `<w:tblStyle>`.
+        let t = parse_tbl_with_styles(
+            r#"<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+            &styles,
+        );
+        // 108 twips = 5.4 pt — TableNormal's left/right cell padding.
+        assert_eq!(t.cell_margin_top, 0.0);
+        assert_eq!(t.cell_margin_bottom, 0.0);
+        assert_eq!(t.cell_margin_left, 5.4);
+        assert_eq!(t.cell_margin_right, 5.4);
+    }
+
+    /// Regression guard: an inline `<w:tblCellMar>` still wins over the
+    /// inherited style values (§17.4.42 explicit-overrides-default).
+    #[test]
+    fn inline_tbl_cell_mar_overrides_style_default() {
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="table" w:default="1" w:styleId="TableNormal">
+                <w:tblPr>
+                  <w:tblCellMar>
+                    <w:left w:w="108" w:type="dxa"/>
+                    <w:right w:w="108" w:type="dxa"/>
+                  </w:tblCellMar>
+                </w:tblPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        // Inline tblCellMar with ONLY left set (200 twips = 10pt). The other
+        // edges should inherit from the style chain (right=5.4pt; top/bottom
+        // unset on both → 0).
+        let t = parse_tbl_with_styles(
+            r#"<w:tblPr>
+                 <w:tblCellMar><w:left w:w="200" w:type="dxa"/></w:tblCellMar>
+               </w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+            &styles,
+        );
+        assert_eq!(t.cell_margin_left, 10.0, "inline left wins");
+        assert_eq!(t.cell_margin_right, 5.4, "right inherits TableNormal");
+        assert_eq!(t.cell_margin_top, 0.0);
+        assert_eq!(t.cell_margin_bottom, 0.0);
+    }
+
+    /// When no table style exists at all and the table omits
+    /// `<w:tblCellMar>`, §17.4.34 / §17.4.11 declare the spec default:
+    /// 115 twips (= 5.75pt) for left/right; §17.4.5 / §17.4.75 declare 0 for
+    /// top/bottom. The previous code used 3.6pt — a magic constant with no
+    /// spec basis. After this fix the fallback is the documented 115/0.
+    #[test]
+    fn no_style_no_inline_uses_spec_default_115_twips_left_right() {
+        let t = parse_tbl_with_styles(
+            r#"<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+            "", // no styles
+        );
+        assert_eq!(t.cell_margin_top, 0.0);
+        assert_eq!(t.cell_margin_bottom, 0.0);
+        assert_eq!(t.cell_margin_left, 5.75);
+        assert_eq!(t.cell_margin_right, 5.75);
     }
 
     // Regression guard for PR #516: a STANDALONE internal hyperlink OUTSIDE any

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -244,6 +244,21 @@ pub struct TableStyleDef {
     pub col_band_size: Option<usize>,
     /// keyed by w:tblStylePr w:type (firstRow, band1Horz, band2Horz, …).
     pub cond: HashMap<String, CondFmt>,
+    /// ECMA-376 §17.4.42 `<w:tblPr><w:tblCellMar>`: per-edge default cell
+    /// margins (in points). `None` means the style omitted that edge, in
+    /// which case the value inherits from the basedOn chain via
+    /// `resolve_table_style`. The default table style (`<w:style
+    /// w:type="table" w:default="1">`, typically "TableNormal") carries the
+    /// values Word/Office apply when a table omits `<w:tblCellMar>`
+    /// entirely; the parser falls back to these values through
+    /// `default_table_style_id`. If a margin is never specified in the
+    /// style hierarchy, §17.4.34 / §17.4.11 / §17.4.5 / §17.4.75 define the
+    /// spec defaults (115 twips for left/right, 0 for top/bottom) which the
+    /// caller applies.
+    pub cell_margin_top: Option<f64>,
+    pub cell_margin_bottom: Option<f64>,
+    pub cell_margin_left: Option<f64>,
+    pub cell_margin_right: Option<f64>,
 }
 
 pub struct StyleMap {
@@ -254,6 +269,14 @@ pub struct StyleMap {
     /// styleId of the style with w:default="1" and w:type="paragraph".
     /// Applied to paragraphs that have no explicit pStyle.
     default_para_style_id: Option<String>,
+    /// styleId of the style with `w:default="1"` and `w:type="table"`
+    /// (typically "TableNormal" / "Normal Table"). ECMA-376 §17.7.4 makes
+    /// this the implicit table style for tables that omit `<w:tblStyle>`,
+    /// so its `<w:tblCellMar>` (and any other tblPr defaults) apply when a
+    /// table inherits silently. Stored separately from
+    /// `default_para_style_id` since the paragraph default and table default
+    /// are independent.
+    default_table_style_id: Option<String>,
 }
 
 impl StyleMap {
@@ -261,6 +284,17 @@ impl StyleMap {
     /// International templates may use non-English IDs (e.g. "a", "標準").
     pub fn default_para_style_id(&self) -> Option<&str> {
         self.default_para_style_id.as_deref()
+    }
+
+    /// Style ID of the `w:type="table" w:default="1"` style (typically
+    /// "TableNormal" / "Normal Table"). ECMA-376 §17.4.42 + §17.7.4: a
+    /// table that omits `<w:tblCellMar>` inherits from its associated table
+    /// style, and a table that omits `<w:tblStyle>` is associated with the
+    /// default table style. Callers in `parser.rs` use this to resolve cell
+    /// margin defaults when the document never names a table style on the
+    /// table itself.
+    pub fn default_table_style_id(&self) -> Option<&str> {
+        self.default_table_style_id.as_deref()
     }
 
     pub fn parse(xml: &str) -> Self {
@@ -297,6 +331,7 @@ impl StyleMap {
         // index them in the same StyleMap so cell resolution can look
         // them up by ID.
         let mut default_para_style_id: Option<String> = None;
+        let mut default_table_style_id: Option<String> = None;
         let mut table_styles: HashMap<String, TableStyleDef> = HashMap::new();
         for style_node in children_w(root, "style") {
             let Some(style_id) = attr_w(style_node, "styleId") else {
@@ -309,6 +344,11 @@ impl StyleMap {
 
             if style_type == "paragraph" && attr_w(style_node, "default").as_deref() == Some("1") {
                 default_para_style_id = Some(style_id.clone());
+            }
+            // §17.7.4: track `<w:style w:type="table" w:default="1">` so
+            // tables that omit `<w:tblStyle>` can inherit its tblCellMar etc.
+            if style_type == "table" && attr_w(style_node, "default").as_deref() == Some("1") {
+                default_table_style_id = Some(style_id.clone());
             }
 
             let based_on = child_w(style_node, "basedOn").and_then(|n| attr_w(n, "val"));
@@ -348,6 +388,7 @@ impl StyleMap {
             defaults_para,
             defaults_run,
             default_para_style_id,
+            default_table_style_id,
         }
     }
 
@@ -358,6 +399,7 @@ impl StyleMap {
             defaults_para: ParaFmt::default(),
             defaults_run: RunFmt::default(),
             default_para_style_id: None,
+            default_table_style_id: None,
         }
     }
 
@@ -395,6 +437,24 @@ impl StyleMap {
             }
             if def.col_band_size.is_some() {
                 out.col_band_size = def.col_band_size;
+            }
+            // §17.4.42: per-edge tblCellMar inherits through basedOn — a
+            // derived style that omits an edge keeps the base value, and
+            // an explicit edge value overrides. Each edge is independent
+            // (Word writes `<w:left w:w="108"/>` without writing `<w:top>`
+            // in TableNormal, and a derived style may override only
+            // `<w:bottom>` without resetting the others).
+            if def.cell_margin_top.is_some() {
+                out.cell_margin_top = def.cell_margin_top;
+            }
+            if def.cell_margin_bottom.is_some() {
+                out.cell_margin_bottom = def.cell_margin_bottom;
+            }
+            if def.cell_margin_left.is_some() {
+                out.cell_margin_left = def.cell_margin_left;
+            }
+            if def.cell_margin_right.is_some() {
+                out.cell_margin_right = def.cell_margin_right;
             }
             // §17.7.6: a derived table style's whole-table rPr/pPr layers ON TOP
             // of the base style's. We fold each level into a single accumulated
@@ -1192,6 +1252,25 @@ fn parse_tbl_style_def(style_node: roxmltree::Node, based_on: Option<String>) ->
             .and_then(|n| attr_w(n, "val"))
             .and_then(|v| v.parse::<usize>().ok())
             .map(|n| n.max(1));
+        // ECMA-376 §17.4.42 `<w:tblCellMar>`: per-edge default cell margins
+        // for tables that inherit this style. Each edge is stored as
+        // Option<f64> (points) so a derived style omitting an edge inherits
+        // the base via `resolve_table_style`. §17.18.90 ST_TblWidth says
+        // dxa = 1/20 pt; w:type other than dxa is ignored for margins.
+        if let Some(m) = child_w(tbl_pr, "tblCellMar") {
+            let edge = |name: &str| -> Option<f64> {
+                child_w(m, name)
+                    .filter(|n| attr_w(*n, "type").map(|t| t == "dxa").unwrap_or(true))
+                    .and_then(|n| attr_w(n, "w"))
+                    .map(|v| twips_to_pt(&v))
+            };
+            def.cell_margin_top = edge("top");
+            def.cell_margin_bottom = edge("bottom");
+            // §17.4.34 / §17.4.35 use `start`/`end` in the schema; Word also
+            // writes the legacy `left`/`right` aliases. Accept either.
+            def.cell_margin_left = edge("left").or_else(|| edge("start"));
+            def.cell_margin_right = edge("right").or_else(|| edge("end"));
+        }
     }
     if let Some(tc_pr) = child_w(style_node, "tcPr") {
         def.cell_shd = shd_fill(tc_pr);
@@ -1497,6 +1576,96 @@ mod tests {
             Some("ff0000"),
             "direct run color must override the conditional base"
         );
+    }
+
+    // ===== Table-style tblCellMar inheritance (§17.4.42 / §17.7.6) =====
+
+    /// styles.xml mirroring sample-3: the default table style "TableNormal"
+    /// (`w:default="1"`) carries `<w:tblPr><w:tblCellMar>` with left/right=108
+    /// twips. ECMA-376 §17.4.42 says a table whose `<w:tblPr>` omits
+    /// `<w:tblCellMar>` inherits the margins from its associated table style;
+    /// when no style is set, the spec maps the table to the default table
+    /// style. The parser must therefore (a) capture per-edge margins on
+    /// `TableStyleDef`, (b) flatten them through the basedOn chain, and (c)
+    /// expose the default table style so `parser.rs` can fall back to it when
+    /// no `<w:tblStyle>` is present on the table.
+    fn default_table_style_map() -> StyleMap {
+        let xml = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="table" w:default="1" w:styleId="TableNormal">
+                <w:name w:val="Normal Table"/>
+                <w:tblPr>
+                  <w:tblCellMar>
+                    <w:top w:w="0" w:type="dxa"/>
+                    <w:left w:w="108" w:type="dxa"/>
+                    <w:bottom w:w="0" w:type="dxa"/>
+                    <w:right w:w="108" w:type="dxa"/>
+                  </w:tblCellMar>
+                </w:tblPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        StyleMap::parse(&xml)
+    }
+
+    #[test]
+    fn table_style_captures_tbl_cell_mar_per_edge() {
+        // §17.4.42: a table style's `<w:tblPr><w:tblCellMar>` defines defaults
+        // for tables that inherit from it. The parser must surface each edge
+        // on TableStyleDef so a table that omits `<w:tblCellMar>` can fall
+        // back to these values (sample-3 root cause). 108 twips = 5.4 pt.
+        let sm = default_table_style_map();
+        let def = sm.resolve_table_style("TableNormal");
+        assert_eq!(def.cell_margin_top, Some(0.0));
+        assert_eq!(def.cell_margin_bottom, Some(0.0));
+        assert_eq!(def.cell_margin_left, Some(5.4));
+        assert_eq!(def.cell_margin_right, Some(5.4));
+    }
+
+    #[test]
+    fn default_table_style_id_is_exposed() {
+        // §17.7.4: a `<w:style w:type="table" w:default="1">` is the implicit
+        // style for tables that omit `<w:tblStyle>`. The parser must expose
+        // the styleId so callers can resolve the default style chain
+        // (sample-3's TableNormal carries the 108-twips cell margins that
+        // make tcMar-absent cells line up).
+        let sm = default_table_style_map();
+        assert_eq!(sm.default_table_style_id(), Some("TableNormal"));
+    }
+
+    #[test]
+    fn tbl_cell_mar_inherits_through_based_on_chain() {
+        // §17.7.6 + §17.4.42: a derived table style that omits `<w:tblCellMar>`
+        // inherits the per-edge values from its base. A derived style that
+        // sets ONLY one edge keeps the base values for the rest.
+        let xml = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="table" w:default="1" w:styleId="TableNormal">
+                <w:tblPr>
+                  <w:tblCellMar>
+                    <w:left w:w="108" w:type="dxa"/>
+                    <w:right w:w="108" w:type="dxa"/>
+                  </w:tblCellMar>
+                </w:tblPr>
+              </w:style>
+              <w:style w:type="table" w:styleId="Derived">
+                <w:basedOn w:val="TableNormal"/>
+                <w:tblPr>
+                  <w:tblCellMar>
+                    <w:left w:w="200" w:type="dxa"/>
+                  </w:tblCellMar>
+                </w:tblPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        let sm = StyleMap::parse(&xml);
+        let def = sm.resolve_table_style("Derived");
+        // Derived overrides left (200 twips = 10pt) …
+        assert_eq!(def.cell_margin_left, Some(10.0));
+        // … but right inherits TableNormal (108 twips = 5.4pt).
+        assert_eq!(def.cell_margin_right, Some(5.4));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A table whose `<w:tblPr>` omits `<w:tblCellMar>` must inherit its
per-edge cell margins from the associated table style (ECMA-376
§17.4.42), and a table that omits `<w:tblStyle>` is implicitly
associated with the `<w:style w:type=\"table\" w:default=\"1\">` style —
typically `TableNormal` / "Normal Table" (§17.7.4). The previous parser
implementation never read `<w:tblCellMar>` from any table style and
fell back to a hard-coded `3.6 pt` for left/right cell padding — a
magic constant with no spec basis.

In documents that mix cells with explicit `<w:tcMar>` and cells
without, the bogus 3.6 pt fallback misaligned the tcMar-absent cells
by 1.8 pt per edge from where Word renders them. The user-visible
symptom: in a sample document whose `TableNormal` carries
`<w:tblCellMar><w:left w:w=\"108\"/><w:right w:w=\"108\"/></w:tblCellMar>`
(5.4 pt), cells without `<w:tcMar>` rendered with a 3.6 pt left edge
while sibling cells with explicit `<w:tcMar w:left=\"115\">` (5.75 pt)
rendered at 5.75 pt — a visible step at column boundaries, plus text
that ran past the right edge of the cell because the content width was
overestimated.

This change resolves cell margins per §17.4.42 with the three-tier
priority the spec mandates:

1. Inline `<w:tblPr><w:tblCellMar>` per-edge value wins.
2. Each edge omitted inline inherits from the resolved table style
   chain (which now includes `TableNormal` and any other
   `w:default=\"1\"` table style).
3. Edges never specified in the style hierarchy use the spec default:
   115 twips (5.75 pt) for left/right per §17.4.34 / §17.4.11, and
   0 for top/bottom per §17.4.5 / §17.4.75. The previous 3.6 pt
   fallback is removed.

The implementation:

- Adds `cell_margin_{top,bottom,left,right}: Option<f64>` to
  `TableStyleDef` and reads them from `<w:tblPr><w:tblCellMar>` in
  `parse_tbl_style_def`. Each edge is captured independently; the
  modern `start`/`end` schema names and legacy `left`/`right` aliases
  are both accepted at every layer (§17.4.34 / §17.4.35).
- Flattens the per-edge values through `basedOn` in
  `resolve_table_style` so a derived style that omits an edge inherits
  the base.
- Tracks the `default_table_style_id` on `StyleMap` (style with
  `w:type=\"table\" w:default=\"1\"`) and exposes it via
  `default_table_style_id()`.
- In `parse_table`, falls back to the default table style when the
  table omits `<w:tblStyle>` so its `tblCellMar` (and other tstyle
  attributes) apply.

## Spec references

- §17.4.42 *tblCellMar (Table Cell Margin Defaults)* — "If this
  element is omitted, then it shall inherit the table cell margins
  from the associated table style. If table margins are never
  specified in the style hierarchy, then each margin shall use its
  default margin size."
- §17.7.4 — the `w:default=\"1\"` table style is the implicit table
  style for tables that omit `<w:tblStyle>`.
- §17.4.34 *start (Table Cell Leading Margin Default)* — when never
  specified, leading margin defaults to 115 twips (0.08 in).
- §17.4.11 *end (Table Cell Trailing Margin Default)* — same 115 twips
  default for the trailing edge.
- §17.4.5 / §17.4.75 *bottom / top (Table Cell …Margin Default)* —
  default is no padding (0 twips) when never specified.

## Test plan

- [x] 6 new unit tests covering per-edge style capture, `basedOn`
  inheritance, `default_table_style_id` accessor, the
  default-style-only inheritance path in `parse_table`, the inline
  override of inherited values, and the §17.4.34 spec fallback when
  the style hierarchy carries no `<w:tblCellMar>` at all.
- [x] All 145 cargo tests green; `cargo fmt --all` and
  `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] Root `pnpm typecheck` green across every workspace package
  (markdown, node, vscode-extension included).
- [x] Local `pnpm --filter @silurus/ooxml-docx vrt` runs 21/21 green
  on demo and private samples.
- [x] Pixel-level check on the bug-target sample: in a 3-column
  Japanese-resume layout where the `\"First Up Consultants\"` cell has
  no `<w:tcMar>` but the sibling body cell has
  `<w:tcMar w:left=\"115\">`, the left edge moves from
  x=174 (3.6 pt fallback) to x=176 (TableNormal 5.4 pt inheritance),
  which matches Word's PDF reference (x=176) exactly. Cells with
  explicit `<w:tcMar>` are unchanged. The two classes of cells now
  line up under each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)