### PR TITLE
fix(docx): paragraph shading fills the border box (reach the border's w:space)

### DIFF
--- a/packages/docx/src/para-shading-border.test.ts
+++ b/packages/docx/src/para-shading-border.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { paraShadingRect } from './renderer.js';
+import type { ParagraphBorders } from './types';
+
+// ECMA-376 §17.3.1.31 — paragraph shading fills the border BOX: it extends to
+// each present border, which §17.3.1.7 offsets outward by `w:space`. The fill
+// must reach the border, not stop `space` short of it (sample-11: a right border
+// with space=4 pt left the gray box detached from its border).
+
+const edge = (space: number, style = 'single') =>
+  ({ style, width: 4, color: '000000', space } as unknown as NonNullable<ParagraphBorders['right']>);
+
+const noEdges: ParagraphBorders = { top: null, bottom: null, left: null, right: null, between: null };
+
+describe('paraShadingRect (§17.3.1.31 shading fills the border box)', () => {
+  it('extends the fill by a present border edge’s space (matching drawParaBorders)', () => {
+    // Right border, space=4 pt, scale=2 → the fill widens by 4*2=8 px on the right.
+    const b: ParagraphBorders = { ...noEdges, right: edge(4) };
+    const r = paraShadingRect(100, 50, 300, 20, b, undefined, 2);
+    expect(r.x).toBe(100);           // no left border → left unchanged
+    expect(r.y).toBe(50);
+    expect(r.w).toBe(300 + 8);       // right border space 4pt × scale 2 = 8 px
+    expect(r.h).toBe(20);
+  });
+
+  it('extends every present edge; a `none`-style edge and absent borders do not', () => {
+    const b: ParagraphBorders = {
+      ...noEdges,
+      left: edge(2),
+      right: edge(3),
+      top: edge(1),
+      bottom: edge(5, 'none'), // none → no ink → no extension
+    };
+    const r = paraShadingRect(100, 50, 300, 20, b, undefined, 1);
+    expect(r.x).toBe(100 - 2);       // left space 2
+    expect(r.w).toBe(300 + 2 + 3);   // left 2 + right 3
+    expect(r.y).toBe(50 - 1);        // top space 1
+    expect(r.h).toBe(20 + 1 + 0);    // top 1 + bottom 0 (none)
+  });
+
+  it('returns the content box unchanged when there are no borders', () => {
+    expect(paraShadingRect(10, 20, 30, 40, null, undefined, 2)).toEqual({ x: 10, y: 20, w: 30, h: 40 });
+  });
+
+  it('honors a merged run: suppressed top uses `between`; suppressed bottom does not extend', () => {
+    const b: ParagraphBorders = { ...noEdges, top: edge(9), between: edge(2), bottom: edge(7) };
+    // suppressTop → top edge gives way to `between` (space 2); suppressBottom → no bottom extension.
+    const r = paraShadingRect(0, 0, 100, 10, b, { suppressTop: true, suppressBottom: true }, 1);
+    expect(r.y).toBe(-2);            // between space 2 (not top's 9)
+    expect(r.h).toBe(10 + 2 + 0);    // top(between) 2 + bottom 0 (suppressed)
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3573,7 +3573,8 @@ function renderEmptyMarkParagraph(
   const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby, state.docEastAsian, ctx, state.fontFamilyClasses);
   if (para.shading && !dryRun) {
     ctx.fillStyle = `#${para.shading}`;
-    ctx.fillRect(contentX + indLeft, markRectTop, paraW, emptyH);
+    const sb = paraShadingRect(contentX + indLeft, markRectTop, paraW, emptyH, para.borders, borderMerge, scale);
+    ctx.fillRect(sb.x, sb.y, sb.w, sb.h);
   }
   state.y += emptyH;
   if (para.borders && !dryRun) {
@@ -4141,7 +4142,8 @@ function renderParagraph(
   if (para.shading && !dryRun) {
     const totalTextH = lines.reduce((s, l) => s + lineHForLine(l), 0);
     ctx.fillStyle = `#${para.shading}`;
-    ctx.fillRect(contentX + indLeft, textAreaTopY, paraW, totalTextH);
+    const sb = paraShadingRect(contentX + indLeft, textAreaTopY, paraW, totalTextH, para.borders, borderMerge, scale);
+    ctx.fillRect(sb.x, sb.y, sb.w, sb.h);
   }
 
   // ECMA-376 §17.18.44 ST_Jc: "both" and "distribute" fully justify the line
@@ -8006,6 +8008,32 @@ interface ParaBorderMerge {
   suppressTop?: boolean;
   /** A same-border paragraph is adjacent below ⇒ don't draw this `bottom` edge. */
   suppressBottom?: boolean;
+}
+
+/** ECMA-376 §17.3.1.31 — paragraph shading fills the border BOX, not just the
+ *  text extent: `<w:pBdr>` edges are offset OUTWARD from the content box by their
+ *  `w:space` (§17.3.1.7, applied by {@link drawParaBorders}), and the shading
+ *  reaches those borders. Return the content box grown by each PRESENT border's
+ *  space, using the SAME per-edge conditions as drawParaBorders so the fill meets
+ *  the border exactly. Without a bordered edge (or no borders at all) that edge is
+ *  not extended. (sample-11: a right border with `space=4` left the gray box
+ *  detached from its border because the fill stopped `space` short of it.)
+ *  Exported for unit testing the per-edge extension. */
+export function paraShadingRect(
+  x: number, y: number, w: number, h: number,
+  borders: ParagraphBorders | null | undefined,
+  merge: ParaBorderMerge | undefined,
+  scale: number,
+): { x: number; y: number; w: number; h: number } {
+  if (!borders) return { x, y, w, h };
+  const sp = (edge: ParaBorderEdge | null): number =>
+    edge && edge.style !== 'none' ? (edge.space ?? 0) * scale : 0;
+  const topEdge = merge?.suppressTop ? borders.between : borders.top;
+  const l = sp(borders.left);
+  const r = sp(borders.right);
+  const t = sp(topEdge);
+  const b = merge?.suppressBottom ? 0 : sp(borders.bottom);
+  return { x: x - l, y: y - t, w: w + l + r, h: h + t + b };
 }
 
 function drawParaBorders(


### PR DESCRIPTION
## Bug (reported on sample-11 page 2)
A right-aligned paragraph with a light-gray `<w:shd>` background AND a `<w:pBdr>` right border rendered the **dark border line floating ~4 pt to the right of the gray box**. In Word the border touches the box.

## Root cause
`<w:pBdr>` edges are offset OUTWARD from the content box by their `w:space` (§17.3.1.7) — `drawParaBorders` draws the right border at `x + w + space`. But the shading fill was drawn at the content box `[x, x+w]`, i.e. `space` short of the border, leaving a gap.

Verified against Word (100-dpi PDF render): Word's gray box right edge = 756 px, border = 757 px (touching); the box sits at `content + space`, NOT the content edge — so Word fills the shading OUT to the border. Our fill stopped at the content edge (measured gap box→border = 4 px; Word ≈ 0–1 px).

## Fix
ECMA-376 §17.3.1.31 — paragraph shading fills the **border box**. Add `paraShadingRect`, which grows the content box by each PRESENT border edge's space, using the SAME per-edge conditions as `drawParaBorders`:
- a `none`-style or absent edge does not extend;
- a merged run's suppressed top uses the `between` edge; a suppressed bottom does not extend.

Applied at both shading fill sites (empty paragraph-mark line + text area). After: measured gap box→border = 1 px, matching Word.

## Verification
- New `para-shading-border.test.ts` (4 cases: single-edge extension, per-edge + none/absent, no-borders passthrough, merged-run suppress/between).
- All 327 docx tests green; docx `tsc --noEmit` clean.
- Browser render of sample-11 p.2: the gray box now reaches its right border (visual + pixel-measured).

Independent of the text-box work (#640) — separate concern, off current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)