### PR TITLE
perf(core): ship the mathjax bundle as a real emitted asset (math.mjs 4.13MB → 1.1KB)

### DIFF
--- a/packages/core/src/math/engine.ts
+++ b/packages/core/src/math/engine.ts
@@ -16,6 +16,19 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+// `?url` (not a bare `new URL(..., import.meta.url)`) so the same `wasmAssetUrl`
+// build plugin that keeps the WASM parsers out of the base64 data-URL trap emits
+// this ~3 MB engine as a real asset too. In Vite **library mode** a bare
+// `new URL` is force-inlined as a `data:text/javascript;base64,…` string, which
+// turned the opt-in `math.mjs` chunk into a 4.1 MB base64 blob; the `?url` form
+// is intercepted by the plugin, `emitFile`d as a real asset next to the chunk,
+// and handed back as a plain URL the `<script>` loader below can fetch.
+//
+// The engine URL is not otherwise configurable: a consumer that needs to serve
+// it from elsewhere injects their own `MathRenderer` via the viewer `math`
+// option (the whole engine is already a swappable dependency), so no dedicated
+// `mathUrl`/asset-override option is warranted.
+import mathjaxAssetUrl from '../../assets/mathjax-stix2.js?url';
 import { type MathSvg, svgExtents } from './mathjax';
 
 interface Stix2Engine {
@@ -26,7 +39,11 @@ interface Stix2Engine {
 let enginePromise: Promise<Stix2Engine> | null = null;
 
 function resolveAssetUrl(): string {
-  return new URL('../../assets/mathjax-stix2.js', import.meta.url).href;
+  // `?url` yields the asset href directly — an absolute URL at build time, the
+  // dev-served path in dev. Resolve against the module URL so a bare relative
+  // dev value still becomes an absolute href fetchable from any realm (matches
+  // the `new URL(wasmAssetUrl, …)` pattern in the format handles).
+  return new URL(mathjaxAssetUrl, import.meta.url).href;
 }
 
 function loadScript(src: string): Promise<void> {

--- a/packages/core/src/vite-env.d.ts
+++ b/packages/core/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+// Brings Vite's ambient module declarations (e.g. `declare module '*?url'`) into
+// scope so the `?url` asset import in `math/engine.ts` type-checks. The bundle is
+// emitted as a real asset (not a base64 data URL) by the root `wasmAssetUrl`
+// build plugin (see `vite.config.ts`); this file only supplies the
+// `import … from '…?url'` typing.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,29 +8,38 @@ import { readFile } from 'fs/promises';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Emit `*.wasm?url` imports as real asset files instead of base64 `data:` URLs.
+ * Emit `?url` asset imports as real asset files instead of base64 `data:` URLs.
+ * (Named hashlessly here — `rollupOptions.output.assetFileNames` is `[name]`.)
  *
  * Vite **library mode** force-inlines every `?url` asset as a
- * `data:application/wasm;base64,…` string regardless of `assetsInlineLimit`
- * (a number or a `() => false` function does NOT override it). That inflates the
- * WASM by +33 % and blocks `WebAssembly.compileStreaming` (a data URL cannot be
- * fetch-streamed — the worker has to `atob` the base64 by hand).
+ * `data:<mime>;base64,…` string regardless of `assetsInlineLimit` (a number or a
+ * `() => false` function does NOT override it — `build.lib` unconditionally
+ * returns `true` from Vite's internal `shouldInline`). Two heavy asset kinds ride
+ * on this path:
+ *   - the three parser WASM modules (`*_parser_bg.wasm?url`, ~0.6–0.7 MB each) —
+ *     base64 inflates them +33 % and blocks `WebAssembly.compileStreaming`
+ *     (a data URL cannot be fetch-streamed; the worker must `atob` by hand);
+ *   - the MathJax + STIX Two Math engine (`assets/mathjax-stix2.js?url`, ~3 MB) —
+ *     inlined it turned the opt-in `math.mjs` chunk into a 4.1 MB base64 blob,
+ *     even though consumers only import it when a document actually has equations.
  *
- * The single `.wasm?url` import lives in each format's main-thread handle
- * (`document.ts` / `presentation.ts` / `workbook.ts`). We intercept it here,
- * `emitFile` the bytes as a hashless asset next to the chunk, and hand back the
- * standard ESM asset reference `new URL('<name>.wasm', import.meta.url)` — the
- * form Vite / webpack 5 / Rollup / esbuild all rewrite when they re-bundle our
- * `.mjs`, and which resolves correctly for a plain `<script type=module>` too.
- * wasm-bindgen's `--target web` glue then `fetch()`es that URL and hits
- * `instantiateStreaming`.
+ * All of these are `?url` imports in a single owner module each (the format
+ * main-thread handles — `document.ts` / `presentation.ts` / `workbook.ts` — and
+ * `math/engine.ts`). We intercept the `?url` variant here, `emitFile` the bytes
+ * as an asset next to the chunk, and hand back the standard ESM asset reference
+ * `new URL('<name>', import.meta.url)` — the form Vite / webpack 5 / Rollup /
+ * esbuild all rewrite when they re-bundle our `.mjs`, and which resolves
+ * correctly for a plain `<script type=module>` too. wasm-bindgen's `--target web`
+ * glue then `fetch()`es its URL and hits `instantiateStreaming`; the math engine
+ * is lazy-loaded via a `<script src>` pointed at the emitted asset.
  *
- * Runs with `enforce: 'pre'` and only claims the `?url` variant; the bare-`.wasm`
- * import (owned by `vite-plugin-wasm`) is untouched — though nothing in the tree
- * imports bare `.wasm`, so in practice this is the only WASM interception point.
+ * Runs with `enforce: 'pre'` and claims every `?url` import; a bare-`.wasm`
+ * import (owned by `vite-plugin-wasm`) is untouched. Nothing in the tree imports
+ * bare `.wasm`, and every `?url` here is a real on-disk asset we want emitted —
+ * exactly what Vite's non-lib mode would do anyway.
  */
 function wasmAssetUrl(): Plugin {
-  const SUFFIX = '.wasm?url';
+  const SUFFIX = '?url';
   return {
     name: 'wasm-asset-url',
     enforce: 'pre',
@@ -41,7 +50,7 @@ function wasmAssetUrl(): Plugin {
     apply: 'build',
     async load(id) {
       if (!id.endsWith(SUFFIX)) return null;
-      const filePath = id.slice(0, -'?url'.length);
+      const filePath = id.slice(0, -SUFFIX.length);
       const source = await readFile(filePath);
       const referenceId = this.emitFile({
         type: 'asset',
@@ -50,7 +59,8 @@ function wasmAssetUrl(): Plugin {
       });
       // `import.meta.ROLLUP_FILE_URL_<id>` expands to the emitted asset's URL at
       // render time; wrapping it in `new URL(…, import.meta.url)` yields an
-      // absolute href the worker can fetch from any realm.
+      // absolute href the worker (or the math engine's `<script>` loader) can
+      // fetch from any realm.
       return `export default new URL(import.meta.ROLLUP_FILE_URL_${referenceId}, import.meta.url).href;`;
     },
   };


### PR DESCRIPTION
## Summary

The lazy `math` chunk was 4.13MB because Vite's library mode inlined the MathJax bundle as a base64 data-URL. Same disease, same cure as E4 (#681): the existing `wasmAssetUrl` plugin in the root `vite.config.ts` is generalized from `.wasm?url` to all `?url` imports (every `?url` in the tree is a real on-disk asset that should be emitted — the three wasm handles already flow through this exact pattern), and `math/engine.ts` switches from a bare `new URL(...)` to the same `?url` import idiom. `apply:'build'` preserved — dev mode verified to keep Vite's stock `?url` handling with no `ROLLUP_FILE_URL` leak (the E4 CI-smoke failure mode).

| | Before | After |
|---|---|---|
| `dist/math.mjs` | 4,130,959 B (base64-inlined) | **1,100 B** |
| `dist/mathjax-stix2.js` | — (inlined) | 3,097,439 B (standalone, hashed in Storybook builds) |

**No new URL-override option**: unlike the wasm (baked into the format handles, hence `wasmUrl`), the math engine is already fully injectable via the `math` option (`MathRenderer`), so a dedicated asset override would be redundant API surface (documented in `engine.ts`). A `packages/core/src/vite-env.d.ts` was added for the `?url` ambient type (docx/pptx/xlsx already had one each).

## Verification

- `pnpm build` green with the sizes above; `npm pack` tarball contains both files; node smoke on the built artifacts converts `x²+1` → valid SVG through the emitted asset.
- Dev-mode probe (Vite `createServer`): plugin correctly absent (`apply:'build'`), stock `?url` serves the source path.
- `pnpm build:wasm && pnpm build-storybook` succeeds, emitting `mathjax-stix2-*.js` as a hashed asset.
- `npx vitest run packages/core/src/math` 12/12 · full suite 1,702 green · root typecheck + ast-grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)