### PR TITLE
refactor: ooxml_common theme + rels modules, deterministic JSON key order (D5+D6)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,7 +1,7 @@
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
 use ooxml_common::zip::read_zip_string;
 use roxmltree::Document as XmlDoc;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use zip::ZipArchive;
 
 use crate::numbering::NumberingMap;
@@ -787,8 +787,8 @@ fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
 /// this map as the primary source of serif/sans-serif classification, falling
 /// back to name-pattern matching only when the font is absent or classified
 /// as `auto`.
-fn parse_font_table(xml: &str) -> HashMap<String, String> {
-    let mut map = HashMap::new();
+fn parse_font_table(xml: &str) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
     let Ok(doc) = XmlDoc::parse(xml) else {
         return map;
     };

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -531,68 +531,30 @@ impl ThemeColors {
         let mut map: HashMap<String, String> = HashMap::new();
         let mut fonts: HashMap<String, String> = HashMap::new();
         let theme_xml = Some(xml.to_string());
-        let doc = match XmlDoc::parse(xml) {
-            Ok(d) => d,
-            Err(_) => {
-                return Self {
-                    map,
-                    fonts,
-                    theme_xml,
-                    ..Default::default()
-                }
-            }
-        };
-        let root = doc.root_element();
-        if let Some(scheme) = root
-            .descendants()
-            .find(|n| n.is_element() && n.tag_name().name() == "clrScheme")
-        {
-            for child in scheme.children().filter(|n| n.is_element()) {
-                let name = child.tag_name().name().to_string();
-                let hex = child.children().filter(|n| n.is_element()).find_map(|n| {
-                    match n.tag_name().name() {
-                        "srgbClr" => n.attribute("val").map(|v| v.to_uppercase()),
-                        "sysClr" => n.attribute("lastClr").map(|v| v.to_uppercase()),
-                        _ => None,
-                    }
-                });
-                if let Some(h) = hex {
-                    map.insert(name, h);
+
+        // Color slots: shared clrScheme parse; docx uppercases each hex and keys
+        // by slot name. prstClr now resolves through the shared preset table
+        // (previously dropped), so a preset scheme slot contributes its color.
+        for (slot, hex) in ooxml_common::theme::ThemeColorScheme::parse(xml).iter() {
+            map.insert(slot.to_string(), hex.to_uppercase());
+        }
+
+        // Font scheme: shared parse mapped onto docx's "{group}/{axis}" keys
+        // (e.g. "minor/latin"). Empty typefaces are already dropped by the
+        // shared parser.
+        let theme_fonts = ooxml_common::theme::ThemeFonts::parse(xml);
+        for (group, prefix) in [(&theme_fonts.major, "major"), (&theme_fonts.minor, "minor")] {
+            for (face, axis) in [
+                (&group.latin, "latin"),
+                (&group.ea, "ea"),
+                (&group.cs, "cs"),
+            ] {
+                if let Some(typeface) = face {
+                    fonts.insert(format!("{prefix}/{axis}"), typeface.clone());
                 }
             }
         }
-        if let Some(font_scheme) = root
-            .descendants()
-            .find(|n| n.is_element() && n.tag_name().name() == "fontScheme")
-        {
-            for group_name in &["majorFont", "minorFont"] {
-                let prefix = if *group_name == "majorFont" {
-                    "major"
-                } else {
-                    "minor"
-                };
-                if let Some(group) = font_scheme
-                    .children()
-                    .find(|n| n.is_element() && n.tag_name().name() == *group_name)
-                {
-                    for child in group.children().filter(|n| n.is_element()) {
-                        let typ = match child.tag_name().name() {
-                            "latin" => Some("latin"),
-                            "ea" => Some("ea"),
-                            "cs" => Some("cs"),
-                            _ => None,
-                        };
-                        if let Some(t) = typ {
-                            if let Some(face) = child.attribute("typeface") {
-                                if !face.is_empty() {
-                                    fonts.insert(format!("{prefix}/{t}"), face.to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+
         Self {
             map,
             fonts,

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1330,11 +1330,14 @@ fn load_media_map(
     let mut media_map: HashMap<String, String> = HashMap::new();
     for (rid, target) in rel_map {
         if target.contains("media/") || target.contains("image") {
-            let path = if target.starts_with('/') {
-                target.trim_start_matches('/').to_string()
-            } else {
-                format!("{}{}", base_dir, target)
-            };
+            // Resolve the Target against the source part's directory via the
+            // shared OPC resolver (ECMA-376 Part 2 §9.3): this handles
+            // root-absolute Targets (`/word/media/...`) AND normalizes `..`
+            // segments, so a chart/footnote media ref like
+            // `../media/image.png` (base_dir `word/charts/`) resolves to
+            // `word/media/image.png` instead of the unresolved
+            // `word/charts/../media/image.png` the old `format!` left behind.
+            let path = ooxml_common::rels::resolve_target(base_dir, target);
             // Confirm the part exists before mapping the rId (keeps the lazy
             // pipeline honest: a path in the map is always extractable).
             // `index_for_name` consults only the central directory — no inflate,
@@ -5565,25 +5568,16 @@ fn apply_direct_run(base: &mut RunFmt, direct: &RunFmt) {
     base.font_size_cs_set_here = false;
 }
 
+/// id → target map for a `.rels` part. Thin adapter over
+/// [`ooxml_common::rels::parse_rels`] that flattens each `RelTarget` to its raw
+/// target string (both Internal part names and External hyperlink URLs are kept
+/// verbatim; part-name resolution happens later in [`load_media_map`]),
+/// preserving this parser's `HashMap<rId, Target>` shape.
 fn parse_rels(xml: &str) -> HashMap<String, String> {
-    let mut map = HashMap::new();
-    if xml.is_empty() {
-        return map;
-    }
-    let doc = match XmlDoc::parse(xml) {
-        Ok(d) => d,
-        Err(_) => return map,
-    };
-    for rel in doc
-        .root_element()
-        .children()
-        .filter(|n| n.tag_name().name() == "Relationship")
-    {
-        if let (Some(id), Some(target)) = (rel.attribute("Id"), rel.attribute("Target")) {
-            map.insert(id.to_string(), target.to_string());
-        }
-    }
-    map
+    ooxml_common::rels::parse_rels(xml)
+        .into_iter()
+        .map(|(id, rel)| (id, rel.target))
+        .collect()
 }
 
 #[cfg(test)]
@@ -7990,6 +7984,45 @@ mod svg_blip_tests {
         assert!(
             !has_image,
             "an rId whose media part is absent must be dropped, yielding no ImageRun"
+        );
+    }
+
+    /// `load_media_map` must normalize `..` segments in a relationship Target
+    /// (ECMA-376 Part 2 §9.3). A media ref that walks up out of a nested part's
+    /// directory — e.g. `../media/footnote.png` resolved against
+    /// `word/charts/` — must become the canonical part name
+    /// `word/media/footnote.png`, so the existence check finds the entry and the
+    /// rId is mapped. Before the shared `ooxml_common::rels::resolve_target`
+    /// migration, docx concatenated `base_dir + target` verbatim, leaving the
+    /// unresolved `word/charts/../media/footnote.png`; whether that matched a
+    /// zip entry was left to the zip lib's leniency. This pins the fix.
+    #[test]
+    fn load_media_map_normalizes_dotdot_target() {
+        use zip::write::SimpleFileOptions;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            let mut put = |name: &str, bytes: &[u8]| {
+                use std::io::Write;
+                zw.start_file(name, opts).unwrap();
+                zw.write_all(bytes).unwrap();
+            };
+            // The media part lives at the canonical (normalized) name.
+            put("word/media/footnote.png", PNG_1X1);
+            zw.finish().unwrap();
+        }
+        let mut zip: Zip = ZipArchive::new(Cursor::new(buf)).unwrap();
+
+        // A part at word/charts/chart1.xml references the media one directory up.
+        let mut rel_map: HashMap<String, String> = HashMap::new();
+        rel_map.insert("rIdImg".to_string(), "../media/footnote.png".to_string());
+        let media_map = load_media_map(&mut zip, &rel_map, "word/charts/");
+
+        assert_eq!(
+            media_map.get("rIdImg").map(String::as_str),
+            Some("word/media/footnote.png"),
+            "`..` must be normalized so the resolved path is the canonical part name"
         );
     }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Serialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -25,8 +25,10 @@ pub struct Document {
     /// correct CSS generic family (roman→serif, swiss→sans-serif, modern→monospace)
     /// without relying on name-pattern heuristics. Empty when fontTable.xml
     /// is absent or malformed.
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub font_family_classes: HashMap<String, String>,
+    /// Serialized as a `BTreeMap` so JSON key order is deterministic (font names
+    /// sorted), making the parser output byte-stable for identical input.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub font_family_classes: BTreeMap<String, String>,
     /// ECMA-376 §17.13.5 — track-changes events found in the body. Each entry
     /// is one `<w:ins>` or `<w:del>` block, with the change author / date /
     /// text content. Empty when the document has no tracked changes.

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -12,4 +12,5 @@ pub mod color;
 pub mod math;
 pub mod rels;
 pub mod text;
+pub mod theme;
 pub mod zip;

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -10,5 +10,6 @@ pub mod blip;
 pub mod chart;
 pub mod color;
 pub mod math;
+pub mod rels;
 pub mod text;
 pub mod zip;

--- a/packages/ooxml-common/src/rels.rs
+++ b/packages/ooxml-common/src/rels.rs
@@ -1,0 +1,261 @@
+//! OPC relationship (`.rels`) parsing and part-name resolution shared by the
+//! docx, pptx and xlsx parsers.
+//!
+//! Every OOXML package resolves references through the Open Packaging
+//! Conventions relationship grammar (ECMA-376 Part 2 §9.3, ISO/IEC 29500-2):
+//! a `_rels/<part>.rels` file lists `<Relationship Id Type Target
+//! TargetMode?>` entries, and a part references another by relationship id
+//! (`r:id` / `r:embed`). The three parsers had three near-identical private
+//! copies of "parse the rels map" and "resolve a Target against the source
+//! part's directory". Sharing them keeps path resolution byte-identical across
+//! formats — notably the `../` normalization that docx's private copy was
+//! missing (it concatenated `base_dir + target` verbatim, leaving
+//! `word/charts/../media/image.png` unresolved for chart / footnote media).
+//!
+//! Scope is deliberately "types + parse + pure predicate": this module computes
+//! the *zip part name* a relationship points at. It does not read bytes, does
+//! not extract media, and does not know about any host schema — each parser
+//! keeps its own media pipeline and only borrows the resolution logic.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// ECMA-376 Part 2 §9.3.2 `TargetMode`: whether a relationship's `Target`
+/// names a part *inside* the package (`Internal`, the default) or an external
+/// resource such as a hyperlink URL (`External`). External targets are opaque
+/// URLs and must never be run through part-name resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TargetMode {
+    /// `TargetMode="Internal"` (or omitted). `Target` is a package part name,
+    /// relative to the source part's directory (or root-absolute with a leading
+    /// `/`); resolve it with [`resolve_target`].
+    Internal,
+    /// `TargetMode="External"`. `Target` is an absolute URI (hyperlink, linked
+    /// image, etc.) that is used verbatim — never resolved as a zip path.
+    External,
+}
+
+/// A single parsed relationship: its `Target` string exactly as authored, plus
+/// its [`TargetMode`]. The target is kept raw (unresolved) so callers can decide
+/// whether to resolve it as a part name (Internal) or use it as a URL
+/// (External); resolution against a base directory is a separate step
+/// ([`resolve_target`]) because the base differs per source part.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelTarget {
+    /// The `Target` attribute verbatim (e.g. `../media/image1.png`,
+    /// `/word/media/image1.png`, or `https://example.com/`).
+    pub target: String,
+    /// Internal (package part) vs External (opaque URL).
+    pub mode: TargetMode,
+}
+
+/// Parse a `.rels` XML document into a `rId → `[`RelTarget`] map.
+///
+/// Reads every `<Relationship>` child of the root `<Relationships>` element
+/// that carries both an `Id` and a `Target`, recording its `TargetMode`
+/// (`External` when the attribute equals `"External"` case-insensitively, else
+/// `Internal` — the spec default). Malformed XML or an empty string yields an
+/// empty map. The returned [`BTreeMap`] keeps ids in sorted order so any
+/// serialized form is deterministic.
+///
+/// This does not resolve targets to part names — Targets are stored verbatim;
+/// call [`resolve_target`] per source part for Internal entries.
+pub fn parse_rels(xml: &str) -> BTreeMap<String, RelTarget> {
+    let mut map = BTreeMap::new();
+    if xml.is_empty() {
+        return map;
+    }
+    let doc = match roxmltree::Document::parse(xml) {
+        Ok(d) => d,
+        Err(_) => return map,
+    };
+    for rel in doc
+        .root_element()
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "Relationship")
+    {
+        let (Some(id), Some(target)) = (rel.attribute("Id"), rel.attribute("Target")) else {
+            continue;
+        };
+        // TargetMode is optional; only "External" (case-insensitive per the OPC
+        // schema's xsd:string enumeration usage in the wild) diverts a target
+        // away from part-name resolution.
+        let mode = match rel.attribute("TargetMode") {
+            Some(m) if m.eq_ignore_ascii_case("External") => TargetMode::External,
+            _ => TargetMode::Internal,
+        };
+        map.insert(
+            id.to_string(),
+            RelTarget {
+                target: target.to_string(),
+                mode,
+            },
+        );
+    }
+    map
+}
+
+/// Resolve an OPC relationship `Target` to a normalized zip part name.
+///
+/// Two cases, both anchored at the package root (ECMA-376 Part 2 §9.3 — part
+/// names are root-relative, `/`-separated, with no `.`/`..` segments in their
+/// canonical form):
+///
+/// - **Root-absolute** (`Target` starts with `/`, e.g. openpyxl's
+///   `/xl/drawings/drawing1.xml` or `/word/media/image1.png`): resolved from the
+///   package root, ignoring `base_dir`. The leading slash is dropped so the
+///   result is a bare part name that matches a zip entry.
+/// - **Relative** (`../media/image1.png`, `slide1.xml`): resolved against
+///   `base_dir` — the *directory* of the source part (e.g. `xl/drawings` for
+///   `xl/drawings/_rels/drawing1.xml.rels`). `base_dir` may carry a trailing
+///   slash; empty segments are dropped so both `word/` and `xl/worksheets`
+///   forms work.
+///
+/// `..` pops one segment and `.` / empty segments are skipped, yielding a
+/// normalized name with no relative components — so `word/charts` +
+/// `../media/x.png` becomes `word/media/x.png`, never the unresolved
+/// `word/charts/../media/x.png`.
+pub fn resolve_target(base_dir: &str, target: &str) -> String {
+    let mut parts: Vec<&str> = if target.starts_with('/') {
+        // Root-absolute part name: ignore base_dir entirely.
+        Vec::new()
+    } else {
+        base_dir.split('/').filter(|s| !s.is_empty()).collect()
+    };
+    for seg in target.split('/') {
+        match seg {
+            ".." => {
+                parts.pop();
+            }
+            "." | "" => {}
+            s => parts.push(s),
+        }
+    }
+    parts.join("/")
+}
+
+impl RelTarget {
+    /// Resolve this relationship's target against `base_dir`, honoring
+    /// [`TargetMode`]: Internal targets are normalized to a part name via
+    /// [`resolve_target`]; External targets (URLs) are returned verbatim.
+    pub fn resolve(&self, base_dir: &str) -> String {
+        match self.mode {
+            TargetMode::Internal => resolve_target(base_dir, &self.target),
+            TargetMode::External => self.target.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_reads_id_target_and_mode() {
+        let xml = r#"<?xml version="1.0"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Type="…/image" Target="../media/image1.png"/>
+          <Relationship Id="rId2" Type="…/hyperlink" Target="https://example.com/" TargetMode="External"/>
+        </Relationships>"#;
+        let map = parse_rels(xml);
+        assert_eq!(map.len(), 2);
+        assert_eq!(
+            map.get("rId1"),
+            Some(&RelTarget {
+                target: "../media/image1.png".to_string(),
+                mode: TargetMode::Internal,
+            })
+        );
+        assert_eq!(
+            map.get("rId2"),
+            Some(&RelTarget {
+                target: "https://example.com/".to_string(),
+                mode: TargetMode::External,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_defaults_missing_target_mode_to_internal() {
+        let xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Target="slide1.xml"/>
+        </Relationships>"#;
+        assert_eq!(
+            parse_rels(xml).get("rId1").unwrap().mode,
+            TargetMode::Internal
+        );
+    }
+
+    #[test]
+    fn parse_empty_or_malformed_is_empty() {
+        assert!(parse_rels("").is_empty());
+        assert!(parse_rels("<not xml").is_empty());
+    }
+
+    #[test]
+    fn resolve_relative_target_against_base_dir() {
+        // The everyday case: a part references a sibling directory's media.
+        assert_eq!(
+            resolve_target("ppt/slides", "../media/image1.png"),
+            "ppt/media/image1.png"
+        );
+        assert_eq!(
+            resolve_target("xl/worksheets", "../drawings/drawing1.xml"),
+            "xl/drawings/drawing1.xml"
+        );
+    }
+
+    #[test]
+    fn resolve_absolute_leading_slash_ignores_base_dir() {
+        // Root-absolute Targets (openpyxl style) resolve from the package root.
+        assert_eq!(
+            resolve_target("ppt/slides", "/ppt/charts/chart5.xml"),
+            "ppt/charts/chart5.xml"
+        );
+        assert_eq!(
+            resolve_target("xl/drawings", "/xl/charts/chart1.xml"),
+            "xl/charts/chart1.xml"
+        );
+        // A trailing-slash base (docx's "word/" convention) is irrelevant for
+        // absolute targets and must not leak in.
+        assert_eq!(
+            resolve_target("word/", "/word/media/image1.png"),
+            "word/media/image1.png"
+        );
+    }
+
+    #[test]
+    fn resolve_multi_level_dotdot_normalizes() {
+        // Deeply nested relative targets fully normalize — this is exactly the
+        // case docx's old `format!("{}{}", base_dir, target)` left unresolved.
+        assert_eq!(
+            resolve_target("word/charts", "../../media/deep.png"),
+            "media/deep.png"
+        );
+        assert_eq!(
+            resolve_target("word/charts", "../media/chart_img.png"),
+            "word/media/chart_img.png"
+        );
+        // Trailing-slash base with a single `..` (docx "word/" convention).
+        assert_eq!(
+            resolve_target("word/", "../media/footnote.png"),
+            "media/footnote.png"
+        );
+    }
+
+    #[test]
+    fn resolve_via_rel_target_honors_external() {
+        let internal = RelTarget {
+            target: "../media/image1.png".to_string(),
+            mode: TargetMode::Internal,
+        };
+        assert_eq!(internal.resolve("ppt/slides"), "ppt/media/image1.png");
+        let external = RelTarget {
+            target: "https://example.com/x".to_string(),
+            mode: TargetMode::External,
+        };
+        // External targets pass through untouched regardless of base_dir.
+        assert_eq!(external.resolve("ppt/slides"), "https://example.com/x");
+    }
+}

--- a/packages/ooxml-common/src/theme.rs
+++ b/packages/ooxml-common/src/theme.rs
@@ -1,0 +1,335 @@
+//! DrawingML theme parsing (`<a:theme>`) shared by the docx, pptx and xlsx
+//! parsers.
+//!
+//! Every OOXML host embeds the same theme grammar (ECMA-376 §20.1.6 /
+//! §14.2.7 / §20.1.4.1): a `<a:clrScheme>` of twelve named color slots, a
+//! `<a:fontScheme>` with major/minor typefaces per script, and a
+//! `<a:fmtScheme><a:lnStyleLst>` of reference line widths. The three parsers had
+//! three partial, drifting copies — pptx resolved `<a:prstClr>` preset names
+//! while docx and xlsx silently dropped them; xlsx never read the font scheme;
+//! docx never read line styles. Consolidating the *parse* here fixes the prstClr
+//! gap uniformly (a preset color now resolves in all three formats) while each
+//! parser keeps its own thin key-format adapter and color casing.
+//!
+//! Scope is "types + parse + pure predicate". This module reads the theme XML
+//! into owned structs and stores each color slot's hex **exactly as authored**
+//! (the `srgbClr@val` / `sysClr@lastClr` string verbatim, or a preset's
+//! canonical hex). Case-folding, `#` prefixing, logical-name (`clrMap`)
+//! resolution and the runtime color transforms (lumMod/tint/…) are NOT here —
+//! they diverge per host and stay in each parser / the renderer.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// DrawingML main namespace — the `a:` elements a theme is built from.
+const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+/// The twelve `<a:clrScheme>` slot names in ECMA-376 §20.1.6.2 declaration
+/// order: `dk1`, `lt1`, `dk2`, `lt2`, `accent1`..`accent6`, `hlink`,
+/// `folHlink`. Exposed so a consumer that needs positional order (xlsx indexes
+/// its palette by slot ordinal) can iterate without hard-coding the list.
+pub const CLR_SCHEME_SLOTS: [&str; 12] = [
+    "dk1", "lt1", "dk2", "lt2", "accent1", "accent2", "accent3", "accent4", "accent5", "accent6",
+    "hlink", "folHlink",
+];
+
+/// The parsed `<a:clrScheme>`: slot name → hex string, stored **raw** (as
+/// authored — no `#`, no case-folding). Keys are the twelve slot names present
+/// in the theme; a slot whose color could not be read (unsupported child, or a
+/// `prstClr` name outside [`preset_color`]) is simply absent.
+///
+/// A [`BTreeMap`] backs it so any serialized form is deterministic; lookups by
+/// slot name are the common case ([`ThemeColorScheme::get`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThemeColorScheme {
+    colors: BTreeMap<String, String>,
+}
+
+impl ThemeColorScheme {
+    /// Parse the `<a:clrScheme>` from a theme XML document. Each slot child holds
+    /// one color element; `srgbClr` contributes its `val`, `sysClr` its
+    /// `lastClr`, and `prstClr` its [`preset_color`] hex. The stored string is
+    /// verbatim (the caller applies any casing / `#` prefix). Missing scheme or
+    /// malformed XML yields an empty scheme.
+    pub fn parse(xml: &str) -> Self {
+        let mut colors = BTreeMap::new();
+        let Ok(doc) = roxmltree::Document::parse(xml) else {
+            return Self { colors };
+        };
+        let Some(scheme) = doc
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "clrScheme")
+        else {
+            return Self { colors };
+        };
+        for slot in scheme.children().filter(|n| n.is_element()) {
+            let name = slot.tag_name().name().to_owned();
+            for c in slot.children().filter(|n| n.is_element()) {
+                let hex = color_node_hex(c);
+                if let Some(h) = hex {
+                    colors.insert(name, h);
+                    break;
+                }
+            }
+        }
+        Self { colors }
+    }
+
+    /// Look up a slot's raw hex by name (`dk1`, `accent1`, `hlink`, …).
+    pub fn get(&self, slot: &str) -> Option<&str> {
+        self.colors.get(slot).map(String::as_str)
+    }
+
+    /// The twelve slots in spec order (`CLR_SCHEME_SLOTS`), each `Some(raw hex)`
+    /// when present. Lets a positional consumer (xlsx builds a `Vec` indexed by
+    /// ordinal) reconstruct its ordered palette while dropping absent slots as it
+    /// sees fit.
+    pub fn slots_in_order(&self) -> [Option<&str>; 12] {
+        CLR_SCHEME_SLOTS.map(|slot| self.get(slot))
+    }
+
+    /// Iterate slot-name → raw-hex pairs (sorted by slot name). For a host that
+    /// stores the palette in its own string-keyed map.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.colors.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
+    /// True when no slot color was parsed.
+    pub fn is_empty(&self) -> bool {
+        self.colors.is_empty()
+    }
+}
+
+/// Resolve a single DrawingML color element to its raw hex, covering the three
+/// forms a `<a:clrScheme>` slot uses: `srgbClr@val`, `sysClr@lastClr`, and
+/// `prstClr@val` (via [`preset_color`]). Other elements (e.g. `scheme`-relative
+/// colors, which never appear inside a theme's own scheme) yield `None`. The
+/// returned string is verbatim — no casing or `#` is applied.
+fn color_node_hex(node: roxmltree::Node<'_, '_>) -> Option<String> {
+    match node.tag_name().name() {
+        "srgbClr" => node.attribute("val").map(str::to_owned),
+        "sysClr" => node.attribute("lastClr").map(str::to_owned),
+        "prstClr" => preset_color(node.attribute("val").unwrap_or_default()),
+        _ => None,
+    }
+}
+
+/// The parsed `<a:fontScheme>`: the major (heading) and minor (body) typeface
+/// for each script axis. Stored as owned strings; a script with no `typeface`
+/// (or an empty one) is `None`. Each parser maps these onto its own key format
+/// (pptx `+mj-lt`, docx `major/latin`, …) in its adapter.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThemeFonts {
+    /// `<a:majorFont>` typefaces (latin / ea / cs).
+    pub major: ThemeFontGroup,
+    /// `<a:minorFont>` typefaces (latin / ea / cs).
+    pub minor: ThemeFontGroup,
+}
+
+/// The three script typefaces of one font group (`<a:majorFont>` or
+/// `<a:minorFont>`): Latin (`<a:latin>`), East-Asian (`<a:ea>`) and
+/// complex-script (`<a:cs>`). Empty `typeface=""` (common for `ea`/`cs`) is
+/// normalized to `None`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThemeFontGroup {
+    pub latin: Option<String>,
+    pub ea: Option<String>,
+    pub cs: Option<String>,
+}
+
+impl ThemeFonts {
+    /// Parse the `<a:fontScheme>` (major + minor × latin/ea/cs). Missing scheme
+    /// or malformed XML yields all-`None`.
+    pub fn parse(xml: &str) -> Self {
+        let Ok(doc) = roxmltree::Document::parse(xml) else {
+            return Self::default();
+        };
+        let Some(scheme) = doc
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "fontScheme")
+        else {
+            return Self::default();
+        };
+        Self {
+            major: parse_font_group(scheme, "majorFont"),
+            minor: parse_font_group(scheme, "minorFont"),
+        }
+    }
+}
+
+/// Read one `<a:majorFont>` / `<a:minorFont>` child's latin/ea/cs typefaces.
+fn parse_font_group(scheme: roxmltree::Node<'_, '_>, group_name: &str) -> ThemeFontGroup {
+    let Some(group) = scheme
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == group_name)
+    else {
+        return ThemeFontGroup::default();
+    };
+    let read = |axis: &str| -> Option<String> {
+        group
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == axis)
+            .and_then(|n| n.attribute("typeface"))
+            .filter(|t| !t.is_empty())
+            .map(str::to_owned)
+    };
+    ThemeFontGroup {
+        latin: read("latin"),
+        ea: read("ea"),
+        cs: read("cs"),
+    }
+}
+
+/// Parse `<a:fmtScheme><a:lnStyleLst>` line-reference widths (EMU), in
+/// declaration order. A drawing shape's `<a:style><a:lnRef idx="N">` resolves
+/// its outline width from entry N (1-based) of this list (ECMA-376 §20.1.4.2.19);
+/// an `<a:ln>` without an explicit `w` uses the CT_LineProperties default 9525
+/// EMU = 0.75 pt (§20.1.2.2.24). Missing scheme or malformed XML yields an empty
+/// list.
+pub fn parse_ln_style_widths(xml: &str) -> Vec<i64> {
+    let Ok(doc) = roxmltree::Document::parse(xml) else {
+        return Vec::new();
+    };
+    for node in doc.descendants() {
+        if node.tag_name().name() == "lnStyleLst" && node.tag_name().namespace() == Some(A_NS) {
+            return node
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "ln")
+                .map(|ln| {
+                    ln.attribute("w")
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(9525)
+                })
+                .collect();
+        }
+    }
+    Vec::new()
+}
+
+/// Resolve a DrawingML `<a:prstClr>` preset color name (ECMA-376 §20.1.10.48
+/// ST_PresetColorVal) to its canonical uppercase hex. Covers the presets that
+/// appear in real theme scheme slots; unrecognized names yield `None` (the
+/// caller leaves the slot unset). Single source of truth for the three parsers,
+/// which previously either handled a subset (pptx) or none (docx/xlsx).
+pub fn preset_color(name: &str) -> Option<String> {
+    let hex = match name {
+        "black" => "000000",
+        "white" => "FFFFFF",
+        "red" => "FF0000",
+        "green" => "008000",
+        "blue" => "0000FF",
+        "yellow" => "FFFF00",
+        "cyan" => "00FFFF",
+        "magenta" => "FF00FF",
+        "orange" => "FFA500",
+        "gray" | "grey" => "808080",
+        "darkGray" | "darkGrey" => "404040",
+        "lightGray" | "lightGrey" => "D3D3D3",
+        _ => return None,
+    };
+    Some(hex.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const THEME: &str = r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <a:themeElements>
+        <a:clrScheme name="Office">
+          <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+          <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+          <a:dk2><a:srgbClr val="44546A"/></a:dk2>
+          <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+          <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+          <a:accent2><a:prstClr val="orange"/></a:accent2>
+          <a:hlink><a:srgbClr val="0563C1"/></a:hlink>
+          <a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+        </a:clrScheme>
+        <a:fontScheme name="Office">
+          <a:majorFont>
+            <a:latin typeface="Aptos Display"/>
+            <a:ea typeface="Yu Gothic"/>
+            <a:cs typeface=""/>
+          </a:majorFont>
+          <a:minorFont>
+            <a:latin typeface="Aptos"/>
+            <a:ea typeface=""/>
+            <a:cs typeface=""/>
+          </a:minorFont>
+        </a:fontScheme>
+        <a:fmtScheme name="Office">
+          <a:lnStyleLst>
+            <a:ln w="6350"/>
+            <a:ln w="12700"/>
+            <a:ln/>
+          </a:lnStyleLst>
+        </a:fmtScheme>
+      </a:themeElements>
+    </a:theme>"#;
+
+    #[test]
+    fn clr_scheme_reads_srgb_sys_and_preset_raw() {
+        let s = ThemeColorScheme::parse(THEME);
+        // sysClr uses lastClr, srgbClr uses val — both raw (as authored).
+        assert_eq!(s.get("dk1"), Some("000000"));
+        assert_eq!(s.get("lt1"), Some("FFFFFF"));
+        assert_eq!(s.get("dk2"), Some("44546A"));
+        assert_eq!(s.get("accent1"), Some("4472C4"));
+        // prstClr resolves through preset_color (uniform across formats).
+        assert_eq!(s.get("accent2"), Some("FFA500"));
+        assert_eq!(s.get("hlink"), Some("0563C1"));
+        // Slots not present in the XML are absent (not empty strings).
+        assert_eq!(s.get("accent3"), None);
+    }
+
+    #[test]
+    fn clr_scheme_slots_in_order_matches_spec_positions() {
+        let s = ThemeColorScheme::parse(THEME);
+        let ordered = s.slots_in_order();
+        assert_eq!(ordered[0], Some("000000")); // dk1
+        assert_eq!(ordered[1], Some("FFFFFF")); // lt1
+        assert_eq!(ordered[4], Some("4472C4")); // accent1
+        assert_eq!(ordered[5], Some("FFA500")); // accent2 (preset)
+        assert_eq!(ordered[6], None); // accent3 absent
+        assert_eq!(ordered[10], Some("0563C1")); // hlink
+    }
+
+    #[test]
+    fn font_scheme_reads_axes_and_drops_empty() {
+        let f = ThemeFonts::parse(THEME);
+        assert_eq!(f.major.latin.as_deref(), Some("Aptos Display"));
+        assert_eq!(f.major.ea.as_deref(), Some("Yu Gothic"));
+        // Empty typeface="" normalizes to None (not Some("")).
+        assert_eq!(f.major.cs, None);
+        assert_eq!(f.minor.latin.as_deref(), Some("Aptos"));
+        assert_eq!(f.minor.ea, None);
+        assert_eq!(f.minor.cs, None);
+    }
+
+    #[test]
+    fn ln_style_widths_reads_list_with_default() {
+        // Third <a:ln> has no w → CT_LineProperties default 9525.
+        assert_eq!(parse_ln_style_widths(THEME), vec![6350, 12700, 9525]);
+    }
+
+    #[test]
+    fn preset_color_covers_named_presets() {
+        assert_eq!(preset_color("black").as_deref(), Some("000000"));
+        assert_eq!(preset_color("white").as_deref(), Some("FFFFFF"));
+        assert_eq!(preset_color("gray").as_deref(), Some("808080"));
+        assert_eq!(preset_color("grey").as_deref(), Some("808080"));
+        assert_eq!(preset_color("orange").as_deref(), Some("FFA500"));
+        // Unknown → None (caller leaves the slot unset).
+        assert_eq!(preset_color("chartreuse"), None);
+    }
+
+    #[test]
+    fn empty_and_malformed_yield_empty() {
+        assert!(ThemeColorScheme::parse("").is_empty());
+        assert!(ThemeColorScheme::parse("<not xml").is_empty());
+        assert_eq!(ThemeFonts::parse(""), ThemeFonts::default());
+        assert!(parse_ln_style_widths("").is_empty());
+    }
+}

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2007,42 +2007,46 @@ fn resolve_path(base_dir: &str, target: &str) -> String {
 
 /// Parse the color scheme from a theme XML file.
 /// Returns a map: scheme slot name (e.g. "dk1", "lt1", "acc1") → hex string.
+///
+/// The clrScheme and fontScheme are parsed by the shared
+/// [`ooxml_common::theme`] grammar; this function keeps pptx's flat merged-map
+/// storage (colors, `+mj-lt`/`+mn-*` font keys, `+lnRef-N` line widths and
+/// `+txDef`/`+spDef` object defaults all in one `HashMap<String, String>`)
+/// because ~30 call sites look these up by string key. The lnStyleLst and
+/// objectDefaults handling stays local — the former's "record only entries with
+/// an explicit `w`, as a raw string" contract differs from the shared
+/// default-filling `parse_ln_style_widths`, and the latter is pptx-specific.
 fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
+
+    // Color slots: shared parse, kept RAW (pptx applies no case-folding, unlike
+    // docx/xlsx). prstClr is now resolved via the shared preset table.
+    for (slot, hex) in ooxml_common::theme::ThemeColorScheme::parse(xml).iter() {
+        map.insert(slot.to_owned(), hex.to_owned());
+    }
+
+    // Font scheme: shared parse, mapped onto pptx's `+mj-*` / `+mn-*` keys.
+    let fonts = ooxml_common::theme::ThemeFonts::parse(xml);
+    for (group, prefix) in [(&fonts.major, "+mj"), (&fonts.minor, "+mn")] {
+        for (face, axis) in [(&group.latin, "lt"), (&group.ea, "ea"), (&group.cs, "cs")] {
+            if let Some(typeface) = face {
+                map.insert(format!("{prefix}-{axis}"), typeface.clone());
+            }
+        }
+    }
+
     let doc = match roxmltree::Document::parse(xml) {
         Ok(d) => d,
         Err(_) => return map,
     };
     let root = doc.root_element();
 
-    let clr_scheme = match root
-        .descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "clrScheme")
-    {
-        Some(n) => n,
-        None => return map,
-    };
-    // Each child of clrScheme is a slot: dk1, lt1, dk2, lt2, acc1–acc6, hlink, folHlink
-    for slot in clr_scheme.children().filter(|n| n.is_element()) {
-        let name = slot.tag_name().name().to_owned();
-        // The slot contains exactly one color child; parse it without theme context
-        for c in slot.children().filter(|n| n.is_element()) {
-            let hex = match c.tag_name().name() {
-                "srgbClr" => attr(&c, "val"),
-                "sysClr" => attr(&c, "lastClr"),
-                "prstClr" => preset_color(attr(&c, "val").unwrap_or_default().as_str()),
-                _ => None,
-            };
-            if let Some(h) = hex {
-                map.insert(name, h);
-                break;
-            }
-        }
-    }
-
     // Parse fmtScheme > lnStyleLst so lnRef idx="N" can resolve to the theme's
     // canonical stroke width (9525 is wrong; theme defines 12700 / 19050 / 25400).
-    // Stored under "+lnRef-1", "+lnRef-2", "+lnRef-3".
+    // Stored under "+lnRef-1", "+lnRef-2", "+lnRef-3". Kept local: only entries
+    // that declare an explicit `w` get a key (a bare `<a:ln/>` is skipped, unlike
+    // the shared helper which fills the CT_LineProperties 9525 default), and the
+    // value is the raw `w` string the consumer re-parses.
     if let Some(fmt_scheme) = root
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "fmtScheme")
@@ -2055,32 +2059,6 @@ fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
             {
                 if let Some(w) = attr(&ln, "w") {
                     map.insert(format!("+lnRef-{}", i + 1), w);
-                }
-            }
-        }
-    }
-
-    // Parse font scheme: majorFont (+mj-lt, +mj-ea, +mj-cs) and minorFont (+mn-lt, +mn-ea, +mn-cs)
-    // Store as special keys in the theme map so the renderer can resolve +mj-lt → actual typeface.
-    if let Some(font_scheme) = root
-        .descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "fontScheme")
-    {
-        let pairs: &[(&str, &[&str])] = &[
-            ("majorFont", &["+mj-lt", "+mj-ea", "+mj-cs"]),
-            ("minorFont", &["+mn-lt", "+mn-ea", "+mn-cs"]),
-        ];
-        let scripts = ["latin", "ea", "cs"];
-        for (element_name, keys) in pairs {
-            if let Some(font_node) = child(font_scheme, element_name) {
-                for (script, key) in scripts.iter().zip(keys.iter()) {
-                    if let Some(typeface) =
-                        child(font_node, script).and_then(|n| attr(&n, "typeface"))
-                    {
-                        if !typeface.is_empty() {
-                            map.insert(key.to_string(), typeface.to_string());
-                        }
-                    }
                 }
             }
         }
@@ -2342,23 +2320,11 @@ fn parse_color_node_tint(
     None
 }
 
+/// Resolve a DrawingML `<a:prstClr>` preset name to hex. Thin alias for the
+/// shared [`ooxml_common::theme::preset_color`] (the single source of truth),
+/// kept as a local name so the `prstClr` call sites read unchanged.
 fn preset_color(name: &str) -> Option<String> {
-    let hex = match name {
-        "black" => "000000",
-        "white" => "FFFFFF",
-        "red" => "FF0000",
-        "green" => "008000",
-        "blue" => "0000FF",
-        "yellow" => "FFFF00",
-        "cyan" => "00FFFF",
-        "magenta" => "FF00FF",
-        "orange" => "FFA500",
-        "gray" | "grey" => "808080",
-        "darkGray" | "darkGrey" => "404040",
-        "lightGray" | "lightGrey" => "D3D3D3",
-        _ => return None,
-    };
-    Some(hex.to_owned())
+    ooxml_common::theme::preset_color(name)
 }
 
 // ===========================

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1917,19 +1917,16 @@ fn attr_f64(node: &roxmltree::Node<'_, '_>, local: &str) -> Option<f64> {
 //  Relationships helpers
 // ===========================
 
-/// id → target  (used for image/slide lookups by rId)
+/// id → target  (used for image/slide lookups by rId). Thin adapter over
+/// [`ooxml_common::rels::parse_rels`] that flattens each `RelTarget` back to its
+/// raw target string (both Internal part names and External URLs are kept
+/// verbatim — resolution to a zip part happens later via [`resolve_path`]),
+/// preserving this parser's long-standing `HashMap<rId, Target>` shape.
 fn parse_rels(xml: &str) -> HashMap<String, String> {
-    let doc = match roxmltree::Document::parse(xml) {
-        Ok(d) => d,
-        Err(_) => return HashMap::new(),
-    };
-    let mut map = HashMap::new();
-    for rel in doc.root_element().children().filter(|n| n.is_element()) {
-        if let (Some(id), Some(target)) = (attr(&rel, "Id"), attr(&rel, "Target")) {
-            map.insert(id, target);
-        }
-    }
-    map
+    ooxml_common::rels::parse_rels(xml)
+        .into_iter()
+        .map(|(id, rel)| (id, rel.target))
+        .collect()
 }
 
 /// Pair diagramData rels with diagramDrawing rels in a slide's rels XML by filename
@@ -1995,29 +1992,13 @@ fn find_rel_target_by_type(rels_xml: &str, type_suffix: &str) -> Option<String> 
 }
 
 /// Resolve a relative path against a base directory inside the ZIP.
+///
+/// Thin alias for the shared [`ooxml_common::rels::resolve_target`], which
+/// handles both root-absolute (`/ppt/charts/chart5.xml`) and relative
+/// (`../charts/chart1.xml`) Targets with `..` normalization (ECMA-376 Part 2
+/// §9.3). Kept as a local name so the many call sites read unchanged.
 fn resolve_path(base_dir: &str, target: &str) -> String {
-    // A relationship Target beginning with "/" is a package-root-absolute part
-    // name (e.g. `/ppt/charts/chart5.xml`), not a reference relative to the
-    // source part's directory. Resolve it from the package root and ignore
-    // `base_dir`; otherwise the base is prepended, yielding a path that doesn't
-    // exist in the archive (OPC part names are root-anchored when they start
-    // with "/" — ECMA-376 Part 2 §9.3). xlsx::resolve_zip_path and docx's
-    // media path resolution already handle this; pptx was the outlier.
-    let mut parts: Vec<&str> = if target.starts_with('/') {
-        Vec::new()
-    } else {
-        base_dir.split('/').collect()
-    };
-    for seg in target.split('/') {
-        match seg {
-            ".." => {
-                parts.pop();
-            }
-            "." | "" => {}
-            s => parts.push(s),
-        }
-    }
-    parts.join("/")
+    ooxml_common::rels::resolve_target(base_dir, target)
 }
 
 // ===========================

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -289,71 +289,28 @@ pub(crate) fn parse_theme_ln_widths(archive: &mut XlsxZip) -> Vec<i64> {
     let Ok(xml) = read_zip_string(archive, "xl/theme/theme1.xml") else {
         return Vec::new();
     };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else {
-        return Vec::new();
-    };
-    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
-    let mut widths: Vec<i64> = Vec::new();
-    for node in doc.descendants() {
-        if node.tag_name().name() == "lnStyleLst" && node.tag_name().namespace() == Some(a_ns) {
-            for ln in node
-                .children()
-                .filter(|n| n.is_element() && n.tag_name().name() == "ln")
-            {
-                widths.push(
-                    ln.attribute("w")
-                        .and_then(|s| s.parse().ok())
-                        .unwrap_or(9525),
-                );
-            }
-            break;
-        }
-    }
-    widths
+    // Shared parse: reference line widths (EMU) in declaration order, filling the
+    // CT_LineProperties 9525 default for a bare `<a:ln>` — matching xlsx's prior
+    // behavior exactly (ECMA-376 §20.1.4.2.19 / §20.1.2.2.24).
+    ooxml_common::theme::parse_ln_style_widths(&xml)
 }
 
 fn parse_theme_colors(archive: &mut XlsxZip) -> Vec<String> {
     let Ok(xml) = read_zip_string(archive, "xl/theme/theme1.xml") else {
         return Vec::new();
     };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else {
-        return Vec::new();
-    };
-    let a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
-
-    // Find clrScheme node and collect child color elements in order
-    // OOXML order: dk1, lt1, dk2, lt2, accent1, accent2, accent3, accent4, accent5, accent6, hlink, folHlink
-    let mut colors: Vec<String> = Vec::new();
-    for node in doc.descendants() {
-        if node.tag_name().name() == "clrScheme" && node.tag_name().namespace() == Some(a_ns) {
-            for child in node.children() {
-                if !child.is_element() {
-                    continue;
-                }
-                // Each child is a color slot; its first child element holds the actual color
-                for color_node in child.children() {
-                    if !color_node.is_element() {
-                        continue;
-                    }
-                    let hex = match color_node.tag_name().name() {
-                        "srgbClr" => color_node
-                            .attribute("val")
-                            .map(|v| format!("#{}", v.to_uppercase())),
-                        "sysClr" => color_node
-                            .attribute("lastClr")
-                            .map(|v| format!("#{}", v.to_uppercase())),
-                        _ => None,
-                    };
-                    if let Some(h) = hex {
-                        colors.push(h);
-                        break;
-                    }
-                }
-            }
-            break;
-        }
-    }
-    colors
+    // Shared clrScheme parse; xlsx keeps its own `#RRGGBB` uppercase formatting
+    // and positional (spec-order) Vec. Slots are emitted in the canonical order
+    // dk1, lt1, dk2, lt2, accent1..6, hlink, folHlink; a slot with no readable
+    // color is skipped (compacting the Vec), preserving the prior contract.
+    // prstClr now resolves through the shared preset table (previously dropped),
+    // so a preset scheme slot contributes its color instead of being skipped.
+    ooxml_common::theme::ThemeColorScheme::parse(&xml)
+        .slots_in_order()
+        .into_iter()
+        .flatten()
+        .map(|hex| format!("#{}", hex.to_uppercase()))
+        .collect()
 }
 
 /// Convert hex color + tint to resulting hex color using HLS model.

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{Cursor, Read};
 use wasm_bindgen::prelude::*;
 
@@ -669,8 +669,8 @@ fn parse_worksheet(
     let r_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
     let mut rows = Vec::new();
-    let mut col_widths: HashMap<u32, f64> = HashMap::new();
-    let mut row_heights: HashMap<u32, f64> = HashMap::new();
+    let mut col_widths: BTreeMap<u32, f64> = BTreeMap::new();
+    let mut row_heights: BTreeMap<u32, f64> = BTreeMap::new();
     let mut merge_cells: Vec<MergeCell> = Vec::new();
     let mut freeze_rows: u32 = 0;
     let mut freeze_cols: u32 = 0;
@@ -2316,6 +2316,39 @@ mod sheet_view_tests {
         );
         let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
         assert_eq!(ws.col_widths.get(&2).copied(), Some(10.0));
+    }
+
+    /// The serialized worksheet JSON is deterministic: `colWidths` keys come out
+    /// in ascending column order regardless of `<col>` declaration order, and
+    /// two serializations of the same parse are byte-identical. This is the
+    /// BTreeMap guarantee — with the former `HashMap` field the key order
+    /// followed the randomized hash seed, so identical input could serialize to
+    /// different byte streams across runs.
+    #[test]
+    fn worksheet_json_is_deterministic_and_key_ordered() {
+        // Columns declared out of order (3, then 1, then 2).
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols>
+                 <col customWidth="1" min="3" max="3" width="30"/>
+                 <col customWidth="1" min="1" max="1" width="10"/>
+                 <col customWidth="1" min="2" max="2" width="20"/>
+               </cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        let json = serde_json::to_string(&ws).expect("serialize");
+        // Two serializations of the same value are byte-identical.
+        assert_eq!(json, serde_json::to_string(&ws).expect("serialize"));
+
+        // colWidths keys appear in ascending column order in the JSON string.
+        let widths = &json[json.find("\"colWidths\"").expect("colWidths present")..];
+        let p1 = widths.find("\"1\"").expect("col 1 key");
+        let p2 = widths.find("\"2\"").expect("col 2 key");
+        let p3 = widths.find("\"3\"").expect("col 3 key");
+        assert!(
+            p1 < p2 && p2 < p3,
+            "colWidths keys must serialize in ascending order (1,2,3), got positions {p1},{p2},{p3} in {widths}"
+        );
     }
 }
 

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1323,17 +1323,16 @@ fn parse_worksheet(
 }
 
 /// Parse a .rels file into rId → Target map.
+/// id → target map for a `.rels` part. Thin adapter over
+/// [`ooxml_common::rels::parse_rels`] that flattens each `RelTarget` to its raw
+/// target string (both Internal part names and External hyperlink URLs are kept
+/// verbatim; part-name resolution happens later via [`resolve_zip_path`]),
+/// preserving this parser's `HashMap<rId, Target>` shape.
 pub(crate) fn parse_rels_map(xml: &str) -> HashMap<String, String> {
-    let Ok(doc) = roxmltree::Document::parse(xml) else {
-        return HashMap::new();
-    };
-    let mut map = HashMap::new();
-    for rel in doc.root_element().children().filter(|n| n.is_element()) {
-        if let (Some(id), Some(target)) = (rel.attribute("Id"), rel.attribute("Target")) {
-            map.insert(id.to_string(), target.to_string());
-        }
-    }
-    map
+    ooxml_common::rels::parse_rels(xml)
+        .into_iter()
+        .map(|(id, rel)| (id, rel.target))
+        .collect()
 }
 
 /// Parse xl/comments{N}.xml referenced from the sheet's rels and collect the
@@ -1640,28 +1639,13 @@ fn load_hyperlinks(
         .collect()
 }
 
-/// Resolve a relative path ("../media/image1.png") against a base dir ("xl/drawings").
+/// Resolve a relative path ("../media/image1.png") against a base dir
+/// ("xl/drawings"). Thin alias for the shared
+/// [`ooxml_common::rels::resolve_target`], which handles root-absolute Targets
+/// (openpyxl's `/xl/...`) and `..` normalization uniformly (ECMA-376 Part 2
+/// §9.3). Kept as a local name so existing call sites read unchanged.
 pub(crate) fn resolve_zip_path(base_dir: &str, target: &str) -> String {
-    // An absolute Target (leading "/", e.g. openpyxl's
-    // `/xl/drawings/drawing1.xml`) is package-root-relative and must ignore
-    // `base_dir`; otherwise the base would be prepended, producing a path that
-    // doesn't exist in the archive (ECMA-376 / OPC part names are root-anchored
-    // when they start with "/").
-    let mut parts: Vec<&str> = if target.starts_with('/') {
-        Vec::new()
-    } else {
-        base_dir.split('/').filter(|s| !s.is_empty()).collect()
-    };
-    for seg in target.split('/') {
-        match seg {
-            ".." => {
-                parts.pop();
-            }
-            "." | "" => {}
-            s => parts.push(s),
-        }
-    }
-    parts.join("/")
+    ooxml_common::rels::resolve_target(base_dir, target)
 }
 
 pub(crate) fn resolve_fill_color(

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -58,8 +58,11 @@ pub struct MergeCell {
 pub struct Worksheet {
     pub name: String,
     pub rows: Vec<Row>,
-    pub col_widths: HashMap<u32, f64>,
-    pub row_heights: HashMap<u32, f64>,
+    /// Serialized as `BTreeMap`s so JSON key order is deterministic (columns /
+    /// rows in ascending index order), making the parser output byte-stable for
+    /// identical input.
+    pub col_widths: BTreeMap<u32, f64>,
+    pub row_heights: BTreeMap<u32, f64>,
     pub default_col_width: f64,
     pub default_row_height: f64,
     pub merge_cells: Vec<MergeCell>,


### PR DESCRIPTION
## Summary

Phase 3 items D5 / D6 + the BTreeMap determinism follow-up from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md).

### D6 — `ooxml_common::rels`
`parse_rels` (BTreeMap of `RelTarget { target, mode: Internal|External }`) + `resolve_target` (leading-slash **and** `../` normalization in one impl). All three parsers now delegate via thin local aliases. Inspection corrected the plan: leading-slash was already handled by all three (not just pptx); the real gap was **docx's `load_media_map` passing un-normalized `../` targets to the ZIP** — now routed through `resolve_target` with a pinning test. No sample in the corpus uses `..` targets, so output is unchanged (latent robustness fix).

### D5 — `ooxml_common::theme`
`ThemeColorScheme` (12 slots, srgb/sys/**prst**), `ThemeFonts` (major/minor × latin/ea/cs), `parse_ln_style_widths`, and `preset_color` moved from pptx. Each parser keeps a thin adapter preserving its exact output shape (pptx flat map with `+mj-lt` keys + raw hex; xlsx positional Vec; docx slot map) — **byte-stable output**. xlsx/docx gain prstClr resolution (no corpus sample uses it in clrScheme — latent). Deliberately NOT shared: pptx's lnStyleLst (different contract: raw string, explicit-`w`-only) and objectDefaults (pptx-only) — per the no-false-abstraction rule.

### Deterministic JSON
Exhaustive sweep of serialized `HashMap` fields found exactly three — xlsx `colWidths`/`rowHeights`, docx `fontFamilyClasses` — now `BTreeMap` (the pre-existing nondeterminism surfaced in #671). New test pins two consecutive parses byte-identical with ordered keys.

## Verification
- cargo fmt / clippy -D warnings / test --workspace (478, +14 new) — green
- pnpm build:wasm → test (1555) / typecheck / lint — green
- pnpm smoke 6/6; **VRT: pptx 75 / xlsx 67 / docx 21 — all pass, output unchanged**, references untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)