### PR TITLE
fix(docx): tblW=auto tables size to tcW/content, not the stale grid (§17.4.63)

### DIFF
--- a/packages/docx/src/column-widths.test.ts
+++ b/packages/docx/src/column-widths.test.ts
@@ -21,7 +21,7 @@ type ColState = Parameters<typeof resolveColumnWidths>[2];
 
 const EMPTY_STATE = {} as unknown as ColState;
 
-function cell(colSpan: number, widthPct: number | null): DocTableCell {
+function cell(colSpan: number, widthPct: number | null, widthPt: number | null = null): DocTableCell {
   return {
     content: [],
     colSpan,
@@ -29,7 +29,7 @@ function cell(colSpan: number, widthPct: number | null): DocTableCell {
     borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
     background: null,
     vAlign: 'top',
-    widthPt: null,
+    widthPt,
     widthPct,
     marginTop: 0,
     marginBottom: 0,
@@ -42,9 +42,10 @@ function row(cells: DocTableCell[]): DocTableRow {
   return { cells, rowHeight: null, rowHeightRule: 'auto', isHeader: false } as unknown as DocTableRow;
 }
 
-/** sample-3-shaped table: an unequal 2-column grid whose single-column cells
- *  each prefer ~50% via `tcW=pct`. */
-function table(rows: DocTableRow[]): DocTable {
+/** sample-3-shaped table: a fixed-preferred-width table (`tblW=pct`, the
+ *  whole-table preferred width Word baked its auto-fit into) with an unequal
+ *  2-column grid whose single-column cells each prefer ~50% via `tcW=pct`. */
+function table(rows: DocTableRow[], width: Partial<DocTable> = { widthPct: 5000 }): DocTable {
   return {
     colWidths: [70, 30], // grid: deliberately UNEQUAL
     rows,
@@ -54,11 +55,12 @@ function table(rows: DocTableRow[]): DocTable {
     cellMarginLeft: 0,
     cellMarginRight: 0,
     jc: 'left',
+    ...width,
     // layout omitted ⇒ autofit (the branch under test).
   } as unknown as DocTable;
 }
 
-describe('resolveColumnWidths — grid (§17.4.48) governs autofit widths, not per-cell tcW (§17.4.71)', () => {
+describe('resolveColumnWidths — a tblW=dxa/pct grid (§17.4.48) governs widths, not per-cell tcW (§17.4.71)', () => {
   it('keeps the (unequal) tblGrid proportions even when cells prefer ~equal tcW=pct', () => {
     // Two rows of single-column cells, each preferring 50% (2500/5000). The grid
     // says 70/30. Word renders 70/30 (the grid); tcW must NOT equalize to 50/50.
@@ -87,5 +89,44 @@ describe('resolveColumnWidths — grid (§17.4.48) governs autofit widths, not p
     const w = resolveColumnWidths(t, 50, EMPTY_STATE);
     expect(w[0]).toBeCloseTo(35, 5);
     expect(w[1]).toBeCloseTo(15, 5);
+  });
+});
+
+// ECMA-376 §17.4.63 (`<w:tblW>`) / §17.18.87 (ST_TblWidth "auto"). A
+// tblW=auto table ("AutoFit to Contents") has NO preferred table width: Word
+// sizes columns from content + per-cell `<w:tcW>`, and the saved `<w:gridCol>`
+// is the style/layout default (frequently the full text column), NOT a baked
+// auto-fit result. So for tblW=auto the grid must NOT drive the widths — tcW /
+// content does. (sample-7's cover tables carry gridCol=full-page yet a 100 pt
+// tcW; trusting the grid made them full-width and defeated their own w:jc
+// right/left placement.) Contrast the tblW=dxa/pct case above, where the grid
+// IS Word's baked layout and stays authoritative (sample-3).
+describe('resolveColumnWidths — a tblW=auto table sizes to tcW/content, ignoring the stale full-width grid', () => {
+  const autofit = (rows: DocTableRow[], colWidths: number[]): DocTable =>
+    ({
+      ...table(rows, { widthPt: undefined, widthPct: undefined }),
+      colWidths,
+    }) as unknown as DocTable;
+
+  it('a single-column tblW=auto table settles at the cell tcW (not the full-page grid)', () => {
+    // sample-7 leaders table: gridCol = full content width (415 pt-ish, here
+    // 415), but the cell prefers tcW=100 pt. AutoFit-to-Contents ⇒ column = 100.
+    const t = autofit([row([cell(1, null, 100)]), row([cell(1, null, 100)])], [415]);
+    const w = resolveColumnWidths(t, 415, EMPTY_STATE);
+    expect(w[0]).toBeCloseTo(100, 5);
+  });
+
+  it('a two-column tblW=auto table uses each cell tcW, leaving the table narrower than the page', () => {
+    // sample-7 Arabic table: gridCol=[207.65,207.65] (full width), but the cells
+    // prefer tcW col0=120, col1=20. The resolved table is 140 wide (< 415), so
+    // its w:jc can place it at the right margin. The grid (415) is ignored.
+    const t = autofit(
+      [row([cell(1, null, 120), cell(1, null, 20)])],
+      [207.65, 207.65],
+    );
+    const w = resolveColumnWidths(t, 415, EMPTY_STATE);
+    expect(w[0]).toBeCloseTo(120, 5);
+    expect(w[1]).toBeCloseTo(20, 5);
+    expect(w[0] + w[1]).toBeLessThan(415);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2221,15 +2221,18 @@ function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: nu
  *   - layout === 'fixed': use the tblGrid widths verbatim (the historical
  *     behavior), then scale down proportionally if the grid total overflows the
  *     available content width.
- *   - layout absent or 'autofit' (the spec default): the tblGrid widths
- *     (§17.4.48) ARE the column widths, scaled to fit `contentWPt`, with each
- *     column's content min-width (§17.4.52 auto-fit grows a column too narrow
- *     for its longest token) the only thing that can raise it. Per-cell `tcW`
- *     (§17.4.71) is NOT applied here: Word bakes the resolved auto-fit widths
- *     back into the saved `<w:gridCol>`, so for a round-tripped file the grid is
- *     already the tcW-resolved layout (see the in-body comment for the full
- *     rationale + the sample-3 evidence + the tblW=pct limitation). Only a
- *     degenerate all-zero grid falls back to a tcW-preference distribution.
+ *   - autofit (the spec default) WITH a preferred table width (tblW=dxa/pct,
+ *     §17.4.63): the tblGrid widths (§17.4.48) ARE the column widths, scaled to
+ *     fit `contentWPt`, content min-width the only grower. Per-cell `tcW`
+ *     (§17.4.71) is NOT re-applied: Word bakes the resolved auto-fit widths back
+ *     into the saved `<w:gridCol>`, so for a round-tripped preferred-width table
+ *     the grid already is the tcW-resolved layout (sample-3).
+ *   - autofit with tblW=auto ("AutoFit to Contents"), or a degenerate all-zero
+ *     grid: per-cell `tcW` + content min drive the column sizes. The saved grid
+ *     is the style/default full text column, not a baked layout, so it must not
+ *     pin the width — otherwise the table spans the page and overrides its own
+ *     `w:jc` placement (sample-7's cover tables). See the in-body comment for the
+ *     full rationale and the commit-8a3d8a5 history.
  *
  * The returned widths sum to at most `contentWPt`. Both `renderTable` (which
  * then multiplies by the device scale) and `computeTableRowHeights` (which
@@ -2387,41 +2390,51 @@ export function resolveColumnWidths(table: DocTable, contentWPt: number, state: 
     return g;
   }
 
-  // Autofit (default). Use the `<w:tblGrid>` (§17.4.48 / gridCol §17.4.16) as
-  // the column widths, scaled to fit, with content min-widths the only grower.
+  // Autofit (default). The width source depends on the table's preferred width
+  // (ECMA-376 §17.4.63 `<w:tblW>` / §17.18.87 ST_TblWidth):
   //
-  // DELIBERATE DEVIATION from the literal autofit algorithm, to match Word's
-  // actual output: §17.4.16 (gridCol Note) and §17.4.52 (tblLayout) make a
-  // cell's preferred `<w:tcW>` (§17.4.71) an INPUT that can OVERRIDE the grid's
-  // initial widths. But Word does not ship the pre-autofit state — it BAKES the
-  // resolved autofit widths back into the saved `<w:gridCol>` values. So for a
-  // round-tripped Word file (every real-world docx) the grid already IS the
-  // tcW-resolved layout; re-applying `tcW` on top double-counts and diverges
-  // from the ground-truth PDF. sample-3's résumé grid is [2137, 222, 2430, 279,
-  // 2427, 279] twips (a deliberately narrow first content column), yet each
-  // row's single-column cells carry `tcW≈30%`; the old "tcW overrides grid"
-  // path equalized the columns to ~116 pt apiece, shifting every later column
-  // right (the 2nd heading moved ~11 pt past Word's x) and re-wrapping the
-  // description paragraphs past their divider rule. Trusting the grid reproduces
-  // Word exactly.
+  // (a) tblW=dxa or pct (a FIXED preferred width) ⇒ trust the `<w:tblGrid>`
+  //     (§17.4.48 / gridCol §17.4.16), scaled to fit, with content min-widths
+  //     the only grower. DELIBERATE DEVIATION from the literal autofit algorithm
+  //     to match Word: §17.4.16/§17.4.52 make a cell's `<w:tcW>` (§17.4.71) an
+  //     input that can override the grid's initial widths, but Word does not ship
+  //     the pre-autofit state — it BAKES the resolved autofit widths back into
+  //     the saved `<w:gridCol>`. So for a round-tripped, preferred-width Word
+  //     table the grid already IS the tcW-resolved layout; re-applying `tcW`
+  //     double-counts. sample-3's résumé grid is [2137, 222, 2430, 279, 2427,
+  //     279] twips (a deliberately narrow first content column), yet each row's
+  //     single-column cells carry `tcW≈30%`; the old "tcW overrides grid" path
+  //     equalized the columns to ~116 pt apiece, shifting every later column
+  //     right and re-wrapping the description paragraphs. Trusting the grid
+  //     reproduces Word exactly.
   //
-  // LIMITATION: a `tblW=pct` (§17.4.63) table whose SAVED grid no longer matches
-  // the available width (e.g. authored under different margins, or by a tool
-  // that did not bake the grid) is NOT re-scaled up to the pct target here — the
-  // grid is taken as-is (only scaled DOWN by `fitToContent` on overflow). In
-  // practice the renderer lays a table out at the same content width Word saved
-  // it under, so the grid sums to that width; the gap only appears for stale /
-  // non-Word grids. Tracked for a future full tblW pass.
+  // (b) tblW=auto ("AutoFit to Contents") ⇒ the table has NO preferred width, so
+  //     the saved `<w:gridCol>` is the style/layout default (commonly the FULL
+  //     text column), NOT a baked autofit result. Trusting it makes the table
+  //     span the page and defeats its own `w:jc` placement (sample-7's cover
+  //     tables carry gridCol=full-page yet a 100 pt `tcW`; the grid path centred
+  //     them and broke the right/left alignment). So tblW=auto falls through to
+  //     the tcW/content-preference autofit below, exactly as before commit
+  //     8a3d8a5 sized every autofit table — that change correctly fixed the
+  //     preferred-width case (a) but wrongly applied the grid to (b) too.
+  //
+  // A degenerate grid (no `<w:gridCol>` widths) also falls through to (b): with
+  // no grid to anchor the columns, tcW + content are the only sizing signal.
+  //
+  // LIMITATION: a `tblW=pct` table whose SAVED grid no longer matches the
+  // available width (authored under different margins, or by a tool that did not
+  // bake the grid) is NOT re-scaled up to the pct target — the grid is taken
+  // as-is (only scaled DOWN on overflow). Tracked for a future full tblW pass.
+  const hasPreferredWidth = table.widthPt != null || table.widthPct != null;
   const gridSum = grid.reduce((s, w) => s + w, 0);
-  if (gridSum > 0) {
+  if (gridSum > 0 && hasPreferredWidth) {
     const desired = grid.map((g, c) => Math.max(g, minW[c]));
     return fitToContent(desired);
   }
 
-  // Degenerate grid (no `<w:gridCol>` widths, e.g. a hand-built model or a
-  // malformed table): fall back to preferred-width autofit, where `tcW` and
-  // content drive the column sizes since there is no grid to anchor them.
-  // `pref[c]` accumulates the strongest single-column preference seen so far.
+  // (b) tblW=auto (or a degenerate grid): preferred-width autofit, where `tcW`
+  // and content drive the column sizes. `pref[c]` accumulates the strongest
+  // single-column preference seen so far.
   const pref: number[] = new Array(n).fill(0);
   // `hasPref[c]` is true once any cell has expressed a preference for c.
   const hasPref: boolean[] = new Array(n).fill(false);


### PR DESCRIPTION
## Regression hotfix (0.66.1)

sample-7's cover page lost its table alignment: the `jc=right` Arabic table ("1. التأمين الصحي") no longer sat at the right margin and the `jc=left` leaders table ("first leader name") no longer sat at the left — both stretched full-width and centred.

### Root cause
Commit `8a3d8a5` (0.65.0 table-geometry rework) routed **every** autofit table through the saved `<w:tblGrid>`. That is correct for a preferred-width table (`tblW=dxa/pct`), where Word bakes its resolved auto-fit back into the grid (sample-3). But a **`tblW=auto`** table ("AutoFit to Contents", ECMA-376 §17.4.63 / §17.18.87 ST_TblWidth) has no preferred width — its `gridCol` is the style/layout default (often the full text column), not a baked layout. Pinning the width to that grid makes the table span the page and silently overrides its own `w:tblPr/w:jc` placement.

### Fix
Split the autofit branch by `tblW` type: `tblW=dxa/pct` keeps the grid authoritative; `tblW=auto` (and degenerate all-zero grids) size from `tcW`/content — restoring the pre-`8a3d8a5` behaviour for that case only.

### Verification (Word PDF = ground truth)
- "first leader name" lands at x≈109 pt (Word: 109.5); the Arabic table returns to the right margin.
- **sample-1** (tblW=auto with tcW==grid) and **sample-3** (tblW=pct/dxa) render pixel-identical before/after.
- docx unit tests 256/256; `column-widths.test` now covers both branches; root typecheck clean.