### PR TITLE
fix(docx): text-box vertical layout — clip noAutofit boxes, inherit paragraph spacing/line-spacing

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3824,8 +3824,15 @@ fn parse_wsp_shape(
 
     // Shape body text: <wps:txbx><w:txbxContent>...</w:txbxContent></wps:txbx>
     // and the bodyPr (insets / vertical anchor).
-    let (text_blocks, text_anchor, text_inset_l, text_inset_t, text_inset_r, text_inset_b) =
-        parse_shape_text_body(style_map, wsp, theme, media_map);
+    let (
+        text_blocks,
+        text_anchor,
+        text_autofit,
+        text_inset_l,
+        text_inset_t,
+        text_inset_r,
+        text_inset_b,
+    ) = parse_shape_text_body(style_map, wsp, theme, media_map);
 
     Some(ShapeRun {
         width_pt,
@@ -3851,6 +3858,7 @@ fn parse_wsp_shape(
         wrap_mode: anchor_meta.wrap_mode.clone(),
         text_blocks,
         text_anchor,
+        text_autofit,
         text_inset_l,
         text_inset_t,
         text_inset_r,
@@ -3874,7 +3882,15 @@ fn parse_shape_text_body(
     wsp: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
-) -> (Vec<ShapeText>, Option<String>, f64, f64, f64, f64) {
+) -> (
+    Vec<ShapeText>,
+    Option<String>,
+    Option<String>,
+    f64,
+    f64,
+    f64,
+    f64,
+) {
     let txbx = wsp
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "txbx");
@@ -3885,6 +3901,17 @@ fn parse_shape_text_body(
     let anchor = body_pr
         .and_then(|b| b.attribute("anchor"))
         .map(|s| s.to_string());
+    // ECMA-376 §21.1.2.1.1 auto-fit: the bodyPr's autofit is a CHILD element,
+    // one of <a:noAutofit/> / <a:spAutoFit/> / <a:normAutofit/>. Record its tag
+    // so the renderer can clip a fixed (noAutofit) box's overflowing text.
+    let autofit = body_pr.and_then(|b| {
+        b.children().find_map(|n| match n.tag_name().name() {
+            name @ ("noAutofit" | "spAutoFit" | "normAutofit") if n.is_element() => {
+                Some(name.to_string())
+            }
+            _ => None,
+        })
+    });
     let emu_to_pt = |v: &str| v.parse::<f64>().ok().map(|e| e / 12700.0).unwrap_or(0.0);
     // ECMA-376 §21.1.2.1.1 defaults: lIns=rIns=91440 EMU, tIns=bIns=45720 EMU
     let l = body_pr
@@ -3917,7 +3944,7 @@ fn parse_shape_text_body(
         })
         .unwrap_or_default();
 
-    (blocks, anchor, l, t, r, b)
+    (blocks, anchor, autofit, l, t, r, b)
 }
 
 /// Reduce a <w:p> inside <w:txbxContent> to a single ShapeText. Pulls
@@ -4092,15 +4119,46 @@ fn extract_simple_paragraph_text(
     // reserved INSIDE the text box (twips → pt). Word offsets the text down by
     // `w:before` (sample-13's "Journal homepage" line carries `w:before="1000"`,
     // i.e. 50 pt, which is why it sits well below the box top). Absent ⇒ 0.
+    // Per-attribute resolution mirroring the indent path above: a direct
+    // `w:before`/`w:after` wins; otherwise inherit the style-chain-resolved value
+    // (`style_para`, which folds in docDefaults §17.7.2). Without the style
+    // fallback a txbxContent paragraph carrying no direct `<w:spacing>` lost the
+    // inter-paragraph gaps Word applies (sample-6's 3-line box then kept its
+    // clipped 3rd line visible).
     let spacing = child_w(p, "pPr").and_then(|ppr| child_w(ppr, "spacing"));
     let space_before = spacing
         .and_then(|s| attr_w(s, "before"))
         .map(|v| twips_to_pt(&v))
+        .or(style_para.space_before)
         .unwrap_or(0.0);
     let space_after = spacing
         .and_then(|s| attr_w(s, "after"))
         .map(|v| twips_to_pt(&v))
+        .or(style_para.space_after)
         .unwrap_or(0.0);
+    // ECMA-376 §17.3.1.33 line spacing (line/lineRule), same direct-wins-then-
+    // style fallback. Encoding matches styles.rs: auto ⇒ raw/240 (multiplier on
+    // the natural line box), exact/atLeast ⇒ raw/20 (pt). A txbxContent paragraph
+    // with no direct line inherits the style chain's value (sample-6 inherits the
+    // docDefault `line=276 lineRule=auto` = 1.15×, which grows the 3-line box past
+    // its 82 pt bound so Word — and now the renderer — clips the 3rd line).
+    let (line_spacing_val, line_spacing_rule) = match spacing.and_then(|s| attr_w(s, "line")) {
+        Some(v) => {
+            let raw: f64 = v.parse().unwrap_or(240.0);
+            let rule = spacing
+                .and_then(|s| attr_w(s, "lineRule"))
+                .unwrap_or_else(|| "auto".to_string());
+            match rule.as_str() {
+                "exact" => (Some(raw / 20.0), Some("exact".to_string())),
+                "atLeast" => (Some(raw / 20.0), Some("atLeast".to_string())),
+                _ => (Some(raw / 240.0), Some("auto".to_string())),
+            }
+        }
+        None => (
+            style_para.line_spacing_val,
+            style_para.line_spacing_rule.clone(),
+        ),
+    };
 
     // Single block-level format fields come from the FIRST text run (kept for
     // backward compatibility with existing consumers and the image-block path).
@@ -4139,6 +4197,8 @@ fn extract_simple_paragraph_text(
         alignment: normalize_align(&alignment).to_string(),
         space_before,
         space_after,
+        line_spacing_val,
+        line_spacing_rule,
         indent_left,
         indent_right,
         indent_first,
@@ -8867,7 +8927,7 @@ mod txbx_inline_image_tests {
         let mut media = HashMap::new();
         media.insert("rIdImg".to_string(), "word/media/image1.emf".to_string());
 
-        let (blocks, _anchor, _l, _t, _r, _b) = parse_shape_text_body(
+        let (blocks, _anchor, _autofit, _l, _t, _r, _b) = parse_shape_text_body(
             &StyleMap::default(),
             doc.root_element(),
             &ThemeColors::default(),
@@ -8905,6 +8965,44 @@ mod txbx_inline_image_tests {
             "caption paragraph carries no image"
         );
         assert_eq!(blocks[1].alignment, "center");
+    }
+
+    /// `parse_shape_text_body` records the bodyPr auto-fit CHILD element
+    /// (§21.1.2.1.1): `<a:noAutofit/>` ⇒ Some("noAutofit") (fixed box → the
+    /// renderer clips overflow), `<a:spAutoFit/>` ⇒ Some("spAutoFit"), and an
+    /// absent auto-fit ⇒ None (overflow visible).
+    #[test]
+    fn parse_shape_text_body_records_autofit_mode() {
+        let wsp = |body_pr: &str| {
+            format!(
+                r#"<wps:wsp
+                     xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+                     xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                     xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                     <wps:txbx><w:txbxContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:txbxContent></wps:txbx>
+                     {body_pr}
+                   </wps:wsp>"#
+            )
+        };
+        let autofit_of = |xml: String| {
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            parse_shape_text_body(
+                &StyleMap::default(),
+                doc.root_element(),
+                &ThemeColors::default(),
+                &HashMap::new(),
+            )
+            .2
+        };
+        assert_eq!(
+            autofit_of(wsp(r#"<wps:bodyPr><a:noAutofit/></wps:bodyPr>"#)).as_deref(),
+            Some("noAutofit")
+        );
+        assert_eq!(
+            autofit_of(wsp(r#"<wps:bodyPr><a:spAutoFit/></wps:bodyPr>"#)).as_deref(),
+            Some("spAutoFit")
+        );
+        assert_eq!(autofit_of(wsp(r#"<wps:bodyPr/>"#)), None);
     }
 
     /// An image-only paragraph (empty text) must NOT be dropped — the prior
@@ -9015,6 +9113,57 @@ mod txbx_inline_image_tests {
         .unwrap();
         assert!((block.space_before - 50.0).abs() < 1e-6);
         assert!((block.space_after - 9.0).abs() < 1e-6);
+    }
+
+    /// A text-box paragraph with NO direct `<w:spacing>` inherits space
+    /// before/after from its style chain (§17.3.1.33 + docDefaults), the same
+    /// way indent resolves. Per attribute: a direct value overrides the style;
+    /// an absent one falls through to the style. (Regression: sample-6's txbx
+    /// paragraphs had no direct spacing, so the 3-line box lost the inter-
+    /// paragraph gaps Word applies and its clipped 3rd line stayed visible.)
+    #[test]
+    fn extract_simple_paragraph_text_inherits_style_spacing() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Spaced">
+                <w:pPr><w:spacing w:before="240" w:after="120"/></w:pPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        // No direct spacing → both inherit from the style (240 tw = 12 pt, 120 tw = 6 pt).
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Spaced"/></w:pPr>
+                 <w:r><w:t>x</w:t></w:r></w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert!((block.space_before - 12.0).abs() < 1e-6);
+        assert!((block.space_after - 6.0).abs() < 1e-6);
+
+        // A direct `after` overrides the style per-attribute; `before` (absent
+        // on the direct spacing) still inherits.
+        let doc2 = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Spaced"/><w:spacing w:after="360"/></w:pPr>
+                 <w:r><w:t>x</w:t></w:r></w:p>"#,
+        )
+        .unwrap();
+        let block2 = extract_simple_paragraph_text(
+            &styles,
+            doc2.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert!((block2.space_before - 12.0).abs() < 1e-6);
+        assert!((block2.space_after - 18.0).abs() < 1e-6);
     }
 
     /// ECMA-376 §17.3.1.12 — a text-box paragraph surfaces its own `<w:ind>`

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3902,13 +3902,17 @@ fn parse_shape_text_body(
         .and_then(|b| b.attribute("anchor"))
         .map(|s| s.to_string());
     // ECMA-376 §21.1.2.1.1 auto-fit: the bodyPr's autofit is a CHILD element,
-    // one of <a:noAutofit/> / <a:spAutoFit/> / <a:normAutofit/>. Record its tag
-    // so the renderer can clip a fixed (noAutofit) box's overflowing text.
+    // one of <a:noAutofit/> / <a:spAutoFit/> / <a:normAutofit/>. Normalize it to
+    // the shared core vocabulary (packages/core src/types/common.ts `autoFit`):
+    // `noAutofit → "none"` (fixed box → the renderer clips overflow),
+    // `spAutoFit → "sp"` (box grows to fit), `normAutofit → "norm"` (text
+    // shrinks to fit). This matches the pptx path so all three formats emit the
+    // same enum; an absent auto-fit ⇒ None (overflow visible).
     let autofit = body_pr.and_then(|b| {
         b.children().find_map(|n| match n.tag_name().name() {
-            name @ ("noAutofit" | "spAutoFit" | "normAutofit") if n.is_element() => {
-                Some(name.to_string())
-            }
+            "noAutofit" if n.is_element() => Some("none".to_string()),
+            "spAutoFit" if n.is_element() => Some("sp".to_string()),
+            "normAutofit" if n.is_element() => Some("norm".to_string()),
             _ => None,
         })
     });
@@ -4119,46 +4123,30 @@ fn extract_simple_paragraph_text(
     // reserved INSIDE the text box (twips → pt). Word offsets the text down by
     // `w:before` (sample-13's "Journal homepage" line carries `w:before="1000"`,
     // i.e. 50 pt, which is why it sits well below the box top). Absent ⇒ 0.
-    // Per-attribute resolution mirroring the indent path above: a direct
-    // `w:before`/`w:after` wins; otherwise inherit the style-chain-resolved value
-    // (`style_para`, which folds in docDefaults §17.7.2). Without the style
-    // fallback a txbxContent paragraph carrying no direct `<w:spacing>` lost the
-    // inter-paragraph gaps Word applies (sample-6's 3-line box then kept its
-    // clipped 3rd line visible).
-    let spacing = child_w(p, "pPr").and_then(|ppr| child_w(ppr, "spacing"));
-    let space_before = spacing
-        .and_then(|s| attr_w(s, "before"))
-        .map(|v| twips_to_pt(&v))
+    // Resolved EXACTLY like the indent path above — direct `<w:spacing>` wins
+    // (via `parse_para_fmt`'s `direct_ind`, which reads the paragraph's OWN
+    // `<w:pPr>`), else inherit the style-chain-resolved value (`style_para`,
+    // which folds in docDefaults §17.7.2). `ParaFmt` already carries the
+    // spaceBefore/After and line/lineRule values with the same twips→pt and
+    // auto⇒raw/240 · exact/atLeast⇒raw/20 encoding, so we reuse them instead of
+    // re-parsing `<w:spacing>` here. Without the style fallback a txbxContent
+    // paragraph carrying no direct `<w:spacing>` lost the inter-paragraph gaps
+    // Word applies (sample-6's 3-line box then kept its clipped 3rd line
+    // visible); the docDefault `line=276 lineRule=auto` = 1.15× likewise grows
+    // the 3-line box past its 82 pt bound so Word — and the renderer — clip it.
+    let space_before = direct_ind
+        .space_before
         .or(style_para.space_before)
         .unwrap_or(0.0);
-    let space_after = spacing
-        .and_then(|s| attr_w(s, "after"))
-        .map(|v| twips_to_pt(&v))
+    let space_after = direct_ind
+        .space_after
         .or(style_para.space_after)
         .unwrap_or(0.0);
-    // ECMA-376 §17.3.1.33 line spacing (line/lineRule), same direct-wins-then-
-    // style fallback. Encoding matches styles.rs: auto ⇒ raw/240 (multiplier on
-    // the natural line box), exact/atLeast ⇒ raw/20 (pt). A txbxContent paragraph
-    // with no direct line inherits the style chain's value (sample-6 inherits the
-    // docDefault `line=276 lineRule=auto` = 1.15×, which grows the 3-line box past
-    // its 82 pt bound so Word — and now the renderer — clips the 3rd line).
-    let (line_spacing_val, line_spacing_rule) = match spacing.and_then(|s| attr_w(s, "line")) {
-        Some(v) => {
-            let raw: f64 = v.parse().unwrap_or(240.0);
-            let rule = spacing
-                .and_then(|s| attr_w(s, "lineRule"))
-                .unwrap_or_else(|| "auto".to_string());
-            match rule.as_str() {
-                "exact" => (Some(raw / 20.0), Some("exact".to_string())),
-                "atLeast" => (Some(raw / 20.0), Some("atLeast".to_string())),
-                _ => (Some(raw / 240.0), Some("auto".to_string())),
-            }
-        }
-        None => (
-            style_para.line_spacing_val,
-            style_para.line_spacing_rule.clone(),
-        ),
-    };
+    let line_spacing_val = direct_ind.line_spacing_val.or(style_para.line_spacing_val);
+    let line_spacing_rule = direct_ind
+        .line_spacing_rule
+        .clone()
+        .or_else(|| style_para.line_spacing_rule.clone());
 
     // Single block-level format fields come from the FIRST text run (kept for
     // backward compatibility with existing consumers and the image-block path).
@@ -8967,10 +8955,10 @@ mod txbx_inline_image_tests {
         assert_eq!(blocks[1].alignment, "center");
     }
 
-    /// `parse_shape_text_body` records the bodyPr auto-fit CHILD element
-    /// (§21.1.2.1.1): `<a:noAutofit/>` ⇒ Some("noAutofit") (fixed box → the
-    /// renderer clips overflow), `<a:spAutoFit/>` ⇒ Some("spAutoFit"), and an
-    /// absent auto-fit ⇒ None (overflow visible).
+    /// `parse_shape_text_body` normalizes the bodyPr auto-fit CHILD element
+    /// (§21.1.2.1.1) to the shared core vocabulary: `<a:noAutofit/>` ⇒
+    /// Some("none") (fixed box → the renderer clips overflow), `<a:spAutoFit/>`
+    /// ⇒ Some("sp"), and an absent auto-fit ⇒ None (overflow visible).
     #[test]
     fn parse_shape_text_body_records_autofit_mode() {
         let wsp = |body_pr: &str| {
@@ -8996,11 +8984,11 @@ mod txbx_inline_image_tests {
         };
         assert_eq!(
             autofit_of(wsp(r#"<wps:bodyPr><a:noAutofit/></wps:bodyPr>"#)).as_deref(),
-            Some("noAutofit")
+            Some("none")
         );
         assert_eq!(
             autofit_of(wsp(r#"<wps:bodyPr><a:spAutoFit/></wps:bodyPr>"#)).as_deref(),
-            Some("spAutoFit")
+            Some("sp")
         );
         assert_eq!(autofit_of(wsp(r#"<wps:bodyPr/>"#)), None);
     }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -735,6 +735,13 @@ pub struct ShapeRun {
     /// "b" (bottom). Read from <wps:bodyPr @anchor>. Default = "t".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_anchor: Option<String>,
+    /// Text auto-fit mode from the `<wps:bodyPr>` child (ECMA-376 §21.1.2.1.1):
+    /// "noAutofit" (`<a:noAutofit/>`, fixed box — overflowing text is CLIPPED to
+    /// the box), "spAutoFit" (`<a:spAutoFit/>`, box grows to text), or
+    /// "normAutofit" (`<a:normAutofit/>`, text shrinks to fit). Absent ⇒ None
+    /// (renderer treats as the spec default: overflow visible / no clip).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_autofit: Option<String>,
     /// Body-pr text insets in pt (left/top/right/bottom). Default 0 each.
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub text_inset_l: f64,
@@ -1073,6 +1080,15 @@ pub struct ShapeText {
     /// pt — reserved below the paragraph. 0 when absent.
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub space_after: f64,
+    /// ECMA-376 §17.3.1.33 `<w:spacing w:line>` line-spacing value, resolved
+    /// through the style chain (incl. docDefaults). Encoded per `line_spacing_rule`:
+    /// "auto" ⇒ a MULTIPLIER on the natural line box (276/240 = 1.15); "exact" /
+    /// "atLeast" ⇒ pt. Absent ⇒ single spacing (natural line box).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_spacing_val: Option<f64>,
+    /// Line-spacing rule: "auto" | "exact" | "atLeast" (see `line_spacing_val`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_spacing_rule: Option<String>,
     /// ECMA-376 §17.3.1.12 `<w:ind w:left/@start>` — paragraph left indent (pt).
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub indent_left: f64,

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -735,11 +735,12 @@ pub struct ShapeRun {
     /// "b" (bottom). Read from <wps:bodyPr @anchor>. Default = "t".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_anchor: Option<String>,
-    /// Text auto-fit mode from the `<wps:bodyPr>` child (ECMA-376 §21.1.2.1.1):
-    /// "noAutofit" (`<a:noAutofit/>`, fixed box — overflowing text is CLIPPED to
-    /// the box), "spAutoFit" (`<a:spAutoFit/>`, box grows to text), or
-    /// "normAutofit" (`<a:normAutofit/>`, text shrinks to fit). Absent ⇒ None
-    /// (renderer treats as the spec default: overflow visible / no clip).
+    /// Text auto-fit mode from the `<wps:bodyPr>` child (ECMA-376 §21.1.2.1.1),
+    /// normalized to the shared core vocabulary (core `src/types/common.ts`
+    /// `autoFit`): "none" (`<a:noAutofit/>`, fixed box — overflowing text is
+    /// CLIPPED to the box), "sp" (`<a:spAutoFit/>`, box grows to text), or
+    /// "norm" (`<a:normAutofit/>`, text shrinks to fit). Absent ⇒ None (renderer
+    /// treats as the spec default: overflow visible / no clip).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_autofit: Option<String>,
     /// Body-pr text insets in pt (left/top/right/bottom). Default 0 each.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6742,8 +6742,36 @@ export function renderShapeText(
   type BlockIndent = { leftPx: number; firstPx: number; paraW: number; firstLineW: number };
   type BlockLayout =
     | { kind: 'image'; fitW: number; fitH: number; ind: BlockIndent }
-    | { kind: 'text'; lines: string[]; lineH: number; ind: BlockIndent }
-    | { kind: 'rich'; lines: RichToken[][]; lineHeights: number[]; ind: BlockIndent };
+    | { kind: 'text'; lines: string[]; lineH: number; asc: number; ind: BlockIndent }
+    | { kind: 'rich'; lines: RichToken[][]; lineHeights: number[]; ascents: number[]; ind: BlockIndent };
+  // ECMA-376 line box: the font's NATURAL line height (OS/2 win metrics, read via
+  // the browser's fontBoundingBox and corrected for substituted faces by
+  // correctLineMetrics), NOT a flat 1.2×em. The flat factor understates real
+  // faces, so a text box's trailing line stayed inside a `noAutofit` box that
+  // Word clips (sample-6's 3-line banner). Returns {lineH, asc} so the draw pass
+  // can baseline at the true ascent instead of back-deriving from a 1.2 factor.
+  const shapeLineMetrics = (
+    family: string | null | undefined,
+    bold: boolean,
+    italic: boolean,
+    fontPx: number,
+    b: ShapeText,
+  ): { lineH: number; asc: number } => {
+    ctx.font = buildFont(bold, italic, fontPx, family ?? null, fontFamilyClasses);
+    const m = ctx.measureText('Mg');
+    const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
+    const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
+    const c = correctLineMetrics(family ?? null, fontPx, rawAsc, rawDesc);
+    const natural = c.ascent + c.descent;
+    // ECMA-376 §17.3.1.33 line-spacing rule applied to the natural line box:
+    //   "exact"   ⇒ a fixed pt height; "atLeast" ⇒ max(natural, pt);
+    //   "auto" (multiplier, e.g. 276/240 = 1.15) ⇒ natural × val.
+    let lineH = natural;
+    if (b.lineSpacingRule === 'exact' && b.lineSpacingVal != null) lineH = b.lineSpacingVal * scale;
+    else if (b.lineSpacingRule === 'atLeast' && b.lineSpacingVal != null) lineH = Math.max(natural, b.lineSpacingVal * scale);
+    else if (b.lineSpacingVal != null) lineH = natural * b.lineSpacingVal;
+    return { lineH, asc: c.ascent };
+  };
   const layouts: BlockLayout[] = blocks.map((b) => {
     const ind = indentOf(b);
     if (b.imagePath) {
@@ -6753,19 +6781,30 @@ export function renderShapeText(
       return { kind: 'image', fitW, fitH, ind };
     }
     // Rich path: a paragraph with explicit per-run formatting lays out as mixed
-    // fonts. Each line's height is the tallest run on it × 1.2 (ECMA-376 line
-    // box ≈ largest font on the line).
+    // fonts. Each line's height is the TALLEST run's natural line box (ECMA-376
+    // line box ≈ largest font on the line).
     if (b.runs && b.runs.length > 0) {
       const lines = wrapShapeRuns(ctx, b.runs, ind.paraW, scale, fontFamilyClasses, ind.firstLineW);
-      const lineHeights = lines.map((toks) => {
-        const maxPt = toks.reduce((m, t) => Math.max(m, t.run.fontSizePt), 0);
-        return (maxPt > 0 ? maxPt : b.fontSizePt) * scale * 1.2;
+      const metrics = lines.map((toks) => {
+        const tallest = toks.reduce<RichToken | null>(
+          (best, t) => (best && best.run.fontSizePt >= t.run.fontSizePt ? best : t),
+          null,
+        );
+        const run = tallest?.run;
+        const fontPx = (run?.fontSizePt ?? b.fontSizePt) * scale;
+        return shapeLineMetrics(run?.fontFamily ?? b.fontFamily, run?.bold ?? false, run?.italic ?? false, fontPx, b);
       });
-      return { kind: 'rich', lines, lineHeights, ind };
+      return {
+        kind: 'rich',
+        lines,
+        lineHeights: metrics.map((x) => x.lineH),
+        ascents: metrics.map((x) => x.asc),
+        ind,
+      };
     }
     const fontPx = b.fontSizePt * scale;
-    ctx.font = buildFont(b.bold ?? false, b.italic ?? false, fontPx, b.fontFamily ?? null, fontFamilyClasses);
-    return { kind: 'text', lines: wrapShapeText(ctx, b.text, ind.paraW, ind.firstLineW), lineH: fontPx * 1.2, ind };
+    const { lineH, asc } = shapeLineMetrics(b.fontFamily, b.bold ?? false, b.italic ?? false, fontPx, b);
+    return { kind: 'text', lines: wrapShapeText(ctx, b.text, ind.paraW, ind.firstLineW), lineH, asc, ind };
   });
   const blockHeight = (l: BlockLayout): number => {
     if (l.kind === 'image') return l.fitH;
@@ -6794,6 +6833,21 @@ export function renderShapeText(
     cursorY = innerY + Math.max(0, (innerH - totalH) / 2);
   } else {
     cursorY = innerY;
+  }
+
+  // ECMA-376 §21.1.2.1.1 — a `<a:noAutofit/>` text box keeps a FIXED size and
+  // Word CLIPS text that overflows the box (spAutoFit grows the box, normAutofit
+  // shrinks the text, so only noAutofit needs a clip: the box is already the
+  // resolved size for the other modes). Clip to the shape's box so an
+  // overflowing trailing line is hidden exactly as Word does — e.g. sample-6's
+  // 3-line banner box whose 3rd line ("All mccp … Creative Commons licence")
+  // sits below the 82 pt box and is not shown in Word.
+  const clipToBox = shape.textAutofit === 'noAutofit';
+  if (clipToBox) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(x, y, w, h);
+    ctx.clip();
   }
 
   for (let i = 0; i < blocks.length; i++) {
@@ -6859,9 +6913,9 @@ export function renderShapeText(
         } else if (edge === 'right') {
           tx = regionLeft + Math.max(0, regionW - lineW);
         }
-        // Baseline uses the tallest font on the line (lineH / 1.2 × 0.85).
-        const lineMaxFontPx = lineH / 1.2;
-        const baseline = cursorY + lineMaxFontPx * 0.85;
+        // Baseline sits the true ascent below the line-box top (metric-based, so
+        // it matches the natural line height used for advancing cursorY).
+        const baseline = cursorY + layout.ascents[li];
         // UAX#9 visual reorder (rule L2), the SAME pass body paragraphs use. A
         // rich line draws one token per fillText, so — unlike the single-fillText
         // plain path below, where the canvas reorders internally — the tokens
@@ -6919,12 +6973,14 @@ export function renderShapeText(
       } else if (edge === 'right') {
         tx = regionLeft + Math.max(0, regionW - m.width);
       }
-      // Baseline = line top + ascent (approx 0.85 of font size for default fonts).
-      const baseline = cursorY + fontPx * 0.85;
+      // Baseline = line top + the font's true ascent (metric-based, matching
+      // the natural line height used to advance cursorY).
+      const baseline = cursorY + layout.asc;
       ctx.fillText(line, tx, baseline);
       cursorY += layout.lineH;
     }
   }
+  if (clipToBox) ctx.restore();
   ctx.direction = 'ltr'; // reset for subsequent draws
 }
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6742,35 +6742,43 @@ export function renderShapeText(
   type BlockIndent = { leftPx: number; firstPx: number; paraW: number; firstLineW: number };
   type BlockLayout =
     | { kind: 'image'; fitW: number; fitH: number; ind: BlockIndent }
-    | { kind: 'text'; lines: string[]; lineH: number; asc: number; ind: BlockIndent }
-    | { kind: 'rich'; lines: RichToken[][]; lineHeights: number[]; ascents: number[]; ind: BlockIndent };
+    | { kind: 'text'; lines: string[]; lineH: number; baselineOffset: number; ind: BlockIndent }
+    | { kind: 'rich'; lines: RichToken[][]; lineHeights: number[]; baselineOffsets: number[]; ind: BlockIndent };
   // ECMA-376 line box: the font's NATURAL line height (OS/2 win metrics, read via
   // the browser's fontBoundingBox and corrected for substituted faces by
   // correctLineMetrics), NOT a flat 1.2×em. The flat factor understates real
   // faces, so a text box's trailing line stayed inside a `noAutofit` box that
-  // Word clips (sample-6's 3-line banner). Returns {lineH, asc} so the draw pass
-  // can baseline at the true ascent instead of back-deriving from a 1.2 factor.
+  // Word clips (sample-6's 3-line banner). The §17.3.1.33 line-spacing rule is
+  // applied by the SHARED `lineBoxHeight` (single source of truth with the body
+  // renderer, incl. the `intendedSingleLinePx` floor that keeps a substituted
+  // CJK face — Meiryo — from under-measuring). Returns the CENTERED baseline
+  // offset (half-leading) so the draw pass seats glyphs the way Word centers the
+  // font's natural line within an expanded line box, instead of top-aligning.
   const shapeLineMetrics = (
     family: string | null | undefined,
     bold: boolean,
     italic: boolean,
     fontPx: number,
     b: ShapeText,
-  ): { lineH: number; asc: number } => {
+  ): { lineH: number; baselineOffset: number } => {
     ctx.font = buildFont(bold, italic, fontPx, family ?? null, fontFamilyClasses);
     const m = ctx.measureText('Mg');
     const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
     const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
     const c = correctLineMetrics(family ?? null, fontPx, rawAsc, rawDesc);
-    const natural = c.ascent + c.descent;
-    // ECMA-376 §17.3.1.33 line-spacing rule applied to the natural line box:
-    //   "exact"   ⇒ a fixed pt height; "atLeast" ⇒ max(natural, pt);
-    //   "auto" (multiplier, e.g. 276/240 = 1.15) ⇒ natural × val.
-    let lineH = natural;
-    if (b.lineSpacingRule === 'exact' && b.lineSpacingVal != null) lineH = b.lineSpacingVal * scale;
-    else if (b.lineSpacingRule === 'atLeast' && b.lineSpacingVal != null) lineH = Math.max(natural, b.lineSpacingVal * scale);
-    else if (b.lineSpacingVal != null) lineH = natural * b.lineSpacingVal;
-    return { lineH, asc: c.ascent };
+    const intended = intendedSingleLinePx(family ?? null, fontPx);
+    const natural = Math.max(c.ascent + c.descent, intended);
+    const ls: LineSpacing | null = b.lineSpacingRule
+      ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
+      : null;
+    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, undefined, false, intended, false);
+    // Word centers the font's natural line within the expanded line box
+    // (half-leading): when line-spacing grows the box (auto 1.15×, atLeast,
+    // exact taller than natural) the extra space is split above and below, so
+    // the baseline is (lineH − natural)/2 below the box top plus the ascent.
+    // With no expansion (natural == lineH) this reduces to c.ascent.
+    const baselineOffset = (lineH - natural) / 2 + c.ascent;
+    return { lineH, baselineOffset };
   };
   const layouts: BlockLayout[] = blocks.map((b) => {
     const ind = indentOf(b);
@@ -6798,13 +6806,13 @@ export function renderShapeText(
         kind: 'rich',
         lines,
         lineHeights: metrics.map((x) => x.lineH),
-        ascents: metrics.map((x) => x.asc),
+        baselineOffsets: metrics.map((x) => x.baselineOffset),
         ind,
       };
     }
     const fontPx = b.fontSizePt * scale;
-    const { lineH, asc } = shapeLineMetrics(b.fontFamily, b.bold ?? false, b.italic ?? false, fontPx, b);
-    return { kind: 'text', lines: wrapShapeText(ctx, b.text, ind.paraW, ind.firstLineW), lineH, asc, ind };
+    const { lineH, baselineOffset } = shapeLineMetrics(b.fontFamily, b.bold ?? false, b.italic ?? false, fontPx, b);
+    return { kind: 'text', lines: wrapShapeText(ctx, b.text, ind.paraW, ind.firstLineW), lineH, baselineOffset, ind };
   });
   const blockHeight = (l: BlockLayout): number => {
     if (l.kind === 'image') return l.fitH;
@@ -6835,14 +6843,20 @@ export function renderShapeText(
     cursorY = innerY;
   }
 
-  // ECMA-376 §21.1.2.1.1 — a `<a:noAutofit/>` text box keeps a FIXED size and
-  // Word CLIPS text that overflows the box (spAutoFit grows the box, normAutofit
-  // shrinks the text, so only noAutofit needs a clip: the box is already the
-  // resolved size for the other modes). Clip to the shape's box so an
-  // overflowing trailing line is hidden exactly as Word does — e.g. sample-6's
-  // 3-line banner box whose 3rd line ("All mccp … Creative Commons licence")
-  // sits below the 82 pt box and is not shown in Word.
-  const clipToBox = shape.textAutofit === 'noAutofit';
+  // ECMA-376 §21.1.2.1.1 — a `<a:noAutofit/>` (normalized to "none") text box
+  // keeps a FIXED size and Word CLIPS text that overflows the box ("sp"/spAutoFit
+  // grows the box, "norm"/normAutofit shrinks the text, so only "none" needs a
+  // clip: the box is already the resolved size for the other modes). Clip to the
+  // shape's box so an overflowing trailing line is hidden exactly as Word does —
+  // e.g. sample-6's 3-line banner box whose 3rd line ("All mccp … Creative
+  // Commons licence") sits below the 82 pt box and is not shown in Word.
+  //
+  // Deliberate cross-package divergence (do NOT unify): PowerPoint does NOT clip
+  // its shape text — an overflowing paragraph renders past the shape bounds — so
+  // the pptx renderer intentionally omits this clip (see packages/pptx/src/
+  // renderer.ts, "does NOT clip text that overflows its shape"). Word clips a
+  // fixed box; PowerPoint overflows. Same bodyPr concept, different app behavior.
+  const clipToBox = shape.textAutofit === 'none';
   if (clipToBox) {
     ctx.save();
     ctx.beginPath();
@@ -6913,9 +6927,11 @@ export function renderShapeText(
         } else if (edge === 'right') {
           tx = regionLeft + Math.max(0, regionW - lineW);
         }
-        // Baseline sits the true ascent below the line-box top (metric-based, so
-        // it matches the natural line height used for advancing cursorY).
-        const baseline = cursorY + layout.ascents[li];
+        // Baseline sits at the CENTERED offset below the line-box top (half-
+        // leading, metric-based): the natural line is centered within the
+        // (possibly expanded) line height used for advancing cursorY, matching
+        // the body renderer instead of top-aligning.
+        const baseline = cursorY + layout.baselineOffsets[li];
         // UAX#9 visual reorder (rule L2), the SAME pass body paragraphs use. A
         // rich line draws one token per fillText, so — unlike the single-fillText
         // plain path below, where the canvas reorders internally — the tokens
@@ -6973,9 +6989,11 @@ export function renderShapeText(
       } else if (edge === 'right') {
         tx = regionLeft + Math.max(0, regionW - m.width);
       }
-      // Baseline = line top + the font's true ascent (metric-based, matching
-      // the natural line height used to advance cursorY).
-      const baseline = cursorY + layout.asc;
+      // Baseline = line top + the CENTERED offset (half-leading, metric-based):
+      // the natural line is centered within the (possibly expanded) line height
+      // used to advance cursorY, matching the body renderer instead of top-
+      // aligning.
+      const baseline = cursorY + layout.baselineOffset;
       ctx.fillText(line, tx, baseline);
       cursorY += layout.lineH;
     }

--- a/packages/docx/src/textbox-paragraph-spacing.test.ts
+++ b/packages/docx/src/textbox-paragraph-spacing.test.ts
@@ -85,10 +85,12 @@ describe('text-box paragraph spacing (§17.3.1.33)', () => {
     const b = calls.find((c) => c.text === 'BBB');
     expect(a).toBeDefined();
     expect(b).toBeDefined();
-    // One line of 10 pt text ⇒ block height = 10 * 1.2 = 12. Gap A→B baseline =
-    // blockHeight + max(after=20, before=10) = 12 + 20 = 32 (collapse), NOT
-    // 12 + (20 + 10) = 42 (sum).
+    // One line of 10 pt text ⇒ block height = the font's natural line box (the
+    // mock reports fontBoundingBox = 0.8 + 0.2 = 1.0 em, so 10 px). Gap A→B
+    // baseline = blockHeight + max(after=20, before=10) = 10 + 20 = 30 (collapse),
+    // NOT 10 + (20 + 10) = 40 (sum). The block height is metric-based (the shape
+    // text line box is the font's natural line height, not a flat 1.2× em).
     const gap = (b as Call).y - (a as Call).y;
-    expect(gap).toBeCloseTo(32, 1);
+    expect(gap).toBeCloseTo(30, 1);
   });
 });

--- a/packages/docx/src/textbox-paragraph-spacing.test.ts
+++ b/packages/docx/src/textbox-paragraph-spacing.test.ts
@@ -85,12 +85,17 @@ describe('text-box paragraph spacing (§17.3.1.33)', () => {
     const b = calls.find((c) => c.text === 'BBB');
     expect(a).toBeDefined();
     expect(b).toBeDefined();
-    // One line of 10 pt text ⇒ block height = the font's natural line box (the
-    // mock reports fontBoundingBox = 0.8 + 0.2 = 1.0 em, so 10 px). Gap A→B
-    // baseline = blockHeight + max(after=20, before=10) = 10 + 20 = 30 (collapse),
-    // NOT 10 + (20 + 10) = 40 (sum). The block height is metric-based (the shape
-    // text line box is the font's natural line height, not a flat 1.2× em).
+    // One line of 10 pt Times New Roman ⇒ block height = the font's INTENDED
+    // single-line box (font-metrics.ts floors the substituted-face measurement to
+    // the design hhea height 2355/2048 = 1.1499 em, so 11.499 px — larger than the
+    // mock's naive 0.8 + 0.2 = 1.0 em / 10 px). Both lines share font/size and
+    // carry no line-spacing rule, so no box expansion ⇒ their half-leading
+    // baseline offsets are equal and cancel in the delta. Gap A→B baseline =
+    // blockHeight + max(after=20, before=10) = 11.499 + 20 = 31.499 (COLLAPSE),
+    // NOT 11.499 + (20 + 10) = 41.499 (sum). The collapse-vs-sum distinction — the
+    // point of this test — is unchanged; only the block height is now the metric
+    // floor rather than the mock's flat em.
     const gap = (b as Call).y - (a as Call).y;
-    expect(gap).toBeCloseTo(30, 1);
+    expect(gap).toBeCloseTo(31.5, 1);
   });
 });

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -579,6 +579,10 @@ export interface ShapeRun {
   textBlocks?: ShapeText[];
   /** "t" | "ctr" | "b" — vertical anchor for the shape's text body (`<wps:bodyPr @anchor>`). */
   textAnchor?: string | null;
+  /** ECMA-376 §21.1.2.1.1 auto-fit mode from `<wps:bodyPr>`: "noAutofit"
+   *  (fixed box — overflowing text is CLIPPED to the box), "spAutoFit" (box
+   *  grows to text), or "normAutofit" (text shrinks). Absent ⇒ overflow visible. */
+  textAutofit?: string | null;
   textInsetL?: number;  // pt
   textInsetT?: number;  // pt
   textInsetR?: number;  // pt
@@ -635,6 +639,12 @@ export interface ShapeText {
   /** ECMA-376 §17.3.1.33 `<w:spacing w:after>` of this text-box paragraph, in
    *  pt — reserved BELOW the paragraph. Absent/0 ⇒ no offset. */
   spaceAfter?: number;
+  /** ECMA-376 §17.3.1.33 line spacing value (style-chain resolved). Encoded per
+   *  {@link lineSpacingRule}: "auto" ⇒ a MULTIPLIER on the natural line box
+   *  (1.15 = 276/240), "exact"/"atLeast" ⇒ pt. Absent ⇒ single (natural). */
+  lineSpacingVal?: number;
+  /** "auto" | "exact" | "atLeast" — see {@link lineSpacingVal}. */
+  lineSpacingRule?: string;
   /** ECMA-376 §17.3.1.12 `<w:ind w:left/@start>` — paragraph left indent (pt).
    *  Absent/0 ⇒ flush to the box's inner left edge. */
   indentLeft?: number;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -579,9 +579,11 @@ export interface ShapeRun {
   textBlocks?: ShapeText[];
   /** "t" | "ctr" | "b" — vertical anchor for the shape's text body (`<wps:bodyPr @anchor>`). */
   textAnchor?: string | null;
-  /** ECMA-376 §21.1.2.1.1 auto-fit mode from `<wps:bodyPr>`: "noAutofit"
-   *  (fixed box — overflowing text is CLIPPED to the box), "spAutoFit" (box
-   *  grows to text), or "normAutofit" (text shrinks). Absent ⇒ overflow visible. */
+  /** ECMA-376 §21.1.2.1.1 auto-fit mode from `<wps:bodyPr>`, normalized to the
+   *  shared core `autoFit` vocabulary (core `src/types/common.ts`): "none"
+   *  (`<a:noAutofit/>`, fixed box — overflowing text is CLIPPED to the box),
+   *  "sp" (`<a:spAutoFit/>`, box grows to text), or "norm" (`<a:normAutofit/>`,
+   *  text shrinks). Absent ⇒ overflow visible. */
   textAutofit?: string | null;
   textInsetL?: number;  // pt
   textInsetT?: number;  // pt


### PR DESCRIPTION
Fixes two of the three differences reported on `private/sample-6.docx` page 1 vs Word (the third, the CC-badge WMF, is #639). Both stem from the docx **text-box vertical-layout model** + the parser not inheriting text-box paragraph spacing.

## Diff 1 — "All mccp resources are released under a Creative Commons licence" 3rd line showed (Word clips it) ✅ fixed
The banner text box is `<a:noAutofit/>` (fixed 82 pt). Word clips text that overflows a noAutofit box; we didn't. Two root causes:
- **Parser**: `extract_simple_paragraph_text` resolved the txbxContent paragraph's `<w:spacing>` (before/after **and** line) from its DIRECT value only — unlike indent, which already inherits through the style chain. So the box's paragraphs lost the inter-paragraph gaps + the `line=276 auto` (1.15×) spacing Word applies, and the 3-line box stayed short enough to fit the 3rd line.
- **Renderer**: no clip for noAutofit; shape-text line height was a flat `1.2× em` heuristic.

Fix: parser inherits spacing + line-spacing (per-attribute, direct-wins-then-style); renderer clips noAutofit boxes, uses the font's **natural line box** (fontBoundingBox → correctLineMetrics, like the body) instead of 1.2×, and applies the §17.3.1.33 line-spacing rule (auto ×val / exact / atLeast). With correct heights the 3rd line falls below the box and the clip removes it — matching Word.

## Diff 2 — text box overlapped the green banner (sat too high) ✅ largely fixed
Same root cause: the missing spacing/line-spacing made the box too short and its content sat ~16 pt too high, overlapping the banner wave. With the spacing inherited and the metric line box, the box drops to Word's position. **Residual: line 1 is ~5 pt higher than Word (was ~16 pt)** — a minor anchor/first-line-spacing subtlety; visually the block now matches Word.

## Before → after (sample-6 p.1)
- Before: 3 gray lines incl. "All mccp …", block overlapping the green wave.
- After: 2 gray lines ("mathcentre community project" / "encouraging …"), 3rd line clipped, block clear of the banner — matching Word.

## Verification
- Parser: 175 tests (incl. new `inherits_style_spacing` + `records_autofit_mode`).
- Renderer: 327 docx tests (updated `textbox-paragraph-spacing` to the metric line box).
- Rust fmt + clippy -D warnings clean; root `tsc --build` clean.
- **Regression check**: sample-10's four noAutofit boxes (title, abstract, header, figure caption) re-rendered — no clipping/overflow, only a minor line-spacing refinement (page 1 pixel-identical).

## Scope note
The shape-text line-box change replaces a `1.2× em` heuristic with real metrics (the repo's spec-first stance), which slightly shifts every text box's internal spacing toward Word. sample-6 & sample-10 verified; other textbox samples (none in the docx VRT set) were not exhaustively checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)