### PR TITLE
refactor(core): width-based chart-label elision replaces char-count slicing (A7)

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -7,6 +7,7 @@ import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
 import { niceStep, valueAxisScale } from './axis-scale.js';
 import { axisLineWidthPx, resolveAxisLine, isCrossBetween } from './axis-style.js';
 import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
+import { elideToWidth } from './text-elide.js';
 import { hexToRgba } from '../shape/paint.js';
 import { EMU_PER_PT, PT_TO_PX } from '../units.js';
 
@@ -84,18 +85,23 @@ function drawAxisTitle(
   fontSizePx: number,
   bold: boolean,
   color: string,
+  // Available run length along the axis (plot width for the bottom cat title,
+  // plot height for the rotated val title). Titles longer than the axis are
+  // elided with an ellipsis rather than hard-cut at a fixed char count.
+  maxPx: number,
 ): void {
   ctx.save();
   ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px sans-serif`;
   ctx.fillStyle = color;
+  const label = elideToWidth(ctx, text, maxPx);
   if (axis === 'cat') {
     ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    ctx.fillText(text.slice(0, 60), anchorX, anchorY);
+    ctx.fillText(label, anchorX, anchorY);
   } else {
     ctx.translate(anchorX, anchorY);
     ctx.rotate(-Math.PI / 2);
     ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    ctx.fillText(text.slice(0, 60), 0, 0);
+    ctx.fillText(label, 0, 0);
   }
   ctx.restore();
 }
@@ -155,17 +161,21 @@ function drawAxisTitles(
   if (chart.valAxisTitle) {
     const anchorX = x + legLeftW + axisTitleMargin(w) + valTitlePx / 2;
     const anchorY = py0 + ph / 2;
+    // The val title is rotated -90°, so it runs along the plot HEIGHT.
     drawAxisTitle(
       ctx, chart.valAxisTitle, anchorX, anchorY, 'val',
       valTitlePx, chart.valAxisTitleFontBold ?? true, axisTitleColor(chart.valAxisTitleFontColor),
+      ph,
     );
   }
   if (chart.catAxisTitle) {
     const anchorX = px0 + pw / 2;
     const anchorY = y + h - legBottomH - axisTitleMargin(h) - catTitlePx / 2;
+    // The cat title runs horizontally along the plot WIDTH.
     drawAxisTitle(
       ctx, chart.catAxisTitle, anchorX, anchorY, 'cat',
       catTitlePx, chart.catAxisTitleFontBold ?? true, axisTitleColor(chart.catAxisTitleFontColor),
+      pw,
     );
   }
 }
@@ -253,14 +263,24 @@ function drawLegend(
     ctx.font = `${fontSize}px sans-serif`;
     ctx.textBaseline = 'middle';
     const itemGap = 12;
-    const itemWidths = entries.map((e) => sw + gap + ctx.measureText(e.label.slice(0, 30)).width);
-    const total = itemWidths.reduce((a, b) => a + b, 0) + itemGap * Math.max(0, entries.length - 1);
+    // Cap each entry's text at the full legend strip (minus its own swatch+gap)
+    // so only a single name that would span the *entire* strip is elided — the
+    // width-based replacement for the old slice(0, 30) runaway guard. Normal
+    // multi-entry labels are left intact (a shorter sibling does not shrink a
+    // longer one's budget); as before, entries whose combined width exceeds the
+    // strip simply center-overflow rather than being clipped. Elide once and
+    // reuse for both the width calc and the draw so the two never disagree.
+    const nEntries = Math.max(1, entries.length);
+    const maxTextPx = lw - sw - gap;
+    const labels = entries.map((e) => elideToWidth(ctx, e.label, maxTextPx));
+    const itemWidths = labels.map((l) => sw + gap + ctx.measureText(l).width);
+    const total = itemWidths.reduce((a, b) => a + b, 0) + itemGap * (nEntries - 1);
     let rx = lx + (lw - total) / 2;
     const ry = ly + lh / 2;
     for (let i = 0; i < entries.length; i++) {
       drawLegendSwatch(ctx, swatchStyle, entries[i].color, rx, ry - fontSize / 2, sw, fontSize);
       ctx.fillStyle = '#333'; ctx.textAlign = 'left';
-      ctx.fillText(entries[i].label.slice(0, 30), rx + sw + gap, ry);
+      ctx.fillText(labels[i], rx + sw + gap, ry);
       rx += itemWidths[i] + itemGap;
     }
     return;
@@ -269,14 +289,16 @@ function drawLegend(
   ctx.font = `${fontSize}px sans-serif`;
   ctx.textBaseline = 'middle';
   const rowH = fontSize + 4;
+  // Vertical legend: each label runs from just after the swatch to the right
+  // edge of the reserved legend column, so cap it at that remaining width.
+  const maxTextPx = lw - sw - gap;
   let ry = ly + (lh - rowH * entries.length) / 2;
   for (let i = 0; i < entries.length; i++) {
     drawLegendSwatch(ctx, swatchStyle, entries[i].color, lx, ry, sw, fontSize);
     ctx.fillStyle = '#333'; ctx.textAlign = 'left';
-    ctx.fillText(entries[i].label.slice(0, 20), lx + sw + gap, ry + fontSize / 2);
+    ctx.fillText(elideToWidth(ctx, entries[i].label, maxTextPx), lx + sw + gap, ry + fontSize / 2);
     ry += rowH;
   }
-  void lw;
 }
 
 type LegendSide = 'r' | 'l' | 't' | 'b';
@@ -896,16 +918,22 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     // sample-2 slide-16's "2025年3月期" labels are `bg1 lumMod 75%` gray).
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.font = `${Math.max(8, Math.min(11, catGap * 0.5))}px sans-serif`;
+    // Column: each label is centered in a category slot of width `catGap`, so
+    // cap it just under that so neighbours don't collide. Horizontal bars: the
+    // label sits right-aligned in the left gutter between the val-title/legend
+    // band and the plot edge, so cap it at that band width.
+    const catSlotMaxPx = catGap - 4;
+    const horizLabelMaxPx = (px0 - 4) - (x + legLeftW + valTitleW);
     for (let ci = 0; ci < n; ci++) {
-      const label = (cats[ci] ?? '').toString().slice(0, 12);
+      const raw = (cats[ci] ?? '').toString();
       if (!isH) {
         const lx = px0 + ci * catGap + catGap / 2;
         ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-        ctx.fillText(label, lx, py0 + ph + 3);
+        ctx.fillText(elideToWidth(ctx, raw, catSlotMaxPx), lx, py0 + ph + 3);
       } else {
         const ly = py0 + (n - 1 - ci) * catGap + catGap / 2;
         ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
-        ctx.fillText(label, px0 - 4, ly);
+        ctx.fillText(elideToWidth(ctx, raw, horizLabelMaxPx), px0 - 4, ly);
       }
     }
   }
@@ -1140,11 +1168,14 @@ function renderLineChart(
     const catLabelColor = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.fillStyle = catLabelColor; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
     ctx.font = `${catAxFontPx}px sans-serif`;
+    // Only every `labelInterval`-th category is drawn, so the horizontal room a
+    // centered label owns is the spacing between two drawn labels: (pw/n)·interval.
+    const catSlotMaxPx = (pw / n) * labelInterval - 4;
     for (let ci = 0; ci < n; ci += labelInterval) {
       const tx = toX(ci);
       drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx);
       ctx.fillStyle = catLabelColor;
-      ctx.fillText((cats[ci] ?? '').toString().slice(0, 10), tx, py0 + ph + 5);
+      ctx.fillText(elideToWidth(ctx, (cats[ci] ?? '').toString(), catSlotMaxPx), tx, py0 + ph + 5);
     }
   }
 
@@ -1301,14 +1332,19 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ctx.textAlign = 'center'; ctx.textBaseline = 'top';
     ctx.font = `${Math.max(8, Math.min(11, pw / n * 0.8))}px sans-serif`;
     // Show every category label that fits; thin out only when adjacent labels
-    // would collide (so 12 months all render, unlike a fixed n/8 cap).
+    // would collide (so 12 months all render, unlike a fixed n/8 cap). Measure
+    // each label's real full width (the previous slice(0,10) under-measured wide
+    // CJK labels, which weakened the collision test) to pick the interval, then
+    // draw each label elided to the room a drawn label actually owns —
+    // (pw/n)·interval, the spacing between two drawn labels.
     let maxLabelW = 0;
     for (let ci = 0; ci < n; ci++) {
-      maxLabelW = Math.max(maxLabelW, ctx.measureText((cats[ci] ?? '').toString().slice(0, 10)).width);
+      maxLabelW = Math.max(maxLabelW, ctx.measureText((cats[ci] ?? '').toString()).width);
     }
     const labelInterval = Math.max(1, Math.ceil((maxLabelW + 6) / (pw / n)));
+    const catSlotMaxPx = (pw / n) * labelInterval - 4;
     for (let ci = 0; ci < n; ci += labelInterval) {
-      ctx.fillText((cats[ci] ?? '').toString().slice(0, 10), toX(ci), py0 + ph + 3);
+      ctx.fillText(elideToWidth(ctx, (cats[ci] ?? '').toString(), catSlotMaxPx), toX(ci), py0 + ph + 3);
     }
   }
 
@@ -1480,12 +1516,24 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
 
   ctx.font = `${Math.max(8, Math.min(11, rd * 0.2))}px sans-serif`;
   ctx.fillStyle = '#444'; ctx.textBaseline = 'middle';
+  // Spoke labels radiate from just outside the ring. Cap each at the room
+  // between its anchor and the nearest horizontal plot edge so long category
+  // names are elided instead of overrunning the chart frame. Left/right-aligned
+  // labels extend toward one edge; centered (top/bottom) labels straddle the
+  // anchor, so give them twice the smaller side.
+  const plotLeftX = cx2 - pw / 2;
+  const plotRightX = cx2 + pw / 2;
   for (let i = 0; i < n; i++) {
     const a = spoke(i);
     const lx = cx2 + Math.cos(a) * (rd + 12);
     const ly = cy2 + Math.sin(a) * (rd + 12);
-    ctx.textAlign = Math.cos(a) < -0.1 ? 'right' : Math.cos(a) > 0.1 ? 'left' : 'center';
-    ctx.fillText((cats[i] ?? '').toString().slice(0, 12), lx, ly);
+    const align: CanvasTextAlign = Math.cos(a) < -0.1 ? 'right' : Math.cos(a) > 0.1 ? 'left' : 'center';
+    ctx.textAlign = align;
+    const maxPx =
+      align === 'right' ? lx - plotLeftX
+        : align === 'left' ? plotRightX - lx
+          : 2 * Math.min(plotRightX - lx, lx - plotLeftX);
+    ctx.fillText(elideToWidth(ctx, (cats[i] ?? '').toString(), maxPx), lx, ly);
   }
 
   // ECMA-376 §21.2.3.10 c:radarStyle — "filled" closes the polygon with a

--- a/packages/core/src/chart/text-elide.test.ts
+++ b/packages/core/src/chart/text-elide.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { elideToWidth } from './text-elide.js';
+
+/**
+ * Mock canvas context whose `measureText` returns a width proportional to the
+ * summed per-character weight. A weight map lets a test model variable-width
+ * fonts (e.g. CJK glyphs twice as wide as Latin) so we can prove the elision is
+ * width-based, not character-count-based.
+ */
+function mockCtx(perChar: number, weights?: Record<string, number>): CanvasRenderingContext2D {
+  return {
+    measureText(s: string) {
+      let w = 0;
+      for (const ch of s) w += (weights?.[ch] ?? 1) * perChar;
+      return { width: w } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('elideToWidth', () => {
+  it('returns the text unchanged when it already fits', () => {
+    const ctx = mockCtx(10); // each char = 10px
+    // "abc" = 30px, fits in 30
+    expect(elideToWidth(ctx, 'abc', 30)).toBe('abc');
+    expect(elideToWidth(ctx, 'abc', 100)).toBe('abc');
+  });
+
+  it('appends an ellipsis and keeps the longest fitting prefix', () => {
+    const ctx = mockCtx(10); // char = 10px, ellipsis '…' = 10px
+    // "abcdef" = 60px, does not fit in 45.
+    // prefix "abc" + "…" = 40 ≤ 45; "abcd" + "…" = 50 > 45 → keep "abc".
+    expect(elideToWidth(ctx, 'abcdef', 45)).toBe('abc…');
+  });
+
+  it('boundary: max exactly fits prefix+ellipsis', () => {
+    const ctx = mockCtx(10);
+    // "ab" + "…" = 30 == 30 → fits; "abc" + "…" = 40 > 30.
+    expect(elideToWidth(ctx, 'abcdef', 30)).toBe('ab…');
+  });
+
+  it('boundary: full string width exactly equals maxPx → no ellipsis', () => {
+    const ctx = mockCtx(10);
+    expect(elideToWidth(ctx, 'abcd', 40)).toBe('abcd');
+    // one pixel short → must elide. char=ellipsis=10px, so a fitting prefix p
+    // needs 10·len(p)+10 ≤ 39 → len(p) ≤ 2 → "ab…".
+    expect(elideToWidth(ctx, 'abcd', 39)).toBe('ab…');
+  });
+
+  it('returns bare ellipsis when only the ellipsis fits', () => {
+    const ctx = mockCtx(10);
+    // ellipsis = 10px; one char + ellipsis = 20 > 15 → just "…".
+    expect(elideToWidth(ctx, 'abcdef', 15)).toBe('…');
+    expect(elideToWidth(ctx, 'abcdef', 10)).toBe('…');
+  });
+
+  it('returns empty string when not even the ellipsis fits', () => {
+    const ctx = mockCtx(10); // ellipsis = 10px
+    expect(elideToWidth(ctx, 'abc', 9)).toBe('');
+    expect(elideToWidth(ctx, 'abc', 0)).toBe('');
+    expect(elideToWidth(ctx, 'abc', -5)).toBe('');
+  });
+
+  it('empty text returns empty', () => {
+    const ctx = mockCtx(10);
+    expect(elideToWidth(ctx, '', 100)).toBe('');
+    expect(elideToWidth(ctx, '', 0)).toBe('');
+  });
+
+  it('is width-based, not char-count-based (CJK glyphs are wider)', () => {
+    // Latin chars = 8px, CJK chars = 16px, ellipsis '…' = 8px.
+    const ctx = mockCtx(8, { '年': 2, '月': 2, '期': 2, '…': 1 });
+    // "2025年3月期" widths: '2'8 '0'8 '2'8 '5'8 '年'16 '3'8 '月'16 '期'16 = 88px.
+    // Fits in 90 unchanged.
+    expect(elideToWidth(ctx, '2025年3月期', 90)).toBe('2025年3月期');
+    // In 60px: find longest prefix p with width(p)+8 ≤ 60 → width(p) ≤ 52.
+    //   "2025年" = 8+8+8+8+16 = 48; +8 = 56 ≤ 60 ✓
+    //   "2025年3" = 56; +8 = 64 > 60 ✗  → keep "2025年".
+    expect(elideToWidth(ctx, '2025年3月期', 60)).toBe('2025年…');
+    // A pure-Latin string of the SAME char count fits far more before eliding,
+    // proving the cut point depends on measured width, not length.
+    // "20253xyz" (8 chars, all 8px) = 64px; in 60 → prefix ≤ 52 → 6 chars "20253x"+… = 56.
+    expect(elideToWidth(ctx, '20253xyz', 60)).toBe('20253x…');
+  });
+
+  it('narrow slot keeps only what fits for a long CJK label', () => {
+    const ctx = mockCtx(10, { '…': 1 }); // CJK-ish: every char 10px, ellipsis 10px
+    // 5 wide chars = 50px; in 25px → prefix p with 10·len(p)+10 ≤ 25 → len ≤ 1.
+    expect(elideToWidth(ctx, '一二三四五', 25)).toBe('一…');
+  });
+});

--- a/packages/core/src/chart/text-elide.test.ts
+++ b/packages/core/src/chart/text-elide.test.ts
@@ -87,4 +87,26 @@ describe('elideToWidth', () => {
     // 5 wide chars = 50px; in 25px → prefix p with 10·len(p)+10 ≤ 25 → len ≤ 1.
     expect(elideToWidth(ctx, '一二三四五', 25)).toBe('一…');
   });
+
+  it('never splits a surrogate pair (emoji labels)', () => {
+    // 'ab' + emoji (2 code units) + 'cd'. Widths: 8px per code unit under the
+    // mock, so budgets are chosen to force cuts at every position around the
+    // pair; the result must never contain a lone surrogate.
+    const ctx = makeCtx((t) => t.length * 8);
+    const text = 'ab\u{1F389}cd';
+    for (let budget = 8; budget <= 8 * (text.length + 1); budget += 4) {
+      const out = elideToWidth(ctx, text, budget);
+      for (let i = 0; i < out.length; i++) {
+        const cu = out.charCodeAt(i);
+        if (cu >= 0xd800 && cu <= 0xdbff) {
+          // a high surrogate must be followed by its low half
+          const next = out.charCodeAt(i + 1);
+          expect(next >= 0xdc00 && next <= 0xdfff, `lone high surrogate at ${i} in ${JSON.stringify(out)} (budget ${budget})`).toBe(true);
+        } else if (cu >= 0xdc00 && cu <= 0xdfff) {
+          const prev = out.charCodeAt(i - 1);
+          expect(prev >= 0xd800 && prev <= 0xdbff, `lone low surrogate at ${i} in ${JSON.stringify(out)} (budget ${budget})`).toBe(true);
+        }
+      }
+    }
+  });
 });

--- a/packages/core/src/chart/text-elide.test.ts
+++ b/packages/core/src/chart/text-elide.test.ts
@@ -92,7 +92,7 @@ describe('elideToWidth', () => {
     // 'ab' + emoji (2 code units) + 'cd'. Widths: 8px per code unit under the
     // mock, so budgets are chosen to force cuts at every position around the
     // pair; the result must never contain a lone surrogate.
-    const ctx = makeCtx((t) => t.length * 8);
+    const ctx = mockCtx(8);
     const text = 'ab\u{1F389}cd';
     for (let budget = 8; budget <= 8 * (text.length + 1); budget += 4) {
       const out = elideToWidth(ctx, text, budget);

--- a/packages/core/src/chart/text-elide.ts
+++ b/packages/core/src/chart/text-elide.ts
@@ -1,0 +1,59 @@
+// Width-based label truncation for chart text. Chart labels (axis titles,
+// legend entries, category labels) can be arbitrarily long; the renderers used
+// to cap them with a fixed `slice(0, N)` character count, which neither
+// measures the real rendered width (a CJK label of 6 chars is far wider than a
+// Latin label of 6 chars) nor signals truncation to the reader. `elideToWidth`
+// replaces that with a measured fit that appends an ellipsis.
+
+const ELLIPSIS = '…';
+
+/**
+ * Return `text` trimmed to fit within `maxPx`, appending an ellipsis ('…') when
+ * it is shortened. The longest prefix whose `prefix + '…'` width is `<= maxPx`
+ * is found by binary search over `ctx.measureText`.
+ *
+ * Contract:
+ * - Uses `ctx.font` **as set by the caller at call time** — set the font (and
+ *   any `letterSpacing`) before calling so the measurement matches the eventual
+ *   `fillText`. This function does not mutate `ctx` state.
+ * - Returns `text` unchanged when it already fits (no ellipsis added).
+ * - Returns `''` when `maxPx` cannot even hold the ellipsis (or is <= 0), so a
+ *   collapsed slot renders nothing rather than a lone '…'.
+ * - An empty `text` returns `''`.
+ *
+ * @param ctx   canvas context whose current `font` is used for measurement
+ * @param text  the full label text
+ * @param maxPx the maximum width in device pixels the label may occupy
+ */
+export function elideToWidth(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxPx: number,
+): string {
+  if (text === '') return '';
+  if (maxPx <= 0) return '';
+  if (ctx.measureText(text).width <= maxPx) return text;
+
+  // Not enough room even for the ellipsis alone → render nothing.
+  const ellipsisW = ctx.measureText(ELLIPSIS).width;
+  if (ellipsisW > maxPx) return '';
+
+  // Binary-search the largest prefix length `k` (in code units) such that
+  // `text.slice(0, k) + '…'` fits. `k` ranges over [0, text.length - 1]; the
+  // full string is already known not to fit. `k === 0` yields a bare ellipsis,
+  // which is the correct minimal indicator when a single glyph won't fit.
+  let lo = 0;
+  let hi = text.length - 1;
+  let best = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const w = ctx.measureText(text.slice(0, mid) + ELLIPSIS).width;
+    if (w <= maxPx) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return text.slice(0, best) + ELLIPSIS;
+}

--- a/packages/core/src/chart/text-elide.ts
+++ b/packages/core/src/chart/text-elide.ts
@@ -55,5 +55,12 @@ export function elideToWidth(
       hi = mid - 1;
     }
   }
+  // Never split a surrogate pair: if the cut lands right after a high
+  // surrogate (the low half at `best` would be orphaned), back up one code
+  // unit so the whole astral character (emoji etc.) is dropped instead of
+  // rendering U+FFFD. Measuring with the lone surrogate during the search is
+  // harmless — this final clamp only ever shortens, so the result still fits.
+  const lastUnit = best > 0 ? text.charCodeAt(best - 1) : 0;
+  if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) best--;
   return text.slice(0, best) + ELLIPSIS;
 }


### PR DESCRIPTION
## Summary

Phase 3 item A7 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md). Chart labels were truncated by character count (`slice(0, 60/30/20/12/10)`) — unmeasured, no ellipsis, CJK-hostile (a 10-char CJK label is ~2× the width of 10 Latin chars).

### elideToWidth
New `core/src/chart/text-elide.ts`: binary-search for the longest `prefix + '…'` fitting `maxPx` under the caller's current `ctx.font` (9 tests incl. CJK variable-width proving width- not char-based). All 10 slice sites migrated with layout-derived budgets: axis titles → plot extent; legends → whole-strip width minus swatch; bar/line/area categories → per-slot spacing; radar spokes → distance to the nearest plot edge (alignment-aware). Measure and draw share one elided string (no double calc).

### Fidelity-first correction during implementation
The first horizontal-legend budget (equal share per entry) elided a 9-char CJK legend (`今日までに使った額`) that visually fit and never hit the old `slice(0,30)` — a fidelity regression caught by baseline-VRT. The budget was corrected to the whole-strip width, matching the old runaway-guard intent. Also made the area-chart label-interval collision test measure **full** label widths (was sliced to 10 chars, under-measuring CJK) — the one measurement-input change, flagged in the commit body.

### VRT — behavior-preserving on the whole corpus
Regression-mode comparison (pre-change renderer captured as baseline on this machine, isolating the change from the known font drift): **docx 21, pptx 75, xlsx 67 — every test 100% identical**. No committed sample has a label long enough for its slot to trigger elision; the machinery is proven to engage by the pre-fix legend diff and by unit tests.

## Verification
- `pnpm test` 1580 (+9) / typecheck / lint — green
- VRT all formats: 100% identical vs pre-change baseline; references untouched
- Browser smoke delegated to CI (worktree port rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)