### PR TITLE
fix(docx): floor textbox rich-run line box by the eastAsia design face

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6772,13 +6772,29 @@ export function renderShapeText(
     italic: boolean,
     fontPx: number,
     b: ShapeText,
+    familyEa?: string | null | undefined,
   ): { lineH: number; baselineOffset: number } => {
     ctx.font = buildFont(bold, italic, fontPx, family ?? null, fontFamilyClasses);
     const m = ctx.measureText('Mg');
     const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
     const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
     const c = correctLineMetrics(family ?? null, fontPx, rawAsc, rawDesc);
-    const intended = intendedSingleLinePx(family ?? null, fontPx);
+    // Floor the single-line box by the TALLEST design line among the run's
+    // declared faces (ascii §17.3.2.26 + eastAsia). The canvas measurement /
+    // correctLineMetrics above stay on the ascii `family` (the substituted-face
+    // natural box), but the line box must fit whichever face renders the glyphs:
+    // the common Japanese encoding sets Meiryo (1.596×em) / Sakkal Majalla
+    // (1.3965×em) ONLY on `<w:rFonts w:eastAsia>` while `<w:rFonts w:ascii>`
+    // stays an untabled Latin default, so an ascii-only floor would leave the
+    // box flat (intendedSingleLinePx(untabledAscii)=0). This is a FLOOR, not a
+    // replace — intendedSingleLinePx returns 0 for every untabled face, so
+    // non-Meiryo/Sakkal text boxes are unchanged. Mirrors the xlsx shape-text
+    // floor (PR #646) and the docx BODY per-eastAsia-segment floor. It is NOT
+    // per-glyph CJK font switching (a larger change deferred here).
+    const intended = Math.max(
+      intendedSingleLinePx(family ?? null, fontPx),
+      intendedSingleLinePx(familyEa ?? null, fontPx),
+    );
     const natural = Math.max(c.ascent + c.descent, intended);
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
@@ -6812,7 +6828,18 @@ export function renderShapeText(
         );
         const run = tallest?.run;
         const fontPx = (run?.fontSizePt ?? b.fontSizePt) * scale;
-        return shapeLineMetrics(run?.fontFamily ?? b.fontFamily, run?.bold ?? false, run?.italic ?? false, fontPx, b);
+        return shapeLineMetrics(
+          run?.fontFamily ?? b.fontFamily,
+          run?.bold ?? false,
+          run?.italic ?? false,
+          fontPx,
+          b,
+          // eastAsia axis (§17.3.2.26) of the tallest run — floors the line box
+          // to Meiryo/Sakkal's design line even when only `<w:rFonts w:eastAsia>`
+          // names a tabled face (ascii left default). Rich runs carry this on the
+          // model (ShapeTextRun.fontFamilyEastAsia); no parser change needed.
+          run?.fontFamilyEastAsia,
+        );
       });
       return {
         kind: 'rich',
@@ -6823,6 +6850,20 @@ export function renderShapeText(
       };
     }
     const fontPx = b.fontSizePt * scale;
+    // Single-format (legacy, run-less) fallback. SCOPED OUT of the eastAsia
+    // line-box floor: block-level `ShapeText` carries only the CONFLATED
+    // `fontFamily` (ascii → eastAsia → default, parser.rs resolve_font_with_default)
+    // and has NO block-level eastAsia field on the Rust `ShapeText` struct
+    // (types.rs) or the TS interface (types.ts) — so there is no untabled-ascii /
+    // tabled-eastAsia split to floor against here. In practice the parser emits a
+    // `ShapeTextRun` for every `<w:r>` with text (parser.rs, extract loop), so a
+    // TEXT paragraph always takes the rich path above; this branch only serves
+    // image-less legacy blocks. Wiring an eastAsia floor here would need a new
+    // block-level `font_family_east_asia` field threaded through types.rs + the
+    // parser + types.ts + a WASM rebuild — nontrivial plumbing for a path the
+    // current parser never feeds text into. Deferred as a follow-up rather than
+    // half-plumbed. The rich path (ShapeTextRun.fontFamilyEastAsia) fixes the
+    // common case (PR #646 mirror).
     const { lineH, baselineOffset } = shapeLineMetrics(b.fontFamily, b.bold ?? false, b.italic ?? false, fontPx, b);
     return { kind: 'text', lines: wrapShapeText(ctx, b.text, ind.paraW, ind.firstLineW), lineH, baselineOffset, ind };
   });

--- a/packages/docx/src/textbox-eastasia-line-floor.test.ts
+++ b/packages/docx/src/textbox-eastasia-line-floor.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { renderShapeText } from './renderer.js';
+import type { ShapeRun, ShapeText } from './types';
+
+// ECMA-376 §17.3.1.33 / §17.3.2.26 — a text-box (txbxContent) run's single-line
+// box must be floored to the DESIGN line height of whichever declared face
+// renders its glyphs. The common Japanese encoding sets a substituted CJK face
+// (Meiryo, win ratio 3269/2048 = 1.5962×em) ONLY on `<w:rFonts w:eastAsia>`
+// while `<w:rFonts w:ascii>` stays an UNTABLED Latin default. Before the fix the
+// shape/textbox measure pass floored on the ascii face alone
+// (`intendedSingleLinePx(untabledAscii) = 0`), so the line box stayed flat at the
+// substituted font's natural box (this mock: 1.0×em) instead of growing to
+// Meiryo's 1.5962×em. This mirrors the xlsx shape-text floor (PR #646) and the
+// docx BODY per-eastAsia-segment floor.
+//
+// The floor is asserted on the LINE-BOX height, which in the draw pass equals
+// the vertical delta between consecutive wrapped lines' baselines
+// (`cursorY += lineH; baseline = cursorY + baselineOffset`). Two wrapped lines
+// with the same run give one such delta = the first line's lineH.
+
+interface FillTextEvent { text: string; x: number; y: number }
+
+/** A recording 2D-context whose substituted-font natural box is a flat 1.0×em
+ *  (ascent 0.8 + descent 0.2). No family is in the metric table via measureText,
+ *  so any design-line growth must come from `intendedSingleLinePx` (the floor
+ *  under test), not from the mock's own metrics. */
+function makeRecordingCanvas(): { ctx: CanvasRenderingContext2D; fillTexts: FillTextEvent[] } {
+  let font = '11px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const fillTexts: FillTextEvent[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, drawImage() {}, clearRect() {},
+    arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    fillRect() {}, strokeRect() {},
+    fillText(text: string, x: number, y: number) { fillTexts.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fillTexts };
+}
+
+/** A no-fill/no-line text box holding one rich block whose single run has the
+ *  given ascii + eastAsia faces. The run text is wide enough to wrap into ≥2
+ *  lines in a narrow box (the mock's measureText is chars × px). */
+function textboxWith(fontFamily: string | null, fontFamilyEastAsia: string | null | undefined): ShapeRun {
+  const block: ShapeText = {
+    text: 'aa bb cc dd ee ff gg hh',
+    fontSizePt: 20,
+    alignment: 'left',
+    runs: [
+      { text: 'aa bb cc dd ee ff gg hh', fontSizePt: 20, fontFamily, fontFamilyEastAsia },
+    ],
+  } as ShapeText;
+  return {
+    type: 'shape',
+    zOrder: 0, subpaths: [], presetGeometry: 'rect',
+    fill: null, stroke: null,
+    behindDoc: false,
+    wrapMode: 'none',
+    widthPt: 120, heightPt: 400,
+    textBlocks: [block], textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+  } as unknown as ShapeRun;
+}
+
+/** Vertical delta between the first two DISTINCT baseline y values among the
+ *  recorded fillText events = the first wrapped line's line-box height. */
+function firstLineHeight(fillTexts: FillTextEvent[]): number {
+  const ys = [...new Set(fillTexts.map((f) => f.y))].sort((a, b) => a - b);
+  expect(ys.length).toBeGreaterThanOrEqual(2);
+  return ys[1] - ys[0];
+}
+
+describe('textbox line-box floors on the eastAsia face (ECMA-376 §17.3.2.26)', () => {
+  const scale = 1;
+  const emPx = 20 * scale; // fontSizePt=20, scale=1
+  const MEIRYO_RATIO = 3269 / 2048; // 1.5962…, WIN_METRICS Meiryo win sum
+  const NATURAL_RATIO = 1.0;        // mock substituted-font box (0.8 + 0.2)
+
+  it('grows the line box to Meiryo when Meiryo is only on the eastAsia axis (untabled ascii)', () => {
+    const { ctx, fillTexts } = makeRecordingCanvas();
+    // Untabled ascii ('Calibri' is NOT in WIN_METRICS) + Meiryo on eastAsia.
+    renderShapeText(textboxWith('Calibri', 'Meiryo'), 0, 0, 120, 400, ctx, scale);
+    const lineH = firstLineHeight(fillTexts);
+    // Floored to Meiryo's design line, NOT the flat 1.0×em natural box.
+    expect(lineH).toBeCloseTo(MEIRYO_RATIO * emPx, 3);
+    expect(lineH).toBeGreaterThan(NATURAL_RATIO * emPx + 0.5);
+  });
+
+  it('stays flat for an untabled ascii run with NO eastAsia face (zero regression)', () => {
+    const { ctx, fillTexts } = makeRecordingCanvas();
+    // Untabled ascii, no eastAsia axis: intendedSingleLinePx returns 0 for both,
+    // so the line box keeps the substituted-font natural box (1.0×em) — proving
+    // the change is a FLOOR, not a replace.
+    renderShapeText(textboxWith('Calibri', undefined), 0, 0, 120, 400, ctx, scale);
+    const lineH = firstLineHeight(fillTexts);
+    expect(lineH).toBeCloseTo(NATURAL_RATIO * emPx, 3);
+  });
+});


### PR DESCRIPTION
Cross-package follow-up surfaced by PR #646 (xlsx shape-text ea floor). docx **shape/textbox** text had the SAME latin-only line-box floor gap: `shapeLineMetrics` (`packages/docx/src/renderer.ts`) was fed only the ascii/latin face, so a textbox run whose tabled face (Meiryo/Meiryo UI 1.5962×em, Sakkal Majalla 1.3965×em) is on `<w:rFonts w:eastAsia>` with an untabled ascii face floored on `intendedSingleLinePx(untabledAscii)=0` — its line box stayed flat instead of growing to the eastAsia design line. (docx BODY text already floors per-eastAsia-segment; pptx floors per-glyph via `familyEa` — both fine. Only docx shape/textbox had the gap.)

## Change (1 commit)
`shapeLineMetrics` gains an optional `familyEa` param; the single-line floor becomes `Math.max(intendedSingleLinePx(ascii, px), intendedSingleLinePx(eastAsia, px))` (the canvas measurement + `correctLineMetrics` still key on the ascii axis = the substituted-face natural box; only the design-line FLOOR now considers both faces). The rich call site threads the tallest run's `fontFamilyEastAsia` (already on the model — **no parser change**). Result: a textbox run with an untabled ascii face + Meiryo/Sakkal on eastAsia grows its line box to the eastAsia design line. Pure FLOOR (untabled faces → 0 → non-Meiryo/Sakkal textboxes unchanged). Mirrors the xlsx #646 `max(latin, ea)` floor and the docx body per-eastAsia floor. NOT per-glyph CJK switching. No `cs` axis exists on the docx shape run model, so the floor is `max(latin, ea)` (consistent with xlsx after #646 dropped cs from its line-box floor).

## Single-format path scoped out (documented)
The legacy run-less block path (`ShapeText.fontFamily` only, conflated ascii→ea→default; no block-level eastAsia field in Rust/TS) is left with a precise comment. The parser emits a `ShapeTextRun` for every `<w:r>` with text, so a text paragraph always takes the rich path; this branch serves only image-less legacy blocks. Wiring an eastAsia floor there needs new types.rs + parser + types.ts plumbing — deferred rather than half-plumbed.

## Verification
- New `textbox-eastasia-line-floor.test.ts` (2 tests): untabled ascii + Meiryo eastAsia → floors to Meiryo's 1.5962×em; untabled ascii, no eastAsia → stays flat (proves FLOOR not replace). Verified characterizing (with the fix stashed the first test fails 20 vs 31.92).
- docx suite **326** passed; `tsc` adds zero new errors (only pre-existing `TS2307` for the gitignored `./wasm/docx_parser.js`). No Word PDF ground truth available (docx samples gitignored); correctness rests on the FLOOR semantics (untabled unchanged) + parity with xlsx #646 / docx body / pptx. No reference images touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)