### PR TITLE
fix(docx): size Times New Roman / Arial lines from the hhea design height

### DIFF
--- a/packages/docx/src/cell-valign-leading-spacing.test.ts
+++ b/packages/docx/src/cell-valign-leading-spacing.test.ts
@@ -79,10 +79,17 @@ function makeRecordingCanvas(): {
 
 // ---------- model builders ----------
 
+// A deliberately SYNTHETIC, untabled font: the mock canvas reports a clean
+// 1.0 em box (0.8/0.2) for it, so these vAlign tests isolate the §17.4.84 leading
+// trim without the font-metrics single-line FLOOR. (Real Latin faces like Times
+// New Roman / Arial are tabled with their hhea design height — see font-metrics.ts
+// — which raises the line box and is covered by font-metrics.test.ts instead.)
+const TEST_FONT = 'Synthetic Untabled Serif';
+
 function textRun(text: string): DocxTextRun {
   return {
     text, bold: false, italic: false, underline: false, strikethrough: false,
-    fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: '',
+    fontSize: 10, color: null, fontFamily: TEST_FONT, fontFamilyEastAsia: '',
     isLink: false, background: null, vertAlign: null, hyperlink: null,
   };
 }
@@ -97,7 +104,7 @@ function paraOf(text: string, opts: Partial<DocParagraph> = {}): CellElement {
     spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
     numbering: null, tabStops: [],
     runs: [{ type: 'text', ...textRun(text) } as DocParagraph['runs'][number]],
-    defaultFontSize: 10, defaultFontFamily: 'Times New Roman',
+    defaultFontSize: 10, defaultFontFamily: TEST_FONT,
     widowControl: false,
     ...opts,
   } as unknown as CellElement;
@@ -147,7 +154,7 @@ function docWithTable(t: DocTable): DocxDocumentModel {
     body: [{ type: 'table', ...t } as BodyElement],
     headers: { default: null, first: null, even: null },
     footers: { default: null, first: null, even: null },
-    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    fontFamilyClasses: { [TEST_FONT]: 'roman' },
   } as unknown as DocxDocumentModel;
 }
 

--- a/packages/docx/src/font-metrics.test.ts
+++ b/packages/docx/src/font-metrics.test.ts
@@ -17,12 +17,20 @@ describe('fontWinLineHeightRatio', () => {
     expect(fontWinLineHeightRatio('meiryo ui')).toBeCloseTo(3269 / 2048, 5);
     expect(fontWinLineHeightRatio('MEIRYO')).toBeCloseTo(3269 / 2048, 5);
   });
-  it('returns null for untabled fonts (Latin / unknown / null)', () => {
-    // Latin fonts are intentionally absent — their win ratio (~1.15–1.22) is
-    // close to the browser fallback, so no correction is needed.
-    expect(fontWinLineHeightRatio('Arial')).toBeNull();
-    expect(fontWinLineHeightRatio('Calibri')).toBeNull();
+  it('returns the hhea single-line ratio for tabled Latin fonts (Times New Roman, Arial)', () => {
+    // Word sizes a line from the hhea line height (ascent+|descent|+lineGap), not
+    // the win sum Canvas reports. Times New Roman: (1825+443+87)/2048 = 1.1499 em;
+    // Arial: (1854+434+67)/2048 = 1.1499 em. Verified from the installed fonts.
+    expect(fontWinLineHeightRatio('Times New Roman')).toBeCloseTo(2355 / 2048, 5);
+    expect(fontWinLineHeightRatio('arial')).toBeCloseTo(2355 / 2048, 5);
+  });
+  it('matches Latin entries EXACTLY so variant families keep their own metrics', () => {
+    // "Arial Narrow" / "Arial Black" / "Arial Nova" and any other family must NOT
+    // be caught by the Arial/Times entries — they have different design metrics.
     expect(fontWinLineHeightRatio('Arial Nova')).toBeNull();
+    expect(fontWinLineHeightRatio('Arial Narrow')).toBeNull();
+    expect(fontWinLineHeightRatio('Arial Black')).toBeNull();
+    expect(fontWinLineHeightRatio('Calibri')).toBeNull();
     expect(fontWinLineHeightRatio(null)).toBeNull();
     expect(fontWinLineHeightRatio(undefined)).toBeNull();
     expect(fontWinLineHeightRatio('')).toBeNull();
@@ -38,7 +46,7 @@ describe('intendedSingleLinePx', () => {
     expect(intendedSingleLinePx('Meiryo UI', 18)).toBeCloseTo(meiryo * 18, 5);
   });
   it('returns 0 (no-op sentinel) for untabled fonts', () => {
-    expect(intendedSingleLinePx('Arial', 96)).toBe(0);
+    expect(intendedSingleLinePx('Calibri', 96)).toBe(0);
     expect(intendedSingleLinePx(null, 96)).toBe(0);
   });
 });
@@ -65,7 +73,16 @@ describe('correctLineMetrics', () => {
     expect(intendedSingleLinePx('Meiryo UI', 18)).toBeCloseTo((3269 / 2048) * 18, 5);
   });
   it('passes through measured metrics unchanged for untabled fonts', () => {
-    const r = correctLineMetrics('Arial', 12, 11, 3);
+    const r = correctLineMetrics('Calibri', 12, 11, 3);
     expect(r).toEqual({ ascent: 11, descent: 3 });
+  });
+  it('keeps the measured box for an installed Latin font shorter than its design box', () => {
+    // Times New Roman is tabled (design 1.1499 em). At em = 12 the design box is
+    // ~13.8 px; the Canvas win box (≈1.107 em ≈ 13.3 px, here 10.7 + 2.6) is
+    // SMALLER, so correctLineMetrics passes it through and the intendedSingleLinePx
+    // floor (not this function) raises the LINE BOX — matching the Meiryo regime.
+    const r = correctLineMetrics('Times New Roman', 12, 10.7, 2.6);
+    expect(r).toEqual({ ascent: 10.7, descent: 2.6 });
+    expect(intendedSingleLinePx('Times New Roman', 12)).toBeCloseTo((2355 / 2048) * 12, 5);
   });
 });

--- a/packages/docx/src/font-metrics.ts
+++ b/packages/docx/src/font-metrics.ts
@@ -147,9 +147,12 @@ function lookupWinMetric(family: string | null | undefined): WinMetric | null {
 }
 
 /**
- * Win line-height ratio (`(usWinAscent+usWinDescent)/unitsPerEm`) for a
- * requested font family, or `null` when the font is not in the table (the
- * caller should then fall back to the substituted font's Canvas metrics).
+ * Word's design single-line-height ratio for a requested font family, or `null`
+ * when the font is not in the table (the caller then falls back to the
+ * substituted font's Canvas metrics). The ratio is the win sum
+ * `(usWinAscent+usWinDescent)/unitsPerEm` for the CJK/Arabic faces and the hhea
+ * sum `(ascent+|descent|+lineGap)/unitsPerEm` for the Latin faces (see
+ * WIN_METRICS). The legacy name is kept to avoid churn at the call sites.
  */
 export function fontWinLineHeightRatio(family: string | null | undefined): number | null {
   const m = lookupWinMetric(family);
@@ -172,18 +175,20 @@ export function intendedSingleLinePx(family: string | null | undefined, emPx: nu
  * against the DOCUMENT font's design line box.
  *
  * Two regimes, decided by comparing the substitute's natural box with the
- * document font's win box (`usWinAscent+usWinDescent / unitsPerEm`):
+ * document font's design box (`asc + desc` from the table — the win sum for the
+ * CJK/Arabic faces, the hhea sum for the Latin faces; see WIN_METRICS):
  *
- * - Substitute box ≤ document box (e.g. Meiryo drawn via Hiragino): return the
- *   substitute's measured metrics UNCHANGED. The {@link intendedSingleLinePx}
- *   floor (applied by layoutLines) raises the LINE BOX to the document font's
- *   win height, and the renderer centers the natural line inside it — keeping
- *   the substitute's glyph ink centered where Word's ink sits. Replacing the
- *   split here instead shifted every line's ink upward and regressed the
- *   Word-reference VRT (private/sample-3).
+ * - Substitute box ≤ document box (e.g. Meiryo drawn via Hiragino, or an
+ *   installed Times New Roman whose win-box Canvas metrics fall short of its hhea
+ *   design height): return the substitute's measured metrics UNCHANGED. The
+ *   {@link intendedSingleLinePx} floor (applied by layoutLines) raises the LINE
+ *   BOX to the document font's design height, and the renderer centers the
+ *   natural line inside it — keeping the glyph ink centered where Word's ink
+ *   sits. Replacing the split here instead shifted every line's ink upward and
+ *   regressed the Word-reference VRT (private/sample-3).
  *
  * - Substitute box > document box (Sakkal Majalla drawn via Noto Naskh Arabic,
- *   win 2.2 em vs 1.3965 em): return the document font's win ascent/descent.
+ *   2.2 em vs 1.3965 em): return the document font's design ascent/descent.
  *   Without the shrink, exact-height rows (§17.4.81) and vAlign-centered cells
  *   (§17.4.84) overflow — the sample-7 page-2 header case.
  *

--- a/packages/docx/src/font-metrics.ts
+++ b/packages/docx/src/font-metrics.ts
@@ -52,25 +52,41 @@
 //     the band top; Word fits the 1.3965 × 12 ≈ 16.8 pt box inside the row with
 //     visible top/bottom gaps.
 //
-// This table provides the intended font's win ascent and descent ratios
-// (`usWinAscent / unitsPerEm` and `usWinDescent / unitsPerEm`) so the line box
-// can be sized — and the baseline placed within it — as Word would, independent
-// of which fallback ends up drawing the glyphs. Carrying ascent and descent
-// separately (rather than only their sum) matters when the substitute's
+// This table provides the intended font's design ascent and descent ratios so
+// the line box can be sized — and the baseline placed within it — as Word would,
+// independent of which fallback ends up drawing the glyphs. Carrying ascent and
+// descent separately (rather than only their sum) matters when the substitute's
 // ascent:descent split differs from the document font's: using the substitute's
 // split would mis-place the baseline inside an otherwise correctly sized box,
 // shifting vertically-centered text off center. Only fonts whose metrics are
-// verified from real OS/2 data belong here — never a value tuned to make one
-// sample look right. Latin fonts are intentionally absent: their win ratio
-// (~1.15–1.22 em) is close to what the browser fallback already reports, so the
-// correction is negligible.
+// verified from real OS/2 / hhea data belong here — never a value tuned to make
+// one sample look right.
+//
+// Win vs hhea — which single-line height Word uses
+// ------------------------------------------------
+// Word sizes one `lineRule="auto"` line from the font's DESIGN line height. For
+// the CJK / Arabic faces below (Meiryo, Sakkal Majalla) that is the OS/2 win sum
+// `(usWinAscent + usWinDescent) / unitsPerEm`, and their hhea `lineGap` is 0 so
+// the win sum already equals the full hhea line height. For Latin faces it is
+// the hhea line height `(ascent + |descent| + lineGap) / unitsPerEm`, which is
+// LARGER than the win sum by exactly the hhea `lineGap` (Times New Roman: win
+// 2268/2048 = 1.107 em vs hhea 2355/2048 = 1.150 em; Arial: 1.117 vs 1.150).
+// Canvas `fontBoundingBoxAscent/Descent` reports the win box, so without these
+// Latin entries an installed Times New Roman / Arial body renders ~4 % too tight
+// vertically (sample-13: the two-column body and every multi-line paragraph were
+// short, pushing later content up). The lineGap is folded into `desc` so the
+// design sum is correct; the renderer's lineBoxHeight floor (intendedSingleLinePx)
+// raises the line box to it and the draw path centers the glyph ink with
+// symmetric half-leading. The Latin ratios here are face-independent of weight
+// (Arial Regular and Bold both report hhea 1.150).
 
 interface WinMetric {
-  /** `usWinAscent / unitsPerEm`. */ asc: number;
-  /** `usWinDescent / unitsPerEm`. */ desc: number;
+  /** Design ascent ratio (ascent units / unitsPerEm). */ asc: number;
+  /** Design descent ratio: `(|descent| + hhea lineGap) / unitsPerEm` so
+   *  `asc + desc` is the font's full design single-line height. */ desc: number;
 }
 
-/** A known font's win metrics. Keyed by a normalized (lowercased) name test. */
+/** A known font's design line metrics. Keyed by a normalized (lowercased) name test. */
 const WIN_METRICS: ReadonlyArray<readonly [test: (n: string) => boolean, m: WinMetric]> = [
   // Meiryo / Meiryo UI — unitsPerEm 2048, usWinAscent 2210, usWinDescent 1059
   // (OS/2 table; USE_TYPO_METRICS fsSelection bit 7 is clear, so Word uses the
@@ -102,6 +118,23 @@ const WIN_METRICS: ReadonlyArray<readonly [test: (n: string) => boolean, m: WinM
   // reports ≈2.2 em from fontBoundingBox with a more ascent-heavy split, so
   // without this both the line box and the baseline position are wrong.
   [(n) => n.includes('sakkal majalla') || n.includes('majalla'), { asc: 1810 / 2048, desc: 1050 / 2048 }],
+  // Times New Roman — unitsPerEm 2048; hhea ascent 1825, descent −443, lineGap
+  // 87 (extracted from the installed `Times New Roman.ttf` via fontTools; OS/2
+  // USE_TYPO_METRICS bit clear). Word's single-line height is the hhea line
+  // height (1825 + 443 + 87)/2048 = 2355/2048 = 1.1499 em — verified against the
+  // Word PDF of sample-13: a 10 pt body line is 11.52 pt = 1.152 em (the win sum
+  // 2268/2048 = 1.107 em that Canvas fontBoundingBox reports is 0.043 em short).
+  // lineGap folded into desc: asc 1825/2048, desc (443 + 87)/2048 = 530/2048.
+  // EXACT match: the Bold/Italic faces share this hhea ratio, but unrelated
+  // families must not be caught by a substring test.
+  [(n) => n === 'times new roman', { asc: 1825 / 2048, desc: 530 / 2048 }],
+  // Arial — unitsPerEm 2048; hhea ascent 1854, descent −434, lineGap 67 (from the
+  // installed `Arial.ttf`; USE_TYPO_METRICS clear). hhea line height
+  // (1854 + 434 + 67)/2048 = 2355/2048 = 1.1499 em, vs win sum 2288/2048 =
+  // 1.117 em. lineGap folded into desc: asc 1854/2048, desc (434 + 67)/2048.
+  // EXACT match: "Arial Narrow" (1.1475), "Arial Black" (1.4102) and "Arial Nova"
+  // have DIFFERENT metrics, so a substring test would mis-size them.
+  [(n) => n === 'arial', { asc: 1854 / 2048, desc: 501 / 2048 }],
 ];
 
 function lookupWinMetric(family: string | null | undefined): WinMetric | null {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7639,16 +7639,17 @@ function emptyLineNaturalPx(fontSizePt: number, scale: number): { asc: number; d
 
 /** Corrected single-line ascent/descent (px) from an ALREADY-measured
  *  `TextMetrics`: the Canvas `fontBoundingBox` (with the synthetic 0.8/0.2-em
- *  fallback when the engine reports none), rescaled to the document font's win
- *  box via {@link correctLineMetrics}. The single source of truth for "how tall
- *  is one line of `family`", shared by the text-line path (layoutLines) and the
- *  empty paragraph-mark path (paragraphMarkLineHeight) so the two cannot drift —
- *  that drift (the empty path skipping `correctLineMetrics`) was the
+ *  fallback when the engine reports none), rescaled to the document font's design
+ *  line box via {@link correctLineMetrics}. The single source of truth for "how
+ *  tall is one line of `family`", shared by the text-line path (layoutLines) and
+ *  the empty paragraph-mark path (paragraphMarkLineHeight) so the two cannot
+ *  drift — that drift (the empty path skipping `correctLineMetrics`) was the
  *  empty-paragraph under-measure bug (§17.3.1.29 / §17.3.1.33). `fallbackEmPx`
  *  sizes the synthetic box (the run's full size); `correctionEmPx` is the design
  *  size handed to `correctLineMetrics` — they differ only for smallCaps/vertAlign
  *  runs (where the text path keeps the full-size fallback) and coincide for a
- *  plain paragraph-mark line. */
+ *  plain paragraph-mark line. The hhea single-line FLOOR for tabled fonts is
+ *  applied separately by lineBoxHeight via {@link intendedSingleLinePx}. */
 function correctedLineMetrics(
   m: TextMetrics,
   family: string | null | undefined,
@@ -7697,9 +7698,10 @@ function paragraphMarkLineHeight(
     // cells); others probe a Latin glyph. fontBoundingBox is reported per
     // resolved face (not per glyph), so the probe choice does not change the box
     // for a face that contains it — and the probe is script-matched, so the mark
-    // font does. correctLineMetrics rescales a substituted font to the document
-    // font's win box, identical to the text path (a no-op for fonts absent from
-    // the win-metric table, e.g. Latin).
+    // font does. correctedLineMetrics rescales a substituted font to the document
+    // font's design box, identical to the text path; the hhea single-line floor
+    // (intendedSingleLinePx, via emptyIntendedSinglePx below) then raises tabled
+    // fonts — Latin included — to Word's line height.
     const prevFont = ctx.font;
     ctx.font = buildFont(false, false, fs * scale, family, fontFamilyClasses);
     const m = ctx.measureText(eastAsian ? 'あ' : 'x');


### PR DESCRIPTION
## Problem

Word sizes a `lineRule=\"auto\"` line from the font's **hhea** line height (`ascent + |descent| + lineGap`), but Canvas `fontBoundingBoxAscent/Descent` reports the OS/2 **win** box, which omits the hhea `lineGap`. For installed Latin faces this understates Word's line height:

| font | win (Canvas) | hhea (Word) |
|---|---|---|
| Times New Roman | 1.107 em | **1.150 em** |
| Arial | 1.117 em | **1.150 em** |

So every multi-line Latin paragraph rendered ~4 % too tight vertically. In **sample-13** the two-column body and the intro paragraphs were short (a 10 pt body line was 11.05 pt vs Word's 11.52 pt), which also pulled later content upward.

Verified from the installed fonts' OS/2 / hhea tables (fontTools) and against the Word PDF of sample-13 (10 pt body line = 11.52 pt = 1.152 em).

## Fix

Add Times New Roman and Arial to the `font-metrics.ts` design-line table with their hhea ratios. The existing `intendedSingleLinePx` **floor** (already used for Meiryo / Sakkal Majalla) raises the line box, and the draw path centers the glyph ink with symmetric half-leading — so the result is identical for browser-main, worker, and node renders.

- Pure-data table → **worker-equivalence diff 0.000 %** (an earlier DOM `line-height:normal` probe gave the same pixels on the main thread but broke worker mode, where there is no DOM — 2.55 % diff).
- **EXACT** name match so `Arial Narrow` (1.1475), `Arial Black` (1.4102), `Arial Nova`, etc. keep their own metrics.
- `lineGap` folded into the descent ratio so `asc + desc` is the full design single-line height.

## Verification

- docx unit tests: **283 passed** (font-metrics tests updated for the new tabled Latin entries; the vAlign leading-spacing test switched to a synthetic untabled font to keep isolating §17.4.84).
- root `pnpm typecheck`: clean.
- docx VRT (references = Word export PNGs): **21/21 passed**, demo/sample-1 page 1 improved to 100 % match.
- worker-equivalence: **0.000 %** diff.
- Browser (Storybook, real Times New Roman): sample-13 body line height 13.0 px → **13.52 px = 11.50 pt** (Word 11.52 pt); 5 pages preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)