### PR TITLE
fix(docx): split a CJK run before a glued non-starter instead of pushing it down whole

### DIFF
--- a/packages/docx/src/cjk-glued-nonstarter-wrap.test.ts
+++ b/packages/docx/src/cjk-glued-nonstarter-wrap.test.ts
@@ -138,5 +138,28 @@ describe('CJK run + glued non-starter — fill the line instead of pushing the w
     // down whole behind its glued "。". Pre-fix line 1 held 6 cells (only run A).
     expect(line1Chars.length).toBe(10);
     expect(line1Chars).toContain('い'); // run B reached line 1
+    expect(line1Chars).not.toContain('。'); // the non-starter stays with its tail
+  });
+
+  it('keeps the glued "。" off the next line head when the CJK run exactly fills the line', async () => {
+    // The contract the fix leans on: with the pre-flush skipped, a CJK run that
+    // EXACTLY fills the line (10 cells) followed by a standalone "。" must not
+    // orphan "。" at the next line's head — §17.3.1.16 kinsoku retracts the run's
+    // last cell so "。" follows a CJK char ("あ。"), never leading a line.
+    const calls = await render([gluedPara(['ああああああああああ', '。'])], section());
+    expect(calls.length).toBeGreaterThan(0);
+
+    const byY = new Map<number, { text: string; x: number }[]>();
+    for (const c of calls) {
+      const k = Math.round(c.y);
+      (byY.get(k) ?? byY.set(k, []).get(k)!).push({ text: c.text, x: c.x });
+    }
+    // Every line: its leading (min-x) glyph must not be the non-starter "。".
+    for (const [, glyphs] of byY) {
+      const head = glyphs.slice().sort((p, q) => p.x - q.x)[0];
+      expect(head.text).not.toBe('。');
+    }
+    // And "。" is actually present (it was rendered, not dropped).
+    expect(calls.map((c) => c.text).join('')).toContain('。');
   });
 });

--- a/packages/docx/src/cjk-glued-nonstarter-wrap.test.ts
+++ b/packages/docx/src/cjk-glued-nonstarter-wrap.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// Regression: a CJK run followed by a glued non-starter ("。" / "、" etc., in its
+// OWN run with no intervening space) must still CJK-split to fill the line. The
+// non-starter carries `joinPrev` (UAX#14 LB13, keeps "。" off a line head); the
+// line-breaker's glued-group pre-flush — meant for ATOMIC Latin/small-caps groups
+// like "system" + "," — wrongly treated {CJK-run, 。} as atomic too, flushing the
+// WHOLE group to the next line instead of splitting the (breakable) CJK run. The
+// prior line then carried far fewer characters and a justified paragraph stretched
+// it wide (sample-9: line 2 held 27 of 39 chars, spacing ~46% too wide).
+//
+// The fix skips the pre-flush when the lead segment is CJK-breakable, so the CJK
+// run splits normally and "。" stays with its tail (kinsoku still keeps it off the
+// next line's head). This guards the docx side; pptx/xlsx do not share this path.
+
+const FONT_PX = 20; // glyph advance per CJK char in the stub (scale = 1)
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; x: number; y: number }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fillTextCalls: { text: string; x: number; y: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) { fillTextCalls.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+/** A `both`-justified paragraph whose runs are: a CJK run that fills the line
+ *  start, a CJK run that must split to fill the rest, and a glued non-starter
+ *  "。" in its own run (→ joinPrev). */
+function gluedPara(texts: string[]): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'both',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: texts.map((t) => ({ type: 'text', ...textRun(t) }) as DocRun),
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 200, pageHeight: 400, // contentWidth 200 → exactly 10 CJK cells/line
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    ...overrides,
+  };
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(body: BodyElement[], sec: SectionProps) {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, { dpr: 1, width: sec.pageWidth });
+  return fillTextCalls;
+}
+
+describe('CJK run + glued non-starter — fill the line instead of pushing the whole group down', () => {
+  it('splits the CJK run onto the first line; does not orphan its space', async () => {
+    // availW = 200 px = 10 cells. run A "あ"×6 (120px) fills the start; run B
+    // "い"×6 must split (4 onto line 1 → full 10, 2 to line 2); run C "。" is a
+    // glued non-starter (its own run → joinPrev). Pre-fix: the glued-group
+    // pre-flush moved {B,。} whole to line 2, leaving line 1 with only A's 6 cells.
+    const calls = await render(
+      [gluedPara(['ああああああ', 'いいいいいい', '。'])],
+      section(),
+    );
+    expect(calls.length).toBeGreaterThan(0);
+
+    // First (top) line.
+    const byY = new Map<number, { text: string; x: number }[]>();
+    for (const c of calls) {
+      const k = Math.round(c.y);
+      (byY.get(k) ?? byY.set(k, []).get(k)!).push({ text: c.text, x: c.x });
+    }
+    const firstY = Math.min(...byY.keys());
+    const line1 = byY.get(firstY)!.slice().sort((p, q) => p.x - q.x);
+    // Count CHARACTERS, not fillText calls: a justified CJK line is drawn in
+    // pieces (one call may cover several glyphs), so the call count is not the
+    // cell count.
+    const line1Chars = [...line1.map((g) => g.text).join('')];
+
+    // The breakable CJK run B must split to fill line 1 (10 cells), not be pushed
+    // down whole behind its glued "。". Pre-fix line 1 held 6 cells (only run A).
+    expect(line1Chars.length).toBe(10);
+    expect(line1Chars).toContain('い'); // run B reached line 1
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5666,14 +5666,16 @@ function layoutLines(
     // let the group split across lines. Pre-measure it and, if it does not fit on
     // the current (non-empty) line, flush so it starts fresh.
     //
-    // ONLY when the lead segment is NOT itself CJK-breakable, though. A glued
-    // group whose lead is a CJK run (e.g. "…通過する" + "。") is NOT atomic — the
-    // run can split at any inter-CJK boundary, with the trailing non-starter
-    // staying on the run's LAST piece (kinsoku keeps it off the next line's
-    // head). Pre-flushing it instead pushes the whole run down and leaves the
-    // prior line far short, which a `both` line then stretches wide (sample-9).
-    // For a non-breakable Latin/small-caps lead the group truly is atomic, so the
-    // pre-flush (and the over-long-word char-break path below) still applies.
+    // ONLY when the lead segment is NOT itself CJK-breakable. A glued group whose
+    // lead is a CJK run (e.g. "…通過する" + "。") is NOT atomic: the run splits at
+    // an inter-CJK boundary and the trailing non-starter stays on its LAST piece
+    // (§17.3.1.16 kinsoku keeps it off the next line's head when enabled — the
+    // default; with kinsoku off it may lead the line, as it did before PR #602).
+    // Pre-flushing the whole run instead leaves the prior line far short, which a
+    // `both` line then stretches wide (sample-9). `joinPrev` stays a pure "this is
+    // a non-starter" marker; the atomic-vs-breakable decision lives HERE. A
+    // non-breakable Latin / small-caps lead is genuinely atomic, so the pre-flush
+    // (and the over-long-word char-break path below) still applies there.
     if (
       !s.joinPrev &&
       currentLine.length > 0 &&

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5659,14 +5659,27 @@ function layoutLines(
     const wForFit = w - trailingSpaceW;
     const shrinkBudget = lineTotalTrailingW * SPACE_SHRINK_RATIO;
 
-    // Small-caps glued group: when THIS segment starts a glued group (its
-    // followers in the queue are `joinPrev` case-pieces of the SAME word — e.g.
-    // "I" then "NTRODUCTION"), the whole group must stay on one line. The
-    // per-segment wrap below would let the reduced remainder spill to the next
-    // line. Pre-measure the group and, if it does not fit on the current
-    // (non-empty) line, flush so it starts fresh. (If the group is wider than a
-    // full line it still char-breaks via the over-long-word path below.)
-    if (!s.joinPrev && currentLine.length > 0 && (queue[0] as LayoutTextSeg | undefined)?.joinPrev) {
+    // Atomic glued group: when THIS segment starts a glued group (its followers
+    // in the queue are `joinPrev` pieces — small-caps case-pieces of the SAME
+    // word like "I" then "NTRODUCTION", or a UAX#14 LB13 non-starter authored in
+    // its own run like a trailing "," / "。"), the per-segment wrap below would
+    // let the group split across lines. Pre-measure it and, if it does not fit on
+    // the current (non-empty) line, flush so it starts fresh.
+    //
+    // ONLY when the lead segment is NOT itself CJK-breakable, though. A glued
+    // group whose lead is a CJK run (e.g. "…通過する" + "。") is NOT atomic — the
+    // run can split at any inter-CJK boundary, with the trailing non-starter
+    // staying on the run's LAST piece (kinsoku keeps it off the next line's
+    // head). Pre-flushing it instead pushes the whole run down and leaves the
+    // prior line far short, which a `both` line then stretches wide (sample-9).
+    // For a non-breakable Latin/small-caps lead the group truly is atomic, so the
+    // pre-flush (and the over-long-word char-break path below) still applies.
+    if (
+      !s.joinPrev &&
+      currentLine.length > 0 &&
+      (queue[0] as LayoutTextSeg | undefined)?.joinPrev &&
+      !hasCJKBreakOpportunity(s.text)
+    ) {
       let groupW = w;
       let groupTrail = trailingSpaceW;
       for (let k = 0; k < queue.length && (queue[k] as LayoutTextSeg).joinPrev; k++) {


### PR DESCRIPTION
## 概要

両端揃え（`jc=both`）の CJK 段落で、**行が本来より大幅に間延びする**バグの修正。

`sample-9.docx` の「セロハンテープの接着面でない面からは…」の一文で、2行目が Word では39字（「隙間、すなわち…発生したため、スリットの隙間を通」）入るのに、我々は27字（「…発生した」）で折り返して justify で約46%広く引き伸ばされていた、という指摘の根治。

## 原因

CJK の run（run4「ため、…であった」）の直後に、**非starter「。」が独立した run（run5）** として続く（間に空白なし）。UAX#14 LB13 のパス（[renderer.ts](packages/docx/src/renderer.ts) 内、PR #602 由来）が「。」を `joinPrev` でマークし行頭に来ないようにする。

ところが line-breaker の **glued-group 先行 flush**（small-caps の語片や Latin の「system」+「,」のような**不可分グループ**を1行に保つための処理）が、`{CJK run, 。}` も不可分扱いしてしまい、グループが入らないと **CJK run を分割せず丸ごと次行へ flush**。その結果、前の行が本来より少ない文字数で確定し、両端揃えで大きく引き伸ばされる。

実測（headless skia + Word PDF）:
- 修正前: 2行目 = 27字、送り 16.23pt（自然幅11.1の約46%増）
- Word: 2行目 = 39字、送り 11.1pt

## 修正

glued-group 先行 flush を **lead セグメントが CJK 分割可能でない時のみ** に限定（`!hasCJKBreakOpportunity(s.text)`）。

- CJK run が lead の場合はグループは**不可分ではない** → 通常の CJK 分割で行を埋め、末尾の非starter「。」は run の最後のピースに付いて行く（行頭禁則は kinsoku が担保）。
- Latin / small-caps の不可分 lead は従来どおり先行 flush（PR #602 の LB13 折返しと small-caps グルーピングは不変）。

```diff
- if (!s.joinPrev && currentLine.length > 0 && (queue[0]…)?.joinPrev) {
+ if (!s.joinPrev && currentLine.length > 0 && (queue[0]…)?.joinPrev
+     && !hasCJKBreakOpportunity(s.text)) {
```

## 検証

- 実 `sample-9.docx` を headless 再描画: 該当2行目が **39字・自然送り11.11pt**（x[90..512]）に。Word（39字 x[90..523]）と一致。1・3行目も一致。
- 新規回帰テスト `cjk-glued-nonstarter-wrap.test.ts`: CJK run＋glued「。」の両端揃え行が行を埋める（修正前は10セル中6セルしか入らない）。RED→GREEN 確認。
- docx 全 **305 テスト合格**（LB13 `latin-nonstarter-wrap` / distribute / docgrid 含め回帰なし）、docx typecheck クリーン。

## 横断

この glued-group 先行 flush は **docx 固有**のパス（pptx/xlsx は別の CJK wrap 実装で本パスを共有しない）。LB13 の joinPrev 自体は #602 で3パッケージ統一済みだが、グルーピングの flush ロジックは docx のみが持つため修正も docx に閉じる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)