### PR TITLE
fix(docx): gate the section-break spacer suppression to continuous breaks

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1121,6 +1121,17 @@ export function computePages(
     return section.sectionStart ?? 'nextPage';
   };
 
+  // Whether `body[idx]` is an empty section-break spacer whose break is CONTINUOUS
+  // — the precise trigger for Word's spacing-before suppression (see
+  // isSectionBreakSpacerAt). The break at idx+1 is governed by the FOLLOWING
+  // section's start type (§17.6.22), so its effective kind is sectionKindFrom of
+  // the section starting at idx+2 (the marker's own `.kind` can read "nextPage"
+  // while the section actually continues — sample-13). A next-page/odd/even break
+  // does NOT suppress (the spacer there is the closing section's trailing line on
+  // a page that is ending anyway).
+  const isContinuousSectionSpacer = (idx: number): boolean =>
+    isSectionBreakSpacerAt(body, idx) && sectionKindFrom(idx + 2) === 'continuous';
+
   // ECMA-376 §17.10.1 — the resolved header/footer set + `<w:titlePg>` flag for
   // the section that OWNS the content starting at body index `startIdx`. Mirrors
   // `sectionColumnsFrom`: the owning section's set is carried on the NEXT
@@ -1344,7 +1355,7 @@ export function computePages(
         const p = e as unknown as DocParagraph;
         if (p.pageBreakBefore) return { height: Infinity, terminated: false };
         if (p.framePr) continue; // frame is out of flow (adds no column height)
-        const suppress = contextualSuppressed(prevP, p) || isSectionBreakSpacerAt(body, j);
+        const suppress = contextualSuppressed(prevP, p) || isContinuousSectionSpacer(j);
         const before = suppress ? 0 : p.spaceBefore;
         total += estimateParagraphHeight(ms, p, colWPt, suppress, 0) - Math.min(prevAfter, before);
         prevAfter = p.spaceAfter;
@@ -1615,12 +1626,13 @@ export function computePages(
         continue;
       }
       const contextual = contextualSuppressed(prevPara, para);
-      // An empty section-break spacer drops only ITS OWN before (gap collapses to
-      // prev.after, normally 0) — NOT the previous paragraph's after (see
-      // isSectionBreakSpacerAt). contextualSpacing drops both. Stamp the element so
-      // the paint pass (which gets per-page lists with the sectionBreak already
-      // consumed, so it cannot re-detect the adjacency) applies the same drop.
-      const spacer = isSectionBreakSpacerAt(body, i);
+      // An empty CONTINUOUS-section-break spacer drops only ITS OWN before (gap
+      // collapses to prev.after, normally 0) — NOT the previous paragraph's after
+      // (see isSectionBreakSpacerAt). contextualSpacing drops both. Stamp the
+      // element so the paint pass (which gets per-page lists with the sectionBreak
+      // already consumed, so it cannot re-detect the adjacency) applies the same
+      // drop.
+      const spacer = isContinuousSectionSpacer(i);
       if (spacer) (el as PaginatedBodyElement).sectionBreakSpacer = true;
       const suppressBefore = contextual || spacer;
 
@@ -2838,28 +2850,32 @@ function isInklessParagraph(p: DocParagraph): boolean {
  * emits a sectPr-bearing paragraph as a `Paragraph` followed by a `SectionBreak`,
  * so the spacer paragraph and its break are adjacent siblings.)
  *
- * Such a paragraph's spacing-BEFORE is suppressed: it sits flush below the
- * preceding paragraph (it is a section transition, not normal content flow).
+ * This adjacency is the structural test; the CALLER additionally gates on the
+ * break being CONTINUOUS (isContinuousSectionSpacer) — that is the measured
+ * trigger. When it holds, the spacer's spacing-BEFORE is suppressed: it sits
+ * flush below the preceding paragraph (a section transition, not normal flow).
  *
- * Intentionally NOT gated to "continuous" breaks. The break's effective kind is
- * the FOLLOWING section's start type (§17.6.22), not the marker's own `.kind`
- * (sample-13's marker is `nextPage` yet renders continuous), so a `kind` check
- * here would mis-fire. The all-kinds form is safe: for a genuine next-page break
- * the spacer is the closing section's LAST line, sitting at the page bottom — the
- * next section resets to a fresh page regardless — so dropping its before can
- * only shift that one trailing empty mark up by its own before, never the
- * following content.
- *
- * NOTE — interop heuristic, not ECMA-376. §17.3.1.33 would apply the `before`
- * normally (a consumer takes `max(prev.after, this.before)`), and no clause —
- * nor any [MS-DOC] / [MS-OI29500] note — suppresses it for a section-break or
- * empty paragraph (verified independently). But Microsoft Word AND LibreOffice
- * both render it with NO before: in sample-13 the empty `mSectionBreak` spacer
- * between "Keywords" and "1. INTRODUCTION" carries `w:before="440"` (22pt); with
- * that applied the two-column body started ~22pt too low, while both editors omit
- * it (confirmed by the document author placing a character in the spacer and
- * watching the heading NOT move). This matches that shared behaviour; revisit and
- * cite if a primary source ever surfaces.
+ * NOTE — this matches Microsoft WORD's observed layout, NOT a spec rule. ECMA-376
+ * §17.3.1.33 would apply the `before` normally (a consumer takes
+ * `max(prev.after, this.before)`), and no clause — nor any [MS-DOC] /
+ * [MS-OI29500] note — suppresses it for a section-break or empty paragraph
+ * (verified independently). The model is reconstructed from Word's OWN output:
+ *   - sample-13 has two empty `mSectionBreak` paragraphs (each `w:before="440"`,
+ *     22pt) before a continuous 2-column break. Measuring the Word PDF
+ *     (pdftotext -bbox), Word keeps BOTH empty line boxes but renders them flush
+ *     — i.e. it drops exactly ONE 22pt `before` — so "1. INTRODUCTION" sits at
+ *     64.4pt below "Keywords" instead of our pre-fix 87.3pt.
+ *   - Ablation against Word's output pinned the trigger: removing the section
+ *     break removes the suppression; putting text in the spacer removes it;
+ *     changing the spacer's style does NOT (same-style is irrelevant); 1-col vs
+ *     2-col does NOT (column count is irrelevant). So: an EMPTY paragraph at a
+ *     CONTINUOUS section boundary, with only its own `before` dropped.
+ * So we drop ONLY the spacer's own `before` and keep both line boxes — Word's
+ * decomposition. (LibreOffice independently suppresses here too — corroborating
+ * that this is real, undocumented Word-compat behaviour, tdf#166503 — but via a
+ * DIFFERENT mechanism that collapses a whole paragraph (~33.5pt); we deliberately
+ * do NOT follow its amount, only Word's measured −22pt.) Revisit and cite if a
+ * primary source ever surfaces.
  */
 function isSectionBreakSpacerAt(body: ArrayLike<{ type?: string }>, i: number): boolean {
   const el = body[i] as { type?: string } | undefined;

--- a/packages/docx/src/section-break-spacer.test.ts
+++ b/packages/docx/src/section-break-spacer.test.ts
@@ -118,6 +118,32 @@ describe('section-break spacer suppresses spacing-before (Word/LibreOffice inter
     expect(bControl - bSpacer).toBeCloseTo(SPACER_BEFORE, 1);
   });
 
+  it('suppresses when the break MARKER is nextPage but the section resolves continuous (§17.6.22 — sample-13 shape)', async () => {
+    // sample-13: the sectPr-bearing spacer's break marker is kind="nextPage", yet
+    // the FOLLOWING section starts continuous (docOf sets section.sectionStart),
+    // so the EFFECTIVE break is continuous and the spacer's before is dropped. Two
+    // empty paragraphs like the real doc; the SECOND (immediately before the break)
+    // is the spacer whose before collapses against the first.
+    const body: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('', SPACER_BEFORE) as unknown as BodyElement, // empty 1
+      para('', SPACER_BEFORE) as unknown as BodyElement, // empty 2 = spacer
+      { type: 'sectionBreak', kind: 'nextPage' } as unknown as BodyElement, // marker says nextPage…
+      para('B') as unknown as BodyElement,
+    ];
+    const control: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('', SPACER_BEFORE) as unknown as BodyElement,
+      para('', SPACER_BEFORE) as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const bBody = await baselineOf(body, 'B');
+    const bControl = await baselineOf(control, 'B');
+    // …but the section resolves continuous, so the SECOND empty's before is dropped
+    // (gap empty1→empty2 = 0): B is exactly 20pt higher than the no-break control.
+    expect(bControl - bBody).toBeCloseTo(SPACER_BEFORE, 1);
+  });
+
   it('a NON-empty paragraph followed by a section break keeps its before (only empty spacers are suppressed)', async () => {
     // The section-ending paragraph here has text, so it is not an inkless spacer.
     const withText: BodyElement[] = [


### PR DESCRIPTION
Follow-up to #595 (empty section-break spacer spacing-before suppression). An ablation against **Microsoft Word's own output** pinned the exact trigger, so this tightens the gate to match Word's measured behaviour instead of firing on any section break.

## Measured (Word PDF of sample-13, `pdftotext -bbox`)

Toggling the spacer's break / style / emptiness / column count:

| change | result | conclusion |
|---|---|---|
| remove the section break | suppression gone | a break is **required** |
| put text in the spacer | suppression gone | the paragraph must be **empty** |
| change the spacer's style | still suppressed | same-style is **irrelevant** |
| 1-col vs 2-col following section | unchanged | column count is **irrelevant** |
| next-page vs continuous | only continuous suppresses | trigger is **continuous** |

So the trigger is an **empty paragraph at a continuous section boundary**, and Word keeps **both** empty line boxes while dropping exactly **one** `before` (−22pt: "1. INTRODUCTION" sits 64.4pt below "Keywords", not the pre-#595 87.3pt). #595 already does the right decomposition (drop only the spacer's own `before`, keep both lines); this adds the missing **continuous** gate.

## Change

`isContinuousSectionSpacer(idx)` = `isSectionBreakSpacerAt(body, idx) && sectionKindFrom(idx+2) === 'continuous'`. The break's effective kind is the **following section's start type** (§17.6.22), not the marker's own `.kind` — sample-13's marker reads `nextPage` yet the section continues, so a naive kind check would mis-fire. A next-page / odd / even break no longer suppresses.

## Provenance (clean-room)

This matches **Word's** layout; there is **no ECMA-376 / [MS-DOC] / [MS-OI29500] basis** (verified). LibreOffice independently suppresses here too — corroborating that this is real, undocumented **Word-compat** behaviour (tdf#166503) — but it collapses a *whole paragraph* (~33.5pt) via a different mechanism; we deliberately follow **Word's −22pt decomposition**, not LibreOffice's amount. The model is reconstructed from Word's observed output, not from any other implementation's code.

## Verification

- New test pins the §17.6.22 resolution: a `nextPage` marker whose section resolves continuous still suppresses (sample-13 shape).
- docx unit **286 passed**; root `pnpm typecheck` clean.
- docx VRT **21/21** (sample-5 multi-section unchanged); worker-equivalence 0.000%.
- Parsed sample-13: `section.sectionStart = "continuous"`, spacer's `sectionKindFrom(12)` → continuous ⇒ gate passes, suppression preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)