### PR TITLE
perf: stateful archive handles — one buffer copy, one ZIP open, xlsx shared parts parsed once (D2+D3)

### DIFF
--- a/docs/improvement-plan-2026-07-checklist.md
+++ b/docs/improvement-plan-2026-07-checklist.md
@@ -68,8 +68,8 @@ cargo test
 
 - [ ] ベンチ基盤: 代表ファイル 3 種で初回表示 / シート・スライド切替 / スクロール FPS の計測スクリプトを用意（以降の各項目で前後比較）
 - [ ] C2+B7+D9: 境界プロトコル統一 — parser は `Vec<u8>`（JSON bytes）返却 → worker は transferable 素通し → 受信側で 1 回 `JSON.parse`。**3 フォーマット同時に**
-- [ ] D2: stateful `#[wasm_bindgen]` アーカイブハンドル（bytes + central directory index 保持、`extract(path)` / `parse_sheet(i)`）。worker の `currentBuffer` ライフサイクルに載せる
-- [ ] D3: xlsx sharedStrings / theme / workbook.xml のハンドル内キャッシュ。sheet rels + drawing XML の parse-once 化（現状 1 つの drawing を 3 回以上 DOM 化）
+- [x] D2: stateful `#[wasm_bindgen]` アーカイブハンドル（`DocxArchive`/`PptxArchive`/`XlsxArchive` = 所有 `ZipArchive<Cursor<Vec<u8>>>` + `max` 保持）。bytes を WASM へ 1 回コピー・central directory を 1 回スキャンし `parse()`/`extract_image(path)`/`parse_sheet(i,name)` を retained archive 上で提供。フリー関数（`parse_*`/`extract_*`）は所有 archive を張る thin wrapper 化で温存（node/markdown/stories/MCP 無変更）。各 worker は `currentBuffer: Uint8Array` を `archive: *Archive|null` に置換し、構築後は JS 側 bytes を保持しない（メモリ二重化解消）。再 parse 時 `disposeArchive()` で明示 free（二重 free/UAF ガード）。ベンチ: pptx sample-4 (15MB, parse+5 media) **1.49×**、docx sample-9 (13 images) 1.10×
+- [x] D3: xlsx `WorkbookShared`（workbook.xml/rels source + sheet list + theme palette + sharedStrings）をハンドル内で 1 回パースし全シート切替で再利用。`parse_sheet` 毎の sharedStrings/theme 全再パースを解消（`parse_sheet_with`/`parse_xlsx_inner_with` に分離、フリー関数は毎回 fresh build で従来コスト維持）。ベンチ: sample-12 (8 sheets) **1.61×**、sample-9 (3 sheets) 1.30×。roxmltree `Document` は借用のためキャッシュ不可 → cached string から都度再パース（inflate なしで安価）。drawing XML の parse-once 化は sheet 単位再パース解消を主目的とし本コミット範囲では見送り（別項）
 - [ ] D4: pptx マスター DOM の parse-once 化（~10-12 回 → 1 回）、layout cache 追加（`master_cache` の鏡映）、slide XML の 2 回パース解消
 - [ ] B3: docx 画像デコードキャッシュ（`Map<string, DecodedImage>` を DocxDocument に、`destroy()` で解放）
 - [ ] A8(後半): core に `getCachedBitmapByPath`（SVG キャッシュの sibling、ImageBitmap の close 管理付き）を追加し 3 フォーマットで共用

--- a/docs/improvement-plan-2026-07.md
+++ b/docs/improvement-plan-2026-07.md
@@ -68,8 +68,8 @@
 | # | 指摘 | 場所 | 工数 |
 |---|------|------|------|
 | D1 | 存在確認のためだけにメディアを全 inflate（3 パーサー共通パターン） | `docx/parser/src/parser.rs:1270`, `xlsx/parser/src/drawing.rs:1443`, `pptx/parser/src/lib.rs:9328` | S |
-| D2 | `extract_image` / `parse_sheet` 等が呼び出し毎に全ファイルを JS→WASM コピー + central directory 再スキャン。stateful `#[wasm_bindgen]` ハンドルで解消 | 各 parser の WASM 面 | M |
-| D3 | [xlsx] `parse_sheet` 毎に workbook.xml / theme / **sharedStrings 全体**を再パース。同一 drawing XML をシート毎に 3 回以上 DOM 化 | `xlsx/parser/src/lib.rs:51-99`, `drawing.rs:1361-1500` | M |
+| D2 ✅ | `extract_image` / `parse_sheet` 等が呼び出し毎に全ファイルを JS→WASM コピー + central directory 再スキャン。stateful `#[wasm_bindgen]` ハンドルで解消 → `DocxArchive`/`PptxArchive`/`XlsxArchive`（所有 `ZipArchive<Cursor<Vec<u8>>>`）。フリー関数は thin wrapper で温存、worker は `archive` を保持し JS 側 bytes 破棄（メモリ二重化解消）。pptx sample-4 (15MB) parse+media 反復で **1.49×** | 各 parser の WASM 面 | M |
+| D3 ✅ | [xlsx] `parse_sheet` 毎に workbook.xml / theme / **sharedStrings 全体**を再パース → ハンドル内 `WorkbookShared` を 1 回パースし全シートで再利用（`parse_sheet_with`/`parse_xlsx_inner_with` に分離）。sample-12 (8 sheets) **1.61×**。drawing XML の per-sheet parse-once はシート単位再パース解消を主目的とし別途 | `xlsx/parser/src/lib.rs:51-99`, `drawing.rs:1361-1500` | M |
 | D4 | [pptx] マスター XML を ~10-12 回 DOM 再パース、レイアウトキャッシュ無し（50 スライド 1 レイアウトで 50 回パース + 50 コピー保持）、スライド XML も 2 回パース | `pptx/parser/src/lib.rs:8976, 9160-9290` | M–L |
 | D5 | theme パース 3 重実装 → `ooxml_common::theme` へ | pptx `lib.rs:1926`, xlsx `lib.rs:242`, docx `parser.rs:506` | M |
 | D6 | OPC rels + パス解決 3 重実装（leading-slash バグは pptx のみ修正済み = 他 2 つに同じ穴の可能性） → `ooxml_common::rels` へ | 各 parser | S/M |

--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -19,8 +19,8 @@ mod xml_util;
 pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
-    let doc =
-        parser::parse(data).map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
+    let doc = parser::parse_from_bytes(data)
+        .map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
     serde_json::to_vec(&doc).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
@@ -31,7 +31,7 @@ pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u
 pub fn docx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
-    let doc = parser::parse(data).map_err(|e| JsValue::from_str(&e))?;
+    let doc = parser::parse_from_bytes(data).map_err(|e| JsValue::from_str(&e))?;
     Ok(markdown::render_document(&doc))
 }
 
@@ -49,10 +49,76 @@ pub fn extract_image(
         .map_err(|e| JsValue::from_str(&e))
 }
 
+/// A stateful handle over an opened docx archive.
+///
+/// The free functions above (`parse_docx` / `docx_to_markdown` / `extract_image`)
+/// each re-copy the whole file into WASM and re-scan the ZIP central directory on
+/// every call. A `DocxArchive` copies the bytes into WASM **once** (in `new`) and
+/// keeps the opened [`parser::Zip`] alive, so a `parse` followed by any number of
+/// `extract_image` calls (the viewer's parse-then-lazily-load-media pattern)
+/// pays the copy + open cost a single time. `ZipArchive<Cursor<Vec<u8>>>` is
+/// self-contained (it owns its bytes and holds no borrow into the input), which
+/// is what lets it live in a `#[wasm_bindgen]` struct field.
+///
+/// The retained `max` mirrors the per-call `scoped_max` guard the free functions
+/// install: every method re-installs it for its own scope so the zip-bomb entry
+/// cap is honored identically whether callers use the handle or the free
+/// functions.
+#[wasm_bindgen]
+pub struct DocxArchive {
+    archive: parser::Zip,
+    max: Option<u64>,
+}
+
+#[wasm_bindgen]
+impl DocxArchive {
+    /// Copy `data` into WASM once and open the ZIP central directory once.
+    /// `max_zip_entry_bytes` is retained and applied on every subsequent method
+    /// call (identical semantics to the free functions' `scoped_max` guard).
+    #[wasm_bindgen(constructor)]
+    pub fn new(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<DocxArchive, JsValue> {
+        console_error_panic_hook::set_once();
+        let archive = zip::ZipArchive::new(std::io::Cursor::new(data.to_vec()))
+            .map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
+        Ok(DocxArchive {
+            archive,
+            max: max_zip_entry_bytes,
+        })
+    }
+
+    /// Parse the retained archive and return the model as UTF-8 JSON bytes.
+    /// Byte-for-byte identical to `parse_docx` on the same file — same parser,
+    /// same serializer, same error strings.
+    pub fn parse(&mut self) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let doc = parser::parse(&mut self.archive)
+            .map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
+        serde_json::to_vec(&doc).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
+    }
+
+    /// Extract raw bytes for one embedded entry (e.g. "word/media/image1.png")
+    /// from the retained archive. Twin of the free `extract_image`, but reads
+    /// through the already-open archive instead of re-opening it.
+    pub fn extract_image(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        ooxml_common::zip::read_zip_bytes(&mut self.archive, path)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
+    /// GitHub-flavoured markdown projection of the retained archive. Mirrors the
+    /// free `docx_to_markdown`.
+    pub fn to_markdown(&mut self) -> Result<String, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let doc = parser::parse(&mut self.archive).map_err(|e| JsValue::from_str(&e))?;
+        Ok(markdown::render_document(&doc))
+    }
+}
+
 /// Native equivalent of `parse_docx` for use from the MCP server.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_docx_native(data: &[u8]) -> Result<String, String> {
-    parser::parse(data).and_then(|doc| serde_json::to_string(&doc).map_err(|e| e.to_string()))
+    parser::parse_from_bytes(data)
+        .and_then(|doc| serde_json::to_string(&doc).map_err(|e| e.to_string()))
 }
 
 /// Parse a docx and project the result to GitHub-flavoured markdown:
@@ -63,7 +129,7 @@ pub fn parse_docx_native(data: &[u8]) -> Result<String, String> {
 /// section properties, font metrics, drawing shapes.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
-    let doc = parser::parse(data)?;
+    let doc = parser::parse_from_bytes(data)?;
     Ok(markdown::render_document(&doc))
 }
 
@@ -92,14 +158,14 @@ mod tests {
     /// the TS-side `JSON.parse` throw a confusing SyntaxError instead of the
     /// real cause. We can't call the `#[wasm_bindgen]` fn from a plain unit
     /// test (that needs wasm-bindgen-test), but `parse_docx` is now a thin
-    /// `parser::parse(...).map_err(...)?` wrapper, so proving the internal
-    /// parse returns a plain `Err(String)` for bad input is enough: the JSON
-    /// escaping hazard is gone *by construction* because the error never round
-    /// trips through hand-assembled JSON — wasm-bindgen serializes the string.
+    /// `parser::parse_from_bytes(...).map_err(...)?` wrapper, so proving the
+    /// internal parse returns a plain `Err(String)` for bad input is enough: the
+    /// JSON escaping hazard is gone *by construction* because the error never
+    /// round trips through hand-assembled JSON — wasm-bindgen serializes it.
     #[test]
     fn parse_rejects_non_zip_bytes_without_json_escaping_hazard() {
-        // Not a zip archive — parser::parse must return Err, not panic.
-        let err = parser::parse(&[1, 2, 3]).expect_err("non-zip bytes must error");
+        // Not a zip archive — opening the archive must return Err, not panic.
+        let err = parser::parse_from_bytes(&[1, 2, 3]).expect_err("non-zip bytes must error");
         // A raw String error is returned verbatim; even a `"`-laden message is
         // carried as-is (no manual `{"error":"…"}` templating to corrupt).
         let quoted = format!("boom: \"{}\"", err);

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -17,7 +17,13 @@ const DEFAULT_FONT_SIZE: f64 = 10.0; // pt fallback
 /// OMML (math) namespace — ECMA-376 §22.
 const M_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/math";
 
-type Zip<'a> = ZipArchive<std::io::Cursor<&'a [u8]>>;
+/// The parser's ZIP archive type. Owns its backing bytes (`Cursor<Vec<u8>>`)
+/// rather than borrowing them, so a `DocxArchive` handle can keep a single
+/// opened archive alive across `parse` / `extract_image` / `to_markdown` calls —
+/// the central directory is scanned once and the bytes are copied into WASM once.
+/// `ZipArchive<Cursor<Vec<u8>>>` is fully self-contained (no borrow into the
+/// input), which is what lets the `#[wasm_bindgen]` handle store it as a field.
+pub(crate) type Zip = ZipArchive<std::io::Cursor<Vec<u8>>>;
 
 /// Section-level header/footer references collected from sectPr.
 /// Maps reference type ("default" | "first" | "even") to the target xml path (e.g. "header1.xml").
@@ -71,11 +77,19 @@ fn resolve_section_refs(
     out
 }
 
-pub fn parse(data: &[u8]) -> Result<Document, String> {
-    let cursor = std::io::Cursor::new(data);
-    let mut zip = ZipArchive::new(cursor).map_err(|e| e.to_string())?;
+/// Parse a docx from raw archive bytes. Thin wrapper that opens a fresh
+/// [`Zip`] (owning a copy of `data`) and delegates to [`parse`]. Kept so the
+/// free `parse_docx` WASM entry point and the native `parse_docx_native` path
+/// keep their `&[u8]` signature; the stateful `DocxArchive` handle calls
+/// [`parse`] directly on its retained archive to avoid re-opening it per call.
+pub fn parse_from_bytes(data: &[u8]) -> Result<Document, String> {
+    let mut zip =
+        ZipArchive::new(std::io::Cursor::new(data.to_vec())).map_err(|e| e.to_string())?;
+    parse(&mut zip)
+}
 
-    let rels_xml = read_zip_string(&mut zip, "word/_rels/document.xml.rels").unwrap_or_default();
+pub fn parse(zip: &mut Zip) -> Result<Document, String> {
+    let rels_xml = read_zip_string(zip, "word/_rels/document.xml.rels").unwrap_or_default();
     let rel_map = parse_rels(&rels_xml);
 
     // Styles are referenced from the document relationships (Target may be
@@ -89,7 +103,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             }
         })
         .unwrap_or_else(|| "word/styles.xml".to_string());
-    let style_map = read_zip_string(&mut zip, &styles_path)
+    let style_map = read_zip_string(zip, &styles_path)
         .map(|s| StyleMap::parse(&s))
         .unwrap_or_else(|_| StyleMap::parse(""));
 
@@ -118,11 +132,11 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             .map(|(d, _)| d)
             .unwrap_or("word");
         let rels_path = format!("{}/_rels/{}.xml.rels", dir, stem);
-        let rels_xml = read_zip_string(&mut zip, &rels_path).unwrap_or_default();
+        let rels_xml = read_zip_string(zip, &rels_path).unwrap_or_default();
         let rel_map = parse_rels(&rels_xml);
-        load_media_map(&mut zip, &rel_map, &format!("{}/", dir))
+        load_media_map(zip, &rel_map, &format!("{}/", dir))
     };
-    let mut num_map = read_zip_string(&mut zip, &numbering_path)
+    let mut num_map = read_zip_string(zip, &numbering_path)
         .map(|s| NumberingMap::parse(&s, &numbering_media_map))
         .unwrap_or_default();
 
@@ -135,7 +149,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             } else {
                 format!("word/{}", t)
             };
-            read_zip_string(&mut zip, &p)
+            read_zip_string(zip, &p)
                 .map(|s| ThemeColors::parse(&s))
                 .unwrap_or_default()
         })
@@ -156,7 +170,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     // §17.10.1 even/odd headers is a settings.xml flag (not a sectPr property), so
     // capture it here and stamp it onto the section below.
     let mut even_and_odd_headers = false;
-    if let Ok(settings_xml) = read_zip_string(&mut zip, &settings_path) {
+    if let Ok(settings_xml) = read_zip_string(zip, &settings_path) {
         if let Some(lang) = parse_theme_font_bidi_lang(&settings_xml) {
             theme.fill_default_cs_font(&lang);
         }
@@ -175,9 +189,9 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     }
     let theme = theme;
 
-    let media_map = load_media_map(&mut zip, &rel_map, "word/");
+    let media_map = load_media_map(zip, &rel_map, "word/");
 
-    let doc_xml = read_zip_string(&mut zip, "word/document.xml")?;
+    let doc_xml = read_zip_string(zip, "word/document.xml")?;
     let xml_doc = XmlDoc::parse(&doc_xml).map_err(|e| e.to_string())?;
 
     let body_node = xml_doc
@@ -215,22 +229,10 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
     let mut body_headers = HeadersFooters::default();
     let mut body_footers = HeadersFooters::default();
     for (node_id, refs, title_page) in &section_snapshots {
-        let headers = load_header_footer_set(
-            &mut zip,
-            &refs.headers,
-            "hdr",
-            &style_map,
-            &mut num_map,
-            &theme,
-        );
-        let footers = load_header_footer_set(
-            &mut zip,
-            &refs.footers,
-            "ftr",
-            &style_map,
-            &mut num_map,
-            &theme,
-        );
+        let headers =
+            load_header_footer_set(zip, &refs.headers, "hdr", &style_map, &mut num_map, &theme);
+        let footers =
+            load_header_footer_set(zip, &refs.footers, "ftr", &style_map, &mut num_map, &theme);
         if Some(*node_id) == body_level_sect_id {
             body_headers = headers;
             body_footers = footers;
@@ -274,7 +276,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
             }
         })
         .unwrap_or_else(|| "word/fontTable.xml".to_string());
-    let font_family_classes = read_zip_string(&mut zip, &font_table_path)
+    let font_family_classes = read_zip_string(zip, &font_table_path)
         .map(|s| parse_font_table(&s))
         .unwrap_or_default();
 
@@ -292,7 +294,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
                 format!("word/{}", t)
             }
         })
-        .and_then(|p| read_zip_string(&mut zip, &p).ok())
+        .and_then(|p| read_zip_string(zip, &p).ok())
         .map(|xml| parse_comments(&xml))
         .unwrap_or_default();
     let footnotes_path = find_rel_target(&rels_xml, "footnotes").map(|t| {
@@ -303,7 +305,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
         }
     });
     let footnotes = footnotes_path
-        .map(|p| parse_notes(&mut zip, &p, "footnote", &style_map, &mut num_map, &theme))
+        .map(|p| parse_notes(zip, &p, "footnote", &style_map, &mut num_map, &theme))
         .unwrap_or_default();
     let endnotes_path = find_rel_target(&rels_xml, "endnotes").map(|t| {
         if t.starts_with('/') {
@@ -313,7 +315,7 @@ pub fn parse(data: &[u8]) -> Result<Document, String> {
         }
     });
     let endnotes = endnotes_path
-        .map(|p| parse_notes(&mut zip, &p, "endnote", &style_map, &mut num_map, &theme))
+        .map(|p| parse_notes(zip, &p, "endnote", &style_map, &mut num_map, &theme))
         .unwrap_or_default();
 
     Ok(Document {
@@ -7907,7 +7909,7 @@ mod svg_blip_tests {
   </wp:inline>
 </w:drawing></w:r></w:p>"#;
         let data = build_docx_with_media(body);
-        let doc = parse(&data).expect("parse must succeed");
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = doc
             .body
             .iter()
@@ -7979,7 +7981,8 @@ mod svg_blip_tests {
             // NOTE: word/media/image1.png is intentionally NOT written.
             zw.finish().unwrap();
         }
-        let doc = parse(&buf).expect("parse must succeed even with a dangling image rId");
+        let doc =
+            parse_from_bytes(&buf).expect("parse must succeed even with a dangling image rId");
         let has_image = doc.body.iter().any(|el| match el {
             BodyElement::Paragraph(p) => p.runs.iter().any(|r| matches!(r, DocRun::Image(_))),
             _ => false,
@@ -8016,7 +8019,7 @@ mod svg_blip_tests {
   </wp:inline>
 </w:drawing></w:r></w:p>"#;
         let data = build_docx_with_media(body);
-        let doc = parse(&data).expect("parse must succeed");
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = doc
             .body
             .iter()
@@ -8079,7 +8082,7 @@ mod svg_blip_tests {
   </wp:inline>
 </w:drawing></w:r></w:p>"#;
         let data = build_docx_with_media(body);
-        let doc = parse(&data).expect("parse must succeed");
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = only_image(&doc);
         let sr = img
             .src_rect
@@ -8116,7 +8119,7 @@ mod svg_blip_tests {
 </w:drawing></w:r></w:p>"#
             );
             let data = build_docx_with_media(&body);
-            let doc = parse(&data).expect("parse must succeed");
+            let doc = parse_from_bytes(&data).expect("parse must succeed");
             let img = only_image(&doc);
             assert!(
                 img.src_rect.is_none(),
@@ -8314,7 +8317,7 @@ mod anchor_image_relative_from_tests {
             r#"<wp:positionV relativeFrom="margin"><wp:align>top</wp:align></wp:positionV>"#,
         );
         let data = build_docx(&body);
-        let doc = parse(&data).expect("parse must succeed");
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = first_image(&doc);
         assert_eq!(
             img.anchor_y_relative_from.as_deref(),
@@ -8332,7 +8335,7 @@ mod anchor_image_relative_from_tests {
             r#"<wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>"#,
         );
         let data = build_docx(&body);
-        let doc = parse(&data).expect("parse must succeed");
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = first_image(&doc);
         assert_eq!(img.anchor_x_relative_from.as_deref(), Some("margin"));
         assert_eq!(img.anchor_x_align.as_deref(), Some("left"));
@@ -8347,7 +8350,7 @@ mod anchor_image_relative_from_tests {
             r#"<wp:positionV relativeFrom="page"><wp:align>center</wp:align></wp:positionV>"#,
         );
         let data = build_docx(&body);
-        let doc = parse(&data).expect("parse must succeed");
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = first_image(&doc);
         assert_eq!(img.anchor_x_relative_from.as_deref(), Some("page"));
         assert_eq!(img.anchor_y_relative_from.as_deref(), Some("page"));
@@ -8371,7 +8374,7 @@ mod anchor_image_relative_from_tests {
   </wp:inline>
 </w:drawing></w:r></w:p>"#;
         let data = build_docx(body);
-        let doc = parse(&data).expect("parse must succeed");
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = first_image(&doc);
         assert!(img.anchor_x_relative_from.is_none());
         assert!(img.anchor_y_relative_from.is_none());

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -7,7 +7,7 @@
  *
  * Single-document contract: the proxy issues one `parse` and then renders.
  */
-import init, { parse_docx, extract_image } from './wasm/docx_parser.js';
+import init, { DocxArchive } from './wasm/docx_parser.js';
 import { decodeDataUrl, preloadGoogleFonts } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
 import { paginateDocument, renderDocumentToCanvas } from './renderer';
@@ -17,26 +17,35 @@ import type { RenderWorkerRequest, RenderWorkerResponse, DocumentMeta } from './
 let initPromise: Promise<unknown> | null = null;
 let doc: DocxDocumentModel | null = null;
 let pages: PaginatedBodyElement[][] | null = null;
-// The buffer is transferred into the worker on `parse` (main thread's copy
-// neutered), so the worker owns it. Retained so the in-worker `getImage`
-// closure can read image bytes by zip path straight from it (no transfer).
-let currentBuffer: Uint8Array | null = null;
-let currentMaxZipEntryBytes: bigint | undefined;
+// A `DocxArchive` handle over the opened zip. `new DocxArchive(bytes, max)`
+// copies the file into WASM ONCE and opens it ONCE; the in-worker `getImage`
+// closure then reads image bytes by zip path straight from the retained archive
+// (no transfer, no re-open, no JS-side buffer kept alive). Freed + replaced on a
+// re-parse.
+let archive: DocxArchive | null = null;
 const imageCache = new Map<string, Promise<Blob>>();
 
 const post = (msg: RenderWorkerResponse, transfer?: Transferable[]) =>
   (self.postMessage as (m: unknown, t?: Transferable[]) => void)(msg, transfer);
 
+/** Free the current handle (if any) and null it out — double-free / UAF guard. */
+function disposeArchive(): void {
+  if (archive) {
+    archive.free();
+    archive = null;
+  }
+}
+
 /** In-worker image-byte loader (twin of pptx's render-worker `getImage`). The
  *  renderer's `fetchImage` routes here in worker mode, so image bytes are
- *  decoded straight from the retained buffer with no main-thread round-trip.
+ *  decoded straight from the retained archive with no main-thread round-trip.
  *  Mime travels on the element, so the caller supplies it. */
 function getImage(path: string, mimeType: string): Promise<Blob> {
   const hit = imageCache.get(path);
   if (hit) return hit;
   const p = (async () => {
-    if (!currentBuffer) throw new Error('No docx loaded');
-    const bytes = extract_image(currentBuffer, path, currentMaxZipEntryBytes);
+    if (!archive) throw new Error('No docx loaded');
+    const bytes = archive.extract_image(path);
     return new Blob([new Uint8Array(bytes).slice()], { type: mimeType });
   })();
   imageCache.set(path, p);
@@ -56,19 +65,22 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       // Cached blobs belong to the previous document; serving them after a
       // re-parse would silently return the wrong file's image.
       imageCache.clear();
-      currentMaxZipEntryBytes =
+      const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      currentBuffer = new Uint8Array(req.data);
-      // `parse_docx` throws on parse/serialize failure (Result<Vec<u8>,
-      // JsValue>); the outer try/catch converts it into an error response, so
-      // the bytes here are always the success model — no error-field probe.
-      // Render mode consumes the model in-worker, so decode + parse it here (one
-      // decode, no passthrough).
-      const parsed = JSON.parse(
-        new TextDecoder().decode(parse_docx(currentBuffer, currentMaxZipEntryBytes)),
-      );
+      // Constructing the handle copies `req.data` into WASM; the worker then
+      // holds no reference to the transferred bytes (memory is not doubled).
+      // Replace any prior handle first so a re-parse frees the old archive.
+      disposeArchive();
+      const bytes = new Uint8Array(req.data);
+      archive = new DocxArchive(bytes, max);
+      // `parse()` throws on parse/serialize failure (Result<Vec<u8>, JsValue>);
+      // the outer try/catch converts it into an error response, so the bytes here
+      // are always the success model — no error-field probe. Render mode consumes
+      // the model in-worker, so decode + parse it here (one decode, no
+      // passthrough).
+      const parsed = JSON.parse(new TextDecoder().decode(archive.parse()));
       doc = parsed as DocxDocumentModel;
       if (req.useGoogleFonts) {
         // Pagination measures text, so fonts must land BEFORE computePages —
@@ -115,10 +127,10 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
     if (req.type === 'extractImage') {
       // Worker render mode decodes images in-worker via the getImage closure;
       // this arm exists only for protocol parity with worker.ts. Raw bytes are
-      // read straight from the retained buffer (no mime needed for a byte
+      // read straight from the retained archive (no mime needed for a byte
       // transfer).
-      if (!currentBuffer) throw new Error('No docx loaded');
-      const raw = extract_image(currentBuffer, req.path, currentMaxZipEntryBytes);
+      if (!archive) throw new Error('No docx loaded');
+      const raw = archive.extract_image(req.path);
       const bytes = new Uint8Array(raw).slice().buffer;
       post({ type: 'imageExtracted', id, bytes }, [bytes]);
       return;

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -1,13 +1,25 @@
-import init, { parse_docx, extract_image } from './wasm/docx_parser.js';
+import init, { DocxArchive } from './wasm/docx_parser.js';
 import { decodeDataUrl } from '@silurus/ooxml-core';
 import type { WorkerRequest, WorkerResponse } from './types';
 
 let initPromise: Promise<unknown> | null = null;
-// The buffer is transferred into the worker on `parse` (the main thread's copy
-// is neutered), so the worker is its rightful owner. Retain it so a later
-// `extractImage` can read media bytes by zip path without re-sending the file.
-let currentBuffer: Uint8Array | null = null;
-let currentMaxZipEntryBytes: bigint | undefined;
+// A `DocxArchive` handle over the opened zip: `new DocxArchive(bytes, max)`
+// copies the file into WASM ONCE and scans the central directory ONCE, then a
+// later `extractImage` reads media by zip path straight from the retained
+// archive (no re-copy, no re-open, and no JS-side buffer kept alive — the copy
+// lives inside WASM). Held across the worker's lifetime; freed + replaced on a
+// re-parse so we never leak the previous document's WASM allocation.
+let archive: DocxArchive | null = null;
+
+/** Free the current handle (if any) and null it out. Guards against a double
+ *  free / use-after-free: after this the next `extractImage` throws the same
+ *  "No docx loaded" error as before a first parse. */
+function disposeArchive(): void {
+  if (archive) {
+    archive.free();
+    archive = null;
+  }
+}
 
 self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;
@@ -23,19 +35,24 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   try {
     await initPromise;
     if (req.type === 'parse') {
-      currentMaxZipEntryBytes =
+      const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      currentBuffer = new Uint8Array(req.data);
-      // `parse_docx` returns the model as UTF-8 JSON bytes on success and throws
-      // a JS Error on parse/serialize failure (Result<Vec<u8>, JsValue>),
-      // matching pptx/xlsx. The throw is caught by the outer try/catch below, so
-      // no error-field probe is needed here. wasm-bindgen hands back a fresh
+      // Constructing the handle copies `req.data` into WASM; after that the
+      // worker holds no reference to the transferred bytes (memory is not
+      // doubled — the sole copy lives in WASM linear memory). Replace any prior
+      // handle first so re-parsing a new file frees the old archive.
+      disposeArchive();
+      const bytes = new Uint8Array(req.data);
+      archive = new DocxArchive(bytes, max);
+      // `parse()` returns the model as UTF-8 JSON bytes on success and throws a
+      // JS Error on parse/serialize failure (Result<Vec<u8>, JsValue>). The throw
+      // is caught by the outer try/catch below. wasm-bindgen hands back a fresh
       // Uint8Array (a copy of the Rust Vec), so its buffer is exclusively ours:
       // forward it to the main thread as a transferable — no clone, no decode
       // here. The single decode + JSON.parse happens once, on the main thread.
-      const json = parse_docx(currentBuffer, currentMaxZipEntryBytes);
+      const json = archive.parse();
       const documentJson = json.buffer as ArrayBuffer;
       const res: WorkerResponse = { type: 'parsed', id, documentJson };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [
@@ -44,8 +61,8 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       return;
     }
     if (req.type === 'extractImage') {
-      if (!currentBuffer) throw new Error('No docx loaded');
-      const bytes = extract_image(currentBuffer, req.path, currentMaxZipEntryBytes);
+      if (!archive) throw new Error('No docx loaded');
+      const bytes = archive.extract_image(req.path);
       const copy = new Uint8Array(bytes).slice().buffer;
       const res: WorkerResponse = { type: 'imageExtracted', id, bytes: copy };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [copy]);

--- a/packages/node/src/bench-handle.mjs
+++ b/packages/node/src/bench-handle.mjs
@@ -1,0 +1,238 @@
+/**
+ * Stateful-archive-handle benchmark (Phase 2 D2 + D3).
+ *
+ * `bench-parse.mjs` measures a single `parse` across the WASM boundary. This
+ * script measures the *repeated* work the viewer actually does after a parse:
+ *
+ *   - xlsx: parse the workbook index, then parse EVERY sheet (sheet switching).
+ *   - docx / pptx: parse the document, then extract EVERY embedded image.
+ *
+ * It runs each workload two ways and reports both so the win is visible:
+ *
+ *   - "free"   : the pre-handle path — call the free functions repeatedly, each
+ *                re-copying the whole file into WASM and re-opening the ZIP (and,
+ *                for xlsx, re-parsing workbook.xml / sharedStrings / theme on
+ *                every sheet). This is what the code paid before this change.
+ *   - "handle" : the new path — build one `{Xlsx,Pptx,Docx}Archive`, then call
+ *                its methods. The bytes are copied + the ZIP opened ONCE; xlsx
+ *                additionally parses the shared workbook parts once and reuses
+ *                them for every sheet (the D3 win).
+ *
+ * The handle classes only exist on the post-change WASM. When they are absent
+ * (running against origin/main WASM for a before/after comparison) the "handle"
+ * mode is reported as "n/a" and only "free" is measured — so a single script,
+ * pointed at the before WASM and then the after WASM, yields the full picture:
+ *
+ *   BEFORE (origin/main):  handle=n/a,  free=<baseline>
+ *   AFTER  (this branch):  handle=<fast>, free≈<baseline>   (free path unchanged)
+ *
+ * Usage:
+ *   node packages/node/src/bench-handle.mjs <file> [iterations] [--wasm-dir <dir>]
+ *
+ *   --wasm-dir <dir>   Load *_parser.js / *_parser_bg.wasm from <dir> instead of
+ *                      the package's src/wasm. Point it at a saved "before" build
+ *                      to measure the baseline. <dir> may contain the files
+ *                      directly or in a per-format subdir (docx/ pptx/ xlsx/).
+ *
+ * Requires freshly built WASM (`pnpm build:wasm`) for the "after" run.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, extname, basename, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WARMUP = 1;
+const DEFAULT_ITERS = 5;
+const decoder = new TextDecoder();
+
+/** Load a wasm-pack `--target web` module and synchronously init it from disk. */
+function loadModule(jsPath, wasmPath) {
+  const bytes = readFileSync(wasmPath);
+  const module = new WebAssembly.Module(bytes);
+  return import(jsPath).then((mod) => {
+    mod.initSync({ module });
+    return mod;
+  });
+}
+
+/** Resolve the JS + WASM paths for a format, honoring `--wasm-dir`. */
+function wasmPaths(fmt, wasmDir) {
+  const stem = `${fmt}_parser`;
+  if (wasmDir) {
+    // Accept either "<dir>/<fmt>/<stem>.*" or "<dir>/<stem>.*".
+    const sub = join(wasmDir, fmt, `${stem}.js`);
+    const base = join(wasmDir, `${stem}.js`);
+    const jsPath = existsSync(sub) ? sub : base;
+    const wasmPath = jsPath.replace(/\.js$/, '_bg.wasm');
+    return { jsPath, wasmPath };
+  }
+  const jsPath = resolve(HERE, `../../${fmt}/src/wasm/${stem}.js`);
+  const wasmPath = resolve(HERE, `../../${fmt}/src/wasm/${stem}_bg.wasm`);
+  return { jsPath, wasmPath };
+}
+
+function stats(samples) {
+  const s = [...samples].sort((a, b) => a - b);
+  const n = s.length;
+  const median = n % 2 ? s[(n - 1) / 2] : (s[n / 2 - 1] + s[n / 2]) / 2;
+  return { min: s[0], median, mean: s.reduce((a, x) => a + x, 0) / n };
+}
+
+/** Time `fn` `iters` times after `WARMUP` untimed runs; returns per-run ms. */
+function timeIt(fn, iters) {
+  for (let i = 0; i < WARMUP; i++) fn();
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = performance.now();
+    const sink = fn();
+    const t1 = performance.now();
+    if (sink == null) throw new Error('workload produced null');
+    samples.push(t1 - t0);
+  }
+  return stats(samples);
+}
+
+// ── xlsx: parse workbook + parse every sheet ────────────────────────────────
+
+function xlsxWorkloads(mod, bytes) {
+  const wbFree = () => JSON.parse(decoder.decode(mod.parse_xlsx(bytes, undefined)));
+  const sheets = wbFree().workbook.sheets;
+
+  const free = () => {
+    // Re-parse the index (as the worker's `parse` does) + every sheet.
+    let touched = 0;
+    mod.parse_xlsx(bytes, undefined);
+    for (let i = 0; i < sheets.length; i++) {
+      const ws = mod.parse_sheet(bytes, i, sheets[i].name, undefined);
+      touched += ws.length;
+    }
+    return touched;
+  };
+
+  const handle = mod.XlsxArchive
+    ? () => {
+        let touched = 0;
+        const ar = new mod.XlsxArchive(bytes, undefined);
+        try {
+          ar.parse();
+          for (let i = 0; i < sheets.length; i++) {
+            touched += ar.parse_sheet(i, sheets[i].name).length;
+          }
+        } finally {
+          ar.free();
+        }
+        return touched;
+      }
+    : null;
+
+  return { free, handle, unit: `${sheets.length} sheets`, count: sheets.length };
+}
+
+// ── docx / pptx: parse + extract every image ────────────────────────────────
+
+/** Collect every embedded media/image zip path from a parsed model. */
+function collectImagePaths(model, fmt) {
+  const paths = new Set();
+  const prefix = fmt === 'pptx' ? 'ppt/media/' : 'word/media/';
+  const walk = (v) => {
+    if (v == null) return;
+    if (typeof v === 'string') {
+      if (v.startsWith(prefix)) paths.add(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const x of v) walk(x);
+      return;
+    }
+    if (typeof v === 'object') for (const k of Object.keys(v)) walk(v[k]);
+  };
+  walk(model);
+  return [...paths];
+}
+
+function docParseWorkloads(mod, bytes, fmt) {
+  const parseFn = fmt === 'pptx' ? mod.parse_pptx : mod.parse_docx;
+  const Handle = fmt === 'pptx' ? mod.PptxArchive : mod.DocxArchive;
+  const model = JSON.parse(decoder.decode(parseFn(bytes, undefined)));
+  const imgs = collectImagePaths(model, fmt);
+
+  const free = () => {
+    let touched = 0;
+    parseFn(bytes, undefined);
+    for (const p of imgs) touched += mod.extract_image(bytes, p, undefined).length;
+    return touched + 1;
+  };
+
+  const handle = Handle
+    ? () => {
+        let touched = 0;
+        const ar = new Handle(bytes, undefined);
+        try {
+          ar.parse();
+          for (const p of imgs) touched += ar.extract_image(p).length;
+        } finally {
+          ar.free();
+        }
+        return touched + 1;
+      }
+    : null;
+
+  return { free, handle, unit: `${imgs.length} images`, count: imgs.length };
+}
+
+function fmtRow(label, r) {
+  if (!r) return `  ${label.padEnd(8)}: n/a (handle class not in this WASM)`;
+  const f = (x) => x.toFixed(2).padStart(9);
+  return `  ${label.padEnd(8)}: min${f(r.min)}  median${f(r.median)}  mean${f(r.mean)} ms`;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  let wasmDir = null;
+  const di = argv.indexOf('--wasm-dir');
+  if (di !== -1) {
+    wasmDir = resolve(process.cwd(), argv[di + 1]);
+    argv.splice(di, 2);
+  }
+  const [file, itersArg] = argv;
+  if (!file) {
+    console.error(
+      'usage: node packages/node/src/bench-handle.mjs <file> [iterations] [--wasm-dir <dir>]',
+    );
+    process.exit(1);
+  }
+  const iters = itersArg ? Number(itersArg) : DEFAULT_ITERS;
+  const fmt = extname(file).toLowerCase().slice(1);
+  if (!['xlsx', 'pptx', 'docx'].includes(fmt)) {
+    throw new Error(`unsupported extension: .${fmt} (expected .xlsx/.pptx/.docx)`);
+  }
+  const bytes = readFileSync(resolve(process.cwd(), file));
+
+  const { jsPath, wasmPath } = wasmPaths(fmt, wasmDir);
+  const mod = await loadModule(jsPath, wasmPath);
+
+  const w = fmt === 'xlsx' ? xlsxWorkloads(mod, bytes) : docParseWorkloads(mod, bytes, fmt);
+  const source = wasmDir ? `before (${basename(wasmDir)})` : 'after (src/wasm)';
+
+  const freeStats = timeIt(w.free, iters);
+  const handleStats = w.handle ? timeIt(w.handle, iters) : null;
+
+  const speedup = handleStats ? (freeStats.median / handleStats.median).toFixed(2) : 'n/a';
+
+  console.log(`file      : ${basename(file)} (${(bytes.length / 1_000_000).toFixed(2)} MB)`);
+  console.log(`workload  : parse + ${w.unit}   [${fmt}]   wasm=${source}`);
+  console.log(`iters     : warmup=${WARMUP} iters=${iters}`);
+  console.log(fmtRow('free', freeStats));
+  console.log(fmtRow('handle', handleStats));
+  console.log(`  speedup : ${speedup}x  (free median / handle median)`);
+  // Machine-readable line for scripted collection.
+  const h = handleStats ? handleStats.median.toFixed(2) : 'na';
+  console.log(
+    `RESULT\t${basename(file)}\t${fmt}\t${source}\t${w.count}\tfree=${freeStats.median.toFixed(2)}\thandle=${h}\tspeedup=${speedup}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -43,7 +43,7 @@ fn note_layout_master_parse() {
 pub fn parse_pptx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
-    let presentation = parse_presentation(data)
+    let presentation = parse_presentation_from_bytes(data)
         .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
     serde_json::to_vec(&presentation)
         .map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
@@ -56,21 +56,14 @@ pub fn parse_pptx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u
 pub fn pptx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
-    let pres = parse_presentation(data)
+    let pres = parse_presentation_from_bytes(data)
         .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
-    let mut out = String::new();
-    for (i, slide) in pres.slides.iter().enumerate() {
-        if i > 0 {
-            out.push_str("\n---\n\n");
-        }
-        render_slide_md(slide, &mut out);
-    }
-    Ok(out)
+    Ok(render_presentation_md(&pres))
 }
 
 /// Native equivalent of `parse_pptx` for use from the MCP server.
 pub fn parse_pptx_native(data: &[u8]) -> Result<String, String> {
-    let presentation = parse_presentation(data).map_err(|e| e.to_string())?;
+    let presentation = parse_presentation_from_bytes(data).map_err(|e| e.to_string())?;
     serde_json::to_string(&presentation).map_err(|e| e.to_string())
 }
 
@@ -81,15 +74,8 @@ pub fn parse_pptx_native(data: &[u8]) -> Result<String, String> {
 /// need to read content efficiently — typical 10-30× token reduction vs. the
 /// raw JSON of `parse_pptx_native`.
 pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
-    let pres = parse_presentation(data).map_err(|e| e.to_string())?;
-    let mut out = String::new();
-    for (i, slide) in pres.slides.iter().enumerate() {
-        if i > 0 {
-            out.push_str("\n---\n\n");
-        }
-        render_slide_md(slide, &mut out);
-    }
-    Ok(out)
+    let pres = parse_presentation_from_bytes(data).map_err(|e| e.to_string())?;
+    Ok(render_presentation_md(&pres))
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -398,6 +384,96 @@ pub fn extract_image(
 ) -> Result<Vec<u8>, JsValue> {
     ooxml_common::zip::extract_zip_entry(data, path, max_zip_entry_bytes)
         .map_err(|e| JsValue::from_str(&e))
+}
+
+/// Project a parsed presentation to GitHub-flavoured markdown. Slides are joined
+/// by a `---` rule. Shared by `pptx_to_markdown`, `to_markdown_native`, and
+/// `PptxArchive::to_markdown` so every markdown path stays in lock-step.
+fn render_presentation_md(pres: &Presentation) -> String {
+    let mut out = String::new();
+    for (i, slide) in pres.slides.iter().enumerate() {
+        if i > 0 {
+            out.push_str("\n---\n\n");
+        }
+        render_slide_md(slide, &mut out);
+    }
+    out
+}
+
+/// A stateful handle over an opened pptx archive.
+///
+/// The free functions above (`parse_pptx` / `pptx_to_markdown` / `extract_media`
+/// / `extract_image`) each re-copy the whole file into WASM and re-scan the ZIP
+/// central directory on every call. A `PptxArchive` copies the bytes into WASM
+/// **once** (in `new`) and keeps the opened [`PptxZip`] alive, so a `parse`
+/// followed by any number of `extract_media` / `extract_image` calls (the
+/// viewer's parse-then-lazily-load-media pattern) pays the copy + open cost a
+/// single time. `ZipArchive<Cursor<Vec<u8>>>` is self-contained (it owns its
+/// bytes and holds no borrow into the input), which is what lets it live in a
+/// `#[wasm_bindgen]` struct field.
+///
+/// The retained `max` mirrors the per-call `scoped_max` guard the free functions
+/// install: every method re-installs it for its own scope so the zip-bomb entry
+/// cap is honored identically whether callers use the handle or the free
+/// functions.
+#[wasm_bindgen]
+pub struct PptxArchive {
+    archive: PptxZip,
+    max: Option<u64>,
+}
+
+#[wasm_bindgen]
+impl PptxArchive {
+    /// Copy `data` into WASM once and open the ZIP central directory once.
+    /// `max_zip_entry_bytes` is retained and applied on every subsequent method
+    /// call (identical semantics to the free functions' `scoped_max` guard).
+    #[wasm_bindgen(constructor)]
+    pub fn new(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<PptxArchive, JsValue> {
+        console_error_panic_hook::set_once();
+        let archive = zip::ZipArchive::new(Cursor::new(data.to_vec()))
+            .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
+        Ok(PptxArchive {
+            archive,
+            max: max_zip_entry_bytes,
+        })
+    }
+
+    /// Parse the retained archive and return the model as UTF-8 JSON bytes.
+    /// Byte-for-byte identical to `parse_pptx` on the same file.
+    pub fn parse(&mut self) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let presentation = parse_presentation(&mut self.archive)
+            .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
+        serde_json::to_vec(&presentation)
+            .map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
+    }
+
+    /// Extract raw bytes for one media entry (e.g. "ppt/media/media2.mp4") from
+    /// the retained archive. Twin of the free `extract_media`, but reads through
+    /// the already-open archive instead of re-opening it.
+    pub fn extract_media(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        ooxml_common::zip::read_zip_bytes(&mut self.archive, path)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
+    /// Extract raw bytes for one embedded image entry (e.g.
+    /// "ppt/media/image1.png") from the retained archive. Twin of the free
+    /// `extract_image`.
+    pub fn extract_image(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        ooxml_common::zip::read_zip_bytes(&mut self.archive, path)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
+    /// GitHub-flavoured markdown projection of the retained archive. Mirrors the
+    /// free `pptx_to_markdown`.
+    pub fn to_markdown(&mut self) -> Result<String, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let pres = parse_presentation(&mut self.archive)
+            .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
+        Ok(render_presentation_md(&pres))
+    }
 }
 
 // ===========================
@@ -1738,9 +1814,16 @@ struct TextOutline {
 //  ZIP helpers
 // ===========================
 
-type PptxZip<'a> = zip::ZipArchive<Cursor<&'a [u8]>>;
+/// The parser's ZIP archive type. Owns its backing bytes (`Cursor<Vec<u8>>`)
+/// rather than borrowing them, so a `PptxArchive` handle can keep a single
+/// opened archive alive across `parse` / `extract_media` / `extract_image` /
+/// `to_markdown` calls — the central directory is scanned once and the bytes are
+/// copied into WASM once. `ZipArchive<Cursor<Vec<u8>>>` is fully self-contained
+/// (no borrow into the input), which is what lets a `#[wasm_bindgen]` handle
+/// store it as a field.
+type PptxZip = zip::ZipArchive<Cursor<Vec<u8>>>;
 
-fn read_zip_str(zip: &mut PptxZip<'_>, path: &str) -> Result<String, Box<dyn std::error::Error>> {
+fn read_zip_str(zip: &mut PptxZip, path: &str) -> Result<String, Box<dyn std::error::Error>> {
     let max = ooxml_common::zip::current_max();
     let mut file = zip
         .by_name(path)
@@ -1852,7 +1935,7 @@ fn parse_rels(xml: &str) -> HashMap<String, String> {
 /// Pair diagramData rels with diagramDrawing rels in a slide's rels XML by filename
 /// number (data1.xml ↔ drawing1.xml, data2.xml ↔ drawing2.xml, ...), then load each
 /// drawing XML from the zip. Returns dm_rid → drawing_xml_content.
-fn build_smartart_drawings(rels_xml: &str, zip: &mut PptxZip<'_>) -> HashMap<String, String> {
+fn build_smartart_drawings(rels_xml: &str, zip: &mut PptxZip) -> HashMap<String, String> {
     let mut result: HashMap<String, String> = HashMap::new();
     let doc = match roxmltree::Document::parse(rels_xml) {
         Ok(d) => d,
@@ -3890,7 +3973,7 @@ fn parse_master_level_bullets(
     theme: &HashMap<String, String>,
     master_rels: &HashMap<String, String>,
     master_dir: &str,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> HashMap<String, LevelBullets> {
     let mut map: HashMap<String, LevelBullets> = HashMap::new();
 
@@ -4141,7 +4224,7 @@ fn parse_layout_placeholders(
     theme: &HashMap<String, String>,
     layout_dir: &str,
     layout_rels: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> LayoutPlaceholders {
     let mut lph = LayoutPlaceholders {
         master_by_type: master_transforms.clone(),
@@ -4503,7 +4586,7 @@ fn parse_layout(
     theme: &HashMap<String, String>,
     layout_dir: &str,
     layout_rels: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> ParsedLayout {
     note_layout_master_parse();
     let doc = match roxmltree::Document::parse(layout_xml) {
@@ -4597,7 +4680,7 @@ fn parse_text_body(
     inherited_space_after: Option<i64>,
     inherited_line_spacing: Option<f64>,
     shape_kind: ShapeKind,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> TextBody {
     let body_pr = child(tx_body, "bodyPr");
     // ECMA-376 §20.1.6.7 objectDefaults. The theme-level `<a:txDef>` (and
@@ -4923,7 +5006,7 @@ fn parse_paragraph(
     level_font_sizes: &LevelFontSizes,
     level_indents: &LevelIndents,
     level_bullets: &LevelBullets,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> Paragraph {
     let p_pr = child(p_node, "pPr");
 
@@ -6591,7 +6674,7 @@ fn parse_shape(
     theme: &HashMap<String, String>,
     rels: &HashMap<String, String>,
     group_fill: Option<&Fill>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> Option<ShapeElement> {
     // --- Placeholder info (for layout fallback) ---
     let ph_node = sp_node
@@ -7024,7 +7107,7 @@ fn svg_blip_path(
     blip: roxmltree::Node<'_, '_>,
     slide_dir: &str,
     rels: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> Option<String> {
     let svg_rid = svg_blip_rid(blip)?;
     let svg_target = rels.get(&svg_rid)?;
@@ -7041,7 +7124,7 @@ fn parse_picture(
     slide_dir: &str,
     rels: &HashMap<String, String>,
     theme: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> Option<PictureElement> {
     let sp_pr = child(pic_node, "spPr")?;
     let xfrm_node = child(sp_pr, "xfrm")?;
@@ -7490,7 +7573,7 @@ fn parse_table(
     t: &Transform,
     theme: &HashMap<String, String>,
     rels: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> Option<TableElement> {
     // Parse tblPr attributes and look up table style
     let tbl_pr = child(tbl, "tblPr");
@@ -7745,7 +7828,7 @@ fn parse_table_row(
     tr: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
     rels: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> TableRow {
     let height = attr_i64(&tr, "h").unwrap_or(0);
     let cells: Vec<TableCell> = tr
@@ -7760,7 +7843,7 @@ fn parse_table_cell(
     tc: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
     rels: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> TableCell {
     let tc_pr = child(tc, "tcPr");
     // tcPr > anchor controls vertical text alignment within the cell
@@ -7869,7 +7952,7 @@ fn extract_decorative_shapes(
     rels: &HashMap<String, String>,
     smartart_drawings: &HashMap<String, String>,
     theme: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
     out: &mut Vec<SlideElement>,
 ) {
     if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
@@ -7912,7 +7995,7 @@ fn parse_slide(
     index: usize,
     rels: &HashMap<String, String>,
     smartart_drawings: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> Result<Slide, Box<dyn std::error::Error>> {
     // Destructure the per-slide master bundle into the local names the rest of
     // this function uses. `theme` here is the slide's effective theme (the
@@ -8130,7 +8213,7 @@ fn parse_slide(
 /// Resolve the slide's `notesSlide` relationship, read the notes part, and
 /// return its plain text (paragraphs joined by '\n'). Returns `None` when
 /// the slide has no notes part or the part can't be read.
-fn load_notes_slide(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> Option<String> {
+fn load_notes_slide(zip: &mut PptxZip, rels: &HashMap<String, String>) -> Option<String> {
     // rels here is the slide's _rels map (rId → Target) parsed by the caller.
     // The relationship Type ends with "/notesSlide". The cleanest way to find
     // the right entry is to look at every value in the map and pick the one
@@ -8173,7 +8256,7 @@ fn load_notes_slide(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> Op
 /// Resolve and parse the slide's `comments` relationship (legacy
 /// `<p:cmLst>` format). Modern threaded comments live in a different
 /// namespace and are not yet supported.
-fn load_pptx_comments(zip: &mut PptxZip<'_>, rels: &HashMap<String, String>) -> Vec<PptxComment> {
+fn load_pptx_comments(zip: &mut PptxZip, rels: &HashMap<String, String>) -> Vec<PptxComment> {
     let Some(target) = rels.values().find(|t| t.contains("comments/")) else {
         return Vec::new();
     };
@@ -8237,7 +8320,7 @@ fn parse_sp_tree_node(
     slide_dir: &str,
     rels: &HashMap<String, String>,
     smartart_drawings: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
     theme: &HashMap<String, String>,
     out: &mut Vec<SlideElement>,
     skip_placeholders: bool,
@@ -8720,7 +8803,7 @@ fn parse_smartart_drawing(
     gf_xfrm: &Transform,
     theme: &HashMap<String, String>,
     out: &mut Vec<SlideElement>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) {
     let doc = match roxmltree::Document::parse(drawing_xml) {
         Ok(d) => d,
@@ -9104,7 +9187,7 @@ struct EffectiveMaster {
 fn build_master_bundle(
     master_path: &str,
     fallback_theme: &HashMap<String, String>,
-    zip: &mut PptxZip<'_>,
+    zip: &mut PptxZip,
 ) -> MasterBundle {
     let master_xml_opt: Option<String> = read_zip_str(zip, master_path).ok();
 
@@ -9236,12 +9319,20 @@ fn build_master_bundle(
     }
 }
 
-fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::Error>> {
-    let cursor = Cursor::new(data);
-    let mut zip = zip::ZipArchive::new(cursor)?;
+/// Parse a presentation from raw archive bytes. Thin wrapper that opens a fresh
+/// owned [`PptxZip`] (copying `data`) and delegates to [`parse_presentation`].
+/// Kept so the free `parse_pptx` / `pptx_to_markdown` WASM entry points and the
+/// native `parse_pptx_native` path keep their `&[u8]` signature; the stateful
+/// `PptxArchive` handle calls [`parse_presentation`] directly on its retained
+/// archive to avoid re-opening it per call.
+fn parse_presentation_from_bytes(data: &[u8]) -> Result<Presentation, Box<dyn std::error::Error>> {
+    let mut zip = zip::ZipArchive::new(Cursor::new(data.to_vec()))?;
+    parse_presentation(&mut zip)
+}
 
+fn parse_presentation(zip: &mut PptxZip) -> Result<Presentation, Box<dyn std::error::Error>> {
     // --- presentation.xml ---
-    let pres_xml = read_zip_str(&mut zip, "ppt/presentation.xml")?;
+    let pres_xml = read_zip_str(zip, "ppt/presentation.xml")?;
     let pres_doc = roxmltree::Document::parse(&pres_xml)?;
     let pres_root = pres_doc.root_element();
 
@@ -9260,7 +9351,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         .unwrap_or_default();
 
     // --- ppt/_rels/presentation.xml.rels ---
-    let pres_rels_xml = read_zip_str(&mut zip, "ppt/_rels/presentation.xml.rels")?;
+    let pres_rels_xml = read_zip_str(zip, "ppt/_rels/presentation.xml.rels")?;
     let pres_rels = parse_rels(&pres_rels_xml);
 
     // --- Presentation-level theme colors ---
@@ -9269,7 +9360,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
     // master that declares no /theme relationship of its own.
     let theme_xml = find_rel_target_by_type(&pres_rels_xml, "/theme")
         .map(|t| resolve_path("ppt", &t))
-        .and_then(|path| read_zip_str(&mut zip, &path).ok())
+        .and_then(|path| read_zip_str(zip, &path).ok())
         .unwrap_or_default();
     let theme = parse_theme_colors(&theme_xml);
 
@@ -9292,10 +9383,10 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
     // presentation-master bundle.
     let no_master_bundle: Option<MasterBundle> = match pres_master_path.as_deref() {
         Some(p) => {
-            master_cache.insert(p.to_owned(), build_master_bundle(p, &theme, &mut zip));
+            master_cache.insert(p.to_owned(), build_master_bundle(p, &theme, zip));
             None
         }
-        None => Some(build_master_bundle("", &theme, &mut zip)),
+        None => Some(build_master_bundle("", &theme, zip)),
     };
 
     // Cache of the layout single-pass extraction (`ParsedLayout`) keyed by layout
@@ -9350,10 +9441,10 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
             .to_owned();
         let rels_path = format!("ppt/slides/_rels/{slide_file}.rels");
 
-        let slide_xml = read_zip_str(&mut zip, &slide_path)?;
-        let slide_rels_xml = read_zip_str(&mut zip, &rels_path).unwrap_or_default();
+        let slide_xml = read_zip_str(zip, &slide_path)?;
+        let slide_rels_xml = read_zip_str(zip, &rels_path).unwrap_or_default();
         let slide_rels = parse_rels(&slide_rels_xml);
-        let smartart_drawings = build_smartart_drawings(&slide_rels_xml, &mut zip);
+        let smartart_drawings = build_smartart_drawings(&slide_rels_xml, zip);
 
         // Layout XML
         let layout_path = find_rel_target_by_type(&slide_rels_xml, "/slideLayout")
@@ -9361,7 +9452,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
 
         let layout_xml = layout_path
             .as_deref()
-            .and_then(|path| read_zip_str(&mut zip, path).ok());
+            .and_then(|path| read_zip_str(zip, path).ok());
 
         let layout_dir = layout_path
             .as_deref()
@@ -9376,7 +9467,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
             .and_then(|path| {
                 let file = path.split('/').next_back().unwrap_or("layout.xml");
                 let rels_p = format!("ppt/slideLayouts/_rels/{file}.rels");
-                read_zip_str(&mut zip, &rels_p).ok()
+                read_zip_str(zip, &rels_p).ok()
             })
             .unwrap_or_default();
         let layout_rels = parse_rels(&layout_rels_xml);
@@ -9407,7 +9498,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         let bundle: &MasterBundle = match raw.master_path.as_deref() {
             Some(mp) if !mp.is_empty() => {
                 if !master_cache.contains_key(mp) {
-                    let b = build_master_bundle(mp, &theme, &mut zip);
+                    let b = build_master_bundle(mp, &theme, zip);
                     master_cache.insert(mp.to_owned(), b);
                 }
                 &master_cache[mp]
@@ -9470,7 +9561,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         // Built fully here (in `parse_presentation`, where `zip` is available — the
         // master `<p:bg>` may reference a blip) BEFORE `parse_slide`; `EffectiveMaster`
         // owns its data and holds no `zip` borrow, so the mutable borrow taken to
-        // resolve `master_bg` ends before `parse_slide(&mut zip)` is called.
+        // resolve `master_bg` ends before `parse_slide(zip)` is called.
         let effective_master: Option<EffectiveMaster> = clr_map_ovr.map(|ovr| {
             let mut theme = bundle.theme.clone();
             apply_clr_map(&mut theme, Some(&ovr));
@@ -9507,7 +9598,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
                         &theme,
                         &bundle.master_rels,
                         &bundle.master_dir,
-                        &mut zip,
+                        zip,
                     )
                 })
                 .unwrap_or_default();
@@ -9534,7 +9625,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         };
         // Build a `ParsedLayout` from a layout XML string with the resolved
         // theme/bullets and this bundle's remaining (theme-independent) maps.
-        let build_parsed_layout = |lx: &str, zip: &mut PptxZip<'_>| -> ParsedLayout {
+        let build_parsed_layout = |lx: &str, zip: &mut PptxZip| -> ParsedLayout {
             parse_layout(
                 lx,
                 &bundle.master_font_sizes,
@@ -9566,12 +9657,12 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
         ) {
             (true, Some(lx), Some(lp)) => {
                 if !layout_cache.contains_key(lp) {
-                    let pl = build_parsed_layout(lx, &mut zip);
+                    let pl = build_parsed_layout(lx, zip);
                     layout_cache.insert(lp.to_owned(), pl);
                 }
                 None // borrowed from the cache below
             }
-            (_, Some(lx), _) => Some(build_parsed_layout(lx, &mut zip)),
+            (_, Some(lx), _) => Some(build_parsed_layout(lx, zip)),
             (_, None, _) => Some(ParsedLayout::default()),
         };
         let parsed_layout: &ParsedLayout = match &fresh_layout {
@@ -9592,7 +9683,7 @@ fn parse_presentation(data: &[u8]) -> Result<Presentation, Box<dyn std::error::E
             raw.index,
             &raw.slide_rels,
             &raw.smartart_drawings,
-            &mut zip,
+            zip,
         )?;
         slides.push(slide);
     }
@@ -10031,7 +10122,7 @@ mod tests {
             eprintln!("skipping test_parse_chartex: local sample not found");
             return;
         };
-        let cursor = std::io::Cursor::new(data.as_slice());
+        let cursor = std::io::Cursor::new(data.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         let mut xml = String::new();
         zip.by_name("ppt/charts/chartEx1.xml")
@@ -10059,7 +10150,7 @@ mod tests {
             eprintln!("skipping test_slide8_chart_rid: local sample not found");
             return;
         };
-        let cursor = std::io::Cursor::new(data.as_slice());
+        let cursor = std::io::Cursor::new(data.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         let mut slide_xml = String::new();
         zip.by_name("ppt/slides/slide8.xml")
@@ -10107,7 +10198,7 @@ mod tests {
             eprintln!("skipping test_slide8_full_parse: local sample not found");
             return;
         };
-        let pres = parse_presentation(&data).unwrap();
+        let pres = parse_presentation_from_bytes(&data).unwrap();
         let slide = &pres.slides[7]; // 0-indexed, slide 8
         println!("Slide 8 elements: {}", slide.elements.len());
         for (i, el) in slide.elements.iter().enumerate() {
@@ -10132,7 +10223,7 @@ mod tests {
             eprintln!("skipping test_slide8_chartex_pipeline: local sample not found");
             return;
         };
-        let cursor = std::io::Cursor::new(data.as_slice());
+        let cursor = std::io::Cursor::new(data.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
 
         let mut rels_xml = String::new();
@@ -10584,7 +10675,7 @@ mod tests {
         // Archive deliberately LACKS ppt/media/missing.png (it holds an unrelated
         // part so it isn't empty). index_for_name(missing.png) → None.
         let bytes = zip_with_parts(&[("ppt/media/other.png", b"\x89PNG")]);
-        let cursor = Cursor::new(bytes.as_slice());
+        let cursor = Cursor::new(bytes.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
 
         let master_doc = roxmltree::Document::parse(master).unwrap();
@@ -10616,7 +10707,7 @@ mod tests {
         // bullet resolves to Bullet::Blip — proving the test distinguishes
         // presence from absence rather than always inheriting.
         let bytes_ok = zip_with_parts(&[("ppt/media/missing.png", b"\x89PNG")]);
-        let cursor_ok = Cursor::new(bytes_ok.as_slice());
+        let cursor_ok = Cursor::new(bytes_ok.clone());
         let mut zip_ok = zip::ZipArchive::new(cursor_ok).unwrap();
         let m_ok = parse_master_level_bullets(
             master_root,
@@ -11019,7 +11110,7 @@ mod tests {
         let master_rels = HashMap::new();
         // Char bullets only — no media part lookups, so an empty archive suffices.
         let bytes = empty_zip_bytes();
-        let cursor = Cursor::new(bytes.as_slice());
+        let cursor = Cursor::new(bytes.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         let master_doc = roxmltree::Document::parse(master).unwrap();
         let m = parse_master_level_bullets(
@@ -11142,7 +11233,7 @@ mod tests {
         let theme = HashMap::new();
         let rels = HashMap::new();
         let bytes = empty_zip_bytes();
-        let cursor = Cursor::new(bytes.as_slice());
+        let cursor = Cursor::new(bytes.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         // `lst_style` sets the body lstStyle (the inherited per-level cascade);
         // `p_pr` is the paragraph's own pPr. Returns the single paragraph.
@@ -11215,7 +11306,7 @@ mod tests {
     #[test]
     fn layout_over_master_level_indents_merge_per_axis() {
         let bytes = empty_zip_bytes();
-        let cursor = Cursor::new(bytes.as_slice());
+        let cursor = Cursor::new(bytes.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
 
         // Master authors only marL on the body level; layout authors only indent.
@@ -11306,7 +11397,7 @@ mod tests {
             let mut theme: HashMap<String, String> = HashMap::new();
             theme.insert("accent1".to_string(), accent1_hex.to_string());
             let bytes = empty_zip_bytes();
-            let cursor = Cursor::new(bytes.as_slice());
+            let cursor = Cursor::new(bytes.clone());
             let mut zip = zip::ZipArchive::new(cursor).unwrap();
             parse_layout(
                 layout,
@@ -11472,7 +11563,7 @@ mod tests {
         let count_for = |n: usize| -> usize {
             let data = build_shared_layout_deck(n);
             LAYOUT_MASTER_PARSE_COUNT.with(|c| c.set(0));
-            let pres = parse_presentation(&data).expect("parse");
+            let pres = parse_presentation_from_bytes(&data).expect("parse");
             assert_eq!(pres.slides.len(), n);
             LAYOUT_MASTER_PARSE_COUNT.with(|c| c.get())
         };
@@ -11718,7 +11809,7 @@ mod tests {
         // parse_text_body now takes a &mut PptxZip (to verify buBlip parts). This
         // body declares no picture bullets, so an empty archive is sufficient.
         let bytes = empty_zip_bytes();
-        let cursor = Cursor::new(bytes.as_slice());
+        let cursor = Cursor::new(bytes.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         let mut parse = |body_pr: &str| -> TextBody {
             let xml = format!(
@@ -11789,7 +11880,7 @@ mod tests {
         // parse_text_body now takes a &mut PptxZip (to verify buBlip parts). No
         // picture bullets here, so an empty archive is sufficient.
         let bytes = empty_zip_bytes();
-        let cursor = Cursor::new(bytes.as_slice());
+        let cursor = Cursor::new(bytes.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         // `lst_style` lets a test set the body lvl1pPr default; `p_pr` is the
         // paragraph's own pPr. Returns the single paragraph's ea_ln_brk.
@@ -11896,7 +11987,7 @@ mod tests {
             let theme: HashMap<String, String> = HashMap::new();
             let rels: HashMap<String, String> = HashMap::new();
             let bytes = empty_zip_bytes();
-            let cursor = Cursor::new(bytes.as_slice());
+            let cursor = Cursor::new(bytes.clone());
             let mut zip = zip::ZipArchive::new(cursor).unwrap();
             parse_table(tbl, &t, &theme, &rels, &mut zip).unwrap()
         }
@@ -12405,7 +12496,7 @@ mod tests {
     #[test]
     fn master_sptree_pic_appears_on_slide() {
         let data = build_master_sp_pptx(None);
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         let slide = &pres.slides[0];
 
         let pic = slide.elements.iter().find_map(|e| match e {
@@ -12436,7 +12527,7 @@ mod tests {
     #[test]
     fn master_sptree_hidden_when_layout_show_master_sp_false() {
         let data = build_master_sp_pptx(Some(false));
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         let slide = &pres.slides[0];
 
         let has_master_pic = slide
@@ -12459,7 +12550,7 @@ mod tests {
     #[test]
     fn master_sptree_shown_when_layout_show_master_sp_true() {
         let data = build_master_sp_pptx(Some(true));
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         let slide = &pres.slides[0];
         assert!(
             slide
@@ -12601,7 +12692,7 @@ mod tests {
     }
 
     fn master_band_fill_hex(data: &[u8]) -> String {
-        let pres = parse_presentation(data).expect("parse");
+        let pres = parse_presentation_from_bytes(data).expect("parse");
         let slide = &pres.slides[0];
         let shape = slide
             .elements
@@ -12771,7 +12862,7 @@ mod tests {
     #[test]
     fn slide_inherits_master_blip_background() {
         let data = build_master_bg_blip_pptx();
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         let bg = pres.slides[0]
             .background
             .as_ref()
@@ -12874,7 +12965,7 @@ mod tests {
 
         let theme = HashMap::new();
         let data = build_blip_media_zip(PNG_1X1, SVG);
-        let cursor = Cursor::new(data.as_slice());
+        let cursor = Cursor::new(data.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
 
         let pic = parse_picture(pic_node, "ppt/slides", &rels, &theme, &mut zip)
@@ -12931,7 +13022,7 @@ mod tests {
         rels.insert("rIdPng".to_string(), "../media/image1.png".to_string());
         let theme = HashMap::new();
         let data = build_blip_media_zip(PNG_1X1, b"<svg/>");
-        let cursor = Cursor::new(data.as_slice());
+        let cursor = Cursor::new(data.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
         let pic = parse_picture(pic_node, "ppt/slides", &rels, &theme, &mut zip)
             .expect("parse_picture should succeed");
@@ -12985,7 +13076,7 @@ mod tests {
         let theme = HashMap::new();
         // Only the .svg part is referenced; the PNG arg is unused here.
         let data = build_blip_media_zip(b"", SVG);
-        let cursor = Cursor::new(data.as_slice());
+        let cursor = Cursor::new(data.clone());
         let mut zip = zip::ZipArchive::new(cursor).unwrap();
 
         let pic = parse_picture(pic_node, "ppt/slides", &rels, &theme, &mut zip)
@@ -13252,7 +13343,7 @@ mod tests {
     fn theme_resolved_per_slide_via_layout_master_chain() {
         let default_clr_map = r#"<p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>"#;
         let data = build_two_master_pptx(default_clr_map);
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         assert_eq!(pres.slides.len(), 2, "expected two slides");
 
         let s1 = first_shape_fill_color(&pres.slides[0]);
@@ -13278,7 +13369,7 @@ mod tests {
         // Swap bg1<->tx1 on masterA only.
         let swapped = r#"<p:clrMap bg1="dk1" tx1="lt1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>"#;
         let data = build_two_master_pptx(swapped);
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
 
         // slide2 (masterB, default clrMap) has the Tx1Rect: tx1 -> dk1 (#222222).
         let tx1_default = shape_fill_color_by_name(&pres.slides[1], "Tx1Rect");
@@ -13308,7 +13399,7 @@ mod tests {
     fn clr_map_tx1_resolves_to_lt1_on_swapped_master() {
         let swapped = r#"<p:clrMap bg1="dk1" tx1="lt1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>"#;
         let data = build_two_master_pptx_with_tx1_on_a(swapped);
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         // slide1 (masterA, swapped) has the Tx1Rect: tx1 -> lt1 (#FAFAFA).
         let tx1_swapped = shape_fill_color_by_name(&pres.slides[0], "Tx1Rect");
         assert_eq!(
@@ -13592,7 +13683,7 @@ mod tests {
     fn clr_map_ovr_override_remaps_logical_scheme_names() {
         let override_inner = r#"<a:overrideClrMapping bg1="dk1" tx1="lt1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>"#;
         let data = build_clr_map_ovr_pptx(override_inner);
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         assert_eq!(pres.slides.len(), 1, "expected one slide");
 
         // tx1 under the override → lt1 (#FAFAFA), NOT the master's dk1 (#222222).
@@ -13615,7 +13706,7 @@ mod tests {
         let layout_override = r#"<a:overrideClrMapping bg1="dk1" tx1="lt1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>"#;
         let data =
             build_clr_map_ovr_pptx_with_layout("<a:masterClrMapping/>", Some(layout_override));
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         assert_eq!(pres.slides.len(), 1, "expected one slide");
 
         let tx1 = shape_fill_color_by_name(&pres.slides[0], "Tx1Rect");
@@ -13634,7 +13725,7 @@ mod tests {
         let layout_override = r#"<a:overrideClrMapping bg1="dk1" tx1="lt1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>"#;
         // Empty slide-level inner ⇒ the builder omits <p:clrMapOvr> on the slide.
         let data = build_clr_map_ovr_pptx_with_layout("", Some(layout_override));
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         assert_eq!(pres.slides.len(), 1, "expected one slide");
 
         let tx1 = shape_fill_color_by_name(&pres.slides[0], "Tx1Rect");
@@ -13654,7 +13745,7 @@ mod tests {
     #[test]
     fn slide_master_clr_mapping_without_layout_override_uses_master() {
         let data = build_clr_map_ovr_pptx_with_layout("<a:masterClrMapping/>", None);
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         assert_eq!(pres.slides.len(), 1, "expected one slide");
 
         let tx1 = shape_fill_color_by_name(&pres.slides[0], "Tx1Rect");
@@ -13804,7 +13895,7 @@ mod tests {
     fn clr_map_ovr_flips_master_inherited_background() {
         let override_inner = r#"<a:overrideClrMapping bg1="dk1" tx1="lt1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>"#;
         let data = build_clr_map_ovr_master_bg_pptx(override_inner);
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         assert_eq!(pres.slides.len(), 1, "expected one slide");
 
         let bg = slide_bg_color(&pres.slides[0]);
@@ -13821,7 +13912,7 @@ mod tests {
     #[test]
     fn master_inherited_background_default_without_override() {
         let data = build_clr_map_ovr_master_bg_pptx("<a:masterClrMapping/>");
-        let pres = parse_presentation(&data).expect("parse");
+        let pres = parse_presentation_from_bytes(&data).expect("parse");
         assert_eq!(pres.slides.len(), 1, "expected one slide");
 
         let bg = slide_bg_color(&pres.slides[0]);

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -10,7 +10,7 @@
  * resume against the new model — callers must not interleave them.
  */
 import type { MediaElement, Presentation } from './types';
-import init, { parse_pptx, extract_media, extract_image } from './wasm/pptx_parser.js';
+import init, { PptxArchive } from './wasm/pptx_parser.js';
 import { renderSlide } from './renderer';
 import { selectNotes } from './notes';
 import { findMimeTypeForPath } from './media-mime';
@@ -20,8 +20,12 @@ import type { RenderWorkerRequest, RenderWorkerResponse, PresentationMeta } from
 
 let ready = false;
 let pres: Presentation | null = null;
-let currentBuffer: Uint8Array | null = null;
-let currentMaxZipEntryBytes: bigint | undefined;
+// A `PptxArchive` handle over the opened zip. `new PptxArchive(bytes, max)`
+// copies the file into WASM ONCE and opens it ONCE; the in-worker
+// `getMedia` / `getImage` closures then read bytes by zip path straight from the
+// retained archive (no transfer, no re-open, no JS-side buffer kept alive).
+// Freed + replaced on a re-parse.
+let archive: PptxArchive | null = null;
 /** Settled before any render when `useGoogleFonts` was requested. */
 let fontsLoaded: Promise<void> = Promise.resolve();
 const mediaCache = new Map<string, Promise<Blob>>();
@@ -29,6 +33,14 @@ const imageCache = new Map<string, Promise<Blob>>();
 
 const post = (msg: RenderWorkerResponse, transfer?: Transferable[]) =>
   (self.postMessage as (m: unknown, t?: Transferable[]) => void)(msg, transfer);
+
+/** Free the current handle (if any) and null it out — double-free / UAF guard. */
+function disposeArchive(): void {
+  if (archive) {
+    archive.free();
+    archive = null;
+  }
+}
 
 async function initWasm(wasmUrl: string) {
   await init(decodeDataUrl(wasmUrl) ?? wasmUrl);
@@ -40,8 +52,8 @@ function getMedia(path: string): Promise<Blob> {
   const hit = mediaCache.get(path);
   if (hit) return hit;
   const p = (async () => {
-    if (!currentBuffer || !pres) throw new Error('No pptx loaded');
-    const bytes = extract_media(currentBuffer, path, currentMaxZipEntryBytes);
+    if (!archive || !pres) throw new Error('No pptx loaded');
+    const bytes = archive.extract_media(path);
     return new Blob([new Uint8Array(bytes).slice()], { type: findMimeTypeForPath(pres, path) });
   })();
   mediaCache.set(path, p);
@@ -50,14 +62,14 @@ function getMedia(path: string): Promise<Blob> {
 
 /** In-worker image-byte loader (twin of {@link getMedia}). The renderer's
  *  `fetchImage` routes here in worker mode, so image bytes are decoded straight
- *  from the retained buffer with no main-thread round-trip. Mime travels on the
+ *  from the retained archive with no main-thread round-trip. Mime travels on the
  *  element, so the caller supplies it. */
 function getImage(path: string, mimeType: string): Promise<Blob> {
   const hit = imageCache.get(path);
   if (hit) return hit;
   const p = (async () => {
-    if (!currentBuffer) throw new Error('No pptx loaded');
-    const bytes = extract_image(currentBuffer, path, currentMaxZipEntryBytes);
+    if (!archive) throw new Error('No pptx loaded');
+    const bytes = archive.extract_image(path);
     return new Blob([new Uint8Array(bytes).slice()], { type: mimeType });
   })();
   imageCache.set(path, p);
@@ -81,17 +93,20 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       // re-parse would silently return the wrong file's media/image.
       mediaCache.clear();
       imageCache.clear();
-      currentBuffer = new Uint8Array(req.buffer);
-      currentMaxZipEntryBytes =
+      const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      // `parse_pptx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>). Render
-      // mode consumes the model in-worker, so decode + parse here (one decode,
-      // no passthrough).
-      pres = JSON.parse(
-        new TextDecoder().decode(parse_pptx(currentBuffer, currentMaxZipEntryBytes)),
-      ) as Presentation;
+      // Constructing the handle copies `req.buffer` into WASM; the worker then
+      // holds no reference to those bytes (memory is not doubled). Replace any
+      // prior handle first so a re-parse frees the old archive.
+      disposeArchive();
+      const bytes = new Uint8Array(req.buffer);
+      archive = new PptxArchive(bytes, max);
+      // `parse()` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>). Render mode
+      // consumes the model in-worker, so decode + parse here (one decode, no
+      // passthrough).
+      pres = JSON.parse(new TextDecoder().decode(archive.parse())) as Presentation;
       if (req.useGoogleFonts) {
         // Kick the preload now so it overlaps with main-thread work; renders
         // await `fontsLoaded` so text never rasterizes with fallback metrics.
@@ -150,10 +165,10 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
     if (req.kind === 'extractImage') {
       // Worker render mode decodes images in-worker via the getImage closure;
       // this message arm exists only for protocol parity with worker.ts. Raw
-      // bytes are read straight from the retained buffer (no mime needed for a
+      // bytes are read straight from the retained archive (no mime needed for a
       // byte transfer).
-      if (!currentBuffer) throw new Error('No pptx loaded');
-      const raw = extract_image(currentBuffer, req.path, currentMaxZipEntryBytes);
+      if (!archive) throw new Error('No pptx loaded');
+      const raw = archive.extract_image(req.path);
       const bytes = new Uint8Array(raw).slice().buffer;
       post({ kind: 'imageExtracted', id: req.id, bytes }, [bytes]);
       return;

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -1,9 +1,21 @@
 import type { WorkerRequest, WorkerResponse } from './types';
-import init, { parse_pptx, extract_media, extract_image } from './wasm/pptx_parser.js';
+import init, { PptxArchive } from './wasm/pptx_parser.js';
 
 let ready = false;
-let currentBuffer: Uint8Array | null = null;
-let currentMaxZipEntryBytes: bigint | undefined;
+// A `PptxArchive` handle over the opened zip: `new PptxArchive(bytes, max)`
+// copies the file into WASM ONCE and scans the central directory ONCE, then a
+// later `extractMedia` / `extractImage` reads by zip path straight from the
+// retained archive (no re-copy, no re-open, and no JS-side buffer kept alive —
+// the sole copy lives in WASM). Freed + replaced on a re-parse.
+let archive: PptxArchive | null = null;
+
+/** Free the current handle (if any) and null it out — double-free / UAF guard. */
+function disposeArchive(): void {
+  if (archive) {
+    archive.free();
+    archive = null;
+  }
+}
 
 function decodeDataUrl(url: string): ArrayBuffer | null {
   if (!url.startsWith('data:')) return null;
@@ -39,17 +51,22 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
       return;
     }
     try {
-      const bytes = new Uint8Array(req.buffer);
-      currentBuffer = bytes;
-      currentMaxZipEntryBytes =
+      const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      // `parse_pptx` returns the model as UTF-8 JSON bytes (Result<Vec<u8>,
+      // Constructing the handle copies `req.buffer` into WASM; after that the
+      // worker holds no reference to those bytes (memory is not doubled — the
+      // sole copy lives in WASM linear memory). Replace any prior handle first so
+      // re-parsing a new file frees the old archive.
+      disposeArchive();
+      const bytes = new Uint8Array(req.buffer);
+      archive = new PptxArchive(bytes, max);
+      // `parse()` returns the model as UTF-8 JSON bytes (Result<Vec<u8>,
       // JsValue>). wasm-bindgen hands back a fresh Uint8Array that owns its
       // buffer, so forward it to the main thread as a transferable — no clone,
       // no decode here. The single decode + JSON.parse happens once, on main.
-      const json = parse_pptx(bytes, currentMaxZipEntryBytes);
+      const json = archive.parse();
       const presentationJson = json.buffer as ArrayBuffer;
       const msg: WorkerResponse = { kind: 'parsed', id: req.id, presentationJson };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [
@@ -67,13 +84,13 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
   }
 
   if (req.kind === 'extractMedia') {
-    if (!currentBuffer) {
+    if (!archive) {
       const msg: WorkerResponse = { kind: 'error', id: req.id, message: 'No pptx loaded' };
       self.postMessage(msg);
       return;
     }
     try {
-      const bytes = extract_media(currentBuffer, req.path, currentMaxZipEntryBytes);
+      const bytes = archive.extract_media(req.path);
       const copy = new Uint8Array(bytes).slice().buffer;
       const msg: WorkerResponse = { kind: 'mediaExtracted', id: req.id, bytes: copy };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [copy]);
@@ -89,13 +106,13 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
   }
 
   if (req.kind === 'extractImage') {
-    if (!currentBuffer) {
+    if (!archive) {
       const msg: WorkerResponse = { kind: 'error', id: req.id, message: 'No pptx loaded' };
       self.postMessage(msg);
       return;
     }
     try {
-      const bytes = extract_image(currentBuffer, req.path, currentMaxZipEntryBytes);
+      const bytes = archive.extract_image(req.path);
       const copy = new Uint8Array(bytes).slice().buffer;
       const msg: WorkerResponse = { kind: 'imageExtracted', id: req.id, bytes: copy };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [copy]);

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -2,12 +2,11 @@ use crate::types::*;
 use crate::{parse_rels_map, resolve_fill_color, resolve_zip_path};
 use ooxml_common::zip::read_zip_string;
 use std::collections::HashMap;
-use std::io::Cursor;
 
 /// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse
 /// its drawing(s) for chart anchors (`<xdr:graphicFrame>` elements).
 pub(crate) fn load_sheet_charts(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
     sheet_path: &str,
     theme_colors: &[String],
 ) -> Vec<ChartAnchor> {

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -8,6 +8,9 @@ use ooxml_common::zip::read_zip_string;
 // subset that lacked the `svg` arm and so dropped SVG parts).
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
 use std::collections::HashMap;
+// `Cursor` is only used to build in-memory archives in this module's tests; the
+// production archive type is `crate::XlsxZip`.
+#[cfg(test)]
 use std::io::Cursor;
 
 /// Parse `<xdr:twoCellAnchor>` elements from a drawing XML and resolve
@@ -17,7 +20,7 @@ pub(crate) fn parse_drawing_anchors(
     drawing_xml: &str,
     drawing_rels: &HashMap<String, String>,
     drawing_dir: &str,
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
 ) -> Vec<ImageAnchor> {
     let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
         return Vec::new();
@@ -1362,7 +1365,7 @@ pub(crate) fn parse_shape_anchors(
 }
 
 pub(crate) fn load_sheet_shape_groups(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
     sheet_path: &str,
     theme_colors: &[String],
 ) -> Vec<ShapeAnchor> {
@@ -1413,7 +1416,7 @@ pub(crate) fn load_sheet_shape_groups(
 /// renderer fetches each referenced image's bytes lazily via `extract_image`,
 /// so this maps to zip paths rather than inlining base64.
 pub(crate) fn build_drawing_rid_urls(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
     drawing_path: &str,
 ) -> HashMap<String, String> {
     let Some((drawing_dir, drawing_file)) = drawing_path.rsplit_once('/') else {
@@ -1455,7 +1458,7 @@ pub(crate) fn build_drawing_rid_urls(
 /// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse
 /// its drawing(s), and return all image anchors found.
 pub(crate) fn load_sheet_images(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
     sheet_path: &str, // e.g. "worksheets/sheet1.xml"
 ) -> Vec<ImageAnchor> {
     // sheet rels path:  xl/worksheets/_rels/sheet1.xml.rels
@@ -2275,7 +2278,7 @@ mod blip_svg_tests {
     fn parse_one(blip_inner: &str, rels: &HashMap<String, String>) -> ImageAnchor {
         let xml = drawing_xml(blip_inner);
         let data = build_media_zip(PNG_1X1, SVG);
-        let cursor = Cursor::new(data.as_slice());
+        let cursor = Cursor::new(data.clone());
         let mut archive = zip::ZipArchive::new(cursor).unwrap();
         let anchors = parse_drawing_anchors(&xml, rels, "xl/drawings", &mut archive);
         assert_eq!(anchors.len(), 1, "exactly one picture anchor expected");

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -19,6 +19,17 @@ use slicer::*;
 mod table;
 use table::*;
 
+/// The parser's ZIP archive type. Owns its backing bytes (`Cursor<Vec<u8>>`)
+/// rather than borrowing them, so an `XlsxArchive` handle can keep a single
+/// opened archive alive across `parse` / `parse_sheet` / `extract_image` calls —
+/// the central directory is scanned once, the bytes are copied into WASM once,
+/// and (crucially for xlsx) the shared workbook parts are parsed once and reused
+/// on every sheet switch instead of being re-parsed per `parse_sheet`.
+/// `ZipArchive<Cursor<Vec<u8>>>` is fully self-contained (no borrow into the
+/// input), which is what lets it live in a `#[wasm_bindgen]` struct field and be
+/// passed by `&mut` to every per-sheet loader.
+pub(crate) type XlsxZip = zip::ZipArchive<Cursor<Vec<u8>>>;
+
 // Excel built-in indexed color palette (indices 0-63)
 // Standard Excel 2003 color palette
 const INDEXED_COLORS: &[&str] = &[
@@ -55,6 +66,113 @@ pub fn parse_xlsx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u
     serde_json::to_vec(&wb).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
+/// Workbook-level parts that every `parse_sheet` needs but that do NOT change
+/// between sheets: the workbook.xml / workbook.xml.rels source strings, the
+/// resolved sheet list, the theme palette, and the shared-string table.
+///
+/// Building these is the bulk of a sheet parse's fixed cost — `sharedStrings.xml`
+/// in particular is decompressed and walked in full. The free `parse_sheet`
+/// rebuilds them on every call (unchanged behavior); the stateful `XlsxArchive`
+/// builds them ONCE and reuses them for every sheet switch (the D3 win).
+///
+/// The XML is kept as owned `String`s rather than as `roxmltree::Document`s: a
+/// `Document` borrows its source, so it can't be cached across calls, but
+/// re-parsing the small workbook.xml / rels strings from memory (no zip inflate)
+/// is negligible next to re-decompressing + re-walking sharedStrings/theme.
+struct WorkbookShared {
+    workbook_xml: String,
+    rels_xml: String,
+    sheets: Vec<SheetMeta>,
+    theme_colors: Vec<String>,
+    shared_strings: Vec<SharedString>,
+}
+
+impl WorkbookShared {
+    /// Read + parse the workbook-level shared parts from an opened archive.
+    ///
+    /// `workbook.xml` is mandatory (a workbook without it is unparseable), but
+    /// `workbook.xml.rels` is read leniently (empty on absence): the original
+    /// `parse_xlsx` tolerated a missing rels part (tab colors skipped), while
+    /// `parse_sheet` required it — so the mandatory-rels enforcement stays in
+    /// `parse_sheet_with`, where an empty rels string fails `resolve_sheet_path`
+    /// exactly as the old `?` on the rels read did.
+    fn load(archive: &mut XlsxZip) -> Result<WorkbookShared, String> {
+        let workbook_xml = read_zip_string(archive, "xl/workbook.xml")?;
+        let sheets = {
+            let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
+            parse_workbook_sheets(&wb_doc)
+        };
+        let rels_xml = read_zip_string(archive, "xl/_rels/workbook.xml.rels").unwrap_or_default();
+        let theme_colors = parse_theme_colors(archive);
+        let shared_strings = read_shared_strings(archive, &theme_colors);
+        Ok(WorkbookShared {
+            workbook_xml,
+            rels_xml,
+            sheets,
+            theme_colors,
+            shared_strings,
+        })
+    }
+}
+
+/// Parse one worksheet from an opened archive, reusing already-loaded
+/// [`WorkbookShared`] parts. This is the shared core of the free `parse_sheet`
+/// and `XlsxArchive::parse_sheet`; the only difference between them is whether
+/// `shared` was built fresh for this call or cached across sheet switches.
+///
+/// `wb_doc` / `rels_doc` are re-parsed here from the cached source strings (cheap
+/// in-memory roxmltree parses, no zip inflate) because a `roxmltree::Document`
+/// borrows its input and so can't be stored in `WorkbookShared`.
+fn parse_sheet_with(
+    archive: &mut XlsxZip,
+    shared: &WorkbookShared,
+    sheet_index: u32,
+    name: &str,
+) -> Result<Vec<u8>, JsValue> {
+    let wb_doc = roxmltree::Document::parse(&shared.workbook_xml).map_err(|e| e.to_string())?;
+    // `workbook.xml.rels` is mandatory for a sheet parse (the original
+    // `parse_sheet` read it with `?`). `WorkbookShared` caches it leniently for
+    // the `parse_xlsx` path, so on the (defensive) missing-rels case re-read it
+    // here to surface the identical "entry not found" error the old code raised.
+    if shared.rels_xml.is_empty() {
+        read_zip_string(archive, "xl/_rels/workbook.xml.rels")
+            .map_err(|e| JsValue::from_str(&e))?;
+    }
+    let rels_doc = roxmltree::Document::parse(&shared.rels_xml).map_err(|e| e.to_string())?;
+
+    let sheet_meta = shared
+        .sheets
+        .get(sheet_index as usize)
+        .ok_or_else(|| format!("sheet index {} out of range", sheet_index))?;
+
+    let sheet_path = resolve_sheet_path(&rels_doc, &sheet_meta.r_id)
+        .ok_or_else(|| format!("rId {} not found in rels", sheet_meta.r_id))?;
+
+    let theme_colors = &shared.theme_colors;
+    let sheet_xml = read_zip_string(archive, &format!("xl/{}", sheet_path))?;
+    let (mut ws, hyperlink_rids) =
+        parse_worksheet(&sheet_xml, &shared.shared_strings, theme_colors, name)
+            .map_err(|e| e.to_string())?;
+
+    // Attach any drawing-anchored images and charts for this sheet
+    ws.images = load_sheet_images(archive, &sheet_path);
+    ws.charts = load_sheet_charts(archive, &sheet_path, theme_colors);
+    ws.shape_groups = load_sheet_shape_groups(archive, &sheet_path, theme_colors);
+    ws.hyperlinks = load_hyperlinks(archive, &sheet_path, hyperlink_rids);
+    ws.comments = load_sheet_comments(archive, &sheet_path);
+    ws.comment_refs = ws.comments.iter().map(|c| c.cell_ref.clone()).collect();
+    ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
+    ws.tables = load_sheet_tables(archive, &sheet_path, theme_colors);
+    ws.slicers = load_sheet_slicers(archive, &sheet_path);
+    ws.sparkline_groups =
+        load_sheet_sparklines(archive, &sheet_xml, &shared.sheets, &rels_doc, theme_colors);
+    let (df_family, df_size) = parse_default_font(archive);
+    ws.default_font_family = df_family;
+    ws.default_font_size = df_size;
+
+    serde_json::to_vec(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
 /// Parse one worksheet's cell data + layout and return it as UTF-8 JSON
 /// **bytes** (see `parse_xlsx` for the bytes-return rationale).
 #[wasm_bindgen]
@@ -66,87 +184,51 @@ pub fn parse_sheet(
 ) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
     let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
-    let cursor = Cursor::new(data);
-    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
-
-    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
-    let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
-    let sheets = parse_workbook_sheets(&wb_doc);
-
-    let sheet_meta = sheets
-        .get(sheet_index as usize)
-        .ok_or_else(|| format!("sheet index {} out of range", sheet_index))?;
-
-    // Resolve rId → target path from workbook.xml.rels
-    let rels_xml = read_zip_string(&mut archive, "xl/_rels/workbook.xml.rels")?;
-    let rels_doc = roxmltree::Document::parse(&rels_xml).map_err(|e| e.to_string())?;
-    let sheet_path = resolve_sheet_path(&rels_doc, &sheet_meta.r_id)
-        .ok_or_else(|| format!("rId {} not found in rels", sheet_meta.r_id))?;
-
-    let theme_colors = parse_theme_colors(&mut archive);
-    let shared_strings = read_shared_strings(&mut archive, &theme_colors);
-    let sheet_xml = read_zip_string(&mut archive, &format!("xl/{}", sheet_path))?;
-    let (mut ws, hyperlink_rids) =
-        parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
-            .map_err(|e| e.to_string())?;
-
-    // Attach any drawing-anchored images and charts for this sheet
-    ws.images = load_sheet_images(&mut archive, &sheet_path);
-    ws.charts = load_sheet_charts(&mut archive, &sheet_path, &theme_colors);
-    ws.shape_groups = load_sheet_shape_groups(&mut archive, &sheet_path, &theme_colors);
-    ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
-    ws.comments = load_sheet_comments(&mut archive, &sheet_path);
-    ws.comment_refs = ws.comments.iter().map(|c| c.cell_ref.clone()).collect();
-    ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
-    ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
-    ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
-    ws.sparkline_groups =
-        load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
-    let (df_family, df_size) = parse_default_font(&mut archive);
-    ws.default_font_family = df_family;
-    ws.default_font_size = df_size;
-
-    serde_json::to_vec(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(data.to_vec())).map_err(|e| e.to_string())?;
+    // The free function rebuilds the shared parts per call (behavior unchanged).
+    // `XlsxArchive::parse_sheet` reuses a cached `WorkbookShared` instead.
+    let shared = WorkbookShared::load(&mut archive).map_err(|e| JsValue::from_str(&e))?;
+    parse_sheet_with(&mut archive, &shared, sheet_index, name)
 }
 
-fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
-    let cursor = Cursor::new(data);
-    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
-
-    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
-    let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
-    let sheets = parse_workbook_sheets(&wb_doc);
-
-    let theme_colors = parse_theme_colors(&mut archive);
-    let shared_strings = read_shared_strings(&mut archive, &theme_colors);
-    let styles = parse_styles(&mut archive, &theme_colors)?;
+fn parse_xlsx_inner_with(
+    archive: &mut XlsxZip,
+    shared: &WorkbookShared,
+) -> Result<ParsedWorkbook, String> {
+    let theme_colors = &shared.theme_colors;
+    let styles = parse_styles(archive, theme_colors)?;
 
     // Surface each sheet's tab color (`<sheetPr><tabColor>`) on the workbook
     // sheet list so the viewer can paint every tab up front. `<sheetPr>` is the
     // first child of `<worksheet>` (ECMA-376 §18.3.1.99 element order), so a
     // small head read of each sheet entry is enough — we never decompress the
     // (potentially huge) `<sheetData>` body just to read the tab color.
-    let mut sheets = sheets;
-    if let Ok(rels_xml) = read_zip_string(&mut archive, "xl/_rels/workbook.xml.rels") {
-        if let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) {
-            for sheet in sheets.iter_mut() {
-                let Some(path) = resolve_sheet_path(&rels_doc, &sheet.r_id) else {
-                    continue;
-                };
-                let Ok(head) = read_zip_entry_head(&mut archive, &format!("xl/{}", path), 16_384)
-                else {
-                    continue;
-                };
-                sheet.tab_color = extract_tab_color_from_head(&head, &theme_colors);
-            }
+    let mut sheets = shared.sheets.clone();
+    if let Ok(rels_doc) = roxmltree::Document::parse(&shared.rels_xml) {
+        for sheet in sheets.iter_mut() {
+            let Some(path) = resolve_sheet_path(&rels_doc, &sheet.r_id) else {
+                continue;
+            };
+            let Ok(head) = read_zip_entry_head(archive, &format!("xl/{}", path), 16_384) else {
+                continue;
+            };
+            sheet.tab_color = extract_tab_color_from_head(&head, theme_colors);
         }
     }
 
     Ok(ParsedWorkbook {
         workbook: Workbook { sheets },
         styles,
-        shared_strings,
+        shared_strings: shared.shared_strings.clone(),
     })
+}
+
+fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(data.to_vec())).map_err(|e| e.to_string())?;
+    let shared = WorkbookShared::load(&mut archive)?;
+    parse_xlsx_inner_with(&mut archive, &shared)
 }
 
 /// Read only the first `max_bytes` of a ZIP entry as text. Used to probe the
@@ -154,7 +236,7 @@ fn parse_xlsx_inner(data: &[u8]) -> Result<ParsedWorkbook, String> {
 /// Lossy UTF-8 keeps a multibyte character split at the cut from erroring; the
 /// region we care about (`<sheetPr><tabColor>`) is pure ASCII near the start.
 fn read_zip_entry_head(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut XlsxZip,
     name: &str,
     max_bytes: u64,
 ) -> Result<String, String> {
@@ -203,7 +285,7 @@ fn extract_tab_color_from_head(head: &str, theme_colors: &[String]) -> Option<St
 /// from entry N (1-based) of this list (ECMA-376 §20.1.4.2.19); an entry
 /// without an explicit `w` uses the CT_LineProperties default 9525 EMU =
 /// 0.75 pt (§20.1.2.2.24).
-pub(crate) fn parse_theme_ln_widths(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<i64> {
+pub(crate) fn parse_theme_ln_widths(archive: &mut XlsxZip) -> Vec<i64> {
     let Ok(xml) = read_zip_string(archive, "xl/theme/theme1.xml") else {
         return Vec::new();
     };
@@ -230,7 +312,7 @@ pub(crate) fn parse_theme_ln_widths(archive: &mut zip::ZipArchive<Cursor<&[u8]>>
     widths
 }
 
-fn parse_theme_colors(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Vec<String> {
+fn parse_theme_colors(archive: &mut XlsxZip) -> Vec<String> {
     let Ok(xml) = read_zip_string(archive, "xl/theme/theme1.xml") else {
         return Vec::new();
     };
@@ -513,10 +595,7 @@ fn resolve_sheet_path(doc: &roxmltree::Document, r_id: &str) -> Option<String> {
     None
 }
 
-fn read_shared_strings(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
-    theme_colors: &[String],
-) -> Vec<SharedString> {
+fn read_shared_strings(archive: &mut XlsxZip, theme_colors: &[String]) -> Vec<SharedString> {
     let Ok(xml) = read_zip_string(archive, "xl/sharedStrings.xml") else {
         return Vec::new();
     };
@@ -1264,10 +1343,7 @@ pub(crate) fn parse_rels_map(xml: &str) -> HashMap<String, String> {
 /// Reads xl/commentsN.xml for the given sheet and returns each `<comment>` as
 /// a structured `XlsxComment` (cell ref, resolved author name, plain text).
 /// Callers can derive `comment_refs: Vec<String>` from `c.cell_ref`.
-fn load_sheet_comments(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
-    sheet_path: &str,
-) -> Vec<XlsxComment> {
+fn load_sheet_comments(archive: &mut XlsxZip, sheet_path: &str) -> Vec<XlsxComment> {
     let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
         return Vec::new();
     };
@@ -1326,7 +1402,7 @@ fn load_sheet_comments(
 /// (Office-365 threaded-comment authors, MS-XLSX schema
 /// `…/office/spreadsheetml/2018/threadedcomments`). `<person displayName id/>`.
 /// Returns an empty map when no persons part exists.
-fn load_persons(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> HashMap<String, String> {
+fn load_persons(archive: &mut XlsxZip) -> HashMap<String, String> {
     let mut out: HashMap<String, String> = HashMap::new();
     // Persons live under xl/persons/ by convention; collect every part there so
     // we don't depend on the exact file name (person.xml vs person1.xml).
@@ -1539,7 +1615,7 @@ fn parse_data_validations(ws_root: roxmltree::Node<'_, '_>) -> Vec<DataValidatio
 
 /// Resolve hyperlink rIds to URLs from the sheet rels file.
 fn load_hyperlinks(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut XlsxZip,
     sheet_path: &str,
     hyperlink_rids: HyperlinkRids,
 ) -> Vec<Hyperlink> {
@@ -1743,7 +1819,7 @@ fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> 
 /// reading the referenced sheet from the archive (cached per call to avoid
 /// re-reads). Theme colors are flattened to `#RRGGBB` via `parse_color`.
 fn load_sheet_sparklines(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut XlsxZip,
     sheet_xml: &str,
     sheets: &[SheetMeta],
     rels_doc: &roxmltree::Document,
@@ -2036,6 +2112,101 @@ pub fn extract_image(
         .map_err(|e| JsValue::from_str(&e))
 }
 
+/// A stateful handle over an opened xlsx archive.
+///
+/// Two costs the free functions pay on every call are eliminated here:
+///
+/// 1. **Buffer copy + central-directory scan** (like docx / pptx): `new` copies
+///    the bytes into WASM once and opens the ZIP once, then `parse` / `parse_sheet`
+///    / `extract_image` reuse the retained archive.
+/// 2. **Shared-part re-parse (D3)**: the free `parse_sheet` re-reads and re-parses
+///    `xl/workbook.xml`, `xl/sharedStrings.xml`, and the theme on EVERY sheet
+///    switch — decompressing + walking `sharedStrings.xml` in full each time. The
+///    handle parses those [`WorkbookShared`] parts ONCE (on the first `parse` or
+///    `parse_sheet`) and reuses them for every subsequent sheet, so switching
+///    sheets only reads that one sheet's XML + its drawings.
+///
+/// `ZipArchive<Cursor<Vec<u8>>>` and every cached part are fully owned (no borrow
+/// into the input), which is what lets them live in a `#[wasm_bindgen]` struct.
+/// The retained `max` mirrors the per-call `scoped_max` guard the free functions
+/// install.
+#[wasm_bindgen]
+pub struct XlsxArchive {
+    archive: XlsxZip,
+    max: Option<u64>,
+    /// Workbook-level parts parsed once and reused across sheet switches. Loaded
+    /// lazily on the first `parse` / `parse_sheet` (see [`XlsxArchive::shared`]).
+    shared: Option<WorkbookShared>,
+}
+
+#[wasm_bindgen]
+impl XlsxArchive {
+    /// Copy `data` into WASM once and open the ZIP central directory once.
+    /// `max_zip_entry_bytes` is retained and applied on every subsequent method
+    /// call (identical semantics to the free functions' `scoped_max` guard). The
+    /// shared workbook parts are parsed lazily on the first `parse`/`parse_sheet`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<XlsxArchive, JsValue> {
+        console_error_panic_hook::set_once();
+        let archive = zip::ZipArchive::new(Cursor::new(data.to_vec()))
+            .map_err(|e| JsValue::from_str(&format!("xlsx-parser error: {e}")))?;
+        Ok(XlsxArchive {
+            archive,
+            max: max_zip_entry_bytes,
+            shared: None,
+        })
+    }
+
+    /// Parse (once) and return the workbook-level shared parts, caching them for
+    /// reuse. Borrows `self` split so the cached `shared` and the `archive` can be
+    /// used together by callers.
+    fn ensure_shared(&mut self) -> Result<(), JsValue> {
+        if self.shared.is_none() {
+            let shared =
+                WorkbookShared::load(&mut self.archive).map_err(|e| JsValue::from_str(&e))?;
+            self.shared = Some(shared);
+        }
+        Ok(())
+    }
+
+    /// Parse the workbook index (sheet list + styles + shared strings) and return
+    /// it as UTF-8 JSON bytes. Byte-for-byte identical to `parse_xlsx`.
+    pub fn parse(&mut self) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        self.ensure_shared()?;
+        let shared = self.shared.as_ref().expect("shared loaded above");
+        let wb =
+            parse_xlsx_inner_with(&mut self.archive, shared).map_err(|e| JsValue::from_str(&e))?;
+        serde_json::to_vec(&wb).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
+    }
+
+    /// Parse one worksheet by 0-based index and return it as UTF-8 JSON bytes.
+    /// Byte-for-byte identical to `parse_sheet`, but the workbook / sharedStrings
+    /// / theme parts are taken from the cache instead of re-parsed (the D3 win).
+    pub fn parse_sheet(&mut self, sheet_index: u32, name: &str) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        self.ensure_shared()?;
+        let shared = self.shared.as_ref().expect("shared loaded above");
+        parse_sheet_with(&mut self.archive, shared, sheet_index, name)
+    }
+
+    /// Extract raw bytes for one embedded image entry (e.g.
+    /// "xl/media/image1.png") from the retained archive. Twin of the free
+    /// `extract_image`, but reads through the already-open archive.
+    pub fn extract_image(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        ooxml_common::zip::read_zip_bytes(&mut self.archive, path)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
+    /// GitHub-flavoured markdown projection of the retained archive. Mirrors the
+    /// free `xlsx_to_markdown`.
+    pub fn to_markdown(&mut self) -> Result<String, JsValue> {
+        let _guard = ooxml_common::zip::scoped_max(self.max);
+        to_markdown_from_archive(&mut self.archive).map_err(|e| JsValue::from_str(&e))
+    }
+}
+
 /// cached `<v>` so formula formulas show their results, not the formula text.
 /// Designed for AI agents that need to read the spreadsheet content
 /// efficiently — drops styling, formatting, charts, sparklines, drawings.
@@ -2046,65 +2217,56 @@ pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
 /// Shared implementation between `to_markdown_native` (mcp-server) and
 /// `xlsx_to_markdown` (browser / Node WASM).
 fn to_markdown_impl(data: &[u8]) -> Result<String, String> {
-    let cursor = Cursor::new(data);
-    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
-    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
-    let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
-    let sheets = parse_workbook_sheets(&wb_doc);
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(data.to_vec())).map_err(|e| e.to_string())?;
+    to_markdown_from_archive(&mut archive)
+}
 
+/// Render every sheet of an opened archive to markdown. Shared by the free
+/// `xlsx_to_markdown` / `to_markdown_native` and `XlsxArchive::to_markdown`;
+/// loads the workbook-level [`WorkbookShared`] parts once and renders each sheet
+/// through the same `parse_sheet_with` pipeline as the JSON path (so markdown and
+/// JSON never diverge on cell values).
+fn to_markdown_from_archive(archive: &mut XlsxZip) -> Result<String, String> {
+    let shared = WorkbookShared::load(archive)?;
     let mut out = String::new();
-    for (idx, sheet_meta) in sheets.iter().enumerate() {
-        let sheet_json = parse_sheet_native(data, idx as u32, &sheet_meta.name)
-            .map_err(|e| format!("sheet '{}' (#{}) parse failed: {}", sheet_meta.name, idx, e))?;
+    for (idx, sheet_meta) in shared.sheets.iter().enumerate() {
+        let sheet_json =
+            parse_sheet_with(archive, &shared, idx as u32, &sheet_meta.name).map_err(|e| {
+                format!(
+                    "sheet '{}' (#{}) parse failed: {}",
+                    sheet_meta.name,
+                    idx,
+                    jsvalue_to_string(&e)
+                )
+            })?;
         let sheet: serde_json::Value =
-            serde_json::from_str(&sheet_json).map_err(|e| e.to_string())?;
+            serde_json::from_slice(&sheet_json).map_err(|e| e.to_string())?;
         markdown::render_sheet(&sheet, &mut out);
     }
     Ok(out)
 }
 
 /// Parses a single worksheet by 0-based index and returns it as JSON.
-/// Native equivalent of `parse_sheet` for use from the MCP server.
+/// Native equivalent of `parse_sheet` for use from the MCP server. Shares the
+/// exact per-sheet pipeline (`WorkbookShared::load` + `parse_sheet_with`) with
+/// the WASM `parse_sheet`, then decodes the JSON bytes to a `String` — so the
+/// native and WASM paths can never drift.
 pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<String, String> {
-    let cursor = Cursor::new(data);
-    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| e.to_string())?;
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(data.to_vec())).map_err(|e| e.to_string())?;
+    let shared = WorkbookShared::load(&mut archive)?;
+    let json = parse_sheet_with(&mut archive, &shared, sheet_index, name)
+        .map_err(|e| jsvalue_to_string(&e))?;
+    String::from_utf8(json).map_err(|e| e.to_string())
+}
 
-    let workbook_xml = read_zip_string(&mut archive, "xl/workbook.xml")?;
-    let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
-    let sheets = parse_workbook_sheets(&wb_doc);
-
-    let sheet_meta = sheets
-        .get(sheet_index as usize)
-        .ok_or_else(|| format!("sheet index {} out of range", sheet_index))?;
-
-    let rels_xml = read_zip_string(&mut archive, "xl/_rels/workbook.xml.rels")?;
-    let rels_doc = roxmltree::Document::parse(&rels_xml).map_err(|e| e.to_string())?;
-    let sheet_path = resolve_sheet_path(&rels_doc, &sheet_meta.r_id)
-        .ok_or_else(|| format!("rId {} not found in rels", sheet_meta.r_id))?;
-
-    let theme_colors = parse_theme_colors(&mut archive);
-    let shared_strings = read_shared_strings(&mut archive, &theme_colors);
-    let sheet_xml = read_zip_string(&mut archive, &format!("xl/{}", sheet_path))?;
-    let (mut ws, hyperlink_rids) =
-        parse_worksheet(&sheet_xml, &shared_strings, &theme_colors, name)
-            .map_err(|e| e.to_string())?;
-
-    ws.images = load_sheet_images(&mut archive, &sheet_path);
-    ws.charts = load_sheet_charts(&mut archive, &sheet_path, &theme_colors);
-    ws.shape_groups = load_sheet_shape_groups(&mut archive, &sheet_path, &theme_colors);
-    ws.hyperlinks = load_hyperlinks(&mut archive, &sheet_path, hyperlink_rids);
-    ws.comments = load_sheet_comments(&mut archive, &sheet_path);
-    ws.comment_refs = ws.comments.iter().map(|c| c.cell_ref.clone()).collect();
-    ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
-    ws.tables = load_sheet_tables(&mut archive, &sheet_path, &theme_colors);
-    ws.slicers = load_sheet_slicers(&mut archive, &sheet_path);
-    ws.sparkline_groups =
-        load_sheet_sparklines(&mut archive, &sheet_xml, &sheets, &rels_doc, &theme_colors);
-    let (df_family, df_size) = parse_default_font(&mut archive);
-    ws.default_font_family = df_family;
-    ws.default_font_size = df_size;
-
-    serde_json::to_string(&ws).map_err(|e| e.to_string())
+/// Best-effort `JsValue` → `String` for the native (mcp-server) paths that reuse
+/// the WASM-typed `parse_sheet_with`. On wasm the error is a JS string; natively
+/// `JsValue` carries the message via its `Debug`/`Into<String>` impls, so this
+/// preserves the original error text raised by the shared pipeline.
+fn jsvalue_to_string(v: &JsValue) -> String {
+    v.as_string().unwrap_or_else(|| format!("{v:?}"))
 }
 
 #[cfg(test)]

--- a/packages/xlsx/parser/src/slicer.rs
+++ b/packages/xlsx/parser/src/slicer.rs
@@ -2,7 +2,6 @@ use crate::resolve_zip_path;
 use crate::types::*;
 use ooxml_common::zip::read_zip_string;
 use std::collections::HashMap;
-use std::io::Cursor;
 
 // ─── Slicer loading ─────────────────────────────────────────────────────────
 //
@@ -33,9 +32,7 @@ pub(crate) struct PivotCacheFields {
 /// Parse every `xl/pivotCache/pivotCacheDefinition*.xml` and merge its
 /// cacheFields (indexed by `@name`) into a single map. Sample workbooks
 /// typically have one pivotCache but the loop keeps the code general.
-pub(crate) fn load_all_pivot_cache_fields(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
-) -> PivotCacheFields {
+pub(crate) fn load_all_pivot_cache_fields(archive: &mut crate::XlsxZip) -> PivotCacheFields {
     let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     let mut out = PivotCacheFields::default();
     let names: Vec<String> = (0..archive.len())
@@ -84,7 +81,7 @@ pub(crate) fn load_all_pivot_cache_fields(
 /// the slicerCache's `@name` attribute (e.g. `"スライサー_贈答相手1"`). That
 /// name is what `<slicer cache="…"/>` in `xl/slicers/slicerN.xml` references.
 pub(crate) fn load_all_slicer_caches(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
 ) -> HashMap<String, SlicerCacheInfo> {
     let mut out: HashMap<String, SlicerCacheInfo> = HashMap::new();
     let names: Vec<String> = (0..archive.len())
@@ -155,7 +152,7 @@ pub(crate) fn parse_slicers_xml(xml: &str) -> HashMap<String, SlicerDef> {
 }
 
 pub(crate) fn load_sheet_slicers(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
     sheet_path: &str, // e.g. "worksheets/sheet1.xml"
 ) -> Vec<SlicerAnchor> {
     let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {

--- a/packages/xlsx/parser/src/styles.rs
+++ b/packages/xlsx/parser/src/styles.rs
@@ -1,16 +1,13 @@
 use crate::parse_color;
 use crate::types::*;
 use ooxml_common::zip::read_zip_string;
-use std::io::Cursor;
 
 /// Resolve the workbook's Normal-style font (family name + point size) by
 /// following `<cellStyleXfs>[0].fontId` → `<fonts>[fontId]`. Returns `(None,
 /// None)` if `xl/styles.xml` is missing or malformed. The renderer uses this
 /// to compute the Max Digit Width for column-width pixel conversion
 /// (ECMA-376 §18.3.1.13).
-pub(crate) fn parse_default_font(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
-) -> (Option<String>, Option<f64>) {
+pub(crate) fn parse_default_font(archive: &mut crate::XlsxZip) -> (Option<String>, Option<f64>) {
     let Ok(xml) = read_zip_string(archive, "xl/styles.xml") else {
         return (None, None);
     };
@@ -60,7 +57,7 @@ pub(crate) fn parse_default_font(
 }
 
 pub(crate) fn parse_styles(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
     theme_colors: &[String],
 ) -> Result<Styles, String> {
     let xml = read_zip_string(archive, "xl/styles.xml")?;

--- a/packages/xlsx/parser/src/table.rs
+++ b/packages/xlsx/parser/src/table.rs
@@ -1,7 +1,6 @@
 use crate::types::*;
 use crate::{parse_cell_ref, resolve_zip_path};
 use ooxml_common::zip::read_zip_string;
-use std::io::Cursor;
 
 /// Parse `xl/tables/tableN.xml` files referenced from the sheet rels and
 /// collect them for the renderer. Each table carries a ref range, style name
@@ -48,7 +47,7 @@ pub(crate) struct TableStyleElements {
 /// Parse `<tableStyles><tableStyle name="…"><tableStyleElement type="…" dxfId="…"/>`
 /// into a lookup keyed by table-style name.
 pub(crate) fn parse_table_styles_map(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
 ) -> std::collections::HashMap<String, TableStyleElements> {
     use std::collections::HashMap;
     let mut map: HashMap<String, TableStyleElements> = HashMap::new();
@@ -119,7 +118,7 @@ pub(crate) fn resolve_table_style_accent(style_name: &str, theme_colors: &[Strin
 }
 
 pub(crate) fn load_sheet_tables(
-    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    archive: &mut crate::XlsxZip,
     sheet_path: &str,
     theme_colors: &[String],
 ) -> Vec<TableInfo> {

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -10,7 +10,7 @@ pub struct Workbook {
 /// Sheet visibility (`<sheet state>`, ECMA-376 §18.2.19 `ST_SheetState`).
 /// `Hidden` = hidden but user-unhideable via the UI; `VeryHidden` = revealable
 /// only programmatically. Default is `Visible`.
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum SheetVisibility {
     Visible,
@@ -26,7 +26,7 @@ impl SheetVisibility {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SheetMeta {
     pub name: String,

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -9,7 +9,7 @@
  * re-`parse` resets all per-document caches so a reused worker never serves
  * stale sheets / images.
  */
-import init, { parse_xlsx, parse_sheet, extract_image } from './wasm/xlsx_parser.js';
+import init, { XlsxArchive } from './wasm/xlsx_parser.js';
 import { decodeDataUrl, preloadGoogleFonts } from '@silurus/ooxml-core';
 import { renderWorksheetViewport } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
@@ -18,8 +18,12 @@ import type { RenderWorkerRequest, RenderWorkerResponse } from './worker-protoco
 
 let initPromise: Promise<unknown> | null = null;
 let workbook: ParsedWorkbook | null = null;
-let rawData: ArrayBuffer | null = null;
-let maxZipEntryBytes: bigint | undefined;
+// An `XlsxArchive` handle over the opened zip. `new XlsxArchive(bytes, max)`
+// copies the file into WASM ONCE and opens it ONCE; the workbook / sharedStrings
+// / theme parts are parsed ONCE and reused on every `parse_sheet` (the D3 win).
+// `getImage` also reads bytes by zip path straight from the retained archive. No
+// JS-side buffer kept alive. Freed + replaced on a re-parse.
+let archive: XlsxArchive | null = null;
 let fontsLoaded: Promise<void> = Promise.resolve();
 const sheetCache = new Map<number, Worksheet>();
 const imageCache = new Map<string, CanvasImageSource | null>();
@@ -32,16 +36,24 @@ const imageBlobCache = new Map<string, Promise<Blob>>();
 const post = (msg: RenderWorkerResponse, transfer?: Transferable[]) =>
   (self.postMessage as (m: unknown, t?: Transferable[]) => void)(msg, transfer);
 
+/** Free the current handle (if any) and null it out — double-free / UAF guard. */
+function disposeArchive(): void {
+  if (archive) {
+    archive.free();
+    archive = null;
+  }
+}
+
 /** In-worker image-byte loader (twin of the docx render-worker `getImage`). The
  *  orchestrator's `fetchImage` routes here in worker mode, so image bytes are
- *  read straight from the retained `rawData` with no main-thread round-trip.
+ *  read straight from the retained archive with no main-thread round-trip.
  *  Mime travels on the element, so the caller supplies it. */
 function getImage(path: string, mimeType: string): Promise<Blob> {
   const hit = imageBlobCache.get(path);
   if (hit) return hit;
   const p = (async () => {
-    if (!rawData) throw new Error('Workbook not loaded');
-    const bytes = extract_image(new Uint8Array(rawData), path, maxZipEntryBytes);
+    if (!archive) throw new Error('Workbook not loaded');
+    const bytes = archive.extract_image(path);
     return new Blob([new Uint8Array(bytes).slice()], { type: mimeType });
   })();
   imageBlobCache.set(path, p);
@@ -50,16 +62,18 @@ function getImage(path: string, mimeType: string): Promise<Blob> {
 
 /** Lazily parse one worksheet directly via WASM and cache it — the worker-side
  *  equivalent of XlsxWorkbook.getWorksheet (same `parse_sheet` call, same
- *  cache). Shared by the `renderViewport` handler. */
+ *  decode cache). The handle's own shared-part cache means repeat sheet switches
+ *  no longer re-parse the workbook / sharedStrings / theme. Shared by the
+ *  `renderViewport` handler. */
 function parseSheetLocally(sheetIndex: number): Worksheet {
   const cached = sheetCache.get(sheetIndex);
   if (cached) return cached;
-  if (!workbook || !rawData) throw new Error('Workbook not loaded');
+  if (!workbook || !archive) throw new Error('Workbook not loaded');
   const sheetMeta = workbook.workbook.sheets[sheetIndex];
   if (!sheetMeta) throw new Error(`Sheet index ${sheetIndex} out of range`);
   // `parse_sheet` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); the
   // render worker consumes the model in-worker, so decode + parse here.
-  const json = parse_sheet(new Uint8Array(rawData), sheetIndex, sheetMeta.name, maxZipEntryBytes);
+  const json = archive.parse_sheet(sheetIndex, sheetMeta.name);
   const ws = JSON.parse(new TextDecoder().decode(json)) as Worksheet;
   sheetCache.set(sheetIndex, ws);
   return ws;
@@ -80,16 +94,19 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       sheetCache.clear();
       imageCache.clear();
       imageBlobCache.clear();
-      maxZipEntryBytes =
+      const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      // `parse_xlsx` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); decode
-      // + parse the workbook index here (consumed in-worker, then a light copy
-      // is sent to the proxy as an object).
-      const json = parse_xlsx(new Uint8Array(req.data), maxZipEntryBytes);
-      workbook = JSON.parse(new TextDecoder().decode(json)) as ParsedWorkbook;
-      rawData = req.data;
+      // Constructing the handle copies `req.data` into WASM; the worker then
+      // holds no reference to those bytes (memory is not doubled). Replace any
+      // prior handle first so a re-parse frees the old archive.
+      disposeArchive();
+      archive = new XlsxArchive(new Uint8Array(req.data), max);
+      // `parse()` returns UTF-8 JSON bytes (Result<Vec<u8>, JsValue>); decode +
+      // parse the workbook index here (consumed in-worker, then a light copy is
+      // sent to the proxy as an object).
+      workbook = JSON.parse(new TextDecoder().decode(archive.parse())) as ParsedWorkbook;
       if (req.useGoogleFonts) {
         // Mirror XlsxWorkbook._load exactly: queue Google Fonts substitutes for
         // every styled font name, plus the generic Arabic fallbacks. Fonts must
@@ -131,10 +148,10 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
     if (req.type === 'extractImage') {
       // Worker render mode decodes images in-worker via the getImage closure;
       // this arm exists only for protocol parity with worker.ts. Raw bytes are
-      // read straight from the retained rawData (no mime needed for a byte
+      // read straight from the retained archive (no mime needed for a byte
       // transfer).
-      if (!rawData) throw new Error('Workbook not loaded');
-      const raw = extract_image(new Uint8Array(rawData), req.path, maxZipEntryBytes);
+      if (!archive) throw new Error('Workbook not loaded');
+      const raw = archive.extract_image(req.path);
       const bytes = new Uint8Array(raw).slice().buffer;
       post({ type: 'imageExtracted', id, bytes }, [bytes]);
       return;

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -1,14 +1,24 @@
-import init, { parse_xlsx, parse_sheet, extract_image } from './wasm/xlsx_parser.js';
+import init, { XlsxArchive } from './wasm/xlsx_parser.js';
 import { decodeDataUrl } from '@silurus/ooxml-core';
 import type { WorkerRequest, WorkerResponse } from './types.js';
 
 let initPromise: Promise<unknown> | null = null;
-// The buffer is *copied* into the worker on `parse` (xlsx clones rather than
-// transfers, so the main thread keeps its own copy too). Retain it so a later
-// `extractImage` can read media bytes by zip path without re-sending the file —
-// mirroring how docx/pptx worker.ts keep `currentBuffer`.
-let currentBuffer: Uint8Array | null = null;
-let currentMaxZipEntryBytes: bigint | undefined;
+// An `XlsxArchive` handle over the opened zip. `new XlsxArchive(bytes, max)`
+// copies the file into WASM ONCE and scans the central directory ONCE; the
+// workbook / sharedStrings / theme parts are then parsed ONCE and reused on every
+// `parseSheet` (the D3 win — a sheet switch previously re-parsed all of them).
+// `extractImage` also reads by zip path straight from the retained archive. No
+// JS-side buffer is kept alive (the sole copy lives in WASM). Freed + replaced on
+// a re-parse.
+let archive: XlsxArchive | null = null;
+
+/** Free the current handle (if any) and null it out — double-free / UAF guard. */
+function disposeArchive(): void {
+  if (archive) {
+    archive.free();
+    archive = null;
+  }
+}
 
 self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;
@@ -24,45 +34,46 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   try {
     await initPromise;
     if (req.type === 'parse') {
-      currentMaxZipEntryBytes =
+      const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
-      currentBuffer = new Uint8Array(req.data);
-      // `parse_xlsx` returns the workbook index as UTF-8 JSON bytes
-      // (Result<Vec<u8>, JsValue>). wasm-bindgen hands back a fresh Uint8Array
-      // that owns its buffer, so forward it to main as a transferable — no
-      // clone, no decode here. The single decode + JSON.parse happens on main.
-      const json = parse_xlsx(currentBuffer, currentMaxZipEntryBytes);
+      // Constructing the handle copies `req.data` into WASM; after that the
+      // worker holds no reference to those bytes (memory is not doubled). Replace
+      // any prior handle first so re-parsing a new file frees the old archive.
+      disposeArchive();
+      const bytes = new Uint8Array(req.data);
+      archive = new XlsxArchive(bytes, max);
+      // `parse()` returns the workbook index as UTF-8 JSON bytes (Result<Vec<u8>,
+      // JsValue>). wasm-bindgen hands back a fresh Uint8Array that owns its
+      // buffer, so forward it to main as a transferable — no clone, no decode
+      // here. The single decode + JSON.parse happens on main.
+      const json = archive.parse();
       const workbookJson = json.buffer as ArrayBuffer;
       const res: WorkerResponse = { type: 'parsed', id, workbookJson };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [
         workbookJson,
       ]);
     } else if (req.type === 'parseSheet') {
-      // Reuse the buffer retained at `parse` instead of re-receiving it — the
-      // whole file no longer crosses the worker boundary on every sheet switch
-      // (twin of the `extractImage` reuse below). A `parseSheet` before any
-      // `parse` has no buffer to work with: that is a protocol violation, so
-      // fail loudly rather than silently returning an empty sheet.
-      if (!currentBuffer) {
-        throw new Error('parseSheet before parse: no buffer retained');
+      // Parse straight off the retained archive, reusing its cached workbook /
+      // sharedStrings / theme parts — the whole file no longer crosses the worker
+      // boundary and those shared parts are no longer re-parsed on every sheet
+      // switch. A `parseSheet` before any `parse` has no archive to work with:
+      // that is a protocol violation, so fail loudly.
+      if (!archive) {
+        throw new Error('parseSheet before parse: no archive retained');
       }
-      const maxBytes =
-        typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
-          ? BigInt(req.maxZipEntryBytes)
-          : undefined;
       // `parse_sheet` also returns UTF-8 JSON bytes; forward its transferable
       // buffer to main the same way (single decode + parse on main).
-      const json = parse_sheet(currentBuffer, req.sheetIndex, req.sheetName, maxBytes);
+      const json = archive.parse_sheet(req.sheetIndex, req.sheetName);
       const worksheetJson = json.buffer as ArrayBuffer;
       const res: WorkerResponse = { type: 'parsedSheet', id, worksheetJson };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [
         worksheetJson,
       ]);
     } else if (req.type === 'extractImage') {
-      if (!currentBuffer) throw new Error('No xlsx loaded');
-      const bytes = extract_image(currentBuffer, req.path, currentMaxZipEntryBytes);
+      if (!archive) throw new Error('No xlsx loaded');
+      const bytes = archive.extract_image(req.path);
       const copy = new Uint8Array(bytes).slice().buffer;
       const res: WorkerResponse = { type: 'imageExtracted', id, bytes: copy };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [copy]);


### PR DESCRIPTION
## Summary

Phase 2 items D2 + D3 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md). Every `extract_image` / `parse_sheet` call used to re-copy the whole file across the WASM boundary and re-scan the ZIP central directory; xlsx additionally re-parsed workbook.xml / sharedStrings / theme on every sheet switch.

### Design
- `#[wasm_bindgen]` handle per format — `DocxArchive` / `PptxArchive` / `XlsxArchive` — owning `ZipArchive<Cursor<Vec<u8>>>` (self-contained; one concrete type instead of threading `<R: Read+Seek>` through ~40 helpers). Bytes are copied into WASM memory **once** at construction; workers replace their retained `currentBuffer`/`rawData` with the handle (memory doubling resolved), with a `disposeArchive()` double-free/UAF guard.
- `XlsxArchive` caches `WorkbookShared` (workbook.xml + rels strings, sheet list, theme, sharedStrings) parsed once — D3. Cached as owned strings/structs, not `Document`s (roxmltree borrows). Drawing-XML dedup noted as deferred.
- **All free-function and native signatures byte-identical** (verified against generated .d.ts) — they became thin wrappers opening a throwaway handle, so node / markdown / stories / MCP are untouched.

### Benchmark (bench-handle.mjs — parse then switch every sheet / extract every image; median ms)
| workload | free (before) | handle (after) | |
|---|--:|--:|--:|
| xlsx sample-12, 8 sheets | 4.14 | **2.73** | **1.61×** |
| xlsx sample-9, 3 sheets | 5.08 | 3.95 | 1.30× |
| pptx sample-4, 15 MB + 5 media | 15.08 | **10.83** | **1.49×** |
| docx sample-9, +13 images | 11.56 | 10.80 | 1.10× |

xlsx scales with sheet count, pptx with file size; docx's ZIP re-open was already cheap next to its XML parse.

### Output identity
Model JSON / extracted bytes verified byte-exact — with one caveat that predates this PR: serde emits two HashMap-backed maps (`colWidths`, `fontFamilyClasses`) in randomized key order, so consecutive calls differ on the **base commit** too. After key-normalization everything matches exactly; VRT confirms the renderer is order-insensitive.

## Verification
- cargo fmt / clippy -D warnings / test --workspace (463) — green
- pnpm build:wasm → test (1526) / typecheck / lint — green
- pnpm smoke 6/6 (real workers); **pnpm vrt: docx 21 / pptx 75 / xlsx 67 — all pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)