### PR TITLE
fix(docx): replace the 1-em float-side line-start heuristic with Word's measured 1-inch rule

### DIFF
--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -92,16 +92,18 @@ export const WORD_MIN_LINE_START_PT = 72;
  *  sample-22 page 7: a frame authored so the gap is 72.0pt is beside). But a gap
  *  that is nominally 1 inch is computed as content-width − frame-width through
  *  twip→EMU→px conversions and lands slightly under 72: this renderer computes
- *  71.963716pt for the 72.0pt frame (a ~0.036pt deficit — half-twip authoring
- *  granularity, not pure IEEE-754). Without tolerance the inclusive boundary
- *  flips to below and disagrees with Word. Half a twip (1 twip = 1/20 pt) is the
- *  natural authoring granularity of a frame width, so a gap short of 1 inch by
- *  less than half a twip is treated as exactly 1 inch. This is ≫ the observed
- *  0.036pt deficit yet ≪ the 2pt step that discriminates the fixtures (70pt
- *  stays below, 72pt goes beside), so it never promotes a genuinely sub-inch
- *  gap. Applied in the render's px space as `× scale` (see resolveLineFloatWindow).
- *  Same half-unit-rounding rationale as FLOAT_PAGE_RIGHT_SLACK. */
-export const LINE_START_GAP_EPS_PT = 0.05; // half a twip
+ *  71.963716pt for the 72.0pt frame (a ~0.036pt deficit — sub-twip conversion
+ *  rounding, not pure IEEE-754). Without tolerance the inclusive boundary
+ *  flips to below and disagrees with Word. One twip (1/20 pt = 0.05pt) is the
+ *  authoring granularity of a frame width, so a gap short of 1 inch by less
+ *  than one twip is treated as exactly 1 inch. One twip covers the observed
+ *  0.036pt deficit (a half twip, 0.025pt, would NOT) yet is ≪ the 2pt step
+ *  that discriminates the fixtures (70pt stays below, 72pt goes beside), so it
+ *  never promotes a genuinely sub-inch gap. Applied in the render's px space
+ *  as `× scale` (see resolveLineFloatWindow). Same rationale as
+ *  FLOAT_PAGE_RIGHT_SLACK: a tolerance sized to the coordinate-rounding
+ *  granularity it absorbs. */
+export const LINE_START_GAP_EPS_PT = 0.05; // one twip (1/20 pt)
 
 /** The `requiredWidth` (px) every docx caller passes to `resolveLineFloatWindow`
  *  for a line-start probe: Word's 1-inch minimum side-gap, minus the half-twip

--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -71,9 +71,57 @@ export const FLOAT_OVERLAP_EPS = 0.01;
  *  full-width displacement, not an edge-touch test. */
 export const FLOAT_PAGE_RIGHT_SLACK = 0.5;
 
-/** Minimum width (px) a free side-gap must have to hold a line start. Floors the
- *  required-width probe so a zero-width probe (an empty line with no content yet)
- *  still rejects sub-pixel slivers between full-width floats. */
+/** Minimum horizontal space (pt) a free side-gap must have before Word will
+ *  START a line beside a float, rather than flowing it below the float band.
+ *  Measured — NOT from ECMA-376, which mandates no side-gap minimum (§20.4.2.17
+ *  only says text wraps around the rectangle; §17.18.3 `<w:br w:clear>` is the
+ *  sole spec-mandated flow onto a float-free region). Word's rule is exactly
+ *  1 inch (1440 twips): established from the fixture set private/sample-19/20/22,
+ *  Word-exported PDF, pdftotext bbox — a gap of 70pt flows the line below, a gap
+ *  of 72pt starts the line beside. The threshold is INDEPENDENT of the line's
+ *  content (an empty paragraph mark and a text line switch at the same width),
+ *  of font size (8/12/24pt all switch at 72pt), and of line spacing
+ *  (single/1.5/double all switch at 72pt) — i.e. it is an absolute width, not
+ *  an em- or line-height-proportional quantity. See issue #676. Callers convert
+ *  to px with `WORD_MIN_LINE_START_PT * scale` (renderer scale is px/pt). */
+export const WORD_MIN_LINE_START_PT = 72;
+
+/** Tolerance (pt) subtracted from the 1-inch requirement when testing a side
+ *  gap, to make Word's INCLUSIVE ≥ 1-inch boundary robust to coordinate noise.
+ *  Word places a line beside a float at a gap of exactly 1 inch (issue #676 /
+ *  sample-22 page 7: a frame authored so the gap is 72.0pt is beside). But a gap
+ *  that is nominally 1 inch is computed as content-width − frame-width through
+ *  twip→EMU→px conversions and lands slightly under 72: this renderer computes
+ *  71.963716pt for the 72.0pt frame (a ~0.036pt deficit — half-twip authoring
+ *  granularity, not pure IEEE-754). Without tolerance the inclusive boundary
+ *  flips to below and disagrees with Word. Half a twip (1 twip = 1/20 pt) is the
+ *  natural authoring granularity of a frame width, so a gap short of 1 inch by
+ *  less than half a twip is treated as exactly 1 inch. This is ≫ the observed
+ *  0.036pt deficit yet ≪ the 2pt step that discriminates the fixtures (70pt
+ *  stays below, 72pt goes beside), so it never promotes a genuinely sub-inch
+ *  gap. Applied in the render's px space as `× scale` (see resolveLineFloatWindow).
+ *  Same half-unit-rounding rationale as FLOAT_PAGE_RIGHT_SLACK. */
+export const LINE_START_GAP_EPS_PT = 0.05; // half a twip
+
+/** The `requiredWidth` (px) every docx caller passes to `resolveLineFloatWindow`
+ *  for a line-start probe: Word's 1-inch minimum side-gap, minus the half-twip
+ *  rounding tolerance, at the render scale (px/pt). Single source of truth so the
+ *  paint pass and both paginator mirrors agree bit-for-bit on the flow/beside
+ *  decision. See WORD_MIN_LINE_START_PT and LINE_START_GAP_EPS_PT (issue #676). */
+export function wordMinLineStartPx(scale: number): number {
+  return (WORD_MIN_LINE_START_PT - LINE_START_GAP_EPS_PT) * scale;
+}
+
+/** Minimum width (px) a free side-gap must have to hold a line start. Internal
+ *  defensive floor of `resolveLineFloatWindow`: it floors a zero-width probe so
+ *  a `requiredWidth === 0` call still rejects sub-pixel slivers between
+ *  full-width floats. In the docx renderer this floor no longer GOVERNS the
+ *  line-start decision — every caller now passes `wordMinLineStartPx(scale)`
+ *  (≈ 54px even at scale 0.75), far above 1px, so `Math.max` always yields the
+ *  1-inch requirement (issue #676). Kept because `resolveLineFloatWindow` is an
+ *  exported pure function unit-tested on its own contract: a hypothetical
+ *  `requiredWidth = 0` caller must still not wedge a line into a coordinate-noise
+ *  sliver. */
 export const MIN_LINE_GAP = 1;
 
 export function isWrapFloat(mode?: string | null): boolean {
@@ -118,9 +166,12 @@ export function widestFreeGap(blocked: Gap[], left: number, right: number): Gap 
  * Resolve where a single line box may sit relative to the page's active floats.
  *
  * Given the line's intended top Y and the minimum horizontal width it needs to
- * be placeable (`requiredWidth` — the width of its first atomic token, or, for
- * an empty paragraph-mark line, one em of the mark font), this returns the Y at
- * which the line actually starts plus the horizontal sub-window it may use.
+ * be placeable (`requiredWidth`), this returns the Y at which the line actually
+ * starts plus the horizontal sub-window it may use. Every docx caller passes
+ * `wordMinLineStartPx(scale)` for `requiredWidth` — Word's measured 1-inch
+ * minimum side-gap less a half-twip rounding tolerance (see that helper,
+ * WORD_MIN_LINE_START_PT, and issue #676), applied uniformly to empty
+ * paragraph-mark lines and text lines alike.
  *
  * Two ECMA-376 wrap rules are applied, in order:
  *   1. topAndBottom floats (§20.4.2.16): a line intersecting one is pushed below
@@ -130,12 +181,16 @@ export function widestFreeGap(blocked: Gap[], left: number, right: number): Gap 
  *      horizontal gap. If no gap is wide enough for `requiredWidth` the line
  *      cannot sit here at all and flows below the obstruction (advance to the
  *      lowest blocking float bottom and re-evaluate). The square/topAndBottom
- *      geometry itself is spec-defined; but routing empty / anchor-only
- *      paragraph-mark lines through this with `requiredWidth` = one em (so they
- *      drop below a full-width float band) is an implementation-defined
- *      HEURISTIC (see resolveEmptyMarkTop): ECMA-376 does not require a
- *      float-free row for a paragraph mark — only `<w:br w:clear>` (§17.18.3)
- *      mandates flowing onto a float-free region.
+ *      geometry is spec-defined; the `requiredWidth` gate — how much clear space
+ *      a line needs before Word starts it beside a float rather than below —
+ *      is NOT in ECMA-376 (§17.18.3 `<w:br w:clear>` is the only spec-mandated
+ *      flow onto a float-free region). It is Word's observed 1-inch rule, a
+ *      GROUNDED runtime measurement (private/sample-19/20/22 PDF bbox, issue
+ *      #676), not a fitted constant: 70pt → below, 72pt → beside, independent of
+ *      content / font size / line spacing. A line placed beside the float whose
+ *      first word overruns the (≥1-inch) gap is force-broken there — Word breaks
+ *      the word rather than refusing the gap (observed "AFTE"/"R-10" wrap); the
+ *      caller's over-long-word char-break handles that.
  */
 export function resolveLineFloatWindow(
   topY: number,
@@ -173,8 +228,11 @@ export function resolveLineFloatWindow(
   // 2. Horizontal constraint from square floats.
   const paraXLeft = paraX;
   const paraXRight = paraX + maxWidth;
-  // A gap must fit the line's first atomic token to be usable. Floor so a
-  // zero-width probe (no content yet) still rejects sub-pixel slivers.
+  // A gap must be at least `requiredWidth` wide to host a line start. Every docx
+  // caller passes Word's 1-inch rule already reduced by its rounding tolerance,
+  // `wordMinLineStartPx(scale)` (= (WORD_MIN_LINE_START_PT − LINE_START_GAP_EPS_PT)
+  // × scale). MIN_LINE_GAP floors a degenerate `requiredWidth === 0` probe against
+  // sub-pixel slivers; it does not govern when a real caller passes ≥ ~1 inch.
   const usableGap = Math.max(requiredWidth, MIN_LINE_GAP);
   let xOffset = 0;
   let lineMaxWidth = maxWidth;
@@ -203,6 +261,10 @@ export function resolveLineFloatWindow(
       break;
     }
     // Widest free horizontal gap between the blocked spans across the column.
+    // The caller's `requiredWidth` already carries the 1-inch tolerance
+    // (wordMinLineStartPx), so a gap meant to be exactly 1 inch but computed a
+    // hair under 72 (twip/px rounding noise) still meets Word's inclusive
+    // ≥ 1-inch boundary (issue #676, sample-22 p.7).
     const best = widestFreeGap(blocked, paraXLeft, paraXRight);
     if (best && best.r - best.l >= usableGap) {
       xOffset = Math.max(0, best.l - paraXLeft);

--- a/packages/docx/src/float-line-start-one-inch.test.ts
+++ b/packages/docx/src/float-line-start-one-inch.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveLineFloatWindow,
+  wordMinLineStartPx,
+  WORD_MIN_LINE_START_PT,
+  LINE_START_GAP_EPS_PT,
+  type FloatRect,
+} from './float-layout.js';
+import {
+  __test_layoutLines as layoutLines,
+  type __test_LayoutSeg as LayoutSeg,
+  type __test_LayoutTextSeg as LayoutTextSeg,
+  type __test_WrapLayoutCtx as WrapLayoutCtx,
+} from './renderer.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Word's measured minimum line-start rule beside a float (issue #676).
+//
+// GROUND TRUTH (fixtures private/sample-19/20/22, Word-exported PDF, pdftotext
+// bbox): Word starts a line beside a float ONLY when the free horizontal gap is
+// ≥ 72pt (= 1 inch = 1440 twips), and always when it is. The threshold is:
+//   - content-independent (an empty paragraph mark and a text line switch at the
+//     same width),
+//   - font-size-independent (8/12/24pt switch at 72pt),
+//   - line-spacing-independent (single/1.5/double switch at 72pt),
+// i.e. an ABSOLUTE width, not an em- or line-height-proportional quantity. At a
+// gap of 70pt the line flows below the band; at 72pt it sits beside. A first
+// word that overruns the ≥1-inch gap is force-broken there (Word's "AFTE"/"R-10"
+// wrap), not refused.
+//
+// The boundary is INCLUSIVE at 1 inch, but a frame authored so the gap is
+// exactly 1 inch computes as content-width − frame-width slightly under 72
+// (sample-22 p.7 → 71.963716pt in this renderer). The callers therefore pass
+// `wordMinLineStartPx(scale)` = (72 − LINE_START_GAP_EPS_PT) × scale, a half-twip
+// rounding tolerance, so the effective threshold is 71.95pt at scale 1: 70/71.9pt
+// stay below, 71.95pt and up (incl. the 71.96pt computed for a 72.0pt frame) go
+// beside. See issue #676.
+//
+// This file pins the pure geometry gate (resolveLineFloatWindow) and the
+// layoutLines integration that consumes it. It replaces the prior 1-em-of-the-
+// mark-font heuristic (resolveEmptyMarkTop) and the first-atomic-token-width
+// probe (the former requiredLineWidth), both retired in favour of this single
+// grounded rule.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A LEFT-anchored square float band occupying [0, floatRightPx] horizontally on
+ *  rows [0, floatBottomPx). paraX is 0, so with a column of `colWpx` the free
+ *  RIGHT gap is `colWpx - floatRightPx`. */
+function leftBand(floatRightPx: number, floatBottomPx: number): FloatRect {
+  return {
+    kind: 'shape', mode: 'square', imageKey: 'x',
+    imageX: 0, imageY: 0, imageW: floatRightPx, imageH: floatBottomPx,
+    xLeft: 0, xRight: floatRightPx, yTop: 0, yBottom: floatBottomPx,
+    side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
+    paraId: 1, drawn: false,
+  } as FloatRect;
+}
+
+/** Query resolveLineFloatWindow with a given free-gap width (px) at a given
+ *  scale, passing EXACTLY what the docx renderer passes for a line-start probe
+ *  (`wordMinLineStartPx(scale)`). Returns whether the line was placed BESIDE the
+ *  band (topY 0 with a non-zero xOffset) or FLOWED BELOW it (topY advanced past
+ *  the band bottom). */
+function placeLine(gapPx: number, scale: number): { beside: boolean; topY: number; xOffset: number } {
+  const colW = 1000 * scale;
+  const floatBottom = 50 * scale;
+  const floatRight = colW - gapPx; // leave exactly `gapPx` of free gap on the right
+  const win = resolveLineFloatWindow(
+    0, wordMinLineStartPx(scale), 10 * scale, 0, colW, [leftBand(floatRight, floatBottom)],
+  );
+  const beside = win.topY === 0 && win.xOffset > 0;
+  return { beside, topY: win.topY, xOffset: win.xOffset };
+}
+
+describe('resolveLineFloatWindow — Word 1-inch line-start gate (issue #676)', () => {
+  it('the grounded constant is exactly 1 inch (72pt) with a half-twip tolerance', () => {
+    expect(WORD_MIN_LINE_START_PT).toBe(72);
+    expect(LINE_START_GAP_EPS_PT).toBe(0.05); // half a twip (1 twip = 1/20 pt)
+    expect(wordMinLineStartPx(1)).toBeCloseTo(71.95, 10);
+    expect(wordMinLineStartPx(2)).toBeCloseTo(143.9, 10);
+  });
+
+  it('(a) a 71.9pt gap flows the line BELOW the band (clear of the tolerance band)', () => {
+    // 71.9 < 71.95 effective threshold → below. 71.9pt is the largest "below"
+    // probe that stays outside the half-twip tolerance (a genuinely sub-inch gap).
+    const r = placeLine(71.9, 1);
+    expect(r.beside).toBe(false);
+    expect(r.topY).toBe(50); // pushed to the band bottom
+  });
+
+  it('(b) a 72.0pt gap places the line BESIDE the band (exactly 1 inch)', () => {
+    const r = placeLine(72.0, 1);
+    expect(r.beside).toBe(true);
+    expect(r.topY).toBe(0);
+    expect(r.xOffset).toBeGreaterThan(0);
+  });
+
+  it('(b) sample-22 p.7: a gap computed at 71.9637pt (a 72.0pt frame) is BESIDE', () => {
+    // The exact value this renderer computes for the gap=72.0pt frame — the
+    // tolerance exists precisely so this lands beside, matching Word's PDF.
+    expect(placeLine(71.963716, 1).beside).toBe(true);
+  });
+
+  it('a 70pt gap is below, a 74pt gap is beside (the sample-22 bracket)', () => {
+    expect(placeLine(70, 1).beside).toBe(false);
+    expect(placeLine(74, 1).beside).toBe(true);
+  });
+
+  it('(e) the 70/72pt boundary is identical in PT space at scale 0.75', () => {
+    const s = 0.75;
+    // 70pt and 72pt gaps expressed in px at this scale must still switch across
+    // the 1-inch boundary (requiredWidth is wordMinLineStartPx(scale), so the
+    // decision is taken in pt space and is scale-invariant).
+    expect(placeLine(70 * s, s).beside).toBe(false);
+    expect(placeLine(72 * s, s).beside).toBe(true);
+  });
+
+  it('(e) the boundary is identical across scales (absolute pt width)', () => {
+    for (const s of [1, 2, 0.5, 1.5, 0.75, 3]) {
+      expect(placeLine(70 * s, s).beside).toBe(false); // 70pt < 1 inch → below
+      expect(placeLine(72 * s, s).beside).toBe(true);  // 72pt = 1 inch → beside
+    }
+  });
+
+  it('is a pure width gate: no content input, so font size / empty-vs-filled cannot matter', () => {
+    // resolveLineFloatWindow takes only a numeric requiredWidth — there is no
+    // content input at all. The gate therefore cannot depend on font size or the
+    // line being empty vs. filled; every caller resolves to wordMinLineStartPx.
+    // (c)+(d) parity is enforced structurally by the single call site.
+    expect(placeLine(71.9, 1).beside).toBe(false);
+    expect(placeLine(72.0, 1).beside).toBe(true);
+  });
+});
+
+// ── layoutLines integration ──────────────────────────────────────────────────
+// Linear mock canvas: glyph advance = perPx · px · chars; ascent/descent 0.8/0.2
+// em. Perfectly scale-linear so the wrap ALGORITHM is isolated from font hinting.
+function makeLinearCtx(perPx = 0.5): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const pxOf = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = pxOf();
+      const per = p * perPx;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function textSeg(text: string, fontSize = 10, extra: Partial<LayoutTextSeg> = {}): LayoutSeg {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'Times New Roman', vertAlign: null,
+    measuredWidth: 0, ...extra,
+  } as LayoutSeg;
+}
+
+function wrapCtx(floats: FloatRect[]): WrapLayoutCtx {
+  return {
+    startPageY: 0,
+    paraX: 0,
+    floats,
+    lineBoxH: (asc: number, desc: number) => asc + desc,
+    pageH: 100000,
+  } as WrapLayoutCtx;
+}
+
+/** Was the FIRST line placed beside the band (topY 0, xOffset > 0) or flowed
+ *  below it (topY past the band bottom)? */
+function firstLinePlacement(lines: ReturnType<typeof layoutLines>): 'beside' | 'below' {
+  const l = lines[0];
+  return l.topY === 0 && l.xOffset > 0 ? 'beside' : 'below';
+}
+
+describe('layoutLines — 1-inch line-start rule end to end (issue #676)', () => {
+  const scale = 1;
+  const colW = 1000;
+  const floatBottom = 50;
+
+  // A gap just under 1 inch (70px) and just over (72px) at scale 1.
+  const bandFor = (gapPx: number) => [leftBand(colW - gapPx, floatBottom)];
+
+  it('(c) an empty-content line flows below a sub-inch gap and beside a ≥1-inch gap', () => {
+    // No width-bearing content — the empty/paragraph-mark line path.
+    const emptyBelow = layoutLines(makeLinearCtx(), [textSeg('', 10)], colW, 0, scale, [], wrapCtx(bandFor(70)), {}, 0);
+    const emptyBeside = layoutLines(makeLinearCtx(), [textSeg('', 10)], colW, 0, scale, [], wrapCtx(bandFor(72)), {}, 0);
+    expect(firstLinePlacement(emptyBelow)).toBe('below');
+    expect(firstLinePlacement(emptyBeside)).toBe('beside');
+  });
+
+  it('(c) a text line makes the SAME below/beside decision as the empty line', () => {
+    const textBelow = layoutLines(makeLinearCtx(), [textSeg('hi', 10)], colW, 0, scale, [], wrapCtx(bandFor(70)), {}, 0);
+    const textBeside = layoutLines(makeLinearCtx(), [textSeg('hi', 10)], colW, 0, scale, [], wrapCtx(bandFor(72)), {}, 0);
+    expect(firstLinePlacement(textBelow)).toBe('below');
+    expect(firstLinePlacement(textBeside)).toBe('beside');
+  });
+
+  it('(d) the below/beside decision is font-size-independent (8pt vs 24pt agree)', () => {
+    for (const fs of [8, 24]) {
+      const below = layoutLines(makeLinearCtx(), [textSeg('X', fs)], colW, 0, scale, [], wrapCtx(bandFor(70)), {}, 0);
+      const beside = layoutLines(makeLinearCtx(), [textSeg('X', fs)], colW, 0, scale, [], wrapCtx(bandFor(72)), {}, 0);
+      expect(firstLinePlacement(below)).toBe('below');
+      expect(firstLinePlacement(beside)).toBe('beside');
+    }
+  });
+
+  it('(d) a SHORT token no longer wedges into a sub-inch gap it would have fit', () => {
+    // "X" at 10pt is 5px wide — under the old 1-em (10px) probe it might have
+    // been rejected, but a longer prior-behaviour concern was a short token
+    // fitting a sub-inch sliver. With the 1-inch rule, a 5px-wide token in a
+    // 30px gap (well under 1 inch) is sent below, matching Word.
+    const lines = layoutLines(makeLinearCtx(), [textSeg('X', 10)], colW, 0, scale, [], wrapCtx(bandFor(30)), {}, 0);
+    expect(firstLinePlacement(lines)).toBe('below');
+  });
+
+  it('force-wrap: a word wider than a ≥1-inch gap is CHAR-BROKEN in the gap (Word "AFTE"/"R-10")', () => {
+    // Gap = 72px (exactly 1 inch). Word "AFTERTENAFTERTEN" = 16 chars × 5px = 80px,
+    // wider than the 72px gap. The line IS started beside the band (gap ≥ 1 inch)
+    // and the word is force-broken to fit — it is NOT sent below.
+    const lines = layoutLines(
+      makeLinearCtx(), [textSeg('AFTERTENAFTERTEN', 10)], colW, 0, scale, [], wrapCtx(bandFor(72)), {}, 0,
+    );
+    // First line beside the band, holding as many chars as fit the 72px gap.
+    expect(firstLinePlacement(lines)).toBe('beside');
+    expect(lines.length).toBeGreaterThan(1); // the word was split across lines
+    const firstText = (lines[0].segments[0] as LayoutTextSeg).text;
+    const secondText = (lines[1].segments[0] as LayoutTextSeg).text;
+    // 72px gap / 5px per char = 14 chars fit; the split preserves the whole word.
+    expect(firstText.length).toBeGreaterThan(0);
+    expect(firstText.length).toBeLessThan('AFTERTENAFTERTEN'.length);
+    expect(firstText + secondText).toBe('AFTERTENAFTERTEN');
+    // The line sat in the gap (xOffset at the band's right edge), not full width.
+    expect(lines[0].xOffset).toBeGreaterThan(0);
+    expect(lines[0].availWidth).toBeLessThanOrEqual(72 + 1e-6);
+  });
+
+  it('a word narrower than the ≥1-inch gap sits beside the band without splitting', () => {
+    // Gap = 200px. "AFTER" = 5 chars × 5px = 25px < 200px → sits beside, no split.
+    const lines = layoutLines(makeLinearCtx(), [textSeg('AFTER', 10)], colW, 0, scale, [], wrapCtx(bandFor(200)), {}, 0);
+    expect(firstLinePlacement(lines)).toBe('beside');
+    expect((lines[0].segments[0] as LayoutTextSeg).text).toBe('AFTER');
+  });
+});

--- a/packages/docx/src/layout-lines-scale-invariance.test.ts
+++ b/packages/docx/src/layout-lines-scale-invariance.test.ts
@@ -253,10 +253,12 @@ describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, t
     const mkWrap = (s: number): WrapLayoutCtx => ({
       startPageY: 0 * s,
       paraX: 0 * s,
-      floats: [{ x: 0 * s, y: 0 * s, w: 30 * s, h: 24 * s } as unknown as WrapLayoutCtx['floats'][number]],
+      floats: [{
+        mode: 'square', side: 'bothSides',
+        xLeft: 0 * s, xRight: 30 * s, yTop: 0 * s, yBottom: 24 * s,
+      } as unknown as WrapLayoutCtx['floats'][number]],
       lineBoxH: (asc: number, desc: number) => asc + desc, // linear in px → scales ×s
       pageH: 1000 * s,
-      markEmPx: 10 * s,
     });
     const { ctx: c1 } = makeLinearCtx();
     const base = layoutLines(c1, cloneSegs(segs()), 120, 0, 1, [], mkWrap(1), {}, 0);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -61,6 +61,7 @@ import {
   isWrapFloat,
   resolveLineFloatWindow,
   skipPastTopAndBottom,
+  wordMinLineStartPx,
 } from './float-layout.js';
 import {
   distributeLineSlack,
@@ -2672,9 +2673,12 @@ function estimateParagraphHeight(
   if (hasFloats) cursor = skipPastTopAndBottom(cursor, state.floats);
   const flowMarkLine = (): void => {
     // Empty / anchor-only paragraph: one paragraph-mark line box, flowed below a
-    // full-width float band exactly like renderEmptyMarkParagraph.
+    // full-width float band exactly like renderEmptyMarkParagraph. Uses Word's
+    // measured 1-inch minimum side-gap (wordMinLineStartPx; scale 1 here in the
+    // paginator's pt-space mirror), the SAME content-independent threshold as the
+    // paint pass — issue #676.
     if (hasFloats) {
-      const win = resolveLineFloatWindow(cursor, paragraphMarkEmPx(para, 1), 10, paraX, paraW, state.floats);
+      const win = resolveLineFloatWindow(cursor, wordMinLineStartPx(1), 10, paraX, paraW, state.floats);
       if (win.topY > cursor) cursor = win.topY;
     }
     cursor += paragraphMarkLineHeight(para, 1, grid, paraHasRuby, state.docEastAsian, state.ctx, state.fontFamilyClasses);
@@ -2691,7 +2695,6 @@ function estimateParagraphHeight(
       floats: state.floats,
       lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0, paragraphIsEastAsian(para)),
       pageH: state.pageH,
-      markEmPx: paragraphMarkEmPx(para, 1),
     } : undefined;
     const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, gridCharDeltaPx(grid, 1), state.defaultTabPt);
     if (lines.length === 0) {
@@ -2910,7 +2913,6 @@ function splitParagraphAcrossPages(
     floats: measureState.floats,
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0, paragraphIsEastAsian(para)),
     pageH: measureState.pageH,
-    markEmPx: paragraphMarkEmPx(para, 1),
   } : undefined;
   const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku, gridCharDeltaPx(paraGrid(para, measureState), 1), measureState.defaultTabPt);
   if (lines.length === 0) {
@@ -4720,26 +4722,34 @@ function renderParagraph(
   // A paragraph with no inline content (literally empty, or anchor-only) still
   // produces ONE paragraph-mark line box (ECMA-376 §17.3.1.29 regulates only the
   // existence of that line; the horizontal wrap geometry around a square float is
-  // §20.4.2.17). The behavior below — firing an automatic "flow the mark line
-  // below the float band when it cannot sit beside it" displacement, and using
-  // ONE EM of the mark font as the width the gap must hold — is NOT specified by
-  // ECMA-376 Part 1. It is an implementation-defined HEURISTIC chosen to match
-  // Word: the only spec-mandated flow of a line onto a float-free region is the
-  // explicit `<w:br w:clear>` of §17.18.3, which is not what fires here. Without
-  // this heuristic an empty paragraph mark wedges into a sub-em sliver beside a
-  // full-width float band and the following paragraphs (and any wrapNone image
-  // they anchor) stay pinned inside the band. We resolve the mark line's flowed
-  // top here and use it for the mark advance, the shading/border rect, and the
-  // paragraph-relative base of any wrapNone anchor image drawn below.
+  // §20.4.2.17). The displacement below — flow the mark line below the float band
+  // when the side gap cannot hold a line start — has no dedicated §x.x.x: the
+  // only SPEC-mandated flow of a line onto a float-free region is the explicit
+  // `<w:br w:clear>` of §17.18.3, which is not what fires here. But the TRIGGER
+  // (how much clear side-space Word requires before it starts a line beside a
+  // float) is not implementation-free-choice — it is Word's measured behaviour:
+  // exactly 1 inch of horizontal gap (WORD_MIN_LINE_START_PT), independent of the
+  // line's content, font size, and line spacing. Grounded from Word-exported PDFs
+  // (fixtures private/sample-19/20/22, pdftotext bbox: 70pt gap → below, 72pt →
+  // beside), NOT fitted to a single sample — see issue #676, which this replaces
+  // (the prior code used a 1-em-of-the-mark-font width here as an admitted
+  // HEURISTIC; the 1-inch rule discriminated against it because at gap = 1.5em
+  // for a 24pt mark, i.e. 36pt < 1 inch, Word still refuses to start the line
+  // beside the band). Without this an empty paragraph mark wedges into a sub-inch
+  // sliver beside a full-width float band and the following paragraphs (and any
+  // wrapNone image they anchor) stay pinned inside the band. We resolve the mark
+  // line's flowed top here and use it for the mark advance, the shading/border
+  // rect, and the paragraph-relative base of any wrapNone anchor image drawn
+  // below.
   const resolveEmptyMarkTop = (): number => {
     if (state.floats.length === 0) return textAreaTopY;
-    // Required width for an empty mark line: one em of the mark font (HEURISTIC,
-    // see above — not a spec-defined threshold). A side gap narrower than this is
-    // treated as unable to hold the line start, so the line flows below.
-    const markEm = paragraphMarkEmPx(para, scale);
+    // Required side-gap for the mark line: Word's measured 1 inch
+    // (wordMinLineStartPx), the SAME threshold used for text lines — the rule is
+    // content-independent (issue #676). A gap narrower than 1 inch cannot hold
+    // the line start, so the mark line flows below the band.
     const probeH = 10 * scale;
     const win = resolveLineFloatWindow(
-      textAreaTopY, markEm, probeH, paraX, paraW, state.floats,
+      textAreaTopY, wordMinLineStartPx(scale), probeH, paraX, paraW, state.floats,
     );
     return win.topY;
   };
@@ -4760,7 +4770,6 @@ function renderParagraph(
     floats: state.floats,
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0, paragraphIsEastAsian(para)),
     pageH: state.pageH,
-    markEmPx: paragraphMarkEmPx(para, scale),
   } : undefined;
 
   // ECMA-376 §17.3.1.12 (hanging) + §17.3.1.38 (a hanging indent implicitly
@@ -5880,11 +5889,6 @@ interface WrapLayoutCtx {
   lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number) => number;
   /** Hard cap on Y to keep layout from running past the page. */
   pageH: number;
-  /** Paragraph-mark em width (px), from paragraphMarkEmPx(para). Shared with
-   *  resolveEmptyMarkTop so an empty / anchor-only mark line that has no
-   *  trailing-break font of its own falls below a float band on the SAME
-   *  threshold the empty-paragraph path uses. */
-  markEmPx: number;
 }
 
 /**
@@ -6490,13 +6494,30 @@ function layoutLines(
   let lineXOffset = 0;
   let currentLineTopY = wrapCtx?.startPageY ?? 0;
 
+  // Minimum clear side-space (px) a line needs before it may START beside a
+  // float rather than flow below the band. Word's measured rule is 1 inch
+  // (wordMinLineStartPx(scale) — the 1-inch requirement less a half-twip rounding
+  // tolerance), INDEPENDENT of the line's content — the same threshold for an
+  // empty paragraph mark, a short-token line, and a long-word line (a first word
+  // that overruns the ≥1-inch gap is force-broken there by the over-long-word
+  // char-break below, matching Word's "AFTE"/"R-10" wrapping). This replaces two
+  // former implementation-defined branches — a per-line first-atomic-token width
+  // probe for text lines, and a 1-em-of-the-mark-font reservation
+  // (`wrapCtx.markEmPx`) for empty/trailing-break lines — both of which
+  // mis-placed lines relative to Word (they wedged short-token lines into
+  // sub-inch gaps and refused ≥1-inch gaps to long-word lines). See issue #676
+  // (fixtures private/sample-19/20/22, pdftotext bbox). Shared by the paint pass
+  // and the paginator's two mirror layouts (they call layoutLines with scale 1),
+  // so the flow/beside decision agrees across passes.
+  const minLineStartWidth = (): number => wordMinLineStartPx(scale);
+
   // Compute wrap constraints for a new line about to start. Mutates
-  // lineXOffset/lineMaxWidth/currentLineTopY. `minWidth` is the smallest width
-  // the upcoming line must have to be placeable here (the width of its first
-  // atomic token, or the paragraph-mark em for an empty line); a free gap
-  // narrower than this is treated as unusable and the line is sent below the
-  // intervening float(s) — the ECMA-376 wrap rule that text which cannot fit
-  // beside a floating object flows past it.
+  // lineXOffset/lineMaxWidth/currentLineTopY. `minWidth` is the smallest clear
+  // side-space the upcoming line must have to START here (minLineStartWidth() —
+  // Word's 1-inch rule, §676); a free gap narrower than this is treated as
+  // unusable and the line is sent below the intervening float(s), which is how
+  // Word flows a line that cannot start beside a floating object (there is no
+  // ECMA-376 §x.x.x for this trigger — see resolveLineFloatWindow / issue #676).
   const startLine = (minWidth: number = 0): void => {
     lineXOffset = 0;
     lineMaxWidth = maxWidth;
@@ -6547,7 +6568,7 @@ function layoutLines(
     lineIntendedSingle = 0;
     lineHasRuby = false;
     isFirst = false;
-    startLine(requiredLineWidth());
+    startLine(minLineStartWidth());
   };
 
   const addToLine = (
@@ -6626,44 +6647,6 @@ function layoutLines(
   // Use an explicit queue so CJK split-tails can be re-queued
   const queue: LayoutSeg[] = [...segs];
 
-  // Smallest width the NEXT line must have to be placeable beside a float: the
-  // width of its first atomic token. For text we measure the first wrap unit
-  // (CJK: one grapheme — kinsoku may force more, but one char is the floor;
-  // Latin: up to the first space). For an image/math the whole object. An empty
-  // line (no remaining content) still reserves the paragraph-mark em so a
-  // sliver gap between full-width floats does not "fit" it. Used by startLine to
-  // decide whether to wrap in a gap or send the line below the floats.
-  const requiredLineWidth = (): number => {
-    // First inline token that actually occupies width on the line. Anchor-image
-    // segments are floats (drawn separately, measuredWidth 0) and lineBreaks
-    // carry no width, so skip them — otherwise the float's own width would be
-    // mistaken for the line's required width and wrongly push every wrap line
-    // below the float.
-    const q = queue.find((s) => !('lineBreak' in s) && !('imagePath' in s && s.anchor));
-    if (!q) {
-      // Empty/paragraph-mark line: reserve one em so a sub-glyph gap is rejected
-      // and the mark line drops below the floats. A trailing `<w:br/>` carries
-      // its own (line-local) font size; otherwise use the shared paragraph-mark
-      // em (paragraphMarkEmPx, threaded via wrapCtx) so this fallback agrees with
-      // resolveEmptyMarkTop. Outside a float context the result is unused
-      // (startLine no-ops), so fall back to the legacy estimate.
-      if (trailingBreakFontSize !== null) return trailingBreakFontSize * scale;
-      if (wrapCtx) return wrapCtx.markEmPx;
-      return (segs[0] && 'fontSize' in segs[0] ? segs[0].fontSize : 10) * scale;
-    }
-    if ('isTab' in q) return q.measuredWidth || 0;
-    if ('imagePath' in q) return q.widthPt * scale;
-    if ('mathNodes' in q) return q.measuredWidth || 0;
-    const ts = q as LayoutTextSeg;
-    // First wrap unit: leading run up to the first space (Latin word) or the
-    // first character (CJK / no space). Whichever is shorter bounds the floor.
-    const sp = ts.text.indexOf(' ');
-    const head = sp > 0 ? ts.text.slice(0, sp) : ts.text;
-    const firstChar = [...head][0] ?? '';
-    const probe = { ...ts, text: firstChar };
-    return segAdvance(probe);
-  };
-
   // A `<w:br/>` always starts a new line (§17.3.3.1) — when it is the LAST
   // content of the paragraph that new line is an EMPTY line that still
   // occupies one line height (Word reserves it; visible e.g. as extra table
@@ -6671,7 +6654,7 @@ function layoutLines(
   let trailingBreakFontSize: number | null = null;
 
   // Establish the first line's wrap window now that the content queue exists.
-  startLine(requiredLineWidth());
+  startLine(minLineStartWidth());
 
   while (queue.length > 0) {
     const seg = queue.shift()!;
@@ -9624,16 +9607,6 @@ function picBulletSizePt(num: NumberingInfo, para: DocParagraph): { w: number; h
     w: num.picBulletWidthPt ?? fallback,
     h: num.picBulletHeightPt ?? fallback,
   };
-}
-
-/** Width (px) of the paragraph-mark "em" — the smallest horizontal gap a
- *  float-bordered empty / anchor-only paragraph-mark line is allowed to sit in
- *  before it flows below the float band. Single source of truth shared by the
- *  empty-mark float-window probe (resolveEmptyMarkTop) and the layoutLines
- *  empty-line fallback, so the two paths agree on what "one em of the mark
- *  font" means. HEURISTIC threshold (see resolveEmptyMarkTop), not spec. */
-function paragraphMarkEmPx(para: DocParagraph, scale: number): number {
-  return getDefaultFontSize(para) * scale;
 }
 
 /** First text/field run's font family — used to size empty paragraphs whose


### PR DESCRIPTION
## Summary

Closes #676. The float-side line-start decision had two implementation-defined branches: empty paragraph marks needed a side gap of **one em of the mark font** (the documented HEURISTIC), and non-empty lines needed their **first token's measured width**. Purpose-built fixtures (`private/sample-19/20/22`, 40 cases across font sizes 8–24pt × gaps 0.5em–30em × line spacings, Word-exported PDFs measured via pdftotext bbox) pinned Word's actual rule:

> **A line starts beside a float iff the horizontal gap is ≥ 72pt (exactly 1 inch / 1440 twips) — independent of the line's content, font size, and line spacing. In a qualifying gap, an over-wide first word is force-broken, not sent below.**

Both branches are replaced by a single grounded rule: `WORD_MIN_LINE_START_PT = 72` in float-layout, passed by all three float-window sites (`resolveEmptyMarkTop`, the paginator's `flowMarkLine`, `layoutLines`). The 35-line `requiredLineWidth` (first-token/1-em split) collapses to a constant `minLineStartWidth`; dead `paragraphMarkEmPx` and `WrapLayoutCtx.markEmPx` are removed; the HEURISTIC declaration is rewritten as the measured rule with fixture provenance. Force-wrap needed no new code — the existing over-long-word char-break (≥1 char per line, loop-free) already matches Word (verified: "AFTER-10" breaks to "AFTE" at x=451.1 vs Word's 451.2).

One real boundary defect surfaced and fixed during validation: a gap authored as exactly 72.0pt computes as 71.9637pt through twip→EMU→px conversion (half-twip authoring granularity), putting the inclusive boundary on the wrong side. A half-twip tolerance (`LINE_START_GAP_EPS_PT = 0.05pt`) makes the ≥1-inch comparison robust without promoting any genuine sub-inch gap (fixture discrimination step is 2pt).

## Verification

- **Word PDF match on all three fixtures: sample-19 15/15, sample-20 15/15, sample-22 10/10** — including the critical 70pt→below / 72pt→beside boundary and the 24pt force-wrap page.
- **VRT byte-identical to pre-change** (0/500,395 px across all 15 fidelity pages; worker-equivalence 0.000%): the committed corpus never exercises the full-width-float→empty-mark path, so no reference updates.
- docx suite **515 green**; root tsc + ast-grep clean. One existing test touched (`layout-lines-scale-invariance.test.ts`): removed the dead `markEmPx` field and fixed an inert FloatRect that was missing `mode` — assertions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)