### PR TITLE
chore(release): 0.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.69.0 — 2026-06-30
+
+Minor. A CJK text-layout fidelity pass across docx / pptx, plus indent, tab-stop,
+and paragraph-border accuracy. No public API changes; the Feature Support table is
+unchanged (all affected features were already supported — this release sharpens
+their rendering).
+
+**docx**
+
+- **CJK justify / 約物連続:** East Asian runs under a document grid and on
+  fully-distributed justified lines are now drawn as one contiguous `fillText`
+  with canvas letter-spacing, instead of one isolated draw per glyph. This honours
+  the browser's JIS X 4051 約物連続 packing (a closing-class punctuation followed
+  by an opening bracket — `：［`, `、［`, `）（` — packs ~half-em), so an opening
+  bracket no longer overruns the following glyph (§17.6.5, §17.18.44). (#626, #630)
+- **Justify line ends:** a justified (`both`) line terminated by a manual `<w:br/>`
+  is left-aligned (a logical line end), while `distribute` still fills it
+  (§17.18.44 + §17.3.3.1). A breakable CJK run glued after a Latin word is no longer
+  measured as atomic. (#618, #623)
+- **Indents:** a numbered paragraph's direct `<w:ind>` overrides the numbering
+  level per attribute (§17.9.22); a numbering level's `firstLine` keeps its sign
+  (§17.3.1.12); text-box paragraphs honour `<w:ind>` (§17.3.1.12). (#611, #612, #621)
+- **Tab stops:** parse `<w:defaultTabStop>` and compute a spec-correct,
+  margin-relative tab advance (§17.3.1.37 / §17.15.1.25). (#628)
+- **Paragraph borders / shading:** honour a paragraph's *direct* `pPr`
+  borders/shading (an `apply_direct_para` drift dropped them); merge borders
+  per-edge across the style hierarchy; an explicit nil/none edge clears an
+  inherited edge (§17.3.1.7). (#613, #617, #619)
+- **Robustness / internals:** cap paragraph paint at the laid-out line count so a
+  continuation slice never indexes a phantom line; unify `apply_direct_run` with
+  the canonical `apply_run`. (#615, #616)
+
+**pptx**
+
+- **CJK justify / @spc / 約物連続:** `@spc` (rPr letter-spacing) justify pieces,
+  `@spc` tab-stop segments, and fully-distributed justified runs are drawn
+  contiguously with canvas letter-spacing, so 約物連続 opening brackets no longer
+  overlap the next glyph (§21.1.2.3.x, §20.1.10.59). (#627, #629, #631)
+- **Justify line ends:** a justified (`just`) line ended by a manual `<a:br>` is
+  left-aligned, while `dist` / `thaiDist` still fill it (§20.1.10.59 + §21.1.2.2.1). (#624)
+- **First-line indent:** unified across the wrap measurement, wrap budget, and the
+  draw offset; a positive first-line indent narrows the first line's wrap width;
+  list levels inherit `marL` / `marR` / `indent` from the lstStyle cascade
+  (§21.1.2.2.7, §21.1.2.4.13). (#614, #622, #625)
+
+**xlsx**
+
+- **Shape text:** honour paragraph indent (`marL` / `marR` / `indent`) on
+  shape / text-box paragraphs (§21.1.2.2.7). (#620)
+
 ## 0.68.0 — 2026-06-29
 
 Minor. XLSX viewer interactions — drag-to-resize columns/rows, mouse-wheel /

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",


### PR DESCRIPTION
Release **0.69.0** — a CJK text-layout fidelity pass plus indent / tab-stop / paragraph-border accuracy. **No public API changes.**

## Scope
21 PRs since v0.68.0 (#611–#631). All are fidelity / spec-correctness fixes (plus a few parser features that sharpen already-supported behaviour), so the **Feature Support table is unchanged** (per the release procedure: "bug fix / 精度向上だけなら対応表は動かさず") and the **showcase-site API reference is unchanged** (no `*Viewer` option/method or headless-API change — verified: no `src/{viewer,index,presentation,document}.ts` change touches the public surface).

## What's in this PR
- **CHANGELOG.md** — new `## 0.69.0 — 2026-06-30` section (docx / pptx / xlsx bullets with §refs + PR numbers).
- **Version bump** — all 8 packages (`root` + core/pptx/xlsx/docx/markdown/node/vscode-extension) → `0.69.0` (inter-package deps are `workspace:*`, so no lockfile change).

## Headline changes (see CHANGELOG for the full list)
- **約物連続 (JIS X 4051) bracket packing** — docx (docGrid + justify) and pptx (@spc + tab-stop + justify) now draw CJK runs contiguously with canvas letter-spacing, so an opening bracket after a closing punctuation (`：［`) no longer overruns the next glyph. (#626, #627, #629, #630, #631)
- **Justify line ends** — a justified line ended by a manual `<w:br/>` / `<a:br>` is left-aligned; `distribute`/`dist` still fill it. (#623, #624)
- **Indents** — numbered-paragraph direct `w:ind` override, signed `firstLine`, text-box `w:ind`, pptx first-line-indent unification + lstStyle inheritance, xlsx shape-text indent. (#611, #612, #614, #620, #621, #622, #625)
- **Tab stops** — `w:defaultTabStop` parsing + spec-correct margin-relative advance. (#628)
- **Paragraph borders/shading** — direct `pPr` borders honoured, per-edge inheritance, explicit nil clears an inherited edge. (#613, #617, #619)

## Screenshots
`docs/images/{docx,pptx,xlsx}.png` are **kept** — this release has no new top-level feature and no headline visual change to the representative viewer demos; the fixes are subtle text-layout corrections, so the existing shots remain accurate.

## After merge
Tag `v0.69.0` → `deploy-pages.yml` + npm publish + VS Code Marketplace (`vsce publish`) run on the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)