### PR TITLE
fix(xlsx): resolve wrap rich-text base direction per LF paragraph

### DIFF
--- a/packages/xlsx/src/bidi-line.ts
+++ b/packages/xlsx/src/bidi-line.ts
@@ -44,6 +44,23 @@ export function segmentsHaveRtl(segments: readonly unknown[]): boolean {
   return false;
 }
 
+/**
+ * Resolve whether one cell line / paragraph needs the bidi pass and its base
+ * direction, from the xf @readingOrder (§18.8.1) and the line/paragraph text.
+ * Gated so pure-LTR text (no strong-RTL char and not explicitly RTL) keeps the
+ * exact pre-bidi path: `needBidi` false ⇒ no UAX#9 reorder. `baseRtl` is only
+ * resolved when the pass will run. The single source of truth for the gate +
+ * base-direction rule shared by the non-wrap ({@link cellBaseRtl} per LF line)
+ * and wrap (per LF paragraph) rich-text paths — keeping the two in lockstep.
+ */
+export function resolveCellBidi(
+  readingOrder: number | undefined,
+  text: string,
+): { needBidi: boolean; baseRtl: boolean } {
+  const needBidi = readingOrder === 2 || RTL_GATE.test(text);
+  return { needBidi, baseRtl: needBidi && cellBaseRtl(readingOrder, text) };
+}
+
 export interface LineVisualOrder {
   /** Logical segment indices in visual (left-to-right) order. */
   order: number[];

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -773,6 +773,12 @@ interface RichSeg {
 interface RichLine {
   segments: RichSeg[];
   maxFontSize: number; // pt (line-height source)
+  /** 0-based index of the LF-delimited paragraph (hard-break region) this line
+   *  belongs to. Soft-wrapped continuation lines share their paragraph's index;
+   *  it advances only at a hard break. Indexes the per-paragraph bidi base
+   *  direction the wrap draw path resolves — UAX#9: a soft wrap does NOT start a
+   *  new paragraph, but a hard break does. */
+  para: number;
 }
 
 /**
@@ -804,12 +810,16 @@ export function layoutRichTextLines(
   // line, which has no segment of its own. Mirrors drawShapeText's `lastTextPt`
   // seed (PR #583); falls back to the cell's base font.
   let lastTextPt = baseFont.size;
+  // 0-based index of the current LF-delimited paragraph. Advances only at a hard
+  // break (not at a soft wrap), so every line records which paragraph it belongs
+  // to — the wrap draw path resolves a Context base direction per paragraph.
+  let paraIdx = 0;
 
   // `flush` drops an empty region — used at soft-wrap (kinsoku) breaks, where a
   // line carried wholly to the next line must not leave a blank behind.
   const flush = () => {
     if (cur.length === 0) return;
-    lines.push({ segments: cur, maxFontSize: curMaxSize });
+    lines.push({ segments: cur, maxFontSize: curMaxSize, para: paraIdx });
     cur = []; curW = 0; curMaxSize = 0;
   };
 
@@ -819,7 +829,7 @@ export function layoutRichTextLines(
   // reserves one single-line height (the cell analog of PR #583 / docx #582).
   const flushRegion = () => {
     if (cur.length === 0) {
-      lines.push({ segments: [], maxFontSize: lastTextPt || DEFAULT_FONT_SIZE });
+      lines.push({ segments: [], maxFontSize: lastTextPt || DEFAULT_FONT_SIZE, para: paraIdx });
       return;
     }
     flush();
@@ -908,7 +918,11 @@ export function layoutRichTextLines(
       }
     }
     for (const tok of tokens) {
-      if (tok === '\n') flushRegion();
+      // A hard break closes the current paragraph region and opens the next, so
+      // the following lines record the new paragraph index. A soft wrap (handled
+      // inside `push`) keeps the same index — UAX#9 P1: only a hard break starts
+      // a new bidi paragraph.
+      if (tok === '\n') { flushRegion(); paraIdx++; }
       else push(tok, font);
     }
   }
@@ -1180,12 +1194,20 @@ export function drawNonWrapRichText(
  * Lay out and draw WRAP-mode rich text (mixed-font runs, §18.8.1 wrapText on).
  * `layoutRichTextLines` soft-wraps at word / CJK boundaries (and hard breaks),
  * and each resulting line is painted by the shared {@link drawResolvedRichLine}
- * (super/subscript §18.4.14, underline/strike, bidi). The wrapped display lines
- * share one paragraph base direction (§18.8.1 readingOrder), computed once here.
+ * (super/subscript §18.4.14, underline/strike, bidi).
+ *
+ * Base direction (§18.8.1 readingOrder) is resolved PER LF-delimited paragraph,
+ * not once for the whole cell: a soft wrap continues the same bidi paragraph (its
+ * display lines share a direction), but a hard break (Alt+Enter LF) starts a new
+ * paragraph that, under Context reading order (0/absent), resolves its OWN base
+ * direction from its OWN first strong character (UAX#9 P1–P3). Explicit LTR/RTL
+ * (1/2) is cell-wide, so only Context varies between paragraphs. Each line carries
+ * its paragraph index ({@link RichLine.para}) to pick the matching direction.
+ *
  * Drives both the in-viewport draw path and the off-screen-anchor merge pre-pass
  * so a merged wrapped cell renders identically regardless of anchor visibility.
  */
-function drawWrappedRichText(
+export function drawWrappedRichText(
   ctx: CanvasRenderingContext2D,
   runs: Run[],
   baseFont: CellFont,
@@ -1201,17 +1223,23 @@ function drawWrappedRichText(
   if (alignV === 'top') yy = cy + paddingY;
   else if (alignV === 'center') yy = cy + (cellH - totalH) / 2;
   else yy = cy + cellH - totalH - paddingY;
-  // Bidi base direction for the cell (@readingOrder / first-strong); the wrapped
-  // display lines share one paragraph direction. Gated so pure-LTR cells keep
-  // the exact pre-bidi path.
-  const needBidi = opts.readingOrder === 2 || segmentsHaveRtl(runs);
-  const baseRtl = needBidi && cellBaseRtl(opts.readingOrder, runs.map((r) => r.text).join(''));
+  // Resolve the bidi base direction for each LF-delimited paragraph from its own
+  // text (Context = first-strong; explicit 1/2 = cell-wide). `line.para` indexes
+  // this, so soft-wrapped lines share their paragraph's direction while a hard
+  // break gets its own. Each entry is gated so pure-LTR paragraphs keep the exact
+  // pre-bidi path.
+  const paraTexts = runs.map((r) => r.text).join('').split('\n');
+  const paraBidi = paraTexts.map((t) => {
+    const needBidi = opts.readingOrder === 2 || segmentsHaveRtl([{ text: t }]);
+    return { needBidi, baseRtl: needBidi && cellBaseRtl(opts.readingOrder, t) };
+  });
   for (const line of rLines) {
     const totalW = line.segments.reduce((s, seg) => s + seg.width, 0);
     let xx: number;
     if (alignH === 'right') xx = cx + cellW - paddingX - totalW;
     else if (alignH === 'center') xx = cx + cellW / 2 - totalW / 2;
     else xx = cx + leftPad;
+    const { needBidi, baseRtl } = paraBidi[line.para];
     drawResolvedRichLine(ctx, line.segments, xx, yy, 'top', cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl });
     yy += vMetricPx(line.maxFontSize, cs, 1.2);
   }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -8,7 +8,7 @@ import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAux
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
-import { computeLineVisualOrder, cellBaseRtl, segmentsHaveRtl } from './bidi-line.js';
+import { computeLineVisualOrder, cellBaseRtl, resolveCellBidi } from './bidi-line.js';
 import { parseA1 } from './a1.js';
 
 // Default font stack. Calibri is the workbook default font in Excel; on
@@ -1070,8 +1070,7 @@ function drawRichLine(
   if (alignH === 'right') startX = cx + cellW - paddingX - totalWidth;
   else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
   else startX = cx + leftPad;
-  const needBidi = opts.readingOrder === 2 || segmentsHaveRtl(segs);
-  const baseRtl = needBidi && cellBaseRtl(opts.readingOrder, segs.map((s) => s.text).join(''));
+  const { needBidi, baseRtl } = resolveCellBidi(opts.readingOrder, segs.map((s) => s.text).join(''));
   drawResolvedRichLine(ctx, segs, startX, textY, baseline, cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl });
 }
 
@@ -1226,13 +1225,10 @@ export function drawWrappedRichText(
   // Resolve the bidi base direction for each LF-delimited paragraph from its own
   // text (Context = first-strong; explicit 1/2 = cell-wide). `line.para` indexes
   // this, so soft-wrapped lines share their paragraph's direction while a hard
-  // break gets its own. Each entry is gated so pure-LTR paragraphs keep the exact
-  // pre-bidi path.
+  // break gets its own. `resolveCellBidi` gates each so pure-LTR paragraphs keep
+  // the exact pre-bidi path — the same gate the non-wrap path uses per line.
   const paraTexts = runs.map((r) => r.text).join('').split('\n');
-  const paraBidi = paraTexts.map((t) => {
-    const needBidi = opts.readingOrder === 2 || segmentsHaveRtl([{ text: t }]);
-    return { needBidi, baseRtl: needBidi && cellBaseRtl(opts.readingOrder, t) };
-  });
+  const paraBidi = paraTexts.map((t) => resolveCellBidi(opts.readingOrder, t));
   for (const line of rLines) {
     const totalW = line.segments.reduce((s, seg) => s + seg.width, 0);
     let xx: number;

--- a/packages/xlsx/src/wrap-rich-text-context-bidi.test.ts
+++ b/packages/xlsx/src/wrap-rich-text-context-bidi.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { drawWrappedRichText, layoutRichTextLines } from './renderer.js';
+import { computeLineVisualOrder } from './bidi-line.js';
+import type { CellFont, Run } from './types.js';
+import type { RichCellGeom } from './renderer.js';
+
+// ECMA-376 §18.8.1 readingOrder: 0/absent = Context → UAX#9 first-strong (P1–P3).
+// A soft wrap does NOT start a new bidi paragraph, so all soft-wrapped display
+// lines of one logical paragraph share a base direction. But a HARD break (LF /
+// Alt+Enter, preserved in the run text per §18.4.12 t @xml:space) DOES start a
+// new paragraph — under Context reading order each LF-delimited paragraph must
+// resolve its OWN base direction from its OWN first strong character.
+//
+// `drawWrappedRichText` used to resolve ONE cell-wide first-strong direction over
+// the whole joined run text and apply it to every LF paragraph, so a wrapped cell
+// whose paragraph 1 is LTR-first and paragraph 2 is RTL-first rendered paragraph 2
+// under the wrong (paragraph-1) base direction. The non-wrap hard-break path
+// (`drawMultiLineRichText` → `drawRichLine`) already resolves per LF line; this
+// covers the wrap path.
+
+const BASE: CellFont = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  size: 11,
+  color: null,
+  name: null,
+};
+
+interface FillTextCall { text: string; x: number; y: number; }
+
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; calls: FillTextCall[] } {
+  let font = '11px sans-serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText(text: string, x: number, y: number) { calls.push({ text, x, y }); },
+    save() {}, restore() {}, beginPath() {}, moveTo() {}, lineTo() {}, stroke() {},
+    fillStyle: '#000' as string,
+    strokeStyle: '#000' as string,
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as 'ltr' | 'rtl',
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+// A very wide cell so nothing soft-wraps — only the explicit LF splits paragraphs.
+const WIDE = 100000;
+function geom(): RichCellGeom {
+  return { alignH: 'left', alignV: 'top', cx: 0, cy: 0, cellW: WIDE, cellH: 1000, leftPad: 0, paddingX: 0, paddingY: 0 };
+}
+
+/** The texts painted on each distinct display line (a line per distinct y), in
+ *  paint (= visual, left-to-right) order. */
+function linesByY(calls: FillTextCall[]): { y: number; texts: string[] }[] {
+  const ys = [...new Set(calls.map((c) => c.y))].sort((a, b) => a - b);
+  return ys.map((y) => ({ y, texts: calls.filter((c) => c.y === y).map((c) => c.text) }));
+}
+
+/** The segments `drawWrappedRichText` lays out for a single-paragraph value,
+ *  using the same tokenizer/widths so segment identity matches the draw path. */
+function segmentsOf(text: string): { text: string }[] {
+  const { ctx } = makeRecordingCtx();
+  return layoutRichTextLines(ctx, [{ text }] as Run[], BASE, 1, WIDE).flatMap((l) => l.segments);
+}
+
+describe('drawWrappedRichText — Context base direction is per LF paragraph (§18.8.1 / UAX#9 P1–P3)', () => {
+  it('paragraph 2 (RTL-first) is ordered under its OWN base, not paragraph 1’s (LTR)', () => {
+    const P1 = 'ab';           // LTR first-strong
+    const P2 = 'שלום abc';      // RTL first-strong, mixed RTL + LTR
+    const runs: Run[] = [{ text: `${P1}\n${P2}` }];
+
+    const { ctx, calls } = makeRecordingCtx();
+    // readingOrder undefined = Context (first-strong per paragraph).
+    drawWrappedRichText(ctx, runs, BASE, geom(), 1, 1, {});
+
+    const lines = linesByY(calls);
+    expect(lines).toHaveLength(2);
+    expect(lines[0].texts).toEqual([P1]); // paragraph 1 unchanged
+
+    const p2segs = segmentsOf(P2);
+    const ownRtl = computeLineVisualOrder(p2segs, true);   // P2’s own base (Hebrew first-strong → RTL)
+    const cellLtr = computeLineVisualOrder(p2segs, false); // the bug: cell-wide base from P1 → LTR
+    // Precondition: this input actually exercises the bug (the two orders differ).
+    expect(ownRtl.order).not.toEqual(cellLtr.order);
+
+    const expected = ownRtl.order.map((i) => p2segs[i].text);
+    expect(lines[1].texts).toEqual(expected);
+  });
+
+  it('a single paragraph (no hard break) still uses its first-strong base — unchanged', () => {
+    const P = 'שלום abc'; // one paragraph: cell-wide == per-paragraph
+    const { ctx, calls } = makeRecordingCtx();
+    drawWrappedRichText(ctx, [{ text: P }], BASE, geom(), 1, 1, {});
+
+    const lines = linesByY(calls);
+    expect(lines).toHaveLength(1);
+    const segs = segmentsOf(P);
+    const expected = computeLineVisualOrder(segs, true).order.map((i) => segs[i].text);
+    expect(lines[0].texts).toEqual(expected);
+  });
+
+  it('preserves a blank line between paragraphs in the drawn vertical advance', () => {
+    // Control: "A\nB" advances one line height between A and B.
+    const ctrl = makeRecordingCtx();
+    drawWrappedRichText(ctrl.ctx, [{ text: 'A\nB' }], BASE, geom(), 1, 1, {});
+    const cl = linesByY(ctrl.calls);
+    expect(cl.map((l) => l.texts)).toEqual([['A'], ['B']]);
+    const oneGap = cl[1].y - cl[0].y;
+
+    // Subject: "A\n\nB" — the blank middle line paints nothing but still reserves
+    // one line height, so B sits two line heights below A.
+    const subj = makeRecordingCtx();
+    drawWrappedRichText(subj.ctx, [{ text: 'A\n\nB' }], BASE, geom(), 1, 1, {});
+    const sl = linesByY(subj.calls);
+    expect(sl.map((l) => l.texts)).toEqual([['A'], ['B']]); // only 2 painted lines
+    expect(sl[1].y - sl[0].y).toBeCloseTo(2 * oneGap, 5);
+  });
+});


### PR DESCRIPTION
## Problem

`drawWrappedRichText` (the WRAP rich-text draw helper) computed the bidi base direction **once for the whole cell**:

```ts
const baseRtl = needBidi && cellBaseRtl(opts.readingOrder, runs.map((r) => r.text).join(''));
```

For soft-wrapped display lines that is correct — UAX#9: a soft wrap does **not** start a new bidi paragraph, so all display lines of one paragraph share a base direction.

But a cell can be **both** `wrapText` **and** contain hard breaks (Alt+Enter `LF`). `LF` (U+000A) is Unicode bidi class **B (paragraph separator)**, so each LF-delimited region is a separate bidi paragraph. Under `readingOrder=0` (Context / first-strong, ECMA-376 §18.8.1) each paragraph should resolve its **own** base direction from its **own** first strong character (UAX#9 P1–P3). The single cell-wide first-strong direction meant a wrapped cell whose paragraph 1 starts LTR and paragraph 2 starts with a strong-RTL char (Hebrew/Arabic) rendered **paragraph 2 under the wrong base direction**.

The non-wrap hard-break path (`drawMultiLineRichText` → `drawRichLine`) already resolves base direction per LF line; this aligns the wrap path with it.

Pre-existing; surfaced during independent review of #587 (which refactored the inline wrap loop into `drawWrappedRichText` without changing the computation).

## Fix

- `layoutRichTextLines` now tags each `RichLine` with its **LF-paragraph index** (`para`), which advances only at a hard break — soft-wrapped continuation lines keep their paragraph's index. All existing layout / blank-line / kinsoku / height behaviour is untouched.
- `drawWrappedRichText` resolves the base direction **per LF paragraph** from that paragraph's own text and indexes it by `line.para`. Explicit LTR/RTL (`readingOrder` 1/2) stays cell-wide; only Context (0/absent) varies between paragraphs. The pure-LTR gate is preserved per paragraph.

## Tests

- New `wrap-rich-text-context-bidi.test.ts` (mock-context unit test — the real guard, since this niche mixed-direction multi-paragraph case is not exercised by VRT):
  - paragraph 2 (RTL-first) is ordered under its **own** RTL base, not paragraph 1's LTR base (the bug, with a precondition asserting the two orders actually differ);
  - a single-paragraph mixed cell still uses its first-strong base (unchanged);
  - a blank line between paragraphs is still preserved in the drawn vertical advance.
- Full xlsx unit suite: **162 passed**.
- xlsx VRT: **67 passed, 0 failed** (1 pre-existing skip), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)