### PR TITLE
ci: rendering smoke suite, Rust cache for typecheck, node probe tests un-skipped (E1+E3+E8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            packages/pptx/parser
+            packages/xlsx/parser
+            packages/docx/parser
+
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
@@ -69,18 +77,56 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      # Unit tests for pure-logic modules (formula engine, number formats).
-      # No WASM needed.
-      - name: Unit tests
-        run: pnpm test
-
       # The WASM parsers are git-ignored build output; the TypeScript packages
       # import their generated .d.ts/.js, so typecheck requires building them first.
       - name: Build WASM
         run: pnpm build:wasm
+
+      # Unit tests. Most cover pure-logic modules, but the packages/node canvas
+      # probes dynamically import the WASM parsers (built above) and skia-canvas,
+      # so they run AFTER Build WASM. OOXML_REQUIRE_SKIA=1 turns a missing binding
+      # from a silent skip into a hard failure, guaranteeing the probes execute.
+      - name: Unit tests
+        run: pnpm test
+        env:
+          OOXML_REQUIRE_SKIA: '1'
 
       - name: Typecheck
         run: pnpm typecheck
 
       - name: Build packages
         run: pnpm build:packages
+
+  # Rendering smoke: boots Storybook, drives the Layouts stories in a real
+  # Chrome, and asserts every canvas receives ink. The only CI job that
+  # exercises the full parse -> render pipeline in a browser.
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            packages/pptx/parser
+            packages/xlsx/parser
+            packages/docx/parser
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build WASM
+        run: pnpm build:wasm
+      - name: Install Playwright Chrome
+        run: pnpm exec playwright install chrome --with-deps
+      - name: Smoke tests
+        run: pnpm smoke

--- a/package.json
+++ b/package.json
@@ -64,12 +64,14 @@
     "build-storybook": "storybook build",
     "build:wasm": "pnpm --filter @silurus/ooxml-docx wasm && pnpm --filter @silurus/ooxml-xlsx wasm && pnpm --filter @silurus/ooxml-pptx wasm",
     "vrt": "pnpm -r vrt",
+    "smoke": "playwright test --config tests/smoke/playwright.config.ts",
     "test": "vitest run",
     "lint": "ast-grep scan",
     "lint:test": "ast-grep test --skip-snapshot-tests"
   },
   "devDependencies": {
     "@ast-grep/cli": "^0.43.0",
+    "@playwright/test": "^1.59.1",
     "@chromatic-com/storybook": "^5.1.2",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "build-storybook": "storybook build",
     "build:wasm": "pnpm --filter @silurus/ooxml-docx wasm && pnpm --filter @silurus/ooxml-xlsx wasm && pnpm --filter @silurus/ooxml-pptx wasm",
     "vrt": "pnpm -r vrt",
-    "smoke": "playwright test --config tests/smoke/playwright.config.ts",
+    "smoke": "playwright test --config tests/smoke/playwright.config.ts layouts",
     "test": "vitest run",
     "lint": "ast-grep scan",
     "lint:test": "ast-grep test --skip-snapshot-tests"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "skia-canvas": "^2.0.0",
     "typescript": "^6.0.2"
   }
 }

--- a/packages/node/src/bevel-render.test.ts
+++ b/packages/node/src/bevel-render.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { renderSlideNode } from './render';
 import type { NodeCanvasFactory } from './render';
 import type { Presentation, Slide, PictureElement } from '@silurus/ooxml-pptx';
+import { loadSkiaForTests } from './test-imports';
 
-// skia-canvas ships a native binding that CI deliberately omits (VRT and other
-// canvas-backed checks are local-only). Load it dynamically so the suite skips
-// cleanly when the binding is absent instead of failing at module load.
-const skia = await import('skia-canvas').catch(() => null);
+// skia-canvas ships a native binding via a devDependency, so `pnpm install`
+// provides it in CI as well as locally. Load it through the shared test helper:
+// absent → skip cleanly (local), but under OOXML_REQUIRE_SKIA=1 (CI) a load
+// failure becomes a hard error instead of a silent skip.
+const skia = await loadSkiaForTests();
 // Non-null aliases for use inside the (skia-gated) test bodies. When `skia` is
 // null the whole suite is skipped via `describe.skipIf`, so these are never
 // dereferenced; the cast keeps the helpers strongly typed without `as any`.

--- a/packages/node/src/docx-border-crisp.probe.test.ts
+++ b/packages/node/src/docx-border-crisp.probe.test.ts
@@ -24,9 +24,11 @@
  * at dpr=1; clean 2-device-row band at dpr=2). It fails against the pre-fix
  * renderer, so it is a genuine regression guard — not a tautology.
  *
- * CI-safe: skia-canvas ships a native binding CI omits, and docx.ts statically
- * imports gitignored WASM glue, so the suite is gated with
- * `describe.skipIf(!skia || !docxMod)` — both loaded via caught dynamic import.
+ * CI-safe: skia-canvas is a devDependency (present in CI and locally), and
+ * docx.ts statically imports gitignored WASM glue (present after `pnpm
+ * build:wasm`), so the suite is gated with `describe.skipIf(!skia || !docxMod)`
+ * — both loaded through the shared test helper (skip locally, fail under
+ * OOXML_REQUIRE_SKIA=1).
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -35,15 +37,17 @@ import { dirname, resolve } from 'node:path';
 import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
 import type { NodeCanvasFactory } from './render.ts';
 import type { DocxDocumentModel, DocParagraph, BodyElement } from '@silurus/ooxml-docx';
+import { importForTests, loadSkiaForTests } from './test-imports';
 
-const skia = await import('skia-canvas').catch(() => null);
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas } = (skia ?? {}) as Skia;
 
-// docx.ts statically imports the gitignored WASM glue (docx_parser.js). In CI
-// `pnpm test` runs BEFORE `pnpm build:wasm`, so a static import here would fail at
-// collection; load it dynamically and skip when absent — same gate as skia.
-const docxMod = await import('./docx.ts').catch(() => null);
+// docx.ts statically imports the gitignored WASM glue (docx_parser.js). CI runs
+// `pnpm build:wasm` before `pnpm test`, so it is present there; load it through
+// the shared helper so it skips when absent locally but hard-fails under
+// OOXML_REQUIRE_SKIA=1 — same gate as skia.
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
 
 const factory: NodeCanvasFactory = {
   createCanvas: (w, h) =>
@@ -62,7 +66,10 @@ const SAMPLE = resolve(ROOT, 'packages/docx/public/demo/sample-1.docx');
 // render-orchestrator.ts directly by path (the type-only import above still uses
 // the package specifier, resolved by TS for typecheck and erased at runtime).
 const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
-const rendererMod = await import(RENDERER_PATH).catch(() => null);
+const rendererMod = await importForTests(
+  () => import(RENDERER_PATH),
+  'packages/docx/src/renderer.ts',
+);
 // Opt-in diagnostics: set PROBE_OUT to a directory to dump the full render plus
 // an 8x crop of the measured border. Null by default → the test writes no files.
 const OUT_DIR = process.env.PROBE_OUT ?? null;

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -7,11 +7,13 @@ import {
   installOffscreenCanvasShim,
   type NodeCanvasFactory,
 } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
 
-// skia-canvas is a local-only peer dep (CI omits it); the private journal
-// samples are git-ignored (not redistributable). Skip cleanly when either is
-// absent — this suite is a local ground-truth gate, like the VRT specs.
-const skia = await import('skia-canvas').catch(() => null);
+// skia-canvas is a devDependency, so `pnpm install` provides it in CI as well as
+// locally; the private journal samples are git-ignored (not redistributable), so
+// this suite still self-skips where they are absent. Load skia through the shared
+// helper: absent → skip cleanly (local), OOXML_REQUIRE_SKIA=1 (CI) → hard failure.
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas, loadImage } = (skia ?? {}) as Skia;
 
@@ -22,11 +24,16 @@ const factory: NodeCanvasFactory = {
     loadImage(Buffer.from(buf as Uint8Array))) as unknown as NodeCanvasFactory['loadImage'],
 };
 
-const docxMod = skia ? await import('./docx.ts').catch(() => null) : null;
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '../../..');
 const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
-const rendererMod = skia ? await import(RENDERER_PATH).catch(() => null) : null;
+// The WASM-backed docx parser + renderer are only loaded when skia is present.
+// Both statically import git-ignored WASM glue, so they need `pnpm build:wasm`
+// first; under OOXML_REQUIRE_SKIA=1 a failure to load is a hard error.
+const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
+const rendererMod = skia
+  ? await importForTests(() => import(RENDERER_PATH), 'packages/docx/src/renderer.ts')
+  : null;
 
 const samplePath = (n: number) =>
   resolve(ROOT, `packages/docx/public/private/sample-${n}.docx`);

--- a/packages/node/src/docx-para-border-merge.probe.test.ts
+++ b/packages/node/src/docx-para-border-merge.probe.test.ts
@@ -18,10 +18,12 @@
  * and MEASURES the device-pixel luminance to count the horizontal rules between
  * the code lines — asserting only the box edges remain.
  *
- * CI-safe: skia-canvas ships a native binding CI omits, and docx.ts statically
- * imports gitignored WASM glue, so the suite is gated with
- * `describe.skipIf(!skia || !docxMod || !rendererMod)` — all loaded via caught
- * dynamic import (mirrors docx-border-crisp.probe.test.ts).
+ * CI-safe: skia-canvas is a devDependency (present in CI and locally), and
+ * docx.ts statically imports gitignored WASM glue (present after `pnpm
+ * build:wasm`), so the suite is gated with
+ * `describe.skipIf(!skia || !docxMod || !rendererMod)` — all loaded through the
+ * shared test helper (skip locally, fail under OOXML_REQUIRE_SKIA=1; mirrors
+ * docx-border-crisp.probe.test.ts).
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -35,18 +37,22 @@ import type {
   BodyElement,
   ParaBorderEdge,
 } from '@silurus/ooxml-docx';
+import { importForTests, loadSkiaForTests } from './test-imports';
 
-const skia = await import('skia-canvas').catch(() => null);
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas } = (skia ?? {}) as Skia;
 
-const docxMod = await import('./docx.ts').catch(() => null);
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '../../..');
 const SAMPLE = resolve(ROOT, 'packages/docx/public/demo/sample-1.docx');
 const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
-const rendererMod = await import(RENDERER_PATH).catch(() => null);
+const rendererMod = await importForTests(
+  () => import(RENDERER_PATH),
+  'packages/docx/src/renderer.ts',
+);
 
 const factory: NodeCanvasFactory = {
   createCanvas: (w, h) =>

--- a/packages/node/src/pptx-line-crisp.probe.test.ts
+++ b/packages/node/src/pptx-line-crisp.probe.test.ts
@@ -24,23 +24,25 @@
  * row at dpr=1; clean 2-device-row band at dpr=2). It fails against the pre-fix
  * renderer, so it is a genuine regression guard — not a tautology.
  *
- * CI-safe: skia-canvas ships a native binding CI omits, so the suite is gated
- * with `describe.skipIf(!skia)`. The render helper (`./render.ts`) and the pptx
- * renderer it dynamically imports do NOT statically import WASM, but to stay
- * future-proof the render module is itself loaded via a caught dynamic import and
- * gated too.
+ * CI-safe: skia-canvas is a devDependency (present in CI and locally), so the
+ * suite is gated with `describe.skipIf(!skia)` — loaded through the shared test
+ * helper (skip locally, fail under OOXML_REQUIRE_SKIA=1). The render helper
+ * (`./render.ts`) and the pptx renderer it dynamically imports do NOT statically
+ * import WASM, but to stay future-proof the render module is itself loaded via
+ * the same helper and gated too.
  */
 import { describe, it, expect } from 'vitest';
 import type { Presentation, Slide, TableElement, Stroke } from '@silurus/ooxml-pptx';
+import { importForTests, loadSkiaForTests } from './test-imports';
 
-const skia = await import('skia-canvas').catch(() => null);
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas } = (skia ?? {}) as Skia;
 
-// `./render.ts` does not statically import WASM today, but load it via a caught
-// dynamic import (and gate on it) so the suite never fails at collection if that
+// `./render.ts` does not statically import WASM today, but load it through the
+// shared helper (and gate on it) so the suite never fails at collection if that
 // ever changes.
-const renderMod = await import('./render.ts').catch(() => null);
+const renderMod = await importForTests(() => import('./render.ts'), './render.ts');
 
 const EMU_PER_PX = 9525; // 96 dpi → 1 logical px
 

--- a/packages/node/src/render.test.ts
+++ b/packages/node/src/render.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { installOffscreenCanvasShim, installImageBitmapShim } from './render';
 import type { NodeCanvasFactory } from './render';
+import { loadSkiaForTests } from './test-imports';
 
-// skia-canvas ships a native binding that CI deliberately omits (it is a
-// peerDependency, not installed by `pnpm install --frozen-lockfile`, and the
-// canvas-backed checks are local-only like the VRT suites). Load it dynamically
-// so these suites skip cleanly when the binding is absent instead of failing
-// the whole run at module load. `describe.skipIf(!skia)` gates every block.
-const skia = await import('skia-canvas').catch(() => null);
+// skia-canvas ships a native binding via a devDependency, so `pnpm install`
+// provides it in CI as well as locally — these canvas-backed checks run
+// everywhere. Load it through the shared test helper: absent → skip cleanly
+// (local), but under OOXML_REQUIRE_SKIA=1 (CI) a load failure becomes a hard
+// error instead of a silent skip. `describe.skipIf(!skia)` gates every block.
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas, loadImage } = (skia ?? {}) as Skia;
 

--- a/packages/node/src/source-buffer-image.test.ts
+++ b/packages/node/src/source-buffer-image.test.ts
@@ -7,10 +7,13 @@ import {
 } from './render';
 import type { NodeCanvasFactory } from './render';
 import type { Presentation, Slide, PictureElement } from '@silurus/ooxml-pptx';
+import { loadSkiaForTests } from './test-imports';
 
-// skia-canvas ships a native binding CI omits; load dynamically so the
-// canvas-backed block skips cleanly when absent (mirrors render.test.ts).
-const skia = await import('skia-canvas').catch(() => null);
+// skia-canvas ships a native binding via a devDependency, so `pnpm install`
+// provides it in CI as well as locally. Load it through the shared test helper:
+// absent → skip cleanly (local), OOXML_REQUIRE_SKIA=1 (CI) → hard failure
+// instead of a silent skip (mirrors render.test.ts).
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas, loadImage } = (skia ?? {}) as Skia;
 
@@ -19,8 +22,14 @@ const factory: NodeCanvasFactory | null =
     ? {
         createCanvas: (w, h) =>
           new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
-        loadImage: (buf) =>
-          loadImage(buf as Buffer) as unknown as ReturnType<NodeCanvasFactory['loadImage']>,
+        // skia-canvas@2 `loadImage` accepts only Buffer/string, but the image
+        // pipeline hands this factory an ArrayBuffer (via installImageBitmapShim →
+        // blob.arrayBuffer()); wrap it in a Buffer, matching the sibling suites
+        // (docx-continuous-columns.test.ts).
+        loadImage: ((buf: ArrayBuffer | Uint8Array | Buffer) =>
+          loadImage(
+            Buffer.from(buf as Uint8Array),
+          )) as unknown as NodeCanvasFactory['loadImage'],
       }
     : null;
 
@@ -96,10 +105,11 @@ function makeZipWithEntry(name: string, data: Uint8Array): Uint8Array {
   return out;
 }
 
-// The WASM parser bindings are git-ignored build output; in CI `pnpm test` runs
-// BEFORE `pnpm build:wasm`, so they may be absent here. Probe once via the
-// dynamic extract_image path and skip these byte-level assertions when the wasm
-// is unavailable (they run locally after a wasm build), mirroring the `skia` gate.
+// The WASM parser bindings are git-ignored build output. CI runs `pnpm build:wasm`
+// before `pnpm test`, so they are present there; but a local run before a wasm
+// build (or a stripped environment) may lack them. Probe once via the dynamic
+// extract_image path and skip these byte-level assertions when the wasm is
+// unavailable, mirroring the `skia` gate.
 const wasmReady = await (async () => {
   try {
     const probe = makeZipWithEntry('probe.bin', new Uint8Array([7]));
@@ -209,7 +219,7 @@ describe.skipIf(!skia)('renderSlideNode sourceBuffer wiring', () => {
     expect(px[3]).toBeGreaterThan(200); // A (opaque — image painted)
   });
 
-  it('without sourceBuffer or fetchImage the picture draws nothing (transparent)', async () => {
+  it('without sourceBuffer or fetchImage the picture draws no image (bare slide background)', async () => {
     const width = 200;
     const dpr = 1;
     const canvas = new Canvas(width * dpr, 200 * dpr);
@@ -226,6 +236,14 @@ describe.skipIf(!skia)('renderSlideNode sourceBuffer wiring', () => {
     }
     const ctx = canvas.getContext('2d');
     const px = ctx.getImageData(100, 100, 1, 1).data;
-    expect(px[3]).toBe(0); // fully transparent — prior empty-Blob behavior preserved
+    // With no byte source the empty-Blob default fails to decode, so the picture
+    // paints nothing — the pixel is the slide's opaque-white background
+    // (renderSlide fills `bg ?? '#FFFFFF'` at full alpha for a null background),
+    // NOT the red an actually-painted image would produce. This still proves the
+    // picture drew no ink: no red channel dominance, just white.
+    expect(px[0]).toBeGreaterThan(200); // R (white background, not red image)
+    expect(px[1]).toBeGreaterThan(200); // G
+    expect(px[2]).toBeGreaterThan(200); // B
+    expect(px[3]).toBe(255); // opaque slide background
   });
 });

--- a/packages/node/src/test-imports.ts
+++ b/packages/node/src/test-imports.ts
@@ -1,0 +1,69 @@
+/**
+ * Test-only dynamic-import helpers.
+ *
+ * Several node test suites depend on modules that may be absent depending on
+ * the build state or environment:
+ *
+ *   - `skia-canvas` — the native Canvas binding these canvas-backed checks use.
+ *     It is a devDependency, so `pnpm install` provides it in CI as well as
+ *     locally; but a contributor who has not installed it (or a stripped
+ *     environment) should still be able to run the pure-logic suites.
+ *   - the WASM-backed parser entrypoints (`./xlsx.ts`, `./docx.ts`, and the
+ *     renderer sources they reach) — these statically import the git-ignored
+ *     WASM glue, which only exists after `pnpm build:wasm`.
+ *
+ * Historically each suite loaded these via `await import(...).catch(() => null)`
+ * and gated itself with `describe.skipIf(!mod)`. That is convenient locally, but
+ * on CI it means a broken/missing dependency degrades to a SILENT skip: the job
+ * stays green while testing nothing. To close that hole, CI sets
+ * `OOXML_REQUIRE_SKIA=1`, which flips every such optional import from
+ * "return null and skip" to "throw and fail the run". Locally the variable is
+ * unset, so the suites keep skipping cleanly when a binding is absent.
+ */
+
+/** Truthy check for the CI opt-in flag (any non-empty value except "0"/"false"). */
+function requireBindings(): boolean {
+  const v = process.env.OOXML_REQUIRE_SKIA;
+  return !!v && v !== '0' && v !== 'false';
+}
+
+/**
+ * Run a dynamic `import()` for a test dependency.
+ *
+ * On success returns the module. On failure the behaviour depends on the
+ * environment: when `OOXML_REQUIRE_SKIA` is truthy (CI) it re-throws an error
+ * naming `what` and the underlying cause, turning a silent skip into a hard
+ * failure; otherwise it returns `null` so the calling suite can
+ * `describe.skipIf(!mod)` itself out.
+ *
+ * @param load - Thunk performing the `import()` (e.g. `() => import('skia-canvas')`).
+ * @param what - Human-readable name of the dependency, used in the thrown error.
+ */
+export async function importForTests<T>(
+  load: () => Promise<T>,
+  what: string,
+): Promise<T | null> {
+  try {
+    return await load();
+  } catch (err) {
+    if (requireBindings()) {
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `OOXML_REQUIRE_SKIA is set but ${what} failed to load: ${cause}. ` +
+          `In CI this dependency must be present (skia-canvas is a devDependency; ` +
+          `the WASM parsers require \`pnpm build:wasm\` to have run first).`,
+        { cause: err },
+      );
+    }
+    return null;
+  }
+}
+
+/**
+ * Load `skia-canvas` for a test suite. Thin wrapper over {@link importForTests}
+ * so every canvas-backed suite shares one gate: null → skip locally, throw →
+ * fail under `OOXML_REQUIRE_SKIA=1` (CI).
+ */
+export function loadSkiaForTests(): Promise<typeof import('skia-canvas') | null> {
+  return importForTests(() => import('skia-canvas'), 'skia-canvas');
+}

--- a/packages/node/src/xlsx-border-crisp.probe.test.ts
+++ b/packages/node/src/xlsx-border-crisp.probe.test.ts
@@ -24,8 +24,10 @@
  * at dpr=1; clean 2-device-row band at dpr=2). It fails against the pre-fix
  * renderer, so it is a genuine regression guard — not a tautology.
  *
- * CI-safe: skia-canvas ships a native binding CI omits, so the suite is gated
- * with `describe.skipIf(!skia)` exactly like render.test.ts.
+ * CI-safe: skia-canvas is a devDependency (present in CI and locally), so the
+ * suite is gated with `describe.skipIf(!skia)` exactly like render.test.ts —
+ * loaded through the shared test helper (skip locally, fail under
+ * OOXML_REQUIRE_SKIA=1).
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -40,16 +42,17 @@ import type {
   CellXf,
   ViewportRange,
 } from '@silurus/ooxml-xlsx';
+import { importForTests, loadSkiaForTests } from './test-imports';
 
-const skia = await import('skia-canvas').catch(() => null);
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas } = (skia ?? {}) as Skia;
 
-// xlsx.ts statically imports the gitignored WASM glue (xlsx_parser.js). In CI
-// `pnpm test` runs BEFORE `pnpm build:wasm`, so a static import here would fail
-// at collection; load it dynamically and skip when absent — same gate as skia
-// (see source-buffer-image.test.ts).
-const xlsxMod = await import('./xlsx.ts').catch(() => null);
+// xlsx.ts statically imports the gitignored WASM glue (xlsx_parser.js). CI runs
+// `pnpm build:wasm` before `pnpm test`, so it is present there; load it through
+// the shared helper so it skips when absent locally but hard-fails under
+// OOXML_REQUIRE_SKIA=1 — same gate as skia (see source-buffer-image.test.ts).
+const xlsxMod = await importForTests(() => import('./xlsx.ts'), './xlsx.ts (xlsx WASM)');
 
 const factory: NodeCanvasFactory = {
   createCanvas: (w, h) =>

--- a/packages/node/src/xlsx-merge-border-zorder.probe.test.ts
+++ b/packages/node/src/xlsx-merge-border-zorder.probe.test.ts
@@ -43,8 +43,12 @@ import type {
   Row,
   ViewportRange,
 } from '@silurus/ooxml-xlsx';
+import { loadSkiaForTests } from './test-imports';
 
-const skia = await import('skia-canvas').catch(() => null);
+// skia-canvas is a devDependency (`pnpm install` provides it in CI as well as
+// locally). Load it through the shared helper: absent → skip cleanly (local),
+// OOXML_REQUIRE_SKIA=1 (CI) → hard failure instead of a silent skip.
+const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
 const { Canvas } = (skia ?? {}) as Skia;
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3277,10 +3277,14 @@ export function getCachedBitmap(
   const entry: BitmapCacheEntry = { promise };
   // Record the resolved bitmap on the entry so the synchronous bullet draw
   // (peekCachedBitmap) can read it after the warm pass awaits this promise.
-  // A `null` (unsupported metafile) is recorded too, so the draw skips it.
+  // A `null` (unsupported metafile) is recorded too, so the draw skips it. The
+  // `.catch(() => {})` swallows a decode rejection on THIS side-chain (the real
+  // caller still sees it via the returned `promise`): without it a failed decode
+  // — e.g. an empty/undecodable blob — would surface as an unhandled rejection.
+  // On failure `entry.bitmap` simply stays undefined (treated as "not ready").
   void promise.then((bmp) => {
     entry.bitmap = bmp;
-  });
+  }).catch(() => {});
   // Don't poison the cache on a transient decode failure.
   promise.catch(() => cache.delete(imagePath));
   cache.set(imagePath, entry);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@chromatic-com/storybook':
         specifier: ^5.1.2
         version: 5.1.2(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@storybook/addon-a11y':
         specifier: ^10.3.5
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,13 +117,13 @@ importers:
       '@silurus/ooxml-xlsx':
         specifier: workspace:*
         version: link:../xlsx
-      skia-canvas:
-        specifier: ^2.0.0
-        version: 2.0.2
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      skia-canvas:
+        specifier: ^2.0.0
+        version: 2.0.2
       typescript:
         specifier: ^6.0.2
         version: 6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 packages:
   - "packages/*"
   - "site"
+
+# pnpm 10 blocks dependency build scripts unless approved. skia-canvas ships
+# its native binding via a node-pre-gyp install script (no napi-style prebuilt
+# optionalDependencies), so without this approval `pnpm install` leaves
+# lib/v8/index.node absent and every canvas probe suite dies at import time
+# (caught in CI by the OOXML_REQUIRE_SKIA gate).
+onlyBuiltDependencies:
+  - skia-canvas

--- a/tests/smoke/playwright.config.ts
+++ b/tests/smoke/playwright.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
   webServer: {
     command: 'pnpm storybook --port 6007 --no-open',
     url: 'http://localhost:6007/iframe.html',
-    reuseExistingServer: true,
+    // Locally, reuse a Storybook already serving on 6007; in CI always boot a
+    // fresh one so the run never binds to a stale/unrelated server.
+    reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },
 });


### PR DESCRIPTION
## Summary

First safety-net PR from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md) (Phase 1, items E1/E3/E8). Until now CI rendered zero pixels; worker-protocol or WASM-init breakage could merge green.

### E8 — node canvas/WASM probe suites now run in CI
- `skia-canvas` was only present on the maintainer's machine outside the lockfile, so all 9 canvas-backed suites in `packages/node` silently skipped in CI. It is now a proper devDependency.
- New `test-imports.ts` helper: with `OOXML_REQUIRE_SKIA=1` (set in CI) a failed `skia-canvas`/WASM dynamic import becomes a **hard failure** instead of a silent skip. Gate proven by hiding the module: without env → 5 skipped; with env → exit 1.
- Running these suites for the first time surfaced real bugs, fixed here:
  - `source-buffer-image.test.ts` passed an `ArrayBuffer` to skia@2 `loadImage` (Buffer required), and asserted a transparent pixel where the renderer's contract paints opaque white (`bg ?? '#FFFFFF'`, renderer.ts:1218).
  - `pptx/renderer.ts` `getCachedBitmap`: the cache side-chain (`void promise.then(...)`) had no `.catch`, so any decode failure became an unhandled rejection. Callers still observe failures via the returned promise.

### E1 — rendering smoke in CI
- New root `pnpm smoke` entrypoint scoped to `tests/smoke/layouts.spec.ts` (the committed `readme-screenshots.spec.ts` is a release-time utility with a docs/images overwrite side effect — excluded).
- New `smoke` CI job: build WASM → boot Storybook → drive the 6 Layouts stories in real Chrome → assert every canvas receives ink. Uses only the redistributable `demo/sample-1` fixtures.
- `reuseExistingServer` is now CI-aware.

### E3 — Rust cache for the typecheck job
- `Swatinem/rust-cache@v2` (same 3-workspace spec as publish.yml) added to typecheck; previously every PR cold-built all three parsers.
- Unit tests now run **after** Build WASM (probe suites dynamically import parser output).

## Verification
- `pnpm test`: 166 files / 1468 tests green, node suite 23 passed / 0 skipped (probes confirmed executing)
- `OOXML_REQUIRE_SKIA=1 pnpm test`: green; with skia hidden: hard failure as designed
- `pnpm smoke`: 6/6 green, `docs/images/` untouched
- `pnpm typecheck`, `pnpm lint`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)