### PR TITLE
perf(xlsx): dedup shared-string cells + drop dead colRef (render byte-identical)

### DIFF
--- a/packages/node/src/xlsx-border-crisp.probe.test.ts
+++ b/packages/node/src/xlsx-border-crisp.probe.test.ts
@@ -128,7 +128,6 @@ function buildInjected(): { ws: Worksheet; styles: Styles } {
   const injectedCell = {
     col: INJ_COL,
     row: INJ_ROW,
-    colRef: `${INJ_COL}`,
     value: { type: 'empty' as const },
     styleIndex,
   };

--- a/packages/node/src/xlsx-merge-border-zorder.probe.test.ts
+++ b/packages/node/src/xlsx-merge-border-zorder.probe.test.ts
@@ -108,7 +108,7 @@ function buildSynthetic(): { ws: Worksheet; styles: Styles } {
       index: r,
       height: null,
       cells: [
-        { col: MERGE_COL, row: r, colRef: `${MERGE_COL}`, value: { type: 'empty' }, styleIndex: 1 },
+        { col: MERGE_COL, row: r, value: { type: 'empty' }, styleIndex: 1 },
       ],
     });
   }

--- a/packages/node/src/xlsx-shared-string-resolve.test.ts
+++ b/packages/node/src/xlsx-shared-string-resolve.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression guard for the SC1 wire change (shared-string dedup): the public
+ * node parse API must return CONCRETE cell text, not the on-wire
+ * `{type:'shared',si}` reference.
+ *
+ * SC1 made the WASM emit `t="s"` cells as `{type:'shared',si}` (deduped) and
+ * pushed resolution to the TS consumer. The browser `XlsxWorkbook` path resolves
+ * it, but `parseXlsxSheet` / `parseXlsxAllSheets` (public headless exports) do a
+ * raw `JSON.parse` — without a resolve step they would leak the unresolved
+ * variant and a caller reading `cell.value.text` on a shared-string cell would
+ * see blank text. This test parses demo/sample-1.xlsx (many shared-string cells)
+ * and asserts none survive as `shared`, and that real text came through.
+ *
+ * Gated on the gitignored xlsx WASM like the sibling xlsx probes (skip locally
+ * when absent, hard-fail under OOXML_REQUIRE_SKIA=1).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import type { Worksheet } from '@silurus/ooxml-xlsx';
+import { importForTests } from './test-imports';
+
+const xlsxMod = await importForTests(() => import('./xlsx.ts'), './xlsx.ts (xlsx WASM)');
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const SAMPLE = resolve(ROOT, 'packages/xlsx/public/demo/sample-1.xlsx');
+
+function countByType(ws: Worksheet): { shared: number; text: number } {
+  let shared = 0;
+  let text = 0;
+  for (const row of ws.rows) {
+    for (const cell of row.cells) {
+      if (cell.value.type === 'shared') shared++;
+      else if (cell.value.type === 'text') text++;
+    }
+  }
+  return { shared, text };
+}
+
+describe.skipIf(!xlsxMod)('node parseXlsxSheet resolves shared strings', () => {
+  it('parseSheet returns no unresolved shared-string cells, with real text', () => {
+    if (!xlsxMod) return;
+    const buf = readFileSync(SAMPLE);
+    const parsed = xlsxMod.parseXlsx(buf);
+    const ws = xlsxMod.parseSheet(buf, 0, parsed.workbook.sheets[0].name);
+    const { shared, text } = countByType(ws);
+    expect(shared).toBe(0);
+    expect(text).toBeGreaterThan(0);
+  });
+
+  it('parseXlsxAllSheets resolves shared strings on every sheet', () => {
+    if (!xlsxMod) return;
+    const buf = readFileSync(SAMPLE);
+    const { worksheets } = xlsxMod.parseXlsxAllSheets(buf);
+    for (const ws of Object.values(worksheets)) {
+      expect(countByType(ws as Worksheet).shared).toBe(0);
+    }
+  });
+});

--- a/packages/node/src/xlsx.ts
+++ b/packages/node/src/xlsx.ts
@@ -1,4 +1,8 @@
 import type { ParsedWorkbook, Worksheet } from '@silurus/ooxml-xlsx';
+// The package typecheck alias maps '@silurus/ooxml-xlsx' to types.ts (types
+// only), so the resolver value is imported from source directly — mirroring the
+// relative WASM import below. (index.ts re-exports it for external consumers.)
+import { resolveSharedStrings } from '../../xlsx/src/shared-strings.ts';
 // @ts-ignore — wasm-pack generated JS without a d.ts entry for the bare module path
 import * as xlsxWasm from '../../xlsx/src/wasm/xlsx_parser.js';
 import { loadWasmModule, resolveWasm } from './wasm-loader.ts';
@@ -26,10 +30,10 @@ export function parseXlsx(buffer: ArrayBuffer | Uint8Array | Buffer): ParsedWork
   return JSON.parse(new TextDecoder().decode(json)) as ParsedWorkbook;
 }
 
-/** Parse a single sheet's cell data and layout. The browser path does this
- *  on demand from a Web Worker; in Node we just call the WASM export
- *  synchronously. */
-export function parseSheet(
+/** Parse a single sheet's cell model without resolving shared-string cells
+ *  (they stay `{type:'shared',si}`). Internal — callers resolve against the
+ *  workbook's sharedStrings table. */
+function parseSheetRaw(
   buffer: ArrayBuffer | Uint8Array | Buffer,
   sheetIndex: number,
   sheetName: string,
@@ -44,6 +48,21 @@ export function parseSheet(
   return JSON.parse(new TextDecoder().decode(json)) as Worksheet;
 }
 
+/** Parse a single sheet's cell data and layout. The browser path does this
+ *  on demand from a Web Worker; in Node we just call the WASM export
+ *  synchronously. Shared-string cells are resolved to concrete text against the
+ *  workbook table (matching the browser `XlsxWorkbook` path), so callers reading
+ *  `cell.value` always get `{type:'text',...}` rather than a `{type:'shared'}`
+ *  reference. */
+export function parseSheet(
+  buffer: ArrayBuffer | Uint8Array | Buffer,
+  sheetIndex: number,
+  sheetName: string,
+): Worksheet {
+  const ws = parseSheetRaw(buffer, sheetIndex, sheetName);
+  return resolveSharedStrings(ws, parseXlsx(buffer).sharedStrings);
+}
+
 /** Eagerly parse every sheet referenced by the workbook. Useful for batch
  *  jobs (diffing two workbooks, dumping to markdown) where you want the
  *  whole model in one go. */
@@ -54,7 +73,12 @@ export function parseXlsxAllSheets(
   const worksheets: Record<string, Worksheet> = {};
   for (let i = 0; i < parsed.workbook.sheets.length; i++) {
     const meta = parsed.workbook.sheets[i];
-    worksheets[meta.name] = parseSheet(buffer, i, meta.name);
+    // Resolve against the already-parsed table (avoids re-parsing the workbook
+    // index once per sheet, which routing through `parseSheet` would do).
+    worksheets[meta.name] = resolveSharedStrings(
+      parseSheetRaw(buffer, i, meta.name),
+      parsed.sharedStrings,
+    );
   }
   return { workbook: parsed.workbook, worksheets };
 }

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2013,7 +2013,10 @@ fn load_sheet_sparklines(
 
 fn parse_row_cells(
     row_node: &roxmltree::Node,
-    shared_strings: &[SharedString],
+    // Shared-string cells now ship an `si` reference (resolved consumer-side),
+    // so this table is no longer read here. Kept in the signature for symmetry
+    // with `parse_worksheet`'s threading; prefixed `_` to silence the warning.
+    _shared_strings: &[SharedString],
     theme_colors: &[String],
 ) -> Vec<Cell> {
     let mut cells = Vec::new();
@@ -2064,18 +2067,13 @@ fn parse_row_cells(
         } else {
             match cell_type {
                 "s" => {
+                    // Ship only the shared-string index; the consumer resolves
+                    // it against the workbook `sharedStrings` table (once per
+                    // workbook, not cloned per cell). Emit `Shared`
+                    // unconditionally — an out-of-range index resolves to empty
+                    // text consumer-side, matching the historical fallback.
                     let idx: usize = v_text.parse().unwrap_or(0);
-                    if let Some(ss) = shared_strings.get(idx) {
-                        CellValue::Text {
-                            text: ss.text.clone(),
-                            runs: ss.runs.clone(),
-                        }
-                    } else {
-                        CellValue::Text {
-                            text: String::new(),
-                            runs: None,
-                        }
-                    }
+                    CellValue::Shared { si: idx }
                 }
                 "str" => CellValue::Text {
                     text: v_text,
@@ -2101,7 +2099,6 @@ fn parse_row_cells(
         cells.push(Cell {
             col,
             row,
-            col_ref: cell_ref,
             value,
             style_index,
             formula,
@@ -2301,7 +2298,7 @@ fn to_markdown_from_archive(archive: &mut XlsxZip) -> Result<String, String> {
             })?;
         let sheet: serde_json::Value =
             serde_json::from_slice(&sheet_json).map_err(|e| e.to_string())?;
-        markdown::render_sheet(&sheet, &mut out);
+        markdown::render_sheet(&sheet, &shared.shared_strings, &mut out);
     }
     Ok(out)
 }
@@ -2925,9 +2922,11 @@ mod strict_namespace_cell_tests {
         let cells = &ws.rows[0].cells;
         assert_eq!(cells.len(), 3, "Strict <c> must be found via is_x_ns");
 
+        // The wire now ships an `si` reference for `t="s"`; the text
+        // ("Shared Hello") resolves consumer-side from `shared[0]`.
         match &cells[0].value {
-            CellValue::Text { text, .. } => assert_eq!(text, "Shared Hello"),
-            other => panic!("expected shared-string text, got {other:?}"),
+            CellValue::Shared { si } => assert_eq!(*si, 0),
+            other => panic!("expected shared-string reference, got {other:?}"),
         }
         assert_eq!(
             cells[0].style_index, 2,

--- a/packages/xlsx/parser/src/markdown.rs
+++ b/packages/xlsx/parser/src/markdown.rs
@@ -10,7 +10,9 @@ use std::fmt::Write as _;
 
 use serde_json::Value;
 
-pub(crate) fn render_sheet(sheet: &Value, out: &mut String) {
+use crate::types::SharedString;
+
+pub(crate) fn render_sheet(sheet: &Value, shared_strings: &[SharedString], out: &mut String) {
     let name = sheet["name"].as_str().unwrap_or("(unnamed)");
     let _ = writeln!(out, "## {}\n", name);
 
@@ -32,7 +34,7 @@ pub(crate) fn render_sheet(sheet: &Value, out: &mut String) {
             continue;
         };
         for cell in cells {
-            let s = cell_display(cell);
+            let s = cell_display(cell, shared_strings);
             if s.is_empty() {
                 continue;
             }
@@ -78,7 +80,7 @@ pub(crate) fn render_sheet(sheet: &Value, out: &mut String) {
             }
             let r = (row_idx - min_row) as usize;
             let c = (col - min_col) as usize;
-            grid[r][c] = cell_display(cell);
+            grid[r][c] = cell_display(cell, shared_strings);
         }
     }
 
@@ -123,13 +125,21 @@ fn escape_cell(s: &str) -> String {
     s.replace('|', "\\|").replace('\n', "<br>")
 }
 
-fn cell_display(cell: &Value) -> String {
+fn cell_display(cell: &Value, shared_strings: &[SharedString]) -> String {
     // CellValue has `rename_all = "camelCase"` so the JSON tag is lowercase
     // ("text"/"number"/...). PascalCase would silently never match — same
     // class of bug that hid pptx_extract_text earlier.
     let value = &cell["value"];
     match value["type"].as_str().unwrap_or("empty") {
         "text" => value["text"].as_str().unwrap_or("").to_string(),
+        // A `t="s"` cell ships only an `si` index now; resolve it back to the
+        // shared-string table's plain text (markdown drops runs anyway,
+        // matching the `"text"` arm).
+        "shared" => value["si"]
+            .as_u64()
+            .and_then(|i| shared_strings.get(i as usize))
+            .map(|s| s.text.clone())
+            .unwrap_or_default(),
         "number" => value["number"]
             .as_f64()
             .map(format_number)
@@ -192,4 +202,67 @@ fn collect_merge_continuation_cells(merge_cells: &Value) -> HashSet<(u32, u32)> 
         }
     }
     set
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A `{"type":"shared","si":N}` cell must resolve to the sharedStrings
+    /// table's text — the wire ships only the index, so markdown has to look
+    /// it up (mirrors the runtime `t="s"` path).
+    #[test]
+    fn shared_cell_resolves_against_table() {
+        let shared = vec![
+            SharedString {
+                text: "Alpha".to_string(),
+                runs: None,
+            },
+            SharedString {
+                text: "Beta".to_string(),
+                runs: None,
+            },
+        ];
+        let sheet = json!({
+            "name": "Sheet1",
+            "rows": [
+                {
+                    "index": 1,
+                    "cells": [
+                        { "col": 1, "row": 1, "value": { "type": "shared", "si": 1 } },
+                        { "col": 2, "row": 1, "value": { "type": "number", "number": 3.0 } }
+                    ]
+                }
+            ]
+        });
+        let mut out = String::new();
+        render_sheet(&sheet, &shared, &mut out);
+        assert!(
+            out.contains("Beta"),
+            "si=1 must resolve to shared[1] text, got:\n{out}"
+        );
+    }
+
+    /// An out-of-range `si` resolves to empty text (historical fallback),
+    /// leaving no populated cell — the sheet renders as empty.
+    #[test]
+    fn shared_cell_out_of_range_is_empty() {
+        let shared: Vec<SharedString> = Vec::new();
+        let sheet = json!({
+            "name": "Sheet1",
+            "rows": [
+                {
+                    "index": 1,
+                    "cells": [
+                        { "col": 1, "row": 1, "value": { "type": "shared", "si": 9 } }
+                    ]
+                }
+            ]
+        });
+        let mut out = String::new();
+        render_sheet(&sheet, &shared, &mut out);
+        // No populated cells → only the heading is emitted (no table body).
+        assert!(!out.contains('|'), "empty sheet must have no table: {out}");
+    }
 }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -1441,13 +1441,20 @@ pub struct Row {
     pub cells: Vec<Cell>,
 }
 
+/// serde `skip_serializing_if` predicate: drop the common unstyled `0` so the
+/// per-cell JSON doesn't carry a redundant `styleIndex` on every plain cell.
+/// The TS side reads it as `styleIndex ?? 0`, so an omitted field is equivalent.
+fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}
+
 #[derive(Debug, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Cell {
     pub col: u32,
     pub row: u32,
-    pub col_ref: String,
     pub value: CellValue,
+    #[serde(skip_serializing_if = "is_zero_u32")]
     pub style_index: u32,
     /// Raw `<f>` formula text (ECMA-376 §18.3.1.40), when present. The
     /// renderer uses this to recompute volatile functions like TODAY() /
@@ -1475,6 +1482,13 @@ pub enum CellValue {
     },
     Error {
         error: String,
+    },
+    /// Shared-string reference into the workbook `sharedStrings` table
+    /// (ECMA-376 §18.4.8 `<si>` / §18.3.1.4 cell `t="s"`), resolved on the
+    /// consumer side so the full string + runs are shipped once in the
+    /// workbook, not cloned per cell.
+    Shared {
+        si: usize,
     },
 }
 

--- a/packages/xlsx/src/conditional-format.test.ts
+++ b/packages/xlsx/src/conditional-format.test.ts
@@ -29,7 +29,6 @@ function numCell(row: number, col: number, n: number): Cell {
   return {
     col,
     row,
-    colRef: `${String.fromCharCode(65 + col)}${row + 1}`,
     value: { type: 'number', number: n } as CellValue,
     styleIndex: 0,
   };
@@ -40,7 +39,6 @@ function textCell(row: number, col: number, t: string): Cell {
   return {
     col,
     row,
-    colRef: `${String.fromCharCode(65 + col)}${row + 1}`,
     value: { type: 'text', text: t } as CellValue,
     styleIndex: 0,
   };

--- a/packages/xlsx/src/formula.test.ts
+++ b/packages/xlsx/src/formula.test.ts
@@ -3,7 +3,7 @@ import { evalFormulaToBool } from './formula.js';
 import type { Cell } from './types.js';
 
 function numCell(row: number, col: number, n: number): Cell {
-  return { row, col, colRef: '', value: { type: 'number', number: n }, styleIndex: 0 };
+  return { row, col, value: { type: 'number', number: n }, styleIndex: 0 };
 }
 
 function ctx(opts: { cells?: Cell[]; row?: number; col?: number } = {}) {

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -5,6 +5,10 @@ export { XlsxViewer } from './viewer.js';
 export type { ResolvedList } from './validation-list.js';
 export type { XlsxViewerOptions, HiddenSheetMode, CellAddress, CellRange, SelectionMode } from './viewer.js';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
+// Resolve `{type:'shared',si}` cells against a workbook's sharedStrings table
+// (ECMA-376 §18.4.8). Exported so headless callers that parse a Worksheet
+// directly (e.g. @silurus/ooxml-node's parseXlsxSheet) can concretize cell text.
+export { resolveSharedStrings } from './shared-strings.js';
 // Typed load-time error surfaced by XlsxWorkbook.load (e.g. a password-protected
 // or legacy-binary .xls file). Re-exported so `@silurus/ooxml/xlsx` consumers can
 // narrow on `err.code`.

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -16,7 +16,7 @@ function styles(formatCode: string): Styles {
 }
 
 function numCell(n: number): Cell {
-  return { row: 1, col: 1, colRef: 'A1', value: { type: 'number', number: n }, styleIndex: 0 };
+  return { row: 1, col: 1, value: { type: 'number', number: n }, styleIndex: 0 };
 }
 
 /** Format a number with a custom format code, as Excel would render it. */
@@ -135,7 +135,7 @@ describe('General format — 11 significant digit rounding (XL2)', () => {
 
 describe('non-numeric cells', () => {
   it('passes text through when no 4th section', () => {
-    const cell: Cell = { row: 1, col: 1, colRef: 'A1', value: { type: 'text', text: 'hello' }, styleIndex: 0 };
+    const cell: Cell = { row: 1, col: 1, value: { type: 'text', text: 'hello' }, styleIndex: 0 };
     expect(formatCellValue(cell, styles('0.00'))).toBe('hello');
   });
 });
@@ -239,7 +239,7 @@ describe('volatile TODAY()/NOW() exemption from date1904 (§18.17.4.1)', () => {
     // irrelevant — the volatile path recomputes it) and the style is a date
     // format. We deliberately store a serial that would misrender if the flag
     // were NOT overridden.
-    return { row: 1, col: 1, colRef: 'A1', value: { type: 'number', number: 0 }, styleIndex: 0, formula };
+    return { row: 1, col: 1, value: { type: 'number', number: 0 }, styleIndex: 0, formula };
   }
 
   it('TODAY() in a 1904 workbook renders the correct 1900-system today (not 1462 days off)', () => {
@@ -262,7 +262,7 @@ describe('volatile TODAY()/NOW() exemption from date1904 (§18.17.4.1)', () => {
   it('a non-volatile stored serial in a 1904 workbook still honors the 1904 epoch', () => {
     // Contrast: without a volatile formula the stored serial uses the workbook
     // date system. 1904-system serial 43830 = 2024-01-01.
-    const cell: Cell = { row: 1, col: 1, colRef: 'A1', value: { type: 'number', number: 43830 }, styleIndex: 0 };
+    const cell: Cell = { row: 1, col: 1, value: { type: 'number', number: 43830 }, styleIndex: 0 };
     expect(formatCellValue(cell, styles('yyyy-mm-dd'), null, true)).toBe('2024-01-01');
   });
 

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -10,6 +10,10 @@ function cellValueText(value: CellValue): string {
     case 'number': return String(value.number);
     case 'bool': return value.bool ? 'TRUE' : 'FALSE';
     case 'error': return value.error;
+    // `shared` cells are resolved to `text` (see shared-strings.ts) before any
+    // consumer runs, so this is unreachable at runtime — present only to keep
+    // the switch exhaustive over CellValue.
+    case 'shared': return '';
   }
 }
 

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -13,6 +13,7 @@ import init, { XlsxArchive } from './wasm/xlsx_parser.js';
 import { decodeDataUrl, preloadGoogleFonts } from '@silurus/ooxml-core';
 import { renderWorksheetViewport } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
+import { resolveSharedStrings } from './shared-strings.js';
 import type { ParsedWorkbook, Worksheet } from './types.js';
 import type { RenderWorkerRequest, RenderWorkerResponse } from './worker-protocol.js';
 
@@ -75,6 +76,10 @@ function parseSheetLocally(sheetIndex: number): Worksheet {
   // render worker consumes the model in-worker, so decode + parse here.
   const json = archive.parse_sheet(sheetIndex, sheetMeta.name);
   const ws = JSON.parse(new TextDecoder().decode(json)) as Worksheet;
+  // Resolve `{ type: 'shared', si }` cells against the dedup'd sharedStrings
+  // table so the renderer only ever sees fully-materialized text (worker-mode
+  // twin of workbook.ts getWorksheet).
+  resolveSharedStrings(ws, workbook.sharedStrings);
   sheetCache.set(sheetIndex, ws);
   return ws;
 }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2126,7 +2126,7 @@ function renderQuadrant(
       // only as the neighbour's bottom/right still shows at the viewport edge.
       const aboveCell = cellMap.get(`${rowIndex - 1}:${colIndex}`);
       const aboveBottom = aboveCell
-        ? resolveXf(styles, aboveCell.styleIndex).border.bottom
+        ? resolveXf(styles, aboveCell.styleIndex ?? 0).border.bottom
         : null;
       if (aboveBottom?.style && (ri === 0 || mergedBorder.top?.style)) {
         mergedBorder = { ...mergedBorder, top: pickStrongerEdge(mergedBorder.top, aboveBottom) };
@@ -2137,7 +2137,7 @@ function renderQuadrant(
         // neighbour's xf.right re-introduces the internal vertical we just hid.
         const leftCell = cellMap.get(`${rowIndex}:${colIndex - 1}`);
         const leftRight = leftCell
-          ? resolveXf(styles, leftCell.styleIndex).border.right
+          ? resolveXf(styles, leftCell.styleIndex ?? 0).border.right
           : null;
         if (leftRight?.style && (ci === 0 || mergedBorder.left?.style)) {
           mergedBorder = { ...mergedBorder, left: pickStrongerEdge(mergedBorder.left, leftRight) };
@@ -3931,7 +3931,7 @@ function resolveMergeBorder(
     if (r === anchorRow && c === anchorCol) return null;
     const cell = cellMap.get(`${r}:${c}`);
     if (!cell) return null;
-    return resolveXf(styles, cell.styleIndex).border;
+    return resolveXf(styles, cell.styleIndex ?? 0).border;
   };
   const rightB  = edgeBorder(anchorRow, rightCol);
   const bottomB = edgeBorder(bottomRow, anchorCol);

--- a/packages/xlsx/src/shared-strings.test.ts
+++ b/packages/xlsx/src/shared-strings.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSharedStrings } from './shared-strings.js';
+import type { SharedString, Worksheet, Cell, Run } from './types.js';
+
+/** Build a minimal single-row Worksheet carrying the given cells. Only the
+ *  fields `resolveSharedStrings` touches (`rows[].cells[].value`) matter; the
+ *  rest are filled with harmless defaults so the object type-checks. */
+function ws(cells: Cell[]): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [{ index: 1, height: null, cells }],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+  };
+}
+
+function sharedCell(col: number, si: number): Cell {
+  return { col, row: 1, value: { type: 'shared', si } };
+}
+
+describe('resolveSharedStrings', () => {
+  it('resolves si=0 (boundary) to the first table entry', () => {
+    const table: SharedString[] = [{ text: 'first' }, { text: 'second' }];
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 0)]), table);
+    expect(sheet.rows[0].cells[0].value).toEqual({ type: 'text', text: 'first' });
+  });
+
+  it('resolves a mid-table index', () => {
+    const table: SharedString[] = [{ text: 'a' }, { text: 'b' }, { text: 'c' }];
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 2)]), table);
+    expect(sheet.rows[0].cells[0].value).toEqual({ type: 'text', text: 'c' });
+  });
+
+  it('resolves an out-of-range si to empty text (parser fallback parity)', () => {
+    const table: SharedString[] = [{ text: 'only' }];
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 9)]), table);
+    // Matches the historical Rust fallback: a missing index → empty string,
+    // no runs.
+    expect(sheet.rows[0].cells[0].value).toEqual({ type: 'text', text: '' });
+  });
+
+  it('resolves against an empty table to empty text', () => {
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 0)]), []);
+    expect(sheet.rows[0].cells[0].value).toEqual({ type: 'text', text: '' });
+  });
+
+  it('resolves an empty-string shared entry to empty text (no runs key)', () => {
+    const table: SharedString[] = [{ text: '' }];
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 0)]), table);
+    const v = sheet.rows[0].cells[0].value;
+    expect(v).toEqual({ type: 'text', text: '' });
+    // A shared string with no runs must NOT introduce a `runs` key — the
+    // resolved shape must match exactly what the parser used to emit inline.
+    expect('runs' in (v as { runs?: Run[] })).toBe(false);
+  });
+
+  it('preserves multiple rich-text runs verbatim', () => {
+    const runs: Run[] = [
+      { text: 'Bold', font: { bold: true, italic: false, underline: false, strike: false } },
+      { text: ' plain' },
+      { text: ' red', font: { bold: false, italic: false, underline: false, strike: false, color: '#FF0000' } },
+    ];
+    const table: SharedString[] = [{ text: 'Bold plain red', runs }];
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 0)]), table);
+    expect(sheet.rows[0].cells[0].value).toEqual({
+      type: 'text',
+      text: 'Bold plain red',
+      runs,
+    });
+    // Same array reference is fine (the table lives for the workbook lifetime),
+    // but the run contents must round-trip identically.
+    expect((sheet.rows[0].cells[0].value as { runs?: Run[] }).runs).toEqual(runs);
+  });
+
+  it('leaves inline / non-shared cells untouched while resolving shared ones', () => {
+    const table: SharedString[] = [{ text: 'SHARED' }];
+    const inline: Cell = { col: 2, row: 1, value: { type: 'text', text: 'inline', runs: [{ text: 'inline' }] } };
+    const num: Cell = { col: 3, row: 1, value: { type: 'number', number: 42 } };
+    const empty: Cell = { col: 4, row: 1, value: { type: 'empty' } };
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 0), inline, num, empty]), table);
+    expect(sheet.rows[0].cells[0].value).toEqual({ type: 'text', text: 'SHARED' });
+    // Non-shared values pass through by identity.
+    expect(sheet.rows[0].cells[1].value).toEqual({ type: 'text', text: 'inline', runs: [{ text: 'inline' }] });
+    expect(sheet.rows[0].cells[2].value).toEqual({ type: 'number', number: 42 });
+    expect(sheet.rows[0].cells[3].value).toEqual({ type: 'empty' });
+  });
+
+  it('is idempotent: a worksheet with no shared cells is returned unchanged', () => {
+    const num: Cell = { col: 1, row: 1, value: { type: 'number', number: 7 } };
+    const sheet = ws([num]);
+    const before = JSON.stringify(sheet);
+    const out = resolveSharedStrings(sheet, [{ text: 'x' }]);
+    expect(out).toBe(sheet); // same object (mutated in place, returned)
+    expect(JSON.stringify(out)).toBe(before);
+  });
+});

--- a/packages/xlsx/src/shared-strings.ts
+++ b/packages/xlsx/src/shared-strings.ts
@@ -1,0 +1,30 @@
+import type { SharedString, Worksheet } from './types.js';
+
+/**
+ * Resolve every `{ type: 'shared', si }` cell in `ws` to a concrete
+ * `{ type: 'text', text, runs? }` by looking `si` up in the workbook
+ * `sharedStrings` table (ECMA-376 §18.4.8). Mutates cells in place and returns
+ * `ws` for chaining. Out-of-range / missing `si` resolves to empty text —
+ * matching the parser's historical fallback. Idempotent: a `Worksheet` with no
+ * `shared` cells is returned unchanged.
+ *
+ * This keeps the dedup win on the wire (each shared string ships ONCE in the
+ * workbook) while every downstream consumer — renderer, formula engine, number
+ * formatter, markdown — still sees fully-resolved cell text.
+ */
+export function resolveSharedStrings(ws: Worksheet, sharedStrings: SharedString[]): Worksheet {
+  for (const row of ws.rows) {
+    for (const cell of row.cells) {
+      const v = cell.value;
+      if (v.type === 'shared') {
+        const ss = sharedStrings[v.si];
+        cell.value = ss
+          ? ss.runs !== undefined
+            ? { type: 'text', text: ss.text, runs: ss.runs }
+            : { type: 'text', text: ss.text }
+          : { type: 'text', text: '' };
+      }
+    }
+  }
+  return ws;
+}

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -598,9 +598,10 @@ export interface Row {
 export interface Cell {
   col: number;
   row: number;
-  colRef: string;
   value: CellValue;
-  styleIndex: number;
+  /** Style index into the styles table. Omitted on the wire when `0` (the
+   *  common unstyled case), so read it as `styleIndex ?? 0`. */
+  styleIndex?: number;
   /** Raw `<f>` formula text (ECMA-376 §18.3.1.40), when present. The renderer
    *  uses this to recompute volatile functions (TODAY, NOW) at display time
    *  so the cached `<v>` — frozen when the file was last saved — doesn't
@@ -613,7 +614,12 @@ export type CellValue =
   | { type: 'text'; text: string; runs?: Run[] }
   | { type: 'number'; number: number }
   | { type: 'bool'; bool: boolean }
-  | { type: 'error'; error: string };
+  | { type: 'error'; error: string }
+  /** Shared-string reference into `ParsedWorkbook.sharedStrings` (ECMA-376
+   *  §18.4.8). Resolved to `{ type: 'text', ... }` by the workbook before the
+   *  renderer (or any other consumer) sees it, so downstream code never
+   *  encounters this variant. */
+  | { type: 'shared'; si: number };
 
 export interface Run {
   text: string;

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -15,6 +15,7 @@ import { selectSheetVisibility } from './sheet-visibility.js';
 import { renderWorksheetViewport } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { formatCellValue } from './number-format.js';
+import { resolveSharedStrings } from './shared-strings.js';
 import {
   parseListFormula,
   resolveListValues,
@@ -234,6 +235,10 @@ export class XlsxWorkbook {
       const { worksheetJson } = res as Extract<WorkerResponse, { type: 'parsedSheet' }>;
       ws = JSON.parse(new TextDecoder().decode(new Uint8Array(worksheetJson))) as Worksheet;
     }
+    // Resolve shared-string references (`{ type: 'shared', si }`) against the
+    // workbook's dedup'd sharedStrings table so no consumer downstream ever
+    // sees an unresolved cell. Covers BOTH decode paths above.
+    resolveSharedStrings(ws, this.parsedWorkbook.sharedStrings);
     this.sheetCache.set(sheetIndex, ws);
     return ws;
   }


### PR DESCRIPTION
## Summary
Fix the xlsx wire model's sharedStrings dedup self-sabotage (SC1). Cells cloned the full string + rich-text runs per cell (the shared table was sent but unused) plus a dead `colRef` field and un-skipped defaults, making sheet JSON redundant. **Rendering is byte-identical (VRT)**; sheet JSON shrinks.

## Changes
**Rust** (`types.rs`/`lib.rs`/`markdown.rs`): added `CellValue::Shared { si }` (ECMA-376 §18.4.8/§18.3.1.4) so `t="s"` cells ship a sharedStrings index reference instead of a clone (out-of-range `si` resolves to empty, matching the historical fallback). Removed the dead `col_ref` field; `skip_serializing_if` on `style_index`; threaded sharedStrings into markdown rendering.

**TS** (`types.ts`/new `shared-strings.ts`/`workbook.ts`/`render-worker.ts`/`renderer.ts`/`number-format.ts`): added the `{type:'shared';si}` variant; new `resolveSharedStrings(ws, sharedStrings)` (in-place, idempotent) called in **both** decode paths (main `getWorksheet` and the render worker's `parseSheetLocally`), so the renderer/formula/number-format code never sees the `shared` variant.

**node public API** (review follow-up): `parseXlsxSheet` / `parseXlsxAllSheets` now resolve shared strings too (they previously leaked the unresolved reference — a regression from the pre-dedup behavior); `resolveSharedStrings` is exported from `@silurus/ooxml-xlsx` for external headless callers.

## Verification
- **VRT byte-identity (absolute condition): PASS** — every sheet (68 views across demo/sample-1 + 27 private) `diff=0.0%`, both main and worker mode.
- Payload: 1,285,014 -> 1,082,221 bytes (15.8%); the dead `colRef` removal was the dominant win.
- Roundtrip tests (Rust + TS) for si=0 / out-of-range / empty / rich runs / inline mix / idempotency; a node test asserts no `shared` cell survives the public parse API.
- Gates: cargo 132/141, vitest 1198, node/markdown/vscode typecheck clean.