### PR TITLE
feat(charts): pie data-label callout boxes + leader lines (bestFit)

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2233,3 +2233,108 @@ describe('CH13 — stock chart (high/low/close)', () => {
     expect(hiLoLines(rec.segs).length).toBe(3);
   });
 });
+
+// ─── CH14 — pie callout data labels (Word boxed labels, §21.2.2.197) ─────────
+//
+// When a pie/doughnut series `<c:dLbls>` carries a `<c:spPr>` box shape the
+// labels are drawn as boxed callouts OUTSIDE each slice: a filled+bordered
+// rectangle with the category name and percent on separate lines, plus a
+// leader line back to the rim for a box pulled far from its slice. Without a
+// box shape the historical plain-text label path is preserved.
+
+/** A pie model whose series data labels request Word's boxed callout layout. */
+function pieCalloutModel(over: Partial<ChartModel> = {}): ChartModel {
+  return baseModel({
+    chartType: 'pie',
+    categories: ['Brazil', 'Vietnam', 'Colombia', 'Indonesia', 'Honduras', 'Other'],
+    series: [series({
+      name: 'Prod',
+      values: [51500, 28500, 14000, 10800, 8349, 61000],
+      seriesDataLabels: {
+        showVal: false, showCatName: true, showSerName: false, showPercent: true,
+        position: 'bestFit',
+        labelBox: { fill: 'FFFFFF', borderColor: '4472C4', borderWidthEmu: 12700 },
+        showLeaderLines: true,
+        leaderLineColor: 'A6A6A6',
+        leaderLineWidthEmu: 9525,
+      },
+      dataLabelOverrides: [
+        // idx 0 (Brazil) is a per-point styling override: empty text (reuses the
+        // composed cat/percent), blue font, its own box.
+        { idx: 0, text: '', position: 'bestFit', fontColor: '4472C4', fontSizeHpt: 1000, fontBold: false,
+          labelBox: { fill: 'FFFFFF', borderColor: '4472C4', borderWidthEmu: 12700 } },
+      ],
+    })],
+    ...over,
+  });
+}
+
+describe('CH14 — pie callout data labels', () => {
+  it('draws a filled callout box per slice (category name + percent on separate lines)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, pieCalloutModel(), RECT, 1);
+    // White box fills — one per drawn label. The box fill is the parsed white
+    // (`#FFFFFF`); the slice wedges fill with palette colors, so filter on the
+    // box color to isolate the callout rectangles.
+    const boxes = rec.rects.filter(r => r.fs === '#FFFFFF');
+    expect(boxes.length).toBe(6);
+    // Category names and percents are drawn as SEPARATE fillText lines.
+    const texts = rec.texts.map(t => t.text);
+    expect(texts).toContain('Brazil');
+    expect(texts).toContain('Other');
+    expect(texts).toContain('30%'); // 51500 / 174149 ≈ 29.6% → 30
+    expect(texts).toContain('16%'); // 28500 / 174149 ≈ 16.4% → 16
+    // No space-joined "Brazil 30%" composite — category and percent are split.
+    expect(texts.some(t => /Brazil\s+\d/.test(t))).toBe(false);
+  });
+
+  it('colors the per-point (Brazil) label with its override font color', () => {
+    // Purpose-built context that snapshots fillStyle with each fillText so the
+    // per-point font-color override (`#4472C4` for Brazil vs `#000` default)
+    // can be asserted directly.
+    const calls: { text: string; fs: string }[] = [];
+    const state: Record<string, unknown> = {
+      font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+      textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+    };
+    const handler: ProxyHandler<Record<string, unknown>> = {
+      get(_t, prop: string) {
+        if (prop in state && typeof state[prop] !== 'function') return state[prop];
+        if (prop === 'measureText') return (t: string) => ({ width: String(t).length * 6 });
+        if (prop === 'fillText') return (text: string) => calls.push({ text, fs: String(state.fillStyle) });
+        if (prop === 'createLinearGradient' || prop === 'createRadialGradient') return () => ({ addColorStop() {} });
+        return () => undefined;
+      },
+      set(_t, prop: string, value) { state[prop] = value; return true; },
+    };
+    const ctx = new Proxy(state, handler) as unknown as CanvasRenderingContext2D;
+    renderChart(ctx, pieCalloutModel(), RECT, 1);
+    const brazil = calls.find(c => c.text === 'Brazil');
+    expect(brazil?.fs).toBe('#4472C4');
+    // A non-overridden slice uses the default black font (no series fontColor).
+    const other = calls.find(c => c.text === 'Other');
+    expect(other?.fs).toBe('#000');
+  });
+
+  it('draws leader lines in the parsed leader color when a box is pulled off its slice', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, pieCalloutModel(), RECT, 1);
+    // Leader lines are stroked in the parsed leader color (#A6A6A6). The small
+    // slices (Colombia/Indonesia/Honduras) get pulled far enough out to draw a
+    // leader; assert at least one leader segment exists in that color.
+    const leaders = rec.segs.filter(s => s.ss === '#A6A6A6');
+    expect(leaders.length).toBeGreaterThan(0);
+  });
+
+  it('keeps plain-text labels (no boxes) when the dLbls carries no box shape', () => {
+    const rec = recordingCtx();
+    const model = pieCalloutModel();
+    // Strip the box → falls back to the historical plain outer-ring text path.
+    const sdl = model.series[0].seriesDataLabels;
+    if (sdl) { sdl.labelBox = undefined; sdl.showLeaderLines = false; }
+    model.series[0].dataLabelOverrides = null;
+    renderChart(rec.ctx, model, RECT, 1);
+    // No white callout boxes are drawn.
+    expect(rec.rects.filter(r => r.fs === '#FFFFFF').length).toBe(0);
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3,7 +3,7 @@
 // scatter, waterfall). Ported from the xlsx implementation with pptx
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
-import type { ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, SecondaryValueAxis } from '../types/chart';
+import type { ChartDataLabelOverride, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, SecondaryValueAxis } from '../types/chart';
 import {
   computeChartFrame,
   cartesianTitleBand,
@@ -2597,7 +2597,7 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // slices. Only runs when a rich definition is present; the plain percent
   // labels above are byte-identical to the pre-CH8 pie.
   if (hasRichLabels) {
-    drawPieRichLabels(ctx, chart, richDef, s, cats, vals, total, cx2, cy2, outerR, innerR, startAngle, dLblFont);
+    drawPieRichLabels(ctx, chart, richDef, s, cats, vals, total, cx2, cy2, outerR, innerR, startAngle, dLblFont, ptToPx, x, w, y, h);
   }
 
   if (pieLeg) {
@@ -2619,7 +2619,14 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
  *  `<c:dLbls>` (§21.2.2.35: showVal / showCatName / showSerName / showPercent +
  *  dLblPos). Only called when such a definition exists; the plain percent-label
  *  path stays inline in the slice loop (byte-stable). `font` is the pre-resolved
- *  data-label CSS font-family. */
+ *  data-label CSS font-family.
+ *
+ *  When the `<c:dLbls>` carries a callout-box shape (`<c:spPr>` → `def.labelBox`,
+ *  §21.2.2.197) the labels are drawn Word-style: each is a boxed callout placed
+ *  OUTSIDE its slice at the slice mid-angle, with adjacent boxes pushed apart to
+ *  avoid overlap (`bestFit`), and a leader line back to the rim for any box that
+ *  ends up far from its slice. Without a box shape the historical plain-text
+ *  layout is preserved byte-for-byte. */
 function drawPieRichLabels(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -2632,7 +2639,15 @@ function drawPieRichLabels(
   outerR: number, innerR: number,
   startAngle: number,
   font: string,
+  ptToPx: number,
+  boundsX: number, boundsW: number, boundsY: number, boundsH: number,
 ): void {
+  // Callout mode: a `<c:spPr>` box shape on the dLbls (Word's boxed pie labels).
+  if (def.labelBox) {
+    drawPieCalloutLabels(ctx, chart, def, s, cats, vals, total, cx2, cy2, outerR, startAngle, font, ptToPx, boundsX, boundsW, boundsY, boundsH);
+    return;
+  }
+
   let angle = startAngle;
   for (let i = 0; i < vals.length; i++) {
     const slice = (vals[i] / total) * Math.PI * 2;
@@ -2660,6 +2675,219 @@ function drawPieRichLabels(
     ctx.fillStyle = def.fontColor ? `#${def.fontColor}` : (outside ? '#333' : '#fff');
     ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
     ctx.fillText(text, lx2, ly2);
+  }
+}
+
+/** One laid-out pie callout label: its wrapped text lines, box rectangle, the
+ *  rim anchor point on its slice, and the resolved per-point style. */
+interface PieCalloutLabel {
+  lines: string[];
+  /** Slice mid-angle (canvas radians) — the leader-line target direction. */
+  midAngle: number;
+  /** Rim anchor point (on the outer arc at `midAngle`). */
+  rimX: number;
+  rimY: number;
+  /** Half-height of the text block (px) — box grows symmetrically around cy. */
+  boxW: number;
+  boxH: number;
+  /** Box centre (mutated by the collision pass). */
+  cxBox: number;
+  cyBox: number;
+  /** true when the label sits on the left half (box hangs to the left). */
+  leftSide: boolean;
+  fontColor: string;
+  boxFill: string | null;
+  boxBorder: string | null;
+  boxBorderPx: number;
+  fontPx: number;
+  bold: boolean;
+}
+
+/** Word-style boxed pie/doughnut callout labels (`bestFit`). Each label is a
+ *  filled+bordered rectangle placed just outside its slice at the slice
+ *  mid-angle; adjacent boxes on the same side are pushed vertically apart so
+ *  they do not overlap, and a leader line is drawn back to the rim for any box
+ *  whose gap from the rim exceeds a small threshold. Style (box fill/border,
+ *  leader colour/width, per-point font colour and box overrides) all comes from
+ *  the parsed model — no empirical constants beyond the layout paddings, which
+ *  are geometry (not spec values). */
+function drawPieCalloutLabels(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  def: ChartSeriesDataLabels,
+  s: ChartSeries,
+  cats: string[],
+  vals: number[],
+  total: number,
+  cx2: number, cy2: number,
+  outerR: number,
+  startAngle: number,
+  font: string,
+  ptToPx: number,
+  boundsX: number, boundsW: number, boundsY: number, boundsH: number,
+): void {
+  const overrides = s.dataLabelOverrides ?? [];
+  const findOverride = (i: number): ChartDataLabelOverride | undefined =>
+    overrides.find(o => o.idx === i);
+
+  // Base font size: series default (hpt → px) or a radius-relative fallback.
+  const baseFontPx = def.fontSizeHpt ? def.fontSizeHpt / 100 : Math.max(9, outerR * 0.09);
+  // Box padding around the text block (px). Geometry, not a spec constant.
+  const padX = Math.max(4, baseFontPx * 0.45);
+  const padY = Math.max(2, baseFontPx * 0.28);
+  const lineGap = baseFontPx * 0.22;
+
+  const seriesBox = def.labelBox;
+
+  // ── Build each label: wrapped lines + measured box + rim anchor ──────────
+  const labels: PieCalloutLabel[] = [];
+  let angle = startAngle;
+  for (let i = 0; i < vals.length; i++) {
+    const slice = (vals[i] / total) * Math.PI * 2;
+    const midAngle = angle + slice / 2;
+    angle += slice;
+    if (slice <= 0) continue;
+
+    const ov = findOverride(i);
+    // A `<c:delete val="1"/>` label carries an empty override text and NO
+    // styling — skip it entirely. A per-point *styling* override (sample-25's
+    // idx 0) also has text==="" but carries position/fontColor/box, in which
+    // case the label is still drawn using the composed cat/percent text.
+    const isDeleted = ov != null && ov.text === '' && ov.position === undefined
+      && ov.fontColor === undefined && ov.fontSizeHpt === undefined
+      && ov.fontBold === undefined && ov.labelBox === undefined;
+    if (isDeleted) continue;
+
+    // §21.2.2.35 composition. Word stacks category name and percent on
+    // SEPARATE lines (see sample-25.pdf), so each `show*` part is its own line
+    // rather than space-joined.
+    const lines: string[] = [];
+    if (def.showCatName) { const c = (cats[i] ?? '').toString(); if (c) lines.push(c); }
+    if (def.showSerName && s.name) lines.push(s.name);
+    if (def.showVal) lines.push(formatChartValWithCode(vals[i], def.formatCode ?? null, chart.date1904 ?? false));
+    if (def.showPercent) lines.push(`${Math.round((vals[i] / total) * 100)}%`);
+    if (lines.length === 0) continue;
+
+    // Per-point overrides (font colour/size/bold + box), else series defaults.
+    const fontPx = ov?.fontSizeHpt ? ov.fontSizeHpt / 100 : baseFontPx;
+    const bold = ov?.fontBold ?? def.fontBold ?? false;
+    const fontColor = ov?.fontColor ? `#${ov.fontColor}` : (def.fontColor ? `#${def.fontColor}` : '#000');
+    const box = ov?.labelBox ?? seriesBox;
+    const boxFill = box?.fill ? `#${box.fill}` : null;
+    const boxBorder = box?.borderColor ? `#${box.borderColor}` : null;
+    const boxBorderPx = box?.borderWidthEmu
+      ? Math.max(0.75, (box.borderWidthEmu / EMU_PER_PT) * ptToPx)
+      : 1;
+
+    // Measure the widest line to size the box.
+    ctx.font = `${bold ? 'bold ' : ''}${fontPx}px ${font}`;
+    let textW = 0;
+    for (const ln of lines) textW = Math.max(textW, ctx.measureText(ln).width);
+    const lineH = fontPx + lineGap;
+    const boxW = textW + padX * 2;
+    const boxH = lines.length * lineH - lineGap + padY * 2;
+
+    const rimX = cx2 + Math.cos(midAngle) * outerR;
+    const rimY = cy2 + Math.sin(midAngle) * outerR;
+    const leftSide = Math.cos(midAngle) < 0;
+
+    // Initial box centre: outside the rim along the mid-angle. The gap scales
+    // with the box so small slices get pulled further out (Word `bestFit`).
+    const outGap = Math.max(boxW, boxH) * 0.55 + outerR * 0.06;
+    const cxBox = rimX + Math.cos(midAngle) * outGap;
+    const cyBox = rimY + Math.sin(midAngle) * outGap;
+
+    labels.push({
+      lines, midAngle, rimX, rimY, boxW, boxH, cxBox, cyBox,
+      leftSide, fontColor, boxFill, boxBorder, boxBorderPx, fontPx, bold,
+    });
+  }
+
+  // ── Collision pass (bestFit): split into left/right columns and push boxes
+  //    apart vertically so their rectangles do not overlap. Word lays labels
+  //    out radially then de-overlaps; this greedy top-down separation +
+  //    within-bounds fit-back is a faithful, deterministic approximation (no
+  //    sample-specific tuning). ──
+  const topLimit = boundsY + 2;
+  const bottomLimit = boundsY + boundsH - 2;
+  const separate = (col: PieCalloutLabel[]): void => {
+    if (col.length === 0) return;
+    col.sort((a, b) => a.cyBox - b.cyBox);
+    // Push each box below the previous one by at least their combined half
+    // heights (+ a small gap) so rectangles never overlap.
+    for (let k = 1; k < col.length; k++) {
+      const prev = col[k - 1];
+      const cur = col[k];
+      const minGap = (prev.boxH + cur.boxH) / 2 + 3;
+      if (cur.cyBox - prev.cyBox < minGap) cur.cyBox = prev.cyBox + minGap;
+    }
+    // If the stack now runs past the bottom bound, slide the whole column up
+    // (but not above the top bound) so it stays inside the chart area.
+    const last = col[col.length - 1];
+    const overflow = (last.cyBox + last.boxH / 2) - bottomLimit;
+    if (overflow > 0) for (const l of col) l.cyBox -= overflow;
+    const first = col[0];
+    const underflow = topLimit - (first.cyBox - first.boxH / 2);
+    if (underflow > 0) for (const l of col) l.cyBox += underflow;
+  };
+  separate(labels.filter(l => !l.leftSide));
+  separate(labels.filter(l => l.leftSide));
+
+  // Horizontal clamp: keep each box fully inside the chart rect.
+  const leftLimit = boundsX + 2;
+  const rightLimit = boundsX + boundsW - 2;
+  for (const l of labels) {
+    const half = l.boxW / 2;
+    if (l.cxBox - half < leftLimit) l.cxBox = leftLimit + half;
+    if (l.cxBox + half > rightLimit) l.cxBox = rightLimit - half;
+  }
+
+  // ── Draw leader lines first (under the boxes), then boxes + text ─────────
+  const leaderColor = def.leaderLineColor ? `#${def.leaderLineColor}` : '#a6a6a6';
+  const leaderPx = def.leaderLineWidthEmu
+    ? Math.max(0.5, (def.leaderLineWidthEmu / EMU_PER_PT) * ptToPx)
+    : 1;
+
+  for (const l of labels) {
+    // The box edge nearest the pie centre — where a leader line should meet.
+    const edgeX = l.cxBox + (l.leftSide ? l.boxW / 2 : -l.boxW / 2);
+    const edgeY = l.cyBox;
+    // Distance from the box's inner edge to its slice rim. When the box abuts
+    // the slice the leader is redundant; draw one only past a small threshold.
+    const dx = edgeX - l.rimX;
+    const dy = edgeY - l.rimY;
+    const dist = Math.hypot(dx, dy);
+    if (def.showLeaderLines && dist > l.fontPx * 0.9) {
+      ctx.beginPath();
+      ctx.moveTo(l.rimX, l.rimY);
+      ctx.lineTo(edgeX, edgeY);
+      ctx.strokeStyle = leaderColor;
+      ctx.lineWidth = leaderPx;
+      ctx.stroke();
+    }
+  }
+
+  for (const l of labels) {
+    const bx = l.cxBox - l.boxW / 2;
+    const by = l.cyBox - l.boxH / 2;
+    // Box fill + border (§21.2.2.197 spPr). Fill may carry an 8-digit RGBA hex
+    // (e.g. a 90%-opacity white) — valid canvas fillStyle.
+    if (l.boxFill) { ctx.fillStyle = l.boxFill; ctx.fillRect(bx, by, l.boxW, l.boxH); }
+    if (l.boxBorder) {
+      ctx.strokeStyle = l.boxBorder;
+      ctx.lineWidth = l.boxBorderPx;
+      ctx.strokeRect(bx, by, l.boxW, l.boxH);
+    }
+    // Text: centred, stacked lines.
+    ctx.font = `${l.bold ? 'bold ' : ''}${l.fontPx}px ${font}`;
+    ctx.fillStyle = l.fontColor;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const lineH = l.fontPx + lineGap;
+    const blockTop = l.cyBox - (l.lines.length * lineH - lineGap) / 2 + l.fontPx / 2;
+    for (let li = 0; li < l.lines.length; li++) {
+      ctx.fillText(l.lines[li], l.cxBox, blockTop + li * lineH);
+    }
   }
 }
 

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -195,6 +195,23 @@ export interface ChartDataLabelOverride {
   fontSizeHpt?: number;
   /** `<a:defRPr b="1">` inside the per-idx rich text. */
   fontBold?: boolean;
+  /** Per-point callout box (`<c:dLbl><c:spPr>`, ECMA-376 §21.2.2.47/§21.2.2.197):
+   *  overrides the series-default box for this one slice. */
+  labelBox?: ChartLabelBox;
+}
+
+/** Callout-box style for a pie/doughnut data label — the white (or themed)
+ *  rounded rectangle with a thin border Word draws around a `bestFit` label
+ *  placed outside its slice. From the label's `<c:spPr>` (§21.2.2.197). All
+ *  fields optional: absent → transparent / unbordered. Mirror of Rust
+ *  `ChartLabelBox`. */
+export interface ChartLabelBox {
+  /** `<a:solidFill>` resolved hex (no `#`). Box background. */
+  fill?: string;
+  /** `<a:ln><a:solidFill>` resolved hex (no `#`). Border stroke. */
+  borderColor?: string;
+  /** `<a:ln w>` border width in EMU (12700 EMU = 1 pt). */
+  borderWidthEmu?: number;
 }
 
 export interface ChartSeriesDataLabels {
@@ -209,6 +226,18 @@ export interface ChartSeriesDataLabels {
   fontBold?: boolean;
   /** Series-level font size for data labels (OOXML hundredths of a point). */
   fontSizeHpt?: number;
+  /** Series-default callout box (`<c:dLbls><c:spPr>`, ECMA-376 §21.2.2.49/
+   *  §21.2.2.197). When present the pie/doughnut renderer draws Word's boxed
+   *  callout layout (box + optional leader line) instead of plain text. */
+  labelBox?: ChartLabelBox;
+  /** `<c:dLbls><c:showLeaderLines val>` (§21.2.2.183) — draw leader lines from
+   *  a pulled-away label back to its slice. Default false. */
+  showLeaderLines?: boolean;
+  /** `<c:leaderLines><c:spPr><a:ln><a:solidFill>` (§21.2.2.92) resolved hex
+   *  (no `#`). undefined → renderer uses a neutral grey. */
+  leaderLineColor?: string;
+  /** `<c:leaderLines><c:spPr><a:ln w>` leader-line width in EMU. */
+  leaderLineWidthEmu?: number;
 }
 
 export interface ChartErrBars {

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -166,7 +166,7 @@ pub struct ChartModel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secondary_val_axis: Option<SecondaryValueAxis>,
     // ── Pie / doughnut geometry (CH8) ───────────────────────────────────────
-    /// `<c:doughnutChart><c:holeSize val>` (§21.2.2.60, `ST_HoleSizePercent`
+    /// `<c:doughnutChart><c:holeSize val>` (§21.2.2.82, `ST_HoleSizePercent`
     /// §21.2.3.55) — hole diameter as 1–90% of the outer diameter. `None` when
     /// absent; the renderer defaults an absent doughnut hole to 50%.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1169,7 +1169,7 @@ pub fn extract_legend_font_color(root: Node, resolver: &dyn ColorResolver) -> Op
 // Pie / doughnut geometry (CH8)
 // ============================================================================
 
-/// `<c:doughnutChart><c:holeSize val>` (§21.2.2.60) — hole diameter percentage
+/// `<c:doughnutChart><c:holeSize val>` (§21.2.2.82) — hole diameter percentage
 /// (1–90). Clamped to the ECMA range. `None` when absent. `root` is the chart
 /// space (or `<c:chart>`); the search is scoped to a `<c:doughnutChart>` so a
 /// hole size only ever comes from a doughnut plot.

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -425,6 +425,36 @@ pub struct ChartDataLabelOverride {
     pub font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_bold: Option<bool>,
+    /// Per-point label callout box style (`<c:dLbl>` §21.2.2.47 `<c:spPr>`
+    /// §21.2.2.197): background fill / border, mirroring the series-level
+    /// defaults. Present only when the point's `<c:spPr>` overrides the shape
+    /// (e.g. a differently tinted callout for one slice). See [`ChartLabelBox`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_box: Option<ChartLabelBox>,
+}
+
+/// Callout-box style for a pie/doughnut data label — the white (or themed)
+/// rounded rectangle with a thin border that Word draws around a `bestFit`
+/// label placed outside its slice. Parsed from the label's `<c:spPr>`
+/// (§21.2.2.197, the shape properties of a `<c:dLbl>` §21.2.2.47 /
+/// `<c:dLbls>` §21.2.2.49): the direct `<a:solidFill>` is the box fill and the
+/// `<a:ln>` is its border.
+///
+/// A `None` on `ChartSeriesDataLabels::label_box` means the file wrote no box
+/// shape, so the renderer keeps the historical plain-text label (no callout).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartLabelBox {
+    /// `<c:spPr><a:solidFill>` resolved hex (no `#`). The box background;
+    /// `<a:noFill>`/absent leaves this `None` (transparent box).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill: Option<String>,
+    /// `<c:spPr><a:ln><a:solidFill>` resolved hex (no `#`) — border stroke.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub border_color: Option<String>,
+    /// `<c:spPr><a:ln w>` border width in EMU (12700 EMU = 1 pt).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub border_width_emu: Option<u32>,
 }
 
 /// Mirror of TS `ChartSeriesDataLabels`.
@@ -445,6 +475,27 @@ pub struct ChartSeriesDataLabels {
     pub font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_size_hpt: Option<i32>,
+    /// Series-default callout-box style (`<c:dLbls>` §21.2.2.49 `<c:spPr>`
+    /// §21.2.2.197) — the box drawn around each pie/doughnut label. When present
+    /// the pie renderer switches from plain outer-ring text to Word's boxed
+    /// callout layout (box + optional leader line); `None` keeps the plain
+    /// labels.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_box: Option<ChartLabelBox>,
+    /// `<c:dLbls><c:showLeaderLines val>` (§21.2.2.183) — whether leader lines
+    /// connect a label pulled away from its slice back to the slice. Absent =
+    /// `false` (Office omits the element when leader lines are off). Only
+    /// consulted by the pie/doughnut callout renderer.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub show_leader_lines: bool,
+    /// `<c:dLbls><c:leaderLines>` (§21.2.2.92) `<c:spPr><a:ln><a:solidFill>`
+    /// resolved hex (no `#`) — the leader-line stroke color. `None` falls back
+    /// to a neutral grey in the renderer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub leader_line_color: Option<String>,
+    /// `<c:dLbls><c:leaderLines><c:spPr><a:ln w>` leader-line width in EMU.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub leader_line_width_emu: Option<u32>,
 }
 
 /// Mirror of TS `ChartErrBars`.
@@ -2087,6 +2138,59 @@ pub fn flatten_rich_text(rich_root: Node, cellrange_cache: Option<&str>) -> Stri
     out
 }
 
+/// Parse a data-label `<c:spPr>` (§21.2.2.197) into a callout [`ChartLabelBox`]
+/// (fill + border). Returns `None` when the shape node is absent OR carries
+/// neither a resolvable fill nor a border — i.e. nothing that would draw a box.
+/// The direct-child `<a:solidFill>` is the box fill; the `<a:ln>` solidFill and
+/// its `w` attribute are the border. Colors resolve through
+/// [`ColorResolver::resolve_shape_fill`] so a `<a:sysClr>`/`<a:schemeClr>` picks
+/// up its transforms (Office writes the default white box as
+/// `<a:sysClr val="window">`).
+fn parse_label_box(sp_pr: Option<Node>, resolver: &dyn ColorResolver) -> Option<ChartLabelBox> {
+    let sp = sp_pr?;
+    let fill = resolver.resolve_shape_fill(sp);
+    let (border_color, border_width_emu) = match child(sp, "ln") {
+        None => (None, None),
+        Some(ln) => {
+            let color = resolver.resolve_shape_fill(ln);
+            let width = ln.attribute("w").and_then(|v| v.parse::<u32>().ok());
+            (color, width)
+        }
+    };
+    if fill.is_none() && border_color.is_none() && border_width_emu.is_none() {
+        return None;
+    }
+    Some(ChartLabelBox {
+        fill,
+        border_color,
+        border_width_emu,
+    })
+}
+
+/// Parse `<c:dLbls><c:leaderLines>` into `(show_leader_lines, color, width_emu)`.
+/// `show` comes from the sibling `<c:showLeaderLines val>` (§21.2.2.183); the
+/// stroke style comes from `<c:leaderLines>` (§21.2.2.92) `<c:spPr><a:ln>`.
+fn parse_leader_lines(
+    d_lbls: Node,
+    resolver: &dyn ColorResolver,
+) -> (bool, Option<String>, Option<u32>) {
+    let show = child(d_lbls, "showLeaderLines")
+        .and_then(|c| c.attribute("val"))
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let (color, width) = match child(d_lbls, "leaderLines")
+        .and_then(|ll| child(ll, "spPr"))
+        .and_then(|sp| child(sp, "ln"))
+    {
+        None => (None, None),
+        Some(ln) => (
+            resolver.resolve_shape_fill(ln),
+            ln.attribute("w").and_then(|v| v.parse::<u32>().ok()),
+        ),
+    };
+    (show, color, width)
+}
+
 /// Parse a series-level `<c:dLbls>` into `(series_defaults, per_idx_overrides)`.
 /// ECMA-376 §21.2.2.47. Colors resolve through [`ColorResolver::resolve_shape_fill`]
 /// so a scheme-color label text picks up its lumMod/lumOff transforms.
@@ -2136,6 +2240,19 @@ pub fn parse_series_data_labels(
             .and_then(|v| v.parse::<i32>().ok())
     });
 
+    // §21.2.2.197 series-level callout-box shape (`<c:dLbls><c:spPr>`) and
+    // §21.2.2.183/§21.2.2.92 leader-line style. `<c:spPr>` may appear both as a
+    // direct child of `<c:dLbls>` (the series default) and inside each
+    // `<c:dLbl>` (per-point) — pick the direct child here.
+    let label_box = parse_label_box(
+        d_lbls
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "spPr"),
+        resolver,
+    );
+    let (show_leader_lines, leader_line_color, leader_line_width_emu) =
+        parse_leader_lines(d_lbls, resolver);
+
     let series_defaults = ChartSeriesDataLabels {
         show_val: bool_attr(d_lbls, "showVal"),
         show_cat_name: bool_attr(d_lbls, "showCatName"),
@@ -2146,6 +2263,10 @@ pub fn parse_series_data_labels(
         format_code,
         font_bold: font_bold_default,
         font_size_hpt: font_size_default,
+        label_box,
+        show_leader_lines,
+        leader_line_color,
+        leader_line_width_emu,
     };
 
     let mut overrides = Vec::new();
@@ -2190,6 +2311,13 @@ pub fn parse_series_data_labels(
             })
             .and_then(|def| def.attribute("b"))
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+        // Per-point callout box (`<c:dLbl>` §21.2.2.47 `<c:spPr>` §21.2.2.197):
+        // direct child spPr overrides the series-default box for this one point.
+        let label_box = parse_label_box(
+            dl.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "spPr"),
+            resolver,
+        );
         overrides.push(ChartDataLabelOverride {
             idx,
             text,
@@ -2197,6 +2325,7 @@ pub fn parse_series_data_labels(
             font_color,
             font_size_hpt,
             font_bold,
+            label_box,
         });
     }
 
@@ -2208,7 +2337,11 @@ pub fn parse_series_data_labels(
         || series_defaults.font_color.is_some()
         || series_defaults.format_code.is_some()
         || series_defaults.font_bold.is_some()
-        || series_defaults.font_size_hpt.is_some();
+        || series_defaults.font_size_hpt.is_some()
+        || series_defaults.label_box.is_some()
+        || series_defaults.show_leader_lines
+        || series_defaults.leader_line_color.is_some()
+        || series_defaults.leader_line_width_emu.is_some();
     let series_out = if any_default {
         Some(series_defaults)
     } else {
@@ -5285,6 +5418,78 @@ mod tests {
         assert_eq!(o.idx, 1);
         assert_eq!(o.text, "Custom");
         assert_eq!(o.position.as_deref(), Some("outEnd"));
+    }
+
+    #[test]
+    fn parse_series_data_labels_callout_box_and_leader_lines() {
+        // Mirror of sample-25 (Word pie callout labels): the series `<c:dLbls>`
+        // carries a `<c:spPr>` box (white fill + coloured border), a per-point
+        // `<c:dLbl>` with its own box, and `<c:showLeaderLines>` +
+        // `<c:leaderLines>` style. All must round-trip into the model.
+        let cache = std::collections::HashMap::new();
+        let xml = format!(
+            r#"<c:ser xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+              <c:dLbls>
+                <c:dLbl>
+                  <c:idx val="0"/>
+                  <c:spPr>
+                    <a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>
+                    <a:ln w="12700"><a:solidFill><a:srgbClr val="4472C4"/></a:solidFill></a:ln>
+                  </c:spPr>
+                  <c:showCatName val="1"/>
+                  <c:showPercent val="1"/>
+                </c:dLbl>
+                <c:spPr>
+                  <a:solidFill><a:srgbClr val="FEFEFE"/></a:solidFill>
+                  <a:ln w="12700"><a:solidFill><a:srgbClr val="4472C4"/></a:solidFill></a:ln>
+                </c:spPr>
+                <c:showVal val="0"/>
+                <c:showCatName val="1"/>
+                <c:showPercent val="1"/>
+                <c:showLeaderLines val="1"/>
+                <c:leaderLines>
+                  <c:spPr><a:ln w="9525"><a:solidFill><a:srgbClr val="A6A6A6"/></a:solidFill></a:ln></c:spPr>
+                </c:leaderLines>
+              </c:dLbls>
+            </c:ser>"#
+        );
+        let d = root_of(&xml);
+        let (defaults, overrides) =
+            parse_series_data_labels(d.root_element(), &FixtureResolver, &cache);
+        let defaults = defaults.expect("series-level dLbls present");
+        let box_ = defaults.label_box.expect("series callout box");
+        assert_eq!(box_.fill.as_deref(), Some("FEFEFE"));
+        assert_eq!(box_.border_color.as_deref(), Some("4472C4"));
+        assert_eq!(box_.border_width_emu, Some(12700));
+        assert!(defaults.show_leader_lines);
+        assert_eq!(defaults.leader_line_color.as_deref(), Some("A6A6A6"));
+        assert_eq!(defaults.leader_line_width_emu, Some(9525));
+
+        assert_eq!(overrides.len(), 1);
+        let o = &overrides[0];
+        assert_eq!(o.idx, 0);
+        let obox = o.label_box.as_ref().expect("per-point callout box");
+        assert_eq!(obox.fill.as_deref(), Some("FFFFFF"));
+        assert_eq!(obox.border_color.as_deref(), Some("4472C4"));
+        assert_eq!(obox.border_width_emu, Some(12700));
+    }
+
+    #[test]
+    fn parse_series_data_labels_no_box_leaves_callout_fields_unset() {
+        // A plain `<c:dLbls>` with no `<c:spPr>` / leader lines must NOT
+        // synthesize a callout box (keeps the historical plain-label path).
+        let cache = std::collections::HashMap::new();
+        let xml = format!(
+            r#"<c:ser xmlns:c="{C_NS}">
+              <c:dLbls><c:showPercent val="1"/></c:dLbls>
+            </c:ser>"#
+        );
+        let d = root_of(&xml);
+        let (defaults, _) = parse_series_data_labels(d.root_element(), &FixtureResolver, &cache);
+        let defaults = defaults.expect("series-level dLbls present");
+        assert!(defaults.label_box.is_none());
+        assert!(!defaults.show_leader_lines);
+        assert!(defaults.leader_line_color.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Word draws pie data labels as bordered callout boxes outside the slices, with leader lines when a box is pulled off its rim. Our renderer drew in-slice text only (overlapping on thin slices). Implements the callout presentation, honoring everything Word writes in the XML. User-requested (issue #755).

Closes #755

## XML findings (sample-25)
The series `<c:dLbls>` carries it all — no manual layout, positioning is pure `bestFit`: `<c:spPr>` white box fill (sysClr window + 90% alpha) + 1pt `4472C4` border; `showCatName`/`showPercent`; `showLeaderLines=1` + `<c:leaderLines>` (0.75pt `A6A6A6`); one per-point `<c:dLbl idx=0>` (Brazil) with blue font + its own box.

## Safety gate
The callout layout activates **only when the dLbls carry a `<c:spPr>` box shape** (`def.labelBox`). Pies without one keep the historical plain-text path byte-for-byte — **renderer-signature snapshot untouched**, existing pies (pptx sample-14, xlsx) unchanged.

## Changes (3 commits)
- docs: holeSize § citation → **§21.2.2.82** (the #753 review NIT). New citations verified against the spec (leaderLines §21.2.2.92, showLeaderLines §21.2.2.183, spPr §21.2.2.197, dLbl §21.2.2.47, dLbls §21.2.2.49).
- parser: `ChartLabelBox` (fill/border/width) on series + per-point overrides, `showLeaderLines`/leader color/width, in ooxml-common + TS mirror. Reuses `resolve_shape_fill` (sysClr/schemeClr transforms). +2 Rust tests.
- renderer: `drawPieCalloutLabels` — boxed callouts outside each slice, category+% stacked, greedy per-side vertical de-overlap with fit-back, leader lines only when pulled off the rim, per-point overrides, 8-digit RGBA fills. +4 tests.

## Verification
- Browser production render closely matches `sample-25.pdf` (boxed callouts, blue Brazil, leader lines on small slices).
- Non-regression: all committed references pass — xlsx demo 7/7, pptx demo 12/12, docx demo 8/8, docx private 1..5 13/13.
- Gates: cargo 179 / fmt / clippy clean; core vitest 892 (signature snapshot untouched); docx vitest 592; root tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)