### PR TITLE
fix(docx): place the body |margin| inside the page edge for a negative pgMar top/bottom (§17.6.11)

### DIFF
--- a/packages/docx/src/footer-reserve.test.ts
+++ b/packages/docx/src/footer-reserve.test.ts
@@ -167,17 +167,43 @@ describe('footer reserve — content never overlaps a tall footer (ECMA-376 §17
     expect(Math.max(...noteY)).toBeLessThan(Math.min(...footerY));
   });
 
-  it('does not reserve a footer when the bottom margin is negative (§17.6.11 exception)', async () => {
-    // §17.6.11: a negative bottom margin measures the main text from the page bottom
-    // REGARDLESS of the footer, so the text overlaps the footer and nothing is
-    // reserved. Hence the same body reaches exactly as far down WITH the tall footer
-    // as WITHOUT one. (The earlier max(0, marginBottom − footerDistance) allowance
-    // clamp wrongly reserved the whole footer here, pulling the body up.)
+  it('places the body bottom at |bottom| above the page bottom for a negative bottom margin (§17.6.11)', async () => {
+    // §17.6.11 (pgMar/@bottom), the SYMMETRIC twin of the @top rule: a negative bottom
+    // margin measures the main text from the bottom of the page extent by |bottom|
+    // "regardless of the footer ... and therefore shall overlap the footer text". The
+    // spec's own example (w:bottom="-720") keeps the body ½ inch (|bottom|) ABOVE the
+    // page bottom. So with marginBottom = −10 the body's lowest line must clear the
+    // bottom of the page by 10pt — the SAME extent a +10 bottom margin (no footer to
+    // reserve against) gives it — NOT packed down to the raw −10 offset (which sits
+    // BELOW the page bottom, off-canvas). Pre-fix the content height used the raw signed
+    // marginBottom (pageHeight − marginTop − (−10) ⇒ a TALLER page), so the body packed
+    // past the page bottom and diverged from the +10 placement.
+    // A body long enough that page 0 fills to its content bottom in BOTH cases, so the
+    // page-0 fill genuinely depends on the content height. A negative bottom margin must
+    // NOT enlarge that height (pageHeight − marginTop − |bottom|); pre-fix it did
+    // (… − (−10) ⇒ +10 taller), letting ~2 extra lines pack onto page 0 past the bottom.
+    const longBody = (): BodyElement[] =>
+      Array.from({ length: 70 }, () => para('BODY') as unknown as BodyElement);
     const bodyY = (calls: Call[]) => calls.filter((c) => c.text === 'BODY').map((c) => c.y);
-    const negTall = await renderPage0(docWithFooter(body(), tallFooter, { marginBottom: -10 }));
-    const negNone = await renderPage0(docWithFooter(body(), null, { marginBottom: -10 }));
+    const negTall = await renderPage0(docWithFooter(longBody(), tallFooter, { marginBottom: -10 }));
+    const negNone = await renderPage0(docWithFooter(longBody(), null, { marginBottom: -10 }));
+    const posNone = await renderPage0(docWithFooter(longBody(), null, { marginBottom: 10 }));
 
+    // Sanity: the tall footer is still painted (the negative margin only stops the
+    // RESERVE, it does not suppress the footer).
     expect(negTall.filter((c) => c.text === 'FTR').length).toBeGreaterThan(0);
+
+    // EXCEPTION: nothing is reserved — the body reaches the same depth WITH the tall
+    // footer as WITHOUT one.
     expect(Math.max(...bodyY(negTall))).toBeCloseTo(Math.max(...bodyY(negNone)), 1);
+
+    // MAGNITUDE: |−10| keeps the body bottom exactly where a +10 bottom margin (no
+    // reserve) does. This is the spec's "measured from the page bottom by |bottom|"
+    // rule, and it is what fixes the content-height computation under a negative margin.
+    expect(Math.max(...bodyY(negNone))).toBeCloseTo(Math.max(...bodyY(posNone)), 1);
+
+    // DIRECTION: the body's lowest line on page 0 stays within the page (above the page
+    // bottom), not pushed off-canvas below it as the raw negative offset would.
+    expect(Math.max(...bodyY(negNone))).toBeLessThanOrEqual(600);
   });
 });

--- a/packages/docx/src/header-reserve.test.ts
+++ b/packages/docx/src/header-reserve.test.ts
@@ -154,17 +154,35 @@ describe('header reserve — content never overlaps a tall header (ECMA-376 §17
     expect(Math.min(...bodyCalls.map((c) => c.y))).toBeGreaterThan(Math.max(...headerY));
   });
 
-  it('does not reserve a header when the top margin is negative (§17.6.11 exception)', async () => {
-    // §17.6.11: a negative top margin measures the main text from the page top
-    // REGARDLESS of the header, so the text overlaps the header and nothing is
-    // reserved. Hence the same body starts at exactly the same y WITH the tall header
-    // as WITHOUT one. (A naive max(0, header extent − top) without the negative-top
-    // guard would wrongly reserve the whole header here, pushing the body down.)
+  it('places the body at |top| below the page top for a negative top margin (§17.6.11)', async () => {
+    // §17.6.11 (pgMar/@top): a negative top margin measures the main text from the top
+    // of the page extent by |top| "regardless of the header ... and therefore shall
+    // overlap the header text". The spec's own example (w:top="-720") puts the body
+    // ½ inch (|top|) BELOW the page top. So with marginTop = −10 the body's first line
+    // must land 10pt below the page top — the SAME place a +10 top margin (no header to
+    // reserve against) puts it — NOT at the raw −10pt offset (which sits ABOVE the page
+    // top, off-canvas). Pre-fix the render path used the raw signed marginTop, so the
+    // body was painted above the page top and diverged from the +10 placement.
     const bodyY = (calls: Call[]) => calls.filter((c) => c.text === 'BODY').map((c) => c.y);
     const negTall = await renderPage0(docWithHeader(body(), tallHeader, { marginTop: -10 }));
     const negNone = await renderPage0(docWithHeader(body(), null, { marginTop: -10 }));
+    const posNone = await renderPage0(docWithHeader(body(), null, { marginTop: 10 }));
 
+    // Sanity: the tall header is still painted (the negative margin only stops the
+    // RESERVE, it does not suppress the header).
     expect(negTall.filter((c) => c.text === 'HDR').length).toBeGreaterThan(0);
+
+    // EXCEPTION: nothing is reserved — the body starts at the same y WITH the tall
+    // header as WITHOUT one (a naive max(0, header extent − top) would wrongly push
+    // it down here).
     expect(Math.min(...bodyY(negTall))).toBeCloseTo(Math.min(...bodyY(negNone)), 1);
+
+    // MAGNITUDE: |−10| places the body exactly where a +10 top margin (no reserve)
+    // does. This is the spec's "measured from the page top by |top|" rule.
+    expect(Math.min(...bodyY(negNone))).toBeCloseTo(Math.min(...bodyY(posNone)), 1);
+
+    // DIRECTION: the body's first line sits BELOW the page top (positive y), not
+    // off-canvas above it as the raw negative offset would place it.
+    expect(Math.min(...bodyY(negNone))).toBeGreaterThan(0);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -664,13 +664,20 @@ export async function renderDocumentToCanvas(
   for (const [id, n] of endnoteNums) noteNumbers.set(`endnote:${id}`, n);
 
   const docEA = documentHasEastAsian(doc.body);
+  // ECMA-376 §17.6.11: the body is inset from each page edge by the margin's MAGNITUDE
+  // (a negative margin places the body |margin| inside the edge, overlapping the
+  // header/footer — see bodyMarginInsetPt). Identity for the non-negative common case.
+  // The header/footer reserves below still use the SIGNED margin (header/footerOverflowPt
+  // return 0 for a negative one), so a negative margin reserves nothing yet insets |margin|.
+  const bodyTopPt = bodyMarginInsetPt(sec.marginTop);
+  const bodyBottomPt = bodyMarginInsetPt(sec.marginBottom);
   const baseState: RenderState = {
     ctx,
     scale,
     dpr,
     contentX: sec.marginLeft * scale,
     contentW: (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale,
-    y: sec.marginTop * scale,
+    y: bodyTopPt * scale,
     pageH: cssHeight,
     defaultColor: opts.defaultTextColor ?? '#000000',
     pageIndex,
@@ -679,8 +686,10 @@ export async function renderDocumentToCanvas(
     dryRun: false,
     marginLeft: sec.marginLeft,
     marginRight: sec.marginRight,
-    marginTop: sec.marginTop,
-    marginBottom: sec.marginBottom,
+    // §17.6.11: store the body inset (|margin|), the value the paint pass re-adds as a
+    // column's region top (state.marginTop, renderBodyElements); never the raw sign.
+    marginTop: bodyTopPt,
+    marginBottom: bodyBottomPt,
     pageWidth: sec.pageWidth,
     floats: [],
     floatParaSeq: 0,
@@ -744,7 +753,7 @@ export async function renderDocumentToCanvas(
   // and the header's extent, so a tall header (headerReservePx > 0) pushes the first
   // body line down to the header's bottom. The same overflow shrank the paginated
   // content area from the top (computeHeaderReserves), so the body fits within margins.
-  const bodyState: RenderState = { ...baseState, y: sec.marginTop * scale + headerReservePx };
+  const bodyState: RenderState = { ...baseState, y: bodyTopPt * scale + headerReservePx };
   // Optional column separator rules (`<w:cols w:sep="1">`), drawn before the text
   // so glyphs sit on top. A thin rule is centred in each inter-column gap and
   // spans the content height. With per-section columns a page can carry more than
@@ -845,7 +854,7 @@ function drawPageFootnotes(
   const gapPx = FOOTNOTE_SEPARATOR_GAP_PT * scale;
   // Clear a footer taller than the bottom margin (§17.6.11): the footnote block, like
   // the body, sits above the footer's overflow (footerReservePx), not just the margin.
-  const blockTopY = cssHeight - sec.marginBottom * scale - footerReservePx - contentPt * scale;
+  const blockTopY = cssHeight - bodyMarginInsetPt(sec.marginBottom) * scale - footerReservePx - contentPt * scale;
 
   // Separator rule: short left-aligned line (Word's default footnote separator,
   // ~1/3 of the text width), centered in the gap above the notes.
@@ -899,7 +908,7 @@ function drawEndnotes(
   // margin. We do NOT spill endnotes onto a dedicated trailing page yet.
   const ctx = bodyState.ctx;
   let y = bodyState.y + FOOTNOTE_SEPARATOR_GAP_PT * 2 * scale;
-  const maxY = cssHeight - sec.marginBottom * scale;
+  const maxY = cssHeight - bodyMarginInsetPt(sec.marginBottom) * scale;
   if (y >= maxY) return;
 
   // Separator rule above the endnotes.
@@ -1091,7 +1100,12 @@ export function computePages(
    *  (the common case). Computed by paginateWithHeaderFooterReserve's second pass. */
   pageReserves: PageReserve[] = [],
 ): PaginatedBodyElement[][] {
-  const fullContentH = section.pageHeight - section.marginTop - section.marginBottom;
+  // ECMA-376 §17.6.11: the body is inset from each page edge by the margin's MAGNITUDE
+  // (a negative margin measures the body |margin| from the edge and overlaps the
+  // header/footer — see bodyMarginInsetPt). Identity for the non-negative common case.
+  const bodyTopPt = bodyMarginInsetPt(section.marginTop);
+  const bodyBottomPt = bodyMarginInsetPt(section.marginBottom);
+  const fullContentH = section.pageHeight - bodyTopPt - bodyBottomPt;
   const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body));
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
@@ -1249,7 +1263,7 @@ export function computePages(
   // Page-absolute pt of the current region top, stamped on elements so the paint
   // pass resets a column's cursor to the region top (front-loaded layout: the
   // renderer consumes this instead of independently deciding the column top).
-  const colTopAbsPt = () => section.marginTop + colTopY;
+  const colTopAbsPt = () => bodyTopPt + colTopY;
 
   // Run `fn` with the measure state's content band temporarily re-pointed at the
   // CURRENT newspaper column (#513). The paint pass (renderBodyElements) sets
@@ -1291,7 +1305,7 @@ export function computePages(
   // like the real renderer does. floatParaSeq is reset together with floats so
   // the paraId採番 matches the renderer, which starts each page at 0 (a fresh
   // RenderState per page in renderDocumentToCanvas).
-  measureState.y = section.marginTop;
+  measureState.y = bodyTopPt;
   measureState.floats = [];
   measureState.floatParaSeq = 0;
   // ECMA-376 §20.4.3.2/§20.4.3.5: a wp:anchor whose positionV relativeFrom is
@@ -1352,7 +1366,7 @@ export function computePages(
       balanceColH = null;
       prevPara = null;
       prevSpaceAfter = 0;
-      measureState.y = section.marginTop;
+      measureState.y = bodyTopPt;
       // Floats are PAGE-scoped (ECMA-376 §20.4.2.x): a new page starts with a
       // clean float set. Columns of the SAME page share floats (see nextColumn).
       measureState.floats = [];
@@ -1381,7 +1395,7 @@ export function computePages(
     y = colTopY;
     prevPara = null;
     prevSpaceAfter = 0;
-    measureState.y = section.marginTop + colTopY;
+    measureState.y = bodyTopPt + colTopY;
   };
   // Overflow handler shared by element placement and paragraph/table splitting:
   // move to the next column if one remains on this page, otherwise to a new page.
@@ -1406,7 +1420,7 @@ export function computePages(
     startIdx: number,
     colWPt: number,
   ): { height: number; terminated: boolean } => {
-    const ms: RenderState = { ...measureState, y: section.marginTop, floats: [], floatParaSeq: 0 };
+    const ms: RenderState = { ...measureState, y: bodyTopPt, floats: [], floatParaSeq: 0 };
     let total = 0;
     let prevAfter = 0;
     let prevP: DocParagraph | null = null;
@@ -1564,7 +1578,7 @@ export function computePages(
       balanceColH = null;
       prevPara = null;
       prevSpaceAfter = 0;
-      measureState.y = section.marginTop;
+      measureState.y = bodyTopPt;
       measureState.floats = [];
       measureState.floatParaSeq = 0;
       // Pre-register page-level wrap floats from the next body element onward
@@ -1615,7 +1629,7 @@ export function computePages(
         // this clears the overprint and the page-fill error regardless.
         const regionBottom = Math.max(maxColBottomY, y);
         y = regionBottom;
-        measureState.y = section.marginTop + regionBottom;
+        measureState.y = bodyTopPt + regionBottom;
         colTopY = regionBottom;
         maxColBottomY = regionBottom;
         prevPara = null;
@@ -1635,7 +1649,7 @@ export function computePages(
         balanceColH = null;
         prevPara = null;
         prevSpaceAfter = 0;
-        measureState.y = section.marginTop;
+        measureState.y = bodyTopPt;
         measureState.floats = [];
         measureState.floatParaSeq = 0;
         // Pre-register page-level wrap floats from the next body element onward
@@ -1909,7 +1923,7 @@ export function computePages(
         // filled their column/page exactly, so the break callback ran between
         // them).
         y = placed.endY;
-        measureState.y = section.marginTop + placed.endY;
+        measureState.y = bodyTopPt + placed.endY;
         // A split footnote-bearing paragraph reserves on the page where it
         // ends. Rare; the separator region re-applies if that page had none.
         if (haveFootnotes && newRefIds.length > 0) {
@@ -1992,11 +2006,11 @@ export function computePages(
           () => colIndex,
           columns,
           () => colTopY,
-          section.marginTop,
+          bodyTopPt,
           () => currentSectionHF,
         );
         y = endY;
-        measureState.y = section.marginTop + endY;
+        measureState.y = bodyTopPt + endY;
       } else {
         // §17.6.4 column balancing (wantsBalanceBreak) OR a table that doesn't fit
         // the rest of this column ⇒ advance to the next column / page.
@@ -2037,6 +2051,19 @@ function footerOverflowPt(footerH: number, marginBottom: number, footerDistance:
 function headerOverflowPt(headerH: number, marginTop: number, headerDistance: number): number {
   if (marginTop < 0) return 0;
   return Math.max(0, headerDistance + headerH - marginTop);
+}
+
+/** ECMA-376 §17.6.11 (pgMar/@top,@bottom): the body text's distance (pt) from the page
+ *  edge is the margin's MAGNITUDE. A non-negative margin insets the body, and the
+ *  header/footer is reserved against it (header/footerOverflowPt push the body further
+ *  in). A NEGATIVE margin measures the body |margin| from the page edge "regardless of
+ *  the header/footer ... and therefore shall overlap the header/footer text" — the
+ *  spec's w:top="-720"/w:bottom="-720" examples place the body ½ inch (|margin|) inside
+ *  the page edge while overlapping the running head/foot (those functions then reserve
+ *  0). Either way the body's inset from the page edge is |margin|. Math.abs is identity
+ *  for the non-negative common case, so this only changes negative-margin documents. */
+function bodyMarginInsetPt(margin: number): number {
+  return Math.abs(margin);
 }
 
 /** Resolve the footer that applies to `pageIndex` with the §17.10.1/§17.10.6
@@ -2202,8 +2229,11 @@ function buildMeasureState(
     dryRun: true,
     marginLeft: section.marginLeft,
     marginRight: section.marginRight,
-    marginTop: section.marginTop,
-    marginBottom: section.marginBottom,
+    // §17.6.11: the measure state's marginTop is the body inset (|margin|) — the base for
+    // the page-absolute region top stamped on slices (splitParagraphAcrossPages' colTopPt),
+    // which must match the paint pass. Never the raw sign. Identity for non-negative.
+    marginTop: bodyMarginInsetPt(section.marginTop),
+    marginBottom: bodyMarginInsetPt(section.marginBottom),
     pageWidth: section.pageWidth,
     floats: [],
     floatParaSeq: 0,
@@ -3194,8 +3224,10 @@ function drawColumnSeparators(
   sec: SectionProps,
   scale: number,
 ): void {
-  const topY = sec.marginTop * scale;
-  const botY = (sec.pageHeight - sec.marginBottom) * scale;
+  // §17.6.11: the separators span the body content band, whose top/bottom are inset from
+  // the page edges by the margins' MAGNITUDE (bodyMarginInsetPt). Identity for non-negative.
+  const topY = bodyMarginInsetPt(sec.marginTop) * scale;
+  const botY = (sec.pageHeight - bodyMarginInsetPt(sec.marginBottom)) * scale;
   ctx.save();
   ctx.strokeStyle = '#000000';
   ctx.lineWidth = Math.max(1, Math.round(0.5 * scale));


### PR DESCRIPTION
## What

ECMA-376 **§17.6.11 (pgMar/@top,@bottom)**: when a top/bottom margin is **negative**, the spec says the body is *"measured from the top/bottom of the page extent regardless of the header/footer ... and therefore shall overlap the header/footer text."* The spec's own examples (`w:top="-720"`, `w:bottom="-720"`) place the body **½ inch (|margin|) inside the page edge** while overlapping the running head/foot.

The header/footer **reserve** was already correct for this case (`header/footerOverflowPt` return `0` for a negative margin — nothing is reserved). But the **body itself** was then placed at the **raw signed margin**:

- **Top:** `bodyState.y = marginTop * scale + headerReservePx` → with `marginTop = -36pt`, reserve `0`, the body landed at `-36pt` (above the page top, off-canvas) instead of `+36pt` below it.
- **Bottom:** `fullContentH = pageHeight - marginTop - marginBottom` → a negative `marginBottom` made the content area *taller* (`… - (-36) = +36`), so body lines packed *past* the page bottom; the footnote/endnote anchors used the raw negative bottom too.

This was **pre-existing** (not introduced by the header-reserve PR #601) and symmetric across both sides.

## Fix

Introduce `bodyMarginInsetPt(margin) = Math.abs(margin)` — the body's distance from the page edge in **both** cases (non-negative: header/footer reserve still pushes the body further in; negative: body overlaps, nothing reserved). Apply it at **every body-region site**:

- `computePages` `fullContentH` + all measure region tops / stamped `colTopPt` bases
- render `baseState` / `bodyState` y and the `RenderState.marginTop/Bottom` fields the paint pass re-adds as a column's region top
- footnote / endnote bottom anchors
- column separator band

The **signed** margin is kept **only** for `header/footerOverflowPt` (which decide overlap-vs-reserve).

`Math.abs` is **identity for non-negative margins**, so every existing document is byte-for-byte unchanged — only negative-margin documents are affected.

## Tests (red → green)

Strengthened the negative cases in `header-reserve.test.ts` / `footer-reserve.test.ts` (previously they only asserted that a negative margin reserves *nothing*). They now also assert the body lands at **|margin|** from the page edge — equal to where a `+|margin|` margin (no header/footer to reserve against) places it, and **not** at the raw negative offset:

- `places the body at |top| below the page top for a negative top margin (§17.6.11)`
- `places the body bottom at |bottom| above the page bottom for a negative bottom margin (§17.6.11)`

Both fail before the fix (top off by `2×|top|`; bottom packs `~23pt` past the page bottom) and pass after.

```
docx unit suite: 304 passed (304)
docx typecheck:  clean
```

## Cross-package note

**docx-only.** Negative pgMar top/bottom is a Word page-margin concept; xlsx has no flowing-body footer/pagination model and pptx has no body reflow, so there is no shared structure to fix here (same conclusion as the footer-reserve work in #599).

🤖 Generated with [Claude Code](https://claude.com/claude-code)