### PR TITLE
fix(xlsx): render non-wrap rich-text cells correctly in both draw paths

### DIFF
--- a/packages/xlsx/src/nonwrap-rich-text-hard-break.test.ts
+++ b/packages/xlsx/src/nonwrap-rich-text-hard-break.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { drawNonWrapRichText } from './renderer.js';
+import type { CellFont, Run } from './types.js';
+
+// ECMA-376 §18.8.1 (CT_CellAlignment) @wrapText: when wrapText is OFF a cell is
+// NOT soft-wrapped, but Excel still renders a hard line break authored with
+// Alt+Enter (a literal LF, U+000A, inside the run text — §18.4.4 r / §18.4.12 t,
+// xml:space="preserve") as a SEPARATE line. The plain-text non-wrap path already
+// splits on LF ("to match Excel's behavior"); the rich-text (mixed-font runs)
+// non-wrap path used to lay every run on one horizontal line (`runX += width`),
+// silently dropping every hard break. This is the rich-text sibling of that
+// plain-text behavior and of the wrap-path blank-line fix (PR #585).
+//
+// The cell path derives line height analytically (font size × 1.2 via vMetricPx),
+// not from font metrics, so the line spacing is visible without an asymmetric
+// font stub: each line — including a blank one from consecutive breaks — reserves
+// the SAME 1.2-em single-line height, exactly as the wrap path and Excel do.
+
+const BASE: CellFont = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  size: 11,
+  color: null,
+  name: null,
+};
+
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+}
+
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; calls: FillTextCall[] } {
+  let font = '11px sans-serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText(text: string, x: number, y: number) {
+      calls.push({ text, x, y });
+    },
+    // underline / strike decoration stubs (not exercised by these LTR plain runs)
+    save() {},
+    restore() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    fillStyle: '#000' as string,
+    strokeStyle: '#000' as string,
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+// A top-anchored, wrap:none cell. Top anchoring isolates the line-height
+// contribution: each line's top y is the cumulative sum of the heights of the
+// lines above it, so the gap between two drawn lines reports exactly how much
+// the lines between them reserved.
+const GEOM = {
+  alignH: 'left' as const,
+  alignV: 'top' as const,
+  cx: 0,
+  cy: 0,
+  cellW: 10000, // wide enough that nothing soft-wraps (only LF splits)
+  cellH: 10000,
+  leftPad: 3,
+  paddingX: 3,
+  paddingY: 2,
+};
+
+function draw(runs: Run[]): FillTextCall[] {
+  const { ctx, calls } = makeRecordingCtx();
+  drawNonWrapRichText(ctx, runs, BASE, GEOM, 1, 1);
+  return calls;
+}
+
+function run(text: string, font?: Run['font']): Run {
+  return font ? { text, font } : { text };
+}
+
+describe('non-wrap rich text honors hard breaks (§18.8.1 wrapText off / §18.4.4 r)', () => {
+  it('a single run with an embedded LF draws two lines', () => {
+    const calls = draw([run('A\nB')]);
+    expect(calls.map((c) => c.text)).toEqual(['A', 'B']);
+    expect(calls[1].y).toBeGreaterThan(calls[0].y);
+  });
+
+  it('a hard break across two (mixed-font) runs draws two lines', () => {
+    // The break sits at the boundary between two differently-fonted runs:
+    // "Hello" on line 1, "World" on line 2. Previously both ran together on a
+    // single horizontal line.
+    const calls = draw([
+      run('Hello\n', { bold: true, italic: false, underline: false, strike: false, size: 11 }),
+      run('World', { bold: false, italic: false, underline: false, strike: false, size: 11 }),
+    ]);
+    expect(calls.map((c) => c.text)).toEqual(['Hello', 'World']);
+    expect(calls[1].y).toBeGreaterThan(calls[0].y);
+  });
+
+  it('the two lines are spaced exactly one single-line height apart', () => {
+    const calls = draw([run('A\nB')]);
+    // vMetricPx(11, cs=1, 1.2) = round(11 * (96/72) * 1.2) = round(17.6) = 18
+    const PT_TO_PX = 96 / 72;
+    const lineH = Math.round(11 * PT_TO_PX * 1.2);
+    expect(calls[1].y - calls[0].y).toBe(lineH);
+  });
+
+  it('a blank line from consecutive breaks reserves one line height', () => {
+    // "A\n\nB": A on line 1, a BLANK line 2, B on line 3. The blank middle line
+    // must push B down by one extra single-line height (gap = 2 line heights),
+    // not collapse it back next to A.
+    const ctrl = draw([run('A\nB')]);
+    const subj = draw([run('A\n\nB')]);
+    const gapCtrl = ctrl[1].y - ctrl[0].y;
+    const gapSubj = subj[1].y - subj[0].y;
+    expect(subj.map((c) => c.text)).toEqual(['A', 'B']);
+    expect(gapSubj).toBe(gapCtrl * 2);
+  });
+
+  it('a cell with no hard break still draws on a single line (no regression)', () => {
+    const calls = draw([
+      run('foo', { bold: false, italic: false, underline: false, strike: false, size: 11 }),
+      run('bar', { bold: true, italic: false, underline: false, strike: false, size: 11 }),
+    ]);
+    expect(calls.map((c) => c.text)).toEqual(['foo', 'bar']);
+    // Same baseline → same y; the two runs sit side by side on one line.
+    expect(calls[0].y).toBe(calls[1].y);
+    expect(calls[1].x).toBeGreaterThan(calls[0].x);
+  });
+});

--- a/packages/xlsx/src/nonwrap-rich-text-hard-break.test.ts
+++ b/packages/xlsx/src/nonwrap-rich-text-hard-break.test.ts
@@ -2,14 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { drawNonWrapRichText } from './renderer.js';
 import type { CellFont, Run } from './types.js';
 
-// ECMA-376 §18.8.1 (CT_CellAlignment) @wrapText: when wrapText is OFF a cell is
-// NOT soft-wrapped, but Excel still renders a hard line break authored with
-// Alt+Enter (a literal LF, U+000A, inside the run text — §18.4.4 r / §18.4.12 t,
-// xml:space="preserve") as a SEPARATE line. The plain-text non-wrap path already
-// splits on LF ("to match Excel's behavior"); the rich-text (mixed-font runs)
-// non-wrap path used to lay every run on one horizontal line (`runX += width`),
-// silently dropping every hard break. This is the rich-text sibling of that
-// plain-text behavior and of the wrap-path blank-line fix (PR #585).
+// ECMA-376 §18.8.1 (CT_CellAlignment) @wrapText governs only soft-wrapping. It
+// says nothing about hard breaks — but Excel still renders a break authored with
+// Alt+Enter (a literal LF, U+000A, preserved in the run text via §18.4.12 t
+// xml:space="preserve"; the run is §18.4.4 r) as a SEPARATE line even with
+// wrapText off. That is undocumented runtime behavior, matched for parity: the
+// plain-text non-wrap path already splits on LF ("to match Excel's behavior"),
+// while the rich-text (mixed-font runs) non-wrap path used to lay every run on
+// one horizontal line (`runX += width`), silently dropping every hard break.
+// This is the rich-text sibling of that plain-text behavior and of the wrap-path
+// blank-line fix (PR #585).
 //
 // The cell path derives line height analytically (font size × 1.2 via vMetricPx),
 // not from font metrics, so the line spacing is visible without an asymmetric

--- a/packages/xlsx/src/nonwrap-rich-text-singleline.test.ts
+++ b/packages/xlsx/src/nonwrap-rich-text-singleline.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { drawNonWrapRichText } from './renderer.js';
+import type { CellFont, Run } from './types.js';
+
+// Companion to nonwrap-rich-text-hard-break.test.ts. `drawNonWrapRichText` is the
+// single entry point for NON-wrapped rich-text cells; both the in-viewport draw
+// path and the off-screen-anchor merge pre-pass route through it so they render
+// identically (the off-screen pre-pass previously drew a break-free rich cell as
+// joined base-font text via one `ctx.fillText`, losing per-run fonts/colors — a
+// fidelity gap vs the same cell on-screen). For a BREAK-FREE value the helper
+// must draw each run with its own font/color (ECMA-376 §18.4.4 r / §18.4.7 rPr)
+// and anchor the single line with the cell's alignV-dependent baseline
+// ('top' / 'middle' / 'bottom'), matching the legacy in-viewport single-line
+// path it now shares — NOT the 'top'-only multi-line model used for hard breaks.
+
+const BASE: CellFont = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  size: 11,
+  color: null,
+  name: null,
+};
+
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+  font: string;
+  baseline: CanvasTextBaseline;
+  fillStyle: string;
+}
+
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; calls: FillTextCall[] } {
+  let font = '11px sans-serif';
+  let baseline: CanvasTextBaseline = 'alphabetic';
+  let fillStyle = '#000';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get textBaseline() { return baseline; },
+    set textBaseline(v: CanvasTextBaseline) { baseline = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText(text: string, x: number, y: number) {
+      calls.push({ text, x, y, font, baseline, fillStyle });
+    },
+    save() {},
+    restore() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    strokeStyle: '#000' as string,
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+const CELL_H = 10000;
+const PADDING_Y = 2;
+
+function geom(alignV: 'top' | 'center' | 'bottom') {
+  return {
+    alignH: 'left' as const,
+    alignV,
+    cx: 0,
+    cy: 0,
+    cellW: 10000,
+    cellH: CELL_H,
+    leftPad: 3,
+    paddingX: 3,
+    paddingY: PADDING_Y,
+  };
+}
+
+function draw(runs: Run[], alignV: 'top' | 'center' | 'bottom' = 'bottom'): FillTextCall[] {
+  const { ctx, calls } = makeRecordingCtx();
+  drawNonWrapRichText(ctx, runs, BASE, geom(alignV), 1, 1);
+  return calls;
+}
+
+function rf(color: string | null, size = 11) {
+  return { bold: false, italic: false, underline: false, strike: false, size, color };
+}
+
+describe('non-wrap break-free rich text mirrors the in-viewport per-run single-line path', () => {
+  it('draws each run with its own color (off-screen pre-pass no longer collapses to base font)', () => {
+    const calls = draw([
+      { text: 'AA', font: rf('#FF0000') },
+      { text: 'BB', font: rf('#00FF00') },
+    ]);
+    expect(calls.map((c) => c.text)).toEqual(['AA', 'BB']);
+    // Per-run color: the two runs paint in their own colors, not one base color.
+    expect(calls[0].fillStyle).not.toBe(calls[1].fillStyle);
+    expect(calls[0].fillStyle).toContain('255'); // red channel of #FF0000
+    expect(calls[1].fillStyle).toContain('255'); // green channel of #00FF00
+  });
+
+  it('draws each run at its own font size', () => {
+    const calls = draw([
+      { text: 'small', font: rf(null, 11) },
+      { text: 'BIG', font: rf(null, 22) },
+    ]);
+    expect(calls.map((c) => c.text)).toEqual(['small', 'BIG']);
+    // Each fillText is preceded by ctx.font set to that run's size.
+    expect(/\b15px\b/.test(calls[0].font)).toBe(true); // 11pt → round(11 * 96/72) = 15px
+    expect(/\b29px\b/.test(calls[1].font)).toBe(true); // 22pt → round(22 * 96/72) = 29px
+  });
+
+  it('lays the two runs side by side on one line (single line, not stacked)', () => {
+    const calls = draw([
+      { text: 'foo', font: rf(null) },
+      { text: 'bar', font: rf(null) },
+    ]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].y).toBe(calls[1].y); // same baseline
+    expect(calls[1].x).toBeGreaterThan(calls[0].x);
+  });
+
+  it('anchors the single line with the alignV-dependent baseline, not the top-only model', () => {
+    // alignV='bottom' (the cell default): the legacy single-line path uses a
+    // 'bottom' baseline at cy + cellH - paddingY — the off-screen pre-pass must
+    // match it so an off-screen-anchored merge sits where the on-screen cell does.
+    const bottom = draw([{ text: 'X', font: rf(null) }], 'bottom');
+    expect(bottom).toHaveLength(1);
+    expect(bottom[0].baseline).toBe('bottom');
+    expect(bottom[0].y).toBe(CELL_H - PADDING_Y); // 9998, not a reserved-line top
+
+    const top = draw([{ text: 'X', font: rf(null) }], 'top');
+    expect(top[0].baseline).toBe('top');
+    expect(top[0].y).toBe(PADDING_Y);
+
+    const center = draw([{ text: 'X', font: rf(null) }], 'center');
+    expect(center[0].baseline).toBe('middle');
+    expect(center[0].y).toBe(CELL_H / 2);
+  });
+});

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -936,21 +936,127 @@ export interface NonWrapRichGeom {
 }
 
 /**
+ * Draw a single line of rich text (no hard break) with per-run fonts. The line
+ * is anchored with the cell's alignV-dependent baseline — `'top'` at the top
+ * padding, `'middle'` at the cell centre, `'bottom'` at the bottom padding —
+ * which is exactly how Excel paints a one-line rich cell. Each run draws with
+ * its own font/color, ~65%-size super/subscript baseline shift (§18.4.6
+ * ST_VerticalAlignRun), underline / strike decoration, and the bidi visual-order
+ * pass (UAX#9 rule L2). Shared by the in-viewport draw path and the off-screen-
+ * anchor merge pre-pass so a merged rich cell renders identically whether or not
+ * its anchor is scrolled out of view.
+ */
+function drawSingleLineRichText(
+  ctx: CanvasRenderingContext2D,
+  runs: Run[],
+  baseFont: CellFont,
+  geom: NonWrapRichGeom,
+  cs: number,
+  dpr: number,
+  opts: { fontColor?: string | null; readingOrder?: number } = {},
+): void {
+  const { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY } = geom;
+  // Per-run drawing: compute font for each run, measure widths, draw LTR.
+  // Layout uses the run's *base* font size (line height & x-position budget);
+  // super/subscript runs are rendered at ~65% size with a baseline shift,
+  // matching how Excel paints them. ECMA-376 §18.4.6 (ST_VerticalAlignRun)
+  // leaves the exact ratio implementation-defined.
+  const baseRunFonts = runs.map(r => applyRunFont(baseFont, r));
+  const runVAlign = runs.map(r => r.font?.vertAlign);
+  const drawRunFonts = baseRunFonts.map((f, i) => {
+    if (runVAlign[i] === 'superscript' || runVAlign[i] === 'subscript') {
+      return { ...f, size: f.size * 0.65 };
+    }
+    return f;
+  });
+  const runWidths: number[] = runs.map((r, i) => {
+    ctx.font = buildFont(drawRunFonts[i], cs);
+    return ctx.measureText(r.text).width;
+  });
+  const totalWidth = runWidths.reduce((a, b) => a + b, 0);
+  let startX: number;
+  if (alignH === 'right') startX = cx + cellW - paddingX - totalWidth;
+  else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
+  else startX = cx + leftPad;
+  // Use left alignment since we position each run ourselves
+  ctx.textAlign = 'left';
+  let textY: number;
+  if (alignV === 'top') { ctx.textBaseline = 'top'; textY = cy + paddingY; }
+  else if (alignV === 'center') { ctx.textBaseline = 'middle'; textY = cy + cellH / 2; }
+  else { ctx.textBaseline = 'bottom'; textY = cy + cellH - paddingY; }
+  // Bidi: draw the runs in visual order (UAX#9 rule L2) under the cell's base
+  // direction (@readingOrder, or first-strong for Context), each with
+  // ctx.direction set so Canvas shapes/orders it internally. The x-budget
+  // (totalWidth/startX) is order-independent. Gated so pure-LTR cells keep the
+  // exact pre-bidi path (no per-repaint UAX#9 cost).
+  const richNeedsBidi = opts.readingOrder === 2 || segmentsHaveRtl(runs);
+  const richVis = richNeedsBidi
+    ? computeLineVisualOrder(runs, cellBaseRtl(opts.readingOrder, runs.map(r => r.text).join('')))
+    : null;
+  const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
+  let runX = startX;
+  for (let vi = 0; vi < runs.length; vi++) {
+    const i = richVis ? richVis.order[vi] : vi;
+    if (richVis) { try { dctx.direction = richVis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
+    const rf = drawRunFonts[i];
+    const baseRf = baseRunFonts[i];
+    ctx.font = buildFont(rf, cs);
+    const runColor = opts.fontColor ?? rf.color;
+    ctx.fillStyle = runColor ? hexToRgba(runColor) : '#000000';
+    // Baseline shift for super/subscript. With textBaseline 'bottom' (the
+    // typical case) shift up for super and slightly down for sub so each run
+    // sits at the right vertical band relative to the line.
+    const baseSizePx = vMetricPx(baseRf.size, cs);
+    let yShift = 0;
+    if (runVAlign[i] === 'superscript') yShift = -Math.round(baseSizePx * 0.35);
+    else if (runVAlign[i] === 'subscript') yShift = Math.round(baseSizePx * 0.10);
+    ctx.fillText(runs[i].text, runX, textY + yShift);
+    const rSizePx = vMetricPx(rf.size, cs);
+    if (rf.underline) {
+      const uyBase = alignV === 'top'
+        ? cy + paddingY + rSizePx + 1
+        : alignV === 'center'
+          ? cy + cellH / 2 + Math.round(rSizePx * 0.55)
+          : cy + cellH - paddingY + 1;
+      const uy = uyBase + yShift;
+      const stroke = runColor ? hexToRgba(runColor) : '#000000';
+      drawTextDecoLine(ctx, runX, runX + runWidths[i], uy, stroke, rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting', dpr);
+    }
+    if (rf.strike) {
+      const syBase = alignV === 'top'
+        ? cy + paddingY + Math.round(rSizePx * 0.5)
+        : alignV === 'center'
+          ? cy + cellH / 2
+          : cy + cellH - paddingY - Math.round(rSizePx * 0.35);
+      const sy = syBase + yShift + crispOffset(syBase + yShift, 0.5, dpr);
+      ctx.save();
+      ctx.strokeStyle = runColor ? hexToRgba(runColor) : '#000000';
+      ctx.lineWidth = 0.5;
+      ctx.beginPath(); ctx.moveTo(runX, sy); ctx.lineTo(runX + runWidths[i], sy); ctx.stroke();
+      ctx.restore();
+    }
+    runX += runWidths[i];
+  }
+  // Defensive reset (the per-cell ctx.restore() also restores direction).
+  if (richVis) { try { dctx.direction = 'ltr'; } catch { /* ignore */ } }
+}
+
+/**
  * Draw rich text (mixed-font runs) in a NON-wrapped cell, honoring hard line
  * breaks (LF / Alt+Enter). ECMA-376 §18.8.1 (CT_CellAlignment @wrapText): with
  * wrapText off the cell is not soft-wrapped, but Excel still renders each LF
  * (§18.4.4 r / §18.4.12 t, xml:space="preserve") as a separate line — exactly
- * as the plain-text non-wrap path and the wrap rich-text path already do. Runs
- * are split at every LF into lines; a blank line from consecutive / leading /
- * trailing breaks reserves one single-line height (the cell analog of PR #585 /
- * docx #582), sized from the nearest preceding text run.
+ * as the plain-text non-wrap path and the wrap rich-text path already do.
  *
- * Each line is drawn at a `'top'` baseline (matching the wrap rich path), with
- * per-run super/subscript baseline shifts (§18.4.6 ST_VerticalAlignRun, ~65%
- * size), underline / strike decoration, and the bidi visual-order pass (UAX#9
- * rule L2) applied per line. The whole multi-line block is anchored vertically
- * by `alignV` over its summed height. A single line with no break renders the
- * same as one drawn line of the legacy single-line path.
+ * A break-free value is one line: it is delegated to {@link drawSingleLineRichText},
+ * which anchors with the cell's alignV-dependent baseline (the exact in-viewport
+ * rendering). Only a hard break triggers the multi-line layout here: runs are
+ * split at every LF; a blank line from consecutive / leading / trailing breaks
+ * reserves one single-line height (the cell analog of PR #585 / docx #582), sized
+ * from the nearest preceding text run; each line is drawn at a `'top'` baseline
+ * (matching the wrap rich path) with the same per-run super/subscript, underline /
+ * strike, and per-line bidi handling, and the block is anchored by `alignV` over
+ * its summed height.
  */
 export function drawNonWrapRichText(
   ctx: CanvasRenderingContext2D,
@@ -961,6 +1067,12 @@ export function drawNonWrapRichText(
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
 ): void {
+  // Break-free value → single line with the alignV-dependent baseline (mirrors
+  // the in-viewport path). Only a hard break needs the multi-line layout below.
+  if (!runs.some((r) => r.text.includes('\n'))) {
+    drawSingleLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts);
+    return;
+  }
   const { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY } = geom;
 
   // Split runs into lines at LF. A run "A\nB" yields "A" on the current line and
@@ -1644,9 +1756,10 @@ function renderQuadrant(
       for (let li = 0; li < lines.length; li++) {
         ctx.fillText(lines[li], textX, startY + li * lineH);
       }
-    } else if (hasRichText && runs.some((r) => r.text.includes('\n'))) {
-      // Non-wrap rich text with hard breaks — same helper as the in-viewport
-      // path so an off-screen-anchored merge renders identical multi-line text.
+    } else if (hasRichText) {
+      // Non-wrap rich text — same helper as the in-viewport path so an
+      // off-screen-anchored merge renders identical per-run text (single line, or
+      // multiple lines on a hard break) instead of joined base-font text.
       drawNonWrapRichText(
         ctx, runs, fontForDraw,
         { alignH, alignV, cx: aCx, cy: aCy, cellW: cW, cellH: cH, leftPad, paddingX, paddingY },
@@ -2293,102 +2406,17 @@ function renderQuadrant(
         for (let li = 0; li < lines.length; li++) {
           ctx.fillText(lines[li], textX, startY + li * lineH);
         }
-      } else if (hasRichText && runs.some((r) => r.text.includes('\n'))) {
-        // Rich text with hard line breaks (Alt+Enter) but wrapText off: split
-        // runs at each LF and lay out multiple lines. ECMA-376 §18.8.1 — Excel
-        // honors Alt+Enter breaks even when wrapText is off, exactly as the
-        // plain-text `\n` split below and the wrap blank-line fix (#585) do. The
-        // shared helper keeps this in-viewport path and the off-screen-anchor
-        // pre-pass identical.
+      } else if (hasRichText) {
+        // Non-wrap rich text: per-run fonts, honoring hard breaks (Alt+Enter LF;
+        // ECMA-376 §18.8.1 — Excel renders breaks even with wrapText off). The
+        // shared helper draws a break-free value as a single alignV-anchored line
+        // and a value with breaks as multiple lines, keeping this in-viewport
+        // path and the off-screen-anchor pre-pass identical.
         drawNonWrapRichText(
           ctx, runs, fontForDraw,
           { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY },
           cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
         );
-      } else if (hasRichText) {
-        // Per-run drawing: compute font for each run, measure widths, draw LTR.
-        // Layout uses the run's *base* font size (line height & x-position
-        // budget); super/subscript runs are rendered at ~65% size with a
-        // baseline shift, matching how Excel paints them. ECMA-376 §18.4.6
-        // (ST_VerticalAlignRun) leaves the exact ratio implementation-defined.
-        const baseRunFonts = runs.map(r => applyRunFont(fontForDraw, r));
-        const runVAlign = runs.map(r => r.font?.vertAlign);
-        const drawRunFonts = baseRunFonts.map((f, i) => {
-          if (runVAlign[i] === 'superscript' || runVAlign[i] === 'subscript') {
-            return { ...f, size: f.size * 0.65 };
-          }
-          return f;
-        });
-        const runWidths: number[] = runs.map((r, i) => {
-          ctx.font = buildFont(drawRunFonts[i], cs);
-          return ctx.measureText(r.text).width;
-        });
-        const totalWidth = runWidths.reduce((a, b) => a + b, 0);
-        let startX: number;
-        if (alignH === 'right') startX = cx + cellW - paddingX - totalWidth;
-        else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
-        else startX = cx + leftPad;
-        // Use left alignment since we position each run ourselves
-        ctx.textAlign = 'left';
-        let textY: number;
-        if (alignV === 'top') { ctx.textBaseline = 'top'; textY = cy + paddingY; }
-        else if (alignV === 'center') { ctx.textBaseline = 'middle'; textY = cy + cellH / 2; }
-        else { ctx.textBaseline = 'bottom'; textY = cy + cellH - paddingY; }
-        // Bidi: draw the runs in visual order (UAX#9 rule L2) under the cell's
-        // base direction (xf @readingOrder, or first-strong for Context), each
-        // with ctx.direction set so Canvas shapes/orders it internally. The
-        // x-budget (totalWidth/startX) is order-independent. Gated so pure-LTR
-        // cells keep the exact pre-bidi path (no per-repaint UAX#9 cost).
-        const richNeedsBidi = xf.readingOrder === 2 || segmentsHaveRtl(runs);
-        const richVis = richNeedsBidi
-          ? computeLineVisualOrder(runs, cellBaseRtl(xf.readingOrder, runs.map(r => r.text).join('')))
-          : null;
-        const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
-        let runX = startX;
-        for (let vi = 0; vi < runs.length; vi++) {
-          const i = richVis ? richVis.order[vi] : vi;
-          if (richVis) { try { dctx.direction = richVis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
-          const rf = drawRunFonts[i];
-          const baseRf = baseRunFonts[i];
-          ctx.font = buildFont(rf, cs);
-          const runColor = cf.fontColor ?? rf.color;
-          ctx.fillStyle = runColor ? hexToRgba(runColor) : '#000000';
-          // Baseline shift for super/subscript. With textBaseline 'bottom'
-          // (the typical case) shift up for super and slightly down for sub
-          // so each run sits at the right vertical band relative to the line.
-          const baseSizePx = vMetricPx(baseRf.size, cs);
-          let yShift = 0;
-          if (runVAlign[i] === 'superscript') yShift = -Math.round(baseSizePx * 0.35);
-          else if (runVAlign[i] === 'subscript') yShift = Math.round(baseSizePx * 0.10);
-          ctx.fillText(runs[i].text, runX, textY + yShift);
-          const rSizePx = vMetricPx(rf.size, cs);
-          if (rf.underline) {
-            const uyBase = alignV === 'top'
-              ? cy + paddingY + rSizePx + 1
-              : alignV === 'center'
-                ? cy + cellH / 2 + Math.round(rSizePx * 0.55)
-                : cy + cellH - paddingY + 1;
-            const uy = uyBase + yShift;
-            const stroke = runColor ? hexToRgba(runColor) : '#000000';
-            drawTextDecoLine(ctx, runX, runX + runWidths[i], uy, stroke, rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting', dpr);
-          }
-          if (rf.strike) {
-            const syBase = alignV === 'top'
-              ? cy + paddingY + Math.round(rSizePx * 0.5)
-              : alignV === 'center'
-                ? cy + cellH / 2
-                : cy + cellH - paddingY - Math.round(rSizePx * 0.35);
-            const sy = syBase + yShift + crispOffset(syBase + yShift, 0.5, dpr);
-            ctx.save();
-            ctx.strokeStyle = runColor ? hexToRgba(runColor) : '#000000';
-            ctx.lineWidth = 0.5;
-            ctx.beginPath(); ctx.moveTo(runX, sy); ctx.lineTo(runX + runWidths[i], sy); ctx.stroke();
-            ctx.restore();
-          }
-          runX += runWidths[i];
-        }
-        // Defensive reset (the per-cell ctx.restore() also restores direction).
-        if (richVis) { try { dctx.direction = 'ltr'; } catch { /* ignore */ } }
       } else {
         // ECMA-376 §18.4.6 — cell-level super/subscript: render the glyphs at
         // ~65% size, shifted off the baseline so the cell still reads at the

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -917,6 +917,153 @@ export function layoutRichTextLines(
   return lines;
 }
 
+/** Cell geometry + alignment for {@link drawNonWrapRichText}. `alignH`/`alignV`
+ *  accept the raw `xf` strings; any value other than `right`/`center` anchors
+ *  left, and other than `top`/`center` anchors bottom (matching the legacy
+ *  single-line path's handling of `justify` / `centerContinuous` / etc.). */
+export interface NonWrapRichGeom {
+  alignH: string;
+  alignV: string;
+  /** Cell top-left in canvas px (merge span included). */
+  cx: number;
+  cy: number;
+  cellW: number;
+  cellH: number;
+  /** Left text inset (paddingX + indent) and the symmetric paddings. */
+  leftPad: number;
+  paddingX: number;
+  paddingY: number;
+}
+
+/**
+ * Draw rich text (mixed-font runs) in a NON-wrapped cell, honoring hard line
+ * breaks (LF / Alt+Enter). ECMA-376 §18.8.1 (CT_CellAlignment @wrapText): with
+ * wrapText off the cell is not soft-wrapped, but Excel still renders each LF
+ * (§18.4.4 r / §18.4.12 t, xml:space="preserve") as a separate line — exactly
+ * as the plain-text non-wrap path and the wrap rich-text path already do. Runs
+ * are split at every LF into lines; a blank line from consecutive / leading /
+ * trailing breaks reserves one single-line height (the cell analog of PR #585 /
+ * docx #582), sized from the nearest preceding text run.
+ *
+ * Each line is drawn at a `'top'` baseline (matching the wrap rich path), with
+ * per-run super/subscript baseline shifts (§18.4.6 ST_VerticalAlignRun, ~65%
+ * size), underline / strike decoration, and the bidi visual-order pass (UAX#9
+ * rule L2) applied per line. The whole multi-line block is anchored vertically
+ * by `alignV` over its summed height. A single line with no break renders the
+ * same as one drawn line of the legacy single-line path.
+ */
+export function drawNonWrapRichText(
+  ctx: CanvasRenderingContext2D,
+  runs: Run[],
+  baseFont: CellFont,
+  geom: NonWrapRichGeom,
+  cs: number,
+  dpr: number,
+  opts: { fontColor?: string | null; readingOrder?: number } = {},
+): void {
+  const { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY } = geom;
+
+  // Split runs into lines at LF. A run "A\nB" yields "A" on the current line and
+  // "B" on a new one; an empty piece (consecutive / leading / trailing LF) adds
+  // no segment but the line still exists, so a blank line is preserved.
+  const lineRuns: Run[][] = [[]];
+  for (const run of runs) {
+    const parts = run.text.split('\n');
+    for (let p = 0; p < parts.length; p++) {
+      if (p > 0) lineRuns.push([]);
+      if (parts[p] !== '') lineRuns[lineRuns.length - 1].push({ ...run, text: parts[p] });
+    }
+  }
+
+  // Per-line height source (pt). A text line uses the max run size on it; a
+  // blank line inherits the nearest preceding text run's size — the same seed
+  // `layoutRichTextLines` / `drawShapeText` use for blank lines (PR #585).
+  let lastTextPt = baseFont.size;
+  const lineSizes = lineRuns.map((lr) => {
+    if (lr.length === 0) return lastTextPt || DEFAULT_FONT_SIZE;
+    let m = 0;
+    for (const r of lr) {
+      const sz = applyRunFont(baseFont, r).size;
+      if (sz > m) m = sz;
+      lastTextPt = sz; // nearest preceding text size, for a following blank line
+    }
+    return m;
+  });
+  const lineHeights = lineSizes.map((s) => vMetricPx(s, cs, 1.2));
+  const totalH = lineHeights.reduce((a, b) => a + b, 0);
+
+  let yy: number;
+  if (alignV === 'top') yy = cy + paddingY;
+  else if (alignV === 'center') yy = cy + (cellH - totalH) / 2;
+  else yy = cy + cellH - totalH - paddingY;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
+  let usedBidi = false;
+
+  for (let li = 0; li < lineRuns.length; li++) {
+    const lr = lineRuns[li];
+    const lineH = lineHeights[li];
+    if (lr.length === 0) { yy += lineH; continue; } // blank line: reserve height only
+
+    // Per-run draw fonts: super/subscript runs render at ~65% size with a
+    // baseline shift; the x-budget uses the run's base size (§18.4.6).
+    const baseRunFonts = lr.map((r) => applyRunFont(baseFont, r));
+    const runVAlign = lr.map((r) => r.font?.vertAlign);
+    const drawRunFonts = baseRunFonts.map((f, i) =>
+      (runVAlign[i] === 'superscript' || runVAlign[i] === 'subscript') ? { ...f, size: f.size * 0.65 } : f);
+    const runWidths = lr.map((r, i) => {
+      ctx.font = buildFont(drawRunFonts[i], cs);
+      return ctx.measureText(r.text).width;
+    });
+    const totalW = runWidths.reduce((a, b) => a + b, 0);
+    let xx: number;
+    if (alignH === 'right') xx = cx + cellW - paddingX - totalW;
+    else if (alignH === 'center') xx = cx + cellW / 2 - totalW / 2;
+    else xx = cx + leftPad;
+
+    // Bidi: draw the line's runs in visual order (UAX#9 rule L2) under the
+    // cell's base direction. Gated so pure-LTR lines keep the non-bidi path.
+    const needBidi = opts.readingOrder === 2 || segmentsHaveRtl(lr);
+    const vis = needBidi ? computeLineVisualOrder(lr, cellBaseRtl(opts.readingOrder, lr.map((r) => r.text).join(''))) : null;
+    if (needBidi) usedBidi = true;
+
+    for (let vi = 0; vi < lr.length; vi++) {
+      const i = vis ? vis.order[vi] : vi;
+      if (vis) { try { dctx.direction = vis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
+      const rf = drawRunFonts[i];
+      const baseRf = baseRunFonts[i];
+      ctx.font = buildFont(rf, cs);
+      const runColor = opts.fontColor ?? rf.color;
+      ctx.fillStyle = runColor ? hexToRgba(runColor) : '#000000';
+      const baseSizePx = vMetricPx(baseRf.size, cs);
+      let yShift = 0;
+      if (runVAlign[i] === 'superscript') yShift = -Math.round(baseSizePx * 0.35);
+      else if (runVAlign[i] === 'subscript') yShift = Math.round(baseSizePx * 0.10);
+      ctx.fillText(lr[i].text, xx, yy + yShift);
+      const rSizePx = vMetricPx(rf.size, cs);
+      if (rf.underline) {
+        const stroke = runColor ? hexToRgba(runColor) : '#000000';
+        const dbl = rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting';
+        drawTextDecoLine(ctx, xx, xx + runWidths[i], yy + rSizePx + 1 + yShift, stroke, dbl, dpr);
+      }
+      if (rf.strike) {
+        const syBase = yy + Math.round(rSizePx * 0.5) + yShift;
+        const sy = syBase + crispOffset(syBase, 0.5, dpr);
+        ctx.save();
+        ctx.strokeStyle = runColor ? hexToRgba(runColor) : '#000000';
+        ctx.lineWidth = 0.5;
+        ctx.beginPath(); ctx.moveTo(xx, sy); ctx.lineTo(xx + runWidths[i], sy); ctx.stroke();
+        ctx.restore();
+      }
+      xx += runWidths[i];
+    }
+    yy += lineH;
+  }
+  // Defensive reset (the per-cell ctx.restore() also restores direction).
+  if (usedBidi) { try { dctx.direction = 'ltr'; } catch { /* ignore */ } }
+}
+
 function colToLetter(col: number): string {
   let result = '';
   while (col > 0) {
@@ -1497,6 +1644,14 @@ function renderQuadrant(
       for (let li = 0; li < lines.length; li++) {
         ctx.fillText(lines[li], textX, startY + li * lineH);
       }
+    } else if (hasRichText && runs.some((r) => r.text.includes('\n'))) {
+      // Non-wrap rich text with hard breaks — same helper as the in-viewport
+      // path so an off-screen-anchored merge renders identical multi-line text.
+      drawNonWrapRichText(
+        ctx, runs, fontForDraw,
+        { alignH, alignV, cx: aCx, cy: aCy, cellW: cW, cellH: cH, leftPad, paddingX, paddingY },
+        cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
+      );
     } else {
       let textY: number;
       if (alignV === 'top') { ctx.textBaseline = 'top'; textY = aCy + paddingY; }
@@ -2138,6 +2293,18 @@ function renderQuadrant(
         for (let li = 0; li < lines.length; li++) {
           ctx.fillText(lines[li], textX, startY + li * lineH);
         }
+      } else if (hasRichText && runs.some((r) => r.text.includes('\n'))) {
+        // Rich text with hard line breaks (Alt+Enter) but wrapText off: split
+        // runs at each LF and lay out multiple lines. ECMA-376 §18.8.1 — Excel
+        // honors Alt+Enter breaks even when wrapText is off, exactly as the
+        // plain-text `\n` split below and the wrap blank-line fix (#585) do. The
+        // shared helper keeps this in-viewport path and the off-screen-anchor
+        // pre-pass identical.
+        drawNonWrapRichText(
+          ctx, runs, fontForDraw,
+          { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY },
+          cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
+        );
       } else if (hasRichText) {
         // Per-run drawing: compute font for each run, measure widths, draw LTR.
         // Layout uses the run's *base* font size (line height & x-position

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -935,16 +935,112 @@ export interface NonWrapRichGeom {
   paddingY: number;
 }
 
+/** Underline / strike decoration y for a run on a line, given the line's text
+ *  baseline and its `textY`. With a `'top'` baseline `textY` is the line top, so
+ *  the underline sits a full text height below it and the strike near mid-height;
+ *  `'middle'` / `'bottom'` shift relative to the centre / bottom baseline. The
+ *  caller adds any super/subscript `yShift`. One function so the single-line and
+ *  multi-line paths place decorations identically. */
+function decoYForBaseline(baseline: CanvasTextBaseline, textY: number, rSizePx: number): { underline: number; strike: number } {
+  if (baseline === 'middle') return { underline: textY + Math.round(rSizePx * 0.55), strike: textY };
+  if (baseline === 'bottom') return { underline: textY + 1, strike: textY - Math.round(rSizePx * 0.35) };
+  return { underline: textY + rSizePx + 1, strike: textY + Math.round(rSizePx * 0.5) };
+}
+
 /**
- * Draw a single line of rich text (no hard break) with per-run fonts. The line
- * is anchored with the cell's alignV-dependent baseline — `'top'` at the top
- * padding, `'middle'` at the cell centre, `'bottom'` at the bottom padding —
- * which is exactly how Excel paints a one-line rich cell. Each run draws with
- * its own font/color, ~65%-size super/subscript baseline shift (§18.4.6
- * ST_VerticalAlignRun), underline / strike decoration, and the bidi visual-order
- * pass (UAX#9 rule L2). Shared by the in-viewport draw path and the off-screen-
- * anchor merge pre-pass so a merged rich cell renders identically whether or not
- * its anchor is scrolled out of view.
+ * Draw one already-grouped line of rich-text runs at `textY` under `baseline`,
+ * each run with its own font/color, ~65%-size super/subscript baseline shift
+ * (ECMA-376 §18.4.14 vertAlign / ST_VerticalAlignRun §22.9.2.17 — the size ratio
+ * and offset are implementation-defined), underline / strike decoration, and the
+ * per-line bidi visual-order pass (UAX#9 rule L2). The line is positioned
+ * horizontally by `geom.alignH` over its measured width. The single shared
+ * per-run drawer for every non-wrap rich path, so they paint runs identically.
+ */
+function drawRichLine(
+  ctx: CanvasRenderingContext2D,
+  lineRuns: Run[],
+  baseFont: CellFont,
+  geom: NonWrapRichGeom,
+  cs: number,
+  dpr: number,
+  opts: { fontColor?: string | null; readingOrder?: number },
+  textY: number,
+  baseline: CanvasTextBaseline,
+): void {
+  const { alignH, cx, cellW, leftPad, paddingX } = geom;
+  // Per-run draw fonts: super/subscript runs render at ~65% size with a baseline
+  // shift; the x-budget uses the run's *base* size.
+  const baseRunFonts = lineRuns.map((r) => applyRunFont(baseFont, r));
+  const runVAlign = lineRuns.map((r) => r.font?.vertAlign);
+  const drawRunFonts = baseRunFonts.map((f, i) =>
+    (runVAlign[i] === 'superscript' || runVAlign[i] === 'subscript') ? { ...f, size: f.size * 0.65 } : f);
+  const runWidths = lineRuns.map((r, i) => {
+    ctx.font = buildFont(drawRunFonts[i], cs);
+    return ctx.measureText(r.text).width;
+  });
+  const totalWidth = runWidths.reduce((a, b) => a + b, 0);
+  let runX: number;
+  if (alignH === 'right') runX = cx + cellW - paddingX - totalWidth;
+  else if (alignH === 'center') runX = cx + cellW / 2 - totalWidth / 2;
+  else runX = cx + leftPad;
+  // We position each run ourselves, so draw left-aligned at the run's baseline.
+  ctx.textAlign = 'left';
+  ctx.textBaseline = baseline;
+  // Bidi: draw the runs in visual order (UAX#9 rule L2) under the cell's base
+  // direction (@readingOrder, or first-strong for Context), each with
+  // ctx.direction set so Canvas shapes/orders it internally. The x-budget is
+  // order-independent. Gated so pure-LTR lines keep the exact pre-bidi path.
+  const needBidi = opts.readingOrder === 2 || segmentsHaveRtl(lineRuns);
+  const vis = needBidi
+    ? computeLineVisualOrder(lineRuns, cellBaseRtl(opts.readingOrder, lineRuns.map((r) => r.text).join('')))
+    : null;
+  const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
+  for (let vi = 0; vi < lineRuns.length; vi++) {
+    const i = vis ? vis.order[vi] : vi;
+    if (vis) { try { dctx.direction = vis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
+    const rf = drawRunFonts[i];
+    const baseRf = baseRunFonts[i];
+    ctx.font = buildFont(rf, cs);
+    const runColor = opts.fontColor ?? rf.color;
+    ctx.fillStyle = runColor ? hexToRgba(runColor) : '#000000';
+    // Baseline shift for super/subscript: up for super, slightly down for sub so
+    // each run sits at the right vertical band relative to the line.
+    const baseSizePx = vMetricPx(baseRf.size, cs);
+    let yShift = 0;
+    if (runVAlign[i] === 'superscript') yShift = -Math.round(baseSizePx * 0.35);
+    else if (runVAlign[i] === 'subscript') yShift = Math.round(baseSizePx * 0.10);
+    ctx.fillText(lineRuns[i].text, runX, textY + yShift);
+    const rSizePx = vMetricPx(rf.size, cs);
+    if (rf.underline || rf.strike) {
+      const deco = decoYForBaseline(baseline, textY, rSizePx);
+      if (rf.underline) {
+        const stroke = runColor ? hexToRgba(runColor) : '#000000';
+        const dbl = rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting';
+        drawTextDecoLine(ctx, runX, runX + runWidths[i], deco.underline + yShift, stroke, dbl, dpr);
+      }
+      if (rf.strike) {
+        const syBase = deco.strike + yShift;
+        const sy = syBase + crispOffset(syBase, 0.5, dpr);
+        ctx.save();
+        ctx.strokeStyle = runColor ? hexToRgba(runColor) : '#000000';
+        ctx.lineWidth = 0.5;
+        ctx.beginPath(); ctx.moveTo(runX, sy); ctx.lineTo(runX + runWidths[i], sy); ctx.stroke();
+        ctx.restore();
+      }
+    }
+    runX += runWidths[i];
+  }
+  // Defensive reset (the per-cell ctx.restore() also restores direction).
+  if (vis) { try { dctx.direction = 'ltr'; } catch { /* ignore */ } }
+}
+
+/**
+ * Draw a single line of rich text (no hard break) with per-run fonts, anchored
+ * by the cell's alignV-dependent baseline — `'top'` at the top padding,
+ * `'middle'` at the cell centre, `'bottom'` at the bottom padding — exactly how
+ * Excel paints a one-line rich cell. Shared by the in-viewport draw path and the
+ * off-screen-anchor merge pre-pass so a merged rich cell renders identically
+ * whether or not its anchor is scrolled out of view.
  */
 function drawSingleLineRichText(
   ctx: CanvasRenderingContext2D,
@@ -955,110 +1051,24 @@ function drawSingleLineRichText(
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
 ): void {
-  const { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY } = geom;
-  // Per-run drawing: compute font for each run, measure widths, draw LTR.
-  // Layout uses the run's *base* font size (line height & x-position budget);
-  // super/subscript runs are rendered at ~65% size with a baseline shift,
-  // matching how Excel paints them. ECMA-376 §18.4.6 (ST_VerticalAlignRun)
-  // leaves the exact ratio implementation-defined.
-  const baseRunFonts = runs.map(r => applyRunFont(baseFont, r));
-  const runVAlign = runs.map(r => r.font?.vertAlign);
-  const drawRunFonts = baseRunFonts.map((f, i) => {
-    if (runVAlign[i] === 'superscript' || runVAlign[i] === 'subscript') {
-      return { ...f, size: f.size * 0.65 };
-    }
-    return f;
-  });
-  const runWidths: number[] = runs.map((r, i) => {
-    ctx.font = buildFont(drawRunFonts[i], cs);
-    return ctx.measureText(r.text).width;
-  });
-  const totalWidth = runWidths.reduce((a, b) => a + b, 0);
-  let startX: number;
-  if (alignH === 'right') startX = cx + cellW - paddingX - totalWidth;
-  else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
-  else startX = cx + leftPad;
-  // Use left alignment since we position each run ourselves
-  ctx.textAlign = 'left';
+  const { alignV, cy, cellH, paddingY } = geom;
   let textY: number;
-  if (alignV === 'top') { ctx.textBaseline = 'top'; textY = cy + paddingY; }
-  else if (alignV === 'center') { ctx.textBaseline = 'middle'; textY = cy + cellH / 2; }
-  else { ctx.textBaseline = 'bottom'; textY = cy + cellH - paddingY; }
-  // Bidi: draw the runs in visual order (UAX#9 rule L2) under the cell's base
-  // direction (@readingOrder, or first-strong for Context), each with
-  // ctx.direction set so Canvas shapes/orders it internally. The x-budget
-  // (totalWidth/startX) is order-independent. Gated so pure-LTR cells keep the
-  // exact pre-bidi path (no per-repaint UAX#9 cost).
-  const richNeedsBidi = opts.readingOrder === 2 || segmentsHaveRtl(runs);
-  const richVis = richNeedsBidi
-    ? computeLineVisualOrder(runs, cellBaseRtl(opts.readingOrder, runs.map(r => r.text).join('')))
-    : null;
-  const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
-  let runX = startX;
-  for (let vi = 0; vi < runs.length; vi++) {
-    const i = richVis ? richVis.order[vi] : vi;
-    if (richVis) { try { dctx.direction = richVis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
-    const rf = drawRunFonts[i];
-    const baseRf = baseRunFonts[i];
-    ctx.font = buildFont(rf, cs);
-    const runColor = opts.fontColor ?? rf.color;
-    ctx.fillStyle = runColor ? hexToRgba(runColor) : '#000000';
-    // Baseline shift for super/subscript. With textBaseline 'bottom' (the
-    // typical case) shift up for super and slightly down for sub so each run
-    // sits at the right vertical band relative to the line.
-    const baseSizePx = vMetricPx(baseRf.size, cs);
-    let yShift = 0;
-    if (runVAlign[i] === 'superscript') yShift = -Math.round(baseSizePx * 0.35);
-    else if (runVAlign[i] === 'subscript') yShift = Math.round(baseSizePx * 0.10);
-    ctx.fillText(runs[i].text, runX, textY + yShift);
-    const rSizePx = vMetricPx(rf.size, cs);
-    if (rf.underline) {
-      const uyBase = alignV === 'top'
-        ? cy + paddingY + rSizePx + 1
-        : alignV === 'center'
-          ? cy + cellH / 2 + Math.round(rSizePx * 0.55)
-          : cy + cellH - paddingY + 1;
-      const uy = uyBase + yShift;
-      const stroke = runColor ? hexToRgba(runColor) : '#000000';
-      drawTextDecoLine(ctx, runX, runX + runWidths[i], uy, stroke, rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting', dpr);
-    }
-    if (rf.strike) {
-      const syBase = alignV === 'top'
-        ? cy + paddingY + Math.round(rSizePx * 0.5)
-        : alignV === 'center'
-          ? cy + cellH / 2
-          : cy + cellH - paddingY - Math.round(rSizePx * 0.35);
-      const sy = syBase + yShift + crispOffset(syBase + yShift, 0.5, dpr);
-      ctx.save();
-      ctx.strokeStyle = runColor ? hexToRgba(runColor) : '#000000';
-      ctx.lineWidth = 0.5;
-      ctx.beginPath(); ctx.moveTo(runX, sy); ctx.lineTo(runX + runWidths[i], sy); ctx.stroke();
-      ctx.restore();
-    }
-    runX += runWidths[i];
-  }
-  // Defensive reset (the per-cell ctx.restore() also restores direction).
-  if (richVis) { try { dctx.direction = 'ltr'; } catch { /* ignore */ } }
+  let baseline: CanvasTextBaseline;
+  if (alignV === 'top') { baseline = 'top'; textY = cy + paddingY; }
+  else if (alignV === 'center') { baseline = 'middle'; textY = cy + cellH / 2; }
+  else { baseline = 'bottom'; textY = cy + cellH - paddingY; }
+  drawRichLine(ctx, runs, baseFont, geom, cs, dpr, opts, textY, baseline);
 }
 
 /**
- * Draw rich text (mixed-font runs) in a NON-wrapped cell, honoring hard line
- * breaks (LF / Alt+Enter). ECMA-376 §18.8.1 (CT_CellAlignment @wrapText): with
- * wrapText off the cell is not soft-wrapped, but Excel still renders each LF
- * (§18.4.4 r / §18.4.12 t, xml:space="preserve") as a separate line — exactly
- * as the plain-text non-wrap path and the wrap rich-text path already do.
- *
- * A break-free value is one line: it is delegated to {@link drawSingleLineRichText},
- * which anchors with the cell's alignV-dependent baseline (the exact in-viewport
- * rendering). Only a hard break triggers the multi-line layout here: runs are
- * split at every LF; a blank line from consecutive / leading / trailing breaks
- * reserves one single-line height (the cell analog of PR #585 / docx #582), sized
- * from the nearest preceding text run; each line is drawn at a `'top'` baseline
- * (matching the wrap rich path) with the same per-run super/subscript, underline /
- * strike, and per-line bidi handling, and the block is anchored by `alignV` over
- * its summed height.
+ * Lay out and draw rich text with hard line breaks (LF / Alt+Enter) in a
+ * non-wrapped cell. Runs are split at every LF into lines; a blank line from
+ * consecutive / leading / trailing breaks reserves one single-line height (the
+ * cell analog of PR #585 / docx #582), sized from the nearest preceding text
+ * run. Each line is drawn at a `'top'` baseline (matching the wrap rich path)
+ * and the whole block is anchored vertically by `alignV` over its summed height.
  */
-export function drawNonWrapRichText(
+function drawMultiLineRichText(
   ctx: CanvasRenderingContext2D,
   runs: Run[],
   baseFont: CellFont,
@@ -1067,13 +1077,7 @@ export function drawNonWrapRichText(
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
 ): void {
-  // Break-free value → single line with the alignV-dependent baseline (mirrors
-  // the in-viewport path). Only a hard break needs the multi-line layout below.
-  if (!runs.some((r) => r.text.includes('\n'))) {
-    drawSingleLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts);
-    return;
-  }
-  const { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY } = geom;
+  const { alignV, cy, cellH, paddingY } = geom;
 
   // Split runs into lines at LF. A run "A\nB" yields "A" on the current line and
   // "B" on a new one; an empty piece (consecutive / leading / trailing LF) adds
@@ -1108,72 +1112,41 @@ export function drawNonWrapRichText(
   if (alignV === 'top') yy = cy + paddingY;
   else if (alignV === 'center') yy = cy + (cellH - totalH) / 2;
   else yy = cy + cellH - totalH - paddingY;
-  ctx.textAlign = 'left';
-  ctx.textBaseline = 'top';
-  const dctx = ctx as CanvasRenderingContext2D & { direction: 'ltr' | 'rtl' };
-  let usedBidi = false;
 
   for (let li = 0; li < lineRuns.length; li++) {
     const lr = lineRuns[li];
-    const lineH = lineHeights[li];
-    if (lr.length === 0) { yy += lineH; continue; } // blank line: reserve height only
-
-    // Per-run draw fonts: super/subscript runs render at ~65% size with a
-    // baseline shift; the x-budget uses the run's base size (§18.4.6).
-    const baseRunFonts = lr.map((r) => applyRunFont(baseFont, r));
-    const runVAlign = lr.map((r) => r.font?.vertAlign);
-    const drawRunFonts = baseRunFonts.map((f, i) =>
-      (runVAlign[i] === 'superscript' || runVAlign[i] === 'subscript') ? { ...f, size: f.size * 0.65 } : f);
-    const runWidths = lr.map((r, i) => {
-      ctx.font = buildFont(drawRunFonts[i], cs);
-      return ctx.measureText(r.text).width;
-    });
-    const totalW = runWidths.reduce((a, b) => a + b, 0);
-    let xx: number;
-    if (alignH === 'right') xx = cx + cellW - paddingX - totalW;
-    else if (alignH === 'center') xx = cx + cellW / 2 - totalW / 2;
-    else xx = cx + leftPad;
-
-    // Bidi: draw the line's runs in visual order (UAX#9 rule L2) under the
-    // cell's base direction. Gated so pure-LTR lines keep the non-bidi path.
-    const needBidi = opts.readingOrder === 2 || segmentsHaveRtl(lr);
-    const vis = needBidi ? computeLineVisualOrder(lr, cellBaseRtl(opts.readingOrder, lr.map((r) => r.text).join(''))) : null;
-    if (needBidi) usedBidi = true;
-
-    for (let vi = 0; vi < lr.length; vi++) {
-      const i = vis ? vis.order[vi] : vi;
-      if (vis) { try { dctx.direction = vis.rtl[i] ? 'rtl' : 'ltr'; } catch { /* ignore */ } }
-      const rf = drawRunFonts[i];
-      const baseRf = baseRunFonts[i];
-      ctx.font = buildFont(rf, cs);
-      const runColor = opts.fontColor ?? rf.color;
-      ctx.fillStyle = runColor ? hexToRgba(runColor) : '#000000';
-      const baseSizePx = vMetricPx(baseRf.size, cs);
-      let yShift = 0;
-      if (runVAlign[i] === 'superscript') yShift = -Math.round(baseSizePx * 0.35);
-      else if (runVAlign[i] === 'subscript') yShift = Math.round(baseSizePx * 0.10);
-      ctx.fillText(lr[i].text, xx, yy + yShift);
-      const rSizePx = vMetricPx(rf.size, cs);
-      if (rf.underline) {
-        const stroke = runColor ? hexToRgba(runColor) : '#000000';
-        const dbl = rf.underlineStyle === 'double' || rf.underlineStyle === 'doubleAccounting';
-        drawTextDecoLine(ctx, xx, xx + runWidths[i], yy + rSizePx + 1 + yShift, stroke, dbl, dpr);
-      }
-      if (rf.strike) {
-        const syBase = yy + Math.round(rSizePx * 0.5) + yShift;
-        const sy = syBase + crispOffset(syBase, 0.5, dpr);
-        ctx.save();
-        ctx.strokeStyle = runColor ? hexToRgba(runColor) : '#000000';
-        ctx.lineWidth = 0.5;
-        ctx.beginPath(); ctx.moveTo(xx, sy); ctx.lineTo(xx + runWidths[i], sy); ctx.stroke();
-        ctx.restore();
-      }
-      xx += runWidths[i];
-    }
-    yy += lineH;
+    // A blank line draws nothing but still reserves its height.
+    if (lr.length > 0) drawRichLine(ctx, lr, baseFont, geom, cs, dpr, opts, yy, 'top');
+    yy += lineHeights[li];
   }
-  // Defensive reset (the per-cell ctx.restore() also restores direction).
-  if (usedBidi) { try { dctx.direction = 'ltr'; } catch { /* ignore */ } }
+}
+
+/**
+ * Draw rich text (mixed-font runs, ECMA-376 §18.4.4 r) in a NON-wrapped cell.
+ * A break-free value is one alignV-anchored line ({@link drawSingleLineRichText});
+ * a value with a hard break is laid out as multiple lines
+ * ({@link drawMultiLineRichText}).
+ *
+ * §18.8.1 (CT_CellAlignment @wrapText) governs only soft-wrapping; it says
+ * nothing about hard breaks. Rendering a literal LF (Alt+Enter, preserved in the
+ * run text via §18.4.12 t @xml:space) as a line break even when wrapText is off
+ * is undocumented Excel runtime behavior — matched here for parity with the
+ * plain-text non-wrap path and the wrap rich-text path (#585).
+ */
+export function drawNonWrapRichText(
+  ctx: CanvasRenderingContext2D,
+  runs: Run[],
+  baseFont: CellFont,
+  geom: NonWrapRichGeom,
+  cs: number,
+  dpr: number,
+  opts: { fontColor?: string | null; readingOrder?: number } = {},
+): void {
+  if (runs.some((r) => r.text.includes('\n'))) {
+    drawMultiLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts);
+  } else {
+    drawSingleLineRichText(ctx, runs, baseFont, geom, cs, dpr, opts);
+  }
 }
 
 function colToLetter(col: number): string {
@@ -2418,10 +2391,11 @@ function renderQuadrant(
           cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
         );
       } else {
-        // ECMA-376 §18.4.6 — cell-level super/subscript: render the glyphs at
-        // ~65% size, shifted off the baseline so the cell still reads at the
-        // right vertical band. Excel uses these defaults (size ratio is
-        // implementation-defined; ratios match Office's visual output).
+        // ECMA-376 §18.4.14 vertAlign / ST_VerticalAlignRun §22.9.2.17 —
+        // cell-level super/subscript: render the glyphs at ~65% size, shifted
+        // off the baseline so the cell still reads at the right vertical band.
+        // §18.4.14 mandates the size reduction; the exact ratio/offset is
+        // implementation-defined (ratios match Office's visual output).
         const cellVertAlign = fontForDraw.vertAlign;
         const baseSizePxOrig = vMetricPx(font.size, cs);
         let vaYShift = 0;


### PR DESCRIPTION
## Summary

Makes **non-wrap rich-text cells** (mixed-font `<r>` runs, ECMA-376 §18.4.4 `r`) render correctly in both draw paths.

1. **Hard breaks** — a cell with rich runs **and** an embedded Alt+Enter break (LF preserved in `<t xml:space="preserve">`) rendered every run on a single line, dropping the breaks. §18.8.1 governs only soft-wrapping; honoring the LF break with `wrapText` off is Excel runtime behavior, matched for parity with the plain-text non-wrap path and the wrap rich-text path ([#585](https://github.com/yukiyokotani/office-open-xml-viewer/pull/585)).
2. **Per-run fonts in the off-screen pre-pass** — the off-screen-anchor merge pre-pass drew a *break-free* rich cell as joined **base-font** text via one `ctx.fillText`, so a merged rich cell showed the wrong fonts/colors once its anchor scrolled out of view (§18.4.7 `rPr`).

## Design

- One entry point `drawNonWrapRichText` dispatches break-free → `drawSingleLineRichText` (alignV-dependent baseline) vs hard-break → `drawMultiLineRichText`. A blank line from consecutive/leading/trailing breaks reserves one single-line height (cell analog of #585 / docx #582), sized from the nearest preceding text run.
- Per-run drawing (font/color, super/subscript §18.4.14, underline/strike, per-line bidi UAX#9 L2) lives in **one shared `drawRichLine`**; the only per-baseline difference (decoration y) is a pure `decoYForBaseline`.
- Both the in-viewport path and the off-screen pre-pass call `drawNonWrapRichText` unconditionally for rich text → they render identically.

## Review response (independent multi-dimensional review)

Three independent reviewers (spec-first / single-responsibility+dedup / cross-package). Addressed:
- **Dedup + cohesion**: extracted `drawRichLine` + `decoYForBaseline` (removed ~45 duplicated lines), split the dispatcher from the multi-line layout — **behavior-preserving (VRT byte-identical)**.
- **Spec citations**: `§18.4.6` is `rPh (Phonetic Run)`; corrected super/subscript refs to `§18.4.14 vertAlign` / `§22.9.2.17 ST_VerticalAlignRun`. Clarified the LF-break is Excel runtime behavior, not §18.8.1-mandated.
- **Cross-package**: verified docx (`<w:br>` elements + real metrics) and pptx (`<a:br>` + maxSizePx fallback) already handle break-reserves-height; xlsx's LF-in-`<t>` is genuinely format-specific → no docx/pptx change owed, nothing to `core`. (Pre-existing text-drawer signature divergence noted as a separate follow-up.)

## Test Plan

- [x] Two mock-context vitest files (hard-break + single-line/per-run + alignV baseline): 9 tests.
- [x] Full xlsx unit suite: 155/155.
- [x] `tsc --noEmit` (xlsx) clean.
- [x] `pnpm --filter @silurus/ooxml-xlsx vrt`: **67 passed / 0 failed / 1 skipped**, **byte-identical across the whole branch** on every sample (no reference auto-updated). The off-screen-anchored-rich case is too niche for a reference shot — the unit tests are the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)