### PR TITLE
perf(xlsx): rAF-coalesced repaints, backing-store reuse, stale worker-frame dropping (C4)

### DIFF
--- a/packages/xlsx/src/render-orchestrator-resize.test.ts
+++ b/packages/xlsx/src/render-orchestrator-resize.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { renderWorksheetViewport, type RenderDeps } from './render-orchestrator.js';
+import type { Worksheet } from './types.js';
+import type { ParsedWorkbook } from './types.js';
+
+/**
+ * Canvas re-allocation guard (improvement plan C4, commit 2): the orchestrator
+ * must assign `canvas.width` / `canvas.height` only when the target dimensions
+ * actually change. Re-assigning the same value re-allocates (and clears) the GPU
+ * backing store, so a steady scroll/zoom stream — same size every frame — must
+ * NOT touch width/height after the first frame. A real size change (dpr, scale,
+ * container resize) still re-allocates. And because the assignment is skipped,
+ * the DPR transform is applied absolutely (setTransform), never a compounding
+ * ctx.scale, so a skipped frame keeps the correct 1:1 device mapping.
+ */
+
+/** A fake 2D context that records `setTransform` and no-ops every draw call via
+ *  a Proxy, so an empty-worksheet render runs without a real canvas. */
+function makeCtx(canvas: FakeCanvas): { ctx: CanvasRenderingContext2D; transforms: number[][] } {
+  const transforms: number[][] = [];
+  const target: Record<string, unknown> = {
+    canvas,
+    setTransform: (...m: number[]) => {
+      transforms.push(m);
+    },
+    scale: (x: number, y: number) => {
+      // Record a scale as a transform too, so a test can detect if the code path
+      // ever falls back to the compounding scale() instead of setTransform().
+      transforms.push(['scale', x, y] as unknown as number[]);
+    },
+    measureText: (s: string) => ({ width: [...String(s)].length * 7 }),
+    createLinearGradient: () => ({ addColorStop() {} }),
+    createPattern: () => null,
+    getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+  };
+  const ctx = new Proxy(target, {
+    get(t, prop: string) {
+      if (prop in t) return t[prop];
+      // Any unlisted property read: return a no-op function (draw ops) or a
+      // benign value. Assignments (fillStyle, font, …) are absorbed by set().
+      return () => undefined;
+    },
+    set(t, prop: string, value: unknown) {
+      t[prop] = value;
+      return true;
+    },
+  });
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, transforms };
+}
+
+/** A fake HTMLCanvas whose width/height setters count assignments (any write,
+ *  even same-value), mirroring the real backing-store re-allocation cost. */
+class FakeCanvas {
+  private _w = 0;
+  private _h = 0;
+  widthWrites = 0;
+  heightWrites = 0;
+  clientWidth = 800;
+  clientHeight = 600;
+  style: Record<string, string> = {};
+  _ctx: { ctx: CanvasRenderingContext2D; transforms: number[][] };
+  constructor() {
+    this._ctx = makeCtx(this);
+  }
+  get width(): number {
+    return this._w;
+  }
+  set width(v: number) {
+    this._w = v;
+    this.widthWrites++;
+  }
+  get height(): number {
+    return this._h;
+  }
+  set height(v: number) {
+    this._h = v;
+    this.heightWrites++;
+  }
+  getContext(): CanvasRenderingContext2D {
+    return this._ctx.ctx;
+  }
+}
+
+/** Minimal empty worksheet: no rows/images/shapes ⇒ the render does its canvas
+ *  sizing + a background clear and returns, exercising exactly the resize path. */
+function emptyWorksheet(): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 64,
+    defaultRowHeight: 20,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    charts: [],
+    images: [],
+    shapeGroups: [],
+  } as unknown as Worksheet;
+}
+
+function deps(): RenderDeps {
+  return {
+    ws: emptyWorksheet(),
+    styles: { fonts: [], fills: [], borders: [], cellXfs: [], numFmts: {} } as unknown as ParsedWorkbook['styles'],
+    imageCache: new Map(),
+  };
+}
+
+const VIEWPORT = { row: 1, col: 1, rows: 10, cols: 10 };
+
+describe('renderWorksheetViewport canvas re-allocation guard (C4 commit 2)', () => {
+  it('does not re-assign width/height when the size is unchanged across frames', async () => {
+    const canvas = new FakeCanvas();
+    const opts = { width: 800, height: 600, dpr: 1 };
+
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, opts);
+    // First frame sizes the backing store once.
+    expect(canvas.widthWrites).toBe(1);
+    expect(canvas.heightWrites).toBe(1);
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(600);
+
+    // Subsequent identical frames must NOT re-assign (no re-allocation).
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, opts);
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, opts);
+    expect(canvas.widthWrites).toBe(1);
+    expect(canvas.heightWrites).toBe(1);
+  });
+
+  it('re-assigns width/height when dpr changes', async () => {
+    const canvas = new FakeCanvas();
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, {
+      width: 800,
+      height: 600,
+      dpr: 1,
+    });
+    expect(canvas.width).toBe(800);
+    expect(canvas.widthWrites).toBe(1);
+
+    // DPR 2 ⇒ backing store must grow to 1600×1200 ⇒ a real re-assignment.
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, {
+      width: 800,
+      height: 600,
+      dpr: 2,
+    });
+    expect(canvas.width).toBe(1600);
+    expect(canvas.height).toBe(1200);
+    expect(canvas.widthWrites).toBe(2);
+    expect(canvas.heightWrites).toBe(2);
+  });
+
+  it('re-assigns width/height when the logical size changes', async () => {
+    const canvas = new FakeCanvas();
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, {
+      width: 800,
+      height: 600,
+      dpr: 1,
+    });
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, {
+      width: 1024,
+      height: 600,
+      dpr: 1,
+    });
+    expect(canvas.width).toBe(1024);
+    expect(canvas.widthWrites).toBe(2);
+    // Height was unchanged (600) ⇒ its setter must not have fired a 2nd time.
+    expect(canvas.heightWrites).toBe(1);
+  });
+
+  it('applies the DPR transform absolutely every frame (no compounding scale)', async () => {
+    const canvas = new FakeCanvas();
+    const opts = { width: 800, height: 600, dpr: 2 };
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, opts);
+    // Same-size frames skip the resize; the transform must still be set to the
+    // absolute DPR matrix, and never via the compounding scale() path.
+    await renderWorksheetViewport(deps(), canvas as unknown as HTMLCanvasElement, VIEWPORT, opts);
+
+    const t = canvas._ctx.transforms;
+    // No frame used the compounding scale() fallback.
+    expect(t.some((m) => (m as unknown[])[0] === 'scale')).toBe(false);
+    // Every frame set the absolute DPR matrix [2,0,0,2,0,0].
+    const dprMatrices = t.filter(
+      (m) => m.length === 6 && m[0] === 2 && m[1] === 0 && m[2] === 0 && m[3] === 2 && m[4] === 0 && m[5] === 0,
+    );
+    expect(dprMatrices.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -224,18 +224,34 @@ export async function renderWorksheetViewport(
   const width = opts.width ?? rawW;
   const height = opts.height ?? rawH;
 
-  target.width = Math.round(width * dpr);
-  target.height = Math.round(height * dpr);
+  // Resize only when the backing store dimensions actually change. Assigning
+  // canvas.width/height re-allocates (and clears) the GPU backing store, so on a
+  // steady-state scroll/zoom stream — where width/height/dpr are unchanged frame
+  // to frame — re-assigning the same value wastes an allocation every frame
+  // (improvement plan C4). The inner renderViewport starts with an explicit
+  // clearRect + white fill, so nothing depends on the width-assignment's implicit
+  // clear; skipping the same-size resize is safe.
+  const bw = Math.round(width * dpr);
+  const bh = Math.round(height * dpr);
+  if (target.width !== bw) target.width = bw;
+  if (target.height !== bh) target.height = bh;
   // Set CSS display size so the browser renders at 1:1 device pixels (no browser-level scaling).
   // Without this, canvas.width=2400 on a DPR=2 display causes the canvas to be laid out at
   // 2400 CSS px, making all content appear blurry when viewed in a 1200 CSS px container.
   if (isHTMLCanvas(target)) {
-    target.style.width = `${width}px`;
-    target.style.height = `${height}px`;
+    const cssW = `${width}px`;
+    const cssH = `${height}px`;
+    if (target.style.width !== cssW) target.style.width = cssW;
+    if (target.style.height !== cssH) target.style.height = cssH;
   }
 
   const ctx = (target as HTMLCanvasElement).getContext('2d') as CanvasRenderingContext2D;
-  ctx.scale(dpr, dpr);
+  // Set the DPR transform absolutely rather than ctx.scale(dpr, dpr): when the
+  // resize above is skipped the backing store is NOT re-created, so its transform
+  // is not reset to identity, and a relative scale() would compound the dpr every
+  // frame (progressive zoom). setTransform is idempotent whether or not the store
+  // was reallocated.
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
   renderViewport(ctx, ws, styles, viewport, { ...opts, dpr, loadedImages: imageCache });
 }

--- a/packages/xlsx/src/viewer-destroy-test-dom.ts
+++ b/packages/xlsx/src/viewer-destroy-test-dom.ts
@@ -34,6 +34,10 @@ export interface FakeEl {
   classList: { add(...c: string[]): void; remove(...c: string[]): void; contains(c: string): boolean };
   _attrs: Map<string, string>;
   _listeners: Map<string, Array<(e: unknown) => void>>;
+  /** Persisted bitmaprenderer context (worker mode). Records the last painted
+   *  bitmap so tests can assert which frame reached the canvas. Lazily created
+   *  by {@link getContext}('bitmaprenderer'); null until then. */
+  _bitmapCtx: { lastBitmap: unknown; transferFromImageBitmap(bmp: unknown): void } | null;
   // geometry (constructor reads a few; 0 is fine — no events are fired)
   scrollTop: number;
   scrollLeft: number;
@@ -109,6 +113,7 @@ export function makeEl(tag: string): FakeEl {
     dataset: {},
     _attrs: new Map(),
     _listeners: new Map(),
+    _bitmapCtx: null,
     scrollTop: 0,
     scrollLeft: 0,
     clientWidth: 0,
@@ -205,7 +210,16 @@ export function makeEl(tag: string): FakeEl {
     releasePointerCapture() {},
     getContext(kind: string) {
       if (kind === 'bitmaprenderer') {
-        return { transferFromImageBitmap() {}, lastBitmap: null };
+        // Persist one bitmaprenderer context per canvas (a real canvas holds a
+        // single context type for its lifetime) and record the last painted
+        // bitmap, so worker-mode tests can assert which frame reached the canvas.
+        this._bitmapCtx ??= {
+          lastBitmap: null,
+          transferFromImageBitmap(bmp: unknown) {
+            this.lastBitmap = bmp;
+          },
+        };
+        return this._bitmapCtx;
       }
       return {};
     },

--- a/packages/xlsx/src/viewer-render-coalesce.test.ts
+++ b/packages/xlsx/src/viewer-render-coalesce.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * A controllable `requestAnimationFrame` shim: each `requestAnimationFrame(cb)`
+ * queues `cb` and returns an incrementing handle; `flush()` runs (and clears)
+ * every queued callback, simulating one animation frame; `cancelAnimationFrame`
+ * removes a still-queued callback. Installed into globals so the viewer's
+ * `scheduleRender` coalesces against it. Returns the queue controls.
+ */
+function installRaf(): { flush: () => void; queued: () => number } {
+  let nextHandle = 1;
+  const cbs = new Map<number, FrameRequestCallback>();
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+    const h = nextHandle++;
+    cbs.set(h, cb);
+    return h;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (h: number): void => {
+    cbs.delete(h);
+  });
+  return {
+    flush() {
+      const pending = [...cbs.values()];
+      cbs.clear();
+      for (const cb of pending) cb(0);
+    },
+    queued: () => cbs.size,
+  };
+}
+
+/**
+ * The scroll → render path is coalesced through `requestAnimationFrame`
+ * (improvement plan C4, commit 1): a burst of scroll events within one frame
+ * must schedule exactly one `renderCurrentSheet`, and each subsequent frame
+ * needs its own scroll to render again. Explicit API calls must still render
+ * synchronously. These pin all three, plus the destroy-cancels-the-frame
+ * completeness that PR #659 established.
+ *
+ * The viewer is exercised against the hand-rolled fake DOM (no jsdom in the
+ * repo); `renderCurrentSheet` is private, so we spy on it and count invocations
+ * — it early-returns without a loaded worksheet, which is fine: the count of
+ * scheduled renders is exactly what commit 1 changes.
+ */
+describe('XlsxViewer scroll-render coalescing (C4 commit 1)', () => {
+  function build() {
+    installDom();
+    const raf = installRaf();
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement);
+    // The scrollHost is the 2nd child of canvasArea (canvas, overlay, scrollHost…).
+    // Reach it via the wrapper subtree the constructor mounted in the container.
+    const wrapper = container.children[0] as FakeEl;
+    const canvasArea = wrapper.children[0] as FakeEl;
+    const scrollHost = canvasArea.children.find(
+      (c) => c.style.overflow === 'auto' || c._listeners.has('scroll'),
+    ) as FakeEl;
+    return { v, raf, container, scrollHost };
+  }
+
+  it('collapses many scroll events in one frame to a single render', () => {
+    const { v, raf, scrollHost } = build();
+    const render = vi.spyOn(
+      v as unknown as { renderCurrentSheet: () => Promise<void> },
+      'renderCurrentSheet',
+    );
+    // 100 scroll events, all before the frame runs.
+    for (let i = 0; i < 100; i++) scrollHost.dispatch('scroll');
+    // Coalesced: nothing rendered yet, exactly one frame queued.
+    expect(render).toHaveBeenCalledTimes(0);
+    expect(raf.queued()).toBe(1);
+    // The frame fires → exactly one render for the whole burst.
+    raf.flush();
+    expect(render).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+
+  it('renders once per frame across successive scroll bursts', () => {
+    const { v, raf, scrollHost } = build();
+    const render = vi.spyOn(
+      v as unknown as { renderCurrentSheet: () => Promise<void> },
+      'renderCurrentSheet',
+    );
+    for (let frame = 0; frame < 3; frame++) {
+      scrollHost.dispatch('scroll');
+      scrollHost.dispatch('scroll');
+      raf.flush();
+    }
+    // Three frames, each with its own scroll → three renders (not six).
+    expect(render).toHaveBeenCalledTimes(3);
+    v.destroy();
+  });
+
+  it('a scroll after the frame flushes schedules a fresh render', () => {
+    const { v, raf, scrollHost } = build();
+    const render = vi.spyOn(
+      v as unknown as { renderCurrentSheet: () => Promise<void> },
+      'renderCurrentSheet',
+    );
+    scrollHost.dispatch('scroll');
+    raf.flush();
+    expect(render).toHaveBeenCalledTimes(1);
+    // A new gesture in a later frame must not be swallowed by the cleared handle.
+    scrollHost.dispatch('scroll');
+    expect(raf.queued()).toBe(1);
+    raf.flush();
+    expect(render).toHaveBeenCalledTimes(2);
+    v.destroy();
+  });
+
+  it('destroy() cancels a pending coalesced frame (no render after teardown)', () => {
+    const { v, raf, scrollHost } = build();
+    const render = vi.spyOn(
+      v as unknown as { renderCurrentSheet: () => Promise<void> },
+      'renderCurrentSheet',
+    );
+    scrollHost.dispatch('scroll'); // schedules a frame
+    expect(raf.queued()).toBe(1);
+    v.destroy();
+    // The queued frame was cancelled by destroy(); flushing runs nothing.
+    expect(raf.queued()).toBe(0);
+    raf.flush();
+    expect(render).toHaveBeenCalledTimes(0);
+  });
+
+  it('falls back to a synchronous render when requestAnimationFrame is unavailable', () => {
+    installDom(); // no rAF stub here → typeof requestAnimationFrame !== 'function'
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement);
+    const render = vi.spyOn(
+      v as unknown as { renderCurrentSheet: () => Promise<void> },
+      'renderCurrentSheet',
+    ).mockResolvedValue(undefined);
+    const wrapper = container.children[0] as FakeEl;
+    const canvasArea = wrapper.children[0] as FakeEl;
+    const scrollHost = canvasArea.children.find((c) => c._listeners.has('scroll')) as FakeEl;
+    scrollHost.dispatch('scroll');
+    // No rAF: the render runs inline, preserving the old synchronous semantics.
+    expect(render).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+});

--- a/packages/xlsx/src/viewer-worker-stale-frame.test.ts
+++ b/packages/xlsx/src/viewer-worker-stale-frame.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
+import type { Worksheet } from './types.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** A fake ImageBitmap: records close() and carries dimensions for the canvas
+ *  resize path. */
+function fakeBitmap(width = 800, height = 600): { width: number; height: number; close: ReturnType<typeof vi.fn> } {
+  return { width, height, close: vi.fn() };
+}
+
+/** Minimal worksheet the render path can walk (empty grid, default sizes). */
+function emptyWorksheet(): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 64,
+    defaultRowHeight: 20,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    charts: [],
+    images: [],
+    shapeGroups: [],
+  } as unknown as Worksheet;
+}
+
+/**
+ * Build a worker-mode viewer with its private state wired so `renderCurrentSheet`
+ * reaches the worker branch: a nonzero canvasArea, a current worksheet, and a
+ * fake workbook whose `renderViewportToBitmap` returns a caller-controlled
+ * deferred promise. Returns handles to drive frames and inspect the canvas.
+ */
+function buildWorker() {
+  installDom();
+  const container = makeContainer();
+  const v = new XlsxViewer(container as unknown as HTMLElement, { mode: 'worker' });
+
+  // Each renderViewportToBitmap call parks its {resolve, bitmap} so the test can
+  // resolve frames out of order.
+  const inflight: Array<{ resolve: (b: unknown) => void; promise: Promise<unknown> }> = [];
+  const renderViewportToBitmap = vi.fn(() => {
+    let resolve!: (b: unknown) => void;
+    const promise = new Promise<unknown>((r) => {
+      resolve = r;
+    });
+    inflight.push({ resolve, promise });
+    return promise;
+  });
+
+  const fakeWb = {
+    renderViewportToBitmap,
+    sheetNames: ['Sheet1'],
+    sheetCount: 1,
+    destroy: vi.fn(),
+  };
+
+  // Inject private state (the vitest env is node; there is no real load()).
+  const priv = v as unknown as {
+    wb: unknown;
+    currentWorksheet: Worksheet;
+    currentSheet: number;
+    canvasArea: FakeEl;
+    canvas: FakeEl;
+    renderCurrentSheet: () => Promise<void>;
+  };
+  priv.wb = fakeWb;
+  priv.currentWorksheet = emptyWorksheet();
+  priv.currentSheet = 0;
+  priv.canvasArea.clientWidth = 800;
+  priv.canvasArea.clientHeight = 600;
+
+  return {
+    v,
+    inflight,
+    renderViewportToBitmap,
+    canvas: priv.canvas,
+    render: () => priv.renderCurrentSheet(),
+  };
+}
+
+/**
+ * Worker-mode stale-frame dropping (improvement plan C4, commit 3): worker
+ * bitmap renders overlap — a slow bitmap for an old scroll position can resolve
+ * after a newer render was requested. The stale bitmap must be closed (GPU
+ * memory freed) and NOT painted over the fresher frame. Single-canvas analogue
+ * of the pptx scroll-viewer render epoch.
+ */
+describe('XlsxViewer worker-mode stale-frame drop (C4 commit 3)', () => {
+  it('drops the older in-flight bitmap and paints only the latest', async () => {
+    const { inflight, canvas, render } = buildWorker();
+
+    // Frame A and frame B both dispatched before either resolves (a scroll
+    // burst): two renders in flight.
+    const pA = render();
+    const pB = render();
+    expect(inflight.length).toBe(2);
+
+    const bmpA = fakeBitmap(800, 600);
+    const bmpB = fakeBitmap(800, 600);
+
+    // Resolve the NEWER frame (B) first: it is current, so it paints.
+    inflight[1].resolve(bmpB);
+    await pB;
+    expect(bmpB.close).not.toHaveBeenCalled();
+    expect(canvas._bitmapCtx?.lastBitmap).toBe(bmpB);
+
+    // Now the OLDER frame (A) resolves late: it is stale (B superseded it), so
+    // it must be closed and never painted.
+    inflight[0].resolve(bmpA);
+    await pA;
+    expect(bmpA.close).toHaveBeenCalledTimes(1);
+    // The canvas still shows B — the stale A was not transferred.
+    expect(canvas._bitmapCtx?.lastBitmap).toBe(bmpB);
+  });
+
+  it('paints a single in-flight frame normally (no false stale-drop)', async () => {
+    const { inflight, canvas, render } = buildWorker();
+    const p = render();
+    const bmp = fakeBitmap(800, 600);
+    inflight[0].resolve(bmp);
+    await p;
+    expect(bmp.close).not.toHaveBeenCalled();
+    expect(canvas._bitmapCtx?.lastBitmap).toBe(bmp);
+  });
+
+  it('drops a bitmap that resolves after destroy() (no paint on a torn-down canvas)', async () => {
+    const { v, inflight, canvas, render } = buildWorker();
+    const p = render();
+    v.destroy();
+    const bmp = fakeBitmap(800, 600);
+    inflight[0].resolve(bmp);
+    await p;
+    // destroy() advanced the generation ⇒ this frame is stale ⇒ closed, unpainted.
+    expect(bmp.close).toHaveBeenCalledTimes(1);
+    expect(canvas._bitmapCtx?.lastBitmap).toBeNull();
+  });
+
+  it('does not re-assign canvas width/height when a same-size frame paints (C4 commit 2, worker path)', async () => {
+    const { inflight, canvas, render } = buildWorker();
+
+    // First frame sizes the canvas.
+    const p1 = render();
+    inflight[0].resolve(fakeBitmap(800, 600));
+    await p1;
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(600);
+
+    // Track further width/height writes on the canvas via a spy on the setters.
+    let widthWrites = 0;
+    let heightWrites = 0;
+    Object.defineProperty(canvas, 'width', {
+      get: () => 800,
+      set: () => {
+        widthWrites++;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(canvas, 'height', {
+      get: () => 600,
+      set: () => {
+        heightWrites++;
+      },
+      configurable: true,
+    });
+
+    // A same-size frame must NOT re-assign width/height.
+    const p2 = render();
+    inflight[1].resolve(fakeBitmap(800, 600));
+    await p2;
+    expect(widthWrites).toBe(0);
+    expect(heightWrites).toBe(0);
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -2244,10 +2244,18 @@ export class XlsxViewer {
       // Render the viewport off the main thread and paint the returned bitmap.
       // The selection overlay (geometry-based, from getCellRect) is unaffected.
       const bmp = await this.workbook.renderViewportToBitmap(this.currentSheet, viewport, renderOpts);
-      this.canvas.width = bmp.width;
-      this.canvas.height = bmp.height;
-      this.canvas.style.width = `${w}px`;
-      this.canvas.style.height = `${h}px`;
+      // Resize the canvas only when the bitmap dimensions actually change.
+      // Re-assigning canvas.width/height re-allocates the GPU backing store even
+      // when the value is identical, which on a steady scroll stream (same size
+      // every frame) is a wasted allocation per frame (improvement plan C4).
+      // transferFromImageBitmap replaces the whole canvas, so the resize's
+      // implicit clear is not relied upon; skipping the no-op resize is safe.
+      if (this.canvas.width !== bmp.width) this.canvas.width = bmp.width;
+      if (this.canvas.height !== bmp.height) this.canvas.height = bmp.height;
+      const cssW = `${w}px`;
+      const cssH = `${h}px`;
+      if (this.canvas.style.width !== cssW) this.canvas.style.width = cssW;
+      if (this.canvas.style.height !== cssH) this.canvas.style.height = cssH;
       this._bitmapCtx?.transferFromImageBitmap(bmp);
     } else {
       await this.workbook.renderViewport(this.canvas, this.currentSheet, viewport, renderOpts);

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -349,6 +349,18 @@ export class XlsxViewer {
   private _bitmapCtx: ImageBitmapRenderingContext | null = null;
   private resizeObserver: ResizeObserver | null = null;
   /**
+   * Pending `requestAnimationFrame` handle for a coalesced re-render, or `null`
+   * when none is scheduled. High-frequency event-driven repaints (scroll, live
+   * resize drag, selection drag, container resize) route through
+   * {@link scheduleRender} so at most one render runs per animation frame: a
+   * burst of scroll events within a single frame collapses to one draw at the
+   * frame's latest scroll position (`renderCurrentSheet` reads the live scroll
+   * offset, so "latest wins" needs no stored position). Explicit API calls
+   * (`showSheet`/`goToSheet`, `select`, `setScale`) stay synchronous — they must
+   * paint immediately, not a frame later. `destroy()` cancels any pending frame.
+   */
+  private _rafId: number | null = null;
+  /**
    * Start-anchored horizontal scroll position (the {@link effectiveScrollLeft}
    * value last produced by a real user scroll or a programmatic reset), kept
    * as the source of truth across container size changes. The native
@@ -548,7 +560,11 @@ export class XlsxViewer {
       if (this.scrollHost.clientWidth > 0) {
         this.effectiveH = this.effectiveScrollLeft;
       }
-      this.renderCurrentSheet();
+      // Coalesce into the next frame: a scroll gesture fires many events per
+      // frame, and the previous synchronous redraw ran the full render on each
+      // one. The overlay update is cheap DOM geometry (no canvas paint) and must
+      // track the scroll immediately, so it stays synchronous.
+      this.scheduleRender();
       this.updateSelectionOverlay();
     });
 
@@ -558,7 +574,10 @@ export class XlsxViewer {
     // view drifts (or, after a hidden mount, stays stranded at the far end).
     this.resizeObserver = new ResizeObserver(() => {
       this.reanchorHorizontalScroll();
-      this.renderCurrentSheet();
+      // Container resizes can burst (a live window/pane drag); coalesce the
+      // canvas paint into one frame. The re-anchor, overlay and nav updates are
+      // cheap and must reflect the new size at once, so they stay synchronous.
+      this.scheduleRender();
       this.updateSelectionOverlay();
       this.updateNavButtons();
     });
@@ -1074,7 +1093,10 @@ export class XlsxViewer {
     sheetAxisCache.delete(ws); // sizes changed → rebuild the cumulative-offset axes
     this.updateSpacerSize(ws);
     this.updateSelectionOverlay();
-    void this.renderCurrentSheet();
+    // Live resize drag fires per pointermove; coalesce the canvas repaint into
+    // one frame. The spacer (scrollbar extent) and overlay updates are cheap DOM
+    // writes that must track the drag immediately, so they stay synchronous.
+    this.scheduleRender();
   }
 
   /**
@@ -1746,7 +1768,10 @@ export class XlsxViewer {
       }
 
       this.updateSelectionOverlay();
-      void this.renderCurrentSheet();
+      // Drag-select fires per pointermove; coalesce the canvas repaint (the
+      // header-highlight bands the renderer draws) into one frame. The overlay
+      // rect and the selection-change callback stay synchronous.
+      this.scheduleRender();
       this.opts.onSelectionChange?.(this.selection);
     });
 
@@ -2115,6 +2140,30 @@ export class XlsxViewer {
     this.spacer.style.height = `${totalH}px`;
   }
 
+  /**
+   * Coalesce a re-render into the next animation frame. Called from the
+   * high-frequency event-driven paths (scroll, live column/row resize, drag-
+   * selection, container resize); a burst of these within one frame schedules a
+   * single {@link renderCurrentSheet}, avoiding the previous behavior where every
+   * scroll event forced its own synchronous full redraw. Already-scheduled frames
+   * are not re-scheduled — the one pending render reads the live scroll/scale
+   * state when it runs, so the most recent position always wins without threading
+   * a coordinate through. Falls back to a synchronous render when
+   * `requestAnimationFrame` is unavailable (e.g. a non-DOM host), preserving the
+   * old semantics there.
+   */
+  private scheduleRender(): void {
+    if (this._rafId !== null) return;
+    if (typeof requestAnimationFrame !== 'function') {
+      void this.renderCurrentSheet();
+      return;
+    }
+    this._rafId = requestAnimationFrame(() => {
+      this._rafId = null;
+      void this.renderCurrentSheet();
+    });
+  }
+
   private async renderCurrentSheet(): Promise<void> {
     if (!this.currentWorksheet) return;
     const ws = this.currentWorksheet;
@@ -2267,6 +2316,13 @@ export class XlsxViewer {
    */
   destroy(): void {
     this.resizeObserver?.disconnect();
+    // Cancel any coalesced render still queued for the next frame so it can't
+    // fire against a torn-down viewer (matches the destroy-completeness flow:
+    // no scheduled work outlives destroy()).
+    if (this._rafId !== null && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
     this.hideCommentPopup();
     this.hideValidationPanel();
     if (this.keydownHandler) {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -361,6 +361,20 @@ export class XlsxViewer {
    */
   private _rafId: number | null = null;
   /**
+   * Monotonic render-request counter for worker-mode stale-frame dropping.
+   * Every {@link renderCurrentSheet} bumps it and captures the value before it
+   * awaits the worker's bitmap; on resolution a captured value below the current
+   * one means a newer render was requested meanwhile (scroll moved on, the sheet
+   * switched, a zoom changed), so that bitmap is stale and must be closed and
+   * dropped instead of painted over the fresher frame. The WorkerBridge already
+   * correlates each request↔response by id, but requests overlap — a slow bitmap
+   * for an old scroll position can resolve after a newer one — so the viewer
+   * needs this generation guard, the single-canvas analogue of the pptx
+   * scroll-viewer's per-slot render epoch (PR #663). The main-thread path renders
+   * synchronously and cannot interleave, so it needs no guard.
+   */
+  private _renderSeq = 0;
+  /**
    * Start-anchored horizontal scroll position (the {@link effectiveScrollLeft}
    * value last produced by a real user scroll or a programmatic reset), kept
    * as the source of truth across container size changes. The native
@@ -2171,6 +2185,10 @@ export class XlsxViewer {
     const h = this.canvasArea.clientHeight;
     if (w <= 0 || h <= 0) return;
 
+    // Claim a render generation up front so a later render started while this one
+    // awaits the worker can mark this frame stale (worker mode only; see below).
+    const seq = ++this._renderSeq;
+
     const cs = this.opts.cellScale ?? 1;
     const dpr = window.devicePixelRatio ?? 1;
 
@@ -2244,6 +2262,15 @@ export class XlsxViewer {
       // Render the viewport off the main thread and paint the returned bitmap.
       // The selection overlay (geometry-based, from getCellRect) is unaffected.
       const bmp = await this.workbook.renderViewportToBitmap(this.currentSheet, viewport, renderOpts);
+      // Drop a stale frame: if a newer render was requested while this bitmap was
+      // in flight (scroll moved on, the sheet switched, a zoom changed), painting
+      // it would overwrite the fresher frame. Close it to free the GPU memory
+      // (PR #659/#663 flow) and return without painting. The freshest render owns
+      // the canvas.
+      if (seq !== this._renderSeq) {
+        bmp.close();
+        return;
+      }
       // Resize the canvas only when the bitmap dimensions actually change.
       // Re-assigning canvas.width/height re-allocates the GPU backing store even
       // when the value is identical, which on a steady scroll stream (same size
@@ -2331,6 +2358,10 @@ export class XlsxViewer {
       cancelAnimationFrame(this._rafId);
       this._rafId = null;
     }
+    // Advance the render generation so any worker bitmap still in flight is
+    // treated as stale on resolution (closed + not painted), never touching the
+    // torn-down canvas.
+    this._renderSeq++;
     this.hideCommentPopup();
     this.hideValidationPanel();
     if (this.keydownHandler) {


### PR DESCRIPTION
## Summary

Phase 2 item C4 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md) — xlsx scroll rendering.

### rAF coalescing (100× fewer renders under scroll)
The scroll listener called `renderCurrentSheet()` synchronously per event. High-frequency event paths (scroll, ResizeObserver bursts, selection-drag pointermove, live column/row drag) now funnel through `scheduleRender()` — one render per animation frame, latest-wins by reading live state at render time. Explicit APIs (`showSheet`/`goToSheet`/`select`/`setScale`) stay synchronous; zoom keeps its existing no-op guard + must apply its spacer/scrollbar/anchor bookkeeping atomically. `destroy()` cancels the pending frame. **Test: 100 scroll events in one frame → 1 render (was 100).**

### Backing-store reuse
`canvas.width/height` were re-assigned every render, discarding the GPU backing store each frame. Now guarded to actual size changes — **in the orchestrator too, not just the viewer** (the report cited the viewer, but default main-mode re-allocates inside `render-orchestrator.ts`; guarding only the worker path would have missed the common case). Correctness follow-through: a skipped re-assign no longer resets the 2D transform, so `ctx.scale(dpr,dpr)` became idempotent `ctx.setTransform(...)`, and the inner render's explicit clear was verified before dropping the implicit one.

### Stale worker-frame dropping
Worker mode had no generation management — a slow bitmap response could overwrite a newer frame. A monotonic `_renderSeq` captured at dispatch and re-checked on resolution drops superseded bitmaps (**with `close()`** for GPU memory). Chose a counter over pptx's per-canvas WeakMap token deliberately: xlsx receives bitmaps over correlated worker responses, so a dispatch-epoch is the faithful minimal analogue.

## Verification
- `pnpm test` 1520 passed (13 new tests across 3 suites) / typecheck / lint — green
- xlsx VRT (isolated port): sheets 99.8–100% vs references; **worker-vs-main 0.000% diff on all sheets**
- Browser smoke delegated to this PR's CI (implemented in a worktree; main tree owns port 6007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)