### PR TITLE
docs: Angular CLI setup for the parser WASM asset (assets copy + wasmUrl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@ pnpm add @silurus/ooxml
 
 > **Bundler note**: the Rust parsers ship as real `.wasm` asset files next to the
 > JavaScript, referenced with the standard `new URL('…', import.meta.url)` form
-> and fetched (streaming-compiled) at load time. Vite, webpack 5, Rollup,
-> esbuild and Parcel detect that reference and copy the asset automatically — no
-> extra WebAssembly plugin is required. If your bundler cannot emit the asset (or
-> you want to serve the parser WASM from a CDN or a path you control), pass its
-> URL via the `wasmUrl` load option:
+> and fetched (streaming-compiled) at load time. Vite, webpack 5, Rollup and
+> Parcel detect that reference and copy the asset automatically — no extra
+> WebAssembly plugin is required. esbuild and the Angular CLI (whose application
+> builder is esbuild-based) do **not** process that reference
+> ([esbuild#795](https://github.com/evanw/esbuild/issues/795)): copy the `.wasm`
+> into your served output yourself and point the viewer at it with the `wasmUrl`
+> load option — see the [Angular example](#framework-examples) for the two-step
+> setup. `wasmUrl` also serves the parser WASM from a CDN or any path you
+> control:
 >
 > ```typescript
 > new DocxViewer(canvas, { wasmUrl: 'https://cdn.example.com/docx_parser_bg.wasm' });
@@ -376,6 +380,28 @@ onMounted(async () => {
 <details>
 <summary><strong>Angular 19</strong></summary>
 
+The Angular CLI's esbuild-based builder does not process the `new URL('…', import.meta.url)`
+asset reference the parsers use ([angular-cli#22388](https://github.com/angular/angular-cli/issues/22388)),
+so the `.wasm` never reaches the build output — and under `ng serve` the dependency
+optimizer additionally rewrites the reference into its own cache path. **Both steps
+below are required** (the asset copy alone fixes only production builds; `ng serve`
+still 404s without `wasmUrl`):
+
+```jsonc
+// angular.json — copy the parser WASM into the served root
+// (restart `ng serve` after editing this file)
+"architect": {
+  "build": {
+    "options": {
+      "assets": [
+        { "glob": "*_parser_bg.wasm", "input": "node_modules/@silurus/ooxml/dist", "output": "/" },
+        { "glob": "**/*", "input": "public" }
+      ]
+    }
+  }
+}
+```
+
 ```typescript
 // Angular 19 — standalone component with signal-based state
 import {
@@ -404,6 +430,7 @@ export class PptxViewerComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     this.viewer = new PptxViewer(this.canvasEl().nativeElement, {
+      wasmUrl: '/pptx_parser_bg.wasm',
       onSlideChange: (i, t) => { this.current.set(i); this.total.set(t); },
     });
     this.viewer.load('/deck.pptx');
@@ -414,7 +441,10 @@ export class PptxViewerComponent implements AfterViewInit {
 }
 ```
 
-> Add `"allowSyntheticDefaultImports": true` and configure `@angular-builders/custom-webpack` (or use `esbuild` builder) with WASM support in your Angular workspace.
+> The `*_parser_bg.wasm` glob copies all three parsers; narrow it to
+> `pptx_parser_bg.wasm` if you only use one format. If you deploy under a
+> non-root `base href`, adjust `wasmUrl` so it resolves under your base (a
+> relative `wasmUrl` is resolved against the document URL).
 
 </details>
 


### PR DESCRIPTION
## Summary

In v0.70.0 (#681) the parsers switched from base64 data-URL inlining to real `.wasm` assets referenced via `new URL('…', import.meta.url)`. The README's bundler note claimed esbuild picks that reference up automatically — it does not ([evanw/esbuild#795](https://github.com/evanw/esbuild/issues/795)), and neither does the Angular CLI's esbuild-based application builder ([angular/angular-cli#22388](https://github.com/angular/angular-cli/issues/22388)). Angular users upgrading past v0.68.0 hit a runtime WASM fetch failure (#709).

This PR fixes the bundler note, rewrites the Angular 19 example with the verified two-step setup, and retires the stale `@angular-builders/custom-webpack` advice left over from the data-URL-inline era.

## Verification (Angular CLI 19.2.27 + `@silurus/ooxml@0.70.0`, headless Chromium)

Machine-judged (console errors + canvas pixel scan), two independent runs with matching results:

| Setup | `ng serve` | `ng build` + static serve |
|---|---|---|
| none (repro) | ❌ 404 → `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok` | ❌ same (no `.wasm` in `dist`) |
| angular.json assets glob only | ❌ still 404 — the dep optimizer rewrites the reference into `.angular/cache/…/vite/deps/` | ✅ 200 `application/wasm`, page renders |
| assets glob **+** `wasmUrl: '/docx_parser_bg.wasm'` | ✅ renders | ✅ renders |

Hence the README documents both steps as required, with a note that `ng serve` must be restarted after editing `angular.json` and that a non-root `base href` needs an adjusted `wasmUrl`.

Ref #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)