### PR TITLE
chore(release): 0.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.67.0 — 2026-06-29
+
+Minor. A large DOCX fidelity pass — journal templates (sample-9/12/13) now match
+Word across headers/footers, line breaking, justification, and text metrics —
+plus cross-format CJK/Latin line-breaking and XLSX rich-text fixes.
+
+- **docx (headers / footers):** headers and footers are now resolved per active
+  section per page, including first-page (`w:titlePg`, §17.10.6) and even/odd
+  (`w:evenAndOddHeaders`, §17.10.1); a header or footer taller than its page
+  margin reserves space so the body never overlaps it (§17.6.11), across every
+  column of a multi-column section.
+- **docx (line breaking / justification):** a justified (`both` / `distribute`)
+  line spreads slack across every inter-CJK boundary including the line's last
+  segment (§17.18.44); a CJK run followed by a glued non-starter ("。" / "、" in its
+  own run) splits to fill the line instead of being pushed down whole; and a
+  UAX#14 LB13 non-starter authored across a run boundary (a leading "," / "。")
+  stays glued to its word — fixed consistently in docx, pptx, and xlsx with the
+  shared predicate centralized in core.
+- **docx (text metrics / layout):** Times New Roman / Arial line height comes from
+  the hhea design metrics (matching Word's line box); small caps are sized per
+  character so a capital initial stays full size (§17.3.2.33); anchored text-box
+  content renders with correct paragraph spacing, style alignment, and z-order; an
+  empty paragraph mark reserves a full line; heading numbering shares one counter
+  per abstract list (§17.9); a `numId=0` de-listed paragraph drops the inherited
+  list indent; a negative `w:pgMar` top/bottom places the body's `|margin|` inside
+  the page edge (§17.6.11); and continuous-section spacer paragraphs collapse /
+  suppress spacing-before to match Word.
+- **docx (columns / figures):** continuous two-column sections balance at line
+  granularity; EMF figures crop to their `rclFrame`.
+- **xlsx (rich text):** empty shape / cell paragraphs reserve a line; non-wrapped
+  rich text honors `\n`; wrapped super/subscript sizes correctly; and a wrapped
+  rich cell re-resolves the bidi base direction per LF paragraph.
+- **cross-format (core):** `<a:srcRect>` image cropping is unified in core and
+  shared by docx, pptx, and xlsx (including the metafile gate via `isMetafileMime`).
+
 ## 0.66.3 — 2026-06-24
 
 Patch. DOCX cover-page fix — resolves the 0.66.1 hotfix trade-off (sample-5 and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.66.3",
+  "version": "0.67.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.66.3",
+  "version": "0.67.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.66.3",
+  "version": "0.67.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.66.3",
+  "version": "0.67.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.66.3",
+  "version": "0.67.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.66.3",
+  "version": "0.67.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.66.3",
+  "version": "0.67.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.66.3",
+  "version": "0.67.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.67.0 — a large DOCX fidelity pass (v0.66.3 以降の ~30 PR を取りまとめ).

## 含まれる主な変更（CHANGELOG.md 参照）
- **docx headers/footers**: per-section + first-page(titlePg §17.10.6) + even/odd(§17.10.1)、margin超のheader/footer reserve(§17.6.11、複数段組み全column)
- **docx 行分割/両端揃え**: 最終CJKセグメントへの分配(§17.18.44)、CJK run＋glued非starter「。」の充填分割、run跨ぎLB13非starter glue(docx/pptx/xlsx横断、core集約)
- **docx テキストメトリクス/レイアウト**: TNR/Arial hhea行高、smallCaps文字別(§17.3.2.33)、anchored textbox、空段落マーク行高、見出し採番共有カウンタ(§17.9)、numId=0 de-list、負margin body(§17.6.11)、連続セクションspacer collapse
- **docx 段組み/図**: 連続2段balance行粒度、EMF rclFrameクロップ
- **xlsx rich-text**: 空段落行高、非折返し`\n`、折返しsuper/sub、LF段落ごとbidi base
- **cross-format core**: `<a:srcRect>` クロップ core 集約(docx/pptx/xlsx共有)

## リリース手順チェック
- [x] CHANGELOG 0.67.0 追記（area別 bullet、§番号併記）
- [x] バージョン bump 計8ファイル → 0.67.0（root + core/pptx/xlsx/docx/markdown/node/vscode-extension、inter-dep は `workspace:*`）
- [x] README 整合性検証: ESM-only(`.mjs`)・install/import(ESM)・Bundle size note は実態と一致。Feature Support 表は even/odd headers・kinsoku・CJK both/distribute を既に収録、本リリースは精度向上が主体で表変更なし
- [x] 公開 API 不変（viewer/document/presentation 無変更、core 追加 export は内部述語のみ）→ site api-reference / Capabilities 更新不要
- [ ] README スクリーンショット: 既存(docs/images/*.png)を維持。今回は描画忠実度の精度向上が主で代表サンプルの構図・外観は実質不変のため再撮影による不整合リスクを避けて据え置き（再撮影ご希望あれば対応します）

マージ後に `v0.67.0` タグを push → VS Code 拡張 publish + Pages デプロイが自動実行されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)