### PR TITLE
chore(release): 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.68.0 — 2026-06-29
+
+Minor. XLSX viewer interactions — drag-to-resize columns/rows, mouse-wheel /
+trackpad-pinch zoom, and a customizable selection color — all **view-only**: the
+loaded file is never modified. Plus a spec-fidelity and consolidation pass.
+
+- **xlsx (resize):** drag a column or row header border to resize it (`resizable`
+  option, default on; set `false` to disable). The dragged size is written into
+  the in-memory worksheet model only — it never modifies the loaded file. Column
+  widths convert per ECMA-376 §18.3.1.13. (#567, #607, #609)
+- **xlsx (zoom):** Ctrl/⌘ + mouse-wheel and trackpad-pinch zoom, in addition to
+  the Excel-style slider. The step is exponential in the wheel delta, so the
+  total zoom tracks the scroll distance rather than the number of events — a
+  trackpad pinch and a mouse wheel covering the same distance zoom by the same
+  amount. (#607, #609)
+- **xlsx (selection):** customizable cell-selection accent color (`selectionColor`
+  option / `setSelectionColor()`; default Google blue, fill at 8% opacity). (#607)
+- **xlsx (internals):** the column-width px conversion is now ECMA-376
+  §18.3.1.13-exact; the resize hit-test is extracted to a pure, unit-tested
+  helper; the local `hexToRgba` is folded into core's shared version (used by
+  docx/pptx); and `XlsxViewerOptions` extends the shared core `LoadOptions`
+  instead of re-declaring its fields. (#609)
+
 ## 0.67.0 — 2026-06-29
 
 Minor. A large DOCX fidelity pass — journal templates (sample-9/12/13) now match

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release 0.68.0.

XLSX viewer interactions — drag-to-resize columns/rows, mouse-wheel / trackpad-pinch zoom, and a customizable selection color — all **view-only** (the loaded file is never modified), plus a spec-fidelity and consolidation pass.

- xlsx (resize): drag a column/row header border to resize (`resizable` option, default on); writes the in-memory model only, never the file; widths per ECMA-376 §18.3.1.13. (#567, #607, #609)
- xlsx (zoom): Ctrl/⌘+wheel and trackpad-pinch zoom; step exponential in delta so total zoom tracks scroll distance, not event count. (#607, #609)
- xlsx (selection): `selectionColor` option / `setSelectionColor()`. (#607)
- xlsx (internals): §18.3.1.13-exact column-width conversion; pure `resizeHitIndex`; `hexToRgba` folded into core; `XlsxViewerOptions extends LoadOptions`. (#609)

Version bumped across all 8 package.json files; CHANGELOG updated. No rendering changes, so README screenshots are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)