### PR TITLE
perf: unify the WASM boundary on JSON bytes — one parse, one decode, transferable passthrough (C2+B7+D9)

### DIFF
--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -8,13 +8,20 @@ mod styles;
 mod types;
 mod xml_util;
 
+/// Parse a docx archive and return the model as UTF-8 JSON **bytes**.
+///
+/// Returning `Vec<u8>` (a fresh copy on the JS side) instead of `String` keeps
+/// the model out of the JsString/UTF-16 representation: the worker forwards the
+/// resulting `ArrayBuffer` to the main thread as a transferable and the main
+/// thread does a single `TextDecoder.decode` + `JSON.parse`, collapsing three
+/// serializations (Rust String → JsString → structured clone) into one decode.
 #[wasm_bindgen]
-pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
+pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let doc =
         parser::parse(data).map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
-    serde_json::to_string(&doc).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
+    serde_json::to_vec(&doc).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
 /// WASM-callable markdown projection (mirrors `to_markdown_native`). Returns

--- a/packages/docx/src/DocxViewer.stories.ts
+++ b/packages/docx/src/DocxViewer.stories.ts
@@ -172,8 +172,10 @@ export const DebugJson: Story = {
       try {
         await wasmReady;
         const buf = await file.arrayBuffer();
+        // `parse_docx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>);
+        // decode + parse to inspect the model.
         const json = parse_docx(new Uint8Array(buf));
-        const parsed = JSON.parse(json);
+        const parsed = JSON.parse(new TextDecoder().decode(json));
         // Images now carry a short `imagePath` (zip path) + `mimeType` rather
         // than inlined base64, so the JSON is already readable as-is.
         pre.textContent = JSON.stringify(parsed, null, 2);

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -128,7 +128,12 @@ export class DocxDocument {
     if (this._mode === 'worker') {
       this._meta = (res as Extract<RenderWorkerResponse, { type: 'parsedMeta' }>).meta;
     } else {
-      this._document = (res as Extract<WorkerResponse, { type: 'parsed' }>).document;
+      // The model arrives as transferred UTF-8 JSON bytes; decode + parse once
+      // here (the only serialization on the parse-mode path).
+      const { documentJson } = res as Extract<WorkerResponse, { type: 'parsed' }>;
+      this._document = JSON.parse(
+        new TextDecoder().decode(new Uint8Array(documentJson)),
+      ) as DocxDocumentModel;
     }
   }
 

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -61,10 +61,14 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
       currentBuffer = new Uint8Array(req.data);
-      // `parse_docx` throws on parse/serialize failure (Result<String,
+      // `parse_docx` throws on parse/serialize failure (Result<Vec<u8>,
       // JsValue>); the outer try/catch converts it into an error response, so
-      // the JSON here is always the success model — no error-field probe.
-      const parsed = JSON.parse(parse_docx(currentBuffer, currentMaxZipEntryBytes));
+      // the bytes here are always the success model — no error-field probe.
+      // Render mode consumes the model in-worker, so decode + parse it here (one
+      // decode, no passthrough).
+      const parsed = JSON.parse(
+        new TextDecoder().decode(parse_docx(currentBuffer, currentMaxZipEntryBytes)),
+      );
       doc = parsed as DocxDocumentModel;
       if (req.useGoogleFonts) {
         // Pagination measures text, so fonts must land BEFORE computePages —

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1094,7 +1094,10 @@ export type WorkerRequest =
   | { type: 'extractImage'; id: number; path: string };
 
 export type WorkerResponse =
-  | { type: 'parsed'; id: number; document: DocxDocumentModel }
+  // The model crosses the worker boundary as raw UTF-8 JSON bytes (transferred,
+  // not cloned); the main thread does the single `TextDecoder.decode` +
+  // `JSON.parse` into a `DocxDocumentModel`. See `parse_docx` (Rust) for why.
+  | { type: 'parsed'; id: number; documentJson: ArrayBuffer }
   | { type: 'imageExtracted'; id: number; bytes: ArrayBuffer }
   | { type: 'error'; id: number; message: string };
 

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -28,14 +28,19 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
       currentBuffer = new Uint8Array(req.data);
-      // `parse_docx` returns the model JSON on success and throws a JS Error on
-      // parse/serialize failure (Result<String, JsValue>), matching pptx/xlsx.
-      // The throw is caught by the outer try/catch below, so no error-field
-      // probe is needed here.
+      // `parse_docx` returns the model as UTF-8 JSON bytes on success and throws
+      // a JS Error on parse/serialize failure (Result<Vec<u8>, JsValue>),
+      // matching pptx/xlsx. The throw is caught by the outer try/catch below, so
+      // no error-field probe is needed here. wasm-bindgen hands back a fresh
+      // Uint8Array (a copy of the Rust Vec), so its buffer is exclusively ours:
+      // forward it to the main thread as a transferable — no clone, no decode
+      // here. The single decode + JSON.parse happens once, on the main thread.
       const json = parse_docx(currentBuffer, currentMaxZipEntryBytes);
-      const document = JSON.parse(json);
-      const res: WorkerResponse = { type: 'parsed', id, document };
-      self.postMessage(res);
+      const documentJson = json.buffer as ArrayBuffer;
+      const res: WorkerResponse = { type: 'parsed', id, documentJson };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [
+        documentJson,
+      ]);
       return;
     }
     if (req.type === 'extractImage') {

--- a/packages/node/src/bench-parse.mjs
+++ b/packages/node/src/bench-parse.mjs
@@ -1,0 +1,152 @@
+/**
+ * WASM-boundary parse benchmark.
+ *
+ * Measures the end-to-end cost of parsing one OOXML file through the WASM
+ * boundary as the main thread actually pays it: the WASM call itself + whatever
+ * marshalling the parser return needs + `JSON.parse` to materialize the model.
+ *
+ * It deliberately spans the whole "bytes in → model object out" path so the
+ * before/after numbers for the boundary-protocol change (String return +
+ * JSON.parse  vs.  Vec<u8> return + TextDecoder.decode + JSON.parse) are a fair,
+ * apples-to-apples comparison. The script auto-detects the parser's return type
+ * (string vs. Uint8Array), so the SAME file measures both protocol variants
+ * without edits — only the WASM behind it changes.
+ *
+ * Usage:
+ *   node packages/node/src/bench-parse.mjs <file> [iterations]
+ *
+ * Example:
+ *   node packages/node/src/bench-parse.mjs packages/docx/public/private/sample-10.docx
+ *
+ * Requires the WASM artifacts to be freshly built (`pnpm build:wasm`) so it
+ * measures the current parser source, not a stale committed pkg.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, extname, basename } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WARMUP = 1;
+const DEFAULT_ITERS = 5;
+
+/** Load a wasm-pack `--target web` module and synchronously initialize it from
+ *  disk bytes (mirrors packages/node/src/wasm-loader.ts). No OffscreenCanvas
+ *  shim is needed — parsing never touches a canvas. */
+function loadParser(relJs, relWasm) {
+  const wasmPath = resolve(HERE, relWasm);
+  const bytes = readFileSync(wasmPath);
+  const module = new WebAssembly.Module(bytes);
+  return import(resolve(HERE, relJs)).then((mod) => {
+    mod.initSync({ module });
+    return mod;
+  });
+}
+
+/** Decode whatever the parser returned into the model object, timing the
+ *  marshalling + parse the same way the real main-thread receiver does.
+ *  - String return  → JSON.parse(str)                     (old protocol)
+ *  - Uint8Array     → JSON.parse(TextDecoder.decode(u8))  (new protocol) */
+const decoder = new TextDecoder();
+function toModel(ret) {
+  if (typeof ret === 'string') return JSON.parse(ret);
+  if (ret instanceof Uint8Array) return JSON.parse(decoder.decode(ret));
+  throw new Error(`unexpected parser return type: ${Object.prototype.toString.call(ret)}`);
+}
+
+/** Pick the parser call for a file extension. Returns { module, call, label }.
+ *  `call(mod, bytes)` runs the WASM parse and returns its raw result (string or
+ *  Uint8Array). For xlsx we additionally parse sheet 0 so the measured work is
+ *  representative of what the viewer does on open (index + first sheet). */
+async function selectParser(ext) {
+  switch (ext) {
+    case '.docx': {
+      const mod = await loadParser(
+        '../../docx/src/wasm/docx_parser.js',
+        '../../docx/src/wasm/docx_parser_bg.wasm',
+      );
+      return {
+        label: 'parse_docx',
+        run: (bytes) => mod.parse_docx(bytes, undefined),
+      };
+    }
+    case '.pptx': {
+      const mod = await loadParser(
+        '../../pptx/src/wasm/pptx_parser.js',
+        '../../pptx/src/wasm/pptx_parser_bg.wasm',
+      );
+      return {
+        label: 'parse_pptx',
+        run: (bytes) => mod.parse_pptx(bytes, undefined),
+      };
+    }
+    case '.xlsx': {
+      const mod = await loadParser(
+        '../../xlsx/src/wasm/xlsx_parser.js',
+        '../../xlsx/src/wasm/xlsx_parser_bg.wasm',
+      );
+      return {
+        label: 'parse_xlsx',
+        run: (bytes) => mod.parse_xlsx(bytes, undefined),
+      };
+    }
+    default:
+      throw new Error(`unsupported extension: ${ext} (expected .docx/.pptx/.xlsx)`);
+  }
+}
+
+function stats(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const n = sorted.length;
+  const min = sorted[0];
+  const mean = sorted.reduce((s, x) => s + x, 0) / n;
+  const median =
+    n % 2 === 1 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  return { min, median, mean };
+}
+
+async function main() {
+  const [, , file, itersArg] = process.argv;
+  if (!file) {
+    console.error('usage: node packages/node/src/bench-parse.mjs <file> [iterations]');
+    process.exit(1);
+  }
+  const iters = itersArg ? Number(itersArg) : DEFAULT_ITERS;
+  const ext = extname(file).toLowerCase();
+  const bytes = readFileSync(resolve(process.cwd(), file));
+  const { label, run } = await selectParser(ext);
+
+  // Warmup (JIT + WASM linear-memory growth) — not counted.
+  let returnKind = 'unknown';
+  for (let i = 0; i < WARMUP; i++) {
+    const ret = run(bytes);
+    returnKind = typeof ret === 'string' ? 'string' : 'Uint8Array';
+    toModel(ret); // include decode so warmup exercises the same path
+  }
+
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = performance.now();
+    const ret = run(bytes);
+    const model = toModel(ret);
+    const t1 = performance.now();
+    // Touch the model so a clever engine can't dead-code-eliminate the parse.
+    if (model == null) throw new Error('parse produced null model');
+    samples.push(t1 - t0);
+  }
+
+  const { min, median, mean } = stats(samples);
+  const fmt = (x) => x.toFixed(2).padStart(9);
+  console.log(`file      : ${basename(file)} (${(bytes.length / 1_000_000).toFixed(2)} MB)`);
+  console.log(`parser    : ${label}  return=${returnKind}  warmup=${WARMUP} iters=${iters}`);
+  console.log('           ' + ['min', 'median', 'mean'].map((h) => h.padStart(9)).join(' '));
+  console.log(`  ms      :${fmt(min)} ${fmt(median)} ${fmt(mean)}`);
+  // Machine-readable line for scripted collection.
+  console.log(
+    `RESULT\t${basename(file)}\t${returnKind}\t${min.toFixed(2)}\t${median.toFixed(2)}\t${mean.toFixed(2)}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/node/src/docx.ts
+++ b/packages/node/src/docx.ts
@@ -20,6 +20,10 @@ export function parseDocx(buffer: ArrayBuffer | Uint8Array | Buffer): DocxDocume
     buffer instanceof Uint8Array
       ? buffer
       : new Uint8Array(buffer as ArrayBuffer);
-  const json = (docxWasm as unknown as { parse_docx: (b: Uint8Array) => string }).parse_docx(bytes);
-  return JSON.parse(json) as DocxDocumentModel;
+  // `parse_docx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); decode +
+  // parse once. Matches the browser main-thread receiver.
+  const json = (docxWasm as unknown as { parse_docx: (b: Uint8Array) => Uint8Array }).parse_docx(
+    bytes,
+  );
+  return JSON.parse(new TextDecoder().decode(json)) as DocxDocumentModel;
 }

--- a/packages/node/src/pptx.ts
+++ b/packages/node/src/pptx.ts
@@ -26,8 +26,12 @@ export function parsePptx(buffer: ArrayBuffer | Uint8Array | Buffer): Presentati
     buffer instanceof Uint8Array
       ? buffer
       : new Uint8Array(buffer as ArrayBuffer);
-  const json = (pptxWasm as unknown as { parse_pptx: (b: Uint8Array) => string }).parse_pptx(bytes);
-  return JSON.parse(json) as Presentation;
+  // `parse_pptx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); decode +
+  // parse once. Matches the browser main-thread receiver.
+  const json = (pptxWasm as unknown as { parse_pptx: (b: Uint8Array) => Uint8Array }).parse_pptx(
+    bytes,
+  );
+  return JSON.parse(new TextDecoder().decode(json)) as Presentation;
 }
 
 /** Extract raw bytes for a single media entry (e.g. `ppt/media/image1.png`)

--- a/packages/node/src/xlsx.ts
+++ b/packages/node/src/xlsx.ts
@@ -18,8 +18,12 @@ function ensureInit(): void {
 export function parseXlsx(buffer: ArrayBuffer | Uint8Array | Buffer): ParsedWorkbook {
   ensureInit();
   const bytes = toUint8(buffer);
-  const json = (xlsxWasm as unknown as { parse_xlsx: (b: Uint8Array) => string }).parse_xlsx(bytes);
-  return JSON.parse(json) as ParsedWorkbook;
+  // `parse_xlsx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); decode +
+  // parse once. Matches the browser main-thread receiver.
+  const json = (xlsxWasm as unknown as { parse_xlsx: (b: Uint8Array) => Uint8Array }).parse_xlsx(
+    bytes,
+  );
+  return JSON.parse(new TextDecoder().decode(json)) as ParsedWorkbook;
 }
 
 /** Parse a single sheet's cell data and layout. The browser path does this
@@ -32,10 +36,12 @@ export function parseSheet(
 ): Worksheet {
   ensureInit();
   const bytes = toUint8(buffer);
+  // `parse_sheet` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); decode +
+  // parse once.
   const json = (xlsxWasm as unknown as {
-    parse_sheet: (b: Uint8Array, idx: number, name: string) => string;
+    parse_sheet: (b: Uint8Array, idx: number, name: string) => Uint8Array;
   }).parse_sheet(bytes, sheetIndex, sheetName);
-  return JSON.parse(json) as Worksheet;
+  return JSON.parse(new TextDecoder().decode(json)) as Worksheet;
 }
 
 /** Eagerly parse every sheet referenced by the workbook. Useful for batch

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -12,13 +12,20 @@ mod table_style_presets;
 //  Public WASM entry points
 // ===========================
 
+/// Parse a pptx archive and return the model as UTF-8 JSON **bytes**.
+///
+/// Returning `Vec<u8>` (a fresh copy on the JS side) instead of `String` keeps
+/// the model out of the JsString/UTF-16 representation: the worker forwards the
+/// resulting `ArrayBuffer` to the main thread as a transferable and the main
+/// thread does a single `TextDecoder.decode` + `JSON.parse`, collapsing three
+/// serializations (Rust String → JsString → structured clone) into one decode.
 #[wasm_bindgen]
-pub fn parse_pptx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
+pub fn parse_pptx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let presentation = parse_presentation(data)
         .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
-    serde_json::to_string(&presentation)
+    serde_json::to_vec(&presentation)
         .map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -168,8 +168,10 @@ export const DebugJson: Story = {
       try {
         await wasmReady;
         const buf = await file.arrayBuffer();
+        // `parse_pptx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>);
+        // decode + parse to inspect the model.
         const json = parse_pptx(new Uint8Array(buf));
-        const parsed = JSON.parse(json);
+        const parsed = JSON.parse(new TextDecoder().decode(json));
         // Print summary: slide count, element count per slide
         const summary = {
           slideWidth: parsed.slideWidth,

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -187,7 +187,12 @@ export class PptxPresentation {
     if (this._mode === 'worker') {
       this._meta = (res as Extract<RenderWorkerResponse, { kind: 'parsedMeta' }>).meta;
     } else {
-      this._presentation = (res as Extract<WorkerResponse, { kind: 'parsed' }>).presentation;
+      // The model arrives as transferred UTF-8 JSON bytes; decode + parse once
+      // here (the only serialization on the parse-mode path).
+      const { presentationJson } = res as Extract<WorkerResponse, { kind: 'parsed' }>;
+      this._presentation = JSON.parse(
+        new TextDecoder().decode(new Uint8Array(presentationJson)),
+      ) as Presentation;
     }
   }
 

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -86,7 +86,12 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      pres = JSON.parse(parse_pptx(currentBuffer, currentMaxZipEntryBytes)) as Presentation;
+      // `parse_pptx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>). Render
+      // mode consumes the model in-worker, so decode + parse here (one decode,
+      // no passthrough).
+      pres = JSON.parse(
+        new TextDecoder().decode(parse_pptx(currentBuffer, currentMaxZipEntryBytes)),
+      ) as Presentation;
       if (req.useGoogleFonts) {
         // Kick the preload now so it overlaps with main-thread work; renders
         // await `fontsLoaded` so text never rasterizes with fallback metrics.

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -631,7 +631,10 @@ export type WorkerRequest =
 
 export type WorkerResponse =
   | { kind: 'ready' }
-  | { kind: 'parsed'; id: number; presentation: Presentation }
+  // The model crosses the worker boundary as raw UTF-8 JSON bytes (transferred,
+  // not cloned); the main thread does the single `TextDecoder.decode` +
+  // `JSON.parse` into a `Presentation`. See `parse_pptx` (Rust) for why.
+  | { kind: 'parsed'; id: number; presentationJson: ArrayBuffer }
   | { kind: 'mediaExtracted'; id: number; bytes: ArrayBuffer }
   | { kind: 'imageExtracted'; id: number; bytes: ArrayBuffer }
   | { kind: 'error'; id: number; message: string };

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -1,4 +1,4 @@
-import type { Presentation, WorkerRequest, WorkerResponse } from './types';
+import type { WorkerRequest, WorkerResponse } from './types';
 import init, { parse_pptx, extract_media, extract_image } from './wasm/pptx_parser.js';
 
 let ready = false;
@@ -45,10 +45,16 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      const jsonStr = parse_pptx(bytes, currentMaxZipEntryBytes);
-      const presentation: Presentation = JSON.parse(jsonStr);
-      const msg: WorkerResponse = { kind: 'parsed', id: req.id, presentation };
-      self.postMessage(msg);
+      // `parse_pptx` returns the model as UTF-8 JSON bytes (Result<Vec<u8>,
+      // JsValue>). wasm-bindgen hands back a fresh Uint8Array that owns its
+      // buffer, so forward it to the main thread as a transferable — no clone,
+      // no decode here. The single decode + JSON.parse happens once, on main.
+      const json = parse_pptx(bytes, currentMaxZipEntryBytes);
+      const presentationJson = json.buffer as ArrayBuffer;
+      const msg: WorkerResponse = { kind: 'parsed', id: req.id, presentationJson };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [
+        presentationJson,
+      ]);
     } catch (err) {
       const msg: WorkerResponse = {
         kind: 'error',

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -40,21 +40,30 @@ const INDEXED_COLORS: &[&str] = &[
     "#333333", // 56-63
 ];
 
+/// Parse a xlsx archive's workbook index and return it as UTF-8 JSON **bytes**.
+///
+/// Returning `Vec<u8>` (a fresh copy on the JS side) instead of `String` keeps
+/// the model out of the JsString/UTF-16 representation: the worker forwards the
+/// resulting `ArrayBuffer` to the main thread as a transferable and the main
+/// thread does a single `TextDecoder.decode` + `JSON.parse`, collapsing three
+/// serializations (Rust String → JsString → structured clone) into one decode.
 #[wasm_bindgen]
-pub fn parse_xlsx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
+pub fn parse_xlsx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let wb = parse_xlsx_inner(data).map_err(|e| JsValue::from_str(&e))?;
-    serde_json::to_string(&wb).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
+    serde_json::to_vec(&wb).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
+/// Parse one worksheet's cell data + layout and return it as UTF-8 JSON
+/// **bytes** (see `parse_xlsx` for the bytes-return rationale).
 #[wasm_bindgen]
 pub fn parse_sheet(
     data: &[u8],
     sheet_index: u32,
     name: &str,
     max_zip_entry_bytes: Option<u64>,
-) -> Result<String, JsValue> {
+) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
     let cursor = Cursor::new(data);
@@ -97,7 +106,7 @@ pub fn parse_sheet(
     ws.default_font_family = df_family;
     ws.default_font_size = df_size;
 
-    serde_json::to_string(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
+    serde_json::to_vec(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -121,8 +121,10 @@ export const DebugJson: Story = {
       try {
         await wasmReady;
         const buf = await file.arrayBuffer();
+        // `parse_xlsx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>);
+        // decode + parse to inspect the model.
         const json = parse_xlsx(new Uint8Array(buf));
-        const parsed = JSON.parse(json);
+        const parsed = JSON.parse(new TextDecoder().decode(json));
         pre.textContent = JSON.stringify(parsed, null, 2);
         console.log('[xlsx debug] full JSON:', parsed);
       } catch (err) {

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -57,8 +57,10 @@ function parseSheetLocally(sheetIndex: number): Worksheet {
   if (!workbook || !rawData) throw new Error('Workbook not loaded');
   const sheetMeta = workbook.workbook.sheets[sheetIndex];
   if (!sheetMeta) throw new Error(`Sheet index ${sheetIndex} out of range`);
+  // `parse_sheet` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); the
+  // render worker consumes the model in-worker, so decode + parse here.
   const json = parse_sheet(new Uint8Array(rawData), sheetIndex, sheetMeta.name, maxZipEntryBytes);
-  const ws = JSON.parse(json) as Worksheet;
+  const ws = JSON.parse(new TextDecoder().decode(json)) as Worksheet;
   sheetCache.set(sheetIndex, ws);
   return ws;
 }
@@ -82,8 +84,11 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      // `parse_xlsx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); decode
+      // + parse the workbook index here (consumed in-worker, then a light copy
+      // is sent to the proxy as an object).
       const json = parse_xlsx(new Uint8Array(req.data), maxZipEntryBytes);
-      workbook = JSON.parse(json) as ParsedWorkbook;
+      workbook = JSON.parse(new TextDecoder().decode(json)) as ParsedWorkbook;
       rawData = req.data;
       if (req.useGoogleFonts) {
         // Mirror XlsxWorkbook._load exactly: queue Google Fonts substitutes for

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -1002,7 +1002,11 @@ export type WorkerRequest =
   | { type: 'extractImage'; id: number; path: string };
 
 export type WorkerResponse =
-  | { type: 'parsed'; id: number; workbook: ParsedWorkbook }
-  | { type: 'parsedSheet'; id: number; worksheet: Worksheet }
+  // The workbook index / worksheet cross the worker boundary as raw UTF-8 JSON
+  // bytes (transferred, not cloned); the main thread does the single
+  // `TextDecoder.decode` + `JSON.parse` into a `ParsedWorkbook` / `Worksheet`.
+  // See `parse_xlsx` (Rust) for why.
+  | { type: 'parsed'; id: number; workbookJson: ArrayBuffer }
+  | { type: 'parsedSheet'; id: number; worksheetJson: ArrayBuffer }
   | { type: 'imageExtracted'; id: number; bytes: ArrayBuffer }
   | { type: 'error'; id: number; message: string };

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -130,8 +130,16 @@ export class XlsxWorkbook {
           } satisfies WorkerRequest),
     );
     // Both modes carry the light, workbook-level ParsedWorkbook back, so
-    // sheetNames / tabColors / resolveValidationList keep working.
-    this.parsedWorkbook = (parsed as Extract<WorkerResponse, { type: 'parsed' }>).workbook;
+    // sheetNames / tabColors / resolveValidationList keep working. In parse mode
+    // it arrives as transferred UTF-8 JSON bytes — decode + parse once here.
+    if (this._mode === 'worker') {
+      this.parsedWorkbook = (parsed as Extract<RenderWorkerResponse, { type: 'parsed' }>).workbook;
+    } else {
+      const { workbookJson } = parsed as Extract<WorkerResponse, { type: 'parsed' }>;
+      this.parsedWorkbook = JSON.parse(
+        new TextDecoder().decode(new Uint8Array(workbookJson)),
+      ) as ParsedWorkbook;
+    }
     if (this._mode === 'main' && opts.useGoogleFonts) {
       await preloadGoogleFonts(
         xlsxFontPreloadNames(this.parsedWorkbook),
@@ -196,7 +204,16 @@ export class XlsxWorkbook {
       sheetName: sheetMeta.name,
       maxZipEntryBytes: this.maxZipEntryBytes,
     }));
-    const ws = (res as Extract<WorkerResponse, { type: 'parsedSheet' }>).worksheet;
+    // Parse mode: the worker forwards the sheet as transferred UTF-8 JSON bytes
+    // — decode + parse once here. Worker (render) mode: the worker already
+    // decoded it and sends the object back as a structured clone.
+    let ws: Worksheet;
+    if (this._mode === 'worker') {
+      ws = (res as Extract<RenderWorkerResponse, { type: 'parsedSheet' }>).worksheet;
+    } else {
+      const { worksheetJson } = res as Extract<WorkerResponse, { type: 'parsedSheet' }>;
+      ws = JSON.parse(new TextDecoder().decode(new Uint8Array(worksheetJson))) as Worksheet;
+    }
     this.sheetCache.set(sheetIndex, ws);
     return ws;
   }

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -1,4 +1,10 @@
-import type { ViewportRange, RenderViewportOptions, WorkerResponse } from './types.js';
+import type {
+  ViewportRange,
+  RenderViewportOptions,
+  WorkerResponse,
+  ParsedWorkbook,
+  Worksheet,
+} from './types.js';
 
 /** Serializable subset of RenderViewportOptions: drop the callback, the image
  *  cache, and the `fetchImage` loader (all non-cloneable; the worker owns its
@@ -32,9 +38,15 @@ export type RenderWorkerRequest =
   | { type: 'extractImage'; id: number; path: string };
 
 export type RenderWorkerResponse =
-  // `parsed` / `parsedSheet` / `error` are reused from WorkerResponse: xlsx DOES
-  // transfer the (light, workbook-level) ParsedWorkbook back to the proxy, so
-  // synchronous getters (sheetNames, tabColors, …) keep working; per-sheet data
-  // stays worker-side and is parsed there on demand.
-  | WorkerResponse
+  // `imageExtracted` / `error` are reused from WorkerResponse. `parsed` and
+  // `parsedSheet` are NOT reused: the parse-only worker returns those models as
+  // transferred JSON bytes, but the render worker has already decoded them
+  // worker-side (it consumes them to render), so it sends the objects back to
+  // the proxy as structured clones — no re-serialization. The light,
+  // workbook-level ParsedWorkbook keeps synchronous getters (sheetNames,
+  // tabColors, …) working; per-sheet data stays worker-side and is parsed on
+  // demand.
+  | Exclude<WorkerResponse, { type: 'parsed' } | { type: 'parsedSheet' }>
+  | { type: 'parsed'; id: number; workbook: ParsedWorkbook }
+  | { type: 'parsedSheet'; id: number; worksheet: Worksheet }
   | { type: 'viewportRendered'; id: number; bitmap: ImageBitmap };

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -29,10 +29,16 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
       currentBuffer = new Uint8Array(req.data);
+      // `parse_xlsx` returns the workbook index as UTF-8 JSON bytes
+      // (Result<Vec<u8>, JsValue>). wasm-bindgen hands back a fresh Uint8Array
+      // that owns its buffer, so forward it to main as a transferable — no
+      // clone, no decode here. The single decode + JSON.parse happens on main.
       const json = parse_xlsx(currentBuffer, currentMaxZipEntryBytes);
-      const workbook = JSON.parse(json);
-      const res: WorkerResponse = { type: 'parsed', id, workbook };
-      self.postMessage(res);
+      const workbookJson = json.buffer as ArrayBuffer;
+      const res: WorkerResponse = { type: 'parsed', id, workbookJson };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [
+        workbookJson,
+      ]);
     } else if (req.type === 'parseSheet') {
       // Reuse the buffer retained at `parse` instead of re-receiving it — the
       // whole file no longer crosses the worker boundary on every sheet switch
@@ -46,10 +52,14 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      // `parse_sheet` also returns UTF-8 JSON bytes; forward its transferable
+      // buffer to main the same way (single decode + parse on main).
       const json = parse_sheet(currentBuffer, req.sheetIndex, req.sheetName, maxBytes);
-      const worksheet = JSON.parse(json);
-      const res: WorkerResponse = { type: 'parsedSheet', id, worksheet };
-      self.postMessage(res);
+      const worksheetJson = json.buffer as ArrayBuffer;
+      const res: WorkerResponse = { type: 'parsedSheet', id, worksheetJson };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [
+        worksheetJson,
+      ]);
     } else if (req.type === 'extractImage') {
       if (!currentBuffer) throw new Error('No xlsx loaded');
       const bytes = extract_image(currentBuffer, req.path, currentMaxZipEntryBytes);


### PR DESCRIPTION
## Summary

Phase 2 tranche 1 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md): the parse result used to be serialized **three times** (Rust `serde_json::to_string` → UTF-8→UTF-16 JsString marshalling at the WASM boundary → `JSON.parse` in the worker → structured clone over `postMessage`). 

### New protocol
- All four parse entrypoints (`parse_docx`, `parse_pptx`, `parse_xlsx`, `parse_sheet`) return `Result<Vec<u8>, JsValue>` (JSON bytes via `serde_json::to_vec`)
- Parse-only workers forward the bytes as a **transferable ArrayBuffer** — no worker-side parse, no structured clone of the model
- The main thread does a single `TextDecoder.decode` + `JSON.parse`
- Render-workers (which consume the model in-worker) decode+parse in-worker — they were already single-parse and stay that way
- `extract_image`/`extract_media`/`*_to_markdown`/`*_native` untouched

### Benchmark (Node boundary, warmup 1 + 5 iters, median)
| File | before | after |
|---|--:|--:|
| sample-10.docx (1.9 MB) | 4.30 ms | 4.34 ms (noise) |
| **sample-4.pptx (15.2 MB)** | **30.01 ms** | **15.43 ms (~2×)** |
| sample-27.xlsx (1.7 MB) | 1.37 ms | 1.01 ms |

Large payloads win from dropping `to_string`'s UTF-8 validation + JsString UTF-16 marshalling; the browser additionally saves one structured clone per parse (worker→main), which the smoke suite exercises end-to-end. New `packages/node/src/bench-parse.mjs` harness (auto-detects string/bytes return, so before/after used identical code).

## Verification
- cargo fmt / clippy -D warnings / test --workspace (459) — green
- pnpm build:wasm → test (1510) / typecheck / lint — green
- pnpm smoke 6/6 (real-browser transferable path)
- **pnpm vrt: 163 passed (docx 21 / xlsx 67 / pptx 75), rendering fully invariant**, references untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)