### PR TITLE
docs(changelog): backtick the bare @spc in the 0.69.0 heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ their rendering).
 
 **pptx**
 
-- **CJK justify / @spc / 約物連続:** `@spc` (rPr letter-spacing) justify pieces,
+- **CJK justify / `@spc` / 約物連続:** `@spc` (rPr letter-spacing) justify pieces,
   `@spc` tab-stop segments, and fully-distributed justified runs are drawn
   contiguously with canvas letter-spacing, so 約物連続 opening brackets no longer
   overlap the next glyph (§21.1.2.3.x, §20.1.10.59). (#627, #629, #631)


### PR DESCRIPTION
The 0.69.0 CHANGELOG heading `**CJK justify / @spc / 約物連続:**` contained a **bare `@spc`**, which GitHub renders as an @-mention of an unrelated user (it showed up as a "contributor" on the v0.69.0 release). `@spc` denotes the OOXML rPr `spc` (character-spacing) attribute, not a person. Wrapped in backticks so it renders as code, not a mention.

The published **GitHub Release v0.69.0 notes were already corrected** (the `spc` references there now read `rPr \`spc\``). This PR fixes the same bare mention in the repo's `CHANGELOG.md`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)