### PR TITLE
fix(docx,pptx): scroll viewers reject a <canvas> container at construction

### DIFF
--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -9,6 +9,9 @@ import type { WireRenderPageOptions } from './worker-protocol';
  *  clientHeight/Width, event listeners, removeChild/remove, canvas ctx. */
 export interface FakeEl {
   tag: string;
+  /** Uppercase tag, mirroring the real DOM (`div` → `DIV`) — the viewer's
+   *  canvas-container guard reads it. */
+  tagName: string;
   textContent: string;
   innerHTML: string;
   style: Record<string, string> & { cssText: string };
@@ -55,6 +58,7 @@ export function makeEl(tag: string): FakeEl {
   const style: Record<string, string> = {};
   const el: FakeEl = {
     tag,
+    tagName: tag.toUpperCase(),
     textContent: '',
     innerHTML: '',
     width: 0,

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxScrollViewer } from './scroll-viewer.js';
 import { DocxDocument } from './document.js';
-import { installDom, makeContainer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+import { installDom, makeContainer, makeEl, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
 import * as docxIndex from './index.js';
 
 afterEach(() => {
@@ -59,6 +59,19 @@ describe('DocxScrollViewer — skeleton (T1)', () => {
     installDom();
     const v = new DocxScrollViewer(makeContainer() as unknown as HTMLElement, {});
     expect(v.pageCount).toBe(0);
+    v.destroy();
+  });
+
+  // A <canvas> type-checks as HTMLElement (the pager API takes one), but canvas
+  // children never render — the viewer would come up silently blank. Rejected
+  // loudly at construction instead.
+  it('throws when the container is a <canvas> (pager-API confusion)', () => {
+    installDom();
+    expect(
+      () => new DocxScrollViewer(makeEl('canvas') as unknown as HTMLElement, {}),
+    ).toThrow(/container element .* not a <canvas>/i);
+    // A plain div (the documented contract) constructs fine.
+    const v = new DocxScrollViewer(makeContainer() as unknown as HTMLElement, {});
     v.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -236,6 +236,17 @@ export class DocxScrollViewer {
   private readonly _pageShadow: string | false;
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
+    // A <canvas> is an HTMLElement too, so the type system cannot stop a caller
+    // used to the pager API (DocxViewer takes a canvas) from passing one — but
+    // canvas children never render, so the viewer would come up silently blank.
+    // Fail loudly with the fix instead. (tagName, not instanceof: cross-realm safe.)
+    if (container.tagName === 'CANVAS') {
+      throw new Error(
+        'DocxScrollViewer takes a container element (e.g. a <div>), not a <canvas> — ' +
+          'the viewer creates and manages its own canvases. Pass a block container; ' +
+          'for the single-page canvas API use DocxViewer.',
+      );
+    }
     this._container = container;
     this._opts = opts;
     // `??` (not `||`): a caller's explicit `false` must disable the shadow, not

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -7,6 +7,9 @@ import type { PptxTextRunInfo } from './renderer';
  *  clientHeight/Width, event listeners, removeChild/remove, canvas ctx. */
 export interface FakeEl {
   tag: string;
+  /** Uppercase tag, mirroring the real DOM (`div` → `DIV`) — the viewer's
+   *  canvas-container guard reads it. */
+  tagName: string;
   textContent: string;
   innerHTML: string;
   style: Record<string, string> & { cssText: string };
@@ -53,6 +56,7 @@ export function makeEl(tag: string): FakeEl {
   const style: Record<string, string> = {};
   const el: FakeEl = {
     tag,
+    tagName: tag.toUpperCase(),
     textContent: '',
     innerHTML: '',
     width: 0,

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { PptxScrollViewer } from './scroll-viewer.js';
 import { PptxPresentation } from './presentation.js';
-import { installDom, makeContainer, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+import { installDom, makeContainer, makeEl, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
 import * as pptxIndex from './index.js';
 
 afterEach(() => {
@@ -59,6 +59,19 @@ describe('PptxScrollViewer — skeleton (T1)', () => {
     installDom();
     const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {});
     expect(v.slideCount).toBe(0);
+    v.destroy();
+  });
+
+  // A <canvas> type-checks as HTMLElement (the pager API takes one), but canvas
+  // children never render — the viewer would come up silently blank. Rejected
+  // loudly at construction instead.
+  it('throws when the container is a <canvas> (pager-API confusion)', () => {
+    installDom();
+    expect(
+      () => new PptxScrollViewer(makeEl('canvas') as unknown as HTMLElement, {}),
+    ).toThrow(/container element .* not a <canvas>/i);
+    // A plain div (the documented contract) constructs fine.
+    const v = new PptxScrollViewer(makeContainer() as unknown as HTMLElement, {});
     v.destroy();
   });
 

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -245,6 +245,17 @@ export class PptxScrollViewer {
   private readonly _pageShadow: string | false;
 
   constructor(container: HTMLElement, opts: PptxScrollViewerOptions = {}) {
+    // A <canvas> is an HTMLElement too, so the type system cannot stop a caller
+    // used to the pager API (PptxViewer takes a canvas) from passing one — but
+    // canvas children never render, so the viewer would come up silently blank.
+    // Fail loudly with the fix instead. (tagName, not instanceof: cross-realm safe.)
+    if (container.tagName === 'CANVAS') {
+      throw new Error(
+        'PptxScrollViewer takes a container element (e.g. a <div>), not a <canvas> — ' +
+          'the viewer creates and manages its own canvases. Pass a block container; ' +
+          'for the single-slide canvas API use PptxViewer.',
+      );
+    }
     this._container = container;
     this._opts = opts;
     // `??` (not `||`): a caller's explicit `false` must disable the shadow, not


### PR DESCRIPTION
## Summary

User-spotted API sharp edge: the scroll viewers take a **container** (`HTMLElement`), while the pagers take a `<canvas>` — and since a canvas *is* an `HTMLElement`, the type system cannot stop a caller from passing one. Canvas children never render, so the misuse produced a **silently blank viewer**.

Both constructors now fail loudly:

```
DocxScrollViewer takes a container element (e.g. a <div>), not a <canvas> — the
viewer creates and manages its own canvases. Pass a block container; for the
single-page canvas API use DocxViewer.
```

`tagName === 'CANVAS'` check (cross-realm safe, unlike `instanceof`). `HTMLElement` stays the parameter type — it's the `XlsxViewer` container convention, and narrowing to `HTMLDivElement` would reject legitimate containers (`<section>`, `<main>`, …). The test harness `FakeEl` gains the real DOM's `tagName` field; one rejection + one plain-div acceptance test per viewer.

## Verification

docx + pptx suites 772/772 across both packages; package + root typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)