### PR TITLE
fix(docx): reserve a header taller than its top margin so body never overlaps it (§17.6.11)

### DIFF
--- a/packages/docx/src/footer-reserve.test.ts
+++ b/packages/docx/src/footer-reserve.test.ts
@@ -7,7 +7,7 @@ import type { BodyElement, DocNote, DocParagraph, DocxDocumentModel, HeaderFoote
 // bottom-margin allowance (marginBottom − footerDistance) rises into the content area
 // and content (body AND footnotes) must clear it: Word never lays main text over a
 // footer. The paginator measures each page's footer and re-paginates with that
-// reservation (paginateWithFooterReserve), and the footnote block is raised by the
+// reservation (paginateWithHeaderFooterReserve), and the footnote block is raised by the
 // same overflow. A NEGATIVE bottom margin is the spec's explicit exception — text is
 // then measured from the page bottom regardless of the footer and overlaps it, so
 // nothing is reserved. These tests pin those rules with a synthetic doc whose footer

--- a/packages/docx/src/header-reserve.test.ts
+++ b/packages/docx/src/header-reserve.test.ts
@@ -15,7 +15,7 @@ import type { BodyElement, DocParagraph, DocxDocumentModel, HeaderFooter, Sectio
 // nothing is reserved. These tests pin those rules with a synthetic doc whose header is
 // far taller than its top margin (the header-side mirror of sample-13's masthead).
 
-interface Call { text: string; y: number; }
+interface Call { text: string; x: number; y: number; }
 
 function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
   let font = '10px serif';
@@ -38,8 +38,8 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
     setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
     bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
     drawImage() {},
-    fillText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
-    strokeText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    fillText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    strokeText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
     fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
     textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
     globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
@@ -70,13 +70,13 @@ function para(text: string): DocParagraph {
 function docWithHeader(
   body: BodyElement[],
   header: HeaderFooter | null,
-  opts: { marginTop?: number } = {},
+  opts: { marginTop?: number; pageHeight?: number; columns?: SectionProps['columns'] } = {},
 ): DocxDocumentModel {
   const section: SectionProps = {
-    pageWidth: 400, pageHeight: 600,
+    pageWidth: 400, pageHeight: opts.pageHeight ?? 600,
     marginTop: opts.marginTop ?? 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
     headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
-    sectionStart: 'nextPage',
+    sectionStart: 'nextPage', columns: opts.columns ?? null,
   } as SectionProps;
   return {
     section,
@@ -128,6 +128,30 @@ describe('header reserve — content never overlaps a tall header (ECMA-376 §17
     // above is not satisfied trivially and that the reservation, not a short header, is
     // what clears the header band.
     expect(minBodyNone).toBeLessThan(maxHeader);
+  });
+
+  it('starts EVERY newspaper column below a tall header (ECMA-376 §17.6.4 + §17.6.11)', async () => {
+    // The reserve shrinks the content area from the top for the WHOLE page, not just
+    // column 0. A short page so column 0 overflows into column 1 on page 0; a tall
+    // header that overflows the top margin. Each newspaper column (§17.6.4) restarts
+    // at the section's region top, which must be the RESERVED top, not the bare margin.
+    const cols = { count: 2, spacePt: 20, equalWidth: true, sep: false, cols: [] };
+    const manyBody = Array.from({ length: 40 }, () => para('BODY') as unknown as BodyElement);
+    const calls = await renderPage0(docWithHeader(manyBody, tallHeader, { columns: cols, pageHeight: 300 }));
+
+    const bodyCalls = calls.filter((c) => c.text === 'BODY');
+    const headerY = calls.filter((c) => c.text === 'HDR').map((c) => c.y);
+
+    // Preconditions: the header is painted, and the body genuinely reached the SECOND
+    // column (≥2 distinct x positions) — otherwise the invariant below is vacuous.
+    expect(headerY.length).toBeGreaterThan(0);
+    const distinctX = new Set(bodyCalls.map((c) => Math.round(c.x)));
+    expect(distinctX.size).toBeGreaterThanOrEqual(2);
+
+    // INVARIANT: the topmost body line across BOTH columns sits below the bottom-most
+    // header line. Pre-fix, column 1 reset to the bare top margin and painted into the
+    // header band (its first line is the global minimum), so this caught the overlap.
+    expect(Math.min(...bodyCalls.map((c) => c.y))).toBeGreaterThan(Math.max(...headerY));
   });
 
   it('does not reserve a header when the top margin is negative (§17.6.11 exception)', async () => {

--- a/packages/docx/src/header-reserve.test.ts
+++ b/packages/docx/src/header-reserve.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, HeaderFooter, SectionProps } from './types';
+
+// ECMA-376 §17.6.11 (pgMar/@top) — the SYMMETRIC twin of the footer rule in
+// footer-reserve.test.ts. The main-document text TOP is placed at the GREATER of the
+// top margin and the header's extent ("The value of top / The extent of the header
+// text"), so a header taller than its top-margin allowance (marginTop − headerDistance)
+// rises into the content area and the body must start BELOW it: Word never lays main
+// text over a header ("the main text extent ends at the bottom of the header region").
+// The paginator reserves that overflow at the TOP of every page's content area and the
+// body's first line is pushed down by the same amount. A NEGATIVE top margin is the
+// spec's explicit exception — the main text is then "measured from the top of the page
+// extent regardless of the header ... and therefore shall overlap the header text", so
+// nothing is reserved. These tests pin those rules with a synthetic doc whose header is
+// far taller than its top margin (the header-side mirror of sample-13's masthead).
+
+interface Call { text: string; y: number; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    strokeText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function para(text: string): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text
+      ? [{
+          type: 'text', text, bold: false, italic: false, underline: false,
+          strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+          fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+        } as DocParagraph['runs'][number]]
+      : [],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+// pageHeight 600, margins 10, headerDistance 4 → top-margin allowance for the header
+// is marginTop − headerDistance = 6pt. A header taller than 6pt overflows the top.
+function docWithHeader(
+  body: BodyElement[],
+  header: HeaderFooter | null,
+  opts: { marginTop?: number } = {},
+): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 400, pageHeight: 600,
+    marginTop: opts.marginTop ?? 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage',
+  } as SectionProps;
+  return {
+    section,
+    body,
+    headers: { default: header, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderPage0(doc: DocxDocumentModel): Promise<Call[]> {
+  const { canvas, calls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: 400 });
+  return calls;
+}
+
+describe('header reserve — content never overlaps a tall header (ECMA-376 §17.6.11)', () => {
+  // A few single-line body paragraphs (page 0 holds them comfortably) — enough to read
+  // the topmost body line. The reserve, not a long body, is what places that line.
+  const body = (): BodyElement[] =>
+    Array.from({ length: 6 }, () => para('BODY') as unknown as BodyElement);
+  // A header far taller than the 6pt allowance (6 lines ≈ ~70pt), so its bottom edge
+  // sinks well below the top margin and into the body's region.
+  const tallHeader: HeaderFooter = {
+    body: Array.from({ length: 6 }, () => para('HDR') as unknown as BodyElement),
+  };
+
+  it('starts the body below a tall header so no line is painted into the header band', async () => {
+    const withHeader = await renderPage0(docWithHeader(body(), tallHeader));
+    const noHeader = await renderPage0(docWithHeader(body(), null));
+
+    const bodyY = (calls: Call[]) => calls.filter((c) => c.text === 'BODY').map((c) => c.y);
+    const headerY = (calls: Call[]) => calls.filter((c) => c.text === 'HDR').map((c) => c.y);
+
+    const minBodyTall = Math.min(...bodyY(withHeader));
+    const maxHeader = Math.max(...headerY(withHeader));
+    const minBodyNone = Math.min(...bodyY(noHeader));
+
+    // Sanity: the tall header is actually painted on page 0.
+    expect(headerY(withHeader).length).toBeGreaterThan(0);
+
+    // INVARIANT: with the tall header reserved, the topmost body line on page 0 sits
+    // BELOW the bottom-most header line — body never overlaps the header.
+    expect(minBodyTall).toBeGreaterThan(maxHeader);
+
+    // NON-TRIVIALITY: the SAME body, with no header to reserve against, starts at the
+    // top margin — ABOVE where the tall header's bottom sits — proving the invariant
+    // above is not satisfied trivially and that the reservation, not a short header, is
+    // what clears the header band.
+    expect(minBodyNone).toBeLessThan(maxHeader);
+  });
+
+  it('does not reserve a header when the top margin is negative (§17.6.11 exception)', async () => {
+    // §17.6.11: a negative top margin measures the main text from the page top
+    // REGARDLESS of the header, so the text overlaps the header and nothing is
+    // reserved. Hence the same body starts at exactly the same y WITH the tall header
+    // as WITHOUT one. (A naive max(0, header extent − top) without the negative-top
+    // guard would wrongly reserve the whole header here, pushing the body down.)
+    const bodyY = (calls: Call[]) => calls.filter((c) => c.text === 'BODY').map((c) => c.y);
+    const negTall = await renderPage0(docWithHeader(body(), tallHeader, { marginTop: -10 }));
+    const negNone = await renderPage0(docWithHeader(body(), null, { marginTop: -10 }));
+
+    expect(negTall.filter((c) => c.text === 'HDR').length).toBeGreaterThan(0);
+    expect(Math.min(...bodyY(negTall))).toBeCloseTo(Math.min(...bodyY(negNone)), 1);
+  });
+});

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -153,6 +153,29 @@ describe('computePages — empty-paragraph relocation (C2: §17.3.1.29)', () => 
   });
 });
 
+describe('computePages — tall header/footer reserve indexing (§17.6.11)', () => {
+  it('applies a uniform reserve to EVERY page, not just those in the array (pass-2 page growth)', () => {
+    // The two-pass paginator computes reserves from pass 1, then re-paginates; a tall
+    // header shrinks every page from the top, so pass 2 routinely has MORE pages than
+    // pass 1. A page index past the reserve array must clamp to the last entry (the
+    // uniform reserve), not fall to zero — else later pages stay un-reserved, over-pack,
+    // and the down-shifted body overflows the bottom margin.
+    // content height = 100; empty mark = 20px → 5/page bare, 4/page with a 20px top reserve.
+    const body = Array.from({ length: 14 }, () => para());
+    const reserve = { top: 20, bottom: 0 };
+    // A single-entry array expresses "uniform 20px top reserve" (one page measured).
+    const short = computePages(body, section(), makeCtx(), {}, undefined, [], [reserve]);
+    // The same reserve spelled out for more pages than the body can ever need.
+    const full = computePages(body, section(), makeCtx(), {}, undefined, [], Array.from({ length: 14 }, () => reserve));
+    // The short (clamped) array must paginate identically to the fully-specified one.
+    expect(short.map((p) => p.length)).toEqual(full.map((p) => p.length));
+    // Non-triviality: the reserve really is in force (4 per page, not the bare 5) and
+    // the body genuinely spans several pages where the clamp matters.
+    expect(short[0].length).toBe(4);
+    expect(short.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
 describe('computePages — line-boundary splitting + widowControl (C1: §17.3.1.44)', () => {
   // contentW = 160, glyph advance = fontPx; at 20px → 8 chars/line. 48 chars → 6 lines.
   // content height = 100 → 5 lines (100px) fit per page.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -645,7 +645,7 @@ export async function renderDocumentToCanvas(
   ctx.fillRect(0, 0, cssWidth, cssHeight);
 
   const kinsoku = resolveKinsokuRules(doc.settings);
-  const pages = opts.prebuiltPages ?? paginateWithFooterReserve(doc, ctx, doc.fontFamilyClasses ?? {}, kinsoku, doc.footnotes ?? []);
+  const pages = opts.prebuiltPages ?? paginateWithHeaderFooterReserve(doc, ctx, doc.fontFamilyClasses ?? {}, kinsoku, doc.footnotes ?? []);
   const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
   const elements = pages[pageIndex] ?? pages[0] ?? [];
 
@@ -706,18 +706,26 @@ export async function renderDocumentToCanvas(
   const pageSection = resolvePageSection(pages, pageIndex, doc);
   const isEvenPage = pageIndex % 2 === 1;
 
-  // Header: top of page, starting at headerDistance
+  // Header: top of page, starting at headerDistance. A header taller than its
+  // top-margin allowance (§17.6.11) overflows the content area downward; the body
+  // was already paginated to clear it (paginateWithHeaderFooterReserve), and its
+  // start y is pushed down by the same overflow so no body line sits over the header.
   const header = pickHeaderFooter(
     pageSection.headers, pageSection.isFirstPageOfSection, isEvenPage,
     pageSection.titlePage, doc.section.evenAndOddHeaders,
   );
+  let headerReservePx = 0;
   if (header) {
+    const headerHeight = measureHeaderFooterHeight(header, baseState);
     renderHeaderFooter(header, sec.headerDistance * scale, baseState);
+    // §17.6.11 overflow in device px (headerHeight is at canvas scale), via the shared
+    // formula so the body start matches the pagination reserve exactly.
+    headerReservePx = headerOverflowPt(headerHeight, sec.marginTop * scale, sec.headerDistance * scale);
   }
 
   // Footer: anchored from bottom, rising by its measured height. A footer taller
   // than its bottom-margin allowance (§17.6.11) overflows the content area; the body
-  // was already paginated to clear it (paginateWithFooterReserve), and the same
+  // was already paginated to clear it (paginateWithHeaderFooterReserve), and the same
   // overflow raises the footnote block below so notes clear it too.
   const footer = resolvePageFooter(pages, pageIndex, doc);
   let footerReservePx = 0;
@@ -735,7 +743,11 @@ export async function renderDocumentToCanvas(
   // used as the fallback for elements that carry no per-section `colGeom` (single-
   // section docs, where it equals the whole-body geometry — unchanged path).
   const columns = computeColumns(sec);
-  const bodyState: RenderState = { ...baseState, y: sec.marginTop * scale };
+  // ECMA-376 §17.6.11 (pgMar/@top): the body starts at the GREATER of the top margin
+  // and the header's extent, so a tall header (headerReservePx > 0) pushes the first
+  // body line down to the header's bottom. The same overflow shrank the paginated
+  // content area from the top (computeHeaderReserves), so the body fits within margins.
+  const bodyState: RenderState = { ...baseState, y: sec.marginTop * scale + headerReservePx };
   // Optional column separator rules (`<w:cols w:sep="1">`), drawn before the text
   // so glyphs sit on top. A thin rule is centred in each inter-column gap and
   // spans the content height. With per-section columns a page can carry more than
@@ -1072,6 +1084,7 @@ export function computePages(
   kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
   footnotes: DocNote[] = [],
   footerReservePt: number[] = [],
+  headerReservePt: number[] = [],
 ): PaginatedBodyElement[][] {
   const fullContentH = section.pageHeight - section.marginTop - section.marginBottom;
   const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body));
@@ -1297,9 +1310,16 @@ export function computePages(
   // references the same note twice doesn't double-count, and the renderer draws
   // each note once). Reset on every page flip.
   let pageNoteIds = new Set<string>();
-  // Effective content height for the current page: the full text column minus
-  // the footnote area reserved at the bottom of THIS page.
-  const effContentH = () => fullContentH - (footnoteReservePt[pages.length - 1] ?? 0) - (footerReservePt[pages.length - 1] ?? 0);
+  // Effective content height for the current page: the full text column minus the
+  // footnote + tall-footer reserve at the BOTTOM and the tall-header reserve at the TOP
+  // of THIS page (ECMA-376 §17.6.11). The body cursor is page-relative (0 = content
+  // top); the header reserve also shifts the render-time body start down by the same
+  // amount (renderDocumentToCanvas), so reducing the height here keeps the body within
+  // the bottom margin while it begins below the header.
+  const effContentH = () => fullContentH
+    - (footnoteReservePt[pages.length - 1] ?? 0)
+    - (footerReservePt[pages.length - 1] ?? 0)
+    - (headerReservePt[pages.length - 1] ?? 0);
   const startPageBookkeeping = () => {
     footnoteReservePt[pages.length - 1] = 0;
     pageNoteIds = new Set<string>();
@@ -1993,6 +2013,20 @@ function footerOverflowPt(footerH: number, marginBottom: number, footerDistance:
   return Math.max(0, footerDistance + footerH - marginBottom);
 }
 
+/** ECMA-376 §17.6.11 (pgMar/@top): the SYMMETRIC twin of footerOverflowPt. The
+ *  main-document text TOP is placed at the GREATER of the top margin and the header's
+ *  extent — a header taller than the top-margin allowance pushes content DOWN. Returns
+ *  the pt by which a header of height `headerH` overflows the top margin and must be
+ *  reserved (content starts at the header's bottom, `headerDistance + headerH` from the
+ *  page top). A NEGATIVE top margin means the text is measured from the page top
+ *  regardless of the header — it overlaps the header — so nothing is reserved.
+ *  Unit-agnostic: pass all three args in one unit (pt for the pagination reserve, px
+ *  for the paint-time body start). */
+function headerOverflowPt(headerH: number, marginTop: number, headerDistance: number): number {
+  if (marginTop < 0) return 0;
+  return Math.max(0, headerDistance + headerH - marginTop);
+}
+
 /** Resolve the footer that applies to `pageIndex` with the §17.10.1/§17.10.6
  *  first/even/default precedence (resolvePageSection + pickHeaderFooter), or null if
  *  none. One selection shared by the reserve pass, the footer paint, and the footnote
@@ -2008,9 +2042,23 @@ function resolvePageFooter(
   );
 }
 
-/** Below this (pt) a footer's overflow is sub-point noise — skip the second
- *  pagination pass when no page's footer overflows by at least this much. */
-const MIN_FOOTER_OVERFLOW_PT = 0.5;
+/** Resolve the header that applies to `pageIndex` with the same §17.10.1/§17.10.6
+ *  first/even/default precedence as resolvePageFooter. One selection shared by the
+ *  reserve pass and the header paint so both size and place the SAME header. */
+function resolvePageHeader(
+  pages: PaginatedBodyElement[][],
+  pageIndex: number,
+  doc: DocxDocumentModel,
+): HeaderFooter | null {
+  const ps = resolvePageSection(pages, pageIndex, doc);
+  return pickHeaderFooter(
+    ps.headers, ps.isFirstPageOfSection, pageIndex % 2 === 1, ps.titlePage, doc.section.evenAndOddHeaders,
+  );
+}
+
+/** Below this (pt) a header's/footer's overflow is sub-point noise — skip the second
+ *  pagination pass when no page's header or footer overflows by at least this much. */
+const MIN_MARGIN_OVERFLOW_PT = 0.5;
 
 /**
  * ECMA-376 §17.6.11 (pgMar/@bottom) — per-page pt to reserve at the bottom of the
@@ -2036,22 +2084,46 @@ function computeFooterReserves(
 }
 
 /**
- * Paginate with footer-height awareness (ECMA-376 §17.6.11). Pass 1 paginates without
- * reservation; a tall footer's overflow into the content area is measured per page
- * (computeFooterReserves) and fed into a second pass so body content never overlaps
- * the footer. When no footer overflows — the common case — pass 1 is returned
+ * ECMA-376 §17.6.11 (pgMar/@top) — the SYMMETRIC twin of computeFooterReserves: the
+ * per-page pt to reserve at the TOP of the content area for a header taller than its
+ * top-margin allowance. The main text top sits at the greater of the top margin and the
+ * header extent (`headerDistance + headerHeight`); when the header extent wins, the body
+ * starts at the header's bottom (Word never lays body text over a header). A header that
+ * fits the margin — or a negative top margin (§17.6.11: text then overlaps the header) —
+ * reserves 0. See headerOverflowPt for the exact rule.
+ */
+function computeHeaderReserves(
+  pages: PaginatedBodyElement[][],
+  doc: DocxDocumentModel,
+  measure: RenderState,
+): number[] {
+  const sec = doc.section;
+  return pages.map((_unused, pageIdx) => {
+    const header = resolvePageHeader(pages, pageIdx, doc);
+    if (!header) return 0;
+    const headerH = measureHeaderFooterHeight(header, measure); // pt (measure is scale 1)
+    return headerOverflowPt(headerH, sec.marginTop, sec.headerDistance);
+  });
+}
+
+/**
+ * Paginate with header/footer-height awareness (ECMA-376 §17.6.11). Pass 1 paginates
+ * without reservation; a header or footer taller than its margin allowance overflows
+ * the content area (computeHeaderReserves reserves at the top, computeFooterReserves at
+ * the bottom, measured per page) and both are fed into a second pass so body content
+ * never overlaps either. When nothing overflows — the common case — pass 1 is returned
  * unchanged. Shared by the main render path and the worker so the two can never
  * paginate differently.
  *
  * One re-pass is used (not iterated to a fixpoint). It is exact when an overflowing
- * footer is a section's FIRST-page footer beginning a PAGE-STARTING break
- * (nextPage/odd/even) — e.g. sample-13's masthead DOI block — since such a section
- * always starts at a fresh page top and its page index is identical in both passes.
- * The unhandled edge is a CONTINUOUS section whose tall first-page footer's page index
- * could shift when the reserve repacks content; that combination is exotic and is
+ * header/footer applies uniformly across pages (the usual default header/footer) or is a
+ * section's FIRST-page header/footer beginning a PAGE-STARTING break (nextPage/odd/even)
+ * — e.g. sample-13's masthead — since the page index is then identical in both passes.
+ * The unhandled edge is a CONTINUOUS section whose tall first-page header/footer's page
+ * index could shift when the reserve repacks content; that combination is exotic and is
  * left for a fixpoint pass if a real document ever needs it.
  */
-function paginateWithFooterReserve(
+function paginateWithHeaderFooterReserve(
   doc: DocxDocumentModel,
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   fontFamilyClasses: Record<string, string>,
@@ -2060,9 +2132,11 @@ function paginateWithFooterReserve(
 ): PaginatedBodyElement[][] {
   const pass1 = computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes);
   const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, kinsoku, documentHasEastAsian(doc.body));
-  const reserves = computeFooterReserves(pass1, doc, measure);
-  if (!reserves.some((r) => r > MIN_FOOTER_OVERFLOW_PT)) return pass1;
-  return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, reserves);
+  const footerReserves = computeFooterReserves(pass1, doc, measure);
+  const headerReserves = computeHeaderReserves(pass1, doc, measure);
+  const overflows = (rs: number[]): boolean => rs.some((r) => r > MIN_MARGIN_OVERFLOW_PT);
+  if (!overflows(footerReserves) && !overflows(headerReserves)) return pass1;
+  return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, footerReserves, headerReserves);
 }
 
 /** Paginate with a throwaway measure context. Pagination must use the same
@@ -2074,7 +2148,7 @@ function paginateWithFooterReserve(
 export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[][] {
   const ctx = new OffscreenCanvas(1, 1).getContext('2d');
   if (!ctx) return [doc.body];
-  return paginateWithFooterReserve(
+  return paginateWithHeaderFooterReserve(
     doc,
     ctx,
     doc.fontFamilyClasses ?? {},

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -698,22 +698,19 @@ export async function renderDocumentToCanvas(
     noteNumbers,
   };
 
-  // ECMA-376 §17.10.1 — per-section header/footer selection. Resolve the section
-  // active at the top of this page (and whether it's that section's first page)
-  // from the paginated elements' stamped `sectionHF`, then apply the spec
-  // precedence (first → even → default). Single-section docs resolve to
-  // doc.headers/footers/section.titlePage, unchanged.
-  const pageSection = resolvePageSection(pages, pageIndex, doc);
-  const isEvenPage = pageIndex % 2 === 1;
+  // ECMA-376 §17.10.1 — per-section header/footer selection. resolvePageHeader and
+  // resolvePageFooter resolve the section active at the top of this page (and whether
+  // it is that section's first page) from the paginated elements' stamped `sectionHF`,
+  // then apply the spec precedence (first → even → default). Single-section docs
+  // resolve to doc.headers/footers/section.titlePage, unchanged. The paint path uses
+  // the SAME resolvers as the reserve pass (computeHeaderReserves / computeFooterReserves)
+  // so the body's start/end can never drift from the gap pagination reserved.
 
   // Header: top of page, starting at headerDistance. A header taller than its
   // top-margin allowance (§17.6.11) overflows the content area downward; the body
   // was already paginated to clear it (paginateWithHeaderFooterReserve), and its
   // start y is pushed down by the same overflow so no body line sits over the header.
-  const header = pickHeaderFooter(
-    pageSection.headers, pageSection.isFirstPageOfSection, isEvenPage,
-    pageSection.titlePage, doc.section.evenAndOddHeaders,
-  );
+  const header = resolvePageHeader(pages, pageIndex, doc);
   let headerReservePx = 0;
   if (header) {
     const headerHeight = measureHeaderFooterHeight(header, baseState);
@@ -771,7 +768,7 @@ export async function renderDocumentToCanvas(
     if (geoms.length === 0 && columns.length > 1) geoms.push(columns);
     for (const g of geoms) drawColumnSeparators(ctx, g, sec, scale);
   }
-  renderBodyElements(elements, bodyState, columns);
+  renderBodyElements(elements, bodyState, columns, headerReservePx);
 
   // Footnotes referenced on this page (ECMA-376 §17.11): drawn at the bottom of
   // the text column, above a short separator rule. The page area was already
@@ -1076,6 +1073,13 @@ export function computeColumns(section: SectionProps): ColumnGeom[] {
   return out;
 }
 
+/** ECMA-376 §17.6.11 — the per-page content-area insets (pt) reserved for a header
+ *  taller than its top-margin allowance (`top`) and a footer taller than its
+ *  bottom-margin allowance (`bottom`). One value per page; see headerOverflowPt /
+ *  footerOverflowPt. */
+interface PageReserve { top: number; bottom: number }
+const ZERO_RESERVE: PageReserve = { top: 0, bottom: 0 };
+
 export function computePages(
   body: BodyElement[],
   section: SectionProps,
@@ -1083,8 +1087,9 @@ export function computePages(
   fontFamilyClasses: Record<string, string> = {},
   kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
   footnotes: DocNote[] = [],
-  footerReservePt: number[] = [],
-  headerReservePt: number[] = [],
+  /** Per-page tall header/footer reserve (ECMA-376 §17.6.11). Empty ⇒ no reserve
+   *  (the common case). Computed by paginateWithHeaderFooterReserve's second pass. */
+  pageReserves: PageReserve[] = [],
 ): PaginatedBodyElement[][] {
   const fullContentH = section.pageHeight - section.marginTop - section.marginBottom;
   const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body));
@@ -1316,10 +1321,17 @@ export function computePages(
   // top); the header reserve also shifts the render-time body start down by the same
   // amount (renderDocumentToCanvas), so reducing the height here keeps the body within
   // the bottom margin while it begins below the header.
-  const effContentH = () => fullContentH
-    - (footnoteReservePt[pages.length - 1] ?? 0)
-    - (footerReservePt[pages.length - 1] ?? 0)
-    - (headerReservePt[pages.length - 1] ?? 0);
+  // Clamp past the array end to the last entry: a tall header/footer shrinks every
+  // page, so this (second) pass can have MORE pages than the (first) pass the reserves
+  // were measured over. For a uniform header/footer the last measured reserve is the
+  // right value for any extra page (and a first-page-only reserve's last entry is 0,
+  // also correct). Empty ⇒ no reserve (the common no-overflow path).
+  const reserveAt = (i: number): PageReserve =>
+    pageReserves.length === 0 ? ZERO_RESERVE : (pageReserves[Math.min(i, pageReserves.length - 1)] ?? ZERO_RESERVE);
+  const effContentH = () => {
+    const r = reserveAt(pages.length - 1);
+    return fullContentH - (footnoteReservePt[pages.length - 1] ?? 0) - r.bottom - r.top;
+  };
   const startPageBookkeeping = () => {
     footnoteReservePt[pages.length - 1] = 0;
     pageNoteIds = new Set<string>();
@@ -2115,13 +2127,20 @@ function computeHeaderReserves(
  * unchanged. Shared by the main render path and the worker so the two can never
  * paginate differently.
  *
- * One re-pass is used (not iterated to a fixpoint). It is exact when an overflowing
- * header/footer applies uniformly across pages (the usual default header/footer) or is a
- * section's FIRST-page header/footer beginning a PAGE-STARTING break (nextPage/odd/even)
- * — e.g. sample-13's masthead — since the page index is then identical in both passes.
- * The unhandled edge is a CONTINUOUS section whose tall first-page header/footer's page
- * index could shift when the reserve repacks content; that combination is exotic and is
- * left for a fixpoint pass if a real document ever needs it.
+ * One re-pass is used (not iterated to a fixpoint), with two bounded approximations:
+ *  - Page-count growth: a tall reserve shrinks every page, so pass 2 can have MORE pages
+ *    than the pass-1 reserve array covers. computePages clamps a past-the-end page to the
+ *    last reserve — exact for a uniform header/footer (every page the same) and for a
+ *    first-page-only reserve (its trailing entry is 0). An even/odd header of DIFFERING
+ *    height on a grown page is the residual gap (exotic, untested).
+ *  - Page-index shift: a CONTINUOUS section whose tall first-page header/footer's page
+ *    index moves when the reserve repacks content is left for a fixpoint pass if a real
+ *    document ever needs it (sample-13's masthead begins a PAGE-STARTING break, so its
+ *    index is identical in both passes).
+ * The reserve shrinks the content height and shifts the body start; it does NOT re-anchor
+ * page-level floats (wrapTopAndBottom / page-anchored), which still measure from the bare
+ * top margin. No bundled document pairs a tall header/footer with such a float; if one
+ * arises, shift measureState.y by the reserve at each page open to keep floats in frame.
  */
 function paginateWithHeaderFooterReserve(
   doc: DocxDocumentModel,
@@ -2136,7 +2155,11 @@ function paginateWithHeaderFooterReserve(
   const headerReserves = computeHeaderReserves(pass1, doc, measure);
   const overflows = (rs: number[]): boolean => rs.some((r) => r > MIN_MARGIN_OVERFLOW_PT);
   if (!overflows(footerReserves) && !overflows(headerReserves)) return pass1;
-  return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, footerReserves, headerReserves);
+  const pageReserves = pass1.map((_unused, i): PageReserve => ({
+    top: headerReserves[i] ?? 0,
+    bottom: footerReserves[i] ?? 0,
+  }));
+  return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, pageReserves);
 }
 
 /** Paginate with a throwaway measure context. Pagination must use the same
@@ -3196,6 +3219,13 @@ function renderBodyElements(
    *  footer, single-column). Omitted ⇒ the state's existing full-width
    *  contentX/contentW is used unchanged. */
   columns?: ColumnGeom[],
+  /** ECMA-376 §17.6.11 — device-px the content top is reserved below the top
+   *  margin for a header taller than its top-margin allowance. `state.y` already
+   *  carries it for column 0 (the caller's `bodyState.y`); it must be re-added
+   *  whenever a newspaper column (§17.6.4) restarts at its section's region top,
+   *  which is otherwise a bare-margin `colTopPt`. 0 (default) for header/footer
+   *  and nested renders, which have no such reserve. */
+  headerReservePx = 0,
 ): void {
   let prevPara: DocParagraph | null = null;
   let prevSpaceAfter = 0;
@@ -3272,8 +3302,10 @@ function renderBodyElements(
         // the preceding single-column content, not the page content top. The
         // paginator computed and stamped it (`colTopPt`, page-absolute pt); the
         // paint pass consumes it rather than re-deriving the column top. Absent ⇒
-        // a page-spanning section ⇒ the page content top, unchanged.
-        state.y = (el.colTopPt ?? state.marginTop) * state.scale;
+        // a page-spanning section ⇒ the page content top, unchanged. A tall header
+        // (§17.6.11) shifts the whole content frame down — `colTopPt` is the bare
+        // margin top, so re-add the reserve, matching column 0's `bodyState.y`.
+        state.y = (el.colTopPt ?? state.marginTop) * state.scale + headerReservePx;
       }
       prevPara = null;
       prevSpaceAfter = 0;
@@ -3289,7 +3321,7 @@ function renderBodyElements(
       // previous section being multi-column so a 1-col→1-col continuous break
       // (sample-5) keeps the exact prior behavior (continue at the current y).
       if (activeGeom && activeGeom.length > 1 && el.colTopPt != null) {
-        state.y = Math.max(state.y, el.colTopPt * state.scale);
+        state.y = Math.max(state.y, el.colTopPt * state.scale + headerReservePx);
       }
       const col = cols[0];
       state.contentX = col.xPt * state.scale;


### PR DESCRIPTION
## Summary

Implements the **header-side mirror** of the footer-reserve fix ([#599](https://github.com/yukiyokotani/office-open-xml-viewer/pull/599)).

ECMA-376 **§17.6.11** (`pgMar/@top`) is the symmetric twin of the `@bottom` rule:

> If the value of top is non-negative, then the text is placed at the greater of: **the value of top** / **the extent of the header text** … the main text extent ends at the bottom of the header region.

So a header taller than its top-margin allowance (`marginTop − headerDistance`) rises into the content area and the body must start **below** it. The render path previously started the body at `marginTop` unconditionally — painting body lines over a tall header. This is the exact mirror of the overlap #599 fixed at the bottom.

## Change — mirrors the footer reserve piece-for-piece

| Footer (existing) | Header (this PR) |
|---|---|
| `footerOverflowPt` | `headerOverflowPt(headerH, marginTop, headerDistance)` |
| `resolvePageFooter` | `resolvePageHeader` |
| `computeFooterReserves` | `computeHeaderReserves` |
| `footerReservePt[]` shrinks content from bottom | `headerReservePt[]` shrinks content from top |

- `headerOverflowPt` honors the spec's **negative-top exception** (negative top margin → text measured from the page top regardless of the header, overlapping it → reserve `0`).
- `computePages` gains `headerReservePt[]` reducing `effContentH` from the top; the render path shifts the body's start `y` down by the same overflow, so pagination and paint stay in lockstep.
- `paginateWithFooterReserve` → **`paginateWithHeaderFooterReserve`** (now reserves both margins); `MIN_FOOTER_OVERFLOW_PT` → `MIN_MARGIN_OVERFLOW_PT`. Both names generalized for honesty.

## No-op for existing docs

No bundled sample triggers this (sample-13's header is short → reserve `0`). When nothing overflows, pass 1 is returned unchanged and `headerReservePt` is all-zero — an **exact no-op**, so the footer path stays byte-identical.

## Tests

Driven by `header-reserve.test.ts` (style of `footer-reserve.test.ts`): a synthetic doc whose header is far taller than its top margin asserts the first body line sits **below** the header's bottom, with a non-triviality check that the same body absent the reserve packs *into* the header band; a negative-top case reserves nothing.

- ✅ Verified **red→green** by removing the reserve, and ablated the negative-top guard (removing it fails that test).
- ✅ Full docx unit suite green (incl. `footer-reserve`, `pagination`, `page-anchor-prescan`, `docgrid-char`).
- ✅ `tsc --noEmit` clean.

docx-only, consistent with #599's cross-package adjudication (xlsx/pptx have no pagination reflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)