### PR TITLE
fix(docx): balance newspaper columns at line granularity (§17.6.4)

### DIFF
--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -53,7 +53,7 @@ function textRun(text: string, fontSize: number): DocRun {
 
 type DocRun = DocParagraph['runs'][number];
 
-function para(opts: { text?: string; fontSize?: number; widowControl?: boolean } = {}): BodyElement {
+function para(opts: { text?: string; fontSize?: number; widowControl?: boolean; keepLines?: boolean } = {}): BodyElement {
   const fontSize = opts.fontSize ?? 20;
   const p: DocParagraph = {
     alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
@@ -61,6 +61,7 @@ function para(opts: { text?: string; fontSize?: number; widowControl?: boolean }
     runs: opts.text ? [textRun(opts.text, fontSize)] : [],
     defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
     widowControl: opts.widowControl,
+    keepLines: opts.keepLines,
   };
   return { type: 'paragraph', ...p } as BodyElement;
 }
@@ -541,6 +542,50 @@ describe('computePages — newspaper column balancing (§17.6.4, non-final conti
     // Balanced: p0–p2 in col0, p3–p5 in col1.
     expect([colByText.p0, colByText.p1, colByText.p2]).toEqual([0, 0, 0]);
     expect([colByText.p3, colByText.p4, colByText.p5]).toEqual([1, 1, 1]);
+  });
+
+  it('splits a LONG paragraph across balanced columns at the LINE level (not packed whole into col0)', () => {
+    // section(): content height 100, 2-col ⇒ col width 70, ~3 CJK chars/line at
+    // 20px, 20px/line. A 24-char paragraph = 8 lines = 160px. The 2-col section
+    // ends with a continuous break ⇒ balanced ⇒ balanceColH = 160/2 = 80px = 4
+    // lines. The paragraph must SPLIT — ~4 lines in col0, the rest in col1 — not
+    // pack all 8 lines into col0 (the sample-12 p.2 bug: a long first paragraph
+    // left column 0 full and column 1 nearly empty).
+    const body: BodyElement[] = [
+      para({ text: 'あ'.repeat(24), fontSize: 20 }),
+      sectionBreak('continuous', twoColSpec),
+      para({ text: 'x', fontSize: 20 }),
+    ];
+    const pages = computePages(body, section(), makeCtx()); // final section = 1-col
+    const slices = pages[0].filter((e) => e.type === 'paragraph' && sliceOf(e));
+    const col0 = slices.filter((e) => (colOf(e) ?? 0) === 0);
+    const col1 = slices.filter((e) => colOf(e) === 1);
+    // One slice per column — the paragraph spans the balance boundary.
+    expect(col0).toHaveLength(1);
+    expect(col1).toHaveLength(1);
+    const s0 = sliceOf(col0[0]) as { start: number; end: number };
+    const s1 = sliceOf(col1[0]) as { start: number; end: number };
+    expect(s0.start).toBe(0);
+    expect(s0.end).toBe(4); // balance target = 4 lines
+    expect(s1).toEqual({ start: 4, end: 8 }); // remainder in col1
+  });
+
+  it('moves a keepLines paragraph WHOLE to balance (does not split it across columns)', () => {
+    // A keepLines paragraph (§17.3.1.14) cannot be split, so balancing falls back
+    // to the whole-paragraph move. Short para (1 line) fills col0; the 3-line
+    // keepLines paragraph exceeds the balance target (4 lines total ⇒ 2-line
+    // target) and moves WHOLE into col1 — intact, no lineSlice.
+    const body: BodyElement[] = [
+      para({ text: 'x', fontSize: 20 }),
+      para({ text: 'あ'.repeat(9), fontSize: 20, keepLines: true }), // 9 / 3 = 3 lines
+      sectionBreak('continuous', twoColSpec),
+      para({ text: 'after', fontSize: 20 }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    const keep = pages[0].find((e) => textOf(e).startsWith('あ'));
+    expect(keep).toBeDefined();
+    expect(colOf(keep as PaginatedBodyElement) ?? 0).toBe(1); // moved to col1
+    expect(sliceOf(keep as PaginatedBodyElement)).toBeUndefined(); // whole, not split
   });
 
   it('does NOT balance the FINAL (body) section — it fills col0 greedily', () => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1647,11 +1647,20 @@ export function computePages(
       // past the bottom; it is split at a line boundary by the path below
       // (Word's default behaviour). A keep-on-page float forces relocation too.
       const keepIntact = para.keepLines || needNext > 0 || addReservePt > 0;
-      // ECMA-376 §17.6.4 column balancing: move the whole paragraph to the next
-      // column once the current (non-last) column has reached the balanced target
-      // (reuses the relocate machinery below, which rolls back / re-registers this
-      // paragraph's floats against the new column). No-op when balancing is off.
-      const balanceBreak = wantsBalanceBreak(fitHeight);
+      // A paragraph splits at line boundaries unless keepLines (§17.3.1.14) holds
+      // and it still fits a page (a keepLines paragraph taller than a page must
+      // split anyway). Used both for the balance whole-move below and the
+      // page/balance split path further down.
+      const splittable = !para.keepLines || h > effContentH();
+      // ECMA-376 §17.6.4 column balancing. Move the WHOLE paragraph to the next
+      // column when the current (non-last) column has reached the balanced target —
+      // but ONLY for a paragraph that cannot be split at a line boundary
+      // (keepLines). A splittable paragraph is instead split AT the balance target
+      // by the split path below, so a long paragraph fills column 0 up to the
+      // target and spills the remainder into column 1 (even columns), rather than
+      // being shoved whole into the next column (which left column 0 nearly empty
+      // and column 1 overfull, sample-12 p.2). No-op when balancing is off.
+      const balanceBreak = wantsBalanceBreak(fitHeight) && !splittable;
       if (breakForFloat || balanceBreak || (overflowsHere && keepIntact && needed <= effContentH())) {
         const pagesBeforeRelocate = pages.length;
         // Relocating THIS paragraph to a fresh page: pre-scan from `i` so the
@@ -1690,8 +1699,19 @@ export function computePages(
       // (§17.3.1.14) forbids splitting unless the paragraph cannot fit on any
       // page (taller than the full content height), where it must split anyway.
       const pageContentH = effContentH();
-      const remainingH = pageContentH - y;
-      const splittable = !para.keepLines || h > pageContentH;
+      // ECMA-376 §17.6.4 — in a BALANCED newspaper section every non-last column
+      // fills only to the balance target (the region top + height/ncols); the last
+      // column absorbs the remainder. Cap the split at that target so a paragraph
+      // taller than one balanced column is split AT the balance point instead of
+      // packed whole into column 0 (which left column 0 visibly fuller than column
+      // 1, sample-12 p.2). Unbalanced / greedy sections (balanceColH == null) and
+      // the last column return the page bottom, so this is behaviour-neutral there.
+      // Read live (colIndex / colTopY / balanceColH change as the split advances).
+      const columnBottomLimit = (): number =>
+        balanceColH != null && colIndex < columns.length - 1
+          ? Math.min(effContentH(), colTopY + balanceColH)
+          : effContentH();
+      const remainingH = columnBottomLimit() - y;
       if (fitHeight > remainingH && splittable) {
         const placed = splitParagraphAcrossPages(
           measureState, para, colW(), suppressBefore, colX(),
@@ -1708,6 +1728,7 @@ export function computePages(
           () => colIndex,
           columns,
           () => colTopY,
+          columnBottomLimit,
         );
         // After splitting, `y` is the bottom of the last slice in the
         // current column (continues for the LAST slice; intermediate slices
@@ -2073,8 +2094,17 @@ function splitParagraphAcrossPages(
    *  section restarts here (below the preceding single-column content), not at
    *  the page top. Omitted ⇒ the page content top (0). */
   columnTop?: () => number,
+  /** ECMA-376 §17.6.4 — the content-relative BOTTOM (pt) the current column may
+   *  fill to, read AFTER each `newPage()`. For a balanced newspaper section this
+   *  is the balance target (`colTop + height/ncols`) on every non-last column, so
+   *  a single paragraph taller than one balanced column is split at the balance
+   *  point rather than packed into column 0; the last column (and any unbalanced
+   *  section) is uncapped at the page content bottom. Omitted ⇒ `contentH` (the
+   *  page bottom) — behaviour-neutral for the single-column / greedy paths. */
+  columnBottom?: () => number,
 ): { endY: number } {
   const colTop = columnTop ?? (() => 0);
+  const colBot = columnBottom ?? (() => contentH);
   const stamp = (el: PaginatedBodyElement): PaginatedBodyElement => {
     if (tagColIndex) el.colIndex = tagColIndex();
     if (colGeom) el.colGeom = colGeom;
@@ -2102,7 +2132,7 @@ function splitParagraphAcrossPages(
   const placeMarkOnly = (): { endY: number } => {
     let markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
     let top = initialY;
-    if (initialY > 0 && initialY + markH - para.spaceAfter > contentH) {
+    if (initialY > 0 && initialY + markH - para.spaceAfter > colBot()) {
       newPage(initialY);
       top = colTop();
       markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
@@ -2142,8 +2172,9 @@ function splitParagraphAcrossPages(
   let cursorY = initialY;
   let isFirstSliceOnPage = true; // first slice carries spaceBefore
   while (lineIdx < lines.length) {
-    // Available space on the current page from cursorY downward.
-    const remaining = contentH - cursorY;
+    // Available space in the current column from cursorY downward (balance target
+    // for a non-last balanced column; the page bottom otherwise).
+    const remaining = colBot() - cursorY;
     // First slice on a page reserves spaceBefore; the LAST slice (covering
     // the final line) reserves spaceAfter.
     const sliceLeading = isFirstSliceOnPage ? spaceBefore : 0;


### PR DESCRIPTION
## Problem (dev-notes follow-up item 2)

sample-12 page 2's 2-column body balanced unevenly. A long paragraph was either packed whole into column 0, or — when column 0 already held a short note — shoved whole into column 1, leaving one column nearly empty. Word balances at **line** granularity: it splits the paragraph across the balance boundary so the columns end at roughly equal heights.

## Fix

Two changes to the §17.6.4 balancing path in `computePages`:

1. **Balance-aware column bottom for the split.** `splitParagraphAcrossPages` gets a `columnBottom()` thunk: a non-last column of a balanced section fills only to the balance target (`region top + height/ncols`); the last column (and any unbalanced/greedy section) is uncapped at the page bottom.
2. **Whole-move only for non-splittable paragraphs.** The whole-paragraph balance move (`wantsBalanceBreak`) now fires only for paragraphs that cannot be split (`keepLines`). A splittable paragraph is split AT the balance target instead, so column 0 fills to the target and the remainder flows into column 1.

A split paragraph's first slice stays in its original column, so its paragraph-anchored floats (registered at the column top) need no re-registration — only the whole-move path (kept for `keepLines`) re-anchors floats.

## Verification

- **Rendered sample-12 page 2** (Word PDF ground truth): the long "You will continue…" paragraph now splits across column 0 → column 1 at the balance boundary, matching Word; the top and bottom 2-column sections are even.
- sample-12 still **3 pages**, sample-13 still **5 pages** (balancing page count preserved).
- docx **271** tests (incl. a new line-granular split test) + node page-count gate + root typecheck green.
- Behaviour-neutral for unbalanced/greedy sections (`balanceColH == null` ⇒ page-bottom limit, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)