### PR TITLE
feat(docx): vertical (tbRl) text layout via rotate-layout (§17.6.20)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1660,6 +1660,7 @@ fn parse_section(
         title_page: false,
         even_and_odd_headers: false,
         section_start: None,
+        text_direction: None,
         doc_grid_type: None,
         doc_grid_line_pitch: None,
         doc_grid_char_space: None,
@@ -1690,6 +1691,17 @@ fn parse_section(
     // sections carry their start type on their own SectionBreak marker; the
     // paginator needs the final section's here to resolve the boundary INTO it.
     props.section_start = read_section_break_type(sp);
+
+    // ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93).
+    // The default "lrTb" (horizontal, left-to-right / top-to-bottom) is dropped to
+    // `None` so horizontal documents serialize exactly as before (the field is
+    // `skip_serializing_if = "Option::is_none"`); only a non-default value (most
+    // commonly "tbRl" for vertical Japanese) is carried through to the renderer.
+    if let Some(td) = child_w(sp, "textDirection").and_then(|n| attr_w(n, "val")) {
+        if td != "lrTb" {
+            props.text_direction = Some(td);
+        }
+    }
 
     // ECMA-376 §17.6.5 w:docGrid. When @type=lines|linesAndChars with a
     // linePitch, Word renders each line of text at intervals of linePitch
@@ -10412,6 +10424,34 @@ mod column_tests {
         );
         // Absent <w:type> ⇒ None (paginator falls back to "nextPage").
         assert_eq!(parse(r#"<w:cols w:num="2"/>"#).section_start, None);
+    }
+
+    /// ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93) is
+    /// surfaced on SectionProps so the renderer can rotate the page for vertical
+    /// Japanese. The default "lrTb" is dropped to None so horizontal documents
+    /// keep byte-identical rendering; a non-default value (most commonly "tbRl")
+    /// is carried through.
+    #[test]
+    fn section_props_carries_text_direction() {
+        let parse = |sect: &str| {
+            let xml = format!(r#"<w:sectPr xmlns:w="{ns}">{sect}</w:sectPr>"#, ns = W_NS);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let rel_map: HashMap<String, String> = HashMap::new();
+            parse_section(Some(doc.root_element()), &rel_map).0
+        };
+        // sample-26's vertical newspaper: tbRl carried through verbatim.
+        assert_eq!(
+            parse(r#"<w:textDirection w:val="tbRl"/>"#).text_direction,
+            Some("tbRl".to_string())
+        );
+        // The default horizontal value is dropped so lrTb documents don't emit
+        // the field (byte-identical serialization to the pre-vertical parser).
+        assert_eq!(
+            parse(r#"<w:textDirection w:val="lrTb"/>"#).text_direction,
+            None
+        );
+        // Absent <w:textDirection> ⇒ None (horizontal).
+        assert_eq!(parse(r#"<w:cols w:num="2"/>"#).text_direction, None);
     }
 
     /// ECMA-376 §17.10.1 — header/footer references inherit across sections.

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1692,11 +1692,16 @@ fn parse_section(
     // paginator needs the final section's here to resolve the boundary INTO it.
     props.section_start = read_section_break_type(sp);
 
-    // ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93).
-    // The default "lrTb" (horizontal, left-to-right / top-to-bottom) is dropped to
+    // ECMA-376 §17.6.20 `<w:textDirection w:val>`. Word writes the TRANSITIONAL
+    // ST_TextDirection enum (Part 4 §14.11.7): `lrTb`|`tbRl`|`btLr`|`lrTbV`|
+    // `tbLrV`|`tbRlV` — NOT the Part 1 §17.18.93 Strict set (`tb`|`rl`|`lr`|…).
+    // The default "lrTb" (horizontal, left→right / top→bottom) is dropped to
     // `None` so horizontal documents serialize exactly as before (the field is
-    // `skip_serializing_if = "Option::is_none"`); only a non-default value (most
-    // commonly "tbRl" for vertical Japanese) is carried through to the renderer.
+    // `skip_serializing_if = "Option::is_none"`); any other value (most commonly
+    // "tbRl" for vertical Japanese) is carried through verbatim so the renderer
+    // decides which are vertical (see `isVerticalSection`). The parser does not
+    // validate the enum — an unknown value is carried and the renderer treats it
+    // as horizontal, which is the safe default.
     if let Some(td) = child_w(sp, "textDirection").and_then(|n| attr_w(n, "val")) {
         if td != "lrTb" {
             props.text_direction = Some(td);
@@ -10426,11 +10431,11 @@ mod column_tests {
         assert_eq!(parse(r#"<w:cols w:num="2"/>"#).section_start, None);
     }
 
-    /// ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93) is
-    /// surfaced on SectionProps so the renderer can rotate the page for vertical
-    /// Japanese. The default "lrTb" is dropped to None so horizontal documents
-    /// keep byte-identical rendering; a non-default value (most commonly "tbRl")
-    /// is carried through.
+    /// ECMA-376 §17.6.20 `<w:textDirection w:val>` (TRANSITIONAL ST_TextDirection,
+    /// Part 4 §14.11.7 — the enum Word writes) is surfaced on SectionProps so the
+    /// renderer can rotate the page for vertical Japanese. The default "lrTb" is
+    /// dropped to None so horizontal documents keep byte-identical rendering; any
+    /// other value (most commonly "tbRl") is carried through verbatim.
     #[test]
     fn section_props_carries_text_direction() {
         let parse = |sect: &str| {
@@ -10443,6 +10448,16 @@ mod column_tests {
         assert_eq!(
             parse(r#"<w:textDirection w:val="tbRl"/>"#).text_direction,
             Some("tbRl".to_string())
+        );
+        // Other transitional values (§14.11.7) are carried verbatim too — the
+        // renderer, not the parser, decides which flow vertically.
+        assert_eq!(
+            parse(r#"<w:textDirection w:val="tbLrV"/>"#).text_direction,
+            Some("tbLrV".to_string())
+        );
+        assert_eq!(
+            parse(r#"<w:textDirection w:val="btLr"/>"#).text_direction,
+            Some("btLr".to_string())
         );
         // The default horizontal value is dropped so lrTb documents don't emit
         // the field (byte-identical serialization to the pre-vertical parser).

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -231,6 +231,15 @@ pub struct SectionProps {
     /// "nextPage" (the spec default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub section_start: Option<String>,
+    /// ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93)
+    /// — the section's flow direction. "lrTb" (the default; left-to-right,
+    /// top-to-bottom horizontal) is treated as `None` here so horizontal
+    /// documents keep byte-identical rendering; "tbRl" (top-to-bottom,
+    /// right-to-left — vertical Japanese: glyphs stack downward, lines advance
+    /// right→left) and its relatives are carried so the renderer can rotate the
+    /// page. `None` ⇒ horizontal (lrTb).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_direction: Option<String>,
     /// ECMA-376 §17.6.5 w:docGrid/@w:type ("default" | "lines" |
     /// "linesAndChars" | "snapToChars"). None = default.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -231,13 +231,14 @@ pub struct SectionProps {
     /// "nextPage" (the spec default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub section_start: Option<String>,
-    /// ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93)
-    /// — the section's flow direction. "lrTb" (the default; left-to-right,
-    /// top-to-bottom horizontal) is treated as `None` here so horizontal
-    /// documents keep byte-identical rendering; "tbRl" (top-to-bottom,
-    /// right-to-left — vertical Japanese: glyphs stack downward, lines advance
-    /// right→left) and its relatives are carried so the renderer can rotate the
-    /// page. `None` ⇒ horizontal (lrTb).
+    /// ECMA-376 §17.6.20 `<w:textDirection w:val>` — the section's flow
+    /// direction, using the TRANSITIONAL ST_TextDirection enum Word writes
+    /// (Part 4 §14.11.7: `lrTb`|`tbRl`|`btLr`|`lrTbV`|`tbLrV`|`tbRlV`), NOT the
+    /// Part 1 §17.18.93 Strict set. "lrTb" (the default; horizontal, left→right /
+    /// top→bottom) is treated as `None` here so horizontal documents keep
+    /// byte-identical rendering; "tbRl" (vertical Japanese: glyphs stack downward,
+    /// lines advance right→left) and the other non-default values are carried so
+    /// the renderer can decide which flow vertically. `None` ⇒ horizontal (lrTb).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_direction: Option<String>,
     /// ECMA-376 §17.6.5 w:docGrid/@w:type ("default" | "lines" |

--- a/packages/docx/src/anchor-vertical-physical.test.ts
+++ b/packages/docx/src/anchor-vertical-physical.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { __test_resolveAnchorBox, type RenderState } from './renderer.js';
+import { physicalToLogicalAnchorBox } from './vertical-text.js';
+import type { ImageRun } from './types.js';
+
+// ECMA-376 §17.6.20 (tbRl) + §20.4.3.x — a DrawingML anchor on a VERTICAL page is
+// resolved against the PHYSICAL (un-rotated) page, then projected into the swapped
+// logical layout frame. This pins the CRITICAL fix (PR #770 review): the raw
+// positionH/positionV offsets must NOT be fed unrotated into the logical frame;
+// they resolve physically and map through `physicalToLogicalAnchorBox`, so after
+// the +90° page paint the image lands at Word's physical centroid.
+//
+// Ground truth = private/sample-26.docx + sample-26.pdf (Word landscape vertical
+// newspaper). All numbers are pt (scale=1 ⇒ px==pt):
+//   page: 842 × 595.05 (landscape); physical margins L=56.7 T=70.9 R=56.7 B=70.9
+//   anchor: positionH margin +387.6, positionV margin +327.0; extent 96.2 × 123.0
+//   Word/PDF physical centroid: (492.4, 459.35)
+
+// A vertical RenderState carries the LOGICAL (swapped) geometry PLUS `verticalPhys`
+// (the physical page geometry the anchor path resolves against). Mirror what the
+// baseState writer builds for sample-26. resolveAnchorBox reads only geometry
+// fields, so a minimal cast stand-in suffices (as in anchor-image-relativefrom).
+const PHYS_W = 842;
+const PHYS_H = 595.05;
+const PHYS_ML = 56.7;
+const PHYS_MT = 70.9;
+const PHYS_MR = 56.7;
+const PHYS_MB = 70.9;
+
+const verticalState = {
+  scale: 1,
+  // Logical (swapped) geometry — verticalLayoutSection(sample-26 physical):
+  pageWidth: PHYS_H, // logical width = physical height
+  marginLeft: PHYS_MT, // logical left = physical top
+  marginRight: PHYS_MB, // logical right = physical bottom
+  marginTop: PHYS_MR, // logical top = physical right
+  marginBottom: PHYS_ML, // logical bottom = physical left
+  pageH: PHYS_W, // logical height (px) = physical width
+  verticalCJK: true,
+  verticalPhys: {
+    pageWidth: PHYS_W,
+    pageHeight: PHYS_H,
+    marginLeft: PHYS_ML,
+    marginRight: PHYS_MR,
+    marginTop: PHYS_MT,
+    marginBottom: PHYS_MB,
+    cssWidthPx: PHYS_W,
+  },
+} as unknown as RenderState;
+
+// sample-26's floated image: wrapSquare, positionH/V relativeFrom="margin".
+const sample26Image: ImageRun = {
+  imagePath: 'word/media/image1.png',
+  mimeType: 'image/png',
+  widthPt: 96.2,
+  heightPt: 123.0,
+  anchor: true,
+  wrapMode: 'square',
+  anchorXPt: 387.6,
+  anchorYPt: 327.0,
+  anchorXRelativeFrom: 'margin',
+  anchorYRelativeFrom: 'margin',
+  anchorXFromMargin: false,
+  anchorYFromPara: false,
+  distLeft: 9,
+  distRight: 9,
+  distTop: 0,
+  distBottom: 0,
+};
+
+/** Reconstruct the physical centroid from a resolved LOGICAL anchor box by
+ *  applying the page transform `physical = (cssW − logical.y, logical.x)` to the
+ *  logical box centre. The logical box was produced by physicalToLogicalAnchorBox,
+ *  so this inverts it back to physical space. */
+function physicalCentroid(
+  box: { x: number; y: number; w: number; h: number },
+  cssW: number,
+): { cx: number; cy: number } {
+  const logCx = box.x + box.w / 2;
+  const logCy = box.y + box.h / 2;
+  return { cx: cssW - logCy, cy: logCx };
+}
+
+describe('resolveAnchorBox — vertical (tbRl) physical anchor mapping (§20.4.3.x)', () => {
+  it('lands the sample-26 image at Word/PDF physical centroid (492.4, 459.35)', () => {
+    const box = __test_resolveAnchorBox(sample26Image, verticalState, 0);
+    const { cx, cy } = physicalCentroid(box, PHYS_W);
+    // ±0.5px of the PDF ground truth (Word centroid 492.4, 459.35).
+    expect(cx).toBeCloseTo(492.4, 1);
+    expect(cy).toBeCloseTo(459.35, 1);
+  });
+
+  it('returns the logical-projected box (w↔h swap) so the flow wraps correctly', () => {
+    const box = __test_resolveAnchorBox(sample26Image, verticalState, 0);
+    // Physical TL is (ML+posH, MT+posV) = (444.3, 397.9); project to logical.
+    const expected = physicalToLogicalAnchorBox(
+      PHYS_ML + 387.6,
+      PHYS_MT + 327.0,
+      96.2,
+      123.0,
+      PHYS_W,
+    );
+    expect(box.x).toBeCloseTo(expected.x, 4);
+    expect(box.y).toBeCloseTo(expected.y, 4);
+    expect(box.w).toBeCloseTo(expected.w, 4); // = physical height 123.0
+    expect(box.h).toBeCloseTo(expected.h, 4); // = physical width 96.2
+  });
+
+  it('rotates dist* padding one quarter-turn (physical T/B ↦ logical L/R)', () => {
+    const box = __test_resolveAnchorBox(sample26Image, verticalState, 0);
+    // physical distTop/distBottom (0) ↦ logical dl/dr; physical distRight/distLeft
+    // (9) ↦ logical dt/db.
+    expect(box.dl).toBe(0);
+    expect(box.dr).toBe(0);
+    expect(box.dt).toBe(9);
+    expect(box.db).toBe(9);
+  });
+});

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -12,7 +12,7 @@ import {
   type MathRenderer,
 } from '@silurus/ooxml-core';
 import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerRequest, WorkerResponse, DocComment, DocNote } from './types';
-import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache } from './renderer';
+import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache, physicalPageSizePt } from './renderer';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
 import type {
@@ -328,10 +328,14 @@ export class DocxDocument {
     const pages = this._getPages();
     const clamped = Math.max(0, Math.min(pageIndex, pages.length - 1));
     const g = pages[clamped]?.[0]?.sectionGeom;
-    return {
-      widthPt: g?.pageWidth ?? this._document.section.pageWidth,
-      heightPt: g?.pageHeight ?? this._document.section.pageHeight,
-    };
+    // The stamped `sectionGeom` is in LOGICAL dims for a vertical (tbRl) section
+    // (pagination runs on the swapped page); `physicalPageSizePt` un-swaps it so
+    // this reports the visible PHYSICAL page box (identity for horizontal docs).
+    return physicalPageSizePt(
+      this._document.section,
+      g?.pageWidth ?? this._document.section.pageWidth,
+      g?.pageHeight ?? this._document.section.pageHeight,
+    );
   }
 
   renderPage(

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -10,7 +10,7 @@
 import init, { DocxArchive } from './wasm/docx_parser.js';
 import { decodeDataUrl, preloadGoogleFonts } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
-import { paginateDocument, renderDocumentToCanvas } from './renderer';
+import { paginateDocument, renderDocumentToCanvas, physicalPageSizePt } from './renderer';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
 import type { RenderWorkerRequest, RenderWorkerResponse, DocumentMeta } from './worker-protocol';
@@ -106,10 +106,14 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       const model = doc;
       const pageSizes = pages.map((els) => {
         const g = els[0]?.sectionGeom;
-        return {
-          widthPt: g?.pageWidth ?? model.section.pageWidth,
-          heightPt: g?.pageHeight ?? model.section.pageHeight,
-        };
+        // A vertical (tbRl) section paginates on the SWAPPED logical geometry, so
+        // un-swap the stamped dims back to the PHYSICAL page box the meta reports
+        // (identity for horizontal docs).
+        return physicalPageSizePt(
+          model.section,
+          g?.pageWidth ?? model.section.pageWidth,
+          g?.pageHeight ?? model.section.pageHeight,
+        );
       });
       const meta: DocumentMeta = {
         pageCount: pages.length,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -140,7 +140,11 @@ import {
   emphasisMarkCenters,
   emphasisMarkGeometry,
 } from './emphasis-mark.js';
-import { drawVerticalRun, drawUprightBox } from './vertical-text.js';
+import {
+  drawVerticalRun,
+  drawUprightBox,
+  physicalToLogicalAnchorBox,
+} from './vertical-text.js';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -330,6 +334,26 @@ export interface RenderState {
    *  false ⇒ horizontal (lrTb) — the whole layout + paint path is byte-identical
    *  to the pre-vertical renderer. */
   verticalCJK?: boolean;
+  /** ECMA-376 §17.6.20 + §20.4.3.x — the PHYSICAL page geometry for a vertical
+   *  (tbRl) page, in the SAME units the rest of RenderState uses (margins/page
+   *  size in pt; `cssWidthPx` in px). Present only when `verticalCJK` is set.
+   *  A DrawingML anchor's `<wp:positionH/V>` is resolved against the PHYSICAL page
+   *  (the drawing layer is placed independently of the text-flow rotation), so the
+   *  anchor path builds a PHYSICAL-geometry proxy RenderState from this and maps
+   *  the resolved physical box into the swapped logical frame via
+   *  {@link physicalToLogicalAnchorBox}. The four margins are the physical
+   *  pgMar values (already the body inset for the top/bottom, matching
+   *  `bodyMarginInsetPt`). `cssWidthPx` = physical page width in px = the page
+   *  transform's `translate(cssWidth, 0)` term. Absent ⇒ horizontal. */
+  verticalPhys?: {
+    pageWidth: number;
+    pageHeight: number;
+    marginLeft: number;
+    marginRight: number;
+    marginTop: number;
+    marginBottom: number;
+    cssWidthPx: number;
+  };
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -1014,6 +1038,24 @@ export async function renderDocumentToCanvas(
     // (CJK) glyphs so they stand up inside the +90°-rotated page (see the page
     // transform above and `drawVerticalRun`).
     verticalCJK: vertical,
+    // ECMA-376 §20.4.3.x — physical page geometry for resolving DrawingML anchors
+    // against the un-rotated physical page (see `verticalPhys` docs and
+    // `resolveAnchorBox`). `sec` here is the LOGICAL (swapped) section, so un-swap
+    // it back to physical: physical left/top/right/bottom margin = logical
+    // bottom/left/top/right (the inverse of `verticalLayoutSection`). Top/bottom
+    // are stored as body insets (`bodyMarginInsetPt`) to match the horizontal
+    // path's `marginTop`/`marginBottom` (§17.6.11 text-margin = body edge).
+    verticalPhys: vertical
+      ? {
+          pageWidth: physPageWidth,
+          pageHeight: physPageHeight,
+          marginLeft: sec.marginBottom,
+          marginRight: sec.marginTop,
+          marginTop: bodyMarginInsetPt(sec.marginLeft),
+          marginBottom: bodyMarginInsetPt(sec.marginRight),
+          cssWidthPx: cssWidth,
+        }
+      : undefined,
   };
 
   // ECMA-376 §17.10.1 — per-section header/footer selection. resolvePageHeader and
@@ -6966,7 +7008,32 @@ export const __test_renderInlineImage = (
   baseline: number,
   scale: number,
   images: Map<string, DecodedImage>,
-): void => renderInlineImage(ctx, seg, x, baseline, scale, images);
+  vertical = false,
+): void => renderInlineImage(ctx, seg, x, baseline, scale, images, vertical);
+
+/** ECMA-376 §17.6.20 + §20.4.3.x — a RenderState view whose page/margin geometry
+ *  is the PHYSICAL (un-rotated) page, used to resolve a DrawingML anchor's
+ *  `<wp:positionH/V>` against the physical page for a vertical (tbRl) section
+ *  (Word places the drawing layer independently of the text-flow rotation). Only
+ *  the geometry fields `xContainer`/`yContainer`/`resolveAnchorX`/`resolveAnchorY`
+ *  read are overridden (scale, page size, margins, `pageH`); everything else is
+ *  the live logical state. Callers map the resolved physical box back into the
+ *  logical layout frame with {@link physicalToLogicalAnchorBox}. */
+function physicalAnchorState(state: RenderState): RenderState {
+  const p = state.verticalPhys;
+  if (!p) return state;
+  return {
+    ...state,
+    pageWidth: p.pageWidth,
+    marginLeft: p.marginLeft,
+    marginRight: p.marginRight,
+    marginTop: p.marginTop,
+    marginBottom: p.marginBottom,
+    // yContainer reads `pageH` (px) for the page-relative bands; the physical
+    // page height in px is `pageHeight(pt) * scale`.
+    pageH: p.pageHeight * state.scale,
+  };
+}
 
 function resolveAnchorBox(
   img: ImageRun,
@@ -6976,6 +7043,10 @@ function resolveAnchorBox(
   const scale = state.scale;
   const w = img.widthPt * scale;
   const h = img.heightPt * scale;
+  const dl = (img.distLeft   ?? 0) * scale;
+  const dr = (img.distRight  ?? 0) * scale;
+  const dt = (img.distTop    ?? 0) * scale;
+  const db = (img.distBottom ?? 0) * scale;
   // ECMA-376 §20.4.3.1 wp:align — when positionH/V carry <wp:align>, the
   // renderer aligns the image within its relativeFrom container instead of
   // using the (discarded) posOffset. Mirrors resolveShapeBox (the ShapeRun
@@ -6990,6 +7061,32 @@ function resolveAnchorBox(
   // anchorXFromMargin / anchorYFromPara hints still gate page-vs-margin when
   // no raw relativeFrom is present. When align is absent, resolveAnchorX/Y
   // fall back to the offset path.
+  if (state.verticalPhys) {
+    // ECMA-376 §17.6.20 (tbRl): the anchor's positionH/V are PHYSICAL-page
+    // relative (the drawing layer is not rotated with the text flow). Resolve
+    // the box in physical space, then project it into the swapped logical layout
+    // frame the body text flows in — so the float-exclusion band and the
+    // (drawUprightBox-un-swapped) painted image share one geometry. paraBaseY is
+    // a LOGICAL flow coordinate and only feeds paragraph-relative positionV; the
+    // vertical samples in scope anchor page/margin-relative, so it is not
+    // physical-mapped here (paragraph-relative vertical anchors in tbRl are a
+    // follow-up — see the vertical-text stage-1 scope note).
+    const phys = physicalAnchorState(state);
+    const px = resolveAnchorX(
+      img.anchorXAlign, img.anchorXFromMargin ?? false, img.anchorXPt ?? 0, w, phys,
+      img.anchorXRelativeFrom ?? null, null, null,
+    );
+    const py = resolveAnchorY(
+      img.anchorYAlign, img.anchorYFromPara ?? false, img.anchorYPt ?? 0, h, paraBaseY, phys,
+      img.anchorYRelativeFrom ?? null, null, null,
+    );
+    const box = physicalToLogicalAnchorBox(px, py, w, h, state.verticalPhys.cssWidthPx);
+    // Rotate the dist* padding one quarter-turn with the box: physical top/bottom
+    // become logical left/right; physical right/left become logical top/bottom
+    // (logical y runs opposite physical x). Symmetric wrapSquare dist is common,
+    // but rotate the labels so asymmetric dist stays correct.
+    return { x: box.x, y: box.y, w: box.w, h: box.h, dl: dt, dr: db, dt: dr, db: dl };
+  }
   const x = resolveAnchorX(
     img.anchorXAlign, img.anchorXFromMargin ?? false, img.anchorXPt ?? 0, w, state,
     img.anchorXRelativeFrom ?? null, null, null,
@@ -6998,16 +7095,7 @@ function resolveAnchorBox(
     img.anchorYAlign, img.anchorYFromPara ?? false, img.anchorYPt ?? 0, h, paraBaseY, state,
     img.anchorYRelativeFrom ?? null, null, null,
   );
-  return {
-    x,
-    y,
-    w,
-    h,
-    dl: (img.distLeft   ?? 0) * scale,
-    dr: (img.distRight  ?? 0) * scale,
-    dt: (img.distTop    ?? 0) * scale,
-    db: (img.distBottom ?? 0) * scale,
-  };
+  return { x, y, w, h, dl, dr, dt, db };
 }
 
 /** ECMA-376 §20.4.3.2 / §20.4.3.5 — a `<wp:positionV>` `relativeFrom` value

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -144,6 +144,7 @@ import {
   drawVerticalRun,
   drawUprightBox,
   physicalToLogicalAnchorBox,
+  verticalTextLayerPlacement,
 } from './vertical-text.js';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
@@ -371,6 +372,13 @@ export interface DocxTextRunInfo {
   fontSize: number;
   /** CSS `font` shorthand used for canvas drawing (e.g. `"bold 16px Arial"`). */
   font: string;
+  /** ECMA-376 §17.6.20 (tbRl) — when the page is vertical the canvas is the
+   *  physical landscape page rotated +90° at paint, so this run's `x`/`y` are the
+   *  PHYSICAL top-left the overlay span must sit at, and `transform` is the CSS
+   *  rotation (`"rotate(90deg)"`, applied about the span's top-left) that lays the
+   *  horizontal DOM span along the drawn (rotated) glyph run. Absent for
+   *  horizontal pages (the span is placed at `x`/`y` untransformed). */
+  transform?: string;
 }
 
 export interface RenderDocumentOptions {
@@ -5771,14 +5779,23 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         }
 
         if (state.onTextRun && s.text) {
+          // ECMA-376 §17.6.20 (tbRl) — `x`/`state.y` are LOGICAL flow coords; on a
+          // vertical page the overlay DOM lives on the physical (rotated) canvas,
+          // so project the logical top-left to physical and hand the span the +90°
+          // rotation. `verticalTextLayerPlacement` returns null on horizontal pages
+          // (the span stays at the logical `x`/`y`, byte-identical to before).
+          const place = verticalTextLayerPlacement(
+            x, state.y, state.verticalPhys?.cssWidthPx ?? 0, !!state.verticalCJK,
+          );
           state.onTextRun({
             text: s.text,
-            x,
-            y: state.y,
+            x: place ? place.left : x,
+            y: place ? place.top : state.y,
             w: spanW,
             h: lineH,
             fontSize: effSizePx,
             font: ctx.font,
+            transform: place?.transform,
           });
         }
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5440,7 +5440,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         continue;
       }
       if ('imagePath' in seg) {
-        if (!dryRun) renderInlineImage(ctx, seg as LayoutImageSeg, x, baseline, scale, state.images);
+        if (!dryRun) renderInlineImage(ctx, seg as LayoutImageSeg, x, baseline, scale, state.images, !!state.verticalCJK);
         x += seg.measuredWidth;
         continue;
       }
@@ -6020,23 +6020,40 @@ function renderInlineImage(
   baseline: number,
   scale: number,
   images: Map<string, DecodedImage>,
+  vertical: boolean,
 ): void {
   // Anchor images are skipped during layout (measuredWidth=0, not added to line.segments)
   // and are drawn later by renderAnchorImages — so this function only handles inline images.
   if (seg.anchor) return;
   const w = seg.widthPt * scale;
   const h = seg.heightPt * scale;
+  const boxY = baseline - h;
+  // ECMA-376 §17.6.20 (tbRl) — an inline image/chart is a graphic, not text, so it
+  // stands UPRIGHT inside the +90°-rotated page. `drawUprightBox` counter-rotates
+  // the flow box (logical `x,boxY,w,h`) −90° about its centre and invokes the
+  // callback with the un-swapped upright rect, so the image/chart is painted right
+  // way up. On horizontal pages the callback runs with the box unchanged (no
+  // rotation), byte-identical to the pre-vertical inline draw.
+  const paint = (
+    draw: (dx: number, dy: number, dw: number, dh: number) => void,
+  ): void => {
+    if (vertical) drawUprightBox(ctx, x, boxY, w, h, draw);
+    else draw(x, boxY, w, h);
+  };
   // ECMA-376 §21.2 inline chart: paint through the shared core chart renderer
   // (the same entry point pptx/xlsx use), at the inline box's top-left. `scale`
   // is px-per-pt in this renderer, which is exactly the `ptToPx` renderChart
   // wants to scale the chart's point-sized fonts/axes — so pass it straight.
   if (seg.chart) {
-    renderChart(ctx as CanvasRenderingContext2D, seg.chart, { x, y: baseline - h, w, h }, scale);
+    const chart = seg.chart;
+    paint((dx, dy, dw, dh) =>
+      renderChart(ctx as CanvasRenderingContext2D, chart, { x: dx, y: dy, w: dw, h: dh }, scale),
+    );
     return;
   }
   const bmp = images.get(imageKey(seg.imagePath, seg.colorReplaceFrom));
   if (!bmp) return;
-  drawImageCropped(ctx, bmp, seg.srcRect, x, baseline - h, w, h);
+  paint((dx, dy, dw, dh) => drawImageCropped(ctx, bmp, seg.srcRect, dx, dy, dw, dh));
 }
 
 /** Collect and draw anchor images with wrapMode='none' (or unspecified).

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -140,6 +140,7 @@ import {
   emphasisMarkCenters,
   emphasisMarkGeometry,
 } from './emphasis-mark.js';
+import { drawVerticalRun, drawUprightBox } from './vertical-text.js';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: '#FFFF00', cyan: '#00FFFF', green: '#00FF00', magenta: '#FF00FF',
@@ -320,6 +321,15 @@ export interface RenderState {
    *  and replays them after the whole page's flow, so front floats land on top.
    *  `null`/absent ⇒ draw in place (headers/footers and measurement passes). */
   deferFront?: Array<() => void> | null;
+  /** ECMA-376 §17.6.20 vertical writing (tbRl). When true the page is laid out
+   *  in a SWAPPED logical coordinate space (logical width = physical page height)
+   *  and the whole page paint is rotated +90° into physical space by
+   *  {@link renderDocumentToCanvas}; the glyph-draw path then counter-rotates each
+   *  upright (CJK) glyph −90° about its own centre so ideographs stand upright
+   *  while Latin/digits stay sideways (correct for vertical Japanese). Absent /
+   *  false ⇒ horizontal (lrTb) — the whole layout + paint path is byte-identical
+   *  to the pre-vertical renderer. */
+  verticalCJK?: boolean;
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -746,6 +756,74 @@ export async function preloadImages(
  */
 const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
 
+/** True when a section is set to vertical writing (ECMA-376 §17.6.20 tbRl:
+ *  glyphs stack top-to-bottom, lines advance right-to-left). Vertical variants
+ *  that Word also defines (`tbLr`, `lrV`, `tbRlV`) are treated the same for
+ *  layout purposes here; only `tbRl` appears in the vertical-Japanese samples.
+ *  Horizontal (`lrTb`, dropped to null by the parser) ⇒ false. */
+function isVerticalSection(s: SectionProps): boolean {
+  const td = s.textDirection;
+  return td === 'tbRl' || td === 'tbLr' || td === 'tbRlV' || td === 'lrV';
+}
+
+/** Map a vertical (tbRl) section's PHYSICAL page geometry to the SWAPPED LOGICAL
+ *  geometry the horizontal layout engine lays the page out in: logical width =
+ *  physical height, and the four margins rotate one quarter-turn so the logical
+ *  layout, once the page paint is rotated +90° back into physical space, lands
+ *  the margins on the correct physical edges (§17.6.11). With the page transform
+ *  `physical = (pageW_phys − logical.y, logical.x)`:
+ *    logical.marginLeft  (flow start / column top)  → physical TOP     margin
+ *    logical.marginTop   (before the first line)     → physical RIGHT   margin
+ *    logical.marginRight (after the last line)        → physical LEFT    margin
+ *    logical.marginBottom (flow end / column bottom)  → physical BOTTOM  margin
+ *  Non-geometry fields (docGrid, columns, textDirection, …) are preserved so the
+ *  logical layout keeps the section's grid pitch, columns and vertical flag. */
+function verticalLayoutSection(phys: SectionProps): SectionProps {
+  return {
+    ...phys,
+    pageWidth: phys.pageHeight,
+    pageHeight: phys.pageWidth,
+    marginLeft: phys.marginTop,
+    marginTop: phys.marginRight,
+    marginRight: phys.marginBottom,
+    marginBottom: phys.marginLeft,
+    // header/footer distances follow the top/bottom margins into the logical
+    // top/bottom (left/right in physical); vertical docs in scope carry no
+    // header/footer so this is a best-effort mapping, not yet exercised.
+    headerDistance: phys.headerDistance,
+    footerDistance: phys.footerDistance,
+  };
+}
+
+/** Return a shallow copy of `doc` with its body-level section (and any per-body
+ *  sectionBreak geometry) swapped to the vertical LOGICAL geometry, so the
+ *  pagination + layout engine — which reads `doc.section` and per-element
+ *  `sectionGeom` — organises the page as a rotated horizontal page. Only invoked
+ *  when the body section is vertical; horizontal docs are returned untouched
+ *  (referential identity), keeping the horizontal path byte-identical. */
+function verticalLayoutDoc(doc: DocxDocumentModel): DocxDocumentModel {
+  if (!isVerticalSection(doc.section)) return doc;
+  return { ...doc, section: verticalLayoutSection(doc.section) };
+}
+
+/** Map a page's stamped `sectionGeom` width/height back to PHYSICAL page size.
+ *  Pagination for a vertical (tbRl) section runs on the SWAPPED logical geometry
+ *  (`verticalLayoutDoc`), so a page's stamped `pageWidth`/`pageHeight` are the
+ *  LOGICAL dims (width = physical height). Callers that report the visible page
+ *  box (e.g. `DocxDocument.pageSize`, the worker's `pageSizes` meta, a scroll
+ *  viewer's spacer) want the PHYSICAL size, so this un-swaps for vertical sections
+ *  and is identity for horizontal ones. `section` is the body-level section (its
+ *  `textDirection` decides the flow); `w`/`h` are the page's stamped dims. */
+export function physicalPageSizePt(
+  section: SectionProps,
+  w: number,
+  h: number,
+): { widthPt: number; heightPt: number } {
+  return isVerticalSection(section)
+    ? { widthPt: h, heightPt: w }
+    : { widthPt: w, heightPt: h };
+}
+
 export async function renderDocumentToCanvas(
   doc: DocxDocumentModel,
   canvas: HTMLCanvasElement | OffscreenCanvas,
@@ -771,7 +849,15 @@ export async function renderDocumentToCanvas(
   // The pagination fallback (paginateWithHeaderFooterReserve) needs this ctx.
   const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   const kinsoku = resolveKinsokuRules(doc.settings);
-  const pages = opts.prebuiltPages ?? paginateWithHeaderFooterReserve(doc, ctx, doc.fontFamilyClasses ?? {}, kinsoku, doc.footnotes ?? []);
+  // ECMA-376 §17.6.20 — for a vertical (tbRl) section the page is laid out in a
+  // SWAPPED logical space (logical width = physical page height) and rotated +90°
+  // into physical space at paint. `layoutDoc` carries the swapped geometry through
+  // pagination + per-page section resolution; horizontal docs get `doc` unchanged
+  // (referential identity ⇒ byte-identical). The vertical flag is read from the
+  // ORIGINAL section (the swap preserves textDirection).
+  const vertical = isVerticalSection(doc.section);
+  const layoutDoc = verticalLayoutDoc(doc);
+  const pages = opts.prebuiltPages ?? paginateWithHeaderFooterReserve(layoutDoc, ctx, layoutDoc.fontFamilyClasses ?? {}, kinsoku, layoutDoc.footnotes ?? []);
   const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
   const elements = pages[pageIndex] ?? pages[0] ?? [];
 
@@ -784,12 +870,25 @@ export async function renderDocumentToCanvas(
   // rails, so only the page-box geometry needs the per-page swap here. For a
   // single-section document `geom` equals `doc.section`, so `sec === doc.section` in
   // value — byte-identical output.
-  const pageGeom = resolvePageSection(pages, pageIndex, doc).geom;
-  const sec: SectionProps = { ...doc.section, ...pageGeom };
+  // `sec` is the LOGICAL section the body/header/footer are laid out in: for a
+  // vertical page that is the swapped geometry (from `layoutDoc`), for horizontal
+  // it equals the physical section. All RenderState geometry below (contentX/W,
+  // margins, pageWidth, docGrid) reads `sec`, so the entire layout is expressed
+  // in logical coordinates and the page transform maps it to physical space.
+  const pageGeom = resolvePageSection(pages, pageIndex, layoutDoc).geom;
+  const sec: SectionProps = { ...layoutDoc.section, ...pageGeom };
 
-  const cssWidth = opts.width ?? sec.pageWidth * PT_TO_PX;
-  const scale = cssWidth / sec.pageWidth;  // px per pt
-  const cssHeight = sec.pageHeight * scale;
+  // The CANVAS is sized to the PHYSICAL page (visible landscape page for tbRl):
+  // physical width = logical height, physical height = logical width. `scale`
+  // (px per pt) is isotropic, so the logical layout — whose logical width in px
+  // is `sec.pageWidth * scale = physicalHeight * scale = cssHeight` — maps 1:1
+  // onto the rotated physical box. For horizontal pages physW/H equal sec's and
+  // this is the pre-vertical computation unchanged.
+  const physPageWidth = vertical ? sec.pageHeight : sec.pageWidth;
+  const physPageHeight = vertical ? sec.pageWidth : sec.pageHeight;
+  const cssWidth = opts.width ?? physPageWidth * PT_TO_PX;
+  const scale = cssWidth / physPageWidth;  // px per pt
+  const cssHeight = physPageHeight * scale;
 
   // Clamp the backing store to browser canvas limits (RB5). A pathological page
   // size (or a large dpr × page size) can exceed the per-axis / total-area cap,
@@ -815,6 +914,19 @@ export async function renderDocumentToCanvas(
   ctx.scale(effectiveDpr, effectiveDpr);
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(0, 0, cssWidth, cssHeight);
+
+  // ECMA-376 §17.6.20 (tbRl): rotate the whole page paint +90° so the logical
+  // horizontal layout (built in the swapped `sec`) lands in physical vertical
+  // space. The map is `physical = (cssWidth − logical.y, logical.x)`
+  // (`translate(cssWidth, 0)` then `rotate(+90°)`): logical +x (character flow)
+  // → physical +y (down the column), logical +y (line stacking) → physical −x
+  // (columns advance right→left). The white background above stays in physical
+  // space (drawn before the rotate). Glyphs are counter-rotated per-glyph in the
+  // draw path (`state.verticalCJK`) so CJK ideographs stand upright.
+  if (vertical) {
+    ctx.translate(cssWidth, 0);
+    ctx.rotate(Math.PI / 2);
+  }
 
   const images = await preloadImages(doc, opts.fetchImage);
   // A newer render of this canvas started while we awaited image decode — stop
@@ -847,7 +959,12 @@ export async function renderDocumentToCanvas(
     contentX: sec.marginLeft * scale,
     contentW: (sec.pageWidth - sec.marginLeft - sec.marginRight) * scale,
     y: bodyTopPt * scale,
-    pageH: cssHeight,
+    // `pageH` is the LOGICAL page height in px (`sec.pageHeight * scale`). For a
+    // horizontal page that equals `cssHeight`; for a vertical page the logical
+    // height is the physical WIDTH, so it equals `cssWidth`. Using the logical
+    // height keeps the body-flow / footnote / bottom-margin math in the same
+    // (logical) coordinate space the page transform maps to physical.
+    pageH: sec.pageHeight * scale,
     defaultColor: opts.defaultTextColor ?? '#000000',
     pageIndex,
     totalPages,
@@ -877,6 +994,10 @@ export async function renderDocumentToCanvas(
     onTextRun: opts.onTextRun,
     showTrackChanges: opts.showTrackChanges ?? true,
     noteNumbers,
+    // ECMA-376 §17.6.20 — when set, the glyph-draw path counter-rotates upright
+    // (CJK) glyphs so they stand up inside the +90°-rotated page (see the page
+    // transform above and `drawVerticalRun`).
+    verticalCJK: vertical,
   };
 
   // ECMA-376 §17.10.1 — per-section header/footer selection. resolvePageHeader and
@@ -2657,12 +2778,20 @@ function paginateWithHeaderFooterReserve(
 export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[][] {
   const ctx = new OffscreenCanvas(1, 1).getContext('2d');
   if (!ctx) return [doc.body];
+  // ECMA-376 §17.6.20 — a vertical (tbRl) section is laid out in the SWAPPED
+  // logical geometry (see `verticalLayoutDoc`), so pagination — which stamps each
+  // page's `sectionGeom` — must run on the swapped section. `renderDocumentToCanvas`
+  // reads that stamped geometry back through `resolvePageSection`, so paginating on
+  // the swapped doc here keeps the two passes consistent whether the pages are
+  // prebuilt (this path) or paginated inline. Horizontal docs are unchanged
+  // (referential identity).
+  const layoutDoc = verticalLayoutDoc(doc);
   return paginateWithHeaderFooterReserve(
-    doc,
+    layoutDoc,
     ctx,
-    doc.fontFamilyClasses ?? {},
-    resolveKinsokuRules(doc.settings),
-    doc.footnotes ?? [],
+    layoutDoc.fontFamilyClasses ?? {},
+    resolveKinsokuRules(layoutDoc.settings),
+    layoutDoc.footnotes ?? [],
   );
 }
 
@@ -5151,7 +5280,15 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // shifted by lvlJc (§17.9.8) so a "right" level period-aligns its right
           // edge at firstLineX. The body was advanced past the marker above
           // (numBodyOffset).
-          ctx.fillText(markerDisplayText(para.numbering!), lineLeft + indFirst + markerJcShiftPx, baseline);
+          const markerText = markerDisplayText(para.numbering!);
+          const markerX = lineLeft + indFirst + markerJcShiftPx;
+          if (state.verticalCJK) {
+            // §17.6.20 (tbRl) — draw the bullet/number upright inside the rotated
+            // page, same per-glyph counter-rotation as body glyphs.
+            drawVerticalRun(ctx, markerText, markerX, baseline, numFontSize, 0);
+          } else {
+            ctx.fillText(markerText, markerX, baseline);
+          }
         }
       }
     }
@@ -5393,7 +5530,24 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         //      `justifiedPiecePositions` slice-at-gaps path.
         //   3. Neither: a single fillText (the common path).
         const segGridDelta = gridSegDeltaPx(s.text, drawGridDeltaPx);
-        if (segGridDelta !== 0) {
+        if (state.verticalCJK) {
+          // ECMA-376 §17.6.20 (tbRl) — the run flows DOWN the column (logical
+          // +x). Draw each glyph advancing by its measured horizontal width plus
+          // the per-cell grid delta, counter-rotating upright (CJK) glyphs so
+          // they stand up inside the +90°-rotated page while Latin/digits stay
+          // sideways. The docGrid cell delta (segGridDelta, non-zero only on a
+          // pure-EA segment) becomes the vertical inter-glyph pitch; the
+          // horizontal-only justify slicing (cases below) does not apply in
+          // vertical stage-1 (the sample's columns are start-aligned).
+          drawVerticalRun(
+            ctx,
+            s.text,
+            x,
+            baseline + yOffset,
+            effSizePx,
+            segGridDelta !== 0 ? drawGridDeltaPx : 0,
+          );
+        } else if (segGridDelta !== 0) {
           const cps = [...s.text]; // code points (handles surrogate pairs)
           // Draw each CONTIGUOUS piece (sliced only at justify gaps) as ONE
           // contextually-shaped `fillText`, with the per-EA-glyph grid delta
@@ -5892,7 +6046,15 @@ function renderAnchorImages(
     // does not displace text and is not displaced by other floats), so dist* is
     // unused here.
     const { x: pageX, y: pageY, w, h } = resolveAnchorBox(img, state, paragraphTopPx);
-    drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, pageX, pageY, w, h);
+    if (state.verticalCJK) {
+      // §17.6.20 (tbRl) — an anchored image is not text: keep it UPRIGHT inside
+      // the +90°-rotated page by counter-rotating about its box centre.
+      drawUprightBox(state.ctx, pageX, pageY, w, h, (dx, dy, dw, dh) =>
+        drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, dx, dy, dw, dh),
+      );
+    } else {
+      drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, pageX, pageY, w, h);
+    }
   }
 }
 
@@ -7009,7 +7171,16 @@ function registerImageFloat(
 
   if (!state.dryRun) {
     const bmp = state.images.get(key);
-    if (bmp) drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
+    if (bmp) {
+      if (state.verticalCJK) {
+        // §17.6.20 (tbRl) — keep the floated image UPRIGHT inside the rotated page.
+        drawUprightBox(state.ctx, rect.imageX, rect.imageY, rect.imageW, rect.imageH, (dx, dy, dw, dh) =>
+          drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, dx, dy, dw, dh),
+        );
+      } else {
+        drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
+      }
+    }
     rect.drawn = true;
   }
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -756,14 +756,30 @@ export async function preloadImages(
  */
 const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
 
-/** True when a section is set to vertical writing (ECMA-376 §17.6.20 tbRl:
- *  glyphs stack top-to-bottom, lines advance right-to-left). Vertical variants
- *  that Word also defines (`tbLr`, `lrV`, `tbRlV`) are treated the same for
- *  layout purposes here; only `tbRl` appears in the vertical-Japanese samples.
- *  Horizontal (`lrTb`, dropped to null by the parser) ⇒ false. */
+/** True when a section flows VERTICALLY (glyphs stack top→bottom, lines advance
+ *  across the page). `<w:sectPr><w:textDirection>` uses the TRANSITIONAL
+ *  ST_TextDirection enum (ECMA-376 Part 4 §14.11.7; Word writes these, not the
+ *  Part 1 §17.18.93 Strict `tb|rl|lr|…` set):
+ *    - `tbRl`  (≡ Strict `rl`)  — vertical, lines right→left: standard vertical
+ *                                 Japanese; the only value in the samples.
+ *    - `tbRlV` (≡ Strict `rlV`) — vertical R→L, non-EA glyphs rotated 90° CW.
+ *    - `tbLrV` (≡ Strict `lrV`) — vertical L→R, non-EA glyphs rotated 90° CW.
+ *  These three share the +90° page rotation + upright-CJK glyph path (stage-1
+ *  approximates the `V` variants' non-EA rotation the same as `tbRl`, which the
+ *  glyph path already draws Latin sideways for).
+ *
+ *  Two values are VERTICAL but NOT handled by this stage-1 path, so they return
+ *  false (parsed and carried, but rendered as horizontal until implemented):
+ *    - `btLr`  (≡ Strict `lr`)  — vertical, but lines flow LEFT→RIGHT and glyphs
+ *                                 stack BOTTOM→TOP: needs the opposite page
+ *                                 rotation/flow, a separate follow-up.
+ *  And two are HORIZONTAL (glyphs upright, lines top→bottom) ⇒ false:
+ *    - `lrTb`  (≡ Strict `tb`, the default) — dropped to null by the parser.
+ *    - `lrTbV` (≡ Strict `tbV`) — horizontal, EA glyphs rotated 270°; still a
+ *                                 horizontal flow, so not this vertical path. */
 function isVerticalSection(s: SectionProps): boolean {
   const td = s.textDirection;
-  return td === 'tbRl' || td === 'tbLr' || td === 'tbRlV' || td === 'lrV';
+  return td === 'tbRl' || td === 'tbRlV' || td === 'tbLrV';
 }
 
 /** Map a vertical (tbRl) section's PHYSICAL page geometry to the SWAPPED LOGICAL
@@ -7830,6 +7846,13 @@ function renderCell(
     // cell edge.
     ctx.save();
     ctx.beginPath();
+    // `ctx.canvas.width` is the PHYSICAL device width; on a vertical (§17.6.20
+    // tbRl) page the ctx is rotated, so this clip rect is expressed in LOGICAL
+    // coordinates and the physical-width span makes it OVER-wide along the logical
+    // x-axis. That is harmless here — the clip is a Y-band anti-bleed guard, so an
+    // over-wide x-extent still fully contains the intended row band (it never
+    // UNDER-clips). Vertical tables are not yet exercised by a ground-truth
+    // fixture; when they are, tighten this to the logical content width.
     ctx.rect(0, y, ctx.canvas.width, h);
     ctx.clip();
     renderCellContent(cell.content, cellState);

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -35,10 +35,19 @@ export function buildDocxTextLayer(
     // ligatures are left at the browser default ('auto') because canvas
     // `measureText` / `fillText` also apply them by default — forcing them
     // off here would make the span wider than the drawn text.
+    // ECMA-376 §17.6.20 (tbRl) — a vertical page reports `x`/`y` as the PHYSICAL
+    // top-left and carries a `transform` (`rotate(90deg)`); rotate the span about
+    // its top-left so the horizontal DOM text lies along the drawn (rotated) glyph
+    // run. Horizontal pages carry no transform and place the span at `x`/`y`
+    // untransformed (byte-identical to the pre-vertical overlay).
+    const transform = run.transform
+      ? `transform:${run.transform};transform-origin:top left;`
+      : '';
     span.style.cssText =
       `position:absolute;` +
       `left:${run.x}px;top:${run.y}px;` +
       `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
+      transform +
       `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
     layer.appendChild(span);
   }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1254,8 +1254,11 @@ export interface RenderPageOptions {
   width?: number;
   dpr?: number;
   defaultTextColor?: string;
-  /** Called for each rendered text segment. Used to build a transparent text selection overlay. */
-  onTextRun?: (run: { text: string; x: number; y: number; w: number; h: number; fontSize: number; font: string }) => void;
+  /** Called for each rendered text segment. Used to build a transparent text
+   *  selection overlay. On a vertical (§17.6.20 tbRl) page `x`/`y` are the
+   *  PHYSICAL top-left and `transform` is the CSS rotation the overlay span
+   *  applies about its top-left; absent for horizontal pages. */
+  onTextRun?: (run: { text: string; x: number; y: number; w: number; h: number; fontSize: number; font: string; transform?: string }) => void;
   /** Default `true`. When false, ECMA-376 §17.13.5 track-changes runs render
    *  in their normal style (no author colour, no underline / strikethrough)
    *  — equivalent to Word's "Final / No Markup" view. */

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -181,6 +181,14 @@ export interface SectionProps {
    *  spec default). Non-final sections carry their start type on their own
    *  SectionBreak marker. */
   sectionStart?: string | null;
+  /** ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93) —
+   *  the section's flow direction. Absent / `null` ⇒ "lrTb" (horizontal,
+   *  left-to-right / top-to-bottom, the default). `"tbRl"` = vertical Japanese
+   *  (glyphs stack top→bottom, lines advance right→left); the renderer lays the
+   *  page out horizontally and rotates it +90° at paint, keeping CJK glyphs
+   *  upright and Latin sideways. Only a non-default value is emitted by the
+   *  parser, so horizontal documents keep byte-identical rendering. */
+  textDirection?: string | null;
   /** ECMA-376 §17.6.5 w:docGrid/@w:type — "default" | "lines" | "linesAndChars" | "snapToChars". */
   docGridType?: string | null;
   /** ECMA-376 §17.6.5 w:docGrid/@w:linePitch in pt. When docGridType is "lines" or

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -181,13 +181,16 @@ export interface SectionProps {
    *  spec default). Non-final sections carry their start type on their own
    *  SectionBreak marker. */
   sectionStart?: string | null;
-  /** ECMA-376 §17.6.20 `<w:textDirection w:val>` (ST_TextDirection §17.18.93) —
-   *  the section's flow direction. Absent / `null` ⇒ "lrTb" (horizontal,
-   *  left-to-right / top-to-bottom, the default). `"tbRl"` = vertical Japanese
-   *  (glyphs stack top→bottom, lines advance right→left); the renderer lays the
-   *  page out horizontally and rotates it +90° at paint, keeping CJK glyphs
-   *  upright and Latin sideways. Only a non-default value is emitted by the
-   *  parser, so horizontal documents keep byte-identical rendering. */
+  /** ECMA-376 §17.6.20 `<w:textDirection w:val>` — the section's flow direction,
+   *  using the TRANSITIONAL ST_TextDirection enum Word writes (Part 4 §14.11.7:
+   *  `lrTb`|`tbRl`|`btLr`|`lrTbV`|`tbLrV`|`tbRlV`), NOT the Part 1 §17.18.93
+   *  Strict set. Absent / `null` ⇒ "lrTb" (horizontal, left→right / top→bottom,
+   *  the default). `"tbRl"` = vertical Japanese (glyphs stack top→bottom, lines
+   *  advance right→left); the renderer (see `isVerticalSection`) lays the page out
+   *  horizontally and rotates it +90° at paint for the vertical values
+   *  (`tbRl`/`tbRlV`/`tbLrV`), keeping CJK glyphs upright and Latin sideways. Only
+   *  a non-default value is emitted by the parser, so horizontal documents keep
+   *  byte-identical rendering. */
   textDirection?: string | null;
   /** ECMA-376 §17.6.5 w:docGrid/@w:type — "default" | "lines" | "linesAndChars" | "snapToChars". */
   docGridType?: string | null;

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -5,6 +5,7 @@ import {
   splitVerticalOrientationRuns,
   drawVerticalRun,
   drawUprightBox,
+  physicalToLogicalAnchorBox,
 } from './vertical-text.js';
 
 // ECMA-376 §17.6.20 vertical writing (tbRl). These are the pure classification
@@ -160,5 +161,72 @@ describe('drawUprightBox (§17.6.20 — keep images upright inside the rotated p
     // Balanced save/restore.
     expect(ops[0]).toEqual({ op: 'save' });
     expect(ops[ops.length - 1]).toEqual({ op: 'restore' });
+  });
+});
+
+describe('physicalToLogicalAnchorBox (§17.6.20 + §20.4.3.x — physical anchor ↦ logical flow)', () => {
+  it('projects a physical image box into the swapped logical frame (w↔h swap)', () => {
+    // sample-26 ground truth (px at scale=1 = pt): physical page width 842pt,
+    // image physical TL (444.3, 397.85), size 96.2 × 123.0. Word's physical
+    // centroid (PDF-verified) is (492.4, 459.35).
+    const cssW = 842;
+    const box = physicalToLogicalAnchorBox(444.3, 397.85, 96.2, 123.0, cssW);
+    // logical.x = physical.y ; logical.y = cssW − (physical.x + w) ; w↔h swap.
+    expect(box.x).toBeCloseTo(397.85, 5);
+    expect(box.y).toBeCloseTo(842 - (444.3 + 96.2), 5); // 301.5
+    expect(box.w).toBeCloseTo(123.0, 5);
+    expect(box.h).toBeCloseTo(96.2, 5);
+  });
+
+  it('round-trips: drawUprightBox on the logical box lands the image at the physical centroid', () => {
+    // Feed the logical box through drawUprightBox and reconstruct the physical
+    // rectangle by composing the page transform (translate(cssW,0)·rotate(+90))
+    // with drawUprightBox's own (translate(centre)·rotate(−90)) — the net must be
+    // the physical image box, upright.
+    const cssW = 842;
+    const px = 444.3;
+    const py = 397.85;
+    const w = 96.2;
+    const h = 123.0;
+    const box = physicalToLogicalAnchorBox(px, py, w, h, cssW);
+    const { ctx, ops } = mockCtx();
+    let local: number[] | null = null;
+    drawUprightBox(ctx, box.x, box.y, box.w, box.h, (dx, dy, dw, dh) => {
+      local = [dx, dy, dw, dh];
+    });
+    // The draw rect corners, transformed through page·drawUprightBox, must span
+    // the physical image box.
+    const translate = ops.find(
+      (o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate',
+    );
+    // Compose: physical = P · translate(cx,cy) · rotate(−90) · localCorner.
+    const cx = translate?.x ?? 0;
+    const cy = translate?.y ?? 0;
+    const P = (lx: number, ly: number): [number, number] => {
+      // page transform: translate(cssW,0) then rotate(+90): (x,y) → (cssW−y, x)
+      return [cssW - ly, lx];
+    };
+    const boxLocal = (dx: number, dy: number): [number, number] => {
+      // drawUprightBox frame: translate(cx,cy)·rotate(−90): (x,y)→(cx+y, cy−x)
+      const rx = cx + dy;
+      const ry = cy - dx;
+      return P(rx, ry);
+    };
+    const [dx, dy, dw, dh] = local as unknown as number[];
+    const corners = [
+      boxLocal(dx, dy),
+      boxLocal(dx + dw, dy),
+      boxLocal(dx, dy + dh),
+      boxLocal(dx + dw, dy + dh),
+    ];
+    const xs = corners.map((c) => c[0]);
+    const ys = corners.map((c) => c[1]);
+    expect(Math.min(...xs)).toBeCloseTo(px, 4); // physical left
+    expect(Math.min(...ys)).toBeCloseTo(py, 4); // physical top
+    expect(Math.max(...xs) - Math.min(...xs)).toBeCloseTo(w, 4); // physical width
+    expect(Math.max(...ys) - Math.min(...ys)).toBeCloseTo(h, 4); // physical height
+    // Centroid matches Word / PDF ground truth.
+    expect((Math.min(...xs) + Math.max(...xs)) / 2).toBeCloseTo(492.4, 3);
+    expect((Math.min(...ys) + Math.max(...ys)) / 2).toBeCloseTo(459.35, 3);
   });
 });

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -6,6 +6,7 @@ import {
   drawVerticalRun,
   drawUprightBox,
   physicalToLogicalAnchorBox,
+  verticalTextLayerPlacement,
 } from './vertical-text.js';
 
 // ECMA-376 §17.6.20 vertical writing (tbRl). These are the pure classification
@@ -228,5 +229,17 @@ describe('physicalToLogicalAnchorBox (§17.6.20 + §20.4.3.x — physical anchor
     // Centroid matches Word / PDF ground truth.
     expect((Math.min(...xs) + Math.max(...xs)) / 2).toBeCloseTo(492.4, 3);
     expect((Math.min(...ys) + Math.max(...ys)) / 2).toBeCloseTo(459.35, 3);
+  });
+});
+
+describe('verticalTextLayerPlacement (§17.6.20 — overlay span physical placement)', () => {
+  it('maps a logical run top-left to the physical rotated placement', () => {
+    // Logical run at (100, 200) on an 842px-wide physical page.
+    const place = verticalTextLayerPlacement(100, 200, 842, true);
+    expect(place).toEqual({ left: 842 - 200, top: 100, transform: 'rotate(90deg)' });
+  });
+
+  it('returns null on a horizontal page (span placed at logical x/y, no transform)', () => {
+    expect(verticalTextLayerPlacement(100, 200, 842, false)).toBeNull();
   });
 });

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isUprightVerticalGlyph,
+  verticalGlyphOffset,
+  splitVerticalOrientationRuns,
+  drawVerticalRun,
+  drawUprightBox,
+} from './vertical-text.js';
+
+// ECMA-376 §17.6.20 vertical writing (tbRl). These are the pure classification
+// + geometry primitives the renderer wires into the glyph/image draw path behind
+// the `verticalCJK` flag.
+
+describe('isUprightVerticalGlyph (§17.6.20 — CJK stands upright, Latin rotates)', () => {
+  const cp = (ch: string): number => ch.codePointAt(0) ?? 0;
+
+  it('classifies CJK ideographs / kana / CJK punctuation as upright', () => {
+    for (const ch of ['富', '士', 'あ', 'ア', 'ー', '、', '。', '「', '」', '（', '）']) {
+      expect(isUprightVerticalGlyph(cp(ch))).toBe(true);
+    }
+  });
+
+  it('classifies Latin letters and Western digits as NOT upright (they rotate)', () => {
+    for (const ch of ['A', 'z', '0', '5', '9', '@', '-', '.']) {
+      expect(isUprightVerticalGlyph(cp(ch))).toBe(false);
+    }
+  });
+});
+
+describe('verticalGlyphOffset (§ JIS X 4051 — small comma/period sit upper-right)', () => {
+  const cp = (ch: string): number => ch.codePointAt(0) ?? 0;
+
+  it('nudges the ideographic comma/full stop toward the upper-right corner', () => {
+    for (const ch of ['、', '。', '，', '．']) {
+      const off = verticalGlyphOffset(cp(ch));
+      expect(off.dx).toBeGreaterThan(0); // rightward
+      expect(off.dy).toBeLessThan(0); // upward
+    }
+  });
+
+  it('leaves other glyphs centred in their cell', () => {
+    for (const ch of ['富', 'A', 'ー']) {
+      expect(verticalGlyphOffset(cp(ch))).toEqual({ dx: 0, dy: 0 });
+    }
+  });
+});
+
+describe('splitVerticalOrientationRuns (§17.6.20 — group by upright vs sideways)', () => {
+  it('splits a mixed run into maximal same-orientation pieces in logical order', () => {
+    const pieces = splitVerticalOrientationRuns('第5回大会');
+    expect(pieces).toEqual([
+      { text: '第', upright: true },
+      { text: '5', upright: false },
+      { text: '回大会', upright: true },
+    ]);
+  });
+
+  it('keeps a pure-CJK run as one upright piece', () => {
+    expect(splitVerticalOrientationRuns('富士町')).toEqual([{ text: '富士町', upright: true }]);
+  });
+
+  it('keeps a pure-Latin run as one sideways piece', () => {
+    expect(splitVerticalOrientationRuns('2026')).toEqual([{ text: '2026', upright: false }]);
+  });
+
+  it('returns nothing for empty text', () => {
+    expect(splitVerticalOrientationRuns('')).toEqual([]);
+  });
+
+  it('preserves surrogate pairs as single code points', () => {
+    const pieces = splitVerticalOrientationRuns('𠀋'); // CJK Ext-B ideograph (surrogate pair)
+    expect(pieces).toHaveLength(1);
+    expect(pieces[0].text).toBe('𠀋');
+  });
+});
+
+// A minimal 2D-context spy recording the transform + text/box draw ops so we can
+// assert the draw geometry without a real canvas.
+type Op =
+  | { op: 'save' }
+  | { op: 'restore' }
+  | { op: 'translate'; x: number; y: number }
+  | { op: 'rotate'; a: number }
+  | { op: 'fillText'; text: string; x: number; y: number; align: string; baseline: string }
+  | { op: 'draw'; dx: number; dy: number; dw: number; dh: number };
+
+function mockCtx(): { ctx: any; ops: Op[] } {
+  const ops: Op[] = [];
+  const ctx: any = {
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    letterSpacing: '0px',
+    save() {
+      ops.push({ op: 'save' });
+    },
+    restore() {
+      ops.push({ op: 'restore' });
+    },
+    translate(x: number, y: number) {
+      ops.push({ op: 'translate', x, y });
+    },
+    rotate(a: number) {
+      ops.push({ op: 'rotate', a });
+    },
+    measureText(s: string) {
+      // Every code point is 10px wide.
+      return { width: [...s].length * 10 };
+    },
+    fillText(text: string, x: number, y: number) {
+      ops.push({ op: 'fillText', text, x, y, align: this.textAlign, baseline: this.textBaseline });
+    },
+  };
+  return { ctx, ops };
+}
+
+describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin sideways)', () => {
+  it('counter-rotates every upright glyph −90° about its cell centre', () => {
+    const { ctx, ops } = mockCtx();
+    drawVerticalRun(ctx, '富士', 100, 200, 12, 0);
+    // Two upright glyphs → two save/rotate(−90°)/restore triples.
+    const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
+    expect(rotates).toHaveLength(2);
+    expect(rotates.every((r) => Math.abs(r.a - -Math.PI / 2) < 1e-9)).toBe(true);
+    // First cell centre: x=100 + adv/2 (adv=10) = 105, baseline y=200.
+    const firstTranslate = ops.find((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(firstTranslate).toEqual({ op: 'translate', x: 105, y: 200 });
+    // Upright glyphs draw centred.
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills.every((f) => f.align === 'center' && f.baseline === 'middle')).toBe(true);
+  });
+
+  it('draws a Latin glyph sideways (no rotation, alphabetic baseline, at the advance x)', () => {
+    const { ctx, ops } = mockCtx();
+    drawVerticalRun(ctx, 'A', 100, 200, 12, 0);
+    expect(ops.some((o) => o.op === 'rotate')).toBe(false);
+    const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    // Sideways: left at run x (advance 0), baseline y kept.
+    expect(fill).toMatchObject({ text: 'A', x: 100, y: 200 });
+  });
+
+  it('advances each glyph by measure + letterSpacing (measure == draw)', () => {
+    const { ctx, ops } = mockCtx();
+    drawVerticalRun(ctx, 'AB', 0, 0, 12, 4); // adv = 10 + 4 = 14 per glyph
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills.map((f) => f.x)).toEqual([0, 14]);
+  });
+});
+
+describe('drawUprightBox (§17.6.20 — keep images upright inside the rotated page)', () => {
+  it('rotates −90° about the box centre and passes the swapped local box', () => {
+    const { ctx, ops } = mockCtx();
+    let called: number[] | null = null;
+    drawUprightBox(ctx, 10, 20, 100, 40, (dx, dy, dw, dh) => {
+      called = [dx, dy, dw, dh];
+    });
+    expect(ops).toContainEqual({ op: 'translate', x: 60, y: 40 }); // centre (10+50, 20+20)
+    expect(ops).toContainEqual({ op: 'rotate', a: -Math.PI / 2 });
+    // Local box: width↔height swap, centred on the pivot → (−h/2, −w/2, h, w).
+    expect(called).toEqual([-20, -50, 40, 100]);
+    // Balanced save/restore.
+    expect(ops[0]).toEqual({ op: 'save' });
+    expect(ops[ops.length - 1]).toEqual({ op: 'restore' });
+  });
+});

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -305,3 +305,36 @@ export function physicalToLogicalAnchorBox(
     h: w,
   };
 }
+
+/**
+ * CSS placement (top-left + transform) for one vertical-page text-selection
+ * overlay span (ECMA-376 §17.6.20 tbRl). The renderer emits each run's geometry
+ * in the SWAPPED LOGICAL frame (`onTextRun` reports logical `x`/`y`/`w`/`h`); the
+ * canvas is the PHYSICAL landscape page rotated +90° at paint. A DOM overlay span
+ * is horizontal text, so to land it on the drawn (rotated) glyphs we place it at
+ * the physical point the logical top-left maps to and rotate it +90° about that
+ * corner — matching the page transform.
+ *
+ * Page transform: `physical = (cssWidth − logical.y, logical.x)`. The logical
+ * run top-left `(x, y)` therefore lands at physical `(cssWidth − y, x)`. Applying
+ * `transform: rotate(90deg)` with `transform-origin: top left` sends the span's
+ * own advance axis (+x local) to physical +y (down the column) and its line-box
+ * thickness (+y local) to physical −x — exactly the drawn run's footprint, so the
+ * transparent span overlays the glyphs and native selection/search hit-tests land
+ * correctly. (CJK glyphs are drawn upright while the span text is rotated sideways;
+ * the span still covers the same cell rectangle, which is what selection needs.
+ * Per-glyph upright overlay spans are a follow-up.)
+ *
+ * @returns `{ left, top }` in physical CSS px and the `transform` string, or
+ *          `null` when `!vertical` (horizontal pages place the span at `(x, y)`
+ *          untransformed — the byte-identical legacy path).
+ */
+export function verticalTextLayerPlacement(
+  x: number,
+  y: number,
+  cssWidthPx: number,
+  vertical: boolean,
+): { left: number; top: number; transform: string } | null {
+  if (!vertical) return null;
+  return { left: cssWidthPx - y, top: x, transform: 'rotate(90deg)' };
+}

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -250,3 +250,58 @@ export function drawUprightBox(
   draw(-h / 2, -w / 2, h, w);
   ctx.restore();
 }
+
+/** A rectangle `{ x, y, w, h }` in some coordinate frame (px). */
+export interface Box {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Map a DrawingML anchor's box from PHYSICAL page space into the SWAPPED LOGICAL
+ * layout frame the vertical (tbRl) renderer flows text in (ECMA-376 §17.6.20 +
+ * §20.4.3.x).
+ *
+ * A `<wp:positionH>` / `<wp:positionV>` anchor is resolved against the PHYSICAL
+ * page — Word places the drawing layer before/independently of the text-flow
+ * rotation, so the image stays upright at physical `(px, py, w, h)` exactly as in
+ * a horizontal document. The body text, however, is laid out in the logical frame
+ * that the page paint transform `physical = (cssWidth − logical.y, logical.x)`
+ * maps to physical. Inverting that transform (`logical.x = physical.y`,
+ * `logical.y = cssWidth − physical.x`) projects the physical image rectangle onto
+ * the logical frame:
+ *   - logical x-range = `[py, py + h]`         (physical y ↦ logical x, downward)
+ *   - logical y-range = `[cssWidth − (px + w), cssWidth − px]`
+ *                                               (physical x ↦ logical y, reversed)
+ * so the logical box has `w ↔ h` swapped: logical width = physical height and
+ * logical height = physical width.
+ *
+ * The returned box drives BOTH the float-exclusion rectangle (text wraps around
+ * this logical projection, in the same frame as the flow) AND {@link drawUprightBox}
+ * (which un-swaps it back to the upright physical image). Because the two derive
+ * from one box, the wrap band and the painted image stay locked together
+ * (packages/docx/CLAUDE.md — no duplicated geometry).
+ *
+ * @param px         Physical left of the image box (px).
+ * @param py         Physical top of the image box (px).
+ * @param w          Physical image width (px).
+ * @param h          Physical image height (px).
+ * @param cssWidthPx The canvas CSS width in px (= physical page width) — the
+ *                   `translate(cssWidth, 0)` term of the page transform.
+ */
+export function physicalToLogicalAnchorBox(
+  px: number,
+  py: number,
+  w: number,
+  h: number,
+  cssWidthPx: number,
+): Box {
+  return {
+    x: py,
+    y: cssWidthPx - (px + w),
+    w: h,
+    h: w,
+  };
+}

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -1,0 +1,229 @@
+// ECMA-376 §17.6.20 vertical writing (`<w:textDirection w:val="tbRl">`) — the
+// glyph-level primitives for rendering a page that has been laid out in the
+// SWAPPED logical coordinate space and rotated +90° into physical space by the
+// renderer's page transform (see `renderDocumentToCanvas`).
+//
+// After the page transform, a normal `ctx.fillText(text, x, baseline)` paints
+// the run flowing DOWNWARD in physical space (logical +x → physical +y), which
+// is exactly the character progression a vertical line wants — but every glyph
+// is lying on its right side (rotated +90° CW with the page). For vertical
+// Japanese:
+//   • CJK ideographs, kana and CJK punctuation must stand UPRIGHT. We draw each
+//     such glyph with a local −90° counter-rotation about its own centre, which
+//     cancels the page rotation so it appears upright while still advancing down
+//     the line.
+//   • Latin letters and Western digits stay SIDEWAYS (rotated with the page):
+//     that is the conventional "縦中横 not applied" appearance for runs of Latin
+//     text set in vertical Japanese, so they need no counter-rotation and are
+//     drawn as an ordinary contextual `fillText` (which also preserves the
+//     browser's shaping/advance for the run).
+//
+// This module owns ONLY the pure geometry + classification; the renderer wires
+// it into the three whole-run `fillText` draw sites behind the `verticalCJK`
+// flag, so the horizontal path stays byte-identical.
+
+import { isCjkBreakChar } from '@silurus/ooxml-core';
+
+/**
+ * True when `cp` renders UPRIGHT in vertical Japanese (UTR#50 Vertical_
+ * Orientation ≈ "U"/"Tu"): CJK ideographs, kana, Hangul, and CJK/fullwidth
+ * punctuation. Latin letters, Western digits and other rotate-in-vertical
+ * ("R") code points return false so the renderer leaves them sideways.
+ *
+ * Stage-1 scope (§ JIS X 4051): we reuse core's CJK block predicate
+ * ({@link isCjkBreakChar}), which already covers the upright set — CJK
+ * Symbols & Punctuation, Hiragana, Katakana, CJK Unified Ideographs (incl.
+ * Ext-A), Hangul Syllables, CJK Compatibility Ideographs, and the Halfwidth/
+ * Fullwidth Forms block — while excluding ASCII Latin/digits, which rotate.
+ *
+ * @param cp A Unicode scalar value (e.g. from `String.prototype.codePointAt`).
+ */
+export function isUprightVerticalGlyph(cp: number): boolean {
+  return isCjkBreakChar(cp);
+}
+
+/** A punctuation glyph that is DRAWN at a shifted position in vertical text
+ *  (§ JIS X 4051): the small ideographic comma/period sit in the upper-right
+ *  cell corner rather than the lower-left, and the corner brackets / parens are
+ *  mirrored to their vertical forms. Stage-1 handles the most visible ones by a
+ *  draw-time offset (see {@link verticalGlyphOffset}); full vertical-form glyph
+ *  substitution (U+FE10–U+FE19) is a follow-up. */
+const VERTICAL_PUNCT_UPPER_RIGHT = new Set<number>([
+  0x3001, // 、 ideographic comma
+  0x3002, // 。 ideographic full stop
+  0xff0c, // ， fullwidth comma
+  0xff0e, // ． fullwidth full stop
+]);
+
+/**
+ * Per-glyph draw offset (in em fractions of the font size) applied in the
+ * glyph's own UPRIGHT local frame — i.e. after the −90° counter-rotation, in
+ * physical (dx = rightward, dy = downward) terms. Returns `{ dx, dy }` em
+ * fractions; the caller multiplies by the font px size.
+ *
+ * The small ideographic comma / full stop occupy the upper-right of their cell
+ * in vertical text (unlike horizontal, where they sit at the lower-left). We
+ * approximate that by nudging them up and to the right within the cell. Every
+ * other glyph returns `{0,0}` (centred in its cell).
+ */
+export function verticalGlyphOffset(cp: number): { dx: number; dy: number } {
+  if (VERTICAL_PUNCT_UPPER_RIGHT.has(cp)) {
+    // Move toward the upper-right corner of the cell: right ~0.4em, up ~0.4em.
+    return { dx: 0.4, dy: -0.4 };
+  }
+  return { dx: 0, dy: 0 };
+}
+
+/**
+ * Split a run's text into maximal runs of same-orientation code points, so the
+ * vertical draw path can counter-rotate the UPRIGHT (CJK) segments per glyph
+ * while drawing SIDEWAYS (Latin/digit) segments as a single contextual
+ * `fillText`. Preserves surrogate pairs (iterates by code point) and returns
+ * the pieces in logical order with each piece's starting code-point index.
+ *
+ * @param text The run's text.
+ * @returns Ordered pieces, each `{ text, upright }`.
+ */
+export function splitVerticalOrientationRuns(
+  text: string,
+): Array<{ text: string; upright: boolean }> {
+  const pieces: Array<{ text: string; upright: boolean }> = [];
+  let cur = '';
+  let curUpright: boolean | null = null;
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    const upright = isUprightVerticalGlyph(cp);
+    if (curUpright === null) {
+      curUpright = upright;
+      cur = ch;
+    } else if (upright === curUpright) {
+      cur += ch;
+    } else {
+      pieces.push({ text: cur, upright: curUpright });
+      cur = ch;
+      curUpright = upright;
+    }
+  }
+  if (cur !== '' && curUpright !== null) {
+    pieces.push({ text: cur, upright: curUpright });
+  }
+  return pieces;
+}
+
+type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+/**
+ * Draw one run's glyphs in vertical mode. The context is assumed to already be
+ * in the page's SWAPPED logical frame (the +90° page rotation is installed by
+ * `renderDocumentToCanvas`), so an ordinary `fillText` advances DOWN the line.
+ *
+ * The run flows along logical +x (physical +y). Each glyph occupies a cell of
+ * width = its horizontal advance (`ctx.measureText`) plus `letterSpacingPx`
+ * (the docGrid / justification pitch the layout measured the box with), so the
+ * total advance equals the run's measured width — measure == draw. Upright
+ * (CJK) glyphs are counter-rotated −90° about their cell centre so they stand
+ * upright; sideways (Latin/digit) pieces are painted as a single contextual
+ * `fillText`, preserving the browser's shaping.
+ *
+ * @param ctx              2D context, already in the rotated logical page frame.
+ *                         `ctx.font`/`ctx.fillStyle` are set by the caller.
+ * @param text             The run's text.
+ * @param x                Logical left edge of the run (px).
+ * @param baseline         Logical baseline y of the line (px).
+ * @param fontPx           Effective font size in px (for cell centring).
+ * @param letterSpacingPx  Per-glyph extra advance (docGrid cell delta or
+ *                         justification pitch); 0 for the common path.
+ */
+export function drawVerticalRun(
+  ctx: Ctx2D,
+  text: string,
+  x: number,
+  baseline: number,
+  fontPx: number,
+  letterSpacingPx: number,
+): void {
+  const prevAlign = ctx.textAlign;
+  const prevBaseline = ctx.textBaseline;
+  let ax = 0; // cumulative advance from run left (logical +x)
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    const upright = isUprightVerticalGlyph(cp);
+    const adv = ctx.measureText(ch).width + letterSpacingPx;
+    if (upright) {
+      // Cell centre in logical space. Counter-rotate −90° about it so the glyph
+      // (which the page rotation would otherwise lay on its side) stands upright.
+      const cx = x + ax + adv / 2;
+      const off = verticalGlyphOffset(cp);
+      ctx.save();
+      ctx.translate(cx, baseline);
+      ctx.rotate(-Math.PI / 2);
+      // In the upright local frame: draw centred horizontally (the cell centre)
+      // and with an alphabetic baseline nudged so the ideograph sits centred in
+      // its cell. The em-box centre for CJK is ~0.5em below the cap line; using
+      // `middle` baseline centres the glyph box, then shift up by ~0.12em so the
+      // visual centre lands on the cell centre for typical CJK metrics.
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(
+        ch,
+        off.dx * fontPx,
+        (0.12 + off.dy) * fontPx,
+      );
+      ctx.restore();
+    } else {
+      // Sideways (Latin/digit): draw as-is (rotated with the page). Keep the
+      // caller's alphabetic baseline; position the glyph's left at the current
+      // advance. Group of consecutive sideways glyphs would ideally be one
+      // fillText for shaping, but per-glyph keeps the advance model uniform and
+      // Latin advances are context-free enough at these sizes.
+      ctx.textAlign = prevAlign;
+      ctx.textBaseline = prevBaseline;
+      ctx.fillText(ch, x + ax, baseline);
+    }
+    ax += adv;
+  }
+  ctx.textAlign = prevAlign;
+  ctx.textBaseline = prevBaseline;
+}
+
+/**
+ * Run `draw` with the context counter-rotated so a graphic that would otherwise
+ * be painted lying on its side (rotated with the +90° page transform) appears
+ * UPRIGHT. Used for inline / anchored images and shapes in a vertical (tbRl)
+ * page: an image is not text, so it keeps its natural upright orientation even
+ * though the surrounding characters advance downward.
+ *
+ * The box is specified by its logical top-left `(x, y)` and logical size
+ * `(w, h)` — the same coordinates the horizontal draw path uses. We rotate −90°
+ * about the box centre (cancelling the page rotation) and invoke `draw(dx, dy,
+ * dw, dh)` with the box re-expressed in the upright local frame: the logical
+ * width becomes the local HEIGHT and vice-versa, so the caller draws the image
+ * at `(-h/2, -w/2, h, w)` centred on the pivot. The net effect places an upright
+ * image inside the rotated page footprint.
+ *
+ * @param ctx  2D context already in the rotated logical page frame.
+ * @param x    Logical left of the box (px).
+ * @param y    Logical top of the box (px).
+ * @param w    Logical width of the box (px).
+ * @param h    Logical height of the box (px).
+ * @param draw Callback painting the graphic at `(dx, dy, dw, dh)` in the upright
+ *             local frame.
+ */
+export function drawUprightBox(
+  ctx: Ctx2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  draw: (dx: number, dy: number, dw: number, dh: number) => void,
+): void {
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(-Math.PI / 2);
+  // In the upright local frame the logical width spans the local y-axis and the
+  // logical height spans the local x-axis, so the box is (−h/2, −w/2, h, w).
+  draw(-h / 2, -w / 2, h, w);
+  ctx.restore();
+}

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -19,8 +19,19 @@
 //     browser's shaping/advance for the run).
 //
 // This module owns ONLY the pure geometry + classification; the renderer wires
-// it into the three whole-run `fillText` draw sites behind the `verticalCJK`
-// flag, so the horizontal path stays byte-identical.
+// it into the whole-run glyph draw sites, the anchor/inline/float image draws,
+// and the text-selection overlay behind the `verticalCJK` flag, so the
+// horizontal path stays byte-identical.
+//
+// STAGE-1 SCOPE (issue #771 tracks stage-2). Implemented: +90° page rotation,
+// upright-CJK / sideways-Latin glyph draw, anchor images resolved against the
+// physical page then projected into the logical flow (PDF-verified centroid),
+// inline/anchored/float image uprighting, and the vertical text-layer transform.
+// NOT yet implemented (approximated or deferred): vertical-form punctuation
+// substitution (U+FE10–U+FE19) and the `0.12em`/`0.4em` glyph nudges are
+// font-dependent stage-1 heuristics (flagged inline); 縦中横 (tate-chū-yoko),
+// `btLr` flow, header/footer + tables in tbRl, and paragraph-relative vertical
+// anchors are follow-ups.
 
 import { isCjkBreakChar } from '@silurus/ooxml-core';
 
@@ -68,7 +79,14 @@ const VERTICAL_PUNCT_UPPER_RIGHT = new Set<number>([
  */
 export function verticalGlyphOffset(cp: number): { dx: number; dy: number } {
   if (VERTICAL_PUNCT_UPPER_RIGHT.has(cp)) {
-    // Move toward the upper-right corner of the cell: right ~0.4em, up ~0.4em.
+    // HEURISTIC (stage-1 approximation, font-dependent): move the small comma/
+    // full stop toward the upper-right corner of the cell by ~0.4em each way.
+    // This is NOT a spec constant — JIS X 4051 §4.x gives the punctuation cell
+    // geometry (the glyph occupies a quarter-em corner box), not a 0.4em nudge.
+    // The correct fix is full vertical-form glyph substitution (U+FE10–U+FE19,
+    // Unicode CJK Compatibility Forms) so the font supplies the pre-positioned
+    // vertical comma/period; then this offset is deleted. Tracked in issue #771
+    // (vertical-text stage-2).
     return { dx: 0.4, dy: -0.4 };
   }
   return { dx: 0, dy: 0 };
@@ -158,10 +176,15 @@ export function drawVerticalRun(
       ctx.translate(cx, baseline);
       ctx.rotate(-Math.PI / 2);
       // In the upright local frame: draw centred horizontally (the cell centre)
-      // and with an alphabetic baseline nudged so the ideograph sits centred in
-      // its cell. The em-box centre for CJK is ~0.5em below the cap line; using
-      // `middle` baseline centres the glyph box, then shift up by ~0.12em so the
-      // visual centre lands on the cell centre for typical CJK metrics.
+      // with a `middle` baseline that centres the glyph box on the cell.
+      // HEURISTIC (stage-1 approximation, font-dependent): the extra +0.12em
+      // vertical shift nudges typical CJK metrics so the visual centre lands on
+      // the cell centre — it is NOT a spec constant (JIS X 4051 positions the
+      // glyph from the font's ideographic em-box / vertical baseline, which the
+      // browser does not expose here). The correct fix is to place each glyph
+      // from the font's vertical metrics (ideographic baseline / `ideographic`
+      // textBaseline once broadly supported); replace 0.12em then. Tracked in
+      // issue #771 (vertical-text stage-2).
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       ctx.fillText(

--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -14,6 +14,10 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   // locally with UPDATE_REFS=1 — they are never committed.
   { name: 'private/sample-24', pageCount: 3, width: 595 },
   { name: 'private/sample-25', pageCount: 1, width: 595 },
+  // XF9 vertical writing (§17.6.20 tbRl): a landscape vertical-Japanese
+  // newspaper. width = physical page width (842pt, A4 landscape). Reference is
+  // private (gitignored) and generated locally with UPDATE_REFS=1.
+  { name: 'private/sample-26', pageCount: 1, width: 842 },
   { name: 'demo/sample-1', pageCount: 6, width: 595 },
 ];
 


### PR DESCRIPTION
## Summary
XF9 stage 1: docx body vertical writing (`<w:textDirection w:val="tbRl">`, §17.6.20). Ground truth: user-authored Word `private/sample-26.docx` + PDF (a vertical Japanese newsletter).

## Approach — rotate-layout (no layout-engine changes)
Reuses the horizontal layout engine wholesale, gated entirely on `RenderState.verticalCJK` so the horizontal path stays byte-identical:
1. **layout swap**: the vertical section lays out in a swapped logical section (logical width = physical page height; margins quarter-rotated). pagination / line-layout / docGrid / justify / kinsoku / numbering run unchanged.
2. **page transform**: after painting the white ground, `ctx.translate(cssWidth,0); ctx.rotate(π/2)` maps logical-horizontal onto physical vertical (lines advancing right→left).
3. **per-glyph uprighting**: CJK glyphs counter-rotate −90° about the cell center to stand upright; Latin/digits stay sideways.

## Review-fix round (independent review: 3 MAJOR + MINOR)
The first pass over-claimed "inline/anchored/float upright"; the review found three real defects, now fixed (one commit each):

- **`fix(docx): place vertical-page anchor images from the physical page` (§20.4.3.x)** — CRITICAL. A `<wp:anchor>`'s positionH/V were fed **unrotated** into the swapped logical frame, so the image landed **~90px off** (sample-26 photo ≈(397,507) vs Word ≈(492,459)). Word resolves the drawing layer against the **physical** page; we now resolve there (physical-geometry `RenderState` proxy) and project the box into the logical flow via `physicalToLogicalAnchorBox` (one box drives both the wrap-exclusion rect and `drawUprightBox`). **PDF-verified: rendered photo centroid (492.4, 459.35)pt — 1px of Word's ground truth.**
- **`fix(docx): keep inline images and inline charts upright`** — MAJOR. The inline `drawImageCropped` / `renderChart` paths were **not** wrapped in `drawUprightBox`, so inline images/charts rendered on their side. Now uprighted (matching anchored/float).
- **`fix(docx): transform the text-selection overlay`** — MAJOR. `onTextRun` reported logical coords onto the +90° physical canvas, so selection/search boxes were mis-placed. The overlay now emits the physical top-left + `rotate(90deg)` so spans land on the drawn glyph cells.
- **`fix(docx): correct ST_TextDirection enum + flag stage-1 heuristics`** — MINOR. `<w:textDirection>` uses the **transitional** enum Word writes (Part 4 §14.11.7: `lrTb|tbRl|btLr|lrTbV|tbLrV|tbRlV`), not the Part 1 §17.18.93 Strict set; `isVerticalSection` corrected to `tbRl|tbRlV|tbLrV`. The `0.12em` baseline nudge and `0.4em` punctuation offset are labeled HEURISTIC (font-dependent stage-1, tracked in **#771**); the table-cell clip's physical-width use is commented (untested for vertical tables).

## Verification
- **Anchor placement PDF-verified**: sample-26 photo centroid (492.4, 459.35)pt matches Word/PDF within ~1px (was ~90px off). Analytic centroid pinned in `anchor-vertical-physical.test.ts`.
- sample-26 render matches the PDF: title "富士町子ども会新聞" vertical at the right edge ("子ども会" red), articles + team bullets + editorial + contact flowing right→left, CJK upright, digits/email sideways, photo upright.
- **Horizontal path byte-identical**: docx VRT private sample-2/4/5 all 0px; sample-1/3 + demo/sample-1 unchanged from their pre-existing noise ratchet. Committed (demo) references unchanged; sample-26 reference regenerated (private, gitignored) after confirming PDF alignment.
- Gates: parser fmt / clippy (-D warnings) / test **226**; docx vitest **639** (incl. new anchor-physical + overlay unit tests); docx tsc clean; worker-vs-main 0.000%.

## Stage-2 follow-ups (issue #771)
- Replace the `0.12em` / `0.4em` glyph heuristics with font-vertical-metric placement + U+FE10–19 vertical-form substitution.
- 縦中横 (tate-chū-yoko); `btLr` flow (vertical, opposite direction — parsed but rendered horizontal); paragraph-relative vertical anchors; header/footer + tables in tbRl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)