### PR TITLE
docs(readme): add collapsible author note on project motivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 > **This entire codebase — Rust parsers, TypeScript renderers, tests, and tooling — was implemented by [Claude](https://claude.ai)** (Anthropic's AI assistant) through iterative prompting. No human-written application code exists in this repository.
 
+<details>
+<summary><b>Why this project exists — a note from the author</b></summary>
+
+<br>
+
+OOXML's behavior is defined by a written specification (ECMA-376 / ISO-29500), and there is a clear answer to compare against: Word, Excel, and PowerPoint themselves. In principle, anyone with enough patience could have built a faithful viewer — the spec says what to implement, and the Office applications show whether you got it right.
+
+In practice, it didn't happen. For more than a decade, no free, open-source library reached a rendering quality good enough for real use. There are a few commercial libraries with decent fidelity (and editing support), but their pricing makes them hard to adopt casually. I think the reason is simply cost: the specification is huge, and reading and implementing it faithfully takes far more effort than volunteers can afford.
+
+Generative AI changed that. A viewer is an unusually good fit for AI-driven iterative development ("vibe coding"): there is a spec to read and a correct output to aim for, so the work comes down to interpreting the specification and refining the rendering until it matches. Limiting the scope to viewing also avoids the most serious risk an Office library can carry — corrupting a user's files.
+
+So I'm building this library with Claude, spec-first, and keeping it free to use. For some documents it already reproduces the desktop Office applications more faithfully than commercial libraries — and sometimes even the official Microsoft 365 web apps.
+
+</details>
+
 <p align="center">
   <img src="docs/images/icon.png" alt="office-open-xml-viewer" width="160" height="160">
 </p>


### PR DESCRIPTION
## Summary

Adds a collapsible (closed by default) "Why this project exists — a note from the author" section right below the Claude credit line at the top of the README.

The note covers:
- OOXML behavior is fully specified (ECMA-376 / ISO-29500) and the Office applications themselves serve as the ground truth, so a faithful viewer has always been possible in principle.
- In practice no free OSS viewer with adequate rendering quality appeared for over a decade; commercial libraries exist but are hard to adopt casually. The reason is cost — the spec is huge and reading/implementing it faithfully exceeds what volunteer effort can sustain.
- Generative AI changed that: a viewer is an unusually good fit for AI-driven iterative development, and scoping to viewing only avoids the file-corruption risk an Office library can carry.
- Hence this library: built with Claude, spec-first, free to use — for some documents already more faithful to desktop Office than commercial libraries or the Microsoft 365 web apps.

## Changes
- README.md only (15 lines added, no code changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)