### PR TITLE
fix(docx): center textbox CJK ink in the eastAsia-floored line box + floor by all runs

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6774,38 +6774,52 @@ export function renderShapeText(
     b: ShapeText,
     familyEa?: string | null | undefined,
   ): { lineH: number; baselineOffset: number } => {
-    ctx.font = buildFont(bold, italic, fontPx, family ?? null, fontFamilyClasses);
+    // Floor the single-line box by the TALLEST design line among the run's
+    // declared faces (ascii §17.3.2.26 + eastAsia). The common Japanese encoding
+    // sets Meiryo (1.596×em) / Sakkal Majalla (1.3965×em) ONLY on
+    // `<w:rFonts w:eastAsia>` while `<w:rFonts w:ascii>` stays an untabled Latin
+    // default, so an ascii-only floor would leave the box flat
+    // (intendedSingleLinePx(untabledAscii)=0). This is a FLOOR, not a replace —
+    // intendedSingleLinePx returns 0 for every untabled face, so non-Meiryo/
+    // Sakkal text boxes are unchanged. Mirrors the xlsx shape-text floor
+    // (PR #646) and the docx BODY per-eastAsia-segment floor. It is NOT per-glyph
+    // CJK font switching (a larger change deferred here).
+    const asciiIntended = intendedSingleLinePx(family ?? null, fontPx);
+    const eaIntended = intendedSingleLinePx(familyEa ?? null, fontPx);
+    const intended = Math.max(asciiIntended, eaIntended);
+    // Measure the glyph metrics on the RENDERING face — the one whose design line
+    // wins the floor. When the eastAsia face is tabled and taller than the ascii
+    // box (the CJK glyphs are the tallest ink on the line), read c.ascent/descent
+    // from `familyEa`, not the untabled ascii default, so the baseline is placed
+    // relative to the CJK ink — mirroring the body's `line.ascent` being the
+    // eastAsia-resolved corrected ascent. If the ascii face wins (Latin line, or
+    // both untabled) keep measuring ascii, so an all-untabled line is byte-for-
+    // byte unchanged from before this change.
+    const measureFamily = eaIntended > asciiIntended ? (familyEa ?? null) : (family ?? null);
+    ctx.font = buildFont(bold, italic, fontPx, measureFamily, fontFamilyClasses);
     const m = ctx.measureText('Mg');
     const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
     const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
-    const c = correctLineMetrics(family ?? null, fontPx, rawAsc, rawDesc);
-    // Floor the single-line box by the TALLEST design line among the run's
-    // declared faces (ascii §17.3.2.26 + eastAsia). The canvas measurement /
-    // correctLineMetrics above stay on the ascii `family` (the substituted-face
-    // natural box), but the line box must fit whichever face renders the glyphs:
-    // the common Japanese encoding sets Meiryo (1.596×em) / Sakkal Majalla
-    // (1.3965×em) ONLY on `<w:rFonts w:eastAsia>` while `<w:rFonts w:ascii>`
-    // stays an untabled Latin default, so an ascii-only floor would leave the
-    // box flat (intendedSingleLinePx(untabledAscii)=0). This is a FLOOR, not a
-    // replace — intendedSingleLinePx returns 0 for every untabled face, so
-    // non-Meiryo/Sakkal text boxes are unchanged. Mirrors the xlsx shape-text
-    // floor (PR #646) and the docx BODY per-eastAsia-segment floor. It is NOT
-    // per-glyph CJK font switching (a larger change deferred here).
-    const intended = Math.max(
-      intendedSingleLinePx(family ?? null, fontPx),
-      intendedSingleLinePx(familyEa ?? null, fontPx),
-    );
-    const natural = Math.max(c.ascent + c.descent, intended);
+    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc);
+    // The glyph box (measured, corrected) is kept SEPARATE from the floored line
+    // box: `intended` may inflate `lineH` above the glyph box, and Word centers
+    // the glyph box within that expanded box (half-leading) rather than pinning
+    // the ink to the top. Mirrors the body's `glyphNatural = ascent + descent`
+    // (lineBoxHeight) vs the floor-inflated `natural`.
+    const glyphNatural = c.ascent + c.descent;
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
     const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, undefined, false, intended, false);
-    // Word centers the font's natural line within the expanded line box
-    // (half-leading): when line-spacing grows the box (auto 1.15×, atLeast,
-    // exact taller than natural) the extra space is split above and below, so
-    // the baseline is (lineH − natural)/2 below the box top plus the ascent.
-    // With no expansion (natural == lineH) this reduces to c.ascent.
-    const baselineOffset = (lineH - natural) / 2 + c.ascent;
+    // Word centers the font's GLYPH box within the (possibly expanded) line box
+    // (half-leading): when line-spacing or the design-line floor grows the box
+    // the extra space is split above and below the glyph box, so the baseline is
+    // (lineH − glyphNatural)/2 below the box top plus the ascent. With no
+    // expansion (glyphNatural == lineH) this reduces to c.ascent. This is the
+    // SAME math as the body draw baseline (naturalLineH = ascent+descent, NOT
+    // floor-inflated) — so an inflated box floats the glyphs centered with real
+    // half-leading instead of top-pinning them.
+    const baselineOffset = (lineH - glyphNatural) / 2 + c.ascent;
     return { lineH, baselineOffset };
   };
   const layouts: BlockLayout[] = blocks.map((b) => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6773,6 +6773,14 @@ export function renderShapeText(
     fontPx: number,
     b: ShapeText,
     familyEa?: string | null | undefined,
+    // Explicit design-line floor (px). The body floors the line box by the MAX
+    // intendedSingleLinePx across ALL segments on the line (~5684), not just the
+    // tallest one, because a shorter-but-tabled face (e.g. a small Meiryo run
+    // after a large untabled-ascii run) still raises the box. The rich call site
+    // passes that all-runs max here; when omitted (the single-format path) the
+    // floor falls back to this run's own ascii+eastAsia faces. Either way it is a
+    // FLOOR (0 for all-untabled lines ⇒ unchanged).
+    lineFloorPx?: number,
   ): { lineH: number; baselineOffset: number } => {
     // Floor the single-line box by the TALLEST design line among the run's
     // declared faces (ascii §17.3.2.26 + eastAsia). The common Japanese encoding
@@ -6786,7 +6794,10 @@ export function renderShapeText(
     // CJK font switching (a larger change deferred here).
     const asciiIntended = intendedSingleLinePx(family ?? null, fontPx);
     const eaIntended = intendedSingleLinePx(familyEa ?? null, fontPx);
-    const intended = Math.max(asciiIntended, eaIntended);
+    // Use the explicit all-runs floor when provided (rich path); else fall back
+    // to this run's own faces (single-format path). Both are a floor, so the
+    // per-run ascii/eastAsia max is still folded in for the fallback.
+    const intended = lineFloorPx ?? Math.max(asciiIntended, eaIntended);
     // Measure the glyph metrics on the RENDERING face — the one whose design line
     // wins the floor. When the eastAsia face is tabled and taller than the ascii
     // box (the CJK glyphs are the tallest ink on the line), read c.ascent/descent
@@ -6842,17 +6853,33 @@ export function renderShapeText(
         );
         const run = tallest?.run;
         const fontPx = (run?.fontSizePt ?? b.fontSizePt) * scale;
+        // Design-line floor is the MAX intendedSingleLinePx over EVERY run on the
+        // line — both its ascii AND eastAsia face (§17.3.2.26), each at that run's
+        // own size — not just the tallest run's faces. The tallest run may be an
+        // untabled Latin face while a shorter-but-equal-or-smaller Meiryo run
+        // still raises the box to Meiryo's design line; flooring on the tallest
+        // run alone missed that. Mirrors the body's per-segment max (~5684-5685).
+        // 0 for an all-untabled line ⇒ unchanged.
+        const lineFloorPx = toks.reduce((floor, t) => {
+          const runPx = t.run.fontSizePt * scale;
+          return Math.max(
+            floor,
+            intendedSingleLinePx(t.run.fontFamily ?? null, runPx),
+            intendedSingleLinePx(t.run.fontFamilyEastAsia ?? null, runPx),
+          );
+        }, 0);
         return shapeLineMetrics(
           run?.fontFamily ?? b.fontFamily,
           run?.bold ?? false,
           run?.italic ?? false,
           fontPx,
           b,
-          // eastAsia axis (§17.3.2.26) of the tallest run — floors the line box
-          // to Meiryo/Sakkal's design line even when only `<w:rFonts w:eastAsia>`
-          // names a tabled face (ascii left default). Rich runs carry this on the
-          // model (ShapeTextRun.fontFamilyEastAsia); no parser change needed.
+          // eastAsia axis (§17.3.2.26) of the TALLEST run selects the measurement
+          // face inside shapeLineMetrics (the glyph box read for the baseline).
+          // The design-line FLOOR, however, is the all-runs max computed above and
+          // passed explicitly — so a shorter tabled run still raises the box.
           run?.fontFamilyEastAsia,
+          lineFloorPx,
         );
       });
       return {

--- a/packages/docx/src/textbox-eastasia-line-floor.test.ts
+++ b/packages/docx/src/textbox-eastasia-line-floor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderShapeText } from './renderer.js';
-import type { ShapeRun, ShapeText } from './types';
+import type { ShapeRun, ShapeText, ShapeTextRun } from './types';
 
 // ECMA-376 §17.3.1.33 / §17.3.2.26 — a text-box (txbxContent) run's single-line
 // box must be floored to the DESIGN line height of whichever declared face
@@ -87,6 +87,35 @@ function firstLineHeight(fillTexts: FillTextEvent[]): number {
   return ys[1] - ys[0];
 }
 
+/** The FIRST (topmost) recorded baseline y. With textAnchor='t' and zero insets
+ *  the first line's box top is 0, so this equals that line's baselineOffset
+ *  (= half-leading above the glyph box + the ascent). */
+function firstBaselineY(fillTexts: FillTextEvent[]): number {
+  const ys = [...new Set(fillTexts.map((f) => f.y))].sort((a, b) => a - b);
+  expect(ys.length).toBeGreaterThanOrEqual(1);
+  return ys[0];
+}
+
+/** A no-fill/no-line text box holding one rich block with the given runs. */
+function textboxWithRuns(runs: ShapeTextRun[]): ShapeRun {
+  const block: ShapeText = {
+    text: runs.map((r) => r.text).join(''),
+    fontSizePt: runs[0]?.fontSizePt ?? 20,
+    alignment: 'left',
+    runs,
+  } as ShapeText;
+  return {
+    type: 'shape',
+    zOrder: 0, subpaths: [], presetGeometry: 'rect',
+    fill: null, stroke: null,
+    behindDoc: false,
+    wrapMode: 'none',
+    widthPt: 120, heightPt: 400,
+    textBlocks: [block], textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+  } as unknown as ShapeRun;
+}
+
 describe('textbox line-box floors on the eastAsia face (ECMA-376 §17.3.2.26)', () => {
   const scale = 1;
   const emPx = 20 * scale; // fontSizePt=20, scale=1
@@ -111,5 +140,52 @@ describe('textbox line-box floors on the eastAsia face (ECMA-376 §17.3.2.26)', 
     renderShapeText(textboxWith('Calibri', undefined), 0, 0, 120, 400, ctx, scale);
     const lineH = firstLineHeight(fillTexts);
     expect(lineH).toBeCloseTo(NATURAL_RATIO * emPx, 3);
+    // Baseline is ALSO byte-for-byte unchanged: with no floor the glyph box fills
+    // the line box (lineH == glyphNatural), so half-leading is 0 and the baseline
+    // reduces to c.ascent (= 0.8×em) exactly as before Fix 1 — proving the
+    // centering + rendering-face change is inert on an all-untabled line.
+    expect(firstBaselineY(fillTexts)).toBeCloseTo(0.8 * emPx, 3);
+  });
+
+  // Fix 1 — the glyph ink is CENTERED in the (Meiryo-)inflated line box (real
+  // half-leading above the baseline), not top-pinned. Before the fix,
+  // baselineOffset folded `intended` into `natural`, so it collapsed to c.ascent
+  // (the ink sat at the box top). Body path: baseline = top + (lineH −
+  // glyphNatural)/2 + ascent, glyphNatural = ascent+descent NOT floor-inflated.
+  it('centers the CJK glyph box in the inflated line box (half-leading, not top-pinned)', () => {
+    const { ctx, fillTexts } = makeRecordingCanvas();
+    renderShapeText(textboxWith('Calibri', 'Meiryo'), 0, 0, 120, 400, ctx, scale);
+    const baselineY = firstBaselineY(fillTexts); // = first line's baselineOffset
+    const ascentPx = 0.8 * emPx;                 // mock glyph ascent (0.8×em)
+    const glyphNaturalPx = 1.0 * emPx;           // mock glyph box (0.8 + 0.2)
+    const lineHPx = MEIRYO_RATIO * emPx;         // floored line box (Fix #648)
+    const expectedHalfLeading = (lineHPx - glyphNaturalPx) / 2;
+    // Centered: baseline = half-leading + ascent, strictly BELOW the top-pinned
+    // c.ascent (the pre-fix value). Half-leading is real and positive.
+    expect(expectedHalfLeading).toBeGreaterThan(0.5);
+    expect(baselineY).toBeCloseTo(expectedHalfLeading + ascentPx, 3);
+    expect(baselineY).toBeGreaterThan(ascentPx + 0.5); // NOT top-pinned (== ascent)
+  });
+
+  // Fix 2 — the design-line floor is the MAX over ALL runs on the line, not just
+  // the TALLEST run's faces. Here the tallest run (ties → earliest) is an
+  // untabled-ascii run; a later EQUAL-size Meiryo-eastAsia run shares line 1.
+  // The tallest-only code floored on the untabled run (0) and left line 1 flat;
+  // the all-runs max floors line 1 to Meiryo's design line. Mirrors the body's
+  // per-segment lineIntendedSingle max.
+  it('floors a mixed line to Meiryo when a non-tallest run carries it (all-runs max)', () => {
+    const { ctx, fillTexts } = makeRecordingCanvas();
+    // 20px/char in the mock, box 120px ⇒ 6 chars/line. Line 1 packs the untabled
+    // ascii word 'ab ' (3) + 'あいう' (3) = 6 chars; 'えお' wraps to line 2. Both
+    // runs are size 20, so the earliest (untabled ascii) is the "tallest".
+    const runs: ShapeTextRun[] = [
+      { text: 'ab ', fontSizePt: 20, fontFamily: 'Calibri' }, // untabled, tallest (tie → first)
+      { text: 'あいうえお', fontSizePt: 20, fontFamily: null, fontFamilyEastAsia: 'Meiryo' },
+    ];
+    renderShapeText(textboxWithRuns(runs), 0, 0, 120, 400, ctx, scale);
+    const lineH = firstLineHeight(fillTexts);
+    // The Meiryo run on line 1 raises the box despite not being the tallest run.
+    expect(lineH).toBeCloseTo(MEIRYO_RATIO * emPx, 3);
+    expect(lineH).toBeGreaterThan(NATURAL_RATIO * emPx + 0.5);
   });
 });


### PR DESCRIPTION
Follow-up from PR #648's review — two PRE-EXISTING seams in `shapeLineMetrics`/`renderShapeText` that #648's (correct) taller line box surfaced. Converges the docx textbox path onto the already-correct docx BODY path.

## Fix 1 (MED) — center the glyph box; measure on the rendering face
`shapeLineMetrics` folded the design-line floor into `natural = max(c.ascent+c.descent, intended)` and computed `baselineOffset = (lineH − natural)/2 + c.ascent` with `c` measured on the ASCII face. When the eastAsia floor inflated the box, `natural == intended == lineH` → half-leading collapsed to 0 → CJK ink **top-pinned** in the taller box.
Now:
- `glyphNatural = c.ascent + c.descent` is kept SEPARATE from the floored `lineH` (mirrors the body's `glyphNatural` vs floor-inflated `natural` in `lineBoxHeight`);
- `baselineOffset = (lineH − glyphNatural)/2 + c.ascent` — the SAME math as the body draw baseline (`(lineH − naturalLineH)/2 + line.ascent`), so the glyph box floats **centered** with real half-leading;
- `c` is measured on the RENDERING face — `measureFamily = eaIntended > asciiIntended ? familyEa : family` — so a CJK line's baseline is placed relative to the eastAsia ink (mirrors the body's `line.ascent` being the eastAsia-resolved corrected ascent). Ascii-winning / all-untabled lines keep measuring ascii.

Before/after (20 pt CJK line, Meiryo on eastAsia, untabled ascii; substitute glyph box ≈ 20 px, ascent 16 px, floor = 1.5962×20 = 31.92 px): today `baselineOffset = (31.92−31.92)/2 + 16 = 16` (top-pinned); after `= (31.92−20)/2 + 16 = 21.96` (centered, 5.96 px half-leading). `lineH` stays 31.92 (box height unchanged from #648). `correctLineMetrics` only caps an over-large substitute box down to the design, never grows a small one up, so `glyphNatural` stays the measured box and the centering is real.

## Fix 2 (LOW) — floor by ALL runs on the line, not just the tallest
`renderShapeText` floored only the `tallest` run's faces; a wrapped line mixing an earlier untabled-ascii run and a later equal-size Meiryo-eastAsia run read the earlier run → `max(0,0)=0` → no floor. Now `lineFloorPx = max over EVERY run of intendedSingleLinePx(fontFamily), intendedSingleLinePx(fontFamilyEastAsia)` (each at its own size), passed explicitly into `shapeLineMetrics` (mirrors the body's per-segment max). The tallest run still selects the font size / measurement face; only the FLOOR spans all runs. The single-format (run-less) path passes no floor → falls back to its own ascii+eastAsia max (unchanged).

## Verification (no Word PDF — docx samples gitignored)
- `textbox-eastasia-line-floor.test.ts` +2: (a) CJK baseline is CENTERED (`> c.ascent`, not top-pinned); (b) a mixed-run line floors to Meiryo via the all-runs max (tallest-only missed it). Strengthened the untabled test to pin the baseline to `c.ascent` — proving the change is **byte-for-byte inert on all-untabled lines** (FLOOR preserved: `intendedSingleLinePx=0` → `measureFamily=ascii`, `lineH==glyphNatural`, `baselineOffset` reduces to `c.ascent`).
- docx **328** tests pass (+2); `tsc` clean. Correctness rests on parity with the body's centered-baseline math + the FLOOR semantics. No reference images touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)