### PR TITLE
refactor(docx): unify apply_direct_run with canonical apply_run

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -6,7 +6,7 @@ use zip::ZipArchive;
 
 use crate::numbering::NumberingMap;
 use crate::styles::{
-    apply_para, merge_cond_layers, parse_para_fmt, parse_run_fmt, CondFmt, EdgeBorder,
+    apply_para, apply_run, merge_cond_layers, parse_para_fmt, parse_run_fmt, CondFmt, EdgeBorder,
     RawTblBorders, RunFmt, StyleMap,
 };
 use crate::types::*;
@@ -5404,101 +5404,17 @@ fn normalize_align(s: &str) -> &str {
     }
 }
 
+/// Layer a run's DIRECT rPr (`direct`) over its resolved formatting (`base`).
+/// Reuse the canonical field merge (`styles::apply_run`) so the direct path can
+/// never drift from the style cascade (a drift previously dropped direct
+/// `<w:highlight>` / `<w:bdr>` on styleless body runs); the szCs-mirror rule
+/// (§17.3.2.18) and the auto-breaks-inheritance color rule (§17.3.2.6) both live
+/// there. The ONE divergence: `apply_run` OR-propagates the `*_set_here` markers
+/// so a folded rStyle sub-chain can re-mirror `w:sz`→szCs later, but the direct
+/// rPr is the TERMINAL merge — the szCs mirror is now fully resolved, so reset the
+/// markers to stop them leaking into any subsequent merge.
 fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
-    if direct.bold.is_some() {
-        base.bold = direct.bold;
-    }
-    if direct.italic.is_some() {
-        base.italic = direct.italic;
-    }
-    if direct.underline.is_some() {
-        base.underline = direct.underline;
-    }
-    if direct.strikethrough.is_some() {
-        base.strikethrough = direct.strikethrough;
-    }
-    if direct.font_size.is_some() {
-        base.font_size = direct.font_size;
-    }
-    // Color, with the same auto-breaks-inheritance rule as styles::apply_run:
-    // a direct `w:color="auto"` (§17.3.2.6) clears any inherited concrete color
-    // and defers the final color to background contrast at render time (an
-    // implementation-defined black/white pick; no normative algorithm); a
-    // concrete direct color overrides and clears the auto flag.
-    if direct.color_auto {
-        base.color = None;
-        base.color_auto = true;
-    } else if direct.color.is_some() {
-        base.color = direct.color.clone();
-        base.color_auto = false;
-    }
-    if direct.font_family_ascii.is_some() {
-        base.font_family_ascii = direct.font_family_ascii.clone();
-    }
-    if direct.font_family_east_asia.is_some() {
-        base.font_family_east_asia = direct.font_family_east_asia.clone();
-    }
-    if direct.background.is_some() {
-        base.background = direct.background.clone();
-    }
-    if direct.vert_align.is_some() {
-        base.vert_align = direct.vert_align.clone();
-    }
-    if direct.rtl.is_some() {
-        base.rtl = direct.rtl;
-    }
-    if direct.cs_toggle.is_some() {
-        base.cs_toggle = direct.cs_toggle;
-    }
-    if direct.font_family_cs.is_some() {
-        base.font_family_cs = direct.font_family_cs.clone();
-    }
-    if direct.bold_cs.is_some() {
-        base.bold_cs = direct.bold_cs;
-    }
-    if direct.italic_cs.is_some() {
-        base.italic_cs = direct.italic_cs;
-    }
-    if direct.lang_bidi.is_some() {
-        base.lang_bidi = direct.lang_bidi.clone();
-    }
-    // The following arms must stay in parity with styles::apply_run — this
-    // function is a hand-maintained mirror of it for the direct-rPr path, and
-    // a missing arm silently drops a directly-applied run property (the cause
-    // of `<w:highlight>` / `<w:bdr>` not rendering on styleless body runs).
-    if direct.all_caps.is_some() {
-        base.all_caps = direct.all_caps;
-    }
-    if direct.small_caps.is_some() {
-        base.small_caps = direct.small_caps;
-    }
-    if direct.dstrike.is_some() {
-        base.dstrike = direct.dstrike;
-    }
-    if direct.vanish.is_some() {
-        base.vanish = direct.vanish;
-    }
-    if direct.web_hidden.is_some() {
-        base.web_hidden = direct.web_hidden;
-    }
-    if direct.highlight.is_some() {
-        base.highlight = direct.highlight.clone();
-    }
-    if direct.border.is_some() {
-        base.border = direct.border.clone();
-    }
-
-    // Complex-script font size: a directly-applied `w:sz` without an
-    // accompanying `w:szCs` mirrors into the cs size (ECMA-376 §17.3.2.18 —
-    // see `styles::apply_run` for the full rationale). An explicit `w:szCs`
-    // always wins; otherwise inherited-only szCs is carried unchanged.
-    if direct.font_size_cs_set_here {
-        base.font_size_cs = direct.font_size_cs;
-    } else if direct.font_size_set_here {
-        base.font_size_cs = direct.font_size;
-    } else if direct.font_size_cs.is_some() {
-        base.font_size_cs = direct.font_size_cs;
-    }
+    apply_run(base, direct);
     base.font_size_set_here = false;
     base.font_size_cs_set_here = false;
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5558,10 +5558,11 @@ mod tests {
         assert_eq!(t.width_pct, None);
     }
 
-    // Regression guard for the direct-rPr merge path. `apply_direct_run` is a
-    // hand-maintained mirror of `styles::apply_run`; a missing arm silently
-    // drops a directly-applied run property. This previously dropped
-    // `<w:highlight>` and (after PR A) `<w:bdr>` / `w:color="auto"` on styleless
+    // Regression guard for the direct-rPr merge path. `apply_direct_run` now
+    // delegates to `styles::apply_run` (the single source of truth) — this test
+    // pins the end-to-end direct-rPr contract so a future change to that merge
+    // can't silently drop a directly-applied run property. Such a drop previously
+    // lost `<w:highlight>` and (later) `<w:bdr>` / `w:color="auto"` on styleless
     // body runs, which `parse_run_fmt`-only unit tests could not catch.
     #[test]
     fn apply_direct_run_carries_decoration_fields() {

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -674,7 +674,15 @@ pub(crate) fn apply_para(dst: &mut ParaFmt, src: &ParaFmt) {
     }
 }
 
-fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
+/// Layer the run format `src` OVER `dst`: every property `src` explicitly sets
+/// replaces `dst`'s. The single source of truth for "which run properties
+/// override on merge" — used by the style cascade (docDefaults → style chain →
+/// rStyle) AND, via `parser::apply_direct_run`, for a run's DIRECT rPr. Keep new
+/// `RunFmt` fields here only; the direct path reuses this so the two can never
+/// drift. The trailing `*_set_here` markers are OR-propagated (see below) so a
+/// folded rStyle sub-chain still mirrors `w:sz`→szCs when re-applied; the direct
+/// path resets them afterwards because it is the terminal merge.
+pub(crate) fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.bold.is_some() {
         dst.bold = src.bold;
     }


### PR DESCRIPTION
## What

`apply_direct_run` (merge of a run's DIRECT `rPr` over its resolved formatting) was a hand-maintained mirror of the style-cascade `apply_run` — the **last duplicated merge** after [#613](https://github.com/yukiyokotani/office-open-xml-viewer/pull/613) unified the paragraph path (`apply_direct_para` → `apply_para`). Field sets were identical today (no live bug), but a new `RunFmt` field would have to be added in two places and could silently drift — the exact bug class #613 fixed for paragraphs (a dropped field stopped direct `<w:highlight>`/`<w:bdr>` from rendering on styleless runs).

## Change

- `apply_run` is now `pub(crate)` — the single source of truth for "which run properties override on merge".
- `apply_direct_run` reduces to: `apply_run(base, direct)` then reset the two `*_set_here` markers (~95 lines → 4).

The ONLY divergence between the two paths is those markers: `apply_run` OR-propagates them (so a folded rStyle sub-chain can re-mirror `w:sz`→szCs when re-applied); the direct `rPr` is the TERMINAL merge (szCs mirror fully resolved), so it resets them to stop leakage. `OR`-then-`reset` ≡ the previous direct `reset` (reset overwrites the OR), and the szCs resolution reads `src` not `dst`, so it is unaffected.

## Verification — pure refactor, no behavior change (proven 3 ways)

1. **Named guards pass**: `apply_direct_run_carries_decoration_fields`, `apply_direct_run_color_auto_breaks_inherited_color`, the szCs-mirror tests, the cs_toggle parity tests.
2. **Full parser suite green**: 166 passed; `cargo fmt --check` + `clippy -D warnings` clean.
3. **Byte-identical models**: parsed model JSON is byte-for-byte identical before/after across all 18 local docx samples (built OLD vs NEW wasm, `cmp` each).

Follow-up from the PR #613 review (task to close the last hand-mirrored merge). Mirrors the paragraph unification exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)