### PR TITLE
fix(docx): row-split overflowing floating tables + clamp page-anchored boxes (§17.4.57/§17.3.1.11, Word ground truth)

### DIFF
--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -214,6 +214,55 @@ describe('floating table geometry (§17.4.57) — vertical placement', () => {
   });
 });
 
+// Word ground truth (private/sample-18 Sec B, Word-exported PDF via pdftotext):
+// a vertAnchor="page" floating table whose requested tblpY would push its BOTTOM
+// past the physical page edge is shifted UP so its bottom sits flush on the page
+// bottom (measured top 741.9pt = 841.9 − 100 for a 100pt table), NOT left
+// overflowing. computeFloatTableBox clamps it via clampAbsBoxIntoContainer.
+// vertAnchor="text" is NOT clamped (its overflow is row-split by the paginator).
+describe('floating table geometry (§17.4.57) — page/margin-anchored clamp (Word ground truth)', () => {
+  it('vertAnchor="page": a box overflowing the page bottom is clamped up to pageH − boxH', () => {
+    // The sample-18 Sec B geometry at A4 (pageH 841.9, table 100pt): tblpY=775
+    // would put the bottom at 875 > 841.9 ⇒ clamp to y = 841.9 − 100 = 741.9.
+    const st = makeState({ pageH: 841.9 });
+    const b = box(tblp({ vertAnchor: 'page', tblpY: 775 }), st, 300, 250, 100);
+    expect(b.y).toBeCloseTo(841.9 - 100, 6); // 741.9 — clamped to the page bottom
+  });
+
+  it('vertAnchor="page": a box that already fits is NOT moved (clamp is idempotent)', () => {
+    const st = makeState(); // pageH 800
+    const b = box(tblp({ vertAnchor: 'page', tblpY: 5 }), st, 300, 150, 60);
+    expect(b.y).toBe(5); // 5 + 60 = 65 ≤ 800 ⇒ unchanged
+  });
+
+  it('vertAnchor="page": a box TALLER than the page pins to the top (floor = page top)', () => {
+    // boxH 900 > pageH 800: pageH − boxH = −100 would push it above the page top,
+    // so the floor (containerStart = 0) wins — the box overflows the bottom instead.
+    const st = makeState(); // pageH 800
+    const b = box(tblp({ vertAnchor: 'page', tblpY: 50 }), st, 300, 150, 900);
+    expect(b.y).toBe(0); // clamped to the page top, not −100
+  });
+
+  it('vertAnchor="margin": a box overflowing the bottom margin is clamped to (pageH − marginBottom) − boxH', () => {
+    // margin band [72, 728]: tblpY=700 ⇒ y=772, bottom 872 > 728 ⇒ clamp to
+    // 728 − 100 = 628 (the container end is the bottom text margin, ASSUMED — no
+    // fixture pins where Word clamps a margin-anchored overflow; symmetric with page).
+    const st = makeState(); // margin band [72, 728]
+    const b = box(tblp({ vertAnchor: 'margin', tblpY: 700 }), st, 300, 150, 100);
+    expect(b.y).toBe(728 - 100); // 628 — clamped to the margin band bottom
+  });
+
+  it('vertAnchor="text": an overflowing box is NOT clamped (paginator row-split handles it)', () => {
+    // A vertAnchor="text" table rides the flow cursor; its overflow is split
+    // row-by-row by computePages, so the geometry must leave the box at paraTop +
+    // tblpY even when that runs past the page — clamping here would corrupt the
+    // per-slice band. paraTop 780, tblpY 0, tableH 100 ⇒ y stays 780 (bottom 880).
+    const st = makeState(); // pageH 800
+    const b = box(tblp({ vertAnchor: 'text', tblpY: 0 }), st, 780, 150, 100);
+    expect(b.y).toBe(780); // NOT clamped to 700 — text-anchored is the paginator's job
+  });
+});
+
 describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
   it('registers a square wrap float padded by the *FromText dist values', () => {
     const st = makeState();

--- a/packages/docx/src/float-table-geometry.ts
+++ b/packages/docx/src/float-table-geometry.ts
@@ -19,6 +19,7 @@ import {
   frameYContainer,
   resolveAlignedPosH,
   resolveAlignedPosV,
+  clampAbsBoxIntoContainer,
   pushFloatRect,
 } from './frame-geometry.js';
 
@@ -90,6 +91,17 @@ export function computeFloatTableBox(
   } else {
     // §17.4.57 tblpY: absolute signed offset from the vertAnchor band start.
     y = vBand.start + tp.tblpY * sc;
+  }
+
+  // Word ground truth (sample-18 Sec B): a vertAnchor=page/margin floating table
+  // whose bottom would fall past its container is shifted UP to sit flush on the
+  // container bottom (physical page edge for page-anchored: measured top 741.9pt =
+  // 841.9 − 100 for a 100pt table), not left overflowing. vertAnchor="text" is
+  // excluded — its overflow is handled by the paginator's row-split (the floating
+  // analogue of splitTableAcrossPages), and its band rides the flow cursor, so
+  // clamping here would be wrong. Mirrors computeFrameBox exactly (§17.3.1.11).
+  if (tp.vertAnchor === 'page' || tp.vertAnchor === 'margin') {
+    y = clampAbsBoxIntoContainer(y, tableH, vBand);
   }
 
   return { x, y, w: tableW, h: tableH };

--- a/packages/docx/src/float-table-page-fit.test.ts
+++ b/packages/docx/src/float-table-page-fit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { computePages } from './renderer.js';
 import type {
   BodyElement,
+  CellElement,
   DocParagraph,
   DocTable,
   DocTableRow,
@@ -11,20 +12,26 @@ import type {
   PaginatedBodyElement,
 } from './types';
 
-// Unit tests for the keep-with-anchor pagination of a page-overflowing FLOATING
-// table (ECMA-376 §17.4.57 `<w:tblpPr>`). §17.4.57 pins only the table's
-// size/position; keeping an undivided floating table with its anchor context on
-// the next page is Word runtime behaviour — the SAME "keep on page" semantics
-// already covered for a text frame (§17.3.1.11, frame-keep-with-anchor.test.ts)
-// and a paragraph-anchored image float. These assertions guard that behaviour,
-// which the private-sample VRT (sample-11's small top-of-page float only, never
-// a page-boundary one) cannot cover.
+// Unit tests for the page-fit pagination of a page-overflowing FLOATING table
+// (ECMA-376 §17.4.57 `<w:tblpPr>`).
+//
+// HISTORY: PR #691 shipped "relocate the whole undivided floating table to the
+// next page". That was measured to be WRONG against Word: the Word-exported PDFs
+// of private/sample-18 + sample-21 (pdftotext bbox — see issue #674's reopening
+// comment) show Word SPLITS a page-overflowing vertAnchor="text" floating table
+// ROW BY ROW like a block table, spilling the remainder onto continuation pages,
+// and flows the anchor paragraph beside the FINAL continuation band from that
+// page's body TOP. The old whole-table-relocation tests are therefore replaced
+// here with row-split assertions. A page/margin-anchored floating table is still
+// NOT split — its absolute in-page y is instead clamped up into its container by
+// computeFloatTableBox (geometry; see float-table-geometry.test.ts), so it stays a
+// single element on its page.
 //
 // The stub canvas mirrors frame-keep-with-anchor.test.ts / pagination.test.ts:
 // glyph advance = charCount × fontPx and the font box = 0.8/0.2 em, so a single
 // line is exactly fontPx tall. Table row heights are pinned with
-// rowHeightRule="exact" so `tableH` is deterministic (independent of the stub's
-// cell measurement), the table analogue of the frame's hRule="exact"/h.
+// rowHeightRule="exact" so each row's height is deterministic (independent of the
+// stub's cell measurement), the table analogue of the frame's hRule="exact"/h.
 
 function makeCtx(): CanvasRenderingContext2D {
   let font = '10px serif';
@@ -101,13 +108,14 @@ function tblp(over: Partial<TblpPr> = {}): TblpPr {
 }
 
 /** A single-cell row of the given exact pt height (`rowHeightRule="exact"` short-
- *  circuits content measurement, so `tableH` == `rowHeight` regardless of the
- *  stub canvas — the table analogue of the frame's hRule="exact"/h). */
-function row(heightPt: number): DocTableRow {
+ *  circuits content measurement, so the row height == `heightPt` regardless of the
+ *  stub canvas — the table analogue of the frame's hRule="exact"/h). The optional
+ *  `label` cell text lets a test read which rows landed on which page. */
+function row(heightPt: number, label = ''): DocTableRow {
   return {
     cells: [
       {
-        content: [],
+        content: label ? [para({ text: label }) as unknown as CellElement] : [],
         colSpan: 1,
         vMerge: null,
         borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
@@ -122,12 +130,15 @@ function row(heightPt: number): DocTableRow {
   };
 }
 
-/** A floating table (`w:tblpPr`) of total height `tableHPt`, laid out as one
- *  exact-height row so its measured extent is deterministic. */
-function floatTable(tp: TblpPr, tableHPt: number): BodyElement {
+/** A floating table (`w:tblpPr`) of `n` exact-height rows, each `rowHPt` tall and
+ *  labelled `r1`, `r2`, … so a test can read the per-page row split. Its total
+ *  height is `n × rowHPt`, deterministic under the stub. */
+function floatTableRows(tp: TblpPr, n: number, rowHPt: number): BodyElement {
+  const rows: DocTableRow[] = [];
+  for (let i = 1; i <= n; i++) rows.push(row(rowHPt, `r${i}`));
   const t: DocTable = {
     colWidths: [80],
-    rows: [row(tableHPt)],
+    rows,
     borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
     cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
     jc: 'left',
@@ -136,12 +147,32 @@ function floatTable(tp: TblpPr, tableHPt: number): BodyElement {
   return { type: 'table', ...t } as unknown as BodyElement;
 }
 
+/** A floating table (`w:tblpPr`) of total height `tableHPt`, laid out as one
+ *  exact-height row so its measured extent is deterministic. */
+function floatTable(tp: TblpPr, tableHPt: number): BodyElement {
+  return floatTableRows(tp, 1, tableHPt);
+}
+
 /** True when an element is a floating table (identified by its tblpPr). */
 const isFloatTable = (el: PaginatedBodyElement): boolean =>
   el.type === 'table' && (el as unknown as DocTable).tblpPr != null;
 
-/** True when a page holds a floating table. */
+/** True when a page holds a floating table (any slice). */
 const hasFloatTable = (page: PaginatedBodyElement[]): boolean => page.some(isFloatTable);
+
+/** The row labels (r1, r2, …) of the floating-table slice(s) on a page, in order. */
+const floatRowsOn = (page: PaginatedBodyElement[]): string[] => {
+  const out: string[] = [];
+  for (const el of page) {
+    if (!isFloatTable(el)) continue;
+    for (const r of (el as unknown as DocTable).rows) {
+      const c0 = r.cells[0]?.content?.[0] as unknown as DocParagraph | undefined;
+      const t = c0?.runs?.filter((x) => x.type === 'text').map((x) => (x as DocxTextRun).text).join('') ?? '';
+      out.push(t);
+    }
+  }
+  return out;
+};
 
 /** Text of a paragraph element (joins its text runs). */
 const textOf = (el: PaginatedBodyElement): string =>
@@ -163,133 +194,224 @@ const colOf = (el: PaginatedBodyElement): number | undefined => el.colIndex;
 const floatTableEl = (page: PaginatedBodyElement[]): PaginatedBodyElement | undefined =>
   page.find(isFloatTable);
 
-describe('computePages — floating-table page-fit / keep-with-anchor (§17.4.57)', () => {
-  // Content band 160×100, bodyTop 20. Table: vertAnchor="text", one exact row of
-  // height H ⇒ table body box [paraTop, paraTop+H]. With N leading 20pt lines the
-  // table's in-flow top is at y=20N; the table overflows the 100pt content area
-  // once 20N + H > 100.
+describe('computePages — floating-table page-fit / row-split (§17.4.57, Word ground truth)', () => {
+  // Content band 160×100, bodyTop 20. A vertAnchor="text" table's first slice sits
+  // at its in-flow anchor (y=20N after N leading 20pt lines); it overflows once
+  // 20N + tableH > 100 and is then SPLIT row-by-row, the remainder continuing at
+  // the next page's body top.
 
-  it('relocates a text-anchored floating table + its anchor text to the next page when it overflows the bottom', () => {
-    // 3 leading lines (y advances 20→40→60), then the floating table (60 tall:
-    // 60+60 > 100 ⇒ overflow), then the anchor text paragraph.
+  it('(a) splits a text-anchored floating table across pages, greedily filling page 1 from the anchor', () => {
+    // 2 leading 20pt lines (y 20→40), then a 5-row table (each 20pt). Anchor at
+    // y=40 ⇒ remaining band to the content bottom (100) is 60pt ⇒ 3 rows (r1–r3)
+    // fit on page 1; r4–r5 continue at page 2's body top. The trailing anchor text
+    // follows onto page 2 (kept with the final band).
     const body = [
       para({ text: 'a' }),
       para({ text: 'b' }),
-      para({ text: 'c' }),
-      floatTable(tblp({ vertAnchor: 'text', tblpY: 0 }), 60),
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 5, 20),
       para({ text: 'anchor' }),
     ];
     const pages = computePages(body, section(), makeCtx());
     expect(pages.length).toBe(2);
-    // The table does NOT stay on page 1 (would overflow); it moves to page 2…
-    expect(hasFloatTable(pages[0])).toBe(false);
-    expect(hasFloatTable(pages[1])).toBe(true);
-    // …and its trailing anchor text follows it onto page 2 (kept together).
-    expect(hasAnchorText(pages[1], 'anchor')).toBe(true);
-    expect(hasAnchorText(pages[0], 'anchor')).toBe(false);
-    // Page 1 keeps only the three leading lines (no float band leaked over).
-    expect(pages[0].map(textOf)).toEqual(['a', 'b', 'c']);
+    // Page 1: the two leading lines + a slice holding exactly the rows that fit.
+    expect(floatRowsOn(pages[0])).toEqual(['r1', 'r2', 'r3']);
+    // Page 2: the continuation slice with the remaining rows.
+    expect(floatRowsOn(pages[1])).toEqual(['r4', 'r5']);
+    // Every row appears exactly once across the split (no duplication, no loss).
+    expect([...floatRowsOn(pages[0]), ...floatRowsOn(pages[1])]).toEqual([
+      'r1', 'r2', 'r3', 'r4', 'r5',
+    ]);
   });
 
-  it('relocates an overflowing floating table to the NEXT COLUMN (not a new page) in a multi-column section', () => {
-    // 2 equal columns: colW = (160-20)/2 = 70; content height 100 (5 × 20pt per
-    // column). Column 0 gets 3 leading lines (y 20→40→60); the table body box
-    // (60 tall) then overflows column 0's bottom (60+60 > 100). With a column
-    // still available on the page, it relocates to column 1 — NOT a new page.
+  it('(b) splits a tall floating table across pages until every row is placed (sample-21 shape)', () => {
+    // A single leading 20pt line (anchor at y=20) then an 8-row table (20pt each ⇒
+    // 160pt total, > the 100pt content area, so it needs 2 pages). Page 1's band
+    // runs from the anchor (y=20) to the bottom (100) = 80pt ⇒ 4 rows (r1–r4);
+    // page 2 (fresh, full 100pt band) takes the remaining 4 (r5–r8). This is the
+    // reduced analogue of sample-21 (800pt/32 rows → r1–r23 then r24–r32).
+    const body = [
+      para({ text: 'a' }),
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 8, 20),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages.length).toBe(2);
+    expect(floatRowsOn(pages[0])).toEqual(['r1', 'r2', 'r3', 'r4']);
+    expect(floatRowsOn(pages[1])).toEqual(['r5', 'r6', 'r7', 'r8']);
+  });
+
+  it('(c) flows the trailing anchor paragraph from the TERMINAL page body top, not below the band', () => {
+    // 2 leading lines (anchor at y=40), 5-row 20pt table split (r1–r3 | r4–r5).
+    // The anchor paragraph must land on page 2 (the terminal continuation page) —
+    // Word flows it beside the final band from that page's body top, so it never
+    // stays on page 1 and never starts below the band.
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 5, 20),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    expect(hasAnchorText(pages[0], 'anchor')).toBe(false);
+    expect(hasAnchorText(pages[1], 'anchor')).toBe(true);
+    // The anchor paragraph is the FIRST paragraph on page 2 after the continuation
+    // slice (the slice is pushed before the anchor so the wrap band is registered
+    // first) — i.e. it starts at the body top beside the band, not after it.
+    const page2Types = pages[1].map((el) => (isFloatTable(el) ? 'slice' : textOf(el)));
+    expect(page2Types).toEqual(['slice', 'anchor']);
+  });
+
+  it('(a-multicol) splits a text-anchored floating table into the NEXT COLUMN in a multi-column section', () => {
+    // 2 equal columns: colW = (160-20)/2 = 70; content height 100. Column 0 gets 2
+    // leading lines (y 20→40); a 5-row 20pt table then overflows column 0 from the
+    // anchor (40 + 60 = 100 exactly for 3 rows, r4–r5 spill). With a column still
+    // available on the page, the remainder continues in COLUMN 1 — not a new page.
     const twoCol = section({ columns: { count: 2, spacePt: 20, equalWidth: true, sep: false, cols: [] } });
     const body = [
       para({ text: 'a' }),
       para({ text: 'b' }),
-      para({ text: 'c' }),
-      floatTable(tblp({ vertAnchor: 'text', horzAnchor: 'text', tblpY: 0 }), 60),
+      floatTableRows(tblp({ vertAnchor: 'text', horzAnchor: 'text', tblpY: 0 }), 5, 20),
       para({ text: 'anchor' }),
     ];
     const pages = computePages(body, twoCol, makeCtx());
-    // Still a single page (column 1 absorbed the table + anchor).
+    // Still a single page (column 1 absorbed the remaining rows + the anchor).
     expect(pages.length).toBe(1);
-    const f = floatTableEl(pages[0]);
-    expect(f).toBeDefined();
-    expect(colOf(f as PaginatedBodyElement)).toBe(1); // moved into column 1
-    // The three leading lines (a/b/c) stayed in column 0.
-    const leadCols = pages[0]
-      .filter((el) => ['a', 'b', 'c'].includes(textOf(el)))
-      .map(colOf);
-    expect(leadCols).toEqual([0, 0, 0]);
-    // The trailing anchor text follows the table into column 1.
+    // The first slice sits in column 0, the continuation slice in column 1.
+    const slices = pages[0].filter(isFloatTable);
+    expect(slices.length).toBe(2);
+    expect(colOf(slices[0])).toBe(0);
+    expect(colOf(slices[1])).toBe(1);
+    // The trailing anchor text follows the final band into column 1.
     const anchor = pages[0].find((el) => textOf(el) === 'anchor');
     expect(anchor).toBeDefined();
     expect(colOf(anchor as PaginatedBodyElement)).toBe(1);
   });
 
-  it('keeps a text-anchored floating table in place when it fits (near the top of the page)', () => {
-    // Only 1 leading line (y=20). Table body box [20,80] fits within [0,100] ⇒
-    // no relocation. Everything stays on page 1. (sample-11 shape: a small
-    // vertAnchor="text" tblpY=1 float near the page top must NOT be sent.)
+  it('(f) keeps a text-anchored floating table as ONE element when every row fits (no split)', () => {
+    // Only 1 leading line (anchor at y=20). A 3-row 20pt table (60pt) fits within
+    // [20,100] ⇒ no split. Everything stays on page 1 as a single float element
+    // (sample-11 shape: a small vertAnchor="text" float near the page top must not
+    // be divided or relocated).
     const body = [
       para({ text: 'a' }),
-      floatTable(tblp({ vertAnchor: 'text', tblpY: 1 }), 60),
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 1 }), 3, 20),
       para({ text: 'anchor' }),
     ];
     const pages = computePages(body, section(), makeCtx());
     expect(pages.length).toBe(1);
-    expect(hasFloatTable(pages[0])).toBe(true);
+    expect(floatRowsOn(pages[0])).toEqual(['r1', 'r2', 'r3']);
+    // Exactly ONE floating-table element (not sliced).
+    const floatCount = pages.reduce((s, p) => s + p.filter(isFloatTable).length, 0);
+    expect(floatCount).toBe(1);
     expect(hasAnchorText(pages[0], 'anchor')).toBe(true);
   });
 
-  it('does NOT relocate (or loop) a floating table taller than the page content area', () => {
-    // 150 tall > content height 100: the table can never fit on any page, so
-    // relocating would loop forever. It is left in place and allowed to overflow.
-    // The real assertion is that this terminates (no timeout / infinite paging)
-    // AND that the floating table is NOT row-split (Word keeps it undivided).
+  it('moves the whole table to the next page when not even the first row fits the remaining band', () => {
+    // 4 leading lines (anchor at y=80), then a 3-row 30pt table. The remaining band
+    // (100−80 = 20pt) cannot hold even the first row (30pt), and a fuller band is
+    // one page away ⇒ the WHOLE table moves to page 2 first (no page-1 slice), then
+    // fills there (30+30 = 60 ≤ 100 ⇒ all 3 rows: 30·3 = 90 ≤ 100).
     const body = [
       para({ text: 'a' }),
       para({ text: 'b' }),
       para({ text: 'c' }),
-      floatTable(tblp({ vertAnchor: 'text', tblpY: 0 }), 150),
+      para({ text: 'd' }),
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 3, 30),
       para({ text: 'anchor' }),
     ];
     const pages = computePages(body, section(), makeCtx());
-    // Table stays on page 1 with its three leading lines (no relocation).
-    expect(hasFloatTable(pages[0])).toBe(true);
-    // A floating table adds no flow height, so the anchor stays on the same page.
-    expect(hasAnchorText(pages[0], 'anchor')).toBe(true);
-    expect(pages.length).toBe(1);
-    // Exactly ONE floating-table element exists across all pages (not split into
-    // per-page slices like a block table).
+    expect(pages.length).toBe(2);
+    // No slice on page 1 (the four leading lines only).
+    expect(hasFloatTable(pages[0])).toBe(false);
+    expect(pages[0].map(textOf)).toEqual(['a', 'b', 'c', 'd']);
+    // All rows land on page 2 (a fresh full band fits them).
+    expect(floatRowsOn(pages[1])).toEqual(['r1', 'r2', 'r3']);
+    expect(hasAnchorText(pages[1], 'anchor')).toBe(true);
+  });
+
+  it('terminates (no loop) and places a single over-tall row on the page it best fits', () => {
+    // 3 leading lines (anchor at y=60), then a 1-row table 150pt tall — taller than
+    // the whole 100pt content area, so it can never fit any band. The forward-
+    // progress guarantee places it (overflowing) rather than looping. Because the
+    // remaining page-1 band (40pt) can't hold it AND a fuller band is one page
+    // away, it moves to page 2 first, then is placed there (over-tall rows are not
+    // sub-divided — a floating table splits by ROW, and one row is atomic).
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      para({ text: 'c' }),
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 1, 150),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    // Terminates with a bounded page count; the over-tall single row is placed once.
+    expect(pages.length).toBe(2);
+    expect(floatRowsOn(pages[1])).toEqual(['r1']);
     const floatCount = pages.reduce((s, p) => s + p.filter(isFloatTable).length, 0);
     expect(floatCount).toBe(1);
   });
 
-  it('does NOT relocate a page-anchored floating table that overflows (absolute y is honored in place)', () => {
-    // vertAnchor="page", tblpY=90: the table is pinned at page-y 90 with H=60 ⇒
-    // bottom 150, past the 140 page edge. An absolute page position is the SAME
-    // on any page, so relocation cannot help — Word draws it there (overflowing).
+  it('(d) does NOT split a page-anchored floating table (absolute y; clamped in place by geometry)', () => {
+    // vertAnchor="page", tblpY=90: the table is pinned at page-y 90 with total
+    // height 60 ⇒ it would reach y=150, past the 140 page edge. An absolute page
+    // position is the SAME on any page, so it is NOT split or relocated — it stays
+    // one element on page 1 (computeFloatTableBox clamps the box UP into the page;
+    // see float-table-geometry.test.ts for the clamped y).
     const body = [
       para({ text: 'a' }),
       para({ text: 'b' }),
       para({ text: 'c' }),
-      floatTable(tblp({ vertAnchor: 'page', tblpY: 90 }), 60),
+      floatTableRows(tblp({ vertAnchor: 'page', tblpY: 90 }), 2, 30),
       para({ text: 'anchor' }),
     ];
     const pages = computePages(body, section(), makeCtx());
     expect(pages.length).toBe(1);
     expect(hasFloatTable(pages[0])).toBe(true);
+    // Not sliced — both rows are on the single element.
+    expect(floatRowsOn(pages[0])).toEqual(['r1', 'r2']);
+    const floatCount = pages.reduce((s, p) => s + p.filter(isFloatTable).length, 0);
+    expect(floatCount).toBe(1);
     expect(hasAnchorText(pages[0], 'anchor')).toBe(true);
   });
 
-  it('does NOT relocate a margin-anchored floating table that overflows (absolute y is honored in place)', () => {
-    // vertAnchor="margin", tblpY=70: table at margin-top(20)+70 = 90, H=60 ⇒
-    // bottom 150, past the bottom margin. Absolute ⇒ left in place (mirrors
-    // vertAnchor="page").
+  it('(e) does NOT split a margin-anchored floating table (absolute y; clamped in place by geometry)', () => {
+    // vertAnchor="margin", tblpY=70: the table is at margin-top(20)+70 = 90 with
+    // total height 60 ⇒ bottom 150, past the bottom margin. Absolute ⇒ left as one
+    // element (mirrors vertAnchor="page"); the box clamps up into the margin band.
     const body = [
       para({ text: 'a' }),
       para({ text: 'b' }),
       para({ text: 'c' }),
-      floatTable(tblp({ vertAnchor: 'margin', tblpY: 70 }), 60),
+      floatTableRows(tblp({ vertAnchor: 'margin', tblpY: 70 }), 2, 30),
       para({ text: 'anchor' }),
     ];
     const pages = computePages(body, section(), makeCtx());
     expect(pages.length).toBe(1);
     expect(hasFloatTable(pages[0])).toBe(true);
+    expect(floatRowsOn(pages[0])).toEqual(['r1', 'r2']);
+    const floatCount = pages.reduce((s, p) => s + p.filter(isFloatTable).length, 0);
+    expect(floatCount).toBe(1);
+  });
+
+  it('registers each slice as its own floating table so both pages report a float element', () => {
+    // Sanity: a split leaves a floating-table element on BOTH pages (one slice
+    // each), never a single element straddling the boundary.
+    const body = [
+      para({ text: 'a' }),
+      para({ text: 'b' }),
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 5, 20),
+      para({ text: 'anchor' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    expect(hasFloatTable(pages[0])).toBe(true);
+    expect(hasFloatTable(pages[1])).toBe(true);
+    // Two slices total (one per page).
+    const floatCount = pages.reduce((s, p) => s + p.filter(isFloatTable).length, 0);
+    expect(floatCount).toBe(2);
+    // Each slice still carries a tblpPr so the paint pass diverts to renderFloatTable.
+    for (const p of pages) {
+      const el = floatTableEl(p);
+      if (el) expect((el as unknown as DocTable).tblpPr).toBeDefined();
+    }
   });
 });

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -282,6 +282,61 @@ describe('frame geometry (§17.3.1.11 / §22.9.2.20) — yAlign is vAnchor-band 
   });
 });
 
+// Word ground truth (private/sample-17 Sec B, Word-exported PDF via pdftotext):
+// a vAnchor="page" frame whose requested `y` would push its BOTTOM past the
+// physical page edge is shifted UP so its bottom sits flush on the page bottom
+// (measured top 741.9pt = 841.9 − 100 for a 100pt frame), NOT left overflowing.
+// computeFrameBox clamps it via clampAbsBoxIntoContainer — identical to the
+// floating-table clamp (float-table-geometry.test.ts). vAnchor="text" is NOT
+// clamped (its overflow is the paginator's keep-with-anchor).
+describe('frame geometry (§17.3.1.11) — page/margin-anchored clamp (Word ground truth)', () => {
+  it('vAnchor="page": a frame overflowing the page bottom is clamped up to pageH − frameH', () => {
+    // The sample-17 Sec B geometry at A4 (pageH 841.9, frame 100pt): y=775 would
+    // put the bottom at 875 > 841.9 ⇒ clamp to y = 841.9 − 100 = 741.9.
+    const st = makeState({ pageH: 841.9 });
+    const fp = frame({ vAnchor: 'page', hRule: 'exact', h: 100, y: 775 });
+    const b = box(fp, st, 300, 250, 100, 12);
+    expect(b.y).toBeCloseTo(841.9 - 100, 6); // 741.9 — clamped to the page bottom
+  });
+
+  it('vAnchor="page": a frame that already fits is NOT moved (clamp is idempotent)', () => {
+    const st = makeState(); // pageH 800
+    const fp = frame({ vAnchor: 'page', hRule: 'exact', h: 60, y: 5 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(5); // 5 + 60 = 65 ≤ 800 ⇒ unchanged
+  });
+
+  it('vAnchor="page": a frame TALLER than the page pins to the top (floor = page top)', () => {
+    // frameH 900 > pageH 800: pageH − frameH = −100 would push it above the page
+    // top, so the floor (containerStart = 0) wins — it overflows the bottom instead.
+    const st = makeState(); // pageH 800
+    const fp = frame({ vAnchor: 'page', hRule: 'exact', h: 900, y: 50 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(0); // clamped to the page top, not −100
+  });
+
+  it('vAnchor="margin": a frame overflowing the bottom margin is clamped to (pageH − marginBottom) − frameH', () => {
+    // margin band [72, 728]: y=700 ⇒ frameY=772, bottom 872 > 728 ⇒ clamp to
+    // 728 − 100 = 628 (container end = bottom text margin, ASSUMED — no fixture
+    // pins where Word clamps a margin-anchored overflow; symmetric with page).
+    const st = makeState(); // margin band [72, 728]
+    const fp = frame({ vAnchor: 'margin', hRule: 'exact', h: 100, y: 700 });
+    const b = box(fp, st, 300, 40, 100, 12);
+    expect(b.y).toBe(728 - 100); // 628 — clamped to the margin band bottom
+  });
+
+  it('vAnchor="text": an overflowing frame is NOT clamped (paginator keep-with-anchor handles it)', () => {
+    // A vAnchor="text" frame rides the flow cursor; the paginator relocates it (and
+    // its anchor context) when it overflows, so the geometry must leave the box at
+    // paraTop + y even past the page — clamping here would fight that. paraTop 780,
+    // y 0, h 100 ⇒ y stays 780 (bottom 880).
+    const st = makeState(); // pageH 800
+    const fp = frame({ vAnchor: 'text', hRule: 'exact', h: 100, y: 0 });
+    const b = box(fp, st, 780, 40, 100, 12);
+    expect(b.y).toBe(780); // NOT clamped — text-anchored is the paginator's job
+  });
+});
+
 describe('frame geometry (§17.3.1.11) — generic frame (dropCap="none") sizing', () => {
   it('hRule="exact" forces the frame height to h regardless of content', () => {
     const st = makeState();

--- a/packages/docx/src/frame-geometry.ts
+++ b/packages/docx/src/frame-geometry.ts
@@ -159,6 +159,43 @@ export function resolveAlignedPosV(
 }
 
 /**
+ * Clamp an absolutely-positioned (vAnchor=page/margin) box so it stays inside its
+ * vertical container band — Word ground truth (sample-17 Sec B frame,
+ * sample-18 Sec B floating table): a `vAnchor="page"` box requesting a `y` that
+ * would push its BOTTOM past the physical page edge is shifted UP so its bottom
+ * sits exactly on the page bottom (measured 741.9pt = 841.9 − 100 for a 100pt
+ * box), NOT left overflowing. This is the frame / floating-table analogue of the
+ * pagination keep-with-anchor that a vAnchor="text" box gets instead (moving the
+ * anchor cursor); page/margin boxes have an ABSOLUTE in-page y that pagination
+ * cannot help, so the geometry clamps them here.
+ *
+ *   y = max(containerStart, containerEnd − boxH)
+ *
+ * The floor is `containerStart` (container top): a box TALLER than its container
+ * pins to the top and is allowed to overflow the bottom (clamping to
+ * `end − boxH < start` would push it ABOVE the container top, which is worse). For
+ * vAnchor="page" the container is the physical page [0, pageH], matching the
+ * sample-17/18 physical-bottom measurements. For vAnchor="margin" the clamp
+ * target (container end = the bottom text margin) is NOT independently observed —
+ * no fixture pins where Word clamps a margin-anchored overflow — so it is ASSUMED
+ * to be the container's own end (the margin band bottom), symmetric with the page
+ * case. Callers pass the SAME `frameYContainer(vAnchor,…)` band the placement was
+ * resolved against, so the clamp target always matches the anchor semantics.
+ *
+ * Only meaningful for vAnchor=page/margin: the caller gates on that (vAnchor=text
+ * is handled by pagination, and its band start/end ride the flow cursor, so this
+ * clamp must not run there). Idempotent for a box that already fits (y unchanged).
+ */
+export function clampAbsBoxIntoContainer(
+  y: number,
+  boxH: number,
+  band: { start: number; end: number },
+): number {
+  if (y + boxH <= band.end) return y; // already inside — no-op (common case).
+  return Math.max(band.start, band.end - boxH);
+}
+
+/**
  * Resolve a frame's box in canvas px. `paraTop` is the in-flow top of the frame
  * paragraph (post-spaceBefore). `contentW`/`contentH` are the frame content's
  * measured natural size (px); `anchorLineHpx` is one line height of the
@@ -232,6 +269,16 @@ export function computeFrameBox(
   } else {
     // §17.3.1.11 y: absolute signed offset from the vAnchor band start.
     frameY = vBand.start + (fp.y != null ? fp.y * sc : 0);
+  }
+
+  // Word ground truth (sample-17 Sec B): a vAnchor=page/margin frame whose bottom
+  // would fall past its container is shifted UP to sit flush on the container
+  // bottom (physical page edge for page-anchored), not left overflowing. A
+  // vAnchor="text" frame is excluded — its overflow is handled by the paginator's
+  // keep-with-anchor (moving the anchor cursor), and its band rides the flow, so
+  // clamping here would be wrong. See clampAbsBoxIntoContainer.
+  if (fp.vAnchor === 'page' || fp.vAnchor === 'margin') {
+    frameY = clampAbsBoxIntoContainer(frameY, frameH, vBand);
   }
 
   // Exclusion padding: hSpace L/R applies only with wrap="around" (§17.3.1.11

--- a/packages/docx/src/frame-keep-with-anchor.test.ts
+++ b/packages/docx/src/frame-keep-with-anchor.test.ts
@@ -218,10 +218,14 @@ describe('computePages — text-frame keep-with-anchor (§17.3.1.11)', () => {
     expect(pages.length).toBe(1);
   });
 
-  it('does NOT relocate a page-anchored frame that overflows (absolute y is honored in place)', () => {
-    // vAnchor="page", y=90: the frame is pinned at page-y 90 with h=60 ⇒ bottom
-    // 150, past the 140 page edge. An absolute page position is the SAME on any
-    // page, so relocation cannot help — Word draws it there and lets it overflow.
+  it('does NOT relocate a page-anchored frame that overflows (absolute y ⇒ kept on page, box clamped)', () => {
+    // vAnchor="page", y=90: the frame is pinned at page-y 90 with h=60 ⇒ its
+    // requested bottom is 150, past the 140 page edge. An absolute page position is
+    // the SAME on any page, so PAGINATION cannot help — the frame stays on page 1
+    // (no relocation). Word does not let it overflow: computeFrameBox clamps the box
+    // UP into the page (to pageH − h; see frame-geometry.test.ts "clamp"). This test
+    // guards only the pagination decision (page count / no relocation); the clamped
+    // box y is asserted in the geometry suite.
     const body = [
       para({ text: 'a' }),
       para({ text: 'b' }),
@@ -235,9 +239,11 @@ describe('computePages — text-frame keep-with-anchor (§17.3.1.11)', () => {
     expect(hasAnchorText(pages[0], 'anchor')).toBe(true);
   });
 
-  it('does NOT relocate a margin-anchored frame that overflows (absolute y is honored in place)', () => {
-    // vAnchor="margin", y=70: frame at margin-top(20)+70 = 90, h=60 ⇒ bottom 150,
-    // past the bottom margin. Absolute ⇒ left in place (mirrors vAnchor="page").
+  it('does NOT relocate a margin-anchored frame that overflows (absolute y ⇒ kept on page, box clamped)', () => {
+    // vAnchor="margin", y=70: frame at margin-top(20)+70 = 90, h=60 ⇒ requested
+    // bottom 150, past the bottom margin. Absolute ⇒ kept on page 1 (mirrors
+    // vAnchor="page"); the box is clamped up into the margin band by computeFrameBox
+    // (geometry suite). This test guards only the pagination decision.
     const body = [
       para({ text: 'a' }),
       para({ text: 'b' }),

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2159,33 +2159,27 @@ export function computePages(
       // the table.
       //
       // §17.4.57 defines only the table's SIZE and POSITION, not what happens
-      // when it overflows the page bottom. Word's runtime keeps a floating table
-      // undivided and relocates it (with the anchor context that follows it) to
-      // the next page rather than splitting or clipping — the SAME "keep on
-      // page" semantics already implemented for a page-overflowing text frame
-      // (§17.3.1.11; see the framePr branch above) and a paragraph-anchored image
-      // float (anchoredFloatBottomOffset, §20.4.3.5). The tblpPr anchor/alignment
-      // vocabulary lines up 1:1 with framePr (§17.4.57 vertAnchor↔§17.3.1.11
-      // vAnchor, tblpY↔y), so this reuses that established pattern rather than
-      // inventing table-specific math:
-      //   • vertAnchor="text": the table top rides the anchor paragraph's in-flow
-      //     cursor, so moving the anchor to the next page moves the table with it.
-      //     If the table body box overflows the current column's bottom, relocate
-      //     it — the anchor text that follows it (which adds no height of its own)
-      //     trails onto the new column/page.
-      //   • vertAnchor="page"/"margin" (parser default is "page"): y is an
-      //     ABSOLUTE in-page position, so the table lands at the same spot on any
-      //     page. Relocating cannot help (Word draws it at its specified position
-      //     and lets it overflow), so these are left in place — matching the
-      //     pre-existing behaviour.
-      // A table TALLER than the page content area can never fit on a fresh page,
-      // so relocating it is futile (it would just overflow the next page too):
-      // leave it in place. This mirrors the text-frame / anchored-image guard's
-      // `<= effContentH()` fresh-fit test. Unlike a block table (below), a
-      // FLOATING table is not row-split here — Word does not divide a floating
-      // table across pages, so an over-tall one is left to overflow in place. (The
-      // table element is placed once and `continue`s, so no relocation can loop —
-      // this guard only suppresses a pointless page break for an over-tall table.)
+      // when it overflows the page bottom. Word's ACTUAL behaviour (measured from
+      // Word-exported PDFs of private/sample-18 + sample-21 via pdftotext bbox —
+      // see issue #674's reopening comment) is:
+      //   • vertAnchor="text": Word does NOT relocate the whole table. It SPLITS it
+      //     ROW-BY-ROW like a block table — the rows that fit the remaining band
+      //     from the anchor down to the body bottom stay on the current page, and
+      //     the rest continue in a band at the top of the next page(s), for as many
+      //     pages as needed. The anchor paragraph then flows beside the FINAL
+      //     continuation band, starting from that page's body top (NOT below the
+      //     band). This is the floating analogue of splitTableAcrossPages; the wrap
+      //     band is split alongside the rows (one FloatRect per slice).
+      //   • vertAnchor="page"/"margin" (parser default is "page"): y is an ABSOLUTE
+      //     in-page position, so the table lands at the same spot on any page and
+      //     is NOT split. Word keeps it on its page but CLAMPS the box up to the
+      //     container bottom when it would overflow (computeFloatTableBox /
+      //     clampAbsBoxIntoContainer handles that geometry; sample-18 Sec B: top
+      //     741.9 = 841.9 − 100). So these take the single-element path unchanged.
+      // The tblpPr anchor vocabulary lines up 1:1 with framePr (§17.4.57
+      // vertAnchor↔§17.3.1.11 vAnchor, tblpY↔y). Was PR #691's whole-table
+      // relocation, replaced here after the Word-PDF ground truth showed row
+      // splitting (issue #674).
       if (tbl.tblpPr) {
         // #513: re-point measureState.contentX/contentW at the CURRENT newspaper
         // column for the duration of the placement so the paginator estimates the
@@ -2199,19 +2193,22 @@ export function computePages(
         // computeTableLayout expects (it re-divides by scale internally); colX()
         // (pt) is likewise the column's page-absolute left edge.
         //
-        // Lay the table out against the CURRENT column band and resolve its box.
-        // computeTableLayout is the only (heavy) measurement; its `tableH` drives
-        // both the overflow test and the wrap float below (compute-once — the
-        // decision reuses this box's height, never re-measures it separately).
+        // Lay the table out against the CURRENT column band and resolve its box +
+        // per-row heights (B2 stage 1b: computeTableLayout is the ONE heavy
+        // measurement — its rowHeights drive the overflow test, the row-split
+        // greedy fit, and the paint-reuse stamp below; never re-measured). `tp` is
+        // the tblpPr under which the FIRST slice is placed (at the in-flow anchor);
+        // continuation slices clone it with tblpY=0 so their box sits at body top.
         const tp = tbl.tblpPr;
-        const measureFloatBox = () =>
+        const measureFloat = () =>
           withColumnBand(() => {
             const cW = colW() * measureState.scale;
             const layout = computeTableLayout(tbl, cW, measureState);
             const tableH = layout.rowHeights.reduce((s, x) => s + x, 0);
-            return computeFloatTableBox(tp, measureState, measureState.y, layout.tableW, tableH);
+            const box = computeFloatTableBox(tp, measureState, measureState.y, layout.tableW, tableH);
+            return { box, layout, contentWPt: cW / measureState.scale };
           });
-        let box = measureFloatBox();
+        const first = measureFloat();
         // Distance from the table's in-flow top (measureState.y == paraTop) down
         // to its body-box bottom — the table analogue of the frame's
         // frameBottomOff. The bottom is vSpace-exclusive (box.h is the bare table
@@ -2219,28 +2216,78 @@ export function computePages(
         // the table's own area). For vertAnchor="text" this is the table's y
         // offset + its height; for page/margin it mixes an absolute box.y with the
         // flow cursor and is not a keep signal, so it is gated out below.
-        const tableBottomOff = box.y + box.h - measureState.y;
+        const tableBottomOff = first.box.y + first.box.h - measureState.y;
         const isTextAnchored = tp.vertAnchor !== 'page' && tp.vertAnchor !== 'margin';
-        const tableOverflowsHere = isTextAnchored && tableBottomOff > 0 && y + tableBottomOff > effContentH();
-        const tableFitsFresh = tableBottomOff > 0 && tableBottomOff <= effContentH();
-        if (y > 0 && tableOverflowsHere && tableFitsFresh) {
-          // Relocate the floating table to the next column/page BEFORE its float
-          // is registered, so no stale exclusion band is left on the old page
-          // (newPage clears floats wholesale; nextColumn keeps page-scoped ones
-          // but the table has not registered yet). The trailing anchor paragraph
-          // adds no height across this table, so it follows onto the new page. The
-          // column width can differ between columns (box.h / wrap side depend on
-          // it), so re-measure the box against the column the table landed in.
-          nextColumnOrPage(i);
-          box = measureFloatBox();
+        const tableOverflowsHere =
+          isTextAnchored && tableBottomOff > 0 && y + tableBottomOff > effContentH();
+
+        if (isTextAnchored && tableOverflowsHere) {
+          // ── Row-split across pages (Word ground truth, issue #674) ──
+          // Greedy-fit the rows from the anchor down to the body bottom, spilling
+          // the remainder onto continuation pages. Registers one wrap FloatRect
+          // per slice and leaves the body cursor at the FINAL continuation page's
+          // body top so the trailing anchor paragraph flows from there.
+          const endY = splitFloatTableAcrossPages(
+            tbl,
+            tp,
+            first.layout.colWidths, // scale-1 (px==pt) column grid, constant across slices
+            first.layout.rowHeights,
+            first.box.y - measureState.y, // tblpY offset (pt) of slice 1 from anchor
+            first.contentWPt,
+            () => y,
+            () => colTopY,
+            () => effContentH(),
+            () => nextColumnOrPage(i),
+            (sliceEl) => {
+              // Register the slice's wrap float + push it, both against the CURRENT
+              // column band on the page it landed on. registerTableFloat pushes onto
+              // measureState.floats so a following same-page paragraph (the anchor
+              // beside the final band) wraps around it. The box's WIDTH/HEIGHT come
+              // from the slice's stamp (the anchor-column layout, resolved once — so
+              // every slice uses one consistent geometry, matching the greedy fit);
+              // only its x/side re-resolve against the current column via
+              // withColumnBand (a continuation may land in a different newspaper
+              // column, #513). scale is 1 here (px==pt), so the stamp is used as-is.
+              withColumnBand(() => {
+                const sp = sliceEl as PaginatedBodyElement;
+                const sliceTp = (sliceEl as unknown as DocTable).tblpPr as TblpPr;
+                const tableW = (sp.tableColWidthsPt ?? []).reduce((s, w) => s + w, 0) * measureState.scale;
+                const sliceH = (sp.tableRowHeightsPt ?? []).reduce((s, h) => s + h, 0) * measureState.scale;
+                const sliceBox = computeFloatTableBox(
+                  sliceTp, measureState, measureState.y, tableW, sliceH,
+                );
+                const side = floatTableWrapSide(sliceBox, measureState);
+                registerTableFloat(sliceBox, sliceTp, measureState, side, tbl.overlap !== 'never');
+              });
+              pushTagged(sliceEl);
+            },
+          );
+          y = endY;
+          measureState.y = bodyTopPt() + endY;
+          // The split always advanced at least once (the whole table did not fit at
+          // the anchor), so the final continuation page's advancePage already reset
+          // prevPara/prevSpaceAfter; re-assert them so the trailing anchor paragraph
+          // spaces from the body top (no collapse against a pre-split paragraph).
+          prevPara = null;
+          prevSpaceAfter = 0;
+          continue;
         }
-        // Register the wrap float against the (possibly new) column band so the
-        // box x / wrap side match the column the table now sits in, and the float
-        // is registered on the page it actually landed on.
+
+        // Fits (or page/margin-anchored): single element, box registered in place.
+        // Register the wrap float against the column band so the box x / wrap side
+        // match the column the table sits in. (page/margin: the box may be clamped
+        // up by computeFloatTableBox; the float band follows the clamped box.)
         withColumnBand(() => {
-          const side = floatTableWrapSide(box, measureState);
-          registerTableFloat(box, tp, measureState, side, tbl.overlap !== 'never');
+          const side = floatTableWrapSide(first.box, measureState);
+          registerTableFloat(first.box, tp, measureState, side, tbl.overlap !== 'never');
         });
+        // B2 stage 1b — stamp the whole-table layout so the paint pass reuses it.
+        stampTableLayout(
+          el as PaginatedBodyElement,
+          first.layout.colWidths,
+          first.layout.rowHeights,
+          first.contentWPt,
+        );
         pushTagged(el as PaginatedBodyElement);
         continue;
       }
@@ -3456,6 +3503,131 @@ export function splitTableAcrossPages(
     }
   }
   return y;
+}
+
+/**
+ * Split a FLOATING table (ECMA-376 §17.4.57 `<w:tblpPr>`, vertAnchor="text") that
+ * overflows the page bottom across page boundaries, row by row — the Word ground
+ * truth for a page-overflowing floating table (issue #674; measured from
+ * private/sample-18 + sample-21 Word-exported PDFs). It is the out-of-flow analogue
+ * of {@link splitTableAcrossPages}:
+ *   • The FIRST slice sits at the table's in-flow anchor (`slice1TopOffset` below
+ *     the flow cursor `y`), taking the rows that fit down to the body bottom.
+ *   • Each CONTINUATION slice sits at the next page's body TOP (its tblpPr is cloned
+ *     with tblpY=0 so computeFloatTableBox anchors it at `paraTop` = the body top,
+ *     with no in-flow offset), taking the next run of rows.
+ *   • A floating table adds NO flow height, so no header rows are repeated and no
+ *     column-top stamp is threaded (the box y is fully dictated by tblpPr, resolved
+ *     at paint by renderFloatTable). The trailing anchor paragraph flows beside the
+ *     FINAL band from the terminal page's body top, so the caller sets the body
+ *     cursor to that page's region top (the returned `endY`).
+ *
+ * `emitSlice` is invoked once per slice (on the page it landed on) to register its
+ * wrap FloatRect and push it onto the current page — the caller owns the column
+ * band / float bookkeeping. `advancePage` moves to the next column/page (clearing
+ * page-scoped floats there). `curY` / `regionTopY` / `contentH` are read live
+ * (AFTER each `advancePage`) so multi-column regions and per-page reserves are
+ * honored.
+ *
+ * Rows are placed greedily but ALWAYS at least one per slice (forward-progress
+ * guarantee, mirroring splitTableAcrossPages): a single row taller than a full page
+ * is placed overflowing rather than looping. When the anchor sits so low that not
+ * even the first row fits the remaining band, the whole table is moved to the next
+ * page FIRST (no page-1 slice) — matching Word (a floating table row is not left
+ * hanging past the bottom margin when a fuller band is one page away). Breaks land
+ * only on vMerge-safe boundaries ({@link tableBreakAllowedBefore}).
+ *
+ * Returns the body cursor (content-relative pt) after the final slice: the terminal
+ * page's region top, so the anchor paragraph flows from the body top beside the
+ * last band.
+ */
+export function splitFloatTableAcrossPages(
+  table: DocTable,
+  tp: TblpPr,
+  colWidthsPt: number[],
+  rowHs: number[],
+  /** pt offset of slice 1's top below the flow cursor (`tp.tblpY × scale`; ~0 for
+   *  a tblpY=1twip auto-converted float). Continuation slices ignore it (tblpY=0). */
+  slice1TopOffset: number,
+  /** pt content-band width the columns were fit to (for the paint-reuse stamp). */
+  contentWPt: number,
+  /** Current body cursor (content-relative pt), read live. Slice 1's top is
+   *  `curY() + slice1TopOffset`; a continuation slice's top is `regionTopY()`. */
+  curY: () => number,
+  /** Current column-region top (content-relative pt), read AFTER each advancePage. */
+  regionTopY: () => number,
+  /** Effective content height (content-relative pt) of the current page, read live
+   *  (respects the per-page footnote/header/footer reserve). */
+  contentH: () => number,
+  /** Advance to the next column / page (clears page-scoped floats there). */
+  advancePage: () => void,
+  /** Push the fully-stamped slice element onto the current page (and register its
+   *  wrap float). Called once per slice, on the page it landed on. Omitted (direct
+   *  unit tests) ⇒ the slice is dropped (the test asserts geometry via a stub). */
+  emitSlice?: (sliceEl: PaginatedBodyElement) => void,
+): number {
+  const n = rowHs.length;
+  let start = 0;
+  let firstSlice = true;
+
+  while (start < n) {
+    // Slice top (content-relative pt): the in-flow anchor for slice 1, else the
+    // fresh page/column region top.
+    const sliceTopRel = firstSlice ? curY() + slice1TopOffset : regionTopY();
+    const avail = contentH() - sliceTopRel;
+
+    // If not even the first row fits the remaining band AND a fuller band exists on
+    // a fresh page/column, move the whole (remaining) table there first — no slice
+    // on this page. Only possible for a slice whose top is below the region top
+    // (i.e. slice 1 low on the page); a fresh page's `avail` already equals the max
+    // band, so this never loops. (A row taller than a full page still gets placed
+    // below, since then `avail == the max band` and the guard is false.)
+    if (rowHs[start] > avail && sliceTopRel > regionTopY()) {
+      advancePage();
+      firstSlice = false;
+      continue;
+    }
+
+    // Greedy-fit rows [start, end); always take the first row (forward progress).
+    let used = 0;
+    let end = start;
+    while (end < n) {
+      const h = rowHs[end];
+      if (end > start && used + h > avail && tableBreakAllowedBefore(table, end)) break;
+      used += h;
+      end++;
+    }
+
+    // Build the slice element: a subset of rows, its own tblpPr (slice 1 keeps the
+    // original in-flow anchor; continuations anchor at the body top via tblpY=0).
+    // §17.4.78 tblHeader repeats are DELIBERATELY not applied: no fixture shows Word
+    // repeating a floating table's header rows on continuation bands (unlike a block
+    // table), and sample-18/21 have no header rows — so the safe, observed behaviour
+    // is to carry each row exactly once (UNOBSERVED for headers; revisit with a
+    // header fixture if one surfaces).
+    const sliceTp: TblpPr = firstSlice ? tp : { ...tp, tblpY: 0 };
+    const sliceEl = {
+      ...table,
+      type: 'table',
+      rows: table.rows.slice(start, end),
+      tblpPr: sliceTp,
+    } as unknown as PaginatedBodyElement;
+    // B2 stage 1b — stamp the full column grid (constant across slices) + this
+    // slice's own rows so the paint pass (renderFloatTable → computeTableLayout)
+    // reuses them 1:1 instead of re-measuring, and emitSlice's box math below reuses
+    // the same stamp.
+    stampTableLayout(sliceEl, colWidthsPt, rowHs.slice(start, end), contentWPt);
+
+    emitSlice?.(sliceEl);
+
+    start = end;
+    firstSlice = false;
+    if (start < n) advancePage();
+  }
+
+  // Terminal page's region top: the anchor paragraph flows from the body top beside
+  // the final band.
+  return regionTopY();
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #674 (reopened). #691 shipped whole-table relocation for overflowing text-anchored floating tables; Word-exported PDFs of purpose-built fixtures (`private/sample-18/21`, measured via pdftotext bbox) proved Word's actual behavior is different in two ways, both fixed here:

**Commit 1 — row-by-row splitting.** A `vertAnchor="text"` floating table that overflows the column bottom is split greedily: rows that fit stay in the current page's band, the rest continue in a band at the top of the next page (repeating across as many pages as needed), and the trailing anchor paragraph flows from the terminal page's body top beside the final band. Implementation: `splitFloatTableAcrossPages` (out-of-flow analogue of `splitTableAcrossPages`) emits per-page slice elements — first slice keeps the original `tblpPr`, continuations clone it with `tblpY: 0` so they anchor at the body top — each stamped (B2 stage-1b reuse) and registered as its own wrap FloatRect on the page it lands on. Always ≥1 row per slice (loop-free); a table whose first row doesn't fit the remaining band moves to the next page first. Floating continuation slices do **not** repeat `tblHeader` rows (unobserved for floating tables; documented in-code).

**Commit 2 — page/margin-anchored clamp.** A `page`/`margin`-anchored frame **or** floating table whose absolute box overflows its container is clamped upward to fit (`y = max(containerStart, containerEnd − boxH)`), shared via `clampAbsBoxIntoContainer` in frame-geometry. Word measurement: requested y 775pt with a 100pt box lands at **741.9pt = 841.9 − 100** (physical page bottom) — both for frames (sample-17 Sec B) and floating tables (sample-18 Sec B). The margin-container end is assumed symmetric (unobserved, documented). `vAnchor="text"` is untouched (pagination owns it).

## Ground-truth validation (self-render vs Word PDF, exact)

| Case | Word PDF | Our render |
|---|---|---|
| sample-18 Sec A | p1 = 27 fillers + r1 · p2 = r2–r4 + AFTER at body top | ✅ exact |
| sample-21 (800pt, 32 rows) | p1 = r1–r23 · p2 = r24–r32 + AFTER at body top | ✅ exact (23/9) |
| sample-18 Sec B (page-anchored) | box top **741.9pt**, AFTER not pushed | ✅ 741.9 |
| sample-17 Sec B (page-anchored frame) | box top **741.9pt** | ✅ 741.9 |

## Tests / verification

- `float-table-page-fit.test.ts` rewritten (10 tests) — the #691 relocation assertions asserted the disproven behavior; the file-head comment records the history. Clamp geometry suites added to frame-geometry/float-table-geometry tests; two stale comments in `frame-keep-with-anchor.test.ts` corrected (assertions unchanged).
- docx suite **501 passed**; node skia render suite 29 passed; root tsc + ast-grep clean; docx VRT 21/21 (no floating-table sample in the VRT set; references untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)