### PR TITLE
feat(charts): boxWhisker + sunburst chartEx renderers (CH15)

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2427,6 +2427,39 @@ describe('CH15 — chartEx box-and-whisker', () => {
     }), RECT, 1);
     expect(rec.fillRects.length).toBe(6);
   });
+
+  it('sizes the title from titleFontSizeHpt (chartStyle part) rather than an area-proportional guess', () => {
+    // With titleFontSizeHpt=1400 (14pt, Word's default modern chartStyle) at
+    // scale 1 the title renders at 14px — far below the Math.max(10, h*0.085) ≈
+    // 30.6px the fallback would produce for this 360px-tall rect. Capture the
+    // font active at each fillText so we can read the title's px size.
+    const drawn: Array<{ text: string; px: number }> = [];
+    const state: Record<string, unknown> = {
+      font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+      textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+    };
+    const px = (font: string): number => {
+      const m = /(\d+(?:\.\d+)?)px/.exec(font);
+      return m ? parseFloat(m[1]) : 10;
+    };
+    const ctx = new Proxy(state, {
+      get(_t, prop: string) {
+        if (prop in state && typeof state[prop] !== 'function') return state[prop];
+        if (prop === 'measureText') return (t: string) => ({ width: String(t).length * px(String(state.font)) * 0.6 });
+        if (prop === 'fillText') return (text: string) => { drawn.push({ text, px: px(String(state.font)) }); };
+        if (prop === 'createLinearGradient' || prop === 'createRadialGradient') return () => ({ addColorStop() {} });
+        return () => undefined;
+      },
+      set(_t, prop: string, value) { state[prop] = value; return true; },
+    }) as unknown as CanvasRenderingContext2D;
+
+    renderChart(ctx, boxModel({ title: 'the box title', titleFontSizeHpt: 1400 }), RECT, 1);
+    const titleDraw = drawn.find(d => d.text === 'the box title');
+    expect(titleDraw).toBeDefined();
+    // 1400 hpt → 14pt → 14px at scale 1. Assert it honored the size (14, not the
+    // ~30.6px area-proportional fallback).
+    expect(titleDraw?.px).toBeCloseTo(14, 5);
+  });
 });
 
 // CH15 — chartEx sunburst (MS 2014 chartex ext). Verify the hierarchy folds

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2428,6 +2428,22 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(rec.fillRects.length).toBe(6);
   });
 
+  it('strokes the box outline (median / whisker / mean ×) in the series accent × lumMod 80%', () => {
+    // PowerPoint's default modern chart style darkens a boxWhisker series'
+    // outline to its accent × 0.8 (`<cs:dataPoint>` line phClr + one variation
+    // step). sample-24 p.2's accent2 fill ED7D31 → outline BE6427 (pixel-
+    // verified). Assert every accent-derived stroke segment uses that color and
+    // that the plain fill accent (#ed7d31) is NOT used for any stroke.
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, boxModel(), RECT, 1);
+    const accentSegs = rec.segs.filter(s => s.ss.toLowerCase() === '#be6427');
+    // median + two whisker stems + two whisker caps + mean × (2 strokes) = ≥5
+    // accent-colored segments (gridlines/axis use gray, not the accent).
+    expect(accentSegs.length).toBeGreaterThanOrEqual(5);
+    // The un-darkened fill accent must never be a stroke color.
+    expect(rec.segs.some(s => s.ss.toLowerCase() === '#ed7d31')).toBe(false);
+  });
+
   it('sizes the title from titleFontSizeHpt (chartStyle part) rather than an area-proportional guess', () => {
     // With titleFontSizeHpt=1400 (14pt, Word's default modern chartStyle) at
     // scale 1 the title renders at 14px — far below the Math.max(10, h*0.085) ≈

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2338,3 +2338,93 @@ describe('CH14 — pie callout data labels', () => {
     expect(rec.rects.filter(r => r.fs === '#FFFFFF').length).toBe(0);
   });
 });
+
+// CH15 — chartEx box-and-whisker (MS 2014 chartex ext). Verify the derived
+// statistics (exclusive quartiles + 1.5·IQR outlier fence + mean) and the
+// value-axis scale drive observable geometry: the IQR box rects, the outlier
+// dots, and the nice-rounded axis labels.
+describe('CH15 — chartEx box-and-whisker', () => {
+  // The sample-24 Category-1 orange series: an obvious outlier at 128 sits far
+  // beyond Q3 + 1.5·IQR, so the whisker stops at 34 and 128 is drawn as a dot.
+  const CAT1_ORANGE = [-3, 1, -6, 10, 34, 128, 22, -12, -28];
+
+  function boxModel(over: Partial<ChartModel> = {}): ChartModel {
+    return baseModel({
+      chartType: 'boxWhisker',
+      title: 'box',
+      chartexAccents: ['5B9BD5', 'ED7D31', 'A5A5A5', 'FFC000', '4472C4', '70AD47'],
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [
+          {
+            name: 'S1',
+            color: 'ED7D31',
+            valuesByCategory: [CAT1_ORANGE],
+            meanMarker: true,
+            meanLine: false,
+            showOutliers: true,
+            showNonoutliers: false,
+            quartileMethod: 'exclusive',
+          },
+        ],
+      },
+      ...over,
+    });
+  }
+
+  it('labels the value axis with Excel nice-rounded gridline values including a negative bound', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel(), RECT, 1);
+    const labels = rec.texts.map(t => t.text);
+    // The data spans −28..128, so the auto axis must reach BELOW zero (a
+    // negative label) and ABOVE the max (a label ≥ 128's rounded ceiling),
+    // and cross zero. Exact bounds depend on the axis length, so assert the
+    // scale SHAPE rather than pinned numbers.
+    expect(labels).toContain('0');
+    expect(labels.some(l => l.startsWith('-'))).toBe(true);
+    expect(labels.some(l => Number(l) >= 130)).toBe(true);
+  });
+
+  it('draws exactly one IQR box rect and one outlier dot for a single box with one outlier', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel(), RECT, 1);
+    // Exactly one filled IQR rect (Q1..Q3) for the single box.
+    expect(rec.fillRects.length).toBe(1);
+    // The 128 point is the sole outlier → one dot (arc). The box-and-whisker
+    // renderer draws arcs ONLY for outliers (the mean `×` and whiskers are line
+    // segments), so the arc count equals the outlier count.
+    expect(rec.arcs.length).toBe(1);
+    // The outlier dot sits ABOVE the box top (smaller y = higher value).
+    const box = rec.fillRects[0];
+    expect(rec.arcs[0].y).toBeLessThan(box.y);
+  });
+
+  it('suppresses outlier dots when <cx:visibility outliers="0">', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [{
+          name: 'S1', color: 'ED7D31', valuesByCategory: [CAT1_ORANGE],
+          meanMarker: true, meanLine: false, showOutliers: false, showNonoutliers: false,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 1);
+    expect(rec.arcs.length).toBe(0);
+  });
+
+  it('draws one IQR box per (category, series) — 3 categories × 2 series = 6 boxes', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['A', 'B', 'C'],
+        series: [
+          { name: 'S1', color: '5B9BD5', valuesByCategory: [[1, 2, 3], [4, 5, 6], [7, 8, 9]], meanMarker: true, meanLine: false, showOutliers: true, showNonoutliers: false, quartileMethod: 'exclusive' },
+          { name: 'S2', color: 'ED7D31', valuesByCategory: [[2, 3, 4], [5, 6, 7], [8, 9, 10]], meanMarker: true, meanLine: false, showOutliers: true, showNonoutliers: false, quartileMethod: 'exclusive' },
+        ],
+      },
+    }), RECT, 1);
+    expect(rec.fillRects.length).toBe(6);
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2428,3 +2428,73 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(rec.fillRects.length).toBe(6);
   });
 });
+
+// CH15 — chartEx sunburst (MS 2014 chartex ext). Verify the hierarchy folds
+// into concentric rings, each branch's sub-tree shares its accent color, and
+// angular spans are size-proportional.
+describe('CH15 — chartEx sunburst', () => {
+  // Two branches, each with two stems, each stem with one leaf. Branch A is
+  // twice the total of Branch B (so it must sweep twice the angle).
+  function sunburstModel(over: Partial<ChartModel> = {}): ChartModel {
+    return baseModel({
+      chartType: 'sunburst',
+      title: 'sun',
+      chartexAccents: ['5B9BD5', 'ED7D31', 'A5A5A5', 'FFC000', '4472C4', '70AD47'],
+      chartexSunburst: {
+        rows: [
+          { path: ['Branch A', 'Stem 1', 'Leaf 1'], size: 30 },
+          { path: ['Branch A', 'Stem 2', 'Leaf 2'], size: 30 },
+          { path: ['Branch B', 'Stem 3', 'Leaf 3'], size: 15 },
+          { path: ['Branch B', 'Stem 4', 'Leaf 4'], size: 15 },
+        ],
+      },
+      ...over,
+    });
+  }
+
+  it('draws three concentric rings (Branch / Stem / Leaf) with distinct radii', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel(), RECT, 1);
+    // Each ring segment emits an outer + inner arc; across all segments the
+    // distinct radii cluster into 3 outer + 3 inner boundaries → at least 3
+    // distinct radius bands (inner hole excluded).
+    const radii = [...new Set(rec.arcs.map(a => Math.round(a.r)))].sort((a, b) => a - b);
+    // 4 radius boundaries: hole, branch/stem, stem/leaf, outer.
+    expect(radii.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('colors every node in a branch with that branch\'s accent (branch A=accent1, B=accent2)', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel(), RECT, 1);
+    // Segment fills (excluding the white label fills). Branch A subtree (root +
+    // 2 stems + 2 leaves = 5 nodes) all accent1; Branch B (5 nodes) all accent2.
+    const segFills = rec.fills.filter(f => f !== '#ffffff' && f !== '#000');
+    const a1 = segFills.filter(f => f === '#5B9BD5').length;
+    const a2 = segFills.filter(f => f === '#ED7D31').length;
+    expect(a1).toBe(5);
+    expect(a2).toBe(5);
+  });
+
+  it('draws white segment labels for the branch/stem/leaf names', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel(), RECT, 1);
+    const whiteLabels = rec.fontTexts.filter(t => t.fill === '#ffffff').map(t => t.text);
+    // Labels are word-wrapped, so assert on the first word of each name.
+    expect(whiteLabels.some(t => t.includes('Branch'))).toBe(true);
+    expect(whiteLabels.some(t => t.includes('Stem'))).toBe(true);
+    expect(whiteLabels.some(t => t.includes('Leaf'))).toBe(true);
+  });
+
+  it('sweeps each branch proportional to its aggregated size (Branch A twice Branch B)', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel(), RECT, 1);
+    // The innermost ring (smallest non-hole outer radius) carries the two branch
+    // segments. Each segment's outer arc sweep = a1 − a0. Branch A (size 60) must
+    // sweep ~2× Branch B (size 30).
+    const innerOuterR = [...new Set(rec.arcs.map(a => Math.round(a.r)))].sort((a, b) => a - b)[1];
+    const branchArcs = rec.arcs.filter(a => Math.round(a.r) === innerOuterR && !a.ccw);
+    const sweeps = branchArcs.map(a => Math.abs(a.a1 - a.a0)).sort((x, y) => y - x);
+    expect(sweeps.length).toBeGreaterThanOrEqual(2);
+    expect(sweeps[0] / sweeps[1]).toBeCloseTo(2, 1);
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -39,6 +39,29 @@ function pieSliceColor(idx: number, series: ChartSeries): string {
   return `#${CHART_PALETTE[idx % CHART_PALETTE.length]}`;
 }
 
+/**
+ * Scale a `#rrggbb` hex color's channels by `factor` (clamped 0..1), returning a
+ * new `#rrggbb`. Used for the box-and-whisker outline: PowerPoint's default
+ * modern chart style colors a boxWhisker series' outline (box edge / median /
+ * whisker / mean marker) at the series accent darkened by `lumMod 80%` (its
+ * `<cs:dataPoint>` line rides `phClr` and the style darkens it one variation
+ * step). Measured on sample-24.pdf p.2 the accent2 orange fill `ED7D31`
+ * darkens to `BE6427`, which is exactly a linear ×0.8 of each RGB channel
+ * (`lumMod` on a fully-saturated accent reduces to an RGB scale here), so a
+ * straight channel multiply reproduces Word's rendering. `#` prefix optional on
+ * input; always present on output.
+ */
+function scaleHexRgb(hex: string, factor: number): string {
+  const h = hex.startsWith('#') ? hex.slice(1) : hex;
+  if (h.length < 6) return `#${h}`;
+  const f = Math.max(0, Math.min(1, factor));
+  const r = Math.round(parseInt(h.slice(0, 2), 16) * f);
+  const g = Math.round(parseInt(h.slice(2, 4), 16) * f);
+  const b = Math.round(parseInt(h.slice(4, 6), 16) * f);
+  const to2 = (n: number): string => n.toString(16).padStart(2, '0');
+  return `#${to2(r)}${to2(g)}${to2(b)}`;
+}
+
 // ─── Font-face resolution (CH10) ─────────────────────────────────────────────
 // Chart text elements draw with, in priority order: the element's own
 // `<a:latin typeface>` (from its `<c:txPr>`), else the theme font-scheme face
@@ -4066,7 +4089,10 @@ interface BoxStats {
   whiskerHi: number;
   mean: number;
   outliers: number[];
-  /** Interior (non-outlier) points, for the optional inner-point dots. */
+  /** Interior (non-outlier) points. Kept alongside the outliers so the optional
+   *  interior-dot overlay (`ChartexBoxSeries.showNonoutliers`) has its data
+   *  ready; that overlay is not drawn yet (flag parsed; interior-dot rendering
+   *  pending a fixture that enables it — sample-24 ships `nonoutliers="0"`). */
   inner: number[];
 }
 
@@ -4223,10 +4249,15 @@ function renderBoxWhiskerChart(ctx: CanvasRenderingContext2D, chart: ChartModel,
     const fill = box.series[si].color ?? accent ?? CHART_PALETTE[si % CHART_PALETTE.length];
     return `#${fill}`;
   };
-  // A darker edge for the box border / median / whisker: reuse the fill so the
-  // outline reads as the same accent (Office draws box outlines in the series
-  // color at full strength over a lighter fill). We fill solid and stroke in a
-  // slightly darkened variant for legibility.
+  // Outline color for the box edge / median / whisker / mean marker: the series
+  // accent darkened by `lumMod 80%` — PowerPoint's default modern chart style
+  // (`<cs:dataPoint>` line = `phClr` + one variation step). On sample-24 p.2 the
+  // accent2 fill `ED7D31` darkens to `BE6427` (pixel-verified), which equals a
+  // linear RGB ×0.8, so `scaleHexRgb(fill, 0.8)` reproduces Word's outline. (The
+  // full style part isn't resolved here beyond the title size — this 80% is the
+  // documented boxWhisker constant; if a chart ever overrides the dataPoint line
+  // via `<cx:spPr>` that would need reading, none of the CH15 fixtures do.)
+  const LUM_MOD_80 = 0.8;
 
   const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
   for (let ci = 0; ci < nCat; ci++) {
@@ -4238,6 +4269,7 @@ function renderBoxWhiskerChart(ctx: CanvasRenderingContext2D, chart: ChartModel,
       const bx = slotLeft + si * (boxW + boxGutter);
       const cx = bx + boxW / 2;
       const fill = paletteOf(si);
+      const edge = scaleHexRgb(fill, LUM_MOD_80);
       const yQ1 = yOf(stats.q1);
       const yQ3 = yOf(stats.q3);
       const boxTop = Math.min(yQ1, yQ3);
@@ -4245,7 +4277,7 @@ function renderBoxWhiskerChart(ctx: CanvasRenderingContext2D, chart: ChartModel,
 
       // Whiskers: vertical line from box edges to whisker ends, with end caps.
       const capW = boxW * 0.4;
-      ctx.strokeStyle = fill;
+      ctx.strokeStyle = edge;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.moveTo(cx, yOf(stats.whiskerHi)); ctx.lineTo(cx, yQ3);
@@ -4254,24 +4286,24 @@ function renderBoxWhiskerChart(ctx: CanvasRenderingContext2D, chart: ChartModel,
       ctx.moveTo(cx - capW / 2, yOf(stats.whiskerLo)); ctx.lineTo(cx + capW / 2, yOf(stats.whiskerLo));
       ctx.stroke();
 
-      // IQR box: solid accent fill + a thin darker edge.
+      // IQR box: solid accent fill + a thin accent×0.8 edge.
       ctx.fillStyle = fill;
       ctx.fillRect(bx, boxTop, boxW, boxH);
-      ctx.strokeStyle = '#404040';
+      ctx.strokeStyle = edge;
       ctx.lineWidth = 0.75;
       ctx.strokeRect(bx + 0.375, boxTop + 0.375, boxW - 0.75, boxH - 0.75);
 
       // Median line across the box.
       const yMed = yOf(stats.median);
-      ctx.strokeStyle = '#404040';
+      ctx.strokeStyle = edge;
       ctx.lineWidth = 1;
       ctx.beginPath(); ctx.moveTo(bx, yMed); ctx.lineTo(bx + boxW, yMed); ctx.stroke();
 
-      // Mean `×` marker.
+      // Mean `×` marker (same accent×0.8 as the rest of the outline).
       if (s.meanMarker) {
         const mY = yOf(stats.mean);
         const mR = Math.max(2, boxW * 0.14);
-        ctx.strokeStyle = '#595959';
+        ctx.strokeStyle = edge;
         ctx.lineWidth = 1;
         ctx.beginPath();
         ctx.moveTo(cx - mR, mY - mR); ctx.lineTo(cx + mR, mY + mR);

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -4054,6 +4054,256 @@ function renderWaterfallChart(ctx: CanvasRenderingContext2D, chart: ChartModel, 
   ctx.restore();
 }
 
+// ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
+
+/** Statistics of one box in a box-and-whisker plot. */
+interface BoxStats {
+  q1: number;
+  median: number;
+  q3: number;
+  /** Whisker ends = min/max of the NON-outlier points. */
+  whiskerLo: number;
+  whiskerHi: number;
+  mean: number;
+  outliers: number[];
+  /** Interior (non-outlier) points, for the optional inner-point dots. */
+  inner: number[];
+}
+
+/**
+ * Linear-interpolated quantile of `sorted` at probability `p` (0..1).
+ * `method === 'inclusive'` uses the R-7 / Excel `QUARTILE.INC` rank
+ * `p·(n−1)`; anything else uses the `exclusive` (R-6 / `QUARTILE.EXC`) rank
+ * `p·(n+1)` clamped into `[1, n]` — the box-and-whisker default Office writes
+ * (`<cx:statistics quartileMethod="exclusive">`).
+ */
+function boxQuantile(sorted: number[], p: number, method: string): number {
+  const n = sorted.length;
+  if (n === 0) return 0;
+  if (n === 1) return sorted[0];
+  let pos: number;
+  if (method === 'inclusive') {
+    pos = p * (n - 1) + 1; // 1-based rank
+  } else {
+    pos = p * (n + 1);
+    if (pos < 1) pos = 1;
+    if (pos > n) pos = n;
+  }
+  const lo = Math.floor(pos);
+  const frac = pos - lo;
+  if (lo >= n) return sorted[n - 1];
+  return sorted[lo - 1] + frac * (sorted[lo] - sorted[lo - 1]);
+}
+
+/**
+ * Compute the five-number summary + mean + outliers for one box, using the
+ * 1.5·IQR outlier fence (the Tukey rule Office applies; points beyond
+ * `Q1 − 1.5·IQR` / `Q3 + 1.5·IQR` are outliers and the whiskers stop at the
+ * most extreme non-outlier).
+ */
+function computeBoxStats(values: number[], method: string): BoxStats | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const q1 = boxQuantile(sorted, 0.25, method);
+  const median = boxQuantile(sorted, 0.5, method);
+  const q3 = boxQuantile(sorted, 0.75, method);
+  const iqr = q3 - q1;
+  const loFence = q1 - 1.5 * iqr;
+  const hiFence = q3 + 1.5 * iqr;
+  const inner: number[] = [];
+  const outliers: number[] = [];
+  for (const v of sorted) {
+    if (v < loFence || v > hiFence) outliers.push(v);
+    else inner.push(v);
+  }
+  const whiskerLo = inner.length ? inner[0] : sorted[0];
+  const whiskerHi = inner.length ? inner[inner.length - 1] : sorted[sorted.length - 1];
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  return { q1, median, q3, whiskerLo, whiskerHi, mean, outliers, inner };
+}
+
+/**
+ * Render a chartEx box-and-whisker chart (MS 2014 chartex extension — there is
+ * no ECMA-376 section; the structure is Microsoft's `<cx:chartSpace>` with a
+ * `<cx:series layoutId="boxWhisker">` per column, each referencing raw sample
+ * points via `<cx:dataId>`). The parser (`parse_chartex_boxwhisker`) groups the
+ * raw points by category and threads the `<cx:layoutPr>` visibility/statistics
+ * flags into `chart.chartexBox`; this renderer derives the five-number summary
+ * per (category, series) and draws, for each box: the IQR rectangle (Q1..Q3),
+ * the median line, whiskers to the non-outlier min/max (with end caps), the
+ * mean `×` marker, and outlier dots. Colors come from the theme accent palette
+ * (`chart.chartexAccents`, cycled by series) — the blue/orange/gray Office
+ * default — falling back to `CHART_PALETTE` when a resolver supplies no palette.
+ */
+function renderBoxWhiskerChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect, ptToPx: number): void {
+  const box = chart.chartexBox;
+  if (!box || box.categories.length === 0 || box.series.length === 0) return;
+  const { x, y, w, h } = r;
+
+  // Shared title band + cartesian plot rect. Reserve a category-label band at
+  // the bottom and a value-label gutter on the left; no legend (Office draws
+  // box-and-whisker without one by default).
+  const titleBand = cartesianTitleBand(chart, h, ptToPx);
+  const catAxFontPx0 = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  const valAxFontPx0 = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+  const pad = {
+    t: titleBand.bandH + valAxFontPx0 / 2 + 2,
+    r: w * 0.02,
+    b: (chart.catAxisHidden ? h * 0.02 : catAxisLabelBandH(catAxFontPx0)),
+    l: chart.valAxisHidden ? w * 0.02 : w * 0.1,
+  };
+  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
+    titleBand,
+    legendSideReserveFrac: 0,
+    pad,
+  });
+  drawChartTitle(ctx, chart, x, y + frame.title.topPad, w, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+
+  const cats = box.categories;
+  const nCat = cats.length;
+  const nSer = box.series.length;
+
+  // Value-axis extent across every sample point in every box.
+  let dataMin = Infinity;
+  let dataMax = -Infinity;
+  for (const s of box.series) {
+    for (const group of s.valuesByCategory) {
+      for (const v of group) {
+        if (v < dataMin) dataMin = v;
+        if (v > dataMax) dataMax = v;
+      }
+    }
+  }
+  if (!isFinite(dataMin) || !isFinite(dataMax)) return;
+  // Excel's auto value axis (nice-rounded min/max/step). For the sample data
+  // (−78..128) this yields −100..150 step 50, matching PowerPoint.
+  const { min: axisMin, max: axisMax, step } = valueAxisScale(
+    dataMin, dataMax, chart.valMin, chart.valMax, ph / ptToPx, chart.valAxisMajorUnit,
+  );
+  const span = axisMax - axisMin || 1;
+  const yOf = (v: number): number => py0 + ph * (1 - (v - axisMin) / span);
+
+  const font = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
+  const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
+
+  // Value-axis gridlines + labels (unless the value axis is hidden).
+  ctx.save();
+  if (!chart.valAxisHidden) {
+    ctx.font = `${valFontPx}px ${font}`;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (let v = axisMin; v <= axisMax + 1e-6; v += step) {
+      const gy = yOf(v);
+      ctx.strokeStyle = '#e6e6e6';
+      ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+      ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
+      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 4, gy);
+    }
+  }
+  // Category-axis baseline.
+  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
+    ctx.strokeStyle = '#bfbfbf';
+    ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
+  }
+
+  // Category slots; each slot holds `nSer` boxes side by side. `<cx:catScaling
+  // gapWidth>` widens the inter-category gap (parser normalizes the fraction to
+  // the legacy percent, default 150%). The boxes fill the slot minus that gap,
+  // split evenly with a thin inter-box gutter.
+  const slotW = pw / nCat;
+  const gapWidthPct = chart.barGapWidth ?? 150;
+  const groupW = slotW / (1 + gapWidthPct / 100);
+  const boxGutter = groupW * 0.06;
+  const boxW = (groupW - boxGutter * (nSer - 1)) / nSer;
+  const paletteOf = (si: number): string => {
+    const accent = chart.chartexAccents?.[si % (chart.chartexAccents?.length ?? 1)];
+    const fill = box.series[si].color ?? accent ?? CHART_PALETTE[si % CHART_PALETTE.length];
+    return `#${fill}`;
+  };
+  // A darker edge for the box border / median / whisker: reuse the fill so the
+  // outline reads as the same accent (Office draws box outlines in the series
+  // color at full strength over a lighter fill). We fill solid and stroke in a
+  // slightly darkened variant for legibility.
+
+  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  for (let ci = 0; ci < nCat; ci++) {
+    const slotLeft = px0 + slotW * ci + (slotW - groupW) / 2;
+    for (let si = 0; si < nSer; si++) {
+      const s = box.series[si];
+      const stats = computeBoxStats(s.valuesByCategory[ci] ?? [], s.quartileMethod);
+      if (!stats) continue;
+      const bx = slotLeft + si * (boxW + boxGutter);
+      const cx = bx + boxW / 2;
+      const fill = paletteOf(si);
+      const yQ1 = yOf(stats.q1);
+      const yQ3 = yOf(stats.q3);
+      const boxTop = Math.min(yQ1, yQ3);
+      const boxH = Math.max(1, Math.abs(yQ1 - yQ3));
+
+      // Whiskers: vertical line from box edges to whisker ends, with end caps.
+      const capW = boxW * 0.4;
+      ctx.strokeStyle = fill;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(cx, yOf(stats.whiskerHi)); ctx.lineTo(cx, yQ3);
+      ctx.moveTo(cx, yQ1); ctx.lineTo(cx, yOf(stats.whiskerLo));
+      ctx.moveTo(cx - capW / 2, yOf(stats.whiskerHi)); ctx.lineTo(cx + capW / 2, yOf(stats.whiskerHi));
+      ctx.moveTo(cx - capW / 2, yOf(stats.whiskerLo)); ctx.lineTo(cx + capW / 2, yOf(stats.whiskerLo));
+      ctx.stroke();
+
+      // IQR box: solid accent fill + a thin darker edge.
+      ctx.fillStyle = fill;
+      ctx.fillRect(bx, boxTop, boxW, boxH);
+      ctx.strokeStyle = '#404040';
+      ctx.lineWidth = 0.75;
+      ctx.strokeRect(bx + 0.375, boxTop + 0.375, boxW - 0.75, boxH - 0.75);
+
+      // Median line across the box.
+      const yMed = yOf(stats.median);
+      ctx.strokeStyle = '#404040';
+      ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(bx, yMed); ctx.lineTo(bx + boxW, yMed); ctx.stroke();
+
+      // Mean `×` marker.
+      if (s.meanMarker) {
+        const mY = yOf(stats.mean);
+        const mR = Math.max(2, boxW * 0.14);
+        ctx.strokeStyle = '#595959';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(cx - mR, mY - mR); ctx.lineTo(cx + mR, mY + mR);
+        ctx.moveTo(cx + mR, mY - mR); ctx.lineTo(cx - mR, mY + mR);
+        ctx.stroke();
+      }
+
+      // Outlier dots.
+      if (s.showOutliers) {
+        ctx.fillStyle = fill;
+        const oR = Math.max(1.5, boxW * 0.06);
+        for (const o of stats.outliers) {
+          ctx.beginPath(); ctx.arc(cx, yOf(o), oR, 0, Math.PI * 2); ctx.fill();
+        }
+      }
+    }
+
+    // Category label (centered under the slot), word-wrapped like the other
+    // cartesian renderers.
+    if (!chart.catAxisHidden) {
+      ctx.font = `${catFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
+      ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      const label = cats[ci];
+      const ccx = px0 + slotW * ci + slotW / 2;
+      ctx.fillText(label, ccx, py0 + ph + 4);
+    }
+  }
+  ctx.restore();
+}
+
 // ─── Background frame + dispatcher ──────────────────────────────────────────
 
 /**
@@ -4099,7 +4349,11 @@ export function renderChart(
     ctx.restore();
   }
 
-  if (chart.series.length === 0) {
+  // chartEx box-and-whisker / sunburst carry their data in the structured
+  // `chartexBox` / `chartexSunburst` fields, not the flat `series` array, so the
+  // empty-series "(no data)" guard must not fire for them.
+  const hasChartexData = chart.chartexBox != null || chart.chartexSunburst != null;
+  if (chart.series.length === 0 && !hasChartexData) {
     ctx.fillStyle = '#888';
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
@@ -4137,6 +4391,8 @@ export function renderChart(
       renderWaterfallChart(ctx, chart, rect); break;
     case 'stock':
       renderStockChart(ctx, chart, rect, ptToPx); break;
+    case 'boxWhisker':
+      renderBoxWhiskerChart(ctx, chart, rect, ptToPx); break;
     default:
       ctx.fillStyle = '#888';
       ctx.font = '11px sans-serif';

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -4304,6 +4304,228 @@ function renderBoxWhiskerChart(ctx: CanvasRenderingContext2D, chart: ChartModel,
   ctx.restore();
 }
 
+// ─── chartEx: sunburst (CH15, MS 2014 chartex ext) ───────────────────────────
+
+/** A node in the sunburst ring tree. `value` is the sum of descendant leaf
+ *  sizes (or the node's own size when it is a leaf). `a0`/`a1` are its angular
+ *  span (radians, canvas convention) once laid out; `depth` is its ring index
+ *  (0 = innermost / root). */
+interface SunburstNode {
+  label: string;
+  value: number;
+  depth: number;
+  children: SunburstNode[];
+  /** Root-branch index (which top-level branch this node descends from) — used
+   *  to color the whole sub-tree in one accent. */
+  branchIndex: number;
+  a0: number;
+  a1: number;
+}
+
+/**
+ * Fold the flat `path`/`size` rows into a ring tree. Each row is a root→leaf
+ * label chain; walking the chain interns each label under its parent. The size
+ * is added at the DEEPEST node of the row (a node's `value` is the sum of the
+ * sizes beneath it). Children keep first-seen (source) order so the ring sweep
+ * order matches PowerPoint.
+ */
+function buildSunburstTree(rows: { path: string[]; size: number }[]): SunburstNode {
+  const root: SunburstNode = {
+    label: '', value: 0, depth: -1, children: [], branchIndex: -1, a0: 0, a1: 0,
+  };
+  for (const row of rows) {
+    let node = root;
+    for (let d = 0; d < row.path.length; d++) {
+      const label = row.path[d];
+      let child = node.children.find(c => c.label === label);
+      if (!child) {
+        child = {
+          label,
+          value: 0,
+          depth: d,
+          children: [],
+          // Top-level nodes (d === 0) define the branch index; deeper nodes
+          // inherit their ancestor's.
+          branchIndex: d === 0 ? node.children.length : node.branchIndex,
+          a0: 0, a1: 0,
+        };
+        node.children.push(child);
+      }
+      child.value += row.size;
+      node = child;
+    }
+  }
+  root.value = root.children.reduce((s, c) => s + c.value, 0);
+  return root;
+}
+
+/** Assign angular spans top-down: each node partitions its `[a0, a1)` range
+ *  across its children proportional to their value, in child (source) order. */
+function layoutSunburstAngles(node: SunburstNode): void {
+  const total = node.children.reduce((s, c) => s + c.value, 0);
+  if (total <= 0) return;
+  let a = node.a0;
+  for (const child of node.children) {
+    const sweep = ((node.a1 - node.a0) * child.value) / total;
+    child.a0 = a;
+    child.a1 = a + sweep;
+    a = child.a1;
+    layoutSunburstAngles(child);
+  }
+}
+
+/** Maximum ring depth (number of levels below the root). */
+function sunburstMaxDepth(node: SunburstNode): number {
+  if (node.children.length === 0) return node.depth;
+  return Math.max(...node.children.map(sunburstMaxDepth));
+}
+
+/**
+ * Render a chartEx sunburst (MS 2014 chartex extension — no ECMA-376 section;
+ * the structure is a `<cx:series layoutId="sunburst">` over a `<cx:strDim
+ * type="cat">` of several `<cx:lvl>` and one `<cx:numDim type="size">`). The
+ * parser (`parse_chartex_sunburst`) yields the flat root→leaf `path`/`size`
+ * rows in `chart.chartexSunburst`; this renderer folds them into a ring tree,
+ * lays out each node's angular span proportional to its aggregated size, and
+ * draws concentric rings (inner = root/Branch, outward = Stem, Leaf) from 12
+ * o'clock clockwise. Every node in a branch shares that branch's theme accent
+ * (`chart.chartexAccents`, cycled by top-level index — the blue/orange/gray
+ * Office default). Labels are drawn white and centered in each segment, rotated
+ * to follow the arc and elided when the wedge is too small.
+ */
+function renderSunburstChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect, ptToPx: number): void {
+  const sb = chart.chartexSunburst;
+  if (!sb || sb.rows.length === 0) return;
+  const { x, y, w, h } = r;
+
+  // Radial frame (title band on top, no legend — Office draws sunburst without
+  // one). Reuse the pie frame params so the geometry matches the other radial
+  // charts.
+  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
+    titleTopPadFrac: 0.035,
+    titleBottomPadFrac: 0.035,
+    legendSideReserveFrac: 0,
+    radialGapFrac: 0.02,
+  });
+  drawChartTitle(ctx, chart, x, y + frame.title.topPad, w, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+  const cx = px0 + pw / 2;
+  const cy = py0 + ph / 2;
+  const outerR = Math.min(pw, ph) * 0.46;
+
+  const root = buildSunburstTree(sb.rows);
+  if (root.value <= 0 || root.children.length === 0) return;
+  // Full circle from 12 o'clock (−90°), clockwise (canvas angles grow CW), each
+  // parent partitioning its range across its children in source (first-seen)
+  // order. This is the natural spec-consistent reading of the `<cx:lvl>` point
+  // order. NB: Excel's own sunburst places the branches AFTER the first in a
+  // different rotational order (for sample-24 the observed clockwise order is
+  // Branch 1, 3, 2 rather than 1, 2, 3) — an undocumented runtime layout choice.
+  // Matching it exactly would require reverse-engineering that ordering, which
+  // the project's spec-first policy forbids without a documented rule, so the
+  // rings/hierarchy/proportions/colors match while the branch *placement* order
+  // is the straightforward source order.
+  root.a0 = -Math.PI / 2;
+  root.a1 = -Math.PI / 2 + Math.PI * 2;
+  layoutSunburstAngles(root);
+
+  const maxDepth = sunburstMaxDepth(root); // 0-based deepest ring index
+  const ringCount = maxDepth + 1;
+  // Small center hole (Office draws a modest hole, ~18% of the outer radius);
+  // the remaining band is split evenly across the rings.
+  const innerR = outerR * 0.18;
+  const ringBand = (outerR - innerR) / ringCount;
+
+  const accents = chart.chartexAccents;
+  const branchColor = (bi: number): string => {
+    const hex = accents?.[bi % accents.length] ?? CHART_PALETTE[bi % CHART_PALETTE.length];
+    return `#${hex}`;
+  };
+
+  const labelFont = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
+  const labelPx = Math.max(7, Math.min(13, outerR * 0.075));
+
+  // Draw every non-root node as a ring segment, deepest-last so borders read on
+  // top. Iterate breadth-first by depth.
+  const byDepth: SunburstNode[][] = Array.from({ length: ringCount }, () => []);
+  const collect = (n: SunburstNode): void => {
+    if (n.depth >= 0) byDepth[n.depth].push(n);
+    n.children.forEach(collect);
+  };
+  collect(root);
+
+  ctx.save();
+  for (let d = 0; d < ringCount; d++) {
+    const rInner = innerR + d * ringBand;
+    const rOuter = rInner + ringBand;
+    for (const node of byDepth[d]) {
+      const sweep = node.a1 - node.a0;
+      if (sweep <= 1e-4) continue;
+      ctx.beginPath();
+      ctx.arc(cx, cy, rOuter, node.a0, node.a1);
+      ctx.arc(cx, cy, rInner, node.a1, node.a0, true);
+      ctx.closePath();
+      ctx.fillStyle = branchColor(node.branchIndex);
+      ctx.fill();
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+
+      // Label: white, centered at the mid-radius / mid-angle, rotated to run
+      // along the arc (tangential), word-wrapped and elided to the wedge.
+      const midA = (node.a0 + node.a1) / 2;
+      const midR = (rInner + rOuter) / 2;
+      // Radial room the label may occupy (the ring band, minus padding).
+      const radialRoom = ringBand - 4;
+      // Tangential arc length at the mid radius.
+      const arcLen = sweep * midR;
+      // Skip labels that plainly cannot fit even one glyph.
+      if (radialRoom < labelPx * 0.9 && arcLen < labelPx * 0.9) continue;
+
+      ctx.save();
+      ctx.translate(cx + Math.cos(midA) * midR, cy + Math.sin(midA) * midR);
+      // Orient the text so it reads along the ring: rotate to the tangent, and
+      // flip on the left half so it isn't upside-down.
+      let rot = midA + Math.PI / 2;
+      const deg = ((rot * 180) / Math.PI) % 360;
+      if (deg > 90 && deg < 270) rot += Math.PI;
+      ctx.rotate(rot);
+      ctx.font = `${labelPx}px ${labelFont}`;
+      ctx.fillStyle = '#ffffff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      // The text runs along the tangent (rotated frame's x-axis), so its
+      // available width is the arc length and its stacking room (wrap lines) is
+      // the radial band.
+      const words = node.label.split(/\s+/).filter(Boolean);
+      const maxLineW = arcLen - 2;
+      const lines: string[] = [];
+      let cur = '';
+      for (const word of words) {
+        const trial = cur ? `${cur} ${word}` : word;
+        if (ctx.measureText(trial).width <= maxLineW || !cur) {
+          cur = trial;
+        } else {
+          lines.push(cur);
+          cur = word;
+        }
+      }
+      if (cur) lines.push(cur);
+      // Cap the number of lines to what the radial band holds.
+      const lineH = labelPx * 1.05;
+      const maxLines = Math.max(1, Math.floor(radialRoom / lineH));
+      const shown = lines.slice(0, maxLines).map(l => elideToWidth(ctx, l, maxLineW));
+      const totalH = shown.length * lineH;
+      shown.forEach((line, li) => {
+        if (line === '') return;
+        ctx.fillText(line, 0, -totalH / 2 + lineH / 2 + li * lineH);
+      });
+      ctx.restore();
+    }
+  }
+  ctx.restore();
+}
+
 // ─── Background frame + dispatcher ──────────────────────────────────────────
 
 /**
@@ -4393,6 +4615,8 @@ export function renderChart(
       renderStockChart(ctx, chart, rect, ptToPx); break;
     case 'boxWhisker':
       renderBoxWhiskerChart(ctx, chart, rect, ptToPx); break;
+    case 'sunburst':
+      renderSunburstChart(ctx, chart, rect, ptToPx); break;
     default:
       ctx.fillStyle = '#888';
       ctx.font = '11px sans-serif';

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -684,7 +684,10 @@ export interface ChartexBoxSeries {
   meanLine: boolean;
   /** `<cx:visibility outliers>` — draw outlier points. */
   showOutliers: boolean;
-  /** `<cx:visibility nonoutliers>` — draw interior (non-outlier) points too. */
+  /** `<cx:visibility nonoutliers>` — draw the interior (non-outlier) sample
+   *  points as jittered dots on top of the box. Flag parsed; interior-dot
+   *  rendering is pending a fixture that enables it (every sample-24 series
+   *  ships `nonoutliers="0"`, so there is nothing to verify against yet). */
   showNonoutliers: boolean;
   /** `<cx:statistics quartileMethod>` — "exclusive" (Excel default) | "inclusive". */
   quartileMethod: string;

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -269,6 +269,8 @@ export type ChartType =
   | 'pie' | 'doughnut'
   | 'scatter' | 'bubble' | 'radar' | 'waterfall'
   | 'stock'
+  // chartEx (MS 2014 chartex ext) layouts CH15 renders.
+  | 'boxWhisker' | 'sunburst'
   | string;
 
 export interface ChartModel {
@@ -639,6 +641,77 @@ export interface ChartModel {
    * NOT yet draw them (tracked follow-up). null/undefined when absent.
    */
   stockUpDownBars?: boolean | null;
+  // ── chartEx box-and-whisker / sunburst (CH15, MS 2014 chartex ext) ─────────
+  /**
+   * Structured box-and-whisker data (`chartType === 'boxWhisker'`). Present
+   * ONLY for boxWhisker charts; null/absent otherwise so the flat
+   * `categories`/`series` model the other chartEx renderers consume is
+   * untouched. The renderer computes quartiles / mean / whiskers / outliers.
+   */
+  chartexBox?: ChartexBoxWhisker | null;
+  /**
+   * Structured sunburst hierarchy (`chartType === 'sunburst'`). Present ONLY
+   * for sunburst charts; null/absent otherwise.
+   */
+  chartexSunburst?: ChartexSunburst | null;
+  /**
+   * Theme accent palette (`accent1..6`, hex without '#') for chartEx charts
+   * that color by branch/series index (boxWhisker series, sunburst branches).
+   * null/absent when the resolver supplies no default palette (pptx); the
+   * renderer then falls back to its own `CHART_PALETTE`.
+   */
+  chartexAccents?: string[] | null;
+}
+
+/**
+ * One box-and-whisker series (chartEx `boxWhisker`, MS 2014 chartex ext). Each
+ * `<cx:series>` references its own raw sample points via `<cx:dataId>`; the
+ * parser groups them by category and threads the `<cx:layoutPr>` flags. The
+ * renderer derives the statistics.
+ */
+export interface ChartexBoxSeries {
+  /** Series display name (`<cx:tx><cx:v>`). */
+  name: string;
+  /** Fill (hex, no '#') — theme accent cycled by series index. null = fall
+   *  back to the renderer palette. */
+  color?: string | null;
+  /** Raw sample values grouped by category (outer = category index parallel to
+   *  {@link ChartexBoxWhisker.categories}, inner = the points in that group). */
+  valuesByCategory: number[][];
+  /** `<cx:visibility meanMarker>` — draw the mean `×`. */
+  meanMarker: boolean;
+  /** `<cx:visibility meanLine>` — draw a mean connector line across categories. */
+  meanLine: boolean;
+  /** `<cx:visibility outliers>` — draw outlier points. */
+  showOutliers: boolean;
+  /** `<cx:visibility nonoutliers>` — draw interior (non-outlier) points too. */
+  showNonoutliers: boolean;
+  /** `<cx:statistics quartileMethod>` — "exclusive" (Excel default) | "inclusive". */
+  quartileMethod: string;
+}
+
+/** A chartEx box-and-whisker chart: unique categories + one series per column. */
+export interface ChartexBoxWhisker {
+  /** Unique category labels in first-seen order. */
+  categories: string[];
+  /** One entry per `<cx:series>`. */
+  series: ChartexBoxSeries[];
+}
+
+/**
+ * One row of a chartEx `sunburst`: the branch→…→leaf label chain (empty
+ * trailing segments trimmed) and its size value.
+ */
+export interface ChartexSunburstRow {
+  /** Label chain root→leaf. */
+  path: string[];
+  /** `<cx:numDim type="size">` value attaching to the deepest node in `path`. */
+  size: number;
+}
+
+/** A chartEx sunburst: the flat rows the renderer folds into a ring tree. */
+export interface ChartexSunburst {
+  rows: ChartexSunburstRow[];
 }
 
 /**

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1456,11 +1456,38 @@ fn load_chart_map(
         let Ok(xml) = read_zip_string(zip, &path) else {
             continue;
         };
-        if let Some(chart) = parse_docx_chart(&xml, theme) {
+        // A chartEx part reads its title font size from the associated
+        // chartStyle sidecar (`styleN.xml`), reached via the chart part's OWN
+        // rels (`word/charts/_rels/chartN.xml.rels`,
+        // `.../2011/relationships/chartStyle`). Resolve+read it best-effort;
+        // legacy `<c:>` charts ignore it (their title size is inline).
+        let style_xml = load_chart_style_xml(zip, &path);
+        if let Some(chart) = parse_docx_chart(&xml, style_xml.as_deref(), theme) {
             chart_map.insert(rid.clone(), chart);
         }
     }
     chart_map
+}
+
+/// Read the chartStyle part (`styleN.xml`) associated with a chart part at
+/// `chart_path` (e.g. `word/charts/chart6.xml`), following that part's own
+/// relationships (`word/charts/_rels/chart6.xml.rels`) to the
+/// `.../2011/relationships/chartStyle` target. Returns `None` when the chart
+/// has no chartStyle relationship or the part cannot be read (the chartEx
+/// title then falls back to its inline size, or the renderer's default).
+fn load_chart_style_xml(zip: &mut Zip, chart_path: &str) -> Option<String> {
+    // Split `word/charts/chart6.xml` into dir (`word/charts`) + file
+    // (`chart6.xml`) so the rels path is `word/charts/_rels/chart6.xml.rels`.
+    let (dir, file) = match chart_path.rsplit_once('/') {
+        Some((d, f)) => (d, f),
+        None => ("", chart_path),
+    };
+    let rels_path = format!("{}/_rels/{}.rels", dir, file);
+    let rels_xml = read_zip_string(zip, &rels_path).ok()?;
+    let target =
+        find_rel_target_by_type(&rels_xml, ooxml_common::chart::CHART_STYLE_REL_TYPE_SUFFIX)?;
+    let style_path = ooxml_common::rels::resolve_target(&format!("{}/", dir), &target);
+    read_zip_string(zip, &style_path).ok()
 }
 
 fn load_header_footer_set(
@@ -5358,6 +5385,7 @@ impl ooxml_common::chart::ColorResolver for DocxColorResolver<'_> {
 /// no recognized chart type.
 fn parse_docx_chart(
     chart_xml: &str,
+    style_xml: Option<&str>,
     theme: &ThemeColors,
 ) -> Option<ooxml_common::chart::ChartModel> {
     let doc = XmlDoc::parse(chart_xml).ok()?;
@@ -5368,7 +5396,9 @@ fn parse_docx_chart(
         .namespace()
         .is_some_and(|ns| ns.contains("chartex") || ns.contains("chartEx"));
     if is_chartex {
-        ooxml_common::chart::parse_chartex_part(root, &resolver)
+        // chartEx (waterfall/boxWhisker/…) reads its title font size from the
+        // associated chartStyle part when the `<cx:title>` itself carries none.
+        ooxml_common::chart::parse_chartex_part(root, &resolver, style_xml)
     } else {
         ooxml_common::chart::parse_chart_part(root, &resolver)
     }
@@ -6309,6 +6339,22 @@ fn parse_rels(xml: &str) -> HashMap<String, String> {
         .into_iter()
         .map(|(id, rel)| (id, rel.target))
         .collect()
+}
+
+/// Target of the first `<Relationship>` whose `Type` ends with `type_suffix`.
+/// Matched by `ends_with` so both the Transitional and Strict namespace
+/// prefixes resolve (mirrors pptx's `find_rel_target_by_type`). `None` when no
+/// relationship of that type is present.
+fn find_rel_target_by_type(rels_xml: &str, type_suffix: &str) -> Option<String> {
+    let doc = roxmltree::Document::parse(rels_xml).ok()?;
+    for rel in doc.root_element().children().filter(|n| n.is_element()) {
+        if let Some(rel_type) = rel.attribute("Type") {
+            if rel_type.ends_with(type_suffix) {
+                return rel.attribute("Target").map(|t| t.to_string());
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -9744,7 +9790,7 @@ mod anchor_image_relative_from_tests {
             <c:axId val="1"/><c:axId val="2"/>
           </c:barChart></c:plotArea></c:chart>
         </c:chartSpace>"#;
-        let chart = parse_docx_chart(chart_xml, &theme).expect("chart must parse");
+        let chart = parse_docx_chart(chart_xml, None, &theme).expect("chart must parse");
         assert_eq!(chart.chart_type, "clusteredBar");
         assert_eq!(chart.categories, vec!["Q1".to_string(), "Q2".to_string()]);
         assert_eq!(chart.series.len(), 1);
@@ -9799,6 +9845,7 @@ mod anchor_image_relative_from_tests {
                     <c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
                 </c:ser><c:axId val="1"/><c:axId val="2"/>
               </c:barChart></c:plotArea></c:chart></c:chartSpace>"#,
+            None,
             &theme,
         )
         .expect("model");
@@ -9869,7 +9916,7 @@ mod anchor_image_relative_from_tests {
             </cx:plotArea>
           </cx:chart>
         </cx:chartSpace>"#;
-        let chart = parse_docx_chart(chartex_xml, &theme).expect("chartex part must parse");
+        let chart = parse_docx_chart(chartex_xml, None, &theme).expect("chartex part must parse");
         assert_eq!(chart.chart_type, "boxWhisker");
         assert_eq!(
             chart.categories,
@@ -9925,6 +9972,7 @@ mod anchor_image_relative_from_tests {
                 <cx:series layoutId="sunburst"/>
               </cx:plotAreaRegion></cx:plotArea></cx:chart>
             </cx:chartSpace>"#,
+            None,
             &theme,
         )
         .expect("chartex model");

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -1097,6 +1097,66 @@ pub fn extract_chart_title_size(node: Node) -> Option<i32> {
     })
 }
 
+/// chartEx (`<cx:chartSpace>`) title font size in hundredths of a point.
+///
+/// Unlike the legacy chart, whose `<c:title>` is a direct child of the chart
+/// node, a chartEx title lives at `<cx:chart><cx:title>` (a grandchild of the
+/// part root), so this walks all descendants to find the first `<cx:title>` and
+/// reads its first `<a:defRPr@sz>` / `<a:rPr@sz>`. `None` when the title carries
+/// no explicit size — which is the common case (see
+/// [`extract_chartex_style_title_size`]).
+fn extract_chartex_title_size(root: Node) -> Option<i32> {
+    let title = root
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "title")?;
+    title.descendants().find_map(|n| {
+        if !n.is_element() {
+            return None;
+        }
+        let tag = n.tag_name().name();
+        if tag != "defRPr" && tag != "rPr" {
+            return None;
+        }
+        n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
+    })
+}
+
+/// Relationship-type suffix that a chart part's `.rels` uses to point at its
+/// chartStyle sidecar (`styleN.xml`). Matched by `ends_with` so both the
+/// Transitional and Strict namespace prefixes resolve. Shared by the pptx /
+/// xlsx / docx callers so they resolve the same relationship the same way.
+pub const CHART_STYLE_REL_TYPE_SUFFIX: &str = "office/2011/relationships/chartStyle";
+
+/// Title font size (hundredths of a point) declared by the chart's associated
+/// chartStyle part (`<cs:chartStyle><cs:title><cs:defRPr@sz>`).
+///
+/// A chartEx part almost never inlines the title size on its own `<cx:title>`;
+/// instead the size lives in the sibling `styleN.xml` reached via the chart
+/// part's `.../2011/relationships/chartStyle` relationship. Word's default
+/// modern chart style writes `<cs:title><cs:defRPr sz="1400">` (14pt), so
+/// without reading it a chartEx title would fall back to an area-proportional
+/// guess that is visibly too large. `None` when `style_xml` is absent, malformed,
+/// or declares no `<cs:title>` size.
+pub fn extract_chartex_style_title_size(style_xml: &str) -> Option<i32> {
+    let doc = roxmltree::Document::parse(style_xml).ok()?;
+    let title = doc
+        .root_element()
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "title")?;
+    // `<cs:title>`'s size sits on its direct-child `<cs:defRPr@sz>`; scan
+    // descendants so a nested `<a:defRPr>`/`<a:rPr>` (if any) is also honored.
+    title.descendants().find_map(|n| {
+        if !n.is_element() {
+            return None;
+        }
+        let tag = n.tag_name().name();
+        if tag != "defRPr" && tag != "rPr" {
+            return None;
+        }
+        n.attribute("sz").and_then(|v| v.parse::<i32>().ok())
+    })
+}
+
 /// First `<a:defRPr@b>` / `<a:rPr@b>` bold flag inside `node`'s direct-child
 /// `<c:title>`. `None` when not specified (renderer treats as not bold).
 pub fn extract_chart_title_bold(node: Node) -> Option<bool> {
@@ -1793,6 +1853,7 @@ pub fn extract_chartex_axis_hidden(root: Node) -> (bool, bool) {
 pub fn parse_chartex_part(
     chartspace_root: Node,
     resolver: &dyn ColorResolver,
+    style_xml: Option<&str>,
 ) -> Option<ChartModel> {
     let root = chartspace_root;
 
@@ -1809,7 +1870,8 @@ pub fn parse_chartex_part(
     // identically. Only populated for the layouts CH15 renders (boxWhisker /
     // sunburst) so waterfall/treemap wire output stays byte-stable. `None`
     // otherwise.
-    let chartex_title = if chart_type == "boxWhisker" || chart_type == "sunburst" {
+    let renders_chartex = chart_type == "boxWhisker" || chart_type == "sunburst";
+    let chartex_title = if renders_chartex {
         root.descendants()
             .find(|n| n.is_element() && n.tag_name().name() == "title")
             .and_then(|t| {
@@ -1818,6 +1880,20 @@ pub fn parse_chartex_part(
             })
             .map(|rich| flatten_rich_text(rich, None))
             .filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+
+    // ── chartEx title font size (MS 2014 chartex ext) ────────────────────────
+    // Precedence: an explicit `sz` on the chartEx part's own `<cx:title>` rich
+    // text wins; otherwise fall back to the associated chartStyle part's
+    // `<cs:title><cs:defRPr@sz>` (Word's default modern style = 1400 = 14pt).
+    // Without the style part a chartEx title would be sized by the renderer's
+    // area-proportional guess (≈21pt on sample-24), 1.5× too large. Only
+    // populated for the rendered layouts so waterfall/treemap stay byte-stable.
+    let chartex_title_font_size_hpt = if renders_chartex {
+        extract_chartex_title_size(root)
+            .or_else(|| style_xml.and_then(extract_chartex_style_title_size))
     } else {
         None
     };
@@ -2035,7 +2111,7 @@ pub fn parse_chartex_part(
         cat_axis_cross_between: "between".to_string(),
         val_axis_major_tick_mark: "cross".to_string(),
         cat_axis_major_tick_mark: "cross".to_string(),
-        title_font_size_hpt: None,
+        title_font_size_hpt: chartex_title_font_size_hpt,
         title_font_color: None,
         title_font_face: None,
         cat_axis_font_size_hpt: None,
@@ -6079,6 +6155,7 @@ mod tests {
     // `Calibri Light` / `Calibri` as the theme major/minor faces.
 
     const CX_NS: &str = "http://schemas.microsoft.com/office/drawing/2014/chartex";
+    const CS_NS: &str = "http://schemas.microsoft.com/office/drawing/2012/chartStyle";
 
     /// (a) Waterfall with the full decoration set: a category dimension, a value
     /// dimension with negatives, `<cx:subtotals>` (idx 0 is implicit, idx 5 is
@@ -6136,7 +6213,8 @@ mod tests {
             </cx:chartSpace>"#
         );
         let d = chart_space_of(&xml);
-        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("waterfall parses");
+        let m =
+            parse_chartex_part(d.root_element(), &FixtureResolver, None).expect("waterfall parses");
 
         assert_eq!(m.chart_type, "waterfall");
         assert_eq!(m.categories, vec!["Start", "Up", "Down", "End"]);
@@ -6208,7 +6286,8 @@ mod tests {
             </cx:chartSpace>"#
         );
         let d = chart_space_of(&xml);
-        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("treemap parses");
+        let m =
+            parse_chartex_part(d.root_element(), &FixtureResolver, None).expect("treemap parses");
 
         assert_eq!(m.chart_type, "treemap");
         assert_eq!(m.categories, vec!["North", "South", "East"]);
@@ -6231,7 +6310,7 @@ mod tests {
             r#"<cx:chartSpace xmlns:cx="{CX_NS}"><cx:chart><cx:plotArea/></cx:chart></cx:chartSpace>"#
         );
         let d = chart_space_of(&xml);
-        assert!(parse_chartex_part(d.root_element(), &FixtureResolver).is_none());
+        assert!(parse_chartex_part(d.root_element(), &FixtureResolver, None).is_none());
     }
 
     /// (d) Newlines inside a category `<cx:pt>` are flattened to spaces (Office
@@ -6252,7 +6331,7 @@ mod tests {
             </cx:chartSpace>"#
         );
         let d = chart_space_of(&xml);
-        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("parses");
+        let m = parse_chartex_part(d.root_element(), &FixtureResolver, None).expect("parses");
         assert_eq!(m.categories, vec!["FY2024 1Q"]);
     }
 
@@ -6310,7 +6389,8 @@ mod tests {
             </cx:chartSpace>"#
         );
         let d = chart_space_of(&xml);
-        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("boxWhisker parses");
+        let m = parse_chartex_part(d.root_element(), &FixtureResolver, None)
+            .expect("boxWhisker parses");
         assert_eq!(m.chart_type, "boxWhisker");
         assert_eq!(m.title.as_deref(), Some("My box chart"));
         assert_eq!(
@@ -6373,7 +6453,8 @@ mod tests {
             </cx:chartSpace>"#
         );
         let d = chart_space_of(&xml);
-        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("sunburst parses");
+        let m =
+            parse_chartex_part(d.root_element(), &FixtureResolver, None).expect("sunburst parses");
         assert_eq!(m.chart_type, "sunburst");
         assert_eq!(m.title.as_deref(), Some("My sunburst"));
         let sb = m.chartex_sunburst.expect("sunburst data present");
@@ -6406,11 +6487,77 @@ mod tests {
             </cx:chartSpace>"#
         );
         let d = chart_space_of(&xml);
-        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("waterfall parses");
+        let m =
+            parse_chartex_part(d.root_element(), &FixtureResolver, None).expect("waterfall parses");
         assert!(m.chartex_box.is_none());
         assert!(m.chartex_sunburst.is_none());
         assert!(m.chartex_accents.is_none());
         assert!(m.title.is_none());
+    }
+
+    /// `<cs:title><cs:defRPr sz>` in a chartStyle part extracts the title size
+    /// (hpt). Word's default modern chart style writes 1400 (14pt).
+    #[test]
+    fn extract_chartex_style_title_size_reads_cs_defrpr() {
+        let style = format!(
+            r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}">
+              <cs:title><cs:defRPr sz="1400" b="0"/></cs:title>
+            </cs:chartStyle>"#
+        );
+        assert_eq!(extract_chartex_style_title_size(&style), Some(1400));
+        // No <cs:title> / no sz → None.
+        assert!(extract_chartex_style_title_size(&format!(
+            r#"<cs:chartStyle xmlns:cs="{CS_NS}"><cs:dataPoint/></cs:chartStyle>"#
+        ))
+        .is_none());
+        // Malformed XML → None (not a panic).
+        assert!(extract_chartex_style_title_size("<not xml").is_none());
+    }
+
+    /// A chartEx title with no inline `sz` falls back to the chartStyle part's
+    /// `<cs:title>` size; an inline `sz` on the `<cx:title>` rich text wins over
+    /// the style part; and with no style part at all the size is `None` (the
+    /// renderer's area-proportional fallback).
+    #[test]
+    fn parse_chartex_part_title_size_resolves_from_style_part() {
+        let chart_xml = |title_rpr: &str| {
+            format!(
+                r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+                  <cx:chartData><cx:data id="0">
+                    <cx:strDim type="cat"><cx:lvl ptCount="1"><cx:pt idx="0">Leaf</cx:pt></cx:lvl></cx:strDim>
+                    <cx:numDim type="size"><cx:lvl ptCount="1"><cx:pt idx="0">1</cx:pt></cx:lvl></cx:numDim>
+                  </cx:data></cx:chartData>
+                  <cx:chart>
+                    <cx:title><cx:tx><cx:rich><a:p><a:pPr>{title_rpr}</a:pPr>
+                      <a:r><a:t>T</a:t></a:r></a:p></cx:rich></cx:tx></cx:title>
+                    <cx:plotArea><cx:plotAreaRegion>
+                      <cx:series layoutId="sunburst"><cx:dataId val="0"/></cx:series>
+                    </cx:plotAreaRegion></cx:plotArea>
+                  </cx:chart>
+                </cx:chartSpace>"#
+            )
+        };
+        let style = format!(
+            r#"<cs:chartStyle xmlns:cs="{CS_NS}"><cs:title><cs:defRPr sz="1400"/></cs:title></cs:chartStyle>"#
+        );
+
+        // No inline sz + style part → style part's 1400.
+        let x0 = chart_xml("<a:defRPr/>");
+        let d0 = chart_space_of(&x0);
+        let m0 = parse_chartex_part(d0.root_element(), &FixtureResolver, Some(&style)).unwrap();
+        assert_eq!(m0.title_font_size_hpt, Some(1400));
+
+        // Inline sz on the title wins over the style part.
+        let x1 = chart_xml(r#"<a:defRPr sz="2000"/>"#);
+        let d1 = chart_space_of(&x1);
+        let m1 = parse_chartex_part(d1.root_element(), &FixtureResolver, Some(&style)).unwrap();
+        assert_eq!(m1.title_font_size_hpt, Some(2000));
+
+        // No style part and no inline sz → None (renderer fallback).
+        let x2 = chart_xml("<a:defRPr/>");
+        let d2 = chart_space_of(&x2);
+        let m2 = parse_chartex_part(d2.root_element(), &FixtureResolver, None).unwrap();
+        assert_eq!(m2.title_font_size_hpt, None);
     }
 
     // ── CH13: 3D flattening / stock / ofPie type detection ───────────────────

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -591,7 +591,10 @@ pub struct ChartexBoxSeries {
     /// `<cx:layoutPr><cx:visibility outliers>` — draw outlier points.
     pub show_outliers: bool,
     /// `<cx:layoutPr><cx:visibility nonoutliers>` — draw the non-outlier
-    /// (interior) points as dots in addition to the box.
+    /// (interior) points as dots in addition to the box. Flag parsed;
+    /// interior-dot rendering is pending a fixture that enables it (every
+    /// sample-24 series ships `nonoutliers="0"`, so there is nothing to verify
+    /// the overlay against yet).
     pub show_nonoutliers: bool,
     /// `<cx:layoutPr><cx:statistics quartileMethod>` — `"exclusive"` (Excel
     /// default, median excluded when splitting halves) or `"inclusive"`.

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -305,6 +305,24 @@ pub struct ChartModel {
     /// does NOT yet draw them (tracked as a follow-up). `None` when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stock_up_down_bars: Option<bool>,
+    // ── chartEx box-and-whisker / sunburst (CH15, MS 2014 chartex ext) ────────
+    /// Structured box-and-whisker data (`chart_type == "boxWhisker"`). `None`
+    /// for every other chart type — the field is populated ONLY by
+    /// `parse_chartex_part` when the series `layoutId` is `boxWhisker`, so the
+    /// flat `categories`/`series` model (which waterfall/treemap consume) is
+    /// unchanged and the wire stays byte-stable for those.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_box: Option<ChartexBoxWhisker>,
+    /// Structured sunburst hierarchy (`chart_type == "sunburst"`). `None`
+    /// otherwise (byte-stable for the flat-model chartEx charts).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_sunburst: Option<ChartexSunburst>,
+    /// Theme accent palette (`accent1..6` resolved to hex, no `#`) for chartEx
+    /// charts that color by branch/series index (boxWhisker series, sunburst
+    /// branches). `None` when the resolver supplies no default palette (pptx);
+    /// the renderer then falls back to its own `CHART_PALETTE`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_accents: Option<Vec<String>>,
 }
 
 /// Mirror of TS `ChartSeries`.
@@ -541,6 +559,81 @@ pub struct SecondaryValueAxis {
     pub title_font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_color: Option<String>,
+}
+
+/// One box-and-whisker series (chartEx `boxWhisker`, MS 2014 chartex ext).
+///
+/// A chartEx box-and-whisker chart carries one `<cx:series layoutId="boxWhisker">`
+/// per data column, each referencing its own `<cx:data>` (via `<cx:dataId>`) of
+/// RAW sample points grouped by category. Statistics (quartiles / mean /
+/// whiskers / outliers) are computed by the renderer per the
+/// `<cx:layoutPr><cx:statistics quartileMethod>` and `<cx:visibility>` flags;
+/// the parser only groups the raw points by category and threads the flags.
+/// Mirror of TS `ChartexBoxSeries`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartexBoxSeries {
+    /// Series display name (`<cx:tx><cx:txData><cx:v>`), e.g. "Series1".
+    pub name: String,
+    /// Series fill (hex, no `#`) — the theme accent cycled by series index
+    /// (`accent[(idx % 6) + 1]`). `None` when the resolver supplies no default
+    /// palette (pptx); the renderer then falls back to its own palette.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    /// Raw sample values grouped by category, parallel to
+    /// `ChartexBoxWhisker::categories`. Outer index = category, inner = the
+    /// sample points that fell in that category (source order preserved).
+    pub values_by_category: Vec<Vec<f64>>,
+    /// `<cx:layoutPr><cx:visibility meanMarker>` — draw the mean `×` marker.
+    pub mean_marker: bool,
+    /// `<cx:layoutPr><cx:visibility meanLine>` — draw a mean connector line.
+    pub mean_line: bool,
+    /// `<cx:layoutPr><cx:visibility outliers>` — draw outlier points.
+    pub show_outliers: bool,
+    /// `<cx:layoutPr><cx:visibility nonoutliers>` — draw the non-outlier
+    /// (interior) points as dots in addition to the box.
+    pub show_nonoutliers: bool,
+    /// `<cx:layoutPr><cx:statistics quartileMethod>` — `"exclusive"` (Excel
+    /// default, median excluded when splitting halves) or `"inclusive"`.
+    pub quartile_method: String,
+}
+
+/// A chartEx box-and-whisker chart: the unique categories plus one series per
+/// data column. Mirror of TS `ChartexBoxWhisker`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartexBoxWhisker {
+    /// Unique category labels in first-seen order (the box groups on the
+    /// category axis). Each series bins its raw points into these.
+    pub categories: Vec<String>,
+    /// One entry per `<cx:series>`.
+    pub series: Vec<ChartexBoxSeries>,
+}
+
+/// One row of a chartEx `sunburst` (MS 2014 chartex ext). A sunburst encodes
+/// its hierarchy as one `<cx:strDim type="cat">` with several `<cx:lvl>`
+/// (lvl[0] = deepest / Leaf, last lvl = root / Branch) and a single
+/// `<cx:numDim type="size">`. Each row's `path` is the branch→…→leaf label
+/// chain with empty trailing segments trimmed (a node that is itself a leaf
+/// terminates early); `size` is that row's size value. Mirror of TS
+/// `ChartexSunburstRow`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartexSunburstRow {
+    /// Label chain root→leaf (Branch, Stem, …, Leaf), empty tail trimmed.
+    pub path: Vec<String>,
+    /// `<cx:numDim type="size">` value for this row (attaches to the deepest
+    /// node in `path`).
+    pub size: f64,
+}
+
+/// A chartEx sunburst: the flat rows the renderer folds into a ring tree, plus
+/// the theme accent palette to color branches. Mirror of TS `ChartexSunburst`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartexSunburst {
+    /// One row per deepest-level data point.
+    pub rows: Vec<ChartexSunburstRow>,
 }
 
 /// Mirror of TS `ChartManualLayout`.
@@ -1710,6 +1803,58 @@ pub fn parse_chartex_part(
     let layout_id = attr(&series_node, "layoutId").unwrap_or_default();
     let chart_type = layout_id; // "waterfall", "treemap", etc.
 
+    // ── chartEx title (MS 2014 chartex ext) ──────────────────────────────────
+    // `<cx:chart><cx:title><cx:tx><cx:rich>` mirrors the DrawingML rich-text of a
+    // legacy `<c:title>`; `flatten_rich_text` walks its `<a:p>/<a:r>/<a:t>`
+    // identically. Only populated for the layouts CH15 renders (boxWhisker /
+    // sunburst) so waterfall/treemap wire output stays byte-stable. `None`
+    // otherwise.
+    let chartex_title = if chart_type == "boxWhisker" || chart_type == "sunburst" {
+        root.descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "title")
+            .and_then(|t| {
+                t.descendants()
+                    .find(|n| n.is_element() && n.tag_name().name() == "rich")
+            })
+            .map(|rich| flatten_rich_text(rich, None))
+            .filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+
+    // ── chartEx theme accent palette ─────────────────────────────────────────
+    // boxWhisker series and sunburst branches color by index off the theme
+    // accents (`accent[(idx % 6) + 1]`, the same cycle Office draws). Resolve
+    // accent1..6 once here; `None` when the resolver owns no default palette
+    // (pptx), letting the renderer fall back to its own `CHART_PALETTE`.
+    let chartex_accents: Option<Vec<String>> =
+        if chart_type == "boxWhisker" || chart_type == "sunburst" {
+            let accents: Vec<String> = (0..6)
+                .filter_map(|i| resolver.resolve_series_accent(i))
+                .collect();
+            if accents.len() == 6 {
+                Some(accents)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+    // ── chartEx box-and-whisker structured parse ─────────────────────────────
+    let chartex_box = if chart_type == "boxWhisker" {
+        parse_chartex_boxwhisker(root, resolver)
+    } else {
+        None
+    };
+
+    // ── chartEx sunburst structured parse ────────────────────────────────────
+    let chartex_sunburst = if chart_type == "sunburst" {
+        parse_chartex_sunburst(root)
+    } else {
+        None
+    };
+
     // Categories from chartData > data > strDim[@type="cat"] > lvl > pt
     let categories: Vec<String> = root
         .descendants()
@@ -1875,7 +2020,7 @@ pub fn parse_chartex_part(
 
     Some(ChartModel {
         chart_type,
-        title: None,
+        title: chartex_title,
         categories,
         series,
         val_max: None,
@@ -1984,7 +2129,274 @@ pub fn parse_chartex_part(
         stock_hi_low_lines: None,
         stock_hi_low_line_color: None,
         stock_up_down_bars: None,
+        chartex_box,
+        chartex_sunburst,
+        chartex_accents,
     })
+}
+
+/// Parse the structured box-and-whisker data of a chartEx `boxWhisker`.
+///
+/// A box-and-whisker chart has one `<cx:series layoutId="boxWhisker">` per data
+/// column; each series' `<cx:dataId val="N">` selects a `<cx:data id="N">`
+/// carrying RAW sample points (a `<cx:strDim type="cat">` of per-point category
+/// labels and a `<cx:numDim type="val">` of the sample values). This groups
+/// each series' points by the unique categories (taken in first-seen order from
+/// the first series' data) and threads the `<cx:layoutPr>` visibility /
+/// statistics flags. Quartiles / mean / whiskers / outliers are the renderer's
+/// job. Returns `None` when there is no plottable series.
+fn parse_chartex_boxwhisker(root: Node, resolver: &dyn ColorResolver) -> Option<ChartexBoxWhisker> {
+    // Build id -> <cx:data> lookup.
+    let data_by_id: std::collections::HashMap<String, Node> = root
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "data")
+        .filter_map(|d| attr(&d, "id").map(|id| (id, d)))
+        .collect();
+
+    // Series nodes, in document order (one column each).
+    let series_nodes: Vec<Node> = root
+        .descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "series")
+        .collect();
+    if series_nodes.is_empty() {
+        return None;
+    }
+
+    // Per-series raw (category-label, value) points, resolving each series' own
+    // <cx:dataId> -> <cx:data>.
+    let per_series_points: Vec<Vec<(String, f64)>> = series_nodes
+        .iter()
+        .map(|s| {
+            let data_id = s
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "dataId")
+                .and_then(|n| attr(&n, "val"));
+            let data = data_id.as_ref().and_then(|id| data_by_id.get(id).copied());
+            match data {
+                Some(d) => chartex_data_cat_val_points(d),
+                None => Vec::new(),
+            }
+        })
+        .collect();
+
+    // Unique categories in first-seen order across all series (first series'
+    // order dominates; later series only contribute unseen labels).
+    let mut categories: Vec<String> = Vec::new();
+    for pts in &per_series_points {
+        for (cat, _) in pts {
+            if !categories.iter().any(|c| c == cat) {
+                categories.push(cat.clone());
+            }
+        }
+    }
+    if categories.is_empty() {
+        return None;
+    }
+    let cat_index: std::collections::HashMap<&str, usize> = categories
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.as_str(), i))
+        .collect();
+
+    let series: Vec<ChartexBoxSeries> = series_nodes
+        .iter()
+        .enumerate()
+        .map(|(si, s)| {
+            let name = s
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "txData")
+                .and_then(|tx| tx.children().find(|n| n.tag_name().name() == "v"))
+                .and_then(|v| v.text().map(|t| t.to_string()))
+                .unwrap_or_default();
+
+            // Bin this series' raw points into the shared category order.
+            let mut values_by_category: Vec<Vec<f64>> = vec![Vec::new(); categories.len()];
+            for (cat, v) in &per_series_points[si] {
+                if let Some(&ci) = cat_index.get(cat.as_str()) {
+                    values_by_category[ci].push(*v);
+                }
+            }
+
+            // `<cx:layoutPr><cx:visibility …>` flags; Office defaults when omitted:
+            // meanMarker on, meanLine off, outliers on, nonoutliers off.
+            let vis = s
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "visibility");
+            let bool_attr = |name: &str, dflt: bool| {
+                vis.and_then(|v| attr(&v, name))
+                    .map(|s| s == "1" || s == "true")
+                    .unwrap_or(dflt)
+            };
+            let quartile_method = s
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "statistics")
+                .and_then(|st| attr(&st, "quartileMethod"))
+                .unwrap_or_else(|| "exclusive".to_string());
+
+            ChartexBoxSeries {
+                name,
+                color: resolver.resolve_series_accent(si),
+                values_by_category,
+                mean_marker: bool_attr("meanMarker", true),
+                mean_line: bool_attr("meanLine", false),
+                show_outliers: bool_attr("outliers", true),
+                show_nonoutliers: bool_attr("nonoutliers", false),
+                quartile_method,
+            }
+        })
+        .collect();
+
+    Some(ChartexBoxWhisker { categories, series })
+}
+
+/// Collect a chartEx `<cx:data>`'s (category-label, value) sample points: the
+/// `<cx:strDim type="cat">` first `<cx:lvl>` supplies per-point labels, the
+/// `<cx:numDim type="val">` first `<cx:lvl>` the values. Points align by their
+/// `idx` attribute; a point with no numeric value is dropped.
+fn chartex_data_cat_val_points(data: Node) -> Vec<(String, f64)> {
+    let cat_lvl = data
+        .descendants()
+        .find(|n| {
+            n.is_element()
+                && n.tag_name().name() == "strDim"
+                && attr(n, "type").as_deref() == Some("cat")
+        })
+        .and_then(|dim| {
+            dim.descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "lvl")
+        });
+    let val_lvl = data
+        .descendants()
+        .find(|n| {
+            n.is_element()
+                && n.tag_name().name() == "numDim"
+                && matches!(attr(n, "type").as_deref(), Some("val") | Some("size"))
+        })
+        .and_then(|dim| {
+            dim.descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "lvl")
+        });
+    let (Some(cat_lvl), Some(val_lvl)) = (cat_lvl, val_lvl) else {
+        return Vec::new();
+    };
+
+    // Index the category labels by their `idx`.
+    let cats: std::collections::HashMap<usize, String> = cat_lvl
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+        .filter_map(|pt| {
+            let idx = attr(&pt, "idx").and_then(|v| v.parse::<usize>().ok())?;
+            let label = pt.text().unwrap_or("").to_string();
+            Some((idx, label))
+        })
+        .collect();
+
+    val_lvl
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+        .filter_map(|pt| {
+            let idx = attr(&pt, "idx").and_then(|v| v.parse::<usize>().ok())?;
+            let v = pt.text().and_then(|t| t.parse::<f64>().ok())?;
+            let cat = cats.get(&idx).cloned().unwrap_or_default();
+            Some((cat, v))
+        })
+        .collect()
+}
+
+/// Parse the structured hierarchy of a chartEx `sunburst`.
+///
+/// A sunburst's single `<cx:data>` carries a `<cx:strDim type="cat">` with
+/// several `<cx:lvl>` (lvl[0] = deepest / Leaf, subsequent lvls step toward the
+/// root, last lvl = Branch) and one `<cx:numDim type="size">`. Each data-point
+/// `idx` yields a root→leaf `path` (Branch, …, Leaf) with empty trailing
+/// segments trimmed — a node that is itself a leaf terminates before the
+/// deepest level — and the `size` value at that `idx`. Returns `None` when
+/// there is no size dimension or no rows.
+fn parse_chartex_sunburst(root: Node) -> Option<ChartexSunburst> {
+    let cat_dim = root.descendants().find(|n| {
+        n.is_element()
+            && n.tag_name().name() == "strDim"
+            && attr(n, "type").as_deref() == Some("cat")
+    })?;
+    // Levels in document order: lvl[0] = Leaf (deepest), last = Branch (root).
+    let levels: Vec<Node> = cat_dim
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "lvl")
+        .collect();
+    if levels.is_empty() {
+        return None;
+    }
+
+    // size dimension (chartEx sunburst uses type="size").
+    let size_lvl = root
+        .descendants()
+        .find(|n| {
+            n.is_element()
+                && n.tag_name().name() == "numDim"
+                && matches!(attr(n, "type").as_deref(), Some("size") | Some("val"))
+        })
+        .and_then(|dim| {
+            dim.descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "lvl")
+        })?;
+    let sizes: std::collections::HashMap<usize, f64> = size_lvl
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+        .filter_map(|pt| {
+            let idx = attr(&pt, "idx").and_then(|v| v.parse::<usize>().ok())?;
+            let v = pt.text().and_then(|t| t.parse::<f64>().ok())?;
+            Some((idx, v))
+        })
+        .collect();
+
+    // Per-level idx -> label maps.
+    let level_maps: Vec<std::collections::HashMap<usize, String>> = levels
+        .iter()
+        .map(|lvl| {
+            lvl.children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "pt")
+                .filter_map(|pt| {
+                    let idx = attr(&pt, "idx").and_then(|v| v.parse::<usize>().ok())?;
+                    let label = pt.text().unwrap_or("").to_string();
+                    Some((idx, label))
+                })
+                .collect()
+        })
+        .collect();
+
+    // Row count = the max ptCount / max idx across levels + sizes.
+    let n = sizes
+        .keys()
+        .chain(level_maps.iter().flat_map(|m| m.keys()))
+        .copied()
+        .max()
+        .map(|m| m + 1)
+        .unwrap_or(0);
+
+    let mut rows: Vec<ChartexSunburstRow> = Vec::new();
+    for idx in 0..n {
+        let size = *sizes.get(&idx).unwrap_or(&0.0);
+        // Build path root→leaf: iterate levels from LAST (Branch/root) to FIRST
+        // (Leaf/deepest). Trailing empty leaf cells are trimmed so a node that is
+        // itself a leaf terminates early.
+        let mut path: Vec<String> = Vec::new();
+        for lvl in level_maps.iter().rev() {
+            let label = lvl.get(&idx).cloned().unwrap_or_default();
+            if label.is_empty() {
+                // Empty deeper cell terminates the path (no further descent).
+                break;
+            }
+            path.push(label);
+        }
+        if path.is_empty() {
+            continue;
+        }
+        rows.push(ChartexSunburstRow { path, size });
+    }
+    if rows.is_empty() {
+        return None;
+    }
+    Some(ChartexSunburst { rows })
 }
 
 // ============================================================================
@@ -3842,6 +4254,10 @@ pub fn parse_chart_part(
         stock_hi_low_lines,
         stock_hi_low_line_color,
         stock_up_down_bars,
+        // Legacy `c:` charts never carry the chartEx boxWhisker/sunburst model.
+        chartex_box: None,
+        chartex_sunburst: None,
+        chartex_accents: None,
     })
 }
 
@@ -4038,6 +4454,9 @@ mod tests {
             stock_hi_low_lines: None,
             stock_hi_low_line_color: None,
             stock_up_down_bars: None,
+            chartex_box: None,
+            chartex_sunburst: None,
+            chartex_accents: None,
         };
         let v = serde_json::to_value(&m).unwrap();
         let obj = v.as_object().unwrap();
@@ -4940,6 +5359,13 @@ mod tests {
         fn theme_minor_font_latin(&self) -> Option<String> {
             Some("Calibri".to_string())
         }
+
+        fn resolve_series_accent(&self, idx: usize) -> Option<String> {
+            // Cycle a 6-accent palette exactly like the docx resolver so chartEx
+            // box/sunburst tests can assert the branch/series colors.
+            const ACCENTS: [&str; 6] = ["5B9BD5", "ED7D31", "A5A5A5", "FFC000", "4472C4", "70AD47"];
+            Some(ACCENTS[idx % 6].to_string())
+        }
     }
 
     fn chart_space_of(xml: &str) -> Document<'_> {
@@ -5828,6 +6254,163 @@ mod tests {
         let d = chart_space_of(&xml);
         let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("parses");
         assert_eq!(m.categories, vec!["FY2024 1Q"]);
+    }
+
+    // ── CH15: chartEx boxWhisker / sunburst structured parse ─────────────────
+
+    /// A box-and-whisker chart with two series, each referencing its own
+    /// `<cx:data>` (via `<cx:dataId>`) of RAW sample points grouped across two
+    /// categories. Verifies: (a) categories unique-in-order, (b) each series'
+    /// points binned by category, (c) series colored by the cycled theme accent,
+    /// (d) `<cx:visibility>` / `<cx:statistics>` flags threaded, (e) the title
+    /// is parsed and the accent palette exposed.
+    #[test]
+    fn parse_chartex_part_boxwhisker_two_series_binned_by_category() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+              <cx:chartData>
+                <cx:data id="0">
+                  <cx:strDim type="cat"><cx:lvl ptCount="3">
+                    <cx:pt idx="0">Cat A</cx:pt><cx:pt idx="1">Cat A</cx:pt><cx:pt idx="2">Cat B</cx:pt>
+                  </cx:lvl></cx:strDim>
+                  <cx:numDim type="val"><cx:lvl ptCount="3">
+                    <cx:pt idx="0">1</cx:pt><cx:pt idx="1">3</cx:pt><cx:pt idx="2">10</cx:pt>
+                  </cx:lvl></cx:numDim>
+                </cx:data>
+                <cx:data id="1">
+                  <cx:strDim type="cat"><cx:lvl ptCount="3">
+                    <cx:pt idx="0">Cat A</cx:pt><cx:pt idx="1">Cat B</cx:pt><cx:pt idx="2">Cat B</cx:pt>
+                  </cx:lvl></cx:strDim>
+                  <cx:numDim type="val"><cx:lvl ptCount="3">
+                    <cx:pt idx="0">5</cx:pt><cx:pt idx="1">7</cx:pt><cx:pt idx="2">9</cx:pt>
+                  </cx:lvl></cx:numDim>
+                </cx:data>
+              </cx:chartData>
+              <cx:chart>
+                <cx:title><cx:tx><cx:rich><a:p><a:r><a:t>My box chart</a:t></a:r></a:p></cx:rich></cx:tx></cx:title>
+                <cx:plotArea><cx:plotAreaRegion>
+                  <cx:series layoutId="boxWhisker">
+                    <cx:tx><cx:txData><cx:v>Series1</cx:v></cx:txData></cx:tx>
+                    <cx:dataId val="0"/>
+                    <cx:layoutPr>
+                      <cx:visibility meanLine="0" meanMarker="1" nonoutliers="0" outliers="1"/>
+                      <cx:statistics quartileMethod="exclusive"/>
+                    </cx:layoutPr>
+                  </cx:series>
+                  <cx:series layoutId="boxWhisker">
+                    <cx:tx><cx:txData><cx:v>Series2</cx:v></cx:txData></cx:tx>
+                    <cx:dataId val="1"/>
+                    <cx:layoutPr>
+                      <cx:visibility meanLine="1" meanMarker="0" nonoutliers="1" outliers="0"/>
+                      <cx:statistics quartileMethod="inclusive"/>
+                    </cx:layoutPr>
+                  </cx:series>
+                </cx:plotAreaRegion></cx:plotArea>
+              </cx:chart>
+            </cx:chartSpace>"#
+        );
+        let d = chart_space_of(&xml);
+        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("boxWhisker parses");
+        assert_eq!(m.chart_type, "boxWhisker");
+        assert_eq!(m.title.as_deref(), Some("My box chart"));
+        assert_eq!(
+            m.chartex_accents.as_deref(),
+            Some(
+                &["5B9BD5", "ED7D31", "A5A5A5", "FFC000", "4472C4", "70AD47"].map(String::from)[..]
+            )
+        );
+        let box_data = m.chartex_box.expect("box data present");
+        assert_eq!(box_data.categories, vec!["Cat A", "Cat B"]);
+        assert_eq!(box_data.series.len(), 2);
+
+        let s0 = &box_data.series[0];
+        assert_eq!(s0.name, "Series1");
+        assert_eq!(s0.color.as_deref(), Some("5B9BD5")); // accent1 (series idx 0)
+                                                         // Series1: Cat A got points 1 & 3, Cat B got 10.
+        assert_eq!(s0.values_by_category, vec![vec![1.0, 3.0], vec![10.0]]);
+        assert!(s0.mean_marker && !s0.mean_line && s0.show_outliers && !s0.show_nonoutliers);
+        assert_eq!(s0.quartile_method, "exclusive");
+
+        let s1 = &box_data.series[1];
+        assert_eq!(s1.name, "Series2");
+        assert_eq!(s1.color.as_deref(), Some("ED7D31")); // accent2 (series idx 1)
+                                                         // Series2: Cat A got 5, Cat B got 7 & 9.
+        assert_eq!(s1.values_by_category, vec![vec![5.0], vec![7.0, 9.0]]);
+        assert!(!s1.mean_marker && s1.mean_line && !s1.show_outliers && s1.show_nonoutliers);
+        assert_eq!(s1.quartile_method, "inclusive");
+    }
+
+    /// A sunburst with three `<cx:lvl>` (Leaf / Stem / Branch, in document
+    /// order) and a `<cx:numDim type="size">`. Verifies each row's path is built
+    /// root→leaf (Branch first) with empty trailing (leaf) cells trimmed so a
+    /// node that is itself a leaf terminates early, and that sizes attach by idx.
+    #[test]
+    fn parse_chartex_part_sunburst_hierarchy_paths_trim_empty_tail() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+              <cx:chartData><cx:data id="0">
+                <cx:strDim type="cat">
+                  <cx:lvl ptCount="3">
+                    <cx:pt idx="0">Leaf 1</cx:pt><cx:pt idx="1"/><cx:pt idx="2">Leaf 3</cx:pt>
+                  </cx:lvl>
+                  <cx:lvl ptCount="3">
+                    <cx:pt idx="0">Stem 1</cx:pt><cx:pt idx="1">Leaf 2</cx:pt><cx:pt idx="2">Stem 2</cx:pt>
+                  </cx:lvl>
+                  <cx:lvl ptCount="3">
+                    <cx:pt idx="0">Branch 1</cx:pt><cx:pt idx="1">Branch 1</cx:pt><cx:pt idx="2">Branch 2</cx:pt>
+                  </cx:lvl>
+                </cx:strDim>
+                <cx:numDim type="size"><cx:lvl ptCount="3">
+                  <cx:pt idx="0">22</cx:pt><cx:pt idx="1">17</cx:pt><cx:pt idx="2">18</cx:pt>
+                </cx:lvl></cx:numDim>
+              </cx:data></cx:chartData>
+              <cx:chart>
+                <cx:title><cx:tx><cx:rich><a:p><a:r><a:t>My sunburst</a:t></a:r></a:p></cx:rich></cx:tx></cx:title>
+                <cx:plotArea><cx:plotAreaRegion>
+                  <cx:series layoutId="sunburst"><cx:dataId val="0"/></cx:series>
+                </cx:plotAreaRegion></cx:plotArea>
+              </cx:chart>
+            </cx:chartSpace>"#
+        );
+        let d = chart_space_of(&xml);
+        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("sunburst parses");
+        assert_eq!(m.chart_type, "sunburst");
+        assert_eq!(m.title.as_deref(), Some("My sunburst"));
+        let sb = m.chartex_sunburst.expect("sunburst data present");
+        assert_eq!(sb.rows.len(), 3);
+        // Row 0: full Branch→Stem→Leaf chain.
+        assert_eq!(sb.rows[0].path, vec!["Branch 1", "Stem 1", "Leaf 1"]);
+        assert_eq!(sb.rows[0].size, 22.0);
+        // Row 1: empty Leaf cell → path terminates at Stem ("Leaf 2" is itself a leaf).
+        assert_eq!(sb.rows[1].path, vec!["Branch 1", "Leaf 2"]);
+        assert_eq!(sb.rows[1].size, 17.0);
+        // Row 2: full chain under a different branch.
+        assert_eq!(sb.rows[2].path, vec!["Branch 2", "Stem 2", "Leaf 3"]);
+        assert_eq!(sb.rows[2].size, 18.0);
+    }
+
+    /// A waterfall chart (the pre-CH15 chartEx path) must NOT get any of the new
+    /// boxWhisker/sunburst structured fields — they stay `None`, keeping the wire
+    /// byte-stable for the flat-model chartEx renderers.
+    #[test]
+    fn parse_chartex_part_waterfall_leaves_chartex_box_sunburst_none() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}">
+              <cx:chartData><cx:data id="0">
+                <cx:strDim type="cat"><cx:lvl ptCount="1"><cx:pt idx="0">A</cx:pt></cx:lvl></cx:strDim>
+                <cx:numDim type="val"><cx:lvl ptCount="1"><cx:pt idx="0">5</cx:pt></cx:lvl></cx:numDim>
+              </cx:data></cx:chartData>
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                <cx:series layoutId="waterfall"/>
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+            </cx:chartSpace>"#
+        );
+        let d = chart_space_of(&xml);
+        let m = parse_chartex_part(d.root_element(), &FixtureResolver).expect("waterfall parses");
+        assert!(m.chartex_box.is_none());
+        assert!(m.chartex_sunburst.is_none());
+        assert!(m.chartex_accents.is_none());
+        assert!(m.title.is_none());
     }
 
     // ── CH13: 3D flattening / stock / ofPie type detection ───────────────────

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -67,11 +67,17 @@ pub(crate) fn parse_legacy_chart(
 /// wraps the resulting [`ChartModel`] in a pptx [`ChartElement`] graphic frame.
 /// The frame geometry (`x`/`y`/`width`/`height`) is filled in by the caller
 /// from the slide's `<p:graphicFrame><a:xfrm>`; here it defaults to 0.
-pub(crate) fn parse_chartex(xml: &str, theme: &HashMap<String, String>) -> Option<ChartElement> {
+pub(crate) fn parse_chartex(
+    xml: &str,
+    style_xml: Option<&str>,
+    theme: &HashMap<String, String>,
+) -> Option<ChartElement> {
     let doc = roxmltree::Document::parse(xml).ok()?;
     let root = doc.root_element();
     let resolver = PptxColorResolver { theme };
-    let chart = ooxml_common::chart::parse_chartex_part(root, &resolver)?;
+    // chartEx (waterfall/boxWhisker/…) reads its title font size from the
+    // associated chartStyle part when the `<cx:title>` itself carries none.
+    let chart = ooxml_common::chart::parse_chartex_part(root, &resolver, style_xml)?;
     Some(ChartElement {
         x: 0,
         y: 0,

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1747,7 +1747,7 @@ mod tests {
             .read_to_string(&mut xml)
             .unwrap();
         let theme = HashMap::new();
-        let result = parse_chartex(&xml, &theme);
+        let result = parse_chartex(&xml, None, &theme);
         println!("parse_chartex result: {:?}", result.is_some());
         if let Some(ref c) = result {
             println!("  chart_type: {}", c.chart.chart_type);
@@ -1859,7 +1859,7 @@ mod tests {
 
         if let Ok(chart_xml) = result {
             let theme = HashMap::new();
-            let r = parse_chartex(&chart_xml, &theme);
+            let r = parse_chartex(&chart_xml, None, &theme);
             println!("parse_chartex: {:?}", r.is_some());
         }
     }

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -16,13 +16,29 @@ use crate::text::{
 };
 use crate::types::*;
 use crate::{
-    attr, attr_f64, attr_i64, attr_r, child, read_zip_str, resolve_path, table_style_presets,
-    PptxZip, TableStyleDef,
+    attr, attr_f64, attr_i64, attr_r, child, find_rel_target_by_type, read_zip_str, resolve_path,
+    table_style_presets, PptxZip, TableStyleDef,
 };
 use ooxml_common::blip::{mime_from_ext, parse_src_rect, svg_blip_rid};
 use ooxml_common::ns::{is_diagram_uri, is_pml_ole_uri};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
+
+/// Read the chartStyle part (`styleN.xml`) associated with a chart part at
+/// `chart_path` (e.g. `ppt/charts/chart1.xml`), following that part's own
+/// relationships (`ppt/charts/_rels/chart1.xml.rels`) to the
+/// `.../2011/relationships/chartStyle` target. Returns `None` when the chart
+/// has no chartStyle relationship or the part cannot be read (the chartEx
+/// title then falls back to its inline size, or the renderer's default).
+fn load_chart_style_xml(zip: &mut PptxZip, chart_path: &str) -> Option<String> {
+    let (dir, file) = chart_path.rsplit_once('/')?;
+    let rels_path = format!("{}/_rels/{}.rels", dir, file);
+    let rels_xml = read_zip_str(zip, &rels_path).ok()?;
+    let target =
+        find_rel_target_by_type(&rels_xml, ooxml_common::chart::CHART_STYLE_REL_TYPE_SUFFIX)?;
+    let style_path = resolve_path(dir, &target);
+    read_zip_str(zip, &style_path).ok()
+}
 
 /// OOXML spec default positions for common placeholder types.
 /// Values are in EMU, assuming a 9144000×6858000 slide (10"×7.5").
@@ -1845,7 +1861,12 @@ pub(crate) fn parse_sp_tree_node(
                         let chart_path = resolve_path(slide_dir, rel_target);
                         if let Ok(chart_xml) = read_zip_str(zip, &chart_path) {
                             let chart_opt = if uri.contains("chartex") || uri.contains("chartEx") {
-                                parse_chartex(&chart_xml, theme)
+                                // chartEx title font size lives in the chart
+                                // part's associated chartStyle sidecar
+                                // (`styleN.xml`), reached via that part's OWN
+                                // rels. Read it best-effort before parsing.
+                                let style_xml = load_chart_style_xml(zip, &chart_path);
+                                parse_chartex(&chart_xml, style_xml.as_deref(), theme)
                             } else {
                                 parse_legacy_chart(&chart_xml, theme)
                             };

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1,7 +1,23 @@
 use crate::types::*;
-use crate::{parse_rels_map, resolve_fill_color, resolve_zip_path};
+use crate::{find_rel_target_by_type, parse_rels_map, resolve_fill_color, resolve_zip_path};
 use ooxml_common::ns::{is_c_ns, is_r_ns, is_xdr_ns};
 use ooxml_common::zip::read_zip_string;
+
+/// Read the chartStyle part (`styleN.xml`) associated with a chart part at
+/// `chart_path` (e.g. `xl/charts/chart1.xml`), following that part's own
+/// relationships (`xl/charts/_rels/chart1.xml.rels`) to the
+/// `.../2011/relationships/chartStyle` target. Returns `None` when the chart
+/// has no chartStyle relationship or the part cannot be read (the chartEx
+/// title then falls back to its inline size, or the renderer's default).
+fn load_chart_style_xml(archive: &mut crate::XlsxZip, chart_path: &str) -> Option<String> {
+    let (dir, file) = chart_path.rsplit_once('/')?;
+    let rels_path = format!("{}/_rels/{}.rels", dir, file);
+    let rels_xml = read_zip_string(archive, &rels_path).ok()?;
+    let target =
+        find_rel_target_by_type(&rels_xml, ooxml_common::chart::CHART_STYLE_REL_TYPE_SUFFIX)?;
+    let style_path = resolve_zip_path(dir, &target);
+    read_zip_string(archive, &style_path).ok()
+}
 
 /// Given a sheet path (e.g. "worksheets/sheet1.xml"), locate and parse
 /// its drawing(s) for chart anchors (`<xdr:graphicFrame>` elements).
@@ -201,6 +217,13 @@ pub(crate) fn load_sheet_charts(
             let Ok(chart_xml) = read_zip_string(archive, &chart_path) else {
                 continue;
             };
+            // A chartEx part reads its title font size from the associated
+            // chartStyle sidecar (`styleN.xml`), reached via the chart part's
+            // OWN rels (`xl/charts/_rels/chartN.xml.rels`,
+            // `.../2011/relationships/chartStyle`). Read it best-effort now
+            // (before the chart doc is parsed, since both borrow `archive`);
+            // legacy `<c:>` charts ignore it (their title size is inline).
+            let style_xml = load_chart_style_xml(archive, &chart_path);
             // Parse the chart directly through the shared `parse_chart_part`
             // (the single superset parser for pptx + xlsx). The xlsx theme
             // palette + major/minor Latin faces ride on the `XlsxColorResolver`,
@@ -220,7 +243,11 @@ pub(crate) fn load_sheet_charts(
                 theme_minor_font_latin: theme_fonts.1,
             };
             let chart_opt = if is_chartex {
-                ooxml_common::chart::parse_chartex_part(chart_doc.root_element(), &resolver)
+                ooxml_common::chart::parse_chartex_part(
+                    chart_doc.root_element(),
+                    &resolver,
+                    style_xml.as_deref(),
+                )
             } else {
                 ooxml_common::chart::parse_chart_part(chart_doc.root_element(), &resolver)
             };

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1356,6 +1356,22 @@ pub(crate) fn parse_rels_map(xml: &str) -> HashMap<String, String> {
         .collect()
 }
 
+/// Target of the first `<Relationship>` whose `Type` ends with `type_suffix`.
+/// Matched by `ends_with` so both the Transitional and Strict namespace
+/// prefixes resolve (mirrors pptx/docx `find_rel_target_by_type`). `None` when
+/// no relationship of that type is present or the XML is malformed.
+pub(crate) fn find_rel_target_by_type(rels_xml: &str, type_suffix: &str) -> Option<String> {
+    let doc = roxmltree::Document::parse(rels_xml).ok()?;
+    for rel in doc.root_element().children().filter(|n| n.is_element()) {
+        if let Some(rel_type) = rel.attribute("Type") {
+            if rel_type.ends_with(type_suffix) {
+                return rel.attribute("Target").map(|t| t.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Parse xl/comments{N}.xml referenced from the sheet's rels and collect the
 /// list of A1-style cell refs that have a `<comment>` associated. The
 /// renderer draws a small red triangle in each cell's top-right corner to


### PR DESCRIPTION
## Summary
CH15 — the final Phase 2 item. boxWhisker and sunburst chartEx charts now render for real (previously typed placeholders). Ground truth: user-authored Word sample `private/sample-24.pdf` p.2 (box & whisker) / p.3 (sunburst).

## Parser extension (shared, layoutId-gated)
The flat chartEx parse was unusable for these types (single series over pseudo-categories). `parse_chartex_part` now emits structured data, gated on `layoutId` so **waterfall/treemap remain byte-stable**:
- **boxWhisker**: per-series raw sample points binned per category (`chartexBox`), plus `<cx:layoutPr>` statistics/visibility flags and `quartileMethod`.
- **sunburst**: multi-level `<cx:strDim>` (Branch/Stem/Leaf) + `<cx:numDim type="size">` as root→leaf `path` rows (`chartexSunburst`), leaf cells trimmed.
- Also: chartEx `<cx:title>` rich text and theme accents via the existing `ColorResolver::resolve_series_accent`.

## Renderers (core)
- `renderBoxWhiskerChart` (`2c45680`): IQR box, median line, whiskers + caps, mean ×, outlier dots beyond the 1.5·IQR fence; exclusive/inclusive quartile methods; Excel nice-axis (−100..150 step 50 on the fixture).
- `renderSunburstChart` (`c901c6f`): hierarchical rings, size-proportional angles, per-branch accent colors, arc-rotated wrapped white labels, center hole.

## PDF fidelity
- **boxWhisker**: structural match — 3 cats × 3 series, boxes/medians/means/whiskers align; the Cat-1 orange outlier at 128 draws as a dot; quartile math verified numerically against the PDF.
- **sunburst**: rings/hole/colors/labels and the Branch 1 sweep (incl. internal leaf order) match. One documented difference: Excel orders branches after the first in an undocumented rotational order (measured 1,3,2 vs source 1,2,3); matching would require reverse-engineering a runtime choice, which the spec-first policy forbids — noted in a code comment.
- treemap intentionally skipped: no ground-truth fixture and the flat model only covers single-level; not shipping an unverifiable renderer.

## Gates
- cargo: ooxml-common 180 (+3), fmt/clippy(-D warnings) clean.
- core vitest 224 (+8); **renderer-signature 18/18 — waterfall and every existing chart byte-identical**; tsc clean.
- docx vitest 592; docx VRT 24 pass (sample-24 p.2/p.3 = 100% vs regenerated private references, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)