### PR TITLE
build: types-first exports, sideEffects:false, hardened npm publish gates (E2+E5+E6)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,8 +57,40 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # A tag must never publish code whose unit tests are red. WASM was built
+      # above, so the renderer/parser probe suites have their .wasm available.
+      - name: Unit tests
+        run: pnpm test
+
       - name: Build library
         run: pnpm build
+
+      # ── Verify the package that is about to be published ──────────────────────
+      # publint checks packaging correctness (exports ordering, file presence,
+      # module/type field sanity). attw checks that every entrypoint resolves to
+      # type declarations under each module-resolution mode. Both run against the
+      # real `npm pack` tarball, so a broken `exports` map fails the release
+      # instead of shipping. `--profile esm-only` acknowledges this package is
+      # intentionally ESM-only: it ignores the node10 and node16-from-CJS
+      # resolutions (which cannot succeed without a legacy CJS build we do not
+      # ship) while still failing on any regression in the ESM / bundler columns.
+      - name: Verify package exports (publint + attw)
+        run: |
+          npx --yes publint
+          npx --yes @arethetypeswrong/cli --pack . --profile esm-only
+
+      # Smoke test the actual tarball a consumer would install: pack it, install
+      # it into a throwaway project, and import each subpath in a DOM-less Node
+      # process. This proves the published entrypoints resolve AND that importing
+      # them has no top-level side effect (a stray `document` touch would throw
+      # `ReferenceError` here), which is the contract behind `sideEffects: false`.
+      - name: Smoke test the packed tarball
+        run: |
+          npm pack
+          mkdir -p /tmp/pack-smoke && cd /tmp/pack-smoke
+          npm init -y
+          npm i "$GITHUB_WORKSPACE"/silurus-ooxml-*.tgz
+          node --input-type=module -e "const m = await import('@silurus/ooxml/docx'); if (!m.DocxViewer) throw new Error('DocxViewer missing'); const p = await import('@silurus/ooxml/pptx'); if (!p.PptxViewer) throw new Error('PptxViewer missing'); const x = await import('@silurus/ooxml/xlsx'); if (!x.XlsxViewer) throw new Error('XlsxViewer missing'); console.log('pack smoke OK');"
 
       # ── Publish ──────────────────────────────────────────────────────────────
       - name: Publish to npm

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "provenance": true
   },
   "type": "module",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -35,24 +35,29 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/types/index.d.ts"
+      "default": "./dist/index.mjs"
     },
     "./docx": {
+      "types": "./dist/types/docx.d.ts",
       "import": "./dist/docx.mjs",
-      "types": "./dist/types/docx.d.ts"
+      "default": "./dist/docx.mjs"
     },
     "./xlsx": {
+      "types": "./dist/types/xlsx.d.ts",
       "import": "./dist/xlsx.mjs",
-      "types": "./dist/types/xlsx.d.ts"
+      "default": "./dist/xlsx.mjs"
     },
     "./pptx": {
+      "types": "./dist/types/pptx.d.ts",
       "import": "./dist/pptx.mjs",
-      "types": "./dist/types/pptx.d.ts"
+      "default": "./dist/pptx.mjs"
     },
     "./math": {
+      "types": "./dist/types/math.d.ts",
       "import": "./dist/math.mjs",
-      "types": "./dist/types/math.d.ts"
+      "default": "./dist/math.mjs"
     }
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/yukiyokotani/office-open-xml-viewer/issues"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/yukiyokotani/office-open-xml-viewer/issues"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/yukiyokotani/office-open-xml-viewer/issues"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/yukiyokotani/office-open-xml-viewer/issues"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## Summary

Phase 1 items E2 / E5 / E6 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md) — the last Phase 1 PR.

### E2 — `types` first + `default` condition (a real, tool-verified defect)
Plain `tsc --noEmit` passed in all four quadrants (bundler/node16 × before/after) — but the tooling exposed the defect the review predicted: **attw flagged 🐛 'Used fallback condition' (TypeScript bug microsoft/TypeScript#50762) on bundler and node16-ESM for all five entries**, and publint reported 5 errors (`types should be the first`). After reordering (+ `default` catch-all pointing at the same .mjs): attw 🟢 on bundler + node16-ESM for all entries, publint 'All good!'. node10 💀 / node16-CJS ⚠️ are unchanged and inherent to the deliberate ESM-only design. dist content is byte-identical — resolution metadata only.

### E5 — `sideEffects: false` (root + core/docx/pptx/xlsx)
Verified two independent ways before declaring: (a) grep audit — the only top-level global writes are `self.onmessage` in worker entry files, which live in separate worker bundles outside the static import graph; (b) the DOM-less Node pack-smoke below imports all three subpaths successfully — a top-level `document` touch would have thrown. The plan's '`docx` flat re-export asymmetry' turned out to be a misread (each package has its own uniform named barrel; the root wrappers are symmetric) — **no API change made**.

### E6 — publish gates (was: typecheck only)
publish.yml now runs, between build and publish: `pnpm test` → `publint` → `attw --pack . --profile esm-only` (**fail-closed**: ignores only the two resolutions an ESM-only package genuinely cannot satisfy, instead of a blanket `|| true`) → a tarball smoke that `npm i`s the packed tgz in a temp dir and imports `@silurus/ooxml/{docx,pptx,xlsx}` in bare Node asserting the viewer classes exist. All steps verified green locally against the packed 0.69.0 tarball.

## Verification
- `pnpm test` (1500 passed / 3 skipped) / `pnpm typecheck` / `pnpm lint` / `pnpm build` — green in the worktree
- publint exit 0 / attw esm-only exit 0 (5 green cells) / pack smoke OK
- Browser smoke intentionally left to this PR's CI (implemented in an isolated worktree; running Storybook there would collide with the main tree's port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)