### PR TITLE
docs(docx): clarify the §17.6.11 signed-margin vs body-inset contract (review follow-up)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -194,10 +194,18 @@ export interface RenderState {
   dryRun: boolean;
   /** section left margin in pt — used to convert margin-relative anchor X to page-absolute */
   marginLeft: number;
-  /** section right/top/bottom margins in pt — used by anchor positioning to
-   *  resolve `<wp:positionH/V relativeFrom="margin">` and the
-   *  `*Margin` family containers. */
+  /** section right margin in pt — used by anchor positioning to resolve
+   *  `<wp:positionH relativeFrom="margin">` and the `*Margin` family containers. */
   marginRight: number;
+  /** ECMA-376 §17.6.11: the body's TOP/BOTTOM **inset** from the page edge in pt — the
+   *  margin's MAGNITUDE (|margin|), NOT the signed pgMar value. A negative top/bottom
+   *  margin (ST_SignedTwipsMeasure) measures the body |margin| from the page edge and
+   *  overlaps the header/footer; `bodyMarginInsetPt` derives this at the writers
+   *  (baseState, buildMeasureState). Read as the column region top (renderBodyElements /
+   *  splitParagraphAcrossPages) and as the text-margin container for `relativeFrom=
+   *  "topMargin"/"bottomMargin"/"margin"` anchors/frames (anchor-geometry, frame-geometry;
+   *  §17.18.100 — the text-margin location IS the body edge). Do NOT treat as the signed
+   *  margin: the overflow decision keeps the sign separately (header/footerOverflowPt). */
   marginTop: number;
   marginBottom: number;
   /** Section page width in pt. */
@@ -3335,8 +3343,10 @@ function renderBodyElements(
         // paginator computed and stamped it (`colTopPt`, page-absolute pt); the
         // paint pass consumes it rather than re-deriving the column top. Absent ⇒
         // a page-spanning section ⇒ the page content top, unchanged. A tall header
-        // (§17.6.11) shifts the whole content frame down — `colTopPt` is the bare
-        // margin top, so re-add the reserve, matching column 0's `bodyState.y`.
+        // (§17.6.11) shifts the whole content frame down — `colTopPt`/`state.marginTop`
+        // carry the body inset (|margin|, not the signed margin), so re-add the reserve
+        // to match column 0's `bodyState.y`. A negative top margin reserves 0, so the
+        // re-add is a no-op there (the body already overlaps the header).
         state.y = (el.colTopPt ?? state.marginTop) * state.scale + headerReservePx;
       }
       prevPara = null;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -117,9 +117,14 @@ export interface HeaderFooter {
 export interface SectionProps {
   pageWidth: number;   // pt
   pageHeight: number;  // pt
-  marginTop: number;   // pt
+  // ECMA-376 §17.6.11 — top/bottom are ST_SignedTwipsMeasure (§17.18.81) and MAY be
+  // negative (the body is then measured |margin| from the page edge and overlaps the
+  // header/footer). Keep the SIGN here: header/footerOverflowPt need it to decide
+  // overlap-vs-reserve. The renderer's bodyMarginInsetPt derives the body inset (|margin|).
+  // Do NOT Math.abs at the parser or overflow sites. left/right are ST_TwipsMeasure (unsigned).
+  marginTop: number;   // pt — signed (§17.6.11)
   marginRight: number;
-  marginBottom: number;
+  marginBottom: number; // pt — signed (§17.6.11)
   marginLeft: number;
   headerDistance: number;   // pt — top of page to header
   footerDistance: number;   // pt — bottom of page to footer


### PR DESCRIPTION
Comment-only follow-up to #604 (negative pgMar body inset, §17.6.11). **No behavioral change** — rendering is byte-identical and the full docx unit suite (306 tests) is green.

## Why

Independent critical review of #604 found no blockers, but flagged a **latent trap**: after the fix, `RenderState.marginTop/marginBottom` hold the body **inset** (`|margin|`), not the signed pgMar value — and that distinction is load-bearing, because `header/footerOverflowPt` must keep the sign to decide overlap-vs-reserve. A future contributor could "helpfully" `Math.abs` the margin at the parser/overflow sites and silently break the negative-margin overlap behavior.

## Changes (documentation only)

- **`RenderState.marginTop/marginBottom`**: document that they carry the body inset (`|margin|`, §17.6.11), are derived by `bodyMarginInsetPt` at the writers (`baseState`, `buildMeasureState`), and are read both as the column region top (`renderBodyElements`/`splitParagraphAcrossPages`) and as the text-margin container for `relativeFrom="topMargin"/"bottomMargin"/"margin"` anchors/frames (`anchor-geometry`/`frame-geometry`; §17.18.100 — the text-margin location *is* the body edge).
- **`SectionProps.marginTop/marginBottom`**: note they are `ST_SignedTwipsMeasure` (§17.18.81, may be negative); keep the sign — `header/footerOverflowPt` need it. `left`/`right` are unsigned `ST_TwipsMeasure`.
- Fix the now-stale paint-pass comment that called `colTopPt` "the bare margin top" (it carries `|margin|`; a negative top margin reserves 0, so the reserve re-add is a no-op there).

The review also confirmed: spec-faithful, single-responsibility, no duplication, and **docx-only** (proven by grep-confirmed absence of any page/print/reserve model in xlsx and pptx — different domains by design, no shared 穴).

🤖 Generated with [Claude Code](https://claude.com/claude-code)