### PR TITLE
refactor(docx): extract drawParagraphLine from renderParagraph

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4192,7 +4192,76 @@ function renderParagraph(
   // overflow direction is bounded (the wrap differs by at most a line or two), so
   // all of the paragraph's text is still painted across its slices.
   const paintEnd = Math.min(sliceEnd, lines.length);
+  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft, indFirst, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
   for (let li = sliceStart; li < paintEnd; li++) {
+    drawParagraphLine(li, drawCtx);
+  }
+
+  if (para.borders && !dryRun) {
+    const textH = state.y - textAreaTopY;
+    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale, state.dpr, borderMerge);
+  }
+
+  // spaceAfter is paragraph-level; only emit it on the slice that covers
+  // the FINAL line of the paragraph (or when no slice is set at all).
+  const isFinalSlice = !lineSlice || lineSlice.end >= lines.length;
+  if (isFinalSlice) state.y += para.spaceAfter * scale;
+
+  // Anchor images are absolutely positioned — draw after inline flow.
+  // Skip this for continuation slices: anchor positioning is paragraph-relative
+  // and the first slice already painted them.
+  if (!lineSlice || lineSlice.start === 0) {
+    renderAnchorImages(para, state, paragraphStartY);
+  }
+}
+
+/** Per-line draw context for {@link drawParagraphLine}. Bundles the read-only
+ *  paragraph-scope values the line loop reads (plus `state`, mutated by
+ *  reference via `state.y`). Extracted from {@link renderParagraph} verbatim so
+ *  the per-line drawing is a single thin call; no behaviour change. */
+interface ParagraphLineDrawCtx {
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+  scale: number;
+  state: RenderState;
+  para: DocParagraph;
+  dryRun: boolean;
+  defaultColor: string;
+  fontFamilyClasses: Record<string, string>;
+  contentX: number;
+  contentW: number;
+  lines: LayoutLine[];
+  grid: DocGridCtx;
+  paraX: number;
+  firstLineX: number;
+  paraW: number;
+  indLeft: number;
+  indFirst: number;
+  baseRtl: boolean;
+  hasMarker: boolean;
+  numTab: number;
+  numBodyOffset: number;
+  markerJcShiftPx: number;
+  picBullet: { bmp: DecodedImage; w: number; h: number } | null;
+  isJustified: boolean;
+  stretchLastLine: boolean;
+  alignEdge: ReturnType<typeof resolveAlignEdge>;
+  paraNeedsBidi: boolean;
+  decimalAutoTabPx: number | null;
+  drawGridDeltaPx: number;
+  lineHForLine: (l: LayoutLine) => number;
+}
+
+/** Draws line `li` of a paragraph. Extracted from {@link renderParagraph}'s
+ *  per-line loop body verbatim (the loop simply calls this for each line);
+ *  `state.y` is advanced by reference, exactly as before. */
+function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
+  const {
+    ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses,
+    contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft,
+    indFirst, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx,
+    picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi,
+    decimalAutoTabPx, drawGridDeltaPx, lineHForLine,
+  } = c;
     const line = lines[li];
     // First-line indent and numbering prefix only apply to the paragraph's
     // ORIGINAL first line, not the first line of a continuation slice.
@@ -4759,24 +4828,6 @@ function renderParagraph(
     if (paraNeedsBidi) ctx.direction = 'ltr'; // reset for subsequent draws
 
     state.y += lineH;
-  }
-
-  if (para.borders && !dryRun) {
-    const textH = state.y - textAreaTopY;
-    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale, state.dpr, borderMerge);
-  }
-
-  // spaceAfter is paragraph-level; only emit it on the slice that covers
-  // the FINAL line of the paragraph (or when no slice is set at all).
-  const isFinalSlice = !lineSlice || lineSlice.end >= lines.length;
-  if (isFinalSlice) state.y += para.spaceAfter * scale;
-
-  // Anchor images are absolutely positioned — draw after inline flow.
-  // Skip this for continuation slices: anchor positioning is paragraph-relative
-  // and the first slice already painted them.
-  if (!lineSlice || lineSlice.start === 0) {
-    renderAnchorImages(para, state, paragraphStartY);
-  }
 }
 
 // ===== Text layout =====


### PR DESCRIPTION
## What

Second step of the in-file refactor of `packages/docx/src/renderer.ts` (follows #635). Moves `renderParagraph`'s **per-line draw loop body (~565 lines)** into a file-local helper:

```ts
function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void { ... }
```

The loop is now a 3-line call. A `ParagraphLineDrawCtx` struct bundles the **29 read-only paragraph-scope values** the body reads (plus `state`, mutated by reference via `state.y`).

## Why

`renderParagraph` drops from **846 → 282 lines** and now reads as a clear `setup → layout → draw → finalize` skeleton. A per-line drawing change (justify, numbering markers, run borders, bidi reorder, inline images/math, tab leaders) now lands in the focused 575-line `drawParagraphLine` that `grep` routes to directly, instead of being buried mid-way through `renderParagraph`.

## Behavior preservation

Pure mechanical extraction. The 565-line loop body is **byte-identical** — `git diff` shows it as unchanged context; the only `+/-` lines are the new interface, the helper signature + destructure, the `drawCtx` literal, and the 3-line call. No logic, arithmetic, condition, or control-flow change.

Verified the control flow is safe to move wholesale: the outer per-line loop body has **no** top-level `continue`/`break`/`return`. The `continue`s belong to the inner segment loop, the `return` is inside the `flushBorderGroup` closure, and the `break` is in a nested segment scan — all nested, all moved verbatim.

Checks (independently re-run):
- **Full docx suite: 54 files, 327 tests — all green.**
- **Typecheck**: zero new errors vs baseline (stash-diff; the package's pre-existing environmental errors from unbuilt `core` / gitignored wasm are unchanged, only line-number shifts).
- **Lint** (`ast-grep scan`): clean.

No visual change ⇒ no VRT/preview needed; the characterization tests assert glyph positions and stay green.

## Series

- #635 — extract `resolveNumberingMarker` (merged)
- **this** — extract `drawParagraphLine`
- next candidates: decompose `drawParagraphLine`'s inner segment loop / marker draw, then `computePages` (949L), `layoutLines` (595L).

🤖 Generated with [Claude Code](https://claude.com/claude-code)