### PR TITLE
feat(docx): per-section page geometry — pgSz/pgMar on SectionBreak, per-page sizing, pageSize(i) fact (§17.6.13/§17.6.11)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1221,6 +1221,61 @@ fn read_section_break_type(sect_pr: roxmltree::Node) -> Option<String> {
 /// come from `<w:br w:type="column"/>` ⇒ `ColumnBreak`); the renderer would
 /// otherwise have no defined column geometry to advance into across a section
 /// boundary.
+/// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — extract a section's page
+/// geometry from its `<w:sectPr>` into a `SectionGeom`. Returns `None` when the
+/// sectPr declares NEITHER `<w:pgSz>` NOR `<w:pgMar>` (a section that inherits both
+/// from the body — the renderer then uses the body-level geometry). When either is
+/// present, absent sub-attributes fall back to the spec defaults (US Letter portrait,
+/// 1" margins, 0.5" header/footer) — the SAME defaults `parse_section` uses so a
+/// SectionBreak's geometry and `Document.section` agree for a fully-inherited section.
+fn section_geom(sect_pr: roxmltree::Node) -> Option<SectionGeom> {
+    let pg_sz = child_w(sect_pr, "pgSz");
+    let pg_mar = child_w(sect_pr, "pgMar");
+    if pg_sz.is_none() && pg_mar.is_none() {
+        return None;
+    }
+    // Spec defaults (identical to parse_section's `default`).
+    let mut geom = SectionGeom {
+        page_width: 612.0,
+        page_height: 792.0,
+        margin_top: 72.0,
+        margin_right: 72.0,
+        margin_bottom: 72.0,
+        margin_left: 72.0,
+        header_distance: 36.0,
+        footer_distance: 36.0,
+    };
+    if let Some(pg_sz) = pg_sz {
+        if let Some(w) = attr_w(pg_sz, "w") {
+            geom.page_width = twips_to_pt(&w);
+        }
+        if let Some(h) = attr_w(pg_sz, "h") {
+            geom.page_height = twips_to_pt(&h);
+        }
+    }
+    if let Some(pg_mar) = pg_mar {
+        if let Some(v) = attr_w(pg_mar, "top") {
+            geom.margin_top = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "right") {
+            geom.margin_right = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "bottom") {
+            geom.margin_bottom = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "left") {
+            geom.margin_left = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "header") {
+            geom.header_distance = twips_to_pt(&v);
+        }
+        if let Some(v) = attr_w(pg_mar, "footer") {
+            geom.footer_distance = twips_to_pt(&v);
+        }
+    }
+    Some(geom)
+}
+
 fn section_break_element(
     sect_pr: roxmltree::Node,
     section_hf: &HashMap<roxmltree::NodeId, ResolvedSectionHf>,
@@ -1242,6 +1297,8 @@ fn section_break_element(
         headers: resolved.headers,
         footers: resolved.footers,
         title_page: resolved.title_page,
+        // ECMA-376 §17.6.13 / §17.6.11 — this ending section's page geometry.
+        geom: section_geom(sect_pr),
     }
 }
 
@@ -8736,6 +8793,50 @@ mod column_tests {
             }
             other => panic!("expected SectionBreak, got {other:?}"),
         }
+    }
+
+    /// ECMA-376 §17.6.13 `<w:pgSz>` / §17.6.11 `<w:pgMar>` — a mid-body section
+    /// break carries its ENDING section's page geometry on `geom`. The final
+    /// (body-level) section's geometry stays on `Document.section` (unchanged);
+    /// this closes the hole where mid-body sections dropped pgSz/pgMar entirely,
+    /// so an earlier landscape section had no page size at all (rendered at the
+    /// body width). Values are twips → pt (twips_to_pt divides by 20): 15840 twips
+    /// = 792 pt (11"), 12240 twips = 612 pt (8.5"), 1440 twips = 72 pt (1").
+    #[test]
+    fn section_break_carries_page_geometry() {
+        // A landscape first section (w=15840, h=12240) ended by a nextPage break,
+        // followed by a portrait body section. Parsed through parse_body_elements
+        // (via `body_from`) so the pPr-nested sectPr becomes a SectionBreak marker.
+        let body = body_from(
+            r#"
+            <w:p>
+              <w:pPr>
+                <w:sectPr>
+                  <w:pgSz w:w="15840" w:h="12240"/>
+                  <w:pgMar w:top="1440" w:right="1080" w:bottom="1440" w:left="1080" w:header="720" w:footer="720"/>
+                  <w:type w:val="nextPage"/>
+                </w:sectPr>
+              </w:pPr>
+            </w:p>
+            <w:p><w:r><w:t>body</w:t></w:r></w:p>
+            "#,
+        );
+        let sb = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::SectionBreak { geom, .. } => Some(geom.clone()),
+                _ => None,
+            })
+            .expect("a SectionBreak marker");
+        let g = sb.expect("SectionBreak carries page geometry");
+        assert_eq!(g.page_width, 792.0);
+        assert_eq!(g.page_height, 612.0);
+        assert_eq!(g.margin_top, 72.0);
+        assert_eq!(g.margin_right, 54.0);
+        assert_eq!(g.margin_bottom, 72.0);
+        assert_eq!(g.margin_left, 54.0);
+        assert_eq!(g.header_distance, 36.0);
+        assert_eq!(g.footer_distance, 36.0);
     }
 
     /// A single-column ending section (`<w:cols>` with no `@w:num` ⇒ §17.6.4

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1212,15 +1212,27 @@ fn read_section_break_type(sect_pr: roxmltree::Node) -> Option<String> {
         .find_map(|n| attr_w(n, "val"))
 }
 
-/// Build a `BodyElement::SectionBreak` for a sectPr that ENDS a section
-/// (ECMA-376 §17.6.x). Carries the section's `<w:cols>` (§17.6.4, via
-/// `parse_columns` ⇒ `None` for a single column) and its ST_SectionMark kind
-/// (§17.18.79), normalized: an absent/unknown `<w:type>` ⇒ "nextPage" (the spec
-/// default). `nextColumn` is normalized to "nextPage" — a section-level
-/// nextColumn break is not modeled distinctly (column breaks within a section
-/// come from `<w:br w:type="column"/>` ⇒ `ColumnBreak`); the renderer would
-/// otherwise have no defined column geometry to advance into across a section
-/// boundary.
+/// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` spec defaults for a
+/// section's page geometry: US Letter portrait (612×792 pt), 1" margins (72 pt),
+/// 0.5" header/footer distance (36 pt). This is the ONE place these defaults
+/// live — `section_geom` seeds absent sub-attributes from it, and `parse_section`
+/// falls back to it when a sectPr declares neither `<w:pgSz>` nor `<w:pgMar>`, so
+/// a SectionBreak's geometry and `Document.section` agree for a fully-inherited
+/// section. (Deliberately NOT `SectionGeom::default()`: a derived default is
+/// all-zeros, which is a 0×0 page — a footgun, not the spec default.)
+fn spec_default_geom() -> SectionGeom {
+    SectionGeom {
+        page_width: 612.0,
+        page_height: 792.0,
+        margin_top: 72.0,
+        margin_right: 72.0,
+        margin_bottom: 72.0,
+        margin_left: 72.0,
+        header_distance: 36.0,
+        footer_distance: 36.0,
+    }
+}
+
 /// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — extract a section's page
 /// geometry from its `<w:sectPr>` into a `SectionGeom`. Returns `None` when the
 /// sectPr declares NEITHER `<w:pgSz>` NOR `<w:pgMar>` (a section that inherits both
@@ -1234,17 +1246,8 @@ fn section_geom(sect_pr: roxmltree::Node) -> Option<SectionGeom> {
     if pg_sz.is_none() && pg_mar.is_none() {
         return None;
     }
-    // Spec defaults (identical to parse_section's `default`).
-    let mut geom = SectionGeom {
-        page_width: 612.0,
-        page_height: 792.0,
-        margin_top: 72.0,
-        margin_right: 72.0,
-        margin_bottom: 72.0,
-        margin_left: 72.0,
-        header_distance: 36.0,
-        footer_distance: 36.0,
-    };
+    // Spec defaults (identical to parse_section's fallback).
+    let mut geom = spec_default_geom();
     if let Some(pg_sz) = pg_sz {
         if let Some(w) = attr_w(pg_sz, "w") {
             geom.page_width = twips_to_pt(&w);
@@ -1276,6 +1279,15 @@ fn section_geom(sect_pr: roxmltree::Node) -> Option<SectionGeom> {
     Some(geom)
 }
 
+/// Build a `BodyElement::SectionBreak` for a sectPr that ENDS a section
+/// (ECMA-376 §17.6.x). Carries the section's `<w:cols>` (§17.6.4, via
+/// `parse_columns` ⇒ `None` for a single column) and its ST_SectionMark kind
+/// (§17.18.79), normalized: an absent/unknown `<w:type>` ⇒ "nextPage" (the spec
+/// default). `nextColumn` is normalized to "nextPage" — a section-level
+/// nextColumn break is not modeled distinctly (column breaks within a section
+/// come from `<w:br w:type="column"/>` ⇒ `ColumnBreak`); the renderer would
+/// otherwise have no defined column geometry to advance into across a section
+/// boundary.
 fn section_break_element(
     sect_pr: roxmltree::Node,
     section_hf: &HashMap<roxmltree::NodeId, ResolvedSectionHf>,
@@ -1470,15 +1482,17 @@ fn parse_section(
     sect_pr: Option<roxmltree::Node>,
     rel_map: &HashMap<String, String>,
 ) -> (SectionProps, SectionRefs) {
+    // Geometry (pgSz/pgMar) defaults live in ONE place — `spec_default_geom`.
+    let default_geom = spec_default_geom();
     let default = SectionProps {
-        page_width: 612.0,
-        page_height: 792.0,
-        margin_top: 72.0,
-        margin_right: 72.0,
-        margin_bottom: 72.0,
-        margin_left: 72.0,
-        header_distance: 36.0,
-        footer_distance: 36.0,
+        page_width: default_geom.page_width,
+        page_height: default_geom.page_height,
+        margin_top: default_geom.margin_top,
+        margin_right: default_geom.margin_right,
+        margin_bottom: default_geom.margin_bottom,
+        margin_left: default_geom.margin_left,
+        header_distance: default_geom.header_distance,
+        footer_distance: default_geom.footer_distance,
         title_page: false,
         even_and_odd_headers: false,
         section_start: None,
@@ -1493,34 +1507,20 @@ fn parse_section(
     };
 
     let mut props = default;
-    if let Some(pg_sz) = child_w(sp, "pgSz") {
-        if let Some(w) = attr_w(pg_sz, "w") {
-            props.page_width = twips_to_pt(&w);
-        }
-        if let Some(h) = attr_w(pg_sz, "h") {
-            props.page_height = twips_to_pt(&h);
-        }
-    }
-    if let Some(pg_mar) = child_w(sp, "pgMar") {
-        if let Some(v) = attr_w(pg_mar, "top") {
-            props.margin_top = twips_to_pt(&v);
-        }
-        if let Some(v) = attr_w(pg_mar, "right") {
-            props.margin_right = twips_to_pt(&v);
-        }
-        if let Some(v) = attr_w(pg_mar, "bottom") {
-            props.margin_bottom = twips_to_pt(&v);
-        }
-        if let Some(v) = attr_w(pg_mar, "left") {
-            props.margin_left = twips_to_pt(&v);
-        }
-        if let Some(v) = attr_w(pg_mar, "header") {
-            props.header_distance = twips_to_pt(&v);
-        }
-        if let Some(v) = attr_w(pg_mar, "footer") {
-            props.footer_distance = twips_to_pt(&v);
-        }
-    }
+    // ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — reuse `section_geom`
+    // as the single extraction source. When the sectPr declares neither element
+    // it returns `None`, so we fall back to the same spec defaults `default` was
+    // seeded with (behavior-preserving); when either is present, the extraction
+    // is identical to reading the attributes here.
+    let geom = section_geom(sp).unwrap_or_else(spec_default_geom);
+    props.page_width = geom.page_width;
+    props.page_height = geom.page_height;
+    props.margin_top = geom.margin_top;
+    props.margin_right = geom.margin_right;
+    props.margin_bottom = geom.margin_bottom;
+    props.margin_left = geom.margin_left;
+    props.header_distance = geom.header_distance;
+    props.footer_distance = geom.footer_distance;
     props.title_page = child_w(sp, "titlePg").is_some();
     // ECMA-376 §17.6.22 — the body (final) section's start type. Non-final
     // sections carry their start type on their own SectionBreak marker; the
@@ -8813,7 +8813,7 @@ mod column_tests {
               <w:pPr>
                 <w:sectPr>
                   <w:pgSz w:w="15840" w:h="12240"/>
-                  <w:pgMar w:top="1440" w:right="1080" w:bottom="1440" w:left="1080" w:header="720" w:footer="720"/>
+                  <w:pgMar w:top="1701" w:right="1080" w:bottom="1985" w:left="1080" w:header="851" w:footer="992"/>
                   <w:type w:val="nextPage"/>
                 </w:sectPr>
               </w:pPr>
@@ -8831,12 +8831,84 @@ mod column_tests {
         let g = sb.expect("SectionBreak carries page geometry");
         assert_eq!(g.page_width, 792.0);
         assert_eq!(g.page_height, 612.0);
-        assert_eq!(g.margin_top, 72.0);
+        // Non-default pgMar values (twips ÷ 20) so a dropped attribute would be
+        // caught — 1440/720 would collapse onto the spec defaults (72/36) and
+        // silently pass.
+        assert_eq!(g.margin_top, 85.05);
         assert_eq!(g.margin_right, 54.0);
-        assert_eq!(g.margin_bottom, 72.0);
+        assert_eq!(g.margin_bottom, 99.25);
         assert_eq!(g.margin_left, 54.0);
+        assert_eq!(g.header_distance, 42.55);
+        assert_eq!(g.footer_distance, 49.6);
+    }
+
+    /// ECMA-376 §17.6.13 — a sectPr with `<w:pgSz>` but NO `<w:pgMar>` still
+    /// carries `geom` (page size present ⇒ Some), and the absent pgMar
+    /// sub-attributes resolve to the SPEC defaults (72/72/72/72 margins, 36/36
+    /// header/footer) — NOT zeros. This pins the contract a later per-section
+    /// geometry task depends on: a partially-declared section inherits the spec
+    /// defaults, not an all-zeros box.
+    #[test]
+    fn section_break_pgsz_only_uses_spec_default_margins() {
+        let body = body_from(
+            r#"
+            <w:p>
+              <w:pPr>
+                <w:sectPr>
+                  <w:pgSz w:w="12240" w:h="15840"/>
+                  <w:type w:val="nextPage"/>
+                </w:sectPr>
+              </w:pPr>
+            </w:p>
+            <w:p><w:r><w:t>body</w:t></w:r></w:p>
+            "#,
+        );
+        let sb = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::SectionBreak { geom, .. } => Some(geom.clone()),
+                _ => None,
+            })
+            .expect("a SectionBreak marker");
+        let g = sb.expect("pgSz present ⇒ geom is Some");
+        assert_eq!(g.page_width, 612.0);
+        assert_eq!(g.page_height, 792.0);
+        // pgMar absent ⇒ spec defaults, not zeros.
+        assert_eq!(g.margin_top, 72.0);
+        assert_eq!(g.margin_right, 72.0);
+        assert_eq!(g.margin_bottom, 72.0);
+        assert_eq!(g.margin_left, 72.0);
         assert_eq!(g.header_distance, 36.0);
         assert_eq!(g.footer_distance, 36.0);
+    }
+
+    /// ECMA-376 §17.6.11 — `w:top` / `w:bottom` are ST_SignedTwipsMeasure and MAY
+    /// be negative (a header/footer that overlaps the body text region). The sign
+    /// must be preserved: `w:top="-1440"` ⇒ `margin_top == -72.0`.
+    #[test]
+    fn section_break_negative_top_margin_keeps_sign() {
+        let body = body_from(
+            r#"
+            <w:p>
+              <w:pPr>
+                <w:sectPr>
+                  <w:pgMar w:top="-1440" w:right="1080" w:bottom="1440" w:left="1080" w:header="720" w:footer="720"/>
+                  <w:type w:val="nextPage"/>
+                </w:sectPr>
+              </w:pPr>
+            </w:p>
+            <w:p><w:r><w:t>body</w:t></w:r></w:p>
+            "#,
+        );
+        let sb = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::SectionBreak { geom, .. } => Some(geom.clone()),
+                _ => None,
+            })
+            .expect("a SectionBreak marker");
+        let g = sb.expect("pgMar present ⇒ geom is Some");
+        assert_eq!(g.margin_top, -72.0, "negative signed top margin keeps sign");
     }
 
     /// A single-column ending section (`<w:cols>` with no `@w:num` ⇒ §17.6.4
@@ -8859,9 +8931,15 @@ mod column_tests {
         assert_eq!(body.len(), 3);
         assert!(matches!(body[0], BodyElement::Paragraph(_)));
         match &body[1] {
-            BodyElement::SectionBreak { kind, columns, .. } => {
+            BodyElement::SectionBreak {
+                kind,
+                columns,
+                geom,
+                ..
+            } => {
                 assert_eq!(kind, "nextPage");
                 assert!(columns.is_none(), "single-column ⇒ None");
+                assert!(geom.is_none(), "sectPr without pgSz/pgMar carries no geom");
             }
             other => panic!("expected SectionBreak, got {other:?}"),
         }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -145,6 +145,35 @@ pub struct HeaderFooter {
     pub body: Vec<BodyElement>,
 }
 
+/// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — a section's page
+/// geometry: page size + margins + header/footer distances (all pt, converted
+/// from twips). Carried on a `BodyElement::SectionBreak` (`geom`) so mid-body
+/// sections keep their own page size (the FINAL section's geometry lives on the
+/// `SectionProps` fields of `Document.section`). Mirrored on the TS side as
+/// `SectionGeom`; the renderer resolves per-page geometry from it.
+///
+/// `orient` is intentionally omitted: Word swaps `w`/`h` for a landscape page,
+/// so the verbatim `w`/`h` already give the correct dims — no orientation flag
+/// is needed to size the page.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SectionGeom {
+    /// page width in pt (converted from twips)
+    pub page_width: f64,
+    /// page height in pt
+    pub page_height: f64,
+    /// §17.6.11 top/bottom are ST_SignedTwipsMeasure and MAY be negative — keep
+    /// the sign (identical to `SectionProps.margin_top/bottom`).
+    pub margin_top: f64,
+    pub margin_right: f64,
+    pub margin_bottom: f64,
+    pub margin_left: f64,
+    /// distance from top of page to header (pt)
+    pub header_distance: f64,
+    /// distance from bottom of page to footer (pt)
+    pub footer_distance: f64,
+}
+
 #[derive(Serialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SectionProps {
@@ -294,6 +323,12 @@ pub enum BodyElement {
         /// distinct first-page header/footer. NOT inherited (each sectPr's flag
         /// stands alone, like the body-level `Document.section.title_page`).
         title_page: bool,
+        /// ECMA-376 §17.6.13 / §17.6.11 — this ENDING section's page geometry
+        /// (size + margins). `None` when the sectPr declares no `<w:pgSz>` /
+        /// `<w:pgMar>` (the renderer then falls back to the body-level section).
+        /// The final (body-level) section's geometry stays on `Document.section`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        geom: Option<SectionGeom>,
     },
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -155,7 +155,12 @@ pub struct HeaderFooter {
 /// `orient` is intentionally omitted: Word swaps `w`/`h` for a landscape page,
 /// so the verbatim `w`/`h` already give the correct dims — no orientation flag
 /// is needed to size the page.
-#[derive(Serialize, Debug, Clone, Default)]
+///
+/// No `Default` derive on purpose: zeros ≠ spec defaults; a derived default is an
+/// all-zeros geometry (0×0 page, zero margins), which is NOT the ECMA-376 spec
+/// default (US Letter portrait, 1" margins, 0.5" header/footer). Use
+/// `spec_default_geom()` (parser.rs) when a spec-default geometry is needed.
+#[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SectionGeom {
     /// page width in pt (converted from twips)

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -223,6 +223,31 @@ export class DocxDocument {
     return this._pages;
   }
 
+  /**
+   * ECMA-376 §17.6.13 / §17.6.11 — the page size (pt) of page `pageIndex`, per
+   * section (a mixed portrait/landscape document returns different sizes per page).
+   * Available in BOTH modes: worker mode reads the worker-built `pageSizes` meta;
+   * main mode reads the paginated pages' stamped geometry. Returns the body-level
+   * section size for an out-of-range index (clamped) or a page with no stamped
+   * geometry. A 0-page document (empty `pageSizes`/no pages) yields `{ 0, 0 }`.
+   * The recommended way to ask "how big is page i?" for layout.
+   */
+  pageSize(pageIndex: number): { widthPt: number; heightPt: number } {
+    if (this._meta) {
+      const sizes = this._meta.pageSizes;
+      const clamped = Math.max(0, Math.min(pageIndex, sizes.length - 1));
+      return sizes[clamped] ?? { widthPt: 0, heightPt: 0 };
+    }
+    if (!this._document) return { widthPt: 0, heightPt: 0 };
+    const pages = this._getPages();
+    const clamped = Math.max(0, Math.min(pageIndex, pages.length - 1));
+    const g = pages[clamped]?.[0]?.sectionGeom;
+    return {
+      widthPt: g?.pageWidth ?? this._document.section.pageWidth,
+      heightPt: g?.pageHeight ?? this._document.section.pageHeight,
+    };
+  }
+
   renderPage(
     target: HTMLCanvasElement | OffscreenCanvas,
     pageIndex: number,

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -229,14 +229,19 @@ export class DocxDocument {
    * Available in BOTH modes: worker mode reads the worker-built `pageSizes` meta;
    * main mode reads the paginated pages' stamped geometry. Returns the body-level
    * section size for an out-of-range index (clamped) or a page with no stamped
-   * geometry. A 0-page document (empty `pageSizes`/no pages) yields `{ 0, 0 }`.
+   * geometry. `{ 0, 0 }` means "not loaded" (before `load()` resolves or after
+   * `destroy()`). Returns a fresh object per call — safe to mutate.
    * The recommended way to ask "how big is page i?" for layout.
    */
   pageSize(pageIndex: number): { widthPt: number; heightPt: number } {
     if (this._meta) {
       const sizes = this._meta.pageSizes;
       const clamped = Math.max(0, Math.min(pageIndex, sizes.length - 1));
-      return sizes[clamped] ?? { widthPt: 0, heightPt: 0 };
+      const s = sizes[clamped];
+      // Copy — never alias the meta's stored object (a caller mutating the
+      // return value must not corrupt subsequent reads; main mode below already
+      // builds a fresh object per call).
+      return s ? { widthPt: s.widthPt, heightPt: s.heightPt } : { widthPt: 0, heightPt: 0 };
     }
     if (!this._document) return { widthPt: 0, heightPt: 0 };
     const pages = this._getPages();

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -7,6 +7,9 @@ export type {
   DocxDocumentModel,
   DocSettings,
   SectionProps,
+  // Per-section page geometry (reachable via the BodyElement sectionBreak arm's
+  // `geom` and PaginatedBodyElement's `sectionGeom`, ECMA-376 §17.6.13/§17.6.11).
+  SectionGeom,
   // Multi-column section sub-types (reachable via SectionProps.columns).
   ColumnsSpec,
   ColSpec,

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -372,3 +372,19 @@ describe('per-section page geometry (§17.6.13/§17.6.11) — renderer', () => {
     expect(canvas.width / canvas.height).toBeCloseTo(300 / 400, 2);
   });
 });
+
+describe('page-size fact (§17.6.13/§17.6.11) — paginateDocument sectionGeom', () => {
+  it('exposes per-page width/height via the first element sectionGeom', () => {
+    // paginateDocument is the shared primitive DocxDocument.pageSize (main mode)
+    // and render-worker's pageSizes[] both read. Each page's first element carries
+    // its section geometry.
+    const doc = mixedDoc();
+    const pages = paginateDocument(doc);
+    const sizeOf = (i: number) => {
+      const g = (pages[i]?.[0] as PaginatedBodyElement | undefined)?.sectionGeom;
+      return { widthPt: g?.pageWidth ?? doc.section.pageWidth, heightPt: g?.pageHeight ?? doc.section.pageHeight };
+    };
+    expect(sizeOf(0)).toEqual({ widthPt: 200, heightPt: 140 });
+    expect(sizeOf(1)).toEqual({ widthPt: 140, heightPt: 200 });
+  });
+});

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { computePages, paginateDocument } from './renderer.js';
+import type {
+  BodyElement, DocParagraph, DocxTextRun, SectionProps, DocxDocumentModel,
+  SectionGeom, PaginatedBodyElement,
+} from './types';
+
+// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — page geometry is
+// PER-SECTION. A mid-body SectionBreak carries its ending section's `geom`; the
+// paginator stamps each element's `sectionGeom` (upcoming SectionBreak's geom, or
+// the body-level section for the final section) so the renderer sizes each page
+// from its own section. Single-section documents stamp the body-level geometry
+// everywhere (byte-identical layout).
+
+// Deterministic stub canvas: glyph advance = charCount × fontPx, font box =
+// 0.8/0.2 em (a single line is exactly fontPx tall). Copied from pagination.test.ts.
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, fillText() {}, strokeText() {}, beginPath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fillRect() {}, drawImage() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    letterSpacing: '0px',
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+type DocRun = DocParagraph['runs'][number];
+function textRun(text: string, fontSize: number): DocRun {
+  const run: DocxTextRun = {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  } as unknown as DocxTextRun;
+  return { type: 'text', ...run } as DocRun;
+}
+function para(text: string, fontSize = 20): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [textRun(text, fontSize)],
+    defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as unknown as DocParagraph;
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+// A portrait first section (200×140) ended by a nextPage break, then a landscape
+// body section (140×200) via doc.section. `geom` on the break carries the portrait
+// section's page size; doc.section carries the landscape body size.
+function mixedDoc(): DocxDocumentModel {
+  const portrait: SectionGeom = {
+    pageWidth: 200, pageHeight: 140,
+    marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+    headerDistance: 0, footerDistance: 0,
+  };
+  const bodySection: SectionProps = {
+    pageWidth: 140, pageHeight: 200,
+    marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+  const body: BodyElement[] = [
+    para('PORTRAIT_SECTION'),
+    { type: 'sectionBreak', kind: 'nextPage', geom: portrait } as BodyElement,
+    para('LANDSCAPE_SECTION'),
+  ];
+  return {
+    section: bodySection, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: {},
+  } as unknown as DocxDocumentModel;
+}
+
+describe('per-section page geometry (§17.6.13/§17.6.11) — paginator', () => {
+  it('stamps each element with its section geometry', () => {
+    const doc = mixedDoc();
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    // Page 0 = portrait section (the first section, ended by the nextPage break).
+    const p0 = pages[0].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(p0.sectionGeom?.pageWidth).toBe(200);
+    expect(p0.sectionGeom?.pageHeight).toBe(140);
+    // Page 1 = landscape body section (no following break ⇒ body-level geometry).
+    const p1 = pages[1].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(p1.sectionGeom?.pageWidth).toBe(140);
+    expect(p1.sectionGeom?.pageHeight).toBe(200);
+  });
+
+  it('single-section document stamps the body-level geometry on every element', () => {
+    const section: SectionProps = {
+      pageWidth: 200, pageHeight: 140,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const doc = {
+      section, body: [para('A'), para('B')],
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    for (const page of pages) {
+      for (const el of page) {
+        expect((el as PaginatedBodyElement).sectionGeom?.pageWidth).toBe(200);
+        expect((el as PaginatedBodyElement).sectionGeom?.pageHeight).toBe(140);
+      }
+    }
+  });
+});

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { computePages, paginateDocument } from './renderer.js';
 import type {
   BodyElement, DocParagraph, DocxTextRun, SectionProps, DocxDocumentModel,
-  SectionGeom, PaginatedBodyElement,
+  SectionGeom, PaginatedBodyElement, HeaderFooter,
 } from './types';
 
 // ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — page geometry is
@@ -36,6 +36,15 @@ function makeCtx(): CanvasRenderingContext2D {
   };
   return ctx as unknown as CanvasRenderingContext2D;
 }
+
+// `paginateDocument` builds its measure ctx from `new OffscreenCanvas(...)`, which
+// the node test env lacks. Polyfill it with the SAME deterministic stub (line
+// height = fontPx) so the HF-reserve paginator runs headless and its page-fit
+// arithmetic is exact. (The paginator-stamp/renderer tests above inject their ctx
+// directly via computePages/renderDocumentToCanvas and don't need this.)
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeCtx(); }
+};
 
 type DocRun = DocParagraph['runs'][number];
 function textRun(text: string, fontSize: number): DocRun {
@@ -210,5 +219,61 @@ describe('per-section page geometry (§17.6.13/§17.6.11) — paginator', () => 
         expect((el as PaginatedBodyElement).sectionGeom?.pageHeight).toBe(140);
       }
     }
+  });
+});
+
+// A single 40pt paragraph measures exactly 40pt tall under the mock ctx (line
+// height = fontPx). Same footer shape as per-section-headers-footers.test.ts's
+// `footer()` — { body: [para(...)] } — but sized to 40pt so the reserve arithmetic
+// is round. Verified empirically: measureHeaderFooterHeight(FOOTER_40PT) = 40.
+const FOOTER_40PT: HeaderFooter = { body: [para('F', 40)] };
+
+describe('per-section HF reserves (§17.6.11) — paginator', () => {
+  it('reserves footer overflow against the PAGE section margins, not the body section', () => {
+    // Mid-body section sec1 (page 0): pageHeight 200, marginTop 20, marginBottom 60,
+    // footerDistance 10 ⇒ footer extent 10+40=50 FITS the 60pt bottom margin ⇒ reserve
+    // 0. Its frame = 200−20−60 = 120 ⇒ five 20pt lines (100pt) fit.
+    // Body section (page 1): marginBottom 20 ⇒ footer extent 50 overflows ⇒ reserve 30
+    // (its OWN page). B1 fits regardless.
+    // WITHOUT the fix, computeFooterReserves reads the body-level marginBottom (20) for
+    // EVERY page ⇒ page 0 gets a phantom reserve 30 ⇒ usable 90 ⇒ only 4 lines ⇒ A5
+    // spills to page 1. WITH the fix, page 0 reads sec1's stamped marginBottom (60) ⇒
+    // reserve 0 ⇒ all five A* stay on page 0.
+    const sec1: SectionGeom = {
+      pageWidth: 200, pageHeight: 200,
+      marginTop: 20, marginRight: 20, marginBottom: 60, marginLeft: 20,
+      headerDistance: 0, footerDistance: 10,
+    };
+    const bodySection: SectionProps = {
+      pageWidth: 200, pageHeight: 200,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 10, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const doc = {
+      section: bodySection,
+      body: [
+        para('A1'), para('A2'), para('A3'), para('A4'), para('A5'),
+        {
+          // The mid-body section must carry the footer itself — otherwise it resolves
+          // no footer on its pages and the (phantom) reserve is never applied there,
+          // so the bug can't surface. Mirror doc.footers on the break.
+          type: 'sectionBreak', kind: 'nextPage', geom: sec1,
+          headers: { default: null, first: null, even: null },
+          footers: { default: FOOTER_40PT, first: null, even: null },
+          titlePage: false,
+        } as BodyElement,
+        para('B1'),
+      ],
+      headers: { default: null, first: null, even: null },
+      footers: { default: FOOTER_40PT, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = paginateDocument(doc);
+    const textsOn = (i: number) =>
+      (pages[i] ?? []).filter((e) => e.type === 'paragraph')
+        .map((e) => ((e as { runs?: { text?: string }[] }).runs ?? []).map((r) => r.text).join(''));
+    // All five A-paragraphs fit page 0 (reserve 0 under ITS section's marginBottom 60).
+    expect(textsOn(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
+    expect(textsOn(1)).toEqual(['B1']);
   });
 });

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -337,6 +337,23 @@ describe('per-section page geometry (§17.6.13/§17.6.11) — renderer', () => {
     expect(c1.width / c1.height).toBeCloseTo(140 / 200, 2);
   });
 
+  it('honours opts.width per CALL: same pixel width, per-page height from aspect', async () => {
+    // The scroll viewer's contract: `width` is the canvas CSS width for THIS call.
+    // Mixed-width pages rendered at a constant width fill the same pixels at
+    // different px-per-pt scales; height still follows each page's OWN aspect.
+    // Page 0 (portrait 200×140): height = 400·140/200 = 280.
+    // Page 1 (landscape 140×200): height = 400·200/140 ≈ 571.
+    const doc = mixedDoc();
+    const { canvas: c0 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c0, 0, { width: 400, dpr: 1 });
+    const { canvas: c1 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c1, 1, { width: 400, dpr: 1 });
+    expect(c0.width).toBe(400);
+    expect(c1.width).toBe(400);
+    expect(c0.height).toBe(280);
+    expect(c1.height).toBe(Math.round(400 * (200 / 140)));
+  });
+
   it('single-section document sizes every page from doc.section (no regression)', async () => {
     const section: SectionProps = {
       pageWidth: 300, pageHeight: 400,

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -387,4 +387,41 @@ describe('page-size fact (§17.6.13/§17.6.11) — paginateDocument sectionGeom'
     expect(sizeOf(0)).toEqual({ widthPt: 200, heightPt: 140 });
     expect(sizeOf(1)).toEqual({ widthPt: 140, heightPt: 200 });
   });
+
+  // Direct unit coverage of DocxDocument.pageSize itself. The class needs a
+  // Worker/WASM to construct normally, so inject the private state onto a bare
+  // prototype instance (TS-private fields are runtime-assignable) — covering the
+  // worker branch (_meta), the main branch (_document + pagination), clamping,
+  // the not-loaded {0,0} contract, and the fresh-object (no aliasing) guarantee.
+  it('DocxDocument.pageSize: both branches, clamp, not-loaded, no aliasing', async () => {
+    const { DocxDocument } = await import('./document.js');
+    // The constructor is private, so derive the instance type from the factory.
+    type Doc = Awaited<ReturnType<typeof DocxDocument.load>>;
+    const make = (state: Record<string, unknown>) => {
+      const d = Object.create(DocxDocument.prototype) as Doc;
+      Object.assign(d, { _meta: null, _document: null, _pages: null }, state);
+      return d;
+    };
+
+    // Worker branch: reads _meta.pageSizes with clamp; returns a COPY.
+    const meta = { pageCount: 2, comments: [], footnotes: [], endnotes: [],
+      pageSizes: [{ widthPt: 200, heightPt: 140 }, { widthPt: 140, heightPt: 200 }] };
+    const w = make({ _meta: meta });
+    expect(w.pageSize(0)).toEqual({ widthPt: 200, heightPt: 140 });
+    expect(w.pageSize(1)).toEqual({ widthPt: 140, heightPt: 200 });
+    expect(w.pageSize(-5)).toEqual({ widthPt: 200, heightPt: 140 }); // clamp low
+    expect(w.pageSize(99)).toEqual({ widthPt: 140, heightPt: 200 }); // clamp high
+    const returned = w.pageSize(0);
+    returned.widthPt = 9999; // mutating the return value must not corrupt the meta
+    expect(w.pageSize(0)).toEqual({ widthPt: 200, heightPt: 140 });
+
+    // Main branch: paginates the model and reads the stamped sectionGeom.
+    const m = make({ _document: mixedDoc() });
+    expect(m.pageSize(0)).toEqual({ widthPt: 200, heightPt: 140 });
+    expect(m.pageSize(1)).toEqual({ widthPt: 140, heightPt: 200 });
+    expect(m.pageSize(99)).toEqual({ widthPt: 140, heightPt: 200 }); // clamp high
+
+    // Not loaded (pre-load / post-destroy): {0,0}.
+    expect(make({}).pageSize(0)).toEqual({ widthPt: 0, heightPt: 0 });
+  });
 });

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computePages, paginateDocument } from './renderer.js';
+import { computePages, paginateDocument, renderDocumentToCanvas } from './renderer.js';
 import type {
   BodyElement, DocParagraph, DocxTextRun, SectionProps, DocxDocumentModel,
   SectionGeom, PaginatedBodyElement, HeaderFooter,
@@ -275,5 +275,83 @@ describe('per-section HF reserves (§17.6.11) — paginator', () => {
     // All five A-paragraphs fit page 0 (reserve 0 under ITS section's marginBottom 60).
     expect(textsOn(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
     expect(textsOn(1)).toEqual(['B1']);
+  });
+});
+
+// A recording canvas that exposes width/height + records fillText, so a test can
+// assert both the page pixel size and which paragraph text landed on a page.
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; texts: string[] } {
+  let font = '10px serif';
+  const texts: string[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string) { texts.push(s); }, strokeText(s: string) { texts.push(s); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, texts };
+}
+
+describe('per-section page geometry (§17.6.13/§17.6.11) — renderer', () => {
+  it('sizes each page from its own section (portrait then landscape)', async () => {
+    const doc = mixedDoc();
+    // dpr:1 so canvas.width == cssWidth. No `width` override ⇒ each page sizes from
+    // its OWN section's pageWidth × PT_TO_PX. Page 0 = portrait 200×140,
+    // page 1 = landscape 140×200. The bug was every page sizing from doc.section
+    // (140×200), so page 0 would come out 140-wide.
+    const { canvas: c0, texts: t0 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c0, 0, { dpr: 1 });
+    const { canvas: c1, texts: t1 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c1, 1, { dpr: 1 });
+
+    // Join with '' — the deterministic mock ctx wraps "PORTRAIT_SECTION" into two
+    // fillText calls at the content-width boundary, so the text arrives split.
+    expect(t0.join('')).toContain('PORTRAIT_SECTION');
+    expect(t1.join('')).toContain('LANDSCAPE_SECTION');
+    // Portrait page is wider than tall; landscape page is taller than wide. This is
+    // the load-bearing discriminator: before the fix page 0 sized from the body-level
+    // (landscape 140×200) section, so c0 would be TALLER than wide (test Red).
+    expect(c0.width).toBeGreaterThan(c0.height);
+    expect(c1.height).toBeGreaterThan(c1.width);
+    // Aspect ratios match the two sections (200/140 vs 140/200). Precision 2: canvas
+    // dims are integer-pixel (Math.round(cssW/H*dpr)), so the ratio carries a ~7e-4
+    // rounding residual — precision 2 still cleanly separates 1.43 from the buggy 0.70.
+    expect(c0.width / c0.height).toBeCloseTo(200 / 140, 2);
+    expect(c1.width / c1.height).toBeCloseTo(140 / 200, 2);
+  });
+
+  it('single-section document sizes every page from doc.section (no regression)', async () => {
+    const section: SectionProps = {
+      pageWidth: 300, pageHeight: 400,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const doc = {
+      section, body: [para('ONLY_SECTION')],
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const { canvas } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1 });
+    // Precision 2: integer-pixel rounding gives 400/533 = 0.7505, ~5e-4 off 0.75.
+    expect(canvas.width / canvas.height).toBeCloseTo(300 / 400, 2);
   });
 });

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -97,6 +97,100 @@ describe('per-section page geometry (§17.6.13/§17.6.11) — paginator', () => 
     expect(p1.sectionGeom?.pageHeight).toBe(200);
   });
 
+  // Height-sensitive spill — proves the const→arrow conversion of the page frame.
+  // A first section of 200×140 with margins 20 has a content height of 100pt ⇒ five
+  // 20pt paragraphs per page, so a SIXTH paragraph spills to a second page WITHIN the
+  // first section. If the frame were still read from the body-level section (140×200,
+  // content 160 ⇒ eight 20pt lines fit), all six would stay on page 0 and this test
+  // would fail — i.e. it regresses the moment the per-section frame reverts to a const.
+  it('paginates each section against ITS OWN page height (const→arrow)', () => {
+    const portrait: SectionGeom = {
+      pageWidth: 200, pageHeight: 140,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0,
+    };
+    const bodySection: SectionProps = {
+      pageWidth: 140, pageHeight: 200,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    // Six 20pt paragraphs in the portrait first section, then a nextPage break into
+    // the landscape body section carrying one paragraph.
+    const body: BodyElement[] = [
+      para('A1'), para('A2'), para('A3'), para('A4'), para('A5'), para('A6'),
+      { type: 'sectionBreak', kind: 'nextPage', geom: portrait } as BodyElement,
+      para('B1'),
+    ];
+    const doc = {
+      section: bodySection, body,
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    const texts = pages.map((page) =>
+      page
+        .filter((e) => e.type === 'paragraph')
+        .map((e) => (e as unknown as { runs: { text: string }[] }).runs.map((r) => r.text).join('')),
+    );
+    // Portrait content height 100 ⇒ A1..A5 on page 0, A6 spills to page 1 (still the
+    // portrait section), then the break opens page 2 for the landscape section.
+    expect(texts).toEqual([['A1', 'A2', 'A3', 'A4', 'A5'], ['A6'], ['B1']]);
+    // The spilled A6 still carries the portrait section geometry (it precedes the
+    // break); B1 carries the body-level landscape geometry.
+    const a6 = pages[1].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(a6.sectionGeom?.pageWidth).toBe(200);
+    expect(a6.sectionGeom?.pageHeight).toBe(140);
+    const b1 = pages[2].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(b1.sectionGeom?.pageWidth).toBe(140);
+    expect(b1.sectionGeom?.pageHeight).toBe(200);
+  });
+
+  // Geom-less middle break — exercises `e.geom ?? bodySectionGeom`. Three sections:
+  // break1 carries geom, break2 does NOT. `sectionGeomFrom` walks FORWARD, so the
+  // element BETWEEN the two breaks (S2) belongs to the section ENDING at break2,
+  // which has no geom ⇒ it falls back to the body-level geometry. S1 (before break1)
+  // gets break1's geom; S3 (after break2, the final section) gets the body geometry.
+  it('falls back to body geometry for a section whose break carries no geom', () => {
+    const geom1: SectionGeom = {
+      pageWidth: 300, pageHeight: 400,
+      marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+      headerDistance: 0, footerDistance: 0,
+    };
+    const bodySection: SectionProps = {
+      pageWidth: 140, pageHeight: 200,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const body: BodyElement[] = [
+      para('S1'),
+      { type: 'sectionBreak', kind: 'nextPage', geom: geom1 } as BodyElement,
+      para('S2'),
+      // No `geom`: this section inherits pgSz/pgMar ⇒ bodySectionGeom fallback.
+      { type: 'sectionBreak', kind: 'nextPage' } as BodyElement,
+      para('S3'),
+    ];
+    const doc = {
+      section: bodySection, body,
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    const s1 = pages[0].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    const s2 = pages[1].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    const s3 = pages[2].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    // S1: section ending at break1 ⇒ break1's geom.
+    expect(s1.sectionGeom?.pageWidth).toBe(300);
+    expect(s1.sectionGeom?.pageHeight).toBe(400);
+    // S2: section ending at break2, which has NO geom ⇒ body-level geometry.
+    expect(s2.sectionGeom?.pageWidth).toBe(140);
+    expect(s2.sectionGeom?.pageHeight).toBe(200);
+    // S3: final section ⇒ body-level geometry.
+    expect(s3.sectionGeom?.pageWidth).toBe(140);
+    expect(s3.sectionGeom?.pageHeight).toBe(200);
+  });
+
   it('single-section document stamps the body-level geometry on every element', () => {
     const section: SectionProps = {
       pageWidth: 200, pageHeight: 140,

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -73,11 +73,22 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         );
       }
       pages = paginateDocument(doc);
+      // ECMA-376 §17.6.13 / §17.6.11 — per-page size from each page's first
+      // element's stamped `sectionGeom` (body-level fallback for an empty page).
+      const model = doc;
+      const pageSizes = pages.map((els) => {
+        const g = els[0]?.sectionGeom;
+        return {
+          widthPt: g?.pageWidth ?? model.section.pageWidth,
+          heightPt: g?.pageHeight ?? model.section.pageHeight,
+        };
+      });
       const meta: DocumentMeta = {
         pageCount: pages.length,
         comments: doc.comments ?? [],
         footnotes: doc.footnotes ?? [],
         endnotes: doc.endnotes ?? [],
+        pageSizes,
       };
       post({ type: 'parsedMeta', id, meta });
       return;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
+  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
@@ -1128,9 +1128,14 @@ export function computePages(
   // ECMA-376 §17.6.11: the body is inset from each page edge by the margin's MAGNITUDE
   // (a negative margin measures the body |margin| from the edge and overlaps the
   // header/footer — see bodyMarginInsetPt). Identity for the non-negative common case.
-  const bodyTopPt = bodyMarginInsetPt(section.marginTop);
-  const bodyBottomPt = bodyMarginInsetPt(section.marginBottom);
-  const fullContentH = section.pageHeight - bodyTopPt - bodyBottomPt;
+  // ECMA-376 §17.6.11 — the body inset (|margin|) and §17.6.13 full content height
+  // are PER-SECTION now: a section break can change the page size/margins. These
+  // read the ACTIVE section (`currentSectionGeom`, reassigned at every break) so a
+  // landscape section paginates against its own (wider/shorter) page. For a
+  // single-section document `currentSectionGeom` never changes ⇒ identical values.
+  const bodyTopPt = () => bodyMarginInsetPt(currentSectionGeom.marginTop);
+  const bodyBottomPt = () => bodyMarginInsetPt(currentSectionGeom.marginBottom);
+  const fullContentH = () => currentSectionGeom.pageHeight - bodyTopPt() - bodyBottomPt();
   const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body), defaultTabPt);
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
@@ -1245,6 +1250,33 @@ export function computePages(
     return undefined;
   };
 
+  // ECMA-376 §17.6.13 / §17.6.11 — the page geometry (size + margins) of the
+  // section that OWNS the content starting at body index `startIdx`. Mirrors
+  // `sectionColumnsFrom` / `sectionHFFrom`: the owning section's geometry is on the
+  // NEXT `SectionBreak` marker's `geom` at/after `startIdx` (the marker ENDS that
+  // section); if there is none, the content belongs to the FINAL (body-level)
+  // section whose geometry lives on `section`. A `geom`-less marker (a section that
+  // inherits pgSz/pgMar) also falls back to the body-level geometry. For a
+  // single-section document there are no markers, so every element gets the
+  // body-level geometry — behaviour-neutral.
+  const bodySectionGeom: SectionGeom = {
+    pageWidth: section.pageWidth,
+    pageHeight: section.pageHeight,
+    marginTop: section.marginTop,
+    marginRight: section.marginRight,
+    marginBottom: section.marginBottom,
+    marginLeft: section.marginLeft,
+    headerDistance: section.headerDistance,
+    footerDistance: section.footerDistance,
+  };
+  const sectionGeomFrom = (startIdx: number): SectionGeom => {
+    for (let j = startIdx; j < body.length; j++) {
+      const e = body[j];
+      if (e.type === 'sectionBreak') return e.geom ?? bodySectionGeom;
+    }
+    return bodySectionGeom;
+  };
+
   // The active section's column geometry. Reassigned (a) here for the first
   // section and (b) at every `SectionBreak` as the flow enters the next section.
   // `colIndex` tracks which column we are filling; `colX()`/`colW()` give its
@@ -1262,6 +1294,11 @@ export function computePages(
   // on each element so the renderer picks the active section's header/footer per
   // page. `undefined` for the final section ⇒ the renderer's body-level fallback.
   let currentSectionHF = sectionHFFrom(0);
+  // ECMA-376 §17.6.13 / §17.6.11 — the active section's page geometry, tracked in
+  // lockstep with `columns`/`currentSectionHF` (reassigned at every SectionBreak).
+  // Stamped on each element so the renderer sizes each page from its own section.
+  // For a single-section document this stays the body-level geometry throughout.
+  let currentSectionGeom = sectionGeomFrom(0);
   // ECMA-376 §17.6.4 / §17.18.79 — the CURRENT multi-column region's vertical
   // extent on the current page, in content-relative pt (0 = page content top,
   // i.e. the same frame as `y`). A region tiled into N newspaper columns is a
@@ -1288,7 +1325,7 @@ export function computePages(
   // Page-absolute pt of the current region top, stamped on elements so the paint
   // pass resets a column's cursor to the region top (front-loaded layout: the
   // renderer consumes this instead of independently deciding the column top).
-  const colTopAbsPt = () => bodyTopPt + colTopY;
+  const colTopAbsPt = () => bodyTopPt() + colTopY;
 
   // Run `fn` with the measure state's content band temporarily re-pointed at the
   // CURRENT newspaper column (#513). The paint pass (renderBodyElements) sets
@@ -1330,7 +1367,7 @@ export function computePages(
   // like the real renderer does. floatParaSeq is reset together with floats so
   // the paraId採番 matches the renderer, which starts each page at 0 (a fresh
   // RenderState per page in renderDocumentToCanvas).
-  measureState.y = bodyTopPt;
+  measureState.y = bodyTopPt();
   measureState.floats = [];
   measureState.floatParaSeq = 0;
   // ECMA-376 §20.4.3.2/§20.4.3.5: a wp:anchor whose positionV relativeFrom is
@@ -1369,7 +1406,7 @@ export function computePages(
     pageReserves.length === 0 ? ZERO_RESERVE : (pageReserves[Math.min(i, pageReserves.length - 1)] ?? ZERO_RESERVE);
   const effContentH = () => {
     const r = reserveAt(pages.length - 1);
-    return fullContentH - (footnoteReservePt[pages.length - 1] ?? 0) - r.bottom - r.top;
+    return fullContentH() - (footnoteReservePt[pages.length - 1] ?? 0) - r.bottom - r.top;
   };
   const startPageBookkeeping = () => {
     footnoteReservePt[pages.length - 1] = 0;
@@ -1391,7 +1428,7 @@ export function computePages(
       balanceColH = null;
       prevPara = null;
       prevSpaceAfter = 0;
-      measureState.y = bodyTopPt;
+      measureState.y = bodyTopPt();
       // Floats are PAGE-scoped (ECMA-376 §20.4.2.x): a new page starts with a
       // clean float set. Columns of the SAME page share floats (see nextColumn).
       measureState.floats = [];
@@ -1420,7 +1457,7 @@ export function computePages(
     y = colTopY;
     prevPara = null;
     prevSpaceAfter = 0;
-    measureState.y = bodyTopPt + colTopY;
+    measureState.y = bodyTopPt() + colTopY;
   };
   // Overflow handler shared by element placement and paragraph/table splitting:
   // move to the next column if one remains on this page, otherwise to a new page.
@@ -1445,7 +1482,7 @@ export function computePages(
     startIdx: number,
     colWPt: number,
   ): { height: number; terminated: boolean } => {
-    const ms: RenderState = { ...measureState, y: bodyTopPt, floats: [], floatParaSeq: 0 };
+    const ms: RenderState = { ...measureState, y: bodyTopPt(), floats: [], floatParaSeq: 0 };
     let total = 0;
     let prevAfter = 0;
     let prevP: DocParagraph | null = null;
@@ -1575,6 +1612,7 @@ export function computePages(
     el.colGeom = columns;
     el.colTopPt = colTopAbsPt();
     el.sectionHF = currentSectionHF;
+    el.sectionGeom = currentSectionGeom;
     pages[pages.length - 1].push(el);
   };
 
@@ -1603,7 +1641,7 @@ export function computePages(
       balanceColH = null;
       prevPara = null;
       prevSpaceAfter = 0;
-      measureState.y = bodyTopPt;
+      measureState.y = bodyTopPt();
       measureState.floats = [];
       measureState.floatParaSeq = 0;
       // Pre-register page-level wrap floats from the next body element onward
@@ -1633,6 +1671,8 @@ export function computePages(
       // ECMA-376 §17.10.1 — the section starting at i+1 owns the following pages'
       // headers/footers (resolved from the NEXT marker, or the body-level set).
       currentSectionHF = sectionHFFrom(i + 1);
+      // ECMA-376 §17.6.13 / §17.6.11 — and its page geometry (size + margins).
+      currentSectionGeom = sectionGeomFrom(i + 1);
       // The break is governed by the UPCOMING section's start type (§17.6.22),
       // not this marker's own kind (the section it closes). See sectionKindFrom.
       // The sample-5 cover overprint that prompted the 0.66.1 hotfix is now fixed
@@ -1654,7 +1694,7 @@ export function computePages(
         // this clears the overprint and the page-fill error regardless.
         const regionBottom = Math.max(maxColBottomY, y);
         y = regionBottom;
-        measureState.y = bodyTopPt + regionBottom;
+        measureState.y = bodyTopPt() + regionBottom;
         colTopY = regionBottom;
         maxColBottomY = regionBottom;
         prevPara = null;
@@ -1674,7 +1714,7 @@ export function computePages(
         balanceColH = null;
         prevPara = null;
         prevSpaceAfter = 0;
-        measureState.y = bodyTopPt;
+        measureState.y = bodyTopPt();
         measureState.floats = [];
         measureState.floatParaSeq = 0;
         // Pre-register page-level wrap floats from the next body element onward
@@ -1942,13 +1982,14 @@ export function computePages(
           () => colTopY,
           columnBottomLimit,
           () => currentSectionHF,
+          () => currentSectionGeom,
         );
         // After splitting, `y` is the bottom of the last slice in the
         // current column (continues for the LAST slice; intermediate slices
         // filled their column/page exactly, so the break callback ran between
         // them).
         y = placed.endY;
-        measureState.y = bodyTopPt + placed.endY;
+        measureState.y = bodyTopPt() + placed.endY;
         // A split footnote-bearing paragraph reserves on the page where it
         // ends. Rare; the separator region re-applies if that page had none.
         if (haveFootnotes && newRefIds.length > 0) {
@@ -2031,11 +2072,12 @@ export function computePages(
           () => colIndex,
           columns,
           () => colTopY,
-          bodyTopPt,
+          bodyTopPt(),
           () => currentSectionHF,
+          () => currentSectionGeom,
         );
         y = endY;
-        measureState.y = bodyTopPt + endY;
+        measureState.y = bodyTopPt() + endY;
       } else {
         // §17.6.4 column balancing (wantsBalanceBreak) OR a table that doesn't fit
         // the rest of this column ⇒ advance to the next column / page.
@@ -2495,6 +2537,11 @@ function splitParagraphAcrossPages(
    *  stamped so the renderer picks the right section's header/footer per page.
    *  Omitted ⇒ the renderer's body-level fallback. */
   tagSectionHF?: () => PaginatedBodyElement['sectionHF'],
+  /** ECMA-376 §17.6.13 / §17.6.11 — the active SECTION's page geometry (size +
+   *  margins). A paragraph never spans a section boundary, so this is constant for
+   *  all slices; stamped so the renderer sizes each page from the right section.
+   *  Omitted ⇒ the renderer's body-level fallback. */
+  tagSectionGeom?: () => SectionGeom,
 ): { endY: number } {
   const colTop = columnTop ?? (() => 0);
   const colBot = columnBottom ?? (() => contentH);
@@ -2505,6 +2552,7 @@ function splitParagraphAcrossPages(
     // pass resets this slice's column cursor to it instead of the page top.
     if (columnTop) el.colTopPt = measureState.marginTop + colTop();
     if (tagSectionHF) el.sectionHF = tagSectionHF();
+    if (tagSectionGeom) el.sectionGeom = tagSectionGeom();
     return el;
   };
   const indLeft = para.indentLeft;
@@ -3011,6 +3059,10 @@ export function splitTableAcrossPages(
    *  across the split). Stamped so the renderer picks the right section's header/
    *  footer per page. Omitted ⇒ the renderer's body-level fallback. */
   tagSectionHF?: () => PaginatedBodyElement['sectionHF'],
+  /** ECMA-376 §17.6.13 / §17.6.11 — the active SECTION's page geometry (size +
+   *  margins; constant across the split). Stamped so the renderer sizes each page
+   *  from the right section. Omitted ⇒ the renderer's body-level fallback. */
+  tagSectionGeom?: () => SectionGeom,
 ): number {
   const colTop = columnTop ?? (() => 0);
   const n = table.rows.length;
@@ -3046,6 +3098,7 @@ export function splitTableAcrossPages(
     // pass resets this slice's column cursor to it instead of the page top.
     if (columnTop && marginTopPt != null) sliceEl.colTopPt = marginTopPt + colTop();
     if (tagSectionHF) sliceEl.sectionHF = tagSectionHF();
+    if (tagSectionGeom) sliceEl.sectionGeom = tagSectionGeom();
     pages[pages.length - 1].push(sliceEl);
 
     y += used;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2211,12 +2211,21 @@ function computeFooterReserves(
   doc: DocxDocumentModel,
   measure: RenderState,
 ): number[] {
-  const sec = doc.section;
   return pages.map((_unused, pageIdx) => {
     const footer = resolvePageFooter(pages, pageIdx, doc);
     if (!footer) return 0;
     const footerH = measureHeaderFooterHeight(footer, measure); // pt (measure is scale 1)
-    return footerOverflowPt(footerH, sec.marginBottom, sec.footerDistance);
+    // ECMA-376 §17.6.11 — margins/distances are PER-SECTION: read this page's stamped
+    // geometry (body-level fallback only for a truly empty page). Residual: footer
+    // CONTENT is still measured at the body-level width (`measure` is built once from
+    // doc.section); per-section measure width is a follow-up — it matters only when
+    // mixed page WIDTHS meet a wrapping footer.
+    const g = pages[pageIdx]?.[0]?.sectionGeom;
+    return footerOverflowPt(
+      footerH,
+      g?.marginBottom ?? doc.section.marginBottom,
+      g?.footerDistance ?? doc.section.footerDistance,
+    );
   });
 }
 
@@ -2234,12 +2243,21 @@ function computeHeaderReserves(
   doc: DocxDocumentModel,
   measure: RenderState,
 ): number[] {
-  const sec = doc.section;
   return pages.map((_unused, pageIdx) => {
     const header = resolvePageHeader(pages, pageIdx, doc);
     if (!header) return 0;
     const headerH = measureHeaderFooterHeight(header, measure); // pt (measure is scale 1)
-    return headerOverflowPt(headerH, sec.marginTop, sec.headerDistance);
+    // ECMA-376 §17.6.11 — margins/distances are PER-SECTION: read this page's stamped
+    // geometry (body-level fallback only for a truly empty page). Residual: header
+    // CONTENT is still measured at the body-level width (`measure` is built once from
+    // doc.section); per-section measure width is a follow-up — it matters only when
+    // mixed page WIDTHS meet a wrapping header.
+    const g = pages[pageIdx]?.[0]?.sectionGeom;
+    return headerOverflowPt(
+      headerH,
+      g?.marginTop ?? doc.section.marginTop,
+      g?.headerDistance ?? doc.section.headerDistance,
+    );
   });
 }
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1133,6 +1133,8 @@ export function computePages(
   // read the ACTIVE section (`currentSectionGeom`, reassigned at every break) so a
   // landscape section paginates against its own (wider/shorter) page. For a
   // single-section document `currentSectionGeom` never changes ⇒ identical values.
+  // `currentSectionGeom` is declared below (TDZ-safe: these arrows only close over
+  // it, and the first call happens during the element loop, after its `let` init).
   const bodyTopPt = () => bodyMarginInsetPt(currentSectionGeom.marginTop);
   const bodyBottomPt = () => bodyMarginInsetPt(currentSectionGeom.marginBottom);
   const fullContentH = () => currentSectionGeom.pageHeight - bodyTopPt() - bodyBottomPt();
@@ -1155,9 +1157,14 @@ export function computePages(
     for (let j = startIdx; j < body.length; j++) {
       const e = body[j];
       if (e.type === 'sectionBreak') {
-        // computeColumns reads only `section.columns` + the page geometry (which
-        // is constant across the body), so resolve this section's cols by
-        // swapping in its ColumnsSpec.
+        // Resolve this section's cols by swapping in its ColumnsSpec. Page
+        // GEOMETRY is now per-section (`sectionGeomFrom`), but `computeColumns`
+        // here still receives the BODY-LEVEL width (`section.pageWidth`/margins) —
+        // a documented residual: a mid-body section with a different page WIDTH and
+        // multiple columns tiles against the body width, not its own. Single-column
+        // sections and uniform-width documents are unaffected. Aligning column
+        // widths to the per-section width is the width-residual follow-up in the
+        // design doc; do NOT change it here.
         return computeColumns({ ...section, columns: e.columns ?? null });
       }
     }
@@ -1259,16 +1266,7 @@ export function computePages(
   // inherits pgSz/pgMar) also falls back to the body-level geometry. For a
   // single-section document there are no markers, so every element gets the
   // body-level geometry — behaviour-neutral.
-  const bodySectionGeom: SectionGeom = {
-    pageWidth: section.pageWidth,
-    pageHeight: section.pageHeight,
-    marginTop: section.marginTop,
-    marginRight: section.marginRight,
-    marginBottom: section.marginBottom,
-    marginLeft: section.marginLeft,
-    headerDistance: section.headerDistance,
-    footerDistance: section.footerDistance,
-  };
+  const bodySectionGeom: SectionGeom = sectionGeomOf(section);
   const sectionGeomFrom = (startIdx: number): SectionGeom => {
     for (let j = startIdx; j < body.length; j++) {
       const e = body[j];
@@ -1681,7 +1679,21 @@ export function computePages(
       // without forcing every nextPage→continuous boundary to break a page.
       const upcomingKind = sectionKindFrom(i + 1);
       if (upcomingKind === 'continuous') {
-        // ECMA-376 §17.18.79 "continuous": NO page break — the next section's
+        // ECMA-376 §17.18.77 (ST_SectionMark) / §17.6.22 (type) — geometry residual:
+        // reassigning `currentSectionGeom` above activates the incoming section's
+        // page frame MID-PAGE (`bodyTopPt()`/`effContentH()` switch here). The spec
+        // does NOT mandate promoting a continuous break to a new page when the page
+        // size differs; it says the opposite — "continuous section breaks might not
+        // specify certain page-level section properties, since they shall be
+        // inherited from the following section" (§17.18.77 / §17.6.22). The only
+        // spec-defined exception is a footnote reference on the break page (§17.11.14
+        // ⇒ the new section begins on the following page). Word additionally defers a
+        // differing page geometry to the next page in practice, but that is a runtime
+        // behaviour, not a spec rule — left as a documented residual (see design doc),
+        // NOT reverse-engineered here (root CLAUDE.md: spec-first, no runtime guessing
+        // without approval).
+        //
+        // ECMA-376 §17.18.77 "continuous": NO page break — the next section's
         // content continues on the SAME page. It must start below the BOTTOM of
         // EVERY column of the section just ended (ECMA-376 §17.6.4), not at the
         // last-filled column's cursor: a 2-col section whose first column ran to
@@ -2133,6 +2145,25 @@ function bodyMarginInsetPt(margin: number): number {
   return Math.abs(margin);
 }
 
+/** ECMA-376 §17.6.13 (pgSz) + §17.6.11 (pgMar) — project a {@link SectionProps}
+ *  onto the smaller {@link SectionGeom} view (page size + margins + header/footer
+ *  distances, dropping the section's title-page/columns/etc.). Used to seed the
+ *  body-level fallback geometry in `computePages` (bodySectionGeom); a private
+ *  module helper so the boundary-promotion path can reuse the SAME 8-field
+ *  projection when comparing an incoming section's geometry to the ending one. */
+function sectionGeomOf(s: SectionProps): SectionGeom {
+  return {
+    pageWidth: s.pageWidth,
+    pageHeight: s.pageHeight,
+    marginTop: s.marginTop,
+    marginRight: s.marginRight,
+    marginBottom: s.marginBottom,
+    marginLeft: s.marginLeft,
+    headerDistance: s.headerDistance,
+    footerDistance: s.footerDistance,
+  };
+}
+
 /** Resolve the footer that applies to `pageIndex` with the §17.10.1/§17.10.6
  *  first/even/default precedence (resolvePageSection + pickHeaderFooter), or null if
  *  none. One selection shared by the reserve pass, the footer paint, and the footnote
@@ -2302,9 +2333,13 @@ function buildMeasureState(
     dryRun: true,
     marginLeft: section.marginLeft,
     marginRight: section.marginRight,
-    // §17.6.11: the measure state's marginTop is the body inset (|margin|) — the base for
-    // the page-absolute region top stamped on slices (splitParagraphAcrossPages' colTopPt),
-    // which must match the paint pass. Never the raw sign. Identity for non-negative.
+    // §17.6.11: the measure state's marginTop is the BODY-LEVEL body inset (|margin|).
+    // Per-section colTopPt stamps no longer read this field directly: the split
+    // functions derive the region top from the threaded `tagSectionGeom` closure
+    // (`bodyMarginInsetPt(tagSectionGeom().marginTop)`), matching pushTagged's
+    // `bodyTopPt()` per-section convention. This body-level value is only the
+    // single-section-equivalent fallback (identical when there is one section) and
+    // still seeds contentW/pageH below. Never the raw sign. Identity for non-negative.
     marginTop: bodyMarginInsetPt(section.marginTop),
     marginBottom: bodyMarginInsetPt(section.marginBottom),
     pageWidth: section.pageWidth,
@@ -2549,8 +2584,21 @@ function splitParagraphAcrossPages(
     if (tagColIndex) el.colIndex = tagColIndex();
     if (colGeom) el.colGeom = colGeom;
     // Front-loaded layout: stamp the region top (page-absolute pt) so the paint
-    // pass resets this slice's column cursor to it instead of the page top.
-    if (columnTop) el.colTopPt = measureState.marginTop + colTop();
+    // pass resets this slice's column cursor to it instead of the page top. The
+    // top inset is PER-SECTION (§17.6.11): a slice in a mid-body section with a
+    // different marginTop must anchor against ITS section, not the body-level
+    // `measureState.marginTop` (frozen at buildMeasureState). `tagSectionGeom` is
+    // the active section's geometry (constant across a paragraph's slices), so
+    // `bodyMarginInsetPt(tagSectionGeom().marginTop)` matches pushTagged's
+    // `bodyTopPt()` convention exactly. For a single-section document this equals
+    // `measureState.marginTop` (both are `bodyMarginInsetPt(section.marginTop)`)
+    // — value-identical. Falls back to the body-level inset when no geom thunk.
+    if (columnTop) {
+      const topInset = tagSectionGeom
+        ? bodyMarginInsetPt(tagSectionGeom().marginTop)
+        : measureState.marginTop;
+      el.colTopPt = topInset + colTop();
+    }
     if (tagSectionHF) el.sectionHF = tagSectionHF();
     if (tagSectionGeom) el.sectionGeom = tagSectionGeom();
     return el;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -639,8 +639,28 @@ export async function renderDocumentToCanvas(
   const myToken = (tokenHost.__docxRenderToken = (tokenHost.__docxRenderToken ?? 0) + 1);
   const superseded = () => tokenHost.__docxRenderToken !== myToken;
 
-  const sec = doc.section;
   const dpr = opts.dpr ?? defaultDpr();
+  // getContext before sizing is legal: resizing a canvas after getContext resets
+  // its drawing state, and the ctx.scale/fill below run AFTER canvas.width/height.
+  // The pagination fallback (paginateWithHeaderFooterReserve) needs this ctx.
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+  const kinsoku = resolveKinsokuRules(doc.settings);
+  const pages = opts.prebuiltPages ?? paginateWithHeaderFooterReserve(doc, ctx, doc.fontFamilyClasses ?? {}, kinsoku, doc.footnotes ?? []);
+  const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
+  const elements = pages[pageIndex] ?? pages[0] ?? [];
+
+  // ECMA-376 §17.6.13 / §17.6.11 — page geometry is PER-SECTION. Size THIS page from
+  // the section active at its top (resolvePageSection.geom, stamped by the paginator),
+  // NOT from the single body-level `doc.section`. `sec` merges the resolved geometry
+  // (size + margins + header/footer distances) over the body-level section so the
+  // docGrid / columns / sectionStart / even-odd fields keep their body-level values —
+  // those already flow per-section through the paginator's `colGeom`/docGrid state
+  // rails, so only the page-box geometry needs the per-page swap here. For a
+  // single-section document `geom` equals `doc.section`, so `sec === doc.section` in
+  // value — byte-identical output.
+  const pageGeom = resolvePageSection(pages, pageIndex, doc).geom;
+  const sec: SectionProps = { ...doc.section, ...pageGeom };
+
   const cssWidth = opts.width ?? sec.pageWidth * PT_TO_PX;
   const scale = cssWidth / sec.pageWidth;  // px per pt
   const cssHeight = sec.pageHeight * scale;
@@ -654,16 +674,9 @@ export async function renderDocumentToCanvas(
     if (!canvas.style.display) canvas.style.display = 'block';
   }
 
-  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   ctx.scale(dpr, dpr);
-
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(0, 0, cssWidth, cssHeight);
-
-  const kinsoku = resolveKinsokuRules(doc.settings);
-  const pages = opts.prebuiltPages ?? paginateWithHeaderFooterReserve(doc, ctx, doc.fontFamilyClasses ?? {}, kinsoku, doc.footnotes ?? []);
-  const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
-  const elements = pages[pageIndex] ?? pages[0] ?? [];
 
   const images = await preloadImages(doc, opts.fetchImage);
   // A newer render of this canvas started while we awaited image decode — stop
@@ -3217,14 +3230,19 @@ function resolvePageSection(
   pages: PaginatedBodyElement[][],
   pageIndex: number,
   doc: DocxDocumentModel,
-): { headers: HeadersFooters; footers: HeadersFooters; titlePage: boolean; isFirstPageOfSection: boolean } {
+): { headers: HeadersFooters; footers: HeadersFooters; titlePage: boolean; isFirstPageOfSection: boolean; geom: SectionGeom } {
   const sectionOf = (idx: number): PaginatedBodyElement['sectionHF'] => pages[idx]?.[0]?.sectionHF;
   const active = sectionOf(pageIndex);
   const headers = active?.headers ?? doc.headers;
   const footers = active?.footers ?? doc.footers;
   const titlePage = active?.titlePage ?? doc.section.titlePage;
   const isFirstPageOfSection = pageIndex === 0 || sectionOf(pageIndex - 1) !== active;
-  return { headers, footers, titlePage, isFirstPageOfSection };
+  // ECMA-376 §17.6.13 / §17.6.11 — the page's geometry, from the paginator's stamp
+  // on this page's first element, falling back to the body-level section (the value
+  // the paginator itself stamps for the final/single section, so this fallback only
+  // fires for a truly empty page). Sizes the canvas + margins per page.
+  const geom: SectionGeom = pages[pageIndex]?.[0]?.sectionGeom ?? sectionGeomOf(doc.section);
+  return { headers, footers, titlePage, isFirstPageOfSection, geom };
 }
 
 function renderHeaderFooter(hf: HeaderFooter, topY: number, base: RenderState): void {

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -125,7 +125,13 @@ export interface HeaderFooter {
  *  {@link DocxDocumentModel.section}. Also stamped per {@link PaginatedBodyElement}
  *  (`sectionGeom`) by the paginator so the renderer sizes each page from its own
  *  section. `orient` is omitted — Word swaps w/h for landscape, so verbatim w/h
- *  already give the correct dims. */
+ *  already give the correct dims.
+ *
+ *  ⚠ Spread over the body-level {@link SectionProps} in `renderDocumentToCanvas`
+ *  (`{ ...doc.section, ...pageGeom }`): only add per-section PAGE-BOX fields that
+ *  exist on `SectionProps` with the same name and semantics — an optional field
+ *  colliding with a non-geometry `SectionProps` name would silently override the
+ *  body-level value the renderer promises to preserve. */
 export interface SectionGeom {
   pageWidth: number;   // pt
   pageHeight: number;  // pt
@@ -1095,7 +1101,11 @@ export type WorkerResponse =
 // ===== Public API types =====
 
 export interface RenderPageOptions {
-  /** Canvas CSS width in px; height is auto-computed from page aspect ratio */
+  /** Canvas CSS width in px; height is auto-computed from page aspect ratio.
+   *  Applies per CALL — pages of different physical widths (per-section pgSz,
+   *  §17.6.13) rendered at the same `width` get different px-per-pt scales.
+   *  For a uniform document scale, derive a per-page width from
+   *  `DocxDocument.pageSize(i)` instead of passing a constant. */
   width?: number;
   dpr?: number;
   defaultTextColor?: string;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -118,6 +118,26 @@ export interface HeaderFooter {
   body: BodyElement[];
 }
 
+/** ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — a section's page
+ *  geometry: page size + margins + header/footer distances (pt). Mirrors the Rust
+ *  `SectionGeom`. Carried on a {@link BodyElement} `sectionBreak` arm (`geom`) so a
+ *  mid-body section keeps its own page size; the FINAL section's geometry lives on
+ *  {@link DocxDocumentModel.section}. Also stamped per {@link PaginatedBodyElement}
+ *  (`sectionGeom`) by the paginator so the renderer sizes each page from its own
+ *  section. `orient` is omitted — Word swaps w/h for landscape, so verbatim w/h
+ *  already give the correct dims. */
+export interface SectionGeom {
+  pageWidth: number;   // pt
+  pageHeight: number;  // pt
+  /** §17.6.11 — top/bottom MAY be negative (ST_SignedTwipsMeasure); keep the sign. */
+  marginTop: number;
+  marginRight: number;
+  marginBottom: number;
+  marginLeft: number;
+  headerDistance: number;
+  footerDistance: number;
+}
+
 export interface SectionProps {
   pageWidth: number;   // pt
   pageHeight: number;  // pt
@@ -223,6 +243,10 @@ export type BodyElement =
       headers?: HeadersFooters;
       footers?: HeadersFooters;
       titlePage?: boolean;
+      /** ECMA-376 §17.6.13 / §17.6.11 — this ENDING section's page geometry
+       *  (size + margins). Absent when the sectPr inherits both pgSz and pgMar
+       *  (the renderer then falls back to the body-level section geometry). */
+      geom?: SectionGeom;
     };
 
 /** A BodyElement annotated with a line range to render. Set when the
@@ -286,6 +310,14 @@ export type PaginatedBodyElement = BodyElement & {
    *  falls back to the body-level `doc.headers`/`doc.footers`/`section.titlePage`.
    *  Runtime-only — never emitted by the parser. */
   sectionHF?: { headers: HeadersFooters; footers: HeadersFooters; titlePage: boolean };
+  /** ECMA-376 §17.6.13 / §17.6.11 — the page geometry (size + margins) of the
+   *  SECTION this element belongs to. Stamped by the paginator (from the upcoming
+   *  `SectionBreak`'s `geom`, or the body-level section for the final section) so the
+   *  renderer sizes each page from its own section — mirroring how `sectionHF`
+   *  resolves per-section headers/footers and `colGeom` per-section columns. Absent ⇒
+   *  the renderer uses the body-level `doc.section` geometry (single-section docs are
+   *  unaffected). Runtime-only — never emitted by the parser. */
+  sectionGeom?: SectionGeom;
 };
 
 export interface DocParagraph {

--- a/packages/docx/src/worker-protocol.ts
+++ b/packages/docx/src/worker-protocol.ts
@@ -8,6 +8,11 @@ export interface DocumentMeta {
   comments: DocComment[];
   footnotes: DocNote[];
   endnotes: DocNote[];
+  /** ECMA-376 §17.6.13 / §17.6.11 — per-page page size (pt), one entry per page,
+   *  index-aligned with `pageCount`. Built worker-side from the paginated pages'
+   *  `sectionGeom` so the main thread can lay out (e.g. a scroll viewer's spacer)
+   *  without the full model. Genuinely per-page for a mixed-geometry document. */
+  pageSizes: { widthPt: number; heightPt: number }[];
 }
 
 /** Serializable subset of RenderPageOptions (callbacks cannot cross the wire). */


### PR DESCRIPTION
## Summary

Fixes the single-section page-geometry simplification (#513): a docx document with **mixed page sizes / orientation** (e.g. a landscape section mid-document) now renders each page at its true size. Per ECMA-376 **§17.6.13** (`<w:pgSz>`) / **§17.6.11** (`<w:pgMar>`), page size and margins are per-section properties; previously mid-body `SectionBreak`s discarded them and every page was sized from the body-level `doc.section`.

This is **WS1 of the continuous-scroll-viewer workstream (#572)** — the engine fact (`pageSize(i)`) the upcoming `DocxScrollViewer` lays out its spacer from.

## Design (additive, type-API non-breaking)

Sections are stored positionally (body-level `sectPr` = the *final* section, §17.6.17), so the fix rides the exact rail `columns`/`headers`/`footers` already use:

- **Rust parser**: `SectionGeom` struct; `section_break_element` captures the ending section's `pgSz`/`pgMar` onto `BodyElement::SectionBreak.geom` (`None` when the sectPr declares neither). `parse_section` now consumes the same extractor — spec defaults live in one place (`spec_default_geom`).
- **TS model**: mirrored `SectionGeom`, `sectionBreak.geom?`, `PaginatedBodyElement.sectionGeom?` — all optional, `doc.section` untouched.
- **Paginator**: `computePages` tracks `currentSectionGeom` (reassigned at each break, stamped on every element); page frame (`bodyTopPt`/`bodyBottomPt`/`fullContentH`) reads the active section, so pagination breaks correctly when page height changes mid-document. Paragraph/table split stamps thread the geometry closure.
- **HF reserves**: `computeHeaderReserves`/`computeFooterReserves` read the page's stamped margins instead of body-level (phantom-reserve fix).
- **Renderer**: `resolvePageSection` returns the page's geometry; `renderDocumentToCanvas` sizes each page from `{ ...doc.section, ...pageGeom }` — paint-time HF placement now agrees with the reserve pass.
- **Fact API**: `DocumentMeta.pageSizes[]` (worker) + `DocxDocument.pageSize(i)` (both modes, clamped, returns a copy).

**Documented residuals** (in-code comments): HF content is still *measured* at body-level width (matters only for mixed page widths + wrapping headers); continuous breaks activate new geometry mid-page (§17.18.77 specifies inheritance only — Word's next-page deferral is runtime behavior, not spec).

## Behavior change

- Single-section documents: **byte-identical** (VRT 21/21 against existing references, no ref updates).
- Multi-section documents with mixed geometry: rendered output and `pageCount` can change — this is the bug fix.

## Verification

- vitest: docx suite **57 files / 338 tests** green (10 new per-section geometry tests, Red→Green verified per task; plan-fixture flaws caught and corrected during review).
- Rust: `cargo test --workspace` (454), `cargo fmt`, `clippy -D warnings` — clean.
- Root `pnpm typecheck` (incl. vscode-extension) — clean.
- Local VRT without `UPDATE_REFS` — 21/21.
- Every task passed independent spec-compliance + code-quality review; all findings addressed in follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)