### PR TITLE
feat(charts): flatten 3D charts to 2D + stockChart renderer + ofPie fallback (CH13)

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2153,3 +2153,83 @@ describe('CH6-follow — series trendlines (commit 3)', () => {
     expect(rec.segs.every(s => !s.dashed)).toBe(true);
   });
 });
+
+describe('CH13 — stock chart (high/low/close)', () => {
+  // High/Low/Close over three dates. Value axis 0..70 so the plot geometry is
+  // easy to reason about.
+  const stockModel = (over: Partial<ChartModel> = {}): ChartModel => baseModel({
+    chartType: 'stock',
+    categories: ['1/5/2002', '1/6/2002', '1/7/2002'],
+    valMin: 0,
+    valMax: 70,
+    stockHiLowLines: true,
+    stockHiLowLineColor: '595959',
+    series: [
+      series({ name: 'High', values: [55, 57, 57] }),
+      series({ name: 'Low', values: [11, 12, 13] }),
+      series({ name: 'Close', values: [32, 35, 34] }),
+    ],
+    ...over,
+  });
+
+  /** Near-vertical segments in the hi-lo line color that span a large Y range —
+   *  these are the per-category low↔high lines. */
+  function hiLoLines(segs: Seg[]): Seg[] {
+    return segs.filter(
+      s => Math.abs(s.x1 - s.x0) < 0.5 && Math.abs(s.y1 - s.y0) > 20 && s.ss === '#595959',
+    );
+  }
+
+  it('draws one vertical low↔high line per category, spanning the correct value range', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, stockModel(), RECT, 1);
+    const lines = hiLoLines(rec.segs);
+    expect(lines.length).toBe(3);
+
+    // The tallest line (category 2: 12..57 = 45 units) is taller than the
+    // shortest of the three, and every line's two endpoints map High above Low
+    // (smaller Y = higher value in canvas coords).
+    for (const l of lines) {
+      const top = Math.min(l.y0, l.y1);
+      const bot = Math.max(l.y0, l.y1);
+      expect(bot).toBeGreaterThan(top);
+    }
+    // Category ordering left→right: the three lines have increasing X.
+    const xs = lines.map(l => l.x0).sort((a, b) => a - b);
+    expect(xs[0]).toBeLessThan(xs[1]);
+    expect(xs[1]).toBeLessThan(xs[2]);
+
+    // The hi-lo span is proportional to (high - low): category 1 (55-11=44) is
+    // shorter than category 2 (57-12=45) by roughly the same pixel ratio.
+    const span = (l: Seg): number => Math.abs(l.y1 - l.y0);
+    const byX = [...lines].sort((a, b) => a.x0 - b.x0);
+    // 44 vs 45 vs 44 units — cat2 is the tallest.
+    expect(span(byX[1])).toBeGreaterThanOrEqual(span(byX[0]));
+  });
+
+  it('renders the title and a series-driven legend (High / Low / Close)', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, stockModel({ title: 'Stock', showLegend: true, legendPos: 'b' }), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    expect(labels).toContain('Stock');
+    expect(labels).toContain('High');
+    expect(labels).toContain('Low');
+    expect(labels).toContain('Close');
+  });
+
+  it('honors an explicit hi-lo line color', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, stockModel({ stockHiLowLineColor: 'FF0000' }), RECT, 1);
+    const red = rec.segs.filter(
+      s => Math.abs(s.x1 - s.x0) < 0.5 && Math.abs(s.y1 - s.y0) > 20 && s.ss === '#FF0000',
+    );
+    expect(red.length).toBe(3);
+  });
+
+  it('falls back to a default gray hi-lo line when no color is given', () => {
+    const rec = segRecordingCtx();
+    // stockHiLowLineColor omitted → renderer default '#595959'.
+    renderChart(rec.ctx, stockModel({ stockHiLowLineColor: null }), RECT, 1);
+    expect(hiLoLines(rec.segs).length).toBe(3);
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -202,7 +202,7 @@ function legendSwatchStyle(chartType: string | undefined): LegendSwatchStyle {
   if (!chartType) return 'fill';
   if (
     chartType === 'line' || chartType === 'stackedLine' || chartType === 'stackedLinePct' ||
-    chartType === 'radar' || chartType === 'scatter'
+    chartType === 'radar' || chartType === 'scatter' || chartType === 'stock'
   ) {
     return 'line';
   }
@@ -1869,6 +1869,240 @@ function renderLineChart(
       ctx, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
       secFontPx, secLabelBandW, primaryLabelColor, chart.date1904,
     );
+  }
+
+  drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleH + 2);
+  drawAxisTitles(ctx, chart, x, y, w, h, px0, py0, pw, ph, legLeftW, legBottomH, catTitlePx, valTitlePx);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Stock chart (ECMA-376 §21.2.2.198)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * High-low-close (and open-high-low-close) stock chart. Series order is fixed
+ * by the spec: a 3-series chart is High, Low, Close; a 4-series chart is Open,
+ * High, Low, Close. For each category we draw:
+ *   - a thin vertical "hi-lo line" from the Low value to the High value
+ *     (`<c:hiLowLines>`, §21.2.2.60) — always, when hiLowLines is present;
+ *   - the Close series marker at its value (a short tick / dot);
+ *   - the Open series marker (4-series only).
+ * The value axis, date/category axis, title and legend reuse the shared
+ * Cartesian scaffolding (identical to the line renderer). `<c:upDownBars>`
+ * (§21.2.2.227) is recognized at parse time but not drawn here.
+ */
+function renderStockChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+): void {
+  const { x, y, w, h } = r;
+  const cats = chartCategories(chart);
+  const n = cats.length;
+  if (n === 0) return;
+
+  // Fixed spec series roles by position. With 4 series the first is Open; the
+  // last three are always High, Low, Close. Fewer than 3 series can't form a
+  // hi-lo-close plot, so fall back to plotting each series' markers only.
+  const series = chart.series;
+  const hasOpen = series.length >= 4;
+  const openIdx = hasOpen ? 0 : -1;
+  const highIdx = hasOpen ? 1 : 0;
+  const lowIdx = hasOpen ? 2 : 1;
+  const closeIdx = hasOpen ? 3 : 2;
+  const highS = series[highIdx];
+  const lowS = series[lowIdx];
+  const closeS = series[closeIdx] as ChartSeries | undefined;
+  const openS = openIdx >= 0 ? series[openIdx] : undefined;
+
+  // ── Shared Cartesian frame (mirrors renderLineChart's band computation) ──
+  const titleBand = cartesianTitleBand(chart, h, ptToPx);
+  const titleFontPx = titleBand.fontPx;
+  const titleTopPad = titleBand.topPad;
+  const titleH = titleBand.bandH;
+  const leg = chartLegendReserve(chart, w, h, 0.22);
+  const { legRightW, legLeftW, legBottomH, legTopH } = chartLegendBands(leg);
+  const catAxFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  const valAxFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+  const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
+  const catTitlePx = axBands.catFontPx;
+  const valTitlePx = axBands.valFontPx;
+  const catTitleH = axBands.catBandH;
+  const valTitleW = axBands.valBandW;
+
+  const padT = titleH + legTopH + valAxFontPx / 2 + 2;
+  const padB = catAxisLabelBandH(catAxFontPx) + catTitleH + legBottomH;
+
+  const pad = {
+    t: padT,
+    r: legRightW + w * 0.05,
+    b: padB,
+    l: valAxFontPx * 2.2 + 10 + valTitleW + legLeftW,
+  };
+
+  drawChartTitle(ctx, chart, x, y + titleTopPad, w, titleFontPx);
+
+  const { plotRect: { px0, py0, pw, ph } } = computeChartFrame(chart, x, y, w, h, ptToPx, {
+    titleBand,
+    legendSideReserveFrac: 0.22,
+    pad,
+  });
+  if (pw <= 0 || ph <= 0) return;
+
+  if (chart.plotAreaBg) {
+    ctx.fillStyle = `#${chart.plotAreaBg}`;
+    ctx.fillRect(px0, py0, pw, ph);
+  }
+
+  // ── Value-axis extent: across every series' plotted values (the hi-lo line
+  // needs both the low and high extremes). Anchored at 0 for positive data
+  // (matching Excel's stock chart) unless the file sets an explicit min. ──
+  let dataMin = Infinity;
+  let dataMax = -Infinity;
+  for (const s of series) {
+    for (let ci = 0; ci < n; ci++) {
+      const v = s.values[ci];
+      if (v == null) continue;
+      dataMin = Math.min(dataMin, v);
+      dataMax = Math.max(dataMax, v);
+    }
+  }
+  if (!isFinite(dataMin)) { dataMin = 0; dataMax = 1; }
+  if (chart.valMin != null) dataMin = chart.valMin;
+  else if (dataMin > 0) dataMin = 0;
+  if (chart.valMax != null) dataMax = chart.valMax;
+  else if (dataMax < 0) dataMax = 0;
+  if (dataMax === dataMin) dataMax = dataMin + 1;
+
+  const plan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx);
+  if (plan.max - plan.min === 0) return;
+  const toY = (v: number) => py0 + ph - plan.frac(v) * ph;
+
+  // Category X mapping — stock charts use crossBetween="between" by default so
+  // the first/last hi-lo line isn't flush against the axes (matches Excel).
+  const between = isCrossBetween(chart);
+  const catRev = catAxisReversed(chart);
+  const toX = between
+    ? (i0: number) => { const i = catRev ? n - 1 - i0 : i0; return px0 + ((i + 0.5) / n) * pw; }
+    : (i0: number) => { const i = catRev ? n - 1 - i0 : i0; return px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw); };
+
+  // ── Value axis: gridlines + ticks + labels (identical to the line renderer) ──
+  if (!chart.valAxisHidden) {
+    ctx.font = `${valAxFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
+    ctx.textBaseline = 'middle';
+    const grid = valGridStroke(chart, ptToPx);
+    for (const v of plan.minorLines) strokeValueGridlineH(ctx, px0, pw, toY(v), false, grid);
+    const drawMajorGrid = drawValMajorGridlines(chart);
+    const drawLabels = chart.valAxisTickLabelPos !== 'none';
+    for (const v of plan.majorLines) {
+      const gy = toY(v);
+      if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, v === 0, grid);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy);
+      if (drawLabels) {
+        ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
+        ctx.textAlign = 'right';
+        ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
+      }
+    }
+  }
+
+  // Axis rules (bottom = category, left = value).
+  ctx.strokeStyle = '#aaa'; ctx.lineWidth = 1;
+  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
+    ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+  }
+  if (!chart.valAxisHidden && !chart.valAxisLineHidden) {
+    ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+  }
+
+  // ── Hi-lo lines: vertical Low↔High per category. Drawn when the file declares
+  // `<c:hiLowLines>` (the normal case) OR whenever both High and Low series are
+  // present — a stock chart without them is degenerate. Color from the resolved
+  // `<c:hiLowLines>` line fill, else a neutral gray. ──
+  const drawHiLo = (chart.stockHiLowLines ?? true) && highS != null && lowS != null;
+  if (drawHiLo && highS && lowS) {
+    ctx.strokeStyle = chart.stockHiLowLineColor ? `#${chart.stockHiLowLineColor}` : '#595959';
+    ctx.lineWidth = Math.max(1, 0.75 * ptToPx);
+    ctx.setLineDash([]);
+    for (let ci = 0; ci < n; ci++) {
+      const hi = highS.values[ci];
+      const lo = lowS.values[ci];
+      if (hi == null || lo == null) continue;
+      const cx = toX(ci);
+      ctx.beginPath();
+      ctx.moveTo(cx, toY(hi));
+      ctx.lineTo(cx, toY(lo));
+      ctx.stroke();
+    }
+  }
+
+  // ── Close (and Open) markers. A stock chart's close is drawn as a short tick.
+  // If the series carries an explicit `<c:marker>` (symbol/size/fill), honor it;
+  // otherwise draw a left/right tick in the series color. ──
+  const drawStockTick = (
+    s: ChartSeries | undefined,
+    seriesIndex: number,
+    side: 'left' | 'right' | 'both',
+  ): void => {
+    if (!s) return;
+    const color = chartColor(seriesIndex, s);
+    const symbol = s.markerSymbol ?? null;
+    const hasExplicitMarker = symbol != null && symbol !== 'none' && seriesHasMarkerDetail(s);
+    const tickLen = Math.max(3, (pw / n) * 0.22);
+    for (let ci = 0; ci < n; ci++) {
+      const v = s.values[ci];
+      if (v == null) continue;
+      const cx = toX(ci);
+      const cy = toY(v);
+      if (hasExplicitMarker) {
+        drawMarker(
+          ctx, cx, cy, symbol as string,
+          s.markerSize ?? 3, s.markerFill ?? color, s.markerLine ?? null, ptToPx,
+        );
+        continue;
+      }
+      // Horizontal tick: close ticks to the RIGHT of the line, open ticks to the
+      // LEFT (Excel's open-high-low-close convention). `both` centers it.
+      ctx.strokeStyle = color;
+      ctx.lineWidth = Math.max(1, 0.75 * ptToPx);
+      ctx.beginPath();
+      const x0 = side === 'right' ? cx : side === 'left' ? cx - tickLen : cx - tickLen / 2;
+      const x1 = side === 'right' ? cx + tickLen : side === 'left' ? cx : cx + tickLen / 2;
+      ctx.moveTo(x0, cy);
+      ctx.lineTo(x1, cy);
+      ctx.stroke();
+    }
+  };
+  drawStockTick(openS, openIdx, 'left');
+  drawStockTick(closeS, closeIdx, 'right');
+
+  // If fewer than 3 series (not a real hi-lo-close), still plot each series'
+  // markers so nothing is silently dropped.
+  if (series.length < 3) {
+    for (let si = 0; si < series.length; si++) {
+      drawStockTick(series[si], si, 'both');
+    }
+  }
+
+  // ── Category (date) axis labels — same path as the line renderer. ──
+  if (!chart.catAxisHidden) {
+    const labelInterval = Math.max(1, Math.ceil(n / 8));
+    const catLabelColor = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
+    ctx.fillStyle = catLabelColor; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    ctx.font = `${catAxFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
+    const catSlotMaxPx = (pw / n) * labelInterval - 4;
+    const showLabels = catLabelsVisible(chart);
+    const rotRad = catLabelRotationRad(chart);
+    for (let ci = 0; ci < n; ci += labelInterval) {
+      const tx = toX(ci);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx);
+      if (!showLabels) continue;
+      ctx.fillStyle = catLabelColor;
+      const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
+      const budget = rotRad === 0 ? catSlotMaxPx : ph * 0.4;
+      drawRotatedCatLabel(ctx, elideToWidth(ctx, label, budget), tx, py0 + ph + 5, rotRad);
+    }
   }
 
   drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleH + 2);
@@ -3673,6 +3907,8 @@ export function renderChart(
       renderScatterChart(ctx, chart, rect, ptToPx); break;
     case 'waterfall':
       renderWaterfallChart(ctx, chart, rect); break;
+    case 'stock':
+      renderStockChart(ctx, chart, rect, ptToPx); break;
     default:
       ctx.fillStyle = '#888';
       ctx.font = '11px sans-serif';

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -239,6 +239,7 @@ export type ChartType =
   | 'area' | 'stackedArea' | 'stackedAreaPct'
   | 'pie' | 'doughnut'
   | 'scatter' | 'bubble' | 'radar' | 'waterfall'
+  | 'stock'
   | string;
 
 export interface ChartModel {
@@ -590,6 +591,25 @@ export interface ChartModel {
    * /0 ⇒ horizontal labels (byte-stable).
    */
   catAxisLabelRotation?: number | null;
+  // ── Stock chart (CH13, §21.2.2.198) ──────────────────────────────────────
+  /**
+   * `<c:stockChart><c:hiLowLines>` presence (ECMA-376 §21.2.2.60). When true
+   * the stock renderer draws a vertical line spanning each category's low↔high
+   * value. Only set for `chartType === "stock"`; null/undefined on every other
+   * chart type (byte-stable).
+   */
+  stockHiLowLines?: boolean | null;
+  /**
+   * `<c:hiLowLines><c:spPr><a:ln><a:solidFill>` resolved color (hex, no `#`).
+   * null = the renderer's default gray hi-lo line.
+   */
+  stockHiLowLineColor?: string | null;
+  /**
+   * `<c:stockChart><c:upDownBars>` presence (ECMA-376 §21.2.2.227). Parsed so a
+   * stock file carrying open-close up/down bars is recognized; the renderer does
+   * NOT yet draw them (tracked follow-up). null/undefined when absent.
+   */
+  stockUpDownBars?: boolean | null;
 }
 
 /**

--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -9,6 +9,11 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   { name: 'private/sample-3', pageCount: 3, width: 595 },
   { name: 'private/sample-4', pageCount: 1, width: 595 },
   { name: 'private/sample-5', pageCount: 7, width: 595 },
+  // CH13 chart coverage: sample-24 p.3 carries a stockChart (hi-lo-close);
+  // sample-25 is a pie3DChart. References are private (gitignored) and generated
+  // locally with UPDATE_REFS=1 — they are never committed.
+  { name: 'private/sample-24', pageCount: 3, width: 595 },
+  { name: 'private/sample-25', pageCount: 1, width: 595 },
   { name: 'demo/sample-1', pageCount: 6, width: 595 },
 ];
 

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -2524,55 +2524,61 @@ pub fn parse_chart_part(
             .find(|n| n.is_element() && n.tag_name().name() == name)
     };
 
-    let chart_type = if let Some(bc) = find_chart("barChart") {
-        let grouping = bc
+    // ECMA-376 3D chart types (§21.2.2.15 bar3DChart, §21.2.2.96 line3DChart,
+    // §21.2.2.4 area3DChart, §21.2.2.140 pie3DChart) are FLATTENED to their 2D
+    // equivalents: the child data structure (`<c:ser>`/`<c:cat>`/`<c:val>`/
+    // grouping/`<c:dLbls>`) is identical to the 2D form, so a 3D chart is drawn
+    // as the corresponding 2D chart. The 3D-only elements (`<c:view3D>`
+    // §21.2.2.228, `<c:surface>` §21.2.2.177, `<a:scene3d>`/`<a:sp3d>` shape 3D
+    // and `<c:gapDepth>` §21.2.2.55) are ignored. This 2D-flattening is the
+    // established strategy of web chart engines (Google Slides, Keynote) and was
+    // approved in the CH13 plan; a faithful isometric 3D projection is out of
+    // scope. `surfaceChart`/`surface3DChart` are NOT flattened (they have no 2D
+    // analogue) and stay "unknown".
+    let read_grouping = |group: &Node, default: &str| -> String {
+        group
             .children()
             .find(|c| c.is_element() && c.tag_name().name() == "grouping")
             .and_then(|n| attr(&n, "val"))
-            .unwrap_or_else(|| "clustered".into());
+            .unwrap_or_else(|| default.into())
+    };
+    let chart_type = if let Some(bc) = find_chart("barChart").or_else(|| find_chart("bar3DChart")) {
+        // §21.2.2.17 barDir + §21.2.2.79 grouping. bar3DChart shares both
+        // (its extra `<c:gapDepth>` is ignored). `clustered` is the 2D default;
+        // `standard` (the bar3DChart default) folds to clustered as well since
+        // `canonical_chart_type` treats any non-stacked grouping as clustered.
+        let grouping = read_grouping(&bc, "clustered");
         let bar_dir = bc
             .children()
             .find(|c| c.is_element() && c.tag_name().name() == "barDir")
             .and_then(|n| attr(&n, "val"))
             .unwrap_or_else(|| "col".into());
-        let horizontal = bar_dir == "bar";
-        match (grouping.as_str(), horizontal) {
-            ("stacked" | "percentStacked", false) => "stackedBar".to_string(),
-            ("stacked" | "percentStacked", true) => "stackedBarH".to_string(),
-            (_, false) => "clusteredBar".to_string(),
-            (_, true) => "clusteredBarH".to_string(),
-        }
-    } else if let Some(lc) = find_chart("lineChart") {
-        let grouping = lc
-            .children()
-            .find(|c| c.is_element() && c.tag_name().name() == "grouping")
-            .and_then(|n| attr(&n, "val"))
-            .unwrap_or_else(|| "standard".into());
-        match grouping.as_str() {
-            "stacked" => "stackedLine".to_string(),
-            "percentStacked" => "stackedLinePct".to_string(),
-            _ => "line".to_string(),
-        }
-    } else if find_chart("pieChart").is_some() {
+        canonical_chart_type("bar", &bar_dir, &grouping)
+    } else if let Some(lc) = find_chart("lineChart").or_else(|| find_chart("line3DChart")) {
+        let grouping = read_grouping(&lc, "standard");
+        canonical_chart_type("line", "col", &grouping)
+    } else if find_chart("pieChart").is_some() || find_chart("pie3DChart").is_some() {
+        "pie".to_string()
+    } else if find_chart("ofPieChart").is_some() {
+        // §21.2.2.126 ofPieChart (pie-of-pie / bar-of-pie). Rendered as a single
+        // plain pie over the whole series — the secondary plot (the exploded
+        // detail pie/bar) is NOT split out. See the ofPie handling note below.
         "pie".to_string()
     } else if find_chart("doughnutChart").is_some() {
         "doughnut".to_string()
-    } else if let Some(ac) = find_chart("areaChart") {
-        let grouping = ac
-            .children()
-            .find(|c| c.is_element() && c.tag_name().name() == "grouping")
-            .and_then(|n| attr(&n, "val"))
-            .unwrap_or_else(|| "standard".into());
-        match grouping.as_str() {
-            "stacked" => "stackedArea".to_string(),
-            _ => "area".to_string(),
-        }
+    } else if let Some(ac) = find_chart("areaChart").or_else(|| find_chart("area3DChart")) {
+        let grouping = read_grouping(&ac, "standard");
+        canonical_chart_type("area", "col", &grouping)
     } else if find_chart("scatterChart").is_some() {
         "scatter".to_string()
     } else if find_chart("bubbleChart").is_some() {
         "bubble".to_string()
     } else if find_chart("radarChart").is_some() {
         "radar".to_string()
+    } else if find_chart("stockChart").is_some() {
+        // §21.2.2.198 stockChart — high/low/close[/open] series drawn as
+        // per-category hi-lo lines + close ticks by the core stock renderer.
+        "stock".to_string()
     } else {
         "unknown".to_string()
     };
@@ -2749,15 +2755,19 @@ pub fn parse_chart_part(
     // renderer dispatches on (mixed bar+line charts key line vs. non-line off
     // this field). Mirrors the xlsx `type_map`; `bubbleChart` folds to
     // `scatter` like everything else.
+    // 3D groups fold to the same series type as their 2D equivalent (they are
+    // flattened above); `stockChart`/`ofPieChart` have no combo-mixing role so
+    // map to a plain type too.
     let group_series_type = |group_name: &str| -> Option<String> {
         match group_name {
-            "barChart" => Some("bar"),
-            "lineChart" => Some("line"),
-            "areaChart" => Some("area"),
-            "pieChart" => Some("pie"),
+            "barChart" | "bar3DChart" => Some("bar"),
+            "lineChart" | "line3DChart" => Some("line"),
+            "areaChart" | "area3DChart" => Some("area"),
+            "pieChart" | "pie3DChart" | "ofPieChart" => Some("pie"),
             "doughnutChart" => Some("doughnut"),
             "radarChart" => Some("radar"),
             "scatterChart" | "bubbleChart" => Some("scatter"),
+            "stockChart" => Some("stock"),
             _ => None,
         }
         .map(|s| s.to_string())
@@ -2957,6 +2967,36 @@ pub fn parse_chart_part(
                 })
                 .collect();
 
+            // §21.2.2.228 `<c:varyColors>`: a pie/doughnut varies each DATA POINT
+            // by the theme accent palette (`accent[(i % 6) + 1]`), rather than
+            // giving the whole series one fill. It defaults to ON for the pie
+            // family, so an absent element still cycles the accents. When on, fill
+            // every slice that lacks an explicit `<c:dPt>` fill from the resolver's
+            // accent for that point index — this is the same palette Office draws,
+            // so a docx/xlsx pie matches Word/Excel instead of falling back to the
+            // renderer's built-in default colors. Resolvers that own their own
+            // palette (pptx `resolve_series_accent` → None) contribute nothing here
+            // and stay byte-stable. Non-pie families are unaffected: only the pie
+            // renderer consumes `data_point_colors`, and a multi-series pie (rare)
+            // still varies by point within series[0].
+            let is_pie_family = chart_type == "pie" || chart_type == "doughnut";
+            let mut data_point_colors = data_point_colors;
+            if is_pie_family {
+                let vary = group
+                    .and_then(|g| child(g, "varyColors"))
+                    .and_then(|n| attr(&n, "val"))
+                    // ECMA-376 default for the pie family is "vary" (true); the
+                    // `<c:varyColors>` element `val` attribute is xsd:boolean.
+                    .map(|v| v != "0" && v != "false")
+                    .unwrap_or(true);
+                if vary {
+                    for (i, slot) in data_point_colors.iter_mut().enumerate() {
+                        if slot.is_none() {
+                            *slot = color_resolver.resolve_series_accent(i);
+                        }
+                    }
+                }
+            }
             let has_dpt_colors = data_point_colors.iter().any(|c| c.is_some());
 
             // Per-point `<c:dPt>` overrides (§21.2.2.39): marker (symbol/size/
@@ -4918,15 +4958,14 @@ mod tests {
         assert!(!m.cat_axis_hidden);
     }
 
-    /// (e) `chart_type` normalization for stacked/percentStacked, as actually
-    /// computed inline by `parse_chart_part` (a separate code path from the
-    /// standalone `canonical_chart_type` helper — pptx's `ChartModel` only
-    /// keeps the resolved string, not the raw `grouping`/`barDir`, so this
-    /// inline match IS the contract for the pptx wire value). Pins the real
-    /// (not necessarily "clean") existing behavior: for BAR, `stacked` and
-    /// `percentStacked` collapse to the SAME string (no `Pct` variant at this
-    /// layer); for LINE they're distinguished; a `percentStacked` AREA isn't
-    /// matched at all and falls through to plain `"area"`.
+    /// (e) `chart_type` normalization for stacked/percentStacked. As of CH13,
+    /// `parse_chart_part` routes bar/line/area type detection through the shared
+    /// `canonical_chart_type` helper (previously an inline match duplicated the
+    /// logic and — as a latent bug — folded a percentStacked BAR down to plain
+    /// `stackedBar`, so the renderer's `stackedBarPct` 100%-normalization never
+    /// fired for a parsed chart). It now distinguishes the percent variant for
+    /// BAR (`stackedBarPct` / `stackedBarHPct`) and AREA (`stackedAreaPct`),
+    /// matching the LINE behavior and the standalone helper's own matrix test.
     #[test]
     fn parse_chart_part_stacked_percent_stacked_chart_type() {
         fn bar_chart_type(grouping: &str, bar_dir: &str) -> String {
@@ -4966,11 +5005,11 @@ mod tests {
         }
 
         assert_eq!(bar_chart_type("stacked", "col"), "stackedBar");
-        // NOT "stackedBarPct" — parse_chart_part's inline bar match folds
-        // percentStacked into the same bucket as stacked.
-        assert_eq!(bar_chart_type("percentStacked", "col"), "stackedBar");
-        assert_eq!(bar_chart_type("percentStacked", "bar"), "stackedBarH");
-        // Line DOES distinguish percentStacked, unlike bar.
+        // CH13: percentStacked now maps to the Pct canonical variant (the
+        // renderer normalizes those to 100%), fixing the prior fold-to-stacked.
+        assert_eq!(bar_chart_type("percentStacked", "col"), "stackedBarPct");
+        assert_eq!(bar_chart_type("percentStacked", "bar"), "stackedBarHPct");
+        // Line + area also distinguish percentStacked.
         assert_eq!(line_chart_type("percentStacked"), "stackedLinePct");
     }
 
@@ -5482,5 +5521,193 @@ mod tests {
         let d = chart_space_of(&xml);
         let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("parses");
         assert_eq!(m.categories, vec!["FY2024 1Q"]);
+    }
+
+    // ── CH13: 3D flattening / stock / ofPie type detection ───────────────────
+
+    /// Build a minimal `<c:chartSpace>` whose plot area holds a single
+    /// chart-group element (`group_xml`) with one series. Used by the CH13
+    /// type-detection probes below.
+    fn chart_space_with_group(group_xml: &str) -> String {
+        format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+              <c:chart><c:plotArea>
+                {group_xml}
+                <c:catAx><c:axId val="1"/><c:axPos val="b"/></c:catAx>
+                <c:valAx><c:axId val="2"/><c:axPos val="l"/></c:valAx>
+              </c:plotArea></c:chart>
+            </c:chartSpace>"#
+        )
+    }
+
+    const CH13_SER: &str = r#"<c:ser><c:idx val="0"/>
+        <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt></c:strCache></c:cat>
+        <c:val><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt><c:pt idx="1"><c:v>7</c:v></c:pt></c:numCache></c:val>
+      </c:ser>"#;
+
+    /// §21.2.2.140 pie3DChart flattens to a plain 2D `pie`. The `<a:scene3d>` /
+    /// `<c:varyColors>` decoration is ignored; the series/cat/val flow through.
+    #[test]
+    fn parse_chart_part_pie3d_flattens_to_pie() {
+        let group = format!(r#"<c:pie3DChart><c:varyColors val="1"/>{CH13_SER}</c:pie3DChart>"#);
+        let xml_p = chart_space_with_group(&group);
+        let d = chart_space_of(&xml_p);
+        let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("pie3D parses");
+        assert_eq!(m.chart_type, "pie");
+        assert_eq!(m.series.len(), 1);
+        assert_eq!(m.series[0].values, vec![Some(3.0), Some(7.0)]);
+        assert_eq!(m.categories, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    /// §21.2.2.15 bar3DChart with `barDir=col` + `grouping=stacked` flattens to
+    /// `stackedBar` (the `<c:gapDepth>` 3D-only attr is ignored).
+    #[test]
+    fn parse_chart_part_bar3d_flattens_by_grouping_and_dir() {
+        let group = format!(
+            r#"<c:bar3DChart><c:barDir val="col"/><c:grouping val="stacked"/><c:gapDepth val="150"/>{CH13_SER}</c:bar3DChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("bar3D parses");
+        assert_eq!(m.chart_type, "stackedBar");
+
+        // barDir=bar (horizontal) + clustered → clusteredBarH.
+        let group_h = format!(
+            r#"<c:bar3DChart><c:barDir val="bar"/><c:grouping val="clustered"/>{CH13_SER}</c:bar3DChart>"#
+        );
+        let xml_h = chart_space_with_group(&group_h);
+        let d2 = chart_space_of(&xml_h);
+        let m2 = parse_chart_part(d2.root_element(), &FixtureResolver).expect("bar3D-h parses");
+        assert_eq!(m2.chart_type, "clusteredBarH");
+    }
+
+    /// §21.2.2.96 line3DChart → `line`; §21.2.2.4 area3DChart(stacked) →
+    /// `stackedArea`.
+    #[test]
+    fn parse_chart_part_line3d_area3d_flatten() {
+        let line = format!(r#"<c:line3DChart>{CH13_SER}</c:line3DChart>"#);
+        let xml_l = chart_space_with_group(&line);
+        let dl = chart_space_of(&xml_l);
+        assert_eq!(
+            parse_chart_part(dl.root_element(), &FixtureResolver)
+                .unwrap()
+                .chart_type,
+            "line"
+        );
+        let area =
+            format!(r#"<c:area3DChart><c:grouping val="stacked"/>{CH13_SER}</c:area3DChart>"#);
+        let xml_a = chart_space_with_group(&area);
+        let da = chart_space_of(&xml_a);
+        assert_eq!(
+            parse_chart_part(da.root_element(), &FixtureResolver)
+                .unwrap()
+                .chart_type,
+            "stackedArea"
+        );
+    }
+
+    /// §21.2.2.198 stockChart → `stock` (its high/low/close series flow through
+    /// the shared collectors unchanged).
+    #[test]
+    fn parse_chart_part_stock_detected() {
+        let hi = r#"<c:ser><c:idx val="0"/><c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>High</c:v></c:pt></c:strCache></c:strRef></c:tx>
+            <c:cat><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:cat>
+            <c:val><c:numCache><c:pt idx="0"><c:v>55</c:v></c:pt></c:numCache></c:val></c:ser>"#;
+        let group = format!(r#"<c:stockChart>{hi}<c:hiLowLines/></c:stockChart>"#);
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("stock parses");
+        assert_eq!(m.chart_type, "stock");
+        assert_eq!(m.series.len(), 1);
+        assert_eq!(m.series[0].name, "High");
+        assert_eq!(m.series[0].values, vec![Some(55.0)]);
+    }
+
+    /// §21.2.2.126 ofPieChart → `pie` (main-pie-only fallback; the secondary
+    /// plot is not split out — see the parse-time note).
+    #[test]
+    fn parse_chart_part_ofpie_flattens_to_pie() {
+        let group = format!(
+            r#"<c:ofPieChart><c:ofPieType val="pie"/><c:varyColors val="1"/>{CH13_SER}</c:ofPieChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("ofPie parses");
+        assert_eq!(m.chart_type, "pie");
+        assert_eq!(m.series[0].values, vec![Some(3.0), Some(7.0)]);
+    }
+
+    /// A resolver that DOES supply the default series accent palette (like the
+    /// real docx/xlsx resolvers), used to pin the §21.2.2.228 `<c:varyColors>`
+    /// per-slice accent fill. `FixtureResolver` returns `None` for accents so it
+    /// cannot exercise this path.
+    struct AccentResolver;
+    impl ColorResolver for AccentResolver {
+        fn resolve_solid_fill(&self, node: Node) -> Option<String> {
+            node.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "srgbClr")
+                .and_then(|n| attr(&n, "val"))
+                .map(|v| v.to_uppercase())
+        }
+        fn resolve_series_accent(&self, idx: usize) -> Option<String> {
+            // Six-accent cycle, matching `theme.accent[(idx % 6) + 1]`.
+            const ACCENTS: [&str; 6] =
+                ["4472C4", "ED7D31", "A5A5A5", "FFC000", "5B9BD5", "70AD47"];
+            Some(ACCENTS[idx % 6].to_string())
+        }
+    }
+
+    /// §21.2.2.228 varyColors (default ON for pie): each slice without an
+    /// explicit `<c:dPt>` fill takes the theme accent for its point index, so a
+    /// docx/xlsx pie matches Office instead of the renderer's built-in palette.
+    /// The one slice that DOES carry a `<c:dPt>` fill keeps it.
+    #[test]
+    fn parse_chart_part_pie_vary_colors_fills_accents() {
+        let ser = r#"<c:ser><c:idx val="0"/>
+            <c:dPt><c:idx val="0"/><c:spPr><a:solidFill><a:srgbClr val="112233"/></a:solidFill></c:spPr></c:dPt>
+            <c:cat><c:strCache>
+              <c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt><c:pt idx="2"><c:v>C</c:v></c:pt>
+            </c:strCache></c:cat>
+            <c:val><c:numCache>
+              <c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt><c:pt idx="2"><c:v>3</c:v></c:pt>
+            </c:numCache></c:val></c:ser>"#;
+        // No <c:varyColors> element → defaults to ON for the pie family.
+        let group = format!(r#"<c:pieChart>{ser}</c:pieChart>"#);
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &AccentResolver).expect("pie parses");
+        let colors = m.series[0]
+            .data_point_colors
+            .as_ref()
+            .expect("varyColors populates slice palette");
+        assert_eq!(colors[0].as_deref(), Some("112233")); // explicit dPt wins
+        assert_eq!(colors[1].as_deref(), Some("ED7D31")); // accent2
+        assert_eq!(colors[2].as_deref(), Some("A5A5A5")); // accent3
+
+        // varyColors="0" disables the per-slice accent fill: only the explicit
+        // dPt color remains, the rest fall back to None (renderer palette).
+        let group_off =
+            format!(r#"<c:pieChart><c:varyColors val="0"/>{ser}</c:pieChart>"#);
+        let xml_off = chart_space_with_group(&group_off);
+        let d2 = chart_space_of(&xml_off);
+        let m2 = parse_chart_part(d2.root_element(), &AccentResolver).expect("pie parses");
+        let colors2 = m2.series[0].data_point_colors.as_ref().unwrap();
+        assert_eq!(colors2[0].as_deref(), Some("112233"));
+        assert_eq!(colors2[1], None);
+        assert_eq!(colors2[2], None);
+    }
+
+    /// A NON-pie chart (bar) never gets varyColors slice accents even when the
+    /// resolver supplies them — only the pie renderer consumes
+    /// `data_point_colors`, so a bar's slice palette must stay empty (`None`).
+    #[test]
+    fn parse_chart_part_bar_no_vary_colors_slice_fill() {
+        let group = format!(
+            r#"<c:barChart><c:barDir val="col"/><c:grouping val="clustered"/>{CH13_SER}</c:barChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &AccentResolver).expect("bar parses");
+        assert!(m.series[0].data_point_colors.is_none());
     }
 }

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -2654,7 +2654,7 @@ pub fn parse_chart_part(
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "chart");
     let title_node_opt = chart_node.and_then(|c| child(c, "title"));
-    let title = title_node_opt.and_then(|title_node| {
+    let mut title = title_node_opt.and_then(|title_node| {
         let texts: Vec<String> = title_node
             .descendants()
             .filter(|n| n.is_element() && n.tag_name().name() == "t")
@@ -3193,6 +3193,41 @@ pub fn parse_chart_part(
             }
         })
         .collect();
+
+    // Auto-title (ECMA-376 §21.2.2.7 `<c:autoTitleDeleted>`). When the chart has
+    // no explicit title text but auto-titling is enabled, Word synthesizes a
+    // title and shows it in the chart frame. §21.2.2.7 says the element only
+    // governs WHETHER an auto title may be shown ("val=0/false ⇒ the chart title
+    // SHALL be shown" when otherwise absent; "val=1/true ⇒ it SHALL NOT be
+    // shown"); the spec leaves the auto title's TEXT implementation-defined.
+    // Word's observed rule — the ground truth here is sample-25.docx / .pdf,
+    // whose `<c:title>` carries a `<c:txPr>` (fonts, `cap="all"`) but NO `<c:tx>`
+    // text, `<c:autoTitleDeleted val="0"/>`, and exactly one series named
+    // "Production in 2017" — is:
+    //   * exactly ONE series  → the auto title is that single series' name
+    //   * two or more series   → NO auto title (a lone series name would be
+    //                            misleading, so Word shows none)
+    // We adopt only the single-series case; multi-series charts stay untitled,
+    // matching Word. The title's `<a:defRPr cap="all">` would uppercase the
+    // rendered glyphs ("PRODUCTION IN 2017"); chart-title `cap` is a display
+    // transform we do not yet apply, so the model carries the series name
+    // VERBATIM ("Production in 2017"). Making the title APPEAR is the goal; the
+    // caps transform is a separate, tracked rendering-layer limitation.
+    if title.is_none() {
+        let auto_title_deleted = chart_node
+            .and_then(|c| child(c, "autoTitleDeleted"))
+            .and_then(|n| attr(&n, "val"))
+            // CT_Boolean: default false (auto title may be shown) when the
+            // element or its `val` is absent.
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false);
+        if !auto_title_deleted && series.len() == 1 {
+            let ser_name = series[0].name.trim();
+            if !ser_name.is_empty() {
+                title = Some(ser_name.to_string());
+            }
+        }
+    }
 
     // Data labels are on when `<c:dLbls>` enables `<c:showVal>` OR
     // `<c:showPercent>` (ECMA-376 §21.2.2.189 / §21.2.2.187) — at chart level
@@ -5850,5 +5885,90 @@ mod tests {
         let d = chart_space_of(&xml);
         let m = parse_chart_part(d.root_element(), &AccentResolver).expect("bar parses");
         assert!(m.series[0].data_point_colors.is_none());
+    }
+
+    /// A named single series in `<c:tx>` — reused by the auto-title tests. `idx`
+    /// distinguishes the two series in the multi-series fixture.
+    fn named_ser(idx: u32, name: &str) -> String {
+        format!(
+            r#"<c:ser><c:idx val="{idx}"/>
+              <c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>{name}</c:v></c:pt></c:strCache></c:strRef></c:tx>
+              <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt></c:strCache></c:cat>
+              <c:val><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:val>
+            </c:ser>"#
+        )
+    }
+
+    /// A `<c:chart>` with an optional `<c:autoTitleDeleted val=…>`, NO explicit
+    /// `<c:title>` text, and the given series in a bar plot area. Models the
+    /// sample-25 shape (auto-title chart: title frame present but empty, so the
+    /// synthesized title comes from the series name).
+    fn chart_space_auto_title(auto_title_deleted: Option<&str>, sers: &str) -> String {
+        let atd = auto_title_deleted
+            .map(|v| format!(r#"<c:autoTitleDeleted val="{v}"/>"#))
+            .unwrap_or_default();
+        format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+              <c:chart>
+                {atd}
+                <c:plotArea>
+                  <c:barChart><c:barDir val="col"/><c:grouping val="clustered"/>{sers}</c:barChart>
+                  <c:catAx><c:axId val="1"/><c:axPos val="b"/></c:catAx>
+                  <c:valAx><c:axId val="2"/><c:axPos val="l"/></c:valAx>
+                </c:plotArea>
+              </c:chart>
+            </c:chartSpace>"#
+        )
+    }
+
+    /// ECMA-376 §21.2.2.7 auto-title: a chart with NO explicit title text,
+    /// `autoTitleDeleted` absent (⇒ auto title may show), and EXACTLY ONE named
+    /// series adopts that series' name as the chart title. Ground truth:
+    /// sample-25.docx — pie3D with a lone "Production in 2017" series and an
+    /// empty title frame — where Word shows "Production in 2017" as the title.
+    #[test]
+    fn parse_chart_part_auto_title_single_series() {
+        let xml = chart_space_auto_title(None, &named_ser(0, "Production in 2017"));
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("parses");
+        // The series name is promoted VERBATIM (the `cap="all"` uppercase is a
+        // rendering-layer transform we do not apply at parse time).
+        assert_eq!(m.title.as_deref(), Some("Production in 2017"));
+
+        // An explicit `autoTitleDeleted val="0"` behaves identically (0 ⇒ auto
+        // title may be shown).
+        let xml0 = chart_space_auto_title(Some("0"), &named_ser(0, "Production in 2017"));
+        let d0 = chart_space_of(&xml0);
+        let m0 = parse_chart_part(d0.root_element(), &FixtureResolver).expect("parses");
+        assert_eq!(m0.title.as_deref(), Some("Production in 2017"));
+    }
+
+    /// §21.2.2.7 `autoTitleDeleted val="1"` (or `"true"`) suppresses the auto
+    /// title even for a single named series — Word shows no title.
+    #[test]
+    fn parse_chart_part_auto_title_deleted_shows_no_title() {
+        for v in ["1", "true"] {
+            let xml = chart_space_auto_title(Some(v), &named_ser(0, "Production in 2017"));
+            let d = chart_space_of(&xml);
+            let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("parses");
+            assert_eq!(m.title, None, "autoTitleDeleted={v} should suppress title");
+        }
+    }
+
+    /// §21.2.2.7 auto-title applies ONLY to single-series charts. With TWO
+    /// series, Word shows no synthesized title (a lone series name would be
+    /// misleading), so `title` stays `None`.
+    #[test]
+    fn parse_chart_part_auto_title_multi_series_none() {
+        let sers = format!(
+            "{}{}",
+            named_ser(0, "Series One"),
+            named_ser(1, "Series Two")
+        );
+        let xml = chart_space_auto_title(None, &sers);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("parses");
+        assert_eq!(m.series.len(), 2);
+        assert_eq!(m.title, None);
     }
 }

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -288,6 +288,23 @@ pub struct ChartModel {
     /// tick-label rotation. `None`/0 = horizontal (byte-stable).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_label_rotation: Option<i32>,
+    // ── Stock chart (CH13, §21.2.2.198) ──────────────────────────────────────
+    /// `<c:stockChart><c:hiLowLines>` (§21.2.2.60) presence. When `Some(true)`
+    /// the stock renderer draws a vertical line spanning each category's
+    /// low↔high value. Only emitted for a stock chart (`chart_type == "stock"`);
+    /// `None` on every other chart type keeps the wire byte-stable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stock_hi_low_lines: Option<bool>,
+    /// `<c:hiLowLines><c:spPr><a:ln><a:solidFill>` resolved color (hex, no `#`).
+    /// `None` = the renderer's default gray. Only meaningful with
+    /// `stock_hi_low_lines == Some(true)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stock_hi_low_line_color: Option<String>,
+    /// `<c:stockChart><c:upDownBars>` (§21.2.2.227) presence. Parsed so a file
+    /// that carries open-close up/down bars is recognized; the stock renderer
+    /// does NOT yet draw them (tracked as a follow-up). `None` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stock_up_down_bars: Option<bool>,
 }
 
 /// Mirror of TS `ChartSeries`.
@@ -1913,6 +1930,9 @@ pub fn parse_chartex_part(
         cat_axis_tick_label_pos: None,
         val_axis_tick_label_pos: None,
         cat_axis_label_rotation: None,
+        stock_hi_low_lines: None,
+        stock_hi_low_line_color: None,
+        stock_up_down_bars: None,
     })
 }
 
@@ -2581,6 +2601,34 @@ pub fn parse_chart_part(
         "stock".to_string()
     } else {
         "unknown".to_string()
+    };
+
+    // §21.2.2.198 stockChart decoration: `<c:hiLowLines>` (§21.2.2.60) and
+    // `<c:upDownBars>` (§21.2.2.227). Both are direct children of `<c:stockChart>`.
+    // The hi-lo line spans each category's low↔high; its `<c:spPr><a:ln>` fill is
+    // resolved so the renderer strokes it in the file's color (else a gray
+    // default). up/down bars are recognized but not yet drawn (follow-up). Every
+    // field stays `None` for non-stock charts (byte-stable wire).
+    let (stock_hi_low_lines, stock_hi_low_line_color, stock_up_down_bars) = if chart_type == "stock"
+    {
+        let stock = find_chart("stockChart");
+        let hi_low = stock.and_then(|s| child(s, "hiLowLines"));
+        let hi_low_color = hi_low
+            .and_then(|hl| child(hl, "spPr"))
+            .and_then(|sp| child(sp, "ln"))
+            .and_then(|ln| {
+                ln.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+            })
+            .and_then(|fill| color_resolver.resolve_solid_fill(fill));
+        let up_down = stock.and_then(|s| child(s, "upDownBars")).is_some();
+        (
+            Some(hi_low.is_some()),
+            hi_low_color,
+            if up_down { Some(true) } else { None },
+        )
+    } else {
+        (None, None, None)
     };
 
     // Title text. The CHART title is the direct-child `<c:title>` of `<c:chart>`
@@ -3610,6 +3658,9 @@ pub fn parse_chart_part(
         cat_axis_tick_label_pos,
         val_axis_tick_label_pos,
         cat_axis_label_rotation,
+        stock_hi_low_lines,
+        stock_hi_low_line_color,
+        stock_up_down_bars,
     })
 }
 
@@ -3803,6 +3854,9 @@ mod tests {
             cat_axis_tick_label_pos: None,
             val_axis_tick_label_pos: None,
             cat_axis_label_rotation: None,
+            stock_hi_low_lines: None,
+            stock_hi_low_line_color: None,
+            stock_up_down_bars: None,
         };
         let v = serde_json::to_value(&m).unwrap();
         let obj = v.as_object().unwrap();
@@ -5613,7 +5667,9 @@ mod tests {
         let hi = r#"<c:ser><c:idx val="0"/><c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>High</c:v></c:pt></c:strCache></c:strRef></c:tx>
             <c:cat><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:cat>
             <c:val><c:numCache><c:pt idx="0"><c:v>55</c:v></c:pt></c:numCache></c:val></c:ser>"#;
-        let group = format!(r#"<c:stockChart>{hi}<c:hiLowLines/></c:stockChart>"#);
+        let group = format!(
+            r#"<c:stockChart>{hi}<c:hiLowLines><c:spPr><a:ln><a:solidFill><a:srgbClr val="808080"/></a:solidFill></a:ln></c:spPr></c:hiLowLines></c:stockChart>"#
+        );
         let xml = chart_space_with_group(&group);
         let d = chart_space_of(&xml);
         let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("stock parses");
@@ -5621,6 +5677,27 @@ mod tests {
         assert_eq!(m.series.len(), 1);
         assert_eq!(m.series[0].name, "High");
         assert_eq!(m.series[0].values, vec![Some(55.0)]);
+        // hiLowLines present + its resolved line color; no upDownBars in fixture.
+        assert_eq!(m.stock_hi_low_lines, Some(true));
+        assert_eq!(m.stock_hi_low_line_color.as_deref(), Some("808080"));
+        assert_eq!(m.stock_up_down_bars, None);
+    }
+
+    /// A stock chart WITHOUT `<c:hiLowLines>` but WITH `<c:upDownBars>`: the
+    /// hi-lo flag is `Some(false)` (element absent) and up/down bars are
+    /// recognized as `Some(true)` even though the renderer does not draw them.
+    #[test]
+    fn parse_chart_part_stock_up_down_bars_recognized() {
+        let ser = r#"<c:ser><c:idx val="0"/>
+            <c:cat><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:cat>
+            <c:val><c:numCache><c:pt idx="0"><c:v>5</c:v></c:pt></c:numCache></c:val></c:ser>"#;
+        let group = format!(r#"<c:stockChart>{ser}<c:upDownBars/></c:stockChart>"#);
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("stock parses");
+        assert_eq!(m.stock_hi_low_lines, Some(false));
+        assert_eq!(m.stock_hi_low_line_color, None);
+        assert_eq!(m.stock_up_down_bars, Some(true));
     }
 
     /// §21.2.2.126 ofPieChart → `pie` (main-pie-only fallback; the secondary
@@ -5651,8 +5728,7 @@ mod tests {
         }
         fn resolve_series_accent(&self, idx: usize) -> Option<String> {
             // Six-accent cycle, matching `theme.accent[(idx % 6) + 1]`.
-            const ACCENTS: [&str; 6] =
-                ["4472C4", "ED7D31", "A5A5A5", "FFC000", "5B9BD5", "70AD47"];
+            const ACCENTS: [&str; 6] = ["4472C4", "ED7D31", "A5A5A5", "FFC000", "5B9BD5", "70AD47"];
             Some(ACCENTS[idx % 6].to_string())
         }
     }
@@ -5686,8 +5762,7 @@ mod tests {
 
         // varyColors="0" disables the per-slice accent fill: only the explicit
         // dPt color remains, the rest fall back to None (renderer palette).
-        let group_off =
-            format!(r#"<c:pieChart><c:varyColors val="0"/>{ser}</c:pieChart>"#);
+        let group_off = format!(r#"<c:pieChart><c:varyColors val="0"/>{ser}</c:pieChart>"#);
         let xml_off = chart_space_with_group(&group_off);
         let d2 = chart_space_of(&xml_off);
         let m2 = parse_chart_part(d2.root_element(), &AccentResolver).expect("pie parses");

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -289,7 +289,7 @@ pub struct ChartModel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_label_rotation: Option<i32>,
     // ── Stock chart (CH13, §21.2.2.198) ──────────────────────────────────────
-    /// `<c:stockChart><c:hiLowLines>` (§21.2.2.60) presence. When `Some(true)`
+    /// `<c:stockChart><c:hiLowLines>` (§21.2.2.80) presence. When `Some(true)`
     /// the stock renderer draws a vertical line spanning each category's
     /// low↔high value. Only emitted for a stock chart (`chart_type == "stock"`);
     /// `None` on every other chart type keeps the wire byte-stable.
@@ -300,7 +300,7 @@ pub struct ChartModel {
     /// `stock_hi_low_lines == Some(true)`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stock_hi_low_line_color: Option<String>,
-    /// `<c:stockChart><c:upDownBars>` (§21.2.2.227) presence. Parsed so a file
+    /// `<c:stockChart><c:upDownBars>` (§21.2.2.218) presence. Parsed so a file
     /// that carries open-close up/down bars is recognized; the stock renderer
     /// does NOT yet draw them (tracked as a follow-up). `None` when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2549,11 +2549,13 @@ pub fn parse_chart_part(
     // equivalents: the child data structure (`<c:ser>`/`<c:cat>`/`<c:val>`/
     // grouping/`<c:dLbls>`) is identical to the 2D form, so a 3D chart is drawn
     // as the corresponding 2D chart. The 3D-only elements (`<c:view3D>`
-    // §21.2.2.228, `<c:surface>` §21.2.2.177, `<a:scene3d>`/`<a:sp3d>` shape 3D
-    // and `<c:gapDepth>` §21.2.2.55) are ignored. This 2D-flattening is the
-    // established strategy of web chart engines (Google Slides, Keynote) and was
-    // approved in the CH13 plan; a faithful isometric 3D projection is out of
-    // scope. `surfaceChart`/`surface3DChart` are NOT flattened (they have no 2D
+    // §21.2.2.228, the 3D chart-space surfaces `<c:floor>` §21.2.2.69 /
+    // `<c:sideWall>` §21.2.2.191 / `<c:backWall>` §21.2.2.11 (all `CT_Surface`),
+    // `<a:scene3d>`/`<a:sp3d>` shape 3D and `<c:gapDepth>` §21.2.2.74) are
+    // ignored. This 2D-flattening is the established strategy of web chart
+    // engines (Google Slides, Keynote) and was approved in the CH13 plan; a
+    // faithful isometric 3D projection is out of scope.
+    // `surfaceChart`/`surface3DChart` are NOT flattened (they have no 2D
     // analogue) and stay "unknown".
     let read_grouping = |group: &Node, default: &str| -> String {
         group
@@ -2563,7 +2565,7 @@ pub fn parse_chart_part(
             .unwrap_or_else(|| default.into())
     };
     let chart_type = if let Some(bc) = find_chart("barChart").or_else(|| find_chart("bar3DChart")) {
-        // §21.2.2.17 barDir + §21.2.2.79 grouping. bar3DChart shares both
+        // §21.2.2.17 barDir + §21.2.2.77 grouping (Bar Grouping). bar3DChart shares both
         // (its extra `<c:gapDepth>` is ignored). `clustered` is the 2D default;
         // `standard` (the bar3DChart default) folds to clustered as well since
         // `canonical_chart_type` treats any non-stacked grouping as clustered.
@@ -2583,8 +2585,8 @@ pub fn parse_chart_part(
         // §21.2.2.126 ofPieChart (pie-of-pie / bar-of-pie). DECISION: draw the
         // whole series as ONE plain pie (main-pie-only fallback) rather than
         // splitting the tail data points into the secondary pie/bar. The
-        // split is governed by `<c:splitType>` (§21.2.2.197: `auto` / `cust` /
-        // `percent` / `pos` / `val`), `<c:splitPos>` (§21.2.2.196) and
+        // split is governed by `<c:splitType>` (§21.2.2.196: `auto` / `cust` /
+        // `percent` / `pos` / `val`), `<c:splitPos>` (§21.2.2.195) and
         // `<c:custSplit>`, plus `<c:secondPieSize>` and `<c:serLines>` for the
         // connector geometry — all of which need a validated fixture to lay out
         // correctly. Without one, splitting risks assigning the wrong points to
@@ -2614,8 +2616,8 @@ pub fn parse_chart_part(
         "unknown".to_string()
     };
 
-    // §21.2.2.198 stockChart decoration: `<c:hiLowLines>` (§21.2.2.60) and
-    // `<c:upDownBars>` (§21.2.2.227). Both are direct children of `<c:stockChart>`.
+    // §21.2.2.198 stockChart decoration: `<c:hiLowLines>` (§21.2.2.80) and
+    // `<c:upDownBars>` (§21.2.2.218). Both are direct children of `<c:stockChart>`.
     // The hi-lo line spans each category's low↔high; its `<c:spPr><a:ln>` fill is
     // resolved so the renderer strokes it in the file's color (else a gray
     // default). up/down bars are recognized but not yet drawn (follow-up). Every
@@ -3026,7 +3028,7 @@ pub fn parse_chart_part(
                 })
                 .collect();
 
-            // §21.2.2.228 `<c:varyColors>`: a pie/doughnut varies each DATA POINT
+            // §21.2.2.227 `<c:varyColors>`: a pie/doughnut varies each DATA POINT
             // by the theme accent palette (`accent[(i % 6) + 1]`), rather than
             // giving the whole series one fill. It defaults to ON for the pie
             // family, so an absent element still cycles the accents. When on, fill
@@ -5779,7 +5781,7 @@ mod tests {
     }
 
     /// A resolver that DOES supply the default series accent palette (like the
-    /// real docx/xlsx resolvers), used to pin the §21.2.2.228 `<c:varyColors>`
+    /// real docx/xlsx resolvers), used to pin the §21.2.2.227 `<c:varyColors>`
     /// per-slice accent fill. `FixtureResolver` returns `None` for accents so it
     /// cannot exercise this path.
     struct AccentResolver;
@@ -5797,7 +5799,7 @@ mod tests {
         }
     }
 
-    /// §21.2.2.228 varyColors (default ON for pie): each slice without an
+    /// §21.2.2.227 varyColors (default ON for pie): each slice without an
     /// explicit `<c:dPt>` fill takes the theme accent for its point index, so a
     /// docx/xlsx pie matches Office instead of the renderer's built-in palette.
     /// The one slice that DOES carry a `<c:dPt>` fill keeps it.

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -2580,9 +2580,20 @@ pub fn parse_chart_part(
     } else if find_chart("pieChart").is_some() || find_chart("pie3DChart").is_some() {
         "pie".to_string()
     } else if find_chart("ofPieChart").is_some() {
-        // §21.2.2.126 ofPieChart (pie-of-pie / bar-of-pie). Rendered as a single
-        // plain pie over the whole series — the secondary plot (the exploded
-        // detail pie/bar) is NOT split out. See the ofPie handling note below.
+        // §21.2.2.126 ofPieChart (pie-of-pie / bar-of-pie). DECISION: draw the
+        // whole series as ONE plain pie (main-pie-only fallback) rather than
+        // splitting the tail data points into the secondary pie/bar. The
+        // split is governed by `<c:splitType>` (§21.2.2.197: `auto` / `cust` /
+        // `percent` / `pos` / `val`), `<c:splitPos>` (§21.2.2.196) and
+        // `<c:custSplit>`, plus `<c:secondPieSize>` and `<c:serLines>` for the
+        // connector geometry — all of which need a validated fixture to lay out
+        // correctly. Without one, splitting risks assigning the wrong points to
+        // the secondary plot; a single combined pie is a lossless, always-correct
+        // representation of the same data (every point is shown as a slice). The
+        // secondary-plot elements are ignored (not errors). A `bar` `ofPieType`
+        // is likewise flattened to a pie — the bar-of-pie's detail column is the
+        // same subset-of-points concern. `<c:varyColors>` still cycles the accent
+        // palette across the slices (handled by the shared pie color path below).
         "pie".to_string()
     } else if find_chart("doughnutChart").is_some() {
         "doughnut".to_string()
@@ -5700,8 +5711,9 @@ mod tests {
         assert_eq!(m.stock_up_down_bars, Some(true));
     }
 
-    /// §21.2.2.126 ofPieChart → `pie` (main-pie-only fallback; the secondary
-    /// plot is not split out — see the parse-time note).
+    /// §21.2.2.126 ofPieChart → `pie` (main-pie-only fallback). Uses the
+    /// two-point CH13_SER for the type-only assertion; the full-contract test
+    /// below adds the secondary-plot elements.
     #[test]
     fn parse_chart_part_ofpie_flattens_to_pie() {
         let group = format!(
@@ -5712,6 +5724,58 @@ mod tests {
         let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("ofPie parses");
         assert_eq!(m.chart_type, "pie");
         assert_eq!(m.series[0].values, vec![Some(3.0), Some(7.0)]);
+    }
+
+    /// Full ofPieChart contract: the secondary-plot elements (`<c:splitType>`,
+    /// `<c:splitPos>`, `<c:secondPieSize>`, `<c:serLines>`) are IGNORED — the
+    /// whole series still becomes a single `pie` whose every data point is a
+    /// slice, and `<c:varyColors>` cycles the accent palette across the slices.
+    /// A `bar` `ofPieType` flattens the same way. Pins the "draw one combined
+    /// pie" decision so a future edit can't silently start honoring the split.
+    #[test]
+    fn parse_chart_part_ofpie_full_contract_ignores_split() {
+        let ser = r#"<c:ser><c:idx val="0"/>
+            <c:cat><c:strCache>
+              <c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt>
+              <c:pt idx="2"><c:v>C</c:v></c:pt><c:pt idx="3"><c:v>D</c:v></c:pt>
+            </c:strCache></c:cat>
+            <c:val><c:numCache>
+              <c:pt idx="0"><c:v>40</c:v></c:pt><c:pt idx="1"><c:v>30</c:v></c:pt>
+              <c:pt idx="2"><c:v>20</c:v></c:pt><c:pt idx="3"><c:v>10</c:v></c:pt>
+            </c:numCache></c:val></c:ser>"#;
+        // bar-of-pie with a custom split of the last two points into the bar,
+        // plus connector series-lines — all of which we ignore.
+        let group = format!(
+            r#"<c:ofPieChart>
+                <c:ofPieType val="bar"/>
+                <c:varyColors val="1"/>
+                {ser}
+                <c:gapWidth val="100"/>
+                <c:splitType val="pos"/>
+                <c:splitPos val="2"/>
+                <c:secondPieSize val="75"/>
+                <c:serLines/>
+            </c:ofPieChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &AccentResolver).expect("ofPie parses");
+        assert_eq!(m.chart_type, "pie");
+        // Every one of the four points is present as a slice value (nothing was
+        // diverted to a phantom secondary plot).
+        assert_eq!(
+            m.series[0].values,
+            vec![Some(40.0), Some(30.0), Some(20.0), Some(10.0)]
+        );
+        // varyColors cycled the accent palette across all four slices.
+        let colors = m.series[0]
+            .data_point_colors
+            .as_ref()
+            .expect("varyColors slice palette");
+        assert_eq!(colors[0].as_deref(), Some("4472C4")); // accent1
+        assert_eq!(colors[1].as_deref(), Some("ED7D31")); // accent2
+        assert_eq!(colors[2].as_deref(), Some("A5A5A5")); // accent3
+        assert_eq!(colors[3].as_deref(), Some("FFC000")); // accent4
     }
 
     /// A resolver that DOES supply the default series accent palette (like the


### PR DESCRIPTION
## Summary
bar3D/line3D/area3D/pie3D, stockChart, and ofPieChart all rendered as the gray "Chart: unknown" placeholder. Now: 3D charts flatten to their 2D analogues (the established Google Slides/Keynote strategy), stock charts get a real hi-lo-close renderer, and ofPie renders as a single combined pie. Ground truth: user-authored Word samples `private/sample-25.pdf` (pie3D) and `private/sample-24.pdf` p.3 (stock).

## Changes (4 commits)
- **3D flattening** (`2098d36`): bar3DChart→clusteredBar/stackedBar[HPct] (per grouping+barDir), line3DChart→line/stackedLine[Pct], area3DChart→area/stackedArea[Pct], pie3DChart→pie (§21.2.2.15/.96/.4/.140). 3D-only elements (view3D, surface, gapDepth) ignored; surfaceChart stays "unknown" (no 2D analogue). Routed through the shared `canonical_chart_type`, which also fixes a **latent bug**: the old inline match folded percentStacked bars to plain `stackedBar`, so the renderer's 100%-normalization never fired for parsed charts. Plus a §21.2.2.228 **varyColors fix**: pie slices without an explicit `<c:dPt>` take theme accents (pptx unaffected — its resolver returns None; renderer palette remains the fallback).
- **stockChart** (`e13b0c1`): hi-lo vertical lines + close markers honoring the file's marker spec; new optional `ChartModel` fields (`stock_hi_low_lines`, `stock_hi_low_line_color`, `stock_up_down_bars` — parsed, up/down bars not yet drawn, noted). Legend/axes reuse existing parts.
- **ofPieChart** (`29521ff`): single-combined-pie fallback — every point drawn as a slice (lossless). Split geometry (splitType/splitPos/custSplit §21.2.2.196-197) needs a validated fixture to lay out correctly; pinned by a full-contract inline test.
- **VRT registration** (`f6932dd`): sample-24 (3 pages) + sample-25 registered in docx visual.spec (references private/gitignored; UPDATE_REFS used only for these 4 new references).

## PDF fidelity
- **sample-25 pie3D**: slice proportions (30/16/8/6/5/35%) exactly match the PDF's labels; colors match Word's accent1→accent6 after the varyColors fix.
- **sample-24 p.3 stock**: value axis 0-70, five date categories, hi-lo lines at matching heights (Low 11-35, High 55-58), close markers per `<c:marker symbol="dot" size=3>`, legend High/Low/Close.

## Gates & non-regression
- cargo fmt/clippy(-D warnings) clean; tests: ooxml-common 174 (+16) / docx 211 / pptx 130 / xlsx 110.
- vitest: core chart 216 (+4 stock) / docx 592 / pptx 264; tsc clean (core/docx/node/markdown).
- pptx VRT 75/75 pass (accent resolver returns None → byte-stable); docx/xlsx demo references 100%. Renderer-signature snapshots unchanged (new families only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)