### PR TITLE
docx: continuous-section column layout + EMF + release 0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.66.0 — 2026-06-23
+
+Minor. A DOCX continuous-section newspaper-column overhaul plus EMF figure
+support — dense, multi-page journal templates (sample-12/13) now match Word.
+
+- **docx (multi-column sections):** continuation columns start at the section's
+  region top, not the page top (§17.6.4); a section break is governed by the
+  upcoming section's start type, so a `nextPage` title section before a
+  `continuous` body no longer page-breaks (§17.6.22); header/footer references
+  inherit across sections so a running header declared on the first section
+  shows on every page (§17.10.1); non-final continuous multi-column sections are
+  balanced across their columns, matching Word's page fill (§17.6.4).
+- **docx (text & images):** an over-long unbreakable token (e.g. a long URL in a
+  narrow column) breaks at the character level instead of bleeding past the
+  column (overflow-wrap); `<a:srcRect>` image crops are honored, including the
+  rasterization size for cropped metafiles (§20.1.8.55); consecutive paragraphs
+  with identical `<w:pBdr>` borders merge into one box instead of ruling every
+  line (§17.3.1.7).
+- **core (images):** Enhanced Metafile (EMF) parts now rasterize via a new
+  [MS-EMF] player (world transform, polylines/polygons, text, DIBs), so EMF
+  charts/figures render instead of dropping to blank.
+
 ## 0.65.0 — 2026-06-23
 
 Minor. A large PowerPoint chart-fidelity push — blank charts now render, combo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/src/image/emf.test.ts
+++ b/packages/core/src/image/emf.test.ts
@@ -1,0 +1,582 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isEmf } from './wmf.js';
+import { playEmf, renderEmfToBitmap } from './emf.js';
+
+// ── EMF (Enhanced Metafile) player unit tests ───────────────────────────────
+// The renderer falls back to this player for true `.emf` blips the browser can't
+// decode (createImageBitmap throws on metafiles, and EMF is a different, larger
+// 32-bit format than WMF). sample-13.docx embeds two EMF charts (`image3.emf`
+// Fig.2, `image4.emf` Fig.3) whose bars/axes are POLYGON16/POLYLINE16 records
+// and whose labels are EXTTEXTOUTW text-out records, all scaled by a long run of
+// MODIFYWORLDTRANSFORM affines — so the player needs the world transform, an
+// object table (pens+brushes+fonts), polygon/polyline drawing, and text-out.
+//
+// `playEmf(bytes, ctx, W, H)` is the pure record-replay core: it issues
+// moveTo/lineTo/stroke/fill/fillText calls onto an injected ctx, so a recording
+// mock pins coordinate mapping + state without needing OffscreenCanvas (absent
+// in the node test env). The two sample EMFs themselves live only inside the
+// gitignored `sample-13.docx` (docx/pptx/xlsx files are not committed), so these
+// tests craft synthetic EMF byte buffers rather than read the private samples.
+
+// ── byte builders ───────────────────────────────────────────────────────────
+
+/** Little-endian byte writer for crafting EMF records (32-bit / IEEE-754). */
+class Writer {
+  private bytes: number[] = [];
+  u16(v: number) {
+    this.bytes.push(v & 0xff, (v >>> 8) & 0xff);
+    return this;
+  }
+  i16(v: number) {
+    return this.u16(v & 0xffff);
+  }
+  u32(v: number) {
+    this.bytes.push(v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff);
+    return this;
+  }
+  i32(v: number) {
+    return this.u32(v >>> 0);
+  }
+  f32(v: number) {
+    const buf = new ArrayBuffer(4);
+    new DataView(buf).setFloat32(0, v, true);
+    const u8 = new Uint8Array(buf);
+    this.bytes.push(u8[0], u8[1], u8[2], u8[3]);
+    return this;
+  }
+  utf16(s: string) {
+    for (let i = 0; i < s.length; i++) this.u16(s.charCodeAt(i));
+    return this;
+  }
+  raw(...vals: number[]) {
+    for (const v of vals) this.bytes.push(v & 0xff);
+    return this;
+  }
+  get length(): number {
+    return this.bytes.length;
+  }
+  build(): Uint8Array {
+    return new Uint8Array(this.bytes);
+  }
+}
+
+// EMF record type ids ([MS-EMF] 2.1.1 RecordType).
+const EMR = {
+  HEADER: 1,
+  EOF: 14,
+  SETPOLYFILLMODE: 19,
+  SETTEXTALIGN: 22,
+  SETTEXTCOLOR: 24,
+  MODIFYWORLDTRANSFORM: 36,
+  SELECTOBJECT: 37,
+  CREATEPEN: 38,
+  CREATEBRUSHINDIRECT: 39,
+  DELETEOBJECT: 40,
+  EXTCREATEFONTINDIRECTW: 82,
+  EXTTEXTOUTW: 84,
+  POLYGON16: 86,
+  POLYLINE16: 87,
+} as const;
+
+/** An EMF record: u32 iType, u32 nSize (incl. the 8-byte header), then data.
+ *  nSize is padded to a 4-byte boundary. */
+function record(iType: number, data: (w: Writer) => void): Uint8Array {
+  const pw = new Writer();
+  data(pw);
+  let body = pw.build();
+  // 4-byte align the record body.
+  if (body.length % 4 !== 0) {
+    const pad = new Uint8Array(body.length + (4 - (body.length % 4)));
+    pad.set(body, 0);
+    body = pad;
+  }
+  const nSize = 8 + body.length;
+  const head = new Writer().u32(iType).u32(nSize).build();
+  const out = new Uint8Array(head.length + body.length);
+  out.set(head, 0);
+  out.set(body, head.length);
+  return out;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+/** EMR_HEADER with the given inclusive device bounds (left,top,right,bottom).
+ *  The signature " EMF" (0x464D4520) must land at byte offset 40 of the whole
+ *  file → record offset 40 (the header record starts at file offset 0). */
+function emfHeader(left = 0, top = 0, right = 100, bottom = 100): Uint8Array {
+  return record(EMR.HEADER, (w) => {
+    // data starts at record offset 8:
+    w.i32(left).i32(top).i32(right).i32(bottom); // rclBounds   (off 8..24)
+    w.i32(0).i32(0).i32(36000).i32(22000); //        rclFrame    (off 24..40)
+    w.u32(0x464d4520); //                            dSignature  (off 40) " EMF"
+    w.u32(0x00010000); //                            nVersion    (off 44)
+    w.u32(0); //                                     nBytes      (off 48)
+    w.u32(0); //                                     nRecords    (off 52)
+    w.u16(0).u16(0); //                              nHandles/sReserved
+    w.u32(0).u32(0); //                              nDescription/offDescription
+    w.u32(0); //                                     nPalEntries
+    w.i32(1920).i32(1080); //                        szlDevice (px)
+    w.i32(508).i32(286); //                          szlMillimeters
+  });
+}
+
+// ── recording mock ctx (records the draw calls + style mutations) ───────────
+
+interface Call {
+  op: string;
+  args: (number | string)[];
+}
+interface MockCtx {
+  ctx: CanvasRenderingContext2D;
+  calls: Call[];
+  styles: {
+    fill: string[];
+    stroke: string[];
+    text: string[];
+    fillRules: (string | undefined)[];
+  };
+}
+
+function makeRecordingCtx(): MockCtx {
+  const calls: Call[] = [];
+  const styles = {
+    fill: [] as string[],
+    stroke: [] as string[],
+    text: [] as string[],
+    fillRules: [] as (string | undefined)[],
+  };
+  let _fill = '#000';
+  let _stroke = '#000';
+  let _lw = 1;
+  const ctx = {
+    get fillStyle() {
+      return _fill;
+    },
+    set fillStyle(v: string) {
+      _fill = v;
+    },
+    get strokeStyle() {
+      return _stroke;
+    },
+    set strokeStyle(v: string) {
+      _stroke = v;
+    },
+    get lineWidth() {
+      return _lw;
+    },
+    set lineWidth(v: number) {
+      _lw = v;
+    },
+    font: '10px sans-serif',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    lineJoin: 'miter' as CanvasLineJoin,
+    lineCap: 'butt' as CanvasLineCap,
+    save() {
+      calls.push({ op: 'save', args: [] });
+    },
+    restore() {
+      calls.push({ op: 'restore', args: [] });
+    },
+    beginPath() {
+      calls.push({ op: 'beginPath', args: [] });
+    },
+    closePath() {
+      calls.push({ op: 'closePath', args: [] });
+    },
+    moveTo(x: number, y: number) {
+      calls.push({ op: 'moveTo', args: [x, y] });
+    },
+    lineTo(x: number, y: number) {
+      calls.push({ op: 'lineTo', args: [x, y] });
+    },
+    bezierCurveTo(...a: number[]) {
+      calls.push({ op: 'bezierCurveTo', args: a });
+    },
+    ellipse(...a: number[]) {
+      calls.push({ op: 'ellipse', args: a });
+    },
+    rect(x: number, y: number, w: number, h: number) {
+      calls.push({ op: 'rect', args: [x, y, w, h] });
+    },
+    stroke() {
+      calls.push({ op: 'stroke', args: [] });
+      styles.stroke.push(_stroke);
+    },
+    fill(rule?: string) {
+      calls.push({ op: 'fill', args: [] });
+      styles.fill.push(_fill);
+      styles.fillRules.push(rule);
+    },
+    fillText(t: string, x: number, y: number) {
+      calls.push({ op: 'fillText', args: [t, x, y] });
+      styles.text.push(_fill);
+    },
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls, styles };
+}
+
+// ── isEmf detection ─────────────────────────────────────────────────────────
+
+describe('isEmf detection (shared with the WMF sniffer)', () => {
+  it('detects a synthetic EMF header (EMR_HEADER + " EMF" signature@40)', () => {
+    expect(isEmf(emfHeader())).toBe(true);
+  });
+
+  it('rejects a non-EMF buffer (PNG magic)', () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+    expect(isEmf(png)).toBe(false);
+  });
+});
+
+// ── playEmf: world transform + polyline + pen ────────────────────────────────
+
+describe('playEmf — world transform, pen, polyline16', () => {
+  it('maps a polyline through the world transform then device→target px', () => {
+    // bounds 0..100 × 0..100, target 200×200 → device→px scale ×2.
+    // World transform: scale ×0.5 (m11=m22=0.5). So logical (40,60) → device
+    // (20,30) → px (40,60); logical (80,100) → device (40,50) → px (80,100).
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      // MODIFYWORLDTRANSFORM, iMode=4 (MWT_SET): WT = the supplied xform.
+      record(EMR.MODIFYWORLDTRANSFORM, (w) =>
+        w.f32(0.5).f32(0).f32(0).f32(0.5).f32(0).f32(0).u32(4),
+      ),
+      // CREATEPEN ih=1, style=0 (solid), width (1,0), color blue 0x00FF0000.
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0x00ff0000)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      // POLYLINE16: RECTL bounds (skipped), count=2, then 2× POINTS(i16,i16).
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(100).i32(100).u32(2).i16(40).i16(60).i16(80).i16(100),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+
+    const m = makeRecordingCtx();
+    expect(playEmf(file, m.ctx, 200, 200)).toBe(true);
+
+    const moves = m.calls.filter((c) => c.op === 'moveTo');
+    const lines = m.calls.filter((c) => c.op === 'lineTo');
+    expect(moves.length).toBe(1);
+    expect(moves[0].args).toEqual([40, 60]); // (40,60)·0.5·2
+    expect(lines.length).toBe(1);
+    expect(lines[0].args).toEqual([80, 100]); // (80,100)·0.5·2
+
+    const strokes = m.calls.filter((c) => c.op === 'stroke');
+    expect(strokes.length).toBe(1);
+    expect(m.styles.stroke.at(-1)?.toLowerCase()).toBe('#0000ff'); // blue pen
+    expect(m.calls.some((c) => c.op === 'fill')).toBe(false); // polyline never fills
+  });
+
+  it('MWT_LEFTMULTIPLY (iMode=2) composes xform × WT (scale-down then draw)', () => {
+    // First SET ×16, then LEFTMULTIPLY ×(1/16). LEFT-multiplying 1/16 onto a ×16
+    // WT yields identity, so logical (10,20) → device (10,20) → px (10,20) at a
+    // 1:1 device mapping (bounds == target).
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.MODIFYWORLDTRANSFORM, (w) =>
+        w.f32(16).f32(0).f32(0).f32(16).f32(0).f32(0).u32(4),
+      ),
+      record(EMR.MODIFYWORLDTRANSFORM, (w) =>
+        w.f32(1 / 16).f32(0).f32(0).f32(1 / 16).f32(0).f32(0).u32(2),
+      ),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0x00000000)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(100).i32(100).u32(2).i16(10).i16(20).i16(30).i16(40),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    playEmf(file, m.ctx, 100, 100);
+    const moves = m.calls.filter((c) => c.op === 'moveTo');
+    const lines = m.calls.filter((c) => c.op === 'lineTo');
+    expect(moves[0].args[0]).toBeCloseTo(10, 4);
+    expect(moves[0].args[1]).toBeCloseTo(20, 4);
+    expect(lines[0].args[0]).toBeCloseTo(30, 4);
+    expect(lines[0].args[1]).toBeCloseTo(40, 4);
+  });
+
+  it('a PS_NULL pen (style 5) does not stroke', () => {
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(5).i32(1).i32(0).u32(0)), // PS_NULL
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(100).i32(100).u32(2).i16(0).i16(0).i16(10).i16(10),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    playEmf(file, m.ctx, 100, 100);
+    expect(m.calls.some((c) => c.op === 'stroke')).toBe(false);
+  });
+});
+
+// ── playEmf: polygon fill + object table ─────────────────────────────────────
+
+describe('playEmf — polygon16 fill + brush/pen select', () => {
+  it('fills + strokes a POLYGON16 with the current brush + pen', () => {
+    const file = concat(
+      emfHeader(0, 0, 10, 10),
+      // brush ih=1 SOLID(0) green 0x0000FF00; pen ih=2 SOLID red 0x000000FF.
+      record(EMR.CREATEBRUSHINDIRECT, (w) => w.u32(1).u32(0).u32(0x0000ff00).u32(0)),
+      record(EMR.CREATEPEN, (w) => w.u32(2).u32(0).i32(1).i32(0).u32(0x000000ff)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)), // brush
+      record(EMR.SELECTOBJECT, (w) => w.u32(2)), // pen
+      record(EMR.POLYGON16, (w) =>
+        w.i32(0).i32(0).i32(10).i32(10).u32(3).i16(0).i16(0).i16(10).i16(0).i16(5).i16(10),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(playEmf(file, m.ctx, 10, 10)).toBe(true);
+    expect(m.styles.fill.at(-1)?.toLowerCase()).toBe('#00ff00'); // green brush
+    expect(m.styles.stroke.at(-1)?.toLowerCase()).toBe('#ff0000'); // red pen
+  });
+
+  it('a BS_NULL brush (style 1) does not fill', () => {
+    const file = concat(
+      emfHeader(0, 0, 10, 10),
+      record(EMR.CREATEBRUSHINDIRECT, (w) => w.u32(1).u32(1).u32(0).u32(0)), // BS_NULL
+      record(EMR.CREATEPEN, (w) => w.u32(2).u32(0).i32(1).i32(0).u32(0)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(2)),
+      record(EMR.POLYGON16, (w) =>
+        w.i32(0).i32(0).i32(10).i32(10).u32(3).i16(0).i16(0).i16(10).i16(0).i16(5).i16(10),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    playEmf(file, m.ctx, 10, 10);
+    expect(m.calls.some((c) => c.op === 'fill')).toBe(false);
+    expect(m.calls.some((c) => c.op === 'stroke')).toBe(true);
+  });
+
+  it('DELETEOBJECT of the selected pen clears it and frees the slot (no later stroke)', () => {
+    // Mirrors the WMF twin: deleting the object currently selected into the DC
+    // un-selects it (curPen → null), and a later SELECTOBJECT of the now-empty
+    // slot is a no-op. So the polyline issues no stroke — and never throws.
+    const file = concat(
+      emfHeader(0, 0, 10, 10),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0x000000ff)), // red
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.DELETEOBJECT, (w) => w.u32(1)), // clears curPen + frees slot 1
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)), // slot now empty → no-op
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(10).i32(10).u32(2).i16(0).i16(0).i16(5).i16(5),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(() => playEmf(file, m.ctx, 10, 10)).not.toThrow();
+    expect(m.calls.some((c) => c.op === 'stroke')).toBe(false);
+  });
+
+  it('reuses a freed slot when an index is recreated after DELETEOBJECT', () => {
+    // Create red pen at ih=1, select+delete it, recreate ih=1 as green, select →
+    // the stroke uses the recreated green pen (Map slot reused by index).
+    const file = concat(
+      emfHeader(0, 0, 10, 10),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0x000000ff)), // red
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.DELETEOBJECT, (w) => w.u32(1)),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0x0000ff00)), // green
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(10).i32(10).u32(2).i16(0).i16(0).i16(5).i16(5),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    playEmf(file, m.ctx, 10, 10);
+    expect(m.styles.stroke.at(-1)?.toLowerCase()).toBe('#00ff00'); // recreated green
+  });
+});
+
+// ── playEmf: text-out ────────────────────────────────────────────────────────
+
+describe('playEmf — EXTTEXTOUTW text', () => {
+  it('draws the UTF-16 string with the selected font color at the mapped ref point', () => {
+    // offString = byte offset from the RECORD start to the string. The EXTTEXTOUTW
+    // data layout up to the string: header(8) + RECTL(16) + iGraphicsMode(4) +
+    // exScale(4) + eyScale(4) + ptlReference(8) + nChars(4) + offString(4) +
+    // fOptions(4) + rcl RECTL(16) + offDx(4) = 76 bytes → the string starts at 76.
+    const text = 'F1';
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      // font ih=1, lfHeight=-12 (negative = char height), weight=400, not italic.
+      record(EMR.EXTCREATEFONTINDIRECTW, (w) => {
+        w.u32(1); // ihObject
+        // LOGFONT starts at record offset 12 (data offset 4):
+        w.i32(-12).i32(0).i32(0).i32(0).i32(400); // lfHeight..lfWeight
+        w.raw(0, 0, 0, 0); // lfItalic, lfUnderline, lfStrikeOut, lfCharSet
+        w.raw(0, 0, 0, 0); // lfOutPrecision..lfPitchAndFamily (4 bytes)
+        // lfFaceName (UTF-16, 32 code units) at LOGFONT offset 28:
+        const face = 'Arial';
+        w.utf16(face);
+        for (let i = face.length; i < 32; i++) w.u16(0);
+      }),
+      record(EMR.SETTEXTCOLOR, (w) => w.u32(0x000000ff)), // red
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)), // font
+      record(EMR.EXTTEXTOUTW, (w) => {
+        w.i32(0).i32(0).i32(100).i32(100); // RECTL rclBounds
+        w.u32(1); // iGraphicsMode
+        w.f32(1).f32(1); // exScale, eyScale
+        w.i32(20).i32(30); // ptlReference (logical) → identity WT → device (20,30)
+        w.u32(text.length); // nChars
+        w.u32(76); // offString (computed above)
+        w.u32(0); // fOptions
+        w.i32(0).i32(0).i32(0).i32(0); // rcl RECTL
+        w.u32(0); // offDx
+        w.utf16(text); // the string at record offset 76
+      }),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(playEmf(file, m.ctx, 100, 100)).toBe(true);
+    const texts = m.calls.filter((c) => c.op === 'fillText');
+    expect(texts.length).toBe(1);
+    expect(texts[0].args[0]).toBe('F1');
+    expect(texts[0].args.slice(1)).toEqual([20, 30]); // identity WT, ×1 device
+    expect(m.styles.text.at(-1)?.toLowerCase()).toBe('#ff0000'); // red text color
+  });
+});
+
+// ── playEmf: robustness ──────────────────────────────────────────────────────
+
+describe('playEmf — robustness', () => {
+  it('returns false for non-EMF bytes', () => {
+    const m = makeRecordingCtx();
+    expect(playEmf(new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0, 0, 0, 0]), m.ctx, 10, 10)).toBe(
+      false,
+    );
+  });
+
+  it('stops gracefully on a record with a bogus (misaligned/too-small) size', () => {
+    const bad = concat(
+      emfHeader(0, 0, 10, 10),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(10).i32(10).u32(2).i16(0).i16(0).i16(5).i16(5),
+      ),
+      // a corrupt record: nSize = 4 (< 8) → must stop the loop, not throw.
+      new Writer().u32(EMR.POLYLINE16).u32(4).build(),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(() => playEmf(bad, m.ctx, 10, 10)).not.toThrow();
+    expect(m.calls.some((c) => c.op === 'stroke')).toBe(true);
+  });
+
+  it('skips unrecognized records by nSize without throwing', () => {
+    const file = concat(
+      emfHeader(0, 0, 10, 10),
+      // an unknown record type with arbitrary payload — must be skipped by nSize.
+      record(9999, (w) => w.u32(1).u32(2).u32(3)),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(10).i32(10).u32(2).i16(0).i16(0).i16(5).i16(5),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(() => playEmf(file, m.ctx, 10, 10)).not.toThrow();
+    expect(m.calls.some((c) => c.op === 'stroke')).toBe(true);
+  });
+});
+
+// ── renderEmfToBitmap: OffscreenCanvas wrapper (browser/worker only) ──────────
+
+describe('renderEmfToBitmap', () => {
+  beforeEach(() => {
+    // OffscreenCanvas + createImageBitmap don't exist in the node test env.
+    vi.stubGlobal(
+      'OffscreenCanvas',
+      class {
+        width: number;
+        height: number;
+        constructor(w: number, h: number) {
+          this.width = w;
+          this.height = h;
+        }
+        getContext() {
+          return {
+            fillStyle: '#000',
+            strokeStyle: '#000',
+            lineWidth: 1,
+            font: '10px sans-serif',
+            textAlign: 'left',
+            textBaseline: 'top',
+            lineJoin: 'miter',
+            lineCap: 'butt',
+            save() {},
+            restore() {},
+            beginPath() {},
+            closePath() {},
+            moveTo() {},
+            lineTo() {},
+            bezierCurveTo() {},
+            ellipse() {},
+            rect() {},
+            stroke() {},
+            fill() {},
+            fillText() {},
+          };
+        }
+      },
+    );
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(
+        async (src: { width: number; height: number }) =>
+          ({ width: src.width, height: src.height, close() {} }) as unknown as ImageBitmap,
+      ),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('rasterizes a minimal EMF to an ImageBitmap of the requested size', async () => {
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(100).i32(100).u32(2).i16(0).i16(0).i16(50).i16(50),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const bmp = await renderEmfToBitmap(file, 64, 48);
+    expect(bmp).not.toBeNull();
+    expect(bmp?.width).toBe(64);
+    expect(bmp?.height).toBe(48);
+  });
+
+  it('returns null for non-EMF bytes', async () => {
+    const bmp = await renderEmfToBitmap(new Uint8Array([1, 2, 3, 4]), 10, 10);
+    expect(bmp).toBeNull();
+  });
+
+  it('returns null when nothing draws (header + EOF only)', async () => {
+    const file = concat(emfHeader(0, 0, 10, 10), record(EMR.EOF, () => {}));
+    const bmp = await renderEmfToBitmap(file, 16, 16);
+    expect(bmp).toBeNull();
+  });
+
+  it('returns null for a non-positive target size', async () => {
+    const file = concat(emfHeader(0, 0, 10, 10), record(EMR.EOF, () => {}));
+    expect(await renderEmfToBitmap(file, 0, 10)).toBeNull();
+    expect(await renderEmfToBitmap(file, 10, 0)).toBeNull();
+  });
+});

--- a/packages/core/src/image/emf.ts
+++ b/packages/core/src/image/emf.ts
@@ -1,0 +1,1264 @@
+// ── EMF (Enhanced Metafile) player ───────────────────────────────────────────
+//
+// Browsers cannot decode EMF via `createImageBitmap`, so the renderer falls back
+// to this player for `.emf` blips — the EMF twin of {@link ./wmf.ts}. It is a
+// *minimal but spec-faithful* [MS-EMF] interpreter: enough to rasterize the
+// vector charts/diagrams Office embeds (e.g. sample-13.docx `word/media/
+// image3.emf` / `image4.emf`, which carry their bars/axes as POLYGON16 /
+// POLYLINE16 records and their labels as EXTTEXTOUTW text-out records, all
+// scaled by a long run of MODIFYWORLDTRANSFORM affines).
+//
+// Format reference: ECMA-376 references WMF/EMF; the byte layout below follows
+// the [MS-EMF] Enhanced Metafile Format spec.
+//   - File = a sequence of records, each `u32 iType, u32 nSize`, then nSize−8
+//     data bytes. nSize is 4-byte aligned; walk `offset += nSize`. The first
+//     record is EMR_HEADER (iType=1); the last is EMR_EOF (iType=14).
+//   - All values little-endian. COLORREF = u32 0x00BBGGRR (low byte = R), shared
+//     byte layout with WMF (we reuse {@link colorRefToCss}).
+//   - The world transform (EMR_SETWORLDTRANSFORM / EMR_MODIFYWORLDTRANSFORM,
+//     [MS-EMF] 2.3.12) is a 2×3 affine and does *all* scaling for these files
+//     (no SETWINDOW/VIEWPORT records, MM_TEXT default). Getting the affine
+//     multiply order right ([MS-EMF] 2.3.12: MWT_LEFTMULTIPLY ⇒ the supplied
+//     XFORM is the LEFT operand, `newWT = xform × WT`) is what makes
+//     bars/axes/labels land in the right place.
+//
+// Implemented records: HEADER, SETWORLDTRANSFORM, MODIFYWORLDTRANSFORM,
+// SAVEDC/RESTOREDC, SELECTOBJECT (incl. stock objects), DELETEOBJECT,
+// CREATEPEN, EXTCREATEPEN, CREATEBRUSHINDIRECT, CREATEMONOBRUSH /
+// CREATEDIBPATTERNBRUSHPT (→ average solid color), EXTCREATEFONTINDIRECTW,
+// POLYLINE16/POLYGON16/POLYBEZIER16/POLYLINETO16/POLYBEZIERTO16 (+ their 32-bit
+// twins), POLYPOLYGON16/POLYPOLYLINE16 (+ 32-bit twins), MOVETOEX, LINETO,
+// RECTANGLE, ELLIPSE, SETPOLYFILLMODE, EXTTEXTOUTW, SETTEXTCOLOR, SETTEXTALIGN,
+// SETBKMODE, BITBLT, STRETCHDIBITS (minimal DIB decoder), EOF.
+// Ignored (no-op, skipped by nSize): GDICOMMENT (may hold EMF+, out of scope),
+// SETICMMODE, SETMITERLIMIT, SETROP2, SETSTRETCHBLTMODE, INTERSECTCLIPRECT,
+// BEGINPATH/ENDPATH/SELECTCLIPPATH (clipping is ignored in v1 — [MS-EMF] clip
+// records), and any unrecognized iType.
+//
+// Shared across the docx, pptx and xlsx renderers via
+// {@link ./wmf.ts}#decodeRasterOrMetafile, which sniffs the bytes and routes
+// true EMF here.
+
+import { colorRefToCss, isEmf } from './wmf.js';
+
+// EMF record type codes ([MS-EMF] 2.1.1 EMR enumeration; the subset we act on,
+// others are skipped by nSize).
+const EMR = {
+  HEADER: 1,
+  POLYBEZIER: 2,
+  POLYGON: 3,
+  POLYLINE: 4,
+  POLYBEZIERTO: 5,
+  POLYLINETO: 6,
+  POLYPOLYLINE: 7,
+  POLYPOLYGON: 8,
+  EOF: 14,
+  SETPOLYFILLMODE: 19,
+  SETBKMODE: 18,
+  SETTEXTALIGN: 22,
+  SETTEXTCOLOR: 24,
+  MOVETOEX: 27,
+  SAVEDC: 33,
+  RESTOREDC: 34,
+  SETWORLDTRANSFORM: 35,
+  MODIFYWORLDTRANSFORM: 36,
+  SELECTOBJECT: 37,
+  CREATEPEN: 38,
+  CREATEBRUSHINDIRECT: 39,
+  DELETEOBJECT: 40,
+  ELLIPSE: 42,
+  RECTANGLE: 43,
+  LINETO: 54,
+  EXTCREATEFONTINDIRECTW: 82,
+  EXTTEXTOUTW: 84,
+  POLYBEZIER16: 85,
+  POLYGON16: 86,
+  POLYLINE16: 87,
+  POLYBEZIERTO16: 88,
+  POLYLINETO16: 89,
+  POLYPOLYLINE16: 90,
+  POLYPOLYGON16: 91,
+  CREATEMONOBRUSH: 93,
+  CREATEDIBPATTERNBRUSHPT: 94,
+  EXTCREATEPEN: 95,
+  BITBLT: 76,
+  STRETCHDIBITS: 81,
+} as const;
+
+// Stock object handle ids ([MS-EMF] 2.1.31 StockObject) — high bit 0x80000000
+// set in a SELECTOBJECT handle.
+const STOCK = {
+  WHITE_BRUSH: 0x80000000,
+  LTGRAY_BRUSH: 0x80000001,
+  GRAY_BRUSH: 0x80000002,
+  DKGRAY_BRUSH: 0x80000003,
+  BLACK_BRUSH: 0x80000004,
+  NULL_BRUSH: 0x80000005,
+  WHITE_PEN: 0x80000006,
+  BLACK_PEN: 0x80000007,
+  NULL_PEN: 0x80000008,
+  DC_BRUSH: 0x80000012,
+  DC_PEN: 0x8000000e,
+} as const;
+
+// ── color ─────────────────────────────────────────────────────────────────
+// COLORREF → CSS is shared with WMF (identical 0x00BBGGRR layout); imported as
+// `colorRefToCss`.
+
+// ── object table ─────────────────────────────────────────────────────────
+
+interface Pen {
+  kind: 'pen';
+  stroke: string | null; // null = PS_NULL (no stroke)
+  width: number; // logical width; mapped to device px via world+device scale
+}
+interface Brush {
+  kind: 'brush';
+  fill: string | null; // null = BS_NULL / hollow (no fill)
+}
+interface Font {
+  kind: 'font';
+  height: number; // |lfHeight|, logical units
+  weight: number; // lfWeight (400 normal, 700 bold)
+  italic: boolean;
+  face: string;
+}
+type EmfObject = Pen | Brush | Font;
+
+// ── 2×3 affine world transform ([MS-EMF] 2.2.28 XFORM) ──────────────────────
+
+interface Xform {
+  m11: number;
+  m12: number;
+  m21: number;
+  m22: number;
+  dx: number;
+  dy: number;
+}
+
+const identity = (): Xform => ({ m11: 1, m12: 0, m21: 0, m22: 1, dx: 0, dy: 0 });
+
+/**
+ * Affine product `A × B`, treating each 2×3 as a 3×3 with bottom row [0,0,1]
+ * ([MS-EMF] 2.3.12). For MWT_LEFTMULTIPLY the supplied XFORM is the LEFT
+ * operand (`newWT = xform × WT`); for MWT_RIGHTMULTIPLY it is the RIGHT operand.
+ */
+function mulXform(A: Xform, B: Xform): Xform {
+  return {
+    m11: A.m11 * B.m11 + A.m21 * B.m12,
+    m12: A.m12 * B.m11 + A.m22 * B.m12,
+    m21: A.m11 * B.m21 + A.m21 * B.m22,
+    m22: A.m12 * B.m21 + A.m22 * B.m22,
+    dx: A.m11 * B.dx + A.m21 * B.dy + A.dx,
+    dy: A.m12 * B.dx + A.m22 * B.dy + A.dy,
+  };
+}
+
+// ── little-endian cursor over a record's data region ────────────────────────
+//
+// EMF is 32-bit, so the primitives are i32/u32/f32 (plus i16 for POINTS).
+
+class EmfCursor {
+  private p: number;
+  constructor(
+    private readonly dv: DataView,
+    start: number,
+    private readonly end: number, // exclusive
+  ) {
+    this.p = start;
+  }
+  get pos(): number {
+    return this.p;
+  }
+  set pos(v: number) {
+    this.p = v;
+  }
+  get remaining(): number {
+    return this.end - this.p;
+  }
+  i16(): number {
+    const v = this.dv.getInt16(this.p, true);
+    this.p += 2;
+    return v;
+  }
+  i32(): number {
+    const v = this.dv.getInt32(this.p, true);
+    this.p += 4;
+    return v;
+  }
+  u32(): number {
+    const v = this.dv.getUint32(this.p, true);
+    this.p += 4;
+    return v;
+  }
+  f32(): number {
+    const v = this.dv.getFloat32(this.p, true);
+    this.p += 4;
+    return v;
+  }
+  /** Read a 2×3 XFORM (6×f32). */
+  xform(): Xform {
+    return {
+      m11: this.f32(),
+      m12: this.f32(),
+      m21: this.f32(),
+      m22: this.f32(),
+      dx: this.f32(),
+      dy: this.f32(),
+    };
+  }
+  skip(n: number): void {
+    this.p += n;
+  }
+}
+
+// ── any 2D context we can replay onto (Offscreen or HTMLCanvas) ─────────────
+
+type AnyCtx = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+interface PlayState {
+  ctx: AnyCtx;
+  W: number; // target raster width (px)
+  H: number; // target raster height (px)
+  // device extent from EMR_HEADER rclBounds ([MS-EMF] 2.2.9)
+  left: number;
+  top: number;
+  boundsW: number;
+  boundsH: number;
+  // GDI state
+  wt: Xform; // current world transform (logical → device)
+  objects: Map<number, EmfObject>; // indexed by ihObject
+  curPen: Pen | null;
+  curBrush: Brush | null;
+  curFont: Font | null;
+  textColor: string;
+  bkMode: number; // 1 = TRANSPARENT
+  textAlign: number;
+  fillRule: CanvasFillRule;
+  curX: number; // current position (logical)
+  curY: number;
+  stack: SavedDc[]; // SAVEDC/RESTOREDC graphics-state stack
+  drew: boolean;
+}
+
+/** Snapshot of the graphics state pushed by EMR_SAVEDC. */
+interface SavedDc {
+  wt: Xform;
+  curPen: Pen | null;
+  curBrush: Brush | null;
+  curFont: Font | null;
+  textColor: string;
+  bkMode: number;
+  textAlign: number;
+  fillRule: CanvasFillRule;
+  curX: number;
+  curY: number;
+}
+
+// ── coordinate pipeline ─────────────────────────────────────────────────────
+
+/** logical → device via world transform ([MS-EMF] 2.2.28):
+ *  `Xd = m11·Xl + m21·Yl + dx`, `Yd = m12·Xl + m22·Yl + dy`. */
+function worldX(s: PlayState, xl: number, yl: number): number {
+  return s.wt.m11 * xl + s.wt.m21 * yl + s.wt.dx;
+}
+function worldY(s: PlayState, xl: number, yl: number): number {
+  return s.wt.m12 * xl + s.wt.m22 * yl + s.wt.dy;
+}
+
+/** logical point → target px: world transform, then device→target
+ *  `px = (Xd − left)·W/boundsW`, `py = (Yd − top)·H/boundsH`. */
+function toPx(s: PlayState, xl: number, yl: number): [number, number] {
+  const Xd = worldX(s, xl, yl);
+  const Yd = worldY(s, xl, yl);
+  const px = ((Xd - s.left) * s.W) / s.boundsW;
+  const py = ((Yd - s.top) * s.H) / s.boundsH;
+  return [px, py];
+}
+
+/** Average world scale magnitude (column-vector lengths) — used to scale pen
+ *  width logically before the device→target scale. */
+function worldScale(s: PlayState): number {
+  const sx = Math.hypot(s.wt.m11, s.wt.m12);
+  const sy = Math.hypot(s.wt.m21, s.wt.m22);
+  return (sx + sy) / 2;
+}
+/** Average device→target scale (px per device unit). */
+function deviceScale(s: PlayState): number {
+  return (s.W / s.boundsW + s.H / s.boundsH) / 2;
+}
+/** Y-only world scale magnitude (Y column length) — for font px sizing. */
+function worldScaleY(s: PlayState): number {
+  return Math.hypot(s.wt.m21, s.wt.m22);
+}
+/** Y-only device→target scale — for font px sizing. */
+function deviceScaleY(s: PlayState): number {
+  return s.H / s.boundsH;
+}
+
+/** Device line width: scale the pen's logical width through world+device and
+ *  clamp to ≥0.75 so hairlines stay visible. */
+function deviceLineWidth(s: PlayState, logicalWidth: number): number {
+  const w = logicalWidth * worldScale(s) * deviceScale(s);
+  return Math.max(0.75, w);
+}
+
+// ── stock objects ([MS-EMF] 2.1.31) ─────────────────────────────────────────
+
+const STOCK_BRUSH: Record<number, Brush> = {
+  [STOCK.WHITE_BRUSH]: { kind: 'brush', fill: '#ffffff' },
+  [STOCK.LTGRAY_BRUSH]: { kind: 'brush', fill: '#c0c0c0' },
+  [STOCK.GRAY_BRUSH]: { kind: 'brush', fill: '#808080' },
+  [STOCK.DKGRAY_BRUSH]: { kind: 'brush', fill: '#404040' },
+  [STOCK.BLACK_BRUSH]: { kind: 'brush', fill: '#000000' },
+  [STOCK.NULL_BRUSH]: { kind: 'brush', fill: null },
+};
+const STOCK_PEN: Record<number, Pen> = {
+  [STOCK.WHITE_PEN]: { kind: 'pen', stroke: '#ffffff', width: 1 },
+  [STOCK.BLACK_PEN]: { kind: 'pen', stroke: '#000000', width: 1 },
+  [STOCK.NULL_PEN]: { kind: 'pen', stroke: null, width: 1 },
+  [STOCK.DC_PEN]: { kind: 'pen', stroke: '#000000', width: 1 },
+};
+
+/** Apply a stock-object handle to the current pen/brush. Unknown stock ids are
+ *  a no-op (leave current). */
+function selectStock(s: PlayState, handle: number): void {
+  const brush = STOCK_BRUSH[handle];
+  if (brush) {
+    s.curBrush = brush;
+    return;
+  }
+  const pen = STOCK_PEN[handle];
+  if (pen) {
+    s.curPen = pen;
+    return;
+  }
+  if (handle === STOCK.DC_BRUSH) {
+    // DC_BRUSH defaults to white; keep current if any, else fall back to black.
+    s.curBrush = s.curBrush ?? { kind: 'brush', fill: '#000000' };
+  }
+  // Anything else: no-op.
+}
+
+// ── DIB decoder ([MS-WMF] 2.2.2.9 DeviceIndependentBitmap, BITMAPINFOHEADER) ──
+
+interface DecodedDib {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray; // RGBA, top-down
+}
+
+/**
+ * Minimal DIB decoder: BITMAPINFOHEADER (40 bytes) + pixel data, supporting
+ * BI_RGB(0) at 32bpp (BGRA), 24bpp (BGR, 4-byte row padding) and 8bpp palette
+ * (RGBQUAD palette after the header). `bmiOff`/`bitsOff` are byte offsets into
+ * `dv`. Returns `null` for unsupported headers/compression.
+ */
+function decodeDib(
+  dv: DataView,
+  bmiOff: number,
+  bmiLen: number,
+  bitsOff: number,
+  bitsLen: number,
+): DecodedDib | null {
+  if (bmiLen < 40 || bmiOff + 40 > dv.byteLength) return null;
+  const biSize = dv.getUint32(bmiOff, true);
+  if (biSize < 40) return null; // only BITMAPINFOHEADER (or larger) supported
+  const biWidth = dv.getInt32(bmiOff + 4, true);
+  const biHeightRaw = dv.getInt32(bmiOff + 8, true);
+  const biBitCount = dv.getUint16(bmiOff + 14, true);
+  const biCompression = dv.getUint32(bmiOff + 16, true);
+  if (biCompression !== 0) return null; // BI_RGB only
+  const topDown = biHeightRaw < 0;
+  const width = Math.abs(biWidth);
+  const height = Math.abs(biHeightRaw);
+  if (width <= 0 || height <= 0 || width > 1 << 16 || height > 1 << 16) return null;
+
+  const out = new Uint8ClampedArray(width * height * 4);
+  const rowStride = (((width * biBitCount + 31) >> 5) << 2) >>> 0; // 4-byte aligned
+  if (bitsOff + rowStride * height > bitsOff + bitsLen + rowStride) {
+    // Tolerate slight over-read; only bail if obviously out of buffer.
+    if (bitsOff + rowStride * height > dv.byteLength) return null;
+  }
+
+  // Palette for ≤8bpp follows the header.
+  let palette: number[] | null = null;
+  if (biBitCount <= 8) {
+    let clrUsed = dv.getUint32(bmiOff + 32, true);
+    if (clrUsed === 0) clrUsed = 1 << biBitCount;
+    const palOff = bmiOff + biSize;
+    palette = [];
+    for (let i = 0; i < clrUsed; i++) {
+      const o = palOff + i * 4;
+      if (o + 4 > dv.byteLength) break;
+      const b = dv.getUint8(o);
+      const g = dv.getUint8(o + 1);
+      const r = dv.getUint8(o + 2);
+      palette.push((r << 16) | (g << 8) | b);
+    }
+  }
+
+  const putPx = (dstRow: number, x: number, r: number, g: number, b: number, a: number) => {
+    const di = (dstRow * width + x) * 4;
+    out[di] = r;
+    out[di + 1] = g;
+    out[di + 2] = b;
+    out[di + 3] = a;
+  };
+
+  let anyAlpha = false;
+  for (let y = 0; y < height; y++) {
+    const srcRow = topDown ? y : height - 1 - y; // bottom-up unless negative
+    const dstRow = y;
+    const rowOff = bitsOff + srcRow * rowStride;
+    if (rowOff + rowStride > dv.byteLength) break;
+    if (biBitCount === 32) {
+      for (let x = 0; x < width; x++) {
+        const o = rowOff + x * 4;
+        const b = dv.getUint8(o);
+        const g = dv.getUint8(o + 1);
+        const r = dv.getUint8(o + 2);
+        const a = dv.getUint8(o + 3);
+        if (a !== 0) anyAlpha = true;
+        putPx(dstRow, x, r, g, b, a);
+      }
+    } else if (biBitCount === 24) {
+      for (let x = 0; x < width; x++) {
+        const o = rowOff + x * 3;
+        putPx(dstRow, x, dv.getUint8(o + 2), dv.getUint8(o + 1), dv.getUint8(o), 255);
+      }
+      anyAlpha = true;
+    } else if (biBitCount === 8 && palette) {
+      for (let x = 0; x < width; x++) {
+        const idx = dv.getUint8(rowOff + x);
+        const c = palette[idx] ?? 0;
+        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
+      }
+      anyAlpha = true;
+    } else {
+      return null; // unsupported bit depth
+    }
+  }
+
+  // 32bpp DIBs frequently store alpha=0 throughout (the BITBLT raster-op carries
+  // opacity instead). Treat an all-zero alpha plane as fully opaque.
+  if (biBitCount === 32 && !anyAlpha) {
+    for (let i = 3; i < out.length; i += 4) out[i] = 255;
+  }
+  return { width, height, data: out };
+}
+
+/** Average RGB of a decoded DIB (skipping fully transparent pixels) → CSS. */
+function dibAverageColor(dib: DecodedDib): string {
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let n = 0;
+  for (let i = 0; i < dib.data.length; i += 4) {
+    if (dib.data[i + 3] === 0) continue;
+    r += dib.data[i];
+    g += dib.data[i + 1];
+    b += dib.data[i + 2];
+    n++;
+  }
+  if (n === 0) return '#808080';
+  const hex = (v: number) =>
+    Math.round(v / n)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+// ── point readers (16-bit vs 32-bit) ────────────────────────────────────────
+
+type PointReader = (c: EmfCursor) => [number, number];
+const readPoint16: PointReader = (c) => [c.i16(), c.i16()];
+const readPoint32: PointReader = (c) => [c.i32(), c.i32()];
+
+// ── poly drawing ────────────────────────────────────────────────────────────
+
+/** EMR_POLYLINE(16): open path stroked with the current pen. */
+function strokePolyline(s: PlayState, c: EmfCursor, rp: PointReader): void {
+  c.skip(16); // RECTL rclBounds — drawing uses world transform, not bounds
+  const count = c.u32();
+  if (count < 2 || count > 0x100000) return;
+  if (!s.curPen || s.curPen.stroke == null) {
+    // still drop current position to the last point for ...TO continuity callers
+    return;
+  }
+  const { ctx } = s;
+  ctx.beginPath();
+  let lx = 0;
+  let ly = 0;
+  for (let i = 0; i < count; i++) {
+    if (c.remaining < 4) break;
+    const [xl, yl] = rp(c);
+    const [px, py] = toPx(s, xl, yl);
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+    lx = xl;
+    ly = yl;
+  }
+  ctx.strokeStyle = s.curPen.stroke;
+  ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+  ctx.stroke();
+  s.drew = true;
+  s.curX = lx;
+  s.curY = ly;
+}
+
+/** EMR_POLYLINETO(16): like POLYLINE but the implicit first point is the
+ *  current position; updates current position. */
+function strokePolylineTo(s: PlayState, c: EmfCursor, rp: PointReader): void {
+  c.skip(16);
+  const count = c.u32();
+  if (count < 1 || count > 0x100000) return;
+  const { ctx } = s;
+  const draw = s.curPen != null && s.curPen.stroke != null;
+  if (draw) {
+    ctx.beginPath();
+    const [px0, py0] = toPx(s, s.curX, s.curY);
+    ctx.moveTo(px0, py0);
+  }
+  for (let i = 0; i < count; i++) {
+    if (c.remaining < 4) break;
+    const [xl, yl] = rp(c);
+    if (draw) {
+      const [px, py] = toPx(s, xl, yl);
+      ctx.lineTo(px, py);
+    }
+    s.curX = xl;
+    s.curY = yl;
+  }
+  if (draw && s.curPen) {
+    ctx.strokeStyle = s.curPen.stroke as string;
+    ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+    ctx.stroke();
+    s.drew = true;
+  }
+}
+
+/** EMR_POLYGON(16): closed path filled (brush) + stroked (pen). */
+function fillStrokePolygon(s: PlayState, c: EmfCursor, rp: PointReader): void {
+  c.skip(16);
+  const count = c.u32();
+  if (count < 2 || count > 0x100000) return;
+  const { ctx } = s;
+  ctx.beginPath();
+  let started = false;
+  for (let i = 0; i < count; i++) {
+    if (c.remaining < 4) break;
+    const [xl, yl] = rp(c);
+    const [px, py] = toPx(s, xl, yl);
+    if (!started) {
+      ctx.moveTo(px, py);
+      started = true;
+    } else ctx.lineTo(px, py);
+  }
+  if (!started) return;
+  ctx.closePath();
+  if (s.curBrush && s.curBrush.fill != null) {
+    ctx.fillStyle = s.curBrush.fill;
+    ctx.fill(s.fillRule);
+    s.drew = true;
+  }
+  if (s.curPen && s.curPen.stroke != null) {
+    ctx.strokeStyle = s.curPen.stroke;
+    ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+    ctx.stroke();
+    s.drew = true;
+  }
+}
+
+/** EMR_POLYBEZIER(16) / ...TO: cubic Bézier — start (or current pos for the
+ *  ...TO variant), then triples of (control, control, end). Stroked open. */
+function strokePolyBezier(
+  s: PlayState,
+  c: EmfCursor,
+  rp: PointReader,
+  isTo: boolean,
+): void {
+  c.skip(16);
+  const count = c.u32();
+  if (count < 1 || count > 0x100000) return;
+  const pts: Array<[number, number]> = [];
+  for (let i = 0; i < count; i++) {
+    if (c.remaining < 4) break;
+    pts.push(rp(c));
+  }
+  if (pts.length < (isTo ? 3 : 4)) {
+    if (pts.length) {
+      s.curX = pts[pts.length - 1][0];
+      s.curY = pts[pts.length - 1][1];
+    }
+    return;
+  }
+  const draw = s.curPen != null && s.curPen.stroke != null;
+  const { ctx } = s;
+  if (draw) {
+    ctx.beginPath();
+    const start = isTo ? toPx(s, s.curX, s.curY) : toPx(s, pts[0][0], pts[0][1]);
+    ctx.moveTo(start[0], start[1]);
+  }
+  let i = isTo ? 0 : 1;
+  for (; i + 2 < pts.length + (isTo ? 1 : 0); i += 3) {
+    const c1 = pts[i];
+    const c2 = pts[i + 1];
+    const end = pts[i + 2];
+    if (!c1 || !c2 || !end) break;
+    if (draw) {
+      const p1 = toPx(s, c1[0], c1[1]);
+      const p2 = toPx(s, c2[0], c2[1]);
+      const pe = toPx(s, end[0], end[1]);
+      ctx.bezierCurveTo(p1[0], p1[1], p2[0], p2[1], pe[0], pe[1]);
+    }
+    s.curX = end[0];
+    s.curY = end[1];
+  }
+  if (draw && s.curPen) {
+    ctx.strokeStyle = s.curPen.stroke as string;
+    ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+    ctx.stroke();
+    s.drew = true;
+  }
+}
+
+/** EMR_POLYPOLYGON(16) / POLYPOLYLINE(16): one path spanning all sub-polys so
+ *  the fill rule resolves holes correctly. Polygon variant fills+strokes;
+ *  polyline variant only strokes. */
+function fillStrokePolyPoly(
+  s: PlayState,
+  c: EmfCursor,
+  rp: PointReader,
+  isPolygon: boolean,
+): void {
+  c.skip(16); // RECTL rclBounds
+  const numPolys = c.u32();
+  const totalPoints = c.u32();
+  if (numPolys <= 0 || numPolys > 0x10000) return;
+  if (totalPoints <= 0 || totalPoints > 0x200000) return;
+  const counts: number[] = [];
+  for (let i = 0; i < numPolys; i++) {
+    if (c.remaining < 4) return;
+    counts.push(c.u32());
+  }
+  const { ctx } = s;
+  ctx.beginPath();
+  let any = false;
+  for (const cnt of counts) {
+    if (cnt < 2) {
+      for (let i = 0; i < cnt && c.remaining >= 4; i++) rp(c);
+      continue;
+    }
+    for (let i = 0; i < cnt; i++) {
+      if (c.remaining < 4) break;
+      const [xl, yl] = rp(c);
+      const [px, py] = toPx(s, xl, yl);
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    if (isPolygon) ctx.closePath();
+    any = true;
+  }
+  if (!any) return;
+  if (isPolygon && s.curBrush && s.curBrush.fill != null) {
+    ctx.fillStyle = s.curBrush.fill;
+    ctx.fill(s.fillRule);
+    s.drew = true;
+  }
+  if (s.curPen && s.curPen.stroke != null) {
+    ctx.strokeStyle = s.curPen.stroke;
+    ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+    ctx.stroke();
+    s.drew = true;
+  }
+}
+
+/** Fill+stroke an axis-aligned rectangle (EMR_RECTANGLE) given logical corners. */
+function fillStrokeRect(s: PlayState, l: number, t: number, r: number, b: number): void {
+  const { ctx } = s;
+  const c0 = toPx(s, l, t);
+  const c1 = toPx(s, r, t);
+  const c2 = toPx(s, r, b);
+  const c3 = toPx(s, l, b);
+  ctx.beginPath();
+  ctx.moveTo(c0[0], c0[1]);
+  ctx.lineTo(c1[0], c1[1]);
+  ctx.lineTo(c2[0], c2[1]);
+  ctx.lineTo(c3[0], c3[1]);
+  ctx.closePath();
+  if (s.curBrush && s.curBrush.fill != null) {
+    ctx.fillStyle = s.curBrush.fill;
+    ctx.fill(s.fillRule);
+    s.drew = true;
+  }
+  if (s.curPen && s.curPen.stroke != null) {
+    ctx.strokeStyle = s.curPen.stroke;
+    ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+    ctx.stroke();
+    s.drew = true;
+  }
+}
+
+// ── object creators ──────────────────────────────────────────────────────────
+
+/** EMR_CREATEPEN(38): u32 ihObject + LOGPEN{u32 style, POINTL width, COLORREF}. */
+function readCreatePen(c: EmfCursor): [number, Pen] {
+  const ih = c.u32();
+  const style = c.u32();
+  const widthX = c.i32();
+  c.i32(); // POINTL.y (unused)
+  const color = c.u32();
+  const stroke = (style & 0xff) === 5 ? null : colorRefToCss(color); // PS_NULL=5
+  return [ih, { kind: 'pen', stroke, width: Math.abs(widthX) }];
+}
+
+/** EMR_EXTCREATEPEN(95): u32 ihObject, 4×u32 offsets, then ELP {u32 style,
+ *  u32 width, u32 brushStyle, COLORREF color, ...}. */
+function readExtCreatePen(c: EmfCursor): [number, Pen] {
+  const ih = c.u32();
+  c.skip(16); // offBmi, cbBmi, offBits, cbBits
+  const style = c.u32();
+  const width = c.u32();
+  c.u32(); // brushStyle
+  const color = c.u32();
+  const stroke = (style & 0xff) === 5 ? null : colorRefToCss(color); // PS_NULL=5
+  return [ih, { kind: 'pen', stroke, width: Math.abs(width) }];
+}
+
+/** EMR_CREATEBRUSHINDIRECT(39): u32 ihObject + LOGBRUSH{u32 style, COLORREF,
+ *  u32 hatch}. */
+function readCreateBrush(c: EmfCursor): [number, Brush] {
+  const ih = c.u32();
+  const style = c.u32();
+  const color = c.u32();
+  c.u32(); // hatch (HATCHED → solid)
+  const fill = style === 1 ? null : colorRefToCss(color); // BS_NULL=1
+  return [ih, { kind: 'brush', fill }];
+}
+
+/**
+ * EMR_CREATEMONOBRUSH(93) / EMR_CREATEDIBPATTERNBRUSHPT(94): u32 ihObject,
+ * u32 iUsage, u32 offBmi, u32 cbBmi, u32 offBits, u32 cbBits, then a DIB.
+ *
+ * APPROXIMATION: DIB pattern brush ([MS-EMF] 2.3.7) rendered as its average
+ * solid color pending true pattern-brush support. If DIB decode fails, fall
+ * back to mid-gray so bars still show.
+ */
+function readDibPatternBrush(c: EmfCursor, dv: DataView, recStart: number): [number, Brush] {
+  const ih = c.u32();
+  c.u32(); // iUsage
+  const offBmi = c.u32();
+  const cbBmi = c.u32();
+  const offBits = c.u32();
+  const cbBits = c.u32();
+  let fill = '#808080';
+  try {
+    const dib = decodeDib(dv, recStart + offBmi, cbBmi, recStart + offBits, cbBits);
+    if (dib) fill = dibAverageColor(dib);
+  } catch {
+    /* keep mid-gray fallback */
+  }
+  return [ih, { kind: 'brush', fill }];
+}
+
+/** EMR_EXTCREATEFONTINDIRECTW(82): u32 ihObject + LOGFONT (lfHeight,…,lfFaceName
+ *  UTF-16 at LOGFONT offset 28). */
+function readCreateFont(c: EmfCursor, dv: DataView, recStart: number): [number, Font] {
+  const ih = c.u32();
+  const lfBase = recStart + 12; // ihObject (4) after the 8-byte record header
+  const lfHeight = dv.getInt32(lfBase, true);
+  // lfWidth(4), lfEscapement(8), lfOrientation(12)
+  const lfWeight = dv.getInt32(lfBase + 16, true);
+  const lfItalic = dv.getUint8(lfBase + 20);
+  // lfFaceName: UTF-16, up to 32 code units, at LOGFONT offset 28.
+  let face = '';
+  for (let i = 0; i < 32; i++) {
+    const o = lfBase + 28 + i * 2;
+    if (o + 2 > dv.byteLength) break;
+    const cu = dv.getUint16(o, true);
+    if (cu === 0) break;
+    face += String.fromCharCode(cu);
+  }
+  return [
+    ih,
+    {
+      kind: 'font',
+      height: Math.abs(lfHeight),
+      weight: lfWeight,
+      italic: lfItalic !== 0,
+      face,
+    },
+  ];
+}
+
+// ── text — EMR_EXTTEXTOUTW(84) ([MS-EMF] 2.3.5.2) ────────────────────────────
+
+function drawText(s: PlayState, c: EmfCursor, dv: DataView, recStart: number): void {
+  c.skip(16); // RECTL rclBounds (record offset 8..24)
+  c.u32(); // iGraphicsMode
+  c.f32(); // exScale
+  c.f32(); // eyScale
+  // EMRTEXT at record offset 36:
+  const refX = c.i32();
+  const refY = c.i32();
+  const nChars = c.u32();
+  const offString = c.u32(); // BYTE offset from RECORD START to UTF-16 string
+  c.u32(); // fOptions
+  if (nChars <= 0 || nChars > 0x10000) return;
+  // Read nChars UTF-16LE code units at recStart + offString.
+  let str = '';
+  for (let i = 0; i < nChars; i++) {
+    const o = recStart + offString + i * 2;
+    if (o + 2 > dv.byteLength) break;
+    str += String.fromCharCode(dv.getUint16(o, true));
+  }
+  if (str.length === 0) return;
+
+  const font = s.curFont;
+  const px = Math.abs(font?.height ?? 0) * worldScaleY(s) * deviceScaleY(s);
+  if (!Number.isFinite(px) || px < 1) return;
+
+  const { ctx } = s;
+  const [dx, dy] = toPx(s, refX, refY);
+  ctx.fillStyle = s.textColor;
+  const weight = font && font.weight >= 700 ? 'bold ' : '';
+  const italic = font?.italic ? 'italic ' : '';
+  ctx.font = `${italic}${weight}${px}px ${font?.face || 'sans-serif'}`;
+
+  // SETTEXTALIGN: low 2 bits horizontal. TA_LEFT(0), TA_RIGHT(2), TA_CENTER(6).
+  const horiz = s.textAlign & 0x6;
+  ctx.textAlign = horiz === 0x2 ? 'right' : horiz === 0x6 ? 'center' : 'left';
+  // TA_BASELINE(0x18) → alphabetic; else top.
+  ctx.textBaseline = (s.textAlign & 0x18) === 0x18 ? 'alphabetic' : 'top';
+  // bkMode TRANSPARENT(1): never paint a background box (always the case here).
+  try {
+    ctx.fillText(str, dx, dy);
+    s.drew = true;
+  } catch {
+    // Some ctx mocks lack fillText; a missing fillText must not abort the render.
+  }
+}
+
+// ── bitmaps — EMR_BITBLT(76) / EMR_STRETCHDIBITS(81) ([MS-EMF] 2.3.1) ─────────
+
+/** Decode a DIB and blit it into the dest rect (logical corners mapped via
+ *  toPx). Skips gracefully on unsupported DIBs or missing OffscreenCanvas. */
+function blitDib(
+  s: PlayState,
+  dv: DataView,
+  recStart: number,
+  offBmi: number,
+  cbBmi: number,
+  offBits: number,
+  cbBits: number,
+  destL: number,
+  destT: number,
+  destR: number,
+  destB: number,
+): void {
+  if (cbBmi === 0 || cbBits === 0) return; // pattern-only blt → skip
+  try {
+    const dib = decodeDib(dv, recStart + offBmi, cbBmi, recStart + offBits, cbBits);
+    if (!dib) return;
+    if (typeof OffscreenCanvas === 'undefined') return;
+    const tmp = new OffscreenCanvas(dib.width, dib.height);
+    const tctx = tmp.getContext('2d') as OffscreenCanvasRenderingContext2D | null;
+    if (!tctx) return;
+    // Allocate via createImageData (avoids the ImageData-constructor typed-array
+    // overload mismatch) and copy the decoded RGBA in.
+    const imgData = tctx.createImageData(dib.width, dib.height) as ImageData;
+    imgData.data.set(dib.data);
+    tctx.putImageData(imgData, 0, 0);
+    const [x0, y0] = toPx(s, destL, destT);
+    const [x1, y1] = toPx(s, destR, destB);
+    s.ctx.drawImage(tmp, x0, y0, x1 - x0, y1 - y0);
+    s.drew = true;
+  } catch {
+    // Unsupported / missing image API → skip the blit, keep rendering.
+  }
+}
+
+/** EMR_BITBLT(76) ([MS-EMF] 2.3.1.2). */
+function doBitBlt(s: PlayState, c: EmfCursor, dv: DataView, recStart: number): void {
+  c.skip(16); // RECTL rclBounds
+  const xDest = c.i32();
+  const yDest = c.i32();
+  const cxDest = c.i32();
+  const cyDest = c.i32();
+  c.u32(); // bitBltRasterOp
+  c.i32(); // xSrc
+  c.i32(); // ySrc
+  c.skip(24); // XFORM xformSrc (6×f32)
+  c.u32(); // bkColorSrc
+  c.u32(); // usageSrc
+  const offBmi = c.u32();
+  const cbBmi = c.u32();
+  const offBits = c.u32();
+  const cbBits = c.u32();
+  blitDib(
+    s, dv, recStart, offBmi, cbBmi, offBits, cbBits,
+    xDest, yDest, xDest + cxDest, yDest + cyDest,
+  );
+}
+
+/** EMR_STRETCHDIBITS(81) ([MS-EMF] 2.3.1.7). */
+function doStretchDibits(s: PlayState, c: EmfCursor, dv: DataView, recStart: number): void {
+  c.skip(16); // RECTL rclBounds
+  const xDest = c.i32();
+  const yDest = c.i32();
+  c.i32(); // xSrc
+  c.i32(); // ySrc
+  c.i32(); // cxSrc
+  c.i32(); // cySrc
+  const offBmi = c.u32();
+  const cbBmi = c.u32();
+  const offBits = c.u32();
+  const cbBits = c.u32();
+  c.u32(); // usageSrc
+  c.u32(); // bitBltRasterOp
+  const cxDest = c.i32();
+  const cyDest = c.i32();
+  blitDib(
+    s, dv, recStart, offBmi, cbBmi, offBits, cbBits,
+    xDest, yDest, xDest + cxDest, yDest + cyDest,
+  );
+}
+
+// ── core record-replay loop (pure; testable with a mock ctx) ────────────────
+
+/**
+ * Replay an EMF byte buffer onto a 2D context, mapping logical coordinates
+ * through the world transform and then into a `W`×`H` target raster. Returns
+ * `true` if anything was drawn, `false` for a non-EMF buffer or a metafile that
+ * produced no geometry.
+ *
+ * Pure with respect to the injected `ctx`, so it is unit-testable against a
+ * recording mock — no OffscreenCanvas required (the only exception is the
+ * optional BITBLT/STRETCHDIBITS path, which needs a temp OffscreenCanvas and is
+ * skipped gracefully when absent).
+ */
+export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): boolean {
+  if (!isEmf(bytes)) return false;
+  if (W <= 0 || H <= 0) return false;
+
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  const s: PlayState = {
+    ctx,
+    W,
+    H,
+    left: 0,
+    top: 0,
+    boundsW: W,
+    boundsH: H,
+    wt: identity(),
+    objects: new Map(),
+    curPen: null,
+    curBrush: null,
+    curFont: null,
+    textColor: '#000000',
+    bkMode: 1,
+    textAlign: 0,
+    fillRule: 'nonzero',
+    curX: 0,
+    curY: 0,
+    stack: [],
+    drew: false,
+  };
+
+  let pos = 0;
+  while (pos + 8 <= bytes.length) {
+    const iType = dv.getUint32(pos, true);
+    const nSize = dv.getUint32(pos + 4, true);
+    // Validate: nSize ≥ 8 (the iType+nSize header) and 4-aligned and in-bounds.
+    if (nSize < 8 || (nSize & 3) !== 0) break;
+    const recEnd = pos + nSize;
+    if (recEnd > bytes.length) break; // truncated → partial render
+    if (iType === EMR.EOF) break;
+
+    // A cursor over the data region (starts at record offset 8).
+    const c = new EmfCursor(dv, pos + 8, recEnd);
+
+    // Never throw on a malformed record — just advance by nSize.
+    try {
+      switch (iType) {
+        case EMR.HEADER: {
+          // RECTL rclBounds @ data offset 8 (= record offset 16), then rclFrame.
+          const left = dv.getInt32(pos + 8, true);
+          const top = dv.getInt32(pos + 12, true);
+          const right = dv.getInt32(pos + 16, true);
+          const bottom = dv.getInt32(pos + 20, true);
+          s.left = left;
+          s.top = top;
+          s.boundsW = Math.max(1, right - left);
+          s.boundsH = Math.max(1, bottom - top);
+          break;
+        }
+        case EMR.SETWORLDTRANSFORM: {
+          s.wt = c.xform();
+          break;
+        }
+        case EMR.MODIFYWORLDTRANSFORM: {
+          const x = c.xform();
+          const iMode = c.u32();
+          // [MS-EMF] 2.3.12: 1=IDENTITY, 2=LEFTMULTIPLY (xform × WT),
+          // 3=RIGHTMULTIPLY (WT × xform), 4=SET.
+          if (iMode === 1) s.wt = identity();
+          else if (iMode === 2) s.wt = mulXform(x, s.wt);
+          else if (iMode === 3) s.wt = mulXform(s.wt, x);
+          else if (iMode === 4) s.wt = x;
+          break;
+        }
+        case EMR.SAVEDC: {
+          s.stack.push({
+            wt: { ...s.wt },
+            curPen: s.curPen,
+            curBrush: s.curBrush,
+            curFont: s.curFont,
+            textColor: s.textColor,
+            bkMode: s.bkMode,
+            textAlign: s.textAlign,
+            fillRule: s.fillRule,
+            curX: s.curX,
+            curY: s.curY,
+          });
+          break;
+        }
+        case EMR.RESTOREDC: {
+          // data: i32 iRelative (e.g. -1 = pop one). Pop |iRelative| times,
+          // clamped to the stack size.
+          const iRelative = c.i32();
+          const times = Math.min(Math.abs(iRelative) || 1, s.stack.length);
+          let saved: SavedDc | undefined;
+          for (let i = 0; i < times; i++) saved = s.stack.pop();
+          if (saved) {
+            s.wt = saved.wt;
+            s.curPen = saved.curPen;
+            s.curBrush = saved.curBrush;
+            s.curFont = saved.curFont;
+            s.textColor = saved.textColor;
+            s.bkMode = saved.bkMode;
+            s.textAlign = saved.textAlign;
+            s.fillRule = saved.fillRule;
+            s.curX = saved.curX;
+            s.curY = saved.curY;
+          }
+          break;
+        }
+        case EMR.SELECTOBJECT: {
+          const ih = c.u32();
+          if ((ih & 0x80000000) !== 0) {
+            selectStock(s, ih >>> 0);
+          } else {
+            const obj = s.objects.get(ih);
+            if (obj?.kind === 'pen') s.curPen = obj;
+            else if (obj?.kind === 'brush') s.curBrush = obj;
+            else if (obj?.kind === 'font') s.curFont = obj;
+          }
+          break;
+        }
+        case EMR.DELETEOBJECT: {
+          const ih = c.u32();
+          const obj = s.objects.get(ih);
+          if (obj) {
+            if (obj === s.curPen) s.curPen = null;
+            if (obj === s.curBrush) s.curBrush = null;
+            if (obj === s.curFont) s.curFont = null;
+            s.objects.delete(ih);
+          }
+          break;
+        }
+        case EMR.CREATEPEN: {
+          const [ih, pen] = readCreatePen(c);
+          s.objects.set(ih, pen);
+          break;
+        }
+        case EMR.EXTCREATEPEN: {
+          const [ih, pen] = readExtCreatePen(c);
+          s.objects.set(ih, pen);
+          break;
+        }
+        case EMR.CREATEBRUSHINDIRECT: {
+          const [ih, brush] = readCreateBrush(c);
+          s.objects.set(ih, brush);
+          break;
+        }
+        case EMR.CREATEMONOBRUSH:
+        case EMR.CREATEDIBPATTERNBRUSHPT: {
+          const [ih, brush] = readDibPatternBrush(c, dv, pos);
+          s.objects.set(ih, brush);
+          break;
+        }
+        case EMR.EXTCREATEFONTINDIRECTW: {
+          const [ih, font] = readCreateFont(c, dv, pos);
+          s.objects.set(ih, font);
+          break;
+        }
+        case EMR.POLYLINE16:
+          strokePolyline(s, c, readPoint16);
+          break;
+        case EMR.POLYLINE:
+          strokePolyline(s, c, readPoint32);
+          break;
+        case EMR.POLYLINETO16:
+          strokePolylineTo(s, c, readPoint16);
+          break;
+        case EMR.POLYLINETO:
+          strokePolylineTo(s, c, readPoint32);
+          break;
+        case EMR.POLYGON16:
+          fillStrokePolygon(s, c, readPoint16);
+          break;
+        case EMR.POLYGON:
+          fillStrokePolygon(s, c, readPoint32);
+          break;
+        case EMR.POLYBEZIER16:
+          strokePolyBezier(s, c, readPoint16, false);
+          break;
+        case EMR.POLYBEZIER:
+          strokePolyBezier(s, c, readPoint32, false);
+          break;
+        case EMR.POLYBEZIERTO16:
+          strokePolyBezier(s, c, readPoint16, true);
+          break;
+        case EMR.POLYBEZIERTO:
+          strokePolyBezier(s, c, readPoint32, true);
+          break;
+        case EMR.POLYPOLYGON16:
+          fillStrokePolyPoly(s, c, readPoint16, true);
+          break;
+        case EMR.POLYPOLYGON:
+          fillStrokePolyPoly(s, c, readPoint32, true);
+          break;
+        case EMR.POLYPOLYLINE16:
+          fillStrokePolyPoly(s, c, readPoint16, false);
+          break;
+        case EMR.POLYPOLYLINE:
+          fillStrokePolyPoly(s, c, readPoint32, false);
+          break;
+        case EMR.MOVETOEX: {
+          s.curX = c.i32();
+          s.curY = c.i32();
+          break;
+        }
+        case EMR.LINETO: {
+          const xl = c.i32();
+          const yl = c.i32();
+          if (s.curPen && s.curPen.stroke != null) {
+            const [px0, py0] = toPx(s, s.curX, s.curY);
+            const [px1, py1] = toPx(s, xl, yl);
+            ctx.beginPath();
+            ctx.moveTo(px0, py0);
+            ctx.lineTo(px1, py1);
+            ctx.strokeStyle = s.curPen.stroke;
+            ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+            ctx.stroke();
+            s.drew = true;
+          }
+          s.curX = xl;
+          s.curY = yl;
+          break;
+        }
+        case EMR.RECTANGLE: {
+          const left = c.i32();
+          const top = c.i32();
+          const right = c.i32();
+          const bottom = c.i32();
+          fillStrokeRect(s, left, top, right, bottom);
+          break;
+        }
+        case EMR.ELLIPSE: {
+          const left = c.i32();
+          const top = c.i32();
+          const right = c.i32();
+          const bottom = c.i32();
+          const [cxl, cyl] = [(left + right) / 2, (top + bottom) / 2];
+          const [cx, cy] = toPx(s, cxl, cyl);
+          const [ex] = toPx(s, right, cyl);
+          const [, ey] = toPx(s, cxl, bottom);
+          const rx = Math.abs(ex - cx);
+          const ry = Math.abs(ey - cy);
+          ctx.beginPath();
+          ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2);
+          if (s.curBrush && s.curBrush.fill != null) {
+            ctx.fillStyle = s.curBrush.fill;
+            ctx.fill(s.fillRule);
+            s.drew = true;
+          }
+          if (s.curPen && s.curPen.stroke != null) {
+            ctx.strokeStyle = s.curPen.stroke;
+            ctx.lineWidth = deviceLineWidth(s, s.curPen.width);
+            ctx.stroke();
+            s.drew = true;
+          }
+          break;
+        }
+        case EMR.SETPOLYFILLMODE: {
+          const mode = c.u32(); // 1=ALTERNATE→evenodd, 2=WINDING→nonzero
+          s.fillRule = mode === 1 ? 'evenodd' : 'nonzero';
+          break;
+        }
+        case EMR.SETTEXTCOLOR: {
+          s.textColor = colorRefToCss(c.u32());
+          break;
+        }
+        case EMR.SETTEXTALIGN: {
+          s.textAlign = c.u32();
+          break;
+        }
+        case EMR.SETBKMODE: {
+          s.bkMode = c.u32(); // 1 = TRANSPARENT
+          break;
+        }
+        case EMR.EXTTEXTOUTW:
+          drawText(s, c, dv, pos);
+          break;
+        case EMR.BITBLT:
+          doBitBlt(s, c, dv, pos);
+          break;
+        case EMR.STRETCHDIBITS:
+          doStretchDibits(s, c, dv, pos);
+          break;
+        default:
+          // GDICOMMENT (may hold EMF+, out of scope), SETICMMODE,
+          // SETMITERLIMIT, SETROP2, SETSTRETCHBLTMODE, INTERSECTCLIPRECT,
+          // BEGINPATH/ENDPATH/SELECTCLIPPATH (clipping ignored in v1 — [MS-EMF]
+          // clip records), and any unrecognized iType: skip by nSize.
+          break;
+      }
+    } catch {
+      // A malformed record must never abort the whole render — just advance.
+    }
+
+    pos = recEnd;
+  }
+
+  return s.drew;
+}
+
+// ── async OffscreenCanvas wrapper ───────────────────────────────────────────
+
+/**
+ * Rasterize an EMF metafile to an `ImageBitmap` of `targetW`×`targetH`, replaying
+ * onto an `OffscreenCanvas` 2D context. Returns `null` if the bytes are not a
+ * parseable EMF or nothing drew (so the caller can fall back to the existing
+ * "missing image" behavior without crashing). Mirrors
+ * {@link ./wmf.ts}#renderWmfToBitmap.
+ */
+export async function renderEmfToBitmap(
+  bytes: Uint8Array,
+  targetW: number,
+  targetH: number,
+): Promise<ImageBitmap | null> {
+  if (!isEmf(bytes)) return null;
+  if (targetW <= 0 || targetH <= 0) return null;
+  const canvas = new OffscreenCanvas(targetW, targetH);
+  const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D | null;
+  if (!ctx) return null;
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+  const drew = playEmf(bytes, ctx, targetW, targetH);
+  if (!drew) return null;
+  return createImageBitmap(canvas);
+}

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -28,6 +28,12 @@
 // `suppressBoundaryFrame` option (default OFF = spec-clean, draws every edge).
 // docx will opt IN (`suppressBoundaryFrame: true`) when it re-points to core
 // (deferred), to preserve its current behavior.
+//
+// True EMF (a separate, larger 32-bit format — see {@link isEmf}) is rasterized
+// by the sibling player {@link ./emf.ts}#renderEmfToBitmap, routed from
+// {@link decodeRasterOrMetafile}.
+
+import { renderEmfToBitmap } from './emf.js';
 
 // WMF record function codes (the subset we act on; others are skipped by size).
 const META = {
@@ -76,8 +82,8 @@ export function isWmf(bytes: Uint8Array): boolean {
 }
 
 /** True for a true EMF (ENHMETAHEADER): u32@0 == 1 (EMR_HEADER) AND u32@40 ==
- *  0x464D4520 (" EMF"). True EMF is a different, larger format than WMF.
- *  TODO: EMF (ECMA-376 references it too) is a separate format — follow-up. */
+ *  0x464D4520 (" EMF"). True EMF is a different, larger 32-bit format than WMF;
+ *  it is rasterized by the sibling player {@link ./emf.ts}#renderEmfToBitmap. */
 export function isEmf(bytes: Uint8Array): boolean {
   if (bytes.length < 44) return false;
   const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
@@ -86,8 +92,9 @@ export function isEmf(bytes: Uint8Array): boolean {
 
 // ── color ─────────────────────────────────────────────────────────────────
 
-/** COLORREF (u32 0x00BBGGRR) → CSS `#rrggbb`. */
-function colorRefToCss(c: number): string {
+/** COLORREF (u32 0x00BBGGRR) → CSS `#rrggbb`. Shared with the EMF player
+ *  ({@link ./emf.ts}); COLORREF has the same byte layout in [MS-EMF]. */
+export function colorRefToCss(c: number): string {
   const r = c & 0xff;
   const g = (c >>> 8) & 0xff;
   const b = (c >>> 16) & 0xff;
@@ -630,8 +637,9 @@ export interface DecodeRasterOptions {
  *   - {@link isWmf} → rasterize via {@link renderWmfToBitmap} at
  *     {@link wmfRasterTarget}(widthPt, heightPt). A WMF that produces no geometry
  *     returns `null`.
- *   - {@link isEmf} → return `null` (true EMF is a separate, larger format than
- *     WMF; a follow-up). The caller skips the image, as for any null bitmap.
+ *   - {@link isEmf} → rasterize via {@link ./emf.ts}#renderEmfToBitmap at
+ *     {@link wmfRasterTarget}(widthPt, heightPt). An EMF that produces no
+ *     geometry returns `null`.
  *   - otherwise → `createImageBitmap(blob)` (PNG/JPEG/GIF/BMP/WEBP…).
  *
  * Returns `null` (never throws on an unsupported metafile) so every caller can
@@ -653,9 +661,8 @@ export async function decodeRasterOrMetafile(
     return renderWmfToBitmap(bytes, w, h, suppressBoundaryFrame);
   }
   if (isEmf(bytes)) {
-    // EMF is a separate, larger format than WMF — follow-up. Skip gracefully
-    // (drop → caller's "missing image" / null-bitmap behavior, no crash).
-    return null;
+    const { w, h } = wmfRasterTarget(widthPt, heightPt);
+    return renderEmfToBitmap(bytes, w, h);
   }
   return createImageBitmap(data);
 }

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1189,6 +1189,7 @@ fn parse_section(
         footer_distance: 36.0,
         title_page: false,
         even_and_odd_headers: false,
+        section_start: None,
         doc_grid_type: None,
         doc_grid_line_pitch: None,
         doc_grid_char_space: None,
@@ -1229,6 +1230,10 @@ fn parse_section(
         }
     }
     props.title_page = child_w(sp, "titlePg").is_some();
+    // ECMA-376 §17.6.22 — the body (final) section's start type. Non-final
+    // sections carry their start type on their own SectionBreak marker; the
+    // paginator needs the final section's here to resolve the boundary INTO it.
+    props.section_start = read_section_break_type(sp);
 
     // ECMA-376 §17.6.5 w:docGrid. When @type=lines|linesAndChars with a
     // linePitch, Word renders each line of text at intervals of linePitch
@@ -7642,6 +7647,26 @@ mod column_tests {
         let (props, _) = parse_section(Some(doc.root_element()), &rel_map);
         let cols = props.columns.expect("columns surfaced on SectionProps");
         assert_eq!(cols.count, 2);
+    }
+
+    /// ECMA-376 §17.6.22 — the body (final) section's `<w:type>` start type is
+    /// surfaced on SectionProps so the paginator can resolve the boundary INTO the
+    /// final section (a "continuous" body section must not page-break). Absent ⇒
+    /// None (the renderer defaults to the spec's "nextPage").
+    #[test]
+    fn section_props_carries_section_start() {
+        let parse = |sect: &str| {
+            let xml = format!(r#"<w:sectPr xmlns:w="{ns}">{sect}</w:sectPr>"#, ns = W_NS);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let rel_map: HashMap<String, String> = HashMap::new();
+            parse_section(Some(doc.root_element()), &rel_map).0
+        };
+        assert_eq!(
+            parse(r#"<w:type w:val="continuous"/><w:cols w:num="2"/>"#).section_start,
+            Some("continuous".to_string())
+        );
+        // Absent <w:type> ⇒ None (paginator falls back to "nextPage").
+        assert_eq!(parse(r#"<w:cols w:num="2"/>"#).section_start, None);
     }
 
     /// ECMA-376 §17.6.5 `<w:docGrid w:charSpace>` surfaces on SectionProps as a

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2430,12 +2430,46 @@ fn resolve_blip_urls(
     Some((image_path, mime, svg_image_path))
 }
 
+/// ECMA-376 §20.1.8.55 — parse the optional `<a:srcRect>` that sits next to the
+/// `<a:blip>` inside a `<pic:blipFill>`. `blip` is the resolved `<a:blip>` node;
+/// its parent is the `blipFill`, whose `<a:srcRect>` child (if any) carries the
+/// crop. The raw `l/t/r/b` attributes are ST_Percentage in 1000ths of a percent
+/// (e.g. `l="8827"` ⇒ 8.827%); we convert to fractions 0..1 (÷100000) so the
+/// renderer can crop in bitmap pixels without unit knowledge. Returns `None`
+/// when the element is absent OR all four insets are zero (an explicit
+/// `<a:srcRect/>` with no attributes ⇒ no crop).
+fn parse_src_rect(blip: roxmltree::Node) -> Option<SrcRect> {
+    let blip_fill = blip.parent()?;
+    let sr = blip_fill
+        .children()
+        .find(|n| n.tag_name().name() == "srcRect")?;
+    let pct = |name: &str| -> f64 {
+        sr.attribute(name)
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 100000.0
+    };
+    let rect = SrcRect {
+        l: pct("l"),
+        t: pct("t"),
+        r: pct("r"),
+        b: pct("b"),
+    };
+    if rect.l == 0.0 && rect.t == 0.0 && rect.r == 0.0 && rect.b == 0.0 {
+        None
+    } else {
+        Some(rect)
+    }
+}
+
 /// A resolved inline/anchored picture: the drawable source(s) plus the natural
 /// draw size read from `<wp:extent>` (ECMA-376 §20.4.2.7), in points.
 struct InlineBlip {
     image_path: String,
     mime_type: String,
     svg_image_path: Option<String>,
+    /// ECMA-376 §20.1.8.55 `<a:srcRect>` crop (fractions 0..1), or `None`.
+    src_rect: Option<SrcRect>,
     width_pt: f64,
     height_pt: f64,
 }
@@ -2462,6 +2496,7 @@ fn resolve_inline_blip(
 ) -> Option<InlineBlip> {
     let blip = node.descendants().find(|n| n.tag_name().name() == "blip")?;
     let (image_path, mime_type, svg_image_path) = resolve_blip_urls(blip, media_map)?;
+    let src_rect = parse_src_rect(blip);
     let extent = node
         .descendants()
         .find(|n| n.tag_name().name() == "extent")?;
@@ -2471,6 +2506,7 @@ fn resolve_inline_blip(
         image_path,
         mime_type,
         svg_image_path,
+        src_rect,
         width_pt: cx / 12700.0,
         height_pt: cy / 12700.0,
     })
@@ -2498,6 +2534,7 @@ fn parse_inline_drawing(
             image_path,
             mime_type,
             svg_image_path,
+            src_rect,
             width_pt,
             height_pt,
         } = match resolve_inline_blip(container, media_map) {
@@ -2508,6 +2545,7 @@ fn parse_inline_drawing(
             image_path,
             mime_type,
             svg_image_path,
+            src_rect,
             width_pt,
             height_pt,
             anchor: false,
@@ -2646,6 +2684,7 @@ fn parse_inline_drawing(
         image_path,
         mime_type,
         svg_image_path,
+        src_rect,
         width_pt,
         height_pt,
     } = match resolve_inline_blip(container, media_map) {
@@ -2656,6 +2695,7 @@ fn parse_inline_drawing(
         image_path,
         mime_type,
         svg_image_path,
+        src_rect,
         width_pt,
         height_pt,
         anchor: true,
@@ -3063,6 +3103,9 @@ fn parse_group_pic(
     // original, keep the raster as the `image_path` fallback, and never drop an
     // svg-only picture.
     let (image_path, mime_type, svg_image_path) = resolve_blip_urls(blip, media_map)?;
+    // ECMA-376 §20.1.8.55 — source-rectangle crop (sibling of <a:blip> under
+    // <pic:blipFill>), shared with the inline/anchor paths.
+    let src_rect = parse_src_rect(blip);
 
     // Parse a:clrChange if present — used to make a specific color transparent.
     // clrFrom specifies the source color; clrTo with alpha=0 means replace with transparent.
@@ -3077,6 +3120,7 @@ fn parse_group_pic(
         image_path,
         mime_type,
         svg_image_path,
+        src_rect,
         width_pt: cx * xform.scale_x / 12700.0,
         height_pt: cy * xform.scale_y / 12700.0,
         anchor: true,
@@ -3738,6 +3782,10 @@ fn extract_simple_paragraph_text(
             ),
             None => (None, None, None, 0.0, 0.0),
         };
+    // NOTE: ShapeText (VML/txbx inline image) does not yet carry a srcRect crop;
+    // `resolve_inline_blip` parses one but it is unused on this path. Word's
+    // text-box pictures in practice do not use <a:srcRect>, so this is a known
+    // gap rather than a regression (the field exists on ImageRun only).
 
     // Drop a paragraph that is neither text nor image; keep image-only ones.
     if text.is_empty() && image_path.is_none() {
@@ -7110,6 +7158,7 @@ mod svg_blip_tests {
             image_path: "word/media/image1.png".to_string(),
             mime_type: "image/png".to_string(),
             svg_image_path: Some("word/media/image2.svg".to_string()),
+            src_rect: None,
             width_pt: 24.0,
             height_pt: 24.0,
             anchor: false,
@@ -7276,6 +7325,92 @@ mod svg_blip_tests {
             Some("word/media/image2.svg"),
             "svg_image_path must carry the vector original"
         );
+    }
+
+    /// Find the single `ImageRun` produced by parsing a body built with
+    /// `build_docx_with_media` (scoped to this test module).
+    fn only_image(doc: &Document) -> &ImageRun {
+        doc.body
+            .iter()
+            .find_map(|el| match el {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Image(im) => Some(im),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("expected one inline image")
+    }
+
+    /// ECMA-376 §20.1.8.55 — an inline picture whose `<pic:blipFill>` carries a
+    /// non-zero `<a:srcRect>` populates `ImageRun.src_rect` with the four insets
+    /// converted from ST_Percentage (1000ths of a percent) to fractions 0..1.
+    /// Mirrors sample-13 Fig.2's left-slice crop `l="8827" t="5949" r="64210"
+    /// b="65916"` ⇒ 0.08827 / 0.05949 / 0.64210 / 0.65916.
+    #[test]
+    fn inline_drawing_src_rect_populates_fractions() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill>
+          <a:blip r:embed="rIdPng"/>
+          <a:srcRect l="8827" t="5949" r="64210" b="65916"/>
+          <a:stretch><a:fillRect/></a:stretch>
+        </pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx_with_media(body);
+        let doc = parse(&data).expect("parse must succeed");
+        let img = only_image(&doc);
+        let sr = img
+            .src_rect
+            .as_ref()
+            .expect("a non-zero <a:srcRect> must populate src_rect");
+        assert!((sr.l - 0.08827).abs() < 1e-9, "l={}", sr.l);
+        assert!((sr.t - 0.05949).abs() < 1e-9, "t={}", sr.t);
+        assert!((sr.r - 0.64210).abs() < 1e-9, "r={}", sr.r);
+        assert!((sr.b - 0.65916).abs() < 1e-9, "b={}", sr.b);
+    }
+
+    /// An absent `<a:srcRect>` (and the explicit all-zero `<a:srcRect/>` Word
+    /// emits for an uncropped picture) both leave `src_rect` as `None` — the
+    /// renderer then draws the full bitmap.
+    #[test]
+    fn inline_drawing_no_or_zero_src_rect_is_none() {
+        for srcrect in [
+            "",
+            "<a:srcRect/>",
+            r#"<a:srcRect l="0" t="0" r="0" b="0"/>"#,
+        ] {
+            let body = format!(
+                r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill><a:blip r:embed="rIdPng"/>{srcrect}<a:stretch/></pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#
+            );
+            let data = build_docx_with_media(&body);
+            let doc = parse(&data).expect("parse must succeed");
+            let img = only_image(&doc);
+            assert!(
+                img.src_rect.is_none(),
+                "srcRect={srcrect:?} must yield None, got {:?}",
+                img.src_rect
+            );
+        }
     }
 
     /// Regression for the `PathCmd::ArcTo` serde naming bug (mirrors pptx #489).

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -143,7 +143,23 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
         .rfind(|n| n.is_element())
         .filter(|n| n.tag_name().name() == "sectPr");
 
-    let (section, refs) = parse_section(sect_pr, &rel_map);
+    let (section, _body_refs) = parse_section(sect_pr, &rel_map);
+
+    // ECMA-376 §17.10.1 — header/footer references inherit across sections: a
+    // section that omits a reference of a given type uses the previous section's.
+    // The single-section render model (#513) drives one effective header/footer
+    // set, so accumulate references from EVERY sectPr in document order (the body
+    // sectPr last ⇒ it wins for types it specifies, earlier sections fill the
+    // rest). Without this, a header declared only on the first section's sectPr
+    // (e.g. sample-12's running "Journal of …" header) is dropped because the
+    // body-level sectPr carries no reference.
+    let mut refs = SectionRefs::default();
+    for sp in body_node
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "sectPr")
+    {
+        merge_section_refs(sp, &rel_map, &mut refs);
+    }
 
     let body = parse_body_elements(
         body_node,
@@ -1270,8 +1286,26 @@ fn parse_section(
     // (unchanged behavior).
     props.columns = parse_columns(sp);
 
-    // Collect header/footer references
+    // Collect header/footer references from THIS sectPr.
     let mut refs = SectionRefs::default();
+    merge_section_refs(sp, rel_map, &mut refs);
+
+    (props, refs)
+}
+
+/// Merge the `<w:headerReference>` / `<w:footerReference>` entries of one sectPr
+/// into `refs`, per ECMA-376 §17.10.1. Each type ("default" | "first" | "even")
+/// overwrites any prior value — so calling this over every sectPr in document
+/// order accumulates the inheritance (a section that omits a reference of a type
+/// keeps the previous section's), and the body (final) section wins for the
+/// types it specifies. This is why a header declared only on the FIRST section's
+/// sectPr (the common journal-template layout) still applies to the whole
+/// document even though the body-level sectPr carries no reference.
+fn merge_section_refs(
+    sp: roxmltree::Node,
+    rel_map: &HashMap<String, String>,
+    refs: &mut SectionRefs,
+) {
     for child in sp.children().filter(|n| n.is_element()) {
         let local = child.tag_name().name();
         if local != "headerReference" && local != "footerReference" {
@@ -1293,8 +1327,6 @@ fn parse_section(
             refs.footers.insert(kind, target);
         }
     }
-
-    (props, refs)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -7667,6 +7699,44 @@ mod column_tests {
         );
         // Absent <w:type> ⇒ None (paginator falls back to "nextPage").
         assert_eq!(parse(r#"<w:cols w:num="2"/>"#).section_start, None);
+    }
+
+    /// ECMA-376 §17.10.1 — header/footer references inherit across sections.
+    /// `merge_section_refs` accumulates per type with later sectPrs overriding,
+    /// so a reference declared only on the FIRST section's sectPr survives even
+    /// when a later (body) sectPr carries none. This is sample-12's running
+    /// "Journal of …" header, declared on section 0 but not on the body sectPr.
+    #[test]
+    fn header_refs_inherit_from_an_earlier_section() {
+        let xml = r#"<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <w:first><w:sectPr><w:headerReference w:type="default" r:id="rH"/><w:footerReference w:type="default" r:id="rF"/></w:sectPr></w:first>
+              <w:bodylevel><w:sectPr><w:cols w:num="2"/></w:sectPr></w:bodylevel>
+            </w:root>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let rel_map: HashMap<String, String> = [
+            ("rH".to_string(), "header1.xml".to_string()),
+            ("rF".to_string(), "footer1.xml".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let mut refs = SectionRefs::default();
+        for sp in doc
+            .root_element()
+            .descendants()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sectPr")
+        {
+            merge_section_refs(sp, &rel_map, &mut refs);
+        }
+        // The first section's default header/footer survive the body sectPr that
+        // declares none.
+        assert_eq!(
+            refs.headers.get("default").map(String::as_str),
+            Some("header1.xml")
+        );
+        assert_eq!(
+            refs.footers.get("default").map(String::as_str),
+            Some("footer1.xml")
+        );
     }
 
     /// ECMA-376 §17.6.5 `<w:docGrid w:charSpace>` surfaces on SectionProps as a

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -158,6 +158,14 @@ pub struct SectionProps {
     pub title_page: bool,
     /// whether even pages have distinct header/footer
     pub even_and_odd_headers: bool,
+    /// ECMA-376 §17.6.22 ST_SectionMark — the body (final) section's `<w:type>`
+    /// start type ("continuous" | "nextPage" | "oddPage" | "evenPage"). Governs
+    /// how the last section begins relative to the previous one; the paginator
+    /// consumes it at the boundary INTO the final section (non-final sections
+    /// carry their start type on their own `SectionBreak` marker). `None` ⇒
+    /// "nextPage" (the spec default).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section_start: Option<String>,
     /// ECMA-376 §17.6.5 w:docGrid/@w:type ("default" | "lines" |
     /// "linesAndChars" | "snapToChars"). None = default.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1064,6 +1064,22 @@ pub struct ShapeText {
     pub image_height_pt: f64,
 }
 
+/// ECMA-376 §20.1.8.55 `<a:srcRect>` — the source rectangle that selects which
+/// region of the blip's bitmap is drawn (the rest is cropped away). The four
+/// attributes are ST_Percentage insets expressed here as FRACTIONS 0..1 of the
+/// source bitmap, measured inward from each edge: `l`/`t` from the left/top,
+/// `r`/`b` from the right/bottom. The visible source rectangle is therefore
+/// `[l, t, 1−r, 1−b]` of the bitmap. The parser converts the raw 1000ths-of-a-
+/// percent attribute values to fractions (÷100000) so the renderer needs no
+/// unit knowledge. An absent `<a:srcRect>` (or one that is all-zero) ⇒ `None`.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct SrcRect {
+    pub l: f64,
+    pub t: f64,
+    pub r: f64,
+    pub b: f64,
+}
+
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageRun {
@@ -1081,6 +1097,10 @@ pub struct ImageRun {
     /// Its MIME is always `image/svg+xml` and is owned by the SVG decoder.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub svg_image_path: Option<String>,
+    /// ECMA-376 §20.1.8.55 `<a:srcRect>` source-rectangle crop, as fractions
+    /// 0..1 of the decoded bitmap. `None` when absent or all-zero (no crop).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src_rect: Option<SrcRect>,
     /// pt
     pub width_pt: f64,
     /// pt

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -460,24 +460,44 @@ describe('computePages — per-section columns (§17.6.4, regression)', () => {
   });
 
   it('a continuous section break keeps both single-column sections on the SAME page, stacked', () => {
-    // Section A (1 para) — continuous → Section B (1 para) on the same page; final
-    // 2-col section gets a nextPage break. Both A and B are single-column full width
-    // and must NOT reset to the page top (B stacks below A).
+    // ECMA-376 §17.6.22: a section's `<w:type>` describes how THAT section begins
+    // relative to the previous one, and lives on the sectPr that ENDS the section
+    // (the NEXT marker in document order). So the A→B break is governed by section
+    // B's type — the kind of the marker that ENDS B (idx 3) — and the B→final break
+    // by the final (body) section's start type. Here B is continuous (stacks below
+    // A on page 1) and the final 2-col section is nextPage (default) → page 2. Both
+    // A and B are single-column full width and must NOT reset to the page top.
     const body: BodyElement[] = [
       para({ text: 'A', fontSize: 20 }),
-      sectionBreak('continuous', null),
+      sectionBreak('continuous', null), // ends section A (A's own start type)
       para({ text: 'B', fontSize: 20 }),
-      sectionBreak('nextPage', null),
+      sectionBreak('continuous', null), // ends section B ⇒ B begins continuously (A→B same page)
       para({ text: 'final', fontSize: 20 }),
     ];
     const pages = computePages(body, finalTwoCol(), makeCtx());
     expect(pages.length).toBe(2);
-    // A and B share page 1 (continuous), final on page 2.
+    // A and B share page 1 (B continuous), final on page 2 (final section nextPage).
     expect(pages[0].map(textOf)).toEqual(['A', 'B']);
     expect(pages[1].map(textOf)).toEqual(['final']);
     for (const el of pages[0]) {
       expect(colGeomOf(el)).toEqual([{ xPt: 20, wPt: 160 }]);
     }
+  });
+
+  it('the break INTO a section is governed by that section start type, not the prior marker (§17.6.22)', () => {
+    // Regression for the off-by-one: a title section whose own sectPr is nextPage
+    // (the spec default) followed by a continuous body section must NOT page-break —
+    // the boundary is governed by the FOLLOWING (body) section's start type. Mirrors
+    // sample-13, where Word keeps the 2-col body on the title page.
+    const body: BodyElement[] = [
+      para({ text: 'title', fontSize: 20 }),
+      sectionBreak('nextPage', null), // ends the title section (its own start type)
+      para({ text: 'body', fontSize: 20 }),
+    ];
+    const sec = { ...finalTwoCol(), columns: null, sectionStart: 'continuous' };
+    const pages = computePages(body, sec, makeCtx());
+    expect(pages.length).toBe(1);
+    expect(pages[0].map(textOf)).toEqual(['title', 'body']);
   });
 
   it('single-section 2-col docs are UNCHANGED (no SectionBreak markers ⇒ whole body uses section.columns)', () => {

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -518,3 +518,39 @@ describe('computePages — per-section columns (§17.6.4, regression)', () => {
     }
   });
 });
+
+describe('computePages — newspaper column balancing (§17.6.4, non-final continuous sections)', () => {
+  const twoColSpec = { count: 2, spacePt: 20, equalWidth: true, sep: false, cols: [] };
+
+  it('balances a SHORT non-final 2-col section across both columns (not greedy col0)', () => {
+    // section(): content height 100, content width 160, 2-col ⇒ col width 70.
+    // 6 single-line paras × 20px = 120px total. Balanced = 60px/col = 3 paras each.
+    // Greedy (the bug) would put 5 in col0 (fills to 100px) and 1 in col1.
+    // The 2-col section ENDS with a continuous break ⇒ non-final ⇒ balanced.
+    const body: BodyElement[] = [
+      ...Array.from({ length: 6 }, (_, i) => para({ text: `p${i}`, fontSize: 20 })),
+      sectionBreak('continuous', twoColSpec),
+      para({ text: 'after', fontSize: 20 }),
+    ];
+    const pages = computePages(body, section(), makeCtx()); // final section = 1-col
+    const colByText: Record<string, number | undefined> = {};
+    for (const e of pages[0]) {
+      const t = textOf(e);
+      if (t.startsWith('p')) colByText[t] = colOf(e);
+    }
+    // Balanced: p0–p2 in col0, p3–p5 in col1.
+    expect([colByText.p0, colByText.p1, colByText.p2]).toEqual([0, 0, 0]);
+    expect([colByText.p3, colByText.p4, colByText.p5]).toEqual([1, 1, 1]);
+  });
+
+  it('does NOT balance the FINAL (body) section — it fills col0 greedily', () => {
+    // Same 6 paras, but now the 2-col geometry is the body-level (final) section
+    // with NO terminating break. Word leaves the final section greedy (the user's
+    // observation: the last page packs the left column). Greedy: col0 holds 5
+    // (100px), col1 holds 1.
+    const body: BodyElement[] = Array.from({ length: 6 }, (_, i) => para({ text: `p${i}`, fontSize: 20 }));
+    const pages = computePages(body, section({ columns: twoColSpec }), makeCtx());
+    const col0 = pages[0].filter((e) => colOf(e) === 0).map(textOf);
+    expect(col0).toEqual(['p0', 'p1', 'p2', 'p3', 'p4']); // greedy fill, NOT balanced
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4855,14 +4855,38 @@ function layoutLines(
         }
       }
     } else if (currentLine.length === 0) {
-      // Nothing on the line yet and no CJK break — force-fit (word wider than column)
-      s.measuredWidth = w;
-      addToLine(s, w, h, asc, desc);
+      // A single non-CJK word wider than the FULL line width — e.g. a long URL in
+      // a narrow newspaper column. ECMA-376 prescribes no line-break algorithm;
+      // Word breaks such an over-long word at the character level (overflow-wrap)
+      // so it stays inside the column instead of bleeding past the right margin /
+      // into the next column. Fit the widest character prefix (≥1 char so the
+      // split always advances), draw it, and re-queue the remainder. Segments are
+      // already one space-delimited word (splitTextForLayout), so this never
+      // breaks where a space could have wrapped.
+      const available = availW();
+      ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
+      const allChars = [...s.text];
+      let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, gridDeltaPx)].length : 0;
+      if (split < 1) split = 1;
+      if (split >= allChars.length) {
+        // The visible glyphs actually fit (only a trailing space pushed it over the
+        // fit test) — place the word whole.
+        s.measuredWidth = w;
+        addToLine(s, w, h, asc, desc);
+      } else {
+        const prefix = allChars.slice(0, split).join('');
+        const pw = strAdvance(s, prefix);
+        addToLine({ ...s, text: prefix, measuredWidth: pw }, pw, h, asc, desc);
+        queue.unshift({ ...s, text: allChars.slice(split).join(''), measuredWidth: 0 });
+      }
     } else {
-      // Latin word wrap: flush and put this word on the next line
+      // Latin word does not fit on the current (non-empty) line: move it to a fresh
+      // line and re-process. There it either fits, or — when it is wider than the
+      // whole column — the empty-line branch above breaks it at the character level
+      // (overflow-wrap). Re-queueing rather than force-adding is what lets that
+      // over-long-word path run instead of letting the word spill the column.
       flush();
-      s.measuredWidth = w;
-      addToLine(s, w, h, asc, desc);
+      queue.unshift(s);
     }
   }
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1053,6 +1053,26 @@ export function computePages(
     return computeColumns(section);
   };
 
+  // ECMA-376 §17.6.22 (ST_SectionMark): a section's `<w:type>` specifies how
+  // THAT section begins relative to the previous one (continuous ⇒ same page;
+  // nextPage/odd/even ⇒ a new page). The type lives on the section's OWN sectPr,
+  // which the parser stamps on the SectionBreak marker that ENDS that section.
+  // So the break at a boundary is governed by the UPCOMING section's type — the
+  // kind of the NEXT marker at/after `startIdx`, exactly like sectionColumnsFrom
+  // resolves the upcoming section's columns. (A marker's own kind is the start
+  // type of the section it closes — relevant at the PREVIOUS boundary, not this
+  // one. Using it here is an off-by-one that turns e.g. a title section's
+  // type="nextPage" into a spurious page break before a following
+  // type="continuous" body section.) The last section (no following marker) uses
+  // the body sectPr's start type; absent ⇒ "nextPage" (the spec default).
+  const sectionKindFrom = (startIdx: number): string => {
+    for (let j = startIdx; j < body.length; j++) {
+      const e = body[j];
+      if (e.type === 'sectionBreak') return e.kind ?? 'nextPage';
+    }
+    return section.sectionStart ?? 'nextPage';
+  };
+
   // The active section's column geometry. Reassigned (a) here for the first
   // section and (b) at every `SectionBreak` as the flow enters the next section.
   // `colIndex` tracks which column we are filling; `colX()`/`colW()` give its
@@ -1329,7 +1349,10 @@ export function computePages(
       // columns instead of every section inheriting the body-level section's.
       columns = sectionColumnsFrom(i + 1);
       colIndex = 0;
-      if (el.kind === 'continuous') {
+      // The break is governed by the UPCOMING section's start type (§17.6.22),
+      // not this marker's own kind (the section it closes). See sectionKindFrom.
+      const upcomingKind = sectionKindFrom(i + 1);
+      if (upcomingKind === 'continuous') {
         // ECMA-376 §17.18.79 "continuous": NO page break — the next section's
         // content continues on the SAME page. It must start below the BOTTOM of
         // EVERY column of the section just ended (ECMA-376 §17.6.4), not at the
@@ -1365,10 +1388,10 @@ export function computePages(
         // (the sectionBreak itself emits nothing on the new page).
         prescanFloatsFrom(i + 1);
         startPageBookkeeping();
-        if (el.kind === 'oddPage' && pages.length % 2 === 0) {
+        if (upcomingKind === 'oddPage' && pages.length % 2 === 0) {
           pages.push([]);
           startPageBookkeeping();
-        } else if (el.kind === 'evenPage' && pages.length % 2 === 1) {
+        } else if (upcomingKind === 'evenPage' && pages.length % 2 === 1) {
           pages.push([]);
           startPageBookkeeping();
         }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1098,6 +1098,16 @@ export function computePages(
   // single-section / single-column document `colTopY` stays 0 — behaviour-neutral.
   let colTopY = 0;
   let maxColBottomY = 0;
+  // ECMA-376 §17.6.4 — newspaper column BALANCING target (content-relative pt per
+  // column) for the CURRENT section, or null when the section fills greedily.
+  // Word balances a continuous multi-column section that does NOT fill its page —
+  // its content is split so all columns end at roughly the same height — but
+  // leaves the FINAL (body) section greedy (it packs column 0 first). `balanceColH`
+  // is the per-column height target; a non-last column breaks to the next column
+  // once it reaches it (see maybeBalanceBreak). null ⇒ greedy fill to the page
+  // bottom (single-column sections, the final section, or a section taller than
+  // one page).
+  let balanceColH: number | null = null;
   // Page-absolute pt of the current region top, stamped on elements so the paint
   // pass resets a column's cursor to the region top (front-loaded layout: the
   // renderer consumes this instead of independently deciding the column top).
@@ -1184,9 +1194,12 @@ export function computePages(
       pages.push([]);
       y = 0;
       colIndex = 0;
-      // A fresh page: the section's columns span it from the content top.
+      // A fresh page: the section's columns span it from the content top. A
+      // section that reaches a new page is multi-page ⇒ fill the new page greedily
+      // (balancing only applies to a section that fits within its current page).
       colTopY = 0;
       maxColBottomY = 0;
+      balanceColH = null;
       prevPara = null;
       prevSpaceAfter = 0;
       measureState.y = section.marginTop;
@@ -1223,6 +1236,75 @@ export function computePages(
     if (colIndex < columns.length - 1) nextColumn();
     else newPage(pageStartIdx);
   };
+
+  // ECMA-376 §17.6.4 newspaper column balancing. Measure the single-column
+  // content height (pt) of the section STARTING at `startIdx` — up to the next
+  // section/page break — and whether a break terminates it. Uses a throwaway
+  // clone of the measure state so the live cursor / floats are untouched. Mirrors
+  // the per-element height the main loop computes (estimateParagraphHeight /
+  // computeTableRowHeights at the column width, with paragraph spacing collapse),
+  // but is an APPROXIMATION: line-level page splitting and floats are ignored,
+  // which is fine for deciding a balance target. Returns `Infinity` when the
+  // section can't be balanced as one block (an inner page break).
+  const measureSectionColumnHeight = (
+    startIdx: number,
+    colWPt: number,
+  ): { height: number; terminated: boolean } => {
+    const ms: RenderState = { ...measureState, y: section.marginTop, floats: [], floatParaSeq: 0 };
+    let total = 0;
+    let prevAfter = 0;
+    let prevP: DocParagraph | null = null;
+    let terminated = false;
+    for (let j = startIdx; j < body.length; j++) {
+      const e = body[j];
+      if (e.type === 'sectionBreak' || e.type === 'pageBreak') { terminated = true; break; }
+      if (e.type === 'columnBreak') continue;
+      if (e.type === 'paragraph') {
+        const p = e as unknown as DocParagraph;
+        if (p.pageBreakBefore) return { height: Infinity, terminated: false };
+        if (p.framePr) continue; // frame is out of flow (adds no column height)
+        const suppress = contextualSuppressed(prevP, p);
+        const before = suppress ? 0 : p.spaceBefore;
+        total += estimateParagraphHeight(ms, p, colWPt, suppress, 0) - Math.min(prevAfter, before);
+        prevAfter = p.spaceAfter;
+        prevP = p;
+      } else if (e.type === 'table') {
+        const t = e as unknown as DocTable;
+        if (t.tblpPr) continue; // floating table: out of flow
+        total += computeTableRowHeights(ms, t, colWPt).reduce((s, x) => s + x, 0);
+        prevAfter = 0;
+        prevP = null;
+      }
+    }
+    return { height: total, terminated };
+  };
+
+  // Configure balancing for the section starting at `startIdx`. Word balances a
+  // continuous multi-column section that does NOT fill its page (its content is
+  // split so the columns end at roughly equal heights), but leaves greedy: a
+  // single-column section, the FINAL (unterminated) section — Word packs column 0
+  // there, matching the journal templates' last page — and any section taller
+  // than the space available across its columns on this page.
+  const setupBalancing = (startIdx: number): void => {
+    balanceColH = null;
+    const ncols = columns.length;
+    if (ncols < 2) return;
+    const { height, terminated } = measureSectionColumnHeight(startIdx, columns[0].wPt);
+    if (!terminated || !Number.isFinite(height)) return; // final / page-breaking ⇒ greedy
+    const avail = effContentH() - colTopY;
+    if (avail <= 0 || height > ncols * avail) return; // spills past one page ⇒ greedy
+    balanceColH = height / ncols;
+  };
+
+  // True when a whole element of height `fitH` should move to the next column to
+  // keep a balanced section's columns even: balancing is active, the current
+  // column is not the last (the last absorbs the remainder), it already holds
+  // content, and the element would push it past the balanced target.
+  const wantsBalanceBreak = (fitH: number): boolean =>
+    balanceColH != null &&
+    colIndex < columns.length - 1 &&
+    y > colTopY &&
+    y + fitH > colTopY + balanceColH;
 
   // A paragraph-anchored floating object (wp:anchor with positionV
   // relativeFrom="paragraph"/"line", ECMA-376 §20.4.3.4) is positioned by its
@@ -1304,6 +1386,12 @@ export function computePages(
     pages[pages.length - 1].push(el);
   };
 
+  // Balance the FIRST section's columns if it is a non-final multi-column section
+  // that fits on page 1 (§17.6.4). Single-column / multi-page / final first
+  // sections leave `balanceColH` null (greedy), so this is behaviour-neutral for
+  // the common single-section document.
+  setupBalancing(0);
+
   for (let i = 0; i < body.length; i++) {
     const el = body[i];
     if (el.type === 'columnBreak') {
@@ -1320,6 +1408,7 @@ export function computePages(
       y = 0;
       colTopY = 0;
       maxColBottomY = 0;
+      balanceColH = null;
       prevPara = null;
       prevSpaceAfter = 0;
       measureState.y = section.marginTop;
@@ -1371,6 +1460,10 @@ export function computePages(
         maxColBottomY = regionBottom;
         prevPara = null;
         prevSpaceAfter = 0;
+        // ECMA-376 §17.6.4: balance this continuous section's columns if it fits
+        // on the current page below `regionBottom` (Word balances non-final
+        // continuous multi-column sections; the final section stays greedy).
+        setupBalancing(i + 1);
       } else {
         // nextPage (default) / oddPage / evenPage: start a new page (mirrors the
         // pageBreak path, including parity padding). A new page already resets
@@ -1379,6 +1472,7 @@ export function computePages(
         y = 0;
         colTopY = 0;
         maxColBottomY = 0;
+        balanceColH = null;
         prevPara = null;
         prevSpaceAfter = 0;
         measureState.y = section.marginTop;
@@ -1388,6 +1482,8 @@ export function computePages(
         // (the sectionBreak itself emits nothing on the new page).
         prescanFloatsFrom(i + 1);
         startPageBookkeeping();
+        // Balance the new section's columns if it fits on its fresh page (§17.6.4).
+        setupBalancing(i + 1);
         if (upcomingKind === 'oddPage' && pages.length % 2 === 0) {
           pages.push([]);
           startPageBookkeeping();
@@ -1522,7 +1618,12 @@ export function computePages(
       // past the bottom; it is split at a line boundary by the path below
       // (Word's default behaviour). A keep-on-page float forces relocation too.
       const keepIntact = para.keepLines || needNext > 0 || addReservePt > 0;
-      if (breakForFloat || (overflowsHere && keepIntact && needed <= effContentH())) {
+      // ECMA-376 §17.6.4 column balancing: move the whole paragraph to the next
+      // column once the current (non-last) column has reached the balanced target
+      // (reuses the relocate machinery below, which rolls back / re-registers this
+      // paragraph's floats against the new column). No-op when balancing is off.
+      const balanceBreak = wantsBalanceBreak(fitHeight);
+      if (breakForFloat || balanceBreak || (overflowsHere && keepIntact && needed <= effContentH())) {
         const pagesBeforeRelocate = pages.length;
         // Relocating THIS paragraph to a fresh page: pre-scan from `i` so the
         // new page starts with THIS paragraph's own page-level floats counted.
@@ -1672,7 +1773,9 @@ export function computePages(
         y = endY;
         measureState.y = section.marginTop + endY;
       } else {
-        if (y + h > tableContentH) nextColumnOrPage(i);
+        // §17.6.4 column balancing (wantsBalanceBreak) OR a table that doesn't fit
+        // the rest of this column ⇒ advance to the next column / page.
+        if (wantsBalanceBreak(h) || y + h > tableContentH) nextColumnOrPage(i);
         pushTagged(el as PaginatedBodyElement);
         y += h;
         measureState.y += h;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1065,6 +1065,23 @@ export function computePages(
   let colIndex = 0;
   const colX = () => columns[colIndex].xPt;
   const colW = () => columns[colIndex].wPt;
+  // ECMA-376 §17.6.4 / §17.18.79 — the CURRENT multi-column region's vertical
+  // extent on the current page, in content-relative pt (0 = page content top,
+  // i.e. the same frame as `y`). A region tiled into N newspaper columns is a
+  // rectangle [colTopY, …]; every column STARTS at `colTopY`, not the page top.
+  // For a section opened by a "continuous" section break the region begins
+  // partway down the page (below the preceding single-column content), so
+  // `colTopY > 0`. `maxColBottomY` accumulates the deepest column bottom reached
+  // in the region so the NEXT section (after a continuous break) starts below
+  // ALL columns rather than overprinting a taller one. Reset to the page top at
+  // every real page open; re-seeded at each continuous section boundary. For a
+  // single-section / single-column document `colTopY` stays 0 — behaviour-neutral.
+  let colTopY = 0;
+  let maxColBottomY = 0;
+  // Page-absolute pt of the current region top, stamped on elements so the paint
+  // pass resets a column's cursor to the region top (front-loaded layout: the
+  // renderer consumes this instead of independently deciding the column top).
+  const colTopAbsPt = () => section.marginTop + colTopY;
 
   // Run `fn` with the measure state's content band temporarily re-pointed at the
   // CURRENT newspaper column (#513). The paint pass (renderBodyElements) sets
@@ -1147,6 +1164,9 @@ export function computePages(
       pages.push([]);
       y = 0;
       colIndex = 0;
+      // A fresh page: the section's columns span it from the content top.
+      colTopY = 0;
+      maxColBottomY = 0;
       prevPara = null;
       prevSpaceAfter = 0;
       measureState.y = section.marginTop;
@@ -1164,11 +1184,15 @@ export function computePages(
   // line, and a square float keeps constraining the columns its x-range covers).
   // No new page is pushed and footnote reserve is untouched (same page).
   const nextColumn = () => {
+    // Record the just-finished column's bottom, then drop the cursor back to the
+    // REGION top (not the page top) — for a continuous mid-page section the next
+    // column begins below the preceding single-column content (ECMA-376 §17.6.4).
+    maxColBottomY = Math.max(maxColBottomY, y);
     colIndex++;
-    y = 0;
+    y = colTopY;
     prevPara = null;
     prevSpaceAfter = 0;
-    measureState.y = section.marginTop;
+    measureState.y = section.marginTop + colTopY;
   };
   // Overflow handler shared by element placement and paragraph/table splitting:
   // move to the next column if one remains on this page, otherwise to a new page.
@@ -1256,6 +1280,7 @@ export function computePages(
   const pushTagged = (el: PaginatedBodyElement) => {
     el.colIndex = colIndex;
     el.colGeom = columns;
+    el.colTopPt = colTopAbsPt();
     pages[pages.length - 1].push(el);
   };
 
@@ -1273,6 +1298,8 @@ export function computePages(
     if (el.type === 'pageBreak') {
       pages.push([]);
       y = 0;
+      colTopY = 0;
+      maxColBottomY = 0;
       prevPara = null;
       prevSpaceAfter = 0;
       measureState.y = section.marginTop;
@@ -1304,14 +1331,21 @@ export function computePages(
       colIndex = 0;
       if (el.kind === 'continuous') {
         // ECMA-376 §17.18.79 "continuous": NO page break — the next section's
-        // content continues on the SAME page at the CURRENT vertical position
-        // (y is intentionally NOT reset), just in the new section's column 0.
-        // (sample-5's continuous break is 1-col → 1-col, so the two single-column
-        // sections simply stack; full continuous column-balancing for a column-
-        // count change is out of scope per the task.) prevPara is cleared so the
-        // first paragraph of the new section doesn't collapse spacing against the
-        // last paragraph of the previous one. Floats / footnote reserve stay
-        // (page-scoped). measureState.y already tracks the current y.
+        // content continues on the SAME page. It must start below the BOTTOM of
+        // EVERY column of the section just ended (ECMA-376 §17.6.4), not at the
+        // last-filled column's cursor: a 2-col section whose first column ran to
+        // the page bottom while the second is short would otherwise let the new
+        // (e.g. full-width) section overprint the taller column. `regionBottom`
+        // is the deepest column reached; the new section's region then begins
+        // there. (1-col→1-col, e.g. sample-5: maxColBottomY tracks no extra
+        // column, so regionBottom == y — the sections simply stack, unchanged.)
+        // Full column BALANCING of the ended section is a separate fidelity step;
+        // this clears the overprint and the page-fill error regardless.
+        const regionBottom = Math.max(maxColBottomY, y);
+        y = regionBottom;
+        measureState.y = section.marginTop + regionBottom;
+        colTopY = regionBottom;
+        maxColBottomY = regionBottom;
         prevPara = null;
         prevSpaceAfter = 0;
       } else {
@@ -1320,6 +1354,8 @@ export function computePages(
         // colIndex to 0 and clears page-scoped floats.
         pages.push([]);
         y = 0;
+        colTopY = 0;
+        maxColBottomY = 0;
         prevPara = null;
         prevSpaceAfter = 0;
         measureState.y = section.marginTop;
@@ -1508,14 +1544,17 @@ export function computePages(
           measureState, para, colW(), suppressBefore, colX(),
           y, pageContentH, pages,
           // Overflow during the split advances to the next column first, then a
-          // new page (newspaper fill). Each slice is tagged with the column it
-          // landed in via the colIndex thunk, plus this section's column geometry
-          // (constant — a paragraph never spans a section boundary). The
+          // new page (newspaper fill). The just-filled column's bottom is folded
+          // into `maxColBottomY` so a following continuous section clears the
+          // deepest column (ECMA-376 §17.6.4). Each slice is tagged with the
+          // column it landed in via the colIndex thunk, plus this section's column
+          // geometry (constant — a paragraph never spans a section boundary). The
           // continuation slice belongs to THIS paragraph, so the new page's
           // pre-scan starts at `i` (this paragraph index).
-          () => { nextColumnOrPage(i); },
+          (filledColBottom: number) => { maxColBottomY = Math.max(maxColBottomY, filledColBottom); nextColumnOrPage(i); },
           () => colIndex,
           columns,
+          () => colTopY,
         );
         // After splitting, `y` is the bottom of the last slice in the
         // current column (continues for the LAST slice; intermediate slices
@@ -1598,10 +1637,14 @@ export function computePages(
         const endY = splitTableAcrossPages(
           tbl, rowHs, y, tableContentH, pages,
           // Table slices belong to THIS table element, so the new page's
-          // pre-scan starts at `i` (this table's body index).
-          () => { nextColumnOrPage(i); },
+          // pre-scan starts at `i` (this table's body index). The just-filled
+          // column bottom folds into `maxColBottomY` so a following continuous
+          // section clears the deepest column (ECMA-376 §17.6.4).
+          (filledColBottom: number) => { maxColBottomY = Math.max(maxColBottomY, filledColBottom); nextColumnOrPage(i); },
           () => colIndex,
           columns,
+          () => colTopY,
+          section.marginTop,
         );
         y = endY;
         measureState.y = section.marginTop + endY;
@@ -1856,7 +1899,10 @@ function splitParagraphAcrossPages(
   initialY: number,
   contentH: number,
   pages: PaginatedBodyElement[][],
-  newPage: () => void,
+  /** Advance to the next column / page. Receives the bottom (content-relative pt)
+   *  the just-filled column reached, so the caller can track the deepest column
+   *  of a multi-column region (ECMA-376 §17.6.4) for the following section. */
+  newPage: (filledColBottom: number) => void,
   /** ECMA-376 §17.6.4 — current newspaper column index, read AFTER each
    *  `newPage()` (which may advance the column). When provided, every emitted
    *  slice is tagged with the column it landed in so the renderer flows it in the
@@ -1867,10 +1913,19 @@ function splitParagraphAcrossPages(
    *  stamped so the renderer resolves the slice's column against the right
    *  section. Omitted ⇒ the renderer uses the page-level columns. */
   colGeom?: ColumnGeom[],
+  /** ECMA-376 §17.6.4 — content-relative pt of the current column-region TOP,
+   *  read AFTER each `newPage()`. A continuation column of a continuous mid-page
+   *  section restarts here (below the preceding single-column content), not at
+   *  the page top. Omitted ⇒ the page content top (0). */
+  columnTop?: () => number,
 ): { endY: number } {
+  const colTop = columnTop ?? (() => 0);
   const stamp = (el: PaginatedBodyElement): PaginatedBodyElement => {
     if (tagColIndex) el.colIndex = tagColIndex();
     if (colGeom) el.colGeom = colGeom;
+    // Front-loaded layout: stamp the region top (page-absolute pt) so the paint
+    // pass resets this slice's column cursor to it instead of the page top.
+    if (columnTop) el.colTopPt = measureState.marginTop + colTop();
     return el;
   };
   const indLeft = para.indentLeft;
@@ -1893,8 +1948,8 @@ function splitParagraphAcrossPages(
     let markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
     let top = initialY;
     if (initialY > 0 && initialY + markH - para.spaceAfter > contentH) {
-      newPage();
-      top = 0;
+      newPage(initialY);
+      top = colTop();
       markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
     }
     pages[pages.length - 1].push(stamp(para as PaginatedBodyElement));
@@ -1949,8 +2004,8 @@ function splitParagraphAcrossPages(
       // Guard against infinite loop: if we're already at the start of a
       // fresh page (cursorY ≈ 0) and still don't fit, force-emit one line.
       if (cursorY > 0) {
-        newPage();
-        cursorY = 0;
+        newPage(cursorY);
+        cursorY = colTop();
         isFirstSliceOnPage = true;
         continue;
       }
@@ -1977,8 +2032,8 @@ function splitParagraphAcrossPages(
       // (cursorY > 0); a lone line at a fresh page top cannot be helped. Also
       // catches the case the widow pull above just reduced to a single line.
       if (firstFitting === 0 && lastFitting - firstFitting === 1 && cursorY > 0) {
-        newPage();
-        cursorY = 0;
+        newPage(cursorY);
+        cursorY = colTop();
         isFirstSliceOnPage = true;
         continue;
       }
@@ -1993,8 +2048,8 @@ function splitParagraphAcrossPages(
     lineIdx = lastFitting;
     cursorY += usedH;
     if (!isFinalSlice) {
-      newPage();
-      cursorY = 0;
+      newPage(cursorY);
+      cursorY = colTop();
       isFirstSliceOnPage = true;
     }
   }
@@ -2338,7 +2393,10 @@ export function splitTableAcrossPages(
   startY: number,
   contentH: number,
   pages: PaginatedBodyElement[][],
-  newPage: () => void,
+  /** Advance to the next column / page. Receives the bottom (content-relative pt)
+   *  the just-filled column reached so the caller can track the deepest column of
+   *  a multi-column region (ECMA-376 §17.6.4). */
+  newPage: (filledColBottom: number) => void,
   /** ECMA-376 §17.6.4 — current newspaper column index, read AFTER each
    *  `newPage()`. When provided, each table slice is tagged with its column.
    *  Omitted (single-column / direct unit tests) ⇒ no tag. */
@@ -2347,7 +2405,17 @@ export function splitTableAcrossPages(
    *  the split; a table is never split across a section boundary). Stamped on
    *  each slice so the renderer resolves its column against the right section. */
   colGeom?: ColumnGeom[],
+  /** ECMA-376 §17.6.4 — content-relative pt of the current column-region TOP,
+   *  read AFTER each `newPage()`. A continuation column of a continuous mid-page
+   *  section restarts here, not at the page top. Omitted ⇒ the page top (0). The
+   *  region-top page-absolute pt (`marginTop + columnTop()`) is stamped on each
+   *  slice so the paint pass resets its cursor to the region top. */
+  columnTop?: () => number,
+  /** Page-content top (pt) used to convert `columnTop()` to a page-absolute Y for
+   *  the `colTopPt` stamp. Omitted ⇒ no `colTopPt` stamp (single-column tests). */
+  marginTopPt?: number,
 ): number {
+  const colTop = columnTop ?? (() => 0);
   const n = table.rows.length;
   // Leading tblHeader rows repeat on each continuation page.
   let headerCount = 0;
@@ -2377,14 +2445,17 @@ export function splitTableAcrossPages(
     const sliceEl = { ...table, type: 'table', rows: sliceRows } as PaginatedBodyElement;
     if (tagColIndex) sliceEl.colIndex = tagColIndex();
     if (colGeom) sliceEl.colGeom = colGeom;
+    // Front-loaded layout: stamp the region top (page-absolute pt) so the paint
+    // pass resets this slice's column cursor to it instead of the page top.
+    if (columnTop && marginTopPt != null) sliceEl.colTopPt = marginTopPt + colTop();
     pages[pages.length - 1].push(sliceEl);
 
     y += used;
     start = end;
     firstSlice = false;
     if (start < n) {
-      newPage();
-      y = 0;
+      newPage(y);
+      y = colTop();
     }
   }
   return y;
@@ -2562,7 +2633,13 @@ function renderBodyElements(
       state.contentX = col.xPt * state.scale;
       state.contentW = col.wPt * state.scale;
       if (elCol > activeCol && cols === activeGeom) {
-        state.y = state.marginTop * state.scale;
+        // Region top (front-loaded layout): a continuation column restarts at the
+        // SECTION's region top — for a continuous mid-page section that is BELOW
+        // the preceding single-column content, not the page content top. The
+        // paginator computed and stamped it (`colTopPt`, page-absolute pt); the
+        // paint pass consumes it rather than re-deriving the column top. Absent ⇒
+        // a page-spanning section ⇒ the page content top, unchanged.
+        state.y = (el.colTopPt ?? state.marginTop) * state.scale;
       }
       prevPara = null;
       prevSpaceAfter = 0;
@@ -2571,8 +2648,15 @@ function renderBodyElements(
     } else if (!multiCol && cols && cols.length === 1 && cols !== activeGeom) {
       // A single-column SECTION on a multi-section page (e.g. sample-5 sections
       // 1–4): set the full-width content band for this section. Continue at the
-      // current y (continuous) — only the page-level fresh state / a page break
-      // resets to the top, both handled by the caller.
+      // current y (continuous), BUT when the PRECEDING section was multi-column,
+      // never above its deepest column: `colTopPt` carries that section's region
+      // bottom (ECMA-376 §17.6.4), so a full-width section after a 2-column run
+      // clears BOTH columns instead of overprinting the taller one. Gated on the
+      // previous section being multi-column so a 1-col→1-col continuous break
+      // (sample-5) keeps the exact prior behavior (continue at the current y).
+      if (activeGeom && activeGeom.length > 1 && el.colTopPt != null) {
+        state.y = Math.max(state.y, el.colTopPt * state.scale);
+      }
       const col = cols[0];
       state.contentX = col.xPt * state.scale;
       state.contentW = col.wPt * state.scale;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -403,13 +403,24 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
     for (const run of runs) {
       if (run.type === 'image') {
         const img = run as unknown as ImageRun;
+        // ECMA-376 §20.1.8.55 srcRect: a metafile (WMF/EMF) is rasterized to a
+        // bitmap whose SIZE is derived from the requested display extent. When
+        // only a sub-rectangle is shown, request the FULL image's display
+        // footprint (display extent ÷ visible fraction) so the rasterized bitmap
+        // keeps the full image's proportions; drawImageCropped then maps the
+        // sub-rect into the display box without distortion. (Raster blips ignore
+        // the requested size — their bitmap is the natural image — so this is a
+        // no-op for them.)
+        const sr = img.srcRect;
+        const visW = sr ? Math.max(0.01, 1 - sr.l - sr.r) : 1;
+        const visH = sr ? Math.max(0.01, 1 - sr.t - sr.b) : 1;
         record({
           imagePath: img.imagePath,
           mimeType: img.mimeType,
           svgImagePath: img.svgImagePath,
           colorReplaceFrom: img.colorReplaceFrom,
-          widthPt: img.widthPt ?? 0,
-          heightPt: img.heightPt ?? 0,
+          widthPt: (img.widthPt ?? 0) / visW,
+          heightPt: (img.heightPt ?? 0) / visH,
         });
       } else if (run.type === 'shape') {
         // Inline images living inside a text box (<wps:txbx>) ride on the
@@ -555,8 +566,10 @@ export async function preloadImages(
         let img: DecodedImage;
         if (pair.svgImagePath != null) {
           // Prefer the vector original (Microsoft `asvg:svgBlip` extension);
-          // fall back to the raster on any SVG decode failure. docx images have
-          // no srcRect crop, so the vector is always preferred when present.
+          // fall back to the raster on any SVG decode failure. A `<a:srcRect>`
+          // crop (§20.1.8.55), when present, is applied at draw time in bitmap
+          // pixels of whichever source we decoded here, so the vector is still
+          // always preferred when present.
           try {
             img = await getCachedSvgImageByPath(pair.svgImagePath, fetch);
           } catch {
@@ -2740,7 +2753,29 @@ function renderBodyElements(
   // against the right widths.
   let activeCol = -1;
   let activeGeom: ColumnGeom[] | undefined;
-  for (const el of elements) {
+  // ECMA-376 §17.3.1.7 — the next IN-FLOW paragraph that is adjacent to `elements[i]`
+  // in the SAME newspaper column (same colGeom + colIndex), with no intervening
+  // non-paragraph element (a table/floating-table boundary closes the border box).
+  // A `framePr` paragraph is out of flow (§17.3.1.11) and is skipped/blocks the run.
+  // Returns null when the run is broken (column change, table between, end of page).
+  // A page break never appears mid-`elements` (the paginator splits pages), so the
+  // box correctly closes at the column/page bottom without a special case here.
+  const sameColumn = (a: PaginatedBodyElement, b: PaginatedBodyElement): boolean =>
+    (a.colGeom ?? columns) === (b.colGeom ?? columns) && (a.colIndex ?? 0) === (b.colIndex ?? 0);
+  const flowParaInColumn = (cur: PaginatedBodyElement, sibling: PaginatedBodyElement | undefined): DocParagraph | null => {
+    if (!sibling) return null;
+    if (sibling.type !== 'paragraph') return null; // table/other ends the run
+    if (!sameColumn(cur, sibling)) return null; // column change ends the run
+    const p = sibling as unknown as DocParagraph;
+    if (p.framePr) return null; // out-of-flow frame paragraph is not in the run
+    return p;
+  };
+  const prevFlowParaInColumn = (i: number): DocParagraph | null =>
+    flowParaInColumn(elements[i], elements[i - 1]);
+  const nextFlowParaInColumn = (i: number): DocParagraph | null =>
+    flowParaInColumn(elements[i], elements[i + 1]);
+  for (let elIdx = 0; elIdx < elements.length; elIdx++) {
+    const el = elements[elIdx];
     // Per-section column geometry: prefer the element's own (stamped by the
     // paginator), else the page-level columns. A single full-width column (or no
     // geometry) is the unchanged single-column path.
@@ -2812,7 +2847,20 @@ function renderBodyElements(
       // mid-paragraph slices (slice.end < total) suppress spaceAfter — only
       // the slice covering the FINAL line of the paragraph emits it.
       const isContinuation = !!slice && slice.start > 0;
-      renderParagraph(para, state, suppress || isContinuation, slice);
+      // ECMA-376 §17.3.1.7 paragraph-border merge: suppress this paragraph's TOP
+      // edge when the previous IN-FLOW paragraph (already null on column/section
+      // change, table/frame boundary — exactly the run-breaking cases) shares its
+      // border box, and its BOTTOM edge when the next adjacent same-column
+      // paragraph does. The run is thus drawn as one box: top on the first member,
+      // bottom on the last, `between` (if any) at the inner joins.
+      const borderMerge: ParaBorderMerge | undefined =
+        hasAnyBorderEdge(para.borders)
+          ? {
+              suppressTop: parasShareBorderBox(prevFlowParaInColumn(elIdx), para),
+              suppressBottom: parasShareBorderBox(para, nextFlowParaInColumn(elIdx)),
+            }
+          : undefined;
+      renderParagraph(para, state, suppress || isContinuation, slice, false, borderMerge);
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;
     } else if (el.type === 'table') {
@@ -2834,12 +2882,26 @@ function renderBodyElements(
 function renderParaList(paras: DocParagraph[], state: RenderState): void {
   let prevPara: DocParagraph | null = null;
   let prevSpaceAfter = 0;
-  for (const para of paras) {
+  for (let i = 0; i < paras.length; i++) {
+    const para = paras[i];
     const suppress = contextualSuppressed(prevPara, para);
     const effBefore = suppress ? 0 : para.spaceBefore;
     const overlap = Math.min(prevSpaceAfter, effBefore);
     state.y -= overlap * state.scale;
-    renderParagraph(para, state, suppress);
+    // ECMA-376 §17.3.1.7 paragraph-border merge. This list is a single flow (a
+    // note or a table cell), so adjacency is just consecutive list members; a
+    // frame paragraph (§17.3.1.11) is out of flow and breaks the run. `framePr`
+    // siblings are filtered by parasShareBorderBox, so compare with the literal
+    // neighbors here.
+    const prevSibling = (paras[i - 1] ?? null) as DocParagraph | null;
+    const nextSibling = (paras[i + 1] ?? null) as DocParagraph | null;
+    const borderMerge: ParaBorderMerge | undefined = hasAnyBorderEdge(para.borders)
+      ? {
+          suppressTop: parasShareBorderBox(prevSibling, para),
+          suppressBottom: parasShareBorderBox(para, nextSibling),
+        }
+      : undefined;
+    renderParagraph(para, state, suppress, undefined, false, borderMerge);
     prevPara = para;
     prevSpaceAfter = para.spaceAfter;
   }
@@ -2899,11 +2961,13 @@ function renderEmptyMarkParagraph(
     /** Total laid-out line count (0 here); used by the slice guards. */
     totalLines: number;
     lineSlice?: { start: number; end: number };
+    /** §17.3.1.7 paragraph-border merge (suppress top/bottom edges). */
+    borderMerge?: ParaBorderMerge;
   },
 ): void {
   const { ctx, scale, dryRun } = state;
   const { grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY,
-    paragraphStartY, markTop, totalLines, lineSlice } = markCtx;
+    paragraphStartY, markTop, totalLines, lineSlice, borderMerge } = markCtx;
   // Displacement applied by the float-flow (0 when the mark fits where it is).
   const flowShift = Math.max(0, markTop - textAreaTopY);
   if (markTop > state.y) state.y = markTop;
@@ -2915,7 +2979,7 @@ function renderEmptyMarkParagraph(
   }
   state.y += emptyH;
   if (para.borders && !dryRun) {
-    drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale, state.dpr);
+    drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale, state.dpr, borderMerge);
   }
   // Only the slice covering the FINAL line emits spaceAfter. With no inline
   // lines there is a single slice, so this is the whole paragraph.
@@ -3114,6 +3178,12 @@ function renderParagraph(
    *  the frame box). Frame dispatch for a non-frame call lives in
    *  renderBodyElements so it can pass the anchor paragraph's line height. */
   inFrame = false,
+  /** ECMA-376 §17.3.1.7 paragraph-border merge: suppress the top edge when a
+   *  same-border paragraph precedes this one in the same column, and the bottom
+   *  edge when one follows. Computed by the paint loop (renderBodyElements /
+   *  renderParaList), which knows in-flow adjacency. Absent ⇒ draw the full box
+   *  (a standalone bordered paragraph). */
+  borderMerge?: ParaBorderMerge,
 ): void {
   const { ctx, scale, contentX, contentW, defaultColor, dryRun, fontFamilyClasses } = state;
   // Capture Y before spaceBefore — used for paragraph-relative anchor image positioning
@@ -3277,7 +3347,7 @@ function renderParagraph(
     // and (by construction in the paginator) never sliced.
     renderEmptyMarkParagraph(para, state, {
       grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY, paragraphStartY,
-      markTop: resolveEmptyMarkTop(), totalLines: 0, lineSlice: undefined,
+      markTop: resolveEmptyMarkTop(), totalLines: 0, lineSlice: undefined, borderMerge,
     });
     return;
   }
@@ -3346,7 +3416,7 @@ function renderParagraph(
     // images on the first).
     renderEmptyMarkParagraph(para, state, {
       grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY, paragraphStartY,
-      markTop: resolveEmptyMarkTop(), totalLines: lines.length, lineSlice,
+      markTop: resolveEmptyMarkTop(), totalLines: lines.length, lineSlice, borderMerge,
     });
     return;
   }
@@ -3901,7 +3971,7 @@ function renderParagraph(
 
   if (para.borders && !dryRun) {
     const textH = state.y - textAreaTopY;
-    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale, state.dpr);
+    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale, state.dpr, borderMerge);
   }
 
   // spaceAfter is paragraph-level; only emit it on the slice that covers
@@ -3991,6 +4061,11 @@ interface LayoutImageSeg {
   anchorYFromPara: boolean;
   /** When set, pixels matching this hex color are replaced with alpha=0 before drawing. */
   colorReplaceFrom?: string;
+  /** ECMA-376 §20.1.8.55 `<a:srcRect>` source-rectangle crop (fractions 0..1 of
+   *  the decoded bitmap). When present the draw paths use the 9-arg
+   *  `drawImage` to blit only `[l, t, 1−r, 1−b]` of the bitmap into the display
+   *  box. `undefined` ⇒ draw the full bitmap. */
+  srcRect?: { l: number; t: number; r: number; b: number };
   measuredWidth: number;
 }
 
@@ -4245,6 +4320,7 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         anchorXFromMargin: img.anchorXFromMargin ?? false,
         anchorYFromPara: img.anchorYFromPara ?? false,
         colorReplaceFrom: img.colorReplaceFrom,
+        srcRect: img.srcRect ?? undefined,
         measuredWidth: 0,
       });
     } else if (run.type === 'break') {
@@ -5041,6 +5117,45 @@ function drawTabLeader(
   ctx.restore();
 }
 
+/**
+ * Draw a decoded image bitmap into the destination box `[dx, dy, dw, dh]`,
+ * honoring an optional ECMA-376 §20.1.8.55 `<a:srcRect>` source-rectangle crop.
+ *
+ * `srcRect` insets are fractions 0..1 of the bitmap measured inward from each
+ * edge, so the visible source region is `[l, t, 1−r, 1−b]` in bitmap pixels:
+ *   `sx = l·W`, `sy = t·H`, `sw = (1−l−r)·W`, `sh = (1−t−b)·H` (clamped ≥ 1).
+ * The destination box is unchanged — the same display size the document asked
+ * for, now filled by just the cropped slice (the renderer never scales the crop
+ * back up; Word stretches the visible source to fill the display box, which is
+ * exactly the 9-arg `drawImage` behavior). Applies identically to raster and
+ * metafile (WMF/EMF) bitmaps since the crop is in decoded-bitmap pixels.
+ */
+function drawImageCropped(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  bmp: DecodedImage,
+  srcRect: { l: number; t: number; r: number; b: number } | undefined,
+  dx: number,
+  dy: number,
+  dw: number,
+  dh: number,
+): void {
+  if (!srcRect) {
+    ctx.drawImage(bmp, dx, dy, dw, dh);
+    return;
+  }
+  // Use the intrinsic bitmap size. For an HTMLImageElement `width`/`height`
+  // can reflect a CSS/attribute size; `naturalWidth`/`naturalHeight` give the
+  // decoded pixel dimensions. ImageBitmap exposes only `width`/`height` (already
+  // intrinsic). Fall back to `width`/`height` if the natural size is 0.
+  const bw = ('naturalWidth' in bmp && bmp.naturalWidth > 0) ? bmp.naturalWidth : bmp.width;
+  const bh = ('naturalHeight' in bmp && bmp.naturalHeight > 0) ? bmp.naturalHeight : bmp.height;
+  const sx = srcRect.l * bw;
+  const sy = srcRect.t * bh;
+  const sw = Math.max(1, (1 - srcRect.l - srcRect.r) * bw);
+  const sh = Math.max(1, (1 - srcRect.t - srcRect.b) * bh);
+  ctx.drawImage(bmp, sx, sy, sw, sh, dx, dy, dw, dh);
+}
+
 function renderInlineImage(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   seg: LayoutImageSeg,
@@ -5056,7 +5171,7 @@ function renderInlineImage(
   if (!bmp) return;
   const w = seg.widthPt * scale;
   const h = seg.heightPt * scale;
-  ctx.drawImage(bmp, x, baseline - h, w, h);
+  drawImageCropped(ctx, bmp, seg.srcRect, x, baseline - h, w, h);
 }
 
 /** Collect and draw anchor images with wrapMode='none' (or unspecified).
@@ -5104,7 +5219,7 @@ function renderAnchorImages(
     // does not displace text and is not displaced by other floats), so dist* is
     // unused here.
     const { x: pageX, y: pageY, w, h } = resolveAnchorBox(img, state, paragraphTopPx);
-    state.ctx.drawImage(bmp, pageX, pageY, w, h);
+    drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, pageX, pageY, w, h);
   }
 }
 
@@ -5921,7 +6036,7 @@ function registerImageFloat(
 
   if (!state.dryRun) {
     const bmp = state.images.get(key);
-    if (bmp) state.ctx.drawImage(bmp, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
+    if (bmp) drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
     rect.drawn = true;
   }
 }
@@ -6641,12 +6756,33 @@ function drawBorderLine(
   ctx.restore();
 }
 
+/**
+ * ECMA-376 §17.3.1.7 — paragraph-border merge context for a run of consecutive
+ * identically-bordered paragraphs. Word draws ONE box around such a run:
+ *   - the `top` edge only on the FIRST paragraph,
+ *   - the `bottom` edge only on the LAST paragraph,
+ *   - the `<w:between>` edge (if any) at every INNER join,
+ *   - `left`/`right` always (they form the box sides).
+ * The paint loops (renderBodyElements / renderParaList) detect adjacency and
+ * pass `suppressTop` when a same-border paragraph precedes this one, and
+ * `suppressBottom` when one follows. When `suppressTop` is set the `between`
+ * edge (if defined) is drawn at the top join instead of the `top` edge.
+ */
+interface ParaBorderMerge {
+  /** A same-border paragraph is adjacent above ⇒ don't draw this `top` edge
+   *  (draw `between` at the top join instead, when defined). */
+  suppressTop?: boolean;
+  /** A same-border paragraph is adjacent below ⇒ don't draw this `bottom` edge. */
+  suppressBottom?: boolean;
+}
+
 function drawParaBorders(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   x: number, y: number, w: number, h: number,
   borders: ParagraphBorders,
   scale: number,
   dpr = 1,
+  merge?: ParaBorderMerge,
 ): void {
   const drawEdge = (edge: ParaBorderEdge | null, x1: number, y1: number, x2: number, y2: number) => {
     if (!edge || edge.style === 'none') return;
@@ -6654,13 +6790,75 @@ function drawParaBorders(
     drawBorderLine(ctx, x1, y1, x2, y2, spec, scale, dpr);
   };
   const sp = (edge: ParaBorderEdge | null) => (edge?.space ?? 0) * scale;
-  drawEdge(borders.top,    x, y - sp(borders.top),         x + w, y - sp(borders.top));
-  drawEdge(borders.bottom, x, y + h + sp(borders.bottom),  x + w, y + h + sp(borders.bottom));
+  // §17.3.1.7 top edge: on a non-first paragraph of a shared run, the `top` edge
+  // gives way to the `between` edge drawn at the join (nothing when `between` is
+  // absent — the box has no internal rules).
+  const topEdge = merge?.suppressTop ? borders.between : borders.top;
+  drawEdge(topEdge, x, y - sp(topEdge), x + w, y - sp(topEdge));
+  // The `bottom` edge is skipped entirely when a same-border paragraph follows
+  // (the box continues into it; its own join is handled by that paragraph's
+  // suppressed-top `between`).
+  if (!merge?.suppressBottom) {
+    drawEdge(borders.bottom, x, y + h + sp(borders.bottom), x + w, y + h + sp(borders.bottom));
+  }
   drawEdge(borders.left,   x - sp(borders.left), y,        x - sp(borders.left), y + h);
   drawEdge(borders.right,  x + w + sp(borders.right), y,   x + w + sp(borders.right), y + h);
 }
 
 // ===== Utilities =====
+
+/** ECMA-376 §17.3.1.7 — two paragraph-border definitions "match" (and so
+ *  consecutive paragraphs carrying them merge into a single bordered box) iff
+ *  ALL FIVE edges (top/bottom/left/right/between) are pairwise identical in
+ *  style, color, size, and space. A `null`/absent edge equals another absent
+ *  edge but differs from any present edge. Two paragraphs with NO borders are
+ *  not a bordered run (we never merge unbordered paragraphs), so the caller
+ *  gates on "both have a non-empty borders object" before calling this. */
+function sameParaEdge(a: ParaBorderEdge | null, b: ParaBorderEdge | null): boolean {
+  if (a == null || b == null) return a == null && b == null;
+  return (
+    a.style === b.style &&
+    a.width === b.width &&
+    (a.space ?? 0) === (b.space ?? 0) &&
+    (a.color ?? null) === (b.color ?? null)
+  );
+}
+
+function sameParaBorders(
+  a: ParagraphBorders | null | undefined,
+  b: ParagraphBorders | null | undefined,
+): boolean {
+  if (a == null || b == null) return false; // unbordered paragraphs never merge
+  return (
+    sameParaEdge(a.top, b.top) &&
+    sameParaEdge(a.bottom, b.bottom) &&
+    sameParaEdge(a.left, b.left) &&
+    sameParaEdge(a.right, b.right) &&
+    sameParaEdge(a.between, b.between)
+  );
+}
+
+/** True when `borders` defines at least one visible edge (so a paragraph
+ *  carrying it actually paints a box). A borders object whose every edge is
+ *  null/`none` is treated as "no border" for merge purposes. */
+function hasAnyBorderEdge(b: ParagraphBorders | null | undefined): boolean {
+  if (!b) return false;
+  const live = (e: ParaBorderEdge | null) => e != null && e.style !== 'none';
+  return live(b.top) || live(b.bottom) || live(b.left) || live(b.right) || live(b.between);
+}
+
+/** ECMA-376 §17.3.1.7 — two paragraphs form (part of) the same bordered box iff
+ *  both carry a visible paragraph border AND their five border edges match
+ *  exactly. The caller is responsible for the ADJACENCY half of the rule (same
+ *  column/flow, no page/column break or non-paragraph element between); this
+ *  helper covers only the "identical border definition" half. A `framePr`
+ *  (out-of-flow §17.3.1.11) paragraph can never share a run. */
+function parasShareBorderBox(a: DocParagraph | null, b: DocParagraph | null): boolean {
+  if (!a || !b) return false;
+  if (a.framePr || b.framePr) return false;
+  if (!hasAnyBorderEdge(a.borders) || !hasAnyBorderEdge(b.borders)) return false;
+  return sameParaBorders(a.borders, b.borders);
+}
 
 /** ECMA-376 §17.3.2.4 — two `<w:bdr>` borders belong to the same run-border
  *  group iff their attribute sets are identical. We compare the attributes the

--- a/packages/docx/src/run-inline-formatting.test.ts
+++ b/packages/docx/src/run-inline-formatting.test.ts
@@ -195,3 +195,32 @@ describe('run box (w:bdr §17.3.2.4) + shading (w:shd §17.3.2.32) geometry', ()
     expect(fill.w).toBeCloseTo(2 * 16); // |AB| = 2 chars × 16px
   });
 });
+
+describe('over-long word overflow-wrap (long URLs in a narrow column)', () => {
+  it('breaks a no-space token wider than the line at the character level', async () => {
+    // pageWidth 400, margins 0, 16px/char ⇒ 25 chars per line. A 40-char URL with
+    // no break opportunity must wrap (ECMA-376 prescribes no algorithm; Word
+    // breaks an over-long word at the character level so it stays in the column).
+    const url = 'http://example.com/aaaaaaaaaaaaaaaaaaaaa'; // 40 chars, no spaces
+    expect(url.length).toBe(40);
+    const events = await render([textRun(url)]);
+    const texts = events.filter((e) => e.kind === 'fillText') as Array<{ text: string; x: number }>;
+    // It wraps onto more than one line (the bug drew it as a single 640px line).
+    expect(texts.length).toBeGreaterThan(1);
+    // No drawn line exceeds the 400px content width (25 chars × 16px).
+    for (const t of texts) expect(t.text.length * 16).toBeLessThanOrEqual(400 + 1e-6);
+    // Every character is preserved across the wrap (character-level, lossless).
+    expect(texts.map((t) => t.text).join('')).toBe(url);
+  });
+
+  it('still wraps a normal sentence at spaces, not mid-word', async () => {
+    // Guard: ordinary text must keep wrapping at spaces — the over-long path only
+    // engages for a single token wider than the whole line.
+    const events = await render([textRun('alpha bravo charlie delta echo foxtrot')]);
+    const texts = events.filter((e) => e.kind === 'fillText') as Array<{ text: string; x: number }>;
+    // Each drawn token is a whole word (plus trailing space), never a mid-word slice.
+    for (const t of texts) {
+      expect(t.text.trim()).toMatch(/^(alpha|bravo|charlie|delta|echo|foxtrot)$/);
+    }
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -125,6 +125,13 @@ export interface SectionProps {
   footerDistance: number;   // pt — bottom of page to footer
   titlePage: boolean;
   evenAndOddHeaders: boolean;
+  /** ECMA-376 §17.6.22 ST_SectionMark — the body (final) section's `<w:type>`
+   *  start type ("continuous" | "nextPage" | "oddPage" | "evenPage"). Governs
+   *  how the last section begins relative to the previous one; consumed by the
+   *  paginator at the boundary INTO the final section. Absent ⇒ "nextPage" (the
+   *  spec default). Non-final sections carry their start type on their own
+   *  SectionBreak marker. */
+  sectionStart?: string | null;
   /** ECMA-376 §17.6.5 w:docGrid/@w:type — "default" | "lines" | "linesAndChars" | "snapToChars". */
   docGridType?: string | null;
   /** ECMA-376 §17.6.5 w:docGrid/@w:linePitch in pt. When docGridType is "lines" or

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -214,6 +214,17 @@ export type PaginatedBodyElement = BodyElement & {
    *  paths), so single-section documents are unaffected. Runtime-only — never
    *  emitted by the parser. */
   colGeom?: ColumnGeom[];
+  /** ECMA-376 §17.6.4 — page-absolute Y (pt) of the TOP of the multi-column
+   *  region this element belongs to on its page. For a section started by a
+   *  "continuous" section break (§17.18.79) the columns begin partway down the
+   *  page (below the preceding single-column content), not at the page content
+   *  top; the paginator computes that origin once (front-loaded layout) and
+   *  stamps it so the renderer resets a column's vertical cursor to the REGION
+   *  top — never the page top. Also carries the region's bottom (max column
+   *  depth) onto the FIRST element of the following section so it clears all
+   *  columns. Absent ⇒ the renderer uses the page content top (single-column /
+   *  page-spanning section). Runtime-only — never emitted by the parser. */
+  colTopPt?: number;
 };
 
 export interface DocParagraph {

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -738,6 +738,17 @@ export interface ImageRun {
    * image. Its MIME is always `image/svg+xml` and is owned by the SVG decoder.
    */
   svgImagePath?: string;
+  /**
+   * ECMA-376 §20.1.8.55 `<a:srcRect>` — the source-rectangle crop applied to
+   * the decoded bitmap before it is drawn into the display box. The four values
+   * are inset FRACTIONS 0..1 of the source bitmap measured inward from each
+   * edge (`l`/`t` from left/top, `r`/`b` from right/bottom); the visible source
+   * region is `[l, t, 1−r, 1−b]`. The parser converts the raw ST_Percentage
+   * (1000ths of a percent) to fractions, so the renderer crops in bitmap pixels
+   * (`sx = l*w`, `sy = t*h`, `sw = (1−l−r)*w`, `sh = (1−t−b)*h`) without unit
+   * knowledge. Absent / null when there is no crop (the full bitmap is drawn).
+   */
+  srcRect?: { l: number; t: number; r: number; b: number } | null;
   widthPt: number;
   heightPt: number;
   /** true = wp:anchor (absolute positioned), false/undefined = wp:inline (flows with text) */

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -65,13 +65,12 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !haveSamples)(
       expect(paginate(12).length).toBe(3);
     });
 
-    // Now 6 pages (was 7 before the region-top fix, 5 in Word). The overprint is
-    // gone and the §17.6.22 boundary fix keeps the 2-col body on the title page,
-    // but one extra page remains in the figure/table-dense middle section. Word
-    // does NOT balance these columns (its last 2-col page fills the left column
-    // only), so the residual is a figure/table-sizing + greedy-fill fidelity gap,
-    // not balancing. Marked `fails` as a tracking gate against Word's 5 pages.
-    it.fails('sample-13 paginates to 5 pages — residual figure-region fidelity gap', () => {
+    // 5 pages, matching Word, once non-final continuous multi-column sections are
+    // balanced (§17.6.4): a short 2-col section's content is split across both
+    // columns instead of packing column 0, which frees vertical space for the
+    // following full-width element on the same page and densifies the whole flow.
+    // The final (references) section stays greedy, as Word leaves it.
+    it('sample-13 paginates to 5 pages (Word ground truth)', () => {
       expect(paginate(13).length).toBe(5);
     });
   },

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -65,13 +65,13 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !haveSamples)(
       expect(paginate(12).length).toBe(3);
     });
 
-    // Tier 2 (column BALANCING) is not yet implemented: a continuous section's
-    // columns are filled greedily (col 0 to the page bottom, then col 1) instead
-    // of balanced to equal height, so a 2-col run whose last page is half-full
-    // pushes the following full-width section onto a new page. sample-13 thus
-    // over-paginates (7 vs Word's 5). Marked `fails` as a TODO gate: when
-    // balancing lands and this returns 5, the marker flips red — switch to `it`.
-    it.fails('sample-13 paginates to 5 pages — pending column balancing (Tier 2)', () => {
+    // Now 6 pages (was 7 before the region-top fix, 5 in Word). The overprint is
+    // gone and the §17.6.22 boundary fix keeps the 2-col body on the title page,
+    // but one extra page remains in the figure/table-dense middle section. Word
+    // does NOT balance these columns (its last 2-col page fills the left column
+    // only), so the residual is a figure/table-sizing + greedy-fill fidelity gap,
+    // not balancing. Marked `fails` as a tracking gate against Word's 5 pages.
+    it.fails('sample-13 paginates to 5 pages — residual figure-region fidelity gap', () => {
       expect(paginate(13).length).toBe(5);
     });
   },

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  installImageBitmapShim,
+  installOffscreenCanvasShim,
+  type NodeCanvasFactory,
+} from './render.ts';
+
+// skia-canvas is a local-only peer dep (CI omits it); the private journal
+// samples are git-ignored (not redistributable). Skip cleanly when either is
+// absent — this suite is a local ground-truth gate, like the VRT specs.
+const skia = await import('skia-canvas').catch(() => null);
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (async (buf: ArrayBuffer | Uint8Array | Buffer) =>
+    loadImage(Buffer.from(buf as Uint8Array))) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const docxMod = skia ? await import('./docx.ts').catch(() => null) : null;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
+const rendererMod = skia ? await import(RENDERER_PATH).catch(() => null) : null;
+
+const samplePath = (n: number) =>
+  resolve(ROOT, `packages/docx/public/private/sample-${n}.docx`);
+const haveSamples = existsSync(samplePath(12)) && existsSync(samplePath(13));
+
+// ECMA-376 §17.6.4 newspaper columns + §17.18.79 "continuous" section marks.
+// Both journal templates flow their body through `continuous` section breaks
+// that flip the column count (1 ⇄ 2) mid-page. The paginator must place each
+// multi-column region's later columns at the REGION top (where the section
+// began on the page), not the page content top — otherwise the second column
+// overprints the preceding single-column content and the page absorbs too much
+// content (sample-12 collapsed 3 Word pages into 2). Ground truth = the Word
+// PDF page counts next to each .docx.
+describe.skipIf(!skia || !docxMod || !rendererMod || !haveSamples)(
+  'continuous column-count section breaks (sample-12/13)',
+  () => {
+    let restore: Array<() => void> = [];
+    const paginate = (n: number) => {
+      restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
+      try {
+        const { parseDocx } = docxMod!;
+        const { paginateDocument } = rendererMod as {
+          paginateDocument: (doc: unknown) => unknown[][];
+        };
+        const doc = parseDocx(readFileSync(samplePath(n)));
+        return paginateDocument(doc);
+      } finally {
+        restore.forEach((r) => r());
+      }
+    };
+
+    // Tier 1 (column-region top tracking): the second column of a continuous
+    // mid-page multi-column section starts at the region top, not the page top —
+    // so the overprint is gone and sample-12 flows across its 3 Word pages.
+    it('sample-12 paginates to 3 pages (Word ground truth)', () => {
+      expect(paginate(12).length).toBe(3);
+    });
+
+    // Tier 2 (column BALANCING) is not yet implemented: a continuous section's
+    // columns are filled greedily (col 0 to the page bottom, then col 1) instead
+    // of balanced to equal height, so a 2-col run whose last page is half-full
+    // pushes the following full-width section onto a new page. sample-13 thus
+    // over-paginates (7 vs Word's 5). Marked `fails` as a TODO gate: when
+    // balancing lands and this returns 5, the marker flips red — switch to `it`.
+    it.fails('sample-13 paginates to 5 pages — pending column balancing (Tier 2)', () => {
+      expect(paginate(13).length).toBe(5);
+    });
+  },
+);

--- a/packages/node/src/docx-para-border-merge.probe.test.ts
+++ b/packages/node/src/docx-para-border-merge.probe.test.ts
@@ -1,0 +1,247 @@
+/**
+ * ECMA-376 §17.3.1.7 — consecutive identically-bordered paragraphs render as ONE
+ * box, not a rule under every line.
+ *
+ * Background (sample-13 "Code 1" source-code block): a caption paragraph carries
+ * `top`+`bottom` paragraph borders, and the code lines below it each carry ONLY a
+ * `bottom` border. Word compares each adjacent pair's full pBdr set: when they
+ * MATCH it draws the `between` border (here absent ⇒ nothing) instead of the
+ * first paragraph's bottom + the second's top; when they DIFFER the first uses
+ * its bottom and the second its top. So the code lines (all identical, bottom-
+ * only) form one box with NO internal horizontal rules — only the final line's
+ * bottom closes it. The caption, whose border set differs from the code lines,
+ * stays its own box (its bottom rule separates it from the first code line).
+ *
+ * The renderer formerly drew each paragraph's bottom edge independently, so a
+ * rule appeared under every code line. This probe injects that exact synthetic
+ * structure (no dependency on the private sample), renders headlessly via skia,
+ * and MEASURES the device-pixel luminance to count the horizontal rules between
+ * the code lines — asserting only the box edges remain.
+ *
+ * CI-safe: skia-canvas ships a native binding CI omits, and docx.ts statically
+ * imports gitignored WASM glue, so the suite is gated with
+ * `describe.skipIf(!skia || !docxMod || !rendererMod)` — all loaded via caught
+ * dynamic import (mirrors docx-border-crisp.probe.test.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import type {
+  DocxDocumentModel,
+  DocParagraph,
+  BodyElement,
+  ParaBorderEdge,
+} from '@silurus/ooxml-docx';
+
+const skia = await import('skia-canvas').catch(() => null);
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+
+const docxMod = await import('./docx.ts').catch(() => null);
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const SAMPLE = resolve(ROOT, 'packages/docx/public/demo/sample-1.docx');
+const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
+const rendererMod = await import(RENDERER_PATH).catch(() => null);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed for border-merge probe');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+function lum(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+const SINGLE = (): ParaBorderEdge => ({ style: 'single', color: '000000', width: 1, space: 0 });
+
+/** One code-block line carrying ONLY a black bottom border (like sample-13's
+ *  code-style paragraphs). A run of single-character text keeps the line box
+ *  tall enough to isolate adjacent rules. */
+function codeLine(text: string): BodyElement {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: [{ type: 'text', text, fontSize: 11, bold: false, italic: false, color: null, fontFamily: 'Courier New' }],
+    borders: { top: null, bottom: SINGLE(), left: null, right: null, between: null },
+  } as unknown as DocParagraph as unknown as BodyElement;
+}
+
+function caption(text: string): BodyElement {
+  return {
+    type: 'paragraph',
+    alignment: 'center',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: [{ type: 'text', text, fontSize: 11, bold: false, italic: false, color: null, fontFamily: 'Times New Roman' }],
+    // Caption box differs from the code lines: it has BOTH top and bottom.
+    borders: { top: SINGLE(), bottom: SINGLE(), left: null, right: null, between: null },
+  } as unknown as DocParagraph as unknown as BodyElement;
+}
+
+function plain(text: string): BodyElement {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 6,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: text ? [{ type: 'text', text, fontSize: 11, bold: false, italic: false, color: null, fontFamily: 'Times New Roman' }] : [],
+    borders: null,
+  } as unknown as DocParagraph as unknown as BodyElement;
+}
+
+function buildDoc(body: BodyElement[]): DocxDocumentModel {
+  if (!docxMod) throw new Error('docx WASM unavailable (run pnpm build:wasm)');
+  const { parseDocx } = docxMod;
+  const doc = parseDocx(readFileSync(SAMPLE));
+  // Single-column full-width body so the injected block is isolated and wide.
+  doc.section.columns = { count: 1, spacePt: 0, equalWidth: true, sep: false, cols: [] } as unknown as DocxDocumentModel['section']['columns'];
+  doc.body = body;
+  doc.headers = { default: null, first: null, even: null } as unknown as DocxDocumentModel['headers'];
+  doc.footers = { default: null, first: null, even: null } as unknown as DocxDocumentModel['footers'];
+  doc.footnotes = [];
+  doc.endnotes = [];
+  return doc;
+}
+
+async function render(doc: DocxDocumentModel, widthPx: number): Promise<{ data: Uint8ClampedArray; w: number; h: number }> {
+  const { renderDocumentToCanvas } = rendererMod as {
+    renderDocumentToCanvas: (
+      doc: DocxDocumentModel,
+      canvas: unknown,
+      pageIndex: number,
+      opts: { dpr: number; width: number },
+    ) => Promise<void>;
+  };
+  const scale = widthPx / doc.section.pageWidth;
+  const heightPx = Math.round(doc.section.pageHeight * scale);
+  const canvas = new Canvas(widthPx, heightPx);
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: widthPx });
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const w = canvas.width;
+  const h = canvas.height;
+  const img = ctx.getImageData(0, 0, w, h);
+  return { data: img.data, w, h };
+}
+
+/** Count the dark, near-full-width horizontal rules in the image. A "rule" is a
+ *  row whose dark-neutral run covers most of the width; adjacent dark rows are
+ *  collapsed into one rule. Returns the y of each rule's center. */
+function findHorizontalRules(data: Uint8ClampedArray, w: number, h: number): number[] {
+  const minRun = Math.round(w * 0.35);
+  const isDark = (i: number): boolean => {
+    const L = lum(data[i], data[i + 1], data[i + 2]);
+    const spread = Math.max(data[i], data[i + 1], data[i + 2]) - Math.min(data[i], data[i + 1], data[i + 2]);
+    return L < 170 && spread < 24;
+  };
+  const ruleRows: number[] = [];
+  for (let y = 0; y < h; y++) {
+    let cur = 0;
+    let best = 0;
+    for (let x = 0; x < w; x++) {
+      if (isDark((y * w + x) * 4)) {
+        cur++;
+        if (cur > best) best = cur;
+      } else {
+        cur = 0;
+      }
+    }
+    if (best >= minRun) ruleRows.push(y);
+  }
+  // Collapse adjacent rows (≤2 px apart) into a single rule.
+  const rules: number[] = [];
+  for (const y of ruleRows) {
+    if (rules.length && y - rules[rules.length - 1] <= 2) continue;
+    rules.push(y);
+  }
+  return rules;
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)(
+  'docx paragraph-border merge (§17.3.1.7)',
+  () => {
+    it('consecutive same-border code lines draw one box, not a rule per line', async () => {
+      // Caption (top+bottom) then 6 code lines (bottom-only) — sample-13's "Code 1".
+      const doc = buildDoc([
+        plain('intro'),
+        caption('Code 1.  Source code caption.'),
+        codeLine('void main(void)'),
+        codeLine('{ WDTCTL = WDTPW; }'),
+        codeLine('  P3DIR |= 0x01;'),
+        codeLine('  for (;;)'),
+        codeLine('  P3OUT ^= 0xFF;'),
+        codeLine('}'),
+        plain('outro'),
+      ]);
+      const { data, w, h } = await render(doc, 600);
+      const rules = findHorizontalRules(data, w, h);
+
+      // Expected rules: caption TOP, caption BOTTOM (= top of the merged code box),
+      // and the merged code box BOTTOM (after the final '}'). That is THREE rules
+      // total — NOT one-per-code-line (which would be caption-top + 7 bottoms = 8+).
+      // eslint-disable-next-line no-console
+      console.log(`[merge probe] horizontal rules at y=${JSON.stringify(rules)} (count=${rules.length})`);
+      expect(rules.length).toBe(3);
+    }, 30000);
+
+    it('a STANDALONE bordered paragraph (no same-border neighbor) keeps its full box', async () => {
+      // A single boxed paragraph surrounded by unbordered text must still draw
+      // all four edges — the merge must not strip a non-adjacent box.
+      const boxed: BodyElement = {
+        type: 'paragraph',
+        alignment: 'left',
+        indentLeft: 0,
+        indentRight: 0,
+        indentFirst: 0,
+        spaceBefore: 6,
+        spaceAfter: 6,
+        lineSpacing: null,
+        numbering: null,
+        tabStops: [],
+        runs: [{ type: 'text', text: 'boxed', fontSize: 11, bold: false, italic: false, color: null, fontFamily: 'Times New Roman' }],
+        borders: { top: SINGLE(), bottom: SINGLE(), left: SINGLE(), right: SINGLE(), between: null },
+      } as unknown as DocParagraph as unknown as BodyElement;
+      const doc = buildDoc([plain('above'), boxed, plain('below')]);
+      const { data, w, h } = await render(doc, 600);
+      const rules = findHorizontalRules(data, w, h);
+      // The standalone box draws BOTH a top and a bottom horizontal rule.
+      // eslint-disable-next-line no-console
+      console.log(`[standalone probe] rules at y=${JSON.stringify(rules)} (count=${rules.length})`);
+      expect(rules.length).toBe(2);
+    }, 30000);
+  },
+);

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.66.0. DOCX continuous multi-section newspaper-column overhaul (region-top §17.6.4, section-break governance §17.6.22, header/footer inheritance §17.10.1, overflow-wrap, column balancing §17.6.4, a:srcRect §20.1.8.55, paragraph border merge §17.3.1.7) + core EMF rasterization ([MS-EMF]). sample-12/13 journal templates now match Word. 309 core/docx tests + parser tests green, typecheck + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)