### PR TITLE
feat(pptx,docx): PptxScrollViewer + scroll-viewer desk options (background, four-side padding) (#572)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -231,7 +231,7 @@ export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-pos
 export { nextVisibleIndex, resolveVisibleIndex, countVisible } from './nav/visible-index';
 // Virtualization range math for the continuous-scroll viewers (DocxScrollViewer /
 // PptxScrollViewer): pure prefix-sum + binary-search over per-item heights. No DOM.
-export { computeVisibleRange, type VisibleRange } from './layout/virtual-scroll';
+export { computeVisibleRange, type VisibleRange, type VisibleRangePad } from './layout/virtual-scroll';
 // Shared exponential wheel/pinch zoom step (Ctrl/⌘+wheel). Pure — the caller
 // clamps to its own [zoomMin, zoomMax]. Used by XlsxViewer + the scroll viewers.
 export { zoomStepScale } from './interaction/zoom';

--- a/packages/core/src/layout/virtual-scroll.test.ts
+++ b/packages/core/src/layout/virtual-scroll.test.ts
@@ -140,3 +140,68 @@ describe('computeVisibleRange — degenerate inputs', () => {
     expect(computeVisibleRange([100, 100, 100], 10, 110, 50, 0).topIndex).toBe(1);
   });
 });
+
+describe('computeVisibleRange — leading/trailing padding (desk margin)', () => {
+  // pad shifts offsets down by `leading` and extends totalHeight by leading+trailing.
+  // offsets[i] = leading + Σ heights[0..i-1] + i*gap; total = leading + Σh + (n-1)*gap + trailing.
+
+  it('leading pad shifts every offset down and total up by leading+trailing', () => {
+    // 3 uniform 100-tall items, gap 10, pad {24, 24}:
+    // offsets 24, 134, 244; total = 24 + 300 + 2*10 + 24 = 368.
+    const r = computeVisibleRange([100, 100, 100], 10, 0, 1000, 0, { leading: 24, trailing: 24 });
+    expect(r.offsets).toEqual([24, 134, 244]);
+    expect(r.totalHeight).toBe(368);
+  });
+
+  it('omitted pad is identical to pad {0,0} (backward-compatible)', () => {
+    const bare = computeVisibleRange([50, 200, 30], 8, 40, 100, 1);
+    const padded = computeVisibleRange([50, 200, 30], 8, 40, 100, 1, { leading: 0, trailing: 0 });
+    expect(padded).toEqual(bare);
+  });
+
+  it('viewport top inside the leading pad ⇒ topIndex 0 (existing clamp)', () => {
+    // leading 50: offsets = [50, 160, 270]. scrollTop 20 is INSIDE the leading pad
+    // (below every offset), so the search finds lo=0 ⇒ topIndex clamp(-1,0,n-1)=0.
+    const r = computeVisibleRange([100, 100, 100], 10, 20, 80, 0, { leading: 50 });
+    expect(r.topIndex).toBe(0);
+    expect(r.start).toBe(0);
+    // bottom edge 100 → item 0 (top 50) begins before it; item 1 (top 160) does not.
+    expect(r.end).toBe(0);
+  });
+
+  it('viewport ending inside the trailing pad ⇒ end = n-1, no overrun', () => {
+    // leading 0, trailing 100: offsets = [0, 110, 220], total = 300+2*10+100 = 420.
+    // Scroll near the end so the viewport bottom (200+250=450) lands in the trailing
+    // pad; end must clamp to the last real item (2), never past it.
+    const r = computeVisibleRange([100, 100, 100], 10, 200, 250, 1, { trailing: 100 });
+    // offsets [0,110,220]; scrollTop 200 → largest offset ≤ 200 is 110 (item 1).
+    expect(r.topIndex).toBe(1);
+    expect(r.end).toBe(2); // lastVisible (2) + overscan clamped to n-1 — no overrun
+    expect(r.totalHeight).toBe(420);
+  });
+
+  it('pad + gap compose (both contribute, distinctly)', () => {
+    // heights [50, 200, 30], gap 8, pad {12, 40}:
+    // offsets = 12, 12+50+8=70, 12+250+16=278; total = 12 + 280 + 16 + 40 = 348.
+    const r = computeVisibleRange([50, 200, 30], 8, 0, 10, 0, { leading: 12, trailing: 40 });
+    expect(r.offsets).toEqual([12, 70, 278]);
+    expect(r.totalHeight).toBe(348);
+  });
+
+  it('leading-only pad', () => {
+    const r = computeVisibleRange([100, 100], 10, 0, 1000, 0, { leading: 30 });
+    expect(r.offsets).toEqual([30, 140]);
+    expect(r.totalHeight).toBe(30 + 200 + 10); // 240
+  });
+
+  it('trailing-only pad', () => {
+    const r = computeVisibleRange([100, 100], 10, 0, 1000, 0, { trailing: 30 });
+    expect(r.offsets).toEqual([0, 110]);
+    expect(r.totalHeight).toBe(200 + 10 + 30); // 240
+  });
+
+  it('empty input ignores pad entirely (empty-doc no-op contract)', () => {
+    const r = computeVisibleRange([], 16, 0, 500, 1, { leading: 24, trailing: 24 });
+    expect(r).toEqual({ start: 0, end: -1, topIndex: 0, offsets: [], totalHeight: 0 });
+  });
+});

--- a/packages/core/src/layout/virtual-scroll.ts
+++ b/packages/core/src/layout/virtual-scroll.ts
@@ -20,10 +20,25 @@ export interface VisibleRange {
    *  item — the standard virtualization convention; mount-safe, and flips to i+1
    *  exactly at `offsets[i+1]`). */
   topIndex: number;
-  /** Top offset (px) of every item i: Σ heights[0..i-1] + i*gap. length = heights.length. */
+  /** Top offset (px) of every item i: `leading` + Σ heights[0..i-1] + i*gap.
+   *  length = heights.length. With no padding (`leading` 0) this reduces to the
+   *  bare prefix-sum. */
   offsets: number[];
-  /** Σ heights + (n-1)*gap (gap between items only, none after the last) → spacer height. */
+  /** `leading` + Σ heights + (n-1)*gap + `trailing` (gap between items only, none
+   *  after the last) → spacer height. With no padding this reduces to
+   *  Σ heights + (n-1)*gap. */
   totalHeight: number;
+}
+
+/** Optional leading/trailing padding (px) added OUTSIDE the item run — the desk
+ *  margin a PDF reader leaves above the first item and below the last. Distinct
+ *  from `gap`, which only sits BETWEEN adjacent items. Both default 0, so an
+ *  omitted `pad` is exactly the pre-padding behaviour (fully backward-compatible). */
+export interface VisibleRangePad {
+  /** px above the FIRST item (shifts every offset down by this amount). Default 0. */
+  leading?: number;
+  /** px below the LAST item (added to totalHeight only). Default 0. */
+  trailing?: number;
 }
 
 /** Clamp `v` to `[lo, hi]` (hi < lo yields lo — only reached when n === 0, guarded upstream). */
@@ -41,9 +56,20 @@ function clamp(v: number, lo: number, hi: number): number {
  *                       the search / clamps.
  * @param viewportHeight visible height of the scroll surface (px).
  * @param overscan       extra items kept mounted beyond the viewport on each side.
+ * @param pad            optional {@link VisibleRangePad} desk margin OUTSIDE the
+ *                       item run: `leading` px above the first item shifts every
+ *                       offset down; `trailing` px below the last item extends
+ *                       totalHeight. Both default 0 — an omitted `pad` is exactly
+ *                       the pre-padding behaviour (backward-compatible). A viewport
+ *                       top inside the leading pad (scrollTop < leading, so below
+ *                       every offset) yields topIndex 0 via the existing clamp.
  * @returns a {@link VisibleRange}. Empty `heights` ⇒
  *          `{ start: 0, end: -1, topIndex: 0, offsets: [], totalHeight: 0 }`
- *          (an empty mount range: `start > end`).
+ *          (an empty mount range: `start > end`). NOTE: with n === 0 the padding
+ *          is DELIBERATELY NOT applied — an empty document shows no desk padding,
+ *          consistent with the viewers' empty-doc no-op contract (they never mount
+ *          a spacer for a zero-item document). `pad` only takes effect once there
+ *          is at least one item.
  */
 export function computeVisibleRange(
   heights: number[],
@@ -51,21 +77,28 @@ export function computeVisibleRange(
   scrollTop: number,
   viewportHeight: number,
   overscan: number,
+  pad?: VisibleRangePad,
 ): VisibleRange {
   const n = heights.length;
   if (n === 0) {
+    // Empty doc: no items ⇒ no desk padding (leading/trailing deliberately ignored).
+    // Preserves the exact pre-padding empty result the viewers rely on.
     return { start: 0, end: -1, topIndex: 0, offsets: [], totalHeight: 0 };
   }
 
-  // Prefix-sum offsets: offsets[i] = Σ heights[0..i-1] + i*gap.
+  const leading = pad?.leading ?? 0;
+  const trailing = pad?.trailing ?? 0;
+
+  // Prefix-sum offsets: offsets[i] = leading + Σ heights[0..i-1] + i*gap.
   const offsets = new Array<number>(n);
   let acc = 0;
   for (let i = 0; i < n; i++) {
-    offsets[i] = acc + i * gap;
+    offsets[i] = leading + acc + i * gap;
     acc += heights[i];
   }
-  // Σ heights + (n-1) gaps — no trailing gap after the last item.
-  const totalHeight = acc + (n - 1) * gap;
+  // leading + Σ heights + (n-1) gaps + trailing — no gap after the last item; the
+  // desk padding brackets the run (leading above the first, trailing below the last).
+  const totalHeight = leading + acc + (n - 1) * gap + trailing;
 
   // topIndex = largest i with offsets[i] <= scrollTop (the item under the
   // viewport top), clamped to [0, n-1]. Binary search over the non-decreasing

--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -136,6 +136,8 @@ export const ScrollViewer: LayoutStory = {
 
     const viewer = new DocxScrollViewer(container, {
       gap: 16,
+      paddingTop: 24, // desk margin above the first page (defaults to gap when omitted)
+      paddingBottom: 24, // desk margin below the last page
       overscan: 1,
       enableTextSelection: true,
       background: '#525659', // desk gray behind/between pages (like a PDF reader)

--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -138,6 +138,7 @@ export const ScrollViewer: LayoutStory = {
       gap: 16,
       overscan: 1,
       enableTextSelection: true,
+      background: '#525659', // desk gray behind/between pages (like a PDF reader)
       onVisiblePageChange: (top, total) => {
         status.textContent = `Page ${top + 1} / ${total}`;
       },

--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -138,9 +138,11 @@ export const ScrollViewer: LayoutStory = {
       gap: 16,
       paddingTop: 24, // desk margin above the first page (defaults to gap when omitted)
       paddingBottom: 24, // desk margin below the last page
+      paddingLeft: 24, // horizontal desk gutter left of the pages
+      paddingRight: 24, // horizontal desk gutter right of the pages
       overscan: 1,
       enableTextSelection: true,
-      background: '#525659', // desk gray behind/between pages (like a PDF reader)
+      background: '#f5f5f5', // light desk behind/between pages (matches the ScrollView recipe)
       onVisiblePageChange: (top, total) => {
         status.textContent = `Page ${top + 1} / ${total}`;
       },

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -103,6 +103,33 @@ describe('DocxScrollViewer — skeleton (T1)', () => {
     // Injected engine is caller-owned: destroy() must not tear it down.
     expect(engine.destroyed).toBe(false);
   });
+
+  // `background` paints the scroll surface (the "desk") visible behind/between
+  // pages. It applies to the viewer-owned scrollHost; pages keep their own white.
+  it('applies opts.background to the scrollHost element', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      background: '#525659',
+    });
+    const scrollHost = container.children[0].children[0]; // wrapper → scrollHost
+    expect(scrollHost.style.background).toBe('#525659');
+    v.destroy();
+  });
+
+  it('sets no background on the scrollHost by default (transparent — container shows through)', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+    });
+    const scrollHost = container.children[0].children[0];
+    expect(scrollHost.style.background).toBe('');
+    v.destroy();
+  });
 });
 
 describe('DocxScrollViewer — layout + virtualization (T2)', () => {

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -201,7 +201,9 @@ describe('DocxScrollViewer — layout + virtualization (T2)', () => {
     const PT_TO_PX = 4 / 3;
     const scale = 200 / (100 * PT_TO_PX);
     const heights = sizes.map((s) => s.heightPt * PT_TO_PX * scale);
-    const expected = heights.reduce((a, b) => a + b, 0) + (sizes.length - 1) * 10;
+    // New default: paddingTop/paddingBottom each default to `gap` (10), so the
+    // spacer is padTop + Σheights + (n-1)*gap + padBottom.
+    const expected = 10 + heights.reduce((a, b) => a + b, 0) + (sizes.length - 1) * 10 + 10;
     expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
     v.destroy();
     void dom;
@@ -463,6 +465,7 @@ describe('DocxScrollViewer — rendering (T3)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: 10,
+      paddingTop: 0, // flush top so page 0's slot sits at top:0px (asserted below)
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -595,6 +598,11 @@ describe('DocxScrollViewer — zoom (T4)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: 10,
+      // Flush top/bottom (paddingTop/Bottom default to `gap`; the T4 offset
+      // arithmetic below is written for offset[0]===0). This exercises the
+      // "explicit 0 ⇒ old flush behavior reachable" contract.
+      paddingTop: 0,
+      paddingBottom: 0,
       overscan: 1,
       zoomMin: 0.5,
       zoomMax: 3,
@@ -738,6 +746,7 @@ describe('DocxScrollViewer — zoom (T4)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: 10,
+      paddingTop: 0, // flush top so page 0's slot sits at top:0px (asserted below)
       overscan: 1,
       zoomMin: 0.5,
       zoomMax: 3,
@@ -801,6 +810,7 @@ describe('DocxScrollViewer — zoom (T4)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: 10,
+      paddingTop: 0, // flush top so page 0's slot sits at top:0px (asserted below)
       overscan: 1,
       zoomMin: 0.5,
       zoomMax: 3,
@@ -1060,6 +1070,11 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: GAP,
+      // Flush top/bottom: the T6 STRIDE/offset arithmetic assumes offset[0]===0.
+      // paddingTop/Bottom default to `gap`; pinning them to 0 keeps the pre-padding
+      // geometry (and exercises the "explicit 0 ⇒ old flush behavior" contract).
+      paddingTop: 0,
+      paddingBottom: 0,
       ...opts,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -1301,6 +1316,110 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, { document: engine.asDoc() });
     v.destroy();
     expect(disconnected).toBe(1);
+  });
+});
+
+describe('DocxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
+  const PT_TO_PX = 4 / 3;
+  const BASE = 200 / (100 * PT_TO_PX); // 1.5
+  const PAGE_H = 200 * PT_TO_PX * BASE; // 400
+  const GAP = 10;
+  const STRIDE = PAGE_H + GAP; // 410
+
+  function setup(opts = {}, pageCount = 20) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(
+      pageCount,
+      Array.from({ length: pageCount }, () => ({ widthPt: 100, heightPt: 200 })),
+    );
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: GAP,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, container, engine };
+  }
+
+  /** The wrapper currently mounted for page `i` (identified by its top offset). */
+  function slotTopFor(scrollHost: FakeEl, i: number, stride: number, padTop: number): FakeEl | undefined {
+    const want = `${padTop + i * stride}px`;
+    return scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === want,
+    ) as FakeEl | undefined;
+  }
+
+  it('explicit paddingTop mounts the first slot at top = paddingTop px', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24 });
+    expect(v.mountedPageIndicesForTest()).toContain(0);
+    // Page 0's wrapper sits at top = paddingTop (not flush 0).
+    expect(slotTopFor(scrollHost, 0, STRIDE, 24)).toBeDefined();
+    v.destroy();
+  });
+
+  it('spacer height = padTop + Σheights + (n-1)*gap + padBottom', () => {
+    const { scrollHost } = setup({ paddingTop: 24, paddingBottom: 40 });
+    const spacer = scrollHost.children[0] as FakeEl;
+    const expected = 24 + 20 * PAGE_H + 19 * GAP + 40; // 8254
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+  });
+
+  it('DEFAULT paddingTop/paddingBottom = gap (uniform rhythm: no options ⇒ first slot at gap px)', () => {
+    // No paddingTop/paddingBottom → each defaults to `gap` (10). Page 0 sits at
+    // top:10px, NOT flush 0 (this is the sanctioned pre-release default change).
+    const { v, scrollHost } = setup();
+    expect(v.mountedPageIndicesForTest()).toContain(0);
+    expect(slotTopFor(scrollHost, 0, STRIDE, GAP)).toBeDefined();
+    // And the spacer includes both default pads.
+    const spacer = scrollHost.children[0] as FakeEl;
+    const expected = GAP + 20 * PAGE_H + 19 * GAP + GAP;
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+    v.destroy();
+  });
+
+  it('explicit 0 ⇒ flush (old behavior reachable): first slot at top 0, spacer has no pad', () => {
+    const { v, scrollHost } = setup({ paddingTop: 0, paddingBottom: 0 });
+    expect(slotTopFor(scrollHost, 0, STRIDE, 0)).toBeDefined();
+    const spacer = scrollHost.children[0] as FakeEl;
+    const expected = 20 * PAGE_H + 19 * GAP; // no pad
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+    v.destroy();
+  });
+
+  it('scrollToPage(0) lands on offsets[0] (= paddingTop, not 0)', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24 });
+    // Move away first, then navigate to page 0.
+    scrollHost.scrollTop = 3 * STRIDE;
+    scrollHost.dispatch('scroll');
+    v.scrollToPage(0);
+    // offsets[0] = paddingTop (24), so the top edge of page 0 sits below the pad.
+    expect(scrollHost.scrollTop).toBe(24);
+    v.destroy();
+  });
+
+  it('scrollToPage(k) lands on paddingTop + k*stride', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24 });
+    v.scrollToPage(3);
+    expect(Math.abs(scrollHost.scrollTop - (24 + 3 * STRIDE))).toBeLessThan(2);
+    v.destroy();
+  });
+
+  it('re-anchor keeps the page under the viewport top fixed WITH padding intact after setScale', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24, zoomMin: 0.5, zoomMax: 3 });
+    // Scroll so page 3's top sits at the viewport top: offset[3] = 24 + 3*410 = 1254.
+    scrollHost.scrollTop = 24 + 3 * STRIDE;
+    scrollHost.dispatch('scroll');
+    expect(v.topVisiblePage).toBe(3);
+    v.setScale(v.scaleForTest() * 2); // 1.5 → 3.0; PAGE_H' = 800, STRIDE' = 810
+    expect(v.scaleForTest()).toBeCloseTo(3, 5);
+    // Page 3 stays the top page; padding is intact so offset'[3] = 24 + 3*810 = 2454.
+    expect(v.topVisiblePage).toBe(3);
+    expect(Math.abs(scrollHost.scrollTop - (24 + 3 * 810))).toBeLessThan(2);
+    v.destroy();
   });
 });
 

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -152,6 +152,12 @@ describe('DocxScrollViewer — layout + virtualization (T2)', () => {
       gap: 10,
       overscan: 1,
       width: undefined, // fit container width (200) → base scale below
+      // Flush horizontal gutters: paddingLeft/Right default to `gap`, which would
+      // shrink the fit width to 180 and break the base-scale-1.5 geometry the T2
+      // assertions assume (page width px = 200). Pin them to 0 so the fit is the
+      // full 200 container width (same pattern the vertical commit used).
+      paddingLeft: 0,
+      paddingRight: 0,
       ...opts,
     });
     const wrapper = container.children[0] as FakeEl;
@@ -191,6 +197,8 @@ describe('DocxScrollViewer — layout + virtualization (T2)', () => {
       document: engine.asDoc(),
       gap: 10,
       overscan: 1,
+      paddingLeft: 0, // full-width fit (see T2 setup note) → base scale 1.5
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     const spacer = scrollHost.children[0] as FakeEl;
@@ -271,6 +279,8 @@ describe('DocxScrollViewer — rendering (T3)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: 10,
+      paddingLeft: 0, // full-width fit → page width px = 200 (asserted below)
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -302,6 +312,8 @@ describe('DocxScrollViewer — rendering (T3)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: 10,
+      paddingLeft: 0, // full-width fit → base scale 1.5 (page widths 200 / 400)
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -603,6 +615,9 @@ describe('DocxScrollViewer — zoom (T4)', () => {
       // "explicit 0 ⇒ old flush behavior reachable" contract.
       paddingTop: 0,
       paddingBottom: 0,
+      // Flush left/right so the fit width is the full 200 container ⇒ base 1.5.
+      paddingLeft: 0,
+      paddingRight: 0,
       overscan: 1,
       zoomMin: 0.5,
       zoomMax: 3,
@@ -1075,6 +1090,10 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
       // geometry (and exercises the "explicit 0 ⇒ old flush behavior" contract).
       paddingTop: 0,
       paddingBottom: 0,
+      // Flush left/right: the fit width must be the full 200 container so BASE = 1.5
+      // and PAGE_H/STRIDE hold (the default `gap` gutters would shrink the fit).
+      paddingLeft: 0,
+      paddingRight: 0,
       ...opts,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -1336,6 +1355,11 @@ describe('DocxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       gap: GAP,
+      // This block tests the VERTICAL desk margin; pin the horizontal gutters to 0
+      // so the fit width is the full 200 container ⇒ BASE 1.5 / PAGE_H 400 / STRIDE
+      // 410 (the default `gap` gutters would otherwise shrink the fit).
+      paddingLeft: 0,
+      paddingRight: 0,
       ...opts,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -1419,6 +1443,169 @@ describe('DocxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
     // Page 3 stays the top page; padding is intact so offset'[3] = 24 + 3*810 = 2454.
     expect(v.topVisiblePage).toBe(3);
     expect(Math.abs(scrollHost.scrollTop - (24 + 3 * 810))).toBeLessThan(2);
+    v.destroy();
+  });
+});
+
+describe('DocxScrollViewer — paddingLeft/paddingRight (horizontal desk gutters)', () => {
+  const PT_TO_PX = 4 / 3;
+
+  /** Build a viewer over a container of `cw`×400, uniform 100pt×200pt pages. */
+  function setup(cw: number, opts = {}, pageCount = 20) {
+    installDom();
+    const container = makeContainer(cw, 400);
+    const engine = new FakeDocxEngine(
+      pageCount,
+      Array.from({ length: pageCount }, () => ({ widthPt: 100, heightPt: 200 })),
+    );
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 16,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = cw;
+    v.relayout();
+    return { v, scrollHost, container, engine };
+  }
+
+  /** The wrapper mounted for page 0 (flush top ⇒ it sits at top:0px unless a
+   *  vertical pad is set; callers that keep the default gap pass the expected top). */
+  function slot(scrollHost: FakeEl, top: string): FakeEl | undefined {
+    return scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === top,
+    ) as FakeEl | undefined;
+  }
+
+  it('fit subtracts the DEFAULT gutters: container 232 with default gap-16 gutters ⇒ fit 200 ⇒ base 1.5', () => {
+    // 232 − 16 (padL) − 16 (padR) = 200, the same fit the old 200-container tests
+    // used, so the base scale matches their 1.5 (page widthPt 100 → 200/(100×4/3)).
+    const { v } = setup(232);
+    expect(v.baseScaleForTest()).toBeCloseTo(1.5, 5);
+    expect(v.scaleForTest()).toBeCloseTo(1.5, 5);
+    v.destroy();
+  });
+
+  it('explicit paddingLeft:0/paddingRight:0 ⇒ old full-width fit reachable (base uses the FULL container width)', () => {
+    // With the gutters pinned to 0 the fit is the full 200 container width ⇒ base
+    // 1.5, exactly the pre-feature behavior.
+    const { v } = setup(200, { paddingLeft: 0, paddingRight: 0 });
+    expect(v.baseScaleForTest()).toBeCloseTo(1.5, 5);
+    v.destroy();
+  });
+
+  it('explicit opts.width is NOT reduced by the gutters (it is the page CSS-width contract)', () => {
+    // opts.width 150 stays 150 regardless of the gutters: base = 150/(100×4/3) =
+    // 1.125. The gutters still apply to PLACEMENT (asserted in the centering test),
+    // just not to the width.
+    const { v } = setup(400, { width: 150, paddingLeft: 24, paddingRight: 24 });
+    expect(v.baseScaleForTest()).toBeCloseTo(150 / (100 * PT_TO_PX), 5);
+    v.destroy();
+  });
+
+  it('slot left = paddingLeft when the page fills the fit exactly (symmetric gutters ⇒ centre lands on the floor)', () => {
+    // Container 232, default gutters 16 ⇒ fit 200, page px = 200. scrollHost
+    // clientWidth 232, so centre = (232 − 200)/2 = 16 = padL ⇒ left pinned at padL.
+    const { v, scrollHost } = setup(232);
+    // Default vertical padding = gap 16 ⇒ page 0 sits at top:16px.
+    const s0 = slot(scrollHost, '16px');
+    expect(s0).toBeDefined();
+    expect(s0!.style.left).toBe('16px'); // = paddingLeft
+    v.destroy();
+  });
+
+  it('slot is CENTERED when the page is narrower than the viewport (left = (cw − pw)/2 > paddingLeft)', () => {
+    // Explicit width 100 (NOT reduced) ⇒ page px = 100, far narrower than the 400
+    // viewport. centre = (400 − 100)/2 = 150, which exceeds padL 16, so the page is
+    // centred at 150 rather than pinned to the gutter floor.
+    const { v, scrollHost } = setup(400, { width: 100, paddingLeft: 16, paddingRight: 16 });
+    const s0 = slot(scrollHost, '16px'); // default vertical pad = gap 16
+    expect(s0).toBeDefined();
+    expect(parseFloat(s0!.style.left)).toBeCloseTo(150, 3);
+    expect(parseFloat(s0!.style.left)).toBeGreaterThan(16);
+    v.destroy();
+  });
+
+  it('zoomed-in (page wider than viewport): left pins to paddingLeft and the spacer width = pageW + padL + padR', () => {
+    // Explicit width 400 in a 200 viewport ⇒ page px 400 > cw 200. centre =
+    // (200 − 400)/2 = −100, so the floor pins left at padL 24. The horizontal scroll
+    // extent (spacer width) is the page width plus both gutters: 400 + 24 + 24 = 448.
+    const { v, scrollHost } = setup(200, { width: 400, paddingLeft: 24, paddingRight: 24 });
+    const s0 = slot(scrollHost, '16px'); // default vertical pad = gap 16
+    expect(s0).toBeDefined();
+    expect(s0!.style.left).toBe('24px'); // pinned to paddingLeft
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.width)).toBeCloseTo(400 + 24 + 24, 3);
+    v.destroy();
+  });
+
+  it('a Ctrl+wheel zoom that widens the page past the viewport updates the spacer width and pins left to paddingLeft', () => {
+    // Container 200 pinned gutters 0 ⇒ fit 200, base 1.5, page px 200 (== viewport).
+    // Zoom ×2 ⇒ page px 400 > 200 viewport. left floors to padL (0 here) and the
+    // spacer width tracks the new page width + gutters (400 + 0 + 0 = 400).
+    const { v, scrollHost } = setup(200, {
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingTop: 0,
+      zoomMin: 0.5,
+      zoomMax: 4,
+    });
+    expect(v.scaleForTest()).toBeCloseTo(1.5, 5);
+    v.setScale(v.scaleForTest() * 2); // page px 200 → 400
+    const s0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(s0).toBeDefined();
+    expect(s0!.style.left).toBe('0px'); // paddingLeft 0
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.width)).toBeCloseTo(400, 3);
+    v.destroy();
+  });
+
+  it('spacer width uses the WIDEST page over mixed page widths (+ both gutters)', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Page 0 100pt wide (base fit target), page 1 200pt wide (twice as wide).
+    const engine = new FakeDocxEngine(2, [
+      { widthPt: 100, heightPt: 100 },
+      { widthPt: 200, heightPt: 100 },
+    ]);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      paddingLeft: 12,
+      paddingRight: 12,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // fit = 200 − 12 − 12 = 176, base = 176/(100×4/3) = 1.32. Page widths px: page 0
+    // = 176, page 1 = 200×4/3×1.32 = 352 (the widest). Spacer width = 352 + 12 + 12.
+    const base = 176 / (100 * PT_TO_PX);
+    const widest = 200 * PT_TO_PX * base; // 352
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.width)).toBeCloseTo(widest + 12 + 12, 3);
+    v.destroy();
+  });
+
+  it('gutters wider than the container defer layout (non-positive fit ⇒ zero-width deferral)', () => {
+    // padL + padR = 300 > container 200 ⇒ fit ≤ 0 ⇒ deferred (no slots mounted),
+    // mirroring the zero-width container deferral.
+    const { v } = setup(200, { paddingLeft: 150, paddingRight: 150 });
+    expect(v.mountedPageIndicesForTest().length).toBe(0);
+    v.destroy();
+  });
+
+  it('the slot wrapper carries NO CSS auto-centering (explicit JS left replaces margin:0 auto)', () => {
+    // The old wrapper used `left:0;right:0;margin:0 auto`; that would fight the
+    // explicit per-mount `left`. Assert the auto-centering margin is gone.
+    const { v, scrollHost } = setup(232);
+    const s0 = slot(scrollHost, '16px');
+    expect(s0).toBeDefined();
+    expect(s0!.style.margin).toBe(''); // no `0 auto`
+    expect(s0!.style.right).toBe(''); // no right:0 pinning
     v.destroy();
   });
 });

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -21,6 +21,14 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
   width?: number;
   /** Vertical gap (px) between consecutive pages. Default 16. */
   gap?: number;
+  /** Desk padding (px) ABOVE the FIRST page — the margin a PDF reader leaves
+   *  between the top of the scroll surface and the first sheet. Default: `gap`
+   *  (uniform desk rhythm — the first page sits the same distance from the top as
+   *  pages sit from each other). Pass `0` for a flush-top layout. */
+  paddingTop?: number;
+  /** Desk padding (px) BELOW the LAST page — the margin below the final sheet.
+   *  Default: `gap`. Pass `0` for a flush-bottom layout. */
+  paddingBottom?: number;
   /** Pages kept mounted beyond the viewport on each side. Default 1. */
   overscan?: number;
   /** Per-page transparent text-selection overlay. MAIN render mode only:
@@ -342,6 +350,15 @@ export class DocxScrollViewer {
     return this._opts.overscan ?? 1;
   }
 
+  /** Desk padding fed to `computeVisibleRange`: `paddingTop`/`paddingBottom`,
+   *  each defaulting to `gap` (uniform rhythm). Resolved here (not stored) to
+   *  mirror `_gap()`/`_overscan()`, and consumed at EVERY `computeVisibleRange`
+   *  call site so the padded offsets are the single source of geometry. */
+  private _pad(): { leading: number; trailing: number } {
+    const gap = this._gap();
+    return { leading: this._opts.paddingTop ?? gap, trailing: this._opts.paddingBottom ?? gap };
+  }
+
   private _range(): VisibleRange {
     return computeVisibleRange(
       this._heights,
@@ -349,6 +366,7 @@ export class DocxScrollViewer {
       this._scrollHost.scrollTop,
       this._scrollHost.clientHeight,
       this._overscan(),
+      this._pad(),
     );
   }
 
@@ -700,7 +718,14 @@ export class DocxScrollViewer {
     // Rescale, recompute heights, resize the spacer to the new total height.
     this._scale = next;
     this._recomputeHeights();
-    const r1 = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    const r1 = computeVisibleRange(
+      this._heights,
+      this._gap(),
+      0,
+      this._scrollHost.clientHeight,
+      this._overscan(),
+      this._pad(),
+    );
     this._spacer.style.height = `${r1.totalHeight}px`;
 
     // Pin the same fractional position of the same page under the viewport top.
@@ -746,7 +771,14 @@ export class DocxScrollViewer {
     if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) return;
     const clamped = Math.max(0, Math.min(index, this._doc.pageCount - 1));
     // Recompute offsets from the current heights (independent of scrollTop).
-    const r = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    const r = computeVisibleRange(
+      this._heights,
+      this._gap(),
+      0,
+      this._scrollHost.clientHeight,
+      this._overscan(),
+      this._pad(),
+    );
     const target = r.offsets[clamped] ?? 0;
     const maxTop = Math.max(0, r.totalHeight - this._scrollHost.clientHeight);
     const top = Math.min(maxTop, Math.max(0, target));

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -34,6 +34,15 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
   /** Enable `Ctrl`/`Cmd`+wheel zoom. Default true. */
   enableZoom?: boolean;
   /**
+   * CSS `background` shorthand for the scroll surface (the "desk") visible
+   * behind and between pages — the gray a PDF reader paints around the sheet.
+   * Applied to the viewer-owned scroll host. The pages themselves are always
+   * drawn on the document's own white canvas and are unaffected. Default
+   * `undefined`: the scroll surface stays transparent so the host container's
+   * background shows through (non-breaking).
+   */
+  background?: string;
+  /**
    * Inject an already-loaded engine to share one parse across panes (design §14).
    * When set: `load()` is unsupported (throws), the engine's own `mode` wins (an
    * explicitly conflicting `opts.mode` throws at construction, design §11), and
@@ -174,6 +183,9 @@ export class DocxScrollViewer {
     this._wrapper.style.cssText = 'position:relative;width:100%;height:100%;overflow:hidden;';
     this._scrollHost = document.createElement('div');
     this._scrollHost.style.cssText = 'position:absolute;inset:0;overflow:auto;';
+    // The "desk" behind/between pages. Undefined ⇒ transparent (container shows
+    // through); pages keep their own white canvas regardless.
+    if (opts.background) this._scrollHost.style.background = opts.background;
     this._spacer = document.createElement('div');
     this._spacer.style.cssText = 'position:absolute;top:0;left:0;width:1px;height:0;pointer-events:none;';
     this._scrollHost.appendChild(this._spacer);

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -29,6 +29,18 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
   /** Desk padding (px) BELOW the LAST page — the margin below the final sheet.
    *  Default: `gap`. Pass `0` for a flush-bottom layout. */
   paddingBottom?: number;
+  /** Desk gutter (px) to the LEFT of the pages — the horizontal margin between the
+   *  left edge of the scroll surface and a page sitting flush-left (i.e. once
+   *  zoomed wide enough that centering no longer applies). Default: `gap` (uniform
+   *  desk rhythm — the horizontal gutters match the vertical ones). It also shrinks
+   *  the container-derived FIT width so a page sits inside the gutters at 100%
+   *  (an EXPLICIT `opts.width` is the page's CSS-width contract and is NOT reduced;
+   *  the gutters still apply around placement). Pass `0` for a flush-left layout. */
+  paddingLeft?: number;
+  /** Desk gutter (px) to the RIGHT of the pages. Default: `gap`. Shrinks the
+   *  container-derived fit width symmetrically with `paddingLeft`. Pass `0` for a
+   *  flush-right layout. */
+  paddingRight?: number;
   /** Pages kept mounted beyond the viewport on each side. Default 1. */
   overscan?: number;
   /** Per-page transparent text-selection overlay. MAIN render mode only:
@@ -283,11 +295,19 @@ export class DocxScrollViewer {
     return this._doc!.pageSize(i).heightPt * PT_TO_PX * this._scale;
   }
 
-  /** The container (fit) width, deferring when the container is unlaid-out. */
+  /** The fit width (px), deferring when the container is unlaid-out. An EXPLICIT
+   *  `opts.width` is the page's CSS-width contract and is returned UNCHANGED (the
+   *  gutters still apply around placement, not to the width). The container-derived
+   *  default instead targets `containerWidth − padL − padR` so a page sits INSIDE
+   *  the horizontal gutters at 100%. A non-positive result (gutters wider than the
+   *  container) is treated as unlaid-out — the same deferral as a zero-width box. */
   private _fitWidthPx(): number {
     if (this._opts.width && this._opts.width > 0) return this._opts.width;
     const cw = this._container.clientWidth || this._scrollHost.clientWidth;
-    return cw > 0 ? cw : 0; // 0 ⇒ defer (design §11 zero-width deferral)
+    if (cw <= 0) return 0; // 0 ⇒ defer (design §11 zero-width deferral)
+    const { left, right } = this._padH();
+    const fit = cw - left - right;
+    return fit > 0 ? fit : 0; // gutters ≥ container ⇒ defer (same as zero-width)
   }
 
   /** Base scale: first page's width fit to the fit-width. Returns 0 when the
@@ -359,6 +379,16 @@ export class DocxScrollViewer {
     return { leading: this._opts.paddingTop ?? gap, trailing: this._opts.paddingBottom ?? gap };
   }
 
+  /** Horizontal desk gutters: `paddingLeft`/`paddingRight`, each defaulting to
+   *  `gap` (uniform rhythm — the horizontal gutters match the vertical padding).
+   *  Consumed by `_fitWidthPx` (to shrink the container-derived fit), by
+   *  `_positionSlot` (the flush-left floor), and by `_syncSpacer` (the spacer
+   *  width). Resolved here (not stored) to mirror `_gap()`/`_pad()`. */
+  private _padH(): { left: number; right: number } {
+    const gap = this._gap();
+    return { left: this._opts.paddingLeft ?? gap, right: this._opts.paddingRight ?? gap };
+  }
+
   private _range(): VisibleRange {
     return computeVisibleRange(
       this._heights,
@@ -374,6 +404,25 @@ export class DocxScrollViewer {
     const r = this._range();
     this._lastRange = r;
     this._spacer.style.height = `${r.totalHeight}px`;
+    this._syncSpacerWidth();
+  }
+
+  /** Horizontal scroll extent: the widest page (docx pages can differ in width)
+   *  plus both gutters. A spacer NARROWER than the container never creates a
+   *  scrollbar (scrollWidth = max(clientWidth, content)), so it is always safe to
+   *  set — it only matters when a zoomed-in page grows past the viewport, where it
+   *  gives the gutters something to scroll to on either side. Max over per-page
+   *  widths so the extent covers the widest page in the document. Called from
+   *  `_syncSpacer` and after every scale change (zoom / resize re-fit) so the
+   *  extent tracks the current page px width. */
+  private _syncSpacerWidth(): void {
+    const { left, right } = this._padH();
+    let maxW = 0;
+    for (let i = 0; i < this._heights.length; i++) {
+      const w = this._pageWidthPx(i);
+      if (w > maxW) maxW = w;
+    }
+    this._spacer.style.width = `${maxW + left + right}px`;
   }
 
   private _onScroll(): void {
@@ -422,8 +471,11 @@ export class DocxScrollViewer {
       this._scrollHost.appendChild(reused.wrapper);
       return reused;
     }
+    // `left` is set explicitly per mount by `_positionSlot` (JS centering with a
+    // left-gutter floor), so no CSS auto-centering (`left:0;right:0;margin:0 auto`)
+    // here — it would fight the explicit `left`.
     const wrapper = document.createElement('div');
-    wrapper.style.cssText = 'position:absolute;left:0;right:0;margin:0 auto;';
+    wrapper.style.cssText = 'position:absolute;';
     const canvas = document.createElement('canvas');
     canvas.style.cssText = 'display:block;background:#fff;';
     wrapper.appendChild(canvas);
@@ -463,6 +515,16 @@ export class DocxScrollViewer {
     const hpx = this._pageHeightPx(i);
     slot.wrapper.style.width = `${wpx}px`;
     slot.wrapper.style.height = `${hpx}px`;
+    // Horizontal placement (replaces the old CSS `left:0;right:0;margin:0 auto`
+    // auto-centering, which cannot honour a left gutter). Centre the page in the
+    // scroll viewport, but never let its left edge cross the left gutter: when the
+    // page is narrower than the viewport it is centred (`(cw − pw)/2 > padL`); once
+    // zoomed wider than the viewport the centre would go negative, so the floor
+    // pins it at `padL` and the overflow scrolls right. Formula deliberately
+    // duplicated per viewer (one line; not hoisted to core).
+    const { left: padL } = this._padH();
+    const cw = this._scrollHost.clientWidth;
+    slot.wrapper.style.left = `${Math.max(padL, (cw - wpx) / 2)}px`;
   }
 
   /** Device-pixel ratio for a render (opts override → window → 1). */
@@ -727,6 +789,8 @@ export class DocxScrollViewer {
       this._pad(),
     );
     this._spacer.style.height = `${r1.totalHeight}px`;
+    // The page px width changed with the scale, so the horizontal extent moves too.
+    this._syncSpacerWidth();
 
     // Pin the same fractional position of the same page under the viewport top.
     const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -135,6 +135,8 @@ export const ScrollViewer: LayoutStory = {
 
     const viewer = new PptxScrollViewer(container, {
       gap: 16,
+      paddingTop: 24, // desk margin above the first slide (defaults to gap when omitted)
+      paddingBottom: 24, // desk margin below the last slide
       overscan: 1,
       enableTextSelection: true,
       useGoogleFonts: true,

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { buildViewerUI } from './PptxViewer.stories';
 import { PptxPresentation } from './presentation';
 import { PptxViewer } from './viewer';
+import { PptxScrollViewer } from './scroll-viewer';
 import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
 
@@ -96,6 +97,60 @@ export const ScrollView: LayoutStory = {
           buildPptxTextLayer(textLayer, runs, widthPx, cssHeight);
         }
         status.textContent = `Loaded ${pres.slideCount} slides`;
+      })
+      .catch((e: Error) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      });
+
+    return root;
+  },
+};
+
+// The scroll viewer owns a live scroll subscription, a ResizeObserver, and a
+// per-slot canvas pool, so a stale instance left mounted across a Storybook
+// re-render (args change / HMR) would keep observing a detached container and
+// leak canvases. Hold the last instance module-side and destroy it before
+// building a fresh one.
+let scrollViewerInstance: PptxScrollViewer | null = null;
+
+export const ScrollViewer: LayoutStory = {
+  name: 'PptxScrollViewer — virtualized continuous scroll',
+  render() {
+    scrollViewerInstance?.destroy();
+    scrollViewerInstance = null;
+
+    const root = document.createElement('div');
+    root.style.cssText = 'font-family:sans-serif;padding:16px;';
+    const heading = document.createElement('h3');
+    heading.textContent = 'PptxScrollViewer — virtualized (Ctrl/⌘+wheel to zoom)';
+    heading.style.cssText = 'margin:0 0 8px;font-size:14px;';
+    root.appendChild(heading);
+    const status = makeStatus(root);
+
+    // The viewer owns a container-sized scroll surface; give it a fixed box.
+    const container = document.createElement('div');
+    container.style.cssText = 'height:720px;border:1px solid #ccc;background:#f5f5f5;';
+    root.appendChild(container);
+
+    const viewer = new PptxScrollViewer(container, {
+      gap: 16,
+      overscan: 1,
+      enableTextSelection: true,
+      useGoogleFonts: true,
+      onVisibleSlideChange: (top, total) => {
+        status.textContent = `Slide ${top + 1} / ${total}`;
+      },
+      onError: (e) => {
+        status.textContent = `Error: ${e.message}`;
+        status.style.color = 'red';
+      },
+    });
+    scrollViewerInstance = viewer;
+    viewer
+      .load(SAMPLE_URL)
+      .then(() => {
+        status.textContent = `Loaded ${viewer.slideCount} slides`;
       })
       .catch((e: Error) => {
         status.textContent = `Error: ${e.message}`;

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -138,6 +138,7 @@ export const ScrollViewer: LayoutStory = {
       overscan: 1,
       enableTextSelection: true,
       useGoogleFonts: true,
+      background: '#525659', // desk gray behind/between slides (like a slide viewer)
       onVisibleSlideChange: (top, total) => {
         status.textContent = `Slide ${top + 1} / ${total}`;
       },

--- a/packages/pptx/src/Examples.stories.ts
+++ b/packages/pptx/src/Examples.stories.ts
@@ -137,10 +137,12 @@ export const ScrollViewer: LayoutStory = {
       gap: 16,
       paddingTop: 24, // desk margin above the first slide (defaults to gap when omitted)
       paddingBottom: 24, // desk margin below the last slide
+      paddingLeft: 24, // horizontal desk gutter left of the slides
+      paddingRight: 24, // horizontal desk gutter right of the slides
       overscan: 1,
       enableTextSelection: true,
       useGoogleFonts: true,
-      background: '#525659', // desk gray behind/between slides (like a slide viewer)
+      background: '#f5f5f5', // light desk behind/between slides (matches the ScrollView recipe)
       onVisibleSlideChange: (top, total) => {
         status.textContent = `Slide ${top + 1} / ${total}`;
       },

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -1,4 +1,5 @@
 export { PptxViewer, type PptxViewerOptions, type HiddenSlideMode } from './viewer';
+export { PptxScrollViewer, type PptxScrollViewerOptions } from './scroll-viewer';
 export {
   PptxPresentation,
   type LoadOptions,

--- a/packages/pptx/src/presentation.mode.test.ts
+++ b/packages/pptx/src/presentation.mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { PptxPresentation } from './presentation';
+
+/**
+ * `PptxPresentation.mode` is a public fact (WS4 O1): an injected engine's render
+ * mode decides the scroll viewer's render path (renderSlide vs
+ * renderSlideToBitmap) so the viewer routes without error-probing (design §11 —
+ * no silent mis-pathing).
+ *
+ * The constructor opens a real Worker, so we build the instance off-prototype and
+ * inject only the private `_mode` field the getter reads.
+ */
+describe('PptxPresentation.mode', () => {
+  const make = (mode: 'main' | 'worker') => {
+    const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+    instance._mode = mode;
+    return instance as unknown as PptxPresentation;
+  };
+
+  it('reflects the worker mode the engine was loaded with', () => {
+    expect(make('worker').mode).toBe('worker');
+  });
+
+  it('reflects the main mode the engine was loaded with', () => {
+    expect(make('main').mode).toBe('main');
+  });
+});

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -200,6 +200,14 @@ export class PptxPresentation {
   /** Slide height in EMU. */
   get slideHeight(): number { return this._presentation?.slideHeight ?? this._meta?.slideHeight ?? 0; }
 
+  /** The render mode this engine was loaded with ('main' | 'worker'). A fact for
+   *  integrators and the scroll viewer: an injected engine's mode decides whether
+   *  slides render via renderSlide (main) or renderSlideToBitmap (worker) — no
+   *  probing (design §11: no silent mis-pathing). */
+  get mode(): 'main' | 'worker' {
+    return this._mode;
+  }
+
   /**
    * Speaker-notes text for a slide (`ppt/notesSlides/notesSlideN.xml`,
    * ECMA-376 §13.3.5 — Notes Slide). Returns the notes-body text as a single

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -208,6 +208,16 @@ export class FakePptxEngine {
     return this._mode;
   }
   renderSlide(_canvas: unknown, slide: number, opts?: RenderSlideOptions): Promise<void> {
+    // Mirror the real renderer's backing-store sizing so tests can exercise the
+    // dpr≠1 path: the real PptxPresentation.renderSlide sets `canvas.width =
+    // round(cssWidth × dpr)` (and height to keep the slide aspect). A retina (dpr 2)
+    // render leaves canvas.width at 2× the CSS box — the overlay must NOT copy it.
+    if (this._mode === 'main' && opts?.width && opts.width > 0) {
+      const dpr = opts.dpr ?? 1;
+      const canvas = _canvas as { width: number; height: number };
+      canvas.width = Math.round(opts.width * dpr);
+      canvas.height = this.slideWidth > 0 ? Math.round((canvas.width * this.slideHeight) / this.slideWidth) : 0;
+    }
     if (this._mode === 'worker') {
       // Record the attempt BEFORE throwing so a test can assert the viewer never
       // routes a worker-mode engine through renderSlide (and detect wrong-path

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -1,0 +1,258 @@
+import { vi } from 'vitest';
+import type { PptxPresentation, RenderSlideOptions, RenderSlideToBitmapOptions } from './presentation';
+import type { PptxTextRunInfo } from './renderer';
+
+/** A recording fake DOM element. Extends the `FakeEl` pattern from
+ *  text-layer.test.ts with the surface PptxScrollViewer touches: scrollTop,
+ *  clientHeight/Width, event listeners, removeChild/remove, canvas ctx. */
+export interface FakeEl {
+  tag: string;
+  textContent: string;
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  parentElement: FakeEl | null;
+  // canvas-only
+  width: number;
+  height: number;
+  // scrollHost-only (settable by the test to drive the virtualization loop)
+  scrollTop: number;
+  clientHeight: number;
+  clientWidth: number;
+  _listeners: Map<string, Array<(e: unknown) => void>>;
+  _bitmapCtx?: { transferFromImageBitmap: (b: unknown) => void; lastBitmap: unknown };
+  appendChild(c: FakeEl): FakeEl;
+  removeChild(c: FakeEl): FakeEl;
+  remove(): void;
+  insertBefore(n: FakeEl, ref: FakeEl | null): FakeEl;
+  addEventListener(type: string, fn: (e: unknown) => void, opts?: unknown): void;
+  removeEventListener(type: string, fn: (e: unknown) => void): void;
+  getContext(kind: string): unknown;
+  getBoundingClientRect(): { top: number; left: number; width: number; height: number };
+  /** test-only: fire a recorded listener */
+  dispatch(type: string, event?: unknown): void;
+}
+
+export function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    textContent: '',
+    innerHTML: '',
+    width: 0,
+    height: 0,
+    scrollTop: 0,
+    clientHeight: 0,
+    clientWidth: 0,
+    children: [],
+    parentElement: null,
+    _listeners: new Map(),
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const idx = decl.indexOf(':');
+            if (idx > 0) target[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+      get(target, prop: string) {
+        return target[prop] ?? '';
+      },
+    }),
+    appendChild(c: FakeEl) {
+      c.parentElement = this;
+      this.children.push(c);
+      return c;
+    },
+    removeChild(c: FakeEl) {
+      const i = this.children.indexOf(c);
+      if (i >= 0) this.children.splice(i, 1);
+      c.parentElement = null;
+      return c;
+    },
+    remove() {
+      this.parentElement?.removeChild(this);
+    },
+    insertBefore(n: FakeEl, ref: FakeEl | null) {
+      n.parentElement = this;
+      const i = ref ? this.children.indexOf(ref) : -1;
+      if (i >= 0) this.children.splice(i, 0, n);
+      else this.children.push(n);
+      return n;
+    },
+    addEventListener(type: string, fn: (e: unknown) => void) {
+      const arr = this._listeners.get(type) ?? [];
+      arr.push(fn);
+      this._listeners.set(type, arr);
+    },
+    removeEventListener(type: string, fn: (e: unknown) => void) {
+      const arr = this._listeners.get(type);
+      if (arr) this._listeners.set(type, arr.filter((f) => f !== fn));
+    },
+    getContext(kind: string) {
+      if (kind === 'bitmaprenderer') {
+        this._bitmapCtx = {
+          lastBitmap: null,
+          transferFromImageBitmap(b: unknown) {
+            this.lastBitmap = b;
+          },
+        };
+        return this._bitmapCtx;
+      }
+      // A minimal recording 2d context is never actually used by the viewer
+      // (renderSlide owns the ctx); return a no-op object for safety.
+      return {};
+    },
+    getBoundingClientRect() {
+      return { top: 0, left: 0, width: this.clientWidth, height: this.clientHeight };
+    },
+    dispatch(type: string, event: unknown = {}) {
+      for (const fn of this._listeners.get(type) ?? []) fn(event);
+    },
+  };
+  // Mirror the DOM: assigning `innerHTML = ''` detaches all children (both
+  // buildPptxTextLayer's leading clear and the viewer's overlay-teardown clear on
+  // recycle rely on this). A non-empty assignment only records the string (the
+  // viewer/text-layer never set non-empty innerHTML, so no parsing is needed).
+  let _html = '';
+  Object.defineProperty(el, 'innerHTML', {
+    get() {
+      return _html;
+    },
+    set(value: string) {
+      _html = value;
+      if (value === '') {
+        for (const c of el.children) c.parentElement = null;
+        el.children.length = 0;
+      }
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  return el;
+}
+
+/** A container FakeEl with a nonzero clientWidth so `width` defaults resolve. */
+export function makeContainer(clientWidth = 800, clientHeight = 600): FakeEl {
+  const c = makeEl('div');
+  c.clientWidth = clientWidth;
+  c.clientHeight = clientHeight;
+  return c;
+}
+
+/** Install a recording document + window + ResizeObserver into globals.
+ *  Returns the last-constructed ResizeObserver callback so a test can fire a
+ *  synthetic resize. Call `vi.unstubAllGlobals()` in afterEach. */
+export function installDom(): { resizeCb: () => (() => void) | undefined } {
+  let lastResizeCb: (() => void) | undefined;
+  vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+  vi.stubGlobal('window', { devicePixelRatio: 1 });
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(cb: () => void) {
+        lastResizeCb = cb;
+      }
+      observe(): void {}
+      disconnect(): void {}
+    },
+  );
+  return { resizeCb: () => lastResizeCb };
+}
+
+export interface RenderCall {
+  slide: number;
+  /** The per-call `width` (px) the viewer passed — asserted by T3 to confirm
+   *  each slide gets its OWN px width (uniform px width from the deck-wide scale,
+   *  §7). pptx slides are uniform, so every value equals the same px width, but
+   *  the per-call contract still passes a width per slide. */
+  width?: number;
+  resolve: () => void;
+  reject: (e: Error) => void;
+}
+
+/** A fake PptxPresentation covering exactly the surface PptxScrollViewer consumes.
+ *  Slide size is UNIFORM (slideWidth/slideHeight in EMU), unlike docx's per-index
+ *  pageSize. Deferred mode: renderSlide / renderSlideToBitmap return promises the
+ *  test resolves via the recorded RenderCall, so coalescing / stale-drop is
+ *  observable. */
+export class FakePptxEngine {
+  destroyed = false;
+  renderCalls: RenderCall[] = [];
+  bitmapCalls: RenderCall[] = [];
+  createdBitmaps: Array<{ width: number; height: number; close: ReturnType<typeof vi.fn> }> = [];
+  /** Runs fed to `renderSlide`'s `onTextRun` (main mode only) so a test can drive
+   *  the viewer's per-slot text overlay (buildPptxTextLayer) without a real
+   *  render. Empty/undefined ⇒ no runs emitted. */
+  feedTextRuns?: PptxTextRunInfo[];
+  constructor(
+    private _slideCount: number,
+    public readonly slideWidth: number, // EMU, deck-wide (uniform)
+    public readonly slideHeight: number, // EMU, deck-wide (uniform)
+    private _mode: 'main' | 'worker' = 'main',
+    private deferred = false,
+  ) {}
+  get slideCount(): number {
+    return this._slideCount;
+  }
+  /** Mirrors the real `PptxPresentation.mode` fact (presentation.ts) — the exact
+   *  fact the viewer constructor reads to decide the render path (main ⇒
+   *  renderSlide, worker ⇒ renderSlideToBitmap). Design §11: no probing / no
+   *  silent mis-pathing. */
+  get mode(): 'main' | 'worker' {
+    return this._mode;
+  }
+  renderSlide(_canvas: unknown, slide: number, opts?: RenderSlideOptions): Promise<void> {
+    if (this._mode === 'worker') {
+      // Record the attempt BEFORE throwing so a test can assert the viewer never
+      // routes a worker-mode engine through renderSlide (and detect wrong-path
+      // routing). The real PptxPresentation.renderSlide THROWS synchronously in
+      // worker mode — mirror that exactly (do NOT return Promise.reject), reusing
+      // the real error text (presentation.ts).
+      this.renderCalls.push({ slide, resolve: () => {}, reject: () => {} });
+      throw new Error(
+        "renderSlide(canvas) is unavailable in mode: 'worker'; use renderSlideToBitmap() and paint it via an ImageBitmapRenderingContext",
+      );
+    }
+    // Emit any fed runs to the viewer's internal onTextRun so it can build the
+    // per-slot overlay (mirrors the real renderer emitting run geometry).
+    for (const r of this.feedTextRuns ?? []) opts?.onTextRun?.(r);
+    return new Promise<void>((resolve, reject) => {
+      const call: RenderCall = { slide, width: opts?.width, resolve: () => resolve(), reject };
+      this.renderCalls.push(call);
+      if (!this.deferred) resolve();
+    });
+  }
+  renderSlideToBitmap(slide: number, opts?: RenderSlideToBitmapOptions): Promise<ImageBitmap> {
+    const w = opts?.width ?? 960;
+    const h = this.slideWidth > 0 ? Math.round((w * this.slideHeight) / this.slideWidth) : 0;
+    const bmp = { width: w, height: h, close: vi.fn() };
+    this.createdBitmaps.push(bmp);
+    return new Promise<ImageBitmap>((resolve, reject) => {
+      const call: RenderCall = {
+        slide,
+        width: opts?.width,
+        resolve: () => resolve(bmp as unknown as ImageBitmap),
+        reject,
+      };
+      this.bitmapCalls.push(call);
+      if (!this.deferred) resolve(bmp as unknown as ImageBitmap);
+    });
+  }
+  /** The per-call `width` (px) recorded for every renderSlide call, in call order.
+   *  T3 asserts each mounted slide received its OWN px width. */
+  renderSlideWidths(): number[] {
+    return this.renderCalls.map((c) => c.width ?? NaN);
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+  asPres(): PptxPresentation {
+    return this as unknown as PptxPresentation;
+  }
+}

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1023,3 +1023,256 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     v.destroy();
   });
 });
+
+describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
+  // container fit width 200, slide 1000×600 EMU → base scale = 200/1000 = 0.2.
+  // slide height px = 600 * 0.2 = 120. gap 10 ⇒ stride 130.
+  const BASE = 200 / 1000; // 0.2
+  const SLIDE_H = 600 * BASE; // 120
+  const GAP = 10;
+  const STRIDE = SLIDE_H + GAP; // 130 — the top-to-top distance between slides
+
+  function setup(slideCount = 20, opts = {}) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(slideCount, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: GAP,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, container, engine };
+  }
+
+  it('scrollToSlide sets scrollTop to the slide offset and clamps out-of-range', () => {
+    const { v, scrollHost } = setup();
+    // Pick a clientHeight that makes maxTop STRICTLY LESS than the last slide's top
+    // offset, so the `Math.min(maxTop, target)` clamp is actually exercised.
+    // totalHeight = 20*120 + 19*10 = 2590; offsets[19] = 19*130 = 2470.
+    scrollHost.clientHeight = 200; // maxTop = 2590 − 200 = 2390 < offsets[19] 2470
+    v.scrollToSlide(3);
+    expect(Math.abs(scrollHost.scrollTop - 3 * STRIDE)).toBeLessThan(2);
+    v.scrollToSlide(999); // clamps to last slide index (19)
+    const totalHeight = 20 * SLIDE_H + 19 * GAP; // 2590
+    const maxTop = totalHeight - 200; // 2390
+    const lastOffset = 19 * STRIDE; // 2470
+    expect(maxTop).toBeLessThan(lastOffset); // precondition: clamp is exercised
+    expect(Math.abs(scrollHost.scrollTop - maxTop)).toBeLessThan(2);
+    v.scrollToSlide(-5); // clamps to 0
+    expect(scrollHost.scrollTop).toBe(0);
+    v.destroy();
+  });
+
+  it('scrollToSlide: viewport taller than total content ⇒ scrollTop pinned to 0 (negative maxTop guard)', () => {
+    // A 2-slide deck is shorter than a very tall viewport, so
+    // totalHeight − clientHeight is NEGATIVE; the `Math.max(0, …)` maxTop guard must
+    // pin scrollTop to 0 rather than a negative top.
+    const { v, scrollHost } = setup(2);
+    scrollHost.clientHeight = 5000; // >> totalHeight (2*120 + 10 = 250)
+    v.scrollToSlide(1); // last slide; its offset (130) is above maxTop (0)
+    expect(scrollHost.scrollTop).toBe(0);
+    v.destroy();
+  });
+
+  it('onVisibleSlideChange fires only when topIndex changes', () => {
+    const changes: number[] = [];
+    const { v, scrollHost } = setup(20, { onVisibleSlideChange: (i: number) => changes.push(i) });
+    scrollHost.scrollTop = STRIDE; // slide 1 top
+    scrollHost.dispatch('scroll');
+    scrollHost.scrollTop = STRIDE + 10; // still within slide 1
+    scrollHost.dispatch('scroll');
+    scrollHost.scrollTop = 3 * STRIDE; // slide 3 top
+    scrollHost.dispatch('scroll');
+    // Deduped: 0 (initial) → 1 → 3, no repeat for the STRIDE+10 no-op.
+    expect(changes).toEqual([0, 1, 3]);
+    v.destroy();
+  });
+
+  it('scrollToSlide does not re-fire onVisibleSlideChange for the same top slide', () => {
+    const changes: number[] = [];
+    const { v } = setup(20, { onVisibleSlideChange: (i: number) => changes.push(i) });
+    // Initial mount fired 0. scrollToSlide(0) lands on the same top slide — no new fire.
+    v.scrollToSlide(0);
+    expect(changes).toEqual([0]);
+    // Navigate to slide 5 → one fire; navigate there again → no duplicate.
+    v.scrollToSlide(5);
+    v.scrollToSlide(5);
+    expect(changes).toEqual([0, 5]);
+    v.destroy();
+  });
+
+  it('ResizeObserver re-fit preserves the zoom multiplier', () => {
+    // zoomMax headroom: base 0.2, 2× zoom → 0.4; after the width doubles the new
+    // base is 0.4 so the preserved scale is 0.8. zoomMin/zoomMax are ABSOLUTE
+    // px-per-EMU bounds (design §8.2), so a low zoomMax would legitimately CLAMP
+    // the re-fit and break preservation. Give the multiplier room to survive.
+    const { v, container } = setup(20, { zoomMax: 10 });
+    v.setScale(v.baseScaleForTest() * 2); // 2× zoom
+    const zoomMultiplier = v.scaleForTest() / v.baseScaleForTest();
+    // Container widens; the observer callback re-fits base and re-applies the mult.
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    v.resizeForTest(); // fires the observed resize path
+    expect(v.scaleForTest() / v.baseScaleForTest()).toBeCloseTo(zoomMultiplier, 5);
+    v.destroy();
+  });
+
+  it('ResizeObserver re-fit bumps the render epoch (resize is an epoch event)', () => {
+    const { v, container } = setup();
+    const before = v.renderEpochForTest();
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    v.resizeForTest();
+    // A width change re-fits the base scale (routed through setScale), which bumps
+    // the epoch so any bitmap in flight at the old scale is treated as stale.
+    expect(v.renderEpochForTest()).toBeGreaterThan(before);
+    v.destroy();
+  });
+
+  it('ResizeObserver re-fit with an UNCHANGED width does not re-fit or bump the epoch', () => {
+    const { v } = setup();
+    const scaleBefore = v.scaleForTest();
+    const epochBefore = v.renderEpochForTest();
+    v.resizeForTest(); // same width — no-op re-fit
+    expect(v.scaleForTest()).toBe(scaleBefore);
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    v.destroy();
+  });
+
+  it('height-only resize (width unchanged) re-mounts the newly-revealed window without a scroll, no epoch bump, no callback', () => {
+    // F1 regression: a height-only grow used to early-return before `_mountVisible`,
+    // leaving the newly-revealed rows blank until the user scrolled. At scrollTop 0
+    // the initially-mounted window is [0..3] (viewport 400 / stride 130 ≈ 3 slides;
+    // +1 overscan). Growing the viewport must mount more purely from the resize —
+    // no scroll event, no epoch bump (geometry/scale unchanged so cached canvases
+    // stay valid), and no onVisibleSlideChange fire (topIndex stays 0).
+    const changes: number[] = [];
+    const { v, scrollHost } = setup(20, { onVisibleSlideChange: (i: number) => changes.push(i) });
+    const mountedBefore = v.mountedSlideIndicesForTest().slice().sort((a, b) => a - b);
+    expect(mountedBefore.length).toBeGreaterThan(0);
+    expect(changes).toEqual([0]); // initial mount fired 0
+    const epochBefore = v.renderEpochForTest();
+    const scaleBefore = v.scaleForTest();
+
+    // Grow HEIGHT only; width (and thus the fit-width base scale) is unchanged.
+    scrollHost.clientHeight = 1600;
+    v.resizeForTest(); // NO scroll event dispatched
+
+    const mountedAfter = v.mountedSlideIndicesForTest().slice().sort((a, b) => a - b);
+    // The revealed window strictly grows (taller viewport intersects more slides).
+    expect(mountedAfter.length).toBeGreaterThan(mountedBefore.length);
+    expect(Math.max(...mountedAfter)).toBeGreaterThan(Math.max(...mountedBefore));
+    // No epoch bump — nothing was re-scaled, so no in-flight render is stale.
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    expect(v.scaleForTest()).toBe(scaleBefore);
+    // topIndex is still 0 at scrollTop 0 ⇒ callback did NOT fire again.
+    expect(changes).toEqual([0]);
+    v.destroy();
+  });
+
+  it('clamped resize (zoomMax clamp + width & height grow) still refreshes the revealed window', () => {
+    // F1 clamped-path variant: pin zoomMax to the current base so a width grow's
+    // re-fit (newBase × mult) clamps back to the SAME scale, making setScale a no-op
+    // (which skips its own force-re-render mount). The post-setScale `_mountVisible`
+    // must still mount the rows the taller viewport revealed. base = 0.2, no user
+    // zoom ⇒ mult 1; after width→400 newBase 0.4 clamps to zoomMax 0.2 (== _scale).
+    const changes: number[] = [];
+    const { v, scrollHost, container } = setup(20, {
+      zoomMax: BASE, // 0.2 — clamps the re-fit back to the current scale
+      onVisibleSlideChange: (i: number) => changes.push(i),
+    });
+    expect(v.scaleForTest()).toBe(BASE);
+    const mountedBefore = v.mountedSlideIndicesForTest().slice().sort((a, b) => a - b);
+    expect(mountedBefore.length).toBeGreaterThan(0);
+    const epochBefore = v.renderEpochForTest();
+
+    // Grow BOTH width and height. The width grow triggers the re-fit branch, but the
+    // clamp pins the scale unchanged ⇒ setScale no-ops. Heights are therefore
+    // unchanged (scale unchanged), so the taller viewport reveals more of the SAME
+    // geometry.
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    scrollHost.clientWidth = 400;
+    scrollHost.clientHeight = 1600;
+    v.resizeForTest();
+
+    const mountedAfter = v.mountedSlideIndicesForTest().slice().sort((a, b) => a - b);
+    expect(mountedAfter.length).toBeGreaterThan(mountedBefore.length);
+    // Scale stayed pinned at the clamp, so setScale no-oped ⇒ no epoch bump.
+    expect(v.scaleForTest()).toBe(BASE);
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    // topIndex still 0 ⇒ no extra callback.
+    expect(changes).toEqual([0]);
+    v.destroy();
+  });
+
+  it('zero-width container defers, then lays out on first non-zero resize', () => {
+    installDom();
+    const container = makeContainer(0, 0); // unlaid-out
+    const engine = new FakePptxEngine(5, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    expect(v.mountedSlideIndicesForTest().length).toBe(0); // deferred
+    container.clientWidth = 300;
+    scrollHost.clientWidth = 300;
+    scrollHost.clientHeight = 400;
+    v.resizeForTest();
+    expect(v.mountedSlideIndicesForTest().length).toBeGreaterThan(0);
+    v.destroy();
+  });
+
+  it('empty deck: slideCount 0 ⇒ spacer 0, no slots, scrollToSlide no-op', () => {
+    installDom();
+    const container = makeContainer(300, 400);
+    const engine = new FakePptxEngine(0, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
+    v.relayout();
+    const spacer = (container.children[0] as FakeEl).children[0].children[0] as FakeEl;
+    expect(parseFloat(spacer.style.height || '0')).toBe(0);
+    expect(v.mountedSlideIndicesForTest().length).toBe(0);
+    v.scrollToSlide(0); // no throw
+    v.destroy();
+  });
+
+  it('empty deck: resize does not crash and fires no callback', () => {
+    installDom();
+    const container = makeContainer(0, 0);
+    const engine = new FakePptxEngine(0, 1000, 600);
+    const changes: number[] = [];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      onVisibleSlideChange: (i: number) => changes.push(i),
+    });
+    container.clientWidth = 300;
+    (container.children[0] as FakeEl).children[0].clientWidth = 300;
+    v.resizeForTest(); // no slides ⇒ no-op
+    expect(v.mountedSlideIndicesForTest().length).toBe(0);
+    expect(changes).toEqual([]);
+    v.destroy();
+  });
+
+  it('destroy() disconnects the ResizeObserver', () => {
+    installDom();
+    let disconnected = 0;
+    class SpyRO {
+      cb: () => void;
+      constructor(cb: () => void) {
+        this.cb = cb;
+      }
+      observe(): void {}
+      disconnect(): void {
+        disconnected++;
+      }
+    }
+    vi.stubGlobal('ResizeObserver', SpyRO);
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(3, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
+    v.destroy();
+    expect(disconnected).toBe(1);
+  });
+});

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -102,3 +102,119 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
     expect(engine.destroyed).toBe(false);
   });
 });
+
+describe('PptxScrollViewer — layout + virtualization (T2)', () => {
+  // Uniform 1000×600 EMU slides; `_scale` is px-per-EMU (no PT_TO_PX). Fit the
+  // slide width to the container: base scale = clientWidth / slideWidth. With
+  // clientWidth 200 → base 0.2 ⇒ each slide is 200px wide, 120px tall.
+  function setup(slideCount: number, opts = {}) {
+    const dom = installDom();
+    const container = makeContainer(200, 400); // clientWidth 200, clientHeight 400
+    const engine = new FakePptxEngine(slideCount, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      overscan: 1,
+      width: undefined, // fit container width (200) → base scale below
+      ...opts,
+    });
+    const wrapper = container.children[0] as FakeEl;
+    const scrollHost = wrapper.children[0] as FakeEl;
+    const spacer = scrollHost.children[0] as FakeEl;
+    // Drive layout: container width 200, slide width 1000 EMU → base scale maps
+    // 1000 EMU to 200px (0.2 px/EMU). Provide the viewport height.
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    return { dom, container, engine, v, wrapper, scrollHost, spacer };
+  }
+
+  it('sizes the spacer to computeVisibleRange.totalHeight and mounts only the visible window', () => {
+    const { v, scrollHost, spacer } = setup(10);
+    v.relayout(); // T2 exposes an explicit relayout() the viewer calls after load/resize
+    // Spacer height > 0 and equals n * slideHeightPx + (n-1)*gap in px.
+    expect(parseFloat(spacer.style.height)).toBeGreaterThan(0);
+    // At scrollTop 0 with a 400px viewport and 120px-tall slides, several slides
+    // fit; overscan 1 adds one more. Assert the mounted slot count is bounded.
+    const mounted = scrollHost.children.filter((c) => c !== spacer);
+    expect(mounted.length).toBeGreaterThanOrEqual(1);
+    // Viewport 400 / stride 130 ⇒ ~4 slides visible + overscan; comfortably bounded.
+    expect(mounted.length).toBeLessThanOrEqual(6);
+    v.destroy();
+  });
+
+  it('spacer height is exact for uniform slide heights + gap', () => {
+    const dom = installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(3, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      overscan: 1,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    const spacer = scrollHost.children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // base scale = 200 / 1000 = 0.2 px/EMU ⇒ slide height px = 600 * 0.2 = 120.
+    const scale = 200 / 1000;
+    const slideH = 600 * scale; // 120
+    const n = 3;
+    const expected = n * slideH + (n - 1) * 10;
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+    v.destroy();
+    void dom;
+  });
+
+  it('recycles slots on scroll without unbounded canvas growth (pool reuse)', () => {
+    const { v, scrollHost } = setup(50);
+    v.relayout();
+    const initialMount = scrollHost.children.length;
+    // Scroll far down and fire the scroll listener repeatedly.
+    for (let top = 0; top <= 4000; top += 400) {
+      scrollHost.scrollTop = top;
+      scrollHost.dispatch('scroll');
+    }
+    // The DOM child count (spacer + mounted slots) must stay bounded — the pool
+    // reuses slots rather than appending a new canvas per slide.
+    expect(scrollHost.children.length).toBeLessThanOrEqual(initialMount + 2);
+  });
+
+  it('scrolling far then back reuses pooled slot wrappers (bounded distinct allocations)', () => {
+    const { v, scrollHost } = setup(50);
+    v.relayout();
+    // Track EVERY distinct wrapper element the viewer ever appends. If slots are
+    // pooled (recycled), scrolling across the whole deck then back reuses a small
+    // fixed set of wrappers rather than allocating one per visited slide.
+    const seen = new Set<FakeEl>();
+    const collect = () => {
+      for (const c of scrollHost.children) if (c.tag === 'div') seen.add(c);
+    };
+    collect();
+    // Sweep deep into the deck and back to the top.
+    for (const top of [3000, 6000, 3000, 0]) {
+      scrollHost.scrollTop = top;
+      scrollHost.dispatch('scroll');
+      collect();
+    }
+    // 50 slides visited across the sweep; a per-slide allocator would have created
+    // dozens of wrappers. The pool must keep the distinct-wrapper count tiny:
+    // spacer(1) + at most a couple of window-sized generations of slots.
+    expect(seen.size).toBeLessThanOrEqual(12);
+    // Coming back to the top mounts slide 0 again, drawn from the pool.
+    expect(v.mountedSlideIndicesForTest()).toContain(0);
+  });
+
+  it('mounts the correct window for a mid-deck scrollTop', () => {
+    const { v, scrollHost } = setup(20);
+    v.relayout();
+    // Jump to a scrollTop deep in the deck; the mounted slots must include the
+    // slide under the viewport top (topVisibleSlide) and its overscan neighbours.
+    scrollHost.scrollTop = 1300;
+    scrollHost.dispatch('scroll');
+    const top = v.topVisibleSlide;
+    const mountedSlides = v.mountedSlideIndicesForTest(); // T2 test hook
+    expect(mountedSlides).toContain(top);
+    expect(Math.max(...mountedSlides) - Math.min(...mountedSlides)).toBeLessThanOrEqual(6);
+  });
+});

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -13,7 +13,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
   it('builds the wrapper → scrollHost → spacer DOM inside the container', () => {
     installDom();
     const container = makeContainer();
-    const engine = new FakePptxEngine(3, 1000, 600);
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
     // container → wrapper
     const wrapper = container.children[0];
@@ -30,7 +30,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
 
   it('exposes slideCount from the injected engine', () => {
     installDom();
-    const engine = new FakePptxEngine(5, 1000, 600);
+    const engine = new FakePptxEngine(5, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, { presentation: engine.asPres() });
     expect(v.slideCount).toBe(5);
     v.destroy();
@@ -38,7 +38,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
 
   it('load() is unsupported when an engine is injected', async () => {
     installDom();
-    const engine = new FakePptxEngine(1, 1000, 600);
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, { presentation: engine.asPres() });
     await expect(v.load('x.pptx')).rejects.toThrow(/injected/i);
     v.destroy();
@@ -47,7 +47,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
   it('destroy() removes the DOM and does NOT destroy an injected engine', () => {
     installDom();
     const container = makeContainer();
-    const engine = new FakePptxEngine(1, 1000, 600);
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
     expect(container.children.length).toBe(1); // wrapper mounted
     v.destroy();
@@ -67,7 +67,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
   // construction; a matching or absent opts.mode constructs fine.
   it('throws when opts.mode conflicts with an injected worker-mode engine', () => {
     installDom();
-    const engine = new FakePptxEngine(1, 1000, 600, 'worker');
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU, 'worker');
     expect(
       () =>
         new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {
@@ -79,7 +79,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
 
   it('does NOT throw when opts.mode matches an injected worker-mode engine', () => {
     installDom();
-    const engine = new FakePptxEngine(1, 1000, 600, 'worker');
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU, 'worker');
     const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {
       presentation: engine.asPres(),
       mode: 'worker',
@@ -93,7 +93,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
   it('constructs a default-main injected engine with absent opts.mode (load still rejects; destroy preserves engine)', async () => {
     installDom();
     // Default mode is 'main'; opts.mode is absent ⇒ no conflict, resolved path is main.
-    const engine = new FakePptxEngine(2, 1000, 600);
+    const engine = new FakePptxEngine(2, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {
       presentation: engine.asPres(),
     });
@@ -109,7 +109,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
   it('applies opts.background to the scrollHost element', () => {
     installDom();
     const container = makeContainer();
-    const engine = new FakePptxEngine(1, 1000, 600);
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       background: '#525659',
@@ -122,7 +122,7 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
   it('sets no background on the scrollHost by default (transparent — container shows through)', () => {
     installDom();
     const container = makeContainer();
-    const engine = new FakePptxEngine(1, 1000, 600);
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
     });
@@ -132,14 +132,29 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
   });
 });
 
+// Fake slide geometry, chosen so the DIMENSIONLESS base scale is a clean 1.0 and
+// arithmetic stays tidy. `_scale` is now a multiplier over the 96-dpi natural
+// size (natural px = EMU / EMU_PER_PX, EMU_PER_PX = 9525), mirroring docx.
+//   slide width  = 9525 × 200 = 1,905,000 EMU ⇒ natural 200px
+//   slide height = 9525 × 120 = 1,143,000 EMU ⇒ natural 120px
+// Container width 200 ⇒ base = 200 / 200 = 1.0 ⇒ slide 200×120px at base.
+// (Old geometry was 1000×600 EMU with a px-per-EMU scale of 0.2; that yielded the
+// same 200×120px slide, so the stride math below — 120px tall, gap 10, stride 130
+// — is unchanged. Only the SCALE VALUE changes: base 0.2 → 1.0, zoom ×2 → 2.0.)
+const SLIDE_W_EMU = 9525 * 200; // 1,905,000 ⇒ natural 200px
+const SLIDE_H_EMU = 9525 * 120; // 1,143,000 ⇒ natural 120px
+// Tall variant used by the worker recycle/re-mount test: natural 400px tall ⇒
+// 200×400px at base 1.0, so the visible window is exactly one slide + overscan.
+// (Was 1000×2000 EMU with the old 0.2 px/EMU scale — the same 200×400px slide.)
+const SLIDE_H_TALL_EMU = 9525 * 400; // 3,810,000 ⇒ natural 400px
+
 describe('PptxScrollViewer — layout + virtualization (T2)', () => {
-  // Uniform 1000×600 EMU slides; `_scale` is px-per-EMU (no PT_TO_PX). Fit the
-  // slide width to the container: base scale = clientWidth / slideWidth. With
-  // clientWidth 200 → base 0.2 ⇒ each slide is 200px wide, 120px tall.
+  // See the SLIDE_W_EMU/SLIDE_H_EMU note above: container 200 ⇒ dimensionless base
+  // scale 1.0 ⇒ each slide is 200px wide, 120px tall.
   function setup(slideCount: number, opts = {}) {
     const dom = installDom();
     const container = makeContainer(200, 400); // clientWidth 200, clientHeight 400
-    const engine = new FakePptxEngine(slideCount, 1000, 600);
+    const engine = new FakePptxEngine(slideCount, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -150,8 +165,8 @@ describe('PptxScrollViewer — layout + virtualization (T2)', () => {
     const wrapper = container.children[0] as FakeEl;
     const scrollHost = wrapper.children[0] as FakeEl;
     const spacer = scrollHost.children[0] as FakeEl;
-    // Drive layout: container width 200, slide width 1000 EMU → base scale maps
-    // 1000 EMU to 200px (0.2 px/EMU). Provide the viewport height.
+    // Drive layout: container width 200, natural slide width 200px → dimensionless
+    // base scale 1.0. Provide the viewport height.
     scrollHost.clientHeight = 400;
     scrollHost.clientWidth = 200;
     return { dom, container, engine, v, wrapper, scrollHost, spacer };
@@ -174,7 +189,7 @@ describe('PptxScrollViewer — layout + virtualization (T2)', () => {
   it('spacer height is exact for uniform slide heights + gap', () => {
     const dom = installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(3, 1000, 600);
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -185,9 +200,9 @@ describe('PptxScrollViewer — layout + virtualization (T2)', () => {
     scrollHost.clientHeight = 400;
     scrollHost.clientWidth = 200;
     v.relayout();
-    // base scale = 200 / 1000 = 0.2 px/EMU ⇒ slide height px = 600 * 0.2 = 120.
-    const scale = 200 / 1000;
-    const slideH = 600 * scale; // 120
+    // Dimensionless base scale = 200 / 200 (natural width) = 1.0 ⇒ slide height px =
+    // (SLIDE_H_EMU / 9525) * 1.0 = 120.
+    const slideH = SLIDE_H_EMU / 9525; // 120
     const n = 3;
     const expected = n * slideH + (n - 1) * 10;
     expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
@@ -252,7 +267,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
   it("main mode: calls renderSlide once per mounted slot with that slide's px width", () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(10, 1000, 600);
+    const engine = new FakePptxEngine(10, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -266,9 +281,9 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     const rendered = engine.renderCalls.map((c) => c.slide).sort((a, b) => a - b);
     expect(rendered).toEqual(mounted);
     // Each renderSlide call carried the per-call px width. pptx slides are uniform,
-    // so every width equals the same fit-width (base scale = 200/1000 = 0.2 px/EMU;
-    // slide width px = 1000 * 0.2 = 200), but the per-call width contract still
-    // passes a width per slide (mirrors docx's per-page width assertion, §7).
+    // so every width equals the same fit-width (dimensionless base scale 1.0 over
+    // the natural 200px width ⇒ slide width px = 200), but the per-call width
+    // contract still passes a width per slide (mirrors docx's per-page width, §7).
     const widths = engine.renderSlideWidths();
     expect(widths.length).toBe(mounted.length);
     for (const w of widths) expect(w).toBeCloseTo(200, 3);
@@ -281,7 +296,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     // pptx slide size is UNIFORM deck-wide, so unlike docx (mixed page sizes) every
     // slide renders at the SAME px width. The per-call width contract still holds:
     // each mounted slide receives its own width argument, equal to the uniform px.
-    const engine = new FakePptxEngine(2, 1000, 600);
+    const engine = new FakePptxEngine(2, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -290,8 +305,8 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     scrollHost.clientHeight = 400;
     scrollHost.clientWidth = 200;
     v.relayout();
-    // Both slides mount (slide 0 height px = 600*0.2 = 120; slide 1 top 130 within
-    // the 400px viewport), so both get exactly one render.
+    // Both slides mount (slide 0 height px = 120 at base scale 1.0; slide 1 top 130
+    // within the 400px viewport), so both get exactly one render.
     const mounted = v.mountedSlideIndicesForTest().sort((a, b) => a - b);
     expect(mounted).toEqual([0, 1]);
     // Per-slide px widths in call order: uniform 200 each.
@@ -307,7 +322,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
   it('does not re-render a mounted slot for the same slide on a no-op scroll', () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(10, 1000, 600);
+    const engine = new FakePptxEngine(10, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -329,7 +344,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     // mode:'worker' — the real PptxPresentation.renderSlide THROWS synchronously in
     // worker mode; a viewer that mis-routed would blow up (and renderCalls would
     // record the attempt). The direct _mode routing must never touch renderSlide.
-    const engine = new FakePptxEngine(10, 1000, 600, 'worker');
+    const engine = new FakePptxEngine(10, SLIDE_W_EMU, SLIDE_H_EMU, 'worker');
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -351,7 +366,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
   it('worker mode: paints a resolved bitmap into the slot canvas (transfer)', async () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(10, 1000, 600, 'worker');
+    const engine = new FakePptxEngine(10, SLIDE_W_EMU, SLIDE_H_EMU, 'worker');
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -381,7 +396,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     // stale-check closes the orphan (design §11).
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const engine = new FakePptxEngine(50, SLIDE_W_EMU, SLIDE_H_EMU, 'worker', true);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -409,7 +424,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     const container = makeContainer(200, 400);
     // Deferred: renderSlideToBitmap resolves only when the test calls resolve(),
     // so we can scroll a slot's slide out of the window BEFORE the bitmap arrives.
-    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const engine = new FakePptxEngine(50, SLIDE_W_EMU, SLIDE_H_EMU, 'worker', true);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -442,13 +457,13 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     // re-dispatch the live slot's render so the slide never stays blank.
     installDom();
     const container = makeContainer(200, 400);
-    // Tall slides (1000×2000 EMU ⇒ 200×400px at base scale 0.2, stride 410) so the
+    // Tall slides (natural 200×400px ⇒ 200×400px at base scale 1.0, stride 410) so the
     // visible window is exactly one slide + overscan = [0,1], mirroring the docx
     // recycle/re-mount pool dynamics: the re-mounted slide-0 slot is a DIFFERENT
     // pooled object than the in-flight one, so `live !== slot` triggers the
     // re-dispatch. (A short-slide window packs several slots, whose LIFO reuse can
     // hand slide 0 back its own in-flight slot — an epoch-only case not under test.)
-    const engine = new FakePptxEngine(50, 1000, 2000, 'worker', true);
+    const engine = new FakePptxEngine(50, SLIDE_W_EMU, SLIDE_H_TALL_EMU, 'worker', true);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -501,7 +516,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     // →3→4 with onError every round). The onError contract leaves the slide blank.
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const engine = new FakePptxEngine(50, SLIDE_W_EMU, SLIDE_H_EMU, 'worker', true);
     const onError = vi.fn();
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
@@ -540,7 +555,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     installDom();
     const container = makeContainer(200, 400);
     // Deferred so a render is genuinely in flight when we destroy the viewer.
-    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const engine = new FakePptxEngine(50, SLIDE_W_EMU, SLIDE_H_EMU, 'worker', true);
     const onError = vi.fn();
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
@@ -571,13 +586,13 @@ describe('PptxScrollViewer — rendering (T3)', () => {
   it('render epoch: a bitmap dispatched at the old scale is dropped (closed, not painted) after setScale, and re-dispatched at the new scale', async () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(20, 1000, 600, 'worker', true);
+    const engine = new FakePptxEngine(20, SLIDE_W_EMU, SLIDE_H_EMU, 'worker', true);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
       overscan: 1,
-      zoomMin: 0.05,
-      zoomMax: 3,
+      // REAL defaults [0.1, 4]: base fit is 1.0, and setScale(×2)=2.0 is inside them
+      // (the old `zoomMin: 0.05, zoomMax: 3` dodged the px-per-EMU unit bug — WS4b-2).
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -633,14 +648,14 @@ describe('PptxScrollViewer — rendering (T3)', () => {
   it('render epoch: rejecting the OLD-scale dispatch after setScale still yields exactly ONE fresh dispatch at the new scale (bounded)', async () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(20, 1000, 600, 'worker', true);
+    const engine = new FakePptxEngine(20, SLIDE_W_EMU, SLIDE_H_EMU, 'worker', true);
     const onError = vi.fn();
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
       overscan: 1,
-      zoomMin: 0.05,
-      zoomMax: 3,
+      // REAL defaults [0.1, 4]: base fit is 1.0, and setScale(×2)=2.0 is inside them
+      // (the old `zoomMin: 0.05, zoomMax: 3` dodged the px-per-EMU unit bug — WS4b-2).
       onError,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -683,26 +698,25 @@ describe('PptxScrollViewer — rendering (T3)', () => {
 });
 
 describe('PptxScrollViewer — zoom (T4)', () => {
-  // Uniform 1000×600 EMU slides; `_scale` is px-per-EMU (no PT_TO_PX). Container
-  // 200×400, width:undefined ⇒ base fit maps the slide width (1000 EMU) to 200px:
-  //   base = 200 / 1000 = 0.2 px/EMU
-  //   slide height px = 600 * 0.2 = 120
+  // `_scale` is a DIMENSIONLESS multiplier over the 96-dpi natural slide size
+  // (mirrors docx). Container 200×400, width:undefined ⇒ base fit maps the natural
+  // 200px slide width (SLIDE_W_EMU / 9525) to the 200px container:
+  //   base = 200 / 200 = 1.0
+  //   slide height px = (SLIDE_H_EMU / 9525) * 1.0 = 120
   //   offset[i] = i * (120 + gap) = i * 130
-  // Zoom ×2 ⇒ scale 0.4, height 240, stride 250. The two MANDATORY render-epoch
-  // tests (resolve + reject) live in the T3 rendering block above (already covered
-  // by WS4b-1), so they are not repeated here.
+  // Zoom ×2 ⇒ scale 2.0, height 240, stride 250. Because base is now 1.0, base×2 =
+  // 2.0 sits inside the DEFAULT [0.1, 4] bounds, so setup uses REAL defaults — the
+  // old `zoomMin: 0.05, zoomMax: 3` workarounds only existed to dodge the px-per-EMU
+  // base of 0.2 (WS4b-2 review finding) and are removed. The two MANDATORY render-
+  // epoch tests (resolve + reject) live in the T3 rendering block above.
   function setup(slideCount = 20, opts = {}) {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(slideCount, 1000, 600);
+    const engine = new FakePptxEngine(slideCount, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
       overscan: 1,
-      // Give the base fit (0.2) headroom: base ×2 = 0.4 stays within these bounds
-      // so the re-anchor tests exercise the zoom path, not the clamp.
-      zoomMin: 0.05,
-      zoomMax: 3,
       ...opts,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -714,21 +728,21 @@ describe('PptxScrollViewer — zoom (T4)', () => {
 
   it('base fit scale maps the slide width to the container width', () => {
     const { v } = setup();
-    // base = 200 / 1000 = 0.2
-    expect(v.scaleForTest()).toBeCloseTo(0.2, 6);
-    expect(v.baseScaleForTest()).toBeCloseTo(0.2, 6);
+    // base = 200 / 200 (natural width) = 1.0
+    expect(v.scaleForTest()).toBeCloseTo(1.0, 6);
+    expect(v.baseScaleForTest()).toBeCloseTo(1.0, 6);
     v.destroy();
   });
 
   it('re-anchors so the slide under the viewport top stays fixed across a zoom (intraFrac 0)', () => {
     const { v, scrollHost } = setup();
-    // slide 3 top offset at base (0.2): 3 * (120 + 10) = 390
+    // slide 3 top offset at base (1.0): 3 * (120 + 10) = 390
     scrollHost.scrollTop = 390;
     scrollHost.dispatch('scroll');
     expect(v.topVisibleSlide).toBe(3);
-    const cur = v.scaleForTest(); // 0.2
-    v.setScale(cur * 2); // 0.4 (within [0.05, 3], no clamp)
-    expect(v.scaleForTest()).toBeCloseTo(0.4, 6);
+    const cur = v.scaleForTest(); // 1.0
+    v.setScale(cur * 2); // 2.0 (within default [0.1, 4], no clamp)
+    expect(v.scaleForTest()).toBeCloseTo(2.0, 6);
     // slide 3 stays the top slide; new offset = 3 * (240 + 10) = 750
     expect(v.topVisibleSlide).toBe(3);
     expect(Math.abs(scrollHost.scrollTop - 750)).toBeLessThan(2);
@@ -742,7 +756,7 @@ describe('PptxScrollViewer — zoom (T4)', () => {
     scrollHost.scrollTop = 450;
     scrollHost.dispatch('scroll');
     expect(v.topVisibleSlide).toBe(3);
-    v.setScale(v.scaleForTest() * 2); // 0.2 → 0.4; heights' = 240
+    v.setScale(v.scaleForTest() * 2); // 1.0 → 2.0; heights' = 240
     // newScrollTop = offset'[3] + 0.5 * 240 = 750 + 120 = 870
     expect(Math.abs(scrollHost.scrollTop - 870)).toBeLessThan(2);
     // Slide 3 is still under the viewport top: offset'[3]=750 <= 870 < 1000.
@@ -750,19 +764,20 @@ describe('PptxScrollViewer — zoom (T4)', () => {
     v.destroy();
   });
 
-  it('clamps setScale to the absolute [zoomMin, zoomMax] px-per-EMU bounds', () => {
-    const { v } = setup();
+  it('clamps setScale to the absolute [zoomMin, zoomMax] dimensionless bounds', () => {
+    // Explicit bounds so the clamp is unambiguous (base fit is 1.0, inside them).
+    const { v } = setup(20, { zoomMin: 0.5, zoomMax: 3 });
     v.setScale(100); // above zoomMax 3 (absolute, NOT a multiple of base)
     expect(v.scaleForTest()).toBeCloseTo(3, 6);
-    v.setScale(0.001); // below zoomMin 0.05
-    expect(v.scaleForTest()).toBeCloseTo(0.05, 6);
+    v.setScale(0.001); // below zoomMin 0.5
+    expect(v.scaleForTest()).toBeCloseTo(0.5, 6);
     v.destroy();
   });
 
   it('setScale defaults clamp to [0.1, 4] when zoomMin/zoomMax are unset', () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(5, 1000, 600);
+    const engine = new FakePptxEngine(5, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
@@ -775,6 +790,59 @@ describe('PptxScrollViewer — zoom (T4)', () => {
     expect(v.scaleForTest()).toBeCloseTo(4, 5); // default zoomMax
     v.setScale(0.0001);
     expect(v.scaleForTest()).toBeCloseTo(0.1, 5); // default zoomMin
+    v.destroy();
+  });
+
+  // ⚠ MANDATORY real-magnitude regression (WS4b review finding A). Before the
+  // dimensionless-scale fix, `_scale` was px-per-EMU (~6.6e-5 for a real 12.192M-EMU
+  // deck), which the DEFAULT [0.1, 4] clamp then inflated by ~1000× on the first
+  // Ctrl+wheel or resize (spacer 6,274px → 6,172,330px). With the dimensionless
+  // scale, a real 16:9 deck's base fit lands INSIDE the default bounds and a wheel
+  // tick multiplies it by ~e, never explodes.
+  it('real 16:9 deck: base fit is inside [0.1, 4] (NOT clamped) and one wheel tick multiplies the spacer by ~e, not ~1000×', () => {
+    installDom();
+    // A real PowerPoint 16:9 deck: 13.333in × 7.5in = 12,192,000 × 6,858,000 EMU.
+    // Natural width px = 12,192,000 / 9525 = 1280. Container ~1200px.
+    const container = makeContainer(1200, 800);
+    const engine = new FakePptxEngine(10, 12192000, 6858000);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 16,
+      // No zoomMin/zoomMax ⇒ REAL defaults [0.1, 4].
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    const spacer = scrollHost.children[0] as FakeEl;
+    scrollHost.clientHeight = 800;
+    scrollHost.clientWidth = 1200;
+    v.relayout();
+
+    // base = 1200 / 1280 = 0.9375 — INSIDE [0.1, 4], so relayout did NOT clamp.
+    const base = v.scaleForTest();
+    expect(base).toBeCloseTo(0.9375, 6);
+    expect(base).toBeGreaterThan(0.1);
+    expect(base).toBeLessThan(4);
+    const spacerBase = parseFloat(spacer.style.height);
+    expect(spacerBase).toBeGreaterThan(0);
+
+    // One Ctrl+wheel tick up (deltaY −100): zoomStepScale multiplies by exp(1) ≈
+    // 2.71828, so 0.9375 × e ≈ 2.548 — still inside [0.1, 4], NOT clamped to 4.
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: true, metaKey: false, preventDefault() {} });
+    const zoomed = v.scaleForTest();
+    expect(zoomed).toBeCloseTo(0.9375 * Math.E, 4); // ≈ 2.548, not the clamped 4
+    expect(zoomed).toBeLessThan(4);
+
+    // The spacer grew by the scale ratio (≈ e), NOT by ~1000× (the old px-per-EMU
+    // clamp explosion). Slide height px ∝ _scale, so the spacer's slide-height
+    // portion scales by (zoomed / base); with the fixed gap term the total ratio is
+    // very close to e. Bound it well below the old 1000× blowup.
+    const spacerZoomed = parseFloat(spacer.style.height);
+    const ratio = spacerZoomed / spacerBase;
+    expect(ratio).toBeGreaterThan(2.5); // grew ~e×
+    expect(ratio).toBeLessThan(3); // and NOT ~1000× (the pre-fix explosion)
+
+    // setScale(999) still clamps hard to the default zoomMax 4.
+    v.setScale(999);
+    expect(v.scaleForTest()).toBeCloseTo(4, 5);
     v.destroy();
   });
 
@@ -853,7 +921,7 @@ describe('PptxScrollViewer — self-load path (T7 story)', () => {
     // Mock the static loader so load() resolves to a fake engine WITHOUT touching
     // a real Worker / WASM. The viewer must call relayout() after assignment so a
     // self-loaded (non-injected) viewer is not left blank (I-2).
-    const engine = new FakePptxEngine(10, 1000, 600);
+    const engine = new FakePptxEngine(10, SLIDE_W_EMU, SLIDE_H_EMU);
     const loadSpy = vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { gap: 10 });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -900,7 +968,7 @@ describe('PptxScrollViewer — text selection (T5)', () => {
   it('main mode: builds a shape div with a nested run span for each visible slot', async () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(3, 1000, 600);
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
     engine.feedTextRuns = [RUN];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
@@ -932,7 +1000,7 @@ describe('PptxScrollViewer — text selection (T5)', () => {
   it('main mode: a rotated shape gets a CSS rotate() on its shape div', async () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(1, 1000, 600);
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
     // Rotated shape frame: buildPptxTextLayer applies transform:rotate(totalRot).
     engine.feedTextRuns = [{ ...RUN, rotation: 30 }];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
@@ -955,10 +1023,41 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     v.destroy();
   });
 
-  it('main mode: sizes the overlay to the slot canvas size (number args)', async () => {
-    installDom();
+  it('main mode: sizes the overlay to the slot CSS box (literal px, dpr 1)', async () => {
+    installDom(); // window.devicePixelRatio = 1
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(1, 1000, 600);
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
+    engine.feedTextRuns = [RUN];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    const wrapper = findSlotWrapper(scrollHost);
+    const textLayer = findTextLayer(wrapper);
+    // Finding B: the overlay is sized to the CSS box (round(widthPx)/round(
+    // slideHeightPx)), NOT the canvas backing store. At base scale 1.0 the slide is
+    // 200px wide, 120px tall — assert those LITERAL numbers, not a fallback echo.
+    expect(textLayer.style.width).toBe('200px');
+    expect(textLayer.style.height).toBe('120px');
+    v.destroy();
+  });
+
+  it('main mode (dpr 2): overlay is the CSS box, NOT the 2× backing store', async () => {
+    // Finding B regression: on retina (dpr 2) the real renderer sets canvas.width =
+    // cssWidth × 2, so a slot canvas is 400×240 for a 200×120 CSS box. The overlay
+    // must stay 200×120 (the CSS box); copying canvas.width would size it 2× and
+    // overflow the wrapper (inflating the scroll area). The fake renderSlide mirrors
+    // the real backing-store sizing when dpr is passed.
+    installDom();
+    vi.stubGlobal('window', { devicePixelRatio: 2 });
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
     engine.feedTextRuns = [RUN];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
@@ -973,20 +1072,19 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     const wrapper = findSlotWrapper(scrollHost);
     const canvas = wrapper.children.find((c) => c.tag === 'canvas') as FakeEl;
     const textLayer = findTextLayer(wrapper);
-    // buildPptxTextLayer takes NUMBERS and writes `${n}px`. The viewer passes
-    // canvas.width || round(widthPx) and canvas.height || round(slideHeightPx).
-    // base scale = 200/1000 = 0.2 ⇒ widthPx 200, slideHeightPx 120.
-    const expectW = canvas.width || 200;
-    const expectH = canvas.height || 120;
-    expect(textLayer.style.width).toBe(`${expectW}px`);
-    expect(textLayer.style.height).toBe(`${expectH}px`);
+    // The canvas backing store IS 2× (dpr 2): 400×240.
+    expect(canvas.width).toBe(400);
+    expect(canvas.height).toBe(240);
+    // …but the overlay is the CSS box, 200×120 — half the backing store.
+    expect(textLayer.style.width).toBe('200px');
+    expect(textLayer.style.height).toBe('120px');
     v.destroy();
   });
 
   it('main mode: recycling a slot clears its overlay so the free pool holds no stale spans', async () => {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(50, 1000, 600);
+    const engine = new FakePptxEngine(50, SLIDE_W_EMU, SLIDE_H_EMU);
     engine.feedTextRuns = [RUN];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
@@ -1015,7 +1113,7 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     installDom();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(3, 1000, 600, 'worker');
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU, 'worker');
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       enableTextSelection: true,
@@ -1045,14 +1143,14 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     const container = makeContainer(200, 400);
     // Deferred main mode: the test resolves renderSlide manually so setScale can
     // move the epoch WHILE slide 0's first render is in flight.
-    const engine = new FakePptxEngine(20, 1000, 600, 'main', true);
+    const engine = new FakePptxEngine(20, SLIDE_W_EMU, SLIDE_H_EMU, 'main', true);
     engine.feedTextRuns = [RUN];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       enableTextSelection: true,
       gap: 10,
-      zoomMin: 0.05,
-      zoomMax: 4,
+      // REAL defaults [0.1, 4]: base fit is 1.0, and setScale(×2)=2.0 is inside them
+      // (the old `zoomMin: 0.05` dodged the px-per-EMU unit bug — WS4b-2).
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -1079,17 +1177,18 @@ describe('PptxScrollViewer — text selection (T5)', () => {
 });
 
 describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
-  // container fit width 200, slide 1000×600 EMU → base scale = 200/1000 = 0.2.
-  // slide height px = 600 * 0.2 = 120. gap 10 ⇒ stride 130.
-  const BASE = 200 / 1000; // 0.2
-  const SLIDE_H = 600 * BASE; // 120
+  // container fit width 200, natural slide width 200px → DIMENSIONLESS base scale
+  // 200/200 = 1.0. slide height px = (SLIDE_H_EMU / 9525) * 1.0 = 120. gap 10 ⇒
+  // stride 130. (Only the base VALUE moved 0.2 → 1.0; the px geometry is identical.)
+  const BASE = 1.0;
+  const SLIDE_H = SLIDE_H_EMU / 9525; // 120 (natural height px at base 1.0)
   const GAP = 10;
   const STRIDE = SLIDE_H + GAP; // 130 — the top-to-top distance between slides
 
   function setup(slideCount = 20, opts = {}) {
     installDom();
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(slideCount, 1000, 600);
+    const engine = new FakePptxEngine(slideCount, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: GAP,
@@ -1160,9 +1259,9 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
   });
 
   it('ResizeObserver re-fit preserves the zoom multiplier', () => {
-    // zoomMax headroom: base 0.2, 2× zoom → 0.4; after the width doubles the new
-    // base is 0.4 so the preserved scale is 0.8. zoomMin/zoomMax are ABSOLUTE
-    // px-per-EMU bounds (design §8.2), so a low zoomMax would legitimately CLAMP
+    // zoomMax headroom: base 1.0, 2× zoom → 2.0; after the width doubles the new
+    // base is 2.0 so the preserved scale is 4.0. zoomMin/zoomMax are ABSOLUTE
+    // dimensionless bounds (design §8.2), so a low zoomMax would legitimately CLAMP
     // the re-fit and break preservation. Give the multiplier room to survive.
     const { v, container } = setup(20, { zoomMax: 10 });
     v.setScale(v.baseScaleForTest() * 2); // 2× zoom
@@ -1232,11 +1331,11 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     // F1 clamped-path variant: pin zoomMax to the current base so a width grow's
     // re-fit (newBase × mult) clamps back to the SAME scale, making setScale a no-op
     // (which skips its own force-re-render mount). The post-setScale `_mountVisible`
-    // must still mount the rows the taller viewport revealed. base = 0.2, no user
-    // zoom ⇒ mult 1; after width→400 newBase 0.4 clamps to zoomMax 0.2 (== _scale).
+    // must still mount the rows the taller viewport revealed. base = 1.0, no user
+    // zoom ⇒ mult 1; after width→400 newBase 2.0 clamps to zoomMax 1.0 (== _scale).
     const changes: number[] = [];
     const { v, scrollHost, container } = setup(20, {
-      zoomMax: BASE, // 0.2 — clamps the re-fit back to the current scale
+      zoomMax: BASE, // 1.0 — clamps the re-fit back to the current scale
       onVisibleSlideChange: (i: number) => changes.push(i),
     });
     expect(v.scaleForTest()).toBe(BASE);
@@ -1267,7 +1366,7 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
   it('zero-width container defers, then lays out on first non-zero resize', () => {
     installDom();
     const container = makeContainer(0, 0); // unlaid-out
-    const engine = new FakePptxEngine(5, 1000, 600);
+    const engine = new FakePptxEngine(5, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     expect(v.mountedSlideIndicesForTest().length).toBe(0); // deferred
@@ -1282,7 +1381,7 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
   it('empty deck: slideCount 0 ⇒ spacer 0, no slots, scrollToSlide no-op', () => {
     installDom();
     const container = makeContainer(300, 400);
-    const engine = new FakePptxEngine(0, 1000, 600);
+    const engine = new FakePptxEngine(0, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
     v.relayout();
     const spacer = (container.children[0] as FakeEl).children[0].children[0] as FakeEl;
@@ -1295,7 +1394,7 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
   it('empty deck: resize does not crash and fires no callback', () => {
     installDom();
     const container = makeContainer(0, 0);
-    const engine = new FakePptxEngine(0, 1000, 600);
+    const engine = new FakePptxEngine(0, SLIDE_W_EMU, SLIDE_H_EMU);
     const changes: number[] = [];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
@@ -1324,7 +1423,7 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     }
     vi.stubGlobal('ResizeObserver', SpyRO);
     const container = makeContainer(200, 400);
-    const engine = new FakePptxEngine(3, 1000, 600);
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
     v.destroy();
     expect(disconnected).toBe(1);

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -204,7 +204,9 @@ describe('PptxScrollViewer — layout + virtualization (T2)', () => {
     // (SLIDE_H_EMU / 9525) * 1.0 = 120.
     const slideH = SLIDE_H_EMU / 9525; // 120
     const n = 3;
-    const expected = n * slideH + (n - 1) * 10;
+    // New default: paddingTop/paddingBottom each default to `gap` (10), so the
+    // spacer is padTop + Σheights + (n-1)*gap + padBottom.
+    const expected = 10 + n * slideH + (n - 1) * 10 + 10;
     expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
     v.destroy();
     void dom;
@@ -467,6 +469,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
+      paddingTop: 0, // flush top so slide 0's slot sits at top:0px (asserted below)
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -590,6 +593,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
+      paddingTop: 0, // flush top so slide 0's slot sits at top:0px (asserted below)
       overscan: 1,
       // REAL defaults [0.1, 4]: base fit is 1.0, and setScale(×2)=2.0 is inside them
       // (the old `zoomMin: 0.05, zoomMax: 3` dodged the px-per-EMU unit bug — WS4b-2).
@@ -653,6 +657,7 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
+      paddingTop: 0, // flush top so slide 0's slot sits at top:0px (asserted below)
       overscan: 1,
       // REAL defaults [0.1, 4]: base fit is 1.0, and setScale(×2)=2.0 is inside them
       // (the old `zoomMin: 0.05, zoomMax: 3` dodged the px-per-EMU unit bug — WS4b-2).
@@ -716,6 +721,11 @@ describe('PptxScrollViewer — zoom (T4)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
+      // Flush top/bottom (paddingTop/Bottom default to `gap`; the T4 offset
+      // arithmetic below is written for offset[0]===0). This exercises the
+      // "explicit 0 ⇒ old flush behavior reachable" contract.
+      paddingTop: 0,
+      paddingBottom: 0,
       overscan: 1,
       ...opts,
     });
@@ -1192,6 +1202,11 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: GAP,
+      // Flush top/bottom: the T6 STRIDE/offset arithmetic assumes offset[0]===0.
+      // paddingTop/Bottom default to `gap`; pinning them to 0 keeps the pre-padding
+      // geometry (and exercises the "explicit 0 ⇒ old flush behavior" contract).
+      paddingTop: 0,
+      paddingBottom: 0,
       ...opts,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -1427,6 +1442,101 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
     v.destroy();
     expect(disconnected).toBe(1);
+  });
+});
+
+describe('PptxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
+  const SLIDE_H = SLIDE_H_EMU / 9525; // 120 (natural height px at base 1.0)
+  const GAP = 10;
+  const STRIDE = SLIDE_H + GAP; // 130
+
+  function setup(opts = {}, slideCount = 20) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(slideCount, SLIDE_W_EMU, SLIDE_H_EMU);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: GAP,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, container, engine };
+  }
+
+  /** The wrapper currently mounted for slide `i` (identified by its top offset). */
+  function slotTopFor(scrollHost: FakeEl, i: number, stride: number, padTop: number): FakeEl | undefined {
+    const want = `${padTop + i * stride}px`;
+    return scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === want,
+    ) as FakeEl | undefined;
+  }
+
+  it('explicit paddingTop mounts the first slot at top = paddingTop px', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24 });
+    expect(v.mountedSlideIndicesForTest()).toContain(0);
+    expect(slotTopFor(scrollHost, 0, STRIDE, 24)).toBeDefined();
+    v.destroy();
+  });
+
+  it('spacer height = padTop + Σheights + (n-1)*gap + padBottom', () => {
+    const { scrollHost } = setup({ paddingTop: 24, paddingBottom: 40 });
+    const spacer = scrollHost.children[0] as FakeEl;
+    const expected = 24 + 20 * SLIDE_H + 19 * GAP + 40;
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+  });
+
+  it('DEFAULT paddingTop/paddingBottom = gap (uniform rhythm: no options ⇒ first slot at gap px)', () => {
+    // No paddingTop/paddingBottom → each defaults to `gap` (10). Slide 0 sits at
+    // top:10px, NOT flush 0 (this is the sanctioned pre-release default change).
+    const { v, scrollHost } = setup();
+    expect(v.mountedSlideIndicesForTest()).toContain(0);
+    expect(slotTopFor(scrollHost, 0, STRIDE, GAP)).toBeDefined();
+    const spacer = scrollHost.children[0] as FakeEl;
+    const expected = GAP + 20 * SLIDE_H + 19 * GAP + GAP;
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+    v.destroy();
+  });
+
+  it('explicit 0 ⇒ flush (old behavior reachable): first slot at top 0, spacer has no pad', () => {
+    const { v, scrollHost } = setup({ paddingTop: 0, paddingBottom: 0 });
+    expect(slotTopFor(scrollHost, 0, STRIDE, 0)).toBeDefined();
+    const spacer = scrollHost.children[0] as FakeEl;
+    const expected = 20 * SLIDE_H + 19 * GAP; // no pad
+    expect(parseFloat(spacer.style.height)).toBeCloseTo(expected, 3);
+    v.destroy();
+  });
+
+  it('scrollToSlide(0) lands on offsets[0] (= paddingTop, not 0)', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24 });
+    scrollHost.scrollTop = 3 * STRIDE;
+    scrollHost.dispatch('scroll');
+    v.scrollToSlide(0);
+    expect(scrollHost.scrollTop).toBe(24);
+    v.destroy();
+  });
+
+  it('scrollToSlide(k) lands on paddingTop + k*stride', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24 });
+    v.scrollToSlide(3);
+    expect(Math.abs(scrollHost.scrollTop - (24 + 3 * STRIDE))).toBeLessThan(2);
+    v.destroy();
+  });
+
+  it('re-anchor keeps the slide under the viewport top fixed WITH padding intact after setScale', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24, zoomMin: 0.5, zoomMax: 3 });
+    // Scroll so slide 3's top sits at the viewport top: offset[3] = 24 + 3*130 = 414.
+    scrollHost.scrollTop = 24 + 3 * STRIDE;
+    scrollHost.dispatch('scroll');
+    expect(v.topVisibleSlide).toBe(3);
+    v.setScale(v.scaleForTest() * 2); // 1.0 → 2.0; SLIDE_H' = 240, STRIDE' = 250
+    expect(v.scaleForTest()).toBeCloseTo(2, 5);
+    // Slide 3 stays the top slide; padding is intact so offset'[3] = 24 + 3*250 = 774.
+    expect(v.topVisibleSlide).toBe(3);
+    expect(Math.abs(scrollHost.scrollTop - (24 + 3 * 250))).toBeLessThan(2);
+    v.destroy();
   });
 });
 

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -218,3 +218,437 @@ describe('PptxScrollViewer — layout + virtualization (T2)', () => {
     expect(Math.max(...mountedSlides) - Math.min(...mountedSlides)).toBeLessThanOrEqual(6);
   });
 });
+
+describe('PptxScrollViewer — rendering (T3)', () => {
+  it("main mode: calls renderSlide once per mounted slot with that slide's px width", () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(10, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // Every mounted slide got exactly one renderSlide call, no more no less.
+    const mounted = v.mountedSlideIndicesForTest().sort((a, b) => a - b);
+    const rendered = engine.renderCalls.map((c) => c.slide).sort((a, b) => a - b);
+    expect(rendered).toEqual(mounted);
+    // Each renderSlide call carried the per-call px width. pptx slides are uniform,
+    // so every width equals the same fit-width (base scale = 200/1000 = 0.2 px/EMU;
+    // slide width px = 1000 * 0.2 = 200), but the per-call width contract still
+    // passes a width per slide (mirrors docx's per-page width assertion, §7).
+    const widths = engine.renderSlideWidths();
+    expect(widths.length).toBe(mounted.length);
+    for (const w of widths) expect(w).toBeCloseTo(200, 3);
+    v.destroy();
+  });
+
+  it('main mode: passes the uniform px width per slide (per-call width contract, §7)', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // pptx slide size is UNIFORM deck-wide, so unlike docx (mixed page sizes) every
+    // slide renders at the SAME px width. The per-call width contract still holds:
+    // each mounted slide receives its own width argument, equal to the uniform px.
+    const engine = new FakePptxEngine(2, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // Both slides mount (slide 0 height px = 600*0.2 = 120; slide 1 top 130 within
+    // the 400px viewport), so both get exactly one render.
+    const mounted = v.mountedSlideIndicesForTest().sort((a, b) => a - b);
+    expect(mounted).toEqual([0, 1]);
+    // Per-slide px widths in call order: uniform 200 each.
+    const widths = engine.renderCalls
+      .slice()
+      .sort((a, b) => a.slide - b.slide)
+      .map((c) => c.width ?? NaN);
+    expect(widths[0]).toBeCloseTo(200, 3);
+    expect(widths[1]).toBeCloseTo(200, 3);
+    v.destroy();
+  });
+
+  it('does not re-render a mounted slot for the same slide on a no-op scroll', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(10, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const before = engine.renderCalls.length;
+    scrollHost.scrollTop = 0; // unchanged window
+    scrollHost.dispatch('scroll');
+    expect(engine.renderCalls.length).toBe(before); // no duplicate renders
+    v.destroy();
+  });
+
+  it('worker mode: never calls renderSlide — routes every slot through renderSlideToBitmap', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // mode:'worker' — the real PptxPresentation.renderSlide THROWS synchronously in
+    // worker mode; a viewer that mis-routed would blow up (and renderCalls would
+    // record the attempt). The direct _mode routing must never touch renderSlide.
+    const engine = new FakePptxEngine(10, 1000, 600, 'worker');
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engine.renderCalls).toHaveLength(0); // renderSlide never touched
+    // Every mounted slide dispatched exactly one bitmap render.
+    const mounted = v.mountedSlideIndicesForTest().sort((a, b) => a - b);
+    const bitmapSlides = [...new Set(engine.bitmapCalls.map((c) => c.slide))].sort((a, b) => a - b);
+    expect(bitmapSlides).toEqual(mounted);
+    v.destroy();
+  });
+
+  it('worker mode: paints a resolved bitmap into the slot canvas (transfer)', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(10, 1000, 600, 'worker');
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    // A bitmap was produced and transferred into the mounted slot's canvas.
+    expect(engine.createdBitmaps.length).toBeGreaterThan(0);
+    const slotWrapper = scrollHost.children.find((c) => c.children.some((k) => k.tag === 'canvas')) as FakeEl;
+    const canvas = slotWrapper.children.find((k) => k.tag === 'canvas') as FakeEl;
+    // The bitmaprenderer ctx received the bitmap (fake records lastBitmap).
+    expect(canvas._bitmapCtx?.lastBitmap).toBe(engine.createdBitmaps[0]);
+    v.destroy();
+  });
+
+  it('worker mode: closes the ImageBitmap on recycle (deferred — render in flight when the slot recycles)', async () => {
+    // Bitmap-close observability path: the primary path (deterministic slot.bitmap
+    // hold under synchronous resolve) does NOT hold — in non-deferred mode
+    // transferFromImageBitmap consumes the bitmap and nulls slot.bitmap
+    // synchronously BEFORE any scroll-away, so a later recycle has nothing to
+    // close. We use the DOCUMENTED FALLBACK: a deferred fake so the render is
+    // genuinely in flight when the slot recycles, and the on-resolution
+    // stale-check closes the orphan (design §11).
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const firstBatch = engine.bitmapCalls.length;
+    expect(firstBatch).toBeGreaterThan(0);
+    // Scroll far away so the first slides' slots recycle while their renders are
+    // still in flight (deferred → not yet resolved).
+    scrollHost.scrollTop = 6000;
+    scrollHost.dispatch('scroll');
+    // Now resolve the early (now-stale) renders — the viewer must close them.
+    for (const call of engine.bitmapCalls.slice(0, firstBatch)) call.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engine.createdBitmaps.some((b) => b.close.mock.calls.length > 0)).toBe(true);
+    v.destroy();
+  });
+
+  it('worker mode: drops a stale in-flight render — no paint + bitmap closed when the slot moved on', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Deferred: renderSlideToBitmap resolves only when the test calls resolve(),
+    // so we can scroll a slot's slide out of the window BEFORE the bitmap arrives.
+    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    // Slide 0's bitmap is dispatched but NOT yet resolved.
+    const slide0 = engine.bitmapCalls.find((c) => c.slide === 0);
+    expect(slide0).toBeDefined();
+    // Scroll far away so slide 0's slot recycles while its render is in flight.
+    scrollHost.scrollTop = 6000;
+    scrollHost.dispatch('scroll');
+    expect(v.mountedSlideIndicesForTest()).not.toContain(0);
+    // Now the stale render for slide 0 resolves — the viewer must NOT paint it and
+    // must close the orphaned bitmap.
+    const bmp0 = engine.createdBitmaps[engine.bitmapCalls.indexOf(slide0!)];
+    slide0!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bmp0.close.mock.calls.length).toBeGreaterThan(0); // orphan closed
+    v.destroy();
+  });
+
+  it('worker mode: a slide that recycles then re-mounts while in flight still gets a fresh render', async () => {
+    // Coalescing keys on slide index; a naive Set<number> would swallow the
+    // re-mounted slot's render (the stale resolve clears in-flight AFTER the
+    // remount coalesced away → the new slot never paints). The viewer must
+    // re-dispatch the live slot's render so the slide never stays blank.
+    installDom();
+    const container = makeContainer(200, 400);
+    // Tall slides (1000×2000 EMU ⇒ 200×400px at base scale 0.2, stride 410) so the
+    // visible window is exactly one slide + overscan = [0,1], mirroring the docx
+    // recycle/re-mount pool dynamics: the re-mounted slide-0 slot is a DIFFERENT
+    // pooled object than the in-flight one, so `live !== slot` triggers the
+    // re-dispatch. (A short-slide window packs several slots, whose LIFO reuse can
+    // hand slide 0 back its own in-flight slot — an epoch-only case not under test.)
+    const engine = new FakePptxEngine(50, 1000, 2000, 'worker', true);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const slide0Initial = engine.bitmapCalls.find((c) => c.slide === 0);
+    expect(slide0Initial).toBeDefined();
+    const dispatchesForSlide0 = () => engine.bitmapCalls.filter((c) => c.slide === 0).length;
+    expect(dispatchesForSlide0()).toBe(1);
+    // Scroll away (slide 0 recycles, render still in flight) then back to the top
+    // (slide 0 re-mounts on a fresh slot) — all while the initial render is deferred.
+    scrollHost.scrollTop = 12000;
+    scrollHost.dispatch('scroll');
+    expect(v.mountedSlideIndicesForTest()).not.toContain(0);
+    scrollHost.scrollTop = 0;
+    scrollHost.dispatch('scroll');
+    expect(v.mountedSlideIndicesForTest()).toContain(0);
+    // Coalescing pin: slide 0's render is STILL in flight (initial deferred call not
+    // yet resolved), so the re-mount must NOT dispatch a second render for slide 0
+    // — the in-flight guard swallows it. Exactly one dispatch so far.
+    expect(dispatchesForSlide0()).toBe(1);
+    // The initial (now stale) render resolves — the orphan is dropped and the
+    // re-mounted slot's render is (re-)dispatched.
+    slide0Initial!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dispatchesForSlide0()).toBeGreaterThanOrEqual(2); // fresh render issued
+    // Resolve the fresh render and confirm it paints into the live slot.
+    for (const c of engine.bitmapCalls.filter((c) => c.slide === 0)) c.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(slot0).toBeDefined();
+    const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted, not blank
+    v.destroy();
+  });
+
+  it('worker mode: a PLAIN render rejection (slot still live, epoch unchanged) does NOT re-dispatch — no retry storm', async () => {
+    // B1 regression: the finally re-dispatch must gate on STALENESS, not merely
+    // `!painted`. When `renderSlideToBitmap` rejects while the slot is still live
+    // and the epoch is unchanged, `painted` is false and `live === slot`, but
+    // NEITHER staleness test fires, so we must NOT re-dispatch. A `!painted`-only
+    // gate would loop reject → re-dispatch → reject … unbounded (empirically 1→2
+    // →3→4 with onError every round). The onError contract leaves the slide blank.
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const onError = vi.fn();
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      overscan: 1,
+      onError,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+
+    const slide0 = engine.bitmapCalls.find((c) => c.slide === 0);
+    expect(slide0).toBeDefined();
+    expect(v.mountedSlideIndicesForTest()).toContain(0); // slot still live
+    const dispatchesForSlide0 = () => engine.bitmapCalls.filter((c) => c.slide === 0).length;
+    expect(dispatchesForSlide0()).toBe(1);
+
+    // Reject the render with the slot STILL LIVE and no scale change (epoch fixed).
+    slide0!.reject(new Error('worker render failed'));
+    // Flush microtasks generously — a retry storm would keep queuing dispatches.
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+
+    // Dispatch count for slide 0 stayed at 1 — the storm is gone.
+    expect(dispatchesForSlide0()).toBe(1);
+    // onError fired exactly once (the single failure), never again.
+    expect(onError).toHaveBeenCalledTimes(1);
+    // Still no further dispatches after more microtask flushing.
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+    expect(dispatchesForSlide0()).toBe(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+
+  it('worker mode: destroy() mid-flight closes the resolving bitmap and does not fire onError post-destroy', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Deferred so a render is genuinely in flight when we destroy the viewer.
+    const engine = new FakePptxEngine(50, 1000, 600, 'worker', true);
+    const onError = vi.fn();
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      onError,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    const slide0 = engine.bitmapCalls.find((c) => c.slide === 0);
+    expect(slide0).toBeDefined();
+    // Tear down while slide 0's render is still in flight. destroy() recycles the
+    // slot (no bitmap held yet — none received), so the on-resolution stale-check
+    // must close the orphan; the identity guard fails (slot no longer live).
+    v.destroy();
+    const bmp0 = engine.createdBitmaps[engine.bitmapCalls.indexOf(slide0!)];
+    slide0!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bmp0.close.mock.calls.length).toBeGreaterThan(0); // orphan closed, no leak
+    expect(onError).not.toHaveBeenCalled(); // no error surfaced after teardown
+  });
+
+  // ⚠ MANDATORY render-epoch test (T3 review finding I-3). Worker path, deferred:
+  // dispatch at scale A, setScale(B) mid-flight, resolve — the old-scale bitmap is
+  // closed, NOT painted, and a fresh dispatch at scale B repaints the slot.
+  it('render epoch: a bitmap dispatched at the old scale is dropped (closed, not painted) after setScale, and re-dispatched at the new scale', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(20, 1000, 600, 'worker', true);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      overscan: 1,
+      zoomMin: 0.05,
+      zoomMax: 3,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+
+    // Slide 0's bitmap is dispatched at the base (old) scale but NOT yet resolved.
+    const slide0Old = engine.bitmapCalls.find((c) => c.slide === 0);
+    expect(slide0Old).toBeDefined();
+    const oldDispatchCount = engine.bitmapCalls.filter((c) => c.slide === 0).length;
+    expect(oldDispatchCount).toBe(1);
+    const oldWidth = slide0Old!.width;
+
+    // Zoom mid-flight: bumps the render epoch and re-mounts. Slide 0's re-mount is
+    // coalesced away by the in-flight guard (same index still in flight).
+    v.setScale(v.scaleForTest() * 2);
+    expect(v.mountedSlideIndicesForTest()).toContain(0); // slide 0 still visible at top
+    expect(engine.bitmapCalls.filter((c) => c.slide === 0).length).toBe(1); // no double-dispatch yet
+
+    // The OLD-scale render resolves. Epoch moved ⇒ STALE: close, do not paint,
+    // then re-dispatch slide 0 at the NEW scale.
+    const bmpOld = engine.createdBitmaps[engine.bitmapCalls.indexOf(slide0Old!)];
+    slide0Old!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bmpOld.close.mock.calls.length).toBeGreaterThan(0); // old bitmap closed
+    // A fresh dispatch for slide 0 was issued at the new scale.
+    const slide0Calls = engine.bitmapCalls.filter((c) => c.slide === 0);
+    expect(slide0Calls.length).toBeGreaterThanOrEqual(2);
+    const freshCall = slide0Calls[slide0Calls.length - 1];
+    // The fresh dispatch's width reflects the NEW scale (double the old width).
+    expect(freshCall.width).toBeGreaterThan(oldWidth ?? 0);
+
+    // The stale old bitmap was NOT transferred; only the fresh one paints.
+    freshCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(slot0).toBeDefined();
+    const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(canvas0._bitmapCtx?.lastBitmap).not.toBe(bmpOld); // never painted the stale bitmap
+    expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted the fresh one
+    v.destroy();
+  });
+
+  // B1: epoch-then-reject must stay BOUNDED. setScale bumps the epoch mid-flight,
+  // so the OLD dispatch is stale on resolution; whether it resolves or REJECTS,
+  // the finally must issue exactly ONE fresh dispatch at the new epoch. The fresh
+  // dispatch captures the new epoch, so if IT later rejects (same epoch, still
+  // live) nothing re-dispatches — the retry is bounded to a single fresh attempt.
+  it('render epoch: rejecting the OLD-scale dispatch after setScale still yields exactly ONE fresh dispatch at the new scale (bounded)', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(20, 1000, 600, 'worker', true);
+    const onError = vi.fn();
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      overscan: 1,
+      zoomMin: 0.05,
+      zoomMax: 3,
+      onError,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+
+    const slide0Old = engine.bitmapCalls.find((c) => c.slide === 0);
+    expect(slide0Old).toBeDefined();
+    const dispatchesForSlide0 = () => engine.bitmapCalls.filter((c) => c.slide === 0).length;
+    expect(dispatchesForSlide0()).toBe(1);
+    const oldWidth = slide0Old!.width;
+
+    // Zoom mid-flight: bumps the epoch. Slide 0's re-mount is coalesced away.
+    v.setScale(v.scaleForTest() * 2);
+    expect(v.mountedSlideIndicesForTest()).toContain(0);
+    expect(dispatchesForSlide0()).toBe(1);
+
+    // REJECT the old-scale dispatch. Epoch moved ⇒ stale ⇒ re-dispatch (not a plain
+    // failure retry). Exactly ONE fresh dispatch at the new epoch.
+    slide0Old!.reject(new Error('old-scale render failed'));
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+    const afterReject = engine.bitmapCalls.filter((c) => c.slide === 0);
+    expect(afterReject.length).toBe(2); // one fresh dispatch, no storm
+    const freshCall = afterReject[afterReject.length - 1];
+    expect(freshCall.width).toBeGreaterThan(oldWidth ?? 0); // at the NEW (larger) scale
+
+    // The fresh dispatch then SUCCEEDS and paints — the slide is not left blank.
+    freshCall.resolve();
+    for (let k = 0; k < 8; k++) await Promise.resolve();
+    expect(dispatchesForSlide0()).toBe(2); // still exactly two; success does not re-dispatch
+    const slot0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(slot0).toBeDefined();
+    const canvas0 = slot0!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(canvas0._bitmapCtx?.lastBitmap).toBeTruthy(); // painted the fresh bitmap
+    v.destroy();
+  });
+});

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { PptxScrollViewer } from './scroll-viewer.js';
+import { PptxPresentation } from './presentation.js';
 import { installDom, makeContainer, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+import * as pptxIndex from './index.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -817,6 +819,31 @@ describe('PptxScrollViewer — zoom (T4)', () => {
   });
 });
 
+describe('PptxScrollViewer — self-load path (T7 story)', () => {
+  it('load(url) lays out and mounts the first window (relayout wired into load)', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Mock the static loader so load() resolves to a fake engine WITHOUT touching
+    // a real Worker / WASM. The viewer must call relayout() after assignment so a
+    // self-loaded (non-injected) viewer is not left blank (I-2).
+    const engine = new FakePptxEngine(10, 1000, 600);
+    const loadSpy = vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { gap: 10 });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    await v.load('sample.pptx');
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    // Layout happened: slots mounted and the spacer was sized.
+    expect(v.mountedSlideIndicesForTest().length).toBeGreaterThan(0);
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.height)).toBeGreaterThan(0);
+    // The mounted slides were actually rendered (main mode → renderSlide).
+    expect(engine.renderCalls.length).toBeGreaterThan(0);
+    v.destroy();
+  });
+});
+
 describe('PptxScrollViewer — text selection (T5)', () => {
   // A minimal PptxTextRunInfo: richer than docx's flat run — it carries per-shape
   // frame geometry (shapeX/Y/W/H, rotation) so buildPptxTextLayer can group runs
@@ -1274,5 +1301,11 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
     v.destroy();
     expect(disconnected).toBe(1);
+  });
+});
+
+describe('PptxScrollViewer — barrel export (T7)', () => {
+  it('is exported from the package entry', () => {
+    expect(typeof pptxIndex.PptxScrollViewer).toBe('function');
   });
 });

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -652,3 +652,167 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     v.destroy();
   });
 });
+
+describe('PptxScrollViewer — zoom (T4)', () => {
+  // Uniform 1000×600 EMU slides; `_scale` is px-per-EMU (no PT_TO_PX). Container
+  // 200×400, width:undefined ⇒ base fit maps the slide width (1000 EMU) to 200px:
+  //   base = 200 / 1000 = 0.2 px/EMU
+  //   slide height px = 600 * 0.2 = 120
+  //   offset[i] = i * (120 + gap) = i * 130
+  // Zoom ×2 ⇒ scale 0.4, height 240, stride 250. The two MANDATORY render-epoch
+  // tests (resolve + reject) live in the T3 rendering block above (already covered
+  // by WS4b-1), so they are not repeated here.
+  function setup(slideCount = 20, opts = {}) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(slideCount, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      overscan: 1,
+      // Give the base fit (0.2) headroom: base ×2 = 0.4 stays within these bounds
+      // so the re-anchor tests exercise the zoom path, not the clamp.
+      zoomMin: 0.05,
+      zoomMax: 3,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, engine, container };
+  }
+
+  it('base fit scale maps the slide width to the container width', () => {
+    const { v } = setup();
+    // base = 200 / 1000 = 0.2
+    expect(v.scaleForTest()).toBeCloseTo(0.2, 6);
+    expect(v.baseScaleForTest()).toBeCloseTo(0.2, 6);
+    v.destroy();
+  });
+
+  it('re-anchors so the slide under the viewport top stays fixed across a zoom (intraFrac 0)', () => {
+    const { v, scrollHost } = setup();
+    // slide 3 top offset at base (0.2): 3 * (120 + 10) = 390
+    scrollHost.scrollTop = 390;
+    scrollHost.dispatch('scroll');
+    expect(v.topVisibleSlide).toBe(3);
+    const cur = v.scaleForTest(); // 0.2
+    v.setScale(cur * 2); // 0.4 (within [0.05, 3], no clamp)
+    expect(v.scaleForTest()).toBeCloseTo(0.4, 6);
+    // slide 3 stays the top slide; new offset = 3 * (240 + 10) = 750
+    expect(v.topVisibleSlide).toBe(3);
+    expect(Math.abs(scrollHost.scrollTop - 750)).toBeLessThan(2);
+    v.destroy();
+  });
+
+  it('re-anchors preserving the intra-slide fraction (intraFrac ≠ 0)', () => {
+    const { v, scrollHost } = setup();
+    // Scroll so HALF of slide 3 (60 of its 120px) has passed above the viewport
+    // top: scrollTop = offset[3] + 0.5*120 = 390 + 60 = 450 → intraFrac 0.5.
+    scrollHost.scrollTop = 450;
+    scrollHost.dispatch('scroll');
+    expect(v.topVisibleSlide).toBe(3);
+    v.setScale(v.scaleForTest() * 2); // 0.2 → 0.4; heights' = 240
+    // newScrollTop = offset'[3] + 0.5 * 240 = 750 + 120 = 870
+    expect(Math.abs(scrollHost.scrollTop - 870)).toBeLessThan(2);
+    // Slide 3 is still under the viewport top: offset'[3]=750 <= 870 < 1000.
+    expect(v.topVisibleSlide).toBe(3);
+    v.destroy();
+  });
+
+  it('clamps setScale to the absolute [zoomMin, zoomMax] px-per-EMU bounds', () => {
+    const { v } = setup();
+    v.setScale(100); // above zoomMax 3 (absolute, NOT a multiple of base)
+    expect(v.scaleForTest()).toBeCloseTo(3, 6);
+    v.setScale(0.001); // below zoomMin 0.05
+    expect(v.scaleForTest()).toBeCloseTo(0.05, 6);
+    v.destroy();
+  });
+
+  it('setScale defaults clamp to [0.1, 4] when zoomMin/zoomMax are unset', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(5, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    v.setScale(999);
+    expect(v.scaleForTest()).toBeCloseTo(4, 5); // default zoomMax
+    v.setScale(0.0001);
+    expect(v.scaleForTest()).toBeCloseTo(0.1, 5); // default zoomMin
+    v.destroy();
+  });
+
+  it('Ctrl+wheel zooms in and calls preventDefault; bare wheel does not zoom or preventDefault', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+
+    // Bare wheel: no zoom, native scroll (preventDefault NOT called).
+    const barePrevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: false, metaKey: false, preventDefault: barePrevent });
+    expect(v.scaleForTest()).toBe(before);
+    expect(barePrevent).not.toHaveBeenCalled();
+
+    // Ctrl+wheel (deltaY<0 = zoom in): scale increases, preventDefault called.
+    const ctrlPrevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: true, metaKey: false, preventDefault: ctrlPrevent });
+    expect(v.scaleForTest()).toBeGreaterThan(before);
+    expect(ctrlPrevent).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+
+  it('Cmd(meta)+wheel also zooms', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: false, metaKey: true, preventDefault() {} });
+    expect(v.scaleForTest()).toBeGreaterThan(before);
+    v.destroy();
+  });
+
+  it('positive deltaY (ctrl+wheel down) zooms out', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+    scrollHost.dispatch('wheel', { deltaY: 100, ctrlKey: true, metaKey: false, preventDefault() {} });
+    expect(v.scaleForTest()).toBeLessThan(before);
+    v.destroy();
+  });
+
+  it('enableZoom:false installs no wheel handler — ctrl+wheel is inert', () => {
+    const { v, scrollHost } = setup(20, { enableZoom: false });
+    const before = v.scaleForTest();
+    // No wheel listener was registered at all.
+    expect(scrollHost._listeners.has('wheel')).toBe(false);
+    const prevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: -100, ctrlKey: true, preventDefault: prevent });
+    expect(v.scaleForTest()).toBe(before);
+    expect(prevent).not.toHaveBeenCalled();
+    v.destroy();
+  });
+
+  it('a wheel with deltaY 0 is a no-op even with ctrl held', () => {
+    const { v, scrollHost } = setup();
+    const before = v.scaleForTest();
+    const prevent = vi.fn();
+    scrollHost.dispatch('wheel', { deltaY: 0, ctrlKey: true, preventDefault: prevent });
+    expect(v.scaleForTest()).toBe(before);
+    v.destroy();
+  });
+
+  it('setScale to the SAME scale is a no-op (no re-anchor, no epoch bump churn)', () => {
+    const { v, scrollHost } = setup();
+    scrollHost.scrollTop = 390;
+    scrollHost.dispatch('scroll');
+    const topBefore = scrollHost.scrollTop;
+    const epochBefore = v.renderEpochForTest();
+    v.setScale(v.scaleForTest()); // identical scale
+    expect(scrollHost.scrollTop).toBe(topBefore); // unchanged
+    expect(v.renderEpochForTest()).toBe(epochBefore); // no epoch bump
+    v.destroy();
+  });
+});

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -816,3 +816,210 @@ describe('PptxScrollViewer — zoom (T4)', () => {
     v.destroy();
   });
 });
+
+describe('PptxScrollViewer — text selection (T5)', () => {
+  // A minimal PptxTextRunInfo: richer than docx's flat run — it carries per-shape
+  // frame geometry (shapeX/Y/W/H, rotation) so buildPptxTextLayer can group runs
+  // into a positioned shape <div> and nest the run <span> inside it.
+  const RUN = {
+    text: 'Hi',
+    inShapeX: 1,
+    inShapeY: 2,
+    w: 10,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    shapeX: 0,
+    shapeY: 0,
+    shapeW: 100,
+    shapeH: 40,
+    rotation: 0,
+  };
+
+  function findSlotWrapper(scrollHost: FakeEl): FakeEl {
+    return scrollHost.children.find((c) => c.children.some((k) => k.tag === 'canvas')) as FakeEl;
+  }
+  function findTextLayer(slotWrapper: FakeEl): FakeEl {
+    return slotWrapper.children.find((c) => c.tag === 'div') as FakeEl;
+  }
+
+  it('main mode: builds a shape div with a nested run span for each visible slot', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(3, 1000, 600);
+    engine.feedTextRuns = [RUN];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Every mounted slot got its overlay built from that slide's render.
+    const mounted = v.mountedSlideIndicesForTest();
+    expect(mounted.length).toBeGreaterThan(0);
+    for (const wrapper of scrollHost.children.filter((c) => c.children.some((k) => k.tag === 'canvas'))) {
+      const textLayer = findTextLayer(wrapper);
+      // pptx nests spans INSIDE a per-shape <div> (one level deeper than docx):
+      // textLayer → shape <div> → run <span>.
+      expect(textLayer.children.length).toBe(1);
+      const shapeDiv = textLayer.children[0] as FakeEl;
+      expect(shapeDiv.tag).toBe('div');
+      expect(shapeDiv.children.length).toBe(1);
+      expect(shapeDiv.children[0].tag).toBe('span');
+      expect(shapeDiv.children[0].textContent).toBe('Hi');
+    }
+    v.destroy();
+  });
+
+  it('main mode: a rotated shape gets a CSS rotate() on its shape div', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(1, 1000, 600);
+    // Rotated shape frame: buildPptxTextLayer applies transform:rotate(totalRot).
+    engine.feedTextRuns = [{ ...RUN, rotation: 30 }];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    const wrapper = findSlotWrapper(scrollHost);
+    const textLayer = findTextLayer(wrapper);
+    const shapeDiv = textLayer.children[0] as FakeEl;
+    expect(shapeDiv.tag).toBe('div');
+    expect(shapeDiv.style.transform).toBe('rotate(30deg)');
+    // The run span still nests inside the rotated shape div.
+    expect(shapeDiv.children[0].textContent).toBe('Hi');
+    v.destroy();
+  });
+
+  it('main mode: sizes the overlay to the slot canvas size (number args)', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(1, 1000, 600);
+    engine.feedTextRuns = [RUN];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    const wrapper = findSlotWrapper(scrollHost);
+    const canvas = wrapper.children.find((c) => c.tag === 'canvas') as FakeEl;
+    const textLayer = findTextLayer(wrapper);
+    // buildPptxTextLayer takes NUMBERS and writes `${n}px`. The viewer passes
+    // canvas.width || round(widthPx) and canvas.height || round(slideHeightPx).
+    // base scale = 200/1000 = 0.2 ⇒ widthPx 200, slideHeightPx 120.
+    const expectW = canvas.width || 200;
+    const expectH = canvas.height || 120;
+    expect(textLayer.style.width).toBe(`${expectW}px`);
+    expect(textLayer.style.height).toBe(`${expectH}px`);
+    v.destroy();
+  });
+
+  it('main mode: recycling a slot clears its overlay so the free pool holds no stale spans', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(50, 1000, 600);
+    engine.feedTextRuns = [RUN];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    // The overlay is built in the renderSlide .then() microtask.
+    await Promise.resolve();
+    await Promise.resolve();
+    // A slide-0 slot exists with a built overlay (one shape div).
+    const wrapper = findSlotWrapper(scrollHost);
+    const textLayer = findTextLayer(wrapper);
+    expect(textLayer.children.length).toBe(1);
+    // Scroll far away so slide 0 recycles into the free pool.
+    scrollHost.scrollTop = 8000;
+    scrollHost.dispatch('scroll');
+    // The recycled slot's overlay was cleared (no stale spans linger in the pool).
+    expect(textLayer.children.length).toBe(0);
+    v.destroy();
+  });
+
+  it('worker mode: warns once and builds no overlay spans', async () => {
+    installDom();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(3, 1000, 600, 'worker');
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableTextSelection: true,
+      gap: 10,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Warned exactly once with the same wording as PptxViewer, across every
+    // mounted slot's render.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/text selection is unavailable in mode: 'worker'/);
+    // No renderSlide (worker path only) and no overlay children anywhere.
+    expect(engine.renderCalls.length).toBe(0);
+    for (const wrapper of scrollHost.children.filter((c) => c.children.some((k) => k.tag === 'canvas'))) {
+      const textLayer = wrapper.children.find((c) => c.tag === 'div') as FakeEl;
+      expect(textLayer.children.length).toBe(0);
+    }
+    warn.mockRestore();
+    v.destroy();
+  });
+
+  it('stale main render (epoch moved by setScale mid-flight) does NOT rebuild the overlay', async () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    // Deferred main mode: the test resolves renderSlide manually so setScale can
+    // move the epoch WHILE slide 0's first render is in flight.
+    const engine = new FakePptxEngine(20, 1000, 600, 'main', true);
+    engine.feedTextRuns = [RUN];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableTextSelection: true,
+      gap: 10,
+      zoomMin: 0.05,
+      zoomMax: 4,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    // Grab the first (stale) slide-0 render call before resolving it. Capture the
+    // slot wrapper it targets so we can inspect its overlay afterwards.
+    const staleWrapper = scrollHost.children.find((c) => c.children.some((k) => k.tag === 'canvas')) as FakeEl;
+    const staleLayer = staleWrapper.children.find((c) => c.tag === 'div') as FakeEl;
+    const staleCall = engine.renderCalls.find((c) => c.slide === 0)!;
+    // Zoom mid-flight: bumps the epoch and force-re-mounts every slot (which
+    // re-dispatches a fresh slide-0 render at the new scale).
+    v.setScale(v.scaleForTest() * 2);
+    // Now resolve the STALE (old-epoch) render. Its .then must bail on the epoch
+    // guard and NOT build the overlay.
+    staleCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // The stale render built nothing (epoch guard). The fresh render is still
+    // deferred (not resolved), so its overlay isn't built either — the stale
+    // slot/layer holds zero children from the superseded render.
+    expect(staleLayer.children.length).toBe(0);
+    v.destroy();
+  });
+});

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxScrollViewer } from './scroll-viewer.js';
+import { installDom, makeContainer, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('PptxScrollViewer — skeleton (T1)', () => {
+  it('builds the wrapper → scrollHost → spacer DOM inside the container', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakePptxEngine(3, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
+    // container → wrapper
+    const wrapper = container.children[0];
+    expect(wrapper.tag).toBe('div');
+    expect(wrapper.style.position).toBe('relative');
+    // wrapper → scrollHost
+    const scrollHost = wrapper.children[0];
+    expect(scrollHost.style.overflow).toBe('auto');
+    // scrollHost → spacer
+    const spacer = scrollHost.children[0];
+    expect(spacer.style.position).toBe('absolute');
+    v.destroy();
+  });
+
+  it('exposes slideCount from the injected engine', () => {
+    installDom();
+    const engine = new FakePptxEngine(5, 1000, 600);
+    const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, { presentation: engine.asPres() });
+    expect(v.slideCount).toBe(5);
+    v.destroy();
+  });
+
+  it('load() is unsupported when an engine is injected', async () => {
+    installDom();
+    const engine = new FakePptxEngine(1, 1000, 600);
+    const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, { presentation: engine.asPres() });
+    await expect(v.load('x.pptx')).rejects.toThrow(/injected/i);
+    v.destroy();
+  });
+
+  it('destroy() removes the DOM and does NOT destroy an injected engine', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakePptxEngine(1, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { presentation: engine.asPres() });
+    expect(container.children.length).toBe(1); // wrapper mounted
+    v.destroy();
+    expect(container.children.length).toBe(0); // wrapper removed
+    expect(engine.destroyed).toBe(false); // injected engine preserved (caller owns it)
+  });
+
+  it('slideCount is 0 before load resolves (no injected engine)', () => {
+    installDom();
+    const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {});
+    expect(v.slideCount).toBe(0);
+    v.destroy();
+  });
+
+  // O1 (design §11): an injected engine's own `mode` is authoritative. An
+  // EXPLICITLY conflicting opts.mode is a mis-configuration rejected at
+  // construction; a matching or absent opts.mode constructs fine.
+  it('throws when opts.mode conflicts with an injected worker-mode engine', () => {
+    installDom();
+    const engine = new FakePptxEngine(1, 1000, 600, 'worker');
+    expect(
+      () =>
+        new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {
+          presentation: engine.asPres(),
+          mode: 'main',
+        }),
+    ).toThrow(/mode/i);
+  });
+
+  it('does NOT throw when opts.mode matches an injected worker-mode engine', () => {
+    installDom();
+    const engine = new FakePptxEngine(1, 1000, 600, 'worker');
+    const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      mode: 'worker',
+    });
+    expect(v.slideCount).toBe(1);
+    v.destroy();
+    // Injected engine is caller-owned even in the worker case: destroy() leaves it intact.
+    expect(engine.destroyed).toBe(false);
+  });
+
+  it('constructs a default-main injected engine with absent opts.mode (load still rejects; destroy preserves engine)', async () => {
+    installDom();
+    // Default mode is 'main'; opts.mode is absent ⇒ no conflict, resolved path is main.
+    const engine = new FakePptxEngine(2, 1000, 600);
+    const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+    });
+    expect(v.slideCount).toBe(2);
+    await expect(v.load('x.pptx')).rejects.toThrow(/injected/i);
+    v.destroy();
+    // Injected engine is caller-owned: destroy() must not tear it down.
+    expect(engine.destroyed).toBe(false);
+  });
+});

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -160,6 +160,12 @@ describe('PptxScrollViewer — layout + virtualization (T2)', () => {
       gap: 10,
       overscan: 1,
       width: undefined, // fit container width (200) → base scale below
+      // Flush horizontal gutters: paddingLeft/Right default to `gap`, which would
+      // shrink the fit width to 180 and break the base-scale-1.0 geometry the T2
+      // assertions assume (slide width px = 200). Pin them to 0 so the fit is the
+      // full 200 container width (same pattern the vertical commit used).
+      paddingLeft: 0,
+      paddingRight: 0,
       ...opts,
     });
     const wrapper = container.children[0] as FakeEl;
@@ -194,6 +200,8 @@ describe('PptxScrollViewer — layout + virtualization (T2)', () => {
       presentation: engine.asPres(),
       gap: 10,
       overscan: 1,
+      paddingLeft: 0, // full-width fit (see T2 setup note) → base scale 1.0
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     const spacer = scrollHost.children[0] as FakeEl;
@@ -273,6 +281,8 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
+      paddingLeft: 0, // full-width fit → slide width px = 200 (asserted below)
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -302,6 +312,8 @@ describe('PptxScrollViewer — rendering (T3)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: 10,
+      paddingLeft: 0, // full-width fit → base scale 1.0 (slide width px = 200)
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -726,6 +738,9 @@ describe('PptxScrollViewer — zoom (T4)', () => {
       // "explicit 0 ⇒ old flush behavior reachable" contract.
       paddingTop: 0,
       paddingBottom: 0,
+      // Flush left/right so the fit width is the full 200 container ⇒ base 1.0.
+      paddingLeft: 0,
+      paddingRight: 0,
       overscan: 1,
       ...opts,
     });
@@ -819,6 +834,10 @@ describe('PptxScrollViewer — zoom (T4)', () => {
       presentation: engine.asPres(),
       gap: 16,
       // No zoomMin/zoomMax ⇒ REAL defaults [0.1, 4].
+      // Flush horizontal gutters so the fit is the full 1200 container ⇒ base
+      // 1200/1280 = 0.9375 (the default `gap` gutters would shrink it to 1168/1280).
+      paddingLeft: 0,
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     const spacer = scrollHost.children[0] as FakeEl;
@@ -1042,6 +1061,8 @@ describe('PptxScrollViewer — text selection (T5)', () => {
       presentation: engine.asPres(),
       enableTextSelection: true,
       gap: 10,
+      paddingLeft: 0, // full-width fit → slide 200×120px (literal sizes asserted below)
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -1073,6 +1094,8 @@ describe('PptxScrollViewer — text selection (T5)', () => {
       presentation: engine.asPres(),
       enableTextSelection: true,
       gap: 10,
+      paddingLeft: 0, // full-width fit → 200×120 CSS box / 400×240 backing store
+      paddingRight: 0,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
@@ -1207,6 +1230,10 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
       // geometry (and exercises the "explicit 0 ⇒ old flush behavior" contract).
       paddingTop: 0,
       paddingBottom: 0,
+      // Flush left/right: the fit width must be the full 200 container so BASE = 1.0
+      // and SLIDE_H/STRIDE hold (the default `gap` gutters would shrink the fit).
+      paddingLeft: 0,
+      paddingRight: 0,
       ...opts,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -1457,6 +1484,11 @@ describe('PptxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       gap: GAP,
+      // This block tests the VERTICAL desk margin; pin the horizontal gutters to 0
+      // so the fit width is the full 200 container ⇒ BASE 1.0 / SLIDE_H 120 / STRIDE
+      // 130 (the default `gap` gutters would otherwise shrink the fit).
+      paddingLeft: 0,
+      paddingRight: 0,
       ...opts,
     });
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
@@ -1536,6 +1568,147 @@ describe('PptxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
     // Slide 3 stays the top slide; padding is intact so offset'[3] = 24 + 3*250 = 774.
     expect(v.topVisibleSlide).toBe(3);
     expect(Math.abs(scrollHost.scrollTop - (24 + 3 * 250))).toBeLessThan(2);
+    v.destroy();
+  });
+});
+
+describe('PptxScrollViewer — paddingLeft/paddingRight (horizontal desk gutters)', () => {
+  // Slides are UNIFORM: natural width px = SLIDE_W_EMU / 9525 = 200, height 120.
+
+  /** Build a viewer over a container of `cw`×400. */
+  function setup(cw: number, opts = {}, slideCount = 20) {
+    installDom();
+    const container = makeContainer(cw, 400);
+    const engine = new FakePptxEngine(slideCount, SLIDE_W_EMU, SLIDE_H_EMU);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 16,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = cw;
+    v.relayout();
+    return { v, scrollHost, container, engine };
+  }
+
+  /** The wrapper mounted at CSS `top`. */
+  function slot(scrollHost: FakeEl, top: string): FakeEl | undefined {
+    return scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === top,
+    ) as FakeEl | undefined;
+  }
+
+  it('fit subtracts the DEFAULT gutters: container 232 with default gap-16 gutters ⇒ fit 200 ⇒ base 1.0', () => {
+    // 232 − 16 (padL) − 16 (padR) = 200, the same fit the old 200-container tests
+    // used, so the dimensionless base scale matches their 1.0 (natural width 200).
+    const { v } = setup(232);
+    expect(v.baseScaleForTest()).toBeCloseTo(1.0, 6);
+    expect(v.scaleForTest()).toBeCloseTo(1.0, 6);
+    v.destroy();
+  });
+
+  it('explicit paddingLeft:0/paddingRight:0 ⇒ old full-width fit reachable (base uses the FULL container width)', () => {
+    // Gutters pinned to 0 ⇒ fit is the full 200 container ⇒ base 1.0, exactly the
+    // pre-feature behavior.
+    const { v } = setup(200, { paddingLeft: 0, paddingRight: 0 });
+    expect(v.baseScaleForTest()).toBeCloseTo(1.0, 6);
+    v.destroy();
+  });
+
+  it('explicit opts.width is NOT reduced by the gutters (it is the slide CSS-width contract)', () => {
+    // opts.width 150 stays 150 regardless of the gutters: base = 150 / 200 (natural)
+    // = 0.75. The gutters still apply to PLACEMENT, just not to the width.
+    const { v } = setup(400, { width: 150, paddingLeft: 24, paddingRight: 24 });
+    expect(v.baseScaleForTest()).toBeCloseTo(0.75, 6);
+    v.destroy();
+  });
+
+  it('slot left = paddingLeft when the slide fills the fit exactly (symmetric gutters ⇒ centre lands on the floor)', () => {
+    // Container 232, default gutters 16 ⇒ fit 200, slide px = 200. scrollHost
+    // clientWidth 232, so centre = (232 − 200)/2 = 16 = padL ⇒ left pinned at padL.
+    const { v, scrollHost } = setup(232);
+    // Default vertical padding = gap 16 ⇒ slide 0 sits at top:16px.
+    const s0 = slot(scrollHost, '16px');
+    expect(s0).toBeDefined();
+    expect(s0!.style.left).toBe('16px'); // = paddingLeft
+    v.destroy();
+  });
+
+  it('slot is CENTERED when the slide is narrower than the viewport (left = (cw − sw)/2 > paddingLeft)', () => {
+    // Explicit width 100 (NOT reduced) ⇒ slide px = 100, far narrower than the 400
+    // viewport. centre = (400 − 100)/2 = 150, which exceeds padL 16, so the slide is
+    // centred at 150 rather than pinned to the gutter floor.
+    const { v, scrollHost } = setup(400, { width: 100, paddingLeft: 16, paddingRight: 16 });
+    const s0 = slot(scrollHost, '16px'); // default vertical pad = gap 16
+    expect(s0).toBeDefined();
+    expect(parseFloat(s0!.style.left)).toBeCloseTo(150, 3);
+    expect(parseFloat(s0!.style.left)).toBeGreaterThan(16);
+    v.destroy();
+  });
+
+  it('zoomed-in (slide wider than viewport): left pins to paddingLeft and the spacer width = slideW + padL + padR', () => {
+    // Explicit width 400 in a 200 viewport ⇒ slide px 400 > cw 200. centre =
+    // (200 − 400)/2 = −100, so the floor pins left at padL 24. The horizontal scroll
+    // extent (spacer width) is the slide width plus both gutters: 400 + 24 + 24 = 448.
+    const { v, scrollHost } = setup(200, { width: 400, paddingLeft: 24, paddingRight: 24 });
+    const s0 = slot(scrollHost, '16px'); // default vertical pad = gap 16
+    expect(s0).toBeDefined();
+    expect(s0!.style.left).toBe('24px'); // pinned to paddingLeft
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.width)).toBeCloseTo(400 + 24 + 24, 3);
+    v.destroy();
+  });
+
+  it('a Ctrl+wheel zoom that widens the slide past the viewport updates the spacer width and pins left to paddingLeft', () => {
+    // Container 200 pinned gutters 0 ⇒ fit 200, base 1.0, slide px 200 (== viewport).
+    // Zoom ×2 ⇒ slide px 400 > 200 viewport. left floors to padL (0 here) and the
+    // spacer width tracks the new slide width + gutters (400 + 0 + 0 = 400).
+    const { v, scrollHost } = setup(200, {
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingTop: 0,
+      zoomMin: 0.5,
+      zoomMax: 4,
+    });
+    expect(v.scaleForTest()).toBeCloseTo(1.0, 6);
+    v.setScale(v.scaleForTest() * 2); // slide px 200 → 400
+    const s0 = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === '0px',
+    ) as FakeEl | undefined;
+    expect(s0).toBeDefined();
+    expect(s0!.style.left).toBe('0px'); // paddingLeft 0
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.width)).toBeCloseTo(400, 3);
+    v.destroy();
+  });
+
+  it('spacer width = slide width + both gutters (uniform slides)', () => {
+    // Container 200, gutters 12 ⇒ fit 176, base 0.88, slide px = 176. Spacer width =
+    // 176 + 12 + 12 = 200 (== container; a spacer that just fits creates no scrollbar).
+    const { v, scrollHost } = setup(200, { paddingLeft: 12, paddingRight: 12 });
+    const spacer = scrollHost.children[0] as FakeEl;
+    expect(parseFloat(spacer.style.width)).toBeCloseTo(176 + 12 + 12, 3);
+    void v;
+    v.destroy();
+  });
+
+  it('gutters wider than the container defer layout (non-positive fit ⇒ zero-width deferral)', () => {
+    // padL + padR = 300 > container 200 ⇒ fit ≤ 0 ⇒ deferred (no slots mounted),
+    // mirroring the zero-width container deferral.
+    const { v } = setup(200, { paddingLeft: 150, paddingRight: 150 });
+    expect(v.mountedSlideIndicesForTest().length).toBe(0);
+    v.destroy();
+  });
+
+  it('the slot wrapper carries NO CSS auto-centering (explicit JS left replaces margin:0 auto)', () => {
+    // The old wrapper used `left:0;right:0;margin:0 auto`; that would fight the
+    // explicit per-mount `left`. Assert the auto-centering margin is gone.
+    const { v, scrollHost } = setup(232);
+    const s0 = slot(scrollHost, '16px');
+    expect(s0).toBeDefined();
+    expect(s0!.style.margin).toBe(''); // no `0 auto`
+    expect(s0!.style.right).toBe(''); // no right:0 pinning
     v.destroy();
   });
 });

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -103,6 +103,33 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
     // Injected engine is caller-owned: destroy() must not tear it down.
     expect(engine.destroyed).toBe(false);
   });
+
+  // `background` paints the scroll surface (the "desk") visible behind/between
+  // slides. It applies to the viewer-owned scrollHost; slides keep their own white.
+  it('applies opts.background to the scrollHost element', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakePptxEngine(1, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      background: '#525659',
+    });
+    const scrollHost = container.children[0].children[0]; // wrapper → scrollHost
+    expect(scrollHost.style.background).toBe('#525659');
+    v.destroy();
+  });
+
+  it('sets no background on the scrollHost by default (transparent — container shows through)', () => {
+    installDom();
+    const container = makeContainer();
+    const engine = new FakePptxEngine(1, 1000, 600);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+    });
+    const scrollHost = container.children[0].children[0];
+    expect(scrollHost.style.background).toBe('');
+    v.destroy();
+  });
 });
 
 describe('PptxScrollViewer — layout + virtualization (T2)', () => {

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,4 +1,4 @@
-import { computeVisibleRange, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
+import { computeVisibleRange, EMU_PER_PX, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
 import { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
@@ -31,9 +31,10 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
    *  in worker mode `onTextRun` cannot cross the worker boundary, so the overlay
    *  stays empty and the viewer logs one warning (design §11). */
   enableTextSelection?: boolean;
-  /** Minimum zoom scale (px-per-EMU multiplier floor). Default 0.1. */
+  /** Minimum zoom scale — a DIMENSIONLESS multiplier over the 96-dpi natural
+   *  slide size (10% = 0.1), matching `DocxScrollViewer`. Default 0.1. */
   zoomMin?: number;
-  /** Maximum zoom scale. Default 4. */
+  /** Maximum zoom scale (dimensionless multiplier, 400% = 4). Default 4. */
   zoomMax?: number;
   /** Enable `Ctrl`/`Cmd`+wheel zoom. Default true. */
   enableZoom?: boolean;
@@ -99,8 +100,11 @@ export class PptxScrollViewer {
    *  loading, `opts.mode` decides and `load()` passes it to `PptxPresentation.load`. */
   private _mode: 'main' | 'worker';
 
-  /** px-per-EMU zoom multiplier. Base fit maps the (uniform) slide width to the
-   *  container width (or opts.width). Zoom multiplies this (design §7). */
+  /** Dimensionless zoom multiplier over the 96-dpi natural slide size (mirrors
+   *  `DocxScrollViewer`, whose `_scale` multiplies `widthPt × PT_TO_PX`). The
+   *  natural (1×) slide width in CSS px is `slideEmu / EMU_PER_PX`; the base fit
+   *  sets `_scale` so that natural width maps to the container width, and zoom
+   *  multiplies it further (design §7). */
   private _scale = 1;
   /** Whether the base fit scale has been established. Set true the first time
    *  `relayout()` resolves a positive base scale. We use an explicit flag rather
@@ -270,14 +274,16 @@ export class PptxScrollViewer {
     return this._pres?.slideCount ?? 0;
   }
 
-  /** Uniform slide width in CSS px at the current scale. `_scale` is px-per-EMU. */
+  /** Uniform slide width in CSS px at the current scale. `_scale` is a
+   *  dimensionless multiplier over the natural 96-dpi width (`slideEmu /
+   *  EMU_PER_PX`), mirroring docx's `widthPt × PT_TO_PX × _scale`. */
   private _slideWidthPx(): number {
-    return this._pres!.slideWidth * this._scale;
+    return (this._pres!.slideWidth / EMU_PER_PX) * this._scale;
   }
 
   /** Uniform slide height in CSS px at the current scale. */
   private _slideHeightPx(): number {
-    return this._pres!.slideHeight * this._scale;
+    return (this._pres!.slideHeight / EMU_PER_PX) * this._scale;
   }
 
   /** The container (fit) width, deferring when the container is unlaid-out. */
@@ -287,14 +293,16 @@ export class PptxScrollViewer {
     return cw > 0 ? cw : 0; // 0 ⇒ defer (design §11 zero-width deferral)
   }
 
-  /** Base scale: fit the (uniform) slide width to the fit-width. Here `_scale`
-   *  is CSS-px-per-EMU. Returns 0 when the container has no width yet (deferral). */
+  /** Base scale: the DIMENSIONLESS multiplier that fits the (uniform) slide
+   *  width to the fit-width. `natural = slideWidthEmu / EMU_PER_PX` is the 96-dpi
+   *  CSS-px width; `base = fitWidth / natural` (mirrors docx's `w / (widthPt ×
+   *  PT_TO_PX)`). Returns 0 when the container has no width yet (deferral). */
   private _baseScale(): number {
     if (!this._pres || this._pres.slideCount === 0) return 0;
     const w = this._fitWidthPx();
-    const slideW = this._pres.slideWidth;
-    if (w <= 0 || slideW <= 0) return 0;
-    return w / slideW; // px per EMU
+    const naturalW = this._pres.slideWidth / EMU_PER_PX;
+    if (w <= 0 || naturalW <= 0) return 0;
+    return w / naturalW; // dimensionless multiplier over the natural width
   }
 
   /**
@@ -510,16 +518,14 @@ export class PptxScrollViewer {
         // The engine's per-canvas token already discards the superseded pixels.
         if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedSlide !== i) return;
         if (wantOverlay && slot.textLayer) {
-          // buildPptxTextLayer takes NUMBERS (not strings) for width/height. In
-          // main mode renderSlide sets the canvas backing-store size to width*dpr
-          // and the CSS width to `width`; the overlay must match the CSS box, so
-          // compute cssHeight from the uniform slide height (rounded px).
-          buildPptxTextLayer(
-            slot.textLayer,
-            runs,
-            slot.canvas.width || Math.round(widthPx),
-            slot.canvas.height || Math.round(this._slideHeightPx()),
-          );
+          // buildPptxTextLayer takes NUMBERS (not strings) for width/height. The
+          // overlay must match the slot's CSS box, NOT the canvas backing store:
+          // renderSlide sets `canvas.width = cssWidth × dpr`, so on a retina (dpr 2)
+          // display the backing store is 2× the CSS box. Passing it would size the
+          // overlay 2× too large (overflowing the wrapper + inflating the scroll
+          // area). Pass the CSS px directly — the uniform slide width/height at the
+          // current scale (rounded).
+          buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()));
         }
       })
       .catch((err: unknown) => {
@@ -665,7 +671,8 @@ export class PptxScrollViewer {
   }
 
   /**
-   * Set the absolute px-per-EMU zoom scale, clamped inline to
+   * Set the absolute (dimensionless) zoom scale — a multiplier over the 96-dpi
+   * natural slide size, matching `DocxScrollViewer` — clamped inline to
    * `[zoomMin ?? 0.1, zoomMax ?? 4]` (absolute bounds, XlsxViewer convention — NOT
    * multiples of the base fit; design §3 keeps the clamp in the viewer, not core),
    * then re-anchor VERTICALLY so the slide currently under the viewport top stays
@@ -824,9 +831,9 @@ export class PptxScrollViewer {
     // path runs identically to a zoom.
     //
     // zoomMin RATCHET (design §8.2 caveat, see setScale JSDoc): `zoomMin`/`zoomMax`
-    // are ABSOLUTE px-per-EMU bounds, but the re-fit base (`newBase × mult`) is
-    // computed UNCLAMPED. A resize that transits the scale below `zoomMin × slideWidth`
-    // (a wide slide in a container that briefly narrows) is clamped UP by `setScale`,
+    // are ABSOLUTE dimensionless bounds, but the re-fit base (`newBase × mult`) is
+    // computed UNCLAMPED. A resize that transits the scale below `zoomMin` (a wide
+    // slide in a container that briefly narrows) is clamped UP by `setScale`,
     // which permanently inflates the implied multiplier even with zero user zoom —
     // the next re-fit reads back the clamped `_scale` as `mult`. This is bounded and
     // converges (the clamp floor is fixed), but it means the preserved multiplier can
@@ -850,7 +857,7 @@ export class PptxScrollViewer {
     return [...this._slots.keys()];
   }
 
-  /** @internal test hook: the current absolute px-per-EMU scale. */
+  /** @internal test hook: the current absolute (dimensionless) zoom scale. */
   scaleForTest(): number {
     return this._scale;
   }

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -25,6 +25,14 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
   width?: number;
   /** Vertical gap (px) between consecutive slides. Default 16. */
   gap?: number;
+  /** Desk padding (px) ABOVE the FIRST slide — the margin a presentation viewer
+   *  leaves between the top of the scroll surface and the first slide. Default:
+   *  `gap` (uniform desk rhythm — the first slide sits the same distance from the
+   *  top as slides sit from each other). Pass `0` for a flush-top layout. */
+  paddingTop?: number;
+  /** Desk padding (px) BELOW the LAST slide — the margin below the final slide.
+   *  Default: `gap`. Pass `0` for a flush-bottom layout. */
+  paddingBottom?: number;
   /** Slides kept mounted beyond the viewport on each side. Default 1. */
   overscan?: number;
   /** Per-slide transparent text-selection overlay. MAIN render mode only:
@@ -356,6 +364,15 @@ export class PptxScrollViewer {
     return this._opts.overscan ?? 1;
   }
 
+  /** Desk padding fed to `computeVisibleRange`: `paddingTop`/`paddingBottom`,
+   *  each defaulting to `gap` (uniform rhythm). Resolved here (not stored) to
+   *  mirror `_gap()`/`_overscan()`, and consumed at EVERY `computeVisibleRange`
+   *  call site so the padded offsets are the single source of geometry. */
+  private _pad(): { leading: number; trailing: number } {
+    const gap = this._gap();
+    return { leading: this._opts.paddingTop ?? gap, trailing: this._opts.paddingBottom ?? gap };
+  }
+
   private _range(): VisibleRange {
     return computeVisibleRange(
       this._heights,
@@ -363,6 +380,7 @@ export class PptxScrollViewer {
       this._scrollHost.scrollTop,
       this._scrollHost.clientHeight,
       this._overscan(),
+      this._pad(),
     );
   }
 
@@ -716,7 +734,14 @@ export class PptxScrollViewer {
     // Rescale, recompute heights, resize the spacer to the new total height.
     this._scale = next;
     this._recomputeHeights();
-    const r1 = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    const r1 = computeVisibleRange(
+      this._heights,
+      this._gap(),
+      0,
+      this._scrollHost.clientHeight,
+      this._overscan(),
+      this._pad(),
+    );
     this._spacer.style.height = `${r1.totalHeight}px`;
 
     // Pin the same fractional position of the same slide under the viewport top.
@@ -762,7 +787,14 @@ export class PptxScrollViewer {
     if (!this._pres || this._pres.slideCount === 0 || !this._scaleEstablished) return;
     const clamped = Math.max(0, Math.min(index, this._pres.slideCount - 1));
     // Recompute offsets from the current heights (independent of scrollTop).
-    const r = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    const r = computeVisibleRange(
+      this._heights,
+      this._gap(),
+      0,
+      this._scrollHost.clientHeight,
+      this._overscan(),
+      this._pad(),
+    );
     const target = r.offsets[clamped] ?? 0;
     const maxTop = Math.max(0, r.totalHeight - this._scrollHost.clientHeight);
     const top = Math.min(maxTop, Math.max(0, target));

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,0 +1,887 @@
+import { computeVisibleRange, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
+import { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
+import type { PptxTextRunInfo } from './renderer';
+import { buildPptxTextLayer } from './text-layer';
+
+/**
+ * Options for {@link PptxScrollViewer}. Extends `RenderSlideOptions` (per-slide
+ * render knobs, minus `onTextRun`) and `LoadOptions` (parse/worker knobs). See
+ * design §8.2.
+ *
+ * `onTextRun` is omitted deliberately: the viewer drives it internally per
+ * mounted slot to build the optional per-slide selection overlay (gated by
+ * `enableTextSelection`), so exposing it here would let a caller's callback be
+ * silently overridden.
+ *
+ * NOTE: `RenderSlideOptions` also carries `dim` and `skipMediaControls`. The v1
+ * scroll viewer never sets `dim` or `skipMediaControls` (hidden-slide dimming is
+ * a PAGER policy, not a scroll-viewer feature — design §8.2 / Delta 6). These
+ * inherited fields are accepted for type-compatibility but are not part of the
+ * scroll-viewer's supported API.
+ */
+export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTextRun'>, LoadOptions {
+  /** Base fit width in CSS px → base zoom scale. Default: the container's width
+   *  at first non-zero layout (design §7/§11 zero-width deferral). */
+  width?: number;
+  /** Vertical gap (px) between consecutive slides. Default 16. */
+  gap?: number;
+  /** Slides kept mounted beyond the viewport on each side. Default 1. */
+  overscan?: number;
+  /** Per-slide transparent text-selection overlay. MAIN render mode only:
+   *  in worker mode `onTextRun` cannot cross the worker boundary, so the overlay
+   *  stays empty and the viewer logs one warning (design §11). */
+  enableTextSelection?: boolean;
+  /** Minimum zoom scale (px-per-EMU multiplier floor). Default 0.1. */
+  zoomMin?: number;
+  /** Maximum zoom scale. Default 4. */
+  zoomMax?: number;
+  /** Enable `Ctrl`/`Cmd`+wheel zoom. Default true. */
+  enableZoom?: boolean;
+  /**
+   * Inject an already-loaded engine to share one parse across panes (design §14).
+   * When set: `load()` is unsupported (throws), the engine's own `mode` wins (an
+   * explicitly conflicting `opts.mode` throws at construction, design §11), and
+   * `destroy()` does NOT destroy this engine (the caller owns its lifecycle).
+   */
+  presentation?: PptxPresentation;
+  /** Fires when the top-most visible slide changes. `topIndex` from
+   *  `computeVisibleRange` (the first slide intersecting the viewport top,
+   *  EXCLUDING overscan). */
+  onVisibleSlideChange?: (topIndex: number, total: number) => void;
+  /** Error callback. When set, `load()` invokes it and resolves (otherwise the
+   *  error is rethrown — shared viewer error contract). It ALSO fires for async
+   *  per-slot render failures (both main `renderSlide` and worker
+   *  `renderSlideToBitmap` rejections); a failed slide is left blank rather than
+   *  crashing the loop. Without an `onError`, render failures are logged via
+   *  `console.error` so they are never fully silent. */
+  onError?: (err: Error) => void;
+}
+
+/** One mounted slide. `canvas` is the drawn slide; `textLayer` the optional
+ *  per-slide selection overlay (main mode only). `renderedSlide` guards against
+ *  re-rendering a recycled slot for a slide whose render is still in flight. */
+interface SlideSlot {
+  wrapper: HTMLDivElement;
+  canvas: HTMLCanvasElement;
+  textLayer: HTMLDivElement | null;
+  /** slide index this slot is currently rendering / has rendered, or -1 when free. */
+  renderedSlide: number;
+  /** worker-mode: a transient hold on a just-received ImageBitmap, set only
+   *  between receipt from the worker and its `transferFromImageBitmap` (which
+   *  consumes it, after which we null the field). Its purpose is the throw path:
+   *  if the transfer throws, `destroy()`/`_recycleSlot` can still find and
+   *  `.close()` the bitmap. Normally null once transfer completes. */
+  bitmap: ImageBitmap | null;
+  /** bitmaprenderer ctx (worker mode), grabbed once per canvas. */
+  bitmapCtx: ImageBitmapRenderingContext | null;
+}
+
+export class PptxScrollViewer {
+  private _pres: PptxPresentation | null = null;
+  private readonly _injected: boolean;
+  private readonly _opts: PptxScrollViewerOptions;
+  private readonly _container: HTMLElement;
+  private readonly _wrapper: HTMLDivElement;
+  private readonly _scrollHost: HTMLDivElement;
+  private readonly _spacer: HTMLDivElement;
+  /** Resolved render mode. When an engine is injected the engine's own `mode`
+   *  is authoritative (design §11 — no silent mis-pathing / no probing); an
+   *  explicitly conflicting `opts.mode` is rejected at construction. When self-
+   *  loading, `opts.mode` decides and `load()` passes it to `PptxPresentation.load`. */
+  private _mode: 'main' | 'worker';
+
+  /** px-per-EMU zoom multiplier. Base fit maps the (uniform) slide width to the
+   *  container width (or opts.width). Zoom multiplies this (design §7). */
+  private _scale = 1;
+  /** Whether the base fit scale has been established. Set true the first time
+   *  `relayout()` resolves a positive base scale. We use an explicit flag rather
+   *  than a `_scale === 1` sentinel because a fit scale of exactly 1 is a valid
+   *  established state (a 1× fit would otherwise be re-fit forever). */
+  private _scaleEstablished = false;
+  /** Live slots keyed by slide index. */
+  private readonly _slots = new Map<number, SlideSlot>();
+  /** Recyclable detached slots (canvas + textLayer reused across slides). */
+  private readonly _free: SlideSlot[] = [];
+  /** Cached per-slide heights in px at the current scale (index-aligned). All
+   *  slides are the same size, so every entry equals the uniform slide height. */
+  private _heights: number[] = [];
+  private _lastRange: VisibleRange | null = null;
+  private _lastTopIndex = -1;
+  private _scrollListener: (() => void) | null = null;
+  /** Set by `destroy()`. Async render callbacks (main + worker) check it before
+   *  reporting an error so a rejection that lands after teardown is swallowed
+   *  rather than surfaced to a `onError` on a dead viewer. */
+  private _destroyed = false;
+  /** Worker mode: slide indices whose bitmap render is currently dispatched to the
+   *  engine. Coalesces a scroll storm — we never dispatch a second render for a
+   *  slide whose first is still in flight — and lets us drop slides that scrolled
+   *  out of the window before dispatch (design §11 worker coalescing).
+   *
+   *  T4 ZOOM HAZARD (RESOLVED by the render epoch below): coalescing keys on slide
+   *  INDEX only, with no notion of the scale a dispatch was made at. Once
+   *  `setScale` can change the zoom mid-flight, an in-flight bitmap dispatched at
+   *  the OLD scale can still pass the on-resolution identity check if the SAME
+   *  slot object is re-mounted for slide `i` (the pool reuses slot objects, so
+   *  `_slots.get(i) === slot && slot.renderedSlide === i` can hold for an old
+   *  dispatch), and get painted at the WRONG resolution. We fix this with a render
+   *  epoch (`_renderEpoch`): each dispatch captures the epoch, and on resolution a
+   *  moved epoch ⇒ STALE (close + re-dispatch the live slot). See
+   *  `_renderSlotBitmap`. */
+  private readonly _slideInFlight = new Set<number>();
+  /** Render generation, bumped on every effective `setScale` (and the resize
+   *  re-fit in `_onResize`, which routes through `setScale`). Stamped into each async render
+   *  dispatch; a resolution whose captured epoch ≠ this value is STALE — its
+   *  pixels/geometry are at a superseded scale. Worker path: close the orphan
+   *  bitmap + re-dispatch the live slot. Main path: skip the (stale) text-layer
+   *  build; the engine's per-canvas token already discards the stale pixels. */
+  private _renderEpoch = 0;
+  private _wheelListener: ((e: WheelEvent) => void) | null = null;
+  /** One-shot latch for the worker-mode text-selection warning. The overlay is a
+   *  main-mode-only feature: in worker mode the per-run `onTextRun` geometry
+   *  cannot cross the worker boundary, so an `enableTextSelection` overlay stays
+   *  empty. We warn once (parity with `PptxViewer`) rather than per slot. */
+  private _warnedNoTextSelection = false;
+  /** Observes the container so a width change re-fits the base scale. Disconnected
+   *  in `destroy()`. */
+  private _resizeObserver: ResizeObserver | null = null;
+  /** The base fit scale at the last established/re-fit layout. `_onResize` divides
+   *  `_scale` by this to recover the current zoom multiplier so a width change
+   *  re-fits the base while preserving the user's zoom (design §11). */
+  private _prevBase = 0;
+  /** The fit width (px) the base scale was last established at. Lets `_onResize`
+   *  skip the re-fit when only the height changed (a ResizeObserver fires on ANY
+   *  box change, but only a WIDTH change alters the fit-to-width base scale). */
+  private _lastFitWidth = 0;
+
+  constructor(container: HTMLElement, opts: PptxScrollViewerOptions = {}) {
+    this._container = container;
+    this._opts = opts;
+    this._injected = !!opts.presentation;
+    if (this._injected) {
+      const engine = opts.presentation as PptxPresentation;
+      // Injected engine ⇒ its own mode is the fact (design §11). An EXPLICITLY
+      // conflicting opts.mode is a mis-configuration and is rejected here; an
+      // absent opts.mode is fine.
+      if (opts.mode !== undefined && opts.mode !== engine.mode) {
+        throw new Error(
+          `PptxScrollViewer: opts.mode='${opts.mode}' conflicts with the injected engine's mode='${engine.mode}'. ` +
+            'Omit opts.mode when injecting an engine — the engine owns its render mode.',
+        );
+      }
+      this._pres = engine;
+      this._mode = engine.mode;
+    } else {
+      this._mode = opts.mode ?? 'main';
+    }
+
+    // container → wrapper → scrollHost → spacer  (design §6)
+    this._wrapper = document.createElement('div');
+    this._wrapper.style.cssText = 'position:relative;width:100%;height:100%;overflow:hidden;';
+    this._scrollHost = document.createElement('div');
+    this._scrollHost.style.cssText = 'position:absolute;inset:0;overflow:auto;';
+    this._spacer = document.createElement('div');
+    this._spacer.style.cssText = 'position:absolute;top:0;left:0;width:1px;height:0;pointer-events:none;';
+    this._scrollHost.appendChild(this._spacer);
+    this._wrapper.appendChild(this._scrollHost);
+    this._container.appendChild(this._wrapper);
+
+    this._scrollListener = () => this._onScroll();
+    this._scrollHost.addEventListener('scroll', this._scrollListener);
+
+    // Ctrl/Cmd+wheel zoom (design §7). Bare wheel is left untouched so the
+    // scrollHost scrolls natively. `enableZoom:false` installs no handler at all.
+    // `{ passive: false }` is required because we call preventDefault() to stop
+    // the browser's own ctrl+wheel page zoom.
+    if (this._opts.enableZoom !== false) {
+      this._wheelListener = (e: WheelEvent) => {
+        if (!(e.ctrlKey || e.metaKey)) return; // bare wheel scrolls natively
+        e.preventDefault();
+        if (e.deltaY === 0) return;
+        this.setScale(zoomStepScale(this._scale, e.deltaY));
+      };
+      this._scrollHost.addEventListener('wheel', this._wheelListener as EventListener, {
+        passive: false,
+      });
+    }
+
+    // Re-fit the base scale on a container resize (design §11). A container that
+    // is 0-wide at construction (a common flexbox/tab layout) establishes its
+    // scale on the first non-zero resize — the zero-width deferral is completed
+    // here. `ResizeObserver` may be absent in a non-DOM host; guard for it.
+    if (typeof ResizeObserver !== 'undefined') {
+      this._resizeObserver = new ResizeObserver(() => this._onResize());
+      this._resizeObserver.observe(this._container);
+    }
+
+    if (this._injected) {
+      // An injected engine is already loaded, so lay out + mount the first
+      // window immediately. relayout() is idempotent and defers under a
+      // zero-width container (the resize path re-runs it once width appears).
+      this.relayout();
+    }
+  }
+
+  /**
+   * Load a PPTX from URL or ArrayBuffer and render the first window.
+   * UNSUPPORTED when an engine was injected via `opts.presentation` (throws) — the
+   * caller already owns the parsed engine.
+   */
+  async load(source: string | ArrayBuffer): Promise<void> {
+    if (this._injected) {
+      throw new Error(
+        'PptxScrollViewer.load() is unsupported when an engine is injected via opts.presentation; the injected engine is already loaded.',
+      );
+    }
+    try {
+      this._pres = await PptxPresentation.load(source, {
+        useGoogleFonts: this._opts.useGoogleFonts,
+        maxZipEntryBytes: this._opts.maxZipEntryBytes,
+        math: this._opts.math,
+        mode: this._mode,
+      });
+      // Lay out + mount the first window now that the engine exists (mirrors the
+      // injected-engine path in the constructor). relayout() is idempotent and
+      // defers under a zero-width container — `_onResize` re-runs it once width
+      // appears.
+      this.relayout();
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      if (this._opts.onError) {
+        this._opts.onError(e);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  get slideCount(): number {
+    return this._pres?.slideCount ?? 0;
+  }
+
+  /** Uniform slide width in CSS px at the current scale. `_scale` is px-per-EMU. */
+  private _slideWidthPx(): number {
+    return this._pres!.slideWidth * this._scale;
+  }
+
+  /** Uniform slide height in CSS px at the current scale. */
+  private _slideHeightPx(): number {
+    return this._pres!.slideHeight * this._scale;
+  }
+
+  /** The container (fit) width, deferring when the container is unlaid-out. */
+  private _fitWidthPx(): number {
+    if (this._opts.width && this._opts.width > 0) return this._opts.width;
+    const cw = this._container.clientWidth || this._scrollHost.clientWidth;
+    return cw > 0 ? cw : 0; // 0 ⇒ defer (design §11 zero-width deferral)
+  }
+
+  /** Base scale: fit the (uniform) slide width to the fit-width. Here `_scale`
+   *  is CSS-px-per-EMU. Returns 0 when the container has no width yet (deferral). */
+  private _baseScale(): number {
+    if (!this._pres || this._pres.slideCount === 0) return 0;
+    const w = this._fitWidthPx();
+    const slideW = this._pres.slideWidth;
+    if (w <= 0 || slideW <= 0) return 0;
+    return w / slideW; // px per EMU
+  }
+
+  /**
+   * Recompute per-slide heights + the spacer and re-mount the visible window.
+   *
+   * The viewer already calls this automatically after `load()`, an injected
+   * engine, a container resize, and a zoom, so most integrations never need it.
+   * It is public as a deliberate escape hatch: if the host mutates the layout in
+   * a way the `ResizeObserver` cannot observe (e.g. a CSS change on an ancestor
+   * that resizes the container without a box-size event, or a font that finishes
+   * loading after first paint), call `relayout()` to force a re-fit. Idempotent —
+   * safe to call repeatedly, and a no-op while the container has zero width (the
+   * fit is deferred until width appears, design §11).
+   */
+  relayout(): void {
+    if (!this._pres) return;
+    // Establish the base fit scale on the first layout that has a positive
+    // width. Zoom (T4) layers its own multiplier on top of this; here we only
+    // set the base. An explicit `_scaleEstablished` flag (NOT a `_scale === 1`
+    // sentinel) so a legitimate 1× fit is not re-fit on every relayout.
+    if (!this._scaleEstablished) {
+      const base = this._baseScale();
+      if (base > 0) {
+        this._scale = base;
+        this._prevBase = base;
+        this._lastFitWidth = this._fitWidthPx();
+        this._scaleEstablished = true;
+      } else {
+        return; // container has no width yet — retry on the next resize
+      }
+    }
+    this._recomputeHeights();
+    this._syncSpacer();
+    this._mountVisible();
+  }
+
+  /** All slides are the same size, so heights = n × uniform. We still feed this
+   *  full array to computeVisibleRange (never special-case uniform) so offsets /
+   *  topIndex live in one tested place (design §5.1). */
+  private _recomputeHeights(): void {
+    const n = this._pres!.slideCount;
+    const h = this._slideHeightPx();
+    this._heights = new Array<number>(n).fill(h);
+  }
+
+  private _gap(): number {
+    return this._opts.gap ?? 16;
+  }
+
+  private _overscan(): number {
+    return this._opts.overscan ?? 1;
+  }
+
+  private _range(): VisibleRange {
+    return computeVisibleRange(
+      this._heights,
+      this._gap(),
+      this._scrollHost.scrollTop,
+      this._scrollHost.clientHeight,
+      this._overscan(),
+    );
+  }
+
+  private _syncSpacer(): void {
+    const r = this._range();
+    this._lastRange = r;
+    this._spacer.style.height = `${r.totalHeight}px`;
+  }
+
+  private _onScroll(): void {
+    if (!this._pres || !this._scaleEstablished) return;
+    this._mountVisible();
+  }
+
+  /** Mount/recycle slots for the current visible window. */
+  private _mountVisible(): void {
+    if (!this._pres || this._pres.slideCount === 0) return;
+    const r = this._range();
+    this._lastRange = r;
+
+    // Detach slots that left [start, end] into the free pool.
+    for (const [idx, slot] of [...this._slots]) {
+      if (idx < r.start || idx > r.end) {
+        this._recycleSlot(idx, slot);
+      }
+    }
+    // Mount any missing index in the window.
+    for (let i = r.start; i <= r.end; i++) {
+      if (!this._slots.has(i)) {
+        const slot = this._acquireSlot();
+        this._positionSlot(slot, i, r);
+        this._slots.set(i, slot);
+        this._renderSlot(i, slot);
+      } else {
+        // Re-position (offsets shift after a spacer/height change).
+        this._positionSlot(this._slots.get(i)!, i, r);
+      }
+    }
+    // onVisibleSlideChange fires ONLY when the top visible slide actually changes
+    // (change-only latch; `_lastTopIndex` starts at -1 so the first layout fires
+    // once for slide 0). Every mount path — scroll, zoom, resize re-fit, and
+    // scrollToSlide — funnels through here, so navigation never double-fires.
+    if (r.topIndex !== this._lastTopIndex) {
+      this._lastTopIndex = r.topIndex;
+      this._opts.onVisibleSlideChange?.(r.topIndex, this._pres.slideCount);
+    }
+  }
+
+  private _acquireSlot(): SlideSlot {
+    const reused = this._free.pop();
+    if (reused) {
+      // _recycleSlot already reset renderedSlide to -1 before pooling this slot.
+      this._scrollHost.appendChild(reused.wrapper);
+      return reused;
+    }
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'position:absolute;left:0;right:0;margin:0 auto;';
+    const canvas = document.createElement('canvas');
+    canvas.style.cssText = 'display:block;background:#fff;';
+    wrapper.appendChild(canvas);
+    let textLayer: HTMLDivElement | null = null;
+    if (this._opts.enableTextSelection) {
+      textLayer = document.createElement('div');
+      textLayer.style.cssText =
+        'position:absolute;top:0;left:0;width:100%;height:100%;' +
+        'overflow:hidden;pointer-events:none;user-select:text;-webkit-user-select:text;';
+      wrapper.appendChild(textLayer);
+    }
+    this._scrollHost.appendChild(wrapper);
+    const slot: SlideSlot = { wrapper, canvas, textLayer, renderedSlide: -1, bitmap: null, bitmapCtx: null };
+    return slot;
+  }
+
+  private _recycleSlot(idx: number, slot: SlideSlot): void {
+    this._slots.delete(idx);
+    // Close any worker bitmap held by this slot (T3 sets slot.bitmap).
+    if (slot.bitmap) {
+      slot.bitmap.close();
+      slot.bitmap = null;
+    }
+    // Clear the per-slot text overlay so a slot sitting in the free pool holds no
+    // stale spans. buildPptxTextLayer also clears on its next build, but an
+    // unrendered pooled slot never gets that build, and the detached spans would
+    // otherwise linger; drop them here.
+    if (slot.textLayer) slot.textLayer.innerHTML = '';
+    slot.renderedSlide = -1;
+    slot.wrapper.remove();
+    this._free.push(slot);
+  }
+
+  private _positionSlot(slot: SlideSlot, i: number, r: VisibleRange): void {
+    slot.wrapper.style.top = `${r.offsets[i]}px`;
+    slot.wrapper.style.width = `${this._slideWidthPx()}px`;
+    slot.wrapper.style.height = `${this._slideHeightPx()}px`;
+  }
+
+  /** Device-pixel ratio for a render (opts override → window → 1). */
+  private _dpr(): number {
+    return this._opts.dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+  }
+
+  /**
+   * Render slide `i` into `slot`. Routes strictly on the constructor-resolved
+   * `_mode` (design §11 — no probing, no silent mis-pathing): `main` ⇒ paint the
+   * slot's canvas directly via `renderSlide`; `worker` ⇒ transfer an ImageBitmap
+   * from `renderSlideToBitmap`.
+   *
+   * Slot-identity guard: a slot recycled to a DIFFERENT slide while a previous
+   * render is in flight must not repaint the stale slide. `slot.renderedSlide`
+   * tracks the slide this slot is committed to; we stamp it up-front and bail on
+   * resolution if it changed (the engine's own token guard is per-canvas; this is
+   * the viewer's per-slot slide-identity check).
+   *
+   * Render epoch (main path): pixel staleness after a mid-flight `setScale` is
+   * already handled by the engine's per-canvas token (the newer renderSlide on the
+   * same canvas wins) — `setScale` recycles + re-mounts, and the re-mount always
+   * re-dispatches `renderSlide` (renderedSlide reset to -1), so a fresh render is
+   * always issued. But the viewer-side side effects of a STALE resolution — the
+   * text-layer build (its run geometry is at the OLD scale) and the renderedSlide
+   * bookkeeping — must NOT run, or a superseded render would rebuild the overlay
+   * with stale x/y/w/h (the pool reuses slot objects, so the identity check alone
+   * can pass for an old-epoch resolution). We gate them on the captured epoch.
+   */
+  private _renderSlot(i: number, slot: SlideSlot): void {
+    if (!this._pres) return;
+    // Slot-identity guard: this slot is already rendering / has rendered slide i.
+    if (slot.renderedSlide === i) return;
+    slot.renderedSlide = i;
+
+    const dpr = this._dpr();
+    const widthPx = this._slideWidthPx();
+    const epoch = this._renderEpoch;
+
+    if (this._mode === 'worker') {
+      void this._renderSlotBitmap(i, slot, widthPx, dpr);
+      return;
+    }
+
+    // Main mode: render straight onto the slot's canvas.
+    const runs: PptxTextRunInfo[] = [];
+    const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const onTextRun = wantOverlay ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    this._pres
+      .renderSlide(slot.canvas, i, {
+        width: widthPx, // this slide's own px width → uniform px-per-EMU scale (§7)
+        dpr,
+        onTextRun,
+      })
+      .then(() => {
+        // Stale if the epoch moved (a setScale rescaled mid-flight — the run
+        // geometry is at the old scale), or a recycle re-purposed this slot for a
+        // different slide / freed it. Either way: skip the (stale) overlay build.
+        // The engine's per-canvas token already discards the superseded pixels.
+        if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedSlide !== i) return;
+        if (wantOverlay && slot.textLayer) {
+          // buildPptxTextLayer takes NUMBERS (not strings) for width/height. In
+          // main mode renderSlide sets the canvas backing-store size to width*dpr
+          // and the CSS width to `width`; the overlay must match the CSS box, so
+          // compute cssHeight from the uniform slide height (rounded px).
+          buildPptxTextLayer(
+            slot.textLayer,
+            runs,
+            slot.canvas.width || Math.round(widthPx),
+            slot.canvas.height || Math.round(this._slideHeightPx()),
+          );
+        }
+      })
+      .catch((err: unknown) => {
+        this._reportRenderError(err);
+      });
+  }
+
+  /** Warn once when an `enableTextSelection` overlay was requested but the render
+   *  mode is `worker` (so the overlay stays empty). Same wording as
+   *  `PptxViewer` — one warning per viewer, not per slot. */
+  private _maybeWarnNoTextSelection(): void {
+    if (this._opts.enableTextSelection && !this._warnedNoTextSelection) {
+      this._warnedNoTextSelection = true;
+      console.warn(
+        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
+      );
+    }
+  }
+
+  /** Route an async render failure to `onError`, or `console.error` when none is
+   *  set (so failures are never fully silent), and never after teardown. */
+  private _reportRenderError(err: unknown): void {
+    if (this._destroyed) return;
+    const e = err instanceof Error ? err : new Error(String(err));
+    if (this._opts.onError) this._opts.onError(e);
+    else console.error('[ooxml] PptxScrollViewer render failed:', e);
+  }
+
+  /**
+   * Worker-mode slot render: dispatch `renderSlideToBitmap`, transfer the result
+   * via a per-slot `bitmaprenderer` context, and manage the ImageBitmap lifecycle.
+   *
+   * Coalescing / drop-stale (design §11):
+   *  - Skip if slide `i` is already in flight (a scroll storm won't double-dispatch).
+   *  - Skip if slide `i` already left the mounted window before dispatch.
+   *  - On resolution, if `slot` is no longer THIS slide's live slot (it recycled to
+   *    another slide, or slide `i` re-mounted onto a DIFFERENT slot while this render
+   *    was in flight), close the orphan bitmap and skip the paint. In that
+   *    re-mount case a live slot for `i` still awaits a render, so once we clear
+   *    the in-flight guard we re-dispatch it — a slide that recycled and re-mounted
+   *    mid-flight must never stay blank.
+   *  - RENDER EPOCH: the dispatch captures `this._renderEpoch`. `setScale` bumps
+   *    the epoch, so a resolution whose captured epoch ≠ the live epoch is STALE
+   *    even when the SAME slot object is still mounted for slide `i` (the pool
+   *    reuses slot objects, so the identity check alone can't catch a zoom that
+   *    happened mid-flight). A moved epoch ⇒ close the orphan + re-dispatch the
+   *    live slot at the new scale, never paint the old-scale bitmap.
+   *
+   * Do NOT pass `dim` or `skipMediaControls` to `renderSlideToBitmap`. The scroll
+   * viewer never dims slides (design §8.2 / Delta 6); passing neither means the
+   * static play-badge renders on media slides (matching `PptxViewer`'s
+   * non-media-playback path) — acceptable for v1.
+   */
+  private async _renderSlotBitmap(i: number, slot: SlideSlot, widthPx: number, dpr: number): Promise<void> {
+    // Worker-mode + enableTextSelection: the overlay can't be populated (onTextRun
+    // doesn't cross the worker boundary), so warn once (parity with PptxViewer)
+    // and leave the overlay empty. Fires before the coalescing guards so it is
+    // reported even when this particular dispatch is coalesced/dropped.
+    this._maybeWarnNoTextSelection();
+    if (this._slideInFlight.has(i)) return; // coalesce: already dispatched
+    // Drop-stale before dispatch: if this slide already scrolled out of the
+    // mounted window, don't dispatch at all.
+    if (this._slots.get(i) !== slot) return;
+    const epoch = this._renderEpoch;
+    this._slideInFlight.add(i);
+    // Whether this invocation actually painted its slot. When it did NOT (stale
+    // epoch or moved identity), the `finally` may need to re-dispatch a live slot.
+    let painted = false;
+    // Grab the bitmaprenderer ctx ONCE per canvas — a canvas holds one context
+    // type for its lifetime. A recycled canvas keeps the ctx grabbed on its
+    // first worker render (bitmapCtx survives recycle), so we never re-getContext
+    // a canvas that already has one. (getContext for a conflicting type returns
+    // null rather than throwing; caching the first non-null ctx avoids relying on
+    // that and skips redundant lookups.)
+    if (!slot.bitmapCtx) {
+      slot.bitmapCtx = slot.canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext | null;
+    }
+    try {
+      const bmp = await this._pres!.renderSlideToBitmap(i, {
+        width: widthPx,
+        dpr,
+      });
+      // Stale if EITHER (a) the epoch moved (a setScale rescaled mid-flight, so
+      // this bitmap is at a superseded resolution — this catches the case where
+      // the SAME slot object is re-mounted for slide `i`, which the identity check
+      // below cannot), or (b) the slot recycled to a different slide / slide `i`
+      // re-mounted onto a DIFFERENT slot. Either way: close + skip the paint.
+      if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedSlide !== i) {
+        bmp.close();
+        return;
+      }
+      // Close any prior bitmap, then hold the new one on the slot BEFORE the
+      // transfer. JS is single-threaded so nothing recycles between here and the
+      // transfer; the hold's real value is the throw path — if
+      // transferFromImageBitmap throws, `destroy()`/`_recycleSlot` can still find
+      // and close this bitmap. transferFromImageBitmap consumes the bitmap, so we
+      // null the field immediately after — leaving nothing to double-close.
+      if (slot.bitmap) slot.bitmap.close();
+      slot.bitmap = bmp;
+      slot.canvas.width = bmp.width;
+      slot.canvas.height = bmp.height;
+      slot.canvas.style.width = `${Math.round(bmp.width / dpr)}px`;
+      slot.canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
+      slot.bitmapCtx?.transferFromImageBitmap(bmp);
+      slot.bitmap = null; // transfer consumed it
+      painted = true;
+    } catch (err) {
+      this._reportRenderError(err);
+    } finally {
+      this._slideInFlight.delete(i);
+      // Re-dispatch ONLY when this invocation went stale — a LIVE slot for slide
+      // `i` still awaits a correct render and the reason we didn't paint was
+      // staleness, not a render failure. The two staleness cases:
+      //  - IDENTITY MOVED (`live !== slot`): slide `i` re-mounted onto a DIFFERENT
+      //    slot while we ran (the re-mount's own dispatch was coalesced away by
+      //    the in-flight guard), so the live slot has no render in flight.
+      //  - EPOCH MOVED (`epoch !== this._renderEpoch`): a `setScale` bumped the
+      //    epoch mid-flight, so this bitmap was at a superseded scale. The live
+      //    slot may be the SAME object reused from the pool, which the identity
+      //    test alone would miss — the epoch test catches the same-slot case.
+      // NO RETRY ON PLAIN REJECTION: when the slot is still live at the same epoch
+      // and we simply failed (`renderSlideToBitmap` rejected or the transfer threw),
+      // `!painted` holds but BOTH staleness tests are false, so we do NOT
+      // re-dispatch. Retrying a plain failure would loop unbounded (reject →
+      // re-dispatch → reject → …); the onError contract is that "a failed slide is
+      // left blank" (see PptxScrollViewerOptions.onError), so we leave it blank.
+      // Bounded epoch-then-reject: an epoch-moved re-dispatch captures the NEW
+      // epoch, so if that fresh render then rejects at the still-current epoch,
+      // both tests are false and it stops — no unbounded retry.
+      const live = this._slots.get(i);
+      if (
+        !painted &&
+        live &&
+        (live !== slot || epoch !== this._renderEpoch) &&
+        !this._slideInFlight.has(i) &&
+        !this._destroyed
+      ) {
+        // live.renderedSlide === i already (set by _renderSlot on mount); the fresh
+        // dispatch runs at the CURRENT epoch/scale via _slideWidthPx().
+        void this._renderSlotBitmap(i, live, this._slideWidthPx(), this._dpr());
+      }
+    }
+  }
+
+  /**
+   * Set the absolute px-per-EMU zoom scale, clamped inline to
+   * `[zoomMin ?? 0.1, zoomMax ?? 4]` (absolute bounds, XlsxViewer convention — NOT
+   * multiples of the base fit; design §3 keeps the clamp in the viewer, not core),
+   * then re-anchor VERTICALLY so the slide currently under the viewport top stays
+   * fixed. A no-op when nothing is loaded or when the clamped scale is unchanged.
+   *
+   * Re-anchor (written from scratch — XlsxViewer only re-anchors horizontally):
+   * capture `top = topIndex` and the intra-slide fraction `intraFrac` from the
+   * CURRENT range BEFORE rescale; after recomputing heights at the new scale,
+   * `newScrollTop = offsets'[top] + intraFrac × heights'[top]`, clamped to
+   * `[0, totalHeight' − viewportHeight]`. Because a slide's height scales linearly
+   * with `_scale`, the same fractional position maps exactly to the new geometry.
+   *
+   * CAVEAT — base fit below the floor: `relayout()` sets `_scale = base` WITHOUT
+   * clamping to `[zoomMin, zoomMax]`. If the base fit is below `zoomMin` (a wide
+   * slide in a narrow container), the initial scale sits under the floor, but once
+   * the user zooms via `setScale` the clamp pins the minimum to `zoomMin`, so they
+   * can no longer return below the floor to the original base fit through this API.
+   */
+  setScale(scale: number): void {
+    if (!this._pres || this._pres.slideCount === 0 || !this._scaleEstablished) return;
+    const zoomMin = this._opts.zoomMin ?? 0.1;
+    const zoomMax = this._opts.zoomMax ?? 4;
+    const next = Math.min(zoomMax, Math.max(zoomMin, scale));
+    if (next === this._scale) return;
+
+    // Capture the anchor from the CURRENT layout, before rescale.
+    const r0 = this._range();
+    const top = r0.topIndex;
+    const h0 = this._heights[top] || 0;
+    // intraFrac: the fraction of slide `top` that has scrolled above the viewport
+    // top. Clamp to [0,1] — a scrollTop inside the trailing gap after slide `top`
+    // is attributed to `top` by computeVisibleRange and would push intraFrac past
+    // 1, which would drift the re-anchor into the gap; pin the slide instead.
+    let intraFrac = h0 > 0 ? (this._scrollHost.scrollTop - r0.offsets[top]) / h0 : 0;
+    intraFrac = Math.min(1, Math.max(0, intraFrac));
+
+    // Bump the render epoch BEFORE recycling/re-dispatching so any in-flight
+    // render dispatched at the old scale is recognised as stale on resolution.
+    this._renderEpoch++;
+
+    // Rescale, recompute heights, resize the spacer to the new total height.
+    this._scale = next;
+    this._recomputeHeights();
+    const r1 = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    this._spacer.style.height = `${r1.totalHeight}px`;
+
+    // Pin the same fractional position of the same slide under the viewport top.
+    const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);
+    const wantTop = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
+    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, wantTop));
+
+    // Re-mount at the new geometry, forcing a re-render of every slot (its px
+    // size changed under the new scale, so the cached canvas is stale).
+    this._mountVisibleForceRerender();
+  }
+
+  /** Like `_mountVisible` but recycles every live slot first so each re-mounts and
+   *  re-renders at the current scale. Used by `setScale` (and the resize re-fit
+   *  in `_onResize`, which routes through `setScale`): a slot's canvas px size
+   *  changes with the scale, so the previously
+   *  drawn pixels are stale and every visible slide must be redrawn. */
+  private _mountVisibleForceRerender(): void {
+    for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
+    this._mountVisible();
+  }
+
+  /**
+   * Scroll so slide `index`'s top edge sits at the viewport top. Clamps `index` to
+   * `[0, slideCount-1]` (the pager convention) and the resulting scrollTop to
+   * `[0, totalHeight − viewportHeight]` so the last slides don't scroll past the
+   * end. A no-op when nothing is loaded or the deck is empty.
+   *
+   * `opts.behavior` ('auto' | 'smooth', default 'auto') is honoured via
+   * `scrollHost.scrollTo({ top, behavior })` when the host supports it (a real
+   * browser); the stub-DOM has no `scrollTo`, so the fallback sets `scrollTop`
+   * directly (which is what the tests assert). We then call `_mountVisible` once.
+   *
+   * MOUNTING CAVEAT: synchronous mounting of the target slide is guaranteed only on
+   * the DEFAULT/'auto' path — there `scrollTop` has already jumped to `top`, so the
+   * `_mountVisible` call reads the final scroll position and the target slide's slots
+   * exist immediately. With `behavior: 'smooth'` the scroll animates ASYNCHRONOUSLY:
+   * `scrollTop` is still near the old position when `_mountVisible` runs, so the
+   * target slide mounts lazily via the animation's subsequent `scroll` events, not
+   * from this call.
+   */
+  scrollToSlide(index: number, opts?: { behavior?: 'auto' | 'smooth' }): void {
+    if (!this._pres || this._pres.slideCount === 0 || !this._scaleEstablished) return;
+    const clamped = Math.max(0, Math.min(index, this._pres.slideCount - 1));
+    // Recompute offsets from the current heights (independent of scrollTop).
+    const r = computeVisibleRange(this._heights, this._gap(), 0, this._scrollHost.clientHeight, this._overscan());
+    const target = r.offsets[clamped] ?? 0;
+    const maxTop = Math.max(0, r.totalHeight - this._scrollHost.clientHeight);
+    const top = Math.min(maxTop, Math.max(0, target));
+    const host = this._scrollHost as HTMLDivElement & {
+      scrollTo?: (opts: { top: number; behavior?: 'auto' | 'smooth' }) => void;
+    };
+    if (typeof host.scrollTo === 'function') {
+      host.scrollTo({ top, behavior: opts?.behavior ?? 'auto' });
+    } else {
+      this._scrollHost.scrollTop = top;
+    }
+    this._mountVisible();
+  }
+
+  /**
+   * Re-fit the base scale on a container resize while PRESERVING the current zoom
+   * multiplier (design §11), then re-anchor + re-render. A `ResizeObserver` fires
+   * on any box change, but only a WIDTH change alters the fit-to-width base scale;
+   * a height-only change skips the re-fit yet STILL re-mounts the visible window
+   * (via `_mountVisible`), because a taller viewport reveals rows that were below
+   * the fold and would otherwise stay blank until the next scroll. Empty/unloaded
+   * ⇒ no-op; a still-zero width ⇒ defer.
+   *
+   * Zero-width recovery: a container that was 0-wide at construction never
+   * established a scale (`_scaleEstablished` is false), so the first non-zero
+   * resize establishes it here via `relayout()` — completing the T2 deferral.
+   *
+   * Re-fit math (zoom multiplier preserved):
+   *   mult      = _scale / _prevBase            (the user's zoom over the old base)
+   *   newScale  = newBase × mult
+   * Routing through `setScale(newScale)` bumps `_renderEpoch` (resize IS an epoch
+   * event — T4 banner) and re-anchors + force-re-renders every slot at the new
+   * geometry, exactly like a zoom. `setScale`'s clamp/no-op guards apply: an
+   * unchanged newScale (identical width) is a no-op there — so we short-circuit
+   * BEFORE it when the fit-width is unchanged (mounting the revealed window without
+   * a needless force-re-render), and after it we call `_mountVisible` again to cover
+   * the case where the clamp made `setScale` no-op yet the viewport still grew.
+   */
+  private _onResize(): void {
+    if (!this._pres || this._pres.slideCount === 0) return;
+    // Zero-width recovery: first non-zero layout establishes the base scale.
+    if (!this._scaleEstablished) {
+      this.relayout();
+      return;
+    }
+    const newBase = this._baseScale();
+    if (newBase <= 0) return; // still unlaid-out — wait for the next resize
+    const newFitWidth = this._fitWidthPx();
+    if (newFitWidth === this._lastFitWidth) {
+      // Height-only change (or any resize that leaves the fit-width identical):
+      // the base scale is unchanged, so there is no re-fit to do — but a taller
+      // viewport now exposes rows that were below the fold. `_mountVisible`
+      // recomputes the visible range from the CURRENT clientHeight and mounts the
+      // newly-revealed slides; without it those rows stay blank until the user
+      // scrolls (which recomputes the range). No epoch bump — the geometry
+      // (and every mounted slot's px size) is unchanged, so cached canvases are
+      // still valid; we only add the missing slots.
+      this._mountVisible();
+      return;
+    }
+    this._lastFitWidth = newFitWidth;
+    // Preserve the zoom multiplier across the re-fit: newScale = newBase × mult.
+    const mult = this._prevBase > 0 ? this._scale / this._prevBase : 1;
+    this._prevBase = newBase;
+    // Route through setScale so the epoch bumps and the re-anchor/force-re-render
+    // path runs identically to a zoom.
+    //
+    // zoomMin RATCHET (design §8.2 caveat, see setScale JSDoc): `zoomMin`/`zoomMax`
+    // are ABSOLUTE px-per-EMU bounds, but the re-fit base (`newBase × mult`) is
+    // computed UNCLAMPED. A resize that transits the scale below `zoomMin × slideWidth`
+    // (a wide slide in a container that briefly narrows) is clamped UP by `setScale`,
+    // which permanently inflates the implied multiplier even with zero user zoom —
+    // the next re-fit reads back the clamped `_scale` as `mult`. This is bounded and
+    // converges (the clamp floor is fixed), but it means the preserved multiplier can
+    // drift above 1 purely from resize transits below the floor. Accepted consequence
+    // of using absolute bounds (§8.2) with an unclamped relayout base.
+    this.setScale(newBase * mult);
+    // `setScale` no-ops when the clamped scale is unchanged (e.g. already pinned at
+    // a clamp boundary), which would skip its `_mountVisibleForceRerender`. A
+    // width+height growth that ends up clamped to the same scale must still reveal
+    // the taller viewport's rows, so mount here too. Idempotent when `setScale` ran:
+    // the window is already mounted and every present slot is a re-position no-op.
+    this._mountVisible();
+  }
+
+  get topVisibleSlide(): number {
+    return this._lastRange?.topIndex ?? 0;
+  }
+
+  /** @internal test hook: slide indices currently mounted. */
+  mountedSlideIndicesForTest(): number[] {
+    return [...this._slots.keys()];
+  }
+
+  /** @internal test hook: the current absolute px-per-EMU scale. */
+  scaleForTest(): number {
+    return this._scale;
+  }
+
+  /** @internal test hook: the base fit scale (pre-zoom) at the current width. */
+  baseScaleForTest(): number {
+    return this._baseScale();
+  }
+
+  /** @internal test hook: the current render epoch (bumped on setScale + resize). */
+  renderEpochForTest(): number {
+    return this._renderEpoch;
+  }
+
+  /** @internal test hook: fire the observed resize path (a real host drives this
+   *  via the constructor's ResizeObserver). */
+  resizeForTest(): void {
+    this._onResize();
+  }
+
+  /**
+   * Tear down the viewer: remove the DOM subtree and (only for a self-loaded
+   * engine) destroy the engine. An injected engine is left intact — the caller
+   * owns its lifecycle. Per-slot worker ImageBitmaps are closed on recycle.
+   */
+  destroy(): void {
+    this._destroyed = true;
+    if (this._scrollListener) {
+      this._scrollHost.removeEventListener('scroll', this._scrollListener);
+      this._scrollListener = null;
+    }
+    if (this._wheelListener) {
+      this._scrollHost.removeEventListener('wheel', this._wheelListener as EventListener);
+      this._wheelListener = null;
+    }
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
+    for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
+    this._free.length = 0;
+    if (!this._injected) {
+      this._pres?.destroy();
+    }
+    this._pres = null;
+    this._wrapper.remove();
+  }
+}

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -33,6 +33,18 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
   /** Desk padding (px) BELOW the LAST slide — the margin below the final slide.
    *  Default: `gap`. Pass `0` for a flush-bottom layout. */
   paddingBottom?: number;
+  /** Desk gutter (px) to the LEFT of the slides — the horizontal margin between
+   *  the left edge of the scroll surface and a slide sitting flush-left (i.e. once
+   *  zoomed wide enough that centering no longer applies). Default: `gap` (uniform
+   *  desk rhythm — the horizontal gutters match the vertical ones). It also shrinks
+   *  the container-derived FIT width so a slide sits inside the gutters at 100%
+   *  (an EXPLICIT `opts.width` is the slide's CSS-width contract and is NOT reduced;
+   *  the gutters still apply around placement). Pass `0` for a flush-left layout. */
+  paddingLeft?: number;
+  /** Desk gutter (px) to the RIGHT of the slides. Default: `gap`. Shrinks the
+   *  container-derived fit width symmetrically with `paddingLeft`. Pass `0` for a
+   *  flush-right layout. */
+  paddingRight?: number;
   /** Slides kept mounted beyond the viewport on each side. Default 1. */
   overscan?: number;
   /** Per-slide transparent text-selection overlay. MAIN render mode only:
@@ -294,11 +306,19 @@ export class PptxScrollViewer {
     return (this._pres!.slideHeight / EMU_PER_PX) * this._scale;
   }
 
-  /** The container (fit) width, deferring when the container is unlaid-out. */
+  /** The fit width (px), deferring when the container is unlaid-out. An EXPLICIT
+   *  `opts.width` is the slide's CSS-width contract and is returned UNCHANGED (the
+   *  gutters still apply around placement, not to the width). The container-derived
+   *  default instead targets `containerWidth − padL − padR` so a slide sits INSIDE
+   *  the horizontal gutters at 100%. A non-positive result (gutters wider than the
+   *  container) is treated as unlaid-out — the same deferral as a zero-width box. */
   private _fitWidthPx(): number {
     if (this._opts.width && this._opts.width > 0) return this._opts.width;
     const cw = this._container.clientWidth || this._scrollHost.clientWidth;
-    return cw > 0 ? cw : 0; // 0 ⇒ defer (design §11 zero-width deferral)
+    if (cw <= 0) return 0; // 0 ⇒ defer (design §11 zero-width deferral)
+    const { left, right } = this._padH();
+    const fit = cw - left - right;
+    return fit > 0 ? fit : 0; // gutters ≥ container ⇒ defer (same as zero-width)
   }
 
   /** Base scale: the DIMENSIONLESS multiplier that fits the (uniform) slide
@@ -373,6 +393,16 @@ export class PptxScrollViewer {
     return { leading: this._opts.paddingTop ?? gap, trailing: this._opts.paddingBottom ?? gap };
   }
 
+  /** Horizontal desk gutters: `paddingLeft`/`paddingRight`, each defaulting to
+   *  `gap` (uniform rhythm — the horizontal gutters match the vertical padding).
+   *  Consumed by `_fitWidthPx` (to shrink the container-derived fit), by
+   *  `_positionSlot` (the flush-left floor), and by `_syncSpacerWidth` (the spacer
+   *  width). Resolved here (not stored) to mirror `_gap()`/`_pad()`. */
+  private _padH(): { left: number; right: number } {
+    const gap = this._gap();
+    return { left: this._opts.paddingLeft ?? gap, right: this._opts.paddingRight ?? gap };
+  }
+
   private _range(): VisibleRange {
     return computeVisibleRange(
       this._heights,
@@ -388,6 +418,19 @@ export class PptxScrollViewer {
     const r = this._range();
     this._lastRange = r;
     this._spacer.style.height = `${r.totalHeight}px`;
+    this._syncSpacerWidth();
+  }
+
+  /** Horizontal scroll extent: the (uniform deck-wide) slide width plus both
+   *  gutters. A spacer NARROWER than the container never creates a scrollbar
+   *  (scrollWidth = max(clientWidth, content)), so it is always safe to set — it
+   *  only matters when a zoomed-in slide grows past the viewport, where it gives
+   *  the gutters something to scroll to on either side. Called from `_syncSpacer`
+   *  and after every scale change (zoom / resize re-fit) so the extent tracks the
+   *  current slide px width. */
+  private _syncSpacerWidth(): void {
+    const { left, right } = this._padH();
+    this._spacer.style.width = `${this._slideWidthPx() + left + right}px`;
   }
 
   private _onScroll(): void {
@@ -436,8 +479,11 @@ export class PptxScrollViewer {
       this._scrollHost.appendChild(reused.wrapper);
       return reused;
     }
+    // `left` is set explicitly per mount by `_positionSlot` (JS centering with a
+    // left-gutter floor), so no CSS auto-centering (`left:0;right:0;margin:0 auto`)
+    // here — it would fight the explicit `left`.
     const wrapper = document.createElement('div');
-    wrapper.style.cssText = 'position:absolute;left:0;right:0;margin:0 auto;';
+    wrapper.style.cssText = 'position:absolute;';
     const canvas = document.createElement('canvas');
     canvas.style.cssText = 'display:block;background:#fff;';
     wrapper.appendChild(canvas);
@@ -473,8 +519,19 @@ export class PptxScrollViewer {
 
   private _positionSlot(slot: SlideSlot, i: number, r: VisibleRange): void {
     slot.wrapper.style.top = `${r.offsets[i]}px`;
-    slot.wrapper.style.width = `${this._slideWidthPx()}px`;
+    const wpx = this._slideWidthPx();
+    slot.wrapper.style.width = `${wpx}px`;
     slot.wrapper.style.height = `${this._slideHeightPx()}px`;
+    // Horizontal placement (replaces the old CSS `left:0;right:0;margin:0 auto`
+    // auto-centering, which cannot honour a left gutter). Centre the slide in the
+    // scroll viewport, but never let its left edge cross the left gutter: when the
+    // slide is narrower than the viewport it is centred (`(cw − sw)/2 > padL`); once
+    // zoomed wider than the viewport the centre would go negative, so the floor
+    // pins it at `padL` and the overflow scrolls right. Formula deliberately
+    // duplicated per viewer (one line; not hoisted to core).
+    const { left: padL } = this._padH();
+    const cw = this._scrollHost.clientWidth;
+    slot.wrapper.style.left = `${Math.max(padL, (cw - wpx) / 2)}px`;
   }
 
   /** Device-pixel ratio for a render (opts override → window → 1). */
@@ -743,6 +800,8 @@ export class PptxScrollViewer {
       this._pad(),
     );
     this._spacer.style.height = `${r1.totalHeight}px`;
+    // The slide px width changed with the scale, so the horizontal extent moves too.
+    this._syncSpacerWidth();
 
     // Pin the same fractional position of the same slide under the viewport top.
     const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -38,6 +38,15 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
   /** Enable `Ctrl`/`Cmd`+wheel zoom. Default true. */
   enableZoom?: boolean;
   /**
+   * CSS `background` shorthand for the scroll surface (the "desk") visible
+   * behind and between slides — the gray a presentation viewer paints around the
+   * slide. Applied to the viewer-owned scroll host. The slides themselves are
+   * always drawn on their own white canvas and are unaffected. Default
+   * `undefined`: the scroll surface stays transparent so the host container's
+   * background shows through (non-breaking).
+   */
+  background?: string;
+  /**
    * Inject an already-loaded engine to share one parse across panes (design §14).
    * When set: `load()` is unsupported (throws), the engine's own `mode` wins (an
    * explicitly conflicting `opts.mode` throws at construction, design §11), and
@@ -179,6 +188,9 @@ export class PptxScrollViewer {
     this._wrapper.style.cssText = 'position:relative;width:100%;height:100%;overflow:hidden;';
     this._scrollHost = document.createElement('div');
     this._scrollHost.style.cssText = 'position:absolute;inset:0;overflow:auto;';
+    // The "desk" behind/between slides. Undefined ⇒ transparent (container shows
+    // through); slides keep their own white canvas regardless.
+    if (opts.background) this._scrollHost.style.background = opts.background;
     this._spacer = document.createElement('div');
     this._spacer.style.cssText = 'position:absolute;top:0;left:0;width:1px;height:0;pointer-events:none;';
     this._scrollHost.appendChild(this._spacer);


### PR DESCRIPTION
## Summary

**WS4b of #572** — completes the continuous-scroll viewer family and adds the desk-appearance options requested during review of the live viewers.

### PptxScrollViewer (mirror of the shipped DocxScrollViewer)

Full mirror with slide vocabulary: virtualized uniform-slide layout, engine injection (`opts.presentation` + new public `PptxPresentation.mode` fact), worker coalescing/epoch/no-retry gates, zoom with vertical re-anchor, per-slot text overlay (shape grouping + rotation via `buildPptxTextLayer`), nav/resize, Storybook story, barrel export. An independent mirror-fidelity review verified **all 12 review-hardened docx invariants carried over** (vocabulary-normalized diff: zero control-flow drift) and caught two delta-zone defects, both fixed with regression tests:

- **Critical:** the zoom scale was px-per-EMU, so the default `[0.1, 4]` clamp exploded real decks ~1000× on the first wheel tick (browser-confirmed). `_scale` is now **dimensionless** (natural size = EMU / `EMU_PER_PX`), unifying semantics with docx; a real-magnitude (12.2M-EMU) regression test pins it.
- **Major:** text overlays were sized with backing-store px (2× on retina); now CSS px, with a dpr≠1 test.

### Desk options (both scroll viewers, symmetric)

- `background?: string` — CSS background of the scroll surface behind/between pages (default: transparent).
- `paddingTop/Bottom/Left/Right?: number` — desk margins around the page run, each defaulting to `gap` (uniform rhythm). Vertical padding is computed in core (`computeVisibleRange` gains additive `pad?: {leading, trailing}` — offsets/totalHeight padded at the source, so both viewers, scrollTo, and the zoom re-anchor consume it with zero per-viewer shift arithmetic). Horizontal gutters are Layer-3 policy: fit-width targets `container − padL − padR`, slots get explicit centered-with-min-inset placement, and the spacer carries a width so zoomed-in horizontal scrolling keeps gutters on both sides.

## Verification

- pptx suite **214/214** (78 scroll-viewer tests), docx suite **415/415** (75), core layout **23/23**; root `pnpm typecheck` clean; ast-grep clean.
- Browser smoke on both Storybook stories: real-magnitude zoom (spacer ×2.67 ≈ e per tick — not ×1000), four-side 24px margins, `#f5f5f5` desk, horizontal gutter preserved when zoomed in, virtualization windows tracking scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)