### PR TITLE
fix(docx): explicit page-fit relocation for overflowing floating tables (§17.4.57)

### DIFF
--- a/packages/docx/src/float-table-page-fit.test.ts
+++ b/packages/docx/src/float-table-page-fit.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest';
+import { computePages } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocTable,
+  DocTableRow,
+  DocxTextRun,
+  SectionProps,
+  TblpPr,
+  PaginatedBodyElement,
+} from './types';
+
+// Unit tests for the keep-with-anchor pagination of a page-overflowing FLOATING
+// table (ECMA-376 §17.4.57 `<w:tblpPr>`). §17.4.57 pins only the table's
+// size/position; keeping an undivided floating table with its anchor context on
+// the next page is Word runtime behaviour — the SAME "keep on page" semantics
+// already covered for a text frame (§17.3.1.11, frame-keep-with-anchor.test.ts)
+// and a paragraph-anchored image float. These assertions guard that behaviour,
+// which the private-sample VRT (sample-11's small top-of-page float only, never
+// a page-boundary one) cannot cover.
+//
+// The stub canvas mirrors frame-keep-with-anchor.test.ts / pagination.test.ts:
+// glyph advance = charCount × fontPx and the font box = 0.8/0.2 em, so a single
+// line is exactly fontPx tall. Table row heights are pinned with
+// rowHeightRule="exact" so `tableH` is deterministic (independent of the stub's
+// cell measurement), the table analogue of the frame's hRule="exact"/h.
+
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, fillText() {}, strokeText() {}, beginPath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fillRect() {}, drawImage() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1, textAlign: 'left' as CanvasTextAlign,
+    direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+// pageWidth 200 / pageHeight 140, margins 20 ⇒ content band 160×100 (bodyTop 20).
+function section(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 200, pageHeight: 140,
+    marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    ...overrides,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function textRun(text: string, fontSize: number): DocRun {
+  const run: DocxTextRun = {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+  return { type: 'text', ...run } as DocRun;
+}
+
+function para(opts: { text?: string; fontSize?: number } = {}): BodyElement {
+  const fontSize = opts.fontSize ?? 20;
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: opts.text ? [textRun(opts.text, fontSize)] : [],
+    defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+// Full TblpPr with the spec defaults; callers override only the axis under test.
+// The default vertAnchor is 'page' (matching the Rust parser's fill for an
+// absent w:vertAnchor), so the vAnchor gate is exercised by overriding it.
+function tblp(over: Partial<TblpPr> = {}): TblpPr {
+  return {
+    leftFromText: 0,
+    rightFromText: 0,
+    topFromText: 0,
+    bottomFromText: 0,
+    horzAnchor: 'text',
+    horzSpecified: true,
+    vertAnchor: 'page',
+    tblpX: 0,
+    tblpY: 0,
+    ...over,
+  };
+}
+
+/** A single-cell row of the given exact pt height (`rowHeightRule="exact"` short-
+ *  circuits content measurement, so `tableH` == `rowHeight` regardless of the
+ *  stub canvas — the table analogue of the frame's hRule="exact"/h). */
+function row(heightPt: number): DocTableRow {
+  return {
+    cells: [
+      {
+        content: [],
+        colSpan: 1,
+        vMerge: null,
+        borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+        background: null,
+        vAlign: 'top',
+        widthPt: null,
+      },
+    ],
+    rowHeight: heightPt,
+    rowHeightRule: 'exact',
+    isHeader: false,
+  };
+}
+
+/** A floating table (`w:tblpPr`) of total height `tableHPt`, laid out as one
+ *  exact-height row so its measured extent is deterministic. */
+function floatTable(tp: TblpPr, tableHPt: number): BodyElement {
+  const t: DocTable = {
+    colWidths: [80],
+    rows: [row(tableHPt)],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+    tblpPr: tp,
+  };
+  return { type: 'table', ...t } as unknown as BodyElement;
+}
+
+/** True when an element is a floating table (identified by its tblpPr). */
+const isFloatTable = (el: PaginatedBodyElement): boolean =>
+  el.type === 'table' && (el as unknown as DocTable).tblpPr != null;
+
+/** True when a page holds a floating table. */
+const hasFloatTable = (page: PaginatedBodyElement[]): boolean => page.some(isFloatTable);
+
+/** Text of a paragraph element (joins its text runs). */
+const textOf = (el: PaginatedBodyElement): string =>
+  el.type === 'paragraph'
+    ? (el as unknown as DocParagraph).runs
+        .filter((r) => r.type === 'text')
+        .map((r) => (r as DocxTextRun).text)
+        .join('')
+    : '';
+
+/** True when a page holds the anchor paragraph (matched by its text). */
+const hasAnchorText = (page: PaginatedBodyElement[], text: string): boolean =>
+  page.some((el) => textOf(el) === text);
+
+/** The newspaper column an element landed in. */
+const colOf = (el: PaginatedBodyElement): number | undefined => el.colIndex;
+
+/** Find the (first) floating-table element on a page. */
+const floatTableEl = (page: PaginatedBodyElement[]): PaginatedBodyElement | undefined =>
+  page.find(isFloatTable);
+
+describe('computePages — floating-table page-fit / keep-with-anchor (§17.4.57)', () => {
+  // Content band 160×100, bodyTop 20. Table: vertAnchor="text", one exact row of
+  // height H ⇒ table body box [paraTop, paraTop+H]. With N leading 20pt lines the
+  // table's in-flow top is at y=20N; the table overflows the 100pt content area
+  // once 20N + H > 100.
+
+  it('relocates a text-anchored floating table + its anchor text to the next page when it overflows the bottom', () => {
+    // 3 leading lines (y advances 20→40→60), then the floating table (60 tall:
+    // 60+60 > 100 ⇒ overflow), then the anchor text paragraph.
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      para({ text: 'c' }),
+      floatTable(tblp({ vertAnchor: 'text', tblpY: 0 }), 60),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages.length).toBe(2);
+    // The table does NOT stay on page 1 (would overflow); it moves to page 2…
+    expect(hasFloatTable(pages[0])).toBe(false);
+    expect(hasFloatTable(pages[1])).toBe(true);
+    // …and its trailing anchor text follows it onto page 2 (kept together).
+    expect(hasAnchorText(pages[1], 'anchor')).toBe(true);
+    expect(hasAnchorText(pages[0], 'anchor')).toBe(false);
+    // Page 1 keeps only the three leading lines (no float band leaked over).
+    expect(pages[0].map(textOf)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('relocates an overflowing floating table to the NEXT COLUMN (not a new page) in a multi-column section', () => {
+    // 2 equal columns: colW = (160-20)/2 = 70; content height 100 (5 × 20pt per
+    // column). Column 0 gets 3 leading lines (y 20→40→60); the table body box
+    // (60 tall) then overflows column 0's bottom (60+60 > 100). With a column
+    // still available on the page, it relocates to column 1 — NOT a new page.
+    const twoCol = section({ columns: { count: 2, spacePt: 20, equalWidth: true, sep: false, cols: [] } });
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      para({ text: 'c' }),
+      floatTable(tblp({ vertAnchor: 'text', horzAnchor: 'text', tblpY: 0 }), 60),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, twoCol, makeCtx());
+    // Still a single page (column 1 absorbed the table + anchor).
+    expect(pages.length).toBe(1);
+    const f = floatTableEl(pages[0]);
+    expect(f).toBeDefined();
+    expect(colOf(f as PaginatedBodyElement)).toBe(1); // moved into column 1
+    // The three leading lines (a/b/c) stayed in column 0.
+    const leadCols = pages[0]
+      .filter((el) => ['a', 'b', 'c'].includes(textOf(el)))
+      .map(colOf);
+    expect(leadCols).toEqual([0, 0, 0]);
+    // The trailing anchor text follows the table into column 1.
+    const anchor = pages[0].find((el) => textOf(el) === 'anchor');
+    expect(anchor).toBeDefined();
+    expect(colOf(anchor as PaginatedBodyElement)).toBe(1);
+  });
+
+  it('keeps a text-anchored floating table in place when it fits (near the top of the page)', () => {
+    // Only 1 leading line (y=20). Table body box [20,80] fits within [0,100] ⇒
+    // no relocation. Everything stays on page 1. (sample-11 shape: a small
+    // vertAnchor="text" tblpY=1 float near the page top must NOT be sent.)
+    const body = [
+      para({ text: 'a' }),
+      floatTable(tblp({ vertAnchor: 'text', tblpY: 1 }), 60),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages.length).toBe(1);
+    expect(hasFloatTable(pages[0])).toBe(true);
+    expect(hasAnchorText(pages[0], 'anchor')).toBe(true);
+  });
+
+  it('does NOT relocate (or loop) a floating table taller than the page content area', () => {
+    // 150 tall > content height 100: the table can never fit on any page, so
+    // relocating would loop forever. It is left in place and allowed to overflow.
+    // The real assertion is that this terminates (no timeout / infinite paging)
+    // AND that the floating table is NOT row-split (Word keeps it undivided).
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      para({ text: 'c' }),
+      floatTable(tblp({ vertAnchor: 'text', tblpY: 0 }), 150),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    // Table stays on page 1 with its three leading lines (no relocation).
+    expect(hasFloatTable(pages[0])).toBe(true);
+    // A floating table adds no flow height, so the anchor stays on the same page.
+    expect(hasAnchorText(pages[0], 'anchor')).toBe(true);
+    expect(pages.length).toBe(1);
+    // Exactly ONE floating-table element exists across all pages (not split into
+    // per-page slices like a block table).
+    const floatCount = pages.reduce((s, p) => s + p.filter(isFloatTable).length, 0);
+    expect(floatCount).toBe(1);
+  });
+
+  it('does NOT relocate a page-anchored floating table that overflows (absolute y is honored in place)', () => {
+    // vertAnchor="page", tblpY=90: the table is pinned at page-y 90 with H=60 ⇒
+    // bottom 150, past the 140 page edge. An absolute page position is the SAME
+    // on any page, so relocation cannot help — Word draws it there (overflowing).
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      para({ text: 'c' }),
+      floatTable(tblp({ vertAnchor: 'page', tblpY: 90 }), 60),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages.length).toBe(1);
+    expect(hasFloatTable(pages[0])).toBe(true);
+    expect(hasAnchorText(pages[0], 'anchor')).toBe(true);
+  });
+
+  it('does NOT relocate a margin-anchored floating table that overflows (absolute y is honored in place)', () => {
+    // vertAnchor="margin", tblpY=70: table at margin-top(20)+70 = 90, H=60 ⇒
+    // bottom 150, past the bottom margin. Absolute ⇒ left in place (mirrors
+    // vertAnchor="page").
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      para({ text: 'c' }),
+      floatTable(tblp({ vertAnchor: 'margin', tblpY: 70 }), 60),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages.length).toBe(1);
+    expect(hasFloatTable(pages[0])).toBe(true);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2158,9 +2158,34 @@ export function computePages(
       // untouched so the following paragraph spaces against the paragraph BEFORE
       // the table.
       //
-      // ヒューリスティック、§17.4.57 TODO: floating table page-fit is Word runtime
-      // behavior, not spec-defined. Minimal: keep on current page (no break /
-      // relocation across pages here; only the in-page wrap band is modeled).
+      // §17.4.57 defines only the table's SIZE and POSITION, not what happens
+      // when it overflows the page bottom. Word's runtime keeps a floating table
+      // undivided and relocates it (with the anchor context that follows it) to
+      // the next page rather than splitting or clipping — the SAME "keep on
+      // page" semantics already implemented for a page-overflowing text frame
+      // (§17.3.1.11; see the framePr branch above) and a paragraph-anchored image
+      // float (anchoredFloatBottomOffset, §20.4.3.5). The tblpPr anchor/alignment
+      // vocabulary lines up 1:1 with framePr (§17.4.57 vertAnchor↔§17.3.1.11
+      // vAnchor, tblpY↔y), so this reuses that established pattern rather than
+      // inventing table-specific math:
+      //   • vertAnchor="text": the table top rides the anchor paragraph's in-flow
+      //     cursor, so moving the anchor to the next page moves the table with it.
+      //     If the table body box overflows the current column's bottom, relocate
+      //     it — the anchor text that follows it (which adds no height of its own)
+      //     trails onto the new column/page.
+      //   • vertAnchor="page"/"margin" (parser default is "page"): y is an
+      //     ABSOLUTE in-page position, so the table lands at the same spot on any
+      //     page. Relocating cannot help (Word draws it at its specified position
+      //     and lets it overflow), so these are left in place — matching the
+      //     pre-existing behaviour.
+      // A table TALLER than the page content area can never fit on a fresh page,
+      // so relocating it is futile (it would just overflow the next page too):
+      // leave it in place. This mirrors the text-frame / anchored-image guard's
+      // `<= effContentH()` fresh-fit test. Unlike a block table (below), a
+      // FLOATING table is not row-split here — Word does not divide a floating
+      // table across pages, so an over-tall one is left to overflow in place. (The
+      // table element is placed once and `continue`s, so no relocation can loop —
+      // this guard only suppresses a pointless page break for an over-tall table.)
       if (tbl.tblpPr) {
         // #513: re-point measureState.contentX/contentW at the CURRENT newspaper
         // column for the duration of the placement so the paginator estimates the
@@ -2173,13 +2198,48 @@ export function computePages(
         // measureState.scale is 1, so colW() (pt) equals the px content width
         // computeTableLayout expects (it re-divides by scale internally); colX()
         // (pt) is likewise the column's page-absolute left edge.
+        //
+        // Lay the table out against the CURRENT column band and resolve its box.
+        // computeTableLayout is the only (heavy) measurement; its `tableH` drives
+        // both the overflow test and the wrap float below (compute-once — the
+        // decision reuses this box's height, never re-measures it separately).
+        const tp = tbl.tblpPr;
+        const measureFloatBox = () =>
+          withColumnBand(() => {
+            const cW = colW() * measureState.scale;
+            const layout = computeTableLayout(tbl, cW, measureState);
+            const tableH = layout.rowHeights.reduce((s, x) => s + x, 0);
+            return computeFloatTableBox(tp, measureState, measureState.y, layout.tableW, tableH);
+          });
+        let box = measureFloatBox();
+        // Distance from the table's in-flow top (measureState.y == paraTop) down
+        // to its body-box bottom — the table analogue of the frame's
+        // frameBottomOff. The bottom is vSpace-exclusive (box.h is the bare table
+        // extent; the *FromText dist padding is inter-text spacing, not part of
+        // the table's own area). For vertAnchor="text" this is the table's y
+        // offset + its height; for page/margin it mixes an absolute box.y with the
+        // flow cursor and is not a keep signal, so it is gated out below.
+        const tableBottomOff = box.y + box.h - measureState.y;
+        const isTextAnchored = tp.vertAnchor !== 'page' && tp.vertAnchor !== 'margin';
+        const tableOverflowsHere = isTextAnchored && tableBottomOff > 0 && y + tableBottomOff > effContentH();
+        const tableFitsFresh = tableBottomOff > 0 && tableBottomOff <= effContentH();
+        if (y > 0 && tableOverflowsHere && tableFitsFresh) {
+          // Relocate the floating table to the next column/page BEFORE its float
+          // is registered, so no stale exclusion band is left on the old page
+          // (newPage clears floats wholesale; nextColumn keeps page-scoped ones
+          // but the table has not registered yet). The trailing anchor paragraph
+          // adds no height across this table, so it follows onto the new page. The
+          // column width can differ between columns (box.h / wrap side depend on
+          // it), so re-measure the box against the column the table landed in.
+          nextColumnOrPage(i);
+          box = measureFloatBox();
+        }
+        // Register the wrap float against the (possibly new) column band so the
+        // box x / wrap side match the column the table now sits in, and the float
+        // is registered on the page it actually landed on.
         withColumnBand(() => {
-          const cW = colW() * measureState.scale;
-          const layout = computeTableLayout(tbl, cW, measureState);
-          const tableH = layout.rowHeights.reduce((s, x) => s + x, 0);
-          const box = computeFloatTableBox(tbl.tblpPr!, measureState, measureState.y, layout.tableW, tableH);
           const side = floatTableWrapSide(box, measureState);
-          registerTableFloat(box, tbl.tblpPr!, measureState, side, tbl.overlap !== 'never');
+          registerTableFloat(box, tp, measureState, side, tbl.overlap !== 'never');
         });
         pushTagged(el as PaginatedBodyElement);
         continue;


### PR DESCRIPTION
## Summary

Closes #674 — the floating-table sibling of #690 (#675), implemented deliberately symmetric to it.

The `computePages` tblpPr branch kept a floating table on the current page unconditionally (documented HEURISTIC: only the in-page wrap band was modeled; a table that did not fit the remaining page space never moved). This replaces the heuristic with the same explicit keep-with-anchor decision the text-frame branch now uses:

- `vertAnchor='text'` (flow-relative) relocates via the existing `nextColumnOrPage(i)`; `page`/`margin` (absolute y, and the parser default — `parser.rs:5077` fills `"page"` when the attribute is absent, byte-symmetric with the frame's `styles.rs:1051`) stay in place.
- Overflow yardstick is the table **body** box bottom (`box.y + box.h`, *FromText padding-exclusive), against the current column bottom.
- `tableFitsFresh` (table height ≤ full content height) suppresses a futile break; relocation is structurally loop-free (the table element is placed exactly once). A floating table is **not** row-split, unlike a block table — noted in-code.
- The wrap float is registered against the landed column band only; box is re-measured after relocation (column width can change), while the common no-relocation path stays compute-once via a `measureFloatBox()` closure (one `computeTableLayout` per table, same as before).

ECMA-376 §17.4.57 specifies positioning only; page-fit is Word runtime behavior (user-approved scope). HEURISTIC/TODO note removed.

## Verification

- `npx vitest run packages/docx/src` — **480 passed** (474 + 6 new in `float-table-page-fit.test.ts`).
- **Red check**: with only the renderer edit stashed, relocation tests 1–2 fail on origin/main (page 1 vs 2; column 0 vs 1) and invariant tests 3–6 still pass — the suite pins the new behavior and guards the old invariants separately.
- docx VRT 21/21, match percentages unchanged from baseline. The only floating table in the corpus (private/sample-11: small, top-of-page, `vertAnchor="text"`) is outside the VRT suite; test 3 replicates its shape as the no-regression case (never overflows → never relocated).
- Root typecheck + lint green. References untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)