### PR TITLE
fix(docx): return null instead of throwing when a blip has no drawable output

### DIFF
--- a/packages/docx/src/renderer.null-image.test.ts
+++ b/packages/docx/src/renderer.null-image.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock ONLY core's path-keyed bitmap cache so it resolves to `null` — the
+// legitimate "no drawable output" a true EMF or geometry-less metafile produces
+// (see core getCachedBitmapByPath's contract). Everything else in core is the
+// real module (importOriginal). This file is deliberately separate from
+// renderer.image.test.ts, which needs the REAL cache to count fetch/decode
+// calls; a hoisted vi.mock is file-scoped, so keeping the two suites apart lets
+// each see the core it needs.
+vi.mock('@silurus/ooxml-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@silurus/ooxml-core')>();
+  return {
+    ...actual,
+    getCachedBitmapByPath: vi.fn(async () => null),
+  };
+});
+
+import { preloadImages, renderDocumentToCanvas } from './renderer';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  ImageRun,
+  SectionProps,
+} from './types';
+
+/**
+ * A raster/metafile blip can legitimately produce NO drawable output — a true
+ * EMF, or a WMF with no geometry — in which case core's shared
+ * `getCachedBitmapByPath` resolves to `null` (not an error). docx must treat
+ * that as "missing image": drop it from the preloaded map and skip it at every
+ * draw site, exactly like pptx's `if (!bitmap) return` and xlsx's falsy-skip.
+ * The whole page/document render must NOT throw.
+ *
+ * These tests pin that contract at two levels:
+ *   1. `preloadImages` returns a map that simply OMITS the undrawable blip
+ *      (never throws / rejects, never stores an `undefined` value).
+ *   2. `renderDocumentToCanvas` renders a page whose only picture is undrawable
+ *      without throwing, and without emitting a `drawImage` for the missing
+ *      bitmap.
+ */
+
+const fetchImage = vi.fn(
+  async (_path: string, mime: string) => new Blob([new Uint8Array([1, 2, 3])], { type: mime }),
+);
+
+function imageRun(imagePath: string, extra: Partial<ImageRun> = {}): ImageRun {
+  return {
+    type: 'image',
+    imagePath,
+    mimeType: 'image/emf', // sniffed to a true EMF upstream → null base bitmap
+    widthPt: 40,
+    heightPt: 30,
+    // inline (wp:inline): flows with text and reaches renderInlineImage's draw
+    anchor: false,
+  } as unknown as ImageRun;
+}
+
+function imageDoc(runs: ImageRun[]): DocxDocumentModel {
+  const para: DocParagraph = {
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: runs as unknown as DocParagraph['runs'],
+    defaultFontSize: 16, defaultFontFamily: 'Arial',
+    widowControl: false,
+  };
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'paragraph', ...para } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { Arial: 'swiss' },
+  } as unknown as DocxDocumentModel;
+}
+
+/** Recording 2D context that spies on drawImage; mirrors run-inline-formatting's
+ *  makeRecordingCanvas (synthetic 0.8/0.2-em metrics, charCount × fontPx advance). */
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  drawImageCount: () => number;
+} {
+  let font = '16px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '16');
+  let drawImageCalls = 0;
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, setLineDash() {}, clearRect() {}, fillRect() {}, strokeRect() {},
+    arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    fillText() {}, strokeText() {},
+    drawImage() { drawImageCalls++; },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, drawImageCount: () => drawImageCalls };
+}
+
+describe('docx undrawable blip (null base bitmap) is skipped, never crashes', () => {
+  beforeEach(() => {
+    // createImageBitmap is absent in the node test env; a sentinel is enough for
+    // any path that DID decode (none should, since the cache returns null).
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 2, height: 2, close: () => {} }) as unknown as ImageBitmap),
+    );
+    fetchImage.mockClear();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('preloadImages omits a blip whose base bitmap decodes to null (no throw, no undefined value)', async () => {
+    const doc = imageDoc([imageRun('word/media/image1.emf')]);
+    // Must resolve — never reject — even though the only image is undrawable.
+    const map = await preloadImages(doc, fetchImage);
+    expect(map.has('word/media/image1.emf')).toBe(false);
+    expect(map.size).toBe(0);
+    // The map never stores an undefined/null value under any key.
+    for (const v of map.values()) expect(v).toBeTruthy();
+  });
+
+  it('preloadImages drops every undrawable blip and still resolves to a well-formed (empty) map', async () => {
+    // With the cache stubbed to null for ALL paths, every image drops; the point
+    // is the map is well-formed (empty) and the call resolved rather than rejected.
+    const doc = imageDoc([
+      imageRun('word/media/image1.emf'),
+      imageRun('word/media/image2.emf'),
+    ]);
+    const map = await preloadImages(doc, fetchImage);
+    expect(map.size).toBe(0);
+  });
+
+  it('renderDocumentToCanvas renders a page whose only picture is undrawable without throwing (and draws no image)', async () => {
+    const { canvas, drawImageCount } = makeRecordingCanvas();
+    const doc = imageDoc([imageRun('word/media/image1.emf')]);
+    await expect(
+      renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: 400, fetchImage }),
+    ).resolves.toBeUndefined();
+    // The missing bitmap must not reach the draw path.
+    expect(drawImageCount()).toBe(0);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -611,8 +611,12 @@ async function applyColorReplacement(bmp: ImageBitmap, colorHex: string): Promis
  *     unreliable — sample-10's chart is a standard WMF mislabeled `.emf`),
  *     rasterizing a WMF via the minimal player at a size from `widthPt`/`heightPt`,
  *     returning `null` for a true EMF (or a geometry-less metafile), else
- *     `createImageBitmap`. A `null` throws so `preloadImages` drops the image
- *     (the existing "missing image" behavior, no crash).
+ *     `createImageBitmap`. That `null` is a LEGITIMATE "no drawable output" (not
+ *     an error), so we propagate it as `null` and `preloadImages` drops the image
+ *     — the existing "missing image" behavior, no crash. (A *transient* fetch/
+ *     decode failure still rejects; `preloadImages`' per-image catch absorbs that
+ *     too.) Every draw site null-checks the map lookup, matching pptx's
+ *     `if (!bitmap) return` and xlsx's "skip if falsy" draw guards.
  *  2. when a clrChange is requested, the make-transparent result is memoized per
  *     (imagePath, colorReplaceFrom) in {@link colorReplacedCacheFor} so the
  *     expensive getImageData/putImageData pass runs once per document.
@@ -631,14 +635,19 @@ export async function decodeRaster(
   fetchImage: (path: string, mime: string) => Promise<Blob>,
   widthPt = 0,
   heightPt = 0,
-): Promise<ImageBitmap> {
+): Promise<ImageBitmap | null> {
   // Base bitmap (no colour replacement): shared, path-keyed, per-document cache.
   const base = await getCachedBitmapByPath(imagePath, mimeType, fetchImage, {
     widthPt,
     heightPt,
     suppressBoundaryFrame: true,
   });
-  if (!base) throw new Error(`${imagePath} produced no drawable output`);
+  // A `null` base is a legitimate "no drawable output" (a true EMF or a
+  // geometry-less metafile), NOT an error: propagate it so `preloadImages`
+  // drops the image and every draw site skips it via its null-check. We return
+  // null rather than throw so this expected outcome never travels the exception
+  // path (a transient fetch/decode failure still rejects and is caught upstream).
+  if (!base) return null;
   if (!colorReplaceFrom) return base;
   // Second layer: memoize the make-transparent result per (path, colour). The
   // recolor reads the SHARED base bitmap and produces a fresh independent raster,
@@ -683,7 +692,11 @@ export async function preloadImages(
       // undefined case). When true, `blip.svgImagePath` is narrowed to string.
       const blip = { svgImagePath: pair.svgImagePath, srcRect: pair.hasCrop || null };
       try {
-        let img: DecodedImage;
+        // `decodeRaster` may resolve to `null` for a legitimately undrawable
+        // metafile (true EMF / geometry-less WMF). That is not an error, so it
+        // does not travel the `catch` below — we detect it explicitly and drop
+        // the map entry, exactly as the caught (transient-failure) path does.
+        let img: DecodedImage | null;
         if (preferVectorBlip(blip)) {
           // Prefer the vector original (Microsoft `asvg:svgBlip` extension);
           // fall back to the raster on any SVG decode failure. With an
@@ -705,6 +718,8 @@ export async function preloadImages(
         } else {
           img = await decodeRaster(pair.imagePath, pair.mimeType, pair.colorReplaceFrom, fetch, pair.widthPt, pair.heightPt);
         }
+        // Undrawable metafile → drop the entry (draw sites skip a missing key).
+        if (!img) return null;
         return [imageKey(pair.imagePath, pair.colorReplaceFrom), img];
       } catch {
         return null;


### PR DESCRIPTION
## Summary
`decodeRaster` conflated core's two `getCachedBitmapByPath` outcomes: a legitimate `null` (a true EMF or geometry-less metafile — "no drawable output", not an error) and a transient fetch/decode rejection. It turned the null into a `throw`, forcing an expected result onto the exception path where it was only incidentally absorbed by `preloadImages`' per-image try/catch.

## Investigation result
No real crash path existed: the throw was fully absorbed, `preloadImages` never rejects, and all five draw sites already null-check their map lookups. The change aligns the design with pptx (`if (!bitmap) return`) and xlsx (skip-if-falsy) rather than relying on incidental exception absorption.

## Change
- `decodeRaster` returns `Promise<ImageBitmap | null>`; null propagates explicitly and `preloadImages` drops the entry (same as a caught rejection). Transient failures still reject and are still caught.
- New `renderer.null-image.test.ts` (3 tests): with core's cache stubbed to null, `preloadImages` resolves to a well-formed map and `renderDocumentToCanvas` renders without throwing and without drawing the missing bitmap.

## Gates
vitest docx 598 pass (+3); docx tsc clean; docx VRT 21 pass, no diff increase; references untouched.

Found during XF13 (EMF player) work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)