### PR TITLE
fix(xlsx): date1904 epoch support and Excel-faithful General number formatting

### DIFF
--- a/docs/improvement-plan-2026-07b-checklist.md
+++ b/docs/improvement-plan-2026-07b-checklist.md
@@ -41,8 +41,10 @@ node packages/node/src/bench-handle.mjs  # handle 反復 work ベンチ
 > CH1–CH4/CH11 は PR fix/chart-correctness(9 commits)。検証 = vitest 1757 / typecheck / cargo 3 点 / VRT 163 全 green・参照画像差分ゼロ。独立 4 観点レビュー(spec 忠実性・正しさ・横断統一・テスト品質)→ REQUEST_CHANGES 3 件(MAJOR)を修正済み。別トラック送りの発見: pptx の cat_axis_crosses/crossesAt None 固定(CH6 圏)、percentStacked 分母計算の三重実装の共通化(コスメティック)、stacked の null セル= dispBlanksAs zero 既定(CH9 圏)
 
 ### 正しさ(xlsx / DrawingML / docx)
-- [ ] XL1: date1904(+1900-02-29 バグ互換)
-- [ ] XL2: General 書式 11 有効桁
+- [x] XL1: date1904(+1900-02-29 バグ互換) — serial→date 変換を core `excel-date.ts` に集約(逆変換 `utcDateToExcelSerial` 込み、serial 60 は非生成)。**追加発見: 重複は 2 でなく 3 実装だった**(formula.ts の YEAR/MONTH/DAY/WEEKDAY 系も 1900 バグ未補正 → 委譲で解消)。**横断拡張: chart `c:date1904`(§21.2.2.38)も同じ穴** → ooxml-common `extract_chart_date1904` + xlsx/pptx 両パーサー + core renderer 全 19 箇所へ伝搬(chartEx は cx: スキーマに c:date1904 が無いため対象外)。chart spec の epoch 文言(Dec 31 基準)はセル定義 §18.17.4.1 と 1 日矛盾するため後者に統一(文言通りだと全日付が 1 日ズレることを数値検証)。TODAY/NOW volatile は「エンジンが 1900 系 serial を生成 → 1900 系で書式化」で自己一貫(formula エンジン自体の date1904 対応は別トラック)
+- [x] XL2: General 書式 11 有効桁 — `formatGeneralNumber`(toPrecision(11) + trailing zero 除去 + 12 桁以上/1e-6 未満は Excel 式指数表記 E+NN)。小さい数の切替閾値(< 1e-5)は Microsoft 未文書だが Excel 実挙動(1E-06)と一致する一貫則としてコメント明示(spec レビューで許容判定)。列幅依存の桁数調整はスコープ外と明記。チャートの `formatChartVal`(toFixed(6))は同じ穴でないことを確認し不変
+
+> XL1/XL2 は PR fix/xlsx-date-general(9 commits)。検証 = vitest 1806 / typecheck / cargo 3 点(304 tests)/ VRT 163 全 green・参照画像差分ゼロ。独立 4 観点レビュー → REQUEST_CHANGES 2 件(formula.ts の第 3 重複、TODAY/NOW×date1904 テスト欠落)+ LOW 群を全て同ブランチで解消。別トラック送り: formula エンジンへの date1904 伝搬(1904 ブックの TODAY() が 1904 系 serial を返すべき — 現設計は表示レベルで自己一貫)、mcp-server の cell_display は生値抽出面なので General 丸め対象外と判定
 - [ ] XF8: scrgbClr / hslClr / prstClr transforms
 - [ ] XF11: docx 下線 17 種(pptx drawUnderline の core hoist 込み)
 - [ ] XF12: cNvPr@hidden(3フォーマット)

--- a/packages/core/src/chart/chart-number-format.test.ts
+++ b/packages/core/src/chart/chart-number-format.test.ts
@@ -54,6 +54,24 @@ describe('formatChartValWithCode — percent & null', () => {
   });
 });
 
+describe('chart date1904 (c:date1904 §21.2.2.38 / §18.17.4.1)', () => {
+  it('formatChartValWithCode shifts a date serial to the 1904 epoch when date1904=true', () => {
+    // 1900-system serial 44927 and 1904-system serial 43465 are both
+    // 2023-01-01 (offset 1462 days).
+    expect(formatChartValWithCode(44927, 'yyyy-mm-dd')).toBe('2023-01-01');
+    expect(formatChartValWithCode(43465, 'yyyy-mm-dd', true)).toBe('2023-01-01');
+    // Same serial without the flag reads 1462 days early.
+    expect(formatChartValWithCode(43465, 'yyyy-mm-dd')).toBe('2018-12-31');
+  });
+  it('formatCategoryLabel threads date1904 to the date formatter', () => {
+    expect(formatCategoryLabel('43465', 'yyyy-mm-dd', true)).toBe('2023-01-01');
+    expect(formatCategoryLabel('43465', 'yyyy-mm-dd')).toBe('2018-12-31');
+  });
+  it('date1904 does not affect non-date (numeric) codes', () => {
+    expect(formatChartValWithCode(1234567, '#,##0', true)).toBe('1,234,567');
+  });
+});
+
 describe('formatCategoryLabel — category-axis numFmt (§21.2.2.71)', () => {
   it('formats a numeric serial category through a date code', () => {
     // 44927 = 2023-01-01 in the 1900 date system.

--- a/packages/core/src/chart/chart-number-format.ts
+++ b/packages/core/src/chart/chart-number-format.ts
@@ -26,7 +26,13 @@ export function formatChartVal(v: number): string {
  * unquoted. Returns the default `formatChartVal` output when `code` is null
  * or an empty section tells the caller to hide the value.
  */
-export function formatChartValWithCode(v: number, code: string | null | undefined): string {
+export function formatChartValWithCode(
+  v: number,
+  code: string | null | undefined,
+  /** Chart date system (`<c:date1904>`, §21.2.2.38). `true` resolves serial
+   *  date codes against the 1904 epoch. Defaults to false (1900 system). */
+  date1904 = false,
+): string {
   // Absent `code`, or the reserved "General" keyword (ECMA-376 §18.8.30), both
   // mean the General number format. LibreOffice charts emit
   // `<c:numFmt formatCode="General">`; tokenizing it as a literal pattern would
@@ -36,7 +42,7 @@ export function formatChartValWithCode(v: number, code: string | null | undefine
   // route to the date formatter. Charts use this on the X axis of scatter
   // / time-series charts where the value is a serial date.
   if (isDateFormatCode(code)) {
-    return formatExcelDate(v, code);
+    return formatExcelDate(v, code, date1904);
   }
   const sections = splitFormatSections(code);
   // Section selection per §18.8.30: positive;negative;zero;text. When the
@@ -66,7 +72,13 @@ export function formatChartValWithCode(v: number, code: string | null | undefine
  * missing code, `"General"`, or a non-numeric category string falls through
  * to the raw text unchanged — no new interpretation is invented.
  */
-export function formatCategoryLabel(raw: string, code: string | null | undefined): string {
+export function formatCategoryLabel(
+  raw: string,
+  code: string | null | undefined,
+  /** Chart date system (`<c:date1904>`, §21.2.2.38). Threaded to the date
+   *  formatter for serial-date category labels. Defaults to false. */
+  date1904 = false,
+): string {
   if (!code) return raw;
   // Only numeric-looking categories are formatted. `Number('')` and
   // `Number('  ')` are 0 (falsely finite), so reject blank / whitespace text
@@ -74,7 +86,7 @@ export function formatCategoryLabel(raw: string, code: string | null | undefined
   if (raw.trim() === '') return raw;
   const num = Number(raw);
   if (!Number.isFinite(num)) return raw;
-  return formatChartValWithCode(num, code);
+  return formatChartValWithCode(num, code, date1904);
 }
 
 /**

--- a/packages/core/src/chart/chart-number-format.ts
+++ b/packages/core/src/chart/chart-number-format.ts
@@ -5,6 +5,8 @@
 // literal escapes, thousands separators, decimals, percent, and Excel serial
 // dates.
 
+import { excelSerialToUtcDate } from '../excel-date';
+
 /** Excel's default `formatCode="General"` for charts: raw numbers with no
  *  "k"/"M" abbreviation, trailing decimal zeros trimmed. */
 export function formatChartVal(v: number): string {
@@ -100,19 +102,15 @@ function isDateFormatCode(code: string): boolean {
 }
 
 /**
- * Format an Excel serial date with the supplied code. Uses the conventional
- * 1900-based epoch with the spec's leap-year bug (i.e. serial 60 maps to
- * March 1, 1900, treating Feb 29, 1900 as a real day). For most chart
- * usage (post-1900 dates) this matches Excel's display.
+ * Format an Excel serial date with the supplied code. Delegates the serial →
+ * calendar-date conversion to the shared core `excelSerialToUtcDate`
+ * (ECMA-376 §18.17.4.1), which carries the 1900 Lotus leap-year-bug compat and
+ * the 1900/1904 date-system select. `date1904` comes from `<c:date1904>`
+ * (§21.2.2.38); it defaults to false so existing 1900-system charts are
+ * unchanged.
  */
-function formatExcelDate(serial: number, code: string): string {
-  // Days since 1899-12-30 (so serial 1 → 1900-01-01). The leap-year bug
-  // means serials 60..62 are off by one if you use a strict Date — we
-  // mimic Excel by subtracting an extra day for serials < 60.
-  const baseUtcMs = Date.UTC(1899, 11, 30);
-  const adjusted = serial < 60 ? serial + 1 : serial;
-  const ms = baseUtcMs + Math.floor(adjusted) * 86400000;
-  const date = new Date(ms);
+function formatExcelDate(serial: number, code: string, date1904 = false): string {
+  const date = excelSerialToUtcDate(Math.floor(serial), date1904);
   const yyyy = date.getUTCFullYear();
   const M = date.getUTCMonth() + 1;
   const D = date.getUTCDate();

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import type { ChartModel, ChartSeries, ChartRect } from '../types/chart';
 import { renderChart } from './renderer.js';
+import { formatChartValWithCode } from './chart-number-format.js';
 
 interface RectCall { x: number; y: number; w: number; h: number; fs: string }
 interface TextCall { text: string; x: number; y: number }
@@ -674,5 +675,46 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
     // tick label would appear — after the fix the ticks are un-grouped.
     expect(rec.texts.every(t => !t.text.includes('1,000,000'))).toBe(true);
     expect(rec.texts.some(t => /^\d{4,}$/.test(t.text))).toBe(true);
+  });
+});
+
+describe('scatter series data labels honor c:date1904 (§21.2.2.38)', () => {
+  // The scatter path was the one call site (of 18) that did not thread
+  // chart.date1904 into its data-label value formatter, so a date-format-code
+  // label rendered against the 1900 epoch even in a 1904 chart (1462 days off).
+  const SERIAL = 45292; // 1900-system 2024-01-01
+  function scatterWithDateLabel(date1904: boolean): TextCall[] {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'scatter',
+      date1904,
+      series: [series({
+        name: 'S',
+        // No categories → useIndexX; the y-value carries the serial date.
+        values: [SERIAL],
+        seriesDataLabels: {
+          showVal: true,
+          showCatName: false,
+          showSerName: false,
+          showPercent: false,
+          formatCode: 'd-mmm-yy',
+        },
+      })],
+    }), RECT, 1);
+    return rec.texts;
+  }
+
+  it('formats the data label against the chart date system (1900 vs 1904 differ)', () => {
+    const expected1900 = formatChartValWithCode(SERIAL, 'd-mmm-yy', false);
+    const expected1904 = formatChartValWithCode(SERIAL, 'd-mmm-yy', true);
+    // The two epochs are 1462 days apart, so the expected strings must differ —
+    // otherwise the test could not tell whether date1904 was threaded.
+    expect(expected1900).not.toBe(expected1904);
+
+    expect(scatterWithDateLabel(false).some(t => t.text === expected1900)).toBe(true);
+    expect(scatterWithDateLabel(true).some(t => t.text === expected1904)).toBe(true);
+    // Guard against a regression that ignores the flag: the 1904 chart must NOT
+    // emit the 1900-epoch label.
+    expect(scatterWithDateLabel(true).some(t => t.text === expected1900)).toBe(false);
   });
 });

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -636,7 +636,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       const val = axMin + si * step;
       const label = pct
         ? `${Math.round(val)}%`
-        : formatChartValWithCode(val, chart.valAxisFormatCode);
+        : formatChartValWithCode(val, chart.valAxisFormatCode, chart.date1904);
       wmax = Math.max(wmax, ctx.measureText(label).width);
     }
     valLabelBandW = wmax + 16; // ~12px tick+gap to the axis + ~4px to the title
@@ -652,7 +652,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     let wmax = 0;
     const sSteps = Math.round((sMax - sMin) / sStep);
     for (let si = 0; si <= sSteps; si++) {
-      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(sMin + si * sStep, sec.formatCode ?? null)).width);
+      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(sMin + si * sStep, sec.formatCode ?? null, chart.date1904)).width);
     }
     secLabelBandW = wmax + 18;
   }
@@ -734,7 +734,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       const isZero = Math.abs(val) < step * 1e-9;
       const label = pct
         ? `${Math.round(val)}%`
-        : formatChartValWithCode(val, chart.valAxisFormatCode);
+        : formatChartValWithCode(val, chart.valAxisFormatCode, chart.date1904);
       if (!isH) {
         const gy = valY(val);
         strokeValueGridlineH(ctx, px0, pw, gy, isZero);
@@ -887,6 +887,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             : formatChartValWithCode(
                 sv,
                 chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
+                chart.date1904,
               );
           // drawBarDataLabel takes (bx, by, barL=length, barW=thickness). For
           // a vertical column bar, "length" is the bar's height and
@@ -929,6 +930,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             : formatChartValWithCode(
                 sv,
                 chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
+                chart.date1904,
               );
           drawBarDataLabel(
             ctx, text,
@@ -960,7 +962,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     for (let ci = 0; ci < n; ci++) {
       // §21.2.2.71: a category-axis numFmt formats numeric-serial categories
       // (e.g. dateAx serials → real dates). No-op for string categories.
-      const raw = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode);
+      const raw = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
       if (!isH) {
         const lx = px0 + ci * catGap + catGap / 2;
         ctx.textAlign = 'center'; ctx.textBaseline = 'top';
@@ -1027,7 +1029,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         const gy = toYSecondary(sval);
         // Same tick geometry as the left axis, mirrored to the right edge.
         drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true);
-        ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null), axX + 14, gy);
+        ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, chart.date1904), axX + 14, gy);
       }
     }
     if (sec.title) {
@@ -1184,7 +1186,7 @@ function renderLineChart(
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy);
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 6, gy);
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
     }
   }
 
@@ -1256,7 +1258,7 @@ function renderLineChart(
       ctx.fillStyle = catLabelColor;
       // §21.2.2.71: format numeric-serial categories (e.g. dateAx) via the
       // category-axis numFmt; string categories pass through unchanged.
-      const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode);
+      const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
       ctx.fillText(elideToWidth(ctx, label, catSlotMaxPx), tx, py0 + ph + 5);
     }
   }
@@ -1409,7 +1411,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW);
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 6, gy);
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
     }
   }
   // Category-axis baseline + value-axis rule. `<c:*Ax><c:spPr><a:ln><a:noFill>`
@@ -1452,7 +1454,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     // category-axis numFmt before measuring and drawing; string categories
     // pass through unchanged.
     const labels = cats.map(c =>
-      formatCategoryLabel((c ?? '').toString(), chart.catAxisFormatCode));
+      formatCategoryLabel((c ?? '').toString(), chart.catAxisFormatCode, chart.date1904));
     let maxLabelW = 0;
     for (let ci = 0; ci < n; ci++) {
       maxLabelW = Math.max(maxLabelW, ctx.measureText(labels[ci] ?? '').width);
@@ -1642,7 +1644,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
           : 2 * Math.min(plotRightX - lx, lx - plotLeftX);
     // §21.2.2.71: format numeric-serial categories via the category-axis
     // numFmt; string spoke labels pass through unchanged.
-    const label = formatCategoryLabel((cats[i] ?? '').toString(), chart.catAxisFormatCode);
+    const label = formatCategoryLabel((cats[i] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
     ctx.fillText(elideToWidth(ctx, label, maxPx), lx, ly);
   }
 
@@ -1831,7 +1833,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ctx.strokeStyle = '#e0e0e0'; ctx.lineWidth = 0.5;
       ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
       ctx.fillStyle = '#555'; ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 4, gy);
       // Scatter keeps its own undefined colour default (→ drawAxisTick's '#888'),
       // so only the width formula is shared. `axisLineWidthPx`'s 1 px fallback is
       // equivalent to undefined here (drawAxisTick treats both as a hairline).
@@ -1899,7 +1901,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     for (let si = 0; si < xSteps; si++) {
       const v = xMin + si * xStep; if (v > xMax + xStep * 0.01) break;
       const gx = toX(v);
-      ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode), gx, xAxisY + 4);
+      ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode, chart.date1904), gx, xAxisY + 4);
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
       drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx));
     }
@@ -2398,7 +2400,7 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
       // Locale-independent §18.8.30 formatting (honoring `<c:valAx><c:numFmt>`),
       // matching the other renderers — `toLocaleString()` grouped by the
       // viewer's OS locale, so the same chart read differently across machines.
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode), px0 - 4, gy);
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 4, gy);
     }
   }
 
@@ -2471,8 +2473,8 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
     // marker and show the formatted magnitude below the bar.
     const labelFormat = chart.dataLabelFormatCode ?? chart.series[0]?.valFormatCode ?? null;
     const labelText = rawVal < 0
-      ? `△ ${formatChartValWithCode(Math.abs(rawVal), labelFormat)}`
-      : formatChartValWithCode(rawVal, labelFormat);
+      ? `△ ${formatChartValWithCode(Math.abs(rawVal), labelFormat, chart.date1904)}`
+      : formatChartValWithCode(rawVal, labelFormat, chart.date1904);
     // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
     // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
     // then to neutral grey. PowerPoint paints negative-bar labels in
@@ -2506,7 +2508,7 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
     const ccx = px0 + gapW * i + gapW / 2;
     // §21.2.2.71: format numeric-serial categories via the category-axis
     // numFmt; string transaction labels pass through unchanged.
-    const label = formatCategoryLabel(cats[i], chart.catAxisFormatCode);
+    const label = formatCategoryLabel(cats[i], chart.catAxisFormatCode, chart.date1904);
     const lines = label.split(/\s+/);
     lines.forEach((line, li) => ctx.fillText(line, ccx, labelY + li * (fontSize + 2)));
   }

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2012,7 +2012,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     }
 
     // Per-point data labels (`<c:dLbl idx>`) and series-level defaults.
-    drawSeriesDataLabels(ctx, s, cats, useIndexX, toX, toY, ph, ptToPx);
+    drawSeriesDataLabels(ctx, s, cats, useIndexX, toX, toY, ph, ptToPx, chart.date1904);
   }
 
   drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleBand.bandH + 2);
@@ -2204,6 +2204,10 @@ function drawSeriesDataLabels(
   toY: (v: number) => number,
   ph: number,
   ptToPx: number,
+  /** Chart date system (`<c:date1904>`, §21.2.2.38). Threaded so date-format
+   *  value labels resolve against the correct epoch. Defaults to false, which
+   *  also accepts the optional `ChartModel.date1904` when it is undefined. */
+  date1904 = false,
 ): void {
   const overrides = s.dataLabelOverrides ?? [];
   if (overrides.length === 0 && !s.seriesDataLabels) return;
@@ -2223,7 +2227,7 @@ function drawSeriesDataLabels(
       if (seriesDef.showCatName && !useIndexX) parts.push(cats[i] ?? '');
       if (seriesDef.showSerName) parts.push(s.name);
       if (seriesDef.showVal) {
-        parts.push(formatChartValWithCode(yv, seriesDef.formatCode ?? null));
+        parts.push(formatChartValWithCode(yv, seriesDef.formatCode ?? null, date1904));
       }
       text = parts.filter(Boolean).join(' ');
       if (!text) continue;

--- a/packages/core/src/excel-date.test.ts
+++ b/packages/core/src/excel-date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { excelSerialToUtcDate } from './excel-date';
+import { excelSerialToUtcDate, utcDateToExcelSerial } from './excel-date';
 
 // Helper: read back the calendar date a serial maps to, as YYYY-MM-DD in UTC.
 function iso(serial: number, date1904: boolean): string {
@@ -70,5 +70,48 @@ describe('excelSerialToUtcDate — 1904 date system (ECMA-376 §18.17.4.1)', () 
     expect(d.getUTCMonth() + 1).toBe(1);
     expect(d.getUTCDate()).toBe(1);
     expect(d.getUTCHours()).toBe(12);
+  });
+});
+
+describe('utcDateToExcelSerial — inverse of excelSerialToUtcDate', () => {
+  it('maps the 1900 leap-bug boundary dates to serials 1/59/61 (never 60)', () => {
+    const serial = (y: number, m: number, d: number): number =>
+      utcDateToExcelSerial(new Date(Date.UTC(y, m - 1, d)), false);
+    expect(serial(1900, 1, 1)).toBe(1);   // base + 1 day, serial < 60 branch
+    expect(serial(1900, 2, 28)).toBe(59); // last day before the phantom leap day
+    expect(serial(1900, 3, 1)).toBe(61);  // first day after it — skips serial 60
+  });
+
+  it('round-trips every 1900-system serial except the phantom 60', () => {
+    // serial → date → serial must be the identity for all valid serials. Serial
+    // 60 has no real Gregorian date so it is deliberately excluded.
+    for (let s = 0; s <= 200; s++) {
+      if (s === 60) continue;
+      const back = utcDateToExcelSerial(excelSerialToUtcDate(s, false), false);
+      expect(back).toBe(s);
+    }
+    // A modern serial round-trips too.
+    expect(utcDateToExcelSerial(excelSerialToUtcDate(45292, false), false)).toBe(45292);
+  });
+
+  it('the phantom serial 60 is never emitted by the inverse', () => {
+    // Both the serial-59 date (1900-02-28) and the serial-61 date (1900-03-01)
+    // sit on either side of the phantom day; neither reverse-maps to 60.
+    expect(utcDateToExcelSerial(excelSerialToUtcDate(59, false), false)).toBe(59);
+    expect(utcDateToExcelSerial(excelSerialToUtcDate(61, false), false)).toBe(61);
+  });
+
+  it('round-trips 1904-system serials (no leap-year bug)', () => {
+    for (let s = 0; s <= 200; s++) {
+      const back = utcDateToExcelSerial(excelSerialToUtcDate(s, true), true);
+      expect(back).toBe(s);
+    }
+    expect(utcDateToExcelSerial(excelSerialToUtcDate(43830, true), true)).toBe(43830);
+  });
+
+  it('preserves the fractional time-of-day component', () => {
+    // Serial 45292.5 = noon on 2024-01-01. The reverse must carry the .5 back.
+    const back = utcDateToExcelSerial(excelSerialToUtcDate(45292.5, false), false);
+    expect(back).toBe(45292.5);
   });
 });

--- a/packages/core/src/excel-date.test.ts
+++ b/packages/core/src/excel-date.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { excelSerialToUtcDate } from './excel-date';
+
+// Helper: read back the calendar date a serial maps to, as YYYY-MM-DD in UTC.
+function iso(serial: number, date1904: boolean): string {
+  const d = excelSerialToUtcDate(serial, date1904);
+  return `${d.getUTCFullYear().toString().padStart(4, '0')}-${(d.getUTCMonth() + 1)
+    .toString()
+    .padStart(2, '0')}-${d.getUTCDate().toString().padStart(2, '0')}`;
+}
+
+describe('excelSerialToUtcDate — 1900 date system (ECMA-376 §18.17.4.1)', () => {
+  it('maps serial 1 to 1900-01-01 (base date 1899-12-30 is serial 0)', () => {
+    expect(iso(1, false)).toBe('1900-01-01');
+  });
+
+  it('applies the Lotus 1900-02-29 leap-year bug: serial < 60 is shifted +1 day', () => {
+    // Serial 59 is the last serial before the phantom 1900-02-29. Without the
+    // +1 compat adjustment a naive epoch would render it 1900-02-27; Excel
+    // renders 1900-02-28.
+    expect(iso(59, false)).toBe('1900-02-28');
+  });
+
+  it('renders serial 61 as 1900-03-01 (the day after the phantom leap day)', () => {
+    // Serial 60 is the phantom 1900-02-29 (no adjustment); serial 61 is the
+    // first serial ≥ 60 and must land on 1900-03-01.
+    expect(iso(61, false)).toBe('1900-03-01');
+  });
+
+  it('serial 60 keeps the pre-existing core behaviour (no +1 shift, → 1900-02-28)', () => {
+    // 1900-02-29 does not exist in the proleptic Gregorian calendar. The
+    // existing core `formatExcelDate` treated serials ≥ 60 without the +1
+    // shift, so serial 60 lands on 1900-02-28. We deliberately preserve that.
+    expect(iso(60, false)).toBe('1900-02-28');
+  });
+
+  it('maps a modern serial correctly (45292 → 2024-01-01)', () => {
+    expect(iso(45292, false)).toBe('2024-01-01');
+  });
+
+  it('preserves the fractional time-of-day component', () => {
+    // Serial 1.5 = midday on 1900-01-01.
+    const d = excelSerialToUtcDate(1.5, false);
+    expect(d.getUTCFullYear()).toBe(1900);
+    expect(d.getUTCMonth() + 1).toBe(1);
+    expect(d.getUTCDate()).toBe(1);
+    expect(d.getUTCHours()).toBe(12);
+  });
+});
+
+describe('excelSerialToUtcDate — 1904 date system (ECMA-376 §18.17.4.1)', () => {
+  it('maps serial 0 to the 1904 base date 1904-01-01', () => {
+    expect(iso(0, true)).toBe('1904-01-01');
+  });
+
+  it('maps serial 1 to 1904-01-02 (no leap-year bug in the 1904 system)', () => {
+    expect(iso(1, true)).toBe('1904-01-02');
+  });
+
+  it('is offset exactly 1462 days from the 1900 system for the same calendar date', () => {
+    // 2024-01-01 is serial 45292 in the 1900 system and 43830 in the 1904
+    // system. 45292 − 43830 = 1462 (4 years + 1 day = the classic Mac shift).
+    expect(iso(43830, true)).toBe('2024-01-01');
+    expect(45292 - 43830).toBe(1462);
+  });
+
+  it('preserves the fractional time-of-day component', () => {
+    const d = excelSerialToUtcDate(0.5, true);
+    expect(d.getUTCFullYear()).toBe(1904);
+    expect(d.getUTCMonth() + 1).toBe(1);
+    expect(d.getUTCDate()).toBe(1);
+    expect(d.getUTCHours()).toBe(12);
+  });
+});

--- a/packages/core/src/excel-date.ts
+++ b/packages/core/src/excel-date.ts
@@ -49,3 +49,34 @@ export function excelSerialToUtcDate(serial: number, date1904 = false): Date {
   const adjusted = serial < 60 ? serial + 1 : serial;
   return new Date(BASE_1900_MS + adjusted * MS_PER_DAY);
 }
+
+/**
+ * Convert a UTC `Date` back to an Excel date-time serial — the exact inverse of
+ * {@link excelSerialToUtcDate} for every serial except the phantom 60.
+ *
+ * The fractional (time-of-day) part is preserved. For the 1900 date system the
+ * Lotus leap-year-bug compensation is undone so the round-trip holds:
+ *
+ *   • Dates on/before 1900-02-28 (raw offset ≤ 60 days from the 1899-12-30
+ *     base) map to serials 0…59 by subtracting the +1 day that
+ *     `excelSerialToUtcDate` added — 1900-01-01 → 1, 1900-02-28 → 59.
+ *   • Dates on/after 1900-03-01 (raw offset ≥ 61) map straight through —
+ *     1900-03-01 → 61, and so on.
+ *   • The phantom serial 60 (the non-existent 1900-02-29) is never produced:
+ *     the two branches meet at raw offset 60 → serial 59 and 61 → serial 61,
+ *     skipping 60 entirely.
+ *
+ * @param date     A UTC `Date` (read via its epoch milliseconds).
+ * @param date1904 `true` for the 1904 date system; `false`/omitted for 1900.
+ */
+export function utcDateToExcelSerial(date: Date, date1904 = false): number {
+  if (date1904) {
+    return (date.getTime() - BASE_1904_MS) / MS_PER_DAY;
+  }
+  // 1900 system: `rawDays` is the offset from the 1899-12-30 base, i.e. the
+  // "adjusted" value the forward function used. Raw offsets ≤ 60 correspond to
+  // serials < 60 (which had +1 added), so undo it; offsets ≥ 61 pass through.
+  // The boundary at 60 (→ serial 59) / 61 (→ serial 61) skips the phantom 60.
+  const rawDays = (date.getTime() - BASE_1900_MS) / MS_PER_DAY;
+  return rawDays <= 60 ? rawDays - 1 : rawDays;
+}

--- a/packages/core/src/excel-date.ts
+++ b/packages/core/src/excel-date.ts
@@ -14,6 +14,14 @@
 //     real Gregorian date; we leave it unshifted (→ 1900-02-28), matching the
 //     long-standing core behaviour rather than inventing a mapping.
 //
+//     The +1 compensation for serial < 60 is a deliberate choice to match
+//     Excel's on-screen rendering, not the literal base-date arithmetic of
+//     §18.17.4.1 (whose worked example puts serial 1.5 at 1899-12-31T12:00,
+//     which would render serial 1 as 1899-12-31). We render serial 1 as
+//     1900-01-01 because that is what Excel displays; the spec's base-date
+//     formula and Excel's display diverge for serials below the phantom leap
+//     day, and we follow Excel.
+//
 //   • 1904 date system: base date is 1904-01-01 (serial 0), so serial 1 →
 //     1904-01-02. This system has no leap-year bug. The 1904 base is exactly
 //     1462 days after the 1900 base date, which is why a Mac-authored (1904)

--- a/packages/core/src/excel-date.ts
+++ b/packages/core/src/excel-date.ts
@@ -1,0 +1,51 @@
+// Shared Excel serial-date → JS `Date` conversion (ECMA-376 §18.17.4.1).
+//
+// A "serial date-time" is a signed number of days relative to a base date. Two
+// base dates exist, selected by the `<workbookPr date1904>` attribute
+// (§18.2.28) for cells and by `<c:date1904>` (§21.2.2.38) for charts:
+//
+//   • 1900 date system (default): base date is 1899-12-30 (serial 0), so
+//     serial 1 → 1900-01-01. Excel additionally reproduces the Lotus 1-2-3
+//     leap-year bug, treating the non-existent 1900-02-29 as serial 60. That
+//     phantom day shifts every serial ≥ 60 forward by one relative to the
+//     proleptic Gregorian calendar, so to recover the correct calendar date we
+//     add one day back for serials < 60 (which sit before the phantom day and
+//     are therefore off by one under a bug-free epoch). Serial 60 itself has no
+//     real Gregorian date; we leave it unshifted (→ 1900-02-28), matching the
+//     long-standing core behaviour rather than inventing a mapping.
+//
+//   • 1904 date system: base date is 1904-01-01 (serial 0), so serial 1 →
+//     1904-01-02. This system has no leap-year bug. The 1904 base is exactly
+//     1462 days after the 1900 base date, which is why a Mac-authored (1904)
+//     workbook shows dates 1462 days off when read with a 1900 epoch.
+//
+// Times are carried by the fractional part of the serial (§18.17.4.2): 0.5 =
+// noon. All arithmetic is done in UTC so the caller reads `getUTC*` accessors
+// without local-timezone drift.
+
+const MS_PER_DAY = 86_400_000;
+
+// Base dates as UTC epoch milliseconds.
+//   1900: 1899-12-30 (serial 0)
+//   1904: 1904-01-01 (serial 0)
+const BASE_1900_MS = Date.UTC(1899, 11, 30);
+const BASE_1904_MS = Date.UTC(1904, 0, 1);
+
+/**
+ * Convert an Excel date-time serial to a UTC `Date`.
+ *
+ * @param serial   Signed serial date-time (integer part = day, fraction = time).
+ * @param date1904 `true` for the 1904 date system (Mac-authored workbooks /
+ *                 `<c:date1904 val="1">`); `false`/omitted for the default 1900
+ *                 date system.
+ */
+export function excelSerialToUtcDate(serial: number, date1904 = false): Date {
+  if (date1904) {
+    return new Date(BASE_1904_MS + serial * MS_PER_DAY);
+  }
+  // 1900 system: apply the Lotus leap-year-bug compensation. Serials < 60 sit
+  // before the phantom 1900-02-29 and are one day short under the bug-free
+  // 1899-12-30 epoch, so add a day back. Serials ≥ 60 need no adjustment.
+  const adjusted = serial < 60 ? serial + 1 : serial;
+  return new Date(BASE_1900_MS + adjusted * MS_PER_DAY);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -251,7 +251,7 @@ export { isCjkBreakChar, isLatinWordCodePoint } from './text/cjk-ranges';
 // Shared Excel serial-date → UTC `Date` conversion (ECMA-376 §18.17.4.1),
 // with the 1900 Lotus leap-year-bug compat and 1900/1904 date-system select.
 // Used by the xlsx cell formatter and the core chart date formatter.
-export { excelSerialToUtcDate } from './excel-date';
+export { excelSerialToUtcDate, utcDateToExcelSerial } from './excel-date';
 export { highlightBox } from './text/highlight-box';
 export {
   distributeLineSlack,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -248,6 +248,10 @@ export {
   crossRunKinsokuRetract,
 } from './text/kinsoku';
 export { isCjkBreakChar, isLatinWordCodePoint } from './text/cjk-ranges';
+// Shared Excel serial-date → UTC `Date` conversion (ECMA-376 §18.17.4.1),
+// with the 1900 Lotus leap-year-bug compat and 1900/1904 date-system select.
+// Used by the xlsx cell formatter and the core chart date formatter.
+export { excelSerialToUtcDate } from './excel-date';
 export { highlightBox } from './text/highlight-box';
 export {
   distributeLineSlack,

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -370,6 +370,15 @@ export interface ChartModel {
    * value axis (the common case). See {@link SecondaryValueAxis}.
    */
   secondaryValAxis?: SecondaryValueAxis | null;
+  /**
+   * `<c:date1904>` (ECMA-376 §21.2.2.38). When true the chart's serial
+   * date-times resolve against the 1904 date system (base 1904-01-01) instead
+   * of the default 1900 system. Threaded to the date formatters for date-axis
+   * category labels and value-axis tick labels. Omitted/false ⇒ 1900 system.
+   * Note: per §21.2.2.38 the element's `val` defaults to true when present but
+   * the attribute is omitted, so `<c:date1904/>` alone means date1904=true.
+   */
+  date1904?: boolean;
 }
 
 /**

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -165,6 +165,11 @@ pub struct ChartModel {
     pub radar_style: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secondary_val_axis: Option<SecondaryValueAxis>,
+    /// `<c:date1904>` (ECMA-376 §21.2.2.38). `true` = the chart's serial dates
+    /// resolve against the 1904 date system. Omitted from JSON when false (the
+    /// default 1900 system) for wire parity.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub date1904: bool,
 }
 
 /// Mirror of TS `ChartSeries`.
@@ -664,6 +669,21 @@ pub fn extract_axis_title_with_props(
 /// `@w` (EMU) is captured as `u32` regardless of the fill. `<a:schemeClr>` is
 /// intentionally left unresolved here (theme not wired through to chart border
 /// parsing yet).
+/// `<c:date1904>` (ECMA-376 §21.2.2.38) as a direct child of `<c:chartSpace>`.
+/// The element is a `CT_Boolean`: `val` defaults to `true` when the element is
+/// present but the attribute is omitted, so `<c:date1904/>` alone means
+/// date1904=true. `val="0"` / `"false"` disable it. Absent element ⇒ false (the
+/// default 1900 date system, §18.17.4.1).
+pub fn extract_chart_date1904(chart_space_root: Node) -> bool {
+    match child(chart_space_root, "date1904") {
+        Some(n) => match n.attribute("val") {
+            None => true, // element present, val implied true
+            Some(v) => v == "1" || v.eq_ignore_ascii_case("true"),
+        },
+        None => false,
+    }
+}
+
 pub fn extract_chart_space_border(chart_space_root: Node) -> (Option<String>, Option<u32>) {
     let Some(ln) = child(chart_space_root, "spPr").and_then(|sp| child(sp, "ln")) else {
         return (None, None);
@@ -977,6 +997,7 @@ mod tests {
             scatter_style: None,
             radar_style: None,
             secondary_val_axis: None,
+            date1904: false,
         };
         let v = serde_json::to_value(&m).unwrap();
         let obj = v.as_object().unwrap();
@@ -994,6 +1015,8 @@ mod tests {
         assert!(!obj.contains_key("barGapWidth"));
         assert!(!obj.contains_key("secondaryValAxis"));
         assert!(!obj.contains_key("catAxisFontColor"));
+        // date1904 is dropped from the wire when false (default 1900 system).
+        assert!(!obj.contains_key("date1904"));
         // Series: required present, optional dropped; array null preserved.
         let s0 = &obj["series"][0];
         assert_eq!(s0["name"], "S1");
@@ -1392,5 +1415,27 @@ mod tests {
             r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
         let d = root_of(xml);
         assert_eq!(extract_chart_space_border(d.root_element()), (None, None));
+    }
+
+    #[test]
+    fn chart_date1904_variants() {
+        // §21.2.2.38: CT_Boolean. Element present + val omitted ⇒ true.
+        let ns = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+        let bare = format!(r#"<c:chartSpace xmlns:c="{ns}"><c:date1904/></c:chartSpace>"#);
+        assert!(extract_chart_date1904(root_of(&bare).root_element()));
+
+        let one = format!(r#"<c:chartSpace xmlns:c="{ns}"><c:date1904 val="1"/></c:chartSpace>"#);
+        assert!(extract_chart_date1904(root_of(&one).root_element()));
+
+        let word =
+            format!(r#"<c:chartSpace xmlns:c="{ns}"><c:date1904 val="true"/></c:chartSpace>"#);
+        assert!(extract_chart_date1904(root_of(&word).root_element()));
+
+        let zero = format!(r#"<c:chartSpace xmlns:c="{ns}"><c:date1904 val="0"/></c:chartSpace>"#);
+        assert!(!extract_chart_date1904(root_of(&zero).root_element()));
+
+        // Absent element ⇒ false (default 1900 system).
+        let absent = format!(r#"<c:chartSpace xmlns:c="{ns}"/>"#);
+        assert!(!extract_chart_date1904(root_of(&absent).root_element()));
     }
 }

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -1434,6 +1434,12 @@ mod tests {
         let zero = format!(r#"<c:chartSpace xmlns:c="{ns}"><c:date1904 val="0"/></c:chartSpace>"#);
         assert!(!extract_chart_date1904(root_of(&zero).root_element()));
 
+        // Word form of the falsey value: `val="false"` also disables the 1904
+        // system (CT_Boolean accepts both "0" and "false").
+        let false_word =
+            format!(r#"<c:chartSpace xmlns:c="{ns}"><c:date1904 val="false"/></c:chartSpace>"#);
+        assert!(!extract_chart_date1904(root_of(&false_word).root_element()));
+
         // Absent element ⇒ false (default 1900 system).
         let absent = format!(r#"<c:chartSpace xmlns:c="{ns}"/>"#);
         assert!(!extract_chart_date1904(root_of(&absent).root_element()));

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -810,6 +810,11 @@ pub(crate) fn parse_legacy_chart(
     let (chart_border_color, chart_border_width_emu) =
         ooxml_common::chart::extract_chart_space_border(root);
 
+    // `<c:date1904>` (ECMA-376 §21.2.2.38) — direct child of `<c:chartSpace>`
+    // (`root`). Shared with the xlsx parser via ooxml-common so both honor the
+    // CT_Boolean implied-true semantics.
+    let date1904 = ooxml_common::chart::extract_chart_date1904(root);
+
     Some(ChartElement {
         x: 0,
         y: 0,
@@ -887,6 +892,7 @@ pub(crate) fn parse_legacy_chart(
             cat_axis_min: None,
             cat_axis_max: None,
             radar_style: None,
+            date1904,
         },
     })
 }
@@ -1135,6 +1141,10 @@ pub(crate) fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Optio
             cat_axis_min: None,
             cat_axis_max: None,
             radar_style: None,
+            // chartEx (cx: namespace) has its own date-axis model; the legacy
+            // `<c:date1904>` element does not apply here, so keep the 1900
+            // default until/unless a chartEx date system is wired.
+            date1904: false,
         },
     })
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1336,6 +1336,42 @@ mod tests {
     }
 
     #[test]
+    fn legacy_chart_honors_chart_space_date1904() {
+        // `<c:date1904/>` is a direct child of `<c:chartSpace>` (ECMA-376
+        // §21.2.2.38). It must thread through parse_legacy_chart into
+        // ChartModel.date1904 so date-format value labels resolve against the
+        // 1904 epoch. Absent element ⇒ the 1900 default (false).
+        let with = r#"<?xml version="1.0"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+ <c:date1904/>
+ <c:chart><c:plotArea><c:lineChart>
+  <c:ser>
+   <c:val><c:numRef><c:numCache><c:ptCount val="1"/><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+  </c:ser>
+ </c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>"#;
+        let chart = parse_legacy_chart(with, &HashMap::new()).expect("line chart should parse");
+        assert!(
+            chart.chart.date1904,
+            "<c:date1904/> must set ChartModel.date1904 = true"
+        );
+
+        let without = r#"<?xml version="1.0"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+ <c:chart><c:plotArea><c:lineChart>
+  <c:ser>
+   <c:val><c:numRef><c:numCache><c:ptCount val="1"/><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+  </c:ser>
+ </c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>"#;
+        let chart0 = parse_legacy_chart(without, &HashMap::new()).expect("line chart should parse");
+        assert!(
+            !chart0.chart.date1904,
+            "absent <c:date1904> must leave the 1900 default"
+        );
+    }
+
+    #[test]
     fn extract_image_reads_entry() {
         use std::io::{Cursor, Write};
         let mut buf = Vec::new();

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -240,6 +240,7 @@ impl From<ChartData> for ChartModel {
             scatter_style: None,
             radar_style: c.radar_style,
             secondary_val_axis: None,
+            date1904: c.date1904,
         }
     }
 }
@@ -543,6 +544,13 @@ pub(crate) fn parse_chart_xml(
     let (chart_border_color, chart_border_width_emu) = chart_space_root
         .map(ooxml_common::chart::extract_chart_space_border)
         .unwrap_or((None, None));
+
+    // `<c:date1904>` (ECMA-376 §21.2.2.38) — a direct child of `<c:chartSpace>`.
+    // Shared with the pptx chart parser via ooxml-common so both stay in
+    // lockstep on the CT_Boolean val semantics (implied-true when present).
+    let date1904 = chart_space_root
+        .map(ooxml_common::chart::extract_chart_date1904)
+        .unwrap_or(false);
 
     // `<c:title><c:layout><c:manualLayout>` (ECMA-376 §21.2.2.27).
     let title_manual_layout = chart_root
@@ -1070,6 +1078,7 @@ pub(crate) fn parse_chart_xml(
         val_axis_title_color,
         chart_border_color,
         chart_border_width_emu,
+        date1904,
     })
 }
 

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -2470,6 +2470,48 @@ mod pie_doughnut_tests {
         assert_eq!(m.chart_type, "line");
         assert!(m.series[0].categories.is_none());
     }
+
+    /// `<c:date1904/>` as a direct child of `<c:chartSpace>` (ECMA-376
+    /// §21.2.2.38) must surface as `ChartModel.date1904 = true`, threaded from
+    /// `parse_chart_xml` through the `ChartData → ChartModel` adapter. Absence
+    /// of the element leaves it at the default 1900 system (false).
+    #[test]
+    fn adapter_chart_space_date1904_element() {
+        let with = format!(
+            r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}">
+  <c:date1904/>
+  <c:chart><c:plotArea><c:lineChart>
+    <c:ser><c:idx val="0"/><c:order val="0"/>
+      <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+    </c:ser>
+  </c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>"#,
+            c = C_NS,
+            a = A_NS,
+        );
+        let m = ChartModel::from(parse_chart_xml(&with, C_NS, A_NS, &theme()).expect("parses"));
+        assert!(
+            m.date1904,
+            "<c:date1904/> must set ChartModel.date1904 = true"
+        );
+
+        let without = format!(
+            r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}">
+  <c:chart><c:plotArea><c:lineChart>
+    <c:ser><c:idx val="0"/><c:order val="0"/>
+      <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+    </c:ser>
+  </c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>"#,
+            c = C_NS,
+            a = A_NS,
+        );
+        let m0 = ChartModel::from(parse_chart_xml(&without, C_NS, A_NS, &theme()).expect("parses"));
+        assert!(
+            !m0.date1904,
+            "absent <c:date1904> must leave the 1900 default"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -85,6 +85,11 @@ struct WorkbookShared {
     sheets: Vec<SheetMeta>,
     theme_colors: Vec<String>,
     shared_strings: Vec<SharedString>,
+    /// Workbook date system (`<workbookPr date1904>`, ECMA-376 §18.2.28).
+    /// `true` = 1904 date system. Parsed once here and denormalized onto every
+    /// worksheet so the renderer/cell formatter can resolve serial dates
+    /// without a back-reference to the workbook.
+    date1904: bool,
 }
 
 impl WorkbookShared {
@@ -98,9 +103,12 @@ impl WorkbookShared {
     /// exactly as the old `?` on the rels read did.
     fn load(archive: &mut XlsxZip) -> Result<WorkbookShared, String> {
         let workbook_xml = read_zip_string(archive, "xl/workbook.xml")?;
-        let sheets = {
+        let (sheets, date1904) = {
             let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
-            parse_workbook_sheets(&wb_doc)
+            (
+                parse_workbook_sheets(&wb_doc),
+                parse_workbook_date1904(&wb_doc),
+            )
         };
         let rels_xml = read_zip_string(archive, "xl/_rels/workbook.xml.rels").unwrap_or_default();
         let theme_colors = parse_theme_colors(archive);
@@ -111,6 +119,7 @@ impl WorkbookShared {
             sheets,
             theme_colors,
             shared_strings,
+            date1904,
         })
     }
 }
@@ -169,6 +178,10 @@ fn parse_sheet_with(
     let (df_family, df_size) = parse_default_font(archive);
     ws.default_font_family = df_family;
     ws.default_font_size = df_size;
+    // Denormalize the workbook-wide date system onto this sheet so the cell
+    // formatter can resolve serial dates without a workbook back-reference
+    // (ECMA-376 §18.2.28 / §18.17.4.1).
+    ws.date1904 = shared.date1904;
 
     serde_json::to_vec(&ws).map_err(|e| JsValue::from_str(&e.to_string()))
 }
@@ -218,7 +231,10 @@ fn parse_xlsx_inner_with(
     }
 
     Ok(ParsedWorkbook {
-        workbook: Workbook { sheets },
+        workbook: Workbook {
+            sheets,
+            date1904: shared.date1904,
+        },
         styles,
         shared_strings: shared.shared_strings.clone(),
     })
@@ -472,6 +488,19 @@ pub(crate) fn resolve_color_attrs(
     }
 
     None
+}
+
+/// Parse the workbook-level date system from `<workbookPr date1904>`
+/// (ECMA-376 §18.2.28). The attribute is an xsd:boolean; `"1"` or `"true"`
+/// select the 1904 date system. Absent attribute / element ⇒ false (the
+/// default 1900 date system). See §18.17.4.1 for the date-system definitions.
+fn parse_workbook_date1904(doc: &roxmltree::Document) -> bool {
+    let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    doc.descendants()
+        .find(|n| n.tag_name().name() == "workbookPr" && n.tag_name().namespace() == Some(ns))
+        .and_then(|n| n.attribute("date1904"))
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 fn parse_workbook_sheets(doc: &roxmltree::Document) -> Vec<SheetMeta> {
@@ -1274,6 +1303,10 @@ fn parse_worksheet(
             sparkline_groups: Vec::new(),
             default_font_family: None,
             default_font_size: None,
+            // Set by `parse_sheet_with` from the workbook-level `<workbookPr
+            // date1904>` (ECMA-376 §18.2.28); a bare `parse_worksheet` (tests)
+            // defaults to the 1900 date system.
+            date1904: false,
         },
         hyperlink_rids,
     ))
@@ -2672,5 +2705,47 @@ mod sheet_visibility_tests {
         assert_eq!(sheets[1].visibility, SheetVisibility::Hidden);
         assert_eq!(sheets[2].visibility, SheetVisibility::VeryHidden);
         assert_eq!(sheets[3].visibility, SheetVisibility::Visible);
+    }
+}
+
+#[cfg(test)]
+mod date1904_tests {
+    use super::*;
+
+    fn parse(xml: &str) -> bool {
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        parse_workbook_date1904(&doc)
+    }
+
+    #[test]
+    fn workbook_pr_date1904_true() {
+        // ECMA-376 §18.2.28: date1904="1" ⇒ 1904 date system.
+        let xml = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><workbookPr date1904="1"/></workbook>"#;
+        assert!(parse(xml));
+    }
+
+    #[test]
+    fn workbook_pr_date1904_true_word() {
+        let xml = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><workbookPr date1904="true"/></workbook>"#;
+        assert!(parse(xml));
+    }
+
+    #[test]
+    fn workbook_pr_date1904_false() {
+        let xml = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><workbookPr date1904="0"/></workbook>"#;
+        assert!(!parse(xml));
+    }
+
+    #[test]
+    fn workbook_pr_absent_attr_defaults_false() {
+        // §18.2.28: absent attribute ⇒ 1900 date system (false).
+        let xml = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><workbookPr showObjects="all"/></workbook>"#;
+        assert!(!parse(xml));
+    }
+
+    #[test]
+    fn workbook_pr_absent_element_defaults_false() {
+        let xml = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheets/></workbook>"#;
+        assert!(!parse(xml));
     }
 }

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2749,3 +2749,54 @@ mod date1904_tests {
         assert!(!parse(xml));
     }
 }
+
+#[cfg(test)]
+mod date1904_wire_shape_tests {
+    // Wire-parity guard for the `date1904` field on `Workbook` / `Worksheet`:
+    // it must be dropped from the JSON when false (default 1900 system, keeps
+    // existing snapshots byte-stable) and present when true. Mirrors the
+    // `chart_model_serializes_canonical_shape` approach in ooxml-common.
+    use super::*;
+
+    fn workbook(date1904: bool) -> Workbook {
+        Workbook {
+            sheets: Vec::new(),
+            date1904,
+        }
+    }
+
+    fn worksheet(date1904: bool) -> Worksheet {
+        // Parse a minimal sheet so every non-date1904 field is default-populated
+        // (robust to future field additions), then set the flag under test.
+        let xml = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>"#;
+        let (mut ws, _) = parse_worksheet(xml, &[], &[], "Sheet1").expect("worksheet parses");
+        ws.date1904 = date1904;
+        ws
+    }
+
+    #[test]
+    fn workbook_date1904_false_is_omitted_from_wire() {
+        let v = serde_json::to_value(workbook(false)).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(!obj.contains_key("date1904"));
+    }
+
+    #[test]
+    fn workbook_date1904_true_is_serialized() {
+        let v = serde_json::to_value(workbook(true)).unwrap();
+        assert_eq!(v.get("date1904").and_then(|d| d.as_bool()), Some(true));
+    }
+
+    #[test]
+    fn worksheet_date1904_false_is_omitted_from_wire() {
+        let v = serde_json::to_value(worksheet(false)).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(!obj.contains_key("date1904"));
+    }
+
+    #[test]
+    fn worksheet_date1904_true_is_serialized() {
+        let v = serde_json::to_value(worksheet(true)).unwrap();
+        assert_eq!(v.get("date1904").and_then(|d| d.as_bool()), Some(true));
+    }
+}

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -790,6 +790,10 @@ pub struct ChartData {
     /// None = unset (renderer uses a 1px hairline when a color is present).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chart_border_width_emu: Option<u32>,
+    /// `<c:date1904>` (ECMA-376 §21.2.2.38). `true` = the chart's serial dates
+    /// resolve against the 1904 date system. Default false (1900 system).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub date1904: bool,
 }
 
 /// Generic `<c:manualLayout>` block (used for title, plotArea, legend).

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -5,6 +5,12 @@ use std::collections::BTreeMap;
 #[serde(rename_all = "camelCase")]
 pub struct Workbook {
     pub sheets: Vec<SheetMeta>,
+    /// Workbook date system (`<workbookPr date1904>`, ECMA-376 §18.2.28).
+    /// `true` selects the 1904 date system (Mac-authored workbooks). Serial
+    /// dates in cells are resolved against this base (§18.17.4.1). Omitted from
+    /// JSON when false (the default 1900 system) for wire parity.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub date1904: bool,
 }
 
 /// Sheet visibility (`<sheet state>`, ECMA-376 §18.2.19 `ST_SheetState`).
@@ -138,6 +144,12 @@ pub struct Worksheet {
     /// Used together with `default_font_family` to compute Max Digit Width.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_font_size: Option<f64>,
+    /// Workbook date system (`<workbookPr date1904>`, ECMA-376 §18.2.28),
+    /// denormalized onto every worksheet so the cell formatter can resolve
+    /// serial dates (§18.17.4.1) without a workbook back-reference. `true` =
+    /// 1904 date system. Omitted from JSON when false (default 1900 system).
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub date1904: bool,
 }
 
 /// Single sparkline group (`<x14:sparklineGroup>`). Holds the shared formatting

--- a/packages/xlsx/src/formula.test.ts
+++ b/packages/xlsx/src/formula.test.ts
@@ -113,4 +113,57 @@ describe('evalFormulaToBool — DATE', () => {
     expect(ev('DATE(2024,1,1)=45292')).toBe(true);
     expect(ev('DATE(2024,1,15)=45306')).toBe(true);
   });
+
+  it('maps the 1900 leap-bug boundary to serials 1/59/61 (never the phantom 60)', () => {
+    // Now that DATE delegates to the shared excel-date module, the 1900 Lotus
+    // leap-year-bug compensation is honoured: 1900-01-01 → 1, 1900-02-28 → 59,
+    // and 1900-03-01 → 61. Serial 60 (the non-existent 1900-02-29) is skipped.
+    expect(ev('DATE(1900,1,1)=1')).toBe(true);
+    expect(ev('DATE(1900,2,28)=59')).toBe(true);
+    expect(ev('DATE(1900,3,1)=61')).toBe(true);
+  });
+});
+
+describe('evalFormulaToBool — YEAR / MONTH / DAY', () => {
+  it('reads a modern serial (45292 → 2024-01-01)', () => {
+    expect(ev('YEAR(45292)=2024')).toBe(true);
+    expect(ev('MONTH(45292)=1')).toBe(true);
+    expect(ev('DAY(45292)=1')).toBe(true);
+  });
+
+  it('reads serial 1 as 1900-01-01 (1900 leap-bug compensation)', () => {
+    // Before routing through the shared module the formula engine had no
+    // leap-bug correction and read serial 1 as 1899-12-31 (YEAR → 1899). It
+    // must now return the Excel value 1900-01-01.
+    expect(ev('YEAR(1)=1900')).toBe(true);
+    expect(ev('MONTH(1)=1')).toBe(true);
+    expect(ev('DAY(1)=1')).toBe(true);
+  });
+
+  it('reads the leap-bug boundary serials 59 and 61', () => {
+    // Serial 59 = 1900-02-28 (last day before the phantom leap day); serial 61
+    // = 1900-03-01 (first day after it).
+    expect(ev('MONTH(59)=2')).toBe(true);
+    expect(ev('DAY(59)=28')).toBe(true);
+    expect(ev('MONTH(61)=3')).toBe(true);
+    expect(ev('DAY(61)=1')).toBe(true);
+  });
+});
+
+describe('evalFormulaToBool — WEEKDAY', () => {
+  it('returns Sun=1..Sat=7 by default (2024-01-01 is a Monday → 2)', () => {
+    expect(ev('WEEKDAY(45292)=2')).toBe(true);
+    expect(ev('WEEKDAY(45292,1)=2')).toBe(true);
+  });
+
+  it('honours return-type 2 (Mon=1..Sun=7) and 3 (Mon=0..Sun=6)', () => {
+    // Monday: type 2 → 1, type 3 → 0.
+    expect(ev('WEEKDAY(45292,2)=1')).toBe(true);
+    expect(ev('WEEKDAY(45292,3)=0')).toBe(true);
+  });
+
+  it('reads the correct weekday for serial 1 after leap-bug compensation', () => {
+    // 1900-01-01 is a Monday → default return-type 1 gives 2.
+    expect(ev('WEEKDAY(1)=2')).toBe(true);
+  });
 });

--- a/packages/xlsx/src/formula.ts
+++ b/packages/xlsx/src/formula.ts
@@ -1,3 +1,4 @@
+import { excelSerialToUtcDate, utcDateToExcelSerial } from '@silurus/ooxml-core';
 import type { Cell, DefinedName } from './types.js';
 
 // ────────────────────────────────────────────────────────────────
@@ -572,30 +573,39 @@ function makeCriteriaPredicate(criteria: EvalValue): (v: EvalScalar) => boolean 
   };
 }
 
-// Excel date serial: 1 = 1900-01-01, treats 1900 as leap (serial 60 = fake
-// 1900-02-29). For dates ≥ 1900-03-01, offset to Unix epoch is 25569 days.
-const EXCEL_EPOCH_OFFSET = 25569;
-const MS_PER_DAY = 86400000;
+// Serial ↔ calendar-date conversions are delegated to the shared core
+// `excel-date` module (ECMA-376 §18.17.4.1) so the 1900 Lotus leap-year-bug
+// compensation and 1900/1904 epoch selection live in one place. Before this
+// the formula engine carried its own `EXCEL_EPOCH_OFFSET = 25569` arithmetic,
+// which had no leap-bug correction (serials < 60 read the wrong calendar day)
+// and no 1904 support.
+//
+// The formula engine always operates in the 1900 date system: its serials are
+// consumed by the number-format layer, whose volatile-recompute path formats
+// TODAY()/NOW() against the 1900 epoch regardless of `<workbookPr date1904>`
+// (see number-format.ts). So every core call below passes date1904=false.
+// Threading the workbook's date system into the formula engine is a separate
+// track; this change is purely about retiring the duplicate serial math.
 
 export function todaySerial(): number {
   const d = new Date();
-  const utcMid = Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
-  return Math.floor(utcMid / MS_PER_DAY) + EXCEL_EPOCH_OFFSET;
+  const utcMid = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  return utcDateToExcelSerial(utcMid, false);
 }
 
 export function nowSerial(): number {
-  return Date.now() / MS_PER_DAY + EXCEL_EPOCH_OFFSET;
+  return utcDateToExcelSerial(new Date(Date.now()), false);
 }
 
 function dateToSerial(y: number, m: number, d: number): number {
   // Excel rolls over out-of-range months/days (e.g. DATE(2019, 13, 1) = Jan 2020).
-  const ms = Date.UTC(y, m - 1, d);
-  return Math.floor(ms / MS_PER_DAY) + EXCEL_EPOCH_OFFSET;
+  // `Date.UTC` performs the same normalization. Whole days only (no time), so
+  // floor to drop any sub-day residue the leap-bug boundary could introduce.
+  return Math.floor(utcDateToExcelSerial(new Date(Date.UTC(y, m - 1, d)), false));
 }
 
 function serialToJsDate(serial: number): Date {
-  const ms = (Math.floor(serial) - EXCEL_EPOCH_OFFSET) * MS_PER_DAY;
-  return new Date(ms);
+  return excelSerialToUtcDate(Math.floor(serial), false);
 }
 
 function serialToDate(serial: number): { y: number; m: number; d: number } {

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -115,3 +115,26 @@ describe('date formats — 1900 Lotus leap-year-bug compat (§18.17.4.1)', () =>
     expect(fmt(45292, 'yyyy-mm-dd')).toBe('2024-01-01');
   });
 });
+
+describe('date formats — 1904 date system (§18.2.28 / §18.17.4.1)', () => {
+  // A 1904 (Mac-authored) workbook stores serials 1462 days lower than a 1900
+  // workbook for the same calendar date. `formatCellValue`'s 4th arg carries
+  // `<workbookPr date1904>` and shifts the epoch accordingly.
+  const fmt1904 = (n: number, code: string) =>
+    formatCellValue(numCell(n), styles(code), null, true);
+
+  it('renders the same calendar date from the 1904-system serial (43830 → 2024-01-01)', () => {
+    // 1900-system serial 45292 and 1904-system serial 43830 are both 2024-01-01.
+    expect(fmt1904(43830, 'yyyy-mm-dd')).toBe('2024-01-01');
+    // Without the date1904 flag the same serial reads 1462 days early.
+    expect(fmt(43830, 'yyyy-mm-dd')).toBe('2019-12-31');
+  });
+
+  it('serial 0 is the 1904 base date 1904-01-01', () => {
+    expect(fmt1904(0, 'yyyy-mm-dd')).toBe('1904-01-01');
+  });
+
+  it('serial 1 is 1904-01-02 (no 1900 leap-year bug in the 1904 system)', () => {
+    expect(fmt1904(1, 'yyyy-mm-dd')).toBe('1904-01-02');
+  });
+});

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -97,3 +97,21 @@ describe('date formats (Excel serial; 45292 = 2024-01-01)', () => {
     expect(fmt(45292, 'dd')).toBe('01');
   });
 });
+
+describe('date formats — 1900 Lotus leap-year-bug compat (§18.17.4.1)', () => {
+  // The cell formatter now delegates serial → date to the shared core
+  // `excelSerialToUtcDate`, which shifts serials < 60 by +1 day to reproduce
+  // Excel's phantom 1900-02-29. This changes output ONLY for serials ≤ 59.
+  it('serial 1 renders 1900-01-01', () => {
+    expect(fmt(1, 'yyyy-mm-dd')).toBe('1900-01-01');
+  });
+  it('serial 59 renders 1900-02-28 (was off-by-one before the compat fix)', () => {
+    expect(fmt(59, 'yyyy-mm-dd')).toBe('1900-02-28');
+  });
+  it('serial 61 renders 1900-03-01 (day after the phantom leap day)', () => {
+    expect(fmt(61, 'yyyy-mm-dd')).toBe('1900-03-01');
+  });
+  it('modern serials (≥ 60) are unchanged: 45292 → 2024-01-01', () => {
+    expect(fmt(45292, 'yyyy-mm-dd')).toBe('2024-01-01');
+  });
+});

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -123,6 +123,14 @@ describe('General format — 11 significant digit rounding (XL2)', () => {
     expect(fmt(100, 'General')).toBe('100');
     expect(fmt(0.5, 'General')).toBe('0.5');
   });
+  it('handles the rounding-carry boundary: an 11-digit value that rounds up to a 12-digit exponent', () => {
+    // 99999999999.6 rounds to 11 significant digits as 100000000000, whose
+    // decimal exponent (11) crosses the fixed→exponential threshold. The
+    // exponent must be derived from the *rounded* form (this is exactly the
+    // non-obvious case the code comment cites), so it renders "1E+11" rather
+    // than a spurious "99999999999" or "100000000000".
+    expect(fmt(99999999999.6, 'General')).toBe('1E+11');
+  });
 });
 
 describe('non-numeric cells', () => {
@@ -183,5 +191,68 @@ describe('date formats — 1904 date system (§18.2.28 / §18.17.4.1)', () => {
 
   it('serial 1 is 1904-01-02 (no 1900 leap-year bug in the 1904 system)', () => {
     expect(fmt1904(1, 'yyyy-mm-dd')).toBe('1904-01-02');
+  });
+});
+
+describe('volatile TODAY()/NOW() exemption from date1904 (§18.17.4.1)', () => {
+  // TODAY()/NOW() cells carry a cached <v> from the last save that the viewer
+  // recomputes at render time. `todaySerial`/`nowSerial` always emit a
+  // 1900-system serial (they encode "today" as a calendar concept), so even in
+  // a 1904 workbook the recomputed volatile must be formatted against the 1900
+  // epoch — otherwise it would render 1462 days LATE. This pins the
+  // `effectiveDate1904` branch that forces date1904=false for recomputed cells.
+
+  /** Local calendar date as YYYY-MM-DD — matches how `todaySerial` derives the
+   *  serial (Date.UTC of the local Y/M/D). Returns the set of dates that are
+   *  acceptable across a possible midnight tick during the test. */
+  function acceptableTodayStrings(): Set<string> {
+    const iso = (d: Date): string =>
+      `${d.getFullYear().toString().padStart(4, '0')}-${(d.getMonth() + 1)
+        .toString()
+        .padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+    // Capture both the local "today" at the start and end of the assertion so a
+    // midnight rollover between the two clock reads does not make the test flaky.
+    return new Set([iso(new Date()), iso(new Date(Date.now()))]);
+  }
+
+  function volatileCell(formula: string): Cell {
+    // The cached <v> is a stale 1900-system serial (its exact value is
+    // irrelevant — the volatile path recomputes it) and the style is a date
+    // format. We deliberately store a serial that would misrender if the flag
+    // were NOT overridden.
+    return { row: 1, col: 1, colRef: 'A1', value: { type: 'number', number: 0 }, styleIndex: 0, formula };
+  }
+
+  it('TODAY() in a 1904 workbook renders the correct 1900-system today (not 1462 days off)', () => {
+    const before = acceptableTodayStrings();
+    const rendered = formatCellValue(volatileCell('TODAY()'), styles('yyyy-mm-dd'), null, true);
+    const after = acceptableTodayStrings();
+    const acceptable = new Set([...before, ...after]);
+    expect(acceptable.has(rendered)).toBe(true);
+  });
+
+  it('tolerates a leading = and whitespace in the recomputed formula', () => {
+    const before = acceptableTodayStrings();
+    const rendered = formatCellValue(volatileCell(' = TODAY() '), styles('yyyy-mm-dd'), null, true);
+    const after = acceptableTodayStrings();
+    const acceptable = new Set([...before, ...after]);
+    expect(acceptable.has(rendered)).toBe(true);
+  });
+
+  it('NOW() in a 1904 workbook renders the correct 1900-system date portion', () => {
+    const before = acceptableTodayStrings();
+    // NOW() carries a time fraction; the date portion must still be today's
+    // 1900-system calendar date, not the 1904-shifted one.
+    const rendered = formatCellValue(volatileCell('NOW()'), styles('yyyy-mm-dd'), null, true);
+    const after = acceptableTodayStrings();
+    const acceptable = new Set([...before, ...after]);
+    expect(acceptable.has(rendered)).toBe(true);
+  });
+
+  it('a non-volatile stored serial in a 1904 workbook still honors the 1904 epoch', () => {
+    // Contrast: without a volatile formula the stored serial uses the workbook
+    // date system. 1904-system serial 43830 = 2024-01-01.
+    const cell: Cell = { row: 1, col: 1, colRef: 'A1', value: { type: 'number', number: 43830 }, styleIndex: 0 };
+    expect(formatCellValue(cell, styles('yyyy-mm-dd'), null, true)).toBe('2024-01-01');
   });
 });

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -78,6 +78,53 @@ describe('General format code (§18.8.30 / LibreOffice custom numFmt)', () => {
   });
 });
 
+describe('General format — 11 significant digit rounding (XL2)', () => {
+  // Excel's General format is not raw float round-trip: the display engine
+  // rounds to 11 significant digits (15-digit internal precision minus the
+  // ~4 digits Excel reserves for display robustness), so binary floating
+  // point noise from arithmetic (e.g. 0.1 + 0.2) never surfaces to the user.
+  // This table pins the rounding + trailing-zero-trim + exponential-switch
+  // rules against `formatGeneralNumber` (see number-format.ts for the exact
+  // exponent thresholds and their rationale).
+  it('rounds binary floating point noise away', () => {
+    expect(fmt(0.1 + 0.2, 'General')).toBe('0.3');
+    expect(fmt(-(0.1 + 0.2), 'General')).toBe('-0.3');
+  });
+  it('rounds a repeating decimal to 11 significant digits', () => {
+    expect(fmt(1 / 3, 'General')).toBe('0.33333333333');
+  });
+  it('leaves an 11-digit integer untouched', () => {
+    expect(fmt(12345678901, 'General')).toBe('12345678901');
+  });
+  it('switches a 12-digit integer to Excel exponential notation', () => {
+    // Mantissa capped at 6 significant digits (5 decimal places) once the
+    // General format has already committed to scientific notation.
+    expect(fmt(123456789012, 'General')).toBe('1.23457E+11');
+  });
+  it('rounds a many-decimal value to 11 significant digits', () => {
+    expect(fmt(1234.5678901234, 'General')).toBe('1234.5678901');
+  });
+  it('applies the same rounding to negative numbers, sign excluded from digit count', () => {
+    expect(fmt(-0.30000000000000004, 'General')).toBe('-0.3');
+  });
+  it('renders negative zero as "0"', () => {
+    expect(fmt(-0, 'General')).toBe('0');
+  });
+  it('switches a very small number to exponential once fixed-point would bury it past 11 significant digits', () => {
+    expect(fmt(0.000000001234567890123, 'General')).toBe('1.23457E-09');
+  });
+  it('keeps a small-but-not-tiny decimal in fixed-point form', () => {
+    expect(fmt(0.00001, 'General')).toBe('0.00001');
+  });
+  it('switches at the documented exponent boundary (1e-6 range)', () => {
+    expect(fmt(0.000001, 'General')).toBe('1E-06');
+  });
+  it('trims trailing zeros from an exact decimal', () => {
+    expect(fmt(100, 'General')).toBe('100');
+    expect(fmt(0.5, 'General')).toBe('0.5');
+  });
+});
+
 describe('non-numeric cells', () => {
   it('passes text through when no 4th section', () => {
     const cell: Cell = { row: 1, col: 1, colRef: 'A1', value: { type: 'text', text: 'hello' }, styleIndex: 0 };

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -48,8 +48,10 @@ export function formatCellValue(
   // `todaySerial`/`nowSerial` always emit a 1900-system serial (they encode
   // "today" as a calendar concept, independent of the workbook's date system),
   // so a recomputed volatile must be formatted against the 1900 epoch even in a
-  // 1904 workbook — otherwise it would render 1462 days early. Stored cell
-  // values, by contrast, use the workbook's own date system.
+  // 1904 workbook. Formatting a 1900-system serial against the (later) 1904
+  // base date would push it 1462 days into the future — i.e. render it 1462
+  // days late. Stored cell values, by contrast, use the workbook's own date
+  // system.
   const effectiveDate1904 = recomputed !== null ? false : date1904;
   return applyFormat(num, effectiveFmtId, effectiveFmt, effectiveDate1904);
 }
@@ -432,10 +434,10 @@ function formatGeneralExponential(abs: number): string {
  *   side — not a numerically-documented Microsoft threshold, but the
  *   consistent extrapolation of the documented large-number rule.
  *
- * Column-width-dependent narrowing of the *displayed* precision (Excel
- * shrinks General further to fit a narrow column) is intentionally not
- * modeled here; this function always targets the "standard column width"
- * output, matching how the rest of this renderer treats layout as
+ * Column-width narrowing is not modeled: Excel shrinks a General value's
+ * displayed precision further to fit a narrow column, but this function always
+ * emits the full 11-significant-digit form regardless of the destination
+ * column width, matching how the rest of this renderer treats layout as
  * independent of formatting.
  */
 function formatGeneralNumber(num: number): string {

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -17,6 +17,10 @@ export function formatCellValue(
   cell: Cell,
   styles: Styles,
   cfNumFmt?: { numFmtId: number; formatCode: string | null } | null,
+  /** Workbook date system (`<workbookPr date1904>`, §18.2.28). `true` resolves
+   *  serial dates against the 1904 epoch (§18.17.4.1). Defaults to false (1900
+   *  date system) so callers that don't thread the flag are unaffected. */
+  date1904 = false,
 ): string {
   // Resolve the effective format once so both the numeric and text paths
   // honour the same precedence: CF dxf numFmt > style numFmt (§18.8.17).
@@ -39,8 +43,15 @@ export function formatCellValue(
   // Volatile builtins: TODAY()/NOW() cells have a cached `<v>` from the last
   // save, which the viewer would otherwise show as a stale date. Recompute
   // them against the current system clock at render time.
-  const num = recomputeVolatile(cell.formula) ?? cell.value.number;
-  return applyFormat(num, effectiveFmtId, effectiveFmt);
+  const recomputed = recomputeVolatile(cell.formula);
+  const num = recomputed ?? cell.value.number;
+  // `todaySerial`/`nowSerial` always emit a 1900-system serial (they encode
+  // "today" as a calendar concept, independent of the workbook's date system),
+  // so a recomputed volatile must be formatted against the 1900 epoch even in a
+  // 1904 workbook — otherwise it would render 1462 days early. Stored cell
+  // values, by contrast, use the workbook's own date system.
+  const effectiveDate1904 = recomputed !== null ? false : date1904;
+  return applyFormat(num, effectiveFmtId, effectiveFmt, effectiveDate1904);
 }
 
 /**
@@ -367,17 +378,17 @@ function isDateFormatCode(code: string): boolean {
   return /[yd]/i.test(stripped) || /a{3,}/i.test(stripped);
 }
 
-function applyFormat(num: number, numFmtId: number, formatCode: string | null): string {
+function applyFormat(num: number, numFmtId: number, formatCode: string | null, date1904 = false): string {
   // Built-in date/time numFmtIds (ECMA-376 §18.8.30 table)
   const builtinFmt = BUILTIN_DATE_FMT[numFmtId];
-  if (builtinFmt) return formatExcelDateCode(num, builtinFmt);
+  if (builtinFmt) return formatExcelDateCode(num, builtinFmt, date1904);
   // ECMA-376 §18.8.30: "General" is the reserved General number format regardless
   // of numFmtId. LibreOffice writes a custom numFmt (id ≥ 164) with
   // formatCode="General"; tokenizing it as a literal pattern would render the
   // word "General" instead of the value (issue #358).
   if (formatCode && formatCode.trim().toLowerCase() === 'general') return String(num);
   if (formatCode) {
-    if (isDateFormatCode(formatCode)) return formatExcelDateCode(num, formatCode);
+    if (isDateFormatCode(formatCode)) return formatExcelDateCode(num, formatCode, date1904);
     return applyFormatCode(num, formatCode);
   }
   switch (numFmtId) {

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -1,3 +1,4 @@
+import { excelSerialToUtcDate } from '@silurus/ooxml-core';
 import type { Cell, CellValue, Styles } from './types.js';
 import { todaySerial, nowSerial } from './formula.js';
 
@@ -167,19 +168,21 @@ function resolveJpEra(date: Date): { abbr: string; short: string; long: string; 
   return { abbr: last.abbr, short: last.short, long: last.long, year: date.getUTCFullYear() };
 }
 
-/** Convert an Excel date serial to a UTC Date (avoids local-timezone off-by-one errors). */
-function excelSerialToUTCDate(serial: number): Date {
-  return new Date((serial - 25569) * 86400 * 1000);
-}
-
 /**
  * Format an Excel date serial using an ECMA-376 format code.
  * Supports: y/yy/yyy/yyyy, m/mm/mmm/mmmm/mmmmm, d/dd/ddd/dddd,
  *           h/hh, m/mm (minutes when after h), s/ss, AM/PM, A/P,
  *           quoted literals, bracket escapes, _ padding, * fill.
+ *
+ * `date1904` selects the date system (`<workbookPr date1904>`, §18.2.28). The
+ * serial → calendar-date conversion is delegated to the shared core
+ * `excelSerialToUtcDate` (§18.17.4.1), which carries the 1900 Lotus
+ * leap-year-bug compat and the 1904 epoch. It defaults to false so 1900-system
+ * workbooks are unchanged (apart from the serial ≤ 59 leap-bug compat, which is
+ * now correct in both systems).
  */
-function formatExcelDateCode(serial: number, fmtCode: string): string {
-  const date = excelSerialToUTCDate(serial);
+function formatExcelDateCode(serial: number, fmtCode: string, date1904 = false): string {
+  const date = excelSerialToUtcDate(serial, date1904);
   const yr = date.getUTCFullYear();
   const mo = date.getUTCMonth() + 1;   // 1-12
   const dy = date.getUTCDate();

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -378,6 +378,87 @@ function isDateFormatCode(code: string): boolean {
   return /[yd]/i.test(stripped) || /a{3,}/i.test(stripped);
 }
 
+// Excel's General format does not round-trip the raw IEEE-754 double: the
+// display engine rounds to 11 significant digits (of the 15-17 significant
+// digits a double can carry), which is what keeps binary floating point
+// noise from arithmetic (e.g. 0.1 + 0.2 === 0.30000000000000004) from ever
+// reaching the screen. See "Floating-point arithmetic may give inaccurate
+// results in Excel" (Microsoft KB78113) for the 15-digit internal precision
+// this display rounding sits on top of.
+const GENERAL_SIGNIFICANT_DIGITS = 11;
+// Once General has committed to scientific notation (see thresholds below),
+// Excel caps the mantissa at 6 significant digits (1 integer + 5 decimal),
+// e.g. 123456789012 -> "1.23457E+11", independent of the 11-digit budget
+// used for fixed-point display.
+const GENERAL_EXPONENTIAL_MANTISSA_DIGITS = 6;
+
+/** Strips trailing fractional zeros (and a dangling ".") from a fixed-point
+ *  digit string. No-op for strings without a decimal point. */
+function trimTrailingZeros(digits: string): string {
+  if (!digits.includes('.')) return digits;
+  return digits.replace(/0+$/, '').replace(/\.$/, '');
+}
+
+/** Formats `exponent` the way Excel's General exponential notation does:
+ *  always signed, at least two digits (E+05, E+11, E-09, ...). */
+function formatExcelExponent(exponent: number): string {
+  const sign = exponent >= 0 ? '+' : '-';
+  const digits = Math.abs(exponent).toString().padStart(2, '0');
+  return `${sign}${digits}`;
+}
+
+/** Renders a finite, non-zero, non-negative number in Excel's General
+ *  exponential style: mantissa trimmed to `GENERAL_EXPONENTIAL_MANTISSA_DIGITS`
+ *  significant digits with trailing zeros dropped, uppercase `E`, signed
+ *  2+-digit exponent (e.g. 123456789012 -> "1.23457E+11"). */
+function formatGeneralExponential(abs: number): string {
+  const [mantissa, exponent] = abs.toExponential(GENERAL_EXPONENTIAL_MANTISSA_DIGITS - 1).split('e');
+  return `${trimTrailingZeros(mantissa)}E${formatExcelExponent(Number(exponent))}`;
+}
+
+/**
+ * Formats a number the way Excel's "General" cell format does: round to 11
+ * significant digits (hiding binary floating-point round-trip noise like
+ * 0.1 + 0.2), trim trailing fractional zeros, and switch to Excel-style
+ * exponential notation ("1.23457E+11") once the value's decimal exponent
+ * falls outside the fixed-point display budget.
+ *
+ * Thresholds:
+ * - Integer part >= 12 digits (decimal exponent >= 11): Excel General is
+ *   documented to switch 12+ digit numbers to scientific notation.
+ * - Decimal exponent < -5 (value would need 6+ leading fractional zeros
+ *   before the first significant digit): mirrors the same "11 significant
+ *   digits must fit in the fixed-point budget" rule on the small-number
+ *   side — not a numerically-documented Microsoft threshold, but the
+ *   consistent extrapolation of the documented large-number rule.
+ *
+ * Column-width-dependent narrowing of the *displayed* precision (Excel
+ * shrinks General further to fit a narrow column) is intentionally not
+ * modeled here; this function always targets the "standard column width"
+ * output, matching how the rest of this renderer treats layout as
+ * independent of formatting.
+ */
+function formatGeneralNumber(num: number): string {
+  if (!Number.isFinite(num)) return String(num);
+  if (num === 0) return '0'; // canonicalizes -0 to "0"
+
+  const negative = num < 0;
+  const abs = Math.abs(num);
+
+  // Decimal exponent of the value once rounded to the target significant
+  // digits, derived from the (already-rounded) exponential form so a
+  // rounding carry that bumps the digit count (e.g. 99999999999.6 -> 1E+11)
+  // is reflected before the fixed-vs-exponential branch is chosen.
+  const exponent = Number(abs.toExponential(GENERAL_SIGNIFICANT_DIGITS - 1).split('e')[1]);
+  const useExponential = exponent >= GENERAL_SIGNIFICANT_DIGITS || exponent < -5;
+
+  const body = useExponential
+    ? formatGeneralExponential(abs)
+    : trimTrailingZeros(abs.toPrecision(GENERAL_SIGNIFICANT_DIGITS));
+
+  return negative ? `-${body}` : body;
+}
+
 function applyFormat(num: number, numFmtId: number, formatCode: string | null, date1904 = false): string {
   // Built-in date/time numFmtIds (ECMA-376 §18.8.30 table)
   const builtinFmt = BUILTIN_DATE_FMT[numFmtId];
@@ -386,13 +467,13 @@ function applyFormat(num: number, numFmtId: number, formatCode: string | null, d
   // of numFmtId. LibreOffice writes a custom numFmt (id ≥ 164) with
   // formatCode="General"; tokenizing it as a literal pattern would render the
   // word "General" instead of the value (issue #358).
-  if (formatCode && formatCode.trim().toLowerCase() === 'general') return String(num);
+  if (formatCode && formatCode.trim().toLowerCase() === 'general') return formatGeneralNumber(num);
   if (formatCode) {
     if (isDateFormatCode(formatCode)) return formatExcelDateCode(num, formatCode, date1904);
     return applyFormatCode(num, formatCode);
   }
   switch (numFmtId) {
-    case 0: return String(num);
+    case 0: return formatGeneralNumber(num);
     case 1: return Math.round(num).toString();
     case 2: return num.toFixed(2);
     case 3: return formatThousands(num, 0);
@@ -403,7 +484,7 @@ function applyFormat(num: number, numFmtId: number, formatCode: string | null, d
     case 37: case 38: return formatThousands(num, 0);
     case 39: case 40: return formatThousands(num, 2);
     case 49: return String(num);
-    default: return String(num);
+    default: return formatGeneralNumber(num);
   }
 }
 

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1832,7 +1832,7 @@ function renderQuadrant(
     mergeBorderTasks.push(() => renderBorder(ctx, preBorder, aCx, aCy, cW, cH, dpr));
 
     if (!cell) continue;
-    const text = formatCellValue(cell, styles, cf.numFmt);
+    const text = formatCellValue(cell, styles, cf.numFmt, rc.worksheet.date1904);
     if (!text || (text === '0' && rc.worksheet.showZeros === false)) continue;
 
     const effectiveBold = font.bold || !!cf.fontBold;
@@ -2210,7 +2210,7 @@ function renderQuadrant(
       }
 
       if (!cell) continue;
-      const text = formatCellValue(cell, styles, cf.numFmt);
+      const text = formatCellValue(cell, styles, cf.numFmt, rc.worksheet.date1904);
       if (!text || (text === '0' && rc.worksheet.showZeros === false)) continue;
 
       textTasks.push(() => {

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -2,6 +2,11 @@ import type { ChartModel, MathNode, SpaceLine } from '@silurus/ooxml-core';
 
 export interface Workbook {
   sheets: SheetMeta[];
+  /** Workbook date system (`<workbookPr date1904>`, ECMA-376 §18.2.28).
+   *  `true` selects the 1904 date system (Mac-authored workbooks); serial
+   *  dates are resolved against the 1904 epoch (§18.17.4.1). Omitted from the
+   *  parser JSON when false (default 1900 date system). */
+  date1904?: boolean;
 }
 
 /** Sheet visibility (`<sheet state>`, ECMA-376 §18.2.19 `ST_SheetState`). */
@@ -99,6 +104,11 @@ export interface Worksheet {
   defaultFontFamily?: string;
   /** Point size of the workbook's Normal-style font (`<fonts>[N].sz.val`). */
   defaultFontSize?: number;
+  /** Workbook date system (`<workbookPr date1904>`, ECMA-376 §18.2.28),
+   *  denormalized onto every worksheet by the parser so the cell formatter can
+   *  resolve serial dates (§18.17.4.1) without a workbook back-reference.
+   *  `true` = 1904 date system. Omitted (⇒ false) for the default 1900 system. */
+  date1904?: boolean;
 }
 
 export interface SparklineGroup {

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -301,7 +301,7 @@ export class XlsxWorkbook {
     return resolveListValues(parsed, (row, col) => {
       const cell = byRC.get(`${row}:${col}`);
       if (!cell) return null;
-      return formatCellValue(cell, styles);
+      return formatCellValue(cell, styles, null, ws.date1904);
     });
   }
 


### PR DESCRIPTION
## Summary

Phase 1 batch 2/10 from the 2026-07b improvement plan (XL1 + XL2).

### XL1 — date1904 (§18.2.28, §18.17.4.1, §21.2.2.38)
- Workbooks authored with the 1904 date system rendered every date 1,462 days (4 years + 1 day) late: the parser never read `<workbookPr date1904>`, and the serial→date conversion was hardcoded to the 1900 epoch.
- **Consolidated Excel serial→date conversion** into a single pure module `core/src/excel-date.ts` (with the inverse `utcDateToExcelSerial`). The audit found not two but **three** drifted implementations: the xlsx cell formatter (no 1900 leap-bug compensation), the core chart formatter (no date1904), and the xlsx formula engine (`YEAR`/`MONTH`/`DAY`/`WEEKDAY`, no leap-bug compensation). All three now delegate.
- 1900 system honors the Lotus leap-year-bug compatibility (§18.17.4.1): serial 60 is the phantom 1900-02-29, serials < 60 shift +1 day; the inverse never emits serial 60.
- Rust: `<workbookPr date1904>` parsed and denormalized onto each `Worksheet`; threaded through cell formatting and the data-validation resolver.
- **Cross-format**: charts have their own `<c:date1904>` (§21.2.2.38). Added shared `extract_chart_date1904` (ooxml-common), parsed in both xlsx and pptx chart parsers, threaded through all 19 date-capable label sites in the core chart renderer. Chart epochs unified on the §18.17.4.1 cell definition (the chart spec's literal "days since Dec 31" prose would put every real date off by one).
- Volatile `TODAY()`/`NOW()` stay correct in 1904 workbooks (engine emits 1900-system serials; formatting pins to the matching epoch, documented and tested).

### XL2 — General format (11 significant digits)
- General-formatted computed values leaked raw f64 round-trip precision (`0.30000000000000004`). Now rounds to Excel's 11 significant digits with Excel-style scientific notation (`1.23457E+11`) for ≥12-digit integers and sub-1e-5 magnitudes; trailing zeros trimmed; `-0` → `0`. Column-width-dependent narrowing is explicitly out of scope.

### Verification
- `pnpm test` — 1806 passed (200 files); root typecheck clean; `cargo fmt` / `clippy -D warnings` / `cargo test` (304 tests) clean; `pnpm build:wasm` rebuilt
- Full local VRT — 163/163 passed, zero reference-image diffs
- Independent 4-dimension review (spec fidelity, correctness, cross-package unification, test quality); both REQUEST_CHANGES items (third duplicate in formula.ts, untested TODAY/NOW×date1904 exemption) and all LOW findings addressed in-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)