### PR TITLE
fix(charts): axis tick marks, area crossBetween, and pie dPt colours (sample-14)

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -648,7 +648,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     if (drawValLine) strokeAxis(px0, py0 + ph, px0 + pw, py0 + ph, valLineColor, valLineW); // bottom
   }
 
-  // Axis major tick marks (`<c:*Ax><c:majorTickMark>` — ECMA-376 §21.2.2.45).
+  // Axis major tick marks (`<c:*Ax><c:majorTickMark>` — ECMA-376 §21.2.2.101).
   // PowerPoint draws short ruler ticks even when the axis rule itself is light,
   // so the bar renderer must emit them too (the line renderer already does).
   // `drawAxisTick`'s `axis` arg selects GEOMETRY: 'val' = vertical rule with
@@ -1059,11 +1059,11 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // Area anchors the value axis at 0; ignore the returned min.
   const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax);
 
-  // crossBetween="between" (the area/category default) gives each category a
-  // band of width pw/n and plots its point at the band CENTER, leaving a
-  // half-band margin before the first and after the last category — matching
-  // PowerPoint's Jan…Dec inset. "midCat" anchors points on the category
-  // dividers (flush to the axes). ECMA-376 §21.2.2.10.
+  // crossBetween="between" (Office's default; ECMA-376 §21.2.2.32 leaves the
+  // default application-defined) gives each category a band of width pw/n and
+  // plots its point at the band CENTER, leaving a half-band margin before the
+  // first and after the last category — matching PowerPoint's Jan…Dec inset.
+  // "midCat" anchors points on the category dividers (flush to the axes).
   const between = chart.catAxisCrossBetween !== 'midCat';
   const toX = between
     ? (i: number) => px0 + ((i + 0.5) / n) * pw

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -648,6 +648,39 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     if (drawValLine) strokeAxis(px0, py0 + ph, px0 + pw, py0 + ph, valLineColor, valLineW); // bottom
   }
 
+  // Axis major tick marks (`<c:*Ax><c:majorTickMark>` — ECMA-376 §21.2.2.45).
+  // PowerPoint draws short ruler ticks even when the axis rule itself is light,
+  // so the bar renderer must emit them too (the line renderer already does).
+  // `drawAxisTick`'s `axis` arg selects GEOMETRY: 'val' = vertical rule with
+  // horizontal ticks, 'cat' = horizontal rule with vertical ticks. For a
+  // column chart the value axis is vertical (left) and the category axis
+  // horizontal (bottom); a horizontal bar chart swaps the two.
+  if (!chart.valAxisHidden && chart.valAxisMajorTickMark && chart.valAxisMajorTickMark !== 'none') {
+    for (let si = 0; si <= steps; si++) {
+      const val = si * step;
+      if (!isH) {
+        drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, py0 + ph - (val / axMax) * ph, valLineColor, valLineW);
+      } else {
+        drawAxisTick(ctx, chart.valAxisMajorTickMark, 'cat', py0 + ph, px0 + (val / axMax) * pw, valLineColor, valLineW);
+      }
+    }
+  }
+  // Category ticks sit at band BOUNDARIES with crossBetween="between" (the
+  // bar/column default) — the dividers between Q1|Q2|Q3|Q4 (n+1 ticks) — and
+  // at category centers under "midCat".
+  if (!chart.catAxisHidden && chart.catAxisMajorTickMark && chart.catAxisMajorTickMark !== 'none') {
+    const onBoundary = chart.catAxisCrossBetween !== 'midCat';
+    const last = onBoundary ? n : n - 1;
+    for (let ci = 0; ci <= last; ci++) {
+      const frac = onBoundary ? ci / n : (n === 1 ? 0.5 : ci / (n - 1));
+      if (!isH) {
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + frac * pw, catLineColor, catLineW);
+      } else {
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'val', px0, py0 + frac * ph, catLineColor, catLineW);
+      }
+    }
+  }
+
   // Bar cluster geometry — ECMA-376 §21.2.2.13 (gapWidth = % of bar width
   // between categories, default 150) and §21.2.2.25 (overlap = signed % of
   // bar width within a cluster, default 0). Within a cluster the pitch
@@ -1026,31 +1059,28 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // Area anchors the value axis at 0; ignore the returned min.
   const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax);
 
-  const toX = (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
+  // crossBetween="between" (the area/category default) gives each category a
+  // band of width pw/n and plots its point at the band CENTER, leaving a
+  // half-band margin before the first and after the last category — matching
+  // PowerPoint's Jan…Dec inset. "midCat" anchors points on the category
+  // dividers (flush to the axes). ECMA-376 §21.2.2.10.
+  const between = chart.catAxisCrossBetween !== 'midCat';
+  const toX = between
+    ? (i: number) => px0 + ((i + 0.5) / n) * pw
+    : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
   const toY = (v: number) => py0 + ph - (v / axMax) * ph;
 
-  if (!chart.valAxisHidden) {
-    ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
-    ctx.textBaseline = 'middle';
-    const steps = Math.round(axMax / step);
-    for (let si = 0; si <= steps; si++) {
-      const v = si * step; const gy = toY(v);
-      ctx.strokeStyle = si === 0 ? '#aaa' : '#e0e0e0';
-      ctx.lineWidth = si === 0 ? 1 : 0.5;
-      ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
-      ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
-      ctx.textAlign = 'right';
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
-    }
-  }
-  // Category-axis baseline. `<c:catAx><c:spPr><a:ln><a:noFill>` suppresses
-  // the rule (labels stay). Same line-only hide semantics as the line/bar
-  // renderers — see those for the spec reference.
-  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
-    ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
-    ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
-  }
+  // Axis line colour/weight from `<c:*Ax><c:spPr><a:ln>` (EMU → px at scale),
+  // mirroring the bar/line renderers. Office leaves the value-axis rule off by
+  // default (gridlines stand in), so only draw it when the file specifies one.
+  const catLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#aaa';
+  const valLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#aaa';
+  const catLineW = chart.catAxisLineWidthEmu ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
+  const valLineW = chart.valAxisLineWidthEmu ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
 
+  // Draw the translucent series fills FIRST, then lay gridlines, axis rules,
+  // tick marks and labels on top so they stay visible across the filled
+  // region (PowerPoint keeps the gridlines legible under the 55%-alpha area).
   const stackBase = stacked ? new Array(n).fill(0) as number[] : null;
   for (let si = chart.series.length - 1; si >= 0; si--) {
     const s = chart.series[si];
@@ -1080,11 +1110,58 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ctx.stroke();
   }
 
+  if (!chart.valAxisHidden) {
+    ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+    ctx.textBaseline = 'middle';
+    const steps = Math.round(axMax / step);
+    for (let si = 0; si <= steps; si++) {
+      const v = si * step; const gy = toY(v);
+      ctx.strokeStyle = si === 0 ? '#aaa' : '#e0e0e0';
+      ctx.lineWidth = si === 0 ? 1 : 0.5;
+      ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW);
+      ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
+      ctx.textAlign = 'right';
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 6, gy);
+    }
+  }
+  // Category-axis baseline + value-axis rule. `<c:*Ax><c:spPr><a:ln><a:noFill>`
+  // suppresses just the rule (labels/ticks stay) → `*AxisLineHidden`. The value
+  // rule is drawn only when the file gives it a colour, matching the bar/line
+  // renderers (Office's default value axis is line-less, gridlines stand in).
+  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
+    ctx.strokeStyle = catLineColor; ctx.lineWidth = catLineW;
+    ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+  }
+  if (!chart.valAxisHidden && !chart.valAxisLineHidden && chart.valAxisLineColor != null) {
+    ctx.strokeStyle = valLineColor; ctx.lineWidth = valLineW;
+    ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+  }
+  // Category-axis major tick marks. With crossBetween="between" PowerPoint
+  // draws them at the band BOUNDARIES (n+1 dividers); "midCat" ticks centers.
+  if (!chart.catAxisHidden && chart.catAxisMajorTickMark && chart.catAxisMajorTickMark !== 'none') {
+    if (between) {
+      for (let ci = 0; ci <= n; ci++) {
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + (ci / n) * pw, catLineColor, catLineW);
+      }
+    } else {
+      for (let ci = 0; ci < n; ci++) {
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), catLineColor, catLineW);
+      }
+    }
+  }
+
   if (!chart.catAxisHidden) {
-    const labelInterval = Math.max(1, Math.ceil(n / 8));
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.textAlign = 'center'; ctx.textBaseline = 'top';
     ctx.font = `${Math.max(8, Math.min(11, pw / n * 0.8))}px sans-serif`;
+    // Show every category label that fits; thin out only when adjacent labels
+    // would collide (so 12 months all render, unlike a fixed n/8 cap).
+    let maxLabelW = 0;
+    for (let ci = 0; ci < n; ci++) {
+      maxLabelW = Math.max(maxLabelW, ctx.measureText((cats[ci] ?? '').toString().slice(0, 10)).width);
+    }
+    const labelInterval = Math.max(1, Math.ceil((maxLabelW + 6) / (pw / n)));
     for (let ci = 0; ci < n; ci += labelInterval) {
       ctx.fillText((cats[ci] ?? '').toString().slice(0, 10), toX(ci), py0 + ph + 3);
     }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -5510,16 +5510,30 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
                 })
                 .and_then(|fill| parse_color_node(fill, theme));
 
-            // Per-data-point colors from <c:dPt> (important for pie charts)
+            // Per-data-point colors from <c:dPt> (important for pie charts).
+            // The point index is the CHILD element `<c:idx val>` (ECMA-376
+            // §21.2.2.27, CT_UnsignedInt), not an attribute on `<c:dPt>` — the
+            // old `attr(dpt, "idx")` always returned None, so every slice fell
+            // back to the series colour. The fill is `<c:spPr><a:solidFill>`;
+            // restrict to spPr's direct child so a border `<a:ln><a:solidFill>`
+            // can't be mistaken for the slice fill.
             let data_point_colors: Vec<Option<String>> = (0..series_pt_count)
                 .map(|i| {
                     ser.children()
                         .filter(|n| n.is_element() && n.tag_name().name() == "dPt")
                         .find(|dpt| {
-                            attr(dpt, "idx").and_then(|v| v.parse::<usize>().ok()) == Some(i)
+                            dpt.children()
+                                .find(|n| n.is_element() && n.tag_name().name() == "idx")
+                                .and_then(|n| attr(&n, "val"))
+                                .and_then(|v| v.parse::<usize>().ok())
+                                == Some(i)
                         })
                         .and_then(|dpt| {
-                            dpt.descendants()
+                            dpt.children()
+                                .find(|n| n.is_element() && n.tag_name().name() == "spPr")
+                        })
+                        .and_then(|sp| {
+                            sp.children()
                                 .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
                         })
                         .and_then(|fill| parse_color_node(fill, theme))
@@ -9159,6 +9173,40 @@ mod tests {
             chart.series[0].values,
             vec![Some(10.0), Some(20.0), Some(30.0)],
             "all three points must survive — a multi-level cat must not truncate the series"
+        );
+    }
+
+    #[test]
+    fn legacy_chart_parses_per_point_dpt_colors_for_pie() {
+        // `<c:dPt>` carries its point index in a CHILD `<c:idx val>` element
+        // (ECMA-376 §21.2.2.27, CT_UnsignedInt), NOT an attribute on `<c:dPt>`.
+        // Reading it as an attribute always missed, so every pie/doughnut slice
+        // fell back to the series colour (a `<a:schemeClr>` that resolved to the
+        // default accent) — issue #556 follow-up: slide-7 fills were wrong. The
+        // dPt fill must come from `<c:spPr><a:solidFill>`, never the border
+        // `<a:ln><a:solidFill>`.
+        let xml = r#"<?xml version="1.0"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+ <c:chart><c:plotArea><c:pieChart>
+  <c:ser>
+   <c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill><a:ln><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></a:ln></c:spPr>
+   <c:dPt><c:idx val="0"/><c:spPr><a:solidFill><a:srgbClr val="0D9488"/></a:solidFill><a:ln><a:solidFill><a:srgbClr val="F9F9F9"/></a:solidFill></a:ln></c:spPr></c:dPt>
+   <c:dPt><c:idx val="1"/><c:spPr><a:solidFill><a:srgbClr val="14B8A6"/></a:solidFill></c:spPr></c:dPt>
+   <c:cat><c:strRef><c:strCache><c:ptCount val="2"/><c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt></c:strCache></c:strRef></c:cat>
+   <c:val><c:numRef><c:numCache><c:ptCount val="2"/><c:pt idx="0"><c:v>60</c:v></c:pt><c:pt idx="1"><c:v>40</c:v></c:pt></c:numCache></c:numRef></c:val>
+  </c:ser>
+ </c:pieChart></c:plotArea></c:chart>
+</c:chartSpace>"#;
+        let chart = parse_legacy_chart(xml, &HashMap::new()).expect("pie should parse");
+        assert_eq!(chart.chart_type, "pie");
+        let dpc = chart.series[0]
+            .data_point_colors
+            .as_ref()
+            .expect("per-slice dPt colours must be captured");
+        assert_eq!(
+            dpc,
+            &vec![Some("0D9488".to_string()), Some("14B8A6".to_string())],
+            "each slice takes its own <c:dPt><c:spPr> fill, not the series colour or the border"
         );
     }
 

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -5510,10 +5510,11 @@ fn parse_legacy_chart(xml: &str, theme: &HashMap<String, String>) -> Option<Char
                 })
                 .and_then(|fill| parse_color_node(fill, theme));
 
-            // Per-data-point colors from <c:dPt> (important for pie charts).
-            // The point index is the CHILD element `<c:idx val>` (ECMA-376
-            // §21.2.2.27, CT_UnsignedInt), not an attribute on `<c:dPt>` — the
-            // old `attr(dpt, "idx")` always returned None, so every slice fell
+            // Per-data-point colors from <c:dPt> (§21.2.2.52; important for
+            // pie charts). The point index is the CHILD element `<c:idx val>`
+            // (ECMA-376 §21.2.2.84, CT_UnsignedInt), not an attribute on
+            // `<c:dPt>` — the old `attr(dpt, "idx")` always returned None, so
+            // every slice fell
             // back to the series colour. The fill is `<c:spPr><a:solidFill>`;
             // restrict to spPr's direct child so a border `<a:ln><a:solidFill>`
             // can't be mistaken for the slice fill.
@@ -9178,8 +9179,8 @@ mod tests {
 
     #[test]
     fn legacy_chart_parses_per_point_dpt_colors_for_pie() {
-        // `<c:dPt>` carries its point index in a CHILD `<c:idx val>` element
-        // (ECMA-376 §21.2.2.27, CT_UnsignedInt), NOT an attribute on `<c:dPt>`.
+        // `<c:dPt>` (§21.2.2.52) carries its point index in a CHILD `<c:idx val>`
+        // element (ECMA-376 §21.2.2.84, CT_UnsignedInt), NOT an attribute on it.
         // Reading it as an attribute always missed, so every pie/doughnut slice
         // fell back to the series colour (a `<a:schemeClr>` that resolved to the
         // default accent) — issue #556 follow-up: slide-7 fills were wrong. The


### PR DESCRIPTION
Chart-rendering fidelity fixes found while reviewing sample-14 against the PowerPoint PDF, after #557 made the charts render at all. **Stacked on #557** (base = `fix/pptx-chart-absolute-rel-target`); merge that first.

Four of the five reported issues are addressed here; the combo chart (slide-8) is intentionally a separate follow-up PR.

## Fixes

| Slide | Symptom | Root cause | Fix |
|------|---------|-----------|-----|
| 7 (pie/doughnut) | every slice the same blue, theme ignored | `<c:dPt>` index read as an attribute, but it's a child `<c:idx val>` (§21.2.2.27) → no per-slice override matched → fell back to series `schemeClr` (default accent) | read `<c:idx>` child + take `<c:spPr><a:solidFill>` (parser) |
| 3 (column), 9 (bar) | no axis tick marks | bar renderer never drew `<c:majorTickMark>` (only the line renderer did) | draw value + category ticks; category ticks at band boundaries (Q1\|Q2\|Q3\|Q4) for crossBetween="between" |
| 6 (area) | no vertical axis / ticks, no edge margin, months dropped, gridlines hidden | area ignored crossBetween, drew no value rule, capped labels at ~n/8, filled over the gridlines | honor crossBetween="between" (half-band inset, §21.2.2.10), draw fills first then gridlines/rule/ticks/labels on top, thin labels only on measured collision |

## Deferred (documented, not fixed)

- **slide-9 value-axis major unit (PowerPoint 5 vs our 10).** This is the Excel-proprietary, axis-pixel-size-dependent major unit the `axis-scale.ts` comment already flags (±1 unit). slide-6 has nearly the same data range but PowerPoint picks 10 there, so a single `niceStep` target can't satisfy both — forcing 5 regresses slide-6. Left as-is per the "no VRT-chasing heuristics" rule.
- **slide-8 combo chart (bar+line, secondary axis)** — separate PR.

## Verification

- New Rust test `legacy_chart_parses_per_point_dpt_colors_for_pie` (Red→Green).
- `cargo fmt` / `clippy -D warnings` / parser tests, 27 core chart unit tests, root typecheck — all green.
- Headless renders of slide-3/6/7/9 compared against the PowerPoint PDF: pie/doughnut palettes, area shape + axes, and bar tick marks now match.
- Full **pptx (75) + xlsx (68) VRT stays green** — committed demo references unchanged (their charts use `majorTickMark="none"` / have no area chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)