### PR TITLE
feat(charts): extend the secondary value axis to line and area families (CH7)

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -718,3 +718,171 @@ describe('scatter series data labels honor c:date1904 (§21.2.2.38)', () => {
     expect(scatterWithDateLabel(true).some(t => t.text === expected1900)).toBe(false);
   });
 });
+
+// ─── CH7 — secondary value axis for line / area (§21.2.2.*) ──────────────────
+//
+// A combo can bind a series to a SECONDARY value axis (a second `<c:valAx>`
+// with axPos="r" / `<c:crosses val="max">`). Bar already supports this; CH7
+// extends it to the line and area families. The secondary series is plotted
+// against the axis's OWN independent scale, and the axis is drawn on the right
+// edge. Scatter is intentionally NOT wired (Excel/PowerPoint do not define a
+// Y secondary axis for XY scatter).
+
+/** Recording context that captures path vertices (moveTo/lineTo/arc) grouped
+ *  into SEGMENTS delimited by `beginPath`, plus fillText. Line/area build each
+ *  series as its own `beginPath`…path…`fill`/`stroke` sequence, so a segment
+ *  isolates one series' plotted vertices — independent of when the renderer
+ *  sets strokeStyle/fillStyle relative to the path ops (area sets them AFTER
+ *  building the path, so strokeStyle-based grouping would misattribute). A test
+ *  picks the segment for a series by its known draw order. `fillRect` is dropped
+ *  (line/area draw no bars). */
+function pathRecordingCtx(): {
+  ctx: CanvasRenderingContext2D;
+  segments: Array<Array<{ x: number; y: number }>>;
+  texts: TextCall[];
+} {
+  const segments: Array<Array<{ x: number; y: number }>> = [];
+  let current: Array<{ x: number; y: number }> | null = null;
+  const texts: TextCall[] = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  const fontPx = (font: string): number => {
+    const m = /(\d+(?:\.\d+)?)px/.exec(font);
+    return m ? parseFloat(m[1]) : 10;
+  };
+  const push = (x: number, y: number): void => {
+    if (!current) { current = []; segments.push(current); }
+    current.push({ x, y });
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => {
+            const px = fontPx(String(state.font));
+            let w = 0;
+            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+            return { width: w };
+          };
+        case 'beginPath':
+          return () => { current = null; };
+        case 'moveTo':
+        case 'lineTo':
+        case 'arc':
+          return (x: number, y: number) => push(x, y);
+        case 'fillText':
+          return (text: string, x: number, y: number) => texts.push({ text, x, y });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        default:
+          return () => undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, segments, texts };
+}
+
+const SECONDARY_AXIS = {
+  min: null,
+  max: null,
+  title: 'Rate',
+  hidden: false,
+  majorTickMark: 'out',
+  lineHidden: false,
+};
+
+describe('CH7 — line/area series honor a secondary value axis (§21.2.2.*)', () => {
+  // The primary series ASCENDS [10,20,30]; the secondary series DESCENDS
+  // [3,2,1]. Opposite slopes make the secondary series identifiable by geometry
+  // alone (no color/draw-order coupling): its plotted profile falls left→right,
+  // the primary's rises. Crucially the secondary series peaks at the FIRST
+  // category (value 3). Mapped to its OWN axis (0..~3.5) that peak rides near
+  // the plot top; mapped to the PRIMARY axis (0..~35) value 3 barely leaves the
+  // bottom. The primary series peaks at the LAST category, so the LEFT third of
+  // the plot contains a high point ONLY when the secondary axis is wired.
+  const primaryVals = [10, 20, 30];
+  const secondaryVals = [3, 2, 1];
+
+  function comboModel(chartType: 'line' | 'area', withSecondaryAxis: boolean): ChartModel {
+    return baseModel({
+      chartType,
+      categories: ['A', 'B', 'C'],
+      series: [
+        series({ name: 'Big', values: primaryVals }),
+        series({ name: 'Small', values: secondaryVals, useSecondaryAxis: true }),
+      ],
+      secondaryValAxis: withSecondaryAxis ? { ...SECONDARY_AXIS } : null,
+    });
+  }
+
+  /** A "data" segment is a polyline/fill that slopes — its vertices vary in BOTH
+   *  x and y. Gridlines (constant y) and axis rules (constant x) are flat in one
+   *  axis, so this filter isolates the plotted series geometry from the chrome. */
+  function isDataSegment(seg: Array<{ x: number; y: number }>): boolean {
+    if (seg.length < 3) return false;
+    const xs = new Set(seg.map(p => Math.round(p.x)));
+    const ys = new Set(seg.map(p => Math.round(p.y)));
+    return xs.size > 1 && ys.size > 1;
+  }
+
+  /** Highest (min-Y) DATA vertex in the LEFT third of the plot. The primary
+   *  series' high point is on the RIGHT, so a high point here can only be the
+   *  DESCENDING secondary series' value-3 peak — present only when that series
+   *  rides its own (short) axis. Chrome (gridlines / axis rules) is excluded, so
+   *  the measure reflects series geometry alone; independent of color/draw order. */
+  function leftPeakY(segments: Array<Array<{ x: number; y: number }>>): number {
+    const leftThird = RECT.x + RECT.w / 3;
+    const ys = segments
+      .filter(isDataSegment)
+      .flat()
+      .filter(p => p.x < leftThird)
+      .map(p => p.y);
+    expect(ys.length).toBeGreaterThan(0);
+    return Math.min(...ys);
+  }
+
+  for (const chartType of ['line', 'area'] as const) {
+    it(`${chartType}: the secondary series maps to its OWN scale, not the primary`, () => {
+      const wired = pathRecordingCtx();
+      renderChart(wired.ctx, comboModel(chartType, true), RECT, 1);
+      const unwired = pathRecordingCtx();
+      renderChart(unwired.ctx, comboModel(chartType, false), RECT, 1);
+      // Wired: the descending series' value-3 peak sits top-left (small Y).
+      // Unwired: value 3 on the tall primary axis stays low, so the left third
+      // has no high point — its min-Y is far larger. A ≥100px gap can't be noise.
+      const wiredPeak = leftPeakY(wired.segments);
+      const unwiredPeak = leftPeakY(unwired.segments);
+      expect(wiredPeak).toBeLessThan(unwiredPeak - 100);
+    });
+
+    it(`${chartType}: draws right-edge secondary axis tick labels + title`, () => {
+      const rec = pathRecordingCtx();
+      renderChart(rec.ctx, comboModel(chartType, true), RECT, 1);
+      // Primary value labels sit LEFT of the plot; secondary tick labels + title
+      // sit to the RIGHT. A text mark past 75% of the width can only be secondary.
+      const rightLabels = rec.texts.filter(t => t.x > RECT.x + RECT.w * 0.75);
+      expect(rightLabels.length).toBeGreaterThan(0);
+      expect(rec.texts.some(t => t.text === 'Rate')).toBe(true);
+    });
+
+    it(`${chartType}: NO secondary axis (secondaryValAxis null) → no right-edge labels/title`, () => {
+      // Byte-stability guard: without a secondary axis the renderer must draw NO
+      // right-edge axis marks — it degrades to the exact single-axis path.
+      const rec = pathRecordingCtx();
+      renderChart(rec.ctx, comboModel(chartType, false), RECT, 1);
+      expect(rec.texts.some(t => t.text === 'Rate')).toBe(false);
+    });
+  }
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3,7 +3,7 @@
 // scatter, waterfall). Ported from the xlsx implementation with pptx
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
-import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
+import type { ChartModel, ChartRect, ChartSeries, SecondaryValueAxis } from '../types/chart';
 import {
   computeChartFrame,
   chartTitleBand,
@@ -402,6 +402,57 @@ function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: numb
   return Math.max(8, h * 0.045);
 }
 
+/** Resolved secondary value-axis scale (combo charts). `min`/`max`/`step` are
+ *  the "nice" bounds + major unit; `makeToY(py0, ph)` builds the value→pixel
+ *  mapping once the final plot rect is known (the scale is computed BEFORE the
+ *  pad/gutter math from an estimated plot height, so the mapping factory is
+ *  split out). See {@link computeSecondaryAxis}. */
+interface SecondaryAxisScale {
+  min: number;
+  max: number;
+  step: number;
+  makeToY: (py0: number, ph: number) => (v: number) => number;
+}
+
+/** Compute the INDEPENDENT scale of a secondary value axis from the series that
+ *  opt into it (`useSecondaryAxis === true`). Shared by every axis family that
+ *  supports a secondary axis (bar-combo line series, and plain line / area
+ *  series): the axis has its own "nice" major unit / gridline count, anchored so
+ *  its min never sits above 0 (Excel keeps the zero line reachable), with an
+ *  explicit `<c:scaling><c:min/max>` (`sec.min`/`sec.max`) overriding. Returns
+ *  null when no `SecondaryValueAxis` was parsed OR no series opts into it — the
+ *  caller then keeps the single-axis path unchanged.
+ *
+ *  `plotHeightPt` is the estimated plot height in points (the axis is the
+ *  vertical right edge, so its length drives the auto major unit). `getValues`
+ *  yields each opted-in series' raw values.
+ *
+ *  This is a pure refactor of the bar renderer's inline secondary-scale math —
+ *  same `valueAxisScale(Math.min(0, dMin), dMax, sec.min, sec.max, len)` call,
+ *  same empty-data fallback (dMin→0, dMax→1). */
+function computeSecondaryAxis(
+  sec: SecondaryValueAxis | null,
+  seriesForSecondary: ChartSeries[],
+  plotHeightPt: number,
+): SecondaryAxisScale | null {
+  if (!sec) return null;
+  const secVals: number[] = [];
+  for (const s of seriesForSecondary) {
+    if (s.useSecondaryAxis !== true) continue;
+    for (const v of s.values) if (v != null) secVals.push(v);
+  }
+  const dMin = secVals.length ? Math.min(...secVals) : 0;
+  const dMax = secVals.length ? Math.max(...secVals) : 1;
+  const { min, max, step } = valueAxisScale(Math.min(0, dMin), dMax, sec.min, sec.max, plotHeightPt);
+  const range = (max - min) || 1;
+  return {
+    min,
+    max,
+    step,
+    makeToY: (py0: number, ph: number) => (v: number): number => py0 + ph - ((v - min) / range) * ph,
+  };
+}
+
 function drawChartTitle(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -608,19 +659,13 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
 
   // Secondary value-axis scale (combo charts). INDEPENDENT of the primary: its
   // own "nice" major unit / gridline count. Its axis is the vertical right edge,
-  // so its length is the plot height. Explicit `<c:scaling>` wins.
-  let sMin = 0, sMax = 1, sStep = 1;
-  if (sec) {
-    const lineVals: number[] = [];
-    for (const s of lineSeries) {
-      if (s.useSecondaryAxis !== true) continue;
-      for (const v of s.values) if (v != null) lineVals.push(v);
-    }
-    const dMin = lineVals.length ? Math.min(...lineVals) : 0;
-    const dMax = lineVals.length ? Math.max(...lineVals) : 1;
-    const scl = valueAxisScale(Math.min(0, dMin), dMax, sec.min, sec.max, phEst / ptToPx);
-    sMin = scl.min; sMax = scl.max; sStep = scl.step;
-  }
+  // so its length is the plot height. Explicit `<c:scaling>` wins. Computed by
+  // the shared `computeSecondaryAxis` helper (same math the line/area families
+  // reuse); the fallback keeps the no-secondary path unchanged.
+  const secScale = computeSecondaryAxis(sec, lineSeries, phEst / ptToPx);
+  const sMin = secScale ? secScale.min : 0;
+  const sMax = secScale ? secScale.max : 1;
+  const sStep = secScale ? secScale.step : 1;
 
   const secTickFontPx = Math.max(8, Math.min(11, h / 20));
   const tickFontPx = Math.max(8, Math.min(11, phEst / 20));
@@ -715,7 +760,11 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const zeroY = valY(0); // column zero line
   const zeroX = valX(0); // horizontal-bar zero line
   const toYPrimaryLine = valY;
-  const toYSecondary   = (v: number): number => py0 + ph - ((v - sMin) / sRange) * ph;
+  // Secondary line series map through the shared scale's factory (identical to
+  // the old inline `py0 + ph - ((v - sMin) / sRange) * ph`; `makeToY` uses the
+  // same `(max - min) || 1` range). Falls back to the primary map when there is
+  // no secondary axis so `toYSecondary` stays callable.
+  const toYSecondary = secScale ? secScale.makeToY(py0, ph) : valY;
 
   const gridColor = '#e0e0e0';
   const steps = Math.round(axRange / step);

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -453,6 +453,69 @@ function computeSecondaryAxis(
   };
 }
 
+/** Draw a secondary value axis on the RIGHT edge of the plot: its rule, mirrored
+ *  tick marks + labels, and rotated title. Its scale is INDEPENDENT of the
+ *  primary axis (its own "nice" major unit; NOT aligned to the primary
+ *  gridlines) — PowerPoint places these marks independently. Shared by the
+ *  line and area families; the bar renderer keeps its own inline copy for now
+ *  (its call sequence is byte-identical to this helper). Callers pass:
+ *  - `secScale`   the resolved scale (from {@link computeSecondaryAxis}),
+ *  - `toYSecondary` the value→pixel map (`secScale.makeToY(py0, ph)`),
+ *  - `secFontPx` / `secLabelBandW` the tick-label font size + reserved gutter
+ *    width (measured up front so the title clears the labels),
+ *  - `primaryLabelColor` the fallback tick-label color when the axis specifies
+ *    none (the primary value-axis label color). */
+function drawSecondaryValueAxis(
+  ctx: CanvasRenderingContext2D,
+  sec: SecondaryValueAxis,
+  secScale: SecondaryAxisScale,
+  toYSecondary: (v: number) => number,
+  px0: number, py0: number, pw: number, ph: number,
+  h: number,
+  ptToPx: number,
+  secFontPx: number,
+  secLabelBandW: number,
+  primaryLabelColor: string,
+  date1904: boolean | undefined,
+): void {
+  const axX = px0 + pw;
+  const { color: secLineColor, width: secLineW } = resolveAxisLine(sec.lineColor, sec.lineWidthEmu, ptToPx);
+  if (!sec.lineHidden) {
+    ctx.strokeStyle = secLineColor; ctx.lineWidth = secLineW;
+    ctx.beginPath(); ctx.moveTo(axX, py0); ctx.lineTo(axX, py0 + ph); ctx.stroke();
+  }
+  if (!sec.hidden) {
+    ctx.font = `${secFontPx}px sans-serif`;
+    ctx.fillStyle = sec.fontColor ? `#${sec.fontColor}` : primaryLabelColor;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    const sRange = (secScale.max - secScale.min) || 1;
+    const secSteps = Math.max(1, Math.round(sRange / secScale.step));
+    for (let si = 0; si <= secSteps; si++) {
+      const sval = secScale.min + si * secScale.step;
+      const gy = toYSecondary(sval);
+      // Same tick geometry as the left axis, mirrored to the right edge.
+      drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true);
+      ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, date1904), axX + 14, gy);
+    }
+  }
+  if (sec.title) {
+    const tFontPx = sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05);
+    ctx.save();
+    ctx.fillStyle = sec.titleFontColor
+      ? `#${sec.titleFontColor}`
+      : (sec.fontColor ? `#${sec.fontColor}` : '#555');
+    ctx.font = `${sec.titleFontBold ? 'bold ' : ''}${tFontPx}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    // Right-axis title reads top-to-bottom (rotate +90), placed past the labels.
+    ctx.translate(px0 + pw + secLabelBandW + tFontPx * 0.6, py0 + ph / 2);
+    ctx.rotate(Math.PI / 2);
+    ctx.fillText(sec.title, 0, 0);
+    ctx.restore();
+  }
+}
+
 function drawChartTitle(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -1150,6 +1213,19 @@ function renderLineChart(
     return pct && pctTotals ? (sum / pctTotals[ci]) * 100 : sum;
   };
 
+  // Combo line charts may bind some series to a SECONDARY value axis drawn on
+  // the right (ECMA-376 §21.2.2.* — a second `<c:valAx>` with axPos="r"). `sec`
+  // is non-null only when the axis is declared AND at least one series opts in;
+  // secondary series are then excluded from the PRIMARY scale and mapped through
+  // the secondary one. Stacked line charts stack ALL series onto the primary
+  // axis (a percentStacked/stacked secondary combo is not an Office construct),
+  // so the split only applies to plain (unstacked) line charts. When `sec` is
+  // null every series stays on the primary axis, identical to the pre-CH7 path.
+  const sec = !stacked && chart.secondaryValAxis && chart.series.some(s => s.useSecondaryAxis === true)
+    ? chart.secondaryValAxis
+    : null;
+  const isSecondarySeries = (s: ChartSeries): boolean => sec != null && s.useSecondaryAxis === true;
+
   // Shared frame bands. The line family uses title pads 0.045 / 0.035 and the
   // default 0.22 side-legend reserve — passed as params so pixels are unchanged.
   // PowerPoint's auto-layout reserves a title band with air above and below
@@ -1169,12 +1245,45 @@ function renderLineChart(
   const valTitlePx = axBands.valFontPx;
   const catTitleH = axBands.catBandH;
   const valTitleW = axBands.valBandW;
+
+  // Vertical pads (independent of the right gutter) so an estimated plot height
+  // is known before the secondary-axis scale + right-gutter measurement — the
+  // same up-front ordering the bar renderer uses.
+  const padT = titleH + legTopH + valAxFontPx / 2 + 2;
+  const padB = catAxFontPx + 12 + catTitleH + legBottomH;
+  const phEst = h - padT - padB;
+
+  // Secondary value-axis scale (shared helper). Its axis is the vertical right
+  // edge, so its length is the plot height. Null when there is no secondary axis.
+  const secScale = computeSecondaryAxis(sec, chart.series, phEst / ptToPx);
+  // Right-edge gutter for the secondary tick labels + rotated title. Measured
+  // with the SAME font/format the axis is drawn with so the reserve matches the
+  // painted labels (mirrors the bar renderer). Zero when there is no secondary
+  // axis, so `pad.r` is unchanged on the common single-axis path.
+  const secTickFontPx = Math.max(8, Math.min(11, h / 20));
+  const secFontPx = sec?.fontSizeHpt ? (sec.fontSizeHpt / 100) * ptToPx : secTickFontPx;
+  let secLabelBandW = 0;
+  if (sec && secScale && !sec.hidden) {
+    const prevFont = ctx.font;
+    ctx.font = `${secFontPx}px sans-serif`;
+    let wmax = 0;
+    const sSteps = Math.round((secScale.max - secScale.min) / secScale.step);
+    for (let si = 0; si <= sSteps; si++) {
+      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(secScale.min + si * secScale.step, sec.formatCode ?? null, chart.date1904)).width);
+    }
+    secLabelBandW = wmax + 18;
+    ctx.font = prevFont;
+  }
+  const secTitleBandW = sec && sec.title
+    ? (sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05)) + 8
+    : 0;
+
   // Pad based on actual label metrics rather than magic percents so an explicit
   // <c:txPr sz="1000"> (10pt) correctly compresses the plot area.
   const pad = {
-    t: titleH + legTopH + valAxFontPx / 2 + 2,
-    r: legRightW + w * 0.05,
-    b: catAxFontPx + 12 + catTitleH + legBottomH,
+    t: padT,
+    r: legRightW + w * 0.05 + secLabelBandW + secTitleBandW,
+    b: padB,
     l: valAxFontPx * 2.2 + 10 + valTitleW + legLeftW,
   };
 
@@ -1193,12 +1302,15 @@ function renderLineChart(
     ctx.fillRect(px0, py0, pw, ph);
   }
 
-  // Axis extent is taken from the PLOTTED values, so a stacked chart's top line
-  // (the cumulative sum) drives the maximum rather than the tallest single
-  // series. Every category still contributes each series' cumulative value.
+  // Primary axis extent is taken from the PLOTTED values of the PRIMARY series
+  // only (secondary series live on their own axis), so a stacked chart's top
+  // line (the cumulative sum) drives the maximum rather than the tallest single
+  // series. Every category still contributes each primary series' cumulative
+  // value. When `sec` is null every series is primary, identical to pre-CH7.
   let dataMin = Infinity; let dataMax = -Infinity;
   for (let ci = 0; ci < n; ci++) {
     for (let si = 0; si < chart.series.length; si++) {
+      if (isSecondarySeries(chart.series[si])) continue;
       if (!stacked && chart.series[si].values[ci] == null) continue;
       const v = plotted(si, ci);
       dataMin = Math.min(dataMin, v); dataMax = Math.max(dataMax, v);
@@ -1217,6 +1329,11 @@ function renderLineChart(
   const range = axMax - axMin; if (range === 0) return;
 
   const toY = (v: number) => py0 + ph - ((v - axMin) / range) * ph;
+  // Secondary series map through their own scale; `secScale` is null on the
+  // common single-axis path so `yMapFor` always returns the primary `toY`.
+  const toYSecondary = secScale ? secScale.makeToY(py0, ph) : toY;
+  const yMapFor = (s: ChartSeries): ((v: number) => number) =>
+    isSecondarySeries(s) ? toYSecondary : toY;
   // crossBetween="between" (default) insets the first/last category by half a
   // step so points aren't flush against the axes. "midCat" anchors them.
   const between = isCrossBetween(chart);
@@ -1261,6 +1378,9 @@ function renderLineChart(
   for (let si = 0; si < chart.series.length; si++) {
     const s = chart.series[si];
     const color = chartColor(si, s);
+    // Secondary series ride their own vertical scale; primary series (and every
+    // series when there is no secondary axis) map through the primary `toY`.
+    const yOf = yMapFor(s);
     ctx.strokeStyle = color; ctx.lineWidth = lineWidthPx; ctx.setLineDash([]);
     ctx.beginPath();
     let started = false;
@@ -1268,7 +1388,7 @@ function renderLineChart(
       // Unstacked: a null cell breaks the line. Stacked: a null contributes 0
       // to the running sum (no gap), matching the area renderer.
       if (!stacked && s.values[ci] == null) { started = false; continue; }
-      const py = toY(plotted(si, ci)); const px = toX(ci);
+      const py = yOf(plotted(si, ci)); const px = toX(ci);
       if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
     }
     ctx.stroke();
@@ -1281,13 +1401,13 @@ function renderLineChart(
       if (!stacked && s.values[ci] == null) continue;
       const pv = plotted(si, ci);
       if (drawMarkers) {
-        ctx.beginPath(); ctx.arc(toX(ci), toY(pv), markerR, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.arc(toX(ci), yOf(pv), markerR, 0, Math.PI * 2); ctx.fill();
       }
       if (chart.showDataLabels) {
         ctx.font = `${dataLabelPx}px sans-serif`;
         ctx.fillStyle = '#333'; ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
         const labelOffset = drawMarkers ? markerR + 1 : 2;
-        ctx.fillText(formatChartVal(pv), toX(ci), toY(pv) - labelOffset);
+        ctx.fillText(formatChartVal(pv), toX(ci), yOf(pv) - labelOffset);
         ctx.fillStyle = color;
       }
     }
@@ -1310,6 +1430,16 @@ function renderLineChart(
       const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
       ctx.fillText(elideToWidth(ctx, label, catSlotMaxPx), tx, py0 + ph + 5);
     }
+  }
+
+  // Secondary value axis (right edge) — drawn after the series + category labels
+  // so it sits atop the plot, mirroring the bar renderer's ordering.
+  if (sec && secScale) {
+    const primaryLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
+    drawSecondaryValueAxis(
+      ctx, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
+      secFontPx, secLabelBandW, primaryLabelColor, chart.date1904,
+    );
   }
 
   drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleH + 2);
@@ -1347,6 +1477,17 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     return pct && pctTotals ? (raw / pctTotals[ci]) * 100 : raw;
   };
 
+  // Combo area charts may bind some series to a SECONDARY value axis on the
+  // right (ECMA-376 §21.2.2.*). As with line, this applies only to plain
+  // (unstacked) area — a stacked/percentStacked secondary combo is not an Office
+  // construct. `sec` is null (single-axis, byte-identical to pre-CH7) unless the
+  // axis is declared AND a series opts in; secondary series are then excluded
+  // from the primary extent and mapped through the secondary scale.
+  const sec = !stacked && chart.secondaryValAxis && chart.series.some(s => s.useSecondaryAxis === true)
+    ? chart.secondaryValAxis
+    : null;
+  const isSecondarySeries = (s: ChartSeries): boolean => sec != null && s.useSecondaryAxis === true;
+
   // Shared frame bands. Area uses title pads 0.035 / 0.035 and default 0.22
   // side-legend reserve — params keep pixels unchanged.
   const titleBand = chartTitleBand(chart, h, ptToPx, 0.035, 0.035);
@@ -1360,10 +1501,36 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const valTitlePx = axBands.valFontPx;
   const catTitleH = axBands.catBandH;
   const valTitleW = axBands.valBandW;
+
+  // Vertical pads first so the estimated plot height is known before the
+  // secondary-axis scale + right-gutter measurement (same ordering as bar/line).
+  const padT = titleH + legTopH + h * 0.02;
+  const padB = h * 0.14 + catTitleH + legBottomH;
+  const phEst = h - padT - padB;
+
+  const secScale = computeSecondaryAxis(sec, chart.series, phEst / ptToPx);
+  const secTickFontPx = Math.max(8, Math.min(11, h / 20));
+  const secFontPx = sec?.fontSizeHpt ? (sec.fontSizeHpt / 100) * ptToPx : secTickFontPx;
+  let secLabelBandW = 0;
+  if (sec && secScale && !sec.hidden) {
+    const prevFont = ctx.font;
+    ctx.font = `${secFontPx}px sans-serif`;
+    let wmax = 0;
+    const sSteps = Math.round((secScale.max - secScale.min) / secScale.step);
+    for (let si = 0; si <= sSteps; si++) {
+      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(secScale.min + si * secScale.step, sec.formatCode ?? null, chart.date1904)).width);
+    }
+    secLabelBandW = wmax + 18;
+    ctx.font = prevFont;
+  }
+  const secTitleBandW = sec && sec.title
+    ? (sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05)) + 8
+    : 0;
+
   const pad = {
-    t: titleH + legTopH + h * 0.02,
-    r: legRightW + w * 0.05,
-    b: h * 0.14 + catTitleH + legBottomH,
+    t: padT,
+    r: legRightW + w * 0.05 + secLabelBandW + secTitleBandW,
+    b: padB,
     l: w * 0.12 + valTitleW + legLeftW,
   };
 
@@ -1382,6 +1549,9 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ctx.fillRect(px0, py0, pw, ph);
   }
 
+  // Primary extent from the PRIMARY series only (secondary series live on their
+  // own axis). When `sec` is null every series is primary, byte-identical to
+  // the pre-CH7 path.
   let dataMax = 0;
   for (let ci = 0; ci < n; ci++) {
     if (stacked) {
@@ -1389,7 +1559,10 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       for (let si = 0; si < chart.series.length; si++) sum += stackedValue(si, ci);
       dataMax = Math.max(dataMax, sum);
     } else {
-      for (const s of chart.series) dataMax = Math.max(dataMax, s.values[ci] ?? 0);
+      for (const s of chart.series) {
+        if (isSecondarySeries(s)) continue;
+        dataMax = Math.max(dataMax, s.values[ci] ?? 0);
+      }
     }
   }
   // percentStacked always tops out at exactly 100% (each category's Σ|v|
@@ -1411,6 +1584,11 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ? (i: number) => px0 + ((i + 0.5) / n) * pw
     : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
   const toY = (v: number) => py0 + ph - (v / axMax) * ph;
+  // Secondary series map through their own scale; `secScale` is null on the
+  // common single-axis path so `yMapFor` always returns the primary `toY`.
+  const toYSecondary = secScale ? secScale.makeToY(py0, ph) : toY;
+  const yMapFor = (s: ChartSeries): ((v: number) => number) =>
+    isSecondarySeries(s) ? toYSecondary : toY;
 
   // Axis line colour/weight from `<c:*Ax><c:spPr><a:ln>` (EMU → px at scale),
   // mirroring the bar/line renderers. Office leaves the value-axis rule off by
@@ -1426,6 +1604,10 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     const s = chart.series[si];
     const color = chartColor(si, s);
     const baseY = py0 + ph;
+    // Unstacked secondary series ride their own vertical scale; the stacked
+    // branch is never reached with a secondary axis (`sec` is null when
+    // stacked), so its `toY` mapping stays the primary one.
+    const yOf = yMapFor(s);
 
     ctx.beginPath();
     if (stacked && stackBase) {
@@ -1440,7 +1622,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       for (let ci = 0; ci < n; ci++) stackBase[ci] += stackedValue(si, ci);
     } else {
       ctx.moveTo(toX(0), baseY);
-      for (let ci = 0; ci < n; ci++) ctx.lineTo(toX(ci), toY(s.values[ci] ?? 0));
+      for (let ci = 0; ci < n; ci++) ctx.lineTo(toX(ci), yOf(s.values[ci] ?? 0));
       ctx.lineTo(toX(n - 1), baseY);
     }
     ctx.closePath();
@@ -1513,6 +1695,16 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     for (let ci = 0; ci < n; ci += labelInterval) {
       ctx.fillText(elideToWidth(ctx, labels[ci] ?? '', catSlotMaxPx), toX(ci), py0 + ph + 3);
     }
+  }
+
+  // Secondary value axis (right edge) — drawn after the fills + category labels
+  // so it sits atop the plot, mirroring the bar/line ordering.
+  if (sec && secScale) {
+    const primaryLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
+    drawSecondaryValueAxis(
+      ctx, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
+      secFontPx, secLabelBandW, primaryLabelColor, chart.date1904,
+    );
   }
 
   drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleH + 2);
@@ -1765,6 +1957,12 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
 // Scatter chart — X values from series.categories, Y from series.values.
 // ═══════════════════════════════════════════════════════════════════════════
 
+// NB: scatter deliberately has NO secondary value axis. Unlike bar/line/area,
+// an XY scatter's X axis is already a numeric VALUE axis (not a category axis),
+// and Excel/PowerPoint do not define a second Y value axis for a scatter combo
+// (`useSecondaryAxis` / a right-hand `<c:valAx>` pairs with a category-based
+// family). So `computeSecondaryAxis` is never called here — the CH7 helper is
+// wired only into the category-axis families (bar already; line + area now).
 function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect, ptToPx: number): void {
   const { x, y, w, h } = r;
   // Shared frame bands. Scatter uses title pads 0.035 / 0.035 and default 0.22


### PR DESCRIPTION
## Summary

Phase 2 chart-renderer item CH7 (renderer-only, no parser change). A combo chart's secondary value axis was honored only by the bar/column family — a line or area series bound to the secondary axis (`useSecondaryAxis`) was silently plotted against the primary scale, collapsing the two scales into one.

- Extracted the bar renderer's inline secondary-axis math into a pure `computeSecondaryAxis` / `makeToY` helper — a **byte-identical refactor** (verified line-by-line against the base and by the unchanged `renderer-signature` snapshot, including the `combo bar+line secondary` fixture, which draws to the last coordinate digit as before).
- Wired the secondary axis into the line and area renderers via a shared `drawSecondaryValueAxis`: the primary scale is computed from primary-axis series only, secondary series map through the secondary scale, and the right gutter is reserved before the frame — identical construction to bar. Applies to unstacked line/area.
- Scatter is deliberately excluded: an XY scatter's X axis is already numeric and Excel/PowerPoint define no second Y value axis for it (documented in a comment). Stacked line/area are excluded too.
- Charts without a secondary axis retain the single-axis path byte-for-byte (the added gutter is 0, no right-edge marks drawn).

## Verification

- `pnpm test` (core) — 793 passed (+6 CH7 tests: secondary series remaps to its own scale, right-edge ticks + title drawn, no-secondary path unchanged); typecheck clean
- `renderer-signature` snapshot unchanged — bar (incl. the secondary-axis fixture) is byte-stable
- `pnpm build:wasm` + full local VRT — 163/163 passed, zero reference-image diffs (no demo sample has a line/area secondary-axis combo)
- Independent review (byte-stability rigor — the extraction was verified mathematically identical to the base inline code, and line/area wiring / no-secondary degeneracy / scatter exclusion confirmed) — APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)