### PR TITLE
feat(docx): DocxScrollViewer — virtualized continuous-scroll viewer (#572)

### DIFF
--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { buildViewerUI } from './DocxViewer.stories';
 import { DocxDocument } from './document';
 import { DocxViewer } from './viewer';
+import { DocxScrollViewer } from './scroll-viewer';
 import { buildDocxTextLayer } from './text-layer';
 import type { DocxTextRunInfo } from './renderer';
 
@@ -97,6 +98,59 @@ export const ScrollView: LayoutStory = {
           buildDocxTextLayer(textLayer, runs, '100%', '100%');
         }
         status.textContent = `Loaded ${doc.pageCount} pages`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};
+
+// The scroll viewer owns a live scroll subscription, a ResizeObserver, and a
+// per-slot canvas pool, so a stale instance left mounted across a Storybook
+// re-render (args change / HMR) would keep observing a detached container and
+// leak canvases. Hold the last instance module-side and destroy it before
+// building a fresh one.
+let scrollViewerInstance: DocxScrollViewer | null = null;
+
+export const ScrollViewer: LayoutStory = {
+  name: 'DocxScrollViewer — virtualized continuous scroll',
+  render() {
+    scrollViewerInstance?.destroy();
+    scrollViewerInstance = null;
+
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'DocxScrollViewer — virtualized (Ctrl/⌘+wheel to zoom)';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    // The viewer owns a container-sized scroll surface; give it a fixed box.
+    const container = document.createElement('div');
+    container.style.cssText = 'height:720px;border:1px solid #ccc;background:#f5f5f5;';
+    root.appendChild(container);
+
+    const viewer = new DocxScrollViewer(container, {
+      gap: 16,
+      overscan: 1,
+      enableTextSelection: true,
+      onVisiblePageChange: (top, total) => {
+        status.textContent = `Page ${top + 1} / ${total}`;
+      },
+      onError: (e) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      },
+    });
+    scrollViewerInstance = viewer;
+    viewer
+      .load(SAMPLE_URL)
+      .then(() => {
+        status.textContent = `Loaded ${viewer.pageCount} pages`;
       })
       .catch((e: Error) => {
         status.textContent = `Error: ${e.message}`;

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -170,6 +170,14 @@ export class DocxDocument {
     return this._getPages().length;
   }
 
+  /** The render mode this engine was loaded with ('main' | 'worker'). A fact for
+   *  integrators and the scroll viewer: an injected engine's mode decides whether
+   *  pages render via renderPage (main) or renderPageToBitmap (worker) — no
+   *  probing (design §11: no silent mis-pathing). */
+  get mode(): 'main' | 'worker' {
+    return this._mode;
+  }
+
   /**
    * The raw parsed document model. Available only in `mode: 'main'`; in
    * `mode: 'worker'` the model stays in the worker and this throws.

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -1,6 +1,7 @@
 export { DocxDocument, type LoadOptions } from './document';
 export type { WireRenderPageOptions } from './worker-protocol';
 export { DocxViewer, type DocxViewerOptions } from './viewer';
+export { DocxScrollViewer, type DocxScrollViewerOptions } from './scroll-viewer';
 export { buildDocxTextLayer } from './text-layer';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 export { noteText } from './types';

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -399,7 +399,7 @@ describe('page-size fact (§17.6.13/§17.6.11) — paginateDocument sectionGeom'
     type Doc = Awaited<ReturnType<typeof DocxDocument.load>>;
     const make = (state: Record<string, unknown>) => {
       const d = Object.create(DocxDocument.prototype) as Doc;
-      Object.assign(d, { _meta: null, _document: null, _pages: null }, state);
+      Object.assign(d, { _meta: null, _document: null, _pages: null, _mode: 'main' }, state);
       return d;
     };
 
@@ -423,5 +423,12 @@ describe('page-size fact (§17.6.13/§17.6.11) — paginateDocument sectionGeom'
 
     // Not loaded (pre-load / post-destroy): {0,0}.
     expect(make({}).pageSize(0)).toEqual({ widthPt: 0, heightPt: 0 });
+
+    // Engine fact (WS4 O1): the render mode is publicly readable so a viewer
+    // receiving an injected engine can route main vs bitmap paths without probing.
+    const workerish = make({ _mode: 'worker' });
+    expect(workerish.mode).toBe('worker');
+    const mainish = make({ _mode: 'main' });
+    expect(mainish.mode).toBe('main');
   });
 });

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -164,12 +164,21 @@ export class FakeDocxEngine {
   createdBitmaps: Array<{ width: number; height: number; close: ReturnType<typeof vi.fn> }> = [];
   constructor(
     private _pageCount: number,
+    // Uniform-page convention: a single-element `_sizes` array means EVERY page
+    // is that size (pageSize clamps the index). T2 variable-height tests pass a
+    // full per-page array instead.
     private _sizes: Array<{ widthPt: number; heightPt: number }>,
-    public throwOnRenderPage = false, // simulate a worker-mode engine
+    private _mode: 'main' | 'worker' = 'main',
     private deferred = false,
   ) {}
   get pageCount(): number {
     return this._pageCount;
+  }
+  /** Mirrors the real `DocxDocument.mode` fact (document.ts) — the exact fact the
+   *  viewer constructor reads to decide the render path (main ⇒ renderPage,
+   *  worker ⇒ renderPageToBitmap). Design §11: no probing / no silent mis-pathing. */
+  get mode(): 'main' | 'worker' {
+    return this._mode;
   }
   pageSize(i: number): { widthPt: number; heightPt: number } {
     const clamped = Math.max(0, Math.min(i, this._sizes.length - 1));
@@ -177,9 +186,15 @@ export class FakeDocxEngine {
     return { widthPt: s.widthPt, heightPt: s.heightPt };
   }
   renderPage(_canvas: unknown, page: number, _opts?: RenderPageOptions): Promise<void> {
-    if (this.throwOnRenderPage) {
-      return Promise.reject(
-        new Error("renderPage(canvas) is unavailable in mode: 'worker'; use renderPageToBitmap()"),
+    if (this._mode === 'worker') {
+      // Record the attempt BEFORE throwing so a test can assert the viewer never
+      // routes a worker-mode engine through renderPage (and detect wrong-path
+      // routing). The real DocxDocument.renderPage is a non-async method that
+      // THROWS synchronously in worker mode — mirror that exactly (do NOT return
+      // Promise.reject), reusing the real error text (document.ts).
+      this.renderCalls.push({ page, resolve: () => {}, reject: () => {} });
+      throw new Error(
+        "renderPage(canvas) is unavailable in mode: 'worker'; use renderPageToBitmap() and paint it via an ImageBitmapRenderingContext",
       );
     }
     return new Promise<void>((resolve, reject) => {

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -1,0 +1,207 @@
+import { vi } from 'vitest';
+import type { DocxDocument } from './document';
+import type { RenderPageOptions } from './types';
+import type { WireRenderPageOptions } from './worker-protocol';
+
+/** A recording fake DOM element. Extends the `FakeEl` pattern from
+ *  text-layer.test.ts with the surface DocxScrollViewer touches: scrollTop,
+ *  clientHeight/Width, event listeners, removeChild/remove, canvas ctx. */
+export interface FakeEl {
+  tag: string;
+  textContent: string;
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  parentElement: FakeEl | null;
+  // canvas-only
+  width: number;
+  height: number;
+  // scrollHost-only (settable by the test to drive the virtualization loop)
+  scrollTop: number;
+  clientHeight: number;
+  clientWidth: number;
+  _listeners: Map<string, Array<(e: unknown) => void>>;
+  _bitmapCtx?: { transferFromImageBitmap: (b: unknown) => void; lastBitmap: unknown };
+  appendChild(c: FakeEl): FakeEl;
+  removeChild(c: FakeEl): FakeEl;
+  remove(): void;
+  insertBefore(n: FakeEl, ref: FakeEl | null): FakeEl;
+  addEventListener(type: string, fn: (e: unknown) => void, opts?: unknown): void;
+  removeEventListener(type: string, fn: (e: unknown) => void): void;
+  getContext(kind: string): unknown;
+  getBoundingClientRect(): { top: number; left: number; width: number; height: number };
+  /** test-only: fire a recorded listener */
+  dispatch(type: string, event?: unknown): void;
+}
+
+export function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    textContent: '',
+    innerHTML: '',
+    width: 0,
+    height: 0,
+    scrollTop: 0,
+    clientHeight: 0,
+    clientWidth: 0,
+    children: [],
+    parentElement: null,
+    _listeners: new Map(),
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const idx = decl.indexOf(':');
+            if (idx > 0) target[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+      get(target, prop: string) {
+        return target[prop] ?? '';
+      },
+    }),
+    appendChild(c: FakeEl) {
+      c.parentElement = this;
+      this.children.push(c);
+      return c;
+    },
+    removeChild(c: FakeEl) {
+      const i = this.children.indexOf(c);
+      if (i >= 0) this.children.splice(i, 1);
+      c.parentElement = null;
+      return c;
+    },
+    remove() {
+      this.parentElement?.removeChild(this);
+    },
+    insertBefore(n: FakeEl, ref: FakeEl | null) {
+      n.parentElement = this;
+      const i = ref ? this.children.indexOf(ref) : -1;
+      if (i >= 0) this.children.splice(i, 0, n);
+      else this.children.push(n);
+      return n;
+    },
+    addEventListener(type: string, fn: (e: unknown) => void) {
+      const arr = this._listeners.get(type) ?? [];
+      arr.push(fn);
+      this._listeners.set(type, arr);
+    },
+    removeEventListener(type: string, fn: (e: unknown) => void) {
+      const arr = this._listeners.get(type);
+      if (arr) this._listeners.set(type, arr.filter((f) => f !== fn));
+    },
+    getContext(kind: string) {
+      if (kind === 'bitmaprenderer') {
+        this._bitmapCtx = {
+          lastBitmap: null,
+          transferFromImageBitmap(b: unknown) {
+            this.lastBitmap = b;
+          },
+        };
+        return this._bitmapCtx;
+      }
+      // A minimal recording 2d context is never actually used by the viewer
+      // (renderPage owns the ctx); return a no-op object for safety.
+      return {};
+    },
+    getBoundingClientRect() {
+      return { top: 0, left: 0, width: this.clientWidth, height: this.clientHeight };
+    },
+    dispatch(type: string, event: unknown = {}) {
+      for (const fn of this._listeners.get(type) ?? []) fn(event);
+    },
+  };
+  return el;
+}
+
+/** A container FakeEl with a nonzero clientWidth so `width` defaults resolve. */
+export function makeContainer(clientWidth = 800, clientHeight = 600): FakeEl {
+  const c = makeEl('div');
+  c.clientWidth = clientWidth;
+  c.clientHeight = clientHeight;
+  return c;
+}
+
+/** Install a recording document + window + ResizeObserver into globals.
+ *  Returns the last-constructed ResizeObserver callback so a test can fire a
+ *  synthetic resize. Call `vi.unstubAllGlobals()` in afterEach. */
+export function installDom(): { resizeCb: () => (() => void) | undefined } {
+  let lastResizeCb: (() => void) | undefined;
+  vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+  vi.stubGlobal('window', { devicePixelRatio: 1 });
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(cb: () => void) {
+        lastResizeCb = cb;
+      }
+      observe(): void {}
+      disconnect(): void {}
+    },
+  );
+  return { resizeCb: () => lastResizeCb };
+}
+
+export interface RenderCall {
+  page: number;
+  resolve: () => void;
+  reject: (e: Error) => void;
+}
+
+/** A fake DocxDocument covering exactly the surface DocxScrollViewer consumes.
+ *  Deferred mode: renderPage / renderPageToBitmap return promises the test
+ *  resolves via the recorded RenderCall, so coalescing / stale-drop is
+ *  observable. */
+export class FakeDocxEngine {
+  destroyed = false;
+  renderCalls: RenderCall[] = [];
+  bitmapCalls: RenderCall[] = [];
+  createdBitmaps: Array<{ width: number; height: number; close: ReturnType<typeof vi.fn> }> = [];
+  constructor(
+    private _pageCount: number,
+    private _sizes: Array<{ widthPt: number; heightPt: number }>,
+    public throwOnRenderPage = false, // simulate a worker-mode engine
+    private deferred = false,
+  ) {}
+  get pageCount(): number {
+    return this._pageCount;
+  }
+  pageSize(i: number): { widthPt: number; heightPt: number } {
+    const clamped = Math.max(0, Math.min(i, this._sizes.length - 1));
+    const s = this._sizes[clamped] ?? { widthPt: 0, heightPt: 0 };
+    return { widthPt: s.widthPt, heightPt: s.heightPt };
+  }
+  renderPage(_canvas: unknown, page: number, _opts?: RenderPageOptions): Promise<void> {
+    if (this.throwOnRenderPage) {
+      return Promise.reject(
+        new Error("renderPage(canvas) is unavailable in mode: 'worker'; use renderPageToBitmap()"),
+      );
+    }
+    return new Promise<void>((resolve, reject) => {
+      const call: RenderCall = { page, resolve: () => resolve(), reject };
+      this.renderCalls.push(call);
+      if (!this.deferred) resolve();
+    });
+  }
+  renderPageToBitmap(page: number, _opts?: WireRenderPageOptions): Promise<ImageBitmap> {
+    const size = this.pageSize(page);
+    const bmp = { width: Math.round(size.widthPt), height: Math.round(size.heightPt), close: vi.fn() };
+    this.createdBitmaps.push(bmp);
+    return new Promise<ImageBitmap>((resolve, reject) => {
+      const call: RenderCall = { page, resolve: () => resolve(bmp as unknown as ImageBitmap), reject };
+      this.bitmapCalls.push(call);
+      if (!this.deferred) resolve(bmp as unknown as ImageBitmap);
+    });
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+  asDoc(): DocxDocument {
+    return this as unknown as DocxDocument;
+  }
+}

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -149,6 +149,9 @@ export function installDom(): { resizeCb: () => (() => void) | undefined } {
 
 export interface RenderCall {
   page: number;
+  /** The per-call `width` (px) the viewer passed — asserted by T3 to confirm
+   *  each page gets its OWN px width (uniform px-per-pt scale, §7). */
+  width?: number;
   resolve: () => void;
   reject: (e: Error) => void;
 }
@@ -185,7 +188,7 @@ export class FakeDocxEngine {
     const s = this._sizes[clamped] ?? { widthPt: 0, heightPt: 0 };
     return { widthPt: s.widthPt, heightPt: s.heightPt };
   }
-  renderPage(_canvas: unknown, page: number, _opts?: RenderPageOptions): Promise<void> {
+  renderPage(_canvas: unknown, page: number, opts?: RenderPageOptions): Promise<void> {
     if (this._mode === 'worker') {
       // Record the attempt BEFORE throwing so a test can assert the viewer never
       // routes a worker-mode engine through renderPage (and detect wrong-path
@@ -198,20 +201,30 @@ export class FakeDocxEngine {
       );
     }
     return new Promise<void>((resolve, reject) => {
-      const call: RenderCall = { page, resolve: () => resolve(), reject };
+      const call: RenderCall = { page, width: opts?.width, resolve: () => resolve(), reject };
       this.renderCalls.push(call);
       if (!this.deferred) resolve();
     });
   }
-  renderPageToBitmap(page: number, _opts?: WireRenderPageOptions): Promise<ImageBitmap> {
+  renderPageToBitmap(page: number, opts?: WireRenderPageOptions): Promise<ImageBitmap> {
     const size = this.pageSize(page);
     const bmp = { width: Math.round(size.widthPt), height: Math.round(size.heightPt), close: vi.fn() };
     this.createdBitmaps.push(bmp);
     return new Promise<ImageBitmap>((resolve, reject) => {
-      const call: RenderCall = { page, resolve: () => resolve(bmp as unknown as ImageBitmap), reject };
+      const call: RenderCall = {
+        page,
+        width: opts?.width,
+        resolve: () => resolve(bmp as unknown as ImageBitmap),
+        reject,
+      };
       this.bitmapCalls.push(call);
       if (!this.deferred) resolve(bmp as unknown as ImageBitmap);
     });
+  }
+  /** The per-call `width` (px) recorded for every renderPage call, in call order.
+   *  T3 asserts each mounted page received its OWN px width. */
+  renderPageWidths(): number[] {
+    return this.renderCalls.map((c) => c.width ?? NaN);
   }
   destroy(): void {
     this.destroyed = true;

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import type { DocxDocument } from './document';
+import type { DocxTextRunInfo } from './renderer';
 import type { RenderPageOptions } from './types';
 import type { WireRenderPageOptions } from './worker-protocol';
 
@@ -116,6 +117,25 @@ export function makeEl(tag: string): FakeEl {
       for (const fn of this._listeners.get(type) ?? []) fn(event);
     },
   };
+  // Mirror the DOM: assigning `innerHTML = ''` detaches all children (both
+  // buildDocxTextLayer's leading clear and the viewer's overlay-teardown clear on
+  // recycle rely on this). A non-empty assignment only records the string (the
+  // viewer/text-layer never set non-empty innerHTML, so no parsing is needed).
+  let _html = '';
+  Object.defineProperty(el, 'innerHTML', {
+    get() {
+      return _html;
+    },
+    set(value: string) {
+      _html = value;
+      if (value === '') {
+        for (const c of el.children) c.parentElement = null;
+        el.children.length = 0;
+      }
+    },
+    enumerable: true,
+    configurable: true,
+  });
   return el;
 }
 
@@ -165,6 +185,10 @@ export class FakeDocxEngine {
   renderCalls: RenderCall[] = [];
   bitmapCalls: RenderCall[] = [];
   createdBitmaps: Array<{ width: number; height: number; close: ReturnType<typeof vi.fn> }> = [];
+  /** Runs fed to `renderPage`'s `onTextRun` (main mode only) so a test can drive
+   *  the viewer's per-slot text overlay (buildDocxTextLayer) without a real
+   *  render. Empty/undefined ⇒ no runs emitted. */
+  feedTextRuns?: DocxTextRunInfo[];
   constructor(
     private _pageCount: number,
     // Uniform-page convention: a single-element `_sizes` array means EVERY page
@@ -200,6 +224,9 @@ export class FakeDocxEngine {
         "renderPage(canvas) is unavailable in mode: 'worker'; use renderPageToBitmap() and paint it via an ImageBitmapRenderingContext",
       );
     }
+    // Emit any fed runs to the viewer's internal onTextRun so it can build the
+    // per-slot overlay (mirrors the real renderer emitting run geometry).
+    for (const r of this.feedTextRuns ?? []) opts?.onTextRun?.(r);
     return new Promise<void>((resolve, reject) => {
       const call: RenderCall = { page, width: opts?.width, resolve: () => resolve(), reject };
       this.renderCalls.push(call);

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -228,3 +228,208 @@ describe('DocxScrollViewer — layout + virtualization (T2)', () => {
     expect(Math.max(...mountedPages) - Math.min(...mountedPages)).toBeLessThanOrEqual(4);
   });
 });
+
+describe('DocxScrollViewer — rendering (T3)', () => {
+  it("main mode: calls renderPage once per mounted slot with that page's px width", () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(10, [{ widthPt: 100, heightPt: 200 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // Every mounted page got exactly one renderPage call, no more no less.
+    const mounted = v.mountedPageIndicesForTest().sort((a, b) => a - b);
+    const rendered = engine.renderCalls.map((c) => c.page).sort((a, b) => a - b);
+    expect(rendered).toEqual(mounted);
+    // Each renderPage call carried THIS page's own px width (uniform px-per-pt
+    // scale, §7). base scale = 200/(100*PT_TO_PX); page width px = 200 for all.
+    const widths = engine.renderPageWidths();
+    for (const w of widths) expect(w).toBeCloseTo(200, 3);
+    v.destroy();
+  });
+
+  it('does not re-render a mounted slot for the same page on a no-op scroll', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(10, [{ widthPt: 100, heightPt: 200 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const before = engine.renderCalls.length;
+    scrollHost.scrollTop = 0; // unchanged window
+    scrollHost.dispatch('scroll');
+    expect(engine.renderCalls.length).toBe(before); // no duplicate renders
+    v.destroy();
+  });
+
+  it('worker mode: never calls renderPage — routes every slot through renderPageToBitmap', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // mode:'worker' — the real DocxDocument.renderPage THROWS synchronously in
+    // worker mode; a viewer that mis-routed would blow up (and renderCalls would
+    // record the attempt). The direct _mode routing must never touch renderPage.
+    const engine = new FakeDocxEngine(10, [{ widthPt: 100, heightPt: 200 }], 'worker');
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engine.renderCalls).toHaveLength(0); // renderPage never touched
+    // Every mounted page dispatched exactly one bitmap render.
+    const mounted = v.mountedPageIndicesForTest().sort((a, b) => a - b);
+    const bitmapPages = [...new Set(engine.bitmapCalls.map((c) => c.page))].sort((a, b) => a - b);
+    expect(bitmapPages).toEqual(mounted);
+    v.destroy();
+  });
+
+  it('worker mode: paints a resolved bitmap into the slot canvas (transfer)', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(10, [{ widthPt: 100, heightPt: 200 }], 'worker');
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    // A bitmap was produced and transferred into the mounted slot's canvas.
+    expect(engine.createdBitmaps.length).toBeGreaterThan(0);
+    const slotWrapper = scrollHost.children.find((c) =>
+      c.children.some((k) => k.tag === 'canvas'),
+    ) as FakeEl;
+    const canvas = slotWrapper.children.find((k) => k.tag === 'canvas') as FakeEl;
+    // The bitmaprenderer ctx received the bitmap (fake records lastBitmap).
+    expect(canvas._bitmapCtx?.lastBitmap).toBe(engine.createdBitmaps[0]);
+    v.destroy();
+  });
+
+  it('worker mode: closes the ImageBitmap on recycle (deferred — render in flight when the slot recycles)', async () => {
+    // Bitmap-close observability path (plan open question): the primary path
+    // (deterministic slot.bitmap hold under synchronous resolve) does NOT hold —
+    // in non-deferred mode transferFromImageBitmap consumes the bitmap and nulls
+    // slot.bitmap synchronously BEFORE any scroll-away, so a later recycle has
+    // nothing to close. We use the DOCUMENTED FALLBACK: a deferred fake so the
+    // render is genuinely in flight when the slot recycles, and the on-resolution
+    // stale-check closes the orphan (design §11).
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(50, [{ widthPt: 100, heightPt: 200 }], 'worker', true);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const firstBatch = engine.bitmapCalls.length;
+    expect(firstBatch).toBeGreaterThan(0);
+    // Scroll far away so the first pages' slots recycle while their renders are
+    // still in flight (deferred → not yet resolved).
+    scrollHost.scrollTop = 12000;
+    scrollHost.dispatch('scroll');
+    // Now resolve the early (now-stale) renders — the viewer must close them.
+    for (const call of engine.bitmapCalls.slice(0, firstBatch)) call.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engine.createdBitmaps.some((b) => b.close.mock.calls.length > 0)).toBe(true);
+    v.destroy();
+  });
+
+  it('worker mode: drops a stale in-flight render — no paint + bitmap closed when the slot moved on', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Deferred: renderPageToBitmap resolves only when the test calls resolve(),
+    // so we can scroll a slot's page out of the window BEFORE the bitmap arrives.
+    const engine = new FakeDocxEngine(50, [{ widthPt: 100, heightPt: 200 }], 'worker', true);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // Page 0's bitmap is dispatched but NOT yet resolved.
+    const page0 = engine.bitmapCalls.find((c) => c.page === 0);
+    expect(page0).toBeDefined();
+    // Scroll far away so page 0's slot recycles while its render is in flight.
+    scrollHost.scrollTop = 12000;
+    scrollHost.dispatch('scroll');
+    expect(v.mountedPageIndicesForTest()).not.toContain(0);
+    // Now the stale render for page 0 resolves — the viewer must NOT paint it and
+    // must close the orphaned bitmap.
+    const bmp0 = engine.createdBitmaps[engine.bitmapCalls.indexOf(page0!)];
+    page0!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bmp0.close.mock.calls.length).toBeGreaterThan(0); // orphan closed
+    v.destroy();
+  });
+
+  it('worker mode: a page that recycles then re-mounts while in flight still gets a fresh render', async () => {
+    // Coalescing keys on page index; a naive Set<number> would swallow the
+    // re-mounted slot's render (the stale resolve clears in-flight AFTER the
+    // remount coalesced away → the new slot never paints). The viewer must
+    // re-dispatch the live slot's render so the page never stays blank.
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(50, [{ widthPt: 100, heightPt: 200 }], 'worker', true);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const page0Initial = engine.bitmapCalls.find((c) => c.page === 0);
+    expect(page0Initial).toBeDefined();
+    const dispatchesForPage0 = () => engine.bitmapCalls.filter((c) => c.page === 0).length;
+    expect(dispatchesForPage0()).toBe(1);
+    // Scroll away (page 0 recycles, render still in flight) then back to the top
+    // (page 0 re-mounts on a fresh slot) — all while the initial render is deferred.
+    scrollHost.scrollTop = 12000;
+    scrollHost.dispatch('scroll');
+    expect(v.mountedPageIndicesForTest()).not.toContain(0);
+    scrollHost.scrollTop = 0;
+    scrollHost.dispatch('scroll');
+    expect(v.mountedPageIndicesForTest()).toContain(0);
+    // The initial (now stale) render resolves — the orphan is dropped and the
+    // re-mounted slot's render is (re-)dispatched.
+    page0Initial!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dispatchesForPage0()).toBeGreaterThanOrEqual(2); // fresh render issued
+    // Resolve the fresh render and confirm it paints into the live slot.
+    for (const c of engine.bitmapCalls.filter((c) => c.page === 0)) c.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(slot0).toBeDefined();
+    const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted, not blank
+    v.destroy();
+  });
+});

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1010,3 +1010,180 @@ describe('DocxScrollViewer — text selection (T5)', () => {
     v.destroy();
   });
 });
+
+describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
+  const PT_TO_PX = 4 / 3;
+  // container fit width 200, page widthPt 100 → base scale = 200/(100*PT_TO_PX)=1.5.
+  // page height px = heightPt * PT_TO_PX * scale = 200 * (4/3) * 1.5 = 400.
+  // (The plan text mislabelled this as 200px; the viewer fits WIDTH, which scales
+  //  height too — verified against the T2/T4 blocks' identical geometry.)
+  const BASE = 200 / (100 * PT_TO_PX);
+  const PAGE_H = 200 * PT_TO_PX * BASE; // 400
+  const GAP = 10;
+  const STRIDE = PAGE_H + GAP; // 410 — the top-to-top distance between pages
+
+  function setup(pageCount = 20, opts = {}) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(
+      pageCount,
+      Array.from({ length: pageCount }, () => ({ widthPt: 100, heightPt: 200 })),
+    );
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: GAP,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, container, engine };
+  }
+
+  it('scrollToPage sets scrollTop to the page offset and clamps out-of-range', () => {
+    const { v, scrollHost } = setup();
+    v.scrollToPage(3);
+    expect(Math.abs(scrollHost.scrollTop - 3 * STRIDE)).toBeLessThan(2);
+    v.scrollToPage(999); // clamps to last page
+    // Last page's top offset exceeds the max scroll top, so scrollToPage pins to
+    // the max (totalHeight − viewportHeight). Assert we clamped to that bound.
+    const totalHeight = 20 * PAGE_H + 19 * GAP; // Σheights + Σgaps
+    const maxTop = totalHeight - 400; // − viewport height
+    expect(Math.abs(scrollHost.scrollTop - maxTop)).toBeLessThan(2);
+    v.scrollToPage(-5); // clamps to 0
+    expect(scrollHost.scrollTop).toBe(0);
+    v.destroy();
+  });
+
+  it('onVisiblePageChange fires only when topIndex changes', () => {
+    const changes: number[] = [];
+    const { v, scrollHost } = setup(20, { onVisiblePageChange: (i: number) => changes.push(i) });
+    scrollHost.scrollTop = STRIDE; // page 1 top
+    scrollHost.dispatch('scroll');
+    scrollHost.scrollTop = STRIDE + 10; // still within page 1
+    scrollHost.dispatch('scroll');
+    scrollHost.scrollTop = 3 * STRIDE; // page 3 top
+    scrollHost.dispatch('scroll');
+    // Deduped: 0 (initial) → 1 → 3, no repeat for the STRIDE+10 no-op.
+    expect(changes).toEqual([0, 1, 3]);
+    v.destroy();
+  });
+
+  it('scrollToPage does not re-fire onVisiblePageChange for the same top page', () => {
+    const changes: number[] = [];
+    const { v } = setup(20, { onVisiblePageChange: (i: number) => changes.push(i) });
+    // Initial mount fired 0. scrollToPage(0) lands on the same top page — no new fire.
+    v.scrollToPage(0);
+    expect(changes).toEqual([0]);
+    // Navigate to page 5 → one fire; navigate there again → no duplicate.
+    v.scrollToPage(5);
+    v.scrollToPage(5);
+    expect(changes).toEqual([0, 5]);
+    v.destroy();
+  });
+
+  it('ResizeObserver re-fit preserves the zoom multiplier', () => {
+    // zoomMax headroom: base 1.5, 2× zoom → 3.0; after the width doubles the new
+    // base is 3.0 so the preserved scale is 6.0. zoomMin/zoomMax are ABSOLUTE
+    // px-per-pt bounds (design §8.1), so a low zoomMax would legitimately CLAMP
+    // the re-fit and break preservation. Give the multiplier room to survive.
+    const { v, container } = setup(20, { zoomMax: 10 });
+    v.setScale(v.baseScaleForTest() * 2); // 2× zoom
+    const zoomMultiplier = v.scaleForTest() / v.baseScaleForTest();
+    // Container widens; the observer callback re-fits base and re-applies the mult.
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    v.resizeForTest(); // fires the observed resize path
+    expect(v.scaleForTest() / v.baseScaleForTest()).toBeCloseTo(zoomMultiplier, 5);
+    v.destroy();
+  });
+
+  it('ResizeObserver re-fit bumps the render epoch (resize is an epoch event)', () => {
+    const { v, container } = setup();
+    const before = v.renderEpochForTest();
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    v.resizeForTest();
+    // A width change re-fits the base scale (routed through setScale), which bumps
+    // the epoch so any bitmap in flight at the old scale is treated as stale.
+    expect(v.renderEpochForTest()).toBeGreaterThan(before);
+    v.destroy();
+  });
+
+  it('ResizeObserver re-fit with an UNCHANGED width does not re-fit or bump the epoch', () => {
+    const { v } = setup();
+    const scaleBefore = v.scaleForTest();
+    const epochBefore = v.renderEpochForTest();
+    v.resizeForTest(); // same width — no-op re-fit
+    expect(v.scaleForTest()).toBe(scaleBefore);
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    v.destroy();
+  });
+
+  it('zero-width container defers, then lays out on first non-zero resize', () => {
+    installDom();
+    const container = makeContainer(0, 0); // unlaid-out
+    const engine = new FakeDocxEngine(5, Array.from({ length: 5 }, () => ({ widthPt: 100, heightPt: 200 })));
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { document: engine.asDoc() });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    expect(v.mountedPageIndicesForTest().length).toBe(0); // deferred
+    container.clientWidth = 300;
+    scrollHost.clientWidth = 300;
+    scrollHost.clientHeight = 400;
+    v.resizeForTest();
+    expect(v.mountedPageIndicesForTest().length).toBeGreaterThan(0);
+    v.destroy();
+  });
+
+  it('empty document: pageCount 0 ⇒ spacer 0, no slots, scrollToPage no-op', () => {
+    installDom();
+    const container = makeContainer(300, 400);
+    const engine = new FakeDocxEngine(0, []);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { document: engine.asDoc() });
+    v.relayout();
+    const spacer = (container.children[0] as FakeEl).children[0].children[0] as FakeEl;
+    expect(parseFloat(spacer.style.height || '0')).toBe(0);
+    expect(v.mountedPageIndicesForTest().length).toBe(0);
+    v.scrollToPage(0); // no throw
+    v.destroy();
+  });
+
+  it('empty document: resize does not crash and fires no callback', () => {
+    installDom();
+    const container = makeContainer(0, 0);
+    const engine = new FakeDocxEngine(0, []);
+    const changes: number[] = [];
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      onVisiblePageChange: (i: number) => changes.push(i),
+    });
+    container.clientWidth = 300;
+    (container.children[0] as FakeEl).children[0].clientWidth = 300;
+    v.resizeForTest(); // no pages ⇒ no-op
+    expect(v.mountedPageIndicesForTest().length).toBe(0);
+    expect(changes).toEqual([]);
+    v.destroy();
+  });
+
+  it('destroy() disconnects the ResizeObserver', () => {
+    installDom();
+    let disconnected = 0;
+    class SpyRO {
+      cb: () => void;
+      constructor(cb: () => void) {
+        this.cb = cb;
+      }
+      observe(): void {}
+      disconnect(): void {
+        disconnected++;
+      }
+    }
+    vi.stubGlobal('ResizeObserver', SpyRO);
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(3, [{ widthPt: 100, heightPt: 200 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { document: engine.asDoc() });
+    v.destroy();
+    expect(disconnected).toBe(1);
+  });
+});

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -475,6 +475,50 @@ describe('DocxScrollViewer — rendering (T3)', () => {
     v.destroy();
   });
 
+  it('worker mode: a PLAIN render rejection (slot still live, epoch unchanged) does NOT re-dispatch — no retry storm', async () => {
+    // B1 regression: the finally re-dispatch must gate on STALENESS, not merely
+    // `!painted`. When `renderPageToBitmap` rejects while the slot is still live
+    // and the epoch is unchanged, `painted` is false and `live === slot`, but
+    // NEITHER staleness test fires, so we must NOT re-dispatch. A `!painted`-only
+    // gate would loop reject → re-dispatch → reject … unbounded (empirically 1→2
+    // →3→4 with onError every round). The onError contract leaves the page blank.
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(50, [{ widthPt: 100, heightPt: 200 }], 'worker', true);
+    const onError = vi.fn();
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      overscan: 1,
+      onError,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+
+    const page0 = engine.bitmapCalls.find((c) => c.page === 0);
+    expect(page0).toBeDefined();
+    expect(v.mountedPageIndicesForTest()).toContain(0); // slot still live
+    const dispatchesForPage0 = () => engine.bitmapCalls.filter((c) => c.page === 0).length;
+    expect(dispatchesForPage0()).toBe(1);
+
+    // Reject the render with the slot STILL LIVE and no scale change (epoch fixed).
+    page0!.reject(new Error('worker render failed'));
+    // Flush microtasks generously — a retry storm would keep queuing dispatches.
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+
+    // Dispatch count for page 0 stayed at 1 — the storm is gone.
+    expect(dispatchesForPage0()).toBe(1);
+    // onError fired exactly once (the single failure), never again.
+    expect(onError).toHaveBeenCalledTimes(1);
+    // Still no further dispatches after more microtask flushing.
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+    expect(dispatchesForPage0()).toBe(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+
   it('worker mode: destroy() mid-flight closes the resolving bitmap and does not fire onError post-destroy', async () => {
     installDom();
     const container = makeContainer(200, 400);
@@ -713,6 +757,62 @@ describe('DocxScrollViewer — zoom (T4)', () => {
     const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
     expect(canvas0._bitmapCtx?.lastBitmap).not.toBe(bmpOld); // never painted the stale bitmap
     expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted the fresh one
+    v.destroy();
+  });
+
+  // B1: epoch-then-reject must stay BOUNDED. setScale bumps the epoch mid-flight,
+  // so the OLD dispatch is stale on resolution; whether it resolves or REJECTS,
+  // the finally must issue exactly ONE fresh dispatch at the new epoch. The fresh
+  // dispatch captures the new epoch, so if IT later rejects (same epoch, still
+  // live) nothing re-dispatches — the retry is bounded to a single fresh attempt.
+  it('render epoch: rejecting the OLD-scale dispatch after setScale still yields exactly ONE fresh dispatch at the new scale (bounded)', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(20, [{ widthPt: 100, heightPt: 200 }], 'worker', true);
+    const onError = vi.fn();
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      overscan: 1,
+      zoomMin: 0.5,
+      zoomMax: 3,
+      onError,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+
+    const page0Old = engine.bitmapCalls.find((c) => c.page === 0);
+    expect(page0Old).toBeDefined();
+    const dispatchesForPage0 = () => engine.bitmapCalls.filter((c) => c.page === 0).length;
+    expect(dispatchesForPage0()).toBe(1);
+    const oldWidth = page0Old!.width;
+
+    // Zoom mid-flight: bumps the epoch. Page 0's re-mount is coalesced away.
+    v.setScale(v.scaleForTest() * 2);
+    expect(v.mountedPageIndicesForTest()).toContain(0);
+    expect(dispatchesForPage0()).toBe(1);
+
+    // REJECT the old-scale dispatch. Epoch moved ⇒ stale ⇒ re-dispatch (not a plain
+    // failure retry). Exactly ONE fresh dispatch at the new epoch.
+    page0Old!.reject(new Error('old-scale render failed'));
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+    const afterReject = engine.bitmapCalls.filter((c) => c.page === 0);
+    expect(afterReject.length).toBe(2); // one fresh dispatch, no storm
+    const freshCall = afterReject[afterReject.length - 1];
+    expect(freshCall.width).toBeGreaterThan(oldWidth ?? 0); // at the NEW (larger) scale
+
+    // The fresh dispatch then SUCCEEDS and paints — the page is not left blank.
+    freshCall.resolve();
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+    expect(dispatchesForPage0()).toBe(2); // still exactly two; success does not re-dispatch
+    const slot0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(slot0).toBeDefined();
+    const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted the fresh bitmap
     v.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxScrollViewer } from './scroll-viewer.js';
+import { installDom, makeContainer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('DocxScrollViewer — skeleton (T1)', () => {
+  it('builds the wrapper → scrollHost → spacer DOM inside the container', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakeDocxEngine(3, [{ widthPt: 612, heightPt: 792 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { document: engine.asDoc() });
+    // container → wrapper
+    const wrapper = container.children[0];
+    expect(wrapper.tag).toBe('div');
+    expect(wrapper.style.position).toBe('relative');
+    // wrapper → scrollHost
+    const scrollHost = wrapper.children[0];
+    expect(scrollHost.style.overflow).toBe('auto');
+    // scrollHost → spacer
+    const spacer = scrollHost.children[0];
+    expect(spacer.style.position).toBe('absolute');
+    v.destroy();
+  });
+
+  it('exposes pageCount from the injected engine', () => {
+    installDom();
+    const engine = new FakeDocxEngine(5, [{ widthPt: 612, heightPt: 792 }]);
+    const v = new DocxScrollViewer(makeContainer() as unknown as HTMLElement, { document: engine.asDoc() });
+    expect(v.pageCount).toBe(5);
+    v.destroy();
+  });
+
+  it('load() is unsupported when an engine is injected', async () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
+    const v = new DocxScrollViewer(makeContainer() as unknown as HTMLElement, { document: engine.asDoc() });
+    await expect(v.load('x.docx')).rejects.toThrow(/injected/i);
+    v.destroy();
+  });
+
+  it('destroy() removes the DOM and does NOT destroy an injected engine', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { document: engine.asDoc() });
+    expect(container.children.length).toBe(1); // wrapper mounted
+    v.destroy();
+    expect(container.children.length).toBe(0); // wrapper removed
+    expect(engine.destroyed).toBe(false); // injected engine preserved (caller owns it)
+  });
+
+  it('pageCount is 0 before load resolves (no injected engine)', () => {
+    installDom();
+    const v = new DocxScrollViewer(makeContainer() as unknown as HTMLElement, {});
+    expect(v.pageCount).toBe(0);
+    v.destroy();
+  });
+});

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -56,4 +56,46 @@ describe('DocxScrollViewer — skeleton (T1)', () => {
     expect(v.pageCount).toBe(0);
     v.destroy();
   });
+
+  // O1 (design §11): an injected engine's own `mode` is authoritative. An
+  // EXPLICITLY conflicting opts.mode is a mis-configuration rejected at
+  // construction; a matching or absent opts.mode constructs fine.
+  it('throws when opts.mode conflicts with an injected worker-mode engine', () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }], 'worker');
+    expect(
+      () =>
+        new DocxScrollViewer(makeContainer() as unknown as HTMLElement, {
+          document: engine.asDoc(),
+          mode: 'main',
+        }),
+    ).toThrow(/mode/i);
+  });
+
+  it('does NOT throw when opts.mode matches an injected worker-mode engine', () => {
+    installDom();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }], 'worker');
+    const v = new DocxScrollViewer(makeContainer() as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      mode: 'worker',
+    });
+    expect(v.pageCount).toBe(1);
+    v.destroy();
+    // Injected engine is caller-owned even in the worker case: destroy() leaves it intact.
+    expect(engine.destroyed).toBe(false);
+  });
+
+  it('constructs a default-main injected engine with absent opts.mode (load still rejects; destroy preserves engine)', async () => {
+    installDom();
+    // Default mode is 'main'; opts.mode is absent ⇒ no conflict, resolved path is main.
+    const engine = new FakeDocxEngine(2, [{ widthPt: 612, heightPt: 792 }]);
+    const v = new DocxScrollViewer(makeContainer() as unknown as HTMLElement, {
+      document: engine.asDoc(),
+    });
+    expect(v.pageCount).toBe(2);
+    await expect(v.load('x.docx')).rejects.toThrow(/injected/i);
+    v.destroy();
+    // Injected engine is caller-owned: destroy() must not tear it down.
+    expect(engine.destroyed).toBe(false);
+  });
 });

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1043,15 +1043,34 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
 
   it('scrollToPage sets scrollTop to the page offset and clamps out-of-range', () => {
     const { v, scrollHost } = setup();
+    // Pick a clientHeight that makes maxTop STRICTLY LESS than the last page's top
+    // offset, so the `Math.min(maxTop, target)` clamp is actually exercised. With the
+    // default clientHeight 400, offsets[19] === maxTop and the clamp is a degenerate
+    // no-op. totalHeight = 8190, offsets[19] = 19*STRIDE = 7790.
+    scrollHost.clientHeight = 500; // maxTop = 8190 − 500 = 7690 < offsets[19] 7790
     v.scrollToPage(3);
     expect(Math.abs(scrollHost.scrollTop - 3 * STRIDE)).toBeLessThan(2);
-    v.scrollToPage(999); // clamps to last page
-    // Last page's top offset exceeds the max scroll top, so scrollToPage pins to
-    // the max (totalHeight − viewportHeight). Assert we clamped to that bound.
-    const totalHeight = 20 * PAGE_H + 19 * GAP; // Σheights + Σgaps
-    const maxTop = totalHeight - 400; // − viewport height
+    v.scrollToPage(999); // clamps to last page index (19)
+    // Page 19's top offset (7790) exceeds the max scroll top (7690), so scrollToPage
+    // pins to the max (totalHeight − viewportHeight). This asserts the Math.min clamp
+    // fired: scrollTop is maxTop (7690), STRICTLY below offsets[19] (7790).
+    const totalHeight = 20 * PAGE_H + 19 * GAP; // Σheights + Σgaps = 8190
+    const maxTop = totalHeight - 500; // − viewport height = 7690
+    const lastOffset = 19 * STRIDE; // 7790
+    expect(maxTop).toBeLessThan(lastOffset); // precondition: clamp is exercised
     expect(Math.abs(scrollHost.scrollTop - maxTop)).toBeLessThan(2);
     v.scrollToPage(-5); // clamps to 0
+    expect(scrollHost.scrollTop).toBe(0);
+    v.destroy();
+  });
+
+  it('scrollToPage: viewport taller than total content ⇒ scrollTop pinned to 0 (negative maxTop guard)', () => {
+    // A 2-page document is shorter than a very tall viewport, so
+    // totalHeight − clientHeight is NEGATIVE; the `Math.max(0, …)` maxTop guard must
+    // pin scrollTop to 0 rather than a negative top.
+    const { v, scrollHost } = setup(2);
+    scrollHost.clientHeight = 5000; // >> totalHeight (2*400 + 10 = 810)
+    v.scrollToPage(1); // last page; its offset (410) is above maxTop (0)
     expect(scrollHost.scrollTop).toBe(0);
     v.destroy();
   });
@@ -1118,6 +1137,75 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
     v.resizeForTest(); // same width — no-op re-fit
     expect(v.scaleForTest()).toBe(scaleBefore);
     expect(v.renderEpochForTest()).toBe(epochBefore);
+    v.destroy();
+  });
+
+  it('height-only resize (width unchanged) re-mounts the newly-revealed window without a scroll, no epoch bump, no callback', () => {
+    // F1 regression: a height-only grow used to early-return before `_mountVisible`,
+    // leaving the newly-revealed rows blank until the user scrolled. At scrollTop 0
+    // the initially-mounted window is [0,1] (viewport 400 = one page; +1 overscan).
+    // Growing the viewport to 1600 must mount [0..4] purely from the resize — no
+    // scroll event, no epoch bump (geometry/scale unchanged so cached canvases stay
+    // valid), and no onVisiblePageChange fire (topIndex stays 0 at scrollTop 0).
+    const changes: number[] = [];
+    const { v, scrollHost } = setup(20, { onVisiblePageChange: (i: number) => changes.push(i) });
+    const mountedBefore = v.mountedPageIndicesForTest().slice().sort((a, b) => a - b);
+    expect(mountedBefore).toEqual([0, 1]);
+    expect(changes).toEqual([0]); // initial mount fired 0
+    const epochBefore = v.renderEpochForTest();
+    const scaleBefore = v.scaleForTest();
+
+    // Grow HEIGHT only; width (and thus the fit-width base scale) is unchanged.
+    scrollHost.clientHeight = 1600;
+    v.resizeForTest(); // NO scroll event dispatched
+
+    const mountedAfter = v.mountedPageIndicesForTest().slice().sort((a, b) => a - b);
+    // The revealed window grew: bottom edge 1600 now intersects pages 0..3 (+1
+    // overscan ⇒ end 4). The mounted span strictly grows.
+    expect(mountedAfter).toEqual([0, 1, 2, 3, 4]);
+    expect(mountedAfter.length).toBeGreaterThan(mountedBefore.length);
+    // No epoch bump — nothing was re-scaled, so no in-flight render is stale.
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    expect(v.scaleForTest()).toBe(scaleBefore);
+    // topIndex is still 0 at scrollTop 0 ⇒ callback did NOT fire again.
+    expect(changes).toEqual([0]);
+    v.destroy();
+  });
+
+  it('clamped resize (zoomMax clamp + width & height grow) still refreshes the revealed window', () => {
+    // F1 clamped-path variant: pin zoomMax to the current base so a width grow's
+    // re-fit (newBase × mult) clamps back to the SAME scale, making setScale a no-op
+    // (which skips its own force-re-render mount). The post-setScale `_mountVisible`
+    // must still mount the rows the taller viewport revealed. base = 1.5, no user
+    // zoom ⇒ mult 1; after width→400 newBase 3.0 clamps to zoomMax 1.5 (== _scale).
+    const changes: number[] = [];
+    const { v, scrollHost, container } = setup(20, {
+      zoomMax: BASE, // 1.5 — clamps the re-fit back to the current scale
+      onVisiblePageChange: (i: number) => changes.push(i),
+    });
+    expect(v.scaleForTest()).toBe(BASE);
+    const mountedBefore = v.mountedPageIndicesForTest().slice().sort((a, b) => a - b);
+    expect(mountedBefore).toEqual([0, 1]);
+    const epochBefore = v.renderEpochForTest();
+
+    // Grow BOTH width and height. The width grow triggers the re-fit branch, but the
+    // clamp pins the scale unchanged ⇒ setScale no-ops. Heights are therefore
+    // unchanged (scale unchanged), so the taller viewport reveals more of the SAME
+    // geometry: mounted grows to [0..4].
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    scrollHost.clientWidth = 400;
+    scrollHost.clientHeight = 1600;
+    v.resizeForTest();
+
+    const mountedAfter = v.mountedPageIndicesForTest().slice().sort((a, b) => a - b);
+    expect(mountedAfter).toEqual([0, 1, 2, 3, 4]);
+    expect(mountedAfter.length).toBeGreaterThan(mountedBefore.length);
+    // Scale stayed pinned at the clamp, so setScale no-oped ⇒ no epoch bump.
+    expect(v.scaleForTest()).toBe(BASE);
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    // topIndex still 0 ⇒ no extra callback.
+    expect(changes).toEqual([0]);
     v.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -505,6 +505,228 @@ describe('DocxScrollViewer — rendering (T3)', () => {
   });
 });
 
+describe('DocxScrollViewer — zoom (T4)', () => {
+  // PT_TO_PX = 4/3. Uniform 100pt×200pt pages, container 200×400, width:undefined
+  // ⇒ base fit maps page-0 width (100pt) to 200px:
+  //   base = 200 / (100 * 4/3) = 1.5
+  //   page height px = 200 * 4/3 * base = 400
+  //   offset[i] = i * (400 + gap) = i * 410
+  const PT_TO_PX = 4 / 3;
+
+  function setup(pageCount = 20, opts = {}) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(
+      pageCount,
+      Array.from({ length: pageCount }, () => ({ widthPt: 100, heightPt: 200 })),
+    );
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      overscan: 1,
+      zoomMin: 0.5,
+      zoomMax: 3,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, engine, container };
+  }
+
+  it('base fit scale maps the first page width to the container width', () => {
+    const { v } = setup();
+    // base = 200 / (100 * 4/3) = 1.5
+    expect(v.scaleForTest()).toBeCloseTo(1.5, 5);
+    expect(v.baseScaleForTest()).toBeCloseTo(1.5, 5);
+    v.destroy();
+  });
+
+  it('re-anchors so the page under the viewport top stays fixed across a zoom (intraFrac 0)', () => {
+    const { v, scrollHost } = setup();
+    // page 3 top offset at base (1.5): 3 * (400 + 10) = 1230
+    scrollHost.scrollTop = 1230;
+    scrollHost.dispatch('scroll');
+    expect(v.topVisiblePage).toBe(3);
+    const cur = v.scaleForTest(); // 1.5
+    v.setScale(cur * 2); // 3.0 (== zoomMax, no clamp)
+    expect(v.scaleForTest()).toBeCloseTo(3, 5);
+    // page 3 stays the top page; new offset = 3 * (800 + 10) = 2430
+    expect(v.topVisiblePage).toBe(3);
+    expect(Math.abs(scrollHost.scrollTop - 2430)).toBeLessThan(2);
+    v.destroy();
+  });
+
+  it('re-anchors preserving the intra-page fraction (intraFrac ≠ 0)', () => {
+    const { v, scrollHost } = setup();
+    // Scroll so HALF of page 3 (200 of its 400px) has passed above the viewport
+    // top: scrollTop = offset[3] + 0.5*400 = 1230 + 200 = 1430 → intraFrac 0.5.
+    scrollHost.scrollTop = 1430;
+    scrollHost.dispatch('scroll');
+    expect(v.topVisiblePage).toBe(3);
+    v.setScale(v.scaleForTest() * 2); // 1.5 → 3.0; heights' = 800
+    // newScrollTop = offset'[3] + 0.5 * 800 = 2430 + 400 = 2830
+    expect(Math.abs(scrollHost.scrollTop - 2830)).toBeLessThan(2);
+    // Page 3 is still under the viewport top: offset'[3]=2430 <= 2830 < 3240.
+    expect(v.topVisiblePage).toBe(3);
+    v.destroy();
+  });
+
+  it('clamps setScale to the absolute [zoomMin, zoomMax] px-per-pt bounds', () => {
+    const { v } = setup();
+    v.setScale(100); // above zoomMax 3 (absolute, NOT a multiple of base)
+    expect(v.scaleForTest()).toBeCloseTo(3, 5);
+    v.setScale(0.01); // below zoomMin 0.5
+    expect(v.scaleForTest()).toBeCloseTo(0.5, 5);
+    v.destroy();
+  });
+
+  it('setScale defaults clamp to [0.1, 4] when zoomMin/zoomMax are unset', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(5, [{ widthPt: 100, heightPt: 200 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    v.setScale(999);
+    expect(v.scaleForTest()).toBeCloseTo(4, 5); // default zoomMax
+    v.setScale(0.0001);
+    expect(v.scaleForTest()).toBeCloseTo(0.1, 5); // default zoomMin
+    v.destroy();
+  });
+
+  it('Ctrl+wheel zooms in and calls preventDefault; bare wheel does not zoom or preventDefault', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+
+    // Bare wheel: no zoom, native scroll (preventDefault NOT called).
+    const barePrevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: false, metaKey: false, preventDefault: barePrevent });
+    expect(v.scaleForTest()).toBe(before);
+    expect(barePrevent).not.toHaveBeenCalled();
+
+    // Ctrl+wheel (deltaY<0 = zoom in): scale increases, preventDefault called.
+    const ctrlPrevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: true, metaKey: false, preventDefault: ctrlPrevent });
+    expect(v.scaleForTest()).toBeGreaterThan(before);
+    expect(ctrlPrevent).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+
+  it('Cmd(meta)+wheel also zooms', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: false, metaKey: true, preventDefault() {} });
+    expect(v.scaleForTest()).toBeGreaterThan(before);
+    v.destroy();
+  });
+
+  it('positive deltaY (ctrl+wheel down) zooms out', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+    scrollHost.dispatch('wheel', { deltaY: 100, ctrlKey: true, metaKey: false, preventDefault() {} });
+    expect(v.scaleForTest()).toBeLessThan(before);
+    v.destroy();
+  });
+
+  it('enableZoom:false installs no wheel handler — ctrl+wheel is inert', () => {
+    const { v, scrollHost } = setup(20, { enableZoom: false });
+    const before = v.scaleForTest();
+    // No wheel listener was registered at all.
+    expect(scrollHost._listeners.has('wheel')).toBe(false);
+    const prevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: true, preventDefault: prevent });
+    expect(v.scaleForTest()).toBe(before);
+    expect(prevent).not.toHaveBeenCalled();
+    v.destroy();
+  });
+
+  it('a wheel with deltaY 0 is a no-op even with ctrl held', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+    const prevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: 0, ctrlKey: true, preventDefault: prevent });
+    expect(v.scaleForTest()).toBe(before);
+    v.destroy();
+  });
+
+  // ⚠ MANDATORY render-epoch test (T3 review finding I-3). Worker path, deferred:
+  // dispatch at scale A, setScale(B) mid-flight, resolve — the old-scale bitmap is
+  // closed, NOT painted, and a fresh dispatch at scale B repaints the slot.
+  it('render epoch: a bitmap dispatched at the old scale is dropped (closed, not painted) after setScale, and re-dispatched at the new scale', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(20, [{ widthPt: 100, heightPt: 200 }], 'worker', true);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      overscan: 1,
+      zoomMin: 0.5,
+      zoomMax: 3,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+
+    // Page 0's bitmap is dispatched at the base (old) scale but NOT yet resolved.
+    const page0Old = engine.bitmapCalls.find((c) => c.page === 0);
+    expect(page0Old).toBeDefined();
+    const oldDispatchCount = engine.bitmapCalls.filter((c) => c.page === 0).length;
+    expect(oldDispatchCount).toBe(1);
+    const oldWidth = page0Old!.width;
+
+    // Zoom mid-flight: bumps the render epoch and re-mounts. Page 0's re-mount is
+    // coalesced away by the in-flight guard (same index still in flight).
+    v.setScale(v.scaleForTest() * 2);
+    expect(v.mountedPageIndicesForTest()).toContain(0); // page 0 still visible at top
+    expect(engine.bitmapCalls.filter((c) => c.page === 0).length).toBe(1); // no double-dispatch yet
+
+    // The OLD-scale render resolves. Epoch moved ⇒ STALE: close, do not paint,
+    // then re-dispatch page 0 at the NEW scale.
+    const bmpOld = engine.createdBitmaps[engine.bitmapCalls.indexOf(page0Old!)];
+    page0Old!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bmpOld.close.mock.calls.length).toBeGreaterThan(0); // old bitmap closed
+    // A fresh dispatch for page 0 was issued at the new scale.
+    const page0Calls = engine.bitmapCalls.filter((c) => c.page === 0);
+    expect(page0Calls.length).toBeGreaterThanOrEqual(2);
+    const freshCall = page0Calls[page0Calls.length - 1];
+    // The fresh dispatch's width reflects the NEW scale (double the old width).
+    expect(freshCall.width).toBeGreaterThan(oldWidth ?? 0);
+
+    // The stale old bitmap was NOT transferred; only the fresh one paints.
+    freshCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(slot0).toBeDefined();
+    const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(canvas0._bitmapCtx?.lastBitmap).not.toBe(bmpOld); // never painted the stale bitmap
+    expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted the fresh one
+    v.destroy();
+  });
+
+  it('setScale to the SAME scale is a no-op (no re-anchor, no epoch bump churn)', () => {
+    const { v, scrollHost } = setup();
+    scrollHost.scrollTop = 1230;
+    scrollHost.dispatch('scroll');
+    const topBefore = scrollHost.scrollTop;
+    v.setScale(v.scaleForTest()); // identical scale
+    expect(scrollHost.scrollTop).toBe(topBefore); // unchanged
+    v.destroy();
+  });
+});
+
 describe('DocxScrollViewer — self-load path (T7 story)', () => {
   it('load(url) lays out and mounts the first window (relayout wired into load)', async () => {
     installDom();

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -99,3 +99,132 @@ describe('DocxScrollViewer — skeleton (T1)', () => {
     expect(engine.destroyed).toBe(false);
   });
 });
+
+describe('DocxScrollViewer — layout + virtualization (T2)', () => {
+  // Uniform 100pt×200pt pages, dpr:1, PT_TO_PX applied in the viewer. To keep
+  // the assertions in pt-independent terms we drive scrollTop/clientHeight in the
+  // SAME px units the viewer computes heights in. Use pageSize heightPt directly
+  // and set base scale by mapping the FIRST page's width to the container width
+  // (width:undefined ⇒ fit the container).
+  function setup(pageCount: number, opts = {}) {
+    const dom = installDom();
+    const container = makeContainer(200, 400); // clientWidth 200, clientHeight 400
+    const engine = new FakeDocxEngine(
+      pageCount,
+      // Full per-page array (fixed harness treats a single-element array as
+      // uniform, but T2 passes the full array explicitly).
+      Array.from({ length: pageCount }, () => ({ widthPt: 100, heightPt: 200 })),
+    );
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      overscan: 1,
+      width: undefined, // fit container width (200) → base scale below
+      ...opts,
+    });
+    const wrapper = container.children[0] as FakeEl;
+    const scrollHost = wrapper.children[0] as FakeEl;
+    const spacer = scrollHost.children[0] as FakeEl;
+    // Drive layout: container width 200, page width 100pt → base scale maps
+    // 100pt*PT_TO_PX to 200px. Provide the viewport height.
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    return { dom, container, engine, v, wrapper, scrollHost, spacer };
+  }
+
+  it('sizes the spacer to computeVisibleRange.totalHeight and mounts only the visible window', () => {
+    const { v, scrollHost, spacer } = setup(10);
+    v.relayout(); // T2 exposes an explicit relayout() the viewer calls after load/resize
+    // Spacer height > 0 and equals Σ page-heights + (n-1)*gap in px.
+    expect(parseFloat(spacer.style.height)).toBeGreaterThan(0);
+    // At scrollTop 0 with a 400px viewport and pages ~ (100pt fit to 200px wide →
+    // 200pt page becomes 400px tall) only page 0 is fully visible; overscan 1
+    // mounts page 1 too. Assert the mounted slot count is small and bounded.
+    const mounted = scrollHost.children.filter((c) => c !== spacer);
+    expect(mounted.length).toBeGreaterThanOrEqual(1);
+    expect(mounted.length).toBeLessThanOrEqual(3); // topIndex 0 .. lastVisible+overscan
+  });
+
+  it('spacer height is exact for variable page heights + gap', () => {
+    const dom = installDom();
+    const container = makeContainer(200, 400);
+    // Variable heights: widths equal so base scale is one value; heights differ.
+    const sizes = [
+      { widthPt: 100, heightPt: 200 },
+      { widthPt: 100, heightPt: 300 },
+      { widthPt: 100, heightPt: 150 },
+    ];
+    const engine = new FakeDocxEngine(3, sizes);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      overscan: 1,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    const spacer = scrollHost.children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // base scale = 200 / (100 * PT_TO_PX) = 200 / (400/3) = 1.5.
+    const PT_TO_PX = 4 / 3;
+    const scale = 200 / (100 * PT_TO_PX);
+    const heights = sizes.map((s) => s.heightPt * PT_TO_PX * scale);
+    const expected = heights.reduce((a, b) => a + b, 0) + (sizes.length - 1) * 10;
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+    v.destroy();
+    void dom;
+  });
+
+  it('recycles slots on scroll without unbounded canvas growth (pool reuse)', () => {
+    const { v, scrollHost } = setup(50);
+    v.relayout();
+    const initialMount = scrollHost.children.length;
+    // Scroll far down and fire the scroll listener repeatedly.
+    for (let top = 0; top <= 4000; top += 400) {
+      scrollHost.scrollTop = top;
+      scrollHost.dispatch('scroll');
+    }
+    // The DOM child count (spacer + mounted slots) must stay bounded — the pool
+    // reuses slots rather than appending a new canvas per page.
+    expect(scrollHost.children.length).toBeLessThanOrEqual(initialMount + 2);
+  });
+
+  it('scrolling far then back reuses pooled slot wrappers (bounded distinct allocations)', () => {
+    const { v, scrollHost } = setup(50);
+    v.relayout();
+    // Track EVERY distinct wrapper element the viewer ever appends. If slots are
+    // pooled (recycled), scrolling across the whole document then back reuses a
+    // small fixed set of wrappers rather than allocating one per visited page.
+    const seen = new Set<FakeEl>();
+    const collect = () => {
+      for (const c of scrollHost.children) if (c.tag === 'div') seen.add(c);
+    };
+    collect();
+    // Sweep deep into the document and back to the top.
+    for (const top of [8000, 16000, 8000, 0]) {
+      scrollHost.scrollTop = top;
+      scrollHost.dispatch('scroll');
+      collect();
+    }
+    // 50 pages were visited across the sweep; a per-page allocator would have
+    // created dozens of wrappers. The pool must keep the distinct-wrapper count
+    // tiny: spacer(1) + at most a couple of window-sized generations of slots.
+    // Window here is ~2-4 slots; allow generous headroom but far below 50.
+    expect(seen.size).toBeLessThanOrEqual(8);
+    // Coming back to the top mounts page 0 again, drawn from the pool.
+    expect(v.mountedPageIndicesForTest()).toContain(0);
+  });
+
+  it('mounts the correct window for a mid-document scrollTop', () => {
+    const { v, scrollHost } = setup(20);
+    v.relayout();
+    // Jump to a scrollTop deep in the doc; the mounted slots must include the
+    // page under the viewport top (topVisiblePage) and its overscan neighbours.
+    scrollHost.scrollTop = 2000;
+    scrollHost.dispatch('scroll');
+    const top = v.topVisiblePage;
+    const mountedPages = v.mountedPageIndicesForTest(); // T2 test hook
+    expect(mountedPages).toContain(top);
+    expect(Math.max(...mountedPages) - Math.min(...mountedPages)).toBeLessThanOrEqual(4);
+  });
+});

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -851,3 +851,162 @@ describe('DocxScrollViewer — self-load path (T7 story)', () => {
     v.destroy();
   });
 });
+
+describe('DocxScrollViewer — text selection (T5)', () => {
+  const RUN = { text: 'Hi', x: 1, y: 2, w: 10, h: 12, fontSize: 12, font: '12px serif' };
+
+  function findSlotWrapper(scrollHost: FakeEl): FakeEl {
+    return scrollHost.children.find((c) => c.children.some((k) => k.tag === 'canvas')) as FakeEl;
+  }
+  function findTextLayer(slotWrapper: FakeEl): FakeEl {
+    return slotWrapper.children.find((c) => c.tag === 'div') as FakeEl;
+  }
+
+  it('main mode: builds an overlay span per run for each visible slot', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(3, [{ widthPt: 100, heightPt: 200 }]);
+    engine.feedTextRuns = [RUN];
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Every mounted slot got its overlay built from that page's render.
+    const mounted = v.mountedPageIndicesForTest();
+    expect(mounted.length).toBeGreaterThan(0);
+    for (const wrapper of scrollHost.children.filter((c) => c.children.some((k) => k.tag === 'canvas'))) {
+      const textLayer = findTextLayer(wrapper);
+      expect(textLayer.children.length).toBe(1);
+      expect(textLayer.children[0].textContent).toBe('Hi');
+    }
+    v.destroy();
+  });
+
+  it('main mode: sizes the overlay to the slot canvas CSS size', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(1, [{ widthPt: 100, heightPt: 200 }]);
+    engine.feedTextRuns = [RUN];
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    const wrapper = findSlotWrapper(scrollHost);
+    const canvas = wrapper.children.find((c) => c.tag === 'canvas') as FakeEl;
+    const textLayer = findTextLayer(wrapper);
+    // buildDocxTextLayer sizes the layer to the canvas CSS width/height. The
+    // main renderPage owns the canvas so its CSS size falls back to
+    // `${canvas.width}px` — either way the overlay must match the canvas.
+    const expectW = canvas.style.width || `${canvas.width}px`;
+    const expectH = canvas.style.height || `${canvas.height}px`;
+    expect(textLayer.style.width).toBe(expectW);
+    expect(textLayer.style.height).toBe(expectH);
+    v.destroy();
+  });
+
+  it('main mode: recycling a slot clears its overlay so the free pool holds no stale spans', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(50, [{ widthPt: 100, heightPt: 200 }]);
+    engine.feedTextRuns = [RUN];
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    // The overlay is built in the renderPage .then() microtask.
+    await Promise.resolve();
+    await Promise.resolve();
+    // A page-0 slot exists with a built overlay.
+    const wrapper = findSlotWrapper(scrollHost);
+    const textLayer = findTextLayer(wrapper);
+    expect(textLayer.children.length).toBe(1);
+    // Scroll far away so page 0 recycles into the free pool.
+    scrollHost.scrollTop = 8000;
+    scrollHost.dispatch('scroll');
+    // The recycled slot's overlay was cleared (no stale spans linger in the pool).
+    expect(textLayer.children.length).toBe(0);
+    v.destroy();
+  });
+
+  it('worker mode: warns once and builds no overlay spans', async () => {
+    installDom();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(3, [{ widthPt: 100, heightPt: 200 }], 'worker');
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Warned exactly once with the same wording as DocxViewer, across every
+    // mounted slot's render.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/text selection is unavailable in mode: 'worker'/);
+    // No renderPage (worker path only) and no overlay spans anywhere.
+    expect(engine.renderCalls.length).toBe(0);
+    for (const wrapper of scrollHost.children.filter((c) => c.children.some((k) => k.tag === 'canvas'))) {
+      const textLayer = wrapper.children.find((c) => c.tag === 'div') as FakeEl;
+      expect(textLayer.children.length).toBe(0);
+    }
+    warn.mockRestore();
+    v.destroy();
+  });
+
+  it('stale main render (epoch moved by setScale mid-flight) does NOT rebuild the overlay', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Deferred main mode: the test resolves renderPage manually so setScale can
+    // move the epoch WHILE page 0's first render is in flight.
+    const engine = new FakeDocxEngine(20, [{ widthPt: 100, heightPt: 200 }], 'main', true);
+    engine.feedTextRuns = [RUN];
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      enableTextSelection: true,
+      gap: 10,
+      zoomMin: 0.1,
+      zoomMax: 4,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    // Grab the first (stale) page-0 render call before resolving it. Capture the
+    // slot wrapper it targets so we can inspect its overlay afterwards.
+    const staleWrapper = scrollHost.children.find((c) => c.children.some((k) => k.tag === 'canvas')) as FakeEl;
+    const staleLayer = staleWrapper.children.find((c) => c.tag === 'div') as FakeEl;
+    const staleCall = engine.renderCalls.find((c) => c.page === 0)!;
+    // Zoom mid-flight: bumps the epoch and force-re-mounts every slot (which
+    // re-dispatches a fresh page-0 render at the new scale).
+    v.setScale(v.scaleForTest() * 2);
+    // Now resolve the STALE (old-epoch) render. Its .then must bail on the epoch
+    // guard and NOT build the overlay.
+    staleCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // The stale render built nothing (epoch guard). The fresh render is still
+    // deferred (not resolved), so its overlay isn't built either — the stale
+    // slot/layer holds zero spans from the superseded render.
+    expect(staleLayer.children.length).toBe(0);
+    v.destroy();
+  });
+});

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxScrollViewer } from './scroll-viewer.js';
 import { DocxDocument } from './document.js';
 import { installDom, makeContainer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+import * as docxIndex from './index.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -1273,5 +1274,11 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, { document: engine.asDoc() });
     v.destroy();
     expect(disconnected).toBe(1);
+  });
+});
+
+describe('DocxScrollViewer — barrel export (T7)', () => {
+  it('is exported from the package entry', () => {
+    expect(typeof docxIndex.DocxScrollViewer).toBe('function');
   });
 });

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxScrollViewer } from './scroll-viewer.js';
+import { DocxDocument } from './document.js';
 import { installDom, makeContainer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe('DocxScrollViewer — skeleton (T1)', () => {
   it('builds the wrapper → scrollHost → spacer DOM inside the container', () => {
@@ -253,6 +257,40 @@ describe('DocxScrollViewer — rendering (T3)', () => {
     v.destroy();
   });
 
+  it('main mode: passes each page its OWN px width for MIXED page sizes (uniform px-per-pt scale, §7)', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Mixed physical widths: page 0 is 100pt wide, page 1 is 200pt wide. The
+    // uniform document scale is fixed by fitting the FIRST page to the container
+    // (base scale = 200 / (100 * PT_TO_PX) = 1.5), so page 1 — twice as wide —
+    // must render at TWICE the px width, not the same fit-width. A vacuous impl
+    // that hands every page a constant fit-width would give [200, 200].
+    const engine = new FakeDocxEngine(2, [
+      { widthPt: 100, heightPt: 100 },
+      { widthPt: 200, heightPt: 100 },
+    ]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // Both pages mount (page 0 height px = 100*PT_TO_PX*1.5 = 200; page 1 sits at
+    // top 210 and intersects the 400px viewport), so both get exactly one render.
+    const mounted = v.mountedPageIndicesForTest().sort((a, b) => a - b);
+    expect(mounted).toEqual([0, 1]);
+    // Per-page px widths in call order: page 0 → 200, page 1 → 400.
+    const widths = engine.renderCalls
+      .slice()
+      .sort((a, b) => a.page - b.page)
+      .map((c) => c.width ?? NaN);
+    expect(widths[0]).toBeCloseTo(200, 3);
+    expect(widths[1]).toBeCloseTo(400, 3);
+    v.destroy();
+  });
+
   it('does not re-render a mounted slot for the same page on a no-op scroll', () => {
     installDom();
     const container = makeContainer(200, 400);
@@ -414,6 +452,10 @@ describe('DocxScrollViewer — rendering (T3)', () => {
     scrollHost.scrollTop = 0;
     scrollHost.dispatch('scroll');
     expect(v.mountedPageIndicesForTest()).toContain(0);
+    // Coalescing pin: page 0's render is STILL in flight (initial deferred call
+    // not yet resolved), so the re-mount must NOT dispatch a second render for
+    // page 0 — the in-flight guard swallows it. Exactly one dispatch so far.
+    expect(dispatchesForPage0()).toBe(1);
     // The initial (now stale) render resolves — the orphan is dropped and the
     // re-mounted slot's render is (re-)dispatched.
     page0Initial!.resolve();
@@ -430,6 +472,60 @@ describe('DocxScrollViewer — rendering (T3)', () => {
     expect(slot0).toBeDefined();
     const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
     expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted, not blank
+    v.destroy();
+  });
+
+  it('worker mode: destroy() mid-flight closes the resolving bitmap and does not fire onError post-destroy', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Deferred so a render is genuinely in flight when we destroy the viewer.
+    const engine = new FakeDocxEngine(50, [{ widthPt: 100, heightPt: 200 }], 'worker', true);
+    const onError = vi.fn();
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      onError,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const page0 = engine.bitmapCalls.find((c) => c.page === 0);
+    expect(page0).toBeDefined();
+    // Tear down while page 0's render is still in flight. destroy() recycles the
+    // slot (no bitmap held yet — none received), so the on-resolution stale-check
+    // must close the orphan; the identity guard fails (slot no longer live).
+    v.destroy();
+    const bmp0 = engine.createdBitmaps[engine.bitmapCalls.indexOf(page0!)];
+    page0!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bmp0.close.mock.calls.length).toBeGreaterThan(0); // orphan closed, no leak
+    expect(onError).not.toHaveBeenCalled(); // no error surfaced after teardown
+  });
+});
+
+describe('DocxScrollViewer — self-load path (T7 story)', () => {
+  it('load(url) lays out and mounts the first window (relayout wired into load)', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Mock the static loader so load() resolves to a fake engine WITHOUT touching
+    // a real Worker / WASM. The viewer must call relayout() after assignment so a
+    // self-loaded (non-injected) viewer is not left blank (I-2).
+    const engine = new FakeDocxEngine(10, [{ widthPt: 100, heightPt: 200 }]);
+    const loadSpy = vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { gap: 10 });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    await v.load('sample.docx');
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    // Layout happened: slots mounted and the spacer was sized.
+    expect(v.mountedPageIndicesForTest().length).toBeGreaterThan(0);
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.height)).toBeGreaterThan(0);
+    // The mounted pages were actually rendered (main mode → renderPage).
+    expect(engine.renderCalls.length).toBeGreaterThan(0);
     v.destroy();
   });
 });

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,0 +1,150 @@
+import { DocxDocument } from './document';
+import type { LoadOptions } from './document';
+import type { RenderPageOptions } from './types';
+
+/**
+ * Options for {@link DocxScrollViewer}. Extends `RenderPageOptions` (per-page
+ * render knobs) and `LoadOptions` (parse/worker knobs). See design §8.1.
+ */
+export interface DocxScrollViewerOptions extends RenderPageOptions, LoadOptions {
+  /** Base fit width in CSS px → base zoom scale. Default: the container's width
+   *  at first non-zero layout (design §7/§11 zero-width deferral). */
+  width?: number;
+  /** Vertical gap (px) between consecutive pages. Default 16. */
+  gap?: number;
+  /** Pages kept mounted beyond the viewport on each side. Default 1. */
+  overscan?: number;
+  /** Per-page transparent text-selection overlay. MAIN render mode only:
+   *  in worker mode `onTextRun` cannot cross the worker boundary, so the overlay
+   *  stays empty and the viewer logs one warning (design §11). */
+  enableTextSelection?: boolean;
+  /** Minimum zoom scale (px-per-pt multiplier floor). Default 0.1. */
+  zoomMin?: number;
+  /** Maximum zoom scale. Default 4. */
+  zoomMax?: number;
+  /** Enable `Ctrl`/`Cmd`+wheel zoom. Default true. */
+  enableZoom?: boolean;
+  /**
+   * Inject an already-loaded engine to share one parse across panes (design §14).
+   * When set: `load()` is unsupported (throws), the engine's own `mode` wins (an
+   * explicitly conflicting `opts.mode` throws at construction, design §11), and
+   * `destroy()` does NOT destroy this engine (the caller owns its lifecycle).
+   */
+  document?: DocxDocument;
+  /** Fires when the top-most visible page changes. `topIndex` from
+   *  `computeVisibleRange` (the first page intersecting the viewport top,
+   *  EXCLUDING overscan). */
+  onVisiblePageChange?: (topIndex: number, total: number) => void;
+  /** Error callback. When set, `load()` invokes it and resolves; otherwise the
+   *  error is rethrown (shared viewer error contract). */
+  onError?: (err: Error) => void;
+}
+
+/** One mounted page. `canvas` is the drawn page; `textLayer` the optional
+ *  per-page selection overlay (main mode only). `renderedPage` guards against
+ *  re-rendering a recycled slot for a page whose render is still in flight. */
+interface PageSlot {
+  wrapper: HTMLDivElement;
+  canvas: HTMLCanvasElement;
+  textLayer: HTMLDivElement | null;
+  /** page index this slot is currently rendering / has rendered, or -1 when free. */
+  renderedPage: number;
+  /** worker-mode: the last ImageBitmap painted into this slot, to `.close()` on recycle. */
+  bitmap: ImageBitmap | null;
+  /** bitmaprenderer ctx (worker mode), grabbed once per canvas. */
+  bitmapCtx: ImageBitmapRenderingContext | null;
+}
+
+export class DocxScrollViewer {
+  private _doc: DocxDocument | null = null;
+  private readonly _injected: boolean;
+  private readonly _opts: DocxScrollViewerOptions;
+  private readonly _container: HTMLElement;
+  private readonly _wrapper: HTMLDivElement;
+  private readonly _scrollHost: HTMLDivElement;
+  private readonly _spacer: HTMLDivElement;
+  /** Resolved render mode. When an engine is injected the engine's own `mode`
+   *  is authoritative (design §11 — no silent mis-pathing / no probing); an
+   *  explicitly conflicting `opts.mode` is rejected at construction. When self-
+   *  loading, `opts.mode` decides and `load()` passes it to `DocxDocument.load`. */
+  private _mode: 'main' | 'worker';
+
+  constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
+    this._container = container;
+    this._opts = opts;
+    this._injected = !!opts.document;
+    if (this._injected) {
+      const engine = opts.document as DocxDocument;
+      // Injected engine ⇒ its own mode is the fact (design §11). An EXPLICITLY
+      // conflicting opts.mode is a mis-configuration and is rejected here; an
+      // absent opts.mode is fine.
+      if (opts.mode !== undefined && opts.mode !== engine.mode) {
+        throw new Error(
+          `DocxScrollViewer: opts.mode='${opts.mode}' conflicts with the injected engine's mode='${engine.mode}'. ` +
+            'Omit opts.mode when injecting an engine — the engine owns its render mode.',
+        );
+      }
+      this._doc = engine;
+      this._mode = engine.mode;
+    } else {
+      this._mode = opts.mode ?? 'main';
+    }
+
+    // container → wrapper → scrollHost → spacer  (design §6)
+    this._wrapper = document.createElement('div');
+    this._wrapper.style.cssText = 'position:relative;width:100%;height:100%;overflow:hidden;';
+    this._scrollHost = document.createElement('div');
+    this._scrollHost.style.cssText = 'position:absolute;inset:0;overflow:auto;';
+    this._spacer = document.createElement('div');
+    this._spacer.style.cssText = 'position:absolute;top:0;left:0;width:1px;height:0;pointer-events:none;';
+    this._scrollHost.appendChild(this._spacer);
+    this._wrapper.appendChild(this._scrollHost);
+    this._container.appendChild(this._wrapper);
+  }
+
+  /**
+   * Load a DOCX from URL or ArrayBuffer and render the first window.
+   * UNSUPPORTED when an engine was injected via `opts.document` (throws) — the
+   * caller already owns the parsed engine.
+   */
+  async load(source: string | ArrayBuffer): Promise<void> {
+    if (this._injected) {
+      throw new Error(
+        'DocxScrollViewer.load() is unsupported when an engine is injected via opts.document; the injected engine is already loaded.',
+      );
+    }
+    try {
+      this._doc = await DocxDocument.load(source, {
+        useGoogleFonts: this._opts.useGoogleFonts,
+        maxZipEntryBytes: this._opts.maxZipEntryBytes,
+        math: this._opts.math,
+        mode: this._mode,
+      });
+      // Layout + first render wired in T2/T3.
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      if (this._opts.onError) {
+        this._opts.onError(e);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  get pageCount(): number {
+    return this._doc?.pageCount ?? 0;
+  }
+
+  /**
+   * Tear down the viewer: remove the DOM subtree and (only for a self-loaded
+   * engine) destroy the engine. An injected engine is left intact — the caller
+   * owns its lifecycle. Per-slot worker ImageBitmaps are closed in T3's teardown.
+   */
+  destroy(): void {
+    if (!this._injected) {
+      this._doc?.destroy();
+    }
+    this._doc = null;
+    this._wrapper.remove();
+  }
+}

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,3 +1,4 @@
+import { computeVisibleRange, PT_TO_PX, type VisibleRange } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
 import type { RenderPageOptions } from './types';
@@ -69,6 +70,24 @@ export class DocxScrollViewer {
    *  loading, `opts.mode` decides and `load()` passes it to `DocxDocument.load`. */
   private _mode: 'main' | 'worker';
 
+  /** px-per-pt zoom multiplier. Base fit maps the first page's width to the
+   *  container width (or opts.width). Zoom multiplies this (design §7). */
+  private _scale = 1;
+  /** Whether the base fit scale has been established. Set true the first time
+   *  `relayout()` resolves a positive base scale. We use an explicit flag rather
+   *  than a `_scale === 1` sentinel because a fit scale of exactly 1 is a valid
+   *  established state (a 1× fit would otherwise be re-fit forever). */
+  private _scaleEstablished = false;
+  /** Live slots keyed by page index. */
+  private readonly _slots = new Map<number, PageSlot>();
+  /** Recyclable detached slots (canvas + textLayer reused across pages). */
+  private readonly _free: PageSlot[] = [];
+  /** Cached per-page heights in px at the current scale (index-aligned). */
+  private _heights: number[] = [];
+  private _lastRange: VisibleRange | null = null;
+  private _lastTopIndex = -1;
+  private _scrollListener: (() => void) | null = null;
+
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
     this._container = container;
     this._opts = opts;
@@ -100,6 +119,17 @@ export class DocxScrollViewer {
     this._scrollHost.appendChild(this._spacer);
     this._wrapper.appendChild(this._scrollHost);
     this._container.appendChild(this._wrapper);
+
+    this._scrollListener = () => this._onScroll();
+    this._scrollHost.addEventListener('scroll', this._scrollListener);
+
+    if (this._injected) {
+      // An injected engine is already loaded, so lay out + mount the first
+      // window immediately. relayout() is idempotent and defers under a
+      // zero-width container (the resize path — T6 — re-runs it once width
+      // appears).
+      this.relayout();
+    }
   }
 
   /**
@@ -135,12 +165,195 @@ export class DocxScrollViewer {
     return this._doc?.pageCount ?? 0;
   }
 
+  /** CSS px width of page `i` at the current scale. */
+  private _pageWidthPx(i: number): number {
+    return this._doc!.pageSize(i).widthPt * PT_TO_PX * this._scale;
+  }
+
+  /** CSS px height of page `i` at the current scale. */
+  private _pageHeightPx(i: number): number {
+    return this._doc!.pageSize(i).heightPt * PT_TO_PX * this._scale;
+  }
+
+  /** The container (fit) width, deferring when the container is unlaid-out. */
+  private _fitWidthPx(): number {
+    if (this._opts.width && this._opts.width > 0) return this._opts.width;
+    const cw = this._container.clientWidth || this._scrollHost.clientWidth;
+    return cw > 0 ? cw : 0; // 0 ⇒ defer (design §11 zero-width deferral)
+  }
+
+  /** Base scale: first page's width fit to the fit-width. Returns 0 when the
+   *  container has no width yet (deferral). */
+  private _baseScale(): number {
+    if (!this._doc || this._doc.pageCount === 0) return 0;
+    const w = this._fitWidthPx();
+    if (w <= 0) return 0;
+    const firstWpt = this._doc.pageSize(0).widthPt;
+    if (firstWpt <= 0) return 0;
+    return w / (firstWpt * PT_TO_PX);
+  }
+
+  /** Recompute heights + spacer, then mount the visible window. Called after
+   *  load, resize, and zoom. Idempotent. */
+  relayout(): void {
+    if (!this._doc) return;
+    // Establish the base fit scale on the first layout that has a positive
+    // width. Zoom (T4) layers its own multiplier on top of this; here we only
+    // set the base. An explicit `_scaleEstablished` flag (NOT a `_scale === 1`
+    // sentinel) so a legitimate 1× fit is not re-fit on every relayout.
+    if (!this._scaleEstablished) {
+      const base = this._baseScale();
+      if (base > 0) {
+        this._scale = base;
+        this._scaleEstablished = true;
+      } else {
+        return; // container has no width yet — retry on the next resize
+      }
+    }
+    this._recomputeHeights();
+    this._syncSpacer();
+    this._mountVisible();
+  }
+
+  private _recomputeHeights(): void {
+    const n = this._doc!.pageCount;
+    const h = new Array<number>(n);
+    for (let i = 0; i < n; i++) h[i] = this._pageHeightPx(i);
+    this._heights = h;
+  }
+
+  private _gap(): number {
+    return this._opts.gap ?? 16;
+  }
+
+  private _overscan(): number {
+    return this._opts.overscan ?? 1;
+  }
+
+  private _range(): VisibleRange {
+    return computeVisibleRange(
+      this._heights,
+      this._gap(),
+      this._scrollHost.scrollTop,
+      this._scrollHost.clientHeight,
+      this._overscan(),
+    );
+  }
+
+  private _syncSpacer(): void {
+    const r = this._range();
+    this._lastRange = r;
+    this._spacer.style.height = `${r.totalHeight}px`;
+  }
+
+  private _onScroll(): void {
+    if (!this._doc || !this._scaleEstablished) return;
+    this._mountVisible();
+  }
+
+  /** Mount/recycle slots for the current visible window. */
+  private _mountVisible(): void {
+    if (!this._doc || this._doc.pageCount === 0) return;
+    const r = this._range();
+    this._lastRange = r;
+
+    // Detach slots that left [start, end] into the free pool.
+    for (const [idx, slot] of [...this._slots]) {
+      if (idx < r.start || idx > r.end) {
+        this._recycleSlot(idx, slot);
+      }
+    }
+    // Mount any missing index in the window.
+    for (let i = r.start; i <= r.end; i++) {
+      if (!this._slots.has(i)) {
+        const slot = this._acquireSlot();
+        this._positionSlot(slot, i, r);
+        this._slots.set(i, slot);
+        this._renderSlot(i, slot); // T3
+      } else {
+        // Re-position (offsets shift after a spacer/height change).
+        this._positionSlot(this._slots.get(i)!, i, r);
+      }
+    }
+    // onVisiblePageChange only on change (T6 refines; wired here for topIndex).
+    if (r.topIndex !== this._lastTopIndex) {
+      this._lastTopIndex = r.topIndex;
+      this._opts.onVisiblePageChange?.(r.topIndex, this._doc.pageCount);
+    }
+  }
+
+  private _acquireSlot(): PageSlot {
+    const reused = this._free.pop();
+    if (reused) {
+      reused.renderedPage = -1;
+      this._scrollHost.appendChild(reused.wrapper);
+      return reused;
+    }
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'position:absolute;left:0;right:0;margin:0 auto;';
+    const canvas = document.createElement('canvas');
+    canvas.style.cssText = 'display:block;background:#fff;';
+    wrapper.appendChild(canvas);
+    let textLayer: HTMLDivElement | null = null;
+    const bitmapCtx: ImageBitmapRenderingContext | null = null;
+    if (this._opts.enableTextSelection) {
+      textLayer = document.createElement('div');
+      textLayer.style.cssText =
+        'position:absolute;top:0;left:0;width:100%;height:100%;' +
+        'overflow:hidden;pointer-events:none;user-select:text;-webkit-user-select:text;';
+      wrapper.appendChild(textLayer);
+    }
+    this._scrollHost.appendChild(wrapper);
+    const slot: PageSlot = { wrapper, canvas, textLayer, renderedPage: -1, bitmap: null, bitmapCtx };
+    return slot;
+  }
+
+  private _recycleSlot(idx: number, slot: PageSlot): void {
+    this._slots.delete(idx);
+    // Close any worker bitmap held by this slot (T3 sets slot.bitmap).
+    if (slot.bitmap) {
+      slot.bitmap.close();
+      slot.bitmap = null;
+    }
+    slot.renderedPage = -1;
+    slot.wrapper.remove();
+    this._free.push(slot);
+  }
+
+  private _positionSlot(slot: PageSlot, i: number, r: VisibleRange): void {
+    slot.wrapper.style.top = `${r.offsets[i]}px`;
+    const wpx = this._pageWidthPx(i);
+    const hpx = this._pageHeightPx(i);
+    slot.wrapper.style.width = `${wpx}px`;
+    slot.wrapper.style.height = `${hpx}px`;
+  }
+
+  /** Rendered by T3. Stubbed here so the mount loop compiles. */
+  private _renderSlot(_i: number, _slot: PageSlot): void {
+    // filled in T3
+  }
+
+  get topVisiblePage(): number {
+    return this._lastRange?.topIndex ?? 0;
+  }
+
+  /** @internal test hook: page indices currently mounted. */
+  mountedPageIndicesForTest(): number[] {
+    return [...this._slots.keys()];
+  }
+
   /**
    * Tear down the viewer: remove the DOM subtree and (only for a self-loaded
    * engine) destroy the engine. An injected engine is left intact — the caller
-   * owns its lifecycle. Per-slot worker ImageBitmaps are closed in T3's teardown.
+   * owns its lifecycle. Per-slot worker ImageBitmaps are closed on recycle.
    */
   destroy(): void {
+    if (this._scrollListener) {
+      this._scrollHost.removeEventListener('scroll', this._scrollListener);
+      this._scrollListener = null;
+    }
+    for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
+    this._free.length = 0;
     if (!this._injected) {
       this._doc?.destroy();
     }

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,4 +1,4 @@
-import { computeVisibleRange, PT_TO_PX, type VisibleRange } from '@silurus/ooxml-core';
+import { computeVisibleRange, PT_TO_PX, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
 import type { DocxTextRunInfo } from './renderer';
@@ -112,18 +112,25 @@ export class DocxScrollViewer {
    *  page whose first is still in flight — and lets us drop pages that scrolled
    *  out of the window before dispatch (design §11 worker coalescing).
    *
-   *  T4 ZOOM HAZARD (must fix when `setScale` lands): coalescing keys on page
-   *  INDEX only, with no notion of the scale a dispatch was made at. When
-   *  `setScale` changes the zoom mid-flight, an in-flight bitmap dispatched at the
-   *  OLD scale can still pass the on-resolution identity check (`_slots.get(i) ===
-   *  slot && slot.renderedPage === i`) if the same slot is still mounted for page
-   *  `i`, and get painted at the WRONG resolution — with no re-dispatch, because
-   *  the index is (or was) already in this Set. T4 MUST either (a) add a render
-   *  epoch/generation bumped on every `setScale` and fold it into the in-flight
-   *  identity (dispatch at epoch E, drop on resolve if the live epoch moved), or
-   *  (b) on scale change clear `_bitmapInFlight` and force-redispatch the mounted
-   *  window. A same-index Set alone is not enough once scale is mutable. */
+   *  T4 ZOOM HAZARD (RESOLVED by the render epoch below): coalescing keys on page
+   *  INDEX only, with no notion of the scale a dispatch was made at. Once
+   *  `setScale` can change the zoom mid-flight, an in-flight bitmap dispatched at
+   *  the OLD scale can still pass the on-resolution identity check if the SAME
+   *  slot object is re-mounted for page `i` (the pool reuses slot objects, so
+   *  `_slots.get(i) === slot && slot.renderedPage === i` can hold for an old
+   *  dispatch), and get painted at the WRONG resolution. We fix this with a render
+   *  epoch (`_renderEpoch`): each dispatch captures the epoch, and on resolution a
+   *  moved epoch ⇒ STALE (close + re-dispatch the live slot). See
+   *  `_renderSlotBitmap`. */
   private readonly _bitmapInFlight = new Set<number>();
+  /** Render generation, bumped on every effective `setScale` (and the T6 resize
+   *  re-fit, which routes through `setScale`). Stamped into each async render
+   *  dispatch; a resolution whose captured epoch ≠ this value is STALE — its
+   *  pixels/geometry are at a superseded scale. Worker path: close the orphan
+   *  bitmap + re-dispatch the live slot. Main path: skip the (stale) text-layer
+   *  build; the engine's per-canvas token already discards the stale pixels. */
+  private _renderEpoch = 0;
+  private _wheelListener: ((e: WheelEvent) => void) | null = null;
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
     this._container = container;
@@ -159,6 +166,22 @@ export class DocxScrollViewer {
 
     this._scrollListener = () => this._onScroll();
     this._scrollHost.addEventListener('scroll', this._scrollListener);
+
+    // Ctrl/Cmd+wheel zoom (design §7). Bare wheel is left untouched so the
+    // scrollHost scrolls natively. `enableZoom:false` installs no handler at all.
+    // `{ passive: false }` is required because we call preventDefault() to stop
+    // the browser's own ctrl+wheel page zoom.
+    if (this._opts.enableZoom !== false) {
+      this._wheelListener = (e: WheelEvent) => {
+        if (!(e.ctrlKey || e.metaKey)) return; // bare wheel scrolls natively
+        e.preventDefault();
+        if (e.deltaY === 0) return;
+        this.setScale(zoomStepScale(this._scale, e.deltaY));
+      };
+      this._scrollHost.addEventListener('wheel', this._wheelListener as EventListener, {
+        passive: false,
+      });
+    }
 
     if (this._injected) {
       // An injected engine is already loaded, so lay out + mount the first
@@ -384,6 +407,16 @@ export class DocxScrollViewer {
    * tracks the page this slot is committed to; we stamp it up-front and bail on
    * resolution if it changed (the engine's own token guard is per-canvas; this is
    * the viewer's per-slot page-identity check).
+   *
+   * Render epoch (main path): pixel staleness after a mid-flight `setScale` is
+   * already handled by the engine's per-canvas token (the newer renderPage on the
+   * same canvas wins) — `setScale` recycles + re-mounts, and the re-mount always
+   * re-dispatches `renderPage` (renderedPage reset to -1), so a fresh render is
+   * always issued. But the viewer-side side effects of a STALE resolution — the
+   * text-layer build (its run geometry is at the OLD scale) and the renderedPage
+   * bookkeeping — must NOT run, or a superseded render would rebuild the overlay
+   * with stale x/y/w/h (the pool reuses slot objects, so the identity check alone
+   * can pass for an old-epoch resolution). We gate them on the captured epoch.
    */
   private _renderSlot(i: number, slot: PageSlot): void {
     if (!this._doc) return;
@@ -393,6 +426,7 @@ export class DocxScrollViewer {
 
     const dpr = this._dpr();
     const widthPx = this._pageWidthPx(i);
+    const epoch = this._renderEpoch;
 
     if (this._mode === 'worker') {
       void this._renderSlotBitmap(i, slot, widthPx, dpr);
@@ -412,9 +446,11 @@ export class DocxScrollViewer {
         onTextRun,
       })
       .then(() => {
-        // A recycle may have re-purposed this slot for a different page (or freed
-        // it) mid-render; bail without painting the stale page.
-        if (this._slots.get(i) !== slot || slot.renderedPage !== i) return;
+        // Stale if the epoch moved (a setScale rescaled mid-flight — the run
+        // geometry is at the old scale), or a recycle re-purposed this slot for a
+        // different page / freed it. Either way: skip the (stale) overlay build.
+        // The engine's per-canvas token already discards the superseded pixels.
+        if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedPage !== i) return;
         if (wantOverlay && slot.textLayer) {
           buildDocxTextLayer(
             slot.textLayer,
@@ -451,13 +487,23 @@ export class DocxScrollViewer {
    *    re-mount case a live slot for `i` still awaits a render, so once we clear
    *    the in-flight guard we re-dispatch it — a page that recycled and re-mounted
    *    mid-flight must never stay blank.
+   *  - RENDER EPOCH: the dispatch captures `this._renderEpoch`. `setScale` bumps
+   *    the epoch, so a resolution whose captured epoch ≠ the live epoch is STALE
+   *    even when the SAME slot object is still mounted for page `i` (the pool
+   *    reuses slot objects, so the identity check alone can't catch a zoom that
+   *    happened mid-flight). A moved epoch ⇒ close the orphan + re-dispatch the
+   *    live slot at the new scale, never paint the old-scale bitmap.
    */
   private async _renderSlotBitmap(i: number, slot: PageSlot, widthPx: number, dpr: number): Promise<void> {
     if (this._bitmapInFlight.has(i)) return; // coalesce: already dispatched
     // Drop-stale before dispatch: if this page already scrolled out of the
     // mounted window, don't dispatch at all.
     if (this._slots.get(i) !== slot) return;
+    const epoch = this._renderEpoch;
     this._bitmapInFlight.add(i);
+    // Whether this invocation actually painted its slot. When it did NOT (stale
+    // epoch or moved identity), the `finally` may need to re-dispatch a live slot.
+    let painted = false;
     // Grab the bitmaprenderer ctx ONCE per canvas — a canvas holds one context
     // type for its lifetime. A recycled canvas keeps the ctx grabbed on its
     // first worker render (bitmapCtx survives recycle), so we never re-getContext
@@ -474,10 +520,12 @@ export class DocxScrollViewer {
         defaultTextColor: this._opts.defaultTextColor,
         showTrackChanges: this._opts.showTrackChanges,
       });
-      // The slot may have recycled to a different page while the worker ran, or
-      // page `i` may have re-mounted onto a DIFFERENT slot. Either way this bitmap
-      // is stale for THIS slot: close it and skip the paint (drop-stale, §11).
-      if (this._slots.get(i) !== slot || slot.renderedPage !== i) {
+      // Stale if EITHER (a) the epoch moved (a setScale rescaled mid-flight, so
+      // this bitmap is at a superseded resolution — this catches the case where
+      // the SAME slot object is re-mounted for page `i`, which the identity check
+      // below cannot), or (b) the slot recycled to a different page / page `i`
+      // re-mounted onto a DIFFERENT slot. Either way: close + skip the paint.
+      if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedPage !== i) {
         bmp.close();
         return;
       }
@@ -495,20 +543,88 @@ export class DocxScrollViewer {
       slot.canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
       slot.bitmapCtx?.transferFromImageBitmap(bmp);
       slot.bitmap = null; // transfer consumed it
+      painted = true;
     } catch (err) {
       this._reportRenderError(err);
     } finally {
       this._bitmapInFlight.delete(i);
-      // If a LIVE slot for page `i` still awaits its render (page `i` re-mounted
-      // onto a different slot while this render was in flight, so the re-mount's
-      // dispatch was coalesced away), issue it now that the guard is clear.
+      // Re-dispatch when a LIVE slot for page `i` still awaits a correct render
+      // and this invocation did NOT paint it. Two mid-flight cases produce that:
+      //  - page `i` re-mounted onto a DIFFERENT slot while we ran (identity moved,
+      //    the re-mount's dispatch was coalesced away by the in-flight guard), or
+      //  - a `setScale` bumped the epoch (this bitmap was at the old scale; the
+      //    live slot may be the SAME object reused from the pool, so a `live !==
+      //    slot` test would wrongly skip it).
+      // `!painted` covers both without special-casing which staleness fired; when
+      // we DID paint, `live === slot` and no re-dispatch is needed.
       const live = this._slots.get(i);
-      if (live && live !== slot && !this._bitmapInFlight.has(i)) {
-        // live.renderedPage === i already (set by _renderSlot on mount); the
-        // dispatch was swallowed by the in-flight guard, not the identity guard.
+      if (!painted && live && !this._bitmapInFlight.has(i) && !this._destroyed) {
+        // live.renderedPage === i already (set by _renderSlot on mount); the fresh
+        // dispatch runs at the CURRENT epoch/scale via _pageWidthPx(i).
         void this._renderSlotBitmap(i, live, this._pageWidthPx(i), this._dpr());
       }
     }
+  }
+
+  /**
+   * Set the absolute px-per-pt zoom scale, clamped inline to
+   * `[zoomMin ?? 0.1, zoomMax ?? 4]` (absolute bounds, XlsxViewer convention — NOT
+   * multiples of the base fit; design §3 keeps the clamp in the viewer, not core),
+   * then re-anchor VERTICALLY so the page currently under the viewport top stays
+   * fixed. A no-op when nothing is loaded or when the clamped scale is unchanged.
+   *
+   * Re-anchor (written from scratch — XlsxViewer only re-anchors horizontally):
+   * capture `top = topIndex` and the intra-page fraction `intraFrac` from the
+   * CURRENT range BEFORE rescale; after recomputing heights at the new scale,
+   * `newScrollTop = offsets'[top] + intraFrac × heights'[top]`, clamped to
+   * `[0, totalHeight' − viewportHeight]`. Because a page's height scales linearly
+   * with `_scale`, the same fractional position maps exactly to the new geometry.
+   */
+  setScale(scale: number): void {
+    if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) return;
+    const zoomMin = this._opts.zoomMin ?? 0.1;
+    const zoomMax = this._opts.zoomMax ?? 4;
+    const next = Math.min(zoomMax, Math.max(zoomMin, scale));
+    if (next === this._scale) return;
+
+    // Capture the anchor from the CURRENT layout, before rescale.
+    const r0 = this._range();
+    const top = r0.topIndex;
+    const h0 = this._heights[top] || 0;
+    // intraFrac: the fraction of page `top` that has scrolled above the viewport
+    // top. Clamp to [0,1] — a scrollTop inside the trailing gap after page `top`
+    // is attributed to `top` by computeVisibleRange and would push intraFrac past
+    // 1, which would drift the re-anchor into the gap; pin the page instead.
+    let intraFrac = h0 > 0 ? (this._scrollHost.scrollTop - r0.offsets[top]) / h0 : 0;
+    intraFrac = Math.min(1, Math.max(0, intraFrac));
+
+    // Bump the render epoch BEFORE recycling/re-dispatching so any in-flight
+    // render dispatched at the old scale is recognised as stale on resolution.
+    this._renderEpoch++;
+
+    // Rescale, recompute heights, resize the spacer to the new total height.
+    this._scale = next;
+    this._recomputeHeights();
+    const r1 = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    this._spacer.style.height = `${r1.totalHeight}px`;
+
+    // Pin the same fractional position of the same page under the viewport top.
+    const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);
+    const wantTop = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
+    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, wantTop));
+
+    // Re-mount at the new geometry, forcing a re-render of every slot (its px
+    // size changed under the new scale, so the cached canvas is stale).
+    this._mountVisibleForceRerender();
+  }
+
+  /** Like `_mountVisible` but recycles every live slot first so each re-mounts and
+   *  re-renders at the current scale. Used by `setScale` (and the T6 resize
+   *  re-fit): a slot's canvas px size changes with the scale, so the previously
+   *  drawn pixels are stale and every visible page must be redrawn. */
+  private _mountVisibleForceRerender(): void {
+    for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
+    this._mountVisible();
   }
 
   get topVisiblePage(): number {
@@ -518,6 +634,16 @@ export class DocxScrollViewer {
   /** @internal test hook: page indices currently mounted. */
   mountedPageIndicesForTest(): number[] {
     return [...this._slots.keys()];
+  }
+
+  /** @internal test hook: the current absolute px-per-pt scale. */
+  scaleForTest(): number {
+    return this._scale;
+  }
+
+  /** @internal test hook: the base fit scale (pre-zoom) at the current width. */
+  baseScaleForTest(): number {
+    return this._baseScale();
   }
 
   /**
@@ -530,6 +656,10 @@ export class DocxScrollViewer {
     if (this._scrollListener) {
       this._scrollHost.removeEventListener('scroll', this._scrollListener);
       this._scrollListener = null;
+    }
+    if (this._wheelListener) {
+      this._scrollHost.removeEventListener('wheel', this._wheelListener as EventListener);
+      this._wheelListener = null;
     }
     for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
     this._free.length = 0;

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -548,17 +548,33 @@ export class DocxScrollViewer {
       this._reportRenderError(err);
     } finally {
       this._bitmapInFlight.delete(i);
-      // Re-dispatch when a LIVE slot for page `i` still awaits a correct render
-      // and this invocation did NOT paint it. Two mid-flight cases produce that:
-      //  - page `i` re-mounted onto a DIFFERENT slot while we ran (identity moved,
-      //    the re-mount's dispatch was coalesced away by the in-flight guard), or
-      //  - a `setScale` bumped the epoch (this bitmap was at the old scale; the
-      //    live slot may be the SAME object reused from the pool, so a `live !==
-      //    slot` test would wrongly skip it).
-      // `!painted` covers both without special-casing which staleness fired; when
-      // we DID paint, `live === slot` and no re-dispatch is needed.
+      // Re-dispatch ONLY when this invocation went stale — a LIVE slot for page
+      // `i` still awaits a correct render and the reason we didn't paint was
+      // staleness, not a render failure. The two staleness cases:
+      //  - IDENTITY MOVED (`live !== slot`): page `i` re-mounted onto a DIFFERENT
+      //    slot while we ran (the re-mount's own dispatch was coalesced away by
+      //    the in-flight guard), so the live slot has no render in flight.
+      //  - EPOCH MOVED (`epoch !== this._renderEpoch`): a `setScale` bumped the
+      //    epoch mid-flight, so this bitmap was at a superseded scale. The live
+      //    slot may be the SAME object reused from the pool, which the identity
+      //    test alone would miss — the epoch test catches the same-slot case.
+      // NO RETRY ON PLAIN REJECTION: when the slot is still live at the same epoch
+      // and we simply failed (`renderPageToBitmap` rejected or the transfer threw),
+      // `!painted` holds but BOTH staleness tests are false, so we do NOT
+      // re-dispatch. Retrying a plain failure would loop unbounded (reject →
+      // re-dispatch → reject → …); the onError contract is that "a failed page is
+      // left blank" (see DocxScrollViewerOptions.onError), so we leave it blank.
+      // Bounded epoch-then-reject: an epoch-moved re-dispatch captures the NEW
+      // epoch, so if that fresh render then rejects at the still-current epoch,
+      // both tests are false and it stops — no unbounded retry.
       const live = this._slots.get(i);
-      if (!painted && live && !this._bitmapInFlight.has(i) && !this._destroyed) {
+      if (
+        !painted &&
+        live &&
+        (live !== slot || epoch !== this._renderEpoch) &&
+        !this._bitmapInFlight.has(i) &&
+        !this._destroyed
+      ) {
         // live.renderedPage === i already (set by _renderSlot on mount); the fresh
         // dispatch runs at the CURRENT epoch/scale via _pageWidthPx(i).
         void this._renderSlotBitmap(i, live, this._pageWidthPx(i), this._dpr());
@@ -579,6 +595,12 @@ export class DocxScrollViewer {
    * `newScrollTop = offsets'[top] + intraFrac × heights'[top]`, clamped to
    * `[0, totalHeight' − viewportHeight]`. Because a page's height scales linearly
    * with `_scale`, the same fractional position maps exactly to the new geometry.
+   *
+   * CAVEAT — base fit below the floor: `relayout()` sets `_scale = base` WITHOUT
+   * clamping to `[zoomMin, zoomMax]`. If the base fit is below `zoomMin` (a wide
+   * page in a narrow container), the initial scale sits under the floor, but once
+   * the user zooms via `setScale` the clamp pins the minimum to `zoomMin`, so they
+   * can no longer return below the floor to the original base fit through this API.
    */
   setScale(scale: number): void {
     if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) return;

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,6 +1,8 @@
 import { computeVisibleRange, PT_TO_PX, type VisibleRange } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
+import type { DocxTextRunInfo } from './renderer';
+import { buildDocxTextLayer } from './text-layer';
 import type { RenderPageOptions } from './types';
 
 /**
@@ -87,6 +89,11 @@ export class DocxScrollViewer {
   private _lastRange: VisibleRange | null = null;
   private _lastTopIndex = -1;
   private _scrollListener: (() => void) | null = null;
+  /** Worker mode: page indices whose bitmap render is currently dispatched to the
+   *  engine. Coalesces a scroll storm — we never dispatch a second render for a
+   *  page whose first is still in flight — and lets us drop pages that scrolled
+   *  out of the window before dispatch (design §11 worker coalescing). */
+  private readonly _bitmapInFlight = new Set<number>();
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
     this._container = container;
@@ -328,9 +335,133 @@ export class DocxScrollViewer {
     slot.wrapper.style.height = `${hpx}px`;
   }
 
-  /** Rendered by T3. Stubbed here so the mount loop compiles. */
-  private _renderSlot(_i: number, _slot: PageSlot): void {
-    // filled in T3
+  /** Device-pixel ratio for a render (opts override → window → 1). */
+  private _dpr(): number {
+    return this._opts.dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+  }
+
+  /**
+   * Render page `i` into `slot`. Routes strictly on the constructor-resolved
+   * `_mode` (design §11 — no probing, no silent mis-pathing): `main` ⇒ paint the
+   * slot's canvas directly via `renderPage`; `worker` ⇒ transfer an ImageBitmap
+   * from `renderPageToBitmap`.
+   *
+   * Slot-identity guard: a slot recycled to a DIFFERENT page while a previous
+   * render is in flight must not repaint the stale page. `slot.renderedPage`
+   * tracks the page this slot is committed to; we stamp it up-front and bail on
+   * resolution if it changed (the engine's own token guard is per-canvas; this is
+   * the viewer's per-slot page-identity check).
+   */
+  private _renderSlot(i: number, slot: PageSlot): void {
+    if (!this._doc) return;
+    // Slot-identity guard: this slot is already rendering / has rendered page i.
+    if (slot.renderedPage === i) return;
+    slot.renderedPage = i;
+
+    const dpr = this._dpr();
+    const widthPx = this._pageWidthPx(i);
+
+    if (this._mode === 'worker') {
+      void this._renderSlotBitmap(i, slot, widthPx, dpr);
+      return;
+    }
+
+    // Main mode: render straight onto the slot's canvas.
+    const runs: DocxTextRunInfo[] = [];
+    const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const onTextRun = wantOverlay ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
+    this._doc
+      .renderPage(slot.canvas, i, {
+        width: widthPx, // this page's own px width → uniform px-per-pt scale (§7)
+        dpr,
+        defaultTextColor: this._opts.defaultTextColor,
+        showTrackChanges: this._opts.showTrackChanges,
+        onTextRun,
+      })
+      .then(() => {
+        // A recycle may have re-purposed this slot for a different page (or freed
+        // it) mid-render; bail without painting the stale page.
+        if (this._slots.get(i) !== slot || slot.renderedPage !== i) return;
+        if (wantOverlay && slot.textLayer) {
+          buildDocxTextLayer(
+            slot.textLayer,
+            runs,
+            slot.canvas.style.width || `${slot.canvas.width}px`,
+            slot.canvas.style.height || `${slot.canvas.height}px`,
+          );
+        }
+      })
+      .catch((err: unknown) => {
+        this._opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+      });
+  }
+
+  /**
+   * Worker-mode slot render: dispatch `renderPageToBitmap`, transfer the result
+   * via a per-slot `bitmaprenderer` context, and manage the ImageBitmap lifecycle.
+   *
+   * Coalescing / drop-stale (design §11):
+   *  - Skip if page `i` is already in flight (a scroll storm won't double-dispatch).
+   *  - Skip if page `i` already left the mounted window before dispatch.
+   *  - On resolution, if `slot` is no longer THIS page's live slot (it recycled to
+   *    another page, or page `i` re-mounted onto a DIFFERENT slot while this render
+   *    was in flight), close the orphan bitmap and skip the paint. In that
+   *    re-mount case a live slot for `i` still awaits a render, so once we clear
+   *    the in-flight guard we re-dispatch it — a page that recycled and re-mounted
+   *    mid-flight must never stay blank.
+   */
+  private async _renderSlotBitmap(i: number, slot: PageSlot, widthPx: number, dpr: number): Promise<void> {
+    if (this._bitmapInFlight.has(i)) return; // coalesce: already dispatched
+    // Drop-stale before dispatch: if this page already scrolled out of the
+    // mounted window, don't dispatch at all.
+    if (this._slots.get(i) !== slot) return;
+    this._bitmapInFlight.add(i);
+    // Grab the bitmaprenderer ctx ONCE per canvas — a canvas holds one context
+    // type for its lifetime. A recycled canvas keeps the ctx grabbed on its
+    // first worker render (bitmapCtx survives recycle), so we never re-getContext
+    // a canvas that already has one (which would throw a type-flip in the DOM).
+    if (!slot.bitmapCtx) {
+      slot.bitmapCtx = slot.canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext | null;
+    }
+    try {
+      const bmp = await this._doc!.renderPageToBitmap(i, {
+        width: widthPx,
+        dpr,
+        showTrackChanges: this._opts.showTrackChanges,
+      });
+      // The slot may have recycled to a different page while the worker ran, or
+      // page `i` may have re-mounted onto a DIFFERENT slot. Either way this bitmap
+      // is stale for THIS slot: close it and skip the paint (drop-stale, §11).
+      if (this._slots.get(i) !== slot || slot.renderedPage !== i) {
+        bmp.close();
+        return;
+      }
+      // Close the slot's previous bitmap, then hold the new one BEFORE transfer so
+      // a concurrent recycle between now and transfer can close it (the recycle
+      // path closes slot.bitmap). transferFromImageBitmap consumes the bitmap, so
+      // we null the field immediately after — leaving nothing to double-close.
+      if (slot.bitmap) slot.bitmap.close();
+      slot.bitmap = bmp;
+      slot.canvas.width = bmp.width;
+      slot.canvas.height = bmp.height;
+      slot.canvas.style.width = `${Math.round(bmp.width / dpr)}px`;
+      slot.canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
+      slot.bitmapCtx?.transferFromImageBitmap(bmp);
+      slot.bitmap = null; // transfer consumed it
+    } catch (err) {
+      this._opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      this._bitmapInFlight.delete(i);
+      // If a LIVE slot for page `i` still awaits its render (page `i` re-mounted
+      // onto a different slot while this render was in flight, so the re-mount's
+      // dispatch was coalesced away), issue it now that the guard is clear.
+      const live = this._slots.get(i);
+      if (live && live !== slot && !this._bitmapInFlight.has(i)) {
+        // live.renderedPage === i already (set by _renderSlot on mount); the
+        // dispatch was swallowed by the in-flight guard, not the identity guard.
+        void this._renderSlotBitmap(i, live, this._pageWidthPx(i), this._dpr());
+      }
+    }
   }
 
   get topVisiblePage(): number {

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -710,9 +710,15 @@ export class DocxScrollViewer {
    * `opts.behavior` ('auto' | 'smooth', default 'auto') is honoured via
    * `scrollHost.scrollTo({ top, behavior })` when the host supports it (a real
    * browser); the stub-DOM has no `scrollTo`, so the fallback sets `scrollTop`
-   * directly (which is what the tests assert). After moving we re-mount the
-   * visible window synchronously so the target page's slots exist immediately
-   * (a `smooth` scroll's own `scroll` events would otherwise mount them lazily).
+   * directly (which is what the tests assert). We then call `_mountVisible` once.
+   *
+   * MOUNTING CAVEAT: synchronous mounting of the target page is guaranteed only on
+   * the DEFAULT/'auto' path — there `scrollTop` has already jumped to `top`, so the
+   * `_mountVisible` call reads the final scroll position and the target page's slots
+   * exist immediately. With `behavior: 'smooth'` the scroll animates ASYNCHRONOUSLY:
+   * `scrollTop` is still near the old position when `_mountVisible` runs, so the
+   * target page mounts lazily via the animation's subsequent `scroll` events, not
+   * from this call.
    */
   scrollToPage(index: number, opts?: { behavior?: 'auto' | 'smooth' }): void {
     if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) return;
@@ -737,8 +743,10 @@ export class DocxScrollViewer {
    * Re-fit the base scale on a container resize while PRESERVING the current zoom
    * multiplier (design §11), then re-anchor + re-render. A `ResizeObserver` fires
    * on any box change, but only a WIDTH change alters the fit-to-width base scale;
-   * a height-only change is ignored (the visible window is recomputed on the next
-   * scroll/relayout anyway). Empty/unloaded ⇒ no-op; a still-zero width ⇒ defer.
+   * a height-only change skips the re-fit yet STILL re-mounts the visible window
+   * (via `_mountVisible`), because a taller viewport reveals rows that were below
+   * the fold and would otherwise stay blank until the next scroll. Empty/unloaded
+   * ⇒ no-op; a still-zero width ⇒ defer.
    *
    * Zero-width recovery: a container that was 0-wide at construction never
    * established a scale (`_scaleEstablished` is false), so the first non-zero
@@ -750,8 +758,10 @@ export class DocxScrollViewer {
    * Routing through `setScale(newScale)` bumps `_renderEpoch` (resize IS an epoch
    * event — T4 banner) and re-anchors + force-re-renders every slot at the new
    * geometry, exactly like a zoom. `setScale`'s clamp/no-op guards apply: an
-   * unchanged newScale (identical width) is a no-op there, so we also short-circuit
-   * before it when the width is unchanged to avoid churn.
+   * unchanged newScale (identical width) is a no-op there — so we short-circuit
+   * BEFORE it when the fit-width is unchanged (mounting the revealed window without
+   * a needless force-re-render), and after it we call `_mountVisible` again to cover
+   * the case where the clamp made `setScale` no-op yet the viewport still grew.
    */
   private _onResize(): void {
     if (!this._doc || this._doc.pageCount === 0) return;
@@ -763,14 +773,41 @@ export class DocxScrollViewer {
     const newBase = this._baseScale();
     if (newBase <= 0) return; // still unlaid-out — wait for the next resize
     const newFitWidth = this._fitWidthPx();
-    if (newFitWidth === this._lastFitWidth) return; // height-only change — no re-fit
+    if (newFitWidth === this._lastFitWidth) {
+      // Height-only change (or any resize that leaves the fit-width identical):
+      // the base scale is unchanged, so there is no re-fit to do — but a taller
+      // viewport now exposes rows that were below the fold. `_mountVisible`
+      // recomputes the visible range from the CURRENT clientHeight and mounts the
+      // newly-revealed pages; without it those rows stay blank until the user
+      // scrolls (which recomputes the range). No epoch bump — the geometry
+      // (and every mounted slot's px size) is unchanged, so cached canvases are
+      // still valid; we only add the missing slots.
+      this._mountVisible();
+      return;
+    }
     this._lastFitWidth = newFitWidth;
     // Preserve the zoom multiplier across the re-fit: newScale = newBase × mult.
     const mult = this._prevBase > 0 ? this._scale / this._prevBase : 1;
     this._prevBase = newBase;
     // Route through setScale so the epoch bumps and the re-anchor/force-re-render
     // path runs identically to a zoom.
+    //
+    // zoomMin RATCHET (design §8.1 caveat, see setScale JSDoc): `zoomMin`/`zoomMax`
+    // are ABSOLUTE px-per-pt bounds, but the re-fit base (`newBase × mult`) is
+    // computed UNCLAMPED. A resize that transits the scale below `zoomMin × pageWidth`
+    // (a wide page in a container that briefly narrows) is clamped UP by `setScale`,
+    // which permanently inflates the implied multiplier even with zero user zoom —
+    // the next re-fit reads back the clamped `_scale` as `mult`. This is bounded and
+    // converges (the clamp floor is fixed), but it means the preserved multiplier can
+    // drift above 1 purely from resize transits below the floor. Accepted consequence
+    // of using absolute bounds (§8.1) with an unclamped relayout base.
     this.setScale(newBase * mult);
+    // `setScale` no-ops when the clamped scale is unchanged (e.g. already pinned at
+    // a clamp boundary), which would skip its `_mountVisibleForceRerender`. A
+    // width+height growth that ends up clamped to the same scale must still reveal
+    // the taller viewport's rows, so mount here too. Idempotent when `setScale` ran:
+    // the window is already mounted and every present slot is a re-position no-op.
+    this._mountVisible();
   }
 
   get topVisiblePage(): number {

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -123,8 +123,8 @@ export class DocxScrollViewer {
    *  moved epoch ⇒ STALE (close + re-dispatch the live slot). See
    *  `_renderSlotBitmap`. */
   private readonly _bitmapInFlight = new Set<number>();
-  /** Render generation, bumped on every effective `setScale` (and the T6 resize
-   *  re-fit, which routes through `setScale`). Stamped into each async render
+  /** Render generation, bumped on every effective `setScale` (and the resize
+   *  re-fit in `_onResize`, which routes through `setScale`). Stamped into each async render
    *  dispatch; a resolution whose captured epoch ≠ this value is STALE — its
    *  pixels/geometry are at a superseded scale. Worker path: close the orphan
    *  bitmap + re-dispatch the live slot. Main path: skip the (stale) text-layer
@@ -136,6 +136,17 @@ export class DocxScrollViewer {
    *  cannot cross the worker boundary, so an `enableTextSelection` overlay stays
    *  empty. We warn once (parity with `DocxViewer`) rather than per slot. */
   private _warnedNoTextSelection = false;
+  /** Observes the container so a width change re-fits the base scale. Disconnected
+   *  in `destroy()`. */
+  private _resizeObserver: ResizeObserver | null = null;
+  /** The base fit scale at the last established/re-fit layout. `_onResize` divides
+   *  `_scale` by this to recover the current zoom multiplier so a width change
+   *  re-fits the base while preserving the user's zoom (design §11). */
+  private _prevBase = 0;
+  /** The fit width (px) the base scale was last established at. Lets `_onResize`
+   *  skip the re-fit when only the height changed (a ResizeObserver fires on ANY
+   *  box change, but only a WIDTH change alters the fit-to-width base scale). */
+  private _lastFitWidth = 0;
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
     this._container = container;
@@ -188,11 +199,19 @@ export class DocxScrollViewer {
       });
     }
 
+    // Re-fit the base scale on a container resize (design §11). A container that
+    // is 0-wide at construction (a common flexbox/tab layout) establishes its
+    // scale on the first non-zero resize — the zero-width deferral is completed
+    // here. `ResizeObserver` may be absent in a non-DOM host; guard for it.
+    if (typeof ResizeObserver !== 'undefined') {
+      this._resizeObserver = new ResizeObserver(() => this._onResize());
+      this._resizeObserver.observe(this._container);
+    }
+
     if (this._injected) {
       // An injected engine is already loaded, so lay out + mount the first
       // window immediately. relayout() is idempotent and defers under a
-      // zero-width container (the resize path — T6 — re-runs it once width
-      // appears).
+      // zero-width container (the resize path re-runs it once width appears).
       this.relayout();
     }
   }
@@ -217,8 +236,8 @@ export class DocxScrollViewer {
       });
       // Lay out + mount the first window now that the engine exists (mirrors the
       // injected-engine path in the constructor). relayout() is idempotent and
-      // defers under a zero-width container — the resize path (T6) re-runs it
-      // once width appears.
+      // defers under a zero-width container — `_onResize` re-runs it once width
+      // appears.
       this.relayout();
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
@@ -274,6 +293,8 @@ export class DocxScrollViewer {
       const base = this._baseScale();
       if (base > 0) {
         this._scale = base;
+        this._prevBase = base;
+        this._lastFitWidth = this._fitWidthPx();
         this._scaleEstablished = true;
       } else {
         return; // container has no width yet — retry on the next resize
@@ -344,7 +365,10 @@ export class DocxScrollViewer {
         this._positionSlot(this._slots.get(i)!, i, r);
       }
     }
-    // onVisiblePageChange only on change (T6 refines; wired here for topIndex).
+    // onVisiblePageChange fires ONLY when the top visible page actually changes
+    // (change-only latch; `_lastTopIndex` starts at -1 so the first layout fires
+    // once for page 0). Every mount path — scroll, zoom, resize re-fit, and
+    // scrollToPage — funnels through here, so navigation never double-fires.
     if (r.topIndex !== this._lastTopIndex) {
       this._lastTopIndex = r.topIndex;
       this._opts.onVisiblePageChange?.(r.topIndex, this._doc.pageCount);
@@ -668,12 +692,85 @@ export class DocxScrollViewer {
   }
 
   /** Like `_mountVisible` but recycles every live slot first so each re-mounts and
-   *  re-renders at the current scale. Used by `setScale` (and the T6 resize
-   *  re-fit): a slot's canvas px size changes with the scale, so the previously
+   *  re-renders at the current scale. Used by `setScale` (and the resize re-fit
+   *  in `_onResize`, which routes through `setScale`): a slot's canvas px size
+   *  changes with the scale, so the previously
    *  drawn pixels are stale and every visible page must be redrawn. */
   private _mountVisibleForceRerender(): void {
     for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
     this._mountVisible();
+  }
+
+  /**
+   * Scroll so page `index`'s top edge sits at the viewport top. Clamps `index` to
+   * `[0, pageCount-1]` (the pager convention) and the resulting scrollTop to
+   * `[0, totalHeight − viewportHeight]` so the last pages don't scroll past the
+   * end. A no-op when nothing is loaded or the document is empty.
+   *
+   * `opts.behavior` ('auto' | 'smooth', default 'auto') is honoured via
+   * `scrollHost.scrollTo({ top, behavior })` when the host supports it (a real
+   * browser); the stub-DOM has no `scrollTo`, so the fallback sets `scrollTop`
+   * directly (which is what the tests assert). After moving we re-mount the
+   * visible window synchronously so the target page's slots exist immediately
+   * (a `smooth` scroll's own `scroll` events would otherwise mount them lazily).
+   */
+  scrollToPage(index: number, opts?: { behavior?: 'auto' | 'smooth' }): void {
+    if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) return;
+    const clamped = Math.max(0, Math.min(index, this._doc.pageCount - 1));
+    // Recompute offsets from the current heights (independent of scrollTop).
+    const r = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    const target = r.offsets[clamped] ?? 0;
+    const maxTop = Math.max(0, r.totalHeight - this._scrollHost.clientHeight);
+    const top = Math.min(maxTop, Math.max(0, target));
+    const host = this._scrollHost as HTMLDivElement & {
+      scrollTo?: (opts: { top: number; behavior?: 'auto' | 'smooth' }) => void;
+    };
+    if (typeof host.scrollTo === 'function') {
+      host.scrollTo({ top, behavior: opts?.behavior ?? 'auto' });
+    } else {
+      this._scrollHost.scrollTop = top;
+    }
+    this._mountVisible();
+  }
+
+  /**
+   * Re-fit the base scale on a container resize while PRESERVING the current zoom
+   * multiplier (design §11), then re-anchor + re-render. A `ResizeObserver` fires
+   * on any box change, but only a WIDTH change alters the fit-to-width base scale;
+   * a height-only change is ignored (the visible window is recomputed on the next
+   * scroll/relayout anyway). Empty/unloaded ⇒ no-op; a still-zero width ⇒ defer.
+   *
+   * Zero-width recovery: a container that was 0-wide at construction never
+   * established a scale (`_scaleEstablished` is false), so the first non-zero
+   * resize establishes it here via `relayout()` — completing the T2 deferral.
+   *
+   * Re-fit math (zoom multiplier preserved):
+   *   mult      = _scale / _prevBase            (the user's zoom over the old base)
+   *   newScale  = newBase × mult
+   * Routing through `setScale(newScale)` bumps `_renderEpoch` (resize IS an epoch
+   * event — T4 banner) and re-anchors + force-re-renders every slot at the new
+   * geometry, exactly like a zoom. `setScale`'s clamp/no-op guards apply: an
+   * unchanged newScale (identical width) is a no-op there, so we also short-circuit
+   * before it when the width is unchanged to avoid churn.
+   */
+  private _onResize(): void {
+    if (!this._doc || this._doc.pageCount === 0) return;
+    // Zero-width recovery: first non-zero layout establishes the base scale.
+    if (!this._scaleEstablished) {
+      this.relayout();
+      return;
+    }
+    const newBase = this._baseScale();
+    if (newBase <= 0) return; // still unlaid-out — wait for the next resize
+    const newFitWidth = this._fitWidthPx();
+    if (newFitWidth === this._lastFitWidth) return; // height-only change — no re-fit
+    this._lastFitWidth = newFitWidth;
+    // Preserve the zoom multiplier across the re-fit: newScale = newBase × mult.
+    const mult = this._prevBase > 0 ? this._scale / this._prevBase : 1;
+    this._prevBase = newBase;
+    // Route through setScale so the epoch bumps and the re-anchor/force-re-render
+    // path runs identically to a zoom.
+    this.setScale(newBase * mult);
   }
 
   get topVisiblePage(): number {
@@ -695,6 +792,17 @@ export class DocxScrollViewer {
     return this._baseScale();
   }
 
+  /** @internal test hook: the current render epoch (bumped on setScale + resize). */
+  renderEpochForTest(): number {
+    return this._renderEpoch;
+  }
+
+  /** @internal test hook: fire the observed resize path (a real host drives this
+   *  via the constructor's ResizeObserver). */
+  resizeForTest(): void {
+    this._onResize();
+  }
+
   /**
    * Tear down the viewer: remove the DOM subtree and (only for a self-loaded
    * engine) destroy the engine. An injected engine is left intact — the caller
@@ -710,6 +818,8 @@ export class DocxScrollViewer {
       this._scrollHost.removeEventListener('wheel', this._wheelListener as EventListener);
       this._wheelListener = null;
     }
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
     for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
     this._free.length = 0;
     if (!this._injected) {

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -281,8 +281,18 @@ export class DocxScrollViewer {
     return w / (firstWpt * PT_TO_PX);
   }
 
-  /** Recompute heights + spacer, then mount the visible window. Called after
-   *  load, resize, and zoom. Idempotent. */
+  /**
+   * Recompute per-page heights + the spacer and re-mount the visible window.
+   *
+   * The viewer already calls this automatically after `load()`, an injected
+   * engine, a container resize, and a zoom, so most integrations never need it.
+   * It is public as a deliberate escape hatch: if the host mutates the layout in
+   * a way the `ResizeObserver` cannot observe (e.g. a CSS change on an ancestor
+   * that resizes the container without a box-size event, or a font that finishes
+   * loading after first paint), call `relayout()` to force a re-fit. Idempotent —
+   * safe to call repeatedly, and a no-op while the container has zero width (the
+   * fit is deferred until width appears, design §11).
+   */
   relayout(): void {
     if (!this._doc) return;
     // Establish the base fit scale on the first layout that has a positive

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -131,6 +131,11 @@ export class DocxScrollViewer {
    *  build; the engine's per-canvas token already discards the stale pixels. */
   private _renderEpoch = 0;
   private _wheelListener: ((e: WheelEvent) => void) | null = null;
+  /** One-shot latch for the worker-mode text-selection warning. The overlay is a
+   *  main-mode-only feature: in worker mode the per-run `onTextRun` geometry
+   *  cannot cross the worker boundary, so an `enableTextSelection` overlay stays
+   *  empty. We warn once (parity with `DocxViewer`) rather than per slot. */
+  private _warnedNoTextSelection = false;
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
     this._container = container;
@@ -378,6 +383,11 @@ export class DocxScrollViewer {
       slot.bitmap.close();
       slot.bitmap = null;
     }
+    // Clear the per-slot text overlay so a slot sitting in the free pool holds no
+    // stale spans. buildDocxTextLayer also clears on its next build, but an
+    // unrendered pooled slot never gets that build, and the detached spans would
+    // otherwise linger; drop them here.
+    if (slot.textLayer) slot.textLayer.innerHTML = '';
     slot.renderedPage = -1;
     slot.wrapper.remove();
     this._free.push(slot);
@@ -465,6 +475,18 @@ export class DocxScrollViewer {
       });
   }
 
+  /** Warn once when an `enableTextSelection` overlay was requested but the render
+   *  mode is `worker` (so the overlay stays empty). Same wording as
+   *  `DocxViewer._render` — one warning per viewer, not per slot. */
+  private _maybeWarnNoTextSelection(): void {
+    if (this._opts.enableTextSelection && !this._warnedNoTextSelection) {
+      this._warnedNoTextSelection = true;
+      console.warn(
+        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
+      );
+    }
+  }
+
   /** Route an async render failure to `onError`, or `console.error` when none is
    *  set (so failures are never fully silent), and never after teardown. */
   private _reportRenderError(err: unknown): void {
@@ -495,6 +517,11 @@ export class DocxScrollViewer {
    *    live slot at the new scale, never paint the old-scale bitmap.
    */
   private async _renderSlotBitmap(i: number, slot: PageSlot, widthPx: number, dpr: number): Promise<void> {
+    // Worker-mode + enableTextSelection: the overlay can't be populated (onTextRun
+    // doesn't cross the worker boundary), so warn once (parity with DocxViewer)
+    // and leave the overlay empty. Fires before the coalescing guards so it is
+    // reported even when this particular dispatch is coalesced/dropped.
+    this._maybeWarnNoTextSelection();
     if (this._bitmapInFlight.has(i)) return; // coalesce: already dispatched
     // Drop-stale before dispatch: if this page already scrolled out of the
     // mounted window, don't dispatch at all.

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -7,9 +7,15 @@ import type { RenderPageOptions } from './types';
 
 /**
  * Options for {@link DocxScrollViewer}. Extends `RenderPageOptions` (per-page
- * render knobs) and `LoadOptions` (parse/worker knobs). See design §8.1.
+ * render knobs, minus `onTextRun`) and `LoadOptions` (parse/worker knobs). See
+ * design §8.1.
+ *
+ * `onTextRun` is omitted deliberately: the viewer drives it internally per
+ * mounted slot to build the optional per-page selection overlay (gated by
+ * `enableTextSelection`), so exposing it here would let a caller's callback be
+ * silently overridden.
  */
-export interface DocxScrollViewerOptions extends RenderPageOptions, LoadOptions {
+export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onTextRun'>, LoadOptions {
   /** Base fit width in CSS px → base zoom scale. Default: the container's width
    *  at first non-zero layout (design §7/§11 zero-width deferral). */
   width?: number;
@@ -38,8 +44,12 @@ export interface DocxScrollViewerOptions extends RenderPageOptions, LoadOptions 
    *  `computeVisibleRange` (the first page intersecting the viewport top,
    *  EXCLUDING overscan). */
   onVisiblePageChange?: (topIndex: number, total: number) => void;
-  /** Error callback. When set, `load()` invokes it and resolves; otherwise the
-   *  error is rethrown (shared viewer error contract). */
+  /** Error callback. When set, `load()` invokes it and resolves (otherwise the
+   *  error is rethrown — shared viewer error contract). It ALSO fires for async
+   *  per-slot render failures (both main `renderPage` and worker
+   *  `renderPageToBitmap` rejections); a failed page is left blank rather than
+   *  crashing the loop. Without an `onError`, render failures are logged via
+   *  `console.error` so they are never fully silent. */
   onError?: (err: Error) => void;
 }
 
@@ -52,7 +62,11 @@ interface PageSlot {
   textLayer: HTMLDivElement | null;
   /** page index this slot is currently rendering / has rendered, or -1 when free. */
   renderedPage: number;
-  /** worker-mode: the last ImageBitmap painted into this slot, to `.close()` on recycle. */
+  /** worker-mode: a transient hold on a just-received ImageBitmap, set only
+   *  between receipt from the worker and its `transferFromImageBitmap` (which
+   *  consumes it, after which we null the field). Its purpose is the throw path:
+   *  if the transfer throws, `destroy()`/`_recycleSlot` can still find and
+   *  `.close()` the bitmap. Normally null once transfer completes. */
   bitmap: ImageBitmap | null;
   /** bitmaprenderer ctx (worker mode), grabbed once per canvas. */
   bitmapCtx: ImageBitmapRenderingContext | null;
@@ -89,10 +103,26 @@ export class DocxScrollViewer {
   private _lastRange: VisibleRange | null = null;
   private _lastTopIndex = -1;
   private _scrollListener: (() => void) | null = null;
+  /** Set by `destroy()`. Async render callbacks (main + worker) check it before
+   *  reporting an error so a rejection that lands after teardown is swallowed
+   *  rather than surfaced to a `onError` on a dead viewer. */
+  private _destroyed = false;
   /** Worker mode: page indices whose bitmap render is currently dispatched to the
    *  engine. Coalesces a scroll storm — we never dispatch a second render for a
    *  page whose first is still in flight — and lets us drop pages that scrolled
-   *  out of the window before dispatch (design §11 worker coalescing). */
+   *  out of the window before dispatch (design §11 worker coalescing).
+   *
+   *  T4 ZOOM HAZARD (must fix when `setScale` lands): coalescing keys on page
+   *  INDEX only, with no notion of the scale a dispatch was made at. When
+   *  `setScale` changes the zoom mid-flight, an in-flight bitmap dispatched at the
+   *  OLD scale can still pass the on-resolution identity check (`_slots.get(i) ===
+   *  slot && slot.renderedPage === i`) if the same slot is still mounted for page
+   *  `i`, and get painted at the WRONG resolution — with no re-dispatch, because
+   *  the index is (or was) already in this Set. T4 MUST either (a) add a render
+   *  epoch/generation bumped on every `setScale` and fold it into the in-flight
+   *  identity (dispatch at epoch E, drop on resolve if the live epoch moved), or
+   *  (b) on scale change clear `_bitmapInFlight` and force-redispatch the mounted
+   *  window. A same-index Set alone is not enough once scale is mutable. */
   private readonly _bitmapInFlight = new Set<number>();
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
@@ -157,7 +187,11 @@ export class DocxScrollViewer {
         math: this._opts.math,
         mode: this._mode,
       });
-      // Layout + first render wired in T2/T3.
+      // Lay out + mount the first window now that the engine exists (mirrors the
+      // injected-engine path in the constructor). relayout() is idempotent and
+      // defers under a zero-width container — the resize path (T6) re-runs it
+      // once width appears.
+      this.relayout();
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       if (this._opts.onError) {
@@ -276,7 +310,7 @@ export class DocxScrollViewer {
         const slot = this._acquireSlot();
         this._positionSlot(slot, i, r);
         this._slots.set(i, slot);
-        this._renderSlot(i, slot); // T3
+        this._renderSlot(i, slot);
       } else {
         // Re-position (offsets shift after a spacer/height change).
         this._positionSlot(this._slots.get(i)!, i, r);
@@ -292,7 +326,7 @@ export class DocxScrollViewer {
   private _acquireSlot(): PageSlot {
     const reused = this._free.pop();
     if (reused) {
-      reused.renderedPage = -1;
+      // _recycleSlot already reset renderedPage to -1 before pooling this slot.
       this._scrollHost.appendChild(reused.wrapper);
       return reused;
     }
@@ -302,7 +336,6 @@ export class DocxScrollViewer {
     canvas.style.cssText = 'display:block;background:#fff;';
     wrapper.appendChild(canvas);
     let textLayer: HTMLDivElement | null = null;
-    const bitmapCtx: ImageBitmapRenderingContext | null = null;
     if (this._opts.enableTextSelection) {
       textLayer = document.createElement('div');
       textLayer.style.cssText =
@@ -311,7 +344,7 @@ export class DocxScrollViewer {
       wrapper.appendChild(textLayer);
     }
     this._scrollHost.appendChild(wrapper);
-    const slot: PageSlot = { wrapper, canvas, textLayer, renderedPage: -1, bitmap: null, bitmapCtx };
+    const slot: PageSlot = { wrapper, canvas, textLayer, renderedPage: -1, bitmap: null, bitmapCtx: null };
     return slot;
   }
 
@@ -392,8 +425,17 @@ export class DocxScrollViewer {
         }
       })
       .catch((err: unknown) => {
-        this._opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+        this._reportRenderError(err);
       });
+  }
+
+  /** Route an async render failure to `onError`, or `console.error` when none is
+   *  set (so failures are never fully silent), and never after teardown. */
+  private _reportRenderError(err: unknown): void {
+    if (this._destroyed) return;
+    const e = err instanceof Error ? err : new Error(String(err));
+    if (this._opts.onError) this._opts.onError(e);
+    else console.error('[ooxml] DocxScrollViewer render failed:', e);
   }
 
   /**
@@ -419,7 +461,9 @@ export class DocxScrollViewer {
     // Grab the bitmaprenderer ctx ONCE per canvas — a canvas holds one context
     // type for its lifetime. A recycled canvas keeps the ctx grabbed on its
     // first worker render (bitmapCtx survives recycle), so we never re-getContext
-    // a canvas that already has one (which would throw a type-flip in the DOM).
+    // a canvas that already has one. (getContext for a conflicting type returns
+    // null rather than throwing; caching the first non-null ctx avoids relying on
+    // that and skips redundant lookups.)
     if (!slot.bitmapCtx) {
       slot.bitmapCtx = slot.canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext | null;
     }
@@ -427,6 +471,7 @@ export class DocxScrollViewer {
       const bmp = await this._doc!.renderPageToBitmap(i, {
         width: widthPx,
         dpr,
+        defaultTextColor: this._opts.defaultTextColor,
         showTrackChanges: this._opts.showTrackChanges,
       });
       // The slot may have recycled to a different page while the worker ran, or
@@ -436,10 +481,12 @@ export class DocxScrollViewer {
         bmp.close();
         return;
       }
-      // Close the slot's previous bitmap, then hold the new one BEFORE transfer so
-      // a concurrent recycle between now and transfer can close it (the recycle
-      // path closes slot.bitmap). transferFromImageBitmap consumes the bitmap, so
-      // we null the field immediately after — leaving nothing to double-close.
+      // Close any prior bitmap, then hold the new one on the slot BEFORE the
+      // transfer. JS is single-threaded so nothing recycles between here and the
+      // transfer; the hold's real value is the throw path — if
+      // transferFromImageBitmap throws, `destroy()`/`_recycleSlot` can still find
+      // and close this bitmap. transferFromImageBitmap consumes the bitmap, so we
+      // null the field immediately after — leaving nothing to double-close.
       if (slot.bitmap) slot.bitmap.close();
       slot.bitmap = bmp;
       slot.canvas.width = bmp.width;
@@ -449,7 +496,7 @@ export class DocxScrollViewer {
       slot.bitmapCtx?.transferFromImageBitmap(bmp);
       slot.bitmap = null; // transfer consumed it
     } catch (err) {
-      this._opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+      this._reportRenderError(err);
     } finally {
       this._bitmapInFlight.delete(i);
       // If a LIVE slot for page `i` still awaits its render (page `i` re-mounted
@@ -479,6 +526,7 @@ export class DocxScrollViewer {
    * owns its lifecycle. Per-slot worker ImageBitmaps are closed on recycle.
    */
   destroy(): void {
+    this._destroyed = true;
     if (this._scrollListener) {
       this._scrollHost.removeEventListener('scroll', this._scrollListener);
       this._scrollListener = null;

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -144,6 +144,7 @@ export class DocxViewer {
       const bmp = await this._doc.renderPageToBitmap(this._currentPage, {
         width: this._opts.width,
         dpr: this._opts.dpr,
+        defaultTextColor: this._opts.defaultTextColor,
         showTrackChanges: this._opts.showTrackChanges,
       });
       this._canvas.width = bmp.width;


### PR DESCRIPTION
## Summary

**WS4a of #572** — the feature the issue asked for: scroll through every page of a document in **one component**. `DocxScrollViewer(container, opts)` owns a scroll container and virtualizes pages: only the visible window (+overscan) holds live canvases, pooled and recycled; large documents stay fast.

Built entirely on the previously-merged substrate: `pageSize(i)` fact (WS1), `computeVisibleRange`/`zoomStepScale` (WS2), `buildDocxTextLayer` (WS3) — the viewer is Layer-3 policy + DOM only (design 3-layer separation).

## What's in the component

- **Virtualized continuous scroll** — spacer establishes the full scroll range; `Map`+free-list slot pool mounts only `computeVisibleRange`'s window; per-section page sizes honored (mixed portrait/landscape documents lay out correctly).
- **Engine injection** (`opts.document`) with strict ownership: injected engines are never destroyed by the viewer; explicit `opts.mode` conflicting with an injected engine's mode throws (a new public `DocxDocument.mode` fact replaces error-probing).
- **Rendering** — main mode renders each slot at its own per-page px width (uniform px-per-pt scale); worker mode uses `renderPageToBitmap` with per-slot `bitmaprenderer` contexts, dispatch coalescing, drop-stale, a **render epoch** (zoom/resize invalidation), bounded re-dispatch (no retry storm on plain rejection), and `ImageBitmap.close()` on recycle/teardown.
- **Zoom** — `setScale` + Ctrl/⌘+wheel via core `zoomStepScale`, absolute clamps (0.1–4 default), and a from-scratch **vertical re-anchor** (page under the viewport top + intra-page fraction preserved across rescale).
- **Text selection** — per-slot transparent overlay via the shared `buildDocxTextLayer`, epoch-gated against stale geometry; worker mode warns once (pager parity).
- **Navigation & resize** — `scrollToPage` (clamped, maxTop-guarded), change-only `onVisiblePageChange`, ResizeObserver re-fit preserving the user's zoom multiplier, zero-width-container recovery, height-only resizes remount revealed rows, empty-document no-ops.
- Storybook story (`DocxViewer/Examples › DocxScrollViewer`), barrel export, export-completeness green.

## Verification

- 63 unit tests for the viewer alone (stub-DOM harness, node env); docx suite **396/396**; package + root typecheck clean; ast-grep clean.
- Every task passed independent review (spec + quality, mutation testing on load-bearing guards); review-found defects — an error-retry storm, blank rows on height-only resize, a vacuous width assertion, a probe-based mode check — all fixed and regression-pinned before this PR.
- Browser smoke-check on the Storybook story: virtualization window follows scroll (3 canvases for 6 pages), zoom clamps + re-anchors, 420-span selection overlay, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)