### PR TITLE
chore(release): 0.66.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.66.3 — 2026-06-24
+
+Patch. DOCX cover-page fix — resolves the 0.66.1 hotfix trade-off (sample-5 and
+sample-13 are now both correct).
+
+- **docx (cover page):** sample-5's novel body overprinted the 夢十夜 title page,
+  and the 0.66.1 hotfix that fixed it pushed sample-13's intro off the title page.
+  The cover is a Word "Cover Pages" building block (ECMA-376 §17.5.2
+  `docPartGallery="Cover Pages"`) whose text flow is empty — the page is filled by
+  page-anchored cover graphics that don't advance the text cursor — so Word places
+  it on its own page via an implicit break. The parser now emits a page break after
+  a Cover Pages block, and the section-break reading is restored to the upcoming
+  section's start type (§17.6.22). The cover stands alone (sample-5: 7 pages) while
+  a `continuous` body after a title section stays on the title page (sample-13: 5
+  pages); sample-12 unchanged (3 pages). A redundant cover break adjacent to an
+  explicit page/section break is dropped to avoid a spurious blank page.
+
 ## 0.66.2 — 2026-06-23
 
 Patch. DOCX RTL / table fidelity fixes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.66.2",
+  "version": "0.66.3",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Patch release. DOCX cover-page section-break fix — resolves the 0.66.1 hotfix trade-off so sample-5 and sample-13 are both correct.

See [#573](https://github.com/yukiyokotani/office-open-xml-viewer/pull/573) for the fix. The cover (夢十夜) is a Word "Cover Pages" building block (ECMA-376 §17.5.2 `docPartGallery`) with an empty text flow; the parser now emits a page break after such a block, and the section-break reading is restored to the upcoming section's start type (§17.6.22).

Ground truth (Word PDFs): sample-5 = cover alone, 7 pages; sample-13 = intro on title page, 5 pages; sample-12 = 3 pages (unchanged).

- CHANGELOG: 0.66.3 entry
- Version bump: root + 7 packages → 0.66.3
- No public API / format / bundle changes (bug fix only); README Feature Support unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)