### PR TITLE
fix(docx): left-align a justified line ended by a manual <w:br/> (§17.18.44 + §17.3.3.1)

### DIFF
--- a/packages/docx/src/justify-line-break.test.ts
+++ b/packages/docx/src/justify-line-break.test.ts
@@ -67,11 +67,13 @@ function textRun(text: string): DocxTextRun {
 
 type DocRun = DocParagraph['runs'][number];
 
-/** A `both`-justified paragraph: a short run, a MANUAL line break, then a long
- *  run. The first line (the short run) ends at the break — it must NOT justify. */
-function breakPara(): BodyElement {
+/** A justified paragraph: a short run, a MANUAL line break, then a long run.
+ *  The first line (the short run) ends at the break. For `both` it must NOT
+ *  justify (logical line end → left-aligned); for `distribute` it STILL gets
+ *  filled to the margin (§17.18.44, see the distribute test below). */
+function breakPara(alignment: DocParagraph['alignment'] = 'both'): BodyElement {
   const p: DocParagraph = {
-    alignment: 'both',
+    alignment,
     indentLeft: 0, indentRight: 0, indentFirst: 0,
     spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
     runs: [
@@ -136,6 +138,45 @@ describe('justified paragraph — a line ended by a manual <w:br/> is left-align
     // Inter-glyph advances stay at the natural pitch (~FONT_PX), not spread wide.
     for (let i = 1; i < line.length; i++) {
       expect(line[i].x - line[i - 1].x).toBeLessThan(FONT_PX * 1.5);
+    }
+  });
+
+  // ECMA-376 §17.18.44 (ST_Jc): `distribute` justifies EVERY line — inter-word
+  // AND inter-character — including the paragraph's final line. So unlike `both`
+  // (which leaves a logical line end left-aligned), a `distribute` line that ends
+  // at a manual `<w:br/>` is STILL stretched to the margin. The renderer encodes
+  // this as the `stretchLastLine = (alignment === 'distribute')` carve-out:
+  //   applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)
+  // This test guards that carve-out: with the SAME content as the `both` case
+  // above, the break-terminated first line must spread toward the right margin.
+  it('still stretches the break-terminated first line under distribute', async () => {
+    const calls = await render([breakPara('distribute')], section());
+    expect(calls.length).toBeGreaterThan(0);
+
+    const byY = new Map<number, { text: string; x: number }[]>();
+    for (const c of calls) {
+      const key = Math.round(c.y);
+      (byY.get(key) ?? byY.set(key, []).get(key)!).push(c);
+    }
+    const firstY = Math.min(...byY.keys());
+    const line = byY.get(firstY)!.slice().sort((p, q) => p.x - q.x);
+
+    // Same first line "ああああ" (4 glyphs) ended by the break.
+    expect(line.length).toBe(4);
+    expect(line[0].x).toBeLessThan(FONT_PX); // still starts at the left margin
+
+    // Stretched: the last glyph is pushed FAR past its natural end (4 × FONT_PX
+    // = 80px) toward the ~210px right margin. Observed last-glyph x is ~190px
+    // (the 4th of 4 glyphs spread across the ~210px line, cell pitch ~63px).
+    // Threshold 120 sits well above the natural 80px and well below the observed
+    // 190px, so it robustly distinguishes "stretched" from "natural width".
+    const naturalRight = 4 * FONT_PX; // 80px
+    expect(line[3].x).toBeGreaterThan(120);
+    expect(line[3].x).toBeGreaterThan(naturalRight);
+    // Inter-glyph advances are spread WIDE (well beyond the natural pitch),
+    // confirming inter-character distribution on the break-terminated line.
+    for (let i = 1; i < line.length; i++) {
+      expect(line[i].x - line[i - 1].x).toBeGreaterThan(FONT_PX * 1.5);
     }
   });
 });

--- a/packages/docx/src/justify-line-break.test.ts
+++ b/packages/docx/src/justify-line-break.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.18.44 (ST_Jc `both`) + §17.3.3.1 (`<w:br>` text-wrapping break):
+// a line terminated by a MANUAL line break is the end of a logical line and is
+// LEFT-aligned (not stretched) in a justified paragraph — exactly like the
+// paragraph's final line. Word does this; sample-16 is one giant `both`-justified
+// paragraph whose items are separated by `<w:br/>`, and each item's last line
+// (e.g. "…インデントなし。") renders left-aligned in Word but was stretched
+// (sparse) by us because the renderer only un-justified the paragraph's TRUE last
+// line (`li === lines.length - 1`), not lines ending at a break.
+
+const FONT_PX = 20; // glyph advance per CJK char in the stub (scale = 1)
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; x: number; y: number }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fillTextCalls: { text: string; x: number; y: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) { fillTextCalls.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+/** A `both`-justified paragraph: a short run, a MANUAL line break, then a long
+ *  run. The first line (the short run) ends at the break — it must NOT justify. */
+function breakPara(): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'both',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [
+      { type: 'text', ...textRun('ああああ') } as DocRun,
+      { type: 'break', breakType: 'line' } as DocRun,
+      { type: 'text', ...textRun('いいいいいいいいいいいいいいいい') } as DocRun,
+    ],
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(): SectionProps {
+  return {
+    pageWidth: 210, pageHeight: 400,
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    // Active char grid so every full-width glyph is drawn individually → one
+    // fillText per glyph, letting us read the realised inter-glyph pitch.
+    // Cell = 20 + (-2048/4096) = 19.5px; availW 210 → 10 cells fit.
+    docGridType: 'linesAndChars', docGridLinePitch: 20, docGridCharSpace: -2048,
+  } as SectionProps;
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(body: BodyElement[], sec: SectionProps) {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, { dpr: 1, width: sec.pageWidth });
+  return fillTextCalls;
+}
+
+describe('justified paragraph — a line ended by a manual <w:br/> is left-aligned (§17.18.44 + §17.3.3.1)', () => {
+  it('does not stretch the break-terminated first line', async () => {
+    const calls = await render([breakPara()], section());
+    expect(calls.length).toBeGreaterThan(0);
+
+    // Group glyphs by baseline y; the first (top) line is the break-terminated one.
+    const byY = new Map<number, { text: string; x: number }[]>();
+    for (const c of calls) {
+      const key = Math.round(c.y);
+      (byY.get(key) ?? byY.set(key, []).get(key)!).push(c);
+    }
+    const firstY = Math.min(...byY.keys());
+    const line = byY.get(firstY)!.slice().sort((p, q) => p.x - q.x);
+
+    // The first line is "ああああ" (4 glyphs) ended by the break.
+    expect(line.length).toBe(4);
+
+    // Left-aligned: it starts at the margin and ends at its NATURAL width
+    // (≈ 4 × FONT_PX), NOT stretched toward the 210px right margin.
+    expect(line[0].x).toBeLessThan(FONT_PX); // starts at the left margin
+    const naturalRight = 4 * FONT_PX;
+    expect(line[3].x).toBeLessThan(naturalRight); // last glyph near natural end
+    // Inter-glyph advances stay at the natural pitch (~FONT_PX), not spread wide.
+    for (let i = 1; i < line.length; i++) {
+      expect(line[i].x - line[i - 1].x).toBeLessThan(FONT_PX * 1.5);
+    }
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4130,7 +4130,12 @@ function renderParagraph(
 
     const lineWidth = line.segments.reduce((s, seg) => s + seg.measuredWidth, 0);
     const lineSlack = effAvailW - (x - lineLeft) - lineWidth;
-    const applyJustify = isJustified && (!isLastLine || stretchLastLine);
+    // §17.18.44: a `both` line justifies UNLESS it is the paragraph's true last
+    // line OR ends at a manual `<w:br/>` (§17.3.3.1) — both terminate a logical
+    // line and are left-aligned. `distribute` (stretchLastLine) still spreads
+    // every line, including these.
+    const endsLogicalLine = isLastLine || (line.endsWithBreak ?? false);
+    const applyJustify = isJustified && (!endsLogicalLine || stretchLastLine);
     let alignOffset = 0;
     // ECMA-376 §22.1.2.88 `m:jc` / §22.1.2.30 `m:defJc` — a display equation's
     // justification is independent of the paragraph's text alignment. When this
@@ -4743,6 +4748,11 @@ interface LayoutLine {
   /** Set when at least one segment on this line carries a ruby annotation —
    *  enables docGrid pitch snapping in lineBoxHeight. */
   hasRuby?: boolean;
+  /** ECMA-376 §17.3.3.1 — this line is terminated by a MANUAL line break
+   *  (`<w:br w:type="textWrapping"/>`). In a justified (`both`) paragraph it is
+   *  the end of a logical line and must be left-aligned, not stretched — exactly
+   *  like the paragraph's final line (§17.18.44). */
+  endsWithBreak?: boolean;
 }
 
 /** Additional context passed to layoutLines so it can honor floats on the current page. */
@@ -5385,7 +5395,7 @@ function layoutLines(
   const availW = () => lineMaxWidth - (isFirst ? firstIndent : 0);
 
   let lineHasRuby = false;
-  const flush = (forceHeight?: number) => {
+  const flush = (forceHeight?: number, brTerminated = false) => {
     const h = forceHeight !== undefined ? forceHeight : (lineHeight || 10);
     // If the line has no measured content (empty/line-break line), synthesize
     // stable ascent/descent from the effective font size so wrap/baseline math
@@ -5403,6 +5413,7 @@ function layoutLines(
       availWidth: lineMaxWidth,
       topY: wrapCtx ? currentLineTopY : undefined,
       hasRuby: lineHasRuby,
+      endsWithBreak: brTerminated,
     });
     if (wrapCtx) {
       currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle);
@@ -5530,7 +5541,9 @@ function layoutLines(
 
     // ── Line-break sentinel ──────────────────────────────
     if ('lineBreak' in seg) {
-      flush(seg.fontSize);
+      // The line being flushed ends at a MANUAL break (§17.3.3.1) — mark it so a
+      // justified paragraph left-aligns it like its final line (§17.18.44).
+      flush(seg.fontSize, true);
       trailingBreakFontSize = seg.fontSize;
       continue;
     }


### PR DESCRIPTION
## Symptom (sample-16)

In sample-16, the item "(1) スタイル名：…MS P明朝9p。行間固定値14p。インデントなし。" renders with its **last line ("インデントなし。") stretched** — characters spread across the column (sparse). Word shows it **left-aligned**.

## Root cause

sample-16's entire "(1)…(11)…" block is **one paragraph** whose effective alignment is `both` (justify) via **docDefaults `<w:jc w:val="both"/>`** (afe→a0/Normal→docDefaults), and whose items are separated by **13 `<w:br/>` manual line breaks** (one right after "インデントなし。").

The renderer un-justified only the paragraph's **true** last line (`li === lines.length - 1`). Every line terminated by a manual break is mid-paragraph, so it got justified — but in Word a line ended by a `<w:br/>` (text-wrapping break, §17.3.3.1) is the end of a logical line and is **left-aligned**, exactly like the paragraph's final line (§17.18.44).

## Fix

- `LayoutLine` gains `endsWithBreak`; `flush()` (the sole line emitter) takes a `brTerminated` flag, set `true` at the `lineBreak` sentinel in `layoutLines`.
- The justify gate becomes `endsLogicalLine = isLastLine || line.endsWithBreak; applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)`.
- `distribute` (均等割り付け, `stretchLastLine`) still spreads every line including break-terminated ones; normal wrapped lines and the paragraph's true last line are unchanged.

## Verification

- New `justify-line-break.test.ts` (recording-canvas, mirrors `cjk-justify-last-segment.test.ts`): a `both` paragraph `ああああ<br>いい…` — **Red**: the break line's last glyph sat at x≈190 (stretched to the 210px margin); **Green**: it sits at the natural ~58px (left-aligned), inter-glyph advances at grid pitch.
- Full docx vitest **310 passed** (incl. the CJK-justify / glued-nonstarter regressions — normal justify intact). Typecheck clean. Renderer-only (no parser/WASM).
- Root cause cross-checked against the XML (docDefaults `jc=both`; `<w:br/>` after "インデントなし。") and the Word PDF ground truth.

> Opened for review — **not merged** (per the requester asking to "確認").

🤖 Generated with [Claude Code](https://claude.com/claude-code)