### PR TITLE
feat(xlsx): hidden-sheet display modes (show/skip/dim) + shared nav helpers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,4 +228,4 @@ export {
 export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-positions';
 // Format-agnostic index navigation for hidden-item "skip" mode (pptx hidden
 // slides, xlsx hidden sheets): pure math over an isHidden(i) callback.
-export { nextVisibleIndex, resolveVisibleIndex } from './nav/visible-index';
+export { nextVisibleIndex, resolveVisibleIndex, countVisible } from './nav/visible-index';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -226,3 +226,6 @@ export {
   type SegStretch,
 } from './text/line-distribute';
 export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-positions';
+// Format-agnostic index navigation for hidden-item "skip" mode (pptx hidden
+// slides, xlsx hidden sheets): pure math over an isHidden(i) callback.
+export { nextVisibleIndex, resolveVisibleIndex } from './nav/visible-index';

--- a/packages/core/src/nav/visible-index.test.ts
+++ b/packages/core/src/nav/visible-index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { nextVisibleIndex, resolveVisibleIndex } from './visible-index.js';
+import { nextVisibleIndex, resolveVisibleIndex, countVisible } from './visible-index.js';
 
 describe('nextVisibleIndex (skip-mode sequential nav)', () => {
   const isHidden = (i: number) => i === 1 || i === 2; // visible: 0,3,4
@@ -31,5 +31,14 @@ describe('resolveVisibleIndex (initial load / entering skip mode)', () => {
   });
   it('returns current on an empty list', () => {
     expect(resolveVisibleIndex(0, () => true, 0)).toBe(0);
+  });
+});
+
+describe('countVisible', () => {
+  it('counts the non-hidden items', () => {
+    expect(countVisible((i) => i === 1 || i === 2, 5)).toBe(3);
+    expect(countVisible(() => false, 4)).toBe(4);
+    expect(countVisible(() => true, 4)).toBe(0);
+    expect(countVisible(() => false, 0)).toBe(0);
   });
 });

--- a/packages/core/src/nav/visible-index.test.ts
+++ b/packages/core/src/nav/visible-index.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { nextVisibleIndex, resolveVisibleIndex } from './visible-index.js';
+
+describe('nextVisibleIndex (skip-mode sequential nav)', () => {
+  const isHidden = (i: number) => i === 1 || i === 2; // visible: 0,3,4
+  const count = 5;
+  it('skips hidden items going forward', () => {
+    expect(nextVisibleIndex(0, 1, isHidden, count)).toBe(3);
+  });
+  it('skips hidden items going backward', () => {
+    expect(nextVisibleIndex(3, -1, isHidden, count)).toBe(0);
+  });
+  it('stays put when no visible item exists in that direction', () => {
+    expect(nextVisibleIndex(4, 1, isHidden, count)).toBe(4);
+    expect(nextVisibleIndex(0, -1, isHidden, count)).toBe(0);
+  });
+});
+
+describe('resolveVisibleIndex (initial load / entering skip mode)', () => {
+  it('keeps the current item when it is visible', () => {
+    expect(resolveVisibleIndex(3, (i) => i === 0, 5)).toBe(3);
+  });
+  it('advances to the next visible item when current is hidden', () => {
+    expect(resolveVisibleIndex(0, (i) => i === 0 || i === 1, 5)).toBe(2);
+  });
+  it('falls back to the previous visible item when none follow', () => {
+    expect(resolveVisibleIndex(4, (i) => i >= 2, 5)).toBe(1);
+  });
+  it('returns current when every item is hidden (skip degenerates)', () => {
+    expect(resolveVisibleIndex(2, () => true, 5)).toBe(2);
+  });
+  it('returns current on an empty list', () => {
+    expect(resolveVisibleIndex(0, () => true, 0)).toBe(0);
+  });
+});

--- a/packages/core/src/nav/visible-index.ts
+++ b/packages/core/src/nav/visible-index.ts
@@ -33,3 +33,14 @@ export function resolveVisibleIndex(
   if (fwd !== current) return fwd;
   return nextVisibleIndex(current, -1, isHidden, count);
 }
+
+/**
+ * Count how many of `count` items are visible (not hidden), per the same
+ * `isHidden` callback the skip-navigation helpers use. Shared by viewers'
+ * `visible*Count` getters (pptx visibleSlideCount, xlsx visibleSheetCount).
+ */
+export function countVisible(isHidden: (i: number) => boolean, count: number): number {
+  let n = 0;
+  for (let i = 0; i < count; i++) if (!isHidden(i)) n++;
+  return n;
+}

--- a/packages/core/src/nav/visible-index.ts
+++ b/packages/core/src/nav/visible-index.ts
@@ -1,0 +1,35 @@
+/**
+ * Next visible (non-hidden) absolute index in `dir` (+1 forward, -1 back),
+ * searching strictly AFTER `from`. Shared by viewers whose sequential-navigation
+ * ("skip") mode jumps over hidden items (pptx hidden slides, xlsx hidden sheets).
+ * Returns the found index, or `from` itself when no other visible item exists in
+ * that direction (caller then stays put).
+ */
+export function nextVisibleIndex(
+  from: number,
+  dir: 1 | -1,
+  isHidden: (i: number) => boolean,
+  count: number,
+): number {
+  for (let i = from + dir; i >= 0 && i < count; i += dir) {
+    if (!isHidden(i)) return i;
+  }
+  return from;
+}
+
+/**
+ * Resolve which item to show on initial load or when entering "skip" mode:
+ * keep `current` if visible; else the nearest visible item AFTER it; else the
+ * nearest visible item BEFORE it; else `current` (every item hidden — skip
+ * degenerates, so show it anyway). All indices are absolute.
+ */
+export function resolveVisibleIndex(
+  current: number,
+  isHidden: (i: number) => boolean,
+  count: number,
+): number {
+  if (count === 0 || !isHidden(current)) return current;
+  const fwd = nextVisibleIndex(current, 1, isHidden, count);
+  if (fwd !== current) return fwd;
+  return nextVisibleIndex(current, -1, isHidden, count);
+}

--- a/packages/pptx/src/hidden.test.ts
+++ b/packages/pptx/src/hidden.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { selectHidden, nextVisibleIndex, resolveVisibleIndex } from './hidden.js';
+import { selectHidden } from './hidden.js';
 import type { Slide } from './types.js';
 
 /** Build a slide list where `hiddenFlags[i]` toggles `Slide.hidden`. */
@@ -28,40 +28,5 @@ describe('selectHidden (PptxPresentation.isHidden core)', () => {
     expect(selectHidden(s, 1)).toBe(false);
     expect(selectHidden(s, 0.5)).toBe(false);
     expect(selectHidden([], 0)).toBe(false);
-  });
-});
-
-describe('nextVisibleIndex (skip-mode sequential nav)', () => {
-  // hidden at 1 and 2; visible 0,3,4
-  const isHidden = (i: number) => i === 1 || i === 2;
-  const count = 5;
-  it('skips hidden slides going forward', () => {
-    expect(nextVisibleIndex(0, 1, isHidden, count)).toBe(3);
-  });
-  it('skips hidden slides going backward', () => {
-    expect(nextVisibleIndex(3, -1, isHidden, count)).toBe(0);
-  });
-  it('stays put when no visible slide exists in that direction', () => {
-    expect(nextVisibleIndex(4, 1, isHidden, count)).toBe(4); // nothing after 4
-    expect(nextVisibleIndex(0, -1, isHidden, count)).toBe(0); // nothing before 0
-  });
-});
-
-describe('resolveVisibleIndex (initial load / entering skip mode)', () => {
-  it('keeps the current slide when it is visible', () => {
-    expect(resolveVisibleIndex(3, (i) => i === 0, 5)).toBe(3);
-  });
-  it('advances to the next visible slide when current is hidden', () => {
-    expect(resolveVisibleIndex(0, (i) => i === 0 || i === 1, 5)).toBe(2);
-  });
-  it('falls back to the previous visible slide when none follow', () => {
-    // visible: 0,1 ; hidden: 2,3,4 ; current 4 → nearest visible before is 1
-    expect(resolveVisibleIndex(4, (i) => i >= 2, 5)).toBe(1);
-  });
-  it('returns current when every slide is hidden (skip degenerates)', () => {
-    expect(resolveVisibleIndex(2, () => true, 5)).toBe(2);
-  });
-  it('returns current on an empty deck', () => {
-    expect(resolveVisibleIndex(0, () => true, 0)).toBe(0);
   });
 });

--- a/packages/pptx/src/hidden.ts
+++ b/packages/pptx/src/hidden.ts
@@ -14,4 +14,4 @@ export function selectHidden(slides: readonly Slide[], slideIndex: number): bool
 }
 
 // Generic index-navigation helpers live in core (shared with xlsx hidden sheets).
-export { nextVisibleIndex, resolveVisibleIndex } from '@silurus/ooxml-core';
+export { nextVisibleIndex, resolveVisibleIndex, countVisible } from '@silurus/ooxml-core';

--- a/packages/pptx/src/hidden.ts
+++ b/packages/pptx/src/hidden.ts
@@ -13,37 +13,5 @@ export function selectHidden(slides: readonly Slide[], slideIndex: number): bool
   return slides[slideIndex].hidden ?? false;
 }
 
-/**
- * Next visible (non-hidden) absolute slide index in `dir` (+1 forward, -1 back),
- * searching strictly AFTER `from`. Used by {@link PptxViewer}'s `'skip'` mode for
- * sequential navigation. Returns the found index, or `from` itself when no other
- * visible slide exists in that direction (caller then stays put).
- */
-export function nextVisibleIndex(
-  from: number,
-  dir: 1 | -1,
-  isHidden: (i: number) => boolean,
-  count: number,
-): number {
-  for (let i = from + dir; i >= 0 && i < count; i += dir) {
-    if (!isHidden(i)) return i;
-  }
-  return from;
-}
-
-/**
- * Resolve which slide to show on initial load or when entering `'skip'` mode:
- * keep `current` if visible; else the nearest visible slide AFTER it; else the
- * nearest visible slide BEFORE it; else `current` (every slide hidden — skip
- * degenerates, so show it anyway). All indices are absolute.
- */
-export function resolveVisibleIndex(
-  current: number,
-  isHidden: (i: number) => boolean,
-  count: number,
-): number {
-  if (count === 0 || !isHidden(current)) return current;
-  const fwd = nextVisibleIndex(current, 1, isHidden, count);
-  if (fwd !== current) return fwd;
-  return nextVisibleIndex(current, -1, isHidden, count);
-}
+// Generic index-navigation helpers live in core (shared with xlsx hidden sheets).
+export { nextVisibleIndex, resolveVisibleIndex } from '@silurus/ooxml-core';

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -1,7 +1,7 @@
 import type { RenderOptions, PptxTextRunInfo } from './renderer';
 import { PptxPresentation, type LoadOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
-import { nextVisibleIndex, resolveVisibleIndex } from './hidden';
+import { nextVisibleIndex, resolveVisibleIndex, countVisible } from './hidden';
 import type { DimOptions } from './types';
 
 /** How {@link PptxViewer} presents hidden slides (`<p:sld show="0">`). */
@@ -199,9 +199,8 @@ export class PptxViewer {
   /** Number of non-hidden slides (absolute `slideCount` is unchanged). */
   get visibleSlideCount(): number {
     if (!this.engine) return 0;
-    let n = 0;
-    for (let i = 0; i < this.slideCount; i++) if (!this.engine.isHidden(i)) n++;
-    return n;
+    const engine = this.engine;
+    return countVisible((i) => engine.isHidden(i), this.slideCount);
   }
 
   get slideIndex(): number { return this.currentSlide; }

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -456,11 +456,17 @@ fn parse_workbook_sheets(doc: &roxmltree::Document) -> Vec<SheetMeta> {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(1);
             let r_id = node.attribute((r_ns, "id")).unwrap_or("").to_string();
+            let visibility = match node.attribute("state") {
+                Some("hidden") => SheetVisibility::Hidden,
+                Some("veryHidden") => SheetVisibility::VeryHidden,
+                _ => SheetVisibility::Visible,
+            };
             sheets.push(SheetMeta {
                 name,
                 sheet_id,
                 r_id,
                 tab_color: None,
+                visibility,
             });
         }
     }
@@ -2537,5 +2543,22 @@ mod extract_image_tests {
             w.finish().unwrap();
         }
         assert_eq!(extract_image(&buf, "xl/media/i.png", None).unwrap(), b"X");
+    }
+}
+
+#[cfg(test)]
+mod sheet_visibility_tests {
+    use super::*;
+
+    #[test]
+    fn sheet_state_attr_maps_to_visibility() {
+        // ECMA-376 §18.2.19 ST_SheetState: visible (default) | hidden | veryHidden.
+        let xml = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="A" sheetId="1" r:id="rId1"/><sheet name="B" sheetId="2" r:id="rId2" state="hidden"/><sheet name="C" sheetId="3" r:id="rId3" state="veryHidden"/><sheet name="D" sheetId="4" r:id="rId4" state="visible"/></sheets></workbook>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let sheets = parse_workbook_sheets(&doc);
+        assert_eq!(sheets[0].visibility, SheetVisibility::Visible); // absent ⇒ visible
+        assert_eq!(sheets[1].visibility, SheetVisibility::Hidden);
+        assert_eq!(sheets[2].visibility, SheetVisibility::VeryHidden);
+        assert_eq!(sheets[3].visibility, SheetVisibility::Visible);
     }
 }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -7,6 +7,25 @@ pub struct Workbook {
     pub sheets: Vec<SheetMeta>,
 }
 
+/// Sheet visibility (`<sheet state>`, ECMA-376 §18.2.19 `ST_SheetState`).
+/// `Hidden` = hidden but user-unhideable via the UI; `VeryHidden` = revealable
+/// only programmatically. Default is `Visible`.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SheetVisibility {
+    Visible,
+    Hidden,
+    VeryHidden,
+}
+
+impl SheetVisibility {
+    /// For `skip_serializing_if`: omit the default (`Visible`) so existing
+    /// workbook JSON snapshots are unchanged.
+    pub fn is_visible(&self) -> bool {
+        matches!(self, SheetVisibility::Visible)
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SheetMeta {
@@ -19,6 +38,10 @@ pub struct SheetMeta {
     /// sheet declares no tab color.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tab_color: Option<String>,
+    /// Sheet visibility (`<sheet state>`, ECMA-376 §18.2.19). Omitted from JSON
+    /// when `Visible` (the default) so existing snapshots are unchanged.
+    #[serde(skip_serializing_if = "SheetVisibility::is_visible")]
+    pub visibility: SheetVisibility,
 }
 
 #[derive(Debug, Serialize)]

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -8,6 +8,7 @@ export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Workbook,
   SheetMeta,
+  SheetVisibility,
   Worksheet,
   Row,
   Cell,

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -3,7 +3,7 @@ export type { WireRenderViewportOptions } from './worker-protocol.js';
 export { XlsxViewer } from './viewer.js';
 // Resolved list-validation values (reachable via XlsxWorkbook.resolveValidationList).
 export type { ResolvedList } from './validation-list.js';
-export type { XlsxViewerOptions, CellAddress, CellRange, SelectionMode } from './viewer.js';
+export type { XlsxViewerOptions, HiddenSheetMode, CellAddress, CellRange, SelectionMode } from './viewer.js';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {
   Workbook,

--- a/packages/xlsx/src/sheet-visibility.test.ts
+++ b/packages/xlsx/src/sheet-visibility.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { selectSheetVisibility } from './sheet-visibility.js';
+import type { SheetMeta } from './types.js';
+
+/** Build a sheet list where `vis[i]` sets SheetMeta.visibility. */
+function sheets(vis: Array<'hidden' | 'veryHidden' | undefined>): SheetMeta[] {
+  return vis.map((v, i) => ({
+    name: `S${i}`,
+    sheetId: i + 1,
+    rId: `rId${i + 1}`,
+    ...(v ? { visibility: v } : {}),
+  }));
+}
+
+describe('selectSheetVisibility (XlsxWorkbook.sheetVisibility core)', () => {
+  it('returns the visibility for an in-range sheet', () => {
+    const s = sheets([undefined, 'hidden', 'veryHidden']);
+    expect(selectSheetVisibility(s, 0)).toBe('visible');
+    expect(selectSheetVisibility(s, 1)).toBe('hidden');
+    expect(selectSheetVisibility(s, 2)).toBe('veryHidden');
+  });
+  it('treats absent visibility as visible', () => {
+    expect(selectSheetVisibility(sheets([undefined]), 0)).toBe('visible');
+  });
+  it('returns visible for out-of-range / non-integer (non-clamped, like pptx)', () => {
+    const s = sheets(['hidden']);
+    expect(selectSheetVisibility(s, -1)).toBe('visible');
+    expect(selectSheetVisibility(s, 1)).toBe('visible');
+    expect(selectSheetVisibility(s, 0.5)).toBe('visible');
+    expect(selectSheetVisibility([], 0)).toBe('visible');
+  });
+});

--- a/packages/xlsx/src/sheet-visibility.ts
+++ b/packages/xlsx/src/sheet-visibility.ts
@@ -1,0 +1,17 @@
+import type { SheetMeta, SheetVisibility } from './types';
+
+/**
+ * Pure core of {@link XlsxWorkbook.sheetVisibility}: the visibility of the sheet
+ * at `sheetIndex` (0-based, absolute). Like pptx's `selectHidden`/`selectNotes`,
+ * the index is NOT clamped — out-of-range / non-integer ⇒ `'visible'`
+ * ("no sheet here, so treat as visible").
+ */
+export function selectSheetVisibility(
+  sheets: readonly SheetMeta[],
+  sheetIndex: number,
+): SheetVisibility {
+  if (!Number.isInteger(sheetIndex) || sheetIndex < 0 || sheetIndex >= sheets.length) {
+    return 'visible';
+  }
+  return sheets[sheetIndex].visibility ?? 'visible';
+}

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -4,6 +4,9 @@ export interface Workbook {
   sheets: SheetMeta[];
 }
 
+/** Sheet visibility (`<sheet state>`, ECMA-376 §18.2.19 `ST_SheetState`). */
+export type SheetVisibility = 'visible' | 'hidden' | 'veryHidden';
+
 export interface SheetMeta {
   name: string;
   sheetId: number;

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -12,6 +12,11 @@ export interface SheetMeta {
    *  `#RRGGBB`. Surfaced at workbook-list time so tabs can be painted up front.
    *  Absent when the sheet declares no tab color. */
   tabColor?: string | null;
+  /** Sheet visibility (`<sheet state>`, ECMA-376 §18.2.19 `ST_SheetState`).
+   *  Absent ⇒ visible. `'veryHidden'` sheets are revealable only
+   *  programmatically in Excel. Read via `XlsxWorkbook.isHidden` /
+   *  `XlsxWorkbook.sheetVisibility`. */
+  visibility?: 'hidden' | 'veryHidden';
 }
 
 export interface MergeCell {

--- a/packages/xlsx/src/viewer-hidden.test.ts
+++ b/packages/xlsx/src/viewer-hidden.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import type { XlsxViewer, XlsxViewerOptions, HiddenSheetMode } from './viewer.js';
+import { nextVisibleIndex, resolveVisibleIndex } from '@silurus/ooxml-core';
+
+/**
+ * Compile-time API-surface assertions (erased at runtime, enforced by
+ * `pnpm typecheck`). XlsxViewer is DOM-bound and the vitest env is `node`, so —
+ * like pptx's viewer-hidden.test.ts — the viewer is verified at the type level;
+ * its skip policy is delegated to the pure core helpers tested in core.
+ */
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type _Modes = Expect<Equal<HiddenSheetMode, 'show' | 'skip' | 'dim'>>;
+type _SetMode = Expect<Equal<XlsxViewer['setHiddenSheetMode'], (mode: HiddenSheetMode) => Promise<void>>>;
+type _ModeGetter = Expect<Equal<XlsxViewer['hiddenSheetMode'], HiddenSheetMode>>;
+type _VisibleCount = Expect<Equal<XlsxViewer['visibleSheetCount'], number>>;
+const _opts: XlsxViewerOptions = { hiddenSheetMode: 'skip' };
+
+describe('XlsxViewer hidden-sheet policy (delegated core helpers)', () => {
+  it('skip navigation jumps over hidden sheets via the tested core helpers', () => {
+    const isHidden = (i: number) => i === 1; // visible: 0, 2
+    expect(nextVisibleIndex(0, 1, isHidden, 3)).toBe(2);
+    expect(resolveVisibleIndex(1, isHidden, 3)).toBe(2);
+    void _opts;
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,7 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { ViewportRange, Worksheet, XlsxComment } from './types.js';
 import type { LoadOptions } from '@silurus/ooxml-core';
-import { nextVisibleIndex, resolveVisibleIndex } from '@silurus/ooxml-core';
+import { nextVisibleIndex, resolveVisibleIndex, countVisible } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
@@ -35,6 +35,11 @@ const TAB_GAP = 1;
 
 /** How {@link XlsxViewer} presents hidden sheets (`<sheet state>`, §18.2.19). */
 export type HiddenSheetMode = 'show' | 'skip' | 'dim';
+
+/** `'dim'`-mode tab opacity: hidden/veryHidden tabs are greyed but selectable.
+ *  A UI-presentation default (ECMA-376 defines no hidden-tab rendering); mirrors
+ *  the named pptx `DEFAULT_HIDDEN_DIM` constant. */
+const HIDDEN_TAB_DIM_OPACITY = 0.45;
 
 export interface XlsxViewerOptions extends LoadOptions {
   /** Scale factor for cell/header dimensions (default 1). 0.5 = half size. */
@@ -1080,9 +1085,8 @@ export class XlsxViewer {
   /** Number of non-hidden sheets (absolute `sheetCount` is unchanged). */
   get visibleSheetCount(): number {
     if (!this.wb) return 0;
-    let n = 0;
-    for (let i = 0; i < this.sheetCount; i++) if (!this.wb.isHidden(i)) n++;
-    return n;
+    const wb = this.wb;
+    return countVisible((i) => wb.isHidden(i), this.sheetCount);
   }
 
   /** Copy the selected cell range as tab-separated text to the clipboard. */
@@ -1881,8 +1885,11 @@ export class XlsxViewer {
     // page vertically — on first load that jumped the whole page down to the
     // tab bar (the active sheet is set during load). Adjust the strip's
     // scrollLeft directly so the page never moves.
+    // `offsetParent === null` for a `display:none` tab (a hidden sheet reached
+    // by an explicit goToSheet in 'skip' mode). Its getBoundingClientRect is all
+    // zeros, which would spuriously scroll the strip — skip the scroll for it.
     const tab = this.tabs[index];
-    if (tab) {
+    if (tab && tab.offsetParent !== null) {
       const strip = this.tabStrip;
       const tabRect = tab.getBoundingClientRect();
       const stripRect = strip.getBoundingClientRect();
@@ -1932,7 +1939,7 @@ export class XlsxViewer {
   private tabCss(i: number, active: boolean): string {
     let css = this.tabStyle(active, this.tabColors[i]);
     if (this._hiddenSheetMode !== 'show' && this.wb?.isHidden(i)) {
-      css += this._hiddenSheetMode === 'skip' ? 'display:none;' : 'opacity:0.45;';
+      css += this._hiddenSheetMode === 'skip' ? 'display:none;' : `opacity:${HIDDEN_TAB_DIM_OPACITY};`;
     }
     return css;
   }

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,6 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { ViewportRange, Worksheet, XlsxComment } from './types.js';
 import type { LoadOptions } from '@silurus/ooxml-core';
+import { nextVisibleIndex, resolveVisibleIndex } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
@@ -31,6 +32,9 @@ const TAB_BAR_H = 30;
 // space so it is offset from the row-header boundary by the same margin that
 // separates tabs from each other.
 const TAB_GAP = 1;
+
+/** How {@link XlsxViewer} presents hidden sheets (`<sheet state>`, §18.2.19). */
+export type HiddenSheetMode = 'show' | 'skip' | 'dim';
 
 export interface XlsxViewerOptions extends LoadOptions {
   /** Scale factor for cell/header dimensions (default 1). 0.5 = half size. */
@@ -81,6 +85,19 @@ export interface XlsxViewerOptions extends LoadOptions {
    * require `'main'` (the math engine cannot cross the worker boundary).
    */
   mode?: 'main' | 'worker';
+  /**
+   * How hidden / veryHidden sheets (`<sheet state>`, ECMA-376 §18.2.19) are
+   * presented:
+   * - `'show'` (default): every sheet gets a tab — current behavior.
+   * - `'skip'`: hidden/veryHidden sheets get no tab and are jumped over by
+   *   `nextSheet`/`prevSheet` and initial load; absolute indices are unchanged,
+   *   and an explicit `goToSheet(i)` to a hidden sheet is still honored.
+   * - `'dim'`: hidden/veryHidden tabs are shown greyed but stay selectable.
+   *
+   * Named to match the {@link XlsxViewer.hiddenSheetMode} getter and
+   * {@link XlsxViewer.setHiddenSheetMode} setter. Mirrors pptx `hiddenSlideMode`.
+   */
+  hiddenSheetMode?: HiddenSheetMode;
 }
 
 export interface CellAddress {
@@ -269,6 +286,7 @@ export class XlsxViewer {
   private zoomSlider: HTMLInputElement | null = null;
   private zoomLabel: HTMLSpanElement | null = null;
   private currentSheet = 0;
+  private _hiddenSheetMode: HiddenSheetMode;
   private currentWorksheet: Worksheet | null = null;
   private opts: XlsxViewerOptions;
   /** 'main' renders on this thread; 'worker' paints worker-produced bitmaps. */
@@ -345,6 +363,7 @@ export class XlsxViewer {
   constructor(container: HTMLElement, opts: XlsxViewerOptions = {}) {
     this.opts = opts;
     this._mode = opts.mode ?? 'main';
+    this._hiddenSheetMode = opts.hiddenSheetMode ?? 'show';
 
     const wrapper = document.createElement('div');
     wrapper.style.cssText =
@@ -523,7 +542,7 @@ export class XlsxViewer {
       });
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
-      await this.showSheet(0);
+      await this.showSheet(this._initialSheet());
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       if (this.opts.onError) {
@@ -647,11 +666,27 @@ export class XlsxViewer {
   }
 
   async nextSheet(): Promise<void> {
-    await this.goToSheet(this.currentSheet + 1);
+    await this.goToSheet(this._stepSheet(1));
   }
 
   async prevSheet(): Promise<void> {
-    await this.goToSheet(this.currentSheet - 1);
+    await this.goToSheet(this._stepSheet(-1));
+  }
+
+  /** Next sheet index for sequential nav: skip mode jumps over hidden sheets. */
+  private _stepSheet(dir: 1 | -1): number {
+    if (this._hiddenSheetMode === 'skip' && this.wb) {
+      return nextVisibleIndex(this.currentSheet, dir, (i) => this.wb!.isHidden(i), this.sheetCount);
+    }
+    return this.currentSheet + dir;
+  }
+
+  /** Initial sheet for load() / entering skip mode: land on a visible sheet. */
+  private _initialSheet(): number {
+    if (this._hiddenSheetMode === 'skip' && this.wb) {
+      return resolveVisibleIndex(0, (i) => this.wb!.isHidden(i), this.sheetCount);
+    }
+    return 0;
   }
 
   /** Returns the cell at canvas-client coordinates, or null if outside the cell grid. */
@@ -1021,6 +1056,33 @@ export class XlsxViewer {
   setSelectionColor(color: string): void {
     this.opts.selectionColor = color;
     this.updateSelectionOverlay();
+  }
+
+  /**
+   * Switch the hidden-sheet mode at runtime: restyle the tabs and re-render.
+   * Entering `'skip'` while on a hidden sheet advances to the nearest visible.
+   */
+  async setHiddenSheetMode(mode: HiddenSheetMode): Promise<void> {
+    this._hiddenSheetMode = mode;
+    this.buildTabs();
+    if (mode === 'skip' && this.wb && this.wb.isHidden(this.currentSheet)) {
+      await this.showSheet(
+        resolveVisibleIndex(this.currentSheet, (i) => this.wb!.isHidden(i), this.sheetCount),
+      );
+    } else {
+      this.updateTabActive(this.currentSheet);
+    }
+  }
+
+  /** The current hidden-sheet mode. */
+  get hiddenSheetMode(): HiddenSheetMode { return this._hiddenSheetMode; }
+
+  /** Number of non-hidden sheets (absolute `sheetCount` is unchanged). */
+  get visibleSheetCount(): number {
+    if (!this.wb) return 0;
+    let n = 0;
+    for (let i = 0; i < this.sheetCount; i++) if (!this.wb.isHidden(i)) n++;
+    return n;
   }
 
   /** Copy the selected cell range as tab-separated text to the clipboard. */
@@ -1736,7 +1798,7 @@ export class XlsxViewer {
       const btn = document.createElement('button');
       btn.textContent = name;
       btn.title = name;
-      btn.style.cssText = this.tabStyle(false, this.tabColors[i]);
+      btn.style.cssText = this.tabCss(i, false);
       btn.addEventListener('click', () => this.showSheet(i));
       this.tabStrip.appendChild(btn);
       this.tabs.push(btn);
@@ -1812,7 +1874,7 @@ export class XlsxViewer {
 
   private updateTabActive(index: number): void {
     this.tabs.forEach((btn, i) => {
-      btn.style.cssText = this.tabStyle(i === index, this.tabColors[i]);
+      btn.style.cssText = this.tabCss(i, i === index);
     });
     // Keep the active tab visible by scrolling the tab strip HORIZONTALLY only.
     // `scrollIntoView` walks every scrollable ancestor, so it also scrolls the
@@ -1859,6 +1921,20 @@ export class XlsxViewer {
         `height:${inactiveH}px;font-size:11px;` +
         `background:#e0e0e0;color:#555;` +
         bar;
+  }
+
+  /**
+   * Full inline style for the tab of sheet `i`, honoring the hidden-sheet mode:
+   * `'skip'` hides the tab of a hidden/veryHidden sheet (`display:none`); `'dim'`
+   * greys it but leaves it clickable; `'show'` styles every tab normally. Used
+   * by both buildTabs and updateTabActive so navigation never wipes the styling.
+   */
+  private tabCss(i: number, active: boolean): string {
+    let css = this.tabStyle(active, this.tabColors[i]);
+    if (this._hiddenSheetMode !== 'show' && this.wb?.isHidden(i)) {
+      css += this._hiddenSheetMode === 'skip' ? 'display:none;' : 'opacity:0.45;';
+    }
+    return css;
   }
 
   /** Excel-style zoom control pinned to the right end of the tab bar:

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -8,7 +8,8 @@ import {
   type LoadOptions as CoreLoadOptions,
   type MathRenderer,
 } from '@silurus/ooxml-core';
-import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, WorkerRequest, WorkerResponse, Cell } from './types.js';
+import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, WorkerRequest, WorkerResponse, Cell, SheetVisibility } from './types.js';
+import { selectSheetVisibility } from './sheet-visibility.js';
 import { renderWorksheetViewport } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { formatCellValue } from './number-format.js';
@@ -151,6 +152,27 @@ export class XlsxWorkbook {
    *  `null` for sheets that declare no tab color. */
   get tabColors(): (string | null)[] {
     return this.parsedWorkbook?.workbook.sheets.map((s) => s.tabColor ?? null) ?? [];
+  }
+
+  /**
+   * Full visibility fact for the sheet at `sheetIndex` (0-based):
+   * `'visible'` | `'hidden'` | `'veryHidden'` (`<sheet state>`, ECMA-376
+   * §18.2.19). NOT clamped — out-of-range / non-integer ⇒ `'visible'`. This is a
+   * *fact*; deciding what to do with a hidden sheet (hide/skip/dim its tab) is
+   * {@link XlsxViewer}'s policy. `'veryHidden'` is revealable only
+   * programmatically in Excel; it is surfaced distinctly here.
+   */
+  sheetVisibility(sheetIndex: number): SheetVisibility {
+    return selectSheetVisibility(this.parsedWorkbook?.workbook.sheets ?? [], sheetIndex);
+  }
+
+  /**
+   * Whether the sheet at `sheetIndex` is hidden or veryHidden. Convenience over
+   * {@link sheetVisibility}; mirrors {@link PptxPresentation.isHidden} (non-
+   * clamped: out-of-range / non-integer ⇒ `false`).
+   */
+  isHidden(sheetIndex: number): boolean {
+    return this.sheetVisibility(sheetIndex) !== 'visible';
   }
 
   async getWorksheet(sheetIndex: number): Promise<Worksheet> {


### PR DESCRIPTION
## Summary

Parses xlsx sheet visibility (`<sheet state>`, ECMA-376 §18.2.19 `ST_SheetState` = `visible` | `hidden` | `veryHidden`) and lets `XlsxViewer` choose how hidden sheets are presented — mirroring the pptx hidden-slide modes from #637. Closes the fidelity gap where a hidden worksheet rendered as a fully visible, clickable tab.

Also consolidates the two format-agnostic skip-navigation helpers into `@silurus/ooxml-core` so pptx and xlsx share one implementation instead of duplicating.

## Three modes (`XlsxViewer`, default `'show'` = backward-compatible)

- `'show'`: every sheet gets a tab — current behavior.
- `'skip'`: hidden/veryHidden sheets get **no tab** and are jumped over by `nextSheet`/`prevSheet` and initial load. **Absolute indices preserved** (explicit `goToSheet(i)` to a hidden sheet still honored) — Excel-faithful.
- `'dim'`: hidden/veryHidden tabs are shown greyed but stay selectable (PowerPoint-thumbnail parallel).

## Design: facts in the engine, policy in the viewer (mirrors pptx)

| Layer | What it owns |
|---|---|
| `XlsxWorkbook` (engine) | **facts** — `isHidden(sheetIndex)` (non-clamped, mirrors `PptxPresentation.isHidden`) and `sheetVisibility(sheetIndex)` (`'visible'\|'hidden'\|'veryHidden'`, preserves the veryHidden distinction `isHidden` collapses) |
| `XlsxViewer` (policy) | `hiddenSheetMode` enum, `setHiddenSheetMode()` (runtime switch), skip navigation, per-mode tab styling, `visibleSheetCount` |

The `veryHidden` distinction is preserved as a fact (`sheetVisibility`); the viewer's modes treat hidden and veryHidden alike, leaving the Excel "veryHidden is programmatic-only" nuance to consumers.

## Cross-package consolidation (no duplication)

`nextVisibleIndex` / `resolveVisibleIndex` were pptx-local pure helpers (index math over an `(i)=>boolean` callback — format-agnostic). This PR hoists them to `@silurus/ooxml-core`; pptx re-exports them (its imports/tests unchanged), and xlsx imports them from core. `selectHidden` (pptx, `Slide`-specific) and the new `selectSheetVisibility` (xlsx) stay per-package.

## Commits (1 concern = 1 commit)

1. `refactor(core)`: hoist `nextVisibleIndex`/`resolveVisibleIndex` from pptx to core
2. `feat(xlsx)`: parse `<sheet state>` into `SheetMeta.visibility` (§18.2.19; `veryHidden` preserved, `Visible` omitted from JSON)
3. `feat(xlsx)`: `XlsxWorkbook.isHidden` / `sheetVisibility` (+ pure `selectSheetVisibility`)
4. `feat(xlsx)`: `XlsxViewer` modes + `setHiddenSheetMode`

## Public API additions

- `XlsxViewerOptions.hiddenSheetMode?: 'show' | 'skip' | 'dim'` (default `'show'`)
- `XlsxViewer.setHiddenSheetMode(mode)`, `.hiddenSheetMode`, `.visibleSheetCount`
- `XlsxWorkbook.isHidden(sheetIndex)`, `.sheetVisibility(sheetIndex)`
- `SheetMeta.visibility?: 'hidden' | 'veryHidden'`; new `SheetVisibility`, `HiddenSheetMode` exported types
- core: `nextVisibleIndex`, `resolveVisibleIndex`

## Testing

- Rust: `sheet_state_attr_maps_to_visibility` (hidden/veryHidden/visible/absent). `cargo fmt`/`clippy -D warnings`/`test` (70) all clean.
- TS: core `visible-index.test.ts` (8), xlsx `sheet-visibility.test.ts` (3), xlsx `viewer-hidden.test.ts` (compile-time API surface, mirroring pptx). xlsx suite **239 passing**; pptx unaffected (helpers via re-export).
- `pnpm typecheck`: pass.

> Note: full-workspace `pnpm test` shows 2 failures in `packages/node/src/source-buffer-image.test.ts` — a **pre-existing, environment-dependent** skia-canvas `loadImage` issue. That file is byte-identical to `main` (this branch touches only core/pptx/xlsx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)