### PR TITLE
chore(release): 0.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,71 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.65.0 — 2026-06-23
+
+Minor. A large PowerPoint chart-fidelity push — blank charts now render, combo
+charts gain a secondary value axis, and pie/doughnut colours and labels match
+PowerPoint — on top of an extensive DOCX table / floating-layout / list batch
+and continued cross-format core unification.
+
+### charts (pptx)
+
+- **Charts that silently rendered as a blank area now render.** Two root causes:
+  a relationship `Target` that is a package-root-absolute part name (leading
+  `/`, e.g. `/ppt/charts/chart5.xml`; OPC / ECMA-376 Part 2 §9.3) was joined onto
+  the source part's directory and the chart graphicFrame was dropped; and a
+  `<c:cat>` backed by a `<c:multiLvlStrCache>` (multi-level category axis,
+  §21.2.2.114) collapsed every series to a single point — an area chart of one
+  point is a zero-width sliver. Both fixed, plus the same absolute-`Target` fix
+  for slide parts. (PR #557)
+- **Combo charts** (`<c:barChart>` + `<c:lineChart>` in one plot) now plot the
+  line series against an independent **secondary value axis** drawn on the right
+  — its own nice scale, ticks, labels and rotated title (`axPos="r"` /
+  `<c:crosses val="max">`, §21.2.2.33). The auto value-axis major unit is now
+  axis-length-aware (a longer axis gets finer gridlines, matching PowerPoint's
+  roughly constant gridline spacing), the category baseline draws on top of the
+  bars, and value-axis numbers clear the tick marks. (PR #560)
+- **Pie / doughnut**: per-slice `<c:dPt>` fill colours render correctly (the
+  point index is a child `<c:idx>` element, §21.2.2.84, not an attribute, so
+  every slice previously fell back to the series colour), and `<c:showPercent>`
+  slice labels (`54% / 27% / …`) now draw. (PR #559, #561)
+- Bar / column / area charts gained `<c:majorTickMark>` ruler ticks (default
+  `out`, ST_TickMark §21.2.3.48, shared with xlsx); area honours the category
+  axis `crossBetween` (half-band inset), draws the value-axis rule, and labels
+  every category. (PR #559)
+
+### docx
+
+- **Tables**: cell and column widths size from `<w:tblGrid>` / `<w:tcW>` spec
+  geometry via a shared two-pass measure, `tblCellMar` inherits through the
+  `TableNormal` style chain (§17.4.41), exact-height row clipping is Y-only so
+  nested-table borders survive (§17.4.80), `tblOverlap` is scoped correctly
+  (§17.4.56), and border render order / double-border rails and conditional
+  (`cnf`) row/column formatting are honoured. (PR #513, #518, #527–#531, #538,
+  #542–#547, #549, #553, #555)
+- **Floating layout**: page- and margin-anchored floats are pre-scanned so
+  earlier paragraphs wrap around them (§20.4.3.x), floating tables, frame
+  `vAnchor` banding (§22.9.2.20), drop-cap `framePr`, and image-anchor
+  `relativeFrom` / alignment are threaded through (§20.4.3.5 / §20.4.3.2).
+  (PR #515, #520, #521, #526, #543, #550, #554)
+- **Lists / text**: picture bullets and bullet/inline symbol-font resolution,
+  table-of-contents styling (including the in-field hyperlink colour),
+  per-section column layout, and sample-10/-11 multi-column + inline-formatting
+  fixes. (PR #507, #514, #516, #519, #522, #524, #525, #534, #540)
+
+### core
+
+- Continued cross-format unification: a shared font generic classifier and
+  WMF/metafile decoder, symbol-font (Wingdings/Webdings) handling, dash-pattern
+  and auto-contrast colour helpers, complex-script code-point segmentation, and
+  shared chart axis-line / `crossBetween` helpers. (PR #509–#512, #528,
+  #535–#537, #541, #562)
+
+### xlsx
+
+- Merged-cell border z-order and the shared two-pass table-cell sizing path.
+  (PR #517, #546)
+
 ## 0.64.3 — 2026-06-21
 
 Patch. Crisp 1-px rendering of Excel grid/border lines at devicePixelRatio = 1, header/data alignment, and toned-down homepage copy.

--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ export const PptxViewerComponent = component$<{ src: string }>(({ src }) => {
 | | Charts (pie, doughnut) | ✅ |
 | | Charts (scatter — `scatterStyle` marker / line / smooth variants) | ✅ |
 | | Charts (bubble — `bubbleSize` per-point area scaling) | ✅ |
+| | Charts (combo — bar + line with a secondary value axis on the right) | ✅ |
 | | SmartArt (renders the PowerPoint-saved drawing layout `dsp:drawing`; no native diagram layout engine) | ✅ |
 | | OLE embedded objects (`p:oleObj` — preview/icon rendering) | ❌ Not planned |
 | | Video / audio (poster + interactive playback) | ✅ |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.64.3",
+  "version": "0.65.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/src/components/Capabilities.astro
+++ b/site/src/components/Capabilities.astro
@@ -36,7 +36,7 @@ const cols = [
       'Preset & custom geometry shapes',
       'Shape & picture effects — shadows, glow, reflection',
       '3D scene camera, bevel & extrusion shading (sp3d)',
-      'Charts with axis & label styling',
+      'Charts — combo bar+line, secondary axis, data labels',
       'Math equations (OMML, STIX Two Math)',
       'SmartArt text, grouped transforms',
       'SVG images, gradient / image fills, theme colours',


### PR DESCRIPTION
Release 0.65.0. Bumps all 8 packages, adds the CHANGELOG entry, the pptx combo-charts Feature Support row, and the site capability line.

## Highlights

**Charts (pptx)** — the headline of this release:
- Charts that silently rendered as a **blank area now render** (package-root-absolute relationship `Target`s, OPC §9.3; `<c:multiLvlStrCache>` multi-level category axes, §21.2.2.114).
- **Combo charts** (bar + line) with an independent **secondary value axis** on the right (§21.2.2.33), plus an axis-length-aware auto major unit, baseline-on-top-of-bars, and clearer tick/label spacing.
- **Pie / doughnut** per-slice `<c:dPt>` colours (§21.2.2.84) and `<c:showPercent>` labels; bar/area `<c:majorTickMark>` ticks (default `out`, §21.2.3.48) and area `crossBetween`.

**DOCX** — large table / floating-layout / list fidelity batch (PR #507–#555): spec-geometry table cell/column sizing, `tblCellMar` inheritance (§17.4.41), Y-only exact-height clipping (§17.4.80), `tblOverlap` scope (§17.4.56), pre-scanned page/margin float wrap (§20.4.3.x), floating tables, frame `vAnchor` banding (§22.9.2.20), ToC styling, picture/symbol bullets, per-section columns.

**core** — continued cross-format unification (font classifier, WMF decoder, symbol fonts, dash/auto-contrast helpers, complex-script segmentation, shared chart axis-style helpers).

**xlsx** — merged-cell border z-order, shared two-pass table-cell sizing.

## Release checklist

- [x] Bump 8 `package.json` → 0.65.0
- [x] CHANGELOG `## 0.65.0` (charts / docx / core / xlsx)
- [x] README Feature Support: pptx combo charts row
- [x] site `Capabilities.astro`: pptx charts → combo + secondary axis
- [x] README consistency (ESM-only `.mjs`, no stale versions / `require(`)
- [x] No public-API change → `site/src/lib/api-reference.ts` untouched
- [ ] `docs/images/*.png` screenshots — **intentionally not retaken**: the hero composition is a title slide unaffected by the chart-fidelity work; the fixes aren't visible in that shot.

After merge: tag `v0.65.0` → GitHub Release (triggers npm publish, VS Code Marketplace, and the site/Storybook deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)