### PR TITLE
fix(xlsx): floor shape-text line box by the East-Asian/complex-script face (a:ea/a:cs)

### DIFF
--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -413,10 +413,13 @@ pub(crate) fn parse_custom_path(path_node: &roxmltree::Node) -> PathInfo {
 /// Parse `<xdr:txBody>` into a `ShapeText`. Returns `None` if the body
 /// contains no visible runs. Run formatting follows ECMA-376 §21.1.2.3.1
 /// (`<a:rPr>`): `sz` is hundredths of a point, `b="1"` = bold, `i="1"`
-/// = italic, `<a:solidFill>` overrides shape-level font color, and
-/// `<a:latin@typeface>` selects the Latin font face (we don't yet
-/// distinguish East-Asian / complex-script fonts — `<a:ea>` and `<a:cs>`
-/// are ignored for typeface).
+/// = italic, `<a:solidFill>` overrides shape-level font color,
+/// `<a:latin@typeface>` selects the Latin font face, and `<a:ea@typeface>` /
+/// `<a:cs@typeface>` the East-Asian / complex-script faces. The renderer
+/// floors the line box by whichever of these declares a tabled (Meiryo /
+/// Sakkal Majalla) design line — the common Japanese encoding sets Meiryo on
+/// `<a:ea>` while leaving `<a:latin>` default. Per-glyph font switching is
+/// still not modeled (a larger change); only the line-box floor uses ea/cs.
 /// Point size for an equation: the first `a:rPr@sz` on an actual math RUN
 /// (`m:r`), in pt. Scoped to `m:r` so the size on `<m:ctrlPr>` (control
 /// properties — structural delimiters, not visible glyphs) is ignored.
@@ -589,6 +592,12 @@ pub(crate) fn parse_tx_body(
                             let mut size: f64 = 0.0;
                             let mut color: Option<String> = None;
                             let mut font_face: Option<String> = None;
+                            // ECMA-376 §21.1.2.3.1 `<a:ea>` / `<a:cs>` typefaces.
+                            // Parsed alongside `<a:latin>` so the renderer can
+                            // floor the line box by a tabled East-Asian face
+                            // (e.g. Meiryo set only on `<a:ea>`).
+                            let mut font_face_ea: Option<String> = None;
+                            let mut font_face_cs: Option<String> = None;
                             for rc in pc.children().filter(|n| n.is_element()) {
                                 match rc.tag_name().name() {
                                     "rPr" => {
@@ -607,6 +616,14 @@ pub(crate) fn parse_tx_body(
                                                 }
                                                 "latin" => {
                                                     font_face =
+                                                        rpc.attribute("typeface").map(String::from);
+                                                }
+                                                "ea" => {
+                                                    font_face_ea =
+                                                        rpc.attribute("typeface").map(String::from);
+                                                }
+                                                "cs" => {
+                                                    font_face_cs =
                                                         rpc.attribute("typeface").map(String::from);
                                                 }
                                                 _ => {}
@@ -629,6 +646,8 @@ pub(crate) fn parse_tx_body(
                                     size,
                                     color,
                                     font_face,
+                                    font_face_ea,
+                                    font_face_cs,
                                 });
                             }
                         }
@@ -1814,6 +1833,92 @@ mod math_tests {
         assert!(
             v.get("font_face").is_none(),
             "snake_case `font_face` must not appear"
+        );
+    }
+
+    /// ECMA-376 §21.1.2.3.1 `<a:ea>` (East-Asian) / `<a:cs>` (complex-script)
+    /// typefaces parse onto the run alongside `<a:latin>`. The common Japanese
+    /// encoding sets Meiryo on `<a:ea>` while leaving `<a:latin>` default; the
+    /// renderer floors the line box by the tabled face. They serialize as
+    /// camelCase `fontFaceEa` / `fontFaceCs` and are additive (omitted when
+    /// absent), so shapes without ea/cs stay byte-identical.
+    #[test]
+    fn parses_ea_and_cs_typefaces() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:p>
+                <a:r>
+                  <a:rPr sz="1400">
+                    <a:ea typeface="Meiryo"/>
+                    <a:cs typeface="Sakkal Majalla"/>
+                  </a:rPr>
+                  <a:t>あ</a:t>
+                </a:r>
+              </a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        let run = &text.paragraphs[0].runs[0];
+        match run {
+            ShapeTextRun::Text {
+                font_face,
+                font_face_ea,
+                font_face_cs,
+                ..
+            } => {
+                assert!(font_face.is_none(), "latin left default → font_face None");
+                assert_eq!(
+                    font_face_ea.as_deref(),
+                    Some("Meiryo"),
+                    "<a:ea> → fontFaceEa"
+                );
+                assert_eq!(
+                    font_face_cs.as_deref(),
+                    Some("Sakkal Majalla"),
+                    "<a:cs> → fontFaceCs"
+                );
+            }
+            other => panic!("expected Text run, got {other:?}"),
+        }
+
+        let v: serde_json::Value = serde_json::to_value(run).unwrap();
+        assert_eq!(
+            v["fontFaceEa"], "Meiryo",
+            "serializes as camelCase fontFaceEa"
+        );
+        assert_eq!(
+            v["fontFaceCs"], "Sakkal Majalla",
+            "serializes as camelCase fontFaceCs"
+        );
+    }
+
+    /// Additive guarantee: a run with no `<a:ea>` / `<a:cs>` omits both keys
+    /// from JSON entirely (serde `skip_serializing_if = "Option::is_none"`), so
+    /// existing shape JSON stays byte-identical.
+    #[test]
+    fn omits_ea_and_cs_when_absent() {
+        let xml = format!(
+            r#"<xdr:txBody {NS}>
+              <a:p>
+                <a:r>
+                  <a:rPr sz="1400"><a:latin typeface="Calibri"/></a:rPr>
+                  <a:t>hi</a:t>
+                </a:r>
+              </a:p>
+            </xdr:txBody>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let text = parse_tx_body(&doc.root_element(), &[]).expect("txBody parses");
+        let run = &text.paragraphs[0].runs[0];
+        let v: serde_json::Value = serde_json::to_value(run).unwrap();
+        assert!(
+            v.get("fontFaceEa").is_none(),
+            "fontFaceEa omitted when absent"
+        );
+        assert!(
+            v.get("fontFaceCs").is_none(),
+            "fontFaceCs omitted when absent"
         );
     }
 

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -977,6 +977,17 @@ pub enum ShapeTextRun {
         color: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         font_face: Option<String>,
+        /// East-Asian typeface (`<a:ea@typeface>`, ECMA-376 §21.1.2.3.1). The
+        /// common encoding for Japanese shape text sets Meiryo here while
+        /// leaving `<a:latin>` default. The renderer floors the line box by
+        /// this face's design line too. Additive — omitted from JSON when None
+        /// so shapes without `<a:ea>` stay byte-identical.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        font_face_ea: Option<String>,
+        /// Complex-script typeface (`<a:cs@typeface>`, ECMA-376 §21.1.2.3.1).
+        /// Additive — omitted from JSON when None.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        font_face_cs: Option<String>,
     },
     /// Soft line break (`<a:br>`).
     Break,

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3670,7 +3670,11 @@ export function drawShapeText(
       // this paragraph, falling back to the body default.
       if (lineHeight === 0) {
         const fallbackPx = (lastTextPt || DEFAULT_FONT_SIZE) * PT_TO_PX * cs;
-        lineHeight = Math.max(fallbackPx * 1.2, intendedSingleLinePx(lastTextFace, fallbackPx));
+        const designFloor = Math.max(
+          intendedSingleLinePx(lastTextFace, fallbackPx),
+          intendedSingleLinePx(lastTextFaceEa, fallbackPx),
+        );
+        lineHeight = Math.max(fallbackPx * 1.2, designFloor);
         lineAscent = fallbackPx * 0.85;
       }
       lineHeight = applyLineSpacing(lineHeight);
@@ -3681,9 +3685,12 @@ export function drawShapeText(
     // Nearest preceding text size (pt) in this paragraph — inline math with no
     // explicit rPr@sz inherits it (then falls back to the default).
     let lastTextPt = 0;
-    // Nearest preceding text AUTHORED face — used to floor an empty/blank line's
-    // reserved single-line height by that font's design line (intendedSingleLinePx).
+    // Nearest preceding text AUTHORED faces — used to floor an empty/blank
+    // line's reserved single-line height by the tallest design line among the
+    // declared latin / ea faces (intendedSingleLinePx), matching the text-run
+    // floor below (cs is excluded from the line-box floor — see there).
     let lastTextFace: string | undefined;
+    let lastTextFaceEa: string | undefined;
 
     for (const run of p.runs) {
       if (run.type === 'break') { flushLine(); continue; }
@@ -3724,6 +3731,7 @@ export function drawShapeText(
       // Text run.
       lastTextPt = run.size > 0 ? run.size : DEFAULT_FONT_SIZE;
       lastTextFace = run.fontFace;
+      lastTextFaceEa = run.fontFaceEa;
       const { font, px: pxSize } = textFont(run);
       const color = run.color ?? '#000000';
       // Floor the natural single line (Excel's flat 1.2×em) by the AUTHORED
@@ -3731,9 +3739,23 @@ export function drawShapeText(
       // core's intendedSingleLinePx — same floor docx/pptx apply. It returns 0
       // for every untabled face (Calibri etc. stay on 1.2×em); a substituted
       // Meiryo (1.596×em) / Sakkal Majalla must measure to its taller design
-      // line. Pass run.fontFace (the metric table keys on authored names), NOT
-      // the fallback stack from fontStackFor. Keep it a FLOOR — not a replace.
-      const singleLinePx = Math.max(pxSize * 1.2, intendedSingleLinePx(run.fontFace, pxSize));
+      // line. Floor by the tallest of the LATIN and EAST-ASIAN faces (the common
+      // Japanese encoding sets Meiryo only on `<a:ea>` while leaving `<a:latin>`
+      // default, §21.1.2.3.1). `<a:cs>` is parsed (see fontFaceCs) but
+      // deliberately NOT in this line-box floor: per the font-slot rules
+      // (§21.1.2.3.1 / §17.3.2.26) the complex-script face renders ONLY
+      // complex-script glyphs (Arabic/Hebrew/Thai), so an unconditional
+      // line-box floor by cs would over-grow a run whose glyphs are Latin/CJK
+      // (e.g. a Japanese run that merely also declares a tabled cs face). Getting
+      // cs right needs per-glyph/per-script handling (deferred, like pptx's
+      // per-glyph floor). Pass the authored names (the metric table keys on
+      // them), NOT the fallback stack. FLOOR, not a replace; matches the docx
+      // shape-text floor's max(latin, ea).
+      const designFloor = Math.max(
+        intendedSingleLinePx(run.fontFace, pxSize),
+        intendedSingleLinePx(run.fontFaceEa, pxSize),
+      );
+      const singleLinePx = Math.max(pxSize * 1.2, designFloor);
       lineHeight = Math.max(lineHeight, singleLinePx);
       lineAscent = Math.max(lineAscent, pxSize * 0.85);
       ctx.font = font;

--- a/packages/xlsx/src/shape-text-line-spacing.test.ts
+++ b/packages/xlsx/src/shape-text-line-spacing.test.ts
@@ -46,6 +46,19 @@ function para(text: string, spaceLine?: ShapeParagraph['spaceLine'], fontFace?: 
   return { align: 'l', runs: [textRun(text, 20, fontFace)], spaceLine };
 }
 
+/** A paragraph whose single run declares only an East-Asian face (`<a:ea>`),
+ *  latin left undefined — the common Japanese shape-text encoding. */
+function paraEa(text: string, fontFaceEa: string): ShapeParagraph {
+  return { align: 'l', runs: [{ type: 'text', text, bold: false, italic: false, size: 20, fontFaceEa }] };
+}
+
+/** A paragraph whose single run declares a tabled complex-script face (`<a:cs>`)
+ *  but untabled latin/ea — the cs face must NOT floor the line box (it renders
+ *  only complex-script glyphs). */
+function paraCs(text: string, fontFaceCs: string): ShapeParagraph {
+  return { align: 'l', runs: [{ type: 'text', text, bold: false, italic: false, size: 20, fontFaceCs }] };
+}
+
 /** Top-anchored, wrap:none, so a line's baseline is the cumulative sum of the
  *  heights of the lines above it. With two single-line paragraphs the A→B
  *  baseline gap equals the applied per-line height of the (identical) first line
@@ -127,5 +140,35 @@ describe('shape-text single-line height floor by font design metric (§21.1.2.1.
     expect(intendedSingleLinePx('Calibri', em)).toBe(0);
     const h = gap([para('A', undefined, 'Calibri'), para('B', undefined, 'Calibri')]);
     expect(h).toBeCloseTo(em * 1.2, 5);
+  });
+
+  // ECMA-376 §21.1.2.3.1: a tabled face declared ONLY on `<a:ea>` (latin left
+  // default) — the common Japanese shape-text encoding — must still floor the
+  // line box by that face's design line. Before parsing `<a:ea>` the run's
+  // fontFace stayed undefined and the floor never fired (PR #643 follow-up).
+  it('a tabled EA face (Meiryo on <a:ea>, latin undefined) floors the line', () => {
+    const meiryoFloor = intendedSingleLinePx('Meiryo', em);
+    expect(meiryoFloor).toBeGreaterThan(em * 1.2); // sanity: the ea floor bites
+    const h = gap([paraEa('A', 'Meiryo'), paraEa('B', 'Meiryo')]);
+    expect(h).toBeCloseTo(meiryoFloor, 5);
+  });
+
+  it('a Calibri-latin run with no <a:ea> stays on the flat 1.2×em', () => {
+    // Regression guard for the ea floor: an untabled latin face without any ea
+    // must not grow (both floors return 0).
+    const h = gap([para('A', undefined, 'Calibri'), para('B', undefined, 'Calibri')]);
+    expect(h).toBeCloseTo(em * 1.2, 5);
+  });
+
+  // §21.1.2.3.1 font slots: the complex-script (`<a:cs>`) face renders ONLY
+  // complex-script glyphs (Arabic/Hebrew/Thai). A tabled cs face on a run whose
+  // glyphs are Latin/CJK must NOT floor the line box (that would over-grow it by
+  // a face that renders none of the text — e.g. sample-25's Japanese run that
+  // also declares Meiryo UI on cs). cs is parsed/modeled but excluded from the
+  // line-box floor; correct cs handling is deferred to per-glyph layout.
+  it('a tabled CS face (Meiryo on <a:cs>) does NOT floor the line box', () => {
+    expect(intendedSingleLinePx('Meiryo', em)).toBeGreaterThan(em * 1.2); // Meiryo IS tabled
+    const h = gap([paraCs('A', 'Meiryo'), paraCs('B', 'Meiryo')]);
+    expect(h).toBeCloseTo(em * 1.2, 5); // stays flat — cs is not in the floor
   });
 });

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -603,6 +603,18 @@ export type ShapeTextRun =
       size: number;
       color?: string;
       fontFace?: string;
+      /** East-Asian typeface (`<a:ea@typeface>`, ECMA-376 §21.1.2.3.1). The
+       *  common Japanese encoding sets Meiryo here while leaving `<a:latin>`
+       *  default; the renderer floors the line box by this face's design line
+       *  too (see `drawShapeText`). Undefined when the run declares no `<a:ea>`. */
+      fontFaceEa?: string;
+      /** Complex-script typeface (`<a:cs@typeface>`, ECMA-376 §21.1.2.3.1).
+       *  Parsed/modeled but NOT used in the line-box floor: the cs face renders
+       *  only complex-script glyphs (Arabic/Hebrew/Thai), so flooring the whole
+       *  line box by it would over-grow Latin/CJK runs (deferred to per-glyph
+       *  handling — see `drawShapeText`). Undefined when the run declares no
+       *  `<a:cs>`. */
+      fontFaceCs?: string;
     }
   | { type: 'break' }
   | {


### PR DESCRIPTION
Follow-up from the line-metrics review (PRs #642/#643). The xlsx shape-text single-line-height FLOOR (`drawShapeText`, via core `intendedSingleLinePx`) only fired when the tabled face (Meiryo / Meiryo UI 1.5962×em, Sakkal Majalla) was authored in `<a:latin@typeface>`. The shape-run parser read ONLY `<a:latin>`, ignoring `<a:ea>` — so a Meiryo set only as `<a:ea>` (the common Japanese encoding, latin left default) left `run.fontFace` undefined → floor 0 → the design-line floor never fired.

## Changes (2 commits)
1. `feat(xlsx)`: parse `<a:ea@typeface>` / `<a:cs@typeface>` on shape runs into new `ShapeTextRun::Text` fields `fontFaceEa` / `fontFaceCs` (Rust `types.rs` + `drawing.rs`; additive `skip_serializing_if=None` → JSON byte-identical for shapes without ea/cs). WASM rebuilt. +2 parser tests.
2. `feat(xlsx)`: `drawShapeText` floors the single line against the tallest of the LATIN and EAST-ASIAN faces — `max(pxSize*1.2, intendedSingleLinePx(fontFace), intendedSingleLinePx(fontFaceEa))` — at the run site and the empty-line fallback. Still a FLOOR (untabled → 0, unchanged); matches the docx shape-text floor's `max(latin, ea)`. TS types + 3 renderer tests.

## `<a:cs>` is parsed but NOT in the line-box floor (review-driven)
The first cut floored by `max(latin, ea, cs)`. The independent review flagged that this over-grows the ONLY affected sample: `private/sample-25`'s shape run is **Japanese** text with the tabled face `Meiryo UI` on **`<a:cs>`** (its `<a:latin>`/`<a:ea>` are the untabled `MS PGothic`). Per the ECMA-376 §21.1.2.3.1 / §17.3.2.26 font-slot rules, Japanese glyphs render via the **`<a:ea>`** slot; **`<a:cs>` (complex-script) renders only Arabic/Hebrew/Thai** — it renders NONE of that run's glyphs. Flooring the line box by cs there would grow it to Meiryo UI's design line (16.8→22.35 px) based on a face that renders no text — an off-slot, unverifiable height (no Excel reference), which the repo's house rule ("推測で定数を入れない") forbids. So cs is now **parsed/modeled but excluded from the line-box floor**; correct complex-script handling needs per-glyph/per-script layout (deferred, as pptx does per-glyph). This also keeps xlsx consistent with docx (both floor `max(latin, ea)`).

Net effect: **inert on the current corpus** — no present sample declares a tabled face on the slot (latin/ea) that actually renders its glyphs. sample-25 stays at its flat height (we can't do better without MS PGothic's metrics; flooring by an unrelated cs font would be a guess). The change closes the `<a:ea>` hole for future Japanese-on-ea shapes, matching pptx/docx. A cs-not-floored test pins the corrected behavior.

## Verification
- cargo test (xlsx parser) **75**; `cargo fmt --check` + `clippy -D warnings` clean; WASM rebuilt.
- vitest **250** (+3 renderer: Meiryo-on-`<a:ea>` floors; Calibri-latin-no-ea stays flat; Meiryo-on-`<a:cs>` does NOT floor); `tsc` clean.
- VRT: only `demo/sample-1` has committed refs (shape-free) — unchanged; `private/*` refs gitignored. No reference images modified.

## Cross-package (tracked follow-ups)
docx **shape/textbox** had the same latin-only gap → fixed in parallel (`max(latin, ea)`, no cs axis on the docx model). docx **body** floors per-eastAsia-segment and pptx per-glyph via `familyEa` — both already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)