### PR TITLE
fix(xlsx): reserve one line height for blank lines in rich-text cells

### DIFF
--- a/packages/xlsx/src/empty-line-cell-rich-text-height.test.ts
+++ b/packages/xlsx/src/empty-line-cell-rich-text-height.test.ts
@@ -3,7 +3,7 @@ import { layoutRichTextLines } from './renderer.js';
 import type { CellFont, Run } from './types.js';
 
 // ECMA-376 §18.8.1 (CT_CellAlignment) @wrapText: text in a cell is line-wrapped
-// within the cell. Cell rich text is stored as <r>/<t> runs (§18.4.7 / §18.4.12)
+// within the cell. Cell rich text is stored as <r>/<t> runs (§18.4.4 / §18.4.12)
 // with xml:space="preserve", so a hard line break authored with Alt+Enter is a
 // literal LF (U+000A) inside the run text. Each rendered line — INCLUDING a blank
 // line produced by consecutive breaks, or a leading/trailing break — reserves one
@@ -51,7 +51,7 @@ function layout(text: string, font?: Run['font']) {
   return layoutRichTextLines(makeCtx(), [{ text, font }] as Run[], BASE, 1, 100000);
 }
 
-describe('empty line height in cell rich text (§18.8.1 wrapText / §18.4.7 r)', () => {
+describe('empty line height in cell rich text (§18.8.1 wrapText / §18.4.4 r)', () => {
   it('a blank line between two text lines reserves one single-line height', () => {
     // Reference: "A\nB" — two single-line regions, no blank between.
     const ctrl = layout('A\nB');

--- a/packages/xlsx/src/empty-line-cell-rich-text-height.test.ts
+++ b/packages/xlsx/src/empty-line-cell-rich-text-height.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { layoutRichTextLines } from './renderer.js';
+import type { CellFont, Run } from './types.js';
+
+// ECMA-376 §18.8.1 (CT_CellAlignment) @wrapText: text in a cell is line-wrapped
+// within the cell. Cell rich text is stored as <r>/<t> runs (§18.4.7 / §18.4.12)
+// with xml:space="preserve", so a hard line break authored with Alt+Enter is a
+// literal LF (U+000A) inside the run text. Each rendered line — INCLUDING a blank
+// line produced by consecutive breaks, or a leading/trailing break — reserves one
+// single-line height, exactly as Excel renders it and as the shape-text path now
+// does (PR #583, the xlsx sibling of docx PR #582).
+//
+// `layoutRichTextLines` flushes a line region at every LF, but its `flush` helper
+// early-returned when the region was empty (`if (cur.length === 0) return;`), so a
+// blank line was silently dropped and every line below it pulled up by one line
+// height. This is the cell rich-text analog of the same blank-line-collapse bug.
+//
+// The cell path derives line height analytically (font size × 1.2 via vMetricPx),
+// not from font metrics, so the bug is visible without an asymmetric font stub: a
+// blank line must contribute the SAME 1.2-em height as a text line of the same
+// effective font size — here exposed as `RichLine.maxFontSize`, the per-line
+// height source the renderer feeds to `vMetricPx`.
+
+const BASE: CellFont = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  size: 11,
+  color: null,
+  name: null,
+};
+
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '11px sans-serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  return {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+/** Lay out a single-run cell value. A very wide maxWidth disables soft-wrapping
+ *  so only explicit LF breaks split lines — isolating the blank-line behaviour. */
+function layout(text: string, font?: Run['font']) {
+  return layoutRichTextLines(makeCtx(), [{ text, font }] as Run[], BASE, 1, 100000);
+}
+
+describe('empty line height in cell rich text (§18.8.1 wrapText / §18.4.7 r)', () => {
+  it('a blank line between two text lines reserves one single-line height', () => {
+    // Reference: "A\nB" — two single-line regions, no blank between.
+    const ctrl = layout('A\nB');
+    expect(ctrl.length).toBe(2);
+    expect(ctrl[0].segments.length).toBe(1);
+    expect(ctrl[1].segments.length).toBe(1);
+
+    // Subject: "A\n\nB" — the consecutive LFs create a blank middle line. It must
+    // be emitted (3 lines, not 2) so the "B" line sits one line height lower.
+    const subj = layout('A\n\nB');
+    expect(subj.length).toBe(3);
+    // The middle line is blank (no drawn segments) ...
+    expect(subj[1].segments.length).toBe(0);
+    // ... yet reserves the SAME single-line height as a text line, not 0.
+    expect(subj[1].maxFontSize).toBe(11);
+    expect(subj[1].maxFontSize).toBe(subj[0].maxFontSize);
+  });
+
+  it('the blank line is sized from the effective run font size, not a constant or 0', () => {
+    const r = layout('A\n\nB', {
+      bold: false,
+      italic: false,
+      underline: false,
+      strike: false,
+      size: 22,
+    });
+    expect(r.length).toBe(3);
+    expect(r[1].segments.length).toBe(0);
+    // 22pt run → the blank line reserves a 22pt line height, not the 11pt default.
+    expect(r[1].maxFontSize).toBe(22);
+  });
+
+  it('a leading blank line (value begins with a break) is preserved', () => {
+    const r = layout('\nA');
+    expect(r.length).toBe(2);
+    expect(r[0].segments.length).toBe(0);
+    expect(r[0].maxFontSize).toBe(11);
+    expect(r[1].segments.length).toBe(1);
+  });
+
+  it('a trailing blank line (value ends with a break) is preserved', () => {
+    const r = layout('A\n');
+    expect(r.length).toBe(2);
+    expect(r[0].segments.length).toBe(1);
+    expect(r[1].segments.length).toBe(0);
+    expect(r[1].maxFontSize).toBe(11);
+  });
+
+  it('an empty rich-text value produces no fabricated line', () => {
+    // A value with no characters and no breaks contributes nothing — the renderer
+    // must not invent a blank line out of an empty cell.
+    expect(layout('').length).toBe(0);
+  });
+});

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -780,9 +780,14 @@ interface RichLine {
  * CJK characters for granular wrapping). Per-run font is preserved so measurement
  * and drawing use the correct font.
  *
- * Follows ECMA-376 §18.3.1.53 (w:r) semantics: runs are inline and share the
- * paragraph width. wrapText breaks at word boundaries (ASCII spaces) and at any
- * CJK code point boundary.
+ * Runs are inline and share the cell width (ECMA-376 §18.4.4 r / §18.4.8 si /
+ * §18.4.9 sst); wrapText (§18.8.1) breaks at word boundaries (ASCII spaces) and
+ * at any CJK code point boundary, and a hard break (LF) starts a new line.
+ *
+ * An empty value returns `[]` (no fabricated line). This deliberately differs
+ * from the plain-text `wrapTextLines`, whose `split('\n')` yields `['']`: an
+ * empty cell has no glyphs, so reserving a line for it would only mis-anchor the
+ * (non-existent) text.
  */
 export function layoutRichTextLines(
   ctx: CanvasRenderingContext2D,
@@ -795,30 +800,26 @@ export function layoutRichTextLines(
   let cur: RichSeg[] = [];
   let curW = 0;
   let curMaxSize = 0;
-  // Effective font size (pt) of the run currently being laid out — the height
-  // source for a blank line, which has no segment of its own to measure. Mirrors
-  // the shape-text path's `lastTextPt` seed (drawShapeText, PR #583).
-  let lastSizePt = baseFont.size;
+  // Size (pt) of the nearest preceding text run — the height source for a blank
+  // line, which has no segment of its own. Mirrors drawShapeText's `lastTextPt`
+  // seed (PR #583); falls back to the cell's base font.
+  let lastTextPt = baseFont.size;
 
-  // Flush the current line region as-is. Used at soft-wrap (kinsoku) breaks, where
-  // the region being closed always has content — an empty region here means the
-  // whole line was carried down to the next line, so nothing is emitted.
+  // `flush` drops an empty region — used at soft-wrap (kinsoku) breaks, where a
+  // line carried wholly to the next line must not leave a blank behind.
   const flush = () => {
     if (cur.length === 0) return;
     lines.push({ segments: cur, maxFontSize: curMaxSize });
     cur = []; curW = 0; curMaxSize = 0;
   };
 
-  // Flush a region delimited by a hard line break (LF) or end-of-value. Unlike
-  // `flush`, an EMPTY region is emitted as a blank line: ECMA-376 §18.8.1
-  // (CT_CellAlignment @wrapText) line-wraps a multi-line cell, and each line —
-  // including a blank one from consecutive / leading / trailing breaks — reserves
-  // one single-line height, as tall as a one-character line of the same font.
-  // Without this the blank line collapsed to zero height and pulled the lines
-  // below it up (the cell analog of the shape-text fix in PR #583 / docx #582).
-  const flushRegion = (emptySizePt: number) => {
+  // `flushRegion` emits an empty region as a blank line — used at a hard break
+  // (LF) or end-of-value. ECMA-376 §18.8.1 (wrapText): each line of a multi-line
+  // cell, including a blank one from consecutive / leading / trailing breaks,
+  // reserves one single-line height (the cell analog of PR #583 / docx #582).
+  const flushRegion = () => {
     if (cur.length === 0) {
-      lines.push({ segments: [], maxFontSize: emptySizePt || DEFAULT_FONT_SIZE });
+      lines.push({ segments: [], maxFontSize: lastTextPt || DEFAULT_FONT_SIZE });
       return;
     }
     flush();
@@ -826,6 +827,7 @@ export function layoutRichTextLines(
 
   const push = (text: string, font: CellFont) => {
     if (!text) return;
+    lastTextPt = font.size; // nearest preceding text size, for the next blank line
     ctx.font = buildFont(font, cs);
     const w = ctx.measureText(text).width;
     if (cur.length > 0 && curW + w > maxWidth) {
@@ -874,7 +876,6 @@ export function layoutRichTextLines(
 
   for (const run of runs) {
     const font = applyRunFont(baseFont, run);
-    lastSizePt = font.size;
     // Tokenize: runs of non-space latin, spaces, or individual CJK chars
     const tokens: string[] = [];
     let i = 0;
@@ -905,14 +906,14 @@ export function layoutRichTextLines(
       }
     }
     for (const tok of tokens) {
-      if (tok === '\n') flushRegion(font.size);
+      if (tok === '\n') flushRegion();
       else push(tok, font);
     }
   }
   // Trailing region. If the value ended with a break, `cur` is empty but a line
   // was already produced, so a trailing blank line is reserved; a value with no
   // content and no breaks (no segments, no prior line) produces nothing.
-  if (cur.length > 0 || lines.length > 0) flushRegion(lastSizePt);
+  if (cur.length > 0 || lines.length > 0) flushRegion();
   return lines;
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -795,11 +795,33 @@ export function layoutRichTextLines(
   let cur: RichSeg[] = [];
   let curW = 0;
   let curMaxSize = 0;
+  // Effective font size (pt) of the run currently being laid out — the height
+  // source for a blank line, which has no segment of its own to measure. Mirrors
+  // the shape-text path's `lastTextPt` seed (drawShapeText, PR #583).
+  let lastSizePt = baseFont.size;
 
+  // Flush the current line region as-is. Used at soft-wrap (kinsoku) breaks, where
+  // the region being closed always has content — an empty region here means the
+  // whole line was carried down to the next line, so nothing is emitted.
   const flush = () => {
     if (cur.length === 0) return;
     lines.push({ segments: cur, maxFontSize: curMaxSize });
     cur = []; curW = 0; curMaxSize = 0;
+  };
+
+  // Flush a region delimited by a hard line break (LF) or end-of-value. Unlike
+  // `flush`, an EMPTY region is emitted as a blank line: ECMA-376 §18.8.1
+  // (CT_CellAlignment @wrapText) line-wraps a multi-line cell, and each line —
+  // including a blank one from consecutive / leading / trailing breaks — reserves
+  // one single-line height, as tall as a one-character line of the same font.
+  // Without this the blank line collapsed to zero height and pulled the lines
+  // below it up (the cell analog of the shape-text fix in PR #583 / docx #582).
+  const flushRegion = (emptySizePt: number) => {
+    if (cur.length === 0) {
+      lines.push({ segments: [], maxFontSize: emptySizePt || DEFAULT_FONT_SIZE });
+      return;
+    }
+    flush();
   };
 
   const push = (text: string, font: CellFont) => {
@@ -852,6 +874,7 @@ export function layoutRichTextLines(
 
   for (const run of runs) {
     const font = applyRunFont(baseFont, run);
+    lastSizePt = font.size;
     // Tokenize: runs of non-space latin, spaces, or individual CJK chars
     const tokens: string[] = [];
     let i = 0;
@@ -882,11 +905,14 @@ export function layoutRichTextLines(
       }
     }
     for (const tok of tokens) {
-      if (tok === '\n') flush();
+      if (tok === '\n') flushRegion(font.size);
       else push(tok, font);
     }
   }
-  flush();
+  // Trailing region. If the value ended with a break, `cur` is empty but a line
+  // was already produced, so a trailing blank line is reserved; a value with no
+  // content and no breaks (no segments, no prior line) produces nothing.
+  if (cur.length > 0 || lines.length > 0) flushRegion(lastSizePt);
   return lines;
 }
 


### PR DESCRIPTION
## Problem

In `packages/xlsx/src/renderer.ts`, `layoutRichTextLines` (the wrapped **cell** rich-text layout) flushes a line region at every hard break (LF), but its `flush` helper early-returned on an empty region:

```ts
const flush = () => {
  if (cur.length === 0) return;   // empty region dropped — never pushed
  ...
};
```

So a `wrapText` cell whose value contains consecutive newlines (`A\n\nB`, i.e. Alt+Enter twice), or a leading/trailing break, **dropped the blank line** and pulled every line below it up by one line height — vertical misalignment of wrapped cell text.

This is the cell rich-text analog of the shape-text empty-paragraph fix in #583 (and docx #582). The repo's [cross-package integrative principle](../blob/main/CLAUDE.md) flags one such bug as a signal to check the sibling surfaces — this is the third instance of the same shared concept.

## Ground truth (spec-faithful, no heuristic)

- **ECMA-376 §18.8.1** (`CT_CellAlignment` `@wrapText`): the text in a cell is line-wrapped within the cell.
- Cell rich text is stored as `<r>`/`<t>` runs (§18.4.7 / §18.4.12) with `xml:space="preserve"`, so an Alt+Enter break is a literal LF inside the run text.
- Each rendered line — **including a blank one** — reserves one single-line height, as tall as a one-character line of the same font. This is universal text-layout behaviour and exactly what the **plain single-run cell path already does** (`wrapTextLines` splits on `'\n'`, and an empty paragraph yields a `['']` line). The bug was unique to the rich-run path; this change aligns it.

## Fix

`flush` keeps its old behaviour for the soft-wrap (kinsoku) path (a line carried wholly to the next line must not fabricate a blank). A new `flushRegion(emptySizePt)` — used for hard breaks and end-of-value — emits a blank `RichLine` for an empty region, sized from the current run's effective font size (falling back to the cell default, then `DEFAULT_FONT_SIZE`), mirroring the shape-text seed in #583. `RichLine.maxFontSize` feeds `vMetricPx(size, cs, 1.2)` downstream, so a blank line now reserves exactly one line height.

Leading and trailing blank lines are preserved (matching Excel and the shape path); a value with no content and no breaks still produces no line.

## Tests / verification

- New CI-runnable mock-context test `packages/xlsx/src/empty-line-cell-rich-text-height.test.ts` (mirrors #583's `empty-paragraph-shape-text-height.test.ts`): asserts `A\n\nB` emits a middle blank line of the same height as a text line, that the blank line is sized from the effective run size (22pt → 22pt, not 0/default), and that leading/trailing blanks are kept while a truly empty value produces no line. **Red** before the fix (blank lines dropped), **green** after.
- Full xlsx unit suite green (147 tests).
- Root/xlsx typecheck clean.
- xlsx VRT: **67 passed / 0 failed** across all 30 private samples + demo. No reference images updated. (No sample contains a rich-run cell with a blank line, so the VRT can't exercise this path — same coverage gap as #583; the unit test is the behavioural guard.)