### PR TITLE
feat(xlsx,docx): recognize chartEx parts via shared parse_chartex_part (CH14)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3146,13 +3146,28 @@ fn parse_inline_drawing(
         // relationship. When both resolve, emit a `ChartRun` from the pre-parsed
         // `chart_map` (keyed by the SAME rId), sized from `<wp:extent>` exactly like
         // an inline image. A non-chart graphicData falls through to the blip path.
+        //
+        // A modern chartEx chart (Microsoft 2014 chartex extension — waterfall,
+        // boxWhisker, treemap, sunburst, …) is wired identically: Word emits
+        // `<a:graphicData uri="http://schemas.microsoft.com/office/drawing/
+        // 2014/chartex">` wrapping the SAME `<c:chart r:id>` child (the
+        // transitional `c:` local name, not `cx:` — only the graphicData `uri`
+        // and the target part's own root namespace distinguish it), typically
+        // inside `<mc:AlternateContent><mc:Choice Requires="cx">` with a
+        // rendered-image `<mc:Fallback>`. `chart_map` already holds its
+        // `ChartModel` (via `load_chart_map` → `parse_docx_chart`, which
+        // dispatches on the part's root namespace), so accepting the chartex
+        // uri here — matching pptx's `uri.contains("chartex")` check in
+        // `shape.rs` — is the only change needed to stop silently dropping it.
         if let Some(graphic_data) = container
             .descendants()
             .find(|n| n.tag_name().name() == "graphicData")
         {
-            let is_chart = graphic_data
-                .attribute("uri")
-                .is_some_and(|uri| uri.contains("drawingml/2006/chart"));
+            let is_chart = graphic_data.attribute("uri").is_some_and(|uri| {
+                uri.contains("drawingml/2006/chart")
+                    || uri.contains("chartex")
+                    || uri.contains("chartEx")
+            });
             if is_chart {
                 if let Some(chart_node) = container
                     .descendants()
@@ -5227,17 +5242,36 @@ impl ooxml_common::chart::ColorResolver for DocxColorResolver<'_> {
     }
 }
 
-/// Parse a `word/charts/chartN.xml` part into the shared [`ChartModel`] via
-/// [`ooxml_common::chart::parse_chart_part`], resolving theme colours/fonts with
-/// [`DocxColorResolver`]. `None` when the XML is malformed or holds no
-/// recognized chart type.
+/// Parse a `word/charts/chartN.xml` part into the shared [`ChartModel`].
+/// Dispatches on the root element's namespace: a legacy DrawingML chart
+/// (`<c:chartSpace>`, ECMA-376 §21.2) goes through
+/// [`ooxml_common::chart::parse_chart_part`]; a modern chartEx part
+/// (`<cx:chartSpace>`, Microsoft 2014 chartex extension — waterfall,
+/// boxWhisker, treemap, sunburst, …) goes through
+/// [`ooxml_common::chart::parse_chartex_part`]. Both roots share the local
+/// name `chartSpace`, so the namespace URI (not the tag name) is the only
+/// reliable signal — the same "chartex" substring check pptx's
+/// `shape.rs`/`chart.rs` use on the `<a:graphicData>` `uri` attribute, applied
+/// here to the chart part's own root namespace instead (the part itself
+/// carries the same URI declaration). Theme colours/fonts resolve through
+/// [`DocxColorResolver`] either way. `None` when the XML is malformed or holds
+/// no recognized chart type.
 fn parse_docx_chart(
     chart_xml: &str,
     theme: &ThemeColors,
 ) -> Option<ooxml_common::chart::ChartModel> {
     let doc = XmlDoc::parse(chart_xml).ok()?;
+    let root = doc.root_element();
     let resolver = DocxColorResolver { theme };
-    ooxml_common::chart::parse_chart_part(doc.root_element(), &resolver)
+    let is_chartex = root
+        .tag_name()
+        .namespace()
+        .is_some_and(|ns| ns.contains("chartex") || ns.contains("chartEx"));
+    if is_chartex {
+        ooxml_common::chart::parse_chartex_part(root, &resolver)
+    } else {
+        ooxml_common::chart::parse_chart_part(root, &resolver)
+    }
 }
 
 // ===== Table parsing =====
@@ -9582,6 +9616,206 @@ mod anchor_image_relative_from_tests {
         let empty: HashMap<String, ooxml_common::chart::ChartModel> = HashMap::new();
         let none = parse_inline_drawing(&style_map, drawing, &media, &empty, &theme);
         assert!(none.is_empty(), "unresolvable chart rId must emit nothing");
+    }
+
+    /// CH14 — `parse_docx_chart` dispatches on the chart part's root
+    /// namespace: a `<cx:chartSpace>` (Microsoft 2014 chartex extension) goes
+    /// through `parse_chartex_part`, not `parse_chart_part`. Before this, every
+    /// chartEx part silently returned `None` because `parse_chart_part` never
+    /// finds a `c:barChart`/`c:lineChart`/etc. element and short-circuits to
+    /// nothing draws. The chart type comes out as the raw `cx:series
+    /// layoutId` string ("boxWhisker" here, matching sample-24's box-and-
+    /// whisker chart), which the core renderer currently draws as a labeled
+    /// placeholder box until CH15 adds a real box-whisker renderer.
+    #[test]
+    fn parse_docx_chart_dispatches_chartex_to_parse_chartex_part() {
+        let theme = ThemeColors::default();
+        let chartex_xml = r#"<cx:chartSpace
+            xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <cx:chartData>
+            <cx:data id="0">
+              <cx:strDim type="cat">
+                <cx:lvl ptCount="3">
+                  <cx:pt idx="0">Category 1</cx:pt>
+                  <cx:pt idx="1">Category 2</cx:pt>
+                  <cx:pt idx="2">Category 3</cx:pt>
+                </cx:lvl>
+              </cx:strDim>
+              <cx:numDim type="val">
+                <cx:lvl ptCount="3">
+                  <cx:pt idx="0">-7</cx:pt>
+                  <cx:pt idx="1">36</cx:pt>
+                  <cx:pt idx="2">14</cx:pt>
+                </cx:lvl>
+              </cx:numDim>
+            </cx:data>
+          </cx:chartData>
+          <cx:chart>
+            <cx:plotArea>
+              <cx:plotAreaRegion>
+                <cx:series layoutId="boxWhisker"/>
+              </cx:plotAreaRegion>
+            </cx:plotArea>
+          </cx:chart>
+        </cx:chartSpace>"#;
+        let chart = parse_docx_chart(chartex_xml, &theme).expect("chartex part must parse");
+        assert_eq!(chart.chart_type, "boxWhisker");
+        assert_eq!(
+            chart.categories,
+            vec![
+                "Category 1".to_string(),
+                "Category 2".to_string(),
+                "Category 3".to_string()
+            ]
+        );
+        assert_eq!(chart.series.len(), 1);
+    }
+
+    /// CH14 — the inline-drawing chart gate accepts the chartex
+    /// `<a:graphicData uri>` (Microsoft 2014 extension) alongside the legacy
+    /// DrawingML chart uri. Mirrors Word's actual sample-24 wire format
+    /// exactly: `<a:graphicData uri=".../2014/chartex">` still wraps a
+    /// `<c:chart r:id>` child (the transitional `c:` local name, NOT `cx:`),
+    /// resolved through the SAME `chart_map` a legacy chart drawing uses.
+    /// Before this fix the uri gate only matched `drawingml/2006/chart`, so
+    /// this drawing fell all the way through to the blip/picture path and (no
+    /// blip present) emitted nothing.
+    #[test]
+    fn inline_chartex_drawing_emits_chart_run() {
+        let xml = r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:r><w:drawing>
+            <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                       xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+              <wp:extent cx="5486400" cy="3200400"/>
+              <wp:docPr id="3" name="Chart 3"/>
+              <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/drawing/2014/chartex">
+                <c:chart r:id="rIdChartEx"/>
+              </a:graphicData></a:graphic>
+            </wp:inline>
+          </w:drawing></w:r>
+        </w:p>"#;
+        let doc = XmlDoc::parse(xml).unwrap();
+        let drawing = doc
+            .descendants()
+            .find(|n| n.tag_name().name() == "drawing")
+            .unwrap();
+        let style_map = StyleMap::parse("");
+        let media: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+
+        let model = parse_docx_chart(
+            r#"<cx:chartSpace xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex">
+              <cx:chartData><cx:data id="0">
+                <cx:numDim type="val"><cx:lvl ptCount="1"><cx:pt idx="0">1</cx:pt></cx:lvl></cx:numDim>
+              </cx:data></cx:chartData>
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                <cx:series layoutId="sunburst"/>
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+            </cx:chartSpace>"#,
+            &theme,
+        )
+        .expect("chartex model");
+        let mut chart_map: HashMap<String, ooxml_common::chart::ChartModel> = HashMap::new();
+        chart_map.insert("rIdChartEx".to_string(), model);
+
+        let runs = parse_inline_drawing(&style_map, drawing, &media, &chart_map, &theme);
+        assert_eq!(runs.len(), 1, "one chartex chart run expected");
+        match &runs[0] {
+            DocRun::Chart(c) => {
+                assert!(!c.anchor);
+                assert_eq!(c.chart.chart_type, "sunburst");
+                // 5486400 EMU / 12700 = 432pt; 3200400 / 12700 = 252pt.
+                assert!((c.width_pt - 432.0).abs() < 1e-6, "width_pt={}", c.width_pt);
+                assert!(
+                    (c.height_pt - 252.0).abs() < 1e-6,
+                    "height_pt={}",
+                    c.height_pt
+                );
+            }
+            other => panic!("expected DocRun::Chart, got {other:?}"),
+        }
+    }
+
+    /// CH14 end-to-end — `private/sample-24.docx` has 6 `<w:drawing>` chart
+    /// references total (`word/charts/chart1.xml`..`chart6.xml`, rId5..rId11
+    /// each used exactly once in `document.xml`). Two of the six parts —
+    /// `chart4.xml` (box-and-whisker) and `chart6.xml` (sunburst) — are
+    /// actually `<cx:chartSpace>` chartEx parts wrapped in
+    /// `<mc:AlternateContent><mc:Choice Requires="cx">` (with an `mc:Fallback`
+    /// rendered-image for older Word versions); the other four
+    /// (`chart1`/`chart2`/`chart3`/`chart5`) are legacy `<c:chartSpace>`
+    /// bar/line/radar/stock charts. Before this fix the uri gate in
+    /// `parse_inline_drawing` only matched the legacy DrawingML chart uri, so
+    /// chart4/chart6 fell through to the (blip-less) picture path and
+    /// produced nothing — this confirms the full zip → document.xml →
+    /// AlternateContent/Choice → inline drawing → chart_map pipeline now
+    /// surfaces both as `DocRun::Chart`, and that all 6 chart drawings still
+    /// produce exactly one `DocRun::Chart` each (no regression, no
+    /// duplication from the `mc:Fallback` branch). `stockChart` (chart5) is
+    /// not implemented by `parse_chart_part` and reports as "unknown" —  a
+    /// pre-existing legacy-chart gap, unrelated to and out of scope for this
+    /// chartex wiring task. Skips gracefully when the private,
+    /// non-redistributable fixture is not present (e.g. CI).
+    #[test]
+    fn sample24_chartex_charts_parse_as_chart_runs() {
+        const LOCAL_SAMPLE_24: &str = "../public/private/sample-24.docx";
+        let Ok(data) = std::fs::read(LOCAL_SAMPLE_24) else {
+            eprintln!(
+                "skipping sample24_chartex_charts_parse_as_chart_runs: local sample not found"
+            );
+            return;
+        };
+        let doc = parse_from_bytes(&data).expect("sample-24.docx must parse");
+
+        fn collect_from_paragraph(p: &DocParagraph, out: &mut Vec<String>) {
+            for run in &p.runs {
+                if let DocRun::Chart(c) = run {
+                    out.push(c.chart.chart_type.clone());
+                }
+            }
+        }
+        fn collect_from_table(t: &DocTable, out: &mut Vec<String>) {
+            for row in &t.rows {
+                for cell in &row.cells {
+                    for el in &cell.content {
+                        match el {
+                            CellElement::Paragraph(p) => collect_from_paragraph(p, out),
+                            CellElement::Table(t) => collect_from_table(t, out),
+                        }
+                    }
+                }
+            }
+        }
+        let mut chart_types = Vec::new();
+        for el in &doc.body {
+            match el {
+                BodyElement::Paragraph(p) => collect_from_paragraph(p, &mut chart_types),
+                BodyElement::Table(t) => collect_from_table(t, &mut chart_types),
+                _ => {}
+            }
+        }
+
+        assert_eq!(
+            chart_types.iter().filter(|t| *t == "boxWhisker").count(),
+            1,
+            "expected exactly one boxWhisker chartex chart, got {chart_types:?}"
+        );
+        assert_eq!(
+            chart_types.iter().filter(|t| *t == "sunburst").count(),
+            1,
+            "expected exactly one sunburst chartex chart, got {chart_types:?}"
+        );
+        // 6 chart drawings total: chart1(bar)/chart2(line)/chart3(radar)/
+        // chart5(stock, unimplemented → "unknown") legacy + chart4(boxWhisker)/
+        // chart6(sunburst) chartex. No duplication from mc:Fallback.
+        assert_eq!(
+            chart_types.len(),
+            6,
+            "expected 6 total chart runs (4 legacy + 2 chartex), got {chart_types:?}"
+        );
     }
 
     /// §20.4.2.5 — an anchored drawing whose `<wp:docPr hidden="1">` is set is

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -85,6 +85,14 @@ pub(crate) fn load_sheet_charts(
             // oneCellAnchor size: `<xdr:ext cx cy>` in EMU.
             let (mut ext_cx, mut ext_cy) = (0i64, 0i64);
             let mut chart_rid: Option<String> = None;
+            // Modern chartEx (Microsoft `cx:` namespace, 2014) parts are wired the
+            // same way as a legacy chart — `<a:graphicData>` still carries a
+            // `<c:chart r:id>` child (the transitional `c:` local name, not `cx:`)
+            // — but the `graphicData@uri` is the chartex extension URI instead of
+            // the DrawingML chart URI. Track it alongside `chart_rid` so the part
+            // is dispatched to `parse_chartex_part`, matching pptx's
+            // `uri.contains("chartex")` detection in shape.rs.
+            let mut is_chartex = false;
 
             for child in anchor.children() {
                 if !child.is_element() {
@@ -139,6 +147,20 @@ pub(crate) fn load_sheet_charts(
                         if crate::drawing::xdr_node_hidden(&child) {
                             continue;
                         }
+                        // `<a:graphicData uri>` distinguishes a chartEx part
+                        // (`http://schemas.microsoft.com/office/drawing/2014/chartex`)
+                        // from a legacy DrawingML chart
+                        // (`http://schemas.openxmlformats.org/drawingml/2006/chart`).
+                        // Both wire the part through a `<c:chart r:id>` child, so
+                        // the rId resolution below is unchanged either way.
+                        if let Some(gd) = child
+                            .descendants()
+                            .find(|n| n.tag_name().name() == "graphicData")
+                        {
+                            if let Some(uri) = gd.attribute("uri") {
+                                is_chartex = uri.contains("chartex") || uri.contains("chartEx");
+                            }
+                        }
                         // Look for a:graphic/a:graphicData/c:chart[@r:id]
                         for gf_child in child.descendants() {
                             if gf_child.tag_name().name() == "chart"
@@ -183,6 +205,12 @@ pub(crate) fn load_sheet_charts(
             // (the single superset parser for pptx + xlsx). The xlsx theme
             // palette + major/minor Latin faces ride on the `XlsxColorResolver`,
             // so no `ChartData` intermediate / `From` adapter is needed.
+            //
+            // A chartEx part (`is_chartex`) has a `<cx:chartSpace>` root instead
+            // of `<c:chartSpace>` and uses the shared
+            // `parse_chartex_part` structure walk (waterfall / boxWhisker /
+            // treemap / sunburst / … — ECMA-376 does not cover these; they are
+            // the Microsoft 2014 chartex extension). Same `ColorResolver`.
             let Ok(chart_doc) = roxmltree::Document::parse(&chart_xml) else {
                 continue;
             };
@@ -191,9 +219,12 @@ pub(crate) fn load_sheet_charts(
                 theme_major_font_latin: theme_fonts.0,
                 theme_minor_font_latin: theme_fonts.1,
             };
-            let Some(chart) =
+            let chart_opt = if is_chartex {
+                ooxml_common::chart::parse_chartex_part(chart_doc.root_element(), &resolver)
+            } else {
                 ooxml_common::chart::parse_chart_part(chart_doc.root_element(), &resolver)
-            else {
+            };
+            let Some(chart) = chart_opt else {
                 continue;
             };
 
@@ -497,5 +528,143 @@ mod hidden_tests {
             );
             assert_eq!(charts.len(), 1, "visible chart dropped (attr={attr})");
         }
+    }
+}
+
+/// CH14 — chartEx (Microsoft 2014 `cx:` namespace) recognition for xlsx.
+/// `xdr:graphicFrame` wires a chartEx part through the SAME `<c:chart r:id>`
+/// child a legacy chart uses (the transitional `c:` local name, not `cx:`); only
+/// `<a:graphicData@uri>` distinguishes it
+/// (`http://schemas.microsoft.com/office/drawing/2014/chartex` vs the
+/// DrawingML chart URI). No private xlsx fixture currently contains a chartEx
+/// part (`unzip -l ... | grep -i chartex` across every `packages/xlsx/public/
+/// private/*.xlsx` sample found none — all still use `<c:chartSpace>`), so this
+/// exercises the full zip → drawing → chartEx-part round trip with an inline
+/// waterfall fixture, mirroring `parse_chartex_part_waterfall_full_contract`
+/// in `ooxml-common`'s chart tests.
+#[cfg(test)]
+mod chartex_tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+    use zip::write::SimpleFileOptions;
+
+    const NS: &str = concat!(
+        r#"xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" "#,
+        r#"xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" "#,
+        r#"xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships""#,
+    );
+    const CX_NS: &str = "http://schemas.microsoft.com/office/drawing/2014/chartex";
+
+    fn theme() -> Vec<String> {
+        vec!["#111111".into(); 12]
+    }
+
+    /// A minimal waterfall chartEx part: one category dimension, one value
+    /// dimension with a negative point, and the `cx:series layoutId` that
+    /// `parse_chartex_part` reads as the chart type.
+    fn waterfall_chartex_xml() -> String {
+        format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <cx:chartData>
+                <cx:data id="0">
+                  <cx:strDim type="cat">
+                    <cx:lvl ptCount="3">
+                      <cx:pt idx="0">Start</cx:pt>
+                      <cx:pt idx="1">Change</cx:pt>
+                      <cx:pt idx="2">End</cx:pt>
+                    </cx:lvl>
+                  </cx:strDim>
+                  <cx:numDim type="val">
+                    <cx:lvl ptCount="3">
+                      <cx:pt idx="0">50</cx:pt>
+                      <cx:pt idx="1">-15</cx:pt>
+                      <cx:pt idx="2">35</cx:pt>
+                    </cx:lvl>
+                  </cx:numDim>
+                </cx:data>
+              </cx:chartData>
+              <cx:chart>
+                <cx:plotArea>
+                  <cx:plotAreaRegion>
+                    <cx:series layoutId="waterfall"/>
+                  </cx:plotAreaRegion>
+                </cx:plotArea>
+              </cx:chart>
+            </cx:chartSpace>"#
+        )
+    }
+
+    /// `<xdr:graphicFrame>` for a chartEx part. Structurally identical to the
+    /// legacy `drawing_xml` fixture in `hidden_tests` except for the
+    /// `graphicData@uri`, which is exactly the wire-format signal
+    /// `load_sheet_charts` now checks.
+    fn chartex_drawing_xml() -> String {
+        format!(
+            r#"<xdr:wsDr {NS}><xdr:twoCellAnchor>
+              <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+              <xdr:to><xdr:col>8</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>16</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+              <xdr:graphicFrame>
+                <xdr:nvGraphicFramePr><xdr:cNvPr id="2" name="Chart 1"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr>
+                <xdr:xfrm><a:off x="0" y="0"/><a:ext cx="4000000" cy="3000000"/></xdr:xfrm>
+                <a:graphic><a:graphicData uri="{CX_NS}">
+                  <c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" r:id="rIdChart"/>
+                </a:graphicData></a:graphic>
+              </xdr:graphicFrame>
+              <xdr:clientData/>
+            </xdr:twoCellAnchor></xdr:wsDr>"#,
+            NS = NS,
+            CX_NS = CX_NS,
+        )
+    }
+
+    /// Builds the same `sheet1.xml.rels` → `drawing1.xml` → `drawing1.xml.rels`
+    /// → `charts/chart1.xml` chain as `hidden_tests::archive_with_chart`, but
+    /// with a chartEx part at the end instead of a legacy one.
+    fn archive_with_chartex_chart() -> crate::XlsxZip {
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let o = SimpleFileOptions::default();
+
+            zw.start_file("xl/worksheets/_rels/sheet1.xml.rels", o)
+                .unwrap();
+            zw.write_all(br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#).unwrap();
+
+            zw.start_file("xl/drawings/drawing1.xml", o).unwrap();
+            zw.write_all(chartex_drawing_xml().as_bytes()).unwrap();
+
+            zw.start_file("xl/drawings/_rels/drawing1.xml.rels", o)
+                .unwrap();
+            zw.write_all(br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/></Relationships>"#).unwrap();
+
+            zw.start_file("xl/charts/chart1.xml", o).unwrap();
+            zw.write_all(waterfall_chartex_xml().as_bytes()).unwrap();
+
+            zw.finish().unwrap();
+        }
+        zip::ZipArchive::new(Cursor::new(buf)).unwrap()
+    }
+
+    #[test]
+    fn chartex_graphicframe_parses_through_parse_chartex_part() {
+        let mut archive = archive_with_chartex_chart();
+        let charts = load_sheet_charts(
+            &mut archive,
+            "worksheets/sheet1.xml",
+            &theme(),
+            (None, None),
+        );
+        assert_eq!(
+            charts.len(),
+            1,
+            "chartEx graphicFrame did not produce a chart"
+        );
+        let chart = &charts[0].chart;
+        assert_eq!(chart.chart_type, "waterfall");
+        assert_eq!(chart.series.len(), 1, "expected exactly one chartEx series");
+        assert_eq!(
+            chart.categories,
+            vec!["Start".to_string(), "Change".to_string(), "End".to_string()]
+        );
     }
 }


### PR DESCRIPTION
## Summary
xlsx skipped chartEx (cx: 2014 namespace) parts entirely, and docx's chart branch (CH12) matched only the legacy chart URI. Both now recognize chartEx and parse it through the shared `ooxml_common::chart::parse_chartex_part` (#750). Waterfall chartEx renders immediately (the shared renderer already has a waterfall case); boxWhisker/sunburst/treemap show the typed placeholder until CH15.

## Changes (2 commits)
- **xlsx** (`parser/src/chart.rs`): the `xdr:graphicFrame` walk reads `<a:graphicData@uri>`; when it contains `chartex`, dispatches to `parse_chartex_part` instead of `parse_chart_part` (same signal as pptx's shape.rs). No private xlsx sample carries a chartEx part (verified across all 30), so coverage is an inline waterfall fixture exercising the full zip → drawing → chart-part round trip.
- **docx** (`parser/src/parser.rs`): `parse_docx_chart` dispatches on the chart part's root namespace (`c:chartSpace` → legacy, `cx:chartSpace` → chartEx); the inline-drawing `is_chart` gate also accepts the chartex URI. Confirmed Word's actual wire format against sample-24: the chartex `graphicData` still wraps a `<c:chart r:id>` child (legacy local name) inside `mc:AlternateContent/mc:Choice[@Requires="cx"]` — the existing AlternateContent handling already walks into Choice, so only the two gates needed changes.

## Verification
- **Real fixture**: sample-24.docx's chart4 (boxWhisker) and chart6 (sunburst) now parse as `DocRun::Chart` and draw the typed placeholder ("Chart: boxWhisker"/"Chart: sunburst") at the correct position/size — no crash, no layout corruption (headless render).
- **Non-regression**: docx VRT 21/21, xlsx VRT 67/67 — match percentages identical to the pre-change baseline (legacy charts untouched).
- Gates: cargo fmt/clippy(-D warnings)/test workspace (ooxml-common 165 / xlsx 111 / docx 214), build:wasm, vitest 2112, tsc + node typecheck.

## Follow-up
CH15 replaces the boxWhisker/sunburst/treemap placeholders with real renderers (ground truth: docx `private/sample-24.pdf` p.2-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)