### PR TITLE
fix(docx): suppress spacing-before on empty section-break spacer paragraphs

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2841,6 +2841,15 @@ function isInklessParagraph(p: DocParagraph): boolean {
  * Such a paragraph's spacing-BEFORE is suppressed: it sits flush below the
  * preceding paragraph (it is a section transition, not normal content flow).
  *
+ * Intentionally NOT gated to "continuous" breaks. The break's effective kind is
+ * the FOLLOWING section's start type (§17.6.22), not the marker's own `.kind`
+ * (sample-13's marker is `nextPage` yet renders continuous), so a `kind` check
+ * here would mis-fire. The all-kinds form is safe: for a genuine next-page break
+ * the spacer is the closing section's LAST line, sitting at the page bottom — the
+ * next section resets to a fresh page regardless — so dropping its before can
+ * only shift that one trailing empty mark up by its own before, never the
+ * following content.
+ *
  * NOTE — interop heuristic, not ECMA-376. §17.3.1.33 would apply the `before`
  * normally (a consumer takes `max(prev.after, this.before)`), and no clause —
  * nor any [MS-DOC] / [MS-OI29500] note — suppresses it for a section-break or

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1344,7 +1344,7 @@ export function computePages(
         const p = e as unknown as DocParagraph;
         if (p.pageBreakBefore) return { height: Infinity, terminated: false };
         if (p.framePr) continue; // frame is out of flow (adds no column height)
-        const suppress = contextualSuppressed(prevP, p);
+        const suppress = contextualSuppressed(prevP, p) || isSectionBreakSpacerAt(body, j);
         const before = suppress ? 0 : p.spaceBefore;
         total += estimateParagraphHeight(ms, p, colWPt, suppress, 0) - Math.min(prevAfter, before);
         prevAfter = p.spaceAfter;
@@ -1614,7 +1614,15 @@ export function computePages(
         pushTagged(el as PaginatedBodyElement);
         continue;
       }
-      const suppressBefore = contextualSuppressed(prevPara, para);
+      const contextual = contextualSuppressed(prevPara, para);
+      // An empty section-break spacer drops only ITS OWN before (gap collapses to
+      // prev.after, normally 0) — NOT the previous paragraph's after (see
+      // isSectionBreakSpacerAt). contextualSpacing drops both. Stamp the element so
+      // the paint pass (which gets per-page lists with the sectionBreak already
+      // consumed, so it cannot re-detect the adjacency) applies the same drop.
+      const spacer = isSectionBreakSpacerAt(body, i);
+      if (spacer) (el as PaginatedBodyElement).sectionBreakSpacer = true;
+      const suppressBefore = contextual || spacer;
 
       // Collapse with the previous paragraph's spaceAfter — Word takes
       // max(prev.after, this.before) between paragraphs, not the sum.
@@ -1622,7 +1630,7 @@ export function computePages(
       // §17.3.1.9 contextualSpacing: same-style adjacent paragraphs drop BOTH the
       // previous after and this before (gap = 0), keeping the paginator's fill in
       // lockstep with the paint pass.
-      const overlap = suppressBefore ? prevSpaceAfter : Math.min(prevSpaceAfter, effectiveBefore);
+      const overlap = contextual ? prevSpaceAfter : Math.min(prevSpaceAfter, effectiveBefore);
       y -= overlap;
       measureState.y -= overlap;
 
@@ -2812,6 +2820,47 @@ function contextualSuppressed(prev: DocParagraph | null, curr: DocParagraph): bo
 }
 
 /**
+ * Whether a paragraph places NO inline content — no text, image, shape, math, or
+ * break run. It still produces one paragraph-mark line box (§17.3.1.29), but
+ * carries no glyphs.
+ */
+function isInklessParagraph(p: DocParagraph): boolean {
+  return !(p.runs ?? []).some((r) => {
+    const run = r as { type?: string; text?: string };
+    if (run.type === 'text') return (run.text ?? '').length > 0;
+    return true; // image / shape / math / break runs are visible content
+  });
+}
+
+/**
+ * Whether `body[i]` is an empty paragraph that carries a SECTION BREAK — an
+ * inkless paragraph immediately followed by a `sectionBreak` element. (The parser
+ * emits a sectPr-bearing paragraph as a `Paragraph` followed by a `SectionBreak`,
+ * so the spacer paragraph and its break are adjacent siblings.)
+ *
+ * Such a paragraph's spacing-BEFORE is suppressed: it sits flush below the
+ * preceding paragraph (it is a section transition, not normal content flow).
+ *
+ * NOTE — interop heuristic, not ECMA-376. §17.3.1.33 would apply the `before`
+ * normally (a consumer takes `max(prev.after, this.before)`), and no clause —
+ * nor any [MS-DOC] / [MS-OI29500] note — suppresses it for a section-break or
+ * empty paragraph (verified independently). But Microsoft Word AND LibreOffice
+ * both render it with NO before: in sample-13 the empty `mSectionBreak` spacer
+ * between "Keywords" and "1. INTRODUCTION" carries `w:before="440"` (22pt); with
+ * that applied the two-column body started ~22pt too low, while both editors omit
+ * it (confirmed by the document author placing a character in the spacer and
+ * watching the heading NOT move). This matches that shared behaviour; revisit and
+ * cite if a primary source ever surfaces.
+ */
+function isSectionBreakSpacerAt(body: ArrayLike<{ type?: string }>, i: number): boolean {
+  const el = body[i] as { type?: string } | undefined;
+  if (!el || el.type !== 'paragraph') return false;
+  const next = body[i + 1] as { type?: string } | undefined;
+  if (next?.type !== 'sectionBreak') return false;
+  return isInklessParagraph(el as unknown as DocParagraph);
+}
+
+/**
  * Sum the heights of a cell's content elements with paragraph spacing collapsed
  * the same way `renderCellContent` paints them, so a cell measured for row
  * sizing equals the height it actually paints. Two collapse rules apply
@@ -3019,13 +3068,19 @@ function renderBodyElements(
         renderFrameParagraph(para, state, frameAnchorLineHeightPx(elements, el, state));
         continue;
       }
-      const suppress = contextualSuppressed(prevPara, para);
+      const contextual = contextualSuppressed(prevPara, para);
+      // Empty section-break spacer: drop only its own before (see
+      // isSectionBreakSpacerAt); contextualSpacing drops the previous after too.
+      // The adjacency was detected during pagination and stamped (the sectionBreak
+      // marker is gone from this per-page list), so read the tag here.
+      const spacer = !!(el as PaginatedBodyElement).sectionBreakSpacer;
+      const suppress = contextual || spacer;
       // Collapse spaceAfter+spaceBefore like Word: use max, not sum.
       const effBefore = suppress ? 0 : para.spaceBefore;
       // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both
       // set it, BOTH the previous after and this before are dropped (gap = 0), not
       // just collapsed — so e.g. a code listing's lines sit tight.
-      const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+      const overlap = contextual ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
       state.y -= overlap * state.scale;
       // Continuation slices (slice.start > 0) suppress spaceBefore: the
       // earlier slice already consumed it on the previous page. Likewise

--- a/packages/docx/src/section-break-spacer.test.ts
+++ b/packages/docx/src/section-break-spacer.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// Interop behaviour (NOT ECMA-376 — see isSectionBreakSpacerAt): an EMPTY
+// paragraph that carries a section break (an inkless paragraph immediately
+// followed by a `sectionBreak` element) has its spacing-BEFORE suppressed. Word
+// and LibreOffice both render such a "section-break spacer" flush below the
+// preceding paragraph (sample-13: the empty `mSectionBreak` between "Keywords"
+// and "1. INTRODUCTION" carries before=22pt but neither editor applies it). A
+// normal empty paragraph (not followed by a section break) keeps its before.
+
+interface Call { text: string; y: number; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    strokeText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function para(text: string, spaceBefore = 0): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text
+      ? [{
+          type: 'text', text, bold: false, italic: false, underline: false,
+          strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+          fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+        } as DocParagraph['runs'][number]]
+      : [],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function docOf(body: BodyElement[]): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 400, pageHeight: 600,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    // The final section (containing B) starts CONTINUOUS so the section break is
+    // not a page break and B stays on page 0 (§17.6.22 — the break is governed by
+    // the FOLLOWING section's start type).
+    sectionStart: 'continuous',
+  } as SectionProps;
+  return {
+    section,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function baselineOf(body: BodyElement[], text: string): Promise<number> {
+  const { canvas, calls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(docOf(body), canvas, 0, { dpr: 1, width: 400 });
+  const c = calls.find((k) => k.text === text);
+  expect(c, `expected to paint ${text}`).toBeDefined();
+  return (c as Call).y;
+}
+
+const SPACER_BEFORE = 20;
+
+describe('section-break spacer suppresses spacing-before (Word/LibreOffice interop)', () => {
+  it('an empty paragraph followed by a section break drops its 20pt before', async () => {
+    // [A] [empty before=20] [sectionBreak continuous] [B]
+    const spacerBody: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('', SPACER_BEFORE) as unknown as BodyElement,
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    // Control: same, but the empty paragraph is NOT followed by a section break,
+    // so it is a normal empty paragraph and keeps its 20pt before.
+    const controlBody: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('', SPACER_BEFORE) as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+
+    const aSpacer = await baselineOf(spacerBody, 'A');
+    const bSpacer = await baselineOf(spacerBody, 'B');
+    const aControl = await baselineOf(controlBody, 'A');
+    const bControl = await baselineOf(controlBody, 'B');
+
+    // 'A' is at the same place in both (nothing above it changed).
+    expect(aSpacer).toBeCloseTo(aControl, 3);
+    // The control applies the empty paragraph's 20pt before; the section-break
+    // spacer suppresses it, so B sits exactly 20pt higher.
+    expect(bControl - bSpacer).toBeCloseTo(SPACER_BEFORE, 1);
+  });
+
+  it('a NON-empty paragraph followed by a section break keeps its before (only empty spacers are suppressed)', async () => {
+    // The section-ending paragraph here has text, so it is not an inkless spacer.
+    const withText: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('X', SPACER_BEFORE) as unknown as BodyElement,
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const control: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('X', SPACER_BEFORE) as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const xWith = await baselineOf(withText, 'X');
+    const xControl = await baselineOf(control, 'X');
+    // The non-empty paragraph keeps its before regardless of the following break.
+    expect(xWith).toBeCloseTo(xControl, 1);
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -225,6 +225,14 @@ export type BodyElement =
  *  sections. */
 export type PaginatedBodyElement = BodyElement & {
   lineSlice?: { start: number; end: number };
+  /** An empty paragraph that carries a section break (an inkless paragraph
+   *  immediately followed by a `sectionBreak` element) has its spacing-BEFORE
+   *  suppressed — Word/LibreOffice render it flush below the preceding paragraph.
+   *  Stamped by the paginator because the paint pass receives per-page element
+   *  lists with the `sectionBreak` marker already consumed, so it cannot re-detect
+   *  the adjacency itself. Runtime-only — never emitted by the parser. See
+   *  `isSectionBreakSpacerAt` in renderer.ts. */
+  sectionBreakSpacer?: boolean;
   colIndex?: number;
   /** ECMA-376 §17.6.4 — the column geometry of the SECTION this element belongs
    *  to (per-section newspaper columns). Stamped by the paginator so the renderer


### PR DESCRIPTION
## Problem

In **sample-13** the heading **1. INTRODUCTION** (and the whole two-column body) sat **~22 pt too low**: the gap from "Keywords" to "1. INTRODUCTION" was **87.3 pt** vs Word's **64.4 pt**.

Between "Keywords" and the body there are **two empty `mSectionBreak` paragraphs**, each with `w:before="440"` (22 pt); the second carries the continuous section break to the two-column layout. Our renderer applies both `before`s per ECMA-376 §17.3.1.33 (max-collapse), but Word — and **LibreOffice** — render the **section-break spacer flush below the preceding paragraph** (its `before` is dropped).

The document author confirmed empirically: typing a character into the spacer line did **not** move "1. INTRODUCTION", and arrow-key navigation steps Keywords → spacer → INTRODUCTION (the section-break paragraph is not a cursor stop). So the suppression is tied to the **section-break paragraph**, not to the preceding paragraph being empty.

## Not in ECMA-376 — matched as interop behaviour

Verified independently (a prior review agent **and** Codex): §17.3.1.33 has no clause suppressing `before` for empty/section-break paragraphs; §17.3.1.9 `contextualSpacing` is the only same-style suppression and is gated on an explicit element that is **absent** here; no `[MS-DOC]`/`[MS-OI29500]` note covers it. But **Microsoft Word and LibreOffice both** render it this way — two independent implementations agree — so it is matched as a documented interop behaviour and flagged as such in `isSectionBreakSpacerAt` (no ECMA cite; revisit if a primary source surfaces).

## Fix

- `isSectionBreakSpacerAt(body, i)` = an **inkless** paragraph immediately followed by a `sectionBreak` element. Used by the paginator and the section-content-height measure (both see the full body).
- The **paint pass** receives per-page element lists with the `sectionBreak` marker already consumed, so it cannot re-detect the adjacency — the paginator stamps a `sectionBreakSpacer` tag on the element (exactly like `colTopPt` / `lineSlice`) and the paint pass reads it.
- Only the spacer's **own** `before` is dropped (gap collapses to `prev.after`, normally 0); `contextualSpacing` still drops both. Scoped to **inkless** paragraphs, so a non-empty section-ending paragraph keeps its `before`.

## Verification

- **sample-13**: "1. INTRODUCTION" 398.5 → **376.5 pt** (Word 376.2); left "1. INTRODUCTION" and right "APPENDIX" now top-aligned; 5 pages preserved.
- New unit test `section-break-spacer.test.ts`: the spacer drops its 20 pt before (B sits 20 pt higher than the no-break control); a **non-empty** section-ending paragraph keeps its before.
- docx unit: **285 passed**; root `pnpm typecheck` clean.
- docx VRT (refs = Word export PNGs): **21/21**, **sample-5 (multi-section continuous breaks) unchanged**.
- worker-equivalence: **0.000 %** (tag is set + read within the same render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)