### PR TITLE
feat(pptx,docx): line-end decorations on all callout families + retract leaders (§20.1.8.3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,7 +73,7 @@ export {
 } from './shape/custgeom-endpoints';
 export { hexToRgba, relativeLuma, autoContrastColor, resolveFill, applyStroke } from './shape/paint';
 export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/preset';
-export { drawArrowHead } from './shape/arrow';
+export { drawArrowHead, lineEndRetract, retractLineEndpoint } from './shape/arrow';
 // Shared embedded-SVG decoder (Microsoft asvg:svgBlip extension) — used by all
 // three renderers to prefer the vector original over the raster fallback.
 // Path-keyed for the lazy byte-on-demand pipeline: fetches SVG bytes via a

--- a/packages/core/src/shape/arrow.test.ts
+++ b/packages/core/src/shape/arrow.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { lineEndRetract, retractLineEndpoint } from './arrow';
+import type { ArrowEnd, Stroke } from '../types/common';
+
+const stroke: Stroke = { color: '#000000', width: 10 };
+const end = (type: string, w = 'med', len = 'med'): ArrowEnd => ({ type, w, len });
+
+describe('lineEndRetract — how far to pull the leader line back from the tip', () => {
+  // A filled decoration (triangle/stealth/diamond/oval) covers the segment from
+  // the tip back to `-len`; the line must stop there so its cap hides inside the
+  // decoration. An open `arrow` (V) and `none` leave the line running to the tip.
+  // lw = max(0.5, width·scale) = 10; med len multiplier = 6 → len = 60.
+  it('triangle / stealth / diamond / oval retract by the decoration length', () => {
+    expect(lineEndRetract(end('triangle'), stroke, 1)).toBeCloseTo(60, 5);
+    expect(lineEndRetract(end('stealth'), stroke, 1)).toBeCloseTo(60, 5);
+    expect(lineEndRetract(end('diamond'), stroke, 1)).toBeCloseTo(60, 5);
+    expect(lineEndRetract(end('oval'), stroke, 1)).toBeCloseTo(60, 5);
+  });
+
+  it('open arrow and none do not retract (line reaches the tip)', () => {
+    expect(lineEndRetract(end('arrow'), stroke, 1)).toBe(0);
+    expect(lineEndRetract(end('none'), stroke, 1)).toBe(0);
+  });
+
+  it('scales with len multiplier (lg = 8·lw) and stroke width·scale', () => {
+    expect(lineEndRetract(end('triangle', 'med', 'lg'), stroke, 1)).toBeCloseTo(80, 5);
+    expect(lineEndRetract(end('triangle', 'med', 'sm'), stroke, 1)).toBeCloseTo(40, 5);
+    // width 5, scale 2 → lw = 10 → same as above
+    expect(lineEndRetract(end('triangle'), { color: '#000', width: 5 }, 2)).toBeCloseTo(60, 5);
+  });
+});
+
+describe('retractLineEndpoint — pull a point toward its neighbour by `amount`', () => {
+  it('returns the point unchanged when amount is 0', () => {
+    expect(retractLineEndpoint({ x: 0, y: 0 }, { x: 10, y: 0 }, 0)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('moves the point toward the neighbour by `amount`', () => {
+    const p = retractLineEndpoint({ x: 0, y: 0 }, { x: 10, y: 0 }, 3);
+    expect(p.x).toBeCloseTo(3, 5);
+    expect(p.y).toBeCloseTo(0, 5);
+  });
+
+  it('does not overshoot past the neighbour', () => {
+    const p = retractLineEndpoint({ x: 0, y: 0 }, { x: 10, y: 0 }, 25);
+    expect(p.x).toBeCloseTo(10, 5);
+    expect(p.y).toBeCloseTo(0, 5);
+  });
+
+  it('works on a diagonal (length 5 → 3-4-5 triangle)', () => {
+    const p = retractLineEndpoint({ x: 0, y: 0 }, { x: 3, y: 4 }, 2.5);
+    expect(p.x).toBeCloseTo(1.5, 5);
+    expect(p.y).toBeCloseTo(2.0, 5);
+  });
+});

--- a/packages/core/src/shape/arrow.ts
+++ b/packages/core/src/shape/arrow.ts
@@ -1,6 +1,60 @@
 import type { ArrowEnd, Stroke } from '../types/common';
 import { hexToRgba } from './paint';
 
+/** A 2D point in canvas pixels. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Resolve a line-end decoration's pixel geometry. The width/length steps
+ * (sm/med/lg) are *relative* in the spec (§20.1.10.31–.32); the multipliers of
+ * line width below are calibrated against PowerPoint. `lw` is the line width in
+ * device px, `halfW` the half-span across the line, `len` the extent along it.
+ */
+function arrowGeom(
+  arrowEnd: ArrowEnd,
+  stroke: Stroke,
+  scale: number,
+): { lw: number; halfW: number; len: number } {
+  const lw = Math.max(0.5, stroke.width * scale);
+  const wMul = arrowEnd.w === 'sm' ? 4 : arrowEnd.w === 'lg' ? 8 : 6;
+  const lMul = arrowEnd.len === 'sm' ? 4 : arrowEnd.len === 'lg' ? 8 : 6;
+  return { lw, halfW: (lw * wMul) / 2, len: lw * lMul };
+}
+
+/** Decorations whose filled body covers the tip→`-len` span, so the leader line
+ *  must stop at `-len` (retract) for its cap to hide inside the shape. The open
+ *  `arrow` (a stroked V) and `none` keep the line running all the way to the tip. */
+const RETRACTING_ENDS = new Set(['triangle', 'stealth', 'diamond', 'oval']);
+
+/**
+ * How far (device px) the leader line should be pulled back from the tip so a
+ * line-end decoration's filled body hides the line's end cap. Zero for `arrow`
+ * and `none`. Matches the `len` used by {@link drawArrowHead} so the line stops
+ * exactly at the decoration's base.
+ */
+export function lineEndRetract(arrowEnd: ArrowEnd, stroke: Stroke, scale: number): number {
+  if (!RETRACTING_ENDS.has(arrowEnd.type)) return 0;
+  return arrowGeom(arrowEnd, stroke, scale).len;
+}
+
+/**
+ * Pull `p` toward its neighbour `toward` by `amount` px, clamped so it never
+ * passes the neighbour. Used to retract a polyline's terminal vertex before
+ * stroking, so a decorated end stops at the decoration's base.
+ */
+export function retractLineEndpoint(p: Point, toward: Point, amount: number): Point {
+  if (amount <= 0) return { x: p.x, y: p.y };
+  const dx = toward.x - p.x;
+  const dy = toward.y - p.y;
+  const d = Math.hypot(dx, dy);
+  if (d < 1e-9) return { x: p.x, y: p.y };
+  const t = Math.min(amount, d) / d;
+  return { x: p.x + dx * t, y: p.y + dy * t };
+}
+
 /**
  * Draw a DrawingML line-end decoration (arrow head) at `(tipX, tipY)`,
  * oriented along `angle` radians (0 = pointing right, +x axis).
@@ -25,11 +79,7 @@ export function drawArrowHead(
   scale: number,
 ): void {
   if (arrowEnd.type === 'none') return;
-  const lw = Math.max(0.5, stroke.width * scale);
-  const wMul = arrowEnd.w === 'sm' ? 4 : arrowEnd.w === 'lg' ? 8 : 6;
-  const lMul = arrowEnd.len === 'sm' ? 4 : arrowEnd.len === 'lg' ? 8 : 6;
-  const halfW = (lw * wMul) / 2;
-  const len = lw * lMul;
+  const { lw, halfW, len } = arrowGeom(arrowEnd, stroke, scale);
   const color = hexToRgba(stroke.color);
 
   ctx.save();

--- a/packages/core/src/shape/preset-geometry/index.ts
+++ b/packages/core/src/shape/preset-geometry/index.ts
@@ -167,11 +167,15 @@ export function renderPresetShape(
     }
 
     if (path.stroke && applyAndStroke) {
-      // A connector/callout's leader line is the trailing fill="none" stroke
-      // path. When the caller will re-stroke it retracted from its decorated
-      // ends (so the line stops at the arrow base), skip it here. Rect borders
-      // and accent bars (earlier paths, or fill≠"none") always stroke.
-      const isTrailingLeader = i === lastIdx && path.fill === 'none';
+      // A connector/callout's leader line is the geometry's trailing stroke
+      // path with no fill — usually fill="none", but the `line` preset's sole
+      // path uses fill:null, so treat a missing fill the same (else `line`
+      // double-strokes and its cap pokes through the arrow tip). When the
+      // caller re-strokes the leader retracted from its decorated ends (so the
+      // line stops at the arrow base), skip it here. The accent bar is also
+      // fill="none" but is spared because it is NOT the last path; rect borders
+      // (fill≠none) likewise always stroke.
+      const isTrailingLeader = i === lastIdx && (path.fill === 'none' || path.fill == null);
       if (!(opts?.skipTrailingStroke && isTrailingLeader)) {
         applyAndStroke();
       }

--- a/packages/core/src/shape/preset-geometry/index.ts
+++ b/packages/core/src/shape/preset-geometry/index.ts
@@ -106,6 +106,7 @@ export function renderPresetShape(
   baseFill: string | CanvasGradient | CanvasPattern | null,
   applyAndStroke: (() => void) | null,
   clearShadow: () => void,
+  opts?: { skipTrailingStroke?: boolean },
 ): boolean {
   const key = geom.toLowerCase();
   let def = PRESETS[key];
@@ -137,7 +138,9 @@ export function renderPresetShape(
 
   let shadowCleared = false;
 
-  for (const path of def.paths) {
+  const lastIdx = def.paths.length - 1;
+  for (let i = 0; i < def.paths.length; i++) {
+    const path = def.paths[i];
     ctx.beginPath();
     applyPresetPath(ctx, path, evaluator, x, y, w, h);
 
@@ -164,7 +167,14 @@ export function renderPresetShape(
     }
 
     if (path.stroke && applyAndStroke) {
-      applyAndStroke();
+      // A connector/callout's leader line is the trailing fill="none" stroke
+      // path. When the caller will re-stroke it retracted from its decorated
+      // ends (so the line stops at the arrow base), skip it here. Rect borders
+      // and accent bars (earlier paths, or fill≠"none") always stroke.
+      const isTrailingLeader = i === lastIdx && path.fill === 'none';
+      if (!(opts?.skipTrailingStroke && isTrailingLeader)) {
+        applyAndStroke();
+      }
     }
   }
 
@@ -172,13 +182,21 @@ export function renderPresetShape(
 }
 
 /**
- * For connector presets (straight / bent / curved), return the canvas-space
- * tip points and outgoing tangent angles at the start and end of the path.
- * Used by the renderer to place arrow heads with the correct orientation.
+ * For connector AND callout presets, return the canvas-space tip points and
+ * outgoing tangent angles at the two ends of the geometry's *leader line*
+ * (its last `<path>`). Used by the renderer to place line-end decorations
+ * (headEnd / tailEnd) with the correct orientation.
  *
- * `start.angle` is the direction **from** the path **toward** the start tip
- * (so arrow heads "headEnd" point outward); `end.angle` is the direction
- * the pen was moving as it reached the end tip.
+ * - Connectors (straight / bent / curved) have a single path, so the leader is
+ *   that path.
+ * - Callouts (callout1/2/3 and their border / accent variants) emit the leader
+ *   as the LAST path — after the text rectangle and any accent bar. callout1's
+ *   leader is a 2-point line; callout2/3 are 3-/4-point polylines whose tip is
+ *   the final vertex.
+ *
+ * `start.angle` is the direction **from** the line **toward** the attach (start)
+ * tip, so a "headEnd" decoration points outward; `end.angle` is the pen's travel
+ * direction as it reaches the tip, so a "tailEnd" decoration points outward.
  */
 export function getConnectorAnchors(
   geom: string,
@@ -187,10 +205,18 @@ export function getConnectorAnchors(
 ): {
   start: { x: number; y: number; angle: number };
   end:   { x: number; y: number; angle: number };
+  /** Every vertex of the leader polyline (m/l/C endpoints), in draw order, so
+   *  callers can retract a decorated end before re-stroking the line. */
+  vertices: Array<{ x: number; y: number }>;
 } | null {
   const def = PRESETS[geom.toLowerCase()];
   if (!def || def.paths.length === 0) return null;
-  const path = def.paths[0];
+  // The decoratable line is the geometry's LAST <path>. For a connector that is
+  // its only path; for a callout it is the leader line, which presets.json
+  // emits after the text rectangle (and, for accent variants, the accent bar).
+  // So paths[last] picks the leader for callout1/2/3 and is a no-op for the
+  // single-path connectors.
+  const path = def.paths[def.paths.length - 1];
   const evaluator = createEvaluator({ w, h, adj }, def.adj, def.gd);
   const sx = path.w != null ? w / path.w : 1;
   const sy = path.h != null ? h / path.h : 1;
@@ -202,6 +228,7 @@ export function getConnectorAnchors(
   let startTanX = 0, startTanY = 0;
   let startTanSet = false;
   let endTanX = 0, endTanY = 0;
+  const vertices: Array<{ x: number; y: number }> = [];
 
   for (const cmd of path.cmds) {
     switch (cmd[0]) {
@@ -209,6 +236,7 @@ export function getConnectorAnchors(
         penX = toAbsX(evaluator.resolve(cmd[1]));
         penY = toAbsY(evaluator.resolve(cmd[2]));
         startX = penX; startY = penY;
+        vertices.push({ x: penX, y: penY });
         break;
       }
       case 'l': {
@@ -217,6 +245,7 @@ export function getConnectorAnchors(
         if (!startTanSet) { startTanX = nx - penX; startTanY = ny - penY; startTanSet = true; }
         endTanX = nx - penX; endTanY = ny - penY;
         penX = nx; penY = ny;
+        vertices.push({ x: penX, y: penY });
         break;
       }
       case 'C': {
@@ -229,6 +258,7 @@ export function getConnectorAnchors(
         if (!startTanSet) { startTanX = c1x - penX; startTanY = c1y - penY; startTanSet = true; }
         endTanX = nx - c2x; endTanY = ny - c2y;
         penX = nx; penY = ny;
+        vertices.push({ x: penX, y: penY });
         break;
       }
     }
@@ -240,6 +270,7 @@ export function getConnectorAnchors(
   return {
     start: { x: startX, y: startY, angle: startAngle },
     end:   { x: penX,   y: penY,   angle: endAngle   },
+    vertices,
   };
 }
 

--- a/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
+++ b/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
@@ -375,4 +375,17 @@ describe('renderPresetShape — skipTrailingStroke (callout leader retract hook)
     );
     expect(c.strokes).toBe(0);
   });
+
+  it('suppresses the `line` leader, whose single path has fill=null (not "none")', () => {
+    // The `line` preset is the ONE retractable geom whose leader path carries
+    // fill:null rather than the string "none" (every connector/callout uses
+    // "none"). The skip must treat a missing fill the same, else the common
+    // "Line with arrow" double-strokes and the full-length cap pokes through.
+    const d = strokeCounter();
+    renderPresetShape(
+      d.ctx, 'line', 0, 0, 200, 100, [], null, d.stroke, () => {},
+      { skipTrailingStroke: true },
+    );
+    expect(d.strokes).toBe(0);
+  });
 });

--- a/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
+++ b/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { renderPresetShape, hasPreset, buildPresetGeometryPath } from './index';
+import {
+  renderPresetShape,
+  hasPreset,
+  buildPresetGeometryPath,
+  getConnectorAnchors,
+} from './index';
 
 /**
  * Records every path vertex the engine emits so we can assert on the resulting
@@ -248,5 +253,126 @@ describe('renderPresetShape (core preset-geometry engine)', () => {
       expect(ops).not.toContain('fill');
       expect(ops.filter((o) => o === 'stroke')).toHaveLength(1);
     });
+  });
+});
+
+describe('getConnectorAnchors — callout leader-line endpoints', () => {
+  // A callout's leader line is the LAST <path> of its presets.json definition
+  // (after the text rect and, for accent variants, the accent bar). The arrow
+  // head must decorate that leader's attach/tip ends, NOT the rectangle.
+  // ECMA-376 §20.1.9: callout1 = 2-point leader, callout2 = 3-point polyline,
+  // callout3 = 4-point polyline; the tip is the final vertex.
+  const W = 200;
+  const H = 100;
+
+  it('callout1: attach + tip come from the 2-point leader (default adj)', () => {
+    const a = getConnectorAnchors('callout1', 0, 0, W, H, []);
+    expect(a).not.toBeNull();
+    // attach = (w·adj2, h·adj1) = (-16.667, 18.75)
+    expect(a!.start.x).toBeCloseTo(-16.6666, 2);
+    expect(a!.start.y).toBeCloseTo(18.75, 2);
+    // tip = (w·adj4, h·adj3) = (-76.667, 112.5)
+    expect(a!.end.x).toBeCloseTo(-76.6666, 2);
+    expect(a!.end.y).toBeCloseTo(112.5, 2);
+    // tip tangent = travel direction of the single segment (attach → tip)
+    expect(a!.end.angle).toBeCloseTo(Math.atan2(93.75, -60), 4);
+  });
+
+  it('callout2: tip is the 3rd polyline vertex (default adj)', () => {
+    const a = getConnectorAnchors('callout2', 0, 0, W, H, []);
+    expect(a).not.toBeNull();
+    expect(a!.start.x).toBeCloseTo(-16.6666, 2);
+    expect(a!.start.y).toBeCloseTo(18.75, 2);
+    expect(a!.end.x).toBeCloseTo(-93.3334, 2);
+    expect(a!.end.y).toBeCloseTo(112.5, 2);
+    // last segment v2 → v3 = (-60, 93.75)
+    expect(a!.end.angle).toBeCloseTo(Math.atan2(93.75, -60), 4);
+  });
+
+  it('callout3: tip is the 4th polyline vertex (default adj)', () => {
+    const a = getConnectorAnchors('callout3', 0, 0, W, H, []);
+    expect(a).not.toBeNull();
+    expect(a!.end.x).toBeCloseTo(-16.6666, 2);
+    expect(a!.end.y).toBeCloseTo(112.963, 2);
+    // last segment v3 → v4 = (16.668, 12.963)
+    expect(a!.end.angle).toBeCloseTo(Math.atan2(12.963, 16.668), 3);
+  });
+
+  it('accentBorderCallout1: leader is the LAST path, not the accent bar', () => {
+    const a = getConnectorAnchors('accentbordercallout1', 0, 0, W, H, []);
+    expect(a).not.toBeNull();
+    // same leader as callout1 (adj defaults identical)
+    expect(a!.start.x).toBeCloseTo(-16.6666, 2);
+    expect(a!.end.x).toBeCloseTo(-76.6666, 2);
+    expect(a!.end.y).toBeCloseTo(112.5, 2);
+  });
+
+  it('straightConnector1: single-path connector endpoints are unchanged', () => {
+    const a = getConnectorAnchors('straightconnector1', 0, 0, W, H, []);
+    expect(a).not.toBeNull();
+    expect(a!.start.x).toBeCloseTo(0, 2);
+    expect(a!.start.y).toBeCloseTo(0, 2);
+    expect(a!.end.x).toBeCloseTo(W, 2);
+    expect(a!.end.y).toBeCloseTo(H, 2);
+  });
+
+  it('exposes the full leader polyline as `vertices` (callout1/2/3)', () => {
+    const round = (a: ReturnType<typeof getConnectorAnchors>) =>
+      a!.vertices.map((v) => [Math.round(v.x * 100) / 100, Math.round(v.y * 100) / 100]);
+    expect(round(getConnectorAnchors('callout1', 0, 0, W, H, []))).toEqual([
+      [-16.67, 18.75], [-76.67, 112.5],
+    ]);
+    expect(round(getConnectorAnchors('callout2', 0, 0, W, H, []))).toEqual([
+      [-16.67, 18.75], [-33.33, 18.75], [-93.33, 112.5],
+    ]);
+    expect(round(getConnectorAnchors('callout3', 0, 0, W, H, []))).toEqual([
+      [-16.67, 18.75], [-33.33, 18.75], [-33.33, 100], [-16.67, 112.96],
+    ]);
+  });
+
+  it('vertices on a single-path connector are just its two endpoints', () => {
+    const a = getConnectorAnchors('straightconnector1', 0, 0, W, H, []);
+    expect(a!.vertices.length).toBe(2);
+    expect(a!.vertices[0].x).toBeCloseTo(0, 2);
+    expect(a!.vertices[1].x).toBeCloseTo(W, 2);
+  });
+});
+
+describe('renderPresetShape — skipTrailingStroke (callout leader retract hook)', () => {
+  // borderCallout2 has two stroked paths: the text rectangle (fill=null) and the
+  // leader line (fill="none"). skipTrailingStroke must suppress ONLY the trailing
+  // leader stroke so the renderer can re-draw it retracted, while the rect border
+  // still paints.
+  function strokeCounter() {
+    const { ctx } = makeRecorder();
+    let strokes = 0;
+    return { ctx, stroke: () => { strokes++; }, get strokes() { return strokes; } };
+  }
+
+  it('without the flag, both the rect border and the leader stroke', () => {
+    const a = strokeCounter();
+    renderPresetShape(a.ctx, 'bordercallout2', 0, 0, 200, 100, [], '#fff', a.stroke, () => {});
+    expect(a.strokes).toBe(2);
+  });
+
+  it('with the flag, the trailing fill=none leader stroke is skipped', () => {
+    const b = strokeCounter();
+    renderPresetShape(
+      b.ctx, 'bordercallout2', 0, 0, 200, 100, [], '#fff', b.stroke, () => {},
+      { skipTrailingStroke: true },
+    );
+    expect(b.strokes).toBe(1);
+  });
+
+  it('the flag is a no-op for a single-path connector (its only path is not fill=none-after-others… it IS the leader)', () => {
+    // straightConnector1 is a single fill=none stroked path → it counts as the
+    // trailing leader, so the flag suppresses it (the connector renderer never
+    // sets the flag, so this only documents the boundary).
+    const c = strokeCounter();
+    renderPresetShape(
+      c.ctx, 'straightconnector1', 0, 0, 200, 100, [], null, c.stroke, () => {},
+      { skipTrailingStroke: true },
+    );
+    expect(c.strokes).toBe(0);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -15,6 +15,8 @@ import {
   resolveFill,
   applyStroke,
   drawArrowHead,
+  lineEndRetract,
+  retractLineEndpoint,
   getConnectorAnchors,
   mathToMathML,
   recolorSvg,
@@ -6279,6 +6281,14 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     preset.startsWith('straightconnector') ||
     preset.startsWith('bentconnector') ||
     preset.startsWith('curvedconnector');
+  // Straight / bent connectors whose leader we re-stroke retracted from filled
+  // line-end decorations (so the line stops at the arrow base). Curved
+  // connectors are excluded — their Bézier leader can't be retracted from a
+  // polyline vertex without straightening it, so they keep the preset leader.
+  const isRetractableLeader =
+    preset === 'line' ||
+    preset.startsWith('straightconnector') ||
+    preset.startsWith('bentconnector');
   if (w < 0 || h < 0) return;
   if (isLineGeom ? w === 0 && h === 0 : w === 0 || h === 0) return;
 
@@ -6345,6 +6355,10 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
       fillStyle, strokeCb,
       // docx shapes carry no shadow state, so the clear-shadow hook is a no-op.
       () => {},
+      // A retractable connector leader is re-stroked retracted below; suppress
+      // the preset engine's full-length leader stroke to avoid a double line /
+      // a cap poking through the arrow tip.
+      isRetractableLeader ? { skipTrailingStroke: true } : undefined,
     );
   } else {
     ctx.beginPath();
@@ -6383,6 +6397,25 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     );
     if (anchors) {
       ctx.setLineDash([]);
+      // Re-stroke the leader retracted from any filled decoration so the line
+      // stops at the arrow base instead of poking through its tip (Word /
+      // PowerPoint behaviour). Straight/bent only; curved keeps its preset leader.
+      if (isRetractableLeader && anchors.vertices.length >= 2) {
+        const pts = anchors.vertices.map((v) => ({ x: v.x, y: v.y }));
+        if (coreStroke.tailEnd) {
+          const r = lineEndRetract(coreStroke.tailEnd, coreStroke, scale);
+          pts[pts.length - 1] = retractLineEndpoint(pts[pts.length - 1], pts[pts.length - 2], r);
+        }
+        if (coreStroke.headEnd) {
+          const r = lineEndRetract(coreStroke.headEnd, coreStroke, scale);
+          pts[0] = retractLineEndpoint(pts[0], pts[1], r);
+        }
+        applyStroke(ctx as CanvasRenderingContext2D, coreStroke, scale);
+        ctx.beginPath();
+        ctx.moveTo(pts[0].x, pts[0].y);
+        for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+        ctx.stroke();
+      }
       if (coreStroke.tailEnd) {
         drawArrowHead(ctx as CanvasRenderingContext2D, anchors.end.x, anchors.end.y, anchors.end.angle, coreStroke.tailEnd, coreStroke, scale);
       }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -42,6 +42,8 @@ import {
   getConnectorAnchors,
   getCustGeomEndpoints,
   drawArrowHead,
+  lineEndRetract,
+  retractLineEndpoint,
   computeScene3dQuad,
   isScene3dNonIdentity,
   drawProjected,
@@ -1527,11 +1529,25 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     'curvedconnector2', 'curvedconnector3', 'curvedconnector4', 'curvedconnector5',
   ]);
 
-  // callout1 family — `<a:ln><a:headEnd|tailEnd>` decorate the line path
-  // (path 1 in presets.json), not the surrounding text rectangle (path 0).
-  const CALLOUT1_GEOMS = new Set([
-    'callout1', 'bordercallout1', 'accentcallout1', 'accentbordercallout1',
+  // callout family — `<a:ln><a:headEnd|tailEnd>` decorate the LEADER line
+  // (the geometry's last `<path>` in presets.json), not the text rectangle
+  // (path 0) or the accent bar. callout1 = 2-point leader, callout2/3 =
+  // 3-/4-point polylines; getConnectorAnchors resolves the leader's two ends
+  // for every variant, so all twelve share the connector decoration path.
+  const CALLOUT_GEOMS = new Set([
+    'callout1', 'callout2', 'callout3',
+    'bordercallout1', 'bordercallout2', 'bordercallout3',
+    'accentcallout1', 'accentcallout2', 'accentcallout3',
+    'accentbordercallout1', 'accentbordercallout2', 'accentbordercallout3',
   ]);
+
+  // A leader line we re-stroke retracted from its filled decorations: every
+  // callout plus the straight / bent (polyline) connectors. Curved connectors
+  // are excluded — their leader is a Bézier and getConnectorAnchors.vertices only
+  // captures segment endpoints, so retracting from a vertex would straighten the
+  // curve. Those keep their preset-engine leader (decoration overlap unchanged).
+  const isRetractableLeader = (g: string): boolean =>
+    CALLOUT_GEOMS.has(g) || g === 'line' || g === 'straightconnector1' || g.startsWith('bentconnector');
 
   // ── Dispatch to preset engine when possible ────────────────────────────
   // Preference order: custGeom → generic preset engine → legacy switch.
@@ -1576,6 +1592,11 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
         target, geom, x, y, w, h,
         [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
         tFill, tStroke, tClearShadow,
+        // A retractable leader (callout / straight / bent connector) is
+        // re-stroked retracted from its decorated ends in the line-end block
+        // below, so suppress the preset engine's full-length leader stroke to
+        // avoid a double line / a cap poking through the arrow tip.
+        isRetractableLeader(geom) ? { skipTrailingStroke: true } : undefined,
       );
       return;
     }
@@ -1674,16 +1695,45 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     ctx.restore();
   }
 
-  if (el.stroke && CONNECTOR_GEOMS.has(geom)) {
+  if (el.stroke && (CONNECTOR_GEOMS.has(geom) || CALLOUT_GEOMS.has(geom))) {
+    // Connectors and callouts both decorate a *leader line* whose two ends +
+    // outward tangents are resolved by getConnectorAnchors from the geometry's
+    // last `<path>` (presets.json). For a connector that is the line itself;
+    // for a callout it is the attach→tip leader (callout1 straight, callout2/3
+    // polyline). headEnd sits on the attach end, tailEnd on the tip — exactly
+    // as the `m … l …` order of the preset's leader path dictates.
     const anchors = getConnectorAnchors(geom, x, y, w, h, [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8]);
     if (anchors) {
       // ECMA-376 §20.1.8.42 — compound line styles. For straight lines /
       // connectors we re-stroke the segment with multiple parallel lines
-      // along the perpendicular of the line direction. Curved connectors
-      // fall through to the single-stroke fast path (parallel curves are
-      // a non-trivial geometric operation).
+      // along the perpendicular of the line direction. Curved connectors and
+      // callout leaders fall through to the single-stroke fast path (parallel
+      // curves / polylines are a non-trivial geometric operation).
       const cmpd = el.stroke.cmpd;
       const isStraight = geom === 'line' || geom === 'straightconnector1';
+      // Retractable leaders (callout / straight / bent connector): paintShapeBody
+      // suppressed the preset leader stroke, so re-stroke the polyline here with
+      // each decorated end pulled back by the decoration's length, so the line
+      // stops at the arrow base instead of poking through its tip (PowerPoint
+      // behaviour). Filled ends (triangle/stealth/diamond/oval) retract; open
+      // `arrow` / `none` do not (lineEndRetract → 0). A compound straight segment
+      // is drawn by drawCompoundLine below instead, so skip the retract there.
+      if (isRetractableLeader(geom) && anchors.vertices.length >= 2 && !(cmpd && isStraight)) {
+        const pts = anchors.vertices.map((v) => ({ x: v.x, y: v.y }));
+        if (el.stroke.tailEnd) {
+          const r = lineEndRetract(el.stroke.tailEnd, el.stroke, scale);
+          pts[pts.length - 1] = retractLineEndpoint(pts[pts.length - 1], pts[pts.length - 2], r);
+        }
+        if (el.stroke.headEnd) {
+          const r = lineEndRetract(el.stroke.headEnd, el.stroke, scale);
+          pts[0] = retractLineEndpoint(pts[0], pts[1], r);
+        }
+        applyStroke(ctx, el.stroke, scale);
+        ctx.beginPath();
+        ctx.moveTo(pts[0].x, pts[0].y);
+        for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+        ctx.stroke();
+      }
       if (cmpd && isStraight) {
         drawCompoundLine(ctx, anchors.start, anchors.end, el.stroke, cmpd, scale);
       }
@@ -1693,29 +1743,6 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       if (el.stroke.headEnd) {
         drawArrowHead(ctx, anchors.start.x, anchors.start.y, anchors.start.angle, el.stroke.headEnd, el.stroke, scale);
       }
-    }
-  } else if (el.stroke && CALLOUT1_GEOMS.has(geom)) {
-    // Callout1 family carries an `<a:ln>` whose head/tail decorations belong
-    // on the *line* (path 1: m,x1,y1 → l,x2,y2), not on the rectangle (path 0).
-    // ECMA-376 callout1 gd: y1=h·adj1/100000, x1=w·adj2/100000 (attach point);
-    // y2=h·adj3/100000, x2=w·adj4/100000 (tip). Tip and attach may sit
-    // outside the bbox. Compute both, then orient the head/tail along the
-    // attach→tip direction.
-    const attXf = ((el.adj2 ?? -8333) as number) / 100000;
-    const attYf = ((el.adj  ?? 18750) as number) / 100000;
-    const tipXf = ((el.adj4 ?? -38333) as number) / 100000;
-    const tipYf = ((el.adj3 ?? 112500) as number) / 100000;
-    const attX = x + attXf * w;
-    const attY = y + attYf * h;
-    const tipX = x + tipXf * w;
-    const tipY = y + tipYf * h;
-    const tailAngle = Math.atan2(tipY - attY, tipX - attX);
-    const headAngle = tailAngle + Math.PI;
-    if (el.stroke.tailEnd) {
-      drawArrowHead(ctx, tipX, tipY, tailAngle, el.stroke.tailEnd, el.stroke, scale);
-    }
-    if (el.stroke.headEnd) {
-      drawArrowHead(ctx, attX, attY, headAngle, el.stroke.headEnd, el.stroke, scale);
     }
   } else if (
     el.stroke &&


### PR DESCRIPTION
## What

DrawingML line-end decorations (`<a:headEnd>`/`<a:tailEnd>`, ECMA-376 §20.1.8.3; ST_LineEndType §20.1.10.33: none/triangle/stealth/diamond/oval/arrow) had two defects:

1. **Only the callout1 family decorated** (4 of 12 presets). callout2/3 families (`callout2/3`, `borderCallout2/3`, `accentCallout2/3`, `accentBorderCallout2/3`) had a leader line but no head/tail decoration.
2. **Decorated leaders poked through the arrow tip** — the line was stroked full-length to the tip and the decoration drawn on top, so the line cap showed past the arrow's point.

## Fixes

1. **All 12 callout families decorate.** `getConnectorAnchors` now resolves the leader from a geometry's **LAST `<path>`** (the leader line, emitted after the text rect and any accent bar in presets.json) instead of `paths[0]`. Connectors are single-path so unchanged. The pptx renderer routes all 12 callout families through the same connector decoration path.
2. **Retract the leader to the arrow base** (PowerPoint behaviour). Filled decorations (triangle/stealth/diamond/oval) pull the leader back by the decoration length so the cap hides inside the arrow; open `arrow` / `none` keep the line to the tip. Applied cross-package: pptx callouts + straight/bent connectors, docx straight/bent connectors. Curved connectors are excluded (their Bézier leader can't retract from a polyline vertex without straightening).

## Shared core

- `lineEndRetract` / `retractLineEndpoint` (pure) in `core/shape/arrow.ts`
- `getConnectorAnchors.vertices` (full leader polyline) + `renderPresetShape({ skipTrailingStroke })` to suppress the preset leader so the renderer re-strokes it retracted

## Verification

- unit: core 141 / pptx 125 / docx+xlsx 562 — all pass (new TDD: lineEndRetract, retractLineEndpoint, leader vertices, skipTrailingStroke)
- typecheck: pass
- VRT demo samples: pptx 12 / docx 8 pass, no regression
- visual (Storybook, real Canvas): callout matches PowerPoint PDF (sample-3 slides 18–21, all 5 end types incl. oval); connector retract confirmed on straight/bent

🤖 Generated with [Claude Code](https://claude.com/claude-code)