### PR TITLE
feat(docx): per-section headers/footers + titlePage

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -21,10 +21,53 @@ type Zip<'a> = ZipArchive<std::io::Cursor<&'a [u8]>>;
 
 /// Section-level header/footer references collected from sectPr.
 /// Maps reference type ("default" | "first" | "even") to the target xml path (e.g. "header1.xml").
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct SectionRefs {
     headers: HashMap<String, String>,
     footers: HashMap<String, String>,
+}
+
+/// A section's effective header/footer set + its own `<w:titlePg>` flag, ready to
+/// stamp on the `SectionBreak` marker that ends that section. Loaded from the
+/// package zip after `resolve_section_refs` computes each section's inherited
+/// reference snapshot (ECMA-376 §17.10.1).
+#[derive(Default, Clone)]
+struct ResolvedSectionHf {
+    headers: HeadersFooters,
+    footers: HeadersFooters,
+    title_page: bool,
+}
+
+/// ECMA-376 §17.10.1 — resolve each section's EFFECTIVE header/footer references
+/// with inheritance preserved. Walks every `<w:sectPr>` in `body_node` in
+/// document order (mid-body sectPrs in pPr / loose, then the body-level one last),
+/// maintaining a running `SectionRefs`: for each section it merges THAT section's
+/// own references onto the running state (so a section that omits a reference of a
+/// given type inherits the previous section's — e.g. sample-12's running header
+/// declared only on the first section), then SNAPSHOTS the running state as that
+/// section's effective set.
+///
+/// `<w:titlePg>` is NOT inherited: each snapshot carries its own sectPr's flag.
+///
+/// Returns one `(NodeId, SectionRefs, title_page)` per sectPr, keyed by the sectPr
+/// node id so `parse_body_elements` can attach the resolved set to the matching
+/// `SectionBreak` marker (and `parse()` resolve the body-level one for
+/// `Document.headers/footers`).
+fn resolve_section_refs(
+    body_node: roxmltree::Node,
+    rel_map: &HashMap<String, String>,
+) -> Vec<(roxmltree::NodeId, SectionRefs, bool)> {
+    let mut running = SectionRefs::default();
+    let mut out = Vec::new();
+    for sp in body_node
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "sectPr")
+    {
+        merge_section_refs(sp, rel_map, &mut running);
+        let title_page = child_w(sp, "titlePg").is_some();
+        out.push((sp.id(), running.clone(), title_page));
+    }
+    out
 }
 
 pub fn parse(data: &[u8]) -> Result<Document, String> {
@@ -145,20 +188,54 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
 
     let (section, _body_refs) = parse_section(sect_pr, &rel_map);
 
-    // ECMA-376 §17.10.1 — header/footer references inherit across sections: a
-    // section that omits a reference of a given type uses the previous section's.
-    // The single-section render model (#513) drives one effective header/footer
-    // set, so accumulate references from EVERY sectPr in document order (the body
-    // sectPr last ⇒ it wins for types it specifies, earlier sections fill the
-    // rest). Without this, a header declared only on the first section's sectPr
-    // (e.g. sample-12's running "Journal of …" header) is dropped because the
-    // body-level sectPr carries no reference.
-    let mut refs = SectionRefs::default();
-    for sp in body_node
-        .descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "sectPr")
-    {
-        merge_section_refs(sp, &rel_map, &mut refs);
+    // ECMA-376 §17.10.1 — header/footer references inherit across sections, but
+    // each section keeps its OWN effective set (a "first" footer declared on the
+    // title section must not be overwritten by a later section's "first" footer).
+    // Resolve every section's inherited reference snapshot in document order, then
+    // load each from the package. The body-level (last) sectPr's snapshot drives
+    // `Document.headers/footers`; every non-final section's snapshot is stamped on
+    // its `SectionBreak` marker (in `parse_body_elements`) so the renderer can pick
+    // the active section's header/footer per page. (The previous single global
+    // accumulation collapsed all sections into one set, dropping section 0's
+    // first-page footer — e.g. sample-13's "DOI: …" line — and its titlePg flag.)
+    let section_snapshots = resolve_section_refs(body_node, &rel_map);
+    let body_level_sect_id = sect_pr.map(|n| n.id());
+
+    // Load each section's snapshot into a per-node resolved set. The body-level
+    // sectPr's resolved set is held out for Document.headers/footers.
+    let mut section_hf: HashMap<roxmltree::NodeId, ResolvedSectionHf> = HashMap::new();
+    let mut body_headers = HeadersFooters::default();
+    let mut body_footers = HeadersFooters::default();
+    for (node_id, refs, title_page) in &section_snapshots {
+        let headers = load_header_footer_set(
+            &mut zip,
+            &refs.headers,
+            "hdr",
+            &style_map,
+            &mut num_map,
+            &theme,
+        );
+        let footers = load_header_footer_set(
+            &mut zip,
+            &refs.footers,
+            "ftr",
+            &style_map,
+            &mut num_map,
+            &theme,
+        );
+        if Some(*node_id) == body_level_sect_id {
+            body_headers = headers;
+            body_footers = footers;
+        } else {
+            section_hf.insert(
+                *node_id,
+                ResolvedSectionHf {
+                    headers,
+                    footers,
+                    title_page: *title_page,
+                },
+            );
+        }
     }
 
     let body = parse_body_elements(
@@ -168,24 +245,11 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
         &media_map,
         &rel_map,
         &theme,
+        &section_hf,
     );
 
-    let headers = load_header_footer_set(
-        &mut zip,
-        &refs.headers,
-        "hdr",
-        &style_map,
-        &mut num_map,
-        &theme,
-    );
-    let footers = load_header_footer_set(
-        &mut zip,
-        &refs.footers,
-        "ftr",
-        &style_map,
-        &mut num_map,
-        &theme,
-    );
+    let headers = body_headers;
+    let footers = body_footers;
 
     let major_font = theme.theme_font("major", "latin");
     let minor_font = theme.theme_font("minor", "latin");
@@ -413,6 +477,7 @@ fn parse_notes(
         if id.is_empty() || id == "-1" || id == "0" || is_special {
             continue;
         }
+        // Footnote/endnote bodies carry no nested sections; pass an empty map.
         let content = parse_body_elements(
             n,
             style_map,
@@ -420,6 +485,7 @@ fn parse_notes(
             &local_media_map,
             &local_rel_map,
             theme,
+            &HashMap::new(),
         );
         out.push(crate::types::DocxNote { id, content });
     }
@@ -792,6 +858,7 @@ fn body_children_with_cover_breaks<'a, 'input>(
     out
 }
 
+#[allow(clippy::too_many_arguments)]
 fn parse_body_elements(
     body_node: roxmltree::Node,
     style_map: &StyleMap,
@@ -799,6 +866,7 @@ fn parse_body_elements(
     media_map: &HashMap<String, String>,
     rel_map: &HashMap<String, String>,
     theme: &ThemeColors,
+    section_hf: &HashMap<roxmltree::NodeId, ResolvedSectionHf>,
 ) -> Vec<BodyElement> {
     let mut body: Vec<BodyElement> = Vec::new();
     // The body-level sectPr (the last element) defines the final section and
@@ -879,7 +947,7 @@ fn parse_body_elements(
                         if let Some(sect_pr) =
                             child_w(child, "pPr").and_then(|ppr| child_w(ppr, "sectPr"))
                         {
-                            body.push(section_break_element(sect_pr));
+                            body.push(section_break_element(sect_pr, section_hf));
                         }
                     }
                 }
@@ -893,7 +961,7 @@ fn parse_body_elements(
             // pPr-nested case above). The final body-level sectPr only defines
             // section settings (surfaced on Document.section) — skip it.
             "sectPr" if Some(child.id()) != body_level_sect_id => {
-                body.push(section_break_element(child));
+                body.push(section_break_element(child, section_hf));
             }
             _ => {}
         }
@@ -1120,7 +1188,10 @@ fn read_section_break_type(sect_pr: roxmltree::Node) -> Option<String> {
 /// come from `<w:br w:type="column"/>` ⇒ `ColumnBreak`); the renderer would
 /// otherwise have no defined column geometry to advance into across a section
 /// boundary.
-fn section_break_element(sect_pr: roxmltree::Node) -> BodyElement {
+fn section_break_element(
+    sect_pr: roxmltree::Node,
+    section_hf: &HashMap<roxmltree::NodeId, ResolvedSectionHf>,
+) -> BodyElement {
     let kind = match read_section_break_type(sect_pr).as_deref() {
         Some("continuous") => "continuous",
         Some("oddPage") => "oddPage",
@@ -1128,9 +1199,16 @@ fn section_break_element(sect_pr: roxmltree::Node) -> BodyElement {
         _ => "nextPage",
     }
     .to_string();
+    // ECMA-376 §17.10.1 — the resolved (inherited) header/footer set for this
+    // ending section + its own titlePg flag, pre-loaded in `parse()`. Empty when
+    // unavailable (e.g. the `body_from` test harness has no package to load from).
+    let resolved = section_hf.get(&sect_pr.id()).cloned().unwrap_or_default();
     BodyElement::SectionBreak {
         kind,
         columns: parse_columns(sect_pr),
+        headers: resolved.headers,
+        footers: resolved.footers,
+        title_page: resolved.title_page,
     }
 }
 
@@ -1199,6 +1277,9 @@ fn load_header_footer_set(
             continue;
         };
 
+        // Header/footer bodies carry no nested sections, so pass an empty
+        // section-resolution map (any stray sectPr would only produce an empty
+        // resolved set, never recursing into header loading).
         let body = parse_body_elements(
             root,
             style_map,
@@ -1206,6 +1287,7 @@ fn load_header_footer_set(
             &local_media_map,
             &local_rel_map,
             theme,
+            &HashMap::new(),
         );
         let hf = HeaderFooter { body };
         match kind.as_str() {
@@ -5725,6 +5807,7 @@ mod tests {
             &media,
             &rels,
             &theme,
+            &HashMap::new(),
         );
         let texts: Vec<&TextRun> = elems
             .iter()
@@ -6350,6 +6433,7 @@ mod cs_toggle_tests {
             &HashMap::new(),
             &HashMap::new(),
             &ThemeColors::default(),
+            &HashMap::new(),
         );
         for e in elems {
             if let BodyElement::Paragraph(p) = e {
@@ -6403,6 +6487,7 @@ mod cs_toggle_tests {
             &HashMap::new(),
             &HashMap::new(),
             &ThemeColors::default(),
+            &HashMap::new(),
         );
         for e in elems {
             if let BodyElement::Paragraph(p) = e {
@@ -6590,6 +6675,7 @@ mod rtl_tests {
             &media_map,
             &rel_map,
             &theme,
+            &HashMap::new(),
         )
     }
 
@@ -7009,6 +7095,7 @@ mod footnote_tests {
             &HashMap::new(),
             &HashMap::new(),
             &ThemeColors::default(),
+            &HashMap::new(),
         );
         for e in elems {
             if let BodyElement::Paragraph(p) = e {
@@ -7781,6 +7868,7 @@ mod column_tests {
             &media_map,
             &rel_map,
             &theme,
+            &HashMap::new(),
         )
     }
 
@@ -8174,7 +8262,7 @@ mod column_tests {
         assert_eq!(body.len(), 2);
         assert!(matches!(body[0], BodyElement::Paragraph(_)));
         match &body[1] {
-            BodyElement::SectionBreak { kind, columns } => {
+            BodyElement::SectionBreak { kind, columns, .. } => {
                 assert_eq!(kind, "continuous");
                 let c = columns.as_ref().expect("num=3 ⇒ multi-column");
                 assert_eq!(c.count, 3);
@@ -8203,7 +8291,7 @@ mod column_tests {
         assert_eq!(body.len(), 3);
         assert!(matches!(body[0], BodyElement::Paragraph(_)));
         match &body[1] {
-            BodyElement::SectionBreak { kind, columns } => {
+            BodyElement::SectionBreak { kind, columns, .. } => {
                 assert_eq!(kind, "nextPage");
                 assert!(columns.is_none(), "single-column ⇒ None");
             }
@@ -8226,12 +8314,91 @@ mod column_tests {
         // sectPr skipped.
         assert_eq!(body.len(), 3);
         match &body[1] {
-            BodyElement::SectionBreak { kind, columns } => {
+            BodyElement::SectionBreak { kind, columns, .. } => {
                 assert_eq!(kind, "oddPage");
                 assert!(columns.is_none());
             }
             other => panic!("expected SectionBreak, got {other:?}"),
         }
+    }
+
+    /// ECMA-376 §17.10.1 — per-section header/footer references resolve with
+    /// INHERITANCE preserved: a section that omits a reference of a given type
+    /// keeps the previous section's, but a section that DECLARES its own value
+    /// overwrites only that type (and must not leak into the earlier section's
+    /// snapshot). `<w:titlePg>` is NOT inherited — each snapshot carries its own
+    /// sectPr's flag. This is the model that lets sample-13's title section keep
+    /// its `first` footer (the DOI line) while a later masthead section declares a
+    /// different `first` footer.
+    #[test]
+    fn resolve_section_refs_preserves_per_section_inheritance() {
+        // Section 0: first=footerA, default=footerD, titlePg.
+        // Section 1: first=footerB only (default inherits footerD; no titlePg).
+        let xml = format!(
+            r#"<w:document xmlns:w="{w}" xmlns:r="{r}"><w:body>
+                 <w:p><w:pPr><w:sectPr>
+                   <w:footerReference w:type="first" r:id="ridA"/>
+                   <w:footerReference w:type="default" r:id="ridD"/>
+                   <w:titlePg/>
+                 </w:sectPr></w:pPr></w:p>
+                 <w:p><w:r><w:t>body</w:t></w:r></w:p>
+                 <w:sectPr>
+                   <w:footerReference w:type="first" r:id="ridB"/>
+                 </w:sectPr>
+               </w:body></w:document>"#,
+            w = W_NS,
+            r = R_NS,
+        );
+        let doc = XmlDoc::parse(&xml).unwrap();
+        let body_node = doc
+            .root_element()
+            .descendants()
+            .find(|n| n.tag_name().name() == "body")
+            .unwrap();
+        let rel_map: HashMap<String, String> = [
+            ("ridA".to_string(), "footerA.xml".to_string()),
+            ("ridB".to_string(), "footerB.xml".to_string()),
+            ("ridD".to_string(), "footerD.xml".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        let snaps = resolve_section_refs(body_node, &rel_map);
+        assert_eq!(snaps.len(), 2, "two sections");
+
+        // Section 0 snapshot: first=footerA, default=footerD, titlePg=true.
+        let (_id0, refs0, tp0) = &snaps[0];
+        assert!(tp0, "section 0 declares <w:titlePg>");
+        assert_eq!(
+            refs0.footers.get("first").map(String::as_str),
+            Some("footerA.xml")
+        );
+        assert_eq!(
+            refs0.footers.get("default").map(String::as_str),
+            Some("footerD.xml")
+        );
+
+        // Section 1 (body-level) snapshot: first OVERWRITTEN to footerB; default
+        // INHERITED from section 0 (footerD); titlePg NOT inherited (false).
+        let (_id1, refs1, tp1) = &snaps[1];
+        assert!(!tp1, "section 1 has no <w:titlePg> — not inherited");
+        assert_eq!(
+            refs1.footers.get("first").map(String::as_str),
+            Some("footerB.xml"),
+            "section 1's own first reference wins"
+        );
+        assert_eq!(
+            refs1.footers.get("default").map(String::as_str),
+            Some("footerD.xml"),
+            "section 1 inherits section 0's default footer (§17.10.1)"
+        );
+
+        // Inheritance must not retroactively mutate section 0's snapshot.
+        assert_eq!(
+            refs0.footers.get("first").map(String::as_str),
+            Some("footerA.xml"),
+            "section 0 keeps its own first footer (snapshot is independent)"
+        );
     }
 }
 
@@ -8611,6 +8778,7 @@ mod numbering_marker_font_tests {
             &HashMap::new(),
             &HashMap::new(),
             &ThemeColors::default(),
+            &HashMap::new(),
         );
         elems
             .into_iter()
@@ -8699,6 +8867,7 @@ mod numbering_marker_font_tests {
             &HashMap::new(),
             &HashMap::new(),
             &ThemeColors::default(),
+            &HashMap::new(),
         );
         let para = elems
             .into_iter()

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -47,7 +47,8 @@ struct ResolvedSectionHf {
 /// declared only on the first section), then SNAPSHOTS the running state as that
 /// section's effective set.
 ///
-/// `<w:titlePg>` is NOT inherited: each snapshot carries its own sectPr's flag.
+/// `<w:titlePg>` (§17.10.6) is NOT inherited: each snapshot carries its own
+/// sectPr's flag (only the header/footer references inherit, §17.10.1).
 ///
 /// Returns one `(NodeId, SectionRefs, title_page)` per sectPr, keyed by the sectPr
 /// node id so `parse_body_elements` can attach the resolved set to the matching

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -270,6 +270,24 @@ pub enum BodyElement {
         /// full-width column.
         #[serde(skip_serializing_if = "Option::is_none")]
         columns: Option<ColumnsSpec>,
+        /// ECMA-376 §17.10.1 — the resolved header set for the section that ENDS
+        /// at this marker (its own `<w:headerReference>`s layered onto the
+        /// inherited running state, then loaded from the package). Lets the
+        /// renderer pick the active section's header per page, exactly as
+        /// `columns` lets it pick the section's column geometry. Empty when no
+        /// section in the inheritance chain declared a header.
+        #[serde(default)]
+        headers: HeadersFooters,
+        /// ECMA-376 §17.10.1 — the resolved footer set for the section that ENDS
+        /// at this marker (see `headers`). sample-13's first section declares a
+        /// `first` footer (the DOI line) here; the renderer renders it on that
+        /// section's first page.
+        #[serde(default)]
+        footers: HeadersFooters,
+        /// ECMA-376 §17.10.1 `<w:titlePg>` — whether THIS ending section has a
+        /// distinct first-page header/footer. NOT inherited (each sectPr's flag
+        /// stands alone, like the body-level `Document.section.title_page`).
+        title_page: bool,
     },
 }
 

--- a/packages/docx/src/per-section-headers-footers.test.ts
+++ b/packages/docx/src/per-section-headers-footers.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement, DocParagraph, DocxDocumentModel, SectionProps, HeaderFooter, HeadersFooters,
+} from './types';
+
+// ECMA-376 §17.10.1 — per-section headers/footers + titlePage. A `SectionBreak`
+// marker carries its ENDING section's resolved header/footer set + `<w:titlePg>`
+// flag; the body-level section's set lives on `doc.headers`/`doc.footers`/
+// `doc.section.titlePage`. The renderer must, per page, select the header/footer
+// of the section ACTIVE at that page's top, applying the §17.10.1 precedence
+// (first → even → default) with `first` keyed off the section's FIRST page (not
+// document page 0). This guards the sample-13 bug: the title section's first-page
+// footer (the DOI line) was dropped when a later section overwrote the global set.
+
+// A minimal canvas that records every fillText call so a test can assert which
+// header/footer text rendered on a given page. measureText returns a width
+// proportional to length so layout produces non-degenerate lines.
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; texts: string[] } {
+  let font = '10px serif';
+  const texts: string[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string) { texts.push(s); },
+    strokeText(s: string) { texts.push(s); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, texts };
+}
+
+function para(text: string): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 11, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 11, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function footer(text: string): HeaderFooter {
+  return { body: [para(text) as unknown as BodyElement] };
+}
+
+function hf(parts: Partial<HeadersFooters>): HeadersFooters {
+  return { default: null, first: null, even: null, ...parts };
+}
+
+// Two sections, each a full page of its own. Section A ends at a nextPage section
+// break carrying footerA (first + default) and titlePage=true. Section B is the
+// final (body-level) section with footerB as its default. With pageHeight tuned so
+// each paragraph fills exactly one page, page 0 belongs to section A, page 1 to B.
+function twoSectionDoc(): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 400, pageHeight: 120,
+    marginTop: 10, marginRight: 10, marginBottom: 30, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+  const body: BodyElement[] = [
+    para('SECTION_A_BODY') as unknown as BodyElement,
+    {
+      type: 'sectionBreak', kind: 'nextPage',
+      headers: hf({}),
+      footers: hf({ first: footer('FOOTER_A_FIRST'), default: footer('FOOTER_A_DEFAULT') }),
+      titlePage: true,
+    } as BodyElement,
+    para('SECTION_B_BODY') as unknown as BodyElement,
+  ];
+  return {
+    section,
+    body,
+    headers: hf({}),
+    // body-level (section B) default footer
+    footers: hf({ default: footer('FOOTER_B_DEFAULT') }),
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderPageTexts(doc: DocxDocumentModel, pageIndex: number): Promise<string[]> {
+  const { canvas, texts } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc, canvas, pageIndex, { dpr: 1, width: 400 });
+  return texts;
+}
+
+describe('per-section headers/footers (§17.10.1)', () => {
+  it('page 0 = section A first page → renders section A first-page footer', async () => {
+    const texts = await renderPageTexts(twoSectionDoc(), 0);
+    const joined = texts.join('|');
+    expect(joined).toContain('SECTION_A_BODY');
+    // titlePage on section A + page 0 is its first page ⇒ `first` footer.
+    expect(joined).toContain('FOOTER_A_FIRST');
+    expect(joined).not.toContain('FOOTER_A_DEFAULT');
+    // Section B's footer must NOT appear on page 0.
+    expect(joined).not.toContain('FOOTER_B_DEFAULT');
+  });
+
+  it('page 1 = section B → renders section B default footer, not section A footer', async () => {
+    const texts = await renderPageTexts(twoSectionDoc(), 1);
+    const joined = texts.join('|');
+    expect(joined).toContain('SECTION_B_BODY');
+    expect(joined).toContain('FOOTER_B_DEFAULT');
+    expect(joined).not.toContain('FOOTER_A_FIRST');
+    expect(joined).not.toContain('FOOTER_A_DEFAULT');
+  });
+
+  it('falls back to body-level footer for a single-section document (unchanged path)', async () => {
+    const section: SectionProps = {
+      pageWidth: 400, pageHeight: 200,
+      marginTop: 10, marginRight: 10, marginBottom: 30, marginLeft: 10,
+      headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const doc = {
+      section, body: [para('ONLY_BODY') as unknown as BodyElement],
+      headers: hf({}), footers: hf({ default: footer('GLOBAL_FOOTER') }),
+      fontFamilyClasses: { 'Times New Roman': 'roman' },
+    } as unknown as DocxDocumentModel;
+    const texts = await renderPageTexts(doc, 0);
+    const joined = texts.join('|');
+    expect(joined).toContain('ONLY_BODY');
+    expect(joined).toContain('GLOBAL_FOOTER');
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
-  DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun, HeaderFooter, LineSpacing, BorderSpec, TableBorders, CellBorders,
+  DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
@@ -688,14 +688,28 @@ export async function renderDocumentToCanvas(
     noteNumbers,
   };
 
+  // ECMA-376 §17.10.1 — per-section header/footer selection. Resolve the section
+  // active at the top of this page (and whether it's that section's first page)
+  // from the paginated elements' stamped `sectionHF`, then apply the spec
+  // precedence (first → even → default). Single-section docs resolve to
+  // doc.headers/footers/section.titlePage, unchanged.
+  const pageSection = resolvePageSection(pages, pageIndex, doc);
+  const isEvenPage = pageIndex % 2 === 1;
+
   // Header: top of page, starting at headerDistance
-  const header = pickHeaderFooter(doc.headers, pageIndex, totalPages, doc.section.titlePage, doc.section.evenAndOddHeaders);
+  const header = pickHeaderFooter(
+    pageSection.headers, pageSection.isFirstPageOfSection, isEvenPage,
+    pageSection.titlePage, doc.section.evenAndOddHeaders,
+  );
   if (header) {
     renderHeaderFooter(header, sec.headerDistance * scale, baseState);
   }
 
   // Footer: anchored from bottom, rising by its measured height
-  const footer = pickHeaderFooter(doc.footers, pageIndex, totalPages, doc.section.titlePage, doc.section.evenAndOddHeaders);
+  const footer = pickHeaderFooter(
+    pageSection.footers, pageSection.isFirstPageOfSection, isEvenPage,
+    pageSection.titlePage, doc.section.evenAndOddHeaders,
+  );
   if (footer) {
     const footerHeight = measureHeaderFooterHeight(footer, baseState);
     const footerTopY = cssHeight - sec.footerDistance * scale - footerHeight;
@@ -904,6 +918,12 @@ function drawEndnotes(
  *  approximation for the common case. */
 const FOOTNOTE_SEPARATOR_GAP_PT = 6;
 
+/** ECMA-376 §17.10.1 — an empty header/footer set (no default/first/even). Used
+ *  when a per-section `SectionBreak` declares one reference type but not others:
+ *  the absent types fall back to this so `pickHeaderFooter` simply finds none and
+ *  renders nothing for that page kind. */
+const EMPTY_HEADERS_FOOTERS: HeadersFooters = { default: null, first: null, even: null };
+
 /** Build a map from a note's `@w:id` to its 1-based sequential number, in the
  *  order the notes appear in footnotes.xml / endnotes.xml (ECMA-376 §17.11
  *  default decimal numbering, start=1, no restart). */
@@ -1091,6 +1111,30 @@ export function computePages(
     return section.sectionStart ?? 'nextPage';
   };
 
+  // ECMA-376 §17.10.1 — the resolved header/footer set + `<w:titlePg>` flag for
+  // the section that OWNS the content starting at body index `startIdx`. Mirrors
+  // `sectionColumnsFrom`: the owning section's set is carried on the NEXT
+  // `SectionBreak` marker at/after `startIdx` (the marker ENDS that section); if
+  // there is none, the content belongs to the FINAL (body-level) section whose
+  // set lives on `doc.headers`/`doc.footers`/`section.titlePage`. The paginator
+  // stamps this on each element so the renderer can pick the active section's
+  // header/footer per page without re-deriving the body→page mapping.
+  const sectionHFFrom = (startIdx: number): PaginatedBodyElement['sectionHF'] => {
+    for (let j = startIdx; j < body.length; j++) {
+      const e = body[j];
+      if (e.type === 'sectionBreak') {
+        return {
+          headers: e.headers ?? EMPTY_HEADERS_FOOTERS,
+          footers: e.footers ?? EMPTY_HEADERS_FOOTERS,
+          titlePage: e.titlePage ?? false,
+        };
+      }
+    }
+    // Final section: the body-level set. `undefined` ⇒ the renderer's fallback
+    // (doc.headers/footers/section.titlePage), which IS this same set.
+    return undefined;
+  };
+
   // The active section's column geometry. Reassigned (a) here for the first
   // section and (b) at every `SectionBreak` as the flow enters the next section.
   // `colIndex` tracks which column we are filling; `colX()`/`colW()` give its
@@ -1103,6 +1147,11 @@ export function computePages(
   let colIndex = 0;
   const colX = () => columns[colIndex].xPt;
   const colW = () => columns[colIndex].wPt;
+  // ECMA-376 §17.10.1 — the active section's resolved header/footer set + titlePg,
+  // tracked in lockstep with `columns` (reassigned at every SectionBreak). Stamped
+  // on each element so the renderer picks the active section's header/footer per
+  // page. `undefined` for the final section ⇒ the renderer's body-level fallback.
+  let currentSectionHF = sectionHFFrom(0);
   // ECMA-376 §17.6.4 / §17.18.79 — the CURRENT multi-column region's vertical
   // extent on the current page, in content-relative pt (0 = page content top,
   // i.e. the same frame as `y`). A region tiled into N newspaper columns is a
@@ -1401,6 +1450,7 @@ export function computePages(
     el.colIndex = colIndex;
     el.colGeom = columns;
     el.colTopPt = colTopAbsPt();
+    el.sectionHF = currentSectionHF;
     pages[pages.length - 1].push(el);
   };
 
@@ -1456,6 +1506,9 @@ export function computePages(
       // columns instead of every section inheriting the body-level section's.
       columns = sectionColumnsFrom(i + 1);
       colIndex = 0;
+      // ECMA-376 §17.10.1 — the section starting at i+1 owns the following pages'
+      // headers/footers (resolved from the NEXT marker, or the body-level set).
+      currentSectionHF = sectionHFFrom(i + 1);
       // The break is governed by the UPCOMING section's start type (§17.6.22),
       // not this marker's own kind (the section it closes). See sectionKindFrom.
       // The sample-5 cover overprint that prompted the 0.66.1 hotfix is now fixed
@@ -1730,6 +1783,7 @@ export function computePages(
           columns,
           () => colTopY,
           columnBottomLimit,
+          () => currentSectionHF,
         );
         // After splitting, `y` is the bottom of the last slice in the
         // current column (continues for the LAST slice; intermediate slices
@@ -1820,6 +1874,7 @@ export function computePages(
           columns,
           () => colTopY,
           section.marginTop,
+          () => currentSectionHF,
         );
         y = endY;
         measureState.y = section.marginTop + endY;
@@ -2103,6 +2158,11 @@ function splitParagraphAcrossPages(
    *  section) is uncapped at the page content bottom. Omitted ⇒ `contentH` (the
    *  page bottom) — behaviour-neutral for the single-column / greedy paths. */
   columnBottom?: () => number,
+  /** ECMA-376 §17.10.1 — the active SECTION's resolved header/footer set. A
+   *  paragraph never spans a section boundary, so this is constant for all slices;
+   *  stamped so the renderer picks the right section's header/footer per page.
+   *  Omitted ⇒ the renderer's body-level fallback. */
+  tagSectionHF?: () => PaginatedBodyElement['sectionHF'],
 ): { endY: number } {
   const colTop = columnTop ?? (() => 0);
   const colBot = columnBottom ?? (() => contentH);
@@ -2112,6 +2172,7 @@ function splitParagraphAcrossPages(
     // Front-loaded layout: stamp the region top (page-absolute pt) so the paint
     // pass resets this slice's column cursor to it instead of the page top.
     if (columnTop) el.colTopPt = measureState.marginTop + colTop();
+    if (tagSectionHF) el.sectionHF = tagSectionHF();
     return el;
   };
   const indLeft = para.indentLeft;
@@ -2614,6 +2675,10 @@ export function splitTableAcrossPages(
   /** Page-content top (pt) used to convert `columnTop()` to a page-absolute Y for
    *  the `colTopPt` stamp. Omitted ⇒ no `colTopPt` stamp (single-column tests). */
   marginTopPt?: number,
+  /** ECMA-376 §17.10.1 — the active SECTION's resolved header/footer set (constant
+   *  across the split). Stamped so the renderer picks the right section's header/
+   *  footer per page. Omitted ⇒ the renderer's body-level fallback. */
+  tagSectionHF?: () => PaginatedBodyElement['sectionHF'],
 ): number {
   const colTop = columnTop ?? (() => 0);
   const n = table.rows.length;
@@ -2648,6 +2713,7 @@ export function splitTableAcrossPages(
     // Front-loaded layout: stamp the region top (page-absolute pt) so the paint
     // pass resets this slice's column cursor to it instead of the page top.
     if (columnTop && marginTopPt != null) sliceEl.colTopPt = marginTopPt + colTop();
+    if (tagSectionHF) sliceEl.sectionHF = tagSectionHF();
     pages[pages.length - 1].push(sliceEl);
 
     y += used;
@@ -2661,16 +2727,53 @@ export function splitTableAcrossPages(
   return y;
 }
 
+/**
+ * ECMA-376 §17.10.1 precedence for picking a section's header/footer for one page:
+ *   1. `first` — on the section's FIRST page when `<w:titlePg>` is set;
+ *   2. `even`  — on even-parity pages when `<w:evenAndOddHeaders>` is set;
+ *   3. `default` — otherwise.
+ * `isFirstPageOfSection` (the section's first page, not necessarily page 0) and
+ * `isEvenPage` (document page parity) are resolved per page by the caller so this
+ * works for per-section title pages (e.g. sample-13's masthead section gets its
+ * own first-page footer on whatever document page it begins).
+ */
 function pickHeaderFooter(
-  set: DocxDocumentModel['headers'],
-  pageIndex: number,
-  _totalPages: number,
+  set: HeadersFooters,
+  isFirstPageOfSection: boolean,
+  isEvenPage: boolean,
   titlePage: boolean,
   evenAndOdd: boolean,
 ): HeaderFooter | null {
-  if (titlePage && pageIndex === 0 && set.first) return set.first;
-  if (evenAndOdd && pageIndex % 2 === 1 && set.even) return set.even;
+  if (titlePage && isFirstPageOfSection && set.first) return set.first;
+  if (evenAndOdd && isEvenPage && set.even) return set.even;
   return set.default ?? null;
+}
+
+/**
+ * ECMA-376 §17.10.1 — resolve the section active at the TOP of `pageIndex` (the
+ * section that owns that page's content) and whether `pageIndex` is that section's
+ * FIRST page. The paginator stamps each element's `sectionHF` (the upcoming
+ * `SectionBreak`'s resolved set, or — when absent — the body-level section). So the
+ * active section for a page is the `sectionHF` of its first element; `undefined`
+ * means the final/body section (`doc.headers`/`doc.footers`/`section.titlePage`).
+ *
+ * `isFirstPageOfSection` is true when this is page 0 or the active section differs
+ * from the previous page's — i.e. a section boundary fell on this page's top. Two
+ * distinct sections are compared by reference identity of their stamped `sectionHF`
+ * object (each section is stamped with one shared object instance).
+ */
+function resolvePageSection(
+  pages: PaginatedBodyElement[][],
+  pageIndex: number,
+  doc: DocxDocumentModel,
+): { headers: HeadersFooters; footers: HeadersFooters; titlePage: boolean; isFirstPageOfSection: boolean } {
+  const sectionOf = (idx: number): PaginatedBodyElement['sectionHF'] => pages[idx]?.[0]?.sectionHF;
+  const active = sectionOf(pageIndex);
+  const headers = active?.headers ?? doc.headers;
+  const footers = active?.footers ?? doc.footers;
+  const titlePage = active?.titlePage ?? doc.section.titlePage;
+  const isFirstPageOfSection = pageIndex === 0 || sectionOf(pageIndex - 1) !== active;
+  return { headers, footers, titlePage, isFirstPageOfSection };
 }
 
 function renderHeaderFooter(hf: HeaderFooter, topY: number, base: RenderState): void {

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -200,8 +200,21 @@ export type BodyElement =
    *  "continuous" (same page), "nextPage" (default; page break), "oddPage" /
    *  "evenPage" (page break + parity padding). The paginator switches its active
    *  newspaper-column geometry per section at each marker — fixing the regression
-   *  where every section inherited the body-level section's columns. */
-  | { type: 'sectionBreak'; kind: 'continuous' | 'nextPage' | 'oddPage' | 'evenPage' | string; columns?: ColumnsSpec | null };
+   *  where every section inherited the body-level section's columns.
+   *
+   *  `headers`/`footers` carry the ENDING section's resolved (§17.10.1-inherited)
+   *  header/footer set, and `titlePage` its own `<w:titlePg>` flag, so the renderer
+   *  can pick the active section's header/footer per page (mirroring how `columns`
+   *  drives per-section column geometry). The body-level (final) section's sets
+   *  live on {@link DocxDocumentModel.section}/`.headers`/`.footers` instead. */
+  | {
+      type: 'sectionBreak';
+      kind: 'continuous' | 'nextPage' | 'oddPage' | 'evenPage' | string;
+      columns?: ColumnsSpec | null;
+      headers?: HeadersFooters;
+      footers?: HeadersFooters;
+      titlePage?: boolean;
+    };
 
 /** A BodyElement annotated with a line range to render. Set when the
  *  paginator splits a paragraph that doesn't fit on a single page —
@@ -232,6 +245,14 @@ export type PaginatedBodyElement = BodyElement & {
    *  columns. Absent ⇒ the renderer uses the page content top (single-column /
    *  page-spanning section). Runtime-only — never emitted by the parser. */
   colTopPt?: number;
+  /** ECMA-376 §17.10.1 — the resolved header/footer set + `<w:titlePg>` flag of
+   *  the SECTION this element belongs to. Stamped by the paginator (from the
+   *  upcoming `SectionBreak` marker, or the body-level section for the final
+   *  section) so the renderer picks the active section's header/footer per page —
+   *  mirroring how `colGeom` resolves per-section columns. Absent ⇒ the renderer
+   *  falls back to the body-level `doc.headers`/`doc.footers`/`section.titlePage`.
+   *  Runtime-only — never emitted by the parser. */
+  sectionHF?: { headers: HeadersFooters; footers: HeadersFooters; titlePage: boolean };
 };
 
 export interface DocParagraph {


### PR DESCRIPTION
## Problem

On sample-13 page 1, Word shows a first-page footer — "DOI: 10.2478/mr-2026-00xx" / "*Corresponding author: authorB@institution.edu (F. SurnameB)" / page number — that our render dropped entirely.

## Root cause

Our DOCX model carried a SINGLE document-global header/footer set + one `titlePage` flag, taken by accumulating every `<w:sectPr>`'s references into one set (body-level sectPr wins). sample-13 has 9 sections: section 0 (`titlePg=True`) references footer3.xml (the DOI text) as its `first` footer, but a later masthead section also declares a `first` footer (page-number only) that overwrote it in the global merge, and the body-level sectPr has `titlePg=False`. So footer3 + titlePage were lost (parsed model showed `TITLEPAGE=false`, `FOOTERS.first` = page-number field only).

This is the per-section header/footer limitation tracked in #513 (only `columns` were modeled per-section).

## Fix

Model headers/footers/titlePage **per section**, mirroring the existing per-section `columns` mechanism (each `SectionBreak` marker carries the terminating section's geometry; the renderer peeks forward to size the current section).

**Parser (§17.10.1 inheritance preserved):** walk every `<w:sectPr>` in document order keeping a running `SectionRefs`; merge each section's own refs onto it (so a section that omits a type inherits the previous section's — this is what keeps sample-12's running header that is declared only on the first section), snapshot per section, and resolve to `HeadersFooters`. Each `SectionBreak` is stamped with its terminating section's resolved `headers`/`footers`/`titlePage`; the body-level (last) section's set stays on `Document.headers/footers` + `Document.section.titlePage`. `titlePg` is per-sectPr (not inherited).

**Renderer:** for each page, resolve the section active at the page top (the next `SectionBreak` at/after the page's first body element, or the body-level set) plus whether the page is that section's first page; `pickHeaderFooter` now selects first/even/default by `isFirstPageOfSection` + page parity instead of raw `pageIndex===0`. Body pagination is untouched (footers sit within the bottom margin; the `sectionHF` stamp is never read during pagination).

## Verification (headless skia render)

- **sample-13 page 0**: footer3 renders — "DOI:" and "*Corresponding" at y≈767.7 (page height 841.9, bottom-margin band).
- **sample-13 page 1**: no DOI footer (0 runs); default page-number footer "2" at the bottom; the "MSR - Instructions…" title still at the top (y=70.9, unchanged → pagination intact).
- **sample-12 page 0** (regression guard): the running "Journal of Digital Forensics…" header still renders (§17.10.1 inheritance intact).
- Pagination ground-truth unchanged (sample-12=3, sample-13=5, sample-5=7 pages).

## Cross-format

WordprocessingML-specific (§17.6 / §17.10.1 section header/footer references). pptx/xlsx do not share this concept; nothing moves to `core` / `ooxml-common`.

## Tests / gates

- New Rust unit test: per-section snapshot resolution with §17.10.1 inheritance (section 1's default inherits section 0's; `first` overrides stay per-section).
- New renderer unit test `per-section-headers-footers.test.ts`: two sections with different footers → each page picks its section's footer; single-section fallback.
- `cargo test` 158 passed, fmt + clippy clean; `vitest run packages/docx` 277 passed; docx/core/node/vscode-extension typechecks clean; wasm rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)