### PR TITLE
feat(xlsx): honor shape-text paragraph indent (marL/marR/indent, §21.1.2.2.7)

### DIFF
--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -530,6 +530,9 @@ pub(crate) fn parse_tx_body(
             "p" => {
                 let mut align = String::from("l");
                 let mut rtl = false;
+                let mut mar_l: Option<i64> = None;
+                let mut mar_r: Option<i64> = None;
+                let mut indent: Option<i64> = None;
                 let mut runs: Vec<ShapeTextRun> = Vec::new();
                 for pc in c.children().filter(|n| n.is_element()) {
                     match pc.tag_name().name() {
@@ -543,6 +546,13 @@ pub(crate) fn parse_tx_body(
                                 .attribute("rtl")
                                 .map(|v| v == "1" || v == "true")
                                 .unwrap_or(false);
+                            // ECMA-376 §21.1.2.2.7 (`CT_TextParagraphProperties`)
+                            // direct indent attributes (EMU). `indent` may be
+                            // negative (hanging). Direct-attribute-only — xlsx
+                            // text boxes have no lstStyle/level cascade.
+                            mar_l = pc.attribute("marL").and_then(|v| v.parse().ok());
+                            mar_r = pc.attribute("marR").and_then(|v| v.parse().ok());
+                            indent = pc.attribute("indent").and_then(|v| v.parse().ok());
                         }
                         "r" => {
                             // Run text + run-level formatting.
@@ -609,7 +619,14 @@ pub(crate) fn parse_tx_body(
                     }
                 }
                 if !runs.is_empty() {
-                    paragraphs.push(ShapeParagraph { align, rtl, runs });
+                    paragraphs.push(ShapeParagraph {
+                        align,
+                        rtl,
+                        mar_l,
+                        mar_r,
+                        indent,
+                        runs,
+                    });
                 }
             }
             _ => {}
@@ -1581,6 +1598,59 @@ mod math_tests {
         let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
         assert_eq!(text.paragraphs.len(), 1);
         assert!(!text.paragraphs[0].rtl, "absent @rtl → rtl false");
+    }
+
+    /// `<a:pPr marL marR indent>` (ECMA-376 §21.1.2.2.7,
+    /// `CT_TextParagraphProperties`) are the direct paragraph indent attributes
+    /// in EMU. `indent` may be negative (hanging). They parse onto the
+    /// `ShapeParagraph` as `Option<i64>` so an absent attribute stays `None`.
+    #[test]
+    fn parses_paragraph_indent_attributes() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:p>
+                <a:pPr marL="457200" marR="91440" indent="-228600"/>
+                <a:r><a:t>indented</a:t></a:r>
+              </a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        assert_eq!(text.paragraphs.len(), 1);
+        let p = &text.paragraphs[0];
+        assert_eq!(p.mar_l, Some(457200), "marL parses as EMU i64");
+        assert_eq!(p.mar_r, Some(91440), "marR parses as EMU i64");
+        assert_eq!(
+            p.indent,
+            Some(-228600),
+            "indent parses (negative = hanging)"
+        );
+    }
+
+    /// Absent indent attributes (or absent `<a:pPr>` entirely) leave all three
+    /// fields `None` so the JSON output stays byte-identical (additive).
+    #[test]
+    fn paragraph_indent_defaults_none_when_absent() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:p>
+                <a:r><a:t>plain</a:t></a:r>
+              </a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        assert_eq!(text.paragraphs.len(), 1);
+        let p = &text.paragraphs[0];
+        assert_eq!(p.mar_l, None, "absent marL → None");
+        assert_eq!(p.mar_r, None, "absent marR → None");
+        assert_eq!(p.indent, None, "absent indent → None");
+
+        // None of the three keys should appear in the serialized JSON.
+        let v: serde_json::Value = serde_json::to_value(p).unwrap();
+        assert!(v.get("marL").is_none(), "marL omitted when None");
+        assert!(v.get("marR").is_none(), "marR omitted when None");
+        assert!(v.get("indent").is_none(), "indent omitted when None");
     }
 
     /// `ShapeTextRun` uses an enum-level `#[serde(tag = "type", rename_all =

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -888,6 +888,19 @@ pub struct ShapeParagraph {
     /// byte-identical (additive, like the other Phase 0 direction flags).
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub rtl: bool,
+    /// `<a:pPr@marL>` — left margin (EMU). ECMA-376 §21.1.2.2.7
+    /// (`CT_TextParagraphProperties`). Direct attribute only (xlsx text boxes
+    /// have no lstStyle/level cascade). `None` = unset. Omitted from JSON when
+    /// `None` so existing output stays byte-identical (additive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mar_l: Option<i64>,
+    /// `<a:pPr@marR>` — right margin (EMU). ECMA-376 §21.1.2.2.7. `None` = unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mar_r: Option<i64>,
+    /// `<a:pPr@indent>` — first-line indent (EMU; negative = hanging). ECMA-376
+    /// §21.1.2.2.7. `None` = unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent: Option<i64>,
     pub runs: Vec<ShapeTextRun>,
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3585,7 +3585,10 @@ export function drawShapeText(
     const align = p.align || 'l';
     // ECMA-376 §21.1.2.2.7 direct paragraph indent (EMU → px, scaled by cs).
     // Mirrors the pptx renderer (marLPx/marRPx/indentPx + firstLineIndent).
-    // Direct-attribute-only: xlsx text boxes have no lstStyle/level cascade.
+    // Direct-attribute-only: xlsx text boxes have no lstStyle/level cascade, so
+    // the spec's literal implied defaults (marL=347663, indent=−342900) are
+    // deliberately NOT applied — there is no list-style tier to feed them, and
+    // pptx's resolver leaves a plain bulletless paragraph at 0 too. Absent ⇒ 0.
     const marLpx = ((p.marL ?? 0) / EMU_PER_PX) * cs;
     const marRpx = ((p.marR ?? 0) / EMU_PER_PX) * cs;
     const indentPx = ((p.indent ?? 0) / EMU_PER_PX) * cs;
@@ -3639,8 +3642,11 @@ export function drawShapeText(
         const color = run.color ?? '#000000';
         if (run.display) {
           // Block equation occupies its own line (centered per paragraph align).
+          // It takes the paragraph left margin (marLpx) but NOT the first-line
+          // indent — `indent` is a run-in indent for the first line of TEXT, not
+          // for a block equation — so use marLpx/paraW regardless of line position.
           flushLine();
-          lines.push({ segs: [{ kind: 'math', render, color, w, ascent, descent }], align, height: ascent + descent, ascent, hasMath: true, leftInset: lineLeftInset(), availW: lineAvailW() });
+          lines.push({ segs: [{ kind: 'math', render, color, w, ascent, descent }], align, height: ascent + descent, ascent, hasMath: true, leftInset: marLpx, availW: paraW });
           firstLineDone = true;
           continue;
         }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3564,7 +3564,11 @@ export function drawShapeText(
   type Seg =
     | { kind: 'text'; text: string; font: string; color: string; w: number }
     | { kind: 'math'; render: MathRender; color: string; w: number; ascent: number; descent: number };
-  type Line = { segs: Seg[]; align: string; height: number; ascent: number; hasMath: boolean };
+  // `leftInset` = px from padX to this line's left edge (paragraph left margin,
+  // plus the first-line indent on a paragraph's first line). `availW` = the
+  // width of the alignment region for this line (paraW, minus the first-line
+  // indent on the first line). ECMA-376 §21.1.2.2.7 (marL/marR/indent).
+  type Line = { segs: Seg[]; align: string; height: number; ascent: number; hasMath: boolean; leftInset: number; availW: number };
 
   // Font string + px size for a text run (math runs have no run-level font).
   const textFont = (run: Extract<import('./types.js').ShapeTextRun, { type: 'text' }>): { font: string; px: number } => {
@@ -3579,6 +3583,22 @@ export function drawShapeText(
   const lines: Line[] = [];
   for (const p of txt.paragraphs) {
     const align = p.align || 'l';
+    // ECMA-376 §21.1.2.2.7 direct paragraph indent (EMU → px, scaled by cs).
+    // Mirrors the pptx renderer (marLPx/marRPx/indentPx + firstLineIndent).
+    // Direct-attribute-only: xlsx text boxes have no lstStyle/level cascade.
+    const marLpx = ((p.marL ?? 0) / EMU_PER_PX) * cs;
+    const marRpx = ((p.marR ?? 0) / EMU_PER_PX) * cs;
+    const indentPx = ((p.indent ?? 0) / EMU_PER_PX) * cs;
+    // First-line indent eats into available width only when positive; a hanging
+    // (negative) indent has no bullet gutter in xlsx, so it is clamped to 0.
+    const firstLineIndent = Math.max(0, indentPx);
+    const paraW = Math.max(0, innerW - marLpx - marRpx);
+    // First line of the paragraph carries marLpx + firstLineIndent; continuation
+    // lines carry only marLpx. Flipped to true on the first flush within the
+    // paragraph (and on a display-math line, which is its own line).
+    let firstLineDone = false;
+    const lineLeftInset = () => (firstLineDone ? marLpx : marLpx + firstLineIndent);
+    const lineAvailW = () => (firstLineDone ? paraW : paraW - firstLineIndent);
     let segs: Seg[] = [];
     let lineW = 0;
     let lineHeight = 0;
@@ -3598,7 +3618,8 @@ export function drawShapeText(
         lineHeight = fallbackPx * 1.2;
         lineAscent = fallbackPx * 0.85;
       }
-      lines.push({ segs, align, height: lineHeight, ascent: lineAscent, hasMath });
+      lines.push({ segs, align, height: lineHeight, ascent: lineAscent, hasMath, leftInset: lineLeftInset(), availW: lineAvailW() });
+      firstLineDone = true;
       segs = []; lineW = 0; lineHeight = 0; lineAscent = 0; hasMath = false;
     };
     // Nearest preceding text size (pt) in this paragraph — inline math with no
@@ -3619,11 +3640,14 @@ export function drawShapeText(
         if (run.display) {
           // Block equation occupies its own line (centered per paragraph align).
           flushLine();
-          lines.push({ segs: [{ kind: 'math', render, color, w, ascent, descent }], align, height: ascent + descent, ascent, hasMath: true });
+          lines.push({ segs: [{ kind: 'math', render, color, w, ascent, descent }], align, height: ascent + descent, ascent, hasMath: true, leftInset: lineLeftInset(), availW: lineAvailW() });
+          firstLineDone = true;
           continue;
         }
-        // Inline equation: treat as an atomic, non-breaking "word".
-        if (wrap && lineW + w > innerW && segs.length > 0) flushLine();
+        // Inline equation: treat as an atomic, non-breaking "word". Budget is
+        // this line's available width (paraW, minus first-line indent on the
+        // first line) rather than the full innerW.
+        if (wrap && lineW + w > lineAvailW() && segs.length > 0) flushLine();
         segs.push({ kind: 'math', render, color, w, ascent, descent });
         lineW += w;
         lineHeight = Math.max(lineHeight, ascent + descent);
@@ -3651,12 +3675,15 @@ export function drawShapeText(
           lineW += w;
           continue;
         }
-        // Greedy character-level wrap (adequate for Latin + CJK).
+        // Greedy character-level wrap (adequate for Latin + CJK). The wrap
+        // budget is the CURRENT line's available width — paraW on continuation
+        // lines, paraW − firstLineIndent on the paragraph's first line — not the
+        // full innerW (ECMA-376 §21.1.2.2.7 marL/marR/indent).
         let buf = '';
         for (const ch of piece) {
           const candidate = buf + ch;
           const cw = ctx.measureText(candidate).width;
-          if (lineW + cw > innerW && (buf.length > 0 || segs.length > 0)) {
+          if (lineW + cw > lineAvailW() && (buf.length > 0 || segs.length > 0)) {
             if (buf) {
               const w = ctx.measureText(buf).width;
               segs.push({ kind: 'text', text: buf, font, color, w });
@@ -3694,9 +3721,13 @@ export function drawShapeText(
   let lineTop = y0;
   for (const line of lines) {
     const totalW = line.segs.reduce((s, seg) => s + seg.w, 0);
-    let x = padX;
-    if (line.align === 'ctr') x = padX + Math.max(0, (innerW - totalW) / 2);
-    else if (line.align === 'r') x = padX + Math.max(0, innerW - totalW);
+    // Per-line region: the left edge is padX + the paragraph's left inset
+    // (marL, plus first-line indent on the first line), and alignment happens
+    // within the line's available width (paraW). ECMA-376 §21.1.2.2.7.
+    const base = padX + line.leftInset;
+    let x = base;
+    if (line.align === 'ctr') x = base + Math.max(0, (line.availW - totalW) / 2);
+    else if (line.align === 'r') x = base + Math.max(0, line.availW - totalW);
 
     if (line.hasMath) {
       // A line containing an equation aligns text AND the math raster to a

--- a/packages/xlsx/src/shape-paragraph-indent.test.ts
+++ b/packages/xlsx/src/shape-paragraph-indent.test.ts
@@ -93,3 +93,54 @@ describe('shape paragraph indent attributes (§21.1.2.2.7 marL/marR/indent)', ()
     expect(drawFirstX(p)).toBeCloseTo(padX + marLpx + indentPx, 5);
   });
 });
+
+// The cases above only exercise wrap:'none' + left-align (first line, left
+// branch). These cover the genuinely new per-line machinery: the first-vs-
+// continuation `leftInset`/`availW` selection, the wrap budget = paraW (− the
+// first-line indent on line 1), `ctr` alignment within the indented region, the
+// hanging-indent clamp, and marR narrowing the wrap width.
+describe('shape paragraph indent — wrapping, alignment region, hanging, marR', () => {
+  const PADX = 7; // padX = 7 * cs (cs=1)
+  // All fillText calls for a single paragraph at a given wrap mode (sw=sh=300, cs=1).
+  function callsFor(p: ShapeParagraph, wrap: 'none' | 'normal'): FillTextCall[] {
+    const { ctx, calls } = makeRecordingCtx();
+    drawShapeText(ctx, { anchor: 't', wrap, paragraphs: [p] }, 300, 300, 1);
+    return calls;
+  }
+
+  it('wrapping: the first line carries the indent, continuation lines carry only marL', () => {
+    // indent = 457200 EMU = 48 px shrinks ONLY the first line's wrap budget.
+    const indentPx = 457200 / EMU_PER_PX; // 48
+    const text = 'X'.repeat(40);
+    const without = callsFor({ align: 'l', runs: [textRun(text)] }, 'normal');
+    const withInd = callsFor({ align: 'l', indent: 457200, runs: [textRun(text)] }, 'normal');
+    expect(withInd.length).toBeGreaterThanOrEqual(2);
+    expect(withInd[0].x).toBeCloseTo(PADX + indentPx, 5); // first line shifted by indent
+    expect(withInd[1].x).toBeCloseTo(PADX, 5); // continuation: no first-line indent
+    // The narrower first-line budget wraps it earlier than the un-indented first line.
+    expect(withInd[0].text.length).toBeLessThan(without[0].text.length);
+  });
+
+  it('center alignment is within the indented region (marL shifts the center by marL/2)', () => {
+    // Centering within paraW (= innerW − marL) instead of full innerW shifts a
+    // centered line right by exactly marL/2 (independent of the text width).
+    const marLpx = 457200 / EMU_PER_PX; // 48
+    const base = callsFor({ align: 'ctr', runs: [textRun('XX')] }, 'none')[0].x;
+    const shifted = callsFor({ align: 'ctr', marL: 457200, runs: [textRun('XX')] }, 'none')[0].x;
+    expect(shifted - base).toBeCloseTo(marLpx / 2, 5);
+  });
+
+  it('a hanging (negative) indent is clamped to 0 — the first line stays at marL', () => {
+    // marL=48px, indent=−24px ⇒ firstLineIndent=max(0,−24)=0, so x = padX + marL.
+    const x = callsFor({ align: 'l', marL: 457200, indent: -228600, runs: [textRun('X')] }, 'none')[0].x;
+    expect(x).toBeCloseTo(PADX + 457200 / EMU_PER_PX, 5);
+  });
+
+  it('marR reduces the wrap width (forces an earlier wrap)', () => {
+    const text = 'X'.repeat(12);
+    const noMarR = callsFor({ align: 'l', runs: [textRun(text)] }, 'normal');
+    const bigMarR = callsFor({ align: 'l', marR: 2286000, runs: [textRun(text)] }, 'normal'); // 240px
+    expect(noMarR.length).toBe(1); // 12 chars fit the full box on one line
+    expect(bigMarR.length).toBeGreaterThan(1); // the narrowed region forces a wrap
+  });
+});

--- a/packages/xlsx/src/shape-paragraph-indent.test.ts
+++ b/packages/xlsx/src/shape-paragraph-indent.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { drawShapeText } from './renderer.js';
+import type { ShapeParagraph, ShapeText, ShapeTextRun } from './types.js';
+
+// ECMA-376 §21.1.2.2.7 (`CT_TextParagraphProperties`): a shape paragraph's
+// direct `<a:pPr>` indent attributes — `marL` (left margin), `marR` (right
+// margin), `indent` (first-line indent, negative = hanging) — shift the text's
+// horizontal layout box. Previously `drawShapeText` dropped them entirely, so
+// indented paragraphs drew flush-left at `padX`. The renderer now mirrors the
+// pptx consumption: leftInset = marL/EMU_PER_PX*cs (+ first-line indent on the
+// first line), and the per-line alignment region width = paraW. All units are
+// EMU on the model and converted with EMU_PER_PX = 9525, scaled by `cs`.
+
+const EMU_PER_PX = 9525;
+
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+}
+
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; calls: FillTextCall[] } {
+  let font = '11px sans-serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText(text: string, x: number, y: number) {
+      calls.push({ text, x, y });
+    },
+    drawImage() {},
+    fillStyle: '#000' as string | CanvasGradient | CanvasPattern,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+function textRun(text: string, size = 11): ShapeTextRun {
+  return { type: 'text', text, bold: false, italic: false, size };
+}
+
+function shapeOf(paragraphs: ShapeParagraph[]): ShapeText {
+  // wrap:none keeps each paragraph on a single line so the first fillText x is
+  // the line's left edge (no wrapping interference).
+  return { anchor: 't', wrap: 'none', paragraphs };
+}
+
+function drawFirstX(p: ShapeParagraph): number {
+  const { ctx, calls } = makeRecordingCtx();
+  drawShapeText(ctx, shapeOf([p]), 300, 300, 1);
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[0].x;
+}
+
+describe('shape paragraph indent attributes (§21.1.2.2.7 marL/marR/indent)', () => {
+  it('a left-aligned paragraph with marL draws shifted right by marL/EMU_PER_PX*cs', () => {
+    const baseline: ShapeParagraph = { align: 'l', runs: [textRun('X')] };
+    // marL = 457200 EMU = 0.5 inch = 48 px at EMU_PER_PX=9525, cs=1.
+    const indented: ShapeParagraph = { align: 'l', marL: 457200, runs: [textRun('X')] };
+
+    const baseX = drawFirstX(baseline);
+    const indentedX = drawFirstX(indented);
+
+    const expectedShift = (457200 / EMU_PER_PX) * 1; // 48 px
+    expect(expectedShift).toBeCloseTo(48, 5);
+    expect(indentedX - baseX).toBeCloseTo(expectedShift, 5);
+  });
+
+  it('a paragraph with no indent attrs is byte-identical (same x) to the baseline', () => {
+    // Invariant: when marL/marR/indent are all absent, leftInset=0 and
+    // availW=innerW, so the draw x is exactly padX (the pre-change value).
+    const noAttrs: ShapeParagraph = { align: 'l', runs: [textRun('X')] };
+    const padX = 7 * 1; // padX = 7 * cs in drawShapeText
+    expect(drawFirstX(noAttrs)).toBeCloseTo(padX, 5);
+  });
+
+  it('first-line indent shifts the first line right by indent on top of marL', () => {
+    const marLpx = (457200 / EMU_PER_PX) * 1; // 48 px
+    const indentPx = (228600 / EMU_PER_PX) * 1; // 24 px
+    const p: ShapeParagraph = {
+      align: 'l',
+      marL: 457200,
+      indent: 228600,
+      runs: [textRun('X')],
+    };
+    const padX = 7 * 1;
+    expect(drawFirstX(p)).toBeCloseTo(padX + marLpx + indentPx, 5);
+  });
+});

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -553,6 +553,16 @@ export interface ShapeParagraph {
   /** `<a:pPr@rtl>` — whether the paragraph reads right-to-left
    *  (ECMA-376 §21.1.2.2.7). Omitted (undefined) when false. */
   rtl?: boolean;
+  /** `<a:pPr@marL>` — left margin in EMU (ECMA-376 §21.1.2.2.7,
+   *  `CT_TextParagraphProperties`). Direct attribute only — xlsx text boxes
+   *  have no lstStyle/level cascade. Omitted (undefined) when unset. */
+  marL?: number;
+  /** `<a:pPr@marR>` — right margin in EMU (ECMA-376 §21.1.2.2.7).
+   *  Omitted (undefined) when unset. */
+  marR?: number;
+  /** `<a:pPr@indent>` — first-line indent in EMU (negative = hanging),
+   *  ECMA-376 §21.1.2.2.7. Omitted (undefined) when unset. */
+  indent?: number;
   runs: ShapeTextRun[];
 }
 


### PR DESCRIPTION
> **Note for the XLSX session:** this touches `packages/xlsx` (`ShapeParagraph` / `drawing.rs` / `drawShapeText`) — the same area as the active `fix/xlsx-empty-para-shape-line-height` worktree. Opened for your review — **not merged** (per the requester's choice). Please review/merge when convenient.

## Gap

xlsx rich-text (drawing/shape) paragraphs dropped the DrawingML paragraph indent attributes — the `<a:pPr>` handler read only `algn`/`rtl`. A direct `marL`/`marR`/`indent` on a text box was silently ignored and the text drew flush-left, unlike pptx and docx which honor the same `CT_TextParagraphProperties`. Surfaced as the cross-package "same hole" while reviewing pptx #614.

## Change

**Parser** — `ShapeParagraph` gains `mar_l`/`mar_r`/`indent: Option<i64>` (EMU), parsed from `<a:pPr@marL/@marR/@indent>`. Additive serde (`skip_serializing_if = Option::is_none`) → JSON byte-identical when absent; serializes as `marL`/`marR`/`indent`.

**Renderer** (`drawShapeText`) — mirrors the pptx renderer:
- per-paragraph `marLpx`/`marRpx`/`indentPx` (EMU→px via `EMU_PER_PX`, scaled by `cs`);
- `paraW = innerW − marLpx − marRpx` is the wrap/alignment region;
- `firstLineIndent = max(0, indentPx)` adds a first-line indent (hanging/negative clamped — xlsx text boxes have no bullet gutter); continuation lines (incl. `<a:br>`-induced) carry only `marL`;
- alignment (`ctr`/`r`) now happens within the paragraph's indented region (`availW`), not the full box width.

**Scope** — direct attributes only. xlsx text boxes have no `lstStyle`/level cascade, so there is no inherited-default tier to resolve (unlike pptx #614).

## Verification

- New Rust tests: `marL/marR/indent` parse to EMU `i64` (negative `indent` = hanging); absent → all `None` and omitted from JSON.
- New TS renderer test (mock-ctx, mirrors `empty-paragraph-shape-text-height.test.ts`): `marL=457200` (0.5in) shifts the first `fillText` x by exactly 48px; first-line `indent` stacks on top of `marL`; **no-attrs draws at `padX` (byte-identical invariant)**.
- `cargo test` 69 passed, `cargo fmt --check` + `cargo clippy -D warnings` clean. xlsx vitest green (incl. the pre-existing shape-text height test, unchanged). WASM builds.
- No PDF/VRT comparison: no local xlsx sample authors a shape-text `marL` (samples gitignored). Existing shapes are unaffected (zero-attr invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)