### PR TITLE
feat(charts): axis model, pie/doughnut geometry, and chart fonts (CH6 + CH8 + CH10)

### DIFF
--- a/docs/improvement-plan-2026-07b-checklist.md
+++ b/docs/improvement-plan-2026-07b-checklist.md
@@ -86,12 +86,14 @@ node packages/node/src/bench-handle.mjs  # handle 反復 work ベンチ
 
 ## Phase 2 — チャートエンジンの制覇
 
-- [ ] CH5: チャート XML パース ooxml-common 一本化(enabling step、byte-stable oracle)
-- [ ] CH6: 軸モデル完成(gridlines / units / log / orientation / rot / trendline)
-- [ ] CH7: 第2軸の全ファミリー化
-- [ ] CH8: pie / doughnut 完成
-- [ ] CH9: line ファミリーのマーカー / エラーバー / ラベル / smooth
-- [ ] CH10: チャートフォント(テーマ + c:txPr)
+- [ ] CH5: チャート XML パース ooxml-common 一本化(enabling step、byte-stable oracle) — **ユーザー判断で後回し**(2026-07-04): CH5 パーサー統一はレンダラー系 CH6-10 の前提ではない(CH6-10 は renderer 消費、CH5 は parse 構造)。真に必要なのは CH12 docx チャート/CH14-15 chartEx の enabling → CH12 着手時に実施。
+- [x] CH6: 軸モデル完成(gridlines / units / log / orientation / rot / trendline) — **完了**(PR feat/chart-axes-pie-fonts、commit 4264413/4001d02/d386928)。majorGridlines 有無(§21.2.2.102、既定=描画継続で byte-stable)/majorUnit・minorUnit(§21.2.2.116/.126、auto 上書き)/logBase(§21.2.2.104、log スケール値→px + decade gridline)/orientation maxMin(§21.2.2.130、値軸・カテゴリ軸反転)/ラベル rot(§ST_Angle ÷60000 = XSD 確認)/tickLblPos none/trendline(§21.2.2.212、linear 最小二乗+movingAvg 描画、exp/log/power/poly はパースのみ非描画=注記)。bar+line に配線(area/radar/scatter は byte-stable 据置)。ooxml-common に extractor + ChartTrendline 集約。
+- [x] CH7: 第2軸の全ファミリー化 — **完了**(PR #732)。bar の第2軸を純ヘルパー computeSecondaryAxis に抽出(bar byte-identical を snapshot で証明)、line/area に配線。scatter は spec 上 Y 第2軸なしで対象外。
+- [x] CH8: pie / doughnut 完成 — **完了**(PR feat/chart-axes-pie-fonts、commit fdb8237/b3efbd5)。holeSize(§21.2.2.60、% 除去 1-90 clamp、absent→50% で byte-stable)/firstSliceAngle(§21.2.2.52、既定 0=12時=旧-90°)/explosion(dPt §21.2.2.61、mid-angle 方向オフセット、doc は de-facto Office %)/多重リング(doughnut 複数 series を同心リング)/dLbls(per-slice showVal/CatName/SerName/Percent)/穴透明化。pie(非 doughnut)byte-stable、snapshot は doughnut のみ変化。
+- [x] CH9: line ファミリーのマーカー / エラーバー / ラベル / smooth — **完了**(PR #734)。scatter 実装を line/area に流用(marker 詳細/errBar/per-point ラベル)+ smooth(§21.2.2.194 Catmull-Rom、c:smooth を ooxml-common で新規パース)+ dispBlanksAs(§21.2.2.42/§21.2.3.10、gap/zero/span、@val 既定 zero・要素不在 gap)。詳細を持たない既存 line/area は byte-stable。レビュー検出=stacked-area の marker/label が積み上げ逆順とズレ(reverse-cumulative 修正)+ zero モードのラベル整合。
+- [x] CH10: チャートフォント(テーマ + c:txPr) — **完了**(PR feat/chart-axes-pie-fonts、commit fdb8237/b3efbd5)。28 の sans-serif ハードコードを txPr の a:latin typeface ?? theme majorFont/minorFont(fontScheme §20.1.4.2、+mj-lt/+mn-lt 解決)?? sans-serif に。軸ラベル/データラベル/凡例/目盛りに配線。xlsx は theme font threading を新規(parse_theme_fonts → WorkbookShared → chart)。**VRT は fontless で no-op**(E9 フォント可搬性 — Office フォント環境で正しく効くが CI/VRT マシンでは同フォールバックで参照差分ゼロ。ringRecordingCtx テストで ctx.font 解決の正しさを裏取り)。
+
+> CH6-CH10 は PR feat/chart-axes-pie-fonts(6 commits)+ CH7 #732 + CH9 #734。検証 = cargo 各パーサー / core 860 / typecheck / VRT 163 全 green・**参照画像差分ゼロ**(byte-stability: CH6/8 既定不変・snapshot は doughnut のみ・CH10 は fontless no-op)。独立2観点レビュー(spec 忠実性+byte-stability / テスト+wire+横断)ともに APPROVE、XSD で spec 値全照合。別トラック: CH6 は bar+line のみ(area/radar/scatter 第2軸/軸モデルの全ファミリー化)、trendline の exp/log/power/poly 描画 + dispEq/dispRSqr テキスト。
 - [ ] CH12: docx チャート(参照画像承認とセット)
 - [ ] CH13: 3D 平坦化 + stock + ofPie
 - [ ] CH14: xlsx chartEx 認識

--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -962,8 +962,8 @@ fillText "Margin" 529.2,207.8 fs=#333 font=12px sans-serif al=left bl=middle"
 
 exports[`renderChart draw-call signature (characterization) > is stable for: doughnut+legendBottom 1`] = `
 "beginPath
-moveTo 332,189.2
 arc 332,189.2,136.08,-1.5708,0.3142
+arc 332,189.2,68.04,0.3142,-1.5708
 closePath
 set fillStyle=#AA0000
 fill fs=#AA0000 ga=1
@@ -975,8 +975,8 @@ set textAlign=center
 set textBaseline=middle
 fillText "30%" 414.5683,129.2106 fs=#fff font=bold 13.607999999999999px sans-serif al=center bl=middle
 beginPath
-moveTo 332,189.2
 arc 332,189.2,136.08,0.3142,3.1416
+arc 332,189.2,68.04,3.1416,0.3142
 closePath
 set fillStyle=#ED7D31
 fill fs=#ED7D31 ga=1
@@ -984,17 +984,14 @@ stroke ss=#fff lw=1 dash=
 set fillStyle=#fff
 fillText "45%" 316.0343,290.0035 fs=#fff font=bold 13.607999999999999px sans-serif al=center bl=middle
 beginPath
-moveTo 332,189.2
 arc 332,189.2,136.08,3.1416,4.7124
+arc 332,189.2,68.04,4.7124,3.1416
 closePath
 set fillStyle=#CC0000
 fill fs=#CC0000 ga=1
 stroke ss=#fff lw=1 dash=
 set fillStyle=#fff
 fillText "25%" 259.8327,117.0327 fs=#fff font=bold 13.607999999999999px sans-serif al=center bl=middle
-beginPath
-arc 332,189.2,68.04,0,6.2832
-fill fs=#fff ga=1
 set font=12px sans-serif
 set fillStyle=#AA0000
 fillRect 277.4,359.6,10,12 fs=#AA0000

--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { niceStep, niceAxisMax, niceAxisMin, valueAxisScale } from './axis-scale.js';
+import {
+  niceStep,
+  niceAxisMax,
+  niceAxisMin,
+  valueAxisScale,
+  axisFraction,
+  logAxisScale,
+} from './axis-scale.js';
 
 describe('niceStep', () => {
   it('picks 1/2/5 × 10ⁿ for ~5 gridlines', () => {
@@ -84,5 +91,79 @@ describe('valueAxisScale (one niceStep drives min, max and gridline step)', () =
     expect(min).toBe(0);
     expect(step).toBeCloseTo(0.02, 12);
     expect(max).toBeCloseTo(0.12, 12);
+  });
+
+  it('an explicit majorUnit overrides the auto step (min/max still auto)', () => {
+    // <c:valAx><c:majorUnit val="25"/> forces the gridline spacing.
+    expect(valueAxisScale(0, 41, undefined, undefined, undefined, 25)).toEqual({
+      min: 0,
+      max: 50,
+      step: 25,
+    });
+  });
+  it('a null/undefined majorUnit keeps the auto step (byte-stable)', () => {
+    expect(valueAxisScale(0, 41, undefined, undefined, undefined, null)).toEqual(
+      valueAxisScale(0, 41),
+    );
+    expect(valueAxisScale(0, 41, undefined, undefined, undefined, undefined)).toEqual(
+      valueAxisScale(0, 41),
+    );
+  });
+  it('a non-positive majorUnit is ignored (no infinite gridline loop)', () => {
+    expect(valueAxisScale(0, 41, undefined, undefined, undefined, 0)).toEqual(
+      valueAxisScale(0, 41),
+    );
+    expect(valueAxisScale(0, 41, undefined, undefined, undefined, -5)).toEqual(
+      valueAxisScale(0, 41),
+    );
+  });
+});
+
+describe('axisFraction (value → 0..1 position along an axis)', () => {
+  it('linear, normal orientation is exactly (v - min) / (max - min) — byte-stable', () => {
+    expect(axisFraction(5, 0, 10)).toBe(0.5);
+    expect(axisFraction(0, 0, 10)).toBe(0);
+    expect(axisFraction(10, 0, 10)).toBe(1);
+    expect(axisFraction(2, -10, 10)).toBe(0.6);
+  });
+  it('reversed orientation (maxMin) flips the fraction', () => {
+    expect(axisFraction(5, 0, 10, { reversed: true })).toBe(0.5);
+    expect(axisFraction(0, 0, 10, { reversed: true })).toBe(1);
+    expect(axisFraction(10, 0, 10, { reversed: true })).toBe(0);
+  });
+  it('log axis maps in log space', () => {
+    // base-10 axis 1..1000 → 10 sits at log10(10/1)/log10(1000/1) = 1/3
+    expect(axisFraction(10, 1, 1000, { logBase: 10 })).toBeCloseTo(1 / 3, 12);
+    expect(axisFraction(100, 1, 1000, { logBase: 10 })).toBeCloseTo(2 / 3, 12);
+    expect(axisFraction(1, 1, 1000, { logBase: 10 })).toBe(0);
+    expect(axisFraction(1000, 1, 1000, { logBase: 10 })).toBeCloseTo(1, 12);
+  });
+  it('log axis + reversed composes both', () => {
+    expect(axisFraction(10, 1, 1000, { logBase: 10, reversed: true })).toBeCloseTo(2 / 3, 12);
+  });
+  it('degenerate zero range returns 0 (no NaN)', () => {
+    expect(axisFraction(5, 5, 5)).toBe(0);
+  });
+});
+
+describe('logAxisScale (power-of-base bounds + gridline exponents)', () => {
+  it('snaps bounds down/up to powers of the base and lists the decade lines', () => {
+    // data 3..700, base 10 → min 1 (10^0), max 1000 (10^3), lines 1,10,100,1000
+    const s = logAxisScale(3, 700, 10);
+    expect(s.min).toBe(1);
+    expect(s.max).toBe(1000);
+    expect(s.lines).toEqual([1, 10, 100, 1000]);
+  });
+  it('explicit min/max override the snapped bounds', () => {
+    const s = logAxisScale(3, 700, 10, 1, 100);
+    expect(s.min).toBe(1);
+    expect(s.max).toBe(100);
+    expect(s.lines).toEqual([1, 10, 100]);
+  });
+  it('clamps a non-positive data minimum up to the base (log undefined at <= 0)', () => {
+    // data 0..500 can't take log(0); floor to the base's smallest positive decade.
+    const s = logAxisScale(0, 500, 10);
+    expect(s.min).toBeGreaterThan(0);
+    expect(s.max).toBe(1000);
   });
 });

--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -6,6 +6,7 @@ import {
   valueAxisScale,
   axisFraction,
   logAxisScale,
+  fitTrendline,
 } from './axis-scale.js';
 
 describe('niceStep', () => {
@@ -165,5 +166,40 @@ describe('logAxisScale (power-of-base bounds + gridline exponents)', () => {
     const s = logAxisScale(0, 500, 10);
     expect(s.min).toBeGreaterThan(0);
     expect(s.max).toBe(1000);
+  });
+});
+
+describe('fitTrendline', () => {
+  it('linear least squares recovers a perfect line', () => {
+    // y = 2x + 1 at x = 0,1,2,3
+    const t = fitTrendline([0, 1, 2, 3], [1, 3, 5, 7], 'linear');
+    expect(t.xs).toEqual([0, 3]);
+    expect(t.ys[0]).toBeCloseTo(1, 9);
+    expect(t.ys[1]).toBeCloseTo(7, 9);
+  });
+  it('linear fit through noisy data has the least-squares slope', () => {
+    // x 0..3, y 1,2,2,5 → slope = (nΣxy-ΣxΣy)/(nΣx²-(Σx)²) = (4*29-6*10)/(4*14-36)=56/20=1.2
+    const t = fitTrendline([0, 1, 2, 3], [1, 2, 2, 5], 'linear');
+    const slope = (t.ys[1] - t.ys[0]) / (t.xs[1] - t.xs[0]);
+    expect(slope).toBeCloseTo(1.2, 9);
+  });
+  it('linear fit honors a forced intercept', () => {
+    // Force b=0: m = Σxy/Σx². Σxy = 0·1+1·2+2·2+3·5 = 21; Σx² = 14 → m = 1.5.
+    const t = fitTrendline([0, 1, 2, 3], [1, 2, 2, 5], 'linear', { intercept: 0 });
+    expect(t.ys[0]).toBeCloseTo(0, 9); // line passes through (0,0)
+    const slope = (t.ys[1] - t.ys[0]) / (t.xs[1] - t.xs[0]);
+    expect(slope).toBeCloseTo(21 / 14, 9);
+  });
+  it('moving average (period 2) trails the mean of the last two points', () => {
+    const t = fitTrendline([0, 1, 2, 3], [10, 20, 30, 40], 'movingAvg', { period: 2 });
+    expect(t.xs).toEqual([1, 2, 3]);
+    expect(t.ys).toEqual([15, 25, 35]);
+  });
+  it('unsupported types return empty (parse-only for now)', () => {
+    expect(fitTrendline([0, 1, 2], [1, 2, 4], 'exp')).toEqual({ xs: [], ys: [] });
+    expect(fitTrendline([0, 1, 2], [1, 2, 4], 'poly')).toEqual({ xs: [], ys: [] });
+  });
+  it('too few points returns empty', () => {
+    expect(fitTrendline([0], [1], 'linear')).toEqual({ xs: [], ys: [] });
   });
 });

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -63,9 +63,80 @@ export function valueAxisScale(
   dataMin: number, dataMax: number,
   explicitMin?: number | null, explicitMax?: number | null,
   axisLenPt?: number,
+  majorUnit?: number | null,
 ): { min: number; max: number; step: number } {
-  const step = niceStep(dataMax - dataMin, targetStepsForAxis(axisLenPt));
-  const min = explicitMin ?? niceAxisMin(dataMin, step);
-  const max = explicitMax ?? niceAxisMax(dataMax, step, min);
+  // A file-specified `<c:valAx><c:majorUnit>` (ECMA-376 §21.2.2.103) overrides
+  // the auto "nice" step. Non-positive / non-finite values are ignored (they'd
+  // wedge the gridline loop) so an absent/invalid majorUnit is byte-stable.
+  const autoStep = niceStep(dataMax - dataMin, targetStepsForAxis(axisLenPt));
+  const step = majorUnit != null && isFinite(majorUnit) && majorUnit > 0 ? majorUnit : autoStep;
+  // The auto min/max still round against the AUTO step (Excel derives the bounds
+  // before the user's manual major unit is applied); explicit scaling wins.
+  const min = explicitMin ?? niceAxisMin(dataMin, autoStep);
+  const max = explicitMax ?? niceAxisMax(dataMax, autoStep, min);
   return { min, max, step };
+}
+
+/** Options for {@link axisFraction}: a logarithmic base and/or a reversed
+ *  (`maxMin`) orientation. Both default off, in which case the fraction is the
+ *  plain linear `(v - min) / (max - min)` — byte-identical to the renderers'
+ *  historical inline math. */
+export interface AxisFractionOpts {
+  /** `<c:scaling><c:logBase val>` (ECMA-376 §21.2.2.98). When set (>= 2) the
+   *  value maps in log space. min/max must be positive. */
+  logBase?: number | null;
+  /** `<c:scaling><c:orientation val="maxMin">` — reverse the axis. */
+  reversed?: boolean;
+}
+
+/** Map a value to its 0..1 position along an axis spanning `min`..`max`.
+ *
+ *  This is the single shared primitive the per-chart-type renderers build their
+ *  `toY` / `valX` closures on: a caller does `py0 + ph - axisFraction(v, min,
+ *  max) * ph`. With no options it returns exactly `(v - min) / (max - min)`, so
+ *  a linear, normally-oriented axis is byte-stable. A log base maps in log space
+ *  (gridlines fall on powers of the base); `reversed` flips the fraction for a
+ *  `maxMin` orientation. A degenerate zero range yields 0 (no NaN/∞). */
+export function axisFraction(
+  v: number, min: number, max: number, opts?: AxisFractionOpts,
+): number {
+  let frac: number;
+  const logBase = opts?.logBase;
+  if (logBase != null && isFinite(logBase) && logBase >= 2 && min > 0 && max > 0) {
+    const lo = Math.log(min);
+    const hi = Math.log(max);
+    const denom = hi - lo;
+    frac = denom === 0 ? 0 : (Math.log(Math.max(v, Number.MIN_VALUE)) - lo) / denom;
+  } else {
+    const denom = max - min;
+    frac = denom === 0 ? 0 : (v - min) / denom;
+  }
+  return opts?.reversed ? 1 - frac : frac;
+}
+
+/** Logarithmic value-axis bounds + gridline decades. Snaps `dataMin` down and
+ *  `dataMax` up to whole powers of `base` (Excel's log-axis behavior) and lists
+ *  every power-of-base gridline in `[min, max]`. Explicit `<c:scaling><c:min /
+ *  max>` override the snapped bounds. A non-positive `dataMin` (log undefined at
+ *  <= 0) floors to the base's lowest decade at or below the smallest positive
+ *  datum, defaulting to `base^0 = 1` when there is none. */
+export function logAxisScale(
+  dataMin: number, dataMax: number, base: number,
+  explicitMin?: number | null, explicitMax?: number | null,
+): { min: number; max: number; lines: number[] } {
+  const b = isFinite(base) && base >= 2 ? base : 10;
+  const logB = (x: number): number => Math.log(x) / Math.log(b);
+  const posMax = dataMax > 0 ? dataMax : 1;
+  // Floor the min to a decade; clamp a non-positive min up to the smallest
+  // decade that is still <= the positive max.
+  const rawMin = dataMin > 0 ? dataMin : posMax;
+  const minExp = Math.floor(logB(rawMin));
+  const maxExp = Math.ceil(logB(posMax));
+  const min = explicitMin != null ? explicitMin : Math.pow(b, minExp);
+  const max = explicitMax != null ? explicitMax : Math.pow(b, Math.max(maxExp, minExp + 1));
+  const lines: number[] = [];
+  const startExp = Math.ceil(logB(min) - 1e-9);
+  const endExp = Math.floor(logB(max) + 1e-9);
+  for (let e = startExp; e <= endExp; e++) lines.push(Math.pow(b, e));
+  return { min, max, lines };
 }

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -140,3 +140,57 @@ export function logAxisScale(
   for (let e = startExp; e <= endExp; e++) lines.push(Math.pow(b, e));
   return { min, max, lines };
 }
+
+/** A fitted trendline as a list of `(x, y)` points in DATA space (x = the
+ *  point's category index / x-value, y = the fitted value). The renderer maps
+ *  these through the chart's category→pixel and value→pixel transforms. Empty
+ *  when the type is unsupported or there is too little data to fit. */
+export interface TrendlinePoints { xs: number[]; ys: number[] }
+
+/** Fit a trendline to `(xs, ys)` data points (nulls already filtered by the
+ *  caller). Implements the two most common ECMA-376 `ST_TrendlineType`
+ *  (§21.2.3.50) styles:
+ *   - `linear` — ordinary least-squares `y = m·x + b` (honors a forced
+ *     `intercept`), sampled at the first and last x (a straight line).
+ *   - `movingAvg` — the trailing average of the previous `period` points
+ *     (default 2), producing a point from index `period-1` onward.
+ *  Other types (`exp` / `log` / `power` / `poly`) return an empty result for
+ *  now (they parse but aren't plotted — tracked as a follow-up). */
+export function fitTrendline(
+  xs: number[], ys: number[], type: string,
+  opts?: { period?: number | null; intercept?: number | null },
+): TrendlinePoints {
+  const n = Math.min(xs.length, ys.length);
+  if (n < 2) return { xs: [], ys: [] };
+  if (type === 'linear') {
+    // Least squares. With a forced intercept b0, fit only the slope through
+    // the shifted data: m = Σ x(y-b0) / Σ x².
+    const forced = opts?.intercept;
+    let sx = 0, sy = 0, sxx = 0, sxy = 0;
+    for (let i = 0; i < n; i++) { sx += xs[i]; sy += ys[i]; sxx += xs[i] * xs[i]; sxy += xs[i] * ys[i]; }
+    let m: number, b: number;
+    if (forced != null && isFinite(forced)) {
+      const sxx0 = sxx; const sxy0 = sxy - forced * sx;
+      m = sxx0 === 0 ? 0 : sxy0 / sxx0;
+      b = forced;
+    } else {
+      const denom = n * sxx - sx * sx;
+      m = denom === 0 ? 0 : (n * sxy - sx * sy) / denom;
+      b = (sy - m * sx) / n;
+    }
+    const x0 = xs[0]; const x1 = xs[n - 1];
+    return { xs: [x0, x1], ys: [m * x0 + b, m * x1 + b] };
+  }
+  if (type === 'movingAvg') {
+    const period = Math.max(2, Math.round(opts?.period ?? 2));
+    if (n < period) return { xs: [], ys: [] };
+    const ox: number[] = []; const oy: number[] = [];
+    for (let i = period - 1; i < n; i++) {
+      let sum = 0;
+      for (let k = 0; k < period; k++) sum += ys[i - k];
+      ox.push(xs[i]); oy.push(sum / period);
+    }
+    return { xs: ox, ys: oy };
+  }
+  return { xs: [], ys: [] };
+}

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1585,3 +1585,164 @@ describe('CH10 — chart text font faces', () => {
     expect(titleFont).toContain('Aptos Display');
   });
 });
+
+// ── CH6 — axis scale model (gridlines / units / logBase / orientation) ───────
+
+interface Seg { x0: number; y0: number; x1: number; y1: number; ss: string; lw: number }
+interface SegRecorded { ctx: CanvasRenderingContext2D; segs: Seg[]; texts: TextCall[] }
+
+/** Recording context that captures stroked line SEGMENTS (moveTo→lineTo→stroke)
+ *  plus fillText, so gridline presence/orientation can be asserted. */
+function segRecordingCtx(): SegRecorded {
+  const segs: Seg[] = [];
+  const texts: TextCall[] = [];
+  let cx = 0, cy = 0, mx = 0, my = 0;
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+  };
+  const fontPx = (font: string): number => {
+    const m = /(\d+(?:\.\d+)?)px/.exec(font);
+    return m ? parseFloat(m[1]) : 10;
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => {
+            const px = fontPx(String(state.font));
+            let w = 0;
+            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+            return { width: w };
+          };
+        case 'moveTo': return (x: number, y: number) => { cx = x; cy = y; mx = x; my = y; };
+        case 'lineTo': return (x: number, y: number) => {
+          segs.push({ x0: cx, y0: cy, x1: x, y1: y, ss: String(state.strokeStyle), lw: Number(state.lineWidth) });
+          cx = x; cy = y;
+        };
+        case 'fillText': return (text: string, x: number, y: number) => texts.push({ text, x, y });
+        case 'createLinearGradient': case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        case 'closePath': return () => { cx = mx; cy = my; };
+        case 'save': case 'restore': case 'beginPath': case 'fill': case 'stroke':
+        case 'arc': case 'bezierCurveTo': case 'quadraticCurveTo': case 'rect':
+        case 'fillRect': case 'strokeRect': case 'clearRect': case 'strokeText':
+        case 'setLineDash': case 'translate': case 'rotate': case 'scale': case 'clip':
+        case 'setTransform': case 'resetTransform': case 'getTransform':
+          return () => undefined;
+        default: return undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, segs, texts };
+}
+
+/** Value-axis MAJOR/MINOR gridlines: near-flat segments spanning the plot width
+ *  drawn in the gridline colors (`#e0e0e0` faint or `#aaa` zero line). The
+ *  category axis bottom rule is also `#aaa` horizontal, so it's excluded by
+ *  dropping the single bottom-most horizontal `#aaa` segment (the axis line). */
+function horizGridlines(segs: Seg[]): Seg[] {
+  const flat = segs.filter(s => Math.abs(s.y0 - s.y1) < 0.5 && Math.abs(s.x1 - s.x0) > 50);
+  const grids = flat.filter(s => s.ss === '#e0e0e0' || s.ss === '#aaa');
+  // Drop the bottom-most `#aaa` line (the category axis rule) if present.
+  const aaa = grids.filter(s => s.ss === '#aaa');
+  if (aaa.length === 0) return grids;
+  const maxY = Math.max(...aaa.map(s => s.y0));
+  let dropped = false;
+  return grids.filter(s => {
+    if (!dropped && s.ss === '#aaa' && Math.abs(s.y0 - maxY) < 0.5) { dropped = true; return false; }
+    return true;
+  });
+}
+
+describe('CH6 — axis scale model', () => {
+  const lineModel = (over: Partial<ChartModel>): ChartModel => baseModel({
+    chartType: 'line',
+    categories: ['A', 'B', 'C'],
+    series: [series({ name: 'S', values: [10, 20, 30] })],
+    ...over,
+  });
+
+  it('valAxisMajorGridlines=false suppresses the value gridlines (labels stay)', () => {
+    const on = segRecordingCtx();
+    renderChart(on.ctx, lineModel({}), RECT, 1);
+    const gridsOn = horizGridlines(on.segs).length;
+    expect(gridsOn).toBeGreaterThan(0);
+
+    const off = segRecordingCtx();
+    renderChart(off.ctx, lineModel({ valAxisMajorGridlines: false }), RECT, 1);
+    // No horizontal gridlines spanning the plot when suppressed.
+    expect(horizGridlines(off.segs).length).toBe(0);
+    // Tick labels still drawn.
+    expect(off.texts.some(t => t.text === '10')).toBe(true);
+  });
+
+  it('valAxisTickLabelPos="none" hides value tick labels (gridlines stay)', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, lineModel({ valAxisTickLabelPos: 'none' }), RECT, 1);
+    // Value labels (numeric) gone; gridlines still present.
+    expect(rec.texts.some(t => /^\d+$/.test(t.text))).toBe(false);
+    expect(horizGridlines(rec.segs).length).toBeGreaterThan(0);
+  });
+
+  it('an explicit valAxisMajorUnit changes the gridline count', () => {
+    // Data 10..30 → auto step 5 (0,5,…,35 ≈ 8 lines). majorUnit 10 → coarser.
+    const auto = segRecordingCtx();
+    renderChart(auto.ctx, lineModel({}), RECT, 1);
+    const coarse = segRecordingCtx();
+    renderChart(coarse.ctx, lineModel({ valAxisMajorUnit: 10 }), RECT, 1);
+    expect(horizGridlines(coarse.segs).length).toBeLessThan(horizGridlines(auto.segs).length);
+    // Labels land on 0,10,20,30,… (multiples of 10) only.
+    const coarseLabels = coarse.texts.map(t => t.text).filter(t => /^\d+$/.test(t));
+    expect(coarseLabels).toContain('10');
+    expect(coarseLabels).toContain('20');
+    expect(coarseLabels).not.toContain('5');
+  });
+
+  it('valAxisOrientation="maxMin" reverses the value axis (bar heights flip)', () => {
+    const normal = recordingCtx();
+    renderChart(normal.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B'],
+      series: [series({ name: 'S', values: [10, 30] })],
+    }), RECT, 1);
+    const reversed = recordingCtx();
+    renderChart(reversed.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B'],
+      series: [series({ name: 'S', values: [10, 30] })],
+      valAxisOrientation: 'maxMin',
+    }), RECT, 1);
+    // Normal: taller value (30) → shorter y (higher up) and greater height.
+    // Reversed: the axis flips, so the bar for 30 grows DOWNWARD from the top.
+    const nBig = normal.rects[1];
+    const rBig = reversed.rects[1];
+    // In the reversed axis the "30" bar's top edge sits at the plot top area
+    // and it extends toward the (now-inverted) zero at the bottom-flipped end;
+    // its y origin differs from the normal orientation.
+    expect(rBig.y).not.toBeCloseTo(nBig.y, 1);
+  });
+
+  it('valAxisLogBase=10 places gridlines on powers of ten', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, lineModel({
+      categories: ['A', 'B', 'C'],
+      series: [series({ name: 'S', values: [1, 10, 100] })],
+      valAxisLogBase: 10,
+    }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    // Decade tick labels 1 / 10 / 100 present (1000 not required for this range).
+    expect(labels).toContain('1');
+    expect(labels).toContain('10');
+    expect(labels).toContain('100');
+  });
+
+  it('a chart with no CH6 fields renders identical gridlines to before (byte-stable)', () => {
+    // Guard: the default (no CH6 fields) must keep the historical value gridlines.
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, lineModel({}), RECT, 1);
+    expect(horizGridlines(rec.segs).length).toBeGreaterThan(2);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1464,6 +1464,10 @@ describe('CH8 — pie / doughnut geometry', () => {
   });
 
   it('explosion offsets the slice center outward (arc center moves)', () => {
+    const base = ringRecordingCtx();
+    renderChart(base.ctx, pieModel({
+      series: [series({ name: 'S', values: [30, 45, 25] })],
+    }), RECT, 1);
     const rec = ringRecordingCtx();
     renderChart(rec.ctx, pieModel({
       series: [series({
@@ -1476,6 +1480,39 @@ describe('CH8 — pie / doughnut geometry', () => {
     // center is displaced. Collect the distinct arc centers.
     const centers = new Set(rec.arcs.map(a => `${Math.round(a.x)},${Math.round(a.y)}`));
     expect(centers.size).toBeGreaterThan(1);
+    // The non-exploded pie's shared center — every arc (all 3 slices) is drawn
+    // around this single point.
+    const trueCenter = base.arcs[0];
+    expect(base.arcs.every(a => a.x === trueCenter.x && a.y === trueCenter.y)).toBe(true);
+    // Slice 0 and slice 2 (not exploded) still share the true center in the
+    // exploded render — only slice 1 moves.
+    const outerR = Math.max(...rec.arcs.map(a => a.r));
+    const slice0Arcs = rec.arcs.filter(a => a.a0 === base.arcs[0].a0 && a.a1 === base.arcs[0].a1);
+    expect(slice0Arcs.length).toBeGreaterThan(0);
+    for (const a of slice0Arcs) {
+      expect(a.x).toBeCloseTo(trueCenter.x, 6);
+      expect(a.y).toBeCloseTo(trueCenter.y, 6);
+    }
+    // Slice 1 (idx 1, explosion 40): §21.2.2.61 explosion, interpreted (de facto,
+    // see ChartDataPointOverride.explosion) as a percentage of the outer radius
+    // the slice is displaced outward along its own mid-angle.
+    // Values [30, 45, 25] over 2π starting at -π/2 (12 o'clock, clockwise) put
+    // slice 1's span at [-π/2 + 0.6π, -π/2 + 1.5π]; its mid-angle is -π/2 + 1.05π.
+    const total = 100;
+    const startAngle = -Math.PI / 2;
+    const slice0Frac = 30 / total;
+    const slice1Frac = 45 / total;
+    const midAngle = startAngle + slice0Frac * 2 * Math.PI + (slice1Frac * 2 * Math.PI) / 2;
+    const expectedOffset = 0.4 * outerR;
+    const expectedX = trueCenter.x + Math.cos(midAngle) * expectedOffset;
+    const expectedY = trueCenter.y + Math.sin(midAngle) * expectedOffset;
+    const slice1Arc = rec.arcs.find(a => Math.abs(a.x - trueCenter.x) > 1 || Math.abs(a.y - trueCenter.y) > 1);
+    expect(slice1Arc).toBeDefined();
+    expect(slice1Arc?.x).toBeCloseTo(expectedX, 4);
+    expect(slice1Arc?.y).toBeCloseTo(expectedY, 4);
+    // Displacement magnitude is exactly 40% of the outer radius.
+    const dist = Math.hypot((slice1Arc?.x ?? 0) - trueCenter.x, (slice1Arc?.y ?? 0) - trueCenter.y);
+    expect(dist).toBeCloseTo(expectedOffset, 4);
   });
 
   it('a multi-series doughnut draws concentric rings (multiple distinct radii)', () => {
@@ -1494,6 +1531,32 @@ describe('CH8 — pie / doughnut geometry', () => {
     // would produce.
     const distinctRadii = new Set(rec.arcs.map(a => Math.round(a.r * 10) / 10));
     expect(distinctRadii.size).toBeGreaterThanOrEqual(3);
+    // The single-series doughnut geometry (asserted in the tests above) gives
+    // us an independently-derived outer radius for this RECT — reuse it so the
+    // band boundaries below aren't just copied from the renderer's own formula.
+    const single = ringRecordingCtx();
+    renderChart(single.ctx, baseModel({
+      chartType: 'doughnut', categories: ['A'], series: [series({ name: 'S', values: [1] })], holeSize: 40,
+    }), RECT, 1);
+    // Use the RAW (unrounded) outer radius so the derived band boundaries below
+    // don't compound `ringRadii`'s rounding into a spurious mismatch.
+    const outerR = Math.max(...single.arcs.map(a => a.r));
+    const innerR = outerR * 0.4; // holeSize 40 → hole is 40% of the outer radius
+    const ringBand = (outerR - innerR) / 2; // band from hole to outer edge, split evenly across 2 rings
+    const expectRadiiCloseTo = (arcs: RingArc[], expected: number[]): void => {
+      const actual = [...new Set(arcs.map(a => Math.round(a.r * 1000) / 1000))].sort((a, b) => b - a);
+      const wanted = [...expected].sort((a, b) => b - a);
+      expect(actual.length).toBe(wanted.length);
+      actual.forEach((r, i) => expect(r).toBeCloseTo(wanted[i], 2));
+    };
+    // Each ring draws 2 arcs (outer + inner annulus edge) per category (A, B) →
+    // 4 arcs per ring, 8 total. Ring 0 ("Outer" series) is drawn FIRST and
+    // occupies the OUTERMOST band.
+    expectRadiiCloseTo(rec.arcs.slice(0, 4), [outerR, outerR - ringBand]);
+    // Ring 1 ("Inner" series) is drawn SECOND and occupies the band adjacent to
+    // the hole; its outer edge meets ring 0's inner edge, its inner edge is the
+    // hole radius.
+    expectRadiiCloseTo(rec.arcs.slice(4), [outerR - ringBand, innerR]);
   });
 
   it('rich pie dLbls compose showCatName + showPercent', () => {
@@ -1717,12 +1780,32 @@ describe('CH6 — axis scale model', () => {
     }), RECT, 1);
     // Normal: taller value (30) → shorter y (higher up) and greater height.
     // Reversed: the axis flips, so the bar for 30 grows DOWNWARD from the top.
-    const nBig = normal.rects[1];
-    const rBig = reversed.rects[1];
+    const [nSmall, nBig] = normal.rects;
+    const [rSmall, rBig] = reversed.rects;
     // In the reversed axis the "30" bar's top edge sits at the plot top area
     // and it extends toward the (now-inverted) zero at the bottom-flipped end;
     // its y origin differs from the normal orientation.
     expect(rBig.y).not.toBeCloseTo(nBig.y, 1);
+    // §21.2.2.130 orientation="maxMin" is a true mirror of the value axis, not
+    // just "a different y": every value's pixel position reflects across the
+    // plot's vertical midline. Both bars are zero-anchored (clustered, single
+    // series), so — independent of any internal renderer constant — the
+    // reversed zero line is the SHARED top edge of both reversed bars, and the
+    // normal zero line is the SHARED bottom edge of both normal bars.
+    const reversedZeroY = rSmall.y; // = rBig.y — both bars start at the (flipped) zero line
+    expect(rBig.y).toBeCloseTo(reversedZeroY, 6);
+    const normalZeroY = nSmall.y + nSmall.h; // = nBig.y + nBig.h — both bars end at zero
+    expect(nBig.y + nBig.h).toBeCloseTo(normalZeroY, 6);
+    // The mirror axis: for any value v, reversedBottom(v) = 2*reversedZeroY +
+    // (normalZeroY - reversedZeroY) - normalTop(v). A reversed bar's BOTTOM
+    // edge is the mirror image of the corresponding normal bar's TOP edge
+    // around the (reversedZeroY, normalZeroY) span.
+    const mirror = (yNormalTop: number): number => 2 * reversedZeroY + (normalZeroY - reversedZeroY) - yNormalTop;
+    expect(rSmall.y + rSmall.h).toBeCloseTo(mirror(nSmall.y), 4);
+    expect(rBig.y + rBig.h).toBeCloseTo(mirror(nBig.y), 4);
+    // The smaller value (10) still produces the smaller bar on the reversed
+    // axis too — reversal flips direction, not relative magnitude.
+    expect(rSmall.h).toBeLessThan(rBig.h);
   });
 
   it('valAxisLogBase=10 places gridlines on powers of ten', () => {

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1746,3 +1746,88 @@ describe('CH6 — axis scale model', () => {
     expect(horizGridlines(rec.segs).length).toBeGreaterThan(2);
   });
 });
+
+/** Recording context that counts rotate() calls and captures fillText, for the
+ *  category-label rotation / tickLblPos tests. */
+function rotateRecordingCtx(): { ctx: CanvasRenderingContext2D; rotates: number[]; texts: string[] } {
+  const rotates: number[] = [];
+  const texts: string[] = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+  };
+  const fontPx = (font: string): number => {
+    const m = /(\d+(?:\.\d+)?)px/.exec(font);
+    return m ? parseFloat(m[1]) : 10;
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => {
+            const px = fontPx(String(state.font));
+            let w = 0;
+            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+            return { width: w };
+          };
+        case 'rotate': return (r: number) => { rotates.push(r); };
+        case 'fillText': return (text: string) => texts.push(String(text));
+        case 'createLinearGradient': case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        case 'save': case 'restore': case 'beginPath': case 'closePath':
+        case 'fill': case 'stroke': case 'moveTo': case 'lineTo': case 'arc':
+        case 'bezierCurveTo': case 'quadraticCurveTo': case 'rect': case 'fillRect':
+        case 'strokeRect': case 'clearRect': case 'strokeText': case 'setLineDash':
+        case 'translate': case 'scale': case 'clip': case 'setTransform':
+        case 'resetTransform': case 'getTransform':
+          return () => undefined;
+        default: return undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, rotates, texts };
+}
+
+describe('CH6 — category-axis label rotation + tickLblPos (commit 2)', () => {
+  const colModel = (over: Partial<ChartModel>): ChartModel => baseModel({
+    chartType: 'clusteredBar',
+    categories: ['Alpha', 'Beta', 'Gamma'],
+    series: [series({ name: 'S', values: [10, 20, 30] })],
+    ...over,
+  });
+
+  it('catAxisTickLabelPos="none" hides the category labels', () => {
+    const shown = rotateRecordingCtx();
+    renderChart(shown.ctx, colModel({}), RECT, 1);
+    expect(shown.texts.some(t => t.startsWith('Alpha'))).toBe(true);
+
+    const hidden = rotateRecordingCtx();
+    renderChart(hidden.ctx, colModel({ catAxisTickLabelPos: 'none' }), RECT, 1);
+    expect(hidden.texts.some(t => t.startsWith('Alpha'))).toBe(false);
+    // Value tick labels still present.
+    expect(hidden.texts.some(t => /^\d+$/.test(t))).toBe(true);
+  });
+
+  it('catAxisLabelRotation rotates the column category labels', () => {
+    const flat = rotateRecordingCtx();
+    renderChart(flat.ctx, colModel({}), RECT, 1);
+    expect(flat.rotates.length).toBe(0);
+
+    const rot = rotateRecordingCtx();
+    // -2700000 60000ths = -45°.
+    renderChart(rot.ctx, colModel({ catAxisLabelRotation: -2_700_000 }), RECT, 1);
+    expect(rot.rotates.length).toBeGreaterThan(0);
+    const rad = rot.rotates[0];
+    expect(rad).toBeCloseTo((-45 * Math.PI) / 180, 6);
+    // Labels still drawn (just rotated).
+    expect(rot.texts.some(t => t.startsWith('Alpha'))).toBe(true);
+  });
+
+  it('rotation 0 keeps the un-rotated fast path (byte-stable, no rotate calls)', () => {
+    const rec = rotateRecordingCtx();
+    renderChart(rec.ctx, colModel({ catAxisLabelRotation: 0 }), RECT, 1);
+    expect(rec.rotates.length).toBe(0);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1831,3 +1831,77 @@ describe('CH6 — category-axis label rotation + tickLblPos (commit 2)', () => {
     expect(rec.rotates.length).toBe(0);
   });
 });
+
+/** Recording context that captures line-dash state alongside stroked segments,
+ *  so a dashed trendline can be distinguished from the solid data line. */
+function dashSegRecordingCtx(): { ctx: CanvasRenderingContext2D; segs: Array<{ dashed: boolean }> } {
+  const segs: Array<{ dashed: boolean }> = [];
+  let dash: number[] = [];
+  let pending = false;
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText': return (t: string) => ({ width: String(t).length * 6 });
+        case 'setLineDash': return (d: number[]) => { dash = d ?? []; };
+        case 'getLineDash': return () => dash;
+        case 'lineTo': return () => { pending = true; };
+        case 'stroke': return () => { if (pending) { segs.push({ dashed: dash.length > 0 }); pending = false; } };
+        case 'createLinearGradient': case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        case 'save': case 'restore': case 'beginPath': case 'closePath':
+        case 'fill': case 'moveTo': case 'arc': case 'bezierCurveTo':
+        case 'quadraticCurveTo': case 'rect': case 'fillRect': case 'strokeRect':
+        case 'clearRect': case 'fillText': case 'strokeText': case 'translate':
+        case 'rotate': case 'scale': case 'clip': case 'setTransform':
+        case 'resetTransform': case 'getTransform':
+          return () => undefined;
+        default: return undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, segs };
+}
+
+describe('CH6-follow — series trendlines (commit 3)', () => {
+  const lineWithTrend = (over: Partial<ChartSeries>): ChartModel => baseModel({
+    chartType: 'line',
+    categories: ['A', 'B', 'C', 'D'],
+    series: [series({ name: 'S', values: [1, 3, 5, 7], ...over })],
+  });
+
+  it('a linear trendline draws a dashed line', () => {
+    const noTrend = dashSegRecordingCtx();
+    renderChart(noTrend.ctx, lineWithTrend({}), RECT, 1);
+    expect(noTrend.segs.some(s => s.dashed)).toBe(false);
+
+    const withTrend = dashSegRecordingCtx();
+    renderChart(withTrend.ctx, lineWithTrend({ trendLines: [{ trendlineType: 'linear' }] }), RECT, 1);
+    expect(withTrend.segs.some(s => s.dashed)).toBe(true);
+    // The solid data line is still drawn too.
+    expect(withTrend.segs.some(s => !s.dashed)).toBe(true);
+  });
+
+  it('a movingAvg trendline draws a dashed line', () => {
+    const rec = dashSegRecordingCtx();
+    renderChart(rec.ctx, lineWithTrend({ trendLines: [{ trendlineType: 'movingAvg', period: 2 }] }), RECT, 1);
+    expect(rec.segs.some(s => s.dashed)).toBe(true);
+  });
+
+  it('an unsupported trendline type draws nothing extra (dashed absent)', () => {
+    const rec = dashSegRecordingCtx();
+    renderChart(rec.ctx, lineWithTrend({ trendLines: [{ trendlineType: 'poly', order: 2 }] }), RECT, 1);
+    expect(rec.segs.some(s => s.dashed)).toBe(false);
+  });
+
+  it('no trendLines field is byte-stable (no dashed segments)', () => {
+    const rec = dashSegRecordingCtx();
+    renderChart(rec.ctx, lineWithTrend({}), RECT, 1);
+    expect(rec.segs.every(s => !s.dashed)).toBe(true);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1331,3 +1331,257 @@ describe('CH9 — dispBlanksAs="zero" applies to per-point data labels too (§21
     expect(labelTexts).toContain('0');
   });
 });
+
+// ─── CH8 — pie / doughnut geometry ───────────────────────────────────────────
+
+interface RingArc { x: number; y: number; r: number; a0: number; a1: number; ccw: boolean }
+interface FontText { text: string; font: string; fill: string }
+
+interface RingRecorded {
+  ctx: CanvasRenderingContext2D;
+  arcs: RingArc[];
+  fills: string[];
+  fontTexts: FontText[];
+}
+
+/** Recording context that also captures arc() (radius + angles) and, for each
+ *  fillText, the active font + fillStyle. Used by the pie/doughnut + font tests
+ *  which assert on ring radii, slice start angle, explosion offsets, and the
+ *  resolved `ctx.font` family. */
+function ringRecordingCtx(): RingRecorded {
+  const arcs: RingArc[] = [];
+  const fills: string[] = [];
+  const fontTexts: FontText[] = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+  };
+  const fontPx = (font: string): number => {
+    const m = /(\d+(?:\.\d+)?)px/.exec(font);
+    return m ? parseFloat(m[1]) : 10;
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => {
+            const px = fontPx(String(state.font));
+            let w = 0;
+            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+            return { width: w };
+          };
+        case 'arc':
+          return (x: number, y: number, r: number, a0: number, a1: number, ccw = false) =>
+            arcs.push({ x, y, r, a0, a1, ccw });
+        case 'fill':
+          return () => fills.push(String(state.fillStyle));
+        case 'fillText':
+          return (text: string) =>
+            fontTexts.push({ text, font: String(state.font), fill: String(state.fillStyle) });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        case 'save': case 'restore': case 'beginPath': case 'closePath':
+        case 'stroke': case 'moveTo': case 'lineTo': case 'bezierCurveTo':
+        case 'quadraticCurveTo': case 'rect': case 'fillRect': case 'strokeRect':
+        case 'clearRect': case 'strokeText': case 'setLineDash': case 'translate':
+        case 'rotate': case 'scale': case 'clip': case 'setTransform':
+        case 'resetTransform': case 'getTransform':
+          return () => undefined;
+        default:
+          return undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, arcs, fills, fontTexts };
+}
+
+/** Outer/inner ring radii for a pie/doughnut: the outer radius is the largest
+ *  arc radius; the inner radius is the smallest DISTINCT smaller radius (0 for a
+ *  solid pie whose wedges are a single radius). */
+function ringRadii(arcs: RingArc[]): { outer: number; inner: number } {
+  const rs = [...new Set(arcs.map(a => Math.round(a.r * 100) / 100))].sort((a, b) => b - a);
+  return { outer: rs[0] ?? 0, inner: rs.length > 1 ? rs[rs.length - 1] : 0 };
+}
+
+describe('CH8 — pie / doughnut geometry', () => {
+  const pieModel = (over: Partial<ChartModel>): ChartModel =>
+    baseModel({
+      chartType: 'pie',
+      categories: ['A', 'B', 'C'],
+      series: [series({ name: 'S', values: [30, 45, 25] })],
+      ...over,
+    });
+
+  it('a plain pie draws solid wedges (inner radius 0)', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, pieModel({}), RECT, 1);
+    const { outer, inner } = ringRadii(rec.arcs);
+    expect(outer).toBeGreaterThan(0);
+    expect(inner).toBe(0);
+  });
+
+  it('doughnut holeSize sets the inner radius fraction of the outer radius', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, pieModel({ chartType: 'doughnut', holeSize: 60 }), RECT, 1);
+    const { outer, inner } = ringRadii(rec.arcs);
+    expect(inner).toBeGreaterThan(0);
+    // holeSize 60 → inner ≈ 0.60 × outer.
+    expect(inner / outer).toBeCloseTo(0.6, 2);
+  });
+
+  it('a smaller holeSize yields a smaller hole', () => {
+    const big = ringRecordingCtx();
+    const small = ringRecordingCtx();
+    renderChart(big.ctx, pieModel({ chartType: 'doughnut', holeSize: 80 }), RECT, 1);
+    renderChart(small.ctx, pieModel({ chartType: 'doughnut', holeSize: 20 }), RECT, 1);
+    expect(ringRadii(big.arcs).inner).toBeGreaterThan(ringRadii(small.arcs).inner);
+  });
+
+  it('firstSliceAngle rotates the first slice start clockwise from 12 o\'clock', () => {
+    const base = ringRecordingCtx();
+    const rot = ringRecordingCtx();
+    renderChart(base.ctx, pieModel({}), RECT, 1);
+    renderChart(rot.ctx, pieModel({ firstSliceAngle: 90 }), RECT, 1);
+    // The first wedge's start angle. Default 0 → -90° (canvas up = -π/2).
+    const startBase = base.arcs[0].a0;
+    const startRot = rot.arcs[0].a0;
+    expect(startBase).toBeCloseTo(-Math.PI / 2, 4);
+    // +90° → -π/2 + π/2 = 0 (3 o'clock).
+    expect(startRot).toBeCloseTo(0, 4);
+  });
+
+  it('a transparent hole is NOT overpainted with an opaque fill (doughnut)', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, pieModel({ chartType: 'doughnut', holeSize: 50 }), RECT, 1);
+    // Pre-CH8 drew a full 0..2π white circle to mask the wedge centers. The
+    // annular geometry removes it: no arc should be a full circle at the inner
+    // radius drawn with a white fill immediately after.
+    const fullCircles = rec.arcs.filter(a => Math.abs((a.a1 - a.a0) - Math.PI * 2) < 1e-6);
+    expect(fullCircles.length).toBe(0);
+  });
+
+  it('explosion offsets the slice center outward (arc center moves)', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, pieModel({
+      series: [series({
+        name: 'S',
+        values: [30, 45, 25],
+        dataPointOverrides: [{ idx: 1, explosion: 40 }],
+      })],
+    }), RECT, 1);
+    // Every wedge shares the pie center EXCEPT the exploded one, whose arc
+    // center is displaced. Collect the distinct arc centers.
+    const centers = new Set(rec.arcs.map(a => `${Math.round(a.x)},${Math.round(a.y)}`));
+    expect(centers.size).toBeGreaterThan(1);
+  });
+
+  it('a multi-series doughnut draws concentric rings (multiple distinct radii)', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'doughnut',
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'Outer', values: [1, 1] }),
+        series({ name: 'Inner', values: [1, 1] }),
+      ],
+      holeSize: 40,
+    }), RECT, 1);
+    // Two rings → at least three distinct radii (outer ring outer/inner + inner
+    // ring outer/inner, some shared) — assert more than the two a single ring
+    // would produce.
+    const distinctRadii = new Set(rec.arcs.map(a => Math.round(a.r * 10) / 10));
+    expect(distinctRadii.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it('rich pie dLbls compose showCatName + showPercent', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, pieModel({
+      series: [series({
+        name: 'S',
+        categories: ['Alpha', 'Beta', 'Gamma'],
+        values: [30, 45, 25],
+        seriesDataLabels: {
+          showVal: false, showCatName: true, showSerName: false, showPercent: true,
+        },
+      })],
+    }), RECT, 1);
+    const texts = rec.fontTexts.map(t => t.text);
+    // "Alpha 30%" etc. — category name and percent joined.
+    expect(texts.some(t => t.includes('Alpha') && t.includes('30%'))).toBe(true);
+  });
+});
+
+// ─── CH10 — chart text font faces ────────────────────────────────────────────
+
+describe('CH10 — chart text font faces', () => {
+  // No data labels: the only numeric text is then the value-axis ticks, so the
+  // `/^[\d.]+$/` filter isolates the value-axis font cleanly (data-label values
+  // legitimately use the SEPARATE dataLabelFontFace and would otherwise blur the
+  // assertion).
+  const barWithLabels = (over: Partial<ChartModel>): ChartModel =>
+    baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B'],
+      series: [series({ name: 'S', values: [10, 20] })],
+      valAxisTitle: 'Units',
+      ...over,
+    });
+
+  it('an explicit value-axis face is used for value-axis tick labels', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, barWithLabels({ valAxisFontFace: 'Georgia' }), RECT, 1);
+    // The value-axis ticks ("0", "5", …) are drawn with the Georgia family.
+    const tickFonts = rec.fontTexts.filter(t => /^[\d.]+$/.test(t.text)).map(t => t.font);
+    expect(tickFonts.some(f => f.includes('Georgia'))).toBe(true);
+  });
+
+  it('falls back to the theme body (minor) font when no element face is set', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, barWithLabels({ themeMinorFontLatin: 'Aptos Narrow' }), RECT, 1);
+    const tickFonts = rec.fontTexts.filter(t => /^[\d.]+$/.test(t.text)).map(t => t.font);
+    expect(tickFonts.some(f => f.includes('Aptos Narrow'))).toBe(true);
+  });
+
+  it('an element face wins over the theme font', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, barWithLabels({
+      valAxisFontFace: 'Georgia',
+      themeMinorFontLatin: 'Aptos Narrow',
+    }), RECT, 1);
+    const tickFonts = rec.fontTexts.filter(t => /^[\d.]+$/.test(t.text)).map(t => t.font);
+    expect(tickFonts.some(f => f.includes('Georgia'))).toBe(true);
+    expect(tickFonts.some(f => f.includes('Aptos Narrow'))).toBe(false);
+  });
+
+  it('with no face and no theme, the built-in sans-serif is used (byte-stable)', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, barWithLabels({}), RECT, 1);
+    const tickFonts = rec.fontTexts.filter(t => /^[\d.]+$/.test(t.text)).map(t => t.font);
+    expect(tickFonts.length).toBeGreaterThan(0);
+    expect(tickFonts.every(f => f.endsWith('sans-serif') && !f.includes('"'))).toBe(true);
+  });
+
+  it('a `+mn-lt` theme reference face resolves to the theme minor font', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, barWithLabels({
+      valAxisFontFace: '+mn-lt',
+      themeMinorFontLatin: 'Aptos Narrow',
+      themeMajorFontLatin: 'Aptos Display',
+    }), RECT, 1);
+    const tickFonts = rec.fontTexts.filter(t => /^[\d.]+$/.test(t.text)).map(t => t.font);
+    // "+mn-lt" must NOT appear literally; it resolves to the minor face.
+    expect(tickFonts.some(f => f.includes('Aptos Narrow'))).toBe(true);
+    expect(tickFonts.some(f => f.includes('+mn-lt'))).toBe(false);
+  });
+
+  it('axis titles use the theme heading (major) font as fallback', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, barWithLabels({ themeMajorFontLatin: 'Aptos Display' }), RECT, 1);
+    const titleFont = rec.fontTexts.find(t => t.text === 'Units')?.font;
+    expect(titleFont).toBeDefined();
+    expect(titleFont).toContain('Aptos Display');
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2219,8 +2219,12 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const ringBand = (outerR - innerR) / rings.length;
 
   // Explosion offset for slice `i` of series `ser`: move the slice out from the
-  // center by `explosion`% of the outer radius along its mid-angle. Absent /
-  // zero explosion → no offset (byte-stable).
+  // center along its mid-angle by `explosion`% of the outer radius. §21.2.2.61
+  // only defines `explosion` as an unbounded `xsd:unsignedInt` "amount the data
+  // point shall be moved from the center of the pie" — the 0-100-as-percent
+  // interpretation is a de-facto Office convention (the Point Explosion UI
+  // slider), not a spec-mandated range (see `ChartDataPointOverride.explosion`
+  // in types/chart.ts). Absent / zero explosion → no offset (byte-stable).
   const explodeOffset = (ser: ChartSeries, i: number): number => {
     const e = (ser.dataPointOverrides ?? []).find(d => d.idx === i)?.explosion ?? 0;
     return e > 0 ? (e / 100) * outerR : 0;

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -13,7 +13,7 @@ import {
   axisTitleMargin,
   type ChartLegendReserve,
 } from './layout.js';
-import { niceStep, valueAxisScale } from './axis-scale.js';
+import { niceStep, valueAxisScale, axisFraction, logAxisScale } from './axis-scale.js';
 import { axisLineWidthPx, resolveAxisLine, isCrossBetween } from './axis-style.js';
 import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 import { elideToWidth } from './text-elide.js';
@@ -465,6 +465,91 @@ function strokeValueGridlineH(
   ctx.stroke();
 }
 
+/** True when the value axis is reversed (`<c:valAx><c:scaling><c:orientation
+ *  val="maxMin">`, ECMA-376 §21.2.2.130). Absent/"minMax" ⇒ false (byte-stable). */
+function valAxisReversed(chart: ChartModel): boolean {
+  return chart.valAxisOrientation === 'maxMin';
+}
+
+/** True when the category axis is reversed (`<c:catAx>…orientation="maxMin">`). */
+function catAxisReversed(chart: ChartModel): boolean {
+  return chart.catAxisOrientation === 'maxMin';
+}
+
+/** Whether to draw value-axis MAJOR gridlines. Office writes `<c:majorGridlines>`
+ *  on the value axis by default, so the historical always-on behavior maps to
+ *  "draw unless the model explicitly says the element is absent". `undefined`
+ *  (parser didn't model it) ⇒ true (byte-stable); `false` (axis present without
+ *  the element) ⇒ off. */
+function drawValMajorGridlines(chart: ChartModel): boolean {
+  return chart.valAxisMajorGridlines !== false;
+}
+
+/** A resolved value-axis plan: rounded bounds, the major gridline VALUES to
+ *  stroke, an optional minor gridline VALUES list, and the value→fraction map
+ *  (0 at the axis min end, 1 at the max end — before any pixel flip). Centralizes
+ *  the CH6 major unit / logBase / orientation handling so every value-axis
+ *  family shares one spec-faithful code path. With no CH6 fields set the plan is
+ *  byte-identical to the old inline math: `step`/bounds from `valueAxisScale`,
+ *  `majorLines = [min, min+step, … max]`, `frac(v) = (v-min)/(max-min)`. */
+interface ValueAxisPlan {
+  min: number;
+  max: number;
+  step: number;
+  majorLines: number[];
+  minorLines: number[];
+  /** 0..1 position of `v` from the axis minimum toward the maximum (log-aware,
+   *  orientation-aware). Renderers turn this into a pixel with
+   *  `plotBottom - frac(v) * plotHeight` (vertical) — the reversal is already
+   *  baked in, so callers keep their existing `- frac*len` form. */
+  frac: (v: number) => number;
+}
+
+/** Build a {@link ValueAxisPlan} for the primary value axis. `dataMin`/`dataMax`
+ *  are the raw data extents already massaged by the caller (0-anchoring, pct
+ *  normalization, explicit valMin/valMax). `axisLenPt` drives the auto major
+ *  unit. Reversal is read from the chart's value-axis orientation. */
+function planValueAxis(
+  chart: ChartModel, dataMin: number, dataMax: number, axisLenPt?: number,
+): ValueAxisPlan {
+  const reversed = valAxisReversed(chart);
+  const logBase = chart.valAxisLogBase;
+  if (logBase != null && isFinite(logBase) && logBase >= 2) {
+    // Logarithmic axis (ECMA-376 §21.2.2.98): bounds snap to powers of the base,
+    // gridlines fall on those decades, values map in log space.
+    const { min, max, lines } = logAxisScale(dataMin, dataMax, logBase, chart.valMin, chart.valMax);
+    return {
+      min, max,
+      step: lines.length > 1 ? lines[1] - lines[0] : max - min,
+      majorLines: lines,
+      minorLines: [],
+      frac: (v: number) => axisFraction(v, min, max, { logBase, reversed }),
+    };
+  }
+  const { min, max, step } = valueAxisScale(
+    dataMin, dataMax, chart.valMin, chart.valMax, axisLenPt, chart.valAxisMajorUnit,
+  );
+  const range = (max - min) || 1;
+  const majorLines: number[] = [];
+  const steps = Math.round((max - min) / step);
+  for (let si = 0; si <= steps; si++) majorLines.push(min + si * step);
+  // Minor gridlines (ECMA-376 §21.2.2.109/§21.2.2.112): only when the file both
+  // declares `<c:minorGridlines>` AND a positive `<c:minorUnit>`; the minor lines
+  // between the majors are the interior multiples of the minor unit.
+  const minorLines: number[] = [];
+  const mu = chart.valAxisMinorUnit;
+  if (chart.valAxisMinorGridlines && mu != null && isFinite(mu) && mu > 0 && mu < step) {
+    for (let v = min + mu; v < max - 1e-9; v += mu) {
+      // Skip values that coincide with a major line.
+      if (Math.abs((v - min) / step - Math.round((v - min) / step)) > 1e-6) minorLines.push(v);
+    }
+  }
+  return {
+    min, max, step, majorLines, minorLines,
+    frac: (v: number) => (reversed ? 1 - (v - min) / range : (v - min) / range),
+  };
+}
+
 /** Resolve an axis label font size (px) from <c:txPr> hpt or a proportional
  *  fallback. ptToPx comes from the host renderer (EMU/px scale at display). */
 function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: number): number {
@@ -792,7 +877,10 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   if (chart.valMax != null) dataMax = chart.valMax;
   if (chart.valMin != null) dataMin = chart.valMin;
   if (dataMax === 0 && dataMin === 0) dataMax = 1;
-  const { min: axMin, max: axMax, step } = valueAxisScale(dataMin, dataMax, chart.valMin, chart.valMax, valAxisLenPt);
+  // `planValueAxis` folds in the CH6 major unit / logBase / orientation; with
+  // none set it is byte-identical to `valueAxisScale` + a linear map.
+  const plan = planValueAxis(chart, dataMin, dataMax, valAxisLenPt);
+  const { min: axMin, max: axMax, step } = plan;
 
   // Secondary value-axis scale (combo charts). INDEPENDENT of the primary: its
   // own "nice" major unit / gridline count. Its axis is the vertical right edge,
@@ -894,8 +982,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // mapping is unchanged. `valX`/`valY` give the on-axis pixel for a value on
   // the value axis (X for horizontal bars, Y for columns).
   const axRange = (axMax - axMin) || 1;
-  const valY = (v: number): number => py0 + ph - ((v - axMin) / axRange) * ph;
-  const valX = (v: number): number => px0 + ((v - axMin) / axRange) * pw;
+  const valY = (v: number): number => py0 + ph - plan.frac(v) * ph;
+  const valX = (v: number): number => px0 + plan.frac(v) * pw;
   const zeroY = valY(0); // column zero line
   const zeroX = valX(0); // horizontal-bar zero line
   const toYPrimaryLine = valY;
@@ -915,8 +1003,19 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   ctx.fillStyle = valLabelColor;
 
   if (!chart.valAxisHidden) {
-    for (let si = 0; si <= steps; si++) {
-      const val = axMin + si * step;
+    // Minor gridlines (under the majors) when the file declares them.
+    for (const val of plan.minorLines) {
+      if (!isH) {
+        strokeValueGridlineH(ctx, px0, pw, valY(val), false);
+      } else {
+        const gx = valX(val);
+        ctx.strokeStyle = gridColor; ctx.lineWidth = 0.5;
+        ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
+      }
+    }
+    const drawMajorGrid = drawValMajorGridlines(chart);
+    const drawLabels = chart.valAxisTickLabelPos !== 'none';
+    for (const val of plan.majorLines) {
       // The zero line is the emphasized gridline (`si === 0` was that line only
       // while the axis was anchored at 0; with a negative minimum it moves up).
       const isZero = Math.abs(val) < step * 1e-9;
@@ -925,16 +1024,22 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         : formatChartValWithCode(val, chart.valAxisFormatCode, chart.date1904);
       if (!isH) {
         const gy = valY(val);
-        strokeValueGridlineH(ctx, px0, pw, gy, isZero);
-        ctx.textAlign = 'right';
-        ctx.fillText(label, px0 - 12, gy);
+        if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, isZero);
+        if (drawLabels) {
+          ctx.textAlign = 'right';
+          ctx.fillText(label, px0 - 12, gy);
+        }
       } else {
         const gx = valX(val);
-        ctx.strokeStyle = isZero ? '#aaa' : gridColor;
-        ctx.lineWidth = isZero ? 1 : 0.5;
-        ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
-        ctx.textAlign = 'center';
-        ctx.fillText(label, gx, py0 + ph + 10);
+        if (drawMajorGrid) {
+          ctx.strokeStyle = isZero ? '#aaa' : gridColor;
+          ctx.lineWidth = isZero ? 1 : 0.5;
+          ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
+        }
+        if (drawLabels) {
+          ctx.textAlign = 'center';
+          ctx.fillText(label, gx, py0 + ph + 10);
+        }
       }
     }
   }
@@ -1405,18 +1510,25 @@ function renderLineChart(
     }
   }
   if (!isFinite(dataMin)) { dataMin = 0; dataMax = 1; }
+  // A log axis can't anchor at 0 (log undefined) — keep the positive data
+  // minimum so `logAxisScale` can floor it to a decade. Linear axes keep the
+  // historical 0-anchor for positive data (byte-stable).
+  const isLogAxis = chart.valAxisLogBase != null && chart.valAxisLogBase >= 2;
   if (chart.valMin != null) dataMin = chart.valMin;
-  else if (dataMin > 0) dataMin = 0;
+  else if (dataMin > 0 && !isLogAxis) dataMin = 0;
   if (chart.valMax != null) dataMax = chart.valMax;
   else if (dataMax < 0) dataMax = 0;
   if (dataMax === dataMin) dataMax = dataMin + 1;
 
   // Value axis is vertical → its length is the plot height (axis-length-aware
-  // auto major unit, same model as the bar/column renderer).
-  const { min: axMin, max: axMax, step } = valueAxisScale(dataMin, dataMax, chart.valMin, chart.valMax, ph / ptToPx);
-  const range = axMax - axMin; if (range === 0) return;
+  // auto major unit, same model as the bar/column renderer). `planValueAxis`
+  // folds in the CH6 major unit / logBase / orientation; with none set it is
+  // byte-identical to the old `valueAxisScale` + linear `toY`.
+  const plan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx);
+  const { min: axMin, max: axMax, step } = plan;
+  if (axMax - axMin === 0) return;
 
-  const toY = (v: number) => py0 + ph - ((v - axMin) / range) * ph;
+  const toY = (v: number) => py0 + ph - plan.frac(v) * ph;
   // Secondary series map through their own scale; `secScale` is null on the
   // common single-axis path so `yMapFor` always returns the primary `toY`.
   const toYSecondary = secScale ? secScale.makeToY(py0, ph) : toY;
@@ -1430,17 +1542,22 @@ function renderLineChart(
     : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
 
   if (!chart.valAxisHidden) {
-    const steps = Math.round((axMax - axMin) / step);
     ctx.font = `${valAxFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     ctx.textBaseline = 'middle';
-    for (let si = 0; si <= steps; si++) {
-      const v = axMin + si * step;
+    // Minor gridlines first (under the majors), then major gridlines + ticks +
+    // labels. Minor lines are only populated when the file declares them.
+    for (const v of plan.minorLines) strokeValueGridlineH(ctx, px0, pw, toY(v), false);
+    const drawMajorGrid = drawValMajorGridlines(chart);
+    const drawLabels = chart.valAxisTickLabelPos !== 'none';
+    for (const v of plan.majorLines) {
       const gy = toY(v);
-      strokeValueGridlineH(ctx, px0, pw, gy, v === 0);
+      if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, v === 0);
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy);
-      ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
-      ctx.textAlign = 'right';
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
+      if (drawLabels) {
+        ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
+        ctx.textAlign = 'right';
+        ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
+      }
     }
   }
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -557,6 +557,43 @@ function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: numb
   return Math.max(8, h * 0.045);
 }
 
+/** Whether the CATEGORY tick labels should be drawn. `<c:catAx><c:tickLblPos
+ *  val="none">` (ECMA-376 §21.2.2.207) hides them; anything else (incl. absent)
+ *  shows them, so the default is byte-stable. */
+function catLabelsVisible(chart: ChartModel): boolean {
+  return chart.catAxisTickLabelPos !== 'none';
+}
+
+/** Category-axis label rotation in RADIANS (canvas convention), from
+ *  `<c:catAx><c:txPr><a:bodyPr rot>` (DrawingML `ST_Angle`, 60000ths of a
+ *  degree). Returns 0 when unset — the un-rotated fast path callers keep. */
+function catLabelRotationRad(chart: ChartModel): number {
+  const rot = chart.catAxisLabelRotation;
+  if (rot == null || rot === 0) return 0;
+  return (rot / 60000) * (Math.PI / 180);
+}
+
+/** Draw a category label at `(x, y)` with optional rotation. `rotRad === 0`
+ *  keeps the exact non-rotated draw the callers used before (byte-stable):
+ *  `ctx.fillText(text, x, y)` with the caller's current align/baseline. When
+ *  rotated, the label pivots around `(x, y)` and is right-aligned+middle so the
+ *  text trails up-left from the tick, matching PowerPoint's angled axis labels. */
+function drawRotatedCatLabel(
+  ctx: CanvasRenderingContext2D, text: string, x: number, y: number, rotRad: number,
+): void {
+  if (rotRad === 0) {
+    ctx.fillText(text, x, y);
+    return;
+  }
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.rotate(rotRad);
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, 0, 0);
+  ctx.restore();
+}
+
 /** Resolved secondary value-axis scale (combo charts). `min`/`max`/`step` are
  *  the "nice" bounds + major unit; `makeToY(py0, ph)` builds the value→pixel
  *  mapping once the final plot rect is known (the scale is computed BEFORE the
@@ -1241,7 +1278,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     }
   }
 
-  if (!chart.catAxisHidden) {
+  if (!chart.catAxisHidden && catLabelsVisible(chart)) {
     // `<c:catAx><c:txPr>…<a:solidFill>` colors the category tick labels (e.g.
     // sample-2 slide-16's "2025年3月期" labels are `bg1 lumMod 75%` gray).
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
@@ -1252,6 +1289,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     // band and the plot edge, so cap it at that band width.
     const catSlotMaxPx = catGap - 4;
     const horizLabelMaxPx = (px0 - 4) - (x + legLeftW + valTitleW);
+    // `<c:catAx><c:txPr><a:bodyPr rot>` rotates the column labels (0 = flat).
+    const rotRad = catLabelRotationRad(chart);
     for (let ci = 0; ci < n; ci++) {
       // §21.2.2.71: a category-axis numFmt formats numeric-serial categories
       // (e.g. dateAx serials → real dates). No-op for string categories.
@@ -1259,7 +1298,10 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       if (!isH) {
         const lx = px0 + ci * catGap + catGap / 2;
         ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-        ctx.fillText(elideToWidth(ctx, raw, catSlotMaxPx), lx, py0 + ph + 3);
+        // Rotation elides against a longer diagonal budget; unrotated keeps the
+        // slot width and the byte-stable `fillText(text, x, y)` path.
+        const budget = rotRad === 0 ? catSlotMaxPx : ph * 0.4;
+        drawRotatedCatLabel(ctx, elideToWidth(ctx, raw, budget), lx, py0 + ph + 3, rotRad);
       } else {
         const ly = py0 + (n - 1 - ci) * catGap + catGap / 2;
         ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
@@ -1681,14 +1723,19 @@ function renderLineChart(
     // Only every `labelInterval`-th category is drawn, so the horizontal room a
     // centered label owns is the spacing between two drawn labels: (pw/n)·interval.
     const catSlotMaxPx = (pw / n) * labelInterval - 4;
+    // Ticks are still drawn under `tickLblPos="none"`; only the labels drop.
+    const showLabels = catLabelsVisible(chart);
+    const rotRad = catLabelRotationRad(chart);
     for (let ci = 0; ci < n; ci += labelInterval) {
       const tx = toX(ci);
       drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx);
+      if (!showLabels) continue;
       ctx.fillStyle = catLabelColor;
       // §21.2.2.71: format numeric-serial categories (e.g. dateAx) via the
       // category-axis numFmt; string categories pass through unchanged.
       const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
-      ctx.fillText(elideToWidth(ctx, label, catSlotMaxPx), tx, py0 + ph + 5);
+      const budget = rotRad === 0 ? catSlotMaxPx : ph * 0.4;
+      drawRotatedCatLabel(ctx, elideToWidth(ctx, label, budget), tx, py0 + ph + 5, rotRad);
     }
   }
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -13,7 +13,7 @@ import {
   axisTitleMargin,
   type ChartLegendReserve,
 } from './layout.js';
-import { niceStep, valueAxisScale, axisFraction, logAxisScale } from './axis-scale.js';
+import { niceStep, valueAxisScale, axisFraction, logAxisScale, fitTrendline } from './axis-scale.js';
 import { axisLineWidthPx, resolveAxisLine, isCrossBetween } from './axis-style.js';
 import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 import { elideToWidth } from './text-elide.js';
@@ -548,6 +548,60 @@ function planValueAxis(
     min, max, step, majorLines, minorLines,
     frac: (v: number) => (reversed ? 1 - (v - min) / range : (v - min) / range),
   };
+}
+
+/** Draw a series' `<c:trendline>` regression lines (ECMA-376 §21.2.2.211).
+ *  Each trendline is fitted over the series' non-null `(categoryIndex, value)`
+ *  points via {@link fitTrendline} and stroked (dashed) through the chart's
+ *  `toX` (category-index → pixel) and `toY` (value → pixel) maps. `forward` /
+ *  `backward` extend the linear fit past the data ends by that many category
+ *  units. Unsupported types (exp/log/power/poly) fit to nothing and draw
+ *  nothing. `seriesColor` is the fallback stroke when the trendline declares no
+ *  `<a:ln>` color. Byte-stable no-op for series with no trendline. */
+function drawSeriesTrendlines(
+  ctx: CanvasRenderingContext2D,
+  s: ChartSeries,
+  seriesColor: string,
+  toX: (i: number) => number,
+  toY: (v: number) => number,
+  ptToPx: number,
+): void {
+  const tls = s.trendLines;
+  if (!tls || tls.length === 0) return;
+  // Collect the fittable (index, value) points once.
+  const xs: number[] = []; const ys: number[] = [];
+  for (let i = 0; i < s.values.length; i++) {
+    const v = s.values[i];
+    if (v != null) { xs.push(i); ys.push(v); }
+  }
+  if (xs.length < 2) return;
+  const prevDash = ctx.getLineDash ? ctx.getLineDash() : [];
+  for (const tl of tls) {
+    const fit = fitTrendline(xs, ys, tl.trendlineType, {
+      period: tl.period, intercept: tl.intercept,
+    });
+    if (fit.xs.length < 2) continue;
+    // For a linear fit, forward/backward extend the two endpoints along the
+    // fitted slope (in category-index units).
+    let fxs = fit.xs; let fys = fit.ys;
+    if (tl.trendlineType === 'linear') {
+      const m = (fit.ys[1] - fit.ys[0]) / ((fit.xs[1] - fit.xs[0]) || 1);
+      const bwd = tl.backward ?? 0; const fwd = tl.forward ?? 0;
+      const x0 = fit.xs[0] - bwd; const x1 = fit.xs[1] + fwd;
+      fxs = [x0, x1];
+      fys = [fit.ys[0] - m * bwd, fit.ys[1] + m * fwd];
+    }
+    ctx.strokeStyle = tl.lineColor ? `#${tl.lineColor}` : seriesColor;
+    ctx.lineWidth = tl.lineWidthEmu ? axisLineWidthPx(tl.lineWidthEmu, ptToPx) : 1.5;
+    ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    for (let i = 0; i < fxs.length; i++) {
+      const px = toX(fxs[i]); const py = toY(fys[i]);
+      if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+  }
+  ctx.setLineDash(prevDash);
 }
 
 /** Resolve an axis label font size (px) from <c:txPr> hpt or a proportional
@@ -1338,6 +1392,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
           ctx.beginPath(); ctx.arc(lx, ly, 3, 0, Math.PI * 2); ctx.fill();
         }
       }
+      // Trendlines (`<c:trendline>`, §21.2.2.211) for the combo line series.
+      drawSeriesTrendlines(ctx, s, color, (i) => px0 + i * catGap + catGap / 2, yOf, ptToPx);
     }
   }
 
@@ -1567,8 +1623,7 @@ function renderLineChart(
   // folds in the CH6 major unit / logBase / orientation; with none set it is
   // byte-identical to the old `valueAxisScale` + linear `toY`.
   const plan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx);
-  const { min: axMin, max: axMax, step } = plan;
-  if (axMax - axMin === 0) return;
+  if (plan.max - plan.min === 0) return;
 
   const toY = (v: number) => py0 + ph - plan.frac(v) * ph;
   // Secondary series map through their own scale; `secScale` is null on the
@@ -1578,10 +1633,12 @@ function renderLineChart(
     isSecondarySeries(s) ? toYSecondary : toY;
   // crossBetween="between" (default) insets the first/last category by half a
   // step so points aren't flush against the axes. "midCat" anchors them.
+  // A `maxMin` category orientation (§21.2.2.130) mirrors the index left↔right.
   const between = isCrossBetween(chart);
+  const catRev = catAxisReversed(chart);
   const toX = between
-    ? (i: number) => px0 + ((i + 0.5) / n) * pw
-    : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
+    ? (i0: number) => { const i = catRev ? n - 1 - i0 : i0; return px0 + ((i + 0.5) / n) * pw; }
+    : (i0: number) => { const i = catRev ? n - 1 - i0 : i0; return px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw); };
 
   if (!chart.valAxisHidden) {
     ctx.font = `${valAxFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
@@ -1713,6 +1770,11 @@ function renderLineChart(
         ctx.fillStyle = color;
       }
     }
+
+    // Trendlines (`<c:trendline>`, §21.2.2.211) over this series' points —
+    // drawn on top of the line/markers, dashed, in the series color unless the
+    // trendline declares its own `<a:ln>`.
+    drawSeriesTrendlines(ctx, s, color, toX, yOf, ptToPx);
   }
 
   if (!chart.catAxisHidden) {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3,7 +3,7 @@
 // scatter, waterfall). Ported from the xlsx implementation with pptx
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
-import type { ChartModel, ChartRect, ChartSeries, SecondaryValueAxis } from '../types/chart';
+import type { ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, SecondaryValueAxis } from '../types/chart';
 import {
   computeChartFrame,
   chartTitleBand,
@@ -36,6 +36,40 @@ function pieSliceColor(idx: number, series: ChartSeries): string {
   const override = series.dataPointColors?.[idx];
   if (override) return `#${override}`;
   return `#${CHART_PALETTE[idx % CHART_PALETTE.length]}`;
+}
+
+// ─── Font-face resolution (CH10) ─────────────────────────────────────────────
+// Chart text elements draw with, in priority order: the element's own
+// `<a:latin typeface>` (from its `<c:txPr>`), else the theme font-scheme face
+// (heading `majorFont` for titles, body `minorFont` for tick labels / data
+// labels / legend, ECMA-376 §20.1.4.2), else the built-in `sans-serif`. When
+// neither a per-element face nor a theme face is present the result is exactly
+// `sans-serif`, so charts that specify no faces render byte-identically to
+// before. A resolved face is quoted and given the same Calibri/Arial fallback
+// chain as the chart title, so a font the platform lacks still degrades to a
+// sans-serif rather than a serif default.
+type ChartFontRole = 'major' | 'minor';
+
+/** Resolve a DrawingML theme font-scheme reference (`+mj-lt` / `+mn-lt` etc.,
+ *  ECMA-376 §20.1.4.1.16) to the concrete theme face. `+mj-*` = heading
+ *  (majorFont), `+mn-*` = body (minorFont); the axis suffix (`-lt`/`-ea`/`-cs`)
+ *  is ignored here — chart text is Latin. A non-reference face passes through.
+ *  Returns null when a reference can't be resolved (theme not threaded). */
+function resolveThemeFontRef(chart: ChartModel, face: string | null | undefined): string | null | undefined {
+  if (!face) return face;
+  if (face.startsWith('+mj')) return chart.themeMajorFontLatin ?? null;
+  if (face.startsWith('+mn')) return chart.themeMinorFontLatin ?? null;
+  return face;
+}
+
+function chartFontFamily(
+  chart: ChartModel,
+  elementFace: string | null | undefined,
+  role: ChartFontRole,
+): string {
+  const themeFace = role === 'major' ? chart.themeMajorFontLatin : chart.themeMinorFontLatin;
+  const face = resolveThemeFontRef(chart, elementFace) ?? themeFace;
+  return face ? `"${face}", Calibri, Arial, sans-serif` : 'sans-serif';
 }
 
 /** Chart types whose legend lists one entry per category (data point of the
@@ -89,9 +123,11 @@ function drawAxisTitle(
   // plot height for the rotated val title). Titles longer than the axis are
   // elided with an ellipsis rather than hard-cut at a fixed char count.
   maxPx: number,
+  // Resolved CSS font-family (element face ?? theme heading ?? sans-serif).
+  fontFamily = 'sans-serif',
 ): void {
   ctx.save();
-  ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px sans-serif`;
+  ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px ${fontFamily}`;
   ctx.fillStyle = color;
   const label = elideToWidth(ctx, text, maxPx);
   if (axis === 'cat') {
@@ -138,7 +174,7 @@ function drawAxisTitles(
     drawAxisTitle(
       ctx, chart.valAxisTitle, anchorX, anchorY, 'val',
       valTitlePx, chart.valAxisTitleFontBold ?? true, axisTitleColor(chart.valAxisTitleFontColor),
-      ph,
+      ph, chartFontFamily(chart, chart.valAxisTitleFontFace, 'major'),
     );
   }
   if (chart.catAxisTitle) {
@@ -148,7 +184,7 @@ function drawAxisTitles(
     drawAxisTitle(
       ctx, chart.catAxisTitle, anchorX, anchorY, 'cat',
       catTitlePx, chart.catAxisTitleFontBold ?? true, axisTitleColor(chart.catAxisTitleFontColor),
-      pw,
+      pw, chartFontFamily(chart, chart.catAxisTitleFontFace, 'major'),
     );
   }
 }
@@ -220,20 +256,40 @@ function buildLegendEntries(series: ChartSeries[], chartType: string | undefined
   }));
 }
 
+/** Resolved legend text styling (CH10). All optional so the default (no
+ *  `<c:legend><c:txPr>`) reproduces the historical `sans-serif` / `#333`
+ *  legend byte-for-byte. `fontFamily` already carries the theme-body fallback;
+ *  `sizePx` overrides the proportional size only when the file set one. */
+interface LegendTextStyle {
+  fontFamily: string;
+  color: string;
+  bold: boolean;
+  sizePx: number | null;
+}
+
+const DEFAULT_LEGEND_STYLE: LegendTextStyle = {
+  fontFamily: 'sans-serif',
+  color: '#333',
+  bold: false,
+  sizePx: null,
+};
+
 function drawLegend(
   ctx: CanvasRenderingContext2D,
   series: ChartSeries[],
   lx: number, ly: number, lw: number, lh: number,
   orient: 'vertical' | 'horizontal' = 'vertical',
   chartType?: string,
+  style: LegendTextStyle = DEFAULT_LEGEND_STYLE,
 ): void {
   const sw = 10; const gap = 4;
   const swatchStyle = legendSwatchStyle(chartType);
   const entries = buildLegendEntries(series, chartType);
+  const boldPrefix = style.bold ? 'bold ' : '';
   if (orient === 'horizontal') {
     // Excel lays a bottom/top legend as a single horizontal row, centered.
-    const fontSize = Math.max(9, Math.min(12, lh * 0.7));
-    ctx.font = `${fontSize}px sans-serif`;
+    const fontSize = style.sizePx ?? Math.max(9, Math.min(12, lh * 0.7));
+    ctx.font = `${boldPrefix}${fontSize}px ${style.fontFamily}`;
     ctx.textBaseline = 'middle';
     const itemGap = 12;
     // Cap each entry's text at the full legend strip (minus its own swatch+gap)
@@ -252,14 +308,14 @@ function drawLegend(
     const ry = ly + lh / 2;
     for (let i = 0; i < entries.length; i++) {
       drawLegendSwatch(ctx, swatchStyle, entries[i].color, rx, ry - fontSize / 2, sw, fontSize);
-      ctx.fillStyle = '#333'; ctx.textAlign = 'left';
+      ctx.fillStyle = style.color; ctx.textAlign = 'left';
       ctx.fillText(labels[i], rx + sw + gap, ry);
       rx += itemWidths[i] + itemGap;
     }
     return;
   }
-  const fontSize = Math.max(9, Math.min(12, lh / (entries.length + 1)));
-  ctx.font = `${fontSize}px sans-serif`;
+  const fontSize = style.sizePx ?? Math.max(9, Math.min(12, lh / (entries.length + 1)));
+  ctx.font = `${boldPrefix}${fontSize}px ${style.fontFamily}`;
   ctx.textBaseline = 'middle';
   const rowH = fontSize + 4;
   // Vertical legend: each label runs from just after the swatch to the right
@@ -268,10 +324,23 @@ function drawLegend(
   let ry = ly + (lh - rowH * entries.length) / 2;
   for (let i = 0; i < entries.length; i++) {
     drawLegendSwatch(ctx, swatchStyle, entries[i].color, lx, ry, sw, fontSize);
-    ctx.fillStyle = '#333'; ctx.textAlign = 'left';
+    ctx.fillStyle = style.color; ctx.textAlign = 'left';
     ctx.fillText(elideToWidth(ctx, entries[i].label, maxTextPx), lx + sw + gap, ry + fontSize / 2);
     ry += rowH;
   }
+}
+
+/** Build the resolved legend text style for a chart (CH10). Absent legend
+ *  `<c:txPr>` fields fall back to the historical defaults, keeping legends
+ *  byte-stable for files that style nothing. */
+function legendTextStyle(chart: ChartModel): LegendTextStyle {
+  const face = resolveThemeFontRef(chart, chart.legendFontFace) ?? chart.themeMinorFontLatin;
+  return {
+    fontFamily: face ? `"${face}", Calibri, Arial, sans-serif` : 'sans-serif',
+    color: chart.legendFontColor ? `#${chart.legendFontColor}` : '#333',
+    bold: chart.legendFontBold ?? false,
+    sizePx: chart.legendFontSizeHpt != null ? chart.legendFontSizeHpt / 100 : null,
+  };
 }
 
 // Legend placement is resolved by `chartLegendReserve` (layout.ts). This alias
@@ -289,6 +358,7 @@ function drawLegendForLayout(
   topBand: number,
 ): void {
   if (!leg) return;
+  const legStyle = legendTextStyle(chart);
   // `<c:legend><c:manualLayout>` (§21.2.2.31) wins over the default side-based
   // rectangle. We honor the `edge` placement mode — fractions are measured
   // from the top-left of the chart space — which matches what Excel's built-in
@@ -304,21 +374,21 @@ function drawLegendForLayout(
     // when on left/right. A manual box wider than tall implies horizontal —
     // matches Excel's one-row legend rendering for top/bottom manual layouts.
     const orient = lw >= lh ? 'horizontal' : 'vertical';
-    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType);
+    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType, legStyle);
     return;
   }
   switch (leg.side) {
     case 'r':
-      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType);
+      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle);
       break;
     case 'l':
-      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType);
+      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle);
       break;
     case 't':
-      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType);
+      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle);
       break;
     case 'b':
-      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType);
+      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle);
       break;
   }
 }
@@ -522,7 +592,11 @@ function drawChartTitle(
   x: number, y: number, w: number, fontSize: number,
 ): void {
   if (!chart.title) return;
-  const face = chart.titleFontFace ? `"${chart.titleFontFace}", Calibri, Arial, sans-serif` : 'Calibri, Arial, sans-serif';
+  // Resolve a theme-scheme reference (`+mj-lt` / `+mn-lt`) title face; a
+  // concrete face passes through. When no face is set, keep the historical
+  // Calibri/Arial default chain (byte-stable for charts without a title face).
+  const titleFace = resolveThemeFontRef(chart, chart.titleFontFace);
+  const face = titleFace ? `"${titleFace}", Calibri, Arial, sans-serif` : 'Calibri, Arial, sans-serif';
   ctx.font = `${(chart.titleFontBold ?? true) ? 'bold ' : ''}${fontSize}px ${face}`;
   ctx.fillStyle = chart.titleFontColor ? `#${chart.titleFontColor}` : '#333';
   ctx.textAlign = 'center';
@@ -737,7 +811,9 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // wider left band for the category labels).
   let valLabelBandW = 0;
   if (!isH && !chart.valAxisHidden) {
-    ctx.font = `${tickFontPx}px sans-serif`;
+    // Measure with the same face the value-axis ticks draw with (below), so the
+    // reserved gutter width matches the painted labels when a real face is set.
+    ctx.font = `${tickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     let wmax = 0;
     const vSteps = Math.round((axMax - axMin) / step);
     for (let si = 0; si <= vSteps; si++) {
@@ -832,7 +908,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const gridColor = '#e0e0e0';
   const steps = Math.round(axRange / step);
   ctx.textBaseline = 'middle';
-  ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+  ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
   // Honor `<c:valAx><c:txPr>…<a:solidFill>` when present (ECMA-376 §21.2.2.*);
   // otherwise keep the neutral gray default.
   const valLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
@@ -993,7 +1069,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
           const lsz = chart.dataLabelFontSizeHpt
             ? (chart.dataLabelFontSizeHpt / 100) * ptToPx
             : Math.max(7, Math.min(11, barW * 0.6));
-          ctx.font = `bold ${lsz}px sans-serif`;
+          ctx.font = `bold ${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
           const text = pct
             ? `${Math.round(sv)}%`
             : formatChartValWithCode(
@@ -1036,7 +1112,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
           const lsz = chart.dataLabelFontSizeHpt
             ? (chart.dataLabelFontSizeHpt / 100) * ptToPx
             : Math.max(7, Math.min(11, barW * 0.6));
-          ctx.font = `bold ${lsz}px sans-serif`;
+          ctx.font = `bold ${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
           const text = pct
             ? `${Math.round(sv)}%`
             : formatChartValWithCode(
@@ -1064,7 +1140,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     // `<c:catAx><c:txPr>…<a:solidFill>` colors the category tick labels (e.g.
     // sample-2 slide-16's "2025年3月期" labels are `bg1 lumMod 75%` gray).
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
-    ctx.font = `${Math.max(8, Math.min(11, catGap * 0.5))}px sans-serif`;
+    ctx.font = `${Math.max(8, Math.min(11, catGap * 0.5))}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
     // Column: each label is centered in a category slot of width `catGap`, so
     // cap it just under that so neighbours don't collide. Horizontal bars: the
     // label sits right-aligned in the left gutter between the val-title/legend
@@ -1355,7 +1431,7 @@ function renderLineChart(
 
   if (!chart.valAxisHidden) {
     const steps = Math.round((axMax - axMin) / step);
-    ctx.font = `${valAxFontPx}px sans-serif`;
+    ctx.font = `${valAxFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     ctx.textBaseline = 'middle';
     for (let si = 0; si <= steps; si++) {
       const v = axMin + si * step;
@@ -1448,6 +1524,7 @@ function renderLineChart(
       // plotted null (a stacked sum already reads null as 0), and unstacked
       // "zero" mode plots the null at 0 — both cases get a label too.
       stacked || dispBlanks === 'zero',
+      chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
     );
     if (perPointLabels) ctx.fillStyle = color;
     for (let ci = 0; ci < n; ci++) {
@@ -1470,7 +1547,7 @@ function renderLineChart(
         }
       }
       if (chart.showDataLabels && !perPointLabels) {
-        ctx.font = `${dataLabelPx}px sans-serif`;
+        ctx.font = `${dataLabelPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
         ctx.fillStyle = '#333'; ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
         const labelOffset = drawMarkers ? markerR + 1 : 2;
         ctx.fillText(formatChartVal(pv), toX(ci), yOf(pv) - labelOffset);
@@ -1483,7 +1560,7 @@ function renderLineChart(
     const labelInterval = Math.max(1, Math.ceil(n / 8));
     const catLabelColor = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.fillStyle = catLabelColor; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-    ctx.font = `${catAxFontPx}px sans-serif`;
+    ctx.font = `${catAxFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
     // Only every `labelInterval`-th category is drawn, so the horizontal room a
     // centered label owns is the spacing between two drawn labels: (pw/n)·interval.
     const catSlotMaxPx = (pw / n) * labelInterval - 4;
@@ -1778,12 +1855,13 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       // from before this parameter existed).
       drawCategoryDataLabels(
         ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false, true,
+        chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
       );
     }
   }
 
   if (!chart.valAxisHidden) {
-    ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px sans-serif`;
+    ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     ctx.textBaseline = 'middle';
     const steps = Math.round(axMax / step);
     for (let si = 0; si <= steps; si++) {
@@ -1824,7 +1902,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   if (!chart.catAxisHidden) {
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-    ctx.font = `${Math.max(8, Math.min(11, pw / n * 0.8))}px sans-serif`;
+    ctx.font = `${Math.max(8, Math.min(11, pw / n * 0.8))}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
     // Show every category label that fits; thin out only when adjacent labels
     // would collide (so 12 months all render, unlike a fixed n/8 cap). Measure
     // each label's real full width (the previous slice(0,10) under-measured wide
@@ -1892,37 +1970,100 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const cx2 = frame.center.cx;
   const cy2 = frame.center.cy;
   const outerR = Math.min(pw, ph) * 0.42;
-  const innerR = isDoughnut ? outerR * 0.5 : 0;
 
-  let angle = -Math.PI / 2;
-  for (let i = 0; i < vals.length; i++) {
-    const slice = (vals[i] / total) * Math.PI * 2;
-    const color = pieSliceColor(i, s);
-    ctx.beginPath();
-    ctx.moveTo(cx2, cy2);
-    ctx.arc(cx2, cy2, outerR, angle, angle + slice);
-    ctx.closePath();
-    ctx.fillStyle = color; ctx.fill();
-    ctx.strokeStyle = '#fff'; ctx.lineWidth = 1; ctx.stroke();
+  // §21.2.2.52 firstSliceAng: the first slice begins `firstSliceAngle` degrees
+  // clockwise from 12 o'clock. Canvas 0 rad points right (+x) and its angles
+  // grow clockwise (y-down), so 12 o'clock is −90°. Default 0 keeps the
+  // historical −90° start (byte-stable for files without the element).
+  const startAngle = -Math.PI / 2 + ((chart.firstSliceAngle ?? 0) * Math.PI) / 180;
 
-    if (chart.showDataLabels && slice > 0.15) {
+  // §21.2.2.60 holeSize (doughnut only): hole diameter as 1–90% of the outer
+  // diameter. The ECMA schema default is 10%, but a real doughnut always writes
+  // an explicit holeSize (Office emits 50–75%); 50% is the historical inner
+  // radius, so an absent holeSize keeps the prior look (byte-stable). Pie has
+  // no hole (innerR = 0).
+  const holePct = isDoughnut ? Math.max(1, Math.min(90, chart.holeSize ?? 50)) : 0;
+
+  // Concentric rings. Doughnut plots EVERY series as a ring (outermost =
+  // series[0]); pie plots only series[0]. The band from the hole radius to the
+  // outer radius is split evenly across the rings. A single-series doughnut is
+  // byte-identical to the prior single-ring geometry.
+  const rings = isDoughnut ? chart.series : [s];
+  const innerR = outerR * (holePct / 100);
+  const ringBand = (outerR - innerR) / rings.length;
+
+  // Explosion offset for slice `i` of series `ser`: move the slice out from the
+  // center by `explosion`% of the outer radius along its mid-angle. Absent /
+  // zero explosion → no offset (byte-stable).
+  const explodeOffset = (ser: ChartSeries, i: number): number => {
+    const e = (ser.dataPointOverrides ?? []).find(d => d.idx === i)?.explosion ?? 0;
+    return e > 0 ? (e / 100) * outerR : 0;
+  };
+
+  // The legacy `showDataLabels` percent label (drawn INLINE per slice on the
+  // outer ring, exactly as before) is used only when the series has no rich
+  // `<c:dLbls>` definition; the rich labels are drawn in a separate pass after
+  // all slices. Keeping the legacy path inline preserves the historical
+  // draw-call order for a plain pie/doughnut (byte-stable).
+  const richDef = s.seriesDataLabels;
+  const hasRichLabels = richDef != null &&
+    (richDef.showVal || richDef.showCatName || richDef.showSerName || richDef.showPercent);
+  const legacyLabels = chart.showDataLabels && !hasRichLabels;
+  const dLblFont = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
+
+  for (let ring = 0; ring < rings.length; ring++) {
+    const rs = rings[ring];
+    const rVals = rs.values.map(v => Math.abs(v ?? 0));
+    const rTotal = rVals.reduce((a, b) => a + b, 0);
+    if (rTotal === 0) continue;
+    // Ring 0 is the OUTERMOST band; deeper rings step inward toward the hole.
+    const rOuter = outerR - ring * ringBand;
+    const rInner = rOuter - ringBand;
+
+    let angle = startAngle;
+    for (let i = 0; i < rVals.length; i++) {
+      const slice = (rVals[i] / rTotal) * Math.PI * 2;
+      const color = pieSliceColor(i, rs);
       const midAngle = angle + slice / 2;
-      const labelR = outerR * (isDoughnut ? 0.75 : 0.6);
-      const lx2 = cx2 + Math.cos(midAngle) * labelR;
-      const ly2 = cy2 + Math.sin(midAngle) * labelR;
-      const pct2 = Math.round((vals[i] / total) * 100);
-      const lsz = Math.max(8, outerR * 0.1);
-      ctx.font = `bold ${lsz}px sans-serif`;
-      ctx.fillStyle = '#fff'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      ctx.fillText(`${pct2}%`, lx2, ly2);
-    }
+      const off = explodeOffset(rs, i);
+      const ox = off > 0 ? Math.cos(midAngle) * off : 0;
+      const oy = off > 0 ? Math.sin(midAngle) * off : 0;
+      ctx.beginPath();
+      if (rInner > 0.01) {
+        // Annular slice (doughnut ring): outer arc CW, inner arc CCW.
+        ctx.arc(cx2 + ox, cy2 + oy, rOuter, angle, angle + slice);
+        ctx.arc(cx2 + ox, cy2 + oy, rInner, angle + slice, angle, true);
+      } else {
+        // Solid wedge (pie, or the innermost pie-like ring).
+        ctx.moveTo(cx2 + ox, cy2 + oy);
+        ctx.arc(cx2 + ox, cy2 + oy, rOuter, angle, angle + slice);
+      }
+      ctx.closePath();
+      ctx.fillStyle = color; ctx.fill();
+      ctx.strokeStyle = '#fff'; ctx.lineWidth = 1; ctx.stroke();
 
-    angle += slice;
+      // Legacy percent label — outer ring only, drawn inline (byte-stable).
+      if (legacyLabels && ring === 0 && slice > 0.15) {
+        const labelR = outerR * (isDoughnut ? 0.75 : 0.6);
+        const lx2 = cx2 + ox + Math.cos(midAngle) * labelR;
+        const ly2 = cy2 + oy + Math.sin(midAngle) * labelR;
+        const pct2 = Math.round((rVals[i] / rTotal) * 100);
+        const lsz = Math.max(8, outerR * 0.1);
+        ctx.font = `bold ${lsz}px ${dLblFont}`;
+        ctx.fillStyle = '#fff'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.fillText(`${pct2}%`, lx2, ly2);
+      }
+
+      angle += slice;
+    }
   }
 
-  if (isDoughnut) {
-    ctx.beginPath(); ctx.arc(cx2, cy2, innerR, 0, Math.PI * 2);
-    ctx.fillStyle = '#fff'; ctx.fill();
+  // Rich data labels (`<c:dLbls>`: showVal / showCatName / showSerName /
+  // showPercent + dLblPos, §21.2.2.35), drawn on the OUTER ring after all
+  // slices. Only runs when a rich definition is present; the plain percent
+  // labels above are byte-identical to the pre-CH8 pie.
+  if (hasRichLabels) {
+    drawPieRichLabels(ctx, chart, richDef, s, cats, vals, total, cx2, cy2, outerR, innerR, startAngle, dLblFont);
   }
 
   if (pieLeg) {
@@ -1937,6 +2078,54 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       ctx, { ...chart, series: legendSeries } as ChartModel, pieLeg,
       x, y, w, h, plotLeft, plotTop, pw, ph, titleH + 2,
     );
+  }
+}
+
+/** Draw the rich outer-ring data labels for a pie / doughnut from a series-level
+ *  `<c:dLbls>` (§21.2.2.35: showVal / showCatName / showSerName / showPercent +
+ *  dLblPos). Only called when such a definition exists; the plain percent-label
+ *  path stays inline in the slice loop (byte-stable). `font` is the pre-resolved
+ *  data-label CSS font-family. */
+function drawPieRichLabels(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  def: ChartSeriesDataLabels,
+  s: ChartSeries,
+  cats: string[],
+  vals: number[],
+  total: number,
+  cx2: number, cy2: number,
+  outerR: number, innerR: number,
+  startAngle: number,
+  font: string,
+): void {
+  let angle = startAngle;
+  for (let i = 0; i < vals.length; i++) {
+    const slice = (vals[i] / total) * Math.PI * 2;
+    const midAngle = angle + slice / 2;
+    angle += slice;
+    // §21.2.2.35 label composition. dLblPos: "outEnd" places the label just
+    // beyond the rim; "inEnd"/"ctr" (and default) sit inside the slice at the
+    // radial midpoint. Percent is derived from the slice's share of the total.
+    const parts: string[] = [];
+    if (def.showCatName) parts.push((cats[i] ?? '').toString());
+    if (def.showSerName) parts.push(s.name);
+    if (def.showVal) parts.push(formatChartValWithCode(vals[i], def.formatCode ?? null, chart.date1904 ?? false));
+    if (def.showPercent) parts.push(`${Math.round((vals[i] / total) * 100)}%`);
+    const text = parts.filter(Boolean).join(' ');
+    if (!text) continue;
+    const pos = def.position ?? 'bestFit';
+    const outside = pos === 'outEnd';
+    const labelR = outside
+      ? outerR + Math.max(10, outerR * 0.12)
+      : (innerR + outerR) / 2;
+    const lx2 = cx2 + Math.cos(midAngle) * labelR;
+    const ly2 = cy2 + Math.sin(midAngle) * labelR;
+    const sizePx = def.fontSizeHpt ? def.fontSizeHpt / 100 : Math.max(8, outerR * 0.1);
+    ctx.font = `${def.fontBold ? 'bold ' : ''}${sizePx}px ${font}`;
+    ctx.fillStyle = def.fontColor ? `#${def.fontColor}` : (outside ? '#333' : '#fff');
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText(text, lx2, ly2);
   }
 }
 
@@ -2003,7 +2192,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
   // overlapping the origin point.
   if (!chart.valAxisHidden) {
     const valAxPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
-    ctx.font = `${valAxPx}px sans-serif`;
+    ctx.font = `${valAxPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     ctx.fillStyle = '#555';
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
@@ -2014,7 +2203,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
     }
   }
 
-  ctx.font = `${Math.max(8, Math.min(11, rd * 0.2))}px sans-serif`;
+  ctx.font = `${Math.max(8, Math.min(11, rd * 0.2))}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
   ctx.fillStyle = '#444'; ctx.textBaseline = 'middle';
   // Spoke labels radiate from just outside the ring. Cap each at the room
   // between its anchor and the nearest horizontal plot edge so long category
@@ -2222,7 +2411,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   // Y-axis gridlines + labels + major tick marks.
   if (!chart.valAxisHidden) {
     const yTickFontPx = Math.max(8, Math.min(11, ph / 20));
-    ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${yTickFontPx}px sans-serif`;
+    ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${yTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     const ySteps = Math.round((yMax - yMin) / yAxisStep) + 1;
     for (let si = 0; si < ySteps; si++) {
       const v = yMin + si * yAxisStep; if (v > yMax + yAxisStep * 0.01) break;
@@ -2291,7 +2480,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   // depend on.
   if (!chart.catAxisHidden) {
     const tickFontPx = Math.max(8, Math.min(11, ph / 20));
-    ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${tickFontPx}px sans-serif`;
+    ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${tickFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
     const xStep = niceStep(xMax - xMin);
     const xSteps = Math.round((xMax - xMin) / xStep) + 1;
     ctx.fillStyle = '#555'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
@@ -2409,7 +2598,10 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     }
 
     // Per-point data labels (`<c:dLbl idx>`) and series-level defaults.
-    drawSeriesDataLabels(ctx, s, cats, useIndexX, toX, toY, ph, ptToPx, chart.date1904);
+    drawSeriesDataLabels(
+      ctx, s, cats, useIndexX, toX, toY, ph, ptToPx, chart.date1904,
+      chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
+    );
   }
 
   drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleBand.bandH + 2);
@@ -2605,6 +2797,8 @@ function drawSeriesDataLabels(
    *  value labels resolve against the correct epoch. Defaults to false, which
    *  also accepts the optional `ChartModel.date1904` when it is undefined. */
   date1904 = false,
+  /** Resolved data-label CSS font-family; defaults to sans-serif (byte-stable). */
+  fontFamily = 'sans-serif',
 ): void {
   const overrides = s.dataLabelOverrides ?? [];
   if (overrides.length === 0 && !s.seriesDataLabels) return;
@@ -2638,7 +2832,7 @@ function drawSeriesDataLabels(
       : Math.max(9, Math.min(11, ph / 25));
     const color = ovr?.fontColor ?? seriesDef?.fontColor;
     const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
-    drawDataLabelText(ctx, toX(xv), toY(yv), text, pos, fontSizePx, color, bold);
+    drawDataLabelText(ctx, toX(xv), toY(yv), text, pos, fontSizePx, color, bold, fontFamily);
   }
 }
 
@@ -2650,9 +2844,10 @@ function drawDataLabelText(
   fontSizePx: number,
   color: string | undefined,
   bold: boolean,
+  fontFamily = 'sans-serif',
 ): void {
   ctx.save();
-  ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px sans-serif`;
+  ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px ${fontFamily}`;
   ctx.fillStyle = color ? `#${color}` : '#333';
   const offset = fontSizePx * 0.6;
   let tx = cx, ty = cy;
@@ -2828,6 +3023,10 @@ function drawCategoryDataLabels(
   ptToPx: number,
   date1904: boolean,
   plotNullAsZero: boolean,
+  // Resolved data-label CSS font-family (element face ?? theme body ??
+  // sans-serif). Defaults to sans-serif so callers that don't pass it stay
+  // byte-stable.
+  fontFamily = 'sans-serif',
 ): boolean {
   const overrides = s.dataLabelOverrides ?? [];
   const seriesDef = s.seriesDataLabels;
@@ -2855,7 +3054,7 @@ function drawCategoryDataLabels(
     const fontSizePx = sizeHpt ? (sizeHpt / 100) * ptToPx : Math.max(9, Math.min(11, ph / 25));
     const color = ovr?.fontColor ?? seriesDef?.fontColor;
     const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
-    drawDataLabelText(ctx, xAt(ci), yAt(pv), text, pos, fontSizePx, color, bold);
+    drawDataLabelText(ctx, xAt(ci), yAt(pv), text, pos, fontSizePx, color, bold, fontFamily);
   }
   return true;
 }
@@ -2935,7 +3134,7 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
   const step = niceStep(padded);
   ctx.save();
   const fontSize = Math.round(h * 0.042);
-  ctx.font = `${fontSize}px sans-serif`;
+  ctx.font = `${fontSize}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
 
   // ECMA-376 / chartEx §axis@hidden: when the value axis is hidden, skip the
   // value-axis gridlines, tick labels and the left segment of the L-frame.
@@ -3039,7 +3238,7 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
         ? `#${chart.dataLabelFontColor}`
         : '#595959';
     ctx.fillStyle = labelColor;
-    ctx.font = `bold ${Math.round(h * 0.044)}px sans-serif`;
+    ctx.font = `bold ${Math.round(h * 0.044)}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
     ctx.textAlign = 'center';
     // Negative bars: label sits BELOW the bar (`outEnd` for a negative value
     // points downward in chartEx). Positive bars and subtotals: label ABOVE.
@@ -3055,7 +3254,8 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
   ctx.fillStyle = '#666';
-  ctx.font = `${Math.round(h * 0.038)}px sans-serif`;
+  // Category (transaction) labels below the bars → category-axis face.
+  ctx.font = `${Math.round(h * 0.038)}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
   const labelY = py0 + ph + 4;
   for (let i = 0; i < n; i++) {
     const ccx = px0 + gapW * i + gapW / 2;

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -172,10 +172,15 @@ export interface ChartDataPointOverride {
   markerFill?: string;
   markerLine?: string;
   /**
-   * `<c:dPt><c:explosion val>` (ECMA-376 §21.2.2.61) — the amount, as a
-   * percentage 0–100, that this pie/doughnut slice is moved out from the
-   * center. undefined/absent = 0 (no explosion, flush with the ring). Only
-   * consulted by the pie/doughnut renderer.
+   * `<c:dPt><c:explosion val>` (ECMA-376 §21.2.2.61) — the amount this
+   * pie/doughnut slice is moved out from the center. The schema type is
+   * `CT_UnsignedInt` (unbounded `xsd:unsignedInt`); the spec text only says
+   * "the amount the data point shall be moved from the center of the pie"
+   * and does not itself define units or a 0–100 range. We treat it as a
+   * de-facto percentage of the outer radius (0–100 typical), matching
+   * Office's UI (the Point Explosion slider caps at 100%) rather than a
+   * spec-mandated bound. undefined/absent = 0 (no explosion, flush with the
+   * ring). Only consulted by the pie/doughnut renderer.
    */
   explosion?: number;
 }

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -463,6 +463,66 @@ export interface ChartModel {
    * consulted for the line and area families. null/undefined = "gap".
    */
   dispBlanksAs?: string | null;
+  // ── Axis scale model (CH6) ───────────────────────────────────────────────
+  // Gridline presence, manual major/minor units, log scale and orientation.
+  // Every field is byte-stable when absent: the renderer keeps its historical
+  // "value gridlines always on, category gridlines off, linear minMax axis"
+  // behavior unless one of these is explicitly set.
+  /**
+   * `<c:valAx><c:majorGridlines>` presence (ECMA-376 §21.2.2.100). `false` when
+   * the value axis exists but omits the element (Office suppresses value
+   * gridlines). null/undefined ⇒ the renderer's historical always-on value
+   * gridlines (byte-stable). `true` is redundant with the default but honored.
+   */
+  valAxisMajorGridlines?: boolean | null;
+  /**
+   * `<c:catAx><c:majorGridlines>` presence (§21.2.2.100). `true` turns on
+   * category-axis gridlines (Office omits them by default). null/undefined/false
+   * ⇒ no category gridlines (the historical default, byte-stable).
+   */
+  catAxisMajorGridlines?: boolean | null;
+  /** `<c:valAx><c:minorGridlines>` presence (§21.2.2.109). Only drawn when a
+   *  minor step is resolvable (see {@link valAxisMinorUnit}). */
+  valAxisMinorGridlines?: boolean | null;
+  /**
+   * `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit distance between major
+   * gridlines/ticks, overriding the Excel-style auto "nice" step. null/undefined
+   * ⇒ auto step (byte-stable).
+   */
+  valAxisMajorUnit?: number | null;
+  /** `<c:valAx><c:minorUnit val>` (§21.2.2.112) — explicit minor step. Drives
+   *  minor gridlines/ticks when present. null ⇒ no minor divisions. */
+  valAxisMinorUnit?: number | null;
+  /**
+   * `<c:valAx><c:scaling><c:logBase val>` (§21.2.2.98, `ST_LogBase` §21.2.3.25)
+   * — logarithmic value-axis base (>= 2). When set, values map to pixels in log
+   * space and gridlines fall on powers of the base. null/undefined ⇒ linear
+   * (byte-stable).
+   */
+  valAxisLogBase?: number | null;
+  /**
+   * `<c:valAx><c:scaling><c:orientation val>` (§21.2.2.130, `ST_Orientation`
+   * §21.2.3.30) — "minMax" (normal) | "maxMin" (reversed, so the value axis runs
+   * top→bottom max→min). null/undefined/"minMax" ⇒ normal (byte-stable).
+   */
+  valAxisOrientation?: 'minMax' | 'maxMin' | string | null;
+  /** `<c:catAx><c:scaling><c:orientation val>` — "maxMin" reverses the category
+   *  axis left↔right. null/"minMax" ⇒ normal. */
+  catAxisOrientation?: 'minMax' | 'maxMin' | string | null;
+  /**
+   * `<c:catAx><c:tickLblPos val>` (§21.2.2.207, `ST_TickLblPos` §21.2.3.47) —
+   * "nextTo" (default) | "low" | "high" | "none". "none" hides the category tick
+   * labels. null/undefined ⇒ nextTo (byte-stable).
+   */
+  catAxisTickLabelPos?: string | null;
+  /** `<c:valAx><c:tickLblPos val>` (§21.2.2.207). "none" hides value tick labels. */
+  valAxisTickLabelPos?: string | null;
+  /**
+   * `<c:catAx><c:txPr><a:bodyPr rot>` (DrawingML `ST_Angle`, 60000ths of a
+   * degree) — category tick-label rotation. e.g. -2700000 = -45°. null/undefined
+   * /0 ⇒ horizontal labels (byte-stable).
+   */
+  catAxisLabelRotation?: number | null;
 }
 
 /**

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -121,6 +121,46 @@ export interface ChartSeries {
    * polyline (the default; byte-stable for series that never set it).
    */
   smooth?: boolean | null;
+  /**
+   * `<c:ser><c:trendline>` per-series trendlines (ECMA-376 §21.2.2.211,
+   * `CT_Trendline`). A series can carry several (e.g. a linear fit + a moving
+   * average). null/undefined/empty = no trendline (the default; byte-stable for
+   * series that never declare one).
+   */
+  trendLines?: ChartTrendline[] | null;
+}
+
+/**
+ * `<c:ser><c:trendline>` (ECMA-376 §21.2.2.211). A regression/smoothing curve
+ * fitted to the series' data points.
+ */
+export interface ChartTrendline {
+  /**
+   * `<c:trendlineType val>` (§21.2.2.213, `ST_TrendlineType` §21.2.3.50):
+   * "linear" | "exp" | "log" | "power" | "poly" | "movingAvg". The renderer
+   * currently draws "linear" (least squares) and "movingAvg"; other types parse
+   * but are not yet plotted (tracked as a follow-up).
+   */
+  trendlineType: string;
+  /** `<c:order val>` — polynomial order (`poly`, default 2). */
+  order?: number | null;
+  /** `<c:period val>` — moving-average window (`movingAvg`, default 2). */
+  period?: number | null;
+  /** `<c:forward val>` — units to extend the line past the last point. */
+  forward?: number | null;
+  /** `<c:backward val>` — units to extend the line before the first point. */
+  backward?: number | null;
+  /** `<c:intercept val>` — forced y-intercept (linear/exp). null = free fit. */
+  intercept?: number | null;
+  /** `<c:dispRSqr val="1">` — show the R² value (label; not yet rendered). */
+  dispRSqr?: boolean | null;
+  /** `<c:dispEq val="1">` — show the fit equation (label; not yet rendered). */
+  dispEq?: boolean | null;
+  /** `<c:spPr><a:ln><a:solidFill>` trendline color (hex without '#'). null =
+   *  inherit the series color. */
+  lineColor?: string | null;
+  /** `<c:spPr><a:ln w>` trendline width in EMU. */
+  lineWidthEmu?: number | null;
 }
 
 export interface ChartDataPointOverride {

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -131,6 +131,13 @@ export interface ChartDataPointOverride {
   markerSize?: number;
   markerFill?: string;
   markerLine?: string;
+  /**
+   * `<c:dPt><c:explosion val>` (ECMA-376 §21.2.2.61) — the amount, as a
+   * percentage 0–100, that this pie/doughnut slice is moved out from the
+   * center. undefined/absent = 0 (no explosion, flush with the ring). Only
+   * consulted by the pie/doughnut renderer.
+   */
+  explosion?: number;
 }
 
 export interface ChartDataLabelOverride {
@@ -304,6 +311,41 @@ export interface ChartModel {
   valAxisTitleFontBold?: boolean | null;
   /** `<c:valAx><c:title>` run-prop color (hex without '#'). null = default. */
   valAxisTitleFontColor?: string | null;
+  // ── Chart text font faces (CH10) ─────────────────────────────────────────
+  // Each is the `<a:latin typeface>` (ECMA-376 §20.1.4.2.24) resolved from the
+  // element's `<c:txPr>`. When absent the renderer falls back to the theme
+  // body/heading font (`themeMinorFontLatin` / `themeMajorFontLatin`) and
+  // finally to the built-in sans-serif, so a chart that specifies no faces is
+  // byte-stable. Faces mirror the existing color/size/bold groups.
+  /** `<c:catAx><c:txPr>…<a:latin typeface>` tick-label font. */
+  catAxisFontFace?: string | null;
+  /** `<c:valAx><c:txPr>…<a:latin typeface>` tick-label font. */
+  valAxisFontFace?: string | null;
+  /** `<c:catAx><c:title>…<a:latin typeface>` axis-title font. */
+  catAxisTitleFontFace?: string | null;
+  /** `<c:valAx><c:title>…<a:latin typeface>` axis-title font. */
+  valAxisTitleFontFace?: string | null;
+  /** `<c:dLbls><c:txPr>…<a:latin typeface>` data-label font. */
+  dataLabelFontFace?: string | null;
+  /** `<c:legend><c:txPr>…<a:latin typeface>` legend font. */
+  legendFontFace?: string | null;
+  /** `<c:legend><c:txPr>…<a:solidFill>` legend text color (hex without '#'). */
+  legendFontColor?: string | null;
+  /** `<c:legend><c:txPr>` legend font size (OOXML hundredths of a point). */
+  legendFontSizeHpt?: number | null;
+  /** `<c:legend><c:txPr>…defRPr@b` legend bold flag. */
+  legendFontBold?: boolean | null;
+  /**
+   * Theme font-scheme faces (`<a:fontScheme>`, ECMA-376 §20.1.4.2). Latin
+   * heading (majorFont) and body (minorFont) typefaces, used as the fallback
+   * for any chart text element whose own `<c:txPr>` supplies no `<a:latin>`.
+   * null when the theme is not threaded to the chart (then the renderer's
+   * built-in sans-serif remains, byte-stable). Axis titles / chart title use
+   * the major (heading) face; tick labels / data labels / legend use the
+   * minor (body) face — matching Office's default chart text styling.
+   */
+  themeMajorFontLatin?: string | null;
+  themeMinorFontLatin?: string | null;
   /** Explicit chart border color (hex without '#') from
    *  `<c:chartSpace><c:spPr><a:ln><a:solidFill><a:srgbClr>`. Only set when the
    *  XML explicitly declares a paintable line; null otherwise (no default
@@ -387,6 +429,25 @@ export interface ChartModel {
    * the attribute is omitted, so `<c:date1904/>` alone means date1904=true.
    */
   date1904?: boolean;
+  /**
+   * `<c:doughnutChart><c:holeSize val>` (ECMA-376 §21.2.2.60,
+   * `ST_HoleSizePercent` §21.2.3.55) — the doughnut hole diameter as a
+   * percentage 1–90 of the outer diameter. Ignored for pie (which has no
+   * hole). null/undefined = use the renderer's doughnut default when the
+   * element is absent. Note the ECMA `CT_HoleSize` schema default is 10%, but
+   * a real doughnut file always writes an explicit `<c:holeSize>` (Excel /
+   * PowerPoint emit 50–75%); the renderer falls back to 50% only for the
+   * pathological absent case.
+   */
+  holeSize?: number | null;
+  /**
+   * `<c:pieChart | doughnutChart><c:firstSliceAng val>` (ECMA-376 §21.2.2.52,
+   * `ST_FirstSliceAng` §21.2.3.15) — the angle in degrees (0–360, clockwise
+   * from the 12 o'clock position) at which the first slice begins.
+   * null/undefined = 0 (start at 12 o'clock), which matches the renderer's
+   * historical fixed −90° (canvas up) start.
+   */
+  firstSliceAngle?: number | null;
   /**
    * `<c:chartSpace><c:chart><c:dispBlanksAs val>` (ECMA-376 §21.2.2.42,
    * `ST_DispBlanksAs` §21.2.3.10) — how blank (null) cells are plotted on

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -224,6 +224,52 @@ pub struct ChartModel {
     /// when the file sets it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disp_blanks_as: Option<String>,
+    // ── Axis scale model (CH6) ──────────────────────────────────────────────
+    /// `<c:valAx><c:majorGridlines>` presence (§21.2.2.100). `Some(false)` when
+    /// the value axis exists but omits the element — Office suppresses the value
+    /// gridlines then. `None` when there is no value axis (or the parser path
+    /// doesn't model it); the renderer keeps its historical always-on value
+    /// gridlines, so a `None`/absent field is byte-stable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_major_gridlines: Option<bool>,
+    /// `<c:catAx><c:majorGridlines>` presence (§21.2.2.100). `Some(true)` turns
+    /// on category-axis gridlines (Office omits them by default). `None`/absent
+    /// keeps the renderer's historical no-category-gridlines behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_major_gridlines: Option<bool>,
+    /// `<c:valAx><c:minorGridlines>` presence (§21.2.2.109).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_gridlines: Option<bool>,
+    /// `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit major gridline
+    /// step, overriding the auto "nice" step. `None` = auto (byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_major_unit: Option<f64>,
+    /// `<c:valAx><c:minorUnit val>` (§21.2.2.112) — explicit minor gridline step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_unit: Option<f64>,
+    /// `<c:valAx><c:scaling><c:logBase val>` (§21.2.2.98) — logarithmic value
+    /// axis base (>= 2). `None` = linear (byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_log_base: Option<f64>,
+    /// `<c:valAx><c:scaling><c:orientation val>` (§21.2.2.130) — `"minMax"`
+    /// (normal) | `"maxMin"` (reversed). `None`/`"minMax"` = normal (byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_orientation: Option<String>,
+    /// `<c:catAx><c:scaling><c:orientation val>` — reverses the category axis
+    /// left↔right when `"maxMin"`. `None`/`"minMax"` = normal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_orientation: Option<String>,
+    /// `<c:catAx><c:tickLblPos val>` (§21.2.2.207) — `"nextTo"` (default) |
+    /// `"low"` | `"high"` | `"none"` (labels hidden). `None` = nextTo.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_tick_label_pos: Option<String>,
+    /// `<c:valAx><c:tickLblPos val>` (§21.2.2.207).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_tick_label_pos: Option<String>,
+    /// `<c:catAx><c:txPr><a:bodyPr rot>` (60000ths of a degree) — category
+    /// tick-label rotation. `None`/0 = horizontal (byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_label_rotation: Option<i32>,
 }
 
 /// Mirror of TS `ChartSeries`.
@@ -1027,6 +1073,99 @@ pub fn extract_axis_line_style(
     (color, width, no_fill)
 }
 
+// ============================================================================
+// Axis scale model (CH6) — gridlines / units / logBase / orientation / labels
+// ============================================================================
+//
+// All helpers take the already-located `<c:catAx>` / `<c:valAx>` node (per
+// EG_AxShared, ECMA-376 §21.2.2). `<c:majorGridlines>` / `<c:minorGridlines>`
+// are direct children of the axis; `<c:logBase>` / `<c:orientation>` live under
+// `<c:scaling>`; `<c:majorUnit>` / `<c:minorUnit>` are direct children of a
+// `<c:valAx>` (after `<c:crossBetween>`).
+
+/// `<c:catAx|valAx><c:majorGridlines>` presence (ECMA-376 §21.2.2.100,
+/// `CT_ChartLines`). The element carries only an optional `<c:spPr>` line
+/// style; its mere PRESENCE requests gridlines. Returns `true` when the axis
+/// declares `<c:majorGridlines>`. Office writes it on the value axis by default
+/// and omits it on the category axis, so this maps directly to "draw them".
+pub fn axis_has_major_gridlines(axis_node: Node) -> bool {
+    child(axis_node, "majorGridlines").is_some()
+}
+
+/// `<c:catAx|valAx><c:minorGridlines>` presence (ECMA-376 §21.2.2.109). Same
+/// presence-only semantics as [`axis_has_major_gridlines`]. Minor gridlines
+/// require a minor unit to place them; the renderer only draws them when both a
+/// `<c:minorGridlines>` element and a resolvable minor step exist.
+pub fn axis_has_minor_gridlines(axis_node: Node) -> bool {
+    child(axis_node, "minorGridlines").is_some()
+}
+
+/// `<c:valAx><c:majorUnit val>` (ECMA-376 §21.2.2.103, `ST_AxisUnit`
+/// §21.2.3.1) — an explicit distance between major ticks/gridlines. Must be a
+/// positive floating-point number; non-positive values are rejected so they
+/// can't wedge the renderer into an infinite gridline loop. `None` when absent
+/// (the renderer keeps its Excel-style auto "nice" step).
+pub fn extract_axis_major_unit(axis_node: Node) -> Option<f64> {
+    child(axis_node, "majorUnit")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| v.is_finite() && *v > 0.0)
+}
+
+/// `<c:valAx><c:minorUnit val>` (ECMA-376 §21.2.2.112) — explicit distance
+/// between minor ticks/gridlines. Positive floating-point; `None` when absent.
+pub fn extract_axis_minor_unit(axis_node: Node) -> Option<f64> {
+    child(axis_node, "minorUnit")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| v.is_finite() && *v > 0.0)
+}
+
+/// `<c:catAx|valAx><c:scaling><c:logBase val>` (ECMA-376 §21.2.2.98,
+/// `ST_LogBase` §21.2.3.25) — the base of a logarithmic value axis. Per the
+/// spec the base shall be `>= 2`; smaller/invalid values are rejected. `None`
+/// when the axis is linear (the common case).
+pub fn extract_axis_log_base(axis_node: Node) -> Option<f64> {
+    let scaling = child(axis_node, "scaling")?;
+    child(scaling, "logBase")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| v.is_finite() && *v >= 2.0)
+}
+
+/// `<c:catAx|valAx><c:scaling><c:orientation val>` (ECMA-376 §21.2.2.130,
+/// `ST_Orientation` §21.2.3.30) — axis direction. Returns the raw enum string
+/// `"minMax"` (normal, the default) or `"maxMin"` (reversed). `None` when the
+/// element is absent (the renderer treats absent and `"minMax"` identically, so
+/// omitting it is byte-stable).
+pub fn extract_axis_orientation(axis_node: Node) -> Option<String> {
+    let scaling = child(axis_node, "scaling")?;
+    child(scaling, "orientation")
+        .and_then(|n| n.attribute("val"))
+        .map(|s| s.to_string())
+}
+
+/// `<c:catAx|valAx><c:tickLblPos val>` (ECMA-376 §21.2.2.207, `ST_TickLblPos`
+/// §21.2.3.47) — where the tick labels sit: `"high"` | `"low"` | `"nextTo"`
+/// (default) | `"none"` (labels not drawn). Returns the raw enum string; `None`
+/// when absent (renderer treats absent as `"nextTo"`, byte-stable).
+pub fn extract_axis_tick_label_pos(axis_node: Node) -> Option<String> {
+    child(axis_node, "tickLblPos")
+        .and_then(|n| n.attribute("val"))
+        .map(|s| s.to_string())
+}
+
+/// `<c:catAx|valAx><c:txPr><a:bodyPr rot>` (DrawingML `ST_Angle`, 60000ths of a
+/// degree — §20.1.10.3) — tick-label rotation. Scoped to the axis's `<c:txPr>`
+/// body properties so a title's rotation isn't misread. Returns the raw
+/// 60000ths-degree integer; `None` when absent or 0 is not written (renderer
+/// treats absent as 0, byte-stable). A value like `-2700000` = -45°.
+pub fn extract_axis_tick_label_rotation(axis_node: Node) -> Option<i32> {
+    let txpr = child(axis_node, "txPr")?;
+    let body_pr = child(txpr, "bodyPr")?;
+    body_pr.attribute("rot").and_then(|v| v.parse::<i32>().ok())
+}
+
 /// chartEx (`<cx:chartSpace>`) axis visibility. ChartEx encodes the
 /// scale type via a `<cx:catScaling>` / `<cx:valScaling>` child rather
 /// than separate `<c:catAx>` / `<c:valAx>` elements, so callers can't just
@@ -1236,6 +1375,17 @@ mod tests {
             theme_minor_font_latin: None,
             date1904: false,
             disp_blanks_as: None,
+            val_axis_major_gridlines: None,
+            cat_axis_major_gridlines: None,
+            val_axis_minor_gridlines: None,
+            val_axis_major_unit: None,
+            val_axis_minor_unit: None,
+            val_axis_log_base: None,
+            val_axis_orientation: None,
+            cat_axis_orientation: None,
+            cat_axis_tick_label_pos: None,
+            val_axis_tick_label_pos: None,
+            cat_axis_label_rotation: None,
         };
         let v = serde_json::to_value(&m).unwrap();
         let obj = v.as_object().unwrap();
@@ -1853,6 +2003,114 @@ mod tests {
         assert_eq!(
             extract_axis_tick_label_face(root_of(&xml).root_element()).as_deref(),
             Some("+mn-lt")
+        );
+    }
+
+    // ── Axis scale model (CH6) ──────────────────────────────────────────────
+
+    #[test]
+    fn axis_gridlines_presence() {
+        // Value axis with `<c:majorGridlines>` → true; category axis without → false.
+        let val = format!(r#"<c:valAx xmlns:c="{C_NS}"><c:majorGridlines/></c:valAx>"#);
+        assert!(axis_has_major_gridlines(root_of(&val).root_element()));
+        assert!(!axis_has_minor_gridlines(root_of(&val).root_element()));
+
+        let cat = format!(r#"<c:catAx xmlns:c="{C_NS}"/>"#);
+        assert!(!axis_has_major_gridlines(root_of(&cat).root_element()));
+
+        let both = format!(
+            r#"<c:valAx xmlns:c="{C_NS}"><c:majorGridlines/><c:minorGridlines/></c:valAx>"#
+        );
+        assert!(axis_has_major_gridlines(root_of(&both).root_element()));
+        assert!(axis_has_minor_gridlines(root_of(&both).root_element()));
+    }
+
+    #[test]
+    fn axis_major_minor_unit() {
+        let xml = format!(
+            r#"<c:valAx xmlns:c="{C_NS}"><c:crossBetween val="between"/><c:majorUnit val="500"/><c:minorUnit val="100"/></c:valAx>"#
+        );
+        assert_eq!(
+            extract_axis_major_unit(root_of(&xml).root_element()),
+            Some(500.0)
+        );
+        assert_eq!(
+            extract_axis_minor_unit(root_of(&xml).root_element()),
+            Some(100.0)
+        );
+        // Absent → None (auto step).
+        let bare = format!(r#"<c:valAx xmlns:c="{C_NS}"/>"#);
+        assert_eq!(extract_axis_major_unit(root_of(&bare).root_element()), None);
+        // Non-positive rejected (would wedge the gridline loop).
+        let zero = format!(r#"<c:valAx xmlns:c="{C_NS}"><c:majorUnit val="0"/></c:valAx>"#);
+        assert_eq!(extract_axis_major_unit(root_of(&zero).root_element()), None);
+    }
+
+    #[test]
+    fn axis_log_base() {
+        let xml = format!(
+            r#"<c:valAx xmlns:c="{C_NS}"><c:scaling><c:logBase val="10"/></c:scaling></c:valAx>"#
+        );
+        assert_eq!(
+            extract_axis_log_base(root_of(&xml).root_element()),
+            Some(10.0)
+        );
+        // Base < 2 is invalid per ST_LogBase → rejected.
+        let bad = format!(
+            r#"<c:valAx xmlns:c="{C_NS}"><c:scaling><c:logBase val="1"/></c:scaling></c:valAx>"#
+        );
+        assert_eq!(extract_axis_log_base(root_of(&bad).root_element()), None);
+        // Absent scaling / logBase → None (linear).
+        let bare = format!(r#"<c:valAx xmlns:c="{C_NS}"><c:scaling/></c:valAx>"#);
+        assert_eq!(extract_axis_log_base(root_of(&bare).root_element()), None);
+    }
+
+    #[test]
+    fn axis_orientation() {
+        let rev = format!(
+            r#"<c:valAx xmlns:c="{C_NS}"><c:scaling><c:orientation val="maxMin"/></c:scaling></c:valAx>"#
+        );
+        assert_eq!(
+            extract_axis_orientation(root_of(&rev).root_element()).as_deref(),
+            Some("maxMin")
+        );
+        let norm = format!(
+            r#"<c:valAx xmlns:c="{C_NS}"><c:scaling><c:orientation val="minMax"/></c:scaling></c:valAx>"#
+        );
+        assert_eq!(
+            extract_axis_orientation(root_of(&norm).root_element()).as_deref(),
+            Some("minMax")
+        );
+        // Absent → None (renderer treats as minMax).
+        let bare = format!(r#"<c:valAx xmlns:c="{C_NS}"><c:scaling/></c:valAx>"#);
+        assert_eq!(
+            extract_axis_orientation(root_of(&bare).root_element()),
+            None
+        );
+    }
+
+    #[test]
+    fn axis_tick_label_pos_and_rotation() {
+        let xml = format!(
+            r#"<c:catAx xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:tickLblPos val="low"/><c:txPr><a:bodyPr rot="-2700000"/></c:txPr></c:catAx>"#
+        );
+        assert_eq!(
+            extract_axis_tick_label_pos(root_of(&xml).root_element()).as_deref(),
+            Some("low")
+        );
+        assert_eq!(
+            extract_axis_tick_label_rotation(root_of(&xml).root_element()),
+            Some(-2_700_000)
+        );
+        // Absent → None (renderer treats as nextTo / 0°).
+        let bare = format!(r#"<c:catAx xmlns:c="{C_NS}"/>"#);
+        assert_eq!(
+            extract_axis_tick_label_pos(root_of(&bare).root_element()),
+            None
+        );
+        assert_eq!(
+            extract_axis_tick_label_rotation(root_of(&bare).root_element()),
+            None
         );
     }
 }

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -366,7 +366,12 @@ pub struct ChartDataPointOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub marker_line: Option<String>,
     /// `<c:dPt><c:explosion val>` (§21.2.2.61) — pie/doughnut slice pull-out
-    /// percentage (0–100). `None`/absent = 0 (byte-stable).
+    /// amount. The schema type is `CT_UnsignedInt` (unbounded `xsd:unsignedInt`);
+    /// the spec text itself doesn't define a 0–100 range or "percentage" unit,
+    /// only "the amount the data point shall be moved from the center of the
+    /// pie". Renderers interpret it as a de-facto percentage of the outer
+    /// radius (0–100 typical), matching Office's Point Explosion UI slider
+    /// rather than a spec-mandated bound. `None`/absent = 0 (byte-stable).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub explosion: Option<u32>,
 }
@@ -922,7 +927,10 @@ pub fn extract_first_slice_angle(root: Node) -> Option<u32> {
 }
 
 /// `<c:dPt><c:explosion val>` (§21.2.2.61) — pie/doughnut slice pull-out
-/// percentage. Caller passes a `<c:dPt>` node. `None` when absent.
+/// amount, parsed as the unbounded `xsd:unsignedInt` the schema (`CT_UnsignedInt`)
+/// actually specifies (no 0–100 clamp here; see `ChartDataPointOverride::explosion`
+/// for how renderers interpret the value). Caller passes a `<c:dPt>` node.
+/// `None` when absent.
 pub fn extract_dpt_explosion(dpt_node: Node) -> Option<u32> {
     child(dpt_node, "explosion")
         .and_then(|n| n.attribute("val"))

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -318,6 +318,36 @@ pub struct ChartSeries {
     /// polyline (the default); only serialized when the file sets it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smooth: Option<bool>,
+    /// `<c:ser><c:trendline>` per-series trendlines (§21.2.2.211). `None`/empty
+    /// when the series declares none (byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trend_lines: Option<Vec<ChartTrendline>>,
+}
+
+/// Mirror of TS `ChartTrendline` — `<c:ser><c:trendline>` (§21.2.2.211).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartTrendline {
+    /// `<c:trendlineType val>` (§21.2.2.213) — linear|exp|log|power|poly|movingAvg.
+    pub trendline_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub period: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forward: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backward: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intercept: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disp_r_sqr: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disp_eq: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_width_emu: Option<u32>,
 }
 
 /// Mirror of TS `ChartDataPointOverride`.
@@ -940,6 +970,76 @@ pub fn extract_series_smooth(ser_node: Node) -> Option<bool> {
     })
 }
 
+/// Parse `bool_val`: a `CT_Boolean` child's `val` where an absent attribute
+/// implies true (the OOXML default when the element is present).
+fn bool_child(parent: Node, name: &str) -> Option<bool> {
+    child(parent, name).map(|n| match n.attribute("val") {
+        None => true,
+        Some(v) => v == "1" || v.eq_ignore_ascii_case("true"),
+    })
+}
+
+/// `<c:ser><c:trendline>` (ECMA-376 §21.2.2.211, `CT_Trendline`) — every
+/// trendline declared on `ser_node` (0..N). Each carries a required
+/// `<c:trendlineType>` plus optional order/period/forward/backward/intercept,
+/// the `<c:dispRSqr>` / `<c:dispEq>` label flags, and an `<c:spPr><a:ln>` line
+/// style (color resolved via `resolver`, width in EMU). Returns `None` when the
+/// series declares no trendline (byte-stable); otherwise the parsed vec. Shared
+/// so pptx and xlsx honor trendlines identically.
+pub fn extract_series_trendlines(
+    ser_node: Node,
+    resolver: &dyn ColorResolver,
+) -> Option<Vec<ChartTrendline>> {
+    let mut out = Vec::new();
+    for tl in ser_node
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "trendline")
+    {
+        // trendlineType is required per the schema; skip a malformed trendline
+        // that somehow lacks it rather than emitting an empty type.
+        let Some(trendline_type) = child(tl, "trendlineType").and_then(|n| n.attribute("val"))
+        else {
+            continue;
+        };
+        let u32_val = |name: &str| -> Option<u32> {
+            child(tl, name)
+                .and_then(|n| n.attribute("val"))
+                .and_then(|v| v.parse::<u32>().ok())
+        };
+        let f64_val = |name: &str| -> Option<f64> {
+            child(tl, name)
+                .and_then(|n| n.attribute("val"))
+                .and_then(|v| v.parse::<f64>().ok())
+        };
+        // `<c:spPr><a:ln>` line style: solidFill color + width.
+        let (line_color, line_width_emu) = match child(tl, "spPr").and_then(|sp| child(sp, "ln")) {
+            None => (None, None),
+            Some(ln) => {
+                let color = child(ln, "solidFill").and_then(|sf| resolver.resolve_solid_fill(sf));
+                let width = ln.attribute("w").and_then(|v| v.parse::<u32>().ok());
+                (color, width)
+            }
+        };
+        out.push(ChartTrendline {
+            trendline_type: trendline_type.to_string(),
+            order: u32_val("order"),
+            period: u32_val("period"),
+            forward: f64_val("forward"),
+            backward: f64_val("backward"),
+            intercept: f64_val("intercept"),
+            disp_r_sqr: bool_child(tl, "dispRSqr"),
+            disp_eq: bool_child(tl, "dispEq"),
+            line_color,
+            line_width_emu,
+        });
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
 /// `<c:chart><c:dispBlanksAs val>` (ECMA-376 §21.2.2.42, `ST_DispBlanksAs`
 /// §21.2.3.10) — how blank cells are plotted ("gap" | "zero" | "span").
 /// `root` may be the `<c:chartSpace>` or `<c:chart>` node; the single
@@ -1298,6 +1398,7 @@ mod tests {
                 err_bars: None,
                 bubble_sizes: None,
                 smooth: None,
+                trend_lines: None,
             }],
             show_data_labels: false,
             val_min: None,
@@ -2112,5 +2213,40 @@ mod tests {
             extract_axis_tick_label_rotation(root_of(&bare).root_element()),
             None
         );
+    }
+
+    #[test]
+    fn series_trendlines_parse() {
+        // No trendline → None (byte-stable).
+        let none = format!(r#"<c:ser xmlns:c="{C_NS}"/>"#);
+        assert_eq!(
+            extract_series_trendlines(root_of(&none).root_element(), &StubResolver),
+            None
+        );
+        // A linear fit + a period-3 moving average, the linear one with a red line.
+        let xml = format!(
+            r#"<c:ser xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+                 <c:trendline>
+                   <c:spPr><a:ln w="19050"><a:solidFill><a:srgbClr val="ff0000"/></a:solidFill></a:ln></c:spPr>
+                   <c:trendlineType val="linear"/>
+                   <c:dispEq val="1"/>
+                   <c:dispRSqr val="1"/>
+                 </c:trendline>
+                 <c:trendline>
+                   <c:trendlineType val="movingAvg"/>
+                   <c:period val="3"/>
+                 </c:trendline>
+               </c:ser>"#
+        );
+        let got = extract_series_trendlines(root_of(&xml).root_element(), &StubResolver).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].trendline_type, "linear");
+        assert_eq!(got[0].line_color.as_deref(), Some("FF0000"));
+        assert_eq!(got[0].line_width_emu, Some(19050));
+        assert_eq!(got[0].disp_eq, Some(true));
+        assert_eq!(got[0].disp_r_sqr, Some(true));
+        assert_eq!(got[1].trendline_type, "movingAvg");
+        assert_eq!(got[1].period, Some(3));
+        assert_eq!(got[1].line_color, None);
     }
 }

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -165,6 +165,54 @@ pub struct ChartModel {
     pub radar_style: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secondary_val_axis: Option<SecondaryValueAxis>,
+    // ── Pie / doughnut geometry (CH8) ───────────────────────────────────────
+    /// `<c:doughnutChart><c:holeSize val>` (§21.2.2.60, `ST_HoleSizePercent`
+    /// §21.2.3.55) — hole diameter as 1–90% of the outer diameter. `None` when
+    /// absent; the renderer defaults an absent doughnut hole to 50%.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hole_size: Option<u32>,
+    /// `<c:pieChart | doughnutChart><c:firstSliceAng val>` (§21.2.2.52,
+    /// `ST_FirstSliceAng` §21.2.3.15) — start angle 0–360° clockwise from 12
+    /// o'clock. `None` = 0 (byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_slice_angle: Option<u32>,
+    // ── Chart text font faces (CH10) ────────────────────────────────────────
+    /// `<c:catAx><c:txPr>…<a:latin typeface>` tick-label font.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_font_face: Option<String>,
+    /// `<c:valAx><c:txPr>…<a:latin typeface>` tick-label font.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_font_face: Option<String>,
+    /// `<c:catAx><c:title>…<a:latin typeface>` axis-title font.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_title_font_face: Option<String>,
+    /// `<c:valAx><c:title>…<a:latin typeface>` axis-title font.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_title_font_face: Option<String>,
+    /// `<c:dLbls><c:txPr>…<a:latin typeface>` data-label font.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_label_font_face: Option<String>,
+    /// `<c:legend><c:txPr>…<a:latin typeface>` legend font.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend_font_face: Option<String>,
+    /// `<c:legend><c:txPr>…<a:solidFill>` legend text color (hex, no `#`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend_font_color: Option<String>,
+    /// `<c:legend><c:txPr>` legend font size (OOXML hundredths of a point).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend_font_size_hpt: Option<i32>,
+    /// `<c:legend><c:txPr>…defRPr@b` legend bold flag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legend_font_bold: Option<bool>,
+    /// Theme heading (majorFont) Latin face — fallback for chart title / axis
+    /// titles when their `<c:txPr>` supplies no `<a:latin>`. `None` when the
+    /// theme is not threaded (renderer keeps sans-serif; byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme_major_font_latin: Option<String>,
+    /// Theme body (minorFont) Latin face — fallback for tick labels / data
+    /// labels / legend. `None` when the theme is not threaded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme_minor_font_latin: Option<String>,
     /// `<c:date1904>` (ECMA-376 §21.2.2.38). `true` = the chart's serial dates
     /// resolve against the 1904 date system. Omitted from JSON when false (the
     /// default 1900 system) for wire parity.
@@ -241,6 +289,10 @@ pub struct ChartDataPointOverride {
     pub marker_fill: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub marker_line: Option<String>,
+    /// `<c:dPt><c:explosion val>` (§21.2.2.61) — pie/doughnut slice pull-out
+    /// percentage (0–100). `None`/absent = 0 (byte-stable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explosion: Option<u32>,
 }
 
 /// Mirror of TS `ChartDataLabelOverride`.
@@ -666,6 +718,141 @@ pub fn extract_axis_title_with_props(
     }
 }
 
+// ============================================================================
+// Chart text font faces (CH10) — `<c:txPr>` / `<c:title>` → `<a:latin@typeface>`
+// ============================================================================
+
+/// First `<a:latin typeface>` (DrawingML §20.1.4.2.24) descendant of `container`.
+/// Empty typefaces are dropped; a theme reference like `+mn-lt` / `+mj-lt` is
+/// returned verbatim so the caller can resolve it against the font scheme.
+fn first_latin_typeface(container: Node) -> Option<String> {
+    container.descendants().find_map(|n| {
+        if !n.is_element() || n.tag_name().name() != "latin" {
+            return None;
+        }
+        n.attribute("typeface")
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+    })
+}
+
+/// `<c:catAx|valAx><c:txPr>…<a:latin typeface>` — the axis tick-label font face.
+/// Scoped to the axis's `<c:txPr>` so an axis *title* face (under `<c:title>`)
+/// is not misread as the tick face. `None` when absent (renderer falls back to
+/// the theme body font, then sans-serif).
+pub fn extract_axis_tick_label_face(axis_node: Node) -> Option<String> {
+    first_latin_typeface(child(axis_node, "txPr")?)
+}
+
+/// `<c:catAx|valAx><c:title>…<a:latin typeface>` — the axis-title font face.
+/// Scoped to the axis's direct-child `<c:title>`. `None` when absent.
+pub fn extract_axis_title_face(axis_node: Node) -> Option<String> {
+    first_latin_typeface(child(axis_node, "title")?)
+}
+
+/// First `<c:dLbls><c:txPr>…<a:latin typeface>` in the chart — the data-label
+/// font face. Scoped to a `<c:txPr>` inside a `<c:dLbls>` so a series-value
+/// run's face isn't picked up. `None` when absent.
+pub fn extract_data_label_face(root: Node) -> Option<String> {
+    root.descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "dLbls")
+        .find_map(|dlbls| first_latin_typeface(child(dlbls, "txPr")?))
+}
+
+/// `<c:legend><c:txPr>` text properties (CH10). Returns
+/// `(face, size_hpt, bold)` — the legend `<a:latin typeface>`, first
+/// `<a:defRPr|rPr@sz>` (hundredths of a point) and `@b` bold flag. Color is
+/// resolved separately via [`extract_legend_font_color`] (needs the theme
+/// resolver). All `None` when the legend has no `<c:txPr>`.
+pub fn extract_legend_text_props(root: Node) -> (Option<String>, Option<i32>, Option<bool>) {
+    let Some(legend) = root
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "legend")
+    else {
+        return (None, None, None);
+    };
+    let Some(txpr) = child(legend, "txPr") else {
+        return (None, None, None);
+    };
+    let face = first_latin_typeface(txpr);
+    let size = txpr.descendants().find_map(|n| {
+        let tag = n.tag_name().name();
+        if n.is_element() && (tag == "defRPr" || tag == "rPr") {
+            n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
+        } else {
+            None
+        }
+    });
+    let bold = txpr.descendants().find_map(|n| {
+        let tag = n.tag_name().name();
+        if n.is_element() && (tag == "defRPr" || tag == "rPr") {
+            n.attribute("b")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        } else {
+            None
+        }
+    });
+    (face, size, bold)
+}
+
+/// `<c:legend><c:txPr>…<a:solidFill>` legend text color, resolved to a hex
+/// string (no `#`) via the caller's `ColorResolver`. Scoped to the legend's
+/// `<c:txPr>` so a legend-frame `<c:spPr>` fill doesn't leak. `None` when absent.
+pub fn extract_legend_font_color(root: Node, resolver: &dyn ColorResolver) -> Option<String> {
+    let legend = root
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "legend")?;
+    let txpr = child(legend, "txPr")?;
+    txpr.descendants().find_map(|n| {
+        if n.is_element() && n.tag_name().name() == "solidFill" {
+            resolver.resolve_solid_fill(n)
+        } else {
+            None
+        }
+    })
+}
+
+// ============================================================================
+// Pie / doughnut geometry (CH8)
+// ============================================================================
+
+/// `<c:doughnutChart><c:holeSize val>` (§21.2.2.60) — hole diameter percentage
+/// (1–90). Clamped to the ECMA range. `None` when absent. `root` is the chart
+/// space (or `<c:chart>`); the search is scoped to a `<c:doughnutChart>` so a
+/// hole size only ever comes from a doughnut plot.
+pub fn extract_hole_size(root: Node) -> Option<u32> {
+    let doughnut = root
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "doughnutChart")?;
+    child(doughnut, "holeSize")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.trim_end_matches('%').parse::<u32>().ok())
+        .map(|v| v.clamp(1, 90))
+}
+
+/// `<c:pieChart|doughnutChart><c:firstSliceAng val>` (§21.2.2.52) — start angle
+/// in degrees (0–360, clockwise from 12 o'clock). Clamped to the ECMA range.
+/// `None` when absent (renderer defaults to 0).
+pub fn extract_first_slice_angle(root: Node) -> Option<u32> {
+    root.descendants()
+        .find(|n| {
+            n.is_element()
+                && (n.tag_name().name() == "pieChart" || n.tag_name().name() == "doughnutChart")
+        })
+        .and_then(|pie| child(pie, "firstSliceAng"))
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<u32>().ok())
+        .map(|v| v.min(360))
+}
+
+/// `<c:dPt><c:explosion val>` (§21.2.2.61) — pie/doughnut slice pull-out
+/// percentage. Caller passes a `<c:dPt>` node. `None` when absent.
+pub fn extract_dpt_explosion(dpt_node: Node) -> Option<u32> {
+    child(dpt_node, "explosion")
+        .and_then(|n| n.attribute("val"))
+        .and_then(|v| v.parse::<u32>().ok())
+}
+
 /// Explicit chart-frame border from `<c:chartSpace><c:spPr><a:ln>` (ECMA-376
 /// §21.2.2.5 / DrawingML §20.1.2.2.24). `chart_space_root` is the
 /// `<c:chartSpace>` element. Returns `(srgb_color, width_emu)` under the locked
@@ -1034,6 +1221,19 @@ mod tests {
             scatter_style: None,
             radar_style: None,
             secondary_val_axis: None,
+            hole_size: None,
+            first_slice_angle: None,
+            cat_axis_font_face: None,
+            val_axis_font_face: None,
+            cat_axis_title_font_face: None,
+            val_axis_title_font_face: None,
+            data_label_font_face: None,
+            legend_font_face: None,
+            legend_font_color: None,
+            legend_font_size_hpt: None,
+            legend_font_bold: None,
+            theme_major_font_latin: None,
+            theme_minor_font_latin: None,
             date1904: false,
             disp_blanks_as: None,
         };
@@ -1531,5 +1731,128 @@ mod tests {
         // Absent element ⇒ false (default 1900 system).
         let absent = format!(r#"<c:chartSpace xmlns:c="{ns}"/>"#);
         assert!(!extract_chart_date1904(root_of(&absent).root_element()));
+    }
+
+    // ── CH8 — pie / doughnut geometry ───────────────────────────────────────
+
+    const C_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    #[test]
+    fn hole_size_from_doughnut() {
+        let xml = format!(
+            r#"<c:chart xmlns:c="{C_NS}"><c:plotArea><c:doughnutChart><c:holeSize val="60"/></c:doughnutChart></c:plotArea></c:chart>"#
+        );
+        assert_eq!(extract_hole_size(root_of(&xml).root_element()), Some(60));
+        // Clamped to the ECMA 1–90 range.
+        let hi = format!(
+            r#"<c:chart xmlns:c="{C_NS}"><c:doughnutChart><c:holeSize val="200"/></c:doughnutChart></c:chart>"#
+        );
+        assert_eq!(extract_hole_size(root_of(&hi).root_element()), Some(90));
+        // A pie chart has no hole → None even if a stray holeSize appears elsewhere.
+        let pie = format!(r#"<c:chart xmlns:c="{C_NS}"><c:pieChart/></c:chart>"#);
+        assert_eq!(extract_hole_size(root_of(&pie).root_element()), None);
+    }
+
+    #[test]
+    fn first_slice_angle_from_pie_or_doughnut() {
+        let pie = format!(
+            r#"<c:chart xmlns:c="{C_NS}"><c:pieChart><c:firstSliceAng val="90"/></c:pieChart></c:chart>"#
+        );
+        assert_eq!(
+            extract_first_slice_angle(root_of(&pie).root_element()),
+            Some(90)
+        );
+        let dn = format!(
+            r#"<c:chart xmlns:c="{C_NS}"><c:doughnutChart><c:firstSliceAng val="270"/></c:doughnutChart></c:chart>"#
+        );
+        assert_eq!(
+            extract_first_slice_angle(root_of(&dn).root_element()),
+            Some(270)
+        );
+        // Absent ⇒ None (renderer defaults to 0).
+        let none = format!(r#"<c:chart xmlns:c="{C_NS}"><c:pieChart/></c:chart>"#);
+        assert_eq!(
+            extract_first_slice_angle(root_of(&none).root_element()),
+            None
+        );
+    }
+
+    #[test]
+    fn dpt_explosion() {
+        let with =
+            format!(r#"<c:dPt xmlns:c="{C_NS}"><c:idx val="1"/><c:explosion val="25"/></c:dPt>"#);
+        assert_eq!(
+            extract_dpt_explosion(root_of(&with).root_element()),
+            Some(25)
+        );
+        let without = format!(r#"<c:dPt xmlns:c="{C_NS}"><c:idx val="1"/></c:dPt>"#);
+        assert_eq!(
+            extract_dpt_explosion(root_of(&without).root_element()),
+            None
+        );
+    }
+
+    // ── CH10 — chart text font faces ────────────────────────────────────────
+
+    #[test]
+    fn axis_tick_and_title_faces() {
+        // Tick face lives in the axis `<c:txPr>`; the title face in `<c:title>`.
+        // Extractors must NOT cross-contaminate.
+        let xml = format!(
+            r#"<c:valAx xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+                 <c:title><a:p><a:r><a:rPr><a:latin typeface="Georgia"/></a:rPr><a:t>Y</a:t></a:r></a:p></c:title>
+                 <c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface="Verdana"/></a:defRPr></a:pPr></a:p></c:txPr>
+               </c:valAx>"#
+        );
+        let root = root_of(&xml);
+        let ax = root.root_element();
+        assert_eq!(extract_axis_tick_label_face(ax).as_deref(), Some("Verdana"));
+        assert_eq!(extract_axis_title_face(ax).as_deref(), Some("Georgia"));
+    }
+
+    #[test]
+    fn data_label_face_scoped_to_dlbls() {
+        let xml = format!(
+            r#"<c:chart xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+                 <c:plotArea><c:barChart>
+                   <c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface="Consolas"/></a:defRPr></a:pPr></a:p></c:txPr></c:dLbls>
+                 </c:barChart></c:plotArea>
+               </c:chart>"#
+        );
+        assert_eq!(
+            extract_data_label_face(root_of(&xml).root_element()).as_deref(),
+            Some("Consolas")
+        );
+    }
+
+    #[test]
+    fn legend_text_props_face_size_bold() {
+        let xml = format!(
+            r#"<c:chart xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+                 <c:legend><c:legendPos val="b"/>
+                   <c:txPr><a:p><a:pPr><a:defRPr sz="1100" b="1"><a:latin typeface="Calibri"/></a:defRPr></a:pPr></a:p></c:txPr>
+                 </c:legend>
+               </c:chart>"#
+        );
+        let (face, size, bold) = extract_legend_text_props(root_of(&xml).root_element());
+        assert_eq!(face.as_deref(), Some("Calibri"));
+        assert_eq!(size, Some(1100));
+        assert_eq!(bold, Some(true));
+    }
+
+    #[test]
+    fn theme_reference_typeface_passes_through() {
+        // A `+mn-lt` theme reference is returned verbatim (the renderer resolves
+        // it against the theme font scheme).
+        let xml = format!(
+            r#"<c:valAx xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+                 <c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface="+mn-lt"/></a:defRPr></a:pPr></a:p></c:txPr>
+               </c:valAx>"#
+        );
+        assert_eq!(
+            extract_axis_tick_label_face(root_of(&xml).root_element()).as_deref(),
+            Some("+mn-lt")
+        );
     }
 }

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -882,6 +882,28 @@ pub(crate) fn parse_legacy_chart(
     let hole_size = ooxml_common::chart::extract_hole_size(root);
     let first_slice_angle = ooxml_common::chart::extract_first_slice_angle(root);
 
+    // ── Axis scale model (CH6) ──────────────────────────────────────────────
+    // Gridline presence, manual major/minor units, log scale and orientation —
+    // all via the shared ooxml-common extractors on the primary val/cat axes.
+    // `<c:majorGridlines>` presence: Office writes it on the value axis by
+    // default (renderer keeps its historical always-on when the field is None),
+    // so we only emit `Some(false)` when a value axis EXISTS without the element.
+    let val_axis_major_gridlines =
+        val_ax.map(|ax| ooxml_common::chart::axis_has_major_gridlines(ax));
+    let cat_axis_major_gridlines =
+        cat_ax.map(|ax| ooxml_common::chart::axis_has_major_gridlines(ax));
+    let val_axis_minor_gridlines =
+        val_ax.map(|ax| ooxml_common::chart::axis_has_minor_gridlines(ax));
+    let val_axis_major_unit = val_ax.and_then(ooxml_common::chart::extract_axis_major_unit);
+    let val_axis_minor_unit = val_ax.and_then(ooxml_common::chart::extract_axis_minor_unit);
+    let val_axis_log_base = val_ax.and_then(ooxml_common::chart::extract_axis_log_base);
+    let val_axis_orientation = val_ax.and_then(ooxml_common::chart::extract_axis_orientation);
+    let cat_axis_orientation = cat_ax.and_then(ooxml_common::chart::extract_axis_orientation);
+    let cat_axis_tick_label_pos = cat_ax.and_then(ooxml_common::chart::extract_axis_tick_label_pos);
+    let val_axis_tick_label_pos = val_ax.and_then(ooxml_common::chart::extract_axis_tick_label_pos);
+    let cat_axis_label_rotation =
+        cat_ax.and_then(ooxml_common::chart::extract_axis_tick_label_rotation);
+
     // Chart title font face (`<c:title>…<a:latin>`) — parity with xlsx, which
     // already extracts it. `extract_axis_title_face` scopes to a node's
     // direct-child `<c:title>`, so pass the title's parent (`<c:chart>`).
@@ -982,6 +1004,18 @@ pub(crate) fn parse_legacy_chart(
             radar_style: None,
             date1904,
             disp_blanks_as,
+            // ── Axis scale model (CH6) ──────────────────────────────────────
+            val_axis_major_gridlines,
+            cat_axis_major_gridlines,
+            val_axis_minor_gridlines,
+            val_axis_major_unit,
+            val_axis_minor_unit,
+            val_axis_log_base,
+            val_axis_orientation,
+            cat_axis_orientation,
+            cat_axis_tick_label_pos,
+            val_axis_tick_label_pos,
+            cat_axis_label_rotation,
         },
     })
 }
@@ -1254,6 +1288,20 @@ pub(crate) fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Optio
             date1904: false,
             // chartEx waterfall has no line/area blanks to display.
             disp_blanks_as: None,
+            // chartEx (cx:) has its own axis model (`<cx:axis>`); the classic
+            // `<c:catAx>`/`<c:valAx>` scale properties don't apply, so leave the
+            // CH6 fields unset — the renderer keeps its defaults (byte-stable).
+            val_axis_major_gridlines: None,
+            cat_axis_major_gridlines: None,
+            val_axis_minor_gridlines: None,
+            val_axis_major_unit: None,
+            val_axis_minor_unit: None,
+            val_axis_log_base: None,
+            val_axis_orientation: None,
+            cat_axis_orientation: None,
+            cat_axis_tick_label_pos: None,
+            val_axis_tick_label_pos: None,
+            cat_axis_label_rotation: None,
         },
     })
 }

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -564,6 +564,12 @@ pub(crate) fn parse_legacy_chart(
                 // Shared with the xlsx parser via ooxml-common so both honor the
                 // CT_Boolean implied-true semantics.
                 smooth: ooxml_common::chart::extract_series_smooth(*ser),
+                // `<c:ser><c:trendline>` (§21.2.2.211) — regression lines. Shared
+                // extractor; the line color resolves through the pptx theme.
+                trend_lines: ooxml_common::chart::extract_series_trendlines(
+                    *ser,
+                    &PptxColorResolver { theme },
+                ),
             }
         })
         .collect();
@@ -1173,6 +1179,8 @@ pub(crate) fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Optio
         err_bars: None,
         // chartEx (waterfall) has no `<c:smooth>` concept.
         smooth: None,
+        // chartEx series carry no classic `<c:trendline>`.
+        trend_lines: None,
     }];
 
     // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -465,6 +465,32 @@ pub(crate) fn parse_legacy_chart(
 
             let has_dpt_colors = data_point_colors.iter().any(|c| c.is_some());
 
+            // Per-point `<c:dPt><c:explosion>` (§21.2.2.61) — pie/doughnut slice
+            // pull-out. Only the explosion is captured here (fills already flow
+            // through `data_point_colors`); a dPt with no explosion yields no
+            // override so the wire stays clean for the common non-exploded pie.
+            let data_point_overrides: Vec<ooxml_common::chart::ChartDataPointOverride> = ser
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "dPt")
+                .filter_map(|dpt| {
+                    let idx = dpt
+                        .children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "idx")
+                        .and_then(|n| attr(&n, "val"))
+                        .and_then(|v| v.parse::<u32>().ok())?;
+                    let explosion = ooxml_common::chart::extract_dpt_explosion(dpt)?;
+                    Some(ooxml_common::chart::ChartDataPointOverride {
+                        idx,
+                        color: None,
+                        marker_symbol: None,
+                        marker_size: None,
+                        marker_fill: None,
+                        marker_line: None,
+                        explosion: Some(explosion),
+                    })
+                })
+                .collect();
+
             // Series value number format from `<c:val>…<c:numCache><c:formatCode>`.
             // Used for data labels when `<c:dLbls>` carries no explicit `<c:numFmt>`
             // (ECMA-376 §21.2.2.121). "General" means "no format" → drop it so the
@@ -526,7 +552,11 @@ pub(crate) fn parse_legacy_chart(
                 marker_size: None,
                 marker_fill: None,
                 marker_line: None,
-                data_point_overrides: None,
+                data_point_overrides: if data_point_overrides.is_empty() {
+                    None
+                } else {
+                    Some(data_point_overrides)
+                },
                 data_label_overrides: None,
                 series_data_labels: None,
                 err_bars: None,
@@ -752,10 +782,12 @@ pub(crate) fn parse_legacy_chart(
     let mut cat_axis_title_size: Option<i32> = None;
     let mut cat_axis_title_bold: Option<bool> = None;
     let mut cat_axis_title_color: Option<String> = None;
+    let mut cat_axis_title_face: Option<String> = None;
     let mut val_axis_title: Option<String> = None;
     let mut val_axis_title_size: Option<i32> = None;
     let mut val_axis_title_bold: Option<bool> = None;
     let mut val_axis_title_color: Option<String> = None;
+    let mut val_axis_title_face: Option<String> = None;
     for ax in plot_area
         .children()
         .filter(|n| n.is_element() && matches!(n.tag_name().name(), "catAx" | "dateAx" | "valAx"))
@@ -779,6 +811,7 @@ pub(crate) fn parse_legacy_chart(
                     cat_axis_title_size = sz;
                     cat_axis_title_bold = b;
                     cat_axis_title_color = col;
+                    cat_axis_title_face = ooxml_common::chart::extract_axis_title_face(ax);
                 }
             }
         } else if val_axis_title.is_none() {
@@ -788,6 +821,7 @@ pub(crate) fn parse_legacy_chart(
                 val_axis_title_size = sz;
                 val_axis_title_bold = b;
                 val_axis_title_color = col;
+                val_axis_title_face = ooxml_common::chart::extract_axis_title_face(ax);
             }
         }
     }
@@ -823,6 +857,38 @@ pub(crate) fn parse_legacy_chart(
     // line/area. Shared with the xlsx parser via ooxml-common.
     let disp_blanks_as = ooxml_common::chart::extract_disp_blanks_as(root);
 
+    // ── Chart text font faces (CH10) ────────────────────────────────────────
+    // Tick-label faces (`<c:catAx|valAx><c:txPr>…<a:latin>`), data-label face
+    // (`<c:dLbls><c:txPr>…<a:latin>`) and legend text props, all via the shared
+    // ooxml-common extractors so pptx/xlsx stay in lockstep. Absent faces stay
+    // None; the renderer falls back to the theme body/heading font.
+    let cat_axis_font_face = cat_ax.and_then(ooxml_common::chart::extract_axis_tick_label_face);
+    let val_axis_font_face = val_ax.and_then(ooxml_common::chart::extract_axis_tick_label_face);
+    let data_label_font_face = ooxml_common::chart::extract_data_label_face(root);
+    let (legend_font_face, legend_font_size_hpt, legend_font_bold) =
+        ooxml_common::chart::extract_legend_text_props(root);
+    let legend_font_color = {
+        let resolver = PptxColorResolver { theme };
+        ooxml_common::chart::extract_legend_font_color(root, &resolver)
+    };
+    // Theme fallback fonts: pptx stores the theme's major/minor Latin faces in
+    // the `+mj-lt` / `+mn-lt` keys of the color+font map (see lib.rs
+    // parse_theme_colors). None when the theme lacks a fontScheme.
+    let theme_major_font_latin = theme.get("+mj-lt").cloned();
+    let theme_minor_font_latin = theme.get("+mn-lt").cloned();
+
+    // ── Pie / doughnut geometry (CH8) ───────────────────────────────────────
+    // holeSize (doughnut) / firstSliceAng (pie + doughnut), shared extractors.
+    let hole_size = ooxml_common::chart::extract_hole_size(root);
+    let first_slice_angle = ooxml_common::chart::extract_first_slice_angle(root);
+
+    // Chart title font face (`<c:title>…<a:latin>`) — parity with xlsx, which
+    // already extracts it. `extract_axis_title_face` scopes to a node's
+    // direct-child `<c:title>`, so pass the title's parent (`<c:chart>`).
+    let title_font_face = title_node_opt
+        .and_then(|t| t.parent())
+        .and_then(ooxml_common::chart::extract_axis_title_face);
+
     Some(ChartElement {
         x: 0,
         y: 0,
@@ -847,7 +913,7 @@ pub(crate) fn parse_legacy_chart(
             cat_axis_major_tick_mark,
             title_font_size_hpt,
             title_font_color: None,
-            title_font_face: None,
+            title_font_face,
             cat_axis_font_size_hpt,
             val_axis_font_size_hpt,
             cat_axis_font_color,
@@ -885,6 +951,20 @@ pub(crate) fn parse_legacy_chart(
             chart_border_color,
             chart_border_width_emu,
             secondary_val_axis,
+            // Pie/doughnut geometry (CH8) + chart text font faces (CH10).
+            hole_size,
+            first_slice_angle,
+            cat_axis_font_face,
+            val_axis_font_face,
+            cat_axis_title_font_face: cat_axis_title_face,
+            val_axis_title_font_face: val_axis_title_face,
+            data_label_font_face,
+            legend_font_face,
+            legend_font_color,
+            legend_font_size_hpt,
+            legend_font_bold,
+            theme_major_font_latin,
+            theme_minor_font_latin,
             // ChartModel fields the legacy pptx `<c:chart>` path leaves unset
             // (they were never in the pptx `ChartElement` copy, so they defaulted
             // to `undefined` on the TS side and stay absent on the wire).
@@ -1140,6 +1220,22 @@ pub(crate) fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Optio
             chart_border_color: None,
             chart_border_width_emu: None,
             secondary_val_axis: None,
+            // chartEx charts (waterfall/treemap/etc.) are not pie/doughnut and
+            // don't carry `<c:txPr>` axis/legend faces; only the theme fallback
+            // fonts are threaded so their data labels can pick up the body font.
+            hole_size: None,
+            first_slice_angle: None,
+            cat_axis_font_face: None,
+            val_axis_font_face: None,
+            cat_axis_title_font_face: None,
+            val_axis_title_font_face: None,
+            data_label_font_face: None,
+            legend_font_face: None,
+            legend_font_color: None,
+            legend_font_size_hpt: None,
+            legend_font_bold: None,
+            theme_major_font_latin: theme.get("+mj-lt").cloned(),
+            theme_minor_font_latin: theme.get("+mn-lt").cloned(),
             val_axis_minor_tick_mark: None,
             cat_axis_minor_tick_mark: None,
             legend_manual_layout: None,

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -259,6 +259,18 @@ impl From<ChartData> for ChartModel {
             theme_minor_font_latin: c.theme_minor_font_latin,
             date1904: c.date1904,
             disp_blanks_as: c.disp_blanks_as,
+            // ── Axis scale model (CH6) ──────────────────────────────────────
+            val_axis_major_gridlines: c.val_axis_major_gridlines,
+            cat_axis_major_gridlines: c.cat_axis_major_gridlines,
+            val_axis_minor_gridlines: c.val_axis_minor_gridlines,
+            val_axis_major_unit: c.val_axis_major_unit,
+            val_axis_minor_unit: c.val_axis_minor_unit,
+            val_axis_log_base: c.val_axis_log_base,
+            val_axis_orientation: c.val_axis_orientation,
+            cat_axis_orientation: c.cat_axis_orientation,
+            cat_axis_tick_label_pos: c.cat_axis_tick_label_pos,
+            val_axis_tick_label_pos: c.val_axis_tick_label_pos,
+            cat_axis_label_rotation: c.cat_axis_label_rotation,
         }
     }
 }
@@ -659,6 +671,21 @@ pub(crate) fn parse_chart_xml(
     let mut cat_axis_crosses_at: Option<f64> = None;
     let mut val_axis_crosses: Option<String> = None;
     let mut val_axis_crosses_at: Option<f64> = None;
+    // ── Axis scale model (CH6) — gridlines / units / logBase / orientation ──
+    // Populated in the catAx/valAx branches via the shared ooxml-common
+    // extractors. Gridline flags stay None unless the corresponding axis is
+    // seen, so a chart with no value axis keeps the renderer's default gridlines.
+    let mut val_axis_major_gridlines: Option<bool> = None;
+    let mut cat_axis_major_gridlines: Option<bool> = None;
+    let mut val_axis_minor_gridlines: Option<bool> = None;
+    let mut val_axis_major_unit: Option<f64> = None;
+    let mut val_axis_minor_unit: Option<f64> = None;
+    let mut val_axis_log_base: Option<f64> = None;
+    let mut val_axis_orientation: Option<String> = None;
+    let mut cat_axis_orientation: Option<String> = None;
+    let mut cat_axis_tick_label_pos: Option<String> = None;
+    let mut val_axis_tick_label_pos: Option<String> = None;
+    let mut cat_axis_label_rotation: Option<i32> = None;
     let mut bar_gap_width: Option<i32> = None;
     let mut bar_overlap: Option<i32> = None;
     let mut radar_style: Option<String> = None;
@@ -740,6 +767,22 @@ pub(crate) fn parse_chart_xml(
                 }
                 if cat_axis_minor_tick_mark.is_none() {
                     cat_axis_minor_tick_mark = extract_axis_tick_mark(&child, "minorTickMark");
+                }
+                // ── Axis scale model (CH6) — category axis ──────────────────
+                if cat_axis_major_gridlines.is_none() {
+                    cat_axis_major_gridlines =
+                        Some(ooxml_common::chart::axis_has_major_gridlines(child));
+                }
+                if cat_axis_orientation.is_none() {
+                    cat_axis_orientation = ooxml_common::chart::extract_axis_orientation(child);
+                }
+                if cat_axis_tick_label_pos.is_none() {
+                    cat_axis_tick_label_pos =
+                        ooxml_common::chart::extract_axis_tick_label_pos(child);
+                }
+                if cat_axis_label_rotation.is_none() {
+                    cat_axis_label_rotation =
+                        ooxml_common::chart::extract_axis_tick_label_rotation(child);
                 }
                 if let Some((mn, mx)) = extract_axis_scaling(&child) {
                     if cat_axis_min.is_none() {
@@ -827,6 +870,22 @@ pub(crate) fn parse_chart_xml(
                     if cat_axis_minor_tick_mark.is_none() {
                         cat_axis_minor_tick_mark = extract_axis_tick_mark(&child, "minorTickMark");
                     }
+                    // ── Axis scale model (CH6) — scatter X (category) axis ──
+                    if cat_axis_major_gridlines.is_none() {
+                        cat_axis_major_gridlines =
+                            Some(ooxml_common::chart::axis_has_major_gridlines(child));
+                    }
+                    if cat_axis_orientation.is_none() {
+                        cat_axis_orientation = ooxml_common::chart::extract_axis_orientation(child);
+                    }
+                    if cat_axis_tick_label_pos.is_none() {
+                        cat_axis_tick_label_pos =
+                            ooxml_common::chart::extract_axis_tick_label_pos(child);
+                    }
+                    if cat_axis_label_rotation.is_none() {
+                        cat_axis_label_rotation =
+                            ooxml_common::chart::extract_axis_tick_label_rotation(child);
+                    }
                     let (cr, cra) = extract_axis_crosses(&child);
                     if cat_axis_crosses.is_none() {
                         cat_axis_crosses = cr;
@@ -894,6 +953,31 @@ pub(crate) fn parse_chart_xml(
                     }
                     if val_axis_minor_tick_mark.is_none() {
                         val_axis_minor_tick_mark = extract_axis_tick_mark(&child, "minorTickMark");
+                    }
+                    // ── Axis scale model (CH6) — value axis ─────────────────
+                    if val_axis_major_gridlines.is_none() {
+                        val_axis_major_gridlines =
+                            Some(ooxml_common::chart::axis_has_major_gridlines(child));
+                    }
+                    if val_axis_minor_gridlines.is_none() {
+                        val_axis_minor_gridlines =
+                            Some(ooxml_common::chart::axis_has_minor_gridlines(child));
+                    }
+                    if val_axis_major_unit.is_none() {
+                        val_axis_major_unit = ooxml_common::chart::extract_axis_major_unit(child);
+                    }
+                    if val_axis_minor_unit.is_none() {
+                        val_axis_minor_unit = ooxml_common::chart::extract_axis_minor_unit(child);
+                    }
+                    if val_axis_log_base.is_none() {
+                        val_axis_log_base = ooxml_common::chart::extract_axis_log_base(child);
+                    }
+                    if val_axis_orientation.is_none() {
+                        val_axis_orientation = ooxml_common::chart::extract_axis_orientation(child);
+                    }
+                    if val_axis_tick_label_pos.is_none() {
+                        val_axis_tick_label_pos =
+                            ooxml_common::chart::extract_axis_tick_label_pos(child);
                     }
                     if axis_is_deleted(&child) {
                         val_axis_hidden = true;
@@ -1146,6 +1230,18 @@ pub(crate) fn parse_chart_xml(
         legend_font_bold,
         theme_major_font_latin: theme_major_font_latin.map(|s| s.to_string()),
         theme_minor_font_latin: theme_minor_font_latin.map(|s| s.to_string()),
+        // ── Axis scale model (CH6) ──────────────────────────────────────────
+        val_axis_major_gridlines,
+        cat_axis_major_gridlines,
+        val_axis_minor_gridlines,
+        val_axis_major_unit,
+        val_axis_minor_unit,
+        val_axis_log_base,
+        val_axis_orientation,
+        cat_axis_orientation,
+        cat_axis_tick_label_pos,
+        val_axis_tick_label_pos,
+        cat_axis_label_rotation,
     })
 }
 

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -146,6 +146,8 @@ impl From<ChartSeries> for CmSeries {
             err_bars: some_if_nonempty(s.err_bars),
             bubble_sizes: None,
             smooth: s.smooth,
+            // Shared `ChartTrendline` type flows straight through (no adapter).
+            trend_lines: s.trend_lines,
             // `order` is xlsx parse-time only (used for stacking/legend sort
             // before emit); core `ChartSeries` has no such field.
         }
@@ -1629,6 +1631,10 @@ pub(crate) fn parse_chart_series(
     // `<c:ser><c:smooth>` (§21.2.2.194) — line/area spline flag. Shared with the
     // pptx parser so both honor the CT_Boolean implied-true semantics.
     let smooth = ooxml_common::chart::extract_series_smooth(*node);
+    // `<c:ser><c:trendline>` (§21.2.2.211) — regression lines. Shared extractor;
+    // the line color resolves through the workbook theme.
+    let trend_lines =
+        ooxml_common::chart::extract_series_trendlines(*node, &XlsxColorResolver { theme_colors });
 
     ChartSeries {
         name,
@@ -1649,6 +1655,7 @@ pub(crate) fn parse_chart_series(
         series_data_labels,
         err_bars,
         smooth,
+        trend_lines,
     }
 }
 

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -55,6 +55,7 @@ impl From<DataPointOverride> for CmDataPointOverride {
             marker_size: o.marker_size.map(|v| v as f64),
             marker_fill: o.marker_fill,
             marker_line: o.marker_line,
+            explosion: o.explosion,
         }
     }
 }
@@ -242,6 +243,20 @@ impl From<ChartData> for ChartModel {
             scatter_style: None,
             radar_style: c.radar_style,
             secondary_val_axis: None,
+            // Pie/doughnut geometry (CH8) + chart text font faces (CH10).
+            hole_size: c.hole_size,
+            first_slice_angle: c.first_slice_angle,
+            cat_axis_font_face: c.cat_axis_font_face,
+            val_axis_font_face: c.val_axis_font_face,
+            cat_axis_title_font_face: c.cat_axis_title_font_face,
+            val_axis_title_font_face: c.val_axis_title_font_face,
+            data_label_font_face: c.data_label_font_face,
+            legend_font_face: c.legend_font_face,
+            legend_font_color: c.legend_font_color,
+            legend_font_size_hpt: c.legend_font_size_hpt,
+            legend_font_bold: c.legend_font_bold,
+            theme_major_font_latin: c.theme_major_font_latin,
+            theme_minor_font_latin: c.theme_minor_font_latin,
             date1904: c.date1904,
             disp_blanks_as: c.disp_blanks_as,
         }
@@ -254,6 +269,7 @@ pub(crate) fn load_sheet_charts(
     archive: &mut crate::XlsxZip,
     sheet_path: &str,
     theme_colors: &[String],
+    theme_fonts: (Option<&str>, Option<&str>),
 ) -> Vec<ChartAnchor> {
     let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
         return Vec::new();
@@ -423,7 +439,7 @@ pub(crate) fn load_sheet_charts(
             let Ok(chart_xml) = read_zip_string(archive, &chart_path) else {
                 continue;
             };
-            let Some(chart_data) = parse_chart_xml(&chart_xml, theme_colors) else {
+            let Some(chart_data) = parse_chart_xml(&chart_xml, theme_colors, theme_fonts) else {
                 continue;
             };
 
@@ -447,8 +463,15 @@ pub(crate) fn load_sheet_charts(
 
 // ─── Chart XML parser ────────────────────────────────────────────────────────
 
-/// Parse a `xl/charts/chartN.xml` file into a `ChartData`.
-pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<ChartData> {
+/// Parse a `xl/charts/chartN.xml` file into a `ChartData`. `theme_fonts` is the
+/// workbook theme's `(majorFont.latin, minorFont.latin)` Latin faces (ECMA-376
+/// §20.1.4.2), used as the fallback for chart text elements whose `<c:txPr>`
+/// carries no `<a:latin>` (CH10).
+pub(crate) fn parse_chart_xml(
+    xml: &str,
+    theme_colors: &[String],
+    theme_fonts: (Option<&str>, Option<&str>),
+) -> Option<ChartData> {
     let doc = roxmltree::Document::parse(xml).ok()?;
 
     // Find c:chart root element
@@ -462,6 +485,7 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
     let title_font_color = extract_chart_title_color(&chart_root);
     let title_font_face = extract_chart_title_face(&chart_root);
     let title_font_bold = extract_chart_title_bold(&chart_root);
+    let (theme_major_font_latin, theme_minor_font_latin) = theme_fonts;
 
     // Legend presence: <c:chart><c:legend> is the authoritative signal. Absence
     // means Excel hides the legend (default for a single-series chart with no
@@ -602,6 +626,12 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
     let mut val_axis_title_color: Option<String> = None;
     let mut cat_axis_font_size_hpt: Option<i32> = None;
     let mut val_axis_font_size_hpt: Option<i32> = None;
+    // Axis tick-label + title font faces (CH10, `<c:txPr>`/`<c:title>` →
+    // `<a:latin typeface>`), populated in the axis loop via ooxml-common helpers.
+    let mut cat_axis_font_face: Option<String> = None;
+    let mut val_axis_font_face: Option<String> = None;
+    let mut cat_axis_title_font_face: Option<String> = None;
+    let mut val_axis_title_font_face: Option<String> = None;
     let mut val_axis_format_code: Option<String> = None;
     // ECMA-376 §21.2.2.40 — `<c:delete val="1"/>` on a `<c:catAx>`/`<c:valAx>`
     // hides the axis (labels, ticks, and lines). Default is "0" (visible).
@@ -680,10 +710,15 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
                         cat_axis_title_size = sz;
                         cat_axis_title_bold = b;
                         cat_axis_title_color = c;
+                        cat_axis_title_font_face =
+                            ooxml_common::chart::extract_axis_title_face(child);
                     }
                 }
                 if cat_axis_font_size_hpt.is_none() {
                     cat_axis_font_size_hpt = extract_axis_tick_label_size(&child);
+                }
+                if cat_axis_font_face.is_none() {
+                    cat_axis_font_face = ooxml_common::chart::extract_axis_tick_label_face(child);
                 }
                 if cat_axis_format_code.is_none() {
                     cat_axis_format_code = extract_axis_format_code(&child);
@@ -752,6 +787,8 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
                             cat_axis_title_size = sz;
                             cat_axis_title_bold = b;
                             cat_axis_title_color = c;
+                            cat_axis_title_font_face =
+                                ooxml_common::chart::extract_axis_title_face(child);
                         }
                     }
                     if cat_axis_format_code.is_none() {
@@ -767,6 +804,10 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
                     }
                     if cat_axis_font_size_hpt.is_none() {
                         cat_axis_font_size_hpt = extract_axis_tick_label_size(&child);
+                    }
+                    if cat_axis_font_face.is_none() {
+                        cat_axis_font_face =
+                            ooxml_common::chart::extract_axis_tick_label_face(child);
                     }
                     if cat_axis_font_bold.is_none() {
                         cat_axis_font_bold = extract_axis_tick_label_bold(&child);
@@ -807,10 +848,16 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
                             val_axis_title_size = sz;
                             val_axis_title_bold = b;
                             val_axis_title_color = c;
+                            val_axis_title_font_face =
+                                ooxml_common::chart::extract_axis_title_face(child);
                         }
                     }
                     if val_axis_font_size_hpt.is_none() {
                         val_axis_font_size_hpt = extract_axis_tick_label_size(&child);
+                    }
+                    if val_axis_font_face.is_none() {
+                        val_axis_font_face =
+                            ooxml_common::chart::extract_axis_tick_label_face(child);
                     }
                     if val_axis_format_code.is_none() {
                         val_axis_format_code = extract_axis_format_code(&child);
@@ -1010,6 +1057,19 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
     // legend order, independent of document order.
     all_series.sort_by_key(|s| s.order);
 
+    // ── Chart text font faces (CH10) ────────────────────────────────────────
+    // Data-label face + legend text props via the shared ooxml-common helpers
+    // so xlsx/pptx stay in lockstep. Legend color needs the theme resolver.
+    let data_label_font_face = ooxml_common::chart::extract_data_label_face(chart_root);
+    let (legend_font_face, legend_font_size_hpt, legend_font_bold) =
+        ooxml_common::chart::extract_legend_text_props(chart_root);
+    let legend_font_color =
+        ooxml_common::chart::extract_legend_font_color(chart_root, &xlsx_resolver);
+
+    // ── Pie / doughnut geometry (CH8) ───────────────────────────────────────
+    let hole_size = ooxml_common::chart::extract_hole_size(chart_root);
+    let first_slice_angle = ooxml_common::chart::extract_first_slice_angle(chart_root);
+
     Some(ChartData {
         chart_type: primary_type,
         bar_dir,
@@ -1073,6 +1133,19 @@ pub(crate) fn parse_chart_xml(xml: &str, theme_colors: &[String]) -> Option<Char
         chart_border_width_emu,
         date1904,
         disp_blanks_as,
+        hole_size,
+        first_slice_angle,
+        cat_axis_font_face,
+        val_axis_font_face,
+        cat_axis_title_font_face,
+        val_axis_title_font_face,
+        data_label_font_face,
+        legend_font_face,
+        legend_font_color,
+        legend_font_size_hpt,
+        legend_font_bold,
+        theme_major_font_latin: theme_major_font_latin.map(|s| s.to_string()),
+        theme_minor_font_latin: theme_minor_font_latin.map(|s| s.to_string()),
     })
 }
 
@@ -1569,6 +1642,7 @@ pub(crate) fn parse_data_point_overrides(
             .find(|n| n.tag_name().name() == "marker" && is_c_ns(n.tag_name().namespace()));
         let (marker_symbol, marker_size, marker_fill, marker_line) =
             parse_marker_block(mk, theme_colors);
+        let explosion = ooxml_common::chart::extract_dpt_explosion(dpt);
         result.push(DataPointOverride {
             idx,
             color,
@@ -1576,6 +1650,7 @@ pub(crate) fn parse_data_point_overrides(
             marker_size,
             marker_fill,
             marker_line,
+            explosion,
         });
     }
     result
@@ -2237,7 +2312,7 @@ mod pie_doughnut_tests {
     #[test]
     fn pie_chart_series_and_categories() {
         let xml = pie_chart_xml("pieChart");
-        let chart = parse_chart_xml(&xml, &theme()).expect("pie chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("pie chart parses");
         assert_eq!(chart.chart_type, "pie");
         assert_eq!(chart.title.as_deref(), Some("Share"));
         assert_eq!(chart.categories, vec!["North", "South", "East"]);
@@ -2252,7 +2327,7 @@ mod pie_doughnut_tests {
     #[test]
     fn doughnut_chart_type() {
         let xml = pie_chart_xml("doughnutChart");
-        let chart = parse_chart_xml(&xml, &theme()).expect("doughnut chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("doughnut chart parses");
         assert_eq!(chart.chart_type, "doughnut");
         assert_eq!(chart.categories.len(), 3);
         assert_eq!(chart.series.len(), 1);
@@ -2306,7 +2381,7 @@ mod pie_doughnut_tests {
 
     #[test]
     fn adapter_bar_defaults_and_series_mapping() {
-        let data = parse_chart_xml(&bar_chart_xml(), &theme()).expect("bar parses");
+        let data = parse_chart_xml(&bar_chart_xml(), &theme(), (None, None)).expect("bar parses");
         // `order` exists on the parse-time series but not on the emitted model.
         assert_eq!(data.series[0].order, 0);
         let m = ChartModel::from(data);
@@ -2370,7 +2445,7 @@ mod pie_doughnut_tests {
             c = C_NS,
             a = A_NS,
         );
-        let m = ChartModel::from(parse_chart_xml(&xml, &theme()).expect("parses"));
+        let m = ChartModel::from(parse_chart_xml(&xml, &theme(), (None, None)).expect("parses"));
         assert_eq!(m.chart_type, "stackedBarH");
         // spPr present but noFill → transparent, so NOT the white default.
         assert!(
@@ -2395,7 +2470,7 @@ mod pie_doughnut_tests {
             c = C_NS,
             a = A_NS,
         );
-        let m = ChartModel::from(parse_chart_xml(&xml, &theme()).expect("parses"));
+        let m = ChartModel::from(parse_chart_xml(&xml, &theme(), (None, None)).expect("parses"));
         assert_eq!(m.chart_type, "line");
         assert!(m.series[0].categories.is_none());
     }
@@ -2420,7 +2495,7 @@ mod pie_doughnut_tests {
             c = C_NS,
             a = A_NS,
         );
-        let m = ChartModel::from(parse_chart_xml(&xml, &theme()).expect("parses"));
+        let m = ChartModel::from(parse_chart_xml(&xml, &theme(), (None, None)).expect("parses"));
         assert_eq!(m.series[0].smooth, Some(true));
         assert_eq!(m.series[1].smooth, None);
     }
@@ -2444,7 +2519,7 @@ mod pie_doughnut_tests {
             c = C_NS,
             a = A_NS,
         );
-        let m = ChartModel::from(parse_chart_xml(&with, &theme()).expect("parses"));
+        let m = ChartModel::from(parse_chart_xml(&with, &theme(), (None, None)).expect("parses"));
         assert_eq!(m.disp_blanks_as.as_deref(), Some("span"));
 
         let without = format!(
@@ -2458,7 +2533,8 @@ mod pie_doughnut_tests {
             c = C_NS,
             a = A_NS,
         );
-        let m0 = ChartModel::from(parse_chart_xml(&without, &theme()).expect("parses"));
+        let m0 =
+            ChartModel::from(parse_chart_xml(&without, &theme(), (None, None)).expect("parses"));
         assert_eq!(m0.disp_blanks_as, None);
     }
 
@@ -2480,7 +2556,7 @@ mod pie_doughnut_tests {
             c = C_NS,
             a = A_NS,
         );
-        let m = ChartModel::from(parse_chart_xml(&with, &theme()).expect("parses"));
+        let m = ChartModel::from(parse_chart_xml(&with, &theme(), (None, None)).expect("parses"));
         assert!(
             m.date1904,
             "<c:date1904/> must set ChartModel.date1904 = true"
@@ -2497,7 +2573,8 @@ mod pie_doughnut_tests {
             c = C_NS,
             a = A_NS,
         );
-        let m0 = ChartModel::from(parse_chart_xml(&without, &theme()).expect("parses"));
+        let m0 =
+            ChartModel::from(parse_chart_xml(&without, &theme(), (None, None)).expect("parses"));
         assert!(
             !m0.date1904,
             "absent <c:date1904> must leave the 1900 default"
@@ -2642,7 +2719,7 @@ mod axis_title_and_border_tests {
             <a:defRPr sz="1800" b="1"/>
           </a:pPr><a:r><a:rPr sz="1800" b="1"/><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx></c:title>"#;
         let xml = bar_chart_xml("", val_title, "");
-        let chart = parse_chart_xml(&xml, &theme()).expect("chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("chart parses");
         assert_eq!(chart.val_axis_title.as_deref(), Some("Revenue"));
         assert_eq!(chart.val_axis_title_size, Some(1800));
         assert_eq!(chart.val_axis_title_bold, Some(true));
@@ -2654,7 +2731,7 @@ mod axis_title_and_border_tests {
         let val_title = r#"<c:title><c:tx><c:rich><a:p>
             <a:r><a:rPr sz="1800"/><a:t>Units</a:t></a:r></a:p></c:rich></c:tx></c:title>"#;
         let xml = bar_chart_xml("", val_title, "");
-        let chart = parse_chart_xml(&xml, &theme()).expect("chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("chart parses");
         assert_eq!(chart.val_axis_title_size, Some(1800));
         assert_eq!(chart.val_axis_title_bold, None);
     }
@@ -2666,7 +2743,7 @@ mod axis_title_and_border_tests {
         let cat_title = r#"<c:title><c:tx><c:rich><a:p>
             <a:r><a:rPr sz="1800"><a:solidFill><a:srgbClr val="ff0000"/></a:solidFill></a:rPr><a:t>Month</a:t></a:r></a:p></c:rich></c:tx></c:title>"#;
         let xml = bar_chart_xml(cat_title, "", "");
-        let chart = parse_chart_xml(&xml, &theme()).expect("chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("chart parses");
         assert_eq!(chart.cat_axis_title.as_deref(), Some("Month"));
         assert_eq!(chart.cat_axis_title_size, Some(1800));
         assert_eq!(chart.cat_axis_title_color.as_deref(), Some("ff0000"));
@@ -2676,7 +2753,7 @@ mod axis_title_and_border_tests {
     #[test]
     fn fixture_c_no_sp_pr_no_border() {
         let xml = bar_chart_xml("", "", "");
-        let chart = parse_chart_xml(&xml, &theme()).expect("chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("chart parses");
         assert!(!chart.has_chart_sp_pr);
         assert_eq!(chart.chart_border_color, None);
         assert_eq!(chart.chart_border_width_emu, None);
@@ -2688,7 +2765,7 @@ mod axis_title_and_border_tests {
     fn fixture_d_explicit_ln_solid_fill_border() {
         let sp_pr = r#"<c:spPr><a:ln w="9525"><a:solidFill><a:srgbClr val="808080"/></a:solidFill></a:ln></c:spPr>"#;
         let xml = bar_chart_xml("", "", sp_pr);
-        let chart = parse_chart_xml(&xml, &theme()).expect("chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("chart parses");
         assert!(chart.has_chart_sp_pr);
         assert_eq!(chart.chart_border_color.as_deref(), Some("808080"));
         assert_eq!(chart.chart_border_width_emu, Some(9525));
@@ -2699,7 +2776,7 @@ mod axis_title_and_border_tests {
     fn fixture_e_ln_nofill_no_border() {
         let sp_pr = r#"<c:spPr><a:ln w="12700"><a:noFill/></a:ln></c:spPr>"#;
         let xml = bar_chart_xml("", "", sp_pr);
-        let chart = parse_chart_xml(&xml, &theme()).expect("chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("chart parses");
         assert!(chart.has_chart_sp_pr);
         assert_eq!(chart.chart_border_color, None);
     }
@@ -2760,7 +2837,7 @@ mod axis_title_and_border_tests {
         let y_title = r#"<c:title><c:tx><c:rich><a:p>
             <a:r><a:rPr sz="1800"/><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>"#;
         let xml = scatter_chart_xml(x_title, y_title);
-        let chart = parse_chart_xml(&xml, &theme()).expect("scatter parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("scatter parses");
         // Bottom (X) valAx → cat-axis title, bold 18pt.
         assert_eq!(chart.cat_axis_title.as_deref(), Some("Acid/Bromate"));
         assert_eq!(chart.cat_axis_title_size, Some(1800));
@@ -2914,7 +2991,7 @@ mod date_axis_tests {
     #[test]
     fn date_axis_format_code_populates_cat_axis_format_code() {
         let xml = date_axis_chart_xml(r#"<c:numFmt formatCode="m/d/yyyy" sourceLinked="0"/>"#);
-        let chart = parse_chart_xml(&xml, &theme()).expect("dateAx chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("dateAx chart parses");
         assert_eq!(chart.cat_axis_format_code.as_deref(), Some("m/d/yyyy"));
     }
 
@@ -2923,7 +3000,7 @@ mod date_axis_tests {
     #[test]
     fn date_axis_delete_hides_cat_axis() {
         let xml = date_axis_chart_xml(r#"<c:delete val="1"/>"#);
-        let chart = parse_chart_xml(&xml, &theme()).expect("dateAx chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("dateAx chart parses");
         assert!(chart.cat_axis_hidden);
     }
 
@@ -2933,7 +3010,7 @@ mod date_axis_tests {
         let title = r#"<c:title><c:tx><c:rich><a:p>
             <a:r><a:rPr sz="1200"/><a:t>Date</a:t></a:r></a:p></c:rich></c:tx></c:title>"#;
         let xml = date_axis_chart_xml(title);
-        let chart = parse_chart_xml(&xml, &theme()).expect("dateAx chart parses");
+        let chart = parse_chart_xml(&xml, &theme(), (None, None)).expect("dateAx chart parses");
         assert_eq!(chart.cat_axis_title.as_deref(), Some("Date"));
         assert_eq!(chart.cat_axis_title_size, Some(1200));
     }
@@ -2997,7 +3074,8 @@ mod strict_namespace_tests {
             a = A_NS_STRICT,
         );
 
-        let chart = parse_chart_xml(&xml, &theme()).expect("Strict chartSpace must parse");
+        let chart =
+            parse_chart_xml(&xml, &theme(), (None, None)).expect("Strict chartSpace must parse");
         assert_eq!(chart.chart_type, "bar");
         assert_eq!(chart.title.as_deref(), Some("Strict Share"));
         assert_eq!(chart.categories, vec!["Q1", "Q2"]);
@@ -3102,7 +3180,12 @@ mod hidden_tests {
     fn hidden_chart_graphicframe_is_not_emitted() {
         for attr in [r#" hidden="1""#, r#" hidden="true""#] {
             let mut archive = archive_with_chart(attr);
-            let charts = load_sheet_charts(&mut archive, "worksheets/sheet1.xml", &theme());
+            let charts = load_sheet_charts(
+                &mut archive,
+                "worksheets/sheet1.xml",
+                &theme(),
+                (None, None),
+            );
             assert!(charts.is_empty(), "hidden chart emitted (attr={attr})");
         }
     }
@@ -3111,7 +3194,12 @@ mod hidden_tests {
     fn visible_chart_graphicframe_is_emitted_unchanged() {
         for attr in ["", r#" hidden="0""#, r#" hidden="false""#] {
             let mut archive = archive_with_chart(attr);
-            let charts = load_sheet_charts(&mut archive, "worksheets/sheet1.xml", &theme());
+            let charts = load_sheet_charts(
+                &mut archive,
+                "worksheets/sheet1.xml",
+                &theme(),
+                (None, None),
+            );
             assert_eq!(charts.len(), 1, "visible chart dropped (attr={attr})");
         }
     }

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -85,6 +85,9 @@ struct WorkbookShared {
     rels_xml: String,
     sheets: Vec<SheetMeta>,
     theme_colors: Vec<String>,
+    /// Workbook theme `(majorFont.latin, minorFont.latin)` Latin faces
+    /// (§20.1.4.2). Chart-text fallback font (CH10).
+    theme_fonts: (Option<String>, Option<String>),
     shared_strings: Vec<SharedString>,
     /// Workbook date system (`<workbookPr date1904>`, ECMA-376 §18.2.28).
     /// `true` = 1904 date system. Parsed once here and denormalized onto every
@@ -113,12 +116,14 @@ impl WorkbookShared {
         };
         let rels_xml = read_zip_string(archive, "xl/_rels/workbook.xml.rels").unwrap_or_default();
         let theme_colors = parse_theme_colors(archive);
+        let theme_fonts = parse_theme_fonts(archive);
         let shared_strings = read_shared_strings(archive, &theme_colors);
         Ok(WorkbookShared {
             workbook_xml,
             rels_xml,
             sheets,
             theme_colors,
+            theme_fonts,
             shared_strings,
             date1904,
         })
@@ -171,7 +176,15 @@ fn parse_sheet_with(
     // list; their preview parts are referenced from the worksheet XML + rels.
     ws.images
         .extend(load_sheet_ole_images(archive, &sheet_path, &sheet_xml));
-    ws.charts = load_sheet_charts(archive, &sheet_path, theme_colors);
+    ws.charts = load_sheet_charts(
+        archive,
+        &sheet_path,
+        theme_colors,
+        (
+            shared.theme_fonts.0.as_deref(),
+            shared.theme_fonts.1.as_deref(),
+        ),
+    );
     ws.shape_groups = load_sheet_shape_groups(archive, &sheet_path, theme_colors);
     ws.hyperlinks = load_hyperlinks(archive, &sheet_path, hyperlink_rids);
     ws.comments = load_sheet_comments(archive, &sheet_path);
@@ -333,6 +346,18 @@ fn parse_theme_colors(archive: &mut XlsxZip) -> Vec<String> {
         .flatten()
         .map(|hex| format!("#{}", hex.to_uppercase()))
         .collect()
+}
+
+/// Workbook theme `(majorFont.latin, minorFont.latin)` Latin faces
+/// (`<a:fontScheme>`, ECMA-376 §20.1.4.2). Used as the chart-text fallback font
+/// (CH10) when a chart element's `<c:txPr>` carries no explicit `<a:latin>`.
+/// `(None, None)` when the theme is absent or declares no font scheme.
+fn parse_theme_fonts(archive: &mut XlsxZip) -> (Option<String>, Option<String>) {
+    let Ok(xml) = read_zip_string(archive, "xl/theme/theme1.xml") else {
+        return (None, None);
+    };
+    let fonts = ooxml_common::theme::ThemeFonts::parse(&xml);
+    (fonts.major.latin, fonts.minor.latin)
 }
 
 /// Convert hex color + tint to resulting hex color using HLS model.

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -849,6 +849,41 @@ pub struct ChartData {
     /// Theme body (minorFont) Latin face — fallback for ticks/data labels/legend.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub theme_minor_font_latin: Option<String>,
+    // ── Axis scale model (CH6) ──────────────────────────────────────────────
+    /// `<c:valAx><c:majorGridlines>` presence (§21.2.2.100). `Some(false)` when
+    /// the value axis exists without the element. `None` = no value axis parsed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_major_gridlines: Option<bool>,
+    /// `<c:catAx><c:majorGridlines>` presence (§21.2.2.100).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_major_gridlines: Option<bool>,
+    /// `<c:valAx><c:minorGridlines>` presence (§21.2.2.109).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_gridlines: Option<bool>,
+    /// `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit major step.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_major_unit: Option<f64>,
+    /// `<c:valAx><c:minorUnit val>` (§21.2.2.112) — explicit minor step.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_unit: Option<f64>,
+    /// `<c:valAx><c:scaling><c:logBase val>` (§21.2.2.98) — log base (>= 2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_log_base: Option<f64>,
+    /// `<c:valAx><c:scaling><c:orientation val>` (§21.2.2.130) — minMax|maxMin.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_orientation: Option<String>,
+    /// `<c:catAx><c:scaling><c:orientation val>` — minMax|maxMin.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_orientation: Option<String>,
+    /// `<c:catAx><c:tickLblPos val>` (§21.2.2.207).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_tick_label_pos: Option<String>,
+    /// `<c:valAx><c:tickLblPos val>` (§21.2.2.207).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_tick_label_pos: Option<String>,
+    /// `<c:catAx><c:txPr><a:bodyPr rot>` (60000ths of a degree) — label rotation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_label_rotation: Option<i32>,
 }
 
 /// Generic `<c:manualLayout>` block (used for title, plotArea, legend).

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -463,6 +463,11 @@ pub struct ChartSeries {
     /// element is present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub smooth: Option<bool>,
+    /// `<c:ser><c:trendline>` per-series trendlines (ECMA-376 §21.2.2.211).
+    /// Reuses the shared `ooxml_common` type so it flows straight to the
+    /// ChartModel. None = no trendline (byte-stable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trend_lines: Option<Vec<ooxml_common::chart::ChartTrendline>>,
 }
 
 /// Per-point override pulled from `<c:dPt idx="N">` siblings of a series

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -482,6 +482,9 @@ pub struct DataPointOverride {
     pub marker_fill: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub marker_line: Option<String>,
+    /// `<c:dPt><c:explosion val>` (§21.2.2.61) — pie/doughnut slice pull-out %.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explosion: Option<u32>,
 }
 
 /// Custom data label for one point (`<c:dLbl idx="N">`).
@@ -804,6 +807,48 @@ pub struct ChartData {
     /// (renderer defaults to "gap").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disp_blanks_as: Option<String>,
+    // ── Pie / doughnut geometry (CH8) ───────────────────────────────────────
+    /// `<c:doughnutChart><c:holeSize val>` (§21.2.2.60) — hole % (1–90).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hole_size: Option<u32>,
+    /// `<c:pieChart|doughnutChart><c:firstSliceAng val>` (§21.2.2.52) — start
+    /// angle (0–360°, clockwise from 12 o'clock).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_slice_angle: Option<u32>,
+    // ── Chart text font faces (CH10) ────────────────────────────────────────
+    /// `<c:catAx><c:txPr>…<a:latin typeface>` tick-label font.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_font_face: Option<String>,
+    /// `<c:valAx><c:txPr>…<a:latin typeface>` tick-label font.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_font_face: Option<String>,
+    /// `<c:catAx><c:title>…<a:latin typeface>` axis-title font.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cat_axis_title_font_face: Option<String>,
+    /// `<c:valAx><c:title>…<a:latin typeface>` axis-title font.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub val_axis_title_font_face: Option<String>,
+    /// `<c:dLbls><c:txPr>…<a:latin typeface>` data-label font.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_label_font_face: Option<String>,
+    /// `<c:legend><c:txPr>…<a:latin typeface>` legend font.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legend_font_face: Option<String>,
+    /// `<c:legend><c:txPr>…<a:solidFill>` legend text color (hex, no `#`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legend_font_color: Option<String>,
+    /// `<c:legend><c:txPr>` legend font size (hundredths of a point).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legend_font_size_hpt: Option<i32>,
+    /// `<c:legend><c:txPr>…defRPr@b` legend bold flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legend_font_bold: Option<bool>,
+    /// Theme heading (majorFont) Latin face — fallback for title/axis titles.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theme_major_font_latin: Option<String>,
+    /// Theme body (minorFont) Latin face — fallback for ticks/data labels/legend.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theme_minor_font_latin: Option<String>,
 }
 
 /// Generic `<c:manualLayout>` block (used for title, plotArea, legend).


### PR DESCRIPTION
## Summary

Phase 2 chart-renderer batch (CH6 + CH8 + CH10). All three add parser fields (ooxml-common extractors + pptx/xlsx wiring + TS types) consumed by `core/src/chart/renderer.ts`. **Zero reference-image diffs** — CH6/CH8 defaults are byte-stable and CH10's font-name changes are a no-op on the fontless VRT machine (correct on machines with the Office fonts installed; the E9 font-portability limitation).

- **CH6 — axis model**: majorGridlines presence (§21.2.2.102, default = keep drawing → byte-stable), manual majorUnit/minorUnit (§21.2.2.116/.126), logarithmic axis (§21.2.2.104, log value→px + decade gridlines), orientation `maxMin` reversal (§21.2.2.130), category-label rotation (ST_Angle ÷ 60000, verified against the XSD), `tickLblPos="none"` hiding, and series trendlines (§21.2.2.212 — linear least-squares + moving-average drawn; exp/log/power/poly parsed-but-not-drawn, documented). Wired into bar + line; area/radar/scatter keep the existing value-axis path unchanged.
- **CH8 — pie/doughnut**: holeSize (§21.2.2.60, `%`-stripped, clamped 1–90; absent → 50% for byte-stability), firstSliceAngle (§21.2.2.52; default 0 = 12 o'clock = the historical −90°), per-point explosion (§21.2.2.61, offset along the slice mid-angle), multi-ring doughnuts (each series a concentric ring), rich per-slice data labels, and a transparent center hole (was opaque white). Plain pie is byte-stable; only the doughnut signature snapshot changed (true annulus + no white overpaint).
- **CH10 — chart fonts**: replaced 28 hard-coded `sans-serif` sites with `<c:txPr><a:latin>` ?? theme major/minor font (fontScheme §20.1.4.2, resolving `+mj-lt`/`+mn-lt`) ?? `sans-serif`, across axis labels, data labels, legend, and ticks. Added xlsx theme-font threading (`parse_theme_fonts` → `WorkbookShared` → chart). Font resolution is proven by tests asserting the exact resolved `ctx.font`; the rendered pixels only change on a machine that has the Office fonts.

## Verification

- `cargo fmt --check` / `clippy -D warnings` / `cargo test` — green (+13 extractor tests, real field-value assertions with ECMA range clamping / cross-type isolation)
- `pnpm test` (core) — 860 passed (+CH6/CH8/CH10 renderer + pure-function tests; explosion offset, ring boundaries, and axis-mirror assertions tightened to exact geometry)
- `renderer-signature` snapshot — only `doughnut+legendBottom` changed (intended); pie and 16 other cases byte-identical
- `pnpm build:wasm` + full local VRT — 163/163 passed, **zero reference-image diffs**
- Independent 2-dimension review (spec fidelity/byte-stability — every spec value cross-checked against the local XSD; test/wire/cross-package) — both APPROVE; findings (test-assertion tightening, explosion doc precision) fixed in-branch

Completes the Phase 2 renderer batch (CH7 #732 / CH9 #734 already merged). CH5 (parser unification) deferred to the docx-chart (CH12) work per the sequencing decision — it's the enabling step for docx charts / chartEx, not for these renderer features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)