### PR TITLE
chore(release): 0.66.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.66.2 — 2026-06-23
+
+Patch. DOCX RTL / table fidelity fixes.
+
+- **docx (table auto-fit):** an `AutoFit to Contents` table (`tblW=auto`) was sized
+  from its saved `<w:tblGrid>` (often the full text column), so it spanned the page
+  and overrode its own `w:tblPr/w:jc` placement — sample-7's cover page lost the
+  right-aligned and left-aligned tables. `tblW=auto` now sizes from per-cell `tcW`
+  /content (ECMA-376 §17.4.63 / §17.18.87); a preferred-width table (`tblW=dxa/pct`)
+  still trusts the grid Word baked its layout into (sample-3 unchanged).
+- **docx (RTL numbers):** a decimal inside an Arabic run drew reversed
+  (`1234.56` → `56.1234`). A single common separator between two numbers now joins
+  them into one left-to-right number (UAX#9 W4), so `1234.56` / `1,234.56` / `12:34`
+  stay intact while hyphen-separated dates still reorder.
+- **docx (RTL text boxes):** a rich (multi-format) text box drew its words in
+  logical order, scrambling RTL/mixed text. It now runs the same UAX#9 visual
+  reorder (rule L2) body paragraphs use, so RTL words read right-to-left while
+  Latin/number islands stay left-to-right (sample-8).
+
 ## 0.66.1 — 2026-06-23
 
 Patch. Hotfix for a 0.66.0 regression.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.66.1",
+  "version": "0.66.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release. DOCX RTL / table fidelity fixes ([#569](https://github.com/yukiyokotani/office-open-xml-viewer/pull/569), [#570](https://github.com/yukiyokotani/office-open-xml-viewer/pull/570)).

- **table auto-fit (#569):** `tblW=auto` tables size from `tcW`/content, not the stale full-width grid — restores sample-7's right/left-aligned cover tables (§17.4.63).
- **RTL numbers (#570):** a decimal in an Arabic run no longer reverses (`1234.56`, UAX#9 W4).
- **RTL text boxes (#570):** rich text-box words now reorder per UAX#9 L2 (sample-8 yellow box).

Bumps all 8 package versions to 0.66.2 + CHANGELOG. No API/feature changes.