### PR TITLE
fix(xlsx): reserve one line height for empty shape-text paragraphs

### DIFF
--- a/packages/xlsx/src/empty-paragraph-shape-text-height.test.ts
+++ b/packages/xlsx/src/empty-paragraph-shape-text-height.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { drawShapeText } from './renderer.js';
+import type { ShapeParagraph, ShapeText, ShapeTextRun } from './types.js';
+
+// ECMA-376 §21.1.2.1 (text body) / §21.1.2.2 (paragraph): an EMPTY paragraph in
+// a shape's text body — and a blank line produced by a standalone/trailing
+// `<a:br>` — still occupies ONE single-line height, exactly as tall as a
+// one-character line of the same font would be. `drawShapeText` only raised the
+// per-line height when it saw a text/math run (`lineHeight = max(lineHeight,
+// pxSize * 1.2)`), so a line with no segment reserved ZERO height: the text
+// block under-measured and vertical anchoring (`anchor` 'ctr'/'b') and total
+// height drifted whenever the body contained blank lines. This is the xlsx
+// analog of the docx fix in PR #582 (empty paragraph-mark lines).
+//
+// The shape path derives line height analytically (font size × 1.2), not from
+// font metrics, so the bug is visible without an asymmetric font stub: a fixed
+// empty line should contribute the SAME 1.2-em height as a text line of the
+// paragraph's default font size.
+
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+}
+
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; calls: FillTextCall[] } {
+  let font = '11px sans-serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText(text: string, x: number, y: number) {
+      calls.push({ text, x, y });
+    },
+    drawImage() {},
+    fillStyle: '#000' as string | CanvasGradient | CanvasPattern,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+function textRun(text: string, size = 11): ShapeTextRun {
+  return { type: 'text', text, bold: false, italic: false, size };
+}
+
+/** A paragraph with one text run, or — when `text` is `null` — an EMPTY one. */
+function para(text: string | null): ShapeParagraph {
+  return { align: 'l', runs: text === null ? [] : [textRun(text)] };
+}
+
+function shapeOf(paragraphs: ShapeParagraph[]): ShapeText {
+  // Top-anchored + wrap:none isolates the line-height contribution: each line's
+  // baseline is the cumulative sum of the heights of the lines above it, so the
+  // A→B gap reports exactly how much the middle paragraph reserved.
+  return { anchor: 't', wrap: 'none', paragraphs };
+}
+
+function baselines(paragraphs: ShapeParagraph[]): FillTextCall[] {
+  const { ctx, calls } = makeRecordingCtx();
+  drawShapeText(ctx, shapeOf(paragraphs), 300, 300, 1);
+  return calls;
+}
+
+describe('empty paragraph line height in shape text bodies (§21.1.2.1 / §21.1.2.2)', () => {
+  it('an empty paragraph reserves the SAME single-line height as a text paragraph', () => {
+    // Reference: [A, M, B] — three single-line text paragraphs. The A→B baseline
+    // gap spans one full intervening line (M).
+    const ref = baselines([para('A'), para('M'), para('B')]);
+    const refA = ref.find((c) => c.text === 'A');
+    const refB = ref.find((c) => c.text === 'B');
+    expect(refA).toBeDefined();
+    expect(refB).toBeDefined();
+    const refGap = refB!.y - refA!.y;
+
+    // Subject: [A, <empty>, B] — the middle paragraph has no runs. Its line must
+    // reserve the same single-line height, so the A→B gap is identical.
+    const subj = baselines([para('A'), para(null), para('B')]);
+    const subjA = subj.find((c) => c.text === 'A');
+    const subjB = subj.find((c) => c.text === 'B');
+    expect(subjA).toBeDefined();
+    expect(subjB).toBeDefined();
+    const subjGap = subjB!.y - subjA!.y;
+
+    // Before the fix the empty line reserved 0 px, so subjGap was short by one
+    // full line height (11 pt × 1.2) versus the reference.
+    expect(subjGap).toBeCloseTo(refGap, 5);
+  });
+});

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3250,7 +3250,7 @@ export async function prepareWorksheetMath(ws: Worksheet, math: MathRenderer): P
   }
 }
 
-function drawShapeText(
+export function drawShapeText(
   ctx: CanvasRenderingContext2D,
   txt: import('./types.js').ShapeText,
   sw: number, sh: number,
@@ -3294,6 +3294,19 @@ function drawShapeText(
     let lineAscent = 0;
     let hasMath = false;
     const flushLine = () => {
+      // An empty paragraph (no runs) or a blank line produced by a standalone /
+      // trailing <a:br> contributes no text or math segment, so lineHeight is
+      // still 0. ECMA-376 §21.1.2.1 / §21.1.2.2: such a line still reserves ONE
+      // single-line height — as tall as a one-character line of the paragraph's
+      // effective font. Without this the empty line reserved zero height, so the
+      // block under-measured and vertical anchoring ('ctr'/'b') drifted. Mirror
+      // the text-line formula (pxSize * 1.2) using the nearest preceding text
+      // size in this paragraph, falling back to the body default.
+      if (lineHeight === 0) {
+        const fallbackPx = (lastTextPt || DEFAULT_FONT_SIZE) * PT_TO_PX * cs;
+        lineHeight = fallbackPx * 1.2;
+        lineAscent = fallbackPx * 0.85;
+      }
       lines.push({ segs, align, height: lineHeight, ascent: lineAscent, hasMath });
       segs = []; lineW = 0; lineHeight = 0; lineAscent = 0; hasMath = false;
     };


### PR DESCRIPTION
## Summary

`drawShapeText` raised a line's height only when it hit a text/math run (`lineHeight = max(lineHeight, pxSize * 1.2)`). An **empty paragraph** (no runs) or a blank line from a standalone/trailing `<a:br>` reached `flushLine()` with `lineHeight === 0`, so the line reserved **zero** vertical height. The text block under-measured and vertical anchoring (`anchor` `ctr`/`b`) and total height drifted whenever a shape's text body contained blank lines.

Per ECMA-376 §21.1.2.1 / §21.1.2.2 an empty paragraph still occupies one single-line height — as tall as a one-character line of the paragraph's effective font. `flushLine` now falls a zero-height line back to `(lastTextPt || DEFAULT_FONT_SIZE) * PT_TO_PX * cs * 1.2`, the **same** formula a text line of that size uses.

This is the xlsx analog of the docx fix in #582 (empty paragraph-mark lines) and matches the plain-text wrapped-cell path, which already reserves `vMetricPx(size, cs, 1.2)` per line regardless of emptiness.

## Cross-package status (3-package integration)

- **docx** — fixed in #582
- **xlsx** — this PR
- **pptx** — already correct (`if (maxSizePx === 0) maxSizePx = paraDefaultFontSizePx`)

All three packages now reserve one line height for empty paragraphs.

## Test

New focused test `empty-paragraph-shape-text-height.test.ts` (same spirit as the docx test): an empty paragraph between two text paragraphs must contribute one line height — not zero — to the A→B baseline gap. `drawShapeText` is exported for the test, matching the existing exported-helper pattern (`layoutRichTextLines`, etc.). Verified RED (17.6px gap = one line short) → GREEN (35.2px, matching the all-text reference).

## Verification

- ✅ New test passes; **141** xlsx unit tests green
- ✅ `tsc --noEmit` clean
- ✅ xlsx VRT **byte-identical before/after** across all 64 sheet comparisons (no current sample exercises blank shape-text lines, so the change is purely additive — no reference images updated)

## Follow-up (not in this PR)

The rich-text wrapped-cell path `layoutRichTextLines` drops interior blank lines (`flush()` early-returns on `cur.length === 0`), so a `"A\n\nB"` cell loses its blank line. Excel preserves it, but the trailing-`\n` boundary semantics need verification against Excel ground truth before changing, so it is intentionally left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)