### PR TITLE
feat(docx,core): load embedded fonts (ODTTF de-obfuscation, §17.8.1) (XF14)

### DIFF
--- a/packages/core/src/fonts/embedded.test.ts
+++ b/packages/core/src/fonts/embedded.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  deobfuscateOdttf,
+  registerEmbeddedFonts,
+  type EmbeddedFontFace,
+} from './embedded.js';
+
+const G = globalThis as Record<string, unknown>;
+const ORIG = { document: G.document, self: G.self, FontFace: G.FontFace };
+
+afterEach(() => {
+  G.document = ORIG.document;
+  G.self = ORIG.self;
+  G.FontFace = ORIG.FontFace;
+  vi.restoreAllMocks();
+});
+
+describe('deobfuscateOdttf (ECMA-376 §17.8.1)', () => {
+  // Synthetic: obfuscate a known 32-byte header with a GUID, then de-obfuscate
+  // and assert we recover the original. Because XOR is its own inverse, the
+  // obfuscate step is the same routine — so a round-trip proving recovery also
+  // proves the direction the viewer needs (obfuscated part → plaintext font).
+  it('is an involution: obfuscate then de-obfuscate recovers the bytes', () => {
+    const guid = '{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}';
+    // A plausible sfnt header: 00 01 00 00 (TrueType) + arbitrary tail.
+    const plain = new Uint8Array(64);
+    plain.set([0x00, 0x01, 0x00, 0x00], 0);
+    for (let i = 4; i < 64; i++) plain[i] = (i * 37) & 0xff;
+
+    const obf = deobfuscateOdttf(plain, guid); // XOR masks first 32 bytes
+    // First 32 bytes changed, the rest untouched.
+    expect(Array.from(obf.slice(0, 4))).not.toEqual([0x00, 0x01, 0x00, 0x00]);
+    expect(Array.from(obf.slice(32))).toEqual(Array.from(plain.slice(32)));
+
+    const back = deobfuscateOdttf(obf, guid);
+    expect(Array.from(back)).toEqual(Array.from(plain));
+  });
+
+  it('recovers the TrueType magic 00 01 00 00 from a real ODTTF header slice', () => {
+    // First 32 bytes of sample-11.docx word/fonts/font1.odttf (Ubuntu Regular),
+    // whose w:embedRegular fontKey is {3EEE3167-...}. De-obfuscating must yield
+    // the sfnt version 0x00010000 in the first four bytes.
+    const header = new Uint8Array([
+      0x4d, 0x1c, 0xe3, 0x71, 0x6b, 0xff, 0x49, 0xae, 0x98, 0x43, 0xb8, 0xb5,
+      0x23, 0x62, 0xa7, 0x79, 0x15, 0x12, 0x90, 0x39, 0x6b, 0xef, 0x04, 0x5e,
+      0x98, 0x47, 0xa1, 0xd5, 0x20, 0x61, 0xa1, 0x6d,
+    ]);
+    const out = deobfuscateOdttf(header, '{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}');
+    expect(Array.from(out.slice(0, 4))).toEqual([0x00, 0x01, 0x00, 0x00]);
+  });
+
+  it('accepts a GUID without braces/hyphens', () => {
+    const header = new Uint8Array([
+      0x4d, 0x1c, 0xe3, 0x71, 0x6b, 0xff, 0x49, 0xae, 0x98, 0x43, 0xb8, 0xb5,
+      0x23, 0x62, 0xa7, 0x79, 0x15, 0x12, 0x90, 0x39, 0x6b, 0xef, 0x04, 0x5e,
+      0x98, 0x47, 0xa1, 0xd5, 0x20, 0x61, 0xa1, 0x6d,
+    ]);
+    const out = deobfuscateOdttf(header, '3EEE3167E5B84798AE48EA6B71E31D4D');
+    expect(Array.from(out.slice(0, 4))).toEqual([0x00, 0x01, 0x00, 0x00]);
+  });
+
+  it('leaves bytes past the first 32 untouched even for a short buffer', () => {
+    const short = new Uint8Array([1, 2, 3, 4, 5]);
+    const out = deobfuscateOdttf(short, '{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}');
+    expect(out.length).toBe(5);
+    // Round trip still recovers.
+    expect(Array.from(deobfuscateOdttf(out, '{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}'))).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+
+  it('throws on a malformed fontKey (not 32 hex digits)', () => {
+    expect(() => deobfuscateOdttf(new Uint8Array(32), 'not-a-guid')).toThrow(/invalid fontKey/);
+    expect(() => deobfuscateOdttf(new Uint8Array(32), '{ABCD}')).toThrow(/invalid fontKey/);
+  });
+
+  it('does not mutate the input', () => {
+    const input = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]);
+    const copy = input.slice();
+    deobfuscateOdttf(input, '{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}');
+    expect(Array.from(input)).toEqual(Array.from(copy));
+  });
+});
+
+// ---- registerEmbeddedFonts -------------------------------------------------
+
+interface FakeFace {
+  family: string;
+  source: ArrayBuffer;
+  descriptors?: object;
+  loadCalls: number;
+  load: () => Promise<FakeFace>;
+}
+
+function installFontFaceSet(opts: { failLoad?: (family: string) => boolean } = {}) {
+  const added: FakeFace[] = [];
+  class FakeFontFace implements FakeFace {
+    family: string;
+    source: ArrayBuffer;
+    loadCalls = 0;
+    constructor(family: string, source: ArrayBuffer, public descriptors?: object) {
+      this.family = family;
+      this.source = source;
+    }
+    load(): Promise<FakeFace> {
+      this.loadCalls++;
+      return opts.failLoad?.(this.family)
+        ? Promise.reject(new Error('load failed'))
+        : Promise.resolve(this);
+    }
+  }
+  const set = {
+    faces: added,
+    add: (f: FakeFace) => {
+      added.push(f);
+    },
+    [Symbol.iterator]() {
+      return added[Symbol.iterator]();
+    },
+    ready: Promise.resolve(),
+  };
+  G.FontFace = FakeFontFace;
+  G.document = { fonts: set };
+  delete G.self;
+  return { set, added };
+}
+
+const validHeader = () =>
+  new Uint8Array([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x40, 0x00, 0x30,
+    0x47, 0x53, 0x55, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]);
+
+describe('registerEmbeddedFonts', () => {
+  it('registers a raw (pptx) face and force-loads it', async () => {
+    const { added } = installFontFaceSet();
+    const faces: EmbeddedFontFace[] = [
+      { family: 'MyFont', bytes: validHeader(), odttf: false, weight: 'normal', style: 'normal' },
+    ];
+    await registerEmbeddedFonts(faces);
+    expect(added).toHaveLength(1);
+    expect(added[0].family).toBe('MyFont');
+    expect(added[0].loadCalls).toBe(1);
+    expect(added[0].descriptors).toMatchObject({ weight: 'normal', style: 'normal' });
+  });
+
+  it('de-obfuscates an odttf face before registering (bytes passed to FontFace are plaintext)', async () => {
+    const { added } = installFontFaceSet();
+    // Obfuscate a valid header so registration must de-obfuscate to a valid sfnt.
+    const guid = '{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}';
+    const obf = deobfuscateOdttf(validHeader(), guid);
+    await registerEmbeddedFonts([
+      { family: 'Ubuntu', bytes: obf, odttf: true, fontKey: guid, weight: 'bold', style: 'italic' },
+    ]);
+    expect(added).toHaveLength(1);
+    const src = new Uint8Array(added[0].source);
+    expect(Array.from(src.slice(0, 4))).toEqual([0x00, 0x01, 0x00, 0x00]);
+    expect(added[0].descriptors).toMatchObject({ weight: 'bold', style: 'italic' });
+  });
+
+  it('maps all four style slots (regular/bold/italic/boldItalic) to one family', async () => {
+    const { added } = installFontFaceSet();
+    const faces: EmbeddedFontFace[] = [
+      { family: 'Ubuntu', bytes: validHeader(), odttf: false, weight: 'normal', style: 'normal' },
+      { family: 'Ubuntu', bytes: validHeader(), odttf: false, weight: 'bold', style: 'normal' },
+      { family: 'Ubuntu', bytes: validHeader(), odttf: false, weight: 'normal', style: 'italic' },
+      { family: 'Ubuntu', bytes: validHeader(), odttf: false, weight: 'bold', style: 'italic' },
+    ];
+    await registerEmbeddedFonts(faces);
+    expect(added).toHaveLength(4);
+    expect(added.every((f) => f.family === 'Ubuntu')).toBe(true);
+  });
+
+  it('skips a malformed odttf fontKey without aborting other faces', async () => {
+    const { added } = installFontFaceSet();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await registerEmbeddedFonts([
+      { family: 'Bad', bytes: validHeader(), odttf: true, fontKey: 'nope', weight: 'normal', style: 'normal' },
+      { family: 'Good', bytes: validHeader(), odttf: false, weight: 'normal', style: 'normal' },
+    ]);
+    expect(added.map((f) => f.family)).toEqual(['Good']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Bad'));
+  });
+
+  it('skips an oversized face (memory / zip-bomb safety net)', async () => {
+    const { added } = installFontFaceSet();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await registerEmbeddedFonts(
+      [{ family: 'Huge', bytes: new Uint8Array(100), odttf: false, weight: 'normal', style: 'normal' }],
+      10, // maxBytes = 10
+    );
+    expect(added).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Huge'));
+  });
+
+  it('skips an empty face', async () => {
+    const { added } = installFontFaceSet();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await registerEmbeddedFonts([
+      { family: 'Empty', bytes: new Uint8Array(0), odttf: false, weight: 'normal', style: 'normal' },
+    ]);
+    expect(added).toHaveLength(0);
+  });
+
+  it('warns once when a registered face fails to load', async () => {
+    const { added } = installFontFaceSet({ failLoad: (f) => f === 'Flaky' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await registerEmbeddedFonts([
+      { family: 'Flaky', bytes: validHeader(), odttf: false, weight: 'normal', style: 'normal' },
+    ]);
+    // Still added to the set; the load rejection is surfaced diagnostically.
+    expect(added).toHaveLength(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Flaky'));
+  });
+
+  it('no-ops (no throw) when no FontFaceSet exists', async () => {
+    delete G.document;
+    delete G.self;
+    delete G.FontFace;
+    await expect(
+      registerEmbeddedFonts([
+        { family: 'X', bytes: validHeader(), odttf: false, weight: 'normal', style: 'normal' },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('registers into self.fonts when there is no document (worker context)', async () => {
+    const added: FakeFace[] = [];
+    class FakeFontFace {
+      constructor(public family: string, public source: ArrayBuffer, public descriptors?: object) {}
+      load() {
+        return Promise.resolve(this);
+      }
+    }
+    delete G.document;
+    G.self = {
+      fonts: {
+        add: (f: FakeFace) => added.push(f),
+        ready: Promise.resolve(),
+      },
+    };
+    G.FontFace = FakeFontFace;
+    await registerEmbeddedFonts([
+      { family: 'WorkerFont', bytes: validHeader(), odttf: false, weight: 'normal', style: 'normal' },
+    ]);
+    expect(added).toHaveLength(1);
+    expect(added[0].family).toBe('WorkerFont');
+  });
+});

--- a/packages/core/src/fonts/embedded.ts
+++ b/packages/core/src/fonts/embedded.ts
@@ -1,0 +1,166 @@
+/**
+ * Embedded-font registration shared by docx / pptx / xlsx viewers.
+ *
+ * OOXML documents may ship the fonts they use inside the package so the text
+ * renders with the authored typeface even when it is absent from the host
+ * system. This module turns those embedded font parts into `FontFace` objects
+ * registered into the active FontFaceSet (`document.fonts` on the main thread,
+ * `self.fonts` in a worker), so a subsequent `ctx.font = '… FamilyName'` selects
+ * the real font instead of a substitute.
+ *
+ * Two obfuscation conventions exist across the formats, handled here:
+ *
+ * - **WordprocessingML (docx)** stores fonts as *obfuscated* parts
+ *   (`.odttf`, content type `application/vnd.openxmlformats-officedocument.obfuscatedFont`).
+ *   The first 32 bytes are XOR-masked with the `w:fontKey` GUID per ECMA-376
+ *   §17.8.1 (Font Embedding). {@link deobfuscateOdttf} reverses it.
+ * - **PresentationML (pptx)** stores fonts as `.fntdata` parts, content type
+ *   `application/x-font-ttf` (raw sfnt) or `application/x-fontdata` (EOT). Per
+ *   ECMA-376 §15 (the Font part), the §17.8.1 obfuscation is *only* permitted
+ *   for WordprocessingML, so pptx font bytes are consumed as-is (no XOR).
+ *
+ * The registration mechanism (build `FontFace` from bytes, add to the set,
+ * force `load()`, await `fonts.ready`) mirrors {@link preloadGoogleFonts}: the
+ * two loaders share {@link activeFontSet} and the same first-paint determinism
+ * contract (fonts must be ready before the caller measures/paints text).
+ */
+import { activeFontSet, withFontCeiling } from './preload.js';
+
+/**
+ * ECMA-376 §17.8.1 — de-obfuscate a WordprocessingML embedded font (`.odttf`).
+ *
+ * The algorithm (verbatim from the spec): reverse the order of the bytes in the
+ * `fontKey` GUID (big-endian ordering), then XOR that 16-byte key against the
+ * first 32 bytes of the font binary — once against bytes 0–15, once against
+ * 16–31. The transform is its own inverse, so the same routine de-obfuscates.
+ *
+ * `fontKey` is the GUID string from `<w:embedRegular w:fontKey="{…}"/>` &c.,
+ * e.g. `"{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}"`. Braces and hyphens are
+ * optional; any 32 hex digits are accepted.
+ *
+ * Returns a fresh `Uint8Array` (the input is not mutated). Throws if the GUID
+ * does not yield exactly 16 bytes — a malformed key must not silently produce a
+ * garbage font.
+ */
+export function deobfuscateOdttf(bytes: Uint8Array, fontKey: string): Uint8Array {
+  const key = fontKeyBytes(fontKey);
+  const out = bytes.slice();
+  const n = Math.min(32, out.length);
+  for (let i = 0; i < n; i++) {
+    // Bytes 0–15 XOR key[0..15]; bytes 16–31 XOR the SAME key again (i % 16).
+    out[i] ^= key[i % 16];
+  }
+  return out;
+}
+
+/** Parse a `w:fontKey` GUID into its 16 bytes, reversed (big-endian) as §17.8.1
+ *  requires. The reversal is over the full 16-byte string-order representation
+ *  (the spec example `001B70DC-AA60-4AD5-90EC-18A0948E1EAE` →
+ *  `AE1E8E94-A018-EC90-D54A-60AADC701B00`), NOT the .NET mixed-endian GUID
+ *  layout. Throws on any input that is not exactly 32 hex digits. */
+function fontKeyBytes(fontKey: string): Uint8Array {
+  const hex = fontKey.replace(/[{}\-\s]/g, '');
+  if (hex.length !== 32 || /[^0-9a-fA-F]/.test(hex)) {
+    throw new Error(`invalid fontKey GUID: ${fontKey}`);
+  }
+  const raw = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    raw[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return raw.reverse();
+}
+
+/** One embedded font face to register: the family name it is drawn with, the
+ *  raw part bytes, whether the part is `.odttf`-obfuscated (docx) and, if so,
+ *  the `w:fontKey` GUID, plus the CSS bold/italic descriptors that map the
+ *  style slot (regular / bold / italic / boldItalic). */
+export interface EmbeddedFontFace {
+  /** The FontFaceSet family name — the document's font name (e.g. "Ubuntu").
+   *  The renderer sets `ctx.font` with this exact name so the browser selects
+   *  the embedded face. */
+  family: string;
+  /** Raw bytes of the embedded font part (still obfuscated when `odttf`). */
+  bytes: Uint8Array;
+  /** `true` for docx `.odttf` parts (needs §17.8.1 de-obfuscation with
+   *  `fontKey`); `false` for pptx `.fntdata` (raw sfnt / EOT). */
+  odttf: boolean;
+  /** The `w:fontKey` GUID; required when `odttf` is true, ignored otherwise. */
+  fontKey?: string;
+  /** CSS `font-weight` for this style slot ('normal' | 'bold'). */
+  weight: 'normal' | 'bold';
+  /** CSS `font-style` for this style slot ('normal' | 'italic'). */
+  style: 'normal' | 'italic';
+}
+
+/**
+ * Register a set of embedded font faces into the active FontFaceSet and await
+ * their load, so the caller can measure/paint text with the real typefaces.
+ *
+ * De-obfuscation (docx `.odttf`) is applied per face. A face whose bytes are
+ * corrupt, whose `fontKey` is malformed, or that exceeds {@link maxBytes} is
+ * skipped with a `console.warn` — one bad embedded font must never abort the
+ * whole document. Sizes are capped as a zip-bomb / memory safety net.
+ *
+ * No-ops (resolves immediately) when there is no FontFaceSet or `FontFace` in
+ * the current context (e.g. Node without a shim), matching
+ * {@link preloadGoogleFonts}.
+ *
+ * @param faces      the embedded faces to register
+ * @param maxBytes   per-face size ceiling; faces larger than this are skipped
+ *                   (default 30 MB — comfortably above a full CJK font, well
+ *                   below a memory hazard)
+ */
+export async function registerEmbeddedFonts(
+  faces: Iterable<EmbeddedFontFace>,
+  maxBytes = 30 * 1024 * 1024,
+): Promise<void> {
+  const set = activeFontSet();
+  if (!set || typeof FontFace === 'undefined') return;
+
+  const added: FontFace[] = [];
+  const failed: string[] = [];
+  for (const face of faces) {
+    try {
+      if (face.bytes.length === 0 || face.bytes.length > maxBytes) {
+        failed.push(face.family);
+        continue;
+      }
+      const data = face.odttf
+        ? deobfuscateOdttf(face.bytes, face.fontKey ?? '')
+        : face.bytes;
+      // Copy into a standalone ArrayBuffer: FontFace(source) reads the buffer,
+      // and `data` may be a subarray view into a larger WASM/transfer buffer.
+      const buf = data.buffer.slice(
+        data.byteOffset,
+        data.byteOffset + data.byteLength,
+      ) as ArrayBuffer;
+      const ff = new FontFace(face.family, buf, {
+        weight: face.weight,
+        style: face.style,
+      });
+      set.add(ff);
+      added.push(ff);
+    } catch {
+      // Malformed fontKey / unreadable part: skip this face, keep the document.
+      failed.push(face.family);
+    }
+  }
+
+  if (added.length > 0) {
+    await withFontCeiling(
+      Promise.allSettled(added.map((f) => f.load())).then((results) => {
+        results.forEach((res, i) => {
+          if (res.status === 'rejected') failed.push(added[i].family);
+        });
+        return set.ready;
+      }),
+    );
+  }
+
+  if (failed.length > 0) {
+    console.warn(
+      `[ooxml] failed to register embedded font(s): ${[...new Set(failed)].join(', ')}; ` +
+        `falling back to substitute fonts (text may shift or differ).`,
+    );
+  }
+}

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -44,7 +44,11 @@ export interface FontPreloadEntry {
  */
 const HARD_CEILING_MS = 15000;
 
-function withCeiling<T>(p: Promise<T>): Promise<T | void> {
+/** Race a font-load promise against a generous hard ceiling so a wedged network
+ *  or a `FontFace.load()` that never settles cannot hang the caller forever.
+ *  Shared by the Google-Fonts and embedded-font loaders (same first-paint
+ *  determinism contract). */
+export function withFontCeiling<T>(p: Promise<T>): Promise<T | void> {
   return Promise.race([
     p,
     new Promise<void>((resolve) => setTimeout(resolve, HARD_CEILING_MS)),
@@ -104,8 +108,10 @@ export function parseFontFaceRules(css: string): ParsedFontFace[] {
 }
 
 /** The FontFaceSet of the current context: `document.fonts` on the main
- *  thread, `self.fonts` in a worker, null elsewhere (Node without a shim). */
-function activeFontSet(): FontFaceSet | null {
+ *  thread, `self.fonts` in a worker, null elsewhere (Node without a shim).
+ *  Exported so the embedded-font loader shares one FontFaceSet-resolution rule
+ *  with the Google-Fonts loader (both must register into the SAME set). */
+export function activeFontSet(): FontFaceSet | null {
   if (typeof document !== 'undefined' && document && document.fonts) return document.fonts;
   if (typeof self !== 'undefined' && self && 'fonts' in self) {
     return (self as unknown as { fonts: FontFaceSet }).fonts;
@@ -158,7 +164,7 @@ export async function preloadGoogleFonts(
   //    entries into the active FontFaceSet, keeping references to the faces we
   //    add. Canvas rendering never puts glyphs into the DOM, so registration
   //    alone is not enough — see (2).
-  const faceGroups = await withCeiling(
+  const faceGroups = await withFontCeiling(
     Promise.all(
       [...cssUrls].map((url) => {
         // Cache hit: AWAIT the in-flight registration so concurrent callers join
@@ -202,7 +208,7 @@ export async function preloadGoogleFonts(
   //    quotes (e.g. `"Nunito Sans"`), so a `family`-string filter silently
   //    matches nothing and the fonts never load — the bug this avoids.
   const addedFaces = (Array.isArray(faceGroups) ? faceGroups : []).flat();
-  await withCeiling(
+  await withFontCeiling(
     Promise.allSettled(addedFaces.map((f) => f.load())).then((results) => {
       results.forEach((res, i) => {
         if (res.status === 'rejected') {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,13 @@ export {
 } from './crypto';
 export { readCfbStream } from './errors/cfb-read';
 export { preloadGoogleFonts, type FontPreloadEntry } from './fonts/preload';
+// Embedded-font registration: docx `.odttf` (§17.8.1 obfuscated) + pptx
+// `.fntdata` (raw sfnt) faces turned into FontFace objects in the active set.
+export {
+  registerEmbeddedFonts,
+  deobfuscateOdttf,
+  type EmbeddedFontFace,
+} from './fonts/embedded';
 // Shared Office-font → Google-Fonts substitute registry (Calibri → Carlito,
 // Cambria → Caladea, popular web fonts, Arabic Noto fallbacks). Each package
 // spreads this into its own map; script-fallback Noto faces live in

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -282,9 +282,26 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
             }
         })
         .unwrap_or_else(|| "word/fontTable.xml".to_string());
-    let font_family_classes = read_zip_string(zip, &font_table_path)
-        .map(|s| parse_font_table(&s))
-        .unwrap_or_default();
+    let font_table_xml = read_zip_string(zip, &font_table_path).unwrap_or_default();
+    let font_family_classes = parse_font_table(&font_table_xml);
+    // ECMA-376 §17.8.3.3-.6 — embedded fonts. The `<w:embed*>` r:ids resolve
+    // through the fontTable part's OWN relationships (`word/_rels/fontTable.xml.rels`
+    // when the part is `word/fontTable.xml`): insert `_rels/` before the filename
+    // and append `.rels`. Missing rels ⇒ no embedded fonts (graceful).
+    let embedded_fonts = {
+        let stem = font_table_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(&font_table_path);
+        let dir = font_table_path
+            .rsplit_once('/')
+            .map(|(d, _)| d)
+            .unwrap_or("word");
+        let font_rels_path = format!("{}/_rels/{}.rels", dir, stem);
+        let font_rels_xml = read_zip_string(zip, &font_rels_path).unwrap_or_default();
+        let font_rels = parse_rels(&font_rels_xml);
+        parse_embedded_fonts(&font_table_xml, &font_rels, &format!("{}/", dir))
+    };
 
     // Track-changes events live inline in the body XML; do a second pass to
     // surface them as a flat list with author/date metadata. The body parse
@@ -332,6 +349,7 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
         major_font,
         minor_font,
         font_family_classes,
+        embedded_fonts,
         revisions,
         comments,
         footnotes,
@@ -829,6 +847,78 @@ fn parse_font_table(xml: &str) -> BTreeMap<String, String> {
         }
     }
     map
+}
+
+/// Parse the embedded-font references from `word/fontTable.xml` (ECMA-376
+/// §17.8.3.3-.6 `<w:embedRegular>` / `<w:embedBold>` / `<w:embedItalic>` /
+/// `<w:embedBoldItalic>`), resolving each `r:id` through the fontTable's OWN
+/// relationships (`rels`, rId → raw Target) to a canonical zip part path.
+///
+/// `base_dir` is the fontTable part's directory (e.g. `word/`); each Target is
+/// resolved against it via the shared OPC resolver (root-absolute + `..`
+/// normalization), so `fonts/font1.odttf` becomes `word/fonts/font1.odttf`.
+///
+/// Each `<w:embed*>` also carries a `w:fontKey` GUID (§17.8.1) needed to
+/// de-obfuscate the `.odttf` bytes. A slot is skipped when its `r:id` is
+/// missing / unresolvable or its `w:fontKey` is absent — an embedded face
+/// cannot be registered without both the part and its key.
+fn parse_embedded_fonts(
+    font_table_xml: &str,
+    rels: &HashMap<String, String>,
+    base_dir: &str,
+) -> Vec<crate::types::EmbeddedFont> {
+    let mut out = Vec::new();
+    let Ok(doc) = XmlDoc::parse(font_table_xml) else {
+        return out;
+    };
+    for font in doc.root_element().descendants().filter(|n| {
+        n.is_element() && n.tag_name().name() == "font" && is_w_ns(n.tag_name().namespace())
+    }) {
+        let Some(name) = attr_ns(
+            &font,
+            wordprocessingml::TRANSITIONAL,
+            wordprocessingml::STRICT,
+            "name",
+        ) else {
+            continue;
+        };
+        for child in font.children().filter(|n| n.is_element()) {
+            let style = match child.tag_name().name() {
+                "embedRegular" => "regular",
+                "embedBold" => "bold",
+                "embedItalic" => "italic",
+                "embedBoldItalic" => "boldItalic",
+                _ => continue,
+            };
+            let Some(rid) = attr_ns(
+                &child,
+                relationships::TRANSITIONAL,
+                relationships::STRICT,
+                "id",
+            ) else {
+                continue;
+            };
+            let Some(font_key) = attr_ns(
+                &child,
+                wordprocessingml::TRANSITIONAL,
+                wordprocessingml::STRICT,
+                "fontKey",
+            ) else {
+                continue;
+            };
+            let Some(target) = rels.get(rid) else {
+                continue;
+            };
+            let part_path = ooxml_common::rels::resolve_target(base_dir, target);
+            out.push(crate::types::EmbeddedFont {
+                font_name: name.to_string(),
+                style: style.to_string(),
+                part_path,
+                font_key: font_key.to_string(),
+            });
+        }
+    }
+    out
 }
 
 /// Body children with `<w:sdt>` wrappers unwrapped (identical node sequence to
@@ -12325,5 +12415,132 @@ mod strict_namespace_tests {
             Some(Some("left".to_string())),
             "Strict m:jc/@m:val must reach the Math run"
         );
+    }
+}
+
+/// ECMA-376 §17.8.3.3-.6 — embedded-font references (`<w:embed*>`) from
+/// `word/fontTable.xml`, resolved through the fontTable's own relationships.
+#[cfg(test)]
+mod embedded_font_tests {
+    use super::*;
+    use crate::xml_util::{R_NS, W_NS};
+
+    fn font_table(inner: &str) -> String {
+        format!(
+            r#"<w:fonts xmlns:w="{w}" xmlns:r="{r}">{inner}</w:fonts>"#,
+            w = W_NS,
+            r = R_NS,
+        )
+    }
+
+    /// A font declaring both `<w:embedRegular>` and `<w:embedBold>` yields two
+    /// `EmbeddedFont` entries, each carrying the family name, the style slot, the
+    /// resolved part path (Target resolved against `word/`), and the fontKey.
+    #[test]
+    fn regular_and_bold_slots_resolve() {
+        let xml = font_table(
+            r#"<w:font w:name="Ubuntu">
+                 <w:embedRegular r:id="rId1" w:fontKey="{KEY-REG}"/>
+                 <w:embedBold r:id="rId2" w:fontKey="{KEY-BOLD}"/>
+               </w:font>"#,
+        );
+        let mut rels = HashMap::new();
+        rels.insert("rId1".to_string(), "fonts/font1.odttf".to_string());
+        rels.insert("rId2".to_string(), "fonts/font2.odttf".to_string());
+
+        let fonts = parse_embedded_fonts(&xml, &rels, "word/");
+        assert_eq!(fonts.len(), 2, "two embed slots ⇒ two entries");
+
+        let reg = fonts.iter().find(|f| f.style == "regular").unwrap();
+        assert_eq!(reg.font_name, "Ubuntu");
+        assert_eq!(reg.part_path, "word/fonts/font1.odttf");
+        assert_eq!(reg.font_key, "{KEY-REG}");
+
+        let bold = fonts.iter().find(|f| f.style == "bold").unwrap();
+        assert_eq!(bold.font_name, "Ubuntu");
+        assert_eq!(bold.part_path, "word/fonts/font2.odttf");
+        assert_eq!(bold.font_key, "{KEY-BOLD}");
+    }
+
+    /// All four `<w:embed*>` element names map to their style slot tokens.
+    #[test]
+    fn all_four_style_slots() {
+        let xml = font_table(
+            r#"<w:font w:name="Tahoma">
+                 <w:embedRegular r:id="rId1" w:fontKey="{K1}"/>
+                 <w:embedBold r:id="rId2" w:fontKey="{K2}"/>
+                 <w:embedItalic r:id="rId3" w:fontKey="{K3}"/>
+                 <w:embedBoldItalic r:id="rId4" w:fontKey="{K4}"/>
+               </w:font>"#,
+        );
+        let mut rels = HashMap::new();
+        for n in 1..=4 {
+            rels.insert(format!("rId{n}"), format!("fonts/font{n}.odttf"));
+        }
+        let fonts = parse_embedded_fonts(&xml, &rels, "word/");
+        let mut styles: Vec<&str> = fonts.iter().map(|f| f.style.as_str()).collect();
+        styles.sort_unstable();
+        assert_eq!(styles, ["bold", "boldItalic", "italic", "regular"]);
+    }
+
+    /// A slot whose `r:id` has no entry in the rels map is skipped (the part
+    /// cannot be located, so it cannot be registered).
+    #[test]
+    fn slot_with_unresolvable_rid_is_skipped() {
+        let xml = font_table(
+            r#"<w:font w:name="Ubuntu">
+                 <w:embedRegular r:id="rId1" w:fontKey="{K1}"/>
+                 <w:embedBold r:id="rIdMissing" w:fontKey="{K2}"/>
+               </w:font>"#,
+        );
+        let mut rels = HashMap::new();
+        rels.insert("rId1".to_string(), "fonts/font1.odttf".to_string());
+        // rIdMissing deliberately absent.
+
+        let fonts = parse_embedded_fonts(&xml, &rels, "word/");
+        assert_eq!(fonts.len(), 1, "only the resolvable slot survives");
+        assert_eq!(fonts[0].style, "regular");
+    }
+
+    /// A slot missing its `w:fontKey` is skipped — §17.8.1 de-obfuscation is
+    /// impossible without the key.
+    #[test]
+    fn slot_without_font_key_is_skipped() {
+        let xml = font_table(
+            r#"<w:font w:name="Ubuntu">
+                 <w:embedRegular r:id="rId1"/>
+               </w:font>"#,
+        );
+        let mut rels = HashMap::new();
+        rels.insert("rId1".to_string(), "fonts/font1.odttf".to_string());
+
+        let fonts = parse_embedded_fonts(&xml, &rels, "word/");
+        assert!(fonts.is_empty(), "no fontKey ⇒ slot dropped");
+    }
+
+    /// A font with a `<w:family>` classification but NO `<w:embed*>` children
+    /// contributes nothing to the embedded-font list.
+    #[test]
+    fn font_without_embeds_yields_nothing() {
+        let xml = font_table(r#"<w:font w:name="Calibri"><w:family w:val="swiss"/></w:font>"#);
+        let fonts = parse_embedded_fonts(&xml, &HashMap::new(), "word/");
+        assert!(fonts.is_empty(), "no <w:embed*> ⇒ no embedded fonts");
+    }
+
+    /// A root-absolute Target (leading `/`) resolves from the package root,
+    /// ignoring `base_dir` (ECMA-376 Part 2 §9.3).
+    #[test]
+    fn root_absolute_target_resolves_from_package_root() {
+        let xml = font_table(
+            r#"<w:font w:name="Ubuntu">
+                 <w:embedRegular r:id="rId1" w:fontKey="{K1}"/>
+               </w:font>"#,
+        );
+        let mut rels = HashMap::new();
+        rels.insert("rId1".to_string(), "/word/fonts/font1.odttf".to_string());
+
+        let fonts = parse_embedded_fonts(&xml, &rels, "word/");
+        assert_eq!(fonts.len(), 1);
+        assert_eq!(fonts[0].part_path, "word/fonts/font1.odttf");
     }
 }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -29,6 +29,14 @@ pub struct Document {
     /// sorted), making the parser output byte-stable for identical input.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub font_family_classes: BTreeMap<String, String>,
+    /// ECMA-376 §17.8.3.3-.6 — embedded fonts declared in `word/fontTable.xml`
+    /// (`<w:embedRegular>` / `embedBold` / `embedItalic` / `embedBoldItalic`),
+    /// resolved through `word/_rels/fontTable.xml.rels` to their obfuscated
+    /// `.odttf` part paths. The renderer de-obfuscates (§17.8.1, via the
+    /// `fontKey`) and registers each as a FontFace so text draws with the
+    /// authored typeface. Empty when the document embeds no fonts.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub embedded_fonts: Vec<EmbeddedFont>,
     /// ECMA-376 §17.13.5 — track-changes events found in the body. Each entry
     /// is one `<w:ins>` or `<w:del>` block, with the change author / date /
     /// text content. Empty when the document has no tracked changes.
@@ -55,6 +63,21 @@ pub struct Document {
     /// (the renderer then uses spec defaults: kinsoku ON).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<DocumentSettings>,
+}
+
+/// One embedded font-style slot from `word/fontTable.xml`. `style` is one of
+/// "regular" | "bold" | "italic" | "boldItalic" (the `<w:embed*>` element).
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbeddedFont {
+    /// The `<w:font w:name>` this style belongs to (FontFace family name).
+    pub font_name: String,
+    /// Style slot: "regular" | "bold" | "italic" | "boldItalic".
+    pub style: String,
+    /// Resolved zip part path, e.g. "word/fonts/font1.odttf".
+    pub part_path: String,
+    /// `<w:embed* w:fontKey>` GUID for §17.8.1 de-obfuscation.
+    pub font_key: String,
 }
 
 /// Document-wide settings surfaced from `word/settings.xml`. Only the

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -14,6 +14,7 @@ import {
 import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerRequest, WorkerResponse, DocComment, DocNote } from './types';
 import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache } from './renderer';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
+import { loadEmbeddedFonts } from './embedded-fonts';
 import type {
   DocumentMeta,
   RenderWorkerRequest,
@@ -117,6 +118,13 @@ export class DocxDocument {
         DOCX_GOOGLE_FONTS,
       );
     }
+    // ECMA-376 §17.8.1 / §17.8.3 — register the document's embedded fonts (via
+    // the worker's zip-entry extraction) before the lazy first pagination, so
+    // text measures/draws with the authored typeface. Worker mode does this
+    // inside the worker (before it paginates); here it runs on the main thread.
+    if (mode === 'main' && doc._document?.embeddedFonts?.length) {
+      await loadEmbeddedFonts(doc._document, (p) => doc.getFontBytes(p));
+    }
     // Equations are converted + rasterized before pagination (which reads their
     // extents synchronously). Requires the opt-in `math` engine; without it,
     // equations are skipped (and the engine asset is never bundled). Math is
@@ -188,6 +196,22 @@ export class DocxDocument {
       });
     this._imageCache.set(imagePath, p);
     return p;
+  }
+
+  /**
+   * Extract raw bytes for an embedded font part by zip path (e.g.
+   * `word/fonts/font1.odttf`). Routes through the SAME persistent-worker
+   * `extractImage` message as {@link getImage} — `DocxArchive.extract_image`
+   * reads ANY zip entry, not just media — returning the raw (still obfuscated)
+   * `.odttf` bytes rather than a Blob. Consumed by {@link loadEmbeddedFonts},
+   * which de-obfuscates (ECMA-376 §17.8.1) and registers each as a FontFace.
+   */
+  async getFontBytes(partPath: string): Promise<Uint8Array> {
+    const res = await this._bridge.request(
+      (id) => ({ type: 'extractImage', id, path: partPath }) satisfies WorkerRequest,
+    );
+    const bytes = (res as Extract<WorkerResponse, { type: 'imageExtracted' }>).bytes;
+    return new Uint8Array(bytes);
   }
 
   /**

--- a/packages/docx/src/embedded-fonts.test.ts
+++ b/packages/docx/src/embedded-fonts.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { deobfuscateOdttf } from '@silurus/ooxml-core';
+import { loadEmbeddedFonts } from './embedded-fonts.js';
+import type { DocxDocumentModel, EmbeddedFontRef } from './types';
+
+// `loadEmbeddedFonts` maps `doc.embeddedFonts` → `EmbeddedFontFace[]` and calls
+// the real core `registerEmbeddedFonts`. We stub the global FontFace +
+// FontFaceSet so the faces the mapper produces surface as `added` entries on a
+// fake set — asserting the derived family / weight / style / odttf-plaintext,
+// exactly as core's own embedded.test.ts does.
+
+const G = globalThis as Record<string, unknown>;
+const ORIG = { document: G.document, self: G.self, FontFace: G.FontFace };
+
+afterEach(() => {
+  G.document = ORIG.document;
+  G.self = ORIG.self;
+  G.FontFace = ORIG.FontFace;
+  vi.restoreAllMocks();
+});
+
+interface FakeFace {
+  family: string;
+  source: ArrayBuffer;
+  descriptors?: { weight?: string; style?: string };
+  load: () => Promise<FakeFace>;
+}
+
+function installFontFaceSet() {
+  const added: FakeFace[] = [];
+  class FakeFontFace implements FakeFace {
+    family: string;
+    source: ArrayBuffer;
+    constructor(
+      family: string,
+      source: ArrayBuffer,
+      public descriptors?: { weight?: string; style?: string },
+    ) {
+      this.family = family;
+      this.source = source;
+    }
+    load(): Promise<FakeFace> {
+      return Promise.resolve(this);
+    }
+  }
+  const set = {
+    add: (f: FakeFace) => {
+      added.push(f);
+    },
+    ready: Promise.resolve(),
+  };
+  G.FontFace = FakeFontFace;
+  G.document = { fonts: set };
+  delete G.self;
+  return added;
+}
+
+// A minimal, valid sfnt header (TrueType 0x00010000) so `FontFace(source)`
+// would accept the bytes — mirrors core's `validHeader`.
+const validHeader = () =>
+  new Uint8Array([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0x01, 0x00, 0x00, 0x40, 0x00, 0x30,
+    0x47, 0x53, 0x55, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]);
+
+const GUID = '{3EEE3167-E5B8-4798-AE48-EA6B71E31D4D}';
+
+function modelWith(embeddedFonts?: EmbeddedFontRef[]): DocxDocumentModel {
+  const emptyHf = { default: null, first: null, even: null };
+  return {
+    section: {} as DocxDocumentModel['section'],
+    body: [],
+    headers: emptyHf,
+    footers: emptyHf,
+    embeddedFonts,
+  };
+}
+
+describe('loadEmbeddedFonts (ECMA-376 §17.8.1 / §17.8.3)', () => {
+  it('maps a 4-slot font to 4 faces with the correct weight/style descriptors', async () => {
+    const added = installFontFaceSet();
+    const refs: EmbeddedFontRef[] = [
+      { fontName: 'Ubuntu', style: 'regular', partPath: 'word/fonts/font1.odttf', fontKey: GUID },
+      { fontName: 'Ubuntu', style: 'bold', partPath: 'word/fonts/font2.odttf', fontKey: GUID },
+      { fontName: 'Ubuntu', style: 'italic', partPath: 'word/fonts/font3.odttf', fontKey: GUID },
+      { fontName: 'Ubuntu', style: 'boldItalic', partPath: 'word/fonts/font4.odttf', fontKey: GUID },
+    ];
+    // Every part is a valid header obfuscated with the GUID (so de-obfuscation
+    // yields a valid sfnt), keyed by path.
+    const bytesByPath = new Map(
+      refs.map((r) => [r.partPath, deobfuscateOdttf(validHeader(), GUID)]),
+    );
+    await loadEmbeddedFonts(modelWith(refs), async (p) => bytesByPath.get(p)!);
+
+    expect(added).toHaveLength(4);
+    expect(added.every((f) => f.family === 'Ubuntu')).toBe(true);
+    const byDesc = added.map((f) => `${f.descriptors?.weight}/${f.descriptors?.style}`).sort();
+    expect(byDesc).toEqual([
+      'bold/italic',
+      'bold/normal',
+      'normal/italic',
+      'normal/normal',
+    ]);
+  });
+
+  it('sets odttf=true for a .odttf part (bytes de-obfuscated to plaintext sfnt)', async () => {
+    const added = installFontFaceSet();
+    const refs: EmbeddedFontRef[] = [
+      { fontName: 'Ubuntu', style: 'regular', partPath: 'word/fonts/font1.ODTTF', fontKey: GUID },
+    ];
+    // Obfuscated on the wire; loadEmbeddedFonts must flag odttf (case-insensitive
+    // on the extension) so registerEmbeddedFonts de-obfuscates before FontFace.
+    await loadEmbeddedFonts(modelWith(refs), async () => deobfuscateOdttf(validHeader(), GUID));
+    expect(added).toHaveLength(1);
+    // The first 4 bytes are the plaintext sfnt tag after de-obfuscation.
+    expect(Array.from(new Uint8Array(added[0].source).slice(0, 4))).toEqual([
+      0x00, 0x01, 0x00, 0x00,
+    ]);
+  });
+
+  it('does not de-obfuscate a non-.odttf part (odttf=false)', async () => {
+    const added = installFontFaceSet();
+    const refs: EmbeddedFontRef[] = [
+      { fontName: 'Roboto', style: 'regular', partPath: 'word/fonts/font1.ttf', fontKey: '' },
+    ];
+    // A raw sfnt part: odttf must be false so the bytes reach FontFace verbatim.
+    await loadEmbeddedFonts(modelWith(refs), async () => validHeader());
+    expect(added).toHaveLength(1);
+    expect(Array.from(new Uint8Array(added[0].source).slice(0, 4))).toEqual([
+      0x00, 0x01, 0x00, 0x00,
+    ]);
+  });
+
+  it('skips a face whose fetch rejects, keeping the rest', async () => {
+    const added = installFontFaceSet();
+    const refs: EmbeddedFontRef[] = [
+      { fontName: 'Good', style: 'regular', partPath: 'word/fonts/good.ttf', fontKey: '' },
+      { fontName: 'Missing', style: 'regular', partPath: 'word/fonts/missing.ttf', fontKey: '' },
+    ];
+    await loadEmbeddedFonts(modelWith(refs), async (p) => {
+      if (p.endsWith('missing.ttf')) throw new Error('no such part');
+      return validHeader();
+    });
+    expect(added.map((f) => f.family)).toEqual(['Good']);
+  });
+
+  it('no-ops (no fetch) when embeddedFonts is empty or undefined', async () => {
+    installFontFaceSet();
+    const fetchSpy = vi.fn(async () => validHeader());
+
+    await loadEmbeddedFonts(modelWith([]), fetchSpy);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    await loadEmbeddedFonts(modelWith(undefined), fetchSpy);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docx/src/embedded-fonts.ts
+++ b/packages/docx/src/embedded-fonts.ts
@@ -1,0 +1,60 @@
+import { registerEmbeddedFonts, type EmbeddedFontFace } from '@silurus/ooxml-core';
+import type { DocxDocumentModel, EmbeddedFontRef } from './types';
+
+/**
+ * Register a document's embedded fonts (ECMA-376 §17.8.3.3-.6) into the active
+ * FontFaceSet so the renderer measures and paints text with the authored
+ * typeface instead of a substitute.
+ *
+ * `doc.embeddedFonts` names the obfuscated `.odttf` parts + their `w:fontKey`
+ * GUIDs; the bytes are fetched by zip path through `fetchFontBytes` (the docx
+ * archive extracts any part, not just images), de-obfuscated per §17.8.1 by
+ * {@link registerEmbeddedFonts}, and added to the set under the exact document
+ * font name. Each `<w:embed*>` style slot becomes one CSS weight/style pair:
+ * bold / boldItalic ⇒ `weight: 'bold'`; italic / boldItalic ⇒ `style: 'italic'`.
+ *
+ * MUST run before pagination (which measures text). No-ops when the document
+ * embeds no fonts. Individual part fetches are concurrent; a rejected fetch
+ * skips only that face (the rest still register) so one missing part never
+ * aborts the whole document.
+ */
+export async function loadEmbeddedFonts(
+  doc: DocxDocumentModel,
+  fetchFontBytes: (partPath: string) => Promise<Uint8Array>,
+): Promise<void> {
+  const refs = doc.embeddedFonts;
+  if (!refs || refs.length === 0) return;
+
+  const faces = await Promise.all(
+    refs.map(async (ref): Promise<EmbeddedFontFace | null> => {
+      try {
+        const bytes = await fetchFontBytes(ref.partPath);
+        return {
+          family: ref.fontName,
+          bytes,
+          odttf: ref.partPath.toLowerCase().endsWith('.odttf'),
+          fontKey: ref.fontKey,
+          weight: weightForStyle(ref.style),
+          style: styleForStyle(ref.style),
+        };
+      } catch {
+        // A missing / unreadable part: skip this face, keep the rest.
+        return null;
+      }
+    }),
+  );
+
+  const loadable = faces.filter((f): f is EmbeddedFontFace => f !== null);
+  if (loadable.length === 0) return;
+  await registerEmbeddedFonts(loadable);
+}
+
+/** bold / boldItalic slots ⇒ CSS `font-weight: bold`; otherwise `normal`. */
+function weightForStyle(style: EmbeddedFontRef['style']): 'normal' | 'bold' {
+  return style === 'bold' || style === 'boldItalic' ? 'bold' : 'normal';
+}
+
+/** italic / boldItalic slots ⇒ CSS `font-style: italic`; otherwise `normal`. */
+function styleForStyle(style: EmbeddedFontRef['style']): 'normal' | 'italic' {
+  return style === 'italic' || style === 'boldItalic' ? 'italic' : 'normal';
+}

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -12,6 +12,9 @@ export { noteText } from './types';
 export type {
   DocxDocumentModel,
   DocSettings,
+  // Embedded-font reference (reachable via DocxDocumentModel.embeddedFonts,
+  // ECMA-376 §17.8.3.3-.6). The viewer de-obfuscates + registers these.
+  EmbeddedFontRef,
   SectionProps,
   // Per-section page geometry (reachable via the BodyElement sectionBreak arm's
   // `geom` and PaginatedBodyElement's `sectionGeom`, ECMA-376 §17.6.13/§17.6.11).

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -12,6 +12,7 @@ import { decodeDataUrl, preloadGoogleFonts } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
 import { paginateDocument, renderDocumentToCanvas } from './renderer';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
+import { loadEmbeddedFonts } from './embedded-fonts';
 import type { RenderWorkerRequest, RenderWorkerResponse, DocumentMeta } from './worker-protocol';
 
 let initPromise: Promise<unknown> | null = null;
@@ -89,6 +90,15 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
           docxFontPreloadNames(doc),
           DOCX_GOOGLE_FONTS,
         );
+      }
+      // ECMA-376 §17.8.1 / §17.8.3 — register embedded fonts into the worker's
+      // FontFaceSet (self.fonts) before pagination measures text. Bytes are read
+      // straight from the retained archive (extract_image reads any zip entry).
+      if (doc.embeddedFonts?.length) {
+        await loadEmbeddedFonts(doc, async (p) => {
+          if (!archive) throw new Error('No docx loaded');
+          return new Uint8Array(archive.extract_image(p)).slice();
+        });
       }
       pages = paginateDocument(doc);
       // ECMA-376 §17.6.13 / §17.6.11 — per-page size from each page's first

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -20,6 +20,11 @@ export interface DocxDocumentModel {
    * entry is absent or classified as "auto".
    */
   fontFamilyClasses?: Record<string, string>;
+  /** ECMA-376 §17.8.3.3-.6 — embedded fonts from `word/fontTable.xml`, resolved
+   *  to their `.odttf` part paths + fontKey. The viewer de-obfuscates (§17.8.1)
+   *  and registers each as a FontFace before pagination so text measures/draws
+   *  with the authored typeface. */
+  embeddedFonts?: EmbeddedFontRef[];
   /** ECMA-376 §17.13.5 — flat list of `<w:ins>` / `<w:del>` events in the
    *  body. Each entry carries author / date / text. The renderer marks
    *  runs inline via {@link DocxTextRun.revision}; this array is primarily for
@@ -39,6 +44,15 @@ export interface DocxDocumentModel {
    *  (kinsoku) configuration. Absent when settings.xml has no relevant
    *  elements (the renderer then uses spec defaults: kinsoku ON). */
   settings?: DocSettings;
+}
+
+/** ECMA-376 §17.8.3.3-.6 — one embedded font-style slot from
+ *  `word/fontTable.xml`, resolved to its obfuscated part path + fontKey. */
+export interface EmbeddedFontRef {
+  fontName: string;
+  style: 'regular' | 'bold' | 'italic' | 'boldItalic';
+  partPath: string;
+  fontKey: string;
 }
 
 export interface DocSettings {


### PR DESCRIPTION
## Summary
XF14: documents with embedded fonts now render with the real embedded faces instead of substitutes. docx ships end-to-end (ODTTF de-obfuscation per §17.8.1 + FontFace registration in both main and worker modes); the shared core layer is pptx-ready, with the pptx parser wiring deferred until an embedded-font .pptx fixture exists.

## Changes (3 commits)
- **core** (`0a35862`): `packages/core/src/fonts/embedded.ts` — `deobfuscateOdttf` (§17.8.1: reverse the 16-byte fontKey GUID, XOR bytes 0–15/16–31) + `registerEmbeddedFonts` (FontFaceSet-agnostic, per-face size cap, corrupt faces skipped with a single warn). `preload.ts` refactored to share `activeFontSet`/`withFontCeiling`.
- **docx parser** (`c7c3d17`): `parse_embedded_fonts` reads `<w:embedRegular/Bold/Italic/BoldItalic>` (§17.8.3.3–.6) from fontTable, resolves r:id via fontTable rels, captures fontKey; surfaces `Document.embeddedFonts`. Font bytes stay lazy.
- **docx TS** (`5a7fbf7`): `loadEmbeddedFonts` before pagination in both modes (main → `document.fonts`, worker → `self.fonts`).

## Verification
- Real fixture: `private/sample-11.docx` embeds 6 ODTTF fonts (Ubuntu ×4, Tahoma, Ubuntu Mono). End-to-end: parse → part+fontKey → de-obfuscate → sfnt magic `00 01 00 00`. Unit tests at both layers (involution round-trip, real header slice, GUID brace variants, short-buffer, malformed-key, mutation-safety; parser: 4-slot mapping, case-insensitive detection, fetch-rejection isolation).
- No renderer change needed: `normalizeFontFamily` already leads every chain with the exact document family name, so a registered face wins over substitutes (verified incl. the Arabic path).
- **No committed reference changes** (demo/sample-1 has no embedded fonts → early return → byte-identical). Local private sample-11 reference would change (real fonts) — reported, not touched.
- Gates: cargo fmt/clippy(-D warnings)/test 220 (+6); vitest docx+core 1496, pptx+xlsx 595; tsc core/docx/node/markdown clean.

## Follow-up
pptx `p:embeddedFontLst` wiring (parser + TS analogous to docx; core already handles raw sfnt/EOT via `odttf:false`) — needs a user-provided embedded-font .pptx to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)