### PR TITLE
fix(docx): collapse zero-before continuous-section spacer to match Word

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1132,6 +1132,30 @@ export function computePages(
   const isContinuousSectionSpacer = (idx: number): boolean =>
     isSectionBreakSpacerAt(body, idx) && sectionKindFrom(idx + 2) === 'continuous';
 
+  // A continuous-section spacer whose OWN space-before is zero. Word renders NO
+  // paragraph-mark line box for it: the section mark collapses to zero height
+  // instead of occupying a blank line. (A spacer that DOES carry a space-before
+  // keeps its box — the before manifests as the blank line.)
+  //
+  // NOTE — this matches Microsoft WORD's observed layout, NOT a spec rule.
+  // §17.3.1.29 mandates that every paragraph produces one mark line box; no
+  // ECMA-376 clause (nor [MS-DOC] / [MS-OI29500]) documents a section-mark
+  // collapse. The model is reconstructed clean-room from Word's OWN output:
+  //   - sample-12's spacer is Normal with before=0. Word shows exactly ONE blank
+  //     line between "[Format…single line spacing]" and "1. INTRODUCTION" (the
+  //     user verified this by cursor-walk) and paints the heading ~24pt higher
+  //     than our prior two-blank-line layout — i.e. the spacer's own mark line is
+  //     absent (pdftotext -bbox: INTRODUCTION at 446pt, not 470pt).
+  //   - sample-13's spacer is before=440 (22pt). Word keeps its mark line (TWO
+  //     blank lines, heading at 376pt), so the collapse is gated on before=0.
+  // Both gates were pinned against the Word PDFs; we follow Word's measured
+  // behaviour, not any external implementation.
+  const isCollapsedContinuousSpacer = (idx: number): boolean => {
+    if (!isContinuousSectionSpacer(idx)) return false;
+    const p = body[idx] as unknown as DocParagraph;
+    return (p.spaceBefore ?? 0) === 0;
+  };
+
   // ECMA-376 §17.10.1 — the resolved header/footer set + `<w:titlePg>` flag for
   // the section that OWNS the content starting at body index `startIdx`. Mirrors
   // `sectionColumnsFrom`: the owning section's set is carried on the NEXT
@@ -1634,7 +1658,28 @@ export function computePages(
       // drop.
       const spacer = isContinuousSectionSpacer(i);
       if (spacer) (el as PaginatedBodyElement).sectionBreakSpacer = true;
+      // A zero-before continuous-section spacer renders NO mark line box (Word's
+      // section-mark collapse — see isCollapsedContinuousSpacer). Skip it entirely:
+      // add no height and leave prevPara/prevSpaceAfter as the paragraph BEFORE the
+      // spacer, so the next section's first paragraph spaces against it. The paint
+      // pass mirrors this by skipping the stamped element. (Still pushed so the
+      // per-page element sequence — and any section-geometry stamping keyed off it —
+      // is unchanged.)
+      if (isCollapsedContinuousSpacer(i)) {
+        (el as PaginatedBodyElement).collapsedSpacer = true;
+        pushTagged(el as PaginatedBodyElement);
+        continue;
+      }
       const suppressBefore = contextual || spacer;
+
+      // An empty paragraph that immediately precedes a COLLAPSED continuous spacer
+      // begins the section-break empty run, which Word renders FLUSH below the
+      // preceding content (the section transition collapses upward): the previous
+      // paragraph's spaceAfter is dropped too (sample-12: "[Format…]"'s 6pt after
+      // vanishes, so "1. INTRODUCTION" sits at Word's 446pt rather than ~452pt).
+      // Mirrors contextualSpacing's full drop of the previous after; no-op when the
+      // spacer is NOT collapsed (sample-13, before=22 keeps normal flow).
+      const leadsCollapsedRun = isInklessParagraph(para) && isCollapsedContinuousSpacer(i + 1);
 
       // Collapse with the previous paragraph's spaceAfter — Word takes
       // max(prev.after, this.before) between paragraphs, not the sum.
@@ -1642,7 +1687,7 @@ export function computePages(
       // §17.3.1.9 contextualSpacing: same-style adjacent paragraphs drop BOTH the
       // previous after and this before (gap = 0), keeping the paginator's fill in
       // lockstep with the paint pass.
-      const overlap = contextual ? prevSpaceAfter : Math.min(prevSpaceAfter, effectiveBefore);
+      const overlap = (contextual || leadsCollapsedRun) ? prevSpaceAfter : Math.min(prevSpaceAfter, effectiveBefore);
       y -= overlap;
       measureState.y -= overlap;
 
@@ -3093,6 +3138,13 @@ function renderBodyElements(
         renderFrameParagraph(para, state, frameAnchorLineHeightPx(elements, el, state));
         continue;
       }
+      // A zero-before continuous-section spacer renders no mark line box (Word's
+      // section-mark collapse; stamped by the paginator — see
+      // isCollapsedContinuousSpacer). Skip it: paint nothing, advance y by nothing,
+      // and leave prevPara/prevSpaceAfter as the paragraph BEFORE it so the new
+      // section's first paragraph spaces against that paragraph. Mirrors the
+      // paginator's identical skip so fill and paint stay in lockstep.
+      if ((el as PaginatedBodyElement).collapsedSpacer) continue;
       const contextual = contextualSuppressed(prevPara, para);
       // Empty section-break spacer: drop only its own before (see
       // isSectionBreakSpacerAt); contextualSpacing drops the previous after too.
@@ -3100,12 +3152,19 @@ function renderBodyElements(
       // marker is gone from this per-page list), so read the tag here.
       const spacer = !!(el as PaginatedBodyElement).sectionBreakSpacer;
       const suppress = contextual || spacer;
+      // An empty paragraph immediately before a COLLAPSED continuous spacer begins
+      // the section-break empty run; Word renders it FLUSH below the preceding
+      // content, dropping the previous paragraph's spaceAfter too (mirrors the
+      // paginator's leadsCollapsedRun). The next element carries the
+      // `collapsedSpacer` tag stamped during pagination.
+      const leadsCollapsedRun = isInklessParagraph(para)
+        && !!(elements[elIdx + 1] as PaginatedBodyElement | undefined)?.collapsedSpacer;
       // Collapse spaceAfter+spaceBefore like Word: use max, not sum.
       const effBefore = suppress ? 0 : para.spaceBefore;
       // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both
       // set it, BOTH the previous after and this before are dropped (gap = 0), not
       // just collapsed — so e.g. a code listing's lines sit tight.
-      const overlap = contextual ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+      const overlap = (contextual || leadsCollapsedRun) ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
       state.y -= overlap * state.scale;
       // Continuation slices (slice.start > 0) suppress spaceBefore: the
       // earlier slice already consumed it on the previous page. Likewise

--- a/packages/docx/src/section-break-spacer.test.ts
+++ b/packages/docx/src/section-break-spacer.test.ts
@@ -43,11 +43,11 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
   return { canvas: canvas as unknown as HTMLCanvasElement, calls };
 }
 
-function para(text: string, spaceBefore = 0): DocParagraph {
+function para(text: string, spaceBefore = 0, spaceAfter = 0): DocParagraph {
   return {
     type: 'paragraph', alignment: 'left',
     indentLeft: 0, indentRight: 0, indentFirst: 0,
-    spaceBefore, spaceAfter: 0, lineSpacing: null,
+    spaceBefore, spaceAfter, lineSpacing: null,
     numbering: null, tabStops: [],
     runs: text
       ? [{
@@ -161,5 +161,55 @@ describe('section-break spacer suppresses spacing-before (Word/LibreOffice inter
     const xControl = await baselineOf(control, 'X');
     // The non-empty paragraph keeps its before regardless of the following break.
     expect(xWith).toBeCloseTo(xControl, 1);
+  });
+});
+
+describe('collapsed continuous-section spacer — Word section-mark collapse (sample-12)', () => {
+  // NEW-a (isCollapsedContinuousSpacer): a continuous-section spacer with NO
+  // space-before of its own renders NO paragraph-mark line box (sample-12 — Word
+  // shows ONE blank line, not two, and the heading sits ~24pt higher). A spacer
+  // WITH a space-before keeps its box (sample-13). Reconstructed from Word's output.
+  it('a zero-before continuous spacer drops its mark line; a non-zero-before one keeps it', async () => {
+    const collapse: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('') as unknown as BodyElement, // spacer before=0 → collapses (no line box)
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const keepBox: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('', SPACER_BEFORE) as unknown as BodyElement, // spacer before>0 → keeps its line box
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const aCollapse = await baselineOf(collapse, 'A');
+    const bCollapse = await baselineOf(collapse, 'B');
+    const aKeep = await baselineOf(keepBox, 'A');
+    const bKeep = await baselineOf(keepBox, 'B');
+    // 'A' is unchanged in both (nothing above it differs).
+    expect(aCollapse).toBeCloseTo(aKeep, 3);
+    // The kept-box spacer adds one mark line; the collapsed one adds none — so B is
+    // strictly higher when the spacer collapses (by ~one line height). The spacer's
+    // own before is suppressed in BOTH cases, so the difference is purely the box.
+    expect(bKeep - bCollapse).toBeGreaterThan(6);
+  });
+
+  // NEW-b (leadsCollapsedRun): the empty paragraph that begins the section-break
+  // run (immediately before the collapsed spacer) sits FLUSH below the preceding
+  // paragraph — its space-after is dropped (sample-12: "[Format…]"'s 6pt after
+  // vanishes, placing the heading at Word's 446pt). No-op when not collapsing.
+  it('drops the previous paragraph space-after when an empty run leads into a collapsed spacer', async () => {
+    const mk = (aAfter: number): BodyElement[] => [
+      para('A', 0, aAfter) as unknown as BodyElement, // A carries a space-after
+      para('') as unknown as BodyElement, // empty-run start (inkless), leads the spacer
+      para('') as unknown as BodyElement, // spacer before=0 → collapses
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const bNoAfter = await baselineOf(mk(0), 'B');
+    const bBigAfter = await baselineOf(mk(40), 'B');
+    // A's 40pt space-after is dropped at the section-break run, so B does NOT move
+    // down — it stays within rounding of the no-after case.
+    expect(bBigAfter - bNoAfter).toBeCloseTo(0, 1);
   });
 });

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -233,6 +233,14 @@ export type PaginatedBodyElement = BodyElement & {
    *  the adjacency itself. Runtime-only — never emitted by the parser. See
    *  `isSectionBreakSpacerAt` in renderer.ts. */
   sectionBreakSpacer?: boolean;
+  /** A section-break spacer (see `sectionBreakSpacer`) that ALSO carries no
+   *  space-before of its own: Word renders no paragraph-mark line box for it at
+   *  a CONTINUOUS section break — the section mark collapses to zero height
+   *  rather than occupying a blank line. (A spacer WITH a space-before keeps its
+   *  line box; the before manifests as the blank line.) Stamped by the paginator
+   *  and skipped by both the fill and paint passes so they stay in lockstep. See
+   *  `isCollapsedContinuousSpacer` in renderer.ts. Runtime-only. */
+  collapsedSpacer?: boolean;
   colIndex?: number;
   /** ECMA-376 §17.6.4 — the column geometry of the SECTION this element belongs
    *  to (per-section newspaper columns). Stamped by the paginator so the renderer


### PR DESCRIPTION
## Problem

In **sample-12** the heading **\"1. INTRODUCTION\"** rendered ~24pt (one blank line + ~6pt) too low compared with Word's PDF.

Root cause: at a **continuous section break** formed by empty paragraphs, our renderer drew a mark line box for the empty paragraph that carries the `sectPr`, **and** kept the preceding paragraph's `spaceAfter`. Word does neither when that section-mark paragraph has no `space-before` of its own — it collapses the mark to zero height and sits the empty run flush below the preceding content.

This is the same Word-interop family as the existing section-break-spacer suppression (#595/#597); that fix only dropped the spacer's *own* `before`, which is `0` in sample-12, so it had no effect there.

## Fix

Reconstructed clean-room from Word's measured output (no external implementation referenced):

- **`isCollapsedContinuousSpacer`** — a continuous-section spacer whose own `space-before` is `0` renders **no mark line box** (the section mark collapses). A spacer *with* a `before` keeps its box (the before manifests as the blank line).
- **`leadsCollapsedRun`** — the empty paragraph beginning the run sits **flush** below the preceding paragraph (the previous `spaceAfter` is dropped), so the transition collapses upward.
- The paginator and the paint pass skip the collapsed spacer **in lockstep** (page fill == paint), so pagination is unchanged.

Gated on `before == 0`, which is exactly what distinguishes the two journal templates.

## Verification (browser, real fonts — what the user sees)

Measured INTRODUCTION's Y against the Word PDF (`pdftotext -bbox`), anchored on the \"Keywords\" line:

| sample | before | after | Word | result |
|---|---|---|---|---|
| **sample-12** (spacer before=0) | 470.4pt | **445.8pt** | 446.2pt | ✅ fixed (one blank line, heading flush) |
| **sample-13** (spacer before=22) | 377.6pt | **377.6pt** | 378.1pt | ✅ unchanged (two blank lines kept) |

- `packages/docx` unit tests: **294 pass** (2 new in `section-break-spacer.test.ts` isolating each facet)
- Pagination unchanged: sample-12 → 3 pages, sample-13 → 5, sample-5 → 7
- `pnpm typecheck` (root) ✅ · docx VRT **21/21** ✅ (no demo/private regression; sample-5's continuous breaks unaffected)

## Spec note

This mimics **Microsoft Word's actual layout**, not an ECMA-376 clause: §17.3.1.29 mandates that every paragraph produces one mark line box and no clause documents a section-mark collapse. The model and its `before == 0` gate are pinned against the Word PDFs of both samples. Scope is DOCX-only — `continuous` section breaks / paragraph-level `sectPr` (§17.6) have no analogue in pptx/xlsx, so no cross-package change is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)