### PR TITLE
perf: O(log n) xlsx hit-testing, docx font memo, 44-byte sniff, WeakMap render tokens + core hygiene (C3+B6+A8+C11+A11+A9)

### DIFF
--- a/packages/core/src/canvas/aux-canvas.ts
+++ b/packages/core/src/canvas/aux-canvas.ts
@@ -1,0 +1,36 @@
+/**
+ * Auxiliary (offscreen) canvas allocation shared across the renderers and the
+ * metafile rasterizers.
+ *
+ * Lives under `canvas/` (a leaf utility layer) so both `shape/` (effects,
+ * scene3d) and `image/` (wmf/emf/dib metafile players) can depend on it without
+ * an unnatural `image → shape` edge. `shape/effects.ts` re-exports it for its
+ * historical import path.
+ */
+
+/** A canvas usable off-DOM: an OffscreenCanvas in a worker, else a detached
+ *  `<canvas>`. */
+export type AuxCanvas = HTMLCanvasElement | OffscreenCanvas;
+/** The 2D context type of an {@link AuxCanvas}. */
+export type AuxContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+/**
+ * Allocate an auxiliary canvas. Prefers OffscreenCanvas (no DOM pollution, works
+ * inside a worker); falls back to a detached <canvas>; returns null when neither
+ * is available (e.g. a headless unit-test environment) so callers can no-op.
+ * Dimensions are clamped to >=1 to avoid zero-size canvas errors.
+ */
+export function createAuxCanvas(w: number, h: number): AuxCanvas | null {
+  const cw = Math.max(1, Math.ceil(w));
+  const ch = Math.max(1, Math.ceil(h));
+  if (typeof OffscreenCanvas !== 'undefined') {
+    return new OffscreenCanvas(cw, ch);
+  }
+  if (typeof document !== 'undefined') {
+    const c = document.createElement('canvas');
+    c.width = cw;
+    c.height = ch;
+    return c;
+  }
+  return null;
+}

--- a/packages/core/src/image/dib.ts
+++ b/packages/core/src/image/dib.ts
@@ -7,6 +7,8 @@
 // META_DIBBITBLT / META_DIBSTRETCHBLT, which store the DIB *packed* — header +
 // palette + pixels contiguously — via {@link decodePackedDib}).
 
+import { createAuxCanvas } from '../canvas/aux-canvas.js';
+
 /** A decoded DIB as top-down RGBA (what `ImageData`/`putImageData` expects). */
 export interface DecodedDib {
   width: number;
@@ -182,10 +184,12 @@ export function blitDibToCtx(
   x1: number,
   y1: number,
 ): boolean {
-  if (typeof OffscreenCanvas === 'undefined') return false;
   try {
-    const tmp = new OffscreenCanvas(dib.width, dib.height);
-    const tctx = tmp.getContext('2d') as OffscreenCanvasRenderingContext2D | null;
+    // Shared aux canvas (OffscreenCanvas, else a detached <canvas>); null in a
+    // headless env ⇒ skip the blit and keep rendering, as before.
+    const tmp = createAuxCanvas(dib.width, dib.height);
+    if (!tmp) return false;
+    const tctx = tmp.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
     if (!tctx) return false;
     // Allocate via createImageData (avoids the ImageData-constructor typed-array
     // overload mismatch) and copy the decoded RGBA in.

--- a/packages/core/src/image/emf.ts
+++ b/packages/core/src/image/emf.ts
@@ -42,6 +42,7 @@
 
 import { decodeDib, blitDibToCtx, type DecodedDib } from './dib.js';
 import { colorRefToCss, isEmf } from './wmf.js';
+import { createAuxCanvas } from '../canvas/aux-canvas.js';
 
 // EMF record type codes ([MS-EMF] 2.1.1 EMR enumeration; the subset we act on,
 // others are skipped by nSize).
@@ -1237,12 +1238,13 @@ export async function renderEmfToBitmap(
 ): Promise<ImageBitmap | null> {
   if (!isEmf(bytes)) return null;
   if (targetW <= 0 || targetH <= 0) return null;
-  // Rasterizing needs an OffscreenCanvas; absent (e.g. a headless test / SSR
-  // runtime without the shim) ⇒ degrade gracefully to null, exactly as the
-  // caller already handles an unsupported metafile — never throw.
-  if (typeof OffscreenCanvas === 'undefined') return null;
-  const canvas = new OffscreenCanvas(targetW, targetH);
-  const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D | null;
+  // Rasterize on a shared aux canvas (OffscreenCanvas, else a detached <canvas>).
+  // Absent both (e.g. a headless test / SSR runtime without either) ⇒ degrade
+  // gracefully to null, exactly as the caller already handles an unsupported
+  // metafile — never throw.
+  const canvas = createAuxCanvas(targetW, targetH);
+  if (!canvas) return null;
+  const ctx = canvas.getContext('2d') as AnyCtx | null;
   if (!ctx) return null;
   ctx.lineJoin = 'round';
   ctx.lineCap = 'round';

--- a/packages/core/src/image/wmf.test.ts
+++ b/packages/core/src/image/wmf.test.ts
@@ -775,6 +775,43 @@ describe('decodeRasterOrMetafile', () => {
     expect(cib).toHaveBeenCalledWith(blob);
   });
 
+  it('sniffs a ≤44-byte slice for raster: only the header is read, the Blob is handed to createImageBitmap whole', async () => {
+    const fake = { width: 3, height: 4, close() {} } as unknown as ImageBitmap;
+    const cib = vi.fn(async (_blob: Blob) => fake);
+    vi.stubGlobal('createImageBitmap', cib);
+
+    // A raster smaller than the 44-byte sniff window. slice(0,44) must not throw
+    // and the sub-44-byte `isWmf`/`isEmf` length guards must both return false so
+    // the blob falls through to createImageBitmap.
+    const tiny = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]); // 7 bytes, PNG-ish
+    const base = new Blob([tiny as BlobPart], { type: 'image/png' });
+
+    // Spy on the two Blob reads: the raster path must slice (header sniff) but
+    // must NOT read the whole blob via arrayBuffer() — createImageBitmap consumes
+    // the Blob directly.
+    let sliced = 0;
+    let fullRead = 0;
+    const wrapped = {
+      type: base.type,
+      size: base.size,
+      slice(start?: number, end?: number) {
+        sliced++;
+        return base.slice(start, end);
+      },
+      async arrayBuffer() {
+        fullRead++;
+        return base.arrayBuffer();
+      },
+    } as unknown as Blob;
+
+    const bmp = await decodeRasterOrMetafile(wrapped, { widthPt: 50, heightPt: 50 });
+    expect(bmp).toBe(fake);
+    expect(sliced).toBe(1); // header sniff happened
+    expect(fullRead).toBe(0); // no whole-blob copy on the raster fast path
+    expect(cib).toHaveBeenCalledTimes(1);
+    expect(cib).toHaveBeenCalledWith(wrapped);
+  });
+
   it('an empty WMF (no geometry) → null, not a throw', async () => {
     vi.stubGlobal('createImageBitmap', vi.fn(async (src: { width: number; height: number }) =>
       ({ width: src.width, height: src.height, close() {} }) as unknown as ImageBitmap));

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -713,15 +713,24 @@ export async function decodeRasterOrMetafile(
   opts: DecodeRasterOptions = {},
 ): Promise<ImageBitmap | null> {
   const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false } = opts;
-  const bytes = new Uint8Array(await data.arrayBuffer());
 
-  if (isWmf(bytes)) {
+  // Sniff only the header, not the whole blob. `isEmf` reads bytes 40-43 (u32@40
+  // == " EMF") and `isWmf` at most the 18-byte standard header, so 44 bytes is
+  // sufficient for either magic. The overwhelmingly common case — a raster
+  // (PNG/JPEG/GIF/BMP/WEBP) — then hands the Blob straight to createImageBitmap
+  // without ever materializing the full bytes in JS, avoiding a whole-image
+  // arrayBuffer() copy per decode. A metafile pays a 44-byte read plus the full
+  // read below (two reads), but metafiles are small and rare next to the raster
+  // fast path, so the net is a large reduction in copied bytes.
+  const head = new Uint8Array(await data.slice(0, 44).arrayBuffer());
+
+  if (isWmf(head)) {
     const { w, h } = wmfRasterTarget(widthPt, heightPt);
-    return renderWmfToBitmap(bytes, w, h, suppressBoundaryFrame);
+    return renderWmfToBitmap(new Uint8Array(await data.arrayBuffer()), w, h, suppressBoundaryFrame);
   }
-  if (isEmf(bytes)) {
+  if (isEmf(head)) {
     const { w, h } = wmfRasterTarget(widthPt, heightPt);
-    return renderEmfToBitmap(bytes, w, h);
+    return renderEmfToBitmap(new Uint8Array(await data.arrayBuffer()), w, h);
   }
   return createImageBitmap(data);
 }

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -38,6 +38,7 @@
 
 import { decodePackedDib, blitDibToCtx } from './dib.js';
 import { renderEmfToBitmap } from './emf.js';
+import { createAuxCanvas } from '../canvas/aux-canvas.js';
 
 // WMF record function codes (the subset we act on; others are skipped by size).
 const META = {
@@ -658,8 +659,13 @@ export async function renderWmfToBitmap(
 ): Promise<ImageBitmap | null> {
   if (!isWmf(bytes)) return null;
   if (targetW <= 0 || targetH <= 0) return null;
-  const canvas = new OffscreenCanvas(targetW, targetH);
-  const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D | null;
+  // Prefer OffscreenCanvas but fall back to a detached <canvas> (or null in a
+  // headless env) via the shared allocator, matching emf.ts / dib.ts — a WMF
+  // blip then rasterizes on the main thread too instead of hard-requiring
+  // OffscreenCanvas. null ⇒ degrade to the caller's "missing image" path.
+  const canvas = createAuxCanvas(targetW, targetH);
+  if (!canvas) return null;
+  const ctx = canvas.getContext('2d') as AnyCtx | null;
   if (!ctx) return null;
   ctx.lineJoin = 'round';
   ctx.lineCap = 'round';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,12 @@ export {
 export { drawProjected, expandProjectedQuad } from './shape/scene3d-draw';
 // DrawingML 3D bevel shading (Phase B). ECMA-376 §20.1.5.12 (sp3d) /
 // §20.1.5.3 (bevel) / §20.1.10.9 (ST_BevelPresetType) / §20.1.5.9 (lightRig).
+// `edt1d` / `shadePixel` / `shadeParamsFor` / `fillDirFromKey` are internal
+// bevel-shading helpers with no cross-package consumer — only bevel-shading.test.ts
+// exercises them, and it deep-imports them from './bevel-shading' directly, so they
+// are intentionally NOT re-exported here (they stay `export`ed from their module for
+// that deep import). `materialClass` / `lightDirFromRig` ARE re-exported: the pptx
+// renderer consumes them through this barrel.
 export {
   applyBevelShading,
   applyExtrusion,
@@ -144,11 +150,7 @@ export {
   computeBevelNormals,
   bevelHeightProfile,
   distanceToEdge,
-  edt1d,
-  shadePixel,
-  shadeParamsFor,
   lightDirFromRig,
-  fillDirFromKey,
   materialClass,
   type BevelMaterial,
   type BevelShadeParams,

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -1,5 +1,11 @@
 import type { Shadow, SoftEdge, Reflection } from '../types/common';
 import { hexToRgba } from './paint';
+import { createAuxCanvas, type AuxCanvas, type AuxContext } from '../canvas/aux-canvas';
+
+// createAuxCanvas moved to canvas/aux-canvas.ts so the image/ metafile players
+// can share it without an image → shape dependency. Re-exported here to preserve
+// the historical import path (`shape/effects` / the core barrel).
+export { createAuxCanvas };
 
 /**
  * Canvas 2D rendering of the three DrawingML edge/blur effects that the
@@ -22,9 +28,6 @@ import { hexToRgba } from './paint';
 
 export type PaintShape = (ctx: AuxContext) => void;
 
-type AuxCanvas = HTMLCanvasElement | OffscreenCanvas;
-type AuxContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
-
 /** Bounding box of the shape in device pixels (post-scale). */
 export interface EffectBBox {
   x: number;
@@ -40,27 +43,6 @@ export interface EffectBBox {
  */
 function emuToPx(emu: number, scale: number): number {
   return emu * scale;
-}
-
-/**
- * Allocate an auxiliary canvas. Prefers OffscreenCanvas (no DOM pollution, works
- * inside a worker); falls back to a detached <canvas>; returns null when neither
- * is available (e.g. a headless unit-test environment) so callers can no-op.
- * Dimensions are clamped to >=1 to avoid zero-size canvas errors.
- */
-export function createAuxCanvas(w: number, h: number): AuxCanvas | null {
-  const cw = Math.max(1, Math.ceil(w));
-  const ch = Math.max(1, Math.ceil(h));
-  if (typeof OffscreenCanvas !== 'undefined') {
-    return new OffscreenCanvas(cw, ch);
-  }
-  if (typeof document !== 'undefined') {
-    const c = document.createElement('canvas');
-    c.width = cw;
-    c.height = ch;
-    return c;
-  }
-  return null;
 }
 
 function get2d(canvas: AuxCanvas): AuxContext | null {

--- a/packages/core/src/shape/pattern-bitmaps.ts
+++ b/packages/core/src/shape/pattern-bitmaps.ts
@@ -10,6 +10,8 @@
 // implementation-specific in practice, and falling back to the foreground
 // colour is a safer default than guessing.
 
+import { createAuxCanvas } from '../canvas/aux-canvas.js';
+
 const PATTERN_BITMAPS: Record<string, number[]> = {
   // ── Percentage shading ────────────────────────────────────────────────
   // Sparse-to-dense dot patterns. Bit positions follow the canonical
@@ -79,7 +81,8 @@ export function buildPatternBitmap(
   const rows = PATTERN_BITMAPS[preset];
   if (!rows) return null;
 
-  const tile = createTileCanvas(8, 8);
+  // 8×8 positive-integer tile, so createAuxCanvas's ceil/≥1 clamp is a no-op.
+  const tile = createAuxCanvas(8, 8);
   if (!tile) return null;
   const tctx = tile.getContext('2d') as CanvasRenderingContext2D | null;
   if (!tctx) return null;
@@ -94,21 +97,6 @@ export function buildPatternBitmap(
     }
   }
   return tile;
-}
-
-function createTileCanvas(w: number, h: number): HTMLCanvasElement | OffscreenCanvas | null {
-  // Prefer OffscreenCanvas — same shape, but doesn't pollute the DOM and
-  // is cheaper to allocate per pattern.
-  if (typeof OffscreenCanvas !== 'undefined') {
-    return new OffscreenCanvas(w, h);
-  }
-  if (typeof document !== 'undefined') {
-    const c = document.createElement('canvas');
-    c.width = w;
-    c.height = h;
-    return c;
-  }
-  return null;
 }
 
 function hexToCss(hex: string): string {

--- a/packages/docx/src/font-family.test.ts
+++ b/packages/docx/src/font-family.test.ts
@@ -115,3 +115,45 @@ describe('normalizeFontFamily — CJK language-specific Noto ordering', () => {
     expect(normalizeFontFamily('MS Mincho')).toContain('"Noto Serif JP"');
   });
 });
+
+// B6: normalizeFontFamily is memoized per-document (keyed on the
+// fontFamilyClasses object identity). These pin that memoization is transparent
+// — identical inputs give identical results, and two different fontFamilyClasses
+// objects never share a cache entry (so the fontTable §17.8.3.10 classification,
+// which lives in fontFamilyClasses, still switches the chain).
+describe('normalizeFontFamily — per-document memoization is transparent', () => {
+  it('returns the identical string on repeated calls with the same classes object', () => {
+    const classes = { Arial: 'roman' };
+    const a = normalizeFontFamily('Arial', classes);
+    const b = normalizeFontFamily('Arial', classes);
+    expect(b).toBe(a);
+    // roman ⇒ serif tail, so the cached result is the serif chain.
+    expect(a).toContain('"Arial"');
+    expect(a).toContain('serif');
+  });
+
+  it('does not mix results across different fontFamilyClasses objects', () => {
+    // Same family, two different fontTable classifications: `swiss` (sans) vs
+    // `roman` (serif). The memo must not serve one doc's result to the other.
+    const asSwiss = normalizeFontFamily('Calibri', { Calibri: 'swiss' });
+    const asRoman = normalizeFontFamily('Calibri', { Calibri: 'roman' });
+    expect(asSwiss).not.toBe(asRoman);
+    expect(asSwiss.endsWith('serif')).toBe(true); // sans tail ends "…, sans-serif"
+    expect(asSwiss).not.toContain('Noto Serif');
+    expect(asRoman).toContain('Noto Serif');
+    // Re-querying the first object still yields the swiss (sans) chain, proving
+    // the second object's entry did not overwrite it.
+    expect(normalizeFontFamily('Calibri', { Calibri: 'swiss' })).not.toBe(asRoman);
+  });
+
+  it('handles a null family through the cache without colliding with a real "null" family', () => {
+    const classes = {};
+    const nullChain = normalizeFontFamily(null, classes);
+    // Stable across calls.
+    expect(normalizeFontFamily(null, classes)).toBe(nullChain);
+    // A real face literally named "null" must not be served the null-family result.
+    const namedNull = normalizeFontFamily('null', classes);
+    expect(namedNull).toContain('"null"');
+    expect(namedNull).not.toBe(nullChain);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -620,6 +620,16 @@ export async function preloadImages(
 
 // ===== Main entry =====
 
+/**
+ * Per-canvas monotonic render token for the {@link renderDocumentToCanvas}
+ * cancellation guard. A WeakMap keyed on the canvas replaces the previous
+ * property monkey-patch (`canvas.__docxRenderToken`), so no non-standard field
+ * is written onto the caller's canvas and the `as unknown as` cast is gone.
+ * WeakMap keys are held weakly, so a discarded canvas is collected normally.
+ * (Mirrors the pptx renderSlide guard's renderTokens map.)
+ */
+const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
+
 export async function renderDocumentToCanvas(
   doc: DocxDocumentModel,
   canvas: HTMLCanvasElement | OffscreenCanvas,
@@ -635,9 +645,9 @@ export async function renderDocumentToCanvas(
   // us, stop at the next await so only the latest render's output survives.
   // (Mirrors the pptx renderSlide guard; the worker path renders each page on a
   // fresh OffscreenCanvas, so the token is a no-op there.)
-  const tokenHost = canvas as unknown as { __docxRenderToken?: number };
-  const myToken = (tokenHost.__docxRenderToken = (tokenHost.__docxRenderToken ?? 0) + 1);
-  const superseded = () => tokenHost.__docxRenderToken !== myToken;
+  const myToken = (renderTokens.get(canvas) ?? 0) + 1;
+  renderTokens.set(canvas, myToken);
+  const superseded = () => renderTokens.get(canvas) !== myToken;
 
   const dpr = opts.dpr ?? defaultDpr();
   // getContext before sizing is legal: resizing a canvas after getContext resets

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5825,8 +5825,25 @@ function layoutLines(
 
   const effectiveFontPx = (s: LayoutTextSeg): number => calcEffectiveFontPx(s, scale);
 
+  // Measure-loop font guard: line wrapping calls measureText / strAdvance many
+  // times in a row for the SAME segment (fit search, split prefixes/tails), so
+  // the built font string is usually identical to the previous one. Skip the
+  // redundant `ctx.font =` in that case. This tracker is written by EVERY font
+  // assignment on the measure path (both helpers below route through it), so it
+  // always reflects the context's current measure font — no stale skip. The
+  // draw-path `ctx.font =` sites are separate and left untouched. `buildFont` is
+  // now cheap (normalizeFontFamily is memoized per-doc), so this only elides the
+  // setter call itself.
+  let lastMeasureFont: string | null = null;
+  const setMeasureFont = (font: string): void => {
+    if (font !== lastMeasureFont) {
+      ctx.font = font;
+      lastMeasureFont = font;
+    }
+  };
+
   const measureText = (s: LayoutTextSeg): TextMetrics => {
-    ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
+    setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses));
     return ctx.measureText(s.text);
   };
 
@@ -5839,7 +5856,7 @@ function layoutLines(
   // Grid advance of an arbitrary string under a segment's font (for split
   // prefixes/tails). Selects the font, then applies the same gridWidth model.
   const strAdvance = (s: LayoutTextSeg, text: string): number => {
-    ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
+    setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses));
     return gridWidth(ctx.measureText(text).width, text, gridDeltaPx);
   };
 
@@ -8577,9 +8594,44 @@ function serifTail(cjk: ReturnType<typeof classifyCjkFont>): string {
  *     where fontTable says "auto"). Retained as a safety net for theme fonts
  *     and system fonts that OOXML docs do not list in fontTable.xml.
  */
+/**
+ * Per-document memo for {@link normalizeFontFamily}. The regex/classifier work
+ * inside is a pure function of `(family, fontFamilyClasses)`, and
+ * `fontFamilyClasses` is a stable per-document object (RenderState threads
+ * `doc.fontFamilyClasses` — one identity per render). Keying the outer WeakMap on
+ * that object identity gives per-doc caching with zero call-site churn (both
+ * callers already pass `fontFamilyClasses`) and no leak: the inner
+ * family→result Map is collected with the document's classes object. Same idiom
+ * as `sheetAxisCache` / `mathRenders`. Chosen over threading an explicit cache
+ * param through buildFont because both call sites already carry the classes
+ * object, so identity-keying needs no signature changes anywhere.
+ */
+const fontFamilyNormalizeCache = new WeakMap<Record<string, string>, Map<string, string>>();
+
 export function normalizeFontFamily(
   family: string | null,
   fontFamilyClasses: Record<string, string> = {},
+): string {
+  const perDoc =
+    fontFamilyNormalizeCache.get(fontFamilyClasses) ??
+    (() => {
+      const m = new Map<string, string>();
+      fontFamilyNormalizeCache.set(fontFamilyClasses, m);
+      return m;
+    })();
+  // `family` may be null; use a distinct sentinel key so a null lookup never
+  // collides with a real family named "null".
+  const key = family ?? '\0null';
+  const cached = perDoc.get(key);
+  if (cached !== undefined) return cached;
+  const result = normalizeFontFamilyUncached(family, fontFamilyClasses);
+  perDoc.set(key, result);
+  return result;
+}
+
+function normalizeFontFamilyUncached(
+  family: string | null,
+  fontFamilyClasses: Record<string, string>,
 ): string {
   if (!family) return sansTail(null);
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -4164,6 +4164,15 @@ export function applyDimOverlay(
 type SlideRenderOptions = RenderOptions & { math?: MathRenderer; dim?: DimOptions };
 
 /**
+ * Per-canvas monotonic render token for the {@link renderSlide} cancellation
+ * guard. A WeakMap keyed on the canvas replaces the previous property monkey-
+ * patch (`canvas.__pptxRenderToken`), so no non-standard field is written onto
+ * the caller's canvas and the `as unknown as` cast is gone. WeakMap keys are
+ * held weakly, so a discarded canvas is collected normally.
+ */
+const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
+
+/**
  * Render a single slide onto a <canvas> element.
  * Returns the canvas for convenience.
  */
@@ -4181,9 +4190,9 @@ export async function renderSlide(
   // draws interleave at the await points — ghosting multiple slides together.
   // Stamp a per-canvas token; once a newer render supersedes us, stop drawing at
   // the next await so only the latest render's output survives.
-  const tokenHost = canvas as unknown as { __pptxRenderToken?: number };
-  const myToken = (tokenHost.__pptxRenderToken = (tokenHost.__pptxRenderToken ?? 0) + 1);
-  const superseded = () => tokenHost.__pptxRenderToken !== myToken;
+  const myToken = (renderTokens.get(canvas) ?? 0) + 1;
+  renderTokens.set(canvas, myToken);
+  const superseded = () => renderTokens.get(canvas) !== myToken;
 
   const targetWidth = opts.width ?? ((isHTMLCanvas(canvas) ? canvas.offsetWidth : 0) || 960);
   const scale = targetWidth / slideWidth;

--- a/packages/xlsx/src/viewer-hit-test-axis.test.ts
+++ b/packages/xlsx/src/viewer-hit-test-axis.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { installDom, makeContainer } from './viewer-destroy-test-dom.js';
+import {
+  HEADER_W,
+  HEADER_H,
+  colWidthToPx,
+  rowHeightToPx,
+  getMdwForWorksheet,
+} from './renderer.js';
+import type { Worksheet } from './types.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * C3: getCellAt / getHeaderHit resolve the scrollable region via the O(log n)
+ * {@link AxisMetrics.indexAt} instead of a linear scan from the first scrollable
+ * index to the sheet limit (1,048,576 rows / 16,384 cols). These tests pin that
+ * the fast path returns the SAME cell as the old linear scan across custom row
+ * heights, custom column widths, and frozen panes — including the exact boundary
+ * conditions the scan had (on a cell edge, at the frozen boundary, in the header
+ * strip, and past the sheet's last cell).
+ *
+ * The oracle below is a verbatim re-implementation of the ORIGINAL linear scan
+ * (`for (r = freezeRows + 1; r <= 1048576; r++) { acc += size; if (content <
+ * acc) return r; } return null`) so the fast path is checked against the
+ * behavior it replaced, with expectations fixed by that oracle. The viewer is
+ * driven through its real `getCellAt`; `getBoundingClientRect()` returns
+ * top/left = 0 in the fake DOM and the sheet is LTR, so a client (x, y) maps
+ * directly to the logical layout coordinate the geometry math consumes.
+ */
+
+/** A worksheet with sparse custom sizes + a 2×2 frozen pane. Values chosen so
+ *  the frozen extent and several scrollable cells sit at non-round pixels. */
+function makeSheet(): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [],
+    // Excel column-width units (chars); colWidthToPx converts with mdw.
+    colWidths: { 1: 12, 2: 20, 4: 30, 7: 5 },
+    // Row-height units (points); rowHeightToPx converts.
+    rowHeights: { 1: 25, 2: 40, 5: 60, 9: 12 },
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 2,
+    freezeCols: 2,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+  } as Worksheet;
+}
+
+/** Verbatim copy of the ORIGINAL linear-scan getCellAt (pre-C3), used as the
+ *  oracle. `cs` (cellScale) = 1, LTR, rect origin (0,0). */
+function oldGetCellAt(
+  ws: Worksheet,
+  clientX: number,
+  clientY: number,
+  scrollTop: number,
+  scrollLeft: number,
+): { row: number; col: number } | null {
+  const lx = clientX;
+  const ly = clientY;
+  if (lx < HEADER_W || ly < HEADER_H) return null;
+  const innerX = lx - HEADER_W;
+  const innerY = ly - HEADER_H;
+  const freezeRows = ws.freezeRows ?? 0;
+  const freezeCols = ws.freezeCols ?? 0;
+  const mdw = getMdwForWorksheet(ws);
+
+  let frozenH = 0;
+  const frozenRowH: number[] = [];
+  for (let r = 1; r <= freezeRows; r++) {
+    const h = rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+    frozenRowH.push(h);
+    frozenH += h;
+  }
+  let frozenW = 0;
+  const frozenColW: number[] = [];
+  for (let c = 1; c <= freezeCols; c++) {
+    const w = colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
+    frozenColW.push(w);
+    frozenW += w;
+  }
+
+  let row: number;
+  if (innerY < frozenH) {
+    row = -1;
+    let acc = 0;
+    for (let r = 0; r < freezeRows; r++) {
+      acc += frozenRowH[r];
+      if (innerY < acc) { row = r + 1; break; }
+    }
+    if (row === -1) return null;
+  } else {
+    const contentY = innerY - frozenH + scrollTop;
+    row = -1;
+    let acc = 0;
+    for (let r = freezeRows + 1; r <= 1048576; r++) {
+      acc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+      if (contentY < acc) { row = r; break; }
+    }
+    if (row === -1) return null;
+  }
+
+  let col: number;
+  if (innerX < frozenW) {
+    col = -1;
+    let acc = 0;
+    for (let c = 0; c < freezeCols; c++) {
+      acc += frozenColW[c];
+      if (innerX < acc) { col = c + 1; break; }
+    }
+    if (col === -1) return null;
+  } else {
+    const contentX = innerX - frozenW + scrollLeft;
+    col = -1;
+    let acc = 0;
+    for (let c = freezeCols + 1; c <= 16384; c++) {
+      acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
+      if (contentX < acc) { col = c; break; }
+    }
+    if (col === -1) return null;
+  }
+  return { row, col };
+}
+
+/** Mount a viewer with the fixture worksheet injected and scroll set. */
+function mountViewer(ws: Worksheet, scrollTop = 0, scrollLeft = 0): XlsxViewer {
+  installDom();
+  const v = new XlsxViewer(makeContainer() as unknown as HTMLElement);
+  const priv = v as unknown as {
+    currentWorksheet: Worksheet | null;
+    scrollHost: { scrollTop: number; scrollLeft: number; scrollWidth: number; clientWidth: number };
+  };
+  priv.currentWorksheet = ws;
+  priv.scrollHost.scrollTop = scrollTop;
+  priv.scrollHost.scrollLeft = scrollLeft;
+  return v;
+}
+
+describe('XlsxViewer.getCellAt — AxisMetrics fast path matches old linear scan', () => {
+  it('matches the oracle over a grid sweep at several scroll offsets', () => {
+    const ws = makeSheet();
+    for (const [scrollTop, scrollLeft] of [
+      [0, 0],
+      [37, 51],
+      [123, 200],
+      [1000, 800],
+    ] as const) {
+      const v = mountViewer(ws, scrollTop, scrollLeft);
+      // Sweep the header strip and the scrollable body at a fine granularity.
+      for (let y = 0; y <= 260; y += 7) {
+        for (let x = 0; x <= 320; x += 9) {
+          const got = v.getCellAt(x, y);
+          const want = oldGetCellAt(ws, x, y, scrollTop, scrollLeft);
+          expect(got, `x=${x} y=${y} st=${scrollTop} sl=${scrollLeft}`).toEqual(want);
+        }
+      }
+      v.destroy();
+    }
+  });
+
+  it('resolves an exact-on-cell-edge scrollable point to the same cell as the oracle', () => {
+    const ws = makeSheet();
+    const mdw = getMdwForWorksheet(ws);
+    const freezeRows = ws.freezeRows;
+    const freezeCols = ws.freezeCols;
+
+    // Frozen extents (unscaled px).
+    let frozenH = 0;
+    for (let r = 1; r <= freezeRows; r++) frozenH += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+    let frozenW = 0;
+    for (let c = 1; c <= freezeCols; c++) frozenW += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
+
+    // Height of the first scrollable row (row 3) and width of first scrollable col (col 3).
+    const row3H = rowHeightToPx(ws.rowHeights[3] ?? ws.defaultRowHeight);
+    const col3W = colWidthToPx(ws.colWidths[3] ?? ws.defaultColWidth, mdw);
+
+    const v = mountViewer(ws, 0, 0);
+    // The point exactly on the trailing edge of row 3 / col 3 (contentY == row3H)
+    // belongs to row 4 / col 4 in the half-open `content < acc` convention — the
+    // oracle decides, the fast path must agree.
+    const yEdge = HEADER_H + frozenH + row3H; // exactly at row-3 bottom edge
+    const xEdge = HEADER_W + frozenW + col3W; // exactly at col-3 right edge
+    expect(v.getCellAt(xEdge, yEdge)).toEqual(oldGetCellAt(ws, xEdge, yEdge, 0, 0));
+    // And just inside row 3 / col 3.
+    expect(v.getCellAt(xEdge - 0.5, yEdge - 0.5)).toEqual(
+      oldGetCellAt(ws, xEdge - 0.5, yEdge - 0.5, 0, 0),
+    );
+    v.destroy();
+  });
+
+  it('returns null in the header strip and null past the last cell, matching the oracle', () => {
+    const ws = makeSheet();
+    const v = mountViewer(ws, 0, 0);
+
+    // Header strip (top-left corner region) → null for both.
+    expect(v.getCellAt(1, 1)).toBeNull();
+    expect(oldGetCellAt(ws, 1, 1, 0, 0)).toBeNull();
+
+    // Scroll so far past the end that even the last row/col is above the point.
+    // Row max = 1,048,576; scrolling the whole sheet height + slack lands past it.
+    const bigScroll = 1_048_576 * rowHeightToPx(ws.defaultRowHeight) + 10_000;
+    const bigScrollX = 16_384 * colWidthToPx(ws.defaultColWidth, getMdwForWorksheet(ws)) + 10_000;
+    const vFar = mountViewer(makeSheet(), bigScroll, bigScrollX);
+    const wsFar = (vFar as unknown as { currentWorksheet: Worksheet }).currentWorksheet;
+    // Deep inside the scrollable body but scrolled past the last cell.
+    const px = HEADER_W + 100;
+    const py = HEADER_H + 100;
+    expect(vFar.getCellAt(px, py)).toBeNull();
+    expect(oldGetCellAt(wsFar, px, py, bigScroll, bigScrollX)).toBeNull();
+    vFar.destroy();
+    v.destroy();
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -216,6 +216,34 @@ class AxisMetrics {
     }
     return { index: lo, partial: offset - this.offsetOf(lo) };
   }
+
+  /**
+   * Resolve the 1-based index a hit-test lands on in the *scrollable* region,
+   * given `content` = the logical-px distance from the START of `firstScrollable`
+   * (i.e. `innerPos - frozenExtent + logicalScroll`). Returns `null` when the
+   * point falls at or past the end of the very last cell (`maxIndex`), exactly
+   * like the previous linear scan that walked `r = firstScrollable … maxIndex`
+   * accumulating sizes and returned `null` if none satisfied `content < acc`.
+   *
+   * O(log n) via {@link indexAt}: shifting `content` by `offsetOf(firstScrollable)`
+   * expresses it in the absolute (index-1-origin) coordinate `indexAt` uses. The
+   * only place the linear scan and `indexAt` disagree is past the last cell —
+   * `indexAt` clamps to `maxIndex`, the scan returned `null` — so we reproduce the
+   * null by testing whether the absolute offset reaches the end of `maxIndex`.
+   */
+  scrollableIndexAt(content: number, firstScrollable: number): number | null {
+    const absOffset = content + this.offsetOf(firstScrollable);
+    // Past the end of the last cell ⇒ the old scan found no `content < acc`.
+    if (absOffset >= this.offsetOf(this.maxIndex) + this.sizeOf(this.maxIndex)) {
+      return null;
+    }
+    return this.indexAt(absOffset).index;
+  }
+
+  /** Logical-px span of `index` (1-based): its custom size if any, else default. */
+  private sizeOf(index: number): number {
+    return this.offsetOf(index + 1) - this.offsetOf(index);
+  }
 }
 
 /** Default cell-selection accent (Google blue), used when no `selectionColor`
@@ -753,13 +781,10 @@ export class XlsxViewer {
       if (row === -1) return null;
     } else {
       const contentY = innerY - frozenH + this.scrollHost.scrollTop / cs;
-      row = -1;
-      let acc = 0;
-      for (let r = freezeRows + 1; r <= 1048576; r++) {
-        acc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
-        if (contentY < acc) { row = r; break; }
-      }
-      if (row === -1) return null;
+      const axes = getSheetAxes(ws, getMdwForWorksheet(ws));
+      const r = axes.row.scrollableIndexAt(contentY, freezeRows + 1);
+      if (r === null) return null;
+      row = r;
     }
 
     // Find col
@@ -774,13 +799,10 @@ export class XlsxViewer {
       if (col === -1) return null;
     } else {
       const contentX = innerX - frozenW + this.effectiveScrollLeft / cs;
-      col = -1;
-      let acc = 0;
-      for (let c = freezeCols + 1; c <= 16384; c++) {
-        acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws));
-        if (contentX < acc) { col = c; break; }
-      }
-      if (col === -1) return null;
+      const axes = getSheetAxes(ws, getMdwForWorksheet(ws));
+      const c = axes.col.scrollableIndexAt(contentX, freezeCols + 1);
+      if (c === null) return null;
+      col = c;
     }
 
     return { row, col };
@@ -931,12 +953,9 @@ export class XlsxViewer {
         return null;
       }
       const contentY = innerY - frozenH + this.scrollHost.scrollTop / cs;
-      let acc = 0;
-      for (let r = freezeRows + 1; r <= 1048576; r++) {
-        acc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
-        if (contentY < acc) return { kind: 'row', row: r };
-      }
-      return null;
+      const axes = getSheetAxes(ws, getMdwForWorksheet(ws));
+      const r = axes.row.scrollableIndexAt(contentY, freezeRows + 1);
+      return r === null ? null : { kind: 'row', row: r };
     }
 
     // inColHeader
@@ -957,12 +976,9 @@ export class XlsxViewer {
       return null;
     }
     const contentX = innerX - frozenW + this.effectiveScrollLeft / cs;
-    let acc = 0;
-    for (let c = freezeCols + 1; c <= 16384; c++) {
-      acc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws));
-      if (contentX < acc) return { kind: 'col', col: c };
-    }
-    return null;
+    const axes = getSheetAxes(ws, getMdwForWorksheet(ws));
+    const c = axes.col.scrollableIndexAt(contentX, freezeCols + 1);
+    return c === null ? null : { kind: 'col', col: c };
   }
 
   /**


### PR DESCRIPTION
## Summary

Phase 1 items C3 / B6 / A8(first half) / C11 + hygiene A11 / A9 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md), plus a follow-up dedup.

### C3 — xlsx pointer hit-testing was a linear scan over up to 1M rows
`getCellAt` / `getHeaderHit` walked rows/columns linearly from the freeze boundary on every pointermove. They now route through the existing `AxisMetrics` binary search (new `scrollableIndexAt` adapter preserving the freeze-relative origin and null-past-last-cell semantics). **Bench: 500k-row sheet, 1000 near-bottom hits: 9296ms → 0.378ms (~24,600×), 0 parity mismatches** against a verbatim copy of the old scan used as test oracle (grid sweep ~5300 comparisons + edge/frozen-boundary/header/past-end cases).

### B6 — docx font normalization re-ran its regex chain on every measureText
`normalizeFontFamily` results are now memoized per document via `WeakMap<fontFamilyClasses, Map<family, css>>` (identity-keyed on the per-doc classes object — same idiom as `sheetAxisCache`/`mathRenders`, zero call-site changes). The measure hot loop's two `ctx.font` writers (`measureText` + `strAdvance`) share one same-value skip tracker; guarding only one would go stale when the other writes. Draw-path font sites untouched.

### A8 — image sniff copied the whole Blob
`decodeRasterOrMetafile` sniffed WMF/EMF magic by copying the entire Blob. It now reads a 44-byte slice (EMF needs offsets 40–43; the plan's '8 bytes' was insufficient). Rasters — the vast majority — go straight to `createImageBitmap(blob)` with no full copy; metafiles pay a tiny 44B + full re-read, noted in-code.

### C11 — render tokens were monkey-patched onto canvases
`__pptxRenderToken` **and its docx twin `__docxRenderToken`** (cross-package sweep) move to module-level `WeakMap<Canvas, number>`; the `as unknown as` casts are gone. Supersede semantics unchanged.

### A11 / A9 — hygiene
- Barrel drops 4 test-only bevel exports (`edt1d`/`shadePixel`/`shadeParamsFor`/`fillDirFromKey`); `materialClass`/`lightDirFromRig` stay (pptx uses them). Tests already deep-import.
- `createAuxCanvas` moves to `core/canvas/aux-canvas.ts` (leaf layer, re-exported from effects.ts); wmf/emf/dib all use it — EMF/DIB gain a main-thread `<canvas>` fallback (strict superset). Worker-only `OffscreenCanvas + transferToImageBitmap` paths are legitimately exclusive and left alone. Follow-up commit dedups `pattern-bitmaps.ts`'s `createTileCanvas` into it.

## Verification
- `pnpm test` 1510 / typecheck / lint — green
- `pnpm smoke` 6/6
- `pnpm build:wasm && pnpm vrt` — docx 21 / xlsx 67 / pptx 75 all passed, no failures; xlsx sheets at exact 0-diff (C3 render-invariant); references untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)