### PR TITLE
fix(core,docx): EMF picture-frame mapping + srcRect crop + rotated labels + bar fills

### DIFF
--- a/packages/core/src/image/emf.test.ts
+++ b/packages/core/src/image/emf.test.ts
@@ -67,15 +67,22 @@ const EMR = {
   SETPOLYFILLMODE: 19,
   SETTEXTALIGN: 22,
   SETTEXTCOLOR: 24,
+  SAVEDC: 33,
+  RESTOREDC: 34,
   MODIFYWORLDTRANSFORM: 36,
   SELECTOBJECT: 37,
   CREATEPEN: 38,
   CREATEBRUSHINDIRECT: 39,
   DELETEOBJECT: 40,
+  BEGINPATH: 59,
+  ENDPATH: 60,
+  CLOSEFIGURE: 61,
+  SELECTCLIPPATH: 67,
   EXTCREATEFONTINDIRECTW: 82,
   EXTTEXTOUTW: 84,
   POLYGON16: 86,
   POLYLINE16: 87,
+  CREATEDIBPATTERNBRUSHPT: 94,
 } as const;
 
 /** An EMF record: u32 iType, u32 nSize (incl. the 8-byte header), then data.
@@ -111,12 +118,32 @@ function concat(...parts: Uint8Array[]): Uint8Array {
 
 /** EMR_HEADER with the given inclusive device bounds (left,top,right,bottom).
  *  The signature " EMF" (0x464D4520) must land at byte offset 40 of the whole
- *  file → record offset 40 (the header record starts at file offset 0). */
-function emfHeader(left = 0, top = 0, right = 100, bottom = 100): Uint8Array {
+ *  file → record offset 40 (the header record starts at file offset 0).
+ *
+ *  `opts.frame` (.01 mm) + `opts.dev`/`opts.mm` (reference device px/mm) drive
+ *  the picture-frame mapping (`playEmf` maps the frame, not the ink bounds, onto
+ *  the target). The default leaves the frame degenerate (0,0,0,0) so the player
+ *  falls back to mapping the ink bounds — keeping the coordinate-pipeline tests
+ *  below focused on the world transform + scaling. The frame path has its own
+ *  test (`maps the picture frame … not the ink bounds`). */
+function emfHeader(
+  left = 0,
+  top = 0,
+  right = 100,
+  bottom = 100,
+  opts: {
+    frame?: { l: number; t: number; r: number; b: number };
+    dev?: { cx: number; cy: number };
+    mm?: { cx: number; cy: number };
+  } = {},
+): Uint8Array {
+  const f = opts.frame ?? { l: 0, t: 0, r: 0, b: 0 };
+  const dev = opts.dev ?? { cx: 1920, cy: 1080 };
+  const mm = opts.mm ?? { cx: 508, cy: 286 };
   return record(EMR.HEADER, (w) => {
     // data starts at record offset 8:
     w.i32(left).i32(top).i32(right).i32(bottom); // rclBounds   (off 8..24)
-    w.i32(0).i32(0).i32(36000).i32(22000); //        rclFrame    (off 24..40)
+    w.i32(f.l).i32(f.t).i32(f.r).i32(f.b); //        rclFrame    (off 24..40)
     w.u32(0x464d4520); //                            dSignature  (off 40) " EMF"
     w.u32(0x00010000); //                            nVersion    (off 44)
     w.u32(0); //                                     nBytes      (off 48)
@@ -124,8 +151,8 @@ function emfHeader(left = 0, top = 0, right = 100, bottom = 100): Uint8Array {
     w.u16(0).u16(0); //                              nHandles/sReserved
     w.u32(0).u32(0); //                              nDescription/offDescription
     w.u32(0); //                                     nPalEntries
-    w.i32(1920).i32(1080); //                        szlDevice (px)
-    w.i32(508).i32(286); //                          szlMillimeters
+    w.i32(dev.cx).i32(dev.cy); //                    szlDevice (px)     (off 72)
+    w.i32(mm.cx).i32(mm.cy); //                      szlMillimeters     (off 80)
   });
 }
 
@@ -220,6 +247,15 @@ function makeRecordingCtx(): MockCtx {
     fillText(t: string, x: number, y: number) {
       calls.push({ op: 'fillText', args: [t, x, y] });
       styles.text.push(_fill);
+    },
+    translate(x: number, y: number) {
+      calls.push({ op: 'translate', args: [x, y] });
+    },
+    rotate(a: number) {
+      calls.push({ op: 'rotate', args: [a] });
+    },
+    clip(rule?: string) {
+      calls.push({ op: 'clip', args: rule ? [rule] : [] });
     },
   };
   return { ctx: ctx as unknown as CanvasRenderingContext2D, calls, styles };
@@ -449,6 +485,123 @@ describe('playEmf — EXTTEXTOUTW text', () => {
     expect(texts[0].args[0]).toBe('F1');
     expect(texts[0].args.slice(1)).toEqual([20, 30]); // identity WT, ×1 device
     expect(m.styles.text.at(-1)?.toLowerCase()).toBe('#ff0000'); // red text color
+  });
+
+  it('rotates text by lfEscapement (vertical axis labels)', () => {
+    // lfEscapement = 900 → 90° counterclockwise. The draw becomes
+    // translate(refPx) + rotate(−90°) + fillText at the origin.
+    const text = 'Dx';
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.EXTCREATEFONTINDIRECTW, (w) => {
+        w.u32(1);
+        // lfHeight, lfWidth, lfEscapement=900, lfOrientation, lfWeight
+        w.i32(-12).i32(0).i32(900).i32(0).i32(400);
+        w.raw(0, 0, 0, 0);
+        w.raw(0, 0, 0, 0);
+        const face = 'Arial';
+        w.utf16(face);
+        for (let i = face.length; i < 32; i++) w.u16(0);
+      }),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.EXTTEXTOUTW, (w) => {
+        w.i32(0).i32(0).i32(100).i32(100);
+        w.u32(1);
+        w.f32(1).f32(1);
+        w.i32(20).i32(30);
+        w.u32(text.length);
+        w.u32(76);
+        w.u32(0);
+        w.i32(0).i32(0).i32(0).i32(0);
+        w.u32(0);
+        w.utf16(text);
+      }),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(playEmf(file, m.ctx, 100, 100)).toBe(true);
+    expect(m.calls.find((c) => c.op === 'translate')?.args).toEqual([20, 30]);
+    expect(m.calls.find((c) => c.op === 'rotate')?.args[0]).toBeCloseTo(-Math.PI / 2, 6);
+    expect(m.calls.find((c) => c.op === 'fillText')?.args).toEqual(['Dx', 0, 0]);
+  });
+});
+
+describe('playEmf — picture frame mapping + path clip', () => {
+  it('maps the picture frame onto the target — ink fills a sub-rectangle, not the whole raster', () => {
+    // Ink bounds 0..100 (device px); the picture FRAME is twice as large
+    // (rclFrame 0..200 .01 mm with a 1 px/.01 mm reference device ⇒ frame device
+    // extent 200). GDI maps the FRAME to the target, so on a 200×200 raster the
+    // ink corner (100,100) lands at (100,100) — half the frame — NOT (200,200) as
+    // a bounds-fill mapping would give. This is what lets an `<a:srcRect>` crop
+    // (relative to the frame) select the ink region.
+    const file = concat(
+      emfHeader(0, 0, 100, 100, {
+        frame: { l: 0, t: 0, r: 200, b: 200 },
+        dev: { cx: 50800, cy: 28600 }, // = mm × 100 ⇒ 1 device px per .01 mm
+        mm: { cx: 508, cy: 286 },
+      }),
+      record(EMR.CREATEPEN, (w) => w.u32(1).u32(0).i32(1).i32(0).u32(0x00ff0000)),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYLINE16, (w) =>
+        w.i32(0).i32(0).i32(100).i32(100).u32(2).i16(0).i16(0).i16(100).i16(100),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(playEmf(file, m.ctx, 200, 200)).toBe(true);
+    expect(m.calls.find((c) => c.op === 'moveTo')?.args).toEqual([0, 0]);
+    expect(m.calls.find((c) => c.op === 'lineTo')?.args).toEqual([100, 100]);
+  });
+
+  it('BEGINPATH…ENDPATH + SELECTCLIPPATH sets a clip; the path geometry is not filled', () => {
+    // A polygon between BEGINPATH and ENDPATH defines the clip shape — it must
+    // build the path (no fill/stroke) and SELECTCLIPPATH applies it as a clip,
+    // bracketed by SAVEDC/RESTOREDC on the canvas (sample-13 Fig.3 clips a DIB to
+    // the bar shapes). Without this the clip-path polygon would paint a red fill.
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.CREATEBRUSHINDIRECT, (w) => w.u32(1).u32(0).u32(0x000000ff).u32(0)), // red solid
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.SAVEDC, () => {}),
+      record(EMR.BEGINPATH, () => {}),
+      record(EMR.POLYGON16, (w) =>
+        w.i32(0).i32(0).i32(50).i32(50).u32(3).i16(0).i16(0).i16(50).i16(0).i16(50).i16(50),
+      ),
+      record(EMR.ENDPATH, () => {}),
+      record(EMR.SELECTCLIPPATH, (w) => w.u32(1)), // RGN_AND
+      record(EMR.RESTOREDC, (w) => w.i32(-1)),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    playEmf(file, m.ctx, 100, 100);
+    expect(m.calls.some((c) => c.op === 'clip')).toBe(true);
+    expect(m.calls.some((c) => c.op === 'fill')).toBe(false); // in-path polygon not filled
+    expect(m.calls.some((c) => c.op === 'save')).toBe(true);
+    expect(m.calls.some((c) => c.op === 'restore')).toBe(true);
+  });
+
+  it('decodes a 4bpp DIB pattern brush (MATLAB bar-chart fill colour)', () => {
+    // A 2×2 4bpp BI_RGB DIB, 1-entry palette = blue, all pixels index 0. The
+    // pattern brush averages to that blue, so a polygon fills blue — exercising
+    // the 4bpp decode path that paints sample-13 Fig.3's bars.
+    const file = concat(
+      emfHeader(0, 0, 100, 100),
+      record(EMR.CREATEDIBPATTERNBRUSHPT, (w) => {
+        w.u32(1).u32(0).u32(32).u32(44).u32(76).u32(8); // ih,iUsage,offBmi,cbBmi,offBits,cbBits
+        // BITMAPINFOHEADER (40 bytes) @ record offset 32:
+        w.u32(40).i32(2).i32(2).u16(1).u16(4).u32(0).u32(0).i32(0).i32(0).u32(1).u32(0);
+        w.raw(0xff, 0x00, 0x00, 0x00); // palette[0] = blue (B,G,R,reserved)
+        w.raw(0, 0, 0, 0, 0, 0, 0, 0); // 2 rows × 4-byte stride, all index 0
+      }),
+      record(EMR.SELECTOBJECT, (w) => w.u32(1)),
+      record(EMR.POLYGON16, (w) =>
+        w.i32(0).i32(0).i32(40).i32(40).u32(3).i16(0).i16(0).i16(40).i16(0).i16(40).i16(40),
+      ),
+      record(EMR.EOF, () => {}),
+    );
+    const m = makeRecordingCtx();
+    expect(playEmf(file, m.ctx, 100, 100)).toBe(true);
+    expect(m.styles.fill.at(-1)?.toLowerCase()).toBe('#0000ff');
   });
 });
 

--- a/packages/core/src/image/emf.ts
+++ b/packages/core/src/image/emf.ts
@@ -30,10 +30,11 @@
 // twins), POLYPOLYGON16/POLYPOLYLINE16 (+ 32-bit twins), MOVETOEX, LINETO,
 // RECTANGLE, ELLIPSE, SETPOLYFILLMODE, EXTTEXTOUTW, SETTEXTCOLOR, SETTEXTALIGN,
 // SETBKMODE, BITBLT, STRETCHDIBITS (minimal DIB decoder), EOF.
+// Path clipping IS handled: BEGINPATH/ENDPATH/CLOSEFIGURE build a path and
+// SELECTCLIPPATH applies it as a clip (scoped by SAVEDC/RESTOREDC).
 // Ignored (no-op, skipped by nSize): GDICOMMENT (may hold EMF+, out of scope),
 // SETICMMODE, SETMITERLIMIT, SETROP2, SETSTRETCHBLTMODE, INTERSECTCLIPRECT,
-// BEGINPATH/ENDPATH/SELECTCLIPPATH (clipping is ignored in v1 — [MS-EMF] clip
-// records), and any unrecognized iType.
+// and any unrecognized iType.
 //
 // Shared across the docx, pptx and xlsx renderers via
 // {@link ./wmf.ts}#decodeRasterOrMetafile, which sniffs the bytes and routes
@@ -69,6 +70,10 @@ const EMR = {
   ELLIPSE: 42,
   RECTANGLE: 43,
   LINETO: 54,
+  BEGINPATH: 59,
+  ENDPATH: 60,
+  CLOSEFIGURE: 61,
+  SELECTCLIPPATH: 67,
   EXTCREATEFONTINDIRECTW: 82,
   EXTTEXTOUTW: 84,
   POLYBEZIER16: 85,
@@ -122,6 +127,7 @@ interface Font {
   weight: number; // lfWeight (400 normal, 700 bold)
   italic: boolean;
   face: string;
+  escapement: number; // lfEscapement — tenths of a degree, counterclockwise
 }
 type EmfObject = Pen | Brush | Font;
 
@@ -239,6 +245,7 @@ interface PlayState {
   curY: number;
   stack: SavedDc[]; // SAVEDC/RESTOREDC graphics-state stack
   drew: boolean;
+  inPath: boolean; // between BEGINPATH and ENDPATH — geometry builds a path, no draw
 }
 
 /** Snapshot of the graphics state pushed by EMR_SAVEDC. */
@@ -435,6 +442,26 @@ function decodeDib(
         putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
       }
       anyAlpha = true;
+    } else if (biBitCount === 4 && palette) {
+      // 4bpp: two palette indices per byte, high nibble first (MATLAB exports the
+      // bar-chart fill as a 16-colour STRETCHDIBITS — sample-13 Fig.3 PR_VAR bars).
+      for (let x = 0; x < width; x++) {
+        const byte = dv.getUint8(rowOff + (x >> 1));
+        const idx = (x & 1) === 0 ? (byte >> 4) & 0xf : byte & 0xf;
+        const c = palette[idx] ?? 0;
+        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
+      }
+      anyAlpha = true;
+    } else if (biBitCount === 1 && palette) {
+      // 1bpp: eight palette indices per byte, MSB first (monochrome pattern
+      // brushes — gridlines/axes).
+      for (let x = 0; x < width; x++) {
+        const byte = dv.getUint8(rowOff + (x >> 3));
+        const bit = (byte >> (7 - (x & 7))) & 1;
+        const c = palette[bit] ?? 0;
+        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
+      }
+      anyAlpha = true;
     } else {
       return null; // unsupported bit depth
     }
@@ -544,7 +571,7 @@ function fillStrokePolygon(s: PlayState, c: EmfCursor, rp: PointReader): void {
   const count = c.u32();
   if (count < 2 || count > 0x100000) return;
   const { ctx } = s;
-  ctx.beginPath();
+  if (!s.inPath) ctx.beginPath();
   let started = false;
   for (let i = 0; i < count; i++) {
     if (c.remaining < 4) break;
@@ -557,6 +584,7 @@ function fillStrokePolygon(s: PlayState, c: EmfCursor, rp: PointReader): void {
   }
   if (!started) return;
   ctx.closePath();
+  if (s.inPath) return; // path bracket: defer fill/stroke
   if (s.curBrush && s.curBrush.fill != null) {
     ctx.fillStyle = s.curBrush.fill;
     ctx.fill(s.fillRule);
@@ -643,7 +671,7 @@ function fillStrokePolyPoly(
     counts.push(c.u32());
   }
   const { ctx } = s;
-  ctx.beginPath();
+  if (!s.inPath) ctx.beginPath(); // in a path bracket: accumulate, don't reset
   let any = false;
   for (const cnt of counts) {
     if (cnt < 2) {
@@ -660,7 +688,7 @@ function fillStrokePolyPoly(
     if (isPolygon) ctx.closePath();
     any = true;
   }
-  if (!any) return;
+  if (!any || s.inPath) return; // path bracket: geometry added, defer fill/stroke
   if (isPolygon && s.curBrush && s.curBrush.fill != null) {
     ctx.fillStyle = s.curBrush.fill;
     ctx.fill(s.fillRule);
@@ -681,12 +709,13 @@ function fillStrokeRect(s: PlayState, l: number, t: number, r: number, b: number
   const c1 = toPx(s, r, t);
   const c2 = toPx(s, r, b);
   const c3 = toPx(s, l, b);
-  ctx.beginPath();
+  if (!s.inPath) ctx.beginPath();
   ctx.moveTo(c0[0], c0[1]);
   ctx.lineTo(c1[0], c1[1]);
   ctx.lineTo(c2[0], c2[1]);
   ctx.lineTo(c3[0], c3[1]);
   ctx.closePath();
+  if (s.inPath) return; // path bracket: defer fill/stroke
   if (s.curBrush && s.curBrush.fill != null) {
     ctx.fillStyle = s.curBrush.fill;
     ctx.fill(s.fillRule);
@@ -768,7 +797,9 @@ function readCreateFont(c: EmfCursor, dv: DataView, recStart: number): [number, 
   const ih = c.u32();
   const lfBase = recStart + 12; // ihObject (4) after the 8-byte record header
   const lfHeight = dv.getInt32(lfBase, true);
-  // lfWidth(4), lfEscapement(8), lfOrientation(12)
+  // lfWidth(4), lfEscapement(8), lfOrientation(12) — escapement drives rotated
+  // axis labels (e.g. a vertical "Dx [mm]" at 900 = 90° CCW).
+  const lfEscapement = dv.getInt32(lfBase + 8, true);
   const lfWeight = dv.getInt32(lfBase + 16, true);
   const lfItalic = dv.getUint8(lfBase + 20);
   // lfFaceName: UTF-16, up to 32 code units, at LOGFONT offset 28.
@@ -788,6 +819,7 @@ function readCreateFont(c: EmfCursor, dv: DataView, recStart: number): [number, 
       weight: lfWeight,
       italic: lfItalic !== 0,
       face,
+      escapement: lfEscapement,
     },
   ];
 }
@@ -832,8 +864,23 @@ function drawText(s: PlayState, c: EmfCursor, dv: DataView, recStart: number): v
   // TA_BASELINE(0x18) → alphabetic; else top.
   ctx.textBaseline = (s.textAlign & 0x18) === 0x18 ? 'alphabetic' : 'top';
   // bkMode TRANSPARENT(1): never paint a background box (always the case here).
+  // lfEscapement rotates the text about the reference point (tenths of a degree,
+  // counterclockwise from the device x-axis). Canvas angles are clockwise on a
+  // y-down surface, so negate. Used for vertical axis labels (e.g. 900 = 90°).
+  const escTenths = font?.escapement ?? 0;
   try {
-    ctx.fillText(str, dx, dy);
+    if (escTenths !== 0) {
+      ctx.save();
+      try {
+        ctx.translate(dx, dy);
+        ctx.rotate((-escTenths / 10) * (Math.PI / 180));
+        ctx.fillText(str, 0, 0);
+      } finally {
+        ctx.restore(); // always unwind the save, even if fillText throws
+      }
+    } else {
+      ctx.fillText(str, dx, dy);
+    }
     s.drew = true;
   } catch {
     // Some ctx mocks lack fillText; a missing fillText must not abort the render.
@@ -965,6 +1012,7 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
     curY: 0,
     stack: [],
     drew: false,
+    inPath: false,
   };
 
   let pos = 0;
@@ -984,15 +1032,51 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
     try {
       switch (iType) {
         case EMR.HEADER: {
-          // RECTL rclBounds @ data offset 8 (= record offset 16), then rclFrame.
-          const left = dv.getInt32(pos + 8, true);
-          const top = dv.getInt32(pos + 12, true);
-          const right = dv.getInt32(pos + 16, true);
-          const bottom = dv.getInt32(pos + 20, true);
-          s.left = left;
-          s.top = top;
-          s.boundsW = Math.max(1, right - left);
-          s.boundsH = Math.max(1, bottom - top);
+          // ENHMETAHEADER ([MS-EMF] 2.2.9). rclBounds (the INK bounding box, in
+          // device units) @ record offset 8; rclFrame (the intended PICTURE
+          // FRAME, in .01 mm) @ 24; szlDevice (reference device size, px) @ 72;
+          // szlMillimeters (reference device size, mm) @ 80.
+          const bLeft = dv.getInt32(pos + 8, true);
+          const bTop = dv.getInt32(pos + 12, true);
+          const bRight = dv.getInt32(pos + 16, true);
+          const bBottom = dv.getInt32(pos + 20, true);
+          // Default mapping: the ink bounds fill the target. Used when the frame
+          // or reference device size is absent/degenerate (mirrors the
+          // LibreOffice/POI fallback to the bounds rectangle).
+          s.left = bLeft;
+          s.top = bTop;
+          s.boundsW = Math.max(1, bRight - bLeft);
+          s.boundsH = Math.max(1, bBottom - bTop);
+          // GDI `PlayEnhMetaFile` maps the FRAME — not the ink bounds — onto the
+          // target rectangle, so whitespace around the ink is preserved and a
+          // PowerPoint/Word `<a:srcRect>` crop (defined relative to the frame,
+          // ECMA-376 §20.1.8.55) aligns with the picture. The records draw in
+          // device units (same units as rclBounds), so convert the frame from
+          // .01 mm to those device units via the reference device resolution
+          // (px per .01 mm = szlDevice / (szlMillimeters · 100)) and map THAT
+          // rectangle instead. (Confirmed against [MS-EMF] 2.2.9 + the GDI
+          // PlayEnhMetaFile remarks + LibreOffice emfio / Apache POI HEMF, which
+          // both size the picture to the frame.)
+          if (recEnd >= pos + 88) {
+            const fLeft = dv.getInt32(pos + 24, true);
+            const fTop = dv.getInt32(pos + 28, true);
+            const fRight = dv.getInt32(pos + 32, true);
+            const fBottom = dv.getInt32(pos + 36, true);
+            const devCx = dv.getInt32(pos + 72, true);
+            const devCy = dv.getInt32(pos + 76, true);
+            const mmCx = dv.getInt32(pos + 80, true);
+            const mmCy = dv.getInt32(pos + 84, true);
+            const fwMm = fRight - fLeft;
+            const fhMm = fBottom - fTop;
+            if (fwMm > 0 && fhMm > 0 && devCx > 0 && devCy > 0 && mmCx > 0 && mmCy > 0) {
+              const sx = devCx / (mmCx * 100); // device px per .01 mm (X)
+              const sy = devCy / (mmCy * 100); // device px per .01 mm (Y)
+              s.left = fLeft * sx;
+              s.top = fTop * sy;
+              s.boundsW = Math.max(1, fwMm * sx);
+              s.boundsH = Math.max(1, fhMm * sy);
+            }
+          }
           break;
         }
         case EMR.SETWORLDTRANSFORM: {
@@ -1011,6 +1095,9 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
           break;
         }
         case EMR.SAVEDC: {
+          // Mirror the GDI state push on the canvas too, so a clip set via
+          // SELECTCLIPPATH (below) is scoped to the matching RESTOREDC.
+          s.ctx.save();
           s.stack.push({
             wt: { ...s.wt },
             curPen: s.curPen,
@@ -1031,7 +1118,10 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
           const iRelative = c.i32();
           const times = Math.min(Math.abs(iRelative) || 1, s.stack.length);
           let saved: SavedDc | undefined;
-          for (let i = 0; i < times; i++) saved = s.stack.pop();
+          for (let i = 0; i < times; i++) {
+            saved = s.stack.pop();
+            s.ctx.restore(); // unwind the matching canvas save (clip/state)
+          }
           if (saved) {
             s.wt = saved.wt;
             s.curPen = saved.curPen;
@@ -1043,6 +1133,34 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
             s.fillRule = saved.fillRule;
             s.curX = saved.curX;
             s.curY = saved.curY;
+          }
+          break;
+        }
+        case EMR.BEGINPATH: {
+          // Start a path bracket ([MS-EMF] 2.3.10): subsequent geometry records
+          // build the path instead of drawing it, until ENDPATH.
+          s.ctx.beginPath();
+          s.inPath = true;
+          break;
+        }
+        case EMR.CLOSEFIGURE: {
+          if (s.inPath) s.ctx.closePath();
+          break;
+        }
+        case EMR.ENDPATH: {
+          s.inPath = false;
+          break;
+        }
+        case EMR.SELECTCLIPPATH: {
+          // Use the path just defined as the clip region (intersecting the
+          // current clip — the common RGN_AND case, and what a following blit
+          // relies on, e.g. sample-13 Fig.3 clips a bar-chart DIB to the bar
+          // shapes so its background is masked out). Scoped by the enclosing
+          // SAVEDC/RESTOREDC.
+          try {
+            s.ctx.clip(s.fillRule);
+          } catch {
+            /* a ctx without clip() (some mocks): leave unclipped */
           }
           break;
         }
@@ -1222,9 +1340,9 @@ export function playEmf(bytes: Uint8Array, ctx: AnyCtx, W: number, H: number): b
           break;
         default:
           // GDICOMMENT (may hold EMF+, out of scope), SETICMMODE,
-          // SETMITERLIMIT, SETROP2, SETSTRETCHBLTMODE, INTERSECTCLIPRECT,
-          // BEGINPATH/ENDPATH/SELECTCLIPPATH (clipping ignored in v1 — [MS-EMF]
-          // clip records), and any unrecognized iType: skip by nSize.
+          // SETMITERLIMIT, SETROP2, SETSTRETCHBLTMODE, INTERSECTCLIPRECT, and any
+          // unrecognized iType: skip by nSize. (Path/clip records ARE handled
+          // above.)
           break;
       }
     } catch {

--- a/packages/docx/src/renderer.image.test.ts
+++ b/packages/docx/src/renderer.image.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { decodeRaster, preloadImages } from './renderer';
+import { decodeRaster, preloadImages, metafileRasterSize, drawImageCropped } from './renderer';
 import type { DocxDocumentModel } from './types';
 
 /**
@@ -106,5 +106,47 @@ describe('docx lazy image bytes', () => {
     } as unknown as DocxDocumentModel;
     const map = await preloadImages(doc, undefined);
     expect(map.size).toBe(0);
+  });
+});
+
+/**
+ * EMF/WMF srcRect crop (ECMA-376 §20.1.8.55). A metafile is rasterized at its
+ * FULL picture frame (`metafileRasterSize` scales the box up by 1/(1−crop)), then
+ * `drawImageCropped` selects the frame sub-rectangle with a 9-arg `drawImage`.
+ * This is what lets sample-13 Fig.2 crop one composite EMF into subfigures.
+ */
+describe('metafileRasterSize (full picture-frame raster for cropped metafiles)', () => {
+  it('scales a cropped metafile up to its full frame size', () => {
+    const s = metafileRasterSize('image/emf', { l: 0.1, t: 0.2, r: 0.1, b: 0.2 }, 80, 50);
+    expect(s.widthPt).toBeCloseTo(100, 6); // 80 / (1 − 0.1 − 0.1)
+    expect(s.heightPt).toBeCloseTo(83.333, 3); // 50 / (1 − 0.2 − 0.2)
+  });
+  it('passes an uncropped metafile through unchanged', () => {
+    expect(metafileRasterSize('image/emf', null, 80, 50)).toEqual({ widthPt: 80, heightPt: 50 });
+  });
+  it('passes a raster blip through unchanged even with a crop (raster decodes native)', () => {
+    expect(metafileRasterSize('image/png', { l: 0.1, t: 0, r: 0.1, b: 0 }, 80, 50)).toEqual({
+      widthPt: 80,
+      heightPt: 50,
+    });
+  });
+});
+
+describe('drawImageCropped honors a metafile srcRect crop', () => {
+  it('draws the frame sub-rectangle (9-arg drawImage) for a cropped metafile', () => {
+    const drawImage = vi.fn();
+    const ctx = { drawImage } as unknown as CanvasRenderingContext2D;
+    // A full-frame EMF raster; crop = sample-13 Fig.2 subfigure (a) insets.
+    const img = { width: 900, height: 556 } as unknown as Parameters<typeof drawImageCropped>[1];
+    drawImageCropped(ctx, img, { l: 0.0883, t: 0.0595, r: 0.6421, b: 0.6592 }, 10, 20, 122, 78);
+    expect(drawImage).toHaveBeenCalledTimes(1);
+    const call = drawImage.mock.calls[0];
+    expect(call).toHaveLength(9);
+    const [, sx, sy, sw, sh, dx, dy, dw, dh] = call;
+    expect(sx).toBeCloseTo(0.0883 * 900, 2);
+    expect(sw).toBeCloseTo((1 - 0.0883 - 0.6421) * 900, 2);
+    expect(sy).toBeCloseTo(0.0595 * 556, 2);
+    expect(sh).toBeCloseTo((1 - 0.0595 - 0.6592) * 556, 2);
+    expect([dx, dy, dw, dh]).toEqual([10, 20, 122, 78]);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -368,6 +368,31 @@ function authorColor(author?: string): string {
   return TRACK_CHANGE_AUTHOR_PALETTE[Math.abs(h) % TRACK_CHANGE_AUTHOR_PALETTE.length];
 }
 
+/**
+ * Raster target size (pt) for an embedded image. A raster blip decodes at its
+ * native pixel grid, so its display box is fine. A metafile (WMF/EMF) is
+ * rasterized by us at the size we ask for, and with an `<a:srcRect>` crop
+ * (ECMA-376 §20.1.8.55) the display box is only the visible sub-rectangle. The
+ * crop is relative to the metafile's PICTURE FRAME (the player maps the frame —
+ * not the ink bounds — onto the raster, see `playEmf`), so to crop correctly we
+ * must rasterize the WHOLE frame: scale the target up to the full frame display
+ * size (box ÷ (1−l−r) horizontally, ÷ (1−t−b) vertically). `drawImageCropped`
+ * then selects the right sub-region (e.g. sample-13 Fig.2 crops one composite EMF
+ * into subfigures (a)/(b)(c)). Uncropped metafiles and all raster blips are
+ * unaffected (the box passes through).
+ */
+export function metafileRasterSize(
+  mimeType: string,
+  srcRect: { l: number; t: number; r: number; b: number } | null | undefined,
+  widthPt: number,
+  heightPt: number,
+): { widthPt: number; heightPt: number } {
+  if (!srcRect || !isMetafileMime(mimeType)) return { widthPt, heightPt };
+  const fracW = Math.max(0.01, 1 - srcRect.l - srcRect.r);
+  const fracH = Math.max(0.01, 1 - srcRect.t - srcRect.b);
+  return { widthPt: widthPt / fracW, heightPt: heightPt / fracH };
+}
+
 function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
   const seen = new Map<string, ImagePair>();
   // Record one image reference (collapsing duplicate keys, tracking the max
@@ -415,8 +440,7 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
           mimeType: img.mimeType,
           svgImagePath: img.svgImagePath,
           colorReplaceFrom: img.colorReplaceFrom,
-          widthPt: img.widthPt ?? 0,
-          heightPt: img.heightPt ?? 0,
+          ...metafileRasterSize(img.mimeType, img.srcRect, img.widthPt ?? 0, img.heightPt ?? 0),
           hasCrop: img.srcRect != null,
         });
       } else if (run.type === 'shape') {
@@ -5215,25 +5239,26 @@ function drawTabLeader(
  * the display box, which is exactly the 9-arg `drawImage` behavior. A negative
  * (overscan) edge is clamped to 0 (degrades to a full draw).
  *
- * Crop is applied only for a raster blip, whose decoded `ImageBitmap` is the
- * full source at native resolution. A metafile (WMF/EMF) is rasterized to the
- * CROPPED display box by `decodeRasterOrMetafile`, so cropping its bitmap would
- * squish the whole figure to the sub-rect's aspect (sample-13 Fig.2 / Fig.3) —
- * metafiles draw whole, gated by `isMetafileMime`. When a crop is present
- * `preloadImages` forces the raster decode (an SVG element has no native pixel
- * grid). Mirrors the pptx and xlsx renderers.
+ * Crop applies to BOTH raster blips and metafiles (WMF/EMF). A raster blip's
+ * decoded `ImageBitmap` is the full source at native resolution; a cropped
+ * metafile is rasterized at its FULL PICTURE FRAME — `metafileRasterSize` scales
+ * the raster target up by 1/(1−l−r) and 1/(1−t−b), and `playEmf` maps the EMF
+ * frame (not the ink bounds) onto that raster — so the source rectangle here is
+ * the frame and the fractional crop selects the right sub-region (sample-13 Fig.2
+ * crops one composite EMF into subfigures (a)/(b)(c); Fig.3 trims its frame
+ * margins). When a crop is present `preloadImages` forces the raster decode (an
+ * SVG element has no native pixel grid). Mirrors the pptx and xlsx renderers.
  */
-function drawImageCropped(
+export function drawImageCropped(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   bmp: DecodedImage,
   srcRect: { l: number; t: number; r: number; b: number } | undefined,
-  mimeType: string,
   dx: number,
   dy: number,
   dw: number,
   dh: number,
 ): void {
-  if (srcRect && !isMetafileMime(mimeType) && (srcRect.l || srcRect.t || srcRect.r || srcRect.b)) {
+  if (srcRect && (srcRect.l || srcRect.t || srcRect.r || srcRect.b)) {
     const el = bmp as { naturalWidth?: number; naturalHeight?: number; width?: number; height?: number };
     const bw = el.naturalWidth || el.width || 0;
     const bh = el.naturalHeight || el.height || 0;
@@ -5265,7 +5290,7 @@ function renderInlineImage(
   if (!bmp) return;
   const w = seg.widthPt * scale;
   const h = seg.heightPt * scale;
-  drawImageCropped(ctx, bmp, seg.srcRect, seg.mimeType, x, baseline - h, w, h);
+  drawImageCropped(ctx, bmp, seg.srcRect, x, baseline - h, w, h);
 }
 
 /** Collect and draw anchor images with wrapMode='none' (or unspecified).
@@ -5313,7 +5338,7 @@ function renderAnchorImages(
     // does not displace text and is not displaced by other floats), so dist* is
     // unused here.
     const { x: pageX, y: pageY, w, h } = resolveAnchorBox(img, state, paragraphTopPx);
-    drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, img.mimeType, pageX, pageY, w, h);
+    drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, pageX, pageY, w, h);
   }
 }
 
@@ -6141,7 +6166,7 @@ function registerImageFloat(
 
   if (!state.dryRun) {
     const bmp = state.images.get(key);
-    if (bmp) drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, img.mimeType, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
+    if (bmp) drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
     rect.drawn = true;
   }
 }


### PR DESCRIPTION
## Problem (dev-notes follow-up item 3 — the one that regressed twice)

sample-13's MATLAB figures (`image3.emf` Fig.2, `image4.emf` Fig.3) rendered wrong, and a docx `<a:srcRect>` crop on an EMF could not be honored: Fig.2 showed the full composite squished into each subfigure box, vertical axis labels were not rotated, and Fig.3's bars were unfilled.

Root cause (verified from the [MS-EMF] header + GDI/LibreOffice/POI): our player mapped `rclBounds` (the device-unit **ink** box) onto the target, but GDI maps `rclFrame` (the .01mm **picture frame**). The ink occupies a sub-region of the frame; `<a:srcRect>` is relative to the frame. Plus the player ignored `lfEscapement`, 1bpp/4bpp DIBs, and path clipping.

## Fix

**core (`emf.ts`):**
1. **Picture-frame mapping** — map `rclFrame` (converted to device units via `szlDevice`/`szlMillimeters`) onto the target, not `rclBounds`; fall back to the ink bounds when the frame is degenerate. ([MS-EMF] 2.2.9; matches GDI `PlayEnhMetaFile`, LibreOffice emfio, Apache POI HEMF.)
2. **Rotated text** — read `lfEscapement`, rotate `EXTTEXTOUTW` about the reference point (vertical axis labels).
3. **1bpp + 4bpp DIB decode** — monochrome pattern brushes (gridlines) and 16-colour `STRETCHDIBITS` (bar fills); both previously fell back to grey.
4. **Path clipping** — handle `BEGINPATH`/`ENDPATH`/`CLOSEFIGURE`/`SELECTCLIPPATH`, tie `SAVEDC`/`RESTOREDC` to `ctx.save/restore`, so a DIB blit clipped to a path masks its background.

**docx (`renderer.ts`):**
- Rasterize a cropped metafile at its full picture-frame display size (`metafileRasterSize`) and enable the crop in `drawImageCropped` for metafiles (drop the `isMetafileMime` skip).

## Verification

Rendered in a real browser (EMF needs a real `createImageBitmap`, which the node shim lacks):
- **Fig.2**: one composite EMF cropped into subfigures (a) box-plot / (b)(c) line charts, with rotated axis labels — matches the Word PDF.
- **Fig.3**: 3 histogram panels + the PR_VAR bar graph; bars now **blue on white** (clipped DIB, no black background), rotated labels — matches the Word PDF.

core **21** EMF unit tests (4 new: frame mapping, escapement, path clip, 4bpp decode) + **946** tests across packages + root typecheck green.

Note: the core EMF improvements benefit pptx/xlsx too (shared decoder). Extending the metafile-crop enable to the pptx/xlsx renderers is a follow-up (no cropped-EMF sample there yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)