### PR TITLE
refactor(charts): extract shared axis-line + crossBetween helpers

### DIFF
--- a/packages/core/src/chart/axis-style.test.ts
+++ b/packages/core/src/chart/axis-style.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { axisLineWidthPx, resolveAxisLine, isCrossBetween } from './axis-style.js';
+
+// EMU_PER_PT = 12700. A 1 pt line = 12700 EMU.
+describe('axisLineWidthPx', () => {
+  it('scales EMU width to px by ptToPx, floored at 0.5px', () => {
+    expect(axisLineWidthPx(12700, 1)).toBe(1); // 1pt × ptToPx 1
+    expect(axisLineWidthPx(12700, 2)).toBe(2); // 1pt × ptToPx 2 (dpr 2)
+    expect(axisLineWidthPx(3175, 1)).toBe(0.5); // 0.25pt → floored to 0.5
+  });
+  it('falls back to a 1px hairline when width is absent', () => {
+    expect(axisLineWidthPx(undefined, 2)).toBe(1);
+    expect(axisLineWidthPx(null, 2)).toBe(1);
+    expect(axisLineWidthPx(0, 2)).toBe(1);
+  });
+});
+
+describe('resolveAxisLine', () => {
+  it('prefixes the colour with # and defaults to #aaa', () => {
+    expect(resolveAxisLine('888888', 12700, 1)).toEqual({ color: '#888888', width: 1 });
+    expect(resolveAxisLine(undefined, undefined, 2)).toEqual({ color: '#aaa', width: 1 });
+    expect(resolveAxisLine(null, 25400, 1)).toEqual({ color: '#aaa', width: 2 });
+  });
+});
+
+describe('isCrossBetween', () => {
+  it('is true unless explicitly midCat', () => {
+    expect(isCrossBetween({ catAxisCrossBetween: 'between' })).toBe(true);
+    expect(isCrossBetween({ catAxisCrossBetween: '' })).toBe(true);
+    expect(isCrossBetween({ catAxisCrossBetween: 'midCat' })).toBe(false);
+  });
+});

--- a/packages/core/src/chart/axis-style.ts
+++ b/packages/core/src/chart/axis-style.ts
@@ -1,0 +1,39 @@
+// Shared chart axis-style helpers. The cartesian value-axis renderers
+// (bar / line / area / scatter) and the combo secondary axis all resolved the
+// same `<c:*Ax><c:spPr><a:ln>` colour/width and the same crossBetween default
+// inline; these extract that logic so it lives in one place.
+
+import type { ChartModel } from '../types/chart';
+import { EMU_PER_PT } from '../units.js';
+
+/** An axis rule's `<a:ln@w>` (EMU) → canvas px at the current display scale.
+ *  `ptToPx` is px-per-point. Floored at 0.5 px so a thin rule stays visible;
+ *  an absent width falls back to a 1 px hairline. */
+export function axisLineWidthPx(widthEmu: number | null | undefined, ptToPx: number): number {
+  return widthEmu ? Math.max(0.5, widthEmu / EMU_PER_PT) * ptToPx : 1;
+}
+
+/** Resolve an axis rule's `{ color, width }` from its parsed `<a:ln>` parts.
+ *  Colour defaults to Office's faint default rule (`#aaa`) and width to 1 px.
+ *  Used for the category/value axes (`chart.*AxisLineColor/WidthEmu`) and the
+ *  secondary value axis (`sec.lineColor/lineWidthEmu`) — pass whichever fields
+ *  apply. (Scatter keeps its own `#888`/`undefined` defaults, so it uses
+ *  `axisLineWidthPx` directly rather than this.) */
+export function resolveAxisLine(
+  color: string | null | undefined,
+  widthEmu: number | null | undefined,
+  ptToPx: number,
+): { color: string; width: number } {
+  return {
+    color: color ? `#${color}` : '#aaa',
+    width: axisLineWidthPx(widthEmu, ptToPx),
+  };
+}
+
+/** Category-axis crossBetween: by default categories occupy a band and points
+ *  sit at the band centre ("between"); `"midCat"` anchors them on the dividers.
+ *  ECMA-376 §21.2.2.32 leaves the default application-defined — Office (and we)
+ *  use "between". */
+export function isCrossBetween(chart: Pick<ChartModel, 'catAxisCrossBetween'>): boolean {
+  return chart.catAxisCrossBetween !== 'midCat';
+}

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -5,6 +5,7 @@
 
 import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
 import { niceStep, valueAxisScale } from './axis-scale.js';
+import { axisLineWidthPx, resolveAxisLine, isCrossBetween } from './axis-style.js';
 import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
 import { hexToRgba } from '../shape/paint.js';
 import { EMU_PER_PT, PT_TO_PX } from '../units.js';
@@ -722,16 +723,10 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // stay) → `*AxisLineHidden`; an `<a:solidFill>` gives `*AxisLineColor`/Width
   // (ECMA-376 §21.2.2.* line props). Office leaves the value-axis rule off by
   // default (gridlines stand in), so only draw it when the file specifies one.
-  const catLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#aaa';
-  const valLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#aaa';
-  // Axis line weights from `<c:*Ax><c:spPr><a:ln@w>` (EMU). `ctx.lineWidth`
-  // is in CANVAS pixels, so the point width must be multiplied by `ptToPx`
-  // (px-per-point at the display scale: ~1.333 for xlsx 96dpi, ~1.05 for
-  // pptx) — exactly like the chart-border code in renderChart. Without it the
-  // rule is under-scaled on HiDPI/zoomed canvases. The `: 1` fallback (no
-  // explicit `@w`) stays a 1px hairline.
-  const catLineW = chart.catAxisLineWidthEmu ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
-  const valLineW = chart.valAxisLineWidthEmu ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
+  // Colour defaults to '#aaa' (Office's faint default rule); the EMU `<a:ln@w>`
+  // is scaled to canvas px by `ptToPx`. See `resolveAxisLine`.
+  const { color: catLineColor, width: catLineW } = resolveAxisLine(chart.catAxisLineColor, chart.catAxisLineWidthEmu, ptToPx);
+  const { color: valLineColor, width: valLineW } = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
   const strokeAxis = (x1: number, y1: number, x2: number, y2: number, color: string, lw: number): void => {
     ctx.strokeStyle = color; ctx.lineWidth = lw;
     ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2); ctx.stroke();
@@ -771,7 +766,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     // bar/column default) — the dividers between Q1|Q2|Q3|Q4 (n+1 ticks) — and
     // at category centers under "midCat".
     if (!chart.catAxisHidden && chart.catAxisMajorTickMark && chart.catAxisMajorTickMark !== 'none') {
-      const onBoundary = chart.catAxisCrossBetween !== 'midCat';
+      const onBoundary = isCrossBetween(chart);
       const last = onBoundary ? n : n - 1;
       for (let ci = 0; ci <= last; ci++) {
         const frac = onBoundary ? ci / n : (n === 1 ? 0.5 : ci / (n - 1));
@@ -956,8 +951,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // rule + ticks on the right; ticks mirror the left axis ("out" points right).
   if (sec) {
     const axX = px0 + pw;
-    const secLineColor = sec.lineColor ? `#${sec.lineColor}` : '#aaa';
-    const secLineW = sec.lineWidthEmu ? Math.max(0.5, sec.lineWidthEmu / EMU_PER_PT) * ptToPx : 1;
+    const { color: secLineColor, width: secLineW } = resolveAxisLine(sec.lineColor, sec.lineWidthEmu, ptToPx);
     if (!sec.lineHidden) strokeAxis(axX, py0, axX, py0 + ph, secLineColor, secLineW);
     if (!sec.hidden) {
       ctx.font = `${secFontPx}px sans-serif`;
@@ -1068,7 +1062,7 @@ function renderLineChart(
   const toY = (v: number) => py0 + ph - ((v - axMin) / range) * ph;
   // crossBetween="between" (default) insets the first/last category by half a
   // step so points aren't flush against the axes. "midCat" anchors them.
-  const between = chart.catAxisCrossBetween !== 'midCat';
+  const between = isCrossBetween(chart);
   const toX = between
     ? (i: number) => px0 + ((i + 0.5) / n) * pw
     : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
@@ -1217,7 +1211,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // plots its point at the band CENTER, leaving a half-band margin before the
   // first and after the last category — matching PowerPoint's Jan…Dec inset.
   // "midCat" anchors points on the category dividers (flush to the axes).
-  const between = chart.catAxisCrossBetween !== 'midCat';
+  const between = isCrossBetween(chart);
   const toX = between
     ? (i: number) => px0 + ((i + 0.5) / n) * pw
     : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
@@ -1226,10 +1220,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // Axis line colour/weight from `<c:*Ax><c:spPr><a:ln>` (EMU → px at scale),
   // mirroring the bar/line renderers. Office leaves the value-axis rule off by
   // default (gridlines stand in), so only draw it when the file specifies one.
-  const catLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#aaa';
-  const valLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#aaa';
-  const catLineW = chart.catAxisLineWidthEmu ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
-  const valLineW = chart.valAxisLineWidthEmu ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx : 1;
+  const { color: catLineColor, width: catLineW } = resolveAxisLine(chart.catAxisLineColor, chart.catAxisLineWidthEmu, ptToPx);
+  const { color: valLineColor, width: valLineW } = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
 
   // Draw the translucent series fills FIRST, then lay gridlines, axis rules,
   // tick marks and labels on top so they stay visible across the filled
@@ -1683,10 +1675,11 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
       ctx.fillStyle = '#555'; ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
       ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
+      // Scatter keeps its own undefined colour default (→ drawAxisTick's '#888'),
+      // so only the width formula is shared. `axisLineWidthPx`'s 1 px fallback is
+      // equivalent to undefined here (drawAxisTick treats both as a hairline).
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
-      const yAxisLineWidth = chart.valAxisLineWidthEmu
-        ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx : undefined;
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, yAxisLineColor, yAxisLineWidth);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx));
     }
   }
 
@@ -1720,9 +1713,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
     ctx.save();
     ctx.strokeStyle = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#888';
-    ctx.lineWidth = chart.catAxisLineWidthEmu
-      ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx
-      : 1;
+    ctx.lineWidth = axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx);
     ctx.lineCap = 'butt';
     ctx.beginPath(); ctx.moveTo(px0, xAxisY); ctx.lineTo(px0 + pw, xAxisY); ctx.stroke();
     ctx.restore();
@@ -1730,9 +1721,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   if (!chart.valAxisHidden && !chart.valAxisLineHidden) {
     ctx.save();
     ctx.strokeStyle = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : '#888';
-    ctx.lineWidth = chart.valAxisLineWidthEmu
-      ? Math.max(0.5, chart.valAxisLineWidthEmu / EMU_PER_PT) * ptToPx
-      : 1;
+    ctx.lineWidth = axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx);
     ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
     ctx.restore();
   }
@@ -1755,9 +1744,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       const gx = toX(v);
       ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode), gx, xAxisY + 4);
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
-      const xAxisLineWidth = chart.catAxisLineWidthEmu
-        ? Math.max(0.5, chart.catAxisLineWidthEmu / EMU_PER_PT) * ptToPx : undefined;
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, xAxisLineWidth);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx));
     }
   }
 


### PR DESCRIPTION
Pure DRY refactor of `packages/core/src/chart/renderer.ts` — **no rendering change** (full pptx 75 / xlsx 68 VRT identical, no references regenerated).

The four cartesian value-axis renderers (bar / line / area / scatter) and the combo secondary axis each inlined the same axis-rule resolution and crossBetween default. Extracted into a new `chart/axis-style.ts`:

| Helper | Replaces |
|---|---|
| `resolveAxisLine(color, widthEmu, ptToPx) → {color,width}` | the byte-identical 4-line `cat/valLineColor` + `cat/valLineW` blocks in **bar** and **area**, and the **secondary** axis (`sec.line*` fields). Colour default `#aaa`, width 1. |
| `axisLineWidthPx(widthEmu, ptToPx)` | the EMU→px width formula on its own — reused by **scatter**, which keeps its own `#888`/`undefined` colour defaults (so it can't use `resolveAxisLine`). |
| `isCrossBetween(chart)` | `chart.catAxisCrossBetween !== 'midCat'`, repeated in bar / line / area. |

### Notes
- **Behavior identical.** No rendering constants changed. Scatter's tick-width calls previously passed `undefined` for an absent width; `axisLineWidthPx`'s 1px fallback is equivalent there (`drawAxisTick` maps both `undefined` and `1` to a 4px tick / 1px hairline). Confirmed by unchanged VRT.
- **Item 3 deliberately skipped.** Having line/area adopt the bar's *measured* value-label gutter would change their `w*0.12` gutter to the measured width — a behavior change, not a refactor.

### Verification
- `npx vitest run packages/core/src/chart` → 32 passed (new `axis-style.test.ts`, 4 cases). Note: `@silurus/ooxml-core` has no `test` script, so run vitest directly.
- `pnpm typecheck` green.
- pptx (75) + xlsx (68) VRT unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)