### PR TITLE
fix(core/chart): wrap renderChart() in save/restore to stop canvas-state leak

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`renderChart draw-call signature (characterization) > is stable for: area+legend 1`] = `
-"set font=bold 30.6px Calibri, Arial, sans-serif
+"save
+set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
@@ -208,11 +209,13 @@ set font=bold 10px sans-serif
 set fillStyle=#555
 set textAlign=center
 fillText "Month" 284,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+restore
 restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: bubble 1`] = `
-"set font=11px sans-serif
+"save
+set font=11px sans-serif
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
@@ -352,11 +355,13 @@ save
 beginPath
 arc 620,152.24,31.9343,0,6.2832
 fill fs=#4472C4 ga=1
+restore
 restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: clusteredBar+title+legendR+dataLabels+axisTitles 1`] = `
-"set font=10.725px sans-serif
+"save
+set font=10.725px sans-serif
 set font=10px sans-serif
 set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
@@ -509,11 +514,13 @@ fillText "Units" 0,0 fs=#555 font=bold 10px sans-serif al=center bl=middle
 restore
 save
 fillText "Quarter" 279.835,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+restore
 restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: clusteredBarH+dataLabels 1`] = `
-"set font=bold 30.6px Calibri, Arial, sans-serif
+"save
+set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
@@ -713,11 +720,13 @@ fillText "Beta" 529.2,207.2 fs=#333 font=12px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 fillRect 515.2,217.2,10,12 fs=#ED7D31
 set fillStyle=#333
-fillText "Alpha" 529.2,223.2 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Alpha" 529.2,223.2 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: clusteredBarH+valAxisHidden(manual-ish) 1`] = `
-"set textBaseline=middle
+"save
+set textBaseline=middle
 set font=11px sans-serif
 set fillStyle=#555
 set fillStyle=#4472C4
@@ -731,11 +740,13 @@ fillRect 374.9714,178.6033,214.8571,45.6933 fs=#ED7D31
 set fillStyle=#4472C4
 fillRect 31.2,64.37,243.5048,45.6933 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 274.7048,64.37,315.1238,45.6933 fs=#ED7D31"
+fillRect 274.7048,64.37,315.1238,45.6933 fs=#ED7D31
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: combo bar+line secondary 1`] = `
-"set font=11px sans-serif
+"save
+set font=11px sans-serif
 set font=10px sans-serif
 set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
@@ -928,11 +939,13 @@ fillText "Rev" 529.2,207.2 fs=#333 font=12px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 fillRect 515.2,217.2,10,12 fs=#ED7D31
 set fillStyle=#333
-fillText "Margin" 529.2,223.2 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Margin" 529.2,223.2 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: doughnut+legendBottom 1`] = `
-"beginPath
+"save
+beginPath
 arc 332,189.2,136.08,-1.5708,0.3142
 arc 332,189.2,68.04,0.3142,-1.5708
 closePath
@@ -976,11 +989,13 @@ fillText "Q2" 331.8,365.6 fs=#333 font=12px sans-serif al=left bl=middle
 set fillStyle=#CC0000
 fillRect 358.2,359.6,10,12 fs=#CC0000
 set fillStyle=#333
-fillText "Q3" 372.2,365.6 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Q3" 372.2,365.6 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: line+markers+legend+axisTitles+12cats 1`] = `
-"set font=bold 30.6px Calibri, Arial, sans-serif
+"save
+set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
@@ -1409,19 +1424,23 @@ fillText "Value" 0,0 fs=#555 font=bold 10px sans-serif al=center bl=middle
 restore
 save
 fillText "Month" 281.82,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+restore
 restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: no-data 1`] = `
-"set fillStyle=#888
+"save
+set fillStyle=#888
 set font=12px sans-serif
 set textAlign=center
 set textBaseline=middle
-fillText "(no data)" 332,200 fs=#888 font=12px sans-serif al=center bl=middle"
+fillText "(no data)" 332,200 fs=#888 font=12px sans-serif al=center bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: pie+legendR+dataLabels 1`] = `
-"set font=bold 30.6px Calibri, Arial, sans-serif
+"save
+set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
@@ -1469,11 +1488,13 @@ fillText "Q2" 490.8,229.5 fs=#333 font=12px sans-serif al=left bl=middle
 set fillStyle=#A9D18E
 fillRect 476.8,239.5,10,12 fs=#A9D18E
 set fillStyle=#333
-fillText "Q3" 490.8,245.5 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Q3" 490.8,245.5 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: radar+filled+legend 1`] = `
-"set font=bold 30.6px Calibri, Arial, sans-serif
+"save
+set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
@@ -1613,11 +1634,13 @@ lineTo 525.2,237.5
 stroke ss=#ED7D31 lw=1.8 dash=
 set lineWidth=2
 set fillStyle=#333
-fillText "Y" 529.2,237.5 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Y" 529.2,237.5 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: scatter+lineMarker+axisTitles 1`] = `
-"set font=bold 30.6px Calibri, Arial, sans-serif
+"save
+set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
@@ -1851,11 +1874,13 @@ fillText "Y" 0,0 fs=#555 font=bold 10px sans-serif al=center bl=middle
 restore
 save
 fillText "X" 297.4,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+restore
 restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: stackedArea 1`] = `
-"beginPath
+"save
+beginPath
 moveTo 177.3333,286.2856
 lineTo 354.4,243.2667
 lineTo 531.4667,200.2478
@@ -2053,11 +2078,13 @@ fillText "Alpha" 316,36.4 fs=#333 font=12px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 fillRect 364,30.4,10,12 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 378,36.4 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Beta" 378,36.4 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: stackedBar+legendBottom 1`] = `
-"set font=10.385000000000002px sans-serif
+"save
+set font=10.385000000000002px sans-serif
 set font=10px sans-serif
 set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
@@ -2176,11 +2203,13 @@ fillText "Alpha" 298.231,365.6 fs=#333 font=12px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 fillRect 346.231,359.6,10,12 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 360.231,365.6 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Beta" 360.231,365.6 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: stackedBarPct+legendLeft 1`] = `
-"set font=11px sans-serif
+"save
+set font=11px sans-serif
 set font=10px sans-serif
 set textBaseline=middle
 set font=11px sans-serif
@@ -2347,11 +2376,13 @@ fillText "Alpha" 30,172.775 fs=#333 font=12px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 fillRect 16,182.775,10,12 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 30,188.775 fs=#333 font=12px sans-serif al=left bl=middle"
+fillText "Beta" 30,188.775 fs=#333 font=12px sans-serif al=left bl=middle
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: stackedLine+midCat 1`] = `
-"set font=16.2px sans-serif
+"save
+set font=16.2px sans-serif
 set textBaseline=middle
 set strokeStyle=#aaa
 beginPath
@@ -2560,11 +2591,13 @@ lineTo 620,335.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
-fillText "Q3" 620,340.45 fs=#555 font=16.2px sans-serif al=center bl=top"
+fillText "Q3" 620,340.45 fs=#555 font=16.2px sans-serif al=center bl=top
+restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: waterfall 1`] = `
 "save
+save
 set font=15px sans-serif
 set strokeStyle=#e8e8e8
 set lineWidth=0.7
@@ -2670,11 +2703,13 @@ fillText "Start" 152.8,333.6 fs=#666 font=14px sans-serif al=center bl=top
 fillText "Q1" 293.6,333.6 fs=#666 font=14px sans-serif al=center bl=top
 fillText "Q2" 434.4,333.6 fs=#666 font=14px sans-serif al=center bl=top
 fillText "End" 575.2,333.6 fs=#666 font=14px sans-serif al=center bl=top
+restore
 restore"
 `;
 
 exports[`renderChart draw-call signature (characterization) > is stable for: waterfall+valAxisHidden 1`] = `
 "save
+save
 set font=15px sans-serif
 set strokeStyle=#bbb
 beginPath
@@ -2733,5 +2768,6 @@ fillText "Start" 96.8,333.6 fs=#666 font=14px sans-serif al=center bl=top
 fillText "Q1" 253.6,333.6 fs=#666 font=14px sans-serif al=center bl=top
 fillText "Q2" 410.4,333.6 fs=#666 font=14px sans-serif al=center bl=top
 fillText "End" 567.2,333.6 fs=#666 font=14px sans-serif al=center bl=top
+restore
 restore"
 `;

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2547,3 +2547,102 @@ describe('CH15 — chartEx sunburst', () => {
     expect(sweeps[0] / sweeps[1]).toBeCloseTo(2, 1);
   });
 });
+
+// ─── canvas state leak (#766) ───────────────────────────────────────────────
+//
+// renderChart() previously had no top-level save/restore: per-family
+// renderers (pie labels, "(no data)"/default-case text, etc.) set
+// textAlign='center' / textBaseline='middle' and never restored them, so the
+// mutated state leaked into whatever the caller drew next on the same ctx.
+// docx/pptx call renderChart() bare (no wrapping save/restore of their own),
+// so a chart followed by more text on the same page/slide would render that
+// text center-aligned and vertically mis-baselined. xlsx happened to be
+// immune only because its call site already wraps renderChart() in its own
+// save/clip/restore.
+//
+// Unlike the Proxy-based recordingCtx() above (which no-ops save/restore),
+// this mock implements a real state stack so the fix is actually exercised.
+function stackfulMockCtx(): { ctx: CanvasRenderingContext2D; texts: TextCall[] } {
+  const texts: TextCall[] = [];
+  const defaults = {
+    font: '10px sans-serif',
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  let state: Record<string, unknown> = { ...defaults };
+  const stack: Record<string, unknown>[] = [];
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'save':
+          return () => stack.push({ ...state });
+        case 'restore':
+          return () => { const s = stack.pop(); if (s) state = s; };
+        case 'measureText':
+          return (t: string) => ({ width: String(t).length * 6 });
+        case 'fillText':
+          return (text: string, x: number, y: number) =>
+            texts.push({ text, x, y, align: String(state.textAlign), baseline: String(state.textBaseline) });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        default:
+          return () => undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, texts };
+}
+
+describe('canvas state leak (#766) — renderChart restores ctx state', () => {
+  it('restores textAlign/textBaseline/font/fillStyle after a pie chart (which sets them for its outer-ring labels)', () => {
+    const { ctx } = stackfulMockCtx();
+    // Snapshot the exact props renderChart is known to mutate.
+    const before = {
+      textAlign: ctx.textAlign, textBaseline: ctx.textBaseline,
+      font: ctx.font, fillStyle: ctx.fillStyle,
+    };
+    renderChart(ctx, pieCalloutModel(), RECT, 1);
+    expect(ctx.textAlign).toBe(before.textAlign);
+    expect(ctx.textBaseline).toBe(before.textBaseline);
+    expect(ctx.font).toBe(before.font);
+    expect(ctx.fillStyle).toBe(before.fillStyle);
+  });
+
+  it('restores state via the "(no data)" early-return path (empty series)', () => {
+    const { ctx } = stackfulMockCtx();
+    const before = { textAlign: ctx.textAlign, textBaseline: ctx.textBaseline };
+    renderChart(ctx, baseModel({ chartType: 'pie', series: [] }), RECT, 1);
+    expect(ctx.textAlign).toBe(before.textAlign);
+    expect(ctx.textBaseline).toBe(before.textBaseline);
+  });
+
+  it('restores state via the unknown-chart-type default-case path', () => {
+    const { ctx } = stackfulMockCtx();
+    const before = { textAlign: ctx.textAlign, textBaseline: ctx.textBaseline };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberately invalid chartType to hit the default branch
+    renderChart(ctx, baseModel({ chartType: 'bogus' as any, series: [series({ values: [1] })] }), RECT, 1);
+    expect(ctx.textAlign).toBe(before.textAlign);
+    expect(ctx.textBaseline).toBe(before.textBaseline);
+  });
+
+  it('a fillText drawn immediately after renderChart is not center-aligned (regression for the leaked pie-label state)', () => {
+    const { ctx, texts } = stackfulMockCtx();
+    renderChart(ctx, pieCalloutModel(), RECT, 1);
+    // Simulate the caller (docx/pptx) drawing more text right after the chart,
+    // exactly as it would when a chart shares a page/slide with other content.
+    ctx.fillText('Other countries', 10, 500);
+    const after = texts[texts.length - 1];
+    expect(after.text).toBe('Other countries');
+    expect(after.align).toBe('start');
+    expect(after.baseline).toBe('alphabetic');
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -4576,84 +4576,96 @@ export function renderChart(
    */
   ptToPx: number = PT_TO_PX,
 ): void {
-  const { x, y, w, h } = rect;
-  // Only fill the outer chartSpace when chartBg is set; a null means noFill
-  // (transparent) per OOXML, so the underlying slide/sheet shows through.
-  if (chart.chartBg) {
-    ctx.fillStyle = `#${chart.chartBg}`;
-    ctx.fillRect(x, y, w, h);
-  }
+  // The per-family renderers (and the early-return/default text paths below)
+  // mutate shared canvas state — textAlign, textBaseline, font, fillStyle,
+  // etc. — without restoring it. Callers (docx/pptx draw chart shapes inline
+  // with surrounding text; xlsx happens to wrap the call in its own
+  // save/clip/restore) must not observe those mutations afterward. Wrapping
+  // the whole body in a single save/restore here fixes it once for every
+  // caller instead of requiring each call site to remember to do so.
+  ctx.save();
+  try {
+    const { x, y, w, h } = rect;
+    // Only fill the outer chartSpace when chartBg is set; a null means noFill
+    // (transparent) per OOXML, so the underlying slide/sheet shows through.
+    if (chart.chartBg) {
+      ctx.fillStyle = `#${chart.chartBg}`;
+      ctx.fillRect(x, y, w, h);
+    }
 
-  // Explicit chart border — drawn ONLY when the XML declared a paintable
-  // `<c:chartSpace><c:spPr><a:ln><a:solidFill>` (chartBorderColor is null
-  // otherwise; there is no default Excel-style frame). Width comes from
-  // `<a:ln@w>` (EMU → pt → px); absent width falls back to a 1px hairline.
-  if (chart.chartBorderColor) {
-    ctx.save();
-    ctx.strokeStyle = `#${chart.chartBorderColor}`;
-    // `<a:ln>` with no `@w` means width 0 per ECMA-376 §20.1.2.2.24, i.e. invisible;
-    // but Excel renders a fill-without-width line as a ~hairline, so we draw 1px to
-    // match the app rather than dropping a declared border.
-    ctx.lineWidth = chart.chartBorderWidthEmu
-      ? Math.max(0.5, chart.chartBorderWidthEmu / EMU_PER_PT) * ptToPx
-      : 1;
-    // Inset by half the line width so the full stroke stays inside the rect.
-    const lw = ctx.lineWidth;
-    ctx.strokeRect(x + lw / 2, y + lw / 2, w - lw, h - lw);
-    ctx.restore();
-  }
+    // Explicit chart border — drawn ONLY when the XML declared a paintable
+    // `<c:chartSpace><c:spPr><a:ln><a:solidFill>` (chartBorderColor is null
+    // otherwise; there is no default Excel-style frame). Width comes from
+    // `<a:ln@w>` (EMU → pt → px); absent width falls back to a 1px hairline.
+    if (chart.chartBorderColor) {
+      ctx.save();
+      ctx.strokeStyle = `#${chart.chartBorderColor}`;
+      // `<a:ln>` with no `@w` means width 0 per ECMA-376 §20.1.2.2.24, i.e. invisible;
+      // but Excel renders a fill-without-width line as a ~hairline, so we draw 1px to
+      // match the app rather than dropping a declared border.
+      ctx.lineWidth = chart.chartBorderWidthEmu
+        ? Math.max(0.5, chart.chartBorderWidthEmu / EMU_PER_PT) * ptToPx
+        : 1;
+      // Inset by half the line width so the full stroke stays inside the rect.
+      const lw = ctx.lineWidth;
+      ctx.strokeRect(x + lw / 2, y + lw / 2, w - lw, h - lw);
+      ctx.restore();
+    }
 
-  // chartEx box-and-whisker / sunburst carry their data in the structured
-  // `chartexBox` / `chartexSunburst` fields, not the flat `series` array, so the
-  // empty-series "(no data)" guard must not fire for them.
-  const hasChartexData = chart.chartexBox != null || chart.chartexSunburst != null;
-  if (chart.series.length === 0 && !hasChartexData) {
-    ctx.fillStyle = '#888';
-    ctx.font = '12px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('(no data)', x + w / 2, y + h / 2);
-    return;
-  }
-
-  switch (chart.chartType) {
-    case 'clusteredBar':
-    case 'clusteredBarH':
-    case 'stackedBar':
-    case 'stackedBarH':
-    case 'stackedBarPct':
-    case 'stackedBarHPct':
-      renderBarChart(ctx, chart, rect, ptToPx); break;
-    case 'line':
-    case 'stackedLine':
-    case 'stackedLinePct':
-      renderLineChart(ctx, chart, rect, ptToPx); break;
-    case 'area':
-    case 'stackedArea':
-    case 'stackedAreaPct':
-      renderAreaChart(ctx, chart, rect, ptToPx); break;
-    case 'pie':
-      renderPieChart(ctx, chart, rect, false, ptToPx); break;
-    case 'doughnut':
-      renderPieChart(ctx, chart, rect, true, ptToPx); break;
-    case 'radar':
-      renderRadarChart(ctx, chart, rect, ptToPx); break;
-    case 'scatter':
-    case 'bubble':
-      renderScatterChart(ctx, chart, rect, ptToPx); break;
-    case 'waterfall':
-      renderWaterfallChart(ctx, chart, rect); break;
-    case 'stock':
-      renderStockChart(ctx, chart, rect, ptToPx); break;
-    case 'boxWhisker':
-      renderBoxWhiskerChart(ctx, chart, rect, ptToPx); break;
-    case 'sunburst':
-      renderSunburstChart(ctx, chart, rect, ptToPx); break;
-    default:
+    // chartEx box-and-whisker / sunburst carry their data in the structured
+    // `chartexBox` / `chartexSunburst` fields, not the flat `series` array, so the
+    // empty-series "(no data)" guard must not fire for them.
+    const hasChartexData = chart.chartexBox != null || chart.chartexSunburst != null;
+    if (chart.series.length === 0 && !hasChartexData) {
       ctx.fillStyle = '#888';
-      ctx.font = '11px sans-serif';
+      ctx.font = '12px sans-serif';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(`Chart: ${chart.chartType}`, x + w / 2, y + h / 2);
+      ctx.fillText('(no data)', x + w / 2, y + h / 2);
+      return;
+    }
+
+    switch (chart.chartType) {
+      case 'clusteredBar':
+      case 'clusteredBarH':
+      case 'stackedBar':
+      case 'stackedBarH':
+      case 'stackedBarPct':
+      case 'stackedBarHPct':
+        renderBarChart(ctx, chart, rect, ptToPx); break;
+      case 'line':
+      case 'stackedLine':
+      case 'stackedLinePct':
+        renderLineChart(ctx, chart, rect, ptToPx); break;
+      case 'area':
+      case 'stackedArea':
+      case 'stackedAreaPct':
+        renderAreaChart(ctx, chart, rect, ptToPx); break;
+      case 'pie':
+        renderPieChart(ctx, chart, rect, false, ptToPx); break;
+      case 'doughnut':
+        renderPieChart(ctx, chart, rect, true, ptToPx); break;
+      case 'radar':
+        renderRadarChart(ctx, chart, rect, ptToPx); break;
+      case 'scatter':
+      case 'bubble':
+        renderScatterChart(ctx, chart, rect, ptToPx); break;
+      case 'waterfall':
+        renderWaterfallChart(ctx, chart, rect); break;
+      case 'stock':
+        renderStockChart(ctx, chart, rect, ptToPx); break;
+      case 'boxWhisker':
+        renderBoxWhiskerChart(ctx, chart, rect, ptToPx); break;
+      case 'sunburst':
+        renderSunburstChart(ctx, chart, rect, ptToPx); break;
+      default:
+        ctx.fillStyle = '#888';
+        ctx.font = '11px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(`Chart: ${chart.chartType}`, x + w / 2, y + h / 2);
+    }
+  } finally {
+    ctx.restore();
   }
 }

--- a/packages/docx/src/renderer.chart-ctx-leak.test.ts
+++ b/packages/docx/src/renderer.chart-ctx-leak.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import type { ChartModel } from '@silurus/ooxml-core';
+import { __test_renderInlineImage, type DecodedImage } from './renderer';
+import type { LayoutImageSeg } from './line-layout';
+
+/**
+ * Regression test for #766 — the shared core `renderChart()` had no top-level
+ * save/restore, so per-family renderers (e.g. pie-chart outer-ring labels)
+ * left `ctx.textAlign='center'` / `ctx.textBaseline='middle'` set on return.
+ * docx's inline-chart draw site (`renderInlineImage`, renderer.ts ~line 5807)
+ * calls `renderChart()` bare — no wrapping save/restore of its own — so any
+ * text drawn immediately after a chart segment on the same ctx (the next run
+ * on the same line, or a table cell drawn later in the same paint pass) would
+ * inherit the leaked center-alignment/mid-baseline. This was concretely
+ * visible in sample-25: the "Other countries" table cell overlapped its
+ * neighbor because it was drawn center-aligned instead of left-aligned.
+ *
+ * The mock ctx below implements a REAL save/restore stack (unlike a bare
+ * no-op stub) so the fix in `renderChart` — a single top-level
+ * `ctx.save(); try { … } finally { ctx.restore(); }` — is actually exercised.
+ */
+
+interface TextCall { text: string; x: number; y: number; align: string; baseline: string }
+
+function stackfulMockCtx(): { ctx: CanvasRenderingContext2D; texts: TextCall[] } {
+  const texts: TextCall[] = [];
+  const defaults = {
+    font: '10px sans-serif',
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  let state: Record<string, unknown> = { ...defaults };
+  const stack: Record<string, unknown>[] = [];
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'save':
+          return () => stack.push({ ...state });
+        case 'restore':
+          return () => { const s = stack.pop(); if (s) state = s; };
+        case 'measureText':
+          return (t: string) => ({ width: String(t).length * 6 });
+        case 'fillText':
+          return (text: string, x: number, y: number) =>
+            texts.push({ text, x, y, align: String(state.textAlign), baseline: String(state.textBaseline) });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        default:
+          return () => undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, texts };
+}
+
+function pieChartSeg(over: Partial<ChartModel> = {}): LayoutImageSeg {
+  const chart: ChartModel = {
+    chartType: 'pie',
+    title: null,
+    categories: ['Brazil', 'Vietnam', 'Other countries'],
+    series: [{ name: 'Prod', color: null, values: [51500, 28500, 61000] }],
+    showDataLabels: true,
+    valMin: null,
+    valMax: null,
+    catAxisTitle: null,
+    valAxisTitle: null,
+    catAxisHidden: false,
+    valAxisHidden: false,
+    catAxisLineHidden: false,
+    valAxisLineHidden: false,
+    plotAreaBg: null,
+    chartBg: null,
+    showLegend: false,
+    legendPos: null,
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'out',
+    catAxisMajorTickMark: 'out',
+    titleFontSizeHpt: null,
+    titleFontColor: null,
+    titleFontFace: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
+    subtotalIndices: [],
+    ...over,
+  };
+  return {
+    imagePath: '', mimeType: '', widthPt: 300, heightPt: 200,
+    anchor: false, anchorXPt: 0, anchorYPt: 0, anchorXFromMargin: false, anchorYFromPara: false,
+    chart, measuredWidth: 300,
+  };
+}
+
+describe('docx inline chart draw site does not leak canvas state (#766)', () => {
+  it('a fillText issued right after an inline chart segment is left-aligned/alphabetic-baseline, not the chart-internal center/middle', () => {
+    const { ctx, texts } = stackfulMockCtx();
+    const images = new Map<string, DecodedImage>();
+
+    __test_renderInlineImage(ctx, pieChartSeg(), 10, 220, 1, images);
+    // Simulate the very next draw call on the same ctx — e.g. a table cell's
+    // text drawn later in the same paint pass (sample-25's "Other countries").
+    ctx.fillText('Other countries', 10, 500);
+
+    const after = texts[texts.length - 1];
+    expect(after.text).toBe('Other countries');
+    expect(after.align).toBe('start');
+    expect(after.baseline).toBe('alphabetic');
+  });
+
+  it('ctx.textAlign/textBaseline are byte-identical before and after drawing an inline chart segment', () => {
+    const { ctx } = stackfulMockCtx();
+    const images = new Map<string, DecodedImage>();
+    const before = { textAlign: ctx.textAlign, textBaseline: ctx.textBaseline, font: ctx.font, fillStyle: ctx.fillStyle };
+
+    __test_renderInlineImage(ctx, pieChartSeg(), 10, 220, 1, images);
+
+    expect(ctx.textAlign).toBe(before.textAlign);
+    expect(ctx.textBaseline).toBe(before.textBaseline);
+    expect(ctx.font).toBe(before.font);
+    expect(ctx.fillStyle).toBe(before.fillStyle);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6760,6 +6760,21 @@ export const __test_computeTableLayout = (
 ): { colWidths: number[]; tableW: number; rowHeights: number[] } =>
   computeTableLayout(table, contentWPx, state);
 
+/** Exported for the chart-canvas-state-leak regression test (#766): drives the
+ *  exact call site (line ~5807) that invokes the shared core `renderChart`
+ *  for an inline `<c:chart>` segment, so a unit test can assert that a
+ *  `fillText` issued on the SAME ctx right after a chart segment is not left
+ *  center-aligned / mis-baselined by chart-internal state that used to leak
+ *  past `renderChart` (it now wraps its body in save/restore). */
+export const __test_renderInlineImage = (
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  seg: LayoutImageSeg,
+  x: number,
+  baseline: number,
+  scale: number,
+  images: Map<string, DecodedImage>,
+): void => renderInlineImage(ctx, seg, x, baseline, scale, images);
+
 function resolveAnchorBox(
   img: ImageRun,
   state: RenderState,


### PR DESCRIPTION
## Summary
The real root cause of the sample-25 "Othecountries" collision (superseding the withdrawn #766): `renderChart()` had **no top-level save/restore**. Per-family renderers (pie outer-ring labels, the `(no data)` and unknown-chart-type text paths) set `textAlign='center'`/`textBaseline='middle'` and left them set on return. docx and pptx call `renderChart()` bare, so any text drawn on the same ctx right after a chart — a table cell, a following run on the same line — inherited the leaked alignment/baseline, colliding horizontally and shifting ~18px vertically. xlsx was incidentally immune (it wraps the call in save/clip/restore); this formalizes that.

## Fix
Wrap the entire `renderChart()` body (including the early-return `(no data)` path) in `ctx.save(); try { … } finally { ctx.restore(); }`. Pure indentation wrap — no logic changed. One shared fix repairs all three formats.

## Why this, not #766
#766 (measureText trailing-space) was withdrawn: empirical probing of real WebKit/Firefox/Chromium/skia showed no engine trims trailing spaces, so that change was a no-op and the bug reproduced byte-identically with/without it. The collision was a paint-state leak, not a measurement error — verified by intercepting `fillText` (the colliding text was painted with `textAlign=center` leaked from the chart's `"Other countries 35%"` label).

## Verification
- **renderer-signature snapshot**: diff is exclusively one `save`/`restore` per fixture (18/18) — no draw call, coordinate, or style changed. Behavior-preserving except the intended state restoration.
- New tests with a **stackful** mock ctx (the file's existing mocks no-op save/restore, so couldn't catch this): pie / `(no data)` / unknown-type / post-chart `fillText` all assert `textAlign=start`, `textBaseline=alphabetic`. New docx test drives the real inline-chart call site. All fail on revert, pass with the fix.
- Live Storybook render of sample-25: the "Other countries | 61000" row now renders cleanly left-aligned, no overlap.
- VRT: docx 21 / xlsx 8 / pptx 15 pass, zero committed references changed (the "chart followed by text" combination isn't in committed demo fixtures).
- Gates: vitest core 927 + combined 1450 green; core tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)