### PR TITLE
feat(docx): emphasis marks (w:em) — boten dots/circles/sesame (WD5)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2344,6 +2344,7 @@ fn make_field_run(instr: &str, fmt: &RunFmt, fallback: &str, theme: &ThemeColors
         small_caps: fmt.small_caps.unwrap_or(false),
         double_strikethrough: fmt.dstrike.unwrap_or(false),
         highlight: fmt.highlight.clone(),
+        emphasis_mark: fmt.emphasis_mark.clone(),
     })
 }
 
@@ -6376,6 +6377,34 @@ mod tests {
         let body_override = r#"<w:r><w:rPr><w:em w:val="dot"/></w:rPr><w:t>上書き</w:t></w:r>"#;
         let runs = parse_para(body_override, &base, &styles);
         assert_eq!(first_text(&runs).emphasis_mark.as_deref(), Some("dot"));
+    }
+
+    // §17.3.2.12 w:em on a field run (§17.16.18 fldSimple → make_field_run).
+    // Regression guard: `FieldRun` used to lack `emphasis_mark` entirely (only
+    // `TextRun` carried it), so a PAGE/NUMPAGES field with `<w:em>` silently
+    // dropped its boten mark despite an ordinary emphasised run rendering it
+    // (asymmetric with `highlight`, which every field run already carried).
+    #[test]
+    fn field_run_carries_emphasis_mark() {
+        let base = RunFmt::default();
+        let styles = StyleMap::parse("");
+        let body = r#"<w:fldSimple w:instr="PAGE">
+            <w:r><w:rPr><w:em w:val="dot"/></w:rPr><w:t>1</w:t></w:r>
+        </w:fldSimple>"#;
+        let runs = parse_para(body, &base, &styles);
+        let f = runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Field(f) => Some(f),
+                _ => None,
+            })
+            .expect("expected a field run");
+        assert_eq!(f.field_type, "page");
+        assert_eq!(
+            f.emphasis_mark.as_deref(),
+            Some("dot"),
+            "PAGE field run must carry w:em like a plain text run"
+        );
     }
 
     // A styles part defining a `Hyperlink` character style (blue + underline),

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2401,6 +2401,7 @@ fn text_runs_mergeable(a: &TextRun, b: &TextRun) -> bool {
         && a.small_caps == b.small_caps
         && a.double_strikethrough == b.double_strikethrough
         && a.highlight == b.highlight
+        && a.emphasis_mark == b.emphasis_mark
         && a.rtl == b.rtl
         && a.cs == b.cs
         && a.font_family_cs == b.font_family_cs
@@ -2507,6 +2508,9 @@ fn parse_run_inner(
     let small_caps = fmt.small_caps.unwrap_or(false);
     let double_strikethrough = fmt.dstrike.unwrap_or(false);
     let highlight = fmt.highlight.clone();
+    // ECMA-376 §17.3.2.12 w:em — emphasis mark (boten). Travels to the model so
+    // the renderer can stamp the per-glyph mark; does not affect layout metrics.
+    let emphasis_mark = fmt.emphasis_mark.clone();
     // Run-level color=auto (§17.3.2.6) and border/box (§17.3.2.4). color_auto
     // travels so the renderer can pick black/white from the effective
     // background (implementation-defined contrast; no normative algorithm); the
@@ -2575,6 +2579,7 @@ fn parse_run_inner(
                         small_caps,
                         double_strikethrough,
                         highlight: highlight.clone(),
+                        emphasis_mark: emphasis_mark.clone(),
                         ruby: None,
                         revision: revision.cloned(),
                         rtl,
@@ -2642,6 +2647,7 @@ fn parse_run_inner(
                         small_caps,
                         double_strikethrough,
                         highlight: highlight.clone(),
+                        emphasis_mark: emphasis_mark.clone(),
                         ruby: None,
                         revision: revision.cloned(),
                         rtl,
@@ -2679,6 +2685,7 @@ fn parse_run_inner(
                     small_caps,
                     double_strikethrough,
                     highlight: highlight.clone(),
+                    emphasis_mark: emphasis_mark.clone(),
                     ruby: None,
                     revision: revision.cloned(),
                     rtl,
@@ -2761,6 +2768,7 @@ fn parse_run_inner(
                     small_caps,
                     double_strikethrough,
                     highlight: highlight.clone(),
+                    emphasis_mark: emphasis_mark.clone(),
                     ruby: None,
                     revision: revision.cloned(),
                     rtl,
@@ -2941,6 +2949,7 @@ fn parse_run_inner(
                     small_caps,
                     double_strikethrough,
                     highlight: highlight.clone(),
+                    emphasis_mark: emphasis_mark.clone(),
                     ruby: None,
                     revision: revision.cloned(),
                     rtl,
@@ -6279,6 +6288,7 @@ mod tests {
         let mut base = RunFmt::default();
         let direct = RunFmt {
             highlight: Some("yellow".to_string()),
+            emphasis_mark: Some("dot".to_string()),
             border: Some(EdgeBorder {
                 width: 0.5,
                 color: Some("000000".to_string()),
@@ -6293,6 +6303,9 @@ mod tests {
         };
         apply_direct_run(&mut base, &direct);
         assert_eq!(base.highlight.as_deref(), Some("yellow"));
+        // §17.3.2.12 w:em — a directly-applied emphasis mark must survive the
+        // merge (same value-property shape as highlight).
+        assert_eq!(base.emphasis_mark.as_deref(), Some("dot"));
         assert!(base.border.is_some());
         assert_eq!(base.all_caps, Some(true));
         assert_eq!(base.small_caps, Some(true));
@@ -6317,6 +6330,52 @@ mod tests {
         apply_direct_run(&mut base, &direct);
         assert_eq!(base.color, None);
         assert!(base.color_auto);
+    }
+
+    // ECMA-376 §17.3.2.12 w:em / §17.18.24 ST_Em — each enumerated value parses
+    // onto the model as its literal token; `val="none"` collapses to `None`.
+    #[test]
+    fn emphasis_mark_each_value_parses_to_model() {
+        let base = RunFmt::default();
+        let styles = StyleMap::parse("");
+        for val in ["dot", "comma", "circle", "underDot"] {
+            let body = format!(r#"<w:r><w:rPr><w:em w:val="{val}"/></w:rPr><w:t>圏点</w:t></w:r>"#);
+            let runs = parse_para(&body, &base, &styles);
+            let t = first_text(&runs);
+            assert_eq!(
+                t.emphasis_mark.as_deref(),
+                Some(val),
+                "w:em val={val} must round-trip to the model"
+            );
+        }
+        // val="none" means "no emphasis mark" (§17.18.24) → filters to None.
+        let none_body = r#"<w:r><w:rPr><w:em w:val="none"/></w:rPr><w:t>plain</w:t></w:r>"#;
+        let runs = parse_para(none_body, &base, &styles);
+        assert_eq!(first_text(&runs).emphasis_mark, None);
+        // No <w:em> at all → None.
+        let bare = r#"<w:r><w:t>plain</w:t></w:r>"#;
+        let runs = parse_para(bare, &base, &styles);
+        assert_eq!(first_text(&runs).emphasis_mark, None);
+    }
+
+    // §17.3.2.12 — an emphasis mark inherited from the style chain (modeled here
+    // as the paragraph base RunFmt) reaches the run when the run's direct rPr is
+    // silent, exactly like other inherited value properties (highlight/color).
+    #[test]
+    fn emphasis_mark_inherits_from_style_chain() {
+        let base = RunFmt {
+            emphasis_mark: Some("circle".to_string()),
+            ..Default::default()
+        };
+        let styles = StyleMap::parse("");
+        let body = r#"<w:r><w:t>継承</w:t></w:r>"#;
+        let runs = parse_para(body, &base, &styles);
+        assert_eq!(first_text(&runs).emphasis_mark.as_deref(), Some("circle"));
+
+        // A concrete direct value overrides the inherited one (set-wins).
+        let body_override = r#"<w:r><w:rPr><w:em w:val="dot"/></w:rPr><w:t>上書き</w:t></w:r>"#;
+        let runs = parse_para(body_override, &base, &styles);
+        assert_eq!(first_text(&runs).emphasis_mark.as_deref(), Some("dot"));
     }
 
     // A styles part defining a `Hyperlink` character style (blue + underline),

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -55,6 +55,16 @@ pub struct RunFmt {
     pub web_hidden: Option<bool>,
     /// Highlight color name: "yellow" | "cyan" | "green" | ... (w:highlight)
     pub highlight: Option<String>,
+    /// ECMA-376 §17.3.2.12 `<w:em w:val>` — emphasis (boten) mark applied to
+    /// each non-space character of the run (§17.18.24 ST_Em). One of "dot" |
+    /// "comma" | "circle" | "underDot"; `val="none"` filters to `None` (no mark).
+    /// Resolved through the same style chain as `highlight`: a level that sets a
+    /// concrete value wins. (Like `highlight`, `none` collapses to `None` at
+    /// parse time, so it reads as "unset" rather than an inherit-clearing
+    /// override — emphasis marks are effectively never inherited-then-cleared in
+    /// practice, and this keeps the value-property resolution identical to
+    /// `highlight`.)
+    pub emphasis_mark: Option<String>,
     /// ECMA-376 §17.3.2.4 `<w:bdr>` — a run-level border drawn as a box around
     /// the run's text. Reuses `EdgeBorder` (width pt, color, style, space pt).
     pub border: Option<EdgeBorder>,
@@ -781,6 +791,10 @@ pub(crate) fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.highlight.is_some() {
         dst.highlight = src.highlight.clone();
     }
+    // §17.3.2.12 w:em — value property, set-wins (same shape as highlight).
+    if src.emphasis_mark.is_some() {
+        dst.emphasis_mark = src.emphasis_mark.clone();
+    }
     if src.border.is_some() {
         dst.border = src.border.clone();
     }
@@ -1249,6 +1263,14 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // Highlight
     if let Some(hl) = child_w(rpr, "highlight") {
         fmt.highlight = attr_w(hl, "val").filter(|v| v != "none");
+    }
+
+    // Emphasis mark (ECMA-376 §17.3.2.12 w:em / §17.18.24 ST_Em). A single
+    // ST_Em value ("dot" | "comma" | "circle" | "underDot") drawn over (or,
+    // for underDot, under) each non-space character. `val="none"` = no mark, so
+    // it filters to `None` exactly like `highlight`.
+    if let Some(em) = child_w(rpr, "em") {
+        fmt.emphasis_mark = attr_w(em, "val").filter(|v| v != "none");
     }
 
     // Run border (ECMA-376 §17.3.2.4 w:bdr) — drawn as a box around the run.

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -947,6 +947,12 @@ pub struct FieldRun {
     pub double_strikethrough: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub highlight: Option<String>,
+    /// ECMA-376 §17.3.2.12 `<w:em w:val>` — emphasis (boten / 圏点) mark, mirrors
+    /// `TextRun::emphasis_mark` (§17.18.24 ST_Em). `None` when unset or
+    /// `val="none"`. A field's displayed text (its resolved PAGE/NUMPAGES value
+    /// or fallback text) draws through the same per-glyph stamp as a plain run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emphasis_mark: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1010,6 +1010,14 @@ pub struct TextRun {
     /// OOXML highlight color name: "yellow" | "cyan" | "green" | ... (w:highlight)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub highlight: Option<String>,
+    /// ECMA-376 §17.3.2.12 `<w:em w:val>` — emphasis (boten / 圏点) mark drawn on
+    /// every non-space character of the run (§17.18.24 ST_Em). One of "dot"
+    /// (filled dot above), "comma" (sesame/comma above), "circle" (hollow circle
+    /// above), or "underDot" (filled dot below, in horizontal writing). `None`
+    /// when unset or `val="none"`. The renderer paints the mark per glyph after
+    /// the text; it does not alter the glyph advance.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emphasis_mark: Option<String>,
     /// ECMA-376 §17.3.3.25 ruby annotation (furigana). Set on the rubyBase
     /// text run; renders as a small inline annotation above the base glyphs.
     /// `text` is the annotation string (e.g. "すわ" above "坐"). `font_size_pt`

--- a/packages/docx/src/emphasis-mark-render.test.ts
+++ b/packages/docx/src/emphasis-mark-render.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// ECMA-376 §17.3.2.12 w:em / §17.18.24 ST_Em — characterization of the docx
+// emphasis-mark (圏点) draw path. We record the ctx arc / fill / stroke ops so we
+// can assert the per-glyph mark count, above/below placement, and shape (filled
+// dot / hollow circle / comma) without a real canvas.
+
+interface ArcOp { cx: number; cy: number; r: number; }
+interface Recording {
+  arcs: ArcOp[];
+  fills: number; // fill() calls
+  strokes: number; // stroke() calls
+  // arc → the next terminal op (fill or stroke) tells us the mark shape.
+  arcTerminals: ('fill' | 'stroke')[];
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; rec: Recording } {
+  let font = '10px serif';
+  const rec: Recording = { arcs: [], fills: 0, strokes: 0, arcTerminals: [] };
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  // pendingArc: set by arc(), consumed by the next fill()/stroke() so we can
+  // attribute each ring/disc to how it was closed out.
+  let pendingArc = false;
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        // Each code point advances a fixed half-em, so glyph i centre is
+        // predictable: penX + (i + 0.5) * p * 0.5.
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, closePath() {},
+    beginPath() {},
+    moveTo() {}, lineTo() {},
+    arc(cx: number, cy: number, r: number) {
+      rec.arcs.push({ cx, cy, r });
+      pendingArc = true;
+    },
+    fill() {
+      rec.fills++;
+      if (pendingArc) { rec.arcTerminals.push('fill'); pendingArc = false; }
+    },
+    stroke() {
+      rec.strokes++;
+      if (pendingArc) { rec.arcTerminals.push('stroke'); pendingArc = false; }
+    },
+    fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, rec };
+}
+
+function para(run: Partial<DocParagraph['runs'][number]>, text = 'abc'): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 40, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+      ...run,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 40, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[]): DocxDocumentModel {
+  const section = {
+    pageWidth: 400, pageHeight: 600,
+    marginTop: 5, marginRight: 5, marginBottom: 5, marginLeft: 5,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(run: Partial<DocParagraph['runs'][number]>, text = 'abc') {
+  const { canvas, rec } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc([para(run, text) as unknown as BodyElement]), canvas, 0, { dpr: 1, width: 400 });
+  return rec;
+}
+
+describe('docx emphasis mark (§17.3.2.12 w:em) draw path', () => {
+  it('draws one mark per non-space character (§17.18.24)', async () => {
+    const rec = await render({ emphasisMark: 'dot' }, 'abc');
+    // Three glyphs → three dot arcs, each filled.
+    expect(rec.arcs).toHaveLength(3);
+    expect(rec.arcTerminals).toEqual(['fill', 'fill', 'fill']);
+  });
+
+  it('skips space characters (no mark on the space)', async () => {
+    const rec = await render({ emphasisMark: 'dot' }, 'a b');
+    // 'a' and 'b' get marks; the space does not.
+    expect(rec.arcs).toHaveLength(2);
+  });
+
+  it('draws no marks when the run has no emphasis mark', async () => {
+    const rec = await render({}, 'abc');
+    expect(rec.arcs).toHaveLength(0);
+  });
+
+  it('dot marks sit ABOVE the glyph box (negative-ish y, above baseline)', async () => {
+    // The paragraph baseline for a 40pt run sits well below the box top. All dot
+    // centres must be above the box top (§17.18.24 horizontal writing = above).
+    const rec = await render({ emphasisMark: 'dot' }, 'abc');
+    const ys = rec.arcs.map((a) => a.cy);
+    // Every above-mark shares the same y (same line, same font).
+    expect(new Set(ys).size).toBe(1);
+  });
+
+  it('underDot places the mark BELOW the box, at a larger y than dot (above)', async () => {
+    const above = await render({ emphasisMark: 'dot' }, 'abc');
+    const below = await render({ emphasisMark: 'underDot' }, 'abc');
+    // Canvas y grows downward: the underDot centre is below (greater y) the dot.
+    expect(below.arcs[0].cy).toBeGreaterThan(above.arcs[0].cy);
+  });
+
+  it('circle draws hollow rings (stroked, not filled)', async () => {
+    const rec = await render({ emphasisMark: 'circle' }, 'abc');
+    expect(rec.arcs).toHaveLength(3);
+    // Each ring is closed with stroke(), not fill().
+    expect(rec.arcTerminals).toEqual(['stroke', 'stroke', 'stroke']);
+  });
+
+  it('mark centre x tracks the glyph advance midpoint', async () => {
+    // 40pt @ dpr 1: measureText gives half-em (10px) per glyph. The first glyph's
+    // centre is contentX (left margin 5pt*scale) + 5px. We only assert the marks
+    // are evenly spaced by the glyph advance (10px), which pins the per-glyph
+    // centring without depending on the exact left origin.
+    const rec = await render({ emphasisMark: 'dot' }, 'abc');
+    const xs = rec.arcs.map((a) => a.cx);
+    expect(xs[1] - xs[0]).toBeCloseTo(xs[2] - xs[1], 3);
+    expect(xs[1] - xs[0]).toBeGreaterThan(0);
+  });
+
+  it('mark radius scales with the run font size (~0.07 em)', async () => {
+    const big = await render({ emphasisMark: 'dot', fontSize: 40 }, 'a');
+    const small = await render({ emphasisMark: 'dot', fontSize: 20 }, 'a');
+    expect(big.arcs[0].r).toBeGreaterThan(small.arcs[0].r);
+    // ~40*0.07 vs ~20*0.07 at dpr 1 → ratio ≈ 2.
+    expect(big.arcs[0].r / small.arcs[0].r).toBeCloseTo(2, 1);
+  });
+});

--- a/packages/docx/src/emphasis-mark.test.ts
+++ b/packages/docx/src/emphasis-mark.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { emphasisMarkCenters, emphasisMarkGeometry } from './emphasis-mark.js';
+
+// ECMA-376 §17.3.2.12 w:em / §17.18.24 ST_Em — pure geometry of the emphasis
+// (圏点) marks. These functions decide WHERE each per-glyph mark goes and WHAT
+// shape it is, independent of the canvas; the renderer stamps them.
+
+// A measure that gives every code point a fixed 10px advance, so a mark's centre
+// under glyph i must land at penX + (i + 0.5) * 10 (+ pitch terms).
+const uniform10 = (s: string): number => [...s].length * 10;
+
+describe('emphasisMarkCenters (§17.18.24 — one mark per non-space character)', () => {
+  it('centres a mark under each glyph at the midpoint of its advance', () => {
+    const c = emphasisMarkCenters('abc', uniform10, 0, 0);
+    expect(c.map((p) => p.centerX)).toEqual([5, 15, 25]);
+  });
+
+  it('offsets every centre by the pen x', () => {
+    const c = emphasisMarkCenters('ab', uniform10, 100, 0);
+    expect(c.map((p) => p.centerX)).toEqual([105, 115]);
+  });
+
+  it('skips space characters but still advances the cumulative measure', () => {
+    // "a b" — the middle space gets NO mark, but 'b' still lands at its 3rd cell.
+    const c = emphasisMarkCenters('a b', uniform10, 0, 0);
+    expect(c.map((p) => p.centerX)).toEqual([5, 25]);
+  });
+
+  it('skips the ideographic space U+3000 too (whitespace class)', () => {
+    const c = emphasisMarkCenters('あ　い', uniform10, 0, 0);
+    // Two marks (あ, い); the wide space at index 1 is skipped.
+    expect(c).toHaveLength(2);
+    expect(c.map((p) => p.centerX)).toEqual([5, 25]);
+  });
+
+  it('adds the uniform per-glyph pitch between glyphs (docGrid / justify)', () => {
+    // pitch = 4px: glyph i occupies [i*10 + i*4, (i+1)*10 + (i+1)*4], centre =
+    // ((i*10 + i*4) + ((i+1)*10 + (i+1)*4)) / 2 = i*14 + 7.
+    const c = emphasisMarkCenters('abc', uniform10, 0, 4);
+    expect(c.map((p) => p.centerX)).toEqual([7, 21, 35]);
+  });
+
+  it('keeps surrogate-pair code points as a single glyph', () => {
+    // A single astral code point (U+20B9F 𠮟) is ONE mark, not two UTF-16 units.
+    const c = emphasisMarkCenters('\u{20B9F}', uniform10, 0, 0);
+    expect(c).toHaveLength(1);
+    expect(c[0].centerX).toBe(5);
+  });
+});
+
+describe('emphasisMarkGeometry (§17.18.24 ST_Em value → shape/position)', () => {
+  it('dot → filled disc above the glyphs', () => {
+    const g = emphasisMarkGeometry('dot', 40);
+    expect(g.shape).toBe('dot');
+    expect(g.above).toBe(true);
+    expect(g.radius).toBeCloseTo(40 * 0.07, 6);
+  });
+
+  it('circle → hollow circle above the glyphs', () => {
+    const g = emphasisMarkGeometry('circle', 40);
+    expect(g.shape).toBe('circle');
+    expect(g.above).toBe(true);
+  });
+
+  it('comma → sesame/comma shape above the glyphs', () => {
+    const g = emphasisMarkGeometry('comma', 40);
+    expect(g.shape).toBe('comma');
+    expect(g.above).toBe(true);
+  });
+
+  it('underDot → filled disc BELOW the glyphs (§17.18.24)', () => {
+    const g = emphasisMarkGeometry('underDot', 40);
+    expect(g.shape).toBe('dot');
+    expect(g.above).toBe(false);
+  });
+
+  it('mark radius scales with the effective font size', () => {
+    expect(emphasisMarkGeometry('dot', 20).radius).toBeCloseTo(
+      emphasisMarkGeometry('dot', 40).radius / 2,
+      6,
+    );
+  });
+});

--- a/packages/docx/src/emphasis-mark.ts
+++ b/packages/docx/src/emphasis-mark.ts
@@ -1,0 +1,112 @@
+// ECMA-376 §17.3.2.12 `<w:em>` / §17.18.24 ST_Em — emphasis marks (圏点 / boten).
+//
+// A run may carry a single emphasis-mark style that is stamped on EVERY
+// non-space character of the run (§17.18.24: "applied to each non-space
+// character in a run"). In horizontal writing the mark sits centred above the
+// character (below for `underDot`). The glyph used is implementation-dependent
+// (§17.18.24); we follow the JIS X 4051 圏点 convention and Word's rendering:
+//
+//   dot      → a small filled disc centred above the glyph
+//   circle   → a small hollow (stroked) circle above the glyph
+//   comma    → a filled "sesame" teardrop (bōten «﹅»-like) above the glyph
+//   underDot → a small filled disc centred BELOW the glyph
+//
+// The marks are drawn per glyph AFTER the run's text and never change the glyph
+// advance (they are an overlay, exactly like the ruby / highlight decorations),
+// so layout metrics are untouched. The one metric consequence — a tall mark can
+// reach into the previous line's descent region when the line box is tight — is
+// deliberately NOT compensated here: Word widens line spacing for emphasised
+// text, but the exact reservation is not specified, so we render the mark in the
+// existing line box and accept possible overlap on very tight leading. See the
+// module test + the renderer call site for the rationale.
+
+import type { EmphasisMark } from './types';
+
+/** One emphasis mark to paint, positioned by its horizontal CENTRE (device px,
+ *  absolute — i.e. already offset by the segment pen `x`). */
+export interface EmphasisMarkPlacement {
+  /** Absolute device-x of the mark centre. */
+  centerX: number;
+}
+
+/**
+ * Compute the centre-x of the emphasis mark for every NON-SPACE code point of
+ * `text`, in the same left-to-right pen order the glyphs are drawn.
+ *
+ * The centre of glyph *i* is the midpoint of its drawn advance:
+ *   left_i  = penX + measure(prefix_i)          + i·pitch
+ *   right_i = penX + measure(prefix_{i+1})       + (i+1)·pitch
+ *   centre  = (left_i + right_i) / 2
+ *
+ * `measure(str)` must return the contextual advance width of `str` in the
+ * current font (the caller passes `ctx.measureText(str).width`), so the mark
+ * tracks the browser's contextual CJK metrics (約物半角 half-width collapse etc.)
+ * exactly as the glyph draw does. `pitch` is the uniform per-glyph-boundary
+ * spacing the run was drawn with (docGrid cell delta or justification distribute
+ * pitch, 0 for the common path); it is added between glyphs so the mark stays
+ * centred under justification/grid stretch. Spaces (and other whitespace) get no
+ * mark (§17.18.24) but still advance the cumulative measure.
+ */
+export function emphasisMarkCenters(
+  text: string,
+  measure: (s: string) => number,
+  penX: number,
+  pitch: number,
+): EmphasisMarkPlacement[] {
+  const cps = [...text]; // code points — surrogate pairs stay intact
+  const out: EmphasisMarkPlacement[] = [];
+  let prefix = '';
+  for (let i = 0; i < cps.length; i++) {
+    const cp = cps[i];
+    const left = penX + measure(prefix) + i * pitch;
+    const nextPrefix = prefix + cp;
+    const right = penX + measure(nextPrefix) + (i + 1) * pitch;
+    prefix = nextPrefix;
+    // §17.18.24: no mark on space characters. Test the whole code point so a
+    // combining space or an ideographic space (U+3000) is also skipped.
+    if (!/\s/u.test(cp)) {
+      out.push({ centerX: (left + right) / 2 });
+    }
+  }
+  return out;
+}
+
+/** Geometry of an emphasis mark, in device px, relative to the glyph box.
+ *  `radius` is the mark's radius; `above` = draw centred above the glyph top
+ *  (false ⇒ below the glyph bottom, for `underDot`). */
+export interface EmphasisMarkGeometry {
+  /** 'dot' | 'comma' | 'circle' — the shape to stamp. */
+  shape: 'dot' | 'comma' | 'circle';
+  /** Mark radius (device px). */
+  radius: number;
+  /** True ⇒ mark sits above the glyphs; false ⇒ below (underDot). */
+  above: boolean;
+}
+
+/**
+ * Resolve an {@link EmphasisMark} value to its drawing geometry for a run of the
+ * given effective font size (device px).
+ *
+ * The mark radius is ~7% of the em (⌀ ≈ 0.14 em). JIS X 4051 圏点 are drawn at
+ * roughly a sixth of the character body; a disc of ⌀ 0.14 em reads as a clear
+ * boten without crowding the line above. `underDot` is the only mark placed
+ * below the glyphs (§17.18.24). `comma` reuses the disc radius but is drawn as a
+ * teardrop by the renderer.
+ */
+export function emphasisMarkGeometry(
+  mark: EmphasisMark,
+  effSizePx: number,
+): EmphasisMarkGeometry {
+  const radius = effSizePx * 0.07;
+  switch (mark) {
+    case 'circle':
+      return { shape: 'circle', radius, above: true };
+    case 'comma':
+      return { shape: 'comma', radius, above: true };
+    case 'underDot':
+      return { shape: 'dot', radius, above: false };
+    case 'dot':
+    default:
+      return { shape: 'dot', radius, above: true };
+  }
+}

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1296,8 +1296,9 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         joinPrev: gluePending ? true : undefined,
         doubleStrikethrough: base.doubleStrikethrough ?? false,
         highlight: base.highlight ?? null,
-        // §17.3.2.12 w:em — carried only on DocxTextRun (FieldRun has no em).
-        emphasisMark: r.emphasisMark,
+        // §17.3.2.12 w:em — carried on both DocxTextRun and FieldRun (a field's
+        // resolved/fallback text stamps the mark the same as a plain run).
+        emphasisMark: base.emphasisMark,
         background: base.background ?? null,
         colorAuto: r.colorAuto ?? false,
         border: r.border ?? null,

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -17,7 +17,7 @@
 
 import type {
   DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeTextRun, FieldRun,
-  LineSpacing, TabStop, DocxRunBorder, DocSettings,
+  LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
 import type { MathNode, KinsokuRules, ChartModel } from '@silurus/ooxml-core';
 import type { RenderState, DecodedImage } from './renderer.js';
@@ -69,6 +69,10 @@ export interface LayoutTextSeg {
   joinPrev?: boolean;
   doubleStrikethrough?: boolean;
   highlight?: string | null;
+  /** ECMA-376 §17.3.2.12 `<w:em w:val>` — emphasis (boten / 圏点) mark stamped on
+   *  every non-space character of this segment (§17.18.24 ST_Em). The renderer
+   *  paints it per glyph after the text; it does not affect layout metrics. */
+  emphasisMark?: EmphasisMark;
   /** ECMA-376 §17.3.2.32 `<w:shd w:fill>` — run shading fill (hex 6). Painted as
    *  a solid rect behind the glyphs; also the effective background that an
    *  automatic text color resolves against. */
@@ -1292,6 +1296,8 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         joinPrev: gluePending ? true : undefined,
         doubleStrikethrough: base.doubleStrikethrough ?? false,
         highlight: base.highlight ?? null,
+        // §17.3.2.12 w:em — carried only on DocxTextRun (FieldRun has no em).
+        emphasisMark: r.emphasisMark,
         background: base.background ?? null,
         colorAuto: r.colorAuto ?? false,
         border: r.border ?? null,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -135,6 +135,10 @@ import type {
   LayoutTextSeg,
   WrapLayoutCtx,
 } from './line-layout.js';
+import {
+  emphasisMarkCenters,
+  emphasisMarkGeometry,
+} from './emphasis-mark.js';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -5454,6 +5458,73 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // revColor for ruby).
           ctx.fillStyle = glyphColor;
           ctx.fillText(s.ruby.text, rubyX, rubyBaseline);
+          ctx.restore();
+        }
+
+        // ECMA-376 §17.3.2.12 emphasis mark (圏点): a small glyph stamped on every
+        // NON-SPACE character (§17.18.24), centred above each glyph (below for
+        // `underDot`). Drawn AFTER the text so it overlays; the advance is
+        // unchanged (no layout impact). The per-glyph centre uses the SAME
+        // contextual `measureText` cumulative advance the glyph draw is anchored
+        // to, plus the run's uniform per-glyph pitch so a docGrid cell delta /
+        // fully-distributed justify pitch keeps the mark centred. (A partial
+        // justify split — non-uniform pitch — falls back to pitch 0, which
+        // stays within a fraction of a glyph of centre and is not worth the
+        // complexity of re-deriving the sliced positions.)
+        if (s.emphasisMark) {
+          const geom = emphasisMarkGeometry(s.emphasisMark, effSizePx);
+          // Uniform per-glyph pitch matching the case the glyphs were drawn with.
+          const fullyDistributed =
+            !!stretch &&
+            stretch.splitBefore.length > 0 &&
+            stretch.splitBefore.length === [...s.text].length - 1;
+          const markPitch =
+            segGridDelta !== 0
+              ? drawGridDeltaPx
+              : fullyDistributed
+                ? distPerGap
+                : 0;
+          const measureMark = (str: string): number => ctx.measureText(str).width;
+          const centers = emphasisMarkCenters(s.text, measureMark, x, markPitch);
+          // Above marks sit a small gap above the glyph box top (the same
+          // ~0.85em ascent the box decorations use); below marks (underDot) sit
+          // just under the box bottom (baseline + ~0.25em). The gap keeps the
+          // mark clear of the glyph without stealing line height.
+          const markGap = effSizePx * 0.06;
+          const markCy = geom.above
+            ? boxTop - markGap - geom.radius
+            : boxTop + boxHeight + markGap + geom.radius;
+          ctx.save();
+          ctx.fillStyle = glyphColor;
+          ctx.strokeStyle = glyphColor;
+          for (const { centerX } of centers) {
+            if (geom.shape === 'circle') {
+              // Hollow circle (§17.18.24 "circle"): stroked ring.
+              ctx.lineWidth = Math.max(0.5, geom.radius * 0.35);
+              ctx.beginPath();
+              ctx.arc(centerX, markCy, geom.radius, 0, Math.PI * 2);
+              ctx.stroke();
+            } else if (geom.shape === 'comma') {
+              // Sesame / comma mark (§17.18.24 "comma"): a filled teardrop —
+              // a disc with a short tail down-right, approximating the boten
+              // sesame «﹅». Kept simple (disc + triangle) so it reads at body
+              // sizes without a font dependency.
+              ctx.beginPath();
+              ctx.arc(centerX, markCy, geom.radius, 0, Math.PI * 2);
+              ctx.fill();
+              ctx.beginPath();
+              ctx.moveTo(centerX - geom.radius * 0.5, markCy + geom.radius * 0.2);
+              ctx.lineTo(centerX + geom.radius * 0.5, markCy + geom.radius * 0.2);
+              ctx.lineTo(centerX - geom.radius * 0.1, markCy + geom.radius * 1.4);
+              ctx.closePath();
+              ctx.fill();
+            } else {
+              // Filled dot (§17.18.24 "dot" / "underDot").
+              ctx.beginPath();
+              ctx.arc(centerX, markCy, geom.radius, 0, Math.PI * 2);
+              ctx.fill();
+            }
+          }
           ctx.restore();
         }
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -828,6 +828,10 @@ export interface FieldRun {
   smallCaps?: boolean;
   doubleStrikethrough?: boolean;
   highlight?: string | null;
+  /** ECMA-376 §17.3.2.12 `<w:em w:val>` — emphasis (boten / 圏点) mark, mirrors
+   *  {@link DocxTextRun.emphasisMark} (§17.18.24 ST_Em). Absent (or the
+   *  authored `val="none"`) ⇒ no mark. */
+  emphasisMark?: EmphasisMark;
 }
 
 export interface DocxTextRun {

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -875,6 +875,13 @@ export interface DocxTextRun {
   smallCaps?: boolean;
   doubleStrikethrough?: boolean;
   highlight?: string | null;
+  /** ECMA-376 §17.3.2.12 `<w:em w:val>` — emphasis (boten / 圏点) mark drawn on
+   *  every non-space character of the run (§17.18.24 ST_Em). `'dot'` = filled
+   *  dot above, `'comma'` = sesame/comma above, `'circle'` = hollow circle
+   *  above, `'underDot'` = filled dot below (horizontal writing). Absent (or the
+   *  authored `val="none"`) ⇒ no mark. The renderer stamps the mark per glyph
+   *  after the text and does NOT change the glyph advance. */
+  emphasisMark?: EmphasisMark;
   /** ECMA-376 §17.3.3.25 ruby annotation (furigana). Renders above the
    *  base text in a smaller font; line height is expanded to fit it. */
   ruby?: RubyAnnotation;
@@ -937,6 +944,11 @@ export interface RubyAnnotation {
   /** Annotation font size in pt. Word stores this as half-points in `<w:hps>`. */
   fontSizePt: number;
 }
+
+/** ECMA-376 §17.18.24 ST_Em — the emphasis-mark styles a run may carry via
+ *  `<w:em w:val>` (§17.3.2.12). `'none'` is filtered out by the parser, so the
+ *  model only ever carries one of these four positive marks (or `undefined`). */
+export type EmphasisMark = 'dot' | 'comma' | 'circle' | 'underDot';
 
 export interface ImageRun {
   /**


### PR DESCRIPTION
## Summary
Implements WD5: emphasis marks (`<w:em>`, ECMA-376 §17.3.2.12 / ST_Em §17.18.24) — Japanese boten (圏点) stamped on each non-space character of a run. dot (filled, above), circle (hollow, above), comma (sesame, above), underDot (filled, below); `none`/absent → no mark.

## Changes
- **parser**: `emphasis_mark` on `RunFmt` (parse mirrors `w:highlight`, `none`→None), set-wins merge in `apply_run` (style chain + direct rPr), wire `emphasisMark` on `TextRun` (camelCase), threaded through all 5 construction sites + mergeable equality.
- **renderer**: new pure `emphasis-mark.ts` (`emphasisMarkCenters` — per-glyph centres from contextual measureText cumulative advance + uniform pitch, whitespace/U+3000 skipped, surrogate-safe; `emphasisMarkGeometry` — ST_Em → shape/radius/side). Paint block after ruby draw; overlay only (no advance/metric change).
- §17.18.24 grounding: "applied to each non-space character"; glyph shape is implementation-defined → JIS X 4051 boten convention (radius ≈0.07em), documented.

## Line-height decision
Draw-only, line height unchanged. Word widens leading for emphasised text but the reservation is unspecified; on very tight leading an above-mark can reach the previous line's descent (documented at the call site; follow-up would fold mark height into lineBoxHeight, gated on a Word-behaviour determination).

## Tests / gates
cargo fmt/clippy(-D warnings)/test 216 (incl. 3 new); docx vitest 611 (19 new: 11 pure + 8 renderer mock-ctx); end-to-end via real WASM (synthetic docx, all 5 values round-trip). VRT run pending on the orchestrator side (no private fixtures in the implementing environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)