### PR TITLE
fix(parsers): unify WASM error API, remove panic path, consolidate zip readers (D11+D9+D7)

### DIFF
--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -9,15 +9,12 @@ mod types;
 mod xml_util;
 
 #[wasm_bindgen]
-pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> String {
+pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
-    match parser::parse(data) {
-        Ok(doc) => {
-            serde_json::to_string(&doc).unwrap_or_else(|e| format!("{{\"error\":\"{}\"}}", e))
-        }
-        Err(e) => format!("{{\"error\":\"{}\"}}", e),
-    }
+    let doc =
+        parser::parse(data).map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
+    serde_json::to_string(&doc).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
 /// WASM-callable markdown projection (mirrors `to_markdown_native`). Returns
@@ -79,5 +76,26 @@ mod tests {
             w.finish().unwrap();
         }
         assert_eq!(extract_image(&buf, "word/media/i.png", None).unwrap(), b"X");
+    }
+
+    /// `parse_docx` now returns `Result<String, JsValue>` (Err surfaces as a
+    /// thrown JS Error), replacing the old hand-built `{"error":"…"}` string.
+    /// The old path double-embedded the parser message into JSON *without
+    /// escaping*, so a message containing a `"` produced invalid JSON that made
+    /// the TS-side `JSON.parse` throw a confusing SyntaxError instead of the
+    /// real cause. We can't call the `#[wasm_bindgen]` fn from a plain unit
+    /// test (that needs wasm-bindgen-test), but `parse_docx` is now a thin
+    /// `parser::parse(...).map_err(...)?` wrapper, so proving the internal
+    /// parse returns a plain `Err(String)` for bad input is enough: the JSON
+    /// escaping hazard is gone *by construction* because the error never round
+    /// trips through hand-assembled JSON — wasm-bindgen serializes the string.
+    #[test]
+    fn parse_rejects_non_zip_bytes_without_json_escaping_hazard() {
+        // Not a zip archive — parser::parse must return Err, not panic.
+        let err = parser::parse(&[1, 2, 3]).expect_err("non-zip bytes must error");
+        // A raw String error is returned verbatim; even a `"`-laden message is
+        // carried as-is (no manual `{"error":"…"}` templating to corrupt).
+        let quoted = format!("boom: \"{}\"", err);
+        assert!(quoted.contains('"'), "sanity: message can contain quotes");
     }
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,7 +1,7 @@
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
+use ooxml_common::zip::{read_zip_bytes, read_zip_string};
 use roxmltree::Document as XmlDoc;
 use std::collections::HashMap;
-use std::io::Read;
 use zip::ZipArchive;
 
 use crate::numbering::NumberingMap;
@@ -75,7 +75,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     let cursor = std::io::Cursor::new(data);
     let mut zip = ZipArchive::new(cursor).map_err(|e| e.to_string())?;
 
-    let rels_xml = read_zip_entry(&mut zip, "word/_rels/document.xml.rels").unwrap_or_default();
+    let rels_xml = read_zip_string(&mut zip, "word/_rels/document.xml.rels").unwrap_or_default();
     let rel_map = parse_rels(&rels_xml);
 
     // Styles are referenced from the document relationships (Target may be
@@ -89,7 +89,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             }
         })
         .unwrap_or_else(|| "word/styles.xml".to_string());
-    let style_map = read_zip_entry(&mut zip, &styles_path)
+    let style_map = read_zip_string(&mut zip, &styles_path)
         .map(|s| StyleMap::parse(&s))
         .unwrap_or_else(|_| StyleMap::parse(""));
 
@@ -118,11 +118,11 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             .map(|(d, _)| d)
             .unwrap_or("word");
         let rels_path = format!("{}/_rels/{}.xml.rels", dir, stem);
-        let rels_xml = read_zip_entry(&mut zip, &rels_path).unwrap_or_default();
+        let rels_xml = read_zip_string(&mut zip, &rels_path).unwrap_or_default();
         let rel_map = parse_rels(&rels_xml);
         load_media_map(&mut zip, &rel_map, &format!("{}/", dir))
     };
-    let mut num_map = read_zip_entry(&mut zip, &numbering_path)
+    let mut num_map = read_zip_string(&mut zip, &numbering_path)
         .map(|s| NumberingMap::parse(&s, &numbering_media_map))
         .unwrap_or_default();
 
@@ -135,7 +135,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             } else {
                 format!("word/{}", t)
             };
-            read_zip_entry(&mut zip, &p)
+            read_zip_string(&mut zip, &p)
                 .map(|s| ThemeColors::parse(&s))
                 .unwrap_or_default()
         })
@@ -156,7 +156,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     // §17.10.1 even/odd headers is a settings.xml flag (not a sectPr property), so
     // capture it here and stamp it onto the section below.
     let mut even_and_odd_headers = false;
-    if let Ok(settings_xml) = read_zip_entry(&mut zip, &settings_path) {
+    if let Ok(settings_xml) = read_zip_string(&mut zip, &settings_path) {
         if let Some(lang) = parse_theme_font_bidi_lang(&settings_xml) {
             theme.fill_default_cs_font(&lang);
         }
@@ -177,7 +177,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
 
     let media_map = load_media_map(&mut zip, &rel_map, "word/");
 
-    let doc_xml = read_zip_entry(&mut zip, "word/document.xml")?;
+    let doc_xml = read_zip_string(&mut zip, "word/document.xml")?;
     let xml_doc = XmlDoc::parse(&doc_xml).map_err(|e| e.to_string())?;
 
     let body_node = xml_doc
@@ -274,7 +274,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             }
         })
         .unwrap_or_else(|| "word/fontTable.xml".to_string());
-    let font_family_classes = read_zip_entry(&mut zip, &font_table_path)
+    let font_family_classes = read_zip_string(&mut zip, &font_table_path)
         .map(|s| parse_font_table(&s))
         .unwrap_or_default();
 
@@ -292,7 +292,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
                 format!("word/{}", t)
             }
         })
-        .and_then(|p| read_zip_entry(&mut zip, &p).ok())
+        .and_then(|p| read_zip_string(&mut zip, &p).ok())
         .map(|xml| parse_comments(&xml))
         .unwrap_or_default();
     let footnotes_path = find_rel_target(&rels_xml, "footnotes").map(|t| {
@@ -444,7 +444,7 @@ fn parse_notes(
     num_map: &mut NumberingMap,
     theme: &ThemeColors,
 ) -> Vec<crate::types::DocxNote> {
-    let Ok(xml) = read_zip_entry(zip, path) else {
+    let Ok(xml) = read_zip_string(zip, path) else {
         return Vec::new();
     };
 
@@ -461,7 +461,7 @@ fn parse_notes(
     } else {
         format!("{}/", dir)
     };
-    let rels_xml = read_zip_entry(zip, &rels_path).unwrap_or_default();
+    let rels_xml = read_zip_string(zip, &rels_path).unwrap_or_default();
     let local_rel_map = parse_rels(&rels_xml);
     let local_media_map = load_media_map(zip, &local_rel_map, &base_dir);
 
@@ -1355,7 +1355,7 @@ fn load_header_footer_set(
     let mut out = HeadersFooters::default();
     for (kind, target) in type_to_target {
         let path = format!("word/{}", target);
-        let xml = match read_zip_entry(zip, &path) {
+        let xml = match read_zip_string(zip, &path) {
             Ok(s) => s,
             Err(_) => continue,
         };
@@ -1363,7 +1363,7 @@ fn load_header_footer_set(
         // Per-file rels for image resolution
         let stem = target.trim_end_matches(".xml");
         let rels_path = format!("word/_rels/{}.xml.rels", stem);
-        let rels_xml = read_zip_entry(zip, &rels_path).unwrap_or_default();
+        let rels_xml = read_zip_string(zip, &rels_path).unwrap_or_default();
         let local_rel_map = parse_rels(&rels_xml);
         let local_media_map = load_media_map(zip, &local_rel_map, "word/");
 
@@ -5580,36 +5580,6 @@ fn parse_rels(xml: &str) -> HashMap<String, String> {
         }
     }
     map
-}
-
-fn read_zip_entry(zip: &mut Zip, path: &str) -> Result<String, String> {
-    let max = ooxml_common::zip::current_max();
-    let mut entry = zip.by_name(path).map_err(|e| format!("{}: {}", path, e))?;
-    if entry.size() > max {
-        return Err(format!("{}: exceeds size limit", path));
-    }
-    let mut s = String::new();
-    entry
-        .by_ref()
-        .take(max)
-        .read_to_string(&mut s)
-        .map_err(|e| e.to_string())?;
-    Ok(s)
-}
-
-fn read_zip_bytes(zip: &mut Zip, path: &str) -> Result<Vec<u8>, String> {
-    let max = ooxml_common::zip::current_max();
-    let mut entry = zip.by_name(path).map_err(|e| format!("{}: {}", path, e))?;
-    if entry.size() > max {
-        return Err(format!("{}: exceeds size limit", path));
-    }
-    let mut buf = vec![];
-    entry
-        .by_ref()
-        .take(max)
-        .read_to_end(&mut buf)
-        .map_err(|e| e.to_string())?;
-    Ok(buf)
 }
 
 #[cfg(test)]

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -61,8 +61,10 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
       currentBuffer = new Uint8Array(req.data);
+      // `parse_docx` throws on parse/serialize failure (Result<String,
+      // JsValue>); the outer try/catch converts it into an error response, so
+      // the JSON here is always the success model — no error-field probe.
       const parsed = JSON.parse(parse_docx(currentBuffer, currentMaxZipEntryBytes));
-      if (parsed.error) throw new Error(`Parse error: ${parsed.error}`);
       doc = parsed as DocxDocumentModel;
       if (req.useGoogleFonts) {
         // Pagination measures text, so fonts must land BEFORE computePages —

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -28,9 +28,12 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
       currentBuffer = new Uint8Array(req.data);
+      // `parse_docx` returns the model JSON on success and throws a JS Error on
+      // parse/serialize failure (Result<String, JsValue>), matching pptx/xlsx.
+      // The throw is caught by the outer try/catch below, so no error-field
+      // probe is needed here.
       const json = parse_docx(currentBuffer, currentMaxZipEntryBytes);
       const document = JSON.parse(json);
-      if (document.error) throw new Error(`Parse error: ${document.error}`);
       const res: WorkerResponse = { type: 'parsed', id, document };
       self.postMessage(res);
       return;

--- a/packages/ooxml-common/src/zip.rs
+++ b/packages/ooxml-common/src/zip.rs
@@ -84,6 +84,59 @@ pub fn extract_zip_entry(
     Ok(buf)
 }
 
+/// Read one entry's bytes from an **already-opened** [`ZipArchive`]. Twin of
+/// [`extract_zip_entry`] for callers that keep a single archive open across
+/// many reads (the common case inside a parser) instead of re-opening it from
+/// the raw bytes per entry. Honors the scoped max-entry guard: an entry whose
+/// declared size exceeds the current cap is rejected with an `Err`, never
+/// silently truncated (the zip-bomb DoS guard). Generic over the archive's
+/// reader so each parser's concrete type (`Cursor<&[u8]>`, …) works unchanged.
+pub fn read_zip_bytes<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    path: &str,
+) -> Result<Vec<u8>, String> {
+    use std::io::Read;
+    let max = current_max();
+    let mut entry = archive
+        .by_name(path)
+        .map_err(|e| format!("entry not found: {path}: {e}"))?;
+    if entry.size() > max {
+        return Err(format!("ZIP entry exceeds size limit: {path}"));
+    }
+    let mut buf = Vec::with_capacity(entry.size() as usize);
+    entry
+        .by_ref()
+        .take(max)
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("read error: {e}"))?;
+    Ok(buf)
+}
+
+/// UTF-8 string counterpart of [`read_zip_bytes`] for XML parts. Same cap
+/// enforcement and archive-reuse contract; decodes the entry as UTF-8 (strict —
+/// OOXML parts are well-formed UTF-8, and a decode failure is a real corruption
+/// worth reporting rather than papering over with lossy substitution).
+pub fn read_zip_string<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    path: &str,
+) -> Result<String, String> {
+    use std::io::Read;
+    let max = current_max();
+    let mut entry = archive
+        .by_name(path)
+        .map_err(|e| format!("entry not found: {path}: {e}"))?;
+    if entry.size() > max {
+        return Err(format!("ZIP entry exceeds size limit: {path}"));
+    }
+    let mut buf = String::new();
+    entry
+        .by_ref()
+        .take(max)
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("read error: {e}"))?;
+    Ok(buf)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,6 +177,61 @@ mod tests {
         // A cap above the size reads the entry in full.
         assert_eq!(
             extract_zip_entry(&buf, "ppt/media/big.bin", Some(64)).unwrap(),
+            b"12345678"
+        );
+    }
+
+    /// Build a one-entry in-memory zip for the open-archive helper tests.
+    fn archive_with(name: &str, body: &[u8]) -> zip::ZipArchive<std::io::Cursor<Vec<u8>>> {
+        use std::io::{Cursor, Write};
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default();
+            w.start_file(name, opts).unwrap();
+            w.write_all(body).unwrap();
+            w.finish().unwrap();
+        }
+        zip::ZipArchive::new(Cursor::new(buf)).unwrap()
+    }
+
+    #[test]
+    fn read_zip_bytes_reads_present_and_reports_missing() {
+        let mut ar = archive_with("word/document.xml", b"<xml/>");
+        assert_eq!(
+            read_zip_bytes(&mut ar, "word/document.xml").unwrap(),
+            b"<xml/>"
+        );
+        let err = read_zip_bytes(&mut ar, "word/missing.xml").unwrap_err();
+        assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn read_zip_string_reads_present_and_reports_missing() {
+        let mut ar = archive_with("xl/workbook.xml", b"<workbook/>");
+        assert_eq!(
+            read_zip_string(&mut ar, "xl/workbook.xml").unwrap(),
+            "<workbook/>"
+        );
+        let err = read_zip_string(&mut ar, "xl/nope.xml").unwrap_err();
+        assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn read_zip_helpers_reject_oversized_under_scoped_cap() {
+        // 8-byte entry; a scoped cap of 4 must reject (never truncate) — the
+        // zip-bomb guard applies to the open-archive helpers too.
+        let mut ar = archive_with("ppt/media/big.bin", b"12345678");
+        {
+            let _guard = scoped_max(Some(4));
+            let be = read_zip_bytes(&mut ar, "ppt/media/big.bin").unwrap_err();
+            assert!(be.contains("exceeds size limit"), "got: {be}");
+            let se = read_zip_string(&mut ar, "ppt/media/big.bin").unwrap_err();
+            assert!(se.contains("exceeds size limit"), "got: {se}");
+        }
+        // Cap restored on guard drop → the same entry now reads in full.
+        assert_eq!(
+            read_zip_bytes(&mut ar, "ppt/media/big.bin").unwrap(),
             b"12345678"
         );
     }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1722,17 +1722,6 @@ fn read_zip_str(zip: &mut PptxZip<'_>, path: &str) -> Result<String, Box<dyn std
     Ok(buf)
 }
 
-fn read_zip_bytes(zip: &mut PptxZip<'_>, path: &str) -> Option<Vec<u8>> {
-    let max = ooxml_common::zip::current_max();
-    let mut file = zip.by_name(path).ok()?;
-    if file.size() > max {
-        return None;
-    }
-    let mut buf = Vec::new();
-    file.by_ref().take(max).read_to_end(&mut buf).ok()?;
-    Some(buf)
-}
-
 // ===========================
 //  Table style data model
 // ===========================
@@ -3909,7 +3898,7 @@ fn parse_master_level_bullets(
         // Verify the part exists so a listed-but-missing rId yields None and the
         // bullet falls through to Bullet::Inherit (matches the variant's doc
         // comment), mirroring the master background resolver.
-        read_zip_bytes(zip, &path)?;
+        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
         Some(path)
     };
 
@@ -4229,7 +4218,7 @@ fn parse_layout_placeholders(
             // Verify the part exists so a listed-but-missing rId yields None and
             // the bullet falls through to Bullet::Inherit (matches the variant's
             // doc comment), mirroring the master/layout background resolvers.
-            read_zip_bytes(zip, &path)?;
+            ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
             Some(path)
         };
         let layout_level_bullets: LevelBullets = child(sp, "txBody")
@@ -4292,7 +4281,7 @@ fn parse_layout_placeholders(
             let image_path = resolve_path(layout_dir, rel_target);
             // Verify the part exists so a dangling rId yields None (no inherited
             // fill), preserving the prior data-URL behaviour.
-            read_zip_bytes(zip, &image_path)?;
+            ooxml_common::zip::read_zip_bytes(zip, &image_path).ok()?;
             let mime_type = mime_from_ext(&image_path).to_owned();
             Some(InheritedBlipFill {
                 image_path,
@@ -4620,7 +4609,7 @@ fn parse_text_body(
         // Verify the part exists so a listed-but-missing rId yields None and the
         // bullet falls through to Bullet::Inherit (matches the variant's doc
         // comment), mirroring the slide picture-fill resolvers.
-        read_zip_bytes(zip, &path)?;
+        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
         Some(path)
     };
     let own_level_bullets = extract_level_bullets(tx_body, theme, &mut resolve_slide_blip);
@@ -4863,7 +4852,7 @@ fn parse_paragraph(
         // Verify the part exists so a listed-but-missing rId yields None and the
         // bullet falls through to Bullet::Inherit (matches the variant's doc
         // comment), mirroring the slide picture-fill resolvers.
-        read_zip_bytes(zip, &path)?;
+        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
         Some(path)
     };
     let bullet = match parse_bullet(p_pr, theme, &mut resolve_para_blip) {
@@ -6923,7 +6912,7 @@ fn svg_blip_path(
     let svg_rid = svg_blip_rid(blip)?;
     let svg_target = rels.get(&svg_rid)?;
     let svg_path = resolve_path(slide_dir, svg_target);
-    read_zip_bytes(zip, &svg_path)?;
+    ooxml_common::zip::read_zip_bytes(zip, &svg_path).ok()?;
     Some(svg_path)
 }
 
@@ -6961,7 +6950,7 @@ fn parse_picture(
         let r_id = attr_r(&blip, "embed")?;
         let rel_target = rels.get(&r_id)?;
         let path = resolve_path(slide_dir, rel_target);
-        let image_bytes = read_zip_bytes(zip, &path)?;
+        let image_bytes = ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
         // Intrinsic PNG size for the ink-fallback centering (None for non-PNG,
         // unchanged from the former png_size_from_data_url semantics).
         let size = png_size_from_bytes(&image_bytes);
@@ -7868,7 +7857,7 @@ fn parse_slide(
             // Resolve to the zip path; verify the part exists so a dangling
             // rId still yields None (the bg chain then falls through to the
             // next level), preserving the prior data-URL behaviour.
-            read_zip_bytes(zip, &path)?;
+            ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
             Some(path)
         };
         background = parse_background(n, theme, &mut resolve);
@@ -7882,7 +7871,7 @@ fn parse_slide(
                     let mut resolve = |rid: &str| -> Option<String> {
                         let target = layout_rels.get(rid)?;
                         let path = resolve_path(layout_dir, target);
-                        read_zip_bytes(zip, &path)?;
+                        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
                         Some(path)
                     };
                     background = parse_background(n, theme, &mut resolve);
@@ -8142,7 +8131,7 @@ fn parse_sp_tree_node(
                     if t.cx > 0 && t.cy > 0 {
                         if let Some(target) = rels.get(rid) {
                             let image_path = resolve_path(slide_dir, target);
-                            if let Some(bytes) = read_zip_bytes(zip, &image_path) {
+                            if let Ok(bytes) = ooxml_common::zip::read_zip_bytes(zip, &image_path) {
                                 let mime_type = mime_from_ext(&image_path).to_owned();
                                 let (intrinsic_width_px, intrinsic_height_px) =
                                     match png_size_from_bytes(&bytes) {
@@ -8300,7 +8289,9 @@ fn parse_sp_tree_node(
                         if let Some(rid) = r_id {
                             if let Some(rel_target) = rels.get(&rid) {
                                 let image_path = resolve_path(slide_dir, rel_target);
-                                if let Some(image_bytes) = read_zip_bytes(zip, &image_path) {
+                                if let Ok(image_bytes) =
+                                    ooxml_common::zip::read_zip_bytes(zip, &image_path)
+                                {
                                     let mime_type = mime_from_ext(&image_path).to_owned();
                                     let (intrinsic_width_px, intrinsic_height_px) =
                                         match png_size_from_bytes(&image_bytes) {
@@ -9019,7 +9010,7 @@ fn build_master_bundle(
         let mut resolve = |rid: &str| -> Option<String> {
             let target = master_rels.get(rid)?;
             let path = resolve_path(&master_dir, target);
-            read_zip_bytes(zip, &path)?;
+            ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
             Some(path)
         };
         parse_background(c_sld, &theme, &mut resolve)
@@ -9325,7 +9316,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
                 let mut resolve = |rid: &str| -> Option<String> {
                     let target = bundle.master_rels.get(rid)?;
                     let path = resolve_path(&bundle.master_dir, target);
-                    read_zip_bytes(&mut zip, &path)?;
+                    ooxml_common::zip::read_zip_bytes(&mut zip, &path).ok()?;
                     Some(path)
                 };
                 parse_background(c_sld, &theme, &mut resolve)

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1,5 +1,6 @@
 use crate::types::*;
-use crate::{parse_rels_map, read_zip_entry, resolve_fill_color, resolve_zip_path};
+use crate::{parse_rels_map, resolve_fill_color, resolve_zip_path};
+use ooxml_common::zip::read_zip_string;
 use std::collections::HashMap;
 use std::io::Cursor;
 
@@ -14,7 +15,7 @@ pub(crate) fn load_sheet_charts(
         return Vec::new();
     };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+    let Ok(sheet_rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
     let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
@@ -47,7 +48,7 @@ pub(crate) fn load_sheet_charts(
     for target in drawing_targets {
         // Resolve drawing path relative to the sheet directory
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+        let Ok(drawing_xml) = read_zip_string(archive, &drawing_path) else {
             continue;
         };
         let Ok(draw_doc) = roxmltree::Document::parse(&drawing_xml) else {
@@ -59,7 +60,7 @@ pub(crate) fn load_sheet_charts(
             continue;
         };
         let drawing_rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
-        let drawing_rels = read_zip_entry(archive, &drawing_rels_path)
+        let drawing_rels = read_zip_string(archive, &drawing_rels_path)
             .ok()
             .map(|xml| parse_rels_map(&xml))
             .unwrap_or_default();
@@ -170,7 +171,7 @@ pub(crate) fn load_sheet_charts(
                 continue;
             };
             let chart_path = resolve_zip_path(drawing_dir, chart_target);
-            let Ok(chart_xml) = read_zip_entry(archive, &chart_path) else {
+            let Ok(chart_xml) = read_zip_string(archive, &chart_path) else {
                 continue;
             };
             let Some(chart_data) = parse_chart_xml(&chart_xml, c_ns, a_ns, theme_colors) else {

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1,5 +1,6 @@
 use crate::types::*;
-use crate::{parse_rels_map, read_zip_bytes, read_zip_entry, resolve_zip_path};
+use crate::{parse_rels_map, resolve_zip_path};
+use ooxml_common::zip::{read_zip_bytes, read_zip_string};
 // Shared DrawingML blip helpers (ECMA-376 §20.1.8.13 + Microsoft 2016 SVG
 // extension, MS-ODRAWXML). `mime_from_ext` is the single source of truth for
 // `.svg ⇒ image/svg+xml`; `svg_blip_rid` resolves the vector original nested in
@@ -129,7 +130,7 @@ pub(crate) fn parse_drawing_anchors(
             let media_path = resolve_zip_path(drawing_dir, target);
             // Confirm the entry resolves before emitting its path (preserves the
             // previous "drop when bytes are missing" semantics).
-            read_zip_bytes(archive, &media_path)?;
+            read_zip_bytes(archive, &media_path).ok()?;
             Some(media_path)
         };
 
@@ -1369,7 +1370,7 @@ pub(crate) fn load_sheet_shape_groups(
         return Vec::new();
     };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+    let Ok(sheet_rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
     let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
@@ -1390,7 +1391,7 @@ pub(crate) fn load_sheet_shape_groups(
     let mut all: Vec<ShapeAnchor> = Vec::new();
     for target in drawing_targets {
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+        let Ok(drawing_xml) = read_zip_string(archive, &drawing_path) else {
             continue;
         };
         let rid_urls = build_drawing_rid_urls(archive, &drawing_path);
@@ -1417,7 +1418,7 @@ pub(crate) fn build_drawing_rid_urls(
         return HashMap::new();
     };
     let rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
-    let rels = read_zip_entry(archive, &rels_path)
+    let rels = read_zip_string(archive, &rels_path)
         .ok()
         .map(|xml| parse_rels_map(&xml))
         .unwrap_or_default();
@@ -1440,7 +1441,7 @@ pub(crate) fn build_drawing_rid_urls(
         let media_path = resolve_zip_path(drawing_dir, &target);
         // Only emit the path when the entry actually resolves (preserves the
         // previous behavior of dropping rIds whose bytes are missing).
-        if read_zip_bytes(archive, &media_path).is_some() {
+        if read_zip_bytes(archive, &media_path).is_ok() {
             result.insert(rid, media_path);
         }
     }
@@ -1458,7 +1459,7 @@ pub(crate) fn load_sheet_images(
         return Vec::new();
     };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+    let Ok(sheet_rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
 
@@ -1488,7 +1489,7 @@ pub(crate) fn load_sheet_images(
         // sheet_dir is "worksheets", target typically "../drawings/drawing1.xml"
         // base dir for the drawing = "xl/worksheets" + "../drawings" → "xl/drawings"
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+        let Ok(drawing_xml) = read_zip_string(archive, &drawing_path) else {
             continue;
         };
         // Drawing rels:  xl/drawings/_rels/drawing1.xml.rels
@@ -1496,7 +1497,7 @@ pub(crate) fn load_sheet_images(
             continue;
         };
         let drawing_rels_path = format!("{}/_rels/{}.rels", drawing_dir, drawing_file);
-        let drawing_rels = read_zip_entry(archive, &drawing_rels_path)
+        let drawing_rels = read_zip_string(archive, &drawing_rels_path)
             .ok()
             .map(|xml| parse_rels_map(&xml))
             .unwrap_or_default();

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -42,9 +42,8 @@ const INDEXED_COLORS: &[&str] = &[
 pub fn parse_xlsx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
-    parse_xlsx_inner(data)
-        .map(|wb| serde_json::to_string(&wb).unwrap())
-        .map_err(|e| JsValue::from_str(&e))
+    let wb = parse_xlsx_inner(data).map_err(|e| JsValue::from_str(&e))?;
+    serde_json::to_string(&wb).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
 #[wasm_bindgen]

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::io::{Cursor, Read};
 use wasm_bindgen::prelude::*;
 
+use ooxml_common::zip::read_zip_string;
+
 mod markdown;
 
 mod types;
@@ -58,7 +60,7 @@ pub fn parse_sheet(
     let cursor = Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
 
-    let workbook_xml = read_zip_entry(&mut archive, "xl/workbook.xml")?;
+    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
     let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
     let sheets = parse_workbook_sheets(&wb_doc);
 
@@ -67,14 +69,14 @@ pub fn parse_sheet(
         .ok_or_else(|| format!("sheet index {} out of range", sheet_index))?;
 
     // Resolve rId → target path from workbook.xml.rels
-    let rels_xml = read_zip_entry(&mut archive, "xl/_rels/workbook.xml.rels")?;
+    let rels_xml = read_zip_string(&mut archive, "xl/_rels/workbook.xml.rels")?;
     let rels_doc = roxmltree::Document::parse(&rels_xml).map_err(|e| e.to_string())?;
     let sheet_path = resolve_sheet_path(&rels_doc, &sheet_meta.r_id)
         .ok_or_else(|| format!("rId {} not found in rels", sheet_meta.r_id))?;
 
     let theme_colors = parse_theme_colors(&mut archive);
     let shared_strings = read_shared_strings(&mut archive, &theme_colors);
-    let sheet_xml = read_zip_entry(&mut archive, &format!("xl/{}", sheet_path))?;
+    let sheet_xml = read_zip_string(&mut archive, &format!("xl/{}", sheet_path))?;
     let (mut ws, hyperlink_rids) =
         parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
             .map_err(|e| e.to_string())?;
@@ -102,7 +104,7 @@ fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
     let cursor = Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
 
-    let workbook_xml = read_zip_entry(&mut archive, "xl/workbook.xml")?;
+    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
     let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
     let sheets = parse_workbook_sheets(&wb_doc);
 
@@ -116,7 +118,7 @@ fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
     // small head read of each sheet entry is enough — we never decompress the
     // (potentially huge) `<sheetData>` body just to read the tab color.
     let mut sheets = sheets;
-    if let Ok(rels_xml) = read_zip_entry(&mut archive, "xl/_rels/workbook.xml.rels") {
+    if let Ok(rels_xml) = read_zip_string(&mut archive, "xl/_rels/workbook.xml.rels") {
         if let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) {
             for sheet in sheets.iter_mut() {
                 let Some(path) = resolve_sheet_path(&rels_doc, &sheet.r_id) else {
@@ -187,32 +189,13 @@ fn extract_tab_color_from_head(head: &str, theme_colors: &[String]) -> Option<St
     )
 }
 
-pub(crate) fn read_zip_entry(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
-    name: &str,
-) -> Result<String, String> {
-    let max = ooxml_common::zip::current_max();
-    let mut file = archive
-        .by_name(name)
-        .map_err(|e| format!("entry '{}' not found: {}", name, e))?;
-    if file.size() > max {
-        return Err(format!("entry '{}' exceeds size limit", name));
-    }
-    let mut buf = String::new();
-    file.by_ref()
-        .take(max)
-        .read_to_string(&mut buf)
-        .map_err(|e| e.to_string())?;
-    Ok(buf)
-}
-
 /// Theme `fmtScheme > lnStyleLst` line widths (EMU), in declaration order.
 /// A drawing shape's `<a:style><a:lnRef idx="N">` resolves its outline width
 /// from entry N (1-based) of this list (ECMA-376 §20.1.4.2.19); an entry
 /// without an explicit `w` uses the CT_LineProperties default 9525 EMU =
 /// 0.75 pt (§20.1.2.2.24).
 pub(crate) fn parse_theme_ln_widths(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<i64> {
-    let Ok(xml) = read_zip_entry(archive, "xl/theme/theme1.xml") else {
+    let Ok(xml) = read_zip_string(archive, "xl/theme/theme1.xml") else {
         return Vec::new();
     };
     let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -239,7 +222,7 @@ pub(crate) fn parse_theme_ln_widths(archive: &mut zip::ZipArchive<Cursor<&[u8]>>
 }
 
 fn parse_theme_colors(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<String> {
-    let Ok(xml) = read_zip_entry(archive, "xl/theme/theme1.xml") else {
+    let Ok(xml) = read_zip_string(archive, "xl/theme/theme1.xml") else {
         return Vec::new();
     };
     let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -525,7 +508,7 @@ fn read_shared_strings(
     archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
     theme_colors: &[String],
 ) -> Vec<SharedString> {
-    let Ok(xml) = read_zip_entry(archive, "xl/sharedStrings.xml") else {
+    let Ok(xml) = read_zip_string(archive, "xl/sharedStrings.xml") else {
         return Vec::new();
     };
     let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -1280,7 +1263,7 @@ fn load_sheet_comments(
         return Vec::new();
     };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+    let Ok(rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
     let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else {
@@ -1314,14 +1297,14 @@ fn load_sheet_comments(
 
     if let Some(target) = classic_target {
         let comments_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        if let Ok(comments_xml) = read_zip_entry(archive, &comments_path) {
+        if let Ok(comments_xml) = read_zip_string(archive, &comments_path) {
             return parse_comments_xml(&comments_xml);
         }
     }
 
     if let Some(target) = threaded_target {
         let tc_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        if let Ok(tc_xml) = read_zip_entry(archive, &tc_path) {
+        if let Ok(tc_xml) = read_zip_string(archive, &tc_path) {
             let persons = load_persons(archive);
             return parse_threaded_comments_xml(&tc_xml, &persons);
         }
@@ -1343,7 +1326,7 @@ fn load_persons(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> HashMap<String,
         .filter(|n| n.starts_with("xl/persons/") && n.ends_with(".xml"))
         .collect();
     for path in person_paths {
-        let Ok(xml) = read_zip_entry(archive, &path) else {
+        let Ok(xml) = read_zip_string(archive, &path) else {
             continue;
         };
         let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -1558,7 +1541,7 @@ fn load_hyperlinks(
         return Vec::new();
     };
     let rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let rels = read_zip_entry(archive, &rels_path)
+    let rels = read_zip_string(archive, &rels_path)
         .ok()
         .map(|xml| parse_rels_map(&xml))
         .unwrap_or_default();
@@ -1570,21 +1553,6 @@ fn load_hyperlinks(
             url: rels.get(&rid).cloned(),
         })
         .collect()
-}
-
-/// Read a binary file from the zip.
-pub(crate) fn read_zip_bytes(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
-    path: &str,
-) -> Option<Vec<u8>> {
-    let max = ooxml_common::zip::current_max();
-    let mut file = archive.by_name(path).ok()?;
-    if file.size() > max {
-        return None;
-    }
-    let mut buf = Vec::new();
-    file.by_ref().take(max).read_to_end(&mut buf).ok()?;
-    Some(buf)
 }
 
 /// Resolve a relative path ("../media/image1.png") against a base dir ("xl/drawings").
@@ -1852,7 +1820,7 @@ fn load_sheet_sparklines(
                                 .find(|s| s.name == name)
                                 .and_then(|s| resolve_sheet_path(rels_doc, &s.r_id))
                                 .map(|p| format!("xl/{}", p));
-                            let xml = path.and_then(|p| read_zip_entry(archive, &p).ok());
+                            let xml = path.and_then(|p| read_zip_string(archive, &p).ok());
                             xml_cache.insert(name.clone(), xml);
                         }
                         xml_cache.get(&name).and_then(|o| o.as_deref())
@@ -2071,7 +2039,7 @@ pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
 fn to_markdown_impl(data: &[u8]) -> Result<String, String> {
     let cursor = Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
-    let workbook_xml = read_zip_entry(&mut archive, "xl/workbook.xml")?;
+    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
     let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
     let sheets = parse_workbook_sheets(&wb_doc);
 
@@ -2092,7 +2060,7 @@ pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<S
     let cursor = Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
 
-    let workbook_xml = read_zip_entry(&mut archive, "xl/workbook.xml")?;
+    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
     let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
     let sheets = parse_workbook_sheets(&wb_doc);
 
@@ -2100,14 +2068,14 @@ pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<S
         .get(sheet_index as usize)
         .ok_or_else(|| format!("sheet index {} out of range", sheet_index))?;
 
-    let rels_xml = read_zip_entry(&mut archive, "xl/_rels/workbook.xml.rels")?;
+    let rels_xml = read_zip_string(&mut archive, "xl/_rels/workbook.xml.rels")?;
     let rels_doc = roxmltree::Document::parse(&rels_xml).map_err(|e| e.to_string())?;
     let sheet_path = resolve_sheet_path(&rels_doc, &sheet_meta.r_id)
         .ok_or_else(|| format!("rId {} not found in rels", sheet_meta.r_id))?;
 
     let theme_colors = parse_theme_colors(&mut archive);
     let shared_strings = read_shared_strings(&mut archive, &theme_colors);
-    let sheet_xml = read_zip_entry(&mut archive, &format!("xl/{}", sheet_path))?;
+    let sheet_xml = read_zip_string(&mut archive, &format!("xl/{}", sheet_path))?;
     let (mut ws, hyperlink_rids) =
         parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
             .map_err(|e| e.to_string())?;

--- a/packages/xlsx/parser/src/slicer.rs
+++ b/packages/xlsx/parser/src/slicer.rs
@@ -1,5 +1,6 @@
+use crate::resolve_zip_path;
 use crate::types::*;
-use crate::{read_zip_entry, resolve_zip_path};
+use ooxml_common::zip::read_zip_string;
 use std::collections::HashMap;
 use std::io::Cursor;
 
@@ -42,7 +43,7 @@ pub(crate) fn load_all_pivot_cache_fields(
         .filter(|n| n.starts_with("xl/pivotCache/pivotCacheDefinition") && n.ends_with(".xml"))
         .collect();
     for name in names {
-        let Ok(xml) = read_zip_entry(archive, &name) else {
+        let Ok(xml) = read_zip_string(archive, &name) else {
             continue;
         };
         let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -91,7 +92,7 @@ pub(crate) fn load_all_slicer_caches(
         .filter(|n| n.starts_with("xl/slicerCaches/slicerCache") && n.ends_with(".xml"))
         .collect();
     for path in names {
-        let Ok(xml) = read_zip_entry(archive, &path) else {
+        let Ok(xml) = read_zip_string(archive, &path) else {
             continue;
         };
         let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -161,7 +162,7 @@ pub(crate) fn load_sheet_slicers(
         return Vec::new();
     };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(sheet_rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+    let Ok(sheet_rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
     let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
@@ -195,7 +196,7 @@ pub(crate) fn load_sheet_slicers(
     let mut slicer_defs: HashMap<String, SlicerDef> = HashMap::new();
     for target in &slicer_targets {
         let slicer_path = resolve_zip_path(&format!("xl/{}", sheet_dir), target);
-        let Ok(xml) = read_zip_entry(archive, &slicer_path) else {
+        let Ok(xml) = read_zip_string(archive, &slicer_path) else {
             continue;
         };
         for (k, v) in parse_slicers_xml(&xml) {
@@ -214,7 +215,7 @@ pub(crate) fn load_sheet_slicers(
     let mut out: Vec<SlicerAnchor> = Vec::new();
     for target in drawing_targets {
         let drawing_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(drawing_xml) = read_zip_entry(archive, &drawing_path) else {
+        let Ok(drawing_xml) = read_zip_string(archive, &drawing_path) else {
             continue;
         };
         out.extend(parse_slicer_anchors(

--- a/packages/xlsx/parser/src/styles.rs
+++ b/packages/xlsx/parser/src/styles.rs
@@ -1,5 +1,6 @@
+use crate::parse_color;
 use crate::types::*;
-use crate::{parse_color, read_zip_entry};
+use ooxml_common::zip::read_zip_string;
 use std::io::Cursor;
 
 /// Resolve the workbook's Normal-style font (family name + point size) by
@@ -10,7 +11,7 @@ use std::io::Cursor;
 pub(crate) fn parse_default_font(
     archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
 ) -> (Option<String>, Option<f64>) {
-    let Ok(xml) = read_zip_entry(archive, "xl/styles.xml") else {
+    let Ok(xml) = read_zip_string(archive, "xl/styles.xml") else {
         return (None, None);
     };
     let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -62,7 +63,7 @@ pub(crate) fn parse_styles(
     archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
     theme_colors: &[String],
 ) -> Result<Styles, String> {
-    let xml = read_zip_entry(archive, "xl/styles.xml")?;
+    let xml = read_zip_string(archive, "xl/styles.xml")?;
     let doc = roxmltree::Document::parse(&xml).map_err(|e| e.to_string())?;
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
 

--- a/packages/xlsx/parser/src/table.rs
+++ b/packages/xlsx/parser/src/table.rs
@@ -1,5 +1,6 @@
 use crate::types::*;
-use crate::{parse_cell_ref, read_zip_entry, resolve_zip_path};
+use crate::{parse_cell_ref, resolve_zip_path};
+use ooxml_common::zip::read_zip_string;
 use std::io::Cursor;
 
 /// Parse `xl/tables/tableN.xml` files referenced from the sheet rels and
@@ -51,7 +52,7 @@ pub(crate) fn parse_table_styles_map(
 ) -> std::collections::HashMap<String, TableStyleElements> {
     use std::collections::HashMap;
     let mut map: HashMap<String, TableStyleElements> = HashMap::new();
-    let Ok(xml) = read_zip_entry(archive, "xl/styles.xml") else {
+    let Ok(xml) = read_zip_string(archive, "xl/styles.xml") else {
         return map;
     };
     let Ok(doc) = roxmltree::Document::parse(&xml) else {
@@ -127,7 +128,7 @@ pub(crate) fn load_sheet_tables(
         return Vec::new();
     };
     let sheet_rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let Ok(rels_xml) = read_zip_entry(archive, &sheet_rels_path) else {
+    let Ok(rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
     let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else {
@@ -150,7 +151,7 @@ pub(crate) fn load_sheet_tables(
     let mut tables: Vec<TableInfo> = Vec::new();
     for target in table_targets {
         let table_path = resolve_zip_path(&format!("xl/{}", sheet_dir), &target);
-        let Ok(xml) = read_zip_entry(archive, &table_path) else {
+        let Ok(xml) = read_zip_string(archive, &table_path) else {
             continue;
         };
         let Ok(doc) = roxmltree::Document::parse(&xml) else {


### PR DESCRIPTION
## Summary

Phase 1 items D11 / D9 / D7 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md).

### D11 — `parse_docx` returned hand-rolled, unescaped error JSON
docx was the only parser returning `String` with errors encoded as `format!("{{\"error\":\"{}\"}}", e)` — an error message containing `"` produced invalid JSON, so the TS side's `JSON.parse` threw a corrupt-JSON SyntaxError instead of surfacing the real error. Now `Result<String, JsValue>` like pptx/xlsx; both TS receivers (worker.ts and render-worker.ts) drop the `document.error` probe and rely on the existing catch path. Verified end-to-end: `parse_docx(new Uint8Array([1,2,3]))` throws `docx-parser error: invalid Zip archive: Could not find EOCD`.

### D9 — xlsx serializer panic killed the WASM instance
`serde_json::to_string(&wb).unwrap()` → `map_err` chain (same wording as pptx). A serialize failure now surfaces as a JS error instead of poisoning the instance.

### D7 — five private zip readers folded into `ooxml_common::zip`
Inspection found more duplication than the plan: private readers in pptx (`read_zip_bytes`), xlsx (`read_zip_entry` + `read_zip_bytes`, `pub(crate)` across 6 files / ~30 call sites) **and docx** (parser.rs had its own pair too). All five deleted; common gains generic `read_zip_bytes<R: Read+Seek>` / `read_zip_string<R: Read+Seek>` (Result-returning, cap-guarded, with unit tests for found / missing / cap-exceeded). Call sites preserve behavior byte-for-byte — pptx/xlsx image paths keep the skip-on-cap-exceeded semantics, but the swallow is now an explicit `.ok()` at each call site instead of hidden inside the helper.

## Verification
- `cargo fmt --check` / `clippy -D warnings` / `cargo test --workspace` (458 tests) — green
- `pnpm build:wasm` → `pnpm test` (1503) / `pnpm typecheck` / `pnpm lint` — green
- `pnpm smoke` 6/6 with freshly built WASM (CI=1 fresh Storybook)
- Manual corrupt-input error path verified via node script

🤖 Generated with [Claude Code](https://claude.com/claude-code)