### PR TITLE
refactor(docx): paginator's layout lines are reused by paint — compute-once stage 1 (B2)

### DIFF
--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -117,7 +117,7 @@ function para(text: string, over: Partial<DocParagraph> = {}): DocParagraph {
   } as unknown as DocParagraph;
 }
 
-function doc(body: BodyElement[], pageHeight = 60): DocxDocumentModel {
+function doc(body: BodyElement[], pageHeight = 60, settings?: Record<string, unknown>): DocxDocumentModel {
   const section: SectionProps = {
     pageWidth: 200, pageHeight,
     marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
@@ -130,6 +130,7 @@ function doc(body: BodyElement[], pageHeight = 60): DocxDocumentModel {
     footers: { default: null, first: null, even: null },
     fontFamilyClasses: { 'Times New Roman': 'roman' },
     footnotes: [],
+    ...(settings ? { settings } : {}),
   } as unknown as DocxDocumentModel;
 }
 
@@ -151,7 +152,7 @@ async function renderAllPages(model: DocxDocumentModel, pages: PaginatedBodyElem
  *  report how many measureText calls each variant made so the caller can pin
  *  whether the reuse actually fired (fewer measures) or the gate rejected it
  *  (equal measures). */
-async function assertReuseIdentical(model: DocxDocumentModel): Promise<{ pages: number; drawn: number; split: boolean; measuresOn: number; measuresOff: number }> {
+async function assertReuseIdentical(model: DocxDocumentModel): Promise<{ pages: number; drawn: number; split: boolean; measuresOn: number; measuresOff: number; streams: Call[][] }> {
   const pages = paginateDocument(model);
   // Sanity: this document actually split a paragraph, so stamped lines exist.
   const split = pages.some((pg) => pg.some((el) => (el as PaginatedBodyElement).lineSlice));
@@ -169,7 +170,7 @@ async function assertReuseIdentical(model: DocxDocumentModel): Promise<{ pages: 
     expect(on.perPage[p]).toEqual(off.perPage[p]);
     drawn += on.perPage[p].filter((c) => c.op !== 'img').length;
   }
-  return { pages: pages.length, drawn, split, measuresOn: on.measures, measuresOff: off.measures };
+  return { pages: pages.length, drawn, split, measuresOn: on.measures, measuresOff: off.measures, streams: on.perPage };
 }
 
 describe('compute-once line reuse — pixel identity (Phase 4-1 B2 Stage 1)', () => {
@@ -220,6 +221,44 @@ describe('compute-once line reuse — pixel identity (Phase 4-1 B2 Stage 1)', ()
     // proves the reuse did NOT silently fire on a paragraph whose measure lines
     // would have painted wrong.
     expect(r.measuresOn).toBe(r.measuresOff);
+  });
+
+  it('NUMPAGES field in a splitting paragraph: never stamped — field text resolves against the real page context', async () => {
+    // resolveFieldText is paint-state-dependent: numPages → state.totalPages,
+    // which is 1 in the paginator's measure state but the real count at paint.
+    // Stamped measure-time lines would freeze the stale "1" into the drawn text,
+    // so paragraphSegsStateSensitive excludes such paragraphs from stamping —
+    // they stay on the recompute path (the pre-reuse behaviour).
+    const text = Array.from({ length: 120 }, () => 'w').join(' ');
+    const p = para(text);
+    (p.runs as unknown[]).push({
+      type: 'field', fieldType: 'numPages', instruction: 'NUMPAGES', fallbackText: '?',
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', background: null,
+    });
+    const r = await assertReuseIdentical(doc([p as unknown as BodyElement]));
+    expect(r.pages).toBeGreaterThan(1);
+    expect(r.split).toBe(true);
+    // No stamp → no reuse: ON and OFF recomputed identically.
+    expect(r.measuresOn).toBe(r.measuresOff);
+    // And the CURRENT total page count was drawn (not the measure-time "1" —
+    // with pages > 1 the real count is distinguishable from the stale value).
+    const drewTotal = r.streams.some((page) => page.some((c) => c.text === String(r.pages)));
+    expect(drewTotal).toBe(true);
+  });
+
+  it('custom kinsoku settings: fresh-but-value-equal rule objects still reuse (=== alone would reject)', async () => {
+    // The prebuiltPages production path resolves resolveKinsokuRules(doc.settings)
+    // TWICE — once in paginateDocument, once in renderDocumentToCanvas — and the
+    // resolver builds fresh Set objects per call. With custom settings the rules
+    // are non-default on both sides yet reference-distinct; the gate's value
+    // equivalence must still let the reuse fire.
+    const text = Array.from({ length: 120 }, () => 'w').join(' ');
+    const model = doc([para(text) as unknown as BodyElement], 60,
+      { kinsoku: true, noLineBreaksBefore: '、。！' , noLineBreaksAfter: '（「' });
+    const r = await assertReuseIdentical(model);
+    expect(r.pages).toBeGreaterThan(1);
+    expect(r.measuresOn).toBeLessThan(r.measuresOff); // reuse fired across fresh rule objects
   });
 
   it('same page rendered twice is identical (shared stamped array is never mutated)', async () => {

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas, paginateDocument, __test_setLineReuseEnabled } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, PaginatedBodyElement } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 4-1 B2 Stage 1 — pixel-identity of the compute-once line reuse.
+//
+// renderParagraph reuses the paginator's stamped scale-1 lines instead of
+// re-running layoutLines (see the reuse gate in renderer.ts). This suite pins
+// that the reuse is behaviour-PRESERVING: rendering the exact same page with
+// reuse ON and with reuse OFF must emit a byte-identical paint call stream
+// (every fillText / strokeText / drawImage with identical text, x, y and font).
+//
+// The pages are built with `paginateDocument` (a fresh OffscreenCanvas(1,1)) and
+// handed to `renderDocumentToCanvas` via `prebuiltPages` — the SAME cross-context
+// flow the public `DocxDocument.renderPage` uses, so the test exercises the real
+// production reuse path (paginate ctx ≠ paint ctx), not a same-ctx shortcut. The
+// render width equals the page width so the paint scale is exactly 1 and the
+// reuse gate actually fires.
+//
+// Coverage: a long single-column paragraph that splits across pages (reuse fires),
+// a justified paragraph (per-line slack distribution reads the reused segments),
+// a CJK paragraph (per-glyph wrap), and a NUMBERED list that splits (reuse must
+// NOT fire — the firstLineIndent gate rejects it — yet the recompute path is
+// still identical to itself). Also pins that painting the same page twice is
+// identical (the shared stamped array is never mutated by the draw path).
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Call { op: 'fill' | 'stroke' | 'img'; text: string; x: number; y: number; font: string; }
+
+/** `paginateDocument` builds its measure ctx from `new OffscreenCanvas(1,1)`,
+ *  which the node test env lacks. Polyfill it with the SAME linear metric the
+ *  recording paint canvas uses (glyph width = fontPx·0.5) so the paginate ctx and
+ *  the paint ctx measure identically — the condition under which Stage 1
+ *  guarantees byte-identical reuse. (Real cross-context metric parity is a browser
+ *  Canvas invariant, exercised end-to-end by `pnpm vrt`.) */
+function makeMeasureStubCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const per = p * 0.5;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeMeasureStubCtx(); }
+};
+
+/** A recording context whose glyph advance is LINEAR in the font px size, so the
+ *  scale-1 paginate lines and the scale-1 paint lines are bit-identical (this
+ *  test is about the reuse mechanism, not font hinting). It records every text
+ *  and image draw with position + font for an exact stream comparison. */
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[]; measures: () => number } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  let measures = 0;
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      measures++;
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const per = p * 0.5;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage(_img: unknown, x: number, y: number) { calls.push({ op: 'img', text: '', x, y, font }); },
+    fillText(s: string, x: number, y: number) { calls.push({ op: 'fill', text: s, x, y, font }); },
+    strokeText(s: string, x: number, y: number) { calls.push({ op: 'stroke', text: s, x, y, font }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls, measures: () => measures };
+}
+
+function para(text: string, over: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...over,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[], pageHeight = 60): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+/** Render every page of `model` at scale 1 (width == pageWidth) via the shared
+ *  prebuilt pages, returning the concatenated paint stream per page. */
+async function renderAllPages(model: DocxDocumentModel, pages: PaginatedBodyElement[][]): Promise<{ perPage: Call[][]; measures: number }> {
+  const perPage: Call[][] = [];
+  let measures = 0;
+  for (let p = 0; p < pages.length; p++) {
+    const rec = makeRecordingCanvas();
+    await renderDocumentToCanvas(model, rec.canvas, p, { dpr: 1, width: 200, prebuiltPages: pages });
+    perPage.push(rec.calls);
+    measures += rec.measures();
+  }
+  return { perPage, measures };
+}
+
+/** Assert reuse ON and reuse OFF paint an identical stream on every page, and
+ *  report how many measureText calls each variant made so the caller can pin
+ *  whether the reuse actually fired (fewer measures) or the gate rejected it
+ *  (equal measures). */
+async function assertReuseIdentical(model: DocxDocumentModel): Promise<{ pages: number; drawn: number; split: boolean; measuresOn: number; measuresOff: number }> {
+  const pages = paginateDocument(model);
+  // Sanity: this document actually split a paragraph, so stamped lines exist.
+  const split = pages.some((pg) => pg.some((el) => (el as PaginatedBodyElement).lineSlice));
+
+  const prev = __test_setLineReuseEnabled(false);
+  let off: { perPage: Call[][]; measures: number };
+  try { off = await renderAllPages(model, pages); } finally { __test_setLineReuseEnabled(prev); }
+
+  const on = await renderAllPages(model, pages);
+
+  expect(on.perPage.length).toBe(off.perPage.length);
+  let drawn = 0;
+  for (let p = 0; p < on.perPage.length; p++) {
+    // Exact stream identity — same ops, text, positions, fonts, in the same order.
+    expect(on.perPage[p]).toEqual(off.perPage[p]);
+    drawn += on.perPage[p].filter((c) => c.op !== 'img').length;
+  }
+  return { pages: pages.length, drawn, split, measuresOn: on.measures, measuresOff: off.measures };
+}
+
+describe('compute-once line reuse — pixel identity (Phase 4-1 B2 Stage 1)', () => {
+  it('long single-column paragraph that splits across pages: reuse ON === reuse OFF', async () => {
+    const text = Array.from({ length: 120 }, () => 'w').join(' ');
+    const r = await assertReuseIdentical(doc([para(text) as unknown as BodyElement]));
+    expect(r.pages).toBeGreaterThan(1); // really split
+    expect(r.split).toBe(true);         // stamped lines present
+    expect(r.drawn).toBeGreaterThan(0); // really painted
+    // The reuse actually fired: the paint pass skipped its own wrap-loop
+    // measureText calls, so ON made strictly fewer than OFF.
+    expect(r.measuresOn).toBeLessThan(r.measuresOff);
+  });
+
+  it('justified paragraph (both): slack distribution over reused segments is identical', async () => {
+    const text = Array.from({ length: 120 }, (_, i) => (i % 3 === 0 ? 'lorem' : 'ipsum')).join(' ');
+    const r = await assertReuseIdentical(doc([para(text, { alignment: 'both' }) as unknown as BodyElement]));
+    expect(r.pages).toBeGreaterThan(1);
+    expect(r.drawn).toBeGreaterThan(0);
+    expect(r.measuresOn).toBeLessThan(r.measuresOff); // reuse fired
+  });
+
+  it('CJK paragraph (per-glyph wrap) that splits: reuse ON === reuse OFF', async () => {
+    const text = 'あ'.repeat(200);
+    const r = await assertReuseIdentical(doc([para(text) as unknown as BodyElement]));
+    expect(r.pages).toBeGreaterThan(1);
+    expect(r.drawn).toBeGreaterThan(0);
+    expect(r.measuresOn).toBeLessThan(r.measuresOff); // reuse fired
+  });
+
+  it('numbered list that splits: reuse gate rejects it (firstLineIndent) yet paint is identical', async () => {
+    // A numbered paragraph: measure lays out with para.indentFirst, paint with
+    // numBodyOffset — the gate's firstIndent check fails, so reuse does NOT fire.
+    // The recompute path must still be self-identical (this is the control that
+    // proves the gate's rejection is safe and that toggling reuse is a no-op here).
+    const numbering = { numId: 1, level: 0, format: 'decimal', text: '1.',
+      indentLeft: 36, tab: 36, suff: 'tab', jc: 'left' } as unknown as DocParagraph['numbering'];
+    const text = Array.from({ length: 120 }, () => 'w').join(' ');
+    const p = para(text, {
+      numbering, indentLeft: 36, indentFirst: -18,
+    });
+    const r = await assertReuseIdentical(doc([p as unknown as BodyElement]));
+    expect(r.pages).toBeGreaterThan(1);
+    expect(r.drawn).toBeGreaterThan(0);
+    // The gate REJECTED reuse for the numbered list (firstLineIndent derivation
+    // differs between measure and paint), so ON and OFF recomputed identically —
+    // the measure counts are equal. This is what makes the gate non-vacuous: it
+    // proves the reuse did NOT silently fire on a paragraph whose measure lines
+    // would have painted wrong.
+    expect(r.measuresOn).toBe(r.measuresOff);
+  });
+
+  it('same page rendered twice is identical (shared stamped array is never mutated)', async () => {
+    const text = Array.from({ length: 120 }, () => 'w').join(' ');
+    const model = doc([para(text) as unknown as BodyElement]);
+    const pages = paginateDocument(model);
+    const first = await renderAllPages(model, pages);
+    const second = await renderAllPages(model, pages);
+    for (let p = 0; p < first.perPage.length; p++) expect(second.perPage[p]).toEqual(first.perPage[p]);
+  });
+});

--- a/packages/docx/src/layout-lines-scale-invariance.test.ts
+++ b/packages/docx/src/layout-lines-scale-invariance.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'vitest';
+import {
+  __test_layoutLines as layoutLines,
+  type __test_LayoutSeg as LayoutSeg,
+  type __test_LayoutLine as LayoutLine,
+  type __test_LayoutTextSeg as LayoutTextSeg,
+  type __test_WrapLayoutCtx as WrapLayoutCtx,
+} from './renderer.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 4-1 B2 Stage 1 — scale-invariance characterization of `layoutLines`.
+//
+// `layoutLines` is the ONE line-breaking + measurement kernel called by both the
+// paginator (scale 1, pt space) and the paint pass (device scale). Stage 1's
+// compute-once refactor stamps the paginator's scale-1 lines and rehydrates them
+// at the paint scale by multiplying the px fields by `scale`. For that to be a
+// behaviour-preserving optimisation, the two calls
+//
+//     A = layoutLines(ctx, segs, W,   indent,   1, …, gridΔ·1)
+//     B = layoutLines(ctx, segs, W·s, indent·s, s, …, gridΔ·s)
+//
+// must relate as: every px field of B == s × the A field, and the STRUCTURE
+// (line count, per-line segment count, pt `height`, boolean flags) must be
+// invariant. This file pins that relationship AND, crucially, isolates the ONE
+// place it can break — the Canvas `ctx.measureText` advance is not guaranteed
+// scale-linear with a real (hinted) font. We therefore run the kernel through a
+// LINEAR mock canvas (glyph width exactly ∝ px) to prove the ALGORITHM is scale-
+// clean, and separately through a SUB-LINEAR mock to document the divergence a
+// real font can introduce (the Stage-2 material). No behaviour is changed here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface MeasureCall { font: string; text: string; }
+
+/** A recording 2D-context stub whose glyph advance is EXACTLY `perPx · px · n`
+ *  (linear in the font px size). Font-metric ascent/descent are the fixed 0.8/0.2
+ *  em ratios the renderer's fallback uses. This makes `ctx.measureText` perfectly
+ *  scale-linear, isolating the line-breaking ALGORITHM from font-hinting noise. */
+function makeLinearCtx(perPx = 0.5): { ctx: CanvasRenderingContext2D; calls: MeasureCall[] } {
+  let font = '10px serif';
+  const calls: MeasureCall[] = [];
+  const pxOf = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = pxOf();
+      calls.push({ font, text: s });
+      const per = p * perPx;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+/** A recording context whose glyph advance is SUB-LINEAR in the font px size —
+ *  `px · (perPx − shrink·px) · n` — the direction real font hinting bends (glyphs
+ *  are proportionally narrower at larger sizes). Used only to DOCUMENT the
+ *  non-linearity, never to gate the linear invariant. */
+function makeSubLinearCtx(perPx = 0.5, shrink = 0.01): { ctx: CanvasRenderingContext2D } {
+  let font = '10px serif';
+  const pxOf = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = pxOf();
+      const per = Math.max(0.01, p * (perPx - shrink * p));
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D };
+}
+
+function textSeg(text: string, fontSize = 10, extra: Partial<LayoutTextSeg> = {}): LayoutSeg {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'Times New Roman', vertAlign: null,
+    measuredWidth: 0, ...extra,
+  } as LayoutSeg;
+}
+
+/** Deep-clone segs so a scale=1 call and a scale=s call never share the mutable
+ *  `measuredWidth` fields layoutLines writes into the seg objects. */
+function cloneSegs(segs: LayoutSeg[]): LayoutSeg[] {
+  return segs.map((s) => ({ ...s }));
+}
+
+/** Assert every px field of `b` equals `s ×` the matching field of `a`, and the
+ *  structure (line count, per-line segment count, pt height, flags) matches. This
+ *  is the exact contract Stage 1's stamp→rehydrate relies on. */
+function assertScaleLinear(a: LayoutLine[], b: LayoutLine[], s: number, tol = 1e-6): void {
+  expect(b.length).toBe(a.length);
+  for (let i = 0; i < a.length; i++) {
+    const la = a[i];
+    const lb = b[i];
+    // Structure: same segment partition per line.
+    expect(lb.segments.length).toBe(la.segments.length);
+    // pt height is scale-INVARIANT.
+    expect(lb.height).toBeCloseTo(la.height, tol);
+    // px fields scale by exactly `s`.
+    expect(lb.ascent).toBeCloseTo(la.ascent * s, tol);
+    expect(lb.descent).toBeCloseTo(la.descent * s, tol);
+    expect(lb.intendedSingle).toBeCloseTo(la.intendedSingle * s, tol);
+    expect(lb.xOffset).toBeCloseTo(la.xOffset * s, tol);
+    expect(lb.availWidth).toBeCloseTo(la.availWidth * s, tol);
+    // Boolean flags invariant.
+    expect(!!lb.hasRuby).toBe(!!la.hasRuby);
+    expect(!!lb.endsWithBreak).toBe(!!la.endsWithBreak);
+    // topY (present only under a wrap ctx) scales by `s` too.
+    if (la.topY === undefined) expect(lb.topY).toBeUndefined();
+    else expect(lb.topY as number).toBeCloseTo((la.topY as number) * s, tol);
+    // Per-segment measuredWidth (px) scales by `s`.
+    for (let j = 0; j < la.segments.length; j++) {
+      expect(lb.segments[j].measuredWidth).toBeCloseTo(la.segments[j].measuredWidth * s, tol);
+    }
+  }
+}
+
+const SCALES = [1.5, 2, 3];
+
+describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, the algorithm is scale-clean', () => {
+  it('plain Latin wrap: every px field scales ×s, structure invariant', () => {
+    // 40 single-letter "words" so the breaker has many wrap points; W=100pt.
+    const segs = () => [textSeg(Array.from({ length: 40 }, () => 'w').join(' '))];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 100, 0, 1);
+    expect(base.length).toBeGreaterThan(1); // actually wrapped — non-vacuous
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 100 * s, 0 * s, s);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('first-line indent participates in the ×s relationship', () => {
+    const segs = () => [textSeg(Array.from({ length: 30 }, () => 'ab').join(' '))];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 120, 18, 1);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 120 * s, 18 * s, s);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('mixed font sizes on one paragraph keep the ×s relationship', () => {
+    const segs = () => [
+      textSeg('Heading ', 18),
+      textSeg('body text follows here and wraps around ', 10),
+      textSeg('and a bigger ', 14),
+      textSeg('tail word list goes on and on and on', 10),
+    ];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 90, 0, 1);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 90 * s, 0 * s, s);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('manual line break (endsWithBreak) and empty trailing line survive ×s', () => {
+    const segs = (): LayoutSeg[] => [
+      textSeg('first line here '),
+      { lineBreak: true, fontSize: 10, measuredWidth: 0 } as unknown as LayoutSeg,
+      textSeg('second line here '),
+      { lineBreak: true, fontSize: 10, measuredWidth: 0 } as unknown as LayoutSeg,
+    ];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 200, 0, 1);
+    // The trailing break reserves an empty final line; endsWithBreak flags set.
+    expect(base.some((l) => l.endsWithBreak)).toBe(true);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 200 * s, 0 * s, s);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('CJK wrap (no spaces, per-glyph break) scales ×s under a linear font', () => {
+    const segs = () => [textSeg('あ'.repeat(30), 10)];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 80, 0, 1);
+    expect(base.length).toBeGreaterThan(1);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 80 * s, 0 * s, s);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('docGrid character delta (gridDeltaPx) scales ×s with the box', () => {
+    // linesAndChars grid: a per-EA-glyph cell delta in px. It must scale with the
+    // box so the gridded advance stays ×s. Δ at scale 1 = -2px, at scale s = -2·s.
+    const segs = () => [textSeg('あ'.repeat(20), 10)];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 120, 0, 1, [], undefined, {}, 0,
+      undefined, -2);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 120 * s, 0 * s, s, [], undefined, {}, 0,
+        undefined, -2 * s);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('left tab-stop advance scales ×s (tabStops given in pt, tabOrigin in px)', () => {
+    const segs = (): LayoutSeg[] => [
+      textSeg('a'),
+      { isTab: true, fontSize: 10, measuredWidth: 0, bold: false, italic: false } as unknown as LayoutSeg,
+      textSeg('b'),
+    ];
+    const tabStops = [{ pos: 72, alignment: 'left' as const, leader: 'none' as const }];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 300, 0, 1, tabStops, undefined, {}, 0);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 300 * s, 0 * s, s, tabStops, undefined, {}, 0);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('right/decimal tab-stop advance (look-ahead) scales ×s', () => {
+    const segs = (): LayoutSeg[] => [
+      textSeg('name'),
+      { isTab: true, fontSize: 10, measuredWidth: 0, bold: false, italic: false } as unknown as LayoutSeg,
+      textSeg('99'),
+    ];
+    const tabStops = [{ pos: 200, alignment: 'right' as const, leader: 'dot' as const }];
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 300, 0, 1, tabStops, undefined, {}, 0);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 300 * s, 0 * s, s, tabStops, undefined, {}, 0);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+
+  it('float wrap context (xOffset/availWidth/topY per line) scales ×s', () => {
+    // A left-edge float band on the first ~2 lines forces xOffset/availWidth to
+    // vary per line and each line to carry a topY. All must scale ×s.
+    const segs = () => [textSeg(Array.from({ length: 30 }, () => 'ab').join(' '))];
+    const mkWrap = (s: number): WrapLayoutCtx => ({
+      startPageY: 0 * s,
+      paraX: 0 * s,
+      floats: [{ x: 0 * s, y: 0 * s, w: 30 * s, h: 24 * s } as unknown as WrapLayoutCtx['floats'][number]],
+      lineBoxH: (asc: number, desc: number) => asc + desc, // linear in px → scales ×s
+      pageH: 1000 * s,
+      markEmPx: 10 * s,
+    });
+    const { ctx: c1 } = makeLinearCtx();
+    const base = layoutLines(c1, cloneSegs(segs()), 120, 0, 1, [], mkWrap(1), {}, 0);
+    // The float actually perturbed the first line (xOffset > 0 somewhere).
+    expect(base.some((l) => l.xOffset > 0 || (l.topY ?? 0) > 0)).toBe(true);
+    for (const s of SCALES) {
+      const { ctx } = makeLinearCtx();
+      const scaled = layoutLines(ctx, cloneSegs(segs()), 120 * s, 0 * s, s, [], mkWrap(s), {}, 0);
+      assertScaleLinear(base, scaled, s);
+    }
+  });
+});
+
+describe('layoutLines scale-dependence under a NON-linear (real-font-like) advance — the Stage-2 material', () => {
+  // With a sub-linear glyph advance (the direction real hinting bends), the SAME
+  // paragraph can wrap to a DIFFERENT line count at a larger scale — more glyphs
+  // fit per line. This is the one true source of paginate(scale 1)/paint(scale s)
+  // divergence, and the reason Stage 1's stamp→rehydrate must NOT blindly reuse
+  // the scale-1 line PARTITION when the paint scale would wrap differently. We
+  // pin the divergence exists so Stage 2 can design against it; it is NOT a
+  // regression to fix here.
+  it('DOCUMENTS: a long paragraph wraps to fewer lines at scale 2 than at scale 1', () => {
+    const text = Array.from({ length: 200 }, () => 'w').join(' ');
+    const segs = () => [textSeg(text)];
+    const { ctx: c1 } = makeSubLinearCtx();
+    const a = layoutLines(c1, cloneSegs(segs()), 100, 0, 1);
+    const { ctx: c2 } = makeSubLinearCtx();
+    const b = layoutLines(c2, cloneSegs(segs()), 100 * 2, 0, 2);
+    // Fewer lines at the larger scale — the exact paginate/paint mismatch the
+    // paint loop already guards (paintEnd = min(sliceEnd, lines.length)).
+    expect(b.length).toBeLessThan(a.length);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2395,12 +2395,24 @@ function paginateWithHeaderFooterReserve(
   return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, pageReserves, defaultTabPt);
 }
 
-/** Paginate with a throwaway measure context. Pagination must use the same
- *  fontFamilyClasses + kinsoku rules as the render path, otherwise line-break
- *  decisions (and thus page breaks) diverge between measurement and paint
- *  (ECMA-376 §17.15.1.58–.60). Shared by the main-thread DocxDocument and the
- *  render worker so the two modes can never paginate differently. */
-
+/** Paginate with a throwaway measure context (a fresh OffscreenCanvas, scale 1).
+ *  Pagination must use the same fontFamilyClasses + kinsoku rules as the render
+ *  path, otherwise line-break decisions (and thus page breaks) diverge between
+ *  measurement and paint (ECMA-376 §17.15.1.58–.60). Shared by the main-thread
+ *  DocxDocument and the render worker so the two modes can never paginate
+ *  differently.
+ *
+ *  FONT-LOADING PRECONDITION: the OffscreenCanvas measurement here uses whatever
+ *  fonts are loaded AT CALL TIME. Callers must ensure font loading has completed
+ *  (e.g. await `document.fonts.ready` / the relevant `FontFace.load()`) before
+ *  paginating — paginating against fallback metrics and painting after the real
+ *  fonts arrive yields stale page breaks. This has always been true for the
+ *  lineSlice indices; since the compute-once reuse (Phase 4-1 B2 Stage 1) it
+ *  also covers the stamped line GEOMETRY: at paint scale 1 the renderer reuses
+ *  the lines measured here verbatim (renderParagraph's reuse gate assumes
+ *  measure-time and paint-time text metrics are identical), where the old
+ *  recompute path would at least have re-wrapped the within-page text under the
+ *  late-loaded fonts. */
 export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[][] {
   const ctx = new OffscreenCanvas(1, 1).getContext('2d');
   if (!ctx) return [doc.body];
@@ -2755,6 +2767,12 @@ function splitParagraphAcrossPages(
   }
   const paraHasRuby = paragraphHasRuby(para);
 
+  // Compute-once eligibility, once per paragraph: a paragraph whose segment
+  // TEXT depends on the paint state (page/numPages fields, note references)
+  // must not ship its measure-time lines — the stamped text would be stale.
+  // See paragraphSegsStateSensitive.
+  const stampLines = !paragraphSegsStateSensitive(para);
+
   const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby, l.intendedSingle, paragraphIsEastAsian(para));
   const uniformH = paraHasRuby
     ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), measureState.docGrid, 1)
@@ -2821,28 +2839,34 @@ function splitParagraphAcrossPages(
     }
     const isFinalSlice = lastFitting === lines.length;
     if (isFinalSlice) usedH += spaceAfter;
-    pages[pages.length - 1].push(stamp({
+    const sliceEl = {
       ...(para as object),
       type: 'paragraph',
       lineSlice: { start: firstFitting, end: lastFitting },
-      // Phase 4-1 B2 Stage 1 — hand the paint pass the scale-1 lines this split
-      // already computed so it can skip re-running layoutLines (compute-once).
-      // The FULL array is stamped on every slice (not `lines.slice(...)`) because
-      // the paint loop indexes by absolute line number; `lineSlice` still selects
-      // the sub-range to paint. The same immutable array is shared across slices
-      // and across repeated renderPage calls — the draw path only reads it. The
-      // recorded inputs let the paint pass verify its own layout would be
-      // identical before reusing (see renderParagraph's reuse gate).
-      layoutLines: lines,
-      layoutLinesInputs: {
+    } as PaginatedElementWithLines;
+    // Phase 4-1 B2 Stage 1 — hand the paint pass the scale-1 lines this split
+    // already computed so it can skip re-running layoutLines (compute-once).
+    // The FULL array is stamped on every slice (not `lines.slice(...)`) because
+    // the paint loop indexes by absolute line number; `lineSlice` still selects
+    // the sub-range to paint. The same immutable array is shared across slices
+    // and across repeated renderPage calls — the draw path only reads it. The
+    // recorded inputs let the paint pass verify its own layout would be
+    // identical before reusing (see renderParagraph's reuse gate). Skipped for
+    // state-sensitive segments (stampLines above): those keep the recompute
+    // path so field text resolves against the real page context.
+    if (stampLines) {
+      sliceEl.layoutLines = lines;
+      sliceEl.layoutLinesInputs = {
         scale: 1,
         paraW,
         firstIndent: para.indentFirst,
         tabOriginPx: indLeft,
         gridDeltaPx: gridCharDeltaPx(paraGrid(para, measureState), 1),
         hasFloats: wrapCtx !== undefined,
-      },
-    } as PaginatedElementWithLines));
+        kinsoku: measureState.kinsoku,
+      };
+    }
+    pages[pages.length - 1].push(stamp(sliceEl));
     lineIdx = lastFitting;
     cursorY += usedH;
     if (!isFinalSlice) {
@@ -4313,6 +4337,16 @@ function renderParagraph(
   // (whole-paragraph, first-page) lines do not carry. Rescaling to scale ≠ 1 is
   // deferred to Stage 2 (it changes the line PARTITION under real font hinting —
   // see layout-lines-scale-invariance.test.ts — i.e. a behaviour change).
+  //
+  // Segment stability: the reuse also assumes buildSegments(para.runs, ·) yields
+  // the SAME segments under the paginator's measure state and this paint state.
+  // buildSegments is pure over `para.runs` (both passes read the same paragraph
+  // object) EXCEPT for two paint-context text sources — page/numPages fields and
+  // noteRef labels — and paragraphs carrying those are never stamped in the
+  // first place (paragraphSegsStateSensitive, checked at the stamp site), so no
+  // per-segment gate comparison is needed here. If buildSegments ever gains a
+  // new state-dependent text source, extend that predicate — this gate cannot
+  // see inside the stamped segments.
   const stamped = para as unknown as PaginatedElementWithLines;
   const reuse =
     lineReuseEnabled &&
@@ -4325,7 +4359,13 @@ function renderParagraph(
     stamped.layoutLinesInputs.paraW === paraW &&
     stamped.layoutLinesInputs.firstIndent === firstLineIndent &&
     stamped.layoutLinesInputs.tabOriginPx === indLeft &&
-    stamped.layoutLinesInputs.gridDeltaPx === paintGridDeltaPx;
+    stamped.layoutLinesInputs.gridDeltaPx === paintGridDeltaPx &&
+    // §17.3.1.16 / §17.15.1.58–.59 — kinsoku governs CJK retract decisions in
+    // layoutLines, so differing rules mean a (potentially) different partition.
+    // Value equivalence, NOT `===`: the prebuiltPages path resolves the rules
+    // independently in paginateDocument and here (fresh Sets per call), so the
+    // references legitimately differ while the rules are identical.
+    kinsokuRulesEquivalent(stamped.layoutLinesInputs.kinsoku, state.kinsoku);
   const lines = reuse
     ? (stamped.layoutLines as LayoutLine[])
     : layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt);
@@ -5265,8 +5305,62 @@ type PaginatedElementWithLines = PaginatedBodyElement & {
     tabOriginPx: number; // pt (== indLeft at scale 1)
     gridDeltaPx: number; // pt
     hasFloats: boolean;  // a float context changes wrap → never reuse across it
+    /** The kinsoku rules the paginator laid out with (§17.3.1.16 / §17.15.1.58–.59).
+     *  Compared by {@link kinsokuRulesEquivalent} in the paint gate. NOTE this is
+     *  usually NOT reference-identical to the paint state's rules: the production
+     *  path resolves `resolveKinsokuRules(doc.settings)` once in paginateDocument
+     *  and again in renderDocumentToCanvas, and the resolver builds fresh Set
+     *  objects per call — so the gate needs value equivalence, not `===` alone. */
+    kinsoku: KinsokuRules;
   };
 };
+
+/** Value equivalence of two resolved kinsoku rule sets, with a reference fast
+ *  path. The reuse gate cannot rely on `===` alone: `resolveKinsokuRules` builds
+ *  a FRESH object (fresh Sets) on every call, and the prebuiltPages production
+ *  path (DocxDocument.renderPage) resolves it independently in paginateDocument
+ *  and in renderDocumentToCanvas — same `doc.settings`, different references.
+ *  Both derive from the same immutable settings so they are value-equal there;
+ *  this check is pure defense so a genuinely different rule set (which would
+ *  change CJK retract decisions in layoutLines) can never reuse stale lines. */
+function kinsokuRulesEquivalent(a: KinsokuRules, b: KinsokuRules): boolean {
+  if (a === b) return true;
+  if (a.enabled !== b.enabled) return false;
+  const setEq = (x: Set<number>, y: Set<number>): boolean => {
+    if (x.size !== y.size) return false;
+    for (const cp of x) if (!y.has(cp)) return false;
+    return true;
+  };
+  return setEq(a.lineStartForbidden, b.lineStartForbidden) && setEq(a.lineEndForbidden, b.lineEndForbidden);
+}
+
+/** True when {@link buildSegments} would produce DIFFERENT segments for this
+ *  paragraph under the paginator's measure state versus the paint state — i.e.
+ *  the segment text depends on per-page render context rather than on the runs
+ *  alone. Exactly two sources exist today:
+ *    - `field` runs of type page / numPages: {@link resolveFieldText} returns
+ *      `state.pageIndex + 1` / `state.totalPages`, and the measure state is
+ *      frozen at pageIndex 0 / totalPages 1 (buildMeasureState);
+ *    - `noteRef` text runs: the label resolves via `state.noteNumbers` /
+ *      `state.currentNoteNumber`, which only the paint state carries
+ *      (renderDocumentToCanvas builds the map; the measure state never does).
+ *  Such a paragraph must NOT stamp its measured lines: the stamped segments
+ *  would carry the measure-time text (a stale page number / note label) and the
+ *  paint pass would draw it verbatim. Skipping the stamp keeps those paragraphs
+ *  on the recompute path, which resolves fields against the real page context —
+ *  the pre-reuse behaviour. Extend this predicate if buildSegments ever gains a
+ *  new state-dependent text source. */
+function paragraphSegsStateSensitive(para: DocParagraph): boolean {
+  for (const run of para.runs) {
+    if (run.type === 'field') {
+      const ft = (run as unknown as FieldRun).fieldType;
+      if (ft === 'page' || ft === 'numPages') return true;
+    } else if (run.type === 'text' && (run as unknown as DocxTextRun).noteRef) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /** Phase 4-1 B2 Stage 1 — master switch for the compute-once line reuse. Always
  *  ON in production; the pixel-identity characterization test flips it OFF to

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2825,7 +2825,24 @@ function splitParagraphAcrossPages(
       ...(para as object),
       type: 'paragraph',
       lineSlice: { start: firstFitting, end: lastFitting },
-    } as PaginatedBodyElement));
+      // Phase 4-1 B2 Stage 1 — hand the paint pass the scale-1 lines this split
+      // already computed so it can skip re-running layoutLines (compute-once).
+      // The FULL array is stamped on every slice (not `lines.slice(...)`) because
+      // the paint loop indexes by absolute line number; `lineSlice` still selects
+      // the sub-range to paint. The same immutable array is shared across slices
+      // and across repeated renderPage calls — the draw path only reads it. The
+      // recorded inputs let the paint pass verify its own layout would be
+      // identical before reusing (see renderParagraph's reuse gate).
+      layoutLines: lines,
+      layoutLinesInputs: {
+        scale: 1,
+        paraW,
+        firstIndent: para.indentFirst,
+        tabOriginPx: indLeft,
+        gridDeltaPx: gridCharDeltaPx(paraGrid(para, measureState), 1),
+        hasFloats: wrapCtx !== undefined,
+      },
+    } as PaginatedElementWithLines));
     lineIdx = lastFitting;
     cursorY += usedH;
     if (!isFinalSlice) {
@@ -4281,7 +4298,37 @@ function renderParagraph(
   // indent (positive firstLine, or a bare negative hanging without a marker) to
   // the body as usual. RTL lists keep their existing start-edge handling.
   const firstLineIndent = hasMarker && !baseRtl ? numBodyOffset : firstLineX - paraX;
-  const lines = layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, gridCharDeltaPx(grid, scale), state.defaultTabPt);
+  const paintGridDeltaPx = gridCharDeltaPx(grid, scale);
+  // Phase 4-1 B2 Stage 1 — compute-once reuse. When the paginator split this
+  // paragraph it stamped the scale-1 lines it laid out (splitParagraphAcrossPages).
+  // Reuse them VERBATIM — skipping this scale's layoutLines entirely — but ONLY
+  // when the paint pass would produce a byte-identical array: its scale is 1 (so
+  // no px field needs rescaling; the scale-1 lines ARE the paint lines) AND every
+  // layout input matches the value the paginator used. The input check is what
+  // keeps this pixel-exact across the cases where measure and paint legitimately
+  // differ — most importantly the numbering firstLineIndent (measure uses
+  // para.indentFirst, paint uses numBodyOffset for a marker), which then fails the
+  // firstIndent equality and recomputes. A float context is excluded outright:
+  // float wrap depends on the page-absolute Y of THIS slice, which the stamped
+  // (whole-paragraph, first-page) lines do not carry. Rescaling to scale ≠ 1 is
+  // deferred to Stage 2 (it changes the line PARTITION under real font hinting —
+  // see layout-lines-scale-invariance.test.ts — i.e. a behaviour change).
+  const stamped = para as unknown as PaginatedElementWithLines;
+  const reuse =
+    lineReuseEnabled &&
+    stamped.layoutLines !== undefined &&
+    stamped.layoutLinesInputs !== undefined &&
+    scale === 1 &&
+    stamped.layoutLinesInputs.scale === 1 &&
+    !wrapCtx &&
+    !stamped.layoutLinesInputs.hasFloats &&
+    stamped.layoutLinesInputs.paraW === paraW &&
+    stamped.layoutLinesInputs.firstIndent === firstLineIndent &&
+    stamped.layoutLinesInputs.tabOriginPx === indLeft &&
+    stamped.layoutLinesInputs.gridDeltaPx === paintGridDeltaPx;
+  const lines = reuse
+    ? (stamped.layoutLines as LayoutLine[])
+    : layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt);
 
   // Decimal-tab auto-alignment. ECMA-376 (§17.3.1.37 tabs / §17.18.84 ST_TabJc
   // `decimal`) only positions content at a tab stop when an explicit tab
@@ -5190,6 +5237,43 @@ interface LayoutLine {
    *  like the paragraph's final line (§17.18.44). */
   endsWithBreak?: boolean;
 }
+
+/** Phase 4-1 B2 Stage 1 — a paginated element carrying the paginator's scale-1
+ *  laid-out lines (compute-once). `splitParagraphAcrossPages` stamps the FULL
+ *  paragraph line array (not the per-slice sub-range) onto every slice so the
+ *  paint pass can index it by ABSOLUTE line number exactly like a freshly
+ *  computed array (drawParagraphLine reads `lines[li]` / `lines.length`). Kept as
+ *  a renderer-internal intersection — `LayoutLine` is private to renderer.ts, so
+ *  this deliberately does NOT touch the public `PaginatedBodyElement` in types.ts
+ *  (which would need a renderer↔types import for the payload type; see the
+ *  ColumnGeom note above). `layoutLinesInputs` records the scale-1 inputs the
+ *  paginator laid the lines out with; the paint pass reuses them ONLY when its
+ *  own scale is 1 and every input matches, so no px field is ever rescaled. */
+type PaginatedElementWithLines = PaginatedBodyElement & {
+  layoutLines?: LayoutLine[];
+  /** The line-layout inputs the paginator used (all in the paginator's scale-1 pt
+   *  space). The paint pass reuses the stamped lines ONLY when its own scale is 1
+   *  AND every one of these inputs equals the value it would pass to layoutLines
+   *  itself — a self-verifying gate that stays correct across single/multi-column,
+   *  float wrap, and the numbering firstLineIndent derivation (which differs
+   *  between measure and paint for numbered lists, so those simply fail the
+   *  `firstIndent` check and recompute). No px field is ever rescaled. */
+  layoutLinesInputs?: {
+    scale: number;      // always 1 (paginator space)
+    paraW: number;      // pt
+    firstIndent: number; // pt
+    tabOriginPx: number; // pt (== indLeft at scale 1)
+    gridDeltaPx: number; // pt
+    hasFloats: boolean;  // a float context changes wrap → never reuse across it
+  };
+};
+
+/** Phase 4-1 B2 Stage 1 — master switch for the compute-once line reuse. Always
+ *  ON in production; the pixel-identity characterization test flips it OFF to
+ *  capture a fresh-recompute reference and assert the reuse path paints an
+ *  IDENTICAL stream (see layout-lines-reuse-identity.test.ts). Module-local so it
+ *  never leaks onto the public surface. */
+let lineReuseEnabled = true;
 
 /** Additional context passed to layoutLines so it can honor floats on the current page. */
 interface WrapLayoutCtx {
@@ -7378,6 +7462,16 @@ export const __test_isPageLevelAnchorY = (
  *  pt `height`) — and surfaces any field/branch that is NOT a clean ×scale. */
 export const __test_layoutLines = layoutLines;
 export type { LayoutSeg as __test_LayoutSeg, LayoutLine as __test_LayoutLine, LayoutTextSeg as __test_LayoutTextSeg, WrapLayoutCtx as __test_WrapLayoutCtx };
+
+/** Exported for the compute-once pixel-identity test (Phase 4-1 B2 Stage 1).
+ *  Toggles the stamped-line reuse in renderParagraph so the test can render the
+ *  SAME page with reuse ON and OFF and assert the paint call streams are
+ *  byte-identical. Returns the previous value so the test can restore it. */
+export const __test_setLineReuseEnabled = (v: boolean): boolean => {
+  const prev = lineReuseEnabled;
+  lineReuseEnabled = v;
+  return prev;
+};
 
 function resolveAnchorBox(
   img: ImageRun,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7368,6 +7368,17 @@ export const __test_isPageLevelAnchorY = (
   fromPara: boolean,
 ): boolean => isPageLevelAnchorY(rf, fromPara);
 
+/** Exported for the scale-invariance characterization test (Phase 4-1 B2 Stage 1).
+ *  {@link layoutLines} is the single line-breaking + measurement kernel called by
+ *  BOTH the paginator (scale 1, pt space) and the paint pass (device scale). The
+ *  compute-once refactor stamps the paginator's scale-1 lines and rehydrates them
+ *  at the paint scale, so the test pins EXACTLY which `LayoutLine` fields scale
+ *  linearly with the passed `scale` (px advances, ascent/descent, xOffset,
+ *  availWidth, topY) versus which are scale-invariant (segment count, line count,
+ *  pt `height`) — and surfaces any field/branch that is NOT a clean ×scale. */
+export const __test_layoutLines = layoutLines;
+export type { LayoutSeg as __test_LayoutSeg, LayoutLine as __test_LayoutLine, LayoutTextSeg as __test_LayoutTextSeg, WrapLayoutCtx as __test_WrapLayoutCtx };
+
 function resolveAnchorBox(
   img: ImageRun,
   state: RenderState,


### PR DESCRIPTION
## Summary

Phase 4-1 B2 **Stage 1** from the [2026-07 improvement plan](docs/improvement-plan-2026-07.md): the paginator computed `layoutLines` for every paragraph, kept only `lineSlice`, and threw the lines away — paint recomputed everything. First step of retiring the measure/paint double bookkeeping.

### Scale-linearity characterization (Stage 2's design input)
Under a linear mock font `layoutLines` is **perfectly scale-linear in every field** (px fields ×scale; structure invariant; grep-verified no px quantization in the function body). **The only scale-dependent thing is the line partition itself**, driven by real-font `measureText` hinting non-linearity (documented by a sub-linear-mock test). Everything else rescales cleanly — that's the exact boundary Stage 2 must handle.

### Compute-once with a self-verifying gate
The paginator now stamps its scale-1 lines next to `lineSlice`; `renderParagraph` reuses them **only when** `scale === 1` **and** every layout input it would pass matches what the paginator recorded (paraW / firstIndent / tabOrigin / gridDelta / no-float) — pixel-exact by construction, no rescaling attempted. The default `renderPage` path renders at scale 1, so the gate fires on the common path. Numbered lists deliberately fail the gate: the known measure-vs-paint `firstLineIndent` drift (`para.indentFirst` vs `numBodyOffset`) is real, confirmed, and left untouched — unifying it is Stage 2's explicit behaviour change.

### Proof & payoff
- Temporary real-Chromium spec rendered every docx sample page reuse-ON vs forced-OFF through the full cross-context path: **diffPixels = 0 on all 19 pages** (spec reverted after use).
- VRT all formats: no baseline change (docx 21 / pptx 75 / xlsx 67).
- Re-render bench (53-page doc): **~2.2× faster** (~10.3 → ~4.7 ms/full-doc; wrap-loop measureText skipped on reused paragraphs) — the B4 payoff, delivered structurally.

## Verification
- pnpm test 1603 / typecheck / lint — green
- VRT all formats — no baseline change
- Browser smoke delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)