### PR TITLE
fix(charts): correct auto value-axis major-unit density (undo #735 regression)

### DIFF
--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -72,13 +72,28 @@ describe('valueAxisScale (one niceStep drives min, max and gridline step)', () =
     expect(valueAxisScale(0, 41, -5, null)).toEqual({ min: -5, max: 50, step: 10 });
   });
   it('a longer value axis gets a finer major unit (Excel axis-length model)', () => {
-    // Excel's auto major unit targets ~1 gridline per GRIDLINE_SPACING_PT (40),
+    // Excel's auto major unit targets ~1 gridline per GRIDLINE_SPACING_PT (42),
     // so the SAME data range yields more, finer gridlines on a longer axis.
     // range 44: default target (5) → step 10 (0–50, 5 intervals); a 380pt axis
-    // (target round(380/40)=10) → step 5 (0–50, 10 intervals) — matching the
+    // (target round(380/42)=9) → step 5 (0–50, 10 intervals) — matching the
     // horizontal-bar value axis (sample-14 slide-9) vs PowerPoint.
     expect(valueAxisScale(0, 44)).toEqual({ min: 0, max: 50, step: 10 });
     expect(valueAxisScale(0, 44, undefined, undefined, 380)).toEqual({ min: 0, max: 50, step: 5 });
+  });
+  it('a short axis keeps a fine step via the target floor of 4', () => {
+    // Regression: the demo/sample-1 line chart pins the value axis to an
+    // explicit 60–72 (ECMA-376 §21.2.2.90 min/max, range 12) on a ~124pt plot.
+    // round(124/42)=3 would niceStep(12,3)→step 5 (60,65,70). PowerPoint draws
+    // step 2 (60,62,…,72); the floor of 4 gives niceStep(12,4)→step 2. Without
+    // the floor this axis silently coarsens by one major unit.
+    expect(valueAxisScale(60, 72, 60, 72, 124.1)).toEqual({ min: 60, max: 72, step: 2 });
+  });
+  it('a medium axis is not over-refined (42pt/gridline density)', () => {
+    // Regression: sample-14 slide-6's area axis is range 48.6 on a ~263pt plot.
+    // At 40pt/gridline round(263/40)=7 → niceStep(48.6,7)→step 5, but PowerPoint
+    // draws step 10 (0,10,…,60). At 42pt/gridline round(263/42)=6 → step 10.
+    const { step } = valueAxisScale(0, 48.6, undefined, undefined, 263.2);
+    expect(step).toBe(10);
   });
   it('data 3.5 → max 4 with step 0.5 (fine-grained positive range)', () => {
     // step = niceStep(3.5) = 0.5; min = 0; max = niceAxisMax(3.5,0.5,0):

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -47,16 +47,32 @@ export function niceAxisMin(dataMin: number, step: number): number {
  *  gridline count — it targets a roughly constant on-screen spacing, so a long
  *  axis (e.g. a horizontal bar chart's wide value axis) gets MORE, finer
  *  gridlines than a short one of the same data range. Empirically ~one major
- *  gridline per this many points reproduces PowerPoint across sample-14's
- *  column / area / horizontal-bar / secondary-axis charts. This is a runtime
- *  Excel behavior (not in ECMA-376); the constant is the one tunable. */
-const GRIDLINE_SPACING_PT = 40;
+ *  gridline per this many points reproduces PowerPoint. This is a runtime Excel
+ *  behavior (not in ECMA-376); the constant is the one tunable.
+ *
+ *  Calibrated against every value axis in the demo/sample-1 line chart plus
+ *  sample-14 (column / stacked / area / combo dual-axis / horizontal-bar) and
+ *  sample-2 (stacked-column / horizontal-bar) decks — 12 axes spanning
+ *  124–391 pt. Those axes uniquely pin the density: at ~243 pt one axis needs
+ *  6 intervals (range 79 → step 10) while another needs ≤6 (range 48.6 → step
+ *  10), so the target at 243 pt must be exactly 6 → ~40.6 pt/gridline; at
+ *  ~263 pt an area axis (range 48.6) must stay at 6 (step 10, not 5) → ≥43.9
+ *  pt/gridline. 42 sits in the satisfying band [40.5, 44.2] with the widest
+ *  margin to the nearest rounding flip (≈7.8 pt). The earlier value 40 rounded
+ *  the 263 pt area axis up to 7 gridlines, over-refining it to a step-5 axis
+ *  where PowerPoint draws step 10. */
+const GRIDLINE_SPACING_PT = 42;
 
 /** Pick the `niceStep` target-gridline count for an axis of `axisLenPt` points.
- *  Falls back to 5 (the legacy fixed target) when the length is unknown. */
+ *  Falls back to 5 (the legacy fixed target) when the length is unknown. The
+ *  floor is 4: PowerPoint keeps at least ~4 intervals on a value axis for
+ *  readability, so a short axis (e.g. the demo line chart's 124 pt axis, which
+ *  would otherwise round to 3) still gets a fine enough step — range 12 → step
+ *  2 (60,62,…,72), matching PowerPoint, rather than the coarse step 5 a target
+ *  of 3 produces. */
 function targetStepsForAxis(axisLenPt?: number): number {
   if (axisLenPt == null || !isFinite(axisLenPt) || axisLenPt <= 0) return 5;
-  return Math.min(15, Math.max(3, Math.round(axisLenPt / GRIDLINE_SPACING_PT)));
+  return Math.min(15, Math.max(4, Math.round(axisLenPt / GRIDLINE_SPACING_PT)));
 }
 
 export function valueAxisScale(


### PR DESCRIPTION
## Summary
Fix the auto value-axis major-unit (gridline step) density regressed by #735 (the CH6 axis-scale work). The plot-size heuristic `GRIDLINE_SPACING_PT=40` / `targetStepsForAxis` floor=3 diverged two charts' gridlines from PowerPoint.

## Root cause (#735 regression)
`packages/core/src/chart/axis-scale.ts`: `valueAxisScale` computes `step = niceStep(range, targetStepsForAxis(axisLenPt))`. `targetStepsForAxis` targets ~one gridline per `GRIDLINE_SPACING_PT` points, but 40/floor-3 was calibrated only on sample-14's column charts:
- **demo/sample-1 slide5** (line, explicit `<c:min val="60"/><c:max val="72"/>`, range 12): short axis → targetSteps=3 → `niceStep(12,3)=5` → step 5 (PowerPoint draws **step 2**).
- **sample-14 slide6** (area, range ~48.6): too many target steps → step 5 (PowerPoint draws **step 10**).

**#735 broke both.**

## Fix
- `GRIDLINE_SPACING_PT` 40 → **42**
- `targetStepsForAxis` floor 3 → **4**

Both are required (floor alone fixes the demo but not sample-14 slide6). 42 is the near-center of the satisfying band `[41,44]` derived from all 12 axes; floor 4 reflects PowerPoint keeping >=4 readable value-axis intervals. This is Excel-runtime behavior (not in ECMA-376); documented in comments, user-approved to match the PDF.

## Verification
Measured all 12 value axes across 3 decks vs their PowerPoint PDFs: demo s5 5->2, sample-14 s6 5->10, the other 10 unchanged and still matching. Independent review reproduced the constant sweep (40 breaks one axis, 45 breaks another), the surgical impact (only the 2 intended axes flip across 35 chart slides), and mutation tests (reverting both constants fails exactly the 2 new regression tests). Reference-safe (moves toward the committed reference). Follow-up issue #738 tracks a pre-existing gap (explicit `<c:majorUnit>` ignored on secondary/area/radar/scatter axes).