### PR TITLE
refactor(docx,pptx): extract shared text-layer builders from the viewers (design §10)

### DIFF
--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { buildViewerUI } from './DocxViewer.stories';
 import { DocxDocument } from './document';
 import { DocxViewer } from './viewer';
+import { buildDocxTextLayer } from './text-layer';
 import type { DocxTextRunInfo } from './renderer';
 
 type DemoArgs = { width: number };
@@ -52,18 +53,6 @@ function makeStatus(root: HTMLElement): HTMLDivElement {
   return s;
 }
 
-function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {
-  layer.innerHTML = '';
-  for (const run of runs) {
-    const span = document.createElement('span');
-    span.textContent = run.text;
-    span.style.cssText =
-      `position:absolute;left:${run.x}px;top:${run.y}px;` +
-      `font-size:${run.fontSize}px;line-height:${run.h}px;white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
-    layer.appendChild(span);
-  }
-}
-
 export const ScrollView: LayoutStory = {
   name: 'ScrollView — stack all pages',
   render() {
@@ -105,7 +94,7 @@ export const ScrollView: LayoutStory = {
 
           const runs: DocxTextRunInfo[] = [];
           await doc.renderPage(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
-          buildDocxTextLayer(textLayer, runs);
+          buildDocxTextLayer(textLayer, runs, '100%', '100%');
         }
         status.textContent = `Loaded ${doc.pageCount} pages`;
       })

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -1,6 +1,7 @@
 export { DocxDocument, type LoadOptions } from './document';
 export type { WireRenderPageOptions } from './worker-protocol';
 export { DocxViewer, type DocxViewerOptions } from './viewer';
+export { buildDocxTextLayer } from './text-layer';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export { noteText } from './types';
 export type {

--- a/packages/docx/src/text-layer.test.ts
+++ b/packages/docx/src/text-layer.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildDocxTextLayer } from './text-layer.js';
+import type { DocxTextRunInfo } from './renderer';
+
+// The vitest env is `node` (no document). Following renderer.textbox-image.test.ts's
+// vi.stubGlobal pattern, we stub a minimal recording DOM: createElement returns a
+// fake element that records its style props (via a cssText setter that parses
+// `k:v;` pairs), textContent, and appended children. buildDocxTextLayer lays
+// absolutely-positioned <span>s directly on the layer, one per DocxTextRunInfo.
+
+interface FakeEl {
+  tag: string;
+  textContent: string;
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  appendChild(c: FakeEl): void;
+}
+
+function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    textContent: '',
+    innerHTML: '',
+    children: [],
+    // A cssText setter that parses the `k:v;k:v;` string into individual props,
+    // so tests can assert either the raw cssText or a parsed key.
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const idx = decl.indexOf(':');
+            if (idx > 0) target[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+  };
+  return el;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+function run(partial: Partial<DocxTextRunInfo>): DocxTextRunInfo {
+  return {
+    text: 'X',
+    x: 0,
+    y: 0,
+    w: 10,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    ...partial,
+  };
+}
+
+describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () => {
+  it('sizes the layer to the passed canvas dimensions and clears prior content', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    layer.innerHTML = 'STALE';
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, [], '640px', '480px');
+    expect(layer.innerHTML).toBe(''); // cleared
+    expect(layer.style.width).toBe('640px');
+    expect(layer.style.height).toBe('480px');
+    expect(layer.children.length).toBe(0);
+  });
+
+  it('lays one absolutely-positioned span per run with the shipped inline styles', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [
+      run({ text: 'Hello', x: 12, y: 34, h: 16, font: 'bold 14px Arial' }),
+      run({ text: 'World', x: 50, y: 34, h: 16, font: '14px Arial' }),
+    ];
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '700px', '900px');
+
+    expect(layer.children.length).toBe(2);
+    const [a, b] = layer.children;
+    expect(a.tag).toBe('span');
+    expect(a.textContent).toBe('Hello');
+    // Shipped style contract: absolute position from run.x/run.y, the CSS `font`
+    // shorthand BEFORE line-height, letter-spacing reset, transparent selectable text.
+    expect(a.style.position).toBe('absolute');
+    expect(a.style.left).toBe('12px');
+    expect(a.style.top).toBe('34px');
+    expect(a.style.font).toBe('bold 14px Arial');
+    expect(a.style['line-height']).toBe('16px');
+    expect(a.style['letter-spacing']).toBe('0');
+    expect(a.style['white-space']).toBe('pre');
+    expect(a.style.color).toBe('transparent');
+    expect(a.style.cursor).toBe('text');
+    expect(a.style['pointer-events']).toBe('all');
+    expect(b.textContent).toBe('World');
+    expect(b.style.left).toBe('50px');
+  });
+});

--- a/packages/docx/src/text-layer.test.ts
+++ b/packages/docx/src/text-layer.test.ts
@@ -99,6 +99,11 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
     expect(a.style.color).toBe('transparent');
     expect(a.style.cursor).toBe('text');
     expect(a.style['pointer-events']).toBe('all');
+    // Declaration ORDER is load-bearing: the `font` shorthand resets line-height
+    // to `normal` in real browsers, so `line-height` must come AFTER `font` in the
+    // cssText. The parsed-prop asserts above cannot detect a reorder — pin it on
+    // the raw string.
+    expect(a.style.cssText).toMatch(/font:[^;]+;line-height:/);
     expect(b.textContent).toBe('World');
     expect(b.style.left).toBe('50px');
   });

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -1,0 +1,45 @@
+import type { DocxTextRunInfo } from './renderer';
+
+/**
+ * Build the transparent text-selection overlay for a rendered docx page: one
+ * absolutely-positioned, color-transparent `<span>` per {@link DocxTextRunInfo}
+ * (emitted by `renderPage`'s `onTextRun`), so the browser's native selection
+ * lands on the drawn glyphs. Extracted verbatim from `DocxViewer._buildTextLayer`
+ * so both the pager (DocxViewer) and the continuous-scroll viewer (DocxScrollViewer)
+ * share one implementation; also public API for integrators building their own
+ * overlay (design §10). MAIN render mode only — `onTextRun` cannot cross the
+ * worker boundary.
+ *
+ * @param layer           the overlay div (position:relative parent expected).
+ * @param runs            per-run geometry from `renderPage({ onTextRun })`.
+ * @param canvasCssWidth  the rendered canvas's CSS width (e.g. `"700px"`), used
+ *                        to size the overlay to match the canvas.
+ * @param canvasCssHeight the rendered canvas's CSS height.
+ */
+export function buildDocxTextLayer(
+  layer: HTMLDivElement,
+  runs: DocxTextRunInfo[],
+  canvasCssWidth: string,
+  canvasCssHeight: string,
+): void {
+  layer.innerHTML = '';
+  layer.style.width = canvasCssWidth;
+  layer.style.height = canvasCssHeight;
+
+  for (const run of runs) {
+    const span = document.createElement('span');
+    span.textContent = run.text;
+    // The `font` shorthand must precede `line-height` because the shorthand
+    // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
+    // CSS rule cannot drift the trailing edge of the selection. Kerning /
+    // ligatures are left at the browser default ('auto') because canvas
+    // `measureText` / `fillText` also apply them by default — forcing them
+    // off here would make the span wider than the drawn text.
+    span.style.cssText =
+      `position:absolute;` +
+      `left:${run.x}px;top:${run.y}px;` +
+      `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
+      `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
+    layer.appendChild(span);
+  }
+}

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -2,6 +2,7 @@ import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
 import type { RenderPageOptions } from './types';
 import type { DocxTextRunInfo } from './renderer';
+import { buildDocxTextLayer } from './text-layer';
 
 export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   container?: HTMLElement;
@@ -164,25 +165,11 @@ export class DocxViewer {
   }
 
   private _buildTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {
-    layer.innerHTML = '';
-    layer.style.width = `${this._canvas.style.width || this._canvas.width + 'px'}`;
-    layer.style.height = `${this._canvas.style.height || this._canvas.height + 'px'}`;
-
-    for (const run of runs) {
-      const span = document.createElement('span');
-      span.textContent = run.text;
-      // The `font` shorthand must precede `line-height` because the shorthand
-      // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
-      // CSS rule cannot drift the trailing edge of the selection. Kerning /
-      // ligatures are left at the browser default ('auto') because canvas
-      // `measureText` / `fillText` also apply them by default — forcing them
-      // off here would make the span wider than the drawn text.
-      span.style.cssText =
-        `position:absolute;` +
-        `left:${run.x}px;top:${run.y}px;` +
-        `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
-        `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
-      layer.appendChild(span);
-    }
+    buildDocxTextLayer(
+      layer,
+      runs,
+      this._canvas.style.width || this._canvas.width + 'px',
+      this._canvas.style.height || this._canvas.height + 'px',
+    );
   }
 }

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -3,6 +3,7 @@ import { buildViewerUI } from './PptxViewer.stories';
 import { PptxPresentation } from './presentation';
 import { PptxViewer } from './viewer';
 import type { PptxTextRunInfo } from './renderer';
+import { buildPptxTextLayer } from './text-layer';
 
 type DemoArgs = { width: number };
 type LayoutArgs = Record<string, never>;
@@ -48,37 +49,6 @@ function makeStatus(root: HTMLElement): HTMLDivElement {
   s.textContent = 'Loading…';
   root.appendChild(s);
   return s;
-}
-
-function buildPptxTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
-  layer.innerHTML = '';
-  layer.style.width = `${cssWidth}px`;
-  layer.style.height = `${cssHeight}px`;
-
-  const shapeMap = new Map<string, HTMLDivElement>();
-  for (const run of runs) {
-    const totalRot = run.rotation + (run.textBodyRotation ?? 0);
-    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
-    if (!shapeMap.has(key)) {
-      const div = document.createElement('div');
-      div.style.cssText =
-        `position:absolute;left:${run.shapeX}px;top:${run.shapeY}px;` +
-        `width:${run.shapeW}px;height:${run.shapeH}px;pointer-events:all;overflow:hidden;`;
-      if (totalRot !== 0) {
-        div.style.transformOrigin = 'center center';
-        div.style.transform = `rotate(${totalRot}deg)`;
-      }
-      shapeMap.set(key, div);
-      layer.appendChild(div);
-    }
-    const shape = shapeMap.get(key) as HTMLDivElement;
-    const span = document.createElement('span');
-    span.textContent = run.text;
-    span.style.cssText =
-      `position:absolute;left:${run.inShapeX}px;top:${run.inShapeY}px;` +
-      `font-size:${run.fontSize}px;line-height:${run.h}px;white-space:pre;color:transparent;cursor:text;`;
-    shape.appendChild(span);
-  }
 }
 
 export const ScrollView: LayoutStory = {

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -6,6 +6,7 @@ export {
   type RenderSlideToBitmapOptions,
 } from './presentation';
 export { renderSlide, type RenderOptions, type PptxTextRunInfo, type TextRunCallback } from './renderer';
+export { buildPptxTextLayer } from './text-layer';
 export type { PresentationHandle } from './presentation-handle';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export type {

--- a/packages/pptx/src/text-layer.test.ts
+++ b/packages/pptx/src/text-layer.test.ts
@@ -92,6 +92,8 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     expect(spanA.style.position).toBe('absolute');
     expect(spanA.style.left).toBe('2px');
     expect(spanA.style.top).toBe('4px');
+    expect(spanA.style.font).toBe('12px serif');
+    expect(spanA.style['line-height']).toBe('12px');
     expect(spanA.style['letter-spacing']).toBe('0');
     expect(spanA.style.color).toBe('transparent');
   });

--- a/packages/pptx/src/text-layer.test.ts
+++ b/packages/pptx/src/text-layer.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildPptxTextLayer } from './text-layer.js';
+import type { PptxTextRunInfo } from './renderer';
+
+// node env: no document. Recording DOM stub (see docx text-layer.test.ts). pptx
+// groups runs into one positioned <div> per shape frame (keyed by shape geom +
+// total rotation) and applies a CSS rotate() when the shape is rotated; each
+// run's <span> is absolutely positioned INSIDE its shape div.
+
+interface FakeEl {
+  tag: string;
+  textContent: string;
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  appendChild(c: FakeEl): void;
+}
+function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    textContent: '',
+    innerHTML: '',
+    children: [],
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const i = decl.indexOf(':');
+            if (i > 0) target[decl.slice(0, i).trim()] = decl.slice(i + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+  };
+  return el;
+}
+afterEach(() => vi.unstubAllGlobals());
+
+function run(p: Partial<PptxTextRunInfo>): PptxTextRunInfo {
+  return {
+    text: 'X',
+    inShapeX: 0,
+    inShapeY: 0,
+    w: 10,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    shapeX: 0,
+    shapeY: 0,
+    shapeW: 100,
+    shapeH: 50,
+    rotation: 0,
+    ...p,
+  };
+}
+
+describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () => {
+  it('sizes the layer and groups two runs of the same shape under one div', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    layer.innerHTML = 'STALE';
+    const runs = [
+      run({ text: 'A', inShapeX: 2, inShapeY: 4, shapeX: 10, shapeY: 20, shapeW: 200, shapeH: 80 }),
+      run({ text: 'B', inShapeX: 2, inShapeY: 24, shapeX: 10, shapeY: 20, shapeW: 200, shapeH: 80 }),
+    ];
+    buildPptxTextLayer(layer as unknown as HTMLDivElement, runs, 960, 540);
+
+    expect(layer.innerHTML).toBe('');
+    expect(layer.style.width).toBe('960px');
+    expect(layer.style.height).toBe('540px');
+    // Same shape frame + rotation ⇒ ONE group div, holding both spans.
+    expect(layer.children.length).toBe(1);
+    const shapeDiv = layer.children[0];
+    expect(shapeDiv.tag).toBe('div');
+    expect(shapeDiv.style.position).toBe('absolute');
+    expect(shapeDiv.style.left).toBe('10px');
+    expect(shapeDiv.style.top).toBe('20px');
+    expect(shapeDiv.style.width).toBe('200px');
+    expect(shapeDiv.style.height).toBe('80px');
+    expect(shapeDiv.style.overflow).toBe('hidden');
+    expect(shapeDiv.children.map((c) => c.textContent)).toEqual(['A', 'B']);
+    // Span uses the shipped `font` shorthand + line-height + letter-spacing reset.
+    const spanA = shapeDiv.children[0];
+    expect(spanA.style.position).toBe('absolute');
+    expect(spanA.style.left).toBe('2px');
+    expect(spanA.style.top).toBe('4px');
+    expect(spanA.style['letter-spacing']).toBe('0');
+    expect(spanA.style.color).toBe('transparent');
+  });
+
+  it('splits runs of different shapes into separate group divs', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildPptxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [run({ text: 'A', shapeX: 0, shapeY: 0 }), run({ text: 'B', shapeX: 300, shapeY: 100 })],
+      960,
+      540,
+    );
+    expect(layer.children.length).toBe(2);
+  });
+
+  it('applies a CSS rotate() to a rotated shape (rotation + textBodyRotation)', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // rotation 30 + vertical text body 90 ⇒ totalRot 120.
+    buildPptxTextLayer(layer as unknown as HTMLDivElement, [run({ text: 'R', rotation: 30, textBodyRotation: 90 })], 960, 540);
+    const shapeDiv = layer.children[0];
+    // The verbatim viewer code sets these via DOM style *properties*
+    // (`div.style.transformOrigin` / `.transform`), not via the `cssText`
+    // string, so the recording stub records them under their camelCase keys.
+    expect(shapeDiv.style.transformOrigin).toBe('center center');
+    expect(shapeDiv.style.transform).toBe('rotate(120deg)');
+  });
+
+  it('does not set a transform for an unrotated shape', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildPptxTextLayer(layer as unknown as HTMLDivElement, [run({ text: 'U', rotation: 0 })], 960, 540);
+    const shapeDiv = layer.children[0];
+    expect(shapeDiv.style.transform ?? '').toBe('');
+  });
+});

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -1,0 +1,68 @@
+import type { PptxTextRunInfo } from './renderer';
+
+/**
+ * Build the transparent text-selection overlay for a rendered pptx slide. Unlike
+ * docx (flat spans), pptx groups runs into one positioned `<div>` per shape frame
+ * (keyed by the shape's geometry + total rotation) and applies a CSS `rotate()` to
+ * the group when the shape is rotated, so the browser selection tracks the drawn,
+ * rotated text as a unit. Each run's `<span>` is absolutely positioned INSIDE its
+ * shape div (`inShapeX`/`inShapeY`). Extracted verbatim from
+ * `PptxViewer._buildTextLayer` so the pager (PptxViewer) and the continuous-scroll
+ * viewer (PptxScrollViewer, WS4) share one implementation; public API for
+ * integrators (design §10). MAIN render mode only — `onTextRun` cannot cross the
+ * worker boundary.
+ *
+ * @param layer     the overlay div.
+ * @param runs      per-run + per-shape geometry from `renderSlide({ onTextRun })`.
+ * @param cssWidth  the rendered canvas's CSS width (px, number).
+ * @param cssHeight the rendered canvas's CSS height (px, number).
+ */
+export function buildPptxTextLayer(
+  layer: HTMLDivElement,
+  runs: PptxTextRunInfo[],
+  cssWidth: number,
+  cssHeight: number,
+): void {
+  layer.innerHTML = '';
+  layer.style.width = `${cssWidth}px`;
+  layer.style.height = `${cssHeight}px`;
+
+  // Group runs by shape (same shapeX/shapeY/rotation)
+  type ShapeKey = string;
+  const shapeMap = new Map<ShapeKey, { div: HTMLDivElement; x: number; y: number; w: number; h: number; rot: number }>();
+
+  for (const run of runs) {
+    const totalRot = run.rotation + (run.textBodyRotation ?? 0);
+    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
+    if (!shapeMap.has(key)) {
+      const div = document.createElement('div');
+      div.style.cssText =
+        `position:absolute;` +
+        `left:${run.shapeX}px;top:${run.shapeY}px;` +
+        `width:${run.shapeW}px;height:${run.shapeH}px;` +
+        `pointer-events:all;overflow:hidden;`;
+      if (totalRot !== 0) {
+        div.style.transformOrigin = 'center center';
+        div.style.transform = `rotate(${totalRot}deg)`;
+      }
+      shapeMap.set(key, { div, x: run.shapeX, y: run.shapeY, w: run.shapeW, h: run.shapeH, rot: totalRot });
+      layer.appendChild(div);
+    }
+
+    const shape = shapeMap.get(key)!;
+    const span = document.createElement('span');
+    span.textContent = run.text;
+    // The `font` shorthand must precede `line-height` because the shorthand
+    // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
+    // CSS rule cannot drift the trailing edge of the selection. Kerning /
+    // ligatures are left at the browser default ('auto') because canvas
+    // `measureText` / `fillText` also apply them by default — forcing them
+    // off here would make the span wider than the drawn text.
+    span.style.cssText =
+      `position:absolute;` +
+      `left:${run.inShapeX}px;top:${run.inShapeY}px;` +
+      `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
+      `white-space:pre;color:transparent;cursor:text;`;
+    shape.div.appendChild(span);
+  }
+}

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -1,4 +1,5 @@
 import type { RenderOptions, PptxTextRunInfo } from './renderer';
+import { buildPptxTextLayer } from './text-layer';
 import { PptxPresentation, type LoadOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible } from './hidden';
@@ -276,48 +277,7 @@ export class PptxViewer {
   }
 
   private _buildTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
-    layer.innerHTML = '';
-    layer.style.width = `${cssWidth}px`;
-    layer.style.height = `${cssHeight}px`;
-
-    // Group runs by shape (same shapeX/shapeY/rotation)
-    type ShapeKey = string;
-    const shapeMap = new Map<ShapeKey, { div: HTMLDivElement; x: number; y: number; w: number; h: number; rot: number }>();
-
-    for (const run of runs) {
-      const totalRot = run.rotation + (run.textBodyRotation ?? 0);
-      const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
-      if (!shapeMap.has(key)) {
-        const div = document.createElement('div');
-        div.style.cssText =
-          `position:absolute;` +
-          `left:${run.shapeX}px;top:${run.shapeY}px;` +
-          `width:${run.shapeW}px;height:${run.shapeH}px;` +
-          `pointer-events:all;overflow:hidden;`;
-        if (totalRot !== 0) {
-          div.style.transformOrigin = 'center center';
-          div.style.transform = `rotate(${totalRot}deg)`;
-        }
-        shapeMap.set(key, { div, x: run.shapeX, y: run.shapeY, w: run.shapeW, h: run.shapeH, rot: totalRot });
-        layer.appendChild(div);
-      }
-
-      const shape = shapeMap.get(key)!;
-      const span = document.createElement('span');
-      span.textContent = run.text;
-      // The `font` shorthand must precede `line-height` because the shorthand
-      // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
-      // CSS rule cannot drift the trailing edge of the selection. Kerning /
-      // ligatures are left at the browser default ('auto') because canvas
-      // `measureText` / `fillText` also apply them by default — forcing them
-      // off here would make the span wider than the drawn text.
-      span.style.cssText =
-        `position:absolute;` +
-        `left:${run.inShapeX}px;top:${run.inShapeY}px;` +
-        `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
-        `white-space:pre;color:transparent;cursor:text;`;
-      shape.div.appendChild(span);
-    }
+    buildPptxTextLayer(layer, runs, cssWidth, cssHeight);
   }
 
   /** Clean up the viewer and terminate the background worker. */


### PR DESCRIPTION
## Summary

**WS3 of the continuous-scroll-viewer workstream (#572).** There was no reusable text-selection-layer builder: each viewer held a private `_buildTextLayer`, and the Storybook examples carried *drifted* local copies (font-size-only styling, no `letter-spacing:0`). This extracts the shipped viewer implementations — byte-verbatim — into public per-package builders:

- **docx**: `buildDocxTextLayer(layer, runs, canvasCssWidth, canvasCssHeight)` (`packages/docx/src/text-layer.ts`) — gains two size params (the private method read `this._canvas`).
- **pptx**: `buildPptxTextLayer(layer, runs, cssWidth, cssHeight)` (`packages/pptx/src/text-layer.ts`) — shape-frame grouping + CSS `rotate()` preserved verbatim (signature unchanged).

Viewers delegate; stories import the canonical builders (their drifted copies deleted — stories thereby inherit the shipped `font` shorthand + `letter-spacing:0`, an intended fidelity upgrade). Deliberately **not** unified across packages: the builders differ structurally (flat spans vs shape grouping/rotation) — per design §10, sharing would be a false abstraction.

Characterization tests (stubbed DOM, node env) pin the output: span geometry/style contracts incl. the load-bearing `font`→`line-height` declaration order (docx) and rotation composition `rotation + textBodyRotation` / grouping collapse (pptx).

## Verification

- docx suite 340/340 (incl. export-completeness), pptx suite 134/134 (incl. export-completeness), root `pnpm typecheck` clean, ast-grep scan clean.
- Independent review per task: extractions mechanically diffed (whitespace-normalized) against the deleted viewer methods — zero differences; review follow-ups hardened the tests (declaration-order pin, font-shorthand pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)