### PR TITLE
fix(charts): negative bars, stacked lines, shared color transforms, dateAx, locale-independent labels

### DIFF
--- a/docs/improvement-plan-2026-07b-checklist.md
+++ b/docs/improvement-plan-2026-07b-checklist.md
@@ -32,11 +32,13 @@ node packages/node/src/bench-handle.mjs  # handle 反復 work ベンチ
 ## Phase 1 — 即効の正しさ・安全網・クイックウィン
 
 ### 正しさ(チャート)
-- [ ] CH1: 棒チャート負値
-- [ ] CH2: stackedLine / stackedLinePct
-- [ ] CH3: xlsx チャート色解決の私的コピー排除(bg2/tx2 + HSL)
-- [ ] CH4: c:dateAx 認識
-- [ ] CH11: チャート数値のロケール固定(§18.8.30 エンジンへ)
+- [x] CH1: 棒チャート負値 — 縦棒/横棒とも実 dataMin からゼロライン基準の両方向描画に一般化。stacked は正負分離スタック、percentStacked は符号保持(分母 Σ|v| と逆側スタックは spec が定めない Excel/PowerPoint 実挙動である旨をコメント化)。正値のみチャートは byte-stable(snapshot 不変で証明)
+- [x] CH2: stackedLine / stackedLinePct — area の stackBase パターンを移植。**追加発見: 参照実装とされた stackedAreaPct 自体が正規化未実装** → 同 PR で修正(1c56f66)。bar/line/area の pct 分配規約(Σ|v|・符号保持)を 3 実装で統一
+- [x] CH3: xlsx チャート色解決の私的コピー排除(bg2/tx2 + HSL) — 私的 3 関数を削除し ooxml_common::color::parse_color_node + 共有 XlsxSchemeResolver へ委譲。横断点検の結果 **pptx は委譲済みでバグ無し**(xlsx が唯一の外れ値だった)。注: alpha 付き solidFill は 8 桁 hex になる(shape 経路と整合、旧実装は alpha を落としていた)
+- [x] CH4: c:dateAx 認識 — xlsx/pptx 両パーサーで catAx と同扱い(§21.2.2.39 の EG_AxShared 共有構造)。pptx は従来 None 固定だった cat_axis_format_code の配線も獲得。**レビューで発覚した穴: catAxisFormatCode の TS 側消費者が scatter のみで時系列 line/bar が生シリアル値のまま** → §21.2.2.71 の一般則として全カテゴリ軸ファミリーの目盛りラベル書式化(formatCategoryLabel)を core に追加実装(a39eca8)。baseTimeUnit / majorTimeUnit 等の日付単位制御は CH6 の範囲
+- [x] CH11: チャート数値のロケール固定(§18.8.30 エンジンへ) — **再定義: 実箇所は scatter でなく waterfall のみ**(scatter は formatChartValWithCode 対応済みだった)。waterfall の軸目盛り/データラベル 2+1 箇所を formatChartValWithCode へ(valAxisFormatCode / dataLabelFormatCode 配線込み)。renderer 内の toLocaleString は 0 件に
+
+> CH1–CH4/CH11 は PR fix/chart-correctness(9 commits)。検証 = vitest 1757 / typecheck / cargo 3 点 / VRT 163 全 green・参照画像差分ゼロ。独立 4 観点レビュー(spec 忠実性・正しさ・横断統一・テスト品質)→ REQUEST_CHANGES 3 件(MAJOR)を修正済み。別トラック送りの発見: pptx の cat_axis_crosses/crossesAt None 固定(CH6 圏)、percentStacked 分母計算の三重実装の共通化(コスメティック)、stacked の null セル= dispBlanksAs zero 既定(CH9 圏)
 
 ### 正しさ(xlsx / DrawingML / docx)
 - [ ] XL1: date1904(+1900-02-29 バグ互換)

--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -2353,161 +2353,109 @@ fillText "0" 51.64,351.8 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 57.64,327.0538
-lineTo 620,327.0538
+moveTo 57.64,316.0556
+lineTo 620,316.0556
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,327.0538
-lineTo 57.64,327.0538
+moveTo 53.64,316.0556
+lineTo 57.64,316.0556
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "2" 51.64,327.0538 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "5" 51.64,316.0556 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,302.3077
-lineTo 620,302.3077
+moveTo 57.64,280.3111
+lineTo 620,280.3111
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,302.3077
-lineTo 57.64,302.3077
+moveTo 53.64,280.3111
+lineTo 57.64,280.3111
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "4" 51.64,302.3077 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "10" 51.64,280.3111 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,277.5615
-lineTo 620,277.5615
+moveTo 57.64,244.5667
+lineTo 620,244.5667
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,277.5615
-lineTo 57.64,277.5615
+moveTo 53.64,244.5667
+lineTo 57.64,244.5667
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "6" 51.64,277.5615 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "15" 51.64,244.5667 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,252.8154
-lineTo 620,252.8154
+moveTo 57.64,208.8222
+lineTo 620,208.8222
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,252.8154
-lineTo 57.64,252.8154
+moveTo 53.64,208.8222
+lineTo 57.64,208.8222
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "8" 51.64,252.8154 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "20" 51.64,208.8222 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,228.0692
-lineTo 620,228.0692
+moveTo 57.64,173.0778
+lineTo 620,173.0778
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,228.0692
-lineTo 57.64,228.0692
+moveTo 53.64,173.0778
+lineTo 57.64,173.0778
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "10" 51.64,228.0692 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "25" 51.64,173.0778 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,203.3231
-lineTo 620,203.3231
+moveTo 57.64,137.3333
+lineTo 620,137.3333
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,203.3231
-lineTo 57.64,203.3231
+moveTo 53.64,137.3333
+lineTo 57.64,137.3333
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "12" 51.64,203.3231 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "30" 51.64,137.3333 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,178.5769
-lineTo 620,178.5769
+moveTo 57.64,101.5889
+lineTo 620,101.5889
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,178.5769
-lineTo 57.64,178.5769
+moveTo 53.64,101.5889
+lineTo 57.64,101.5889
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "14" 51.64,178.5769 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "35" 51.64,101.5889 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,153.8308
-lineTo 620,153.8308
+moveTo 57.64,65.8444
+lineTo 620,65.8444
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,153.8308
-lineTo 57.64,153.8308
+moveTo 53.64,65.8444
+lineTo 57.64,65.8444
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "16" 51.64,153.8308 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,129.0846
-lineTo 620,129.0846
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,129.0846
-lineTo 57.64,129.0846
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "18" 51.64,129.0846 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,104.3385
-lineTo 620,104.3385
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,104.3385
-lineTo 57.64,104.3385
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "20" 51.64,104.3385 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,79.5923
-lineTo 620,79.5923
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,79.5923
-lineTo 57.64,79.5923
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "22" 51.64,79.5923 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,54.8462
-lineTo 620,54.8462
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,54.8462
-lineTo 57.64,54.8462
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "24" 51.64,54.8462 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "40" 51.64,65.8444 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
 moveTo 57.64,30.1
 lineTo 620,30.1
@@ -2520,7 +2468,7 @@ lineTo 57.64,30.1
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "26" 51.64,30.1 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "45" 51.64,30.1 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -2535,36 +2483,36 @@ set strokeStyle=#4472C4
 set lineWidth=2.3625
 setLineDash 
 beginPath
-moveTo 57.64,228.0692
-lineTo 338.82,54.8462
-lineTo 620,141.4577
+moveTo 57.64,280.3111
+lineTo 338.82,180.2267
+lineTo 620,230.2689
 stroke ss=#4472C4 lw=2.3625 dash=
 set fillStyle=#4472C4
 beginPath
-arc 57.64,228.0692,2.625,0,6.2832
+arc 57.64,280.3111,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 beginPath
-arc 338.82,54.8462,2.625,0,6.2832
+arc 338.82,180.2267,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 beginPath
-arc 620,141.4577,2.625,0,6.2832
+arc 620,230.2689,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 set strokeStyle=#ED7D31
 setLineDash 
 beginPath
-moveTo 57.64,252.8154
-lineTo 338.82,166.2038
-lineTo 620,79.5923
+moveTo 57.64,223.12
+lineTo 338.82,72.9933
+lineTo 620,72.9933
 stroke ss=#ED7D31 lw=2.3625 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 57.64,252.8154,2.625,0,6.2832
+arc 57.64,223.12,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 338.82,166.2038,2.625,0,6.2832
+arc 338.82,72.9933,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 620,79.5923,2.625,0,6.2832
+arc 620,72.9933,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 set fillStyle=#555
 set textAlign=center

--- a/packages/core/src/chart/chart-number-format.test.ts
+++ b/packages/core/src/chart/chart-number-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
+import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 
 describe('formatChartVal (General)', () => {
   it('shows integers raw with no abbreviation', () => {
@@ -51,5 +51,33 @@ describe('formatChartValWithCode — percent & null', () => {
     expect(formatChartValWithCode(7507, 'General')).toBe('7507');
     expect(formatChartValWithCode(7507, 'general')).toBe('7507');
     expect(formatChartValWithCode(0.5, ' General ')).toBe('0.5');
+  });
+});
+
+describe('formatCategoryLabel — category-axis numFmt (§21.2.2.71)', () => {
+  it('formats a numeric serial category through a date code', () => {
+    // 44927 = 2023-01-01 in the 1900 date system.
+    expect(formatCategoryLabel('44927', 'm/d/yyyy')).toBe('1/1/2023');
+  });
+  it('formats a numeric category through a plain number code', () => {
+    expect(formatCategoryLabel('1234567', '#,##0')).toBe('1,234,567');
+  });
+  it('leaves a string category verbatim even when a code is present', () => {
+    expect(formatCategoryLabel('Q1', 'm/d/yyyy')).toBe('Q1');
+    expect(formatCategoryLabel('North', '#,##0')).toBe('North');
+  });
+  it('leaves a numeric category verbatim when no code is present', () => {
+    expect(formatCategoryLabel('44927', null)).toBe('44927');
+    expect(formatCategoryLabel('44927', undefined)).toBe('44927');
+    expect(formatCategoryLabel('44927', '')).toBe('44927');
+  });
+  it('does not format blank or whitespace-only categories (Number("") is a false 0)', () => {
+    expect(formatCategoryLabel('', 'm/d/yyyy')).toBe('');
+    expect(formatCategoryLabel('   ', '#,##0')).toBe('   ');
+  });
+  it('a General code leaves the raw numeric text unchanged', () => {
+    // "General" routes through formatChartValWithCode → formatChartVal, which
+    // shows the raw number (44927), matching the pre-format behavior.
+    expect(formatCategoryLabel('44927', 'General')).toBe('44927');
   });
 });

--- a/packages/core/src/chart/chart-number-format.ts
+++ b/packages/core/src/chart/chart-number-format.ts
@@ -54,6 +54,28 @@ export function formatChartValWithCode(v: number, code: string | null | undefine
 }
 
 /**
+ * Format a category-axis tick label. Categories arrive as the raw cached
+ * strings the workbook stored (`<c:cat><c:strCache>` text, or the numeric
+ * text of a `<c:numCache>` on a date/number axis). ECMA-376 §21.2.2.71
+ * (`c:numFmt`) lets the category axis carry a number-format code: Excel
+ * applies it to the tick labels just as it does on the value axis. When the
+ * axis has such a code AND the raw category parses to a finite number, format
+ * it (which routes serial dates through `formatExcelDate` automatically); a
+ * missing code, `"General"`, or a non-numeric category string falls through
+ * to the raw text unchanged — no new interpretation is invented.
+ */
+export function formatCategoryLabel(raw: string, code: string | null | undefined): string {
+  if (!code) return raw;
+  // Only numeric-looking categories are formatted. `Number('')` and
+  // `Number('  ')` are 0 (falsely finite), so reject blank / whitespace text
+  // explicitly; keep genuine string categories (e.g. "Q1", "North") verbatim.
+  if (raw.trim() === '') return raw;
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return raw;
+  return formatChartValWithCode(num, code);
+}
+
+/**
  * True when `code` contains date tokens (m / d / y / h / s) outside of
  * quotes. Heuristic but robust: ECMA-376 number-format codes never use
  * those letters as numeric placeholders.

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -210,3 +210,76 @@ describe('CH1 — negative bar/column values extend from the zero line', () => {
     expect(nBar.h).toBeGreaterThan(0);
   });
 });
+
+describe('CH2 — stackedLine / stackedLinePct stack cumulatively', () => {
+  it('stackedLine plots the second series at the cumulative sum', () => {
+    // Two flat series (all 10, all 20). Stacked, the second line rides at
+    // y=30 across every category; unstacked it would ride at y=20. We detect
+    // stacking by the axis maximum: a cumulative 30 forces a taller axis than
+    // an un-stacked max of 20 would.
+    const stackedRec = recordingCtx();
+    renderChart(stackedRec.ctx, baseModel({
+      chartType: 'stackedLine',
+      categories: ['A', 'B', 'C'],
+      series: [
+        series({ name: 'S1', values: [10, 10, 10] }),
+        series({ name: 'S2', values: [20, 20, 20] }),
+      ],
+    }), RECT, 1);
+
+    const plainRec = recordingCtx();
+    renderChart(plainRec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C'],
+      series: [
+        series({ name: 'S1', values: [10, 10, 10] }),
+        series({ name: 'S2', values: [20, 20, 20] }),
+      ],
+    }), RECT, 1);
+
+    const stackedTop = Math.max(...stackedRec.texts
+      .map(t => Number(t.text)).filter(v => Number.isFinite(v)));
+    const plainTop = Math.max(...plainRec.texts
+      .map(t => Number(t.text)).filter(v => Number.isFinite(v)));
+    // Stacking pushes the cumulative maximum (30) above the plain per-series
+    // maximum (20), so the auto axis top must be strictly higher.
+    expect(stackedTop).toBeGreaterThan(plainTop);
+  });
+
+  it('stackedLinePct normalizes each category to 100%', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedLinePct',
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'S1', values: [10, 30] }),
+        series({ name: 'S2', values: [30, 10] }),
+      ],
+    }), RECT, 1);
+    const nums = rec.texts.map(t => Number(String(t.text).replace('%', '')))
+      .filter(v => Number.isFinite(v));
+    // The cumulative top series always reaches exactly 100% per category, so the
+    // axis carries a 100 gridline. Raw magnitudes (max cumulative 40) never
+    // appear — the axis is normalized, not driven by the raw sums.
+    expect(nums).toContain(100);
+    // ...and the axis top is a round value just above 100 (headroom), never the
+    // raw cumulative magnitude of 40.
+    expect(Math.max(...nums)).toBeGreaterThanOrEqual(100);
+    expect(Math.max(...nums)).toBeLessThanOrEqual(120);
+  });
+
+  it('plain line is unaffected (per-series max drives the axis)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'S1', values: [10, 10] }),
+        series({ name: 'S2', values: [20, 20] }),
+      ],
+    }), RECT, 1);
+    const top = Math.max(...rec.texts.map(t => Number(t.text)).filter(Number.isFinite));
+    // Un-stacked: axis reflects the single-series max (20) plus headroom, not 30.
+    expect(top).toBeLessThan(30);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -283,3 +283,55 @@ describe('CH2 — stackedLine / stackedLinePct stack cumulatively', () => {
     expect(top).toBeLessThan(30);
   });
 });
+
+describe('CH3 — labels are locale-independent (§18.8.30)', () => {
+  // `toLocaleString()` groups thousands in every common locale, so an explicit
+  // no-separator format code ("0") is the discriminator: the §18.8.30 engine
+  // honors it (no commas), while toLocaleString ignores it and always inserts
+  // the host locale's group separator. The old code called toLocaleString and
+  // dropped the format code entirely, so these tests were Red before the fix.
+  it('waterfall data labels honor the format code (no host-locale grouping)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'End'],
+      series: [series({ name: 'W', values: [1234567, 0] })],
+      subtotalIndices: [1],
+      dataLabelFormatCode: '0',
+    }), RECT, 1);
+    // The 1234567 subtotal bar's label must be un-grouped ("1234567"), proving
+    // it went through the §18.8.30 engine rather than toLocaleString().
+    expect(rec.texts.some(t => t.text.includes('1234567'))).toBe(true);
+    expect(rec.texts.every(t => !t.text.includes('1,234,567'))).toBe(true);
+  });
+
+  it('waterfall negative data labels keep the △ marker and honor the format code', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Drop', 'End'],
+      series: [series({ name: 'W', values: [2000000, -1234567, 765433] })],
+      subtotalIndices: [2],
+      dataLabelFormatCode: '0',
+    }), RECT, 1);
+    // Negative bar: △ prefix + un-grouped magnitude from the engine.
+    expect(rec.texts.some(t => t.text.includes('△') && t.text.includes('1234567'))).toBe(true);
+    expect(rec.texts.every(t => !t.text.includes('1,234,567'))).toBe(true);
+  });
+
+  it('waterfall value-axis labels honor the format code (through the §18.8.30 engine)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'End'],
+      series: [series({ name: 'W', values: [1000000, 0] })],
+      subtotalIndices: [1],
+      valAxisFormatCode: '0',
+    }), RECT, 1);
+    // A no-separator format code must suppress grouping. The old code ignored
+    // valAxisFormatCode and always grouped via toLocaleString(), so a "1,000,000"
+    // tick label would appear — after the fix the ticks are un-grouped.
+    expect(rec.texts.every(t => !t.text.includes('1,000,000'))).toBe(true);
+    expect(rec.texts.some(t => /^\d{4,}$/.test(t.text))).toBe(true);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -211,6 +211,217 @@ describe('CH1 — negative bar/column values extend from the zero line', () => {
   });
 });
 
+describe('CH6 — negative bar data-label placement mirrors the positive convention (§21.2.2.16)', () => {
+  // Coverage for drawBarDataLabel's `negative` branch. A single chart holds two
+  // categories with a symmetric +37 / -37 value, so BOTH bars share one plot and
+  // one axis (a symmetric ±37 range) — the geometry is a clean mirror across the
+  // zero line. For each dLblPos the negative label must land on the mirror side
+  // of the positive label relative to that shared zero line. "37" / "-37" are
+  // not round gridline values, so each data-label text is unambiguous among the
+  // recorded fillText calls, and each bar is matched to its label by the shared
+  // cross-axis center.
+  function renderMirrorBars(
+    chartType: 'clusteredBar' | 'clusteredBarH',
+    dataLabelPosition: string,
+  ): Recorded {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType,
+      categories: ['P', 'N'],
+      series: [series({ name: 'S', values: [37, -37] })],
+      showDataLabels: true,
+      dataLabelPosition,
+    }), RECT, 1);
+    return rec;
+  }
+  const labelPos = (rec: Recorded, text: string): TextCall => {
+    const hit = rec.texts.find(t => t.text === text);
+    expect(hit, `data label "${text}" was drawn`).toBeDefined();
+    return hit as TextCall;
+  };
+  // Match each value bar to its label by the cross-axis center they share
+  // (x-center for columns, y-center for horizontal bars).
+  const barFor = (rec: Recorded, lbl: TextCall, axis: 'v' | 'h'): RectCall => {
+    const center = (b: RectCall) => axis === 'v' ? b.x + b.w / 2 : b.y + b.h / 2;
+    const key = axis === 'v' ? lbl.x : lbl.y;
+    let best: RectCall | undefined;
+    let bestD = Infinity;
+    for (const b of rec.rects) {
+      const d = Math.abs(center(b) - key);
+      if (d < bestD) { bestD = d; best = b; }
+    }
+    expect(best).toBeDefined();
+    return best as RectCall;
+  };
+
+  describe('vertical columns', () => {
+    for (const pos of ['outEnd', 'inEnd', 'inBase', 'ctr']) {
+      it(`${pos}: the negative label mirrors the positive label across the zero line`, () => {
+        const rec = renderMirrorBars('clusteredBar', pos);
+        const posLbl = labelPos(rec, '37');
+        const negLbl = labelPos(rec, '-37');
+        const posBar = barFor(rec, posLbl, 'v');   // sits ABOVE the zero line
+        const negBar = barFor(rec, negLbl, 'v');   // hangs BELOW the zero line
+        // Each label is horizontally centered on its own bar.
+        expect(posLbl.x).toBeCloseTo(posBar.x + posBar.w / 2, 4);
+        expect(negLbl.x).toBeCloseTo(negBar.x + negBar.w / 2, 4);
+        // Symmetric ±37 → equal bar heights, bars meeting at the shared zero line.
+        expect(negBar.h).toBeCloseTo(posBar.h, 3);
+        const zeroLine = posBar.y + posBar.h;            // positive bottom == neg top
+        expect(negBar.y).toBeCloseTo(zeroLine, 3);
+        // The positive bar's value edge is its TOP; the negative's is its BOTTOM.
+        const posValueEdge = posBar.y;                   // top edge
+        const negValueEdge = negBar.y + negBar.h;        // bottom edge
+        if (pos === 'ctr') {
+          expect(posLbl.y).toBeCloseTo(posBar.y + posBar.h / 2, 4);
+          expect(negLbl.y).toBeCloseTo(negBar.y + negBar.h / 2, 4);
+          // The two centers are mirror images across the zero line.
+          expect(negLbl.y - zeroLine).toBeCloseTo(zeroLine - posLbl.y, 3);
+        } else if (pos === 'outEnd' || pos === 'inEnd') {
+          // Positive label offset from its top edge mirrors the negative label
+          // offset from its bottom edge (positive sits above → −, negative below → +).
+          const posOff = posLbl.y - posValueEdge;
+          const negOff = negLbl.y - negValueEdge;
+          expect(negOff).toBeCloseTo(-posOff, 3);
+        } else {
+          // inBase: anchored at the zero-line (base) edge for both signs.
+          const posBaseEdge = posBar.y + posBar.h;       // bottom (zero line)
+          const negBaseEdge = negBar.y;                  // top (zero line)
+          const posOff = posLbl.y - posBaseEdge;
+          const negOff = negLbl.y - negBaseEdge;
+          expect(negOff).toBeCloseTo(-posOff, 3);
+        }
+      });
+    }
+  });
+
+  describe('horizontal bars', () => {
+    for (const pos of ['outEnd', 'inEnd', 'inBase', 'ctr']) {
+      it(`${pos}: the negative label mirrors the positive label across the zero line`, () => {
+        const rec = renderMirrorBars('clusteredBarH', pos);
+        const posLbl = labelPos(rec, '37');
+        const negLbl = labelPos(rec, '-37');
+        const posBar = barFor(rec, posLbl, 'h');   // extends RIGHT of the zero line
+        const negBar = barFor(rec, negLbl, 'h');   // extends LEFT of the zero line
+        // Each label is vertically centered on its own bar. The recorded rect is
+        // fillRect(bx, by, barL, barW), so its HEIGHT is the bar thickness.
+        expect(posLbl.y).toBeCloseTo(posBar.y + posBar.h / 2, 4);
+        expect(negLbl.y).toBeCloseTo(negBar.y + negBar.h / 2, 4);
+        // Symmetric ±37 → equal bar lengths, meeting at the shared zero line.
+        expect(negBar.w).toBeCloseTo(posBar.w, 3);
+        const zeroLine = posBar.x;                        // positive left == neg right
+        expect(negBar.x + negBar.w).toBeCloseTo(zeroLine, 3);
+        if (pos === 'ctr') {
+          expect(posLbl.x).toBeCloseTo(posBar.x + posBar.w / 2, 4);
+          expect(negLbl.x).toBeCloseTo(negBar.x + negBar.w / 2, 4);
+          expect(negLbl.x - zeroLine).toBeCloseTo(zeroLine - posLbl.x, 3);
+        } else if (pos === 'outEnd' || pos === 'inEnd') {
+          // Positive value edge is the RIGHT edge; negative value edge the LEFT.
+          const posValueEdge = posBar.x + posBar.w;
+          const negValueEdge = negBar.x;
+          const posOff = posLbl.x - posValueEdge;
+          const negOff = negLbl.x - negValueEdge;
+          expect(negOff).toBeCloseTo(-posOff, 3);
+        } else {
+          // inBase: zero-line edge. Positive base is the LEFT edge, negative base
+          // the RIGHT edge — mirrored across the zero line.
+          const posBaseEdge = posBar.x;                  // left (zero line)
+          const negBaseEdge = negBar.x + negBar.w;       // right (zero line)
+          const posOff = posLbl.x - posBaseEdge;
+          const negOff = negLbl.x - negBaseEdge;
+          expect(negOff).toBeCloseTo(-posOff, 3);
+        }
+      });
+    }
+  });
+});
+
+describe('CH7 — percentStacked normalizes signed values against per-category Σ|v| (§21.2.2.76)', () => {
+  // Positive contributions stack up/right, negatives down/left; each series is
+  // normalized to (v / Σ|v|)·100 so the axis spans −100..100.
+  it('vertical percentStacked: positives stack above zero, negatives below, normalized to Σ|v|', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarPct',
+      categories: ['A'],
+      series: [
+        series({ name: 'P', values: [30] }),   // +30
+        series({ name: 'N', values: [-10] }),  // -10  → Σ|v| = 40
+      ],
+    }), RECT, 1);
+    const bars = rec.rects;
+    expect(bars.length).toBe(2);
+    const [p, nBar] = bars;
+    // Positive bar sits above the zero line, negative bar below; they meet at it.
+    expect(nBar.y).toBeCloseTo(p.y + p.h, 3);          // shared zero line
+    expect(nBar.y).toBeGreaterThan(p.y);               // negative is lower
+    // Normalized magnitudes: +30/40 = 75% up, -10/40 = 25% down. Same axis
+    // scale (px per percent) → the positive bar is 3× the negative bar's height.
+    expect(p.h / nBar.h).toBeCloseTo(3, 2);
+    // The value axis carries the ±100 percentStacked gridlines (plus headroom,
+    // so the outermost ticks sit at ±120, matching the line/area pct convention).
+    const nums = rec.texts.map(t => Number(String(t.text).replace('%', '')))
+      .filter(v => Number.isFinite(v));
+    expect(nums).toContain(100);
+    expect(nums).toContain(-100);
+    expect(Math.min(...nums)).toBeLessThanOrEqual(-100);
+    expect(Math.min(...nums)).toBeGreaterThanOrEqual(-120);
+    expect(Math.max(...nums)).toBeGreaterThanOrEqual(100);
+    expect(Math.max(...nums)).toBeLessThanOrEqual(120);
+  });
+
+  it('horizontal percentStacked: positives stack right, negatives left, normalized to Σ|v|', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarHPct',
+      categories: ['A'],
+      series: [
+        series({ name: 'P', values: [30] }),   // +30 → right
+        series({ name: 'N', values: [-10] }),  // -10 → left, Σ|v| = 40
+      ],
+    }), RECT, 1);
+    const bars = rec.rects;
+    expect(bars.length).toBe(2);
+    const [p, nBar] = bars;
+    // Positive bar extends right of the zero line, negative left; they meet at it.
+    expect(nBar.x + nBar.w).toBeCloseTo(p.x, 3);       // shared zero line
+    expect(nBar.x).toBeLessThan(p.x);                  // negative is to the left
+    // +30/40 = 75% right vs -10/40 = 25% left → 3× the width.
+    expect(p.w / nBar.w).toBeCloseTo(3, 2);
+    const nums = rec.texts.map(t => Number(String(t.text).replace('%', '')))
+      .filter(v => Number.isFinite(v));
+    expect(nums).toContain(100);
+    expect(nums).toContain(-100);
+    expect(Math.min(...nums)).toBeLessThanOrEqual(-100);
+    expect(Math.min(...nums)).toBeGreaterThanOrEqual(-120);
+    expect(Math.max(...nums)).toBeGreaterThanOrEqual(100);
+    expect(Math.max(...nums)).toBeLessThanOrEqual(120);
+  });
+
+  it('multi-category percentStacked: each category normalizes to its own Σ|v|', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarPct',
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'P', values: [10, 40] }),  // A: Σ|v|=20  B: Σ|v|=50
+        series({ name: 'N', values: [-10, -10] }),
+      ],
+    }), RECT, 1);
+    const bars = rec.rects;
+    // Two categories × two series = four bars, in draw order: A/P, A/N, B/P, B/N.
+    expect(bars.length).toBe(4);
+    const [aP, aN, bP, bN] = bars;
+    // Category A: 10 and -10 of Σ|v|=20 → 50% up, 50% down → equal heights.
+    expect(aP.h).toBeCloseTo(aN.h, 2);
+    // Category B: 40 and -10 of Σ|v|=50 → 80% up, 20% down → positive is 4× taller.
+    expect(bP.h / bN.h).toBeCloseTo(4, 2);
+    // Per-category normalization (not a global Σ): A's +50% bar and B's +80% bar
+    // are NOT the same height even though A/P is the larger raw share of A.
+    expect(bP.h).toBeGreaterThan(aP.h);
+  });
+});
+
 describe('CH2 — stackedLine / stackedLinePct stack cumulatively', () => {
   it('stackedLine plots the second series at the cumulative sum', () => {
     // Two flat series (all 10, all 20). Stacked, the second line rides at

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -326,6 +326,94 @@ describe('CH4 — stackedAreaPct normalizes like the line/bar percentStacked con
   });
 });
 
+describe('CH5 — category axis numFmt applies to category tick labels (§21.2.2.71)', () => {
+  // dateAx / numeric category axes cache the categories as Excel serial numbers
+  // ("44927"). Before the fix the renderer drew those raw serials; now the
+  // catAxisFormatCode is applied so a time-series line/bar shows real dates.
+  const DATE_CATS = ['44927', '44958', '44986']; // 2023-01-01 / 02-01 / 03-01
+
+  it('a line chart formats numeric-serial categories through the date code', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: DATE_CATS,
+      catAxisFormatCode: 'm/d/yyyy',
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+    }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels).toContain('1/1/2023');
+    expect(labels).toContain('2/1/2023');
+    expect(labels).toContain('3/1/2023');
+    // The raw serials must NOT appear as category labels anymore.
+    expect(labels.some(l => l === '44927')).toBe(false);
+  });
+
+  it('a column chart formats numeric-serial categories through the date code', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: DATE_CATS,
+      catAxisFormatCode: 'm/d/yyyy',
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+    }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels).toContain('1/1/2023');
+    expect(labels.some(l => l === '44927')).toBe(false);
+  });
+
+  it('a horizontal bar chart formats numeric-serial categories through the date code', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBarH',
+      categories: DATE_CATS,
+      catAxisFormatCode: 'm/d/yyyy',
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+    }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels).toContain('1/1/2023');
+    expect(labels.some(l => l === '44927')).toBe(false);
+  });
+
+  it('an area chart formats numeric-serial categories through the date code', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'area',
+      categories: DATE_CATS,
+      catAxisFormatCode: 'm/d/yyyy',
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+    }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels).toContain('1/1/2023');
+    expect(labels.some(l => l === '44927')).toBe(false);
+  });
+
+  it('string categories stay verbatim even when a format code is present', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['Q1', 'Q2', 'Q3'],
+      catAxisFormatCode: 'm/d/yyyy',
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+    }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels).toContain('Q1');
+    expect(labels).toContain('Q2');
+    expect(labels).toContain('Q3');
+  });
+
+  it('numeric categories with no format code render as raw text (unchanged)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: DATE_CATS,
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+    }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels).toContain('44927');
+    expect(labels.some(l => l === '1/1/2023')).toBe(false);
+  });
+});
+
 describe('CH3 — labels are locale-independent (§18.8.30)', () => {
   // `toLocaleString()` groups thousands in every common locale, so an explicit
   // no-separator format code ("0") is the discriminator: the §18.8.30 engine

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1,0 +1,212 @@
+// Behavioral tests for the chart-correctness fixes:
+//   CH1 — bar/column negative values extend downward from the zero line
+//   CH2 — stackedLine / stackedLinePct series are cumulatively stacked
+//   CH3 — tick / data labels use the locale-independent §18.8.30 formatter
+//
+// These assert observable geometry (fillRect bounds, gridline label text)
+// captured through a lightweight recording context, complementing the
+// draw-call-signature characterization test.
+
+import { describe, it, expect } from 'vitest';
+import type { ChartModel, ChartSeries, ChartRect } from '../types/chart';
+import { renderChart } from './renderer.js';
+
+interface RectCall { x: number; y: number; w: number; h: number; fs: string }
+interface TextCall { text: string; x: number; y: number }
+
+interface Recorded {
+  ctx: CanvasRenderingContext2D;
+  rects: RectCall[];
+  texts: TextCall[];
+}
+
+/** Minimal recording 2D context: captures fillRect + fillText, tracks the
+ *  handful of state props the renderer reads, and models text width. */
+function recordingCtx(): Recorded {
+  const rects: RectCall[] = [];
+  const texts: TextCall[] = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  const fontPx = (font: string): number => {
+    const m = /(\d+(?:\.\d+)?)px/.exec(font);
+    return m ? parseFloat(m[1]) : 10;
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => {
+            const px = fontPx(String(state.font));
+            let w = 0;
+            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+            return { width: w };
+          };
+        case 'fillRect':
+          return (x: number, y: number, w: number, h: number) =>
+            rects.push({ x, y, w, h, fs: String(state.fillStyle) });
+        case 'fillText':
+          return (text: string, x: number, y: number) => texts.push({ text, x, y });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        case 'save': case 'restore': case 'beginPath': case 'closePath':
+        case 'fill': case 'stroke': case 'moveTo': case 'lineTo': case 'arc':
+        case 'bezierCurveTo': case 'quadraticCurveTo': case 'rect':
+        case 'strokeRect': case 'clearRect': case 'strokeText': case 'setLineDash':
+        case 'translate': case 'rotate': case 'scale': case 'clip':
+        case 'setTransform': case 'resetTransform': case 'getTransform':
+          return () => undefined;
+        default:
+          return undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, rects, texts };
+}
+
+function baseModel(over: Partial<ChartModel>): ChartModel {
+  return {
+    chartType: 'clusteredBar',
+    title: null,
+    categories: [],
+    series: [],
+    showDataLabels: false,
+    valMin: null,
+    valMax: null,
+    catAxisTitle: null,
+    valAxisTitle: null,
+    catAxisHidden: false,
+    valAxisHidden: false,
+    catAxisLineHidden: false,
+    valAxisLineHidden: false,
+    plotAreaBg: null,
+    chartBg: null,
+    showLegend: false,
+    legendPos: null,
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'out',
+    catAxisMajorTickMark: 'out',
+    titleFontSizeHpt: null,
+    titleFontColor: null,
+    titleFontFace: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
+    subtotalIndices: [],
+    ...over,
+  };
+}
+
+function series(over: Partial<ChartSeries>): ChartSeries {
+  return { name: '', color: null, values: [], ...over };
+}
+
+const RECT: ChartRect = { x: 0, y: 0, w: 640, h: 360 };
+
+describe('CH1 — negative bar/column values extend from the zero line', () => {
+  it('a column chart draws negative bars below the zero line and positive bars above', () => {
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B'],
+      series: [series({ name: 'S', values: [10, -10] })],
+    });
+    renderChart(rec.ctx, model, RECT, 1);
+    const bars = rec.rects;
+    // Two bars, one per category.
+    expect(bars.length).toBe(2);
+    const [pos, neg] = bars;
+    // Symmetric data (+10 / -10) → the zero line sits mid-plot and the two bars
+    // have equal height. The positive bar's bottom edge equals the negative
+    // bar's top edge: they meet at the shared zero line.
+    const posBottom = pos.y + pos.h;
+    const negTop = neg.y;
+    expect(negTop).toBeCloseTo(posBottom, 4); // shared zero line
+    // Negative bar hangs BELOW the zero line, positive bar sits ABOVE it.
+    expect(neg.y).toBeGreaterThan(pos.y);
+    expect(neg.h).toBeGreaterThan(0);
+    // Equal magnitudes → equal bar heights.
+    expect(neg.h).toBeCloseTo(pos.h, 4);
+  });
+
+  it('the value axis includes negative tick labels when data dips below zero', () => {
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A'],
+      series: [series({ name: 'S', values: [-40] })],
+    });
+    renderChart(rec.ctx, model, RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels.some(l => l.startsWith('-'))).toBe(true);
+  });
+
+  it('a horizontal bar chart draws negative bars left of the zero line', () => {
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'clusteredBarH',
+      categories: ['A', 'B'],
+      series: [series({ name: 'S', values: [10, -10] })],
+    });
+    renderChart(rec.ctx, model, RECT, 1);
+    const bars = rec.rects;
+    expect(bars.length).toBe(2);
+    const [pos, neg] = bars;
+    // Positive bar starts at the zero line and extends right; negative bar ends
+    // at the zero line and extends left, so its right edge equals the positive
+    // bar's left edge.
+    expect(neg.x + neg.w).toBeCloseTo(pos.x, 4);
+    expect(neg.x).toBeLessThan(pos.x);
+    expect(neg.w).toBeCloseTo(pos.w, 4);
+  });
+
+  it('positive-only data keeps the axis anchored at 0 (pre-fix behavior)', () => {
+    // Regression guard: min degenerates to 0 so nothing about a positive-only
+    // chart changes. Zero-line bottom edge == plot bottom.
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B'],
+      series: [series({ name: 'S', values: [10, 20] })],
+    });
+    renderChart(rec.ctx, model, RECT, 1);
+    const bars = rec.rects;
+    expect(bars.length).toBe(2);
+    // All bars share the same bottom edge (the axis at 0), none extend below it.
+    const bottoms = bars.map(b => b.y + b.h);
+    expect(bottoms[0]).toBeCloseTo(bottoms[1], 4);
+    // No negative tick labels.
+    expect(rec.texts.every(t => !t.text.startsWith('-'))).toBe(true);
+  });
+
+  it('stacked columns accumulate positives up and negatives down separately', () => {
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'stackedBar',
+      categories: ['A'],
+      series: [
+        series({ name: 'P', values: [30] }),
+        series({ name: 'N', values: [-20] }),
+      ],
+    });
+    renderChart(rec.ctx, model, RECT, 1);
+    const bars = rec.rects;
+    expect(bars.length).toBe(2);
+    const [p, nBar] = bars;
+    // Positive bar sits above the zero line; negative bar below. They meet at
+    // the zero line (positive bottom == negative top).
+    expect(nBar.y).toBeCloseTo(p.y + p.h, 4);
+    expect(nBar.h).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -284,6 +284,48 @@ describe('CH2 — stackedLine / stackedLinePct stack cumulatively', () => {
   });
 });
 
+describe('CH4 — stackedAreaPct normalizes like the line/bar percentStacked convention', () => {
+  it('stackedAreaPct normalizes each category to 100%', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedAreaPct',
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'S1', values: [10, 30] }),
+        series({ name: 'S2', values: [30, 10] }),
+      ],
+    }), RECT, 1);
+    const nums = rec.texts.map(t => Number(String(t.text).replace('%', '')))
+      .filter(v => Number.isFinite(v));
+    // The cumulative top series always reaches exactly 100% per category, so the
+    // axis carries a 100 gridline. Raw magnitudes (max cumulative 40) never
+    // appear — the axis is normalized, not driven by the raw sums (this was Red
+    // before the fix: stackedAreaPct was treated identically to stackedArea, so
+    // the axis topped out at the raw cumulative 40 instead of 100).
+    expect(nums).toContain(100);
+    expect(Math.max(...nums)).toBeGreaterThanOrEqual(100);
+    expect(Math.max(...nums)).toBeLessThanOrEqual(120);
+  });
+
+  it('stackedArea (non-percent) is unaffected — axis reflects the raw cumulative sum', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedArea',
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'S1', values: [10, 30] }),
+        series({ name: 'S2', values: [30, 10] }),
+      ],
+    }), RECT, 1);
+    const nums = rec.texts.map(t => Number(String(t.text).replace('%', '')))
+      .filter(v => Number.isFinite(v));
+    // Raw cumulative max per category is 40 (10+30 / 30+10); the axis must scale
+    // to that magnitude, not be normalized to 100.
+    expect(Math.max(...nums)).toBeGreaterThanOrEqual(40);
+    expect(nums).not.toContain(100);
+  });
+});
+
 describe('CH3 — labels are locale-independent (§18.8.30)', () => {
   // `toLocaleString()` groups thousands in every common locale, so an explicit
   // no-separator format code ("0") is the discriminator: the §18.8.30 engine

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2355,7 +2355,10 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
     for (let v = Math.ceil(dataMin / step) * step; v <= dataMax; v += step) {
       const gy = py0 + ph * (1 - (v - dataMin) / padded);
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
-      ctx.fillText(v.toLocaleString(), px0 - 4, gy);
+      // Locale-independent §18.8.30 formatting (honoring `<c:valAx><c:numFmt>`),
+      // matching the other renderers — `toLocaleString()` grouped by the
+      // viewer's OS locale, so the same chart read differently across machines.
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
     }
   }
 
@@ -2422,9 +2425,14 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
     }
 
     const rawVal = vals[i] ?? 0;
+    // Locale-independent §18.8.30 formatting, honoring the data-label format
+    // code (chart-level `<c:dLbls><c:numFmt>` then the series `formatCode`),
+    // matching the bar renderer's data-label wiring. Negative bars keep the △
+    // marker and show the formatted magnitude below the bar.
+    const labelFormat = chart.dataLabelFormatCode ?? chart.series[0]?.valFormatCode ?? null;
     const labelText = rawVal < 0
-      ? `△ ${Math.abs(rawVal).toLocaleString()}`
-      : rawVal.toLocaleString();
+      ? `△ ${formatChartValWithCode(Math.abs(rawVal), labelFormat)}`
+      : formatChartValWithCode(rawVal, labelFormat);
     // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
     // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
     // then to neutral grey. PowerPoint paints negative-bar labels in

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1069,6 +1069,31 @@ function renderLineChart(
   const cats = chartCategories(chart);
   const n = cats.length; if (n === 0) return;
 
+  // stackedLine (`<c:grouping val="stacked">`) draws each series at the running
+  // sum of the series below it; stackedLinePct (`percentStacked`) normalizes
+  // each category to 100% (ECMA-376 §21.2.2.75). Plain `line` is unstacked.
+  const stacked = chart.chartType === 'stackedLine' || chart.chartType === 'stackedLinePct';
+  const pct = chart.chartType === 'stackedLinePct';
+  // Per-category |Σ| denominator for percent normalization (matches the bar
+  // percentStacked convention). Only computed when needed.
+  const pctTotals = pct
+    ? cats.map((_, ci) => {
+        let t = 0;
+        for (const s of chart.series) t += Math.abs(s.values[ci] ?? 0);
+        return t || 1;
+      })
+    : null;
+  // The plotted (cumulative) value for series `si` at category `ci`: the running
+  // sum of series 0..si, percent-normalized when pct. Un-stacked charts return
+  // the raw value. Null cells contribute 0 to the stack (matching the area
+  // renderer's `?? 0`); full dispBlanksAs support is tracked separately (CH9).
+  const plotted = (si: number, ci: number): number => {
+    if (!stacked) return chart.series[si].values[ci] as number;
+    let sum = 0;
+    for (let k = 0; k <= si; k++) sum += chart.series[k].values[ci] ?? 0;
+    return pct && pctTotals ? (sum / pctTotals[ci]) * 100 : sum;
+  };
+
   // Shared frame bands. The line family uses title pads 0.045 / 0.035 and the
   // default 0.22 side-legend reserve — passed as params so pixels are unchanged.
   // PowerPoint's auto-layout reserves a title band with air above and below
@@ -1112,8 +1137,17 @@ function renderLineChart(
     ctx.fillRect(px0, py0, pw, ph);
   }
 
+  // Axis extent is taken from the PLOTTED values, so a stacked chart's top line
+  // (the cumulative sum) drives the maximum rather than the tallest single
+  // series. Every category still contributes each series' cumulative value.
   let dataMin = Infinity; let dataMax = -Infinity;
-  for (const s of chart.series) for (const v of s.values) if (v != null) { dataMin = Math.min(dataMin, v); dataMax = Math.max(dataMax, v); }
+  for (let ci = 0; ci < n; ci++) {
+    for (let si = 0; si < chart.series.length; si++) {
+      if (!stacked && chart.series[si].values[ci] == null) continue;
+      const v = plotted(si, ci);
+      dataMin = Math.min(dataMin, v); dataMax = Math.max(dataMax, v);
+    }
+  }
   if (!isFinite(dataMin)) { dataMin = 0; dataMax = 1; }
   if (chart.valMin != null) dataMin = chart.valMin;
   else if (dataMin > 0) dataMin = 0;
@@ -1175,26 +1209,29 @@ function renderLineChart(
     ctx.beginPath();
     let started = false;
     for (let ci = 0; ci < n; ci++) {
-      const v = s.values[ci]; if (v == null) { started = false; continue; }
-      const px = toX(ci); const py = toY(v);
+      // Unstacked: a null cell breaks the line. Stacked: a null contributes 0
+      // to the running sum (no gap), matching the area renderer.
+      if (!stacked && s.values[ci] == null) { started = false; continue; }
+      const py = toY(plotted(si, ci)); const px = toX(ci);
       if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
     }
     ctx.stroke();
     ctx.fillStyle = color;
     // ECMA-376 §21.2.2.32 — when the series resolves to no marker, skip the
-    // data-point dots but keep data labels (which pin to each raw value, not
-    // to the marker).
+    // data-point dots but keep data labels. Markers / labels pin to the plotted
+    // (cumulative) value so they ride the stacked line, not the raw datum.
     const drawMarkers = s.showMarker !== false;
     for (let ci = 0; ci < n; ci++) {
-      const v = s.values[ci]; if (v == null) continue;
+      if (!stacked && s.values[ci] == null) continue;
+      const pv = plotted(si, ci);
       if (drawMarkers) {
-        ctx.beginPath(); ctx.arc(toX(ci), toY(v), markerR, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.arc(toX(ci), toY(pv), markerR, 0, Math.PI * 2); ctx.fill();
       }
       if (chart.showDataLabels) {
         ctx.font = `${dataLabelPx}px sans-serif`;
         ctx.fillStyle = '#333'; ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
         const labelOffset = drawMarkers ? markerR + 1 : 2;
-        ctx.fillText(formatChartVal(v), toX(ci), toY(v) - labelOffset);
+        ctx.fillText(formatChartVal(pv), toX(ci), toY(pv) - labelOffset);
         ctx.fillStyle = color;
       }
     }

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -15,7 +15,7 @@ import {
 } from './layout.js';
 import { niceStep, valueAxisScale } from './axis-scale.js';
 import { axisLineWidthPx, resolveAxisLine, isCrossBetween } from './axis-style.js';
-import { formatChartVal, formatChartValWithCode } from './chart-number-format.js';
+import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 import { elideToWidth } from './text-elide.js';
 import { hexToRgba } from '../shape/paint.js';
 import { EMU_PER_PT, PT_TO_PX } from '../units.js';
@@ -958,7 +958,9 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     const catSlotMaxPx = catGap - 4;
     const horizLabelMaxPx = (px0 - 4) - (x + legLeftW + valTitleW);
     for (let ci = 0; ci < n; ci++) {
-      const raw = (cats[ci] ?? '').toString();
+      // §21.2.2.71: a category-axis numFmt formats numeric-serial categories
+      // (e.g. dateAx serials → real dates). No-op for string categories.
+      const raw = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode);
       if (!isH) {
         const lx = px0 + ci * catGap + catGap / 2;
         ctx.textAlign = 'center'; ctx.textBaseline = 'top';
@@ -1249,7 +1251,10 @@ function renderLineChart(
       const tx = toX(ci);
       drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx);
       ctx.fillStyle = catLabelColor;
-      ctx.fillText(elideToWidth(ctx, (cats[ci] ?? '').toString(), catSlotMaxPx), tx, py0 + ph + 5);
+      // §21.2.2.71: format numeric-serial categories (e.g. dateAx) via the
+      // category-axis numFmt; string categories pass through unchanged.
+      const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode);
+      ctx.fillText(elideToWidth(ctx, label, catSlotMaxPx), tx, py0 + ph + 5);
     }
   }
 
@@ -1439,14 +1444,19 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     // CJK labels, which weakened the collision test) to pick the interval, then
     // draw each label elided to the room a drawn label actually owns —
     // (pw/n)·interval, the spacing between two drawn labels.
+    // §21.2.2.71: format numeric-serial categories (e.g. dateAx) via the
+    // category-axis numFmt before measuring and drawing; string categories
+    // pass through unchanged.
+    const labels = cats.map(c =>
+      formatCategoryLabel((c ?? '').toString(), chart.catAxisFormatCode));
     let maxLabelW = 0;
     for (let ci = 0; ci < n; ci++) {
-      maxLabelW = Math.max(maxLabelW, ctx.measureText((cats[ci] ?? '').toString()).width);
+      maxLabelW = Math.max(maxLabelW, ctx.measureText(labels[ci] ?? '').width);
     }
     const labelInterval = Math.max(1, Math.ceil((maxLabelW + 6) / (pw / n)));
     const catSlotMaxPx = (pw / n) * labelInterval - 4;
     for (let ci = 0; ci < n; ci += labelInterval) {
-      ctx.fillText(elideToWidth(ctx, (cats[ci] ?? '').toString(), catSlotMaxPx), toX(ci), py0 + ph + 3);
+      ctx.fillText(elideToWidth(ctx, labels[ci] ?? '', catSlotMaxPx), toX(ci), py0 + ph + 3);
     }
   }
 
@@ -1626,7 +1636,10 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
       align === 'right' ? lx - plotLeftX
         : align === 'left' ? plotRightX - lx
           : 2 * Math.min(plotRightX - lx, lx - plotLeftX);
-    ctx.fillText(elideToWidth(ctx, (cats[i] ?? '').toString(), maxPx), lx, ly);
+    // §21.2.2.71: format numeric-serial categories via the category-axis
+    // numFmt; string spoke labels pass through unchanged.
+    const label = formatCategoryLabel((cats[i] ?? '').toString(), chart.catAxisFormatCode);
+    ctx.fillText(elideToWidth(ctx, label, maxPx), lx, ly);
   }
 
   // ECMA-376 §21.2.3.10 c:radarStyle — "filled" closes the polygon with a
@@ -2487,7 +2500,10 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
   const labelY = py0 + ph + 4;
   for (let i = 0; i < n; i++) {
     const ccx = px0 + gapW * i + gapW / 2;
-    const lines = cats[i].split(/\s+/);
+    // §21.2.2.71: format numeric-serial categories via the category-axis
+    // numFmt; string transaction labels pass through unchanged.
+    const label = formatCategoryLabel(cats[i], chart.catAxisFormatCode);
+    const lines = label.split(/\s+/);
     lines.forEach((line, li) => ctx.fillText(line, ccx, labelY + li * (fontSize + 2)));
   }
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -448,44 +448,52 @@ function drawBarDataLabel(
   orient: 'vertical' | 'horizontal',
   position: string | null,
   color: string | null,
+  negative = false,
 ): void {
   const pos = (position ?? 'outEnd');
   const fill = color ? `#${color}` : '#333';
   ctx.fillStyle = fill;
   if (orient === 'vertical') {
-    // bx/by = top-left of bar rect (bar grows upward from by+barL toward by).
-    // barL here is bar height (pixels) and barW is bar width.
+    // bx/by = top-left of bar rect, barL = bar height, barW = bar width. For a
+    // positive column the value END is the TOP edge (`by`) and the BASE the
+    // bottom (`by + barL`); for a negative column those swap (the bar hangs
+    // below the zero line, so its end is the bottom).
     const cx = bx + barW / 2;
+    const endY  = negative ? by + barL : by;         // the far (value) edge
+    const baseY = negative ? by : by + barL;          // the zero-line edge
     if (pos === 'inBase') {
-      ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
-      ctx.fillText(text, cx, by + barL - 2);
+      ctx.textAlign = 'center'; ctx.textBaseline = negative ? 'top' : 'bottom';
+      ctx.fillText(text, cx, negative ? baseY + 2 : baseY - 2);
     } else if (pos === 'inEnd') {
-      ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-      ctx.fillText(text, cx, by + 2);
+      ctx.textAlign = 'center'; ctx.textBaseline = negative ? 'bottom' : 'top';
+      ctx.fillText(text, cx, negative ? endY - 2 : endY + 2);
     } else if (pos === 'ctr') {
       ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
       ctx.fillText(text, cx, by + barL / 2);
     } else {
-      // outEnd / default: just above the bar's top edge (by).
-      ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
-      ctx.fillText(text, cx, by - 1);
+      // outEnd / default: just beyond the value edge.
+      ctx.textAlign = 'center'; ctx.textBaseline = negative ? 'top' : 'bottom';
+      ctx.fillText(text, cx, negative ? endY + 1 : endY - 1);
     }
   } else {
-    // Horizontal: bar grows to the right from bx.
+    // Horizontal: positive bars grow to the RIGHT from bx, negative bars to the
+    // left (so the value END is the LEFT edge `bx` and the BASE the right edge).
     const cy = by + barW / 2;
+    const endX  = negative ? bx : bx + barL;          // the far (value) edge
+    const baseX = negative ? bx + barL : bx;          // the zero-line edge
     if (pos === 'inBase') {
-      ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, bx + 4, cy);
+      ctx.textAlign = negative ? 'right' : 'left'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, negative ? baseX - 4 : baseX + 4, cy);
     } else if (pos === 'inEnd') {
-      ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, bx + barL - 4, cy);
+      ctx.textAlign = negative ? 'left' : 'right'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, negative ? endX + 4 : endX - 4, cy);
     } else if (pos === 'ctr') {
       ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
       ctx.fillText(text, bx + barL / 2, cy);
     } else {
-      // outEnd / default: just past the bar's right edge.
-      ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, bx + barL + 2, cy);
+      // outEnd / default: just past the value edge.
+      ctx.textAlign = negative ? 'right' : 'left'; ctx.textBaseline = 'middle';
+      ctx.fillText(text, negative ? endX - 2 : endX + 2, cy);
     }
   }
 }
@@ -559,21 +567,44 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     : 0;
   const valAxisLenPt = (isH ? pwEst : phEst) / ptToPx;
 
+  // Value-axis extent. Bars extend from the zero line (the category-axis
+  // crossing) toward each value, so the axis must span both the positive and
+  // negative reach of the data (ECMA-376 §21.2.2.16 barChart). Negative values
+  // pull the axis minimum below 0; positive values push the maximum above it.
+  // Clustered charts take the raw extremes; stacked charts accumulate positive
+  // and negative contributions on separate sides of the zero line (Excel stacks
+  // opposite signs opposite ways), so `dataMax`/`dataMin` come from each
+  // category's positive-sum and negative-sum.
   let dataMax = 0;
+  let dataMin = 0;
   for (let ci = 0; ci < n; ci++) {
-    let stackSum = 0;
+    let posSum = 0;
+    let negSum = 0;
     for (const s of barSeries) {
       const v = s.values[ci] ?? 0;
-      if (stacked) stackSum += Math.abs(v);
-      else dataMax = Math.max(dataMax, Math.abs(v));
+      if (stacked) {
+        if (v >= 0) posSum += v; else negSum += v;
+      } else {
+        dataMax = Math.max(dataMax, v);
+        dataMin = Math.min(dataMin, v);
+      }
     }
-    if (stacked) dataMax = Math.max(dataMax, stackSum);
+    if (stacked) {
+      dataMax = Math.max(dataMax, posSum);
+      dataMin = Math.min(dataMin, negSum);
+    }
   }
-  if (pct) dataMax = 100;
+  if (pct) {
+    // percentStacked normalizes each category to Σ|v|; the axis spans the
+    // side(s) the data actually reaches (100% up if any positives, -100% down
+    // if any negatives).
+    dataMax = dataMax > 0 ? 100 : 0;
+    dataMin = dataMin < 0 ? -100 : 0;
+  }
   if (chart.valMax != null) dataMax = chart.valMax;
-  if (dataMax === 0) dataMax = 1;
-  // Bar/column anchors the value axis at 0; ignore the returned min.
-  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax, valAxisLenPt);
+  if (chart.valMin != null) dataMin = chart.valMin;
+  if (dataMax === 0 && dataMin === 0) dataMax = 1;
+  const { min: axMin, max: axMax, step } = valueAxisScale(dataMin, dataMax, chart.valMin, chart.valMax, valAxisLenPt);
 
   // Secondary value-axis scale (combo charts). INDEPENDENT of the primary: its
   // own "nice" major unit / gridline count. Its axis is the vertical right edge,
@@ -600,11 +631,12 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   if (!isH && !chart.valAxisHidden) {
     ctx.font = `${tickFontPx}px sans-serif`;
     let wmax = 0;
-    const vSteps = Math.round(axMax / step);
+    const vSteps = Math.round((axMax - axMin) / step);
     for (let si = 0; si <= vSteps; si++) {
+      const val = axMin + si * step;
       const label = pct
-        ? `${Math.round(si * step)}%`
-        : formatChartValWithCode(si * step, chart.valAxisFormatCode);
+        ? `${Math.round(val)}%`
+        : formatChartValWithCode(val, chart.valAxisFormatCode);
       wmax = Math.max(wmax, ctx.measureText(label).width);
     }
     valLabelBandW = wmax + 16; // ~12px tick+gap to the axis + ~4px to the title
@@ -672,11 +704,21 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // series bound to the secondary axis map through `toYSecondary`; everything
   // else uses the primary `axMax`.
   const sRange = (sMax - sMin) || 1;
-  const toYPrimaryLine = (v: number): number => py0 + ph - (v / axMax) * ph;
+  // Primary value → pixel. `axRange`/`axMin` generalize the old `v / axMax`
+  // mapping so the zero line sits wherever the axis crosses it (mid-plot when
+  // the data straddles zero); positive-only data keeps `axMin === 0`, so the
+  // mapping is unchanged. `valX`/`valY` give the on-axis pixel for a value on
+  // the value axis (X for horizontal bars, Y for columns).
+  const axRange = (axMax - axMin) || 1;
+  const valY = (v: number): number => py0 + ph - ((v - axMin) / axRange) * ph;
+  const valX = (v: number): number => px0 + ((v - axMin) / axRange) * pw;
+  const zeroY = valY(0); // column zero line
+  const zeroX = valX(0); // horizontal-bar zero line
+  const toYPrimaryLine = valY;
   const toYSecondary   = (v: number): number => py0 + ph - ((v - sMin) / sRange) * ph;
 
   const gridColor = '#e0e0e0';
-  const steps = Math.round(axMax / step);
+  const steps = Math.round(axRange / step);
   ctx.textBaseline = 'middle';
   ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
   // Honor `<c:valAx><c:txPr>…<a:solidFill>` when present (ECMA-376 §21.2.2.*);
@@ -686,19 +728,22 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
 
   if (!chart.valAxisHidden) {
     for (let si = 0; si <= steps; si++) {
-      const val = si * step;
+      const val = axMin + si * step;
+      // The zero line is the emphasized gridline (`si === 0` was that line only
+      // while the axis was anchored at 0; with a negative minimum it moves up).
+      const isZero = Math.abs(val) < step * 1e-9;
       const label = pct
         ? `${Math.round(val)}%`
         : formatChartValWithCode(val, chart.valAxisFormatCode);
       if (!isH) {
-        const gy = py0 + ph - (val / axMax) * ph;
-        strokeValueGridlineH(ctx, px0, pw, gy, si === 0);
+        const gy = valY(val);
+        strokeValueGridlineH(ctx, px0, pw, gy, isZero);
         ctx.textAlign = 'right';
         ctx.fillText(label, px0 - 12, gy);
       } else {
-        const gx = px0 + (val / axMax) * pw;
-        ctx.strokeStyle = si === 0 ? '#aaa' : gridColor;
-        ctx.lineWidth = si === 0 ? 1 : 0.5;
+        const gx = valX(val);
+        ctx.strokeStyle = isZero ? '#aaa' : gridColor;
+        ctx.lineWidth = isZero ? 1 : 0.5;
         ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
         ctx.textAlign = 'center';
         ctx.fillText(label, gx, py0 + ph + 10);
@@ -747,11 +792,11 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     // horizontal (bottom); a horizontal bar chart swaps the two.
     if (!chart.valAxisHidden && chart.valAxisMajorTickMark && chart.valAxisMajorTickMark !== 'none') {
       for (let si = 0; si <= steps; si++) {
-        const val = si * step;
+        const val = axMin + si * step;
         if (!isH) {
-          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, py0 + ph - (val / axMax) * ph, valLineColor, valLineW);
+          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, valY(val), valLineColor, valLineW);
         } else {
-          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'cat', py0 + ph, px0 + (val / axMax) * pw, valLineColor, valLineW);
+          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'cat', py0 + ph, valX(val), valLineColor, valLineW);
         }
       }
     }
@@ -796,7 +841,10 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const catStart   = (catGap - clusterWidth) / 2;
 
   for (let ci = 0; ci < n; ci++) {
-    let stackOffset = 0;
+    // Stacked charts accumulate positive and negative contributions on opposite
+    // sides of the zero line, so each category tracks two running offsets.
+    let posOffset = 0;
+    let negOffset = 0;
     let stackSum = 0;
     if (pct) {
       for (const s of barSeries) stackSum += Math.abs(s.values[ci] ?? 0);
@@ -806,18 +854,26 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     for (let si = 0; si < barSeries.length; si++) {
       const s = barSeries[si];
       const raw = s.values[ci] ?? 0;
-      const val = pct ? (Math.abs(raw) / stackSum) * 100 : Math.abs(raw);
+      // Signed value in axis units (percent keeps its sign — a negative slice of
+      // a percentStacked chart reaches below the zero line).
+      const sv = pct ? (raw / stackSum) * 100 : raw;
+      const negative = sv < 0;
       const color = chartColor(si, s);
 
       if (!isH) {
         const bx = stacked
           ? px0 + ci * catGap + catStart
           : px0 + ci * catGap + catStart + si * clusterGap;
-        const barH = (val / axMax) * ph;
-        const by   = py0 + ph - (stacked ? (stackOffset + val) : val) / axMax * ph;
+        // Column: the bar spans between the zero line and the value. Stacked
+        // bars start at the running offset for their sign; clustered bars start
+        // at the zero line.
+        const y0 = stacked ? valY(negative ? negOffset : posOffset) : zeroY;
+        const y1 = stacked ? valY((negative ? negOffset : posOffset) + sv) : valY(sv);
+        const by = Math.min(y0, y1);
+        const barH = Math.abs(y1 - y0);
         ctx.fillStyle = color;
         ctx.fillRect(bx, by, barW, barH);
-        if (chart.showDataLabels && val > 0) {
+        if (chart.showDataLabels && sv !== 0) {
           // ECMA-376 §21.2.2.30 / §21.1.2.3.10 — data label font size comes from
           // `<c:dLbls><c:txPr>...<a:defRPr@sz>` (hundredths of a point). When
           // the file specifies one we honor it; otherwise the proportional
@@ -827,9 +883,9 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             : Math.max(7, Math.min(11, barW * 0.6));
           ctx.font = `bold ${lsz}px sans-serif`;
           const text = pct
-            ? `${Math.round(val)}%`
+            ? `${Math.round(sv)}%`
             : formatChartValWithCode(
-                val,
+                sv,
                 chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
               );
           // drawBarDataLabel takes (bx, by, barL=length, barW=thickness). For
@@ -845,6 +901,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             'vertical',
             chart.dataLabelPosition ?? null,
             s.labelColor ?? chart.dataLabelFontColor ?? null,
+            negative,
           );
         }
       } else {
@@ -856,19 +913,21 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         const by = stacked
           ? py0 + (n - 1 - ci) * catGap + catStart
           : py0 + (n - 1 - ci) * catGap + catStart + siVisual * clusterGap;
-        const barL = (val / axMax) * pw;
-        const bx   = stacked ? px0 + (stackOffset / axMax) * pw : px0;
+        const x0 = stacked ? valX(negative ? negOffset : posOffset) : zeroX;
+        const x1 = stacked ? valX((negative ? negOffset : posOffset) + sv) : valX(sv);
+        const bx = Math.min(x0, x1);
+        const barL = Math.abs(x1 - x0);
         ctx.fillStyle = color;
         ctx.fillRect(bx, by, barL, barW);
-        if (chart.showDataLabels && val > 0) {
+        if (chart.showDataLabels && sv !== 0) {
           const lsz = chart.dataLabelFontSizeHpt
             ? (chart.dataLabelFontSizeHpt / 100) * ptToPx
             : Math.max(7, Math.min(11, barW * 0.6));
           ctx.font = `bold ${lsz}px sans-serif`;
           const text = pct
-            ? `${Math.round(val)}%`
+            ? `${Math.round(sv)}%`
             : formatChartValWithCode(
-                val,
+                sv,
                 chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
               );
           drawBarDataLabel(
@@ -877,10 +936,13 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             'horizontal',
             chart.dataLabelPosition ?? null,
             s.labelColor ?? chart.dataLabelFontColor ?? null,
+            negative,
           );
         }
       }
-      if (stacked) stackOffset += val;
+      if (stacked) {
+        if (negative) negOffset += sv; else posOffset += sv;
+      }
     }
   }
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1266,6 +1266,26 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const cats = chartCategories(chart);
   const n = cats.length; if (n === 0) return;
   const stacked = chart.chartType === 'stackedArea' || chart.chartType === 'stackedAreaPct';
+  // stackedAreaPct (`<c:grouping val="percentStacked">`, ECMA-376 §21.2.2.75)
+  // normalizes each category to its Σ|v| so the stack always tops out at 100%,
+  // matching the stackedLine/stackedLinePct (renderLineChart) and bar/column
+  // percentStacked convention (sign-preserving per-value normalization against
+  // the per-category |v| sum).
+  const pct = chart.chartType === 'stackedAreaPct';
+  const pctTotals = pct
+    ? cats.map((_, ci) => {
+        let t = 0;
+        for (const s of chart.series) t += Math.abs(s.values[ci] ?? 0);
+        return t || 1;
+      })
+    : null;
+  // The stacked (normalized when pct) contribution of series `si` at category
+  // `ci` — what actually gets added to the running stack base/top. Un-stacked
+  // charts never call this (raw values are used directly below).
+  const stackedValue = (si: number, ci: number): number => {
+    const raw = chart.series[si].values[ci] ?? 0;
+    return pct && pctTotals ? (raw / pctTotals[ci]) * 100 : raw;
+  };
 
   // Shared frame bands. Area uses title pads 0.035 / 0.035 and default 0.22
   // side-legend reserve — params keep pixels unchanged.
@@ -1306,12 +1326,15 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   for (let ci = 0; ci < n; ci++) {
     if (stacked) {
       let sum = 0;
-      for (const s of chart.series) sum += s.values[ci] ?? 0;
+      for (let si = 0; si < chart.series.length; si++) sum += stackedValue(si, ci);
       dataMax = Math.max(dataMax, sum);
     } else {
       for (const s of chart.series) dataMax = Math.max(dataMax, s.values[ci] ?? 0);
     }
   }
+  // percentStacked always tops out at exactly 100% (each category's Σ|v|
+  // normalizes to 100), matching the bar/line percentStacked axis convention.
+  if (pct) dataMax = dataMax > 0 ? 100 : 0;
   if (chart.valMax != null) dataMax = chart.valMax;
   if (dataMax === 0) dataMax = 1;
   // Area anchors the value axis at 0; ignore the returned min. Value axis is
@@ -1347,14 +1370,14 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ctx.beginPath();
     if (stacked && stackBase) {
       for (let ci = 0; ci < n; ci++) {
-        const v = (s.values[ci] ?? 0) + stackBase[ci];
+        const v = stackedValue(si, ci) + stackBase[ci];
         const px = toX(ci); const py = toY(v);
         if (ci === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
       }
       for (let ci = n - 1; ci >= 0; ci--) {
         ctx.lineTo(toX(ci), toY(stackBase[ci]));
       }
-      for (let ci = 0; ci < n; ci++) stackBase[ci] += s.values[ci] ?? 0;
+      for (let ci = 0; ci < n; ci++) stackBase[ci] += stackedValue(si, ci);
     } else {
       ctx.moveTo(toX(0), baseY);
       for (let ci = 0; ci < n; ci++) ctx.lineTo(toX(ci), toY(s.values[ci] ?? 0));

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1073,11 +1073,14 @@ function renderLineChart(
 
   // stackedLine (`<c:grouping val="stacked">`) draws each series at the running
   // sum of the series below it; stackedLinePct (`percentStacked`) normalizes
-  // each category to 100% (ECMA-376 §21.2.2.75). Plain `line` is unstacked.
+  // each category to 100% (ECMA-376 §21.2.2.76 c:grouping / §21.2.3.17
+  // ST_Grouping). Plain `line` is unstacked.
   const stacked = chart.chartType === 'stackedLine' || chart.chartType === 'stackedLinePct';
   const pct = chart.chartType === 'stackedLinePct';
   // Per-category |Σ| denominator for percent normalization (matches the bar
-  // percentStacked convention). Only computed when needed.
+  // percentStacked convention). The spec only mandates scaling to a 100% total;
+  // the Σ|v| denominator (and stacking negatives on the opposite side) is the
+  // Excel/PowerPoint behavior we match. Only computed when needed.
   const pctTotals = pct
     ? cats.map((_, ci) => {
         let t = 0;
@@ -1271,11 +1274,12 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const cats = chartCategories(chart);
   const n = cats.length; if (n === 0) return;
   const stacked = chart.chartType === 'stackedArea' || chart.chartType === 'stackedAreaPct';
-  // stackedAreaPct (`<c:grouping val="percentStacked">`, ECMA-376 §21.2.2.75)
-  // normalizes each category to its Σ|v| so the stack always tops out at 100%,
-  // matching the stackedLine/stackedLinePct (renderLineChart) and bar/column
-  // percentStacked convention (sign-preserving per-value normalization against
-  // the per-category |v| sum).
+  // stackedAreaPct (`<c:grouping val="percentStacked">`, ECMA-376 §21.2.2.76
+  // c:grouping / §21.2.3.17 ST_Grouping) normalizes each category so the stack
+  // tops out at 100%, matching the stackedLine/stackedLinePct (renderLineChart)
+  // and bar/column percentStacked convention. The spec only mandates scaling to
+  // a 100% total; the Σ|v| denominator (sign-preserving per-value normalization
+  // against the per-category |v| sum) is the Excel/PowerPoint behavior we match.
   const pct = chart.chartType === 'stackedAreaPct';
   const pctTotals = pct
     ? cats.map((_, ci) => {

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -159,9 +159,13 @@ pub(crate) fn parse_legacy_chart(
         None
     };
     let secondary_ax_id = secondary_val_ax.as_ref().and_then(ax_id_of);
+    // The category axis is `<c:catAx>` or, for a date/time-series X axis,
+    // `<c:dateAx>` (§21.2.2.39) — same child grammar, so every cat-axis read
+    // below (hidden, tick label size/color/bold, line style, tick marks, format
+    // code) treats them identically.
     let cat_ax = root
         .descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "catAx");
+        .find(|n| n.is_element() && matches!(n.tag_name().name(), "catAx" | "dateAx"));
     let (val_min, val_max) = val_ax
         .map(ooxml_common::chart::extract_axis_min_max)
         .unwrap_or((None, None));
@@ -620,6 +624,11 @@ pub(crate) fn parse_legacy_chart(
 
     // `<c:valAx><c:numFmt formatCode>` — value-axis tick label number format.
     let val_axis_format_code = val_ax.and_then(ooxml_common::chart::extract_axis_format_code);
+    // `<c:catAx|dateAx><c:numFmt formatCode>` — category-axis number format. For
+    // a `<c:dateAx>` this is the date serial format code (e.g. "m/d/yyyy") the TS
+    // side needs to format category labels. Reaches parity with the xlsx parser,
+    // which already wires this field (pptx previously hardcoded it to None).
+    let cat_axis_format_code = cat_ax.and_then(ooxml_common::chart::extract_axis_format_code);
 
     // Secondary value axis (combo charts) — parse the right-hand `<c:valAx>`
     // into a self-contained spec using the same shared helpers as the primary
@@ -743,10 +752,11 @@ pub(crate) fn parse_legacy_chart(
     let mut val_axis_title_size: Option<i32> = None;
     let mut val_axis_title_bold: Option<bool> = None;
     let mut val_axis_title_color: Option<String> = None;
-    for ax in plot_area.children().filter(|n| {
-        n.is_element() && (n.tag_name().name() == "catAx" || n.tag_name().name() == "valAx")
-    }) {
-        let is_cat = if ax.tag_name().name() == "catAx" {
+    for ax in plot_area
+        .children()
+        .filter(|n| n.is_element() && matches!(n.tag_name().name(), "catAx" | "dateAx" | "valAx"))
+    {
+        let is_cat = if matches!(ax.tag_name().name(), "catAx" | "dateAx") {
             true
         } else {
             // valAx: disambiguate by axPos (b/t → X/cat, l/r → Y/val).
@@ -873,7 +883,7 @@ pub(crate) fn parse_legacy_chart(
             cat_axis_crosses_at: None,
             val_axis_crosses: None,
             val_axis_crosses_at: None,
-            cat_axis_format_code: None,
+            cat_axis_format_code,
             cat_axis_min: None,
             cat_axis_max: None,
             radar_style: None,

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -5813,4 +5813,71 @@ mod tests {
             _ => unreachable!(),
         }
     }
+
+    /// A line chart whose horizontal axis is a `<c:dateAx>` (§21.2.2.39) — the
+    /// date/time-series category axis. `axis_inner` is spliced into the dateAx.
+    fn date_axis_chart_xml(axis_inner: &str) -> String {
+        format!(
+            r#"<?xml version="1.0"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="standard"/>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:cat><c:numRef><c:numCache>
+            <c:pt idx="0"><c:v>44927</c:v></c:pt>
+            <c:pt idx="1"><c:v>44958</c:v></c:pt>
+          </c:numCache></c:numRef></c:cat>
+          <c:val><c:numRef><c:numCache>
+            <c:pt idx="0"><c:v>10</c:v></c:pt>
+            <c:pt idx="1"><c:v>20</c:v></c:pt>
+          </c:numCache></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:dateAx>
+        <c:axId val="10"/>
+        <c:axPos val="b"/>
+        {axis}
+      </c:dateAx>
+      <c:valAx><c:axId val="20"/><c:axPos val="l"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>"#,
+            axis = axis_inner,
+        )
+    }
+
+    /// `<c:dateAx>` is recognized as the category axis: its `<c:numFmt>`
+    /// formatCode populates `cat_axis_format_code` so serial dates get formatted.
+    #[test]
+    fn date_axis_format_code_populates_cat_axis_format_code() {
+        let theme = HashMap::new();
+        let xml = date_axis_chart_xml(r#"<c:numFmt formatCode="m/d/yyyy" sourceLinked="0"/>"#);
+        let c = parse_legacy_chart(&xml, &theme).expect("dateAx chart should parse");
+        assert_eq!(c.chart.cat_axis_format_code.as_deref(), Some("m/d/yyyy"));
+    }
+
+    /// A dateAx title maps to the cat-axis title (same wiring as catAx).
+    #[test]
+    fn date_axis_title_maps_to_cat_axis_title() {
+        let theme = HashMap::new();
+        let title = r#"<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="1000"/></a:pPr>
+            <a:r><a:t>Date</a:t></a:r></a:p></c:rich></c:tx></c:title>"#;
+        let xml = date_axis_chart_xml(title);
+        let c = parse_legacy_chart(&xml, &theme).expect("dateAx chart should parse");
+        assert_eq!(c.chart.cat_axis_title.as_deref(), Some("Date"));
+        assert_eq!(c.chart.cat_axis_title_font_size_hpt, Some(1000));
+    }
+
+    /// A deleted dateAx hides the category axis.
+    #[test]
+    fn date_axis_delete_hides_cat_axis() {
+        let theme = HashMap::new();
+        let xml = date_axis_chart_xml(r#"<c:delete val="1"/>"#);
+        let c = parse_legacy_chart(&xml, &theme).expect("dateAx chart should parse");
+        assert!(c.chart.cat_axis_hidden);
+    }
 }

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1544,115 +1544,33 @@ pub(crate) fn parse_marker_block(
     (symbol, size, fill, line)
 }
 
-/// Locate the first `a:solidFill > a:srgbClr@val` or `a:schemeClr@val` under
-/// `node` (children only, not deep descendants — chart spPr is structured
-/// shallowly). Returns the resolved hex without `#`. Handles theme refs and
-/// `lumMod`/`lumOff`/`tint`/`shade`/`alpha` color transforms by delegating
-/// to `apply_color_transforms`.
+/// Locate the first resolvable `<a:solidFill>` among `parent`'s direct children
+/// (children only, not deep descendants — chart spPr is structured shallowly)
+/// and resolve its color to hex **without** `#` (uppercase). The chart wire
+/// model prepends `#` on the TS side, so this matches every other chart color
+/// field.
+///
+/// Delegates the DrawingML color grammar (`srgbClr`/`sysClr`/`prstClr`/
+/// `schemeClr` + `lumMod`/`lumOff`/`tint`/`shade`/`alpha` transforms) to the
+/// shared [`ooxml_common::color::parse_color_node`] via the crate-wide
+/// [`XlsxSchemeResolver`], so scheme slots resolve through the §20.1.6.2 default
+/// clrMap (`tx2`→`dk2`, `bg2`→`lt2`) and luminance transforms apply in HLS space
+/// (§20.1.2.3.20/.21). The prior private copy in this module mapped `bg2`/`tx2`
+/// to the wrong slots and multiplied `lumMod`/`lumOff` in RGB space.
 pub(crate) fn extract_solid_fill_in_drawingml(
     parent: &roxmltree::Node,
     theme_colors: &[String],
 ) -> Option<String> {
-    for fill in parent
+    parent
         .children()
         .filter(|n| n.is_element() && n.tag_name().name() == "solidFill")
-    {
-        for clr in fill.children().filter(|n| n.is_element()) {
-            match clr.tag_name().name() {
-                "srgbClr" => {
-                    if let Some(rgb) = clr.attribute("val") {
-                        return Some(apply_color_transforms(rgb, &clr));
-                    }
-                }
-                "schemeClr" => {
-                    if let Some(scheme) = clr.attribute("val") {
-                        let base = resolve_scheme_color(scheme, theme_colors);
-                        if let Some(b) = base {
-                            return Some(apply_color_transforms(&b, &clr));
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-    None
-}
-
-/// Look up a scheme color name ("dk1"/"lt1"/"dk2"/"lt2"/"accent1"…"accent6"
-/// /"hlink"/"folHlink") in the workbook theme color table. Returns hex
-/// (no `#`) or None when unknown.
-pub(crate) fn resolve_scheme_color(name: &str, theme_colors: &[String]) -> Option<String> {
-    // Theme order (parse_theme_colors): dk1@0, lt1@1, dk2@2, lt2@3,
-    // accent1@4..accent6@9, hlink@10, folHlink@11.
-    let idx = match name {
-        "dk1" | "tx1" | "bg2" => 0,
-        "lt1" | "bg1" | "tx2" => 1,
-        "dk2" => 2,
-        "lt2" => 3,
-        "accent1" => 4,
-        "accent2" => 5,
-        "accent3" => 6,
-        "accent4" => 7,
-        "accent5" => 8,
-        "accent6" => 9,
-        "hlink" => 10,
-        "folHlink" => 11,
-        _ => return None,
-    };
-    theme_colors
-        .get(idx)
-        .map(|s| s.trim_start_matches('#').to_string())
-}
-
-/// Apply DrawingML color transforms (`lumMod`/`lumOff`/`tint`/`shade`/
-/// `alpha` — drop alpha) found as children of a color element. Returns a
-/// hex string without `#`. Already-existing `apply_tint` handles
-/// lumMod-style brightness changes for the simpler `lumMod-only` case;
-/// this widens it to combine multiple transforms.
-pub(crate) fn apply_color_transforms(base_hex: &str, color_el: &roxmltree::Node) -> String {
-    let cleaned = base_hex.trim_start_matches('#');
-    let r = u8::from_str_radix(cleaned.get(0..2).unwrap_or("00"), 16).unwrap_or(0);
-    let g = u8::from_str_radix(cleaned.get(2..4).unwrap_or("00"), 16).unwrap_or(0);
-    let b = u8::from_str_radix(cleaned.get(4..6).unwrap_or("00"), 16).unwrap_or(0);
-    let mut rf = r as f64 / 255.0;
-    let mut gf = g as f64 / 255.0;
-    let mut bf = b as f64 / 255.0;
-    for child in color_el.children().filter(|n| n.is_element()) {
-        let pct = child
-            .attribute("val")
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|v| v / 100000.0);
-        let Some(p) = pct else { continue };
-        match child.tag_name().name() {
-            "lumMod" => {
-                rf *= p;
-                gf *= p;
-                bf *= p;
-            }
-            "lumOff" => {
-                rf += p;
-                gf += p;
-                bf += p;
-            }
-            "tint" => {
-                // ECMA-376: lighten toward 1.0 by `p` (0..1).
-                rf = rf + (1.0 - rf) * p;
-                gf = gf + (1.0 - gf) * p;
-                bf = bf + (1.0 - bf) * p;
-            }
-            "shade" => {
-                // Darken toward 0 by `1 - p`.
-                rf *= p;
-                gf *= p;
-                bf *= p;
-            }
-            // alpha is dropped — we render opaque.
-            _ => {}
-        }
-    }
-    let clamp = |v: f64| -> u8 { (v.clamp(0.0, 1.0) * 255.0).round() as u8 };
-    format!("{:02X}{:02X}{:02X}", clamp(rf), clamp(gf), clamp(bf))
+        .find_map(|fill| {
+            ooxml_common::color::parse_color_node(
+                fill,
+                &crate::drawing::XlsxSchemeResolver { theme_colors },
+                ooxml_common::color::TintMode::PowerPointLinear,
+            )
+        })
 }
 
 /// Walk every `<c:dPt>` direct child of the series and collect per-point
@@ -2803,5 +2721,94 @@ mod axis_title_and_border_tests {
         assert_eq!(chart.val_axis_title.as_deref(), Some("Period"));
         assert_eq!(chart.val_axis_title_size, Some(1800));
         assert_eq!(chart.val_axis_title_bold, None);
+    }
+}
+
+#[cfg(test)]
+mod solid_fill_color_tests {
+    use super::*;
+    use roxmltree::Document;
+
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    // Theme in clrScheme document order: dk1@0, lt1@1, dk2@2, lt2@3,
+    // accent1@4 … folHlink@11. Distinct hexes so a mis-index is obvious.
+    fn theme() -> Vec<String> {
+        vec![
+            "#111111".into(), // dk1 @0
+            "#FEFEFE".into(), // lt1 @1
+            "#222222".into(), // dk2 @2
+            "#EEEEEE".into(), // lt2 @3
+            "#4472C4".into(), // accent1 @4
+            "#00AA00".into(), // accent2 @5
+            "#0000AA".into(), // accent3 @6
+            "#AAAA00".into(), // accent4 @7
+            "#00AAAA".into(), // accent5 @8
+            "#AA00AA".into(), // accent6 @9
+            "#0563C1".into(), // hlink @10
+            "#954F72".into(), // folHlink @11
+        ]
+    }
+
+    fn solid_fill(inner: &str) -> String {
+        format!(r#"<a:spPr xmlns:a="{A_NS}"><a:solidFill>{inner}</a:solidFill></a:spPr>"#)
+    }
+
+    /// §20.1.6.2 default clrMap: `tx2` → `dk2` (theme slot 2), NOT `lt1`.
+    #[test]
+    fn scheme_tx2_resolves_to_dk2_slot() {
+        let xml = solid_fill(r#"<a:schemeClr val="tx2"/>"#);
+        let doc = Document::parse(&xml).unwrap();
+        let out = extract_solid_fill_in_drawingml(&doc.root_element(), &theme());
+        // tx2 → dk2 → theme[2] = "222222" (uppercase, no `#`).
+        assert_eq!(out.as_deref(), Some("222222"));
+    }
+
+    /// §20.1.6.2 default clrMap: `bg2` → `lt2` (theme slot 3), NOT `dk1`.
+    #[test]
+    fn scheme_bg2_resolves_to_lt2_slot() {
+        let xml = solid_fill(r#"<a:schemeClr val="bg2"/>"#);
+        let doc = Document::parse(&xml).unwrap();
+        let out = extract_solid_fill_in_drawingml(&doc.root_element(), &theme());
+        // bg2 → lt2 → theme[3] = "EEEEEE".
+        assert_eq!(out.as_deref(), Some("EEEEEE"));
+    }
+
+    /// tx1 → dk1 and bg1 → lt1 (unchanged, but pinned so a refactor can't drift).
+    #[test]
+    fn scheme_tx1_bg1_resolve_to_dk1_lt1() {
+        let tx1 = solid_fill(r#"<a:schemeClr val="tx1"/>"#);
+        let doc = Document::parse(&tx1).unwrap();
+        assert_eq!(
+            extract_solid_fill_in_drawingml(&doc.root_element(), &theme()).as_deref(),
+            Some("111111") // dk1 @0
+        );
+        let bg1 = solid_fill(r#"<a:schemeClr val="bg1"/>"#);
+        let doc = Document::parse(&bg1).unwrap();
+        assert_eq!(
+            extract_solid_fill_in_drawingml(&doc.root_element(), &theme()).as_deref(),
+            Some("FEFEFE") // lt1 @1
+        );
+    }
+
+    /// `lumMod` is a luminance modulation applied to the HLS `L` channel
+    /// (§20.1.2.3.20), NOT a per-RGB-component multiply. For `4472C4` at
+    /// `lumMod 50000`, the HLS result is `203864`; the (wrong) RGB-space
+    /// multiply would give `223962`.
+    #[test]
+    fn lummod_applies_in_hls_space_not_rgb() {
+        let xml = solid_fill(r#"<a:srgbClr val="4472C4"><a:lumMod val="50000"/></a:srgbClr>"#);
+        let doc = Document::parse(&xml).unwrap();
+        let out = extract_solid_fill_in_drawingml(&doc.root_element(), &theme());
+        assert_eq!(out.as_deref(), Some("203864"));
+    }
+
+    /// A plain srgbClr with no transforms passes through (uppercased, no `#`).
+    #[test]
+    fn plain_srgb_passthrough() {
+        let xml = solid_fill(r#"<a:srgbClr val="ff8000"/>"#);
+        let doc = Document::parse(&xml).unwrap();
+        let out = extract_solid_fill_in_drawingml(&doc.root_element(), &theme());
+        assert_eq!(out.as_deref(), Some("FF8000"));
     }
 }

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -651,7 +651,13 @@ pub(crate) fn parse_chart_xml(
         // Axis title + tick label font size extraction (ECMA-376 §21.2.2.17
         // c:txPr/a:defRPr@sz gives tick labels their hpt size; absent = default).
         match elem_name {
-            "catAx" => {
+            // `<c:dateAx>` (§21.2.2.39) is the date/time-series category axis:
+            // same child grammar as `<c:catAx>` (title, numFmt, delete, ticks,
+            // scaling, line style). Excel emits it when the category source is
+            // dates; the numFmt formatCode drives serial-date label formatting on
+            // the TS side. Advanced date-unit control (baseTimeUnit/majorTimeUnit)
+            // is out of scope here — treated identically to catAx.
+            "catAx" | "dateAx" => {
                 if cat_axis_title.is_none() {
                     let (t, sz, b, c) = extract_axis_title_with_props(&child, c_ns, a_ns);
                     if t.is_some() {
@@ -2810,5 +2816,83 @@ mod solid_fill_color_tests {
         let doc = Document::parse(&xml).unwrap();
         let out = extract_solid_fill_in_drawingml(&doc.root_element(), &theme());
         assert_eq!(out.as_deref(), Some("FF8000"));
+    }
+}
+
+#[cfg(test)]
+mod date_axis_tests {
+    use super::*;
+
+    const C_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    fn theme() -> Vec<String> {
+        vec!["#111111".into(); 12]
+    }
+
+    /// A line chart whose horizontal axis is a `<c:dateAx>` (§21.2.2.39), the
+    /// time-series category axis Excel emits when the category source is dates.
+    /// `axis_inner` is spliced into the `<c:dateAx>` element.
+    fn date_axis_chart_xml(axis_inner: &str) -> String {
+        format!(
+            r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="standard"/>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:cat><c:numRef><c:numCache>
+            <c:pt idx="0"><c:v>44927</c:v></c:pt><c:pt idx="1"><c:v>44958</c:v></c:pt>
+          </c:numCache></c:numRef></c:cat>
+          <c:val><c:numRef><c:numCache>
+            <c:pt idx="0"><c:v>10</c:v></c:pt><c:pt idx="1"><c:v>20</c:v></c:pt>
+          </c:numCache></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="1"/><c:axId val="2"/>
+      </c:lineChart>
+      <c:dateAx>
+        <c:axId val="2"/>
+        <c:axPos val="b"/>
+        {axis}
+      </c:dateAx>
+      <c:valAx><c:axId val="1"/><c:axPos val="l"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>"#,
+            c = C_NS,
+            a = A_NS,
+            axis = axis_inner,
+        )
+    }
+
+    /// `<c:dateAx>` is a category axis (§21.2.2.39): its `<c:numFmt>` formatCode
+    /// must populate `cat_axis_format_code` exactly as `<c:catAx>` does, so the
+    /// TS side formats the serial dates instead of showing raw numbers.
+    #[test]
+    fn date_axis_format_code_populates_cat_axis_format_code() {
+        let xml = date_axis_chart_xml(r#"<c:numFmt formatCode="m/d/yyyy" sourceLinked="0"/>"#);
+        let chart = parse_chart_xml(&xml, C_NS, A_NS, &theme()).expect("dateAx chart parses");
+        assert_eq!(chart.cat_axis_format_code.as_deref(), Some("m/d/yyyy"));
+    }
+
+    /// A deleted `<c:dateAx>` (`<c:delete val="1"/>`) hides the category axis,
+    /// matching the catAx convention.
+    #[test]
+    fn date_axis_delete_hides_cat_axis() {
+        let xml = date_axis_chart_xml(r#"<c:delete val="1"/>"#);
+        let chart = parse_chart_xml(&xml, C_NS, A_NS, &theme()).expect("dateAx chart parses");
+        assert!(chart.cat_axis_hidden);
+    }
+
+    /// A dateAx title maps to the cat-axis title (same as catAx).
+    #[test]
+    fn date_axis_title_maps_to_cat_axis_title() {
+        let title = r#"<c:title><c:tx><c:rich><a:p>
+            <a:r><a:rPr sz="1200"/><a:t>Date</a:t></a:r></a:p></c:rich></c:tx></c:title>"#;
+        let xml = date_axis_chart_xml(title);
+        let chart = parse_chart_xml(&xml, C_NS, A_NS, &theme()).expect("dateAx chart parses");
+        assert_eq!(chart.cat_axis_title.as_deref(), Some("Date"));
+        assert_eq!(chart.cat_axis_title_size, Some(1200));
     }
 }

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -268,8 +268,13 @@ pub(crate) fn parse_xfrm(xfrm_node: &roxmltree::Node) -> Option<Xfrm> {
 /// lt2, accent1..accent6, hlink, folHlink (see `parse_theme_colors`), each
 /// `#RRGGBB`. The `#` is stripped here because the shared transform wants clean
 /// hex; `parse_solid_fill` re-adds it for the returned color.
-struct XlsxSchemeResolver<'a> {
-    theme_colors: &'a [String],
+///
+/// Shared with the chart parser (`chart::extract_solid_fill_in_drawingml`) so a
+/// single positional-slot table serves every xlsx DrawingML color path — the
+/// chart module previously carried a private copy with `bg2`/`tx2` mapped to the
+/// wrong slots (§20.1.6.2).
+pub(crate) struct XlsxSchemeResolver<'a> {
+    pub(crate) theme_colors: &'a [String],
 }
 
 impl ooxml_common::color::ThemeResolver for XlsxSchemeResolver<'_> {


### PR DESCRIPTION
## Summary

Phase 1 chart-correctness batch from the 2026-07b improvement plan (CH1 + CH2 + CH3 + CH4 + CH11, plus one same-shape bug found during implementation).

- **CH1** (`b7158fb`) — bar/column charts drew negative values as positive upward bars. The value-axis range now derives from the real data minimum, and bars span between the zero line and the value in both orientations. Stacked charts accumulate positives and negatives on opposite sides; percentStacked preserves sign. Positive-only charts are byte-stable (proven by unchanged characterization snapshots).
- **CH2** (`ae4f39a`) — `stackedLine` / `stackedLinePct` rendered without stacking. Lines, markers, data labels, and the auto axis extent now read cumulative (and for pct, Σ|v|-normalized) values, mirroring the area implementation.
- **stackedAreaPct** (`1c56f66`) — found while implementing CH2: the area renderer never normalized `stackedAreaPct` either. Fixed with the same convention (§21.2.2.76 / §21.2.3.17 grouping).
- **CH3** (`c0807c7`) — xlsx chart color resolution went through a stale private copy that swapped the `bg2`/`tx2` clrMap slots (§20.1.6.2) and applied `lumMod`/`lumOff` in RGB space instead of HSL (§20.1.2.3.20/.21). Deleted the copy and delegated to `ooxml_common::color` via the shared `XlsxSchemeResolver`. Cross-check: pptx already delegates and had no bug; xlsx chart was the sole outlier.
- **CH4** (`1632797`, `a39eca8`) — `c:dateAx` (§21.2.2.39) was silently ignored by both xlsx and pptx parsers, so time-series charts lost their category labels. Both parsers now treat dateAx as a category axis (shared `EG_AxShared` structure), pptx additionally gained the previously-unwired `cat_axis_format_code`, and the core renderer now applies the category-axis number format to category tick labels (§21.2.2.71) across all category-axis families — so date serials render as formatted dates. Date-unit control (`baseTimeUnit` etc.) stays in Phase 2 CH6.
- **CH11** (`c2fa57a`) — chart numbers formatted with `toLocaleString()` depended on the viewer's OS locale. The remaining call sites (waterfall axis ticks and data labels; scatter was already correct) now use the locale-independent §18.8.30 engine, honoring `valAxisFormatCode` / `dataLabelFormatCode`.
- Review follow-ups (`2d677ef`, `e225268`) — added coverage for negative bar data-label placement and percentStacked negatives; corrected the percentStacked spec citations.

## Verification

- `pnpm test` — 1757 passed (199 files), including new Red-before-fix regression tests
- root `tsc --build` + sub-package typechecks — clean
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — clean (xlsx +8 tests, pptx +3)
- `pnpm build:wasm` + full local VRT — 163/163 passed (pptx 75 / docx 21 / xlsx 67), zero reference-image diffs
- Independent 4-dimension review (spec fidelity, correctness/edge cases, cross-package unification, test quality); all REQUEST_CHANGES items addressed in-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)