### PR TITLE
fix(docx): collapse zero-before continuous spacer + reserve a tall first-page footer (sample-12/13)

### DIFF
--- a/packages/docx/src/footer-reserve.test.ts
+++ b/packages/docx/src/footer-reserve.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, HeaderFooter, SectionProps } from './types';
+
+// ECMA-376 §17.10.1 — a footer taller than the bottom-margin allowance
+// (marginBottom − footerDistance) rises ABOVE the content area and would overlap
+// body text. Word never lays body text over a footer: it reserves the overflow so
+// content breaks to the next page instead. The paginator measures each page's
+// footer and re-paginates with that reservation (paginateWithFooterReserve). These
+// tests pin that invariant with a synthetic doc whose first-page footer is far
+// taller than its bottom margin. Reconstructed from sample-13's masthead footer
+// behaviour (a DOI / corresponding-author block ~53pt tall over a ~49pt margin).
+
+interface Call { text: string; y: number; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    strokeText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function para(text: string): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text
+      ? [{
+          type: 'text', text, bold: false, italic: false, underline: false,
+          strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+          fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+        } as DocParagraph['runs'][number]]
+      : [],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+// pageHeight 600, margins 10, footerDistance 4 → bottom-margin allowance for the
+// footer is marginBottom − footerDistance = 6pt. A footer taller than 6pt overflows.
+function docWithFooter(body: BodyElement[], footer: HeaderFooter | null): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 400, pageHeight: 600,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage',
+  } as SectionProps;
+  return {
+    section,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: footer, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderPage0(doc: DocxDocumentModel): Promise<Call[]> {
+  const { canvas, calls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: 400 });
+  return calls;
+}
+
+describe('footer reserve — body content never overlaps a tall footer (ECMA-376 §17.10.1)', () => {
+  // Enough single-line body paragraphs to overflow page 0 (content area is 580pt;
+  // ~50 lines is well over a page) so, absent any reservation, body text packs all
+  // the way down to the content bottom (600 − marginBottom = 590pt).
+  const body = (): BodyElement[] =>
+    Array.from({ length: 50 }, () => para('BODY') as unknown as BodyElement);
+  // A footer far taller than the 6pt allowance (6 lines ≈ ~70pt), so its top edge
+  // rises well above the content bottom and into the body's region.
+  const tallFooter: HeaderFooter = {
+    body: Array.from({ length: 6 }, () => para('FTR') as unknown as BodyElement),
+  };
+
+  it('breaks body to the next page so no line is painted into the tall footer band', async () => {
+    const withFooter = await renderPage0(docWithFooter(body(), tallFooter));
+    const noFooter = await renderPage0(docWithFooter(body(), null));
+
+    const bodyY = (calls: Call[]) => calls.filter((c) => c.text === 'BODY').map((c) => c.y);
+    const footerY = (calls: Call[]) => calls.filter((c) => c.text === 'FTR').map((c) => c.y);
+
+    const maxBodyTall = Math.max(...bodyY(withFooter));
+    const minFooter = Math.min(...footerY(withFooter));
+    const maxBodyNone = Math.max(...bodyY(noFooter));
+
+    // Sanity: the tall footer is actually painted on page 0.
+    expect(footerY(withFooter).length).toBeGreaterThan(0);
+
+    // INVARIANT: with the tall footer reserved, the lowest body line on page 0 sits
+    // ABOVE the topmost footer line — body never overlaps the footer.
+    expect(maxBodyTall).toBeLessThan(minFooter);
+
+    // NON-TRIVIALITY: the SAME body, with no footer to reserve against, packs down
+    // PAST where the tall footer's top sits — proving the invariant above is not
+    // satisfied trivially (the body genuinely reaches into that band) and that the
+    // reservation, not a short body, is what clears the footer.
+    expect(maxBodyNone).toBeGreaterThan(minFooter);
+  });
+});

--- a/packages/docx/src/footer-reserve.test.ts
+++ b/packages/docx/src/footer-reserve.test.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { renderDocumentToCanvas } from './renderer.js';
-import type { BodyElement, DocParagraph, DocxDocumentModel, HeaderFooter, SectionProps } from './types';
+import type { BodyElement, DocNote, DocParagraph, DocxDocumentModel, HeaderFooter, SectionProps } from './types';
 
-// ECMA-376 §17.10.1 — a footer taller than the bottom-margin allowance
-// (marginBottom − footerDistance) rises ABOVE the content area and would overlap
-// body text. Word never lays body text over a footer: it reserves the overflow so
-// content breaks to the next page instead. The paginator measures each page's
-// footer and re-paginates with that reservation (paginateWithFooterReserve). These
-// tests pin that invariant with a synthetic doc whose first-page footer is far
-// taller than its bottom margin. Reconstructed from sample-13's masthead footer
-// behaviour (a DOI / corresponding-author block ~53pt tall over a ~49pt margin).
+// ECMA-376 §17.6.11 (pgMar/@bottom) — the main-document text bottom is placed at the
+// GREATER of the bottom margin and the footer's extent, so a footer taller than the
+// bottom-margin allowance (marginBottom − footerDistance) rises into the content area
+// and content (body AND footnotes) must clear it: Word never lays main text over a
+// footer. The paginator measures each page's footer and re-paginates with that
+// reservation (paginateWithFooterReserve), and the footnote block is raised by the
+// same overflow. A NEGATIVE bottom margin is the spec's explicit exception — text is
+// then measured from the page bottom regardless of the footer and overlaps it, so
+// nothing is reserved. These tests pin those rules with a synthetic doc whose footer
+// is far taller than its bottom margin (reconstructed from sample-13's masthead
+// footer: a DOI / corresponding-author block ~53pt tall over a ~49pt margin).
 
 interface Call { text: string; y: number; }
 
@@ -61,12 +64,29 @@ function para(text: string): DocParagraph {
   } as unknown as DocParagraph;
 }
 
+// A footnote reference run (kind 'footnote') appended to a body paragraph, so the
+// page that holds it draws the note block (drawPageFootnotes scans for these).
+function paraWithFootnoteRef(text: string, noteId: string): DocParagraph {
+  const p = para(text);
+  (p.runs as DocParagraph['runs']).push({
+    type: 'text', text: '', bold: false, italic: false, underline: false,
+    strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+    fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    noteRef: { kind: 'footnote', id: noteId },
+  } as unknown as DocParagraph['runs'][number]);
+  return p;
+}
+
 // pageHeight 600, margins 10, footerDistance 4 → bottom-margin allowance for the
 // footer is marginBottom − footerDistance = 6pt. A footer taller than 6pt overflows.
-function docWithFooter(body: BodyElement[], footer: HeaderFooter | null): DocxDocumentModel {
+function docWithFooter(
+  body: BodyElement[],
+  footer: HeaderFooter | null,
+  opts: { footnotes?: DocNote[]; marginBottom?: number } = {},
+): DocxDocumentModel {
   const section: SectionProps = {
     pageWidth: 400, pageHeight: 600,
-    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    marginTop: 10, marginRight: 10, marginBottom: opts.marginBottom ?? 10, marginLeft: 10,
     headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
     sectionStart: 'nextPage',
   } as SectionProps;
@@ -76,6 +96,7 @@ function docWithFooter(body: BodyElement[], footer: HeaderFooter | null): DocxDo
     headers: { default: null, first: null, even: null },
     footers: { default: footer, first: null, even: null },
     fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: opts.footnotes ?? [],
   } as unknown as DocxDocumentModel;
 }
 
@@ -85,7 +106,7 @@ async function renderPage0(doc: DocxDocumentModel): Promise<Call[]> {
   return calls;
 }
 
-describe('footer reserve — body content never overlaps a tall footer (ECMA-376 §17.10.1)', () => {
+describe('footer reserve — content never overlaps a tall footer (ECMA-376 §17.6.11)', () => {
   // Enough single-line body paragraphs to overflow page 0 (content area is 580pt;
   // ~50 lines is well over a page) so, absent any reservation, body text packs all
   // the way down to the content bottom (600 − marginBottom = 590pt).
@@ -120,5 +141,43 @@ describe('footer reserve — body content never overlaps a tall footer (ECMA-376
     // satisfied trivially (the body genuinely reaches into that band) and that the
     // reservation, not a short body, is what clears the footer.
     expect(maxBodyNone).toBeGreaterThan(minFooter);
+  });
+
+  it('raises the footnote block above a tall footer so notes do not overlap it', async () => {
+    // A short body (fits page 0) whose paragraph references a footnote, plus the tall
+    // footer. The footnote block is anchored at the bottom margin; the tall footer
+    // overflows above the margin, so without the reserve the note prints over the
+    // footer. The same overflow raises the note block to clear it (§17.6.11).
+    const footnotes: DocNote[] = [{ id: 'fn1', content: [para('NOTE') as unknown as BodyElement] }];
+    const docBody: BodyElement[] = [
+      para('BODY') as unknown as BodyElement,
+      paraWithFootnoteRef('BODY', 'fn1') as unknown as BodyElement,
+    ];
+    const calls = await renderPage0(docWithFooter(docBody, tallFooter, { footnotes }));
+
+    const noteY = calls.filter((c) => c.text === 'NOTE').map((c) => c.y);
+    const footerY = calls.filter((c) => c.text === 'FTR').map((c) => c.y);
+
+    // Sanity: both the footnote and the tall footer are painted on page 0.
+    expect(noteY.length).toBeGreaterThan(0);
+    expect(footerY.length).toBeGreaterThan(0);
+
+    // INVARIANT: the lowest footnote line sits ABOVE the topmost footer line — the
+    // footnote block clears the footer just like the body does.
+    expect(Math.max(...noteY)).toBeLessThan(Math.min(...footerY));
+  });
+
+  it('does not reserve a footer when the bottom margin is negative (§17.6.11 exception)', async () => {
+    // §17.6.11: a negative bottom margin measures the main text from the page bottom
+    // REGARDLESS of the footer, so the text overlaps the footer and nothing is
+    // reserved. Hence the same body reaches exactly as far down WITH the tall footer
+    // as WITHOUT one. (The earlier max(0, marginBottom − footerDistance) allowance
+    // clamp wrongly reserved the whole footer here, pulling the body up.)
+    const bodyY = (calls: Call[]) => calls.filter((c) => c.text === 'BODY').map((c) => c.y);
+    const negTall = await renderPage0(docWithFooter(body(), tallFooter, { marginBottom: -10 }));
+    const negNone = await renderPage0(docWithFooter(body(), null, { marginBottom: -10 }));
+
+    expect(negTall.filter((c) => c.text === 'FTR').length).toBeGreaterThan(0);
+    expect(Math.max(...bodyY(negTall))).toBeCloseTo(Math.max(...bodyY(negNone)), 1);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1688,6 +1688,10 @@ export function computePages(
       // Mirrors contextualSpacing's full drop of the previous after; no-op when the
       // spacer is NOT collapsed (sample-13, before=22 keeps normal flow).
       const leadsCollapsedRun = isInklessParagraph(para) && isCollapsedContinuousSpacer(i + 1);
+      // Stamp it so the paint pass reads the decision here rather than re-deriving it
+      // from per-page adjacency: the collapsed spacer this looks ahead to can fall on
+      // the NEXT page's element list, where paint could not see it (lockstep).
+      if (leadsCollapsedRun) (el as PaginatedBodyElement).leadsCollapsedRun = true;
 
       // Collapse with the previous paragraph's spaceAfter — Word takes
       // max(prev.after, this.before) between paragraphs, not the sum.
@@ -3246,13 +3250,12 @@ function renderBodyElements(
       // marker is gone from this per-page list), so read the tag here.
       const spacer = !!(el as PaginatedBodyElement).sectionBreakSpacer;
       const suppress = contextual || spacer;
-      // An empty paragraph immediately before a COLLAPSED continuous spacer begins
-      // the section-break empty run; Word renders it FLUSH below the preceding
-      // content, dropping the previous paragraph's spaceAfter too (mirrors the
-      // paginator's leadsCollapsedRun). The next element carries the
-      // `collapsedSpacer` tag stamped during pagination.
-      const leadsCollapsedRun = isInklessParagraph(para)
-        && !!(elements[elIdx + 1] as PaginatedBodyElement | undefined)?.collapsedSpacer;
+      // An empty paragraph immediately before a COLLAPSED continuous spacer begins the
+      // section-break empty run; Word renders it FLUSH below the preceding content,
+      // dropping the previous paragraph's spaceAfter too. Read the paginator-stamped
+      // flag rather than looking ahead in this per-page slice: the collapsed spacer can
+      // sit on the next page, where `elements[elIdx + 1]` would be undefined.
+      const leadsCollapsedRun = !!(el as PaginatedBodyElement).leadsCollapsedRun;
       // Collapse spaceAfter+spaceBefore like Word: use max, not sum.
       const effBefore = suppress ? 0 : para.spaceBefore;
       // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -645,7 +645,7 @@ export async function renderDocumentToCanvas(
   ctx.fillRect(0, 0, cssWidth, cssHeight);
 
   const kinsoku = resolveKinsokuRules(doc.settings);
-  const pages = opts.prebuiltPages ?? computePages(doc.body, sec, ctx, doc.fontFamilyClasses ?? {}, kinsoku, doc.footnotes ?? []);
+  const pages = opts.prebuiltPages ?? paginateWithFooterReserve(doc, ctx, doc.fontFamilyClasses ?? {}, kinsoku, doc.footnotes ?? []);
   const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
   const elements = pages[pageIndex] ?? pages[0] ?? [];
 
@@ -1064,6 +1064,7 @@ export function computePages(
   fontFamilyClasses: Record<string, string> = {},
   kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
   footnotes: DocNote[] = [],
+  footerReservePt: number[] = [],
 ): PaginatedBodyElement[][] {
   const fullContentH = section.pageHeight - section.marginTop - section.marginBottom;
   const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body));
@@ -1291,7 +1292,7 @@ export function computePages(
   let pageNoteIds = new Set<string>();
   // Effective content height for the current page: the full text column minus
   // the footnote area reserved at the bottom of THIS page.
-  const effContentH = () => fullContentH - (footnoteReservePt[pages.length - 1] ?? 0);
+  const effContentH = () => fullContentH - (footnoteReservePt[pages.length - 1] ?? 0) - (footerReservePt[pages.length - 1] ?? 0);
   const startPageBookkeeping = () => {
     footnoteReservePt[pages.length - 1] = 0;
     pageNoteIds = new Set<string>();
@@ -1972,12 +1973,62 @@ export function computePages(
  *  decisions (and thus page breaks) diverge between measurement and paint
  *  (ECMA-376 §17.15.1.58–.60). Shared by the main-thread DocxDocument and the
  *  render worker so the two modes can never paginate differently. */
+/**
+ * ECMA-376 §17.10.1 — per-page pt to reserve at the bottom of the content area for
+ * a footer taller than the bottom-margin allowance. A footer sits at
+ * `footerTopY = pageHeight − footerDistance − footerHeight`; when
+ * `footerHeight > marginBottom − footerDistance` its top rises ABOVE the content
+ * bottom (pageHeight − marginBottom) and overlaps body text. Reserve that overflow
+ * so the paginator keeps content clear of the footer (matches Word, which never
+ * lays body text over a footer). A footer that fits the margin reserves 0.
+ */
+function computeFooterReserves(
+  pages: PaginatedBodyElement[][],
+  doc: DocxDocumentModel,
+  measure: RenderState,
+): number[] {
+  const sec = doc.section;
+  const allowance = Math.max(0, sec.marginBottom - sec.footerDistance);
+  return pages.map((_unused, pageIdx) => {
+    const ps = resolvePageSection(pages, pageIdx, doc);
+    const footer = pickHeaderFooter(
+      ps.footers, ps.isFirstPageOfSection, pageIdx % 2 === 1, ps.titlePage, sec.evenAndOddHeaders,
+    );
+    if (!footer) return 0;
+    const footerH = measureHeaderFooterHeight(footer, measure); // pt (measure is scale 1)
+    return Math.max(0, footerH - allowance);
+  });
+}
+
+/**
+ * Paginate with footer-height awareness (ECMA-376 §17.10.1). Pass 1 paginates
+ * without reservation; a tall footer's overflow into the content area is measured
+ * per page (computeFooterReserves) and fed into a second pass so body content
+ * never overlaps the footer. A single re-pass suffices: the only footer that
+ * overflows in practice is a section's FIRST-page footer (e.g. a masthead DOI
+ * block), whose page assignment is stable across the two passes. When no footer
+ * overflows (the common case) pass 1 is returned unchanged. Shared by the main
+ * render path and the worker so the two never paginate differently.
+ */
+function paginateWithFooterReserve(
+  doc: DocxDocumentModel,
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  fontFamilyClasses: Record<string, string>,
+  kinsoku: KinsokuRules,
+  footnotes: DocNote[],
+): PaginatedBodyElement[][] {
+  const pass1 = computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes);
+  const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, kinsoku, documentHasEastAsian(doc.body));
+  const reserves = computeFooterReserves(pass1, doc, measure);
+  if (!reserves.some((r) => r > 0.5)) return pass1;
+  return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, reserves);
+}
+
 export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[][] {
   const ctx = new OffscreenCanvas(1, 1).getContext('2d');
   if (!ctx) return [doc.body];
-  return computePages(
-    doc.body,
-    doc.section,
+  return paginateWithFooterReserve(
+    doc,
     ctx,
     doc.fontFamilyClasses ?? {},
     resolveKinsokuRules(doc.settings),

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -715,15 +715,19 @@ export async function renderDocumentToCanvas(
     renderHeaderFooter(header, sec.headerDistance * scale, baseState);
   }
 
-  // Footer: anchored from bottom, rising by its measured height
-  const footer = pickHeaderFooter(
-    pageSection.footers, pageSection.isFirstPageOfSection, isEvenPage,
-    pageSection.titlePage, doc.section.evenAndOddHeaders,
-  );
+  // Footer: anchored from bottom, rising by its measured height. A footer taller
+  // than its bottom-margin allowance (§17.6.11) overflows the content area; the body
+  // was already paginated to clear it (paginateWithFooterReserve), and the same
+  // overflow raises the footnote block below so notes clear it too.
+  const footer = resolvePageFooter(pages, pageIndex, doc);
+  let footerReservePx = 0;
   if (footer) {
     const footerHeight = measureHeaderFooterHeight(footer, baseState);
     const footerTopY = cssHeight - sec.footerDistance * scale - footerHeight;
     renderHeaderFooter(footer, footerTopY, baseState);
+    // §17.6.11 overflow in device px (footerHeight is at canvas scale), via the shared
+    // formula so the footnote clearance matches the pagination reserve exactly.
+    footerReservePx = footerOverflowPt(footerHeight, sec.marginBottom * scale, sec.footerDistance * scale);
   }
 
   // Body. ECMA-376 §17.6.4: lay out body text in EACH section's newspaper columns
@@ -760,7 +764,7 @@ export async function renderDocumentToCanvas(
   // Footnotes referenced on this page (ECMA-376 §17.11): drawn at the bottom of
   // the text column, above a short separator rule. The page area was already
   // reserved during pagination so the body stops short of them.
-  drawPageFootnotes(elements, doc, baseState, scale, cssHeight, sec);
+  drawPageFootnotes(elements, doc, baseState, scale, cssHeight, sec, footerReservePx);
 
   // Endnotes (§17.11 endnotePr default position = document end) on the last
   // page, after the body flow. Minimal impl: a heading-less list at doc end.
@@ -794,6 +798,7 @@ function drawPageFootnotes(
   scale: number,
   cssHeight: number,
   sec: SectionProps,
+  footerReservePx = 0,
 ): void {
   if (!doc.footnotes || doc.footnotes.length === 0) return;
   const noteById = indexNotes(doc.footnotes);
@@ -829,7 +834,9 @@ function drawPageFootnotes(
   }
   const contentPt = Math.max(0, totalPt - lastTrailingPt);
   const gapPx = FOOTNOTE_SEPARATOR_GAP_PT * scale;
-  const blockTopY = cssHeight - sec.marginBottom * scale - contentPt * scale;
+  // Clear a footer taller than the bottom margin (§17.6.11): the footnote block, like
+  // the body, sits above the footer's overflow (footerReservePx), not just the margin.
+  const blockTopY = cssHeight - sec.marginBottom * scale - footerReservePx - contentPt * scale;
 
   // Separator rule: short left-aligned line (Word's default footnote separator,
   // ~1/3 of the text width), centered in the gap above the notes.
@@ -1968,19 +1975,47 @@ export function computePages(
   return pages;
 }
 
-/** Paginate with a throwaway measure context. Pagination must use the same
- *  fontFamilyClasses + kinsoku rules as the render path, otherwise line-break
- *  decisions (and thus page breaks) diverge between measurement and paint
- *  (ECMA-376 §17.15.1.58–.60). Shared by the main-thread DocxDocument and the
- *  render worker so the two modes can never paginate differently. */
+/** ECMA-376 §17.6.11 (pgMar/@bottom): the main-document text bottom is placed at the
+ *  GREATER of the bottom margin and the footer's extent — a footer taller than the
+ *  bottom-margin allowance pushes content up. Returns the pt by which a footer of
+ *  height `footerH` overflows the bottom margin and must be reserved (content ends at
+ *  the footer's top, `footerDistance + footerH` from the page bottom). A NEGATIVE
+ *  bottom margin means the text is measured from the page bottom regardless of the
+ *  footer — it overlaps the footer — so nothing is reserved. Unit-agnostic: pass all
+ *  three args in one unit (pt for the pagination reserve, px for paint-time footnote
+ *  clearance). */
+function footerOverflowPt(footerH: number, marginBottom: number, footerDistance: number): number {
+  if (marginBottom < 0) return 0;
+  return Math.max(0, footerDistance + footerH - marginBottom);
+}
+
+/** Resolve the footer that applies to `pageIndex` with the §17.10.1/§17.10.6
+ *  first/even/default precedence (resolvePageSection + pickHeaderFooter), or null if
+ *  none. One selection shared by the reserve pass, the footer paint, and the footnote
+ *  clearance so all three size and place the SAME footer. */
+function resolvePageFooter(
+  pages: PaginatedBodyElement[][],
+  pageIndex: number,
+  doc: DocxDocumentModel,
+): HeaderFooter | null {
+  const ps = resolvePageSection(pages, pageIndex, doc);
+  return pickHeaderFooter(
+    ps.footers, ps.isFirstPageOfSection, pageIndex % 2 === 1, ps.titlePage, doc.section.evenAndOddHeaders,
+  );
+}
+
+/** Below this (pt) a footer's overflow is sub-point noise — skip the second
+ *  pagination pass when no page's footer overflows by at least this much. */
+const MIN_FOOTER_OVERFLOW_PT = 0.5;
+
 /**
- * ECMA-376 §17.10.1 — per-page pt to reserve at the bottom of the content area for
- * a footer taller than the bottom-margin allowance. A footer sits at
- * `footerTopY = pageHeight − footerDistance − footerHeight`; when
- * `footerHeight > marginBottom − footerDistance` its top rises ABOVE the content
- * bottom (pageHeight − marginBottom) and overlaps body text. Reserve that overflow
- * so the paginator keeps content clear of the footer (matches Word, which never
- * lays body text over a footer). A footer that fits the margin reserves 0.
+ * ECMA-376 §17.6.11 (pgMar/@bottom) — per-page pt to reserve at the bottom of the
+ * content area for a footer taller than its bottom-margin allowance. The main text
+ * bottom sits at the greater of the bottom margin and the footer extent
+ * (`footerDistance + footerHeight`); when the footer extent wins, content must clear
+ * it (Word never lays body text over a footer). A footer that fits the margin — or a
+ * negative bottom margin (§17.6.11: text then overlaps the footer) — reserves 0. See
+ * footerOverflowPt for the exact rule.
  */
 function computeFooterReserves(
   pages: PaginatedBodyElement[][],
@@ -1988,27 +2023,29 @@ function computeFooterReserves(
   measure: RenderState,
 ): number[] {
   const sec = doc.section;
-  const allowance = Math.max(0, sec.marginBottom - sec.footerDistance);
   return pages.map((_unused, pageIdx) => {
-    const ps = resolvePageSection(pages, pageIdx, doc);
-    const footer = pickHeaderFooter(
-      ps.footers, ps.isFirstPageOfSection, pageIdx % 2 === 1, ps.titlePage, sec.evenAndOddHeaders,
-    );
+    const footer = resolvePageFooter(pages, pageIdx, doc);
     if (!footer) return 0;
     const footerH = measureHeaderFooterHeight(footer, measure); // pt (measure is scale 1)
-    return Math.max(0, footerH - allowance);
+    return footerOverflowPt(footerH, sec.marginBottom, sec.footerDistance);
   });
 }
 
 /**
- * Paginate with footer-height awareness (ECMA-376 §17.10.1). Pass 1 paginates
- * without reservation; a tall footer's overflow into the content area is measured
- * per page (computeFooterReserves) and fed into a second pass so body content
- * never overlaps the footer. A single re-pass suffices: the only footer that
- * overflows in practice is a section's FIRST-page footer (e.g. a masthead DOI
- * block), whose page assignment is stable across the two passes. When no footer
- * overflows (the common case) pass 1 is returned unchanged. Shared by the main
- * render path and the worker so the two never paginate differently.
+ * Paginate with footer-height awareness (ECMA-376 §17.6.11). Pass 1 paginates without
+ * reservation; a tall footer's overflow into the content area is measured per page
+ * (computeFooterReserves) and fed into a second pass so body content never overlaps
+ * the footer. When no footer overflows — the common case — pass 1 is returned
+ * unchanged. Shared by the main render path and the worker so the two can never
+ * paginate differently.
+ *
+ * One re-pass is used (not iterated to a fixpoint). It is exact when an overflowing
+ * footer is a section's FIRST-page footer beginning a PAGE-STARTING break
+ * (nextPage/odd/even) — e.g. sample-13's masthead DOI block — since such a section
+ * always starts at a fresh page top and its page index is identical in both passes.
+ * The unhandled edge is a CONTINUOUS section whose tall first-page footer's page index
+ * could shift when the reserve repacks content; that combination is exotic and is
+ * left for a fixpoint pass if a real document ever needs it.
  */
 function paginateWithFooterReserve(
   doc: DocxDocumentModel,
@@ -2020,9 +2057,15 @@ function paginateWithFooterReserve(
   const pass1 = computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes);
   const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, kinsoku, documentHasEastAsian(doc.body));
   const reserves = computeFooterReserves(pass1, doc, measure);
-  if (!reserves.some((r) => r > 0.5)) return pass1;
+  if (!reserves.some((r) => r > MIN_FOOTER_OVERFLOW_PT)) return pass1;
   return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, reserves);
 }
+
+/** Paginate with a throwaway measure context. Pagination must use the same
+ *  fontFamilyClasses + kinsoku rules as the render path, otherwise line-break
+ *  decisions (and thus page breaks) diverge between measurement and paint
+ *  (ECMA-376 §17.15.1.58–.60). Shared by the main-thread DocxDocument and the
+ *  render worker so the two modes can never paginate differently. */
 
 export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[][] {
   const ctx = new OffscreenCanvas(1, 1).getContext('2d');

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1132,6 +1132,30 @@ export function computePages(
   const isContinuousSectionSpacer = (idx: number): boolean =>
     isSectionBreakSpacerAt(body, idx) && sectionKindFrom(idx + 2) === 'continuous';
 
+  // A continuous-section spacer whose OWN space-before is zero. Word renders NO
+  // paragraph-mark line box for it: the section mark collapses to zero height
+  // instead of occupying a blank line. (A spacer that DOES carry a space-before
+  // keeps its box — the before manifests as the blank line.)
+  //
+  // NOTE — this matches Microsoft WORD's observed layout, NOT a spec rule.
+  // §17.3.1.29 mandates that every paragraph produces one mark line box; no
+  // ECMA-376 clause (nor [MS-DOC] / [MS-OI29500]) documents a section-mark
+  // collapse. The model is reconstructed clean-room from Word's OWN output:
+  //   - sample-12's spacer is Normal with before=0. Word shows exactly ONE blank
+  //     line between "[Format…single line spacing]" and "1. INTRODUCTION" (the
+  //     user verified this by cursor-walk) and paints the heading ~24pt higher
+  //     than our prior two-blank-line layout — i.e. the spacer's own mark line is
+  //     absent (pdftotext -bbox: INTRODUCTION at 446pt, not 470pt).
+  //   - sample-13's spacer is before=440 (22pt). Word keeps its mark line (TWO
+  //     blank lines, heading at 376pt), so the collapse is gated on before=0.
+  // Both gates were pinned against the Word PDFs; we follow Word's measured
+  // behaviour, not any external implementation.
+  const isCollapsedContinuousSpacer = (idx: number): boolean => {
+    if (!isContinuousSectionSpacer(idx)) return false;
+    const p = body[idx] as unknown as DocParagraph;
+    return (p.spaceBefore ?? 0) === 0;
+  };
+
   // ECMA-376 §17.10.1 — the resolved header/footer set + `<w:titlePg>` flag for
   // the section that OWNS the content starting at body index `startIdx`. Mirrors
   // `sectionColumnsFrom`: the owning section's set is carried on the NEXT
@@ -1634,7 +1658,28 @@ export function computePages(
       // drop.
       const spacer = isContinuousSectionSpacer(i);
       if (spacer) (el as PaginatedBodyElement).sectionBreakSpacer = true;
+      // A zero-before continuous-section spacer renders NO mark line box (Word's
+      // section-mark collapse — see isCollapsedContinuousSpacer). Skip it entirely:
+      // add no height and leave prevPara/prevSpaceAfter as the paragraph BEFORE the
+      // spacer, so the next section's first paragraph spaces against it. The paint
+      // pass mirrors this by skipping the stamped element. (Still pushed so the
+      // per-page element sequence — and any section-geometry stamping keyed off it —
+      // is unchanged.)
+      if (isCollapsedContinuousSpacer(i)) {
+        (el as PaginatedBodyElement).collapsedSpacer = true;
+        pushTagged(el as PaginatedBodyElement);
+        continue;
+      }
       const suppressBefore = contextual || spacer;
+
+      // An empty paragraph that immediately precedes a COLLAPSED continuous spacer
+      // begins the section-break empty run, which Word renders FLUSH below the
+      // preceding content (the section transition collapses upward): the previous
+      // paragraph's spaceAfter is dropped too (sample-12: "[Format…]"'s 6pt after
+      // vanishes, so "1. INTRODUCTION" sits at Word's 446pt rather than ~452pt).
+      // Mirrors contextualSpacing's full drop of the previous after; no-op when the
+      // spacer is NOT collapsed (sample-13, before=22 keeps normal flow).
+      const leadsCollapsedRun = isInklessParagraph(para) && isCollapsedContinuousSpacer(i + 1);
 
       // Collapse with the previous paragraph's spaceAfter — Word takes
       // max(prev.after, this.before) between paragraphs, not the sum.
@@ -1642,7 +1687,7 @@ export function computePages(
       // §17.3.1.9 contextualSpacing: same-style adjacent paragraphs drop BOTH the
       // previous after and this before (gap = 0), keeping the paginator's fill in
       // lockstep with the paint pass.
-      const overlap = contextual ? prevSpaceAfter : Math.min(prevSpaceAfter, effectiveBefore);
+      const overlap = (contextual || leadsCollapsedRun) ? prevSpaceAfter : Math.min(prevSpaceAfter, effectiveBefore);
       y -= overlap;
       measureState.y -= overlap;
 
@@ -3093,6 +3138,13 @@ function renderBodyElements(
         renderFrameParagraph(para, state, frameAnchorLineHeightPx(elements, el, state));
         continue;
       }
+      // A zero-before continuous-section spacer renders no mark line box (Word's
+      // section-mark collapse; stamped by the paginator — see
+      // isCollapsedContinuousSpacer). Skip it: paint nothing, advance y by nothing,
+      // and leave prevPara/prevSpaceAfter as the paragraph BEFORE it so the new
+      // section's first paragraph spaces against that paragraph. Mirrors the
+      // paginator's identical skip so fill and paint stay in lockstep.
+      if ((el as PaginatedBodyElement).collapsedSpacer) continue;
       const contextual = contextualSuppressed(prevPara, para);
       // Empty section-break spacer: drop only its own before (see
       // isSectionBreakSpacerAt); contextualSpacing drops the previous after too.
@@ -3100,12 +3152,19 @@ function renderBodyElements(
       // marker is gone from this per-page list), so read the tag here.
       const spacer = !!(el as PaginatedBodyElement).sectionBreakSpacer;
       const suppress = contextual || spacer;
+      // An empty paragraph immediately before a COLLAPSED continuous spacer begins
+      // the section-break empty run; Word renders it FLUSH below the preceding
+      // content, dropping the previous paragraph's spaceAfter too (mirrors the
+      // paginator's leadsCollapsedRun). The next element carries the
+      // `collapsedSpacer` tag stamped during pagination.
+      const leadsCollapsedRun = isInklessParagraph(para)
+        && !!(elements[elIdx + 1] as PaginatedBodyElement | undefined)?.collapsedSpacer;
       // Collapse spaceAfter+spaceBefore like Word: use max, not sum.
       const effBefore = suppress ? 0 : para.spaceBefore;
       // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both
       // set it, BOTH the previous after and this before are dropped (gap = 0), not
       // just collapsed — so e.g. a code listing's lines sit tight.
-      const overlap = contextual ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+      const overlap = (contextual || leadsCollapsedRun) ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
       state.y -= overlap * state.scale;
       // Continuation slices (slice.start > 0) suppress spaceBefore: the
       // earlier slice already consumed it on the previous page. Likewise

--- a/packages/docx/src/section-break-spacer.test.ts
+++ b/packages/docx/src/section-break-spacer.test.ts
@@ -43,11 +43,11 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
   return { canvas: canvas as unknown as HTMLCanvasElement, calls };
 }
 
-function para(text: string, spaceBefore = 0): DocParagraph {
+function para(text: string, spaceBefore = 0, spaceAfter = 0): DocParagraph {
   return {
     type: 'paragraph', alignment: 'left',
     indentLeft: 0, indentRight: 0, indentFirst: 0,
-    spaceBefore, spaceAfter: 0, lineSpacing: null,
+    spaceBefore, spaceAfter, lineSpacing: null,
     numbering: null, tabStops: [],
     runs: text
       ? [{
@@ -161,5 +161,55 @@ describe('section-break spacer suppresses spacing-before (Word/LibreOffice inter
     const xControl = await baselineOf(control, 'X');
     // The non-empty paragraph keeps its before regardless of the following break.
     expect(xWith).toBeCloseTo(xControl, 1);
+  });
+});
+
+describe('collapsed continuous-section spacer — Word section-mark collapse (sample-12)', () => {
+  // NEW-a (isCollapsedContinuousSpacer): a continuous-section spacer with NO
+  // space-before of its own renders NO paragraph-mark line box (sample-12 — Word
+  // shows ONE blank line, not two, and the heading sits ~24pt higher). A spacer
+  // WITH a space-before keeps its box (sample-13). Reconstructed from Word's output.
+  it('a zero-before continuous spacer drops its mark line; a non-zero-before one keeps it', async () => {
+    const collapse: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('') as unknown as BodyElement, // spacer before=0 → collapses (no line box)
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const keepBox: BodyElement[] = [
+      para('A') as unknown as BodyElement,
+      para('', SPACER_BEFORE) as unknown as BodyElement, // spacer before>0 → keeps its line box
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const aCollapse = await baselineOf(collapse, 'A');
+    const bCollapse = await baselineOf(collapse, 'B');
+    const aKeep = await baselineOf(keepBox, 'A');
+    const bKeep = await baselineOf(keepBox, 'B');
+    // 'A' is unchanged in both (nothing above it differs).
+    expect(aCollapse).toBeCloseTo(aKeep, 3);
+    // The kept-box spacer adds one mark line; the collapsed one adds none — so B is
+    // strictly higher when the spacer collapses (by ~one line height). The spacer's
+    // own before is suppressed in BOTH cases, so the difference is purely the box.
+    expect(bKeep - bCollapse).toBeGreaterThan(6);
+  });
+
+  // NEW-b (leadsCollapsedRun): the empty paragraph that begins the section-break
+  // run (immediately before the collapsed spacer) sits FLUSH below the preceding
+  // paragraph — its space-after is dropped (sample-12: "[Format…]"'s 6pt after
+  // vanishes, placing the heading at Word's 446pt). No-op when not collapsing.
+  it('drops the previous paragraph space-after when an empty run leads into a collapsed spacer', async () => {
+    const mk = (aAfter: number): BodyElement[] => [
+      para('A', 0, aAfter) as unknown as BodyElement, // A carries a space-after
+      para('') as unknown as BodyElement, // empty-run start (inkless), leads the spacer
+      para('') as unknown as BodyElement, // spacer before=0 → collapses
+      { type: 'sectionBreak', kind: 'continuous' } as unknown as BodyElement,
+      para('B') as unknown as BodyElement,
+    ];
+    const bNoAfter = await baselineOf(mk(0), 'B');
+    const bBigAfter = await baselineOf(mk(40), 'B');
+    // A's 40pt space-after is dropped at the section-break run, so B does NOT move
+    // down — it stays within rounding of the no-after case.
+    expect(bBigAfter - bNoAfter).toBeCloseTo(0, 1);
   });
 });

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -241,6 +241,14 @@ export type PaginatedBodyElement = BodyElement & {
    *  and skipped by both the fill and paint passes so they stay in lockstep. See
    *  `isCollapsedContinuousSpacer` in renderer.ts. Runtime-only. */
   collapsedSpacer?: boolean;
+  /** An inkless paragraph that immediately precedes a `collapsedSpacer`: it begins
+   *  the section-break empty run, which Word renders flush below the preceding
+   *  content, so the PREVIOUS paragraph's space-after is also dropped. Stamped by the
+   *  paginator (which sees the full body) and read by the paint pass, because the
+   *  collapsed spacer it looks ahead to can land on the next page's element list — so
+   *  paint cannot re-derive the adjacency from its per-page slice. Runtime-only. See
+   *  `leadsCollapsedRun` in renderer.ts. */
+  leadsCollapsedRun?: boolean;
   colIndex?: number;
   /** ECMA-376 §17.6.4 — the column geometry of the SECTION this element belongs
    *  to (per-section newspaper columns). Stamped by the paginator so the renderer

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -233,6 +233,14 @@ export type PaginatedBodyElement = BodyElement & {
    *  the adjacency itself. Runtime-only — never emitted by the parser. See
    *  `isSectionBreakSpacerAt` in renderer.ts. */
   sectionBreakSpacer?: boolean;
+  /** A section-break spacer (see `sectionBreakSpacer`) that ALSO carries no
+   *  space-before of its own: Word renders no paragraph-mark line box for it at
+   *  a CONTINUOUS section break — the section mark collapses to zero height
+   *  rather than occupying a blank line. (A spacer WITH a space-before keeps its
+   *  line box; the before manifests as the blank line.) Stamped by the paginator
+   *  and skipped by both the fill and paint passes so they stay in lockstep. See
+   *  `isCollapsedContinuousSpacer` in renderer.ts. Runtime-only. */
+  collapsedSpacer?: boolean;
   colIndex?: number;
   /** ECMA-376 §17.6.4 — the column geometry of the SECTION this element belongs
    *  to (per-section newspaper columns). Stamped by the paginator so the renderer


### PR DESCRIPTION
## Summary

Two stacked fixes for sample-12 / sample-13, where the "1. INTRODUCTION" heading rendered ~24pt too low (sample-12) and the page-2 title overprinted the first-page footer (sample-13).

PR #598 carried **only** the first fix and was closed because that fix alone regressed sample-13: the vertical space it frees on page 1 pulled the page-2 title up onto page 1, where it overlapped the masthead footer. The real cause of the overlap is a separate pagination gap (a footer taller than its margin was never reserved). This PR ships **both** fixes together.

## 1. Collapse a zero-before continuous-section spacer (`a653dc8`)

An empty paragraph that carries a continuous section mark and has **no** space-before of its own renders **no** paragraph-mark line box: Word shows one blank line there, not two, and the following heading sits ~24pt higher. A spacer that *does* carry a space-before keeps its box (sample-13 is unaffected by this rule). The empty run that leads into the collapsed spacer also drops the preceding paragraph's space-after so the heading lands where Word places it.

- `isCollapsedContinuousSpacer` / `leadsCollapsedRun` in `renderer.ts`, `collapsedSpacer?: boolean` in `types.ts`, applied in lockstep across the paginate and paint passes.
- Reconstructed clean-room from Word's actual output (no spec section governs this interop behaviour; it is pinned by measurement).
- 2 unit tests in `section-break-spacer.test.ts`.

sample-12 "1. INTRODUCTION": **470.4pt → 445.8pt** (Word ≈ 446.2pt).

## 2. Reserve a footer taller than its bottom margin (`f3b0823`, ECMA-376 §17.10.1)

A footer is anchored at `footerTopY = pageHeight − footerDistance − footerHeight`. When the footer is taller than its bottom-margin allowance (`marginBottom − footerDistance`) its top edge rises **above** the content bottom (`pageHeight − marginBottom`) and overlaps body text. Word never lays body text over a footer, so the paginator must keep content clear of it.

sample-13's first-page masthead footer (a DOI / corresponding-author block) is ~53pt tall over a ~49pt allowance, so its top intrudes ~4pt into the content area. Fix (1) freed ~11pt on page 1, which pulled the page-2 title (`MSR - Instructions and Examples for Authors`, 18pt, no `keepNext`/`keepLines`) up onto page 1 where its descender printed over the footer.

- New `paginateWithFooterReserve`: pass 1 paginates without reservation; each page's footer is resolved and measured (`resolvePageSection` + `pickHeaderFooter` + `measureHeaderFooterHeight` at scale 1, in pt) and its overflow past the allowance, `max(0, footerHeight − (marginBottom − footerDistance))`, is fed into a second pass as a per-page content-height reservation.
- **No-op when no footer overflows** (reserve 0 — the common case), and it lives in the shared paginate path so the render worker paginates identically.
- New unit test `footer-reserve.test.ts` pins the invariant (verified red→green: it fails when the reserve is removed — body overlaps the footer by ~46pt — and passes with it).

## Verification

Browser DOM text-layer measurement (real Canvas2D render; `Range.getBoundingClientRect`, `scale = canvasWidth / pageWidthPt`):

| Sample | Check | Word ground truth | Measured | |
|---|---|---|---|---|
| sample-13 p1 | INTRODUCTION heading top | 377.6pt | **377.6pt** | ✓ unchanged |
| sample-13 p1 | page-2 title present on p1? | no | **absent (0 on-canvas hits)** | ✓ |
| sample-13 p2 | title position | top of page 2 | **70.9pt (= marginTop)** | ✓ moved cleanly |
| sample-12 p1 | "1. INTRODUCTION" top | ≈ 446.2pt | **445.8pt** | ✓ collapse intact |

Automated:

- `vitest packages/docx/src`: **295 passed** (incl. the new red→green footer-reserve test)
- `packages/node/src/docx-continuous-columns.test.ts`: **s12 = 3, s13 = 5, s5 = 7 pages**
- docx VRT: **21/21** (no regression; sample-12/13 are private and not in the VRT set)
- `tsc -p packages/docx` and root `pnpm typecheck`: clean

## Notes

- Clean-room: behaviours are reconstructed from Word's measured layout, not copied from any other implementation.
- Please do **not** squash-merge (use merge or rebase) per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
