### PR TITLE
fix(docx,pptx,xlsx): keep a non-starter glued to its word when wrapping across runs (UAX#14 LB13)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -216,7 +216,7 @@ export {
   kinsokuAdjustedSplit,
   crossRunKinsokuRetract,
 } from './text/kinsoku';
-export { isCjkBreakChar } from './text/cjk-ranges';
+export { isCjkBreakChar, isLatinWordCodePoint } from './text/cjk-ranges';
 export { highlightBox } from './text/highlight-box';
 export {
   distributeLineSlack,

--- a/packages/core/src/text/cjk-ranges.test.ts
+++ b/packages/core/src/text/cjk-ranges.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isCjkBreakChar } from './cjk-ranges.js';
+import { isCjkBreakChar, isLatinWordCodePoint } from './cjk-ranges.js';
 
 describe('isCjkBreakChar', () => {
   // [code point, expected] — exercises every range edge (low−1, low, high,
@@ -28,5 +28,25 @@ describe('isCjkBreakChar', () => {
     it(`U+${cp.toString(16).toUpperCase().padStart(4, '0')} → ${expected}`, () => {
       expect(isCjkBreakChar(cp)).toBe(expected);
     });
+  }
+});
+
+describe('isLatinWordCodePoint', () => {
+  // Word characters (no intra-word break) — letters, digits, ASCII punctuation,
+  // and NBSP (U+00A0, non-breaking, so it must NOT count as a break boundary).
+  const wordCps: [string, number][] = [
+    ['a', 0x61], ['Z', 0x5a], ['7', 0x37], ['comma', 0x2c], ['period', 0x2e],
+    ['paren', 0x29], ['hyphen', 0x2d], ['at', 0x40], ['NBSP', 0x00a0],
+  ];
+  for (const [label, c] of wordCps) {
+    it(`${label} is a word code point`, () => expect(isLatinWordCodePoint(c)).toBe(true));
+  }
+  // Break-eligible whitespace and CJK code points are NOT word characters.
+  const nonWordCps: [string, number][] = [
+    ['space', 0x20], ['tab', 0x09], ['LF', 0x0a], ['CR', 0x0d],
+    ['ideograph', 0x6f22], ['ideographic comma', 0x3001], ['fullwidth comma', 0xff0c],
+  ];
+  for (const [label, c] of nonWordCps) {
+    it(`${label} is not a word code point`, () => expect(isLatinWordCodePoint(c)).toBe(false));
   }
 });

--- a/packages/core/src/text/cjk-ranges.ts
+++ b/packages/core/src/text/cjk-ranges.ts
@@ -53,3 +53,20 @@ export function isCjkBreakChar(cp: number): boolean {
     (cp >= 0xff00 && cp <= 0xffef) // Halfwidth/Fullwidth Forms
   );
 }
+
+/**
+ * True when `cp` is a "word" code point for Latin/Western line breaking — one
+ * that carries NO intra-word break opportunity on its own. It is neither
+ * break-eligible whitespace (ASCII space / tab / LF / CR — the inter-word break
+ * points; NBSP is intentionally excluded, it is non-breaking) nor a CJK
+ * character (each of which {@link isCjkBreakChar} treats as its own break
+ * opportunity). Used by the renderers' wrap paths to find the boundary of a
+ * Latin word when applying the UAX#14 LB13 non-starter rule (keep a closing
+ * comma/period/etc. with its preceding word across run boundaries).
+ *
+ * @param cp A Unicode scalar value (e.g. from `String.prototype.codePointAt`).
+ */
+export function isLatinWordCodePoint(cp: number): boolean {
+  if (cp === 0x20 || cp === 0x09 || cp === 0x0a || cp === 0x0d) return false;
+  return !isCjkBreakChar(cp);
+}

--- a/packages/core/src/text/kinsoku/rules.ts
+++ b/packages/core/src/text/kinsoku/rules.ts
@@ -1,20 +1,20 @@
 /* ------------------------------------------------------------------ *
  * Japanese line-breaking (kinsoku shori / 禁則処理)
  *
- * ECMA-376 §17.15.1.58 `w:kinsoku` is a document-wide on/off toggle for
+ * ECMA-376 §17.3.1.16 `w:kinsoku` is a document-wide on/off toggle for
  * "East Asian typography line-breaking rules". Its default, when the
  * element is absent from settings.xml, is TRUE (the toggle is a
  * ST_OnOff whose absence Word treats as enabled for kinsoku). So a doc
  * with no <w:kinsoku> still gets Japanese line breaking — which is what
  * Word does and what users see.
  *
- * §17.15.1.59 `w:noLineBreaksAfter` / §17.15.1.60 `w:noLineBreaksBefore`
+ * §17.15.1.58 `w:noLineBreaksAfter` / §17.15.1.59 `w:noLineBreaksBefore`
  * let a document override the character set used by the kinsoku engine
  * for a given language (`w:lang`):
- *   - noLineBreaksBefore (§.60): characters that "cannot begin a line"
- *     (行頭禁則 — line-start-forbidden).
- *   - noLineBreaksAfter  (§.59): characters that "cannot end a line"
- *     (行末禁則 — line-end-forbidden).
+ *   - noLineBreaksBefore (§17.15.1.59): characters that "cannot begin a
+ *     line" (行頭禁則 — line-start-forbidden).
+ *   - noLineBreaksAfter  (§17.15.1.58): characters that "cannot end a
+ *     line" (行末禁則 — line-end-forbidden).
  * The spec states the `w:val` "specifies the set of characters" — it is
  * the COMPLETE set, so a present override REPLACES the application's
  * default set for that language (it does not extend it). When the
@@ -27,12 +27,16 @@
  * them as two flat string constants (data, not scattered conditionals);
  * membership is a Set lookup.
  *
- * Word applies kinsoku only to East-Asian wrapping (the per-character
- * break path). Pure-Latin word wrap is untouched: these sets contain no
- * ASCII letters/space, and the Latin path never consults them.
+ * Word applies the document-customizable East-Asian kinsoku to the
+ * per-character break path. The `lineStartForbidden` set ALSO contains the
+ * ASCII non-starters (!),.:;?]}) — these belong to the UNIVERSAL Latin line
+ * breaking rule (UAX#14 LB13: no break before a closing/mid-punctuation), not
+ * to East-Asian typography. The renderers' Latin wrap paths consult the DEFAULT
+ * set for those (independent of the §17.3.1.16 toggle and of any custom
+ * §17.15.1.59 override) so a Latin comma is never orphaned at a line start.
  * ------------------------------------------------------------------ */
 
-/** §17.15.1.60 default 行頭禁則 — characters that may NOT begin a line.
+/** §17.15.1.59 default 行頭禁則 — characters that may NOT begin a line.
  *  Closing brackets/quotes, mid/end punctuation, small kana, prolonged
  *  sound mark, iteration marks, and their halfwidth forms. */
 const KINSOKU_DEFAULT_LINE_START_FORBIDDEN =
@@ -52,7 +56,7 @@ const KINSOKU_DEFAULT_LINE_START_FORBIDDEN =
   '｡｣､･ｰﾞﾟ' +
   '!),.:;?]}｠';
 
-/** §17.15.1.59 default 行末禁則 — characters that may NOT end a line.
+/** §17.15.1.58 default 行末禁則 — characters that may NOT end a line.
  *  Opening brackets / quotes and currency/lead symbols. */
 const KINSOKU_DEFAULT_LINE_END_FORBIDDEN =
   // opening brackets / quotes (fullwidth)
@@ -63,8 +67,9 @@ const KINSOKU_DEFAULT_LINE_END_FORBIDDEN =
   '([{｟';
 
 /** Resolved kinsoku configuration for a document.
- *  `enabled` reflects §17.15.1.58; the two sets are §.60 / §.59 (custom
- *  sets replace the defaults — see resolveKinsokuRules). */
+ *  `enabled` reflects §17.3.1.16; the two sets are §17.15.1.59 (start) /
+ *  §17.15.1.58 (end) (custom sets replace the defaults — see
+ *  resolveKinsokuRules). */
 export interface KinsokuRules {
   enabled: boolean;
   /** Code points forbidden at line START (行頭禁則). */
@@ -80,9 +85,9 @@ function codePointSet(text: string): Set<number> {
 }
 
 /** Build the active {@link KinsokuRules} from the document settings.
- *  - `enabled` defaults to TRUE when undefined (§17.15.1.58 default).
+ *  - `enabled` defaults to TRUE when undefined (§17.3.1.16 default).
  *  - A non-undefined custom set REPLACES the default for that direction
- *    (§17.15.1.59 / §.60 "specifies the set of characters"). An empty
+ *    (§17.15.1.58 / §17.15.1.59 "specifies the set of characters"). An empty
  *    string is a legitimate replacement that disables that direction.
  */
 export function resolveKinsokuRules(settings?: {

--- a/packages/docx/src/latin-nonstarter-wrap.test.ts
+++ b/packages/docx/src/latin-nonstarter-wrap.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// UAX#14 LB13 / ECMA-376 §17.15.1.59 (行頭禁則 / line-start-forbidden): a comma
+// (and other closing / mid punctuation — class IS/CL/CP/EX) has NO line-break
+// opportunity before it, so it can never BEGIN a line. Word keeps such a mark
+// with the word it follows even when the two live in different runs.
+//
+// Real-world trigger (sample-12 "Keywords"): the runs are
+//   …"cyber security, "  |  "intrusion detection system"  |  ", metadata"…
+// so the word "system" (end of one run, NO trailing space) is followed by a
+// SEPARATE run that begins with a comma. Splitting on spaces yields the layout
+// segments  … "detection " · "system" · ", " · "metadata" …  with no whitespace
+// between "system" and ",". A naive wrap treats every segment boundary as a
+// break opportunity and orphans the comma at the next line's start; Word wraps
+// "system," together.
+
+interface Call { text: string; x: number; y: number; px: number; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { calls.push({ text: s, x, y, px: px() }); },
+    strokeText(s: string, x: number, y: number) { calls.push({ text: s, x, y, px: px() }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function run(text: string): DocParagraph['runs'][number] {
+  return {
+    type: 'text', text, bold: false, italic: false, underline: false,
+    strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+    fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    smallCaps: false, allCaps: false,
+  } as DocParagraph['runs'][number];
+}
+
+function multiRunPara(texts: string[]): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: texts.map(run),
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[], pageWidth: number): DocxDocumentModel {
+  const section = {
+    pageWidth, pageHeight: 600,
+    marginTop: 5, marginRight: 5, marginBottom: 5, marginLeft: 5,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(body: BodyElement[], pageWidth: number): Promise<Call[]> {
+  const { canvas, calls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(body, pageWidth), canvas, 0, { dpr: 1, width: pageWidth });
+  return calls;
+}
+
+describe('Latin line-start-forbidden wrap (UAX#14 LB13 / §17.15.1.59)', () => {
+  it('does not orphan a comma at the start of a line when it lives in a separate run', async () => {
+    // contentW = 90 - 5 - 5 = 80px (mock: 5px / char @ 10pt). Tuned so "system"
+    // alone would fit at the end of line 1 but "system," (comma glued) does not —
+    // the exact band where a naive wrap orphans the comma onto line 2.
+    const calls = await render(
+      [multiRunPara(['aaaa bbbb system', ', cc']) as unknown as BodyElement],
+      90,
+    );
+    const system = calls.find((c) => c.text === 'system');
+    const comma = calls.find((c) => c.text.includes(','));
+    expect(system, 'painted "system"').toBeDefined();
+    expect(comma, 'painted comma').toBeDefined();
+    // The comma must ride on the SAME line as "system" (never lead a line).
+    expect(comma!.y, '"system" and "," share a line').toBeCloseTo(system!.y, 3);
+    // …and sit immediately AFTER it (to its right), not before.
+    expect(comma!.x).toBeGreaterThan(system!.x);
+  });
+
+  it('still wraps normally at real (whitespace) break opportunities', async () => {
+    // A plain space before the comma DOES permit a break; nothing is glued.
+    const calls = await render(
+      [multiRunPara(['aaaa bbbb cccc dddd eeee ffff gggg']) as unknown as BodyElement],
+      90,
+    );
+    // Sanity: the paragraph wrapped onto more than one line.
+    const ys = new Set(calls.map((c) => Math.round(c.y)));
+    expect(ys.size).toBeGreaterThan(1);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4980,6 +4980,40 @@ function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
       });
     }
   }
+
+  // ── UAX#14 LB13 / ECMA-376 §17.15.1.59 (行頭禁則 — line-start-forbidden) ──────
+  // A closing / mid-punctuation code point (comma, period, ; : ! ? ) ] } and
+  // their CJK forms) carries NO line-break opportunity before it, so it may
+  // never BEGIN a line. When such a char OPENS a segment that is glued to the
+  // previous text segment — no intervening whitespace, e.g. a comma authored in
+  // its own run as in sample-12's "…detection system" | ", metadata" — mark it
+  // `joinPrev` so the group machinery in layoutLines keeps it with the preceding
+  // word and wraps "system," together instead of orphaning "," at the next
+  // line's head.
+  //
+  // This is a UNIVERSAL Latin/Western rule (UAX#14 LB13), NOT the East-Asian
+  // kinsoku feature, so it consults the application's DEFAULT forbidden table
+  // UNCONDITIONALLY — independent of the document's §17.3.1.16 `w:kinsoku`
+  // toggle and of any custom §17.15.1.59 `w:noLineBreaksBefore` set (which
+  // REPLACES the default East-Asian table for a language and so must NOT be able
+  // to drop the ASCII non-starters and re-orphan a Latin comma). The document's
+  // kinsoku settings still govern the separate per-character CJK retract paths
+  // (kinsokuAdjustedSplit / crossRunKinsokuRetract), which read `state.kinsoku`.
+  // The ASCII non-starters (!),.:;?]}) live in that default table (core
+  // rules.ts), so one membership test covers Latin and (incidentally) CJK forms.
+  for (let i = 1; i < segs.length; i++) {
+    const cur = segs[i];
+    if (!('text' in cur) || cur.joinPrev) continue;
+    const firstCp = cur.text.codePointAt(0);
+    if (firstCp === undefined || !DEFAULT_KINSOKU_RULES.lineStartForbidden.has(firstCp)) continue;
+    const prev = segs[i - 1];
+    // Only glue across a boundary that is NOT already a break opportunity: the
+    // preceding unit must be text that does not end in whitespace (a trailing
+    // space is a legal break, so the mark may legitimately start the line).
+    if (!('text' in prev) || /\s$/.test(prev.text)) continue;
+    cur.joinPrev = true;
+  }
+
   return segs;
 }
 

--- a/packages/pptx/src/latin-nonstarter-wrap.test.ts
+++ b/packages/pptx/src/latin-nonstarter-wrap.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// UAX#14 LB13: a closing / mid-punctuation char (comma, period, ;:!?)]} — class
+// IS/CL/CP/EX) has NO break opportunity before it, so it may never BEGIN a line.
+// When a word and a trailing comma live in SEPARATE runs (no whitespace between
+// them), pptx's per-run tokeniser yields "system" + "," as adjacent tokens; the
+// greedy wrap must keep them together (move "system," down as a unit), never
+// orphaning "," at the next line's head. Mirrors the docx fix.
+
+function mockCtx() {
+  let font = '';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => ({ width: s.length * 10 }),
+    fillRect() {}, fillText() {},
+    fillStyle: '', strokeStyle: '',
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function run(text: string, over: Partial<TextRunData> = {}): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Arial', ...over,
+  };
+}
+
+function para(runs: TextRunData[]): Paragraph {
+  return {
+    alignment: 'l', marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null,
+    defItalic: null, defFontFamily: null, tabStops: [], eaLnBrk: true, runs,
+  } as Paragraph;
+}
+
+function lineTexts(line: { segments: { text: string }[] }): string {
+  return line.segments.map((s) => s.text).join('');
+}
+
+describe('pptx Latin line-start-forbidden wrap (UAX#14 LB13)', () => {
+  it('never orphans a comma at the start of a line when it lives in a separate run', () => {
+    // char = 10px (mock). maxWidth=165 puts the break in the band where "system"
+    // alone fits at line 1's end but "system," (comma glued) does not.
+    const lines = layoutParagraph(
+      mockCtx(), para([run('aaaa bbbb system'), run(', cc')]), 165, 20, '000000', 1, 0,
+    );
+    // No line may BEGIN with a comma.
+    for (const ln of lines) {
+      const first = ln.segments.find((s) => s.text.trim().length > 0);
+      if (first) expect(first.text.startsWith(','), `line "${lineTexts(ln)}" starts with comma`).toBe(false);
+    }
+    // "system" must stay intact (not torn into "syste" + "m,").
+    const allText = lines.map(lineTexts).join('|');
+    expect(allText.includes('system'), `"system" intact in: ${allText}`).toBe(true);
+  });
+
+  it('never orphans a comma even when the word is split across runs by a font change', () => {
+    // "system" is split into "sys" (Arial) + "tem" (Courier) by a formatting
+    // change, then a comma in a third run. The comma must still never lead a
+    // line; the word may split at the format seam ("…sys" / "tem, cc"), matching
+    // docx/xlsx, but the non-starter rule (LB13) must still hold.
+    const lines = layoutParagraph(
+      mockCtx(),
+      para([run('aaaa bbbb sys'), run('tem', { fontFamily: 'Courier' }), run(', cc')]),
+      165, 20, '000000', 1, 0,
+    );
+    for (const ln of lines) {
+      const first = ln.segments.find((s) => s.text.trim().length > 0);
+      if (first) expect(first.text.startsWith(','), `line "${lineTexts(ln)}" starts with comma`).toBe(false);
+    }
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -763,6 +763,47 @@ export function layoutParagraph(
     }
   };
 
+  // UAX#14 LB13 (行頭禁則): pull the trailing word of the current line down onto a
+  // fresh line so a glued non-starter (comma, period, … in a SEPARATE run, no
+  // whitespace between) does not orphan at the next line's head nor tear the word.
+  // Re-pushes the word — with its run formatting — to lead the new line; the
+  // caller then appends the non-starter. The trailing word normally lives in the
+  // last (same-meta-merged) segment and is split at its last whitespace; when a
+  // formatting change split the word across segments, the last segment has no
+  // internal whitespace, so the whole tail segment moves down instead (the word
+  // splits at the format seam, but the comma is still never orphaned — matching
+  // docx/xlsx). Returns false (changing nothing) only when that tail segment IS
+  // the whole line (no preceding content / nowhere to retract to). Mirrors the
+  // docx/xlsx fixes; the ASCII non-starters live in
+  // DEFAULT_KINSOKU_RULES.lineStartForbidden.
+  const retractTrailingWord = (): boolean => {
+    const seg = currentLine.segments.at(-1);
+    if (!seg || seg.math) return false;
+    const m = /^(.*\s)(\S+)$/s.exec(seg.text);
+    let word: string;
+    if (m) {
+      seg.text = m[1]; // close the current line on the whitespace boundary
+      word = m[2];
+    } else if (currentLine.segments.length > 1) {
+      currentLine.segments.pop(); // tail segment of a format-split word moves whole
+      word = seg.text;
+    } else {
+      return false; // the segment is the whole line — cannot retract without emptying it
+    }
+    newLine();
+    // Re-push the word (with its run formatting) so it leads the fresh line.
+    push(word, seg.font, seg.sizePx, seg.color, seg.underline, seg.strikethrough, seg.baseline, {
+      strikeDouble: seg.strikeDouble,
+      letterSpacingPx: seg.letterSpacingPx,
+      underlineStyle: seg.underlineStyle,
+      underlineColor: seg.underlineColor,
+      shadow: seg.shadow,
+      outline: seg.outline,
+      highlight: seg.highlight,
+    });
+    return true;
+  };
+
   for (const run of para.runs) {
     if (run.type === 'break') {
       newLine();
@@ -1018,7 +1059,16 @@ export function layoutParagraph(
         // size the bbox correctly. Match that behavior.
         push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
       } else {
-        newLine();
+        // UAX#14 LB13: if the overflowing token is a non-starter (comma, …) glued
+        // to the word ending this line (no whitespace between — e.g. authored in a
+        // separate run), move the WHOLE word down with it so the comma never leads
+        // a line and the word is never torn. Otherwise wrap normally.
+        const firstCp = token.codePointAt(0);
+        const glued =
+          firstCp !== undefined &&
+          DEFAULT_KINSOKU_RULES.lineStartForbidden.has(firstCp) &&
+          /\S$/.test(currentLine.segments.at(-1)?.text ?? '');
+        if (!(glued && retractTrailingWord())) newLine();
         push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
       }
     }

--- a/packages/xlsx/src/latin-nonstarter-wrap.test.ts
+++ b/packages/xlsx/src/latin-nonstarter-wrap.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { layoutRichTextLines } from './renderer.js';
+import type { CellFont, Run } from './types.js';
+
+// UAX#14 LB13: a closing / mid-punctuation char (comma, period, ;:!?)]} — class
+// IS/CL/CP/EX) has NO break opportunity before it, so it may never BEGIN a line.
+// In a WRAPPED rich-text cell, a word and a trailing comma can live in SEPARATE
+// runs (no whitespace between). The per-run tokeniser yields "system" + "," as
+// adjacent tokens; the wrap must keep them together (move "system," down as a
+// unit). The existing kinsoku retract is CHARACTER-level, so it would instead
+// tear the word ("syste" + "m,") — also wrong. Mirrors the docx fix.
+
+const BASE: CellFont = {
+  bold: false, italic: false, underline: false, strike: false,
+  size: 11, color: null, name: null,
+};
+
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '11px sans-serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText() {}, save() {}, restore() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as 'ltr' | 'rtl',
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+describe('xlsx Latin line-start-forbidden wrap (UAX#14 LB13)', () => {
+  it('keeps "system," together — never orphans the comma nor tears the word', () => {
+    // Mock metrics = 15px/char (round(11pt × 96/72)). maxWidth=247 lands in the
+    // band [240,255) where "aaaa bbbb system" fits on line 1 but the comma
+    // overflows: the char-level kinsoku retract used to tear the word into
+    // "aaaa bbbb syste" + "m," (verified empirically). The fix moves the whole
+    // word + comma down together → "aaaa bbbb " / "system, cc".
+    const lines = layoutRichTextLines(
+      makeCtx(), [{ text: 'aaaa bbbb system' }, { text: ', cc' }] as Run[], BASE, 1, 247,
+    );
+    const lineTexts = lines.map((l) => l.segments.map((s) => s.text).join(''));
+    // No line may BEGIN with a comma.
+    for (const lt of lineTexts) {
+      expect(/^\s*,/.test(lt), `line "${lt}" starts with comma`).toBe(false);
+    }
+    // "system" must stay intact (not torn into "syste" + "m,").
+    expect(lineTexts.some((lt) => lt.includes('system')), `"system" intact in: ${lineTexts.join('|')}`).toBe(true);
+  });
+});

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, ChartData, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, xlsxBorderDashArray, drawImageCropped, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, xlsxBorderDashArray, drawImageCropped, type ChartModel, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -694,6 +694,35 @@ function kinsokuRetractCount(lineCps: string[], nextCps: string[]): number {
   return splitAt - adj;
 }
 
+/**
+ * Extend a per-code-point kinsoku retract so it never TEARS a Latin word.
+ *
+ * `kinsokuRetractCount` retracts glyph-by-glyph — correct for CJK, where every
+ * character is a break opportunity, but wrong for Latin: a non-starter (comma,
+ * period, …, UAX#14 LB13) overflowing after "system" retracts a single "m" →
+ * "syste" / "m,". Latin has no mid-word break opportunity, so when the retract
+ * boundary sits between two {@link isLatinWordCodePoint} characters, pull it back
+ * to the last whitespace (the real break) so the WHOLE word moves down ahead of
+ * the non-starter. If the line is one unbroken word (no whitespace to retract
+ * to), keep the original retract rather than empty the line — an over-long
+ * single word is handled by the normal overflow path. NOTE: the retract is still
+ * capped at the last segment by the caller, so a word split across runs by a
+ * formatting change splits at that seam (the comma stays glued to the tail).
+ */
+function extendLatinWordRetract(lineCps: string[], retract: number): number {
+  let r = retract;
+  while (r < lineCps.length) {
+    const keep = lineCps[lineCps.length - r - 1]; // last char staying on the line
+    const move = lineCps[lineCps.length - r];     // first char moving down
+    const keepCp = keep?.codePointAt(0);
+    const moveCp = move?.codePointAt(0);
+    if (keepCp !== undefined && moveCp !== undefined
+        && isLatinWordCodePoint(keepCp) && isLatinWordCodePoint(moveCp)) r++;
+    else break;
+  }
+  return r >= lineCps.length ? retract : r;
+}
+
 /** Word-wrap a single paragraph (no embedded \n). Unlike a naive
  *  `split(' ')`, CJK characters are treated as individual break opportunities
  *  so that Japanese headings like "夏休みアクティビティ カレンダー 2026"
@@ -852,6 +881,11 @@ export function layoutRichTextLines(
       // next line.
       const lineCps = cur.flatMap((s) => [...s.text]);
       let retract = kinsokuRetractCount(lineCps, [...text]);
+      // UAX#14 LB13: a per-glyph retract would tear a Latin word (e.g. a comma in
+      // a separate run overflowing after "system" → "syste" / "m,"). Pull the
+      // retract back to the last whitespace so the whole word rides down with the
+      // non-starter; CJK boundaries (move char is CJK) are left untouched.
+      if (retract > 0) retract = extendLatinWordRetract(lineCps, retract);
       const last = cur[cur.length - 1];
       const lastCps = [...last.text];
       // Only retract within the last segment to preserve each run's font; the


### PR DESCRIPTION
## Problem

A word and a trailing punctuation mark are frequently authored in **separate runs** with no whitespace between them (Word rsid splits, spell-check boundaries, etc.). For example sample-12's *Keywords* line:

```
run: "…cyber security, "  run: "intrusion detection system"  run: ", metadata"
```

All three renderers tokenise **per run**, so the comma becomes its own wrap unit and the greedy line-breaker treats the run boundary as a legal break opportunity. **UAX#14 LB13** forbids a break before a comma / closing punctuation (class IS/CL/CP/EX) — Word keeps `system,` together. The CJK path already honours this via the kinsoku `lineStartForbidden` set (whose default already contains the ASCII non-starters `!),.:;?]}`), but the **Latin path never consulted it**.

The symptom differed per renderer:

| Package | Symptom | Where |
|---|---|---|
| **docx** | comma orphaned to the next line's head | `layoutLines` Latin path had no non-starter rule |
| **pptx** | comma orphaned (same as docx) | `layoutParagraph` Latin token path had no non-starter rule |
| **xlsx** | the **word is torn** (`system` → `syste` / `m,`) | `layoutRichTextLines` already retracts via kinsoku, but **per-code-point**, which splits a Latin word |

## Fix

Each renderer reuses the shared core predicate (`lineStartForbidden` / `isCjkBreakChar`); the wrap mechanics stay local to each renderer (different data models — no false abstraction):

- **docx** — `buildSegments` marks a segment `joinPrev` when it opens with a line-start-forbidden code point and the previous text segment does not end in whitespace; the existing group machinery wraps word + punctuation as one unit.
- **pptx** — `retractTrailingWord` splits the trailing word off the last (merged) segment at its last whitespace and re-pushes it (with run formatting) to lead a fresh line, so word + comma wrap together.
- **xlsx** — `extendLatinWordRetract` pulls a per-glyph retract that lands mid-word back to the last whitespace, so the whole word rides down with the non-starter; CJK boundaries are untouched.

## Verification

- New `latin-nonstarter-wrap.test.ts` in each package (recording-canvas, Red→Green, CI-safe, no sample/WASM dependency).
- docx: real-font skia render of the actual sample-12 confirms `system,` wraps together (before/after).
- xlsx: tear band empirically isolated at `W ∈ [240,255)` (= the comma's width); fix flips `["…syste","m, cc"]` → `["… ","system, cc"]`.
- Full suites green on top of `main`: **568 tests** (docx + pptx + xlsx); typecheck clean.

## Out of scope

The symmetric **line-end-forbidden** case (an opening bracket `(` stranded at a line end — UAX#14 LB14) is a separate bug and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (independent multi-agent review)

Four independent agents reviewed for spec-first correctness, single-responsibility, duplication, cross-package consistency, and adversarial regressions. Changes made in response:

- **core**: added the shared pure predicate `isLatinWordCodePoint(cp)` (next to `isCjkBreakChar`); xlsx now imports it instead of a local copy. Corrected the kinsoku ECMA-376 citations against the Part 1 prose (`w:kinsoku` = §17.3.1.16; `w:noLineBreaksBefore` = §17.15.1.59; `w:noLineBreaksAfter` = §17.15.1.58).
- **docx (spec)**: the Latin glue now consults the **default** forbidden table unconditionally, not the document-resolved `state.kinsoku`. UAX#14 LB13 is universal, so a custom `<w:noLineBreaksBefore>` (which replaces the default set) or `<w:kinsoku w:val="off">` must not be able to drop the ASCII non-starters and re-orphan a Latin comma. The CJK retract paths still honour the document's kinsoku settings.
- **pptx (consistency)**: `retractTrailingWord` now also handles a word split across runs by a formatting change (the previous code orphaned the comma there). It now matches docx/xlsx — the word splits at the format seam but the comma is never orphaned.
- **Verified dismissed**: an "xlsx tears a word that fits on a fresh line" finding was a false positive (the reviewer assumed 11px/char; the renderer uses `round(11pt×96/72)=15px`, so every observed tear is a genuinely over-long word).

The multi-segment (formatting-split word) case is documented in-code: all three keep the comma glued; docx/xlsx may split the word at the format seam (the retract is capped at the last segment). The symmetric line-end-forbidden case (UAX#14 LB14) remains out of scope.

Full suites green on top of latest `main`: **1026 tests** (docx + pptx + xlsx + core); root typecheck clean.