### PR TITLE
sec: raster dimension cap, recursion depth guards, canvas size clamp (RB1/RB2/RB5)

### DIFF
--- a/packages/core/src/canvas/clamp.test.ts
+++ b/packages/core/src/canvas/clamp.test.ts
@@ -115,4 +115,18 @@ describe('clampCanvasSize — degenerate inputs collapse to a 1×1 canvas', () =
     expect(r.width).toBeGreaterThanOrEqual(1);
     expect(r.height).toBeGreaterThanOrEqual(1);
   });
+
+  it('floors a sub-0.5px positive request to 1×1 (Math.round would send it to 0)', () => {
+    // RB5 regression: a positive-but-tiny request (e.g. a 0.4px page at a small
+    // DPR) rounds to 0 and previously fell through the UNCLAMPED branch as a 0×0
+    // backing store, blanking the viewer. It must become a real 1×1 canvas.
+    const r = clampCanvasSize(0.4, 0.4);
+    expect(r).toEqual({ width: 1, height: 1, scale: 1, clamped: false });
+    // Asymmetric sub-pixel request: each axis floored independently to ≥ 1.
+    const r2 = clampCanvasSize(0.2, 3.6);
+    expect(r2.width).toBe(1);
+    expect(r2.height).toBe(4);
+    expect(r2.width).toBeGreaterThanOrEqual(1);
+    expect(r2.height).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/core/src/canvas/clamp.test.ts
+++ b/packages/core/src/canvas/clamp.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampCanvasSize,
+  MAX_CANVAS_DIMENSION,
+  MAX_CANVAS_AREA,
+} from './clamp.js';
+
+// ── clampCanvasSize (RB5): bound a canvas backing size to browser limits ─────
+
+describe('clampCanvasSize — in-budget sizes pass through unchanged', () => {
+  it('leaves a normal page size untouched', () => {
+    const r = clampCanvasSize(1240, 1754); // ~A4 at 150 DPI
+    expect(r).toEqual({ width: 1240, height: 1754, scale: 1, clamped: false });
+  });
+
+  it('rounds fractional requests to integers without flagging a clamp', () => {
+    const r = clampCanvasSize(800.4, 600.6);
+    expect(r.width).toBe(800);
+    expect(r.height).toBe(601);
+    expect(r.clamped).toBe(false);
+    expect(r.scale).toBe(1);
+  });
+
+  it('accepts exactly at the per-axis cap', () => {
+    const r = clampCanvasSize(MAX_CANVAS_DIMENSION, 1);
+    expect(r.width).toBe(MAX_CANVAS_DIMENSION);
+    expect(r.height).toBe(1);
+    expect(r.clamped).toBe(false);
+  });
+
+  it('accepts exactly at the area cap', () => {
+    const side = Math.sqrt(MAX_CANVAS_AREA); // 4096
+    const r = clampCanvasSize(side, side);
+    expect(r.clamped).toBe(false);
+    expect(r.width * r.height).toBeLessThanOrEqual(MAX_CANVAS_AREA);
+  });
+});
+
+describe('clampCanvasSize — over-dimension requests scale down, aspect preserved', () => {
+  it('clamps a single over-wide axis and scales the other by the same factor', () => {
+    // 40000 wide × 500 tall = 20 MP: the width exceeds the axis cap AND the area
+    // slightly exceeds the 16 MP cap, so the harder (area) factor wins. Both caps
+    // must end up satisfied, and the aspect ratio (80:1) preserved.
+    const r = clampCanvasSize(40000, 500);
+    expect(r.clamped).toBe(true);
+    expect(r.width).toBeLessThanOrEqual(MAX_CANVAS_DIMENSION);
+    expect(r.width * r.height).toBeLessThanOrEqual(MAX_CANVAS_AREA);
+    const inputAspect = 40000 / 500; // 80
+    const outAspect = r.width / r.height;
+    // Aspect preserved within a small rounding tolerance.
+    expect(Math.abs(outAspect - inputAspect)).toBeLessThan(inputAspect * 0.02);
+    // The applied scale is whichever cap binds harder.
+    const dimScale = MAX_CANVAS_DIMENSION / 40000;
+    const areaScale = Math.sqrt(MAX_CANVAS_AREA / (40000 * 500));
+    expect(r.scale).toBeCloseTo(Math.min(dimScale, areaScale), 5);
+  });
+
+  it('clamps a purely over-axis request (area within budget) by the dimension factor', () => {
+    // 40000 × 100 = 4 MP (within the area cap) but width over the axis cap: only
+    // the dimension factor applies.
+    const r = clampCanvasSize(40000, 100);
+    expect(r.clamped).toBe(true);
+    expect(r.width).toBeLessThanOrEqual(MAX_CANVAS_DIMENSION);
+    expect(r.scale).toBeCloseTo(MAX_CANVAS_DIMENSION / 40000, 5);
+  });
+});
+
+describe('clampCanvasSize — over-area requests scale down by sqrt', () => {
+  it('clamps a large square within the area cap, preserving squareness', () => {
+    // 10000×10000 = 100 MP, way over the 16 MP area cap but each axis < 32767.
+    const r = clampCanvasSize(10000, 10000);
+    expect(r.clamped).toBe(true);
+    expect(r.width * r.height).toBeLessThanOrEqual(MAX_CANVAS_AREA);
+    // Square in → square out.
+    expect(Math.abs(r.width - r.height)).toBeLessThanOrEqual(1);
+    // Linear factor is sqrt(cap / area).
+    const expected = Math.sqrt(MAX_CANVAS_AREA / (10000 * 10000));
+    expect(r.scale).toBeCloseTo(expected, 5);
+  });
+
+  it('applies whichever cap binds harder (area vs dimension)', () => {
+    // 32000×20000: within the axis cap on both, but 640 MP ≫ area cap. The area
+    // factor must win and bring the product under the area cap.
+    const r = clampCanvasSize(32000, 20000);
+    expect(r.clamped).toBe(true);
+    expect(r.width).toBeLessThanOrEqual(MAX_CANVAS_DIMENSION);
+    expect(r.height).toBeLessThanOrEqual(MAX_CANVAS_DIMENSION);
+    expect(r.width * r.height).toBeLessThanOrEqual(MAX_CANVAS_AREA);
+    const aspectIn = 32000 / 20000;
+    expect(Math.abs(r.width / r.height - aspectIn)).toBeLessThan(0.1);
+  });
+});
+
+describe('clampCanvasSize — degenerate inputs collapse to a 1×1 canvas', () => {
+  it('handles zero, negative, NaN and Infinity', () => {
+    for (const [w, h] of [
+      [0, 100],
+      [-10, 50],
+      [NaN, 20],
+      [Infinity, 30],
+      [10, 0],
+    ] as [number, number][]) {
+      const r = clampCanvasSize(w, h);
+      expect(r.width).toBeGreaterThanOrEqual(1);
+      expect(r.height).toBeGreaterThanOrEqual(1);
+      expect(Number.isInteger(r.width)).toBe(true);
+      expect(Number.isInteger(r.height)).toBe(true);
+    }
+  });
+
+  it('never returns a sub-1px axis even under extreme aspect clamping', () => {
+    // A 1×100000000 strip: the area clamp would drive the 1px axis below 1 — it
+    // must be floored to 1, not 0 (a 0-width canvas is unusable).
+    const r = clampCanvasSize(1, 100_000_000);
+    expect(r.width).toBeGreaterThanOrEqual(1);
+    expect(r.height).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/core/src/canvas/clamp.ts
+++ b/packages/core/src/canvas/clamp.ts
@@ -54,8 +54,10 @@ export interface ClampedCanvasSize {
  * Clamp a requested canvas backing size to the per-axis and total-area limits,
  * preserving aspect ratio.
  *
- * The requested `width`/`height` are first floored to `≥ 1` and rounded to
- * integers. If either the per-axis cap ({@link MAX_CANVAS_DIMENSION}) or the
+ * The requested `width`/`height` are first rounded to integers and floored to
+ * `≥ 1` (so a sub-0.5px request, which `Math.round` would send to 0, still
+ * yields a real 1×1 backing store rather than a 0×0 one that renders blank). If
+ * either the per-axis cap ({@link MAX_CANVAS_DIMENSION}) or the
  * area cap ({@link MAX_CANVAS_AREA}) is exceeded, both axes are multiplied by the
  * single largest factor `s ≤ 1` that brings the size within BOTH caps, so the
  * result keeps the requested aspect ratio.
@@ -65,9 +67,12 @@ export interface ClampedCanvasSize {
  * inputs collapse to a 1×1 canvas.
  */
 export function clampCanvasSize(width: number, height: number): ClampedCanvasSize {
-  // Normalize: non-finite / non-positive → 1. Round to integer pixels.
-  const reqW = Number.isFinite(width) && width > 0 ? Math.round(width) : 1;
-  const reqH = Number.isFinite(height) && height > 0 ? Math.round(height) : 1;
+  // Normalize: non-finite / non-positive → 1. Round to integer pixels, then
+  // floor to ≥ 1 so a sub-0.5px request (which `Math.round` sends to 0) still
+  // becomes a real 1×1 backing store instead of a blank 0×0 one — the unclamped
+  // return path below trusts these to already be valid dimensions.
+  const reqW = Number.isFinite(width) && width > 0 ? Math.max(1, Math.round(width)) : 1;
+  const reqH = Number.isFinite(height) && height > 0 ? Math.max(1, Math.round(height)) : 1;
 
   // Per-axis factor: shrink until each axis is within the dimension cap.
   const dimScale = Math.min(

--- a/packages/core/src/canvas/clamp.ts
+++ b/packages/core/src/canvas/clamp.ts
@@ -1,0 +1,92 @@
+// ── Canvas backing-store size clamp (browser-limit guard) ────────────────────
+//
+// Every browser silently caps the pixel dimensions of a `<canvas>` /
+// `OffscreenCanvas` backing store. Assigning `canvas.width`/`.height` beyond the
+// cap does NOT throw — the browser allocates a SMALLER buffer (or, past the
+// area limit, a zero-size one), so the canvas renders blank or truncated with no
+// error. A document with a pathological page/slide size, or a very large
+// devicePixelRatio × page size, can trip this and produce a blank viewer.
+//
+// `clampCanvasSize` bounds a requested backing size to limits that every major
+// browser honors, scaling BOTH axes by the same factor so the aspect ratio is
+// preserved (a uniformly smaller canvas that the caller then stretches to the
+// intended CSS box, rather than a distorted or blank one).
+
+/**
+ * Maximum canvas backing-store dimension (px) per axis. 32767 is the largest a
+ * `<canvas>` / `OffscreenCanvas` axis every major desktop browser accepts
+ * (Chrome, Firefox and Safari all top out at 32767 on at least one axis; older
+ * WebKit is lower but the area cap below binds first there).
+ */
+export const MAX_CANVAS_DIMENSION = 32767;
+
+/**
+ * Maximum canvas backing-store AREA (total px). Safari/WebKit is the tightest of
+ * the major engines here: its canvas area limit is the smallest, so a canvas
+ * well within the per-axis cap can still exceed the area cap and blank out. We
+ * use 16,777,216 px (2^24 = 4096×4096-equivalent) — the widely-cited iOS/WebKit
+ * canvas-area ceiling — as a conservative cross-engine bound. A page rendered at
+ * or below this always has a real backing store on every engine; a larger
+ * request is scaled down uniformly (and drawn back up to its CSS box).
+ *
+ * A4 at 96 DPI is ~0.6 MP and at a 3× DPR still ~5.3 MP — comfortably inside the
+ * budget; the clamp only bites on genuinely pathological sizes.
+ */
+export const MAX_CANVAS_AREA = 1 << 24; // 16_777_216 px
+
+/** A clamped canvas size plus the uniform scale applied (1 when unclamped). */
+export interface ClampedCanvasSize {
+  /** Clamped, integer backing-store width (≥ 1). */
+  width: number;
+  /** Clamped, integer backing-store height (≥ 1). */
+  height: number;
+  /**
+   * The uniform factor applied to BOTH requested axes (`≤ 1`). 1 means no
+   * clamping happened; `< 1` means the caller should draw the clamped canvas
+   * scaled up by `1 / scale` to fill the originally-intended CSS box.
+   */
+  scale: number;
+  /** True when the requested size exceeded a limit and was scaled down. */
+  clamped: boolean;
+}
+
+/**
+ * Clamp a requested canvas backing size to the per-axis and total-area limits,
+ * preserving aspect ratio.
+ *
+ * The requested `width`/`height` are first floored to `≥ 1` and rounded to
+ * integers. If either the per-axis cap ({@link MAX_CANVAS_DIMENSION}) or the
+ * area cap ({@link MAX_CANVAS_AREA}) is exceeded, both axes are multiplied by the
+ * single largest factor `s ≤ 1` that brings the size within BOTH caps, so the
+ * result keeps the requested aspect ratio.
+ *
+ * Returns the clamped integer dimensions, the applied `scale` (1 when nothing
+ * was clamped), and a `clamped` flag. Never throws; non-finite or non-positive
+ * inputs collapse to a 1×1 canvas.
+ */
+export function clampCanvasSize(width: number, height: number): ClampedCanvasSize {
+  // Normalize: non-finite / non-positive → 1. Round to integer pixels.
+  const reqW = Number.isFinite(width) && width > 0 ? Math.round(width) : 1;
+  const reqH = Number.isFinite(height) && height > 0 ? Math.round(height) : 1;
+
+  // Per-axis factor: shrink until each axis is within the dimension cap.
+  const dimScale = Math.min(
+    1,
+    MAX_CANVAS_DIMENSION / reqW,
+    MAX_CANVAS_DIMENSION / reqH,
+  );
+  // Area factor: the area scales with s², so the linear factor is sqrt(cap/area).
+  const area = reqW * reqH;
+  const areaScale = area > MAX_CANVAS_AREA ? Math.sqrt(MAX_CANVAS_AREA / area) : 1;
+
+  const scale = Math.min(dimScale, areaScale);
+  if (scale >= 1) {
+    return { width: reqW, height: reqH, scale: 1, clamped: false };
+  }
+
+  // Apply the uniform factor; floor to stay strictly within the caps, but never
+  // below 1px on either axis.
+  const w = Math.max(1, Math.floor(reqW * scale));
+  const h = Math.max(1, Math.floor(reqH * scale));
+  return { width: w, height: h, scale, clamped: true };
+}

--- a/packages/core/src/image/dib.ts
+++ b/packages/core/src/image/dib.ts
@@ -8,26 +8,21 @@
 // palette + pixels contiguously — via {@link decodePackedDib}).
 
 import { createAuxCanvas } from '../canvas/aux-canvas.js';
+import { MAX_RASTER_DIMENSION, MAX_RASTER_PIXELS } from './pixel-budget.js';
 
 /**
- * Maximum width or height (px) accepted for a decoded DIB. 32767 is the largest
- * dimension every major browser accepts for a `<canvas>` / `OffscreenCanvas`
- * (Chrome/Firefox/Safari all top out at 32767 on at least one axis). A DIB
- * exceeding this could never be blitted (`blitDibToCtx` allocates an aux canvas
- * of exactly `dib.width × dib.height`), so it is rejected at decode time.
+ * Maximum width or height (px) accepted for a decoded DIB, and the megapixel
+ * budget for the `width × height × 4` RGBA buffer. Shared with the standalone
+ * raster header sniff (`./raster-dimensions.ts`) via `./pixel-budget` so a DIB
+ * embedded in a metafile and a standalone blip are held to the SAME limits: a
+ * DIB past the dimension cap could never be blitted (`blitDibToCtx` allocates an
+ * aux canvas of exactly `dib.width × dib.height`), and one past the megapixel
+ * cap (e.g. a crafted 65535×65535 header ≈ 17 GB RGBA) is refused before the
+ * allocation. With both axes ≤ 32767 the product is exact in a double, so a
+ * plain numeric comparison suffices — no BigInt.
  */
-const MAX_DIB_DIMENSION = 32767;
-
-/**
- * Megapixel budget for a decoded DIB: 64 MP (2^26 px). The decode allocates a
- * `width × height × 4` RGBA buffer, so 64 MP bounds it to 256 MiB — the
- * practical ceiling for a metafile-embedded raster (a 600-DPI A4 scan is
- * ~35 MP, well under this). A crafted 65535×65535 header (≈4.29e9 px → ~17 GB
- * RGBA) exceeds the budget by ~64× and is refused before allocation. The
- * product stays exact in an IEEE-754 double (max ≈ 32767² ≪ 2^53), so a plain
- * numeric comparison suffices — no BigInt needed.
- */
-const MAX_DIB_PIXELS = 1 << 26; // 67_108_864 px = 64 MP
+const MAX_DIB_DIMENSION = MAX_RASTER_DIMENSION;
+const MAX_DIB_PIXELS = MAX_RASTER_PIXELS;
 
 /** A decoded DIB as top-down RGBA (what `ImageData`/`putImageData` expects). */
 export interface DecodedDib {

--- a/packages/core/src/image/pixel-budget.ts
+++ b/packages/core/src/image/pixel-budget.ts
@@ -1,0 +1,27 @@
+// ── Shared raster pixel-dimension budget (DoS / decode-bomb guard) ───────────
+//
+// One source of truth for the caps that bound how large a decoded raster surface
+// may be, used both by the metafile-embedded DIB decoder (`./dib.ts`) and by the
+// pre-`createImageBitmap` header sniff (`./raster-dimensions.ts`). Keeping the
+// two paths on the SAME numbers means a raster that is refused as a standalone
+// blip is also refused when embedded in a WMF/EMF, and vice versa.
+
+/**
+ * Maximum width or height (px) accepted for a decoded raster. 32767 is the
+ * largest dimension every major browser accepts for a `<canvas>` /
+ * `OffscreenCanvas` (Chrome, Firefox and Safari all top out at 32767 on at least
+ * one axis). A raster wider or taller than this could never be drawn to a canvas
+ * anyway, so it is rejected before decode.
+ */
+export const MAX_RASTER_DIMENSION = 32767;
+
+/**
+ * Megapixel budget for a decoded raster: 64 MP (2^26 px). A decoded surface is
+ * `width × height × 4` bytes of RGBA, so 64 MP bounds it to 256 MiB — the
+ * practical ceiling for a document-embedded image (a 600-DPI A4 scan is ~35 MP,
+ * well under this). A crafted 60000×60000 header (~3.6e9 px → ~14 GB RGBA)
+ * exceeds the budget by ~50× and is refused before any allocation. With both
+ * axes ≤ MAX_RASTER_DIMENSION the product stays ≤ ~1.07e9 — exact in an
+ * IEEE-754 double — so a plain numeric comparison suffices (no BigInt).
+ */
+export const MAX_RASTER_PIXELS = 1 << 26; // 67_108_864 px = 64 MP

--- a/packages/core/src/image/raster-dimensions.test.ts
+++ b/packages/core/src/image/raster-dimensions.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sniffRasterDimensions,
+  rasterExceedsBudget,
+  rasterHeaderExceedsBudget,
+} from './raster-dimensions.js';
+import { MAX_RASTER_DIMENSION, MAX_RASTER_PIXELS } from './pixel-budget.js';
+
+// ── Raster header dimension sniff + budget (RB1 decode-bomb guard) ───────────
+//
+// These fixtures are SYNTHETIC: each carries a valid header declaring enormous
+// pixel dimensions but only a handful of bytes of "pixel data" — the shape of a
+// decompression bomb (a tiny compressed blip that decodes to a multi-GB RGBA
+// surface). The guard must recognize the declared dimensions from the header
+// alone and report the image as over budget, WITHOUT decoding it.
+
+/** Big-endian u32 into a byte array at `o`. */
+function putBeU32(b: Uint8Array, o: number, v: number): void {
+  b[o] = (v >>> 24) & 0xff;
+  b[o + 1] = (v >>> 16) & 0xff;
+  b[o + 2] = (v >>> 8) & 0xff;
+  b[o + 3] = v & 0xff;
+}
+/** Little-endian u16. */
+function putLeU16(b: Uint8Array, o: number, v: number): void {
+  b[o] = v & 0xff;
+  b[o + 1] = (v >>> 8) & 0xff;
+}
+/** Little-endian u32. */
+function putLeU32(b: Uint8Array, o: number, v: number): void {
+  b[o] = v & 0xff;
+  b[o + 1] = (v >>> 8) & 0xff;
+  b[o + 2] = (v >>> 16) & 0xff;
+  b[o + 3] = (v >>> 24) & 0xff;
+}
+/** Big-endian u16. */
+function putBeU16(b: Uint8Array, o: number, v: number): void {
+  b[o] = (v >>> 8) & 0xff;
+  b[o + 1] = v & 0xff;
+}
+
+// ── Header builders (declare `w × h`, carry almost no payload) ───────────────
+
+function pngHeader(w: number, h: number): Uint8Array {
+  // 8-byte signature + IHDR chunk (length + "IHDR" + W + H + …). We only need
+  // through offset 24; a couple of trailing bytes stand in for the rest.
+  const b = new Uint8Array(26);
+  b.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  putBeU32(b, 8, 13); // IHDR length
+  b.set([0x49, 0x48, 0x44, 0x52], 12); // "IHDR"
+  putBeU32(b, 16, w);
+  putBeU32(b, 20, h);
+  return b;
+}
+
+function gifHeader(w: number, h: number): Uint8Array {
+  const b = new Uint8Array(13);
+  b.set([0x47, 0x49, 0x46, 0x38, 0x39, 0x61], 0); // "GIF89a"
+  putLeU16(b, 6, w);
+  putLeU16(b, 8, h);
+  return b;
+}
+
+function bmpHeader(w: number, h: number): Uint8Array {
+  // "BM" + 14-byte file header, then a 40-byte BITMAPINFOHEADER.
+  const b = new Uint8Array(54);
+  b.set([0x42, 0x4d], 0); // "BM"
+  putLeU32(b, 14, 40); // biSize = BITMAPINFOHEADER
+  putLeU32(b, 18, w >>> 0); // signed i32, positive here
+  putLeU32(b, 22, h >>> 0);
+  return b;
+}
+
+function webpVp8xHeader(w: number, h: number): Uint8Array {
+  // RIFF…WEBP + "VP8X" chunk with 24-bit canvas width-1 / height-1.
+  const b = new Uint8Array(30);
+  b.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  putLeU32(b, 4, 0); // file size (ignored by the sniff)
+  b.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  b.set([0x56, 0x50, 0x38, 0x58], 12); // "VP8X"
+  putLeU32(b, 16, 10); // VP8X payload size (ignored)
+  // flags byte at 20; canvas width-1 (24-bit LE) at 24, height-1 at 27.
+  const w1 = w - 1;
+  const h1 = h - 1;
+  b[24] = w1 & 0xff;
+  b[25] = (w1 >>> 8) & 0xff;
+  b[26] = (w1 >>> 16) & 0xff;
+  b[27] = h1 & 0xff;
+  b[28] = (h1 >>> 8) & 0xff;
+  b[29] = (h1 >>> 16) & 0xff;
+  return b;
+}
+
+/** A minimal JPEG: SOI, an APP0 segment, then an SOF0 declaring `w × h`. */
+function jpegHeader(w: number, h: number, padApp0 = 0): Uint8Array {
+  // SOI (2) + APP0 marker (2) + APP0 length (2) + APP0 payload (padApp0) +
+  // SOF0 marker (2) + SOF0 length (2) + [prec(1) h(2) w(2) …].
+  const app0Len = 2 + padApp0; // length field counts itself
+  const sof0PayloadLen = 2 + 1 + 2 + 2; // len + prec + h + w
+  const size = 2 + 2 + app0Len + 2 + sof0PayloadLen;
+  const b = new Uint8Array(size);
+  let i = 0;
+  b[i++] = 0xff;
+  b[i++] = 0xd8; // SOI
+  b[i++] = 0xff;
+  b[i++] = 0xe0; // APP0
+  putBeU16(b, i, app0Len);
+  i += 2 + padApp0; // skip APP0 payload
+  b[i++] = 0xff;
+  b[i++] = 0xc0; // SOF0
+  putBeU16(b, i, sof0PayloadLen);
+  i += 2;
+  b[i++] = 8; // precision
+  putBeU16(b, i, h);
+  i += 2;
+  putBeU16(b, i, w);
+  i += 2;
+  return b;
+}
+
+describe('sniffRasterDimensions — reads declared pixel dimensions from the header', () => {
+  it('reads PNG IHDR dimensions', () => {
+    expect(sniffRasterDimensions(pngHeader(1920, 1080))).toEqual({ width: 1920, height: 1080 });
+    expect(sniffRasterDimensions(pngHeader(60000, 60000))).toEqual({ width: 60000, height: 60000 });
+  });
+
+  it('reads GIF logical-screen dimensions', () => {
+    expect(sniffRasterDimensions(gifHeader(800, 600))).toEqual({ width: 800, height: 600 });
+  });
+
+  it('reads BMP BITMAPINFOHEADER dimensions (and |height| for top-down)', () => {
+    expect(sniffRasterDimensions(bmpHeader(1024, 768))).toEqual({ width: 1024, height: 768 });
+    // Negative height (top-down bitmap) is budgeted by magnitude.
+    const b = bmpHeader(1024, 0);
+    putLeU32(b, 22, (-768 >>> 0) as number);
+    expect(sniffRasterDimensions(b)).toEqual({ width: 1024, height: 768 });
+  });
+
+  it('reads WebP VP8X canvas dimensions', () => {
+    expect(sniffRasterDimensions(webpVp8xHeader(4000, 3000))).toEqual({ width: 4000, height: 3000 });
+  });
+
+  it('reads JPEG SOF dimensions, even past an APP0 segment', () => {
+    expect(sniffRasterDimensions(jpegHeader(3264, 2448))).toEqual({ width: 3264, height: 2448 });
+    // With a large APP0 (EXIF/ICC stand-in) the walker still reaches the SOF.
+    expect(sniffRasterDimensions(jpegHeader(3264, 2448, 400))).toEqual({
+      width: 3264,
+      height: 2448,
+    });
+  });
+
+  it('returns null for unrecognized / too-short / SVG headers (fail-open)', () => {
+    expect(sniffRasterDimensions(new Uint8Array([]))).toBeNull();
+    expect(sniffRasterDimensions(new Uint8Array([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+    // SVG starts with "<?xml" or "<svg" — not a recognized raster.
+    expect(sniffRasterDimensions(new TextEncoder().encode('<svg width="9"></svg>'))).toBeNull();
+    // PNG signature but a first chunk that is not IHDR → don't trust it.
+    const notIhdr = pngHeader(10, 10);
+    notIhdr[12] = 0x00; // corrupt "IHDR" → "\0HDR"
+    expect(sniffRasterDimensions(notIhdr)).toBeNull();
+  });
+});
+
+describe('rasterExceedsBudget — enforces the shared pixel budget', () => {
+  it('accepts in-budget dimensions', () => {
+    expect(rasterExceedsBudget({ width: 1920, height: 1080 })).toBe(false);
+    // A ~35 MP scan (within the 64 MP budget and under the per-axis cap).
+    expect(rasterExceedsBudget({ width: 7016, height: 4961 })).toBe(false);
+  });
+
+  it('rejects an over-megapixel image within the per-axis cap', () => {
+    // Both axes ≤ 32767 but the product blows the 64 MP budget.
+    const w = 30000;
+    const h = 30000;
+    expect(w).toBeLessThanOrEqual(MAX_RASTER_DIMENSION);
+    expect(h).toBeLessThanOrEqual(MAX_RASTER_DIMENSION);
+    expect(w * h).toBeGreaterThan(MAX_RASTER_PIXELS);
+    expect(rasterExceedsBudget({ width: w, height: h })).toBe(true);
+  });
+
+  it('rejects an over-dimension image even when it would be within the MP budget', () => {
+    // 40000 × 1: only 40 000 px (well under 64 MP) but past the 32767 axis cap,
+    // so it could never be drawn to a canvas — reject it.
+    expect(rasterExceedsBudget({ width: 40000, height: 1 })).toBe(true);
+  });
+
+  it('treats non-positive or non-finite dimensions as over budget (untrustworthy header)', () => {
+    expect(rasterExceedsBudget({ width: 0, height: 100 })).toBe(true);
+    expect(rasterExceedsBudget({ width: -5, height: 100 })).toBe(true);
+    expect(rasterExceedsBudget({ width: NaN, height: 100 })).toBe(true);
+  });
+
+  it('accepts exactly at the caps (boundary)', () => {
+    expect(rasterExceedsBudget({ width: MAX_RASTER_DIMENSION, height: 1 })).toBe(false);
+    // A 1 × MAX_RASTER_PIXELS strip is exactly the MP budget (but > axis cap):
+    // use a squarer at-budget case instead.
+    expect(rasterExceedsBudget({ width: 8192, height: 8192 })).toBe(false); // 64 MP exactly
+    expect(8192 * 8192).toBe(MAX_RASTER_PIXELS);
+  });
+});
+
+describe('rasterHeaderExceedsBudget — end-to-end neutralization of decode bombs', () => {
+  it('flags a 60000×60000 PNG bomb (tiny payload, huge declared size)', () => {
+    const bomb = pngHeader(60000, 60000);
+    // The fixture is a couple dozen bytes — a real decode would be ~14 GB RGBA.
+    expect(bomb.length).toBeLessThan(64);
+    expect(rasterHeaderExceedsBudget(bomb)).toBe(true);
+  });
+
+  it('flags GIF / BMP / WebP / JPEG bombs alike', () => {
+    expect(rasterHeaderExceedsBudget(gifHeader(50000, 50000))).toBe(true);
+    expect(rasterHeaderExceedsBudget(bmpHeader(40000, 40000))).toBe(true);
+    expect(rasterHeaderExceedsBudget(webpVp8xHeader(16384, 16384))).toBe(true); // 268 MP
+    expect(rasterHeaderExceedsBudget(jpegHeader(60000, 60000))).toBe(true);
+  });
+
+  it('does NOT flag a normal, in-budget image (no false positive)', () => {
+    expect(rasterHeaderExceedsBudget(pngHeader(1920, 1080))).toBe(false);
+    expect(rasterHeaderExceedsBudget(jpegHeader(4032, 3024))).toBe(false);
+    expect(rasterHeaderExceedsBudget(gifHeader(500, 500))).toBe(false);
+  });
+
+  it('does NOT flag an unrecognized header (fail-open — the caller decodes normally)', () => {
+    expect(rasterHeaderExceedsBudget(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe(false);
+    expect(rasterHeaderExceedsBudget(new TextEncoder().encode('<svg/>'))).toBe(false);
+  });
+});

--- a/packages/core/src/image/raster-dimensions.test.ts
+++ b/packages/core/src/image/raster-dimensions.test.ts
@@ -91,6 +91,30 @@ function webpVp8xHeader(w: number, h: number): Uint8Array {
   return b;
 }
 
+/** WebP "VP8L" (lossless): a 32-bit LE field at offset 21 packs width-1 (14
+ * bits) then height-1 (14 bits), after a 0x2F signature byte at offset 20. */
+function webpVp8lHeader(w: number, h: number): Uint8Array {
+  const b = new Uint8Array(25);
+  b.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  b.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  b.set([0x56, 0x50, 0x38, 0x4c], 12); // "VP8L"
+  b[20] = 0x2f; // VP8L signature
+  const bits = ((w - 1) & 0x3fff) | (((h - 1) & 0x3fff) << 14);
+  putLeU32(b, 21, bits >>> 0);
+  return b;
+}
+
+/** WebP "VP8 " (lossy simple): 14-bit dimensions at offsets 26/28. */
+function webpVp8Header(w: number, h: number): Uint8Array {
+  const b = new Uint8Array(30);
+  b.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  b.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  b.set([0x56, 0x50, 0x38, 0x20], 12); // "VP8 "
+  putLeU16(b, 26, w & 0x3fff);
+  putLeU16(b, 28, h & 0x3fff);
+  return b;
+}
+
 /** A minimal JPEG: SOI, an APP0 segment, then an SOF0 declaring `w × h`. */
 function jpegHeader(w: number, h: number, padApp0 = 0): Uint8Array {
   // SOI (2) + APP0 marker (2) + APP0 length (2) + APP0 payload (padApp0) +
@@ -118,6 +142,47 @@ function jpegHeader(w: number, h: number, padApp0 = 0): Uint8Array {
   return b;
 }
 
+/**
+ * A JPEG with a DHT (0xFFC4) segment *before* the SOF0. DHT shares the 0xC0..0xCF
+ * range with SOF markers but is NOT a frame; the walker must skip it (using its
+ * segment length) and keep scanning to reach the real SOF, not misread the DHT
+ * payload as dimensions. `dhtPayload` bytes stand in for Huffman tables.
+ */
+function jpegWithDhtThenSof(w: number, h: number, dhtPayload = 12): Uint8Array {
+  const dhtLen = 2 + dhtPayload; // length field counts itself
+  const sofLen = 2 + 1 + 2 + 2;
+  const size = 2 /* SOI */ + 2 + dhtLen /* DHT */ + 2 + sofLen; /* SOF0 */
+  const b = new Uint8Array(size);
+  let i = 0;
+  b[i++] = 0xff;
+  b[i++] = 0xd8; // SOI
+  b[i++] = 0xff;
+  b[i++] = 0xc4; // DHT (not a frame)
+  putBeU16(b, i, dhtLen);
+  i += 2 + dhtPayload; // skip the DHT payload
+  b[i++] = 0xff;
+  b[i++] = 0xc0; // SOF0
+  putBeU16(b, i, sofLen);
+  i += 2;
+  b[i++] = 8; // precision
+  putBeU16(b, i, h);
+  i += 2;
+  putBeU16(b, i, w);
+  i += 2;
+  return b;
+}
+
+/**
+ * A malformed JPEG whose first non-standalone segment declares a length < 2
+ * (which would leave the walker unable to advance). The sniff must bail (return
+ * null) rather than loop forever or read out of bounds.
+ */
+function jpegMalformedSegLen(): Uint8Array {
+  // SOI, then an APP0 marker with a bogus 1-byte length (< the 2-byte minimum).
+  const b = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x01, 0x00, 0x00]);
+  return b;
+}
+
 describe('sniffRasterDimensions — reads declared pixel dimensions from the header', () => {
   it('reads PNG IHDR dimensions', () => {
     expect(sniffRasterDimensions(pngHeader(1920, 1080))).toEqual({ width: 1920, height: 1080 });
@@ -140,6 +205,18 @@ describe('sniffRasterDimensions — reads declared pixel dimensions from the hea
     expect(sniffRasterDimensions(webpVp8xHeader(4000, 3000))).toEqual({ width: 4000, height: 3000 });
   });
 
+  it('reads WebP VP8L (lossless) dimensions', () => {
+    expect(sniffRasterDimensions(webpVp8lHeader(2000, 1500))).toEqual({ width: 2000, height: 1500 });
+    // Signature byte must be 0x2F; a wrong signature fails open (null).
+    const bad = webpVp8lHeader(2000, 1500);
+    bad[20] = 0x00;
+    expect(sniffRasterDimensions(bad)).toBeNull();
+  });
+
+  it('reads WebP VP8 (lossy simple) dimensions', () => {
+    expect(sniffRasterDimensions(webpVp8Header(640, 480))).toEqual({ width: 640, height: 480 });
+  });
+
   it('reads JPEG SOF dimensions, even past an APP0 segment', () => {
     expect(sniffRasterDimensions(jpegHeader(3264, 2448))).toEqual({ width: 3264, height: 2448 });
     // With a large APP0 (EXIF/ICC stand-in) the walker still reaches the SOF.
@@ -147,6 +224,20 @@ describe('sniffRasterDimensions — reads declared pixel dimensions from the hea
       width: 3264,
       height: 2448,
     });
+  });
+
+  it('skips a DHT (0xFFC4) segment and reads the following SOF, not the DHT payload', () => {
+    // DHT sits in the 0xC0..0xCF range but is not a frame; misreading it would
+    // yield garbage dimensions. The walker must length-skip it to the real SOF.
+    expect(sniffRasterDimensions(jpegWithDhtThenSof(3000, 2000))).toEqual({
+      width: 3000,
+      height: 2000,
+    });
+  });
+
+  it('bails (null) on a JPEG segment length < 2 without looping', () => {
+    // A bogus sub-minimum segment length must terminate the walk, not spin.
+    expect(sniffRasterDimensions(jpegMalformedSegLen())).toBeNull();
   });
 
   it('returns null for unrecognized / too-short / SVG headers (fail-open)', () => {
@@ -214,10 +305,19 @@ describe('rasterHeaderExceedsBudget — end-to-end neutralization of decode bomb
     expect(rasterHeaderExceedsBudget(jpegHeader(60000, 60000))).toBe(true);
   });
 
+  it('flags WebP VP8L / VP8 bombs (both non-VP8X lossy/lossless variants)', () => {
+    // VP8L/VP8 dimensions are 14-bit (≤16383 per axis), so a 16383² bomb is
+    // ~268 MP — well past the 64 MP budget while staying representable.
+    expect(rasterHeaderExceedsBudget(webpVp8lHeader(16383, 16383))).toBe(true);
+    expect(rasterHeaderExceedsBudget(webpVp8Header(16383, 16383))).toBe(true);
+  });
+
   it('does NOT flag a normal, in-budget image (no false positive)', () => {
     expect(rasterHeaderExceedsBudget(pngHeader(1920, 1080))).toBe(false);
     expect(rasterHeaderExceedsBudget(jpegHeader(4032, 3024))).toBe(false);
     expect(rasterHeaderExceedsBudget(gifHeader(500, 500))).toBe(false);
+    expect(rasterHeaderExceedsBudget(webpVp8lHeader(2000, 1500))).toBe(false);
+    expect(rasterHeaderExceedsBudget(webpVp8Header(640, 480))).toBe(false);
   });
 
   it('does NOT flag an unrecognized header (fail-open — the caller decodes normally)', () => {

--- a/packages/core/src/image/raster-dimensions.ts
+++ b/packages/core/src/image/raster-dimensions.ts
@@ -1,0 +1,254 @@
+// ── Raster pixel-dimension sniffing + budget (decode-bomb guard) ─────────────
+//
+// A blip in an OOXML part is attacker-controllable bytes. `createImageBitmap`
+// decodes the compressed image into an uncompressed RGBA surface sized by the
+// image *header*, not by the compressed byte length — so a tiny PNG/JPEG whose
+// header declares, say, 60000×60000 forces the browser to allocate a multi-GB
+// bitmap ("decompression bomb"), which OOMs or hangs the tab. The ZIP-entry
+// size cap (RB11) does not help: the compressed part is small; only the decoded
+// surface is enormous.
+//
+// This module sniffs the pixel dimensions straight from the image header (no
+// full decode) so an over-budget image can be refused BEFORE it ever reaches
+// `createImageBitmap`. It recognizes the raster formats OOXML embeds — PNG,
+// JPEG, GIF, BMP, WebP — and returns `null` for anything it does not recognize
+// (SVG, metafiles, truncated/garbage headers), leaving the caller to fall back
+// to its normal path. Recognizing "too big" is a safe superset: an unrecognized
+// header simply isn't blocked here.
+
+import { MAX_RASTER_DIMENSION, MAX_RASTER_PIXELS } from './pixel-budget.js';
+
+/** Read a big-endian u16 at `o` (bounds already checked by the caller). */
+function beU16(b: Uint8Array, o: number): number {
+  return (b[o] << 8) | b[o + 1];
+}
+
+/** Read a big-endian u32 at `o`. `>>> 0` keeps it an unsigned 32-bit value. */
+function beU32(b: Uint8Array, o: number): number {
+  return ((b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3]) >>> 0;
+}
+
+/** Read a little-endian u16 at `o`. */
+function leU16(b: Uint8Array, o: number): number {
+  return b[o] | (b[o + 1] << 8);
+}
+
+/** Read a little-endian i32 at `o` (BMP dimensions are signed). */
+function leI32(b: Uint8Array, o: number): number {
+  return (b[o] | (b[o + 1] << 8) | (b[o + 2] << 16) | (b[o + 3] << 24)) | 0;
+}
+
+/** Pixel dimensions sniffed from an image header. */
+export interface RasterDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Sniff the pixel width/height of a raster image from its header bytes, or
+ * `null` if the format is not one we recognize (or the header is too short /
+ * malformed to read the dimensions).
+ *
+ * `head` need only contain the leading bytes of the file — 30 bytes covers PNG,
+ * GIF, BMP and WebP; JPEG's dimensions live in a later SOF marker, so for JPEG a
+ * larger prefix (a few hundred bytes typically, ideally the whole file) yields a
+ * result while a short prefix returns `null` (fail-open: not recognized ⇒ not
+ * blocked). Never throws.
+ */
+export function sniffRasterDimensions(head: Uint8Array): RasterDimensions | null {
+  const n = head.length;
+
+  // PNG — 8-byte signature, then the IHDR chunk: [len u32][type "IHDR"][W u32]
+  // [H u32]… Dimensions are big-endian at offsets 16 and 20. ([ISO/IEC 15948])
+  if (
+    n >= 24 &&
+    head[0] === 0x89 &&
+    head[1] === 0x50 && // P
+    head[2] === 0x4e && // N
+    head[3] === 0x47 && // G
+    head[4] === 0x0d &&
+    head[5] === 0x0a &&
+    head[6] === 0x1a &&
+    head[7] === 0x0a
+  ) {
+    // Verify the first chunk really is IHDR before trusting the dimensions.
+    if (head[12] === 0x49 && head[13] === 0x48 && head[14] === 0x44 && head[15] === 0x52) {
+      return { width: beU32(head, 16), height: beU32(head, 20) };
+    }
+    return null;
+  }
+
+  // GIF — "GIF87a"/"GIF89a", then the logical-screen descriptor: width, height
+  // as little-endian u16 at offsets 6 and 8. (Note: this is the canvas size, an
+  // upper bound on any frame — exactly what we want to budget.)
+  if (
+    n >= 10 &&
+    head[0] === 0x47 && // G
+    head[1] === 0x49 && // I
+    head[2] === 0x46 && // F
+    head[3] === 0x38 && // 8
+    (head[4] === 0x37 || head[4] === 0x39) && // 7 | 9
+    head[5] === 0x61 // a
+  ) {
+    return { width: leU16(head, 6), height: leU16(head, 8) };
+  }
+
+  // BMP — "BM", then (skipping the 14-byte file header) a DIB header whose first
+  // u32 is its own size. The two common headers put signed i32 width/height at
+  // offsets 18/22 (BITMAPINFOHEADER, 40-byte, and later). The rare 12-byte
+  // BITMAPCOREHEADER uses u16 width/height at 18/20. Height may be negative
+  // (top-down); budget on its magnitude.
+  if (n >= 26 && head[0] === 0x42 && head[1] === 0x4d) {
+    const dibSize = beU32Le(head, 14);
+    if (dibSize === 12) {
+      // BITMAPCOREHEADER: u16 dimensions.
+      return { width: leU16(head, 18), height: leU16(head, 20) };
+    }
+    // BITMAPINFOHEADER and successors: signed i32 dimensions.
+    return { width: Math.abs(leI32(head, 18)), height: Math.abs(leI32(head, 22)) };
+  }
+
+  // WebP — RIFF container: "RIFF"[size u32]"WEBP", then a chunk FourCC:
+  //   VP8  (lossy):   after the 3-byte frame tag, two u16 dimensions (14-bit,
+  //                   the top 2 bits are scale) at offsets 26/28.
+  //   VP8L (lossless): a 32-bit little-endian field at offset 21 packs
+  //                    width-1 (14 bits) then height-1 (14 bits).
+  //   VP8X (extended): a 24-bit little-endian canvas width-1 / height-1 at
+  //                    offsets 24/27.
+  if (
+    n >= 16 &&
+    head[0] === 0x52 && // R
+    head[1] === 0x49 && // I
+    head[2] === 0x46 && // F
+    head[3] === 0x46 && // F
+    head[8] === 0x57 && // W
+    head[9] === 0x45 && // E
+    head[10] === 0x42 && // B
+    head[11] === 0x50 // P
+  ) {
+    return sniffWebp(head);
+  }
+
+  // JPEG — starts with SOI (FFD8). Walk the marker segments to the first
+  // Start-Of-Frame (SOF0..SOFF, excluding non-SOF FFC4/FFC8/FFCC), whose payload
+  // holds [precision u8][height u16][width u16], big-endian.
+  if (n >= 4 && head[0] === 0xff && head[1] === 0xd8) {
+    return sniffJpegSof(head);
+  }
+
+  return null;
+}
+
+/** Read a little-endian u32 at `o` (used for the BMP DIB-header size). */
+function beU32Le(b: Uint8Array, o: number): number {
+  return (b[o] | (b[o + 1] << 8) | (b[o + 2] << 16) | (b[o + 3] << 24)) >>> 0;
+}
+
+function sniffWebp(b: Uint8Array): RasterDimensions | null {
+  const n = b.length;
+  // Chunk FourCC at offset 12.
+  const c0 = b[12];
+  const c1 = b[13];
+  const c2 = b[14];
+  const c3 = b[15];
+  // "VP8 " (lossy simple)
+  if (c0 === 0x56 && c1 === 0x50 && c2 === 0x38 && c3 === 0x20) {
+    // frame tag at 20 (3 bytes) + start code (3 bytes) then dimensions at 26/28.
+    if (n < 30) return null;
+    const width = leU16(b, 26) & 0x3fff;
+    const height = leU16(b, 28) & 0x3fff;
+    return { width, height };
+  }
+  // "VP8L" (lossless)
+  if (c0 === 0x56 && c1 === 0x50 && c2 === 0x38 && c3 === 0x4c) {
+    if (n < 25) return null;
+    // Signature byte 0x2F at offset 20, then a 32-bit LE field at 21.
+    if (b[20] !== 0x2f) return null;
+    const bits = beU32Le(b, 21);
+    const width = (bits & 0x3fff) + 1;
+    const height = ((bits >>> 14) & 0x3fff) + 1;
+    return { width, height };
+  }
+  // "VP8X" (extended)
+  if (c0 === 0x56 && c1 === 0x50 && c2 === 0x38 && c3 === 0x58) {
+    if (n < 30) return null;
+    // 24-bit LE canvas width-1 at 24, height-1 at 27.
+    const width = (b[24] | (b[25] << 8) | (b[26] << 16)) + 1;
+    const height = (b[27] | (b[28] << 8) | (b[29] << 16)) + 1;
+    return { width, height };
+  }
+  return null;
+}
+
+function sniffJpegSof(b: Uint8Array): RasterDimensions | null {
+  const n = b.length;
+  let i = 2; // past SOI (FFD8)
+  while (i + 1 < n) {
+    // Markers are 0xFF followed by a non-0x00, non-0xFF type byte. Fill bytes
+    // (0xFF 0xFF) and stuffed 0x00 are skipped by advancing one byte.
+    if (b[i] !== 0xff) {
+      i += 1;
+      continue;
+    }
+    const marker = b[i + 1];
+    if (marker === 0xff) {
+      // fill byte
+      i += 1;
+      continue;
+    }
+    // Standalone markers with no length: RSTn (D0..D7), SOI (D8), EOI (D9),
+    // TEM (01). Advance past them.
+    if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
+      i += 2;
+      continue;
+    }
+    if (marker === 0xd9) {
+      // EOI — no frame found.
+      return null;
+    }
+    // All other markers carry a 2-byte big-endian segment length (including the
+    // length field itself). Need the length bytes.
+    if (i + 3 >= n) return null;
+    const segLen = beU16(b, i + 2);
+    // SOF markers: 0xC0..0xCF EXCEPT 0xC4 (DHT), 0xC8 (JPG), 0xCC (DAC).
+    const isSof =
+      marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    if (isSof) {
+      // Payload: [precision u8][height u16][width u16] at i+4.
+      if (i + 8 >= n) return null;
+      const height = beU16(b, i + 5);
+      const width = beU16(b, i + 7);
+      return { width, height };
+    }
+    // Skip this segment: 2 (marker) + segLen (length field + payload).
+    if (segLen < 2) return null; // malformed
+    i += 2 + segLen;
+  }
+  return null;
+}
+
+/**
+ * `true` when `dims` exceeds the raster pixel budget — a per-axis cap or the
+ * total-megapixel cap (see `./pixel-budget`). Non-positive or non-finite
+ * dimensions also count as "over budget" (a header we can't trust). Callers
+ * treat `true` as "do not decode this image".
+ */
+export function rasterExceedsBudget(dims: RasterDimensions): boolean {
+  const { width, height } = dims;
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return true;
+  if (width <= 0 || height <= 0) return true;
+  if (width > MAX_RASTER_DIMENSION || height > MAX_RASTER_DIMENSION) return true;
+  // width, height ≤ MAX_RASTER_DIMENSION (≤ 32767), so the product is ≤ ~1.07e9,
+  // exact in a double — a plain comparison suffices.
+  return width * height > MAX_RASTER_PIXELS;
+}
+
+/**
+ * Convenience: sniff `head` and report whether the image is a recognized raster
+ * that exceeds the pixel budget. `false` for unrecognized headers (fail-open) —
+ * only a recognized, over-budget raster returns `true`.
+ */
+export function rasterHeaderExceedsBudget(head: Uint8Array): boolean {
+  const dims = sniffRasterDimensions(head);
+  return dims !== null && rasterExceedsBudget(dims);
+}

--- a/packages/core/src/image/wmf.test.ts
+++ b/packages/core/src/image/wmf.test.ts
@@ -775,14 +775,62 @@ describe('decodeRasterOrMetafile', () => {
     expect(cib).toHaveBeenCalledWith(blob);
   });
 
-  it('sniffs a ≤44-byte slice for raster: only the header is read, the Blob is handed to createImageBitmap whole', async () => {
+  it('a PNG decode bomb (60000×60000 header, tiny payload) → null, WITHOUT calling createImageBitmap (RB1)', async () => {
+    // The decode-bomb guard: a valid PNG header declaring a 60000×60000 image
+    // (~14 GB RGBA once decoded) must be refused BEFORE createImageBitmap ever
+    // allocates the surface. The fixture is a couple dozen bytes.
+    const cib = vi.fn(async (_blob: Blob) => ({ width: 1, height: 1, close() {} }) as unknown as ImageBitmap);
+    vi.stubGlobal('createImageBitmap', cib);
+    // 8-byte PNG signature + IHDR chunk declaring 60000×60000.
+    const bomb = new Uint8Array(26);
+    bomb.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    // IHDR length (13), "IHDR", then big-endian W=60000, H=60000.
+    bomb.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const put = (o: number, v: number) => {
+      bomb[o] = (v >>> 24) & 0xff;
+      bomb[o + 1] = (v >>> 16) & 0xff;
+      bomb[o + 2] = (v >>> 8) & 0xff;
+      bomb[o + 3] = v & 0xff;
+    };
+    put(16, 60000);
+    put(20, 60000);
+    const blob = new Blob([bomb as BlobPart], { type: 'image/png' });
+    const bmp = await decodeRasterOrMetafile(blob, { widthPt: 50, heightPt: 50 });
+    expect(bmp).toBeNull(); // refused — graceful "skip the picture" contract
+    expect(cib).not.toHaveBeenCalled(); // never handed to the decoder
+  });
+
+  it('an in-budget PNG (1920×1080 header) still decodes (no false positive)', async () => {
+    const fake = { width: 1920, height: 1080, close() {} } as unknown as ImageBitmap;
+    const cib = vi.fn(async (_blob: Blob) => fake);
+    vi.stubGlobal('createImageBitmap', cib);
+    const png = new Uint8Array(26);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52], 8);
+    const put = (o: number, v: number) => {
+      png[o] = (v >>> 24) & 0xff;
+      png[o + 1] = (v >>> 16) & 0xff;
+      png[o + 2] = (v >>> 8) & 0xff;
+      png[o + 3] = v & 0xff;
+    };
+    put(16, 1920);
+    put(20, 1080);
+    const blob = new Blob([png as BlobPart], { type: 'image/png' });
+    const bmp = await decodeRasterOrMetafile(blob, { widthPt: 50, heightPt: 50 });
+    expect(bmp).toBe(fake);
+    expect(cib).toHaveBeenCalledTimes(1);
+  });
+
+  it('sniffs a header slice for raster: only the header is read, the Blob is handed to createImageBitmap whole', async () => {
     const fake = { width: 3, height: 4, close() {} } as unknown as ImageBitmap;
     const cib = vi.fn(async (_blob: Blob) => fake);
     vi.stubGlobal('createImageBitmap', cib);
 
-    // A raster smaller than the 44-byte sniff window. slice(0,44) must not throw
-    // and the sub-44-byte `isWmf`/`isEmf` length guards must both return false so
-    // the blob falls through to createImageBitmap.
+    // A raster smaller than the sniff window. slice(0,N) must not throw (Blob.slice
+    // clamps to the actual length) and the short `isWmf`/`isEmf` length guards must
+    // both return false so the blob falls through to createImageBitmap. This 7-byte
+    // "PNG-ish" buffer has no valid IHDR, so the dimension sniff returns null
+    // (fail-open) and does not block it.
     const tiny = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]); // 7 bytes, PNG-ish
     const base = new Blob([tiny as BlobPart], { type: 'image/png' });
 

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -38,6 +38,7 @@
 
 import { decodePackedDib, blitDibToCtx } from './dib.js';
 import { renderEmfToBitmap } from './emf.js';
+import { rasterHeaderExceedsBudget } from './raster-dimensions.js';
 import { createAuxCanvas } from '../canvas/aux-canvas.js';
 
 // WMF record function codes (the subset we act on; others are skipped by size).
@@ -720,15 +721,18 @@ export async function decodeRasterOrMetafile(
 ): Promise<ImageBitmap | null> {
   const { widthPt = 0, heightPt = 0, suppressBoundaryFrame = false } = opts;
 
-  // Sniff only the header, not the whole blob. `isEmf` reads bytes 40-43 (u32@40
-  // == " EMF") and `isWmf` at most the 18-byte standard header, so 44 bytes is
-  // sufficient for either magic. The overwhelmingly common case — a raster
-  // (PNG/JPEG/GIF/BMP/WEBP) — then hands the Blob straight to createImageBitmap
-  // without ever materializing the full bytes in JS, avoiding a whole-image
-  // arrayBuffer() copy per decode. A metafile pays a 44-byte read plus the full
-  // read below (two reads), but metafiles are small and rare next to the raster
-  // fast path, so the net is a large reduction in copied bytes.
-  const head = new Uint8Array(await data.slice(0, 44).arrayBuffer());
+  // Sniff a header prefix, not the whole blob. `isEmf` reads bytes 40-43 (u32@40
+  // == " EMF") and `isWmf` at most the 18-byte standard header, and the raster
+  // pixel-dimension sniff (below) needs ≤30 bytes for PNG/GIF/BMP/WEBP but must
+  // walk JPEG marker segments to reach the Start-Of-Frame — which can sit a few
+  // hundred bytes in past EXIF/ICC metadata. A 64 KiB prefix covers the SOF of
+  // essentially every real JPEG while staying far smaller than a full-image copy;
+  // if the SOF is even deeper the sniff simply fails open (not recognized ⇒ not
+  // blocked). The common raster case then hands the Blob straight to
+  // createImageBitmap without materializing the full bytes in JS. `Blob.slice`
+  // clamps to the blob's actual length, so a tiny image just yields a short head.
+  const RASTER_SNIFF_BYTES = 64 * 1024;
+  const head = new Uint8Array(await data.slice(0, RASTER_SNIFF_BYTES).arrayBuffer());
 
   if (isWmf(head)) {
     const { w, h } = wmfRasterTarget(widthPt, heightPt);
@@ -738,5 +742,11 @@ export async function decodeRasterOrMetafile(
     const { w, h } = wmfRasterTarget(widthPt, heightPt);
     return renderEmfToBitmap(new Uint8Array(await data.arrayBuffer()), w, h);
   }
+  // Decode-bomb guard: if the header declares a recognized raster (PNG/JPEG/GIF/
+  // BMP/WEBP) whose pixel dimensions exceed the shared budget, refuse it BEFORE
+  // `createImageBitmap` allocates a multi-GB surface. Returning null matches the
+  // existing "unsupported image ⇒ skip the picture, keep rendering" contract that
+  // every caller already handles. An unrecognized header is not blocked here.
+  if (rasterHeaderExceedsBudget(head)) return null;
   return createImageBitmap(data);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -242,6 +242,15 @@ export type { MathNode, MathFormula, MathStyle } from './types/math';
 export { EMU_PER_INCH, EMU_PER_PT, EMU_PER_PX, PT_TO_PX } from './units';
 export { isHTMLCanvas, defaultDpr } from './canvas/env';
 export { crispOffset } from './canvas/crisp';
+// Canvas backing-store size clamp (browser-limit guard, RB5): bound a requested
+// canvas size to per-axis + total-area limits every engine honors, preserving
+// aspect ratio, so a pathological page/slide size can't produce a blank canvas.
+export {
+  clampCanvasSize,
+  MAX_CANVAS_DIMENSION,
+  MAX_CANVAS_AREA,
+  type ClampedCanvasSize,
+} from './canvas/clamp';
 // Shared border / line dash-pattern core (§17.18.2 ST_Border / §18.18.3
 // ST_BorderStyle / §20.1.10.49 ST_PresetLineDashVal shape borders /
 // §20.1.10.82 ST_TextUnderlineType run underlines). The

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -144,6 +144,16 @@ export {
   decodeRasterOrMetafile,
   type DecodeRasterOptions,
 } from './image/wmf';
+// Raster pixel-dimension budget + header sniff (decode-bomb guard, RB1). Shared
+// caps live in `./image/pixel-budget`; `decodeRasterOrMetafile` uses the sniff to
+// refuse an over-budget PNG/JPEG/GIF/BMP/WEBP before `createImageBitmap`.
+export { MAX_RASTER_DIMENSION, MAX_RASTER_PIXELS } from './image/pixel-budget';
+export {
+  sniffRasterDimensions,
+  rasterExceedsBudget,
+  rasterHeaderExceedsBudget,
+  type RasterDimensions,
+} from './image/raster-dimensions';
 // Shared `<a:srcRect>` crop (§20.1.8.55) for all three renderers: the source-rect
 // math, the full-frame raster size for a cropped metafile, and the draw wrapper.
 export {

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -1,8 +1,8 @@
 use crate::styles::{parse_run_fmt, RunFmt};
 use crate::xml_util::*;
 use ooxml_common::blip::mime_from_ext;
+use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::{attr_ns, relationships};
-use roxmltree::Document as XmlDoc;
 use std::collections::{HashMap, HashSet};
 
 /// Parse a single VML CSS length (e.g. `width:9pt`) from a `style` attribute
@@ -161,7 +161,7 @@ impl NumberingMap {
     /// picture bullets, leaving levels on their text/glyph markers.
     pub fn parse(xml: &str, media_map: &HashMap<String, String>) -> Self {
         let mut map = NumberingMap::default();
-        let doc = match XmlDoc::parse(xml) {
+        let doc = match parse_guarded(xml) {
             Ok(d) => d,
             Err(_) => return map,
         };

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,4 +1,5 @@
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
+use ooxml_common::depth::DepthGuard;
 use ooxml_common::ns::{attr_ns, is_w_ns, math, relationships, wordprocessingml};
 use ooxml_common::zip::read_zip_string;
 use roxmltree::Document as XmlDoc;
@@ -197,6 +198,14 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
     let chart_map = load_chart_map(zip, &rel_map, &theme);
 
     let doc_xml = read_zip_string(zip, "word/document.xml")?;
+    // Guard against a pathologically deep `word/document.xml`: roxmltree's tree
+    // builder recurses per element-nesting level, so a document nested thousands
+    // deep overflows the fixed WASM stack and traps *inside* `XmlDoc::parse` before
+    // our own depth-guarded walk runs. Reject it up front. See
+    // `ooxml_common::depth::xml_too_deep`.
+    if ooxml_common::depth::xml_too_deep(doc_xml.as_bytes()) {
+        return Err("word/document.xml nesting depth exceeds the safe limit".to_string());
+    }
     let xml_doc = XmlDoc::parse(&doc_xml).map_err(|e| e.to_string())?;
 
     let body_node = xml_doc
@@ -1060,7 +1069,14 @@ fn parse_body_elements(
             }
             "tbl" => {
                 let tbl = parse_table(
-                    child, style_map, num_map, media_map, chart_map, rel_map, theme,
+                    child,
+                    style_map,
+                    num_map,
+                    media_map,
+                    chart_map,
+                    rel_map,
+                    theme,
+                    DepthGuard::root(),
                 );
                 body.push(BodyElement::Table(tbl));
             }
@@ -5406,6 +5422,12 @@ fn parse_docx_chart(
 
 // ===== Table parsing =====
 
+// `depth` bounds the nested-table recursion (`<w:tbl>` inside a `<w:tc>`,
+// §17.4.38). A hand-crafted document nesting tables thousands deep would
+// otherwise overflow the fixed WASM stack via parse_table → parse_table_row →
+// parse_table_cell → parse_table and trap the whole parse; past the shared limit
+// the over-deep table is dropped and the rest of the document still parses. See
+// `ooxml_common::depth`.
 #[allow(clippy::too_many_arguments)]
 fn parse_table(
     node: roxmltree::Node,
@@ -5415,6 +5437,7 @@ fn parse_table(
     chart_map: &HashMap<String, ooxml_common::chart::ChartModel>,
     rel_map: &HashMap<String, String>,
     theme: &ThemeColors,
+    depth: DepthGuard,
 ) -> DocTable {
     let tbl_pr = child_w(node, "tblPr");
     let tbl_grid = child_w(node, "tblGrid");
@@ -5783,6 +5806,7 @@ fn parse_table(
             // attributes.
             effective_table_style_id,
             &cell_conds,
+            depth,
         );
         rows.push(row);
         all_cell_conds.push(cell_conds);
@@ -5914,6 +5938,8 @@ fn parse_table_row(
     // precedence order), threaded into each cell's content as a base layer below
     // paragraph/char styles. Indexed positionally against the row's `tc` nodes.
     cell_conds: &[CondFmt],
+    // Recursion-depth guard threaded from the owning table (see `parse_table`).
+    depth: DepthGuard,
 ) -> DocTableRow {
     let tr_pr = child_w(node, "trPr");
     let tr_height_node = tr_pr.and_then(|p| child_w(p, "trHeight"));
@@ -5939,6 +5965,7 @@ fn parse_table_row(
             theme,
             table_style_id,
             cond,
+            depth,
         );
         cells.push(cell);
     }
@@ -5963,6 +5990,8 @@ fn parse_table_cell(
     table_style_id: Option<&str>,
     // §17.7.6 resolved conditional formatting for the owning row.
     cond: Option<&CondFmt>,
+    // Recursion-depth guard threaded from the owning row (see `parse_table`).
+    depth: DepthGuard,
 ) -> DocTableCell {
     let tc_pr = child_w(node, "tcPr");
 
@@ -6060,9 +6089,26 @@ fn parse_table_cell(
             ))),
             // A nested table resolves its OWN table style + conditional
             // formatting; the outer cell's `cond` does not propagate into it.
-            "tbl" => content.push(CellElement::Table(parse_table(
-                child, style_map, num_map, media_map, chart_map, rel_map, theme,
-            ))),
+            //
+            // Descend the depth guard here — this `<w:tbl>` inside a `<w:tc>` is
+            // the one real recursion level. Once the shared limit is reached the
+            // nested table is dropped (not recursed into) so a pathologically deep
+            // table nest cannot overflow the stack; the cell's other content is
+            // unaffected.
+            "tbl" => {
+                if let Some(child_depth) = depth.descend() {
+                    content.push(CellElement::Table(parse_table(
+                        child,
+                        style_map,
+                        num_map,
+                        media_map,
+                        chart_map,
+                        rel_map,
+                        theme,
+                        child_depth,
+                    )));
+                }
+            }
             _ => {}
         }
     }
@@ -6378,7 +6424,89 @@ mod tests {
             &HashMap::new(),
             &rels,
             &theme,
+            DepthGuard::root(),
         )
+    }
+
+    // ── Nested-table recursion depth guard (RB2) ───────────────────────────
+    //
+    // A `<w:tbl>` may nest inside a `<w:tc>` (§17.4.38); the natural parser is
+    // directly recursive (parse_table → row → cell → parse_table). A hand-crafted
+    // document nesting tables thousands deep must NOT overflow the WASM stack and
+    // trap the parse — the depth guard bounds it and drops the over-deep tail.
+
+    /// Build `levels` tables nested one-per-cell as the *inner body* of an outer
+    /// `<w:tbl>` (which `parse_tbl` supplies). The innermost cell holds one
+    /// paragraph. Each `<w:tbl>` here plus the outer wrapper is one recursion.
+    fn nested_table_body(levels: usize) -> String {
+        let mut inner = String::from("<w:p><w:r><w:t>x</w:t></w:r></w:p>");
+        for _ in 0..levels {
+            inner = format!("<w:tr><w:tc><w:tbl>{inner}</w:tbl></w:tc></w:tr>");
+        }
+        inner
+    }
+
+    /// Count nested-table depth by walking down the first cell's first table.
+    fn table_nesting_depth(t: &DocTable) -> usize {
+        let mut depth = 1;
+        let mut cur = t;
+        loop {
+            let next = cur
+                .rows
+                .first()
+                .and_then(|r| r.cells.first())
+                .and_then(|c| {
+                    c.content.iter().find_map(|e| match e {
+                        CellElement::Table(inner) => Some(inner),
+                        _ => None,
+                    })
+                });
+            match next {
+                Some(inner) => {
+                    depth += 1;
+                    cur = inner;
+                }
+                None => break,
+            }
+        }
+        depth
+    }
+
+    /// Parse on a generous stack: `roxmltree::Document::parse` itself recurses on
+    /// nesting depth, so give it room. This test targets OUR table-recursion
+    /// guard; the raw-XML depth pre-check in `ooxml_common::depth` guards the
+    /// roxmltree layer separately (with its own tests).
+    fn parse_tbl_deep(levels: usize) -> DocTable {
+        std::thread::Builder::new()
+            .stack_size(256 * 1024 * 1024)
+            .spawn(move || parse_tbl(&nested_table_body(levels)))
+            .unwrap()
+            .join()
+            .unwrap()
+    }
+
+    #[test]
+    fn deeply_nested_tables_do_not_trap() {
+        // ~2 000 nested tables is ~30× the depth limit; pre-guard this recurses
+        // 2 000 frames and traps on the WASM stack. The guard caps the descent so
+        // parsing RETURNS a (truncated) table instead of aborting.
+        let table = parse_tbl_deep(2_000);
+        let observed = table_nesting_depth(&table);
+        // Bounded near the shared depth limit, never the full 2 000 levels.
+        let limit = ooxml_common::depth::MAX_PARSE_DEPTH as usize;
+        assert!(
+            observed <= limit + 1,
+            "nesting must be bounded by the guard, got {observed}"
+        );
+        assert!(observed >= 2, "at least a couple levels should survive");
+    }
+
+    #[test]
+    fn shallow_nested_tables_are_fully_preserved() {
+        // A modest nest (well under the limit) is parsed in full — the guard does
+        // not truncate legitimate documents. 5 inner tables + the outer = depth 6.
+        let table = parse_tbl_deep(5);
+        assert_eq!(table_nesting_depth(&table), 6);
     }
 
     // ECMA-376 §17.4.71 — a cell's `<w:tcW>` preferred width (type="dxa") reaches
@@ -6802,6 +6930,7 @@ mod tests {
             &HashMap::new(),
             &rels,
             &theme,
+            DepthGuard::root(),
         )
     }
 
@@ -11767,6 +11896,7 @@ mod numbering_marker_font_tests {
             &HashMap::new(),
             &rels,
             &theme,
+            DepthGuard::root(),
         )
     }
 

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,7 +1,11 @@
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
-use ooxml_common::depth::DepthGuard;
+use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{attr_ns, is_w_ns, math, relationships, wordprocessingml};
 use ooxml_common::zip::read_zip_string;
+// Production parses go through `ooxml_common::depth::parse_guarded` (depth-guarded
+// before roxmltree's recursive tree builder). The `XmlDoc` alias survives only for
+// the in-module unit tests, which parse trusted, hand-written fixtures directly.
+#[cfg(test)]
 use roxmltree::Document as XmlDoc;
 use std::collections::{BTreeMap, HashMap};
 use zip::ZipArchive;
@@ -198,15 +202,11 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
     let chart_map = load_chart_map(zip, &rel_map, &theme);
 
     let doc_xml = read_zip_string(zip, "word/document.xml")?;
-    // Guard against a pathologically deep `word/document.xml`: roxmltree's tree
-    // builder recurses per element-nesting level, so a document nested thousands
-    // deep overflows the fixed WASM stack and traps *inside* `XmlDoc::parse` before
-    // our own depth-guarded walk runs. Reject it up front. See
-    // `ooxml_common::depth::xml_too_deep`.
-    if ooxml_common::depth::xml_too_deep(doc_xml.as_bytes()) {
-        return Err("word/document.xml nesting depth exceeds the safe limit".to_string());
-    }
-    let xml_doc = XmlDoc::parse(&doc_xml).map_err(|e| e.to_string())?;
+    // `parse_guarded` runs the allocation-free depth pre-check BEFORE roxmltree's
+    // tree builder (which recurses per element-nesting level and would overflow
+    // the fixed WASM stack, trapping the whole parse, on a pathologically deep
+    // `word/document.xml`). Every attacker-controllable part is parsed this way.
+    let xml_doc = parse_guarded(&doc_xml).map_err(|e| e.to_string())?;
 
     let body_node = xml_doc
         .root_element()
@@ -412,7 +412,7 @@ fn collect_revisions(body: roxmltree::Node) -> Vec<crate::types::DocxRevision> {
 
 /// Parse word/comments.xml into a flat list of `<w:comment>` entries.
 fn parse_comments(xml: &str) -> Vec<crate::types::DocxComment> {
-    let Ok(doc) = roxmltree::Document::parse(xml) else {
+    let Ok(doc) = parse_guarded(xml) else {
         return Vec::new();
     };
     let mut out = Vec::new();
@@ -501,7 +501,7 @@ fn parse_notes(
     let local_media_map = load_media_map(zip, &local_rel_map, &base_dir);
     let local_chart_map = load_chart_map(zip, &local_rel_map, theme);
 
-    let Ok(doc) = XmlDoc::parse(&xml) else {
+    let Ok(doc) = parse_guarded(&xml) else {
         return Vec::new();
     };
     let mut out = Vec::new();
@@ -691,7 +691,7 @@ impl ThemeColors {
 
 /// Extract `<w:themeFontLang w:bidi="…"/>` from word/settings.xml (§17.15.1.88).
 fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
-    let doc = XmlDoc::parse(settings_xml).ok()?;
+    let doc = parse_guarded(settings_xml).ok()?;
     let node = doc
         .root_element()
         .descendants()
@@ -706,7 +706,7 @@ fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
 /// `SectionProps.even_and_odd_headers`, which the renderer's `pickHeaderFooter`
 /// already consumes for the even-page branch.
 fn parse_even_and_odd_headers(settings_xml: &str) -> bool {
-    let Ok(doc) = XmlDoc::parse(settings_xml) else {
+    let Ok(doc) = parse_guarded(settings_xml) else {
         return false;
     };
     bool_prop(doc.root_element(), "evenAndOddHeaders").unwrap_or(false)
@@ -727,7 +727,7 @@ fn parse_even_and_odd_headers(settings_xml: &str) -> bool {
 /// Returns `None` when none of these elements are present, so the renderer
 /// falls back to its built-in Japanese defaults with kinsoku ON.
 fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentSettings> {
-    let doc = XmlDoc::parse(settings_xml).ok()?;
+    let doc = parse_guarded(settings_xml).ok()?;
     let root = doc.root_element();
 
     let kinsoku = bool_prop(root, "kinsoku");
@@ -797,7 +797,7 @@ fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
     if rels_xml.is_empty() {
         return None;
     }
-    let doc = XmlDoc::parse(rels_xml).ok()?;
+    let doc = parse_guarded(rels_xml).ok()?;
     for rel in doc
         .root_element()
         .children()
@@ -822,7 +822,7 @@ fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
 /// as `auto`.
 fn parse_font_table(xml: &str) -> BTreeMap<String, String> {
     let mut map = BTreeMap::new();
-    let Ok(doc) = XmlDoc::parse(xml) else {
+    let Ok(doc) = parse_guarded(xml) else {
         return map;
     };
     for font in doc.root_element().descendants().filter(|n| {
@@ -877,7 +877,7 @@ fn parse_embedded_fonts(
     base_dir: &str,
 ) -> Vec<crate::types::EmbeddedFont> {
     let mut out = Vec::new();
-    let Ok(doc) = XmlDoc::parse(font_table_xml) else {
+    let Ok(doc) = parse_guarded(font_table_xml) else {
         return out;
     };
     for font in doc.root_element().descendants().filter(|n| {
@@ -1530,7 +1530,7 @@ fn load_header_footer_set(
         let local_media_map = load_media_map(zip, &local_rel_map, "word/");
         let local_chart_map = load_chart_map(zip, &local_rel_map, theme);
 
-        let xml_doc = match XmlDoc::parse(&xml) {
+        let xml_doc = match parse_guarded(&xml) {
             Ok(d) => d,
             Err(_) => continue,
         };
@@ -5104,7 +5104,7 @@ fn resolve_fill_ref(fill_ref: roxmltree::Node, theme: &ThemeColors) -> Option<Sh
         .unwrap_or("dk1");
 
     let xml = theme.theme_xml.as_ref()?;
-    let doc = XmlDoc::parse(xml).ok()?;
+    let doc = parse_guarded(xml).ok()?;
     let fmt = doc
         .root_element()
         .descendants()
@@ -5404,7 +5404,7 @@ fn parse_docx_chart(
     style_xml: Option<&str>,
     theme: &ThemeColors,
 ) -> Option<ooxml_common::chart::ChartModel> {
-    let doc = XmlDoc::parse(chart_xml).ok()?;
+    let doc = parse_guarded(chart_xml).ok()?;
     let root = doc.root_element();
     let resolver = DocxColorResolver { theme };
     let is_chartex = root

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -1,5 +1,5 @@
 use crate::xml_util::*;
-use roxmltree::Document as XmlDoc;
+use ooxml_common::depth::parse_guarded;
 use std::collections::HashMap;
 
 /// Resolved run (character) formatting.
@@ -321,7 +321,7 @@ impl StyleMap {
     }
 
     pub fn parse(xml: &str) -> Self {
-        let doc = match XmlDoc::parse(xml) {
+        let doc = match parse_guarded(xml) {
             Ok(d) => d,
             Err(_) => return Self::empty(),
         };
@@ -1470,6 +1470,37 @@ mod tests {
         );
         let doc = XmlDoc::parse(&xml).unwrap();
         parse_para_fmt(doc.root_element())
+    }
+
+    // ── RB2 neutralization: a pathologically deep styles.xml is rejected by the
+    //    depth pre-check in `parse_guarded` BEFORE roxmltree's recursive tree
+    //    builder runs, so `StyleMap::parse` returns gracefully instead of trapping
+    //    the whole parse on a stack overflow. This test runs on the DEFAULT
+    //    (small) test-thread stack ON PURPOSE — if `StyleMap::parse` handed the
+    //    5 000-deep XML straight to roxmltree it would overflow and abort the
+    //    process here. That it returns at all is the guarantee. §17.7 (styles).
+    #[test]
+    fn deeply_nested_styles_xml_is_rejected_not_trapped() {
+        let mut xml = format!(r#"<w:styles xmlns:w="{ns}">"#, ns = W_NS);
+        // 5 000 levels — ~20× MAX_XML_DEPTH and well past roxmltree's ~1 000-deep
+        // small-stack overflow threshold. Nest an arbitrary element (styles.xml is
+        // shallow in the wild, so this can only be an attack).
+        for _ in 0..5_000 {
+            xml.push_str("<w:x>");
+        }
+        xml.push('y');
+        for _ in 0..5_000 {
+            xml.push_str("</w:x>");
+        }
+        xml.push_str("</w:styles>");
+
+        // Must return (not trap). The rejected part yields an empty style map —
+        // the "skip the part, keep the document" degradation contract.
+        let map = StyleMap::parse(&xml);
+        assert!(
+            map.styles.is_empty(),
+            "an over-deep styles.xml must be rejected, yielding no styles"
+        );
     }
 
     #[test]

--- a/packages/docx/src/canvas-clamp-render.test.ts
+++ b/packages/docx/src/canvas-clamp-render.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import { MAX_CANVAS_DIMENSION, MAX_CANVAS_AREA } from '@silurus/ooxml-core';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// RB5 — the docx renderer must clamp its backing store to browser canvas limits.
+// A pathological `opts.width` (or page size × dpr) would otherwise trip the
+// silent browser clamp and render blank. Here we drive a mock canvas that records
+// the assigned backing-store size and the `ctx.scale()` factor, and assert the
+// backing store stays within the caps while the CSS box keeps the requested size
+// and the scale is reduced to compensate (aspect preserved).
+
+interface Recording {
+  scaleX: number | null;
+  scaleY: number | null;
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; rec: Recording } {
+  let font = '10px serif';
+  const rec: Recording = { scaleX: null, scaleY: null };
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {},
+    restore() {},
+    closePath() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    arc() {},
+    fill() {},
+    stroke() {},
+    fillRect() {},
+    strokeRect() {},
+    clip() {},
+    rect() {},
+    // Only the FIRST scale() is the dpr transform we care about; later flip
+    // scales are local and wrapped in save/restore, but the render sets the dpr
+    // scale exactly once up front, so record only the first.
+    scale(x: number, y: number) {
+      if (rec.scaleX === null) {
+        rec.scaleX = x;
+        rec.scaleY = y;
+      }
+    },
+    translate() {},
+    rotate() {},
+    setLineDash() {},
+    clearRect() {},
+    quadraticCurveTo() {},
+    bezierCurveTo() {},
+    createLinearGradient() {
+      return { addColorStop() {} };
+    },
+    drawImage() {},
+    fillText() {},
+    strokeText() {},
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, rec };
+}
+
+function para(text = 'x'): DocParagraph {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: [
+      {
+        type: 'text',
+        text,
+        bold: false,
+        italic: false,
+        underline: false,
+        strikethrough: false,
+        fontSize: 12,
+        color: null,
+        fontFamily: 'Times New Roman',
+        fontFamilyEastAsia: '',
+        isLink: false,
+        background: null,
+        vertAlign: null,
+        hyperlink: null,
+      } as DocParagraph['runs'][number],
+    ],
+    defaultFontSize: 12,
+    defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(pageWidth: number, pageHeight: number): DocxDocumentModel {
+  const section = {
+    pageWidth,
+    pageHeight,
+    marginTop: 5,
+    marginRight: 5,
+    marginBottom: 5,
+    marginLeft: 5,
+    headerDistance: 4,
+    footerDistance: 4,
+    titlePage: false,
+    evenAndOddHeaders: false,
+  } as SectionProps;
+  return {
+    section,
+    body: [para() as unknown as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('docx renderer clamps the backing store to browser limits (RB5)', () => {
+  it('a normal page renders at the requested dpr (no clamp)', async () => {
+    const { canvas, rec } = makeRecordingCanvas();
+    // width 800, page 800×600 → 1× scale; dpr 2 → 1600×1200 backing, in budget.
+    await renderDocumentToCanvas(doc(800, 600), canvas, 0, { dpr: 2, width: 800 });
+    expect(canvas.width).toBe(1600);
+    expect(canvas.height).toBe(1200);
+    expect(rec.scaleX).toBe(2);
+    expect(rec.scaleY).toBe(2);
+  });
+
+  it('a pathologically wide request is clamped, aspect preserved, scale reduced', async () => {
+    const { canvas, rec } = makeRecordingCanvas();
+    // Request a 50000-px-wide render of a 50000×500 page: 25 MP at dpr 1, both
+    // over the area cap and (width) over the axis cap.
+    await renderDocumentToCanvas(doc(50000, 500), canvas, 0, { dpr: 1, width: 50000 });
+    // Backing store within BOTH caps.
+    expect(canvas.width).toBeLessThanOrEqual(MAX_CANVAS_DIMENSION);
+    expect(canvas.height).toBeLessThanOrEqual(MAX_CANVAS_DIMENSION);
+    expect(canvas.width * canvas.height).toBeLessThanOrEqual(MAX_CANVAS_AREA);
+    // The dpr transform was reduced below 1 to fit (folded clamp factor).
+    expect(rec.scaleX).toBeLessThan(1);
+    expect(rec.scaleX).toBeGreaterThan(0);
+    // Uniform scale on both axes → aspect preserved.
+    expect(rec.scaleX).toBeCloseTo(rec.scaleY as number, 10);
+  });
+
+  it('a huge dpr on a moderate page is clamped by the area cap', async () => {
+    const { canvas, rec } = makeRecordingCanvas();
+    // 4000×3000 page at dpr 4 → 16000×12000 = 192 MP, far over the area cap.
+    await renderDocumentToCanvas(doc(4000, 3000), canvas, 0, { dpr: 4, width: 4000 });
+    expect(canvas.width * canvas.height).toBeLessThanOrEqual(MAX_CANVAS_AREA);
+    // Effective scale < requested dpr (4).
+    expect(rec.scaleX).toBeLessThan(4);
+    expect(rec.scaleX).toBeGreaterThan(0);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -26,6 +26,7 @@ import {
   resolveBaseDirection,
   isHTMLCanvas,
   defaultDpr,
+  clampCanvasSize,
   classifyCjkFont,
   cjkFallbackChain,
   NON_CJK_SANS_FALLBACKS,
@@ -790,8 +791,20 @@ export async function renderDocumentToCanvas(
   const scale = cssWidth / sec.pageWidth;  // px per pt
   const cssHeight = sec.pageHeight * scale;
 
-  canvas.width = Math.round(cssWidth * dpr);
-  canvas.height = Math.round(cssHeight * dpr);
+  // Clamp the backing store to browser canvas limits (RB5). A pathological page
+  // size (or a large dpr × page size) can exceed the per-axis / total-area cap,
+  // at which point the browser silently allocates a smaller-or-empty buffer and
+  // the page renders blank. `clampCanvasSize` scales BOTH axes by one factor
+  // (≤ 1) so the aspect ratio is kept; we fold that factor into the effective
+  // dpr, keep the CSS box at its intended size, and the browser stretches the
+  // (slightly lower-res) backing store to fill it — a visible page beats a blank
+  // one. `effectiveDpr` is stored on the state so crisp-offset math stays aligned
+  // with the real backing-store scale.
+  const clamped = clampCanvasSize(cssWidth * dpr, cssHeight * dpr);
+  const effectiveDpr = clamped.clamped ? dpr * clamped.scale : dpr;
+
+  canvas.width = clamped.width;
+  canvas.height = clamped.height;
 
   if (isHTMLCanvas(canvas)) {
     canvas.style.width = `${cssWidth}px`;
@@ -799,7 +812,7 @@ export async function renderDocumentToCanvas(
     if (!canvas.style.display) canvas.style.display = 'block';
   }
 
-  ctx.scale(dpr, dpr);
+  ctx.scale(effectiveDpr, effectiveDpr);
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(0, 0, cssWidth, cssHeight);
 
@@ -828,7 +841,9 @@ export async function renderDocumentToCanvas(
   const baseState: RenderState = {
     ctx,
     scale,
-    dpr,
+    // The backing store may have been clamped below `cssSize × dpr`; crisp-offset
+    // math must use the SAME effective dpr the ctx was scaled by (see above).
+    dpr: effectiveDpr,
     contentX: sec.marginLeft * scale,
     contentW: (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale,
     y: bodyTopPt * scale,

--- a/packages/ooxml-common/src/depth.rs
+++ b/packages/ooxml-common/src/depth.rs
@@ -1,0 +1,412 @@
+//! Shared recursion-depth guard for the wild OOXML parsers.
+//!
+//! Several OOXML grammars nest a container element inside its own descendants,
+//! and the natural parser for each is directly recursive:
+//!
+//!   * DrawingML group shapes — `<p:grpSp>` (pptx `parse_sp_tree_node`),
+//!     `<xdr:grpSp>` (xlsx `collect_shapes`);
+//!   * WordprocessingML tables — a `<w:tbl>` may live inside a `<w:tc>`
+//!     (docx `parse_table` ↔ `parse_table_cell`);
+//!   * OMML math — every math container (`<m:f>`, `<m:sSup>`, `<m:d>` …) holds
+//!     child math (`parse_omath_nodes`).
+//!
+//! A hand-crafted document can nest these tens of thousands deep. Because the
+//! parser runs in WASM (a fixed, comparatively small linear-memory stack — the
+//! default `wasm-pack` build reserves 1 MiB), unbounded recursion overflows the
+//! stack and aborts the whole parse with an unrecoverable `RuntimeError:
+//! unreachable` **trap** — the browser tab loses the document, not just the
+//! pathological subtree.
+//!
+//! [`DepthGuard`] bounds that recursion. Each recursive call descends the guard
+//! by one; when the configured limit is reached the caller stops descending and
+//! returns whatever it has parsed so far, so the *rest* of the document still
+//! renders (graceful degradation, matching the "skip the blit / drop the
+//! picture, keep rendering" contract used elsewhere in these parsers).
+//!
+//! ## Why 64
+//!
+//! [`MAX_PARSE_DEPTH`] is 64. That is comfortably above anything a real authoring
+//! tool produces yet far below the stack budget:
+//!
+//!   * Word's own UI caps interactive table nesting well inside this range, and
+//!     even programmatically-authored decks/sheets rarely nest groups past a
+//!     handful of levels; a genuine document never approaches 64.
+//!   * Each recursion frame here is heavy (a `roxmltree::Node` plus several
+//!     `&HashMap`/`&[..]` references and, for tables, `String`/`Vec` locals), so
+//!     64 frames is a tiny fraction of the 1 MiB WASM stack — there is a wide
+//!     safety margin between the guard firing and an actual overflow.
+//!
+//! The limit is intentionally a single shared constant so the three parsers +
+//! the shared OMML grammar behave identically; a document that is "too deep" in
+//! one format is "too deep" in all of them.
+
+/// Maximum nesting depth accepted by any guarded OOXML recursion (group shapes,
+/// nested tables, OMML math). See the module docs for the rationale.
+pub const MAX_PARSE_DEPTH: u32 = 64;
+
+/// A cheap, copyable recursion-depth counter threaded through directly-recursive
+/// OOXML parsing functions.
+///
+/// Callers create one at the top of a recursion with [`DepthGuard::root`], then
+/// obtain a child guard for each descent with [`DepthGuard::descend`]. When
+/// `descend` returns `None` the limit has been reached and the caller must stop
+/// recursing (return the partial result) instead of calling itself again.
+///
+/// The type is `Copy` and holds a single `u32`, so threading it as a by-value
+/// parameter adds no allocation and no borrow-checker friction.
+///
+/// ```
+/// use ooxml_common::depth::{DepthGuard, MAX_PARSE_DEPTH};
+///
+/// fn walk(depth: DepthGuard, fanout: u32) -> u32 {
+///     // Count this node, then descend into `fanout` children if allowed.
+///     let mut n = 1;
+///     if let Some(child) = depth.descend() {
+///         for _ in 0..fanout {
+///             n += walk(child, fanout);
+///         }
+///     }
+///     n
+/// }
+///
+/// // A linear chain (fanout 1) visits exactly MAX_PARSE_DEPTH + 1 nodes before
+/// // the guard stops the descent — it never traps.
+/// assert_eq!(walk(DepthGuard::root(), 1), MAX_PARSE_DEPTH + 1);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DepthGuard {
+    depth: u32,
+    limit: u32,
+}
+
+impl DepthGuard {
+    /// A guard at depth 0 with the shared [`MAX_PARSE_DEPTH`] limit. Use this at
+    /// every top-level (non-recursive) entry into a guarded recursion.
+    #[inline]
+    pub const fn root() -> Self {
+        Self {
+            depth: 0,
+            limit: MAX_PARSE_DEPTH,
+        }
+    }
+
+    /// A guard at depth 0 with an explicit `limit`. Intended for tests; the
+    /// wild parsers should use [`DepthGuard::root`] so every format shares the
+    /// same ceiling.
+    #[inline]
+    pub const fn with_limit(limit: u32) -> Self {
+        Self { depth: 0, limit }
+    }
+
+    /// The current depth (0 at the root).
+    #[inline]
+    pub const fn depth(&self) -> u32 {
+        self.depth
+    }
+
+    /// `true` when descending one more level would exceed the limit — i.e. the
+    /// caller has hit the floor and must not recurse again.
+    #[inline]
+    pub const fn is_exhausted(&self) -> bool {
+        self.depth >= self.limit
+    }
+
+    /// A child guard one level deeper, or `None` when the limit is reached.
+    ///
+    /// `Some(child)` ⇒ recurse with `child`; `None` ⇒ stop and return the
+    /// partial result. The parent guard is unchanged (`Copy`), so sibling
+    /// descents each get their own fresh child.
+    #[inline]
+    pub const fn descend(self) -> Option<Self> {
+        if self.depth >= self.limit {
+            None
+        } else {
+            Some(Self {
+                depth: self.depth + 1,
+                limit: self.limit,
+            })
+        }
+    }
+}
+
+impl Default for DepthGuard {
+    #[inline]
+    fn default() -> Self {
+        Self::root()
+    }
+}
+
+/// Maximum XML element-nesting depth accepted before handing a part off to
+/// `roxmltree::Document::parse` (see [`xml_nesting_exceeds`]).
+///
+/// This is a *separate* concern from [`MAX_PARSE_DEPTH`], which bounds our own
+/// recursive descent (group shapes / tables / OMML). `roxmltree::Document::parse`
+/// **itself recurses proportionally to element nesting** while building its tree,
+/// so a document with a few thousand nested elements overflows the fixed WASM
+/// linear-memory stack (~1 MiB) and traps the whole parse *before any of our code
+/// runs* — our [`DepthGuard`] alone cannot prevent that. Measured on this
+/// roxmltree (0.20) in an optimized build, ~1000-deep nesting is the overflow
+/// threshold at a 1 MiB stack.
+///
+/// 256 keeps a wide safety margin below that threshold while sitting far above
+/// any legitimate OOXML part: real documents nest on the order of tens of levels
+/// (sectPr › tbl › tr › tc › p › r, group-in-group, etc.), never hundreds. A part
+/// deeper than this is rejected so the caller degrades gracefully (skip the part,
+/// keep the rest of the document) instead of trapping.
+pub const MAX_XML_DEPTH: u32 = 256;
+
+/// Scan raw XML `bytes` for element nesting deeper than `limit`, returning `true`
+/// as soon as the limit is exceeded.
+///
+/// This is a cheap, allocation-free, single-pass pre-check run *before*
+/// `roxmltree::Document::parse` so a maliciously deep document is rejected rather
+/// than overflowing roxmltree's recursive tree builder (see [`MAX_XML_DEPTH`]).
+/// It is deliberately a coarse lexer — it does not validate the XML, only tracks
+/// tag nesting well enough to bound depth:
+///
+///   * `<name …>`   — a start tag: depth + 1.
+///   * `</name>`    — an end tag: depth − 1.
+///   * `<name … />` — a self-closing tag: no net change (it is a leaf).
+///   * `<?…?>` (PI), `<!-- … -->` (comment), `<![CDATA[ … ]]>`, `<!DOCTYPE …>`
+///     — skipped without affecting depth; their bodies may contain stray `<`/`>`
+///     that must not be miscounted.
+///
+/// A malformed document can only make this over- or under-count by a little; it
+/// exists purely to catch the pathological "thousands deep" case, and roxmltree
+/// (or graceful skipping) handles ordinary malformedness afterwards. The scan
+/// short-circuits the instant `depth` exceeds `limit`, so a decompression-bomb
+/// style input is rejected in O(bytes-until-limit), not O(bytes).
+pub fn xml_nesting_exceeds(bytes: &[u8], limit: u32) -> bool {
+    let mut depth: u32 = 0;
+    let mut i = 0usize;
+    let n = bytes.len();
+    while i < n {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        // At a '<'. Classify what follows.
+        match bytes.get(i + 1) {
+            Some(b'/') => {
+                // End tag `</…>` — one level up. Saturating so a stray extra end
+                // tag in malformed input can't underflow.
+                depth = depth.saturating_sub(1);
+                i = skip_to_gt(bytes, i + 2);
+            }
+            Some(b'?') => {
+                // Processing instruction `<?…?>` — skip to `?>`.
+                i = skip_until(bytes, i + 2, b"?>");
+            }
+            Some(b'!') => {
+                // `<!-- … -->`, `<![CDATA[ … ]]>`, or `<!DOCTYPE …>`.
+                if bytes[i + 1..].starts_with(b"!--") {
+                    i = skip_until(bytes, i + 4, b"-->");
+                } else if bytes[i + 1..].starts_with(b"![CDATA[") {
+                    i = skip_until(bytes, i + 9, b"]]>");
+                } else {
+                    // DOCTYPE / other declaration — skip to the next '>'. (Internal
+                    // DTD subsets with nested '>' are not produced by OOXML parts.)
+                    i = skip_to_gt(bytes, i + 2);
+                }
+            }
+            Some(_) => {
+                // Start tag `<name …>` or self-closing `<name … />`. Find its '>'
+                // and inspect the byte just before it to tell them apart.
+                let close = skip_to_gt(bytes, i + 2);
+                // `close` points just past '>'; the '>' is at close-1, the char
+                // before it at close-2.
+                let self_closing = close >= 2 && bytes.get(close - 2) == Some(&b'/');
+                if !self_closing {
+                    depth += 1;
+                    if depth > limit {
+                        return true;
+                    }
+                }
+                i = close;
+            }
+            None => break, // trailing '<' at EOF
+        }
+    }
+    false
+}
+
+/// Advance past the next `>` (returns the index just after it, or `bytes.len()`
+/// if none remains).
+#[inline]
+fn skip_to_gt(bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    while i < bytes.len() {
+        if bytes[i] == b'>' {
+            return i + 1;
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+/// Advance past the next occurrence of `needle` (returns the index just after it,
+/// or `bytes.len()` if not found).
+#[inline]
+fn skip_until(bytes: &[u8], from: usize, needle: &[u8]) -> usize {
+    let n = bytes.len();
+    if needle.is_empty() || from >= n {
+        return n;
+    }
+    let last = needle.len() - 1;
+    let mut i = from;
+    while i + last < n {
+        if bytes[i] == needle[0] && &bytes[i..i + needle.len()] == needle {
+            return i + needle.len();
+        }
+        i += 1;
+    }
+    n
+}
+
+/// Convenience over [`xml_nesting_exceeds`] using the shared [`MAX_XML_DEPTH`]
+/// limit. `true` ⇒ the part is too deeply nested and must NOT be handed to
+/// `roxmltree::Document::parse` (parse it would risk a stack-overflow trap).
+#[inline]
+pub fn xml_too_deep(bytes: &[u8]) -> bool {
+    xml_nesting_exceeds(bytes, MAX_XML_DEPTH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_starts_at_zero_with_shared_limit() {
+        let g = DepthGuard::root();
+        assert_eq!(g.depth(), 0);
+        assert!(!g.is_exhausted());
+    }
+
+    #[test]
+    fn descend_increments_and_stops_at_limit() {
+        // A guard limited to 3 permits descents 0→1→2→3, then refuses.
+        let mut g = DepthGuard::with_limit(3);
+        for expected in 1..=3 {
+            g = g.descend().expect("within limit");
+            assert_eq!(g.depth(), expected);
+        }
+        assert!(g.is_exhausted());
+        assert!(g.descend().is_none(), "must refuse past the limit");
+    }
+
+    #[test]
+    fn siblings_get_independent_children() {
+        // `descend` consumes a *copy*, so two children of the same parent are
+        // both at depth 1 and neither observes the other's descent.
+        let parent = DepthGuard::with_limit(MAX_PARSE_DEPTH);
+        let a = parent.descend().unwrap();
+        let b = parent.descend().unwrap();
+        assert_eq!(a.depth(), 1);
+        assert_eq!(b.depth(), 1);
+        assert_eq!(a.descend().unwrap().depth(), 2);
+        // `b` is still at depth 1 — unaffected by `a`'s further descent.
+        assert_eq!(b.depth(), 1);
+    }
+
+    #[test]
+    fn limit_of_zero_refuses_immediately() {
+        let g = DepthGuard::with_limit(0);
+        assert!(g.is_exhausted());
+        assert!(g.descend().is_none());
+    }
+
+    #[test]
+    fn default_matches_root() {
+        assert_eq!(DepthGuard::default(), DepthGuard::root());
+    }
+
+    /// A deep linear chain — the failure this guard exists to prevent — is bounded:
+    /// the recursion runs at most `MAX_PARSE_DEPTH` descents and returns rather
+    /// than trapping. This mirrors the shape of the real recursive parsers.
+    #[test]
+    fn deep_chain_is_bounded_not_trapping() {
+        fn descend_chain(g: DepthGuard) -> u32 {
+            match g.descend() {
+                Some(child) => 1 + descend_chain(child),
+                None => 0,
+            }
+        }
+        assert_eq!(descend_chain(DepthGuard::root()), MAX_PARSE_DEPTH);
+    }
+
+    // ── Raw-XML depth pre-check (guards roxmltree's own recursion) ──────────
+
+    /// `depth` levels of `<a>…</a>` wrapping a text leaf.
+    fn nested_xml(depth: usize) -> Vec<u8> {
+        let mut s = String::new();
+        for _ in 0..depth {
+            s.push_str("<a>");
+        }
+        s.push('x');
+        for _ in 0..depth {
+            s.push_str("</a>");
+        }
+        s.into_bytes()
+    }
+
+    #[test]
+    fn shallow_xml_is_not_flagged() {
+        assert!(!xml_nesting_exceeds(&nested_xml(10), 256));
+        // A real-ish OOXML snippet nests well under the limit.
+        let doc = br#"<w:document xmlns:w="x"><w:body><w:p><w:r><w:t>hi</w:t></w:r></w:p></w:body></w:document>"#;
+        assert!(!xml_too_deep(doc));
+    }
+
+    #[test]
+    fn exactly_at_the_limit_is_allowed_and_one_past_is_flagged() {
+        // `limit` levels deep is fine; `limit + 1` trips the guard.
+        assert!(!xml_nesting_exceeds(&nested_xml(32), 32));
+        assert!(xml_nesting_exceeds(&nested_xml(33), 32));
+    }
+
+    #[test]
+    fn pathologically_deep_xml_is_flagged() {
+        // The case this pre-check exists for: thousands deep would otherwise
+        // overflow roxmltree's recursive tree builder.
+        assert!(xml_too_deep(&nested_xml(10_000)));
+    }
+
+    #[test]
+    fn self_closing_tags_do_not_accumulate_depth() {
+        // 1000 sibling self-closing tags are all leaves — net depth stays 1.
+        let mut s = String::from("<root>");
+        for _ in 0..1000 {
+            s.push_str("<a/>");
+        }
+        s.push_str("</root>");
+        assert!(!xml_nesting_exceeds(s.as_bytes(), 8));
+        // With whitespace before the '/>', still a leaf.
+        assert!(!xml_nesting_exceeds(b"<root><a b=\"1\" /></root>", 4));
+    }
+
+    #[test]
+    fn comments_pis_and_cdata_do_not_affect_depth() {
+        // Stray '<' and '>' inside comments / PIs / CDATA must not be counted as
+        // tags (or the guard could be tricked either way).
+        let xml =
+            br#"<r><!-- <a><b><c> not tags --><?pi <x><y> ?><![CDATA[ </z><w><v> ]]><c/></r>"#;
+        // Real nesting is only <r> … </r> plus a leaf <c/>: depth 1.
+        assert!(!xml_nesting_exceeds(xml, 3));
+    }
+
+    #[test]
+    fn unbalanced_end_tags_saturate_not_underflow() {
+        // Extra end tags must not underflow (u32) and wrap to a huge depth.
+        let xml = b"</a></a></a><b><c></c></b>";
+        assert!(!xml_nesting_exceeds(xml, 4));
+    }
+
+    #[test]
+    fn scan_short_circuits_before_reading_the_whole_input() {
+        // The prefix already exceeds the limit; a megabyte of trailing junk after
+        // it need not be scanned. (Behavioural: still returns true quickly.)
+        let mut v = nested_xml(300);
+        v.extend(std::iter::repeat_n(b'x', 1_000_000));
+        assert!(xml_nesting_exceeds(&v, 256));
+    }
+}

--- a/packages/ooxml-common/src/depth.rs
+++ b/packages/ooxml-common/src/depth.rs
@@ -271,6 +271,60 @@ pub fn xml_too_deep(bytes: &[u8]) -> bool {
     xml_nesting_exceeds(bytes, MAX_XML_DEPTH)
 }
 
+/// Error returned by [`parse_guarded`] — either the depth pre-check rejected the
+/// input, or `roxmltree` itself failed to parse it.
+///
+/// It implements [`Display`](std::fmt::Display) so the many parse sites that map
+/// a parse failure to a `String` (`.map_err(|e| e.to_string())`) keep working
+/// unchanged, while sites that only care whether they got a `Document` can keep
+/// using `.ok()` / `let Ok(..) else`.
+#[derive(Debug)]
+pub enum GuardedParseError {
+    /// The raw XML nests deeper than [`MAX_XML_DEPTH`]; handing it to
+    /// `roxmltree::Document::parse` would risk a stack-overflow trap, so the
+    /// caller must degrade gracefully (skip the part) instead.
+    TooDeep,
+    /// `roxmltree::Document::parse` rejected the (in-depth-budget) input.
+    Xml(roxmltree::Error),
+}
+
+impl std::fmt::Display for GuardedParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GuardedParseError::TooDeep => {
+                write!(f, "XML nesting depth exceeds the safe limit")
+            }
+            GuardedParseError::Xml(e) => std::fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl std::error::Error for GuardedParseError {}
+
+/// Parse `xml` into a [`roxmltree::Document`], but **only after** the
+/// allocation-free [`xml_too_deep`] pre-check confirms the element nesting is
+/// within [`MAX_XML_DEPTH`].
+///
+/// `roxmltree`'s tree builder recurses per element-nesting level, so a part
+/// nested a few thousand deep overflows the fixed WASM linear-memory stack and
+/// **traps the whole parse inside `Document::parse`** — before any of our own
+/// depth-guarded walks (see [`DepthGuard`]) get a chance to run. Every parse of
+/// attacker-controllable XML (any part read out of the untrusted ZIP) must go
+/// through this wrapper rather than calling `roxmltree::Document::parse`
+/// directly, so the pre-check is impossible to forget at an individual site.
+///
+/// On success the returned [`roxmltree::Document`] borrows from `xml`, exactly as
+/// `Document::parse` does. On failure the caller degrades gracefully (skip the
+/// part, keep the rest of the document) — matching the existing
+/// "unsupported/oversized ⇒ skip it, keep rendering" contract in these parsers.
+#[inline]
+pub fn parse_guarded(xml: &str) -> Result<roxmltree::Document<'_>, GuardedParseError> {
+    if xml_too_deep(xml.as_bytes()) {
+        return Err(GuardedParseError::TooDeep);
+    }
+    roxmltree::Document::parse(xml).map_err(GuardedParseError::Xml)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -408,5 +462,51 @@ mod tests {
         let mut v = nested_xml(300);
         v.extend(std::iter::repeat_n(b'x', 1_000_000));
         assert!(xml_nesting_exceeds(&v, 256));
+    }
+
+    // ── parse_guarded (the wrapper every attacker-facing parse site must use) ──
+
+    #[test]
+    fn parse_guarded_accepts_shallow_xml() {
+        let doc = parse_guarded("<r><a>x</a></r>").expect("shallow XML parses");
+        assert_eq!(doc.root_element().tag_name().name(), "r");
+    }
+
+    #[test]
+    fn parse_guarded_rejects_too_deep_before_roxmltree_runs() {
+        // The load-bearing guarantee: a part nested far past MAX_XML_DEPTH is
+        // rejected by the pre-check and never reaches roxmltree's recursive tree
+        // builder (which would overflow the WASM stack and trap). 10_000-deep is
+        // well past the ~1000 overflow threshold, so if the pre-check were absent
+        // this call would trap instead of returning an Err — this test only runs
+        // on the (small) native stack precisely because parse_guarded short-
+        // circuits before roxmltree is invoked.
+        let deep = String::from_utf8(nested_xml(10_000)).unwrap();
+        let err = parse_guarded(&deep).expect_err("over-deep XML is rejected");
+        assert!(matches!(err, GuardedParseError::TooDeep));
+        assert_eq!(err.to_string(), "XML nesting depth exceeds the safe limit");
+    }
+
+    #[test]
+    fn parse_guarded_reports_roxmltree_errors_for_in_budget_input() {
+        // In-depth-budget but malformed input surfaces roxmltree's own error,
+        // Display-forwarded so `.map_err(|e| e.to_string())` sites are unchanged.
+        let err = parse_guarded("<r><a></r>").expect_err("malformed XML is rejected");
+        assert!(matches!(err, GuardedParseError::Xml(_)));
+        // The message is roxmltree's, not the depth message.
+        assert_ne!(err.to_string(), "XML nesting depth exceeds the safe limit");
+    }
+
+    #[test]
+    fn parse_guarded_document_borrows_from_input() {
+        // The returned Document borrows `xml`, just like Document::parse — so a
+        // caller can read node text without an extra allocation.
+        let xml = String::from("<r><t>hello</t></r>");
+        let doc = parse_guarded(&xml).unwrap();
+        let t = doc
+            .descendants()
+            .find(|n| n.tag_name().name() == "t")
+            .unwrap();
+        assert_eq!(t.text(), Some("hello"));
     }
 }

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod blip;
 pub mod chart;
 pub mod color;
+pub mod depth;
 pub mod drawing;
 pub mod fill;
 pub mod math;

--- a/packages/ooxml-common/src/math.rs
+++ b/packages/ooxml-common/src/math.rs
@@ -12,6 +12,8 @@
 use roxmltree::Node;
 use serde::{Deserialize, Serialize};
 
+use crate::depth::DepthGuard;
+
 // `Deserialize` is derived for symmetry with the pptx/xlsx parser type trees
 // (every node there derives both); the math AST is only ever serialized in
 // practice. `default` on the skip-serialized fields keeps a round-trip valid.
@@ -207,7 +209,25 @@ fn on_off(parent: Node, child: &str, default: bool) -> bool {
 }
 
 /// Parse the math children directly under `el` into a node list.
+///
+/// OMML nests arbitrarily (a fraction's numerator can hold another fraction,
+/// etc.), so this recurses; the descent is bounded by a [`DepthGuard`] to stop a
+/// hand-crafted, thousands-deep math tree from overflowing the WASM stack and
+/// trapping the whole parse. Past the limit the subtree is dropped (its runs do
+/// not survive), which is graceful degradation — the surrounding document still
+/// renders.
 pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
+    parse_omath_nodes_d(el, DepthGuard::root())
+}
+
+fn parse_omath_nodes_d(el: Node, depth: DepthGuard) -> Vec<MathNode> {
+    // Stop descending once the shared depth limit is reached: a deeper subtree is
+    // dropped rather than recursed into. `descend()` yields the child guard used
+    // for every recursive call below (via `nodes_in`, `parse_matrix`,
+    // `parse_eqarr`, the delimiter map, and the container fallback).
+    let Some(depth) = depth.descend() else {
+        return Vec::new();
+    };
     let mut out = Vec::new();
     for child in el.children().filter(|n| n.is_element()) {
         match child.tag_name().name() {
@@ -221,25 +241,25 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                 }
             }
             "f" => out.push(MathNode::Fraction {
-                num: nodes_in(child, "num"),
-                den: nodes_in(child, "den"),
+                num: nodes_in(child, "num", depth),
+                den: nodes_in(child, "den", depth),
                 bar: match mval(mchild(child, "fPr").unwrap_or(child), "type").as_deref() {
                     Some("noBar") => Some(false),
                     _ => None,
                 },
             }),
             "sSup" => out.push(MathNode::Sup {
-                base: nodes_in(child, "e"),
-                sup: nodes_in(child, "sup"),
+                base: nodes_in(child, "e", depth),
+                sup: nodes_in(child, "sup", depth),
             }),
             "sSub" => out.push(MathNode::Sub {
-                base: nodes_in(child, "e"),
-                sub: nodes_in(child, "sub"),
+                base: nodes_in(child, "e", depth),
+                sub: nodes_in(child, "sub", depth),
             }),
             "sSubSup" => out.push(MathNode::SubSup {
-                base: nodes_in(child, "e"),
-                sub: nodes_in(child, "sub"),
-                sup: nodes_in(child, "sup"),
+                base: nodes_in(child, "e", depth),
+                sub: nodes_in(child, "sub", depth),
+                sup: nodes_in(child, "sup", depth),
             }),
             "nary" => {
                 let pr = mchild(child, "naryPr");
@@ -250,9 +270,9 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                 out.push(MathNode::Nary {
                     op,
                     lim_loc,
-                    sub: nodes_in(child, "sub"),
-                    sup: nodes_in(child, "sup"),
-                    body: nodes_in(child, "e"),
+                    sub: nodes_in(child, "sub", depth),
+                    sup: nodes_in(child, "sup", depth),
+                    body: nodes_in(child, "e", depth),
                 });
             }
             "d" => {
@@ -266,7 +286,7 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                 let items: Vec<Vec<MathNode>> = child
                     .children()
                     .filter(|n| n.is_element() && n.tag_name().name() == "e")
-                    .map(parse_omath_nodes)
+                    .map(|e| parse_omath_nodes_d(e, depth))
                     .collect();
                 out.push(MathNode::Delimiter {
                     beg_char,
@@ -275,21 +295,21 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                 });
             }
             "rad" => out.push(MathNode::Radical {
-                index: nodes_in(child, "deg"),
-                radicand: nodes_in(child, "e"),
+                index: nodes_in(child, "deg", depth),
+                radicand: nodes_in(child, "e", depth),
             }),
             "limLow" => out.push(MathNode::Limit {
-                base: nodes_in(child, "e"),
-                lower: nodes_in(child, "lim"),
+                base: nodes_in(child, "e", depth),
+                lower: nodes_in(child, "lim", depth),
                 upper: Vec::new(),
             }),
             "limUpp" => out.push(MathNode::Limit {
-                base: nodes_in(child, "e"),
+                base: nodes_in(child, "e", depth),
                 lower: Vec::new(),
-                upper: nodes_in(child, "lim"),
+                upper: nodes_in(child, "lim", depth),
             }),
-            "m" => out.push(parse_matrix(child)),
-            "eqArr" => out.push(parse_eqarr(child)),
+            "m" => out.push(parse_matrix(child, depth)),
+            "eqArr" => out.push(parse_eqarr(child, depth)),
             "groupChr" => {
                 let pr = mchild(child, "groupChrPr");
                 let pos = pr
@@ -305,7 +325,7 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                 out.push(MathNode::GroupChr {
                     chr,
                     pos,
-                    base: nodes_in(child, "e"),
+                    base: nodes_in(child, "e", depth),
                 });
             }
             "bar" => {
@@ -315,7 +335,7 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                     .unwrap_or_else(|| "top".to_string());
                 out.push(MathNode::Bar {
                     pos,
-                    base: nodes_in(child, "e"),
+                    base: nodes_in(child, "e", depth),
                 });
             }
             "acc" => {
@@ -325,12 +345,12 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                     .unwrap_or_else(|| "\u{0302}".to_string());
                 out.push(MathNode::Accent {
                     chr,
-                    base: nodes_in(child, "e"),
+                    base: nodes_in(child, "e", depth),
                 });
             }
             "func" => out.push(MathNode::Func {
-                name: nodes_in(child, "fName"),
-                arg: nodes_in(child, "e"),
+                name: nodes_in(child, "fName", depth),
+                arg: nodes_in(child, "e", depth),
             }),
             "phant" => {
                 // §22.1.2.81/.82 — read the phantPr on/off children. `show` defaults
@@ -345,16 +365,16 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                     zero_wid: pr.map(|p| on_off(p, "zeroWid", false)).unwrap_or(false),
                     zero_asc: pr.map(|p| on_off(p, "zeroAsc", false)).unwrap_or(false),
                     zero_desc: pr.map(|p| on_off(p, "zeroDesc", false)).unwrap_or(false),
-                    base: nodes_in(child, "e"),
+                    base: nodes_in(child, "e", depth),
                 });
             }
             "sPre" => out.push(MathNode::SPre {
-                sub: nodes_in(child, "sub"),
-                sup: nodes_in(child, "sup"),
-                base: nodes_in(child, "e"),
+                sub: nodes_in(child, "sub", depth),
+                sup: nodes_in(child, "sup", depth),
+                base: nodes_in(child, "e", depth),
             }),
             "box" => out.push(MathNode::Box {
-                base: nodes_in(child, "e"),
+                base: nodes_in(child, "e", depth),
             }),
             "borderBox" => {
                 // §22.1.2.11/.12 — the borderBoxPr on/off children select edges and
@@ -371,11 +391,11 @@ pub fn parse_omath_nodes(el: Node) -> Vec<MathNode> {
                     strike_v: f("strikeV"),
                     strike_bltr: f("strikeBLTR"),
                     strike_tlbr: f("strikeTLBR"),
-                    base: nodes_in(child, "e"),
+                    base: nodes_in(child, "e", depth),
                 });
             }
             // Containers / unknowns: descend so inner runs survive (degrade gracefully).
-            _ => out.extend(parse_omath_nodes(child)),
+            _ => out.extend(parse_omath_nodes_d(child, depth)),
         }
     }
     out
@@ -496,7 +516,11 @@ pub fn nodes_to_text(nodes: &[MathNode]) -> String {
 }
 
 /// `m:m` matrix -> array of rows (m:mr) of cells (m:e), centered.
-fn parse_matrix(el: Node) -> MathNode {
+///
+/// `depth` is the guard from the enclosing `parse_omath_nodes_d`; each cell body
+/// recurses under it so a matrix nested deep in a math tree still honours the
+/// shared depth limit.
+fn parse_matrix(el: Node, depth: DepthGuard) -> MathNode {
     let mut rows = Vec::new();
     for mr in el
         .children()
@@ -505,7 +529,7 @@ fn parse_matrix(el: Node) -> MathNode {
         let cells: Vec<Vec<MathNode>> = mr
             .children()
             .filter(|n| n.is_element() && n.tag_name().name() == "e")
-            .map(parse_omath_nodes)
+            .map(|e| parse_omath_nodes_d(e, depth))
             .collect();
         rows.push(cells);
     }
@@ -516,13 +540,16 @@ fn parse_matrix(el: Node) -> MathNode {
 }
 
 /// `m:eqArr` -> array where each `m:e` is a row, split into cells at `&` alignment marks.
-fn parse_eqarr(el: Node) -> MathNode {
+///
+/// `depth` is threaded from the caller so each row body respects the shared
+/// recursion-depth limit (see [`parse_matrix`]).
+fn parse_eqarr(el: Node, depth: DepthGuard) -> MathNode {
     let mut rows = Vec::new();
     for e in el
         .children()
         .filter(|n| n.is_element() && n.tag_name().name() == "e")
     {
-        rows.push(split_align_cells(parse_omath_nodes(e)));
+        rows.push(split_align_cells(parse_omath_nodes_d(e, depth)));
     }
     MathNode::Array {
         rows,
@@ -561,9 +588,9 @@ fn split_align_cells(nodes: Vec<MathNode>) -> Vec<Vec<MathNode>> {
 }
 
 /// Parse the math content of the named child element (`m:<name>`).
-fn nodes_in(parent: Node, name: &str) -> Vec<MathNode> {
+fn nodes_in(parent: Node, name: &str, depth: DepthGuard) -> Vec<MathNode> {
     match mchild(parent, name) {
-        Some(n) => parse_omath_nodes(n),
+        Some(n) => parse_omath_nodes_d(n, depth),
         None => Vec::new(),
     }
 }
@@ -871,5 +898,87 @@ mod tests {
             }
             other => panic!("expected borderBox, got {other:?}"),
         }
+    }
+
+    // ── Recursion depth guard (RB2) ─────────────────────────────────────────
+    //
+    // OMML nests without limit, and `parse_omath_nodes` recurses per level. A
+    // hand-crafted, thousands-deep math tree must NOT overflow the (small, fixed)
+    // WASM stack and trap the whole parse — the depth guard bounds the descent
+    // and drops the over-deep subtree instead.
+
+    /// Build `depth` nested `<m:f><m:num>…</m:num></m:f>` fractions with a single
+    /// run at the very bottom. Each `<m:f>` adds one real recursion level.
+    fn nested_fractions(depth: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..depth {
+            s.push_str("<m:f><m:num>");
+        }
+        s.push_str("<m:r><m:t>x</m:t></m:r>");
+        for _ in 0..depth {
+            s.push_str("</m:num></m:f>");
+        }
+        format!(r#"<m:oMath xmlns:m="{M}">{s}</m:oMath>"#)
+    }
+
+    /// Run `f` on a thread with a generous stack so that `roxmltree::Document::parse`
+    /// itself — which recurses proportionally to XML nesting depth — has room for
+    /// the deep inputs below. That keeps these tests focused on OUR depth guard:
+    /// the roxmltree/parser layer is bounded separately by the raw-XML depth
+    /// pre-check in `crate::depth` (see its own tests). Without the big stack a
+    /// debug build overflows inside roxmltree before our code even runs.
+    fn on_deep_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+        std::thread::Builder::new()
+            .stack_size(256 * 1024 * 1024)
+            .spawn(f)
+            .expect("spawn")
+            .join()
+            .expect("join")
+    }
+
+    #[test]
+    fn deeply_nested_omml_does_not_trap() {
+        // A math tree far deeper than MAX_PARSE_DEPTH must not overflow OUR
+        // recursion. 2 000 levels is ~30× the guard: pre-guard `parse_omath_nodes`
+        // would recurse 2 000 frames and trap on the small WASM stack; the guard
+        // caps the descent, so `parse` RETURNS a value instead of aborting.
+        let nodes = on_deep_stack(|| {
+            let xml = nested_fractions(2_000);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            parse_omath_nodes(doc.root_element())
+        });
+        // A fraction chain always yields exactly one top-level node.
+        assert_eq!(nodes.len(), 1);
+        assert!(matches!(nodes[0], MathNode::Fraction { .. }));
+    }
+
+    #[test]
+    fn depth_guard_truncates_at_the_limit_but_keeps_shallow_content() {
+        // A chain deeper than MAX_PARSE_DEPTH is accepted (no trap) but the bottom
+        // is dropped: walking down the numerators, every level up to the limit is a
+        // Fraction, and beyond it the numerator is empty (the guard refused to
+        // descend). Content ABOVE the limit is fully preserved.
+        use crate::depth::MAX_PARSE_DEPTH;
+        let mut nodes = on_deep_stack(|| {
+            let xml = nested_fractions(MAX_PARSE_DEPTH as usize + 50);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            parse_omath_nodes(doc.root_element())
+        });
+
+        let mut levels = 0u32;
+        // Follow the numerator chain down. Each level should be one Fraction whose
+        // `num` is the next level, until the guard stops producing children.
+        while let Some(MathNode::Fraction { num, .. }) = nodes.first() {
+            levels += 1;
+            nodes = num.clone();
+        }
+        // The top-level `parse_omath_nodes` call spends one descent budget, so the
+        // deepest surviving fraction sits at MAX_PARSE_DEPTH - 1 levels below it.
+        // The exact count is an implementation detail; what matters for the guard
+        // is that it is BOUNDED near the limit, never the full input depth.
+        assert!(
+            (MAX_PARSE_DEPTH - 2..=MAX_PARSE_DEPTH).contains(&levels),
+            "expected truncation near the {MAX_PARSE_DEPTH}-level limit, got {levels}"
+        );
     }
 }

--- a/packages/ooxml-common/src/rels.rs
+++ b/packages/ooxml-common/src/rels.rs
@@ -66,7 +66,7 @@ pub fn parse_rels(xml: &str) -> BTreeMap<String, RelTarget> {
     if xml.is_empty() {
         return map;
     }
-    let doc = match roxmltree::Document::parse(xml) {
+    let doc = match crate::depth::parse_guarded(xml) {
         Ok(d) => d,
         Err(_) => return map,
     };

--- a/packages/ooxml-common/src/theme.rs
+++ b/packages/ooxml-common/src/theme.rs
@@ -51,7 +51,7 @@ impl ThemeColorScheme {
     /// malformed XML yields an empty scheme.
     pub fn parse(xml: &str) -> Self {
         let mut colors = BTreeMap::new();
-        let Ok(doc) = roxmltree::Document::parse(xml) else {
+        let Ok(doc) = crate::depth::parse_guarded(xml) else {
             return Self { colors };
         };
         let Some(scheme) = doc
@@ -140,7 +140,7 @@ impl ThemeFonts {
     /// Parse the `<a:fontScheme>` (major + minor × latin/ea/cs). Missing scheme
     /// or malformed XML yields all-`None`.
     pub fn parse(xml: &str) -> Self {
-        let Ok(doc) = roxmltree::Document::parse(xml) else {
+        let Ok(doc) = crate::depth::parse_guarded(xml) else {
             return Self::default();
         };
         let Some(scheme) = doc
@@ -186,7 +186,7 @@ fn parse_font_group(scheme: roxmltree::Node<'_, '_>, group_name: &str) -> ThemeF
 /// EMU = 0.75 pt (§20.1.2.2.24). Missing scheme or malformed XML yields an empty
 /// list.
 pub fn parse_ln_style_widths(xml: &str) -> Vec<i64> {
-    let Ok(doc) = roxmltree::Document::parse(xml) else {
+    let Ok(doc) = crate::depth::parse_guarded(xml) else {
         return Vec::new();
     };
     for node in doc.descendants() {

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -8,6 +8,7 @@
 
 use crate::parse_color_node;
 use crate::types::*;
+use ooxml_common::depth::parse_guarded;
 use std::collections::HashMap;
 
 /// `ooxml_common::chart::ColorResolver` implementation backed by pptx's
@@ -46,7 +47,7 @@ pub(crate) fn parse_legacy_chart(
     xml: &str,
     theme: &HashMap<String, String>,
 ) -> Option<ChartElement> {
-    let doc = roxmltree::Document::parse(xml).ok()?;
+    let doc = parse_guarded(xml).ok()?;
     let root = doc.root_element();
     let resolver = PptxColorResolver { theme };
     let chart = ooxml_common::chart::parse_chart_part(root, &resolver)?;
@@ -72,7 +73,7 @@ pub(crate) fn parse_chartex(
     style_xml: Option<&str>,
     theme: &HashMap<String, String>,
 ) -> Option<ChartElement> {
-    let doc = roxmltree::Document::parse(xml).ok()?;
+    let doc = parse_guarded(xml).ok()?;
     let root = doc.root_element();
     let resolver = PptxColorResolver { theme };
     // chartEx (waterfall/boxWhisker/…) reads its title font size from the

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -567,6 +567,14 @@ fn parse_slide(
     }
 
     note_layout_master_parse();
+    // Guard against a pathologically deep slide XML: roxmltree's tree builder
+    // recurses per element-nesting level, so a slide nested thousands deep
+    // overflows the fixed WASM stack and traps *inside* `Document::parse` before
+    // our own depth-guarded shape walk runs. Reject it up front. See
+    // `ooxml_common::depth::xml_too_deep`.
+    if ooxml_common::depth::xml_too_deep(xml.as_bytes()) {
+        return Err("slide XML nesting depth exceeds the safe limit".into());
+    }
     let doc = roxmltree::Document::parse(xml)?;
     let root = doc.root_element(); // <p:sld>
     let hidden = slide_is_hidden(root);
@@ -676,6 +684,7 @@ fn parse_slide(
                         &mut elements,
                         true, // skip placeholder shapes
                         None, // no inherited group fill at top level
+                        ooxml_common::depth::DepthGuard::root(),
                     );
                 }
             }
@@ -695,6 +704,7 @@ fn parse_slide(
             &mut elements,
             false,
             None,
+            ooxml_common::depth::DepthGuard::root(),
         );
     }
 

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1,3 +1,4 @@
+use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::is_r_ns;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
@@ -361,7 +362,7 @@ pub(crate) fn build_smartart_drawings(
     zip: &mut PptxZip,
 ) -> HashMap<String, String> {
     let mut result: HashMap<String, String> = HashMap::new();
-    let doc = match roxmltree::Document::parse(rels_xml) {
+    let doc = match parse_guarded(rels_xml) {
         Ok(d) => d,
         Err(_) => return result,
     };
@@ -418,7 +419,7 @@ pub(crate) fn build_smartart_drawings(
 fn smartart_drawing_relid(data_target: &str, zip: &mut PptxZip) -> Option<String> {
     let data_path = resolve_path("ppt/slides", data_target);
     let xml = read_zip_str(zip, &data_path).ok()?;
-    let doc = roxmltree::Document::parse(&xml).ok()?;
+    let doc = parse_guarded(&xml).ok()?;
     doc.descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "dataModelExt")
         .and_then(|n| n.attribute("relId"))
@@ -443,7 +444,7 @@ fn trailing_num(target: &str) -> Option<u32> {
 // prefix still matches — do not change this to an exact-match comparison, or
 // Strict documents will silently stop resolving.
 pub(crate) fn find_rel_target_by_type(rels_xml: &str, type_suffix: &str) -> Option<String> {
-    let doc = roxmltree::Document::parse(rels_xml).ok()?;
+    let doc = parse_guarded(rels_xml).ok()?;
     for rel in doc.root_element().children().filter(|n| n.is_element()) {
         if let Some(rel_type) = attr(&rel, "Type") {
             if rel_type.ends_with(type_suffix) {
@@ -570,12 +571,9 @@ fn parse_slide(
     // Guard against a pathologically deep slide XML: roxmltree's tree builder
     // recurses per element-nesting level, so a slide nested thousands deep
     // overflows the fixed WASM stack and traps *inside* `Document::parse` before
-    // our own depth-guarded shape walk runs. Reject it up front. See
-    // `ooxml_common::depth::xml_too_deep`.
-    if ooxml_common::depth::xml_too_deep(xml.as_bytes()) {
-        return Err("slide XML nesting depth exceeds the safe limit".into());
-    }
-    let doc = roxmltree::Document::parse(xml)?;
+    // our own depth-guarded shape walk runs. The nesting-depth pre-check that
+    // rejects it now lives in `parse_guarded`.
+    let doc = parse_guarded(xml)?;
     let root = doc.root_element(); // <p:sld>
     let hidden = slide_is_hidden(root);
     let c_sld = child(root, "cSld");
@@ -646,7 +644,7 @@ fn parse_slide(
         if eff.is_some() {
             if let Some(mxml) = master_xml {
                 note_layout_master_parse();
-                if let Ok(mdoc) = roxmltree::Document::parse(mxml) {
+                if let Ok(mdoc) = parse_guarded(mxml) {
                     extract_decorative_shapes(
                         mdoc.root_element(),
                         master_dir,
@@ -668,7 +666,7 @@ fn parse_slide(
     // (e.g. coloured bands, logos) that are not placeholder anchors.
     if let Some(lxml) = layout_xml {
         note_layout_master_parse();
-        if let Ok(ldoc) = roxmltree::Document::parse(lxml) {
+        if let Ok(ldoc) = parse_guarded(lxml) {
             let lroot = ldoc.root_element();
             if let Some(lsp_tree) = child(lroot, "cSld").and_then(|n| child(n, "spTree")) {
                 let empty_lph = LayoutPlaceholders::default();
@@ -739,7 +737,7 @@ fn load_notes_slide(zip: &mut PptxZip, rels: &HashMap<String, String>) -> Option
         resolve_path("ppt/slides", target)
     };
     let xml = read_zip_str(zip, &path).ok()?;
-    let doc = roxmltree::Document::parse(&xml).ok()?;
+    let doc = parse_guarded(&xml).ok()?;
     let mut buf = String::new();
     let mut prev_was_text = false;
     for n in doc.descendants() {
@@ -781,7 +779,7 @@ fn load_pptx_comments(zip: &mut PptxZip, rels: &HashMap<String, String>) -> Vec<
     let Ok(xml) = read_zip_str(zip, &path) else {
         return Vec::new();
     };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+    let Ok(doc) = parse_guarded(&xml) else {
         return Vec::new();
     };
 
@@ -789,7 +787,7 @@ fn load_pptx_comments(zip: &mut PptxZip, rels: &HashMap<String, String>) -> Vec<
     let author_xml = read_zip_str(zip, "ppt/commentAuthors.xml").ok();
     let mut authors: HashMap<String, String> = HashMap::new();
     if let Some(ax) = author_xml {
-        if let Ok(adoc) = roxmltree::Document::parse(&ax) {
+        if let Ok(adoc) = parse_guarded(&ax) {
             for a in adoc
                 .descendants()
                 .filter(|n| n.is_element() && n.tag_name().name() == "cmAuthor")
@@ -842,7 +840,7 @@ fn parse_presentation_from_bytes(data: &[u8]) -> Result<Presentation, Box<dyn st
 fn parse_presentation(zip: &mut PptxZip) -> Result<Presentation, Box<dyn std::error::Error>> {
     // --- presentation.xml ---
     let pres_xml = read_zip_str(zip, "ppt/presentation.xml")?;
-    let pres_doc = roxmltree::Document::parse(&pres_xml)?;
+    let pres_doc = parse_guarded(&pres_xml)?;
     let pres_root = pres_doc.root_element();
 
     let sld_sz = child(pres_root, "sldSz");
@@ -1083,7 +1081,7 @@ fn parse_presentation(zip: &mut PptxZip) -> Result<Presentation, Box<dyn std::er
             // (previously each re-parsed the same string — 3 parses per override slide).
             let master_doc = bundle.master_xml.as_deref().and_then(|xml| {
                 note_layout_master_parse();
-                roxmltree::Document::parse(xml).ok()
+                parse_guarded(xml).ok()
             });
             let master_root = master_doc.as_ref().map(|d| d.root_element());
             let master_bg: Option<Fill> = master_root.and_then(|root| {

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -22,6 +22,7 @@ use crate::{
     note_layout_master_parse, parse_rels, read_zip_str, resolve_path, PptxZip,
 };
 use ooxml_common::blip::{mime_from_ext, parse_src_rect, SrcRect};
+use ooxml_common::depth::parse_guarded;
 use std::collections::HashMap;
 
 /// Keyed first by idx (integer), then by type string.
@@ -1399,7 +1400,7 @@ pub(crate) fn parse_layout(
     zip: &mut PptxZip,
 ) -> ParsedLayout {
     note_layout_master_parse();
-    let doc = match roxmltree::Document::parse(layout_xml) {
+    let doc = match parse_guarded(layout_xml) {
         Ok(d) => d,
         // Unparseable layout → same as no layout: default placeholders/bg and
         // showMasterSp = true (the slide's own flag still applies downstream).
@@ -1570,7 +1571,7 @@ pub(crate) fn build_master_bundle(
     // every map defaults to empty, exactly as the prior `Option::map` chain did.
     let master_doc: Option<roxmltree::Document<'_>> = master_xml_opt.as_deref().and_then(|xml| {
         note_layout_master_parse();
-        roxmltree::Document::parse(xml).ok()
+        parse_guarded(xml).ok()
     });
     let master_root: Option<roxmltree::Node<'_, '_>> =
         master_doc.as_ref().map(|d| d.root_element());

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -20,6 +20,7 @@ use crate::{
     table_style_presets, PptxZip, TableStyleDef,
 };
 use ooxml_common::blip::{mime_from_ext, parse_src_rect, svg_blip_rid};
+use ooxml_common::depth::DepthGuard;
 use ooxml_common::ns::{is_diagram_uri, is_pml_ole_uri};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
@@ -1475,6 +1476,7 @@ pub(crate) fn extract_decorative_shapes(
                 out,
                 true, // skip placeholder shapes
                 None, // no inherited group fill at top level
+                DepthGuard::root(),
             );
         }
     }
@@ -1482,6 +1484,11 @@ pub(crate) fn extract_decorative_shapes(
 
 // Recurses the shape tree carrying placeholder/layout context, theme, rels,
 // smartart drawings, the zip, the output buffer and inherited group fill.
+//
+// `depth` bounds the `<p:grpSp>` recursion: a hand-crafted, thousands-deep group
+// nest would otherwise blow the fixed WASM stack and trap the whole parse. Past
+// the shared limit the group's children are dropped and parsing continues with
+// the rest of the slide (graceful degradation). See `ooxml_common::depth`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn parse_sp_tree_node(
     node: roxmltree::Node<'_, '_>,
@@ -1494,6 +1501,7 @@ pub(crate) fn parse_sp_tree_node(
     out: &mut Vec<SlideElement>,
     skip_placeholders: bool,
     group_fill: Option<&Fill>,
+    depth: DepthGuard,
 ) {
     // §20.1.2.2.8 — a shape/pic/graphicFrame/cxnSp/grpSp whose own
     // `<p:cNvPr hidden="1">` marks it hidden is not rendered. Skip at parse
@@ -1752,6 +1760,8 @@ pub(crate) fn parse_sp_tree_node(
             });
             if let Some(choice_node) = choice_node {
                 for child_node in choice_node.children().filter(|n| n.is_element()) {
+                    // `mc:AlternateContent` is a transparent wrapper, not a group
+                    // level — pass `depth` through unchanged.
                     parse_sp_tree_node(
                         child_node,
                         lph,
@@ -1763,6 +1773,7 @@ pub(crate) fn parse_sp_tree_node(
                         out,
                         skip_placeholders,
                         group_fill,
+                        depth,
                     );
                 }
             }
@@ -1783,6 +1794,7 @@ pub(crate) fn parse_sp_tree_node(
                             out,
                             skip_placeholders,
                             group_fill,
+                            depth,
                         );
                     }
                 }
@@ -1973,20 +1985,26 @@ pub(crate) fn parse_sp_tree_node(
                 group_fill.cloned()
             };
 
+            // Bound the group nesting: once the shared depth limit is reached,
+            // stop descending into this group's children (drop the subtree) so a
+            // pathologically deep `<p:grpSp>` nest cannot overflow the stack.
             let start = out.len();
-            for child_node in node.children().filter(|n| n.is_element()) {
-                parse_sp_tree_node(
-                    child_node,
-                    lph,
-                    slide_dir,
-                    rels,
-                    smartart_drawings,
-                    zip,
-                    theme,
-                    out,
-                    skip_placeholders,
-                    child_group_fill.as_ref(),
-                );
+            if let Some(child_depth) = depth.descend() {
+                for child_node in node.children().filter(|n| n.is_element()) {
+                    parse_sp_tree_node(
+                        child_node,
+                        lph,
+                        slide_dir,
+                        rels,
+                        smartart_drawings,
+                        zip,
+                        theme,
+                        out,
+                        skip_placeholders,
+                        child_group_fill.as_ref(),
+                        child_depth,
+                    );
+                }
             }
             if let Some(gt) = gt {
                 for el in &mut out[start..] {
@@ -2414,6 +2432,7 @@ mod ole_tests {
             &mut out,
             false,
             None,
+            DepthGuard::root(),
         );
         out
     }
@@ -2632,6 +2651,7 @@ mod hidden_tests {
             &mut out,
             false,
             None,
+            DepthGuard::root(),
         );
         out
     }
@@ -2713,6 +2733,75 @@ mod hidden_tests {
         let out = run(&xml);
         assert_eq!(out.len(), 1, "expected only the visible child: {out:?}");
     }
+
+    // ── Group-shape recursion depth guard (RB2) ────────────────────────────
+
+    /// `<p:grpSp>` nested `levels` deep (levels ≥ 1), with one visible leaf shape
+    /// at the very bottom. Each `<p:grpSp>` is a real `parse_sp_tree_node`
+    /// recursion. The outermost `<p:grpSp>` carries the namespace decls and is
+    /// returned as the root element (the `run` helper parses it as one node).
+    fn nested_groups(levels: usize) -> String {
+        assert!(levels >= 1);
+        let leaf = concat!(
+            r#"<p:sp><p:nvSpPr><p:cNvPr id="99" name="Leaf"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>"#,
+            r#"<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="457200" cy="457200"/></a:xfrm>"#,
+            r#"<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>"#,
+            r#"<p:txBody><a:bodyPr/><a:p><a:r><a:t>x</a:t></a:r></a:p></p:txBody></p:sp>"#,
+        );
+        // Inner groups carry no xmlns (inherited from the root grpSp).
+        let open_inner = concat!(
+            r#"<p:grpSp><p:nvGrpSpPr><p:cNvPr id="2" name="G"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>"#,
+            r#"<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/>"#,
+            r#"<a:chOff x="0" y="0"/><a:chExt cx="914400" cy="914400"/></a:xfrm></p:grpSpPr>"#,
+        );
+        let mut inner = leaf.to_string();
+        // levels-1 inner groups around the leaf …
+        for _ in 0..levels - 1 {
+            inner = format!("{open_inner}{inner}</p:grpSp>");
+        }
+        // … then the outermost group with the namespace declarations, as root.
+        format!(
+            r#"<p:grpSp xmlns:p="{P}" xmlns:a="{A}"><p:nvGrpSpPr><p:cNvPr id="1" name="Root"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/><a:chOff x="0" y="0"/><a:chExt cx="914400" cy="914400"/></a:xfrm></p:grpSpPr>{inner}</p:grpSp>"#,
+            P = P_NS,
+            A = A_NS,
+        )
+    }
+
+    fn run_deep(levels: usize) -> Vec<SlideElement> {
+        // roxmltree::Document::parse itself recurses on nesting, so parse on a
+        // generous stack; this test targets OUR grpSp guard. (The roxmltree layer
+        // is bounded separately by the raw-XML depth pre-check in
+        // `ooxml_common::depth`.)
+        std::thread::Builder::new()
+            .stack_size(256 * 1024 * 1024)
+            .spawn(move || run(&nested_groups(levels)))
+            .unwrap()
+            .join()
+            .unwrap()
+    }
+
+    #[test]
+    fn deeply_nested_groups_do_not_trap() {
+        // ~2 000 nested groups is ~30× the depth limit; pre-guard this recurses
+        // 2 000 frames and traps on the WASM stack. The guard caps the descent so
+        // parsing RETURNS instead of aborting. A group deeper than the limit drops
+        // its subtree, so the single leaf below it does NOT survive — the assertion
+        // is simply that we get here (no trap) with a bounded result.
+        let out = run_deep(2_000);
+        assert!(out.len() <= 1, "guard should bound the emitted shapes");
+    }
+
+    #[test]
+    fn shallow_nested_groups_keep_their_leaf() {
+        // A modest nest (well under the limit) parses in full: the leaf survives.
+        let out = run_deep(10);
+        assert_eq!(out.len(), 1, "leaf under a shallow group nest must survive");
+        assert!(matches!(out[0], SlideElement::Shape(_)));
+    }
+
+    // Namespaces for `nested_groups` (kept local to these depth tests).
+    const P_NS: &str = "http://schemas.openxmlformats.org/presentationml/2006/main";
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
 }
 
 #[cfg(test)]
@@ -2891,6 +2980,7 @@ mod strict_namespace_tests {
                 &mut out,
                 false,
                 None,
+                DepthGuard::root(),
             );
         }
         out

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -20,7 +20,7 @@ use crate::{
     table_style_presets, PptxZip, TableStyleDef,
 };
 use ooxml_common::blip::{mime_from_ext, parse_src_rect, svg_blip_rid};
-use ooxml_common::depth::DepthGuard;
+use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{is_diagram_uri, is_pml_ole_uri};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
@@ -943,7 +943,7 @@ pub(crate) fn parse_table_styles_xml(
     theme: &HashMap<String, String>,
 ) -> HashMap<String, TableStyleDef> {
     let mut map = HashMap::new();
-    let Ok(doc) = roxmltree::Document::parse(xml) else {
+    let Ok(doc) = parse_guarded(xml) else {
         return map;
     };
     let root = doc.root_element();
@@ -2055,7 +2055,7 @@ fn parse_smartart_drawing(
     out: &mut Vec<SlideElement>,
     zip: &mut PptxZip,
 ) {
-    let doc = match roxmltree::Document::parse(drawing_xml) {
+    let doc = match parse_guarded(drawing_xml) {
         Ok(d) => d,
         Err(_) => return,
     };
@@ -2787,6 +2787,13 @@ mod hidden_tests {
         // parsing RETURNS instead of aborting. A group deeper than the limit drops
         // its subtree, so the single leaf below it does NOT survive — the assertion
         // is simply that we get here (no trap) with a bounded result.
+        //
+        // NB: this runs on a 256 MB stack, so it cannot by itself catch a removed
+        // DepthGuard (the big stack absorbs the recursion). The LOAD-BEARING
+        // coverage for the roxmltree-layer trap is the default-stack neutralization
+        // test `theme::tests::deeply_nested_theme_xml_is_rejected_not_trapped`
+        // (and the docx/xlsx siblings), which would overflow if `parse_guarded`'s
+        // pre-check were bypassed. This test's job is the truncation contract.
         let out = run_deep(2_000);
         assert!(out.len() <= 1, "guard should bound the emitted shapes");
     }

--- a/packages/pptx/parser/src/theme.rs
+++ b/packages/pptx/parser/src/theme.rs
@@ -5,6 +5,7 @@
 //! (`child`, `attr`) stay in `lib.rs` and are imported here.
 
 use crate::{attr, child};
+use ooxml_common::depth::parse_guarded;
 use std::collections::HashMap;
 
 /// Parse the color scheme from a theme XML file.
@@ -37,7 +38,7 @@ pub(crate) fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
         }
     }
 
-    let doc = match roxmltree::Document::parse(xml) {
+    let doc = match parse_guarded(xml) {
         Ok(d) => d,
         Err(_) => return map,
     };
@@ -203,7 +204,7 @@ pub(crate) fn bake_clr_map(theme: &mut HashMap<String, String>, master_xml: Opti
     // Find the master's <p:clrMap> element (direct child of <p:sldMaster>) and
     // resolve its 12 logical→slot attrs, then apply.
     let clr_map = master_xml.and_then(|xml| {
-        let doc = roxmltree::Document::parse(xml).ok()?;
+        let doc = parse_guarded(xml).ok()?;
         let node = child(doc.root_element(), "clrMap")?;
         Some(parse_clr_map_node(node))
     });
@@ -224,7 +225,7 @@ pub(crate) fn parse_clr_map_ovr(xml: &str) -> Option<HashMap<String, String>> {
     if !xml.contains("clrMapOvr") {
         return None;
     }
-    let doc = roxmltree::Document::parse(xml).ok()?;
+    let doc = parse_guarded(xml).ok()?;
     // <p:clrMapOvr> is a direct child of <p:sld> / <p:sldLayout> (right after
     // <p:cSld>); the choice inside is masterClrMapping XOR overrideClrMapping.
     let ovr = child(doc.root_element(), "clrMapOvr")?;
@@ -277,5 +278,55 @@ impl ooxml_common::color::ThemeResolver for PptxSchemeResolver<'_> {
             other => ooxml_common::color::default_scheme_slot(other),
         };
         self.theme.get(canonical).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shallow_theme_xml_parses_colors() {
+        // A normal theme parses through `parse_guarded` unchanged (sanity: the
+        // guard does not reject legitimate parts).
+        let xml = r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <a:themeElements><a:clrScheme name="Office">
+              <a:dk1><a:srgbClr val="000000"/></a:dk1>
+              <a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+            </a:clrScheme></a:themeElements></a:theme>"#;
+        let map = parse_theme_colors(xml);
+        assert_eq!(map.get("dk1").map(String::as_str), Some("000000"));
+        assert_eq!(map.get("lt1").map(String::as_str), Some("FFFFFF"));
+    }
+
+    // ── RB2 neutralization (roxmltree layer): a pathologically deep theme/part
+    //    XML is rejected by the depth pre-check in `parse_guarded` BEFORE
+    //    roxmltree's recursive tree builder runs, so `parse_theme_colors` returns
+    //    gracefully instead of trapping. This runs on the DEFAULT (small)
+    //    test-thread stack ON PURPOSE: handing 5 000-deep XML straight to
+    //    roxmltree here would overflow and abort the process. That it returns is
+    //    the guarantee. (The shape-walk DepthGuard is covered separately in
+    //    shape.rs on a generous stack.)
+    #[test]
+    fn deeply_nested_theme_xml_is_rejected_not_trapped() {
+        let mut xml = String::from(
+            r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">"#,
+        );
+        // 5 000 levels — ~20× MAX_XML_DEPTH and far past roxmltree's ~1 000-deep
+        // small-stack overflow threshold.
+        for _ in 0..5_000 {
+            xml.push_str("<a:x>");
+        }
+        for _ in 0..5_000 {
+            xml.push_str("</a:x>");
+        }
+        xml.push_str("</a:theme>");
+
+        // Must return (not trap); the rejected part yields no colors.
+        let map = parse_theme_colors(&xml);
+        assert!(
+            map.is_empty(),
+            "an over-deep theme XML must be rejected, yielding no colors"
+        );
     }
 }

--- a/packages/pptx/src/poster-decode-bomb.test.ts
+++ b/packages/pptx/src/poster-decode-bomb.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getPosterBitmap } from './renderer.js';
+import type { MediaElement } from './types';
+
+/**
+ * RB1 (poster path): a `<p:pic>` media element's poster image is attacker-
+ * controllable bytes (`posterPath` / `posterMimeType` come from the
+ * `<a:blip>` in shape.rs). `getPosterBitmap` used to hand the raw poster blob
+ * straight to `createImageBitmap`, which sizes its decoded RGBA surface from the
+ * image HEADER — so a tiny PNG declaring 60000×60000 forces a ~14 GB allocation
+ * (a decompression bomb) that OOMs the tab, bypassing the RB1 guard that already
+ * protects picture blips.
+ *
+ * The fix routes the poster through the same `rasterHeaderExceedsBudget` sniff.
+ * These tests assert the bomb is rejected BEFORE `createImageBitmap` is called,
+ * and that a normal in-budget poster still decodes.
+ */
+
+/** Big-endian u32 into a byte array at `o`. */
+function putBeU32(b: Uint8Array, o: number, v: number): void {
+  b[o] = (v >>> 24) & 0xff;
+  b[o + 1] = (v >>> 16) & 0xff;
+  b[o + 2] = (v >>> 8) & 0xff;
+  b[o + 3] = v & 0xff;
+}
+
+/** A PNG header (8-byte sig + IHDR) declaring `w × h` with almost no payload. */
+function pngHeader(w: number, h: number): Uint8Array {
+  const b = new Uint8Array(26);
+  b.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  putBeU32(b, 8, 13);
+  b.set([0x49, 0x48, 0x44, 0x52], 12); // "IHDR"
+  putBeU32(b, 16, w);
+  putBeU32(b, 20, h);
+  return b;
+}
+
+const SENTINEL = { width: 1, height: 1, close: () => {} } as unknown as ImageBitmap;
+
+function mediaEl(posterMimeType = 'image/png'): MediaElement {
+  return {
+    type: 'media',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    mediaKind: 'video',
+    posterPath: 'ppt/media/image1.png',
+    posterMimeType,
+    mediaPath: 'ppt/media/media1.mp4',
+    mimeType: 'video/mp4',
+  } as unknown as MediaElement;
+}
+
+describe('getPosterBitmap — RB1 poster decode-bomb guard', () => {
+  let createImageBitmapSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createImageBitmapSpy = vi.fn(async (_blob: Blob) => SENTINEL);
+    vi.stubGlobal('createImageBitmap', createImageBitmapSpy);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects a 60000×60000 PNG poster bomb WITHOUT calling createImageBitmap', async () => {
+    const bomb = pngHeader(60000, 60000); // ~14 GB decoded — tiny on the wire
+    const fetchMedia = vi.fn(
+      async (_path: string) => new Blob([bomb as BlobPart], { type: 'image/png' }),
+    );
+
+    // A fresh element each time (the cache is keyed by element identity).
+    await expect(getPosterBitmap(mediaEl(), fetchMedia)).rejects.toThrow();
+    expect(createImageBitmapSpy).not.toHaveBeenCalled();
+  });
+
+  it('decodes a normal in-budget poster (guard does not block legitimate images)', async () => {
+    const ok = pngHeader(1920, 1080);
+    const fetchMedia = vi.fn(
+      async (_path: string) => new Blob([ok as BlobPart], { type: 'image/png' }),
+    );
+
+    const bmp = await getPosterBitmap(mediaEl(), fetchMedia);
+    expect(bmp).toBe(SENTINEL);
+    expect(createImageBitmapSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves an unrecognized (non-raster) poster header to decode normally (fail-open)', async () => {
+    // e.g. an SVG poster: not a recognized raster ⇒ not blocked by the sniff.
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+    const fetchMedia = vi.fn(
+      async (_path: string) => new Blob([svg], { type: 'image/svg+xml' }),
+    );
+
+    const bmp = await getPosterBitmap(mediaEl('image/svg+xml'), fetchMedia);
+    expect(bmp).toBe(SENTINEL);
+    expect(createImageBitmapSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -74,6 +74,7 @@ import {
   isSymbolFontFamily,
   drawUnderline,
   intendedSingleLinePx,
+  rasterHeaderExceedsBudget,
 } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
@@ -3181,7 +3182,10 @@ function paintBeveledFlat(
  *  bounded and fine for the per-slide warm-up this serves. */
 const posterBitmapCache = new WeakMap<MediaElement, Promise<ImageBitmap>>();
 
-function getPosterBitmap(
+// Exported for the RB1 poster decode-bomb neutralization test (asserts an
+// over-budget poster is rejected before `createImageBitmap`). Not part of the
+// public package surface.
+export function getPosterBitmap(
   el: MediaElement,
   fetchMedia: (path: string) => Promise<Blob>,
 ): Promise<ImageBitmap> {
@@ -3192,6 +3196,20 @@ function getPosterBitmap(
     const typed = el.posterMimeType
       ? new Blob([blob], { type: el.posterMimeType })
       : blob;
+    // Decode-bomb guard: `el.posterPath`/`posterMimeType` come from the
+    // attacker-controllable `<a:blip>` (shape.rs), and `createImageBitmap` sizes
+    // its decoded RGBA surface from the image HEADER, not the compressed length —
+    // a tiny PNG/JPEG declaring e.g. 60000×60000 forces a multi-GB allocation.
+    // Sniff the pixel dimensions from a 64 KiB header prefix and reject an
+    // over-budget raster BEFORE it reaches createImageBitmap, exactly as
+    // `decodeRasterOrMetafile` (RB1) does for picture blips. A rejection here
+    // makes both callers fall through to their plain media fill (graceful
+    // degradation). The 64 KiB prefix covers a JPEG SOF past EXIF/ICC; an
+    // unrecognized header is not blocked (fail-open).
+    const head = new Uint8Array(await typed.slice(0, 64 * 1024).arrayBuffer());
+    if (rasterHeaderExceedsBudget(head)) {
+      throw new Error('poster raster exceeds the pixel budget');
+    }
     return createImageBitmap(typed);
   })();
   posterBitmapCache.set(el, p);

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -54,6 +54,7 @@ import {
   materialClass,
   isHTMLCanvas,
   defaultDpr,
+  clampCanvasSize,
   classifyCjkFont,
   classifyFontGeneric,
   cjkFallbackChain,
@@ -4061,8 +4062,17 @@ export async function renderSlide(
   const canvasH = Math.round(slideHeight * scale);
 
   const dpr = opts.dpr ?? defaultDpr();
-  canvas.width  = canvasW * dpr;
-  canvas.height = canvasH * dpr;
+  // Clamp the backing store to browser canvas limits (RB5). A huge target width
+  // (or large dpr × slide size) can exceed the per-axis / total-area cap, at
+  // which point the browser silently allocates a smaller-or-empty buffer and the
+  // slide renders blank. `clampCanvasSize` scales BOTH axes by one factor (≤ 1)
+  // so the aspect ratio is kept; we fold that into the effective dpr, keep the
+  // CSS box at its intended size, and the browser stretches the (slightly
+  // lower-res) backing store to fill it — a visible slide beats a blank one.
+  const clamped = clampCanvasSize(canvasW * dpr, canvasH * dpr);
+  const effectiveDpr = clamped.clamped ? dpr * clamped.scale : dpr;
+  canvas.width = clamped.width;
+  canvas.height = clamped.height;
   // CSS size only applies to the visible HTMLCanvasElement (not OffscreenCanvas)
   if (isHTMLCanvas(canvas)) {
     canvas.style.width = `${canvasW}px`;
@@ -4075,13 +4085,17 @@ export async function renderSlide(
 
   const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | null;
   if (!ctx) throw new Error('Could not get 2D context');
-  ctx.scale(dpr, dpr);
+  // Use the effective dpr (folded with any clamp factor) so drawing fills the
+  // clamped backing store and crisp-offset math stays aligned with it.
+  ctx.scale(effectiveDpr, effectiveDpr);
 
   const rc: RenderContext = {
     themeMajorFont: opts.majorFont ?? null,
     themeMinorFont: opts.minorFont ?? null,
     themeHlinkColor: opts.hlinkColor ?? null,
-    dpr,
+    // The backing store may have been clamped below `canvasSize × dpr`; downstream
+    // crisp-offset math must use the SAME effective dpr the ctx was scaled by.
+    dpr: effectiveDpr,
   };
 
   await renderBackground(ctx, slide.background, canvasW, canvasH, scale, opts.fetchImage);

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1,5 +1,6 @@
 use crate::types::*;
 use crate::{find_rel_target_by_type, parse_rels_map, resolve_fill_color, resolve_zip_path};
+use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::{is_c_ns, is_r_ns, is_xdr_ns};
 use ooxml_common::zip::read_zip_string;
 
@@ -34,7 +35,7 @@ pub(crate) fn load_sheet_charts(
     let Ok(sheet_rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
-    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+    let Ok(rels_doc) = parse_guarded(&sheet_rels_xml) else {
         return Vec::new();
     };
 
@@ -63,7 +64,7 @@ pub(crate) fn load_sheet_charts(
         let Ok(drawing_xml) = read_zip_string(archive, &drawing_path) else {
             continue;
         };
-        let Ok(draw_doc) = roxmltree::Document::parse(&drawing_xml) else {
+        let Ok(draw_doc) = parse_guarded(&drawing_xml) else {
             continue;
         };
 
@@ -234,7 +235,7 @@ pub(crate) fn load_sheet_charts(
             // `parse_chartex_part` structure walk (waterfall / boxWhisker /
             // treemap / sunburst / … — ECMA-376 does not cover these; they are
             // the Microsoft 2014 chartex extension). Same `ColorResolver`.
-            let Ok(chart_doc) = roxmltree::Document::parse(&chart_xml) else {
+            let Ok(chart_doc) = parse_guarded(&chart_xml) else {
                 continue;
             };
             let resolver = XlsxColorResolver {

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -7,6 +7,7 @@ use ooxml_common::zip::read_zip_string;
 // a blip's `<a:extLst>`. Replaces xlsx's former local `mime_from_ext` (a strict
 // subset that lacked the `svg` arm and so dropped SVG parts).
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
+use ooxml_common::depth::DepthGuard;
 use ooxml_common::ns::{attr_ns, is_a_ns, is_xdr_ns, relationships};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
@@ -842,6 +843,11 @@ pub(crate) fn parse_sp_geom(sp_pr: &roxmltree::Node) -> Option<ShapeGeom> {
 // recursion (root offset/extent, accumulated scale/translation, theme + rels);
 // bundling them into a struct would only move the same fields elsewhere without
 // improving clarity.
+//
+// `depth` bounds the nested-`<xdr:grpSp>` recursion so a hand-crafted, thousands-
+// deep group nest cannot overflow the fixed WASM stack and trap the parse. Past
+// the shared limit the group's children are dropped and the rest of the drawing
+// still parses (graceful degradation). See `ooxml_common::depth`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn collect_shapes(
     node: &roxmltree::Node,
@@ -858,6 +864,7 @@ pub(crate) fn collect_shapes(
     theme_ln_widths: &[i64],
     rid_urls: &HashMap<String, String>,
     out: &mut Vec<ShapeInfo>,
+    depth: DepthGuard,
 ) {
     for child in node.children().filter(|n| n.is_element()) {
         let tag = child.tag_name().name();
@@ -868,6 +875,12 @@ pub(crate) fn collect_shapes(
             continue;
         }
         if tag == "grpSp" {
+            // Bound the group nesting: once the shared depth limit is reached,
+            // drop this group's subtree rather than recurse into it, so a
+            // pathologically deep `<xdr:grpSp>` nest cannot overflow the stack.
+            let Some(child_depth) = depth.descend() else {
+                continue;
+            };
             // Nested grpSp: compose the transform by the group's own xfrm.
             let grp_sp_pr = child
                 .children()
@@ -917,6 +930,7 @@ pub(crate) fn collect_shapes(
                 theme_ln_widths,
                 rid_urls,
                 out,
+                child_depth,
             );
         } else if tag == "sp" {
             let sp_pr = child
@@ -1339,6 +1353,7 @@ pub(crate) fn parse_shape_anchors(
                 theme_ln_widths,
                 rid_urls,
                 &mut shapes,
+                DepthGuard::root(),
             );
         } else if let Some(sp) = content.children().find(|n| {
             if !n.is_element() {
@@ -1400,6 +1415,7 @@ pub(crate) fn parse_shape_anchors(
                 theme_ln_widths,
                 rid_urls,
                 &mut shapes,
+                DepthGuard::root(),
             );
         } else {
             continue;
@@ -2658,6 +2674,82 @@ mod hidden_tests {
             &HashMap::new(),
         );
         assert!(b.is_empty(), "hidden group leaked");
+    }
+
+    // ── Group-shape recursion depth guard (RB2) ────────────────────────────
+
+    /// A twoCellAnchor holding `<xdr:grpSp>` nested `levels` deep, with one leaf
+    /// `<xdr:sp>` at the bottom. Each `<xdr:grpSp>` is a real `collect_shapes`
+    /// recursion.
+    fn nested_group_anchor(levels: usize) -> String {
+        let leaf = concat!(
+            r#"<xdr:sp><xdr:nvSpPr><xdr:cNvPr id="99" name="Leaf"/><xdr:cNvSpPr/></xdr:nvSpPr>"#,
+            r#"<xdr:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="457200" cy="457200"/></a:xfrm>"#,
+            r#"<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>"#,
+            r#"<a:ln w="6350"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:ln></xdr:spPr></xdr:sp>"#,
+        );
+        let open = concat!(
+            r#"<xdr:grpSp><xdr:nvGrpSpPr><xdr:cNvPr id="2" name="G"/><xdr:cNvGrpSpPr/></xdr:nvGrpSpPr>"#,
+            r#"<xdr:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1828800" cy="1828800"/>"#,
+            r#"<a:chOff x="0" y="0"/><a:chExt cx="1828800" cy="1828800"/></a:xfrm></xdr:grpSpPr>"#,
+        );
+        let mut inner = leaf.to_string();
+        for _ in 0..levels {
+            inner = format!("{open}{inner}</xdr:grpSp>");
+        }
+        format!(
+            r#"<xdr:wsDr {NS}><xdr:twoCellAnchor>
+              <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+              <xdr:to><xdr:col>6</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>6</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+              {inner}
+              <xdr:clientData/>
+            </xdr:twoCellAnchor></xdr:wsDr>"#,
+            NS = NS,
+        )
+    }
+
+    fn anchors_deep(levels: usize) -> Vec<ShapeAnchor> {
+        // roxmltree::Document::parse itself recurses on nesting depth, so parse on
+        // a generous stack; this test targets OUR collect_shapes guard. (The
+        // roxmltree layer is bounded separately by the raw-XML depth pre-check in
+        // `ooxml_common::depth`.)
+        std::thread::Builder::new()
+            .stack_size(256 * 1024 * 1024)
+            .spawn(move || {
+                parse_shape_anchors(
+                    &nested_group_anchor(levels),
+                    &theme(),
+                    &[6_350],
+                    &HashMap::new(),
+                )
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+    }
+
+    #[test]
+    fn deeply_nested_groups_do_not_trap() {
+        // ~2 000 nested groups is ~30× the depth limit; pre-guard this recurses
+        // 2 000 frames and traps on the WASM stack. The guard caps the descent so
+        // parsing RETURNS instead of aborting. A group deeper than the limit drops
+        // its subtree (the single leaf below it does not survive) — the assertion
+        // is that we reach here with a bounded result and no trap.
+        let anchors = anchors_deep(2_000);
+        let leaves: usize = anchors.iter().map(|a| a.shapes.len()).sum();
+        assert!(leaves <= 1, "guard should bound the collected leaves");
+    }
+
+    #[test]
+    fn shallow_nested_groups_keep_their_leaf() {
+        // A modest nest (well under the limit) parses in full: the leaf survives.
+        let anchors = anchors_deep(10);
+        assert_eq!(anchors.len(), 1, "expected the one anchor");
+        assert_eq!(
+            anchors[0].shapes.len(),
+            1,
+            "leaf under a shallow group nest must survive"
+        );
     }
 }
 

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -7,7 +7,7 @@ use ooxml_common::zip::read_zip_string;
 // a blip's `<a:extLst>`. Replaces xlsx's former local `mime_from_ext` (a strict
 // subset that lacked the `svg` arm and so dropped SVG parts).
 use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
-use ooxml_common::depth::DepthGuard;
+use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{attr_ns, is_a_ns, is_xdr_ns, relationships};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
@@ -54,7 +54,7 @@ pub(crate) fn parse_drawing_anchors(
     drawing_dir: &str,
     archive: &mut crate::XlsxZip,
 ) -> Vec<ImageAnchor> {
-    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
+    let Ok(doc) = parse_guarded(drawing_xml) else {
         return Vec::new();
     };
     let mut anchors: Vec<ImageAnchor> = Vec::new();
@@ -1211,7 +1211,7 @@ pub(crate) fn parse_shape_anchors(
     theme_ln_widths: &[i64],
     rid_urls: &HashMap<String, String>,
 ) -> Vec<ShapeAnchor> {
-    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
+    let Ok(doc) = parse_guarded(drawing_xml) else {
         return Vec::new();
     };
     let mut anchors: Vec<ShapeAnchor> = Vec::new();
@@ -1457,7 +1457,7 @@ pub(crate) fn load_sheet_shape_groups(
     let Ok(sheet_rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
-    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+    let Ok(rels_doc) = parse_guarded(&sheet_rels_xml) else {
         return Vec::new();
     };
     let mut drawing_targets: Vec<String> = Vec::new();
@@ -1550,7 +1550,7 @@ pub(crate) fn load_sheet_images(
     };
 
     // Find all drawing relationships
-    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+    let Ok(rels_doc) = parse_guarded(&sheet_rels_xml) else {
         return Vec::new();
     };
     let mut drawing_targets: Vec<String> = Vec::new();
@@ -1817,7 +1817,7 @@ pub(crate) fn parse_ole_object_anchors(
     sheet_dir: &str,
     archive: &mut crate::XlsxZip,
 ) -> Vec<ImageAnchor> {
-    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else {
+    let Ok(doc) = parse_guarded(sheet_xml) else {
         return Vec::new();
     };
 
@@ -1843,7 +1843,7 @@ pub(crate) fn parse_ole_object_anchors(
     let vml = load_legacy_vml_drawing(&doc, sheet_rels, sheet_dir, archive);
     let vml_parsed = vml
         .as_ref()
-        .and_then(|(xml, rels, dir)| roxmltree::Document::parse(xml).ok().map(|d| (d, rels, dir)));
+        .and_then(|(xml, rels, dir)| parse_guarded(xml).ok().map(|d| (d, rels, dir)));
 
     let mut anchors: Vec<ImageAnchor> = Vec::new();
     for ole in ole_objects {
@@ -2749,6 +2749,35 @@ mod hidden_tests {
             anchors[0].shapes.len(),
             1,
             "leaf under a shallow group nest must survive"
+        );
+    }
+
+    // ── RB2 neutralization (roxmltree layer): a pathologically deep drawing XML
+    //    is rejected by the depth pre-check in `parse_guarded` BEFORE roxmltree's
+    //    recursive tree builder runs, so `parse_shape_anchors` returns gracefully
+    //    instead of trapping. Unlike the two tests above (which spawn a 256 MB
+    //    stack to exercise OUR collect_shapes guard), this runs on the DEFAULT
+    //    (small) test-thread stack ON PURPOSE: handing 5 000-deep XML straight to
+    //    roxmltree here would overflow and abort the process. That it returns is
+    //    the guarantee.
+    #[test]
+    fn deeply_nested_drawing_xml_is_rejected_not_trapped() {
+        let mut xml = format!(r#"<xdr:wsDr {NS}>"#, NS = NS);
+        // 5 000 levels — ~20× MAX_XML_DEPTH and far past roxmltree's ~1 000-deep
+        // small-stack overflow threshold.
+        for _ in 0..5_000 {
+            xml.push_str("<xdr:grpSp>");
+        }
+        for _ in 0..5_000 {
+            xml.push_str("</xdr:grpSp>");
+        }
+        xml.push_str("</xdr:wsDr>");
+
+        // Must return (not trap); the rejected part yields no anchors.
+        let anchors = parse_shape_anchors(&xml, &theme(), &[6_350], &HashMap::new());
+        assert!(
+            anchors.is_empty(),
+            "an over-deep drawing XML must be rejected, yielding no anchors"
         );
     }
 }

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -726,6 +726,14 @@ fn parse_worksheet(
     theme_colors: &[String],
     name: &str,
 ) -> Result<(Worksheet, HyperlinkRids), String> {
+    // Guard against a pathologically deep worksheet XML: roxmltree's tree builder
+    // recurses per element-nesting level, so a sheet nested thousands deep
+    // overflows the fixed WASM stack and traps *inside* `Document::parse` before
+    // our own depth-guarded drawing walk runs. Reject it up front. See
+    // `ooxml_common::depth::xml_too_deep`.
+    if ooxml_common::depth::xml_too_deep(xml.as_bytes()) {
+        return Err("worksheet XML nesting depth exceeds the safe limit".to_string());
+    }
     let doc = roxmltree::Document::parse(xml).map_err(|e| e.to_string())?;
 
     let mut rows = Vec::new();

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::io::{Cursor, Read};
 use wasm_bindgen::prelude::*;
 
+use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::{attr_ns, is_r_ns, is_x_ns, relationships};
 use ooxml_common::zip::read_zip_string;
 
@@ -108,7 +109,7 @@ impl WorkbookShared {
     fn load(archive: &mut XlsxZip) -> Result<WorkbookShared, String> {
         let workbook_xml = read_zip_string(archive, "xl/workbook.xml")?;
         let (sheets, date1904) = {
-            let wb_doc = roxmltree::Document::parse(&workbook_xml).map_err(|e| e.to_string())?;
+            let wb_doc = parse_guarded(&workbook_xml).map_err(|e| e.to_string())?;
             (
                 parse_workbook_sheets(&wb_doc),
                 parse_workbook_date1904(&wb_doc),
@@ -144,7 +145,7 @@ fn parse_sheet_with(
     sheet_index: u32,
     name: &str,
 ) -> Result<Vec<u8>, JsValue> {
-    let wb_doc = roxmltree::Document::parse(&shared.workbook_xml).map_err(|e| e.to_string())?;
+    let wb_doc = parse_guarded(&shared.workbook_xml).map_err(|e| e.to_string())?;
     // `workbook.xml.rels` is mandatory for a sheet parse (the original
     // `parse_sheet` read it with `?`). `WorkbookShared` caches it leniently for
     // the `parse_xlsx` path, so on the (defensive) missing-rels case re-read it
@@ -153,7 +154,7 @@ fn parse_sheet_with(
         read_zip_string(archive, "xl/_rels/workbook.xml.rels")
             .map_err(|e| JsValue::from_str(&e))?;
     }
-    let rels_doc = roxmltree::Document::parse(&shared.rels_xml).map_err(|e| e.to_string())?;
+    let rels_doc = parse_guarded(&shared.rels_xml).map_err(|e| e.to_string())?;
 
     let sheet_meta = shared
         .sheets
@@ -237,7 +238,7 @@ fn parse_xlsx_inner_with(
     // small head read of each sheet entry is enough — we never decompress the
     // (potentially huge) `<sheetData>` body just to read the tab color.
     let mut sheets = shared.sheets.clone();
-    if let Ok(rels_doc) = roxmltree::Document::parse(&shared.rels_xml) {
+    if let Ok(rels_doc) = parse_guarded(&shared.rels_xml) {
         for sheet in sheets.iter_mut() {
             let Some(path) = resolve_sheet_path(&rels_doc, &sheet.r_id) else {
                 continue;
@@ -619,7 +620,7 @@ fn read_shared_strings(archive: &mut XlsxZip, theme_colors: &[String]) -> Vec<Sh
     let Ok(xml) = read_zip_string(archive, "xl/sharedStrings.xml") else {
         return Vec::new();
     };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+    let Ok(doc) = parse_guarded(&xml) else {
         return Vec::new();
     };
     let mut strings = Vec::new();
@@ -726,15 +727,11 @@ fn parse_worksheet(
     theme_colors: &[String],
     name: &str,
 ) -> Result<(Worksheet, HyperlinkRids), String> {
-    // Guard against a pathologically deep worksheet XML: roxmltree's tree builder
-    // recurses per element-nesting level, so a sheet nested thousands deep
-    // overflows the fixed WASM stack and traps *inside* `Document::parse` before
-    // our own depth-guarded drawing walk runs. Reject it up front. See
-    // `ooxml_common::depth::xml_too_deep`.
-    if ooxml_common::depth::xml_too_deep(xml.as_bytes()) {
-        return Err("worksheet XML nesting depth exceeds the safe limit".to_string());
-    }
-    let doc = roxmltree::Document::parse(xml).map_err(|e| e.to_string())?;
+    // Guard against a pathologically deep worksheet XML: the nesting-depth
+    // pre-check now lives inside `parse_guarded`, which rejects an over-deep
+    // part before roxmltree's tree builder can recurse and overflow the fixed
+    // WASM stack. See `ooxml_common::depth::parse_guarded`.
+    let doc = parse_guarded(xml).map_err(|e| e.to_string())?;
 
     let mut rows = Vec::new();
     let mut col_widths: BTreeMap<u32, f64> = BTreeMap::new();
@@ -1395,7 +1392,7 @@ fn load_sheet_comments(archive: &mut XlsxZip, sheet_path: &str) -> Vec<XlsxComme
     let Ok(rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
-    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else {
+    let Ok(rels_doc) = parse_guarded(&rels_xml) else {
         return Vec::new();
     };
 
@@ -1458,7 +1455,7 @@ fn load_persons(archive: &mut XlsxZip) -> HashMap<String, String> {
         let Ok(xml) = read_zip_string(archive, &path) else {
             continue;
         };
-        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        let Ok(doc) = parse_guarded(&xml) else {
             continue;
         };
         for p in doc
@@ -1484,7 +1481,7 @@ fn parse_threaded_comments_xml(
     tc_xml: &str,
     persons: &HashMap<String, String>,
 ) -> Vec<XlsxComment> {
-    let Ok(doc) = roxmltree::Document::parse(tc_xml) else {
+    let Ok(doc) = parse_guarded(tc_xml) else {
         return Vec::new();
     };
     // Preserve document order of first appearance per cell ref.
@@ -1543,7 +1540,7 @@ fn parse_threaded_comments_xml(
 /// Returns an empty vec on malformed XML. Split out from `load_sheet_comments`
 /// so the parse path is unit-testable without a ZIP archive.
 fn parse_comments_xml(comments_xml: &str) -> Vec<XlsxComment> {
-    let Ok(comments_doc) = roxmltree::Document::parse(comments_xml) else {
+    let Ok(comments_doc) = parse_guarded(comments_xml) else {
         return Vec::new();
     };
 
@@ -1855,7 +1852,7 @@ fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> 
         return Vec::new();
     }
     let mut values: Vec<Option<f64>> = vec![None; total];
-    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else {
+    let Ok(doc) = parse_guarded(sheet_xml) else {
         return values;
     };
     let row_span = (range.right - range.left + 1) as usize;
@@ -1902,7 +1899,7 @@ fn load_sheet_sparklines(
     rels_doc: &roxmltree::Document,
     theme_colors: &[String],
 ) -> Vec<SparklineGroup> {
-    let Ok(doc) = roxmltree::Document::parse(sheet_xml) else {
+    let Ok(doc) = parse_guarded(sheet_xml) else {
         return Vec::new();
     };
     let mut groups: Vec<SparklineGroup> = Vec::new();

--- a/packages/xlsx/parser/src/slicer.rs
+++ b/packages/xlsx/parser/src/slicer.rs
@@ -1,5 +1,6 @@
 use crate::resolve_zip_path;
 use crate::types::*;
+use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::{is_x_ns, is_xdr_ns};
 use ooxml_common::zip::read_zip_string;
 use std::collections::HashMap;
@@ -43,7 +44,7 @@ pub(crate) fn load_all_pivot_cache_fields(archive: &mut crate::XlsxZip) -> Pivot
         let Ok(xml) = read_zip_string(archive, &name) else {
             continue;
         };
-        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        let Ok(doc) = parse_guarded(&xml) else {
             continue;
         };
         for field in doc.descendants() {
@@ -92,7 +93,7 @@ pub(crate) fn load_all_slicer_caches(
         let Ok(xml) = read_zip_string(archive, &path) else {
             continue;
         };
-        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        let Ok(doc) = parse_guarded(&xml) else {
             continue;
         };
         let root = doc.root_element();
@@ -134,7 +135,7 @@ pub(crate) struct SlicerDef {
 
 pub(crate) fn parse_slicers_xml(xml: &str) -> HashMap<String, SlicerDef> {
     let mut out: HashMap<String, SlicerDef> = HashMap::new();
-    let Ok(doc) = roxmltree::Document::parse(xml) else {
+    let Ok(doc) = parse_guarded(xml) else {
         return out;
     };
     for slicer in doc
@@ -162,7 +163,7 @@ pub(crate) fn load_sheet_slicers(
     let Ok(sheet_rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
-    let Ok(rels_doc) = roxmltree::Document::parse(&sheet_rels_xml) else {
+    let Ok(rels_doc) = parse_guarded(&sheet_rels_xml) else {
         return Vec::new();
     };
 
@@ -231,7 +232,7 @@ pub(crate) fn parse_slicer_anchors(
     slicer_caches: &HashMap<String, SlicerCacheInfo>,
     pivot_fields: &PivotCacheFields,
 ) -> Vec<SlicerAnchor> {
-    let Ok(doc) = roxmltree::Document::parse(drawing_xml) else {
+    let Ok(doc) = parse_guarded(drawing_xml) else {
         return Vec::new();
     };
     let mc_ns = "http://schemas.openxmlformats.org/markup-compatibility/2006";

--- a/packages/xlsx/parser/src/styles.rs
+++ b/packages/xlsx/parser/src/styles.rs
@@ -1,5 +1,6 @@
 use crate::parse_color;
 use crate::types::*;
+use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::is_x_ns;
 use ooxml_common::zip::read_zip_string;
 
@@ -12,7 +13,7 @@ pub(crate) fn parse_default_font(archive: &mut crate::XlsxZip) -> (Option<String
     let Ok(xml) = read_zip_string(archive, "xl/styles.xml") else {
         return (None, None);
     };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+    let Ok(doc) = parse_guarded(&xml) else {
         return (None, None);
     };
     let mut font_id: usize = 0;
@@ -60,7 +61,7 @@ pub(crate) fn parse_styles(
     theme_colors: &[String],
 ) -> Result<Styles, String> {
     let xml = read_zip_string(archive, "xl/styles.xml")?;
-    let doc = roxmltree::Document::parse(&xml).map_err(|e| e.to_string())?;
+    let doc = parse_guarded(&xml).map_err(|e| e.to_string())?;
 
     let num_fmts = parse_num_fmts(&doc);
     let fonts = parse_fonts(&doc, theme_colors);

--- a/packages/xlsx/parser/src/table.rs
+++ b/packages/xlsx/parser/src/table.rs
@@ -1,5 +1,6 @@
 use crate::types::*;
 use crate::{parse_cell_ref, resolve_zip_path};
+use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::is_x_ns;
 use ooxml_common::zip::read_zip_string;
 
@@ -55,7 +56,7 @@ pub(crate) fn parse_table_styles_map(
     let Ok(xml) = read_zip_string(archive, "xl/styles.xml") else {
         return map;
     };
-    let Ok(doc) = roxmltree::Document::parse(&xml) else {
+    let Ok(doc) = parse_guarded(&xml) else {
         return map;
     };
     for n in doc.descendants() {
@@ -130,7 +131,7 @@ pub(crate) fn load_sheet_tables(
     let Ok(rels_xml) = read_zip_string(archive, &sheet_rels_path) else {
         return Vec::new();
     };
-    let Ok(rels_doc) = roxmltree::Document::parse(&rels_xml) else {
+    let Ok(rels_doc) = parse_guarded(&rels_xml) else {
         return Vec::new();
     };
 
@@ -153,7 +154,7 @@ pub(crate) fn load_sheet_tables(
         let Ok(xml) = read_zip_string(archive, &table_path) else {
             continue;
         };
-        let Ok(doc) = roxmltree::Document::parse(&xml) else {
+        let Ok(doc) = parse_guarded(&xml) else {
             continue;
         };
         let root = doc.root_element();

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -1,6 +1,7 @@
 import {
   defaultDpr,
   isHTMLCanvas,
+  clampCanvasSize,
   getCachedSvgImageByPath,
   preferVectorBlip,
   decodeRasterOrMetafile,
@@ -234,8 +235,17 @@ export async function renderWorksheetViewport(
   // (improvement plan C4). The inner renderViewport starts with an explicit
   // clearRect + white fill, so nothing depends on the width-assignment's implicit
   // clear; skipping the same-size resize is safe.
-  const bw = Math.round(width * dpr);
-  const bh = Math.round(height * dpr);
+  // Clamp the backing store to browser canvas limits (RB5). A very large viewport
+  // (or high dpr × large viewport, e.g. an extreme zoom) can exceed the per-axis
+  // or total-area cap, at which point the browser silently allocates a smaller-
+  // or-empty buffer and the sheet renders blank. `clampCanvasSize` scales BOTH
+  // axes by one factor (≤ 1) so the aspect ratio is kept; we fold that factor
+  // into the effective dpr, keep the CSS box at the requested size, and the
+  // browser stretches the (slightly lower-res) backing store to fill it.
+  const clamped = clampCanvasSize(width * dpr, height * dpr);
+  const effectiveDpr = clamped.clamped ? dpr * clamped.scale : dpr;
+  const bw = clamped.width;
+  const bh = clamped.height;
   if (target.width !== bw) target.width = bw;
   if (target.height !== bh) target.height = bh;
   // Set CSS display size so the browser renders at 1:1 device pixels (no browser-level scaling).
@@ -253,8 +263,10 @@ export async function renderWorksheetViewport(
   // resize above is skipped the backing store is NOT re-created, so its transform
   // is not reset to identity, and a relative scale() would compound the dpr every
   // frame (progressive zoom). setTransform is idempotent whether or not the store
-  // was reallocated.
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  // was reallocated. Use the effective dpr (folded with any clamp factor) so
+  // drawing fills the clamped backing store; renderViewport gets the same value
+  // so its own dpr-dependent math stays aligned.
+  ctx.setTransform(effectiveDpr, 0, 0, effectiveDpr, 0, 0);
 
-  renderViewport(ctx, ws, styles, viewport, { ...opts, dpr, loadedImages: imageCache });
+  renderViewport(ctx, ws, styles, viewport, { ...opts, dpr: effectiveDpr, loadedImages: imageCache });
 }


### PR DESCRIPTION
## Summary
Second parser-hardening batch (user-confirmed scope RB1-7): malicious/corrupt files must not kill the render. Malicious-input fixtures + neutralization tests per RB, following the #726 pattern.

## RB1 — raster pixel-dimension cap (`b308bdc`)
Header-sniff W×H for PNG/JPEG/GIF/BMP/WebP in new `core/image/raster-dimensions.ts`, wired into `decodeRasterOrMetafile` before `createImageBitmap`: a decode bomb (e.g. 60000×60000 PNG in a few dozen bytes) is rejected pre-decode. Caps in shared `pixel-budget.ts` (`32767` per axis = max canvas axis; `64 MP` = 256 MiB RGBA) — **dib.ts (RB4) now imports the same constants**, so a raster inside a WMF/EMF and a standalone blip are held to identical limits. Fail-open for unrecognized/SVG/truncated headers.

## RB2 — recursion depth guards (`52fb817`)
Shared `ooxml_common::depth::DepthGuard` (MAX_PARSE_DEPTH=64) threaded into all four recursion sites: pptx `parse_sp_tree_node`, xlsx `collect_shapes`, docx `parse_table`↔cell, OMML `parse_omath_nodes`. Over-limit subtrees drop; the document still parses.
**Deeper finding:** `roxmltree::Document::parse` itself recurses on element nesting and overflows a 1 MiB WASM stack ~1000 deep — before any guarded code runs. Added a second layer: `xml_too_deep` (MAX_XML_DEPTH=256), an allocation-free raw-XML depth pre-scan (comment/PI/CDATA/DOCTYPE-aware), wired before the three attacker-facing primary part parses (docx document.xml, pptx slide, xlsx sheet). Program-generated 2000-deep fixtures return without trapping.

## RB5 — clampCanvasSize (`3e35859`)
New `core/canvas/clamp.ts` bounds the backing store to `32767` per axis and `16 MP` area (the tightest — WebKit — ceiling), scaling both axes by one factor (aspect preserved), folded into effective dpr in all 3 renderers so crisp-offset math stays aligned while the CSS box keeps its size. Prevents silent blank canvases on huge pages.

## Gates
cargo fmt/clippy(-D warnings)/test workspace green; build:wasm ×3; root tsc clean; vitest 2153/238 files; ast-grep clean; **VRT all packages non-regression** (pptx 75 / docx 21 / xlsx 67) — the guards are no-ops for every real sample; references untouched.

## Follow-up (noted, non-blocking)
~30 secondary `Document::parse` sites (rels/styles/theme/comments/charts) don't have the raw-XML pre-scan (lower risk; a deep bomb traps at the first deep primary part). A shared `parse_guarded` wrapper would be belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)