### PR TITLE
fix(docx): share list counters per abstractNum + honor startOverride restart

### DIFF
--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -2,7 +2,7 @@ use crate::styles::{parse_run_fmt, RunFmt};
 use crate::xml_util::*;
 use ooxml_common::blip::mime_from_ext;
 use roxmltree::Document as XmlDoc;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Parse a single VML CSS length (e.g. `width:9pt`) from a `style` attribute
 /// into pt. Supports the units Word emits for picture-bullet shapes: `pt`
@@ -115,8 +115,20 @@ pub struct NumberingMap {
     num_to_abstract: HashMap<u32, u32>,
     /// numId → level override starts
     num_overrides: HashMap<u32, HashMap<u32, u32>>,
-    /// per-numId per-level counter
+    /// per-**abstractNumId** per-level counter. ECMA-376 §17.9: the running
+    /// count belongs to the abstract numbering definition, so every `<w:num>`
+    /// (numId) that references the same `<w:abstractNum>` shares one counter —
+    /// that is how Word's "continue previous list" works and how a restart on
+    /// one numId carries into the next (sample-13's masthead: numId=30 with a
+    /// `<w:startOverride>` restarts abstractNumId 20 to 1, then the body's
+    /// numId=6 — same abstract — continues 2, 3, 4 rather than resuming its own
+    /// page-1 tail at 5, 6, 7).
     pub counters: HashMap<u32, HashMap<u32, u32>>,
+    /// (numId, level) pairs already advanced at least once. A numId carrying a
+    /// `<w:lvlOverride><w:startOverride>` restarts the shared abstract counter
+    /// only on its FIRST appearance at that level (§17.9.6 / §17.9.7); afterward
+    /// it increments the shared counter like any other num on the abstract.
+    started: HashSet<(u32, u32)>,
 }
 
 impl NumberingMap {
@@ -303,39 +315,66 @@ impl NumberingMap {
         self.get_level(num_id, level).map(|l| l.start).unwrap_or(1)
     }
 
-    /// Advance counter for (numId, level), resetting deeper levels.
+    /// Advance the counter for (numId, level), resetting deeper levels.
     ///
-    /// `counters` stores each level's CURRENT displayed value (not the next):
-    /// a level's first appearance shows its `start`, each later advance adds
-    /// one, and advancing a level clears all deeper levels (§17.9.25 default
-    /// `lvlRestart`). Shallower levels are seeded to their `start` so an
-    /// ancestor that only prefixes the marker (e.g. `%1.%2`) still resolves
-    /// when it is never advanced on its own. Returns the value to display.
+    /// The counter is keyed by the numId's **abstractNumId**, so all numIds that
+    /// share an abstract definition advance one running count (§17.9 — see the
+    /// `counters` field doc). Each level stores its CURRENT displayed value (not
+    /// the next): a level's first appearance shows its `start`, each later
+    /// advance adds one, and advancing a level clears all deeper levels (§17.9.25
+    /// default `lvlRestart`). Shallower levels are seeded to their `start` so an
+    /// ancestor that only prefixes the marker (e.g. `%1.%2`) still resolves when
+    /// it is never advanced on its own.
+    ///
+    /// A numId whose `<w:lvlOverride>` carries a `<w:startOverride>` for this
+    /// level RESTARTS the shared abstract counter to the override value on its
+    /// first appearance at that level (§17.9.6 / §17.9.7), then increments
+    /// normally. Returns the value to display.
     pub fn advance(&mut self, num_id: u32, level: u32) -> u32 {
-        // Pre-compute start values to avoid borrow conflicts
+        // Pre-compute start values to avoid borrow conflicts. `get_start`
+        // already folds in any per-numId `<w:startOverride>` for the level.
         let starts: Vec<u32> = (0..=level).map(|l| self.get_start(num_id, l)).collect();
+        let abstract_id = self.abstract_of(num_id);
+        let has_override = self
+            .num_overrides
+            .get(&num_id)
+            .is_some_and(|m| m.contains_key(&level));
+        // `insert` returns true when the pair was NOT already present.
+        let first_for_num = self.started.insert((num_id, level));
 
-        let entry = self.counters.entry(num_id).or_default();
+        let entry = self.counters.entry(abstract_id).or_default();
 
-        // Reset deeper levels
+        // Reset deeper levels (§17.9.25 default lvlRestart).
         let keys: Vec<u32> = entry.keys().copied().filter(|&l| l > level).collect();
         for k in keys {
             entry.remove(&k);
         }
 
         // Seed shallower levels to their start (their displayed value when they
-        // are never advanced themselves).
+        // are never advanced themselves) — but never clobber a live ancestor.
         for (lvl, &start) in starts.iter().enumerate().take(level as usize) {
             entry.entry(lvl as u32).or_insert(start);
         }
 
-        // Current level: first appearance shows start, otherwise increment.
-        let val = match entry.get(&level) {
-            Some(&v) => v + 1,
-            None => starts[level as usize],
+        // A startOverride restarts the shared counter on first use of this num;
+        // otherwise the level shows `start` on its first appearance on the
+        // abstract and increments thereafter.
+        let val = if first_for_num && has_override {
+            starts[level as usize]
+        } else {
+            match entry.get(&level) {
+                Some(&v) => v + 1,
+                None => starts[level as usize],
+            }
         };
         entry.insert(level, val);
         val
+    }
+
+    /// The abstractNumId a numId resolves to, falling back to the numId itself
+    /// when the `<w:num>` is unknown (keeps an orphan num self-consistent).
+    fn abstract_of(&self, num_id: u32) -> u32 {
+        self.num_to_abstract.get(&num_id).copied().unwrap_or(num_id)
     }
 
     /// Resolve the display text for a counter value in the given level.
@@ -353,6 +392,7 @@ impl NumberingMap {
         let Some(lvl) = self.get_level(num_id, level) else {
             return format!("{}.", counter);
         };
+        let abstract_id = self.abstract_of(num_id);
 
         let mut text = lvl.text.clone();
         // Replace from the deepest placeholder down so "%1" can never partially
@@ -363,7 +403,7 @@ impl NumberingMap {
                 counter
             } else {
                 self.counters
-                    .get(&num_id)
+                    .get(&abstract_id)
                     .and_then(|m| m.get(&k))
                     .copied()
                     .unwrap_or_else(|| self.get_start(num_id, k))
@@ -641,5 +681,52 @@ mod tests {
         m.advance(2, 0);
         let c = m.advance(2, 1);
         assert_eq!(m.resolve_text(2, 1, c), "A.1");
+    }
+
+    /// §17.9 — two numIds that reference the SAME abstractNum share one running
+    /// counter. sample-13's masthead: the article body numbers headings with
+    /// numId=6 (1..4), then a section restarts via numId=30 (same abstract 20,
+    /// a `<w:startOverride w:val="1"/>`) and the body resumes with numId=6. Word
+    /// shows 1, 2, 3, 4 across the restart — NOT 5, 6, 7 — because the count is
+    /// owned by abstract 20, not by each numId.
+    #[test]
+    fn shared_abstract_counter_restarts_on_start_override() {
+        let mut m = map(r#"<w:abstractNum w:abstractNumId="20">
+                 <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+               </w:abstractNum>
+               <w:num w:numId="6"><w:abstractNumId w:val="20"/></w:num>
+               <w:num w:numId="30"><w:abstractNumId w:val="20"/>
+                 <w:lvlOverride w:ilvl="0"><w:startOverride w:val="1"/></w:lvlOverride>
+               </w:num>"#);
+        // Article body (numId=6): 1, 2, 3, 4.
+        for expected in ["1.", "2.", "3.", "4."] {
+            let c = m.advance(6, 0);
+            assert_eq!(m.resolve_text(6, 0, c), expected);
+        }
+        // Masthead heading restarts the shared abstract counter to 1 (numId=30).
+        let c = m.advance(30, 0);
+        assert_eq!(m.resolve_text(30, 0, c), "1.");
+        // Body resumes with numId=6 — continues the restarted count: 2, 3, 4.
+        for expected in ["2.", "3.", "4."] {
+            let c = m.advance(6, 0);
+            assert_eq!(m.resolve_text(6, 0, c), expected);
+        }
+    }
+
+    /// A bare `<w:num>` with no override but sharing an abstract with another
+    /// num continues the shared count (no accidental per-numId restart).
+    #[test]
+    fn shared_abstract_counter_continues_across_numids() {
+        let mut m = map(r#"<w:abstractNum w:abstractNumId="7">
+                 <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+               </w:abstractNum>
+               <w:num w:numId="1"><w:abstractNumId w:val="7"/></w:num>
+               <w:num w:numId="2"><w:abstractNumId w:val="7"/></w:num>"#);
+        let a = m.advance(1, 0);
+        assert_eq!(m.resolve_text(1, 0, a), "1.");
+        let b = m.advance(2, 0); // different numId, same abstract ⇒ continues
+        assert_eq!(m.resolve_text(2, 0, b), "2.");
+        let c = m.advance(1, 0);
+        assert_eq!(m.resolve_text(1, 0, c), "3.");
     }
 }

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -107,6 +107,18 @@ impl Default for LevelDef {
     }
 }
 
+/// Key into the running-counter map. numId values and abstractNumId values are
+/// independent ID sequences in WordprocessingML (§17.9.2 / §17.9.5), so they
+/// must NOT share a `u32` key space: a dangling numId (no `<w:num>`) that
+/// happens to equal a real abstractNumId would otherwise hijack that abstract's
+/// live count. `Abstract` holds the shared count for a resolved num; `OrphanNum`
+/// gives an unresolved num its own disjoint counter.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum CounterKey {
+    Abstract(u32),
+    OrphanNum(u32),
+}
+
 #[derive(Default)]
 pub struct NumberingMap {
     /// abstractNumId → [level0..level8]
@@ -122,8 +134,9 @@ pub struct NumberingMap {
     /// one numId carries into the next (sample-13's masthead: numId=30 with a
     /// `<w:startOverride>` restarts abstractNumId 20 to 1, then the body's
     /// numId=6 — same abstract — continues 2, 3, 4 rather than resuming its own
-    /// page-1 tail at 5, 6, 7).
-    pub counters: HashMap<u32, HashMap<u32, u32>>,
+    /// page-1 tail at 5, 6, 7). Keyed by `CounterKey` so an unresolved numId
+    /// gets a disjoint counter instead of colliding with an abstractNumId.
+    counters: HashMap<CounterKey, HashMap<u32, u32>>,
     /// (numId, level) pairs already advanced at least once. A numId carrying a
     /// `<w:lvlOverride><w:startOverride>` restarts the shared abstract counter
     /// only on its FIRST appearance at that level (§17.9.6 / §17.9.7); afterward
@@ -334,7 +347,7 @@ impl NumberingMap {
         // Pre-compute start values to avoid borrow conflicts. `get_start`
         // already folds in any per-numId `<w:startOverride>` for the level.
         let starts: Vec<u32> = (0..=level).map(|l| self.get_start(num_id, l)).collect();
-        let abstract_id = self.abstract_of(num_id);
+        let key = self.counter_key(num_id);
         let has_override = self
             .num_overrides
             .get(&num_id)
@@ -342,7 +355,7 @@ impl NumberingMap {
         // `insert` returns true when the pair was NOT already present.
         let first_for_num = self.started.insert((num_id, level));
 
-        let entry = self.counters.entry(abstract_id).or_default();
+        let entry = self.counters.entry(key).or_default();
 
         // Reset deeper levels (§17.9.25 default lvlRestart).
         let keys: Vec<u32> = entry.keys().copied().filter(|&l| l > level).collect();
@@ -371,10 +384,15 @@ impl NumberingMap {
         val
     }
 
-    /// The abstractNumId a numId resolves to, falling back to the numId itself
-    /// when the `<w:num>` is unknown (keeps an orphan num self-consistent).
-    fn abstract_of(&self, num_id: u32) -> u32 {
-        self.num_to_abstract.get(&num_id).copied().unwrap_or(num_id)
+    /// The counter-map key for a numId: the shared `Abstract(abstractNumId)`
+    /// when the `<w:num>` resolves, else an `OrphanNum(numId)` in a disjoint key
+    /// space so a dangling numId can never collide with a real abstractNumId's
+    /// running counter.
+    fn counter_key(&self, num_id: u32) -> CounterKey {
+        match self.num_to_abstract.get(&num_id) {
+            Some(&abs) => CounterKey::Abstract(abs),
+            None => CounterKey::OrphanNum(num_id),
+        }
     }
 
     /// Resolve the display text for a counter value in the given level.
@@ -392,7 +410,7 @@ impl NumberingMap {
         let Some(lvl) = self.get_level(num_id, level) else {
             return format!("{}.", counter);
         };
-        let abstract_id = self.abstract_of(num_id);
+        let key = self.counter_key(num_id);
 
         let mut text = lvl.text.clone();
         // Replace from the deepest placeholder down so "%1" can never partially
@@ -403,7 +421,7 @@ impl NumberingMap {
                 counter
             } else {
                 self.counters
-                    .get(&abstract_id)
+                    .get(&key)
                     .and_then(|m| m.get(&k))
                     .copied()
                     .unwrap_or_else(|| self.get_start(num_id, k))
@@ -728,5 +746,23 @@ mod tests {
         assert_eq!(m.resolve_text(2, 0, b), "2.");
         let c = m.advance(1, 0);
         assert_eq!(m.resolve_text(1, 0, c), "3.");
+    }
+
+    /// A dangling numId (no `<w:num>`) whose value equals a live abstractNumId
+    /// must NOT hijack that abstract's running counter — numId and abstractNumId
+    /// are independent ID spaces (§17.9.2 / §17.9.5). Here abstractNumId 4 is
+    /// referenced by numId 5; a paragraph then references the unmapped numId 4.
+    #[test]
+    fn orphan_numid_equal_to_abstract_id_keeps_disjoint_counter() {
+        let mut m = map(r#"<w:abstractNum w:abstractNumId="4">
+                 <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+               </w:abstractNum>
+               <w:num w:numId="5"><w:abstractNumId w:val="4"/></w:num>"#);
+        let a = m.advance(5, 0);
+        assert_eq!(m.resolve_text(5, 0, a), "1.");
+        // numId 4 has no <w:num>; it must start its own count at 1, not read
+        // abstractNumId 4's counter (which would yield 2).
+        let b = m.advance(4, 0);
+        assert_eq!(m.resolve_text(4, 0, b), "1.");
     }
 }


### PR DESCRIPTION
## Problem

On sample-13 page 2, the right-column heading numbered **6.** where Word shows **3.** (and the left column showed 1, 5, … instead of 1, 2, …). Headings continued the page-1 article sequence instead of the masthead section's own 1, 2, 3, 4.

## Root cause

ECMA-376 §17.9 tracks the running count on the **abstract numbering definition**, not on each `<w:num>`. Multiple `numId`s that reference the same `abstractNumId` share one counter — that is how Word continues a list across a restart, and how a `<w:lvlOverride><w:startOverride>` on one numId carries into the next.

Our `NumberingMap.counters` was keyed by **numId**, so numIds sharing an abstract counted independently:

- sample-13 article body: `numId=6` → abstractNumId 20 → headings 1..4 (page 1).
- masthead heading: `numId=30` → **same abstractNumId 20**, with `<w:startOverride w:val="1"/>` on every level → "1.".
- masthead body resumes `numId=6` → Word: 2, 3, 4 — we produced 5, 6, 7 (numId=6 resumed its own page-1 tail) and numId=30 counted alone as 1.

## Fix

- Key `counters` by **abstractNumId** so all numIds on an abstract share the running count.
- On a numId's **first appearance** at a level, if it carries a `startOverride`, restart the shared counter to the override value (§17.9.6 / §17.9.7); otherwise show the level `start` on first use and increment thereafter.
- `resolve_text` reads ancestor counters by abstractNumId too.

Result on sample-13: article 1, 2, 3, 4 (page 1); masthead 1, 2, 3, 4 (page 2) — matches Word's PDF (Abbreviations = 1, Identify the headings = 3).

## Cross-format

WordprocessingML-specific (§17.9). pptx `a:buAutoNum` is per-shape autonumbering and xlsx has no list numbering, so there is no shared abstract-list counter to unify — nothing moves to `core` / `ooxml-common`.

## Tests

- New unit tests in `numbering.rs`: `shared_abstract_counter_restarts_on_start_override` (the sample-13 masthead 1,2,3,4 across a numId=30 restart) and `shared_abstract_counter_continues_across_numids`.
- All existing numbering tests green (28 passed); docx unit suite green (274 passed); fmt + clippy clean.
- Verified end-to-end with a headless skia render of sample-13 page 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)