### PR TITLE
fix(xlsx): close cached ImageBitmaps on teardown instead of dropping them

### DIFF
--- a/packages/xlsx/src/render-orchestrator.image.test.ts
+++ b/packages/xlsx/src/render-orchestrator.image.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { prefetchImages, decodeImageSource } from './render-orchestrator';
+import { prefetchImages, decodeImageSource, closeAndClearImageCache } from './render-orchestrator';
 import type { Worksheet } from './types';
 
 /**
@@ -248,5 +248,44 @@ describe('render-orchestrator image decode (lazy bytes)', () => {
     const callsAfterFirst = fetchImage.mock.calls.length;
     await prefetchImages(ws, cache, fetchImage);
     expect(fetchImage.mock.calls.length).toBe(callsAfterFirst);
+  });
+});
+
+describe('closeAndClearImageCache (teardown GPU-bitmap leak guard)', () => {
+  it('closes every cached ImageBitmap before clearing the map', () => {
+    const closeA = vi.fn();
+    const closeB = vi.fn();
+    const bmpA = { close: closeA } as unknown as ImageBitmap;
+    const bmpB = { close: closeB } as unknown as ImageBitmap;
+    const cache = new Map<string, CanvasImageSource | null>([
+      ['xl/media/image1.png', bmpA],
+      ['xl/media/image2.png', bmpB],
+    ]);
+
+    closeAndClearImageCache(cache);
+
+    expect(closeA).toHaveBeenCalledTimes(1);
+    expect(closeB).toHaveBeenCalledTimes(1);
+    expect(cache.size).toBe(0);
+  });
+
+  it('skips a cached null (unsupported metafile) without throwing', () => {
+    const cache = new Map<string, CanvasImageSource | null>([['xl/media/diagram.emf', null]]);
+    expect(() => closeAndClearImageCache(cache)).not.toThrow();
+    expect(cache.size).toBe(0);
+  });
+
+  it('skips a non-closeable CanvasImageSource (e.g. the SVG HTMLImageElement branch)', () => {
+    // The svgBlip vector branch decodes to an HTMLImageElement via
+    // getCachedSvgImageByPath, which has no `.close()` — must not throw.
+    const img = {} as unknown as HTMLImageElement;
+    const cache = new Map<string, CanvasImageSource | null>([['xl/media/image1.svg', img]]);
+    expect(() => closeAndClearImageCache(cache)).not.toThrow();
+    expect(cache.size).toBe(0);
+  });
+
+  it('is safe to call on an already-empty cache', () => {
+    const cache = new Map<string, CanvasImageSource | null>();
+    expect(() => closeAndClearImageCache(cache)).not.toThrow();
   });
 });

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -97,6 +97,33 @@ export async function decodeImageSource(
   return decodeRaster(imagePath, mimeType);
 }
 
+/** Close every `ImageBitmap` held in a decoded-image cache, then clear it.
+ *
+ *  Unlike docx/pptx (which decode through core's path-keyed
+ *  `getCachedBitmapByPath`/`dropBitmapCacheByPath`, so eviction/teardown always
+ *  closes the GPU-backed bitmap), xlsx's `imageCache` is a plain per-instance
+ *  `Map<string, CanvasImageSource | null>` populated directly by
+ *  `decodeImageSource` (see {@link prefetchImages}). A bare `.clear()` on that
+ *  map drops the last reference to each decoded `ImageBitmap` WITHOUT calling
+ *  `.close()`, leaking its GPU backing until GC — worse, GC timing for
+ *  GPU-backed objects is not guaranteed, so repeated load/destroy or
+ *  reparse cycles can accumulate live bitmaps. `HTMLImageElement` (the SVG
+ *  vector-blip branch, via `getCachedSvgImageByPath`) and a cached `null`
+ *  (unsupported metafile) pass through untouched — only `ImageBitmap` values
+ *  own a `.close()` method.
+ *
+ *  Shared by {@link XlsxWorkbook.destroy} (main-thread cache) and the
+ *  render-worker's module-level cache (closed both on re-`parse` and, via the
+ *  realm tearing down, at worker termination). */
+export function closeAndClearImageCache(imageCache: Map<string, CanvasImageSource | null>): void {
+  for (const src of imageCache.values()) {
+    if (src && typeof (src as ImageBitmap).close === 'function') {
+      (src as ImageBitmap).close();
+    }
+  }
+  imageCache.clear();
+}
+
 /** Collect every embedded image referenced by a worksheet and decode the ones
  *  not already in `imageCache`, storing each decoded `CanvasImageSource` under
  *  its zip `imagePath` (the renderer's lookup key). Images appear either as a

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -11,7 +11,7 @@
  */
 import init, { XlsxArchive, reinit } from './wasm/xlsx_parser.js';
 import { decodeDataUrl, preloadGoogleFonts, WasmParserHost } from '@silurus/ooxml-core';
-import { renderWorksheetViewport } from './render-orchestrator.js';
+import { renderWorksheetViewport, closeAndClearImageCache } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { resolveSharedStrings } from './shared-strings.js';
 import type { ParsedWorkbook, Worksheet } from './types.js';
@@ -95,9 +95,11 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
     await host.ensureReady();
     if (req.type === 'parse') {
       // A re-parse starts a fresh document: drop any cached sheets / images so
-      // we never serve stale data from a previous load.
+      // we never serve stale data from a previous load. closeAndClearImageCache
+      // closes each cached ImageBitmap's GPU backing first — a bare `.clear()`
+      // would leak it (same fix as XlsxWorkbook.destroy(); see there for why).
       sheetCache.clear();
-      imageCache.clear();
+      closeAndClearImageCache(imageCache);
       imageBlobCache.clear();
       const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0

--- a/packages/xlsx/src/workbook-destroy.test.ts
+++ b/packages/xlsx/src/workbook-destroy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { WorkerBridge, type WorkerLike } from '@silurus/ooxml-core';
 import { XlsxWorkbook } from './workbook.js';
 
@@ -54,5 +54,68 @@ describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
     const { wb } = makeWorkbook();
     wb.destroy();
     expect(() => wb.destroy()).not.toThrow();
+  });
+});
+
+/**
+ * `destroy()` must close every cached `ImageBitmap` (GPU-backed) before
+ * dropping `imageCache`, not just `.clear()` it — a bare `.clear()` drops the
+ * last reference without releasing the GPU backing, leaking it until GC (which
+ * is not guaranteed to run promptly for GPU-backed objects). See
+ * `closeAndClearImageCache` in render-orchestrator.ts.
+ */
+describe('XlsxWorkbook.destroy() — closes cached ImageBitmaps (GPU-leak guard)', () => {
+  function makeWorkbookWithImageCache(imageCache: Map<string, CanvasImageSource | null>) {
+    const worker = new SilentWorker();
+    const bridge = new WorkerBridge<{ id?: number }>(worker, {
+      correlate: (r) => r.id,
+    });
+    const instance = Object.create(XlsxWorkbook.prototype) as Record<string, unknown>;
+    instance.bridge = bridge;
+    instance.sheetCache = new Map();
+    instance.imageCache = imageCache;
+    instance.imageBlobCache = new Map();
+    instance._fetchImage = () => Promise.resolve(new Blob());
+    return instance as unknown as DestroyProbe;
+  }
+
+  it('calls .close() on each cached ImageBitmap and empties the cache', () => {
+    const close1 = vi.fn();
+    const close2 = vi.fn();
+    const bmp1 = { close: close1 } as unknown as ImageBitmap;
+    const bmp2 = { close: close2 } as unknown as ImageBitmap;
+    const imageCache = new Map<string, CanvasImageSource | null>([
+      ['xl/media/image1.png', bmp1],
+      ['xl/media/image2.png', bmp2],
+    ]);
+    const wb = makeWorkbookWithImageCache(imageCache);
+
+    wb.destroy();
+
+    expect(close1).toHaveBeenCalledTimes(1);
+    expect(close2).toHaveBeenCalledTimes(1);
+    expect(imageCache.size).toBe(0);
+  });
+
+  it('skips a cached null (unsupported metafile) without throwing', () => {
+    const imageCache = new Map<string, CanvasImageSource | null>([
+      ['xl/media/diagram.emf', null],
+    ]);
+    const wb = makeWorkbookWithImageCache(imageCache);
+    expect(() => wb.destroy()).not.toThrow();
+    expect(imageCache.size).toBe(0);
+  });
+
+  it('is safe to destroy() twice — the second call does not re-close an already-closed bitmap', () => {
+    const close = vi.fn();
+    const bmp = { close } as unknown as ImageBitmap;
+    const imageCache = new Map<string, CanvasImageSource | null>([['xl/media/image1.png', bmp]]);
+    const wb = makeWorkbookWithImageCache(imageCache);
+
+    wb.destroy();
+    expect(() => wb.destroy()).not.toThrow();
+    // The map is empty after the first destroy(), so the second pass has
+    // nothing to iterate — close() is called exactly once total.
+    expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -12,7 +12,7 @@ import {
 } from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, WorkerRequest, WorkerResponse, Cell, SheetVisibility } from './types.js';
 import { selectSheetVisibility } from './sheet-visibility.js';
-import { renderWorksheetViewport } from './render-orchestrator.js';
+import { renderWorksheetViewport, closeAndClearImageCache } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { formatCellValue } from './number-format.js';
 import { resolveSharedStrings } from './shared-strings.js';
@@ -407,10 +407,12 @@ export class XlsxWorkbook {
     this.bridge.terminate();
     this.parsedWorkbook = null;
     this.sheetCache.clear();
-    this.imageCache.clear();
+    // Closes each cached ImageBitmap's GPU backing before dropping the map —
+    // see closeAndClearImageCache for why a bare `.clear()` would leak.
+    closeAndClearImageCache(this.imageCache);
     this.imageBlobCache.clear();
     // Revoke this workbook's decoded-SVG object URLs (raster sources live in the
-    // per-instance imageCache cleared above).
+    // per-instance imageCache closed above).
     dropSvgImageCache(this._fetchImage);
     this.rawData = null;
   }


### PR DESCRIPTION
## Summary
`XlsxWorkbook.destroy()` cleared a `Map<string, CanvasImageSource | null>` of cached `ImageBitmap`s with a bare `.clear()`, never calling `.close()` — leaking GPU-backed bitmaps across create/destroy cycles (docx/pptx go through the shared `dropBitmapCacheByPath`, which closes; xlsx's renderer reads a local Map synchronously and bypasses it). Found via a teardown-resource audit. A **second, more frequently-triggered instance** exists in `render-worker.ts`: the module-level `imageCache` is cleared on **every re-parse of a reused worker**, not just teardown — same bug.

## Approach
Minimal close-loop, not shared-cache migration. Migrating xlsx onto `getCachedBitmapByPath` would require threading `fetchImage` through every synchronous draw site in `renderer.ts` — materially larger than the leak warrants (and the Map shape is xlsx-specific, so no core abstraction). Added one helper `closeAndClearImageCache` reused at both sites.

## Changes
- `render-orchestrator.ts`: `closeAndClearImageCache(map)` — closes any value with `.close()` (ImageBitmap), skips cached `null` (unsupported metafile) and non-closeable `CanvasImageSource` (SVG `HTMLImageElement`), then clears.
- `workbook.ts:410` (`destroy()`) and `render-worker.ts:100` (re-parse reset) both call it.
- Tests: `render-orchestrator.image.test.ts` (helper: closes bitmaps, skips null/non-closeable, empty-safe) + `workbook-destroy.test.ts` (through `destroy()`: close spy called, null skipped, double-destroy calls close exactly once).

## Gates
vitest xlsx 338 + core 976; tsc no new errors; **xlsx VRT 67 + worker-equivalence (0.000% diff)** — non-regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)