### PR TITLE
fix(pptx): draw @spc CJK-justify pieces contiguously so 約物半角 punctuation doesn't overlap (§21.1.2.3.x)

### DIFF
--- a/packages/pptx/src/cjk-spc-justify.test.ts
+++ b/packages/pptx/src/cjk-spc-justify.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// ECMA-376 §21.1.2.3.x (rPr @spc, letter-spacing) — 約物半角 bracket overlap, the
+// pptx analog of docx PR #626 (docGrid §17.6.5).
+//
+// When a run carries @spc letter-spacing AND its text is East-Asian with an
+// opening bracket adjacent to kana/kanji, the LAYOUT measures the segment box
+// CONTEXTUALLY: `segW = measureText(seg.text) + ls·codePointCount`. The browser's
+// 約物半角 contextual shaping collapses an opening bracket "［" to half-width when
+// it is FOLLOWED by an East-Asian glyph WITHIN the measured string
+// (`measureText("［あ") < measureText("［") + measureText("あ")`).
+//
+// The bug: `drawWithFont`'s LTR @spc branch painted the segment glyph-by-glyph,
+// advancing the pen by the ISOLATED `measureText(ch) + ls` of each code point.
+// The isolated bracket measures FULL width, so the per-glyph sum OVERRAN the
+// contextual box → the segment's glyphs drifted right and the next run/piece
+// drawn at the contextual box edge overlapped the bracket's tail.
+//
+// The fix draws the whole CONTEXTUALLY-shaped string in ONE `fillText` with
+// `ctx.letterSpacing = ls`, so measure and draw shape the SAME way ⇒ no overlap,
+// measure==draw preserved, and Arabic cursive joining (the RTL path that already
+// used this) is unchanged.
+
+const FONT_PX = 20; // full-width EA glyph advance in the stub
+const SCALE = 1 / 12700; // emuToPx(emu, SCALE) = emu·SCALE; PT_TO_EMU=12700 ⇒ 1pt → 1px
+
+// East-Asian test: CJK Unified, kana, full-/half-width forms, CJK punctuation.
+const EA_RE = /[　-〿぀-ヿ㐀-鿿＀-￯]/;
+
+/** Simulate the browser's 約物半角 contextual half-width collapse of an opening
+ *  bracket "［" when it is FOLLOWED by an East-Asian glyph WITHIN the measured
+ *  string. An isolated "［" measures FULL, but "［あ" measures less than
+ *  "［" + "あ". The collapse must NOT include letterSpacing — the canvas adds ls
+ *  between glyphs of a drawn piece itself. */
+function ctxMeasure(s: string, fontPx: number): number {
+  const cps = [...s];
+  let w = 0;
+  for (let i = 0; i < cps.length; i++) {
+    const ea = EA_RE.test(cps[i + 1] ?? '');
+    w += cps[i] === '［' && ea ? fontPx / 2 : fontPx;
+  }
+  return w;
+}
+
+/** Recording 2D context. `measureText` models 約物半角 contextual collapse and is
+ *  agnostic of letterSpacing (the renderer always measures BEFORE it sets
+ *  letterSpacing). `fillText` records text + x + y AND the current letterSpacing
+ *  at call time, so a test can assert the contiguous-draw fix set
+ *  `ctx.letterSpacing = ls`. */
+function mockCtx(): {
+  ctx: CanvasRenderingContext2D;
+  texts: { text: string; x: number; y: number; letterSpacing: string }[];
+  getLetterSpacing: () => string;
+} {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const texts: { text: string; x: number; y: number; letterSpacing: string }[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: ctxMeasure(s, p),
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText: (t: string, x: number, y: number) => texts.push({ text: t, x, y, letterSpacing }),
+    strokeText: () => {},
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return {
+    ctx: ctx as unknown as CanvasRenderingContext2D,
+    texts,
+    getLetterSpacing: () => letterSpacing,
+  };
+}
+
+/** `letterSpacing` arrives in points and is scaled to px by `ls·PT_TO_EMU·SCALE`;
+ *  with SCALE = 1/12700 that is 1:1, so `letterSpacing: ls` yields `ls` px. A
+ *  distinct `color` forces a SEPARATE layout segment (the layout merges adjacent
+ *  same-style runs into one segment via `sameMeta`). */
+function run(text: string, letterSpacing?: number, color = '000000'): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color, fontFamily: 'Serif',
+    ...(letterSpacing != null ? { letterSpacing } : {}),
+  } as TextRunData;
+}
+
+function bodyWith(alignment: Paragraph['alignment'], runs: TextRunData[]): TextBody {
+  const para: Paragraph = {
+    alignment,
+    marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops: [], eaLnBrk: true, runs,
+  } as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: 20,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  };
+}
+
+type RunInfo = { text: string; inShapeX: number; w: number };
+
+function render(
+  body: TextBody,
+  boxW = 600,
+): {
+  texts: { text: string; x: number; y: number; letterSpacing: string }[];
+  runs: RunInfo[];
+  finalLetterSpacing: string;
+} {
+  const { ctx, texts, getLetterSpacing } = mockCtx();
+  const runs: RunInfo[] = [];
+  renderTextBody(
+    ctx, body, 0, 0, boxW, 400, SCALE,
+    null, 0, false, false, '#000000', undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+    (r) => runs.push({ text: r.text, inShapeX: r.inShapeX, w: r.w }),
+  );
+  return { texts, runs, finalLetterSpacing: getLetterSpacing() };
+}
+
+// Opening bracket adjacent to kana → 約物半角 collapse; 7 EA code points, one run.
+const EA_SPC = '［あ］いうえお';
+const LS = 4; // px of @spc letter-spacing (points == px at SCALE 1/12700)
+
+describe('pptx @spc CJK — 約物半角 brackets are drawn contiguously, never overlap (§21.1.2.3.x)', () => {
+  // (1) RED→GREEN core fix: a NON-justified @spc EA segment is painted by EXACTLY
+  //     ONE contiguous fillText carrying the whole string, with letterSpacing=ls.
+  //     Before the fix: 7 single-code-point fillText calls, letterSpacing '0px'.
+  it('draws the whole @spc EA segment as a single contiguous fillText with letterSpacing=ls', () => {
+    const { texts } = render(bodyWith('l', [run(EA_SPC, LS)]));
+
+    const segCalls = texts.filter((c) => c.text === EA_SPC);
+    expect(segCalls.length, 'one contiguous fillText for the @spc EA segment').toBe(1);
+
+    // No per-single-code-point isolated draw exists for this segment's glyphs.
+    const isolated = texts.filter(
+      (c) => [...c.text].length === 1 && [...EA_SPC].includes(c.text),
+    );
+    expect(isolated.length, 'no per-code-point isolated EA draws').toBe(0);
+
+    // The per-glyph advance is carried by ctx.letterSpacing (字間 spacing kept).
+    expect(segCalls[0].letterSpacing).toBe(`${LS}px`);
+  });
+
+  // (2) No-overlap / contextual abutment: the @spc EA segment is one draw at the
+  //     segment left, its reported box width is the CONTEXTUAL measure + len·ls
+  //     (bracket collapsed), and the following run abuts that edge — the bracket
+  //     tail is never overrun by the per-glyph isolated sum.
+  it('keeps measure==draw so a following run abuts the @spc EA box (no overlap)', () => {
+    // Distinct colour on the Latin run keeps it a SEPARATE segment (else the
+    // layout merges the two same-style runs into one segment).
+    const { texts, runs } = render(bodyWith('l', [run(EA_SPC, LS), run('A', LS, 'FF0000')]));
+
+    const segEA = runs.find((r) => r.text === EA_SPC)!;
+    const segLat = runs.find((r) => r.text === 'A')!;
+
+    const eaCalls = texts.filter((c) => c.text === EA_SPC);
+    expect(eaCalls.length, 'EA segment is a single draw').toBe(1);
+
+    // Reported box width = contextual measure (bracket half) + len·ls.
+    const len = [...EA_SPC].length;
+    const boxW = ctxMeasure(EA_SPC, FONT_PX) + len * LS;
+    expect(segEA.w).toBeCloseTo(boxW, 6);
+
+    // The drawn EA glyphs start at the segment left and span exactly boxW, so the
+    // next run abuts (no overlap, no gap).
+    const latCall = texts.find((c) => c.text === 'A')!;
+    expect(latCall.x).toBeCloseTo(eaCalls[0].x + boxW, 6);
+    expect(segLat.inShapeX).toBeCloseTo(segEA.inShapeX + boxW, 6);
+
+    // The buggy per-glyph isolated sum would have overrun boxW by
+    // (full − half)·bracket = FONT_PX/2; assert the EA draw never crosses the box.
+    expect(eaCalls[0].x).toBeLessThanOrEqual(latCall.x);
+  });
+
+  // (3) letterSpacing is restored after the render — the @spc set is local to the
+  //     draw and the captured-previous value (0px here) is put back.
+  it('restores letterSpacing to its initial value after rendering', () => {
+    const { finalLetterSpacing } = render(bodyWith('l', [run(EA_SPC, LS)]));
+    expect(finalLetterSpacing).toBe('0px');
+  });
+
+  // (4a) No-regression — @spc justify multi-glyph piece: a `dist` line whose CJK
+  //      brackets/kana sever into single-glyph pieces but whose embedded Latin
+  //      pair "AB" stays one piece (no inter-CJK gap between two Latin glyphs).
+  //      That multi-glyph piece must be ONE contiguous fillText with
+  //      letterSpacing=ls — NOT two isolated single-glyph draws at '0px'.
+  it('draws a multi-glyph justify piece contiguously with letterSpacing=ls (no isolated walk)', () => {
+    // "あ［AB］い": gaps at every inter-CJK boundary; A|B (Latin|Latin) opens none,
+    // so the pieces are [あ][［][AB][］][い]. Narrow box → the line is stretched.
+    const { texts } = render(bodyWith('dist', [run('あ［AB］い', LS)]), 200);
+
+    const abCalls = texts.filter((c) => c.text === 'AB');
+    expect(abCalls.length, 'the AB piece is one contiguous draw').toBe(1);
+    expect(abCalls[0].letterSpacing).toBe(`${LS}px`);
+    // No isolated A / B single-glyph draws.
+    expect(texts.filter((c) => c.text === 'A' || c.text === 'B').length).toBe(0);
+  });
+
+  // (4b) No-regression — ls==0 justify: a non-@spc CJK `dist` line still draws via
+  //      single-glyph pieces with letterSpacing left at '0px' (path unchanged).
+  it('leaves letterSpacing 0px for a non-@spc CJK justify line', () => {
+    const { texts } = render(bodyWith('dist', [run('あいうえお')]), 200);
+    const glyphs = [...'あいうえお'];
+    const pieceCalls = texts.filter((c) => glyphs.includes(c.text));
+    expect(pieceCalls.length).toBe(glyphs.length); // 5 single-glyph pieces (4 gaps + 1)
+    for (const c of pieceCalls) expect(c.letterSpacing).toBe('0px');
+    // Strictly increasing x (no overlap / scramble).
+    const xs = pieceCalls.map((c) => c.x);
+    for (let i = 1; i < xs.length; i++) expect(xs[i]).toBeGreaterThan(xs[i - 1]);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2596,23 +2596,23 @@ export function renderTextBody(
       // share it, and so the split-CJK branch below can call it per piece.
       const drawWithFont = (text: string, atX: number, op: 'fill' | 'stroke'): void => {
         const paint = op === 'fill' ? ctx.fillText.bind(ctx) : ctx.strokeText.bind(ctx);
-        if (ls > 0 && text.length > 1 && !segRtl) {
-          // Draw glyph-by-glyph so each character advance is `measure + ls`.
-          // Matches OOXML rPr @spc semantics — extra space added to each
-          // character's advance, including after the last one.
-          let cx = atX;
-          for (const ch of text) {
-            paint(ch, cx, segBaseline);
-            cx += ctx.measureText(ch).width + ls;
-          }
-        } else if (ls > 0 && text.length > 1) {
-          // RTL segment with rPr @spc: per-glyph advance would break Arabic
-          // cursive joining, so distribute the spacing via canvas letterSpacing
-          // and draw the whole shaped text in one paint call.
+        if (ls > 0 && text.length > 1) {
+          // rPr @spc (§21.1.2.3.x): distribute the per-glyph advance via canvas
+          // letterSpacing and draw the whole CONTEXTUALLY-shaped string in ONE
+          // paint. This keeps the drawn advance == the layout's contextual
+          // measure + n·ls (約物半角 contextual half-width collapse honoured, so a
+          // piece's glyphs stay aligned with its contextual `dx` origin and the
+          // next piece/run never overlaps — the pptx analog of docx PR #626), AND
+          // preserves Arabic cursive joining for RTL. (The old LTR branch summed
+          // ISOLATED measure(ch)+ls, which overran the contextual box at 約物
+          // punctuation.) Chromium's measureText adds letterSpacing after every
+          // glyph incl. the trailing one (= natural + n·ls), matching
+          // codePointCount(seg.text)·ls used by the layout's segW.
           const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+          const prev = lctx.letterSpacing;
           try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
           paint(text, atX, segBaseline);
-          try { lctx.letterSpacing = '0px'; } catch { /* ignore */ }
+          try { lctx.letterSpacing = prev; } catch { /* ignore */ }
         } else {
           paint(text, atX, segBaseline);
         }


### PR DESCRIPTION
## Problem

When a pptx run carries `rPr` `@spc` letter-spacing (§21.1.2.3.x) and its text is East-Asian with an opening bracket（［「（）adjacent to kana/kanji, the bracket's glyph and the following text **overlap** — the bracket's tail is painted over by the next piece/run.

## Root cause

`renderTextBody`'s `drawWithFont` had two `ls > 0` branches. The **LTR** one painted the segment glyph-by-glyph, advancing the pen by each code point's **ISOLATED** `measureText(ch) + ls`:

```js
let cx = atX;
for (const ch of text) { paint(ch, cx, segBaseline); cx += ctx.measureText(ch).width + ls; }
```

But the layout sizes the segment box **CONTEXTUALLY** (`segW = ctx.measureText(seg.text).width + ls·codePointCount(seg.text)`), and justified pieces' draw origins come from `justifiedPiecePositions(...)`, whose `dx` anchors to the **contextual** whole-string prefix advance. The browser's 約物半角 shaping collapses an opening bracket to half-width **only inside a multi-glyph string** (`measureText("［あ") < measureText("［") + measureText("あ")`). So the isolated per-glyph sum runs **wider** than the contextual box → the @spc segment's glyphs drift right and whatever is drawn at the contextual box edge (the next piece or run) overlaps the bracket's tail.

This is the pptx analog of **docx PR #626** (docGrid character grid, §17.6.5), which had the identical isolated-vs-contextual mismatch.

## Fix

Unify both `ls > 0` branches onto the path the **RTL** branch already used: set `ctx.letterSpacing = ls` and draw the whole **contextually-shaped** string in **one** `fillText`. Chromium's `measureText` adds letterSpacing after every glyph incl. the trailing one (= natural + n·ls), matching the `codePointCount·ls` the layout's `segW` uses, so measure == draw is preserved, 約物半角 collapse is honoured, and Arabic cursive joining (the reason the RTL branch already used letterSpacing) is unchanged. `letterSpacing` is restored to the **captured previous** value (not a hard-coded `0px`, matching #626).

The pieces loop (`justifiedPiecePositions` + `for … drawWithFont(pieceText, penX + dx, …)`) is unchanged — it already passes contextual `dx`. `measureCb` and the post-draw `ctx.measureText(seg.text)` run before/outside the set/restore, so they never see a non-zero letterSpacing.

## Tests (`packages/pptx/src/cjk-spc-justify.test.ts`)

A recording mock ctx whose `measureText` simulates 約物半角 collapse and whose `fillText` records the current `ctx.letterSpacing`:

1. **RED→GREEN core fix** — the @spc EA segment `［あ］いうえお` is **one** contiguous `fillText` carrying the whole string with `letterSpacing="4px"` (before: 7 isolated single-code-point draws at `0px`).
2. **No-overlap / abutment** — the reported box width equals the contextual measure (bracket half) + len·ls, and a following run abuts that edge.
3. **letterSpacing restored** to its initial `0px` after rendering.
4. **No-regression** — a multi-glyph justify piece (`AB` inside a CJK `dist` line) draws contiguously with `letterSpacing=ls`; and a non-@spc (`ls==0`) CJK justify line still draws via single-glyph pieces at `0px`, strictly increasing x.

RED→GREEN verified by reverting the fix (tests 1, 2, 4a fail; 3 and 4b pass independently). Full pptx unit suite: **117 passed**. typecheck: only the known gitignored `./wasm/*_parser.js` static-import errors; the changed files are clean.

## skia note

Same caveat as #626: the browser honours `ctx.letterSpacing`; headless skia-canvas may ignore it, so under skia the @spc spacing is absent but there is **no overlap** (the single contiguous paint never overruns). The product runtime is the browser.

Cross-ref: #626 (docx docGrid 約物半角).