### PR TITLE
fix(core): sysDashDotDot rendered solid; consolidate preset-dash table; correct underline spec citation (A6)

### DIFF
--- a/packages/core/src/draw/dash.test.ts
+++ b/packages/core/src/draw/dash.test.ts
@@ -3,7 +3,7 @@ import {
   dashArray,
   docxBorderDashArray,
   xlsxBorderDashArray,
-  pptxDashArray,
+  pptxUnderlineDashArray,
   pptxPresetDashArray,
 } from './dash.js';
 
@@ -66,26 +66,26 @@ describe('xlsxBorderDashArray (§18.18.3 ST_BorderStyle, static px)', () => {
   });
 });
 
-// Byte-for-byte equivalence with the former inline pptx implementation
-// (§20.1.10.49 ST_PresetLineDashVal, lineW-relative — the *Heavy variants share
+// Byte-for-byte equivalence with the former inline pptx underline implementation
+// (§20.1.10.82 ST_TextUnderlineType, lineW-relative — the *Heavy variants share
 // the base cadence). The old call site did `dashFor(s).map(v => v*lineW)`.
-describe('pptxDashArray (§20.1.10.49 ST_PresetLineDashVal)', () => {
+describe('pptxUnderlineDashArray (§20.1.10.82 ST_TextUnderlineType)', () => {
   const lineW = 2;
-  it('maps the preset dash names to lineW-scaled patterns', () => {
-    expect(pptxDashArray('dotted', lineW)).toEqual([3, 6]);
-    expect(pptxDashArray('dottedHeavy', lineW)).toEqual([3, 6]);
-    expect(pptxDashArray('dash', lineW)).toEqual([12, 6]);
-    expect(pptxDashArray('dashHeavy', lineW)).toEqual([12, 6]);
-    expect(pptxDashArray('dashLong', lineW)).toEqual([20, 8]);
-    expect(pptxDashArray('dashLongHeavy', lineW)).toEqual([20, 8]);
-    expect(pptxDashArray('dotDash', lineW)).toEqual([12, 6, 3, 6]);
-    expect(pptxDashArray('dotDashHeavy', lineW)).toEqual([12, 6, 3, 6]);
-    expect(pptxDashArray('dotDotDash', lineW)).toEqual([12, 6, 3, 6, 3, 6]);
-    expect(pptxDashArray('dotDotDashHeavy', lineW)).toEqual([12, 6, 3, 6, 3, 6]);
+  it('maps the underline dash names to lineW-scaled patterns', () => {
+    expect(pptxUnderlineDashArray('dotted', lineW)).toEqual([3, 6]);
+    expect(pptxUnderlineDashArray('dottedHeavy', lineW)).toEqual([3, 6]);
+    expect(pptxUnderlineDashArray('dash', lineW)).toEqual([12, 6]);
+    expect(pptxUnderlineDashArray('dashHeavy', lineW)).toEqual([12, 6]);
+    expect(pptxUnderlineDashArray('dashLong', lineW)).toEqual([20, 8]);
+    expect(pptxUnderlineDashArray('dashLongHeavy', lineW)).toEqual([20, 8]);
+    expect(pptxUnderlineDashArray('dotDash', lineW)).toEqual([12, 6, 3, 6]);
+    expect(pptxUnderlineDashArray('dotDashHeavy', lineW)).toEqual([12, 6, 3, 6]);
+    expect(pptxUnderlineDashArray('dotDotDash', lineW)).toEqual([12, 6, 3, 6, 3, 6]);
+    expect(pptxUnderlineDashArray('dotDotDashHeavy', lineW)).toEqual([12, 6, 3, 6, 3, 6]);
   });
-  it('returns [] for solid styles (sng / unknown)', () => {
-    expect(pptxDashArray('sng', lineW)).toEqual([]);
-    expect(pptxDashArray('solid', lineW)).toEqual([]);
+  it('returns [] for solid underline types (sng / unknown)', () => {
+    expect(pptxUnderlineDashArray('sng', lineW)).toEqual([]);
+    expect(pptxUnderlineDashArray('solid', lineW)).toEqual([]);
   });
 });
 

--- a/packages/core/src/draw/dash.test.ts
+++ b/packages/core/src/draw/dash.test.ts
@@ -4,6 +4,7 @@ import {
   docxBorderDashArray,
   xlsxBorderDashArray,
   pptxDashArray,
+  pptxPresetDashArray,
 } from './dash.js';
 
 describe('dashArray (generic on/off × unit helper)', () => {
@@ -85,5 +86,52 @@ describe('pptxDashArray (§20.1.10.49 ST_PresetLineDashVal)', () => {
   it('returns [] for solid styles (sng / unknown)', () => {
     expect(pptxDashArray('sng', lineW)).toEqual([]);
     expect(pptxDashArray('solid', lineW)).toEqual([]);
+  });
+});
+
+// Byte-for-byte equivalence with the former inline shape-stroke implementation
+// (paint.ts DASH_PATTERNS, §20.1.10.49 ST_PresetLineDashVal, lw-relative). The
+// old applyStroke did `DASH_PATTERNS[style].map(v => v * lw)`. All 10 non-solid
+// enum members map to a non-empty pattern; solid / unknown map to [].
+describe('pptxPresetDashArray (§20.1.10.49 ST_PresetLineDashVal, shape borders)', () => {
+  const lw = 2;
+  // The exact relative table that used to live inline in paint.ts.
+  const RELATIVE: Record<string, number[]> = {
+    dash: [6, 3],
+    dot: [1.5, 3],
+    dashDot: [6, 3, 1.5, 3],
+    lgDash: [10, 4],
+    lgDashDot: [10, 4, 1.5, 4],
+    lgDashDotDot: [10, 4, 1.5, 4, 1.5, 4],
+    sysDash: [4, 2],
+    sysDot: [1, 2],
+    sysDashDot: [4, 2, 1, 2],
+    sysDashDotDot: [4, 2, 1, 2, 1, 2],
+  };
+
+  it.each(Object.entries(RELATIVE))(
+    'maps %s to the lw-scaled pattern (byte-identical to the old inline map)',
+    (style, relative) => {
+      expect(pptxPresetDashArray(style, lw)).toEqual(relative.map((v) => v * lw));
+    },
+  );
+
+  it('covers all 10 non-solid ST_PresetLineDashVal members', () => {
+    // Regression guard for the table's completeness (sysDashDotDot was missing,
+    // which rendered that border as solid). solid is filtered upstream ⇒ [].
+    expect(Object.keys(RELATIVE)).toHaveLength(10);
+    for (const style of Object.keys(RELATIVE)) {
+      expect(pptxPresetDashArray(style, lw).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns [] for solid / unknown styles', () => {
+    expect(pptxPresetDashArray('solid', lw)).toEqual([]);
+    expect(pptxPresetDashArray('notARealStyle', lw)).toEqual([]);
+  });
+
+  it('scales with the line width', () => {
+    expect(pptxPresetDashArray('sysDash', 3)).toEqual([12, 6]);
+    expect(pptxPresetDashArray('dash', 1)).toEqual([6, 3]);
   });
 });

--- a/packages/core/src/draw/dash.ts
+++ b/packages/core/src/draw/dash.ts
@@ -164,16 +164,21 @@ export function pptxPresetDashArray(style: string, lineW: number): number[] {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// pptx — ECMA-376 §20.1.10.49 ST_PresetLineDashVal (lineW-relative)
+// pptx — ECMA-376 §20.1.10.82 ST_TextUnderlineType (run underlines, lineW-relative)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * §20.1.10.49 ST_PresetLineDashVal (and the underline enum which reuses the same
- * shape names) → relative `[on, off, …]` pattern in units of the stroked width
- * `lineW`, so the dashes stay proportional at any font size. The *Heavy variants
- * share the cadence of their base name (the heaviness is in the stroke width).
+ * §20.1.10.82 ST_TextUnderlineType → relative `[on, off, …]` pattern in units of
+ * the underline stroke width `lineW`, so the dashes stay proportional at any font
+ * size. This is the run-underline enum (`<a:rPr u="…">`), NOT the shape/line
+ * preset dash of §20.1.10.49: it shares a few shape names (dash / dotDash / …)
+ * but is a distinct enumeration with its own members (e.g. `dashLong`,
+ * `dottedHeavy`, and the `*Heavy` variants, which share the cadence of their base
+ * name — the heaviness is in the stroke width, not the dash rhythm). Underline
+ * types handled elsewhere in the renderer (sng / dbl / wavy*) are absent here and
+ * map to `[]` (a continuous rule).
  */
-const PPTX_DASH_RELATIVE: Record<string, RelativeDashPattern> = {
+const PPTX_UNDERLINE_RELATIVE: Record<string, RelativeDashPattern> = {
   dotted: [1.5, 3],
   dottedHeavy: [1.5, 3],
   dash: [6, 3],
@@ -187,10 +192,11 @@ const PPTX_DASH_RELATIVE: Record<string, RelativeDashPattern> = {
 };
 
 /**
- * pptx ST_PresetLineDashVal style → `setLineDash` pattern scaled by the stroked
- * width `lineW`. Returns `[]` for solid / continuous styles.
+ * pptx ST_TextUnderlineType (§20.1.10.82) style → `setLineDash` pattern scaled by
+ * the underline stroke width `lineW`. Returns `[]` for solid / continuous
+ * underline types (sng / dbl / wavy* / unknown).
  */
-export function pptxDashArray(style: string, lineW: number): number[] {
-  const relative = PPTX_DASH_RELATIVE[style];
+export function pptxUnderlineDashArray(style: string, lineW: number): number[] {
+  const relative = PPTX_UNDERLINE_RELATIVE[style];
   return relative ? dashArray(relative, lineW) : [];
 }

--- a/packages/core/src/draw/dash.ts
+++ b/packages/core/src/draw/dash.ts
@@ -5,9 +5,16 @@
  * parts of the standard, and — importantly — each renders the same *logical*
  * shape (a "dash", a "dot", a "dot-dash") with **different on/off lengths**:
  *
- *   - docx  §17.18.2  ST_Border           (dotted / dashed / dotDash / …)
- *   - xlsx  §18.18.3  ST_BorderStyle      (dashed / dotted / dashDot / hair / …)
+ *   - docx  §17.18.2  ST_Border            (dotted / dashed / dotDash / …)
+ *   - xlsx  §18.18.3  ST_BorderStyle       (dashed / dotted / dashDot / hair / …)
  *   - pptx  §20.1.10.49 ST_PresetLineDashVal (dot / dash / lgDash / sysDash / …)
+ *           — shape/line borders (`<a:ln><a:prstDash>`)
+ *   - pptx  §20.1.10.82 ST_TextUnderlineType (dotted / dash / dotDash / …)
+ *           — run underlines; a distinct enum that reuses some of the same shape
+ *             names as the preset line dash but is NOT the same list.
+ *
+ * pptx therefore carries TWO relative tables here (preset line dash + text
+ * underline), each keyed on its own enum's strings.
  *
  * The standard gives no normative pixel geometry for any of them, so each
  * renderer carries Word-/Excel-/PowerPoint-like approximations whose multipliers
@@ -115,6 +122,45 @@ const XLSX_BORDER_PX: Record<string, RelativeDashPattern> = {
 export function xlsxBorderDashArray(style: string): number[] {
   const px = XLSX_BORDER_PX[style];
   return px ? dashArray(px, 1) : [];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pptx — ECMA-376 §20.1.10.49 ST_PresetLineDashVal (shape/line borders, lw-relative)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * §20.1.10.49 ST_PresetLineDashVal (`<a:ln><a:prstDash val>`) → relative
+ * `[on, off, …]` pattern in units of the stroked width `lineW`, so the dashes
+ * scale with line thickness. The enum has 11 members; `solid` is intentionally
+ * absent (it maps to `[]` — a continuous line) so this table holds the other 10.
+ *
+ * The values are PowerPoint-like approximations and are DELIBERATELY not the
+ * spec's binary bit representations (§20.1.10.49 documents dash/dot cadences as
+ * bit patterns, not pixel lengths). They are part of pptx's visual contract and
+ * MUST NOT be changed. The `sys*` family uses the tighter Windows cosmetic-pen
+ * cadence; `lgDash*` is the "long dash" variant.
+ */
+const PPTX_PRESET_DASH_RELATIVE: Record<string, RelativeDashPattern> = {
+  dash: [6, 3],
+  dot: [1.5, 3],
+  dashDot: [6, 3, 1.5, 3],
+  lgDash: [10, 4],
+  lgDashDot: [10, 4, 1.5, 4],
+  lgDashDotDot: [10, 4, 1.5, 4, 1.5, 4],
+  sysDash: [4, 2],
+  sysDot: [1, 2],
+  sysDashDot: [4, 2, 1, 2],
+  sysDashDotDot: [4, 2, 1, 2, 1, 2],
+};
+
+/**
+ * pptx ST_PresetLineDashVal (§20.1.10.49) style → `setLineDash` pattern scaled
+ * by the stroked width `lineW`. Returns `[]` for solid / continuous styles and
+ * for any unknown value (table miss ⇒ solid line).
+ */
+export function pptxPresetDashArray(style: string, lineW: number): number[] {
+  const relative = PPTX_PRESET_DASH_RELATIVE[style];
+  return relative ? dashArray(relative, lineW) : [];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,15 +175,16 @@ export { EMU_PER_INCH, EMU_PER_PT, EMU_PER_PX, PT_TO_PX } from './units';
 export { isHTMLCanvas, defaultDpr } from './canvas/env';
 export { crispOffset } from './canvas/crisp';
 // Shared border / line dash-pattern core (§17.18.2 ST_Border / §18.18.3
-// ST_BorderStyle / §20.1.10.49 ST_PresetLineDashVal). One logical vocabulary +
-// the [on, off, …].map(x => x*unit) helper + per-format relative tables; each
-// format keeps its own multipliers (output is byte-identical to the old inline
-// implementations).
+// ST_BorderStyle / §20.1.10.49 ST_PresetLineDashVal shape borders /
+// §20.1.10.82 ST_TextUnderlineType run underlines). The
+// [on, off, …].map(x => x*unit) helper + per-format relative tables; each
+// format keeps its own multipliers. pptxPresetDashArray is intentionally not
+// exported — applyStroke consumes it internally.
 export {
   dashArray,
   docxBorderDashArray,
   xlsxBorderDashArray,
-  pptxDashArray,
+  pptxUnderlineDashArray,
   type RelativeDashPattern,
 } from './draw/dash';
 // Shared `double` border rail geometry (§17.18.2 / §18.18.3): floored-thirds

--- a/packages/core/src/shape/paint.test.ts
+++ b/packages/core/src/shape/paint.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { hexToRgba, relativeLuma, autoContrastColor } from './paint.js';
+import { hexToRgba, relativeLuma, autoContrastColor, applyStroke } from './paint.js';
+import type { Stroke } from '../types/common.js';
 
 // hexToRgba is the colour pipeline's exit point: the pptx parser resolves a
 // run's a:highlight (§21.1.2.3.4) to either a 6-char opaque hex or, when an
@@ -79,5 +80,92 @@ describe('autoContrastColor (impl-defined; §17.3.2.6 w:color auto)', () => {
   it('tolerates a leading # (same normalisation as hexToRgba)', () => {
     expect(autoContrastColor('#000000')).toBe('#FFFFFF');
     expect(autoContrastColor('#ffffff')).toBe('#000000');
+  });
+});
+
+// applyStroke turns a Stroke's prstDash value (ST_PresetLineDashVal, §20.1.10.49)
+// into a setLineDash pattern. A minimal mock records the last setLineDash
+// argument so we can assert dashed vs continuous (solid) output.
+function makeStrokeMock(): {
+  ctx: CanvasRenderingContext2D;
+  lastDash: () => number[];
+} {
+  let dash: number[] = [];
+  const ctx = {
+    strokeStyle: '',
+    lineWidth: 0,
+    setLineDash(segments: number[]) {
+      dash = segments;
+    },
+  };
+  return {
+    ctx: ctx as unknown as CanvasRenderingContext2D,
+    lastDash: () => dash,
+  };
+}
+
+function strokeWith(dashStyle: string): Stroke {
+  // width is in EMU; with emuPerPx = 1 the pixel line width lw = max(0.5, 2) = 2.
+  return { color: '#000000', width: 2, dashStyle };
+}
+
+// The Rust parsers filter out "solid" from prstDash @val at parse time, so
+// applyStroke only ever sees the remaining 10 ST_PresetLineDashVal members —
+// each of which must produce a NON-empty setLineDash pattern (a table miss
+// would silently render them as a solid line, which is the bug this guards).
+const PRESET_DASH_STYLES = [
+  'dot',
+  'dash',
+  'lgDash',
+  'dashDot',
+  'lgDashDot',
+  'lgDashDotDot',
+  'sysDash',
+  'sysDot',
+  'sysDashDot',
+  'sysDashDotDot',
+] as const;
+
+describe('applyStroke dash patterns (§20.1.10.49 ST_PresetLineDashVal)', () => {
+  it('renders sysDashDotDot with a non-empty dash pattern (not solid)', () => {
+    const { ctx, lastDash } = makeStrokeMock();
+    applyStroke(ctx, strokeWith('sysDashDotDot'), 1);
+    expect(lastDash().length).toBeGreaterThan(0);
+  });
+
+  it('covers every non-solid ST_PresetLineDashVal value with a dash pattern', () => {
+    for (const style of PRESET_DASH_STYLES) {
+      const { ctx, lastDash } = makeStrokeMock();
+      applyStroke(ctx, strokeWith(style), 1);
+      expect(
+        lastDash().length,
+        `dash style "${style}" should not render as solid`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders solid (no dashStyle) and unknown styles as a continuous line', () => {
+    for (const stroke of [
+      { color: '#000000', width: 2 } as Stroke,
+      { color: '#000000', width: 2, dashStyle: 'solid' } as Stroke,
+      { color: '#000000', width: 2, dashStyle: 'notARealStyle' } as Stroke,
+    ]) {
+      const { ctx, lastDash } = makeStrokeMock();
+      applyStroke(ctx, stroke, 1);
+      expect(lastDash()).toEqual([]);
+    }
+  });
+
+  it('handles a null stroke as a continuous (empty-dash) line', () => {
+    const { ctx, lastDash } = makeStrokeMock();
+    applyStroke(ctx, null, 1);
+    expect(lastDash()).toEqual([]);
+  });
+
+  it('scales the dash pattern by the pixel line width', () => {
+    // sysDash relative pattern is [4, 2]; lw = width(2) * emuPerPx(3) = 6.
+    const { ctx, lastDash } = makeStrokeMock();
+    applyStroke(ctx, strokeWith('sysDash'), 3);
+    expect(lastDash()).toEqual([24, 12]);
   });
 });

--- a/packages/core/src/shape/paint.ts
+++ b/packages/core/src/shape/paint.ts
@@ -1,5 +1,6 @@
 import type { Fill, PatternFill, Stroke } from '../types/common';
 import { buildPatternBitmap } from './pattern-bitmaps';
+import { pptxPresetDashArray } from '../draw/dash';
 
 /**
  * Convert a 6- or 8-char hex colour to a CSS `rgba()` string.
@@ -118,22 +119,13 @@ function resolvePatternFill(
   return pat;
 }
 
-const DASH_PATTERNS: Record<string, number[]> = {
-  dash:         [6, 3],
-  dot:          [1.5, 3],
-  dashDot:      [6, 3, 1.5, 3],
-  lgDash:       [10, 4],
-  lgDashDot:    [10, 4, 1.5, 4],
-  lgDashDotDot: [10, 4, 1.5, 4, 1.5, 4],
-  sysDash:      [4, 2],
-  sysDot:       [1, 2],
-  sysDashDot:   [4, 2, 1, 2],
-  sysDashDotDot:[4, 2, 1, 2, 1, 2],
-};
-
 /**
  * Apply a Stroke to ctx. `emuPerPx` converts stroke width from EMU to px
  * (e.g. scale factor from pptx's emuToPx).
+ *
+ * The dash pattern comes from `pptxPresetDashArray` (§20.1.10.49
+ * ST_PresetLineDashVal), which already scales by the pixel line width and
+ * returns `[]` for solid / unknown styles.
  */
 export function applyStroke(
   ctx: CanvasRenderingContext2D,
@@ -149,6 +141,5 @@ export function applyStroke(
   ctx.strokeStyle = hexToRgba(stroke.color);
   const lw = Math.max(0.5, stroke.width * emuPerPx);
   ctx.lineWidth = lw;
-  const pat = stroke.dashStyle ? DASH_PATTERNS[stroke.dashStyle] : null;
-  ctx.setLineDash(pat ? pat.map((v) => v * lw) : []);
+  ctx.setLineDash(stroke.dashStyle ? pptxPresetDashArray(stroke.dashStyle, lw) : []);
 }

--- a/packages/core/src/shape/paint.ts
+++ b/packages/core/src/shape/paint.ts
@@ -128,6 +128,7 @@ const DASH_PATTERNS: Record<string, number[]> = {
   sysDash:      [4, 2],
   sysDot:       [1, 2],
   sysDashDot:   [4, 2, 1, 2],
+  sysDashDotDot:[4, 2, 1, 2, 1, 2],
 };
 
 /**

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -71,7 +71,7 @@ import {
   highlightBox,
   symbolFontToUnicode,
   isSymbolFontFamily,
-  pptxDashArray,
+  pptxUnderlineDashArray,
   intendedSingleLinePx,
 } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput } from '@silurus/ooxml-core';
@@ -232,8 +232,10 @@ function drawUnderline(
   ctx.setLineDash([]);
 
   // Dash patterns scaled by lineW so they stay proportional at any font size,
-  // computed via core's shared pptxDashArray (§20.1.10.49 ST_PresetLineDashVal,
-  // whose shape names the underline enum reuses) at the call site below.
+  // computed via core's shared pptxUnderlineDashArray (§20.1.10.82
+  // ST_TextUnderlineType — the run-underline enum, distinct from the
+  // §20.1.10.49 preset line dash though it reuses a few shape names) at the
+  // call site below.
 
   if (style && style.startsWith('wavy')) {
     // Sine wave with amplitude ≈ lineW and wavelength ≈ 6×lineW.
@@ -274,7 +276,7 @@ function drawUnderline(
     return;
   }
 
-  ctx.setLineDash(pptxDashArray(style ?? 'sng', lineW));
+  ctx.setLineDash(pptxUnderlineDashArray(style ?? 'sng', lineW));
   ctx.beginPath();
   ctx.moveTo(x, y + crispY);
   ctx.lineTo(x + width, y + crispY);


### PR DESCRIPTION
## Summary

Phase 1 item A6 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md) — **redefined after inspection disproved the original finding**.

### What the plan claimed vs. what the code says
The plan said the two dash tables in core were duplicate implementations of the same concept and that `lgDash` fell through to solid in one of them. Inspection showed they are **different concepts**: `paint.ts`'s `DASH_PATTERNS` handles §20.1.10.49 ST_PresetLineDashVal (outline `prstDash`), while `draw/dash.ts`'s `pptxDashArray` — despite its JSDoc citing §20.1.10.49 — actually keys on **§20.1.10.82 ST_TextUnderlineType** vocabulary and is only ever called from the text-underline painter (`style ?? 'sng'`). No prstDash value ever reaches it, so the claimed lgDash bug does not exist.

### The real bug: sysDashDotDot rendered as a solid line
`DASH_PATTERNS` covered only 10 of ST_PresetLineDashVal's 11 members — `sysDashDotDot` missed the table and fell through to `setLineDash([])`. Added `[4, 2, 1, 2, 1, 2]`, consistent with the existing sys-family approximations (sysDash `[4,2]`, sysDot `[1,2]`, sysDashDot `[4,2,1,2]`). TDD: test written first (Red: 2 failed — pattern was `[]`), fix (Green: 18 passed). A completeness guard now pins all 10 non-solid members.

### Consolidation (behavior-preserving)
The preset table moved to `draw/dash.ts` as `PPTX_PRESET_DASH_RELATIVE` + `pptxPresetDashArray`, completing that file's charter (every format's dash vocabulary in one place); `applyStroke` now consumes it and the inline `pat.map` is gone. A parameterized byte-equivalence suite pins every enum member to the previous inline output. Not added to the barrel — `applyStroke` is the only consumer.

### Rename to prevent the trap the plan fell into
`pptxDashArray` → `pptxUnderlineDashArray` (`PPTX_DASH_RELATIVE` → `PPTX_UNDERLINE_RELATIVE`) with the JSDoc corrected to §20.1.10.82, plus the same citation fix at the pptx call site. Grep confirmed zero external consumers (core barrel + pptx renderer only) — safe 0.x rename, no alias.

## Verification
- `pnpm test`: 169 files / 1503 tests green
- `pnpm typecheck` (root), `pnpm lint`: clean
- `pnpm smoke`: 6/6
- `pnpm build:wasm && pnpm vrt`: docx 21 / xlsx 67 / pptx 75 passed, **zero threshold failures** — sysDashDotDot appears in no committed reference (predicted); references untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)