### PR TITLE
feat(core): render WMF embedded raster bitmaps (META_STRETCHDIBITS)

### DIFF
--- a/packages/core/src/image/dib.test.ts
+++ b/packages/core/src/image/dib.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { decodeDib, decodePackedDib, blitDibToCtx, type DecodedDib } from './dib.js';
+
+// ── DIB decode unit tests ────────────────────────────────────────────────────
+// Both metafile players embed raster bitmaps as DIBs (BITMAPINFOHEADER + optional
+// palette + pixel bits). EMF passes explicit bmi/bits offsets → decodeDib; WMF
+// stores the DIB *packed* (contiguous) → decodePackedDib, which derives the
+// palette/bits offsets and delegates to decodeDib. We hand-build tiny DIBs and
+// assert the returned top-down RGBA matches the BGR/palette source.
+//
+// blitDibToCtx needs OffscreenCanvas (absent in the node test env), so it is only
+// asserted to return false there — pixel output is not testable here.
+
+/** Little-endian byte writer for crafting DIB bytes. */
+class Writer {
+  private bytes: number[] = [];
+  u8(v: number) {
+    this.bytes.push(v & 0xff);
+    return this;
+  }
+  u16(v: number) {
+    this.bytes.push(v & 0xff, (v >>> 8) & 0xff);
+    return this;
+  }
+  i32(v: number) {
+    const u = v >>> 0;
+    this.bytes.push(u & 0xff, (u >>> 8) & 0xff, (u >>> 16) & 0xff, (u >>> 24) & 0xff);
+    return this;
+  }
+  u32(v: number) {
+    return this.i32(v);
+  }
+  build(): Uint8Array {
+    return new Uint8Array(this.bytes);
+  }
+  get length(): number {
+    return this.bytes.length;
+  }
+}
+
+/** BITMAPINFOHEADER (40 bytes). height<0 ⇒ top-down. */
+function bmih(width: number, height: number, bitCount: number, clrUsed = 0): Writer {
+  return new Writer()
+    .u32(40) // biSize
+    .i32(width) // biWidth
+    .i32(height) // biHeight (negative = top-down)
+    .u16(1) // biPlanes
+    .u16(bitCount) // biBitCount
+    .u32(0) // biCompression = BI_RGB
+    .u32(0) // biSizeImage
+    .i32(0) // biXPelsPerMeter
+    .i32(0) // biYPelsPerMeter
+    .u32(clrUsed) // biClrUsed
+    .u32(0); // biClrImportant
+}
+
+/** A top-down 2×2 24-bit BI_RGB DIB. Pixels are given as [r,g,b] top-down,
+ *  row-major; stored on disk as BGR with each row padded to a 4-byte boundary
+ *  (rowStride = ((2*24+31)>>5)<<2 = 8 bytes, i.e. 6 pixel bytes + 2 pad). */
+function dib24(px: [number, number, number][]): { bytes: Uint8Array; bitsOff: number } {
+  const w = new Writer();
+  // header (top-down: negative height)
+  const header = bmih(2, -2, 24).build();
+  for (const b of header) w.u8(b);
+  const bitsOff = w.length;
+  // row 0 = px[0],px[1]; row 1 = px[2],px[3]; each pixel BGR; pad row to 8 bytes.
+  for (let row = 0; row < 2; row++) {
+    for (let col = 0; col < 2; col++) {
+      const [r, g, b] = px[row * 2 + col];
+      w.u8(b).u8(g).u8(r); // BGR on disk
+    }
+    w.u8(0).u8(0); // 2 pad bytes → 8-byte row stride
+  }
+  return { bytes: w.build(), bitsOff };
+}
+
+function dvOf(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function rgbaAt(dib: DecodedDib, x: number, y: number): [number, number, number, number] {
+  const i = (y * dib.width + x) * 4;
+  return [dib.data[i], dib.data[i + 1], dib.data[i + 2], dib.data[i + 3]];
+}
+
+describe('decodeDib — explicit bmi/bits offsets (EMF-style)', () => {
+  it('decodes a top-down 2×2 24-bit BI_RGB DIB, mapping BGR→RGBA (row 4-byte aligned)', () => {
+    const pixels: [number, number, number][] = [
+      [255, 0, 0], // (0,0) red
+      [0, 255, 0], // (1,0) green
+      [0, 0, 255], // (0,1) blue
+      [10, 20, 30], // (1,1)
+    ];
+    const { bytes, bitsOff } = dib24(pixels);
+    const dv = dvOf(bytes);
+    const dib = decodeDib(dv, 0, 40, bitsOff, bytes.length - bitsOff);
+    expect(dib).not.toBeNull();
+    const d = dib as DecodedDib;
+    expect(d.width).toBe(2);
+    expect(d.height).toBe(2);
+    // Top-down: dst row order matches src row order.
+    expect(rgbaAt(d, 0, 0)).toEqual([255, 0, 0, 255]);
+    expect(rgbaAt(d, 1, 0)).toEqual([0, 255, 0, 255]);
+    expect(rgbaAt(d, 0, 1)).toEqual([0, 0, 255, 255]);
+    expect(rgbaAt(d, 1, 1)).toEqual([10, 20, 30, 255]);
+  });
+
+  it('flips a BOTTOM-UP DIB so the returned data is top-down', () => {
+    // Same pixels but authored bottom-up (positive height). Build manually: on
+    // disk the FIRST stored row is the BOTTOM (y=1) row.
+    const w = new Writer();
+    for (const b of bmih(2, 2, 24).build()) w.u8(b);
+    const bitsOff = w.length;
+    // stored row 0 (disk) = image bottom row (y=1): blue, then [10,20,30]
+    w.u8(255).u8(0).u8(0).u8(30).u8(20).u8(10).u8(0).u8(0); // BGR: blue=(0,0,255) → B=255; (10,20,30)→B=30,G=20,R=10
+    // stored row 1 (disk) = image top row (y=0): red, then green
+    w.u8(0).u8(0).u8(255).u8(0).u8(255).u8(0).u8(0).u8(0);
+    const bytes = w.build();
+    const dib = decodeDib(dvOf(bytes), 0, 40, bitsOff, bytes.length - bitsOff);
+    const d = dib as DecodedDib;
+    // After flip, y=0 is the top (red/green), y=1 the bottom (blue/…).
+    expect(rgbaAt(d, 0, 0)).toEqual([255, 0, 0, 255]);
+    expect(rgbaAt(d, 1, 0)).toEqual([0, 255, 0, 255]);
+    expect(rgbaAt(d, 0, 1)).toEqual([0, 0, 255, 255]);
+    expect(rgbaAt(d, 1, 1)).toEqual([10, 20, 30, 255]);
+  });
+
+  it('returns null for a non-BI_RGB (compressed) header', () => {
+    const w = new Writer()
+      .u32(40)
+      .i32(2)
+      .i32(-2)
+      .u16(1)
+      .u16(24)
+      .u32(1) // biCompression = BI_RLE8 (non-zero → unsupported)
+      .u32(0)
+      .i32(0)
+      .i32(0)
+      .u32(0)
+      .u32(0);
+    for (let i = 0; i < 16; i++) w.u8(0);
+    const bytes = w.build();
+    expect(decodeDib(dvOf(bytes), 0, 40, 40, bytes.length - 40)).toBeNull();
+  });
+});
+
+describe('decodePackedDib — contiguous header+palette+bits (WMF-style)', () => {
+  it('decodes a packed 24-bit DIB by deriving bitsOff after the 40-byte header (no palette)', () => {
+    const { bytes } = dib24([
+      [255, 0, 0],
+      [0, 255, 0],
+      [0, 0, 255],
+      [10, 20, 30],
+    ]);
+    const dib = decodePackedDib(dvOf(bytes), 0, bytes.length);
+    expect(dib).not.toBeNull();
+    const d = dib as DecodedDib;
+    expect(d.width).toBe(2);
+    expect(d.height).toBe(2);
+    expect(rgbaAt(d, 0, 0)).toEqual([255, 0, 0, 255]);
+    expect(rgbaAt(d, 1, 1)).toEqual([10, 20, 30, 255]);
+  });
+
+  it('decodes an 8-bit palette DIB, skipping the RGBQUAD palette to reach the bits', () => {
+    // 2×2, 8bpp, top-down. Palette of 3 entries (clrUsed=3): index0=red,
+    // 1=green, 2=blue (RGBQUAD is B,G,R,reserved). rowStride = ((2*8+31)>>5)<<2
+    // = 4 bytes (2 index bytes + 2 pad).
+    const w = new Writer();
+    for (const b of bmih(2, -2, 8, 3).build()) w.u8(b);
+    // palette (BGR + reserved):
+    w.u8(0).u8(0).u8(255).u8(0); // idx0 red
+    w.u8(0).u8(255).u8(0).u8(0); // idx1 green
+    w.u8(255).u8(0).u8(0).u8(0); // idx2 blue
+    // pixel rows (indices), padded to 4 bytes each:
+    w.u8(0).u8(1).u8(0).u8(0); // row0: red, green
+    w.u8(2).u8(1).u8(0).u8(0); // row1: blue, green
+    const bytes = w.build();
+    const dib = decodePackedDib(dvOf(bytes), 0, bytes.length);
+    expect(dib).not.toBeNull();
+    const d = dib as DecodedDib;
+    expect(rgbaAt(d, 0, 0)).toEqual([255, 0, 0, 255]); // red
+    expect(rgbaAt(d, 1, 0)).toEqual([0, 255, 0, 255]); // green
+    expect(rgbaAt(d, 0, 1)).toEqual([0, 0, 255, 255]); // blue
+    expect(rgbaAt(d, 1, 1)).toEqual([0, 255, 0, 255]); // green
+  });
+
+  it('returns null when dibLen is too small for a header', () => {
+    const bytes = new Uint8Array(20);
+    expect(decodePackedDib(dvOf(bytes), 0, 20)).toBeNull();
+  });
+});
+
+describe('blitDibToCtx — OffscreenCanvas absent', () => {
+  it('returns false when OffscreenCanvas is undefined (node test env)', () => {
+    expect(typeof OffscreenCanvas).toBe('undefined');
+    const dib: DecodedDib = { width: 1, height: 1, data: new Uint8ClampedArray([1, 2, 3, 4]) };
+    // A minimal stub ctx — should never be touched when OffscreenCanvas is absent.
+    const ctx = { drawImage() { throw new Error('should not draw'); } } as unknown as CanvasRenderingContext2D;
+    expect(blitDibToCtx(ctx, dib, 0, 0, 1, 1)).toBe(false);
+  });
+});

--- a/packages/core/src/image/dib.test.ts
+++ b/packages/core/src/image/dib.test.ts
@@ -184,6 +184,31 @@ describe('decodePackedDib — contiguous header+palette+bits (WMF-style)', () =>
     expect(rgbaAt(d, 1, 1)).toEqual([0, 255, 0, 255]); // green
   });
 
+  it('skips an OPTIONAL optimization color table on a >8bpp DIB (biClrUsed > 0)', () => {
+    // A 24-bit DIB carries no indexed palette, but MAY prepend an optional
+    // optimization color table when biClrUsed > 0; the pixel bits then follow
+    // AFTER it ([MS-WMF] 2.2.2.9). clrUsed=2 → 8 palette bytes that must be
+    // skipped, else the bits offset misaligns and the decode is garbage.
+    const w = new Writer();
+    for (const b of bmih(2, -2, 24, 2).build()) w.u8(b); // clrUsed = 2
+    w.u8(1).u8(2).u8(3).u8(0).u8(4).u8(5).u8(6).u8(0);    // 2 RGBQUAD entries (skipped)
+    const px: [number, number, number][] = [
+      [10, 20, 30], [40, 50, 60], [70, 80, 90], [100, 110, 120],
+    ];
+    for (let row = 0; row < 2; row++) {
+      for (let col = 0; col < 2; col++) {
+        const [r, g, b] = px[row * 2 + col];
+        w.u8(b).u8(g).u8(r);
+      }
+      w.u8(0).u8(0); // row pad → 8-byte stride
+    }
+    const bytes = w.build();
+    const dib = decodePackedDib(dvOf(bytes), 0, bytes.length);
+    expect(dib).not.toBeNull();
+    expect(rgbaAt(dib as DecodedDib, 0, 0)).toEqual([10, 20, 30, 255]);
+    expect(rgbaAt(dib as DecodedDib, 1, 1)).toEqual([100, 110, 120, 255]);
+  });
+
   it('returns null when dibLen is too small for a header', () => {
     const bytes = new Uint8Array(20);
     expect(decodePackedDib(dvOf(bytes), 0, 20)).toBeNull();

--- a/packages/core/src/image/dib.ts
+++ b/packages/core/src/image/dib.ts
@@ -152,6 +152,12 @@ export function decodePackedDib(dv: DataView, dibOff: number, dibLen: number): D
     let clrUsed = dv.getUint32(dibOff + 32, true);
     if (clrUsed === 0) clrUsed = 1 << biBitCount;
     palEntries = clrUsed;
+  } else {
+    // A >8bpp DIB carries no indexed palette, but MAY still prepend an OPTIONAL
+    // optimization color table when `biClrUsed > 0` (BITMAPINFOHEADER /
+    // [MS-WMF] 2.2.2.9); the pixel bits then follow AFTER it. Skip those bytes so
+    // the derived `bitsOff` stays aligned (0 = no table, the common case).
+    palEntries = dv.getUint32(dibOff + 32, true);
   }
   const palBytes = palEntries * 4;
   const bmiLen = biSize + palBytes;

--- a/packages/core/src/image/dib.ts
+++ b/packages/core/src/image/dib.ts
@@ -1,0 +1,199 @@
+// ── DIB (Device-Independent Bitmap) decode + blit ────────────────────────────
+//
+// Both metafile players embed raster bitmaps as DIBs ([MS-WMF] 2.2.2.9
+// DeviceIndependentBitmap / [MS-EMF] 2.2.2.9), so the decode+blit lives here and
+// is shared by {@link ./emf.ts} (EMR_BITBLT / EMR_STRETCHDIBITS, which pass
+// explicit bmi/bits offsets) and {@link ./wmf.ts} (META_STRETCHDIBITS /
+// META_DIBBITBLT / META_DIBSTRETCHBLT, which store the DIB *packed* — header +
+// palette + pixels contiguously — via {@link decodePackedDib}).
+
+/** A decoded DIB as top-down RGBA (what `ImageData`/`putImageData` expects). */
+export interface DecodedDib {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray; // RGBA, top-down
+}
+
+/**
+ * Minimal DIB decoder: BITMAPINFOHEADER (40 bytes) + pixel data, supporting
+ * BI_RGB(0) at 32bpp (BGRA), 24bpp (BGR, 4-byte row padding) and 8bpp palette
+ * (RGBQUAD palette after the header). `bmiOff`/`bitsOff` are byte offsets into
+ * `dv`. Returns `null` for unsupported headers/compression.
+ */
+export function decodeDib(
+  dv: DataView,
+  bmiOff: number,
+  bmiLen: number,
+  bitsOff: number,
+  bitsLen: number,
+): DecodedDib | null {
+  if (bmiLen < 40 || bmiOff + 40 > dv.byteLength) return null;
+  const biSize = dv.getUint32(bmiOff, true);
+  if (biSize < 40) return null; // only BITMAPINFOHEADER (or larger) supported
+  const biWidth = dv.getInt32(bmiOff + 4, true);
+  const biHeightRaw = dv.getInt32(bmiOff + 8, true);
+  const biBitCount = dv.getUint16(bmiOff + 14, true);
+  const biCompression = dv.getUint32(bmiOff + 16, true);
+  if (biCompression !== 0) return null; // BI_RGB only
+  const topDown = biHeightRaw < 0;
+  const width = Math.abs(biWidth);
+  const height = Math.abs(biHeightRaw);
+  if (width <= 0 || height <= 0 || width > 1 << 16 || height > 1 << 16) return null;
+
+  const out = new Uint8ClampedArray(width * height * 4);
+  const rowStride = (((width * biBitCount + 31) >> 5) << 2) >>> 0; // 4-byte aligned
+  if (bitsOff + rowStride * height > bitsOff + bitsLen + rowStride) {
+    // Tolerate slight over-read; only bail if obviously out of buffer.
+    if (bitsOff + rowStride * height > dv.byteLength) return null;
+  }
+
+  // Palette for ≤8bpp follows the header.
+  let palette: number[] | null = null;
+  if (biBitCount <= 8) {
+    let clrUsed = dv.getUint32(bmiOff + 32, true);
+    if (clrUsed === 0) clrUsed = 1 << biBitCount;
+    const palOff = bmiOff + biSize;
+    palette = [];
+    for (let i = 0; i < clrUsed; i++) {
+      const o = palOff + i * 4;
+      if (o + 4 > dv.byteLength) break;
+      const b = dv.getUint8(o);
+      const g = dv.getUint8(o + 1);
+      const r = dv.getUint8(o + 2);
+      palette.push((r << 16) | (g << 8) | b);
+    }
+  }
+
+  const putPx = (dstRow: number, x: number, r: number, g: number, b: number, a: number) => {
+    const di = (dstRow * width + x) * 4;
+    out[di] = r;
+    out[di + 1] = g;
+    out[di + 2] = b;
+    out[di + 3] = a;
+  };
+
+  let anyAlpha = false;
+  for (let y = 0; y < height; y++) {
+    const srcRow = topDown ? y : height - 1 - y; // bottom-up unless negative
+    const dstRow = y;
+    const rowOff = bitsOff + srcRow * rowStride;
+    if (rowOff + rowStride > dv.byteLength) break;
+    if (biBitCount === 32) {
+      for (let x = 0; x < width; x++) {
+        const o = rowOff + x * 4;
+        const b = dv.getUint8(o);
+        const g = dv.getUint8(o + 1);
+        const r = dv.getUint8(o + 2);
+        const a = dv.getUint8(o + 3);
+        if (a !== 0) anyAlpha = true;
+        putPx(dstRow, x, r, g, b, a);
+      }
+    } else if (biBitCount === 24) {
+      for (let x = 0; x < width; x++) {
+        const o = rowOff + x * 3;
+        putPx(dstRow, x, dv.getUint8(o + 2), dv.getUint8(o + 1), dv.getUint8(o), 255);
+      }
+      anyAlpha = true;
+    } else if (biBitCount === 8 && palette) {
+      for (let x = 0; x < width; x++) {
+        const idx = dv.getUint8(rowOff + x);
+        const c = palette[idx] ?? 0;
+        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
+      }
+      anyAlpha = true;
+    } else if (biBitCount === 4 && palette) {
+      // 4bpp: two palette indices per byte, high nibble first (MATLAB exports the
+      // bar-chart fill as a 16-colour STRETCHDIBITS — sample-13 Fig.3 PR_VAR bars).
+      for (let x = 0; x < width; x++) {
+        const byte = dv.getUint8(rowOff + (x >> 1));
+        const idx = (x & 1) === 0 ? (byte >> 4) & 0xf : byte & 0xf;
+        const c = palette[idx] ?? 0;
+        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
+      }
+      anyAlpha = true;
+    } else if (biBitCount === 1 && palette) {
+      // 1bpp: eight palette indices per byte, MSB first (monochrome pattern
+      // brushes — gridlines/axes).
+      for (let x = 0; x < width; x++) {
+        const byte = dv.getUint8(rowOff + (x >> 3));
+        const bit = (byte >> (7 - (x & 7))) & 1;
+        const c = palette[bit] ?? 0;
+        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
+      }
+      anyAlpha = true;
+    } else {
+      return null; // unsupported bit depth
+    }
+  }
+
+  // 32bpp DIBs frequently store alpha=0 throughout (the BITBLT raster-op carries
+  // opacity instead). Treat an all-zero alpha plane as fully opaque.
+  if (biBitCount === 32 && !anyAlpha) {
+    for (let i = 3; i < out.length; i += 4) out[i] = 255;
+  }
+  return { width, height, data: out };
+}
+
+/**
+ * Decode a *packed* DIB — BITMAPINFOHEADER + optional palette + pixel bits, laid
+ * out contiguously — which is how WMF stores it inline in a record (the EMF
+ * records instead carry explicit bmi/bits offsets, so they call {@link decodeDib}
+ * directly). Reads `biSize`/`biBitCount`/`biClrUsed` from the header, computes
+ * the palette byte count, derives the pixel-bits offset, and delegates to
+ * {@link decodeDib}. `dibOff`/`dibLen` bound the packed blob within `dv`.
+ */
+export function decodePackedDib(dv: DataView, dibOff: number, dibLen: number): DecodedDib | null {
+  if (dibLen < 40 || dibOff + 40 > dv.byteLength) return null;
+  const biSize = dv.getUint32(dibOff, true);
+  if (biSize < 40) return null;
+  const biBitCount = dv.getUint16(dibOff + 14, true);
+  let palEntries = 0;
+  if (biBitCount <= 8) {
+    let clrUsed = dv.getUint32(dibOff + 32, true);
+    if (clrUsed === 0) clrUsed = 1 << biBitCount;
+    palEntries = clrUsed;
+  }
+  const palBytes = palEntries * 4;
+  const bmiLen = biSize + palBytes;
+  const bitsOff = dibOff + bmiLen;
+  const bitsLen = dibLen - bmiLen;
+  if (bitsLen <= 0) return null;
+  return decodeDib(dv, dibOff, bmiLen, bitsOff, bitsLen);
+}
+
+/**
+ * Blit a decoded DIB into the device rect `[x0,y0]`–`[x1,y1]` on `ctx`, via a
+ * temp OffscreenCanvas (`putImageData` the RGBA in, then `drawImage`-scale to the
+ * dest). Returns `true` if it drew, `false` if OffscreenCanvas is unavailable (no
+ * browser/worker canvas API) or any step throws. `x1<x0` / `y1<y0` are normalized
+ * to absolute width/height (the top-left corner is the min of the two corners).
+ */
+export function blitDibToCtx(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  dib: DecodedDib,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+): boolean {
+  if (typeof OffscreenCanvas === 'undefined') return false;
+  try {
+    const tmp = new OffscreenCanvas(dib.width, dib.height);
+    const tctx = tmp.getContext('2d') as OffscreenCanvasRenderingContext2D | null;
+    if (!tctx) return false;
+    // Allocate via createImageData (avoids the ImageData-constructor typed-array
+    // overload mismatch) and copy the decoded RGBA in.
+    const imgData = tctx.createImageData(dib.width, dib.height) as ImageData;
+    imgData.data.set(dib.data);
+    tctx.putImageData(imgData, 0, 0);
+    const dx = Math.min(x0, x1);
+    const dy = Math.min(y0, y1);
+    const dw = Math.abs(x1 - x0);
+    const dh = Math.abs(y1 - y0);
+    ctx.drawImage(tmp, dx, dy, dw, dh);
+    return true;
+  } catch {
+    // Unsupported / missing image API → skip the blit, keep rendering.
+    return false;
+  }
+}

--- a/packages/core/src/image/emf.ts
+++ b/packages/core/src/image/emf.ts
@@ -40,6 +40,7 @@
 // {@link ./wmf.ts}#decodeRasterOrMetafile, which sniffs the bytes and routes
 // true EMF here.
 
+import { decodeDib, blitDibToCtx, type DecodedDib } from './dib.js';
 import { colorRefToCss, isEmf } from './wmf.js';
 
 // EMF record type codes ([MS-EMF] 2.1.1 EMR enumeration; the subset we act on,
@@ -348,132 +349,11 @@ function selectStock(s: PlayState, handle: number): void {
 }
 
 // ── DIB decoder ([MS-WMF] 2.2.2.9 DeviceIndependentBitmap, BITMAPINFOHEADER) ──
-
-interface DecodedDib {
-  width: number;
-  height: number;
-  data: Uint8ClampedArray; // RGBA, top-down
-}
-
-/**
- * Minimal DIB decoder: BITMAPINFOHEADER (40 bytes) + pixel data, supporting
- * BI_RGB(0) at 32bpp (BGRA), 24bpp (BGR, 4-byte row padding) and 8bpp palette
- * (RGBQUAD palette after the header). `bmiOff`/`bitsOff` are byte offsets into
- * `dv`. Returns `null` for unsupported headers/compression.
- */
-function decodeDib(
-  dv: DataView,
-  bmiOff: number,
-  bmiLen: number,
-  bitsOff: number,
-  bitsLen: number,
-): DecodedDib | null {
-  if (bmiLen < 40 || bmiOff + 40 > dv.byteLength) return null;
-  const biSize = dv.getUint32(bmiOff, true);
-  if (biSize < 40) return null; // only BITMAPINFOHEADER (or larger) supported
-  const biWidth = dv.getInt32(bmiOff + 4, true);
-  const biHeightRaw = dv.getInt32(bmiOff + 8, true);
-  const biBitCount = dv.getUint16(bmiOff + 14, true);
-  const biCompression = dv.getUint32(bmiOff + 16, true);
-  if (biCompression !== 0) return null; // BI_RGB only
-  const topDown = biHeightRaw < 0;
-  const width = Math.abs(biWidth);
-  const height = Math.abs(biHeightRaw);
-  if (width <= 0 || height <= 0 || width > 1 << 16 || height > 1 << 16) return null;
-
-  const out = new Uint8ClampedArray(width * height * 4);
-  const rowStride = (((width * biBitCount + 31) >> 5) << 2) >>> 0; // 4-byte aligned
-  if (bitsOff + rowStride * height > bitsOff + bitsLen + rowStride) {
-    // Tolerate slight over-read; only bail if obviously out of buffer.
-    if (bitsOff + rowStride * height > dv.byteLength) return null;
-  }
-
-  // Palette for ≤8bpp follows the header.
-  let palette: number[] | null = null;
-  if (biBitCount <= 8) {
-    let clrUsed = dv.getUint32(bmiOff + 32, true);
-    if (clrUsed === 0) clrUsed = 1 << biBitCount;
-    const palOff = bmiOff + biSize;
-    palette = [];
-    for (let i = 0; i < clrUsed; i++) {
-      const o = palOff + i * 4;
-      if (o + 4 > dv.byteLength) break;
-      const b = dv.getUint8(o);
-      const g = dv.getUint8(o + 1);
-      const r = dv.getUint8(o + 2);
-      palette.push((r << 16) | (g << 8) | b);
-    }
-  }
-
-  const putPx = (dstRow: number, x: number, r: number, g: number, b: number, a: number) => {
-    const di = (dstRow * width + x) * 4;
-    out[di] = r;
-    out[di + 1] = g;
-    out[di + 2] = b;
-    out[di + 3] = a;
-  };
-
-  let anyAlpha = false;
-  for (let y = 0; y < height; y++) {
-    const srcRow = topDown ? y : height - 1 - y; // bottom-up unless negative
-    const dstRow = y;
-    const rowOff = bitsOff + srcRow * rowStride;
-    if (rowOff + rowStride > dv.byteLength) break;
-    if (biBitCount === 32) {
-      for (let x = 0; x < width; x++) {
-        const o = rowOff + x * 4;
-        const b = dv.getUint8(o);
-        const g = dv.getUint8(o + 1);
-        const r = dv.getUint8(o + 2);
-        const a = dv.getUint8(o + 3);
-        if (a !== 0) anyAlpha = true;
-        putPx(dstRow, x, r, g, b, a);
-      }
-    } else if (biBitCount === 24) {
-      for (let x = 0; x < width; x++) {
-        const o = rowOff + x * 3;
-        putPx(dstRow, x, dv.getUint8(o + 2), dv.getUint8(o + 1), dv.getUint8(o), 255);
-      }
-      anyAlpha = true;
-    } else if (biBitCount === 8 && palette) {
-      for (let x = 0; x < width; x++) {
-        const idx = dv.getUint8(rowOff + x);
-        const c = palette[idx] ?? 0;
-        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
-      }
-      anyAlpha = true;
-    } else if (biBitCount === 4 && palette) {
-      // 4bpp: two palette indices per byte, high nibble first (MATLAB exports the
-      // bar-chart fill as a 16-colour STRETCHDIBITS — sample-13 Fig.3 PR_VAR bars).
-      for (let x = 0; x < width; x++) {
-        const byte = dv.getUint8(rowOff + (x >> 1));
-        const idx = (x & 1) === 0 ? (byte >> 4) & 0xf : byte & 0xf;
-        const c = palette[idx] ?? 0;
-        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
-      }
-      anyAlpha = true;
-    } else if (biBitCount === 1 && palette) {
-      // 1bpp: eight palette indices per byte, MSB first (monochrome pattern
-      // brushes — gridlines/axes).
-      for (let x = 0; x < width; x++) {
-        const byte = dv.getUint8(rowOff + (x >> 3));
-        const bit = (byte >> (7 - (x & 7))) & 1;
-        const c = palette[bit] ?? 0;
-        putPx(dstRow, x, (c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff, 255);
-      }
-      anyAlpha = true;
-    } else {
-      return null; // unsupported bit depth
-    }
-  }
-
-  // 32bpp DIBs frequently store alpha=0 throughout (the BITBLT raster-op carries
-  // opacity instead). Treat an all-zero alpha plane as fully opaque.
-  if (biBitCount === 32 && !anyAlpha) {
-    for (let i = 3; i < out.length; i += 4) out[i] = 255;
-  }
-  return { width, height, data: out };
-}
+//
+// The decode + blit live in the shared {@link ./dib.ts} module (used by both the
+// EMF and WMF players); imported here as {@link decodeDib} / {@link blitDibToCtx}
+// / {@link DecodedDib}. `dibAverageColor` (EMF-only, for CREATEDIBPATTERNBRUSHPT
+// → average solid color) stays local.
 
 /** Average RGB of a decoded DIB (skipping fully transparent pixels) → CSS. */
 function dibAverageColor(dib: DecodedDib): string {
@@ -905,25 +785,11 @@ function blitDib(
   destB: number,
 ): void {
   if (cbBmi === 0 || cbBits === 0) return; // pattern-only blt → skip
-  try {
-    const dib = decodeDib(dv, recStart + offBmi, cbBmi, recStart + offBits, cbBits);
-    if (!dib) return;
-    if (typeof OffscreenCanvas === 'undefined') return;
-    const tmp = new OffscreenCanvas(dib.width, dib.height);
-    const tctx = tmp.getContext('2d') as OffscreenCanvasRenderingContext2D | null;
-    if (!tctx) return;
-    // Allocate via createImageData (avoids the ImageData-constructor typed-array
-    // overload mismatch) and copy the decoded RGBA in.
-    const imgData = tctx.createImageData(dib.width, dib.height) as ImageData;
-    imgData.data.set(dib.data);
-    tctx.putImageData(imgData, 0, 0);
-    const [x0, y0] = toPx(s, destL, destT);
-    const [x1, y1] = toPx(s, destR, destB);
-    s.ctx.drawImage(tmp, x0, y0, x1 - x0, y1 - y0);
-    s.drew = true;
-  } catch {
-    // Unsupported / missing image API → skip the blit, keep rendering.
-  }
+  const dib = decodeDib(dv, recStart + offBmi, cbBmi, recStart + offBits, cbBits);
+  if (!dib) return;
+  const [x0, y0] = toPx(s, destL, destT);
+  const [x1, y1] = toPx(s, destR, destB);
+  if (blitDibToCtx(s.ctx, dib, x0, y0, x1, y1)) s.drew = true;
 }
 
 /** EMR_BITBLT(76) ([MS-EMF] 2.3.1.2). */

--- a/packages/core/src/image/wmf.test.ts
+++ b/packages/core/src/image/wmf.test.ts
@@ -105,6 +105,7 @@ const FN = {
   RECTANGLE: 0x041b,
   CREATEPENINDIRECT: 0x02fa,
   CREATEBRUSHINDIRECT: 0x02fc,
+  STRETCHDIBITS: 0x0f43,
 } as const;
 
 // ── recording mock ctx (records the draw calls + style mutations) ───────────
@@ -550,6 +551,68 @@ describe('playWmf — robustness', () => {
   it('returns false for non-WMF bytes', () => {
     const m = makeRecordingCtx();
     expect(playWmf(new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0, 0, 0, 0]), m.ctx, 10, 10)).toBe(false);
+  });
+});
+
+// ── playWmf: STRETCHDIBITS embedded raster DIB ──────────────────────────────
+
+describe('playWmf — STRETCHDIBITS (embedded raster DIB)', () => {
+  // A META_STRETCHDIBITS record wraps a packed DIB. Its params (after the 6-byte
+  // header) are: u32 RasterOp, i16 SrcHeight/SrcWidth/YSrc/XSrc, u16 UsageSrc,
+  // i16 DestHeight/DestWidth/YDest/XDest, then the packed DIB. OffscreenCanvas is
+  // absent in the node test env, so blitDibToCtx returns false (no draw) — we
+  // assert the record parses without throwing and that later records still run.
+
+  /** Append a packed top-down 2×2 24-bit BI_RGB DIB (40-byte header + 16 pixel
+   *  bytes: 2 rows × 8-byte stride). Returns the same Writer for chaining. */
+  function packed2x2Dib24(w: Writer): Writer {
+    // BITMAPINFOHEADER (top-down: height = -2).
+    w.u32(40).u32(2).u32((-2) >>> 0).u16(1).u16(24).u32(0).u32(0).u32(0).u32(0).u32(0).u32(0);
+    // 2 rows, BGR pixels, each row padded to an 8-byte stride.
+    w.raw(0, 0, 255, 0, 255, 0, 0, 0); // row0: red (B0 G0 R255), green (B0 G255 R0), pad
+    w.raw(255, 0, 0, 30, 20, 10, 0, 0); // row1: blue, (10,20,30), pad
+    return w;
+  }
+
+  it('parses a STRETCHDIBITS record without throwing and continues to later records', () => {
+    const m = makeRecordingCtx();
+    const file = concat(
+      wmfHeader(),
+      record(FN.SETWINDOWORG, (w) => w.i16(0).i16(0)),
+      record(FN.SETWINDOWEXT, (w) => w.i16(100).i16(100)),
+      // STRETCHDIBITS: draw the DIB into dest rect (XDest=0,YDest=0, 50×50).
+      record(FN.STRETCHDIBITS, (w) => {
+        w.u32(0x00cc0020); // RasterOperation SRCCOPY (ignored)
+        w.i16(2).i16(2); // SrcHeight, SrcWidth
+        w.i16(0).i16(0); // YSrc, XSrc
+        w.u16(0); // UsageSrc (DIB_RGB_COLORS)
+        w.i16(50).i16(50); // DestHeight, DestWidth
+        w.i16(0).i16(0); // YDest, XDest
+        packed2x2Dib24(w); // packed DIB
+      }),
+      // A polyline AFTER the blt must still execute (proves the loop advanced past
+      // the STRETCHDIBITS record by its size, not by mis-parsing the DIB bytes).
+      record(FN.CREATEPENINDIRECT, (w) => w.u16(0).i16(1).i16(0).u32(0x000000ff)),
+      record(FN.SELECTOBJECT, (w) => w.u16(0)),
+      record(FN.POLYLINE, (w) => w.i16(2).i16(10).i16(10).i16(20).i16(20)),
+      record(FN.EOF, () => {}),
+    );
+
+    // No OffscreenCanvas in the node env ⇒ blitDibToCtx returns false (no draw);
+    // the parse path must still run cleanly and the trailing polyline strokes.
+    let drew = false;
+    expect(() => {
+      drew = playWmf(file, m.ctx, 100, 100);
+    }).not.toThrow();
+    // The trailing polyline drew, so playWmf reports true and the loop advanced
+    // past the STRETCHDIBITS record correctly.
+    expect(drew).toBe(true);
+    const strokes = m.calls.filter((c) => c.op === 'stroke');
+    expect(strokes.length).toBe(1);
+    expect(m.styles.stroke.at(-1)?.toLowerCase()).toBe('#ff0000');
+    // The polyline endpoints mapped ×1 (window 100 → device 100).
+    const moves = m.calls.filter((c) => c.op === 'moveTo');
+    expect(moves[0].args).toEqual([10, 10]);
   });
 });
 

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -18,9 +18,12 @@
 //
 // Implemented records: SETWINDOWORG, SETWINDOWEXT, SETPOLYFILLMODE,
 // CREATEPENINDIRECT, CREATEBRUSHINDIRECT, SELECTOBJECT, DELETEOBJECT,
-// POLYLINE, POLYGON, POLYPOLYGON, RECTANGLE, EOF.
+// POLYLINE, POLYGON, POLYPOLYGON, RECTANGLE, STRETCHDIBITS (embedded raster DIB
+// via the shared decoder in ./dib.ts), EOF.
 // Ignored (no-op, skipped by size): ESCAPE, SETROP2, SETBKMODE, SETTEXTALIGN,
-// SETSTRETCHBLTMODE, SETMAPMODE, and any unrecognized record.
+// SETSTRETCHBLTMODE, SETMAPMODE, DIBBITBLT/DIBSTRETCHBLT (their exact param
+// layout is not decoded here — skipped rather than mis-parsed), and any
+// unrecognized record.
 //
 // Shared across the docx, pptx and xlsx renderers (originally docx-only). The
 // device-boundary edge-suppression heuristic (see `deviceInteriorEdges`) is a
@@ -33,6 +36,7 @@
 // by the sibling player {@link ./emf.ts}#renderEmfToBitmap, routed from
 // {@link decodeRasterOrMetafile}.
 
+import { decodePackedDib, blitDibToCtx } from './dib.js';
 import { renderEmfToBitmap } from './emf.js';
 
 // WMF record function codes (the subset we act on; others are skipped by size).
@@ -49,6 +53,9 @@ const META = {
   RECTANGLE: 0x041b,
   CREATEPENINDIRECT: 0x02fa,
   CREATEBRUSHINDIRECT: 0x02fc,
+  DIBBITBLT: 0x0940,
+  DIBSTRETCHBLT: 0x0b41,
+  STRETCHDIBITS: 0x0f43,
 } as const;
 
 const PLACEABLE_MAGIC = 0x9ac6cdd7; // little-endian bytes D7 CD C6 9A
@@ -559,6 +566,46 @@ export function playWmf(
         ]);
         break;
       }
+      case META.STRETCHDIBITS: {
+        // META_STRETCHDIBITS ([MS-WMF] 2.3.1.6). Params after the 6-byte
+        // size+function header, all little-endian:
+        //   u32 RasterOperation, i16 SrcHeight, i16 SrcWidth, i16 YSrc, i16 XSrc,
+        //   u16 UsageSrc, i16 DestHeight, i16 DestWidth, i16 YDest, i16 XDest,
+        //   then the packed DIB (BITMAPINFOHEADER + palette + pixel bits).
+        // We ignore the raster-op (draw plainly, like the EMF player) and draw
+        // the whole DIB, so Src{Height,Width,X,Y} and UsageSrc are read but unused.
+        c.u32(); // RasterOperation (ignored)
+        c.i16(); // SrcHeight (unused — whole DIB drawn)
+        c.i16(); // SrcWidth
+        c.i16(); // YSrc
+        c.i16(); // XSrc
+        c.u16(); // UsageSrc (unused)
+        const destHeight = c.i16();
+        const destWidth = c.i16();
+        const yDest = c.i16();
+        const xDest = c.i16();
+        // The packed DIB begins at the current cursor position:
+        //   paramStart + 22  (22 = u32 RasterOperation + 9 × i16/u16 = 4 + 18).
+        const dibOff = paramStart + 22;
+        const dibLen = recEnd - dibOff;
+        const dib = decodePackedDib(dv, dibOff, dibLen);
+        if (dib) {
+          const x0 = mapX(s, xDest);
+          const y0 = mapY(s, yDest);
+          const x1 = mapX(s, xDest + destWidth);
+          const y1 = mapY(s, yDest + destHeight);
+          if (blitDibToCtx(s.ctx, dib, x0, y0, x1, y1)) s.drew = true;
+        }
+        break;
+      }
+      case META.DIBSTRETCHBLT:
+      case META.DIBBITBLT:
+        // META_DIBBITBLT / META_DIBSTRETCHBLT ([MS-WMF] 2.3.1.2 / 2.3.1.3) also
+        // carry a packed DIB, but with a different (raster-op-dependent) preamble
+        // whose exact layout we do not decode here. Skipping is safer than
+        // guessing an offset that could mis-parse; STRETCHDIBITS covers the
+        // common embedded-raster case.
+        break;
       default:
         // ESCAPE, SETROP2, SETBKMODE, SETTEXTALIGN, SETSTRETCHBLTMODE,
         // SETMAPMODE, and anything unrecognized: skip by record size.


### PR DESCRIPTION
## Problem
A WMF that embeds a raster via `META_STRETCHDIBITS` (0x0F43) — e.g. the Creative Commons licence badge on `private/sample-6.docx` page 1 — rendered as a solid **black box**. `playWmf` handled only vector records and silently skipped the DIB, so only the underlying black `Rectangle` fill remained.

Before → after (sample-6 p.1 CC badge, Chromium):
- Before: solid black rectangle where the badge should be.
- After: the CC BY-NC-SA badge renders correctly (dark glyphs on light ground).

## Fix
`emf.ts` already had a working DIB decoder + blit, so this **consolidates it into a shared `core/image/dib.ts`** (per the repo's DRY / shared-layer principle) and uses it from BOTH metafile players — no duplicated decoder:

- `decodeDib` (moved verbatim from `emf.ts`; BI_RGB 1/4/8/24/32 bpp)
- `decodePackedDib` (new) — WMF stores the DIB *packed* (header + palette + pixels contiguous) inline in the record
- `blitDibToCtx` (new) — temp-canvas `putImageData` → `drawImage` into the dest rect

`playWmf` gains a `META_STRETCHDIBITS` case ([MS-WMF] 2.3.1.6): it parses the dest rect, maps the corners through the existing `mapX`/`mapY`, decodes the inline packed DIB, and blits. The raster-op is ignored (plain `drawImage`), matching the EMF player. `DIBBITBLT` / `DIBSTRETCHBLT` are **skipped rather than mis-parsed** (their raster-op-dependent preamble is not decoded).

## Cross-package
The decoder is shared, so any WMF-with-embedded-raster now rasterizes for **docx, pptx and xlsx** alike (all route through `decodeRasterOrMetafile`).

## Verification
- New `dib.test.ts` (decodeDib / decodePackedDib against hand-built 24-bit + 8-bit-palette DIBs; blitDibToCtx guard).
- New `wmf.test.ts` STRETCHDIBITS parse test.
- All core image tests green (81 passed).
- Visually confirmed the sample-6 CC badge renders correctly in the browser (Chromium) render.

## Scope note
`private/sample-6.docx` p.1 has two further, unrelated differences vs Word (a text box's 3rd line showing that Word clips; the text box sitting ~16 pt too high). Those are a separate docx text-box vertical-layout concern (parser spacing inheritance + shared shape-text layout) and are tracked as a follow-up — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)