### PR TITLE
fix(pptx): left-align a justified line ended by a manual <a:br> (§20.1.10.59 + §21.1.2.2.1)

### DIFF
--- a/packages/pptx/src/justify-line-break.test.ts
+++ b/packages/pptx/src/justify-line-break.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// ECMA-376 §20.1.10.59 (ST_TextAlignType `just`) + §21.1.2.2.1 (`a:br`): a line
+// terminated by a MANUAL line break is the end of a logical line and is
+// LEFT-aligned in a justified paragraph — exactly like the paragraph's final
+// line (DrawingML `just` leaves the last line natural). PowerPoint does this.
+//
+// Regression guard: the renderer un-justified only the paragraph's TRUE last
+// line (`isLast = i === lines.length - 1`), so a `<a:br>`-terminated non-last
+// line in a `just` paragraph was stretched (sparse). The pptx leg of docx #623.
+
+const SCALE = 1 / 12700; // emuToPx(emu, scale) = emu * scale ⇒ 1pt → 1px
+
+function mockCtx() {
+  const texts: Array<{ text: string; x: number; y: number }> = [];
+  let fillStyle = ''; let font = ''; let direction: CanvasDirection = 'ltr';
+  const ctx = {
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get font() { return font; }, set font(v: string) { font = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    // 10px advance per glyph (font size ignored) → predictable line widths.
+    measureText: (s: string) => ({
+      width: [...s].length * 10, actualBoundingBoxAscent: 8, actualBoundingBoxDescent: 2,
+    }),
+    fillText: (t: string, x: number, y: number) => texts.push({ text: t, x, y }),
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    measureTextWidth: undefined,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Arial',
+  };
+}
+const brk = { type: 'break' } as unknown as TextRunData;
+
+function justBody(runs: TextRunData[]): TextBody {
+  const para: Paragraph = {
+    alignment: 'just',
+    marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops: [], eaLnBrk: true, runs,
+  } as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: 20,
+    defaultBold: null, defaultItalic: null,
+    lIns: 91440, rIns: 91440, tIns: 45720, bIns: 45720,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  };
+}
+
+describe('pptx justify — a line ended by a manual <a:br> is left-aligned (§20.1.10.59 + §21.1.2.2.1)', () => {
+  it('does not stretch the break-terminated first line of a `just` paragraph', () => {
+    const { ctx, texts } = mockCtx();
+    // Box 200px wide; lIns/rIns = 91440 EMU = 7.2px each ⇒ availW ≈ 185.6px.
+    // Line 1 = "ああああ" (4 CJK glyphs, natural 40px) ended by the break; line 2
+    // holds the rest, so line 1 is NOT the paragraph's last line.
+    renderTextBody(ctx, justBody([run('ああああ'), brk, run('いいいいいいいい')]), 0, 0, 200, 200, SCALE);
+    expect(texts.length).toBeGreaterThan(0);
+
+    // First (top) line by baseline y.
+    const byY = new Map<number, { text: string; x: number }[]>();
+    for (const c of texts) {
+      const key = Math.round(c.y);
+      (byY.get(key) ?? byY.set(key, []).get(key)!).push(c);
+    }
+    const firstY = Math.min(...byY.keys());
+    const line = byY.get(firstY)!;
+
+    // Left-aligned: the line's glyphs stay near their NATURAL extent (≤ ~40px),
+    // NOT stretched toward the ~185px right margin.
+    const maxX = Math.max(...line.map((c) => c.x));
+    expect(maxX).toBeLessThan(60);
+  });
+});

--- a/packages/pptx/src/justify-line-break.test.ts
+++ b/packages/pptx/src/justify-line-break.test.ts
@@ -42,9 +42,9 @@ function run(text: string): TextRunData {
 }
 const brk = { type: 'break' } as unknown as TextRunData;
 
-function justBody(runs: TextRunData[]): TextBody {
+function bodyWith(alignment: 'just' | 'dist', runs: TextRunData[]): TextBody {
   const para: Paragraph = {
-    alignment: 'just',
+    alignment,
     marL: 0, marR: 0, indent: 0,
     spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
     bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
@@ -57,6 +57,9 @@ function justBody(runs: TextRunData[]): TextBody {
     wrap: 'square', vert: 'horz', autoFit: 'none',
   };
 }
+
+const justBody = (runs: TextRunData[]): TextBody => bodyWith('just', runs);
+const distBody = (runs: TextRunData[]): TextBody => bodyWith('dist', runs);
 
 describe('pptx justify — a line ended by a manual <a:br> is left-aligned (§20.1.10.59 + §21.1.2.2.1)', () => {
   it('does not stretch the break-terminated first line of a `just` paragraph', () => {
@@ -80,5 +83,38 @@ describe('pptx justify — a line ended by a manual <a:br> is left-aligned (§20
     // NOT stretched toward the ~185px right margin.
     const maxX = Math.max(...line.map((c) => c.x));
     expect(maxX).toBeLessThan(60);
+  });
+
+  // The OPPOSITE policy for `dist`/`thaiDist` (均等割り付け): ECMA-376 §20.1.10.59
+  // says `dist` "distributes the text words across an entire text line", i.e. it
+  // justifies EVERY line — the last line and a manual-break-terminated line
+  // included — whereas `just` leaves those logical-line ends natural. Per
+  // §21.1.2.2.1, an `<a:br>` ends a logical line; the renderer still passes
+  // `endsLogicalLine` to `justifyLine`, but `justifyLine` suppresses ONLY `just`
+  // (`mode === 'just' && isLastLine`). So under `dist` the break-terminated line
+  // MUST stay filled to the right margin. This guards that carve-out, which would
+  // silently regress if the suppression were widened to `if (isLastLine)`.
+  it('still stretches the break-terminated first line of a `dist` paragraph', () => {
+    const { ctx, texts } = mockCtx();
+    // Identical geometry to the `just` case above (box 200px, availW ≈ 185.6px),
+    // only the alignment differs.
+    renderTextBody(ctx, distBody([run('ああああ'), brk, run('いいいいいいいい')]), 0, 0, 200, 200, SCALE);
+    expect(texts.length).toBeGreaterThan(0);
+
+    const byY = new Map<number, { text: string; x: number }[]>();
+    for (const c of texts) {
+      const key = Math.round(c.y);
+      (byY.get(key) ?? byY.set(key, []).get(key)!).push(c);
+    }
+    const firstY = Math.min(...byY.keys());
+    const line = byY.get(firstY)!;
+
+    // Filled: the 4-glyph line ("ああああ", natural extent ~40px) is spread toward
+    // the ~185px margin, so its last glyph sits well to the right. The observed
+    // stretched maxX is ~182.8px (≈ the right margin); 120 is a comfortable floor
+    // below that yet far above both the natural ~40px and the `just` carve-out's
+    // < 60px assertion — it cannot pass unless `dist` actually filled the line.
+    const maxX = Math.max(...line.map((c) => c.x));
+    expect(maxX).toBeGreaterThan(120);
   });
 });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -441,6 +441,11 @@ interface LayoutLine {
     algn: string;
     segments: LayoutSegment[];
   };
+  /** ECMA-376 §21.1.2.2.1 — this line is terminated by a MANUAL line break
+   *  (`<a:br>`). In a `just` paragraph it is the end of a logical line and is
+   *  left-aligned, not stretched — like the paragraph's last line (§20.1.10.59).
+   *  `dist`/`thaiDist` still fill every line, including these. */
+  endsWithBreak?: boolean;
 }
 
 /**
@@ -685,7 +690,8 @@ export function layoutParagraph(
   let tabActive = false;
   let tabStopPx = 0;   // position of tab stop from text area left (px)
 
-  const newLine = () => {
+  const newLine = (endsWithBreak = false) => {
+    if (endsWithBreak) currentLine.endsWithBreak = true;
     lines.push(currentLine);
     currentLine = { segments: [] };
     lineW = 0;
@@ -806,7 +812,9 @@ export function layoutParagraph(
 
   for (const run of para.runs) {
     if (run.type === 'break') {
-      newLine();
+      // The line being closed ends at a MANUAL break (§21.1.2.2.1) — mark it so
+      // a `just` paragraph left-aligns it like its last line (§20.1.10.59).
+      newLine(true);
       continue;
     }
 
@@ -2460,8 +2468,12 @@ export function renderTextBody(
     // justifying it would spread that text across the whole column and overlap
     // the tab-aligned remainder drawn after this loop. Skip justify for it.
     const hasTabStop = !!line.tabStop && line.tabStop.segments.length > 0;
+    // A `just` line ended by a manual <a:br> is left-aligned like the last line
+    // (§20.1.10.59 + §21.1.2.2.1); `dist` ignores this and fills every line
+    // (justifyLine only suppresses the last line for `just`).
+    const endsLogicalLine = isLastLine || (line.endsWithBreak ?? false);
     const drawSegs = justifyMode && !paraNeedsBidi && !hasTabStop
-      ? justifyLine(line.segments, textMaxW - textXOffset, lineWidth, justifyMode, isLastLine)
+      ? justifyLine(line.segments, textMaxW - textXOffset, lineWidth, justifyMode, endsLogicalLine)
       : null;
     const segs: (LayoutSegment & Partial<Justified>)[] = drawSegs ?? line.segments;
 


### PR DESCRIPTION
> **Note for the PPTX session:** touches `packages/pptx/src/renderer.ts` (text layout/justify) only. Opened for review — **not merged** (per the requester's choice). This is the pptx leg of docx #623.

## Bug

In a `just` paragraph, the renderer un-justified only the paragraph's **true** last line (`isLast = i === lines.length - 1`). A line terminated by a **manual line break (`<a:br>`)** is also the end of a logical line and is **left-aligned** in PowerPoint (DrawingML `just` leaves the last line natural, §20.1.10.59) — but we stretched it (sparse). Same shape as the docx bug fixed in #623.

`layoutParagraph` already starts a new line at `<a:br>` (`if (run.type === 'break') newLine()`) but didn't mark it; the draw loop passed only `isLastLine` to `justifyLine`.

## Fix

- `LayoutLine` gains `endsWithBreak`; `newLine(endsWithBreak=false)` sets it; the `<a:br>` handler calls `newLine(true)`.
- The draw loop passes `endsLogicalLine = isLastLine || line.endsWithBreak` to `justifyLine` (in place of `isLastLine`).
- `justifyLine` only suppresses the last line for `just`/`justLow` (`if (mode === 'just' && isLastLine) return null`), so `dist`/`thaiDist` (均等割り付け) still fill **every** line, including break-terminated ones — matching docx's `distribute`/`stretchLastLine` carve-out. `marker`/`textXOffset`/RTL paths are untouched (the change is confined to the justify gate).

## Verification

- New `justify-line-break.test.ts` (drives `renderTextBody` with a recording ctx, mirrors `bullet-image.test.ts`): a `just` paragraph `ああああ<a:br>いい…` — **Red**: the break line's glyphs reached x≈182.8 (stretched to the ~185px margin); **Green**: max x < 60 (left-aligned at the natural extent).
- Full pptx vitest **104 passed** (incl. `text-justify` regressions — `just`/`dist` last-line behavior intact). Typecheck clean. Renderer-only (no parser/WASM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)