### PR TITLE
fix(docx): cap paragraph paint at the laid-out line count (continuation-slice crash)

### DIFF
--- a/packages/docx/src/paginate-paint-line-count.test.ts
+++ b/packages/docx/src/paginate-paint-line-count.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// ECMA-376 §17.6.4 (newspaper columns) + the renderer's scale-independent
+// pagination contract: paginateWithHeaderFooterReserve lays paragraphs out at
+// scale 1 (pt space) so a page assignment is width-independent and cacheable
+// across every render width (opts.prebuiltPages). Painting re-runs layoutLines
+// at the actual render scale, and Canvas ctx.measureText is NOT perfectly
+// scale-invariant (font hinting / sub-pixel glyph advances differ between the
+// pt-size and the device-size run). A long, narrow paragraph can therefore wrap
+// to FEWER lines when painted (larger scale) than the slice indices — computed
+// at scale 1 — assume. The paginator stamps a continuation slice
+// `lineSlice = { start, end }`; the paint pass must paint only the lines it
+// actually has (lines.length) and never index `lines[end-1]` when that line is
+// a phantom that existed only in the scale-1 measurement. Pre-fix the paint loop
+// ran to `sliceEnd` unconditionally and threw
+// "Cannot read properties of undefined (reading 'topY')" on `lines[i].topY`.
+//
+// This reproduces the sample-16 page-2 crash with a synthetic document — no
+// dependency on the (gitignored) private sample. The non-linear measureText mock
+// makes glyphs proportionally NARROWER at a larger font size, so the scale-2
+// paint pass fits more characters per line and wraps the long paragraph to fewer
+// lines than the scale-1 pagination — exactly the real font-hinting direction.
+
+interface Call { text: string; x: number; y: number; }
+
+/** Recording canvas whose glyph width is SUB-LINEAR in the font px size: each
+ *  character is `px * (0.5 - SHRINK * px)` wide. At a larger render scale the
+ *  per-glyph width grows slower than the box, so MORE characters fit per line
+ *  and a long paragraph wraps to fewer lines than at scale 1 — the same
+ *  paginate-vs-paint divergence real fonts produce through hinting. */
+function makeNonLinearCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  const SHRINK = 0.002; // per-px narrowing; tuned so scale 1 vs 2 differ by lines
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const perChar = Math.max(0.05, p * (0.5 - SHRINK * p));
+      return {
+        width: [...s].length * perChar,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    strokeText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function longPara(text: string): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[], pageHeight: number): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+describe('paginate/paint line-count divergence — paint never indexes a phantom line (ECMA-376 §17.6.4)', () => {
+  // A long paragraph of single-letter "words" (each followed by a space so the
+  // line breaker has wrap opportunities). Narrow page + short page height force
+  // it to wrap to many lines and split across multiple pages, so a later page
+  // carries a continuation slice whose `end` is the paragraph's full scale-1
+  // line count.
+  const text = Array.from({ length: 400 }, () => 'w').join(' ');
+  const body = (): BodyElement[] => [longPara(text) as unknown as BodyElement];
+
+  it('renders the final continuation slice without throwing when the paint scale wraps to fewer lines', async () => {
+    // Render at width 400 over a 200pt page → scale 2. The non-linear mock fits
+    // more characters per line at scale 2 than the scale-1 paginator did, so the
+    // paint pass produces fewer lines and the paginator's final-slice `end`
+    // overruns the paint `lines` array. The LAST page carries that slice.
+    const pageHeight = 80; // short page → the paragraph spans several pages
+
+    // Discover how many pages the paragraph spans by rendering page 0 first; then
+    // render every page and assert none throws and content is painted on each.
+    const pageCount = 8; // upper bound; out-of-range indices clamp to page 0 / []
+    let totalLines = 0;
+    let threw: unknown = null;
+    for (let p = 0; p < pageCount; p++) {
+      const { canvas, calls } = makeNonLinearCanvas();
+      try {
+        await renderDocumentToCanvas(doc(body(), pageHeight), canvas, p, { dpr: 1, width: 400 });
+      } catch (e) {
+        threw = e;
+        break;
+      }
+      totalLines += calls.filter((c) => c.text.includes('w')).length;
+    }
+
+    // INVARIANT: no page throws. Pre-fix the final continuation slice indexed a
+    // phantom line and threw the "reading 'topY'" TypeError.
+    expect(threw).toBeNull();
+
+    // NON-TRIVIALITY: the document actually painted content across pages (the
+    // long paragraph really did wrap and split — otherwise the invariant above
+    // would be vacuous).
+    expect(totalLines).toBeGreaterThan(0);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4060,7 +4060,23 @@ function renderParagraph(
   // glyph lands on the box edge, so the painted advance equals measuredWidth by
   // construction. See the gridCharDeltaPx / gridSegDeltaPx header.
   const drawGridDeltaPx = gridCharDeltaPx(grid, scale);
-  for (let li = sliceStart; li < sliceEnd; li++) {
+  // Pagination (paginateWithHeaderFooterReserve) lays a paragraph out at scale 1
+  // (pt space) so its page assignment is width-independent and cacheable across
+  // every render width (opts.prebuiltPages). Painting re-runs layoutLines at the
+  // actual render `scale`, and Canvas ctx.measureText is NOT perfectly
+  // scale-invariant (font hinting / sub-pixel glyph advances differ between the
+  // pt-size and the device-size run). A long, narrow paragraph (e.g. a 70-line
+  // newspaper column, §17.6.4) can therefore wrap to a slightly different line
+  // count here than the slice indices (`lineSlice`, computed at scale 1) assume.
+  // The slice is authoritative for WHICH lines land on this page, but THIS pass's
+  // `lines` array is authoritative for how many lines the text actually occupies
+  // at this scale, so cap the iteration at lines.length: paint every real line and
+  // never index a phantom line that only existed in the scale-1 measurement
+  // (lines[i] would be undefined → "Cannot read properties of undefined"). The
+  // overflow direction is bounded (the wrap differs by at most a line or two), so
+  // all of the paragraph's text is still painted across its slices.
+  const paintEnd = Math.min(sliceEnd, lines.length);
+  for (let li = sliceStart; li < paintEnd; li++) {
     const line = lines[li];
     // First-line indent and numbering prefix only apply to the paragraph's
     // ORIGINAL first line, not the first line of a continuation slice.


### PR DESCRIPTION
## Symptom

Rendering page index 2 (the 3rd page) of a 2-column, multi-section Japanese document with continuous section breaks throws:

```
TypeError: Cannot read properties of undefined (reading 'topY')
    at renderParagraph (renderer.ts)
    at renderBodyElements
    at renderDocumentToCanvas
```

## Root cause

The throwing read is `line.topY` in `renderParagraph`'s line-paint loop, where `line = lines[li]` is `undefined`. The `!== undefined` guard there protects `line.topY` being undefined, **not** `line` itself being undefined.

Pagination (`paginateWithHeaderFooterReserve`) lays each paragraph out with `layoutLines` at **scale 1** (pt space) so the page assignment is width-independent and cacheable across every render width (`opts.prebuiltPages`, also reused over the worker boundary). Painting (`renderParagraph`) re-runs `layoutLines` at the **actual render scale** (e.g. 1.744). Canvas `ctx.measureText` is **not perfectly scale-invariant** — font hinting / sub-pixel glyph advances differ between the pt-size run and the device-size run.

For a long, narrow paragraph (here a 70-line newspaper column, ECMA-376 §17.6.4, in a 2-column section) this makes the wrap diverge:

- Paginate (scale 1): **70 lines** → the paragraph is split, page 3 carries the continuation slice `lineSlice = { start: 39, end: 70 }`.
- Paint (scale 1.744): the same text wraps to only **68 lines**.

The paint loop ran `for (li = 39; li < 70)` and dereferenced `lines[68]` / `lines[69]` = `undefined` → the crash. (Confirmed empirically with instrumentation: `sliceEnd: 70 > lines.length: 68`, `hasFloats: 0` — so this is a pure scale-driven line-count divergence, not a float-window issue.)

## Spec basis for the fix

ECMA-376 defines line breaking in layout (pt/EMU) space; it does not mandate a render scale. The slice is authoritative for **which** lines land on this page, but at the render scale the paragraph genuinely occupies only the lines `layoutLines` produced — the extra trailing indices were phantom lines that existed only in the scale-1 measurement. Capping the iteration at `lines.length` paints every real line of the paragraph across its slices (the divergence is bounded to a line or two, so no text is dropped) and never dereferences a phantom line. The existing `isFinalSlice` / `spaceAfter` logic already keys off `lines.length`, so it stays consistent with the capped loop.

```diff
-  for (let li = sliceStart; li < sliceEnd; li++) {
+  const paintEnd = Math.min(sliceEnd, lines.length);
+  for (let li = sliceStart; li < paintEnd; li++) {
```

## Test

`packages/docx/src/paginate-paint-line-count.test.ts` builds a synthetic single-section document with one long paragraph that splits across pages (no dependency on the gitignored private sample) and a `measureText` mock whose per-glyph width is **sub-linear in the font size**, so a larger render scale fits more characters per line — reproducing the real font-hinting direction. It throws the identical `TypeError: Cannot read properties of undefined (reading 'topY')` before the fix and passes after.

## Verification

- New test fails (same TypeError) with the fix reverted, passes with it.
- Full docx suite green: 307 tests / 48 files.
- The originating document now renders all pages (including the previously-crashing page) with content and no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)