### PR TITLE
feat(docx): parse evenAndOddHeaders for even-page headers/footers

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -192,7 +192,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
         .filter(|n| n.tag_name().name() == "sectPr");
 
     let (mut section, _body_refs) = parse_section(sect_pr, &rel_map);
-    // §17.10.1 / §17.15.1.41 — the even/odd-headers toggle lives in settings.xml,
+    // §17.10.1 — the even/odd-headers toggle lives in settings.xml,
     // not the sectPr; apply the document-wide flag captured above.
     section.even_and_odd_headers = even_and_odd_headers;
 
@@ -700,7 +700,7 @@ fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
     attr_w(node, "bidi").filter(|s| !s.is_empty())
 }
 
-/// ECMA-376 §17.10.1 / §17.15.1.41 `<w:evenAndOddHeaders/>` — a document-wide
+/// ECMA-376 §17.10.1 `<w:evenAndOddHeaders/>` — a document-wide
 /// (settings.xml) ST_OnOff toggle. When on, even-numbered pages use the
 /// section's `even` header/footer reference instead of the default; when absent
 /// (the common case) it is off and every page uses the default. Surfaced onto
@@ -6639,7 +6639,7 @@ mod theme_cs_tests {
 
     #[test]
     fn even_and_odd_headers_flag_from_settings() {
-        // §17.10.1 / §17.15.1.41 — presence (ST_OnOff) turns it on; an explicit
+        // §17.10.1 — presence (ST_OnOff) turns it on; an explicit
         // w:val="false" turns it off; absence is off.
         let w = "xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"";
         assert!(parse_even_and_odd_headers(&format!(

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -153,11 +153,15 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
         })
         .unwrap_or_else(|| "word/settings.xml".to_string());
     let mut document_settings: Option<crate::types::DocumentSettings> = None;
+    // §17.10.1 even/odd headers is a settings.xml flag (not a sectPr property), so
+    // capture it here and stamp it onto the section below.
+    let mut even_and_odd_headers = false;
     if let Ok(settings_xml) = read_zip_entry(&mut zip, &settings_path) {
         if let Some(lang) = parse_theme_font_bidi_lang(&settings_xml) {
             theme.fill_default_cs_font(&lang);
         }
         document_settings = parse_document_settings(&settings_xml);
+        even_and_odd_headers = parse_even_and_odd_headers(&settings_xml);
     }
 
     // ECMA-376 §17.7.2 — record the document default run fonts on the theme so
@@ -187,7 +191,10 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
         .rfind(|n| n.is_element())
         .filter(|n| n.tag_name().name() == "sectPr");
 
-    let (section, _body_refs) = parse_section(sect_pr, &rel_map);
+    let (mut section, _body_refs) = parse_section(sect_pr, &rel_map);
+    // §17.10.1 / §17.15.1.41 — the even/odd-headers toggle lives in settings.xml,
+    // not the sectPr; apply the document-wide flag captured above.
+    section.even_and_odd_headers = even_and_odd_headers;
 
     // ECMA-376 §17.10.1 — header/footer references inherit across sections, but
     // each section keeps its OWN effective set (a "first" footer declared on the
@@ -691,6 +698,19 @@ fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "themeFontLang")?;
     attr_w(node, "bidi").filter(|s| !s.is_empty())
+}
+
+/// ECMA-376 §17.10.1 / §17.15.1.41 `<w:evenAndOddHeaders/>` — a document-wide
+/// (settings.xml) ST_OnOff toggle. When on, even-numbered pages use the
+/// section's `even` header/footer reference instead of the default; when absent
+/// (the common case) it is off and every page uses the default. Surfaced onto
+/// `SectionProps.even_and_odd_headers`, which the renderer's `pickHeaderFooter`
+/// already consumes for the even-page branch.
+fn parse_even_and_odd_headers(settings_xml: &str) -> bool {
+    let Ok(doc) = XmlDoc::parse(settings_xml) else {
+        return false;
+    };
+    bool_prop(doc.root_element(), "evenAndOddHeaders").unwrap_or(false)
 }
 
 /// Parse the typography settings the renderer needs from `word/settings.xml`.
@@ -6615,6 +6635,23 @@ mod theme_cs_tests {
         assert_eq!(s.kinsoku, Some(false));
         assert_eq!(s.no_line_breaks_before, None);
         assert_eq!(s.no_line_breaks_after, None);
+    }
+
+    #[test]
+    fn even_and_odd_headers_flag_from_settings() {
+        // §17.10.1 / §17.15.1.41 — presence (ST_OnOff) turns it on; an explicit
+        // w:val="false" turns it off; absence is off.
+        let w = "xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"";
+        assert!(parse_even_and_odd_headers(&format!(
+            "<w:settings {w}><w:evenAndOddHeaders/></w:settings>"
+        )));
+        assert!(parse_even_and_odd_headers(&format!(
+            "<w:settings {w}><w:evenAndOddHeaders w:val=\"true\"/></w:settings>"
+        )));
+        assert!(!parse_even_and_odd_headers(&format!(
+            "<w:settings {w}><w:evenAndOddHeaders w:val=\"false\"/></w:settings>"
+        )));
+        assert!(!parse_even_and_odd_headers(&format!("<w:settings {w}/>")));
     }
 
     #[test]

--- a/packages/docx/src/per-section-headers-footers.test.ts
+++ b/packages/docx/src/per-section-headers-footers.test.ts
@@ -127,7 +127,7 @@ describe('per-section headers/footers (§17.10.1)', () => {
     expect(joined).not.toContain('FOOTER_A_DEFAULT');
   });
 
-  it('evenAndOddHeaders: even page uses the even footer, odd page the default (§17.10.1 / §17.15.1.41)', async () => {
+  it('evenAndOddHeaders: even page uses the even footer, odd page the default (§17.10.1)', async () => {
     // Single section, document-wide even/odd toggle ON, with distinct default and
     // even footers. Two paragraphs split by a page break ⇒ page 0 (odd) → default,
     // page 1 (even) → even. (Parity is the absolute page index here; for a section

--- a/packages/docx/src/per-section-headers-footers.test.ts
+++ b/packages/docx/src/per-section-headers-footers.test.ts
@@ -127,6 +127,61 @@ describe('per-section headers/footers (§17.10.1)', () => {
     expect(joined).not.toContain('FOOTER_A_DEFAULT');
   });
 
+  it('evenAndOddHeaders: even page uses the even footer, odd page the default (§17.10.1 / §17.15.1.41)', async () => {
+    // Single section, document-wide even/odd toggle ON, with distinct default and
+    // even footers. Two paragraphs split by a page break ⇒ page 0 (odd) → default,
+    // page 1 (even) → even. (Parity is the absolute page index here; for a section
+    // starting at page 0 that equals the section-relative count.)
+    const section: SectionProps = {
+      pageWidth: 400, pageHeight: 120,
+      marginTop: 10, marginRight: 10, marginBottom: 30, marginLeft: 10,
+      headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: true,
+    } as SectionProps;
+    const doc = {
+      section,
+      body: [
+        para('PAGE0_BODY') as unknown as BodyElement,
+        { type: 'pageBreak' } as BodyElement,
+        para('PAGE1_BODY') as unknown as BodyElement,
+      ],
+      headers: hf({}),
+      footers: hf({ default: footer('FOOTER_DEFAULT'), even: footer('FOOTER_EVEN') }),
+      fontFamilyClasses: { 'Times New Roman': 'roman' },
+    } as unknown as DocxDocumentModel;
+
+    const p0 = (await renderPageTexts(doc, 0)).join('|');
+    expect(p0).toContain('PAGE0_BODY');
+    expect(p0).toContain('FOOTER_DEFAULT');
+    expect(p0).not.toContain('FOOTER_EVEN');
+
+    const p1 = (await renderPageTexts(doc, 1)).join('|');
+    expect(p1).toContain('PAGE1_BODY');
+    expect(p1).toContain('FOOTER_EVEN');
+    expect(p1).not.toContain('FOOTER_DEFAULT');
+  });
+
+  it('evenAndOddHeaders OFF: even page still uses the default footer', async () => {
+    const section: SectionProps = {
+      pageWidth: 400, pageHeight: 120,
+      marginTop: 10, marginRight: 10, marginBottom: 30, marginLeft: 10,
+      headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const doc = {
+      section,
+      body: [
+        para('PAGE0_BODY') as unknown as BodyElement,
+        { type: 'pageBreak' } as BodyElement,
+        para('PAGE1_BODY') as unknown as BodyElement,
+      ],
+      headers: hf({}),
+      footers: hf({ default: footer('FOOTER_DEFAULT'), even: footer('FOOTER_EVEN') }),
+      fontFamilyClasses: { 'Times New Roman': 'roman' },
+    } as unknown as DocxDocumentModel;
+    const p1 = (await renderPageTexts(doc, 1)).join('|');
+    expect(p1).toContain('FOOTER_DEFAULT');
+    expect(p1).not.toContain('FOOTER_EVEN');
+  });
+
   it('falls back to body-level footer for a single-section document (unchanged path)', async () => {
     const section: SectionProps = {
       pageWidth: 400, pageHeight: 200,


### PR DESCRIPTION
## Problem

The DOCX parser never read `<w:evenAndOddHeaders/>` from `word/settings.xml`, so `SectionProps.even_and_odd_headers` was hardcoded false and the renderer's even-page header/footer branch (wired up alongside per-section headers/footers in #591) was dead code — even pages always used the default header/footer.

## Fix

ECMA-376 §17.10.1: `<w:evenAndOddHeaders/>` is a document-wide settings.xml ST_OnOff toggle. When on, even-numbered pages use the section's `even` header/footer reference instead of the default.

Parse the flag from settings.xml (`bool_prop` — present/`val="true"` ⇒ on, `val="false"`/absent ⇒ off) and stamp it onto the section in `parse()` (the flag lives in settings, not the sectPr, so it is captured alongside the other settings reads and applied to the resolved `SectionProps`). The TS renderer already consumes `doc.section.evenAndOddHeaders` via `pickHeaderFooter`.

## Tests / verification

- Parser unit test: ST_OnOff cases — `<w:evenAndOddHeaders/>` and `w:val="true"` ⇒ on; `w:val="false"` and absent ⇒ off.
- Renderer unit tests: an even page (index 1) selects the `even` footer when the flag is on, the `default` when off.
- End-to-end through `parseDocx`: sample-8 (which carries `w:val="false"`) ⇒ `evenAndOddHeaders=false`; an on-variant (`<w:evenAndOddHeaders/>`) ⇒ `true`.
- Gates: `cargo test` 159 passed, fmt + clippy clean; `vitest run packages/docx` 279 passed; docx/core typecheck clean; wasm rebuilt.

## Follow-ups (noted, out of scope)

Even/odd parity here uses the absolute document page index; ECMA-376 §17.10.1 counts from the section's page-numbering start (`<w:pgNumType w:start>`), which is not parsed yet. For the common case (numbering starts at 1) the two coincide. Parity-padding blank pages (oddPage/evenPage section starts) still resolve to the body-level header/footer.

docx-specific (§17.10 / §17.15); pptx/xlsx unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)