### PR TITLE
feat(docx): honor w:ind on text-box paragraphs (§17.3.1.12)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4045,14 +4045,36 @@ fn extract_simple_paragraph_text(
     let style_id = child_w(p, "pPr")
         .and_then(|ppr| child_w(ppr, "pStyle"))
         .and_then(|s| attr_w(s, "val"));
+    // Style-chain-resolved ParaFmt (incl. docDefaults) — reused for BOTH the
+    // alignment fallback and the indent resolution below (resolve_para is called
+    // once, not per attribute).
+    let style_para = style_map.resolve_para(style_id.as_deref(), None).0;
     let alignment = direct_jc
-        .or_else(|| {
-            style_map
-                .resolve_para(style_id.as_deref(), None)
-                .0
-                .alignment
-        })
+        .or_else(|| style_para.alignment.clone())
         .unwrap_or_else(|| "left".to_string());
+
+    // ECMA-376 §17.3.1.12 — paragraph indentation (left/right/first-line) for the
+    // text-box paragraph, resolved with §17.7.2 precedence (a DIRECT `<w:ind>`
+    // overrides the style chain PER ATTRIBUTE). `parse_para_fmt` reads the
+    // paragraph's OWN `<w:pPr>` (firstLine stored positive, hanging negative —
+    // signed, §17.3.1.12); `style_para` carries the style-chain-resolved indent.
+    // The first-line sign is KEPT (no clamp): a hanging indent is honored exactly
+    // as the docx BODY renderer does (Word honors a signed hanging first-line
+    // list-independently), unlike the pptx/xlsx shape paths which clamp because
+    // they have no list marker to hang.
+    let direct_ind = child_w(p, "pPr").map(parse_para_fmt).unwrap_or_default();
+    let indent_left = direct_ind
+        .indent_left
+        .or(style_para.indent_left)
+        .unwrap_or(0.0);
+    let indent_right = direct_ind
+        .indent_right
+        .or(style_para.indent_right)
+        .unwrap_or(0.0);
+    let indent_first = direct_ind
+        .indent_first
+        .or(style_para.indent_first)
+        .unwrap_or(0.0);
 
     // ECMA-376 §17.3.1.33 — the txbxContent paragraph's own `<w:spacing>` is
     // reserved INSIDE the text box (twips → pt). Word offsets the text down by
@@ -4105,6 +4127,9 @@ fn extract_simple_paragraph_text(
         alignment: normalize_align(&alignment).to_string(),
         space_before,
         space_after,
+        indent_left,
+        indent_right,
+        indent_first,
         image_path,
         mime_type,
         svg_image_path,
@@ -8962,6 +8987,86 @@ mod txbx_inline_image_tests {
         .unwrap();
         assert!((block.space_before - 50.0).abs() < 1e-6);
         assert!((block.space_after - 9.0).abs() < 1e-6);
+    }
+
+    /// ECMA-376 §17.3.1.12 — a text-box paragraph surfaces its own `<w:ind>`
+    /// left/right/first-line indent (twips→pt). first-line is SIGNED:
+    /// `w:firstLine` is positive, `w:hanging` is negative. Absent ⇒ all 0.
+    #[test]
+    fn extract_simple_paragraph_text_surfaces_indent() {
+        let parse_block = |xml: &str| {
+            let doc = roxmltree::Document::parse(xml).unwrap();
+            extract_simple_paragraph_text(
+                &StyleMap::default(),
+                doc.root_element(),
+                &ThemeColors::default(),
+                &HashMap::new(),
+            )
+            .unwrap()
+        };
+        // left=720 twips = 36 pt, right=360 = 18 pt, hanging=180 = -9 pt (SIGNED).
+        let hanging = parse_block(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                  <w:pPr><w:ind w:left="720" w:right="360" w:hanging="180"/></w:pPr>
+                  <w:r><w:t>x</w:t></w:r></w:p>"#,
+        );
+        assert!((hanging.indent_left - 36.0).abs() < 1e-6);
+        assert!((hanging.indent_right - 18.0).abs() < 1e-6);
+        assert!((hanging.indent_first - -9.0).abs() < 1e-6);
+
+        // firstLine is POSITIVE (a positive first-line indent, not a hang).
+        let first_line = parse_block(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                  <w:pPr><w:ind w:firstLine="240"/></w:pPr>
+                  <w:r><w:t>x</w:t></w:r></w:p>"#,
+        );
+        assert!((first_line.indent_first - 12.0).abs() < 1e-6);
+
+        // Absent <w:ind> ⇒ all indents 0.
+        let none = parse_block(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                  <w:r><w:t>x</w:t></w:r></w:p>"#,
+        );
+        assert_eq!(none.indent_left, 0.0);
+        assert_eq!(none.indent_right, 0.0);
+        assert_eq!(none.indent_first, 0.0);
+    }
+
+    /// ECMA-376 §17.7.2 — a text-box paragraph's indent resolves through the
+    /// paragraph STYLE chain, then a DIRECT `<w:ind>` overrides it PER ATTRIBUTE.
+    /// Here the style sets left/right/firstLine; the paragraph's direct `<w:ind>`
+    /// overrides ONLY left, so the direct left wins while right/firstLine fall to
+    /// the style.
+    #[test]
+    fn extract_simple_paragraph_text_indent_direct_overrides_style_per_attr() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Indented">
+                <w:pPr><w:ind w:left="720" w:right="360" w:firstLine="240"/></w:pPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr>
+                   <w:pStyle w:val="Indented"/>
+                   <w:ind w:left="1440"/>
+                 </w:pPr>
+                 <w:r><w:t>x</w:t></w:r></w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+        // Direct left=1440 twips = 72 pt wins over the style's 36 pt.
+        assert!((block.indent_left - 72.0).abs() < 1e-6);
+        // right/firstLine come from the style (no direct override).
+        assert!((block.indent_right - 18.0).abs() < 1e-6);
+        assert!((block.indent_first - 12.0).abs() < 1e-6);
     }
 
     /// A text-box run with NO `<w:rPr>` at all still inherits the document default

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1067,6 +1067,17 @@ pub struct ShapeText {
     /// pt — reserved below the paragraph. 0 when absent.
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub space_after: f64,
+    /// ECMA-376 §17.3.1.12 `<w:ind w:left/@start>` — paragraph left indent (pt).
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub indent_left: f64,
+    /// ECMA-376 §17.3.1.12 `<w:ind w:right/@end>` — paragraph right indent (pt).
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub indent_right: f64,
+    /// `<w:ind>` first-line indent (pt, SIGNED: w:firstLine positive, w:hanging
+    /// negative). Mirrors the body renderer, which honors a signed hanging
+    /// first-line indent list-independently (Word's behaviour).
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub indent_first: f64,
     /// Embedded zip path of an inline image living inside this text-box
     /// paragraph (`<w:drawing><wp:inline>…<a:blip r:embed>`), e.g.
     /// `word/media/image1.emf`. `None` for a text-only paragraph. Resolved

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
-  DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
+  DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
@@ -6309,6 +6309,10 @@ function wrapShapeText(
   ctx: CanvasRenderingContext2D,
   text: string,
   maxWidth: number,
+  // ECMA-376 §17.3.1.12 — the FIRST line wraps to this width (paraW − firstLine
+  // indent); continuation lines use `maxWidth` (paraW). Defaults to `maxWidth`
+  // so a no-indent caller keeps the original single-width wrap exactly.
+  firstLineWidth: number = maxWidth,
 ): string[] {
   if (!text) return [''];
   if (maxWidth <= 0) return [text];
@@ -6316,10 +6320,14 @@ function wrapShapeText(
 
   const lines: string[] = [];
   let cur = '';
+  // The first line being filled uses firstLineWidth; once a line wraps the
+  // remaining lines use maxWidth.
+  let limit = firstLineWidth;
   for (const tok of tokens) {
-    if (cur !== '' && ctx.measureText(cur + tok).width > maxWidth) {
+    if (cur !== '' && ctx.measureText(cur + tok).width > limit) {
       lines.push(cur.replace(/\s+$/, ''));
       cur = tok.replace(/^\s+/, ''); // a wrapped line never starts with a space
+      limit = maxWidth;
     } else {
       cur += tok;
     }
@@ -6352,6 +6360,10 @@ function wrapShapeRuns(
   maxWidth: number,
   scale: number,
   fontFamilyClasses: Record<string, string>,
+  // ECMA-376 §17.3.1.12 — first line wraps to this width (paraW − firstLine
+  // indent); continuation lines use `maxWidth` (paraW). Defaults to `maxWidth`
+  // so a no-indent caller keeps the original single-width wrap exactly.
+  firstLineWidth: number = maxWidth,
 ): RichToken[][] {
   const tokens: RichToken[] = [];
   for (const run of runs) {
@@ -6369,9 +6381,13 @@ function wrapShapeRuns(
   const lines: RichToken[][] = [];
   let cur: RichToken[] = [];
   let curW = 0;
+  // The first line being filled uses firstLineWidth; once a line wraps the
+  // remaining lines use maxWidth.
+  let limit = firstLineWidth;
   for (const tok of tokens) {
-    if (cur.length > 0 && curW + tok.width > maxWidth) {
+    if (cur.length > 0 && curW + tok.width > limit) {
       lines.push(cur);
+      limit = maxWidth;
       // A wrapped line never starts with a space — drop a leading space token.
       if (tok.text.trim() === '') {
         cur = [];
@@ -6436,34 +6452,55 @@ export function renderShapeText(
   const innerY = y + tIns;
   const innerH = Math.max(0, h - tIns - bIns);
 
+  // ECMA-376 §17.3.1.12 — per-paragraph indent (px). `leftPx`/`rightPx` shrink
+  // the text column from the inner box edges; `firstPx` is the SIGNED first-line
+  // indent (positive = first line further right; negative = first line hangs
+  // LEFT, so its width is WIDER). The body renderer honors the sign the same way
+  // (Word applies a signed hanging first-line list-independently); the shape path
+  // mirrors it rather than clamping. `paraW` is the continuation-line width;
+  // `firstLineW` the first line's. When all indents are 0 ⇒ leftPx=rightPx=
+  // firstPx=0 ⇒ paraW=firstLineW=innerW and regionLeft=innerX (no-op).
+  const indentOf = (b: ShapeText) => {
+    const leftPx = (b.indentLeft ?? 0) * scale;
+    const rightPx = (b.indentRight ?? 0) * scale;
+    const firstPx = (b.indentFirst ?? 0) * scale; // SIGNED
+    const paraW = Math.max(0, innerW - leftPx - rightPx);
+    const firstLineW = Math.max(0, paraW - firstPx);
+    return { leftPx, firstPx, paraW, firstLineW };
+  };
+
   // First pass: lay out each block. Text blocks WRAP to the inner width
   // (ECMA-376 §21.1.2.1.1) — a long title/abstract that exceeds the box width
   // breaks onto multiple lines instead of overflowing the page; image blocks
   // reserve their fitted height. The computed layout drives both vertical
   // anchoring (totalH) and the draw pass (no re-wrapping).
+  type BlockIndent = { leftPx: number; firstPx: number; paraW: number; firstLineW: number };
   type BlockLayout =
-    | { kind: 'image'; fitW: number; fitH: number }
-    | { kind: 'text'; lines: string[]; lineH: number }
-    | { kind: 'rich'; lines: RichToken[][]; lineHeights: number[] };
+    | { kind: 'image'; fitW: number; fitH: number; ind: BlockIndent }
+    | { kind: 'text'; lines: string[]; lineH: number; ind: BlockIndent }
+    | { kind: 'rich'; lines: RichToken[][]; lineHeights: number[]; ind: BlockIndent };
   const layouts: BlockLayout[] = blocks.map((b) => {
+    const ind = indentOf(b);
     if (b.imagePath) {
-      const { w: fitW, h: fitH } = fitShapeImage(b.imageWidthPt ?? 0, b.imageHeightPt ?? 0, innerW, scale);
-      return { kind: 'image', fitW, fitH };
+      // The image occupies the FIRST line, so it fits to firstLineW (= paraW −
+      // signed first-line indent), not the full inner width.
+      const { w: fitW, h: fitH } = fitShapeImage(b.imageWidthPt ?? 0, b.imageHeightPt ?? 0, ind.firstLineW, scale);
+      return { kind: 'image', fitW, fitH, ind };
     }
     // Rich path: a paragraph with explicit per-run formatting lays out as mixed
     // fonts. Each line's height is the tallest run on it × 1.2 (ECMA-376 line
     // box ≈ largest font on the line).
     if (b.runs && b.runs.length > 0) {
-      const lines = wrapShapeRuns(ctx, b.runs, innerW, scale, fontFamilyClasses);
+      const lines = wrapShapeRuns(ctx, b.runs, ind.paraW, scale, fontFamilyClasses, ind.firstLineW);
       const lineHeights = lines.map((toks) => {
         const maxPt = toks.reduce((m, t) => Math.max(m, t.run.fontSizePt), 0);
         return (maxPt > 0 ? maxPt : b.fontSizePt) * scale * 1.2;
       });
-      return { kind: 'rich', lines, lineHeights };
+      return { kind: 'rich', lines, lineHeights, ind };
     }
     const fontPx = b.fontSizePt * scale;
     ctx.font = buildFont(b.bold ?? false, b.italic ?? false, fontPx, b.fontFamily ?? null, fontFamilyClasses);
-    return { kind: 'text', lines: wrapShapeText(ctx, b.text, innerW), lineH: fontPx * 1.2 };
+    return { kind: 'text', lines: wrapShapeText(ctx, b.text, ind.paraW, ind.firstLineW), lineH: fontPx * 1.2, ind };
   });
   const blockHeight = (l: BlockLayout): number => {
     if (l.kind === 'image') return l.fitH;
@@ -6503,18 +6540,23 @@ export function renderShapeText(
     cursorY += gapBefore(i);
 
     if (layout.kind === 'image') {
-      // Inline image inside the text box. Fit to inner width, place
-      // horizontally per the paragraph alignment (figures default to centered),
-      // and advance by the reserved height regardless of whether a bitmap is
-      // present (a missing decode must not shift the rest of the layout).
-      const { fitW, fitH } = layout;
+      // Inline image inside the text box. The image is the paragraph's FIRST
+      // (only) line, so it lives in the first-line region: region-left =
+      // innerX + leftPx + firstPx, region-width = firstLineW (ECMA-376
+      // §17.3.1.12). Place horizontally per the paragraph alignment (figures
+      // default to centered), and advance by the reserved height regardless of
+      // whether a bitmap is present (a missing decode must not shift the rest of
+      // the layout).
+      const { fitW, fitH, ind } = layout;
+      const regionLeft = innerX + ind.leftPx + ind.firstPx;
+      const regionW = ind.firstLineW;
       const bmp = block.imagePath ? images.get(imageKey(block.imagePath)) : undefined;
       if (bmp) {
-        let drawX = innerX + Math.max(0, (innerW - fitW) / 2); // default: centered
+        let drawX = regionLeft + Math.max(0, (regionW - fitW) / 2); // default: centered
         if (block.alignment === 'left' || block.alignment === 'both') {
-          drawX = innerX;
+          drawX = regionLeft;
         } else if (block.alignment === 'right') {
-          drawX = innerX + Math.max(0, innerW - fitW);
+          drawX = regionLeft + Math.max(0, regionW - fitW);
         }
         ctx.drawImage(bmp, drawX, cursorY, fitW, fitH);
       }
@@ -6529,20 +6571,28 @@ export function renderShapeText(
       const edgeFor = (rtl: boolean) =>
         block.alignment === 'distribute' ? 'center' : resolveAlignEdge(block.alignment, rtl);
       ctx.textAlign = 'left';
+      const ind = layout.ind;
       for (let li = 0; li < layout.lines.length; li++) {
         const lineToks = layout.lines[li];
         const lineH = layout.lineHeights[li];
         const lineW = lineToks.reduce((s, t) => s + t.width, 0);
+        // ECMA-376 §17.3.1.12 — align within the per-line INDENTED region: the
+        // first line carries the signed first-line indent, continuation lines do
+        // not. region-left = innerX + leftPx (+ firstPx on the first line);
+        // region-width = firstLineW (first) / paraW (continuation).
+        const isFirstLine = li === 0;
+        const regionLeft = innerX + ind.leftPx + (isFirstLine ? ind.firstPx : 0);
+        const regionW = isFirstLine ? ind.firstLineW : ind.paraW;
         // Base direction (first-strong) from the line's own text, matching the
         // single-format path's per-block resolution but resolved per line.
         const lineText = lineToks.map((t) => t.text).join('');
         const baseRtl = resolveBaseDirection(undefined, lineText) === 'rtl';
         const edge = edgeFor(baseRtl);
-        let tx = innerX;
+        let tx = regionLeft;
         if (edge === 'center') {
-          tx = innerX + Math.max(0, (innerW - lineW) / 2);
+          tx = regionLeft + Math.max(0, (regionW - lineW) / 2);
         } else if (edge === 'right') {
-          tx = innerX + Math.max(0, innerW - lineW);
+          tx = regionLeft + Math.max(0, regionW - lineW);
         }
         // Baseline uses the tallest font on the line (lineH / 1.2 × 0.85).
         const lineMaxFontPx = lineH / 1.2;
@@ -6587,13 +6637,22 @@ export function renderShapeText(
       : resolveAlignEdge(block.alignment, baseRtl);
     ctx.textAlign = 'left';
     ctx.direction = baseRtl ? 'rtl' : 'ltr';
-    for (const line of layout.lines) {
+    const ind = layout.ind;
+    for (let li = 0; li < layout.lines.length; li++) {
+      const line = layout.lines[li];
       const m = ctx.measureText(line);
-      let tx = innerX;
+      // ECMA-376 §17.3.1.12 — align within the per-line INDENTED region: the
+      // first line carries the signed first-line indent, continuation lines do
+      // not (region-left = innerX + leftPx (+ firstPx on the first line);
+      // region-width = firstLineW (first) / paraW (continuation)).
+      const isFirstLine = li === 0;
+      const regionLeft = innerX + ind.leftPx + (isFirstLine ? ind.firstPx : 0);
+      const regionW = isFirstLine ? ind.firstLineW : ind.paraW;
+      let tx = regionLeft;
       if (edge === 'center') {
-        tx = innerX + Math.max(0, (innerW - m.width) / 2);
+        tx = regionLeft + Math.max(0, (regionW - m.width) / 2);
       } else if (edge === 'right') {
-        tx = innerX + Math.max(0, innerW - m.width);
+        tx = regionLeft + Math.max(0, regionW - m.width);
       }
       // Baseline = line top + ascent (approx 0.85 of font size for default fonts).
       const baseline = cursorY + fontPx * 0.85;

--- a/packages/docx/src/textbox-paragraph-indent.test.ts
+++ b/packages/docx/src/textbox-paragraph-indent.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { renderShapeText } from './renderer.js';
+import type { ShapeRun, ShapeText } from './types';
+
+// ECMA-376 §17.3.1.12 — a text-box paragraph honors its `<w:ind>` left/right/
+// first-line indent. The first line carries the (signed) first-line indent; a
+// wrapping continuation line sits at the inner-left + left-indent. Alignment
+// (center/right) is computed within the INDENTED region, not the full inner box.
+// When all three indents are 0 the output is byte-identical to no indent.
+
+interface Call { text: string; x: number; y: number; }
+
+function makeRecordingCanvas(): { ctx: CanvasRenderingContext2D; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    strokeText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+// A rect shape at (x=100,y=50,w=200,h=200) with NO insets so innerX=100,
+// innerW=200. textBlocks is the single argument under test.
+function shapeWith(blocks: ShapeText[]): ShapeRun {
+  return {
+    type: 'shape',
+    presetGeometry: 'rect', wrapMode: 'none', textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    textBlocks: blocks,
+  } as unknown as ShapeRun;
+}
+
+const SHAPE_X = 100, SHAPE_Y = 50, SHAPE_W = 200, SHAPE_H = 200;
+const INNER_X = SHAPE_X; // no insets
+const SCALE = 1;
+const FONTS = { 'Times New Roman': 'roman' };
+
+function render(blocks: ShapeText[]): Call[] {
+  const { ctx, calls } = makeRecordingCanvas();
+  renderShapeText(shapeWith(blocks), SHAPE_X, SHAPE_Y, SHAPE_W, SHAPE_H, ctx, SCALE, FONTS);
+  return calls;
+}
+
+function leftBlock(text: string, extra: Partial<ShapeText> = {}): ShapeText {
+  return { text, fontSizePt: 10, fontFamily: 'Times New Roman', alignment: 'left', ...extra } as unknown as ShapeText;
+}
+
+describe('text-box paragraph indent (§17.3.1.12)', () => {
+  it('shifts a left-aligned first line right by indentLeft*scale', () => {
+    const baseline = render([leftBlock('Hello')]);
+    const indented = render([leftBlock('Hello', { indentLeft: 18 })]);
+    const b = baseline.find((c) => c.text === 'Hello');
+    const i = indented.find((c) => c.text === 'Hello');
+    expect(b).toBeDefined();
+    expect(i).toBeDefined();
+    // No indent ⇒ x = innerX. With indentLeft=18pt (scale 1) ⇒ x = innerX + 18.
+    expect((b as Call).x).toBeCloseTo(INNER_X, 5);
+    expect((i as Call).x).toBeCloseTo(INNER_X + 18, 5);
+  });
+
+  it('adds the (positive) first-line indent on top of the left indent for the first line', () => {
+    const calls = render([leftBlock('Hello', { indentLeft: 10, indentFirst: 8 })]);
+    const i = calls.find((c) => c.text === 'Hello');
+    expect(i).toBeDefined();
+    // First line region-left = innerX + leftPx + firstPx = innerX + 10 + 8.
+    expect((i as Call).x).toBeCloseTo(INNER_X + 18, 5);
+  });
+
+  it('keeps the continuation line at innerX+leftPx while the first line carries the first-line indent', () => {
+    // 0.5px/char width (10px font). innerW=200, leftPx=20 ⇒ paraW=180 (=36 chars).
+    // firstPx=+40 ⇒ firstLineW=140 (=28 chars). A long word stream wraps: the
+    // first line holds fewer chars (narrower firstLineW), the continuation more.
+    const words = Array.from({ length: 30 }, (_, n) => `w${n}`).join(' ');
+    const calls = render([leftBlock(words, { indentLeft: 20, indentFirst: 40 })]);
+    // Lines are emitted top-to-bottom; group fillText by y.
+    const ys = [...new Set(calls.map((c) => c.y))].sort((a, b) => a - b);
+    expect(ys.length).toBeGreaterThanOrEqual(2);
+    const firstLineX = calls.find((c) => c.y === ys[0])?.x;
+    const contLineX = calls.find((c) => c.y === ys[1])?.x;
+    expect(firstLineX).toBeDefined();
+    expect(contLineX).toBeDefined();
+    // First line: innerX + leftPx + firstPx = 100 + 20 + 40 = 160.
+    expect(firstLineX as number).toBeCloseTo(INNER_X + 20 + 40, 5);
+    // Continuation: innerX + leftPx = 100 + 20 = 120 (no first-line indent).
+    expect(contLineX as number).toBeCloseTo(INNER_X + 20, 5);
+  });
+
+  it('centers within the indented region for a ctr paragraph', () => {
+    // ctr block, no indent: x_center0 = innerX + (innerW - w)/2.
+    const word = 'Hi';
+    const w = [...word].length * 10 * 0.5; // 0.5px/char @10px = 10px wide.
+    const base = render([leftBlock(word, { alignment: 'center' })]);
+    const indented = render([leftBlock(word, { alignment: 'center', indentLeft: 30, indentRight: 10 })]);
+    const b = base.find((c) => c.text === word);
+    const i = indented.find((c) => c.text === word);
+    expect(b).toBeDefined();
+    expect(i).toBeDefined();
+    // No indent: centered in [innerX, innerW].
+    expect((b as Call).x).toBeCloseTo(INNER_X + (SHAPE_W - w) / 2, 5);
+    // Indented: region-left = innerX + 30, region-width = innerW - 30 - 10 = 160.
+    const regionLeft = INNER_X + 30;
+    const regionW = SHAPE_W - 30 - 10;
+    expect((i as Call).x).toBeCloseTo(regionLeft + (regionW - w) / 2, 5);
+  });
+
+  it('is byte-identical to no-indent when all three indents are 0', () => {
+    const a = render([leftBlock('Hello world this wraps maybe', { alignment: 'left' })]);
+    const b = render([leftBlock('Hello world this wraps maybe', { alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0 })]);
+    expect(b.map((c) => [c.text, c.x, c.y])).toEqual(a.map((c) => [c.text, c.x, c.y]));
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -631,6 +631,18 @@ export interface ShapeText {
   /** ECMA-376 §17.3.1.33 `<w:spacing w:after>` of this text-box paragraph, in
    *  pt — reserved BELOW the paragraph. Absent/0 ⇒ no offset. */
   spaceAfter?: number;
+  /** ECMA-376 §17.3.1.12 `<w:ind w:left/@start>` — paragraph left indent (pt).
+   *  Absent/0 ⇒ flush to the box's inner left edge. */
+  indentLeft?: number;
+  /** ECMA-376 §17.3.1.12 `<w:ind w:right/@end>` — paragraph right indent (pt).
+   *  Absent/0 ⇒ flush to the box's inner right edge. */
+  indentRight?: number;
+  /** `<w:ind>` first-line indent (pt, SIGNED: `w:firstLine` positive,
+   *  `w:hanging` negative). A negative value hangs the first line further LEFT
+   *  than the continuation lines (the body renderer honors the sign too — Word
+   *  applies a signed hanging first-line list-independently). Absent/0 ⇒ the
+   *  first line aligns with the continuation lines. */
+  indentFirst?: number;
   /** Zip path of an inline image inside this text-box paragraph
    *  (`<w:drawing><wp:inline><a:blip r:embed>`), e.g. `word/media/image1.emf`.
    *  Absent for a text-only paragraph. */


### PR DESCRIPTION
## Gap

docx text box / shape paragraphs (`<wps:txbx>`/`<v:textbox>` → `<w:txbxContent>`) dropped paragraph indentation — the reducer read only `jc` (alignment) and `spacing`, never `<w:ind>` (left/start, right/end, firstLine, hanging). A Word text box whose paragraphs are indented rendered flush against the box inset.

This closes the **docx leg of the cross-package indent series**: docx body already honors `w:ind` with a signed first-line (#611/#612), pptx shape/list indent (#614), xlsx shape-text `marL/marR/indent` (#620). docx textbox was the one path the series hadn't closed — surfaced by the cross-package reviewer of #620.

## Change

**Parser** (`extract_simple_paragraph_text`): resolve `w:ind` reusing the body path — the paragraph STYLE chain (`resolve_para`, hoisted so alignment + indent share one lookup) with the paragraph's **direct** `<w:ind>` (`parse_para_fmt`) overriding **per attribute** (§17.7.2). `indent_first` keeps its **sign** (`w:firstLine` positive / `w:hanging` negative). Carry `indent_left`/`indent_right`/`indent_first` (pt) on `ShapeText` — additive serde (`is_zero_f64`), JSON byte-identical when zero.

**Renderer** (`renderShapeText`): per-paragraph left/right insets shrink the column (`paraW = innerW − left − right`); the first line carries the **signed** first-line indent (`firstLineW = paraW − firstPx`; a hanging indent makes the first line wider, hanging LEFT); continuation lines use `paraW`; alignment happens within the per-line region — across all three paths (image / single-format text / rich). The two wrap helpers gain a `firstLineWidth` (default = `maxWidth`).

**Signed, not clamped** — deliberately unlike pptx/xlsx shape (which clamp): the docx **body** renderer honors a signed hanging first-line list-independently, which is what Word does; the textbox path mirrors the body.

## Verification

- New Rust tests: a `<w:txbxContent>` paragraph's `<w:ind w:left/w:right/w:hanging>` → `ShapeText` pt fields (twips/20; hanging negative); `w:firstLine` positive; absent ⇒ 0; a direct `w:ind` overrides a styled indent per attribute.
- New TS renderer test (mock-ctx, mirrors `textbox-paragraph-spacing.test.ts`): left indent shifts the first fillText x; a wrapping paragraph's continuation line sits at `innerX + leftPx` while the first line carries the indent; `ctr` centers within the indented region; **no-indent is byte-identical** (`.toEqual` on the draw tuples).
- `cargo test` 172 passed, `cargo fmt --check` + `clippy -D warnings` clean; full docx vitest **314 passed**; WASM builds.
- No PDF/VRT: no local docx sample authors a textbox `w:ind` (samples gitignored); verification is unit-test-based + the zero-indent invariant.

> **Note:** opened for review — **not merged** (per the requester's choice). docx (Session B) had no active worktree at branch time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)