### PR TITLE
fix(docx): table/list layout fidelity — row-height, column widths, decimal tab, float wrap, list markers

### DIFF
--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -47,6 +47,11 @@ pub struct LevelDef {
     /// (default), "space", or "nothing". Controls where the body text starts
     /// relative to the marker on the first line.
     pub suff: String,
+    /// ECMA-376 §17.9.8 `<w:lvlJc>` — marker justification at its reference
+    /// position: "left" (default, marker LEFT edge at the hanging-indent
+    /// position), "right" (marker RIGHT edge there — period-aligned roman/decimal
+    /// numerals), or "center". `<w:start>` is unrelated.
+    pub lvl_jc: String,
     pub start: u32,
     /// ECMA-376 §17.9.6 `<w:lvl><w:rPr>` — the level's run (character) properties
     /// for the number/bullet glyph itself. Merged OVER the paragraph's resolved
@@ -94,6 +99,7 @@ impl Default for LevelDef {
             indent_right: None,
             tab: 36.0,
             suff: "tab".to_string(),
+            lvl_jc: "left".to_string(),
             start: 1,
             rpr: RunFmt::default(),
             pic_bullet: None,
@@ -220,6 +226,10 @@ impl NumberingMap {
                 let suff = child_w(lvl_node, "suff")
                     .and_then(|n| attr_w(n, "val"))
                     .unwrap_or_else(|| "tab".to_string());
+                // §17.9.8 `<w:lvlJc>` — marker justification; absent ⇒ "left".
+                let lvl_jc = child_w(lvl_node, "lvlJc")
+                    .and_then(|n| attr_w(n, "val"))
+                    .unwrap_or_else(|| "left".to_string());
                 // §17.9.6 — the level's run properties for the marker glyph.
                 // Parsed with the SAME `parse_run_fmt` body runs use; theme refs
                 // stay as "@theme:<ref>" markers and are resolved at use-site once
@@ -240,6 +250,7 @@ impl NumberingMap {
                     indent_right,
                     tab,
                     suff,
+                    lvl_jc,
                     start,
                     rpr,
                     pic_bullet,

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1396,32 +1396,35 @@ fn parse_paragraph_cond(
             // theme refs. A bare `<w:rFonts w:hint="eastAsia"/>` carries no
             // typeface, so the marker simply inherits the paragraph's ascii (e.g.
             // Times → the auto-number renders serif) and eastAsia (e.g. MS Gothic).
-            let (format, ind_left, tab, suff, marker_ascii, marker_ea, pic_bullet) = num_map
-                .get_level(num_id, num_level)
-                .map(|l| {
-                    let mut marker_fmt = base_run.clone();
-                    apply_direct_run(&mut marker_fmt, &l.rpr);
-                    (
-                        l.format.clone(),
-                        l.indent_left,
-                        l.tab,
-                        l.suff.clone(),
-                        theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
-                        theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
-                        l.pic_bullet.clone(),
-                    )
-                })
-                .unwrap_or_else(|| {
-                    (
-                        "decimal".to_string(),
-                        36.0,
-                        18.0,
-                        "tab".to_string(),
-                        theme.resolve_font_ref(base_run.font_family_ascii.clone()),
-                        theme.resolve_font_ref(base_run.font_family_east_asia.clone()),
-                        None,
-                    )
-                });
+            let (format, ind_left, tab, suff, lvl_jc, marker_ascii, marker_ea, pic_bullet) =
+                num_map
+                    .get_level(num_id, num_level)
+                    .map(|l| {
+                        let mut marker_fmt = base_run.clone();
+                        apply_direct_run(&mut marker_fmt, &l.rpr);
+                        (
+                            l.format.clone(),
+                            l.indent_left,
+                            l.tab,
+                            l.suff.clone(),
+                            l.lvl_jc.clone(),
+                            theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
+                            theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
+                            l.pic_bullet.clone(),
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        (
+                            "decimal".to_string(),
+                            36.0,
+                            18.0,
+                            "tab".to_string(),
+                            "left".to_string(),
+                            theme.resolve_font_ref(base_run.font_family_ascii.clone()),
+                            theme.resolve_font_ref(base_run.font_family_east_asia.clone()),
+                            None,
+                        )
+                    });
             let counter = num_map.advance(num_id, num_level);
             let text = num_map.resolve_text(num_id, num_level, counter);
             let (
@@ -1450,6 +1453,7 @@ fn parse_paragraph_cond(
                 indent_left: ind_left,
                 tab,
                 suff,
+                jc: lvl_jc,
                 font_family: marker_ascii,
                 font_family_east_asia: marker_ea,
                 pic_bullet_image_path,

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -494,6 +494,10 @@ pub struct NumberingInfo {
     /// ECMA-376 §17.9.28 `<w:suff>` — "tab" (default) | "space" | "nothing".
     /// Determines where body text starts after the marker on the first line.
     pub suff: String,
+    /// ECMA-376 §17.9.8 `<w:lvlJc>` — marker justification: "left" (default) |
+    /// "right" (period-aligned numerals — marker right edge at the hanging-indent
+    /// position) | "center". The renderer offsets the marker draw accordingly.
+    pub jc: String,
     /// ECMA-376 §17.3.2.26 ascii axis for the marker glyph, resolved through the
     /// level's `rPr` (§17.9.6) merged over the paragraph's run formatting. The
     /// renderer draws Latin marker chars (e.g. a decimal "1") with this family,

--- a/packages/docx/src/cell-indent-rowheight.test.ts
+++ b/packages/docx/src/cell-indent-rowheight.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRowHeight } from './renderer.js';
+import type { DocTable, DocTableRow, DocTableCell, DocParagraph } from './types.js';
+
+// The render/measure state type, taken from calculateRowHeight's signature so
+// the test does not depend on RenderState being exported (mirrors
+// table-row-height.test's EMPTY_STATE pattern).
+type MeasureState = Parameters<typeof calculateRowHeight>[4];
+
+// ECMA-376 §17.3.1.12 (`<w:ind>`) + §17.4.80 (auto row height): a table cell's
+// auto row height is the tallest cell's measured CONTENT height. The content is
+// laid out inside `cellWidth − cell margins − the paragraph's own left/right
+// indent`, with the FIRST line further inset by `<w:ind w:firstLine>`. The paint
+// path (`renderParagraph`) and the paginator (`estimateParagraphHeight`) both
+// apply those indents; the per-row measurer (`measureParaHeight`) must too, or a
+// cell whose paragraph carries a first-line indent that forces a wrap is sized
+// for FEWER lines than it paints and overflows into the next row.
+//
+// sample-11.docx exposes this: the "City or Town" header cell and the
+// "Cedar University" data cells carry `w:firstLine=432` (21.6 pt). At their
+// column width the text wraps to two lines when the indent is honored, but the
+// (pre-fix) measurer ignored the indent, sized the row for one line, and the
+// second line ("Town" / "University") bled into the row below.
+//
+// This is a DIFFERENTIAL test: two cells identical except for the first-line
+// indent. The recording ctx measures every glyph at `fontSize` px, so the
+// wrap is deterministic. The indented cell MUST be taller (it wraps to two
+// lines); the un-indented cell stays one line. Pre-fix both measured one line
+// (equal heights) — so this fails Red and passes Green.
+
+function makeMeasureState(): MeasureState {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {},
+    restore() {},
+    measureText2() {},
+  };
+  return {
+    ctx: ctx as unknown as CanvasRenderingContext2D,
+    scale: 1,
+    fontFamilyClasses: {},
+    docGrid: { type: null, linePitchPt: null, charSpacePt: null },
+    docEastAsian: false,
+  } as unknown as MeasureState;
+}
+
+function para(text: string, indentFirst: number): DocParagraph {
+  return {
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: [
+      {
+        type: 'text',
+        text,
+        bold: false,
+        italic: false,
+        underline: false,
+        strikethrough: false,
+        fontSize: 10,
+        color: null,
+        fontFamily: 'Times New Roman',
+        fontFamilyEastAsia: 'Times New Roman',
+        isLink: false,
+        background: null,
+        vertAlign: null,
+        hyperlink: null,
+      },
+    ],
+    defaultFontSize: 10,
+    defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function cellWith(p: DocParagraph): DocTableCell {
+  return {
+    content: [{ type: 'paragraph', ...p }],
+    colSpan: 1,
+    vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    background: null,
+    vAlign: 'top',
+    widthPt: 120,
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    marginRight: 0,
+  } as unknown as DocTableCell;
+}
+
+function rowWith(p: DocParagraph): DocTableRow {
+  return {
+    cells: [cellWith(p)],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+  } as unknown as DocTableRow;
+}
+
+function table(): DocTable {
+  return {
+    colWidths: [120],
+    rows: [],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+  } as unknown as DocTable;
+}
+
+describe('calculateRowHeight — paragraph indent affects wrap (§17.3.1.12 / §17.4.80)', () => {
+  const COLS = [120];
+  const SCALE = 1;
+  const t = table();
+  // "WORD ALPHA" = 10 glyphs × 10 px = 100 px. Fits the 120 px column on one
+  // line with no indent. With a 60 px first-line indent the first line only has
+  // 60 px, so it breaks after "WORD" (40 px) and "ALPHA" wraps to a second line.
+  const TEXT = 'WORD ALPHA';
+
+  it('un-indented cell stays one line', () => {
+    const h = calculateRowHeight(rowWith(para(TEXT, 0)), t, COLS, SCALE, makeMeasureState());
+    // One 10 px line box (+ its descent). Comfortably below two lines.
+    expect(h).toBeLessThan(16);
+  });
+
+  it('first-line-indent cell wraps to two lines and the row grows to fit', () => {
+    const h1 = calculateRowHeight(rowWith(para(TEXT, 0)), t, COLS, SCALE, makeMeasureState());
+    const h2 = calculateRowHeight(rowWith(para(TEXT, 60)), t, COLS, SCALE, makeMeasureState());
+    // The indented cell wraps to a second line, so its row must be ~2× taller.
+    expect(h2).toBeGreaterThan(h1 * 1.8);
+  });
+});

--- a/packages/docx/src/column-widths.test.ts
+++ b/packages/docx/src/column-widths.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { resolveColumnWidths } from './renderer.js';
+import type { DocTable, DocTableRow, DocTableCell } from './types.js';
+
+// State type taken from resolveColumnWidths' signature so the test does not
+// depend on RenderState being exported (mirrors table-row-height.test).
+type ColState = Parameters<typeof resolveColumnWidths>[2];
+
+// ECMA-376 §17.4.48 (`<w:tblGrid>`) / §17.4.16 (`<w:gridCol>`) define the
+// column widths; per-cell `<w:tcW>` (§17.4.71) is only a PREFERRED width. Word
+// bakes its resolved auto-fit widths back into the saved grid, so we size
+// columns from the grid (scaled to the table width) and do NOT re-apply tcW
+// (see resolveColumnWidths' comment for why this matches Word over the literal
+// §17.4.52 algorithm). sample-3's résumé regressed because its rows carry
+// single-column `tcW≈30%` each that, under the old tcW-over-grid path,
+// flattened an intentionally-unequal grid ([2137, 222, 2430, …] twips) toward
+// equal columns, shifting later columns right and changing the wrap.
+//
+// Empty cells carry no content, so the min-content floor is 0 and `state` is
+// never dereferenced (mirrors table-row-height.test's EMPTY_STATE).
+
+const EMPTY_STATE = {} as unknown as ColState;
+
+function cell(colSpan: number, widthPct: number | null): DocTableCell {
+  return {
+    content: [],
+    colSpan,
+    vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    background: null,
+    vAlign: 'top',
+    widthPt: null,
+    widthPct,
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    marginRight: 0,
+  } as unknown as DocTableCell;
+}
+
+function row(cells: DocTableCell[]): DocTableRow {
+  return { cells, rowHeight: null, rowHeightRule: 'auto', isHeader: false } as unknown as DocTableRow;
+}
+
+/** sample-3-shaped table: an unequal 2-column grid whose single-column cells
+ *  each prefer ~50% via `tcW=pct`. */
+function table(rows: DocTableRow[]): DocTable {
+  return {
+    colWidths: [70, 30], // grid: deliberately UNEQUAL
+    rows,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+    // layout omitted ⇒ autofit (the branch under test).
+  } as unknown as DocTable;
+}
+
+describe('resolveColumnWidths — grid (§17.4.48) governs autofit widths, not per-cell tcW (§17.4.71)', () => {
+  it('keeps the (unequal) tblGrid proportions even when cells prefer ~equal tcW=pct', () => {
+    // Two rows of single-column cells, each preferring 50% (2500/5000). The grid
+    // says 70/30. Word renders 70/30 (the grid); tcW must NOT equalize to 50/50.
+    const t = table([
+      row([cell(1, 2500), cell(1, 2500)]),
+      row([cell(1, 2500), cell(1, 2500)]),
+    ]);
+    const w = resolveColumnWidths(t, 100, EMPTY_STATE);
+    expect(w[0]).toBeCloseTo(70, 5);
+    expect(w[1]).toBeCloseTo(30, 5);
+  });
+
+  it('a gridSpan cell whose tcW exceeds its grid span does not widen the columns', () => {
+    // A 2-col-spanning cell prefers 100% (5000pct) — wider than the grid's full
+    // 100 pt. The grid still governs: columns stay 70/30, total stays 100.
+    const t = table([row([cell(2, 5000)])]);
+    const w = resolveColumnWidths(t, 100, EMPTY_STATE);
+    expect(w[0]).toBeCloseTo(70, 5);
+    expect(w[1]).toBeCloseTo(30, 5);
+  });
+
+  it('scales the grid proportionally when it overflows the available width', () => {
+    // Grid sums to 100 pt but only 50 pt is available ⇒ scale by 0.5, preserving
+    // the 70/30 proportion.
+    const t = table([row([cell(1, 2500), cell(1, 2500)])]);
+    const w = resolveColumnWidths(t, 50, EMPTY_STATE);
+    expect(w[0]).toBeCloseTo(35, 5);
+    expect(w[1]).toBeCloseTo(15, 5);
+  });
+});

--- a/packages/docx/src/decimal-tab-autoalign.test.ts
+++ b/packages/docx/src/decimal-tab-autoalign.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { DocParagraph, DocxDocumentModel, SectionProps } from './types.js';
+
+// Word runtime behavior (NOT in ECMA-376 §17.3.1.37 / §17.18.84): a paragraph
+// whose first tab stop is a `decimal` tab and whose content is a bare number
+// with NO explicit tab character still aligns that number to the decimal tab —
+// the built-in "Decimal Aligned" style on table number cells. sample-11's
+// College table: 110 / 24 / 998 right-align on the decimal tab even though none
+// carries a tab character. This test pins the auto-alignment: two numbers of
+// different digit counts must share the same right edge (the decimal tab), and a
+// number with NO decimal tab must stay left-aligned (the gate is specific).
+
+interface FillCall {
+  text: string;
+  x: number;
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {}, strokeRect() {},
+    rect() {}, clip() {}, scale() {}, translate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(text: string, x: number) { fills.push({ text, x }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+function numberPara(text: string, withDecimalTab: boolean): DocParagraph {
+  return {
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null,
+    tabStops: withDecimalTab ? [{ pos: 36, alignment: 'decimal', leader: 'none' }] : [],
+    runs: [{
+      type: 'text', text,
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(paras: DocParagraph[]): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 300, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: paras.map((p) => ({ type: 'paragraph', ...p })),
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('decimal-tab auto-alignment for tab-less numbers (Word behavior)', () => {
+  const TAB_POS = 36; // pt; scale = 1 px/pt (width 300, pageWidth 300)
+  const FS = 10; // each glyph is FS px wide in the recording canvas
+
+  it('right-aligns numbers of different digit counts at the decimal tab', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc([numberPara('110', true), numberPara('24', true)]), canvas, 0, { dpr: 1, width: 300 });
+
+    const f110 = fills.find((f) => f.text === '110');
+    const f24 = fills.find((f) => f.text === '24');
+    expect(f110, '"110" must be drawn').toBeDefined();
+    expect(f24, '"24" must be drawn').toBeDefined();
+    // Right edge = x + glyphCount * FS. Both must land on the decimal tab (36 pt).
+    expect(f110!.x + 3 * FS).toBeCloseTo(TAB_POS, 4);
+    expect(f24!.x + 2 * FS).toBeCloseTo(TAB_POS, 4);
+    // 2-digit "24" therefore starts to the RIGHT of 3-digit "110".
+    expect(f24!.x).toBeGreaterThan(f110!.x);
+  });
+
+  it('leaves a number with no decimal tab left-aligned (gate is specific)', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc([numberPara('110', false), numberPara('24', false)]), canvas, 0, { dpr: 1, width: 300 });
+    const f110 = fills.find((f) => f.text === '110');
+    const f24 = fills.find((f) => f.text === '24');
+    // No decimal tab ⇒ both left-align at the margin (x = 0), right edges differ.
+    expect(f110!.x).toBeCloseTo(0, 4);
+    expect(f24!.x).toBeCloseTo(0, 4);
+  });
+});

--- a/packages/docx/src/list-marker-jc.test.ts
+++ b/packages/docx/src/list-marker-jc.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { DocParagraph, DocxDocumentModel, SectionProps } from './types.js';
+
+// ECMA-376 §17.9.8 `<w:lvlJc>` — a list level's marker justification. "right"
+// (period-aligned roman/decimal numerals) right-aligns the marker so its RIGHT
+// edge sits at the hanging-indent reference (firstLineX = indentLeft + the
+// negative firstLine indent); different-width markers ("i." vs "iii.") then share
+// that right edge and their periods line up. We previously drew every marker
+// LEFT-aligned, so the periods staggered (sample-11's "i./ii./iii./iv." list).
+//
+// Recording canvas measures each glyph at fontSize px, so "i." = 20 px and
+// "iii." = 40 px — distinct widths that expose the alignment.
+
+interface FillCall { text: string; x: number }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, rect() {}, clip() {}, scale() {},
+    translate() {}, setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; }, drawImage() {},
+    fillText(text: string, x: number) { fills.push({ text, x }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+function romanItem(markerText: string, body: string, jc: string): DocParagraph {
+  return {
+    alignment: 'left', indentLeft: 57.6, indentRight: 0, indentFirst: -18,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, tabStops: [],
+    numbering: {
+      numId: 7, level: 0, format: 'lowerRoman', text: markerText, indentLeft: 57.6,
+      tab: 18, suff: 'tab', jc, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+    },
+    runs: [{
+      type: 'text', text: body, bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(paras: DocParagraph[]): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: paras.map((p) => ({ type: 'paragraph', ...p })),
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('list marker lvlJc (§17.9.8)', () => {
+  // firstLineX = indentLeft + firstLine = 57.6 + (−18) = 39.6 (margins 0).
+  const FIRST_LINE_X = 39.6;
+
+  it('right: different-width markers share a right edge (period-aligned)', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc([romanItem('i.', 'One', 'right'), romanItem('iii.', 'Three', 'right')]), canvas, 0, { dpr: 1, width: 400 });
+    const mi = fills.find((f) => f.text === 'i.');
+    const miii = fills.find((f) => f.text === 'iii.');
+    expect(mi, 'marker "i." drawn').toBeDefined();
+    expect(miii, 'marker "iii." drawn').toBeDefined();
+    // Right edge = x + glyphs × 10.
+    expect(mi!.x + 2 * 10).toBeCloseTo(FIRST_LINE_X, 3);
+    expect(miii!.x + 4 * 10).toBeCloseTo(FIRST_LINE_X, 3);
+    // Narrow "i." therefore starts to the RIGHT of wide "iii.".
+    expect(mi!.x).toBeGreaterThan(miii!.x);
+    // Body stays at indentLeft (the right-aligned marker fits the hanging indent).
+    const body = fills.find((f) => f.text === 'One');
+    expect(body!.x).toBeCloseTo(57.6, 3);
+  });
+
+  it('left (default): markers share a LEFT edge', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc([romanItem('i.', 'One', 'left'), romanItem('iii.', 'Three', 'left')]), canvas, 0, { dpr: 1, width: 400 });
+    const mi = fills.find((f) => f.text === 'i.');
+    const miii = fills.find((f) => f.text === 'iii.');
+    expect(mi!.x).toBeCloseTo(FIRST_LINE_X, 3);
+    expect(miii!.x).toBeCloseTo(FIRST_LINE_X, 3);
+  });
+});

--- a/packages/docx/src/numbered-marker-tab-advance.test.ts
+++ b/packages/docx/src/numbered-marker-tab-advance.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { DocParagraph, DocxDocumentModel, SectionProps } from './types.js';
+
+// ECMA-376 §17.9.6 (suff="tab") + §17.3.1.37 (a tab never moves backward): a
+// numbered paragraph's marker is followed by a tab that advances the body to the
+// numbering's indentLeft stop — UNLESS the marker overruns that stop (a wide
+// multi-level number like "1.1.1." whose glyphs exceed the hanging indent), in
+// which case the tab advances to the next stop PAST the marker and the body
+// follows. sample-11's "1.1.1. Three" collided because we pinned the body at
+// indentLeft; Word advances "Three" to the next default tab.
+//
+// Recording canvas measures every glyph at fontSize px, so a 4-glyph "1.1."
+// marker is 40 px — wider than the 18 px hanging indent here — forcing the
+// overrun path. Default tab grid = 36 pt.
+
+interface FillCall { text: string; x: number }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, rect() {}, clip() {}, scale() {},
+    translate() {}, setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; }, drawImage() {},
+    fillText(text: string, x: number) { fills.push({ text, x }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+/** A 3rd-level numbered paragraph: marker "1.1." (overruns), body "Body". */
+function numberedPara(markerText: string, indentLeftPt: number, hangingPt: number): DocParagraph {
+  return {
+    alignment: 'left', indentLeft: indentLeftPt, indentRight: 0, indentFirst: -hangingPt,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, tabStops: [],
+    numbering: {
+      numId: 1, level: 2, format: 'decimal', text: markerText, indentLeft: indentLeftPt,
+      tab: hangingPt, suff: 'tab', fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+    },
+    runs: [{
+      type: 'text', text: 'Body', bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(p: DocParagraph): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'paragraph', ...p }],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('numbered list — body clears an over-wide marker (§17.9.6 / §17.3.1.37)', () => {
+  it('advances the body past the marker to the next tab stop, not onto indentLeft', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    // indentLeft 72 pt, hanging 18 pt ⇒ marker budget 18 px; "1.1." is 40 px and
+    // overruns. Marker draws at paraX+indFirst = 72−18 = 54, ends at 94. The body
+    // must advance to the next 36-pt tab past 94 ⇒ 108, NOT stay at 72.
+    await renderDocumentToCanvas(doc(numberedPara('1.1.', 72, 18)), canvas, 0, { dpr: 1, width: 400 });
+    const marker = fills.find((f) => f.text === '1.1.');
+    const body = fills.find((f) => f.text === 'Body');
+    expect(marker, 'marker drawn').toBeDefined();
+    expect(body, 'body drawn').toBeDefined();
+    const markerEnd = marker!.x + 4 * 10; // 4 glyphs × 10 px
+    expect(marker!.x).toBeCloseTo(54, 3);
+    expect(markerEnd).toBeCloseTo(94, 3);
+    // Body advanced to the next default tab (108), clearing the marker.
+    expect(body!.x).toBeCloseTo(108, 3);
+    expect(body!.x, 'body must not overlap the marker').toBeGreaterThanOrEqual(markerEnd);
+  });
+
+  it('leaves the body at indentLeft when the marker fits the hanging indent', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    // "1." is 20 px; hanging 36 px ⇒ fits. Body stays at indentLeft (72), the
+    // normal suff=tab behavior (no overrun advance).
+    await renderDocumentToCanvas(doc(numberedPara('1.', 72, 36)), canvas, 0, { dpr: 1, width: 400 });
+    const body = fills.find((f) => f.text === 'Body');
+    expect(body!.x).toBeCloseTo(72, 3);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2883,6 +2883,12 @@ function renderFrameParagraph(
   registerFrameFloat(box, fp, state);
 }
 
+/** Default tab interval (pt) when no explicit stop matches — Word's default is
+ *  720 twips = 36 pt (ECMA-376 §17.15.1.25 `defaultTabStop`; this document sets
+ *  no override). Shared by the line layout (`layoutLines`) and the numbered-list
+ *  marker's trailing-tab advance (`renderParagraph`). */
+const DEFAULT_TAB_PT = 36;
+
 function renderParagraph(
   para: DocParagraph,
   state: RenderState,
@@ -2962,21 +2968,46 @@ function renderParagraph(
         picBullet = { bmp, w: size.w * scale, h: size.h * scale };
       }
     }
+    // Marker glyph width (px) with its RESOLVED font (§17.3.2.26 + §17.9.6); the
+    // picture bullet's own width when present. Needed for both the suff≠tab abut
+    // and the suff=tab overrun check below, so measure once up front.
+    let markerW: number;
+    if (picBullet) {
+      markerW = picBullet.w;
+    } else {
+      ctx.font = buildFont(false, false, getDefaultFontSize(para) * scale, markerFontFamily(para.numbering), fontFamilyClasses);
+      markerW = ctx.measureText(markerDisplayText(para.numbering)).width;
+    }
     if (suff !== 'tab') {
-      // Body-offset width: the picture bullet's own width if present, else the
-      // measured glyph width (§17.3.2.26 + §17.9.6) with the marker's RESOLVED
-      // font — the width must match the draw below so the body offset is exact
-      // for a serif (Times) vs sans (Gothic) marker alike.
-      let markerW: number;
-      if (picBullet) {
-        markerW = picBullet.w;
-      } else {
-        ctx.font = buildFont(false, false, getDefaultFontSize(para) * scale, markerFontFamily(para.numbering), fontFamilyClasses);
-        markerW = ctx.measureText(markerDisplayText(para.numbering)).width;
-      }
       const spaceW = suff === 'space' ? ctx.measureText(' ').width : 0;
       // marker sits at firstLineX (= paraX + indFirst); body starts at its end.
       numBodyOffset = indFirst + markerW + spaceW;
+    } else {
+      // suff=tab: the marker is followed by a tab that advances the body to the
+      // numbering's indentLeft tab stop (numBodyOffset 0 — the body sits at
+      // paraX). But ECMA-376 §17.9.6 + §17.3.1.37: a tab never moves BACKWARD, so
+      // when the marker overruns that stop — a wide multi-level number like
+      // "1.1.1." whose glyphs exceed the hanging indent (the marker `indFirst`
+      // budget), e.g. in a substitute font — the tab advances to the next stop
+      // PAST the marker end instead, and the body follows it. Without this the
+      // body stays at indentLeft and the marker overprints it (sample-11's
+      // "1.1.1. Three" collided; Word advances "Three" to the next default tab).
+      // markerEndFromIndent is the marker's right edge measured from paraX (the
+      // indentLeft tab); ≤ 0 ⇒ it fits, leave the body at indentLeft.
+      const markerEndFromIndent = indFirst + markerW;
+      if (markerEndFromIndent > 0) {
+        // Next tab stop strictly past the marker end, in paraX-relative px:
+        // honor the paragraph's explicit stops (measured from the text margin,
+        // hence − indLeft to make them paraX-relative), else the default grid.
+        const defTabPx = DEFAULT_TAB_PT * scale;
+        const markerEndFromMargin = indLeft + markerEndFromIndent;
+        let nextFromMargin = Math.ceil((markerEndFromMargin + 0.01) / defTabPx) * defTabPx;
+        for (const ts of para.tabStops ?? []) {
+          const p = ts.pos * scale;
+          if (p > markerEndFromMargin && p < nextFromMargin) nextFromMargin = p;
+        }
+        numBodyOffset = nextFromMargin - indLeft;
+      }
     }
   }
   // True when the paragraph has any marker to draw (text glyph OR picture bullet).
@@ -4309,9 +4340,6 @@ function layoutLines(
   };
 
   const availW = () => lineMaxWidth - (isFirst ? firstIndent : 0);
-
-  // Default tab interval when no matching explicit stop exists (Word's default is 720 twips = 36pt)
-  const DEFAULT_TAB_PT = 36;
 
   let lineHasRuby = false;
   const flush = (forceHeight?: number) => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2953,6 +2953,11 @@ function renderParagraph(
   //   tab (default) → body advances to the indentLeft tab stop (offset 0),
   //   space/nothing → body abuts the marker (marker end, + one space for space).
   let numBodyOffset = 0;
+  // §17.9.8 `<w:lvlJc>` — horizontal shift (px) applied to the LTR marker draw so
+  // it left/right/centre-aligns at the hanging-indent reference (firstLineX).
+  // 0 = left (default); −markerW = right (period-aligned numerals: right edge at
+  // firstLineX); −markerW/2 = centre. Set in the numbering block below.
+  let markerJcShiftPx = 0;
   if (para.numbering) {
     numMarker = para.numbering.text;
     numTab = para.numbering.tab * scale;
@@ -2978,10 +2983,16 @@ function renderParagraph(
       ctx.font = buildFont(false, false, getDefaultFontSize(para) * scale, markerFontFamily(para.numbering), fontFamilyClasses);
       markerW = ctx.measureText(markerDisplayText(para.numbering)).width;
     }
+    // §17.9.8 lvlJc: shift the marker so its left/right/centre aligns at
+    // firstLineX (the hanging-indent reference). The marker's RIGHT edge measured
+    // from paraX (the indentLeft tab) is then `indFirst + shift + markerW`.
+    const lvlJc = para.numbering.jc || 'left';
+    markerJcShiftPx = lvlJc === 'right' ? -markerW : lvlJc === 'center' ? -markerW / 2 : 0;
+    const markerEndFromIndent = indFirst + markerJcShiftPx + markerW;
     if (suff !== 'tab') {
       const spaceW = suff === 'space' ? ctx.measureText(' ').width : 0;
-      // marker sits at firstLineX (= paraX + indFirst); body starts at its end.
-      numBodyOffset = indFirst + markerW + spaceW;
+      // body abuts the marker's right edge (+ one space for suff="space").
+      numBodyOffset = markerEndFromIndent + spaceW;
     } else {
       // suff=tab: the marker is followed by a tab that advances the body to the
       // numbering's indentLeft tab stop (numBodyOffset 0 — the body sits at
@@ -2992,9 +3003,8 @@ function renderParagraph(
       // PAST the marker end instead, and the body follows it. Without this the
       // body stays at indentLeft and the marker overprints it (sample-11's
       // "1.1.1. Three" collided; Word advances "Three" to the next default tab).
-      // markerEndFromIndent is the marker's right edge measured from paraX (the
-      // indentLeft tab); ≤ 0 ⇒ it fits, leave the body at indentLeft.
-      const markerEndFromIndent = indFirst + markerW;
+      // markerEndFromIndent (jc-adjusted right edge from paraX) ≤ 0 ⇒ it fits
+      // (right-aligned markers always do), leave the body at indentLeft.
       if (markerEndFromIndent > 0) {
         // Next tab stop strictly past the marker end, in paraX-relative px:
         // honor the paragraph's explicit stops (measured from the text margin,
@@ -3291,7 +3301,9 @@ function renderParagraph(
         // rests on the line like a glyph.
         const { bmp, w, h } = picBullet;
         const top = baseline - h;
-        const left = baseRtl ? x + lineWidth + numTab - w : lineLeft + indFirst;
+        // LTR: left edge at firstLineX, shifted by lvlJc (§17.9.8); RTL keeps its
+        // own mirrored anchor.
+        const left = baseRtl ? x + lineWidth + numTab - w : lineLeft + indFirst + markerJcShiftPx;
         ctx.drawImage(bmp, left, top, w, h);
       } else {
         const numFontSize = getDefaultFontSize(para) * scale;
@@ -3319,9 +3331,11 @@ function renderParagraph(
         } else {
           // Marker sits in the hanging margin at lineLeft + indFirst (= firstLineX
           // when the line isn't shifted by a float; lineLeft already includes any
-          // float xOffset, so the marker tracks the body that hangs off it). The
-          // body was advanced past the marker above (numBodyOffset).
-          ctx.fillText(markerDisplayText(para.numbering!), lineLeft + indFirst, baseline);
+          // float xOffset, so the marker tracks the body that hangs off it),
+          // shifted by lvlJc (§17.9.8) so a "right" level period-aligns its right
+          // edge at firstLineX. The body was advanced past the marker above
+          // (numBodyOffset).
+          ctx.fillText(markerDisplayText(para.numbering!), lineLeft + indFirst + markerJcShiftPx, baseline);
         }
       }
     }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3053,6 +3053,32 @@ function renderParagraph(
   const firstLineIndent = hasMarker && !baseRtl ? numBodyOffset : firstLineX - paraX;
   const lines = layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, gridCharDeltaPx(grid, scale));
 
+  // Decimal-tab auto-alignment. ECMA-376 (§17.3.1.37 tabs / §17.18.84 ST_TabJc
+  // `decimal`) only positions content at a tab stop when an explicit tab
+  // character advances to it; absent a tab, content starts at the indent. Word,
+  // however, aligns a bare number to a leading DECIMAL tab with NO tab character
+  // — the built-in "Decimal Aligned" paragraph style on table number cells does
+  // exactly this. sample-11's College table proves it: 110 / 103 / +7 etc. each
+  // right-align on the decimal tab at 18 pt (Word PDF bbox: per-column right
+  // edges coincide), where we previously left-aligned them. This is a deliberate
+  // Word-runtime deviation (user-approved); it is gated to NUMERIC content whose
+  // first tab stop is `decimal` and which carries no explicit tab, so ordinary
+  // paragraphs are untouched. We right-edge align the number at the stop — the
+  // same approximation the explicit-tab decimal path uses (frac=1; it does not
+  // split on the '.'), exact for the integers in scope. Applied at DRAW time as
+  // a pure horizontal offset, so the measured row height (and the paginate/paint
+  // height contract) is unaffected.
+  const decimalAutoTabPx: number | null = (() => {
+    if (segments.some((s) => 'isTab' in s)) return null; // explicit tab wins
+    const stops = para.tabStops ?? [];
+    if (stops.length === 0) return null;
+    const firstStop = stops.reduce((a, b) => (b.pos < a.pos ? b : a));
+    if (firstStop.alignment !== 'decimal') return null;
+    const txt = para.runs.map((r) => (r as { text?: string }).text ?? '').join('').trim();
+    if (txt === '' || !/^[+\-(]?[\d., ]+\)?%?$/.test(txt)) return null; // numbers only
+    return firstStop.pos * scale - indLeft; // px, relative to paraX (mirrors layoutLines' stopXof)
+  })();
+
   // A paragraph whose only segments are wrap-float anchors (wp:anchor) places no
   // inline content on any line, so layoutLines returns zero lines. Per ECMA-376
   // §17.3.1.29 the paragraph mark still produces one line box; §20.4.2.x removes
@@ -3212,6 +3238,15 @@ function renderParagraph(
       alignOffset = lineSlack;
     }
     // 'left' and stretched 'justify' keep alignOffset 0.
+    // Decimal-tab auto-alignment (see decimalAutoTabPx above): override the
+    // paragraph alignment so the number's right edge (its decimal point, for an
+    // integer) lands on the decimal tab. `paraX + decimalAutoTabPx` is the stop
+    // in device space; subtracting the line width and the current `x` yields the
+    // left-shift, clamped ≥ 0 so a number wider than the stop simply overflows
+    // right (never pulled left of its natural start).
+    if (decimalAutoTabPx != null && lineWidth > 0) {
+      alignOffset = Math.max(0, paraX + decimalAutoTabPx - lineWidth - x);
+    }
     x += alignOffset;
 
     if (firstLine && hasMarker && !dryRun) {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2020,8 +2020,12 @@ function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt:
     // suppressSpaceBefore flag is for page-break continuations, not intra-cell
     // collapse), so sumCellContentHeight folds in contextualSuppressed
     // (§17.3.1.33) and the prevSpaceAfter/spaceBefore overlap to match the
-    // paint pass's renderCellContent.
-    return cm.top + cm.bottom + sumCellContentHeight(cell.content, (ce) => {
+    // paint pass's renderCellContent. Drop the §17.4.7 trailing structural
+    // empty paragraph after a nested table for the SAME reason the paint-side
+    // measurer (measureCellContentHeightPx) does — otherwise the paginator
+    // would reserve more height than the paint pass uses and break the page
+    // early (the two are contracted to agree, per this function's docstring).
+    return cm.top + cm.bottom + sumCellContentHeight(trimTrailingStructuralMarker(cell.content), (ce) => {
       if (ce.type === 'paragraph') {
         return estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
       }
@@ -2041,16 +2045,15 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
  *   - layout === 'fixed': use the tblGrid widths verbatim (the historical
  *     behavior), then scale down proportionally if the grid total overflows the
  *     available content width.
- *   - layout absent or 'autofit' (the spec default): each grid column's width is
- *     the maximum *preferred* width (cell `widthPt`, i.e. `<w:tcW type="dxa">`,
- *     or `widthPct` resolved against `contentWPt`) over the cells anchored in
- *     it. A gridSpan cell contributes its preference distributed across the
- *     columns it spans, in proportion to those columns' tblGrid widths, but
- *     only raises a column above what single-column cells already require.
- *     Columns with no preference anywhere keep their tblGrid width. If the
- *     resulting table width exceeds `contentWPt`, all columns are scaled
- *     proportionally to fit — this is what Word does when the preferred-width
- *     sum overflows the text column.
+ *   - layout absent or 'autofit' (the spec default): the tblGrid widths
+ *     (§17.4.48) ARE the column widths, scaled to fit `contentWPt`, with each
+ *     column's content min-width (§17.4.52 auto-fit grows a column too narrow
+ *     for its longest token) the only thing that can raise it. Per-cell `tcW`
+ *     (§17.4.71) is NOT applied here: Word bakes the resolved auto-fit widths
+ *     back into the saved `<w:gridCol>`, so for a round-tripped file the grid is
+ *     already the tcW-resolved layout (see the in-body comment for the full
+ *     rationale + the sample-3 evidence + the tblW=pct limitation). Only a
+ *     degenerate all-zero grid falls back to a tcW-preference distribution.
  *
  * The returned widths sum to at most `contentWPt`. Both `renderTable` (which
  * then multiplies by the device scale) and `computeTableRowHeights` (which
@@ -2110,7 +2113,10 @@ function cellMinContentPt(cell: DocTableCell, table: DocTable, state: RenderStat
   return maxTokenPt + cm.left + cm.right;
 }
 
-function resolveColumnWidths(table: DocTable, contentWPt: number, state: RenderState): number[] {
+/** Resolve a table's per-grid-column widths (pt) to fit `contentWPt`. Exported
+ *  for unit tests (column-widths.test) — see {@link calculateRowHeight} for the
+ *  same test-export pattern. */
+export function resolveColumnWidths(table: DocTable, contentWPt: number, state: RenderState): number[] {
   const n = table.colWidths.length;
   if (n === 0) return [];
 
@@ -2205,10 +2211,43 @@ function resolveColumnWidths(table: DocTable, contentWPt: number, state: RenderS
     return g;
   }
 
-  // Autofit (default): preferred widths drive the column sizes.
+  // Autofit (default). Use the `<w:tblGrid>` (§17.4.48 / gridCol §17.4.16) as
+  // the column widths, scaled to fit, with content min-widths the only grower.
+  //
+  // DELIBERATE DEVIATION from the literal autofit algorithm, to match Word's
+  // actual output: §17.4.16 (gridCol Note) and §17.4.52 (tblLayout) make a
+  // cell's preferred `<w:tcW>` (§17.4.71) an INPUT that can OVERRIDE the grid's
+  // initial widths. But Word does not ship the pre-autofit state — it BAKES the
+  // resolved autofit widths back into the saved `<w:gridCol>` values. So for a
+  // round-tripped Word file (every real-world docx) the grid already IS the
+  // tcW-resolved layout; re-applying `tcW` on top double-counts and diverges
+  // from the ground-truth PDF. sample-3's résumé grid is [2137, 222, 2430, 279,
+  // 2427, 279] twips (a deliberately narrow first content column), yet each
+  // row's single-column cells carry `tcW≈30%`; the old "tcW overrides grid"
+  // path equalized the columns to ~116 pt apiece, shifting every later column
+  // right (the 2nd heading moved ~11 pt past Word's x) and re-wrapping the
+  // description paragraphs past their divider rule. Trusting the grid reproduces
+  // Word exactly.
+  //
+  // LIMITATION: a `tblW=pct` (§17.4.63) table whose SAVED grid no longer matches
+  // the available width (e.g. authored under different margins, or by a tool
+  // that did not bake the grid) is NOT re-scaled up to the pct target here — the
+  // grid is taken as-is (only scaled DOWN by `fitToContent` on overflow). In
+  // practice the renderer lays a table out at the same content width Word saved
+  // it under, so the grid sums to that width; the gap only appears for stale /
+  // non-Word grids. Tracked for a future full tblW pass.
+  const gridSum = grid.reduce((s, w) => s + w, 0);
+  if (gridSum > 0) {
+    const desired = grid.map((g, c) => Math.max(g, minW[c]));
+    return fitToContent(desired);
+  }
+
+  // Degenerate grid (no `<w:gridCol>` widths, e.g. a hand-built model or a
+  // malformed table): fall back to preferred-width autofit, where `tcW` and
+  // content drive the column sizes since there is no grid to anchor them.
   // `pref[c]` accumulates the strongest single-column preference seen so far.
   const pref: number[] = new Array(n).fill(0);
-  // `gridFallback[c]` is true while no cell has expressed a preference for c.
+  // `hasPref[c]` is true once any cell has expressed a preference for c.
   const hasPref: boolean[] = new Array(n).fill(false);
 
   // Translate a cell's `<w:tcW>` into a preferred width in pt, or null when the
@@ -5670,12 +5709,22 @@ function measureCellContentHeightPx(
 ): number {
   const cm = effCellMargins(cell, table);
   const contentW = cellW - (cm.left + cm.right) * scale;
+  // ECMA-376 §17.4.7 requires every <w:tc> to end with a <w:p>. When the cell's
+  // visible content is a nested table, Word emits a trailing empty <w:p/> purely
+  // as that syntactic anchor; it carries no ink and does NOT grow the row (Word's
+  // outer cell hugs the inner table — sample-11's "table inside a table" outer
+  // row measures the inner table height, not inner + the structural mark's line
+  // box + its inherited space-before). Drop it from the row-height measurement,
+  // exactly as the vAlign block height already does (trimTrailingStructuralMarker).
+  // The mark itself is still painted by renderCellContent; being empty it adds no
+  // visible content, so excluding it from sizing cannot hide anything.
+  const measured = trimTrailingStructuralMarker(cell.content);
   // measureCellElementHeight always includes paragraph spaceBefore+spaceAfter;
   // sumCellContentHeight folds in contextualSuppressed (§17.3.1.33) and the
   // prevSpaceAfter/spaceBefore overlap collapse to match the paint pass's
   // renderCellContent. Spacing is converted from pt to px with `scale`.
   return (cm.top + cm.bottom) * scale + sumCellContentHeight(
-    cell.content,
+    measured,
     (ce) => measureCellElementHeight(state, ce, contentW, scale),
     scale,
   );
@@ -5895,7 +5944,30 @@ function measureParaHeight(
     const { asc, desc } = emptyLineNaturalPx(fs, scale);
     return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSinglePx(para, scale), paragraphIsEastAsian(para));
   }
-  const lines = layoutLines(state.ctx, segs, maxWidth, 0, scale, para.tabStops, undefined, state.fontFamilyClasses, 0, state.kinsoku, gridCharDeltaPx(grid, scale));
+  // ECMA-376 §17.3.1.12 (`<w:ind>`): the paragraph's own left/right indent
+  // narrows the wrap width and `firstLine` insets the first line — exactly as
+  // the paint pass (renderParagraph) and the paginator (estimateParagraphHeight)
+  // lay it out. The row-height measurer MUST honor them too: without the indent,
+  // a cell paragraph that carries a first-line/left indent (e.g. sample-11's
+  // table cells, firstLine=21.6 pt) is measured for fewer wrapped lines than it
+  // paints, so the row is sized too short and the overflow ("Town" /
+  // "University") bleeds into the next row. `maxWidth` is the cell's inner width
+  // (cell margins already removed by the caller); the paragraph indents come off
+  // it here. `tabOriginPx = indentLeft` mirrors layoutLines' tab origin in the
+  // paint/paginate paths.
+  //
+  // NOTE: like `estimateParagraphHeight` (the paginator), this passes the raw
+  // `indentFirst` and does NOT model a numbering marker's `numBodyOffset` (the
+  // hanging-indent first-line geometry `renderParagraph` applies for a numbered
+  // paragraph). The two non-paint measurers therefore stay consistent with each
+  // other, but a NUMBERED paragraph inside a cell that wraps can still measure
+  // slightly differently from the paint pass. No such cell exists in the covered
+  // samples; revisit together with estimateParagraphHeight if list-in-cell
+  // fidelity is needed.
+  const indLeftPx = para.indentLeft * scale;
+  const indRightPx = para.indentRight * scale;
+  const paraW = Math.max(1, maxWidth - indLeftPx - indRightPx);
+  const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst * scale, scale, para.tabStops, undefined, state.fontFamilyClasses, indLeftPx, state.kinsoku, gridCharDeltaPx(grid, scale));
   return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle, paragraphIsEastAsian(para)), 0);
 }
 

--- a/packages/docx/src/table-geometry.ts
+++ b/packages/docx/src/table-geometry.ts
@@ -74,13 +74,16 @@ export type MeasureCellContentHeight = (cell: DocTableCell, cellWidth: number) =
  *                 honored as a LOWER BOUND (atLeast-equivalent) when `hRule` is
  *                 omitted and `@val` is present: e.g. sample-11.docx's December
  *                 2007 calendar emits `<w:trHeight w:val="576"/>` (hRule
- *                 omitted; spec default = auto) and Word lays each row out at
- *                 ~43.2 pt = 576 / 20, matching `@val` as a floor (pdftotext
- *                 -bbox measures 343.536−300.336 = 43.2 pt). XML inspection
- *                 confirms no other height information exists, so `@val` is the
- *                 only signal that produces Word's geometry. We deliberately
- *                 deviate from the §17.4.80 literal to follow Word's behavior.
- *                 With `@val` absent, auto falls back to `MIN_ROW_HEIGHT_PT`.
+ *                 omitted; spec default = auto) on its date rows, and Word lays
+ *                 each such row out at exactly 576 / 20 = 28.8 pt — `@val` as a
+ *                 floor (pdftotext -bbox confirms the date glyph rows sit on a
+ *                 28.8 pt pitch; the larger ~43.2 pt visual cadence per WEEK is
+ *                 that 28.8 pt date row PLUS an unmarked auto spacer row below
+ *                 it, not a single `@val` row). XML inspection confirms no other
+ *                 height information exists, so `@val` is the only signal that
+ *                 produces Word's geometry. We deliberately deviate from the
+ *                 §17.4.80 literal to follow Word's behavior. With `@val`
+ *                 absent, auto falls back to `MIN_ROW_HEIGHT_PT`.
  *   - gridSpan: a cell's width is the sum of the `cell.colSpan` columns it
  *     anchors (clamped to the remaining columns).
  *   - ECMA-376 §17.4.85 (vMerge): a `vMerge=restart` cell's content occupies the
@@ -118,9 +121,9 @@ export function resolveSingleRowHeight(
   // §17.4.80 literal says `auto` ignores `@val`. Word's output PDFs disagree:
   // when `hRule` is omitted and `@val` is present, Word treats `@val` as a
   // lower bound (atLeast-equivalent). Deliberate deviation to match Word —
-  // ground truth is the Word output PDF (sample-11.docx calendar measured at
-  // 43.2 pt = `@val` 576 / 20). With `@val` absent, auto still collapses to
-  // the implementation-defined minimum.
+  // ground truth is the Word output PDF (sample-11.docx calendar date rows
+  // measured at exactly `@val` 576 / 20 = 28.8 pt). With `@val` absent, auto
+  // still collapses to the implementation-defined minimum.
   let rowH =
     row.rowHeight != null && (row.rowHeightRule === 'atLeast' || row.rowHeightRule === 'auto')
       ? row.rowHeight * scale

--- a/packages/docx/src/table-row-height.test.ts
+++ b/packages/docx/src/table-row-height.test.ts
@@ -11,12 +11,14 @@ import type { DocTable, DocTableRow, DocTableCell } from './types.js';
 //             output PDFs, however, treat @val as a LOWER BOUND (same as
 //             atLeast) when hRule is omitted and @val is present — e.g.
 //             sample-11.docx's December 2007 calendar emits trHeight w:val=576
-//             (no hRule, spec default = auto) and Word renders each row at
-//             ~43.2 pt = 576 / 20, matching @val as a floor (pdftotext -bbox
-//             measurement). XML inspection confirms no other height signal
-//             exists. We deliberately deviate from the §17.4.80 literal to
-//             match Word's behavior; @val absent still falls back to the
-//             implementation-defined minimum.
+//             (no hRule, spec default = auto) on its date rows and Word renders
+//             each such row at exactly 576 / 20 = 28.8 pt, matching @val as a
+//             floor (pdftotext -bbox; the larger per-week cadence is that
+//             28.8 pt date row plus an unmarked auto spacer row, not one @val
+//             row). XML inspection confirms no other height signal exists. We
+//             deliberately deviate from the §17.4.80 literal to match Word's
+//             behavior; @val absent still falls back to the implementation-
+//             defined minimum.
 //
 // These tests pin the floor logic with empty cells: with no content, the cell's
 // content height is just its (here zero) margins, so the row height is governed
@@ -79,8 +81,8 @@ describe('calculateRowHeight — ST_HeightRule (§17.4.80 / §17.18.37)', () => 
   // Word-compatible deviation from the §17.4.80 literal: with hRule omitted
   // (spec default = auto) and @val present, Word honors @val as a lower bound.
   // Ground truth is the Word output PDF — sample-11.docx's December calendar
-  // measures 43.2 pt per row = trHeight @val 576 / 20. See the resolveSingleRowHeight
-  // docstring (table-geometry.ts) for the full rationale.
+  // date rows measure exactly trHeight @val 576 / 20 = 28.8 pt. See the
+  // resolveSingleRowHeight docstring (table-geometry.ts) for the full rationale.
   it('auto with @val — @val is honored as a lower bound (Word-compatible)', () => {
     const h = calculateRowHeight(rowWith(600, 'auto'), t, COLS, SCALE, EMPTY_STATE);
     expect(h).toBe(600 * SCALE);

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -381,6 +381,12 @@ export interface NumberingInfo {
   /** ECMA-376 §17.9.28 `<w:suff>` — "tab" (default) | "space" | "nothing".
    *  Where body text starts after the marker on the first line. */
   suff: string;
+  /** ECMA-376 §17.9.8 `<w:lvlJc>` — marker justification: "left" (default) |
+   *  "right" (period-aligned numerals: marker RIGHT edge at the hanging-indent
+   *  position) | "center". The renderer offsets the marker draw accordingly.
+   *  Always emitted by the parser; optional here so hand-built fixtures may omit
+   *  it (the renderer treats absent as "left"). */
+  jc?: string;
   /** ECMA-376 §17.3.2.26 ascii axis for the marker glyph, resolved through the
    *  level's `rPr` (§17.9.6) merged over the paragraph's run formatting. The
    *  renderer draws Latin marker chars (e.g. a decimal "1") with this family, so

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -832,9 +832,12 @@ export interface DocTable {
   /** table horizontal alignment on the page: 'left' | 'center' | 'right'. */
   jc: string;
   /** ECMA-376 §17.4.52 `<w:tblLayout w:type>` — 'fixed' | 'autofit'. Absent
-   *  (undefined) ⇒ spec default 'autofit': columns are sized by the per-column
-   *  max preferred width (cell `widthPt`), tblGrid only as fallback. 'fixed'
-   *  uses tblGrid widths verbatim (scaled to fit). */
+   *  (undefined) ⇒ spec default 'autofit'. Both paths size columns from the
+   *  tblGrid (§17.4.48) scaled to fit: 'fixed' uses the grid verbatim; 'autofit'
+   *  additionally lets content min-width grow a column. Per-cell `widthPt`/
+   *  `widthPct` (`<w:tcW>`) is NOT re-applied — Word bakes the resolved widths
+   *  into the saved grid (see resolveColumnWidths). Only a degenerate all-zero
+   *  grid falls back to tcW-preference sizing. */
   layout?: string;
   /** ECMA-376 §17.4.63 `<w:tblW>` preferred table width (type="dxa"), pt. */
   widthPt?: number;
@@ -892,12 +895,15 @@ export interface DocTableCell {
   borders: CellBorders;
   background: string | null;
   vAlign: 'top' | 'center' | 'bottom';
-  /** ECMA-376 §17.4.71 `<w:tcW>` preferred cell width (type="dxa"), pt. Drives
-   *  autofit column sizing: each grid column's width is the max `widthPt` over
-   *  the cells anchored in it. */
+  /** ECMA-376 §17.4.71 `<w:tcW>` preferred cell width (type="dxa"), pt. A
+   *  PREFERRED width only: autofit column sizing is driven by the tblGrid
+   *  (§17.4.48), not by re-applying this (Word bakes the resolved widths into
+   *  the saved grid — see resolveColumnWidths). Consulted only for the
+   *  degenerate all-zero-grid fallback. */
   widthPt: number | null;
   /** `<w:tcW>` type="pct": 50ths of a percent of available content width.
-   *  Resolved against the available width at render time. */
+   *  Resolved against the available width at render time. Preferred width only
+   *  (see `widthPt`). */
   widthPct?: number;
   /** Per-cell margins (pt) from `<w:tcPr><w:tcMar>` (ECMA-376 §17.4.42). Each
    *  edge overrides the table-level `cellMargin*` default when set; null/absent


### PR DESCRIPTION
Recovers Word fidelity on sample-11 / sample-3 table, float, and list layout. Found against the Word ground-truth PDFs, verified by 2px/pt headless render (skia) vs `pdftoppm -r 144` and `pdftotext -bbox`. The recent table-height work (#551/#552/#553) did **not** address these — those were spec-grounded but tangential; the real causes were measurement / width / tab / float-ordering / list-marker omissions.

## Reported issues → status
| Issue | Root cause | Status |
|---|---|---|
| sample-11 "City or Town" 2nd line clipped | `measureParaHeight` ignored `indentFirst` → row sized for 1 line, paint wrapped to 2 | **fixed** |
| sample-11 College rows overlapping | same indent omission ("Cedar University" wraps) | **fixed** |
| sample-11 nested table outer too tall | §17.4.7 trailing structural empty paragraph counted in row height | **fixed** (75.6→54.0pt) |
| sample-11 College numbers left-aligned | `DecimalAligned` decimal tab not applied without a tab char | **fixed** |
| sample-11 Images: text wraps left arrow only | page-pinned right arrow anchored to a LATER paragraph; document-order float registration | **fixed** (wraps both arrows) |
| sample-11 "1.1.1. Three" marker/body overlap | suff=tab body pinned at indentLeft; wide marker overran it (§17.9.6/§17.3.1.37) | **fixed** (body→108pt) |
| sample-11 "i./ii./iii./iv." period-alignment | `<w:lvlJc w:val="right">` (§17.9.8) not honored — marker drawn left-aligned | **fixed** (periods align at 39.6pt) |
| sample-3 "主要な職務内容…" shift + overflow | `resolveColumnWidths` let per-cell `tcW=pct` override the tblGrid | **fixed** |
| calendar / arrows position / sample-6 empty page / Undergraduate italic / "An interruption" indent | already resolved by prior commits OR already match Word | no change needed |

## Changes
- **`measureParaHeight`**: honor `indentLeft/Right/First` (§17.3.1.12) when measuring cell row height.
- **`measureCellContentHeightPx` + `computeTableRowHeights`**: drop the §17.4.7 trailing structural empty paragraph in both cell measurers.
- **`resolveColumnWidths`**: autofit sizes columns from the `tblGrid` (§17.4.48); per-cell `tcW` (§17.4.71) no longer overrides it.
- **`renderParagraph`** (decimal tab): auto-align a tab-less numeric paragraph to its leading `decimal` tab.
- **`renderBodyElements`**: pre-register PAGE/MARGIN-relative wrap floats for the page before laying out text.
- **`renderParagraph`** (list markers): advance a suff=tab body past an over-wide marker to the next tab stop (§17.9.6); honor `<w:lvlJc>` (§17.9.8) so a "right" level period-aligns its marker. **Parser**: capture `<w:lvlJc>` per numbering level → `NumberingInfo.jc` (the only Rust/WASM change in this PR).
- New tests: `cell-indent-rowheight`, `column-widths`, `decimal-tab-autoalign`, `float-prepass-wrap`, `numbered-marker-tab-advance`, `list-marker-jc`. Corrected the calendar trHeight comment.

## Verification
- Two independent review agents (spec-fidelity + regression); findings applied.
- docx suite: 243 passed. Root `pnpm typecheck`: green. Rust: `cargo fmt --check` + `clippy -D warnings` + 145 tests clean (CI rebuilds WASM). Page counts unchanged (sample-11=8, sample-3=3, sample-6=19). All reported regions match the Word PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)