### PR TITLE
fix(docx): justify the last CJK segment of a line, not only the earlier ones

### DIFF
--- a/packages/docx/src/cjk-justify-last-segment.test.ts
+++ b/packages/docx/src/cjk-justify-last-segment.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.18.44 (ST_Jc `both`/`distribute`): a justified line spreads its
+// slack EQUALLY across EVERY inter-CJK boundary on the line — Word adds the same
+// inter-character pitch to all glyphs, not just to the earlier segments'.
+//
+// Regression guard: the docx renderer passed the line's VISUALLY-LAST segment
+// index to the shared slack kernel as `lastDrawnSi`, which suppresses ALL of that
+// segment's interior gaps (not only the final glyph's). When the last segment was
+// a multi-character CJK run, it rendered at the un-stretched grid pitch while the
+// earlier segment absorbed every bit of slack — two visibly different inter-
+// character pitches on ONE line. This is exactly sample-10's "でご確認ください．"
+// (loose) vs "使用言語は日本語または英語で" (tight). The fix excludes no segment
+// on an LTR line (the content-span trim already keeps the final glyph on the
+// margin), matching the pptx justifier. See packages/core/src/text/
+// line-distribute.ts and packages/docx/src/renderer.ts (distributeLineSlack call).
+
+const FONT_PX = 20; // glyph advance per CJK char in the stub (scale = 1)
+
+/** Recording 2D context: glyph advance = charCount × fontPx, font box 0.8/0.2 em.
+ *  letterSpacing is ignored on purpose (the grid draw must not depend on it). */
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; x: number; y: number }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fillTextCalls: { text: string; x: number; y: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) { fillTextCalls.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+function textRun(text: string, color: string | null): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+/** A `both`-justified paragraph carrying two adjacent CJK runs. The differing
+ *  colour guarantees two separate layout segments (so the second is the line's
+ *  visually-last segment), reproducing sample-10's run16|run17 split. */
+function twoRunPara(a: string, b: string): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'both',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [
+      { type: 'text', ...textRun(a, null) } as DocRun,
+      { type: 'text', ...textRun(b, 'FF0000') } as DocRun,
+    ],
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 210, pageHeight: 400,
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    // Active character grid (§17.6.5): every full-width EA glyph is drawn
+    // individually, so fillText reports a position PER glyph on every segment —
+    // including the last — which lets us read the realised inter-glyph pitch.
+    docGridType: 'linesAndChars', docGridLinePitch: 20, docGridCharSpace: -2048,
+    ...overrides,
+  };
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(body: BodyElement[], sec: SectionProps) {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, { dpr: 1, width: sec.pageWidth });
+  return fillTextCalls;
+}
+
+describe('CJK justification — even slack distribution across the last segment (§17.18.44)', () => {
+  it('gives the visually-last CJK segment the SAME inter-glyph pitch as the first', async () => {
+    // Cell = 20 + (-2048/4096) = 19.5 px. availW 210 → 10 cells (195) fit with
+    // 15 px slack; the 11th (214.5) overflows. So line 1 = "ああああ" (run A, 4) +
+    // 6 of run B; line 2 holds the rest (and is the natural last line). Line 1 is
+    // a justify candidate with two segments — the bug stretched only run A.
+    const calls = await render(
+      [twoRunPara('ああああ', 'いいいいいいいいいいいいいいいい')],
+      section(),
+    );
+    expect(calls.length).toBeGreaterThan(0);
+
+    // Group glyphs by baseline y; the first (top) line is the justified one.
+    const byY = new Map<number, { text: string; x: number }[]>();
+    for (const c of calls) {
+      const key = Math.round(c.y);
+      (byY.get(key) ?? byY.set(key, []).get(key)!).push(c);
+    }
+    const firstY = Math.min(...byY.keys());
+    const line = byY.get(firstY)!.slice().sort((p, q) => p.x - q.x);
+
+    // The justified line carries the run boundary: run A (4) + part of run B (6).
+    expect(line.length).toBe(10);
+
+    // Consecutive inter-glyph advances must be uniform across the run boundary.
+    const advances: number[] = [];
+    for (let i = 1; i < line.length; i++) advances.push(line[i].x - line[i - 1].x);
+    const max = Math.max(...advances);
+    const min = Math.min(...advances);
+    // Pre-fix: run A advanced ~23.25 px (cell 19.5 + 15/4 perGap), run B ~19.5 px
+    // (excluded) → spread ~3.75. Post-fix: one uniform pitch (cell + 15/9).
+    expect(max - min).toBeLessThan(0.01);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4198,7 +4198,19 @@ function renderParagraph(
         distSegs,
         slack,
         firstContentSi,
-        lastDrawnSi,
+        // The kernel excludes `lastDrawnSi`'s WHOLE segment from opening gaps —
+        // including its interior inter-CJK boundaries, not just the final glyph's.
+        // On an LTR line that over-excludes: §17.18.44 spreads the slack across
+        // EVERY inter-CJK boundary on the line, so a multi-glyph CJK last segment
+        // must still distribute pitch internally (otherwise it renders at the bare
+        // grid pitch while earlier segments absorb all the slack — two different
+        // inter-character pitches on one line). The kernel's content-span trim
+        // already suppresses only the FINAL glyph's gap, keeping that glyph on the
+        // margin, so LTR needs no whole-segment exclusion: pass `segCount` (a
+        // sentinel matching no segment, exactly as the pptx justifier does). Under
+        // bidi the logical-last unit is NOT the visually-last glyph, so the whole-
+        // segment exclusion of the visually-last segment is still required there.
+        paraNeedsBidi ? lastDrawnSi : segCount,
         minPerGap,
         slack > 0,
       );

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4063,8 +4063,10 @@ function renderParagraph(
       : null;
     if (paraNeedsBidi) ctx.textAlign = 'left';
     const segCount = line.segments.length;
-    // The segment whose trailing spaces sit at the line's PHYSICAL end (no
-    // stretch there): the visually-last segment. Equals the logical last in
+    // The visually-last segment (its trailing edge is the line's physical end, so
+    // no gap opens there). Consumed ONLY on the bidi path of the justification
+    // distribution below: an LTR line excludes no segment (the kernel's content-
+    // span trim already closes the final glyph's gap). Equals the logical last in
     // the LTR fast path.
     const lastDrawnSi = visual ? visual.order[segCount - 1] : segCount - 1;
 
@@ -4198,18 +4200,15 @@ function renderParagraph(
         distSegs,
         slack,
         firstContentSi,
-        // The kernel excludes `lastDrawnSi`'s WHOLE segment from opening gaps —
-        // including its interior inter-CJK boundaries, not just the final glyph's.
-        // On an LTR line that over-excludes: §17.18.44 spreads the slack across
-        // EVERY inter-CJK boundary on the line, so a multi-glyph CJK last segment
-        // must still distribute pitch internally (otherwise it renders at the bare
-        // grid pitch while earlier segments absorb all the slack — two different
-        // inter-character pitches on one line). The kernel's content-span trim
-        // already suppresses only the FINAL glyph's gap, keeping that glyph on the
-        // margin, so LTR needs no whole-segment exclusion: pass `segCount` (a
-        // sentinel matching no segment, exactly as the pptx justifier does). Under
-        // bidi the logical-last unit is NOT the visually-last glyph, so the whole-
-        // segment exclusion of the visually-last segment is still required there.
+        // §17.18.44 spreads the slack across EVERY inter-CJK boundary on the line,
+        // so the visually-last segment must still distribute pitch INTERNALLY when
+        // it is a multi-glyph CJK run — else it stays at the bare grid pitch while
+        // earlier segments absorb all the slack (two pitches on one line). The
+        // kernel already closes only the FINAL glyph's gap via its content-span
+        // trim, so an LTR line excludes no segment: pass `segCount`, the no-match
+        // sentinel the pptx justifier also uses. Bidi keeps the whole-segment
+        // exclusion because its logical-last unit is not the visually-last glyph.
+        // See the `lastDrawnSi` option doc in core/src/text/line-distribute.ts.
         paraNeedsBidi ? lastDrawnSi : segCount,
         minPerGap,
         slack > 0,


### PR DESCRIPTION
## 概要

両端揃え（`jc=both`/`distribute`、§17.18.44）の行で、**視覚的に最後のセグメントだけが行揃えのスラック分配から丸ごと除外**され、行末セグメントが多字 CJK のとき**同一行に2種類の文字間ピッチ**が出るバグの修正。

`sample-10.docx` の「でご確認ください．使用言語は日本語または英語で」で、`でご確認ください．`（run16）が緩く、`使用言語…`（run17）が詰まって見える、という指摘の根治。

## 原因

docx renderer は共有スラック分配カーネル（`packages/core/src/text/line-distribute.ts`）に **行内の視覚的最終セグメント index** を `lastDrawnSi` として渡していた。カーネルはこの index のセグメントを「ギャップを一切開かない」扱いにする（内部の inter-CJK 境界も含めて全除外）。そのため最後のセグメントが複数字の CJK 句だと、そのセグメントだけ素の docGrid セル幅のまま、手前のセグメントが全スラックを吸収する。

- 実測（sample-10、docGrid `charSpace=-1161`、10pt）: run16 = **10.935pt/字**、run17 = **9.717pt/字**（Word PDF はどちらも 9.716 で均一）。
- カーネル直接検証: 現行 `lastDrawnSi=1` → seg0 のみ `splitBefore=[1..7]`+trailing（perGap=1.218）、seg1 は perSeg に不在。

pptx の justifier は `lastDrawnSi: segments.length`（どのセグメントにも一致しないセンチネル）を渡しており、この穴は **docx 側だけ**（xlsx はこのパスを未使用）。

## 修正

LTR 行ではカーネルの content-span トリムが最終グリフのギャップだけを既に抑制し margin に着地させるので、セグメント全体の除外は不要。`segCount`（除外なしのセンチネル、pptx と同じ）を渡す。bidi 行のみ「論理最後 ≠ 視覚最後」のため従来どおり視覚的最終セグメントを除外。

```
- lastDrawnSi,
+ paraNeedsBidi ? lastDrawnSi : segCount,
```

行分割は `measuredWidth` 依存で行揃え分配には依存しないため、**折り返し・改ページは不変**。スラックの分配のみ均一化する低リスクな修正。

## 検証

- 実 `sample-10.docx` を headless 再描画: 該当行が run 境界をまたいで **一律 10.159pt/字** に均一化（最終グリフ位置は不変＝margin 着地維持）。
- 新規回帰テスト `cjk-justify-last-segment.test.ts`: 2 run の CJK `both` 行を docGrid 下で描画し、run 境界をまたぐ per-glyph ピッチが均一であることを検証（修正前 spread 3.75px → 修正後 0）。
- docx 全テスト **302 passed**（既存の justify/bidi/docGrid 回帰なし）、docx typecheck クリーン。

## 補足（本 PR 対象外）

この行が Word より約 0.44pt/字 緩いまま残るのは、**行中の全角句読点を半角に詰める約物半角（二分）が未実装**で「です．」まで1行に収まらず早期ラップし、スラックが生じるため。これは独立した fidelity 課題で、Word の FE レイアウト（`useFELayout`）/JIS X 4051 の根拠を特定してから別タスクで対応予定。本 PR は「同一行に2種類の文字間」という可視症状を解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)