### PR TITLE
fix(pptx): unify the first-line indent across measure / wrap / draw (§21.1.2.2.7)

### DIFF
--- a/packages/pptx/src/firstline-indent-autofit.test.ts
+++ b/packages/pptx/src/firstline-indent-autofit.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody, naturalWidthExceedsBbox } from './renderer.js';
+import type { TextBody, Paragraph, Bullet } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// ECMA-376 §21.1.2.2.7 (a:pPr @indent): the first-line indent is applied to the
+// FIRST line only. The SAME amount must be used by all three code paths that
+// consume it — the spAutoFit overflow MEASUREMENT (`naturalWidthExceedsBbox`),
+// the wrap budget (`layoutParagraph`/`lineMaxW`), and the DRAW-side first-line
+// offset (`textXOffset`) — otherwise they disagree:
+//
+//  1. A BULLETED paragraph's first line is NOT narrowed by `indent` (the gutter
+//     is handled by the bullet/textX geometry). `naturalWidthExceedsBbox` used
+//     to subtract `Math.max(0, indentPx)` UNCONDITIONALLY — never checking
+//     `hasBullet` — so it measured a narrower box for a bulleted paragraph than
+//     the wrap/draw passes actually use. (End-to-end this happens to leave the
+//     rendered line count unchanged — `doWrap` only alters output when some
+//     paragraph genuinely wraps, which trips the consistent measurement anyway
+//     — but the measurement's *contract* was wrong, so the three expressions
+//     could drift apart in the future. The fix makes them one shared helper.)
+//  2. For a NEGATIVE non-bullet indent the wrap pass clamps to 0 (full width),
+//     but the draw side honored the raw negative `indentPx`, shifting the first
+//     line left of marL and widening its centre/justify region. Draw and wrap
+//     must agree: a negative non-bullet first-line indent is clamped to 0
+//     everywhere (we do not extend the first line into the marL gutter).
+
+const SCALE = 1 / 12700; // emuToPx(emu) = emu * scale ⇒ 1pt → 1px
+const emu = (px: number) => Math.round(px * 12700); // px → EMU at this scale
+const RC = { themeMajorFont: null, themeMinorFont: null, dpr: 1 };
+
+function mockCtx() {
+  const texts: Array<{ text: string; x: number; y: number }> = [];
+  let fillStyle = ''; let font = ''; let direction: CanvasDirection = 'ltr';
+  const ctx = {
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get font() { return font; }, set font(v: string) { font = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    // 10px advance per code point (font size ignored) → predictable line widths.
+    measureText: (s: string) => ({
+      width: [...s].length * 10, actualBoundingBoxAscent: 8, actualBoundingBoxDescent: 2,
+    }),
+    fillText: (t: string, x: number, y: number) => texts.push({ text: t, x, y }),
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    measureTextWidth: undefined,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Arial',
+  };
+}
+
+const charBullet: Bullet = { type: 'char', char: '•', color: null, sizePct: null, fontFamily: null };
+const noBullet: Bullet = { type: 'none' };
+
+function makePara(opts: {
+  runs: TextRunData[];
+  indent?: number; // EMU
+  bullet?: Bullet;
+  alignment?: Paragraph['alignment'];
+}): Paragraph {
+  return {
+    alignment: opts.alignment ?? 'l',
+    marL: 0, marR: 0, indent: opts.indent ?? 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: opts.bullet ?? noBullet, defFontSize: null, defColor: null, defBold: null,
+    defItalic: null, defFontFamily: null, tabStops: [], eaLnBrk: true, runs: opts.runs,
+  } as Paragraph;
+}
+
+function makeBody(para: Paragraph, over: Partial<TextBody> = {}): TextBody {
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: 20,
+    defaultBold: null, defaultItalic: null,
+    lIns: 91440, rIns: 91440, tIns: 45720, bIns: 45720, // 7.2px insets each
+    wrap: 'square', vert: 'horz', autoFit: 'none', ...over,
+  } as TextBody;
+}
+
+describe('pptx first-line indent: the measurement path ignores indent for a bulleted paragraph (§21.1.2.2.7)', () => {
+  // Box 200px wide, insets 7.2px each ⇒ full text room ≈ 185.6px.
+  // 18 glyphs (180px) fit the FULL width but NOT (185.6 − 50) = 135.6.
+  const TEXT18 = 'あ'.repeat(18);
+  const INDENT_50 = emu(50);
+  const measure = (para: Paragraph) => {
+    const { ctx } = mockCtx();
+    return naturalWidthExceedsBbox(ctx, makeBody(para), 200, 7.2, 7.2, SCALE, RC);
+  };
+
+  it('returns FALSE for a bulleted paragraph whose text fits the box without the indent', () => {
+    // A bullet does not consume first-line width, so the measurement must NOT
+    // subtract the indent: 180px ≤ 185.6px ⇒ does not overflow.
+    expect(measure(makePara({ runs: [run(TEXT18)], indent: INDENT_50, bullet: charBullet }))).toBe(false);
+  });
+
+  it('control: returns TRUE for the SAME positive indent on a NON-bullet paragraph', () => {
+    // A non-bullet positive indent legitimately eats the first line's width:
+    // 180px > 135.6px ⇒ overflows (so the bullet — not a blanket "never
+    // overflows" — is the discriminator).
+    expect(measure(makePara({ runs: [run(TEXT18)], indent: INDENT_50, bullet: noBullet }))).toBe(true);
+  });
+});
+
+describe('pptx first-line indent: the draw path matches the wrap path for a negative indent (§21.1.2.2.7)', () => {
+  it('draws a negative non-bullet first-line indent at the SAME x as indent 0 (no left shift)', () => {
+    // Short single-line text, wrap disabled so only the draw offset is in play.
+    const zero = mockCtx();
+    renderTextBody(zero.ctx, makeBody(makePara({ runs: [run('AAAA')], indent: 0 }), { wrap: 'none' }), 0, 0, 200, 200, SCALE);
+    const neg = mockCtx();
+    renderTextBody(neg.ctx, makeBody(makePara({ runs: [run('AAAA')], indent: emu(-50) }), { wrap: 'none' }), 0, 0, 200, 200, SCALE);
+
+    expect(zero.texts.length).toBeGreaterThan(0);
+    expect(neg.texts.length).toBeGreaterThan(0);
+    const firstX = (t: Array<{ x: number }>) => Math.min(...t.map((c) => c.x));
+    // Negative non-bullet indent is clamped to 0 at draw time (matching the wrap
+    // pass), so the first line starts at the same x as a zero indent — it is NOT
+    // shifted ~50px left into the marL gutter.
+    expect(firstX(neg.texts)).toBeCloseTo(firstX(zero.texts), 5);
+  });
+
+  it('still applies a POSITIVE non-bullet first-line indent at draw time (regression guard)', () => {
+    const zero = mockCtx();
+    renderTextBody(zero.ctx, makeBody(makePara({ runs: [run('AAAA')], indent: 0 }), { wrap: 'none' }), 0, 0, 200, 200, SCALE);
+    const pos = mockCtx();
+    renderTextBody(pos.ctx, makeBody(makePara({ runs: [run('AAAA')], indent: emu(50) }), { wrap: 'none' }), 0, 0, 200, 200, SCALE);
+    const firstX = (t: Array<{ x: number }>) => Math.min(...t.map((c) => c.x));
+    // A positive indent still shifts the first line right by ~50px.
+    expect(firstX(pos.texts) - firstX(zero.texts)).toBeCloseTo(50, 1);
+  });
+});

--- a/packages/pptx/src/firstline-indent-wrap.test.ts
+++ b/packages/pptx/src/firstline-indent-wrap.test.ts
@@ -8,8 +8,8 @@ import type { TextRunData } from '@silurus/ooxml-core';
 // justify region by the indent. The wrap/layout pass must reduce the FIRST
 // line's wrap budget by the same amount, otherwise the first line wraps too
 // late and overruns the right margin (marR). Continuation lines keep the full
-// width. This mirrors willTextOverflow's `textMaxW - firstLineIndent` and the
-// draw-side `textMaxW - textXOffset`, and matches xlsx PR #620.
+// width. This mirrors naturalWidthExceedsBbox's `textMaxW - firstLineIndent`
+// and the draw-side `textMaxW - textXOffset`, and matches xlsx PR #620.
 
 function mockCtx() {
   let font = '';

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -601,14 +601,19 @@ function paragraphHasBullet(para: Paragraph): boolean {
 }
 
 /** First-line indent (ECMA-376 §21.1.2.2.7 `a:pPr@indent`) resolved to the px
- *  amount the FIRST line is shifted right / narrowed by. A positive indent eats
- *  into the first line's width; a negative ("hanging") indent is the bullet's
- *  gutter, not a text-width reduction, so it is clamped to 0 — we do not extend
- *  the first line left of marL. When the paragraph HAS a bullet the gutter is
- *  handled by the bullet/textX geometry, so the first-line indent contributes
- *  nothing here. Shared by the spAutoFit measurement
- *  ({@link naturalWidthExceedsBbox}), the wrap budget ({@link layoutParagraph})
- *  and the draw-side `textXOffset`, so the three paths can never disagree. */
+ *  amount the FIRST line's TEXT is shifted right / narrowed by. A positive indent
+ *  on a non-bullet paragraph eats into the first line's width and shifts its
+ *  start right. Two cases resolve to 0:
+ *   - a BULLETED paragraph: `indent` is the marker's hanging gutter, positioned
+ *     separately by the bullet/textX geometry (`bulletX = textX + raw indentPx`),
+ *     so it does not reduce the text's first-line width here;
+ *   - a NEGATIVE indent on a NON-bullet paragraph: clamped to 0. (Known gap:
+ *     §21.1.2.2.7 would place such a first line left of marL; honoring that
+ *     leftward overhang into the marL gutter is unimplemented. Clamping keeps
+ *     the wrap budget and the draw offset in agreement rather than split-brain.)
+ *  Shared by the spAutoFit measurement ({@link naturalWidthExceedsBbox}), the
+ *  wrap budget ({@link layoutParagraph}) and the draw-side `textXOffset`, so the
+ *  three paths can never disagree. */
 function firstLineIndentPxFor(hasBullet: boolean, indentPx: number): number {
   return hasBullet ? 0 : Math.max(0, indentPx);
 }
@@ -2170,6 +2175,9 @@ export function renderTextBody(
       ? (bw - lPad - rPad - (numCol - 1) * spcColPx) / numCol
       : bw - lPad - rPad;
     const textX    = bx + lPad + marLPx;
+    // The marker seats at the RAW (signed) indent — a hanging gutter is negative,
+    // so this is deliberately NOT routed through firstLineIndentPxFor (which is
+    // the first-line TEXT shift, clamped ≥ 0). Keep them distinct.
     const bulletX  = bx + lPad + marLPx + indentPx;
     const textMaxW = colWidth - marLPx - marRPx;
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -588,6 +588,31 @@ function buildFont(bold: boolean, italic: boolean, sizePx: number, family: strin
  *
  * @param marLPx  Paragraph left margin in canvas px (used for tab stop position calculation)
  */
+/** True when the paragraph carries a leading marker (char / autoNum / picture
+ *  bullet) that occupies the hanging gutter. A picture (`blip`) bullet lives on
+ *  the PPTX-widened {@link Bullet}, so narrow via {@link asBullet} rather than
+ *  comparing the raw union member. */
+function paragraphHasBullet(para: Paragraph): boolean {
+  return (
+    para.bullet.type === 'char' ||
+    para.bullet.type === 'autoNum' ||
+    asBullet(para.bullet).type === 'blip'
+  );
+}
+
+/** First-line indent (ECMA-376 §21.1.2.2.7 `a:pPr@indent`) resolved to the px
+ *  amount the FIRST line is shifted right / narrowed by. A positive indent eats
+ *  into the first line's width; a negative ("hanging") indent is the bullet's
+ *  gutter, not a text-width reduction, so it is clamped to 0 — we do not extend
+ *  the first line left of marL. When the paragraph HAS a bullet the gutter is
+ *  handled by the bullet/textX geometry, so the first-line indent contributes
+ *  nothing here. Shared by the spAutoFit measurement
+ *  ({@link naturalWidthExceedsBbox}), the wrap budget ({@link layoutParagraph})
+ *  and the draw-side `textXOffset`, so the three paths can never disagree. */
+function firstLineIndentPxFor(hasBullet: boolean, indentPx: number): number {
+  return hasBullet ? 0 : Math.max(0, indentPx);
+}
+
 /**
  * Decide whether `<a:spAutoFit/>` should let text wrap based on the paragraphs'
  * natural single-line width. Returns true when at least one paragraph would
@@ -601,7 +626,7 @@ function buildFont(bold: boolean, italic: boolean, sizePx: number, family: strin
  * of glyphs" — and avoids over-eager wrap when a paragraph is barely wider
  * than the bbox due to font-measurement drift.
  */
-function naturalWidthExceedsBbox(
+export function naturalWidthExceedsBbox(
   ctx: CanvasRenderingContext2D,
   body: TextBody,
   bw: number,
@@ -615,10 +640,10 @@ function naturalWidthExceedsBbox(
     const marLPx = emuToPx(para.marL, scale);
     const marRPx = emuToPx(para.marR, scale);
     const indentPx = emuToPx(para.indent, scale);
-    // First-line indent eats into the available width when positive; a
-    // negative indent (hanging) is the bullet's gutter and doesn't reduce
-    // the usable text room.
-    const firstLineIndent = Math.max(0, indentPx);
+    // The first-line indent is consumed only by a NON-bullet paragraph and only
+    // when positive (firstLineIndentPxFor) — the SAME amount the wrap and draw
+    // passes use, so the measurement can't disagree with what actually renders.
+    const firstLineIndent = firstLineIndentPxFor(paragraphHasBullet(para), indentPx);
     const textMaxW = bw - lPad - rPad - marLPx - marRPx - firstLineIndent;
     let lineW = 0;
     for (const run of para.runs) {
@@ -2056,12 +2081,7 @@ export function renderTextBody(
     // indent too — otherwise the first line of a hanging-indent list starts at
     // the bullet's x and renders ON TOP of the picture (cf. the char-bullet em-
     // dash overlap noted below, and docx PR #476).
-    const hasBullet =
-      para.bullet.type === 'char' ||
-      para.bullet.type === 'autoNum' ||
-      // `blip` exists only on the PPTX-widened Bullet (the shared core type omits
-      // it), so narrow via asBullet rather than comparing the raw union member.
-      asBullet(para.bullet).type === 'blip';
+    const hasBullet = paragraphHasBullet(para);
 
     // Per ECMA-376 §21.1.2.4.13: when no buSz* is declared, the bullet takes
     // the first run's font size. Using paraDefaultFontSizePx here (the layout
@@ -2154,11 +2174,12 @@ export function renderTextBody(
     const textMaxW = colWidth - marLPx - marRPx;
 
     const maxW = doWrap ? textMaxW : Infinity;
-    // A positive first-line indent narrows ONLY the first line's wrap budget,
-    // matching the draw-side `textXOffset` (= indentPx for a non-bullet first
-    // line, §below) and willTextOverflow's measurement. A negative (hanging)
-    // indent is the bullet's gutter, not a text-width reduction → max(0, …)=0.
-    const firstLineIndentPx = !hasBullet ? Math.max(0, indentPx) : 0;
+    // A positive first-line indent narrows ONLY the first line's wrap budget
+    // (continuation lines keep the full width). firstLineIndentPxFor keeps this
+    // in lockstep with the draw-side `textXOffset` (§below) and the
+    // naturalWidthExceedsBbox measurement; a bullet's gutter / a negative
+    // (hanging) indent contribute 0.
+    const firstLineIndentPx = firstLineIndentPxFor(hasBullet, indentPx);
     const lines = layoutParagraph(ctx, para, maxW, paraDefaultFontSizePx, paraDefaultColor, scale, marLPx, bodyDefaultBold, bodyDefaultItalic, fontScale, slideNumber, rc, firstLineIndentPx);
 
     // spaceBefore/After are in hundredths of a point → convert to canvas px
@@ -2226,8 +2247,12 @@ export function renderTextBody(
       // layout body lstStyle) get pushed ~10 px below the placeholder top and
       // collide with the chart title sitting just below in the slide.
       const topGap  = isFirst && paraIdx > 0 ? spaceBeforePx : 0;
-      // Non-bullet first-line indent
-      const textXOffset = (!hasBullet && isFirst) ? indentPx : 0;
+      // Non-bullet first-line indent, clamped ≥ 0 via firstLineIndentPxFor so the
+      // draw offset matches the wrap budget and the spAutoFit measurement. A
+      // negative ("hanging") indent is NOT honored at draw time — it would shift
+      // the first line left of marL while the wrap pass keeps full width, so the
+      // two would disagree; we clamp both to 0.
+      const textXOffset = isFirst ? firstLineIndentPxFor(hasBullet, indentPx) : 0;
 
       // Picture bullets, like char/number markers, are drawn only on the
       // paragraph's first line and only when that line carries content (an


### PR DESCRIPTION
## Problem

A paragraph's `a:pPr@indent` (ECMA-376 §21.1.2.2.7) was resolved by **three slightly different expressions** in `packages/pptx/src/renderer.ts`:

1. **spAutoFit overflow measurement** (`naturalWidthExceedsBbox`) subtracted `Math.max(0, indentPx)` **unconditionally** — it never checked `hasBullet`, so it measured a narrower box for a *bulleted* paragraph than the wrap/draw passes actually use.
2. **Wrap budget** (`layoutParagraph` / `lineMaxW`, PR #622) and **draw offset** (`textXOffset`) both gated on `!hasBullet`.
3. The **draw side** used the raw `indentPx` (could be **negative** → shifted the first line left of `marL` and widened its centre/justify region), while the wrap pass clamps negatives to 0.

Flagged as a non-blocking follow-up during the multi-agent review of PR #622.

## Fix

Extract one shared helper and route all three paths through it so they can never disagree:

```ts
function firstLineIndentPxFor(hasBullet: boolean, indentPx: number): number {
  return hasBullet ? 0 : Math.max(0, indentPx);
}
```

(plus `paragraphHasBullet(para)`, replacing an inline `char || autoNum || blip` check that was duplicated).

- The **measurement** no longer narrows a bulleted paragraph by its indent.
- A **negative non-bullet first-line indent is clamped to 0 at draw time too**, matching the wrap pass — we do not extend the first line left of `marL` (honoring a leftward overhang is out of scope; clamping keeps draw and wrap in agreement, the no-regression choice).

## Behavioral scope (honest)

- The **measurement change has no observable rendering effect today**: `doWrap` only alters output when some paragraph *genuinely* wraps, and a paragraph wraps at `maxW` exactly when it trips the now-consistent measurement — so a bullet's spurious "overflow" never actually wraps anything. It was a wrong *contract* (and a drift risk), now fixed and DRY.
- The **draw-side negative-indent clamp IS observable** and is covered by a render test.

## Tests (`firstline-indent-autofit.test.ts`, mock-ctx)

- Measurement (direct contract test; `naturalWidthExceedsBbox` exported as a test seam, like `layoutParagraph`): bulleted + positive indent + text that fits the full box ⇒ `false`; **control** same indent on a non-bullet paragraph ⇒ `true`. (RED before: bullet returned `true`.)
- Draw: a **negative** non-bullet first-line indent draws at the **same x** as indent 0 (no ~50px left shift). (RED before: shifted −50px.) Plus a regression guard that a **positive** non-bullet indent still shifts the first line right.

## Verification

- `vitest`: **112 passed** (4 new; the 3 failing *files* are pre-existing Playwright `tests/visual/*.spec.ts` that vitest can't transform).
- `tsc --build`: clean for the changed files; the only remaining errors are the known gitignored `./wasm/*_parser.js` static imports across all packages (CI builds wasm).
- Renderer-only; no Rust/WASM change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)