### PR TITLE
fix(docx): sample-12 figure caption — empty-paragraph line height + paragraph-float anchor

### DIFF
--- a/packages/docx/src/anchor-paragraph-spacebefore.test.ts
+++ b/packages/docx/src/anchor-paragraph-spacebefore.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, ImageRun, SectionProps } from './types';
+
+// ECMA-376 §20.4.3.5 ST_RelFromV "paragraph": a `<wp:positionV relativeFrom=
+// "paragraph">` float is positioned "relative to the paragraph which contains the
+// drawing anchor" — its TOP edge, BEFORE the paragraph's spaceBefore. Word anchors
+// the float at the paragraph top, NOT at the post-spaceBefore text area, and makes
+// no distinction between wrap modes. The renderer previously anchored WRAP floats
+// (square/tight/topAndBottom) at the post-spaceBefore text top while wrapNone floats
+// used the pre-spaceBefore top — so a wrap float on a paragraph with spaceBefore sat
+// `spaceBefore` pt too low (sample-12's figure: anchor paragraph spaceBefore=12 pt,
+// the image dropped 12 pt and ate the whitespace above its caption). This pins the
+// drawn float Y at the paragraph's pre-spaceBefore top for a wrapSquare image.
+
+interface DrawCall { y: number; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; draws: DrawCall[] } {
+  let font = '10px serif';
+  const draws: DrawCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    // No srcRect ⇒ 5-arg form drawImage(img, dx, dy, dw, dh): dy is the 3rd arg.
+    drawImage(_img: unknown, _dx: number, dy: number) { draws.push({ y: dy }); },
+    fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, draws };
+}
+
+function squareFloat(): ImageRun {
+  return {
+    type: 'image', imagePath: 'word/media/image1.png', mimeType: 'image/png',
+    widthPt: 80, heightPt: 40,
+    anchor: true, anchorYFromPara: true, anchorYRelativeFrom: 'paragraph',
+    anchorYPt: 0, anchorXPt: 0, anchorXFromMargin: true, anchorXRelativeFrom: 'margin',
+    wrapMode: 'square', wrapSide: 'bothSides',
+  } as unknown as ImageRun;
+}
+
+function paraWithFloat(spaceBefore: number): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{ ...squareFloat() } as DocParagraph['runs'][number],
+           { type: 'text', text: 'x', bold: false, italic: false, underline: false,
+             strikethrough: false, fontSize: 11, color: null, fontFamily: 'Times New Roman',
+             fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null,
+             hyperlink: null } as DocParagraph['runs'][number]],
+    defaultFontSize: 11, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function docOf(p: DocParagraph): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 800,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [p as unknown as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('paragraph-anchored wrap float Y (§20.4.3.5)', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 2, height: 2, close: () => {} }) as unknown as ImageBitmap),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('anchors a wrapSquare paragraph float at the pre-spaceBefore paragraph top', async () => {
+    const { canvas, draws } = makeRecordingCanvas();
+    await renderDocumentToCanvas(docOf(paraWithFloat(24)), canvas, 0, {
+      dpr: 1, width: 400, // scale = 1 (px per pt)
+      fetchImage: async (path: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    });
+    // First paragraph, marginTop=0, anchorYPt=0. Pre-spaceBefore top = 0; the
+    // float must draw at y≈0, NOT y≈24 (the post-spaceBefore text area).
+    expect(draws.length).toBeGreaterThan(0);
+    expect(draws[0].y).toBeCloseTo(0, 2);
+  });
+});

--- a/packages/docx/src/empty-paragraph-mark-height.test.ts
+++ b/packages/docx/src/empty-paragraph-mark-height.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  DocxTextRun,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.3.1.33 (line height) + §17.3.1.29 (paragraph mark): an EMPTY
+// paragraph still occupies one paragraph-mark line, whose height is the mark
+// font's single-line height — the SAME computation a text line of that font and
+// size uses (layoutLines → fontBoundingBox). The renderer must not size the
+// empty mark line from a synthetic 1-em box while text lines use the font's real
+// (often substituted) metrics; that asymmetry under-measured every empty
+// paragraph. In sample-12's figure block a run of nine empty "spacer" paragraphs
+// fell ~1.65 pt short per line, so the following centered caption rose into the
+// image float's wrap band and its first line wrapped beside the figure instead
+// of clearing it (the whole caption sits below the figure in Word).
+//
+// This stub reports an ASYMMETRIC ~1.15-em font box (asc 0.95 + desc 0.20),
+// mimicking a substituted Latin font (a real browser/skia "Times New Roman"
+// fallback reports ~1.15 em, NOT the synthetic 1.0 em). With a 1.0-em stub the
+// two code paths would coincide and the regression would be invisible.
+
+interface FillTextCall { text: string; x: number; y: number; }
+
+const ASC_RATIO = 0.95;
+const DESC_RATIO = 0.2; // sum = 1.15 em ≠ the old synthetic 0.8 + 0.2 = 1.0 em
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: FillTextCall[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * ASC_RATIO,
+        fontBoundingBoxDescent: p * DESC_RATIO,
+        actualBoundingBoxAscent: p * ASC_RATIO,
+        actualBoundingBoxDescent: p * DESC_RATIO,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) { calls.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 11, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: '',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as DocxTextRun;
+}
+
+function para(text: string): DocParagraph {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text === '' ? [] : [{ type: 'text', ...textRun(text) } as DocParagraph['runs'][number]],
+    defaultFontSize: 11, defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function docOf(bodyParas: DocParagraph[]): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 800,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: bodyParas as unknown as BodyElement[],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function baselines(bodyParas: DocParagraph[]): Promise<FillTextCall[]> {
+  const { canvas, calls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(docOf(bodyParas), canvas, 0, { dpr: 1, width: 400 });
+  return calls;
+}
+
+describe('empty paragraph mark line height (§17.3.1.29 / §17.3.1.33)', () => {
+  it('an empty paragraph advances the cursor by the SAME single-line height as a text paragraph', async () => {
+    // Reference: [A, M, B] — three single-line text paragraphs. The gap between
+    // A and B baselines = lineHeight(M) + lineHeight(A) (one full intervening line).
+    const refCalls = await baselines([para('A'), para('M'), para('B')]);
+    const refA = refCalls.find((c) => c.text === 'A')!;
+    const refB = refCalls.find((c) => c.text === 'B')!;
+    expect(refA).toBeDefined();
+    expect(refB).toBeDefined();
+    const refGap = refB.y - refA.y;
+
+    // Subject: [A, <empty>, B] — the middle paragraph is empty. Its mark line must
+    // reserve the same single-line height, so the A→B gap is identical.
+    const subjCalls = await baselines([para('A'), para(''), para('B')]);
+    const subjA = subjCalls.find((c) => c.text === 'A')!;
+    const subjB = subjCalls.find((c) => c.text === 'B')!;
+    expect(subjA).toBeDefined();
+    expect(subjB).toBeDefined();
+    const subjGap = subjB.y - subjA.y;
+
+    // Before the fix subjGap was short by (1.15 − 1.0) × 11 = 1.65 pt because the
+    // empty mark line used a synthetic 1-em box while the text lines used the
+    // 1.15-em stub box.
+    expect(subjGap).toBeCloseTo(refGap, 2);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1339,34 +1339,30 @@ export function computePages(
   // 0 when the paragraph has no paragraph-anchored floats (page-absolute floats
   // are pinned regardless of which page the anchor lands on, so they never
   // trigger a break). Measured at scale 1 (pt), matching the paginator's `y`.
-  const anchoredFloatBottomOffset = (para: DocParagraph, spaceBeforePt: number): number => {
+  const anchoredFloatBottomOffset = (para: DocParagraph): number => {
     let maxBottom = 0;
     for (const run of para.runs) {
       if (run.type === 'image') {
         const img = run as unknown as ImageRun;
         if (!img.anchor || !img.anchorYFromPara) continue;
-        // Wrap floats anchor after spaceBefore (registerAnchorFloats uses
-        // state.y post-spaceBefore); non-wrap floats anchor at the paragraph's
-        // pre-spaceBefore top (renderAnchorImages uses paragraphStartY). Mirror
-        // each so the estimate matches the draw position exactly.
-        const anchorBase = isWrapFloat(img.wrapMode) ? spaceBeforePt : 0;
-        const bottom = anchorBase + (img.anchorYPt ?? 0) + img.heightPt;
+        // ECMA-376 §20.4.3.5: a `positionV relativeFrom="paragraph"/"line"` float
+        // anchors against the paragraph's pre-spaceBefore TOP, regardless of wrap
+        // mode (registerAnchorFloats + renderAnchorImages both use paragraphStartY).
+        // So its bottom, measured from the paragraph top (the paginator's `y`), is
+        // anchorYPt + height — no spaceBefore term.
+        const bottom = (img.anchorYPt ?? 0) + img.heightPt;
         if (bottom > maxBottom) maxBottom = bottom;
       } else if (run.type === 'shape') {
         // An anchored shape with positionV relativeFrom="paragraph"/"line" is
-        // kept on its anchor's page the same way an image is. Mirror the image
-        // formula exactly — bottom = anchorBase + anchorYPt + height — but take
-        // the height from resolveShapeBox so sizeRelV / wgp-group scaling is
-        // honored. measureState is scale 1 (pt), so box.h is already in pt.
-        // (paragraphTopPx is passed through for shapes whose height depends on a
-        // paragraph/line container via sizeRelV; it does not affect the height
-        // for the common static-extent case.)
+        // kept on its anchor's page the same way an image is, and anchors at the
+        // same pre-spaceBefore paragraph top. Take the height from resolveShapeBox
+        // so sizeRelV / wgp-group scaling is honored. measureState is scale 1 (pt),
+        // so box.h is already in pt.
         const shp = run as unknown as ShapeRun;
         if (!shp.anchorYFromPara) continue;
-        const anchorBase = isWrapFloat(shp.wrapMode) ? spaceBeforePt : 0;
-        const box = resolveShapeBox(shp, measureState, measureState.y + anchorBase);
+        const box = resolveShapeBox(shp, measureState, measureState.y);
         if (box.h <= 0) continue;
-        const bottom = anchorBase + (shp.anchorYPt ?? 0) + box.h;
+        const bottom = (shp.anchorYPt ?? 0) + box.h;
         if (bottom > maxBottom) maxBottom = bottom;
       }
     }
@@ -1580,7 +1576,12 @@ export function computePages(
       // floats wholesale via newPage(), so this snapshot is unused there.)
       const floatsBefore = measureState.floats.length;
       const floatSeqBefore = measureState.floatParaSeq;
-      const paragraphAnchorY = measureState.y + effectiveBefore;
+      // ECMA-376 §20.4.3.5: a `positionV relativeFrom="paragraph"` float anchors
+      // at the paragraph's TOP (pre-spaceBefore), so register it at measureState.y
+      // BEFORE spaceBefore is folded in — matching the paint pass (paragraphStartY)
+      // and renderAnchorImages (wrapNone). See registerAnchorFloats's call site in
+      // renderParagraph for the spec rationale.
+      const paragraphAnchorY = measureState.y;
       registerAnchorFloats(para, measureState, paragraphAnchorY);
 
       const h = estimateParagraphHeight(measureState, para, colW(), suppressBefore, colX());
@@ -1631,7 +1632,7 @@ export function computePages(
       // keep-on-page behavior). When the float is taller than the page content
       // area it can never fit — leave it on this page and allow the overflow
       // (no break would help, and breaking unconditionally would loop forever).
-      const floatBottomOff = anchoredFloatBottomOffset(para, effectiveBefore);
+      const floatBottomOff = anchoredFloatBottomOffset(para);
       const floatOverflowsHere = floatBottomOff > 0 && y + floatBottomOff > effContentH();
       const floatFitsFresh = floatBottomOff > 0 && floatBottomOff <= effContentH();
       const breakForFloat = y > 0 && floatOverflowsHere && floatFitsFresh;
@@ -1673,7 +1674,7 @@ export function computePages(
           // floats were just discarded): this paragraph is now the first registrant
           // on the fresh page and gets paraId 0 — matching the renderer, which
           // re-registers from a fresh per-page state.
-          registerAnchorFloats(para, measureState, measureState.y + effectiveBefore);
+          registerAnchorFloats(para, measureState, measureState.y);
           // The references move to the new page; nothing was reserved there yet,
           // so the separator region still applies to the first footnote.
           if (haveFootnotes && newRefIds.length > 0) addReservePt = sumReserve(newRefIds);
@@ -1684,7 +1685,7 @@ export function computePages(
           // estimates for this paragraph (and later ones) use the right band.
           measureState.floats.length = floatsBefore;
           measureState.floatParaSeq = floatSeqBefore;
-          registerAnchorFloats(para, measureState, measureState.y + effectiveBefore);
+          registerAnchorFloats(para, measureState, measureState.y);
         }
       }
 
@@ -3257,11 +3258,18 @@ function renderParagraph(
 
   if (!suppressSpaceBefore) state.y += para.spaceBefore * scale;
 
-  // Register anchor floats from this paragraph (must happen after spaceBefore so
-  // that paragraph-relative Y resolves against the textAreaTop, matching Word).
+  // Register anchor floats from this paragraph. ECMA-376 §20.4.3.5: a
+  // `positionV relativeFrom="paragraph"` float is positioned relative to "the
+  // paragraph which contains the drawing anchor" — its TOP edge, BEFORE the
+  // paragraph's spaceBefore (Word anchors the float at the paragraph top, not the
+  // post-spaceBefore text area). So pass `paragraphStartY` (pre-spaceBefore),
+  // identically for wrap AND wrapNone floats (renderAnchorImages below already
+  // uses paragraphStartY). Anchoring wrap floats at the post-spaceBefore text top
+  // placed them spaceBefore too low — e.g. sample-12's figure (anchor paragraph
+  // spaceBefore=12 pt) sat 12 pt under Word, eating the gap above its caption.
   // Skipped for the frame-draw recursion: a frame paragraph's wrap exclusion is
   // its own FloatRect (renderFrameParagraph), not an anchor image/shape float.
-  if (!inFrame) registerAnchorFloats(para, state, state.y);
+  if (!inFrame) registerAnchorFloats(para, state, paragraphStartY);
 
   // behindDoc shapes must render before text so they appear behind it.
   renderAnchorImages(para, state, paragraphStartY, 'behind');

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7469,21 +7469,32 @@ function paragraphMarkLineHeight(
   fontFamilyClasses: Record<string, string> = {},
 ): number {
   const fs = getDefaultFontSize(para);
+  const family = getDefaultFontFamily(para);
   let asc: number;
   let desc: number;
-  if (eastAsian && ctx) {
-    // East Asian document: the empty paragraph-mark line follows the real East
-    // Asian font box so docGrid cell rounding (lineBoxHeight) reserves whole
-    // cells — a 20pt mark on a 20pt pitch → 2 cells (40px), matching Word's title
-    // pages. The synthetic 0.8/0.2 ≈ 1em fallback measures exactly one pitch and
-    // would round down to a single cell. fontBoundingBox is font-wide, so any
-    // East Asian glyph probes it.
+  if (ctx) {
+    // ECMA-376 §17.3.1.29 / §17.3.1.33: an empty paragraph's mark line reserves
+    // the mark font's REAL single-line height — the SAME fontBoundingBox a text
+    // line of that font and size uses (layoutLines), so an empty paragraph is
+    // exactly as tall as a one-character paragraph of the same run properties.
+    // The synthetic 0.8/0.2 ≈ 1em box under-measured every empty paragraph
+    // whenever the (often substituted) font's real box exceeds 1em — a Latin
+    // fallback reports ~1.15em — so a run of empty "spacer" paragraphs fell
+    // short and the following content rose into a preceding float's wrap band
+    // (sample-12: the figure caption wrapped beside the image instead of below
+    // it). East Asian documents probe an EA glyph so docGrid cell rounding
+    // (lineBoxHeight) reserves whole cells (a 20pt mark on a 20pt pitch → 2
+    // cells); others probe a Latin glyph. fontBoundingBox is font-wide, so the
+    // probe glyph choice does not change the box. correctLineMetrics rescales a
+    // substituted font to the document font's win box, identical to the text
+    // path (a no-op for fonts absent from the win-metric table, e.g. Latin).
     const prevFont = ctx.font;
-    ctx.font = buildFont(false, false, fs * scale, getDefaultFontFamily(para), fontFamilyClasses);
-    const m = ctx.measureText('あ');
-    asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fs * scale * 0.8;
-    desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fs * scale * 0.2;
+    ctx.font = buildFont(false, false, fs * scale, family, fontFamilyClasses);
+    const m = ctx.measureText(eastAsian ? 'あ' : 'x');
+    const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fs * scale * 0.8;
+    const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fs * scale * 0.2;
     ctx.font = prevFont;
+    ({ ascent: asc, descent: desc } = correctLineMetrics(family, fs * scale, rawAsc, rawDesc));
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5011,9 +5011,9 @@ function layoutLines(
     // metrics, rescale to the document font's design line box so the line
     // height (and thus baseline centering, row auto-heights, cell vAlign
     // §17.4.84, and pagination) match Word — see font-metrics.ts.
-    const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? s.fontSize * scale * 0.8;
-    const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? s.fontSize * scale * 0.2;
-    const corrected = correctLineMetrics(s.fontFamily, effectiveFontPx(s), rawAsc, rawDesc);
+    // Fallback box at the run's full size; correction at the effective size
+    // (smallCaps/vertAlign shrink it). See correctedLineMetrics.
+    const corrected = correctedLineMetrics(m, s.fontFamily, s.fontSize * scale, effectiveFontPx(s));
     let asc = corrected.ascent;
     const desc = corrected.descent;
     // Ruby annotation: small text rendered above the base. Reserve ascent
@@ -5850,11 +5850,13 @@ export function renderShapeText(
  * X: margin-relative offsets add section.marginLeft (ECMA-376 §20.4.3.4
  * relativeFrom="margin"); otherwise anchorXPt is already page-absolute.
  * Y: paragraph-relative offsets add `paraBaseY`; otherwise page-absolute. The
- * caller supplies `paraBaseY` because the two consumers anchor against different
- * paragraph references — wrap floats use the post-spaceBefore textAreaTop, while
- * wrapNone images use the pre-spaceBefore paragraph top (see the
- * anchoredFloatBottomOffset note in the paginator). This is the box origin BEFORE
- * any overlap displacement; resolveFloatOverlap runs on top of it for floats.
+ * caller supplies `paraBaseY` = the paragraph's pre-spaceBefore TOP for ALL
+ * paragraph-relative floats — wrap and wrapNone alike (ECMA-376 §20.4.3.5: a
+ * `positionV relativeFrom="paragraph"` float is positioned relative to the
+ * paragraph that contains the anchor, i.e. its top edge before spaceBefore).
+ * Page-level floats pass 0 (resolveAnchorY ignores paraBaseY for them). This is
+ * the box origin BEFORE any overlap displacement; resolveFloatOverlap runs on
+ * top of it for floats.
  *
  * Exported under a `_test` alias for the anchor-image relativeFrom wiring test
  * (the public renderer entry points consume the box internally; pin the
@@ -6074,7 +6076,8 @@ function registerImageFloat(
   const mode: 'square' | 'topAndBottom' =
     img.wrapMode === 'topAndBottom' ? 'topAndBottom' : 'square';
 
-  // Wrap floats anchor against the post-spaceBefore textAreaTop (paragraphAnchorY).
+  // Paragraph-relative wrap floats anchor at the pre-spaceBefore paragraph top
+  // (paragraphAnchorY), per ECMA-376 §20.4.3.5 — identical to wrapNone images.
   const box = resolveAnchorBox(img, state, paragraphAnchorY);
   const { w, h, dl, dr, dt, db } = box;
 
@@ -6123,8 +6126,8 @@ function registerShapeFloat(
 
   // Match resolveShapeBox's paragraphTopPx convention. resolveAnchorY reads
   // paragraphTopPx only for relativeFrom="paragraph"/"line" (anchorYFromPara);
-  // wrap floats anchor against the post-spaceBefore textAreaTop, identical to
-  // the image path (resolveAnchorBox uses paragraphAnchorY there).
+  // wrap floats anchor at the pre-spaceBefore paragraph top (§20.4.3.5),
+  // identical to the image path (resolveAnchorBox uses paragraphAnchorY there).
   const { x, y, w, h } = resolveShapeBox(shape, state, paragraphAnchorY);
   // A degenerate (zero/negative-area) box — e.g. a wrap-flagged line preset —
   // reserves no band; bail like renderAnchorShape skips drawing it.
@@ -7458,6 +7461,29 @@ function emptyLineNaturalPx(fontSizePt: number, scale: number): { asc: number; d
   return { asc: fontSizePt * scale * 0.8, desc: fontSizePt * scale * 0.2 };
 }
 
+/** Corrected single-line ascent/descent (px) from an ALREADY-measured
+ *  `TextMetrics`: the Canvas `fontBoundingBox` (with the synthetic 0.8/0.2-em
+ *  fallback when the engine reports none), rescaled to the document font's win
+ *  box via {@link correctLineMetrics}. The single source of truth for "how tall
+ *  is one line of `family`", shared by the text-line path (layoutLines) and the
+ *  empty paragraph-mark path (paragraphMarkLineHeight) so the two cannot drift —
+ *  that drift (the empty path skipping `correctLineMetrics`) was the
+ *  empty-paragraph under-measure bug (§17.3.1.29 / §17.3.1.33). `fallbackEmPx`
+ *  sizes the synthetic box (the run's full size); `correctionEmPx` is the design
+ *  size handed to `correctLineMetrics` — they differ only for smallCaps/vertAlign
+ *  runs (where the text path keeps the full-size fallback) and coincide for a
+ *  plain paragraph-mark line. */
+function correctedLineMetrics(
+  m: TextMetrics,
+  family: string | null | undefined,
+  fallbackEmPx: number,
+  correctionEmPx: number,
+): { ascent: number; descent: number } {
+  const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fallbackEmPx * 0.8;
+  const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fallbackEmPx * 0.2;
+  return correctLineMetrics(family, correctionEmPx, rawAsc, rawDesc);
+}
+
 /**
  * Height (px) of the paragraph-mark line box for a paragraph that places no
  * inline content on any line. Per ECMA-376 §17.3.1.29 the paragraph mark always
@@ -7492,17 +7518,18 @@ function paragraphMarkLineHeight(
     // (sample-12: the figure caption wrapped beside the image instead of below
     // it). East Asian documents probe an EA glyph so docGrid cell rounding
     // (lineBoxHeight) reserves whole cells (a 20pt mark on a 20pt pitch → 2
-    // cells); others probe a Latin glyph. fontBoundingBox is font-wide, so the
-    // probe glyph choice does not change the box. correctLineMetrics rescales a
-    // substituted font to the document font's win box, identical to the text
-    // path (a no-op for fonts absent from the win-metric table, e.g. Latin).
+    // cells); others probe a Latin glyph. fontBoundingBox is reported per
+    // resolved face (not per glyph), so the probe choice does not change the box
+    // for a face that contains it — and the probe is script-matched, so the mark
+    // font does. correctLineMetrics rescales a substituted font to the document
+    // font's win box, identical to the text path (a no-op for fonts absent from
+    // the win-metric table, e.g. Latin).
     const prevFont = ctx.font;
     ctx.font = buildFont(false, false, fs * scale, family, fontFamilyClasses);
     const m = ctx.measureText(eastAsian ? 'あ' : 'x');
-    const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fs * scale * 0.8;
-    const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fs * scale * 0.2;
     ctx.font = prevFont;
-    ({ ascent: asc, descent: desc } = correctLineMetrics(family, fs * scale, rawAsc, rawDesc));
+    // A mark line carries no smallCaps/vertAlign, so fallback == correction size.
+    ({ ascent: asc, descent: desc } = correctedLineMetrics(m, family, fs * scale, fs * scale));
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }


### PR DESCRIPTION
Fixes the sample-12 figure block to match the Word PDF (page 2). Two distinct, spec-grounded root causes — one commit each.

## 1. Caption rendered *beside* the figure — empty paragraph mark line height (§17.3.1.29 / §17.3.1.33)

The caption 「Figure 1 This is a Sample Figure」 wrapped into the right gap beside the photo instead of sitting below it. **Not** a column-assignment bug (the caption is correctly `colIndex=0`, full-width) and **not** a wrapSquare rule.

Real cause: the figure block has 9 **empty spacer paragraphs** before the caption. An empty paragraph still occupies one mark line whose height is the mark font's single-line height — the *same* computation a text line uses. But the renderer sized the empty line from a synthetic `0.8/0.2` ≈ 1 em box, while text lines use the font's real `fontBoundingBox` (a substituted "Times New Roman" reports ≈1.15 em). Each empty line fell ~1.65 pt short × 9 ≈ 14.85 pt, so the caption rose ~11 pt into the image float's wrap band (float bottom 600.18 pt vs caption top 588.73 pt).

`paragraphMarkLineHeight` now measures the mark font's real `fontBoundingBox` (Latin probe for non-EA / EA glyph for EA so docGrid cell rounding still reserves whole cells) and runs `correctLineMetrics`, identical to the text path. No-op for Meiryo. Test: `empty-paragraph-mark-height.test.ts`.

## 2. Too little whitespace between figure and caption — paragraph-float anchor Y (§20.4.3.5)

After fix #1 the caption clears the figure, but only by ~5 pt; Word leaves ~17.5 pt. ST_RelFromV `paragraph` positions a float relative to "the paragraph which contains the drawing anchor" — its **top edge (pre-spaceBefore)**, with no wrap/wrapNone distinction. The renderer anchored **wrap** floats at the post-spaceBefore text top while wrapNone floats already used the pre-spaceBefore top, so the image (anchor paragraph spaceBefore=12 pt) sat 12 pt too low and ate the gap.

`registerAnchorFloats` now receives the pre-spaceBefore paragraph top (`paragraphStartY` / `measureState.y`), matching `renderAnchorImages` and the spec; the image-bottom→caption gap becomes ≈17 pt (Word: 17.5 pt). Test: `anchor-paragraph-spacebefore.test.ts`.

## Verification

- Browser render of sample-12 p.2 matches the Word PDF: caption full-width centered below the figure, with Word-matching whitespace above it.
- 271 docx tests (2 new) + node page-count gate (sample-12 = 3 pages) green; root `pnpm typecheck` green.
- docx VRT 21/21, diffs byte-identical to base (incl. `demo/sample-1` and `sample-3`/Meiryo).
- Fix #2 is surgical: a full before/after sweep of every wrap-float sample (8/9/10/11/13, all pages) is byte-identical — only sample-12 (the one sample whose wrap-float anchor paragraph has non-zero spaceBefore) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)