### PR TITLE
feat(pptx): hidden-slide display modes (show/skip/dim)

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -7767,7 +7767,9 @@ fn parse_table_cell(
 
 /// `<p:sld show="0">` / `show="false"` marks a slide hidden in the slide show
 /// (ECMA-376 §19.3.1.38 `sld` / `CT_Slide` — `show`, xsd:boolean, default true).
-/// Absent or any truthy value ⇒ shown.
+/// Absent or any truthy value ⇒ shown. NB: this matches the FALSY literals —
+/// the inverse of the codebase's usual `== "1" || == "true"` truthy check —
+/// because `show` defaults to true, so a slide is hidden only on explicit false.
 fn slide_is_hidden(root: roxmltree::Node) -> bool {
     matches!(root.attribute("show"), Some("0") | Some("false"))
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -416,6 +416,10 @@ struct Slide {
     /// "threaded comments" are not yet parsed.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     comments: Vec<PptxComment>,
+    /// `<p:sld show="0">` — slide is hidden in the slide show (§19.3.1.38).
+    /// Omitted from JSON when false so existing snapshots are unchanged.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    hidden: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -7761,6 +7765,13 @@ fn parse_table_cell(
 //  Slide parser
 // ===========================
 
+/// `<p:sld show="0">` / `show="false"` marks a slide hidden in the slide show
+/// (ECMA-376 §19.3.1.38 `sld` / `CT_Slide` — `show`, xsd:boolean, default true).
+/// Absent or any truthy value ⇒ shown.
+fn slide_is_hidden(root: roxmltree::Node) -> bool {
+    matches!(root.attribute("show"), Some("0") | Some("false"))
+}
+
 // Threads the full master+layout inheritance context (per-type font sizes,
 // bullets, anchors, transforms, alignments, spacing, bold/italic/caps/color
 // maps) plus zip/theme into one slide parse; this is the inheritance chain
@@ -7866,6 +7877,7 @@ fn parse_slide(
 
     let doc = roxmltree::Document::parse(xml)?;
     let root = doc.root_element(); // <p:sld>
+    let hidden = slide_is_hidden(root);
     let c_sld = child(root, "cSld");
 
     // Background chain: slide → layout → master. Each level resolves a blip
@@ -8018,6 +8030,7 @@ fn parse_slide(
         elements,
         notes,
         comments,
+        hidden,
     })
 }
 
@@ -9437,6 +9450,24 @@ mod tests {
             w.finish().unwrap();
         }
         buf
+    }
+
+    #[test]
+    fn slide_show_attr_marks_hidden() {
+        let ns = r#"xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main""#;
+        let parse = |attr: &str| {
+            let xml = format!(r#"<p:sld {ns} {attr}><p:cSld/></p:sld>"#);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            slide_is_hidden(doc.root_element())
+        };
+        // Absent `show` ⇒ shown (default true ⇒ not hidden).
+        assert!(!parse(""));
+        // `show="0"` / `show="false"` ⇒ hidden (ECMA-376 §19.3.1.38 CT_Slide).
+        assert!(parse(r#"show="0""#));
+        assert!(parse(r#"show="false""#));
+        // Explicit truthy ⇒ shown.
+        assert!(!parse(r#"show="1""#));
+        assert!(!parse(r#"show="true""#));
     }
 
     #[test]

--- a/packages/pptx/src/dim-overlay.test.ts
+++ b/packages/pptx/src/dim-overlay.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { applyDimOverlay } from './renderer.js';
+import type { DimOptions } from './types.js';
+
+/** Recording mock 2D context: captures the ordered calls applyDimOverlay makes. */
+function mockCtx() {
+  const calls: Array<[string, ...unknown[]]> = [];
+  const ctx = {
+    save: () => calls.push(['save']),
+    restore: () => calls.push(['restore']),
+    fillRect: (x: number, y: number, w: number, h: number) => calls.push(['fillRect', x, y, w, h]),
+    set globalAlpha(v: number) { calls.push(['globalAlpha', v]); },
+    set fillStyle(v: string) { calls.push(['fillStyle', v]); },
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, calls };
+}
+
+describe('applyDimOverlay', () => {
+  it('fills the whole canvas with the dim color at the given opacity, save/restore-wrapped', () => {
+    const { ctx, calls } = mockCtx();
+    const dim: DimOptions = { color: '#ffffff', opacity: 0.6 };
+    applyDimOverlay(ctx, dim, 960, 540);
+    expect(calls).toEqual([
+      ['save'],
+      ['globalAlpha', 0.6],
+      ['fillStyle', '#ffffff'],
+      ['fillRect', 0, 0, 960, 540],
+      ['restore'],
+    ]);
+  });
+});

--- a/packages/pptx/src/hidden.test.ts
+++ b/packages/pptx/src/hidden.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { selectHidden, nextVisibleIndex, resolveVisibleIndex } from './hidden.js';
+import type { Slide } from './types.js';
+
+/** Build a slide list where `hiddenFlags[i]` toggles `Slide.hidden`. */
+function slides(hiddenFlags: boolean[]): Slide[] {
+  return hiddenFlags.map((h, i) => ({
+    index: i,
+    slideNumber: i + 1,
+    background: null,
+    elements: [],
+    ...(h ? { hidden: true } : {}),
+  }));
+}
+
+describe('selectHidden (PptxPresentation.isHidden core)', () => {
+  it('reports the hidden flag for an in-range slide', () => {
+    const s = slides([false, true, false]);
+    expect(selectHidden(s, 0)).toBe(false);
+    expect(selectHidden(s, 1)).toBe(true);
+  });
+  it('treats absent hidden as false', () => {
+    expect(selectHidden(slides([false]), 0)).toBe(false);
+  });
+  it('returns false for out-of-range / non-integer (non-clamped, like getNotes)', () => {
+    const s = slides([true]);
+    expect(selectHidden(s, -1)).toBe(false);
+    expect(selectHidden(s, 1)).toBe(false);
+    expect(selectHidden(s, 0.5)).toBe(false);
+    expect(selectHidden([], 0)).toBe(false);
+  });
+});
+
+describe('nextVisibleIndex (skip-mode sequential nav)', () => {
+  // hidden at 1 and 2; visible 0,3,4
+  const isHidden = (i: number) => i === 1 || i === 2;
+  const count = 5;
+  it('skips hidden slides going forward', () => {
+    expect(nextVisibleIndex(0, 1, isHidden, count)).toBe(3);
+  });
+  it('skips hidden slides going backward', () => {
+    expect(nextVisibleIndex(3, -1, isHidden, count)).toBe(0);
+  });
+  it('stays put when no visible slide exists in that direction', () => {
+    expect(nextVisibleIndex(4, 1, isHidden, count)).toBe(4); // nothing after 4
+    expect(nextVisibleIndex(0, -1, isHidden, count)).toBe(0); // nothing before 0
+  });
+});
+
+describe('resolveVisibleIndex (initial load / entering skip mode)', () => {
+  it('keeps the current slide when it is visible', () => {
+    expect(resolveVisibleIndex(3, (i) => i === 0, 5)).toBe(3);
+  });
+  it('advances to the next visible slide when current is hidden', () => {
+    expect(resolveVisibleIndex(0, (i) => i === 0 || i === 1, 5)).toBe(2);
+  });
+  it('falls back to the previous visible slide when none follow', () => {
+    // visible: 0,1 ; hidden: 2,3,4 ; current 4 → nearest visible before is 1
+    expect(resolveVisibleIndex(4, (i) => i >= 2, 5)).toBe(1);
+  });
+  it('returns current when every slide is hidden (skip degenerates)', () => {
+    expect(resolveVisibleIndex(2, () => true, 5)).toBe(2);
+  });
+  it('returns current on an empty deck', () => {
+    expect(resolveVisibleIndex(0, () => true, 0)).toBe(0);
+  });
+});

--- a/packages/pptx/src/hidden.ts
+++ b/packages/pptx/src/hidden.ts
@@ -1,0 +1,49 @@
+import type { Slide } from './types';
+
+/**
+ * Pure core of {@link PptxPresentation.isHidden}: whether the slide at
+ * `slideIndex` (0-based, absolute) is marked hidden. Like `selectNotes`, the
+ * index is NOT clamped — out-of-range / non-integer ⇒ `false` ("no slide here,
+ * so not hidden") rather than the nearest slide's flag.
+ */
+export function selectHidden(slides: readonly Slide[], slideIndex: number): boolean {
+  if (!Number.isInteger(slideIndex) || slideIndex < 0 || slideIndex >= slides.length) {
+    return false;
+  }
+  return slides[slideIndex].hidden ?? false;
+}
+
+/**
+ * Next visible (non-hidden) absolute slide index in `dir` (+1 forward, -1 back),
+ * searching strictly AFTER `from`. Used by {@link PptxViewer}'s `'skip'` mode for
+ * sequential navigation. Returns the found index, or `from` itself when no other
+ * visible slide exists in that direction (caller then stays put).
+ */
+export function nextVisibleIndex(
+  from: number,
+  dir: 1 | -1,
+  isHidden: (i: number) => boolean,
+  count: number,
+): number {
+  for (let i = from + dir; i >= 0 && i < count; i += dir) {
+    if (!isHidden(i)) return i;
+  }
+  return from;
+}
+
+/**
+ * Resolve which slide to show on initial load or when entering `'skip'` mode:
+ * keep `current` if visible; else the nearest visible slide AFTER it; else the
+ * nearest visible slide BEFORE it; else `current` (every slide hidden — skip
+ * degenerates, so show it anyway). All indices are absolute.
+ */
+export function resolveVisibleIndex(
+  current: number,
+  isHidden: (i: number) => boolean,
+  count: number,
+): number {
+  if (count === 0 || !isHidden(current)) return current;
+  const fwd = nextVisibleIndex(current, 1, isHidden, count);
+  if (fwd !== current) return fwd;
+  return nextVisibleIndex(current, -1, isHidden, count);
+}

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -1,4 +1,4 @@
-export { PptxViewer, type PptxViewerOptions } from './viewer';
+export { PptxViewer, type PptxViewerOptions, type HiddenSlideMode } from './viewer';
 export {
   PptxPresentation,
   type LoadOptions,

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -64,4 +64,7 @@ export type {
   // Chart model (reachable via ChartElement.series and renderChart).
   ChartModel,
   ChartSeries,
+  // Hidden-slide dimming options (reachable via RenderSlideOptions.dim /
+  // RenderSlideToBitmapOptions.dim) — the translucent overlay mechanism.
+  DimOptions,
 } from './types';

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -233,7 +233,7 @@ export class PptxPresentation {
    * (`<p:sld show="0">`, ECMA-376 §19.3.1.38). Like {@link getNotes} the index
    * is NOT clamped — out-of-range / non-integer ⇒ `false`. This is a *fact*
    * about the model; deciding what to do with a hidden slide (skip / dim) is the
-   * caller's policy (see {@link PptxViewer}'s `hiddenSlides` modes).
+   * caller's policy (see {@link PptxViewer}'s `hiddenSlideMode` modes).
    */
   isHidden(slideIndex: number): boolean {
     if (this._meta) {

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1,7 +1,8 @@
-import type { MediaElement, Presentation, WorkerRequest, WorkerResponse } from './types';
+import type { DimOptions, MediaElement, Presentation, WorkerRequest, WorkerResponse } from './types';
 import { renderSlide, dropImageBitmapCache, type TextRunCallback } from './renderer';
 import { createPresentationHandle, type PresentationHandle } from './presentation-handle';
 import { selectNotes } from './notes';
+import { selectHidden } from './hidden';
 import {
   preloadGoogleFonts,
   WorkerBridge,
@@ -44,6 +45,8 @@ export interface RenderSlideToBitmapOptions {
    * @internal
    */
   skipMediaControls?: boolean;
+  /** Translucent overlay drawn over the finished slide (hidden-slide dimming). */
+  dim?: DimOptions;
 }
 
 /** Options for rendering a single slide onto a canvas. */
@@ -60,6 +63,8 @@ export interface RenderSlideOptions {
    * its own play/pause chrome without duplication.
    */
   skipMediaControls?: boolean;
+  /** Translucent overlay drawn over the finished slide (hidden-slide dimming). */
+  dim?: DimOptions;
 }
 
 /**
@@ -223,6 +228,20 @@ export class PptxPresentation {
     return selectNotes(this._presentation?.slides ?? [], slideIndex);
   }
 
+  /**
+   * Whether the slide at `slideIndex` (0-based, absolute) is marked hidden
+   * (`<p:sld show="0">`, ECMA-376 §19.3.1.38). Like {@link getNotes} the index
+   * is NOT clamped — out-of-range / non-integer ⇒ `false`. This is a *fact*
+   * about the model; deciding what to do with a hidden slide (skip / dim) is the
+   * caller's policy (see {@link PptxViewer}'s `hiddenSlides` modes).
+   */
+  isHidden(slideIndex: number): boolean {
+    if (this._meta) {
+      return Number.isInteger(slideIndex) ? (this._meta.hidden[slideIndex] ?? false) : false;
+    }
+    return selectHidden(this._presentation?.slides ?? [], slideIndex);
+  }
+
   /** Render a slide onto the given canvas. */
   async renderSlide(
     canvas: HTMLCanvasElement | OffscreenCanvas,
@@ -254,6 +273,7 @@ export class PptxPresentation {
         fetchMedia: (path) => this.getMedia(path),
         fetchImage: this._fetchImage,
         skipMediaControls: opts.skipMediaControls,
+        dim: opts.dim,
         math: this._math,
       },
       opts.onTextRun,
@@ -280,12 +300,12 @@ export class PptxPresentation {
         throw new Error(`Slide index ${slideIndex} out of range (count: ${this.slideCount})`);
       }
       const res = await this._bridge.request(
-        (id) => ({ kind: 'renderSlide', id, slideIndex, width, dpr, skipMediaControls: opts.skipMediaControls }) satisfies RenderWorkerRequest,
+        (id) => ({ kind: 'renderSlide', id, slideIndex, width, dpr, skipMediaControls: opts.skipMediaControls, dim: opts.dim }) satisfies RenderWorkerRequest,
       );
       return (res as Extract<RenderWorkerResponse, { kind: 'slideRendered' }>).bitmap;
     }
     const off = new OffscreenCanvas(1, 1);
-    await this.renderSlide(off, slideIndex, { width, dpr, skipMediaControls: opts.skipMediaControls });
+    await this.renderSlide(off, slideIndex, { width, dpr, skipMediaControls: opts.skipMediaControls, dim: opts.dim });
     return off.transferToImageBitmap();
   }
 
@@ -371,7 +391,7 @@ export class PptxPresentation {
         ? async () => {
             // Whole slide rendered off-thread; the handle snapshots this paint
             // into its own base copy, so the bitmap can be closed right after.
-            const bmp = await this.renderSlideToBitmap(slideIndex, { width, dpr, skipMediaControls: true });
+            const bmp = await this.renderSlideToBitmap(slideIndex, { width, dpr, skipMediaControls: true, dim: opts.dim });
             canvas.width = bmp.width;
             canvas.height = bmp.height;
             // Set only the CSS width and let height follow the intrinsic aspect
@@ -389,6 +409,7 @@ export class PptxPresentation {
               width,
               dpr,
               skipMediaControls: true,
+              dim: opts.dim,
               onTextRun: opts.onTextRun,
             });
 

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -104,6 +104,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         notes: pres.slides.map((_, i) => selectNotes(pres!.slides, i)),
         mediaElements: pres.slides.map((s) =>
           s.elements.filter((el): el is MediaElement => el.type === 'media')),
+        hidden: pres.slides.map((s) => s.hidden ?? false),
       };
       post({ kind: 'parsedMeta', id: req.id, meta });
       return;
@@ -125,6 +126,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         fetchMedia: getMedia,
         fetchImage: getImage,
         skipMediaControls: req.skipMediaControls,
+        dim: req.dim,
         // math intentionally omitted: MathJax needs a DOM <script>; worker
         // mode skips equations (documented in the design spec).
       });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -16,6 +16,7 @@ import type {
   Shadow,
   Glow,
   RenderOptions,
+  DimOptions,
   TabStop,
 } from './types';
 import { asBullet } from './types';
@@ -4082,12 +4083,32 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
 export type { RenderOptions } from './types';
 
 /**
+ * Overlay a translucent rectangle over the whole slide so a hidden slide reads
+ * faintly (PowerPoint's hidden-slide thumbnail look). A pure mechanism — it
+ * never inspects whether the slide is hidden; the caller ({@link PptxViewer}'s
+ * `'dim'` mode) decides when to apply it. `widthPx`/`heightPx` are CSS px; the
+ * ctx is already `scale(dpr, dpr)`d, so a fillRect in CSS px covers the canvas.
+ */
+export function applyDimOverlay(
+  ctx: CanvasRenderingContext2D,
+  dim: DimOptions,
+  widthPx: number,
+  heightPx: number,
+): void {
+  ctx.save();
+  ctx.globalAlpha = dim.opacity;
+  ctx.fillStyle = dim.color;
+  ctx.fillRect(0, 0, widthPx, heightPx);
+  ctx.restore();
+}
+
+/**
  * Internal render options: the shared {@link RenderOptions} plus the opt-in
  * `math` engine. `math` is internal plumbing — the headless {@link
  * PptxPresentation} injects it once at load and threads it here on each draw,
  * so the public `RenderSlideOptions` deliberately does not expose it.
  */
-type SlideRenderOptions = RenderOptions & { math?: MathRenderer };
+type SlideRenderOptions = RenderOptions & { math?: MathRenderer; dim?: DimOptions };
 
 /**
  * Render a single slide onto a <canvas> element.
@@ -4313,6 +4334,11 @@ export async function renderSlide(
       );
     }
   }
+
+  // Hidden-slide dimming (a render mechanism; the caller decides WHEN — see
+  // PptxViewer's 'dim' mode). Overlay AFTER all content so it reads faintly.
+  if (superseded()) return canvas;
+  if (opts.dim) applyDimOverlay(ctx, opts.dim, canvasW, canvasH);
 
   return canvas;
 }

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -142,6 +142,27 @@ export interface Slide {
    * when the slide has no comments.
    */
   comments?: PptxComment[];
+  /**
+   * `<p:sld show="0">` — the slide is marked hidden in the slide show
+   * (ECMA-376 §19.3.1.38). Absent (`undefined`) ⇒ shown. The renderer ignores
+   * this; it is a fact surfaced for tools and for {@link PptxViewer}'s hidden-
+   * slide modes (read it via `PptxPresentation.isHidden`).
+   */
+  hidden?: boolean;
+}
+
+/**
+ * Translucent overlay drawn over a finished slide so it reads faintly
+ * (PowerPoint's hidden-slide thumbnail look). A pure render mechanism: the
+ * renderer never decides *when* to dim — the caller ({@link PptxViewer}'s
+ * `'dim'` mode) does. Both fields are required at the engine boundary; the
+ * viewer-facing override (`PptxViewerOptions.hiddenSlideDim`) is partial.
+ */
+export interface DimOptions {
+  /** CSS color of the overlay (e.g. `'#ffffff'`). */
+  color: string;
+  /** Overlay opacity 0..1 (e.g. `0.6` ⇒ underlying content shows at 40%). */
+  opacity: number;
 }
 
 /** A single legacy slide comment (`<p:cm>` in `ppt/comments/commentN.xml`). */

--- a/packages/pptx/src/viewer-hidden.test.ts
+++ b/packages/pptx/src/viewer-hidden.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import type { PptxViewer, PptxViewerOptions, HiddenSlideMode } from './viewer.js';
+import { nextVisibleIndex, resolveVisibleIndex } from './hidden.js';
+
+/**
+ * Compile-time API-surface assertions (erased at runtime, enforced by
+ * `pnpm typecheck`). PptxViewer is DOM-bound and the vitest env is `node`, so —
+ * like notes.test.ts — the viewer is verified at the type level; its policy
+ * logic is delegated to the pure helpers tested in hidden.test.ts.
+ */
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type _Modes = Expect<Equal<HiddenSlideMode, 'show' | 'skip' | 'dim'>>;
+type _SetMode = Expect<Equal<PptxViewer['setHiddenSlideMode'], (mode: HiddenSlideMode) => Promise<void>>>;
+type _ModeGetter = Expect<Equal<PptxViewer['hiddenSlideMode'], HiddenSlideMode>>;
+type _VisibleCount = Expect<Equal<PptxViewer['visibleSlideCount'], number>>;
+const _opts: PptxViewerOptions = { hiddenSlides: 'dim', hiddenSlideDim: { color: '#fff', opacity: 0.5 } };
+
+describe('PptxViewer hidden-slide policy (delegated pure helpers)', () => {
+  it('skip navigation jumps over hidden slides via the tested helpers', () => {
+    const isHidden = (i: number) => i === 1; // visible: 0, 2
+    expect(nextVisibleIndex(0, 1, isHidden, 3)).toBe(2); // nextSlide from 0 → 2
+    expect(resolveVisibleIndex(1, isHidden, 3)).toBe(2); // entering skip on hidden → 2
+    void _opts;
+  });
+});

--- a/packages/pptx/src/viewer-hidden.test.ts
+++ b/packages/pptx/src/viewer-hidden.test.ts
@@ -16,7 +16,7 @@ type _Modes = Expect<Equal<HiddenSlideMode, 'show' | 'skip' | 'dim'>>;
 type _SetMode = Expect<Equal<PptxViewer['setHiddenSlideMode'], (mode: HiddenSlideMode) => Promise<void>>>;
 type _ModeGetter = Expect<Equal<PptxViewer['hiddenSlideMode'], HiddenSlideMode>>;
 type _VisibleCount = Expect<Equal<PptxViewer['visibleSlideCount'], number>>;
-const _opts: PptxViewerOptions = { hiddenSlides: 'dim', hiddenSlideDim: { color: '#fff', opacity: 0.5 } };
+const _opts: PptxViewerOptions = { hiddenSlideMode: 'dim', hiddenSlideDim: { color: '#fff', opacity: 0.5 } };
 
 describe('PptxViewer hidden-slide policy (delegated pure helpers)', () => {
   it('skip navigation jumps over hidden slides via the tested helpers', () => {

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -1,6 +1,14 @@
 import type { RenderOptions, PptxTextRunInfo } from './renderer';
 import { PptxPresentation, type LoadOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
+import { nextVisibleIndex, resolveVisibleIndex } from './hidden';
+import type { DimOptions } from './types';
+
+/** How {@link PptxViewer} presents hidden slides (`<p:sld show="0">`). */
+export type HiddenSlideMode = 'show' | 'skip' | 'dim';
+
+/** Default `'dim'` overlay: 60% white (hidden content shows at 40%). */
+const DEFAULT_HIDDEN_DIM: DimOptions = { color: '#ffffff', opacity: 0.6 };
 
 export interface PptxViewerOptions extends RenderOptions, LoadOptions {
   /** Called when a slide finishes rendering */
@@ -20,6 +28,20 @@ export interface PptxViewerOptions extends RenderOptions, LoadOptions {
    * browser's native text selection works on slide content.
    */
   enableTextSelection?: boolean;
+  /**
+   * How hidden slides (`<p:sld show="0">`, §19.3.1.38) are presented:
+   * - `'show'` (default): drawn like any other slide.
+   * - `'skip'`: sequential navigation (`nextSlide`/`prevSlide`, initial load)
+   *   jumps over them; absolute indices are unchanged, and an explicit
+   *   `goToSlide(i)` to a hidden slide is still honored.
+   * - `'dim'`: drawn under a translucent overlay (PowerPoint thumbnail look).
+   */
+  hiddenSlides?: HiddenSlideMode;
+  /**
+   * Overrides for the `'dim'` overlay. Merged over the default
+   * `{ color: '#ffffff', opacity: 0.6 }`.
+   */
+  hiddenSlideDim?: { color?: string; opacity?: number };
 }
 
 /**
@@ -39,6 +61,7 @@ export class PptxViewer {
   private engine: PptxPresentation | null = null;
   private readonly opts: PptxViewerOptions;
   private currentSlide = 0;
+  private _hiddenMode: HiddenSlideMode;
   private handle: PresentationHandle | null = null;
   private readonly _mode: 'main' | 'worker';
   /** The canvas's bitmaprenderer context, used only by the static worker-mode
@@ -51,6 +74,7 @@ export class PptxViewer {
     this.opts = opts;
     this.canvas = canvas;
     this._mode = opts.mode ?? 'main';
+    this._hiddenMode = opts.hiddenSlides ?? 'show';
 
     const parent = canvas.parentElement;
     this.wrapper = document.createElement('div');
@@ -98,7 +122,7 @@ export class PptxViewer {
         math: this.opts.math,
         mode: this._mode,
       });
-      this.currentSlide = 0;
+      this.currentSlide = this._initialSlide();
       await this.renderCurrentSlide();
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
@@ -118,11 +142,62 @@ export class PptxViewer {
   }
 
   async nextSlide(): Promise<void> {
-    await this.goToSlide(this.currentSlide + 1);
+    await this.goToSlide(this._step(1));
   }
 
   async prevSlide(): Promise<void> {
-    await this.goToSlide(this.currentSlide - 1);
+    await this.goToSlide(this._step(-1));
+  }
+
+  /** Next index for sequential nav: skip mode jumps over hidden slides. */
+  private _step(dir: 1 | -1): number {
+    if (this._hiddenMode === 'skip' && this.engine) {
+      return nextVisibleIndex(this.currentSlide, dir, (i) => this.engine!.isHidden(i), this.slideCount);
+    }
+    return this.currentSlide + dir;
+  }
+
+  /** Initial slide for load() / mode switch: skip mode lands on a visible one. */
+  private _initialSlide(): number {
+    if (this._hiddenMode === 'skip' && this.engine) {
+      return resolveVisibleIndex(0, (i) => this.engine!.isHidden(i), this.slideCount);
+    }
+    return 0;
+  }
+
+  /** Resolved `'dim'` overlay (defaults merged with the `hiddenSlideDim` option). */
+  private _dim(): DimOptions {
+    return {
+      color: this.opts.hiddenSlideDim?.color ?? DEFAULT_HIDDEN_DIM.color,
+      opacity: this.opts.hiddenSlideDim?.opacity ?? DEFAULT_HIDDEN_DIM.opacity,
+    };
+  }
+
+  /**
+   * Switch the hidden-slide mode at runtime and re-render. Entering `'skip'`
+   * while on a hidden slide advances to the nearest visible slide.
+   */
+  async setHiddenSlideMode(mode: HiddenSlideMode): Promise<void> {
+    this._hiddenMode = mode;
+    if (mode === 'skip' && this.engine) {
+      this.currentSlide = resolveVisibleIndex(
+        this.currentSlide,
+        (i) => this.engine!.isHidden(i),
+        this.slideCount,
+      );
+    }
+    await this.renderCurrentSlide();
+  }
+
+  /** The current hidden-slide mode. */
+  get hiddenSlideMode(): HiddenSlideMode { return this._hiddenMode; }
+
+  /** Number of non-hidden slides (absolute `slideCount` is unchanged). */
+  get visibleSlideCount(): number {
+    if (!this.engine) return 0;
+    let n = 0;
+    for (let i = 0; i < this.slideCount; i++) if (!this.engine.isHidden(i)) n++;
+    return n;
   }
 
   get slideIndex(): number { return this.currentSlide; }
@@ -143,6 +218,10 @@ export class PptxViewer {
 
   private async renderCurrentSlide(): Promise<void> {
     if (!this.engine) return;
+    const dim =
+      this._hiddenMode === 'dim' && this.engine.isHidden(this.currentSlide)
+        ? this._dim()
+        : undefined;
     const targetWidth = this.opts.width ?? (this.canvas.offsetWidth || 960);
     const dpr = this.opts.dpr ?? (window.devicePixelRatio || 1);
 
@@ -173,14 +252,15 @@ export class PptxViewer {
         this.handle = await this.engine.presentSlide(this.canvas, this.currentSlide, {
           width: targetWidth,
           dpr,
+          dim,
         });
       } else if (isWorker) {
-        const bmp = await this.engine.renderSlideToBitmap(this.currentSlide, { width: targetWidth, dpr });
+        const bmp = await this.engine.renderSlideToBitmap(this.currentSlide, { width: targetWidth, dpr, dim });
         this.canvas.width = bmp.width;
         this.canvas.height = bmp.height;
         this._bitmapCtx?.transferFromImageBitmap(bmp);
       } else {
-        await this.engine.renderSlide(this.canvas, this.currentSlide, { width: targetWidth, dpr, onTextRun });
+        await this.engine.renderSlide(this.canvas, this.currentSlide, { width: targetWidth, dpr, onTextRun, dim });
       }
       this.opts.onSlideChange?.(this.currentSlide, this.slideCount);
     } catch (err) {

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -35,13 +35,17 @@ export interface PptxViewerOptions extends RenderOptions, LoadOptions {
    *   jumps over them; absolute indices are unchanged, and an explicit
    *   `goToSlide(i)` to a hidden slide is still honored.
    * - `'dim'`: drawn under a translucent overlay (PowerPoint thumbnail look).
+   *
+   * Named to match the {@link PptxViewer.hiddenSlideMode} getter and
+   * {@link PptxViewer.setHiddenSlideMode} setter.
    */
-  hiddenSlides?: HiddenSlideMode;
+  hiddenSlideMode?: HiddenSlideMode;
   /**
    * Overrides for the `'dim'` overlay. Merged over the default
-   * `{ color: '#ffffff', opacity: 0.6 }`.
+   * `{ color: '#ffffff', opacity: 0.6 }`. A `Partial<DimOptions>` so it stays
+   * in sync if {@link DimOptions} gains a field.
    */
-  hiddenSlideDim?: { color?: string; opacity?: number };
+  hiddenSlideDim?: Partial<DimOptions>;
 }
 
 /**
@@ -74,7 +78,7 @@ export class PptxViewer {
     this.opts = opts;
     this.canvas = canvas;
     this._mode = opts.mode ?? 'main';
-    this._hiddenMode = opts.hiddenSlides ?? 'show';
+    this._hiddenMode = opts.hiddenSlideMode ?? 'show';
 
     const parent = canvas.parentElement;
     this.wrapper = document.createElement('div');

--- a/packages/pptx/src/worker-protocol.ts
+++ b/packages/pptx/src/worker-protocol.ts
@@ -1,4 +1,4 @@
-import type { MediaElement, WorkerResponse } from './types';
+import type { DimOptions, MediaElement, WorkerResponse } from './types';
 
 /** Lightweight summary returned by the render worker's `parse` — everything
  *  the main-thread proxy needs for its synchronous getters. The full model
@@ -14,6 +14,8 @@ export interface PresentationMeta {
   /** Media elements per slide (geometry + paths), for main-thread playback
    *  overlays. Small: a handful of plain objects per slide. */
   mediaElements: MediaElement[][];
+  /** `Slide.hidden` per slide (`<p:sld show="0">`, §19.3.1.38). */
+  hidden: boolean[];
 }
 
 // The base `parse` arm from types.ts is intentionally NOT reused: the render
@@ -25,7 +27,7 @@ export type RenderWorkerRequest =
   | { kind: 'extractMedia'; id: number; path: string }
   | { kind: 'extractImage'; id: number; path: string }
   | { kind: 'parse'; id: number; buffer: ArrayBuffer; maxZipEntryBytes?: number; useGoogleFonts?: boolean }
-  | { kind: 'renderSlide'; id: number; slideIndex: number; width: number; dpr: number; skipMediaControls?: boolean };
+  | { kind: 'renderSlide'; id: number; slideIndex: number; width: number; dpr: number; skipMediaControls?: boolean; dim?: DimOptions };
 
 export type RenderWorkerResponse =
   | Exclude<WorkerResponse, { kind: 'parsed' }>


### PR DESCRIPTION
## Summary

Lets consumers choose how PPTX **hidden slides** (`<p:sld show="0">`, ECMA-376 §19.3.1.38 `CT_Slide` `show` attribute, xsd:boolean default `true`) are presented in `PptxViewer`:

- `'show'` (default): drawn like any other slide — unchanged behavior.
- `'skip'`: sequential navigation (`nextSlide`/`prevSlide`, initial load) jumps over hidden slides. **Absolute indices are preserved** (an explicit `goToSlide(i)` to a hidden slide is still honored); only traversal skips.
- `'dim'`: the hidden slide is drawn under a translucent white overlay (PowerPoint's hidden-slide thumbnail look), configurable via `hiddenSlideDim`.

## Design: facts/mechanism in the engine, policy in the viewer

Deciding *whether to show* a hidden slide is the consumer's responsibility, so the layering is:

| Layer | What it owns |
|---|---|
| `PptxPresentation` (engine) | **facts** — `Slide.hidden`, `isHidden(i)`; **mechanism** — `renderSlide(.., { dim })` (a pure render param; the engine never inspects `hidden` to decide to dim) |
| `PptxViewer` (policy) | `hiddenSlides` mode, `setHiddenSlideMode()` (runtime switch + re-render), skip navigation, deciding when to pass `dim`, `visibleSlideCount` |

Skip math lives in pure, unit-tested helpers (`selectHidden`, `nextVisibleIndex`, `resolveVisibleIndex` in `hidden.ts`); the viewer is thin glue over them. Absolute indices are kept because the `slidenum` field renders the absolute slide number, and runtime mode-switching must not invalidate a consumer's held index.

## Public API additions

- `PptxViewerOptions.hiddenSlideMode?: 'show' | 'skip' | 'dim'` (default `'show'`)
- `PptxViewerOptions.hiddenSlideDim?: { color?: string; opacity?: number }` (merged over `{ color: '#ffffff', opacity: 0.6 }`)
- `PptxViewer.setHiddenSlideMode(mode)`, `PptxViewer.hiddenSlideMode`, `PptxViewer.visibleSlideCount`
- `PptxPresentation.isHidden(slideIndex)` (non-clamped, mirrors `getNotes`)
- `Slide.hidden?: boolean`; new `DimOptions`, `HiddenSlideMode` exported types

## Commits (1 concern = 1 commit)

1. parse `<p:sld show>` into `Slide.hidden` (Rust)
2. `Slide.hidden` + `DimOptions` TS model
3. pure helpers `selectHidden` / `nextVisibleIndex` / `resolveVisibleIndex`
4. `applyDimOverlay` render mechanism + `dim` on `renderSlide`
5. `isHidden` + thread `dim`/`hidden` through engine & worker
6. `PptxViewer` modes + `setHiddenSlideMode`

## Cross-format note

pptx-only here. xlsx's hidden sheet (`<sheet state="hidden">`, §18.2.19) is the analogous concept but diverges entirely in UX (sheet tabs) and rendering; the dim overlay is a few lines of `fillRect` and not worth a `core` abstraction. Recorded as a future-alignment candidate only.

## Testing

- Rust: `slide_show_attr_marks_hidden` (show=0/false ⇒ hidden; absent/1/true ⇒ shown). `cargo fmt`/`clippy -D warnings`/`test` all clean.
- TS: `hidden.test.ts` (11), `dim-overlay.test.ts` (overlay draw calls), `viewer-hidden.test.ts` (compile-time API surface, mirroring `notes.test.ts` since the vitest env is `node` and the viewer is DOM-bound). pptx suite: **138 passing**.
- `pnpm typecheck`: pass.

> Note: the full-workspace `pnpm test` shows 2 failures in `packages/node/src/source-buffer-image.test.ts` — a **pre-existing, environment-dependent** skia-canvas `loadImage` issue (`'src' property value is neither string nor Buffer type'`). That file is byte-identical to `main` (this branch changes only `packages/pptx/`), and pptx is imported there as types only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
