### PR TITLE
refactor: DrawingML color/fill/bodyPr into ooxml-common; xlsx shape-text insets & ascent go spec-faithful (D8+C8)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4598,48 +4598,48 @@ fn resolve_color_element(container: roxmltree::Node, theme: &ThemeColors) -> Opt
     resolve_color_element_with_phclr(container, theme, "")
 }
 
+/// Resolves a `<a:schemeClr val>` name to its base theme hex the Word way, for
+/// the shared [`ooxml_common::color::parse_color_node`]. Carries the `ph_clr`
+/// substitution name: when the scheme name is `phClr` (a placeholder color from
+/// a wps:style/fillRef) and `ph_clr` is non-empty, that name is resolved
+/// instead. The color grammar (srgbClr/sysClr/prstClr + transforms) is shared;
+/// only this theme-slot lookup + phClr substitution is docx-specific.
+struct DocxSchemeResolver<'a> {
+    theme: &'a ThemeColors,
+    ph_clr: &'a str,
+}
+
+impl ooxml_common::color::ThemeResolver for DocxSchemeResolver<'_> {
+    fn resolve_scheme_color(&self, name: &str) -> Option<String> {
+        let resolved = if name == "phClr" && !self.ph_clr.is_empty() {
+            self.ph_clr
+        } else {
+            name
+        };
+        self.theme.resolve(resolved)
+    }
+}
+
 /// Like `resolve_color_element` but, when an inner `<a:schemeClr val="phClr"/>`
 /// is encountered, substitutes the scheme name `ph_clr` (the `<a:schemeClr>`
 /// child of the wps:style/fillRef that triggered theme lookup). Pass an empty
 /// string to disable the substitution.
+///
+/// Thin wrapper over the shared [`ooxml_common::color::parse_color_node`] with
+/// `TintMode::WordLiteral` (the spec-literal `tint = val·input + (1-val)·white`
+/// — see `ooxml-common/src/color.rs` for why this differs from PowerPoint's
+/// linear-sRGB tint). The grammar + transforms live there; [`DocxSchemeResolver`]
+/// supplies Word's theme-slot lookup and the phClr substitution. docx now also
+/// resolves `<a:prstClr>` preset names (previously dropped). Output is unchanged
+/// (uppercase hex, no `#`).
 fn resolve_color_element_with_phclr(
     container: roxmltree::Node,
     theme: &ThemeColors,
     ph_clr: &str,
 ) -> Option<String> {
-    for c in container.children().filter(|n| n.is_element()) {
-        let base = match c.tag_name().name() {
-            "srgbClr" => c.attribute("val").map(|v| v.to_uppercase()),
-            "schemeClr" => {
-                let raw_name = c.attribute("val")?;
-                let name = if raw_name == "phClr" && !ph_clr.is_empty() {
-                    ph_clr
-                } else {
-                    raw_name
-                };
-                theme.resolve(name)
-            }
-            "sysClr" => c
-                .attribute("lastClr")
-                .map(|v| v.to_uppercase())
-                .or_else(|| c.attribute("val").map(|v| v.to_uppercase())),
-            _ => None,
-        };
-        let Some(hex) = base else { continue };
-        return Some(apply_color_mods(&hex, c));
-    }
-    None
-}
-
-/// Word's interpretation of OOXML color modifiers. Wraps the shared
-/// `ooxml_common::color::apply_color_transforms` with TintMode::WordLiteral
-/// — the spec-literal `tint = val·input + (1-val)·white` formulation. See
-/// the comment in `ooxml-common/src/color.rs` for why this differs from
-/// PowerPoint's linear-sRGB tint.
-fn apply_color_mods(hex: &str, color_node: roxmltree::Node) -> String {
-    ooxml_common::color::apply_color_transforms(
-        hex,
-        color_node,
+    ooxml_common::color::parse_color_node(
+        container,
+        &DocxSchemeResolver { theme, ph_clr },
         ooxml_common::color::TintMode::WordLiteral,
     )
 }

--- a/packages/ooxml-common/src/color.rs
+++ b/packages/ooxml-common/src/color.rs
@@ -221,6 +221,142 @@ pub fn apply_color_transforms(hex: &str, node: Node, tint_mode: TintMode) -> Str
     }
 }
 
+/// A DrawingML color element (`<a:srgbClr>` / `<a:sysClr>` / `<a:prstClr>` /
+/// `<a:schemeClr>`), extracted from a color container's first color child but
+/// **not yet resolved to a hex string**. This is the format-agnostic middle
+/// layer between [`extract_color_source`] (which finds the element) and
+/// [`parse_color_node`] (which resolves + transforms it). The three parsers
+/// share the *grammar* here; theme-slot resolution (which differs per host —
+/// pptx bakes a `clrMap`, xlsx indexes a positional palette, docx keys a slot
+/// map) stays behind the [`ThemeResolver`] trait.
+///
+/// The wrapped `Node` is retained so the caller can apply the color-transform
+/// children (lumMod/tint/…) via [`apply_color_transforms`] on the resolved base.
+#[derive(Debug, Clone)]
+pub enum ColorSource<'a, 'input> {
+    /// `<a:srgbClr val="RRGGBB">` — an explicit hex (ECMA-376 §20.1.2.3.32).
+    /// `val` is the raw authored string (case as-authored).
+    SrgbClr { val: String, node: Node<'a, 'input> },
+    /// `<a:sysClr val="windowText" lastClr="RRGGBB">` — a system color
+    /// (§20.1.2.3.33). `last_clr` is the cached resolved hex; `val` is the
+    /// system-color enum name, retained only as a last-ditch fallback (matches
+    /// docx's historical behavior — pptx/xlsx never authored a val-only sysClr).
+    SysClr {
+        last_clr: Option<String>,
+        val: Option<String>,
+        node: Node<'a, 'input>,
+    },
+    /// `<a:prstClr val="black">` — a named preset color (§20.1.2.3.22 /
+    /// §20.1.10.48). Resolved through [`preset_color`](crate::theme::preset_color).
+    PrstClr { val: String },
+    /// `<a:schemeClr val="accent1">` — a theme-slot reference (§20.1.2.3.29).
+    /// `val` is the logical/slot name; the [`ThemeResolver`] maps it to a base
+    /// hex. The node is retained for the transform children.
+    SchemeClr { val: String, node: Node<'a, 'input> },
+}
+
+/// Locate the first DrawingML color element among a container's element
+/// children and return it as a [`ColorSource`]. Covers the four color-choice
+/// members a `<a:solidFill>` / `<a:gs>` / run `<a:rPr>` / shadow etc. carry:
+/// `srgbClr`, `sysClr`, `prstClr`, `schemeClr`. Returns `None` when no such
+/// child exists (e.g. a `<a:noFill>` sibling, or a `<a:solidFill>` with no
+/// color child). The caller supplies the *container* node (the same node its
+/// prior inline `for child` loop walked).
+pub fn extract_color_source<'a, 'input>(
+    container: Node<'a, 'input>,
+) -> Option<ColorSource<'a, 'input>> {
+    for c in container.children().filter(|n| n.is_element()) {
+        match c.tag_name().name() {
+            "srgbClr" => {
+                return Some(ColorSource::SrgbClr {
+                    val: c.attribute("val")?.to_owned(),
+                    node: c,
+                });
+            }
+            "sysClr" => {
+                return Some(ColorSource::SysClr {
+                    last_clr: c.attribute("lastClr").map(str::to_owned),
+                    val: c.attribute("val").map(str::to_owned),
+                    node: c,
+                });
+            }
+            "prstClr" => {
+                return Some(ColorSource::PrstClr {
+                    val: c.attribute("val")?.to_owned(),
+                });
+            }
+            "schemeClr" => {
+                return Some(ColorSource::SchemeClr {
+                    val: c.attribute("val")?.to_owned(),
+                    node: c,
+                });
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Host-specific resolution of a `<a:schemeClr val>` name to its **base hex**
+/// (6-char, no `#`, ready for [`apply_color_transforms`]). Each parser keeps
+/// its own theme storage and logical-name handling:
+///
+/// - pptx bakes the master's `<p:clrMap>` into its theme map and falls back to
+///   the default §19.3.1.6 slot table (plus a `phClr`→dk1 approximation);
+/// - xlsx indexes a positional `dk1,lt1,dk2,lt2,accent1..6,hlink,folHlink`
+///   palette (with the well-known dk/lt index swap);
+/// - docx keys a slot map and substitutes a caller-provided name for `phClr`.
+///
+/// Returning `None` leaves the color unresolved (the caller then falls back —
+/// e.g. to a shape's style color). Implementations must return the base
+/// **without** a leading `#` so the shared transform sees clean input.
+pub trait ThemeResolver {
+    /// Resolve a scheme/logical color name to its base hex (no `#`). `name` is
+    /// the raw `<a:schemeClr val>` string.
+    fn resolve_scheme_color(&self, name: &str) -> Option<String>;
+}
+
+/// Resolve a located color container to a hex string, sharing the DrawingML
+/// color grammar across the docx/pptx/xlsx parsers. Finds the first color child
+/// ([`extract_color_source`]), resolves it, and applies any color-transform
+/// children (lumMod/lumOff/shade/tint/… via [`apply_color_transforms`]):
+///
+/// - `srgbClr` / `sysClr` → their hex + transforms;
+/// - `prstClr` → [`preset_color`](crate::theme::preset_color) (no transforms,
+///   matching the parsers' prior behavior — a transformed preset is a latent
+///   gap shared by all three);
+/// - `schemeClr` → `resolver.resolve_scheme_color(val)` + transforms.
+///
+/// The returned hex is uppercase and has **no** `#` prefix (that is what
+/// [`apply_color_transforms`] emits: `{:02X}`); each caller re-applies its own
+/// casing / `#` convention in a thin adapter. `tint_mode` selects the Word vs
+/// PowerPoint `<a:tint>` interpretation ([`TintMode`]). Returns `None` when no
+/// color child is present or a `schemeClr` fails to resolve.
+pub fn parse_color_node<R: ThemeResolver + ?Sized>(
+    container: Node<'_, '_>,
+    resolver: &R,
+    tint_mode: TintMode,
+) -> Option<String> {
+    match extract_color_source(container)? {
+        ColorSource::SrgbClr { val, node } => Some(apply_color_transforms(&val, node, tint_mode)),
+        ColorSource::SysClr {
+            last_clr,
+            val,
+            node,
+        } => {
+            // Prefer the cached lastClr; fall back to the enum name only when
+            // lastClr is absent (docx's historical behavior — see ColorSource).
+            let hex = last_clr.or(val)?;
+            Some(apply_color_transforms(&hex, node, tint_mode))
+        }
+        ColorSource::PrstClr { val } => crate::theme::preset_color(&val),
+        ColorSource::SchemeClr { val, node } => {
+            let base = resolver.resolve_scheme_color(&val)?;
+            Some(apply_color_transforms(&base, node, tint_mode))
+        }
+    }
+}
+
 /// sRGB → linear light. IEC 61966-2-1 transfer function.
 pub fn srgb_to_linear(c: f64) -> f64 {
     if c <= 0.04045 {
@@ -327,6 +463,153 @@ mod tests {
                 ("folHlink", "folHlink"),
             ]
         );
+    }
+
+    // ── parse_color_node / extract_color_source ─────────────────────────────
+
+    use roxmltree::Document;
+
+    /// A minimal ThemeResolver mapping a couple of slot names to base hex,
+    /// letting the scheme-color path be exercised without a full parser.
+    struct MapResolver;
+    impl ThemeResolver for MapResolver {
+        fn resolve_scheme_color(&self, name: &str) -> Option<String> {
+            match name {
+                "accent1" => Some("4472C4".to_owned()),
+                "dk1" => Some("000000".to_owned()),
+                _ => None,
+            }
+        }
+    }
+
+    fn parse(xml: &str, mode: TintMode) -> Option<String> {
+        // Every fixture wraps the color element in a `<a:solidFill>` container,
+        // matching how the parsers pass the located fill node.
+        let doc = Document::parse(xml).unwrap();
+        parse_color_node(doc.root_element(), &MapResolver, mode)
+    }
+
+    const NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    /// srgbClr resolves to its (uppercased) hex, no `#`, under either TintMode.
+    #[test]
+    fn parse_color_node_srgb_plain() {
+        let xml = format!(r#"<a:solidFill xmlns:a="{NS}"><a:srgbClr val="ff8000"/></a:solidFill>"#);
+        assert_eq!(
+            parse(&xml, TintMode::WordLiteral).as_deref(),
+            Some("FF8000")
+        );
+        assert_eq!(
+            parse(&xml, TintMode::PowerPointLinear).as_deref(),
+            Some("FF8000")
+        );
+    }
+
+    /// sysClr uses lastClr; a transform child (lumMod) is applied on top.
+    #[test]
+    fn parse_color_node_sysclr_lastclr_with_lummod() {
+        let xml = format!(
+            r#"<a:solidFill xmlns:a="{NS}"><a:sysClr val="windowText" lastClr="FFFFFF"><a:lumMod val="50000"/></a:sysClr></a:solidFill>"#
+        );
+        // 50% luminance of white → mid gray (uppercase, no #).
+        assert_eq!(
+            parse(&xml, TintMode::WordLiteral).as_deref(),
+            Some("808080")
+        );
+    }
+
+    /// sysClr with no lastClr falls back to `val` (docx-historical). "windowText"
+    /// is not valid hex, but the fallback path must still fire (produces 000000).
+    #[test]
+    fn parse_color_node_sysclr_val_fallback() {
+        let xml = format!(r#"<a:solidFill xmlns:a="{NS}"><a:sysClr val="000000"/></a:solidFill>"#);
+        assert_eq!(
+            parse(&xml, TintMode::WordLiteral).as_deref(),
+            Some("000000")
+        );
+    }
+
+    /// prstClr resolves via the shared preset table, WITHOUT applying transforms
+    /// (matches the parsers' prior behavior — documented latent gap).
+    #[test]
+    fn parse_color_node_prstclr_via_preset_table() {
+        let xml = format!(r#"<a:solidFill xmlns:a="{NS}"><a:prstClr val="orange"/></a:solidFill>"#);
+        assert_eq!(
+            parse(&xml, TintMode::WordLiteral).as_deref(),
+            Some("FFA500")
+        );
+        // A transform child is intentionally ignored for prstClr.
+        let xml2 = format!(
+            r#"<a:solidFill xmlns:a="{NS}"><a:prstClr val="black"><a:lumMod val="50000"/></a:prstClr></a:solidFill>"#
+        );
+        assert_eq!(
+            parse(&xml2, TintMode::WordLiteral).as_deref(),
+            Some("000000")
+        );
+    }
+
+    /// schemeClr resolves through the injected ThemeResolver, then transforms.
+    #[test]
+    fn parse_color_node_schemeclr_via_resolver() {
+        let xml =
+            format!(r#"<a:solidFill xmlns:a="{NS}"><a:schemeClr val="accent1"/></a:solidFill>"#);
+        assert_eq!(
+            parse(&xml, TintMode::WordLiteral).as_deref(),
+            Some("4472C4")
+        );
+        // Unknown slot → None (caller falls back).
+        let unknown =
+            format!(r#"<a:solidFill xmlns:a="{NS}"><a:schemeClr val="accent9"/></a:solidFill>"#);
+        assert_eq!(parse(&unknown, TintMode::WordLiteral), None);
+    }
+
+    /// The two TintModes diverge on `<a:tint>`: Word reads val as retained input
+    /// (a near-white wash at 20%), PowerPoint lerps toward white in linear sRGB.
+    /// The two must produce DIFFERENT hex for the same input, proving the mode
+    /// is threaded through parse_color_node.
+    #[test]
+    fn parse_color_node_tint_mode_diverges() {
+        let xml = format!(
+            r#"<a:solidFill xmlns:a="{NS}"><a:schemeClr val="accent1"><a:tint val="20000"/></a:schemeClr></a:solidFill>"#
+        );
+        let word = parse(&xml, TintMode::WordLiteral).unwrap();
+        let ppt = parse(&xml, TintMode::PowerPointLinear).unwrap();
+        assert_ne!(word, ppt);
+        // Both are 6-char uppercase hex with no '#'.
+        assert_eq!(word.len(), 6);
+        assert!(!word.contains('#'));
+        assert!(word.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+
+    /// alpha < 1 yields an 8-char RRGGBBAA hex (transform emits the alpha byte).
+    #[test]
+    fn parse_color_node_alpha_yields_eight_hex() {
+        let xml = format!(
+            r#"<a:solidFill xmlns:a="{NS}"><a:srgbClr val="112233"><a:alpha val="50000"/></a:srgbClr></a:solidFill>"#
+        );
+        let out = parse(&xml, TintMode::WordLiteral).unwrap();
+        assert_eq!(out.len(), 8);
+        assert!(out.starts_with("112233"));
+    }
+
+    /// A container with no color child (e.g. a lone noFill sibling) → None.
+    #[test]
+    fn parse_color_node_none_when_no_color_child() {
+        let xml = format!(r#"<a:solidFill xmlns:a="{NS}"><a:noFill/></a:solidFill>"#);
+        assert_eq!(parse(&xml, TintMode::WordLiteral), None);
+    }
+
+    /// extract_color_source returns the first color element and skips others.
+    #[test]
+    fn extract_color_source_picks_first_color_child() {
+        let xml = format!(
+            r#"<a:solidFill xmlns:a="{NS}"><a:srgbClr val="ABCDEF"/><a:schemeClr val="accent1"/></a:solidFill>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        match extract_color_source(doc.root_element()) {
+            Some(ColorSource::SrgbClr { val, .. }) => assert_eq!(val, "ABCDEF"),
+            other => panic!("expected SrgbClr first, got {other:?}"),
+        }
     }
 
     #[test]

--- a/packages/ooxml-common/src/fill.rs
+++ b/packages/ooxml-common/src/fill.rs
@@ -1,0 +1,280 @@
+//! DrawingML gradient / pattern fill parsing (`<a:gradFill>` / `<a:pattFill>`),
+//! shared out of the pptx parser.
+//!
+//! These two fill kinds carry the same DrawingML grammar in every host that
+//! embeds it: a `<a:gradFill>` is a sorted list of `<a:gs pos>` color stops
+//! plus a `<a:lin ang>` / `<a:path>` direction (ECMA-376 §20.1.8.33 /
+//! §20.1.8.36 / §20.1.8.41), and a `<a:pattFill prst>` is a preset pattern with
+//! `<a:fgClr>` / `<a:bgClr>` colors (§20.1.8.40 / §20.1.10.59). The stop /
+//! pattern colors resolve through the shared [`crate::color::parse_color_node`]
+//! (any srgbClr / schemeClr / sysClr / prstClr + transforms), so a caller
+//! supplies its own [`ThemeResolver`](crate::color::ThemeResolver) and the
+//! grammar stays identical.
+//!
+//! Scope is deliberately narrow: only the *parse* moves here. The consuming
+//! parser keeps its own `Fill` model (its serde tags, its `Image` / blipFill /
+//! grpFill variants, its solidFill handling) and assembles these owned
+//! descriptors into it. Currently only the pptx parser implements gradFill /
+//! pattFill *rendering*; docx / xlsx have no consumer yet, so they do not call
+//! these — a future expansion point when their renderers gain gradient /
+//! pattern support.
+
+use crate::color::{parse_color_node, ThemeResolver, TintMode};
+use roxmltree::Node;
+
+/// One `<a:gs>` gradient stop: a position in `[0, 1]` and its resolved hex
+/// color (6-char opaque, or 8-char RRGGBBAA when an alpha transform applies).
+/// The serde shape (`{"position":..,"color":".."}`) matches the pptx parser's
+/// former inline `GradStop`, so its JSON stays byte-identical when it stores a
+/// `Vec<GradStop>` on its own `Fill::Gradient`.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GradStop {
+    /// Stop offset along the gradient axis, `0.0`–`1.0` (raw `pos` / 100000).
+    pub position: f64,
+    /// Resolved stop color (hex, no `#`).
+    pub color: String,
+}
+
+/// A parsed `<a:gradFill>`: its sorted stops plus the gradient direction.
+/// A plain owned descriptor — the caller maps it onto its own fill model.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GradientFill {
+    /// Color stops, sorted ascending by `position`.
+    pub stops: Vec<GradStop>,
+    /// Axis angle in degrees (`<a:lin ang>` / 60000; `0` = left→right,
+    /// `90` = top→bottom). `0.0` for a radial (`<a:path>`) or directionless
+    /// gradient.
+    pub angle: f64,
+    /// `"linear"` (a `<a:lin>` child or neither child) or `"radial"`
+    /// (a `<a:path>` child).
+    pub grad_type: String,
+}
+
+/// A parsed `<a:pattFill>`: its preset pattern name and fg/bg colors.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PatternFill {
+    /// Foreground color (hex, no `#`) — the pattern's "1" pixels. Defaults to
+    /// `000000` when `<a:fgClr>` is missing or unresolved.
+    pub fg: String,
+    /// Background color (hex, no `#`) — the pattern's "0" pixels. Defaults to
+    /// `ffffff` when `<a:bgClr>` is missing or unresolved.
+    pub bg: String,
+    /// `prst` preset value (`pct5`/…/`horz`/`vert`/`cross`/`diagCross`/…).
+    /// Defaults to `pct50` when the attribute is absent.
+    pub preset: String,
+}
+
+/// Unqualified (no-namespace) attribute lookup, matching the pptx `attr` helper
+/// the moved code used.
+fn attr(node: Node<'_, '_>, local: &str) -> Option<String> {
+    node.attributes()
+        .find(|a| a.name() == local && a.namespace().is_none())
+        .map(|a| a.value().to_owned())
+}
+
+/// First child element with the given local name, matching pptx's `child`.
+fn child<'a, 'i>(node: Node<'a, 'i>, local: &str) -> Option<Node<'a, 'i>> {
+    node.children()
+        .find(|n| n.is_element() && n.tag_name().name() == local)
+}
+
+/// Parse a located `<a:gradFill>` node (ECMA-376 §20.1.8.33). Reads the
+/// `<a:gsLst>` color stops (each `<a:gs pos>` resolved via
+/// [`parse_color_node`]), sorts them ascending by position, and derives the
+/// direction from `<a:lin ang>` (linear) or `<a:path>` (radial). Returns `None`
+/// when there are no resolvable stops, so the caller can keep scanning sibling
+/// fill elements (verbatim of the pptx behavior). `resolver` / `tint_mode` are
+/// threaded to the stop colors.
+pub fn parse_grad_fill<R: ThemeResolver + ?Sized>(
+    grad_fill: Node<'_, '_>,
+    resolver: &R,
+    tint_mode: TintMode,
+) -> Option<GradientFill> {
+    let mut stops: Vec<GradStop> = child(grad_fill, "gsLst")
+        .map(|gs_lst| {
+            gs_lst
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "gs")
+                .filter_map(|gs| {
+                    let position = attr(gs, "pos")
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .unwrap_or(0.0)
+                        / 100_000.0;
+                    let color = parse_color_node(gs, resolver, tint_mode)?;
+                    Some(GradStop { position, color })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if stops.is_empty() {
+        return None;
+    }
+    stops.sort_by(|a, b| {
+        a.position
+            .partial_cmp(&b.position)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let (grad_type, angle) = if let Some(lin) = child(grad_fill, "lin") {
+        // OOXML ang: 60000ths of degree, 0 = left→right, 5400000 = top→bottom
+        let ang = attr(lin, "ang")
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 60_000.0;
+        ("linear".to_owned(), ang)
+    } else if child(grad_fill, "path").is_some() {
+        ("radial".to_owned(), 0.0)
+    } else {
+        ("linear".to_owned(), 0.0)
+    };
+    Some(GradientFill {
+        stops,
+        angle,
+        grad_type,
+    })
+}
+
+/// Parse a located `<a:pattFill>` node (ECMA-376 §20.1.8.40). Reads the `prst`
+/// preset (default `pct50`) and the `<a:fgClr>` / `<a:bgClr>` colors via
+/// [`parse_color_node`], defaulting fg→`000000` / bg→`ffffff` when absent or
+/// unresolved (verbatim of the pptx behavior). `resolver` / `tint_mode` are
+/// threaded to the colors.
+pub fn parse_patt_fill<R: ThemeResolver + ?Sized>(
+    patt_fill: Node<'_, '_>,
+    resolver: &R,
+    tint_mode: TintMode,
+) -> PatternFill {
+    let preset = attr(patt_fill, "prst").unwrap_or_else(|| "pct50".to_owned());
+    let fg = child(patt_fill, "fgClr")
+        .and_then(|n| parse_color_node(n, resolver, tint_mode))
+        .unwrap_or_else(|| "000000".to_owned());
+    let bg = child(patt_fill, "bgClr")
+        .and_then(|n| parse_color_node(n, resolver, tint_mode))
+        .unwrap_or_else(|| "ffffff".to_owned());
+    PatternFill { fg, bg, preset }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roxmltree::Document;
+
+    const NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    /// A resolver mapping accent1/accent2 for the scheme-color stops.
+    struct MapResolver;
+    impl ThemeResolver for MapResolver {
+        fn resolve_scheme_color(&self, name: &str) -> Option<String> {
+            match name {
+                "accent1" => Some("4472C4".to_owned()),
+                "accent2" => Some("ED7D31".to_owned()),
+                _ => None,
+            }
+        }
+    }
+
+    fn doc(xml: &str) -> Document<'_> {
+        Document::parse(xml).unwrap()
+    }
+
+    /// gradFill: stops parsed + sorted, linear angle from `<a:lin ang>`.
+    #[test]
+    fn grad_fill_sorts_stops_and_reads_linear_angle() {
+        let xml = format!(
+            r#"<a:gradFill xmlns:a="{NS}">
+                 <a:gsLst>
+                   <a:gs pos="100000"><a:srgbClr val="ffffff"/></a:gs>
+                   <a:gs pos="0"><a:schemeClr val="accent1"/></a:gs>
+                 </a:gsLst>
+                 <a:lin ang="5400000"/>
+               </a:gradFill>"#
+        );
+        let d = doc(&xml);
+        let g =
+            parse_grad_fill(d.root_element(), &MapResolver, TintMode::PowerPointLinear).unwrap();
+        assert_eq!(g.grad_type, "linear");
+        assert_eq!(g.angle, 90.0); // 5400000 / 60000
+                                   // Sorted ascending by position; colors uppercase, no '#'.
+        assert_eq!(g.stops[0].position, 0.0);
+        assert_eq!(g.stops[0].color, "4472C4");
+        assert_eq!(g.stops[1].position, 1.0);
+        assert_eq!(g.stops[1].color, "FFFFFF");
+    }
+
+    /// gradFill with a `<a:path>` (no `<a:lin>`) → radial, angle 0.
+    #[test]
+    fn grad_fill_path_is_radial() {
+        let xml = format!(
+            r#"<a:gradFill xmlns:a="{NS}">
+                 <a:gsLst><a:gs pos="0"><a:srgbClr val="000000"/></a:gs></a:gsLst>
+                 <a:path path="circle"/>
+               </a:gradFill>"#
+        );
+        let d = doc(&xml);
+        let g =
+            parse_grad_fill(d.root_element(), &MapResolver, TintMode::PowerPointLinear).unwrap();
+        assert_eq!(g.grad_type, "radial");
+        assert_eq!(g.angle, 0.0);
+    }
+
+    /// gradFill with no resolvable stops → None (caller keeps scanning).
+    #[test]
+    fn grad_fill_no_stops_is_none() {
+        let xml = format!(r#"<a:gradFill xmlns:a="{NS}"><a:gsLst/></a:gradFill>"#);
+        let d = doc(&xml);
+        assert_eq!(
+            parse_grad_fill(d.root_element(), &MapResolver, TintMode::PowerPointLinear),
+            None
+        );
+        // An unresolvable schemeClr stop is dropped too.
+        let xml2 = format!(
+            r#"<a:gradFill xmlns:a="{NS}"><a:gsLst><a:gs pos="0"><a:schemeClr val="accent9"/></a:gs></a:gsLst></a:gradFill>"#
+        );
+        let d2 = doc(&xml2);
+        assert_eq!(
+            parse_grad_fill(d2.root_element(), &MapResolver, TintMode::PowerPointLinear),
+            None
+        );
+    }
+
+    /// pattFill: preset + fg/bg colors read via the resolver.
+    #[test]
+    fn patt_fill_reads_preset_and_colors() {
+        let xml = format!(
+            r#"<a:pattFill xmlns:a="{NS}" prst="ltDnDiag">
+                 <a:fgClr><a:schemeClr val="accent1"/></a:fgClr>
+                 <a:bgClr><a:srgbClr val="ffffff"/></a:bgClr>
+               </a:pattFill>"#
+        );
+        let d = doc(&xml);
+        let p = parse_patt_fill(d.root_element(), &MapResolver, TintMode::PowerPointLinear);
+        assert_eq!(p.preset, "ltDnDiag");
+        assert_eq!(p.fg, "4472C4");
+        assert_eq!(p.bg, "FFFFFF");
+    }
+
+    /// pattFill defaults: missing prst → pct50, missing fg → 000000, bg → ffffff.
+    #[test]
+    fn patt_fill_defaults() {
+        let xml = format!(r#"<a:pattFill xmlns:a="{NS}"/>"#);
+        let d = doc(&xml);
+        let p = parse_patt_fill(d.root_element(), &MapResolver, TintMode::PowerPointLinear);
+        assert_eq!(p.preset, "pct50");
+        assert_eq!(p.fg, "000000");
+        assert_eq!(p.bg, "ffffff");
+    }
+
+    /// GradStop serializes as {"position":..,"color":".."} (camelCase),
+    /// byte-matching the pptx parser's former inline struct.
+    #[test]
+    fn grad_stop_serde_shape() {
+        let v = serde_json::to_value(GradStop {
+            position: 0.5,
+            color: "ABCDEF".to_owned(),
+        })
+        .unwrap();
+        assert_eq!(v["position"], 0.5);
+        assert_eq!(v["color"], "ABCDEF");
+    }
+}

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod blip;
 pub mod chart;
 pub mod color;
+pub mod fill;
 pub mod math;
 pub mod rels;
 pub mod text;

--- a/packages/ooxml-common/src/text.rs
+++ b/packages/ooxml-common/src/text.rs
@@ -85,6 +85,127 @@ pub fn parse_autofit(body_pr: Node<'_, '_>) -> Option<(String, Option<f64>, Opti
     None
 }
 
+/// ECMA-376 §21.1.2.1.1 default text insets, in EMU. The left/right inset
+/// defaults to 91440 EMU (0.1 in = 7.2 pt = 9.6 px @96dpi); the top/bottom inset
+/// to 45720 EMU (0.05 in = 3.6 pt = 4.8 px). Single source of truth for the
+/// `CT_TextBodyProperties` inset defaults the parsers apply when `<a:bodyPr>`
+/// omits `lIns`/`rIns` / `tIns`/`bIns`.
+pub const DEFAULT_INS_LR_EMU: i64 = 91_440;
+/// See [`DEFAULT_INS_LR_EMU`].
+pub const DEFAULT_INS_TB_EMU: i64 = 45_720;
+
+/// The subset of `<a:bodyPr>` (ECMA-376 §21.1.2.1.1 `CT_TextBodyProperties`)
+/// that the pptx and xlsx parsers share: the vertical anchor, wrap mode, text
+/// direction, the four text insets (EMU), and the autofit mode (+ its stored
+/// normAutofit scales). Multi-column attributes (`numCol` / `spcCol` /
+/// `rtlCol`) are pptx-only and stay in that parser.
+///
+/// Every field is already defaulted — [`parse_body_pr`] layers the bodyPr's own
+/// attributes over a caller-supplied [`BodyPrDefaults`] (which carries each
+/// host's inheritance + theme-objectDefaults resolution). No serde: each parser
+/// maps these onto its own model type (pptx `TextBody`, xlsx `ShapeText`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct BodyPr {
+    /// `@anchor` — vertical alignment (`t`/`ctr`/`b`/`just`/`dist`).
+    pub anchor: String,
+    /// `@wrap` — `square` (wrap to width) or `none`.
+    pub wrap: String,
+    /// `@vert` — text direction (`horz`/`vert`/`vert270`/`eaVert`/…).
+    pub vert: String,
+    /// `@lIns` — left inset (EMU).
+    pub l_ins: i64,
+    /// `@tIns` — top inset (EMU).
+    pub t_ins: i64,
+    /// `@rIns` — right inset (EMU).
+    pub r_ins: i64,
+    /// `@bIns` — bottom inset (EMU).
+    pub b_ins: i64,
+    /// Autofit mode (`sp`/`norm`/`none`) from the autofit child (or the
+    /// default when there is no child). See [`parse_autofit`].
+    pub auto_fit: String,
+    /// `<a:normAutofit@fontScale>` as a fraction (62500 → 0.625). `None` unless
+    /// a `<a:normAutofit>` child carries it.
+    pub font_scale: Option<f64>,
+    /// `<a:normAutofit@lnSpcReduction>` as a fraction. `None` unless present.
+    pub ln_spc_reduction: Option<f64>,
+}
+
+/// Defaults for each `<a:bodyPr>` field, applied by [`parse_body_pr`] when the
+/// attribute (or autofit child) is absent. The caller pre-resolves these from
+/// its own inheritance chain (e.g. pptx: inherited placeholder anchor → theme
+/// `objectDefaults` → spec default; xlsx: just the spec default). Use
+/// [`BodyPrDefaults::spec`] for the bare ECMA-376 defaults.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BodyPrDefaults {
+    pub anchor: String,
+    pub wrap: String,
+    pub vert: String,
+    pub l_ins: i64,
+    pub t_ins: i64,
+    pub r_ins: i64,
+    pub b_ins: i64,
+    /// Autofit mode used when the bodyPr has no autofit child.
+    pub auto_fit: String,
+}
+
+impl BodyPrDefaults {
+    /// The bare ECMA-376 §21.1.2.1.1 defaults: anchor `t`, wrap `square`, vert
+    /// `horz`, insets [`DEFAULT_INS_LR_EMU`] / [`DEFAULT_INS_TB_EMU`], autofit
+    /// `none`. A host with no inheritance / theme layer (xlsx) uses this
+    /// directly; pptx overrides individual fields with its resolved values.
+    pub fn spec() -> Self {
+        Self {
+            anchor: "t".to_owned(),
+            wrap: "square".to_owned(),
+            vert: "horz".to_owned(),
+            l_ins: DEFAULT_INS_LR_EMU,
+            t_ins: DEFAULT_INS_TB_EMU,
+            r_ins: DEFAULT_INS_LR_EMU,
+            b_ins: DEFAULT_INS_TB_EMU,
+            auto_fit: "none".to_owned(),
+        }
+    }
+}
+
+/// Unqualified (no-namespace) integer attribute on `<a:bodyPr>`.
+fn attr_i64(node: Node<'_, '_>, local: &str) -> Option<i64> {
+    node.attributes()
+        .find(|a| a.name() == local && a.namespace().is_none())
+        .and_then(|a| a.value().parse::<i64>().ok())
+}
+
+/// Unqualified (no-namespace) string attribute on `<a:bodyPr>`.
+fn attr_str(node: Node<'_, '_>, local: &str) -> Option<String> {
+    node.attributes()
+        .find(|a| a.name() == local && a.namespace().is_none())
+        .map(|a| a.value().to_owned())
+}
+
+/// Parse a located `<a:bodyPr>` node's shared attributes over `defaults`
+/// (ECMA-376 §21.1.2.1.1). Each attribute uses the bodyPr's own value when
+/// present, else the corresponding `defaults` field; the autofit mode comes
+/// from the autofit child ([`parse_autofit`]) when present, else
+/// `defaults.auto_fit` (with `font_scale` / `ln_spc_reduction` only from a
+/// `<a:normAutofit>` child). The caller passes the located `<a:bodyPr>` and its
+/// pre-resolved [`BodyPrDefaults`], keeping host-specific inheritance out of the
+/// shared grammar.
+pub fn parse_body_pr(body_pr: Node<'_, '_>, defaults: &BodyPrDefaults) -> BodyPr {
+    let (auto_fit, font_scale, ln_spc_reduction) =
+        parse_autofit(body_pr).unwrap_or_else(|| (defaults.auto_fit.clone(), None, None));
+    BodyPr {
+        anchor: attr_str(body_pr, "anchor").unwrap_or_else(|| defaults.anchor.clone()),
+        wrap: attr_str(body_pr, "wrap").unwrap_or_else(|| defaults.wrap.clone()),
+        vert: attr_str(body_pr, "vert").unwrap_or_else(|| defaults.vert.clone()),
+        l_ins: attr_i64(body_pr, "lIns").unwrap_or(defaults.l_ins),
+        t_ins: attr_i64(body_pr, "tIns").unwrap_or(defaults.t_ins),
+        r_ins: attr_i64(body_pr, "rIns").unwrap_or(defaults.r_ins),
+        b_ins: attr_i64(body_pr, "bIns").unwrap_or(defaults.b_ins),
+        auto_fit,
+        font_scale,
+        ln_spc_reduction,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,5 +312,90 @@ mod tests {
         let xml = format!(r#"<a:bodyPr xmlns:a="{A_NS}" anchor="ctr" wrap="square"/>"#);
         let doc = Document::parse(&xml).unwrap();
         assert!(parse_autofit(doc.root_element()).is_none());
+    }
+
+    // ── parse_body_pr ───────────────────────────────────────────────────────
+
+    /// The spec defaults expose ECMA-376 §21.1.2.1.1 values.
+    #[test]
+    fn body_pr_spec_defaults() {
+        let d = BodyPrDefaults::spec();
+        assert_eq!(d.anchor, "t");
+        assert_eq!(d.wrap, "square");
+        assert_eq!(d.vert, "horz");
+        assert_eq!(d.l_ins, 91_440);
+        assert_eq!(d.r_ins, 91_440);
+        assert_eq!(d.t_ins, 45_720);
+        assert_eq!(d.b_ins, 45_720);
+        assert_eq!(d.auto_fit, "none");
+        assert_eq!(DEFAULT_INS_LR_EMU, 91_440);
+        assert_eq!(DEFAULT_INS_TB_EMU, 45_720);
+    }
+
+    /// An empty `<a:bodyPr>` yields exactly the passed defaults.
+    #[test]
+    fn parse_body_pr_uses_defaults_when_absent() {
+        let xml = format!(r#"<a:bodyPr xmlns:a="{A_NS}"/>"#);
+        let doc = Document::parse(&xml).unwrap();
+        let b = parse_body_pr(doc.root_element(), &BodyPrDefaults::spec());
+        assert_eq!(b.anchor, "t");
+        assert_eq!(b.wrap, "square");
+        assert_eq!(b.vert, "horz");
+        assert_eq!(b.l_ins, 91_440);
+        assert_eq!(b.t_ins, 45_720);
+        assert_eq!(b.r_ins, 91_440);
+        assert_eq!(b.b_ins, 45_720);
+        assert_eq!(b.auto_fit, "none");
+        assert_eq!(b.font_scale, None);
+        assert_eq!(b.ln_spc_reduction, None);
+    }
+
+    /// Explicit attributes override defaults; the autofit child sets auto_fit +
+    /// its scales.
+    #[test]
+    fn parse_body_pr_reads_attrs_and_autofit_child() {
+        let xml = format!(
+            r#"<a:bodyPr xmlns:a="{A_NS}" anchor="ctr" wrap="none" vert="vert270" lIns="0" tIns="12700" rIns="0" bIns="12700"><a:normAutofit fontScale="62500" lnSpcReduction="20000"/></a:bodyPr>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        let b = parse_body_pr(doc.root_element(), &BodyPrDefaults::spec());
+        assert_eq!(b.anchor, "ctr");
+        assert_eq!(b.wrap, "none");
+        assert_eq!(b.vert, "vert270");
+        assert_eq!(b.l_ins, 0);
+        assert_eq!(b.t_ins, 12_700);
+        assert_eq!(b.r_ins, 0);
+        assert_eq!(b.b_ins, 12_700);
+        assert_eq!(b.auto_fit, "norm");
+        assert_eq!(b.font_scale, Some(0.625));
+        assert_eq!(b.ln_spc_reduction, Some(0.20));
+    }
+
+    /// Non-spec defaults (e.g. pptx's theme-resolved anchor) are honored when the
+    /// attribute is absent, but overridden when present. Also: the autofit
+    /// default applies only when there is no autofit child.
+    #[test]
+    fn parse_body_pr_honors_custom_defaults() {
+        let defaults = BodyPrDefaults {
+            anchor: "b".to_owned(),
+            wrap: "square".to_owned(),
+            vert: "horz".to_owned(),
+            l_ins: 100_000,
+            t_ins: 50_000,
+            r_ins: 100_000,
+            b_ins: 50_000,
+            auto_fit: "sp".to_owned(),
+        };
+        // Absent attrs → custom defaults; no autofit child → default auto_fit.
+        let xml = format!(r#"<a:bodyPr xmlns:a="{A_NS}"/>"#);
+        let doc = Document::parse(&xml).unwrap();
+        let b = parse_body_pr(doc.root_element(), &defaults);
+        assert_eq!(b.anchor, "b");
+        assert_eq!(b.l_ins, 100_000);
+        assert_eq!(b.auto_fit, "sp");
+        // Present anchor attr wins over the custom default.
+        let xml2 = format!(r#"<a:bodyPr xmlns:a="{A_NS}" anchor="t"/>"#);
+        let doc2 = Document::parse(&xml2).unwrap();
+        assert_eq!(parse_body_pr(doc2.root_element(), &defaults).anchor, "t");
     }
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2263,68 +2263,56 @@ fn parse_color_node(
     parse_color_node_tint(node, theme, ooxml_common::color::TintMode::PowerPointLinear)
 }
 
+/// Resolves a `<a:schemeClr val>` name to its base theme hex the PowerPoint
+/// way, for the shared [`ooxml_common::color::parse_color_node`]. The color
+/// grammar (srgbClr/sysClr/prstClr/schemeClr + transforms) is shared; only this
+/// theme-slot lookup is pptx-specific.
+struct PptxSchemeResolver<'a> {
+    theme: &'a HashMap<String, String>,
+}
+
+impl ooxml_common::color::ThemeResolver for PptxSchemeResolver<'_> {
+    fn resolve_scheme_color(&self, name: &str) -> Option<String> {
+        // Per ECMA-376 §19.3.1.6 the master's <p:clrMap> remaps logical
+        // names (bg1/tx1/bg2/tx2/accentN/hlink/folHlink) to theme slots.
+        // `bake_clr_map` pre-bakes those logical names into the theme
+        // map, so try a direct lookup FIRST — this honors clrMap (e.g.
+        // tx1="lt1"). Fall back to the canonical alias only when the
+        // logical name was not baked (no master / unmapped name), so a
+        // missing clrMap still resolves tx1→dk1, bg1→lt1, etc.
+        if let Some(hex) = self.theme.get(name) {
+            return Some(hex.clone());
+        }
+        // Canonical logical→slot fallback, per the default §19.3.1.6
+        // clrMap (shared table: ooxml_common::color::SCHEME_DEFAULT_SLOTS).
+        // The helper also passes raw slot names (dk1/lt1/…) and accents
+        // through unchanged.
+        let canonical: &str = match name {
+            // phClr = "placeholder color" (inherits from layout).
+            // Approximate as the primary dark text color. Not part of
+            // §19.3.1.6, so it stays a local special case.
+            "phClr" => "dk1",
+            other => ooxml_common::color::default_scheme_slot(other),
+        };
+        self.theme.get(canonical).cloned()
+    }
+}
+
 /// Like `parse_color_node`, but lets the caller pick how `<a:tint>` is interpreted.
 /// Table styles (`<a:tcStyle>` band fills) use `TintMode::WordLiteral` — the literal
 /// ECMA-376 §20.1.2.3.34 definition (`val·input + (1-val)·white`, so a 20% tint is a
 /// near-white wash) — which is how PowerPoint renders table band tints. The SmartArt
 /// accent-recolor path keeps `PowerPointLinear` (see `apply_color_transforms`).
+///
+/// Thin wrapper over the shared [`ooxml_common::color::parse_color_node`]: the
+/// grammar + transforms live there; [`PptxSchemeResolver`] supplies the
+/// pptx-specific theme-slot lookup. Output is unchanged (uppercase hex, no `#`).
 fn parse_color_node_tint(
     node: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
     tint_mode: ooxml_common::color::TintMode,
 ) -> Option<String> {
-    let xform = |hex: &str, c: roxmltree::Node<'_, '_>| {
-        ooxml_common::color::apply_color_transforms(hex, c, tint_mode)
-    };
-    for c in node.children().filter(|n| n.is_element()) {
-        match c.tag_name().name() {
-            "srgbClr" => {
-                let hex = attr(&c, "val")?;
-                return Some(xform(&hex, c));
-            }
-            "sysClr" => {
-                let hex = attr(&c, "lastClr")?;
-                return Some(xform(&hex, c));
-            }
-            "prstClr" => return preset_color(attr(&c, "val")?.as_str()),
-            "schemeClr" => {
-                let scheme_name = attr(&c, "val")?;
-                // Per ECMA-376 §19.3.1.6 the master's <p:clrMap> remaps logical
-                // names (bg1/tx1/bg2/tx2/accentN/hlink/folHlink) to theme slots.
-                // `bake_clr_map` pre-bakes those logical names into the theme
-                // map, so try a direct lookup FIRST — this honors clrMap (e.g.
-                // tx1="lt1"). Fall back to the canonical alias only when the
-                // logical name was not baked (no master / unmapped name), so a
-                // missing clrMap still resolves tx1→dk1, bg1→lt1, etc.
-                if let Some(hex) = theme.get(scheme_name.as_str()) {
-                    let hex = hex.clone();
-                    return Some(xform(&hex, c));
-                }
-                // Canonical logical→slot fallback, per the default §19.3.1.6
-                // clrMap (shared table: ooxml_common::color::SCHEME_DEFAULT_SLOTS).
-                // The helper also passes raw slot names (dk1/lt1/…) and accents
-                // through unchanged.
-                let canonical: &str = match scheme_name.as_str() {
-                    // phClr = "placeholder color" (inherits from layout).
-                    // Approximate as the primary dark text color. Not part of
-                    // §19.3.1.6, so it stays a local special case.
-                    "phClr" => "dk1",
-                    other => ooxml_common::color::default_scheme_slot(other),
-                };
-                let base_hex = theme.get(canonical)?.clone();
-                return Some(xform(&base_hex, c));
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Resolve a DrawingML `<a:prstClr>` preset name to hex. Thin alias for the
-/// shared [`ooxml_common::theme::preset_color`] (the single source of truth),
-/// kept as a local name so the `prstClr` call sites read unchanged.
-fn preset_color(name: &str) -> Option<String> {
-    ooxml_common::theme::preset_color(name)
+    ooxml_common::color::parse_color_node(node, &PptxSchemeResolver { theme }, tint_mode)
 }
 
 // ===========================

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1321,14 +1321,11 @@ struct TileInfo {
     algn: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-struct GradStop {
-    /// 0.0–1.0
-    position: f64,
-    /// hex color (6 chars = opaque, 8 chars = RRGGBBAA with alpha)
-    color: String,
-}
+/// A gradient color stop. The owned type + `<a:gs>` parse now live in
+/// `ooxml_common::fill` (shared DrawingML fill grammar); re-exported here under
+/// the former name so `Fill::Gradient { stops: Vec<GradStop> }` and its
+/// byte-identical `{"position":..,"color":".."}` JSON are unchanged.
+use ooxml_common::fill::GradStop;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -2333,51 +2330,28 @@ fn parse_fill(node: roxmltree::Node<'_, '_>, theme: &HashMap<String, String>) ->
             "noFill" => return Some(Fill::None),
             "pattFill" => {
                 // ECMA-376 §20.1.8.40 — preset pattern with fg/bg colours.
-                let preset = attr(&c, "prst").unwrap_or_else(|| "pct50".to_owned());
-                let fg = child(c, "fgClr")
-                    .and_then(|n| parse_color_node(n, theme))
-                    .unwrap_or_else(|| "000000".to_owned());
-                let bg = child(c, "bgClr")
-                    .and_then(|n| parse_color_node(n, theme))
-                    .unwrap_or_else(|| "ffffff".to_owned());
+                // Shared parse (ooxml_common::fill); colors resolve with pptx's
+                // PowerPointLinear tint via PptxSchemeResolver.
+                let ooxml_common::fill::PatternFill { fg, bg, preset } =
+                    ooxml_common::fill::parse_patt_fill(
+                        c,
+                        &PptxSchemeResolver { theme },
+                        ooxml_common::color::TintMode::PowerPointLinear,
+                    );
                 return Some(Fill::Pattern { fg, bg, preset });
             }
             "gradFill" => {
-                let mut stops: Vec<GradStop> = child(c, "gsLst")
-                    .map(|gs_lst| {
-                        gs_lst
-                            .children()
-                            .filter(|n| n.is_element() && n.tag_name().name() == "gs")
-                            .filter_map(|gs| {
-                                let position = attr_f64(&gs, "pos").unwrap_or(0.0) / 100_000.0;
-                                let color = parse_color_node(gs, theme)?;
-                                Some(GradStop { position, color })
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-
-                if stops.is_empty() {
-                    // No valid stops — continue scanning other fill elements
-                } else {
-                    stops.sort_by(|a, b| {
-                        a.position
-                            .partial_cmp(&b.position)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    });
-                    let (grad_type, angle) = if let Some(lin) = child(c, "lin") {
-                        // OOXML ang: 60000ths of degree, 0 = left→right, 5400000 = top→bottom
-                        let ang = attr_f64(&lin, "ang").unwrap_or(0.0) / 60_000.0;
-                        ("linear".to_owned(), ang)
-                    } else if child(c, "path").is_some() {
-                        ("radial".to_owned(), 0.0)
-                    } else {
-                        ("linear".to_owned(), 0.0)
-                    };
+                // Shared parse (ooxml_common::fill). Returns None when there are
+                // no resolvable stops, so we keep scanning sibling fill elements.
+                if let Some(g) = ooxml_common::fill::parse_grad_fill(
+                    c,
+                    &PptxSchemeResolver { theme },
+                    ooxml_common::color::TintMode::PowerPointLinear,
+                ) {
                     return Some(Fill::Gradient {
-                        stops,
-                        angle,
-                        grad_type,
+                        stops: g.stops,
+                        angle: g.angle,
+                        grad_type: g.grad_type,
                     });
                 }
             }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1,6 +1,6 @@
 use ooxml_common::blip::{mime_from_ext, parse_src_rect, svg_blip_rid, SrcRect};
 use ooxml_common::math::{nodes_to_text, parse_omath_nodes, MathNode};
-use ooxml_common::text::{parse_autofit, parse_lnspc, SpaceLine};
+use ooxml_common::text::{parse_lnspc, SpaceLine};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
@@ -4613,53 +4613,58 @@ fn parse_text_body(
     let theme_auto_fit =
         || -> Option<String> { theme.get(&format!("{def_prefix}-autoFit")).cloned() };
 
-    let vertical_anchor = body_pr
-        .and_then(|n| attr(&n, "anchor"))
-        .map(|a| a.to_string())
-        .or(inherited_anchor)
-        .or_else(|| theme_default_str("anchor"))
-        .unwrap_or_else(|| "t".into());
-    // Text insets (EMU). OOXML defaults: lIns=rIns=91440, tIns=bIns=45720.
-    // Shape attribute → theme objectDefaults → spec default.
-    let l_ins = body_pr
-        .and_then(|n| attr_i64(&n, "lIns"))
-        .or_else(|| theme_default_i64("lIns"))
-        .unwrap_or(91_440);
-    let r_ins = body_pr
-        .and_then(|n| attr_i64(&n, "rIns"))
-        .or_else(|| theme_default_i64("rIns"))
-        .unwrap_or(91_440);
-    let t_ins = body_pr
-        .and_then(|n| attr_i64(&n, "tIns"))
-        .or_else(|| theme_default_i64("tIns"))
-        .unwrap_or(45_720);
-    let b_ins = body_pr
-        .and_then(|n| attr_i64(&n, "bIns"))
-        .or_else(|| theme_default_i64("bIns"))
-        .unwrap_or(45_720);
-    let wrap = body_pr
-        .and_then(|n| attr(&n, "wrap"))
-        .or_else(|| theme_default_str("wrap"))
-        .unwrap_or_else(|| "square".into());
-    let vert = body_pr
-        .and_then(|n| attr(&n, "vert"))
-        .or_else(|| theme_default_str("vert"))
-        .unwrap_or_else(|| "horz".into());
-    // Auto-fit child element (spAutoFit / normAutofit). When the shape's own
-    // bodyPr is absent or contains no autofit child, defer to theme txDef.
-    // For normAutofit, also capture PowerPoint's stored fontScale /
-    // lnSpcReduction (ECMA-376 §21.1.2.1.3) — ST_Percentage in 1000ths of a
-    // percent, so 62500 → 0.625. The renderer applies these directly.
-    // parse_autofit returns None when there is no bodyPr, or a bodyPr with no
-    // autofit child, so both fall through to the theme txDef default.
-    let (auto_fit, font_scale, ln_spc_reduction) =
-        body_pr.and_then(parse_autofit).unwrap_or_else(|| {
-            (
-                theme_auto_fit().unwrap_or_else(|| "none".to_owned()),
-                None,
-                None,
-            )
-        });
+    // Shared `<a:bodyPr>` grammar (anchor / wrap / vert / insets / autofit) via
+    // ooxml_common::text::parse_body_pr. pptx's inheritance + theme
+    // objectDefaults resolution is pre-baked into the defaults: each field is
+    // `inherited?.or(theme objectDefault)?.or(spec default)`, and parse_body_pr
+    // then applies the shape's own bodyPr attribute over it — so the effective
+    // precedence (shape attr → inherited → theme → spec) is unchanged. When the
+    // shape has no `<a:bodyPr>` at all, the resolved defaults ARE the result.
+    //
+    // Insets: OOXML defaults lIns=rIns=91440, tIns=bIns=45720 (the shared
+    // ooxml_common::text::DEFAULT_INS_* constants, via BodyPrDefaults::spec()).
+    // Autofit child (spAutoFit / normAutofit): when absent, defer to theme txDef
+    // (auto_fit default below); a normAutofit also captures PowerPoint's stored
+    // fontScale / lnSpcReduction (ECMA-376 §21.1.2.1.3, 62500 → 0.625).
+    let spec = ooxml_common::text::BodyPrDefaults::spec();
+    let body_pr_defaults = ooxml_common::text::BodyPrDefaults {
+        anchor: inherited_anchor
+            .or_else(|| theme_default_str("anchor"))
+            .unwrap_or(spec.anchor),
+        wrap: theme_default_str("wrap").unwrap_or(spec.wrap),
+        vert: theme_default_str("vert").unwrap_or(spec.vert),
+        l_ins: theme_default_i64("lIns").unwrap_or(spec.l_ins),
+        t_ins: theme_default_i64("tIns").unwrap_or(spec.t_ins),
+        r_ins: theme_default_i64("rIns").unwrap_or(spec.r_ins),
+        b_ins: theme_default_i64("bIns").unwrap_or(spec.b_ins),
+        auto_fit: theme_auto_fit().unwrap_or(spec.auto_fit),
+    };
+    let body = match body_pr {
+        Some(n) => ooxml_common::text::parse_body_pr(n, &body_pr_defaults),
+        // No <a:bodyPr>: every field resolves to its default.
+        None => ooxml_common::text::BodyPr {
+            anchor: body_pr_defaults.anchor.clone(),
+            wrap: body_pr_defaults.wrap.clone(),
+            vert: body_pr_defaults.vert.clone(),
+            l_ins: body_pr_defaults.l_ins,
+            t_ins: body_pr_defaults.t_ins,
+            r_ins: body_pr_defaults.r_ins,
+            b_ins: body_pr_defaults.b_ins,
+            auto_fit: body_pr_defaults.auto_fit.clone(),
+            font_scale: None,
+            ln_spc_reduction: None,
+        },
+    };
+    let vertical_anchor = body.anchor;
+    let l_ins = body.l_ins;
+    let r_ins = body.r_ins;
+    let t_ins = body.t_ins;
+    let b_ins = body.b_ins;
+    let wrap = body.wrap;
+    let vert = body.vert;
+    let auto_fit = body.auto_fit;
+    let font_scale = body.font_scale;
+    let ln_spc_reduction = body.ln_spc_reduction;
     // ECMA-376 §20.1.10.34: numCol on <a:bodyPr> tells the renderer to
     // distribute paragraphs across N columns within the shape. Default 1.
     // spcCol is the inter-column gutter in EMU (default 0). Both fall back

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -262,67 +262,60 @@ pub(crate) fn parse_xfrm(xfrm_node: &roxmltree::Node) -> Option<Xfrm> {
     })
 }
 
-/// Apply the DrawingML color-transform children (`lumMod`, `lumOff`, `shade`,
-/// `tint`, `satMod`, …) declared inside a `<a:srgbClr>` / `<a:schemeClr>` to a
-/// resolved base hex, via the shared transform. Without this, an accent with
-/// e.g. `lumMod 20% + lumOff 80%` (a light tint) renders at full strength — so
-/// "light fill + dark border" pairs collapse to one solid mid-tone.
-fn apply_clr_mods(base_with_hash: &str, clr_node: &roxmltree::Node) -> String {
-    let base = base_with_hash.trim_start_matches('#');
-    let out = ooxml_common::color::apply_color_transforms(
-        base,
-        *clr_node,
-        ooxml_common::color::TintMode::PowerPointLinear,
-    );
-    format!("#{}", out.to_uppercase())
+/// Resolves a `<a:schemeClr val>` name to its base theme hex (no `#`) the way
+/// xlsx stores its palette, for the shared [`ooxml_common::color::parse_color_node`].
+/// `theme_colors` is collected in OOXML clrScheme document order: dk1, lt1, dk2,
+/// lt2, accent1..accent6, hlink, folHlink (see `parse_theme_colors`), each
+/// `#RRGGBB`. The `#` is stripped here because the shared transform wants clean
+/// hex; `parse_solid_fill` re-adds it for the returned color.
+struct XlsxSchemeResolver<'a> {
+    theme_colors: &'a [String],
 }
 
+impl ooxml_common::color::ThemeResolver for XlsxSchemeResolver<'_> {
+    fn resolve_scheme_color(&self, name: &str) -> Option<String> {
+        // Positional index into the clrScheme-order palette. dk1/lt1 and dk2/lt2
+        // are the light/dark logical pairs (the earlier local mapping had them
+        // swapped, which darkened shapes that painted "lt1", the paper colour).
+        let idx = match name {
+            "dk1" | "tx1" => 0,
+            "lt1" | "bg1" => 1,
+            "dk2" | "tx2" => 2,
+            "lt2" | "bg2" => 3,
+            "accent1" => 4,
+            "accent2" => 5,
+            "accent3" => 6,
+            "accent4" => 7,
+            "accent5" => 8,
+            "accent6" => 9,
+            "hlink" => 10,
+            "folHlink" => 11,
+            _ => return None,
+        };
+        self.theme_colors
+            .get(idx)
+            .map(|hex| hex.trim_start_matches('#').to_owned())
+    }
+}
+
+/// Resolve a DrawingML `<a:solidFill>` (or any color container) to `#RRGGBB`
+/// (uppercase). Thin wrapper over the shared
+/// [`ooxml_common::color::parse_color_node`]: the color grammar
+/// (srgbClr/sysClr/prstClr/schemeClr + transforms lumMod/tint/…) lives there;
+/// [`XlsxSchemeResolver`] supplies the positional theme-palette lookup. xlsx
+/// re-applies its own `#`-prefix + uppercase convention on the shared output
+/// (which is already uppercase, no `#`). Without the transforms an accent with
+/// e.g. `lumMod 20% + lumOff 80%` (a light tint) would render at full strength.
 pub(crate) fn parse_solid_fill(
     fill_node: &roxmltree::Node,
     theme_colors: &[String],
 ) -> Option<String> {
-    for c in fill_node.children() {
-        match c.tag_name().name() {
-            "srgbClr" => {
-                let v = c.attribute("val")?;
-                return Some(apply_clr_mods(&format!("#{}", v.to_uppercase()), &c));
-            }
-            "sysClr" => {
-                // System colour (e.g. windowText / window). `lastClr` is the
-                // concrete value the authoring app last resolved it to.
-                let last = c.attribute("lastClr")?;
-                return Some(apply_clr_mods(&format!("#{}", last.to_uppercase()), &c));
-            }
-            "schemeClr" => {
-                let v = c.attribute("val")?;
-                // `theme_colors` is collected in OOXML clrScheme document
-                // order: dk1, lt1, dk2, lt2, accent1..accent6, hlink,
-                // folHlink. See `parse_theme_colors`. The earlier mapping
-                // here had dk1/lt1 and dk2/lt2 swapped which darkened
-                // shapes that painted "lt1" (the sheet paper colour).
-                let idx = match v {
-                    "dk1" | "tx1" => Some(0),
-                    "lt1" | "bg1" => Some(1),
-                    "dk2" | "tx2" => Some(2),
-                    "lt2" | "bg2" => Some(3),
-                    "accent1" => Some(4),
-                    "accent2" => Some(5),
-                    "accent3" => Some(6),
-                    "accent4" => Some(7),
-                    "accent5" => Some(8),
-                    "accent6" => Some(9),
-                    "hlink" => Some(10),
-                    "folHlink" => Some(11),
-                    _ => None,
-                };
-                return idx
-                    .and_then(|i| theme_colors.get(i).cloned())
-                    .map(|base| apply_clr_mods(&base, &c));
-            }
-            _ => {}
-        }
-    }
-    None
+    ooxml_common::color::parse_color_node(
+        *fill_node,
+        &XlsxSchemeResolver { theme_colors },
+        ooxml_common::color::TintMode::PowerPointLinear,
+    )
+    .map(|hex| format!("#{}", hex.to_uppercase()))
 }
 
 /// Parse a single custGeom path element. Each path has its own coordinate

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -516,35 +516,50 @@ pub(crate) fn parse_tx_body(
     tx_body: &roxmltree::Node,
     theme_colors: &[String],
 ) -> Option<ShapeText> {
-    let mut anchor = String::from("t");
-    let mut wrap = String::from("square");
-    // `<a:bodyPr>` autofit child (ECMA-376 §21.1.2.1.1-.3). Default "none"
-    // (xlsx has no theme txDef fallback). Mirrors the pptx parser; for
-    // normAutofit also capture the stored fontScale / lnSpcReduction
-    // (ST_TextFontScalePercentOrPercentString / ST_TextSpacingPercentOrPercentString,
-    // 1000ths of a percent → fraction).
-    let mut auto_fit = String::from("none");
-    let mut font_scale: Option<f64> = None;
-    let mut ln_spc_reduction: Option<f64> = None;
+    // `<a:bodyPr>` shared grammar (anchor / wrap / insets / autofit) via
+    // ooxml_common::text::parse_body_pr over the bare ECMA-376 §21.1.2.1.1
+    // defaults — xlsx has no theme objectDefaults / inheritance layer, so
+    // BodyPrDefaults::spec() is the whole fallback (anchor `t`, wrap `square`,
+    // autofit `none`, insets 91440/45720 EMU). `vert` is parsed but xlsx does
+    // not model it. When there is no `<a:bodyPr>` the spec defaults apply.
+    let body = tx_body
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "bodyPr")
+        .map(|bp| {
+            ooxml_common::text::parse_body_pr(bp, &ooxml_common::text::BodyPrDefaults::spec())
+        })
+        .unwrap_or_else(|| {
+            let d = ooxml_common::text::BodyPrDefaults::spec();
+            ooxml_common::text::BodyPr {
+                anchor: d.anchor,
+                wrap: d.wrap,
+                vert: d.vert,
+                l_ins: d.l_ins,
+                t_ins: d.t_ins,
+                r_ins: d.r_ins,
+                b_ins: d.b_ins,
+                auto_fit: d.auto_fit,
+                font_scale: None,
+                ln_spc_reduction: None,
+            }
+        });
+    let anchor = body.anchor;
+    let wrap = body.wrap;
+    // Text insets (EMU), §21.1.2.1.1. Emitted always (spec default when the
+    // attribute is absent) so the renderer stops using empirical padding.
+    let l_ins = body.l_ins;
+    let t_ins = body.t_ins;
+    let r_ins = body.r_ins;
+    let b_ins = body.b_ins;
+    // Autofit (spAutoFit / normAutofit / noAutofit); normAutofit also carries the
+    // stored fontScale / lnSpcReduction (1000ths of a percent → fraction).
+    let auto_fit = body.auto_fit;
+    let font_scale = body.font_scale;
+    let ln_spc_reduction = body.ln_spc_reduction;
     let mut paragraphs: Vec<ShapeParagraph> = Vec::new();
     for c in tx_body.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
-            "bodyPr" => {
-                if let Some(a) = c.attribute("anchor") {
-                    anchor = a.to_string();
-                }
-                if let Some(w) = c.attribute("wrap") {
-                    wrap = w.to_string();
-                }
-                // Autofit child (spAutoFit / normAutofit / noAutofit). Shared
-                // with pptx; xlsx keeps the "none" default when there is no
-                // autofit child (parse_autofit returns None).
-                if let Some((af, fs, lsr)) = ooxml_common::text::parse_autofit(c) {
-                    auto_fit = af;
-                    font_scale = fs;
-                    ln_spc_reduction = lsr;
-                }
-            }
+            "bodyPr" => {}
             "p" => {
                 let mut align = String::from("l");
                 let mut rtl = false;
@@ -687,6 +702,10 @@ pub(crate) fn parse_tx_body(
             auto_fit,
             font_scale,
             ln_spc_reduction,
+            l_ins,
+            t_ins,
+            r_ins,
+            b_ins,
             paragraphs,
         })
     }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -919,6 +919,17 @@ pub struct ShapeText {
     /// (e.g. 0.20 for `lnSpcReduction="20000"`). `None` when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ln_spc_reduction: Option<f64>,
+    /// `<a:bodyPr@lIns>` — left text inset in EMU (ECMA-376 §21.1.2.1.1
+    /// `CT_TextBodyProperties`). Emitted even at the default so the renderer uses
+    /// the spec inset (91440 EMU = 7.2 pt) instead of an empirical constant.
+    /// Same EMU convention as `ShapeParagraph.marL`.
+    pub l_ins: i64,
+    /// `<a:bodyPr@tIns>` — top text inset in EMU. Default 45720 (3.6 pt).
+    pub t_ins: i64,
+    /// `<a:bodyPr@rIns>` — right text inset in EMU. Default 91440 (7.2 pt).
+    pub r_ins: i64,
+    /// `<a:bodyPr@bIns>` — bottom text inset in EMU. Default 45720 (3.6 pt).
+    pub b_ins: i64,
     pub paragraphs: Vec<ShapeParagraph>,
 }
 

--- a/packages/xlsx/src/empty-paragraph-shape-text-height.test.ts
+++ b/packages/xlsx/src/empty-paragraph-shape-text-height.test.ts
@@ -57,8 +57,10 @@ function para(text: string | null): ShapeParagraph {
 function shapeOf(paragraphs: ShapeParagraph[]): ShapeText {
   // Top-anchored + wrap:none isolates the line-height contribution: each line's
   // baseline is the cumulative sum of the heights of the lines above it, so the
-  // A→B gap reports exactly how much the middle paragraph reserved.
-  return { anchor: 't', wrap: 'none', paragraphs };
+  // A→B gap reports exactly how much the middle paragraph reserved. Insets are
+  // the ECMA-376 §21.1.2.1.1 spec defaults (the parser always emits them); the
+  // gap assertion below is independent of the constant top inset anyway.
+  return { anchor: 't', wrap: 'none', lIns: 91440, tIns: 45720, rIns: 91440, bIns: 45720, paragraphs };
 }
 
 function baselines(paragraphs: ShapeParagraph[]): FillTextCall[] {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3581,10 +3581,18 @@ export function drawShapeText(
   // by `cs` so the contents grow/shrink with the box on Excel's zoom slider —
   // matching how cell text scales via buildFont(font, cs). Without this the box
   // would zoom while the glyphs stayed fixed, drifting out of alignment.
-  const padX = 7 * cs;
-  const padY = 4 * cs;
-  const innerW = Math.max(0, sw - padX * 2);
-  const innerH = Math.max(0, sh - padY * 2);
+  // Text insets from `<a:bodyPr>` (ECMA-376 §21.1.2.1.1), EMU → px, scaled by
+  // `cs` like every other px size here. The parser always emits them (spec
+  // default 91440 EMU L/R = 9.6 px, 45720 EMU T/B = 4.8 px). This replaces the
+  // former empirical padX=7 / padY=4 constants with the real, per-side insets —
+  // the box is inset asymmetrically when the shape authors distinct lIns/rIns or
+  // tIns/bIns.
+  const padLeft = (txt.lIns / EMU_PER_PX) * cs;
+  const padRight = (txt.rIns / EMU_PER_PX) * cs;
+  const padTop = (txt.tIns / EMU_PER_PX) * cs;
+  const padBottom = (txt.bIns / EMU_PER_PX) * cs;
+  const innerW = Math.max(0, sw - padLeft - padRight);
+  const innerH = Math.max(0, sh - padTop - padBottom);
   if (innerW <= 0 || innerH <= 0) return;
 
   // A laid-out segment: measured text or a rasterized equation. `w` is the
@@ -3592,8 +3600,8 @@ export function drawShapeText(
   type Seg =
     | { kind: 'text'; text: string; font: string; color: string; w: number }
     | { kind: 'math'; render: MathRender; color: string; w: number; ascent: number; descent: number };
-  // `leftInset` = px from padX to this line's left edge (paragraph left margin,
-  // plus the first-line indent on a paragraph's first line). `availW` = the
+  // `leftInset` = px from padLeft to this line's left edge (paragraph left
+  // margin, plus the first-line indent on a paragraph's first line). `availW` = the
   // width of the alignment region for this line (paraW, minus the first-line
   // indent on the first line). ECMA-376 §21.1.2.2.7 (marL/marR/indent).
   type Line = { segs: Seg[]; align: string; height: number; ascent: number; hasMath: boolean; leftInset: number; availW: number };
@@ -3604,6 +3612,21 @@ export function drawShapeText(
     const px = size * PT_TO_PX * cs;
     const family = fontStackFor(run.fontFace);
     return { font: `${run.italic ? 'italic ' : ''}${run.bold ? 'bold ' : ''}${px}px ${family}`, px };
+  };
+
+  // Real font ascent for a line's alphabetic baseline (used on lines that mix
+  // text with an inline/display equation, where text and math share a baseline
+  // = lineTop + ascent). Mirrors the pptx renderer: measure the rendered glyphs'
+  // `actualBoundingBoxAscent` rather than the old flat 0.85×em heuristic, which
+  // over-/under-estimated for CJK and tall fonts. `font` must already be a valid
+  // CSS font string (measureText keys off `ctx.font`). Falls back to 0.85×px
+  // when the metric is unavailable (0), matching the prior constant.
+  const measuredAscent = (font: string, px: number): number => {
+    const prev = ctx.font;
+    ctx.font = font;
+    const a = ctx.measureText('M').actualBoundingBoxAscent;
+    ctx.font = prev;
+    return a > 0 ? a : px * 0.85;
   };
 
   // Wrap each paragraph into lines (segments preserve run order).
@@ -3675,7 +3698,12 @@ export function drawShapeText(
           intendedSingleLinePx(lastTextFaceEa, fallbackPx),
         );
         lineHeight = Math.max(fallbackPx * 1.2, designFloor);
-        lineAscent = fallbackPx * 0.85;
+        // An empty line carries no segment, so this ascent is never consumed by
+        // the draw pass (no text/math to place on the baseline); it is set only
+        // to keep the Line shape consistent. Measure it the same way as text
+        // runs — the nearest preceding face at the fallback size — rather than
+        // the old 0.85×em constant.
+        lineAscent = measuredAscent(`${fallbackPx}px ${fontStackFor(lastTextFace)}`, fallbackPx);
       }
       lineHeight = applyLineSpacing(lineHeight);
       lines.push({ segs, align, height: lineHeight, ascent: lineAscent, hasMath, leftInset: lineLeftInset(), availW: lineAvailW() });
@@ -3757,7 +3785,7 @@ export function drawShapeText(
       );
       const singleLinePx = Math.max(pxSize * 1.2, designFloor);
       lineHeight = Math.max(lineHeight, singleLinePx);
-      lineAscent = Math.max(lineAscent, pxSize * 0.85);
+      lineAscent = Math.max(lineAscent, measuredAscent(font, pxSize));
       ctx.font = font;
       // Defensive: a run's text may still contain a literal "\n".
       const pieces = run.text.split('\n');
@@ -3791,7 +3819,7 @@ export function drawShapeText(
             // Re-seed this continuation line with the same design-line-floored
             // single-line height as the run's first line (see singleLinePx above).
             lineHeight = Math.max(lineHeight, singleLinePx);
-            lineAscent = Math.max(lineAscent, pxSize * 0.85);
+            lineAscent = Math.max(lineAscent, measuredAscent(font, pxSize));
           } else {
             buf = candidate;
           }
@@ -3812,17 +3840,17 @@ export function drawShapeText(
   // Vertical anchor — ECMA-376 §20.1.7.2 <a:bodyPr anchor>.
   // For 'ctr' we intentionally skip Math.max(0,...) so the block stays
   // visually centered even when blockH exceeds innerH (text clips at edge).
-  let y0 = padY;
-  if (txt.anchor === 'ctr') y0 = padY + (innerH - blockH) / 2;
-  else if (txt.anchor === 'b') y0 = padY + Math.max(0, innerH - blockH);
+  let y0 = padTop;
+  if (txt.anchor === 'ctr') y0 = padTop + (innerH - blockH) / 2;
+  else if (txt.anchor === 'b') y0 = padTop + Math.max(0, innerH - blockH);
 
   let lineTop = y0;
   for (const line of lines) {
     const totalW = line.segs.reduce((s, seg) => s + seg.w, 0);
-    // Per-line region: the left edge is padX + the paragraph's left inset
+    // Per-line region: the left edge is padLeft + the paragraph's left inset
     // (marL, plus first-line indent on the first line), and alignment happens
     // within the line's available width (paraW). ECMA-376 §21.1.2.2.7.
-    const base = padX + line.leftInset;
+    const base = padLeft + line.leftInset;
     let x = base;
     if (line.align === 'ctr') x = base + Math.max(0, (line.availW - totalW) / 2);
     else if (line.align === 'r') x = base + Math.max(0, line.availW - totalW);

--- a/packages/xlsx/src/shape-paragraph-indent.test.ts
+++ b/packages/xlsx/src/shape-paragraph-indent.test.ts
@@ -73,11 +73,13 @@ describe('shape paragraph indent attributes (§21.1.2.2.7 marL/marR/indent)', ()
     expect(indentedX - baseX).toBeCloseTo(expectedShift, 5);
   });
 
-  it('a paragraph with no indent attrs is byte-identical (same x) to the baseline', () => {
+  it('a paragraph with no indent attrs draws at the left inset (§21.1.2.1.1 lIns)', () => {
     // Invariant: when marL/marR/indent are all absent, leftInset=0 and
-    // availW=innerW, so the draw x is exactly padX (the pre-change value).
+    // availW=innerW, so the draw x is exactly the left text inset padLeft. That
+    // is now the spec lIns (91440 EMU = 9.6 px at cs=1) the parser emits, not the
+    // former empirical padX=7.
     const noAttrs: ShapeParagraph = { align: 'l', runs: [textRun('X')] };
-    const padX = 7 * 1; // padX = 7 * cs in drawShapeText
+    const padX = (91440 / EMU_PER_PX) * 1; // lIns 91440 EMU → 9.6 px @ cs=1
     expect(drawFirstX(noAttrs)).toBeCloseTo(padX, 5);
   });
 
@@ -90,7 +92,7 @@ describe('shape paragraph indent attributes (§21.1.2.2.7 marL/marR/indent)', ()
       indent: 228600,
       runs: [textRun('X')],
     };
-    const padX = 7 * 1;
+    const padX = (91440 / EMU_PER_PX) * 1; // left inset (lIns) = 9.6 px
     expect(drawFirstX(p)).toBeCloseTo(padX + marLpx + indentPx, 5);
   });
 });
@@ -101,7 +103,7 @@ describe('shape paragraph indent attributes (§21.1.2.2.7 marL/marR/indent)', ()
 // first-line indent on line 1), `ctr` alignment within the indented region, the
 // hanging-indent clamp, and marR narrowing the wrap width.
 describe('shape paragraph indent — wrapping, alignment region, hanging, marR', () => {
-  const PADX = 7; // padX = 7 * cs (cs=1)
+  const PADX = 91440 / EMU_PER_PX; // left inset (lIns) 91440 EMU → 9.6 px @ cs=1
   // All fillText calls for a single paragraph at a given wrap mode (sw=sh=300, cs=1).
   function callsFor(p: ShapeParagraph, wrap: 'none' | 'normal'): FillTextCall[] {
     const { ctx, calls } = makeRecordingCtx();

--- a/packages/xlsx/src/shape-paragraph-indent.test.ts
+++ b/packages/xlsx/src/shape-paragraph-indent.test.ts
@@ -47,8 +47,9 @@ function textRun(text: string, size = 11): ShapeTextRun {
 
 function shapeOf(paragraphs: ShapeParagraph[]): ShapeText {
   // wrap:none keeps each paragraph on a single line so the first fillText x is
-  // the line's left edge (no wrapping interference).
-  return { anchor: 't', wrap: 'none', paragraphs };
+  // the line's left edge (no wrapping interference). Insets are the ECMA-376
+  // §21.1.2.1.1 spec defaults (the parser always emits them).
+  return { anchor: 't', wrap: 'none', lIns: 91440, tIns: 45720, rIns: 91440, bIns: 45720, paragraphs };
 }
 
 function drawFirstX(p: ShapeParagraph): number {
@@ -104,7 +105,13 @@ describe('shape paragraph indent — wrapping, alignment region, hanging, marR',
   // All fillText calls for a single paragraph at a given wrap mode (sw=sh=300, cs=1).
   function callsFor(p: ShapeParagraph, wrap: 'none' | 'normal'): FillTextCall[] {
     const { ctx, calls } = makeRecordingCtx();
-    drawShapeText(ctx, { anchor: 't', wrap, paragraphs: [p] }, 300, 300, 1);
+    drawShapeText(
+      ctx,
+      { anchor: 't', wrap, lIns: 91440, tIns: 45720, rIns: 91440, bIns: 45720, paragraphs: [p] },
+      300,
+      300,
+      1,
+    );
     return calls;
   }
 

--- a/packages/xlsx/src/shape-text-line-spacing.test.ts
+++ b/packages/xlsx/src/shape-text-line-spacing.test.ts
@@ -65,7 +65,16 @@ function paraCs(text: string, fontFaceCs: string): ShapeParagraph {
  *  (textBaseline='middle': drawY = lineTop + height/2, so gap = h0/2 + h1/2). */
 function gap(paragraphs: ShapeParagraph[], overrides: Partial<ShapeText> = {}): number {
   const { ctx, calls } = makeRecordingCtx();
-  const txt: ShapeText = { anchor: 't', wrap: 'none', paragraphs, ...overrides };
+  const txt: ShapeText = {
+    anchor: 't',
+    wrap: 'none',
+    lIns: 91440,
+    tIns: 45720,
+    rIns: 91440,
+    bIns: 45720,
+    paragraphs,
+    ...overrides,
+  };
   drawShapeText(ctx, txt, 400, 400, 1);
   const a = calls.find((c) => c.text === 'A');
   const b = calls.find((c) => c.text === 'B');

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -563,6 +563,16 @@ export interface ShapeText {
   /** `<a:normAutofit@lnSpcReduction>` — stored line-spacing reduction fraction
    *  (e.g. 0.20 for `lnSpcReduction="20000"`). Null/absent when unset. */
   lnSpcReduction?: number | null;
+  /** `<a:bodyPr@lIns>` — left text inset in EMU (ECMA-376 §21.1.2.1.1). Always
+   *  present; the spec default 91440 EMU (7.2 pt) when the attribute is absent.
+   *  Same EMU convention as `ShapeParagraph.marL`. */
+  lIns: number;
+  /** `<a:bodyPr@tIns>` — top text inset in EMU. Default 45720 (3.6 pt). */
+  tIns: number;
+  /** `<a:bodyPr@rIns>` — right text inset in EMU. Default 91440 (7.2 pt). */
+  rIns: number;
+  /** `<a:bodyPr@bIns>` — bottom text inset in EMU. Default 45720 (3.6 pt). */
+  bIns: number;
   paragraphs: ShapeParagraph[];
 }
 


### PR DESCRIPTION
## Summary

Phase 3 items D8 + C8 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md).

### D8 — DrawingML parsing into ooxml-common (behavior-preserving, VRT byte-identical)
- **Color nodes** (`ColorSource` + `ThemeResolver` trait + `parse_color_node`): the triplicated srgb/sys/prst/scheme extraction unifies over the already-shared transform math. **xlsx and docx gain `prstClr` resolution** (latent — no corpus sample uses it; unit-tested). `sysClr` unified to `lastClr.or(val)` (docx's historical fallback, spec-cleaner; grep-verified no val-only fixture). Each parser keeps a thin resolver + its exact hex casing/prefix — byte-stable.
- **Fills**: pptx's gradFill/pattFill parsing moves to `ooxml_common::fill` (verbatim; `GradStop` re-exported so pptx JSON is byte-identical). Deliberately NOT rolled out to xlsx/docx (no consumer yet — noted as the extension point).
- **BodyPr**: shared struct + `parse_body_pr` with spec defaults (91440/45720 EMU); pptx's shape→inherited→theme→spec precedence pre-baked into its `BodyPrDefaults` impl. pptx-only numCol/spcCol/rtlCol stay local.

### C8 — xlsx shape text: empirical constants → spec / measured
- Parser now reads `lIns/tIns/rIns/bIns` (was dropped; always emitted, spec-defaulted).
- Renderer: `padX=7 / padY=4` → real per-side insets (9.6/4.8px at the defaults, asymmetric-aware); `ascent = 0.85×size` → `measureText('M').actualBoundingBoxAscent` (kept local — pptx's accumulation isn't an identical extractable function, so no forced core lift; 0.85 retained as fallback). Line height 1.2×em untouched.

### VRT
- **D8 alone: byte-identical across all three formats.**
- **After C8: 67/67 xlsx pass — no threshold tripped; committed demo references byte-identical** (demo has no shape text). Three private sheets show the predicted correct-direction shift (shape text +~2.6px right / +~0.8px down toward Excel's true inset); diff PNGs confirm only in-shape text moved. References untouched — regenerating the 3 private ones is recommended housekeeping post-merge.

## Verification
- cargo fmt / clippy -D warnings / test (all crates; common 90 incl. new suites) — green
- pnpm build:wasm → test (1555) / typecheck / lint / smoke 6/6 — green
- Zero overlap with #678's files (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)