### PR TITLE
fix(docx): keep a numbering level's firstLine indent positive (§17.3.1.12)

### DIFF
--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -42,7 +42,14 @@ pub struct LevelDef {
     /// pt — w:ind@right ≡ logical END indent (Part 4 §14.11.2). RTL list levels
     /// carry their indent here (the renderer maps it to the physical left side).
     pub indent_right: Option<f64>,
-    pub tab: f64, // pt
+    /// pt — SIGNED first-line indent (§17.3.1.12): `w:hanging` ⇒ negative (the
+    /// marker hangs left of the body), `w:firstLine` ⇒ positive (an additional
+    /// first-line indent). Mirrors how `styles.rs` stores a direct `w:ind`.
+    pub indent_first: f64,
+    /// pt — POSITIVE magnitude of the first-line indent (= `indent_first.abs()`).
+    /// Distinct from `indent_first` because the renderer uses it as the marker's
+    /// tab-advance distance (§17.9.6 + §17.3.1.38, suff=tab), which is unsigned.
+    pub tab: f64,
     /// ECMA-376 §17.9.28 `<w:suff>` — what follows the number text: "tab"
     /// (default), "space", or "nothing". Controls where the body text starts
     /// relative to the marker on the first line.
@@ -97,6 +104,7 @@ impl Default for LevelDef {
             text: "%1.".to_string(),
             indent_left: 36.0,
             indent_right: None,
+            indent_first: -36.0,
             tab: 36.0,
             suff: "tab".to_string(),
             lvl_jc: "left".to_string(),
@@ -243,10 +251,20 @@ impl NumberingMap {
                 let indent_right = ind_node
                     .and_then(|i| attr_w(i, "right"))
                     .map(|v| twips_to_pt(&v));
-                let tab = ind_node
-                    .and_then(|i| attr_w(i, "hanging").or_else(|| attr_w(i, "firstLine")))
-                    .map(|v| twips_to_pt(&v))
-                    .unwrap_or(36.0);
+                // §17.3.1.12: a first-line indent is EITHER `w:hanging` (negative —
+                // the marker hangs left of the body) OR `w:firstLine` (positive — an
+                // additional first-line indent); `hanging` wins when both appear, the
+                // same precedence `styles.rs` applies to a direct `w:ind`. Keep the
+                // SIGN in `indent_first`; `tab` keeps the positive magnitude for the
+                // marker's tab-advance.
+                let indent_first = ind_node
+                    .and_then(|i| {
+                        attr_w(i, "hanging")
+                            .map(|v| -twips_to_pt(&v))
+                            .or_else(|| attr_w(i, "firstLine").map(|v| twips_to_pt(&v)))
+                    })
+                    .unwrap_or(-36.0);
+                let tab = indent_first.abs();
                 // §17.9.28: absent <w:suff> means "tab".
                 let suff = child_w(lvl_node, "suff")
                     .and_then(|n| attr_w(n, "val"))
@@ -273,6 +291,7 @@ impl NumberingMap {
                     text,
                     indent_left,
                     indent_right,
+                    indent_first,
                     tab,
                     suff,
                     lvl_jc,

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1747,7 +1747,7 @@ fn parse_paragraph_cond(
     let (indent_left, indent_first) = if let Some(l) = level {
         (
             direct_indent_left.unwrap_or(l.indent_left),
-            direct_indent_first.unwrap_or(-l.tab),
+            direct_indent_first.unwrap_or(l.indent_first),
         )
     } else if base_para.num_id == Some(0) {
         // `numId=0` explicitly removes numbering (ECMA-376 §17.3.1.19 / §17.9.18). That
@@ -7427,6 +7427,78 @@ mod footnote_tests {
             (direct_hang.indent_first + 12.0).abs() < 0.01,
             "a direct hanging (240 twips → −12 pt) overrides the level's −18, got {}",
             direct_hang.indent_first
+        );
+    }
+
+    /// ECMA-376 §17.3.1.12 — a numbering level's first-line indent keeps its SIGN:
+    /// `w:firstLine` is a POSITIVE (additional) first-line indent, `w:hanging` a
+    /// NEGATIVE one. A level authored with `w:firstLine` must yield a positive
+    /// paragraph `indent_first`. Regression guard: the level's first-line magnitude
+    /// was stored unsigned (`tab`) and always negated at use-site (`-l.tab`), which
+    /// turned a `firstLine` level into a hanging one.
+    #[test]
+    fn numbering_level_firstline_keeps_positive_sign() {
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+
+        // numId 4 → a level with a POSITIVE first-line indent (w:firstLine, not w:hanging).
+        let numbering_first = format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="30"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/><w:pPr><w:ind w:left="720" w:firstLine="360"/></w:pPr></w:lvl></w:abstractNum>
+              <w:num w:numId="4"><w:abstractNumId w:val="30"/></w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        );
+        let first = first_para_with(
+            r#"<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="4"/></w:numPr></w:pPr><w:r><w:t>x</w:t></w:r></w:p>"#,
+            &styles,
+            &numbering_first,
+        );
+        assert!(
+            (first.indent_left - 36.0).abs() < 0.01,
+            "level left=720 ⇒ 36 pt, got {}",
+            first.indent_left
+        );
+        assert!(
+            (first.indent_first - 18.0).abs() < 0.01,
+            "a level w:firstLine=360 is a POSITIVE first-line indent (+18 pt), got {}",
+            first.indent_first
+        );
+
+        // Control — a level authored with w:hanging stays NEGATIVE (−18 pt).
+        let numbering_hang = format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="30"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>
+              <w:num w:numId="4"><w:abstractNumId w:val="30"/></w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        );
+        let hang = first_para_with(
+            r#"<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="4"/></w:numPr></w:pPr><w:r><w:t>x</w:t></w:r></w:p>"#,
+            &styles,
+            &numbering_hang,
+        );
+        assert!(
+            (hang.indent_first + 18.0).abs() < 0.01,
+            "a level w:hanging=360 is a NEGATIVE first-line indent (−18 pt), got {}",
+            hang.indent_first
+        );
+
+        // A direct firstLine on the numbered paragraph still overrides the level's
+        // first-line indent, keeping its own positive sign (per-attribute merge).
+        let direct_first = first_para_with(
+            r#"<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="4"/></w:numPr><w:ind w:firstLine="240"/></w:pPr><w:r><w:t>x</w:t></w:r></w:p>"#,
+            &styles,
+            &numbering_hang,
+        );
+        assert!(
+            (direct_first.indent_first - 12.0).abs() < 0.01,
+            "a direct firstLine (240 twips → +12 pt) overrides the level's −18, got {}",
+            direct_first.indent_first
         );
     }
 


### PR DESCRIPTION
## Bug

A numbering level's first-line indent collapsed `w:hanging` and `w:firstLine` into a single **positive magnitude** (`LevelDef.tab`), and the paragraph resolver always **negated** it (`direct_indent_first.unwrap_or(-l.tab)`). So a level authored with a positive `w:firstLine` (an *additional* first-line indent) was resolved as a *hanging* indent — the wrong sign per ECMA-376 §17.3.1.12 (`w:firstLine` = positive/additional; `w:hanging` = negative).

Pre-existing; surfaced while reviewing #611 (which only fixed direct-vs-level precedence and tested only the `hanging` path).

## Fix

- Add a **signed** `LevelDef.indent_first` (`w:hanging` → negative, `w:firstLine` → positive; `hanging` wins when both appear — the same precedence `styles.rs` applies to a direct `w:ind`).
- Consume it directly in `parse_paragraph_cond` (`direct_indent_first.unwrap_or(l.indent_first)`).
- `tab` is retained as the **positive magnitude** (`= indent_first.abs()`) the renderer uses for the marker's tab-advance (§17.9.6 + §17.3.1.38, suff=tab).

Because `tab` is unchanged for every hanging/default level (`|−H| = H`, `|−36| = 36`), marker geometry and all existing (hanging) lists render **byte-for-byte unchanged**; only a `firstLine`-authored level changes — now with the correct positive sign.

## Tests

New `numbering_level_firstline_keeps_positive_sign`: a `w:firstLine=360` level yields `indent_first = +18pt`; control `w:hanging=360` level stays `−18pt`; and a direct `w:firstLine` on the numbered paragraph still overrides the level keeping its positive sign.

`cargo test` 164 passed, `cargo fmt --check` clean, `cargo clippy -D warnings` clean.

## Cross-package

docx-specific: pptx reads a single **signed** `a:pPr@indent` (no hanging/firstLine collapse, so no analogous bug), and xlsx has no firstLine/hanging model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)