### PR TITLE
feat(core): scroll-viewer pure primitives — computeVisibleRange + zoomStepScale hoist (design §5.1/§5.2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,6 +232,9 @@ export { nextVisibleIndex, resolveVisibleIndex, countVisible } from './nav/visib
 // Virtualization range math for the continuous-scroll viewers (DocxScrollViewer /
 // PptxScrollViewer): pure prefix-sum + binary-search over per-item heights. No DOM.
 export { computeVisibleRange, type VisibleRange } from './layout/virtual-scroll';
+// Shared exponential wheel/pinch zoom step (Ctrl/⌘+wheel). Pure — the caller
+// clamps to its own [zoomMin, zoomMax]. Used by XlsxViewer + the scroll viewers.
+export { zoomStepScale } from './interaction/zoom';
 // Format-agnostic font design line-metrics (OS/2 win / hhea sums) for faces the
 // browser substitutes with different metrics — shared so docx (Word's design
 // line box), pptx and xlsx can size line boxes / floor single-line height

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -229,6 +229,9 @@ export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-pos
 // Format-agnostic index navigation for hidden-item "skip" mode (pptx hidden
 // slides, xlsx hidden sheets): pure math over an isHidden(i) callback.
 export { nextVisibleIndex, resolveVisibleIndex, countVisible } from './nav/visible-index';
+// Virtualization range math for the continuous-scroll viewers (DocxScrollViewer /
+// PptxScrollViewer): pure prefix-sum + binary-search over per-item heights. No DOM.
+export { computeVisibleRange, type VisibleRange } from './layout/virtual-scroll';
 // Format-agnostic font design line-metrics (OS/2 win / hhea sums) for faces the
 // browser substitutes with different metrics — shared so docx (Word's design
 // line box), pptx and xlsx can size line boxes / floor single-line height

--- a/packages/core/src/interaction/zoom.test.ts
+++ b/packages/core/src/interaction/zoom.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { zoomStepScale } from './zoom.js';
+
+/**
+ * Ctrl/⌘ + wheel (and trackpad pinch, which the browser reports as a ctrl-wheel)
+ * zoom. The old handler ignored `deltaY` magnitude and added a fixed ±0.1 per
+ * event, so a trackpad pinch — which fires a high-frequency stream of small
+ * wheel events — zoomed far too fast. `zoomStepScale` makes the step
+ * exponential in `deltaY`, so the *total* zoom over a gesture is
+ * `exp(-k·Σ deltaY)` and depends only on the total scroll distance, not on how
+ * many events the OS splits it into.
+ */
+describe('zoomStepScale (ctrl/pinch zoom)', () => {
+  it('scrolling up / pinching out (deltaY < 0) zooms in', () => {
+    expect(zoomStepScale(1, -10)).toBeGreaterThan(1);
+  });
+
+  it('scrolling down / pinching in (deltaY > 0) zooms out', () => {
+    expect(zoomStepScale(1, 10)).toBeLessThan(1);
+  });
+
+  it('honors deltaY magnitude (a bigger delta zooms more)', () => {
+    const small = zoomStepScale(1, -2) - 1;
+    const big = zoomStepScale(1, -20) - 1;
+    expect(big).toBeGreaterThan(small);
+  });
+
+  it('is resolution-independent: two small events ≈ one event of their sum', () => {
+    const twoSteps = zoomStepScale(zoomStepScale(1, -5), -5);
+    const oneStep = zoomStepScale(1, -10);
+    expect(twoSteps).toBeCloseTo(oneStep, 10);
+  });
+
+  it('is symmetric: zooming in then out by the same delta returns to start', () => {
+    expect(zoomStepScale(zoomStepScale(1, -8), 8)).toBeCloseTo(1, 10);
+  });
+
+  it('scales relative to the current zoom (multiplicative, not additive)', () => {
+    // Same delta from 200% must move proportionally more than from 100%.
+    const from1 = zoomStepScale(1, -10) - 1;
+    const from2 = zoomStepScale(2, -10) - 2;
+    expect(from2).toBeCloseTo(from1 * 2, 10);
+  });
+});

--- a/packages/core/src/interaction/zoom.ts
+++ b/packages/core/src/interaction/zoom.ts
@@ -1,0 +1,28 @@
+/** Ctrl/⌘ + wheel (and trackpad pinch) zoom sensitivity. `deltaY` is multiplied
+ *  by this before `exp()`. Purely an interaction-feel constant (no ECMA-376
+ *  bearing); lower = gentler. */
+const ZOOM_WHEEL_SENSITIVITY = 0.01;
+
+/**
+ * New scale for one wheel/pinch zoom step. The step is *exponential* in
+ * `deltaY` rather than a fixed increment, which fixes two problems with a
+ * sign-only `scale ± 0.1`:
+ *
+ *  - A trackpad pinch arrives as a high-frequency stream of small-`deltaY`
+ *    wheel events; a fixed per-event increment compounds across dozens of
+ *    events per gesture and zooms wildly. Because `exp(-k·a)·exp(-k·b) =
+ *    exp(-k·(a+b))`, the total zoom here depends only on the summed `deltaY`
+ *    of the gesture, not on how many events the OS chops it into — so a pinch
+ *    and a mouse wheel covering the same distance zoom by the same amount.
+ *  - It is multiplicative, so a step feels proportional at every zoom level
+ *    (the old additive `+0.1` was huge at 20% and tiny at 400%), and exactly
+ *    symmetric: zooming in then out by the same delta returns to the start.
+ *
+ * Negative `deltaY` (scroll up / pinch out) zooms in. The result is unclamped
+ * and unsnapped; the caller clamps to its `[zoomMin, zoomMax]` range (and, for
+ * XlsxViewer, snaps to whole percent). Shared by XlsxViewer and the two
+ * continuous-scroll viewers (design §5.2).
+ */
+export function zoomStepScale(currentScale: number, deltaY: number): number {
+  return currentScale * Math.exp(-deltaY * ZOOM_WHEEL_SENSITIVITY);
+}

--- a/packages/core/src/layout/virtual-scroll.test.ts
+++ b/packages/core/src/layout/virtual-scroll.test.ts
@@ -127,4 +127,16 @@ describe('computeVisibleRange — degenerate inputs', () => {
     expect(r.topIndex).toBe(0);
     expect(r.start).toBe(0);
   });
+
+  it('viewport top inside a gap is attributed to the PRECEDING item', () => {
+    // offsets = [0, 110, 220]; scrollTop 105 is strictly inside the gap 100..110
+    // between items 0 and 1. Convention (pinned): the gap is trailing padding of
+    // the preceding item ⇒ topIndex 0 (mount-safe; flips to 1 exactly at 110).
+    const r = computeVisibleRange([100, 100, 100], 10, 105, 50, 0);
+    expect(r.topIndex).toBe(0);
+    expect(r.start).toBe(0);
+    expect(r.end).toBe(1); // item 1 begins (110) before the viewport bottom (155)
+    // Exactly at the next item's offset the attribution flips.
+    expect(computeVisibleRange([100, 100, 100], 10, 110, 50, 0).topIndex).toBe(1);
+  });
 });

--- a/packages/core/src/layout/virtual-scroll.test.ts
+++ b/packages/core/src/layout/virtual-scroll.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { computeVisibleRange } from './virtual-scroll.js';
+
+// Design §5.1 contract. computeVisibleRange(heights, gap, scrollTop,
+// viewportHeight, overscan) → { start, end, topIndex, offsets, totalHeight }.
+// offsets[i] = Σ heights[0..i-1] + i*gap; totalHeight = Σ heights + (n-1)*gap
+// (gap BETWEEN items only, none after the last). start/end include overscan
+// (clamped to [0,n-1]); topIndex is the first item intersecting the viewport
+// top, EXCLUDING overscan.
+
+describe('computeVisibleRange — offsets + totalHeight (gap arithmetic)', () => {
+  it('computes prefix-sum offsets with a leading gap per item and gap only between items', () => {
+    // 3 uniform 100-tall items, gap 10: offsets 0, 110, 220; total = 300 + 2*10 = 320.
+    const r = computeVisibleRange([100, 100, 100], 10, 0, 1000, 0);
+    expect(r.offsets).toEqual([0, 110, 220]);
+    expect(r.totalHeight).toBe(320);
+  });
+
+  it('variable heights: offsets follow Σ heights[0..i-1] + i*gap', () => {
+    // heights 50, 200, 30, gap 8 → offsets 0, 58, 266; total = 280 + 2*8 = 296.
+    const r = computeVisibleRange([50, 200, 30], 8, 0, 10, 0);
+    expect(r.offsets).toEqual([0, 58, 266]);
+    expect(r.totalHeight).toBe(296);
+  });
+
+  it('single item has no gap in totalHeight', () => {
+    const r = computeVisibleRange([120], 16, 0, 500, 0);
+    expect(r.offsets).toEqual([0]);
+    expect(r.totalHeight).toBe(120);
+  });
+
+  it('tolerates zero-height items', () => {
+    // heights 100, 0, 100, gap 10 → offsets 0, 110, 120; total = 200 + 2*10 = 220.
+    const r = computeVisibleRange([100, 0, 100], 10, 0, 1000, 0);
+    expect(r.offsets).toEqual([0, 110, 120]);
+    expect(r.totalHeight).toBe(220);
+  });
+});
+
+describe('computeVisibleRange — visible range (uniform)', () => {
+  // 10 items of 100, gap 0. Viewport 250 tall.
+  const heights = Array.from({ length: 10 }, () => 100);
+
+  it('at scrollTop 0 with no overscan mounts the items beginning within the viewport', () => {
+    const r = computeVisibleRange(heights, 0, 0, 250, 0);
+    // items 0 (0..100), 1 (100..200), 2 (200..300 begins at 200 < 250) begin within [0,250).
+    expect(r.topIndex).toBe(0);
+    expect(r.start).toBe(0);
+    expect(r.end).toBe(2);
+  });
+
+  it('scrolled to 250: topIndex is the item under the viewport top', () => {
+    const r = computeVisibleRange(heights, 0, 250, 250, 0);
+    // top edge 250 → item 2 (200..300) intersects the top. Bottom edge 500 →
+    // items whose top < 500: up to index 4 (400..500 begins at 400 < 500).
+    expect(r.topIndex).toBe(2);
+    expect(r.start).toBe(2);
+    expect(r.end).toBe(4);
+  });
+});
+
+describe('computeVisibleRange — overscan clipping at both ends', () => {
+  const heights = Array.from({ length: 10 }, () => 100);
+
+  it('clips overscan at the top (cannot go below 0)', () => {
+    const r = computeVisibleRange(heights, 0, 0, 250, 2);
+    expect(r.topIndex).toBe(0);
+    expect(r.start).toBe(0);        // 0 - 2 clamped to 0
+    expect(r.end).toBe(4);          // lastVisible 2 + overscan 2
+  });
+
+  it('clips overscan at the bottom (cannot exceed n-1)', () => {
+    // scrollTop near the end so lastVisible ≈ 9; +2 overscan clamps to 9.
+    const r = computeVisibleRange(heights, 0, 900, 250, 2);
+    expect(r.topIndex).toBe(9);
+    expect(r.end).toBe(9);          // 9 + 2 clamped to 9
+    expect(r.start).toBe(7);        // 9 - 2
+  });
+
+  it('applies overscan symmetrically in the middle', () => {
+    const r = computeVisibleRange(heights, 0, 300, 200, 1);
+    // top 300 → topIndex 3; bottom 500 → lastVisible 4 (top 400 < 500).
+    expect(r.topIndex).toBe(3);
+    expect(r.start).toBe(2);        // 3 - 1
+    expect(r.end).toBe(5);          // 4 + 1
+  });
+});
+
+describe('computeVisibleRange — topIndex vs start distinction', () => {
+  it('topIndex excludes overscan; start includes it', () => {
+    const heights = Array.from({ length: 8 }, () => 50);
+    const r = computeVisibleRange(heights, 0, 200, 100, 2);
+    // top 200 → topIndex 4 (200..250). start = 4 - 2 = 2 (overscan). They differ.
+    expect(r.topIndex).toBe(4);
+    expect(r.start).toBe(2);
+    expect(r.topIndex).not.toBe(r.start);
+  });
+});
+
+describe('computeVisibleRange — degenerate inputs', () => {
+  it('empty heights → empty mount range', () => {
+    const r = computeVisibleRange([], 16, 0, 500, 1);
+    expect(r).toEqual({ start: 0, end: -1, topIndex: 0, offsets: [], totalHeight: 0 });
+    // start > end ⇒ a `for (i = start; i <= end; i++)` mount loop runs zero times.
+    expect(r.start).toBeGreaterThan(r.end);
+  });
+
+  it('single item, scrollTop 0', () => {
+    const r = computeVisibleRange([300], 16, 0, 500, 1);
+    expect(r.topIndex).toBe(0);
+    expect(r.start).toBe(0);
+    expect(r.end).toBe(0);
+    expect(r.totalHeight).toBe(300);
+  });
+
+  it('scrollTop past the end clamps topIndex/end to the last item', () => {
+    const heights = [100, 100, 100];
+    const r = computeVisibleRange(heights, 0, 99999, 250, 1);
+    expect(r.topIndex).toBe(2);     // clamped to n-1
+    expect(r.end).toBe(2);          // clamped to n-1
+    expect(r.start).toBe(1);        // 2 - 1
+  });
+
+  it('negative scrollTop behaves like 0', () => {
+    const heights = [100, 100, 100];
+    const r = computeVisibleRange(heights, 0, -50, 150, 0);
+    expect(r.topIndex).toBe(0);
+    expect(r.start).toBe(0);
+  });
+});

--- a/packages/core/src/layout/virtual-scroll.ts
+++ b/packages/core/src/layout/virtual-scroll.ts
@@ -8,11 +8,17 @@
  * (docs/dev-notes/2026-07-01-scroll-viewer-design.md).
  */
 export interface VisibleRange {
-  /** First index to mount (inclusive, includes overscan). Empty ⇒ 0 with end -1. */
+  /** First index to mount (inclusive, includes overscan). `start > end` ⇒ nothing
+   *  to mount (empty input, or a 0-height viewport whose top sits exactly on an
+   *  item boundary) — mount loops over `[start, end]` naturally run zero times. */
   start: number;
-  /** Last index to mount (inclusive, includes overscan). Empty ⇒ -1. */
+  /** Last index to mount (inclusive, includes overscan). Empty input ⇒ -1. */
   end: number;
-  /** First item intersecting the viewport top (EXCLUDES overscan) — for onVisiblePageChange. */
+  /** First item intersecting the viewport top (EXCLUDES overscan) — for
+   *  onVisiblePageChange. A viewport top strictly inside the gap BETWEEN items i
+   *  and i+1 is attributed to item i (gap = trailing padding of the preceding
+   *  item — the standard virtualization convention; mount-safe, and flips to i+1
+   *  exactly at `offsets[i+1]`). */
   topIndex: number;
   /** Top offset (px) of every item i: Σ heights[0..i-1] + i*gap. length = heights.length. */
   offsets: number[];

--- a/packages/core/src/layout/virtual-scroll.ts
+++ b/packages/core/src/layout/virtual-scroll.ts
@@ -1,0 +1,93 @@
+/**
+ * Virtualization range math for the continuous-scroll viewers (DocxScrollViewer /
+ * PptxScrollViewer). Pure and DOM-free — the viewer owns the scroll surface and
+ * the slot pool (design §6); this only answers "given the heights, the gap, and
+ * the current scrollTop, which item indices must be mounted, where does each
+ * item sit, and how tall is the whole scroll region?". Prefix-sum offsets +
+ * binary search of the first visible index. See design §5.1
+ * (docs/dev-notes/2026-07-01-scroll-viewer-design.md).
+ */
+export interface VisibleRange {
+  /** First index to mount (inclusive, includes overscan). Empty ⇒ 0 with end -1. */
+  start: number;
+  /** Last index to mount (inclusive, includes overscan). Empty ⇒ -1. */
+  end: number;
+  /** First item intersecting the viewport top (EXCLUDES overscan) — for onVisiblePageChange. */
+  topIndex: number;
+  /** Top offset (px) of every item i: Σ heights[0..i-1] + i*gap. length = heights.length. */
+  offsets: number[];
+  /** Σ heights + (n-1)*gap (gap between items only, none after the last) → spacer height. */
+  totalHeight: number;
+}
+
+/** Clamp `v` to `[lo, hi]` (hi < lo yields lo — only reached when n === 0, guarded upstream). */
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/**
+ * Compute which item slots to mount for a vertical virtualized scroll region.
+ *
+ * @param heights        per-item extent along the scroll axis (px), in order.
+ * @param gap            px between adjacent items (contributes BETWEEN items only,
+ *                       never before the first nor after the last).
+ * @param scrollTop      current scroll offset (px); negative is treated as 0 via
+ *                       the search / clamps.
+ * @param viewportHeight visible height of the scroll surface (px).
+ * @param overscan       extra items kept mounted beyond the viewport on each side.
+ * @returns a {@link VisibleRange}. Empty `heights` ⇒
+ *          `{ start: 0, end: -1, topIndex: 0, offsets: [], totalHeight: 0 }`
+ *          (an empty mount range: `start > end`).
+ */
+export function computeVisibleRange(
+  heights: number[],
+  gap: number,
+  scrollTop: number,
+  viewportHeight: number,
+  overscan: number,
+): VisibleRange {
+  const n = heights.length;
+  if (n === 0) {
+    return { start: 0, end: -1, topIndex: 0, offsets: [], totalHeight: 0 };
+  }
+
+  // Prefix-sum offsets: offsets[i] = Σ heights[0..i-1] + i*gap.
+  const offsets = new Array<number>(n);
+  let acc = 0;
+  for (let i = 0; i < n; i++) {
+    offsets[i] = acc + i * gap;
+    acc += heights[i];
+  }
+  // Σ heights + (n-1) gaps — no trailing gap after the last item.
+  const totalHeight = acc + (n - 1) * gap;
+
+  // topIndex = largest i with offsets[i] <= scrollTop (the item under the
+  // viewport top), clamped to [0, n-1]. Binary search over the non-decreasing
+  // offsets: find the first index whose offset EXCEEDS scrollTop, minus one.
+  let lo = 0;
+  let hi = n; // exclusive upper bound
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (offsets[mid] <= scrollTop) lo = mid + 1;
+    else hi = mid;
+  }
+  const topIndex = clamp(lo - 1, 0, n - 1);
+
+  // lastVisible = last index whose item TOP begins within the viewport
+  // (offsets[i] < scrollTop + viewportHeight). Same binary search on the
+  // viewport bottom edge.
+  const bottom = scrollTop + viewportHeight;
+  lo = 0;
+  hi = n;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (offsets[mid] < bottom) lo = mid + 1;
+    else hi = mid;
+  }
+  const lastVisible = clamp(lo - 1, 0, n - 1);
+
+  const start = clamp(topIndex - overscan, 0, n - 1);
+  const end = clamp(lastVisible + overscan, 0, n - 1);
+
+  return { start, end, topIndex, offsets, totalHeight };
+}

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,7 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { ViewportRange, Worksheet, XlsxComment } from './types.js';
 import type { LoadOptions } from '@silurus/ooxml-core';
-import { nextVisibleIndex, resolveVisibleIndex, countVisible } from '@silurus/ooxml-core';
+import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
@@ -10,6 +10,11 @@ import {
   computeValidationPanelPosition,
   type ResolvedList,
 } from './validation-list.js';
+
+// Re-exported for the existing xlsx zoom tests (resize-zoom.test.ts imports it
+// from this module) and any consumer that referenced it here before it moved to
+// @silurus/ooxml-core. The single source of truth is core (design §5.2).
+export { zoomStepScale } from '@silurus/ooxml-core';
 
 /** Delay (ms) before a hovered comment popup appears. A short hover dwell
  *  prevents the popup from flickering while the cursor sweeps across many
@@ -228,34 +233,6 @@ export function selectionOverlayStyle(color: string): { border: string; backgrou
     border: `2px solid ${color}`,
     background: `color-mix(in srgb, ${color} 8%, transparent)`,
   };
-}
-
-/** Ctrl/⌘ + wheel (and trackpad pinch) zoom sensitivity. `deltaY` is multiplied
- *  by this before `exp()`. Purely an interaction-feel constant (no ECMA-376
- *  bearing); lower = gentler. */
-const ZOOM_WHEEL_SENSITIVITY = 0.01;
-
-/**
- * New cell scale for one wheel/pinch zoom step. The step is *exponential* in
- * `deltaY` rather than a fixed increment, which fixes two problems with a
- * sign-only `scale ± 0.1`:
- *
- *  - A trackpad pinch arrives as a high-frequency stream of small-`deltaY`
- *    wheel events; a fixed per-event increment compounds across dozens of
- *    events per gesture and zooms wildly. Because `exp(-k·a)·exp(-k·b) =
- *    exp(-k·(a+b))`, the total zoom here depends only on the summed `deltaY`
- *    of the gesture, not on how many events the OS chops it into — so a pinch
- *    and a mouse wheel covering the same distance zoom by the same amount.
- *  - It is multiplicative, so a step feels proportional at every zoom level
- *    (the old additive `+0.1` was huge at 20% and tiny at 400%), and exactly
- *    symmetric: zooming in then out by the same delta returns to the start.
- *
- * Negative `deltaY` (scroll up / pinch out) zooms in. The result is unclamped
- * and unsnapped; {@link XlsxViewer.setScale} clamps to `[zoomMin, zoomMax]` and
- * snaps to whole percent.
- */
-export function zoomStepScale(currentScale: number, deltaY: number): number {
-  return currentScale * Math.exp(-deltaY * ZOOM_WHEEL_SENSITIVITY);
 }
 
 interface SheetAxes { col: AxisMetrics; row: AxisMetrics; }


### PR DESCRIPTION
## Summary

**WS2 of the continuous-scroll-viewer workstream (#572)** — the Layer-2 pure primitives both upcoming scroll viewers (`DocxScrollViewer` / `PptxScrollViewer`) consume. Pure math only; no DOM, no behavior change to any shipped component.

- **`computeVisibleRange`** (`core/layout/virtual-scroll.ts`, design §5.1): prefix-sum + binary-search virtualization range math — which item slots to mount for a given `scrollTop`, each item's offset, and the spacer height. Returns `{ start, end, topIndex, offsets, totalHeight }` (`topIndex` excludes overscan, for `onVisiblePageChange`). Edge semantics pinned by 15 tests (empty, single, gap arithmetic, overscan clipping, in-gap attribution, clamps). Follows the `core/nav/visible-index.ts` precedent.
- **`zoomStepScale` hoist** (`core/interaction/zoom.ts`, design §5.2): verbatim move from `XlsxViewer` (single source for the exponential, event-count-independent wheel zoom); xlsx re-imports — behavior-preserving, xlsx public surface unchanged, clamp/snap deliberately left in `XlsxViewer.setScale`.

## Verification

- core layout 15/15, core interaction 6/6, xlsx whole suite 250/250, root `pnpm typecheck` clean.
- Independent review per task: `computeVisibleRange` was brute-force cross-checked against a linear-scan reference over ~250k parameter combinations and mutation-tested (both binary-search off-by-one mutants killed by the committed tests); the zoom hoist was byte-compared against the deleted xlsx code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)