### PR TITLE
fix(docx): RTL number & rich text-box word order (UAX#9 W4 / L2)

### DIFF
--- a/packages/docx/src/digit-groups.test.ts
+++ b/packages/docx/src/digit-groups.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { splitDigitGroups } from './renderer.js';
+
+// ECMA-376 RTL number handling relies on UAX#9. In an AN-classified Arabic run
+// the renderer splits a token into European-digit groups + separators so the
+// per-line bidi pass can reorder a date right-to-left (canvas only reorders
+// EN-LTR within one fillText). A SINGLE common separator (CS) between two numbers
+// joins them into one number (W4) and must NOT split — else a decimal is drawn
+// reversed (sample-8: "1234.56" came out "56.1234").
+describe('splitDigitGroups — UAX#9 W4 keeps a CS-joined number whole', () => {
+  it('keeps a decimal number as one left-to-right group', () => {
+    expect(splitDigitGroups('1234.56')).toEqual(['1234.56']);
+  });
+
+  it('keeps thousands + decimal grouping whole', () => {
+    expect(splitDigitGroups('1,234.56')).toEqual(['1,234.56']);
+  });
+
+  it('keeps a time (colon CS) whole', () => {
+    expect(splitDigitGroups('12:34')).toEqual(['12:34']);
+  });
+
+  it('keeps a slash-joined number whole (CS)', () => {
+    expect(splitDigitGroups('3/4')).toEqual(['3/4']);
+  });
+
+  it('still splits a hyphen date (ES is not CS for AN digits) for RTL reorder', () => {
+    expect(splitDigitGroups('28-02-2026')).toEqual(['28', '-', '02', '-', '2026']);
+  });
+
+  it('splits at a CS that is not flanked by digits on both sides', () => {
+    // Trailing dot (sentence period after a number): not between two digits.
+    expect(splitDigitGroups('1234.')).toEqual(['1234', '.']);
+    // Leading separator.
+    expect(splitDigitGroups('.5')).toEqual(['.', '5']);
+  });
+
+  it('leaves pure non-digit / pure-digit tokens untouched', () => {
+    expect(splitDigitGroups('USD')).toEqual(['USD']);
+    expect(splitDigitGroups('99')).toEqual(['99']);
+    expect(splitDigitGroups('')).toEqual(['']);
+  });
+});

--- a/packages/docx/src/renderer.textbox-image.test.ts
+++ b/packages/docx/src/renderer.textbox-image.test.ts
@@ -356,5 +356,43 @@ describe('textbox rich text — per-run formatting', () => {
   });
 });
 
+// A rich (per-run) text box draws one token per fillText, so — unlike the
+// single-fillText plain path, where the canvas reorders internally — the tokens
+// must be reordered by the UAX#9 visual pass (rule L2, the same one body
+// paragraphs use). Without it, RTL/mixed text drew in logical order and Word's
+// word order was reversed (sample-8's yellow text box).
+describe('renderShapeText — rich-text RTL visual reordering (UAX#9 L2)', () => {
+  const run = (text: string): ShapeTextRun =>
+    ({ text, fontSizePt: 10 }) as unknown as ShapeTextRun;
+  // Drawn texts sorted by x = visual left-to-right reading order.
+  const visualOrder = (calls: { text: string; x: number }[]) =>
+    [...calls].sort((a, b) => a.x - b.x).map((c) => c.text.trim()).filter(Boolean);
+
+  it('reverses pure-RTL words into visual order', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    // Logical Arabic "one two three"; under an RTL base the visual L→R order is
+    // the reverse: three, two, one.
+    const shape = richTextbox([run('واحد اثنان ثلاثة')], 'right');
+    renderShapeText(shape, 0, 0, 300, 100, ctx, 1);
+    expect(visualOrder(fillTextCalls)).toEqual(['ثلاثة', 'اثنان', 'واحد']);
+  });
+
+  it('keeps a Latin/number island left-to-right inside an RTL line', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    // "value 2025 end" in Arabic with an embedded number: words reverse, but the
+    // number stays a single LTR island in the middle.
+    const shape = richTextbox([run('قيمة 2025 نهاية')], 'right');
+    renderShapeText(shape, 0, 0, 300, 100, ctx, 1);
+    expect(visualOrder(fillTextCalls)).toEqual(['نهاية', '2025', 'قيمة']);
+  });
+
+  it('leaves pure-LTR rich text in logical order', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    const shape = richTextbox([run('alpha beta gamma')], 'left');
+    renderShapeText(shape, 0, 0, 300, 100, ctx, 1);
+    expect(visualOrder(fillTextCalls)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+});
+
 // Local alias matching renderer.ts's internal DecodedImage union.
 type DecodedImage = ImageBitmap | HTMLImageElement;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4534,18 +4534,39 @@ function splitByEastAsia(text: string): { text: string; ea: boolean }[] {
 }
 
 /**
- * Split a token into maximal runs of European digits (U+0030–0039) versus
- * everything else, so a date / number in an AN-classified Arabic run can be
+ * Split a token into maximal runs of European digits (U+0030–0039) versus the
+ * separators between them, so a date in an AN-classified Arabic run can be
  * reordered group-by-group by the per-line bidi pass (which works at segment
- * granularity). "28-02-2026" → ["28","-","02","-","2026"].
+ * granularity). "28-02-2026" → ["28","-","02","-","2026"], which the RTL reorder
+ * then lays out right-to-left as Word does.
+ *
+ * EXCEPTION — ECMA-376 relies on UAX#9 W4: a SINGLE common separator (CS) sitting
+ * between two numbers of the same type joins them into ONE number. So a decimal /
+ * thousands / time separator (`.`, `,`, `:`, `/`, NBSP) flanked by European
+ * digits on BOTH sides stays inside the digit group: "1234.56", "1,234.56" and
+ * "12:34" are one left-to-right number, not three reorderable pieces. (A European
+ * separator like `-` is ES, NOT CS, and W4's ES clause is EN-only — these run
+ * digits are AN — so a hyphen still splits, preserving the date case.) Splitting
+ * a decimal sent "1234.56" through the RTL segment reorder and drew it "56.1234".
  */
-function splitDigitGroups(text: string): string[] {
+export function splitDigitGroups(text: string): string[] {
+  const isEuDigit = (c: number) => c >= 0x30 && c <= 0x39;
+  // UAX#9 Common Separator (CS) subset that can join two adjacent numbers (W4).
+  // The last char is NBSP (U+00A0, e.g. a French thousands separator), itself CS;
+  // a plain space is WS and never reaches here (splitTextForLayout breaks on it).
+  const isJoiningCS = (ch: string) =>
+    ch === '.' || ch === ',' || ch === ':' || ch === '/' || ch === ' ';
   const out: string[] = [];
   let buf = '';
   let bufDigit: boolean | null = null;
-  for (const ch of text) {
-    const c = ch.charCodeAt(0);
-    const isDigit = c >= 0x30 && c <= 0x39;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    let isDigit = isEuDigit(ch.charCodeAt(0));
+    // W4: a single CS between two European digits is part of the number — keep it
+    // in the current digit group so the whole number stays one (LTR) segment.
+    if (!isDigit && bufDigit === true && isJoiningCS(ch) && isEuDigit(text.charCodeAt(i + 1))) {
+      isDigit = true;
+    }
     if (bufDigit === null || isDigit === bufDigit) {
       buf += ch;
     } else {
@@ -5717,7 +5738,6 @@ export function renderShapeText(
         // single-format path's per-block resolution but resolved per line.
         const lineText = lineToks.map((t) => t.text).join('');
         const baseRtl = resolveBaseDirection(undefined, lineText) === 'rtl';
-        ctx.direction = baseRtl ? 'rtl' : 'ltr';
         const edge = edgeFor(baseRtl);
         let tx = innerX;
         if (edge === 'center') {
@@ -5728,7 +5748,19 @@ export function renderShapeText(
         // Baseline uses the tallest font on the line (lineH / 1.2 × 0.85).
         const lineMaxFontPx = lineH / 1.2;
         const baseline = cursorY + lineMaxFontPx * 0.85;
-        for (const tok of lineToks) {
+        // UAX#9 visual reorder (rule L2), the SAME pass body paragraphs use. A
+        // rich line draws one token per fillText, so — unlike the single-fillText
+        // plain path below, where the canvas reorders internally — the tokens
+        // must be reordered HERE or RTL/mixed text draws in logical order (Word
+        // reverses it). Shape paragraphs carry no explicit rtl flag, so the base
+        // direction is the line's first-strong char; ctx.textAlign stays 'left'
+        // so tx is each token's left edge and ctx.direction is set per token to
+        // its resolved level (so a Latin/number island still shapes LTR).
+        const visual = computeLineVisualOrder(lineToks, baseRtl);
+        for (let vi = 0; vi < lineToks.length; vi++) {
+          const si = visual.order[vi];
+          const tok = lineToks[si];
+          ctx.direction = visual.rtl[si] ? 'rtl' : 'ltr';
           const fontPx = tok.run.fontSizePt * scale;
           // Per-character font (ascii vs eastAsia axis, §17.3.2.26): a CJK token
           // draws with the eastAsia family, a Latin/digit token with the ascii


### PR DESCRIPTION
Two RTL rendering bugs in sample-8, both in per-line bidi handling.

### 1. Decimal drawn reversed — `1234.56` → `56.1234`
`splitDigitGroups` split a token at every digit/non-digit boundary so an AN-classified date (`28-02-2026`) can be reordered group-by-group by the bidi pass. But it also split the decimal point, sending `[1234][.][56]` through the RTL segment reorder. **UAX#9 W4**: a single common separator (CS) between two same-type numbers joins them into one number. Keep a CS (`.` `,` `:` `/` NBSP) flanked by European digits inside the digit group, so `1234.56` / `1,234.56` / `12:34` stay one LTR number. A hyphen is ES (not CS) for AN digits, so dates still split and reorder.

### 2. Rich text-box words scrambled (the yellow box)
`renderShapeText`'s rich (per-run) path emits one `fillText` per token, so the canvas never reorders across tokens — RTL/mixed text drew in logical order. Apply the same UAX#9 visual pass body paragraphs use (`computeLineVisualOrder`, **rule L2**) and draw tokens in visual order with per-token `ctx.direction`, so RTL words reverse while Latin/number islands stay LTR.

Verified via headless `onTextRun` / `fillText` capture against the logical text; `2025 مختلط ونص RTL اتجاه على يحتوي نص مربع` is the correct RTL visual order. New unit tests (`digit-groups.test`, `renderShapeText` reorder); docx suite 266/266; root typecheck clean.