### PR TITLE
fix(docx): cover page stands alone via §17.5.2 building block (sample-5 + sample-13 both correct)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -818,6 +818,11 @@ fn parse_body_elements(
     // persists across the body's paragraph walk rather than resetting per `<w:p>`.
     let mut field = FieldState::default();
 
+    // Positions in `body` of the synthetic page breaks emitted for Cover Pages
+    // building blocks (§17.5.2), so a redundant one can be dropped post-pass (see
+    // below) when the cover is already followed by a page-advancing construct.
+    let mut cover_break_positions: Vec<usize> = Vec::new();
+
     for (child, cover_break_after) in body_children {
         match child.tag_name().name() {
             "p" => {
@@ -837,43 +842,46 @@ fn parse_body_elements(
                 } else {
                     None
                 };
+                // A lone page/column break paragraph collapses to the break marker.
+                // (Use a fall-through `match` rather than an early `continue` so the
+                // `cover_break_after` push at the loop tail is still reached when a
+                // cover's last child is itself a lone break — rare, but it must not
+                // silently drop the cover's standalone-page break.)
                 match lone_break {
-                    Some(BreakType::Page) => {
-                        body.push(BodyElement::PageBreak { parity: None });
-                        continue;
+                    Some(BreakType::Page) => body.push(BodyElement::PageBreak { parity: None }),
+                    Some(BreakType::Column) => body.push(BodyElement::ColumnBreak),
+                    _ => {
+                        // Mid-paragraph page / column breaks come from
+                        // `<w:br w:type="page"/>` / `<w:br w:type="column"/>` (and the
+                        // ignored `<w:lastRenderedPageBreak/>`). Split the paragraph
+                        // around them and emit BodyElement::PageBreak / ColumnBreak
+                        // between the pieces — each piece keeps the same pPr so layout
+                        // continues correctly after the break.
+                        for piece in split_para_on_page_breaks(result) {
+                            match piece {
+                                ParaPiece::Para(p) => body.push(BodyElement::Paragraph(p)),
+                                ParaPiece::PageBreak => {
+                                    body.push(BodyElement::PageBreak { parity: None })
+                                }
+                                ParaPiece::ColumnBreak => body.push(BodyElement::ColumnBreak),
+                            }
+                        }
+                        // ECMA-376 §17.6.1: a section break inside pPr defines the
+                        // section that ENDS at this paragraph. Emit a SectionBreak
+                        // marker carrying that section's <w:cols> (§17.6.4) AND its
+                        // break kind (ST_SectionMark, §17.18.79) so the renderer can
+                        // switch the active column geometry per section — even for a
+                        // "continuous" break, which produces no page break but may
+                        // still change the column count. (Previously a "continuous"
+                        // break emitted nothing and the others emitted a column-less
+                        // PageBreak, so every section inherited the body-level
+                        // section's columns — the bug this fixes.)
+                        if let Some(sect_pr) =
+                            child_w(child, "pPr").and_then(|ppr| child_w(ppr, "sectPr"))
+                        {
+                            body.push(section_break_element(sect_pr));
+                        }
                     }
-                    Some(BreakType::Column) => {
-                        body.push(BodyElement::ColumnBreak);
-                        continue;
-                    }
-                    _ => {}
-                }
-                // Mid-paragraph page / column breaks come from
-                // `<w:br w:type="page"/>` / `<w:br w:type="column"/>` (and the
-                // ignored `<w:lastRenderedPageBreak/>`). Split the paragraph
-                // around them and emit BodyElement::PageBreak / ColumnBreak
-                // between the pieces — each piece keeps the same pPr so layout
-                // continues correctly after the break.
-                for piece in split_para_on_page_breaks(result) {
-                    match piece {
-                        ParaPiece::Para(p) => body.push(BodyElement::Paragraph(p)),
-                        ParaPiece::PageBreak => body.push(BodyElement::PageBreak { parity: None }),
-                        ParaPiece::ColumnBreak => body.push(BodyElement::ColumnBreak),
-                    }
-                }
-                // ECMA-376 §17.6.1: a section break inside pPr defines the
-                // section that ENDS at this paragraph. Emit a SectionBreak marker
-                // carrying that section's <w:cols> (§17.6.4) AND its break kind
-                // (ST_SectionMark, §17.18.79) so the renderer can switch the
-                // active column geometry per section — even for a "continuous"
-                // break, which produces no page break but may still change the
-                // column count. (Previously a "continuous" break emitted nothing
-                // and the others emitted a column-less PageBreak, so every
-                // section inherited the body-level section's columns — the bug
-                // this fixes.)
-                if let Some(sect_pr) = child_w(child, "pPr").and_then(|ppr| child_w(ppr, "sectPr"))
-                {
-                    body.push(section_break_element(sect_pr));
                 }
             }
             "tbl" => {
@@ -891,12 +899,48 @@ fn parse_body_elements(
         }
         // ECMA-376 §17.5.2: a "Cover Pages" building block occupies its own page
         // in Word — the following content (even a "continuous" section) starts on
-        // the next page. Emit the page break after the cover's content. The
-        // cover's last flattened child is a real paragraph (the anchor host),
-        // never a lone page/column break, so the `continue` fast-paths above are
-        // not taken for it and this push is reached.
+        // the next page. Emit the page break after the cover's content.
         if cover_break_after {
+            cover_break_positions.push(body.len());
             body.push(BodyElement::PageBreak { parity: None });
+        }
+    }
+
+    // Drop a cover's synthetic page break when the cover's content is ALREADY
+    // followed by a construct that starts a new page — a hard `<w:br w:type="page"/>`
+    // (PageBreak) or a section boundary (SectionBreak). In that case the cover
+    // stands alone via that construct, and the extra page break would leave a
+    // spurious BLANK page between the cover and the body (the renderer's pageBreak /
+    // page-advancing sectionBreak handlers push a page unconditionally — only
+    // `newPage()` coalesces an empty page). The common case (cover followed by a
+    // content paragraph, e.g. sample-5) keeps its break. Real consecutive hard page
+    // breaks are untouched: only the synthetic cover breaks are candidates here.
+    //
+    // Dropping before a SectionBreak assumes that boundary is page-advancing. Under
+    // the §17.6.22 upcoming-section reading a `continuous` next section would NOT
+    // advance, so in the (Word-never-emits) shape `cover sdt → loose body-level
+    // <w:sectPr> → continuous section` the cover would lose its standalone page.
+    // Word always carries a section-ending sectPr inside the last paragraph's pPr,
+    // which puts a Paragraph between the cover and the SectionBreak (the sample-5
+    // shape) — so `pos + 1` is that paragraph and the break is kept. Unreachable
+    // from Word output; accepted for hand-authored input.
+    if !cover_break_positions.is_empty() {
+        let drop: Vec<usize> = cover_break_positions
+            .into_iter()
+            .filter(|&pos| {
+                matches!(
+                    body.get(pos + 1),
+                    Some(BodyElement::PageBreak { .. }) | Some(BodyElement::SectionBreak { .. })
+                )
+            })
+            .collect();
+        if !drop.is_empty() {
+            body = body
+                .into_iter()
+                .enumerate()
+                .filter(|(i, _)| !drop.contains(i))
+                .map(|(_, e)| e)
+                .collect();
         }
     }
     body
@@ -8059,6 +8103,74 @@ mod column_tests {
         assert_eq!(body.len(), 2);
         assert!(matches!(body[0], BodyElement::Paragraph(_)));
         assert!(matches!(body[1], BodyElement::Paragraph(_)));
+    }
+
+    /// The synthetic cover break must NOT add a second page advance when the cover
+    /// is already followed by a hard `<w:br w:type="page"/>`: that would leave a
+    /// spurious blank page (the renderer pushes both pages unconditionally). The
+    /// cover stands alone via the explicit break; the synthetic one is dropped.
+    #[test]
+    fn cover_followed_by_hard_pagebreak_does_not_double_break() {
+        let body = body_from(
+            r#"<w:sdt>
+                 <w:sdtPr><w:docPartObj><w:docPartGallery w:val="Cover Pages"/></w:docPartObj></w:sdtPr>
+                 <w:sdtContent><w:p><w:r><w:t>cover</w:t></w:r></w:p></w:sdtContent>
+               </w:sdt>
+               <w:p><w:r><w:br w:type="page"/></w:r></w:p>
+               <w:p><w:r><w:t>body</w:t></w:r></w:p>"#,
+        );
+        // Para(cover), PageBreak (the explicit one only), Para(body) — exactly ONE
+        // page break, not two.
+        assert_eq!(body.len(), 3);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::PageBreak { .. }));
+        assert!(matches!(body[2], BodyElement::Paragraph(_)));
+    }
+
+    /// Likewise when the cover is immediately followed by a section boundary: the
+    /// section break advances the page, so the synthetic cover break is dropped to
+    /// avoid a blank page between the cover and the next section.
+    #[test]
+    fn cover_followed_by_section_break_does_not_double_break() {
+        let body = body_from(
+            r#"<w:sdt>
+                 <w:sdtPr><w:docPartObj><w:docPartGallery w:val="Cover Pages"/></w:docPartObj></w:sdtPr>
+                 <w:sdtContent><w:p><w:r><w:t>cover</w:t></w:r></w:p></w:sdtContent>
+               </w:sdt>
+               <w:sectPr><w:type w:val="nextPage"/></w:sectPr>
+               <w:p><w:r><w:t>body</w:t></w:r></w:p>"#,
+        );
+        // Para(cover), SectionBreak (the loose sectPr), Para(body) — no synthetic
+        // page break between the cover and the section boundary.
+        assert_eq!(body.len(), 3);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::SectionBreak { .. }));
+        assert!(matches!(body[2], BodyElement::Paragraph(_)));
+    }
+
+    /// Even when the cover's LAST content child is itself a lone break, the
+    /// standalone-page break is still emitted (the fall-through `match` reaches the
+    /// `cover_break_after` push). Here the cover ends with a column break; the
+    /// synthetic page break still follows, and is kept because real body content
+    /// (not another page/section break) comes next.
+    #[test]
+    fn cover_ending_in_lone_break_still_emits_standalone_pagebreak() {
+        let body = body_from(
+            r#"<w:sdt>
+                 <w:sdtPr><w:docPartObj><w:docPartGallery w:val="Cover Pages"/></w:docPartObj></w:sdtPr>
+                 <w:sdtContent>
+                   <w:p><w:r><w:t>cover</w:t></w:r></w:p>
+                   <w:p><w:r><w:br w:type="column"/></w:r></w:p>
+                 </w:sdtContent>
+               </w:sdt>
+               <w:p><w:r><w:t>body</w:t></w:r></w:p>"#,
+        );
+        // Para(cover), ColumnBreak, PageBreak (synthetic, kept), Para(body).
+        assert_eq!(body.len(), 4);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::ColumnBreak));
+        assert!(matches!(body[2], BodyElement::PageBreak { .. }));
+        assert!(matches!(body[3], BodyElement::Paragraph(_)));
     }
 
     /// ECMA-376 §17.6.x — a `<w:sectPr>` carried in a paragraph's `pPr` defines

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -751,6 +751,47 @@ fn parse_font_table(xml: &str) -> HashMap<String, String> {
     map
 }
 
+/// Body children with `<w:sdt>` wrappers unwrapped (identical node sequence to
+/// `element_children_flat`), each paired with a flag marking the LAST flattened
+/// child of a **"Cover Pages" building block** (ECMA-376 §17.5.2:
+/// `<w:sdt>/<w:sdtPr>/<w:docPartObj>/<w:docPartGallery w:val="Cover Pages"/>`).
+///
+/// Word treats a Cover Page building block as a standalone page at the document
+/// start: the following content begins on the NEXT page, even across a
+/// "continuous" section break. The cover's own text flow is typically empty —
+/// the visible page is filled by page-/margin-anchored cover graphics that do
+/// not advance the text cursor — so the paginator cannot infer the page-fill
+/// from content height. `parse_body_elements` models Word's behavior by emitting
+/// a `PageBreak` after the cover's content (where the flag is `true`). Without
+/// this, a `continuous` body section after the cover (governed by the upcoming
+/// section's start type, §17.6.22) would flow up onto the cover page.
+fn body_children_with_cover_breaks<'a, 'input>(
+    node: roxmltree::Node<'a, 'input>,
+) -> Vec<(roxmltree::Node<'a, 'input>, bool)> {
+    let mut out: Vec<(roxmltree::Node, bool)> = Vec::new();
+    for child in node.children().filter(|n| n.is_element()) {
+        let tn = child.tag_name();
+        if tn.namespace() == Some(W_NS) && tn.name() == "sdt" {
+            let is_cover = child_w(child, "sdtPr")
+                .and_then(|pr| child_w(pr, "docPartObj"))
+                .and_then(|obj| child_w(obj, "docPartGallery"))
+                .and_then(|g| attr_w(g, "val"))
+                .as_deref()
+                == Some("Cover Pages");
+            if let Some(content) = child_w(child, "sdtContent") {
+                let inner = element_children_flat(content);
+                let last = inner.len();
+                for (idx, c) in inner.into_iter().enumerate() {
+                    out.push((c, is_cover && idx + 1 == last));
+                }
+            }
+        } else {
+            out.push((child, false));
+        }
+    }
+    out
+}
+
 fn parse_body_elements(
     body_node: roxmltree::Node,
     style_map: &StyleMap,
@@ -762,11 +803,13 @@ fn parse_body_elements(
     let mut body: Vec<BodyElement> = Vec::new();
     // The body-level sectPr (the last element) defines the final section and
     // is not a page break. Mid-body sectPrs (nested in pPr) DO imply a page break.
-    let body_children = element_children_flat(body_node);
+    // The walk also flags the end of any "Cover Pages" building block so the
+    // cover gets its own page (see body_children_with_cover_breaks).
+    let body_children = body_children_with_cover_breaks(body_node);
     let body_level_sect_pr = body_children
         .iter()
         .last()
-        .copied()
+        .map(|(n, _)| *n)
         .filter(|n| n.tag_name().name() == "sectPr");
     let body_level_sect_id = body_level_sect_pr.map(|n| n.id());
 
@@ -775,7 +818,7 @@ fn parse_body_elements(
     // persists across the body's paragraph walk rather than resetting per `<w:p>`.
     let mut field = FieldState::default();
 
-    for child in body_children {
+    for (child, cover_break_after) in body_children {
         match child.tag_name().name() {
             "p" => {
                 let result = parse_paragraph(
@@ -845,6 +888,15 @@ fn parse_body_elements(
                 body.push(section_break_element(child));
             }
             _ => {}
+        }
+        // ECMA-376 §17.5.2: a "Cover Pages" building block occupies its own page
+        // in Word — the following content (even a "continuous" section) starts on
+        // the next page. Emit the page break after the cover's content. The
+        // cover's last flattened child is a real paragraph (the anchor host),
+        // never a lone page/column break, so the `continue` fast-paths above are
+        // not taken for it and this push is reached.
+        if cover_break_after {
+            body.push(BodyElement::PageBreak { parity: None });
         }
     }
     body
@@ -7950,6 +8002,63 @@ mod column_tests {
         assert!(matches!(body[2], BodyElement::Paragraph(_)));
         assert!(matches!(body[3], BodyElement::ColumnBreak));
         assert!(matches!(body[4], BodyElement::Paragraph(_)));
+    }
+
+    /// ECMA-376 §17.5.2 — a "Cover Pages" building block (sdt with
+    /// `<w:docPartObj>/<w:docPartGallery w:val="Cover Pages"/>`) occupies its own
+    /// page in Word: the following content starts on the next page. The parser
+    /// unwraps the sdt (its content flows inline) AND emits a `PageBreak` after
+    /// the cover's LAST content child so the paginator reproduces the page-fill.
+    /// Without this a "continuous" body section after the cover (sample-5) flows
+    /// up onto the cover page.
+    #[test]
+    fn cover_pages_building_block_emits_pagebreak_after_its_content() {
+        let body = body_from(
+            r#"<w:sdt>
+                 <w:sdtPr>
+                   <w:docPartObj>
+                     <w:docPartGallery w:val="Cover Pages"/>
+                     <w:docPartUnique/>
+                   </w:docPartObj>
+                 </w:sdtPr>
+                 <w:sdtContent>
+                   <w:p><w:r><w:t>cover-1</w:t></w:r></w:p>
+                   <w:p><w:r><w:t>cover-2</w:t></w:r></w:p>
+                 </w:sdtContent>
+               </w:sdt>
+               <w:p><w:r><w:t>body</w:t></w:r></w:p>"#,
+        );
+        // Para(cover-1), Para(cover-2), PageBreak, Para(body) — the break lands
+        // AFTER the cover's last child, not between the two cover paragraphs.
+        assert_eq!(body.len(), 4);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::Paragraph(_)));
+        assert!(matches!(body[2], BodyElement::PageBreak { .. }));
+        assert!(matches!(body[3], BodyElement::Paragraph(_)));
+    }
+
+    /// A non-cover sdt (no docPartObj, or a different gallery) is still unwrapped
+    /// transparently but must NOT inject a page break — only the "Cover Pages"
+    /// gallery gets the standalone-page treatment.
+    #[test]
+    fn non_cover_sdt_is_unwrapped_without_pagebreak() {
+        let body = body_from(
+            r#"<w:sdt>
+                 <w:sdtPr>
+                   <w:docPartObj>
+                     <w:docPartGallery w:val="Quick Parts"/>
+                   </w:docPartObj>
+                 </w:sdtPr>
+                 <w:sdtContent>
+                   <w:p><w:r><w:t>inside</w:t></w:r></w:p>
+                 </w:sdtContent>
+               </w:sdt>
+               <w:p><w:r><w:t>after</w:t></w:r></w:p>"#,
+        );
+        // Para(inside), Para(after) — no synthetic break.
+        assert_eq!(body.len(), 2);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::Paragraph(_)));
     }
 
     /// ECMA-376 §17.6.x — a `<w:sectPr>` carried in a paragraph's `pPr` defines

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -460,23 +460,44 @@ describe('computePages — per-section columns (§17.6.4, regression)', () => {
   });
 
   it('a continuous section break keeps both single-column sections on the SAME page, stacked', () => {
-    // The break uses the marker's own kind: A→B is a `continuous` break (B stacks
-    // below A on page 1), B→final is a `nextPage` break (final on page 2). Both A
-    // and B are single-column full width and must NOT reset to the page top.
+    // ECMA-376 §17.6.22: a section's `<w:type>` describes how THAT section begins
+    // relative to the previous one, and lives on the sectPr that ENDS the section
+    // (the NEXT marker in document order). So the A→B break is governed by section
+    // B's type — the kind of the marker that ENDS B (idx 3) — and the B→final break
+    // by the final (body) section's start type. Here B is continuous (stacks below
+    // A on page 1) and the final 2-col section is nextPage (default) → page 2. Both
+    // A and B are single-column full width and must NOT reset to the page top.
     const body: BodyElement[] = [
       para({ text: 'A', fontSize: 20 }),
-      sectionBreak('continuous', null),
+      sectionBreak('continuous', null), // ends section A (A's own start type)
       para({ text: 'B', fontSize: 20 }),
-      sectionBreak('nextPage', null),
+      sectionBreak('continuous', null), // ends section B ⇒ B begins continuously (A→B same page)
       para({ text: 'final', fontSize: 20 }),
     ];
     const pages = computePages(body, finalTwoCol(), makeCtx());
     expect(pages.length).toBe(2);
+    // A and B share page 1 (B continuous), final on page 2 (final section nextPage).
     expect(pages[0].map(textOf)).toEqual(['A', 'B']);
     expect(pages[1].map(textOf)).toEqual(['final']);
     for (const el of pages[0]) {
       expect(colGeomOf(el)).toEqual([{ xPt: 20, wPt: 160 }]);
     }
+  });
+
+  it('the break INTO a section is governed by that section start type, not the prior marker (§17.6.22)', () => {
+    // Regression for the off-by-one: a title section whose own sectPr is nextPage
+    // (the spec default) followed by a continuous body section must NOT page-break —
+    // the boundary is governed by the FOLLOWING (body) section's start type. Mirrors
+    // sample-13, where Word keeps the 2-col body on the title page.
+    const body: BodyElement[] = [
+      para({ text: 'title', fontSize: 20 }),
+      sectionBreak('nextPage', null), // ends the title section (its own start type)
+      para({ text: 'body', fontSize: 20 }),
+    ];
+    const sec = { ...finalTwoCol(), columns: null, sectionStart: 'continuous' };
+    const pages = computePages(body, sec, makeCtx());
+    expect(pages.length).toBe(1);
+    expect(pages[0].map(textOf)).toEqual(['title', 'body']);
   });
 
   it('single-section 2-col docs are UNCHANGED (no SectionBreak markers ⇒ whole body uses section.columns)', () => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1055,6 +1055,33 @@ export function computePages(
     return computeColumns(section);
   };
 
+  // ECMA-376 §17.6.22 (ST_SectionMark): a section's `<w:type>` specifies how
+  // THAT section begins relative to the previous one (continuous ⇒ same page;
+  // nextPage/odd/even ⇒ a new page). The type lives on the section's OWN sectPr,
+  // which the parser stamps on the SectionBreak marker that ENDS that section.
+  // So the break at a boundary is governed by the UPCOMING section's type — the
+  // kind of the NEXT marker at/after `startIdx`, exactly like sectionColumnsFrom
+  // resolves the upcoming section's columns. (A marker's own kind is the start
+  // type of the section it closes — relevant at the PREVIOUS boundary, not this
+  // one. Using it here is an off-by-one that turns e.g. a title section's
+  // type="nextPage" into a spurious page break before a following
+  // type="continuous" body section.) The last section (no following marker) uses
+  // the body sectPr's start type; absent ⇒ "nextPage" (the spec default).
+  //
+  // A `continuous` body that would otherwise flow up onto a full cover page does
+  // NOT regress here: Word places a "Cover Pages" building block (ECMA-376
+  // §17.5.2 docPartGallery) on its own page, and the parser models that by
+  // emitting a PageBreak after the cover's content — so the continuous section
+  // after a cover lands on the next page regardless of this upcoming-section
+  // reading. See `parse_body_elements` (cover-page page-fill) in the parser.
+  const sectionKindFrom = (startIdx: number): string => {
+    for (let j = startIdx; j < body.length; j++) {
+      const e = body[j];
+      if (e.type === 'sectionBreak') return e.kind ?? 'nextPage';
+    }
+    return section.sectionStart ?? 'nextPage';
+  };
+
   // The active section's column geometry. Reassigned (a) here for the first
   // section and (b) at every `SectionBreak` as the flow enters the next section.
   // `colIndex` tracks which column we are filling; `colX()`/`colW()` give its
@@ -1424,15 +1451,13 @@ export function computePages(
       // columns instead of every section inheriting the body-level section's.
       columns = sectionColumnsFrom(i + 1);
       colIndex = 0;
-      // HOTFIX: use THIS marker's own kind for the break. The §17.6.22
-      // "upcoming-section" reading (sectionKindFrom) was correct for a continuous
-      // body that follows a title section (sample-13), but it wrongly turned a
-      // cover page's explicit `nextPage` break into a continuous one, flowing the
-      // body up onto the cover (sample-5 — the novel's text overprinted the title
-      // page). The marker's own kind is the safe, regression-free reading; the
-      // upcoming-section nuance needs the cover's page-fill (vAlign) modelled
-      // first. TODO: revisit with sample-5 + sample-13 both pinned.
-      const upcomingKind = el.kind ?? 'nextPage';
+      // The break is governed by the UPCOMING section's start type (§17.6.22),
+      // not this marker's own kind (the section it closes). See sectionKindFrom.
+      // The sample-5 cover overprint that prompted the 0.66.1 hotfix is now fixed
+      // at its real root: the parser emits a PageBreak after a "Cover Pages"
+      // building block, so the continuous body after the cover lands on page 2
+      // without forcing every nextPage→continuous boundary to break a page.
+      const upcomingKind = sectionKindFrom(i + 1);
       if (upcomingKind === 'continuous') {
         // ECMA-376 §17.18.79 "continuous": NO page break — the next section's
         // content continues on the SAME page. It must start below the BOTTOM of

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -30,7 +30,8 @@ const rendererMod = skia ? await import(RENDERER_PATH).catch(() => null) : null;
 
 const samplePath = (n: number) =>
   resolve(ROOT, `packages/docx/public/private/sample-${n}.docx`);
-const haveSamples = existsSync(samplePath(12)) && existsSync(samplePath(13));
+const haveSamples =
+  existsSync(samplePath(5)) && existsSync(samplePath(12)) && existsSync(samplePath(13));
 
 // ECMA-376 §17.6.4 newspaper columns + §17.18.79 "continuous" section marks.
 // Both journal templates flow their body through `continuous` section breaks
@@ -65,13 +66,25 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !haveSamples)(
       expect(paginate(12).length).toBe(3);
     });
 
-    // 5 pages, matching Word, once non-final continuous multi-column sections are
-    // balanced (§17.6.4): a short 2-col section's content is split across both
-    // columns instead of packing column 0, which frees vertical space for the
-    // following full-width element on the same page and densifies the whole flow.
-    // The final (references) section stays greedy, as Word leaves it.
-    it.fails('sample-13 paginates to 5 pages — off-by-one reverted for the sample-5 hotfix (now 6)', () => {
+    // 5 pages, matching Word. The intro 2-col section opens with a "continuous"
+    // section break, so it stays on the title page (§17.6.22: the break is
+    // governed by the upcoming section's start type, not the title section's
+    // nextPage). Restored after the sample-5 cover overprint was fixed at its
+    // real root — a PageBreak after the "Cover Pages" building block (§17.5.2) —
+    // instead of forcing every nextPage→continuous boundary to break a page.
+    it('sample-13 paginates to 5 pages (Word ground truth)', () => {
       expect(paginate(13).length).toBe(5);
+    });
+
+    // sample-5 (夢十夜): the cover is a "Cover Pages" building block (§17.5.2)
+    // whose text flow is empty — the page is filled by page-anchored cover
+    // graphics. Word places it on its own page and starts the novel body on
+    // page 2, even though the body section opens with a "continuous" break. The
+    // parser emits a PageBreak after the cover content so the cover stands alone:
+    // 7 pages. Were the cover detection to fail, the continuous body would flow
+    // up onto page 1 and the document would collapse to 6 pages.
+    it('sample-5 cover page stands alone — 7 pages (Word ground truth)', () => {
+      expect(paginate(5).length).toBe(7);
     });
   },
 );


### PR DESCRIPTION
## Problem

With the spec-correct §17.6.22 reading (a section break is governed by the **upcoming** section's start type), sample-13's 2-col intro correctly stays on the title page (5 pages) — but sample-5's novel body flowed up and **overprinted the 夢十夜 cover**. The 0.66.1 hotfix (`5881795`) reverted to the marker's own kind to stop the overprint, which pushed sample-13's intro back to page 2 (6 pages). The two could not both be correct.

## Root cause (the 0.66.1 handoff guess was wrong)

The handoff note assumed the cover was a full-page floating **image** whose vertical extent should be reserved. **sample-5 has no images at all** (no `word/media/`, zero `<w:drawing>` in the body flow). The cover is a Word **"Cover Pages" building block** — a body-level `<w:sdt>` with `<w:sdtPr>/<w:docPartObj>/<w:docPartGallery w:val="Cover Pages"/>` (ECMA-376 §17.5.2). Its text flow is **empty**; the page is filled by page-/margin-anchored cover graphics (incl. a 556 pt `behindDoc=1` background group) that do **not** advance the text cursor — so the paginator cannot infer the page-fill from content height.

Word places a Cover Pages building block on **its own page** and starts the following content on the next page, even across a `continuous` section break. That page break is **not present in the XML** — it is Word runtime behavior tied to the documented building-block signal.

A `behindDoc`/`wrapNone` float does not reserve text space per §20.4.2.x, so a float-occupancy rule would have been a heuristic. Honoring the documented building-block gallery is narrower and lower-risk.

## Fix

- **renderer.ts**: restore the §17.6.22 `sectionKindFrom` reading (break governed by the upcoming section's start type, not the marker's own kind). Fixes sample-13.
- **parser.rs**: `body_children_with_cover_breaks` detects a body-level Cover Pages sdt; `parse_body_elements` emits a synthetic `PageBreak` after the cover's content so the cover stands alone. Fixes sample-5 at its real root — without forcing every `nextPage → continuous` boundary to break a page.

## Verification (Word PDF ground truth)

| sample | result |
|--------|--------|
| sample-5 | cover **alone** on page 1 (0 body paragraphs; 「こんな夢を見た」 is on page 2), **7 pages** |
| sample-13 | intro on page 1, **5 pages** |
| sample-12 | **3 pages** (unchanged) |

- docx **267** tests + docx-parser **151** tests green (incl. 2 new parser unit tests for the Cover Pages gallery, and the restored §17.6.22 pagination tests).
- root `pnpm typecheck` green.
- `packages/node/src/docx-continuous-columns.test.ts` now gates sample-5 = 7 and sample-13 = 5 against the Word PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)