### PR TITLE
refactor: unify a:srcRect crop across docx/xlsx/pptx (+ fix docx/pptx)

### DIFF
--- a/packages/core/src/image/wmf.test.ts
+++ b/packages/core/src/image/wmf.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   isWmf,
   isEmf,
+  isMetafileMime,
   playWmf,
   renderWmfToBitmap,
   wmfRasterTarget,
@@ -769,5 +770,16 @@ describe('decodeRasterOrMetafile', () => {
     // Opted IN: every edge is on the boundary → nothing strokes → no geometry → null.
     expect(strokeCount).toBe(0);
     expect(sup).toBeNull();
+  });
+});
+
+describe('isMetafileMime', () => {
+  it('is true only for the WMF/EMF metafile MIME types', () => {
+    expect(isMetafileMime('image/wmf')).toBe(true);
+    expect(isMetafileMime('image/emf')).toBe(true);
+    expect(isMetafileMime('image/png')).toBe(false);
+    expect(isMetafileMime('image/jpeg')).toBe(false);
+    expect(isMetafileMime('image/svg+xml')).toBe(false);
+    expect(isMetafileMime(undefined)).toBe(false);
   });
 });

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -90,6 +90,18 @@ export function isEmf(bytes: Uint8Array): boolean {
   return dv.getUint32(0, true) === 1 && dv.getUint32(40, true) === EMF_SIGNATURE;
 }
 
+/** True for the WMF/EMF metafile MIME types (`image/wmf`, `image/emf`). A
+ *  DrawingML `<a:srcRect>` crop (ECMA-376 §20.1.8.55) cannot be honored on a
+ *  metafile because {@link decodeRasterOrMetafile} rasterizes it to the CROPPED
+ *  display box rather than native source pixels — so the docx, pptx and xlsx
+ *  renderers all gate the crop on this and draw a cropped metafile whole. The
+ *  MIME is extension-derived by the parsers (`mime_from_ext`), so a metafile
+ *  mislabeled with a raster extension would slip past this gate; acceptable
+ *  because authored crops on metafiles are rare. */
+export function isMetafileMime(mime: string | undefined): boolean {
+  return mime === 'image/wmf' || mime === 'image/emf';
+}
+
 // ── color ─────────────────────────────────────────────────────────────────
 
 /** COLORREF (u32 0x00BBGGRR) → CSS `#rrggbb`. Shared with the EMF player

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,7 @@ export { getCachedSvgImageByPath, dropSvgImageCache } from './image/svg-image-by
 export {
   isWmf,
   isEmf,
+  isMetafileMime,
   playWmf,
   renderWmfToBitmap,
   wmfRasterTarget,

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,4 +1,4 @@
-use ooxml_common::blip::{blip_embed_rid, mime_from_ext, svg_blip_rid};
+use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
 use roxmltree::Document as XmlDoc;
 use std::collections::HashMap;
 use std::io::Read;
@@ -2526,38 +2526,6 @@ fn resolve_blip_urls(
     Some((image_path, mime, svg_image_path))
 }
 
-/// ECMA-376 §20.1.8.55 — parse the optional `<a:srcRect>` that sits next to the
-/// `<a:blip>` inside a `<pic:blipFill>`. `blip` is the resolved `<a:blip>` node;
-/// its parent is the `blipFill`, whose `<a:srcRect>` child (if any) carries the
-/// crop. The raw `l/t/r/b` attributes are ST_Percentage in 1000ths of a percent
-/// (e.g. `l="8827"` ⇒ 8.827%); we convert to fractions 0..1 (÷100000) so the
-/// renderer can crop in bitmap pixels without unit knowledge. Returns `None`
-/// when the element is absent OR all four insets are zero (an explicit
-/// `<a:srcRect/>` with no attributes ⇒ no crop).
-fn parse_src_rect(blip: roxmltree::Node) -> Option<SrcRect> {
-    let blip_fill = blip.parent()?;
-    let sr = blip_fill
-        .children()
-        .find(|n| n.tag_name().name() == "srcRect")?;
-    let pct = |name: &str| -> f64 {
-        sr.attribute(name)
-            .and_then(|v| v.parse::<f64>().ok())
-            .unwrap_or(0.0)
-            / 100000.0
-    };
-    let rect = SrcRect {
-        l: pct("l"),
-        t: pct("t"),
-        r: pct("r"),
-        b: pct("b"),
-    };
-    if rect.l == 0.0 && rect.t == 0.0 && rect.r == 0.0 && rect.b == 0.0 {
-        None
-    } else {
-        Some(rect)
-    }
-}
-
 /// A resolved inline/anchored picture: the drawable source(s) plus the natural
 /// draw size read from `<wp:extent>` (ECMA-376 §20.4.2.7), in points.
 struct InlineBlip {
@@ -2592,7 +2560,8 @@ fn resolve_inline_blip(
 ) -> Option<InlineBlip> {
     let blip = node.descendants().find(|n| n.tag_name().name() == "blip")?;
     let (image_path, mime_type, svg_image_path) = resolve_blip_urls(blip, media_map)?;
-    let src_rect = parse_src_rect(blip);
+    // The shared parser takes the `<*:blipFill>` (the blip's parent).
+    let src_rect = blip.parent().and_then(parse_src_rect);
     let extent = node
         .descendants()
         .find(|n| n.tag_name().name() == "extent")?;
@@ -3201,7 +3170,8 @@ fn parse_group_pic(
     let (image_path, mime_type, svg_image_path) = resolve_blip_urls(blip, media_map)?;
     // ECMA-376 §20.1.8.55 — source-rectangle crop (sibling of <a:blip> under
     // <pic:blipFill>), shared with the inline/anchor paths.
-    let src_rect = parse_src_rect(blip);
+    // The shared parser takes the `<*:blipFill>` (the blip's parent).
+    let src_rect = blip.parent().and_then(parse_src_rect);
 
     // Parse a:clrChange if present — used to make a specific color transparent.
     // clrFrom specifies the source color; clrTo with alpha=0 means replace with transparent.

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1064,21 +1064,9 @@ pub struct ShapeText {
     pub image_height_pt: f64,
 }
 
-/// ECMA-376 §20.1.8.55 `<a:srcRect>` — the source rectangle that selects which
-/// region of the blip's bitmap is drawn (the rest is cropped away). The four
-/// attributes are ST_Percentage insets expressed here as FRACTIONS 0..1 of the
-/// source bitmap, measured inward from each edge: `l`/`t` from the left/top,
-/// `r`/`b` from the right/bottom. The visible source rectangle is therefore
-/// `[l, t, 1−r, 1−b]` of the bitmap. The parser converts the raw 1000ths-of-a-
-/// percent attribute values to fractions (÷100000) so the renderer needs no
-/// unit knowledge. An absent `<a:srcRect>` (or one that is all-zero) ⇒ `None`.
-#[derive(Serialize, Debug, Clone, PartialEq)]
-pub struct SrcRect {
-    pub l: f64,
-    pub t: f64,
-    pub r: f64,
-    pub b: f64,
-}
+/// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop, shared across the docx,
+/// pptx and xlsx parsers (see `ooxml_common::blip`).
+pub use ooxml_common::blip::SrcRect;
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -35,6 +35,7 @@ import {
   classifyFontGeneric,
   isComplexScriptCodePoint,
   decodeRasterOrMetafile,
+  isMetafileMime,
   symbolFontToUnicode,
   isSymbolFontFamily,
   symbolTextToUnicodeSegments,
@@ -332,6 +333,10 @@ interface ImagePair {
    */
   widthPt: number;
   heightPt: number;
+  /** True when at least one reference to this image carries an `<a:srcRect>`
+   *  crop, so the decode must prefer the raster (the crop math needs the
+   *  bitmap's native pixel grid; an SVG vector original has none). */
+  hasCrop?: boolean;
 }
 
 /** Returns a stable map key for an (imagePath, colorReplaceFrom) pair. */
@@ -376,6 +381,8 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
     } else {
       existing.widthPt = Math.max(existing.widthPt, pair.widthPt);
       existing.heightPt = Math.max(existing.heightPt, pair.heightPt);
+      // If ANY reference is cropped, force the raster decode for this key.
+      existing.hasCrop = existing.hasCrop || pair.hasCrop;
     }
   };
   // ECMA-376 §17.9.9/§17.9.20 — a level's picture-bullet marker is an image
@@ -410,6 +417,7 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
           colorReplaceFrom: img.colorReplaceFrom,
           widthPt: img.widthPt ?? 0,
           heightPt: img.heightPt ?? 0,
+          hasCrop: img.srcRect != null,
         });
       } else if (run.type === 'shape') {
         // Inline images living inside a text box (<wps:txbx>) ride on the
@@ -553,12 +561,13 @@ export async function preloadImages(
       const dataIsSvg = pair.mimeType === 'image/svg+xml';
       try {
         let img: DecodedImage;
-        if (pair.svgImagePath != null) {
+        if (pair.svgImagePath != null && !pair.hasCrop) {
           // Prefer the vector original (Microsoft `asvg:svgBlip` extension);
-          // fall back to the raster on any SVG decode failure. A `<a:srcRect>`
-          // crop (§20.1.8.55), when present, is applied at draw time in bitmap
-          // pixels of whichever source we decoded here, so the vector is still
-          // always preferred when present.
+          // fall back to the raster on any SVG decode failure. With an
+          // `<a:srcRect>` crop (§20.1.8.55) we skip this branch and decode the
+          // raster instead, because the crop math (drawImageCropped) needs the
+          // bitmap's native pixel grid — an SVG element has none. Mirrors the
+          // pptx `!srcRect` / xlsx `hasCrop` vector gate.
           try {
             img = await getCachedSvgImageByPath(pair.svgImagePath, fetch);
           } catch {
@@ -5168,34 +5177,45 @@ function drawTabLeader(
  * Draw a decoded image bitmap into the destination box `[dx, dy, dw, dh]`,
  * honoring an optional ECMA-376 §20.1.8.55 `<a:srcRect>` source-rectangle crop.
  *
- * `srcRect` insets are fractions 0..1 of the bitmap measured inward from each
- * edge, so the visible source region is `[l, t, 1−r, 1−b]` in bitmap pixels:
+ * `srcRect` insets are fractions 0..1 of the source measured inward from each
+ * edge, so the visible region is `[l, t, 1−r, 1−b]` in source pixels:
  *   `sx = l·W`, `sy = t·H`, `sw = (1−l−r)·W`, `sh = (1−t−b)·H` (clamped ≥ 1).
- * The destination box is unchanged — the same display size the document asked
- * for, now filled by just the cropped slice (the renderer never scales the crop
- * back up; Word stretches the visible source to fill the display box, which is
- * exactly the 9-arg `drawImage` behavior). Applies identically to raster and
- * metafile (WMF/EMF) bitmaps since the crop is in decoded-bitmap pixels.
+ * The destination box is unchanged — Word stretches the visible slice to fill
+ * the display box, which is exactly the 9-arg `drawImage` behavior. A negative
+ * (overscan) edge is clamped to 0 (degrades to a full draw).
+ *
+ * Crop is applied only for a raster blip, whose decoded `ImageBitmap` is the
+ * full source at native resolution. A metafile (WMF/EMF) is rasterized to the
+ * CROPPED display box by `decodeRasterOrMetafile`, so cropping its bitmap would
+ * squish the whole figure to the sub-rect's aspect (sample-13 Fig.2 / Fig.3) —
+ * metafiles draw whole, gated by `isMetafileMime`. When a crop is present
+ * `preloadImages` forces the raster decode (an SVG element has no native pixel
+ * grid). Mirrors the pptx and xlsx renderers.
  */
 function drawImageCropped(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   bmp: DecodedImage,
   srcRect: { l: number; t: number; r: number; b: number } | undefined,
+  mimeType: string,
   dx: number,
   dy: number,
   dw: number,
   dh: number,
 ): void {
-  // ECMA-376 §20.1.8.55 srcRect crop is intentionally DISABLED for now. Cropping
-  // works for a raster blip (the bitmap is the true full image), but a metafile
-  // (WMF/EMF) is rasterized into a bitmap sized to the CROPPED display box, so
-  // the whole metafile is squished to the sub-rect's aspect and the crop no
-  // longer aligns with the source — the figure stretches / spills out of its
-  // frame (sample-13 Fig.2 / Fig.3). Until the decoder can rasterize a metafile
-  // at its native aspect and crop from that, draw the full image (the clean,
-  // pre-crop behavior). `srcRect` stays plumbed through (parser → ImageRun) so
-  // re-enabling it is a one-line change here.
-  void srcRect;
+  if (srcRect && !isMetafileMime(mimeType) && (srcRect.l || srcRect.t || srcRect.r || srcRect.b)) {
+    const el = bmp as { naturalWidth?: number; naturalHeight?: number; width?: number; height?: number };
+    const bw = el.naturalWidth || el.width || 0;
+    const bh = el.naturalHeight || el.height || 0;
+    if (bw > 0 && bh > 0) {
+      const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
+      const sx = clamp01(srcRect.l) * bw;
+      const sy = clamp01(srcRect.t) * bh;
+      const sw = Math.max(1, bw - sx - clamp01(srcRect.r) * bw);
+      const sh = Math.max(1, bh - sy - clamp01(srcRect.b) * bh);
+      ctx.drawImage(bmp, sx, sy, sw, sh, dx, dy, dw, dh);
+      return;
+    }
+  }
   ctx.drawImage(bmp, dx, dy, dw, dh);
 }
 
@@ -5214,7 +5234,7 @@ function renderInlineImage(
   if (!bmp) return;
   const w = seg.widthPt * scale;
   const h = seg.heightPt * scale;
-  drawImageCropped(ctx, bmp, seg.srcRect, x, baseline - h, w, h);
+  drawImageCropped(ctx, bmp, seg.srcRect, seg.mimeType, x, baseline - h, w, h);
 }
 
 /** Collect and draw anchor images with wrapMode='none' (or unspecified).
@@ -5262,7 +5282,7 @@ function renderAnchorImages(
     // does not displace text and is not displaced by other floats), so dist* is
     // unused here.
     const { x: pageX, y: pageY, w, h } = resolveAnchorBox(img, state, paragraphTopPx);
-    drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, pageX, pageY, w, h);
+    drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, img.mimeType, pageX, pageY, w, h);
   }
 }
 
@@ -6090,7 +6110,7 @@ function registerImageFloat(
 
   if (!state.dryRun) {
     const bmp = state.images.get(key);
-    if (bmp) drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
+    if (bmp) drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, img.mimeType, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
     rect.drawn = true;
   }
 }

--- a/packages/ooxml-common/src/blip.rs
+++ b/packages/ooxml-common/src/blip.rs
@@ -10,6 +10,7 @@
 //! the three formats' blip handling identical.
 
 use roxmltree::Node;
+use serde::{Deserialize, Serialize};
 
 /// Relationships namespace (`r:`) — where a blip's `embed` / `link` rIds live.
 pub const R_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
@@ -89,6 +90,51 @@ pub fn mime_from_ext(path: &str) -> &'static str {
     }
 }
 
+/// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop (DrawingML
+/// `CT_RelativeRect`). Each edge inset is a fraction `0..1` of the *source*
+/// bitmap, measured inward from that edge, so the visible source region is
+/// `[l, t, 1−r, 1−b]`. The raw attributes are `ST_Percentage` in 1000ths of a
+/// percent; the parser divides by 100000 to a fraction so renderers need no unit
+/// knowledge. Absent edges default to `0`. Shared by the docx, pptx and xlsx
+/// parsers so the three formats crop identically.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SrcRect {
+    pub l: f64,
+    pub t: f64,
+    pub r: f64,
+    pub b: f64,
+}
+
+/// Parse `<a:srcRect l t r b>` from a `<*:blipFill>` node (the parent of the
+/// `<a:blip>`), matched by namespace-local name so a `p:`, `a:` or `xdr:`
+/// blipFill all work. Each edge is divided by 100000 to a fraction; an absent
+/// edge defaults to `0`. Returns `None` when there is no `srcRect` or all four
+/// edges are zero (no crop), so an uncropped picture never forces a renderer
+/// onto the sub-rectangle draw path.
+pub fn parse_src_rect(blip_fill: Node<'_, '_>) -> Option<SrcRect> {
+    let sr = blip_fill
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "srcRect")?;
+    let read = |name: &str| -> f64 {
+        sr.attribute(name)
+            .and_then(|v| v.parse::<f64>().ok())
+            .map(|v| v / 100_000.0)
+            .unwrap_or(0.0)
+    };
+    let rect = SrcRect {
+        l: read("l"),
+        t: read("t"),
+        r: read("r"),
+        b: read("b"),
+    };
+    if rect.l.abs() < 1e-9 && rect.t.abs() < 1e-9 && rect.r.abs() < 1e-9 && rect.b.abs() < 1e-9 {
+        None
+    } else {
+        Some(rect)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,6 +158,30 @@ mod tests {
         let blip = doc.root_element();
         assert_eq!(blip_embed_rid(&blip).as_deref(), Some("rIdPng"));
         assert_eq!(svg_blip_rid(blip).as_deref(), Some("rIdSvg"));
+    }
+
+    #[test]
+    fn parse_src_rect_reads_fractions_and_defaults_absent_edges() {
+        // l/r given, t/b absent → fractions = raw/100000, absent ⇒ 0.
+        let xml = format!(
+            r#"<a:blipFill xmlns:a="{A_NS}"><a:blip/><a:srcRect l="32560" r="3829"/></a:blipFill>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        let sr = parse_src_rect(doc.root_element()).expect("srcRect present");
+        assert!((sr.l - 0.3256).abs() < 1e-9);
+        assert!((sr.r - 0.03829).abs() < 1e-9);
+        assert_eq!(sr.t, 0.0);
+        assert_eq!(sr.b, 0.0);
+    }
+
+    #[test]
+    fn parse_src_rect_none_when_absent_or_all_zero() {
+        let none = format!(r#"<a:blipFill xmlns:a="{A_NS}"><a:blip/></a:blipFill>"#);
+        assert!(parse_src_rect(Document::parse(&none).unwrap().root_element()).is_none());
+        let zero = format!(
+            r#"<a:blipFill xmlns:a="{A_NS}"><a:srcRect l="0" t="0" r="0" b="0"/></a:blipFill>"#
+        );
+        assert!(parse_src_rect(Document::parse(&zero).unwrap().root_element()).is_none());
     }
 
     #[test]

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1,4 +1,4 @@
-use ooxml_common::blip::{mime_from_ext, svg_blip_rid};
+use ooxml_common::blip::{mime_from_ext, parse_src_rect, svg_blip_rid, SrcRect};
 use ooxml_common::math::{nodes_to_text, parse_omath_nodes, MathNode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -1091,24 +1091,6 @@ struct PictureElement {
     sp3d: Option<Sp3d>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "camelCase")]
-struct SrcRect {
-    /// Crop from left as fraction (e.g. 25100/100000 = 0.251)
-    #[serde(skip_serializing_if = "is_zero_f64")]
-    #[serde(default)]
-    l: f64,
-    #[serde(skip_serializing_if = "is_zero_f64")]
-    #[serde(default)]
-    t: f64,
-    #[serde(skip_serializing_if = "is_zero_f64")]
-    #[serde(default)]
-    r: f64,
-    #[serde(skip_serializing_if = "is_zero_f64")]
-    #[serde(default)]
-    b: f64,
-}
-
 fn is_zero_f64(v: &f64) -> bool {
     v.abs() < 1e-9
 }
@@ -1151,30 +1133,6 @@ fn parse_blip_alpha(blip_fill: roxmltree::Node<'_, '_>) -> Option<f64> {
         None
     } else {
         Some(frac.max(0.0))
-    }
-}
-
-/// Parse `<a:srcRect l t r b>` from a `<p:blipFill>` (or `<a:blipFill>`) node.
-/// Returns None if no srcRect or all edges are zero.
-fn parse_src_rect(blip_fill: roxmltree::Node<'_, '_>) -> Option<SrcRect> {
-    let sr = child(blip_fill, "srcRect")?;
-    let read = |name: &str| -> f64 {
-        attr(&sr, name)
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|v| v / 100_000.0)
-            .unwrap_or(0.0)
-    };
-    let rect = SrcRect {
-        l: read("l"),
-        t: read("t"),
-        r: read("r"),
-        b: read("b"),
-    };
-    if is_zero_f64(&rect.l) && is_zero_f64(&rect.t) && is_zero_f64(&rect.r) && is_zero_f64(&rect.b)
-    {
-        None
-    } else {
-        Some(rect)
     }
 }
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -63,6 +63,7 @@ import {
   isCjkBreakChar,
   getCachedSvgImageByPath,
   decodeRasterOrMetafile,
+  isMetafileMime,
   highlightBox,
   symbolFontToUnicode,
   isSymbolFontFamily,
@@ -3187,15 +3188,18 @@ async function renderPicture(
     // ── srcRect sub-rectangle (ECMA-376 a:srcRect). Edge values are fractions
     // of source dims (negative values mean extend past the image, duplicating
     // edge pixels in OOXML; we clamp to [0,1]). Resolve once so both the live
-    // paint and the effect aux paints share identical crop coordinates.
+    // paint and the effect aux paints share identical crop coordinates. Skip a
+    // metafile (WMF/EMF): core's decodeRasterOrMetafile rasterizes it to the
+    // CROPPED display box, so cropping its bitmap would squish the whole picture
+    // (the same gate the docx/xlsx renderers use via `isMetafileMime`).
     const sr = el.srcRect;
     let crop: { sx: number; sy: number; sw: number; sh: number } | null = null;
-    if (sr && (sr.l || sr.t || sr.r || sr.b)) {
+    if (sr && !isMetafileMime(el.mimeType) && (sr.l || sr.t || sr.r || sr.b)) {
       const bw = bitmap.width, bh = bitmap.height;
-      const sl = Math.max(0, Math.min(1, sr.l ?? 0));
-      const st = Math.max(0, Math.min(1, sr.t ?? 0));
-      const srR = Math.max(0, Math.min(1, sr.r ?? 0));
-      const sbB = Math.max(0, Math.min(1, sr.b ?? 0));
+      const sl = Math.max(0, Math.min(1, sr.l));
+      const st = Math.max(0, Math.min(1, sr.t));
+      const srR = Math.max(0, Math.min(1, sr.r));
+      const sbB = Math.max(0, Math.min(1, sr.b));
       const sx = sl * bw;
       const sy = st * bh;
       crop = {

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -561,10 +561,12 @@ export interface PictureElement {
    */
   prstAdjust?: number[];
   /**
-   * ECMA-376 a:srcRect — source image crop as fractions (0..1) of the source
-   * width/height. Omitted when the image is not cropped.
+   * ECMA-376 §20.1.8.55 a:srcRect — source image crop as fractions (0..1) of the
+   * source width/height, measured inward from each edge. Omitted when the image
+   * is not cropped; when present the parser emits all four edges (absent edges
+   * default to 0), so the renderer reads them without a fallback.
    */
-  srcRect?: { l?: number; t?: number; r?: number; b?: number };
+  srcRect?: { l: number; t: number; r: number; b: number };
   /** a:blip > a:alphaModFix@amt as 0..1. Undefined = fully opaque. */
   alpha?: number;
   /**

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -5,42 +5,13 @@ use crate::{parse_rels_map, read_zip_bytes, read_zip_entry, resolve_zip_path};
 // `.svg ⇒ image/svg+xml`; `svg_blip_rid` resolves the vector original nested in
 // a blip's `<a:extLst>`. Replaces xlsx's former local `mime_from_ext` (a strict
 // subset that lacked the `svg` arm and so dropped SVG parts).
-use ooxml_common::blip::{blip_embed_rid, mime_from_ext, svg_blip_rid};
+use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
 use std::collections::HashMap;
 use std::io::Cursor;
 
 /// Parse `<xdr:twoCellAnchor>` elements from a drawing XML and resolve
 /// embedded pictures into data URLs. `drawing_dir` is the folder that
 /// contains `drawing_path` so relative `Target`s resolve correctly.
-/// Parse `<a:srcRect l t r b>` from a `<xdr:blipFill>` node (ECMA-376 §20.1.8.55).
-/// Each edge attribute is a ST_Percentage in 1000ths of a percent, so the crop
-/// fraction is the raw value `/ 100000`; absent edges default to `0`. Returns
-/// `None` when there is no `srcRect` or all four edges are zero (no crop), so an
-/// uncropped picture never forces the renderer onto the sub-rectangle path.
-pub(crate) fn parse_src_rect(blip_fill: roxmltree::Node<'_, '_>) -> Option<SrcRect> {
-    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
-    let sr = blip_fill
-        .children()
-        .find(|n| n.tag_name().name() == "srcRect" && n.tag_name().namespace() == Some(a_ns))?;
-    let read = |name: &str| -> f64 {
-        sr.attribute(name)
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|v| v / 100_000.0)
-            .unwrap_or(0.0)
-    };
-    let rect = SrcRect {
-        l: read("l"),
-        t: read("t"),
-        r: read("r"),
-        b: read("b"),
-    };
-    if rect.l.abs() < 1e-9 && rect.t.abs() < 1e-9 && rect.r.abs() < 1e-9 && rect.b.abs() < 1e-9 {
-        None
-    } else {
-        Some(rect)
-    }
-}
-
 pub(crate) fn parse_drawing_anchors(
     drawing_xml: &str,
     drawing_rels: &HashMap<String, String>,

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -1121,18 +1121,9 @@ pub struct ImageAnchor {
     pub src_rect: Option<SrcRect>,
 }
 
-/// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop. Each edge inset is a
-/// fraction `0..1` of the *source* bitmap (the raw 1000ths-of-a-percent
-/// attribute `/ 100000`), measured inward from that edge, so the visible source
-/// region is `[l, t, 1-r, 1-b]`. Absent edges default to `0`.
-#[derive(Debug, Serialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct SrcRect {
-    pub l: f64,
-    pub t: f64,
-    pub r: f64,
-    pub b: f64,
-}
+/// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop, shared across the docx,
+/// pptx and xlsx parsers (see `ooxml_common::blip`).
+pub use ooxml_common::blip::SrcRect;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, xlsxBorderDashArray, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, xlsxBorderDashArray, isMetafileMime, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -2887,8 +2887,7 @@ export function drawImageCropped(
   dw: number,
   dh: number,
 ): void {
-  const isMetafile = mimeType === 'image/wmf' || mimeType === 'image/emf';
-  if (srcRect && !isMetafile && (srcRect.l || srcRect.t || srcRect.r || srcRect.b)) {
+  if (srcRect && !isMetafileMime(mimeType) && (srcRect.l || srcRect.t || srcRect.r || srcRect.b)) {
     const { w: bw, h: bh } = imageNaturalSize(img);
     if (bw > 0 && bh > 0) {
       const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));


### PR DESCRIPTION
Follow-up to #575. An independent review of the xlsx srcRect fix surfaced that the **same bug class exists in the other formats**, so this PR solves `<a:srcRect>` cropping (ECMA-376 §20.1.8.55) **integratively across docx/xlsx/pptx** rather than per-package.

## The cross-package problem

| | raster crop | metafile crop | SrcRect / parse |
|---|---|---|---|
| **xlsx** (pre-#575) | ❌ ignored → fixed in #575 | n/a | local dup |
| **docx** | ❌ **disabled for ALL blips** | correctly skipped | local dup |
| **pptx** | ✅ works | ❌ **double-crops** (squish) | local dup |

Three copies of `SrcRect` + `parse_src_rect`, three different metafile gates (one missing), and one format (docx) silently rendering every cropped raster image uncropped.

## Changes (one concern per commit)

1. **`refactor(common)`** — move `SrcRect` + `parse_src_rect` into `ooxml_common::blip` (next to the shared blip helpers); all three parsers import them. Drops pptx's per-field `skip_serializing_if` so all four edges serialize uniformly.
2. **`feat(core)`** — add `isMetafileMime(mime)` as the single source of truth for the "can't crop a metafile (it's rasterized to the cropped display box)" gate; xlsx adopts it.
3. **`fix(docx)`** — **re-enable the raster crop** (was `void srcRect` for every blip). Crop raster via the shared 9-arg math, skip metafiles via `isMetafileMime` (sample-13's EMF figures unchanged), and force the raster decode when cropped (`!hasCrop` gates the svgBlip-vector preference). docx now matches pptx/xlsx.
4. **`fix(pptx)`** — add the `isMetafileMime` gate to the crop block (fixes the latent **cropped-metafile double-crop/squish**); tighten the TS `srcRect` type to required `{ l, t, r, b }` and drop the `?? 0` fallbacks.

The result: all three formats now crop raster blips identically, skip metafile crops identically (via one shared gate), and share one `SrcRect` parser.

## Verification

- **Rust**: 154 docx + 100 pptx + 67 xlsx + ooxml-common parser tests, `clippy --workspace`, `cargo fmt` — all green.
- **TS**: 937 vitest (core/docx/pptx/xlsx, incl. new `isMetafileMime` + crop tests), root `pnpm typecheck` — all green.
- **VRT** (no reference updates): xlsx 67 + pptx 75 + docx 21 — all pass, no regressions.
- **docx regression-safety**: sample-13 (the only docx sample with non-empty crops — all on EMF) renders **0-pixel-identical** before/after (metafile gate draws them whole, exactly as the prior disabled behavior). No docx/pptx sample carries a raster crop, so the raster path is verified by parity with the xlsx implementation, which #575 validated pixel-for-pixel against ground truth (sample-27).

## Follow-up (not in scope)
The metafile gate is MIME-string based (extension-derived by the parsers), so a metafile mislabeled with a raster extension would slip past it — a robust fix would thread a structural "rasterized-to-box" signal from the decode path. Documented in code; rare in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)