### PR TITLE
perf: drop zip existence-check inflates, stop re-sending xlsx buffer per sheet, tighten WASM release profile (D1+C1+D10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   # skip themselves when the fixtures are absent.
   rust:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 
@@ -41,6 +42,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
@@ -102,6 +104,7 @@ jobs:
   # exercises the full parse -> render pipeline in a browser.
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
@@ -126,7 +129,18 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build WASM
         run: pnpm build:wasm
-      - name: Install Playwright Chrome
-        run: pnpm exec playwright install chrome --with-deps
+      # ubuntu-latest ships Google Chrome (the `channel: 'chrome'` browser the
+      # smoke config uses), so install only when it is genuinely absent. The
+      # unconditional `playwright install chrome --with-deps` stalled >30min
+      # twice in a row (apt/CDN hang inside --with-deps); the guard skips that
+      # network path entirely and the step timeout bounds the fallback.
+      - name: Install Playwright Chrome (only if missing)
+        timeout-minutes: 5
+        run: |
+          if command -v google-chrome >/dev/null 2>&1; then
+            echo "Google Chrome preinstalled: $(google-chrome --version)"
+          else
+            pnpm exec playwright install chrome --with-deps
+          fi
       - name: Smoke tests
         run: pnpm smoke

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,16 @@ ooxml-common = { path = "packages/ooxml-common" }
 [profile.release]
 opt-level = "s"
 lto = true
+# One codegen unit lets LLVM optimize (and dead-strip) across the whole crate
+# instead of per-unit, trading longer compile time for a smaller, faster .wasm.
+codegen-units = 1
+# wasm has no stack unwinding (wasm-bindgen builds effectively abort on panic
+# already); making it explicit drops the unwind tables and landing pads from
+# every parser's binary. The console_error_panic_hook each parser installs
+# still fires — the panic hook runs during panic handling, before the process
+# aborts — so a panic message + JS stack is still logged to the console; only
+# Rust-level unwinding (which wasm never performed usefully) is gone.
+panic = "abort"
+# Strip DWARF debuginfo from the release artifact (the .wasm ships to browsers;
+# symbol names for panics come from the panic hook, not embedded debuginfo).
+strip = "debuginfo"

--- a/packages/docx/parser/Cargo.toml
+++ b/packages/docx/parser/Cargo.toml
@@ -15,5 +15,10 @@ roxmltree = { workspace = true }
 console_error_panic_hook = { workspace = true }
 ooxml-common = { workspace = true }
 
+# `-Oz` optimizes the wasm binary for size (over the default `-O`), shrinking
+# the artifact browsers download. wasm-pack runs this pass after wasm-bindgen.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz"]
+
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 omit-default-module-path = true

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,5 +1,5 @@
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
-use ooxml_common::zip::{read_zip_bytes, read_zip_string};
+use ooxml_common::zip::read_zip_string;
 use roxmltree::Document as XmlDoc;
 use std::collections::HashMap;
 use zip::ZipArchive;
@@ -1334,9 +1334,11 @@ fn load_media_map(
                 format!("{}{}", base_dir, target)
             };
             // Confirm the part exists before mapping the rId (keeps the lazy
-            // pipeline honest: a path in the map is always extractable). The
-            // bytes are discarded — only the path is retained.
-            if read_zip_bytes(zip, &path).is_ok() {
+            // pipeline honest: a path in the map is always extractable).
+            // `index_for_name` consults only the central directory — no inflate,
+            // unlike the former `read_zip_bytes` which decompressed the whole
+            // entry just to throw the bytes away.
+            if zip.index_for_name(&path).is_some() {
                 media_map.insert(rid.clone(), path);
             }
         }
@@ -7930,6 +7932,62 @@ mod svg_blip_tests {
         assert_eq!(img.mime_type, "image/svg+xml");
         // 304800 EMU / 12700 = 24pt.
         assert!((img.width_pt - 24.0).abs() < 1e-6);
+    }
+
+    /// `load_media_map` must drop an rId whose target part is declared in the
+    /// rels but ABSENT from the package (a path in the map is only ever emitted
+    /// when the entry truly resolves). This is the invariant the existence check
+    /// enforces — the check now uses `index_for_name` (central-directory lookup,
+    /// no inflate) in place of the former read-and-discard `read_zip_bytes`, so
+    /// this pins that the swap preserved the "missing part ⇒ dropped" behaviour.
+    /// With no resolvable blip the whole picture resolution returns `None`, so no
+    /// `DocRun::Image` is produced.
+    #[test]
+    fn missing_media_part_drops_the_image() {
+        use zip::write::SimpleFileOptions;
+        let document_xml = r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+  <w:p><w:r><w:drawing>
+    <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+               xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+               xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <wp:extent cx="304800" cy="304800"/>
+      <a:graphic><a:graphicData>
+        <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:blipFill><a:blip r:embed="rIdPng"/></pic:blipFill>
+        </pic:pic>
+      </a:graphicData></a:graphic>
+    </wp:inline>
+  </w:drawing></w:r></w:p>
+</w:body></w:document>"#;
+        // The rels declare media/image1.png, but the archive below deliberately
+        // omits that part.
+        let rels_xml = r#"<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPng" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>"#;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            let mut put = |name: &str, bytes: &[u8]| {
+                use std::io::Write;
+                zw.start_file(name, opts).unwrap();
+                zw.write_all(bytes).unwrap();
+            };
+            put("word/document.xml", document_xml.as_bytes());
+            put("word/_rels/document.xml.rels", rels_xml.as_bytes());
+            // NOTE: word/media/image1.png is intentionally NOT written.
+            zw.finish().unwrap();
+        }
+        let doc = parse(&buf).expect("parse must succeed even with a dangling image rId");
+        let has_image = doc.body.iter().any(|el| match el {
+            BodyElement::Paragraph(p) => p.runs.iter().any(|r| matches!(r, DocRun::Image(_))),
+            _ => false,
+        });
+        assert!(
+            !has_image,
+            "an rId whose media part is absent must be dropped, yielding no ImageRun"
+        );
     }
 
     /// End-to-end: an inline `<a:blip r:embed>` with a raster fallback AND an

--- a/packages/pptx/parser/Cargo.toml
+++ b/packages/pptx/parser/Cargo.toml
@@ -15,5 +15,10 @@ roxmltree = { workspace = true }
 console_error_panic_hook = { workspace = true }
 ooxml-common = { workspace = true }
 
+# `-Oz` optimizes the wasm binary for size (over the default `-O`), shrinking
+# the artifact browsers download. wasm-pack runs this pass after wasm-bindgen.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz"]
+
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 omit-default-module-path = true

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -3897,8 +3897,10 @@ fn parse_master_level_bullets(
         let path = resolve_path(master_dir, target);
         // Verify the part exists so a listed-but-missing rId yields None and the
         // bullet falls through to Bullet::Inherit (matches the variant's doc
-        // comment), mirroring the master background resolver.
-        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
+        // comment), mirroring the master background resolver. `index_for_name`
+        // checks the central directory only (no inflate), unlike the former
+        // `read_zip_bytes` which decompressed the entry just to discard it.
+        zip.index_for_name(&path)?;
         Some(path)
     };
 
@@ -4218,7 +4220,9 @@ fn parse_layout_placeholders(
             // Verify the part exists so a listed-but-missing rId yields None and
             // the bullet falls through to Bullet::Inherit (matches the variant's
             // doc comment), mirroring the master/layout background resolvers.
-            ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
+            // `index_for_name` reads the central directory only (no inflate),
+            // unlike the former `read_zip_bytes` which decompressed and discarded.
+            zip.index_for_name(&path)?;
             Some(path)
         };
         let layout_level_bullets: LevelBullets = child(sp, "txBody")
@@ -4280,8 +4284,10 @@ fn parse_layout_placeholders(
             let rel_target = layout_rels.get(&rid)?;
             let image_path = resolve_path(layout_dir, rel_target);
             // Verify the part exists so a dangling rId yields None (no inherited
-            // fill), preserving the prior data-URL behaviour.
-            ooxml_common::zip::read_zip_bytes(zip, &image_path).ok()?;
+            // fill), preserving the prior data-URL behaviour. `index_for_name`
+            // reads the central directory only (no inflate), unlike the former
+            // `read_zip_bytes` which decompressed the entry just to discard it.
+            zip.index_for_name(&image_path)?;
             let mime_type = mime_from_ext(&image_path).to_owned();
             Some(InheritedBlipFill {
                 image_path,
@@ -4608,8 +4614,10 @@ fn parse_text_body(
         let path = resolve_path("ppt/slides", target);
         // Verify the part exists so a listed-but-missing rId yields None and the
         // bullet falls through to Bullet::Inherit (matches the variant's doc
-        // comment), mirroring the slide picture-fill resolvers.
-        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
+        // comment), mirroring the slide picture-fill resolvers. `index_for_name`
+        // reads the central directory only (no inflate), unlike the former
+        // `read_zip_bytes` which decompressed the entry just to discard it.
+        zip.index_for_name(&path)?;
         Some(path)
     };
     let own_level_bullets = extract_level_bullets(tx_body, theme, &mut resolve_slide_blip);
@@ -4851,8 +4859,10 @@ fn parse_paragraph(
         let path = resolve_path("ppt/slides", target);
         // Verify the part exists so a listed-but-missing rId yields None and the
         // bullet falls through to Bullet::Inherit (matches the variant's doc
-        // comment), mirroring the slide picture-fill resolvers.
-        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
+        // comment), mirroring the slide picture-fill resolvers. `index_for_name`
+        // reads the central directory only (no inflate), unlike the former
+        // `read_zip_bytes` which decompressed the entry just to discard it.
+        zip.index_for_name(&path)?;
         Some(path)
     };
     let bullet = match parse_bullet(p_pr, theme, &mut resolve_para_blip) {
@@ -6912,7 +6922,10 @@ fn svg_blip_path(
     let svg_rid = svg_blip_rid(blip)?;
     let svg_target = rels.get(&svg_rid)?;
     let svg_path = resolve_path(slide_dir, svg_target);
-    ooxml_common::zip::read_zip_bytes(zip, &svg_path).ok()?;
+    // Existence check only — `index_for_name` reads the central directory
+    // without inflating, unlike the former `read_zip_bytes` which decompressed
+    // the whole SVG part just to discard the bytes.
+    zip.index_for_name(&svg_path)?;
     Some(svg_path)
 }
 
@@ -7857,7 +7870,9 @@ fn parse_slide(
             // Resolve to the zip path; verify the part exists so a dangling
             // rId still yields None (the bg chain then falls through to the
             // next level), preserving the prior data-URL behaviour.
-            ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
+            // `index_for_name` reads the central directory only (no inflate),
+            // unlike the former `read_zip_bytes` which decompressed to discard.
+            zip.index_for_name(&path)?;
             Some(path)
         };
         background = parse_background(n, theme, &mut resolve);
@@ -7871,7 +7886,9 @@ fn parse_slide(
                     let mut resolve = |rid: &str| -> Option<String> {
                         let target = layout_rels.get(rid)?;
                         let path = resolve_path(layout_dir, target);
-                        ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
+                        // Existence check only — central-directory lookup, no
+                        // inflate (former `read_zip_bytes` decompressed to discard).
+                        zip.index_for_name(&path)?;
                         Some(path)
                     };
                     background = parse_background(n, theme, &mut resolve);
@@ -9010,7 +9027,9 @@ fn build_master_bundle(
         let mut resolve = |rid: &str| -> Option<String> {
             let target = master_rels.get(rid)?;
             let path = resolve_path(&master_dir, target);
-            ooxml_common::zip::read_zip_bytes(zip, &path).ok()?;
+            // Existence check only — central-directory lookup, no inflate
+            // (former `read_zip_bytes` decompressed the entry just to discard it).
+            zip.index_for_name(&path)?;
             Some(path)
         };
         parse_background(c_sld, &theme, &mut resolve)
@@ -9316,7 +9335,9 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
                 let mut resolve = |rid: &str| -> Option<String> {
                     let target = bundle.master_rels.get(rid)?;
                     let path = resolve_path(&bundle.master_dir, target);
-                    ooxml_common::zip::read_zip_bytes(&mut zip, &path).ok()?;
+                    // Existence check only — central-directory lookup, no inflate
+                    // (former `read_zip_bytes` decompressed the entry to discard it).
+                    zip.index_for_name(&path)?;
                     Some(path)
                 };
                 parse_background(c_sld, &theme, &mut resolve)
@@ -9402,7 +9423,7 @@ mod tests {
 
     /// Build an in-memory zip containing exactly `parts` (path → bytes). Used to
     /// prove a `<a:buBlip>` whose rId resolves to a part that ISN'T in the
-    /// archive falls through to Bullet::Inherit (read_zip_bytes returns None).
+    /// archive falls through to Bullet::Inherit (index_for_name returns None).
     fn zip_with_parts(parts: &[(&str, &[u8])]) -> Vec<u8> {
         use std::io::Write;
         let mut buf = Vec::new();
@@ -10322,7 +10343,7 @@ mod tests {
     /// ECMA-376 §21.1.2.4.2 — a `<a:buBlip>` whose `r:embed` IS listed in the
     /// part's rels (so `resolve_path` succeeds) but whose target part is NOT in
     /// the package must NOT emit a `Bullet::Blip` carrying a dangling path. The
-    /// resolver verifies part existence with `read_zip_bytes`, so a missing part
+    /// resolver verifies part existence with `index_for_name`, so a missing part
     /// yields `None` and the level falls through to `Bullet::Inherit` (the empty
     /// `LevelBullets` slot), matching the variant's doc comment. Exercised
     /// end-to-end through `parse_master_level_bullets` (one of the now-`zip`-
@@ -10347,7 +10368,7 @@ mod tests {
         master_rels.insert("rId7".to_owned(), "../media/missing.png".to_owned());
 
         // Archive deliberately LACKS ppt/media/missing.png (it holds an unrelated
-        // part so it isn't empty). read_zip_bytes(missing.png) → None.
+        // part so it isn't empty). index_for_name(missing.png) → None.
         let bytes = zip_with_parts(&[("ppt/media/other.png", b"\x89PNG")]);
         let cursor = Cursor::new(bytes.as_slice());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();

--- a/packages/xlsx/parser/Cargo.toml
+++ b/packages/xlsx/parser/Cargo.toml
@@ -15,5 +15,10 @@ roxmltree = { workspace = true }
 console_error_panic_hook = { workspace = true }
 ooxml-common = { workspace = true }
 
+# `-Oz` optimizes the wasm binary for size (over the default `-O`), shrinking
+# the artifact browsers download. wasm-pack runs this pass after wasm-bindgen.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz"]
+
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 omit-default-module-path = true

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1,6 +1,6 @@
 use crate::types::*;
 use crate::{parse_rels_map, resolve_zip_path};
-use ooxml_common::zip::{read_zip_bytes, read_zip_string};
+use ooxml_common::zip::read_zip_string;
 // Shared DrawingML blip helpers (ECMA-376 §20.1.8.13 + Microsoft 2016 SVG
 // extension, MS-ODRAWXML). `mime_from_ext` is the single source of truth for
 // `.svg ⇒ image/svg+xml`; `svg_blip_rid` resolves the vector original nested in
@@ -129,8 +129,10 @@ pub(crate) fn parse_drawing_anchors(
             let target = drawing_rels.get(rid)?;
             let media_path = resolve_zip_path(drawing_dir, target);
             // Confirm the entry resolves before emitting its path (preserves the
-            // previous "drop when bytes are missing" semantics).
-            read_zip_bytes(archive, &media_path).ok()?;
+            // previous "drop when bytes are missing" semantics). `index_for_name`
+            // reads only the central directory — no inflate, unlike the former
+            // `read_zip_bytes` which decompressed the entry only to discard it.
+            archive.index_for_name(&media_path)?;
             Some(media_path)
         };
 
@@ -1441,7 +1443,9 @@ pub(crate) fn build_drawing_rid_urls(
         let media_path = resolve_zip_path(drawing_dir, &target);
         // Only emit the path when the entry actually resolves (preserves the
         // previous behavior of dropping rIds whose bytes are missing).
-        if read_zip_bytes(archive, &media_path).is_ok() {
+        // `index_for_name` checks the central directory only — no inflate, unlike
+        // the former `read_zip_bytes` which decompressed the entry to discard it.
+        if archive.index_for_name(&media_path).is_some() {
             result.insert(rid, media_path);
         }
     }

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -100,7 +100,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       // XlsxWorkbook.getWorksheet / resolveValidationList resolve in worker
       // mode instead of hanging forever. Reuses parseSheetLocally (which parses
       // from the worker's stored rawData and cache); the main-mode message's
-      // `data` / `sheetName` fields are ignored. Reply shape matches worker.ts.
+      // `sheetName` field is ignored. Reply shape matches worker.ts.
       if (!workbook) throw new Error('Workbook not loaded');
       const worksheet = parseSheetLocally(req.sheetIndex);
       post({ type: 'parsedSheet', id, worksheet });

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -984,10 +984,14 @@ export interface RenderViewportOptions {
 export type WorkerRequest =
   | { type: 'init'; wasmUrl: string }
   | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number }
+  /** Parse one sheet lazily. Deliberately carries NO `data`: the worker already
+   *  retained the whole-workbook buffer on the preceding `parse`, so re-sending
+   *  it here would structured-clone the entire file per sheet switch for no
+   *  gain. `parseSheet` is therefore only valid AFTER a `parse` (a `parseSheet`
+   *  with no retained buffer is a protocol violation). */
   | {
       type: 'parseSheet';
       id: number;
-      data: ArrayBuffer;
       sheetIndex: number;
       sheetName: string;
       maxZipEntryBytes?: number;

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -178,17 +178,20 @@ export class XlsxWorkbook {
   async getWorksheet(sheetIndex: number): Promise<Worksheet> {
     const cached = this.sheetCache.get(sheetIndex);
     if (cached) return cached;
+    // `!this.rawData` guards that `parse` has run: the worker retained the
+    // whole-workbook buffer at parse time, and `parseSheet` reuses it. We no
+    // longer re-send the buffer here (it previously structured-cloned the entire
+    // file per sheet switch); the retained `rawData` is still kept for
+    // `getImage`'s route-through-worker path.
     if (!this.parsedWorkbook || !this.rawData) {
       throw new Error('Workbook not loaded');
     }
-    const rawData = this.rawData;
     const sheetMeta = this.parsedWorkbook.workbook.sheets[sheetIndex];
     if (!sheetMeta) throw new Error(`Sheet index ${sheetIndex} out of range`);
 
     const res = await this.bridge.request((id) => ({
       type: 'parseSheet',
       id,
-      data: rawData.slice(0),
       sheetIndex,
       sheetName: sheetMeta.name,
       maxZipEntryBytes: this.maxZipEntryBytes,

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -19,10 +19,11 @@ export type RenderWorkerRequest =
   // resolveValidationList range path that awaits it) work, mirroring how the
   // pptx render worker handles `extractMedia` for getMedia. The render worker
   // already holds `rawData` + `workbook` from `parse`, so only `sheetIndex` is
-  // load-bearing here; `data` / `sheetName` are carried for shape-compat with
-  // the main-mode message getWorksheet posts but are ignored (the worker parses
-  // from its own `rawData` and derives the sheet name from `workbook`).
-  | { type: 'parseSheet'; id: number; data?: ArrayBuffer; sheetIndex: number; sheetName?: string; maxZipEntryBytes?: number }
+  // load-bearing here; `sheetName` is carried for shape-compat with the
+  // main-mode message getWorksheet posts but is ignored (the worker derives the
+  // sheet name from its own `workbook`). No `data`: like main-mode `parseSheet`,
+  // the buffer retained at `parse` is reused — never re-sent per sheet.
+  | { type: 'parseSheet'; id: number; sheetIndex: number; sheetName?: string; maxZipEntryBytes?: number }
   | { type: 'renderViewport'; id: number; sheetIndex: number; viewport: ViewportRange; opts: WireRenderViewportOptions }
   // Worker render mode decodes images in-worker via a getImage closure; this arm
   // exists only for protocol parity with worker.ts (so a stray extractImage

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -34,11 +34,19 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       const res: WorkerResponse = { type: 'parsed', id, workbook };
       self.postMessage(res);
     } else if (req.type === 'parseSheet') {
+      // Reuse the buffer retained at `parse` instead of re-receiving it — the
+      // whole file no longer crosses the worker boundary on every sheet switch
+      // (twin of the `extractImage` reuse below). A `parseSheet` before any
+      // `parse` has no buffer to work with: that is a protocol violation, so
+      // fail loudly rather than silently returning an empty sheet.
+      if (!currentBuffer) {
+        throw new Error('parseSheet before parse: no buffer retained');
+      }
       const maxBytes =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      const json = parse_sheet(new Uint8Array(req.data), req.sheetIndex, req.sheetName, maxBytes);
+      const json = parse_sheet(currentBuffer, req.sheetIndex, req.sheetName, maxBytes);
       const worksheet = JSON.parse(json);
       const res: WorkerResponse = { type: 'parsedSheet', id, worksheet };
       self.postMessage(res);


### PR DESCRIPTION
## Summary

Phase 1 items D1 / C1 / D10(first half) from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md).

### D1 — existence checks were inflating whole media entries (13 sites, not 3)
The plan named one site per parser. A broader sweep found **13** read-and-discard existence checks (docx media map, xlsx blip resolver + drawing rid urls, pptx bullet/background/svg resolvers ×10 including both master-background passes). All now use `ZipArchive::index_for_name` — in zip 2.4.2 `by_name` and `index_for_name` share the same name lookup, so behavior is provably identical minus the wasted decompression. Three genuine byte consumers (pptx `png_size_from_bytes` intrinsic sizing) were deliberately left untouched. New docx unit test pins missing-media-drops-from-map.

### C1 — xlsx re-sent the whole workbook on every sheet switch
`getWorksheet` structured-cloned `rawData.slice(0)` (entire file) to the worker per `parseSheet`, though the worker already retains the buffer from `parse`. The `data` field is removed from the protocol (not optional — a `parseSheet` before `parse` is a contract violation and now errors clearly). Render-worker protocol's vestigial `data?` (justified only as shape-compat) removed too. Per sheet switch: ~file-size bytes cloned → **0**. Worker-vs-main VRT: **0.000% diff on both sheets**.

### D10 — release profile + wasm-opt -Oz
`codegen-units=1` / `panic="abort"` / `strip="debuginfo"` + `wasm-opt=["-Oz"]` per parser.

| parser | before | after | delta |
|---|--:|--:|--:|
| docx | 604,729 | 577,482 | −4.50% |
| xlsx | 691,058 | 675,580 | −2.23% |
| pptx | 671,245 | 650,672 | −3.06% |
| **total** | **1,967,032** | **1,903,734** | **−3.22%** |

`pnpm build:wasm` wall time 23.8s → 33.4s (~1.4×). `panic="abort"` keeps `console_error_panic_hook` output (the hook runs before the abort); native `cargo build --release` incl. mcp-server stays green.

## Verification
- cargo fmt / clippy -D warnings / test --workspace (459) — green
- pnpm build:wasm → test (1503) / typecheck / lint — green
- pnpm smoke 6/6; xlsx worker-vs-main VRT 0.000% diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)