### PR TITLE
refactor(docx): unify table cell measurement on the paint-side layout + stamp/reuse (B2 table stage 1)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -8220,6 +8220,11 @@ function computeTableLayout(
   // round-off ~1e-13 is a geometric equality, not a snap). A slice stamps only its
   // own rows, so `tableRowHeightsPt` aligns 1:1 with `table.rows`; the column stamp
   // is the full grid, shared by every slice.
+  // Kinsoku is deliberately NOT a gate input (unlike the paragraph reuse gate's
+  // kinsokuRulesEquivalent): the paragraph stamp re-lays lines out at paint and
+  // so must prove the layout inputs match, whereas this stamp is the finished
+  // heights — kinsoku was already applied when the paginator measured them, and
+  // both passes resolve kinsoku from the same immutable doc.settings.
   const stamped = table as PaginatedBodyElement;
   const contentWPt1 = contentWPx / scale;
   const reuseInputs = stamped.tableLayoutInputs;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2975,37 +2975,34 @@ function splitParagraphAcrossPages(
   return { endY: cursorY };
 }
 
-/** Per-row heights used by both pagination and the height estimate. Mirrors the
- *  renderer's row sizing (exact / atLeast / auto + vMerge span distribution,
- *  ECMA-376 §17.4.80, §17.4.85) via the shared {@link resolveTableRowHeights}
- *  skeleton. Works in pt (scale 1); the cell measurer is the paginator's
- *  float-aware `estimateParagraphHeight` cursor-walk. Adjacent paragraphs inside
- *  a cell collapse spacing the same way `renderCellContent` does (ECMA-376
- *  §17.3.1.33 contextualSpacing + spaceAfter/spaceBefore overlap = max not sum),
- *  so the measured height matches the painted height. Without this, a cell
- *  containing a nested table followed by a paragraph with `spaceBefore` would
- *  measure taller than it paints, leaving a gap below the nested table. */
+/** Per-row heights (pt) used by both pagination and the keep-with-next height
+ *  estimate. Mirrors the renderer's row sizing (exact / atLeast / auto + vMerge
+ *  span distribution, ECMA-376 §17.4.80, §17.4.85) via the shared
+ *  {@link resolveTableRowHeights} skeleton.
+ *
+ *  B2 table stage 1a — the cell CONTENT measurer is now the SAME single function
+ *  the paint pass uses ({@link measureCellContentHeightPx}), invoked at scale 1
+ *  so it returns pt. Previously the paginator measured each cell with its own
+ *  `estimateParagraphHeight` cursor-walk while the paint pass used
+ *  `measureCellElementHeight`; the two agreed for the common (non-empty, non-ruby,
+ *  float-free) paragraph but DIVERGED for empty paragraph marks (the paginator
+ *  used the corrected `paragraphMarkLineHeight`, the paint pass the synthetic
+ *  `emptyLineNaturalPx`) and ruby paragraphs (only the paginator applied the
+ *  docGrid uniform-pitch snap). That split sized the SAME table's rows with two
+ *  different measurers — the structural source of measure/paint row-height drift
+ *  (clip / overflow / page-split mismatch). Routing both through
+ *  `measureCellContentHeightPx` — whose empty/ruby branches were fixed in this
+ *  stage to equal what `renderParagraph` actually draws — makes "same input →
+ *  same formula → same height" hold, so the paginated row heights are exactly the
+ *  heights the paint pass will lay out. `measureCellContentHeightPx` already folds
+ *  in `effCellMargins`, the §17.4.7 trailing-structural-marker drop, and the
+ *  §17.3.1.33 contextual/overlap spacing collapse (via `sumCellContentHeight`), so
+ *  the caller is a thin delegation. */
 function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt: number): number[] {
   const colWidths = resolveColumnWidths(table, contentWPt, state);
-  return resolveTableRowHeights(table, colWidths, 1, (cell, cellW) => {
-    const cm = effCellMargins(cell, table);
-    const innerW = Math.max(1, cellW - cm.left - cm.right);
-    // pt-space: estimateParagraphHeight emits the full spaceBefore (its
-    // suppressSpaceBefore flag is for page-break continuations, not intra-cell
-    // collapse), so sumCellContentHeight folds in contextualSuppressed
-    // (§17.3.1.33) and the prevSpaceAfter/spaceBefore overlap to match the
-    // paint pass's renderCellContent. Drop the §17.4.7 trailing structural
-    // empty paragraph after a nested table for the SAME reason the paint-side
-    // measurer (measureCellContentHeightPx) does — otherwise the paginator
-    // would reserve more height than the paint pass uses and break the page
-    // early (the two are contracted to agree, per this function's docstring).
-    return cm.top + cm.bottom + sumCellContentHeight(trimTrailingStructuralMarker(cell.content), (ce) => {
-      if (ce.type === 'paragraph') {
-        return estimateParagraphHeight(state, ce as unknown as DocParagraph, innerW);
-      }
-      return estimateTableHeight(state, ce as unknown as DocTable, innerW);
-    }, 1);
-  });
+  return resolveTableRowHeights(table, colWidths, 1, (cell, cellW) =>
+    measureCellContentHeightPx(cell, table, cellW, 1, state),
+  );
 }
 
 function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: number): number {
@@ -8136,13 +8133,21 @@ function computeTableLayout(
   return { colWidths, tableW, rowHeights };
 }
 
-/** Content height (px, at `scale`) of a table cell laid out at total width
- *  `cellW`: cell top/bottom margins plus each content element measured at the
- *  paint pass's `measureCellElementHeight`. Adjacent paragraphs inside the cell
- *  collapse spacing the same way `renderCellContent` does (ECMA-376 §17.3.1.33
- *  contextualSpacing + spaceAfter/spaceBefore overlap = max not sum), so the
- *  measured height matches the painted height. Shared by the per-row skeleton
- *  (via computeTableLayout) and the exported {@link calculateRowHeight}. */
+/** Content height of a table cell laid out at total width `cellW`, in the target
+ *  units the caller works in: px when `scale` is the device scale (paint pass),
+ *  pt when `scale === 1` (paginator). Cell top/bottom margins plus each content
+ *  element measured at `measureCellElementHeight`. Adjacent paragraphs inside the
+ *  cell collapse spacing the same way `renderCellContent` does (ECMA-376
+ *  §17.3.1.33 contextualSpacing + spaceAfter/spaceBefore overlap = max not sum),
+ *  so the measured height matches the painted height.
+ *
+ *  B2 table stage 1a — this is the SINGLE cell-content measurer for the whole
+ *  package. The paginator ({@link computeTableRowHeights}, scale 1), the paint
+ *  layout ({@link computeTableLayout}, device scale), and the exported
+ *  {@link calculateRowHeight} all resolve a cell's height through here, so a
+ *  table's rows can never be sized by two different measurers. Unit-agnostic: it
+ *  is the same formula at any `scale`, and at scale 1 it returns exactly the pt
+ *  height the device-scale paint pass will produce ÷ scale. */
 function measureCellContentHeightPx(
   cell: DocTableCell,
   table: DocTable,
@@ -8383,9 +8388,24 @@ function measureParaHeight(
   const paraHasRuby = paragraphHasRuby(para);
   const grid = paraGrid(para, state);
   if (segs.length === 0) {
-    const fs = getDefaultFontSize(para);
-    const { asc, desc } = emptyLineNaturalPx(fs, scale);
-    return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSinglePx(para, scale), paragraphIsEastAsian(para));
+    // ECMA-376 §17.3.1.29: an empty (or anchor-only) paragraph still produces one
+    // paragraph-mark line box. Size it with the SAME `paragraphMarkLineHeight`
+    // (ctx-based, correctedLineMetrics) the paint pass draws with
+    // (renderEmptyMarkParagraph) — NOT the synthetic 0.8/0.2-em `emptyLineNaturalPx`,
+    // which under-measures every substituted (e.g. Latin ~1.15em) mark font and so
+    // reserved a shorter row than the mark actually paints. Using the drawn height
+    // makes this row measurer measure == draw for empty cell paragraphs, closing
+    // the measure/paint gap that the paginator's `estimateParagraphHeight` (which
+    // already used `paragraphMarkLineHeight`) did not share with the paint side.
+    return paragraphMarkLineHeight(
+      para,
+      scale,
+      grid,
+      paraHasRuby,
+      state.docEastAsian,
+      state.ctx,
+      state.fontFamilyClasses,
+    );
   }
   // ECMA-376 §17.3.1.12 (`<w:ind>`): the paragraph's own left/right indent
   // narrows the wrap width and `firstLine` insets the first line — exactly as
@@ -8411,7 +8431,21 @@ function measureParaHeight(
   const indRightPx = para.indentRight * scale;
   const paraW = Math.max(1, maxWidth - indLeftPx - indRightPx);
   const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst * scale, scale, para.tabStops, undefined, state.fontFamilyClasses, indLeftPx, state.kinsoku, gridCharDeltaPx(grid, scale), state.defaultTabPt);
-  return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle, paragraphIsEastAsian(para)), 0);
+  if (paraHasRuby) {
+    // Ruby paragraph (§17.3.3.25 / §17.6.5): the paint pass (renderParagraph) and
+    // the paginator (estimateParagraphHeight) give EVERY line the same height —
+    // the tallest line's natural box snapped up to an integer docGrid pitch — so
+    // ruby-bearing and ruby-free lines share one baseline grid. Mirror that here
+    // (the row measurer previously summed each line's independent box, which
+    // under/over-measured a wrapped ruby cell relative to what it paints).
+    const uniform = snapParaLineToGrid(
+      Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, paragraphIsEastAsian(para)))),
+      grid,
+      scale,
+    );
+    return lines.length * uniform;
+  }
+  return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, paragraphIsEastAsian(para)), 0);
 }
 
 /** Effective cell margins (pt). Per-cell `<w:tcMar>` overrides (ECMA-376

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2246,8 +2246,11 @@ export function computePages(
       }
 
       // Tables in a multi-column section are sized to the column width, not the
-      // full content band.
-      const rowHs = computeTableRowHeights(measureState, tbl, colW());
+      // full content band. Resolve columns + row heights together (one min-content
+      // scan) so both can be stamped for the paint pass (B2 table stage 1b).
+      const tblContentWPt = colW();
+      const { colWidthsPt: tblColWidthsPt, rowHeightsPt: rowHs } =
+        computeTablePtLayout(measureState, tbl, tblContentWPt);
       const h = rowHs.reduce((s, x) => s + x, 0);
       // Footnote references inside table cells are not folded into the reserve
       // (the per-page reserve is driven by body paragraphs); they still draw at
@@ -2271,6 +2274,10 @@ export function computePages(
           bodyTopPt(),
           () => currentSectionHF,
           () => currentSectionGeom,
+          // B2 table stage 1b — stamp the scale-1 layout onto each slice so the
+          // paint pass reuses it. Each slice records ITS rows' heights; the column
+          // widths + contentWPt are constant across the split.
+          { colWidthsPt: tblColWidthsPt, contentWPt: tblContentWPt },
         );
         y = endY;
         measureState.y = bodyTopPt() + endY;
@@ -2278,6 +2285,8 @@ export function computePages(
         // §17.6.4 column balancing (wantsBalanceBreak) OR a table that doesn't fit
         // the rest of this column ⇒ advance to the next column / page.
         if (wantsBalanceBreak(h) || y + h > tableContentH) nextColumnOrPage(i);
+        // B2 table stage 1b — stamp the whole-table scale-1 layout for paint reuse.
+        stampTableLayout(el as PaginatedBodyElement, tblColWidthsPt, rowHs, tblContentWPt);
         pushTagged(el as PaginatedBodyElement);
         y += h;
         measureState.y += h;
@@ -2999,10 +3008,26 @@ function splitParagraphAcrossPages(
  *  §17.3.1.33 contextual/overlap spacing collapse (via `sumCellContentHeight`), so
  *  the caller is a thin delegation. */
 function computeTableRowHeights(state: RenderState, table: DocTable, contentWPt: number): number[] {
-  const colWidths = resolveColumnWidths(table, contentWPt, state);
-  return resolveTableRowHeights(table, colWidths, 1, (cell, cellW) =>
+  return computeTablePtLayout(state, table, contentWPt).rowHeightsPt;
+}
+
+/** The paginator's scale-1 table layout: the per-grid-column widths (pt) and the
+ *  per-row heights (pt), both resolved through the SAME functions the paint pass
+ *  uses ({@link resolveColumnWidths} + {@link resolveTableRowHeights} with the
+ *  unified {@link measureCellContentHeightPx} at scale 1). Returned together so
+ *  the paginator can stamp both onto the table element (B2 table stage 1b) for the
+ *  paint pass to reuse — one column resolution feeds both the stamp and the row
+ *  heights, so the min-content scan runs once. */
+function computeTablePtLayout(
+  state: RenderState,
+  table: DocTable,
+  contentWPt: number,
+): { colWidthsPt: number[]; rowHeightsPt: number[] } {
+  const colWidthsPt = resolveColumnWidths(table, contentWPt, state);
+  const rowHeightsPt = resolveTableRowHeights(table, colWidthsPt, 1, (cell, cellW) =>
     measureCellContentHeightPx(cell, table, cellW, 1, state),
   );
+  return { colWidthsPt, rowHeightsPt };
 }
 
 function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: number): number {
@@ -3308,6 +3333,23 @@ function tableBreakAllowedBefore(table: DocTable, ri: number): boolean {
   return !table.rows[ri].cells.some((c) => c.vMerge === false);
 }
 
+/** B2 table stage 1b — stamp a table element (whole table or one page slice) with
+ *  the scale-1 layout the paginator resolved, so the paint pass ({@link computeTableLayout})
+ *  reuses it. `rowHeightsPt` must align 1:1 with `el.rows` (a slice passes its own
+ *  rows' heights). `contentWPt` is the pt content-band width the columns were fit
+ *  to; the paint gate re-derives it as `contentW / scale` and reuses the stamp only
+ *  when they match. Sets the runtime-only fields on `PaginatedBodyElement`. */
+function stampTableLayout(
+  el: PaginatedBodyElement,
+  colWidthsPt: number[],
+  rowHeightsPt: number[],
+  contentWPt: number,
+): void {
+  el.tableColWidthsPt = colWidthsPt;
+  el.tableRowHeightsPt = rowHeightsPt;
+  el.tableLayoutInputs = { scale: 1, contentWPt };
+}
+
 /**
  * Split a table that is taller than one page across page boundaries, row by
  * row (ECMA-376 table pagination). Each page receives a {@link DocTable} slice
@@ -3351,6 +3393,12 @@ export function splitTableAcrossPages(
    *  margins; constant across the split). Stamped so the renderer sizes each page
    *  from the right section. Omitted ⇒ the renderer's body-level fallback. */
   tagSectionGeom?: () => SectionGeom,
+  /** B2 table stage 1b — the scale-1 layout to stamp onto each slice for paint
+   *  reuse. `colWidthsPt` is the full grid (constant across the split); each slice
+   *  gets ITS rows' heights (sliced from `rowHs`, with the repeated header rows
+   *  prepended on continuations so the stamp aligns 1:1 with the slice's rows).
+   *  Omitted (direct unit tests) ⇒ slices carry no table stamp and paint recomputes. */
+  tableStamp?: { colWidthsPt: number[]; contentWPt: number },
 ): number {
   const colTop = columnTop ?? (() => 0);
   const n = table.rows.length;
@@ -3359,6 +3407,7 @@ export function splitTableAcrossPages(
   while (headerCount < n && table.rows[headerCount].isHeader) headerCount++;
   const headerRows = table.rows.slice(0, headerCount);
   const headerH = rowHs.slice(0, headerCount).reduce((s, h) => s + h, 0);
+  const headerHeightsPt = rowHs.slice(0, headerCount);
 
   let y = startY;
   let start = 0;
@@ -3387,6 +3436,15 @@ export function splitTableAcrossPages(
     if (columnTop && marginTopPt != null) sliceEl.colTopPt = marginTopPt + colTop();
     if (tagSectionHF) sliceEl.sectionHF = tagSectionHF();
     if (tagSectionGeom) sliceEl.sectionGeom = tagSectionGeom();
+    // B2 table stage 1b — stamp this slice's own row heights (repeated header rows
+    // prepended on continuations, matching `sliceRows`) so the paint pass reuses
+    // them 1:1 instead of re-measuring the slice.
+    if (tableStamp) {
+      const sliceHeightsPt = isContinuation
+        ? [...headerHeightsPt, ...rowHs.slice(start, end)]
+        : rowHs.slice(start, end);
+      stampTableLayout(sliceEl, tableStamp.colWidthsPt, sliceHeightsPt, tableStamp.contentWPt);
+    }
     pages[pages.length - 1].push(sliceEl);
 
     y += used;
@@ -5633,6 +5691,14 @@ function paragraphSegsStateSensitive(para: DocParagraph): boolean {
  *  never leaks onto the public surface. */
 let lineReuseEnabled = true;
 
+/** B2 table stage 1b — master switch for the compute-once TABLE layout reuse
+ *  (stamped column widths + row heights, {@link computeTableLayout}). Always ON in
+ *  production; the characterization test flips it OFF to capture a fresh-recompute
+ *  reference and assert the reuse path resolves an IDENTICAL layout (see
+ *  table-layout-reuse.test.ts). Module-local so it never leaks onto the public
+ *  surface. */
+let tableReuseEnabled = true;
+
 /** Additional context passed to layoutLines so it can honor floats on the current page. */
 interface WrapLayoutCtx {
   startPageY: number;   // absolute canvas Y where the first line should start
@@ -7831,6 +7897,27 @@ export const __test_setLineReuseEnabled = (v: boolean): boolean => {
   return prev;
 };
 
+/** Exported for the compute-once table-layout characterization test (B2 table
+ *  stage 1b). Toggles the stamped column-width/row-height reuse in
+ *  computeTableLayout so the test can resolve the SAME stamped table with reuse ON
+ *  and OFF and assert the layout is identical. Returns the previous value so the
+ *  test can restore it. */
+export const __test_setTableReuseEnabled = (v: boolean): boolean => {
+  const prev = tableReuseEnabled;
+  tableReuseEnabled = v;
+  return prev;
+};
+
+/** Exported for the table-layout reuse test — resolves a table's px column
+ *  widths / row heights through the production {@link computeTableLayout}, so the
+ *  test can drive the reuse gate against a stamped element and a stub RenderState. */
+export const __test_computeTableLayout = (
+  table: DocTable,
+  contentWPx: number,
+  state: RenderState,
+): { colWidths: number[]; tableW: number; rowHeights: number[] } =>
+  computeTableLayout(table, contentWPx, state);
+
 function resolveAnchorBox(
   img: ImageRun,
   state: RenderState,
@@ -8117,9 +8204,42 @@ function computeTableLayout(
   state: RenderState,
 ): { colWidths: number[]; tableW: number; rowHeights: number[] } {
   const { scale } = state;
+
+  // B2 table stage 1b — compute-once reuse. When the paginator laid this table
+  // out it stamped the scale-1 pt column widths and per-row heights it resolved
+  // (splitTableAcrossPages per slice, or the whole-table push). Reuse them at the
+  // paint scale — skipping resolveColumnWidths (which re-measures the min-content
+  // width of every token in every cell) and resolveTableRowHeights (which re-lays
+  // out every cell paragraph) — WHEN this paint's inputs reconstruct to the
+  // paginator's scale-1 space. Both stamps are resolved purely in pt: column
+  // widths are scale-independent (resolveColumnWidths never rounds per scale) and
+  // the paginator now measures cell heights through the SAME measureCellContentHeightPx
+  // as the paint pass (stage 1a), at scale 1, so `× scale` reproduces the paint-
+  // scale layout. The gate compares in the paginator's scale-1 space with the same
+  // magnitude-relative epsilon the paragraph reuse uses (contentW/scale − colfit
+  // round-off ~1e-13 is a geometric equality, not a snap). A slice stamps only its
+  // own rows, so `tableRowHeightsPt` aligns 1:1 with `table.rows`; the column stamp
+  // is the full grid, shared by every slice.
+  const stamped = table as PaginatedBodyElement;
+  const contentWPt1 = contentWPx / scale;
+  const reuseInputs = stamped.tableLayoutInputs;
+  const reuse =
+    tableReuseEnabled &&
+    reuseInputs !== undefined &&
+    stamped.tableColWidthsPt !== undefined &&
+    stamped.tableRowHeightsPt !== undefined &&
+    reuseInputs.scale === 1 &&
+    stamped.tableRowHeightsPt.length === table.rows.length &&
+    Math.abs(reuseInputs.contentWPt - contentWPt1) <= 1e-6 * Math.max(1, Math.abs(contentWPt1));
+  if (reuse) {
+    const colWidths = (stamped.tableColWidthsPt as number[]).map((w) => w * scale);
+    const rowHeights = (stamped.tableRowHeightsPt as number[]).map((h) => h * scale);
+    return { colWidths, tableW: colWidths.reduce((s, w) => s + w, 0), rowHeights };
+  }
+
   // Resolve column widths in pt (autofit by preferred widths, or fixed grid),
   // already scaled to fit the available content width, then convert to px.
-  const colWidths = resolveColumnWidths(table, contentWPx / scale, state).map((w) => w * scale);
+  const colWidths = resolveColumnWidths(table, contentWPt1, state).map((w) => w * scale);
   const tableW = colWidths.reduce((s, w) => s + w, 0);
 
   // Shared ST_HeightRule + §17.4.85 vMerge-span skeleton (resolveTableRowHeights),

--- a/packages/docx/src/table-layout-reuse.test.ts
+++ b/packages/docx/src/table-layout-reuse.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'vitest';
+import {
+  splitTableAcrossPages,
+  __test_computeTableLayout,
+  __test_setTableReuseEnabled,
+} from './renderer.js';
+import type { RenderState } from './renderer.js';
+import type {
+  DocTable,
+  DocTableRow,
+  DocTableCell,
+  DocParagraph,
+  PaginatedBodyElement,
+} from './types';
+
+// B2 table stage 1b — compute-once TABLE layout reuse (stamped column widths +
+// row heights). These characterization tests pin:
+//   1. splitTableAcrossPages stamps each SLICE with its own rows' heights
+//      (repeated tblHeader rows prepended on continuations) + the shared column
+//      widths + the scale-1 contentWPt gate input.
+//   2. computeTableLayout with the reuse ON returns the SAME layout as with reuse
+//      OFF (a fresh resolveColumnWidths/resolveTableRowHeights recompute) — the
+//      reuse is a pure optimization.
+//   3. the reuse returns EXACTLY `stamp × scale` (proving the gate fires, not that
+//      it silently fell through to recompute).
+//   4. a stamp whose `contentWPt` no longer matches the paint band falls back to
+//      recompute (the self-verifying gate rejects a stale stamp).
+
+function emptyBorders() {
+  return { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null };
+}
+
+// ---- Minimal recording 2D context (mirrors table-clip-exact.test) --------------
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {}, strokeRect() {},
+    rect() {}, clip() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  (ctx as unknown as { canvas: unknown }).canvas = { width: 2000, height: 2000 };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function makeState(scale: number): RenderState {
+  return {
+    ctx: makeCtx(),
+    scale,
+    dpr: 1,
+    contentX: 0,
+    contentW: 500 * scale,
+    y: 0,
+    pageH: 1000,
+    defaultColor: '#000000',
+    pageIndex: 0,
+    totalPages: 1,
+    images: new Map(),
+    dryRun: true,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    marginBottom: 0,
+    floats: [],
+    floatParaSeq: 0,
+    docGrid: { type: null, linePitchPt: null, charSpacePt: null },
+    docEastAsian: false,
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    kinsoku: { enabled: false, lineStartForbidden: new Set<number>(), lineEndForbidden: new Set<number>() },
+    defaultTabPt: 36,
+    showTrackChanges: false,
+  } as unknown as RenderState;
+}
+
+function para(text: string): DocParagraph {
+  return {
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text === '' ? [] : [{
+      type: 'text', text,
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function cell(text: string, widthPt: number): DocTableCell {
+  return {
+    content: [{ type: 'paragraph', ...para(text) }],
+    colSpan: 1,
+    vMerge: null,
+    borders: emptyBorders(),
+    background: null,
+    vAlign: 'top',
+    widthPt,
+  } as unknown as DocTableCell;
+}
+
+function twoColRow(a: string, b: string): DocTableRow {
+  return {
+    cells: [cell(a, 200), cell(b, 300)],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+  } as unknown as DocTableRow;
+}
+
+function twoColTable(rows: DocTableRow[]): DocTable {
+  return {
+    colWidths: [200, 300], // pt grid (sums to the 500pt content band)
+    rows,
+    borders: emptyBorders(),
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+    layout: 'fixed', // trust the grid so recompute is deterministic
+  } as unknown as DocTable;
+}
+
+describe('splitTableAcrossPages — table stamp (B2 table stage 1b)', () => {
+  const rowsOf = (slice: PaginatedBodyElement) => (slice as unknown as DocTable).rows;
+
+  it('stamps each slice with its own rows heights + shared column widths + contentWPt', () => {
+    const t = twoColTable(Array.from({ length: 6 }, (_, i) => twoColRow(`a${i}`, `b${i}`)));
+    const rowHs = [10, 20, 30, 40, 50, 60];
+    const colWidthsPt = [200, 300];
+    const pages: PaginatedBodyElement[][] = [[]];
+    const newPage = () => { pages.push([]); };
+    // contentH = 65 ⇒ rows of 10,20,30 = 60 fit on page 1; 40 alone on page 2 (40),
+    // then 50, then 60 — one row per later page (each > 65-startY residual).
+    splitTableAcrossPages(
+      t, rowHs, 0, 65, pages, newPage,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      { colWidthsPt, contentWPt: 500 },
+    );
+
+    // Every slice carries the stamp.
+    const slices = pages.map((p) => p[0]).filter(Boolean);
+    expect(slices.length).toBeGreaterThan(1); // it really split
+    for (const s of slices) {
+      expect(s.tableColWidthsPt).toEqual(colWidthsPt);
+      expect(s.tableLayoutInputs).toEqual({ scale: 1, contentWPt: 500 });
+      // Row-height stamp aligns 1:1 with the slice's rows.
+      expect(s.tableRowHeightsPt!.length).toBe(rowsOf(s).length);
+    }
+
+    // The stamped heights, concatenated across slices, are the original per-row
+    // heights in order (no header repetition here — no isHeader rows).
+    const flat = slices.flatMap((s) => s.tableRowHeightsPt as number[]);
+    expect(flat).toEqual(rowHs);
+  });
+
+  it('prepends the repeated tblHeader rows heights on continuation slices', () => {
+    // Row 0 is a header; it repeats at the top of every continuation slice, so its
+    // height must be prepended to the continuation stamp (aligning with sliceRows).
+    const header: DocTableRow = { ...twoColRow('H0', 'H1'), isHeader: true } as unknown as DocTableRow;
+    const body = Array.from({ length: 4 }, (_, i) => twoColRow(`a${i}`, `b${i}`));
+    const t = twoColTable([header, ...body]);
+    const rowHs = [15, 20, 20, 20, 20]; // header=15, body rows=20 each
+    const pages: PaginatedBodyElement[][] = [[]];
+    const newPage = () => { pages.push([]); };
+    // contentH = 60: page1 = header(15) + 2 body(40) = 55 fit; continuations repeat
+    // header(15) + as many body as fit in 60-15=45 ⇒ 2 body (40).
+    splitTableAcrossPages(
+      t, rowHs, 0, 60, pages, newPage,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      { colWidthsPt: [200, 300], contentWPt: 500 },
+    );
+    const slices = pages.map((p) => p[0]).filter(Boolean);
+    expect(slices.length).toBeGreaterThan(1);
+    // Page 1 slice: header + body rows, stamp = [15, 20, ...].
+    expect(slices[0].tableRowHeightsPt![0]).toBe(15);
+    // Continuation slice(s): first stamped height is the REPEATED header height.
+    for (const s of slices.slice(1)) {
+      expect((s as unknown as DocTable).rows[0].isHeader).toBe(true);
+      expect(s.tableRowHeightsPt![0]).toBe(15); // header height prepended
+      // Length aligns with sliceRows (header + body).
+      expect(s.tableRowHeightsPt!.length).toBe((s as unknown as DocTable).rows.length);
+    }
+  });
+
+  it('omits the stamp when no tableStamp payload is passed (direct callers)', () => {
+    const t = twoColTable(Array.from({ length: 4 }, (_, i) => twoColRow(`a${i}`, `b${i}`)));
+    const pages: PaginatedBodyElement[][] = [[]];
+    const newPage = () => { pages.push([]); };
+    splitTableAcrossPages(t, [30, 30, 30, 30], 0, 65, pages, newPage);
+    for (const p of pages) {
+      const s = p[0];
+      if (!s) continue;
+      expect(s.tableColWidthsPt).toBeUndefined();
+      expect(s.tableRowHeightsPt).toBeUndefined();
+      expect(s.tableLayoutInputs).toBeUndefined();
+    }
+  });
+});
+
+describe('computeTableLayout — stamp reuse (B2 table stage 1b)', () => {
+  function stampedTable(): DocTable {
+    // Build the table, resolve its true layout once at scale 1 (reuse OFF) and
+    // stamp THAT as the paginator would, so the stamp is self-consistent.
+    const t = twoColTable([twoColRow('alpha', 'beta gamma'), twoColRow('x', 'y')]);
+    const prev = __test_setTableReuseEnabled(false);
+    const truth = __test_computeTableLayout(t, 500, makeState(1));
+    __test_setTableReuseEnabled(prev);
+    const el = t as PaginatedBodyElement;
+    el.tableColWidthsPt = truth.colWidths; // scale-1 ⇒ pt
+    el.tableRowHeightsPt = truth.rowHeights; // scale-1 ⇒ pt
+    el.tableLayoutInputs = { scale: 1, contentWPt: 500 };
+    return t;
+  }
+
+  it('reuse ON equals reuse OFF (pure optimization) at a non-unit scale', () => {
+    const t = stampedTable();
+    const scale = 1.5;
+    const contentWPx = 500 * scale;
+
+    const prev = __test_setTableReuseEnabled(false);
+    const off = __test_computeTableLayout(t, contentWPx, makeState(scale));
+    __test_setTableReuseEnabled(prev);
+
+    const on = __test_computeTableLayout(t, contentWPx, makeState(scale));
+
+    expect(on.colWidths).toEqual(off.colWidths);
+    expect(on.rowHeights).toEqual(off.rowHeights);
+    expect(on.tableW).toBe(off.tableW);
+  });
+
+  it('reuse returns exactly stamp × scale (the gate fires, not a silent fallthrough)', () => {
+    const t = stampedTable();
+    const scale = 2;
+    const on = __test_computeTableLayout(t, 500 * scale, makeState(scale));
+    const el = t as PaginatedBodyElement;
+    expect(on.colWidths).toEqual(el.tableColWidthsPt!.map((w) => w * scale));
+    expect(on.rowHeights).toEqual(el.tableRowHeightsPt!.map((h) => h * scale));
+  });
+
+  it('rejects a stamp whose contentWPt no longer matches the paint band (falls back to recompute)', () => {
+    const t = stampedTable();
+    const el = t as PaginatedBodyElement;
+    // Corrupt the stamp so it cannot be reused: pretend it was fit to a much
+    // narrower band. The gate must reject it and recompute against the real band.
+    el.tableRowHeightsPt = el.tableRowHeightsPt!.map(() => 9999);
+    el.tableColWidthsPt = [1, 1];
+    el.tableLayoutInputs = { scale: 1, contentWPt: 123 };
+
+    const scale = 1;
+    const got = __test_computeTableLayout(t, 500 * scale, makeState(scale));
+
+    // A reuse would have returned the corrupt stamp (colWidths [1,1], rows 9999);
+    // the recompute returns the real fixed-grid columns (200,300 at scale 1).
+    expect(got.colWidths).not.toEqual([1, 1]);
+    expect(got.colWidths[0]).toBeCloseTo(200, 6);
+    expect(got.colWidths[1]).toBeCloseTo(300, 6);
+    expect(got.rowHeights.every((h) => h < 9999)).toBe(true);
+  });
+
+  it('reuse OFF (master switch) always recomputes even with a valid stamp', () => {
+    const t = stampedTable();
+    const el = t as PaginatedBodyElement;
+    // Poison the column stamp; with reuse OFF the recompute ignores it.
+    el.tableColWidthsPt = [1, 1];
+    const prev = __test_setTableReuseEnabled(false);
+    const got = __test_computeTableLayout(t, 500, makeState(1));
+    __test_setTableReuseEnabled(prev);
+    expect(got.colWidths[0]).toBeCloseTo(200, 6);
+    expect(got.colWidths[1]).toBeCloseTo(300, 6);
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -324,6 +324,39 @@ export type PaginatedBodyElement = BodyElement & {
    *  the renderer uses the body-level `doc.section` geometry (single-section docs are
    *  unaffected). Runtime-only — never emitted by the parser. */
   sectionGeom?: SectionGeom;
+  /** B2 table stage 1b — compute-once table layout. When this element is a table
+   *  (`type === 'table'`), the paginator stamps the per-grid-column widths (pt) it
+   *  resolved via {@link resolveColumnWidths}. The paint pass ({@link computeTableLayout})
+   *  reuses them (× the paint scale) instead of re-running the column-fit — which
+   *  re-measures the min-content width of every token in every cell — whenever its
+   *  own layout inputs match `tableLayoutInputs`. Column widths are resolved purely
+   *  in pt (scale-independent), so `× scale` reproduces the paint-scale result
+   *  exactly. Absent ⇒ the paint pass resolves the columns itself (the pre-reuse
+   *  behaviour). Runtime-only — never emitted by the parser. */
+  tableColWidthsPt?: number[];
+  /** B2 table stage 1b — the per-row heights (pt) the paginator resolved via
+   *  {@link resolveTableRowHeights} (ST_HeightRule + §17.4.85 vMerge span). For a
+   *  table split across pages this holds the heights of THIS slice's rows only (the
+   *  leading repeated `tblHeader` rows of a continuation slice included), in slice
+   *  row order, so it aligns 1:1 with the slice's `rows`. The paint pass reuses
+   *  them (× scale) when `tableLayoutInputs` matches. Absent ⇒ recompute. Runtime-
+   *  only — never emitted by the parser. */
+  tableRowHeightsPt?: number[];
+  /** B2 table stage 1b — the scale-1 (pt-space) inputs the paginator resolved the
+   *  stamped table layout with. The paint pass reuses `tableColWidthsPt` /
+   *  `tableRowHeightsPt` ONLY when its OWN inputs reconstruct to these values in the
+   *  paginator's scale-1 space — a self-verifying gate mirroring the paragraph
+   *  `layoutLinesInputs` gate. `contentWPt` is the content-band width the columns
+   *  were fit to; `hasFloats` excludes a float-wrap context (a floating table takes
+   *  the out-of-flow path and never carries this stamp anyway). Runtime-only. */
+  tableLayoutInputs?: {
+    /** Always 1 (paginator space). Present so the gate can assert it, matching the
+     *  paragraph `layoutLinesInputs.scale` convention. */
+    scale: number;
+    /** The pt content-band width `resolveColumnWidths` was fit to. Compared with a
+     *  magnitude-relative epsilon against the paint pass's `contentW / scale`. */
+    contentWPt: number;
+  };
 };
 
 export interface DocParagraph {


### PR DESCRIPTION
## Summary

B2 follow-up: tables. The row-height **skeleton** (`resolveTableRowHeights`) was already shared between paginate and paint, but the cell-content measurer was not — the paginator sized cells with `estimateParagraphHeight` (approximate cursor walk) while paint sized them with the real line layout. Two measurers for the same rows is exactly the measure/paint divergence class B2 exists to remove.

**Commit 1 — single measurer.** `computeTableRowHeights` now routes through the same `measureCellContentHeightPx` the paint pass uses, at scale 1; the measure-side lambda is deleted. Two latent divergences in `measureParaHeight` were fixed so the shared measurer equals what paint draws: empty paragraph marks now use ctx-based `paragraphMarkLineHeight` (was the synthetic 0.8/0.2-em estimate), and ruby paragraphs get the same docGrid-snapped uniform line height paint applies. `estimateParagraphHeight` remains for body-flow lookahead only (keepNext, column balance, mark-only placement) — clean split: body flow vs cell content.

**Commit 2 — stamp + reuse (behavior-unchanged).** The paginator stamps `tableColWidthsPt` / `tableRowHeightsPt` / `tableLayoutInputs` on both push sites (whole-table and each `splitTableAcrossPages` slice, with repeated `tblHeader` rows prepended 1:1). `computeTableLayout` reuses the stamp behind a scale-1-space gate (magnitude-relative epsilon on `contentWPt`, row-count match), skipping the per-token min-content scan and per-cell relayout. Kinsoku is deliberately not in the gate: reuse returns stamped heights directly, which already encode the paginator's kinsoku from the same `doc.settings`. As a correctness refinement, split-table slices now share the full-table column grid (§17.4.52 resolves the grid once per table) instead of re-resolving per slice.

Cell-internal paragraph stamping is deferred to T2 (cell paragraphs are not body elements and need a per-cell stamp — structurally separate).

## Verification

- **VRT: 0/19 pages changed** (byte-compare via `cmp`) after each commit — the two measurers were numerically identical on the covered corpus, so the unification lands as pure structural consolidation while making the shared measurer correct for the empty-mark/ruby cases in general.
- Reuse verified to actually fire on the real corpus (sample-3's 12-row table reuses; nested in-cell tables recompute as designed) — instrumentation removed after.
- New `table-layout-reuse.test.ts` (7 cases): reuse ON == OFF at scale 1.5, exact `stamp×scale` passthrough, stale-stamp fallback, master switch, split-slice stamping with header prepend. Suite 487/487; root typecheck + ast-grep lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)