### PR TITLE
feat(xlsx): shape-text line metrics — design-line floor + <a:lnSpc> line spacing + autofit model

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2314,8 +2314,12 @@ export function renderTextBody(
       }
       // normAutofit lnSpcReduction (ECMA-376 §21.1.2.1.3): PowerPoint reduces
       // each paragraph's line spacing by this fraction alongside the font
-      // shrink. Apply it only when normAutofit actually stored a value.
-      if (body.autoFit === 'norm' && body.lnSpcReduction != null) {
+      // shrink. Apply it only when normAutofit stored a value AND the paragraph
+      // has PERCENTAGE line spacing — the spec's normative note reads "This
+      // attribute applies only to paragraphs with percentage line spacing." pct
+      // and the implicit single (= 100 % percentage) qualify; an absolute
+      // spcPts height does not.
+      if (body.autoFit === 'norm' && body.lnSpcReduction != null && para.spaceLine?.type !== 'pts') {
         lineHeight *= 1 - body.lnSpcReduction;
       }
       const linePx  = lineHeight + (isLast ? spaceAfterPx : 0);

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -516,6 +516,14 @@ pub(crate) fn parse_tx_body(
 ) -> Option<ShapeText> {
     let mut anchor = String::from("t");
     let mut wrap = String::from("square");
+    // `<a:bodyPr>` autofit child (ECMA-376 §21.1.2.1.1-.3). Default "none"
+    // (xlsx has no theme txDef fallback). Mirrors the pptx parser; for
+    // normAutofit also capture the stored fontScale / lnSpcReduction
+    // (ST_TextFontScalePercentOrPercentString / ST_TextSpacingPercentOrPercentString,
+    // 1000ths of a percent → fraction).
+    let mut auto_fit = String::from("none");
+    let mut font_scale: Option<f64> = None;
+    let mut ln_spc_reduction: Option<f64> = None;
     let mut paragraphs: Vec<ShapeParagraph> = Vec::new();
     for c in tx_body.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
@@ -526,6 +534,25 @@ pub(crate) fn parse_tx_body(
                 if let Some(w) = c.attribute("wrap") {
                     wrap = w.to_string();
                 }
+                // OOXML spelling is `normAutofit` (lowercase f).
+                for bc in c.children().filter(|n| n.is_element()) {
+                    match bc.tag_name().name() {
+                        "spAutoFit" => auto_fit = String::from("sp"),
+                        "normAutofit" => {
+                            auto_fit = String::from("norm");
+                            font_scale = bc
+                                .attribute("fontScale")
+                                .and_then(|v| v.parse::<f64>().ok())
+                                .map(|v| v / 100000.0);
+                            ln_spc_reduction = bc
+                                .attribute("lnSpcReduction")
+                                .and_then(|v| v.parse::<f64>().ok())
+                                .map(|v| v / 100000.0);
+                        }
+                        "noAutofit" => auto_fit = String::from("none"),
+                        _ => {}
+                    }
+                }
             }
             "p" => {
                 let mut align = String::from("l");
@@ -533,6 +560,7 @@ pub(crate) fn parse_tx_body(
                 let mut mar_l: Option<i64> = None;
                 let mut mar_r: Option<i64> = None;
                 let mut indent: Option<i64> = None;
+                let mut space_line: Option<SpaceLine> = None;
                 let mut runs: Vec<ShapeTextRun> = Vec::new();
                 for pc in c.children().filter(|n| n.is_element()) {
                     match pc.tag_name().name() {
@@ -553,6 +581,34 @@ pub(crate) fn parse_tx_body(
                             mar_l = pc.attribute("marL").and_then(|v| v.parse().ok());
                             mar_r = pc.attribute("marR").and_then(|v| v.parse().ok());
                             indent = pc.attribute("indent").and_then(|v| v.parse().ok());
+                            // ECMA-376 §21.1.2.2.5 `<a:lnSpc>`: spcPct is a
+                            // percentage of the natural single line; spcPts is an
+                            // absolute per-line height (raw @val is hundredths of
+                            // a point → divide by 100, matching pptx SpaceLine).
+                            if let Some(ln_spc) = pc
+                                .children()
+                                .find(|n| n.is_element() && n.tag_name().name() == "lnSpc")
+                            {
+                                let pct = ln_spc
+                                    .children()
+                                    .find(|n| n.is_element() && n.tag_name().name() == "spcPct");
+                                if let Some(v) = pct
+                                    .and_then(|n| n.attribute("val"))
+                                    .and_then(|v| v.parse::<f64>().ok())
+                                {
+                                    space_line = Some(SpaceLine::Pct { val: v });
+                                } else {
+                                    let pts = ln_spc.children().find(|n| {
+                                        n.is_element() && n.tag_name().name() == "spcPts"
+                                    });
+                                    if let Some(v) = pts
+                                        .and_then(|n| n.attribute("val"))
+                                        .and_then(|v| v.parse::<f64>().ok())
+                                    {
+                                        space_line = Some(SpaceLine::Pts { val: v / 100.0 });
+                                    }
+                                }
+                            }
                         }
                         "r" => {
                             // Run text + run-level formatting.
@@ -625,6 +681,7 @@ pub(crate) fn parse_tx_body(
                         mar_l,
                         mar_r,
                         indent,
+                        space_line,
                         runs,
                     });
                 }
@@ -638,6 +695,9 @@ pub(crate) fn parse_tx_body(
         Some(ShapeText {
             anchor,
             wrap,
+            auto_fit,
+            font_scale,
+            ln_spc_reduction,
             paragraphs,
         })
     }
@@ -1651,6 +1711,99 @@ mod math_tests {
         assert!(v.get("marL").is_none(), "marL omitted when None");
         assert!(v.get("marR").is_none(), "marR omitted when None");
         assert!(v.get("indent").is_none(), "indent omitted when None");
+        // spaceLine is additive/omitted when absent; autoFit always present.
+        assert!(p.space_line.is_none(), "absent lnSpc → None");
+        assert!(v.get("spaceLine").is_none(), "spaceLine omitted when None");
+        let vt: serde_json::Value = serde_json::to_value(&text).unwrap();
+        assert_eq!(vt["autoFit"], "none", "no autofit child → autoFit=none");
+        assert!(
+            vt.get("fontScale").is_none(),
+            "fontScale omitted when unset"
+        );
+        assert!(
+            vt.get("lnSpcReduction").is_none(),
+            "lnSpcReduction omitted when unset"
+        );
+    }
+
+    /// `<a:pPr>/<a:lnSpc>` line spacing (ECMA-376 §21.1.2.2.5): spcPct → a
+    /// percent SpaceLine (raw @val), spcPts → a points SpaceLine (raw hundredths
+    /// of a point divided by 100). Mirrors the pptx SpaceLine JSON contract.
+    #[test]
+    fn parses_lnspc_pct_and_pts() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:p>
+                <a:pPr><a:lnSpc><a:spcPct val="150000"/></a:lnSpc></a:pPr>
+                <a:r><a:t>pct</a:t></a:r>
+              </a:p>
+              <a:p>
+                <a:pPr><a:lnSpc><a:spcPts val="1800"/></a:lnSpc></a:pPr>
+                <a:r><a:t>pts</a:t></a:r>
+              </a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        assert_eq!(text.paragraphs.len(), 2);
+
+        let vp0: serde_json::Value = serde_json::to_value(&text.paragraphs[0]).unwrap();
+        assert_eq!(vp0["spaceLine"]["type"], "pct");
+        assert_eq!(vp0["spaceLine"]["val"], 150000.0);
+
+        let vp1: serde_json::Value = serde_json::to_value(&text.paragraphs[1]).unwrap();
+        assert_eq!(vp1["spaceLine"]["type"], "pts");
+        // 1800 hundredths of a point → 18 pt.
+        assert_eq!(vp1["spaceLine"]["val"], 18.0);
+    }
+
+    /// `<a:bodyPr>/<a:normAutofit>` (ECMA-376 §21.1.2.1.3): autoFit="norm" plus
+    /// the stored fontScale / lnSpcReduction (1000ths of a percent → fraction).
+    #[test]
+    fn parses_normautofit_scales() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:bodyPr><a:normAutofit fontScale="62500" lnSpcReduction="20000"/></a:bodyPr>
+              <a:p><a:r><a:t>x</a:t></a:r></a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        let v: serde_json::Value = serde_json::to_value(&text).unwrap();
+        assert_eq!(v["autoFit"], "norm");
+        assert_eq!(v["fontScale"], 0.625);
+        assert_eq!(v["lnSpcReduction"], 0.2);
+    }
+
+    /// `<a:bodyPr>/<a:spAutoFit>` → autoFit="sp" (no scales); `<a:noAutofit>` →
+    /// autoFit="none". Both leave rendering unchanged (renderer applies neither).
+    #[test]
+    fn parses_spautofit_and_noautofit() {
+        let sp_xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:bodyPr><a:spAutoFit/></a:bodyPr>
+              <a:p><a:r><a:t>x</a:t></a:r></a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&sp_xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        let v: serde_json::Value = serde_json::to_value(&text).unwrap();
+        assert_eq!(v["autoFit"], "sp");
+        assert!(
+            v.get("fontScale").is_none(),
+            "spAutoFit stores no fontScale"
+        );
+
+        let no_xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:bodyPr><a:noAutofit/></a:bodyPr>
+              <a:p><a:r><a:t>x</a:t></a:r></a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&no_xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        let v: serde_json::Value = serde_json::to_value(&text).unwrap();
+        assert_eq!(v["autoFit"], "none");
     }
 
     /// `ShapeTextRun` uses an enum-level `#[serde(tag = "type", rename_all =

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -886,6 +886,19 @@ pub struct ShapeInfo {
     pub text: Option<ShapeText>,
 }
 
+/// Paragraph line spacing (`<a:pPr>/<a:lnSpc>`, ECMA-376 §21.1.2.2.5). Mirrors
+/// the pptx `SpaceLine` JSON shape (and core's TS `SpaceLine`): a percentage of
+/// the natural single line, or an absolute per-line height in points.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SpaceLine {
+    /// `<a:spcPct@val>` (e.g. 100000 = 100%, 150000 = 150%).
+    Pct { val: f64 },
+    /// `<a:spcPts@val>` in points (the raw ST_TextSpacingPoint hundredths-of-a-
+    /// point value is divided by 100 by the parser, matching pptx).
+    Pts { val: f64 },
+}
+
 /// Text body inside a shape (`<xdr:txBody>`, ECMA-376 §20.1.2.2). Holds
 /// the paragraphs plus body-level formatting (`<a:bodyPr>`).
 #[derive(Debug, Serialize)]
@@ -898,6 +911,19 @@ pub struct ShapeText {
     /// `<a:bodyPr@wrap>` — `square` (default = wrap to shape width),
     /// `none` (no wrap).
     pub wrap: String,
+    /// `<a:bodyPr>` autofit child (ECMA-376 §21.1.2.1.1-.3): `sp`
+    /// (`spAutoFit`), `norm` (`normAutofit`), or `none` (`noAutofit`/absent).
+    /// Always emitted (default `none`), mirroring the pptx `TextBody.autoFit`.
+    pub auto_fit: String,
+    /// `<a:normAutofit@fontScale>` — PowerPoint/Excel's stored font-shrink
+    /// fraction (e.g. 0.625 for `fontScale="62500"`). `None` when unset.
+    /// Modeled for parity; the xlsx renderer does not currently apply it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_scale: Option<f64>,
+    /// `<a:normAutofit@lnSpcReduction>` — stored line-spacing reduction fraction
+    /// (e.g. 0.20 for `lnSpcReduction="20000"`). `None` when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ln_spc_reduction: Option<f64>,
     pub paragraphs: Vec<ShapeParagraph>,
 }
 
@@ -924,6 +950,11 @@ pub struct ShapeParagraph {
     /// §21.1.2.2.7. `None` = unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent: Option<i64>,
+    /// `<a:pPr>/<a:lnSpc>` line spacing (ECMA-376 §21.1.2.2.5). Direct-only.
+    /// `None` = unset. Omitted from JSON when `None` so existing output stays
+    /// byte-identical (additive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub space_line: Option<SpaceLine>,
     pub runs: Vec<ShapeTextRun>,
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3642,11 +3642,12 @@ export function drawShapeText(
       // single-line height — as tall as a one-character line of the paragraph's
       // effective font. Without this the empty line reserved zero height, so the
       // block under-measured and vertical anchoring ('ctr'/'b') drifted. Mirror
-      // the text-line formula (pxSize * 1.2) using the nearest preceding text
-      // size in this paragraph, falling back to the body default.
+      // the text-line formula (pxSize * 1.2, floored by the font's design line —
+      // see the run sites) using the nearest preceding text size AND face in
+      // this paragraph, falling back to the body default.
       if (lineHeight === 0) {
         const fallbackPx = (lastTextPt || DEFAULT_FONT_SIZE) * PT_TO_PX * cs;
-        lineHeight = fallbackPx * 1.2;
+        lineHeight = Math.max(fallbackPx * 1.2, intendedSingleLinePx(lastTextFace, fallbackPx));
         lineAscent = fallbackPx * 0.85;
       }
       lines.push({ segs, align, height: lineHeight, ascent: lineAscent, hasMath, leftInset: lineLeftInset(), availW: lineAvailW() });
@@ -3656,6 +3657,9 @@ export function drawShapeText(
     // Nearest preceding text size (pt) in this paragraph — inline math with no
     // explicit rPr@sz inherits it (then falls back to the default).
     let lastTextPt = 0;
+    // Nearest preceding text AUTHORED face — used to floor an empty/blank line's
+    // reserved single-line height by that font's design line (intendedSingleLinePx).
+    let lastTextFace: string | undefined;
 
     for (const run of p.runs) {
       if (run.type === 'break') { flushLine(); continue; }
@@ -3692,9 +3696,18 @@ export function drawShapeText(
 
       // Text run.
       lastTextPt = run.size > 0 ? run.size : DEFAULT_FONT_SIZE;
+      lastTextFace = run.fontFace;
       const { font, px: pxSize } = textFont(run);
       const color = run.color ?? '#000000';
-      lineHeight = Math.max(lineHeight, pxSize * 1.2);
+      // Floor the natural single line (Excel's flat 1.2×em) by the AUTHORED
+      // font's design line box (OS/2 win metrics, ECMA-376 §21.1.2.1.1) via
+      // core's intendedSingleLinePx — same floor docx/pptx apply. It returns 0
+      // for every untabled face (Calibri etc. stay on 1.2×em); a substituted
+      // Meiryo (1.596×em) / Sakkal Majalla must measure to its taller design
+      // line. Pass run.fontFace (the metric table keys on authored names), NOT
+      // the fallback stack from fontStackFor. Keep it a FLOOR — not a replace.
+      const singleLinePx = Math.max(pxSize * 1.2, intendedSingleLinePx(run.fontFace, pxSize));
+      lineHeight = Math.max(lineHeight, singleLinePx);
       lineAscent = Math.max(lineAscent, pxSize * 0.85);
       ctx.font = font;
       // Defensive: a run's text may still contain a literal "\n".
@@ -3726,7 +3739,9 @@ export function drawShapeText(
             flushLine();
             buf = ch;
             ctx.font = font;
-            lineHeight = Math.max(lineHeight, pxSize * 1.2);
+            // Re-seed this continuation line with the same design-line-floored
+            // single-line height as the run's first line (see singleLinePx above).
+            lineHeight = Math.max(lineHeight, singleLinePx);
             lineAscent = Math.max(lineAscent, pxSize * 0.85);
           } else {
             buf = candidate;

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3635,6 +3635,25 @@ export function drawShapeText(
     let lineHeight = 0;
     let lineAscent = 0;
     let hasMath = false;
+    // ECMA-376 §21.1.2.2.5 <a:lnSpc> + §21.1.2.1.3 normAutofit lnSpcReduction,
+    // applied to a natural (design-floored) single-line height. Mirrors the pptx
+    // renderer. `h` is the natural single line, so it is the correct pct base;
+    // pts is an absolute per-line height (cs-scaled, like the cell/run px sizes).
+    const applyLineSpacing = (h: number): number => {
+      let out = h;
+      if (p.spaceLine) {
+        if (p.spaceLine.type === 'pct') out = out * (p.spaceLine.val / 100000);
+        else out = p.spaceLine.val * PT_TO_PX * cs;
+      }
+      // normAutofit lnSpcReduction (§21.1.2.1.3): apply the STORED reduction
+      // only. fontScale font-shrink and spAutoFit shape-grow are runtime layout
+      // behaviors intentionally out of scope (modeled but not applied) — the
+      // repo requires explicit user approval for reverse-engineered autofit.
+      if (txt.autoFit === 'norm' && txt.lnSpcReduction != null) {
+        out *= 1 - txt.lnSpcReduction;
+      }
+      return out;
+    };
     const flushLine = () => {
       // An empty paragraph (no runs) or a blank line produced by a standalone /
       // trailing <a:br> contributes no text or math segment, so lineHeight is
@@ -3650,6 +3669,7 @@ export function drawShapeText(
         lineHeight = Math.max(fallbackPx * 1.2, intendedSingleLinePx(lastTextFace, fallbackPx));
         lineAscent = fallbackPx * 0.85;
       }
+      lineHeight = applyLineSpacing(lineHeight);
       lines.push({ segs, align, height: lineHeight, ascent: lineAscent, hasMath, leftInset: lineLeftInset(), availW: lineAvailW() });
       firstLineDone = true;
       segs = []; lineW = 0; lineHeight = 0; lineAscent = 0; hasMath = false;
@@ -3678,7 +3698,10 @@ export function drawShapeText(
           // indent — `indent` is a run-in indent for the first line of TEXT, not
           // for a block equation — so use marLpx/paraW regardless of line position.
           flushLine();
-          lines.push({ segs: [{ kind: 'math', render, color, w, ascent, descent }], align, height: ascent + descent, ascent, hasMath: true, leftInset: marLpx, availW: paraW });
+          // Apply the paragraph's line spacing to a display equation's own line
+          // too (a block equation in a pct-spaced paragraph). ascent is kept
+          // unchanged; the alphabetic-baseline draw distributes the extra leading.
+          lines.push({ segs: [{ kind: 'math', render, color, w, ascent, descent }], align, height: applyLineSpacing(ascent + descent), ascent, hasMath: true, leftInset: marLpx, availW: paraW });
           firstLineDone = true;
           continue;
         }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3646,10 +3646,14 @@ export function drawShapeText(
         else out = p.spaceLine.val * PT_TO_PX * cs;
       }
       // normAutofit lnSpcReduction (§21.1.2.1.3): apply the STORED reduction
-      // only. fontScale font-shrink and spAutoFit shape-grow are runtime layout
-      // behaviors intentionally out of scope (modeled but not applied) — the
-      // repo requires explicit user approval for reverse-engineered autofit.
-      if (txt.autoFit === 'norm' && txt.lnSpcReduction != null) {
+      // only, and ONLY to paragraphs with PERCENTAGE line spacing — the spec's
+      // normative note reads "This attribute applies only to paragraphs with
+      // percentage line spacing." So pct and the implicit single (= 100 %
+      // percentage) get it; an absolute spcPts height does NOT. fontScale
+      // font-shrink and spAutoFit shape-grow are runtime layout behaviors
+      // intentionally out of scope (modeled but not applied) — the repo requires
+      // explicit user approval for reverse-engineered autofit.
+      if (txt.autoFit === 'norm' && txt.lnSpcReduction != null && p.spaceLine?.type !== 'pts') {
         out *= 1 - txt.lnSpcReduction;
       }
       return out;

--- a/packages/xlsx/src/shape-text-line-spacing.test.ts
+++ b/packages/xlsx/src/shape-text-line-spacing.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { PT_TO_PX, intendedSingleLinePx } from '@silurus/ooxml-core';
+import { drawShapeText } from './renderer.js';
+import type { ShapeParagraph, ShapeText, ShapeTextRun } from './types.js';
+
+// ECMA-376 §21.1.2.2.5 <a:lnSpc> + §21.1.2.1.3 normAutofit lnSpcReduction for
+// shape text bodies (drawShapeText). No real xlsx sample carries lnSpc or an
+// applied autofit, so the feature is inert on the VRT corpus; these tests drive
+// it directly with a mock CanvasRenderingContext2D, mirroring the (already
+// verified) pptx model. 20 pt Calibri is used so intendedSingleLinePx returns 0
+// (untabled face) and the natural single line is exactly the flat 1.2×em base.
+
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+}
+
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; calls: FillTextCall[] } {
+  let font = '11px sans-serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText(text: string, x: number, y: number) {
+      calls.push({ text, x, y });
+    },
+    drawImage() {},
+    fillStyle: '#000' as string | CanvasGradient | CanvasPattern,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+function textRun(text: string, size = 20, fontFace?: string): ShapeTextRun {
+  return { type: 'text', text, bold: false, italic: false, size, fontFace };
+}
+
+function para(text: string, spaceLine?: ShapeParagraph['spaceLine'], fontFace?: string): ShapeParagraph {
+  return { align: 'l', runs: [textRun(text, 20, fontFace)], spaceLine };
+}
+
+/** Top-anchored, wrap:none, so a line's baseline is the cumulative sum of the
+ *  heights of the lines above it. With two single-line paragraphs the A→B
+ *  baseline gap equals the applied per-line height of the (identical) first line
+ *  (textBaseline='middle': drawY = lineTop + height/2, so gap = h0/2 + h1/2). */
+function gap(paragraphs: ShapeParagraph[], overrides: Partial<ShapeText> = {}): number {
+  const { ctx, calls } = makeRecordingCtx();
+  const txt: ShapeText = { anchor: 't', wrap: 'none', paragraphs, ...overrides };
+  drawShapeText(ctx, txt, 400, 400, 1);
+  const a = calls.find((c) => c.text === 'A');
+  const b = calls.find((c) => c.text === 'B');
+  expect(a).toBeDefined();
+  expect(b).toBeDefined();
+  return b!.y - a!.y;
+}
+
+describe('shape-text line spacing (§21.1.2.2.5 <a:lnSpc>) + normAutofit lnSpcReduction', () => {
+  const cs = 1;
+  const naturalSingle = 20 * PT_TO_PX * cs * 1.2; // 20 pt Calibri, floor is 0 → flat 1.2×em
+
+  it('baseline: unspaced line height is the natural 1.2×em single line', () => {
+    expect(gap([para('A'), para('B')])).toBeCloseTo(naturalSingle, 5);
+  });
+
+  it('spcPct 200% doubles the natural single-line height', () => {
+    const spaced = gap([para('A', { type: 'pct', val: 200000 }), para('B', { type: 'pct', val: 200000 })]);
+    expect(spaced).toBeCloseTo(naturalSingle * 2, 5);
+    // And exactly 2× the unspaced reference.
+    expect(spaced).toBeCloseTo(gap([para('A'), para('B')]) * 2, 5);
+  });
+
+  it('spcPts 40 makes each line an absolute 40 pt (cs-scaled) height', () => {
+    const spaced = gap([para('A', { type: 'pts', val: 40 }), para('B', { type: 'pts', val: 40 })]);
+    expect(spaced).toBeCloseTo(40 * PT_TO_PX * cs, 5);
+  });
+
+  it('normAutofit lnSpcReduction 0.2 scales each line to 80% of natural', () => {
+    const reduced = gap([para('A'), para('B')], { autoFit: 'norm', lnSpcReduction: 0.2 });
+    expect(reduced).toBeCloseTo(naturalSingle * 0.8, 5);
+  });
+
+  it('spAutoFit / noAutofit leave the natural line height unchanged (not applied)', () => {
+    expect(gap([para('A'), para('B')], { autoFit: 'sp' })).toBeCloseTo(naturalSingle, 5);
+    expect(gap([para('A'), para('B')], { autoFit: 'none' })).toBeCloseTo(naturalSingle, 5);
+    // A stored fontScale is modeled but intentionally NOT applied to layout.
+    expect(gap([para('A'), para('B')], { autoFit: 'norm', fontScale: 0.5 })).toBeCloseTo(naturalSingle, 5);
+  });
+});
+
+// Commit-1 companion: the natural single line is FLOORED by the authored font's
+// design line (intendedSingleLinePx) before line spacing is applied. A tabled
+// face (Meiryo, 1.5962×em) must measure to its taller design box; an untabled
+// face (Calibri) stays on the flat 1.2×em. The mock canvas is metric-agnostic,
+// so this exercises the pure design-metric floor keyed on the authored name.
+describe('shape-text single-line height floor by font design metric (§21.1.2.1.1)', () => {
+  const em = 20 * PT_TO_PX;
+
+  it('a tabled face (Meiryo) floors the line to its design single line, above 1.2×em', () => {
+    const meiryoFloor = intendedSingleLinePx('Meiryo', em);
+    expect(meiryoFloor).toBeGreaterThan(em * 1.2); // sanity: the floor bites
+    const h = gap([para('A', undefined, 'Meiryo'), para('B', undefined, 'Meiryo')]);
+    expect(h).toBeCloseTo(meiryoFloor, 5);
+  });
+
+  it('an untabled face (Calibri) is left on the flat 1.2×em (floor returns 0)', () => {
+    expect(intendedSingleLinePx('Calibri', em)).toBe(0);
+    const h = gap([para('A', undefined, 'Calibri'), para('B', undefined, 'Calibri')]);
+    expect(h).toBeCloseTo(em * 1.2, 5);
+  });
+});

--- a/packages/xlsx/src/shape-text-line-spacing.test.ts
+++ b/packages/xlsx/src/shape-text-line-spacing.test.ts
@@ -92,6 +92,20 @@ describe('shape-text line spacing (§21.1.2.2.5 <a:lnSpc>) + normAutofit lnSpcRe
     // A stored fontScale is modeled but intentionally NOT applied to layout.
     expect(gap([para('A'), para('B')], { autoFit: 'norm', fontScale: 0.5 })).toBeCloseTo(naturalSingle, 5);
   });
+
+  it('lnSpcReduction does NOT reduce absolute spcPts spacing (§21.1.2.1.3 note)', () => {
+    // The spec: lnSpcReduction "applies only to paragraphs with percentage line
+    // spacing." An absolute spcPts line height must be left as-is; only pct and
+    // the implicit single (100 % percentage) are reduced.
+    const pts = [para('A', { type: 'pts', val: 40 }), para('B', { type: 'pts', val: 40 })];
+    const reduced = gap(pts, { autoFit: 'norm', lnSpcReduction: 0.2 });
+    // Still the absolute 40 pt — NOT 40 × 0.8.
+    expect(reduced).toBeCloseTo(40 * PT_TO_PX * cs, 5);
+    // A pct paragraph in the same body IS reduced (control), proving the gate is
+    // on the spacing type, not on the reduction being ignored entirely.
+    const pct = [para('A', { type: 'pct', val: 100000 }), para('B', { type: 'pct', val: 100000 })];
+    expect(gap(pct, { autoFit: 'norm', lnSpcReduction: 0.2 })).toBeCloseTo(naturalSingle * 0.8, 5);
+  });
 });
 
 // Commit-1 companion: the natural single line is FLOORED by the authored font's

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -1,4 +1,4 @@
-import type { MathNode } from '@silurus/ooxml-core';
+import type { MathNode, SpaceLine } from '@silurus/ooxml-core';
 
 export interface Workbook {
   sheets: SheetMeta[];
@@ -552,6 +552,17 @@ export interface ShapeText {
   anchor: string;
   /** `<a:bodyPr@wrap>` — `square` (wrap to width) | `none`. */
   wrap: string;
+  /** `<a:bodyPr>` autofit child — `'sp'` (`spAutoFit`), `'norm'` (`normAutofit`),
+   *  or `'none'` (`noAutofit`/absent). ECMA-376 §21.1.2.1.1-.3. Always present
+   *  (default `'none'`), mirroring the core `TextBody.autoFit`. */
+  autoFit?: string;
+  /** `<a:normAutofit@fontScale>` — stored font-shrink fraction (e.g. 0.625 for
+   *  `fontScale="62500"`). Null/absent when unset. Modeled for parity with
+   *  pptx; the xlsx renderer does not currently apply it. */
+  fontScale?: number | null;
+  /** `<a:normAutofit@lnSpcReduction>` — stored line-spacing reduction fraction
+   *  (e.g. 0.20 for `lnSpcReduction="20000"`). Null/absent when unset. */
+  lnSpcReduction?: number | null;
   paragraphs: ShapeParagraph[];
 }
 
@@ -571,6 +582,9 @@ export interface ShapeParagraph {
   /** `<a:pPr@indent>` — first-line indent in EMU (negative = hanging),
    *  ECMA-376 §21.1.2.2.7. Omitted (undefined) when unset. */
   indent?: number;
+  /** `<a:pPr>/<a:lnSpc>` line spacing (ECMA-376 §21.1.2.2.5). Direct-only;
+   *  omitted when unset. */
+  spaceLine?: SpaceLine | null;
   runs: ShapeTextRun[];
 }
 


### PR DESCRIPTION
Second cross-package follow-up from PR #640's review (stacked on #642). Closes two latent holes in xlsx's shape-text path (`drawShapeText`) that docx and pptx already handle for the identical DrawingML constructs, plus a §21.1.2.1.3 compliance fix surfaced by review that also lands in pptx.

**Context — inert on the current corpus, verified by unit tests.** No xlsx sample uses `<a:lnSpc>`; the only autofit children present are `<a:noAutofit/>` (sample-10) and `<a:spAutoFit/>` (sample-28), both render-inert. There is no Excel ground-truth VRT for xlsx. So correctness rests on ECMA-376 + parity with pptx's already-verified `SpaceLine`/autofit model, backed by new unit tests that drive the feature directly — not on pixel-vs-Excel.

## 1 — `fix(xlsx)`: floor shape-text line height to the font design metric
`drawShapeText` sized every line at a flat `pxSize * 1.2`, ignoring the OS/2 design line. #642 floored the **cell** path (`vMetricPx`) but the **shape** path was missed. Now each single line is `max(pxSize*1.2, intendedSingleLinePx(run.fontFace, pxSize))` — the same core floor docx/pptx use. A FLOOR: `intendedSingleLinePx` returns 0 for untabled faces (Calibri unchanged); a substituted **Meiryo (1.596×em) / Sakkal Majalla** measures to its taller design box (§21.1.2.1.1). The authored family name is passed (not the fallback stack), reused on wrapped continuation lines, and the empty-line fallback floors by the nearest preceding face.

## 2 — `feat(xlsx)`: parse `<a:lnSpc>` + `<a:bodyPr>` autofit into the model
Rust parser + TS types, mirroring pptx exactly. New `SpaceLine` enum (`Pct`/`Pts`, same JSON as pptx / core's TS `SpaceLine`); `ShapeParagraph.spaceLine`; `ShapeText.autoFit` (`sp`/`norm`/`none`, always emitted) + `fontScale` + `lnSpcReduction`. `parse_tx_body` reads the `<a:bodyPr>` autofit child (spAutoFit/normAutofit/noAutofit; fontScale & lnSpcReduction ÷100000) and `<a:pPr>/<a:lnSpc>` (spcPct raw val; **spcPts val ÷100** — hundredths of a point → pt, matching pptx). TS imports `SpaceLine` from core. Additive serde keeps existing JSON byte-identical. +3 Rust parser tests. WASM rebuilt.

## 3 — `feat(xlsx)`: apply line spacing + `normAutofit` lnSpcReduction
`applyLineSpacing` in `drawShapeText` mirrors the pptx renderer: pct scales the natural (floored) single line, pts is an absolute cs-scaled per-line height, then a stored `lnSpcReduction` reduces it (subject to §4). Applied to text lines and the display-equation line. **Intentionally out of scope** (modeled but NOT applied): `normAutofit` fontScale font-shrink and `spAutoFit` shape-grow — runtime layout behaviors the repo's house rule requires explicit user approval for; no sample needs them.

## 4 — `fix(xlsx,pptx)`: gate `lnSpcReduction` to percentage line spacing (§21.1.2.1.3)
Review finding. §21.1.2.1.3 has a normative note — *"This attribute applies only to paragraphs with percentage line spacing."* Both renderers applied the reduction to every paragraph including absolute `spcPts` ones. Now gated on `spaceLine?.type !== 'pts'` (pct + implicit single = 100% percentage still reduce; absolute pts does not). **Cross-package**: the new xlsx code replicated the behavior and pptx carried the same latent non-compliance — both fixed together per the integrative-fix rule. Inert on the corpus (no file pairs `normAutofit` with `spcPts`, pptx VRT unchanged); new xlsx test proves the gate.

## Verification
- **vitest 239 → 247** (+6 line-spacing incl. the new pts+lnSpcReduction gate control; +2 design-floor Meiryo/Calibri). Green.
- **Rust `cargo test` 70 → 73**. `cargo fmt --check` + `clippy -D warnings` clean.
- **Typecheck** clean (xlsx + pptx).
- **VRT**: `demo/sample-1` stays at its pre-existing sub-0.2% self-baseline (provably inert). Every present sample unzipped: zero `lnSpc`, zero `normAutofit`. `private/sample-25` (Meiryo UI shape text authored via `<a:latin>`) legitimately gets a taller design-floored line box — the intended §21.1.2.1.1 change. Reference images NOT modified.

## Known limitation (pre-existing, tracked as follow-up)
The shape-run parser reads the typeface only from `<a:latin@typeface>`; `<a:ea>`/`<a:cs>` are not captured (they never were). So a **Meiryo set *only* as the East-Asian font** (`<a:ea>`, latin left default) is not floored — `run.fontFace` is undefined and the metric lookup returns 0. This is the one case the pptx per-glyph `familyEa` path catches. Not a regression (xlsx shape text never parsed `<a:ea>`), and the floor still fires for faces authored in `<a:latin>` (e.g. sample-25). Follow-up: parse `<a:ea>`/`<a:cs>` and floor against the CJK/complex-rendering face.

## Review
Reviewed by 4 independent adversarial agents (spec-fidelity, single-responsibility/commit-hygiene, DRY, cross-package consistency). All recommend merge. Their two blocking-ish items are addressed here (§4 gate; #642 commit-message scope reword). Non-blocking follow-ups tracked: (a) the `<a:ea>` floor above, (b) consolidating the duplicated Rust `SpaceLine` enum + `<a:lnSpc>`/`<a:bodyPr>`-autofit parse into `ooxml-common` (like `parse_src_rect`, PR #576 precedent).

> Base is `feature/core-line-metrics` (#642) because commit 1 reuses that PR's core `intendedSingleLinePx`. Will retarget to `main` once #642 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)