### PR TITLE
build: ship .wasm as real assets with a wasmUrl option — format chunks −85–89% (E4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ npm install @silurus/ooxml
 pnpm add @silurus/ooxml
 ```
 
-> **Bundler note**: this package embeds `.wasm` files. With Vite add [`vite-plugin-wasm`](https://github.com/Menci/vite-plugin-wasm); with webpack use [`experiments.asyncWebAssembly`](https://webpack.js.org/configuration/experiments/).
+> **Bundler note**: the Rust parsers ship as real `.wasm` asset files next to the
+> JavaScript, referenced with the standard `new URL('…', import.meta.url)` form
+> and fetched (streaming-compiled) at load time. Vite, webpack 5, Rollup,
+> esbuild and Parcel detect that reference and copy the asset automatically — no
+> extra WebAssembly plugin is required. If your bundler cannot emit the asset (or
+> you want to serve the parser WASM from a CDN or a path you control), pass its
+> URL via the `wasmUrl` load option:
+>
+> ```typescript
+> new DocxViewer(canvas, { wasmUrl: 'https://cdn.example.com/docx_parser_bg.wasm' });
+> ```
 
 > **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked Size* sums all four entry bundles, including the **opt-in** math engine (MathJax + STIX Two Math, ~4 MB). What actually lands in your app is much smaller — import only the format you need (e.g. `@silurus/ooxml/pptx`). The math engine is a **separate entry** (`@silurus/ooxml/math`): it is bundled **only if you import it and pass it to a viewer** (see [Rendering equations](#rendering-equations)). Viewers that never receive a `math` engine tree-shake the ~4 MB away entirely.
 
@@ -291,7 +301,7 @@ All three formats follow the same shape: the worker parses the `.docx` / `.xlsx`
 <summary><strong>React 19</strong></summary>
 
 ```tsx
-// React 19.1 — vite-plugin-wasm required in vite.config.ts
+// React 19.1 — Vite copies the parser .wasm asset automatically; no extra plugin needed.
 import { useEffect, useRef, useState } from 'react';
 import { PptxViewer } from '@silurus/ooxml/pptx';
 

--- a/packages/core/src/types/load-options.ts
+++ b/packages/core/src/types/load-options.ts
@@ -22,6 +22,21 @@ export interface LoadOptions {
    */
   useGoogleFonts?: boolean;
   /**
+   * Override the URL the parser worker fetches the WebAssembly module from.
+   *
+   * By default each format resolves the `.wasm` asset that ships next to its
+   * bundle (relative to the module URL), so no configuration is needed. Set
+   * this to serve the parser WASM from a CDN or a self-hosted path instead — a
+   * relative value is resolved against the current document URL. The same
+   * dependency-injection contract across docx / pptx / xlsx.
+   *
+   * The referenced file must be the matching format's `*_parser_bg.wasm`
+   * artifact (the one wasm-bindgen emitted for that parser); pointing it at a
+   * mismatched or missing file makes `load()` reject when the worker
+   * instantiates it.
+   */
+  wasmUrl?: string | URL;
+  /**
    * Override the per-entry ZIP decompression cap (bytes) used by the zip-bomb
    * guard in the Rust parser. Defaults to 512 MiB. Raise it to load documents
    * with very large embedded media, or lower it to tighten the budget for

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -54,14 +54,17 @@ export class DocxDocument {
   private readonly _fetchImage = (path: string, mime: string): Promise<Blob> =>
     this.getImage(path, mime);
 
-  private constructor(worker: Worker, mode: 'main' | 'worker') {
+  private constructor(worker: Worker, mode: 'main' | 'worker', wasmUrlOverride?: string | URL) {
     this._worker = worker;
     this._mode = mode;
     this._bridge = new WorkerBridge<WorkerResponse | RenderWorkerResponse>(this._worker, {
       correlate: (res) => res.id,
       toError: (res) => (res.type === 'error' ? res.message : undefined),
     });
-    const wasmUrl = new URL(wasmAssetUrl, location.href).href;
+    // Default: the parser WASM emitted next to this bundle, resolved relative to
+    // the document URL. `wasmUrl` overrides it (CDN / self-hosted copy); a
+    // relative override is still resolved against `location.href`.
+    const wasmUrl = new URL(wasmUrlOverride ?? wasmAssetUrl, location.href).href;
     this._bridge.post({ type: 'init', wasmUrl } satisfies WorkerRequest);
   }
 
@@ -76,7 +79,7 @@ export class DocxDocument {
       mode === 'worker'
         ? (await import('./render-worker-host')).createRenderWorker()
         : new InlineWorker();
-    const doc = new DocxDocument(worker, mode);
+    const doc = new DocxDocument(worker, mode, opts.wasmUrl);
     let buffer: ArrayBuffer;
     if (typeof source === 'string') {
       const res = await fetch(source);

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -325,6 +325,7 @@ export class DocxScrollViewer {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         workerTimeoutMs: this._opts.workerTimeoutMs,
+        wasmUrl: this._opts.wasmUrl,
         math: this._opts.math,
         mode: this._mode,
       });

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -95,6 +95,7 @@ export class DocxViewer {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         workerTimeoutMs: this._opts.workerTimeoutMs,
+        wasmUrl: this._opts.wasmUrl,
         math: this._opts.math,
         mode: this._mode,
       });

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -103,7 +103,7 @@ export class PptxPresentation {
    *  and are skipped (engine tree-shaken) when omitted. */
   private _math: MathRenderer | undefined;
 
-  private constructor(worker: Worker, mode: 'main' | 'worker') {
+  private constructor(worker: Worker, mode: 'main' | 'worker', wasmUrlOverride?: string | URL) {
     this._worker = worker;
     this._mode = mode;
     this._bridge = new WorkerBridge<WorkerResponse | RenderWorkerResponse>(this._worker, {
@@ -118,7 +118,10 @@ export class PptxPresentation {
         }
       },
     });
-    const wasmUrl = new URL(wasmAssetUrl, location.href).href;
+    // Default: the parser WASM emitted next to this bundle, resolved relative to
+    // the document URL. `wasmUrl` overrides it (CDN / self-hosted copy); a
+    // relative override is still resolved against `location.href`.
+    const wasmUrl = new URL(wasmUrlOverride ?? wasmAssetUrl, location.href).href;
     this._bridge.post({ kind: 'init', wasmUrl } satisfies WorkerRequest);
   }
 
@@ -137,7 +140,7 @@ export class PptxPresentation {
       mode === 'worker'
         ? (await import('./render-worker-host')).createRenderWorker()
         : new InlineWorker();
-    const pres = new PptxPresentation(worker, mode);
+    const pres = new PptxPresentation(worker, mode, opts.wasmUrl);
     let buffer: ArrayBuffer;
     if (typeof source === 'string') {
       const res = await fetch(source);

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -334,6 +334,7 @@ export class PptxScrollViewer {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         workerTimeoutMs: this._opts.workerTimeoutMs,
+        wasmUrl: this._opts.wasmUrl,
         math: this._opts.math,
         mode: this._mode,
       });

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -139,6 +139,7 @@ export class PptxViewer {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         workerTimeoutMs: this.opts.workerTimeoutMs,
+        wasmUrl: this.opts.wasmUrl,
         math: this.opts.math,
         mode: this._mode,
       });

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -613,6 +613,7 @@ export class XlsxViewer {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         workerTimeoutMs: this.opts.workerTimeoutMs,
+        wasmUrl: this.opts.wasmUrl,
         math: this.opts.math,
         mode: this._mode,
       });

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -65,14 +65,17 @@ export class XlsxWorkbook {
   private math: MathRenderer | undefined;
   private _mode: 'main' | 'worker' = 'main';
 
-  private constructor(worker: Worker, mode: 'main' | 'worker') {
+  private constructor(worker: Worker, mode: 'main' | 'worker', wasmUrlOverride?: string | URL) {
     this.worker = worker;
     this._mode = mode;
     this.bridge = new WorkerBridge<WorkerResponse | RenderWorkerResponse>(this.worker, {
       correlate: (res) => res.id,
       toError: (res) => (res.type === 'error' ? res.message : undefined),
     });
-    const wasmUrl = new URL(wasmAssetUrl, location.href).href;
+    // Default: the parser WASM emitted next to this bundle, resolved relative to
+    // the document URL. `wasmUrl` overrides it (CDN / self-hosted copy); a
+    // relative override is still resolved against `location.href`.
+    const wasmUrl = new URL(wasmUrlOverride ?? wasmAssetUrl, location.href).href;
     this.bridge.post({ type: 'init', wasmUrl } satisfies WorkerRequest);
   }
 
@@ -88,7 +91,7 @@ export class XlsxWorkbook {
       mode === 'worker'
         ? (await import('./render-worker-host')).createRenderWorker()
         : new InlineWorker();
-    const wb = new XlsxWorkbook(worker, mode);
+    const wb = new XlsxWorkbook(worker, mode, opts.wasmUrl);
     await wb._load(source, opts);
     return wb;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,59 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import wasm from 'vite-plugin-wasm';
 import dts from 'vite-plugin-dts';
-import { resolve, dirname } from 'path';
+import { resolve, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
+import { readFile } from 'fs/promises';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Emit `*.wasm?url` imports as real asset files instead of base64 `data:` URLs.
+ *
+ * Vite **library mode** force-inlines every `?url` asset as a
+ * `data:application/wasm;base64,…` string regardless of `assetsInlineLimit`
+ * (a number or a `() => false` function does NOT override it). That inflates the
+ * WASM by +33 % and blocks `WebAssembly.compileStreaming` (a data URL cannot be
+ * fetch-streamed — the worker has to `atob` the base64 by hand).
+ *
+ * The single `.wasm?url` import lives in each format's main-thread handle
+ * (`document.ts` / `presentation.ts` / `workbook.ts`). We intercept it here,
+ * `emitFile` the bytes as a hashless asset next to the chunk, and hand back the
+ * standard ESM asset reference `new URL('<name>.wasm', import.meta.url)` — the
+ * form Vite / webpack 5 / Rollup / esbuild all rewrite when they re-bundle our
+ * `.mjs`, and which resolves correctly for a plain `<script type=module>` too.
+ * wasm-bindgen's `--target web` glue then `fetch()`es that URL and hits
+ * `instantiateStreaming`.
+ *
+ * Runs with `enforce: 'pre'` and only claims the `?url` variant; the bare-`.wasm`
+ * import (owned by `vite-plugin-wasm`) is untouched — though nothing in the tree
+ * imports bare `.wasm`, so in practice this is the only WASM interception point.
+ */
+function wasmAssetUrl(): Plugin {
+  const SUFFIX = '.wasm?url';
+  return {
+    name: 'wasm-asset-url',
+    enforce: 'pre',
+    async load(id) {
+      if (!id.endsWith(SUFFIX)) return null;
+      const filePath = id.slice(0, -'?url'.length);
+      const source = await readFile(filePath);
+      const referenceId = this.emitFile({
+        type: 'asset',
+        name: basename(filePath),
+        source,
+      });
+      // `import.meta.ROLLUP_FILE_URL_<id>` expands to the emitted asset's URL at
+      // render time; wrapping it in `new URL(…, import.meta.url)` yields an
+      // absolute href the worker can fetch from any realm.
+      return `export default new URL(import.meta.ROLLUP_FILE_URL_${referenceId}, import.meta.url).href;`;
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
+    wasmAssetUrl(),
     wasm(),
     dts({
       include: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,11 @@ function wasmAssetUrl(): Plugin {
   return {
     name: 'wasm-asset-url',
     enforce: 'pre',
+    // Build-only: emitFile/ROLLUP_FILE_URL are Rollup build machinery and do
+    // not exist on the dev server. In dev, Vite's stock `?url` handling serves
+    // the file directly (the pre-E4 behavior) — intercepting there returned an
+    // unresolvable reference and broke every WASM load (caught by CI smoke).
+    apply: 'build',
     async load(id) {
       if (!id.endsWith(SUFFIX)) return null;
       const filePath = id.slice(0, -'?url'.length);


### PR DESCRIPTION
## Summary

Phase 4 item E4 from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md).

### Before (measured)
Vite **library mode force-inlines `?url` assets** regardless of `assetsInlineLimit`, so every format chunk carried its parser as a `data:application/wasm;base64` string — the confirmed +33% inflation (e.g. pptx 717KB → 956KB of base64), no `compileStreaming`, worker-side `atob`.

### Change
- A small `enforce:'pre'` plugin intercepts the single `*.wasm?url` import per format and `emitFile`s the bytes as a real dist asset, returning the standard `new URL(import.meta.ROLLUP_FILE_URL_x, import.meta.url).href` reference. dist now ships three `.wasm` files, **zero data-URIs**; the wasm-bindgen glue hits `instantiateStreaming`.
- New shared `LoadOptions.wasmUrl?: string | URL` (all 3 formats + 6 viewer/scroll-viewer wrappers forward it) for CDN/self-hosting; unset keeps the bundled-asset relative resolution — no-options usage unchanged. The worker-side data-URL fallback **stays** (one `startsWith('data:')` guard) so consumer bundlers that inline assets keep working.
- README: bundler note + option doc.

| chunk | before | after |
|---|--:|--:|
| docx | 943,360 | **131,512 (−86%)** |
| pptx | 1,079,679 | **123,559 (−89%)** |
| xlsx | 1,108,443 | **162,063 (−85%)** |
| unpacked pkg | 9.00 MB | **8.36 MB (−675 KB)** |

### Worker-chunk 'triplication' — investigated, deliberately not deduped
The plan's premise doesn't hold: WorkerBridge is main-thread-only, and the three `render-worker-host` bundles are format-specific renderers inside self-contained `?worker&inline` Blobs (realm isolation — no external imports possible), dynamically imported only in worker mode. Prior memory also pins that externalizing the worker breaks npm consumers (hardcoded asset path → 404). Kept as-is with the evidence recorded.

## Verification
- pnpm test 1581 / typecheck / lint — green
- pnpm build: 3 real .wasm, publint clean; **local pack smoke** (npm i tarball → bare-Node import ×3 subpaths) passes
- VRT all formats: render unchanged; build-storybook OK
- Browser smoke delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)