### PR TITLE
fix(xlsx): honor a:srcRect image crop and stop the double-draw that hid it

### DIFF
--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -12,6 +12,35 @@ use std::io::Cursor;
 /// Parse `<xdr:twoCellAnchor>` elements from a drawing XML and resolve
 /// embedded pictures into data URLs. `drawing_dir` is the folder that
 /// contains `drawing_path` so relative `Target`s resolve correctly.
+/// Parse `<a:srcRect l t r b>` from a `<xdr:blipFill>` node (ECMA-376 §20.1.8.55).
+/// Each edge attribute is a ST_Percentage in 1000ths of a percent, so the crop
+/// fraction is the raw value `/ 100000`; absent edges default to `0`. Returns
+/// `None` when there is no `srcRect` or all four edges are zero (no crop), so an
+/// uncropped picture never forces the renderer onto the sub-rectangle path.
+pub(crate) fn parse_src_rect(blip_fill: roxmltree::Node<'_, '_>) -> Option<SrcRect> {
+    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    let sr = blip_fill
+        .children()
+        .find(|n| n.tag_name().name() == "srcRect" && n.tag_name().namespace() == Some(a_ns))?;
+    let read = |name: &str| -> f64 {
+        sr.attribute(name)
+            .and_then(|v| v.parse::<f64>().ok())
+            .map(|v| v / 100_000.0)
+            .unwrap_or(0.0)
+    };
+    let rect = SrcRect {
+        l: read("l"),
+        t: read("t"),
+        r: read("r"),
+        b: read("b"),
+    };
+    if rect.l.abs() < 1e-9 && rect.t.abs() < 1e-9 && rect.r.abs() < 1e-9 && rect.b.abs() < 1e-9 {
+        None
+    } else {
+        Some(rect)
+    }
+}
+
 pub(crate) fn parse_drawing_anchors(
     drawing_xml: &str,
     drawing_rels: &HashMap<String, String>,
@@ -41,6 +70,8 @@ pub(crate) fn parse_drawing_anchors(
         let mut svg_rid: Option<String> = None;
         let mut native_ext_cx: i64 = 0;
         let mut native_ext_cy: i64 = 0;
+        // ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop (None ⇒ uncropped).
+        let mut src_rect: Option<SrcRect> = None;
         // ECMA-376 §20.5.2.33 `twoCellAnchor@editAs`. Possible values:
         // "twoCell" (default), "oneCell", "absolute". With "oneCell" Excel
         // preserves the picture's saved size from <xdr:spPr><a:xfrm><a:ext>
@@ -97,6 +128,8 @@ pub(crate) fn parse_drawing_anchors(
                             // blip's `<a:extLst>`), matched by namespace-local name.
                             svg_rid = svg_blip_rid(b);
                         }
+                        // `<a:srcRect>` is a sibling of `<a:blip>` inside blipFill.
+                        src_rect = parse_src_rect(bf);
                     }
                     // <xdr:pic><xdr:spPr><a:xfrm><a:ext cx cy>: the picture's
                     // own saved EMU extent. Authoritative when editAs="oneCell".
@@ -161,6 +194,7 @@ pub(crate) fn parse_drawing_anchors(
             image_path,
             mime_type,
             svg_image_path,
+            src_rect,
         });
     }
     anchors
@@ -1197,7 +1231,20 @@ pub(crate) fn parse_shape_anchors(
                 &mut shapes,
             );
         } else if let Some(sp) = content.children().find(|n| {
-            n.is_element() && (n.tag_name().name() == "sp" || n.tag_name().name() == "pic")
+            if !n.is_element() {
+                return false;
+            }
+            let t = n.tag_name().name();
+            // A standalone `<xdr:sp>` always renders through the shape path. A
+            // standalone `<xdr:pic>` under a `twoCellAnchor`, however, is ALSO a
+            // plain image anchor that `parse_drawing_anchors` already emits into
+            // `ws.images` — WITH its `<a:srcRect>` crop, svgBlip vector original,
+            // and `editAs` size. Capturing it here too would draw the picture a
+            // second time as an uncropped full-image shape, overwriting the
+            // cropped anchor draw (the sample-27 regression). So a `twoCellAnchor`
+            // pic is owned solely by `ws.images`; we only keep a standalone pic
+            // for `oneCellAnchor`, which `parse_drawing_anchors` does not handle.
+            t == "sp" || (t == "pic" && anchor_tag == "oneCellAnchor")
         }) {
             // Stand-alone sp/pic: the shape's own xfrm gives its absolute EMU
             // rect, but for our rendering pipeline the anchor's from/to
@@ -1720,6 +1767,72 @@ mod style_lnref_tests {
         assert_eq!(color.as_deref(), Some("#4472C4"));
         assert_eq!(width, 9_525);
     }
+
+    /// A standalone `<xdr:pic>` directly under a `twoCellAnchor` is a plain image
+    /// anchor owned by `ws.images` (parse_drawing_anchors, WITH its `<a:srcRect>`
+    /// crop). `parse_shape_anchors` must NOT also capture it — otherwise the
+    /// renderer draws the picture twice and the uncropped shape draw overwrites
+    /// the cropped anchor draw (the sample-27 double-draw regression).
+    #[test]
+    fn standalone_twocellanchor_pic_is_not_a_shape_anchor() {
+        let xml = format!(
+            r#"<xdr:wsDr {NS} xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:twoCellAnchor editAs="oneCell">
+              <xdr:from><xdr:col>9</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+              <xdr:to><xdr:col>11</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>10</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+              <xdr:pic>
+                <xdr:nvPicPr><xdr:cNvPr id="2" name="P"/><xdr:cNvPicPr/></xdr:nvPicPr>
+                <xdr:blipFill><a:blip r:embed="rId1"/><a:srcRect l="32560" r="3829"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>
+                <xdr:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2905125" cy="2181225"/></a:xfrm>
+                  <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr>
+              </xdr:pic>
+              <xdr:clientData/>
+            </xdr:twoCellAnchor></xdr:wsDr>"#
+        );
+        let anchors = parse_shape_anchors(&xml, &theme(), &[6_350], &HashMap::new());
+        assert!(
+            anchors.is_empty(),
+            "twoCellAnchor pic belongs to ws.images, not ws.shape_groups: {anchors:?}"
+        );
+    }
+
+    /// A standalone `<xdr:sp>` under the same anchor IS a shape anchor — only the
+    /// `pic` is deduped, never a real shape.
+    #[test]
+    fn standalone_sp_is_still_a_shape_anchor() {
+        let (color, _width) = shape_of(
+            r#"<a:ln w="12700"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln>"#,
+            "",
+        );
+        assert_eq!(color.as_deref(), Some("#FF0000"), "sp still captured");
+    }
+
+    /// A `oneCellAnchor` pic is NOT handled by `parse_drawing_anchors` (which only
+    /// scans `twoCellAnchor`), so the shape path must keep capturing it — else the
+    /// image is dropped entirely.
+    #[test]
+    fn standalone_onecellanchor_pic_is_still_captured() {
+        let xml = format!(
+            r#"<xdr:wsDr {NS} xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:oneCellAnchor>
+              <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+              <xdr:ext cx="914400" cy="914400"/>
+              <xdr:pic>
+                <xdr:nvPicPr><xdr:cNvPr id="2" name="P"/><xdr:cNvPicPr/></xdr:nvPicPr>
+                <xdr:blipFill><a:blip r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>
+                <xdr:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                  <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr>
+              </xdr:pic>
+              <xdr:clientData/>
+            </xdr:oneCellAnchor></xdr:wsDr>"#
+        );
+        let mut rids = HashMap::new();
+        rids.insert("rId1".to_string(), "xl/media/image1.png".to_string());
+        let anchors = parse_shape_anchors(&xml, &theme(), &[6_350], &rids);
+        assert_eq!(anchors.len(), 1, "oneCellAnchor pic must still be captured");
+        assert!(
+            matches!(anchors[0].shapes[0].geom, ShapeGeom::Image { .. }),
+            "captured as an image-geom shape"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1917,6 +2030,51 @@ mod blip_svg_tests {
         assert_eq!(anchor.native_ext_cy, 300000);
     }
 
+    /// End-to-end wiring guard: a `<xdr:pic>` whose `<xdr:blipFill>` carries an
+    /// `<a:srcRect>` sibling of the blip must surface the crop on the parsed
+    /// `ImageAnchor.src_rect` (sample-27's horizontal crop). Catches a regression
+    /// that drops the `parse_src_rect(bf)` wiring from the pic branch.
+    #[test]
+    fn picture_with_src_rect_surfaces_crop() {
+        let blip = r#"<a:blip r:embed="rIdPng"/><a:srcRect l="32560" r="3829"/>"#;
+        let mut rels = HashMap::new();
+        rels.insert("rIdPng".to_string(), "../media/image1.png".to_string());
+
+        let anchor = parse_one(blip, &rels);
+
+        let sr = anchor
+            .src_rect
+            .as_ref()
+            .expect("srcRect surfaced on the anchor");
+        assert!((sr.l - 0.3256).abs() < 1e-9);
+        assert!((sr.r - 0.03829).abs() < 1e-9);
+        assert_eq!(sr.t, 0.0);
+        assert_eq!(sr.b, 0.0);
+
+        // It serializes as camelCase `srcRect` so the TS renderer can read it.
+        let json = serde_json::to_string(&anchor).unwrap();
+        assert!(json.contains("\"srcRect\""), "emits srcRect: {json}");
+    }
+
+    /// An uncropped `<xdr:pic>` (no `<a:srcRect>`) leaves `src_rect == None`, and
+    /// the serialized JSON omits the key entirely (skip_serializing_if), so the
+    /// common case stays on the cheap full-blip draw path.
+    #[test]
+    fn picture_without_src_rect_omits_crop() {
+        let blip = r#"<a:blip r:embed="rIdPng"/>"#;
+        let mut rels = HashMap::new();
+        rels.insert("rIdPng".to_string(), "../media/image1.png".to_string());
+
+        let anchor = parse_one(blip, &rels);
+
+        assert!(anchor.src_rect.is_none());
+        let json = serde_json::to_string(&anchor).unwrap();
+        assert!(
+            !json.contains("srcRect"),
+            "omits srcRect when absent: {json}"
+        );
+    }
+
     /// A `<xdr:pic>` whose `<a:blip>` carries ONLY the `asvg:svgBlip` extension —
     /// no raster `r:embed` fallback (an icon inserted as a pure SVG) — must still
     /// parse. Previously the media filter excluded `.svg` and the resolution
@@ -1992,6 +2150,7 @@ mod blip_svg_tests {
             image_path: "xl/media/image1.png".to_string(),
             mime_type: "image/png".to_string(),
             svg_image_path: Some("xl/media/image2.svg".to_string()),
+            src_rect: None,
         };
         let json = serde_json::to_string(&anchor).unwrap();
         assert!(json.contains("\"imagePath\":\"xl/media/image1.png\""));
@@ -2103,5 +2262,55 @@ mod custom_path_arc_tests {
             "snake_case angle keys must not appear (regresses the NaN bug)"
         );
         assert_eq!(obj.get("swAng").and_then(|v| v.as_f64()), Some(5_400_000.0));
+    }
+}
+
+#[cfg(test)]
+mod src_rect_tests {
+    use super::*;
+
+    const NS: &str = r#"xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+        xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+        xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships""#;
+
+    /// sample-27: `<a:srcRect l="32560" r="3829"/>` ⇒ left 0.3256, right 0.03829,
+    /// top/bottom 0 (absent edges default 0). Edge attrs are ST_Percentage in
+    /// 1000ths of a percent, so the fraction is the raw value / 100000.
+    #[test]
+    fn parses_horizontal_crop_fractions() {
+        let xml = format!(
+            r#"<xdr:blipFill {NS}>
+              <a:blip r:embed="rId1"/>
+              <a:srcRect l="32560" r="3829"/>
+              <a:stretch><a:fillRect/></a:stretch>
+            </xdr:blipFill>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let sr = parse_src_rect(doc.root_element()).expect("srcRect present");
+        assert!((sr.l - 0.3256).abs() < 1e-9, "l = l_attr / 100000");
+        assert!((sr.r - 0.03829).abs() < 1e-9, "r = r_attr / 100000");
+        assert_eq!(sr.t, 0.0, "absent top defaults to 0");
+        assert_eq!(sr.b, 0.0, "absent bottom defaults to 0");
+    }
+
+    /// No `<a:srcRect>` ⇒ None (uncropped picture, the common case).
+    #[test]
+    fn absent_src_rect_is_none() {
+        let xml = format!(
+            r#"<xdr:blipFill {NS}><a:blip r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        assert!(parse_src_rect(doc.root_element()).is_none());
+    }
+
+    /// An all-zero `<a:srcRect>` ⇒ None: an explicit no-op crop must not push the
+    /// renderer onto the 9-arg sub-rect path (which would be an identity draw).
+    #[test]
+    fn all_zero_src_rect_is_none() {
+        let xml = format!(
+            r#"<xdr:blipFill {NS}><a:blip r:embed="rId1"/><a:srcRect l="0" t="0" r="0" b="0"/></xdr:blipFill>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        assert!(parse_src_rect(doc.root_element()).is_none());
     }
 }

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1038,6 +1038,12 @@ pub(crate) fn collect_shapes(
             let svg_image_path = svg_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
             let raster_path = pic_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
 
+            // `<a:srcRect>` crop lives in the leaf's `<xdr:blipFill>` (§20.1.8.55).
+            let src_rect = child
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "blipFill")
+                .and_then(parse_src_rect);
+
             // Prefer the raster as `image_path`; fall back to the SVG when no
             // raster is embedded so an svg-only leaf is never dropped. Drop only
             // when neither resolves. ECMA-376 §20.1.8.13 + MS-ODRAWXML svgBlip.
@@ -1076,6 +1082,7 @@ pub(crate) fn collect_shapes(
                     image_path,
                     mime_type,
                     svg_image_path,
+                    src_rect,
                 },
                 text: None,
             });
@@ -1808,16 +1815,17 @@ mod style_lnref_tests {
 
     /// A `oneCellAnchor` pic is NOT handled by `parse_drawing_anchors` (which only
     /// scans `twoCellAnchor`), so the shape path must keep capturing it — else the
-    /// image is dropped entirely.
+    /// image is dropped entirely. Its `<a:srcRect>` crop must also be surfaced on
+    /// the `ShapeGeom::Image` so the renderer can crop it like a top-level anchor.
     #[test]
-    fn standalone_onecellanchor_pic_is_still_captured() {
+    fn standalone_onecellanchor_pic_is_still_captured_with_crop() {
         let xml = format!(
             r#"<xdr:wsDr {NS} xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:oneCellAnchor>
               <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
               <xdr:ext cx="914400" cy="914400"/>
               <xdr:pic>
                 <xdr:nvPicPr><xdr:cNvPr id="2" name="P"/><xdr:cNvPicPr/></xdr:nvPicPr>
-                <xdr:blipFill><a:blip r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>
+                <xdr:blipFill><a:blip r:embed="rId1"/><a:srcRect l="10000" t="20000"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>
                 <xdr:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
                   <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr>
               </xdr:pic>
@@ -1828,10 +1836,16 @@ mod style_lnref_tests {
         rids.insert("rId1".to_string(), "xl/media/image1.png".to_string());
         let anchors = parse_shape_anchors(&xml, &theme(), &[6_350], &rids);
         assert_eq!(anchors.len(), 1, "oneCellAnchor pic must still be captured");
-        assert!(
-            matches!(anchors[0].shapes[0].geom, ShapeGeom::Image { .. }),
-            "captured as an image-geom shape"
-        );
+        match &anchors[0].shapes[0].geom {
+            ShapeGeom::Image { src_rect, .. } => {
+                let sr = src_rect
+                    .as_ref()
+                    .expect("leaf pic surfaces its srcRect crop");
+                assert!((sr.l - 0.1).abs() < 1e-9);
+                assert!((sr.t - 0.2).abs() < 1e-9);
+            }
+            other => panic!("expected an image-geom shape, got {other:?}"),
+        }
     }
 }
 
@@ -2170,6 +2184,7 @@ mod blip_svg_tests {
             image_path: "xl/media/image1.png".to_string(),
             mime_type: "image/png".to_string(),
             svg_image_path: None,
+            src_rect: None,
         };
         let json = serde_json::to_string(&geom).unwrap();
         assert!(json.contains("\"type\":\"image\""));

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -1108,6 +1108,24 @@ pub struct ImageAnchor {
     /// and is owned by the SVG decoder.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub svg_image_path: Option<String>,
+    /// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop, present only when the
+    /// picture is cropped. `None` (the common case) ⇒ the whole blip fills the
+    /// anchor rect. When set, the renderer draws only the visible sub-rectangle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src_rect: Option<SrcRect>,
+}
+
+/// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop. Each edge inset is a
+/// fraction `0..1` of the *source* bitmap (the raw 1000ths-of-a-percent
+/// attribute `/ 100000`), measured inward from that edge, so the visible source
+/// region is `[l, t, 1-r, 1-b]`. Absent edges default to `0`.
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SrcRect {
+    pub l: f64,
+    pub t: f64,
+    pub r: f64,
+    pub b: f64,
 }
 
 #[derive(Debug, Serialize)]

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -972,6 +972,12 @@ pub enum ShapeGeom {
         mime_type: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         svg_image_path: Option<String>,
+        /// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop on the leaf pic,
+        /// present only when cropped. Honored by the renderer like the top-level
+        /// `ImageAnchor.src_rect` so a `oneCellAnchor` / `grpSp` leaf pic crops
+        /// the same as a `twoCellAnchor` picture.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        src_rect: Option<SrcRect>,
     },
 }
 

--- a/packages/xlsx/src/render-orchestrator.image.test.ts
+++ b/packages/xlsx/src/render-orchestrator.image.test.ts
@@ -168,6 +168,33 @@ describe('render-orchestrator image decode (lazy bytes)', () => {
     expect(createImageBitmap).toHaveBeenCalledTimes(1);
   });
 
+  it('decodeImageSource forces the raster (not the SVG vector) when the picture is cropped', async () => {
+    // A cropped picture (`hasCrop=true`) with an svgBlip vector original must
+    // decode the RASTER fallback: the renderer's `<a:srcRect>` crop math needs
+    // the bitmap's native pixel grid, which an SVG element lacks. So even with
+    // svgImagePath present, createImageBitmap (raster) is the path taken.
+    const bmp = new FakeBitmap('image/png');
+    const createImageBitmap = vi.fn(async () => bmp);
+    vi.stubGlobal('createImageBitmap', createImageBitmap);
+    const fetchImage = vi.fn(async (_p: string, mime: string) => new Blob(['X'], { type: mime }));
+
+    const src = await decodeImageSource(
+      'xl/media/image1.png',
+      'image/png',
+      'xl/media/image1.svg', // svgBlip present …
+      fetchImage,
+      0,
+      0,
+      true, // … but the picture is cropped → raster wins
+    );
+
+    expect(src).toBe(bmp);
+    expect(createImageBitmap).toHaveBeenCalledTimes(1);
+    expect(fetchImage).toHaveBeenCalledWith('xl/media/image1.png', 'image/png');
+    // The SVG part is never fetched when a crop forces the raster path.
+    expect(fetchImage).not.toHaveBeenCalledWith('xl/media/image1.svg', expect.anything());
+  });
+
   it('decodeImageSource rasterizes a WMF blip (no throw) instead of vanishing', async () => {
     // A WMF blob used to throw in createImageBitmap; now decodeImageSource routes
     // through core's decodeRasterOrMetafile, which sniffs + rasterizes it.

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -19,15 +19,20 @@ interface ImageRef {
   svgImagePath?: string;
   widthPt?: number;
   heightPt?: number;
+  /** True when the picture carries an `<a:srcRect>` crop, so the decoder forces
+   *  the raster (the crop math needs native bitmap pixels). */
+  hasCrop?: boolean;
 }
 
 /** Fetch one image's bytes by zip path and decode them to a drawable
  *  `CanvasImageSource`, preferring the Microsoft svgBlip vector original
  *  (MS-ODRAWXML). Unified across the top-level twoCellAnchor picture
  *  (`ImageAnchor`) and the `<xdr:grpSp>` leaf (`ShapeGeom` image) — both carry a
- *  raster `imagePath` fallback plus an optional `svgImagePath`. xlsx images have
- *  no `a:srcRect` crop, so the vector branch always applies when an svgBlip is
- *  present (cf. the contract's `!srcRect` gate).
+ *  raster `imagePath` fallback plus an optional `svgImagePath`. The svgBlip
+ *  vector branch applies only when the picture is NOT cropped: with an
+ *  `<a:srcRect>` crop (`hasCrop`) we force the raster, because the renderer's
+ *  crop math needs the decoded bitmap's native pixel grid (an SVG element has
+ *  none). Mirrors the pptx renderer's `!srcRect` vector gate.
  *
  *  Raster decodes to an `ImageBitmap` through core's
  *  {@link decodeRasterOrMetafile} (which content-sniffs the bytes: a WMF, which
@@ -49,13 +54,16 @@ export async function decodeImageSource(
   fetchImage: (path: string, mime: string) => Promise<Blob>,
   widthPt = 0,
   heightPt = 0,
+  hasCrop = false,
 ): Promise<CanvasImageSource | null> {
   const decodeRaster = async (path: string, mime: string): Promise<CanvasImageSource | null> =>
     decodeRasterOrMetafile(await fetchImage(path, mime), { widthPt, heightPt });
   const dataIsSvg = mimeType === 'image/svg+xml';
-  if (svgImagePath != null) {
-    // Prefer the vector original; fall back to the raster fallback on decode
+  if (svgImagePath != null && !hasCrop) {
+    // No crop: prefer the vector original; fall back to the raster on decode
     // failure (or, when `imagePath` is itself the SVG, the SVG decoder again).
+    // A cropped picture skips this branch so the crop math (below, in the
+    // renderer) runs on the raster bitmap's native pixel dimensions.
     try {
       return await getCachedSvgImageByPath(svgImagePath, fetchImage);
     } catch {
@@ -99,6 +107,8 @@ export async function prefetchImages(
           // Saved EMU extent → pt sizes a metafile raster (0 ⇒ decoder fallback).
           widthPt: img.nativeExtCx > 0 ? img.nativeExtCx / EMU_PER_PT : 0,
           heightPt: img.nativeExtCy > 0 ? img.nativeExtCy / EMU_PER_PT : 0,
+          // An `<a:srcRect>` crop forces the raster decode (native pixel grid).
+          hasCrop: img.srcRect != null,
         });
       }
     }
@@ -130,6 +140,7 @@ export async function prefetchImages(
           fetch,
           ref.widthPt,
           ref.heightPt,
+          ref.hasCrop,
         );
         // Cache the decode result keyed by path — INCLUDING a null for an
         // unsupported metafile (true EMF / geometry-less WMF). Storing the null

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -124,6 +124,8 @@ export async function prefetchImages(
             // Group's saved EMU extent scaled by the leaf's normalized w/h → pt.
             widthPt: grp.nativeExtCx > 0 ? (grp.nativeExtCx * shape.w) / EMU_PER_PT : 0,
             heightPt: grp.nativeExtCy > 0 ? (grp.nativeExtCy * shape.h) / EMU_PER_PT : 0,
+            // A crop forces the raster decode (native pixel grid for the crop).
+            hasCrop: shape.geom.srcRect != null,
           });
         }
       }

--- a/packages/xlsx/src/renderer-image-crop.test.ts
+++ b/packages/xlsx/src/renderer-image-crop.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { drawAnchorImage } from './renderer';
+import type { ImageAnchor } from './types';
+
+/**
+ * `drawAnchorImage` honors an ECMA-376 §20.1.8.55 `<a:srcRect>` crop by drawing
+ * only the visible source sub-rectangle into the (unchanged) anchor box via the
+ * 9-arg `ctx.drawImage` — the bug fix for sample-27, whose picture was a
+ * horizontally-cropped PNG that previously rendered whole and squished.
+ *
+ * The crop is raster-only: a metafile (WMF/EMF) is rasterized to the CROPPED
+ * display box by the decoder, so its bitmap pixels no longer map to source
+ * fractions and the crop is skipped (full draw), matching the docx renderer.
+ */
+
+/** Minimal `ImageAnchor` with a 1×1-cell anchor; callers override the crop. */
+function anchor(over: Partial<ImageAnchor>): ImageAnchor {
+  return {
+    fromCol: 0,
+    fromColOff: 0,
+    fromRow: 0,
+    fromRowOff: 0,
+    toCol: 1,
+    toColOff: 0,
+    toRow: 1,
+    toRowOff: 0,
+    nativeExtCx: 0,
+    nativeExtCy: 0,
+    imagePath: 'xl/media/image1.png',
+    mimeType: 'image/png',
+    ...over,
+  };
+}
+
+/** A decoded bitmap stand-in exposing native pixel `width`/`height`. */
+const fakeImg = (w: number, h: number): CanvasImageSource =>
+  ({ width: w, height: h }) as unknown as CanvasImageSource;
+
+function spyCtx(): { ctx: CanvasRenderingContext2D; drawImage: ReturnType<typeof vi.fn> } {
+  const drawImage = vi.fn();
+  return { ctx: { drawImage } as unknown as CanvasRenderingContext2D, drawImage };
+}
+
+describe('drawAnchorImage srcRect crop', () => {
+  it('draws only the visible sub-rectangle for a raster crop (9-arg drawImage)', () => {
+    const { ctx, drawImage } = spyCtx();
+    const img = fakeImg(2860, 1368); // sample-27 PNG native pixel size
+    // sample-27: left 0.3256, right 0.03829, no vertical crop.
+    const a = anchor({ srcRect: { l: 0.3256, t: 0, r: 0.03829, b: 0 } });
+
+    drawAnchorImage(ctx, img, a, 10, 20, 305, 229);
+
+    expect(drawImage).toHaveBeenCalledTimes(1);
+    const call = drawImage.mock.calls[0];
+    expect(call).toHaveLength(9); // img + (sx,sy,sw,sh) + (dx,dy,dw,dh)
+    const [, sx, sy, sw, sh, dx, dy, dw, dh] = call;
+    expect(sx).toBeCloseTo(0.3256 * 2860, 3); // skip the left 32.56%
+    expect(sy).toBe(0);
+    expect(sw).toBeCloseTo((1 - 0.3256 - 0.03829) * 2860, 3); // keep the middle band
+    expect(sh).toBe(1368); // full height (no vertical crop)
+    // Destination box is unchanged — the slice stretches to fill the anchor rect.
+    expect([dx, dy, dw, dh]).toEqual([10, 20, 305, 229]);
+  });
+
+  it('clamps a crop that extends past the image and never produces a zero-size source', () => {
+    const { ctx, drawImage } = spyCtx();
+    // Pathological insets (sum > 1, negative) must clamp to a ≥1px source rect.
+    const a = anchor({ srcRect: { l: 0.9, t: -0.2, r: 0.9, b: 1.5 } });
+
+    drawAnchorImage(ctx, fakeImg(100, 100), a, 0, 0, 40, 40);
+
+    const [, , , sw, sh] = drawImage.mock.calls[0];
+    expect(sw).toBeGreaterThanOrEqual(1);
+    expect(sh).toBeGreaterThanOrEqual(1);
+  });
+
+  it('draws the whole image (4-arg) when there is no crop', () => {
+    const { ctx, drawImage } = spyCtx();
+    drawAnchorImage(ctx, fakeImg(100, 100), anchor({}), 0, 0, 50, 50);
+    expect(drawImage.mock.calls[0]).toHaveLength(5); // img + (dx,dy,dw,dh)
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 50, 50);
+  });
+
+  it('treats an all-zero srcRect as no crop (full draw)', () => {
+    const { ctx, drawImage } = spyCtx();
+    const a = anchor({ srcRect: { l: 0, t: 0, r: 0, b: 0 } });
+    drawAnchorImage(ctx, fakeImg(100, 100), a, 0, 0, 50, 50);
+    expect(drawImage.mock.calls[0]).toHaveLength(5);
+  });
+
+  it('skips the crop for a metafile (WMF) — it is rasterized to the display box', () => {
+    const { ctx, drawImage } = spyCtx();
+    const a = anchor({ mimeType: 'image/wmf', srcRect: { l: 0.3, t: 0, r: 0.1, b: 0 } });
+    drawAnchorImage(ctx, fakeImg(200, 200), a, 0, 0, 50, 50);
+    expect(drawImage.mock.calls[0]).toHaveLength(5); // full draw, not 9-arg
+  });
+
+  it('skips the crop for an EMF metafile too', () => {
+    const { ctx, drawImage } = spyCtx();
+    const a = anchor({ mimeType: 'image/emf', srcRect: { l: 0.2, t: 0.2, r: 0, b: 0 } });
+    drawAnchorImage(ctx, fakeImg(200, 200), a, 0, 0, 50, 50);
+    expect(drawImage.mock.calls[0]).toHaveLength(5);
+  });
+});

--- a/packages/xlsx/src/renderer-image-crop.test.ts
+++ b/packages/xlsx/src/renderer-image-crop.test.ts
@@ -1,36 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
-import { drawAnchorImage } from './renderer';
-import type { ImageAnchor } from './types';
+import { drawImageCropped } from './renderer';
 
 /**
- * `drawAnchorImage` honors an ECMA-376 §20.1.8.55 `<a:srcRect>` crop by drawing
- * only the visible source sub-rectangle into the (unchanged) anchor box via the
- * 9-arg `ctx.drawImage` — the bug fix for sample-27, whose picture was a
- * horizontally-cropped PNG that previously rendered whole and squished.
+ * `drawImageCropped` honors an ECMA-376 §20.1.8.55 `<a:srcRect>` crop by drawing
+ * only the visible source sub-rectangle into the (unchanged) destination box via
+ * the 9-arg `ctx.drawImage` — the bug fix for sample-27, whose picture was a
+ * horizontally-cropped PNG that previously rendered whole and squished. The same
+ * helper serves the top-level `twoCellAnchor` picture and the `grpSp` /
+ * `oneCellAnchor` leaf pic, so every placement crops uniformly.
  *
  * The crop is raster-only: a metafile (WMF/EMF) is rasterized to the CROPPED
  * display box by the decoder, so its bitmap pixels no longer map to source
- * fractions and the crop is skipped (full draw), matching the docx renderer.
+ * fractions and the crop is skipped (full draw).
  */
-
-/** Minimal `ImageAnchor` with a 1×1-cell anchor; callers override the crop. */
-function anchor(over: Partial<ImageAnchor>): ImageAnchor {
-  return {
-    fromCol: 0,
-    fromColOff: 0,
-    fromRow: 0,
-    fromRowOff: 0,
-    toCol: 1,
-    toColOff: 0,
-    toRow: 1,
-    toRowOff: 0,
-    nativeExtCx: 0,
-    nativeExtCy: 0,
-    imagePath: 'xl/media/image1.png',
-    mimeType: 'image/png',
-    ...over,
-  };
-}
 
 /** A decoded bitmap stand-in exposing native pixel `width`/`height`. */
 const fakeImg = (w: number, h: number): CanvasImageSource =>
@@ -41,14 +23,12 @@ function spyCtx(): { ctx: CanvasRenderingContext2D; drawImage: ReturnType<typeof
   return { ctx: { drawImage } as unknown as CanvasRenderingContext2D, drawImage };
 }
 
-describe('drawAnchorImage srcRect crop', () => {
-  it('draws only the visible sub-rectangle for a raster crop (9-arg drawImage)', () => {
+describe('drawImageCropped srcRect crop', () => {
+  it('draws only the visible sub-rectangle for a horizontal raster crop (9-arg drawImage)', () => {
     const { ctx, drawImage } = spyCtx();
     const img = fakeImg(2860, 1368); // sample-27 PNG native pixel size
     // sample-27: left 0.3256, right 0.03829, no vertical crop.
-    const a = anchor({ srcRect: { l: 0.3256, t: 0, r: 0.03829, b: 0 } });
-
-    drawAnchorImage(ctx, img, a, 10, 20, 305, 229);
+    drawImageCropped(ctx, img, { l: 0.3256, t: 0, r: 0.03829, b: 0 }, 'image/png', 10, 20, 305, 229);
 
     expect(drawImage).toHaveBeenCalledTimes(1);
     const call = drawImage.mock.calls[0];
@@ -58,16 +38,26 @@ describe('drawAnchorImage srcRect crop', () => {
     expect(sy).toBe(0);
     expect(sw).toBeCloseTo((1 - 0.3256 - 0.03829) * 2860, 3); // keep the middle band
     expect(sh).toBe(1368); // full height (no vertical crop)
-    // Destination box is unchanged — the slice stretches to fill the anchor rect.
+    // Destination box is unchanged — the slice stretches to fill the rect.
     expect([dx, dy, dw, dh]).toEqual([10, 20, 305, 229]);
+  });
+
+  it('crops the vertical axis correctly (sy/sh) for a top+bottom crop', () => {
+    const { ctx, drawImage } = spyCtx();
+    // top 0.10, bottom 0.25 → sy=0.10·H, sh=(1−0.10−0.25)·H; no horizontal crop.
+    drawImageCropped(ctx, fakeImg(400, 200), { l: 0, t: 0.1, r: 0, b: 0.25 }, 'image/png', 0, 0, 80, 40);
+
+    const [, sx, sy, sw, sh] = drawImage.mock.calls[0];
+    expect(sx).toBe(0);
+    expect(sw).toBe(400); // full width
+    expect(sy).toBeCloseTo(0.1 * 200, 6); // 20
+    expect(sh).toBeCloseTo((1 - 0.1 - 0.25) * 200, 6); // 130
   });
 
   it('clamps a crop that extends past the image and never produces a zero-size source', () => {
     const { ctx, drawImage } = spyCtx();
-    // Pathological insets (sum > 1, negative) must clamp to a ≥1px source rect.
-    const a = anchor({ srcRect: { l: 0.9, t: -0.2, r: 0.9, b: 1.5 } });
-
-    drawAnchorImage(ctx, fakeImg(100, 100), a, 0, 0, 40, 40);
+    // Pathological insets (sum > 1, negative overscan) must clamp to a ≥1px rect.
+    drawImageCropped(ctx, fakeImg(100, 100), { l: 0.9, t: -0.2, r: 0.9, b: 1.5 }, 'image/png', 0, 0, 40, 40);
 
     const [, , , sw, sh] = drawImage.mock.calls[0];
     expect(sw).toBeGreaterThanOrEqual(1);
@@ -76,29 +66,26 @@ describe('drawAnchorImage srcRect crop', () => {
 
   it('draws the whole image (4-arg) when there is no crop', () => {
     const { ctx, drawImage } = spyCtx();
-    drawAnchorImage(ctx, fakeImg(100, 100), anchor({}), 0, 0, 50, 50);
+    drawImageCropped(ctx, fakeImg(100, 100), undefined, 'image/png', 0, 0, 50, 50);
     expect(drawImage.mock.calls[0]).toHaveLength(5); // img + (dx,dy,dw,dh)
     expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 50, 50);
   });
 
   it('treats an all-zero srcRect as no crop (full draw)', () => {
     const { ctx, drawImage } = spyCtx();
-    const a = anchor({ srcRect: { l: 0, t: 0, r: 0, b: 0 } });
-    drawAnchorImage(ctx, fakeImg(100, 100), a, 0, 0, 50, 50);
+    drawImageCropped(ctx, fakeImg(100, 100), { l: 0, t: 0, r: 0, b: 0 }, 'image/png', 0, 0, 50, 50);
     expect(drawImage.mock.calls[0]).toHaveLength(5);
   });
 
   it('skips the crop for a metafile (WMF) — it is rasterized to the display box', () => {
     const { ctx, drawImage } = spyCtx();
-    const a = anchor({ mimeType: 'image/wmf', srcRect: { l: 0.3, t: 0, r: 0.1, b: 0 } });
-    drawAnchorImage(ctx, fakeImg(200, 200), a, 0, 0, 50, 50);
+    drawImageCropped(ctx, fakeImg(200, 200), { l: 0.3, t: 0, r: 0.1, b: 0 }, 'image/wmf', 0, 0, 50, 50);
     expect(drawImage.mock.calls[0]).toHaveLength(5); // full draw, not 9-arg
   });
 
   it('skips the crop for an EMF metafile too', () => {
     const { ctx, drawImage } = spyCtx();
-    const a = anchor({ mimeType: 'image/emf', srcRect: { l: 0.2, t: 0.2, r: 0, b: 0 } });
-    drawAnchorImage(ctx, fakeImg(200, 200), a, 0, 0, 50, 50);
+    drawImageCropped(ctx, fakeImg(200, 200), { l: 0.2, t: 0.2, r: 0, b: 0 }, 'image/emf', 0, 0, 50, 50);
     expect(drawImage.mock.calls[0]).toHaveLength(5);
   });
 });

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2,7 +2,7 @@ import type {
   Worksheet, Styles, Cell, CellValue, CellFont, CellFill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions, XlsxTextRunInfo,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
-  Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
+  Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem, ImageAnchor,
 } from './types.js';
 import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, xlsxBorderDashArray, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
@@ -2838,6 +2838,60 @@ function sheetYForRow(
   return y;
 }
 
+/** Source pixel dimensions of a decoded image. `ImageBitmap` / `OffscreenCanvas`
+ *  expose native `width`/`height`; an `HTMLImageElement` exposes `naturalWidth`/
+ *  `naturalHeight` (its `width`/`height` may be a CSS layout size). */
+function imageNaturalSize(img: CanvasImageSource): { w: number; h: number } {
+  const el = img as {
+    naturalWidth?: number;
+    naturalHeight?: number;
+    width?: number;
+    height?: number;
+  };
+  return { w: el.naturalWidth || el.width || 0, h: el.naturalHeight || el.height || 0 };
+}
+
+/** Draw an anchored picture into the destination rect `(dx,dy,dw,dh)`, honoring
+ *  an optional ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop.
+ *
+ *  `srcRect` insets are fractions `0..1` of the source bitmap measured inward
+ *  from each edge, so the visible region is `[l, t, 1-r, 1-b]` in source pixels:
+ *  `sx = l·W`, `sy = t·H`, `sw = (1−l−r)·W`, `sh = (1−t−b)·H` (clamped ≥ 1). The
+ *  destination box is unchanged — Word/Excel stretch the visible slice to fill
+ *  the anchor rect, which is exactly the 9-arg `drawImage` behavior.
+ *
+ *  The crop is applied only for raster blips, whose decoded `ImageBitmap` IS the
+ *  full source at native resolution. A metafile (WMF/EMF) is rasterized to the
+ *  CROPPED *display* box (see core `decodeRasterOrMetafile`), so cropping it in
+ *  bitmap pixels would squish the whole picture to the sub-rect's aspect; until
+ *  the decoder can rasterize a metafile at native size we draw it whole (the
+ *  same documented limitation as the docx renderer). */
+export function drawAnchorImage(
+  ctx: CanvasRenderingContext2D,
+  img: CanvasImageSource,
+  anchor: ImageAnchor,
+  dx: number,
+  dy: number,
+  dw: number,
+  dh: number,
+): void {
+  const sr = anchor.srcRect;
+  const isMetafile = anchor.mimeType === 'image/wmf' || anchor.mimeType === 'image/emf';
+  if (sr && !isMetafile && (sr.l || sr.t || sr.r || sr.b)) {
+    const { w: bw, h: bh } = imageNaturalSize(img);
+    if (bw > 0 && bh > 0) {
+      const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
+      const sx = clamp01(sr.l) * bw;
+      const sy = clamp01(sr.t) * bh;
+      const sw = Math.max(1, bw - sx - clamp01(sr.r) * bw);
+      const sh = Math.max(1, bh - sy - clamp01(sr.b) * bh);
+      ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh);
+      return;
+    }
+  }
+  ctx.drawImage(img, dx, dy, dw, dh);
+}
+
 function renderImages(
   ctx: CanvasRenderingContext2D,
   ws: Worksheet,
@@ -2907,7 +2961,7 @@ function renderImages(
     if (canvasX + imgW < scrollAreaX || canvasX > scrollAreaX + scrollAreaW) continue;
     if (canvasY + imgH < scrollAreaY || canvasY > scrollAreaY + scrollAreaH) continue;
 
-    ctx.drawImage(img, canvasX, canvasY, imgW, imgH);
+    drawAnchorImage(ctx, img, anchor, canvasX, canvasY, imgW, imgH);
   }
 
   ctx.restore();

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2,7 +2,7 @@ import type {
   Worksheet, Styles, Cell, CellValue, CellFont, CellFill, Border, BorderEdge, CellXf,
   ViewportRange, RenderViewportOptions, XlsxTextRunInfo,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
-  Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem, ImageAnchor,
+  Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
 import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, xlsxBorderDashArray, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
@@ -2840,7 +2840,11 @@ function sheetYForRow(
 
 /** Source pixel dimensions of a decoded image. `ImageBitmap` / `OffscreenCanvas`
  *  expose native `width`/`height`; an `HTMLImageElement` exposes `naturalWidth`/
- *  `naturalHeight` (its `width`/`height` may be a CSS layout size). */
+ *  `naturalHeight` (its `width`/`height` may be a CSS layout size). On the crop
+ *  path the source is always a raster `ImageBitmap` (a crop forces the raster
+ *  decode — see `decodeImageSource`'s `hasCrop` gate), so `width`/`height` are
+ *  the native pixels; the `naturalWidth` arm is belt-and-suspenders for any
+ *  `HTMLImageElement` that reaches an uncropped draw. */
 function imageNaturalSize(img: CanvasImageSource): { w: number; h: number } {
   const el = img as {
     naturalWidth?: number;
@@ -2851,40 +2855,47 @@ function imageNaturalSize(img: CanvasImageSource): { w: number; h: number } {
   return { w: el.naturalWidth || el.width || 0, h: el.naturalHeight || el.height || 0 };
 }
 
-/** Draw an anchored picture into the destination rect `(dx,dy,dw,dh)`, honoring
- *  an optional ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop.
+/** Draw a picture into the destination rect `(dx,dy,dw,dh)`, honoring an optional
+ *  ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop. Shared by the top-level
+ *  `twoCellAnchor` picture (`ws.images`) and the `grpSp` / `oneCellAnchor` image
+ *  leaf (`ws.shapeGroups`), so every xlsx picture placement crops uniformly.
  *
  *  `srcRect` insets are fractions `0..1` of the source bitmap measured inward
  *  from each edge, so the visible region is `[l, t, 1-r, 1-b]` in source pixels:
  *  `sx = l·W`, `sy = t·H`, `sw = (1−l−r)·W`, `sh = (1−t−b)·H` (clamped ≥ 1). The
- *  destination box is unchanged — Word/Excel stretch the visible slice to fill
- *  the anchor rect, which is exactly the 9-arg `drawImage` behavior.
+ *  destination box is unchanged — Excel stretches the visible slice to fill it,
+ *  which is exactly the 9-arg `drawImage` behavior. A negative (overscan) edge is
+ *  clamped to 0, degrading to a full draw; this overscan simplification is shared
+ *  with the pptx renderer.
  *
- *  The crop is applied only for raster blips, whose decoded `ImageBitmap` IS the
- *  full source at native resolution. A metafile (WMF/EMF) is rasterized to the
- *  CROPPED *display* box (see core `decodeRasterOrMetafile`), so cropping it in
- *  bitmap pixels would squish the whole picture to the sub-rect's aspect; until
- *  the decoder can rasterize a metafile at native size we draw it whole (the
- *  same documented limitation as the docx renderer). */
-export function drawAnchorImage(
+ *  Crop is applied only for raster blips, whose decoded `ImageBitmap` IS the full
+ *  source at native resolution. A metafile (WMF/EMF) is rasterized to the CROPPED
+ *  *display* box by core's `decodeRasterOrMetafile`, so cropping its bitmap would
+ *  squish the whole picture to the sub-rect's aspect — those are drawn whole. The
+ *  pptx renderer applies raster crops the same way; the docx renderer currently
+ *  disables crop for ALL blips (raster included). `mimeType` is the only metafile
+ *  signal available here and is extension-derived, so a metafile mislabeled with
+ *  a raster extension would slip past this gate — acceptable because authored
+ *  crops on metafiles are rare. */
+export function drawImageCropped(
   ctx: CanvasRenderingContext2D,
   img: CanvasImageSource,
-  anchor: ImageAnchor,
+  srcRect: { l: number; t: number; r: number; b: number } | undefined,
+  mimeType: string,
   dx: number,
   dy: number,
   dw: number,
   dh: number,
 ): void {
-  const sr = anchor.srcRect;
-  const isMetafile = anchor.mimeType === 'image/wmf' || anchor.mimeType === 'image/emf';
-  if (sr && !isMetafile && (sr.l || sr.t || sr.r || sr.b)) {
+  const isMetafile = mimeType === 'image/wmf' || mimeType === 'image/emf';
+  if (srcRect && !isMetafile && (srcRect.l || srcRect.t || srcRect.r || srcRect.b)) {
     const { w: bw, h: bh } = imageNaturalSize(img);
     if (bw > 0 && bh > 0) {
       const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
-      const sx = clamp01(sr.l) * bw;
-      const sy = clamp01(sr.t) * bh;
-      const sw = Math.max(1, bw - sx - clamp01(sr.r) * bw);
-      const sh = Math.max(1, bh - sy - clamp01(sr.b) * bh);
+      const sx = clamp01(srcRect.l) * bw;
+      const sy = clamp01(srcRect.t) * bh;
+      const sw = Math.max(1, bw - sx - clamp01(srcRect.r) * bw);
+      const sh = Math.max(1, bh - sy - clamp01(srcRect.b) * bh);
       ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh);
       return;
     }
@@ -2961,7 +2972,7 @@ function renderImages(
     if (canvasX + imgW < scrollAreaX || canvasX > scrollAreaX + scrollAreaW) continue;
     if (canvasY + imgH < scrollAreaY || canvasY > scrollAreaY + scrollAreaH) continue;
 
-    drawAnchorImage(ctx, img, anchor, canvasX, canvasY, imgW, imgH);
+    drawImageCropped(ctx, img, anchor.srcRect, anchor.mimeType, canvasX, canvasY, imgW, imgH);
   }
 
   ctx.restore();
@@ -3159,7 +3170,9 @@ function drawShape(
     // worse.
     const img = loadedImages?.get(shape.geom.imagePath);
     if (img) {
-      ctx.drawImage(img, 0, 0, sw, sh);
+      // Honor an `<a:srcRect>` crop on the leaf pic (oneCellAnchor / grpSp leaf),
+      // same as the top-level anchor path (ECMA-376 §20.1.8.55).
+      drawImageCropped(ctx, img, shape.geom.srcRect, shape.geom.mimeType, 0, 0, sw, sh);
     }
   }
   // Shape text body (ECMA-376 §20.5.2.34 `<xdr:txBody>`). Drawn after

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -665,6 +665,13 @@ export interface ImageAnchor {
    *  svgBlip extension. Its MIME is always `image/svg+xml` and is owned by the
    *  SVG decoder. */
   svgImagePath?: string;
+  /** ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop. Each edge inset is a
+   *  fraction `0..1` of the source bitmap, measured inward, so the visible
+   *  source region is `[l, t, 1-r, 1-b]`. Absent (the common case) ⇒ the whole
+   *  blip fills the anchor rect; when present, the renderer draws only the
+   *  cropped sub-rectangle (raster only — a metafile is rasterized to the
+   *  display box, so its crop can't be honored faithfully and is skipped). */
+  srcRect?: { l: number; t: number; r: number; b: number };
 }
 
 export interface CellRange {

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -611,6 +611,11 @@ export type ShapeGeom =
        *  when the picture carries no svgBlip extension. Its MIME is always
        *  `image/svg+xml` and is owned by the SVG decoder. */
       svgImagePath?: string;
+      /** ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop on the leaf pic
+       *  (fractions `0..1` inward from each edge; visible region `[l, t, 1-r,
+       *  1-b]`). Absent ⇒ the whole blip fills the leaf rect. Honored identically
+       *  to the top-level {@link ImageAnchor.srcRect} (raster only). */
+      srcRect?: { l: number; t: number; r: number; b: number };
     };
 
 export interface PathInfo {


### PR DESCRIPTION
## Problem

A **cropped image** placed on a sheet rendered **uncropped and mis-scaled** — the entire source bitmap was squeezed into an anchor rect authored to show only the cropped sub-region (`private/sample-27.xlsx`, a horizontally-cropped PNG).

## Root causes (two, both fixed)

**1. The parser never read `<a:srcRect>` (ECMA-376 §20.1.8.55).** Added `SrcRect { l, t, r, b }` (fractions `0..1`, raw 1000ths-of-a-percent ÷ 100000) to `ImageAnchor`. The renderer draws only the visible sub-rectangle via the 9-arg `ctx.drawImage`, leaving the destination box unchanged. **Raster only**: a metafile (WMF/EMF) is rasterized to the cropped display box, so cropping its bitmap would squish the whole picture — drawn whole (same as the pptx renderer; the docx renderer currently disables crop entirely). When cropped, `decodeImageSource` forces the raster decode (skips the svgBlip vector) so the crop math has native pixels — mirrors pptx's `!srcRect` gate.

**2. The picture was drawn twice.** A standalone `<xdr:pic>` under a `twoCellAnchor` was parsed into BOTH `ws.images` and `ws.shapeGroups`; with the crop applied, the uncropped shape draw overwrote the cropped anchor draw. Such a pic is now owned solely by `ws.images`; the shape path keeps standalone pics only for `oneCellAnchor` and `grpSp` leaves.

## Independent review follow-up (commit 2)

An independent multi-dimension review (spec fidelity / single responsibility / duplicate logic / cross-package consistency) drove these refinements:

- **Generalized the helper** `drawAnchorImage` → `drawImageCropped(ctx, img, srcRect, mimeType, …)` (drops the whole-`ImageAnchor` coupling; matches docx's vocabulary), reused by both the anchor and the shape-leaf draw.
- **Closed a crop-coverage gap**: `<a:srcRect>` on a `oneCellAnchor` standalone pic or a `grpSp` leaf pic was ignored. `ShapeGeom::Image` now carries `src_rect`, the shape image draw honors it, and the leaf decode forces raster — so **every** xlsx picture placement crops uniformly.
- **Fixed an inaccurate comment** ("matching the docx renderer" → docx actually disables all crop; pptx is the real precedent), and documented the overscan clamp + the extension-derived-MIME caveat of the metafile gate.
- Added tests for the vertical (sy/sh) crop axis and the oneCellAnchor leaf-pic crop.

## Verification

- Parser (real WASM) emits the crop; browser issues a **single 9-arg `drawImage`** with source rect `[931.2, 0, 1819.3, 1368]` (double-draw gone); rendered sub-region matches the expected crop.
- 67 Rust + 147 vitest tests, root typecheck, `clippy --workspace`, `cargo fmt` — all green. **CI green.**
- All 67 xlsx VRT samples pass; uncropped-pic samples are pixel-identical (no regression). sample-27's reference is stale (pre-image) and left untouched per policy.

## Out-of-scope follow-ups (separate PRs)

- **ooxml-common**: consolidate the `SrcRect` struct + `parse_src_rect` (defined 3× across pptx/docx/xlsx) and an `isMetafileMime()` helper; align the TS `srcRect` type shape (pptx uses optional inner edges, xlsx/docx required).
- **docx**: re-enable raster `<a:srcRect>` crop (currently disabled for all blips) with the same `!isMetafile` gate — docx cropped raster images currently render uncropped.
- **pptx**: add the `isMetafile` gate (latent metafile double-crop) and drop the per-field `skip_serializing_if` so its TS edges can be required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)