### PR TITLE
feat(charts): wire markers, error bars, per-point labels, smooth, and dispBlanksAs into the line family (CH9)

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1100,3 +1100,24 @@ describe('CH9 — line/area per-point data labels (§21.2.2.45)', () => {
     });
   }
 });
+
+describe('CH9 — line/area smooth splines (§21.2.2.194)', () => {
+  for (const chartType of ['line', 'area'] as const) {
+    it(`${chartType}: smooth series draws a bezier spline; non-smooth draws straight segments`, () => {
+      const smooth = markerRecordingCtx();
+      renderChart(smooth.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C', 'D'],
+        series: [series({ name: 'S', values: [3, 5, 4, 6], smooth: true })],
+      }), RECT, 1);
+      const straight = markerRecordingCtx();
+      renderChart(straight.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C', 'D'],
+        series: [series({ name: 'S', values: [3, 5, 4, 6] })],
+      }), RECT, 1);
+      expect(smooth.beziers).toBeGreaterThan(0);
+      expect(straight.beziers).toBe(0);
+    });
+  }
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1029,6 +1029,66 @@ describe('CH9 — line/area consume marker detail (§21.2.2.32)', () => {
   }
 });
 
+describe('CH9 — stacked-area markers/labels sit on the fill\'s band top (§21.2.2.32)', () => {
+  // The fill loop draws bands back-to-front (si = length-1 → 0), accumulating
+  // stackBase AFTER each band, so band si's top edge is the REVERSE-cumulative
+  // sum Σ_{k=si..length-1}. Series 0 (drawn last, on top of the stack) ends up
+  // with the FULL total as its top edge; series 1 (drawn first, at the bottom
+  // of the stack) has only its own value as its top edge. A marker/label pass
+  // that instead used a forward-cumulative Σ_{k=0..si} would misplace both.
+  it('a 2-series stacked area places each series\' marker at its own band top, not a forward-cumulative sum', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedArea',
+      categories: ['A'],
+      series: [
+        series({ name: 'S0', values: [10], showMarker: true }),
+        series({ name: 'S1', values: [40], showMarker: true }),
+      ],
+    }), RECT, 1);
+    // One marker arc per series (single category).
+    expect(rec.arcs.length).toBe(2);
+    const ys = rec.arcs.map(a => a.y).sort((a, b) => a - b);
+    // toY is monotonically decreasing in value, so the HIGHER cumulative value
+    // (S0's band top = 10 + 40 = 50) must plot at the SMALLER y (higher on
+    // screen) than S1's band top (= 40 alone). The two must be DISTINCT —
+    // the forward-cumulative bug placed S0 at 10 and S1 at 50, i.e. swapped
+    // relative to the correct reverse-cumulative 50/40 split.
+    const [higherY, lowerY] = ys; // higherY = smaller number = higher on screen
+    expect(higherY).toBeLessThan(lowerY);
+    // Recover the plotted axis value from screen y using the chart's own
+    // scale invariants: with valMax defaulting to the data max (50, rounded up
+    // by valueAxisScale) and a linear py0..py0+ph mapping, the S0 marker (band
+    // top 50) must sit strictly above (smaller y) the S1 marker (band top 40).
+    // Concretely assert the two are NOT equal to the forward-cumulative
+    // (wrong) values, which would give band tops of 10 (S0) and 50 (S1) —
+    // i.e. S0 LOWER on screen (larger y) than S1. Reverse-cumulative flips
+    // that: S0 must be the topmost (smallest y) of the two.
+    const s0Y = rec.arcs[0].y;
+    const s1Y = rec.arcs[1].y;
+    expect(s0Y).toBeLessThan(s1Y);
+  });
+
+  it('a 3-series stacked area orders markers by reverse-cumulative band top (series 0 highest, last series lowest)', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedArea',
+      categories: ['A'],
+      series: [
+        series({ name: 'S0', values: [5], showMarker: true }),
+        series({ name: 'S1', values: [15], showMarker: true }),
+        series({ name: 'S2', values: [30], showMarker: true }),
+      ],
+    }), RECT, 1);
+    expect(rec.arcs.length).toBe(3);
+    // Reverse-cumulative band tops: S0 = 5+15+30 = 50 (highest, smallest y),
+    // S1 = 15+30 = 45, S2 = 30 (lowest, largest y).
+    const [s0Y, s1Y, s2Y] = rec.arcs.map(a => a.y);
+    expect(s0Y).toBeLessThan(s1Y);
+    expect(s1Y).toBeLessThan(s2Y);
+  });
+});
+
 describe('CH9 — line/area draw per-series error bars (§21.2.2.20)', () => {
   for (const chartType of ['line', 'area'] as const) {
     it(`${chartType}: a series with errBars strokes a vertical bar around each point`, () => {
@@ -1189,5 +1249,85 @@ describe('CH9 — dispBlanksAs controls null-cell handling (§21.2.2.42)', () =>
     const lastX = RECT.x + RECT.w * (2.5 / 3);
     expect(line.some(p => Math.abs(p.x - firstX) < RECT.w * 0.12)).toBe(true);
     expect(line.some(p => Math.abs(p.x - lastX) < RECT.w * 0.12)).toBe(true);
+  });
+});
+
+describe('CH9 — dispBlanksAs="zero" applies to per-point data labels too (§21.2.2.42)', () => {
+  // The marker loop (line 1452 in renderer.ts) already draws a marker for a
+  // null point in "zero" mode. drawCategoryDataLabels must agree: a null cell
+  // reads as 0 for BOTH the marker and its label, so "0" is drawn at the null
+  // category — matching the spec's "treat the blank cell as zero" semantics
+  // (a zero value gets a value label like any other plotted point).
+  function labelHoleModel(dispBlanksAs?: string): ChartModel {
+    return baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C'],
+      series: [series({
+        name: 'S',
+        values: [10, null, 20],
+        seriesDataLabels: { showVal: true, showSerName: false, showCatName: false, showPercent: false },
+      })],
+      ...(dispBlanksAs ? { dispBlanksAs } : {}),
+    });
+  }
+
+  /** Data labels only — excludes the value-axis tick column (fixed left x) and
+   *  the category-axis row (fixed bottom y), which also emit plain numeric /
+   *  "A"/"B"/"C" text via fillText. */
+  function dataLabelTexts(texts: TextCall[]): string[] {
+    const axisTickX = Math.min(...texts.map(t => t.x));
+    const catAxisY = Math.max(...texts.map(t => t.y));
+    return texts
+      .filter(t => Math.abs(t.x - axisTickX) > 1 && Math.abs(t.y - catAxisY) > 1)
+      .map(t => t.text);
+  }
+
+  it('zero: the null category gets a "0" label alongside 10 and 20', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, labelHoleModel('zero'), RECT, 1);
+    const labelTexts = dataLabelTexts(rec.texts);
+    expect(labelTexts).toContain('10');
+    expect(labelTexts).toContain('20');
+    expect(labelTexts).toContain('0');
+  });
+
+  it('gap (default when absent): the null category gets no label at all', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, labelHoleModel(), RECT, 1);
+    const labelTexts = dataLabelTexts(rec.texts);
+    expect(labelTexts).toContain('10');
+    expect(labelTexts).toContain('20');
+    expect(labelTexts.some(t => t === '0')).toBe(false);
+  });
+
+  it('span: the null category is skipped (no label), same as gap', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, labelHoleModel('span'), RECT, 1);
+    const labelTexts = dataLabelTexts(rec.texts);
+    expect(labelTexts).toContain('10');
+    expect(labelTexts).toContain('20');
+    expect(labelTexts.some(t => t === '0')).toBe(false);
+  });
+
+  it('a stacked line always labels a null cell at 0, regardless of dispBlanksAs (a stacked sum already reads null as 0)', () => {
+    // Mirrors the marker loop's own gate (renderer.ts ~line 1453): stacked
+    // series never skip a null point, independent of dispBlanksAs — a null
+    // contributes 0 to the running stack sum either way. No dispBlanksAs set
+    // (defaults to "gap" for an unstacked series) must NOT suppress the label
+    // here, since this series is stacked.
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedLine',
+      categories: ['A', 'B', 'C'],
+      series: [series({
+        name: 'S',
+        values: [10, null, 20],
+        seriesDataLabels: { showVal: true, showSerName: false, showCatName: false, showPercent: false },
+      })],
+    }), RECT, 1);
+    const labelTexts = dataLabelTexts(rec.texts);
+    expect(labelTexts).toContain('10');
+    expect(labelTexts).toContain('20');
+    expect(labelTexts).toContain('0');
   });
 });

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1121,3 +1121,73 @@ describe('CH9 — line/area smooth splines (§21.2.2.194)', () => {
     });
   }
 });
+
+describe('CH9 — dispBlanksAs controls null-cell handling (§21.2.2.42)', () => {
+  // A series with a hole in the middle: gap breaks the line, zero pins the
+  // point to the value-axis zero, span bridges the neighbours with a straight
+  // line (the null is skipped, the two sides connect).
+  function holeModel(chartType: 'line', dispBlanksAs?: string): ChartModel {
+    return baseModel({
+      chartType,
+      categories: ['A', 'B', 'C'],
+      series: [series({ name: 'S', values: [10, null, 20] })],
+      ...(dispBlanksAs ? { dispBlanksAs } : {}),
+    });
+  }
+
+  /** The single plotted-line segment (the polyline the series stroked). Chrome
+   *  (gridlines/axis) is flat in one axis; the data line varies in both. */
+  function dataLine(segs: Array<Array<{ x: number; y: number }>>): Array<{ x: number; y: number }> {
+    const data = segs.filter(s => {
+      if (s.length < 2) return false;
+      const xs = new Set(s.map(p => Math.round(p.x)));
+      return xs.size > 1; // spans horizontally → it's the value polyline
+    });
+    // The longest such segment is the series line.
+    return data.sort((a, b) => b.length - a.length)[0] ?? [];
+  }
+
+  it('gap (default when absent): the null breaks the line, nothing plots at the middle category', () => {
+    // With a middle hole the line must NOT connect A→C directly. The default
+    // (no dispBlanksAs) keeps the historical gap behavior (byte-stable).
+    const rec = pathRecordingCtx();
+    renderChart(rec.ctx, holeModel('line'), RECT, 1);
+    const line = dataLine(rec.segments);
+    const midX = RECT.x + RECT.w / 2;
+    const nearMid = line.filter(p => Math.abs(p.x - midX) < RECT.w * 0.1);
+    // gap: no vertex at the middle category (the null point is skipped and not
+    // bridged, so nothing is plotted near the center x from the connecting run).
+    expect(nearMid.length).toBe(0);
+  });
+
+  it('zero: the null cell plots at the value-axis zero (a low mid vertex)', () => {
+    const rec = pathRecordingCtx();
+    renderChart(rec.ctx, holeModel('line', 'zero'), RECT, 1);
+    const line = dataLine(rec.segments);
+    const midX = RECT.x + RECT.w / 2;
+    const midPts = line.filter(p => Math.abs(p.x - midX) < RECT.w * 0.1);
+    // zero: the middle category IS plotted (at value 0), so a vertex exists near
+    // the center x — and it sits at the BOTTOM of the plot (largest y).
+    expect(midPts.length).toBeGreaterThan(0);
+    const maxY = Math.max(...line.map(p => p.y));
+    expect(midPts.some(p => Math.abs(p.y - maxY) < 1)).toBe(true);
+  });
+
+  it('span: the null is skipped but A and C connect directly (no mid vertex, endpoints high)', () => {
+    const rec = pathRecordingCtx();
+    renderChart(rec.ctx, holeModel('line', 'span'), RECT, 1);
+    const line = dataLine(rec.segments);
+    // span: only A and C are vertices, joined by a straight lineTo, so the
+    // polyline has exactly the two endpoints and NO mid vertex (unlike zero) —
+    // yet unlike gap the run is continuous.
+    const midX = RECT.x + RECT.w / 2;
+    const midPts = line.filter(p => Math.abs(p.x - midX) < RECT.w * 0.1);
+    expect(midPts.length).toBe(0);
+    // Both endpoints present and at their real (non-zero) heights — the chord
+    // runs high across the plot, not down to the baseline.
+    const firstX = RECT.x + RECT.w * (0.5 / 3);
+    const lastX = RECT.x + RECT.w * (2.5 / 3);
+    expect(line.some(p => Math.abs(p.x - firstX) < RECT.w * 0.12)).toBe(true);
+    expect(line.some(p => Math.abs(p.x - lastX) < RECT.w * 0.12)).toBe(true);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -886,3 +886,217 @@ describe('CH7 — line/area series honor a secondary value axis (§21.2.2.*)', (
     });
   }
 });
+
+// ─── CH9 — line/area marker detail, error bars, per-point labels, smooth,
+//          dispBlanksAs (§21.2.2.32 / §21.2.2.20 / §21.2.2.45 / §21.2.2.194 /
+//          §21.2.2.42) ─────────────────────────────────────────────────────
+//
+// scatter already consumes s.markerSymbol/size/fill/line, s.errBars,
+// s.dataLabelOverrides + s.seriesDataLabels, and smooth splines. CH9 wires the
+// same series-level fields into the line and area families, adds per-series
+// smooth (`<c:ser><c:smooth>`), and honors the chartSpace `dispBlanksAs` value
+// when deciding how null cells break/span/zero the plotted line.
+
+interface ArcCall { x: number; y: number; r: number }
+interface FillRectCall { x: number; y: number; w: number; h: number }
+
+/** Recording context that captures the primitives markers / smooth / error
+ *  bars emit: `arc` (circle/star markers + the default line dot), `fillRect`
+ *  (square marker + dash), `bezierCurveTo` (smooth spline), and `fillText`
+ *  (data labels). Also groups stroked/filled path vertices into SEGMENTS
+ *  (delimited by `beginPath`) so a test can inspect the polyline a series
+ *  drew — used to tell gap / zero / span apart for dispBlanksAs. */
+function markerRecordingCtx(): {
+  ctx: CanvasRenderingContext2D;
+  arcs: ArcCall[];
+  fillRects: FillRectCall[];
+  beziers: number;
+  texts: TextCall[];
+  segments: Array<Array<{ x: number; y: number }>>;
+} {
+  const arcs: ArcCall[] = [];
+  const fillRects: FillRectCall[] = [];
+  const texts: TextCall[] = [];
+  const segments: Array<Array<{ x: number; y: number }>> = [];
+  let current: Array<{ x: number; y: number }> | null = null;
+  let beziers = 0;
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  const fontPx = (font: string): number => {
+    const m = /(\d+(?:\.\d+)?)px/.exec(font);
+    return m ? parseFloat(m[1]) : 10;
+  };
+  const push = (x: number, y: number): void => {
+    if (!current) { current = []; segments.push(current); }
+    current.push({ x, y });
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => {
+            const px = fontPx(String(state.font));
+            let w = 0;
+            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+            return { width: w };
+          };
+        case 'beginPath':
+          return () => { current = null; };
+        case 'moveTo':
+        case 'lineTo':
+          return (x: number, y: number) => push(x, y);
+        case 'arc':
+          return (x: number, y: number, rad: number) => { arcs.push({ x, y, r: rad }); push(x, y); };
+        case 'fillRect':
+          return (x: number, y: number, w: number, h: number) => fillRects.push({ x, y, w, h });
+        case 'bezierCurveTo':
+          return () => { beziers += 1; };
+        case 'fillText':
+          return (text: string, x: number, y: number) => texts.push({ text, x, y });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        default:
+          return () => undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return {
+    ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
+    arcs, fillRects, texts, segments,
+    get beziers() { return beziers; },
+  } as never;
+}
+
+describe('CH9 — line/area consume marker detail (§21.2.2.32)', () => {
+  for (const chartType of ['line', 'area'] as const) {
+    it(`${chartType}: markerSymbol="square" draws square markers (fillRect), not the default circle`, () => {
+      const rec = markerRecordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C'],
+        series: [series({ name: 'S', values: [3, 5, 4], showMarker: true, markerSymbol: 'square' })],
+      }), RECT, 1);
+      // One square fillRect per data point. (Area also fills the region with a
+      // path, not a fillRect, so every fillRect here is a marker.)
+      expect(rec.fillRects.length).toBe(3);
+      // Squares are square: w === h.
+      for (const fr of rec.fillRects) expect(Math.round(fr.w)).toBe(Math.round(fr.h));
+    });
+
+    it(`${chartType}: markerSize scales the marker (bigger size → bigger square)`, () => {
+      const small = markerRecordingCtx();
+      renderChart(small.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B'],
+        series: [series({ name: 'S', values: [3, 5], showMarker: true, markerSymbol: 'square', markerSize: 4 })],
+      }), RECT, 1);
+      const big = markerRecordingCtx();
+      renderChart(big.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B'],
+        series: [series({ name: 'S', values: [3, 5], showMarker: true, markerSymbol: 'square', markerSize: 20 })],
+      }), RECT, 1);
+      expect(big.fillRects[0].w).toBeGreaterThan(small.fillRects[0].w);
+    });
+
+    it(`${chartType}: a series WITHOUT markerSymbol keeps the default circle marker`, () => {
+      // Byte-stability: the fixed-circle fast path must remain when no symbol
+      // is specified — no fillRect (square), markers are drawn via arc.
+      const rec = markerRecordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C'],
+        series: [series({ name: 'S', values: [3, 5, 4], showMarker: true })],
+      }), RECT, 1);
+      expect(rec.fillRects.length).toBe(0);
+      // 3 marker dots (arcs). Line also strokes with arc-free paths, so all
+      // arcs are markers here.
+      const markerArcs = rec.arcs.filter(a => a.r < 10);
+      expect(markerArcs.length).toBe(3);
+    });
+  }
+});
+
+describe('CH9 — line/area draw per-series error bars (§21.2.2.20)', () => {
+  for (const chartType of ['line', 'area'] as const) {
+    it(`${chartType}: a series with errBars strokes a vertical bar around each point`, () => {
+      const withBars = pathRecordingCtx();
+      renderChart(withBars.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C'],
+        series: [series({
+          name: 'S',
+          values: [10, 20, 15],
+          errBars: [{ dir: 'y', barType: 'both', plus: [2, 2, 2], minus: [2, 2, 2], noEndCap: false }],
+        })],
+      }), RECT, 1);
+      const without = pathRecordingCtx();
+      renderChart(without.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C'],
+        series: [series({ name: 'S', values: [10, 20, 15] })],
+      }), RECT, 1);
+      // Error bars add vertical segments (constant x, varying y) — 2-vertex
+      // "bar" segments the plain plot never emits. Count vertical 2-point segs.
+      const verticalSegs = (segs: Array<Array<{ x: number; y: number }>>): number =>
+        segs.filter(s => s.length === 2 && Math.round(s[0].x) === Math.round(s[1].x)
+          && Math.round(s[0].y) !== Math.round(s[1].y)).length;
+      expect(verticalSegs(withBars.segments)).toBeGreaterThan(verticalSegs(without.segments));
+    });
+  }
+});
+
+describe('CH9 — line/area per-point data labels (§21.2.2.45)', () => {
+  for (const chartType of ['line', 'area'] as const) {
+    it(`${chartType}: dataLabelOverrides render custom text at the point, and delete (empty) skips it`, () => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C'],
+        series: [series({
+          name: 'S',
+          values: [3, 5, 4],
+          dataLabelOverrides: [
+            { idx: 0, text: 'FIRST' },
+            { idx: 1, text: '' }, // deleted
+            { idx: 2, text: 'THIRD', fontColor: 'FF0000' },
+          ],
+        })],
+      }), RECT, 1);
+      const labelTexts = rec.texts.map(t => t.text);
+      expect(labelTexts).toContain('FIRST');
+      expect(labelTexts).toContain('THIRD');
+      // The deleted (empty) label must not appear.
+      expect(labelTexts.some(t => t === '')).toBe(false);
+    });
+
+    it(`${chartType}: seriesDataLabels showVal renders each point's value`, () => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B'],
+        series: [series({
+          name: 'S',
+          values: [42, 7],
+          seriesDataLabels: {
+            showVal: true, showCatName: false, showSerName: false, showPercent: false,
+          },
+        })],
+      }), RECT, 1);
+      expect(rec.texts.some(t => t.text === '42')).toBe(true);
+      expect(rec.texts.some(t => t.text === '7')).toBe(true);
+    });
+  }
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1383,14 +1383,26 @@ function renderLineChart(
     const yOf = yMapFor(s);
     ctx.strokeStyle = color; ctx.lineWidth = lineWidthPx; ctx.setLineDash([]);
     ctx.beginPath();
-    let started = false;
+    // Collect runs of consecutive present points (a null breaks the line into a
+    // fresh run; stacked charts have no nulls in the plotted sum). Each run is
+    // stroked as a polyline or a smooth spline (§21.2.2.194) via appendCurve.
+    // For a non-smooth series this emits the exact prior moveTo/lineTo sequence
+    // (byte-stable); smooth swaps the straight segments for a Bézier curve.
+    const smooth = s.smooth === true;
+    let run: Array<{ x: number; y: number }> = [];
+    const flushRun = (): void => {
+      if (run.length === 0) return;
+      ctx.moveTo(run[0].x, run[0].y);
+      appendCurve(ctx, run, smooth);
+      run = [];
+    };
     for (let ci = 0; ci < n; ci++) {
       // Unstacked: a null cell breaks the line. Stacked: a null contributes 0
       // to the running sum (no gap), matching the area renderer.
-      if (!stacked && s.values[ci] == null) { started = false; continue; }
-      const py = yOf(plotted(si, ci)); const px = toX(ci);
-      if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
+      if (!stacked && s.values[ci] == null) { flushRun(); continue; }
+      run.push({ x: toX(ci), y: yOf(plotted(si, ci)) });
     }
+    flushRun();
     ctx.stroke();
 
     // Error bars (`<c:errBars>`, §21.2.2.20) — drawn under the markers so the
@@ -1639,20 +1651,29 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     // stacked), so its `toY` mapping stays the primary one.
     const yOf = yMapFor(s);
 
+    // Smooth (`<c:ser><c:smooth>`, §21.2.2.194) curves the top edge through the
+    // points; the baseline connection stays straight. Non-smooth keeps the exact
+    // prior moveTo/lineTo sequence (byte-stable) — appendCurve with smooth=false
+    // emits identical lineTo calls.
+    const smooth = s.smooth === true;
     ctx.beginPath();
     if (stacked && stackBase) {
+      const topPts = [];
       for (let ci = 0; ci < n; ci++) {
-        const v = stackedValue(si, ci) + stackBase[ci];
-        const px = toX(ci); const py = toY(v);
-        if (ci === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+        topPts.push({ x: toX(ci), y: toY(stackedValue(si, ci) + stackBase[ci]) });
       }
+      ctx.moveTo(topPts[0].x, topPts[0].y);
+      appendCurve(ctx, topPts, smooth);
       for (let ci = n - 1; ci >= 0; ci--) {
         ctx.lineTo(toX(ci), toY(stackBase[ci]));
       }
       for (let ci = 0; ci < n; ci++) stackBase[ci] += stackedValue(si, ci);
     } else {
+      const topPts = [];
+      for (let ci = 0; ci < n; ci++) topPts.push({ x: toX(ci), y: yOf(s.values[ci] ?? 0) });
       ctx.moveTo(toX(0), baseY);
-      for (let ci = 0; ci < n; ci++) ctx.lineTo(toX(ci), yOf(s.values[ci] ?? 0));
+      ctx.lineTo(topPts[0].x, topPts[0].y);
+      appendCurve(ctx, topPts, smooth);
       ctx.lineTo(toX(n - 1), baseY);
     }
     ctx.closePath();
@@ -2626,6 +2647,36 @@ function drawDataLabelText(
 
 function clamp(v: number, lo: number, hi: number): number {
   return v < lo ? lo : v > hi ? hi : v;
+}
+
+/** Append `pts` to the CURRENT path starting from `pts[0]` (which the caller has
+ *  already `moveTo`'d, or the first point is the current pen position). When
+ *  `smooth` and there are ≥3 points, draw a Catmull-Rom → cubic-Bézier curve
+ *  through the points (tangents from neighbours, the same formula scatter uses,
+ *  ECMA-376 §21.2.2.194); otherwise straight `lineTo` segments. The caller owns
+ *  `beginPath`/`moveTo`/`stroke`/`fill` so this composes into both the line
+ *  stroke and the area fill's top edge. */
+function appendCurve(
+  ctx: CanvasRenderingContext2D,
+  pts: Array<{ x: number; y: number }>,
+  smooth: boolean,
+): void {
+  if (pts.length === 0) return;
+  if (smooth && pts.length >= 3) {
+    for (let i = 0; i < pts.length - 1; i++) {
+      const p0 = pts[i - 1] ?? pts[i];
+      const p1 = pts[i];
+      const p2 = pts[i + 1];
+      const p3 = pts[i + 2] ?? p2;
+      const cp1x = p1.x + (p2.x - p0.x) / 6;
+      const cp1y = p1.y + (p2.y - p0.y) / 6;
+      const cp2x = p2.x - (p3.x - p1.x) / 6;
+      const cp2y = p2.y - (p3.y - p1.y) / 6;
+      ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y);
+    }
+  } else {
+    for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+  }
 }
 
 function dashPatternForPreset(preset: string | undefined): number[] {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1444,6 +1444,10 @@ function renderLineChart(
     // precedence over the family's simple `showDataLabels` value dump.
     const perPointLabels = drawCategoryDataLabels(
       ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false,
+      // Mirror the marker loop's gate just below: stacked series never see a
+      // plotted null (a stacked sum already reads null as 0), and unstacked
+      // "zero" mode plots the null at 0 — both cases get a label too.
+      stacked || dispBlanks === 'zero',
     );
     if (perPointLabels) ctx.fillStyle = color;
     for (let ci = 0; ci < n; ci++) {
@@ -1675,6 +1679,12 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     // points; the baseline connection stays straight. Non-smooth keeps the exact
     // prior moveTo/lineTo sequence (byte-stable) — appendCurve with smooth=false
     // emits identical lineTo calls.
+    //
+    // NB: `CT_AreaSer` (§A.5.1) has no `<c:smooth>` child (only `CT_LineSer` /
+    // `CT_ScatterSer` do), so `extract_series_smooth` never sets `s.smooth` for
+    // a real area series and this branch is dead against actual chart XML —
+    // it only fires for a model constructed directly (tests / other producers).
+    // Kept for symmetry with the line renderer above rather than dropped.
     const smooth = s.smooth === true;
     ctx.beginPath();
     if (stacked && stackBase) {
@@ -1717,12 +1727,17 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // (where "gap" is the historical default).
   {
     const areaMarkerR = Math.max(2, 2.5 * ptToPx);
-    // Cumulative top of each series' band per category (stacked); the raw value
-    // otherwise. Rebuilt here independently of the fill loop's mutated stackBase.
+    // Top of each series' band per category (stacked); the raw value otherwise.
+    // Rebuilt here independently of the fill loop's mutated stackBase. The fill
+    // loop above draws bands back-to-front (si = length-1 → 0) and accumulates
+    // stackBase AFTER each band, so band si's top edge is the REVERSE-cumulative
+    // sum Σ_{k=si..length-1} — series 0 (drawn last, on top) reaches the full
+    // stack total; the last series (drawn first, at the bottom) has only its
+    // own value. A forward sum (Σ_{k=0..si}) would swap that ordering.
     const topValue = (si: number, ci: number): number => {
       if (stacked) {
         let sum = 0;
-        for (let k = 0; k <= si; k++) sum += stackedValue(k, ci);
+        for (let k = si; k < chart.series.length; k++) sum += stackedValue(k, ci);
         return sum;
       }
       return chart.series[si].values[ci] ?? 0;
@@ -1756,9 +1771,13 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
           }
         }
       }
-      // Per-point / series-level data labels.
+      // Per-point / series-level data labels. Area's filled region has always
+      // read a blank cell as 0 (`?? 0`, see the topValue/plottedOf comment
+      // above), so every category index is a "plotted" point here regardless
+      // of dispBlanksAs — pass true unconditionally (byte-stable: unchanged
+      // from before this parameter existed).
       drawCategoryDataLabels(
-        ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false,
+        ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false, true,
       );
     }
   }
@@ -2788,7 +2807,15 @@ function drawCategoryErrorBars(
  *  ({@link drawSeriesDataLabels}), but maps points by CATEGORY INDEX with the
  *  series' plotted value → px mapping. Returns true when it handled the labels
  *  for this series (so the caller skips the family's legacy `showDataLabels`
- *  path), false when the series has no override/series-level label config. */
+ *  path), false when the series has no override/series-level label config.
+ *
+ *  `plotNullAsZero` mirrors the marker loop's dispBlanksAs gate (§21.2.2.42):
+ *  a null cell normally has no label (gap/span leave the point unplotted), but
+ *  in "zero" mode the blank IS a plotted point (value 0) and gets a label like
+ *  any other — the line-chart caller passes `dispBlanks === 'zero'`. The area
+ *  caller passes `true` unconditionally: area's fill has always read a blank
+ *  cell as 0 (`?? 0`, dispBlanksAs is a no-op for the filled region), so its
+ *  per-point labels have likewise always covered every category index. */
 function drawCategoryDataLabels(
   ctx: CanvasRenderingContext2D,
   s: ChartSeries,
@@ -2800,12 +2827,13 @@ function drawCategoryDataLabels(
   ph: number,
   ptToPx: number,
   date1904: boolean,
+  plotNullAsZero: boolean,
 ): boolean {
   const overrides = s.dataLabelOverrides ?? [];
   const seriesDef = s.seriesDataLabels;
   if (overrides.length === 0 && !seriesDef) return false;
   for (let ci = 0; ci < n; ci++) {
-    if (s.values[ci] == null) continue;
+    if (s.values[ci] == null && !plotNullAsZero) continue;
     const pv = plotted(ci);
     const ovr = overrides.find(o => o.idx === ci);
     let text: string;

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1202,12 +1202,24 @@ function renderLineChart(
         return t || 1;
       })
     : null;
+  // How null cells are plotted (`<c:dispBlanksAs>`, §21.2.2.42). Default "gap"
+  // preserves the historical line break (byte-stable). "zero" treats a null as
+  // 0; "span" bridges the neighbours with a straight line (skip the null but
+  // keep the run going). Only unstacked charts see nulls — a stacked sum already
+  // reads null as 0 — so the value only steers the unstacked path below.
+  const dispBlanks = chart.dispBlanksAs ?? 'gap';
+
   // The plotted (cumulative) value for series `si` at category `ci`: the running
   // sum of series 0..si, percent-normalized when pct. Un-stacked charts return
-  // the raw value. Null cells contribute 0 to the stack (matching the area
-  // renderer's `?? 0`); full dispBlanksAs support is tracked separately (CH9).
+  // the raw value (with "zero"-mode nulls read as 0). Null cells contribute 0 to
+  // the stack (matching the area renderer's `?? 0`).
   const plotted = (si: number, ci: number): number => {
-    if (!stacked) return chart.series[si].values[ci] as number;
+    if (!stacked) {
+      const v = chart.series[si].values[ci];
+      // "zero": a blank plots at value 0. gap/span never reach here for a null
+      // (the caller skips those indices), so the `?? 0` is only used by "zero".
+      return v == null ? 0 : v;
+    }
     let sum = 0;
     for (let k = 0; k <= si; k++) sum += chart.series[k].values[ci] ?? 0;
     return pct && pctTotals ? (sum / pctTotals[ci]) * 100 : sum;
@@ -1397,9 +1409,15 @@ function renderLineChart(
       run = [];
     };
     for (let ci = 0; ci < n; ci++) {
-      // Unstacked: a null cell breaks the line. Stacked: a null contributes 0
-      // to the running sum (no gap), matching the area renderer.
-      if (!stacked && s.values[ci] == null) { flushRun(); continue; }
+      // Unstacked null handling per dispBlanksAs (§21.2.2.42): "gap" flushes the
+      // run (line breaks — the historical default); "span" skips the null but
+      // keeps the run open (neighbours join directly); "zero" plots it at 0
+      // (plotted() reads a null as 0). Stacked charts never have plotted nulls.
+      if (!stacked && s.values[ci] == null) {
+        if (dispBlanks === 'gap') { flushRun(); continue; }
+        if (dispBlanks === 'span') continue;
+        // "zero": fall through and push a point at value 0.
+      }
       run.push({ x: toX(ci), y: yOf(plotted(si, ci)) });
     }
     flushRun();
@@ -1429,7 +1447,9 @@ function renderLineChart(
     );
     if (perPointLabels) ctx.fillStyle = color;
     for (let ci = 0; ci < n; ci++) {
-      if (!stacked && s.values[ci] == null) continue;
+      // A null point gets a marker/label only in "zero" mode (plotted at 0);
+      // "gap"/"span" leave the hole empty.
+      if (!stacked && s.values[ci] == null && dispBlanks !== 'zero') continue;
       const pv = plotted(si, ci);
       if (drawMarkers) {
         if (hasMarkerDetail) {
@@ -1689,6 +1709,12 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // fields — an area chart with no marker/errBar/dLbl detail draws exactly as
   // before. The plotted top-of-band value matches where the fill's top edge sat
   // (cumulative for stacked). ECMA-376 §21.2.2.32 / §21.2.2.20 / §21.2.2.45.
+  //
+  // NB: an area chart's filled region has always read a blank cell as 0
+  // (`?? 0`), so `<c:dispBlanksAs>` (§21.2.2.42) is a no-op for the area family
+  // here — breaking or spanning a *filled* region is not modeled, and changing
+  // the default would break byte-stability. dispBlanksAs steers the line family
+  // (where "gap" is the historical default).
   {
     const areaMarkerR = Math.max(2, 2.5 * ptToPx);
     // Cumulative top of each series' band per category (stacked); the raw value

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1392,18 +1392,48 @@ function renderLineChart(
       if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
     }
     ctx.stroke();
+
+    // Error bars (`<c:errBars>`, §21.2.2.20) — drawn under the markers so the
+    // dots overlay the bar tips. Only fires for series that carry them.
+    const plottedOf = (ci: number): number => plotted(si, ci);
+    for (const eb of s.errBars ?? []) {
+      drawCategoryErrorBars(ctx, s, eb, n, toX, yOf, plottedOf, color);
+    }
+
     ctx.fillStyle = color;
     // ECMA-376 §21.2.2.32 — when the series resolves to no marker, skip the
     // data-point dots but keep data labels. Markers / labels pin to the plotted
     // (cumulative) value so they ride the stacked line, not the raw datum.
     const drawMarkers = s.showMarker !== false;
+    // Series carrying explicit `<c:marker>` detail route through drawMarker
+    // (symbol/size/fill/line + per-point `<c:dPt>` overrides). Series without
+    // any detail keep the historical fixed-circle fast path unchanged
+    // (byte-stable). `markerSymbol: "none"` is caught by the showMarker gate.
+    const hasMarkerDetail = seriesHasMarkerDetail(s);
+    // Per-point / series-level data labels (`<c:dLbl idx>` / `<c:dLbls>`) take
+    // precedence over the family's simple `showDataLabels` value dump.
+    const perPointLabels = drawCategoryDataLabels(
+      ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false,
+    );
+    if (perPointLabels) ctx.fillStyle = color;
     for (let ci = 0; ci < n; ci++) {
       if (!stacked && s.values[ci] == null) continue;
       const pv = plotted(si, ci);
       if (drawMarkers) {
-        ctx.beginPath(); ctx.arc(toX(ci), yOf(pv), markerR, 0, Math.PI * 2); ctx.fill();
+        if (hasMarkerDetail) {
+          const dpt = (s.dataPointOverrides ?? []).find(d => d.idx === ci);
+          const symbol = (dpt?.markerSymbol ?? s.markerSymbol ?? 'circle');
+          if (symbol !== 'none') {
+            const sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
+            const fill = dpt?.markerFill ?? dpt?.color ?? s.markerFill ?? color;
+            const line = dpt?.markerLine ?? s.markerLine ?? null;
+            drawMarker(ctx, toX(ci), yOf(pv), symbol, sizePt, fill, line, ptToPx);
+          }
+        } else {
+          ctx.beginPath(); ctx.arc(toX(ci), yOf(pv), markerR, 0, Math.PI * 2); ctx.fill();
+        }
       }
-      if (chart.showDataLabels) {
+      if (chart.showDataLabels && !perPointLabels) {
         ctx.font = `${dataLabelPx}px sans-serif`;
         ctx.fillStyle = '#333'; ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
         const labelOffset = drawMarkers ? markerR + 1 : 2;
@@ -1630,6 +1660,60 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ctx.fill();
     ctx.strokeStyle = color; ctx.lineWidth = 1.5; ctx.setLineDash([]);
     ctx.stroke();
+  }
+
+  // Markers, error bars, and per-point data labels for area series. Drawn in a
+  // SEPARATE forward pass (after all fills) so the fill loop above stays
+  // byte-identical, and each block fires ONLY for series carrying the relevant
+  // fields — an area chart with no marker/errBar/dLbl detail draws exactly as
+  // before. The plotted top-of-band value matches where the fill's top edge sat
+  // (cumulative for stacked). ECMA-376 §21.2.2.32 / §21.2.2.20 / §21.2.2.45.
+  {
+    const areaMarkerR = Math.max(2, 2.5 * ptToPx);
+    // Cumulative top of each series' band per category (stacked); the raw value
+    // otherwise. Rebuilt here independently of the fill loop's mutated stackBase.
+    const topValue = (si: number, ci: number): number => {
+      if (stacked) {
+        let sum = 0;
+        for (let k = 0; k <= si; k++) sum += stackedValue(k, ci);
+        return sum;
+      }
+      return chart.series[si].values[ci] ?? 0;
+    };
+    for (let si = 0; si < chart.series.length; si++) {
+      const s = chart.series[si];
+      const color = chartColor(si, s);
+      const yOf = yMapFor(s);
+      const plottedOf = (ci: number): number => topValue(si, ci);
+      // Error bars first (markers overlay their tips).
+      for (const eb of s.errBars ?? []) {
+        drawCategoryErrorBars(ctx, s, eb, n, toX, yOf, plottedOf, color);
+      }
+      // Markers only when the series opts in (`<c:marker>` symbol/size/… — area
+      // charts default to NO markers, so nothing fires without explicit detail).
+      if (s.showMarker === true || seriesHasMarkerDetail(s)) {
+        for (let ci = 0; ci < n; ci++) {
+          if (s.values[ci] == null) continue;
+          const dpt = (s.dataPointOverrides ?? []).find(d => d.idx === ci);
+          const symbol = (dpt?.markerSymbol ?? s.markerSymbol ?? 'circle');
+          if (symbol === 'none') continue;
+          const px = toX(ci); const py = yOf(plottedOf(ci));
+          if (seriesHasMarkerDetail(s)) {
+            const sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
+            const fill = dpt?.markerFill ?? dpt?.color ?? s.markerFill ?? color;
+            const line = dpt?.markerLine ?? s.markerLine ?? null;
+            drawMarker(ctx, px, py, symbol, sizePt, fill, line, ptToPx);
+          } else {
+            ctx.fillStyle = color;
+            ctx.beginPath(); ctx.arc(px, py, areaMarkerR, 0, Math.PI * 2); ctx.fill();
+          }
+        }
+      }
+      // Per-point / series-level data labels.
+      drawCategoryDataLabels(
+        ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false,
+      );
+    }
   }
 
   if (!chart.valAxisHidden) {
@@ -2556,6 +2640,119 @@ function dashPatternForPreset(preset: string | undefined): number[] {
     case 'dashDotDot':case 'sysDashDotDot':case 'lgDashDotDot': return [4, 2, 1, 2, 1, 2];
     default: return [];
   }
+}
+
+/** True when the series carries any explicit `<c:marker>` detail (symbol, size,
+ *  fill, line) or per-point `<c:dPt>` marker overrides — i.e. a reason to route
+ *  through {@link drawMarker} instead of the line/area family's historical
+ *  fixed-circle fast path. A series without any of these keeps the exact prior
+ *  circle marker (byte-stable), so charts that never parsed marker detail are
+ *  unchanged. `markerSymbol: "none"` counts as detail (it disables the marker),
+ *  handled by the caller's showMarker gate. */
+function seriesHasMarkerDetail(s: ChartSeries): boolean {
+  return (
+    s.markerSymbol != null ||
+    s.markerSize != null ||
+    s.markerFill != null ||
+    s.markerLine != null ||
+    (s.dataPointOverrides != null && s.dataPointOverrides.length > 0)
+  );
+}
+
+/** Draw error bars for a category-axis series (line / area). Mirrors the scatter
+ *  {@link drawSeriesErrorBars} cap/dash geometry, but maps points by CATEGORY
+ *  INDEX (`xAt(ci)`) with a per-series value→px mapping (`yAt`) instead of the
+ *  numeric X mapping scatter uses. Only the Y direction is drawn: a category
+ *  axis has no data-unit X scale, so `<c:errBars dir="x">` cannot be positioned
+ *  (Excel likewise only shows Y error bars on category charts). `plotted`
+ *  returns the point's plotted (possibly stacked) value so bars ride the drawn
+ *  line. Null cells are skipped. */
+function drawCategoryErrorBars(
+  ctx: CanvasRenderingContext2D,
+  s: ChartSeries,
+  eb: NonNullable<ChartSeries['errBars']>[number],
+  n: number,
+  xAt: (ci: number) => number,
+  yAt: (v: number) => number,
+  plotted: (ci: number) => number,
+  fallbackColor: string,
+): void {
+  if (eb.dir === 'x') return; // no data-unit X scale on a category axis
+  const drawPlus = eb.barType === 'plus' || eb.barType === 'both';
+  const drawMinus = eb.barType === 'minus' || eb.barType === 'both';
+  ctx.save();
+  ctx.strokeStyle = eb.color ? `#${eb.color}` : fallbackColor;
+  ctx.lineWidth = eb.lineWidthEmu ? Math.max(0.5, eb.lineWidthEmu / EMU_PER_PT) : 1;
+  ctx.setLineDash(dashPatternForPreset(eb.dash));
+  const capHalf = ctx.lineWidth * 1.5;
+  for (let ci = 0; ci < n; ci++) {
+    if (s.values[ci] == null) continue;
+    const pv = plotted(ci);
+    const px = xAt(ci); const py = yAt(pv);
+    const drawSeg = (dataDelta: number): void => {
+      const y2 = yAt(pv + dataDelta);
+      ctx.beginPath(); ctx.moveTo(px, py); ctx.lineTo(px, y2); ctx.stroke();
+      if (!eb.noEndCap) {
+        ctx.save(); ctx.setLineDash([]);
+        ctx.beginPath();
+        ctx.moveTo(px - capHalf, y2); ctx.lineTo(px + capHalf, y2);
+        ctx.stroke();
+        ctx.restore();
+      }
+    };
+    if (drawPlus) { const v = eb.plus[ci]; if (v != null) drawSeg(v); }
+    if (drawMinus) { const v = eb.minus[ci]; if (v != null) drawSeg(-v); }
+  }
+  ctx.restore();
+}
+
+/** Per-point data labels for a category-axis series (line / area). Consumes the
+ *  same `<c:dLbl idx>` overrides and series-level `<c:dLbls>` block scatter does
+ *  ({@link drawSeriesDataLabels}), but maps points by CATEGORY INDEX with the
+ *  series' plotted value → px mapping. Returns true when it handled the labels
+ *  for this series (so the caller skips the family's legacy `showDataLabels`
+ *  path), false when the series has no override/series-level label config. */
+function drawCategoryDataLabels(
+  ctx: CanvasRenderingContext2D,
+  s: ChartSeries,
+  cats: string[],
+  n: number,
+  xAt: (ci: number) => number,
+  yAt: (v: number) => number,
+  plotted: (ci: number) => number,
+  ph: number,
+  ptToPx: number,
+  date1904: boolean,
+): boolean {
+  const overrides = s.dataLabelOverrides ?? [];
+  const seriesDef = s.seriesDataLabels;
+  if (overrides.length === 0 && !seriesDef) return false;
+  for (let ci = 0; ci < n; ci++) {
+    if (s.values[ci] == null) continue;
+    const pv = plotted(ci);
+    const ovr = overrides.find(o => o.idx === ci);
+    let text: string;
+    if (ovr) {
+      if (ovr.text === '') continue; // `<c:delete val="1"/>` — deleted label
+      text = ovr.text;
+    } else if (seriesDef && (seriesDef.showVal || seriesDef.showSerName || seriesDef.showCatName)) {
+      const parts: string[] = [];
+      if (seriesDef.showCatName) parts.push(cats[ci] ?? '');
+      if (seriesDef.showSerName) parts.push(s.name);
+      if (seriesDef.showVal) parts.push(formatChartValWithCode(pv, seriesDef.formatCode ?? null, date1904));
+      text = parts.filter(Boolean).join(' ');
+      if (!text) continue;
+    } else {
+      continue;
+    }
+    const pos = ovr?.position ?? seriesDef?.position ?? 't';
+    const sizeHpt = ovr?.fontSizeHpt ?? seriesDef?.fontSizeHpt;
+    const fontSizePx = sizeHpt ? (sizeHpt / 100) * ptToPx : Math.max(9, Math.min(11, ph / 25));
+    const color = ovr?.fontColor ?? seriesDef?.fontColor;
+    const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
+    drawDataLabelText(ctx, xAt(ci), yAt(pv), text, pos, fontSizePx, color, bold);
+  }
+  return true;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -113,6 +113,14 @@ export interface ChartSeries {
    * series.
    */
   bubbleSizes?: (number | null)[] | null;
+  /**
+   * `<c:ser><c:smooth val>` (ECMA-376 §21.2.2.194) — line/area series flag
+   * requesting a smoothed (spline) curve through the points instead of straight
+   * segments. Only consulted for the line and area families (scatter carries its
+   * smoothing in `ChartModel.scatterStyle`). null/undefined/false = straight
+   * polyline (the default; byte-stable for series that never set it).
+   */
+  smooth?: boolean | null;
 }
 
 export interface ChartDataPointOverride {

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -387,6 +387,21 @@ export interface ChartModel {
    * the attribute is omitted, so `<c:date1904/>` alone means date1904=true.
    */
   date1904?: boolean;
+  /**
+   * `<c:chartSpace><c:chart><c:dispBlanksAs val>` (ECMA-376 §21.2.2.42,
+   * `ST_DispBlanksAs` §21.2.3.10) — how blank (null) cells are plotted on
+   * line/area charts:
+   *   - "gap"  → leave a gap (break the line). The renderer's historical
+   *              behavior and the model default when the element is absent.
+   *   - "zero" → plot the blank as the value 0 (the point drops to the axis).
+   *   - "span" → skip the blank but connect its neighbours with a straight
+   *              line (bridge the gap).
+   * Note the XSD `@val` default is "zero" (applies when `<c:dispBlanksAs/>` is
+   * present but the attribute is omitted); when the ELEMENT is absent entirely
+   * Office falls back to "gap", which is what we model as the default. Only
+   * consulted for the line and area families. null/undefined = "gap".
+   */
+  dispBlanksAs?: string | null;
 }
 
 /**

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -213,6 +213,11 @@ pub struct ChartSeries {
     pub err_bars: Option<Vec<ChartErrBars>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bubble_sizes: Option<Vec<Option<f64>>>,
+    /// `<c:ser><c:smooth val>` (ECMA-376 §21.2.2.194) — line/area series flag
+    /// requesting a smoothed (spline) curve. `None` (omitted) = straight
+    /// polyline (the default); only serialized when the file sets it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smooth: Option<bool>,
 }
 
 /// Mirror of TS `ChartDataPointOverride`.
@@ -684,6 +689,18 @@ pub fn extract_chart_date1904(chart_space_root: Node) -> bool {
     }
 }
 
+/// `<c:ser><c:smooth val>` (ECMA-376 §21.2.2.194) — line/area series smoothing
+/// flag. `ser_node` is the `<c:ser>` element. Returns `Some(true/false)` when
+/// the element is present (CT_Boolean: `val` implied true when omitted),
+/// `None` when the series has no `<c:smooth>` (straight-polyline default). Shared
+/// so the pptx and xlsx parsers honor the flag identically.
+pub fn extract_series_smooth(ser_node: Node) -> Option<bool> {
+    child(ser_node, "smooth").map(|n| match n.attribute("val") {
+        None => true, // element present, val implied true
+        Some(v) => v == "1" || v.eq_ignore_ascii_case("true"),
+    })
+}
+
 pub fn extract_chart_space_border(chart_space_root: Node) -> (Option<String>, Option<u32>) {
     let Some(ln) = child(chart_space_root, "spPr").and_then(|sp| child(sp, "ln")) else {
         return (None, None);
@@ -935,6 +952,7 @@ mod tests {
                 series_data_labels: None,
                 err_bars: None,
                 bubble_sizes: None,
+                smooth: None,
             }],
             show_data_labels: false,
             val_min: None,
@@ -1117,6 +1135,29 @@ mod tests {
             extract_axis_min_max(d.root_element()),
             (Some(0.0), Some(2500.0))
         );
+    }
+
+    #[test]
+    fn series_smooth_present_and_absent() {
+        // No `<c:smooth>` → None (straight-polyline default).
+        let none =
+            root_of(r#"<c:ser xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#);
+        assert_eq!(extract_series_smooth(none.root_element()), None);
+        // `<c:smooth val="1"/>` → Some(true).
+        let on = root_of(
+            r#"<c:ser xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:smooth val="1"/></c:ser>"#,
+        );
+        assert_eq!(extract_series_smooth(on.root_element()), Some(true));
+        // `<c:smooth val="0"/>` → Some(false) (explicit off).
+        let off = root_of(
+            r#"<c:ser xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:smooth val="0"/></c:ser>"#,
+        );
+        assert_eq!(extract_series_smooth(off.root_element()), Some(false));
+        // Bare `<c:smooth/>` → Some(true) (CT_Boolean implied-true).
+        let bare = root_of(
+            r#"<c:ser xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:smooth/></c:ser>"#,
+        );
+        assert_eq!(extract_series_smooth(bare.root_element()), Some(true));
     }
 
     #[test]

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -170,6 +170,12 @@ pub struct ChartModel {
     /// default 1900 system) for wire parity.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub date1904: bool,
+    /// `<c:chart><c:dispBlanksAs val>` (ECMA-376 §21.2.2.42) — how blank cells
+    /// are plotted on line/area charts ("gap" | "zero" | "span"). `None` when
+    /// the element is absent (the renderer defaults to "gap"); only serialized
+    /// when the file sets it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disp_blanks_as: Option<String>,
 }
 
 /// Mirror of TS `ChartSeries`.
@@ -701,6 +707,19 @@ pub fn extract_series_smooth(ser_node: Node) -> Option<bool> {
     })
 }
 
+/// `<c:chart><c:dispBlanksAs val>` (ECMA-376 §21.2.2.42, `ST_DispBlanksAs`
+/// §21.2.3.10) — how blank cells are plotted ("gap" | "zero" | "span").
+/// `root` may be the `<c:chartSpace>` or `<c:chart>` node; the single
+/// `<c:dispBlanksAs>` is found by descendant walk either way. Returns `None`
+/// when the element is absent (the renderer defaults to "gap"). Per the XSD the
+/// `@val` default is "zero" (applies only when `<c:dispBlanksAs/>` is present
+/// but the attribute is omitted). Shared so pptx and xlsx behave identically.
+pub fn extract_disp_blanks_as(root: Node) -> Option<String> {
+    root.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "dispBlanksAs")
+        .map(|n| n.attribute("val").unwrap_or("zero").to_string())
+}
+
 pub fn extract_chart_space_border(chart_space_root: Node) -> (Option<String>, Option<u32>) {
     let Some(ln) = child(chart_space_root, "spPr").and_then(|sp| child(sp, "ln")) else {
         return (None, None);
@@ -1016,6 +1035,7 @@ mod tests {
             radar_style: None,
             secondary_val_axis: None,
             date1904: false,
+            disp_blanks_as: None,
         };
         let v = serde_json::to_value(&m).unwrap();
         let obj = v.as_object().unwrap();
@@ -1158,6 +1178,33 @@ mod tests {
             r#"<c:ser xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:smooth/></c:ser>"#,
         );
         assert_eq!(extract_series_smooth(bare.root_element()), Some(true));
+    }
+
+    #[test]
+    fn disp_blanks_as_variants() {
+        // Absent element → None (renderer defaults to "gap").
+        let absent = root_of(
+            r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart/></c:chartSpace>"#,
+        );
+        assert_eq!(extract_disp_blanks_as(absent.root_element()), None);
+        // Explicit values pass through.
+        for want in ["gap", "zero", "span"] {
+            let xml = format!(
+                r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:dispBlanksAs val="{want}"/></c:chart></c:chartSpace>"#,
+            );
+            assert_eq!(
+                extract_disp_blanks_as(root_of(&xml).root_element()).as_deref(),
+                Some(want)
+            );
+        }
+        // Bare `<c:dispBlanksAs/>` → XSD @val default "zero".
+        let bare = root_of(
+            r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:dispBlanksAs/></c:chart></c:chartSpace>"#,
+        );
+        assert_eq!(
+            extract_disp_blanks_as(bare.root_element()).as_deref(),
+            Some("zero")
+        );
     }
 
     #[test]

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -530,6 +530,10 @@ pub(crate) fn parse_legacy_chart(
                 data_label_overrides: None,
                 series_data_labels: None,
                 err_bars: None,
+                // `<c:ser><c:smooth>` (§21.2.2.194) — line/area spline flag.
+                // Shared with the xlsx parser via ooxml-common so both honor the
+                // CT_Boolean implied-true semantics.
+                smooth: ooxml_common::chart::extract_series_smooth(*ser),
             }
         })
         .collect();
@@ -1048,6 +1052,8 @@ pub(crate) fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Optio
         data_label_overrides: None,
         series_data_labels: None,
         err_bars: None,
+        // chartEx (waterfall) has no `<c:smooth>` concept.
+        smooth: None,
     }];
 
     // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -819,6 +819,10 @@ pub(crate) fn parse_legacy_chart(
     // CT_Boolean implied-true semantics.
     let date1904 = ooxml_common::chart::extract_chart_date1904(root);
 
+    // `<c:chart><c:dispBlanksAs>` (ECMA-376 §21.2.2.42) — null-cell plotting for
+    // line/area. Shared with the xlsx parser via ooxml-common.
+    let disp_blanks_as = ooxml_common::chart::extract_disp_blanks_as(root);
+
     Some(ChartElement {
         x: 0,
         y: 0,
@@ -897,6 +901,7 @@ pub(crate) fn parse_legacy_chart(
             cat_axis_max: None,
             radar_style: None,
             date1904,
+            disp_blanks_as,
         },
     })
 }
@@ -1151,6 +1156,8 @@ pub(crate) fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Optio
             // `<c:date1904>` element does not apply here, so keep the 1900
             // default until/unless a chartEx date system is wired.
             date1904: false,
+            // chartEx waterfall has no line/area blanks to display.
+            disp_blanks_as: None,
         },
     })
 }

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -144,6 +144,7 @@ impl From<ChartSeries> for CmSeries {
             series_data_labels: s.series_data_labels.map(CmSeriesDataLabels::from),
             err_bars: some_if_nonempty(s.err_bars),
             bubble_sizes: None,
+            smooth: s.smooth,
             // `order` is xlsx parse-time only (used for stacking/legend sort
             // before emit); core `ChartSeries` has no such field.
         }
@@ -1450,6 +1451,9 @@ pub(crate) fn parse_chart_series(
     let (series_data_labels, data_label_overrides) =
         parse_data_labels(node, theme_colors, &dlbl_range_cache);
     let err_bars = parse_error_bars(node, &values, theme_colors);
+    // `<c:ser><c:smooth>` (§21.2.2.194) — line/area spline flag. Shared with the
+    // pptx parser so both honor the CT_Boolean implied-true semantics.
+    let smooth = ooxml_common::chart::extract_series_smooth(*node);
 
     ChartSeries {
         name,
@@ -1469,6 +1473,7 @@ pub(crate) fn parse_chart_series(
         data_label_overrides,
         series_data_labels,
         err_bars,
+        smooth,
     }
 }
 
@@ -2387,6 +2392,31 @@ mod pie_doughnut_tests {
         let m = ChartModel::from(parse_chart_xml(&xml, &theme()).expect("parses"));
         assert_eq!(m.chart_type, "line");
         assert!(m.series[0].categories.is_none());
+    }
+
+    /// `<c:ser><c:smooth val="1"/>` (ECMA-376 §21.2.2.194) surfaces as
+    /// `ChartSeries.smooth = Some(true)` through the adapter; a series without
+    /// `<c:smooth>` stays `None` (straight-polyline default).
+    #[test]
+    fn adapter_series_smooth_flag() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}">
+  <c:chart><c:plotArea><c:lineChart>
+    <c:ser><c:idx val="0"/><c:order val="0"/>
+      <c:smooth val="1"/>
+      <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+    </c:ser>
+    <c:ser><c:idx val="1"/><c:order val="1"/>
+      <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>2</c:v></c:pt></c:numCache></c:numRef></c:val>
+    </c:ser>
+  </c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>"#,
+            c = C_NS,
+            a = A_NS,
+        );
+        let m = ChartModel::from(parse_chart_xml(&xml, &theme()).expect("parses"));
+        assert_eq!(m.series[0].smooth, Some(true));
+        assert_eq!(m.series[1].smooth, None);
     }
 
     /// `<c:date1904/>` as a direct child of `<c:chartSpace>` (ECMA-376

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -243,6 +243,7 @@ impl From<ChartData> for ChartModel {
             radar_style: c.radar_style,
             secondary_val_axis: None,
             date1904: c.date1904,
+            disp_blanks_as: c.disp_blanks_as,
         }
     }
 }
@@ -553,6 +554,10 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
     let date1904 = chart_space_root
         .map(ooxml_common::chart::extract_chart_date1904)
         .unwrap_or(false);
+
+    // `<c:chart><c:dispBlanksAs>` (ECMA-376 §21.2.2.42) — null-cell plotting for
+    // line/area. Shared with the pptx parser via ooxml-common.
+    let disp_blanks_as = chart_space_root.and_then(ooxml_common::chart::extract_disp_blanks_as);
 
     // `<c:title><c:layout><c:manualLayout>` (ECMA-376 §21.2.2.27).
     let title_manual_layout = chart_root
@@ -1067,6 +1072,7 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
         chart_border_color,
         chart_border_width_emu,
         date1904,
+        disp_blanks_as,
     })
 }
 
@@ -2417,6 +2423,43 @@ mod pie_doughnut_tests {
         let m = ChartModel::from(parse_chart_xml(&xml, &theme()).expect("parses"));
         assert_eq!(m.series[0].smooth, Some(true));
         assert_eq!(m.series[1].smooth, None);
+    }
+
+    /// `<c:chart><c:dispBlanksAs val="span"/>` (§21.2.2.42) surfaces on the
+    /// adapter; absence leaves `disp_blanks_as = None` (renderer defaults to
+    /// "gap").
+    #[test]
+    fn adapter_disp_blanks_as() {
+        let with = format!(
+            r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}">
+  <c:chart>
+    <c:plotArea><c:lineChart>
+      <c:ser><c:idx val="0"/><c:order val="0"/>
+        <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart></c:plotArea>
+    <c:dispBlanksAs val="span"/>
+  </c:chart>
+</c:chartSpace>"#,
+            c = C_NS,
+            a = A_NS,
+        );
+        let m = ChartModel::from(parse_chart_xml(&with, &theme()).expect("parses"));
+        assert_eq!(m.disp_blanks_as.as_deref(), Some("span"));
+
+        let without = format!(
+            r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}">
+  <c:chart><c:plotArea><c:lineChart>
+    <c:ser><c:idx val="0"/><c:order val="0"/>
+      <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+    </c:ser>
+  </c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>"#,
+            c = C_NS,
+            a = A_NS,
+        );
+        let m0 = ChartModel::from(parse_chart_xml(&without, &theme()).expect("parses"));
+        assert_eq!(m0.disp_blanks_as, None);
     }
 
     /// `<c:date1904/>` as a direct child of `<c:chartSpace>` (ECMA-376

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -458,6 +458,11 @@ pub struct ChartSeries {
     /// time so the renderer just draws lines.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub err_bars: Vec<ErrBars>,
+    /// `<c:ser><c:smooth val>` (ECMA-376 §21.2.2.194) — line/area smoothing
+    /// flag. None = straight polyline (default); Some(true/false) when the
+    /// element is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub smooth: Option<bool>,
 }
 
 /// Per-point override pulled from `<c:dPt idx="N">` siblings of a series

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -799,6 +799,11 @@ pub struct ChartData {
     /// resolve against the 1904 date system. Default false (1900 system).
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub date1904: bool,
+    /// `<c:chart><c:dispBlanksAs val>` (ECMA-376 §21.2.2.42) — null-cell
+    /// plotting for line/area ("gap" | "zero" | "span"). None = absent
+    /// (renderer defaults to "gap").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disp_blanks_as: Option<String>,
 }
 
 /// Generic `<c:manualLayout>` block (used for title, plotArea, legend).


### PR DESCRIPTION
## Summary

Phase 2 chart item CH9. Scatter already had detailed markers, error bars, smooth splines, and per-point data labels; the line/area families ignored them and hard-coded a fixed circle + gap-on-blank. This wires the existing capability across and adds the two model fields that were missing.

- **Marker detail / error bars / per-point labels** wired into line and area (reusing scatter's `drawMarker` / `drawCategoryErrorBars` / label-override logic). A series with no `<c:marker>` detail keeps the historical fixed-circle fast path bit-for-bit; new paths fire only when the field is present.
- **Smooth (§21.2.2.194)** — `<c:smooth>` was parsed by nobody; added a shared `extract_series_smooth` (CT_Boolean implied-true) + `ChartSeries.smooth` in ooxml-common, wired into pptx and xlsx. The renderer draws smooth series with the spec's Catmull-Rom spline. (`CT_AreaSer` has no `<c:smooth>` per §A.5.1, so the area branch is model-only — commented.)
- **dispBlanksAs (§21.2.2.42 / §21.2.3.10)** — added a shared `extract_disp_blanks_as` + `ChartModel.dispBlanksAs`; line renders blanks as gap (default, byte-stable), zero, or span. The `@val` schema default is `zero` for a bare element; an absent element models to `gap` (Office's real default and the prior behavior) — both documented.
- Error bars on a category axis correctly drop the X direction (no data-unit X scale), matching Excel.

## Verification

- `cargo fmt --check` / `clippy -D warnings` / `cargo test` — green (+4 parser tests: smooth/dispBlanksAs present/absent/variants + xlsx adapter)
- `pnpm test` (core) — 816 passed (+ CH9 marker/errBar/label/smooth/dispBlanksAs oracles, incl. stacked-area band-top and zero-mode-label regression tests); typecheck clean
- `renderer-signature` snapshot unchanged — existing line/area (no marker/errBar/smooth/dispBlanks detail) byte-stable
- `pnpm build:wasm` + full local VRT — 163/163 passed, zero reference-image diffs (demo charts don't use these features)
- Independent 2-dimension review (spec fidelity/byte-stability — dispBlanksAs default split and Catmull-Rom verified against ECMA-376; test/wire). Both REQUEST_CHANGES findings fixed in-branch: **F1** stacked-area marker/label/errBar were mispositioned (forward vs reverse cumulative band-top — the fill stacks back-to-front); **F2** zero-mode data labels now honor null-as-zero to match the marker gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)