### PR TITLE
fix(fonts): refcount + release preloaded Google Fonts on destroy (3-way leak)

### DIFF
--- a/packages/core/src/fonts/embedded.ts
+++ b/packages/core/src/fonts/embedded.ts
@@ -25,6 +25,13 @@
  * contract (fonts must be ready before the caller measures/paints text).
  */
 import { activeFontSet, withFontCeiling } from './preload.js';
+import { retainFace, releaseFaces, _resetFontRegistryForTests } from './font-registry.js';
+
+/** Test hook — clears the shared FontFace refcount registry (does NOT touch any
+ *  FontFaceSet; tests install a fresh fake set per case). Re-exported here under
+ *  the embedded name so existing embedded-font tests keep their reset call; the
+ *  registry itself is now shared with the Google-Fonts preloader. */
+export const _resetEmbeddedRegistryForTests = _resetFontRegistryForTests;
 
 /**
  * ECMA-376 §17.8.1 — de-obfuscate a WordprocessingML embedded font (`.odttf`).
@@ -93,32 +100,16 @@ export interface EmbeddedFontFace {
 }
 
 /**
- * A refcounted embedded-font registration shared across documents.
- *
+ * Embedded fonts dedup + refcount through the shared {@link ./font-registry.ts}:
  * `document.fonts` (the FontFaceSet) is a process-global singleton, so opening
  * the same embedded font in two documents — or the same document twice in an SPA
  * — would otherwise add a second, byte-identical `FontFace` every time and leak
  * them all (nothing ever removed them). We dedup by a stable content signature
- * and refcount: the first registration adds the `FontFace`; later ones reuse it
- * and bump `refs`; {@link unregisterEmbeddedFonts} decrements and only
- * `document.fonts.delete()`s the face when the last holder releases it.
+ * ({@link contentSignature}) and refcount: the first registration adds the
+ * `FontFace`; later ones reuse it and bump refs; {@link unregisterEmbeddedFonts}
+ * decrements and only `document.fonts.delete()`s the face when the last holder
+ * releases it. The refcount machinery is shared with the Google-Fonts preloader.
  */
-interface FontRegistration {
-  face: FontFace;
-  set: FontFaceSet;
-  refs: number;
-}
-
-/** signature → the single shared registration. Module-global to mirror the
- *  process-global FontFaceSet (the same dedup contract as `cssRegistrations`
- *  in {@link ./preload.ts}). */
-const embeddedRegistry = new Map<string, FontRegistration>();
-
-/** Test hook — clears the embedded-font dedup registry (does NOT touch the
- *  FontFaceSet; tests install a fresh fake set per case). */
-export function _resetEmbeddedRegistryForTests(): void {
-  embeddedRegistry.clear();
-}
 
 /** Cheap 32-bit FNV-1a over the (de-obfuscated) font bytes — the content key for
  *  dedup. Combined with family/weight/style so two distinct faces that happen to
@@ -176,30 +167,28 @@ export async function registerEmbeddedFonts(
       const data = face.odttf
         ? deobfuscateOdttf(face.bytes, face.fontKey ?? '')
         : face.bytes;
-      const sig = contentSignature(face.family, face.weight, face.style, data);
+      // `embedded:` namespaces the signature so an embedded face can never share
+      // a registry entry with a Google-Fonts face (a different keyspace).
+      const sig = `embedded:${contentSignature(face.family, face.weight, face.style, data)}`;
 
-      // Dedup: a byte-identical face already in THIS set → reuse + bump refs.
-      const existing = embeddedRegistry.get(sig);
-      if (existing && existing.set === set) {
-        existing.refs++;
-        held.push(existing.face);
-        continue;
-      }
-
-      // Copy into a standalone ArrayBuffer: FontFace(source) reads the buffer,
-      // and `data` may be a subarray view into a larger WASM/transfer buffer.
-      const buf = data.buffer.slice(
-        data.byteOffset,
-        data.byteOffset + data.byteLength,
-      ) as ArrayBuffer;
-      const ff = new FontFace(face.family, buf, {
-        weight: face.weight,
-        style: face.style,
+      // Dedup + refcount via the shared registry: a byte-identical face already
+      // in THIS set → reuse + bump refs; otherwise build + add it once.
+      const { face: ff, isNew } = retainFace(sig, set, () => {
+        // Copy into a standalone ArrayBuffer: FontFace(source) reads the buffer,
+        // and `data` may be a subarray view into a larger WASM/transfer buffer.
+        const buf = data.buffer.slice(
+          data.byteOffset,
+          data.byteOffset + data.byteLength,
+        ) as ArrayBuffer;
+        const created = new FontFace(face.family, buf, {
+          weight: face.weight,
+          style: face.style,
+        });
+        set.add(created);
+        return created;
       });
-      set.add(ff);
-      embeddedRegistry.set(sig, { face: ff, set, refs: 1 });
       held.push(ff);
-      toLoad.push(ff);
+      if (isNew) toLoad.push(ff); // only a freshly-added face needs a load()
     } catch {
       // Malformed fontKey / unreadable part: skip this face, keep the document.
       failed.push(face.family);
@@ -255,28 +244,5 @@ export async function registerEmbeddedFonts(
  * the shared refcount.
  */
 export function unregisterEmbeddedFonts(faces: Iterable<FontFace>): void {
-  // Guard against the same face appearing more than once in THIS call so a
-  // duplicate cannot decrement a shared registration's refcount twice.
-  const seen = new Set<FontFace>();
-  for (const face of faces) {
-    if (seen.has(face)) continue;
-    seen.add(face);
-    // Find the registration for this face (identity match). The registry is
-    // small (one entry per distinct embedded face), so a linear scan is fine.
-    // A face that was already fully released has no entry → this loop finds
-    // nothing and the release is a no-op (cross-call idempotency).
-    for (const [sig, reg] of embeddedRegistry) {
-      if (reg.face !== face) continue;
-      reg.refs--;
-      if (reg.refs <= 0) {
-        try {
-          reg.set.delete(face);
-        } catch {
-          /* a set without delete() (older shim / mock): drop the entry anyway */
-        }
-        embeddedRegistry.delete(sig);
-      }
-      break;
-    }
-  }
+  releaseFaces(faces);
 }

--- a/packages/core/src/fonts/font-registry.test.ts
+++ b/packages/core/src/fonts/font-registry.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { retainFace, releaseFaces, _resetFontRegistryForTests } from './font-registry.js';
+
+afterEach(() => {
+  _resetFontRegistryForTests(); // the registry is module-global
+});
+
+// A minimal FontFace / FontFaceSet stand-in. The registry only needs identity
+// (===) on faces and a `delete()` on the set, so these are intentionally tiny.
+interface FakeFace {
+  family: string;
+}
+function makeSet() {
+  const faces: FakeFace[] = [];
+  const set = {
+    add: (f: FakeFace) => {
+      faces.push(f);
+    },
+    delete: (f: FakeFace) => {
+      const i = faces.indexOf(f);
+      if (i >= 0) faces.splice(i, 1);
+      return i >= 0;
+    },
+  } as unknown as FontFaceSet;
+  return { set, faces };
+}
+/** A create() that builds a fresh fake face, adds it to the set, and records how
+ *  many times it ran (retain must call it ONLY on the first-holder path). */
+function creator(set: FontFaceSet, family: string) {
+  let calls = 0;
+  const create = (): FontFace => {
+    calls++;
+    const f = { family } as unknown as FontFace;
+    (set as unknown as { add: (f: FontFace) => void }).add(f);
+    return f;
+  };
+  return { create, calls: () => calls };
+}
+
+describe('retainFace', () => {
+  it('first holder creates + adds the face and reports isNew', () => {
+    const { set, faces } = makeSet();
+    const c = creator(set, 'A');
+    const { face, isNew } = retainFace('sig-a', set, c.create);
+    expect(isNew).toBe(true);
+    expect(c.calls()).toBe(1);
+    expect(faces).toContain(face as unknown as FakeFace);
+  });
+
+  it('a later holder of the same signature reuses the face and does NOT re-create', () => {
+    const { set, faces } = makeSet();
+    const c = creator(set, 'A');
+    const first = retainFace('sig-a', set, c.create);
+    const second = retainFace('sig-a', set, c.create);
+    expect(second.isNew).toBe(false);
+    expect(second.face).toBe(first.face); // same shared FontFace
+    expect(c.calls()).toBe(1); // create ran once
+    expect(faces).toHaveLength(1); // added once
+  });
+
+  it('distinct signatures create distinct faces', () => {
+    const { set, faces } = makeSet();
+    const a = creator(set, 'A');
+    const b = creator(set, 'B');
+    const ra = retainFace('sig-a', set, a.create);
+    const rb = retainFace('sig-b', set, b.create);
+    expect(ra.face).not.toBe(rb.face);
+    expect(faces).toHaveLength(2);
+  });
+
+  it('the same signature in a DIFFERENT set is treated as absent (creates anew)', () => {
+    const { set: setA } = makeSet();
+    const { set: setB, faces: facesB } = makeSet();
+    const ca = creator(setA, 'A');
+    const cb = creator(setB, 'A');
+    const ra = retainFace('sig-a', setA, ca.create);
+    // Same signature, different set → must NOT hand back setA's face.
+    const rb = retainFace('sig-a', setB, cb.create);
+    expect(rb.isNew).toBe(true);
+    expect(rb.face).not.toBe(ra.face);
+    expect(facesB).toHaveLength(1);
+  });
+});
+
+describe('releaseFaces', () => {
+  it('removes the face from its set when the last (only) holder releases', () => {
+    const { set, faces } = makeSet();
+    const c = creator(set, 'A');
+    const { face } = retainFace('sig-a', set, c.create);
+    expect(faces).toHaveLength(1);
+    releaseFaces([face]);
+    expect(faces).toHaveLength(0);
+  });
+
+  it('keeps the face until the LAST holder releases (refcount)', () => {
+    const { set, faces } = makeSet();
+    const c = creator(set, 'A');
+    const a = retainFace('sig-a', set, c.create).face; // holder 1
+    const b = retainFace('sig-a', set, c.create).face; // holder 2 (same face)
+    expect(a).toBe(b);
+    expect(faces).toHaveLength(1);
+
+    releaseFaces([a]); // holder 1 gone
+    expect(faces).toHaveLength(1); // holder 2 keeps it
+
+    releaseFaces([b]); // holder 2 gone
+    expect(faces).toHaveLength(0);
+  });
+
+  it('the same face passed twice in ONE call is decremented at most once', () => {
+    const { set, faces } = makeSet();
+    const c = creator(set, 'A');
+    const a = retainFace('sig-a', set, c.create).face; // refs 1
+    retainFace('sig-a', set, c.create); // refs 2 (second holder)
+    expect(faces).toHaveLength(1);
+
+    // Duplicate in one release must collapse to a single decrement (2 → 1),
+    // NOT evict the face the second holder still uses.
+    releaseFaces([a, a]);
+    expect(faces).toHaveLength(1);
+  });
+
+  it('re-releasing a fully-released face is a no-op (no negative refs, no cross-hit)', () => {
+    const { set, faces } = makeSet();
+    const c = creator(set, 'A');
+    const a = retainFace('sig-a', set, c.create).face;
+    releaseFaces([a]); // fully released, entry removed
+    expect(faces).toHaveLength(0);
+
+    // A fresh registration of the same signature (distinct FontFace object).
+    const b = retainFace('sig-a', set, c.create).face;
+    expect(b).not.toBe(a);
+    expect(faces).toHaveLength(1);
+
+    // A stray re-release of the OLD face must not disturb b's registration.
+    releaseFaces([a]);
+    expect(faces).toHaveLength(1);
+  });
+
+  it('is a no-op for a face the registry never saw', () => {
+    const { set, faces } = makeSet();
+    creator(set, 'A'); // nothing retained
+    const stray = { family: 'Stray' } as unknown as FontFace;
+    expect(() => releaseFaces([stray])).not.toThrow();
+    expect(faces).toHaveLength(0);
+  });
+
+  it('tolerates a set whose delete() throws (older shim) and still drops the entry', () => {
+    const faces: FakeFace[] = [];
+    const set = {
+      add: (f: FakeFace) => {
+        faces.push(f);
+      },
+      delete: () => {
+        throw new Error('no delete on this shim');
+      },
+    } as unknown as FontFaceSet;
+    const c = creator(set, 'A');
+    const { face } = retainFace('sig-a', set, c.create);
+    // delete() throws, but the release must not throw and must drop the entry so
+    // a later retain of the same signature creates a fresh registration.
+    expect(() => releaseFaces([face])).not.toThrow();
+    const again = retainFace('sig-a', set, c.create);
+    expect(again.isNew).toBe(true); // entry was dropped despite the throwing delete
+  });
+});

--- a/packages/core/src/fonts/font-registry.ts
+++ b/packages/core/src/fonts/font-registry.ts
@@ -1,0 +1,127 @@
+/**
+ * Refcounted FontFace registry shared by the embedded-font loader
+ * ({@link ./embedded.ts}) and the Google-Fonts preloader ({@link ./preload.ts}).
+ *
+ * `document.fonts` (the FontFaceSet) is a process-global singleton, so opening
+ * the same font in two documents — or the same document twice in an SPA — would
+ * otherwise add a second, byte- (or url-) identical `FontFace` every time and
+ * leak them all (nothing ever removes them). Both loaders share this dedup +
+ * refcount so a face is added to the set once, shared by every holder, and
+ * removed from the set only when the LAST holder releases it (e.g. from every
+ * open document's `destroy()`).
+ *
+ * The registry is deliberately format-agnostic: callers own how they compute a
+ * face's signature (embedded fonts hash the de-obfuscated bytes; Google Fonts
+ * key on the CSS url + family + descriptors) and how they build the `FontFace`.
+ * The registry owns only the shared concern — *this exact face is referenced by
+ * N holders; delete it from its set at N = 0* — so neither loader duplicates the
+ * refcount / last-release / double-release-safety logic.
+ */
+
+/** One shared, refcounted FontFace registration. */
+interface FontRegistration {
+  face: FontFace;
+  /** The FontFaceSet the face was added to (`document.fonts` / `self.fonts`).
+   *  Held so release can `delete()` from the SAME set the retain added to, and
+   *  so a stale signature colliding across two different sets never mixes. */
+  set: FontFaceSet;
+  refs: number;
+}
+
+/** signature → the single shared registration. Module-global to mirror the
+ *  process-global FontFaceSet: two callers computing the same signature in the
+ *  same set share one `FontFace`. */
+const registry = new Map<string, FontRegistration>();
+
+/** Test hook — clears the shared refcount registry (does NOT touch any
+ *  FontFaceSet; tests install a fresh fake set per case). */
+export function _resetFontRegistryForTests(): void {
+  registry.clear();
+}
+
+/** Result of {@link retainFace}: the shared `FontFace` this caller now holds a
+ *  reference to, and whether THIS call created it (so the caller knows it must
+ *  force-`load()` the face — an already-shared face was loaded by its first
+ *  holder). */
+export interface RetainResult {
+  face: FontFace;
+  /** `true` when this retain created + added the face (first holder); `false`
+   *  when it reused an existing shared registration (refs bumped). */
+  isNew: boolean;
+}
+
+/**
+ * Retain a shared FontFace for `sig` in `set`, bumping its refcount.
+ *
+ * - First holder of `sig` (in this set): `create()` builds the `FontFace`, it is
+ *   added to the set, and `{ face, isNew: true }` is returned — the caller must
+ *   force-`load()` it.
+ * - A later holder of the same `sig`: the existing shared face is reused, its
+ *   refcount bumped, and `{ face, isNew: false }` returned — already loaded by
+ *   the first holder, so the caller skips the load.
+ *
+ * A signature whose registration lives in a DIFFERENT set (e.g. a stale
+ * cross-context collision) is treated as absent: a fresh registration replaces
+ * it, so a face is never handed back from a set the caller is not adding to.
+ *
+ * `create()` must both construct the `FontFace` AND add it to `set` (the two are
+ * inseparable — the registry cannot know a loader's `set.add` semantics), then
+ * return the face. It runs ONLY on the first-holder path.
+ */
+export function retainFace(sig: string, set: FontFaceSet, create: () => FontFace): RetainResult {
+  const existing = registry.get(sig);
+  if (existing && existing.set === set) {
+    existing.refs++;
+    return { face: existing.face, isNew: false };
+  }
+  const face = create();
+  registry.set(sig, { face, set, refs: 1 });
+  return { face, isNew: true };
+}
+
+/**
+ * Release a set of shared `FontFace` objects (as returned by the loaders'
+ * retain paths). Each face's refcount is decremented; the face is removed from
+ * its FontFaceSet only when the last holder releases it, so a font shared by two
+ * open documents survives until both are destroyed. Safe to call with faces the
+ * registry does not know (no-op).
+ *
+ * **Idempotent / double-release safe (refs are never over-decremented).** Two
+ * independent guards protect a font another document is still using from being
+ * evicted by a stray double-release:
+ *
+ * - *Within one call*: the same `FontFace` appearing twice in `faces` (a caller
+ *   passing a list with duplicates) is decremented AT MOST ONCE — a per-call
+ *   `seen` set skips repeats. Without this, `release([F, F])` would drop refs by
+ *   2 and could delete `F` while a second holder still references it.
+ * - *Across calls*: once a face's refcount reaches 0 its registry entry is
+ *   removed, so a later call that passes the same (now-unregistered) face finds
+ *   no entry and is a no-op — it can never push another registration's refs
+ *   negative.
+ */
+export function releaseFaces(faces: Iterable<FontFace>): void {
+  // Guard against the same face appearing more than once in THIS call so a
+  // duplicate cannot decrement a shared registration's refcount twice.
+  const seen = new Set<FontFace>();
+  for (const face of faces) {
+    if (seen.has(face)) continue;
+    seen.add(face);
+    // Find the registration for this face (identity match). The registry is
+    // small (one entry per distinct face), so a linear scan is fine. A face that
+    // was already fully released has no entry → this loop finds nothing and the
+    // release is a no-op (cross-call idempotency).
+    for (const [sig, reg] of registry) {
+      if (reg.face !== face) continue;
+      reg.refs--;
+      if (reg.refs <= 0) {
+        try {
+          reg.set.delete(face);
+        } catch {
+          /* a set without delete() (older shim / mock): drop the entry anyway */
+        }
+        registry.delete(sig);
+      }
+      break;
+    }
+  }
+}

--- a/packages/core/src/fonts/preload.test.ts
+++ b/packages/core/src/fonts/preload.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { preloadGoogleFonts, parseFontFaceRules, _resetCssCacheForTests, type FontPreloadEntry } from './preload.js';
+import { preloadGoogleFonts, unloadGoogleFonts, parseFontFaceRules, _resetCssCacheForTests, type FontPreloadEntry } from './preload.js';
+import { _resetFontRegistryForTests } from './font-registry.js';
 
 const G = globalThis as Record<string, unknown>;
 const ORIG = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
@@ -10,6 +11,7 @@ afterEach(() => {
   G.fetch = ORIG.fetch;
   G.FontFace = ORIG.FontFace;
   _resetCssCacheForTests();
+  _resetFontRegistryForTests(); // the FontFace refcount registry is module-global
   vi.restoreAllMocks();
 });
 
@@ -71,6 +73,7 @@ function installFakes(opts: { failLoad?: boolean; quoteFamily?: boolean } = {}) 
   const set = {
     faces: added,
     add: (f: FakeFace) => { added.push(f); },
+    delete: (f: FakeFace) => { const i = added.indexOf(f); if (i >= 0) added.splice(i, 1); return i >= 0; },
     [Symbol.iterator]() { return added[Symbol.iterator](); },
     ready: Promise.resolve(),
   };
@@ -115,10 +118,10 @@ describe('preloadGoogleFonts', () => {
     expect(added).toHaveLength(2);
   });
 
-  it('no-ops without any FontFaceSet', async () => {
+  it('no-ops (returns []) without any FontFaceSet', async () => {
     delete G.document;
     delete G.self;
-    await expect(preloadGoogleFonts(['Calibri'], MAP)).resolves.toBeUndefined();
+    await expect(preloadGoogleFonts(['Calibri'], MAP)).resolves.toEqual([]);
   });
 
   it('does not refetch a CSS url already registered in this context', async () => {
@@ -181,12 +184,130 @@ describe('preloadGoogleFonts', () => {
     await Promise.all([a, b]);
     expect(aDone).toBe(true);
     expect(bDone).toBe(true);
-    // Faces are registered exactly once (the joined call does not re-add them)
-    // and the url is fetched once. Each face is force-loaded — both callers run
-    // step 2 against the shared faces, so loadCalls is per-caller, but the
-    // registration (add + fetch) happened a single time.
+    // Faces are registered exactly once (the joined call reuses them via the
+    // shared refcount registry, not re-adding) and the url is fetched once. The
+    // first holder force-loads each face; the second reuses it (already loaded).
     expect(added.map((f) => f.family)).toEqual(['Carlito', 'Carlito']);
     expect((G.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
     expect(added.every((f) => f.loadCalls >= 1)).toBe(true);
+  });
+});
+
+// ---- dedup + destroy() cleanup (Google Fonts preload leak) ------------------
+//
+// document.fonts is a process-global singleton, so preloading the same Google
+// Font twice (two documents, or one document reopened in an SPA) must NOT add a
+// second identical FontFace; and a document's destroy() must remove the faces it
+// preloaded so they don't accumulate forever. Same refcount contract as the
+// embedded-font loader — both share the core FontFace registry.
+describe('preloadGoogleFonts — dedup + unloadGoogleFonts (SPA leak)', () => {
+  it('does not add the same web font twice (dedup by signature)', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    // Simulate preloading the same font in two documents.
+    const a = await preloadGoogleFonts(['Calibri'], MAP);
+    const b = await preloadGoogleFonts(['Calibri'], MAP);
+    // Only the two @font-face rules were added ONCE; the second preload reused them.
+    expect(added.map((f) => f.family)).toEqual(['Carlito', 'Carlito']);
+    // Both callers hold the SAME shared FontFace references.
+    expect(a).toHaveLength(2);
+    expect(b).toHaveLength(2);
+    expect(a[0]).toBe(b[0]);
+    expect(a[1]).toBe(b[1]);
+    // Each shared face is force-loaded exactly once (not per preload).
+    expect(added.every((f) => f.loadCalls === 1)).toBe(true);
+    // And the stylesheet was fetched once.
+    expect((G.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy() removes the document’s web fonts from the FontFaceSet', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const held = await preloadGoogleFonts(['Calibri'], MAP);
+    expect(added).toHaveLength(2);
+    unloadGoogleFonts(held); // what DocxDocument/PptxPresentation/XlsxWorkbook.destroy() calls
+    expect(added).toHaveLength(0); // faces left the set
+  });
+
+  it('a shared web font survives until the LAST holder releases it (refcount)', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const a = await preloadGoogleFonts(['Calibri'], MAP); // document A
+    const b = await preloadGoogleFonts(['Calibri'], MAP); // document B (same font)
+    expect(added).toHaveLength(2);
+
+    unloadGoogleFonts(a); // document A destroyed
+    expect(added).toHaveLength(2); // still referenced by B → faces stay
+
+    unloadGoogleFonts(b); // document B destroyed
+    expect(added).toHaveLength(0); // last holder gone → faces removed
+  });
+
+  it('re-preloading after a full release adds fresh faces (no stale registry entry)', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const a = await preloadGoogleFonts(['Calibri'], MAP);
+    unloadGoogleFonts(a);
+    expect(added).toHaveLength(0);
+    // Opening the same font again after everyone released it registers anew.
+    const b = await preloadGoogleFonts(['Calibri'], MAP);
+    expect(added).toHaveLength(2);
+    expect(b[0]).not.toBe(a[0]); // distinct FontFace object (a's was deleted)
+  });
+
+  it('unloadGoogleFonts is a no-op for unknown / already-released faces', () => {
+    installFakes();
+    G.document = { fonts: undefined };
+    const stray = { family: 'Stray' } as unknown as FontFace;
+    expect(() => unloadGoogleFonts([stray])).not.toThrow();
+  });
+
+  it('the same face passed twice in ONE release is decremented at most once (no over-decrement)', async () => {
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const a = await preloadGoogleFonts(['Calibri'], MAP); // document A
+    const b = await preloadGoogleFonts(['Calibri'], MAP); // document B (shares faces)
+    expect(added).toHaveLength(2);
+    expect(a[0]).toBe(b[0]); // same shared FontFace, refs === 2
+
+    // Document A releases, but its held list mistakenly contains a face twice.
+    // The per-call `seen` guard collapses the duplicate to a single decrement,
+    // so the face STAYS in the set (B still uses it).
+    unloadGoogleFonts([a[0], a[0], a[1]]);
+    expect(added).toHaveLength(2); // survived — B still holds them
+
+    unloadGoogleFonts(b); // B releasing drops the last references
+    expect(added).toHaveLength(0);
+  });
+
+  it('shares one FontFace across two formats requesting the same stylesheet (cross-loader dedup)', async () => {
+    // Two DIFFERENT preload maps (e.g. docx and xlsx) that point at the same
+    // Google Fonts CSS url for the same substitute compute the same signature,
+    // so the FontFace is added once and refcounted across both. This proves the
+    // registry is genuinely shared, not per-map.
+    const { set, added } = installFakes();
+    G.document = { fonts: set };
+    delete G.self;
+    const MAP_A: Record<string, FontPreloadEntry> = {
+      calibri: { url: 'https://fonts.googleapis.com/css2?family=Carlito', loadFamily: 'Carlito' },
+    };
+    const MAP_B: Record<string, FontPreloadEntry> = {
+      // A different Office name mapping to the SAME substitute + url.
+      'calibri light': { url: 'https://fonts.googleapis.com/css2?family=Carlito', loadFamily: 'Carlito' },
+    };
+    const a = await preloadGoogleFonts(['Calibri'], MAP_A);
+    const b = await preloadGoogleFonts(['Calibri Light'], MAP_B);
+    expect(added).toHaveLength(2); // added once despite two maps
+    expect(a[0]).toBe(b[0]);
+
+    unloadGoogleFonts(a);
+    expect(added).toHaveLength(2); // B still holds
+    unloadGoogleFonts(b);
+    expect(added).toHaveLength(0);
   });
 });

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -22,6 +22,8 @@
  * use a system fallback and shift once a later interaction re-rasterized
  * the canvas after the font landed.
  */
+import { retainFace, releaseFaces } from './font-registry.js';
+
 export interface FontPreloadEntry {
   /** Google Fonts CSS URL — `display=swap` recommended. */
   url: string;
@@ -55,22 +57,22 @@ export function withFontCeiling<T>(p: Promise<T>): Promise<T | void> {
   ]);
 }
 
-/** In-flight (or completed) fetch-and-register promise per CSS url, keyed by url.
- *  Resolves with the `FontFace` objects this loader added for that stylesheet
- *  (empty on fetch failure). Storing the PROMISE (not just a flag) lets a
- *  concurrent caller with the same url JOIN the first registration instead of
- *  seeing a cache hit, skipping registration, and resolving while the first
- *  fetch is still in flight (which would defeat the first-paint determinism this
- *  function exists to provide). It also hands step 2 the exact FontFace
- *  references to load — see why that matters there. The stored promise ALWAYS
- *  resolves: failure handling (recording the failed families + deleting the
- *  entry so a later call can retry) happens inside the producing call's own
- *  logic, so a cache-hit awaiter never throws. */
-const cssRegistrations = new Map<string, Promise<FontFace[]>>();
+/** In-flight (or completed) stylesheet FETCH promise per CSS url, keyed by url.
+ *  Resolves with the PARSED `@font-face` rules of that stylesheet (empty on a
+ *  failed fetch). This dedups only the NETWORK fetch: a concurrent caller with
+ *  the same url JOINs the first fetch instead of re-downloading, and the join
+ *  cannot resolve before the fetch settles (first-paint determinism). The actual
+ *  `FontFace` objects are dedup + refcounted separately per call in the shared
+ *  {@link ./font-registry.ts} (so two documents using the same web font share
+ *  one FontFace, and it leaves the set only when both release it). The stored
+ *  promise ALWAYS resolves: a failed fetch records the failed families + deletes
+ *  the entry (so a later call retries) inside the producing call, so a cache-hit
+ *  awaiter never throws. */
+const cssFetches = new Map<string, Promise<ParsedFontFace[]>>();
 
-/** Test hook — clears the per-context CSS registration cache. */
+/** Test hook — clears the per-context CSS fetch cache. */
 export function _resetCssCacheForTests(): void {
-  cssRegistrations.clear();
+  cssFetches.clear();
 }
 
 export interface ParsedFontFace {
@@ -119,12 +121,34 @@ export function activeFontSet(): FontFaceSet | null {
   return null;
 }
 
+/** Stable signature for one Google-Fonts `@font-face`, keyed to the CSS url it
+ *  came from + its identity (family + all CSS descriptors). `gfonts:` namespaces
+ *  it away from embedded-font signatures in the shared registry. Two documents
+ *  requesting the same web font compute the SAME signature and so share one
+ *  refcounted FontFace; distinct subsets (latin vs latin-ext, different weights)
+ *  key distinctly. */
+function googleFaceSignature(url: string, f: ParsedFontFace): string {
+  const d = f.descriptors;
+  return [
+    'gfonts',
+    url,
+    f.family.toLowerCase(),
+    d.style ?? '',
+    d.weight ?? '',
+    d.stretch ?? '',
+    d.unicodeRange ?? '',
+    // `src` last: two rules identical in every descriptor but pointing at
+    // different files (theoretically) still key apart.
+    f.src,
+  ].join('|');
+}
+
 export async function preloadGoogleFonts(
   fontNames: Iterable<string | null | undefined>,
   map: Record<string, FontPreloadEntry>,
-): Promise<void> {
+): Promise<FontFace[]> {
   const fonts = activeFontSet();
-  if (!fonts || typeof FontFace === 'undefined' || typeof fetch === 'undefined') return;
+  if (!fonts || typeof FontFace === 'undefined' || typeof fetch === 'undefined') return [];
 
   const seen = new Set<string>();
   const targetFamilies = new Set<string>();
@@ -138,7 +162,7 @@ export async function preloadGoogleFonts(
   // matching FontFace.load() rejected). Surfaced once at the end via a single
   // console.warn so a failed web font no longer falls back to a system face
   // completely silently. The renderer still degrades gracefully — this is
-  // diagnostics only, the return contract stays `Promise<void>`.
+  // diagnostics only.
   const failedFamilies = new Set<string>();
 
   for (const name of fontNames) {
@@ -158,66 +182,82 @@ export async function preloadGoogleFonts(
     }
     targets.add(family);
   }
-  if (targetFamilies.size === 0) return;
+  if (targetFamilies.size === 0) return [];
 
-  // 1) Fetch each stylesheet once per JS context and register its FontFace
-  //    entries into the active FontFaceSet, keeping references to the faces we
-  //    add. Canvas rendering never puts glyphs into the DOM, so registration
-  //    alone is not enough — see (2).
-  const faceGroups = await withFontCeiling(
+  // 1) Fetch each stylesheet once per JS context (network dedup via cssFetches)
+  //    and PARSE its `@font-face` rules. The rules are shared data; the FontFace
+  //    objects are created + refcounted per call in step 2 so two open documents
+  //    share one face and it leaves the set only when both release it.
+  const parsedGroups = await withFontCeiling(
     Promise.all(
-      [...cssUrls].map((url) => {
-        // Cache hit: AWAIT the in-flight registration so concurrent callers join
-        // the first fetch rather than racing past it. The stored promise never
-        // rejects (see cssRegistrations), so a joined-then-failed registration
-        // just yields no faces in step 2.
-        const inFlight = cssRegistrations.get(url);
-        if (inFlight) return inFlight;
-        const registration = (async (): Promise<FontFace[]> => {
+      [...cssUrls].map(async (url): Promise<{ url: string; rules: ParsedFontFace[] }> => {
+        // Cache hit: AWAIT the in-flight fetch so concurrent callers join the
+        // first download rather than racing past it. The stored promise never
+        // rejects (see cssFetches), so a joined-then-failed fetch yields [].
+        const inFlight = cssFetches.get(url);
+        if (inFlight) return { url, rules: await inFlight };
+        const fetchAndParse = (async (): Promise<ParsedFontFace[]> => {
           try {
             const res = await fetch(url);
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            const added: FontFace[] = [];
-            for (const f of parseFontFaceRules(await res.text())) {
-              const face = new FontFace(f.family, f.src, f.descriptors);
-              fonts.add(face);
-              added.push(face);
-            }
-            return added;
+            return parseFontFaceRules(await res.text());
           } catch {
-            cssRegistrations.delete(url); // free the slot so a later call retries
+            cssFetches.delete(url); // free the slot so a later call retries
             for (const family of urlTargets.get(url) ?? []) {
               failedFamilies.add(family);
             }
             return [];
           }
         })();
-        cssRegistrations.set(url, registration);
-        return registration;
+        cssFetches.set(url, fetchAndParse);
+        return { url, rules: await fetchAndParse };
       }),
     ),
   );
 
-  // 2) Force-load the FontFaces we added and AWAIT them all — no timeout race
-  //    that could resolve mid-download. `face.load()` is required because
-  //    unicode-range gating would otherwise leave the faces `unloaded` and the
-  //    first canvas paint would use a system fallback, shifting once a later
-  //    interaction re-rasterized. We load the FontFace objects WE created (held
-  //    via cssRegistrations) rather than re-selecting them from the set by
-  //    family name: `FontFace.family` serializes a multi-word name back WITH
-  //    quotes (e.g. `"Nunito Sans"`), so a `family`-string filter silently
-  //    matches nothing and the fonts never load — the bug this avoids.
-  const addedFaces = (Array.isArray(faceGroups) ? faceGroups : []).flat();
-  await withFontCeiling(
-    Promise.allSettled(addedFaces.map((f) => f.load())).then((results) => {
-      results.forEach((res, i) => {
-        if (res.status === 'rejected') {
-          failedFamilies.add(addedFaces[i].family.replace(/['"]/g, '').toLowerCase());
-        }
+  // 2) Retain a shared, refcounted FontFace per parsed rule. The FIRST holder of
+  //    a rule (across all open documents) creates the FontFace, adds it to the
+  //    set, and must force-`load()` it; a later holder reuses the shared face
+  //    (already loaded) and only bumps its refcount. `held` is what THIS call
+  //    references — returned so the caller can release it in `destroy()`, the
+  //    fix for the SPA leak where every opened document left its Google FontFace
+  //    objects in `document.fonts` forever.
+  const held: FontFace[] = [];
+  const toLoad: FontFace[] = [];
+  for (const group of Array.isArray(parsedGroups) ? parsedGroups : []) {
+    for (const rule of group.rules) {
+      const sig = googleFaceSignature(group.url, rule);
+      const { face, isNew } = retainFace(sig, fonts, () => {
+        const created = new FontFace(rule.family, rule.src, rule.descriptors);
+        fonts.add(created);
+        return created;
       });
-      return fonts.ready;
-    }),
-  );
+      held.push(face);
+      if (isNew) toLoad.push(face);
+    }
+  }
+
+  // 3) Force-load only the FontFaces this call newly created and AWAIT them —
+  //    no timeout race that could resolve mid-download. `face.load()` is required
+  //    because unicode-range gating would otherwise leave the faces `unloaded`
+  //    and the first canvas paint would use a system fallback, shifting once a
+  //    later interaction re-rasterized. We load the FontFace objects WE created
+  //    rather than re-selecting them from the set by family name: `FontFace.family`
+  //    serializes a multi-word name back WITH quotes (e.g. `"Nunito Sans"`), so a
+  //    `family`-string filter silently matches nothing and the fonts never load —
+  //    the bug this avoids. (Reused faces were already loaded by their first holder.)
+  if (toLoad.length > 0) {
+    await withFontCeiling(
+      Promise.allSettled(toLoad.map((f) => f.load())).then((results) => {
+        results.forEach((res, i) => {
+          if (res.status === 'rejected') {
+            failedFamilies.add(toLoad[i].family.replace(/['"]/g, '').toLowerCase());
+          }
+        });
+        return fonts.ready;
+      }),
+    );
+  }
 
   if (failedFamilies.size > 0) {
     console.warn(
@@ -225,4 +265,21 @@ export async function preloadGoogleFonts(
         `falling back to system fonts (text may shift or differ).`,
     );
   }
+
+  return held;
+}
+
+/**
+ * Release the Google-Fonts `FontFace` objects a document/presentation/workbook
+ * preloaded (the array returned by {@link preloadGoogleFonts}). Refcounted +
+ * dedup-safe via the shared {@link ./font-registry.ts}: each face is removed
+ * from its FontFaceSet only when the LAST holder releases it, so a web font used
+ * by two open documents survives until both are destroyed. Double-release safe
+ * (a face passed twice, or a re-release after full release, is a no-op) and safe
+ * in a context without a FontFaceSet. Twin of `unregisterEmbeddedFonts`; called
+ * from each viewer's `destroy()` to fix the SPA leak where every opened document
+ * left its Google FontFace objects in `document.fonts` forever.
+ */
+export function unloadGoogleFonts(faces: Iterable<FontFace>): void {
+  releaseFaces(faces);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,7 +67,7 @@ export {
   type AgileEncryptionDescriptor,
 } from './crypto';
 export { readCfbStream } from './errors/cfb-read';
-export { preloadGoogleFonts, type FontPreloadEntry } from './fonts/preload';
+export { preloadGoogleFonts, unloadGoogleFonts, type FontPreloadEntry } from './fonts/preload';
 // Embedded-font registration: docx `.odttf` (§17.8.1 obfuscated) + pptx
 // `.fntdata` (raw sfnt) faces turned into FontFace objects in the active set.
 export {

--- a/packages/docx/src/document-destroy.test.ts
+++ b/packages/docx/src/document-destroy.test.ts
@@ -76,6 +76,7 @@ describe('DocxDocument.destroy() — rejects in-flight worker requests', () => {
     // Fields destroy() clears after terminate(); undefined would throw.
     instance._imageCache = new Map();
     instance._embeddedFontFaces = [];
+    instance._googleFontFaces = [];
     instance._fetchImage = () => Promise.resolve(new Blob());
     return { doc: instance as unknown as DestroyProbe, bridge, worker };
   }

--- a/packages/docx/src/document-destroy.test.ts
+++ b/packages/docx/src/document-destroy.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { WorkerBridge, registerEmbeddedFonts, type WorkerLike } from '@silurus/ooxml-core';
+import {
+  WorkerBridge,
+  registerEmbeddedFonts,
+  preloadGoogleFonts,
+  type WorkerLike,
+  type FontPreloadEntry,
+} from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 
 /**
@@ -24,12 +30,14 @@ class SilentWorker implements WorkerLike {
   }
 }
 
-// ── Fake FontFaceSet so destroy()'s embedded-font release is observable ──────
+// ── Fake FontFaceSet so destroy()'s embedded-font / Google-Fonts release is
+// observable ──────────────────────────────────────────────────────────────
 const G = globalThis as Record<string, unknown>;
-const ORIG_FONTS = { document: G.document, self: G.self, FontFace: G.FontFace };
+const ORIG_FONTS = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
 afterEach(() => {
   G.document = ORIG_FONTS.document;
   G.self = ORIG_FONTS.self;
+  G.fetch = ORIG_FONTS.fetch;
   G.FontFace = ORIG_FONTS.FontFace;
 });
 
@@ -52,6 +60,33 @@ function installFontFaceSet(): { added: FakeFace[] } {
   delete G.self;
   return { added };
 }
+
+// ── Google-Fonts flavored fake: `preloadGoogleFonts` needs `fetch` (to pull
+// the CSS) and a string-`src` `FontFace` constructor, unlike the ArrayBuffer
+// source used by the embedded-font fake above. Mirrors the fake used by
+// `presentation-destroy.test.ts` / `workbook-destroy.test.ts`. ──────────────
+const GOOGLE_CSS = `@font-face { font-family: 'Carlito'; font-style: normal; font-weight: 400; src: url(https://fonts.gstatic.com/s/carlito/y.woff2) format('woff2'); }`;
+function installGoogleFontFaceSet(): { added: FakeFace[] } {
+  const added: FakeFace[] = [];
+  class FakeFontFace {
+    constructor(public family: string, public source: string, public descriptors?: object) {}
+    load(): Promise<FakeFontFace> { return Promise.resolve(this); }
+  }
+  const set = {
+    add: (f: FakeFace) => { added.push(f); },
+    delete: (f: FakeFace) => { const i = added.indexOf(f); if (i >= 0) added.splice(i, 1); return i >= 0; },
+    [Symbol.iterator]() { return added[Symbol.iterator](); },
+    ready: Promise.resolve(),
+  };
+  G.FontFace = FakeFontFace;
+  G.document = { fonts: set };
+  G.fetch = async () => ({ ok: true, text: async () => GOOGLE_CSS });
+  delete G.self;
+  return { added };
+}
+const GOOGLE_FONT_MAP: Record<string, FontPreloadEntry> = {
+  calibri: { url: 'https://fonts.googleapis.com/css2?family=Carlito', loadFamily: 'Carlito' },
+};
 
 /** A minimal valid sfnt header so registerEmbeddedFonts accepts the face. */
 const validHeader = (): Uint8Array =>
@@ -117,5 +152,28 @@ describe('DocxDocument.destroy() — rejects in-flight worker requests', () => {
     // left the FontFaceSet, and the held array was cleared.
     expect(added).toHaveLength(0);
     expect((doc as unknown as { _embeddedFontFaces: FontFace[] })._embeddedFontFaces).toHaveLength(0);
+  });
+
+  // Wiring guard: destroy() must actually release the Google-Fonts substitutes
+  // the document preloaded into the shared FontFaceSet. The other tests set
+  // `_googleFontFaces = []`, so they never exercise the unload branch — a
+  // dropped call (or a wrong field name) would go unnoticed. Preload a real
+  // face through core, hand it to the document, then assert destroy() removes
+  // it from the (fake) FontFaceSet and clears the held array. Twin of the
+  // embedded-fonts guard above; same shape as
+  // `presentation-destroy.test.ts` / `workbook-destroy.test.ts`.
+  it('destroy() releases the document’s Google fonts from the FontFaceSet', async () => {
+    const { added } = installGoogleFontFaceSet();
+    const held = await preloadGoogleFonts(['Calibri'], GOOGLE_FONT_MAP);
+    expect(added).toHaveLength(1); // the web font is in the shared set
+
+    const { doc } = makeDocument();
+    (doc as unknown as { _googleFontFaces: FontFace[] })._googleFontFaces = held;
+    doc.destroy();
+
+    // destroy() called unloadGoogleFonts(held): last holder gone → the face
+    // left the FontFaceSet, and the held array was cleared.
+    expect(added).toHaveLength(0);
+    expect((doc as unknown as { _googleFontFaces: FontFace[] })._googleFontFaces).toHaveLength(0);
   });
 });

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -2,6 +2,7 @@ import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/docx_parser_bg.wasm?url';
 import {
   preloadGoogleFonts,
+  unloadGoogleFonts,
   unregisterEmbeddedFonts,
   WorkerBridge,
   defaultDpr,
@@ -57,6 +58,12 @@ export class DocxDocument {
    *  the shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in
    *  core, so a font shared with another open document survives until both go). */
   private _embeddedFontFaces: FontFace[] = [];
+  /** Google-Fonts `FontFace` objects this document preloaded into `document.fonts`
+   *  (main mode only — in worker mode the worker owns them and terminates with its
+   *  own FontFaceSet). Released in {@link destroy} so they do not leak into the
+   *  shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in core,
+   *  so a web font shared with another open document survives until both go). */
+  private _googleFontFaces: FontFace[] = [];
   /** One stable closure per instance: core's path-keyed SVG cache namespaces on
    *  this identity, so two open documents never swap a shared zip path (e.g.
    *  word/media/image1.svg). Reusing one reference also lets the SVG cache hit
@@ -120,7 +127,7 @@ export class DocxDocument {
       opts.workerTimeoutMs,
     );
     if (mode === 'main' && opts.useGoogleFonts && doc._document) {
-      await preloadGoogleFonts(
+      doc._googleFontFaces = await preloadGoogleFonts(
         docxFontPreloadNames(doc._document),
         DOCX_GOOGLE_FONTS,
       );
@@ -181,6 +188,15 @@ export class DocxDocument {
     if (this._embeddedFontFaces.length > 0) {
       unregisterEmbeddedFonts(this._embeddedFontFaces);
       this._embeddedFontFaces = [];
+    }
+    // Release the Google-Fonts substitutes this document preloaded into the
+    // shared FontFaceSet (main mode). Same refcount contract as the embedded
+    // fonts: a web font also used by another open document stays until that one
+    // is destroyed too. Without this, every opened document left its Google
+    // FontFace objects in `document.fonts` forever (SPA memory leak).
+    if (this._googleFontFaces.length > 0) {
+      unloadGoogleFonts(this._googleFontFaces);
+      this._googleFontFaces = [];
     }
     // Release this document's three per-fetchImage image caches: the decoded
     // base raster bitmaps (GPU-backed, shared with pptx/xlsx), the a:clrChange

--- a/packages/pptx/src/presentation-destroy.test.ts
+++ b/packages/pptx/src/presentation-destroy.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { WorkerBridge, type WorkerLike } from '@silurus/ooxml-core';
+import { describe, it, expect, afterEach } from 'vitest';
+import { WorkerBridge, preloadGoogleFonts, type WorkerLike, type FontPreloadEntry } from '@silurus/ooxml-core';
 import { PptxPresentation } from './presentation';
 
 /**
@@ -26,6 +26,40 @@ interface DestroyProbe {
   destroy(): void;
 }
 
+// ── Fake FontFaceSet so destroy()'s Google-Fonts release is observable ───────
+const G = globalThis as Record<string, unknown>;
+const ORIG_FONTS = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
+afterEach(() => {
+  G.document = ORIG_FONTS.document;
+  G.self = ORIG_FONTS.self;
+  G.fetch = ORIG_FONTS.fetch;
+  G.FontFace = ORIG_FONTS.FontFace;
+});
+
+const CSS = `@font-face { font-family: 'Carlito'; font-style: normal; font-weight: 400; src: url(https://fonts.gstatic.com/s/carlito/y.woff2) format('woff2'); }`;
+interface FakeFace { family: string }
+function installFontFaceSet(): { added: FakeFace[] } {
+  const added: FakeFace[] = [];
+  class FakeFontFace {
+    constructor(public family: string, public source: string, public descriptors?: object) {}
+    load(): Promise<FakeFontFace> { return Promise.resolve(this); }
+  }
+  const set = {
+    add: (f: FakeFace) => { added.push(f); },
+    delete: (f: FakeFace) => { const i = added.indexOf(f); if (i >= 0) added.splice(i, 1); return i >= 0; },
+    [Symbol.iterator]() { return added[Symbol.iterator](); },
+    ready: Promise.resolve(),
+  };
+  G.FontFace = FakeFontFace;
+  G.document = { fonts: set };
+  G.fetch = async () => ({ ok: true, text: async () => CSS });
+  delete G.self;
+  return { added };
+}
+const MAP: Record<string, FontPreloadEntry> = {
+  calibri: { url: 'https://fonts.googleapis.com/css2?family=Carlito', loadFamily: 'Carlito' },
+};
+
 describe('PptxPresentation.destroy() — rejects in-flight worker requests', () => {
   function makePresentation() {
     const worker = new SilentWorker();
@@ -37,6 +71,7 @@ describe('PptxPresentation.destroy() — rejects in-flight worker requests', () 
     // Fields destroy() clears after terminate(); undefined would throw.
     instance._mediaCache = new Map();
     instance._imageCache = new Map();
+    instance._googleFontFaces = [];
     instance._fetchImage = () => Promise.resolve(new Blob());
     return { pres: instance as unknown as DestroyProbe, bridge, worker };
   }
@@ -53,5 +88,23 @@ describe('PptxPresentation.destroy() — rejects in-flight worker requests', () 
     const { pres } = makePresentation();
     pres.destroy();
     expect(() => pres.destroy()).not.toThrow();
+  });
+
+  // Wiring guard: destroy() must actually release the Google-Fonts substitutes
+  // the deck preloaded into the shared FontFaceSet. The other tests set
+  // `_googleFontFaces = []`, so they never exercise the unload branch — a dropped
+  // call (or a wrong field name) would go unnoticed. Preload a real face through
+  // core, hand it to the deck, then assert destroy() removes it and clears the array.
+  it('destroy() releases the deck’s Google fonts from the FontFaceSet', async () => {
+    const { added } = installFontFaceSet();
+    const held = await preloadGoogleFonts(['Calibri'], MAP);
+    expect(added).toHaveLength(1); // the web font is in the shared set
+
+    const { pres } = makePresentation();
+    (pres as unknown as { _googleFontFaces: FontFace[] })._googleFontFaces = held;
+    pres.destroy();
+
+    expect(added).toHaveLength(0); // face left the set
+    expect((pres as unknown as { _googleFontFaces: FontFace[] })._googleFontFaces).toHaveLength(0);
   });
 });

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -5,6 +5,7 @@ import { selectNotes } from './notes';
 import { selectHidden } from './hidden';
 import {
   preloadGoogleFonts,
+  unloadGoogleFonts,
   WorkerBridge,
   defaultDpr,
   isHTMLCanvas,
@@ -92,6 +93,12 @@ export class PptxPresentation {
   private _meta: PresentationMeta | null = null;
   private _mediaCache = new Map<string, Promise<Blob>>();
   private _imageCache = new Map<string, Promise<Blob>>();
+  /** Google-Fonts `FontFace` objects this deck preloaded into `document.fonts`
+   *  (main mode only — in worker mode the worker owns them and terminates with
+   *  its own FontFaceSet). Released in {@link destroy} so they do not leak into
+   *  the shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in
+   *  core, so a web font shared with another open deck survives until both go). */
+  private _googleFontFaces: FontFace[] = [];
   /** One stable closure per instance: the decoded-bitmap and SVG caches key on
    *  this identity to scope decodes per deck (so two open decks never swap
    *  images for a shared zip path like ppt/media/image1.png). Reusing the same
@@ -162,7 +169,7 @@ export class PptxPresentation {
       opts.workerTimeoutMs,
     );
     if (mode === 'main' && opts.useGoogleFonts && pres._presentation) {
-      await preloadGoogleFonts(
+      pres._googleFontFaces = await preloadGoogleFonts(
         pptxFontPreloadNames(pres._presentation),
         PPTX_GOOGLE_FONTS,
       );
@@ -471,6 +478,14 @@ export class PptxPresentation {
     this._meta = null;
     this._mediaCache.clear();
     this._imageCache.clear();
+    // Release the Google-Fonts substitutes this deck preloaded into the shared
+    // FontFaceSet (main mode). Refcounted in core: a web font also used by another
+    // open deck stays until that one is destroyed too. Without this, every opened
+    // deck left its Google FontFace objects in `document.fonts` forever (SPA leak).
+    if (this._googleFontFaces.length > 0) {
+      unloadGoogleFonts(this._googleFontFaces);
+      this._googleFontFaces = [];
+    }
     // Release this deck's decoded raster bitmaps (GPU-backed) and SVG object
     // URLs promptly; both caches are keyed by `_fetchImage`.
     dropImageBitmapCache(this._fetchImage);

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -32,8 +32,11 @@ const host = new WasmParserHost<PptxArchive>(init, {
   reinit,
 });
 let pres: Presentation | null = null;
-/** Settled before any render when `useGoogleFonts` was requested. */
-let fontsLoaded: Promise<void> = Promise.resolve();
+/** Settled before any render when `useGoogleFonts` was requested. The resolved
+ *  value (the preloaded FontFace[]) is unused here: the worker owns its own
+ *  FontFaceSet (`self.fonts`) and terminates with it, so there is nothing to
+ *  release — only the sequencing (fonts landed before first paint) matters. */
+let fontsLoaded: Promise<unknown> = Promise.resolve();
 const mediaCache = new Map<string, Promise<Blob>>();
 const imageCache = new Map<string, Promise<Blob>>();
 

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -30,7 +30,11 @@ const host = new WasmParserHost<XlsxArchive>(init, {
   reinit,
 });
 let workbook: ParsedWorkbook | null = null;
-let fontsLoaded: Promise<void> = Promise.resolve();
+/** Settled before any render when `useGoogleFonts` was requested. The resolved
+ *  value (the preloaded FontFace[]) is unused here: the worker owns its own
+ *  FontFaceSet (`self.fonts`) and terminates with it, so there is nothing to
+ *  release — only the sequencing (fonts landed before first paint) matters. */
+let fontsLoaded: Promise<unknown> = Promise.resolve();
 const sheetCache = new Map<number, Worksheet>();
 const imageCache = new Map<string, CanvasImageSource | null>();
 // Fetched image *bytes* (as Blobs) keyed by zip path. Twin of the docx render

--- a/packages/xlsx/src/workbook-destroy.test.ts
+++ b/packages/xlsx/src/workbook-destroy.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { WorkerBridge, type WorkerLike } from '@silurus/ooxml-core';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { WorkerBridge, preloadGoogleFonts, type WorkerLike, type FontPreloadEntry } from '@silurus/ooxml-core';
 import { XlsxWorkbook } from './workbook.js';
 
 /**
@@ -26,6 +26,40 @@ interface DestroyProbe {
   destroy(): void;
 }
 
+// ── Fake FontFaceSet so destroy()'s Google-Fonts release is observable ───────
+const G = globalThis as Record<string, unknown>;
+const ORIG_FONTS = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
+afterEach(() => {
+  G.document = ORIG_FONTS.document;
+  G.self = ORIG_FONTS.self;
+  G.fetch = ORIG_FONTS.fetch;
+  G.FontFace = ORIG_FONTS.FontFace;
+});
+
+const CSS = `@font-face { font-family: 'Carlito'; font-style: normal; font-weight: 400; src: url(https://fonts.gstatic.com/s/carlito/y.woff2) format('woff2'); }`;
+interface FakeFace { family: string }
+function installFontFaceSet(): { added: FakeFace[] } {
+  const added: FakeFace[] = [];
+  class FakeFontFace {
+    constructor(public family: string, public source: string, public descriptors?: object) {}
+    load(): Promise<FakeFontFace> { return Promise.resolve(this); }
+  }
+  const set = {
+    add: (f: FakeFace) => { added.push(f); },
+    delete: (f: FakeFace) => { const i = added.indexOf(f); if (i >= 0) added.splice(i, 1); return i >= 0; },
+    [Symbol.iterator]() { return added[Symbol.iterator](); },
+    ready: Promise.resolve(),
+  };
+  G.FontFace = FakeFontFace;
+  G.document = { fonts: set };
+  G.fetch = async () => ({ ok: true, text: async () => CSS });
+  delete G.self;
+  return { added };
+}
+const MAP: Record<string, FontPreloadEntry> = {
+  calibri: { url: 'https://fonts.googleapis.com/css2?family=Carlito', loadFamily: 'Carlito' },
+};
+
 describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
   function makeWorkbook() {
     const worker = new SilentWorker();
@@ -38,6 +72,7 @@ describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
     instance.sheetCache = new Map();
     instance.imageCache = new Map();
     instance.imageBlobCache = new Map();
+    instance.googleFontFaces = [];
     instance._fetchImage = () => Promise.resolve(new Blob());
     return { wb: instance as unknown as DestroyProbe, bridge, worker };
   }
@@ -54,6 +89,22 @@ describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
     const { wb } = makeWorkbook();
     wb.destroy();
     expect(() => wb.destroy()).not.toThrow();
+  });
+
+  // Wiring guard: destroy() must actually release the Google-Fonts substitutes
+  // the workbook preloaded. The other tests set `googleFontFaces = []`, so they
+  // never exercise the unload branch — a dropped call would go unnoticed.
+  it('destroy() releases the workbook’s Google fonts from the FontFaceSet', async () => {
+    const { added } = installFontFaceSet();
+    const held = await preloadGoogleFonts(['Calibri'], MAP);
+    expect(added).toHaveLength(1);
+
+    const { wb } = makeWorkbook();
+    (wb as unknown as { googleFontFaces: FontFace[] }).googleFontFaces = held;
+    wb.destroy();
+
+    expect(added).toHaveLength(0);
+    expect((wb as unknown as { googleFontFaces: FontFace[] }).googleFontFaces).toHaveLength(0);
   });
 });
 
@@ -75,6 +126,7 @@ describe('XlsxWorkbook.destroy() — closes cached ImageBitmaps (GPU-leak guard)
     instance.sheetCache = new Map();
     instance.imageCache = imageCache;
     instance.imageBlobCache = new Map();
+    instance.googleFontFaces = [];
     instance._fetchImage = () => Promise.resolve(new Blob());
     return instance as unknown as DestroyProbe;
   }

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -2,6 +2,7 @@ import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/xlsx_parser_bg.wasm?url';
 import {
   preloadGoogleFonts,
+  unloadGoogleFonts,
   WorkerBridge,
   defaultDpr,
   dropSvgImageCache,
@@ -66,6 +67,12 @@ export class XlsxWorkbook {
    *  `renderViewport` call reuses it — equations in shapes render when present,
    *  and are skipped (engine tree-shaken) when omitted. */
   private math: MathRenderer | undefined;
+  /** Google-Fonts `FontFace` objects this workbook preloaded into `document.fonts`
+   *  (main mode only — in worker mode the worker owns them and terminates with its
+   *  own FontFaceSet). Released in {@link destroy} so they do not leak into the
+   *  shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in core,
+   *  so a web font shared with another open workbook survives until both go). */
+  private googleFontFaces: FontFace[] = [];
   private _mode: 'main' | 'worker' = 'main';
 
   private constructor(worker: Worker, mode: 'main' | 'worker', wasmUrlOverride?: string | URL) {
@@ -172,7 +179,7 @@ export class XlsxWorkbook {
       console.warn(`[ooxml] xlsx opened with a degraded part: ${workbookError}`);
     }
     if (this._mode === 'main' && opts.useGoogleFonts) {
-      await preloadGoogleFonts(
+      this.googleFontFaces = await preloadGoogleFonts(
         xlsxFontPreloadNames(this.parsedWorkbook),
         XLSX_GOOGLE_FONTS,
       );
@@ -417,6 +424,15 @@ export class XlsxWorkbook {
     this.bridge.terminate();
     this.parsedWorkbook = null;
     this.sheetCache.clear();
+    // Release the Google-Fonts substitutes this workbook preloaded into the
+    // shared FontFaceSet (main mode). Refcounted in core: a web font also used by
+    // another open workbook stays until that one is destroyed too. Without this,
+    // every opened workbook left its Google FontFace objects in `document.fonts`
+    // forever (SPA memory leak).
+    if (this.googleFontFaces.length > 0) {
+      unloadGoogleFonts(this.googleFontFaces);
+      this.googleFontFaces = [];
+    }
     // Closes each cached ImageBitmap's GPU backing before dropping the map —
     // see closeAndClearImageCache for why a bare `.clear()` would leak.
     closeAndClearImageCache(this.imageCache);


### PR DESCRIPTION
## Summary
`preloadGoogleFonts` added `FontFace`s to the global FontFaceSet with no release path — every SPA re-open leaked one FontFace per web font, across all three viewers (none removed them in `destroy()`). Same shape as the #762 embedded-font leak, but 3-way wide. Found via the teardown-resource audit.

## Implementation
- **Shared `core/src/fonts/font-registry.ts`** (new): extracts #762's refcount/dedup/last-release/double-release-safe machinery into a format-agnostic primitive — `retainFace(sig, set, create)` (first holder creates+adds+loads, later holders bump refs), `releaseFaces(faces)` (deletes from the set only at refs 0, per-call `seen` guard + cross-call no-op after full release).
- **embedded.ts** now retains via the shared registry (keyed `embedded:${contentSignature}`); its bespoke refcount code deleted. `unregisterEmbeddedFonts` delegates to `releaseFaces`. Each loader keeps its own signature computation (content-hash vs url+descriptors) — no false abstraction.
- **preload.ts**: `cssFetches` dedups only the network fetch; FontFaces refcounted per-call (keyed `gfonts:url|family|style|weight|stretch|unicodeRange|src`). `preloadGoogleFonts` returns the held `FontFace[]`; new `unloadGoogleFonts(faces)`.
- **3-package destroy() wiring**: docx/pptx/xlsx capture the returned faces at load (main mode) and call `unloadGoogleFonts` in `destroy()`; worker mode discards the return (worker owns `self.fonts`, terminates with it).

## Tests / gates
`font-registry.test.ts` + `preload.test.ts` (dedup, destroy-removes, last-release survival, re-preload, double-release safety, cross-loader dedup); wiring guards in all 3 destroy tests. vitest core+3pkg 2308; root tsc clean; **VRT non-regression** docx 21 / pptx 75 / xlsx 67 (references untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)