### PR TITLE
refactor(ooxml-common): share DrawingML SpaceLine + lnSpc/autofit parse (pptx+xlsx dedup)

### DIFF
--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -10,4 +10,5 @@ pub mod blip;
 pub mod chart;
 pub mod color;
 pub mod math;
+pub mod text;
 pub mod zip;

--- a/packages/ooxml-common/src/text.rs
+++ b/packages/ooxml-common/src/text.rs
@@ -1,0 +1,195 @@
+//! Shared DrawingML text-body helpers used by the pptx and xlsx parsers.
+//!
+//! Both hosts embed the same DrawingML text grammar: a paragraph's line spacing
+//! rides in `<a:lnSpc>` (ECMA-376 §21.1.2.2.5) and a text body's autofit mode in
+//! a `<a:bodyPr>` child (`<a:spAutoFit>` / `<a:normAutofit>` / `<a:noAutofit>`,
+//! §21.1.2.1.1-.4). These leaves were previously read inline in each parser with
+//! byte-identical serde shapes; sharing the type + leaf parse keeps the two
+//! formats' line-spacing / autofit handling identical.
+//!
+//! Following the `parse_src_rect` precedent in [`crate::blip`], each caller
+//! *locates* the node (`<a:lnSpc>` / `<a:bodyPr>`) and keeps its own inheritance
+//! and defaults; the shared function only parses the located leaf.
+
+use roxmltree::Node;
+use serde::{Deserialize, Serialize};
+
+/// Paragraph line spacing (`<a:lnSpc>`, ECMA-376 §21.1.2.2.5): a percentage of
+/// the natural single line, or an absolute per-line height in points. The serde
+/// shape (`{"type":"pct","val":..}` / `{"type":"pts","val":..}`) mirrors core's
+/// TS `SpaceLine`, so the pptx and xlsx JSON stays byte-identical.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SpaceLine {
+    /// `<a:spcPct@val>` (e.g. 100000 = 100%, 150000 = 150%).
+    Pct { val: f64 },
+    /// `<a:spcPts@val>` in points (the raw ST_TextSpacingPoint hundredths-of-a-
+    /// point value is divided by 100 by this parser, matching core / pptx).
+    Pts { val: f64 },
+}
+
+/// Parse a located `<a:lnSpc>` node (ECMA-376 §21.1.2.2.5). A `<a:spcPct@val>`
+/// child yields the raw percentage (e.g. `150000`); otherwise a `<a:spcPts@val>`
+/// child yields points (its raw hundredths-of-a-point `@val` divided by 100).
+/// Returns `None` when neither child carries a parseable `@val`. The caller
+/// passes the located `<a:lnSpc>` node and keeps its own inheritance
+/// (lstStyle / master / body defaults).
+pub fn parse_lnspc(ln_spc: Node<'_, '_>) -> Option<SpaceLine> {
+    if let Some(v) = ln_spc
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "spcPct")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<f64>().ok())
+    {
+        return Some(SpaceLine::Pct { val: v });
+    }
+    ln_spc
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "spcPts")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|v| SpaceLine::Pts { val: v / 100.0 })
+}
+
+/// Parse a located `<a:bodyPr>` node's autofit child (ECMA-376 §21.1.2.1.1-.4).
+/// Returns `None` when the `<a:bodyPr>` has *no* autofit child, so the caller
+/// applies its own default (pptx defers to the theme txDef; xlsx uses `none`).
+/// Otherwise returns `Some((auto_fit, font_scale, ln_spc_reduction))`:
+///
+/// - `<a:spAutoFit>` → `("sp", None, None)`
+/// - `<a:normAutofit fontScale? lnSpcReduction?>` → `("norm", fontScale?, lnSpcReduction?)`,
+///   each scale being the raw ST_Percentage (1000ths of a percent) divided by
+///   100000 to a fraction (e.g. `62500` → `0.625`)
+/// - `<a:noAutofit>` → `("none", None, None)`
+///
+/// The OOXML spelling is `normAutofit` (lowercase `f`).
+pub fn parse_autofit(body_pr: Node<'_, '_>) -> Option<(String, Option<f64>, Option<f64>)> {
+    for c in body_pr.children().filter(|n| n.is_element()) {
+        match c.tag_name().name() {
+            "spAutoFit" => return Some(("sp".to_owned(), None, None)),
+            "normAutofit" => {
+                let font_scale = c
+                    .attribute("fontScale")
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .map(|v| v / 100_000.0);
+                let ln_spc_reduction = c
+                    .attribute("lnSpcReduction")
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .map(|v| v / 100_000.0);
+                return Some(("norm".to_owned(), font_scale, ln_spc_reduction));
+            }
+            "noAutofit" => return Some(("none".to_owned(), None, None)),
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roxmltree::Document;
+
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    /// `<a:spcPct@val>` → a percent SpaceLine carrying the raw `@val`.
+    #[test]
+    fn parse_lnspc_reads_pct_raw_val() {
+        let xml = format!(r#"<a:lnSpc xmlns:a="{A_NS}"><a:spcPct val="150000"/></a:lnSpc>"#);
+        let doc = Document::parse(&xml).unwrap();
+        assert_eq!(
+            parse_lnspc(doc.root_element()),
+            Some(SpaceLine::Pct { val: 150000.0 })
+        );
+    }
+
+    /// `<a:spcPts@val>` → a points SpaceLine (raw hundredths of a point / 100).
+    #[test]
+    fn parse_lnspc_reads_pts_hundredths_of_point() {
+        let xml = format!(r#"<a:lnSpc xmlns:a="{A_NS}"><a:spcPts val="1800"/></a:lnSpc>"#);
+        let doc = Document::parse(&xml).unwrap();
+        // 1800 hundredths of a point → 18 pt.
+        assert_eq!(
+            parse_lnspc(doc.root_element()),
+            Some(SpaceLine::Pts { val: 18.0 })
+        );
+    }
+
+    /// spcPct takes precedence over spcPts, and an empty/absent-val lnSpc → None.
+    #[test]
+    fn parse_lnspc_none_when_no_parseable_child() {
+        let empty = format!(r#"<a:lnSpc xmlns:a="{A_NS}"/>"#);
+        assert!(parse_lnspc(Document::parse(&empty).unwrap().root_element()).is_none());
+        // spcPct with no @val falls through and (here) so does absent spcPts.
+        let no_val = format!(r#"<a:lnSpc xmlns:a="{A_NS}"><a:spcPct/></a:lnSpc>"#);
+        assert!(parse_lnspc(Document::parse(&no_val).unwrap().root_element()).is_none());
+    }
+
+    /// The serde shape matches the two enums it replaces: tag "type", camelCase
+    /// variant tags, plain `val`.
+    #[test]
+    fn space_line_serializes_with_type_tag_and_camelcase() {
+        let pct = serde_json::to_value(SpaceLine::Pct { val: 150000.0 }).unwrap();
+        assert_eq!(pct["type"], "pct");
+        assert_eq!(pct["val"], 150000.0);
+        let pts = serde_json::to_value(SpaceLine::Pts { val: 18.0 }).unwrap();
+        assert_eq!(pts["type"], "pts");
+        assert_eq!(pts["val"], 18.0);
+    }
+
+    /// `<a:normAutofit fontScale lnSpcReduction>` → ("norm", scale/100000,
+    /// reduction/100000).
+    #[test]
+    fn parse_autofit_normautofit_reads_scales() {
+        let xml = format!(
+            r#"<a:bodyPr xmlns:a="{A_NS}"><a:normAutofit fontScale="62500" lnSpcReduction="20000"/></a:bodyPr>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        assert_eq!(
+            parse_autofit(doc.root_element()),
+            Some(("norm".to_owned(), Some(0.625), Some(0.20)))
+        );
+    }
+
+    /// `<a:normAutofit>` with no scale attributes → ("norm", None, None).
+    #[test]
+    fn parse_autofit_normautofit_without_scales() {
+        let xml = format!(r#"<a:bodyPr xmlns:a="{A_NS}"><a:normAutofit/></a:bodyPr>"#);
+        let doc = Document::parse(&xml).unwrap();
+        assert_eq!(
+            parse_autofit(doc.root_element()),
+            Some(("norm".to_owned(), None, None))
+        );
+    }
+
+    /// `<a:spAutoFit>` → ("sp", None, None).
+    #[test]
+    fn parse_autofit_spautofit() {
+        let xml = format!(r#"<a:bodyPr xmlns:a="{A_NS}"><a:spAutoFit/></a:bodyPr>"#);
+        let doc = Document::parse(&xml).unwrap();
+        assert_eq!(
+            parse_autofit(doc.root_element()),
+            Some(("sp".to_owned(), None, None))
+        );
+    }
+
+    /// `<a:noAutofit>` → ("none", None, None).
+    #[test]
+    fn parse_autofit_noautofit() {
+        let xml = format!(r#"<a:bodyPr xmlns:a="{A_NS}"><a:noAutofit/></a:bodyPr>"#);
+        let doc = Document::parse(&xml).unwrap();
+        assert_eq!(
+            parse_autofit(doc.root_element()),
+            Some(("none".to_owned(), None, None))
+        );
+    }
+
+    /// A `<a:bodyPr>` with NO autofit child → None, so the caller applies its own
+    /// default (pptx: theme txDef; xlsx: "none").
+    #[test]
+    fn parse_autofit_none_when_no_child() {
+        let xml = format!(r#"<a:bodyPr xmlns:a="{A_NS}" anchor="ctr" wrap="square"/>"#);
+        let doc = Document::parse(&xml).unwrap();
+        assert!(parse_autofit(doc.root_element()).is_none());
+    }
+}

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1,5 +1,6 @@
 use ooxml_common::blip::{mime_from_ext, parse_src_rect, svg_blip_rid, SrcRect};
 use ooxml_common::math::{nodes_to_text, parse_omath_nodes, MathNode};
+use ooxml_common::text::{parse_autofit, parse_lnspc, SpaceLine};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
@@ -1494,16 +1495,6 @@ fn is_zero_i64(n: &i64) -> bool {
 }
 fn is_false(b: &bool) -> bool {
     !*b
-}
-
-/// Line spacing specification
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "type", rename_all = "camelCase")]
-enum SpaceLine {
-    /// Percentage of the font height (val: e.g. 100000 = 100%, 150000 = 150%)
-    Pct { val: f64 },
-    /// Fixed points (val in pt)
-    Pts { val: f64 },
 }
 
 /// Bullet / list-item marker for a paragraph
@@ -4565,26 +4556,16 @@ fn parse_text_body(
     // For normAutofit, also capture PowerPoint's stored fontScale /
     // lnSpcReduction (ECMA-376 §21.1.2.1.3) — ST_Percentage in 1000ths of a
     // percent, so 62500 → 0.625. The renderer applies these directly.
-    let mut font_scale: Option<f64> = None;
-    let mut ln_spc_reduction: Option<f64> = None;
-    let auto_fit = if let Some(n) = body_pr {
-        if child(n, "spAutoFit").is_some() {
-            "sp".to_owned()
-        }
-        // OOXML uses lowercase 'f': normAutofit (not normAutoFit).
-        else if let Some(na) = child(n, "normAutofit") {
-            font_scale = attr_f64(&na, "fontScale").map(|v| v / 100000.0);
-            ln_spc_reduction = attr_f64(&na, "lnSpcReduction").map(|v| v / 100000.0);
-            "norm".to_owned()
-        } else if child(n, "noAutofit").is_some() {
-            "none".to_owned()
-        } else {
-            // bodyPr present but no autofit child — fall back to theme.
-            theme_auto_fit().unwrap_or_else(|| "none".to_owned())
-        }
-    } else {
-        theme_auto_fit().unwrap_or_else(|| "none".to_owned())
-    };
+    // parse_autofit returns None when there is no bodyPr, or a bodyPr with no
+    // autofit child, so both fall through to the theme txDef default.
+    let (auto_fit, font_scale, ln_spc_reduction) =
+        body_pr.and_then(parse_autofit).unwrap_or_else(|| {
+            (
+                theme_auto_fit().unwrap_or_else(|| "none".to_owned()),
+                None,
+                None,
+            )
+        });
     // ECMA-376 §20.1.10.34: numCol on <a:bodyPr> tells the renderer to
     // distribute paragraphs across N columns within the shape. Default 1.
     // spcCol is the inter-column gutter in EMU (default 0). Both fall back
@@ -4944,16 +4925,8 @@ fn parse_paragraph(
         .or(body_default_space_after);
 
     let space_line = p_pr
-        .and_then(|n| {
-            let spc = child(n, "lnSpc")?;
-            if let Some(pct) = child(spc, "spcPct") {
-                attr_f64(&pct, "val").map(|v| SpaceLine::Pct { val: v })
-            } else {
-                child(spc, "spcPts")
-                    .and_then(|pts| attr_f64(&pts, "val"))
-                    .map(|v| SpaceLine::Pts { val: v / 100.0 }) // hundredths of pt → pt
-            }
-        })
+        .and_then(|n| child(n, "lnSpc"))
+        .and_then(parse_lnspc)
         .or_else(|| body_default_line_spacing.map(|v| SpaceLine::Pct { val: v }));
 
     // Tab stops from pPr > tabLst

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -534,24 +534,13 @@ pub(crate) fn parse_tx_body(
                 if let Some(w) = c.attribute("wrap") {
                     wrap = w.to_string();
                 }
-                // OOXML spelling is `normAutofit` (lowercase f).
-                for bc in c.children().filter(|n| n.is_element()) {
-                    match bc.tag_name().name() {
-                        "spAutoFit" => auto_fit = String::from("sp"),
-                        "normAutofit" => {
-                            auto_fit = String::from("norm");
-                            font_scale = bc
-                                .attribute("fontScale")
-                                .and_then(|v| v.parse::<f64>().ok())
-                                .map(|v| v / 100000.0);
-                            ln_spc_reduction = bc
-                                .attribute("lnSpcReduction")
-                                .and_then(|v| v.parse::<f64>().ok())
-                                .map(|v| v / 100000.0);
-                        }
-                        "noAutofit" => auto_fit = String::from("none"),
-                        _ => {}
-                    }
+                // Autofit child (spAutoFit / normAutofit / noAutofit). Shared
+                // with pptx; xlsx keeps the "none" default when there is no
+                // autofit child (parse_autofit returns None).
+                if let Some((af, fs, lsr)) = ooxml_common::text::parse_autofit(c) {
+                    auto_fit = af;
+                    font_scale = fs;
+                    ln_spc_reduction = lsr;
                 }
             }
             "p" => {
@@ -584,30 +573,12 @@ pub(crate) fn parse_tx_body(
                             // ECMA-376 §21.1.2.2.5 `<a:lnSpc>`: spcPct is a
                             // percentage of the natural single line; spcPts is an
                             // absolute per-line height (raw @val is hundredths of
-                            // a point → divide by 100, matching pptx SpaceLine).
+                            // a point → divide by 100). Shared with pptx.
                             if let Some(ln_spc) = pc
                                 .children()
                                 .find(|n| n.is_element() && n.tag_name().name() == "lnSpc")
                             {
-                                let pct = ln_spc
-                                    .children()
-                                    .find(|n| n.is_element() && n.tag_name().name() == "spcPct");
-                                if let Some(v) = pct
-                                    .and_then(|n| n.attribute("val"))
-                                    .and_then(|v| v.parse::<f64>().ok())
-                                {
-                                    space_line = Some(SpaceLine::Pct { val: v });
-                                } else {
-                                    let pts = ln_spc.children().find(|n| {
-                                        n.is_element() && n.tag_name().name() == "spcPts"
-                                    });
-                                    if let Some(v) = pts
-                                        .and_then(|n| n.attribute("val"))
-                                        .and_then(|v| v.parse::<f64>().ok())
-                                    {
-                                        space_line = Some(SpaceLine::Pts { val: v / 100.0 });
-                                    }
-                                }
+                                space_line = ooxml_common::text::parse_lnspc(ln_spc);
                             }
                         }
                         "r" => {

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -886,18 +886,10 @@ pub struct ShapeInfo {
     pub text: Option<ShapeText>,
 }
 
-/// Paragraph line spacing (`<a:pPr>/<a:lnSpc>`, ECMA-376 §21.1.2.2.5). Mirrors
-/// the pptx `SpaceLine` JSON shape (and core's TS `SpaceLine`): a percentage of
+/// Paragraph line spacing (`<a:pPr>/<a:lnSpc>`, ECMA-376 §21.1.2.2.5). Shared
+/// with the pptx parser (and mirroring core's TS `SpaceLine`): a percentage of
 /// the natural single line, or an absolute per-line height in points.
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum SpaceLine {
-    /// `<a:spcPct@val>` (e.g. 100000 = 100%, 150000 = 150%).
-    Pct { val: f64 },
-    /// `<a:spcPts@val>` in points (the raw ST_TextSpacingPoint hundredths-of-a-
-    /// point value is divided by 100 by the parser, matching pptx).
-    Pts { val: f64 },
-}
+pub use ooxml_common::text::SpaceLine;
 
 /// Text body inside a shape (`<xdr:txBody>`, ECMA-376 §20.1.2.2). Holds
 /// the paragraphs plus body-level formatting (`<a:bodyPr>`).


### PR DESCRIPTION
Follow-up from the line-metrics review (PRs #642/#643). The Rust `SpaceLine` enum and the DrawingML `<a:lnSpc>` line-spacing parse + `<a:bodyPr>` autofit-child parse were DUPLICATED between the pptx parser (`lib.rs`) and the xlsx parser (`types.rs`/`drawing.rs`). Consolidated into `ooxml-common`, following the exact `parse_src_rect` precedent (PR #576) — the house rule ("横断統合の原則": shared TYPES + PARSE live in `ooxml-common`). **Pure behavior-neutral refactor.**

## Changes (3 commits, 1関心=1commit)
1. `refactor(ooxml-common)`: new `text` module — `pub enum SpaceLine { Pct, Pts }` (Serialize+Deserialize, `#[serde(tag="type", rename_all="camelCase")]`, byte-identical JSON to the two enums it replaces) + `parse_lnspc(<a:lnSpc> node) -> Option<SpaceLine>` (spcPct raw val; spcPts val÷100) + `parse_autofit(<a:bodyPr> node) -> Option<(String, Option<f64>, Option<f64>)>` (spAutoFit/normAutofit/noAutofit; fontScale & lnSpcReduction ÷100000). **Leaf-only, `parse_src_rect`-scoped**: the caller locates the node and keeps its own inheritance/defaults — `parse_autofit` returns `None` when the bodyPr has no autofit child, so each caller applies its own default (pptx → theme txDef; xlsx → `none`). +9 unit tests.
2. `refactor(pptx)`: delete the local `enum SpaceLine`; use `ooxml_common::text::{SpaceLine, parse_lnspc, parse_autofit}`. The autofit `unwrap_or_else` preserves the exact theme-txDef fallback for both "no bodyPr" and "bodyPr without autofit child"; `parse_paragraph` keeps its `body_default_line_spacing` inheritance.
3. `refactor(xlsx)`: `types.rs` → `pub use ooxml_common::text::SpaceLine`; `drawing.rs` `parse_tx_body` uses the shared `parse_lnspc`/`parse_autofit`, keeping the `none` default.

## Byte-identical verification
- **Diff-level**: each rewiring replaces the inline read with a call to the identical shared function; the only divergence is on MALFORMED input (a `<a:lnSpc>` carrying an empty `<a:spcPct/>` *and* a `<a:spcPts val>`, or a `<a:bodyPr>` with multiple autofit children) — impossible per `CT_TextSpacing`/`CT_TextBodyProperties` (one child), so identical on every valid file.
- **Tests**: `cargo test` — ooxml-common 55, pptx-parser 105, xlsx-parser 73 (all green, incl. the 9 new text.rs tests + the pre-existing pptx/xlsx SpaceLine/autofit/lnSpc parser tests that assert the JSON shape). `cargo fmt --check` + `clippy -D warnings` clean on all 3 crates.
- **JS**: WASM rebuilt (pptx+xlsx); `pnpm` vitest — pptx 130, xlsx 247 (all green — these parse real samples and assert the model shape, so a JSON drift would fail them).

No TS renderer changes (the TS `SpaceLine` already comes from core and is unaffected). Reference images NOT modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)