### PR TITLE
chore(release): 0.70.2 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.70.2 — 2026-07-03
+
+Patch (hotfix on v0.70.1). Fixes the packaging of the parser WASM asset
+reference, which broke webpack 5 and Next.js consumers in 0.70.x.
+
+- **build:** dist bundles shipped a double-nested
+  `new URL(new URL("….wasm", import.meta.url).href, import.meta.url).href`.
+  webpack 5 compiled the outer call into an empty critical-dependency
+  ContextModule that threw `MODULE_NOT_FOUND` the moment any entry was
+  imported, and Turbopack rewrote the outer `import.meta.url` to `file://`,
+  breaking the worker's WASM fetch in Next.js (dev and build alike). The
+  reference is now emitted as the bare single-level
+  `new URL("…", import.meta.url).href`. Verified end-to-end: webpack 5,
+  Next.js 16 (Turbopack dev/build), Vite 8 dev/build, plain
+  `<script type="module">`. (#715)
+- **README:** bundler note rewritten to the verified compatibility matrix —
+  Vite 7 dev servers need `optimizeDeps: { exclude: ['@silurus/ooxml'] }`
+  (fixed upstream in Vite 8); esbuild / Angular CLI use the `wasmUrl` load
+  option. (#715)
+
 ## 0.70.1 — 2026-07-03
 
 Patch. Documentation-only: correct the Angular / esbuild guidance for loading

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.70.1"
+version = "0.70.2"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -29,15 +29,23 @@ pnpm add @silurus/ooxml
 
 > **Bundler note**: the Rust parsers ship as real `.wasm` asset files next to the
 > JavaScript, referenced with the standard `new URL('…', import.meta.url)` form
-> and fetched (streaming-compiled) at load time. Vite, webpack 5, Rollup and
-> Parcel detect that reference and copy the asset automatically — no extra
-> WebAssembly plugin is required. esbuild and the Angular CLI (whose application
-> builder is esbuild-based) do **not** process that reference
-> ([esbuild#795](https://github.com/evanw/esbuild/issues/795)): copy the `.wasm`
-> into your served output yourself and point the viewer at it with the `wasmUrl`
-> load option — see the [Angular example](#framework-examples) for the two-step
-> setup. `wasmUrl` also serves the parser WASM from a CDN or any path you
-> control:
+> and fetched (streaming-compiled) at load time. Verified to work with zero
+> config: **webpack 5**, **Next.js** (Turbopack, dev and build), **Vite 8**
+> (dev and build), **Vite 7 production builds**, and a plain
+> `<script type="module">` with no bundler at all. Two setups need a hand:
+>
+> - **Vite 7 dev server**: the dependency optimizer rewrites the asset reference
+>   into its own cache path and the load fails (fixed in Vite 8). Add
+>   `optimizeDeps: { exclude: ['@silurus/ooxml'] }` to your `vite.config` —
+>   production builds are unaffected.
+> - **esbuild / Angular CLI** (whose application builder is esbuild-based):
+>   `new URL` asset references are not processed
+>   ([esbuild#795](https://github.com/evanw/esbuild/issues/795)). Copy the
+>   `.wasm` into your served output and point the viewer at it with the
+>   `wasmUrl` load option — see the [Angular example](#framework-examples) for
+>   the two-step setup.
+>
+> `wasmUrl` also serves the parser WASM from a CDN or any path you control:
 >
 > ```typescript
 > new DocxViewer(canvas, { wasmUrl: 'https://cdn.example.com/docx_parser_bg.wasm' });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.70.1"
+version = "0.70.2"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.70.1",
+  "version": "0.70.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.70.1",
+  "version": "0.70.2",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,8 +28,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * `math/engine.ts`). We intercept the `?url` variant here, `emitFile` the bytes
  * as an asset next to the chunk, and hand back the standard ESM asset reference
  * `new URL('<name>', import.meta.url)` — the form Vite / webpack 5 / Rollup /
- * esbuild all rewrite when they re-bundle our `.mjs`, and which resolves
- * correctly for a plain `<script type=module>` too. wasm-bindgen's `--target web`
+ * Turbopack rewrite when they re-bundle our `.mjs`, and which resolves
+ * correctly for a plain `<script type=module>` too. (esbuild — and therefore
+ * the Angular CLI — does NOT process it; those consumers use the `wasmUrl`
+ * load option, see the README bundler note.) wasm-bindgen's `--target web`
  * glue then `fetch()`es its URL and hits `instantiateStreaming`; the math engine
  * is lazy-loaded via a `<script src>` pointed at the emitted asset.
  *
@@ -57,11 +59,17 @@ function wasmAssetUrl(): Plugin {
         name: basename(filePath),
         source,
       });
-      // `import.meta.ROLLUP_FILE_URL_<id>` expands to the emitted asset's URL at
-      // render time; wrapping it in `new URL(…, import.meta.url)` yields an
+      // `import.meta.ROLLUP_FILE_URL_<id>` expands at render time to Rollup's
+      // ES default resolution — `new URL('<name>', import.meta.url).href` — an
       // absolute href the worker (or the math engine's `<script>` loader) can
-      // fetch from any realm.
-      return `export default new URL(import.meta.ROLLUP_FILE_URL_${referenceId}, import.meta.url).href;`;
+      // fetch from any realm. It must be emitted BARE: wrapping it in another
+      // `new URL(…, import.meta.url)` ships a nested pattern that webpack 5
+      // compiles into a critical-dependency ContextModule (the outer first arg
+      // is now an expression, not a literal), throwing MODULE_NOT_FOUND at
+      // module evaluation — `import '@silurus/ooxml/docx'` alone crashed every
+      // webpack consumer. The single-level form is the exact shape webpack 5 /
+      // Turbopack / Vite statically rewrite when re-bundling our `.mjs`.
+      return `export default import.meta.ROLLUP_FILE_URL_${referenceId};`;
     },
   };
 }


### PR DESCRIPTION
## Summary

Hotfix release cut from **v0.70.1** (not main head): cherry-picks the wasm asset-URL packaging fix (#715) and ships it as a pure patch, without the feature work already merged to main (#713 xlsx date fixes, #714 OLE preview — those ride the next minor).

Contents on top of v0.70.1:
- fix(build): single-level `new URL` asset reference — unbreaks webpack 5 (import-time `MODULE_NOT_FOUND`) and Next.js Turbopack (`file://` worker fetch) consumers (cherry-picked from #715)
- docs: verified bundler compatibility matrix in the README (cherry-picked from #715)
- CHANGELOG 0.70.2 + version bump to 0.70.2 (root + 7 packages + site + mcp-server Cargo.toml/Cargo.lock)

**Tag `v0.70.2` will be cut from this branch head** so the published artifacts contain only v0.70.1 + the fix; this PR then merges the branch back into main to keep the version series and CHANGELOG continuous (the #715 changes are already on main, so the merge adds only the release bookkeeping).

Verification on the branch: `pnpm build` green, dist contains zero nested `new URL(new URL(` occurrences, `cargo check -p ooxml-mcp-server` green. Empirical bundler matrix in #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)