### PR TITLE
fix(build): single-level wasm asset URL — unbreaks webpack 5 and Next.js consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,23 @@ pnpm add @silurus/ooxml
 
 > **Bundler note**: the Rust parsers ship as real `.wasm` asset files next to the
 > JavaScript, referenced with the standard `new URL('…', import.meta.url)` form
-> and fetched (streaming-compiled) at load time. Vite, webpack 5, Rollup and
-> Parcel detect that reference and copy the asset automatically — no extra
-> WebAssembly plugin is required. esbuild and the Angular CLI (whose application
-> builder is esbuild-based) do **not** process that reference
-> ([esbuild#795](https://github.com/evanw/esbuild/issues/795)): copy the `.wasm`
-> into your served output yourself and point the viewer at it with the `wasmUrl`
-> load option — see the [Angular example](#framework-examples) for the two-step
-> setup. `wasmUrl` also serves the parser WASM from a CDN or any path you
-> control:
+> and fetched (streaming-compiled) at load time. Verified to work with zero
+> config: **webpack 5**, **Next.js** (Turbopack, dev and build), **Vite 8**
+> (dev and build), **Vite 7 production builds**, and a plain
+> `<script type="module">` with no bundler at all. Two setups need a hand:
+>
+> - **Vite 7 dev server**: the dependency optimizer rewrites the asset reference
+>   into its own cache path and the load fails (fixed in Vite 8). Add
+>   `optimizeDeps: { exclude: ['@silurus/ooxml'] }` to your `vite.config` —
+>   production builds are unaffected.
+> - **esbuild / Angular CLI** (whose application builder is esbuild-based):
+>   `new URL` asset references are not processed
+>   ([esbuild#795](https://github.com/evanw/esbuild/issues/795)). Copy the
+>   `.wasm` into your served output and point the viewer at it with the
+>   `wasmUrl` load option — see the [Angular example](#framework-examples) for
+>   the two-step setup.
+>
+> `wasmUrl` also serves the parser WASM from a CDN or any path you control:
 >
 > ```typescript
 > new DocxViewer(canvas, { wasmUrl: 'https://cdn.example.com/docx_parser_bg.wasm' });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,8 +28,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * `math/engine.ts`). We intercept the `?url` variant here, `emitFile` the bytes
  * as an asset next to the chunk, and hand back the standard ESM asset reference
  * `new URL('<name>', import.meta.url)` — the form Vite / webpack 5 / Rollup /
- * esbuild all rewrite when they re-bundle our `.mjs`, and which resolves
- * correctly for a plain `<script type=module>` too. wasm-bindgen's `--target web`
+ * Turbopack rewrite when they re-bundle our `.mjs`, and which resolves
+ * correctly for a plain `<script type=module>` too. (esbuild — and therefore
+ * the Angular CLI — does NOT process it; those consumers use the `wasmUrl`
+ * load option, see the README bundler note.) wasm-bindgen's `--target web`
  * glue then `fetch()`es its URL and hits `instantiateStreaming`; the math engine
  * is lazy-loaded via a `<script src>` pointed at the emitted asset.
  *
@@ -57,11 +59,17 @@ function wasmAssetUrl(): Plugin {
         name: basename(filePath),
         source,
       });
-      // `import.meta.ROLLUP_FILE_URL_<id>` expands to the emitted asset's URL at
-      // render time; wrapping it in `new URL(…, import.meta.url)` yields an
+      // `import.meta.ROLLUP_FILE_URL_<id>` expands at render time to Rollup's
+      // ES default resolution — `new URL('<name>', import.meta.url).href` — an
       // absolute href the worker (or the math engine's `<script>` loader) can
-      // fetch from any realm.
-      return `export default new URL(import.meta.ROLLUP_FILE_URL_${referenceId}, import.meta.url).href;`;
+      // fetch from any realm. It must be emitted BARE: wrapping it in another
+      // `new URL(…, import.meta.url)` ships a nested pattern that webpack 5
+      // compiles into a critical-dependency ContextModule (the outer first arg
+      // is now an expression, not a literal), throwing MODULE_NOT_FOUND at
+      // module evaluation — `import '@silurus/ooxml/docx'` alone crashed every
+      // webpack consumer. The single-level form is the exact shape webpack 5 /
+      // Turbopack / Vite statically rewrite when re-bundling our `.mjs`.
+      return `export default import.meta.ROLLUP_FILE_URL_${referenceId};`;
     },
   };
 }


### PR DESCRIPTION
## Summary

v0.70.0's real-asset WASM packaging (#681) shipped a **double-nested** `new URL` in every dist bundle:

```js
new URL(new URL("docx_parser_bg.wasm", import.meta.url).href, import.meta.url).href
```

The `wasm-asset-url` plugin wrapped `import.meta.ROLLUP_FILE_URL_<id>` in an extra `new URL(…, import.meta.url).href`, but Rollup's ES resolution already expands the reference to exactly that form — the wrapper was redundant and broke two major consumers:

- **webpack 5**: the outer call's first arg is an expression, so webpack compiles it into an empty critical-dependency ContextModule that throws `MODULE_NOT_FOUND` at module evaluation — `import '@silurus/ooxml/docx'` alone crashed every webpack app.
- **Next.js (Turbopack, dev and build)**: Turbopack rewrites the outer `import.meta.url` to `file://`, so the worker received `file:///_next/static/media/….wasm` and the fetch failed.

Emitting the reference bare produces the statically-analyzable single-level form. Also corrects the plugin's doc comment (esbuild does not rewrite the reference) and rewrites the README bundler note to the verified matrix.

## Verification (empirical, per-bundler consumer apps + Playwright)

Machine-judged: wasm request URL/status/content-type, load promise resolution, canvas pixel scan.

| Consumer | before (npm 0.70.1) | after (this fix) |
|---|---|---|
| webpack 5.108.3 production build | ❌ `MODULE_NOT_FOUND` on import | ✅ 200 `application/wasm`, renders |
| Next.js 16.2.10 Turbopack dev | ❌ `file://` fetch failure | ✅ renders |
| Next.js 16.2.10 build + start | ❌ same | ✅ renders |
| Vite 8.1.3 dev / build | ✅ | ✅ no regression |
| Vite 7.3.6 dev (no exclude) | ❌ (Vite 7 optimizer, unrelated) | ❌ unchanged — `optimizeDeps.exclude` workaround still works |
| Plain `<script type=module>` (no bundler) | ✅ | ✅ no regression |

Local gates: `tsc --build` + markdown/node/vscode-extension typechecks, ast-grep lint, `pnpm build` all green. Dist inspected: all four assets (3× parser wasm + mathjax) now emit single-level `new URL("…", import.meta.url).href`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)