### PR TITLE
fix(pptx): reduce the first line's wrap width by a positive first-line indent

### DIFF
--- a/packages/pptx/src/firstline-indent-wrap.test.ts
+++ b/packages/pptx/src/firstline-indent-wrap.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// A POSITIVE first-line indent (a:pPr@indent > 0 on a NON-bullet paragraph)
+// shifts the first line right at draw time AND narrows that line's alignment /
+// justify region by the indent. The wrap/layout pass must reduce the FIRST
+// line's wrap budget by the same amount, otherwise the first line wraps too
+// late and overruns the right margin (marR). Continuation lines keep the full
+// width. This mirrors willTextOverflow's `textMaxW - firstLineIndent` and the
+// draw-side `textMaxW - textXOffset`, and matches xlsx PR #620.
+
+function mockCtx() {
+  let font = '';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    // Deterministic: every glyph (incl. spaces) is 10px wide.
+    measureText: (s: string) => ({ width: s.length * 10 }),
+    fillRect() {}, fillText() {},
+    fillStyle: '', strokeStyle: '',
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function run(text: string, over: Partial<TextRunData> = {}): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Arial', ...over,
+  };
+}
+
+function para(runs: TextRunData[]): Paragraph {
+  return {
+    alignment: 'l', marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null,
+    defItalic: null, defFontFamily: null, tabStops: [], eaLnBrk: true, runs,
+  } as Paragraph;
+}
+
+function lineTexts(line: { segments: { text: string }[] }): string {
+  return line.segments.map((s) => s.text).join('');
+}
+
+// Width a line occupies = total glyph count × 10 (mock), trailing whitespace
+// included — matching how `lineW` accumulates inside layoutParagraph.
+function lineWidth(line: { segments: { text: string }[] }): number {
+  return lineTexts(line).length * 10;
+}
+
+// Count the non-whitespace tokens that begin the first line.
+function firstLineWordCount(line: { segments: { text: string }[] }): number {
+  return lineTexts(line).trim().split(/\s+/).filter((t) => t.length > 0).length;
+}
+
+describe('pptx non-bullet first-line indent narrows the first wrap line', () => {
+  // Five 4-char words, single spaces between: "aaaa bbbb cccc dddd eeee".
+  // Each word = 40px, each space = 10px. maxWidth = 200px.
+  const TEXT = 'aaaa bbbb cccc dddd eeee';
+  const MAX = 200;
+
+  it('packs more tokens on the first line when there is no indent (baseline)', () => {
+    const lines = layoutParagraph(
+      mockCtx(), para([run(TEXT)]), MAX, 20, '000000', 1, 0,
+    );
+    // "aaaa bbbb cccc dddd" = 4*40 + 3*10 = 190 ≤ 200; "+ eeee" would be 240 > 200.
+    expect(firstLineWordCount(lines[0])).toBe(4);
+    expect(lineWidth(lines[0])).toBeLessThanOrEqual(MAX);
+  });
+
+  it('packs FEWER tokens on the first line with a positive first-line indent', () => {
+    // indent of 80px (~2 words). First-line budget becomes 200 - 80 = 120.
+    // "aaaa bbbb" = 90 ≤ 120; "+ cccc" = 140 > 120, so only 2 words fit.
+    const indentPx = 80;
+    const lines = layoutParagraph(
+      mockCtx(), para([run(TEXT)]), MAX, 20, '000000', 1, 0,
+      false, false, 1.0, undefined,
+      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+      indentPx,
+    );
+    // First line wraps earlier than the baseline (4 → 2 words).
+    expect(firstLineWordCount(lines[0])).toBeLessThan(4);
+    // No overrun: first line width ≤ maxWidth - indent.
+    expect(lineWidth(lines[0])).toBeLessThanOrEqual(MAX - indentPx);
+    // Continuation lines still use the FULL width (not the narrowed budget):
+    // the second line should be allowed to exceed (MAX - indentPx).
+    const continuationMax = Math.max(...lines.slice(1).map(lineWidth));
+    expect(continuationMax).toBeGreaterThan(MAX - indentPx);
+    expect(continuationMax).toBeLessThanOrEqual(MAX);
+  });
+
+  it('is byte-identical to the default when firstLineIndentPx is 0 or omitted', () => {
+    const omitted = layoutParagraph(
+      mockCtx(), para([run(TEXT)]), MAX, 20, '000000', 1, 0,
+    );
+    const explicitZero = layoutParagraph(
+      mockCtx(), para([run(TEXT)]), MAX, 20, '000000', 1, 0,
+      false, false, 1.0, undefined,
+      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+      0,
+    );
+    const texts = (ls: { segments: { text: string }[] }[]) => ls.map(lineTexts);
+    expect(texts(explicitZero)).toEqual(texts(omitted));
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -669,8 +669,13 @@ export function layoutParagraph(
   fontScale: number = 1.0,
   slideNumber?: number,
   rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+  firstLineIndentPx: number = 0,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
+  // The first line's wrap budget is narrower by a POSITIVE first-line indent
+  // (it occupies indentPx of the line); continuation lines use the full width.
+  // `lines.length === 0` ⇒ still filling the first line (newLine() pushes to it).
+  const lineMaxW = () => maxWidthPx - (lines.length === 0 ? firstLineIndentPx : 0);
   let currentLine: LayoutLine = { segments: [] };
   let lineW = 0; // current line's accumulated width
   // ECMA-376 §17.18.93 ST_TextWrappingType "square" is whitespace-aware: a
@@ -822,7 +827,7 @@ export function layoutParagraph(
       const descent = render ? render.descentEm * emPx : 0;
       // Block (display) math gets its own line; the draw pass centres it.
       if (run.display && lineW > 0) newLine();
-      else if (lineW + width > maxWidthPx && lineW > 0) newLine();
+      else if (lineW + width > lineMaxW() && lineW > 0) newLine();
       currentLine.segments.push({
         text: '',
         font: `${emPx}px sans-serif`,
@@ -974,7 +979,7 @@ export function layoutParagraph(
           }
           ctx.font = chFont;
           const chW = ctx.measureText(drawCh).width;
-          if (lineW + chW > maxWidthPx && lineW > 0) newLine();
+          if (lineW + chW > lineMaxW() && lineW > 0) newLine();
           push(drawCh, chFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
         continue;
@@ -1015,7 +1020,7 @@ export function layoutParagraph(
           // content and the token would overflow, wrap once before placing it;
           // never break mid-token (an over-wide token simply overflows).
           const tokenW = measured.reduce((acc, m) => acc + m.w, 0);
-          if (lineW > 0 && lineW + tokenW > maxWidthPx) newLine();
+          if (lineW > 0 && lineW + tokenW > lineMaxW()) newLine();
           for (const m of measured) {
             push(m.ch, m.font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
           }
@@ -1023,7 +1028,7 @@ export function layoutParagraph(
         }
         let rest = measured;
         while (rest.length > 0) {
-          const n = fitCjkLine(rest, lineW, maxWidthPx, DEFAULT_KINSOKU_RULES);
+          const n = fitCjkLine(rest, lineW, lineMaxW(), DEFAULT_KINSOKU_RULES);
           if (n === 0) {
             newLine(); // non-empty line can't take the run head → break, retry empty
             continue;
@@ -1038,17 +1043,17 @@ export function layoutParagraph(
         continue;
       }
 
-      if (lineW + tokW <= maxWidthPx) {
+      if (lineW + tokW <= lineMaxW()) {
         push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         if (isWhitespace) hasWhitespaceOnLine = true;
       } else if (isWhitespace) {
         if (lineW > 0) newLine();
-      } else if (tokW > maxWidthPx) {
+      } else if (tokW > lineMaxW()) {
         if (lineW > 0) newLine();
         for (const ch of token) {
           ctx.font = font;
           const chW = ctx.measureText(ch).width;
-          if (lineW + chW > maxWidthPx && lineW > 0) newLine();
+          if (lineW + chW > lineMaxW() && lineW > 0) newLine();
           push(ch, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
       } else if (!hasWhitespaceOnLine) {
@@ -2141,7 +2146,12 @@ export function renderTextBody(
     const textMaxW = colWidth - marLPx - marRPx;
 
     const maxW = doWrap ? textMaxW : Infinity;
-    const lines = layoutParagraph(ctx, para, maxW, paraDefaultFontSizePx, paraDefaultColor, scale, marLPx, bodyDefaultBold, bodyDefaultItalic, fontScale, slideNumber, rc);
+    // A positive first-line indent narrows ONLY the first line's wrap budget,
+    // matching the draw-side `textXOffset` (= indentPx for a non-bullet first
+    // line, §below) and willTextOverflow's measurement. A negative (hanging)
+    // indent is the bullet's gutter, not a text-width reduction → max(0, …)=0.
+    const firstLineIndentPx = !hasBullet ? Math.max(0, indentPx) : 0;
+    const lines = layoutParagraph(ctx, para, maxW, paraDefaultFontSizePx, paraDefaultColor, scale, marLPx, bodyDefaultBold, bodyDefaultItalic, fontScale, slideNumber, rc, firstLineIndentPx);
 
     // spaceBefore/After are in hundredths of a point → convert to canvas px
     const spaceBeforePx = para.spaceBefore != null ? (para.spaceBefore / 100) * PT_TO_EMU * scale * fontScale : 0;


### PR DESCRIPTION
> **Note for the PPTX session:** touches `packages/pptx/src/renderer.ts` only (text-wrap path, not the custgeom area the active worktrees use). Opened for your review — **not merged** (per the requester's choice).

## Bug

A positive first-line `indent` is applied at draw time — the first line shifts right by `textXOffset` and its alignment/justify region is reduced (`textMaxW - textXOffset`, renderer.ts:2441/2464) — but the **layout/wrap** path wrapped *every* line to the full `textMaxW = colWidth - marLPx - marRPx` (line ~2141). So a positively-indented first line wrapped `indentPx` px too late and could overrun the right margin (marR) on line 1.

The renderer was internally inconsistent: the autofit-measurement helper `willTextOverflow` (~617) already subtracts the first-line indent (`textMaxW = … - Math.max(0, indentPx)`); the layout path did not. (xlsx #620 got this right via `lineAvailW()`.)

## Fix

- `layoutParagraph` gains a trailing `firstLineIndentPx: number = 0`. A `lineMaxW()` helper returns `maxWidthPx - (lines.length === 0 ? firstLineIndentPx : 0)` — the **first** line (still being filled ⇒ `lines.length === 0`) wraps narrower, continuation lines use the full width. All 7 wrap-decision sites (display-math, symbol/PUA, CJK whole-token, CJK kinsoku `fitCjkLine`, Latin token-fits / over-wide / char-break) now compare against `lineMaxW()`.
- Call site (~2153): `const firstLineIndentPx = !hasBullet ? Math.max(0, indentPx) : 0;` passed to `layoutParagraph`. Only a **positive, non-bullet** first-line indent narrows the line — a hanging (negative) indent is the bullet's gutter, not a text-width reduction (`Math.max(0,…)=0`), and the `!hasBullet` gate matches `textXOffset`.

## Consistency / safety

For a positive non-bullet first-line indent, the first line's wrap budget is now `textMaxW - indentPx`, which equals the draw region `textMaxW - textXOffset` — the overrun is gone, and the layout now agrees with `willTextOverflow`. Bulleted paragraphs, continuation lines, and the no-indent case are byte-identical (`firstLineIndentPx = 0`); all other `layoutParagraph` callers default to 0.

## Verification

- New test `firstline-indent-wrap.test.ts` (mock-ctx, exported `layoutParagraph`): with a positive `firstLineIndentPx` the first line packs **fewer** tokens (wraps earlier) and stays within `maxWidthPx - firstLineIndentPx`; continuation lines still fill to `maxWidthPx`; default/0 is byte-identical.
- Full pptx vitest suite **106 passed** (incl. latin-nonstarter-wrap / cjk-wrap / justify — no wrap regressions); pptx typecheck clean. Renderer-only change (no Rust/WASM).
- No PDF/VRT: no local pptx sample authors a positive body first-line `indent` that wraps on line 1 (samples gitignored); verification is unit-test-based + the no-op invariant for the untouched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)