### PR TITLE
fix(docx): a breakable CJK run glued after a Latin word is not atomic in the pre-flush

### DIFF
--- a/packages/docx/src/latin-cjk-glued-nonstarter-wrap.test.ts
+++ b/packages/docx/src/latin-cjk-glued-nonstarter-wrap.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// Regression (mirror of cjk-glued-nonstarter-wrap.ts / sample-9 fb836d6, the
+// OTHER glue direction): a Latin word ("…Roman") immediately followed by a CJK
+// run that STARTS with a line-start-forbidden char ("、…") — the CJK run carries
+// `joinPrev` (UAX#14 LB13 / §17.3.1.16, keeps "、" off a line head). The glued-
+// group pre-flush summed the WHOLE breakable CJK run as one atomic unit glued to
+// "Roman"; finding {Roman + run} too wide for the line, it flushed "Roman" to the
+// next line ALONE even though "Roman" + "、" still fit. A `both`-justified line
+// then held only "Times New" and stretched sparse (sample-16, "Times New Roman"
+// paragraph).
+//
+// A breakable CJK follower is NOT atomic: only its LEADING run of non-starters
+// (the part that would actually orphan at a line head per LB13) must stay glued
+// to the Latin lead; the rest wraps on its own. So the pre-flush group width adds
+// only that prefix's advance and stops. When "Roman" + "、" genuinely don't fit
+// the pre-flush still fires (they start fresh together — no orphan, no mid-word
+// Latin split); when there is room, "Roman" is placed and the CJK run splits
+// normally, keeping "、" with "Roman".
+
+const FONT_PX = 20; // glyph advance per glyph (Latin or CJK) in the stub (scale = 1)
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; x: number; y: number }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fillTextCalls: { text: string; x: number; y: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) { fillTextCalls.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function gluedPara(texts: string[]): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'both',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: texts.map((t) => ({ type: 'text', ...textRun(t) }) as DocRun),
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 320, pageHeight: 400, // contentWidth 320 → exactly 16 cells/line
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    ...overrides,
+  };
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(body: BodyElement[], sec: SectionProps) {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, { dpr: 1, width: sec.pageWidth });
+  return fillTextCalls;
+}
+
+function linesByY(calls: { text: string; x: number; y: number }[]) {
+  const byY = new Map<number, { text: string; x: number }[]>();
+  for (const c of calls) {
+    const k = Math.round(c.y);
+    (byY.get(k) ?? byY.set(k, []).get(k)!).push({ text: c.text, x: c.x });
+  }
+  return [...byY.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, glyphs]) => glyphs.slice().sort((p, q) => p.x - q.x));
+}
+
+describe('Latin word + glued non-starter-led CJK run — keep "Roman" on its line', () => {
+  it('does not orphan "Roman" alone behind a breakable CJK run that starts with "、"', async () => {
+    // Layout (16 cells/line, every glyph 20px):
+    //   line 1: 16 leading CJK cells (full).
+    //   line 2: "Times " (6) + "New " (4) = 10 cells, 6 remaining.
+    //           "Roman" (5) fits (1 cell left); the CJK run "、あいうえお" (6) is
+    //           glued (joinPrev: starts with "、"). "Roman"+"、" = 6 cells = fits;
+    //           "Roman"+whole run = 11 cells = does NOT fit.
+    // Pre-fix: the pre-flush sums Roman+whole run (11 cells) → too wide → flushes
+    //   "Roman" to line 3 alone, leaving line 2 = "Times New" (sparse when `both`).
+    // Post-fix: the pre-flush adds only the leading "、" (1 cell) → Roman+"、" fits
+    //   → "Roman" stays on line 2 and the CJK run splits to fill it.
+    const calls = await render(
+      [gluedPara(['ああああああああああああああああ', 'Times New Roman', '、あいうえお'])],
+      section(),
+    );
+    expect(calls.length).toBeGreaterThan(0);
+
+    const lines = linesByY(calls);
+    // Find the line that holds the Latin word "Times".
+    const latinLine = lines.find((g) => g.map((x) => x.text).join('').includes('Times'));
+    expect(latinLine).toBeDefined();
+    const latinText = latinLine!.map((g) => g.text).join('');
+
+    // "Roman" must be on the SAME line as "Times"/"New" — NOT flushed down alone.
+    // (Pre-fix this line was "Times New " only; "Roman" was orphaned below.)
+    expect(latinText).toContain('New');
+    expect(latinText).toContain('Roman');
+    // The glued non-starter "、" follows "Roman" on that same line (kinsoku keeps
+    // it off the next line's head). The line is now "Times New Roman、" — full.
+    expect(latinText).toContain('、');
+    // No line may BEGIN with the non-starter "、".
+    for (const g of lines) expect(g[0].text.startsWith('、')).toBe(false);
+  });
+
+  it('flushes "Roman" + "、" together when even "、" has no room (no mid-word split, no orphan)', async () => {
+    // Tighten the line so "Times New " uses all but 5 cells: leading CJK fills
+    // line 1; line 2 = "Times " (6) + "New " (4) = 10 cells; "Roman" (5) exactly
+    // fills to 15, leaving 1 cell — but we shrink the column to 15 cells so that
+    // after "Times New " (10) only 5 remain: "Roman" (5) fits exactly with ZERO
+    // room for "、". The pre-flush must then fire (Roman+"、" = 6 > 5) so "Roman"
+    // and "、" start the next line TOGETHER — never "Roman" split mid-word and
+    // never "、" orphaned at a head.
+    const calls = await render(
+      [gluedPara(['あああああああああああああ', 'Times New Roman', '、あいうえお'])],
+      section({ pageWidth: 300 }), // 15 cells/line
+    );
+    expect(calls.length).toBeGreaterThan(0);
+
+    const lines = linesByY(calls);
+    // No line may BEGIN with the non-starter "、".
+    for (const g of lines) {
+      expect(g[0].text.startsWith('、')).toBe(false);
+    }
+    // "Roman" is never split across lines: the full word lands on one line, and
+    // wherever "Roman" is, "、" is on that same line (glued).
+    const romanLine = lines.find((g) => g.map((x) => x.text).join('').includes('Roman'));
+    expect(romanLine).toBeDefined();
+    const romanText = romanLine!.map((x) => x.text).join('');
+    expect(romanText).toContain('、');
+    // "Times New" is contiguous Latin and must not be broken inside a word either.
+    expect(calls.map((c) => c.text).join('')).toContain('Roman');
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5744,6 +5744,30 @@ function layoutLines(
       let groupTrail = trailingSpaceW;
       for (let k = 0; k < queue.length && (queue[k] as LayoutTextSeg).joinPrev; k++) {
         const f = queue[k] as LayoutTextSeg;
+        // A CJK-BREAKABLE follower (e.g. "Roman" + "、あるいは…用いる。") is NOT
+        // atomic: only its LEADING run of line-start-forbidden chars would orphan
+        // at a line head (UAX#14 LB13 / §17.3.1.16); the rest splits at an
+        // inter-CJK boundary and wraps on its own. So glue only that prefix's
+        // advance to the lead and STOP summing here — mirror of the CJK-lead
+        // direction handled by the `!hasCJKBreakOpportunity(s.text)` gate above
+        // (sample-9 fb836d6). Summing the whole breakable run instead would
+        // pre-flush "Roman" down alone, leaving a `both` line stretched sparse
+        // (sample-16). A Latin / small-caps follower (no CJK break opportunity —
+        // the "I" + "NTRODUCTION" case) stays fully atomic: keep full-add.
+        if (hasCJKBreakOpportunity(f.text)) {
+          const chars = [...f.text];
+          let p = 0;
+          while (p < chars.length && DEFAULT_KINSOKU_RULES.lineStartForbidden.has(chars[p].codePointAt(0)!)) p++;
+          if (p < chars.length) {
+            // Breakable rest exists past the leading non-starters: glue only the
+            // prefix (it may be empty — then "Roman" is effectively unglued and
+            // wraps on its own) and end the atomic group here.
+            groupW += strAdvance(f, chars.slice(0, p).join(''));
+            groupTrail = 0;
+            break;
+          }
+          // Entirely non-starters (no breakable rest): fall through to full-add.
+        }
         const fw = segAdvance(f);
         groupW += fw;
         const ft = f.text.replace(/ +$/, '');


### PR DESCRIPTION
## Root cause

In a `both`-justified CJK paragraph, a **Latin word immediately followed by a CJK run that STARTS with a line-start-forbidden char (非starter, e.g. 「、」)** wrapped wrongly, leaving a sparse stretched line.

Concrete case (private/sample-16.docx, "(2)フォント…" paragraph). The runs are:

```
…英文では │ Times New Roman │ 、あるいは類似のフォントを用いる。 │ …
```

`buildSegments` (the LB13 / §17.3.1.16 cross-run non-starter loop) marks the CJK run `joinPrev=true` because its text STARTS with 「、」 and the previous segment ("Roman") doesn't end in whitespace. Then `layoutLines`' **atomic glued-group pre-flush** summed `Roman` + the **whole 17-char CJK run** as one atomic unit, found it doesn't fit, and flushed `Roman` to the next line alone — even though `Roman` alone fits and the CJK run is splittable.

Pre-fix render (sample-16, page 1):
```
y=823: はTimes New          ← sparse 2-token `both` line, "Roman" orphaned
y=847: Roman、あるいは類似のフォントを用いる。この
```

## Spec basis

UAX#14 **LB13** / ECMA-376 **§17.3.1.16** (行頭禁則 — line-start-forbidden): a closing / mid-punctuation code point carries no break opportunity before it, so it may never BEGIN a line. The glue that keeps such a char with the preceding word is the *universal* LB13 rule — it consults `DEFAULT_KINSOKU_RULES.lineStartForbidden`, independent of the document's `w:kinsoku` toggle.

This is the **mirror** of the CJK-lead direction fixed in `fb836d6` (sample-9), where the pre-flush is skipped when the LEAD segment is CJK-breakable. There, a CJK run + trailing 「。」 must split to fill the line rather than move down whole. Here, the lead is Latin (`Roman`, not CJK-breakable, so the pre-flush runs) and the *follower* is the breakable CJK run.

## The fix

A **breakable CJK follower is NOT atomic**: only its **leading run of line-start-forbidden chars** (the part that would actually orphan at a line head per LB13) must stay glued to the lead; the rest splits at an inter-CJK boundary and wraps on its own. In the pre-flush group-sum loop, when a `joinPrev` follower `f` is `hasCJKBreakOpportunity(f.text)` AND has a breakable rest past its leading non-starters, add only that prefix's advance (`DEFAULT_KINSOKU_RULES.lineStartForbidden` — the same universal LB13 table the marking loop uses) and STOP summing. A follower that is **entirely** non-starters keeps the full-add behaviour; Latin / small-caps followers (no CJK break opportunity — the existing `I` + `NTRODUCTION` small-caps glue) are unchanged and stay fully atomic.

Behaviour after the fix:
- **Mid-line room** (`Roman` + 「、」 fits): no pre-flush → `Roman` is placed and the CJK run splits normally, keeping 「、」 with `Roman`.
- **True line end** (no room for even 「、」): the pre-flush still fires (`Roman` + 「、」 doesn't fit) → `Roman、` start fresh together — no orphan at the head, no mid-word Latin split.

`measure==draw` invariant is intact: only the pre-flush **decision** width changes, not how segments are drawn.

Post-fix render (sample-16, page 1):
```
y=799: フォントは、原則として和文では明朝、英文で
y=823: はTimes New Roman、あるいは類似のフォントを   ← "Roman" stays; CJK run fills the line
y=847: 用いる。このテンプレートでは、和文フォントに
```

## Test

`packages/docx/src/latin-cjk-glued-nonstarter-wrap.test.ts` — a synthetic `both`-justified paragraph (mock-context harness, mirror of `cjk-glued-nonstarter-wrap.test.ts`): leading CJK pushes a Latin run `"Times New Roman"` to line 2, followed by a CJK run `"、あいうえお"` (joinPrev), in a narrow column where `Times New Roman` + 「、」 fits but `Times New Roman` + the whole CJK run does not. Asserts `Roman` lands on the SAME line as `Times`/`New` (RED pre-fix: line was `"Times New "` only). A second case verifies the true-line-end behaviour: `Roman` + 「、」 start fresh together, no orphan, no mid-word split. Full `npx vitest run packages/docx` stays green (309 tests / 49 files), incl. sample-9 / sample-10 / kinsoku / small-caps.

## Out of scope (intentionally shelved)

This PR does **not** implement 約物半角 / `compressPunctuation` / `<w:characterSpacingControl>` / any punctuation-width compression — a separate, deliberately-shelved feature (user-adjudicated 2026-06-29). The residual 1-char shift on line 1 (line 1 still ends at 「英文で」 with 「は」 on line 2) is that shelved feature's territory, not this fix. The only goal here: line 2 is no longer sparse.

## Cross-package check (horizontal-integration principle)

The over-glue is **docx-only**. It is a property of docx's two-stage `buildSegments` → `layoutLines` model, where a whole run becomes one `joinPrev` segment that the pre-flush treated atomically. pptx (`renderer.ts` whitespace-token loop → `hasCJK` per-character path with `fitCjkLine`/kinsoku; `retractTrailingWord` only ever moves a single non-starter *token*, never a multi-char CJK run) and xlsx (`wrapParagraphLines` tokenizes CJK per-character; `extendLatinWordRetract` / `kinsokuAdjustedSplit` retract per code point) both never glue a multi-char CJK run wholesale. No analogous bug; no follow-up needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)