### PR TITLE
fix(docx): draw shrink-fitted lines with the compression the fit judgment assumed

### DIFF
--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1055,6 +1055,20 @@ export function splitTextForLayout(text: string): string[] {
  *  (`renderParagraph`). */
 export const DEFAULT_TAB_PT = 36;
 
+/** Knuth-Plass shrink tolerance: the fraction by which the line breaker may
+ *  compress each inter-word space to keep a candidate word on the current line.
+ *  ECMA-376 prescribes no line-breaking algorithm — tolerance-based fit is
+ *  standard typography (TeX, InDesign, Word) and lets the layout absorb the
+ *  canvas `measureText` vs Word advance-width discrepancy (~0.1–0.3 px/glyph)
+ *  that would otherwise push a trailing word to the next line.
+ *
+ *  This is the ONE budget shared by both sides of the fit contract: the wrap
+ *  judgment below admits a word when the line's overflow Δ ≤ SPACE_SHRINK_RATIO ·
+ *  Σ(trailing-space widths), and the renderer's draw pass squeezes the same
+ *  spaces by the same fraction so the admitted line lands inside its box instead
+ *  of overrunning the clip (see `shrinkFitCompression` in text-distribute.ts). */
+export const SPACE_SHRINK_RATIO = 0.25;
+
 /** ECMA-376 §17.15.1.25 — resolve the document's automatic tab-stop interval
  *  (pt): the explicit `<w:defaultTabStop>` value when present, else the spec
  *  absent default of 720 twips (36pt). Mirrors {@link resolveKinsokuRules}: the
@@ -1836,15 +1850,12 @@ export function layoutLines(
     //   1. Trailing-space collapse: if this word becomes the last on the
     //      line, its trailing space (if any) collapses. We subtract it from
     //      the width used to test fit.
-    //   2. Knuth-Plass shrink tolerance: a justified line may compress
-    //      each inter-word space by up to SPACE_SHRINK_RATIO (25%) of its
-    //      natural width without harming readability. This lets us absorb
-    //      the canvas measureText vs Word advance-width discrepancy
-    //      (~0.1–0.3 px/glyph) that would otherwise push a trailing word
-    //      onto the next line. ECMA-376 doesn't prescribe a line-breaking
-    //      algorithm — tolerance-based fit is standard typography (TeX,
-    //      InDesign, Word) and keeps layout close to Word's output.
-    const SPACE_SHRINK_RATIO = 0.25;
+    //   2. Knuth-Plass shrink tolerance: a line may compress each inter-word
+    //      space by up to SPACE_SHRINK_RATIO (25%) of its natural width without
+    //      harming readability — the module constant, shared with the draw pass
+    //      so a line admitted here is squeezed by the same budget when painted
+    //      (shrinkFitCompression in text-distribute.ts) rather than overrunning
+    //      its box. See the SPACE_SHRINK_RATIO doc above.
     const trimmed = s.text.replace(/ +$/, '');
     // Subtract the GRID width of the trimmed text (not the natural width) so the
     // grid delta on EA glyphs cancels and trailingSpaceW is the bare space

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -65,6 +65,8 @@ import {
 } from './float-layout.js';
 import {
   distributeLineSlack,
+  distributedDelta,
+  shrinkFitCompression,
   type SegStretch,
 } from './text-distribute.js';
 import {
@@ -4949,6 +4951,59 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     // every line, including these.
     const endsLogicalLine = isLastLine || (line.endsWithBreak ?? false);
     const applyJustify = isJustified && (!endsLogicalLine || stretchLastLine);
+
+    // Slack distribution across the line's gaps (§17.18.44). `segStretch` /
+    // `distPerGap` drive the draw loop below; they are set either by the JUSTIFY
+    // block (expansion / compression of a jc=both/distribute line) further down,
+    // or — for a NON-justified line whose natural width overran the box because
+    // layoutLines' fit judgment spent the shrink budget to keep it on one row —
+    // by the compression here. The two are mutually exclusive (applyJustify vs
+    // not), so there is no double distribution.
+    let segStretch: Map<number, SegStretch> | null = null;
+    let distPerGap = 0;
+    // First content segment in reading order. Leading-whitespace segments before
+    // it (a paragraph's 字下げ indent) are NOT stretched — Word keeps the indent
+    // fixed and distributes slack only across the line content (§17.18.44). Only
+    // meaningful for LTR: under bidi the logical-leading segment is not the
+    // visually-leading one, so leave the skip off (0) there.
+    let firstContentSi = 0;
+    if (!paraNeedsBidi) {
+      for (let i = 0; i < segCount; i++) {
+        const seg = line.segments[i];
+        if (!('text' in seg) || /\S/.test((seg as LayoutTextSeg).text)) { firstContentSi = i; break; }
+      }
+    }
+    // Shrink-to-fit compression for a NON-justified line that overflows the box
+    // (lineSlack < 0). layoutLines placed the whole line here on the promise that
+    // its inter-word spaces would be squeezed by up to SPACE_SHRINK_RATIO (its fit
+    // test admits Δ ≤ ratio·Σspace); reproduce that squeeze so the last glyph lands
+    // inside the box instead of overrunning its clip (sample-10 p1's centred title
+    // "…Conference" — the final "e" was clipped). Same spaces-only mechanism the
+    // justified negative-slack path uses. `shrinkDelta` (≤ 0) is folded into the
+    // alignment slack below so the now-narrower line re-centres/re-aligns correctly.
+    let shrinkDelta = 0;
+    if (!applyJustify && lineSlack < 0) {
+      const distSegs = line.segments.map(seg =>
+        'text' in seg ? { text: (seg as LayoutTextSeg).text } : {},
+      );
+      const shrinkDist = shrinkFitCompression(
+        distSegs,
+        lineSlack,
+        firstContentSi,
+        paraNeedsBidi ? lastDrawnSi : segCount,
+        line.ascent,
+      );
+      if (shrinkDist) {
+        segStretch = shrinkDist.perSeg;
+        distPerGap = shrinkDist.perGap;
+        shrinkDelta = distributedDelta(shrinkDist);
+      }
+    }
+    // Alignment slack AFTER any shrink squeeze: the drawn width is
+    // lineWidth + shrinkDelta, so the remaining slack the align offset centres /
+    // right-aligns against is lineSlack − shrinkDelta (0 when the squeeze fully
+    // absorbed the overflow ⇒ the line fills the box and align offset is 0).
+    const alignSlack = lineSlack - shrinkDelta;
     let alignOffset = 0;
     // ECMA-376 §22.1.2.88 `m:jc` / §22.1.2.30 `m:defJc` — a display equation's
     // justification is independent of the paragraph's text alignment. When this
@@ -4966,14 +5021,14 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
       : null;
     const effEdge = mathEdge ?? alignEdge;
     if (effEdge === 'right') {
-      alignOffset = lineSlack;
+      alignOffset = alignSlack;
     } else if (effEdge === 'center') {
-      alignOffset = lineSlack / 2;
+      alignOffset = alignSlack / 2;
     } else if (effEdge === 'justify' && baseRtl && !applyJustify) {
       // The unstretched (last) line of a justified RTL paragraph aligns to the
       // leading edge — the RIGHT margin (§17.18.44 `both`: last line is
       // start-aligned). LTR keeps alignOffset 0 as before.
-      alignOffset = lineSlack;
+      alignOffset = alignSlack;
     }
     // 'left' and stretched 'justify' keep alignOffset 0.
     // Decimal-tab auto-alignment (see decimalAutoTabPx above): override the
@@ -5047,22 +5102,11 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     // text-distribute.ts). distributeLineSlack returns, per logical segment, the
     // internal split points and a trailing-gap flag; the draw loop applies
     // `perGap` at each. Only computed when the line is a justify candidate
-    // (jc=both/distribute, not the last line unless distribute).
-    let segStretch: Map<number, SegStretch> | null = null;
-    let distPerGap = 0;
-    // First content segment in reading order. Leading-whitespace segments before
-    // it (a paragraph's 字下げ indent) are NOT stretched — Word keeps the indent
-    // fixed and distributes slack only across the line content (§17.18.44). Only
-    // meaningful for LTR: under bidi the logical-leading segment is not the
-    // visually-leading one, so leave the skip off (0) there.
-    let firstContentSi = 0;
+    // (jc=both/distribute, not the last line unless distribute) — a NON-justified
+    // overflowing line was already squeezed above (`shrinkFitCompression`), and
+    // `segStretch` / `distPerGap` / `firstContentSi` are hoisted before the align
+    // offset so both distributions feed the SAME draw loop.
     if (applyJustify) {
-      if (!paraNeedsBidi) {
-        for (let i = 0; i < segCount; i++) {
-          const seg = line.segments[i];
-          if (!('text' in seg) || /\S/.test((seg as LayoutTextSeg).text)) { firstContentSi = i; break; }
-        }
-      }
       const slack = effAvailW - (x - lineLeft) - lineWidth;
       // Compression cap (negative slack): never eat more than ~a quarter em per
       // gap, estimated from the line ascent. For expansion this is unbounded.
@@ -6304,32 +6348,63 @@ export function renderShapeText(
         const endsLogicalLine = isLastLine || (line.endsWithBreak ?? false);
         const applyJustify = isJustified && (!endsLogicalLine || stretchLastLine);
 
-        // Alignment offset within the region. Justified lines keep 0 (slack is
-        // distributed into the gaps below); the unstretched last line of a
-        // justified RTL paragraph aligns to the leading (right) edge (§17.18.44).
-        let alignOffset = 0;
         const lineSlack = regionW - lineWidth;
+
+        // Slack distribution across the line's gaps (§17.18.44) — the SAME kernel
+        // the body uses. `segStretch` / `distPerGap` are set either by the JUSTIFY
+        // block (expansion / compression of a justified line) or, for a NON-
+        // justified line that overran the region because layoutLines' fit judgment
+        // spent the shrink budget to keep it on one row, by the compression here
+        // (sample-10 p1's centred text-box title). The two are mutually exclusive.
+        let segStretch: Map<number, SegStretch> | null = null;
+        let distPerGap = 0;
+        // First content segment (leading 字下げ whitespace is fixed); 0 under bidi.
+        let firstContentSi = 0;
+        if (!paraNeedsBidi) {
+          for (let i = 0; i < segCount; i++) {
+            const seg = line.segments[i];
+            if (!('text' in seg) || /\S/.test((seg as LayoutTextSeg).text)) { firstContentSi = i; break; }
+          }
+        }
+        // Shrink-to-fit compression for a non-justified overflowing line: squeeze
+        // its inter-word spaces by the SPACE_SHRINK_RATIO budget the fit test
+        // already spent so the last glyph lands inside the box instead of being
+        // clipped. `shrinkDelta` (≤ 0) folds into the align slack so the narrower
+        // line re-aligns correctly.
+        let shrinkDelta = 0;
+        if (!applyJustify && lineSlack < 0) {
+          const distSegs = line.segments.map((seg) =>
+            'text' in seg ? { text: (seg as LayoutTextSeg).text } : {},
+          );
+          const shrinkDist = shrinkFitCompression(
+            distSegs,
+            lineSlack,
+            firstContentSi,
+            paraNeedsBidi ? lastDrawnSi : segCount,
+            line.ascent,
+          );
+          if (shrinkDist) {
+            segStretch = shrinkDist.perSeg;
+            distPerGap = shrinkDist.perGap;
+            shrinkDelta = distributedDelta(shrinkDist);
+          }
+        }
+
+        // Alignment offset within the region, AFTER any shrink squeeze. Justified
+        // lines keep 0 (slack is distributed into the gaps below); the unstretched
+        // last line of a justified RTL paragraph aligns to the leading (right) edge
+        // (§17.18.44). The drawn width is lineWidth + shrinkDelta, so the remaining
+        // slack to centre / right-align against is lineSlack − shrinkDelta.
+        const alignSlack = lineSlack - shrinkDelta;
+        let alignOffset = 0;
         if (!applyJustify) {
-          if (alignEdge === 'right') alignOffset = Math.max(0, lineSlack);
-          else if (alignEdge === 'center') alignOffset = Math.max(0, lineSlack / 2);
-          else if (alignEdge === 'justify' && baseRtl) alignOffset = Math.max(0, lineSlack);
+          if (alignEdge === 'right') alignOffset = Math.max(0, alignSlack);
+          else if (alignEdge === 'center') alignOffset = Math.max(0, alignSlack / 2);
+          else if (alignEdge === 'justify' && baseRtl) alignOffset = Math.max(0, alignSlack);
         }
         let x = regionLeft + alignOffset;
 
-        // Justified-line slack distribution (§17.18.44) — the SAME kernel the body
-        // uses. Positive slack expands inter-word + inter-CJK gaps to fill the
-        // region; negative slack compresses spaces so the last glyph lands on the
-        // region edge. Leading whitespace (a 字下げ indent) is not stretched (LTR).
-        let segStretch: Map<number, SegStretch> | null = null;
-        let distPerGap = 0;
-        let firstContentSi = 0;
         if (applyJustify) {
-          if (!paraNeedsBidi) {
-            for (let i = 0; i < segCount; i++) {
-              const seg = line.segments[i];
-              if (!('text' in seg) || /\S/.test((seg as LayoutTextSeg).text)) { firstContentSi = i; break; }
-            }
-          }
           const minPerGap = -line.ascent * 0.25;
           const distSegs = line.segments.map((seg) =>
             'text' in seg ? { text: (seg as LayoutTextSeg).text } : {},

--- a/packages/docx/src/shrink-fit-draw.test.ts
+++ b/packages/docx/src/shrink-fit-draw.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import { renderShapeText, renderDocumentToCanvas } from './renderer.js';
+import { SPACE_SHRINK_RATIO } from './line-layout.js';
+import type {
+  ShapeRun, ShapeText, ShapeTextRun,
+  BodyElement, DocParagraph, DocxTextRun, DocxDocumentModel, SectionProps,
+} from './types';
+
+// Knuth-Plass shrink-fit: draw the line with the compression the fit judgment
+// assumed. layoutLines admits a word onto the current line when the line's
+// overflow Δ ≤ SPACE_SHRINK_RATIO · Σ(trailing-space widths) — i.e. it PROMISES
+// the draw pass will squeeze the inter-word spaces by up to that budget. Before
+// this fix the draw pass advanced the pen by the NATURAL widths, so an admitted
+// line overran its box's clip and the last glyph was cut (sample-10 p1's centred
+// text-box title "…Conference" lost its final "e"). These tests pin that a
+// shrink-fit non-justified line (center / left / right; body AND text-box) is now
+// squeezed back inside the box, a line that fits naturally is untouched, a
+// justified line is not double-compressed, and the squeeze holds at a non-unit
+// zoom (the #689 rescale path).
+//
+// Mock metric model (shared with the other draw-path tests): measureText width =
+// code-point count × the font px, so every glyph — including a space — is exactly
+// `px` wide. That makes the fit budget exact: one inter-word space = px, so
+// Σtrailing = nSpaces·px and the admitted overflow is ≤ SPACE_SHRINK_RATIO·nSpaces·px.
+
+const FONT_PX = 10;
+
+interface FillTextEvent { text: string; x: number; y: number }
+
+function makeRecordingCanvas(): { ctx: CanvasRenderingContext2D; fillTexts: FillTextEvent[] } {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const ls = () => parseFloat(/(-?\d+(?:\.\d+)?)px/.exec(letterSpacing)?.[1] ?? '0');
+  const fillTexts: FillTextEvent[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      const n = [...s].length;
+      return {
+        width: n * p + n * ls(),
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { fillTexts.push({ text: s, x, y }); },
+    strokeText(s: string, x: number, y: number) { fillTexts.push({ text: s, x, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fillTexts };
+}
+
+// ── Text-box (shape) path ────────────────────────────────────────────────────
+
+const SHAPE_X = 100, SHAPE_Y = 50;
+
+function shapeWith(blocks: ShapeText[]): ShapeRun {
+  return {
+    type: 'shape',
+    presetGeometry: 'rect', wrapMode: 'none', textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    textBlocks: blocks,
+  } as unknown as ShapeRun;
+}
+
+function block(text: string, extra: Partial<ShapeText> = {}): ShapeText {
+  return {
+    text, fontSizePt: FONT_PX, fontFamily: 'serif', alignment: 'left',
+    runs: [{ text, fontSizePt: FONT_PX, fontFamily: 'serif' } as ShapeTextRun],
+    ...extra,
+  } as unknown as ShapeText;
+}
+
+function renderShape(blocks: ShapeText[], w: number, h: number, scale = 1): FillTextEvent[] {
+  const { ctx, fillTexts } = makeRecordingCanvas();
+  renderShapeText(shapeWith(blocks), SHAPE_X * scale, SHAPE_Y * scale, w * scale, h * scale, ctx, scale);
+  return fillTexts;
+}
+
+/** All fills on the single (top) line, left→right. */
+function topLine(evs: FillTextEvent[]): FillTextEvent[] {
+  const minY = Math.min(...evs.map((e) => e.y));
+  return evs.filter((e) => e.y === minY).sort((a, b) => a.x - b.x);
+}
+
+/** Right edge of the last glyph on a line = its x + its trimmed measured width. */
+function lineRight(line: FillTextEvent[]): number {
+  const last = line[line.length - 1];
+  const trimmed = last.text.replace(/ +$/, '');
+  return last.x + [...trimmed].length * FONT_PX;
+}
+
+describe('shrink-fit draw — text-box (shape) path', () => {
+  // "AAAA BBBB CCCC" = 5+5+4 = 140px natural; two spaces ⇒ Σtrailing = 20,
+  // budget = 5px. Inner width 138 ⇒ overflow Δ = 2 ≤ 5, so layoutLines keeps all
+  // three words on ONE line. The draw must squeeze the two spaces by 1px each so
+  // the line's right edge lands on the box edge (138) instead of overrunning to
+  // 140 and clipping the final "C".
+  const CONTENT = 'AAAA BBBB CCCC';
+  const NAT = 140; // 14 glyphs × 10
+  const W = 138;
+
+  it('squeezes a centred shrink-fit line so it lands inside the box (last glyph not clipped)', () => {
+    const line = topLine(renderShape([block(CONTENT, { alignment: 'center' })], W, 400));
+    // One line (all three words admitted).
+    expect(line.map((e) => e.text.replace(/ +$/, '')).join(' ')).toBe('AAAA BBBB CCCC');
+    const right = lineRight(line);
+    // Lands on the inner-right edge, NOT at the natural 140 that would overrun the
+    // box's clip. INNER_X = SHAPE_X (no insets).
+    expect(right).toBeLessThanOrEqual(SHAPE_X + W + 0.01);
+    expect(right).toBeCloseTo(SHAPE_X + W, 1);
+    // The total squeeze equals the overflow (Δ = NAT − W = 2px), within the budget.
+    const squeeze = NAT - (right - line[0].x);
+    expect(squeeze).toBeCloseTo(NAT - W, 1);
+    expect(squeeze).toBeLessThanOrEqual(SPACE_SHRINK_RATIO * 20 + 0.01);
+  });
+
+  it('squeezes a left-aligned shrink-fit line the same way (starts at inner-left, ends on edge)', () => {
+    const line = topLine(renderShape([block(CONTENT, { alignment: 'left' })], W, 400));
+    expect(line[0].x).toBeCloseTo(SHAPE_X, 3); // left edge unmoved
+    expect(lineRight(line)).toBeLessThanOrEqual(SHAPE_X + W + 0.01);
+    expect(lineRight(line)).toBeCloseTo(SHAPE_X + W, 1);
+  });
+
+  it('squeezes a right-aligned shrink-fit line to end exactly on the inner-right edge', () => {
+    const line = topLine(renderShape([block(CONTENT, { alignment: 'right' })], W, 400));
+    expect(lineRight(line)).toBeCloseTo(SHAPE_X + W, 1);
+  });
+
+  it('does NOT compress a line that already fits (spaces keep their natural width)', () => {
+    // Same content, inner width 200 > natural 140 ⇒ positive slack, no squeeze.
+    const line = topLine(renderShape([block(CONTENT, { alignment: 'center' })], 200, 400));
+    // Inter-word gaps stay at exactly one space (10px): "BBBB" starts one space
+    // past the end of "AAAA" glyphs.
+    const a = line[0], b = line[1];
+    const gap = b.x - (a.x + 4 * FONT_PX); // AAAA is 4 glyphs
+    expect(gap).toBeCloseTo(FONT_PX, 3); // full, uncompressed space
+    // And the whole line is NATURAL width, merely centred (right − left = 140).
+    expect(lineRight(line) - line[0].x).toBeCloseTo(NAT, 1);
+  });
+
+  it('does NOT double-compress a justified (both) line — its own §17.18.44 path owns the slack', () => {
+    // A `both` paragraph that WRAPS: line 1 is a justify candidate (not the last
+    // line), so applyJustify is true and the shrink-fit branch (gated on
+    // !applyJustify) is SKIPPED — the justified path alone distributes its slack.
+    // "AAAA BBBB CCCC DDDD EEEE" at W=138 wraps with line 1 = "AAAA BBBB CCCC ".
+    const evs = renderShape([block('AAAA BBBB CCCC DDDD EEEE', { alignment: 'both' })], W, 400);
+    const ys = [...new Set(evs.map((e) => e.y))].sort((a, b) => a - b);
+    expect(ys.length).toBeGreaterThanOrEqual(2); // it wrapped
+    const line1 = evs.filter((e) => e.y === ys[0]).sort((a, b) => a.x - b.x);
+    expect(line1.map((e) => e.text.replace(/ +$/, '')).join(' ')).toBe('AAAA BBBB CCCC');
+    // Justify signature: the inter-word gaps are compressed by an EQUAL amount
+    // (Σ distributed evenly), so the two realised gaps match. If the shrink-fit
+    // path ALSO fired, this line would be compressed twice — either uneven or
+    // pulled well inside — so equal, single-budget gaps prove single application.
+    const [a, b, c] = line1; // "AAAA ", "BBBB ", "CCCC "
+    const gap1 = b.x - (a.x + 4 * FONT_PX); // realised inter-word gap 1
+    const gap2 = c.x - (b.x + 4 * FONT_PX); // realised inter-word gap 2
+    expect(gap1).toBeCloseTo(gap2, 3);      // even distribution (justify)
+    // Compressed from the natural 10px but by a SINGLE justify pass — the gap is
+    // still positive (not squeezed twice below the floor) and within one space.
+    expect(gap1).toBeGreaterThan(0);
+    expect(gap1).toBeLessThan(FONT_PX);
+  });
+
+  it('holds the squeeze at a non-unit zoom (scale = 0.75) — line stays inside the scaled box', () => {
+    const scale = 0.75;
+    const line = topLine(renderShape([block(CONTENT, { alignment: 'center' })], W, 400, scale));
+    // Box inner-right at this scale.
+    const innerRight = (SHAPE_X + W) * scale;
+    expect(lineRight2(line, scale)).toBeLessThanOrEqual(innerRight + 0.5);
+    expect(lineRight2(line, scale)).toBeCloseTo(innerRight, 0);
+  });
+});
+
+/** lineRight with an explicit scale (glyph advance = px·scale under the mock). */
+function lineRight2(line: FillTextEvent[], scale: number): number {
+  const last = line[line.length - 1];
+  const trimmed = last.text.replace(/ +$/, '');
+  return last.x + [...trimmed].length * FONT_PX * scale;
+}
+
+// ── Body path ────────────────────────────────────────────────────────────────
+
+function bodyTextRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'NotInMetrics', isLink: false,
+    background: null, vertAlign: null, hyperlink: null,
+  } as DocxTextRun;
+}
+
+function bodyPara(text: string, alignment: DocParagraph['alignment']): BodyElement {
+  const p: DocParagraph = {
+    alignment,
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...bodyTextRun(text) } as DocParagraph['runs'][number]],
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function bodySection(pageWidth: number): SectionProps {
+  return {
+    pageWidth, pageHeight: 400,
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+}
+
+async function renderBody(body: BodyElement[], sec: SectionProps): Promise<FillTextEvent[]> {
+  const { ctx, fillTexts } = makeRecordingCanvas();
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx } as unknown as HTMLCanvasElement;
+  const model = {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+  await renderDocumentToCanvas(model, canvas, 0, { dpr: 1, width: sec.pageWidth });
+  return fillTexts;
+}
+
+describe('shrink-fit draw — body paragraph path', () => {
+  // "AAAA BBBB CCCC DDDD" = 5+5+5+4 = 190px natural; three spaces ⇒ Σtrailing = 30,
+  // budget = 7.5px. Page width 185 (margins 0) ⇒ overflow Δ = 5 ≤ 7.5 ⇒ one line.
+  const CONTENT = 'AAAA BBBB CCCC DDDD';
+  const NAT = 190;
+  const PAGE = 185;
+
+  it('squeezes a centred shrink-fit body line inside the text margin (last glyph not clipped)', async () => {
+    const evs = await renderBody([bodyPara(CONTENT, 'center')], bodySection(PAGE));
+    const line = topLine(evs);
+    expect(line.map((e) => e.text.replace(/ +$/, '')).join(' ')).toBe('AAAA BBBB CCCC DDDD');
+    const right = lineRight(line);
+    // Margin left = 0, avail = PAGE. The last glyph must land within the margin.
+    expect(right).toBeLessThanOrEqual(PAGE + 0.01);
+    expect(right).toBeCloseTo(PAGE, 1);
+    // Squeeze == overflow, within budget.
+    expect(NAT - (right - line[0].x)).toBeCloseTo(NAT - PAGE, 1);
+  });
+
+  it('does NOT compress a body line that already fits', async () => {
+    const evs = await renderBody([bodyPara(CONTENT, 'center')], bodySection(260));
+    const line = topLine(evs);
+    // Natural width preserved (merely centred).
+    expect(lineRight(line) - line[0].x).toBeCloseTo(NAT, 1);
+  });
+});

--- a/packages/docx/src/text-distribute.ts
+++ b/packages/docx/src/text-distribute.ts
@@ -104,3 +104,56 @@ export function distributeLineSlack(
     ...(includeCJK ? {} : { isGapChar: () => false }),
   });
 }
+
+/** The px total actually applied by a {@link DistributeResult} = perGap summed
+ *  over every gap it opened (interior splits + inter-segment trailing gaps).
+ *  Negative for compression. The drawn line width is `Σ measuredWidth + this`. */
+export function distributedDelta(dist: DistributeResult | null): number {
+  if (!dist) return 0;
+  let gaps = 0;
+  for (const s of dist.perSeg.values()) gaps += s.splitBefore.length + (s.trailingGap ? 1 : 0);
+  return dist.perGap * gaps;
+}
+
+/** Compression for a NON-justified line whose natural width exceeds the available
+ *  width because {@link layoutLines}' fit judgment placed it there on the promise
+ *  that its inter-word spaces would be squeezed (the Knuth-Plass shrink tolerance,
+ *  {@link SPACE_SHRINK_RATIO}). The fit test admits a word when the line's overflow
+ *  Δ ≤ SPACE_SHRINK_RATIO · Σ(trailing-space widths); this reproduces the squeeze
+ *  the test assumed so the drawn advance lands back inside the box instead of
+ *  overrunning its clip (sample-10 p1's centred text-box title — the final "e" of
+ *  "…Conference" was clipped because the pen ran the natural width while the fit
+ *  judgment had already spent the shrink budget to keep the line to one row).
+ *
+ *  Same mechanism as the §17.18.44 justified negative-slack path: spaces only
+ *  (never overlap two ideographs), per-gap floored at a quarter of the line
+ *  ascent. That floor is a superset of the fit judgment's budget — the judgment
+ *  admits Δ ≤ SPACE_SHRINK_RATIO·Σspace, and a line has ascent ≳ a single space
+ *  width, so nGaps·(ascent/4) ≥ SPACE_SHRINK_RATIO·Σspace always covers the
+ *  admitted overflow; the floor only guards a pathological narrow space from
+ *  collapsing. Returns `null` when there is no space to squeeze (an over-long
+ *  single word overflows as before) or the overflow is below the noise floor.
+ *
+ *  @param segments  Line segments in LOGICAL (reading) order (text carries `.text`).
+ *  @param slack     availWidth − Σ measuredWidth, px. Must be < 0 (the caller gates).
+ *  @param firstContentSi First non-whitespace segment (leading 字下げ is fixed); 0 under bidi.
+ *  @param lastDrawnSi    Visually-final segment (see {@link distributeLineSlack}).
+ *  @param ascentPx  The line's px ascent, for the per-gap compression floor.
+ *  @returns The squeeze to draw, or `null` when nothing compresses. */
+export function shrinkFitCompression(
+  segments: readonly { text?: string }[],
+  slack: number,
+  firstContentSi: number,
+  lastDrawnSi: number,
+  ascentPx: number,
+): DistributeResult | null {
+  if (slack >= 0) return null;
+  return distributeLineSlack(
+    segments,
+    slack,
+    firstContentSi,
+    lastDrawnSi,
+    -ascentPx * 0.25, // per-gap floor, same as the justified compression path
+    false, // compression: squeeze inter-word spaces only, never inter-CJK boundaries
+  );
+}


### PR DESCRIPTION
## Summary

User-reported: the sample-10 p1 centered text-box title lost its final "e" ("…Conferenc") while Word shows the full line. Instrumented probe confirmed the mechanism: `layoutLines`' fit test admitted the title onto one row **on the promise of space compression** (natural width 487.62px vs box 481.66px, Δ=5.96px ≤ shrink budget 8.24px — one row, matching Word), but every **non-justified** draw path advanced the pen by natural `measuredWidth`, so the admitted line overran the box clip by exactly Δ.

The fix makes the drawn number equal the judged number by reusing the existing §17.18.44 justified negative-slack machinery for non-justified shrink-fit lines: new `shrinkFitCompression`/`distributedDelta` thin wrappers over the shared `distributeLineSlack` kernel (spaces-only, same per-gap floor), applied in both draw loops (body `drawParagraphLine`, text-box `renderShapeText`) when `!applyJustify && lineSlack < 0`, with the shrink delta folded into the alignment slack so the narrower line re-centres. Justified lines untouched (no double distribution). The squeeze recomputes from current-scale widths, so it is zoom-invariant (#689); `onTextRun` reports post-compression widths via the same path. `SPACE_SHRINK_RATIO` is hoisted to a shared exported constant so judge and draw read one source.

## Verification

- **Pixel probe (real render, red-checked)**: before +5.96px overflow, "e" clipped; after −0.00px, full "Conference" drawn. Word PDF line content matches (13/13 words).
- New `shrink-fit-draw.test.ts` (8 tests: body+shape, center/left/right ≤ box width, fitting lines unchanged, justified not double-compressed, holds at scale 0.75). docx suite **528 green**; VRT 21/21 (references untouched); root tsc + ast-grep clean.
- **Ripple analysis** (before/after screenshots): non-justified shrink-fit lines elsewhere move 0–5px (sub-pixel per gap). One visible case: demo/sample-1 p2's block-quote line compresses 12px — that line was **silently overrunning its column by 11.84px before**; the fix makes it respect the column. Word wraps one word earlier there (the pre-existing fit-tolerance admission tracked by #698's measurement-systematic finding), so the residual tightness is that separate concern made visible, not a regression introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)