### PR TITLE
feat(docx,pptx): flicker-free zoom + pageShadow for the scroll viewers (#572)

### DIFF
--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -23,6 +23,14 @@ export interface FakeEl {
   clientWidth: number;
   _listeners: Map<string, Array<(e: unknown) => void>>;
   _bitmapCtx?: { transferFromImageBitmap: (b: unknown) => void; lastBitmap: unknown };
+  /** Records every DEVICE-BUFFER resize (a `canvas.width`/`canvas.height`
+   *  assignment). The flicker-free CSS-preview path must NOT touch the device
+   *  buffer of an in-window slot (it only CSS-resizes via `style.width/height`),
+   *  so a preview leaves this array untouched; a settle/mount render appends. */
+  _deviceResizes: Array<{ prop: 'width' | 'height'; value: number }>;
+  /** Monotonic id assigned at creation, so tests can order operations and tell a
+   *  freshly-created spare canvas from the on-screen one it replaces. */
+  _uid: number;
   appendChild(c: FakeEl): FakeEl;
   removeChild(c: FakeEl): FakeEl;
   remove(): void;
@@ -34,6 +42,8 @@ export interface FakeEl {
   /** test-only: fire a recorded listener */
   dispatch(type: string, event?: unknown): void;
 }
+
+let _uidSeq = 0;
 
 export function makeEl(tag: string): FakeEl {
   const style: Record<string, string> = {};
@@ -49,6 +59,8 @@ export function makeEl(tag: string): FakeEl {
     children: [],
     parentElement: null,
     _listeners: new Map(),
+    _deviceResizes: [],
+    _uid: _uidSeq++,
     style: new Proxy(style as Record<string, string> & { cssText: string }, {
       set(target, prop: string, value: string) {
         if (prop === 'cssText') {
@@ -136,6 +148,36 @@ export function makeEl(tag: string): FakeEl {
     enumerable: true,
     configurable: true,
   });
+  // Record device-buffer resizes. A real canvas.width/height assignment resizes
+  // (and CLEARS) the backing store; the flicker-free preview path must never do
+  // this to an on-screen slot (it CSS-resizes instead). Making width/height
+  // recording accessors lets the preview tests assert "no device-buffer resize
+  // happened during the CSS preview" (test a). The value is still stored so the
+  // worker transfer path (`canvas.width = bmp.width`) reads back correctly.
+  let _w = 0;
+  let _h = 0;
+  Object.defineProperty(el, 'width', {
+    get() {
+      return _w;
+    },
+    set(value: number) {
+      _w = value;
+      el._deviceResizes.push({ prop: 'width', value });
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(el, 'height', {
+    get() {
+      return _h;
+    },
+    set(value: number) {
+      _h = value;
+      el._deviceResizes.push({ prop: 'height', value });
+    },
+    enumerable: true,
+    configurable: true,
+  });
   return el;
 }
 
@@ -172,6 +214,10 @@ export interface RenderCall {
   /** The per-call `width` (px) the viewer passed — asserted by T3 to confirm
    *  each page gets its OWN px width (uniform px-per-pt scale, §7). */
   width?: number;
+  /** The canvas element the viewer handed to `renderPage` (main mode). The
+   *  flicker-free double-buffer settle renders into a SPARE canvas, so this lets
+   *  a test confirm the on-screen canvas was NOT the render target until swap. */
+  canvas?: FakeEl;
   resolve: () => void;
   reject: (e: Error) => void;
 }
@@ -224,11 +270,25 @@ export class FakeDocxEngine {
         "renderPage(canvas) is unavailable in mode: 'worker'; use renderPageToBitmap() and paint it via an ImageBitmapRenderingContext",
       );
     }
+    // Mirror the real renderer's SYNCHRONOUS device-buffer clear: the real
+    // renderDocumentToCanvas sets `canvas.width = round(cssWidth × dpr)` (which
+    // clears the backing store to blank) up front, BEFORE its first await, then
+    // paints after. The flicker-free settle path relies on this happening on a
+    // SPARE off-screen canvas (never the on-screen one), so recording it lets the
+    // double-buffer test assert the clear landed on the spare (test d).
+    const canvas = _canvas as FakeEl | undefined;
+    if (canvas && opts?.width && opts.width > 0) {
+      const dpr = opts.dpr ?? 1;
+      const size = this.pageSize(page);
+      const scale = size.widthPt > 0 ? opts.width / size.widthPt : 0;
+      canvas.width = Math.round(opts.width * dpr);
+      canvas.height = Math.round(size.heightPt * scale * dpr);
+    }
     // Emit any fed runs to the viewer's internal onTextRun so it can build the
     // per-slot overlay (mirrors the real renderer emitting run geometry).
     for (const r of this.feedTextRuns ?? []) opts?.onTextRun?.(r);
     return new Promise<void>((resolve, reject) => {
-      const call: RenderCall = { page, width: opts?.width, resolve: () => resolve(), reject };
+      const call: RenderCall = { page, width: opts?.width, canvas, resolve: () => resolve(), reject };
       this.renderCalls.push(call);
       if (!this.deferred) resolve();
     });

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1914,6 +1914,133 @@ describe('DocxScrollViewer — flicker-free zoom (T8)', () => {
   });
 });
 
+describe('DocxScrollViewer — pageShadow (T9)', () => {
+  // pageShadow paints a CSS box-shadow on every page CANVAS (not the wrapper).
+  // Default = the recipe drop shadow; `false` disables; a custom string is
+  // honoured verbatim. It must reach EVERY canvas: fresh mounts, the settle
+  // double-buffer SPARE, and recycled+re-mounted slots. Reuses the T8 setup
+  // (deferred engine + fake timers) for the spare-canvas case.
+  const DEFAULT_PAGE_SHADOW = '0 1px 3px rgba(0,0,0,0.2)';
+
+  function setup(opts = {}, mode: 'main' | 'worker' = 'main', deferred = false) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(
+      20,
+      Array.from({ length: 20 }, () => ({ widthPt: 100, heightPt: 200 })),
+      mode,
+      deferred,
+    );
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+      overscan: 1,
+      zoomMin: 0.5,
+      zoomMax: 4,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, engine };
+  }
+
+  /** Every mounted page canvas (each slot wrapper's canvas child). */
+  function mountedCanvases(scrollHost: FakeEl): FakeEl[] {
+    return scrollHost.children
+      .filter((c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas'))
+      .map((w) => w.children.find((k) => k.tag === 'canvas') as FakeEl);
+  }
+
+  it('applies the default recipe shadow to every mounted page canvas', () => {
+    const { v, scrollHost } = setup();
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+    v.destroy();
+  });
+
+  it('pageShadow:false sets no box-shadow on the page canvas', () => {
+    const { v, scrollHost } = setup({ pageShadow: false });
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe('');
+    v.destroy();
+  });
+
+  it('honours a custom pageShadow string verbatim (e.g. a spread-ring border look)', () => {
+    const ring = '0 0 0 1px #c8ccd0';
+    const { v, scrollHost } = setup({ pageShadow: ring });
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe(ring);
+    v.destroy();
+  });
+
+  it('does NOT paint the shadow on the wrapper (only the canvas)', () => {
+    const { v, scrollHost } = setup();
+    const wrapper = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas'),
+    ) as FakeEl;
+    expect(wrapper.style.boxShadow).toBe('');
+    v.destroy();
+  });
+
+  it('the settle double-buffer SPARE canvas carries the shadow (swapped-in canvas keeps it)', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, scrollHost, engine } = setup({}, 'main', true);
+      // Resolve the initial mount renders so the on-screen canvases are painted.
+      for (const c of engine.renderCalls.slice()) c.resolve();
+
+      v.setScale(v.scaleForTest() * 2); // zoom → schedules a settle
+      vi.advanceTimersByTime(200); // past ZOOM_SETTLE_MS → settle dispatched
+
+      // The settle render for page 0 targets a fresh SPARE canvas — it must
+      // already carry the shadow BEFORE the swap.
+      const settleCall = engine.renderCalls.filter((c) => c.page === 0).pop()!;
+      const spare = settleCall.canvas as unknown as FakeEl;
+      expect(spare).toBeDefined();
+      expect(spare.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+
+      // Resolve → swap the spare in. The now-on-screen canvas still has the shadow.
+      settleCall.resolve();
+      const slot = scrollHost.children.find(
+        (c) => c.tag === 'div' && c.style.top === '0px' && c.children.some((k) => k.tag === 'canvas'),
+      ) as FakeEl;
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+          expect(nowCanvas._uid).toBe(spare._uid); // spare swapped in
+          expect(nowCanvas.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+          v.destroy();
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a recycled + re-mounted slot still carries the shadow', () => {
+    const { v, scrollHost } = setup();
+    // Scroll far down so page 0's slot recycles into the free pool, then back to
+    // the top so a POOLED slot is re-mounted for page 0.
+    scrollHost.scrollTop = 5000;
+    scrollHost.dispatch('scroll');
+    scrollHost.scrollTop = 0;
+    scrollHost.dispatch('scroll');
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+    v.destroy();
+  });
+});
+
 describe('DocxScrollViewer — barrel export (T7)', () => {
   it('is exported from the package entry', () => {
     expect(typeof docxIndex.DocxScrollViewer).toBe('function');

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1610,6 +1610,310 @@ describe('DocxScrollViewer — paddingLeft/paddingRight (horizontal desk gutters
   });
 });
 
+describe('DocxScrollViewer — flicker-free zoom (T8)', () => {
+  // Flicker-free zoom (design §7): setScale must NOT blank a visible page.
+  // Three mechanisms — CSS preview (immediate, no device-buffer resize / no
+  // recycle of in-window slots), settle re-render (debounced ZOOM_SETTLE_MS),
+  // double-buffer swap (main-mode settle renders into a SPARE off-DOM canvas and
+  // swaps it in). PT_TO_PX 4/3, uniform 100pt×200pt pages, container 200×400,
+  // flush pads ⇒ base 1.5, PAGE_H 400.
+  const PT_TO_PX = 4 / 3;
+
+  function setup(pageCount = 20, opts = {}, mode: 'main' | 'worker' = 'main', deferred = false) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakeDocxEngine(
+      pageCount,
+      Array.from({ length: pageCount }, () => ({ widthPt: 100, heightPt: 200 })),
+      mode,
+      deferred,
+    );
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+      overscan: 1,
+      zoomMin: 0.5,
+      zoomMax: 4,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, engine, container };
+  }
+
+  /** The wrapper mounted for the page currently at top:`top`px. */
+  function slotAtTop(scrollHost: FakeEl, top: string): FakeEl | undefined {
+    return scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === top,
+    ) as FakeEl | undefined;
+  }
+
+  // (a) setScale does NOT unmount in-window slots (same wrapper before/after) and
+  //     does NOT resize any on-screen canvas device buffer during the preview.
+  it('CSS preview: setScale keeps the SAME in-window slot wrappers and never resizes their device buffer', () => {
+    const { v, scrollHost } = setup();
+    // The page-0 slot mounted at top:0 with its canvas.
+    const before = slotAtTop(scrollHost, '0px');
+    expect(before).toBeDefined();
+    const beforeCanvas = before!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    const resizesBefore = beforeCanvas._deviceResizes.length;
+
+    v.setScale(v.scaleForTest() * 2); // zoom in
+
+    // The very SAME wrapper element is still mounted for page 0 (not recycled +
+    // re-mounted). Its canvas is the SAME element (identity preserved).
+    const after = slotAtTop(scrollHost, '0px');
+    expect(after).toBe(before);
+    const afterCanvas = after!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(afterCanvas).toBe(beforeCanvas);
+    // No device-buffer resize during the CSS preview (the flicker cause). The
+    // preview only sets style.width/height.
+    expect(afterCanvas._deviceResizes.length).toBe(resizesBefore);
+    v.destroy();
+  });
+
+  it('CSS preview: setScale CSS-resizes the slot canvas (style.width/height) to the new layout size immediately', () => {
+    const { v, scrollHost } = setup();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const canvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+    // base 1.5 ⇒ page px width 200. Zoom ×2 ⇒ CSS width 400.
+    v.setScale(v.scaleForTest() * 2);
+    expect(canvas.style.width).toBe('400px');
+    // height: 200pt × PT_TO_PX × 3.0 = 800.
+    expect(canvas.style.height).toBe('800px');
+    v.destroy();
+  });
+
+  it('CSS preview: text layer gets a transform: scale(ratio) matching newScale / renderedScale', async () => {
+    const { v, scrollHost, engine } = setup(20, { enableTextSelection: true });
+    engine.feedTextRuns = [{ text: 'Hi', x: 1, y: 2, w: 10, h: 12, fontSize: 12, font: '12px serif' }];
+    // The overlay is built in the renderPage .then() microtask.
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const textLayer = slot.children.find((k) => k.tag === 'div') as FakeEl;
+    // Zoom ×2 — the overlay was built at the base scale (1.5); the preview scales
+    // it by newScale/renderedScale = 3.0/1.5 = 2.
+    v.setScale(v.scaleForTest() * 2);
+    expect(textLayer.style.transform).toBe('scale(2)');
+    expect(textLayer.style.transformOrigin).toBe('0 0');
+    v.destroy();
+  });
+
+  // (c) NO render dispatch during a burst; ONE dispatch after ZOOM_SETTLE_MS.
+  it('debounce: a burst of setScale calls dispatches NO settle render until ZOOM_SETTLE_MS elapses, then exactly one per slot', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, engine } = setup();
+      const dispatchesBefore = engine.renderCalls.length; // initial mount renders
+      // Three rapid setScale calls within the settle window.
+      v.setScale(v.scaleForTest() * 1.1);
+      vi.advanceTimersByTime(50);
+      v.setScale(v.scaleForTest() * 1.1);
+      vi.advanceTimersByTime(50);
+      v.setScale(v.scaleForTest() * 1.1);
+      // Still inside the settle window (150ms): NO settle re-render dispatched.
+      vi.advanceTimersByTime(50); // total 150 since first, but timer reset each tick
+      expect(engine.renderCalls.length).toBe(dispatchesBefore);
+      // Advance past the settle timeout measured from the LAST setScale.
+      vi.advanceTimersByTime(150);
+      // Now the visible window re-rendered exactly once each (no per-tick storm).
+      const mounted = v.mountedPageIndicesForTest();
+      const settleRenders = engine.renderCalls.length - dispatchesBefore;
+      expect(settleRenders).toBe(mounted.length);
+    } finally {
+      vi.useRealTimers();
+    }
+    // no v.destroy() under real timers needed — installDom stubs are cleaned in afterEach
+  });
+
+  // (d) settle resolution swaps the canvas without a blank: main-mode settle
+  //     renders into a SPARE canvas (device-buffer resize lands on the spare, not
+  //     the on-screen canvas), then swaps it into the wrapper. The old canvas
+  //     stays attached until the fresh one is painted.
+  it('double-buffer (main): settle renders into a SPARE canvas and swaps it in — the on-screen canvas is never device-resized in place', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, scrollHost, engine } = setup(20, {}, 'main', true);
+      // Resolve the initial mount renders so the on-screen canvas is "painted".
+      for (const c of engine.renderCalls.slice()) c.resolve();
+      const slot = slotAtTop(scrollHost, '0px')!;
+      const onScreenCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+      const onScreenUid = onScreenCanvas._uid;
+      const resizesOnScreenBefore = onScreenCanvas._deviceResizes.length;
+
+      v.setScale(v.scaleForTest() * 2);
+      vi.advanceTimersByTime(200); // past ZOOM_SETTLE_MS
+
+      // A settle render was dispatched for page 0 into a canvas that is NOT the
+      // on-screen one (a fresh spare with a higher uid).
+      const settleCall = engine.renderCalls.filter((c) => c.page === 0).pop()!;
+      expect(settleCall.canvas).toBeDefined();
+      expect(settleCall.canvas!._uid).not.toBe(onScreenUid);
+      // The on-screen canvas's device buffer was NOT resized in place by the settle
+      // (the render — and its synchronous clear — targeted the spare).
+      expect(onScreenCanvas._deviceResizes.length).toBe(resizesOnScreenBefore);
+      // The on-screen canvas is still attached (blank-free): the spare has not yet
+      // resolved, so no swap happened.
+      expect(slot.children).toContain(onScreenCanvas);
+
+      // Resolve the spare render → swap it into the wrapper, retire the old canvas.
+      settleCall.resolve();
+      // The swap runs in the render .then() microtask.
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+          expect(nowCanvas._uid).toBe(settleCall.canvas!._uid); // spare swapped in
+          expect(slot.children).not.toContain(onScreenCanvas); // old retired
+          v.destroy();
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('double-buffer (worker): settle renders into the SAME canvas (sync resize+transfer paints no blank frame)', async () => {
+    vi.useFakeTimers();
+    const { v, scrollHost, engine } = setup(20, {}, 'worker', true);
+    // Resolve the initial mount bitmap renders.
+    for (const c of engine.bitmapCalls.slice()) c.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const canvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+    const canvasUid = canvas._uid;
+    const bitmapsBefore = engine.bitmapCalls.length;
+
+    v.setScale(v.scaleForTest() * 2);
+    vi.advanceTimersByTime(200); // past ZOOM_SETTLE_MS
+
+    // Worker settle re-dispatched a bitmap render for the visible window (no spare
+    // canvas created — the sync resize+transfer never paints an intermediate blank).
+    expect(engine.bitmapCalls.length).toBeGreaterThan(bitmapsBefore);
+    const settleCall = engine.bitmapCalls.filter((c) => c.page === 0).pop()!;
+    // createdBitmaps is index-parallel to bitmapCalls (both pushed in the same
+    // renderPageToBitmap call), so this is the bitmap for THIS settle dispatch.
+    const settleBitmap = engine.createdBitmaps[engine.bitmapCalls.indexOf(settleCall)];
+    settleCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // The bitmap was transferred into the SAME on-screen canvas element (identity
+    // preserved — worker mode keeps the same canvas).
+    const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(nowCanvas._uid).toBe(canvasUid);
+    expect(nowCanvas._bitmapCtx?.lastBitmap).toBe(settleBitmap);
+    vi.useRealTimers();
+    v.destroy();
+  });
+
+  // (e) A settle whose epoch is superseded (another setScale during the settle
+  //     render) is discarded per the existing epoch gate.
+  it('stale settle: an epoch bump during the settle render discards the settle (no swap, spare not attached)', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, scrollHost, engine } = setup(20, {}, 'main', true);
+      for (const c of engine.renderCalls.slice()) c.resolve();
+      const slot = slotAtTop(scrollHost, '0px')!;
+      const onScreenCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+
+      v.setScale(v.scaleForTest() * 2);
+      vi.advanceTimersByTime(200); // settle dispatched (deferred, in flight)
+      const settleCall = engine.renderCalls.filter((c) => c.page === 0).pop()!;
+
+      // Another setScale bumps the epoch WHILE the settle render is in flight.
+      v.setScale(v.scaleForTest() * 1.1);
+
+      // The old settle now resolves — epoch moved ⇒ STALE ⇒ no swap.
+      settleCall.resolve();
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+          // The stale spare was NOT swapped in; the on-screen canvas still stands.
+          expect(nowCanvas).toBe(onScreenCanvas);
+          expect(nowCanvas._uid).not.toBe(settleCall.canvas!._uid);
+          v.destroy();
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // (f) destroy during a pending settle timer: no crash, timer cleared, no
+  //     post-destroy dispatch.
+  it('destroy during a pending settle timer clears it — no post-destroy render dispatch, no crash', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, engine } = setup();
+      const dispatchesBefore = engine.renderCalls.length;
+      v.setScale(v.scaleForTest() * 2); // schedules a settle timer
+      v.destroy(); // must clear the pending timer
+      vi.advanceTimersByTime(500); // fire any surviving timer
+      // No settle render dispatched after destroy.
+      expect(engine.renderCalls.length).toBe(dispatchesBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('destroy during an in-flight settle render does not swap or fire onError post-destroy', () => {
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    try {
+      const { v, scrollHost, engine } = setup(20, { onError }, 'main', true);
+      for (const c of engine.renderCalls.slice()) c.resolve();
+      const slot = slotAtTop(scrollHost, '0px')!;
+      const onScreenCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+      v.setScale(v.scaleForTest() * 2);
+      vi.advanceTimersByTime(200);
+      const settleCall = engine.renderCalls.filter((c) => c.page === 0).pop()!;
+      v.destroy(); // tear down while the settle render is in flight
+      settleCall.resolve();
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          // No crash, no error surfaced after teardown, and the (now detached)
+          // wrapper never received a swapped spare.
+          expect(onError).not.toHaveBeenCalled();
+          expect(slot.children).toContain(onScreenCanvas);
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('settle clears the preview transform on the text layer (overlay rebuilt at full resolution)', async () => {
+    vi.useFakeTimers();
+    const { v, scrollHost, engine } = setup(20, { enableTextSelection: true }, 'main', true);
+    engine.feedTextRuns = [{ text: 'Hi', x: 1, y: 2, w: 10, h: 12, fontSize: 12, font: '12px serif' }];
+    for (const c of engine.renderCalls.slice()) c.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const textLayer = slot.children.find((k) => k.tag === 'div') as FakeEl;
+
+    v.setScale(v.scaleForTest() * 2);
+    expect(textLayer.style.transform).toBe('scale(2)'); // preview transform applied
+    vi.advanceTimersByTime(200);
+    const settleCall = engine.renderCalls.filter((c) => c.page === 0).pop()!;
+    settleCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // After settle, the preview transform is cleared (the overlay is rebuilt at the
+    // full resolution so it no longer needs the scale()).
+    expect(textLayer.style.transform).toBe('');
+    vi.useRealTimers();
+    v.destroy();
+  });
+});
+
 describe('DocxScrollViewer — barrel export (T7)', () => {
   it('is exported from the package entry', () => {
     expect(typeof docxIndex.DocxScrollViewer).toBe('function');

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -21,6 +21,14 @@ import type { RenderPageOptions } from './types';
 const ZOOM_SETTLE_MS = 150;
 
 /**
+ * Default CSS `box-shadow` painted on every page canvas — the soft drop shadow a
+ * PDF reader casts under each sheet (matches the Examples/recipe look, which the
+ * scroll viewer now reproduces with zero config). See
+ * {@link DocxScrollViewerOptions.pageShadow}.
+ */
+const DEFAULT_PAGE_SHADOW = '0 1px 3px rgba(0,0,0,0.2)';
+
+/**
  * Options for {@link DocxScrollViewer}. Extends `RenderPageOptions` (per-page
  * render knobs, minus `onTextRun`) and `LoadOptions` (parse/worker knobs). See
  * design §8.1.
@@ -77,6 +85,21 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
    * background shows through (non-breaking).
    */
   background?: string;
+  /**
+   * CSS `box-shadow` painted on every page CANVAS (not the wrapper — the
+   * text-selection overlay must not cast its own shadow). The soft drop shadow a
+   * PDF reader leaves under each sheet.
+   *
+   * - Default (`undefined`): `'0 1px 3px rgba(0,0,0,0.2)'` — the recipe look, so
+   *   the scroll viewer reproduces the Examples appearance with zero config.
+   * - `false`: NO shadow (flat pages).
+   * - A custom string is applied verbatim. A spread-only ring such as
+   *   `'0 0 0 1px #c8ccd0'` gives a crisp 1px BORDER look — and because
+   *   `box-shadow` never affects layout (unlike `border`, which would grow the
+   *   box and shift every offset), a border and a drop shadow are the SAME knob
+   *   here rather than two competing options.
+   */
+  pageShadow?: string | false;
   /**
    * Inject an already-loaded engine to share one parse across panes (design §14).
    * When set: `load()` is unsupported (throws), the engine's own `mode` wins (an
@@ -203,10 +226,21 @@ export class DocxScrollViewer {
    *  skip the re-fit when only the height changed (a ResizeObserver fires on ANY
    *  box change, but only a WIDTH change alters the fit-to-width base scale). */
   private _lastFitWidth = 0;
+  /** Resolved page-canvas `box-shadow` (design: the recipe drop shadow by
+   *  default). Resolved ONCE with `??` — NOT `||` — so `pageShadow: false`
+   *  survives as the "no shadow" sentinel (a `||` would treat `false` as absent
+   *  and wrongly re-apply the default). Applied by `_applyPageShadow` at EVERY
+   *  canvas-creation site (`_acquireSlot` and the double-buffer spare in
+   *  `_settleSlot`) so a recycled/re-mounted slot and a settle-swapped spare all
+   *  carry it. */
+  private readonly _pageShadow: string | false;
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
     this._container = container;
     this._opts = opts;
+    // `??` (not `||`): a caller's explicit `false` must disable the shadow, not
+    // fall through to the default.
+    this._pageShadow = opts.pageShadow ?? DEFAULT_PAGE_SHADOW;
     this._injected = !!opts.document;
     if (this._injected) {
       const engine = opts.document as DocxDocument;
@@ -491,6 +525,16 @@ export class DocxScrollViewer {
     }
   }
 
+  /** Apply the resolved page-canvas shadow (design: recipe drop shadow by
+   *  default, `false` ⇒ none). Single source so `_acquireSlot` and the
+   *  double-buffer spare in `_settleSlot` stay in lock-step — a spare that missed
+   *  this would lose the shadow on the settle swap. `box-shadow` never affects
+   *  layout, so this is safe to (re)set on a live/pooled canvas without shifting
+   *  any offset. */
+  private _applyPageShadow(canvas: HTMLCanvasElement): void {
+    if (this._pageShadow !== false) canvas.style.boxShadow = this._pageShadow;
+  }
+
   private _acquireSlot(): PageSlot {
     const reused = this._free.pop();
     if (reused) {
@@ -505,6 +549,7 @@ export class DocxScrollViewer {
     wrapper.style.cssText = 'position:absolute;';
     const canvas = document.createElement('canvas');
     canvas.style.cssText = 'display:block;background:#fff;';
+    this._applyPageShadow(canvas);
     wrapper.appendChild(canvas);
     let textLayer: HTMLDivElement | null = null;
     if (this._opts.enableTextSelection) {
@@ -984,9 +1029,12 @@ export class DocxScrollViewer {
       return;
     }
 
-    // Main mode: double-buffer. Render into a spare canvas kept off-DOM.
+    // Main mode: double-buffer. Render into a spare canvas kept off-DOM. The
+    // spare REPLACES the on-screen canvas on swap, so it must carry the page
+    // shadow too — otherwise a settle would silently drop it.
     const spare = document.createElement('canvas');
     spare.style.cssText = 'display:block;background:#fff;';
+    this._applyPageShadow(spare);
     const runs: DocxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
     const onTextRun = wantOverlay ? (r: DocxTextRunInfo) => runs.push(r) : undefined;

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -986,9 +986,12 @@ export class DocxScrollViewer {
 
   /** Full-resolution settle re-render of the visible window (design §7 mechanisms
    *  2+3). Re-renders each mounted slot at the current scale via the double-buffer
-   *  swap (main) / same-canvas transfer (worker), then clears the preview
-   *  transform on its overlay. Dispatched at the CURRENT epoch; the existing epoch
-   *  gate discards it if a later `setScale` supersedes it mid-render. */
+   *  swap (main) / same-canvas transfer (worker). Main mode also rebuilds the text
+   *  overlay and clears its preview transform; in worker mode the overlay is
+   *  permanently empty (text selection is main-mode-only), so the transform is
+   *  inert there and is reset on recycle. Dispatched at the CURRENT epoch; the
+   *  existing epoch gate discards it if a later `setScale` supersedes it
+   *  mid-render. */
   private _settleRender(): void {
     if (this._destroyed || !this._doc || this._doc.pageCount === 0) return;
     for (const [i, slot] of [...this._slots]) {
@@ -1013,9 +1016,9 @@ export class DocxScrollViewer {
    * `canvas.width = …` (which CLEARS the backing store to blank) BEFORE its first
    * await and paints AFTER — so rendering into the on-screen canvas would flash it
    * white. Render into a SPARE off-DOM canvas instead; only once it resolves at the
-   * current epoch do we swap it into the wrapper (replacing the old canvas, which
-   * returns to a fresh-context pool). The old canvas keeps showing the stretched
-   * preview until the instant of the swap — blank-free.
+   * current epoch do we swap it into the wrapper (replacing the old canvas, which is
+   * DISCARDED — the pooled unit is the slot, not the canvas). The old canvas keeps
+   * showing the stretched preview until the instant of the swap — blank-free.
    */
   private _settleSlot(i: number, slot: PageSlot): void {
     if (!this._doc) return;

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -6,6 +6,21 @@ import { buildDocxTextLayer } from './text-layer';
 import type { RenderPageOptions } from './types';
 
 /**
+ * Debounce window (ms) after the last `setScale` in a zoom burst before the
+ * full-resolution settle re-render is dispatched (design §7 "Flicker-free zoom").
+ *
+ * This is a UI-INTERACTION-FEEL policy constant, NOT an ECMA-376 / ISO-29500
+ * value: it exists only so a rapid wheel/pinch gesture (which fires dozens of
+ * `setScale` calls) coalesces into a single high-res render at the end instead of
+ * re-rendering per tick. Each `setScale` shows an immediate CSS preview (the
+ * existing bitmap stretched) and resets this timer; the settle fires once the
+ * gesture pauses for `ZOOM_SETTLE_MS`. Lower = snappier but more redundant renders
+ * mid-gesture; higher = fewer renders but a longer soft-preview tail. Deliberately
+ * duplicated per viewer (a one-line timing constant, not shared logic).
+ */
+const ZOOM_SETTLE_MS = 150;
+
+/**
  * Options for {@link DocxScrollViewer}. Extends `RenderPageOptions` (per-page
  * render knobs, minus `onTextRun`) and `LoadOptions` (parse/worker knobs). See
  * design §8.1.
@@ -91,6 +106,12 @@ interface PageSlot {
   textLayer: HTMLDivElement | null;
   /** page index this slot is currently rendering / has rendered, or -1 when free. */
   renderedPage: number;
+  /** The `_scale` at which this slot's on-screen canvas bitmap (and text overlay)
+   *  were last rendered, or -1 when unrendered. The flicker-free CSS preview
+   *  (design §7) stretches that bitmap to the new layout size on `setScale` and
+   *  scales the text overlay by `newScale / renderedScale`; the debounced settle
+   *  re-render then repaints at the new scale and updates this to match. */
+  renderedScale: number;
   /** worker-mode: a transient hold on a just-received ImageBitmap, set only
    *  between receipt from the worker and its `transferFromImageBitmap` (which
    *  consumes it, after which we null the field). Its purpose is the throw path:
@@ -159,6 +180,12 @@ export class DocxScrollViewer {
    *  bitmap + re-dispatch the live slot. Main path: skip the (stale) text-layer
    *  build; the engine's per-canvas token already discards the stale pixels. */
   private _renderEpoch = 0;
+  /** Pending settle-render timer handle (design §7 mechanism 2). Set by
+   *  `_scheduleSettle` after each `setScale`, reset on the next one so a burst
+   *  dispatches ONE settle at the end, and cleared in `destroy()`. `ReturnType`
+   *  of `setTimeout` (a number in the DOM, a Timeout object in node) so the type
+   *  is host-agnostic. */
+  private _settleTimer: ReturnType<typeof setTimeout> | null = null;
   private _wheelListener: ((e: WheelEvent) => void) | null = null;
   /** One-shot latch for the worker-mode text-selection warning. The overlay is a
    *  main-mode-only feature: in worker mode the per-run `onTextRun` geometry
@@ -488,7 +515,15 @@ export class DocxScrollViewer {
       wrapper.appendChild(textLayer);
     }
     this._scrollHost.appendChild(wrapper);
-    const slot: PageSlot = { wrapper, canvas, textLayer, renderedPage: -1, bitmap: null, bitmapCtx: null };
+    const slot: PageSlot = {
+      wrapper,
+      canvas,
+      textLayer,
+      renderedPage: -1,
+      renderedScale: -1,
+      bitmap: null,
+      bitmapCtx: null,
+    };
     return slot;
   }
 
@@ -503,8 +538,15 @@ export class DocxScrollViewer {
     // stale spans. buildDocxTextLayer also clears on its next build, but an
     // unrendered pooled slot never gets that build, and the detached spans would
     // otherwise linger; drop them here.
-    if (slot.textLayer) slot.textLayer.innerHTML = '';
+    if (slot.textLayer) {
+      slot.textLayer.innerHTML = '';
+      // Drop any preview transform so a pooled slot re-used for another page does
+      // not inherit a stale scale() before its overlay is rebuilt.
+      slot.textLayer.style.transform = '';
+      slot.textLayer.style.transformOrigin = '';
+    }
     slot.renderedPage = -1;
+    slot.renderedScale = -1;
     slot.wrapper.remove();
     this._free.push(slot);
   }
@@ -563,9 +605,10 @@ export class DocxScrollViewer {
     const dpr = this._dpr();
     const widthPx = this._pageWidthPx(i);
     const epoch = this._renderEpoch;
+    const scale = this._scale;
 
     if (this._mode === 'worker') {
-      void this._renderSlotBitmap(i, slot, widthPx, dpr);
+      void this._renderSlotBitmap(i, slot, widthPx, dpr, scale);
       return;
     }
 
@@ -587,6 +630,9 @@ export class DocxScrollViewer {
         // different page / freed it. Either way: skip the (stale) overlay build.
         // The engine's per-canvas token already discards the superseded pixels.
         if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedPage !== i) return;
+        // This fresh render defines the scale the on-screen bitmap now lives at,
+        // so a subsequent zoom preview stretches from HERE.
+        slot.renderedScale = scale;
         if (wantOverlay && slot.textLayer) {
           buildDocxTextLayer(
             slot.textLayer,
@@ -642,7 +688,13 @@ export class DocxScrollViewer {
    *    happened mid-flight). A moved epoch ⇒ close the orphan + re-dispatch the
    *    live slot at the new scale, never paint the old-scale bitmap.
    */
-  private async _renderSlotBitmap(i: number, slot: PageSlot, widthPx: number, dpr: number): Promise<void> {
+  private async _renderSlotBitmap(
+    i: number,
+    slot: PageSlot,
+    widthPx: number,
+    dpr: number,
+    scale: number,
+  ): Promise<void> {
     // Worker-mode + enableTextSelection: the overlay can't be populated (onTextRun
     // doesn't cross the worker boundary), so warn once (parity with DocxViewer)
     // and leave the overlay empty. Fires before the coalescing guards so it is
@@ -696,6 +748,9 @@ export class DocxScrollViewer {
       slot.canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
       slot.bitmapCtx?.transferFromImageBitmap(bmp);
       slot.bitmap = null; // transfer consumed it
+      // This bitmap now defines the scale the on-screen canvas lives at, so a
+      // later zoom preview stretches from HERE (design §7 renderedScale).
+      slot.renderedScale = scale;
       painted = true;
     } catch (err) {
       this._reportRenderError(err);
@@ -730,7 +785,7 @@ export class DocxScrollViewer {
       ) {
         // live.renderedPage === i already (set by _renderSlot on mount); the fresh
         // dispatch runs at the CURRENT epoch/scale via _pageWidthPx(i).
-        void this._renderSlotBitmap(i, live, this._pageWidthPx(i), this._dpr());
+        void this._renderSlotBitmap(i, live, this._pageWidthPx(i), this._dpr(), this._scale);
       }
     }
   }
@@ -741,6 +796,11 @@ export class DocxScrollViewer {
    * multiples of the base fit; design §3 keeps the clamp in the viewer, not core),
    * then re-anchor VERTICALLY so the page currently under the viewport top stays
    * fixed. A no-op when nothing is loaded or when the clamped scale is unchanged.
+   *
+   * FLICKER-FREE (design §7): this does NOT re-render the visible pages inline.
+   * It shows an immediate CSS preview (stretch the existing bitmaps, scale the
+   * overlays) and DEBOUNCES a full-resolution settle re-render for ZOOM_SETTLE_MS,
+   * so a wheel/pinch burst never blanks a page and coalesces into one crisp render.
    *
    * Re-anchor (written from scratch — XlsxViewer only re-anchors horizontally):
    * capture `top = topIndex` and the intra-page fraction `intraFrac` from the
@@ -797,19 +857,181 @@ export class DocxScrollViewer {
     const wantTop = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
     this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, wantTop));
 
-    // Re-mount at the new geometry, forcing a re-render of every slot (its px
-    // size changed under the new scale, so the cached canvas is stale).
-    this._mountVisibleForceRerender();
+    // FLICKER-FREE ZOOM (design §7). Do NOT recycle + re-render in-window slots
+    // (that blanks each visible page to white every tick). Instead:
+    //  1. CSS-PREVIEW the currently-mounted slots at the new geometry — reposition
+    //     the wrapper, stretch the existing canvas bitmap via style.width/height
+    //     (soft but never blank), and scale the text overlay by the ratio between
+    //     the new scale and the scale the overlay was built at.
+    //  2. DEBOUNCE a full-resolution settle re-render: schedule it ZOOM_SETTLE_MS
+    //     after the LAST setScale so a wheel/pinch burst coalesces into one render.
+    this._previewVisible();
+    this._scheduleSettle();
   }
 
-  /** Like `_mountVisible` but recycles every live slot first so each re-mounts and
-   *  re-renders at the current scale. Used by `setScale` (and the resize re-fit
-   *  in `_onResize`, which routes through `setScale`): a slot's canvas px size
-   *  changes with the scale, so the previously
-   *  drawn pixels are stale and every visible page must be redrawn. */
-  private _mountVisibleForceRerender(): void {
-    for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
-    this._mountVisible();
+  /**
+   * CSS preview of the visible window at the current `_scale` (design §7
+   * mechanism 1), WITHOUT re-rendering. Slots leaving the window recycle normally;
+   * slots ENTERING the window mount fresh (rendered at the current scale directly,
+   * so they never need a preview); slots that STAY are repositioned and their
+   * canvas + text overlay are CSS-transformed to the new size (the device buffer
+   * is untouched — that is the whole point: no synchronous clear, no blank frame).
+   */
+  private _previewVisible(): void {
+    if (!this._doc || this._doc.pageCount === 0) return;
+    const r = this._range();
+    this._lastRange = r;
+
+    // Recycle slots that left [start, end].
+    for (const [idx, slot] of [...this._slots]) {
+      if (idx < r.start || idx > r.end) this._recycleSlot(idx, slot);
+    }
+    // For every index in the window: mount fresh if missing (renders at the current
+    // scale), or CSS-preview if already mounted (no re-render, no device resize).
+    for (let i = r.start; i <= r.end; i++) {
+      const existing = this._slots.get(i);
+      if (!existing) {
+        const slot = this._acquireSlot();
+        this._positionSlot(slot, i, r);
+        this._slots.set(i, slot);
+        this._renderSlot(i, slot);
+      } else {
+        this._previewSlot(existing, i, r);
+      }
+    }
+    // Fire onVisiblePageChange only when the top page actually changed.
+    if (r.topIndex !== this._lastTopIndex) {
+      this._lastTopIndex = r.topIndex;
+      this._opts.onVisiblePageChange?.(r.topIndex, this._doc.pageCount);
+    }
+  }
+
+  /**
+   * CSS-preview a single already-mounted slot at the new geometry (design §7): the
+   * wrapper is repositioned + sized (via `_positionSlot`), the canvas bitmap is
+   * STRETCHED to the new CSS size (no `canvas.width` — the device buffer, and thus
+   * the drawn pixels, are left intact, just scaled by the browser), and the text
+   * overlay is scaled by `newScale / renderedScale` so it tracks the stretched
+   * page. `renderedScale <= 0` means the slot's first render hasn't resolved yet
+   * (nothing to stretch); the pending render captured the current scale, so it
+   * lands correct and no preview is needed.
+   */
+  private _previewSlot(slot: PageSlot, i: number, r: VisibleRange): void {
+    this._positionSlot(slot, i, r);
+    // Stretch the existing bitmap to the new CSS box (device buffer untouched).
+    slot.canvas.style.width = `${this._pageWidthPx(i)}px`;
+    slot.canvas.style.height = `${this._pageHeightPx(i)}px`;
+    if (slot.textLayer && slot.renderedScale > 0) {
+      const ratio = this._scale / slot.renderedScale;
+      slot.textLayer.style.transformOrigin = '0 0';
+      slot.textLayer.style.transform = `scale(${ratio})`;
+    }
+  }
+
+  /** (Re)schedule the debounced settle re-render (design §7 mechanism 2). Resets
+   *  the timer on every call so a burst of `setScale` dispatches ONE settle
+   *  ZOOM_SETTLE_MS after the LAST call. Cleared in `destroy()`. */
+  private _scheduleSettle(): void {
+    if (this._settleTimer !== null) clearTimeout(this._settleTimer);
+    this._settleTimer = setTimeout(() => {
+      this._settleTimer = null;
+      this._settleRender();
+    }, ZOOM_SETTLE_MS);
+  }
+
+  /** Full-resolution settle re-render of the visible window (design §7 mechanisms
+   *  2+3). Re-renders each mounted slot at the current scale via the double-buffer
+   *  swap (main) / same-canvas transfer (worker), then clears the preview
+   *  transform on its overlay. Dispatched at the CURRENT epoch; the existing epoch
+   *  gate discards it if a later `setScale` supersedes it mid-render. */
+  private _settleRender(): void {
+    if (this._destroyed || !this._doc || this._doc.pageCount === 0) return;
+    for (const [i, slot] of [...this._slots]) {
+      // Skip slots already at the current scale (a slot that entered the window
+      // during the burst mounted fresh at the current scale — nothing to settle).
+      if (slot.renderedScale === this._scale) continue;
+      this._settleSlot(i, slot);
+    }
+  }
+
+  /**
+   * Settle-render one slot at the current scale (design §7 mechanism 3).
+   *
+   * WORKER: re-dispatch the bitmap render into the SAME canvas. The worker path
+   * sizes the device buffer and `transferFromImageBitmap`s it in ONE synchronous
+   * step (no await between `canvas.width = …` and the transfer), so the browser
+   * never composites an intermediate blank frame — no spare canvas is needed. The
+   * `renderedScale === _scale` gate in `_settleRender` plus the epoch gate inside
+   * `_renderSlotBitmap` keep this correct and idempotent.
+   *
+   * MAIN: `renderPage` (via renderDocumentToCanvas) synchronously sets
+   * `canvas.width = …` (which CLEARS the backing store to blank) BEFORE its first
+   * await and paints AFTER — so rendering into the on-screen canvas would flash it
+   * white. Render into a SPARE off-DOM canvas instead; only once it resolves at the
+   * current epoch do we swap it into the wrapper (replacing the old canvas, which
+   * returns to a fresh-context pool). The old canvas keeps showing the stretched
+   * preview until the instant of the swap — blank-free.
+   */
+  private _settleSlot(i: number, slot: PageSlot): void {
+    if (!this._doc) return;
+    const dpr = this._dpr();
+    const widthPx = this._pageWidthPx(i);
+    const scale = this._scale;
+    const epoch = this._renderEpoch;
+
+    if (this._mode === 'worker') {
+      void this._renderSlotBitmap(i, slot, widthPx, dpr, scale);
+      return;
+    }
+
+    // Main mode: double-buffer. Render into a spare canvas kept off-DOM.
+    const spare = document.createElement('canvas');
+    spare.style.cssText = 'display:block;background:#fff;';
+    const runs: DocxTextRunInfo[] = [];
+    const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const onTextRun = wantOverlay ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
+    this._doc
+      .renderPage(spare, i, {
+        width: widthPx,
+        dpr,
+        defaultTextColor: this._opts.defaultTextColor,
+        showTrackChanges: this._opts.showTrackChanges,
+        onTextRun,
+      })
+      .then(() => {
+        // Discard if superseded: a later setScale bumped the epoch (this spare is
+        // at a stale scale), or the slot recycled / moved to another page. Drop
+        // the spare (it is off-DOM, so GC reclaims it) and do NOT swap.
+        if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedPage !== i) return;
+        // Swap the freshly-painted spare in for the old (stretched-preview) canvas.
+        // The old canvas was the only child that showed content; replacing it in
+        // one DOM op means the screen goes from preview → crisp with no blank tick.
+        const old = slot.canvas;
+        slot.wrapper.insertBefore(spare, old);
+        old.remove();
+        slot.canvas = spare;
+        // The retired canvas held a 2d context; keep the pool clean by dropping any
+        // bitmaprenderer handle association (main-mode canvases never had one).
+        slot.bitmapCtx = null;
+        slot.renderedScale = scale;
+        // Rebuild the overlay at the full resolution and CLEAR the preview
+        // transform (the crisp render no longer needs the scale()).
+        if (slot.textLayer) {
+          slot.textLayer.style.transform = '';
+          slot.textLayer.style.transformOrigin = '';
+          if (wantOverlay) {
+            buildDocxTextLayer(
+              slot.textLayer,
+              runs,
+              spare.style.width || `${spare.width}px`,
+              spare.style.height || `${spare.height}px`,
+            );
+          }
+        }
+      })
+      .catch((err: unknown) => {
+        this._reportRenderError(err);
+      });
   }
 
   /**
@@ -874,12 +1096,14 @@ export class DocxScrollViewer {
    *   mult      = _scale / _prevBase            (the user's zoom over the old base)
    *   newScale  = newBase × mult
    * Routing through `setScale(newScale)` bumps `_renderEpoch` (resize IS an epoch
-   * event — T4 banner) and re-anchors + force-re-renders every slot at the new
-   * geometry, exactly like a zoom. `setScale`'s clamp/no-op guards apply: an
-   * unchanged newScale (identical width) is a no-op there — so we short-circuit
-   * BEFORE it when the fit-width is unchanged (mounting the revealed window without
-   * a needless force-re-render), and after it we call `_mountVisible` again to cover
-   * the case where the clamp made `setScale` no-op yet the viewport still grew.
+   * event — T4 banner) and re-anchors + CSS-previews + debounces a settle re-render
+   * of every slot at the new geometry, exactly like a zoom (design §7 flicker-free
+   * path — a rapid ResizeObserver burst therefore also coalesces into one settle).
+   * `setScale`'s clamp/no-op guards apply: an unchanged newScale (identical width)
+   * is a no-op there — so we short-circuit BEFORE it when the fit-width is
+   * unchanged (mounting the revealed window without a needless re-render), and
+   * after it we call `_mountVisible` again to cover the case where the clamp made
+   * `setScale` no-op yet the viewport still grew.
    */
   private _onResize(): void {
     if (!this._doc || this._doc.pageCount === 0) return;
@@ -921,10 +1145,10 @@ export class DocxScrollViewer {
     // of using absolute bounds (§8.1) with an unclamped relayout base.
     this.setScale(newBase * mult);
     // `setScale` no-ops when the clamped scale is unchanged (e.g. already pinned at
-    // a clamp boundary), which would skip its `_mountVisibleForceRerender`. A
-    // width+height growth that ends up clamped to the same scale must still reveal
-    // the taller viewport's rows, so mount here too. Idempotent when `setScale` ran:
-    // the window is already mounted and every present slot is a re-position no-op.
+    // a clamp boundary), which would skip its preview + settle. A width+height
+    // growth that ends up clamped to the same scale must still reveal the taller
+    // viewport's rows, so mount here too. Idempotent when `setScale` ran: the
+    // window is already mounted and every present slot is a re-position no-op.
     this._mountVisible();
   }
 
@@ -975,6 +1199,14 @@ export class DocxScrollViewer {
     }
     this._resizeObserver?.disconnect();
     this._resizeObserver = null;
+    // Cancel a pending settle so no re-render is dispatched after teardown
+    // (design §7 mechanism 2). `_destroyed` also guards `_settleRender`, but
+    // clearing the timer avoids the wasted wake-up and keeps fake-timer tests
+    // deterministic.
+    if (this._settleTimer !== null) {
+      clearTimeout(this._settleTimer);
+      this._settleTimer = null;
+    }
     for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
     this._free.length = 0;
     if (!this._injected) {

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -21,6 +21,14 @@ export interface FakeEl {
   clientWidth: number;
   _listeners: Map<string, Array<(e: unknown) => void>>;
   _bitmapCtx?: { transferFromImageBitmap: (b: unknown) => void; lastBitmap: unknown };
+  /** Records every DEVICE-BUFFER resize (a `canvas.width`/`canvas.height`
+   *  assignment). The flicker-free CSS-preview path must NOT touch the device
+   *  buffer of an in-window slot (it only CSS-resizes via `style.width/height`),
+   *  so a preview leaves this array untouched; a settle/mount render appends. */
+  _deviceResizes: Array<{ prop: 'width' | 'height'; value: number }>;
+  /** Monotonic id assigned at creation, so tests can order operations and tell a
+   *  freshly-created spare canvas from the on-screen one it replaces. */
+  _uid: number;
   appendChild(c: FakeEl): FakeEl;
   removeChild(c: FakeEl): FakeEl;
   remove(): void;
@@ -32,6 +40,8 @@ export interface FakeEl {
   /** test-only: fire a recorded listener */
   dispatch(type: string, event?: unknown): void;
 }
+
+let _uidSeq = 0;
 
 export function makeEl(tag: string): FakeEl {
   const style: Record<string, string> = {};
@@ -47,6 +57,8 @@ export function makeEl(tag: string): FakeEl {
     children: [],
     parentElement: null,
     _listeners: new Map(),
+    _deviceResizes: [],
+    _uid: _uidSeq++,
     style: new Proxy(style as Record<string, string> & { cssText: string }, {
       set(target, prop: string, value: string) {
         if (prop === 'cssText') {
@@ -134,6 +146,37 @@ export function makeEl(tag: string): FakeEl {
     enumerable: true,
     configurable: true,
   });
+  // Record device-buffer resizes. A real canvas.width/height assignment resizes
+  // (and CLEARS) the backing store; the flicker-free preview path must never do
+  // this to an on-screen slot (it CSS-resizes instead). Making width/height
+  // recording accessors lets the preview tests assert "no device-buffer resize
+  // happened during the CSS preview" (test a). The value is still stored so the
+  // worker transfer path (`canvas.width = bmp.width`) and the main renderSlide
+  // backing-store sizing read back correctly.
+  let _w = 0;
+  let _h = 0;
+  Object.defineProperty(el, 'width', {
+    get() {
+      return _w;
+    },
+    set(value: number) {
+      _w = value;
+      el._deviceResizes.push({ prop: 'width', value });
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(el, 'height', {
+    get() {
+      return _h;
+    },
+    set(value: number) {
+      _h = value;
+      el._deviceResizes.push({ prop: 'height', value });
+    },
+    enumerable: true,
+    configurable: true,
+  });
   return el;
 }
 
@@ -172,6 +215,10 @@ export interface RenderCall {
    *  §7). pptx slides are uniform, so every value equals the same px width, but
    *  the per-call contract still passes a width per slide. */
   width?: number;
+  /** The canvas element the viewer handed to `renderSlide` (main mode). The
+   *  flicker-free double-buffer settle renders into a SPARE canvas, so this lets
+   *  a test confirm the on-screen canvas was NOT the render target until swap. */
+  canvas?: FakeEl;
   resolve: () => void;
   reject: (e: Error) => void;
 }
@@ -208,13 +255,18 @@ export class FakePptxEngine {
     return this._mode;
   }
   renderSlide(_canvas: unknown, slide: number, opts?: RenderSlideOptions): Promise<void> {
+    const canvas = _canvas as FakeEl | undefined;
     // Mirror the real renderer's backing-store sizing so tests can exercise the
     // dpr≠1 path: the real PptxPresentation.renderSlide sets `canvas.width =
     // round(cssWidth × dpr)` (and height to keep the slide aspect). A retina (dpr 2)
     // render leaves canvas.width at 2× the CSS box — the overlay must NOT copy it.
-    if (this._mode === 'main' && opts?.width && opts.width > 0) {
+    // This ALSO mirrors the real renderer's SYNCHRONOUS device-buffer clear (the
+    // whole reason main-mode settle must double-buffer): setting canvas.width up
+    // front blanks the backing store, so a settle rendering into the ON-SCREEN
+    // canvas would flash white. The flicker-free path renders into a spare, so this
+    // recorded resize must land on the spare (test d).
+    if (this._mode === 'main' && canvas && opts?.width && opts.width > 0) {
       const dpr = opts.dpr ?? 1;
-      const canvas = _canvas as { width: number; height: number };
       canvas.width = Math.round(opts.width * dpr);
       canvas.height = this.slideWidth > 0 ? Math.round((canvas.width * this.slideHeight) / this.slideWidth) : 0;
     }
@@ -233,7 +285,7 @@ export class FakePptxEngine {
     // per-slot overlay (mirrors the real renderer emitting run geometry).
     for (const r of this.feedTextRuns ?? []) opts?.onTextRun?.(r);
     return new Promise<void>((resolve, reject) => {
-      const call: RenderCall = { slide, width: opts?.width, resolve: () => resolve(), reject };
+      const call: RenderCall = { slide, width: opts?.width, canvas, resolve: () => resolve(), reject };
       this.renderCalls.push(call);
       if (!this.deferred) resolve();
     });

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1999,6 +1999,128 @@ describe('PptxScrollViewer — flicker-free zoom (T8)', () => {
   });
 });
 
+describe('PptxScrollViewer — pageShadow (T9)', () => {
+  // pageShadow paints a CSS box-shadow on every slide CANVAS (not the wrapper).
+  // Default = the recipe drop shadow; `false` disables; a custom string is
+  // honoured verbatim. It must reach EVERY canvas: fresh mounts, the settle
+  // double-buffer SPARE, and recycled+re-mounted slots. Reuses the T8 setup
+  // (deferred engine + fake timers) for the spare-canvas case.
+  const DEFAULT_PAGE_SHADOW = '0 1px 3px rgba(0,0,0,0.2)';
+
+  function setup(opts = {}, mode: 'main' | 'worker' = 'main', deferred = false) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(20, SLIDE_W_EMU, SLIDE_H_EMU, mode, deferred);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+      overscan: 1,
+      zoomMin: 0.5,
+      zoomMax: 4,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, engine };
+  }
+
+  /** Every mounted slide canvas (each slot wrapper's canvas child). */
+  function mountedCanvases(scrollHost: FakeEl): FakeEl[] {
+    return scrollHost.children
+      .filter((c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas'))
+      .map((w) => w.children.find((k) => k.tag === 'canvas') as FakeEl);
+  }
+
+  it('applies the default recipe shadow to every mounted slide canvas', () => {
+    const { v, scrollHost } = setup();
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+    v.destroy();
+  });
+
+  it('pageShadow:false sets no box-shadow on the slide canvas', () => {
+    const { v, scrollHost } = setup({ pageShadow: false });
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe('');
+    v.destroy();
+  });
+
+  it('honours a custom pageShadow string verbatim (e.g. a spread-ring border look)', () => {
+    const ring = '0 0 0 1px #c8ccd0';
+    const { v, scrollHost } = setup({ pageShadow: ring });
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe(ring);
+    v.destroy();
+  });
+
+  it('does NOT paint the shadow on the wrapper (only the canvas)', () => {
+    const { v, scrollHost } = setup();
+    const wrapper = scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas'),
+    ) as FakeEl;
+    expect(wrapper.style.boxShadow).toBe('');
+    v.destroy();
+  });
+
+  it('the settle double-buffer SPARE canvas carries the shadow (swapped-in canvas keeps it)', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, scrollHost, engine } = setup({}, 'main', true);
+      // Resolve the initial mount renders so the on-screen canvases are painted.
+      for (const c of engine.renderCalls.slice()) c.resolve();
+
+      v.setScale(v.scaleForTest() * 2); // zoom → schedules a settle
+      vi.advanceTimersByTime(200); // past ZOOM_SETTLE_MS → settle dispatched
+
+      // The settle render for slide 0 targets a fresh SPARE canvas — it must
+      // already carry the shadow BEFORE the swap.
+      const settleCall = engine.renderCalls.filter((c) => c.slide === 0).pop()!;
+      const spare = settleCall.canvas as unknown as FakeEl;
+      expect(spare).toBeDefined();
+      expect(spare.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+
+      // Resolve → swap the spare in. The now-on-screen canvas still has the shadow.
+      settleCall.resolve();
+      const slot = scrollHost.children.find(
+        (c) => c.tag === 'div' && c.style.top === '0px' && c.children.some((k) => k.tag === 'canvas'),
+      ) as FakeEl;
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+          expect(nowCanvas._uid).toBe(spare._uid); // spare swapped in
+          expect(nowCanvas.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+          v.destroy();
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a recycled + re-mounted slot still carries the shadow', () => {
+    const { v, scrollHost } = setup();
+    // Scroll far down so slide 0's slot recycles into the free pool, then back to
+    // the top so a POOLED slot is re-mounted for slide 0.
+    scrollHost.scrollTop = 5000;
+    scrollHost.dispatch('scroll');
+    scrollHost.scrollTop = 0;
+    scrollHost.dispatch('scroll');
+    const canvases = mountedCanvases(scrollHost);
+    expect(canvases.length).toBeGreaterThan(0);
+    for (const c of canvases) expect(c.style.boxShadow).toBe(DEFAULT_PAGE_SHADOW);
+    v.destroy();
+  });
+});
+
 describe('PptxScrollViewer — barrel export (T7)', () => {
   it('is exported from the package entry', () => {
     expect(typeof pptxIndex.PptxScrollViewer).toBe('function');

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1713,6 +1713,292 @@ describe('PptxScrollViewer — paddingLeft/paddingRight (horizontal desk gutters
   });
 });
 
+describe('PptxScrollViewer — flicker-free zoom (T8)', () => {
+  // Flicker-free zoom (design §7): setScale must NOT blank a visible slide.
+  // Three mechanisms — CSS preview (immediate, no device-buffer resize / no
+  // recycle of in-window slots), settle re-render (debounced ZOOM_SETTLE_MS),
+  // double-buffer swap (main-mode settle renders into a SPARE off-DOM canvas and
+  // swaps it in). Container 200×400, natural slide 200×120px, flush pads ⇒ base
+  // 1.0, slide height px 120.
+  function setup(slideCount = 20, opts = {}, mode: 'main' | 'worker' = 'main', deferred = false) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(slideCount, SLIDE_W_EMU, SLIDE_H_EMU, mode, deferred);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+      overscan: 1,
+      zoomMin: 0.5,
+      zoomMax: 4,
+      ...opts,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    v.relayout();
+    return { v, scrollHost, engine, container };
+  }
+
+  /** The wrapper mounted for the slide currently at top:`top`px. */
+  function slotAtTop(scrollHost: FakeEl, top: string): FakeEl | undefined {
+    return scrollHost.children.find(
+      (c) => c.tag === 'div' && c.children.some((k) => k.tag === 'canvas') && c.style.top === top,
+    ) as FakeEl | undefined;
+  }
+
+  // (a) setScale does NOT unmount in-window slots (same wrapper before/after) and
+  //     does NOT resize any on-screen canvas device buffer during the preview.
+  it('CSS preview: setScale keeps the SAME in-window slot wrappers and never resizes their device buffer', () => {
+    const { v, scrollHost } = setup();
+    const before = slotAtTop(scrollHost, '0px');
+    expect(before).toBeDefined();
+    const beforeCanvas = before!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    const resizesBefore = beforeCanvas._deviceResizes.length;
+
+    v.setScale(v.scaleForTest() * 2); // zoom in
+
+    const after = slotAtTop(scrollHost, '0px');
+    expect(after).toBe(before); // same wrapper (not recycled + re-mounted)
+    const afterCanvas = after!.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(afterCanvas).toBe(beforeCanvas); // same canvas element
+    expect(afterCanvas._deviceResizes.length).toBe(resizesBefore); // no device resize
+    v.destroy();
+  });
+
+  it('CSS preview: setScale CSS-resizes the slot canvas (style.width/height) to the new layout size immediately', () => {
+    const { v, scrollHost } = setup();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const canvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+    // base 1.0 ⇒ slide px 200×120. Zoom ×2 ⇒ CSS 400×240.
+    v.setScale(v.scaleForTest() * 2);
+    expect(canvas.style.width).toBe('400px');
+    expect(canvas.style.height).toBe('240px');
+    v.destroy();
+  });
+
+  it('CSS preview: text layer gets a transform: scale(ratio) matching newScale / renderedScale', async () => {
+    const { v, scrollHost, engine } = setup(20, { enableTextSelection: true });
+    engine.feedTextRuns = [
+      {
+        text: 'Hi',
+        inShapeX: 1,
+        inShapeY: 2,
+        w: 10,
+        h: 12,
+        fontSize: 12,
+        font: '12px serif',
+        shapeX: 0,
+        shapeY: 0,
+        shapeW: 100,
+        shapeH: 40,
+        rotation: 0,
+      },
+    ];
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const textLayer = slot.children.find((k) => k.tag === 'div') as FakeEl;
+    // Zoom ×2 — overlay built at base 1.0; preview scales by newScale/renderedScale
+    // = 2.0/1.0 = 2.
+    v.setScale(v.scaleForTest() * 2);
+    expect(textLayer.style.transform).toBe('scale(2)');
+    expect(textLayer.style.transformOrigin).toBe('0 0');
+    v.destroy();
+  });
+
+  // (c) NO render dispatch during a burst; ONE dispatch after ZOOM_SETTLE_MS.
+  it('debounce: a burst of setScale calls dispatches NO settle render until ZOOM_SETTLE_MS elapses, then exactly one per slot', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, engine } = setup();
+      const dispatchesBefore = engine.renderCalls.length;
+      v.setScale(v.scaleForTest() * 1.1);
+      vi.advanceTimersByTime(50);
+      v.setScale(v.scaleForTest() * 1.1);
+      vi.advanceTimersByTime(50);
+      v.setScale(v.scaleForTest() * 1.1);
+      vi.advanceTimersByTime(50); // timer reset each tick — still inside window
+      expect(engine.renderCalls.length).toBe(dispatchesBefore);
+      vi.advanceTimersByTime(150); // past the settle timeout from the LAST setScale
+      const mounted = v.mountedSlideIndicesForTest();
+      const settleRenders = engine.renderCalls.length - dispatchesBefore;
+      expect(settleRenders).toBe(mounted.length);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // (d) settle resolution swaps the canvas without a blank (main mode double-buffer).
+  it('double-buffer (main): settle renders into a SPARE canvas and swaps it in — the on-screen canvas is never device-resized in place', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, scrollHost, engine } = setup(20, {}, 'main', true);
+      for (const c of engine.renderCalls.slice()) c.resolve();
+      const slot = slotAtTop(scrollHost, '0px')!;
+      const onScreenCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+      const onScreenUid = onScreenCanvas._uid;
+      const resizesOnScreenBefore = onScreenCanvas._deviceResizes.length;
+
+      v.setScale(v.scaleForTest() * 2);
+      vi.advanceTimersByTime(200);
+
+      const settleCall = engine.renderCalls.filter((c) => c.slide === 0).pop()!;
+      expect(settleCall.canvas).toBeDefined();
+      expect(settleCall.canvas!._uid).not.toBe(onScreenUid); // rendered into a spare
+      expect(onScreenCanvas._deviceResizes.length).toBe(resizesOnScreenBefore); // not in-place
+      expect(slot.children).toContain(onScreenCanvas); // still attached (no swap yet)
+
+      settleCall.resolve();
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+          expect(nowCanvas._uid).toBe(settleCall.canvas!._uid); // spare swapped in
+          expect(slot.children).not.toContain(onScreenCanvas); // old retired
+          v.destroy();
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('double-buffer (worker): settle renders into the SAME canvas (sync resize+transfer paints no blank frame)', async () => {
+    vi.useFakeTimers();
+    const { v, scrollHost, engine } = setup(20, {}, 'worker', true);
+    for (const c of engine.bitmapCalls.slice()) c.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const canvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+    const canvasUid = canvas._uid;
+    const bitmapsBefore = engine.bitmapCalls.length;
+
+    v.setScale(v.scaleForTest() * 2);
+    vi.advanceTimersByTime(200);
+
+    expect(engine.bitmapCalls.length).toBeGreaterThan(bitmapsBefore);
+    const settleCall = engine.bitmapCalls.filter((c) => c.slide === 0).pop()!;
+    const settleBitmap = engine.createdBitmaps[engine.bitmapCalls.indexOf(settleCall)];
+    settleCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+    expect(nowCanvas._uid).toBe(canvasUid); // SAME canvas (worker keeps it)
+    expect(nowCanvas._bitmapCtx?.lastBitmap).toBe(settleBitmap);
+    vi.useRealTimers();
+    v.destroy();
+  });
+
+  // (e) stale settle discards per the epoch gate.
+  it('stale settle: an epoch bump during the settle render discards the settle (no swap, spare not attached)', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, scrollHost, engine } = setup(20, {}, 'main', true);
+      for (const c of engine.renderCalls.slice()) c.resolve();
+      const slot = slotAtTop(scrollHost, '0px')!;
+      const onScreenCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+
+      v.setScale(v.scaleForTest() * 2);
+      vi.advanceTimersByTime(200); // settle dispatched (deferred, in flight)
+      const settleCall = engine.renderCalls.filter((c) => c.slide === 0).pop()!;
+
+      v.setScale(v.scaleForTest() * 1.1); // bump epoch mid-settle-render
+
+      settleCall.resolve();
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          const nowCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+          expect(nowCanvas).toBe(onScreenCanvas); // stale spare NOT swapped in
+          expect(nowCanvas._uid).not.toBe(settleCall.canvas!._uid);
+          v.destroy();
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // (f) destroy during a pending settle timer / in-flight settle render.
+  it('destroy during a pending settle timer clears it — no post-destroy render dispatch, no crash', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, engine } = setup();
+      const dispatchesBefore = engine.renderCalls.length;
+      v.setScale(v.scaleForTest() * 2); // schedules a settle timer
+      v.destroy();
+      vi.advanceTimersByTime(500);
+      expect(engine.renderCalls.length).toBe(dispatchesBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('destroy during an in-flight settle render does not swap or fire onError post-destroy', () => {
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    try {
+      const { v, scrollHost, engine } = setup(20, { onError }, 'main', true);
+      for (const c of engine.renderCalls.slice()) c.resolve();
+      const slot = slotAtTop(scrollHost, '0px')!;
+      const onScreenCanvas = slot.children.find((k) => k.tag === 'canvas') as FakeEl;
+      v.setScale(v.scaleForTest() * 2);
+      vi.advanceTimersByTime(200);
+      const settleCall = engine.renderCalls.filter((c) => c.slide === 0).pop()!;
+      v.destroy();
+      settleCall.resolve();
+      return Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => {
+          expect(onError).not.toHaveBeenCalled();
+          expect(slot.children).toContain(onScreenCanvas);
+        });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('settle clears the preview transform on the text layer (overlay rebuilt at full resolution)', async () => {
+    vi.useFakeTimers();
+    const { v, scrollHost, engine } = setup(20, { enableTextSelection: true }, 'main', true);
+    engine.feedTextRuns = [
+      {
+        text: 'Hi',
+        inShapeX: 1,
+        inShapeY: 2,
+        w: 10,
+        h: 12,
+        fontSize: 12,
+        font: '12px serif',
+        shapeX: 0,
+        shapeY: 0,
+        shapeW: 100,
+        shapeH: 40,
+        rotation: 0,
+      },
+    ];
+    for (const c of engine.renderCalls.slice()) c.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const slot = slotAtTop(scrollHost, '0px')!;
+    const textLayer = slot.children.find((k) => k.tag === 'div') as FakeEl;
+
+    v.setScale(v.scaleForTest() * 2);
+    expect(textLayer.style.transform).toBe('scale(2)'); // preview transform applied
+    vi.advanceTimersByTime(200);
+    const settleCall = engine.renderCalls.filter((c) => c.slide === 0).pop()!;
+    settleCall.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(textLayer.style.transform).toBe(''); // cleared after the crisp render
+    vi.useRealTimers();
+    v.destroy();
+  });
+});
+
 describe('PptxScrollViewer — barrel export (T7)', () => {
   it('is exported from the package entry', () => {
     expect(typeof pptxIndex.PptxScrollViewer).toBe('function');

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -19,6 +19,14 @@ import { buildPptxTextLayer } from './text-layer';
 const ZOOM_SETTLE_MS = 150;
 
 /**
+ * Default CSS `box-shadow` painted on every slide canvas — the soft drop shadow a
+ * presentation viewer casts under each slide (matches the Examples/recipe look,
+ * which the scroll viewer now reproduces with zero config). See
+ * {@link PptxScrollViewerOptions.pageShadow}.
+ */
+const DEFAULT_PAGE_SHADOW = '0 1px 3px rgba(0,0,0,0.2)';
+
+/**
  * Options for {@link PptxScrollViewer}. Extends `RenderSlideOptions` (per-slide
  * render knobs, minus `onTextRun`) and `LoadOptions` (parse/worker knobs). See
  * design §8.2.
@@ -82,6 +90,21 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
    * background shows through (non-breaking).
    */
   background?: string;
+  /**
+   * CSS `box-shadow` painted on every slide CANVAS (not the wrapper — the
+   * text-selection overlay must not cast its own shadow). The soft drop shadow a
+   * presentation viewer leaves under each slide.
+   *
+   * - Default (`undefined`): `'0 1px 3px rgba(0,0,0,0.2)'` — the recipe look, so
+   *   the scroll viewer reproduces the Examples appearance with zero config.
+   * - `false`: NO shadow (flat slides).
+   * - A custom string is applied verbatim. A spread-only ring such as
+   *   `'0 0 0 1px #c8ccd0'` gives a crisp 1px BORDER look — and because
+   *   `box-shadow` never affects layout (unlike `border`, which would grow the
+   *   box and shift every offset), a border and a drop shadow are the SAME knob
+   *   here rather than two competing options.
+   */
+  pageShadow?: string | false;
   /**
    * Inject an already-loaded engine to share one parse across panes (design §14).
    * When set: `load()` is unsupported (throws), the engine's own `mode` wins (an
@@ -212,10 +235,21 @@ export class PptxScrollViewer {
    *  skip the re-fit when only the height changed (a ResizeObserver fires on ANY
    *  box change, but only a WIDTH change alters the fit-to-width base scale). */
   private _lastFitWidth = 0;
+  /** Resolved slide-canvas `box-shadow` (design: the recipe drop shadow by
+   *  default). Resolved ONCE with `??` — NOT `||` — so `pageShadow: false`
+   *  survives as the "no shadow" sentinel (a `||` would treat `false` as absent
+   *  and wrongly re-apply the default). Applied by `_applyPageShadow` at EVERY
+   *  canvas-creation site (`_acquireSlot` and the double-buffer spare in
+   *  `_settleSlot`) so a recycled/re-mounted slot and a settle-swapped spare all
+   *  carry it. */
+  private readonly _pageShadow: string | false;
 
   constructor(container: HTMLElement, opts: PptxScrollViewerOptions = {}) {
     this._container = container;
     this._opts = opts;
+    // `??` (not `||`): a caller's explicit `false` must disable the shadow, not
+    // fall through to the default.
+    this._pageShadow = opts.pageShadow ?? DEFAULT_PAGE_SHADOW;
     this._injected = !!opts.presentation;
     if (this._injected) {
       const engine = opts.presentation as PptxPresentation;
@@ -499,6 +533,16 @@ export class PptxScrollViewer {
     }
   }
 
+  /** Apply the resolved slide-canvas shadow (design: recipe drop shadow by
+   *  default, `false` ⇒ none). Single source so `_acquireSlot` and the
+   *  double-buffer spare in `_settleSlot` stay in lock-step — a spare that missed
+   *  this would lose the shadow on the settle swap. `box-shadow` never affects
+   *  layout, so this is safe to (re)set on a live/pooled canvas without shifting
+   *  any offset. */
+  private _applyPageShadow(canvas: HTMLCanvasElement): void {
+    if (this._pageShadow !== false) canvas.style.boxShadow = this._pageShadow;
+  }
+
   private _acquireSlot(): SlideSlot {
     const reused = this._free.pop();
     if (reused) {
@@ -513,6 +557,7 @@ export class PptxScrollViewer {
     wrapper.style.cssText = 'position:absolute;';
     const canvas = document.createElement('canvas');
     canvas.style.cssText = 'display:block;background:#fff;';
+    this._applyPageShadow(canvas);
     wrapper.appendChild(canvas);
     let textLayer: HTMLDivElement | null = null;
     if (this._opts.enableTextSelection) {
@@ -994,9 +1039,12 @@ export class PptxScrollViewer {
       return;
     }
 
-    // Main mode: double-buffer. Render into a spare canvas kept off-DOM.
+    // Main mode: double-buffer. Render into a spare canvas kept off-DOM. The
+    // spare REPLACES the on-screen canvas on swap, so it must carry the slide
+    // shadow too — otherwise a settle would silently drop it.
     const spare = document.createElement('canvas');
     spare.style.cssText = 'display:block;background:#fff;';
+    this._applyPageShadow(spare);
     const runs: PptxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
     const onTextRun = wantOverlay ? (r: PptxTextRunInfo) => runs.push(r) : undefined;

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -997,9 +997,12 @@ export class PptxScrollViewer {
 
   /** Full-resolution settle re-render of the visible window (design §7 mechanisms
    *  2+3). Re-renders each mounted slot at the current scale via the double-buffer
-   *  swap (main) / same-canvas transfer (worker), then clears the preview
-   *  transform on its overlay. Dispatched at the CURRENT epoch; the existing epoch
-   *  gate discards it if a later `setScale` supersedes it mid-render. */
+   *  swap (main) / same-canvas transfer (worker). Main mode also rebuilds the text
+   *  overlay and clears its preview transform; in worker mode the overlay is
+   *  permanently empty (text selection is main-mode-only), so the transform is
+   *  inert there and is reset on recycle. Dispatched at the CURRENT epoch; the
+   *  existing epoch gate discards it if a later `setScale` supersedes it
+   *  mid-render. */
   private _settleRender(): void {
     if (this._destroyed || !this._pres || this._pres.slideCount === 0) return;
     for (const [i, slot] of [...this._slots]) {

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -4,6 +4,21 @@ import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
 
 /**
+ * Debounce window (ms) after the last `setScale` in a zoom burst before the
+ * full-resolution settle re-render is dispatched (design §7 "Flicker-free zoom").
+ *
+ * This is a UI-INTERACTION-FEEL policy constant, NOT an ECMA-376 / ISO-29500
+ * value: it exists only so a rapid wheel/pinch gesture (which fires dozens of
+ * `setScale` calls) coalesces into a single high-res render at the end instead of
+ * re-rendering per tick. Each `setScale` shows an immediate CSS preview (the
+ * existing bitmap stretched) and resets this timer; the settle fires once the
+ * gesture pauses for `ZOOM_SETTLE_MS`. Lower = snappier but more redundant renders
+ * mid-gesture; higher = fewer renders but a longer soft-preview tail. Deliberately
+ * duplicated per viewer (a one-line timing constant, not shared logic).
+ */
+const ZOOM_SETTLE_MS = 150;
+
+/**
  * Options for {@link PptxScrollViewer}. Extends `RenderSlideOptions` (per-slide
  * render knobs, minus `onTextRun`) and `LoadOptions` (parse/worker knobs). See
  * design §8.2.
@@ -96,6 +111,12 @@ interface SlideSlot {
   textLayer: HTMLDivElement | null;
   /** slide index this slot is currently rendering / has rendered, or -1 when free. */
   renderedSlide: number;
+  /** The `_scale` at which this slot's on-screen canvas bitmap (and text overlay)
+   *  were last rendered, or -1 when unrendered. The flicker-free CSS preview
+   *  (design §7) stretches that bitmap to the new layout size on `setScale` and
+   *  scales the text overlay by `newScale / renderedScale`; the debounced settle
+   *  re-render then repaints at the new scale and updates this to match. */
+  renderedScale: number;
   /** worker-mode: a transient hold on a just-received ImageBitmap, set only
    *  between receipt from the worker and its `transferFromImageBitmap` (which
    *  consumes it, after which we null the field). Its purpose is the throw path:
@@ -168,6 +189,12 @@ export class PptxScrollViewer {
    *  bitmap + re-dispatch the live slot. Main path: skip the (stale) text-layer
    *  build; the engine's per-canvas token already discards the stale pixels. */
   private _renderEpoch = 0;
+  /** Pending settle-render timer handle (design §7 mechanism 2). Set by
+   *  `_scheduleSettle` after each `setScale`, reset on the next one so a burst
+   *  dispatches ONE settle at the end, and cleared in `destroy()`. `ReturnType`
+   *  of `setTimeout` (a number in the DOM, a Timeout object in node) so the type
+   *  is host-agnostic. */
+  private _settleTimer: ReturnType<typeof setTimeout> | null = null;
   private _wheelListener: ((e: WheelEvent) => void) | null = null;
   /** One-shot latch for the worker-mode text-selection warning. The overlay is a
    *  main-mode-only feature: in worker mode the per-run `onTextRun` geometry
@@ -496,7 +523,15 @@ export class PptxScrollViewer {
       wrapper.appendChild(textLayer);
     }
     this._scrollHost.appendChild(wrapper);
-    const slot: SlideSlot = { wrapper, canvas, textLayer, renderedSlide: -1, bitmap: null, bitmapCtx: null };
+    const slot: SlideSlot = {
+      wrapper,
+      canvas,
+      textLayer,
+      renderedSlide: -1,
+      renderedScale: -1,
+      bitmap: null,
+      bitmapCtx: null,
+    };
     return slot;
   }
 
@@ -511,8 +546,15 @@ export class PptxScrollViewer {
     // stale spans. buildPptxTextLayer also clears on its next build, but an
     // unrendered pooled slot never gets that build, and the detached spans would
     // otherwise linger; drop them here.
-    if (slot.textLayer) slot.textLayer.innerHTML = '';
+    if (slot.textLayer) {
+      slot.textLayer.innerHTML = '';
+      // Drop any preview transform so a pooled slot re-used for another slide does
+      // not inherit a stale scale() before its overlay is rebuilt.
+      slot.textLayer.style.transform = '';
+      slot.textLayer.style.transformOrigin = '';
+    }
     slot.renderedSlide = -1;
+    slot.renderedScale = -1;
     slot.wrapper.remove();
     this._free.push(slot);
   }
@@ -570,9 +612,10 @@ export class PptxScrollViewer {
     const dpr = this._dpr();
     const widthPx = this._slideWidthPx();
     const epoch = this._renderEpoch;
+    const scale = this._scale;
 
     if (this._mode === 'worker') {
-      void this._renderSlotBitmap(i, slot, widthPx, dpr);
+      void this._renderSlotBitmap(i, slot, widthPx, dpr, scale);
       return;
     }
 
@@ -592,6 +635,9 @@ export class PptxScrollViewer {
         // different slide / freed it. Either way: skip the (stale) overlay build.
         // The engine's per-canvas token already discards the superseded pixels.
         if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedSlide !== i) return;
+        // This fresh render defines the scale the on-screen bitmap now lives at,
+        // so a subsequent zoom preview stretches from HERE.
+        slot.renderedScale = scale;
         if (wantOverlay && slot.textLayer) {
           // buildPptxTextLayer takes NUMBERS (not strings) for width/height. The
           // overlay must match the slot's CSS box, NOT the canvas backing store:
@@ -654,7 +700,13 @@ export class PptxScrollViewer {
    * static play-badge renders on media slides (matching `PptxViewer`'s
    * non-media-playback path) — acceptable for v1.
    */
-  private async _renderSlotBitmap(i: number, slot: SlideSlot, widthPx: number, dpr: number): Promise<void> {
+  private async _renderSlotBitmap(
+    i: number,
+    slot: SlideSlot,
+    widthPx: number,
+    dpr: number,
+    scale: number,
+  ): Promise<void> {
     // Worker-mode + enableTextSelection: the overlay can't be populated (onTextRun
     // doesn't cross the worker boundary), so warn once (parity with PptxViewer)
     // and leave the overlay empty. Fires before the coalescing guards so it is
@@ -706,6 +758,9 @@ export class PptxScrollViewer {
       slot.canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
       slot.bitmapCtx?.transferFromImageBitmap(bmp);
       slot.bitmap = null; // transfer consumed it
+      // This bitmap now defines the scale the on-screen canvas lives at, so a
+      // later zoom preview stretches from HERE (design §7 renderedScale).
+      slot.renderedScale = scale;
       painted = true;
     } catch (err) {
       this._reportRenderError(err);
@@ -740,7 +795,7 @@ export class PptxScrollViewer {
       ) {
         // live.renderedSlide === i already (set by _renderSlot on mount); the fresh
         // dispatch runs at the CURRENT epoch/scale via _slideWidthPx().
-        void this._renderSlotBitmap(i, live, this._slideWidthPx(), this._dpr());
+        void this._renderSlotBitmap(i, live, this._slideWidthPx(), this._dpr(), this._scale);
       }
     }
   }
@@ -752,6 +807,11 @@ export class PptxScrollViewer {
    * multiples of the base fit; design §3 keeps the clamp in the viewer, not core),
    * then re-anchor VERTICALLY so the slide currently under the viewport top stays
    * fixed. A no-op when nothing is loaded or when the clamped scale is unchanged.
+   *
+   * FLICKER-FREE (design §7): this does NOT re-render the visible slides inline.
+   * It shows an immediate CSS preview (stretch the existing bitmaps, scale the
+   * overlays) and DEBOUNCES a full-resolution settle re-render for ZOOM_SETTLE_MS,
+   * so a wheel/pinch burst never blanks a slide and coalesces into one crisp render.
    *
    * Re-anchor (written from scratch — XlsxViewer only re-anchors horizontally):
    * capture `top = topIndex` and the intra-slide fraction `intraFrac` from the
@@ -808,19 +868,175 @@ export class PptxScrollViewer {
     const wantTop = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
     this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, wantTop));
 
-    // Re-mount at the new geometry, forcing a re-render of every slot (its px
-    // size changed under the new scale, so the cached canvas is stale).
-    this._mountVisibleForceRerender();
+    // FLICKER-FREE ZOOM (design §7). Do NOT recycle + re-render in-window slots
+    // (that blanks each visible slide to white every tick). Instead:
+    //  1. CSS-PREVIEW the currently-mounted slots at the new geometry — reposition
+    //     the wrapper, stretch the existing canvas bitmap via style.width/height
+    //     (soft but never blank), and scale the text overlay by the ratio between
+    //     the new scale and the scale the overlay was built at.
+    //  2. DEBOUNCE a full-resolution settle re-render: schedule it ZOOM_SETTLE_MS
+    //     after the LAST setScale so a wheel/pinch burst coalesces into one render.
+    this._previewVisible();
+    this._scheduleSettle();
   }
 
-  /** Like `_mountVisible` but recycles every live slot first so each re-mounts and
-   *  re-renders at the current scale. Used by `setScale` (and the resize re-fit
-   *  in `_onResize`, which routes through `setScale`): a slot's canvas px size
-   *  changes with the scale, so the previously
-   *  drawn pixels are stale and every visible slide must be redrawn. */
-  private _mountVisibleForceRerender(): void {
-    for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
-    this._mountVisible();
+  /**
+   * CSS preview of the visible window at the current `_scale` (design §7
+   * mechanism 1), WITHOUT re-rendering. Slots leaving the window recycle normally;
+   * slots ENTERING the window mount fresh (rendered at the current scale directly,
+   * so they never need a preview); slots that STAY are repositioned and their
+   * canvas + text overlay are CSS-transformed to the new size (the device buffer
+   * is untouched — that is the whole point: no synchronous clear, no blank frame).
+   */
+  private _previewVisible(): void {
+    if (!this._pres || this._pres.slideCount === 0) return;
+    const r = this._range();
+    this._lastRange = r;
+
+    // Recycle slots that left [start, end].
+    for (const [idx, slot] of [...this._slots]) {
+      if (idx < r.start || idx > r.end) this._recycleSlot(idx, slot);
+    }
+    // For every index in the window: mount fresh if missing (renders at the current
+    // scale), or CSS-preview if already mounted (no re-render, no device resize).
+    for (let i = r.start; i <= r.end; i++) {
+      const existing = this._slots.get(i);
+      if (!existing) {
+        const slot = this._acquireSlot();
+        this._positionSlot(slot, i, r);
+        this._slots.set(i, slot);
+        this._renderSlot(i, slot);
+      } else {
+        this._previewSlot(existing, i, r);
+      }
+    }
+    // Fire onVisibleSlideChange only when the top slide actually changed.
+    if (r.topIndex !== this._lastTopIndex) {
+      this._lastTopIndex = r.topIndex;
+      this._opts.onVisibleSlideChange?.(r.topIndex, this._pres.slideCount);
+    }
+  }
+
+  /**
+   * CSS-preview a single already-mounted slot at the new geometry (design §7): the
+   * wrapper is repositioned + sized (via `_positionSlot`), the canvas bitmap is
+   * STRETCHED to the new CSS size (no `canvas.width` — the device buffer, and thus
+   * the drawn pixels, are left intact, just scaled by the browser), and the text
+   * overlay is scaled by `newScale / renderedScale` so it tracks the stretched
+   * slide. `renderedScale <= 0` means the slot's first render hasn't resolved yet
+   * (nothing to stretch); the pending render captured the current scale, so it
+   * lands correct and no preview is needed.
+   */
+  private _previewSlot(slot: SlideSlot, i: number, r: VisibleRange): void {
+    this._positionSlot(slot, i, r);
+    // Stretch the existing bitmap to the new CSS box (device buffer untouched).
+    slot.canvas.style.width = `${this._slideWidthPx()}px`;
+    slot.canvas.style.height = `${this._slideHeightPx()}px`;
+    if (slot.textLayer && slot.renderedScale > 0) {
+      const ratio = this._scale / slot.renderedScale;
+      slot.textLayer.style.transformOrigin = '0 0';
+      slot.textLayer.style.transform = `scale(${ratio})`;
+    }
+  }
+
+  /** (Re)schedule the debounced settle re-render (design §7 mechanism 2). Resets
+   *  the timer on every call so a burst of `setScale` dispatches ONE settle
+   *  ZOOM_SETTLE_MS after the LAST call. Cleared in `destroy()`. */
+  private _scheduleSettle(): void {
+    if (this._settleTimer !== null) clearTimeout(this._settleTimer);
+    this._settleTimer = setTimeout(() => {
+      this._settleTimer = null;
+      this._settleRender();
+    }, ZOOM_SETTLE_MS);
+  }
+
+  /** Full-resolution settle re-render of the visible window (design §7 mechanisms
+   *  2+3). Re-renders each mounted slot at the current scale via the double-buffer
+   *  swap (main) / same-canvas transfer (worker), then clears the preview
+   *  transform on its overlay. Dispatched at the CURRENT epoch; the existing epoch
+   *  gate discards it if a later `setScale` supersedes it mid-render. */
+  private _settleRender(): void {
+    if (this._destroyed || !this._pres || this._pres.slideCount === 0) return;
+    for (const [i, slot] of [...this._slots]) {
+      // Skip slots already at the current scale (a slot that entered the window
+      // during the burst mounted fresh at the current scale — nothing to settle).
+      if (slot.renderedScale === this._scale) continue;
+      this._settleSlot(i, slot);
+    }
+  }
+
+  /**
+   * Settle-render one slot at the current scale (design §7 mechanism 3).
+   *
+   * WORKER: re-dispatch the bitmap render into the SAME canvas. The worker path
+   * sizes the device buffer and `transferFromImageBitmap`s it in ONE synchronous
+   * step (no await between `canvas.width = …` and the transfer), so the browser
+   * never composites an intermediate blank frame — no spare canvas is needed. The
+   * `renderedScale === _scale` gate in `_settleRender` plus the epoch gate inside
+   * `_renderSlotBitmap` keep this correct and idempotent.
+   *
+   * MAIN: `renderSlide` synchronously sets `canvas.width = …` (which CLEARS the
+   * backing store to blank) BEFORE its first await and paints AFTER — so rendering
+   * into the on-screen canvas would flash it white. Render into a SPARE off-DOM
+   * canvas instead; only once it resolves at the current epoch do we swap it into
+   * the wrapper (replacing the old canvas). The old canvas keeps showing the
+   * stretched preview until the instant of the swap — blank-free.
+   */
+  private _settleSlot(i: number, slot: SlideSlot): void {
+    if (!this._pres) return;
+    const dpr = this._dpr();
+    const widthPx = this._slideWidthPx();
+    const scale = this._scale;
+    const epoch = this._renderEpoch;
+
+    if (this._mode === 'worker') {
+      void this._renderSlotBitmap(i, slot, widthPx, dpr, scale);
+      return;
+    }
+
+    // Main mode: double-buffer. Render into a spare canvas kept off-DOM.
+    const spare = document.createElement('canvas');
+    spare.style.cssText = 'display:block;background:#fff;';
+    const runs: PptxTextRunInfo[] = [];
+    const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const onTextRun = wantOverlay ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    this._pres
+      .renderSlide(spare, i, {
+        width: widthPx,
+        dpr,
+        onTextRun,
+      })
+      .then(() => {
+        // Discard if superseded: a later setScale bumped the epoch (this spare is
+        // at a stale scale), or the slot recycled / moved to another slide. Drop
+        // the spare (it is off-DOM, so GC reclaims it) and do NOT swap.
+        if (epoch !== this._renderEpoch || this._slots.get(i) !== slot || slot.renderedSlide !== i) return;
+        // Swap the freshly-painted spare in for the old (stretched-preview) canvas.
+        // The old canvas was the only child that showed content; replacing it in
+        // one DOM op means the screen goes from preview → crisp with no blank tick.
+        const old = slot.canvas;
+        slot.wrapper.insertBefore(spare, old);
+        old.remove();
+        slot.canvas = spare;
+        // The retired canvas held a 2d context; keep the pool clean by dropping any
+        // bitmaprenderer handle association (main-mode canvases never had one).
+        slot.bitmapCtx = null;
+        slot.renderedScale = scale;
+        // Rebuild the overlay at the full resolution and CLEAR the preview
+        // transform (the crisp render no longer needs the scale()).
+        if (slot.textLayer) {
+          slot.textLayer.style.transform = '';
+          slot.textLayer.style.transformOrigin = '';
+          if (wantOverlay) {
+            // buildPptxTextLayer takes NUMBERS: pass the CSS box (uniform slide
+            // width/height at the current scale), NOT the retina backing store.
+            buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()));
+          }
+        }
+      })
+      .catch((err: unknown) => {
+        this._reportRenderError(err);
+      });
   }
 
   /**
@@ -885,12 +1101,14 @@ export class PptxScrollViewer {
    *   mult      = _scale / _prevBase            (the user's zoom over the old base)
    *   newScale  = newBase × mult
    * Routing through `setScale(newScale)` bumps `_renderEpoch` (resize IS an epoch
-   * event — T4 banner) and re-anchors + force-re-renders every slot at the new
-   * geometry, exactly like a zoom. `setScale`'s clamp/no-op guards apply: an
-   * unchanged newScale (identical width) is a no-op there — so we short-circuit
-   * BEFORE it when the fit-width is unchanged (mounting the revealed window without
-   * a needless force-re-render), and after it we call `_mountVisible` again to cover
-   * the case where the clamp made `setScale` no-op yet the viewport still grew.
+   * event — T4 banner) and re-anchors + CSS-previews + debounces a settle re-render
+   * of every slot at the new geometry, exactly like a zoom (design §7 flicker-free
+   * path — a rapid ResizeObserver burst therefore also coalesces into one settle).
+   * `setScale`'s clamp/no-op guards apply: an unchanged newScale (identical width)
+   * is a no-op there — so we short-circuit BEFORE it when the fit-width is
+   * unchanged (mounting the revealed window without a needless re-render), and
+   * after it we call `_mountVisible` again to cover the case where the clamp made
+   * `setScale` no-op yet the viewport still grew.
    */
   private _onResize(): void {
     if (!this._pres || this._pres.slideCount === 0) return;
@@ -932,10 +1150,10 @@ export class PptxScrollViewer {
     // of using absolute bounds (§8.2) with an unclamped relayout base.
     this.setScale(newBase * mult);
     // `setScale` no-ops when the clamped scale is unchanged (e.g. already pinned at
-    // a clamp boundary), which would skip its `_mountVisibleForceRerender`. A
-    // width+height growth that ends up clamped to the same scale must still reveal
-    // the taller viewport's rows, so mount here too. Idempotent when `setScale` ran:
-    // the window is already mounted and every present slot is a re-position no-op.
+    // a clamp boundary), which would skip its preview + settle. A width+height
+    // growth that ends up clamped to the same scale must still reveal the taller
+    // viewport's rows, so mount here too. Idempotent when `setScale` ran: the
+    // window is already mounted and every present slot is a re-position no-op.
     this._mountVisible();
   }
 
@@ -986,6 +1204,14 @@ export class PptxScrollViewer {
     }
     this._resizeObserver?.disconnect();
     this._resizeObserver = null;
+    // Cancel a pending settle so no re-render is dispatched after teardown
+    // (design §7 mechanism 2). `_destroyed` also guards `_settleRender`, but
+    // clearing the timer avoids the wasted wake-up and keeps fake-timer tests
+    // deterministic.
+    if (this._settleTimer !== null) {
+      clearTimeout(this._settleTimer);
+      this._settleTimer = null;
+    }
     for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
     this._free.length = 0;
     if (!this._injected) {


### PR DESCRIPTION
## Summary

Two user-reported polish items for the scroll-viewer family.

### Flicker-free zoom (design §7)

Zooming used to flash white on every wheel tick (all visible slots recycled, blank canvases re-rendered async). Now — per viewer, mirrored:

1. **CSS preview**: in-window slots survive `setScale`; the existing canvas is CSS-resized to the new layout (bitmap stretched, briefly soft — the PDF.js approach) and the text overlay follows with a matching `transform: scale()`. Preview ratio is always computed against the slot's last *rendered* scale — no compounding drift across ticks.
2. **Settle re-render**: full-resolution renders are debounced (`ZOOM_SETTLE_MS = 150`, documented as UI policy, not spec) — one render per gesture, not per tick; the render epoch discards superseded settles.
3. **Double-buffer swap** (main mode): the settle renders into an off-DOM spare canvas and swaps it in on an epoch-current resolution — the engine's synchronous canvas-clear never hits the screen. Worker mode needs no spare (resize+transfer are one synchronous tick; no intermediate blank frame is ever composited).

Resize re-fit inherits the same path (ResizeObserver bursts coalesce). User-confirmed in Storybook: flicker gone.

### `pageShadow?: string | false` (both viewers)

CSS box-shadow on each page/slide canvas; default `'0 1px 3px rgba(0,0,0,0.2)'` (the recipe stories' look — pages float above the desk with zero config), `false` disables, and a spread ring (`'0 0 0 1px #c8ccd0'`) gives a border look with no layout shift — the reason it's one option rather than separate shadow/border. Applied via a single helper at every canvas-creation site including the settle spare; `??` (not `||`) preserves an explicit `false`.

## Verification

- docx suite **431/431** (91 scroll-viewer tests), pptx **230/230** (94); root `pnpm typecheck` clean.
- Independent combined review APPROVEd: preview-ratio compounding, destroy-during-settle safety, pool hygiene (transform reset on recycle, no canvas double-stocking), and docx/pptx symmetry (normalized diff: domain-inherent deltas only) all verified; mutation checks confirm the load-bearing tests bite. Two JSDoc accuracy follow-ups included.
- Browser: zoom confirmed smooth by the user; default shadow verified live (`rgba(0,0,0,0.2) 0 1px 3px` computed style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)