### PR TITLE
feat(docx): zoom-invariant line breaking — reuse layout stamps at any scale (B2 stage 2)

### DIFF
--- a/packages/docx/src/layout-lines-zoom-invariant.test.ts
+++ b/packages/docx/src/layout-lines-zoom-invariant.test.ts
@@ -233,4 +233,53 @@ describe('zoom-invariant line breaking (Phase 4-1 B2 Stage 2)', () => {
     const reuseAt075 = await partitionAtWidth(model, pages, 150);
     expect(reuseAt075).toEqual(recomputeAt1);
   });
+
+  it('an ANCHORED image in the paragraph adds no inline advance at any scale', async () => {
+    // Anchored images live out of inline flow: layoutLines pins measuredWidth=0
+    // and never adds them to line.segments (they are drawn by renderAnchorImages).
+    // Characterizes that the reuse/rehydration path preserves this: the partition
+    // is zoom-invariant AND every line's first glyph starts at the paragraph
+    // origin (∝ scale) — not shifted right by imageWidth·scale, which is what a
+    // rescale that conjured an inline advance for the anchor would produce.
+    const text = Array.from({ length: 120 }, (_, i) => `w${i % 10}`).join(' ');
+    const p = para(text);
+    p.runs.unshift({
+      type: 'image', imagePath: 'word/media/image1.png', mimeType: 'image/png',
+      widthPt: 50, heightPt: 40, anchor: true, anchorXPt: 30, anchorYPt: 20,
+    } as unknown as DocParagraph['runs'][number]);
+    const model = doc([p as unknown as BodyElement]);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+
+    const collect = async (width: number): Promise<{ partition: string[]; firstX: number[] }> => {
+      const partition: string[] = [];
+      const firstX: number[] = [];
+      for (let pg = 0; pg < pages.length; pg++) {
+        const rec = makeRecordingCanvas();
+        await renderDocumentToCanvas(model, rec.canvas, pg, { dpr: 1, width, prebuiltPages: pages });
+        const byLine = new Map<number, Draw[]>();
+        for (const d of rec.draws) {
+          const key = Math.round(d.y * 100) / 100;
+          if (!byLine.has(key)) byLine.set(key, []);
+          byLine.get(key)!.push(d);
+        }
+        for (const [, draws] of [...byLine.entries()].sort((a, b) => a[0] - b[0])) {
+          draws.sort((a, b) => a.x - b.x);
+          partition.push(draws.map((d) => d.text).join(''));
+          firstX.push(draws[0].x);
+        }
+      }
+      return { partition, firstX };
+    };
+
+    const at1 = await collect(200);   // scale 1.0
+    const at075 = await collect(150); // scale 0.75
+    expect(at075.partition).toEqual(at1.partition);
+    // Line starts scale linearly (page origin ∝ scale): x@0.75 = x@1 × 0.75.
+    // A conjured 50pt inline advance would add 37.5px here and fail.
+    expect(at075.firstX.length).toBe(at1.firstX.length);
+    for (let i = 0; i < at1.firstX.length; i++) {
+      expect(at075.firstX[i]).toBeCloseTo(at1.firstX[i] * 0.75, 6);
+    }
+  });
 });

--- a/packages/docx/src/layout-lines-zoom-invariant.test.ts
+++ b/packages/docx/src/layout-lines-zoom-invariant.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderDocumentToCanvas,
+  paginateDocument,
+  __test_setLineReuseEnabled,
+  __test_layoutLines as layoutLines,
+  type __test_LayoutSeg as LayoutSeg,
+} from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, PaginatedBodyElement } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 4-1 B2 Stage 2 — ZOOM-INVARIANT line breaking.
+//
+// Word lays text out in the document's own coordinate space and treats the
+// display scale as a viewport transform: the line PARTITION (which glyphs land
+// on which line) is the same at every zoom. Stage 2 realises this by reusing the
+// paginator's scale-1 line PARTITION at ANY paint scale — re-measuring the glyph
+// geometry at the paint scale (so the pen tracks the glyphs) but never
+// re-deciding the wrap points — instead of re-running layoutLines' break
+// decisions at the paint scale, which under a real (hinted) font whose glyph
+// advance is NOT proportional to the font px size would shift wrap points as the
+// zoom changes (documented in layout-lines-scale-invariance.test.ts).
+//
+// This suite drives the REAL render path (renderParagraph) through a SUB-LINEAR
+// mock canvas — glyph advance shrinks per-px as the size grows, the direction
+// real hinting bends — and asserts the drawn per-line text partition is
+// IDENTICAL at scale 1 and scale 0.75. A control proves the test is non-vacuous:
+// fed the SAME segments, layoutLines' OWN break decisions wrap differently at the
+// two scales under this font, so the invariance is a real property of the reuse.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Sub-linear glyph advance: `px·(perPx − shrink·px)` per code point. NOT
+ *  proportional to px, so a scale-1 layout and a scale-s re-layout would wrap
+ *  differently — the exact hinting non-linearity Stage 2 must make invisible to
+ *  the line partition. The SAME metric backs the paginate ctx (OffscreenCanvas)
+ *  and every paint ctx, so scale-1 paginate and scale-1 paint agree. */
+function subLinearWidth(text: string, fontPx: number): number {
+  const per = Math.max(0.01, fontPx * (0.5 - 0.006 * fontPx));
+  return [...text].length * per;
+}
+
+function makeMeasureStubCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: subLinearWidth(s, p),
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeMeasureStubCtx(); }
+};
+
+interface Draw { text: string; x: number; y: number; }
+
+/** A recording canvas backed by the SAME sub-linear metric. Records every text
+ *  draw with its baseline y so the caller can reconstruct the per-line partition
+ *  (glyphs sharing a baseline belong to one line). */
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; draws: Draw[] } {
+  let font = '10px serif';
+  const draws: Draw[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: subLinearWidth(s, p),
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { if (s) draws.push({ text: s, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, draws };
+}
+
+function para(text: string, over: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...over,
+  } as unknown as DocParagraph;
+}
+
+// A SHORT page (content height ≈ 40pt ⇒ ~3 lines) so the long paragraph SPLITS
+// across pages — the paginator only stamps its scale-1 lines on a split
+// (splitParagraphAcrossPages), which is what arms the reuse path.
+function doc(body: BodyElement[], pageHeight = 60): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+/** Reconstruct the per-line TEXT partition from a paint stream: group draws by
+ *  their baseline y (rounded to absorb sub-px), then concatenate each line's text
+ *  in draw order. Independent of the absolute y values, so it compares across
+ *  scales. */
+function linePartition(draws: Draw[]): string[] {
+  const byLine = new Map<number, { x: number; text: string }[]>();
+  for (const d of draws) {
+    const key = Math.round(d.y * 100) / 100;
+    if (!byLine.has(key)) byLine.set(key, []);
+    byLine.get(key)!.push({ x: d.x, text: d.text });
+  }
+  return [...byLine.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, segs]) => segs.sort((a, b) => a.x - b.x).map((s) => s.text).join(''));
+}
+
+/** Render every page of `model` at `width` (⇒ paint scale = width/pageWidth) and
+ *  return the concatenated per-line text partition across all pages. */
+async function partitionAtWidth(model: DocxDocumentModel, pages: PaginatedBodyElement[][], width: number): Promise<string[]> {
+  const all: string[] = [];
+  for (let p = 0; p < pages.length; p++) {
+    const rec = makeRecordingCanvas();
+    await renderDocumentToCanvas(model, rec.canvas, p, { dpr: 1, width, prebuiltPages: pages });
+    all.push(...linePartition(rec.draws));
+  }
+  return all;
+}
+
+describe('zoom-invariant line breaking (Phase 4-1 B2 Stage 2)', () => {
+  it('a long paragraph draws the SAME per-line partition at scale 1 and scale 0.75', async () => {
+    // 160 single-letter words → many wrap points; page width 200pt so it wraps
+    // and splits across pages. Sub-linear font ⇒ a re-layout at 0.75 would wrap
+    // differently, but the scale-1 stamp reuse pins the partition.
+    const text = Array.from({ length: 160 }, (_, i) => `w${i % 10}`).join(' ');
+    const model = doc([para(text) as unknown as BodyElement]);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1); // actually split
+
+    const at1 = await partitionAtWidth(model, pages, 200);       // scale 1.0
+    const at075 = await partitionAtWidth(model, pages, 150);      // scale 0.75
+    expect(at075).toEqual(at1);
+    // Non-vacuous: the paragraph really wrapped to multiple lines.
+    expect(at1.length).toBeGreaterThan(3);
+  });
+
+  it('CJK per-glyph wrap: same partition at scale 1 and scale 0.5', async () => {
+    const text = 'あ'.repeat(240);
+    const model = doc([para(text) as unknown as BodyElement]);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    const at1 = await partitionAtWidth(model, pages, 200);   // scale 1.0
+    const at05 = await partitionAtWidth(model, pages, 100);  // scale 0.5
+    expect(at05).toEqual(at1);
+  });
+
+  it('CONTROL: the mock font is genuinely NON-linear — a paint-scale re-layout WOULD wrap differently', () => {
+    // Non-vacuity: proves the invariance above is a real property of Stage 2, not
+    // an artefact of a metric that happens to be scale-clean. Feeding the SAME
+    // segments to layoutLines at scale 1 vs scale 0.75 with this sub-linear
+    // advance yields a DIFFERENT line PARTITION (fewer glyphs fit per line at the
+    // smaller px size) — exactly the paint-scale re-break Stage 2 removed by
+    // reusing the scale-1 stamp. If this ever passes trivially the render-level
+    // assertions above would be meaningless.
+    const seg = (text: string): LayoutSeg => ({
+      text, bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', vertAlign: null,
+      measuredWidth: 0,
+    } as unknown as LayoutSeg);
+    const text = Array.from({ length: 200 }, (_, i) => `w${i % 10}`).join(' ');
+
+    // Same real content width (180pt) at two scales: scale-1 box 180, scale-0.75
+    // box 135, first-indent 0. A linear font would give the SAME line count; the
+    // sub-linear font does not.
+    const a = layoutLines(makeMeasureStubCtx(), [seg(text)], 180, 0, 1);
+    const b = layoutLines(makeMeasureStubCtx(), [seg(text)], 135, 0, 0.75);
+    expect(a.length).toBeGreaterThan(1);
+    // The partitions differ — different line count under the non-linear advance.
+    expect(b.length).not.toBe(a.length);
+  });
+
+  it('reuse ON matches the scale-1 recompute partition (the stamp IS the scale-1 layout)', async () => {
+    // Ties the two: the zoom-invariant partition equals what a fresh scale-1
+    // layout produces (reuse OFF at scale 1), so Stage 2 did not silently change
+    // the scale-1 answer — only made every other scale agree with it.
+    const text = Array.from({ length: 160 }, (_, i) => `w${i % 10}`).join(' ');
+    const model = doc([para(text) as unknown as BodyElement]);
+    const pages = paginateDocument(model);
+
+    const prev = __test_setLineReuseEnabled(false);
+    let recomputeAt1: string[];
+    try { recomputeAt1 = await partitionAtWidth(model, pages, 200); } finally { __test_setLineReuseEnabled(prev); }
+
+    const reuseAt075 = await partitionAtWidth(model, pages, 150);
+    expect(reuseAt075).toEqual(recomputeAt1);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4269,7 +4269,13 @@ function rescaleLayoutLines(
         // tab-stop grid scales cleanly with the box).
         return { ...s, measuredWidth: s.measuredWidth * scale };
       }
-      if ('imagePath' in s) return { ...s, measuredWidth: s.widthPt * scale };
+      if ('imagePath' in s) {
+        // Anchored images live out of inline flow: layoutLines pins their
+        // measuredWidth to 0 (they add no pen advance) and their anchor*Pt
+        // fields stay in pt space for the draw-time position resolver.
+        if (s.anchor) return { ...s, measuredWidth: 0 };
+        return { ...s, measuredWidth: s.widthPt * scale };
+      }
       if ('mathNodes' in s) {
         const copy = { ...s, measuredWidth: s.measuredWidth * scale } as LayoutMathSeg;
         copy.mathAscent *= scale;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4185,6 +4185,128 @@ function resolveNumberingMarker(
   return { numTab, picBullet, numBodyOffset, markerJcShiftPx, hasMarker };
 }
 
+/** Phase 4-1 B2 Stage 2 — rehydrate the paginator's scale-1 stamped lines into
+ *  the paint scale, keeping the scale-1 line PARTITION but re-deriving all
+ *  hinting-sensitive geometry at the paint scale.
+ *
+ *  Why not a pure ×scale of the scale-1 fields: a real (hinted) font's Canvas
+ *  metrics are NOT scale-linear — `measureText(pt·s).width ≠ s · measureText(pt)`
+ *  and `fontBoundingBoxAscent(pt·s) ≠ s · fontBoundingBoxAscent(pt)`. The draw
+ *  path advances the pen by each segment's `measuredWidth` while `fillText`
+ *  renders at the paint-scale font, and the line box uses `ascent/descent`; a
+ *  geometric ×scale of those would drift the pen off the glyphs horizontally and
+ *  the baseline off by up to ~1px vertically, accumulating down the page (seen on
+ *  demo/sample-1 p.4). So RE-MEASURE every text segment at the paint scale here —
+ *  the exact same per-segment measurement `layoutLines` does (advance via
+ *  gridWidth, box via correctedLineMetrics, the §17.3.2.33 small-caps full-size
+ *  box, the §17.3.3.25 ruby ascent reserve, and the intended-single-line floor) —
+ *  so measure == draw byte-for-byte, identical to a fresh paint-scale layout of
+ *  the SAME partition. Only WHICH glyphs sit on WHICH line comes from the scale-1
+ *  stamp; that is the zoom-invariant part (Word lays text out in the document's
+ *  coordinate space and the display scale is a viewport transform, not a
+ *  re-layout — the scale-1 partition is correct at every zoom). This makes reuse
+ *  a deliberate behaviour change vs. the old recompute-at-paint-scale path, which
+ *  let hinting shift wrap points per zoom.
+ *
+ *  Geometry that IS scale-linear (a clean ×scale): the float-exclusion `xOffset` /
+ *  `availWidth` / `topY` (pure page geometry, no glyph hinting) and non-text
+ *  advances — image `widthPt·scale`, math `render.*Em·emPx`. Empty/synthetic
+ *  lines (no text segment) fall back to the ×scale of the stamped box, matching
+ *  layoutLines' `h·scale·0.8`/`0.2` synthesis.
+ *
+ *  Returns FRESH line + segment objects (never mutates the shared stamp — the
+ *  draw path and repeated renderPage calls read the same immutable array; see
+ *  layout-lines-reuse-identity.test.ts). `scale === 1` returns the stamp
+ *  unchanged (identity — no copy, no re-measure), so the scale-1 reuse path stays
+ *  byte-for-byte as in Stage 1. */
+function rescaleLayoutLines(
+  lines: LayoutLine[],
+  scale: number,
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  fontFamilyClasses: Record<string, string>,
+  gridDeltaPx: number,
+): LayoutLine[] {
+  if (scale === 1) return lines;
+
+  // Per-text-segment measurement at the PAINT scale — the SAME model layoutLines
+  // uses (segAdvance + the text-segment metric block), so measure == draw.
+  const measureTextSeg = (s: LayoutTextSeg): { advance: number; asc: number; desc: number; intended: number } => {
+    const effPx = calcEffectiveFontPx(s, scale);
+    ctx.font = buildFont(s.bold, s.italic, effPx, s.fontFamily, fontFamilyClasses);
+    const m = ctx.measureText(s.text);
+    const advance = gridWidth(m.width, s.text, gridDeltaPx);
+    // §17.3.2.33 — a small-caps run's LINE BOX follows the FULL run size (measure
+    // the box at fullPx, not the 2pt-reduced glyphs); super/subscript keeps its
+    // shrunk contribution. Mirrors layoutLines' fullPx / metricEmPx split.
+    const fullPx = s.fontSize * scale;
+    let metricM = m;
+    let metricEmPx = effPx;
+    if (s.smallCaps && !s.vertAlign && metricEmPx !== fullPx) {
+      ctx.font = buildFont(s.bold, s.italic, fullPx, s.fontFamily, fontFamilyClasses);
+      metricM = ctx.measureText(s.text || 'X');
+      metricEmPx = fullPx;
+    }
+    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx);
+    // §17.3.3.25 — ruby reserves extra ascent room (rt size × 1.5), same as layoutLines.
+    const asc = s.ruby ? corrected.ascent + s.ruby.fontSizePt * scale * 1.5 : corrected.ascent;
+    // Intended single-line floor (font-metrics.ts) — small caps keep the FULL run
+    // size here too (addToLine's intendedEm).
+    const intendedEm = s.smallCaps && !s.vertAlign ? fullPx : effPx;
+    const intended = intendedSingleLinePx(s.fontFamily, intendedEm);
+    return { advance, asc, desc: corrected.descent, intended };
+  };
+
+  return lines.map((l) => {
+    let asc = 0;
+    let desc = 0;
+    let intended = 0;
+    let hasText = false;
+    const segments = l.segments.map((s) => {
+      if ('isTab' in s) {
+        // Tab advance is position-dependent (pen → next stop) and box-neutral; a
+        // ×scale reproduces the scale-1 tab-to-stop advance scaled to paint space
+        // (the stamp reuse is gated to no-float, non-marker paragraphs, so the
+        // tab-stop grid scales cleanly with the box).
+        return { ...s, measuredWidth: s.measuredWidth * scale };
+      }
+      if ('imagePath' in s) return { ...s, measuredWidth: s.widthPt * scale };
+      if ('mathNodes' in s) {
+        const copy = { ...s, measuredWidth: s.measuredWidth * scale } as LayoutMathSeg;
+        copy.mathAscent *= scale;
+        copy.mathDescent *= scale;
+        asc = Math.max(asc, copy.mathAscent, s.fontSize * scale * 0.8);
+        desc = Math.max(desc, copy.mathDescent, s.fontSize * scale * 0.2);
+        return copy;
+      }
+      const t = s as LayoutTextSeg;
+      const mm = measureTextSeg(t);
+      hasText = true;
+      if (mm.asc > asc) asc = mm.asc;
+      if (mm.desc > desc) desc = mm.desc;
+      if (mm.intended > intended) intended = mm.intended;
+      return { ...t, measuredWidth: mm.advance };
+    });
+    // Empty/synthetic line (no text/math contributing metrics): fall back to the
+    // ×scale of the stamped box (layoutLines synthesises h·scale·0.8/0.2 there).
+    if (!hasText && asc === 0 && desc === 0) {
+      asc = l.ascent * scale;
+      desc = l.descent * scale;
+      intended = l.intendedSingle * scale;
+    }
+    return {
+      ...l,
+      segments,
+      ascent: asc,
+      descent: desc,
+      intendedSingle: intended,
+      // Pure page geometry — scale-linear (no glyph hinting).
+      xOffset: l.xOffset * scale,
+      availWidth: l.availWidth * scale,
+      topY: l.topY === undefined ? undefined : l.topY * scale,
+    };
+  });
+}
+
 function renderParagraph(
   para: DocParagraph,
   state: RenderState,
@@ -4323,20 +4445,35 @@ function renderParagraph(
   // the body as usual. RTL lists keep their existing start-edge handling.
   const firstLineIndent = hasMarker && !baseRtl ? numBodyOffset : firstLineX - paraX;
   const paintGridDeltaPx = gridCharDeltaPx(grid, scale);
-  // Phase 4-1 B2 Stage 1 — compute-once reuse. When the paginator split this
-  // paragraph it stamped the scale-1 lines it laid out (splitParagraphAcrossPages).
-  // Reuse them VERBATIM — skipping this scale's layoutLines entirely — but ONLY
-  // when the paint pass would produce a byte-identical array: its scale is 1 (so
-  // no px field needs rescaling; the scale-1 lines ARE the paint lines) AND every
-  // layout input matches the value the paginator used. The input check is what
-  // keeps this pixel-exact across the cases where measure and paint legitimately
-  // differ — most importantly the numbering firstLineIndent (measure uses
-  // para.indentFirst, paint uses numBodyOffset for a marker), which then fails the
-  // firstIndent equality and recomputes. A float context is excluded outright:
-  // float wrap depends on the page-absolute Y of THIS slice, which the stamped
-  // (whole-paragraph, first-page) lines do not carry. Rescaling to scale ≠ 1 is
-  // deferred to Stage 2 (it changes the line PARTITION under real font hinting —
-  // see layout-lines-scale-invariance.test.ts — i.e. a behaviour change).
+  // Phase 4-1 B2 Stage 2 — compute-once, ZOOM-INVARIANT reuse. When the paginator
+  // split this paragraph it stamped the scale-1 lines it laid out
+  // (splitParagraphAcrossPages). Reuse the scale-1 line PARTITION at ANY paint
+  // scale — skipping this scale's line-BREAK decisions — and rehydrate to the
+  // paint scale by RE-MEASURING each line's glyph geometry at the paint scale
+  // (rescaleLayoutLines: advance + box + tabs, so measure == draw with no hinting
+  // drift; scale 1 returns the stamp unchanged). This is a deliberate BEHAVIOUR
+  // CHANGE from Stage 1, which reused only at scale 1 and otherwise re-ran the
+  // break decisions at the paint scale: with a real (hinted) font those decisions
+  // could move wrap points as the zoom changes, whereas Word lays text out in the
+  // document's coordinate space and treats the display scale as a viewport
+  // transform (the wrap partition is scale 1 at every zoom). Reuse is gated to the
+  // cases where the scale-1 partition is the one this paint would intend — every
+  // layout INPUT must match the paginator's, compared in the paginator's scale-1
+  // space (the paint values are exactly `scale ×` the scale-1 values; see the
+  // per-field derivation below). The input check still rejects the numbering
+  // firstLineIndent case (measure uses para.indentFirst, paint uses numBodyOffset
+  // for a marker) so those recompute. A float context is excluded outright: float
+  // wrap depends on the page-absolute Y of THIS slice, which the stamped
+  // (whole-paragraph, first-page) lines do not carry.
+  //
+  // Scale-1 input reconstruction: the pt sources are read straight off the
+  // paragraph (para.indent*) — NO division — except paraW, whose only scaled term
+  // is contentW (= colW·scale, no rounding), so contentW/scale recovers colW. At
+  // scale 1 every reconstruction is the identity (÷1), so the gate stays
+  // bit-exact there and the Stage-1 pixel-identity test is unaffected. paraW is
+  // compared with a magnitude-relative epsilon because contentW/scale − indL − indR
+  // and (colW − indL − indR) are two float paths to the same real width (round-off
+  // ~1e-13); this is a geometric equality test, not a snapping heuristic.
   //
   // Segment stability: the reuse also assumes buildSegments(para.runs, ·) yields
   // the SAME segments under the paginator's measure state and this paint state.
@@ -4348,27 +4485,54 @@ function renderParagraph(
   // new state-dependent text source, extend that predicate — this gate cannot
   // see inside the stamped segments.
   const stamped = para as unknown as PaginatedElementWithLines;
+  // Reconstruct THIS paint's layout inputs in the paginator's scale-1 pt space.
+  const paraW1 = contentW / scale - (inFrame ? 0 : (baseRtl ? para.indentRight : para.indentLeft)) - (inFrame ? 0 : (baseRtl ? para.indentLeft : para.indentRight));
+  const indLeft1 = inFrame ? 0 : (baseRtl ? para.indentRight : para.indentLeft);
+  const firstIndent1 = hasMarker && !baseRtl ? numBodyOffset / scale : para.indentFirst;
+  const gridDelta1 = gridCharDeltaPx(grid, 1);
   const reuse =
     lineReuseEnabled &&
     stamped.layoutLines !== undefined &&
     stamped.layoutLinesInputs !== undefined &&
-    scale === 1 &&
     stamped.layoutLinesInputs.scale === 1 &&
     !wrapCtx &&
     !stamped.layoutLinesInputs.hasFloats &&
-    stamped.layoutLinesInputs.paraW === paraW &&
-    stamped.layoutLinesInputs.firstIndent === firstLineIndent &&
-    stamped.layoutLinesInputs.tabOriginPx === indLeft &&
-    stamped.layoutLinesInputs.gridDeltaPx === paintGridDeltaPx &&
+    Math.abs(stamped.layoutLinesInputs.paraW - paraW1) <= 1e-6 * Math.max(1, Math.abs(paraW1)) &&
+    stamped.layoutLinesInputs.firstIndent === firstIndent1 &&
+    stamped.layoutLinesInputs.tabOriginPx === indLeft1 &&
+    stamped.layoutLinesInputs.gridDeltaPx === gridDelta1 &&
     // §17.3.1.16 / §17.15.1.58–.59 — kinsoku governs CJK retract decisions in
     // layoutLines, so differing rules mean a (potentially) different partition.
     // Value equivalence, NOT `===`: the prebuiltPages path resolves the rules
     // independently in paginateDocument and here (fresh Sets per call), so the
     // references legitimately differ while the rules are identical.
     kinsokuRulesEquivalent(stamped.layoutLinesInputs.kinsoku, state.kinsoku);
+  // Zoom-invariant line breaking (Phase 4-1 B2 Stage 2). Three cases, all feeding
+  // the SAME draw loop below; rescaleLayoutLines re-measures the geometry at the
+  // paint scale off the scale-1 PARTITION (so measure == draw, no hinting drift):
+  //  1. reuse — the paginator's scale-1 stamp.
+  //  2. no float context — recompute the partition in the paginator's SAME scale-1
+  //     space (paraW1 / firstIndent1 / indLeft1 / gridDelta1). A paragraph that
+  //     missed the stamp (never split, or its inputs differ — e.g. a numbered
+  //     list's firstLineIndent) must STILL break at the scale-1 partition, or a
+  //     page would MIX scale-1-broken (split) and paint-scale-broken (non-split)
+  //     paragraphs — two wrap regimes side by side — and a paint-scale re-break
+  //     can even overflow the height the paginator reserved (estimateParagraphHeight
+  //     also lays out at scale 1). Keeping the whole non-float body on scale-1
+  //     breaking makes the page coherent and paginate-aligned.
+  //  3. float wrap context — stays at the paint scale (a straight layoutLines):
+  //     the wrap windows are evaluated against paint-scale float rectangles at
+  //     page-absolute Y, which have no scale-1 form here (the stamp reuse excludes
+  //     floats for the same reason). Pre-existing paginate(scale 1)/paint(scale s)
+  //     float behaviour, unchanged.
   const lines = reuse
-    ? (stamped.layoutLines as LayoutLine[])
-    : layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt);
+    ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
+    : wrapCtx
+      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt)
+      : rescaleLayoutLines(
+          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt),
+          scale, ctx, state.fontFamilyClasses, paintGridDeltaPx,
+        );
 
   // Decimal-tab auto-alignment. ECMA-376 (§17.3.1.37 tabs / §17.18.84 ST_TabJc
   // `decimal`) only positions content at a tab stop when an explicit tab


### PR DESCRIPTION
## Summary

Phase 4 item **B2 stage 2**. Stage 1 (#684) let `renderParagraph` reuse the paginator's per-paragraph layout stamp, but only at `scale === 1` — which production never hits (`scale = cssWidth / pageWidth` ≈ 1.333 natural, ≈ 0.75 in VRT). At any other scale the painter re-broke lines with `measureText` at the scaled font, and Canvas glyph metrics are not scale-linear (hinting), so **line breaks could differ between zoom levels**. Word's semantics are zoom-invariant layout: zoom is a display factor, line breaking never changes.

This PR drops the `scale === 1` gate and makes the scale-1 line **partition** authoritative at every paint scale:

- **Rehydration re-measures, not ×-scales.** Scaling the stamped px fields propagates hinting non-linearity into pen advance and baseline placement (caught as sub-pixel drift by VRT during development). `rescaleLayoutLines` keeps only the scale-1 partition and re-measures each line's geometry at the paint scale through the same shared helpers `layoutLines` itself uses (grid width, corrected line metrics, §17.3.2.33 small-caps box, §17.3.3.25 ruby reserve, intended-single floor) — so measure == draw exactly, with no drift-prone parallel implementation.
- **Reuse gate compares in the paginator's scale-1 space** (identity at scale 1, so stage-1 pixel-identity stays bit-exact). State-sensitive segments (NUMPAGES/noteRef) and numbering-marker paragraphs still recompute, unchanged.
- **The non-float fallback path is aligned too**: paragraphs that miss the stamp now also lay out in scale-1 space and rehydrate, so a page never mixes scale-1-broken and paint-scale-broken paragraphs. The float-wrap path stays paint-scale by necessity (page-Y-dependent wrap has no scale-1 form; stamp reuse already excludes floats for the same reason).

**Behavior change scope**: only paragraphs whose scale-1 and paint-scale partitions actually differ under hinting. Textbox/table/frame measurement paths untouched; pptx/xlsx untouched.

## Verification

- Full VRT green (docx 21 / xlsx 67 / pptx 75); regression mode vs the pre-change baseline: **19/19 docx pages 0.0% / 0 px byte-identical** — the behavior change is invisible on every VRT sample, no reference updates needed. Worker-equivalence 0.000%.
- `pnpm test` 1,649 green including the stage-1 characterization suites.
- New `layout-lines-zoom-invariant.test.ts`: a sub-linear mock font drives the real render path and asserts the drawn per-line partition is identical at scale 1 vs 0.75/0.5, that reuse-at-0.75 equals the scale-1 recompute, plus a control proving the mock genuinely re-breaks at paint scale without the fix (non-vacuous).
- Root typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)