### PR TITLE
hotfix: cover-page body overprint (sample-5) — revert section-break off-by-one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.66.1 — 2026-06-23
+
+Patch. Hotfix for a 0.66.0 regression.
+
+- **docx:** a cover page's `nextPage` section break was read as continuous, so the
+  body flowed up and overprinted the title page (sample-5). Use the section
+  marker's own break kind again (§17.6.x). A continuous body after a title
+  section (sample-13) goes back to the next page until the cover's vAlign
+  page-fill is modelled.
+
 ## 0.66.0 — 2026-06-23
 
 Minor. A DOCX continuous-section newspaper-column overhaul plus EMF figure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -460,44 +460,23 @@ describe('computePages — per-section columns (§17.6.4, regression)', () => {
   });
 
   it('a continuous section break keeps both single-column sections on the SAME page, stacked', () => {
-    // ECMA-376 §17.6.22: a section's `<w:type>` describes how THAT section begins
-    // relative to the previous one, and lives on the sectPr that ENDS the section
-    // (the NEXT marker in document order). So the A→B break is governed by section
-    // B's type — the kind of the marker that ENDS B (idx 3) — and the B→final break
-    // by the final (body) section's start type. Here B is continuous (stacks below
-    // A on page 1) and the final 2-col section is nextPage (default) → page 2. Both
-    // A and B are single-column full width and must NOT reset to the page top.
+    // The break uses the marker's own kind: A→B is a `continuous` break (B stacks
+    // below A on page 1), B→final is a `nextPage` break (final on page 2). Both A
+    // and B are single-column full width and must NOT reset to the page top.
     const body: BodyElement[] = [
       para({ text: 'A', fontSize: 20 }),
-      sectionBreak('continuous', null), // ends section A (A's own start type)
+      sectionBreak('continuous', null),
       para({ text: 'B', fontSize: 20 }),
-      sectionBreak('continuous', null), // ends section B ⇒ B begins continuously (A→B same page)
+      sectionBreak('nextPage', null),
       para({ text: 'final', fontSize: 20 }),
     ];
     const pages = computePages(body, finalTwoCol(), makeCtx());
     expect(pages.length).toBe(2);
-    // A and B share page 1 (B continuous), final on page 2 (final section nextPage).
     expect(pages[0].map(textOf)).toEqual(['A', 'B']);
     expect(pages[1].map(textOf)).toEqual(['final']);
     for (const el of pages[0]) {
       expect(colGeomOf(el)).toEqual([{ xPt: 20, wPt: 160 }]);
     }
-  });
-
-  it('the break INTO a section is governed by that section start type, not the prior marker (§17.6.22)', () => {
-    // Regression for the off-by-one: a title section whose own sectPr is nextPage
-    // (the spec default) followed by a continuous body section must NOT page-break —
-    // the boundary is governed by the FOLLOWING (body) section's start type. Mirrors
-    // sample-13, where Word keeps the 2-col body on the title page.
-    const body: BodyElement[] = [
-      para({ text: 'title', fontSize: 20 }),
-      sectionBreak('nextPage', null), // ends the title section (its own start type)
-      para({ text: 'body', fontSize: 20 }),
-    ];
-    const sec = { ...finalTwoCol(), columns: null, sectionStart: 'continuous' };
-    const pages = computePages(body, sec, makeCtx());
-    expect(pages.length).toBe(1);
-    expect(pages[0].map(textOf)).toEqual(['title', 'body']);
   });
 
   it('single-section 2-col docs are UNCHANGED (no SectionBreak markers ⇒ whole body uses section.columns)', () => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1055,26 +1055,6 @@ export function computePages(
     return computeColumns(section);
   };
 
-  // ECMA-376 §17.6.22 (ST_SectionMark): a section's `<w:type>` specifies how
-  // THAT section begins relative to the previous one (continuous ⇒ same page;
-  // nextPage/odd/even ⇒ a new page). The type lives on the section's OWN sectPr,
-  // which the parser stamps on the SectionBreak marker that ENDS that section.
-  // So the break at a boundary is governed by the UPCOMING section's type — the
-  // kind of the NEXT marker at/after `startIdx`, exactly like sectionColumnsFrom
-  // resolves the upcoming section's columns. (A marker's own kind is the start
-  // type of the section it closes — relevant at the PREVIOUS boundary, not this
-  // one. Using it here is an off-by-one that turns e.g. a title section's
-  // type="nextPage" into a spurious page break before a following
-  // type="continuous" body section.) The last section (no following marker) uses
-  // the body sectPr's start type; absent ⇒ "nextPage" (the spec default).
-  const sectionKindFrom = (startIdx: number): string => {
-    for (let j = startIdx; j < body.length; j++) {
-      const e = body[j];
-      if (e.type === 'sectionBreak') return e.kind ?? 'nextPage';
-    }
-    return section.sectionStart ?? 'nextPage';
-  };
-
   // The active section's column geometry. Reassigned (a) here for the first
   // section and (b) at every `SectionBreak` as the flow enters the next section.
   // `colIndex` tracks which column we are filling; `colX()`/`colW()` give its
@@ -1444,9 +1424,15 @@ export function computePages(
       // columns instead of every section inheriting the body-level section's.
       columns = sectionColumnsFrom(i + 1);
       colIndex = 0;
-      // The break is governed by the UPCOMING section's start type (§17.6.22),
-      // not this marker's own kind (the section it closes). See sectionKindFrom.
-      const upcomingKind = sectionKindFrom(i + 1);
+      // HOTFIX: use THIS marker's own kind for the break. The §17.6.22
+      // "upcoming-section" reading (sectionKindFrom) was correct for a continuous
+      // body that follows a title section (sample-13), but it wrongly turned a
+      // cover page's explicit `nextPage` break into a continuous one, flowing the
+      // body up onto the cover (sample-5 — the novel's text overprinted the title
+      // page). The marker's own kind is the safe, regression-free reading; the
+      // upcoming-section nuance needs the cover's page-fill (vAlign) modelled
+      // first. TODO: revisit with sample-5 + sample-13 both pinned.
+      const upcomingKind = el.kind ?? 'nextPage';
       if (upcomingKind === 'continuous') {
         // ECMA-376 §17.18.79 "continuous": NO page break — the next section's
         // content continues on the SAME page. It must start below the BOTTOM of

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -70,7 +70,7 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !haveSamples)(
     // columns instead of packing column 0, which frees vertical space for the
     // following full-width element on the same page and densifies the whole flow.
     // The final (references) section stays greedy, as Word leaves it.
-    it('sample-13 paginates to 5 pages (Word ground truth)', () => {
+    it.fails('sample-13 paginates to 5 pages — off-by-one reverted for the sample-5 hotfix (now 6)', () => {
       expect(paginate(13).length).toBe(5);
     });
   },

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Regression hotfix for 0.66.0: sample-5's novel body overprinted the title page because the §17.6.22 upcoming-section break reading turned a cover's nextPage break continuous. Reverts to the marker's own kind. sample-5 fixed; sample-13 back to 6p (intro on page 2, no overlap). docx 254 tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)