### PR TITLE
perf/fix: worker lifecycle — drop double-copy, direct transfer, engine swap, init-hang, unified render errors

### DIFF
--- a/docs/improvement-plan-2026-07b-checklist.md
+++ b/docs/improvement-plan-2026-07b-checklist.md
@@ -62,11 +62,11 @@ node packages/node/src/bench-handle.mjs  # handle 反復 work ベンチ
 - [ ] RB8: cargo audit / pnpm audit ゲート(report-only 開始)
 
 ### worker / ライフサイクル
-- [ ] SC17: Archive 所有権渡し(WASM 内二重コピー解消)
-- [ ] SC18: extract 系の buffer 直 transfer
-- [ ] SC20: load() の旧エンジン orphan 解消(5箇所)
-- [ ] AR4: pptx worker init 失敗の永久 hang
-- [ ] PD14: render エラーの運命統一(onError 契約)
+- [x] **SC17**: Archive 所有権渡し(WASM 内二重コピー解消) — **完了**(branch perf/worker-lifecycle)。`Archive::new` を `Vec<u8>` 所有権受け取りへ(wasm-bindgen ABI は copy であって detach ではないため input `Uint8Array` は生存、free-function 系は buffer 再利用のため `&[u8]` 維持)。ベンチ: 219MB pptx の cold `new` で WASM peak 440→221MB(2×→1×)。
+- [x] **SC18**: extract 系の buffer 直 transfer — **完了**(branch perf/worker-lifecycle)。extract の worker 側 `.slice()` 冗長コピーを削除し `buffer` を直 transfer(wasm-bindgen glue が既に独立した full-span コピーを返すため二重コピー不要)。抽出資産あたり 1 memcpy 削減。契約は `archive-extract-transfer.test.ts` で pin(byteOffset 0・full-span・非 WASM-backed = transferable)。
+- [x] **SC20**: load() の旧エンジン orphan 解消(5箇所) — **完了**(branch perf/worker-lifecycle)。5 viewer/scroll-viewer で `load()` が旧エンジンを success-after-swap で destroy(失敗時は旧を保持して blank 化を回避)。加えて並行 load latch(世代トークン `_loadGen`、本 PR で追加)で overlapping `load(A)`/`load(B)` の遅延解決による orphan も封鎖(stale 側は自分のエンジンのみ destroy、`this.*`/`previous` 不可触)。
+- [x] **AR4**: pptx worker init 失敗の永久 hang — **完了**(branch perf/worker-lifecycle)。pptx worker(+render-worker)を `initPromise` パターンへ統一し、ready ハンドシェイクを完全撤去して init 失敗時の永久 hang を根治(未 ready のまま応答が来ない状態を作らない)。
+- [x] **PD14**: render エラーの運命統一(onError 契約) — **完了**(branch perf/worker-lifecycle)。単 canvas 3 viewer の render エラーを `_reportRenderError`(`onError` else `console.error`、never silent、`load` は resolve)へ統一し scroll-viewer と一致させた。加えて destroy 後ガード(`_destroyed` フラグ、本 PR で追加)で teardown 後に着弾した render 拒否を握り潰す(dead viewer への `onError` 発火を防止)。`load()` の JSDoc に parse/load 失敗(rethrow-or-onError)と render 失敗(`_reportRenderError` 経由・resolve)の 2 相を明記。
 
 ### CI 網
 - [ ] QA1: xlsx smoke

--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -75,10 +75,17 @@ impl DocxArchive {
     /// Copy `data` into WASM once and open the ZIP central directory once.
     /// `max_zip_entry_bytes` is retained and applied on every subsequent method
     /// call (identical semantics to the free functions' `scoped_max` guard).
+    ///
+    /// `data` is taken by value (`Vec<u8>`): wasm-bindgen copies the JS `Uint8Array`
+    /// once into a WASM-owned buffer and hands that allocation to Rust as this
+    /// `Vec`, which `Cursor` then takes by value — a single copy across the
+    /// JS→WASM boundary. Taking `&[u8]` would force a second `to_vec()` copy so
+    /// the `Cursor` could own its backing store, transiently doubling WASM
+    /// linear memory to ~2x the file size during construction.
     #[wasm_bindgen(constructor)]
-    pub fn new(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<DocxArchive, JsValue> {
+    pub fn new(data: Vec<u8>, max_zip_entry_bytes: Option<u64>) -> Result<DocxArchive, JsValue> {
         console_error_panic_hook::set_once();
-        let archive = zip::ZipArchive::new(std::io::Cursor::new(data.to_vec()))
+        let archive = zip::ZipArchive::new(std::io::Cursor::new(data))
             .map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
         Ok(DocxArchive {
             archive,

--- a/packages/docx/src/scroll-viewer-concurrent-load.test.ts
+++ b/packages/docx/src/scroll-viewer-concurrent-load.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxScrollViewer } from './scroll-viewer.js';
+import { DocxDocument } from './document.js';
+import { installDom, makeContainer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SIZE = [{ widthPt: 100, heightPt: 200 }];
+
+/**
+ * Concurrent-load latch for the SELF-LOADED scroll viewer (composes with SC20's
+ * success-after-swap). Two overlapping `load(A)`/`load(B)` calls race the WASM
+ * parse / worker init; the stale one resolving LAST must NOT win the swap — it
+ * destroys its own just-loaded engine and leaves the winner (its engine +
+ * recycle/relayout post-load work) untouched. An injected engine can never orphan
+ * (load() throws up-front there), so this only covers the self-loading path.
+ */
+describe('DocxScrollViewer.load() — concurrent-load latch', () => {
+  function build() {
+    installDom();
+    const container = makeContainer(200, 400);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { gap: 10 });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    return { v };
+  }
+
+  function deferredLoad(engine: FakeDocxEngine): { resolve: () => void; promise: Promise<DocxDocument> } {
+    let resolve!: () => void;
+    const promise = new Promise<DocxDocument>((r) => {
+      resolve = () => r(engine.asDoc());
+    });
+    return { resolve, promise };
+  }
+
+  it('the later-started load winning first leaves the stale load a no-op (its engine destroyed)', async () => {
+    const { v } = build();
+    const a = new FakeDocxEngine(4, SIZE);
+    const b = new FakeDocxEngine(4, SIZE);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(DocxDocument, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const pa = v.load('a.docx'); // gen 1
+    const pb = v.load('b.docx'); // gen 2 — supersedes A
+
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false);
+    expect(a.destroyed).toBe(false);
+
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // loser's engine cleaned up (no leak)
+    expect(b.destroyed).toBe(false); // winner untouched — still current
+    expect(v.pageCount).toBe(4);
+
+    v.destroy();
+    expect(b.destroyed).toBe(true);
+    expect(a.destroyed).toBe(true);
+  });
+
+  it('resolving in start order (A then B) behaves like today — B wins normally', async () => {
+    const { v } = build();
+    const a = new FakeDocxEngine(4, SIZE);
+    const b = new FakeDocxEngine(4, SIZE);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(DocxDocument, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const pa = v.load('a.docx');
+    const pb = v.load('b.docx');
+
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // superseded loser cleaned up
+
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false);
+    expect(v.pageCount).toBe(4);
+
+    v.destroy();
+    expect(b.destroyed).toBe(true);
+  });
+});

--- a/packages/docx/src/scroll-viewer-reload-orphan.test.ts
+++ b/packages/docx/src/scroll-viewer-reload-orphan.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxScrollViewer } from './scroll-viewer.js';
+import { DocxDocument } from './document.js';
+import { installDom, makeContainer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SIZE = [{ widthPt: 100, heightPt: 200 }];
+
+/**
+ * SC20 for the scroll viewer: a SELF-LOADED (non-injected) scroll viewer owns its
+ * engine, so a second `load()` must destroy the previous one instead of orphaning
+ * its worker + WASM. (An injected engine is caller-owned — load() throws there.)
+ */
+describe('DocxScrollViewer.load() — no orphaned engine on re-load (SC20)', () => {
+  function build(opts = {}) {
+    installDom();
+    const container = makeContainer(200, 400);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, { gap: 10, ...opts });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    return { v };
+  }
+
+  it('destroys the previous engine when a self-loaded viewer is re-loaded', async () => {
+    const { v } = build();
+    const first = new FakeDocxEngine(4, SIZE);
+    const second = new FakeDocxEngine(4, SIZE);
+    vi.spyOn(DocxDocument, 'load')
+      .mockResolvedValueOnce(first.asDoc())
+      .mockResolvedValueOnce(second.asDoc());
+
+    await v.load('one.docx');
+    expect(first.destroyed).toBe(false);
+
+    await v.load('two.docx');
+    expect(first.destroyed).toBe(true);
+    expect(second.destroyed).toBe(false);
+
+    v.destroy();
+    expect(second.destroyed).toBe(true);
+  });
+
+  it('keeps the current engine when the re-load fails (atomic swap)', async () => {
+    const onError = vi.fn();
+    const { v } = build({ onError });
+    const first = new FakeDocxEngine(4, SIZE);
+    vi.spyOn(DocxDocument, 'load')
+      .mockResolvedValueOnce(first.asDoc())
+      .mockRejectedValueOnce(new Error('boom'));
+
+    await v.load('one.docx');
+    await v.load('bad.docx');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(first.destroyed).toBe(false);
+    expect(v.pageCount).toBe(4);
+
+    v.destroy();
+    expect(first.destroyed).toBe(true);
+  });
+});

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -180,6 +180,23 @@ export class DocxScrollViewer {
    *  reporting an error so a rejection that lands after teardown is swallowed
    *  rather than surfaced to a `onError` on a dead viewer. */
   private _destroyed = false;
+  /**
+   * Concurrent-load latch (generation token). Every self-loading `load()`
+   * increments this and captures the value; after its engine finishes loading it
+   * re-checks the live value and BAILS (destroying its own just-loaded engine) if
+   * a newer `load()` has since started. Without it, two overlapping
+   * `load(A)`/`load(B)` calls race the WASM parse / worker init, and whichever
+   * RESOLVES last wins the swap — even the stale `load(A)` resolving after
+   * `load(B)`; the loser's freshly created engine (never installed, or installed
+   * then overwritten) then leaks its worker + pinned WASM allocation. The latch
+   * composes with SC20: the check runs AFTER the new engine loads but BEFORE the
+   * field assignment, `previous?.destroy()`, and the recycle/relayout post-load
+   * work, so a superseded load never touches `this._doc` nor frees the current
+   * (newer) engine. Only the self-loading path uses it — the injected path throws
+   * up-front and never reaches here. `destroy()` also bumps it so a load in flight
+   * at teardown is treated as superseded and its engine cleaned up.
+   */
+  private _loadGen = 0;
   /** Worker mode: page indices whose bitmap render is currently dispatched to the
    *  engine. Coalesces a scroll storm — we never dispatch a second render for a
    *  page whose first is still in flight — and lets us drop pages that scrolled
@@ -337,9 +354,10 @@ export class DocxScrollViewer {
     // re-load then keeps the current document rendered rather than going blank.
     // (The injected path returned above can never reach here, so this only ever
     // frees an engine we created.)
+    const gen = ++this._loadGen;
     const previous = this._doc;
     try {
-      this._doc = await DocxDocument.load(source, {
+      const doc = await DocxDocument.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         workerTimeoutMs: this._opts.workerTimeoutMs,
@@ -347,6 +365,16 @@ export class DocxScrollViewer {
         math: this._opts.math,
         mode: this._mode,
       });
+      if (gen !== this._loadGen) {
+        // A newer load() (or destroy()) started while this one was in flight — we
+        // lost the concurrent-load race. Destroy the engine we just loaded (it was
+        // never installed) and leave the winning load's engine + SC20 swap + its
+        // recycle/relayout work untouched: do NOT touch `this._doc` and do NOT
+        // destroy `previous` (irrelevant to the winner; possibly already stale).
+        doc.destroy();
+        return;
+      }
+      this._doc = doc;
       previous?.destroy();
       if (previous) {
         // Re-loading over a prior document: recycle every mounted slot (they hold
@@ -363,6 +391,9 @@ export class DocxScrollViewer {
       // appears.
       this.relayout();
     } catch (err) {
+      // Superseded loads own no error reporting — the winning load (or destroy())
+      // is the outcome the caller awaits; swallow this stale rejection.
+      if (gen !== this._loadGen) return;
       const e = err instanceof Error ? err : new Error(String(err));
       if (this._opts.onError) {
         this._opts.onError(e);
@@ -1270,6 +1301,10 @@ export class DocxScrollViewer {
    */
   destroy(): void {
     this._destroyed = true;
+    // Bump the load generation so a self-loading load() still in flight is treated
+    // as superseded and its engine is cleaned up rather than installed onto a
+    // torn-down viewer.
+    this._loadGen++;
     if (this._scrollListener) {
       this._scrollHost.removeEventListener('scroll', this._scrollListener);
       this._scrollListener = null;

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -331,6 +331,13 @@ export class DocxScrollViewer {
         'DocxScrollViewer.load() is unsupported when an engine is injected via opts.document; the injected engine is already loaded.',
       );
     }
+    // SC20 atomic swap: a self-loaded viewer OWNS its engine (destroy() tears it
+    // down when `!_injected`), so a re-load must not orphan the previous one.
+    // Retain it locally and free it only after the new engine loads — a FAILED
+    // re-load then keeps the current document rendered rather than going blank.
+    // (The injected path returned above can never reach here, so this only ever
+    // frees an engine we created.)
+    const previous = this._doc;
     try {
       this._doc = await DocxDocument.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
@@ -340,6 +347,16 @@ export class DocxScrollViewer {
         math: this._opts.math,
         mode: this._mode,
       });
+      previous?.destroy();
+      if (previous) {
+        // Re-loading over a prior document: recycle every mounted slot (they hold
+        // the OLD document's rendered canvases) and reset the top-index latch so
+        // the new document's first window renders fresh. `_mountVisible` only
+        // RE-renders missing indices, so without this a still-mounted page 0 would
+        // keep the previous document's pixels.
+        for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
+        this._lastTopIndex = -1;
+      }
       // Lay out + mount the first window now that the engine exists (mirrors the
       // injected-engine path in the constructor). relayout() is idempotent and
       // defers under a zero-width container — `_onResize` re-runs it once width

--- a/packages/docx/src/viewer-concurrent-load.test.ts
+++ b/packages/docx/src/viewer-concurrent-load.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxViewer } from './viewer.js';
+import { DocxDocument } from './document.js';
+import { installDom, makeEl, FakeDocxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const A4 = [{ widthPt: 595, heightPt: 842 }];
+
+/**
+ * Concurrent-load latch (composes with SC20's success-after-swap): if a caller
+ * fires `load(A)` and, before it resolves, `load(B)`, both loads race the WASM
+ * parse / worker init concurrently. Whichever resolves LAST must NOT win the swap
+ * when it is the stale one — the loser's freshly-loaded engine (never installed,
+ * or installed then overwritten) must be destroyed, not leaked, and the winner's
+ * engine must stay live and untouched. A generation token (`_loadGen`) closes it.
+ */
+describe('DocxViewer.load() — concurrent-load latch', () => {
+  function mount() {
+    installDom();
+    return { canvas: makeEl('canvas') };
+  }
+
+  /** A load whose resolution the test controls, so two loads can overlap and
+   *  resolve in a chosen order. */
+  function deferredLoad(engine: FakeDocxEngine): { resolve: () => void; promise: Promise<DocxDocument> } {
+    let resolve!: () => void;
+    const promise = new Promise<DocxDocument>((r) => {
+      resolve = () => r(engine.asDoc());
+    });
+    return { resolve, promise };
+  }
+
+  it('the later-started load winning first leaves the stale load a no-op (its engine destroyed)', async () => {
+    const { canvas } = mount();
+    const a = new FakeDocxEngine(2, A4);
+    const b = new FakeDocxEngine(2, A4);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(DocxDocument, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement);
+    const pa = v.load('a.docx'); // gen 1
+    const pb = v.load('b.docx'); // gen 2 — supersedes A
+
+    // B (the later-started load) resolves FIRST and installs normally via SC20.
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false); // winner is live
+    expect(a.destroyed).toBe(false); // A's engine not even loaded yet
+
+    // A resolves LATE. It lost the race (gen 1 ≠ live gen 2): it must destroy its
+    // OWN engine and NOT touch the installed winner B.
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // loser's engine cleaned up (no leak)
+    expect(b.destroyed).toBe(false); // winner untouched — still current
+
+    v.destroy();
+    expect(b.destroyed).toBe(true); // only B is torn down by destroy()
+    expect(a.destroyed).toBe(true); // and it was closed exactly once (still true)
+  });
+
+  it('resolving in start order (A then B) behaves like today — B wins normally', async () => {
+    const { canvas } = mount();
+    const a = new FakeDocxEngine(2, A4);
+    const b = new FakeDocxEngine(2, A4);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(DocxDocument, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement);
+    const pa = v.load('a.docx'); // gen 1
+    const pb = v.load('b.docx'); // gen 2
+
+    // A resolves first but is already superseded: it installs nothing and destroys
+    // its own engine. B resolves next and wins the swap (SC20 unaffected).
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // superseded loser cleaned up
+
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false); // winner is current
+    expect(v.pageCount).toBe(2);
+
+    v.destroy();
+    expect(b.destroyed).toBe(true);
+  });
+
+  it('does not double-destroy or leak when only one load runs (regression guard)', async () => {
+    const { canvas } = mount();
+    const only = new FakeDocxEngine(2, A4);
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(only.asDoc());
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement);
+    await v.load('one.docx');
+    expect(only.destroyed).toBe(false); // installed, never superseded
+    v.destroy();
+    expect(only.destroyed).toBe(true); // destroyed exactly once
+  });
+});

--- a/packages/docx/src/viewer-destroy-during-render.test.ts
+++ b/packages/docx/src/viewer-destroy-during-render.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxViewer } from './viewer.js';
+import { DocxDocument } from './document.js';
+import { installDom, makeEl, FakeDocxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const A4 = [{ widthPt: 595, heightPt: 842 }];
+
+/** Drain the microtask queue so an awaited chain (mocked load → deferred render)
+ *  reaches its next suspension point before the test inspects recorded calls. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+}
+
+/**
+ * Destroy-during-render guard: a render dispatched before `destroy()` can reject
+ * AFTER teardown (the worker/WASM resolve late). The `_destroyed` flag (set as the
+ * first line of `destroy()`) makes `_reportRenderError` swallow such a rejection
+ * so it never fires `onError` / `console.error` on a dead viewer — parity with the
+ * scroll viewers' existing `_destroyed` guard.
+ */
+describe('DocxViewer — destroy-during-render guard', () => {
+  function mount() {
+    installDom();
+    return { canvas: makeEl('canvas') };
+  }
+
+  it('swallows a render rejection that lands after destroy() (no onError)', async () => {
+    const { canvas } = mount();
+    // deferred=true: renderPage returns a promise the test rejects manually, so
+    // the first-page render is still in flight across destroy().
+    const engine = new FakeDocxEngine(2, A4, 'main', true);
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+    const onError = vi.fn();
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+
+    // load() awaits the first render, which is deferred — kick it off but don't
+    // await, so the render call is recorded and pending. Flush the microtasks that
+    // resolve the (mocked) DocxDocument.load and reach the deferred renderPage.
+    const loadPromise = v.load('x.docx');
+    await flushMicrotasks();
+    // The initial render dispatched by load() is the last recorded renderPage call.
+    const call = engine.renderCalls[engine.renderCalls.length - 1];
+    expect(call).toBeDefined();
+
+    // Tear down while the render is in flight, THEN let it reject.
+    v.destroy();
+    call.reject(new Error('late render boom'));
+    await loadPromise;
+    // Give the rejection a microtask to propagate into _render's catch.
+    await Promise.resolve();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('swallows a render rejection after destroy() with no onError (no console.error)', async () => {
+    const { canvas } = mount();
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const engine = new FakeDocxEngine(2, A4, 'main', true);
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement);
+
+    const loadPromise = v.load('x.docx');
+    await flushMicrotasks();
+    const call = engine.renderCalls[engine.renderCalls.length - 1];
+    v.destroy();
+    call.reject(new Error('late render boom'));
+    await loadPromise;
+    await Promise.resolve();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docx/src/viewer-reload-orphan.test.ts
+++ b/packages/docx/src/viewer-reload-orphan.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxViewer } from './viewer.js';
+import { DocxDocument } from './document.js';
+import { installDom, makeEl, FakeDocxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const A4 = [{ widthPt: 595, heightPt: 842 }];
+
+/**
+ * SC20: a second `load()` must not orphan the previous engine (its worker +
+ * pinned WASM). The fix is an atomic swap — load the new engine first, destroy
+ * the old one only on success.
+ */
+describe('DocxViewer.load() — no orphaned engine on re-load (SC20)', () => {
+  function mount() {
+    installDom();
+    const canvas = makeEl('canvas');
+    return { canvas };
+  }
+
+  it('destroys the previous engine when load() is called again', async () => {
+    const { canvas } = mount();
+    const first = new FakeDocxEngine(2, A4);
+    const second = new FakeDocxEngine(2, A4);
+    const loadSpy = vi
+      .spyOn(DocxDocument, 'load')
+      .mockResolvedValueOnce(first.asDoc())
+      .mockResolvedValueOnce(second.asDoc());
+
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement);
+    await v.load('one.docx');
+    expect(first.destroyed).toBe(false);
+
+    await v.load('two.docx');
+    expect(loadSpy).toHaveBeenCalledTimes(2);
+    expect(first.destroyed).toBe(true);
+    expect(second.destroyed).toBe(false);
+
+    v.destroy();
+    expect(second.destroyed).toBe(true);
+  });
+
+  it('keeps the current engine when the re-load fails (atomic swap)', async () => {
+    const { canvas } = mount();
+    const first = new FakeDocxEngine(2, A4);
+    vi.spyOn(DocxDocument, 'load')
+      .mockResolvedValueOnce(first.asDoc())
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const onError = vi.fn();
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+    await v.load('one.docx');
+
+    await v.load('bad.docx');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(first.destroyed).toBe(false);
+    expect(v.pageCount).toBe(2);
+
+    v.destroy();
+    expect(first.destroyed).toBe(true);
+  });
+});

--- a/packages/docx/src/viewer-render-error.test.ts
+++ b/packages/docx/src/viewer-render-error.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxViewer } from './viewer.js';
+import { DocxDocument } from './document.js';
+import { installDom, makeEl, FakeDocxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const A4 = [{ widthPt: 595, heightPt: 842 }];
+
+/** A FakeDocxEngine whose `renderPage` throws, to exercise the render-error path
+ *  (the base fake resolves; we override just renderPage). */
+function throwingEngine(): FakeDocxEngine {
+  const e = new FakeDocxEngine(2, A4);
+  (e as unknown as { renderPage: () => Promise<void> }).renderPage = () => {
+    throw new Error('render boom');
+  };
+  return e;
+}
+
+/**
+ * PD14: a failed page render must follow the scroll-viewer contract — invoke
+ * `onError` if provided, else `console.error` (never silent), and never
+ * propagate (which from a `void`-style `nextPage()` would be an unhandled
+ * rejection). Before the fix `_render` had no try/catch and rethrew to its
+ * caller.
+ */
+describe('DocxViewer render error contract (PD14)', () => {
+  function mount() {
+    installDom();
+    return { canvas: makeEl('canvas') };
+  }
+
+  it('routes a render failure to onError during load() and resolves', async () => {
+    const { canvas } = mount();
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(throwingEngine().asDoc());
+    const onError = vi.fn();
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+    await expect(v.load('x.docx')).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toContain('boom');
+    v.destroy();
+  });
+
+  it('routes a render failure to onError during goToPage() (no rejection)', async () => {
+    const { canvas } = mount();
+    const good = new FakeDocxEngine(2, A4);
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(good.asDoc());
+    const onError = vi.fn();
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+    await v.load('x.docx');
+    expect(onError).not.toHaveBeenCalled(); // clean first render
+
+    // Now make subsequent renders throw and navigate.
+    (good as unknown as { renderPage: () => Promise<void> }).renderPage = () => {
+      throw new Error('nav boom');
+    };
+    await expect(v.nextPage()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toContain('nav boom');
+    v.destroy();
+  });
+
+  it('falls back to console.error when no onError is provided (never silent)', async () => {
+    const { canvas } = mount();
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(throwingEngine().asDoc());
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement);
+    await expect(v.load('x.docx')).resolves.toBeUndefined();
+    expect(spy).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+});

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -176,6 +176,27 @@ export class DocxViewer {
   }
 
   private async _render(): Promise<void> {
+    // PD14 render-error contract (shared with the scroll viewers): navigation
+    // (`nextPage`/`prevPage`/`goToPage`) is often called `void`-style, so an
+    // unguarded throw would surface as an unhandled promise rejection. Catch here
+    // and route to `onError` (or `console.error` — never silent) so a page render
+    // failure is handled the same way in `load()` and every navigation.
+    try {
+      await this._renderPage();
+    } catch (err) {
+      this._reportRenderError(err);
+    }
+  }
+
+  /** Route a render failure to `onError`, or `console.error` when none is given
+   *  (never fully silent). Mirrors the scroll viewers' `_reportRenderError`. */
+  private _reportRenderError(err: unknown): void {
+    const e = err instanceof Error ? err : new Error(String(err));
+    if (this._opts.onError) this._opts.onError(e);
+    else console.error('[ooxml] DocxViewer render failed:', e);
+  }
+
+  private async _renderPage(): Promise<void> {
     if (!this._doc) return;
     const isWorker = this._mode === 'worker';
     // In worker mode rendering happens off the main thread, so the onTextRun

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -90,8 +90,15 @@ export class DocxViewer {
    * the error is rethrown so it is never silently swallowed.
    */
   async load(source: string | ArrayBuffer): Promise<void> {
+    // SC20 atomic swap: retain the previous engine locally and only tear it down
+    // AFTER the new one loads successfully. A re-load thus never orphans the old
+    // engine's worker + pinned WASM allocation (the leak this guards), yet a
+    // FAILED re-load keeps the current document + its rendered page intact rather
+    // than dropping to an empty viewer. The 2× memory window is bounded to the
+    // load itself (the old engine is freed the moment the new model arrives).
+    const previous = this._doc;
     try {
-      this._doc = await DocxDocument.load(source, {
+      const doc = await DocxDocument.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         workerTimeoutMs: this._opts.workerTimeoutMs,
@@ -99,6 +106,8 @@ export class DocxViewer {
         math: this._opts.math,
         mode: this._mode,
       });
+      this._doc = doc;
+      previous?.destroy();
       this._currentPage = 0;
       await this._render();
     } catch (err) {

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -39,6 +39,26 @@ export class DocxViewer {
    *  never used on the same canvas). */
   private _bitmapCtx: ImageBitmapRenderingContext | null = null;
   private _warnedNoTextSelection = false;
+  /** Set by {@link destroy} (first line). Guards {@link _reportRenderError} so a
+   *  render rejection that lands AFTER teardown is swallowed rather than surfaced
+   *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
+   *  viewers' `_destroyed` flag. */
+  private _destroyed = false;
+  /**
+   * Concurrent-load latch (generation token). Every {@link load} increments this
+   * and captures the value; after its engine finishes loading it re-checks the
+   * live value and BAILS (destroying its own just-loaded engine) if a newer
+   * `load()` has since started. Without it, two overlapping `load(A)`/`load(B)`
+   * calls race the WASM parse / worker init, and whichever RESOLVES last wins the
+   * swap — even the stale `load(A)` resolving after `load(B)`; the loser's freshly
+   * created engine (never installed, or installed then overwritten) then leaks its
+   * worker + pinned WASM allocation. The latch composes with SC20: the check runs
+   * AFTER the new engine loads but BEFORE the field assignment and
+   * `previous?.destroy()`, so a superseded load never touches `this._doc` nor
+   * frees the current (newer) engine. {@link destroy} also bumps it so a load in
+   * flight at teardown is treated as superseded and its engine cleaned up.
+   */
+  private _loadGen = 0;
 
   constructor(canvas: HTMLCanvasElement, opts: DocxViewerOptions = {}) {
     this._canvas = canvas;
@@ -96,6 +116,7 @@ export class DocxViewer {
     // FAILED re-load keeps the current document + its rendered page intact rather
     // than dropping to an empty viewer. The 2× memory window is bounded to the
     // load itself (the old engine is freed the moment the new model arrives).
+    const gen = ++this._loadGen;
     const previous = this._doc;
     try {
       const doc = await DocxDocument.load(source, {
@@ -106,11 +127,23 @@ export class DocxViewer {
         math: this._opts.math,
         mode: this._mode,
       });
+      if (gen !== this._loadGen) {
+        // A newer load() (or destroy()) started while this one was in flight — we
+        // lost the concurrent-load race. Destroy the engine we just loaded (it was
+        // never installed) and leave the winning load's engine + SC20 swap
+        // untouched: do NOT touch `this._doc` and do NOT destroy `previous`
+        // (irrelevant to the winner; possibly already stale).
+        doc.destroy();
+        return;
+      }
       this._doc = doc;
       previous?.destroy();
       this._currentPage = 0;
       await this._render();
     } catch (err) {
+      // Superseded loads own no error reporting — the winning load (or destroy())
+      // is the outcome the caller awaits; swallow this stale rejection.
+      if (gen !== this._loadGen) return;
       const e = err instanceof Error ? err : new Error(String(err));
       if (this._opts.onError) {
         this._opts.onError(e);
@@ -153,6 +186,12 @@ export class DocxViewer {
    * is simply removed from the internal wrapper. Safe to call more than once.
    */
   destroy(): void {
+    // First line: block any render rejection racing in from surfacing on a dead
+    // viewer (checked at the top of _reportRenderError). Bump the load generation
+    // too so a load() still in flight is treated as superseded and its engine is
+    // cleaned up rather than installed onto a torn-down viewer.
+    this._destroyed = true;
+    this._loadGen++;
     this._doc?.destroy();
     this._doc = null;
     // Return the caller-owned canvas to its original DOM slot before discarding
@@ -189,8 +228,10 @@ export class DocxViewer {
   }
 
   /** Route a render failure to `onError`, or `console.error` when none is given
-   *  (never fully silent). Mirrors the scroll viewers' `_reportRenderError`. */
+   *  (never fully silent), and never after teardown. Mirrors the scroll viewers'
+   *  `_reportRenderError`. */
   private _reportRenderError(err: unknown): void {
+    if (this._destroyed) return;
     const e = err instanceof Error ? err : new Error(String(err));
     if (this._opts.onError) this._opts.onError(e);
     else console.error('[ooxml] DocxViewer render failed:', e);

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -105,9 +105,15 @@ export class DocxViewer {
   /**
    * Load a DOCX from URL or ArrayBuffer and render the first page.
    *
-   * Error contract (shared by all three viewers): on failure, if an `onError`
-   * callback was provided it is invoked and `load` resolves normally; if not,
-   * the error is rethrown so it is never silently swallowed.
+   * Error contract (shared by all three viewers):
+   * - Parse/load failure (the underlying `DocxDocument.load()` call itself
+   *   rejects): if an `onError` callback was provided it is invoked and `load`
+   *   resolves normally; if not, the error is rethrown so it is never silently
+   *   swallowed.
+   * - Render failure (the first page fails to draw AFTER a successful
+   *   parse/load): routed to the shared `_reportRenderError` contract (`onError`
+   *   if provided, else `console.error` — never silent) and `load` still
+   *   RESOLVES, matching every subsequent navigation call.
    */
   async load(source: string | ArrayBuffer): Promise<void> {
     // SC20 atomic swap: retain the previous engine locally and only tear it down

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -62,10 +62,14 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
     }
     if (req.type === 'extractImage') {
       if (!archive) throw new Error('No docx loaded');
-      const bytes = archive.extract_image(req.path);
-      const copy = new Uint8Array(bytes).slice().buffer;
-      const res: WorkerResponse = { type: 'imageExtracted', id, bytes: copy };
-      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [copy]);
+      // wasm-bindgen already hands back a fresh, standalone Uint8Array here (its
+      // glue does `getArrayU8FromWasm0(ptr,len).slice()` then frees the Rust Vec),
+      // so `.buffer` is a full-span, non-WASM-backed ArrayBuffer we own outright —
+      // transfer it directly. A second `new Uint8Array(bytes).slice()` would just
+      // re-copy the whole entry for nothing.
+      const out = archive.extract_image(req.path).buffer as ArrayBuffer;
+      const res: WorkerResponse = { type: 'imageExtracted', id, bytes: out };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [out]);
       return;
     }
   } catch (err) {

--- a/packages/node/src/archive-extract-transfer.test.ts
+++ b/packages/node/src/archive-extract-transfer.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { crc32 } from 'node:zlib';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — wasm-pack generated JS without a d.ts entry for the bare module path
+import * as pptxWasm from '../../pptx/src/wasm/pptx_parser.js';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import * as docxWasm from '../../docx/src/wasm/docx_parser.js';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import * as xlsxWasm from '../../xlsx/src/wasm/xlsx_parser.js';
+import { loadWasmModule, resolveWasm } from './wasm-loader.ts';
+
+/**
+ * SC18 contract: the wasm-bindgen glue for `{Pptx,Docx,Xlsx}Archive.extract_*`
+ * returns an INDEPENDENT `Uint8Array` — the glue does
+ * `getArrayU8FromWasm0(ptr, len).slice()` then `__wbindgen_free`s the Rust Vec,
+ * so the returned array (a) no longer aliases WASM linear memory and (b) is
+ * full-span over its own `ArrayBuffer` (byteOffset 0, byteLength === buffer
+ * length). Those two facts are exactly what let the three `worker.ts` files
+ * transfer `bytes.buffer` DIRECTLY instead of re-copying via
+ * `new Uint8Array(bytes).slice().buffer`. This test pins the contract so a
+ * future wasm-bindgen upgrade that returned a memory VIEW (which would make a
+ * direct transfer unsafe / throw) fails here loudly.
+ */
+
+// Minimal one-entry STORED zip, same builder shape as source-buffer-image.test.
+function makeZipWithEntry(name: string, data: Uint8Array): Uint8Array {
+  const enc = new TextEncoder();
+  const nameBytes = enc.encode(name);
+  const crc = crc32(Buffer.from(data)) >>> 0;
+  const size = data.length;
+
+  const local = new Uint8Array(30 + nameBytes.length + size);
+  const lv = new DataView(local.buffer);
+  lv.setUint32(0, 0x04034b50, true);
+  lv.setUint16(4, 20, true);
+  lv.setUint16(8, 0, true); // stored
+  lv.setUint32(14, crc, true);
+  lv.setUint32(18, size, true);
+  lv.setUint32(22, size, true);
+  lv.setUint16(26, nameBytes.length, true);
+  local.set(nameBytes, 30);
+  local.set(data, 30 + nameBytes.length);
+
+  const central = new Uint8Array(46 + nameBytes.length);
+  const cv = new DataView(central.buffer);
+  cv.setUint32(0, 0x02014b50, true);
+  cv.setUint16(4, 20, true);
+  cv.setUint16(6, 20, true);
+  cv.setUint32(16, crc, true);
+  cv.setUint32(20, size, true);
+  cv.setUint32(24, size, true);
+  cv.setUint16(28, nameBytes.length, true);
+  central.set(nameBytes, 46);
+
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, 1, true);
+  ev.setUint16(10, 1, true);
+  ev.setUint32(12, central.length, true);
+  ev.setUint32(16, local.length, true);
+
+  const out = new Uint8Array(local.length + central.length + eocd.length);
+  out.set(local, 0);
+  out.set(central, local.length);
+  out.set(eocd, local.length + central.length);
+  return out;
+}
+
+interface ArchiveHandle {
+  extract_image(path: string): Uint8Array;
+  free(): void;
+}
+interface PptxHandle extends ArchiveHandle {
+  extract_media(path: string): Uint8Array;
+}
+
+let wasmReady = false;
+beforeAll(() => {
+  try {
+    loadWasmModule(
+      pptxWasm as unknown as { initSync: (m: WebAssembly.Module) => unknown },
+      resolveWasm(import.meta.url, '../../pptx/src/wasm/pptx_parser_bg.wasm'),
+    );
+    loadWasmModule(
+      docxWasm as unknown as { initSync: (m: WebAssembly.Module) => unknown },
+      resolveWasm(import.meta.url, '../../docx/src/wasm/docx_parser_bg.wasm'),
+    );
+    loadWasmModule(
+      xlsxWasm as unknown as { initSync: (m: WebAssembly.Module) => unknown },
+      resolveWasm(import.meta.url, '../../xlsx/src/wasm/xlsx_parser_bg.wasm'),
+    );
+    wasmReady = true;
+  } catch {
+    wasmReady = false;
+  }
+});
+
+/** Assert the returned array is byte-correct AND a transfer-safe, full-span,
+ *  non-WASM-aliasing buffer (the SC18 precondition for a direct transfer). */
+function assertIndependentFullSpan(bytes: Uint8Array, expected: Uint8Array) {
+  // Byte-correct: the copy the glue made preserves the entry contents.
+  expect(Array.from(bytes)).toEqual(Array.from(expected));
+  // Full-span: a bare `.buffer` transfer carries exactly these bytes, nothing
+  // else (no shared arena, no leading/trailing slop from a subarray view).
+  expect(bytes.byteOffset).toBe(0);
+  expect(bytes.byteLength).toBe(bytes.buffer.byteLength);
+  // Independent of WASM linear memory: an ArrayBuffer is transferable only if it
+  // is not WASM-backed. structuredClone with transfer succeeds here and detaches
+  // the buffer — it would throw for a WASM-memory view.
+  const buf = bytes.buffer;
+  expect(() => structuredClone(buf, { transfer: [buf] })).not.toThrow();
+  expect(buf.byteLength).toBe(0); // detached by the transfer → was standalone
+}
+
+describe('SC18 extract_* returns a transfer-safe buffer', () => {
+  it('pptx: extract_image + extract_media are independent full-span copies', () => {
+    if (!wasmReady) return;
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4, 5, 6]);
+    const mp4 = new Uint8Array([0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70]);
+    // Each path lives in its own one-entry zip (the builder is single-entry).
+    const zip = makeZipWithEntry('ppt/media/image1.png', png);
+    const Handle = (pptxWasm as unknown as { PptxArchive: new (b: Uint8Array) => PptxHandle })
+      .PptxArchive;
+    const ar = new Handle(zip);
+    try {
+      assertIndependentFullSpan(ar.extract_image('ppt/media/image1.png'), png);
+    } finally {
+      ar.free();
+    }
+
+    const zip2 = makeZipWithEntry('ppt/media/media2.mp4', mp4);
+    const ar2 = new Handle(zip2);
+    try {
+      assertIndependentFullSpan(ar2.extract_media('ppt/media/media2.mp4'), mp4);
+    } finally {
+      ar2.free();
+    }
+  });
+
+  it('docx: extract_image is an independent full-span copy', () => {
+    if (!wasmReady) return;
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 9, 8, 7]);
+    const zip = makeZipWithEntry('word/media/image1.png', png);
+    const Handle = (docxWasm as unknown as { DocxArchive: new (b: Uint8Array) => ArchiveHandle })
+      .DocxArchive;
+    const ar = new Handle(zip);
+    try {
+      assertIndependentFullSpan(ar.extract_image('word/media/image1.png'), png);
+    } finally {
+      ar.free();
+    }
+  });
+
+  it('xlsx: extract_image is an independent full-span copy', () => {
+    if (!wasmReady) return;
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 42, 43]);
+    const zip = makeZipWithEntry('xl/media/image1.png', png);
+    const Handle = (xlsxWasm as unknown as { XlsxArchive: new (b: Uint8Array) => ArchiveHandle })
+      .XlsxArchive;
+    const ar = new Handle(zip);
+    try {
+      assertIndependentFullSpan(ar.extract_image('xl/media/image1.png'), png);
+    } finally {
+      ar.free();
+    }
+  });
+});

--- a/packages/node/src/archive-extract-transfer.test.ts
+++ b/packages/node/src/archive-extract-transfer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { crc32 } from 'node:zlib';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — wasm-pack generated JS without a d.ts entry for the bare module path
@@ -77,8 +77,13 @@ interface PptxHandle extends ArchiveHandle {
   extract_media(path: string): Uint8Array;
 }
 
-let wasmReady = false;
-beforeAll(() => {
+// The WASM parser bindings are git-ignored build output. CI runs `pnpm build:wasm`
+// before `pnpm test`, so they are present there; but a local run before a wasm
+// build (or a stripped environment) may lack them. Probe once via a top-level-await
+// IIFE and gate the whole suite with `describe.skipIf` so it reports as SKIPPED
+// (not a silent zero-assertion pass) when the wasm is unavailable — mirroring the
+// sibling `source-buffer-image.test.ts`.
+const wasmReady = await (async () => {
   try {
     loadWasmModule(
       pptxWasm as unknown as { initSync: (m: WebAssembly.Module) => unknown },
@@ -92,11 +97,11 @@ beforeAll(() => {
       xlsxWasm as unknown as { initSync: (m: WebAssembly.Module) => unknown },
       resolveWasm(import.meta.url, '../../xlsx/src/wasm/xlsx_parser_bg.wasm'),
     );
-    wasmReady = true;
+    return true;
   } catch {
-    wasmReady = false;
+    return false;
   }
-});
+})();
 
 /** Assert the returned array is byte-correct AND a transfer-safe, full-span,
  *  non-WASM-aliasing buffer (the SC18 precondition for a direct transfer). */
@@ -115,9 +120,8 @@ function assertIndependentFullSpan(bytes: Uint8Array, expected: Uint8Array) {
   expect(buf.byteLength).toBe(0); // detached by the transfer → was standalone
 }
 
-describe('SC18 extract_* returns a transfer-safe buffer', () => {
+describe.skipIf(!wasmReady)('SC18 extract_* returns a transfer-safe buffer', () => {
   it('pptx: extract_image + extract_media are independent full-span copies', () => {
-    if (!wasmReady) return;
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4, 5, 6]);
     const mp4 = new Uint8Array([0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70]);
     // Each path lives in its own one-entry zip (the builder is single-entry).
@@ -141,7 +145,6 @@ describe('SC18 extract_* returns a transfer-safe buffer', () => {
   });
 
   it('docx: extract_image is an independent full-span copy', () => {
-    if (!wasmReady) return;
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 9, 8, 7]);
     const zip = makeZipWithEntry('word/media/image1.png', png);
     const Handle = (docxWasm as unknown as { DocxArchive: new (b: Uint8Array) => ArchiveHandle })
@@ -155,7 +158,6 @@ describe('SC18 extract_* returns a transfer-safe buffer', () => {
   });
 
   it('xlsx: extract_image is an independent full-span copy', () => {
-    if (!wasmReady) return;
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 42, 43]);
     const zip = makeZipWithEntry('xl/media/image1.png', png);
     const Handle = (xlsxWasm as unknown as { XlsxArchive: new (b: Uint8Array) => ArchiveHandle })

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -152,10 +152,17 @@ impl PptxArchive {
     /// Copy `data` into WASM once and open the ZIP central directory once.
     /// `max_zip_entry_bytes` is retained and applied on every subsequent method
     /// call (identical semantics to the free functions' `scoped_max` guard).
+    ///
+    /// `data` is taken by value (`Vec<u8>`): wasm-bindgen copies the JS `Uint8Array`
+    /// once into a WASM-owned buffer and hands that allocation to Rust as this
+    /// `Vec`, which `Cursor` then takes by value — a single copy across the
+    /// JS→WASM boundary. Taking `&[u8]` would force a second `to_vec()` copy so
+    /// the `Cursor` could own its backing store, transiently doubling WASM
+    /// linear memory to ~2x the file size during construction.
     #[wasm_bindgen(constructor)]
-    pub fn new(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<PptxArchive, JsValue> {
+    pub fn new(data: Vec<u8>, max_zip_entry_bytes: Option<u64>) -> Result<PptxArchive, JsValue> {
         console_error_panic_hook::set_once();
-        let archive = zip::ZipArchive::new(Cursor::new(data.to_vec()))
+        let archive = zip::ZipArchive::new(Cursor::new(data))
             .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
         Ok(PptxArchive {
             archive,

--- a/packages/pptx/src/presentation.image.test.ts
+++ b/packages/pptx/src/presentation.image.test.ts
@@ -30,8 +30,6 @@ describe('PptxPresentation.getImage', () => {
     const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
     instance._bridge = { request };
     instance._imageCache = new Map<string, Promise<Blob>>();
-    instance._workerReady = true;
-    instance._waitForWorker = () => Promise.resolve();
     const pres = instance as unknown as GetImageProbe;
     return { pres, request };
   }

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -98,8 +98,6 @@ export class PptxPresentation {
    *  reference across every render also lets those caches hit across slides. */
   private readonly _fetchImage = (path: string, mime: string): Promise<Blob> =>
     this.getImage(path, mime);
-  private _workerReady = false;
-  private _workerReadyCallbacks: Array<() => void> = [];
   /** Opt-in OMML equation engine, injected once at {@link load}. Every
    *  `renderSlide` / `presentSlide` reuses it — equations render when present,
    *  and are skipped (engine tree-shaken) when omitted. */
@@ -109,16 +107,10 @@ export class PptxPresentation {
     this._worker = worker;
     this._mode = mode;
     this._bridge = new WorkerBridge<WorkerResponse | RenderWorkerResponse>(this._worker, {
-      // The init `ready` handshake carries no id; everything else does.
-      correlate: (msg) => ('id' in msg ? msg.id : undefined),
+      // Every response carries an id (no `ready` handshake — the worker `await`s
+      // its own init promise before each request, docx/xlsx pattern).
+      correlate: (msg) => msg.id,
       toError: (msg) => (msg.kind === 'error' ? msg.message : undefined),
-      onUnsolicited: (msg) => {
-        if (msg.kind === 'ready') {
-          this._workerReady = true;
-          for (const cb of this._workerReadyCallbacks) cb();
-          this._workerReadyCallbacks = [];
-        }
-      },
     });
     // Default: the parser WASM emitted next to this bundle, resolved relative to
     // the document URL. `wasmUrl` overrides it (CDN / self-hosted copy); a
@@ -178,18 +170,12 @@ export class PptxPresentation {
     return pres;
   }
 
-  private _waitForWorker(): Promise<void> {
-    if (this._workerReady) return Promise.resolve();
-    return new Promise((resolve) => this._workerReadyCallbacks.push(resolve));
-  }
-
   private async _parse(
     buffer: ArrayBuffer,
     maxZipEntryBytes?: number,
     useGoogleFonts = false,
     timeoutMs?: number,
   ): Promise<void> {
-    await this._waitForWorker();
     const res = await this._bridge.request(
       (id) =>
         this._mode === 'worker'
@@ -348,7 +334,6 @@ export class PptxPresentation {
     // re-types blobs from MediaElement.mimeType when it builds media controls.
     const mimeType = this._findMimeTypeForPath(mediaPath);
     const p = (async () => {
-      await this._waitForWorker();
       const res = await this._bridge.request(
         (id) => ({ kind: 'extractMedia', id, path: mediaPath }) satisfies WorkerRequest,
       );
@@ -375,7 +360,6 @@ export class PptxPresentation {
     const hit = this._imageCache.get(imagePath);
     if (hit) return hit;
     const p = (async () => {
-      await this._waitForWorker();
       const res = await this._bridge.request(
         (id) => ({ kind: 'extractImage', id, path: imagePath }) satisfies WorkerRequest,
       );

--- a/packages/pptx/src/render-worker-init-hang.test.ts
+++ b/packages/pptx/src/render-worker-init-hang.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * AR4 (worker-render mode twin of worker-init-hang): the render-capable worker
+ * carried the same `ready`-flag hazard. After the initPromise conversion a
+ * REJECTED WASM init must reject the pending request (`error` response) rather
+ * than leaving `load()` hanging. Driven against a mocked WASM module + stubbed
+ * `self`; only the parse arm is exercised (no OffscreenCanvas render needed).
+ */
+
+const initMock = vi.fn();
+class FakePptxArchive {
+  constructor(_bytes: Uint8Array, _max?: bigint) {}
+  parse(): Uint8Array {
+    return new TextEncoder().encode('{"slides":[],"slideWidth":0,"slideHeight":0}');
+  }
+  extract_media(): Uint8Array {
+    return new Uint8Array([1]);
+  }
+  extract_image(): Uint8Array {
+    return new Uint8Array([2]);
+  }
+  free(): void {}
+}
+
+vi.mock('./wasm/pptx_parser.js', () => ({
+  default: (arg: unknown) => initMock(arg),
+  PptxArchive: FakePptxArchive,
+}));
+
+interface FakeSelf {
+  onmessage: ((e: MessageEvent) => void) | null;
+  posted: unknown[];
+  postMessage: (msg: unknown, transfer?: Transferable[]) => void;
+}
+
+function installSelf(): FakeSelf {
+  const posted: unknown[] = [];
+  const fake: FakeSelf = {
+    onmessage: null,
+    posted,
+    postMessage: (msg: unknown) => {
+      posted.push(msg);
+    },
+  };
+  vi.stubGlobal('self', fake);
+  return fake;
+}
+
+async function loadRenderWorker(): Promise<FakeSelf> {
+  const fake = installSelf();
+  vi.resetModules();
+  await import('./render-worker.js');
+  return fake;
+}
+
+beforeEach(() => {
+  initMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('pptx render-worker.ts — init failure never hangs a request (AR4)', () => {
+  it('a parse after a REJECTED init responds with an error (not a hang)', async () => {
+    initMock.mockRejectedValue(new Error('render wasm boom'));
+    const fake = await loadRenderWorker();
+
+    fake.onmessage?.({ data: { kind: 'init', wasmUrl: 'x' } } as MessageEvent);
+    fake.onmessage?.({ data: { kind: 'parse', id: 9, buffer: new ArrayBuffer(4) } } as MessageEvent);
+    await vi.waitFor(() => {
+      expect(fake.posted.some((m) => (m as { kind?: string }).kind === 'error')).toBe(true);
+    });
+
+    const err = fake.posted.find((m) => (m as { kind?: string }).kind === 'error') as {
+      id: number;
+      message: string;
+    };
+    expect(err.id).toBe(9);
+    expect(err.message).toContain('boom');
+  });
+
+  it('a parse after a SUCCESSFUL init responds with parsedMeta and no ready handshake', async () => {
+    initMock.mockResolvedValue(undefined);
+    const fake = await loadRenderWorker();
+
+    fake.onmessage?.({ data: { kind: 'init', wasmUrl: 'x' } } as MessageEvent);
+    fake.onmessage?.({ data: { kind: 'parse', id: 2, buffer: new ArrayBuffer(4) } } as MessageEvent);
+    await vi.waitFor(() => {
+      expect(fake.posted.some((m) => (m as { kind?: string }).kind === 'parsedMeta')).toBe(true);
+    });
+
+    expect(fake.posted.some((m) => (m as { kind?: string }).kind === 'ready')).toBe(false);
+  });
+});

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -18,7 +18,7 @@ import { PPTX_GOOGLE_FONTS, pptxFontPreloadNames } from './google-fonts';
 import { preloadGoogleFonts, decodeDataUrl } from '@silurus/ooxml-core';
 import type { RenderWorkerRequest, RenderWorkerResponse, PresentationMeta } from './worker-protocol';
 
-let ready = false;
+let initPromise: Promise<unknown> | null = null;
 let pres: Presentation | null = null;
 // A `PptxArchive` handle over the opened zip. `new PptxArchive(bytes, max)`
 // copies the file into WASM ONCE and opens it ONCE; the in-worker
@@ -40,12 +40,6 @@ function disposeArchive(): void {
     archive.free();
     archive = null;
   }
-}
-
-async function initWasm(wasmUrl: string) {
-  await init(decodeDataUrl(wasmUrl) ?? wasmUrl);
-  ready = true;
-  post({ kind: 'ready' });
 }
 
 function getMedia(path: string): Promise<Blob> {
@@ -80,15 +74,17 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
   const req = e.data;
 
   if (req.kind === 'init') {
-    initWasm(req.wasmUrl).catch((err) => {
-      console.error('[pptx-render-worker] WASM init failed:', err);
-    });
+    // Retain the init promise (docx/xlsx pattern) rather than a `ready` flag +
+    // handshake. Every request below `await`s it, so a REJECTED init rejects the
+    // request (the outer catch posts an `error` response the bridge turns into a
+    // rejected `load()` / render), never a silent hang on a main-side wait.
+    initPromise = init(decodeDataUrl(req.wasmUrl) ?? req.wasmUrl);
     return;
   }
 
   try {
+    await initPromise;
     if (req.kind === 'parse') {
-      if (!ready) throw new Error('WASM not initialized');
       // Cached blobs belong to the previous document; serving them after a
       // re-parse would silently return the wrong file's media/image.
       mediaCache.clear();

--- a/packages/pptx/src/scroll-viewer-concurrent-load.test.ts
+++ b/packages/pptx/src/scroll-viewer-concurrent-load.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxScrollViewer } from './scroll-viewer.js';
+import { PptxPresentation } from './presentation.js';
+import { installDom, makeContainer, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_W_EMU = 9525 * 200;
+const SLIDE_H_EMU = 9525 * 150;
+
+/**
+ * Concurrent-load latch for the SELF-LOADED scroll viewer (composes with SC20's
+ * success-after-swap). Two overlapping `load(A)`/`load(B)` calls race the WASM
+ * parse / worker init; the stale one resolving LAST must NOT win the swap — it
+ * destroys its own just-loaded engine and leaves the winner (its engine +
+ * recycle/relayout post-load work) untouched. An injected engine can never orphan
+ * (load() throws up-front there), so this only covers the self-loading path.
+ */
+describe('PptxScrollViewer.load() — concurrent-load latch', () => {
+  function build() {
+    installDom();
+    const container = makeContainer(200, 400);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { gap: 10 });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    return { v };
+  }
+
+  function deferredLoad(engine: FakePptxEngine): { resolve: () => void; promise: Promise<PptxPresentation> } {
+    let resolve!: () => void;
+    const promise = new Promise<PptxPresentation>((r) => {
+      resolve = () => r(engine.asPres());
+    });
+    return { resolve, promise };
+  }
+
+  it('the later-started load winning first leaves the stale load a no-op (its engine destroyed)', async () => {
+    const { v } = build();
+    const a = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const b = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(PptxPresentation, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const pa = v.load('a.pptx'); // gen 1
+    const pb = v.load('b.pptx'); // gen 2 — supersedes A
+
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false);
+    expect(a.destroyed).toBe(false);
+
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // loser's engine cleaned up (no leak)
+    expect(b.destroyed).toBe(false); // winner untouched — still current
+    expect(v.slideCount).toBe(3);
+
+    v.destroy();
+    expect(b.destroyed).toBe(true);
+    expect(a.destroyed).toBe(true);
+  });
+
+  it('resolving in start order (A then B) behaves like today — B wins normally', async () => {
+    const { v } = build();
+    const a = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const b = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(PptxPresentation, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const pa = v.load('a.pptx');
+    const pb = v.load('b.pptx');
+
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // superseded loser cleaned up
+
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false);
+    expect(v.slideCount).toBe(3);
+
+    v.destroy();
+    expect(b.destroyed).toBe(true);
+  });
+});

--- a/packages/pptx/src/scroll-viewer-reload-orphan.test.ts
+++ b/packages/pptx/src/scroll-viewer-reload-orphan.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxScrollViewer } from './scroll-viewer.js';
+import { PptxPresentation } from './presentation.js';
+import { installDom, makeContainer, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_W_EMU = 9525 * 200;
+const SLIDE_H_EMU = 9525 * 150;
+
+/**
+ * SC20 for the scroll viewer: a SELF-LOADED (non-injected) scroll viewer owns its
+ * engine, so a second `load()` must destroy the previous one instead of orphaning
+ * its worker + WASM. (An injected engine is caller-owned — load() throws there, so
+ * it can never orphan.)
+ */
+describe('PptxScrollViewer.load() — no orphaned engine on re-load (SC20)', () => {
+  function build() {
+    installDom();
+    const container = makeContainer(200, 400);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { gap: 10 });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+    return { v };
+  }
+
+  it('destroys the previous engine when a self-loaded viewer is re-loaded', async () => {
+    const { v } = build();
+    const first = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const second = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    vi.spyOn(PptxPresentation, 'load')
+      .mockResolvedValueOnce(first.asPres())
+      .mockResolvedValueOnce(second.asPres());
+
+    await v.load('one.pptx');
+    expect(first.destroyed).toBe(false);
+
+    await v.load('two.pptx');
+    expect(first.destroyed).toBe(true);
+    expect(second.destroyed).toBe(false);
+
+    v.destroy();
+    expect(second.destroyed).toBe(true);
+  });
+
+  it('keeps the current engine when the re-load fails (atomic swap)', async () => {
+    const onError = vi.fn();
+    installDom();
+    const container = makeContainer(200, 400);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, { gap: 10, onError });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientHeight = 400;
+    scrollHost.clientWidth = 200;
+
+    const first = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    vi.spyOn(PptxPresentation, 'load')
+      .mockResolvedValueOnce(first.asPres())
+      .mockRejectedValueOnce(new Error('boom'));
+
+    await v.load('one.pptx');
+    await v.load('bad.pptx');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(first.destroyed).toBe(false);
+    expect(v.slideCount).toBe(3);
+
+    v.destroy();
+    expect(first.destroyed).toBe(true);
+  });
+});

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -189,6 +189,23 @@ export class PptxScrollViewer {
    *  reporting an error so a rejection that lands after teardown is swallowed
    *  rather than surfaced to a `onError` on a dead viewer. */
   private _destroyed = false;
+  /**
+   * Concurrent-load latch (generation token). Every self-loading `load()`
+   * increments this and captures the value; after its engine finishes loading it
+   * re-checks the live value and BAILS (destroying its own just-loaded engine) if
+   * a newer `load()` has since started. Without it, two overlapping
+   * `load(A)`/`load(B)` calls race the WASM parse / worker init, and whichever
+   * RESOLVES last wins the swap — even the stale `load(A)` resolving after
+   * `load(B)`; the loser's freshly created engine (never installed, or installed
+   * then overwritten) then leaks its worker + pinned WASM allocation. The latch
+   * composes with SC20: the check runs AFTER the new engine loads but BEFORE the
+   * field assignment, `previous?.destroy()`, and the recycle/relayout post-load
+   * work, so a superseded load never touches `this._pres` nor frees the current
+   * (newer) engine. Only the self-loading path uses it — the injected path throws
+   * up-front and never reaches here. `destroy()` also bumps it so a load in flight
+   * at teardown is treated as superseded and its engine cleaned up.
+   */
+  private _loadGen = 0;
   /** Worker mode: slide indices whose bitmap render is currently dispatched to the
    *  engine. Coalesces a scroll storm — we never dispatch a second render for a
    *  slide whose first is still in flight — and lets us drop slides that scrolled
@@ -346,9 +363,10 @@ export class PptxScrollViewer {
     // re-load then keeps the current deck rendered rather than going blank. (The
     // injected path returned above can never reach here, so this only ever frees
     // an engine we created.)
+    const gen = ++this._loadGen;
     const previous = this._pres;
     try {
-      this._pres = await PptxPresentation.load(source, {
+      const pres = await PptxPresentation.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
         workerTimeoutMs: this._opts.workerTimeoutMs,
@@ -356,6 +374,16 @@ export class PptxScrollViewer {
         math: this._opts.math,
         mode: this._mode,
       });
+      if (gen !== this._loadGen) {
+        // A newer load() (or destroy()) started while this one was in flight — we
+        // lost the concurrent-load race. Destroy the engine we just loaded (it was
+        // never installed) and leave the winning load's engine + SC20 swap + its
+        // recycle/relayout work untouched: do NOT touch `this._pres` and do NOT
+        // destroy `previous` (irrelevant to the winner; possibly already stale).
+        pres.destroy();
+        return;
+      }
+      this._pres = pres;
       previous?.destroy();
       if (previous) {
         // Re-loading over a prior deck: recycle every mounted slot (they hold the
@@ -372,6 +400,9 @@ export class PptxScrollViewer {
       // appears.
       this.relayout();
     } catch (err) {
+      // Superseded loads own no error reporting — the winning load (or destroy())
+      // is the outcome the caller awaits; swallow this stale rejection.
+      if (gen !== this._loadGen) return;
       const e = err instanceof Error ? err : new Error(String(err));
       if (this._opts.onError) {
         this._opts.onError(e);
@@ -1275,6 +1306,10 @@ export class PptxScrollViewer {
    */
   destroy(): void {
     this._destroyed = true;
+    // Bump the load generation so a self-loading load() still in flight is treated
+    // as superseded and its engine is cleaned up rather than installed onto a
+    // torn-down viewer.
+    this._loadGen++;
     if (this._scrollListener) {
       this._scrollHost.removeEventListener('scroll', this._scrollListener);
       this._scrollListener = null;

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -340,6 +340,13 @@ export class PptxScrollViewer {
         'PptxScrollViewer.load() is unsupported when an engine is injected via opts.presentation; the injected engine is already loaded.',
       );
     }
+    // SC20 atomic swap: a self-loaded viewer OWNS its engine (destroy() tears it
+    // down when `!_injected`), so a re-load must not orphan the previous one.
+    // Retain it locally and free it only after the new engine loads — a FAILED
+    // re-load then keeps the current deck rendered rather than going blank. (The
+    // injected path returned above can never reach here, so this only ever frees
+    // an engine we created.)
+    const previous = this._pres;
     try {
       this._pres = await PptxPresentation.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
@@ -349,6 +356,16 @@ export class PptxScrollViewer {
         math: this._opts.math,
         mode: this._mode,
       });
+      previous?.destroy();
+      if (previous) {
+        // Re-loading over a prior deck: recycle every mounted slot (they hold the
+        // OLD deck's rendered canvases) and reset the top-index latch so the new
+        // deck's first window renders fresh. `_mountVisible` only RE-renders
+        // missing indices, so without this a still-mounted slide 0 would keep the
+        // previous deck's pixels.
+        for (const [idx, slot] of [...this._slots]) this._recycleSlot(idx, slot);
+        this._lastTopIndex = -1;
+      }
       // Lay out + mount the first window now that the engine exists (mirrors the
       // injected-engine path in the constructor). relayout() is idempotent and
       // defers under a zero-width container — `_onResize` re-runs it once width

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -532,7 +532,6 @@ export type WorkerRequest =
   | { kind: 'extractImage'; id: number; path: string };
 
 export type WorkerResponse =
-  | { kind: 'ready' }
   // The model crosses the worker boundary as raw UTF-8 JSON bytes (transferred,
   // not cloned); the main thread does the single `TextDecoder.decode` +
   // `JSON.parse` into a `Presentation`. See `parse_pptx` (Rust) for why.

--- a/packages/pptx/src/viewer-concurrent-load.test.ts
+++ b/packages/pptx/src/viewer-concurrent-load.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxViewer } from './viewer.js';
+import { PptxPresentation } from './presentation.js';
+import { installDom, makeEl, FakePptxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_W_EMU = 9144000;
+const SLIDE_H_EMU = 6858000;
+
+/**
+ * Concurrent-load latch (composes with SC20's success-after-swap): if a caller
+ * fires `load(A)` and, before it resolves, `load(B)`, both loads race the WASM
+ * parse / worker init concurrently. Whichever resolves LAST must NOT win the swap
+ * when it is the stale one — the loser's freshly-loaded engine (never installed,
+ * or installed then overwritten) must be destroyed, not leaked, and the winner's
+ * engine must stay live and untouched. A generation token (`_loadGen`) closes it.
+ */
+describe('PptxViewer.load() — concurrent-load latch', () => {
+  function mount() {
+    installDom();
+    return { canvas: makeEl('canvas') };
+  }
+
+  function deferredLoad(engine: FakePptxEngine): { resolve: () => void; promise: Promise<PptxPresentation> } {
+    let resolve!: () => void;
+    const promise = new Promise<PptxPresentation>((r) => {
+      resolve = () => r(engine.asPres());
+    });
+    return { resolve, promise };
+  }
+
+  it('the later-started load winning first leaves the stale load a no-op (its engine destroyed)', async () => {
+    const { canvas } = mount();
+    const a = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const b = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(PptxPresentation, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement);
+    const pa = v.load('a.pptx'); // gen 1
+    const pb = v.load('b.pptx'); // gen 2 — supersedes A
+
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false);
+    expect(a.destroyed).toBe(false);
+
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // loser's engine cleaned up (no leak)
+    expect(b.destroyed).toBe(false); // winner untouched — still current
+
+    v.destroy();
+    expect(b.destroyed).toBe(true);
+    expect(a.destroyed).toBe(true);
+  });
+
+  it('resolving in start order (A then B) behaves like today — B wins normally', async () => {
+    const { canvas } = mount();
+    const a = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const b = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const da = deferredLoad(a);
+    const db = deferredLoad(b);
+    vi.spyOn(PptxPresentation, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement);
+    const pa = v.load('a.pptx');
+    const pb = v.load('b.pptx');
+
+    da.resolve();
+    await pa;
+    expect(a.destroyed).toBe(true); // superseded loser cleaned up
+
+    db.resolve();
+    await pb;
+    expect(b.destroyed).toBe(false);
+    expect(v.slideCount).toBe(3);
+
+    v.destroy();
+    expect(b.destroyed).toBe(true);
+  });
+
+  it('does not double-destroy or leak when only one load runs (regression guard)', async () => {
+    const { canvas } = mount();
+    const only = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(only.asPres());
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement);
+    await v.load('one.pptx');
+    expect(only.destroyed).toBe(false);
+    v.destroy();
+    expect(only.destroyed).toBe(true);
+  });
+});

--- a/packages/pptx/src/viewer-destroy-during-render.test.ts
+++ b/packages/pptx/src/viewer-destroy-during-render.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxViewer } from './viewer.js';
+import { PptxPresentation } from './presentation.js';
+import { installDom, makeEl, FakePptxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_W_EMU = 9144000;
+const SLIDE_H_EMU = 6858000;
+
+/** Drain the microtask queue so an awaited chain (mocked load → deferred render)
+ *  reaches its next suspension point before the test inspects recorded calls. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+}
+
+/**
+ * Destroy-during-render guard: a render dispatched before `destroy()` can reject
+ * AFTER teardown (the worker/WASM resolve late). The `_destroyed` flag (set as the
+ * first line of `destroy()`) makes `_reportRenderError` swallow such a rejection
+ * so it never fires `onError` / `console.error` on a dead viewer — parity with the
+ * scroll viewers' existing `_destroyed` guard.
+ */
+describe('PptxViewer — destroy-during-render guard', () => {
+  function mount() {
+    installDom();
+    return { canvas: makeEl('canvas') };
+  }
+
+  it('swallows a render rejection that lands after destroy() (no onError)', async () => {
+    const { canvas } = mount();
+    // deferred=true: renderSlide returns a promise the test rejects manually, so
+    // the first-slide render is still in flight across destroy().
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU, 'main', true);
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+    const onError = vi.fn();
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+
+    const loadPromise = v.load('x.pptx');
+    await flushMicrotasks();
+    const call = engine.renderCalls[engine.renderCalls.length - 1];
+    expect(call).toBeDefined();
+
+    v.destroy();
+    call.reject(new Error('late render boom'));
+    await loadPromise;
+    await Promise.resolve();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('swallows a render rejection after destroy() with no onError (no console.error)', async () => {
+    const { canvas } = mount();
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU, 'main', true);
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement);
+
+    const loadPromise = v.load('x.pptx');
+    await flushMicrotasks();
+    const call = engine.renderCalls[engine.renderCalls.length - 1];
+    v.destroy();
+    call.reject(new Error('late render boom'));
+    await loadPromise;
+    await Promise.resolve();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pptx/src/viewer-reload-orphan.test.ts
+++ b/packages/pptx/src/viewer-reload-orphan.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxViewer } from './viewer.js';
+import { PptxPresentation } from './presentation.js';
+import { installDom, makeEl, FakePptxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_W_EMU = 9144000;
+const SLIDE_H_EMU = 6858000;
+
+/**
+ * SC20: calling `load()` a second time must not orphan the previously loaded
+ * engine (and its worker + pinned WASM allocation). The viewer holds a single
+ * engine reference; overwriting it without `destroy()` leaks the worker.
+ *
+ * The fix is an atomic swap: the new engine is loaded first, and only on success
+ * is the OLD engine destroyed — so a failed re-load preserves the current one.
+ */
+describe('PptxViewer.load() — no orphaned engine on re-load (SC20)', () => {
+  function mount() {
+    installDom();
+    const canvas = makeEl('canvas');
+    return { canvas };
+  }
+
+  it('destroys the previous engine when load() is called again', async () => {
+    const { canvas } = mount();
+    const first = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const second = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const loadSpy = vi
+      .spyOn(PptxPresentation, 'load')
+      .mockResolvedValueOnce(first.asPres())
+      .mockResolvedValueOnce(second.asPres());
+
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement);
+    await v.load('one.pptx');
+    expect(first.destroyed).toBe(false); // still current after first load
+
+    await v.load('two.pptx');
+    expect(loadSpy).toHaveBeenCalledTimes(2);
+    // First engine (and its worker) torn down; second is now current.
+    expect(first.destroyed).toBe(true);
+    expect(second.destroyed).toBe(false);
+
+    v.destroy();
+    expect(second.destroyed).toBe(true);
+  });
+
+  it('keeps the current engine when the re-load fails (atomic swap)', async () => {
+    const { canvas } = mount();
+    const first = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    vi.spyOn(PptxPresentation, 'load')
+      .mockResolvedValueOnce(first.asPres())
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const onError = vi.fn();
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+    await v.load('one.pptx');
+
+    await v.load('bad.pptx');
+    // The failed load reported via onError and left the first engine intact.
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(first.destroyed).toBe(false);
+    expect(v.slideCount).toBe(3);
+
+    v.destroy();
+    expect(first.destroyed).toBe(true);
+  });
+});

--- a/packages/pptx/src/viewer-render-error.test.ts
+++ b/packages/pptx/src/viewer-render-error.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxViewer } from './viewer.js';
+import { PptxPresentation } from './presentation.js';
+import { installDom, makeEl, FakePptxEngine } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_W_EMU = 9144000;
+const SLIDE_H_EMU = 6858000;
+
+/** A FakePptxEngine whose `renderSlide` throws, to exercise the render-error
+ *  path (the base fake resolves; override just renderSlide). */
+function throwingEngine(): FakePptxEngine {
+  const e = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+  (e as unknown as { renderSlide: () => Promise<void> }).renderSlide = () => {
+    throw new Error('render boom');
+  };
+  return e;
+}
+
+/**
+ * PD14: PptxViewer already routed render failures to `onError`; this pins that,
+ * and that it now also `console.error`s when no `onError` is given (never
+ * silent), so all three single-canvas viewers share one contract.
+ */
+describe('PptxViewer render error contract (PD14)', () => {
+  function mount() {
+    installDom();
+    return { canvas: makeEl('canvas') };
+  }
+
+  it('routes a render failure to onError during load() and resolves', async () => {
+    const { canvas } = mount();
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(throwingEngine().asPres());
+    const onError = vi.fn();
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+    await expect(v.load('x.pptx')).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toContain('boom');
+    v.destroy();
+  });
+
+  it('routes a render failure to onError during goToSlide() (no rejection)', async () => {
+    const { canvas } = mount();
+    const good = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(good.asPres());
+    const onError = vi.fn();
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement, { onError });
+    await v.load('x.pptx');
+    expect(onError).not.toHaveBeenCalled();
+
+    (good as unknown as { renderSlide: () => Promise<void> }).renderSlide = () => {
+      throw new Error('nav boom');
+    };
+    await expect(v.nextSlide()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toContain('nav boom');
+    v.destroy();
+  });
+
+  it('falls back to console.error when no onError is provided (never silent)', async () => {
+    const { canvas } = mount();
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(throwingEngine().asPres());
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement);
+    await expect(v.load('x.pptx')).resolves.toBeUndefined();
+    expect(spy).toHaveBeenCalledTimes(1);
+    v.destroy();
+  });
+});

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -83,6 +83,26 @@ export class PptxViewer {
    *  so this is obtained only when worker mode renders without media playback. */
   private _bitmapCtx: ImageBitmapRenderingContext | null = null;
   private _warnedNoTextSelection = false;
+  /** Set by {@link destroy} (first line). Guards {@link _reportRenderError} so a
+   *  render rejection that lands AFTER teardown is swallowed rather than surfaced
+   *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
+   *  viewers' `_destroyed` flag. */
+  private _destroyed = false;
+  /**
+   * Concurrent-load latch (generation token). Every {@link load} increments this
+   * and captures the value; after its engine finishes loading it re-checks the
+   * live value and BAILS (destroying its own just-loaded engine) if a newer
+   * `load()` has since started. Without it, two overlapping `load(A)`/`load(B)`
+   * calls race the WASM parse / worker init, and whichever RESOLVES last wins the
+   * swap — even the stale `load(A)` resolving after `load(B)`; the loser's freshly
+   * created engine (never installed, or installed then overwritten) then leaks its
+   * worker + pinned WASM allocation. The latch composes with SC20: the check runs
+   * AFTER the new engine loads but BEFORE the field assignment and
+   * `previous?.destroy()`, so a superseded load never touches `this.engine` nor
+   * frees the current (newer) engine. {@link destroy} also bumps it so a load in
+   * flight at teardown is treated as superseded and its engine cleaned up.
+   */
+  private _loadGen = 0;
 
   constructor(canvas: HTMLCanvasElement, opts: PptxViewerOptions = {}) {
     this.opts = opts;
@@ -140,6 +160,7 @@ export class PptxViewer {
     // FAILED re-load keeps the current engine + its rendered slide intact rather
     // than dropping to an empty viewer. The 2× memory window is bounded to the
     // load itself (the old engine is freed the moment the new model arrives).
+    const gen = ++this._loadGen;
     const previous = this.engine;
     try {
       const engine = await PptxPresentation.load(source, {
@@ -150,6 +171,15 @@ export class PptxViewer {
         math: this.opts.math,
         mode: this._mode,
       });
+      if (gen !== this._loadGen) {
+        // A newer load() (or destroy()) started while this one was in flight — we
+        // lost the concurrent-load race. Destroy the engine we just loaded (it was
+        // never installed) and leave the winning load's engine + SC20 swap
+        // untouched: do NOT touch `this.engine`/`this.handle` and do NOT destroy
+        // `previous` (irrelevant to the winner; possibly already stale).
+        engine.destroy();
+        return;
+      }
       // Discard the stale slide's media handle before swapping engines so its RAF
       // loop / object URLs don't outlive the replaced presentation.
       this.handle?.destroy();
@@ -159,6 +189,9 @@ export class PptxViewer {
       this.currentSlide = this._initialSlide();
       await this.renderCurrentSlide();
     } catch (err) {
+      // Superseded loads own no error reporting — the winning load (or destroy())
+      // is the outcome the caller awaits; swallow this stale rejection.
+      if (gen !== this._loadGen) return;
       const e = err instanceof Error ? err : new Error(String(err));
       if (this.opts.onError) {
         this.opts.onError(e);
@@ -310,9 +343,11 @@ export class PptxViewer {
   }
 
   /** PD14 render-error contract: route a render failure to `onError`, or
-   *  `console.error` when none is given (never fully silent). Mirrors the scroll
-   *  viewers' `_reportRenderError` so all three single-canvas viewers agree. */
+   *  `console.error` when none is given (never fully silent), and never after
+   *  teardown. Mirrors the scroll viewers' `_reportRenderError` so all three
+   *  single-canvas viewers agree. */
   private _reportRenderError(err: unknown): void {
+    if (this._destroyed) return;
     const e = err instanceof Error ? err : new Error(String(err));
     if (this.opts.onError) this.opts.onError(e);
     else console.error('[ooxml] PptxViewer render failed:', e);
@@ -328,6 +363,12 @@ export class PptxViewer {
    * is simply removed from the internal wrapper. Safe to call more than once.
    */
   destroy(): void {
+    // First line: block any render rejection racing in from surfacing on a dead
+    // viewer (checked at the top of _reportRenderError). Bump the load generation
+    // too so a load() still in flight is treated as superseded and its engine is
+    // cleaned up rather than installed onto a torn-down viewer.
+    this._destroyed = true;
+    this._loadGen++;
     this.handle?.destroy();
     this.handle = null;
     this.engine?.destroy();

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -297,7 +297,7 @@ export class PptxViewer {
       }
       this.opts.onSlideChange?.(this.currentSlide, this.slideCount);
     } catch (err) {
-      this.opts.onError?.(err instanceof Error ? err : new Error(String(err)));
+      this._reportRenderError(err);
     }
 
     if (this.textLayer && !isWorker) {
@@ -307,6 +307,15 @@ export class PptxViewer {
 
   private _buildTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
     buildPptxTextLayer(layer, runs, cssWidth, cssHeight);
+  }
+
+  /** PD14 render-error contract: route a render failure to `onError`, or
+   *  `console.error` when none is given (never fully silent). Mirrors the scroll
+   *  viewers' `_reportRenderError` so all three single-canvas viewers agree. */
+  private _reportRenderError(err: unknown): void {
+    const e = err instanceof Error ? err : new Error(String(err));
+    if (this.opts.onError) this.opts.onError(e);
+    else console.error('[ooxml] PptxViewer render failed:', e);
   }
 
   /**

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -134,8 +134,15 @@ export class PptxViewer {
    * the error is rethrown so it is never silently swallowed.
    */
   async load(source: string | ArrayBuffer): Promise<void> {
+    // SC20 atomic swap: retain the previous engine locally and only tear it down
+    // AFTER the new one loads successfully. A re-load thus never orphans the old
+    // engine's worker + pinned WASM allocation (the leak this guards), yet a
+    // FAILED re-load keeps the current engine + its rendered slide intact rather
+    // than dropping to an empty viewer. The 2× memory window is bounded to the
+    // load itself (the old engine is freed the moment the new model arrives).
+    const previous = this.engine;
     try {
-      this.engine = await PptxPresentation.load(source, {
+      const engine = await PptxPresentation.load(source, {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         workerTimeoutMs: this.opts.workerTimeoutMs,
@@ -143,6 +150,12 @@ export class PptxViewer {
         math: this.opts.math,
         mode: this._mode,
       });
+      // Discard the stale slide's media handle before swapping engines so its RAF
+      // loop / object URLs don't outlive the replaced presentation.
+      this.handle?.destroy();
+      this.handle = null;
+      this.engine = engine;
+      previous?.destroy();
       this.currentSlide = this._initialSlide();
       await this.renderCurrentSlide();
     } catch (err) {

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -149,9 +149,15 @@ export class PptxViewer {
   /**
    * Load a PPTX from URL or ArrayBuffer and render the first slide.
    *
-   * Error contract (shared by all three viewers): on failure, if an `onError`
-   * callback was provided it is invoked and `load` resolves normally; if not,
-   * the error is rethrown so it is never silently swallowed.
+   * Error contract (shared by all three viewers):
+   * - Parse/load failure (the underlying `PptxPresentation.load()` call itself
+   *   rejects): if an `onError` callback was provided it is invoked and `load`
+   *   resolves normally; if not, the error is rethrown so it is never silently
+   *   swallowed.
+   * - Render failure (the first slide fails to draw AFTER a successful
+   *   parse/load): routed to the shared `_reportRenderError` contract (`onError`
+   *   if provided, else `console.error` — never silent) and `load` still
+   *   RESOLVES, matching every subsequent navigation call.
    */
   async load(source: string | ArrayBuffer): Promise<void> {
     // SC20 atomic swap: retain the previous engine locally and only tear it down

--- a/packages/pptx/src/worker-init-hang.test.ts
+++ b/packages/pptx/src/worker-init-hang.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * AR4: a WASM-init failure must not leave `load()` hanging forever. The worker
+ * used to swallow the init error (log-only) and keep a `ready` flag false, so the
+ * main thread — which blocked on a `ready` handshake — never resolved. The fix
+ * moves pptx to the docx/xlsx `initPromise` pattern: every request `await`s the
+ * init promise, so a rejected init rejects the request (surfacing an `error`
+ * response the bridge turns into a rejected `load()`), never a silent hang.
+ *
+ * These drive the worker's `onmessage` directly against a mocked WASM module and
+ * a stubbed `self`, so no real Worker / WASM is needed.
+ */
+
+const initMock = vi.fn();
+class FakePptxArchive {
+  constructor(_bytes: Uint8Array, _max?: bigint) {}
+  parse(): Uint8Array {
+    return new TextEncoder().encode('{"slides":[],"slideWidth":0,"slideHeight":0}');
+  }
+  extract_media(_p: string): Uint8Array {
+    return new Uint8Array([1, 2, 3]);
+  }
+  extract_image(_p: string): Uint8Array {
+    return new Uint8Array([4, 5, 6]);
+  }
+  free(): void {}
+}
+
+vi.mock('./wasm/pptx_parser.js', () => ({
+  default: (arg: unknown) => initMock(arg),
+  PptxArchive: FakePptxArchive,
+}));
+
+interface FakeSelf {
+  onmessage: ((e: MessageEvent) => void) | null;
+  posted: unknown[];
+  postMessage: (msg: unknown, transfer?: Transferable[]) => void;
+}
+
+function installSelf(): FakeSelf {
+  const posted: unknown[] = [];
+  const fake: FakeSelf = {
+    onmessage: null,
+    posted,
+    postMessage: (msg: unknown) => {
+      posted.push(msg);
+    },
+  };
+  vi.stubGlobal('self', fake);
+  return fake;
+}
+
+/** Import the worker module fresh (its top-level `self.onmessage = …` runs on
+ *  import), after `self` and the WASM mock are installed. */
+async function loadWorker(): Promise<FakeSelf> {
+  const fake = installSelf();
+  vi.resetModules();
+  await import('./worker.js');
+  return fake;
+}
+
+beforeEach(() => {
+  initMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('pptx worker.ts — init failure never hangs a request (AR4)', () => {
+  it('a parse after a REJECTED init responds with an error (not a hang)', async () => {
+    initMock.mockRejectedValue(new Error('wasm boom'));
+    const fake = await loadWorker();
+
+    fake.onmessage?.({ data: { kind: 'init', wasmUrl: 'x' } } as MessageEvent);
+    fake.onmessage?.({ data: { kind: 'parse', id: 7, buffer: new ArrayBuffer(4) } } as MessageEvent);
+    // Let the awaited (rejected) initPromise settle and the handler run its catch.
+    await vi.waitFor(() => {
+      expect(fake.posted.some((m) => (m as { kind?: string }).kind === 'error')).toBe(true);
+    });
+
+    const err = fake.posted.find((m) => (m as { kind?: string }).kind === 'error') as {
+      kind: string;
+      id: number;
+      message: string;
+    };
+    expect(err.id).toBe(7);
+    expect(err.message).toContain('boom');
+    // Crucially: the request settled — no pending promise is left hanging.
+  });
+
+  it('a parse after a SUCCESSFUL init responds with a parsed model', async () => {
+    initMock.mockResolvedValue(undefined);
+    const fake = await loadWorker();
+
+    fake.onmessage?.({ data: { kind: 'init', wasmUrl: 'x' } } as MessageEvent);
+    fake.onmessage?.({ data: { kind: 'parse', id: 3, buffer: new ArrayBuffer(4) } } as MessageEvent);
+    await vi.waitFor(() => {
+      expect(fake.posted.some((m) => (m as { kind?: string }).kind === 'parsed')).toBe(true);
+    });
+
+    const parsed = fake.posted.find((m) => (m as { kind?: string }).kind === 'parsed') as {
+      kind: string;
+      id: number;
+    };
+    expect(parsed.id).toBe(3);
+    // No `ready` handshake is emitted anymore (initPromise pattern replaces it).
+    expect(fake.posted.some((m) => (m as { kind?: string }).kind === 'ready')).toBe(false);
+  });
+});

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -2,7 +2,7 @@ import { decodeDataUrl } from '@silurus/ooxml-core';
 import type { WorkerRequest, WorkerResponse } from './types';
 import init, { PptxArchive } from './wasm/pptx_parser.js';
 
-let ready = false;
+let initPromise: Promise<unknown> | null = null;
 // A `PptxArchive` handle over the opened zip: `new PptxArchive(bytes, max)`
 // copies the file into WASM ONCE and scans the central directory ONCE, then a
 // later `extractMedia` / `extractImage` reads by zip path straight from the
@@ -18,30 +18,24 @@ function disposeArchive(): void {
   }
 }
 
-async function initWasm(wasmUrl: string) {
-  await init(decodeDataUrl(wasmUrl) ?? wasmUrl);
-  ready = true;
-  const msg: WorkerResponse = { kind: 'ready' };
-  self.postMessage(msg);
-}
-
-self.onmessage = (e: MessageEvent<WorkerRequest>) => {
+self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const req = e.data;
 
   if (req.kind === 'init') {
-    initWasm(req.wasmUrl).catch((err) => {
-      console.error('[pptx-worker] WASM init failed:', err);
-    });
+    // Retain the init promise (docx/xlsx pattern) rather than a `ready` flag +
+    // handshake. Every request below `await`s it, so a REJECTED init rejects the
+    // request (the catch posts an `error` response the bridge turns into a
+    // rejected `load()`), never a silent hang on a main-side `ready` wait.
+    initPromise = init(decodeDataUrl(req.wasmUrl) ?? req.wasmUrl);
     return;
   }
 
-  if (req.kind === 'parse') {
-    if (!ready) {
-      const msg: WorkerResponse = { kind: 'error', id: req.id, message: 'WASM not initialized' };
-      self.postMessage(msg);
-      return;
-    }
-    try {
+  // Echo the correlation id so the client routes the response to the right
+  // pending promise (id correlation, not response-type matching).
+  const id = req.id;
+  try {
+    await initPromise;
+    if (req.kind === 'parse') {
       const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
@@ -59,67 +53,41 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
       // no decode here. The single decode + JSON.parse happens once, on main.
       const json = archive.parse();
       const presentationJson = json.buffer as ArrayBuffer;
-      const msg: WorkerResponse = { kind: 'parsed', id: req.id, presentationJson };
+      const msg: WorkerResponse = { kind: 'parsed', id, presentationJson };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [
         presentationJson,
       ]);
-    } catch (err) {
-      const msg: WorkerResponse = {
-        kind: 'error',
-        id: req.id,
-        message: err instanceof Error ? err.message : String(err),
-      };
-      self.postMessage(msg);
-    }
-    return;
-  }
-
-  if (req.kind === 'extractMedia') {
-    if (!archive) {
-      const msg: WorkerResponse = { kind: 'error', id: req.id, message: 'No pptx loaded' };
-      self.postMessage(msg);
       return;
     }
-    try {
+
+    if (req.kind === 'extractMedia') {
+      if (!archive) throw new Error('No pptx loaded');
       // wasm-bindgen already hands back a fresh, standalone Uint8Array here (its
       // glue does `getArrayU8FromWasm0(ptr,len).slice()` then frees the Rust Vec),
       // so `bytes.buffer` is a full-span, non-WASM-backed ArrayBuffer we own
       // outright — transfer it directly. A second `new Uint8Array(bytes).slice()`
       // would just re-copy the whole entry for nothing.
       const out = archive.extract_media(req.path).buffer as ArrayBuffer;
-      const msg: WorkerResponse = { kind: 'mediaExtracted', id: req.id, bytes: out };
+      const msg: WorkerResponse = { kind: 'mediaExtracted', id, bytes: out };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [out]);
-    } catch (err) {
-      const msg: WorkerResponse = {
-        kind: 'error',
-        id: req.id,
-        message: err instanceof Error ? err.message : String(err),
-      };
-      self.postMessage(msg);
-    }
-    return;
-  }
-
-  if (req.kind === 'extractImage') {
-    if (!archive) {
-      const msg: WorkerResponse = { kind: 'error', id: req.id, message: 'No pptx loaded' };
-      self.postMessage(msg);
       return;
     }
-    try {
+
+    if (req.kind === 'extractImage') {
+      if (!archive) throw new Error('No pptx loaded');
       // See extractMedia above: the extracted Uint8Array already owns a
       // standalone full-span buffer, so transfer it without a second copy.
       const out = archive.extract_image(req.path).buffer as ArrayBuffer;
-      const msg: WorkerResponse = { kind: 'imageExtracted', id: req.id, bytes: out };
+      const msg: WorkerResponse = { kind: 'imageExtracted', id, bytes: out };
       (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [out]);
-    } catch (err) {
-      const msg: WorkerResponse = {
-        kind: 'error',
-        id: req.id,
-        message: err instanceof Error ? err.message : String(err),
-      };
-      self.postMessage(msg);
+      return;
     }
-    return;
+  } catch (err) {
+    const msg: WorkerResponse = {
+      kind: 'error',
+      id,
+      message: err instanceof Error ? err.message : String(err),
+    };
+    self.postMessage(msg);
   }
 };

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -81,10 +81,14 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
       return;
     }
     try {
-      const bytes = archive.extract_media(req.path);
-      const copy = new Uint8Array(bytes).slice().buffer;
-      const msg: WorkerResponse = { kind: 'mediaExtracted', id: req.id, bytes: copy };
-      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [copy]);
+      // wasm-bindgen already hands back a fresh, standalone Uint8Array here (its
+      // glue does `getArrayU8FromWasm0(ptr,len).slice()` then frees the Rust Vec),
+      // so `bytes.buffer` is a full-span, non-WASM-backed ArrayBuffer we own
+      // outright — transfer it directly. A second `new Uint8Array(bytes).slice()`
+      // would just re-copy the whole entry for nothing.
+      const out = archive.extract_media(req.path).buffer as ArrayBuffer;
+      const msg: WorkerResponse = { kind: 'mediaExtracted', id: req.id, bytes: out };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [out]);
     } catch (err) {
       const msg: WorkerResponse = {
         kind: 'error',
@@ -103,10 +107,11 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
       return;
     }
     try {
-      const bytes = archive.extract_image(req.path);
-      const copy = new Uint8Array(bytes).slice().buffer;
-      const msg: WorkerResponse = { kind: 'imageExtracted', id: req.id, bytes: copy };
-      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [copy]);
+      // See extractMedia above: the extracted Uint8Array already owns a
+      // standalone full-span buffer, so transfer it without a second copy.
+      const out = archive.extract_image(req.path).buffer as ArrayBuffer;
+      const msg: WorkerResponse = { kind: 'imageExtracted', id: req.id, bytes: out };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(msg, [out]);
     } catch (err) {
       const msg: WorkerResponse = {
         kind: 'error',

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2168,10 +2168,17 @@ impl XlsxArchive {
     /// `max_zip_entry_bytes` is retained and applied on every subsequent method
     /// call (identical semantics to the free functions' `scoped_max` guard). The
     /// shared workbook parts are parsed lazily on the first `parse`/`parse_sheet`.
+    ///
+    /// `data` is taken by value (`Vec<u8>`): wasm-bindgen copies the JS `Uint8Array`
+    /// once into a WASM-owned buffer and hands that allocation to Rust as this
+    /// `Vec`, which `Cursor` then takes by value — a single copy across the
+    /// JS→WASM boundary. Taking `&[u8]` would force a second `to_vec()` copy so
+    /// the `Cursor` could own its backing store, transiently doubling WASM
+    /// linear memory to ~2x the file size during construction.
     #[wasm_bindgen(constructor)]
-    pub fn new(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<XlsxArchive, JsValue> {
+    pub fn new(data: Vec<u8>, max_zip_entry_bytes: Option<u64>) -> Result<XlsxArchive, JsValue> {
         console_error_panic_hook::set_once();
-        let archive = zip::ZipArchive::new(Cursor::new(data.to_vec()))
+        let archive = zip::ZipArchive::new(Cursor::new(data))
             .map_err(|e| JsValue::from_str(&format!("xlsx-parser error: {e}")))?;
         Ok(XlsxArchive {
             archive,

--- a/packages/xlsx/src/viewer-concurrent-load.test.ts
+++ b/packages/xlsx/src/viewer-concurrent-load.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { XlsxWorkbook } from './workbook.js';
+import { installDom, makeContainer } from './viewer-destroy-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** A minimal XlsxWorkbook stand-in covering the surface load() → buildTabs()
+ *  touches, plus a `destroy` spy so the latch can assert the loser's workbook
+ *  (its worker + WASM) is torn down. */
+function fakeWorkbook() {
+  const destroy = vi.fn();
+  const wb = {
+    sheetNames: ['Sheet1'],
+    tabColors: {} as Record<number, string>,
+    destroy,
+    getWorksheet: vi.fn().mockResolvedValue(undefined),
+  };
+  return { wb: wb as unknown as XlsxWorkbook, destroy };
+}
+
+/**
+ * Concurrent-load latch (composes with SC20's success-after-swap): if a caller
+ * fires `load(A)` and, before it resolves, `load(B)`, both loads race the WASM
+ * parse / worker init concurrently. Whichever resolves LAST must NOT win the swap
+ * when it is the stale one — the loser's freshly-loaded workbook (never installed,
+ * or installed then overwritten) must be destroyed, not leaked, and the winner's
+ * workbook must stay live and untouched. A generation token (`_loadGen`) closes it.
+ */
+describe('XlsxViewer.load() — concurrent-load latch', () => {
+  function build() {
+    installDom();
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement);
+    // Isolate the latch from the sheet-render path: showSheet needs a full
+    // worksheet model, out of scope here. The engine-swap happens in load() BEFORE
+    // showSheet, so a resolved no-op keeps this test on the leak.
+    vi.spyOn(
+      v as unknown as { showSheet: (i: number) => Promise<void> },
+      'showSheet',
+    ).mockResolvedValue(undefined);
+    return { v };
+  }
+
+  function deferredLoad(wb: XlsxWorkbook): { resolve: () => void; promise: Promise<XlsxWorkbook> } {
+    let resolve!: () => void;
+    const promise = new Promise<XlsxWorkbook>((r) => {
+      resolve = () => r(wb);
+    });
+    return { resolve, promise };
+  }
+
+  it('the later-started load winning first leaves the stale load a no-op (its workbook destroyed)', async () => {
+    const { v } = build();
+    const a = fakeWorkbook();
+    const b = fakeWorkbook();
+    const da = deferredLoad(a.wb);
+    const db = deferredLoad(b.wb);
+    vi.spyOn(XlsxWorkbook, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const pa = v.load('a.xlsx'); // gen 1
+    const pb = v.load('b.xlsx'); // gen 2 — supersedes A
+
+    db.resolve();
+    await pb;
+    expect(b.destroy).not.toHaveBeenCalled();
+    expect(a.destroy).not.toHaveBeenCalled();
+
+    da.resolve();
+    await pa;
+    expect(a.destroy).toHaveBeenCalledTimes(1); // loser's workbook cleaned up
+    expect(b.destroy).not.toHaveBeenCalled(); // winner untouched — still current
+
+    v.destroy();
+    expect(b.destroy).toHaveBeenCalledTimes(1);
+    expect(a.destroy).toHaveBeenCalledTimes(1); // still exactly once
+  });
+
+  it('resolving in start order (A then B) behaves like today — B wins normally', async () => {
+    const { v } = build();
+    const a = fakeWorkbook();
+    const b = fakeWorkbook();
+    const da = deferredLoad(a.wb);
+    const db = deferredLoad(b.wb);
+    vi.spyOn(XlsxWorkbook, 'load')
+      .mockImplementationOnce(() => da.promise)
+      .mockImplementationOnce(() => db.promise);
+
+    const pa = v.load('a.xlsx');
+    const pb = v.load('b.xlsx');
+
+    da.resolve();
+    await pa;
+    expect(a.destroy).toHaveBeenCalledTimes(1); // superseded loser cleaned up
+
+    db.resolve();
+    await pb;
+    expect(b.destroy).not.toHaveBeenCalled();
+
+    v.destroy();
+    expect(b.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/xlsx/src/viewer-destroy-during-render.test.ts
+++ b/packages/xlsx/src/viewer-destroy-during-render.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer, type XlsxViewerOptions } from './viewer.js';
+import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
+import type { Worksheet } from './types.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function emptyWorksheet(): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 64,
+    defaultRowHeight: 20,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    charts: [],
+    images: [],
+    shapeGroups: [],
+  } as unknown as Worksheet;
+}
+
+/** A worker-mode viewer whose `renderViewportToBitmap` returns a promise the test
+ *  rejects manually, so the render is in flight across `destroy()`. */
+function buildDeferredReject(opts: XlsxViewerOptions = {}) {
+  installDom();
+  const container = makeContainer();
+  const v = new XlsxViewer(container as unknown as HTMLElement, { mode: 'worker', ...opts });
+
+  let reject!: (e: Error) => void;
+  const bitmap = new Promise((_res, rej) => {
+    reject = rej;
+  });
+  const renderViewportToBitmap = vi.fn(() => bitmap);
+  const fakeWb = { renderViewportToBitmap, sheetNames: ['Sheet1'], sheetCount: 1, destroy: vi.fn() };
+
+  const priv = v as unknown as {
+    wb: unknown;
+    currentWorksheet: Worksheet;
+    currentSheet: number;
+    canvasArea: FakeEl;
+    renderCurrentSheet: () => Promise<void>;
+  };
+  priv.wb = fakeWb;
+  priv.currentWorksheet = emptyWorksheet();
+  priv.currentSheet = 0;
+  priv.canvasArea.clientWidth = 800;
+  priv.canvasArea.clientHeight = 600;
+
+  return { v, render: () => priv.renderCurrentSheet(), reject: (e: Error) => reject(e) };
+}
+
+/**
+ * Destroy-during-render guard: a render dispatched before `destroy()` can reject
+ * AFTER teardown (the worker/WASM resolve late). The `_destroyed` flag (set as the
+ * first line of `destroy()`) makes `_reportRenderError` swallow such a rejection
+ * so it never fires `onError` / `console.error` on a dead viewer — parity with the
+ * scroll viewers' existing `_destroyed` guard.
+ */
+describe('XlsxViewer — destroy-during-render guard', () => {
+  it('swallows a render rejection that lands after destroy() (no onError)', async () => {
+    const onError = vi.fn();
+    const { v, render, reject } = buildDeferredReject({ onError });
+
+    const p = render(); // dispatch the worker render; it's now in flight
+    v.destroy(); // tear down while in flight
+    reject(new Error('late render boom'));
+    await p;
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('swallows a render rejection after destroy() with no onError (no console.error)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { v, render, reject } = buildDeferredReject();
+
+    const p = render();
+    v.destroy();
+    reject(new Error('late render boom'));
+    await p;
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/xlsx/src/viewer-reload-orphan.test.ts
+++ b/packages/xlsx/src/viewer-reload-orphan.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer, type XlsxViewerOptions } from './viewer.js';
+import { XlsxWorkbook } from './workbook.js';
+import { installDom, makeContainer } from './viewer-destroy-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** A minimal XlsxWorkbook stand-in covering exactly the surface the viewer's
+ *  load() → buildTabs() path touches, plus a `destroy` spy so SC20 can assert the
+ *  previous workbook (its worker + WASM) is torn down on a re-load. */
+function fakeWorkbook() {
+  const destroy = vi.fn();
+  const wb = {
+    sheetNames: ['Sheet1'],
+    tabColors: {} as Record<number, string>,
+    destroy,
+    getWorksheet: vi.fn().mockResolvedValue(undefined),
+  };
+  return { wb: wb as unknown as XlsxWorkbook, destroy };
+}
+
+/**
+ * SC20: a second `load()` must not orphan the previous workbook (its worker +
+ * pinned WASM). The fix is an atomic swap — load the new workbook first, destroy
+ * the old one only on success.
+ */
+describe('XlsxViewer.load() — no orphaned workbook on re-load (SC20)', () => {
+  function build(opts: XlsxViewerOptions = {}) {
+    installDom();
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement, opts);
+    // Isolate SC20 from the sheet-render path: showSheet needs a full worksheet
+    // model to lay out, which is out of scope here. The engine-swap happens in
+    // load() BEFORE showSheet, so a resolved no-op keeps this test on the leak.
+    vi.spyOn(
+      v as unknown as { showSheet: (i: number) => Promise<void> },
+      'showSheet',
+    ).mockResolvedValue(undefined);
+    return { v };
+  }
+
+  it('destroys the previous workbook when load() is called again', async () => {
+    const { v } = build();
+    const a = fakeWorkbook();
+    const b = fakeWorkbook();
+    const loadSpy = vi
+      .spyOn(XlsxWorkbook, 'load')
+      .mockResolvedValueOnce(a.wb)
+      .mockResolvedValueOnce(b.wb);
+
+    await v.load('one.xlsx');
+    expect(a.destroy).not.toHaveBeenCalled();
+
+    await v.load('two.xlsx');
+    expect(loadSpy).toHaveBeenCalledTimes(2);
+    expect(a.destroy).toHaveBeenCalledTimes(1);
+    expect(b.destroy).not.toHaveBeenCalled();
+
+    v.destroy();
+    expect(b.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the current workbook when the re-load fails (atomic swap)', async () => {
+    const onError = vi.fn();
+    const { v } = build({ onError });
+    const a = fakeWorkbook();
+    vi.spyOn(XlsxWorkbook, 'load')
+      .mockResolvedValueOnce(a.wb)
+      .mockRejectedValueOnce(new Error('boom'));
+
+    await v.load('one.xlsx');
+
+    await v.load('bad.xlsx');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(a.destroy).not.toHaveBeenCalled();
+
+    v.destroy();
+    expect(a.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/xlsx/src/viewer-render-error.test.ts
+++ b/packages/xlsx/src/viewer-render-error.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer, type XlsxViewerOptions } from './viewer.js';
+import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
+import type { Worksheet } from './types.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function emptyWorksheet(): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 64,
+    defaultRowHeight: 20,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    charts: [],
+    images: [],
+    shapeGroups: [],
+  } as unknown as Worksheet;
+}
+
+/** A worker-mode viewer whose `renderViewportToBitmap` REJECTS, wired so
+ *  `renderCurrentSheet` reaches the worker branch. */
+function buildRejecting(opts: XlsxViewerOptions = {}) {
+  installDom();
+  const container = makeContainer();
+  const v = new XlsxViewer(container as unknown as HTMLElement, { mode: 'worker', ...opts });
+
+  const renderViewportToBitmap = vi.fn(() => Promise.reject(new Error('render boom')));
+  const fakeWb = { renderViewportToBitmap, sheetNames: ['Sheet1'], sheetCount: 1, destroy: vi.fn() };
+
+  const priv = v as unknown as {
+    wb: unknown;
+    currentWorksheet: Worksheet;
+    currentSheet: number;
+    canvasArea: FakeEl;
+    renderCurrentSheet: () => Promise<void>;
+  };
+  priv.wb = fakeWb;
+  priv.currentWorksheet = emptyWorksheet();
+  priv.currentSheet = 0;
+  priv.canvasArea.clientWidth = 800;
+  priv.canvasArea.clientHeight = 600;
+
+  return { v, render: () => priv.renderCurrentSheet() };
+}
+
+/**
+ * PD14: a failed sheet render must follow the same contract as the scroll viewer
+ * — invoke `onError` if provided, else `console.error` (never silent), and never
+ * surface as an unhandled promise rejection. Before the fix `renderCurrentSheet`
+ * had no try/catch and was called `void`-style from scroll/resize handlers, so a
+ * render rejection became an unhandled rejection.
+ */
+describe('XlsxViewer render error contract (PD14)', () => {
+  it('routes a render failure to onError and resolves (no rejection)', async () => {
+    const onError = vi.fn();
+    const { render } = buildRejecting({ onError });
+    await expect(render()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((onError.mock.calls[0][0] as Error).message).toContain('boom');
+  });
+
+  it('falls back to console.error when no onError is provided (never silent)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { render } = buildRejecting();
+    await expect(render()).resolves.toBeUndefined();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -347,6 +347,26 @@ export class XlsxViewer {
    *  holds one context type for its lifetime, so this is obtained once and the
    *  main-mode 2d render path is never used on the same canvas. */
   private _bitmapCtx: ImageBitmapRenderingContext | null = null;
+  /** Set by {@link destroy} (first line). Guards {@link _reportRenderError} so a
+   *  render rejection that lands AFTER teardown is swallowed rather than surfaced
+   *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
+   *  viewers' `_destroyed` flag. */
+  private _destroyed = false;
+  /**
+   * Concurrent-load latch (generation token). Every {@link load} increments this
+   * and captures the value; after its workbook finishes loading it re-checks the
+   * live value and BAILS (destroying its own just-loaded workbook) if a newer
+   * `load()` has since started. Without it, two overlapping `load(A)`/`load(B)`
+   * calls race the WASM parse / worker init, and whichever RESOLVES last wins the
+   * swap — even the stale `load(A)` resolving after `load(B)`; the loser's freshly
+   * created workbook (never installed, or installed then overwritten) then leaks
+   * its worker + pinned WASM allocation. The latch composes with SC20: the check
+   * runs AFTER the new workbook loads but BEFORE the field assignment and
+   * `previous?.destroy()`, so a superseded load never touches `this.wb` nor frees
+   * the current (newer) workbook. {@link destroy} also bumps it so a load in
+   * flight at teardown is treated as superseded and its workbook cleaned up.
+   */
+  private _loadGen = 0;
   private resizeObserver: ResizeObserver | null = null;
   /**
    * Pending `requestAnimationFrame` handle for a coalesced re-render, or `null`
@@ -614,6 +634,7 @@ export class XlsxViewer {
     // FAILED re-load keeps the current workbook + its rendered sheet intact rather
     // than dropping to an empty viewer. The 2× memory window is bounded to the
     // load itself (the old workbook is freed the moment the new model arrives).
+    const gen = ++this._loadGen;
     const previous = this.wb;
     try {
       const wb = await XlsxWorkbook.load(source, {
@@ -624,12 +645,24 @@ export class XlsxViewer {
         math: this.opts.math,
         mode: this._mode,
       });
+      if (gen !== this._loadGen) {
+        // A newer load() (or destroy()) started while this one was in flight — we
+        // lost the concurrent-load race. Destroy the workbook we just loaded (it
+        // was never installed) and leave the winning load's workbook + SC20 swap
+        // untouched: do NOT touch `this.wb` and do NOT destroy `previous`
+        // (irrelevant to the winner; possibly already stale).
+        wb.destroy();
+        return;
+      }
       this.wb = wb;
       previous?.destroy();
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
       await this.showSheet(this._initialSheet());
     } catch (err) {
+      // Superseded loads own no error reporting — the winning load (or destroy())
+      // is the outcome the caller awaits; swallow this stale rejection.
+      if (gen !== this._loadGen) return;
       const e = err instanceof Error ? err : new Error(String(err));
       if (this.opts.onError) {
         this.opts.onError(e);
@@ -2203,8 +2236,10 @@ export class XlsxViewer {
   }
 
   /** Route a render failure to `onError`, or `console.error` when none is given
-   *  (never fully silent). Mirrors the scroll viewers' `_reportRenderError`. */
+   *  (never fully silent), and never after teardown. Mirrors the scroll viewers'
+   *  `_reportRenderError`. */
   private _reportRenderError(err: unknown): void {
+    if (this._destroyed) return;
     const e = err instanceof Error ? err : new Error(String(err));
     if (this.opts.onError) this.opts.onError(e);
     else console.error('[ooxml] XlsxViewer render failed:', e);
@@ -2382,6 +2417,12 @@ export class XlsxViewer {
    * leftover sheet is a bounded, harmless cost (see {@link ensureViewerStyleInjected}).
    */
   destroy(): void {
+    // First line: block any render rejection racing in from surfacing on a dead
+    // viewer (checked at the top of _reportRenderError). Bump the load generation
+    // too so a load() still in flight is treated as superseded and its workbook is
+    // cleaned up rather than installed onto a torn-down viewer.
+    this._destroyed = true;
+    this._loadGen++;
     this.resizeObserver?.disconnect();
     // Cancel any coalesced render still queued for the next frame so it can't
     // fire against a torn-down viewer (matches the destroy-completeness flow:

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -2190,6 +2190,27 @@ export class XlsxViewer {
   }
 
   private async renderCurrentSheet(): Promise<void> {
+    // PD14 render-error contract (shared with the scroll viewers): most callers
+    // invoke this `void`-style from scroll/resize/selection handlers, so an
+    // unguarded throw would surface as an unhandled promise rejection. Catch here
+    // and route to `onError` (or `console.error` — never silent), matching
+    // DocxViewer._render and the scroll viewers.
+    try {
+      await this._renderCurrentSheet();
+    } catch (err) {
+      this._reportRenderError(err);
+    }
+  }
+
+  /** Route a render failure to `onError`, or `console.error` when none is given
+   *  (never fully silent). Mirrors the scroll viewers' `_reportRenderError`. */
+  private _reportRenderError(err: unknown): void {
+    const e = err instanceof Error ? err : new Error(String(err));
+    if (this.opts.onError) this.opts.onError(e);
+    else console.error('[ooxml] XlsxViewer render failed:', e);
+  }
+
+  private async _renderCurrentSheet(): Promise<void> {
     if (!this.currentWorksheet) return;
     const ws = this.currentWorksheet;
     const w = this.canvasArea.clientWidth;

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -608,8 +608,15 @@ export class XlsxViewer {
    * the error is rethrown so it is never silently swallowed.
    */
   async load(source: string | ArrayBuffer): Promise<void> {
+    // SC20 atomic swap: retain the previous workbook locally and only tear it down
+    // AFTER the new one loads successfully. A re-load thus never orphans the old
+    // workbook's worker + pinned WASM allocation (the leak this guards), yet a
+    // FAILED re-load keeps the current workbook + its rendered sheet intact rather
+    // than dropping to an empty viewer. The 2× memory window is bounded to the
+    // load itself (the old workbook is freed the moment the new model arrives).
+    const previous = this.wb;
     try {
-      this.wb = await XlsxWorkbook.load(source, {
+      const wb = await XlsxWorkbook.load(source, {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
         workerTimeoutMs: this.opts.workerTimeoutMs,
@@ -617,6 +624,8 @@ export class XlsxViewer {
         math: this.opts.math,
         mode: this._mode,
       });
+      this.wb = wb;
+      previous?.destroy();
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
       await this.showSheet(this._initialSheet());

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -623,9 +623,15 @@ export class XlsxViewer {
   /**
    * Load an XLSX from URL or ArrayBuffer and render the first sheet.
    *
-   * Error contract (shared by all three viewers): on failure, if an `onError`
-   * callback was provided it is invoked and `load` resolves normally; if not,
-   * the error is rethrown so it is never silently swallowed.
+   * Error contract (shared by all three viewers):
+   * - Parse/load failure (the underlying `XlsxWorkbook.load()` call itself
+   *   rejects): if an `onError` callback was provided it is invoked and `load`
+   *   resolves normally; if not, the error is rethrown so it is never silently
+   *   swallowed.
+   * - Render failure (the first sheet fails to draw AFTER a successful
+   *   parse/load): routed to the shared `_reportRenderError` contract (`onError`
+   *   if provided, else `console.error` — never silent) and `load` still
+   *   RESOLVES, matching every subsequent navigation call.
    */
   async load(source: string | ArrayBuffer): Promise<void> {
     // SC20 atomic swap: retain the previous workbook locally and only tear it down

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -73,10 +73,14 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       ]);
     } else if (req.type === 'extractImage') {
       if (!archive) throw new Error('No xlsx loaded');
-      const bytes = archive.extract_image(req.path);
-      const copy = new Uint8Array(bytes).slice().buffer;
-      const res: WorkerResponse = { type: 'imageExtracted', id, bytes: copy };
-      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [copy]);
+      // wasm-bindgen already hands back a fresh, standalone Uint8Array here (its
+      // glue does `getArrayU8FromWasm0(ptr,len).slice()` then frees the Rust Vec),
+      // so `.buffer` is a full-span, non-WASM-backed ArrayBuffer we own outright —
+      // transfer it directly. A second `new Uint8Array(bytes).slice()` would just
+      // re-copy the whole entry for nothing.
+      const out = archive.extract_image(req.path).buffer as ArrayBuffer;
+      const res: WorkerResponse = { type: 'imageExtracted', id, bytes: out };
+      (self.postMessage as (message: unknown, transfer: Transferable[]) => void)(res, [out]);
     }
   } catch (err) {
     const res: WorkerResponse = { type: 'error', id, message: String(err) };


### PR DESCRIPTION
## Summary

Phase 1 batch 7/10 from the 2026-07b improvement plan (SC17 + SC18 + SC20 + AR4 + PD14).

- **SC17** (perf) — `{Docx,Pptx,Xlsx}Archive::new` took `&[u8]` and did `Cursor::new(data.to_vec())`, pinning 2× the file size for the handle's lifetime. Now takes an owned `Vec<u8>` (wasm-bindgen's owned-vector ABI copies once at the boundary and Rust keeps that buffer — no detach, verified against the generated glue). Free functions stay on `&[u8]` (their Node/bench callers reuse the buffer). **Bench**: 219 MB pptx cold `new` peak WASM memory 440 MB → 221 MB (2×→1×), new+parse median 23.1 → 15.5 ms.
- **SC18** (perf) — `extract_media`/`extract_image` worker responses did `new Uint8Array(bytes).slice().buffer` — a redundant second copy. wasm-bindgen's glue already returns an independent, full-span, non-WASM-backed buffer (verified), so the worker now transfers `bytes.buffer` directly. One whole-entry memcpy removed per extracted asset; pinned by a `structuredClone(..., {transfer})` test that would throw for a WASM view.
- **SC20** (lifecycle) — a viewer `load()` overwrote its engine reference, orphaning the old parser worker + pinned WASM. All 5 entry points (3 single-canvas viewers + docx/pptx scroll viewers) now destroy the prior engine after a successful swap (a failed re-load keeps the old engine), plus a `_loadGen` generation-token latch so overlapping `load()` calls destroy the superseded engine instead of orphaning it.
- **AR4** (fix) — a pptx worker whose WASM init rejected left `load()` hanging forever (the ready-handshake sat outside the request timeout). Converted `worker.ts` + `render-worker.ts` to the docx/xlsx `initPromise` pattern and removed the `ready` handshake end-to-end; a rejected init now propagates an error response that rejects the pending `load()`. Also fixes a slow-init race.
- **PD14** (fix) — render errors had three fates (docx rethrow / pptx swallow / xlsx unhandled rejection). All three single-canvas viewers now share `_reportRenderError` (onError else console.error — never silent, load resolves), matching the scroll-viewer contract, with a `_destroyed` guard so a late render rejection never fires on a torn-down viewer.

## Verification

- `cargo fmt --check` / `clippy -D warnings` / `cargo test` — green; `pnpm build:wasm` rebuilt
- `pnpm test` — 2001 passed (239 files; +56 lifecycle/error/perf tests, incl. concurrent-load and init-hang); root typecheck clean; ast-grep clean
- Full local VRT — 163/163 passed, zero reference-image diffs
- Independent 2-dimension review (correctness/concurrency — reviewer verified the no-detach ABI, transfer-safety, init-reject propagation, and never-silent-resolve against glue/tests; test quality/cross-package): all findings (concurrent-load orphan latch, destroy-during-render guard, silent-pass test, JSDoc contract) addressed in-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)