### PR TITLE
fix(core,docx,pptx,xlsx): preserve trailing-space advance on trimming measureText engines

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -292,6 +292,11 @@ export {
   type SegStretch,
 } from './text/line-distribute';
 export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-positions';
+// Trailing-whitespace-robust text advance: `measureText` excludes a run's
+// trailing/lone whitespace on Firefox & WebKit/Safari but includes it on
+// Chrome/Blink & skia-canvas. Shared so docx/pptx/xlsx keep inter-word spaces
+// from collapsing on trimming engines (measure==draw on every engine).
+export { measureAdvanceWithTrailingSpace } from './text/measure-space';
 // Format-agnostic index navigation for hidden-item "skip" mode (pptx hidden
 // slides, xlsx hidden sheets): pure math over an isHidden(i) callback.
 export { nextVisibleIndex, resolveVisibleIndex, countVisible } from './nav/visible-index';

--- a/packages/core/src/text/measure-space.test.ts
+++ b/packages/core/src/text/measure-space.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { measureAdvanceWithTrailingSpace } from './measure-space';
+
+// Model of a Canvas 2D context whose measureText advance is a fixed per-glyph
+// sum, with a switch for the trailing-whitespace divergence.
+//
+//   - CHAR_W per non-space glyph, SPACE_W per space.
+//   - `trims=true` models Firefox/WebKit/Safari: TRAILING spaces (and a wholly
+//     whitespace string) contribute 0; interior spaces still count.
+//   - `trims=false` models Chrome/Blink & skia-canvas: every space counts.
+const CHAR_W = 10;
+const SPACE_W = 4;
+
+function makeCtx(trims: boolean, font = '16px serif'): {
+  ctx: CanvasRenderingContext2D;
+  fontRef: { value: string };
+} {
+  const fontRef = { value: font };
+  const measure = (s: string): number => {
+    const eff = trims ? s.replace(/ +$/, '') : s;
+    let w = 0;
+    for (const ch of eff) w += ch === ' ' ? SPACE_W : CHAR_W;
+    return w;
+  };
+  const ctx = {
+    get font() { return fontRef.value; },
+    set font(v: string) { fontRef.value = v; },
+    measureText: (s: string) => ({ width: measure(s) }) as TextMetrics,
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, fontRef };
+}
+
+describe('measureAdvanceWithTrailingSpace', () => {
+  it('non-trimming engine: identical to raw measureText (pass-through)', () => {
+    const { ctx } = makeCtx(false);
+    // "Other " = 5×10 + 4 = 54, "countries" = 9×10 = 90.
+    expect(measureAdvanceWithTrailingSpace(ctx, 'Other ')).toBe(54);
+    expect(measureAdvanceWithTrailingSpace(ctx, 'countries')).toBe(90);
+  });
+
+  it('trimming engine: restores the trailing-space advance', () => {
+    const { ctx } = makeCtx(true);
+    // Raw would trim "Other " → "Other" = 50; the helper adds one SPACE_W back.
+    expect(measureAdvanceWithTrailingSpace(ctx, 'Other ')).toBe(54);
+    // No trailing space ⇒ unchanged.
+    expect(measureAdvanceWithTrailingSpace(ctx, 'countries')).toBe(90);
+  });
+
+  it('trimming engine: a lone space token (pptx) keeps its advance', () => {
+    const { ctx } = makeCtx(true);
+    // Raw measureText(' ') trims to '' → 0; the helper restores SPACE_W.
+    expect(measureAdvanceWithTrailingSpace(ctx, ' ')).toBe(SPACE_W);
+    expect(measureAdvanceWithTrailingSpace(ctx, '   ')).toBe(3 * SPACE_W);
+  });
+
+  it('interior spaces are never affected on either engine', () => {
+    for (const trims of [false, true]) {
+      const { ctx } = makeCtx(trims);
+      // "a b" = 10 + 4 + 10 = 24 (interior space always counts).
+      expect(measureAdvanceWithTrailingSpace(ctx, 'a b')).toBe(24);
+    }
+  });
+
+  it('empty string is 0', () => {
+    expect(measureAdvanceWithTrailingSpace(makeCtx(true).ctx, '')).toBe(0);
+    expect(measureAdvanceWithTrailingSpace(makeCtx(false).ctx, '')).toBe(0);
+  });
+
+  it('detection is per-font (a size change re-probes and still corrects)', () => {
+    const { ctx, fontRef } = makeCtx(true);
+    expect(measureAdvanceWithTrailingSpace(ctx, 'x ')).toBe(CHAR_W + SPACE_W);
+    fontRef.value = '32px serif';
+    // Same stub advances (font size does not scale the stub), but a fresh font
+    // string forces a re-probe; the correction must still apply.
+    expect(measureAdvanceWithTrailingSpace(ctx, 'x ')).toBe(CHAR_W + SPACE_W);
+  });
+});

--- a/packages/core/src/text/measure-space.ts
+++ b/packages/core/src/text/measure-space.ts
@@ -1,0 +1,86 @@
+/**
+ * Trailing-whitespace-robust text advance measurement.
+ *
+ * `CanvasRenderingContext2D.measureText(s).width` for a string that INCLUDES
+ * trailing (or lone) whitespace is engine-dependent:
+ *
+ *   - Chrome / Blink and skia-canvas INCLUDE the trailing-space advance.
+ *   - Firefox and WebKit / Safari EXCLUDE it — a run's trailing whitespace (and a
+ *     string that is ENTIRELY whitespace, e.g. a lone " ") contributes 0 advance.
+ *
+ * The HTML spec left this ambiguous for years and the engines never converged.
+ * Every OOXML renderer here stores a laid-out text advance as this width and then
+ * advances the draw pen by the same amount, so on a trimming engine an inter-word
+ * space that sits at a segment's edge loses its advance and the next word
+ * collides ("Other countries" → "Othercountries"). The same divergence bites all
+ * three formats — docx (word segments keep their trailing space), pptx (a lone
+ * " " token measures 0) and xlsx (a wrap buffer flushed at a space) — so the
+ * correction lives here, in core, as a single shared source of truth.
+ *
+ * The fix detects ONCE per (context, font) whether the engine trims, and — only
+ * when it does — adds back `trailingSpaceCount × spaceAdvance`, where
+ * `spaceAdvance` is derived from an INTERIOR space ("m m" − "mm") that no engine
+ * trims. On a non-trimming engine the detector reports `trims=false`, so the
+ * helper is a pure pass-through (`ctx.measureText(text).width`) with zero
+ * behaviour change — and for the common no-trailing-space string it never even
+ * runs the detector probe.
+ */
+
+type AnyCtx = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+/** Per-context detector cache. Keyed by the 2D context, holding one entry per
+ *  resolved font string. A WeakMap lets a context be GC'd with its cache. */
+const detectorCache = new WeakMap<AnyCtx, Map<string, TrailingSpaceInfo>>();
+
+interface TrailingSpaceInfo {
+  /** True when this engine excludes trailing whitespace from measureText width. */
+  trims: boolean;
+  /** The interior (never-trimmed) advance of one space in the current font, px. */
+  spaceAdvance: number;
+}
+
+/** Detect (memoized per context+font) whether the engine trims trailing
+ *  whitespace from `measureText` width, and the true per-space advance. */
+function trailingSpaceInfo(ctx: AnyCtx): TrailingSpaceInfo {
+  let perFont = detectorCache.get(ctx);
+  if (!perFont) {
+    perFont = new Map();
+    detectorCache.set(ctx, perFont);
+  }
+  const font = ctx.font;
+  let info = perFont.get(font);
+  if (!info) {
+    // Interior space advance (never trimmed): width('m m') − width('mm').
+    const interior = ctx.measureText('m m').width - ctx.measureText('mm').width;
+    // Trailing space advance: width('m ') − width('m'). ~0 on a trimming engine.
+    const trailing = ctx.measureText('m ').width - ctx.measureText('m').width;
+    // Trims when a genuine interior advance exists but the trailing one vanished.
+    const trims = interior > 0.01 && trailing < interior * 0.5;
+    info = { trims, spaceAdvance: interior };
+    perFont.set(font, info);
+  }
+  return info;
+}
+
+/**
+ * Advance of `text` under the font ALREADY set on `ctx`, corrected so trailing
+ * (and lone) spaces keep their advance on engines whose `measureText` trims
+ * trailing whitespace. On non-trimming engines this equals
+ * `ctx.measureText(text).width` exactly.
+ *
+ * Note the empty-string / all-space case: on a trimming engine
+ * `measureText("  ")` returns 0, and this helper adds back
+ * `spaceCount × spaceAdvance`, so a lone-space token (pptx) or an all-space
+ * segment measures its true width.
+ */
+export function measureAdvanceWithTrailingSpace(ctx: AnyCtx, text: string): number {
+  if (text.length === 0) return 0;
+  const raw = ctx.measureText(text).width;
+  // Count trailing spaces; this also covers the wholly-space string (a lone " "
+  // token: raw is 0 on a trimming engine, so every space must be added back).
+  const trail = /( +)$/.exec(text);
+  if (!trail) return raw;
+  const info = trailingSpaceInfo(ctx);
+  if (!info.trims) return raw;
+  return raw + trail[1].length * info.spaceAdvance;
+}

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -34,6 +34,7 @@ import {
   isComplexScriptCodePoint,
   isSymbolFontFamily,
   symbolTextToUnicodeSegments,
+  measureAdvanceWithTrailingSpace,
 } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import {
@@ -1709,13 +1710,18 @@ export function layoutLines(
   // character-grid delta. This is the SINGLE source of truth shared with the
   // draw paths (gridWidth) — every line-break / fit / tab measurement uses it so
   // line wrapping packs the grid's char count and the box matches what is drawn.
-  const segAdvance = (s: LayoutTextSeg): number =>
-    gridWidth(measureText(s).width, s.text, gridDeltaPx);
+  // `measureAdvanceWithTrailingSpace` (not the raw `ctx.measureText().width`) so a trailing
+  // inter-word space keeps its advance on engines whose measureText trims trailing
+  // whitespace — see the core helper (@silurus/ooxml-core → text/measure-space.ts).
+  const segAdvance = (s: LayoutTextSeg): number => {
+    setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses));
+    return gridWidth(measureAdvanceWithTrailingSpace(ctx, s.text), s.text, gridDeltaPx);
+  };
   // Grid advance of an arbitrary string under a segment's font (for split
   // prefixes/tails). Selects the font, then applies the same gridWidth model.
   const strAdvance = (s: LayoutTextSeg, text: string): number => {
     setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses));
-    return gridWidth(ctx.measureText(text).width, text, gridDeltaPx);
+    return gridWidth(measureAdvanceWithTrailingSpace(ctx, text), text, gridDeltaPx);
   };
 
   // Width of a queued segment, for right/center tab look-ahead.
@@ -1948,10 +1954,12 @@ export function layoutLines(
 
     // ── Text segment ─────────────────────────────────────
     const s = seg as LayoutTextSeg;
-    const m = measureText(s);
+    const m = measureText(s); // sets ctx.font; also feeds ascent/descent below
     // Advance = natural width + character-grid delta (the SINGLE model shared
     // with the draw paths; 0 unless an active grid AND a pure-EA segment).
-    const w = gridWidth(m.width, s.text, gridDeltaPx);
+    // `measureAdvanceWithTrailingSpace` (not `m.width`) so a trailing inter-word space keeps
+    // its advance on engines whose measureText trims trailing whitespace.
+    const w = gridWidth(measureAdvanceWithTrailingSpace(ctx, s.text), s.text, gridDeltaPx);
     // Line-height tracks the un-scaled pt font so super/sub don't shrink the line.
     const h = s.fontSize;
     // Prefer font-metric ascent/descent (stable per font+size) so baselines and
@@ -2240,7 +2248,10 @@ export function rescaleLayoutLines(
     const effPx = calcEffectiveFontPx(s, scale);
     ctx.font = buildFont(s.bold, s.italic, effPx, s.fontFamily, fontFamilyClasses);
     const m = ctx.measureText(s.text);
-    const advance = gridWidth(m.width, s.text, gridDeltaPx);
+    // `measureAdvanceWithTrailingSpace` (not `m.width`) so a trailing inter-word space keeps
+    // its advance at the paint scale too, on engines whose measureText trims
+    // trailing whitespace (must match the layoutLines advance so measure==draw).
+    const advance = gridWidth(measureAdvanceWithTrailingSpace(ctx, s.text), s.text, gridDeltaPx);
     // §17.3.2.33 — a small-caps run's LINE BOX follows the FULL run size (measure
     // the box at fullPx, not the 2pt-reduced glyphs); super/subscript keeps its
     // shrunk contribution. Mirrors layoutLines' fullPx / metricEmPx split.

--- a/packages/docx/src/word-space-trim-engine.test.ts
+++ b/packages/docx/src/word-space-trim-engine.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// Regression: inter-word space advance must survive a `measureText` engine that
+// TRIMS trailing whitespace from `TextMetrics.width` (Firefox / WebKit / Safari,
+// per the HTML canvas history). The docx layout stores a text segment's advance
+// as `measureText(segmentTextIncludingTrailingSpace).width`. On a trimming engine
+// that omits the space, so the pen under-advances and the next word collides
+// ("Other countries" → "Othercountries"). The fix must recover the trailing-space
+// advance so measure==draw holds on EVERY engine (all weights, all alignments) —
+// not a bold-only patch.
+//
+// This mock context models a TRIMMING engine: `measureText(s)` returns the width
+// of `s` with trailing spaces removed (interior spaces still counted). It also
+// records fillText so we can confirm the drawn advance too.
+
+const FONT_PX = 20;
+const CHAR_W = 10; // per non-space glyph advance in the stub (scale 1)
+const SPACE_W = 5; // interior-space advance in the stub
+
+/** Width of `s` under a TRAILING-SPACE-TRIMMING engine: interior spaces count,
+ *  trailing spaces do NOT (the exact Firefox/WebKit measureText divergence). */
+function trimmingMeasure(s: string): number {
+  const trimmed = s.replace(/ +$/, ''); // drop ONLY trailing spaces
+  let w = 0;
+  for (const ch of trimmed) w += ch === ' ' ? SPACE_W : CHAR_W;
+  return w;
+}
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; x: number }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fillTextCalls: { text: string; x: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      const scale = p / FONT_PX;
+      const w = trimmingMeasure(s) * scale;
+      return {
+        width: w,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number) {
+      fillTextCalls.push({ text, x });
+    },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+function textRun(text: string, bold = false): DocxTextRun {
+  return {
+    text, bold, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'NotInMetrics', isLink: false,
+    background: null, vertAlign: null, hyperlink: null,
+  } as unknown as DocxTextRun;
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function para(
+  runs: DocxTextRun[],
+  opts: { alignment?: DocParagraph['alignment'] } = {},
+): BodyElement {
+  const p: DocParagraph = {
+    alignment: opts.alignment ?? 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: runs.map((r) => ({ type: 'text', ...r }) as DocRun),
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics',
+    widowControl: false,
+  } as unknown as DocParagraph;
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 1000, pageHeight: 400,
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    ...overrides,
+  } as SectionProps;
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(
+  body: BodyElement[],
+  sec: SectionProps,
+): Promise<{ runs: DocxTextRunInfo[]; fillTextCalls: { text: string; x: number }[] }> {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  const runs: DocxTextRunInfo[] = [];
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, {
+    dpr: 1,
+    width: sec.pageWidth, // scale = 1 (px per pt)
+    onTextRun: (r) => runs.push(r),
+  });
+  return { runs, fillTextCalls };
+}
+
+describe('inter-word space survives a trailing-space-trimming measureText engine', () => {
+  it('bold left-aligned single run: "Other countries" keeps the space (no collision)', async () => {
+    const { runs } = await render([para([textRun('Other countries', true)])], section());
+    const other = runs.find((r) => /^Other/.test(r.text));
+    const countries = runs.find((r) => /countries/.test(r.text));
+    expect(other).toBeDefined();
+    expect(countries).toBeDefined();
+    // "Other" = 5 glyphs × 10 = 50; trailing space = 5 ⇒ next word starts at 55,
+    // not 50. If the space advance is dropped, countries.x === other.x + 50.
+    const otherGlyphs = 5 * CHAR_W; // 50
+    expect(countries!.x).toBeGreaterThan(other!.x + otherGlyphs + SPACE_W - 0.01);
+  });
+
+  it('regular (non-bold) left run keeps the space too — fix is weight-independent', async () => {
+    const { runs } = await render([para([textRun('Other countries', false)])], section());
+    const other = runs.find((r) => /^Other/.test(r.text))!;
+    const countries = runs.find((r) => /countries/.test(r.text))!;
+    expect(countries.x).toBeGreaterThan(other.x + 5 * CHAR_W + SPACE_W - 0.01);
+  });
+
+  it('three words keep both spaces', async () => {
+    const { runs } = await render([para([textRun('one two three', false)])], section());
+    const one = runs.find((r) => /^one/.test(r.text))!;
+    const two = runs.find((r) => /^two/.test(r.text))!;
+    const three = runs.find((r) => /three/.test(r.text))!;
+    expect(two.x).toBeGreaterThan(one.x + 3 * CHAR_W + SPACE_W - 0.01);
+    expect(three.x).toBeGreaterThan(two.x + 3 * CHAR_W + SPACE_W - 0.01);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -73,6 +73,7 @@ import {
   isSymbolFontFamily,
   drawUnderline,
   intendedSingleLinePx,
+  measureAdvanceWithTrailingSpace,
 } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
@@ -695,7 +696,14 @@ export function layoutParagraph(
     if (!text) return;
     ctx.font = font;
     const lsPx = extras?.letterSpacingPx ?? 0;
-    const baseW = ctx.measureText(text).width;
+    // `measureAdvanceWithTrailingSpace` (not raw measureText): runs are tokenized
+    // on whitespace (`split(/(\s+)/)`), so an inter-word space is pushed as a lone
+    // " " token whose `measureText(" ").width` is 0 on trimming engines (Firefox,
+    // WebKit/Safari) — the token would carry no advance and adjacent words would
+    // collide. The core helper restores the space advance; on Chrome/skia it is a
+    // pure pass-through. The draw pen advances by this same stored `w` (no
+    // re-measure), so measure==draw on every engine.
+    const baseW = measureAdvanceWithTrailingSpace(ctx, text);
     // Letter spacing adds an extra gap between every character, including
     // after the last one — matches the "advance width" semantics of OOXML
     // spc (each glyph's advance grows by spc points). Tab stops measure the
@@ -925,7 +933,10 @@ export function layoutParagraph(
       }
 
       ctx.font = font;
-      const tokW = ctx.measureText(token).width;
+      // Trailing-whitespace-robust so a lone " " wrap token keeps its advance on
+      // trimming engines (see the `push` measure above): the width fed to the
+      // wrap-fit decision must match the width the token is drawn at.
+      const tokW = measureAdvanceWithTrailingSpace(ctx, token);
       const isWhitespace = /^\s+$/.test(token);
 
       // If already in tab mode, collect all text into tabStop.segments (no wrap)

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, GradientFillSpec, ShapeInfo, SlicerItem,
 } from './types.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, measureAdvanceWithTrailingSpace, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValue } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -926,7 +926,10 @@ export function layoutRichTextLines(
     // Measure at the *draw* font so a super/subscript token reserves its reduced
     // (~65%) glyph width; the segment keeps the run's full size for line height.
     ctx.font = buildFont(vertAlignDrawFont(font), cs);
-    const w = ctx.measureText(text).width;
+    // Trailing-space-robust (a wrapped token can end in a space that trimming
+    // engines drop; the draw pen advances by the stored width — see the core
+    // helper docs).
+    const w = measureAdvanceWithTrailingSpace(ctx, text);
     if (cur.length > 0 && curW + w > maxWidth) {
       // Kinsoku at the wrap boundary (ECMA-376 §17.15.1.58–.60): retract
       // trailing code points of the line being closed so it does not end with
@@ -958,10 +961,12 @@ export function layoutRichTextLines(
         } else {
           const keepText = keepCps.join('');
           last.text = keepText;
-          last.width = ctx.measureText(keepText).width;
+          // keepText can end at a whitespace (LB13 retract extends to the last
+          // space) — measure trailing-space-robustly so it keeps that advance.
+          last.width = measureAdvanceWithTrailingSpace(ctx, keepText);
         }
         const moveText = moveCps.join('');
-        carry = { text: moveText, font: last.font, width: ctx.measureText(moveText).width };
+        carry = { text: moveText, font: last.font, width: measureAdvanceWithTrailingSpace(ctx, moveText) };
       }
       flush();
       if (carry) {
@@ -1153,7 +1158,12 @@ function drawRichLine(
   const segs: RichSeg[] = lineRuns.map((r) => {
     const font = applyRunFont(baseFont, r);
     ctx.font = buildFont(vertAlignDrawFont(font), cs);
-    return { text: r.text, font, width: ctx.measureText(r.text).width };
+    // Trailing-space-robust: a rich run can end in a space at an inter-run word
+    // boundary, whose advance Firefox/WebKit trim from measureText. The draw pen
+    // (drawResolvedRichLine) advances by this stored `width`, so trimming would
+    // collide the next run — the core helper restores the space (pass-through on
+    // Chrome/skia).
+    return { text: r.text, font, width: measureAdvanceWithTrailingSpace(ctx, r.text) };
   });
   const totalWidth = segs.reduce((a, s) => a + s.width, 0);
   let startX: number;
@@ -3794,7 +3804,12 @@ export function drawShapeText(
         const piece = pieces[s];
         if (!piece) continue;
         if (!wrap) {
-          const w = ctx.measureText(piece).width;
+          // `measureAdvanceWithTrailingSpace` (not raw measureText): a piece may
+          // end in whitespace whose advance Firefox/WebKit trim from measureText,
+          // which would collapse an inter-word space at the piece edge. The core
+          // helper restores it (pass-through on Chrome/skia); the draw pen
+          // advances by this stored `w`, so measure==draw on every engine.
+          const w = measureAdvanceWithTrailingSpace(ctx, piece);
           segs.push({ kind: 'text', text: piece, font, color, w });
           lineW += w;
           continue;
@@ -3809,7 +3824,10 @@ export function drawShapeText(
           const cw = ctx.measureText(candidate).width;
           if (lineW + cw > lineAvailW() && (buf.length > 0 || segs.length > 0)) {
             if (buf) {
-              const w = ctx.measureText(buf).width;
+              // A wrap buffer flushed here can end in a space; measure it
+              // trailing-space-robustly so the space keeps its advance on
+              // trimming engines (measure==draw with the draw pen below).
+              const w = measureAdvanceWithTrailingSpace(ctx, buf);
               segs.push({ kind: 'text', text: buf, font, color, w });
               lineW += w;
             }
@@ -3825,7 +3843,9 @@ export function drawShapeText(
           }
         }
         if (buf) {
-          const w = ctx.measureText(buf).width;
+          // Final buffer of the piece — same trailing-space-robust measure so a
+          // word ending in a space keeps its advance (see above).
+          const w = measureAdvanceWithTrailingSpace(ctx, buf);
           segs.push({ kind: 'text', text: buf, font, color, w });
           lineW += w;
         }


### PR DESCRIPTION
## Summary
A run like `<w:t>Other countries</w:t>` rendered as "Othecountries" in sample-25's table — the inter-word space advance was dropped. Root cause is **not** bold or table styling: `measureText` for a string **ending in whitespace** is engine-dependent — Chrome/Blink and skia-canvas include the trailing-space advance; **Firefox and WebKit exclude it**. Word-split segments keep their trailing space (`["Other ", "countries"]`), so on a trimming engine the measured advance omits the space and the next word collides. All three packages had the hole.

## Fix
New shared core helper `measureAdvanceWithTrailingSpace(ctx, text)` (`core/src/text/measure-space.ts`): detects once per (context, font) whether the engine trims (interior `"m m"−"mm"` vs trailing `"m "−"m"`) and only then adds back `trailingSpaceCount × spaceAdvance`. **Pure pass-through on non-trimming engines** → zero behavior change on Chrome/skia.

- docx (`d9a439b`): `layoutLines` + `rescaleLayoutLines` measure sites (both needed or draw disagrees with pagination) + tests.
- pptx (`37a09d6`): whitespace tokens measured as lone `" "` (fully trimmed to 0 on trimming engines).
- xlsx (`66a42f0`): pen-chained rich-run/wrap segments ending at a space. Whole-cell single-fillText paths unaffected (interior spaces never at a measured edge) — left as-is.

## Verification
- sample-25 with a patched trimming `measureText`: before `"Other "` w=39.1 → collision (exact reported symptom); after w=43.17 → space restored, identical to native-Chrome positions.
- Native Chrome & skia: byte-identical before/after.
- vitest core+docx+pptx+xlsx **2084 pass** (+9 new: engine-mock unit tests + end-to-end collision guard); node 34; tsc/lint clean.
- Full VRT: docx 21 / pptx 12 / xlsx 8 pass, 0 failures, **no reference updates** (pass-through on the VRT engine).

Found via a background-task chip during the #754 table-style work (pre-existing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)