### PR TITLE
fix(docx): pre-scan page/margin-anchored floats so earlier paragraphs wrap (§20.4.3.x)

### DIFF
--- a/packages/docx/src/page-anchor-prescan.test.ts
+++ b/packages/docx/src/page-anchor-prescan.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from 'vitest';
+import {
+  __test_isPageLevelAnchorY,
+  __test_preRegisterPageFloats,
+  computePages,
+  type RenderState,
+} from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  ImageRun,
+  SectionProps,
+  ShapeRun,
+} from './types.js';
+
+// Pins ECMA-376 §20.4.3.2 / §20.4.3.5 behaviour: a `<wp:anchor>` whose
+// `<wp:positionV>@relativeFrom` resolves Y independently of the source-order
+// anchoring paragraph (page / margin / *Margin / column) is laid out by Word
+// as soon as the page is opened, so paragraphs that PRECEDE the anchor's
+// paragraph in source order still wrap around the float. Renderer mirrors
+// this by pre-scanning page-level floats at every page-start
+// (renderBodyElements + paginator's float-reset call sites) and recording
+// the source paragraph in `state.pageAnchorPrescanned` so the per-paragraph
+// `registerAnchorFloats` skips the duplicate registration when the flow
+// reaches it. These three tests cover (1) the wrap-window narrowing seen by
+// an EARLIER paragraph, (2) the carve-out for paragraph-local Y (which must
+// NOT pre-register), and (3) idempotency (no double FloatRect).
+
+// ===== Stub canvas + helpers (mirrors pagination.test) =====
+
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, fillText() {}, strokeText() {}, beginPath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fillRect() {}, drawImage() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1, textAlign: 'left' as CanvasTextAlign,
+    direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function section(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 200, pageHeight: 200,
+    marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    ...overrides,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function textRun(text: string, fontSize: number): DocRun {
+  const run: DocxTextRun = {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+  return { type: 'text', ...run } as DocRun;
+}
+
+function para(opts: { text?: string; fontSize?: number } = {}): BodyElement {
+  const fontSize = opts.fontSize ?? 20;
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: opts.text ? [textRun(opts.text, fontSize)] : [],
+    defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function paraWith(runs: DocRun[], opts: { fontSize?: number } = {}): BodyElement {
+  const fontSize = opts.fontSize ?? 20;
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs,
+    defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+// Minimal page-level square-anchored image float (positionV relativeFrom=margin
+// + align=top, square wrap). 100×40 pt, pinned at the right edge of the top
+// margin so anything on the page from y∈[20,60], x∈[120,220] wraps around it.
+function pageImageRun(opts: {
+  widthPt?: number;
+  heightPt?: number;
+  anchorXPt?: number;
+  anchorYPt?: number;
+  anchorXRelativeFrom?: string | null;
+  anchorYRelativeFrom?: string | null;
+  anchorXFromMargin?: boolean;
+  anchorYFromPara?: boolean;
+  wrapMode?: string;
+  wrapSide?: string;
+} = {}): DocRun {
+  const img: ImageRun = {
+    imagePath: 'word/media/test1.png',
+    mimeType: 'image/png',
+    widthPt: opts.widthPt ?? 60,
+    heightPt: opts.heightPt ?? 40,
+    anchor: true,
+    anchorXPt: opts.anchorXPt ?? 100,
+    anchorYPt: opts.anchorYPt ?? 0,
+    anchorXFromMargin: opts.anchorXFromMargin ?? true,
+    anchorYFromPara: opts.anchorYFromPara ?? false,
+    wrapMode: opts.wrapMode ?? 'square',
+    wrapSide: opts.wrapSide ?? 'bothSides',
+    anchorXRelativeFrom: opts.anchorXRelativeFrom ?? 'margin',
+    anchorYRelativeFrom: opts.anchorYRelativeFrom ?? 'margin',
+  };
+  return { type: 'image', ...img } as DocRun;
+}
+
+// Minimal page-level wrap shape (positionV relativeFrom=page + topAndBottom).
+function pageShapeRun(opts: {
+  widthPt?: number;
+  heightPt?: number;
+  anchorYPt?: number;
+  anchorYRelativeFrom?: string | null;
+  anchorYFromPara?: boolean;
+  wrapMode?: string | null;
+} = {}): DocRun {
+  const s: ShapeRun = {
+    widthPt: opts.widthPt ?? 160,
+    heightPt: opts.heightPt ?? 30,
+    anchorXPt: 0,
+    anchorYPt: opts.anchorYPt ?? 20,
+    anchorXFromMargin: true,
+    anchorYFromPara: opts.anchorYFromPara ?? false,
+    zOrder: 0,
+    subpaths: [],
+    presetGeometry: 'rect',
+    fill: { fillType: 'solid', color: 'FFFFFF' },
+    stroke: null,
+    wrapMode: opts.wrapMode === undefined ? 'topAndBottom' : opts.wrapMode,
+    wrapSide: null,
+    distTop: 0, distBottom: 0, distLeft: 0, distRight: 0,
+    anchorYRelativeFrom: opts.anchorYRelativeFrom ?? 'page',
+  } as ShapeRun;
+  return { type: 'shape', ...s } as DocRun;
+}
+
+// ===== Tests =====
+
+describe('preRegisterPageFloats — isPageLevelAnchorY classifier (§20.4.3.5)', () => {
+  it('paragraph/line/character ⇒ paragraph-local (NOT page-level)', () => {
+    expect(__test_isPageLevelAnchorY('paragraph', false)).toBe(false);
+    expect(__test_isPageLevelAnchorY('line', false)).toBe(false);
+    expect(__test_isPageLevelAnchorY('character', false)).toBe(false);
+  });
+
+  it('page / margin / *Margin / column ⇒ page-level', () => {
+    for (const rf of ['page', 'margin', 'topMargin', 'bottomMargin', 'leftMargin', 'rightMargin', 'insideMargin', 'outsideMargin', 'column']) {
+      expect(__test_isPageLevelAnchorY(rf, false)).toBe(true);
+    }
+  });
+
+  it('absent relativeFrom defers to anchorYFromPara (page-level only when NOT from-para)', () => {
+    expect(__test_isPageLevelAnchorY(null, false)).toBe(true);
+    expect(__test_isPageLevelAnchorY(null, true)).toBe(false);
+    expect(__test_isPageLevelAnchorY(undefined, false)).toBe(true);
+  });
+});
+
+describe('preRegisterPageFloats — earlier paragraph sees the float band (§20.4.3.2/§20.4.3.5)', () => {
+  // Page-content geometry: contentH = 200 - 40 = 160, contentW = 200 - 40 = 160.
+  // A page-anchored topAndBottom shape carried by paragraph B is pinned at
+  // y∈[20,50] (anchorYPt=20 + heightPt=30, anchorYRelativeFrom='page' ⇒ Y is
+  // page-absolute; a full-width topAndBottom band stamps the full content
+  // width). Paragraph A's first body line WITHOUT pre-scan starts at the
+  // marginTop (no float band registered yet), so its text fits in column-top
+  // space. WITH pre-scan, paragraph A is laid out AFTER the float band is
+  // already in the float set ⇒ its lines flow BELOW y=50 (under the band),
+  // displacing the rest of the body downward.
+  //
+  // Asserts the displacement by comparing the paginated layout against a
+  // sibling test with a paragraph-LOCAL anchor (relativeFrom='paragraph'),
+  // which is NOT pre-registered, so paragraph A keeps the full content top.
+
+  it('a page-level anchor on a LATER paragraph wraps earlier paragraphs (more pages)', () => {
+    // Geometry: contentW=160, contentH=160. 20pt font → 8 chars/line normal.
+    // Paragraph B carries a page-level SQUARE float anchored at x=80 (right
+    // half of content band) y=0 in the top margin, width 80, height 60. Its
+    // exclusion rect (without dist padding) is x∈[100,180], y∈[20,80] (the
+    // anchorXFromMargin/anchorYRelativeFrom='margin' resolve to marginLeft+80
+    // = 100, marginTop+0 = 20). For lines whose top is in [20,80]
+    // (3 lines: y=20→40, 40→60, 60→80), the wrap window narrows to
+    // [20,100] = 80pt = 4 chars/line. Below the float, lines use the full
+    // 160pt = 8 chars/line.
+    //
+    // 64 chars of text in paragraph A — exactly 8 lines × 20pt = 160pt
+    //   pre-scan OFF (paragraph-local Y): A flows full-width ⇒ 8 lines fit
+    //                exactly on page 1; B's anchor-only mark also fits
+    //                (spaceAfter overflow allowed) ⇒ ONE page.
+    //   pre-scan ON: lines 1-3 (y∈[20,80]) wrap into x∈[20,100] = 80pt =
+    //                4 chars/line ⇒ 12 chars consumed in those 3 lines.
+    //                Remaining 52 chars below the float at 8 chars/line ⇒
+    //                ceil(52/8) = 7 lines. Total 10 lines × 20 = 200pt > 160pt
+    //                ⇒ paragraph A alone spills onto a second page.
+    const bodyPage = [
+      para({ text: 'あ'.repeat(64), fontSize: 20 }),
+      paraWith([
+        pageImageRun({
+          widthPt: 80, heightPt: 60,
+          anchorXPt: 80, anchorYPt: 0,
+          anchorXRelativeFrom: 'margin', anchorYRelativeFrom: 'margin',
+          anchorXFromMargin: true, anchorYFromPara: false,
+          wrapMode: 'square', wrapSide: 'bothSides',
+        }),
+      ]),
+    ];
+    const pagesWithPageAnchor = computePages(bodyPage, section(), makeCtx());
+
+    // Paragraph-LOCAL Y anchor (relativeFrom='paragraph'). Pre-scan must
+    // SKIP this float — A flows without it.
+    const bodyLocal = [
+      para({ text: 'あ'.repeat(64), fontSize: 20 }),
+      paraWith([
+        pageImageRun({
+          widthPt: 80, heightPt: 60,
+          anchorXPt: 80, anchorYPt: 0,
+          anchorXRelativeFrom: 'margin', anchorYRelativeFrom: 'paragraph',
+          anchorXFromMargin: true, anchorYFromPara: true,
+          wrapMode: 'square', wrapSide: 'bothSides',
+        }),
+      ]),
+    ];
+    const pagesWithLocalAnchor = computePages(bodyLocal, section(), makeCtx());
+
+    // Signal: under the pre-scan, paragraph A is SPLIT (its 64 chars no
+    // longer fit on one page because the pre-registered float narrows the
+    // wrap window) — page 1 carries a `lineSlice` for A. Under the
+    // paragraph-local anchor, A is NOT split (8 lines × 20pt = 160pt fits
+    // page 1 exactly) — its element is emitted whole, no `lineSlice`.
+    const firstElOf = (pages: ReturnType<typeof computePages>) => pages[0][0] as { lineSlice?: { start: number; end: number } };
+    const pageFirst = firstElOf(pagesWithPageAnchor);
+    const localFirst = firstElOf(pagesWithLocalAnchor);
+    // Page-level case: paragraph A is split (lineSlice present) because the
+    // pre-registered float forced more lines than the page can hold.
+    expect(pageFirst.lineSlice).toBeDefined();
+    // Paragraph-local case: A is NOT pre-narrowed, fits whole on page 1.
+    expect(localFirst.lineSlice).toBeUndefined();
+  });
+});
+
+describe('preRegisterPageFloats — paragraph-local Y is NOT pre-registered', () => {
+  it('pre-scan ignores a wrap float with positionV relativeFrom="paragraph"', () => {
+    const body = [
+      para({ text: 'ABC' }),
+      paraWith([
+        // Paragraph-local: must NOT be pre-registered (paraId stays at the
+        // paragraph's own registration in registerAnchorFloats).
+        pageShapeRun({ widthPt: 100, heightPt: 30, anchorYRelativeFrom: 'paragraph', anchorYFromPara: true, wrapMode: 'topAndBottom' }),
+      ]),
+    ];
+    // Minimal RenderState stub matching what registerImageFloat/registerShapeFloat
+    // touch: scale, marginLeft/Top, pageH, contentX/W, dryRun (no images), floats.
+    const state = {
+      scale: 1,
+      marginLeft: 20, marginRight: 20, marginTop: 20, marginBottom: 20,
+      pageWidth: 200, pageH: 200,
+      contentX: 20, contentW: 160,
+      floats: [],
+      floatParaSeq: 0,
+      dryRun: true,
+      pageAnchorPrescanned: new Set(),
+    } as unknown as RenderState;
+    __test_preRegisterPageFloats(body, 0, state);
+    expect(state.floats.length).toBe(0);
+    expect(state.pageAnchorPrescanned?.size ?? 0).toBe(0);
+  });
+
+  it('pre-scan REGISTERS a page-level (relativeFrom="margin") wrap float on an earlier-scanned paragraph', () => {
+    const body = [
+      para({ text: 'ABC' }), // paragraph A, no floats
+      paraWith([
+        // Paragraph B carries a page-level square anchor
+        pageImageRun({ widthPt: 60, heightPt: 40, anchorYRelativeFrom: 'margin', anchorYFromPara: false, wrapMode: 'square' }),
+      ]),
+    ];
+    const state = {
+      scale: 1,
+      marginLeft: 20, marginRight: 20, marginTop: 20, marginBottom: 20,
+      pageWidth: 200, pageH: 200,
+      contentX: 20, contentW: 160,
+      floats: [],
+      floatParaSeq: 0,
+      images: new Map(),
+      dryRun: true,
+      pageAnchorPrescanned: new Set(),
+    } as unknown as RenderState;
+    __test_preRegisterPageFloats(body, 0, state);
+    expect(state.floats.length).toBe(1);
+    expect(state.pageAnchorPrescanned?.size).toBe(1);
+  });
+});
+
+describe('preRegisterPageFloats — idempotent on repeated pre-scan', () => {
+  it('a paragraph already in pageAnchorPrescanned is not re-registered', () => {
+    const paraB = paraWith([
+      pageImageRun({ widthPt: 60, heightPt: 40, anchorYRelativeFrom: 'margin', wrapMode: 'square' }),
+    ]);
+    const body = [para({ text: 'A' }), paraB];
+    const state = {
+      scale: 1,
+      marginLeft: 20, marginRight: 20, marginTop: 20, marginBottom: 20,
+      pageWidth: 200, pageH: 200,
+      contentX: 20, contentW: 160,
+      floats: [],
+      floatParaSeq: 0,
+      images: new Map(),
+      dryRun: true,
+      pageAnchorPrescanned: new Set(),
+    } as unknown as RenderState;
+    __test_preRegisterPageFloats(body, 0, state);
+    const after1 = state.floats.length;
+    expect(after1).toBe(1);
+    // Second call: same body, same start index. The dedupe key is the
+    // already-pre-registered paragraph in pageAnchorPrescanned, so floats
+    // must NOT grow.
+    __test_preRegisterPageFloats(body, 0, state);
+    expect(state.floats.length).toBe(after1);
+  });
+
+  it('stops at the next pageBreak — items after the break are NOT pre-scanned for this page', () => {
+    const body = [
+      paraWith([pageImageRun({ widthPt: 60, heightPt: 40, anchorYRelativeFrom: 'margin', wrapMode: 'square' })]), // would register
+      { type: 'pageBreak' } as BodyElement,                                                                       // page boundary
+      paraWith([pageImageRun({ widthPt: 60, heightPt: 40, anchorYRelativeFrom: 'margin', wrapMode: 'square' })]), // must be SKIPPED — belongs to the next page
+    ];
+    const state = {
+      scale: 1,
+      marginLeft: 20, marginRight: 20, marginTop: 20, marginBottom: 20,
+      pageWidth: 200, pageH: 200,
+      contentX: 20, contentW: 160,
+      floats: [],
+      floatParaSeq: 0,
+      images: new Map(),
+      dryRun: true,
+      pageAnchorPrescanned: new Set(),
+    } as unknown as RenderState;
+    __test_preRegisterPageFloats(body, 0, state);
+    expect(state.floats.length).toBe(1);
+    expect(state.pageAnchorPrescanned?.size).toBe(1);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -240,6 +240,19 @@ export interface RenderState {
    *  `<w:footnoteRef>` placeholder (which carries no id) renders the note's
    *  number. Undefined for body text. */
   currentNoteNumber?: number;
+  /** ECMA-376 §20.4.3.2/§20.4.3.5: a DrawingML anchor whose `<wp:positionV>`
+   *  uses a page-level `relativeFrom` (page / margin / topMargin / bottomMargin
+   *  / leftMargin / rightMargin / insideMargin / outsideMargin / column) is
+   *  positioned independently of its source-order anchoring paragraph — Word
+   *  lays it out as soon as the page is opened, so paragraphs that come BEFORE
+   *  the anchor's paragraph in source order still wrap around it. To match,
+   *  we pre-scan upcoming body paragraphs at every page-start and register
+   *  these floats up front. This set records which paragraphs have had their
+   *  page-level floats pre-registered on the current page, so
+   *  {@link registerAnchorFloats} skips re-registering them when the main
+   *  flow reaches that paragraph. Reset whenever floats are reset (page flip
+   *  or column relocation that rolls back this paragraph's own floats). */
+  pageAnchorPrescanned?: Set<DocParagraph>;
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -1096,6 +1109,23 @@ export function computePages(
   measureState.y = section.marginTop;
   measureState.floats = [];
   measureState.floatParaSeq = 0;
+  // ECMA-376 §20.4.3.2/§20.4.3.5: a wp:anchor whose positionV relativeFrom is
+  // page-level (page / margin / *Margin / column) is positioned independently
+  // of its source-order anchoring paragraph — Word lays it out at page-open,
+  // so paragraphs PRECEDING the anchor's paragraph on the same page still
+  // wrap around it. We pre-register such floats at every page-start so the
+  // paginator's per-paragraph height estimate matches the renderer (which
+  // does the same pre-scan once per page in renderBodyElements). The
+  // page-start body index is updated at every place that resets `floats`
+  // (initial setup, newPage, pageBreak, sectionBreak/nextPage, +
+  // pageBreakBefore). prescanFloatsFrom() reads it and rescans into the
+  // (already cleared) measureState. See preRegisterPageFloats header.
+  measureState.pageAnchorPrescanned = new Set();
+  const prescanFloatsFrom = (idx: number): void => {
+    measureState.pageAnchorPrescanned = new Set();
+    preRegisterPageFloats(body, idx, measureState);
+  };
+  prescanFloatsFrom(0);
   // Footnote ids already reserved on the current page (so a paragraph that
   // references the same note twice doesn't double-count, and the renderer draws
   // each note once). Reset on every page flip.
@@ -1107,7 +1137,12 @@ export function computePages(
     footnoteReservePt[pages.length - 1] = 0;
     pageNoteIds = new Set<string>();
   };
-  const newPage = () => {
+  /** Open a new page (no-op when the current one is empty). `pageStartIdx`
+   *  is the body index that becomes the new page's first laid-out item — the
+   *  caller's current `i` (a paragraph being split / relocated / a pageBreak
+   *  / a table being split). Used to pre-register page-level wrap floats
+   *  (ECMA-376 §20.4.3.2/§20.4.3.5; see `prescanFloatsFrom`). */
+  const newPage = (pageStartIdx: number) => {
     if (pages[pages.length - 1].length > 0) {
       pages.push([]);
       y = 0;
@@ -1119,6 +1154,7 @@ export function computePages(
       // clean float set. Columns of the SAME page share floats (see nextColumn).
       measureState.floats = [];
       measureState.floatParaSeq = 0;
+      prescanFloatsFrom(pageStartIdx);
       startPageBookkeeping();
     }
   };
@@ -1136,9 +1172,12 @@ export function computePages(
   };
   // Overflow handler shared by element placement and paragraph/table splitting:
   // move to the next column if one remains on this page, otherwise to a new page.
-  const nextColumnOrPage = () => {
+  // `pageStartIdx` is forwarded to `newPage` so a fresh page pre-registers
+  // page-level floats from the right body index (the element that triggered the
+  // overflow); ignored for the same-page next-column path (floats are page-scoped).
+  const nextColumnOrPage = (pageStartIdx: number) => {
     if (colIndex < columns.length - 1) nextColumn();
-    else newPage();
+    else newPage(pageStartIdx);
   };
 
   // A paragraph-anchored floating object (wp:anchor with positionV
@@ -1226,8 +1265,9 @@ export function computePages(
       // ECMA-376 §17.3.1.20 <w:br w:type="column"/>: force the next column (or a
       // new page's first column when already in the last column — newPage() no-ops
       // on an empty page, so a column break in the last column of an as-yet-empty
-      // page simply stays put).
-      nextColumnOrPage();
+      // page simply stays put). Page-start index = the body element AFTER the
+      // break (i + 1) since the break itself emits no content on the new page.
+      nextColumnOrPage(i + 1);
       continue;
     }
     if (el.type === 'pageBreak') {
@@ -1238,6 +1278,9 @@ export function computePages(
       measureState.y = section.marginTop;
       measureState.floats = [];
       measureState.floatParaSeq = 0;
+      // Pre-register page-level wrap floats from the next body element onward
+      // (the pageBreak itself emits nothing on the new page).
+      prescanFloatsFrom(i + 1);
       startPageBookkeeping();
       // ECMA-376 §17.18.79 ST_SectionMark: oddPage / evenPage breaks pad
       // with a blank page when the new section would otherwise start on the
@@ -1282,6 +1325,9 @@ export function computePages(
         measureState.y = section.marginTop;
         measureState.floats = [];
         measureState.floatParaSeq = 0;
+        // Pre-register page-level wrap floats from the next body element onward
+        // (the sectionBreak itself emits nothing on the new page).
+        prescanFloatsFrom(i + 1);
         startPageBookkeeping();
         if (el.kind === 'oddPage' && pages.length % 2 === 0) {
           pages.push([]);
@@ -1295,7 +1341,11 @@ export function computePages(
     }
     if (el.type === 'paragraph') {
       const para = el as unknown as DocParagraph;
-      if (para.pageBreakBefore) newPage();
+      // `pageBreakBefore` opens a fresh page whose first item is THIS paragraph,
+      // so the pre-scan should start at `i` (not i+1) to include its own
+      // page-level floats. (registerAnchorFloats below will then skip the
+      // pre-registered page-level ones via state.pageAnchorPrescanned.)
+      if (para.pageBreakBefore) newPage(i);
 
       // A frame paragraph (ECMA-376 §17.3.1.11) is positioned out of flow: it
       // does not advance the page cursor and is not split. Register its wrap
@@ -1415,7 +1465,9 @@ export function computePages(
       const keepIntact = para.keepLines || needNext > 0 || addReservePt > 0;
       if (breakForFloat || (overflowsHere && keepIntact && needed <= effContentH())) {
         const pagesBeforeRelocate = pages.length;
-        nextColumnOrPage();
+        // Relocating THIS paragraph to a fresh page: pre-scan from `i` so the
+        // new page starts with THIS paragraph's own page-level floats counted.
+        nextColumnOrPage(i);
         const movedToNewPage = pages.length > pagesBeforeRelocate;
         if (movedToNewPage) {
           // newPage() cleared measureState.floats AND reset floatParaSeq to 0, so
@@ -1458,8 +1510,10 @@ export function computePages(
           // Overflow during the split advances to the next column first, then a
           // new page (newspaper fill). Each slice is tagged with the column it
           // landed in via the colIndex thunk, plus this section's column geometry
-          // (constant — a paragraph never spans a section boundary).
-          () => { nextColumnOrPage(); },
+          // (constant — a paragraph never spans a section boundary). The
+          // continuation slice belongs to THIS paragraph, so the new page's
+          // pre-scan starts at `i` (this paragraph index).
+          () => { nextColumnOrPage(i); },
           () => colIndex,
           columns,
         );
@@ -1543,14 +1597,16 @@ export function computePages(
         // pagination). Tables that fit keep the simple place-whole path below.
         const endY = splitTableAcrossPages(
           tbl, rowHs, y, tableContentH, pages,
-          () => { nextColumnOrPage(); },
+          // Table slices belong to THIS table element, so the new page's
+          // pre-scan starts at `i` (this table's body index).
+          () => { nextColumnOrPage(i); },
           () => colIndex,
           columns,
         );
         y = endY;
         measureState.y = section.marginTop + endY;
       } else {
-        if (y + h > tableContentH) nextColumnOrPage();
+        if (y + h > tableContentH) nextColumnOrPage(i);
         pushTagged(el as PaginatedBodyElement);
         y += h;
         measureState.y += h;
@@ -2426,6 +2482,20 @@ function renderBodyElements(
 ): void {
   let prevPara: DocParagraph | null = null;
   let prevSpaceAfter = 0;
+  // ECMA-376 §20.4.3.2/§20.4.3.5: a wp:anchor whose positionV relativeFrom is
+  // page-level (page / margin / *Margin / column — anything but
+  // paragraph/line/character) is positioned independently of its source-order
+  // anchoring paragraph. Word lays such floats out as soon as the page is
+  // opened, so paragraphs PRECEDING the anchor's paragraph on the same page
+  // still wrap around it. Mirror that by pre-registering them at every
+  // page-start — `state` is fresh per page (renderDocumentToCanvas builds a
+  // new bodyState with floats=[] for each render call), so this single call
+  // covers the page. `elements` is already the paginated body for THIS page,
+  // so scanning from index 0 stays within the page (preRegisterPageFloats
+  // additionally stops at the first explicit page/non-continuous section
+  // break, which is a no-op here but matches the paginator's call sites).
+  state.pageAnchorPrescanned = new Set();
+  preRegisterPageFloats(elements, 0, state);
   // The (geometry, column index) the flow `state` is currently set to. `activeCol`
   // starts at -1 so the first element always seeds the column. `activeGeom` tracks
   // the SECTION whose columns are in effect (per-section newspaper columns,
@@ -5265,6 +5335,24 @@ export const __test_resolveAnchorBox = (
 ): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } =>
   resolveAnchorBox(img, state, paraBaseY);
 
+/** Exported for the page-anchor pre-scan test (ECMA-376 §20.4.3.2/§20.4.3.5):
+ *  drives {@link preRegisterPageFloats} from a unit test against a stub
+ *  RenderState so we can pin which paragraphs get pre-registered and that
+ *  duplicate calls are idempotent. */
+export const __test_preRegisterPageFloats = (
+  body: readonly (BodyElement | PaginatedBodyElement)[],
+  startIdx: number,
+  state: RenderState,
+): void => preRegisterPageFloats(body, startIdx, state);
+
+/** Exported for the page-anchor pre-scan test — pins the
+ *  {paragraph,line,character} ⇒ paragraph-local vs everything-else ⇒ page-level
+ *  classification (ECMA-376 §20.4.3.5 ST_RelFromV). */
+export const __test_isPageLevelAnchorY = (
+  rf: string | null | undefined,
+  fromPara: boolean,
+): boolean => isPageLevelAnchorY(rf, fromPara);
+
 function resolveAnchorBox(
   img: ImageRun,
   state: RenderState,
@@ -5307,21 +5395,136 @@ function resolveAnchorBox(
   };
 }
 
+/** ECMA-376 §20.4.3.2 / §20.4.3.5 — a `<wp:positionV>` `relativeFrom` value
+ *  that resolves the float's Y INDEPENDENTLY of its anchoring paragraph (vs.
+ *  `paragraph` / `line` / `character` which resolve against the paragraph's
+ *  top). When Y is page-level, Word treats the float as page-positioned: it
+ *  is laid out as soon as the page is opened and earlier paragraphs on the
+ *  same page wrap around it. {@link preRegisterPageFloats} uses this to
+ *  hoist such floats to page-start; paragraph-local Y still flows the legacy
+ *  per-paragraph path.
+ *
+ *  An anchor with NO explicit `<wp:positionV>` (anchorYRelativeFrom absent)
+ *  still resolves against the page top via the legacy hint
+ *  (`anchorYFromPara=false` ⇒ page-absolute offset), so it qualifies as
+ *  page-level too. */
+function isPageLevelAnchorY(rf: string | null | undefined, fromPara: boolean): boolean {
+  if (rf == null) return !fromPara;
+  switch (rf) {
+    case 'paragraph':
+    case 'line':
+    case 'character':
+      return false;
+    default:
+      return true;
+  }
+}
+
+/** True when this run is a wrap float whose vertical placement is page-level
+ *  (independent of source-order paragraph position) — see
+ *  {@link isPageLevelAnchorY}. `isWrapFloat` already filters inline images
+ *  (their `wrapMode` is undefined) and non-wrapping anchors, so an extra
+ *  `anchor` check is redundant here. */
+function isPageLevelWrapFloat(run: ImageRun | ShapeRun): boolean {
+  if (!isWrapFloat(run.wrapMode)) return false;
+  return isPageLevelAnchorY(run.anchorYRelativeFrom ?? null, run.anchorYFromPara ?? false);
+}
+
 /** Register floats from a paragraph's anchor images and shapes. Anchor images
  *  are drawn immediately; anchor shapes are NOT drawn here (renderAnchorShape
  *  paints them separately) — we only reserve their float-exclusion band so body
- *  text wraps around them (ECMA-376 §20.4.2.16/.17), exactly like images. */
+ *  text wraps around them (ECMA-376 §20.4.2.16/.17), exactly like images.
+ *
+ *  Page-level floats (positionV relativeFrom ∈ {page, margin, *Margin, column},
+ *  ECMA-376 §20.4.3.2/§20.4.3.5) are skipped when this paragraph was already
+ *  pre-registered at the current page's start by {@link preRegisterPageFloats}
+ *  — re-registering would double-stamp the FloatRect (and re-draw the image).
+ *  Paragraph-local floats (`paragraph`/`line`/`character`) keep the per-
+ *  paragraph path so their Y stays anchored at this paragraph's top. */
 function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphAnchorY: number): void {
   // One id per registerAnchorFloats call ⇒ one id per paragraph. Floats sharing
   // a paraId (e.g. two side-by-side photos in one paragraph) never displace each
   // other; floats from different paragraphs do (de-facto overlap avoidance).
   const paraId = state.floatParaSeq++;
+  const prescanned = state.pageAnchorPrescanned?.has(para) ?? false;
   for (const run of para.runs) {
     if (run.type === 'image') {
-      registerImageFloat(run as unknown as ImageRun, state, paragraphAnchorY, paraId);
+      const img = run as unknown as ImageRun;
+      if (prescanned && isPageLevelWrapFloat(img)) continue;
+      registerImageFloat(img, state, paragraphAnchorY, paraId);
     } else if (run.type === 'shape') {
-      registerShapeFloat(run as unknown as ShapeRun, state, paragraphAnchorY, paraId);
+      const shp = run as unknown as ShapeRun;
+      if (prescanned && isPageLevelWrapFloat(shp)) continue;
+      registerShapeFloat(shp, state, paragraphAnchorY, paraId);
     }
+  }
+}
+
+/** Pre-scan upcoming body elements at a page-start moment and register any
+ *  page-level (positionV relativeFrom ∈ {page, margin, *Margin, column})
+ *  wrap floats they carry. Mirrors Word's layout order: page-level floats are
+ *  positioned as soon as the page is opened, so paragraphs that PRECEDE the
+ *  anchoring paragraph in source order on the same page wrap around them
+ *  (ECMA-376 §20.4.3.2/§20.4.3.5 + §20.4.2.16/.17). Each pre-registered
+ *  paragraph is recorded in `state.pageAnchorPrescanned` so the main flow's
+ *  {@link registerAnchorFloats} skips its page-level runs (avoiding a
+ *  duplicate FloatRect / re-drawn image) while still registering its
+ *  paragraph-local floats normally.
+ *
+ *  Bounds: the scan stops at the next forced page boundary that the
+ *  paginator/renderer is guaranteed to honor — an explicit `pageBreak`
+ *  (§17.18.79 / §17.3.1.20) or a non-continuous `sectionBreak`. Content
+ *  overflow may still push paragraphs to later pages mid-scan; the
+ *  paginator's `newPage()` resets the float set wholesale, so those
+ *  paragraphs get re-pre-scanned on the next page. (Same idempotent flow as
+ *  the existing `registerAnchorFloats` post-newPage re-call at the split-
+ *  relocation site.) */
+function preRegisterPageFloats(
+  body: readonly (BodyElement | PaginatedBodyElement)[],
+  startIdx: number,
+  state: RenderState,
+): void {
+  if (!state.pageAnchorPrescanned) state.pageAnchorPrescanned = new Set();
+  for (let j = startIdx; j < body.length; j++) {
+    const el = body[j];
+    if (!el) continue;
+    if (el.type === 'pageBreak') break;
+    if (el.type === 'sectionBreak') {
+      const sb = el as unknown as { kind?: string };
+      if (sb.kind && sb.kind !== 'continuous') break;
+      continue;
+    }
+    if (el.type !== 'paragraph') continue;
+    const para = el as unknown as DocParagraph;
+    // Skip if already pre-registered (renderer may call this once per page;
+    // paginator may re-call after newPage(), but newPage clears the set).
+    if (state.pageAnchorPrescanned.has(para)) continue;
+    let hasPageLevel = false;
+    for (const run of para.runs) {
+      if (run.type === 'image') {
+        if (isPageLevelWrapFloat(run as unknown as ImageRun)) { hasPageLevel = true; break; }
+      } else if (run.type === 'shape') {
+        if (isPageLevelWrapFloat(run as unknown as ShapeRun)) { hasPageLevel = true; break; }
+      }
+    }
+    if (!hasPageLevel) continue;
+    // Register only the page-level floats from this paragraph. paraY=0 is safe
+    // because resolveAnchorY ignores it for page-level relativeFrom containers
+    // (anchor-geometry.ts §20.4.3.x). Allocate a fresh paraId so overlap
+    // avoidance treats these like any other anchor-paragraph float.
+    const paraId = state.floatParaSeq++;
+    for (const run of para.runs) {
+      if (run.type === 'image') {
+        const img = run as unknown as ImageRun;
+        if (!isPageLevelWrapFloat(img)) continue;
+        registerImageFloat(img, state, 0, paraId);
+      } else if (run.type === 'shape') {
+        const shp = run as unknown as ShapeRun;
+        if (!isPageLevelWrapFloat(shp)) continue;
+        registerShapeFloat(shp, state, 0, paraId);
+      }
+    }
+    state.pageAnchorPrescanned.add(para);
   }
 }
 


### PR DESCRIPTION
## Summary

A DrawingML `<wp:anchor>` whose `<wp:positionV>@relativeFrom` resolves Y independently of the source-order anchoring paragraph (ECMA-376 §20.4.3.5 `ST_RelFromV`: `page` / `margin` / `topMargin` / `bottomMargin` / `leftMargin` / `rightMargin` / `insideMargin` / `outsideMargin` / `column` — anything but `paragraph` / `line` / `character`) is laid out by Word **as soon as the page is opened**, so paragraphs that PRECEDE the anchoring paragraph in source order on the same page still wrap around the float (§20.4.2.16 / §20.4.2.17).

The renderer previously registered such floats only when the main flow reached the anchoring paragraph, so earlier paragraphs saw an empty float set and overlapped the float visually.

## Fix

Pre-scan upcoming body elements at every page-start and register page-level wrap floats up front. The originating paragraph is recorded in `state.pageAnchorPrescanned` so the per-paragraph `registerAnchorFloats` skips the duplicate (avoiding a double `FloatRect` / re-drawn bitmap) while still registering paragraph-local (`relativeFrom=paragraph/line/character`) floats the legacy way at their natural site.

The pre-scan runs from **both** code paths so the paginator's height estimate and the paint pass agree:

- **Renderer**: `renderBodyElements` runs the pre-scan once per page (each page gets a fresh `bodyState`).
- **Paginator** (`computePages`): runs the pre-scan at the initial setup, inside `newPage()` (which is now threaded with the body-start index), and at the inline `pageBreak` / non-continuous `sectionBreak` handlers.

`isPageLevelAnchorY` is the classifier; `preRegisterPageFloats` does the scan. Both are exported under `__test_` aliases so the unit tests can pin behaviour without going through a real WASM parser.

## Test plan

- [x] `pnpm vitest run packages/docx` — **all 239 tests in 28 files pass** (8 new tests in `page-anchor-prescan.test.ts`).
- [x] Root `pnpm test` — **all 882 tests in 99 files pass** (no regressions outside docx).
- [x] Root `pnpm typecheck` — green.
- [x] Red-baseline verified: temporarily replacing `prescanFloatsFrom` with a no-op flips the discriminating test (paragraph A is no longer split → `lineSlice` is `undefined`); restoring it returns to green.
- [ ] Local VRT (`pnpm vrt --filter docx`) — not run in this autonomous session; the existing anchor / float-layout / anchor-align unit tests all still pass.

## Spec references

- ECMA-376 §20.4.3.2 `<wp:positionH>` / §20.4.3.5 `<wp:positionV>` — `relativeFrom` semantics.
- ECMA-376 §20.4.2.16 / §20.4.2.17 — wrap modes (`square`, `topAndBottom`).
- ECMA-376 §20.4.2.3 — `allowOverlap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
