### PR TITLE
feat(core,docx,pptx,xlsx): clickable hyperlinks with URL sanitization (IX1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -335,6 +335,16 @@ export { computeVisibleRange, type VisibleRange, type VisibleRangePad } from './
 // Shared exponential wheel/pinch zoom step (Ctrl/⌘+wheel). Pure — the caller
 // clamps to its own [zoomMin, zoomMax]. Used by XlsxViewer + the scroll viewers.
 export { zoomStepScale } from './interaction/zoom';
+// Shared hyperlink model + URL scheme-allowlist sanitiser (IX1). One
+// HyperlinkTarget shape + one sanitizeHyperlinkUrl predicate for docx / pptx /
+// xlsx so the external-URL safety policy is defined once, not per format.
+export {
+  type HyperlinkTarget,
+  DEFAULT_ALLOWED_HYPERLINK_SCHEMES,
+  hyperlinkUrlScheme,
+  sanitizeHyperlinkUrl,
+  openExternalHyperlink,
+} from './interaction/hyperlink';
 // Format-agnostic font design line-metrics (OS/2 win / hhea sums) for faces the
 // browser substitutes with different metrics — shared so docx (Word's design
 // line box), pptx and xlsx can size line boxes / floor single-line height

--- a/packages/core/src/interaction/hyperlink.test.ts
+++ b/packages/core/src/interaction/hyperlink.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeHyperlinkUrl,
+  hyperlinkUrlScheme,
+  openExternalHyperlink,
+  DEFAULT_ALLOWED_HYPERLINK_SCHEMES,
+} from './hyperlink.js';
+
+/**
+ * IX1 hyperlink URL sanitiser. External hyperlink targets come straight out of
+ * an untrusted document's relationship part, so before a click navigates
+ * anywhere the scheme must be checked against an allowlist. The dangerous cases
+ * (`javascript:`, `data:`, `vbscript:`, `file:`) must be blocked even when the
+ * author obfuscates them with leading whitespace or embedded control characters
+ * that browsers strip when resolving the URL.
+ */
+describe('sanitizeHyperlinkUrl (external link scheme allowlist)', () => {
+  it('allows the safe web / contact schemes', () => {
+    expect(sanitizeHyperlinkUrl('https://example.com/a?b=1#c')).toBe('https://example.com/a?b=1#c');
+    expect(sanitizeHyperlinkUrl('http://example.com')).toBe('http://example.com');
+    expect(sanitizeHyperlinkUrl('mailto:hi@example.com')).toBe('mailto:hi@example.com');
+    expect(sanitizeHyperlinkUrl('tel:+15551234567')).toBe('tel:+15551234567');
+  });
+
+  it('blocks script / data / local-file schemes (returns null)', () => {
+    expect(sanitizeHyperlinkUrl('javascript:alert(1)')).toBeNull();
+    expect(sanitizeHyperlinkUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(sanitizeHyperlinkUrl('vbscript:msgbox(1)')).toBeNull();
+    expect(sanitizeHyperlinkUrl('file:///etc/passwd')).toBeNull();
+    expect(sanitizeHyperlinkUrl('about:blank')).toBeNull();
+    expect(sanitizeHyperlinkUrl('blob:https://x/y')).toBeNull();
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(sanitizeHyperlinkUrl('HTTPS://example.com')).toBe('HTTPS://example.com');
+    expect(sanitizeHyperlinkUrl('JavaScript:alert(1)')).toBeNull();
+    expect(sanitizeHyperlinkUrl('JAVASCRIPT:alert(1)')).toBeNull();
+  });
+
+  it('sees through leading whitespace and embedded control chars', () => {
+    // Browsers strip TAB/LF/CR and leading spaces when resolving a URL, so
+    // "java\tscript:" IS the javascript scheme and must be blocked.
+    const tab = String.fromCharCode(9);
+    const lf = String.fromCharCode(10);
+    const cr = String.fromCharCode(13);
+    expect(sanitizeHyperlinkUrl(`  javascript:alert(1)`)).toBeNull();
+    expect(sanitizeHyperlinkUrl(`java${tab}script:alert(1)`)).toBeNull();
+    expect(sanitizeHyperlinkUrl(`java${lf}script:alert(1)`)).toBeNull();
+    expect(sanitizeHyperlinkUrl(`${cr}${tab} javascript:alert(1)`)).toBeNull();
+    // A leading NUL byte likewise must not hide the scheme.
+    expect(sanitizeHyperlinkUrl(`${String.fromCharCode(0)}javascript:alert(1)`)).toBeNull();
+  });
+
+  it('treats a scheme-less (relative / anchor / protocol-relative) target as safe', () => {
+    expect(sanitizeHyperlinkUrl('page.html')).toBe('page.html');
+    expect(sanitizeHyperlinkUrl('#section')).toBe('#section');
+    expect(sanitizeHyperlinkUrl('//example.com/x')).toBe('//example.com/x');
+    expect(sanitizeHyperlinkUrl('/root/rel')).toBe('/root/rel');
+  });
+
+  it('blocks the empty string', () => {
+    expect(sanitizeHyperlinkUrl('')).toBeNull();
+  });
+
+  it('honours a custom allowlist', () => {
+    // An intranet viewer that opts into file: links.
+    const allow = ['https', 'file'];
+    expect(sanitizeHyperlinkUrl('file:///share/doc', allow)).toBe('file:///share/doc');
+    // mailto is no longer allowed under the custom list.
+    expect(sanitizeHyperlinkUrl('mailto:x@y.z', allow)).toBeNull();
+  });
+
+  it('default allowlist is exactly the safe four', () => {
+    expect([...DEFAULT_ALLOWED_HYPERLINK_SCHEMES]).toEqual(['http', 'https', 'mailto', 'tel']);
+  });
+});
+
+describe('openExternalHyperlink (default new-tab open policy)', () => {
+  it('opens an allowed URL in a new tab with noopener,noreferrer', () => {
+    const calls: Array<[string, string, string]> = [];
+    const win = { open: (u: string, t: string, f: string) => { calls.push([u, t, f]); return null; } };
+    const ok = openExternalHyperlink('https://example.com', undefined, win);
+    expect(ok).toBe(true);
+    expect(calls).toEqual([['https://example.com', '_blank', 'noopener,noreferrer']]);
+  });
+
+  it('does NOT open a blocked scheme and returns false', () => {
+    let opened = false;
+    const win = { open: () => { opened = true; return null; } };
+    const ok = openExternalHyperlink('javascript:alert(1)', undefined, win);
+    expect(ok).toBe(false);
+    expect(opened).toBe(false);
+  });
+
+  it('returns false (no throw) when there is no window', () => {
+    expect(openExternalHyperlink('https://example.com', undefined, undefined)).toBe(false);
+  });
+});
+
+describe('hyperlinkUrlScheme', () => {
+  it('extracts and lowercases the scheme', () => {
+    expect(hyperlinkUrlScheme('HTTPS://x')).toBe('https');
+    expect(hyperlinkUrlScheme('mailto:a@b')).toBe('mailto');
+    expect(hyperlinkUrlScheme('ms-word:ofe|u|x')).toBe('ms-word');
+  });
+
+  it('returns null when there is no scheme', () => {
+    expect(hyperlinkUrlScheme('relative/path')).toBeNull();
+    expect(hyperlinkUrlScheme('//host/path')).toBeNull();
+    expect(hyperlinkUrlScheme(':leadingcolon')).toBeNull();
+    expect(hyperlinkUrlScheme('')).toBeNull();
+  });
+});

--- a/packages/core/src/interaction/hyperlink.ts
+++ b/packages/core/src/interaction/hyperlink.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared hyperlink model + URL sanitisation for docx / pptx / xlsx (IX1).
+ *
+ * All three formats carry the same two ECMA-376 concepts:
+ *   - an **external** hyperlink — an absolute URL resolved from a relationship
+ *     part target (`document.xml.rels` for docx §17.16.22, the slide rels for
+ *     pptx §21.1.2.3.5, the worksheet rels for xlsx §18.3.1.47), with
+ *     `TargetMode="External"`.
+ *   - an **internal** hyperlink — a jump within the document itself:
+ *     docx `w:anchor` -> a `<w:bookmarkStart w:name>` (§17.16.23), pptx
+ *     `action="ppaction://hlinksldjump"` -> a slide, xlsx `location` -> a defined
+ *     name or a `Sheet!A1` cell reference.
+ *
+ * The parsers (Rust, one per format) do the format-specific rels lookup and hand
+ * each run / shape / cell a {@link HyperlinkTarget}. Everything downstream — the
+ * text-layer overlay, the viewer default click behaviour, and any integrator
+ * callback — is format-agnostic and consumes this one shape. Keeping the type +
+ * the pure `sanitizeHyperlinkUrl` predicate here (not duplicated per package)
+ * follows the cross-package unification principle: a scheme-allowlist bug fixed
+ * once is fixed everywhere.
+ */
+
+/**
+ * A resolved hyperlink attached to a run, shape, or cell.
+ *
+ *   - `external` — `url` is the raw target as authored in the file. It is NOT
+ *     guaranteed safe; run it through {@link sanitizeHyperlinkUrl} before
+ *     navigating. It is kept verbatim here so an integrator can apply its own
+ *     policy (e.g. allow `file:` on a trusted intranet viewer).
+ *   - `internal` — `ref` is the in-document destination, verbatim from the file:
+ *       docx: the bookmark name (`w:anchor`).
+ *       pptx: the internal action (e.g. `ppaction://hlinksldjump`), with the
+ *             resolved 0-based `slideIndex` when the rels target names a slide.
+ *       xlsx: the `location` string (a defined name or `Sheet1!A1`).
+ */
+export type HyperlinkTarget =
+  | { kind: 'external'; url: string }
+  | { kind: 'internal'; ref: string; slideIndex?: number };
+
+/**
+ * URL schemes permitted for external hyperlink navigation by default.
+ *
+ * `http` / `https` cover the web; `mailto` and `tel` are inert launch handlers
+ * with no script-execution surface. Everything else — notably `javascript:`,
+ * `data:`, `vbscript:`, `file:`, `about:`, `blob:` — is refused, because a
+ * malicious document could otherwise smuggle script execution or local-file
+ * disclosure through a link the user is invited to click. This mirrors the
+ * conservative allowlist browsers apply to `target=_blank` navigations and is
+ * consistent with the library's typed-error / fail-safe stance (RB series):
+ * when in doubt, do nothing rather than execute attacker-controlled input.
+ */
+export const DEFAULT_ALLOWED_HYPERLINK_SCHEMES: readonly string[] = [
+  'http',
+  'https',
+  'mailto',
+  'tel',
+];
+
+/**
+ * Extract the lowercased URL scheme (the token before the first `:`), or `null`
+ * when the string carries no scheme. A scheme is `ALPHA *( ALPHA / DIGIT / "+"
+ * / "-" / "." )` per RFC 3986 §3.1. A leading-colon or empty string has no
+ * scheme.
+ *
+ * All ASCII whitespace and C0 control characters (code points 0x00–0x20),
+ * including the embedded TAB / LF / CR that browsers strip from URLs — the trick
+ * attackers use to hide `java<TAB>script:` from a naive prefix check — are
+ * removed before scanning, so `"  java<LF>script:alert(1)"` is correctly seen as
+ * the `javascript` scheme and rejected.
+ */
+export function hyperlinkUrlScheme(url: string): string | null {
+  // Drop every ASCII control char and space (code points 0x00–0x20). Browsers
+  // ignore embedded TAB/LF/CR and leading spaces when resolving a URL, so a
+  // checker that leaves them in would under-report the real scheme. A code-point
+  // filter is used (rather than a control-char regex literal) to keep this
+  // source file free of embedded control characters.
+  let cleaned = '';
+  for (const ch of url) {
+    const cp = ch.codePointAt(0);
+    if (cp !== undefined && cp > 0x20) cleaned += ch;
+  }
+  const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(cleaned);
+  return m ? m[1].toLowerCase() : null;
+}
+
+/**
+ * Validate an external hyperlink URL against a scheme allowlist and return the
+ * URL to navigate to, or `null` if it must be blocked.
+ *
+ * A URL with **no scheme** (a relative or protocol-relative reference such as
+ * `"page.html"` or `"//example.com/x"`) is treated as safe and returned as-is:
+ * it cannot name a dangerous scheme, and it resolves against the current
+ * document origin exactly like any relative link. A URL whose scheme is not in
+ * `allowed` (default {@link DEFAULT_ALLOWED_HYPERLINK_SCHEMES}) returns `null`
+ * so callers can no-op the click.
+ *
+ * This is a pure predicate: it neither navigates nor mutates. Comparison is
+ * case-insensitive on the scheme; the returned string is the original,
+ * untrimmed input (so query/fragment/casing are preserved for navigation).
+ *
+ * @param url     the raw external target from the file.
+ * @param allowed lowercase scheme allowlist; defaults to the safe set.
+ * @returns the URL to open, or `null` when the scheme is disallowed.
+ */
+export function sanitizeHyperlinkUrl(
+  url: string,
+  allowed: readonly string[] = DEFAULT_ALLOWED_HYPERLINK_SCHEMES,
+): string | null {
+  if (url === '') return null;
+  const scheme = hyperlinkUrlScheme(url);
+  // No scheme -> relative/anchor reference, inherently same-origin-safe.
+  if (scheme === null) return url;
+  return allowed.includes(scheme) ? url : null;
+}
+
+/**
+ * The default action a viewer takes for an **external** hyperlink click when
+ * the integrator supplies no `onHyperlinkClick` handler: sanitise the URL and,
+ * if allowed, open it in a new tab with `noopener,noreferrer` so the opened page
+ * gets no `window.opener` handle back into this document. A blocked scheme is a
+ * silent no-op (returns `false`) — the click does nothing rather than navigate
+ * somewhere dangerous.
+ *
+ * Internal targets are intentionally NOT handled here: the in-document jump
+ * (page / slide / cell) is format-specific and lives in each viewer.
+ *
+ * Split out (not inlined in three viewers) so the "open in new tab, drop opener,
+ * refuse unsafe schemes" policy is defined once. `win` is injected for tests;
+ * defaults to the ambient `window`.
+ *
+ * @returns `true` if navigation was initiated, `false` if the URL was blocked.
+ */
+export function openExternalHyperlink(
+  url: string,
+  allowed: readonly string[] = DEFAULT_ALLOWED_HYPERLINK_SCHEMES,
+  win: Pick<Window, 'open'> | undefined = typeof window !== 'undefined' ? window : undefined,
+): boolean {
+  const safe = sanitizeHyperlinkUrl(url, allowed);
+  if (safe === null || !win) return false;
+  win.open(safe, '_blank', 'noopener,noreferrer');
+  return true;
+}

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -358,10 +358,19 @@ export interface TextRunData {
   /** Set for OOXML field runs (e.g. "slidenum"). When set, renderer replaces text with field value. */
   fieldType?: string;
   /**
-   * Hyperlink target URL resolved from rPr > a:hlinkClick @r:id via the slide's _rels.
-   * Undefined for runs without a hyperlink. ECMA-376 §21.1.2.3.5 (CT_Hyperlink).
+   * Hyperlink target resolved from rPr > a:hlinkClick @r:id via the slide's _rels.
+   * For an external link this is the URL; for an internal slide jump it is the
+   * resolved internal part name (e.g. "../slides/slide3.xml"). Undefined for runs
+   * without a hyperlink. ECMA-376 §21.1.2.3.5 (CT_Hyperlink).
    */
   hyperlink?: string;
+  /**
+   * Raw `<a:hlinkClick @action>` string (e.g. "ppaction://hlinksldjump") when
+   * present — its presence marks {@link hyperlink} as an INTERNAL PowerPoint
+   * action (slide jump / first / last …) rather than an external URL. Undefined
+   * when the hlinkClick has no @action. ECMA-376 §21.1.2.3.5. (IX1)
+   */
+  hyperlinkAction?: string;
   /**
    * Run-level drop shadow on glyphs (`<a:rPr><a:effectLst><a:outerShdw>`),
    * ECMA-376 §20.1.8.45. Independent of the shape-level shadow on `spPr`.

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2262,11 +2262,11 @@ fn parse_para_content(
             "r" => {
                 handle_run_in_para(
                     child, base_run, style_map, media_map, chart_map, theme, runs, field, None,
-                    revision,
+                    None, revision,
                 );
             }
             "hyperlink" => {
-                // Resolve URL from r:id via relationships
+                // Resolve URL from r:id via relationships (§17.16.22, external).
                 let href = attr_ns(
                     &child,
                     relationships::TRANSITIONAL,
@@ -2274,6 +2274,12 @@ fn parse_para_content(
                     "id",
                 )
                 .and_then(|rid| rel_map.get(rid).cloned());
+                // ECMA-376 §17.16.23 `w:anchor` — the internal bookmark target.
+                // Recorded independently of `r:id`; when both are present the
+                // external URL still wins for `hyperlink` (see parse_run_inner),
+                // but the anchor is threaded through so an anchor-only link (no
+                // r:id) is captured as an internal target.
+                let anchor = attr_w(child, "anchor");
                 for r in child
                     .children()
                     .filter(|n| n.is_element() && n.tag_name().name() == "r")
@@ -2288,6 +2294,7 @@ fn parse_para_content(
                         runs,
                         field,
                         Some(href.clone()),
+                        anchor.clone(),
                         revision,
                     );
                 }
@@ -2402,6 +2409,10 @@ fn handle_run_in_para(
     field: &mut FieldState,
     // Outer None = not inside a hyperlink. Some(None) = hyperlink without URL. Some(Some(url)) = hyperlink with URL.
     link_href: Option<Option<String>>,
+    // §17.16.23 `w:anchor` — internal bookmark target, threaded alongside
+    // `link_href`. `None` when the enclosing `<w:hyperlink>` has no anchor (or
+    // the run is not inside a hyperlink at all).
+    link_anchor: Option<String>,
     revision: Option<&RunRevision>,
 ) {
     // Inspect this run for field control characters or instruction text first.
@@ -2510,7 +2521,17 @@ fn handle_run_in_para(
     // Normal run
     let in_toc = field.in_toc();
     parse_run_inner(
-        r_node, base_run, style_map, media_map, chart_map, theme, runs, link_href, revision, in_toc,
+        r_node,
+        base_run,
+        style_map,
+        media_map,
+        chart_map,
+        theme,
+        runs,
+        link_href,
+        link_anchor,
+        revision,
+        in_toc,
     );
 }
 
@@ -2636,6 +2657,9 @@ fn parse_run_inner(
     theme: &ThemeColors,
     runs: &mut Vec<DocRun>,
     link_href: Option<Option<String>>,
+    // §17.16.23 `w:anchor` — internal bookmark target, threaded alongside
+    // `link_href`. `None` when the link has no anchor / this is not a link run.
+    link_anchor: Option<String>,
     revision: Option<&RunRevision>,
     // True when this run is part of a TOC field's result (§17.16.5.69). Used to
     // suppress the Hyperlink character style's blue/underline on TOC entries.
@@ -2689,6 +2713,10 @@ fn parse_run_inner(
     // the renderer can hit-test, and `hyperlink` carries the resolved href.
     let is_link = link_href.is_some();
     let hyperlink = link_href.clone().flatten();
+    // §17.16.23 — internal bookmark target. Recorded independently of the
+    // external URL: when a link has both, `hyperlink` (external) wins downstream
+    // but the anchor is preserved here; an anchor-only link surfaces here alone.
+    let hyperlink_anchor = link_anchor.clone();
 
     let bold = fmt.bold.unwrap_or(false);
     let italic = fmt.italic.unwrap_or(false);
@@ -2789,6 +2817,7 @@ fn parse_run_inner(
                         border: border.clone(),
                         vert_align: vert_align.clone(),
                         hyperlink: hyperlink.clone(),
+                        hyperlink_anchor: hyperlink_anchor.clone(),
                         all_caps,
                         small_caps,
                         double_strikethrough,
@@ -2857,6 +2886,7 @@ fn parse_run_inner(
                         border: border.clone(),
                         vert_align: vert_align.clone(),
                         hyperlink: hyperlink.clone(),
+                        hyperlink_anchor: hyperlink_anchor.clone(),
                         all_caps,
                         small_caps,
                         double_strikethrough,
@@ -2895,6 +2925,7 @@ fn parse_run_inner(
                     border: border.clone(),
                     vert_align: vert_align.clone(),
                     hyperlink: hyperlink.clone(),
+                    hyperlink_anchor: hyperlink_anchor.clone(),
                     all_caps,
                     small_caps,
                     double_strikethrough,
@@ -2978,6 +3009,7 @@ fn parse_run_inner(
                     border: border.clone(),
                     vert_align: vert_align.clone(),
                     hyperlink: hyperlink.clone(),
+                    hyperlink_anchor: hyperlink_anchor.clone(),
                     all_caps,
                     small_caps,
                     double_strikethrough,
@@ -3096,6 +3128,7 @@ fn parse_run_inner(
                             theme,
                             runs,
                             link_href.clone(),
+                            link_anchor.clone(),
                             revision,
                             in_toc,
                         );
@@ -3159,6 +3192,7 @@ fn parse_run_inner(
                     // baseline for that exact token.
                     vert_align: Some("super".to_string()),
                     hyperlink: hyperlink.clone(),
+                    hyperlink_anchor: hyperlink_anchor.clone(),
                     all_caps,
                     small_caps,
                     double_strikethrough,
@@ -12964,6 +12998,58 @@ mod strict_namespace_tests {
             runs[0].hyperlink.as_deref(),
             Some("https://example.com/"),
             "Strict r:id must resolve via relationships"
+        );
+        assert_eq!(
+            runs[0].hyperlink_anchor, None,
+            "an r:id-only link has no internal anchor"
+        );
+    }
+
+    // ECMA-376 §17.16.23 — an anchor-only `<w:hyperlink w:anchor>` (internal
+    // cross-reference / bookmark jump, no r:id) records the bookmark name in
+    // `hyperlink_anchor` and leaves the external `hyperlink` URL unset.
+    #[test]
+    fn hyperlink_anchor_only_captured() {
+        let p = parse_strict_p(
+            r#"<w:hyperlink w:anchor="_Bookmark1"><w:r><w:t>jump</w:t></w:r></w:hyperlink>"#,
+            &HashMap::new(),
+        );
+        let runs = text_runs(&p);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "jump");
+        assert!(runs[0].is_link, "an anchor-only link is still a link");
+        assert_eq!(
+            runs[0].hyperlink, None,
+            "anchor-only link carries no external URL"
+        );
+        assert_eq!(
+            runs[0].hyperlink_anchor.as_deref(),
+            Some("_Bookmark1"),
+            "w:anchor must be captured as the internal target"
+        );
+    }
+
+    // When a `<w:hyperlink>` carries BOTH r:id and w:anchor, the external URL
+    // wins for `hyperlink` while the anchor is still recorded independently.
+    #[test]
+    fn hyperlink_rid_and_anchor_both_recorded() {
+        let mut rels = HashMap::new();
+        rels.insert("rId1".to_string(), "https://example.com/".to_string());
+        let p = parse_strict_p(
+            r#"<w:hyperlink r:id="rId1" w:anchor="_Bookmark1"><w:r><w:t>both</w:t></w:r></w:hyperlink>"#,
+            &rels,
+        );
+        let runs = text_runs(&p);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(
+            runs[0].hyperlink.as_deref(),
+            Some("https://example.com/"),
+            "r:id (external) still wins for the URL"
+        );
+        assert_eq!(
+            runs[0].hyperlink_anchor.as_deref(),
+            Some("_Bookmark1"),
+            "the anchor is recorded even when r:id is present"
         );
     }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1046,6 +1046,13 @@ pub struct TextRun {
     pub vert_align: Option<String>,
     /// Target URL for hyperlinks (from relationships.xml), None if not a link or no URL
     pub hyperlink: Option<String>,
+    /// ECMA-376 §17.16.23 `<w:hyperlink w:anchor>` — internal bookmark name this
+    /// link jumps to (a `<w:bookmarkStart w:name>` in the same document). Set for
+    /// an internal cross-reference / TOC entry. When a `<w:hyperlink>` carries
+    /// BOTH `r:id` and `w:anchor`, the external URL wins for `hyperlink` while the
+    /// anchor is still recorded here. `None` when the link has no anchor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hyperlink_anchor: Option<String>,
     /// Transform all characters to uppercase (w:caps)
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub all_caps: bool,

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -4,6 +4,10 @@ export { DocxViewer, type DocxViewerOptions } from './viewer';
 export { DocxScrollViewer, type DocxScrollViewerOptions } from './scroll-viewer';
 export { buildDocxTextLayer } from './text-layer';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
+// IX1 — the shared hyperlink target shape surfaced by `DocxViewerOptions.
+// onHyperlinkClick`, `DocxTextRunInfo.hyperlink`, and the 5th arg of
+// `buildDocxTextLayer`, plus the default "open in a new tab, sanitised" helper.
+export { type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
 // Typed load-time error surfaced by DocxDocument.load (e.g. a password-protected
 // or legacy-binary .doc file). Re-exported so `@silurus/ooxml/docx` consumers can
 // narrow on `err.code`.

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -19,7 +19,7 @@ import type {
   DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeTextRun, FieldRun,
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
-import type { MathNode, KinsokuRules, ChartModel } from '@silurus/ooxml-core';
+import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget } from '@silurus/ooxml-core';
 import type { RenderState, DecodedImage } from './renderer.js';
 import {
   classifyCjkFont,
@@ -105,6 +105,12 @@ export interface LayoutTextSeg {
    *  per segment, so body behaviour is unchanged); the TEXT-BOX metrics
    *  (`lineMetricsFor`) floor on it so a text box matches PR #640/#646/#648. */
   eaFloorFamily?: string | null;
+  /** IX1 — the resolved hyperlink target of the originating run (ECMA-376
+   *  §17.16.22 external `r:id` URL / §17.16.23 internal `w:anchor` bookmark),
+   *  computed once per run in `buildSegments`. Carried purely so the text-layer
+   *  overlay can build a clickable region; it does NOT affect measurement, line
+   *  breaking, or the drawn glyphs. Absent for a non-link run. */
+  hyperlink?: HyperlinkTarget;
 }
 
 /**
@@ -1232,6 +1238,17 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
     const r = base as DocxTextRun;
     const rtl = r.rtl === true ? true : undefined;
 
+    // IX1 — resolve the run's hyperlink target ONCE (§17.16.22 external URL /
+    // §17.16.23 internal anchor). An external URL (`r.hyperlink`) wins over the
+    // internal `w:anchor` when both are present, matching the parser's rule. A
+    // FieldRun carries neither field, so the `as DocxTextRun` guards yield
+    // undefined. Purely a callback payload — it does not touch measurement.
+    const hyperlink: HyperlinkTarget | undefined = r.hyperlink
+      ? { kind: 'external', url: r.hyperlink }
+      : r.hyperlinkAnchor
+        ? { kind: 'internal', ref: r.hyperlinkAnchor }
+        : undefined;
+
     // ECMA-376 §17.3.2.26 content classification. A run with `w:rtl`
     // (§17.3.2.30) or the `<w:cs/>` toggle (§17.3.2.7) applies complex-script
     // formatting to ALL of its characters; otherwise each character is routed by
@@ -1309,6 +1326,9 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         // §17.3.2.26 declared eastAsia axis — recorded for the text-box line-box
         // floor only (see LayoutTextSeg.eaFloorFamily). Inert for the body path.
         eaFloorFamily: eaFontFamily,
+        // IX1 — resolved hyperlink target of the originating run, for the
+        // text-layer clickable overlay. Does not affect layout or drawing.
+        hyperlink,
       });
       firstSeg = false;
       gluePending = false; // glue applies only to a piece's FIRST segment

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -50,7 +50,7 @@ import {
   drawUnderline,
   renderChart,
 } from '@silurus/ooxml-core';
-import type { MathNode, MathRenderer, KinsokuRules } from '@silurus/ooxml-core';
+import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget } from '@silurus/ooxml-core';
 import { docxUnderlineToDrawingML } from './underline-map.js';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import {
@@ -379,6 +379,11 @@ export interface DocxTextRunInfo {
    *  horizontal DOM span along the drawn (rotated) glyph run. Absent for
    *  horizontal pages (the span is placed at `x`/`y` untransformed). */
   transform?: string;
+  /** IX1 — the resolved hyperlink target of this run (ECMA-376 §17.16.22
+   *  external URL / §17.16.23 internal `w:anchor` bookmark), or absent for a
+   *  non-link run. The text-layer overlay turns a run carrying this into a
+   *  clickable region; the drawn glyphs are unaffected. */
+  hyperlink?: HyperlinkTarget;
 }
 
 export interface RenderDocumentOptions {
@@ -5870,6 +5875,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             fontSize: effSizePx,
             font: ctx.font,
             transform: place?.transform,
+            // IX1 — hand the resolved hyperlink target to the overlay so a link
+            // run becomes clickable. Undefined for non-link runs (no payload
+            // change). Does not touch any drawing above.
+            hyperlink: s.hyperlink,
           });
         }
 

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,4 +1,5 @@
-import { computeVisibleRange, PT_TO_PX, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
+import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
 import type { DocxTextRunInfo } from './renderer';
@@ -111,6 +112,11 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
    *  `computeVisibleRange` (the first page intersecting the viewport top,
    *  EXCLUDING overscan). */
   onVisiblePageChange?: (topIndex: number, total: number) => void;
+  /** IX1 (design decision — NOT user-confirmed, integrator may veto). Called when
+   *  a hyperlink run is clicked. When omitted, the default is: external → open in a
+   *  new tab via core `openExternalHyperlink` (sanitised, noopener,noreferrer);
+   *  internal → jump to the page whose text contains the bookmark (best-effort). */
+  onHyperlinkClick?: (target: HyperlinkTarget) => void;
   /** Error callback. When set, `load()` invokes it and resolves (otherwise the
    *  error is rethrown — shared viewer error contract). It ALSO fires for async
    *  per-slot render failures (both main `renderPage` and worker
@@ -745,6 +751,7 @@ export class DocxScrollViewer {
             runs,
             slot.canvas.style.width || `${slot.canvas.width}px`,
             slot.canvas.style.height || `${slot.canvas.height}px`,
+            this._hyperlinkHandler(),
           );
         }
       })
@@ -763,6 +770,29 @@ export class DocxScrollViewer {
         "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
       );
     }
+  }
+
+  /**
+   * IX1 — the click handler passed to the text-layer overlay. When the caller
+   * supplied `onHyperlinkClick`, it fully owns the behaviour (the default is
+   * suppressed). Otherwise the built-in default is: an external link opens in a
+   * new tab through core `openExternalHyperlink` (URL sanitised against the safe
+   * scheme allowlist, `noopener,noreferrer`); an internal `w:anchor` link is a
+   * no-op for now — jumping to a bookmark needs a bookmark→page/offset map that
+   * the docx pipeline does not yet expose, and faking it would scroll to the
+   * wrong place.
+   */
+  private _hyperlinkHandler(): (target: HyperlinkTarget) => void {
+    const custom = this._opts.onHyperlinkClick;
+    if (custom) return custom;
+    return (target: HyperlinkTarget): void => {
+      if (target.kind === 'external') {
+        openExternalHyperlink(target.url);
+      }
+      // TODO IX1: resolve bookmark -> page/offset (needs a bookmarkStart → page
+      // map from the paginator) and scroll to it; until then an internal anchor
+      // click is intentionally inert rather than scrolling to a guessed page.
+    };
   }
 
   /** Route an async render failure to `onError`, or `console.error` when none is
@@ -1137,6 +1167,7 @@ export class DocxScrollViewer {
               runs,
               spare.style.width || `${spare.width}px`,
               spare.style.height || `${spare.height}px`,
+              this._hyperlinkHandler(),
             );
           }
         }

--- a/packages/docx/src/text-layer-hyperlink.test.ts
+++ b/packages/docx/src/text-layer-hyperlink.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildDocxTextLayer } from './text-layer.js';
+import type { DocxTextRunInfo } from './renderer';
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
+
+// IX1 clickable-hyperlink overlay. Same node-env `vi.stubGlobal` DOM stub as
+// text-layer.test.ts (no jsdom in this workspace), extended with `title` and an
+// `addEventListener` that records the click handler so a test can dispatch a
+// synthetic click. buildDocxTextLayer turns a run carrying a resolved
+// HyperlinkTarget into a clickable span (cursor:pointer + title + click handler)
+// while leaving plain runs byte-identical.
+
+interface FakeEl {
+  tag: string;
+  textContent: string;
+  innerHTML: string;
+  title: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  listeners: Record<string, Array<() => void>>;
+  appendChild(c: FakeEl): void;
+  addEventListener(type: string, cb: () => void): void;
+  click(): void;
+}
+
+function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    textContent: '',
+    innerHTML: '',
+    title: '',
+    children: [],
+    listeners: {},
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const idx = decl.indexOf(':');
+            if (idx > 0) target[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+    addEventListener(type: string, cb: () => void) {
+      (this.listeners[type] ??= []).push(cb);
+    },
+    // Fire every registered click listener, mimicking a user click.
+    click() {
+      for (const cb of this.listeners['click'] ?? []) cb();
+    },
+  };
+  return el;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+function run(partial: Partial<DocxTextRunInfo>): DocxTextRunInfo {
+  return {
+    text: 'X',
+    x: 0,
+    y: 0,
+    w: 10,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    ...partial,
+  };
+}
+
+const EXTERNAL: HyperlinkTarget = { kind: 'external', url: 'https://example.com/' };
+
+describe('buildDocxTextLayer — IX1 clickable hyperlinks', () => {
+  it('makes a hyperlink run clickable and leaves a plain run untouched', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const onHyperlinkClick = vi.fn<(t: HyperlinkTarget) => void>();
+    const runs = [
+      run({ text: 'link', hyperlink: EXTERNAL }),
+      run({ text: 'plain' }),
+    ];
+    buildDocxTextLayer(
+      layer as unknown as HTMLDivElement,
+      runs,
+      '700px',
+      '900px',
+      onHyperlinkClick,
+    );
+
+    expect(layer.children.length).toBe(2);
+    const [linkSpan, plainSpan] = layer.children;
+
+    // The hyperlink span: pointer cursor, a title tooltip = the URL, still a
+    // <span> (NOT an <a href>) with transparent glyphs (drawn on canvas).
+    expect(linkSpan.tag).toBe('span');
+    expect(linkSpan.style.cursor).toBe('pointer');
+    expect(linkSpan.style.color).toBe('transparent');
+    expect(linkSpan.title).toBe('https://example.com/');
+
+    // Clicking it invokes the handler with the exact external target.
+    expect(onHyperlinkClick).not.toHaveBeenCalled();
+    linkSpan.click();
+    expect(onHyperlinkClick).toHaveBeenCalledTimes(1);
+    expect(onHyperlinkClick).toHaveBeenCalledWith(EXTERNAL);
+
+    // The plain run: text cursor, no title, no click handler — clicking does
+    // nothing.
+    expect(plainSpan.style.cursor).toBe('text');
+    expect(plainSpan.title).toBe('');
+    plainSpan.click();
+    expect(onHyperlinkClick).toHaveBeenCalledTimes(1); // still just the one call
+  });
+
+  it('an internal-anchor run tooltips the bookmark ref and fires with the internal target', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const onHyperlinkClick = vi.fn<(t: HyperlinkTarget) => void>();
+    const internal: HyperlinkTarget = { kind: 'internal', ref: '_Bookmark1' };
+    buildDocxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [run({ text: 'jump', hyperlink: internal })],
+      '700px',
+      '900px',
+      onHyperlinkClick,
+    );
+
+    const [span] = layer.children;
+    expect(span.style.cursor).toBe('pointer');
+    expect(span.title).toBe('_Bookmark1');
+    span.click();
+    expect(onHyperlinkClick).toHaveBeenCalledWith(internal);
+  });
+
+  it('without an onHyperlinkClick handler, a hyperlink run stays a plain (text-cursor) span', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // No 5th arg: link runs must render exactly like plain runs (no affordance).
+    buildDocxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [run({ text: 'link', hyperlink: EXTERNAL })],
+      '700px',
+      '900px',
+    );
+
+    const [span] = layer.children;
+    expect(span.style.cursor).toBe('text');
+    expect(span.title).toBe('');
+    expect(span.listeners['click']).toBeUndefined();
+  });
+});

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -1,4 +1,5 @@
 import type { DocxTextRunInfo } from './renderer';
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
 
 /**
  * Build the transparent text-selection overlay for a rendered docx page: one
@@ -10,17 +11,28 @@ import type { DocxTextRunInfo } from './renderer';
  * overlay (design §10). MAIN render mode only — `onTextRun` cannot cross the
  * worker boundary.
  *
- * @param layer           the overlay div (position:relative parent expected).
- * @param runs            per-run geometry from `renderPage({ onTextRun })`.
- * @param canvasCssWidth  the rendered canvas's CSS width (e.g. `"700px"`), used
- *                        to size the overlay to match the canvas.
- * @param canvasCssHeight the rendered canvas's CSS height.
+ * @param layer            the overlay div (position:relative parent expected).
+ * @param runs             per-run geometry from `renderPage({ onTextRun })`.
+ * @param canvasCssWidth   the rendered canvas's CSS width (e.g. `"700px"`), used
+ *                         to size the overlay to match the canvas.
+ * @param canvasCssHeight  the rendered canvas's CSS height.
+ * @param onHyperlinkClick IX1 — invoked when a run carrying a resolved
+ *                         {@link HyperlinkTarget} is clicked. A hyperlink run's
+ *                         span keeps its transparent glyphs (the visible link
+ *                         colour/underline is already drawn on the canvas) but
+ *                         gains `cursor:pointer`, a `title` tooltip (the URL or
+ *                         bookmark ref) and this click handler. A plain
+ *                         `<span>` — not an `<a href>` — is used deliberately so
+ *                         the browser's own navigation can never bypass the
+ *                         caller's URL sanitisation. When omitted, link runs are
+ *                         rendered exactly like plain runs (no click affordance).
  */
 export function buildDocxTextLayer(
   layer: HTMLDivElement,
   runs: DocxTextRunInfo[],
   canvasCssWidth: string,
   canvasCssHeight: string,
+  onHyperlinkClick?: (target: HyperlinkTarget) => void,
 ): void {
   layer.innerHTML = '';
   layer.style.width = canvasCssWidth;
@@ -43,12 +55,23 @@ export function buildDocxTextLayer(
     const transform = run.transform
       ? `transform:${run.transform};transform-origin:top left;`
       : '';
+    // IX1 — a run with a resolved hyperlink target becomes a clickable region.
+    // Only the cursor changes to a pointer and a title tooltip is added; the
+    // glyphs stay `color:transparent` (the link's blue/underline is already
+    // painted on the canvas), so a link run's selection behaviour is otherwise
+    // identical to a plain run. A non-link run is byte-identical to before.
+    const link = onHyperlinkClick ? run.hyperlink : undefined;
+    const cursor = link ? 'pointer' : 'text';
     span.style.cssText =
       `position:absolute;` +
       `left:${run.x}px;top:${run.y}px;` +
       `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
       transform +
-      `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
+      `white-space:pre;color:transparent;cursor:${cursor};pointer-events:all;`;
+    if (link && onHyperlinkClick) {
+      span.title = link.kind === 'external' ? link.url : link.ref;
+      span.addEventListener('click', () => onHyperlinkClick(link));
+    }
     layer.appendChild(span);
   }
 }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -906,6 +906,12 @@ export interface DocxTextRun {
   vertAlign: 'super' | 'sub' | null;
   /** Target URL for hyperlinks (resolved from relationships.xml) */
   hyperlink: string | null;
+  /** ECMA-376 §17.16.23 `<w:hyperlink w:anchor>` — internal bookmark name this
+   *  link jumps to (a `<w:bookmarkStart w:name>` in the same document). Set for an
+   *  internal cross-reference / TOC entry. When a link carries both `r:id` and
+   *  `w:anchor`, {@link DocxTextRun.hyperlink} (external) wins and this still
+   *  records the anchor. Absent when the link has no anchor. */
+  hyperlinkAnchor?: string | null;
   allCaps?: boolean;
   smallCaps?: boolean;
   doubleStrikethrough?: boolean;

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -3,6 +3,8 @@ import type { LoadOptions } from './document';
 import type { RenderPageOptions } from './types';
 import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
+import { openExternalHyperlink } from '@silurus/ooxml-core';
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
 
 export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   container?: HTMLElement;
@@ -13,6 +15,11 @@ export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   enableTextSelection?: boolean;
   /** Called when a page finishes rendering. */
   onPageChange?: (index: number, total: number) => void;
+  /** IX1 (design decision — NOT user-confirmed, integrator may veto). Called when
+   *  a hyperlink run is clicked. When omitted, the default is: external → open in a
+   *  new tab via core `openExternalHyperlink` (sanitised, noopener,noreferrer);
+   *  internal → jump to the page whose text contains the bookmark (best-effort). */
+  onHyperlinkClick?: (target: HyperlinkTarget) => void;
   /** Called on parse or render errors. */
   onError?: (err: Error) => void;
 }
@@ -289,6 +296,30 @@ export class DocxViewer {
       runs,
       this._canvas.style.width || this._canvas.width + 'px',
       this._canvas.style.height || this._canvas.height + 'px',
+      this._hyperlinkHandler(),
     );
+  }
+
+  /**
+   * IX1 — the click handler passed to the text-layer overlay. When the caller
+   * supplied `onHyperlinkClick`, it fully owns the behaviour (the default is
+   * suppressed). Otherwise the built-in default is: an external link opens in a
+   * new tab through core `openExternalHyperlink` (URL sanitised against the safe
+   * scheme allowlist, `noopener,noreferrer`); an internal `w:anchor` link is a
+   * no-op for now — jumping to a bookmark needs a bookmark→page index that the
+   * docx pipeline does not yet expose, and faking it would land on the wrong
+   * page.
+   */
+  private _hyperlinkHandler(): (target: HyperlinkTarget) => void {
+    const custom = this._opts.onHyperlinkClick;
+    if (custom) return custom;
+    return (target: HyperlinkTarget): void => {
+      if (target.kind === 'external') {
+        openExternalHyperlink(target.url);
+      }
+      // TODO IX1: resolve bookmark -> page (needs a bookmarkStart → page map from
+      // the paginator) and call goToPage(); until then an internal anchor click
+      // is intentionally inert rather than jumping to a guessed page.
+    };
   }
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1930,6 +1930,41 @@ mod tests {
         assert_eq!(parsed.hyperlink.as_deref(), Some("https://example.com/"));
     }
 
+    /// ECMA-376 §21.1.2.3.5 — a:hlinkClick @action="ppaction://hlinksldjump"
+    /// marks an INTERNAL slide jump. The r:id resolves to the internal slide
+    /// part (TargetMode=Internal), and the raw action verb is carried through
+    /// on `hyperlink_action` so the TS side can classify it as internal.
+    #[test]
+    fn test_parse_run_hyperlink_internal_slidejump_action() {
+        let xml = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><rPr lang="en-US"><hlinkClick r:id="rId5" action="ppaction://hlinksldjump"/></rPr><t>Go to slide 3</t></r>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::new();
+        let mut rels = HashMap::new();
+        rels.insert("rId5".to_owned(), "../slides/slide3.xml".to_owned());
+
+        let parsed = parse_run(doc.root_element(), None, &theme, &rels).expect("run should parse");
+        assert_eq!(parsed.hyperlink.as_deref(), Some("../slides/slide3.xml"));
+        assert_eq!(
+            parsed.hyperlink_action.as_deref(),
+            Some("ppaction://hlinksldjump")
+        );
+    }
+
+    /// An external URL hlinkClick (no @action) leaves hyperlink_action = None.
+    #[test]
+    fn test_parse_run_hyperlink_external_has_no_action() {
+        let xml = r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><rPr lang="en-US"><hlinkClick r:id="rId7"/></rPr><t>Open site</t></r>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let r_node = doc.root_element();
+        let theme = HashMap::new();
+        let mut rels = HashMap::new();
+        rels.insert("rId7".to_owned(), "https://example.com/".to_owned());
+
+        let parsed = parse_run(r_node, None, &theme, &rels).expect("run should parse");
+        assert_eq!(parsed.hyperlink.as_deref(), Some("https://example.com/"));
+        assert!(parsed.hyperlink_action.is_none());
+    }
+
     /// A run without hlinkClick should have hyperlink = None.
     #[test]
     fn test_parse_run_without_hyperlink_is_none() {

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -109,16 +109,45 @@ pub(crate) fn is_placeholder(node: roxmltree::Node<'_, '_>) -> bool {
         .any(|n| n.is_element() && n.tag_name().name() == "ph")
 }
 
-/// Pull `(id, name)` from a sibling `<p:nvSpPr><p:cNvPr>` (or `<p:nvCxnSpPr>`).
-/// Returns `(None, None)` when the wrapper is missing — both fields are
-/// optional in the JSON output.
-pub(crate) fn read_cnv_pr(sp_node: roxmltree::Node<'_, '_>) -> (Option<String>, Option<String>) {
+/// Non-visual drawing props pulled from a shape's own `<p:cNvPr>`.
+#[derive(Default)]
+pub(crate) struct CNvPrInfo {
+    pub(crate) id: Option<String>,
+    pub(crate) name: Option<String>,
+    /// Shape-level hyperlink target resolved via `rels` (URL for external,
+    /// internal part name for a slide jump). ECMA-376 §21.1.2.3.5.
+    pub(crate) hyperlink: Option<String>,
+    /// Raw `<a:hlinkClick @action>` (e.g. "ppaction://hlinksldjump").
+    pub(crate) hyperlink_action: Option<String>,
+}
+
+/// Pull `id` / `name` / shape-level `hlinkClick` from a node's own
+/// `<p:nvSpPr><p:cNvPr>` (or `nvCxnSpPr` etc.). Returns defaults when the
+/// wrapper is missing — every field is optional in the JSON output.
+///
+/// ECMA-376 §21.1.2.3.5: a `<p:cNvPr>` may carry an `<a:hlinkClick @r:id
+/// [@action]>`, making the whole shape a click target. `@r:id` resolves via the
+/// slide `rels`; `@action` (when a "ppaction://..." verb) marks an internal
+/// navigation, mirroring the text-run hyperlink parse in `parse_run`.
+pub(crate) fn read_cnv_pr(
+    sp_node: roxmltree::Node<'_, '_>,
+    rels: &HashMap<String, String>,
+) -> CNvPrInfo {
     if let Some(cnv) = own_cnv_pr(sp_node) {
-        let id = attr(&cnv, "id");
-        let name = attr(&cnv, "name").filter(|s| !s.is_empty());
-        return (id, name);
+        let hlink_click = child(cnv, "hlinkClick");
+        return CNvPrInfo {
+            id: attr(&cnv, "id"),
+            name: attr(&cnv, "name").filter(|s| !s.is_empty()),
+            hyperlink: hlink_click
+                .and_then(|h| attr_r(&h, "id"))
+                .and_then(|rid| rels.get(&rid).cloned())
+                .filter(|s| !s.is_empty()),
+            hyperlink_action: hlink_click
+                .and_then(|h| attr(&h, "action"))
+                .filter(|s| !s.is_empty()),
+        };
     }
-    (None, None)
+    CNvPrInfo::default()
 }
 
 /// Locate the shape/tree node's OWN `<p:cNvPr>` — the `cNvPr` inside this
@@ -183,7 +212,7 @@ pub(crate) fn parse_shape(
     let placeholder_type_out: Option<String> = ph_node
         .as_ref()
         .map(|n| attr(n, "type").unwrap_or_else(|| "body".into()));
-    let (cnv_id, cnv_name) = read_cnv_pr(sp_node);
+    let cnv = read_cnv_pr(sp_node, rels);
 
     // --- Transform: slide xfrm OR layout fallback ---
     let sp_pr = child(sp_node, "spPr");
@@ -525,8 +554,10 @@ pub(crate) fn parse_shape(
         glow,
         soft_edge,
         reflection,
-        id: cnv_id,
-        name: cnv_name,
+        id: cnv.id,
+        name: cnv.name,
+        hyperlink: cnv.hyperlink,
+        hyperlink_action: cnv.hyperlink_action,
         placeholder_type: placeholder_type_out,
         placeholder_idx: ph_idx,
         text_rect: None,
@@ -2017,7 +2048,7 @@ pub(crate) fn parse_sp_tree_node(
             if skip_placeholders && is_placeholder(node) {
                 return;
             }
-            if let Some(shape) = parse_connector(node, theme) {
+            if let Some(shape) = parse_connector(node, theme, rels) {
                 out.push(SlideElement::Shape(shape));
             }
         }
@@ -2094,7 +2125,7 @@ fn parse_smartart_drawing(
                 }
             }
             "cxnSp" => {
-                if let Some(shape) = parse_connector(node, theme) {
+                if let Some(shape) = parse_connector(node, theme, &empty_rels) {
                     out.push(SlideElement::Shape(shape));
                 }
             }
@@ -2145,7 +2176,7 @@ fn parse_smartart_drawing(
                             }
                         }
                         "cxnSp" => {
-                            if let Some(shape) = parse_connector(child_node, theme) {
+                            if let Some(shape) = parse_connector(child_node, theme, &empty_rels) {
                                 out.push(SlideElement::Shape(shape));
                             }
                         }
@@ -2201,6 +2232,7 @@ fn offset_slide_element(el: &mut SlideElement, dx: i64, dy: i64) {
 fn parse_connector(
     node: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
+    rels: &HashMap<String, String>,
 ) -> Option<ShapeElement> {
     let sp_pr = child(node, "spPr")?;
     let xfrm = child(sp_pr, "xfrm")?;
@@ -2208,7 +2240,7 @@ fn parse_connector(
     if t.cx == 0 && t.cy == 0 {
         return None;
     }
-    let (cnv_id, cnv_name) = read_cnv_pr(node);
+    let cnv = read_cnv_pr(node, rels);
 
     // Style-based stroke fallback. `p:style > a:lnRef idx="N"` references the
     // theme fmtScheme lnStyleLst entry N (1-based). We look up the canonical
@@ -2360,8 +2392,10 @@ fn parse_connector(
         glow: None,
         soft_edge: None,
         reflection: None,
-        id: cnv_id,
-        name: cnv_name,
+        id: cnv.id,
+        name: cnv.name,
+        hyperlink: cnv.hyperlink,
+        hyperlink_action: cnv.hyperlink_action,
         placeholder_type: None,
         placeholder_idx: None,
         text_rect: None,
@@ -2435,6 +2469,86 @@ mod ole_tests {
             DepthGuard::root(),
         );
         out
+    }
+
+    /// ECMA-376 §21.1.2.3.5 — a `<p:cNvPr><a:hlinkClick @r:id>` on a shape makes
+    /// the whole shape an EXTERNAL click target; r:id resolves via slide rels.
+    #[test]
+    fn shape_cnv_hlink_click_external_resolves_url() {
+        let mut rels = HashMap::new();
+        rels.insert("rId9".to_string(), "https://example.com/".to_string());
+        let mut zip = zip_with(&[]);
+        let xml = format!(
+            r#"<p:sp {ns}>
+                <p:nvSpPr>
+                  <p:cNvPr id="3" name="Rect"><a:hlinkClick r:id="rId9"/></p:cNvPr>
+                  <p:cNvSpPr/><p:nvPr/>
+                </p:nvSpPr>
+                <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                  <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+               </p:sp>"#,
+            ns = ns()
+        );
+        let out = run(&xml, &mut zip, &rels);
+        let shape = match &out[0] {
+            SlideElement::Shape(s) => s,
+            _ => panic!("expected a shape element"),
+        };
+        assert_eq!(shape.hyperlink.as_deref(), Some("https://example.com/"));
+        assert!(shape.hyperlink_action.is_none());
+    }
+
+    /// A `<a:hlinkClick action="ppaction://hlinksldjump" r:id>` on a shape is an
+    /// INTERNAL slide jump: `hyperlink` is the resolved internal slide part and
+    /// `hyperlink_action` carries the raw ppaction verb. ECMA-376 §21.1.2.3.5.
+    #[test]
+    fn shape_cnv_hlink_click_internal_slidejump() {
+        let mut rels = HashMap::new();
+        rels.insert("rId3".to_string(), "../slides/slide3.xml".to_string());
+        let mut zip = zip_with(&[]);
+        let xml = format!(
+            r#"<p:sp {ns}>
+                <p:nvSpPr>
+                  <p:cNvPr id="4" name="Btn"><a:hlinkClick action="ppaction://hlinksldjump" r:id="rId3"/></p:cNvPr>
+                  <p:cNvSpPr/><p:nvPr/>
+                </p:nvSpPr>
+                <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                  <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+               </p:sp>"#,
+            ns = ns()
+        );
+        let out = run(&xml, &mut zip, &rels);
+        let shape = match &out[0] {
+            SlideElement::Shape(s) => s,
+            _ => panic!("expected a shape element"),
+        };
+        assert_eq!(shape.hyperlink.as_deref(), Some("../slides/slide3.xml"));
+        assert_eq!(
+            shape.hyperlink_action.as_deref(),
+            Some("ppaction://hlinksldjump")
+        );
+    }
+
+    /// A shape with no cNvPr hlinkClick has both hyperlink fields None.
+    #[test]
+    fn shape_cnv_without_hlink_click_is_none() {
+        let rels = HashMap::new();
+        let mut zip = zip_with(&[]);
+        let xml = format!(
+            r#"<p:sp {ns}>
+                <p:nvSpPr><p:cNvPr id="5" name="Plain"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+                <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                  <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+               </p:sp>"#,
+            ns = ns()
+        );
+        let out = run(&xml, &mut zip, &rels);
+        let shape = match &out[0] {
+            SlideElement::Shape(s) => s,
+            _ => panic!("expected a shape element"),
+        };
+        assert!(shape.hyperlink.is_none());
+        assert!(shape.hyperlink_action.is_none());
     }
 
     /// PowerPoint's canonical OLE output: `mc:Choice Requires="v"` holds a

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -765,6 +765,7 @@ pub(crate) fn parse_paragraph(
                         None
                     },
                     hyperlink: None,
+                    hyperlink_action: None,
                     shadow: None,
                     outline: None,
                     highlight,
@@ -1007,12 +1008,20 @@ pub(crate) fn parse_run(
         .and_then(|v| v.parse::<i32>().ok())
         .filter(|&v| v != 0);
 
-    // a:hlinkClick — hyperlink. r:id refers to the slide rels (Target = URL or local target).
-    // Resolve immediately so the renderer doesn't need access to the rels table.
-    let hyperlink = r_pr
-        .and_then(|n| child(n, "hlinkClick"))
+    // a:hlinkClick — hyperlink. r:id refers to the slide rels (Target = URL or
+    // internal part name). Resolve immediately so the renderer doesn't need
+    // access to the rels table. ECMA-376 §21.1.2.3.5 (CT_Hyperlink): the
+    // optional @action holds a "ppaction://..." verb (e.g. hlinksldjump) that
+    // marks the link as an INTERNAL navigation; carry it through so the TS side
+    // can distinguish a slide jump from an external URL. For a slide jump the
+    // rel is TargetMode=Internal, so `hyperlink` is the internal slide part.
+    let hlink_click = r_pr.and_then(|n| child(n, "hlinkClick"));
+    let hyperlink = hlink_click
         .and_then(|h| attr_r(&h, "id"))
         .and_then(|rid| rels.get(&rid).cloned())
+        .filter(|s| !s.is_empty());
+    let hyperlink_action = hlink_click
+        .and_then(|h| attr(&h, "action"))
         .filter(|s| !s.is_empty());
 
     // ECMA-376 §20.1.8.45 — `<a:rPr><a:effectLst><a:outerShdw>` glyph drop
@@ -1069,6 +1078,7 @@ pub(crate) fn parse_run(
         letter_spacing,
         field_type: None,
         hyperlink,
+        hyperlink_action,
         shadow,
         outline,
         highlight,

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -365,6 +365,18 @@ pub(crate) struct ShapeElement {
     /// "Rectangle 5"). Useful for tools that want a human-readable handle.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) name: Option<String>,
+    /// Shape-level hyperlink resolved from `<p:nvSpPr><p:cNvPr><a:hlinkClick @r:id>`
+    /// via slide _rels (ECMA-376 §21.1.2.3.5). For an EXTERNAL link this is the
+    /// URL; for an INTERNAL slide-jump it is the resolved internal part name.
+    /// None when the shape has no hlinkClick. Clicking anywhere on the shape
+    /// activates it (distinct from a text-run hyperlink).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) hyperlink: Option<String>,
+    /// Raw `<a:hlinkClick @action>` on the shape's cNvPr (e.g.
+    /// "ppaction://hlinksldjump"), marking an internal action. See
+    /// `TextRunData::hyperlink_action`. None when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) hyperlink_action: Option<String>,
     /// `<p:nvSpPr><p:nvPr><p:ph @type>` — placeholder semantic type
     /// ("title" / "ctrTitle" / "body" / "subTitle" / "ftr" / "sldNum" /
     /// "dt" / "obj" / "pic" / etc., ECMA-376 §19.7.10). `None` for
@@ -987,10 +999,19 @@ pub(crate) struct TextRunData {
     pub(crate) letter_spacing: Option<f64>,
     /// Set for OOXML field elements (e.g. "slidenum" for slide number fields)
     pub(crate) field_type: Option<String>,
-    /// Hyperlink target URL resolved from rPr > hlinkClick @r:id via slide _rels.
-    /// None for runs without a:hlinkClick.
+    /// Hyperlink target resolved from rPr > hlinkClick @r:id via slide _rels.
+    /// For an EXTERNAL link this is the URL; for an INTERNAL slide-jump it is the
+    /// resolved internal part name (e.g. "../slides/slide3.xml", TargetMode=Internal).
+    /// None for runs without a:hlinkClick. ECMA-376 §21.1.2.3.5 (CT_Hyperlink).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) hyperlink: Option<String>,
+    /// Raw `<a:hlinkClick @action>` string (e.g. "ppaction://hlinksldjump")
+    /// when present. Its presence marks the link as an INTERNAL PowerPoint
+    /// action (slide jump / first / last / ...) rather than an external URL;
+    /// `hyperlink` then holds the resolved internal part name for a slide jump.
+    /// None when the hlinkClick has no @action. ECMA-376 §21.1.2.3.5.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) hyperlink_action: Option<String>,
     /// ECMA-376 §20.1.8.45 (CT_OuterShadowEffect) — drop shadow on this run's
     /// glyphs from `<a:rPr><a:effectLst><a:outerShdw>`. Distinct from the
     /// shape-level shadow on `spPr`. None = no shadow on the run.

--- a/packages/pptx/src/hyperlink.test.ts
+++ b/packages/pptx/src/hyperlink.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { classifyPptxHyperlink } from './hyperlink.js';
+
+// IX1 — pptx hyperlink classification. The Rust parser hands the TS side a
+// single resolved target string per run/shape plus (for shapes) the raw
+// `<a:hlinkClick @action>`. classifyPptxHyperlink turns that pair into the
+// shared HyperlinkTarget shape used by the overlay + viewer. ECMA-376
+// §21.1.2.3.5: an action verb (ppaction://…) or a scheme-less/internal part
+// name is INTERNAL; a navigable web scheme is EXTERNAL.
+describe('classifyPptxHyperlink', () => {
+  it('returns undefined when there is no link', () => {
+    expect(classifyPptxHyperlink(undefined)).toBeUndefined();
+    expect(classifyPptxHyperlink('')).toBeUndefined();
+    expect(classifyPptxHyperlink('', '')).toBeUndefined();
+  });
+
+  it('classifies a navigable web URL as external', () => {
+    expect(classifyPptxHyperlink('https://example.com/a')).toEqual({ kind: 'external', url: 'https://example.com/a' });
+    expect(classifyPptxHyperlink('http://x')).toEqual({ kind: 'external', url: 'http://x' });
+    expect(classifyPptxHyperlink('mailto:a@b.com')).toEqual({ kind: 'external', url: 'mailto:a@b.com' });
+    expect(classifyPptxHyperlink('tel:+15551234567')).toEqual({ kind: 'external', url: 'tel:+15551234567' });
+  });
+
+  it('classifies a ppaction:// slide-jump as internal, preferring the resolved part name', () => {
+    // Resolved rels target is the slide part; action marks it internal.
+    expect(
+      classifyPptxHyperlink('../slides/slide3.xml', 'ppaction://hlinksldjump'),
+    ).toEqual({ kind: 'internal', ref: '../slides/slide3.xml' });
+    // Action present but no resolved target (rels miss): fall back to the verb.
+    expect(
+      classifyPptxHyperlink(undefined, 'ppaction://hlinkshowjump?jump=firstslide'),
+    ).toEqual({ kind: 'internal', ref: 'ppaction://hlinkshowjump?jump=firstslide' });
+  });
+
+  it('classifies a bare internal part name (no scheme, no action) as internal', () => {
+    expect(classifyPptxHyperlink('../slides/slide2.xml')).toEqual({ kind: 'internal', ref: '../slides/slide2.xml' });
+  });
+
+  it('treats a non-navigable scheme (would be blocked externally) as internal, matching the sanitiser boundary', () => {
+    // The viewer's default open would refuse these; classifying them internal
+    // (rather than external) means the overlay never hands a blocked scheme to
+    // openExternalHyperlink. The parser is unlikely to resolve such a target,
+    // but the boundary must line up with DEFAULT_ALLOWED_HYPERLINK_SCHEMES.
+    expect(classifyPptxHyperlink('javascript:alert(1)')).toEqual({ kind: 'internal', ref: 'javascript:alert(1)' });
+    expect(classifyPptxHyperlink('file:///etc/passwd')).toEqual({ kind: 'internal', ref: 'file:///etc/passwd' });
+  });
+});

--- a/packages/pptx/src/hyperlink.ts
+++ b/packages/pptx/src/hyperlink.ts
@@ -1,0 +1,70 @@
+/**
+ * PPTX hyperlink classification (IX1).
+ *
+ * The Rust parser hands the TS side a single resolved target string per run /
+ * shape (`hyperlink`) plus, for shapes, the raw `<a:hlinkClick @action>`
+ * (`hyperlinkAction`). This module turns that pair into the format-agnostic
+ * {@link HyperlinkTarget} shape the overlay + viewer consume.
+ *
+ * ECMA-376 §21.1.2.3.5 (CT_Hyperlink): a `<a:hlinkClick>` is EXTERNAL when its
+ * relationship `TargetMode="External"` (an absolute URL — http/https/mailto/tel
+ * etc.), and INTERNAL when it names an action verb (`ppaction://hlinksldjump`
+ * → the rel is `TargetMode="Internal"` and resolves to a slide part such as
+ * `../slides/slide3.xml`).
+ *
+ * Classification is done purely from the resolved target string (the core
+ * `TextRun` type only carries `hyperlink`, so text runs cannot smuggle a second
+ * field through — see the pptx types re-export). The rule:
+ *   - an explicit `hyperlinkAction` (any `ppaction://…`), OR
+ *   - a target whose URL scheme is NOT one of the navigable external schemes
+ *     (http/https/mailto/tel — {@link DEFAULT_ALLOWED_HYPERLINK_SCHEMES}),
+ *     which covers `ppaction://…` targets and bare internal part names like
+ *     `../slides/slide3.xml` (no scheme),
+ * ⇒ INTERNAL. Everything else is EXTERNAL.
+ *
+ * Keeping the scheme predicate in core (`hyperlinkUrlScheme`) means the
+ * external-vs-internal boundary matches the sanitiser's allowlist exactly: a
+ * scheme the viewer would refuse to open externally is treated as internal here
+ * rather than silently dropped.
+ */
+import {
+  type HyperlinkTarget,
+  DEFAULT_ALLOWED_HYPERLINK_SCHEMES,
+  hyperlinkUrlScheme,
+} from '@silurus/ooxml-core';
+
+/**
+ * Classify a resolved pptx hyperlink target into a {@link HyperlinkTarget}, or
+ * `undefined` when there is no link.
+ *
+ * @param target the resolved `hyperlink` string (external URL or internal part
+ *               name), or undefined/empty when the run/shape has no hlinkClick.
+ * @param action the raw `<a:hlinkClick @action>` string when present (shapes
+ *               carry this; text runs pass `undefined`).
+ */
+export function classifyPptxHyperlink(
+  target: string | undefined,
+  action?: string,
+): HyperlinkTarget | undefined {
+  // Narrow to non-empty strings so the returned `url` / `ref` are never empty.
+  const t = target !== undefined && target !== '' ? target : undefined;
+  const a = action !== undefined && action !== '' ? action : undefined;
+  if (t === undefined && a === undefined) return undefined;
+
+  // An action verb (ppaction://…) is always internal. `ref` is the resolved
+  // internal part name when we have one, else the raw action verb.
+  if (a !== undefined) {
+    return { kind: 'internal', ref: t ?? a };
+  }
+
+  // No action: classify by the target's URL scheme. A navigable external scheme
+  // (http/https/mailto/tel) ⇒ external; anything else (a bare internal part
+  // name with no scheme, or a non-navigable scheme) ⇒ internal. `t` is defined
+  // here (a was undefined and at least one of t/a is set).
+  const url = t as string;
+  const scheme = hyperlinkUrlScheme(url);
+  if (scheme !== null && DEFAULT_ALLOWED_HYPERLINK_SCHEMES.includes(scheme)) {
+    return { kind: 'external', url };
+  }
+  return { kind: 'internal', ref: url };
+}

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -10,6 +10,10 @@ export { renderSlide, type RenderOptions, type PptxTextRunInfo, type TextRunCall
 export { buildPptxTextLayer } from './text-layer';
 export type { PresentationHandle } from './presentation-handle';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
+// IX1 — the shared hyperlink target shape surfaced by `PptxViewerOptions.
+// onHyperlinkClick`, `PptxTextRunInfo.hyperlink`, and the 5th arg of
+// `buildPptxTextLayer`, plus the default "open in a new tab, sanitised" helper.
+export { type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
 // Typed load-time error surfaced by PptxPresentation.load (e.g. a
 // password-protected or legacy-binary .ppt file). Re-exported so
 // `@silurus/ooxml/pptx` consumers can narrow on `err.code`.

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -78,6 +78,8 @@ import {
 } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
+import { classifyPptxHyperlink } from './hyperlink';
 import { drawPlayBadge } from './media-chrome';
 import {
   segmentsHaveRtl,
@@ -136,6 +138,14 @@ export interface PptxTextRunInfo {
    * `vert="vert270"` → -90). The CSS overlay must add this to `rotation`.
    */
   textBodyRotation?: number;
+  /**
+   * Resolved hyperlink target for this run (IX1), classified into the shared
+   * {@link HyperlinkTarget} shape. Present only for runs whose `<a:rPr>` carried
+   * an `<a:hlinkClick>`; the overlay makes such spans clickable. The glyph
+   * drawing (colour + underline) is unaffected — this is metadata for the
+   * transparent overlay only.
+   */
+  hyperlink?: HyperlinkTarget;
 }
 
 export type TextRunCallback = (run: PptxTextRunInfo) => void;
@@ -359,6 +369,12 @@ type LayoutSegment = {
    */
   highlight?: string;
   /**
+   * Resolved hyperlink target for this segment's run (IX1). Carried so the
+   * onTextRun callback can attach it to the overlay span. Does not affect glyph
+   * drawing (colour + underline already handled via `color`/`underline`).
+   */
+  hyperlink?: HyperlinkTarget;
+  /**
    * Present when this segment is an OMML equation drawn as an image instead of
    * text (`text` is then ""). Box metrics are in px at the current scale.
    */
@@ -505,6 +521,17 @@ export function cssFontStack(normalized: string): string {
   const nonCjk = variant === 'serif' ? NON_CJK_SERIF_FALLBACKS : NON_CJK_SANS_FALLBACKS;
   const nonCjkPart = `${quoteAll(nonCjk)}, `;
   return `"${normalized}", ${subPart}${cjkPart}${nonCjkPart}${generic}`;
+}
+
+/**
+ * Stable string key for a {@link HyperlinkTarget} so adjacent same-format runs
+ * that carry the SAME link still merge into one segment (classification mints a
+ * fresh object per run, so identity comparison would over-split). `undefined`
+ * (no link) and any two links with the same kind + destination compare equal.
+ */
+function hyperlinkKey(t: HyperlinkTarget | undefined): string {
+  if (!t) return '';
+  return t.kind === 'external' ? `e:${t.url}` : `i:${t.ref}`;
 }
 
 function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string, rc: RenderContext): string {
@@ -692,6 +719,8 @@ export function layoutParagraph(
       highlight?: string;
       /** Raw normalized family for the design-line-height floor (see LayoutSegment). */
       fontFamily?: string;
+      /** Resolved hyperlink target (IX1) — passed through to the overlay span. */
+      hyperlink?: HyperlinkTarget;
     },
   ) => {
     if (!text) return;
@@ -710,6 +739,7 @@ export function layoutParagraph(
     const outline = extras?.outline;
     const highlight = extras?.highlight;
     const fontFamily = extras?.fontFamily;
+    const hyperlink = extras?.hyperlink;
     // Shadow / outline use object identity for merging — adjacent runs share
     // the same object since the run is parsed once. Different objects (or
     // one set / one missing) force a new segment.
@@ -727,14 +757,15 @@ export function layoutParagraph(
       a.shadow === shadow &&
       a.outline === outline &&
       (a.highlight ?? '') === (highlight ?? '') &&
-      (a.fontFamily ?? '') === (fontFamily ?? '');
+      (a.fontFamily ?? '') === (fontFamily ?? '') &&
+      hyperlinkKey(a.hyperlink) === hyperlinkKey(hyperlink);
     if (tabActive && currentLine.tabStop) {
       const segs = currentLine.tabStop.segments;
       const last = segs.at(-1);
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        segs.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight });
+        segs.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight, hyperlink });
       }
     } else {
       lineW += w;
@@ -742,7 +773,7 @@ export function layoutParagraph(
       if (last && sameMeta(last)) {
         last.text += text;
       } else {
-        currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight });
+        currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight, hyperlink });
       }
     }
   };
@@ -894,6 +925,12 @@ export function layoutParagraph(
       // RRGGBBAA); hexToRgba handles both, matching how text/underline colours
       // are converted for canvas.
       highlight: run.highlight ? hexToRgba(run.highlight) : undefined,
+      // IX1 — classify the resolved hyperlink target string into the shared
+      // HyperlinkTarget shape (external URL vs internal slide jump). The core
+      // TextRun type carries only `hyperlink` (no action field), so the string
+      // alone drives classification: a ppaction://… or a scheme-less internal
+      // part name is treated as internal. Overlay-only; does not affect glyphs.
+      hyperlink: classifyPptxHyperlink(run.hyperlink),
     };
 
     // Split on whitespace boundaries, keeping the whitespace tokens
@@ -2707,6 +2744,7 @@ export function renderTextBody(
           shapeW: bw,
           shapeH: bh,
           rotation: shapeRotation,
+          hyperlink: seg.hyperlink,
         });
       }
 
@@ -2812,6 +2850,7 @@ export function renderTextBody(
             shapeW: bw,
             shapeH: bh,
             rotation: shapeRotation,
+            hyperlink: seg.hyperlink,
           });
         }
         tabPenX += tabSegW;

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,4 +1,4 @@
-import { computeVisibleRange, EMU_PER_PX, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
+import { computeVisibleRange, EMU_PER_PX, zoomStepScale, type VisibleRange, type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
 import { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
@@ -123,6 +123,16 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
    *  crashing the loop. Without an `onError`, render failures are logged via
    *  `console.error` so they are never fully silent. */
   onError?: (err: Error) => void;
+  /**
+   * IX1 (design decision — NOT user-confirmed, integrator may veto). Fires on a
+   * hyperlink click in any mounted slide's text overlay (requires
+   * {@link enableTextSelection}). Default when omitted: external →
+   * {@link openExternalHyperlink} (new tab, sanitised, noopener); internal
+   * slide-jump → {@link scrollToSlide}(target) once the slide part resolves to
+   * an index (currently a documented no-op). When provided, the viewer calls
+   * this instead and takes NO default action.
+   */
+  onHyperlinkClick?: (target: HyperlinkTarget) => void;
 }
 
 /** One mounted slide. `canvas` is the drawn slide; `textLayer` the optional
@@ -752,7 +762,7 @@ export class PptxScrollViewer {
           // overlay 2× too large (overflowing the wrapper + inflating the scroll
           // area). Pass the CSS px directly — the uniform slide width/height at the
           // current scale (rounded).
-          buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()));
+          buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()), (t) => this._onHyperlinkClick(t));
         }
       })
       .catch((err: unknown) => {
@@ -1142,7 +1152,7 @@ export class PptxScrollViewer {
           if (wantOverlay) {
             // buildPptxTextLayer takes NUMBERS: pass the CSS box (uniform slide
             // width/height at the current scale), NOT the retina backing store.
-            buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()));
+            buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()), (t) => this._onHyperlinkClick(t));
           }
         }
       })
@@ -1194,6 +1204,30 @@ export class PptxScrollViewer {
       this._scrollHost.scrollTop = top;
     }
     this._mountVisible();
+  }
+
+  /**
+   * IX1 hyperlink click dispatch (mirrors {@link PptxViewer._onHyperlinkClick}).
+   * When the integrator supplies `opts.onHyperlinkClick` it OWNS the click (no
+   * default). Otherwise: an external link opens in a new tab via the shared,
+   * scheme-sanitised {@link openExternalHyperlink}; an internal slide jump would
+   * scroll to the target slide via {@link scrollToSlide} once the target part
+   * resolves to a slide index.
+   */
+  private _onHyperlinkClick(target: HyperlinkTarget): void {
+    if (this._opts.onHyperlinkClick) {
+      this._opts.onHyperlinkClick(target);
+      return;
+    }
+    if (target.kind === 'external') {
+      openExternalHyperlink(target.url);
+      return;
+    }
+    // Internal slide jump. Mapping `target.ref` (e.g. "../slides/slide3.xml")
+    // to a 0-based index is NOT cheaply available: the parsed Slide model has no
+    // part name and file-number matching is a forbidden heuristic (see
+    // CLAUDE.md). No-op until the parser surfaces each slide's part name.
+    // TODO IX1: resolve slide part -> index, then `this.scrollToSlide(idx);`.
   }
 
   /**

--- a/packages/pptx/src/text-layer-hyperlink.test.ts
+++ b/packages/pptx/src/text-layer-hyperlink.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildPptxTextLayer } from './text-layer.js';
+import type { PptxTextRunInfo } from './renderer';
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
+
+// IX1 — clickable hyperlink overlay. No DOM environment is installed (the pptx
+// unit tests run in node, see the sibling text-layer.test.ts), so this uses the
+// same recording DOM stub, EXTENDED with `title`, `addEventListener`, and a
+// `click()` that dispatches to registered `click` listeners. That lets us assert
+// the span's click handler fires with the exact HyperlinkTarget without pulling
+// in jsdom/happy-dom.
+
+interface FakeEl {
+  tag: string;
+  textContent: string;
+  innerHTML: string;
+  title: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  _listeners: Record<string, ((e: { preventDefault(): void }) => void)[]>;
+  appendChild(c: FakeEl): void;
+  addEventListener(type: string, fn: (e: { preventDefault(): void }) => void): void;
+  click(): void;
+}
+function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    textContent: '',
+    innerHTML: '',
+    title: '',
+    children: [],
+    _listeners: {},
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const i = decl.indexOf(':');
+            if (i > 0) target[decl.slice(0, i).trim()] = decl.slice(i + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+    addEventListener(type: string, fn: (e: { preventDefault(): void }) => void) {
+      (this._listeners[type] ??= []).push(fn);
+    },
+    click() {
+      for (const fn of this._listeners.click ?? []) fn({ preventDefault() {} });
+    },
+  };
+  return el;
+}
+afterEach(() => vi.unstubAllGlobals());
+
+function run(p: Partial<PptxTextRunInfo>): PptxTextRunInfo {
+  return {
+    text: 'X',
+    inShapeX: 0,
+    inShapeY: 0,
+    w: 10,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    shapeX: 0,
+    shapeY: 0,
+    shapeW: 100,
+    shapeH: 50,
+    rotation: 0,
+    ...p,
+  };
+}
+
+const EXTERNAL: HyperlinkTarget = { kind: 'external', url: 'https://example.com/' };
+
+describe('buildPptxTextLayer — clickable hyperlink spans (IX1)', () => {
+  it('makes a hyperlink run clickable (pointer + title + click handler) and leaves a plain run plain', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const onHyperlinkClick = vi.fn<(t: HyperlinkTarget) => void>();
+    const runs = [
+      run({ text: 'link', inShapeX: 2, inShapeY: 4, hyperlink: EXTERNAL }),
+      run({ text: 'plain', inShapeX: 40, inShapeY: 4 }),
+    ];
+    buildPptxTextLayer(layer as unknown as HTMLDivElement, runs, 960, 540, onHyperlinkClick);
+
+    // Both runs share one shape frame ⇒ one group div holding two spans.
+    const shapeDiv = layer.children[0];
+    const [linkSpan, plainSpan] = shapeDiv.children;
+
+    // Link span: pointer cursor, tooltip = the URL, transparent glyph colour.
+    expect(linkSpan.textContent).toBe('link');
+    expect(linkSpan.style.cursor).toBe('pointer');
+    expect(linkSpan.title).toBe('https://example.com/');
+    expect(linkSpan.style.color).toBe('transparent');
+
+    // Plain span: default text cursor, no tooltip.
+    expect(plainSpan.textContent).toBe('plain');
+    expect(plainSpan.style.cursor).toBe('text');
+    expect(plainSpan.title).toBe('');
+
+    // Clicking the link span invokes the handler with the exact target; the
+    // plain run registered no listener, so clicking it does nothing.
+    linkSpan.click();
+    expect(onHyperlinkClick).toHaveBeenCalledTimes(1);
+    expect(onHyperlinkClick).toHaveBeenCalledWith(EXTERNAL);
+
+    plainSpan.click();
+    expect(onHyperlinkClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves hyperlink spans non-interactive when no onHyperlinkClick is supplied', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildPptxTextLayer(layer as unknown as HTMLDivElement, [run({ text: 'link', hyperlink: EXTERNAL })], 960, 540);
+    const span = layer.children[0].children[0];
+    // Without a handler the span stays a plain, selectable text span.
+    expect(span.style.cursor).toBe('text');
+    expect(span.title).toBe('');
+    expect(span._listeners.click ?? []).toHaveLength(0);
+  });
+
+  it('uses the internal ref as the tooltip for an internal slide-jump link', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const onHyperlinkClick = vi.fn<(t: HyperlinkTarget) => void>();
+    const internal: HyperlinkTarget = { kind: 'internal', ref: '../slides/slide3.xml' };
+    buildPptxTextLayer(layer as unknown as HTMLDivElement, [run({ text: 'go', hyperlink: internal })], 960, 540, onHyperlinkClick);
+    const span = layer.children[0].children[0];
+    expect(span.style.cursor).toBe('pointer');
+    expect(span.title).toBe('../slides/slide3.xml');
+    span.click();
+    expect(onHyperlinkClick).toHaveBeenCalledWith(internal);
+  });
+});

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -1,3 +1,4 @@
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
 import type { PptxTextRunInfo } from './renderer';
 
 /**
@@ -12,16 +13,26 @@ import type { PptxTextRunInfo } from './renderer';
  * integrators (design §10). MAIN render mode only — `onTextRun` cannot cross the
  * worker boundary.
  *
+ * IX1 — when a run carries a resolved `hyperlink` (from `<a:hlinkClick>`) and an
+ * `onHyperlinkClick` callback is supplied, its span becomes a click target
+ * (`cursor:pointer`, a `title` tooltip, and a `click` handler). A plain span
+ * (no hyperlink) is byte-identical to before. A JS click handler is used rather
+ * than an `<a href>` so the URL never bypasses the viewer's sanitisation.
+ *
  * @param layer     the overlay div.
  * @param runs      per-run + per-shape geometry from `renderSlide({ onTextRun })`.
  * @param cssWidth  the rendered canvas's CSS width (px, number).
  * @param cssHeight the rendered canvas's CSS height (px, number).
+ * @param onHyperlinkClick called with the run's resolved {@link HyperlinkTarget}
+ *                         when a hyperlink span is clicked. Omit to leave links
+ *                         non-interactive (spans stay plain, selectable text).
  */
 export function buildPptxTextLayer(
   layer: HTMLDivElement,
   runs: PptxTextRunInfo[],
   cssWidth: number,
   cssHeight: number,
+  onHyperlinkClick?: (target: HyperlinkTarget) => void,
 ): void {
   layer.innerHTML = '';
   layer.style.width = `${cssWidth}px`;
@@ -58,11 +69,24 @@ export function buildPptxTextLayer(
     // ligatures are left at the browser default ('auto') because canvas
     // `measureText` / `fillText` also apply them by default — forcing them
     // off here would make the span wider than the drawn text.
+    // Hyperlink runs become clickable when a handler is wired: pointer cursor +
+    // a tooltip + a JS click handler. `color:transparent` is kept (the glyphs
+    // are painted on the canvas underneath, incl. the theme hyperlink colour and
+    // underline) — the span only supplies the hit region. `cursor:text` stays
+    // the default for plain runs so selection UX is unchanged.
+    const link = onHyperlinkClick ? run.hyperlink : undefined;
     span.style.cssText =
       `position:absolute;` +
       `left:${run.inShapeX}px;top:${run.inShapeY}px;` +
       `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
-      `white-space:pre;color:transparent;cursor:text;`;
+      `white-space:pre;color:transparent;cursor:${link ? 'pointer' : 'text'};`;
+    if (link && onHyperlinkClick) {
+      span.title = link.kind === 'external' ? link.url : link.ref;
+      span.addEventListener('click', (e) => {
+        e.preventDefault();
+        onHyperlinkClick(link);
+      });
+    }
     shape.div.appendChild(span);
   }
 }

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -260,6 +260,15 @@ export interface ShapeElement {
   /** `<a:sp3d>` 3D shape properties (ECMA-376 §20.1.5.12). Parsed but not
    *  rendered in Phase A. */
   sp3d?: Sp3d;
+  /** Shape-level hyperlink target resolved from `<p:cNvPr><a:hlinkClick @r:id>`
+   *  via slide _rels (ECMA-376 §21.1.2.3.5). For an external link this is the
+   *  URL; for an internal slide jump it is the resolved internal part name.
+   *  Undefined when the shape carries no hlinkClick. */
+  hyperlink?: string;
+  /** Raw `<a:hlinkClick @action>` (e.g. `"ppaction://hlinksldjump"`) when the
+   *  shape link is an internal PowerPoint action rather than an external URL.
+   *  Undefined when absent. */
+  hyperlinkAction?: string;
 }
 
 /** Absolute text-frame rectangle in EMU (from SmartArt `<dsp:txXfrm>`). */

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -4,6 +4,7 @@ import { PptxPresentation, type LoadOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible } from './hidden';
 import type { DimOptions } from './types';
+import { type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
 
 /** How {@link PptxViewer} presents hidden slides (`<p:sld show="0">`). */
 export type HiddenSlideMode = 'show' | 'skip' | 'dim';
@@ -47,6 +48,16 @@ export interface PptxViewerOptions extends RenderOptions, LoadOptions {
    * in sync if {@link DimOptions} gains a field.
    */
   hiddenSlideDim?: Partial<DimOptions>;
+  /**
+   * IX1 (design decision — NOT user-confirmed, integrator may veto). Fires on a
+   * hyperlink click (a text run whose `<a:rPr>` carried an `<a:hlinkClick>`;
+   * requires {@link enableTextSelection} so the overlay spans exist). Default
+   * when omitted: external → {@link openExternalHyperlink} (new tab, sanitised,
+   * noopener); internal slide-jump → {@link goToSlide}(target) once the slide
+   * part resolves to an index (currently a documented no-op — see below). When
+   * provided, the viewer calls this instead and takes NO default action.
+   */
+  onHyperlinkClick?: (target: HyperlinkTarget) => void;
 }
 
 /**
@@ -345,7 +356,36 @@ export class PptxViewer {
   }
 
   private _buildTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
-    buildPptxTextLayer(layer, runs, cssWidth, cssHeight);
+    buildPptxTextLayer(layer, runs, cssWidth, cssHeight, (t) => this._onHyperlinkClick(t));
+  }
+
+  /**
+   * IX1 hyperlink click dispatch. When the integrator supplies
+   * `opts.onHyperlinkClick` it OWNS the click (no default action). Otherwise the
+   * viewer applies its default policy: an external link opens in a new tab via
+   * the shared, scheme-sanitised {@link openExternalHyperlink}; an internal
+   * slide jump navigates via {@link goToSlide} once the target part resolves to
+   * a slide index.
+   */
+  private _onHyperlinkClick(target: HyperlinkTarget): void {
+    if (this.opts.onHyperlinkClick) {
+      this.opts.onHyperlinkClick(target);
+      return;
+    }
+    if (target.kind === 'external') {
+      openExternalHyperlink(target.url);
+      return;
+    }
+    // Internal slide jump. `target.ref` is the resolved internal part name
+    // (e.g. "../slides/slide3.xml") or a raw "ppaction://…" verb. Mapping a
+    // slide part to its 0-based presentation index is NOT cheaply available:
+    // the parsed `Slide` model carries no part name, and matching by the file's
+    // numeric suffix (slide3.xml → index 2) is a heuristic that breaks whenever
+    // the slide file numbers don't match the presentation's <p:sldIdLst> order
+    // (CLAUDE.md forbids such heuristics). Left as a no-op until the parser
+    // surfaces each slide's part name.
+    // TODO IX1: resolve slide part -> index (needs Slide.partName from parser),
+    //   then `void this.goToSlide(idx);`.
   }
 
   /** PD14 render-error contract: route a render failure to `onError`, or

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -734,8 +734,15 @@ fn parse_si_node(node: &roxmltree::Node, theme_colors: &[String]) -> SharedStrin
         runs: if has_runs { Some(runs) } else { None },
     }
 }
-/// `(row, col, relationship id)` triples for cell hyperlinks pending rels resolution.
-type HyperlinkRids = Vec<(u32, u32, String)>;
+/// Pending cell-hyperlink descriptors, awaiting rels resolution of the external
+/// `r:id`. Each entry is `(col, row, rid, location, display)`:
+/// - `rid`: the external relationship id (§18.3.1.47 `r:id`), if present.
+/// - `location`: the inline internal target (§18.3.1.47 `location`) — a defined
+///   name or cell ref like `Sheet1!A1`. No rels lookup required.
+/// - `display`: the optional display text (§18.3.1.47 `display`).
+///
+/// A `<hyperlink>` may carry `rid`, `location`, or both, so both are optional.
+type HyperlinkRids = Vec<(u32, u32, Option<String>, Option<String>, Option<String>)>;
 
 fn parse_worksheet(
     xml: &str,
@@ -980,12 +987,19 @@ fn parse_worksheet(
                     // Only first cell of ref range
                     let ref_single = ref_str.split(':').next().unwrap_or(ref_str);
                     let (col, row) = parse_cell_ref(ref_single);
-                    if let Some(rid) = hl
+                    // §18.3.1.47: `r:id` is the external target (resolved later
+                    // via rels); `location` is the inline internal target
+                    // (defined name or cell ref). Either may be present — or
+                    // both — so capture whichever exist and skip only when both
+                    // are absent (nothing to navigate to).
+                    let rid = hl
                         .attributes()
                         .find(|a| a.name() == "id" && is_r_ns(a.namespace()))
-                        .map(|a| a.value().to_string())
-                    {
-                        hyperlink_rids.push((col, row, rid));
+                        .map(|a| a.value().to_string());
+                    let location = hl.attribute("location").map(|s| s.to_string());
+                    let display = hl.attribute("display").map(|s| s.to_string());
+                    if rid.is_some() || location.is_some() {
+                        hyperlink_rids.push((col, row, rid, location, display));
                     }
                 }
             }
@@ -1686,20 +1700,32 @@ fn load_hyperlinks(
     if hyperlink_rids.is_empty() {
         return Vec::new();
     }
-    let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
-        return Vec::new();
+    // Only read the sheet rels part when at least one hyperlink carries an
+    // external `r:id`. A worksheet whose hyperlinks are all internal
+    // (`location`-only) needs no rels lookup (§18.3.1.47).
+    let needs_rels = hyperlink_rids.iter().any(|(_, _, rid, _, _)| rid.is_some());
+    let rels = if needs_rels {
+        match sheet_path.rsplit_once('/') {
+            Some((sheet_dir, sheet_file)) => {
+                let rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
+                read_zip_string(archive, &rels_path)
+                    .ok()
+                    .map(|xml| parse_rels_map(&xml))
+                    .unwrap_or_default()
+            }
+            None => Default::default(),
+        }
+    } else {
+        Default::default()
     };
-    let rels_path = format!("xl/{}/_rels/{}.rels", sheet_dir, sheet_file);
-    let rels = read_zip_string(archive, &rels_path)
-        .ok()
-        .map(|xml| parse_rels_map(&xml))
-        .unwrap_or_default();
     hyperlink_rids
         .into_iter()
-        .map(|(col, row, rid)| Hyperlink {
+        .map(|(col, row, rid, location, display)| Hyperlink {
             col,
             row,
-            url: rels.get(&rid).cloned(),
+            url: rid.as_deref().and_then(|r| rels.get(r).cloned()),
+            location,
+            display,
         })
         .collect()
 }
@@ -2503,6 +2529,73 @@ mod sheet_view_tests {
         assert!(
             p1 < p2 && p2 < p3,
             "colWidths keys must serialize in ascending order (1,2,3), got positions {p1},{p2},{p3} in {widths}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod hyperlink_tests {
+    use super::parse_worksheet;
+
+    const NS: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    const R_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+    /// ECMA-376 §18.3.1.47: `<hyperlink ref r:id>` is an *external* target
+    /// (`r:id` resolved via the sheet rels, populating `url`), while
+    /// `<hyperlink ref location>` is an *internal* target captured inline. The
+    /// parse step must record the pending `r:id` for the external link and the
+    /// inline `location` for the internal one. `parse_worksheet` returns the
+    /// pending `(col, row, rid, location, display)` descriptors before rels
+    /// resolution; both attributes must be threaded through.
+    #[test]
+    fn captures_external_rid_and_internal_location() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}" xmlns:r="{R_NS}"><sheetData/>
+                 <hyperlinks>
+                   <hyperlink ref="A1" r:id="rId1" display="Anthropic"/>
+                   <hyperlink ref="B2" location="Sheet2!A1" display="Go to Sheet2"/>
+                 </hyperlinks>
+               </worksheet>"#
+        );
+        let (_ws, rids) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        // `parse_cell_ref` yields 1-based (col, row): A1 → (1, 1), B2 → (2, 2).
+        // A1 → external: rid present (resolves to url later), no location.
+        let a1 = rids
+            .iter()
+            .find(|(c, r, ..)| *c == 1 && *r == 1)
+            .expect("A1 hyperlink captured");
+        assert_eq!(a1.2.as_deref(), Some("rId1"), "external r:id captured");
+        assert_eq!(a1.3, None, "external hyperlink has no inline location");
+        assert_eq!(a1.4.as_deref(), Some("Anthropic"), "display captured");
+
+        // B2 → internal: location present, no rid.
+        let b2 = rids
+            .iter()
+            .find(|(c, r, ..)| *c == 2 && *r == 2)
+            .expect("B2 hyperlink captured");
+        assert_eq!(b2.2, None, "internal hyperlink has no external r:id");
+        assert_eq!(
+            b2.3.as_deref(),
+            Some("Sheet2!A1"),
+            "internal location captured"
+        );
+        assert_eq!(b2.4.as_deref(), Some("Go to Sheet2"), "display captured");
+    }
+
+    /// A `<hyperlink>` with neither `r:id` nor `location` is not navigable and
+    /// must be skipped (nothing to record).
+    #[test]
+    fn skips_hyperlink_without_target() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData/>
+                 <hyperlinks><hyperlink ref="C3" display="dead"/></hyperlinks>
+               </worksheet>"#
+        );
+        let (_ws, rids) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        assert!(
+            rids.is_empty(),
+            "hyperlink with no r:id/location is skipped"
         );
     }
 }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -924,7 +924,17 @@ pub struct CfValue {
 pub struct Hyperlink {
     pub col: u32,
     pub row: u32,
+    /// External target (ECMA-376 §18.3.1.47 `r:id` → resolved via worksheet
+    /// rels). `None` for a purely internal hyperlink.
     pub url: Option<String>,
+    /// Internal target (§18.3.1.47 `location` attribute): a defined name or a
+    /// cell reference such as `Sheet1!A1`. Inline — no rels resolution needed.
+    /// A `<hyperlink>` may carry `r:id` (external), `location` (internal), or
+    /// both.
+    pub location: Option<String>,
+    /// Optional display text (§18.3.1.47 `display`). Not used for rendering
+    /// (the cell value drives that) but preserved for callers.
+    pub display: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -5,6 +5,9 @@ export { XlsxViewer } from './viewer.js';
 export type { ResolvedList } from './validation-list.js';
 export type { XlsxViewerOptions, HiddenSheetMode, CellAddress, CellRange, SelectionMode } from './viewer.js';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
+// IX1 — the shared hyperlink target shape surfaced by `XlsxViewerOptions.
+// onHyperlinkClick`, plus the default "open in a new tab, sanitised" helper.
+export { type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
 // Resolve `{type:'shared',si}` cells against a workbook's sharedStrings table
 // (ECMA-376 §18.4.8). Exported so headless callers that parse a Worksheet
 // directly (e.g. @silurus/ooxml-node's parseXlsxSheet) can concretize cell text.

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -561,7 +561,15 @@ export interface CellRange {
 export interface Hyperlink {
   col: number;
   row: number;
+  /** External target (ECMA-376 §18.3.1.47 `r:id`, resolved via worksheet rels).
+   *  `null` for a purely internal hyperlink. */
   url: string | null;
+  /** Internal target (§18.3.1.47 `location`): a defined name or a cell reference
+   *  such as `Sheet1!A1`. Present when the hyperlink navigates within the
+   *  workbook rather than to an external URL. */
+  location?: string | null;
+  /** Optional display text (§18.3.1.47 `display`). Not used for rendering. */
+  display?: string | null;
 }
 
 export interface ConditionalFormat {

--- a/packages/xlsx/src/viewer-hyperlink.test.ts
+++ b/packages/xlsx/src/viewer-hyperlink.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import type { XlsxViewerOptions, CellAddress } from './viewer.js';
+import { installDom, makeContainer } from './viewer-destroy-test-dom.js';
+import { HEADER_W, HEADER_H } from './renderer.js';
+import type { Hyperlink, Worksheet } from './types.js';
+import * as core from '@silurus/ooxml-core';
+import type { HyperlinkTarget } from '@silurus/ooxml-core';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * IX1 — clickable hyperlinks in the XLSX viewer. Unlike docx/pptx (which have a
+ * span text-layer), xlsx activation is CELL hit-test based: a click resolves a
+ * {row,col} via `getCellAt`, looks it up in the per-sheet hyperlink map, and
+ * dispatches a `HyperlinkTarget`. These tests inject a worksheet with known
+ * hyperlinks, drive the viewer through its real pointer listeners (rect origin
+ * is (0,0) and the sheet is LTR in the fake DOM, so a client (x,y) maps directly
+ * to the logical layout coordinate), and assert the callback / default handler.
+ *
+ * Hyperlink `row`/`col` are 1-based (parser `parse_cell_ref` / renderer
+ * `hyperlinkMap` keying), matching `getCellAt`'s 1-based return.
+ */
+
+/** A worksheet with default cell sizes and the given hyperlinks. Default col
+ *  width 8.43 / row height 15 give integer-ish px cells so a point a few px past
+ *  the header lands in cell (row 1, col 1). */
+function makeSheet(hyperlinks: Hyperlink[]): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+    hyperlinks,
+  } as unknown as Worksheet;
+}
+
+interface Priv {
+  currentWorksheet: Worksheet | null;
+  scrollHost: {
+    scrollTop: number;
+    scrollLeft: number;
+    scrollWidth: number;
+    scrollHeight: number;
+    clientWidth: number;
+    clientHeight: number;
+    clientLeft: number;
+    clientTop: number;
+    dispatch(type: string, event?: unknown): void;
+  };
+  buildHyperlinkMap(ws: Worksheet): void;
+  dispatchHyperlink(cell: CellAddress): boolean;
+  navigateInternalHyperlink(location: string): void;
+}
+
+/** Mount a viewer, inject the fixture worksheet, and build its hyperlink map so
+ *  hit-testing resolves against the injected sheet (bypasses async load). */
+function mountViewer(ws: Worksheet, opts: XlsxViewerOptions = {}): { v: XlsxViewer; priv: Priv } {
+  installDom();
+  const v = new XlsxViewer(makeContainer() as unknown as HTMLElement, opts);
+  const priv = v as unknown as Priv;
+  priv.currentWorksheet = ws;
+  // Nonzero client size so the pointerdown scrollbar-gutter guard passes and the
+  // press reaches selection/click handling.
+  priv.scrollHost.clientWidth = 800;
+  priv.scrollHost.clientHeight = 600;
+  priv.buildHyperlinkMap(ws);
+  return { v, priv };
+}
+
+/** Fire a full mouse click (pointerdown → pointerup) at client (x, y) through
+ *  the viewer's real scrollHost listeners. `button:0`, `pointerType:'mouse'`. */
+function clickAt(priv: Priv, x: number, y: number): void {
+  const base = { button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse', shiftKey: false, clientX: x, clientY: y, preventDefault() {} };
+  priv.scrollHost.dispatch('pointerdown', base);
+  priv.scrollHost.dispatch('pointerup', { ...base, buttons: 0 });
+}
+
+// A point a few px inside the first data cell (row 1, col 1): past the 50×22 header.
+const CELL_A1_X = HEADER_W + 5;
+const CELL_A1_Y = HEADER_H + 5;
+
+describe('XlsxViewer IX1 hyperlink click', () => {
+  it('fires onHyperlinkClick with {kind:external,url} for an external link', () => {
+    const seen: HyperlinkTarget[] = [];
+    const ws = makeSheet([{ col: 1, row: 1, url: 'https://example.com/', location: null }]);
+    const { v, priv } = mountViewer(ws, { onHyperlinkClick: (t) => seen.push(t) });
+
+    // Sanity: the click coordinate resolves to the hyperlinked cell.
+    expect(v.getCellAt(CELL_A1_X, CELL_A1_Y)).toEqual({ row: 1, col: 1 });
+
+    clickAt(priv, CELL_A1_X, CELL_A1_Y);
+    expect(seen).toEqual([{ kind: 'external', url: 'https://example.com/' }]);
+    v.destroy();
+  });
+
+  it('fires onHyperlinkClick with {kind:internal,ref} for a location link', () => {
+    const seen: HyperlinkTarget[] = [];
+    const ws = makeSheet([{ col: 1, row: 1, url: null, location: 'Sheet2!B7' }]);
+    const { v, priv } = mountViewer(ws, { onHyperlinkClick: (t) => seen.push(t) });
+
+    clickAt(priv, CELL_A1_X, CELL_A1_Y);
+    expect(seen).toEqual([{ kind: 'internal', ref: 'Sheet2!B7' }]);
+    v.destroy();
+  });
+
+  it('does not fire when the clicked cell carries no hyperlink', () => {
+    const seen: HyperlinkTarget[] = [];
+    const ws = makeSheet([{ col: 3, row: 3, url: 'https://example.com/', location: null }]);
+    const { v, priv } = mountViewer(ws, { onHyperlinkClick: (t) => seen.push(t) });
+
+    // Click the top-left cell (no hyperlink there — the link is at C3).
+    clickAt(priv, CELL_A1_X, CELL_A1_Y);
+    expect(seen).toEqual([]);
+    v.destroy();
+  });
+
+  it('passes a blocked scheme through to a custom callback verbatim (raw target)', () => {
+    // A malicious `javascript:` url still reaches a custom callback — sanitising
+    // is the DEFAULT handler's job, not the callback's. The callback owns policy.
+    const seen: HyperlinkTarget[] = [];
+    const ws = makeSheet([{ col: 1, row: 1, url: 'javascript:alert(1)', location: null }]);
+    const { v, priv } = mountViewer(ws, { onHyperlinkClick: (t) => seen.push(t) });
+
+    clickAt(priv, CELL_A1_X, CELL_A1_Y);
+    expect(seen).toEqual([{ kind: 'external', url: 'javascript:alert(1)' }]);
+    v.destroy();
+  });
+});
+
+describe('XlsxViewer IX1 default hyperlink handler (no callback)', () => {
+  it('opens a safe external url in a new tab via window.open', () => {
+    const openSpy = vi.fn();
+    const ws = makeSheet([{ col: 1, row: 1, url: 'https://example.com/', location: null }]);
+    const { priv } = mountViewer(ws); // no onHyperlinkClick → default handler
+
+    // openExternalHyperlink resolves `window.open`; installDom stubs a minimal
+    // window without `open`, so provide one for this assertion.
+    vi.stubGlobal('window', { devicePixelRatio: 1, open: openSpy });
+
+    clickAt(priv, CELL_A1_X, CELL_A1_Y);
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/', '_blank', 'noopener,noreferrer');
+  });
+
+  it('does NOT navigate for a blocked javascript: scheme (default handler sanitises)', () => {
+    const openSpy = vi.fn();
+    const ws = makeSheet([{ col: 1, row: 1, url: 'javascript:alert(1)', location: null }]);
+    const { priv } = mountViewer(ws); // default handler
+    vi.stubGlobal('window', { devicePixelRatio: 1, open: openSpy });
+
+    clickAt(priv, CELL_A1_X, CELL_A1_Y);
+    expect(openSpy).not.toHaveBeenCalled();
+
+    // Cross-check the core policy directly: the blocked scheme yields no
+    // navigation (openExternalHyperlink returns false) with an injected window.
+    const navigated = core.openExternalHyperlink('javascript:alert(1)', undefined, { open: openSpy });
+    expect(navigated).toBe(false);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the referenced sheet for an internal Sheet!Cell location', () => {
+    const ws = makeSheet([{ col: 1, row: 1, url: null, location: 'Sheet2!A1' }]);
+    const { v, priv } = mountViewer(ws);
+    // Stub the workbook so sheetNames resolves and goToSheet is observable.
+    const goSpy = vi.fn().mockResolvedValue(undefined);
+    Object.assign(v as unknown as { wb: unknown }, {
+      wb: { sheetNames: ['Sheet1', 'Sheet2'], sheetCount: 2 },
+    });
+    (v as unknown as { goToSheet: unknown }).goToSheet = goSpy;
+
+    priv.navigateInternalHyperlink('Sheet2!A1');
+    expect(goSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('is a no-op for an internal location whose sheet is unknown', () => {
+    const ws = makeSheet([{ col: 1, row: 1, url: null, location: 'Ghost!A1' }]);
+    const { v, priv } = mountViewer(ws);
+    const goSpy = vi.fn().mockResolvedValue(undefined);
+    Object.assign(v as unknown as { wb: unknown }, {
+      wb: { sheetNames: ['Sheet1', 'Sheet2'], sheetCount: 2 },
+    });
+    (v as unknown as { goToSheet: unknown }).goToSheet = goSpy;
+
+    priv.navigateInternalHyperlink('Ghost!A1');
+    expect(goSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a bare defined name (TODO: defined-name resolution)', () => {
+    const ws = makeSheet([{ col: 1, row: 1, url: null, location: 'MyName' }]);
+    const { v, priv } = mountViewer(ws);
+    const goSpy = vi.fn().mockResolvedValue(undefined);
+    Object.assign(v as unknown as { wb: unknown }, {
+      wb: { sheetNames: ['Sheet1'], sheetCount: 1 },
+    });
+    (v as unknown as { goToSheet: unknown }).goToSheet = goSpy;
+
+    priv.navigateInternalHyperlink('MyName');
+    expect(goSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,7 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
-import type { ViewportRange, Worksheet, XlsxComment } from './types.js';
-import type { LoadOptions } from '@silurus/ooxml-core';
-import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale } from '@silurus/ooxml-core';
+import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.js';
+import type { HyperlinkTarget, LoadOptions } from '@silurus/ooxml-core';
+import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, openExternalHyperlink } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
@@ -114,6 +114,16 @@ export interface XlsxViewerOptions extends LoadOptions {
   onError?: (err: Error) => void;
   /** Called when the selected cell range changes. null means no selection. */
   onSelectionChange?: (selection: CellRange | null) => void;
+  /**
+   * IX1 (design decision — NOT user-confirmed, integrator may veto). Fires when a
+   * cell carrying a hyperlink (ECMA-376 §18.3.1.47) is clicked. Default when
+   * omitted: external → {@link openExternalHyperlink} (new tab, sanitised,
+   * noopener); internal (`location`) → navigate to the referenced sheet/cell
+   * when resolvable. When supplied, this callback fully owns the behaviour and
+   * receives the raw {@link HyperlinkTarget} verbatim (URL sanitisation is the
+   * default handler's job, so a blocked scheme still reaches a custom callback).
+   */
+  onHyperlinkClick?: (target: HyperlinkTarget) => void;
   /**
    * Color of the cell-selection highlight. A single CSS color drives both the
    * selection rectangle's border (drawn in this color) and its fill (the same
@@ -419,6 +429,11 @@ export class XlsxViewer {
   // presses inside the overlay-scrollbar band (a thumb drag must not select
   // the cell underneath).
   private pendingTap: { x: number; y: number; shiftKey: boolean; pointerId: number } | null = null;
+  // IX1 — mouse press bookkeeping for hyperlink activation: the down position and
+  // the cell under it. On pointerup, if the pointer did not move beyond the tap
+  // slop (a genuine click, not a drag-select), a hyperlink on that cell is
+  // dispatched. Touch/pen activate through the pendingTap path instead.
+  private pendingClick: { x: number; y: number; pointerId: number; cell: CellAddress } | null = null;
   // In-flight column/row resize drag (issue #567). `originScaled` is the fixed
   // LTR edge the resized band grows from (left edge for a column, top for a row)
   // in canvasArea CSS px; `mdw` is captured once so the live px→model-unit
@@ -435,6 +450,11 @@ export class XlsxViewer {
   private commentPopup: HTMLDivElement;
   /** `"row:col"` → comment for the current sheet, rebuilt on every showSheet. */
   private commentMap = new Map<string, XlsxComment>();
+  /** IX1 — `"row:col"` → hyperlink for the current sheet, rebuilt on every
+   *  showSheet. Keys mirror the renderer's `hyperlinkMap` (1-based row/col, the
+   *  first cell of a hyperlink `ref` range per the parser), so a `getCellAt`
+   *  {row,col} looks up directly. */
+  private hyperlinkMap = new Map<string, Hyperlink>();
   /** `"row:col"` of the cell whose popup is currently shown (or pending), so a
    *  pointermove within the same cell doesn't restart the show timer. */
   private commentPopupKey: string | null = null;
@@ -696,6 +716,7 @@ export class XlsxViewer {
     this.updateTabActive(index);
     this.currentWorksheet = await this.workbook.getWorksheet(index);
     this.buildCommentMap(this.currentWorksheet);
+    this.buildHyperlinkMap(this.currentWorksheet);
     this.updateSpacerSize(this.currentWorksheet);
     // Reset the horizontal scroll origin to the natural START of the sheet.
     // For RTL sheets the start column (col A) lives at the RIGHT, which means
@@ -1572,6 +1593,86 @@ export class XlsxViewer {
     }
   }
 
+  /** IX1 — index the current sheet's hyperlinks by `"row:col"` (1-based, first
+   *  cell of the `ref` range) so a clicked/hovered cell resolves in O(1). Keys
+   *  match the renderer's `hyperlinkMap` exactly (`${hl.row}:${hl.col}`). */
+  private buildHyperlinkMap(ws: Worksheet): void {
+    this.hyperlinkMap = new Map();
+    for (const hl of ws.hyperlinks ?? []) {
+      this.hyperlinkMap.set(`${hl.row}:${hl.col}`, hl);
+    }
+  }
+
+  /** IX1 — the hyperlink at a cell, or null. `getCellAt` returns 1-based
+   *  {row,col}, matching the parser/renderer keying. */
+  private hyperlinkAtCell(cell: CellAddress): Hyperlink | null {
+    return this.hyperlinkMap.get(`${cell.row}:${cell.col}`) ?? null;
+  }
+
+  /**
+   * IX1 — dispatch a click on a hyperlinked cell. Builds a
+   * {@link HyperlinkTarget} from the parsed hyperlink (external `url` wins over
+   * internal `location`, matching Excel: a `<hyperlink>` carrying both navigates
+   * to the external target) and routes it to the caller's `onHyperlinkClick`
+   * (which fully owns behaviour) or the built-in default. Returns true when a
+   * hyperlink was found and dispatched.
+   */
+  private dispatchHyperlink(cell: CellAddress): boolean {
+    const hl = this.hyperlinkAtCell(cell);
+    if (!hl) return false;
+    let target: HyperlinkTarget;
+    if (hl.url) {
+      target = { kind: 'external', url: hl.url };
+    } else if (hl.location) {
+      target = { kind: 'internal', ref: hl.location };
+    } else {
+      return false; // parser only emits a hyperlink with url or location
+    }
+    const custom = this.opts.onHyperlinkClick;
+    if (custom) {
+      custom(target);
+      return true;
+    }
+    // Built-in default. External: open in a new tab, sanitised against the safe
+    // scheme allowlist (a blocked scheme like `javascript:` is a no-op, not a
+    // navigation). Internal: best-effort sheet navigation, below.
+    if (target.kind === 'external') {
+      openExternalHyperlink(target.url);
+    } else {
+      this.navigateInternalHyperlink(target.ref);
+    }
+    return true;
+  }
+
+  /**
+   * IX1 default handler for an internal `location` target (§18.3.1.47): a defined
+   * name or a cell ref like `Sheet1!A1`. Best-effort: if the part before `!`
+   * names a sheet in the workbook, switch to it. There is no scroll-to-cell
+   * primitive on this viewer, so the cell part is not yet honoured (switching the
+   * sheet already lands the user on the right surface). A bare defined name that
+   * does not resolve to a sheet is a documented no-op.
+   */
+  private navigateInternalHyperlink(location: string): void {
+    const bang = location.lastIndexOf('!');
+    if (bang < 0) {
+      // TODO IX1: resolve defined name → sheet/cell (needs a workbook
+      // definedNames lookup the parser does not yet surface). Inert for now
+      // rather than guessing a destination.
+      return;
+    }
+    // Sheet names with special chars are quoted (`'My Sheet'!A1`) and inner
+    // single quotes doubled per ECMA-376 §18.17.2.4; unwrap for the name match.
+    let sheetPart = location.slice(0, bang);
+    if (sheetPart.startsWith("'") && sheetPart.endsWith("'")) {
+      sheetPart = sheetPart.slice(1, -1).replace(/''/g, "'");
+    }
+    const idx = this.sheetNames.indexOf(sheetPart);
+    if (idx >= 0) {
+      void this.goToSheet(idx);
+    }
+    // Unknown sheet → no-op (do not invent scrolling math; §CLAUDE spec-first).
+  }
+
   /** Show the popup for the comment on `cell` after the hover dwell, anchored to
    *  the cell's current on-screen rect. No-op when the cell carries no comment.
    *  Re-hovering the same cell does not restart the timer. */
@@ -1771,6 +1872,14 @@ export class XlsxViewer {
         return;
       }
 
+      // IX1 — remember the cell under a mouse press so a click (no drag) can
+      // activate its hyperlink on release. Recorded before selection so a
+      // shift-click extend still tracks the destination cell.
+      const downCell = this.getCellAt(e.clientX, e.clientY);
+      this.pendingClick = downCell
+        ? { x: e.clientX, y: e.clientY, pointerId: e.pointerId, cell: downCell }
+        : null;
+
       this.applyPointerSelection(e.clientX, e.clientY, e.shiftKey, e.pointerId, true);
     });
 
@@ -1804,6 +1913,16 @@ export class XlsxViewer {
         }
       }
 
+      // IX1 — a mouse press that turns into a drag (beyond the slop) is a
+      // selection, not a hyperlink click: drop the pending activation.
+      if (this.pendingClick && this.pendingClick.pointerId === e.pointerId) {
+        const dx = e.clientX - this.pendingClick.x;
+        const dy = e.clientY - this.pendingClick.y;
+        if (dx * dx + dy * dy > TAP_SLOP * TAP_SLOP) {
+          this.pendingClick = null;
+        }
+      }
+
       // Comment hover popup (mouse only — touch/pen have no hover, so they get
       // the popup on selection instead, below). Suppressed while drag-selecting
       // so the popup doesn't fight the selection rect. A header hover hides it.
@@ -1811,6 +1930,11 @@ export class XlsxViewer {
         const hovered = this.getCellAt(e.clientX, e.clientY);
         if (hovered) this.scheduleCommentPopup(hovered);
         else this.hideCommentPopup();
+        // IX1 — pointer cursor over a hyperlinked cell. Reached only when the
+        // pointer is NOT over a resize border (that path returns above), so the
+        // resize cursor is never clobbered. Otherwise clear back to default.
+        this.scrollHost.style.cursor =
+          hovered && this.hyperlinkAtCell(hovered) ? 'pointer' : '';
       }
 
       if (!this.isSelecting) return;
@@ -1862,8 +1986,26 @@ export class XlsxViewer {
               this.hideCommentPopup();
             }
           }
+          // IX1 — a touch/pen tap on a hyperlinked cell activates it.
+          if (this.activeCell) this.dispatchHyperlink(this.activeCell);
         }
         this.pendingTap = null;
+      }
+      // IX1 — a mouse click (press+release without a drag) on a hyperlinked cell
+      // activates it. The release must still land on the same cell the press did.
+      if (this.pendingClick && this.pendingClick.pointerId === e.pointerId) {
+        const dx = e.clientX - this.pendingClick.x;
+        const dy = e.clientY - this.pendingClick.y;
+        const upCell = this.getCellAt(e.clientX, e.clientY);
+        if (
+          dx * dx + dy * dy <= TAP_SLOP * TAP_SLOP &&
+          upCell &&
+          upCell.row === this.pendingClick.cell.row &&
+          upCell.col === this.pendingClick.cell.col
+        ) {
+          this.dispatchHyperlink(this.pendingClick.cell);
+        }
+        this.pendingClick = null;
       }
       this.isSelecting = false;
     });
@@ -1874,6 +2016,9 @@ export class XlsxViewer {
       }
       if (this.pendingTap && this.pendingTap.pointerId === e.pointerId) {
         this.pendingTap = null;
+      }
+      if (this.pendingClick && this.pendingClick.pointerId === e.pointerId) {
+        this.pendingClick = null;
       }
       this.isSelecting = false;
     });


### PR DESCRIPTION
## Summary
IX1: hyperlinks become clickable across docx/pptx/xlsx, with a security-first URL sanitizer and a callback viewer API (user-confirmed callback style). Adds **zero canvas drawing** — the visible link color/underline is whatever the file's run properties already specify; clickability is an overlay/hit-test concern only.

## Architecture (parser → overlay → viewer API)
- **Shared core** (`core/src/interaction/hyperlink.ts`): `HyperlinkTarget = {kind:'external',url} | {kind:'internal',ref,slideIndex?}` — one shape all formats produce and all consumers read. `sanitizeHyperlinkUrl` allowlists `http/https/mailto/tel`, blocks `javascript:/data:/vbscript:/file:/about:/blob:`, and strips leading whitespace + embedded C0 control chars **before** reading the scheme (so `java\tscript:` — which browsers still execute — is rejected). `openExternalHyperlink` is the shared default: sanitize → `window.open(url,'_blank','noopener,noreferrer')`.
- **Parsers** (Rust, r:id→rels-target via the existing `rels.rs TargetMode`, no duplication): docx `<w:hyperlink w:anchor>` (§17.16.22/.23); pptx `<a:hlinkClick @action>` on runs and shapes (§21.1.2.3.5, `ppaction://`→internal); xlsx `<hyperlink location display r:id>` (§18.3.1.47).
- **Overlays**: docx/pptx text-layer link runs get `cursor:pointer` + tooltip + click handler on a plain `<span>` (not `<a href>`, so the browser can't bypass sanitization), `color:transparent` (glyphs unchanged). xlsx has no span layer → cell-hit-tested via a per-sheet `hyperlinkMap` with drag-vs-click slop.
- **Viewer API**: `onHyperlinkClick?: (target) => void` on all 3 viewers + both scroll viewers. Default: external → sanitized new tab; internal → xlsx sheet switch. When supplied, the callback fully owns the click.

## Known limitation (tracked follow-up)
docx-anchor and pptx-slide-jump internal navigation are **documented no-op TODOs**: the paginator / Slide model don't yet expose a bookmark→page or slide-part→index map, and file-suffix guessing is a forbidden heuristic. External links (the security-relevant path) and xlsx internal sheet-switch are fully functional.

## Gates
cargo fmt/clippy(-D warnings)/test workspace (docx 235 / pptx 141 / xlsx 118); build:wasm ×3; root tsc + ast-grep clean; vitest core 989 / docx 650 / pptx 277 / xlsx 340 (33 IX1 tests); **VRT non-regression** docx 21 / pptx 75 / xlsx 67 (no reference touched — hyperlinks draw nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)