### PR TITLE
feat: in-document text search + highlight (findText) for docx/pptx/xlsx (IX2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -367,3 +367,21 @@ export {
   intendedSingleLinePx,
   correctLineMetrics,
 } from './text/line-metrics';
+// IX2 in-document text search (findText). Format-agnostic index + match →
+// run-slice resolution (buildTextIndex/findMatches), the pure highlight-extent
+// helper (sliceHorizontalExtent), the active-match cursor arithmetic behind
+// findNext/findPrev (nextActive/prevActive/clampActive), and the shared public
+// FindMatch result shape. Each viewer supplies the run stream + turns a slice
+// into a pixel rect / DOM box in its own geometry; core owns the string math.
+export {
+  buildTextIndex,
+  findMatches,
+  type SearchRun,
+  type TextIndex,
+  type MatchRunSlice,
+  type TextMatch,
+  type FindMatchesOptions,
+} from './search/text-index';
+export { sliceHorizontalExtent } from './search/highlight-rect';
+export { nextActive, prevActive, clampActive } from './search/find-cursor';
+export type { FindMatch } from './search/find-match';

--- a/packages/core/src/search/find-cursor.test.ts
+++ b/packages/core/src/search/find-cursor.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { nextActive, prevActive, clampActive } from './find-cursor.js';
+
+/**
+ * IX2 active-match cursor. `findNext` / `findPrev` cycle a viewer's "active"
+ * match with wrap-around (like a browser's find bar). The arithmetic is pure —
+ * given the current active index and the total match count it returns the next /
+ * previous index — so it lives in core and is shared by all three viewers.
+ */
+describe('nextActive', () => {
+  it('advances to the next match', () => {
+    expect(nextActive(0, 3)).toBe(1);
+    expect(nextActive(1, 3)).toBe(2);
+  });
+
+  it('wraps from the last match back to the first', () => {
+    expect(nextActive(2, 3)).toBe(0);
+  });
+
+  it('lands on the first match when there is no active match yet (-1)', () => {
+    expect(nextActive(-1, 3)).toBe(0);
+  });
+
+  it('returns -1 when there are no matches', () => {
+    expect(nextActive(-1, 0)).toBe(-1);
+    expect(nextActive(0, 0)).toBe(-1);
+  });
+
+  it('stays on the only match in a one-match set', () => {
+    expect(nextActive(0, 1)).toBe(0);
+  });
+});
+
+describe('prevActive', () => {
+  it('steps to the previous match', () => {
+    expect(prevActive(2, 3)).toBe(1);
+    expect(prevActive(1, 3)).toBe(0);
+  });
+
+  it('wraps from the first match to the last', () => {
+    expect(prevActive(0, 3)).toBe(2);
+  });
+
+  it('lands on the last match when there is no active match yet (-1)', () => {
+    expect(prevActive(-1, 3)).toBe(2);
+  });
+
+  it('returns -1 when there are no matches', () => {
+    expect(prevActive(-1, 0)).toBe(-1);
+    expect(prevActive(0, 0)).toBe(-1);
+  });
+
+  it('stays on the only match in a one-match set', () => {
+    expect(prevActive(0, 1)).toBe(0);
+  });
+});
+
+describe('clampActive', () => {
+  it('keeps an in-range index unchanged', () => {
+    expect(clampActive(1, 3)).toBe(1);
+  });
+
+  it('returns -1 for an out-of-range index (matches shrank)', () => {
+    expect(clampActive(5, 3)).toBe(-1);
+    expect(clampActive(3, 3)).toBe(-1);
+  });
+
+  it('returns -1 when there are no matches', () => {
+    expect(clampActive(0, 0)).toBe(-1);
+  });
+
+  it('normalizes any negative index to -1 (no active)', () => {
+    expect(clampActive(-2, 3)).toBe(-1);
+  });
+});

--- a/packages/core/src/search/find-cursor.ts
+++ b/packages/core/src/search/find-cursor.ts
@@ -1,0 +1,53 @@
+/**
+ * IX2 active-match cursor — the pure arithmetic behind `findNext` / `findPrev`.
+ *
+ * A viewer keeps one "active" match highlighted distinctly and cycles it with
+ * wrap-around, exactly like a browser's find bar: `findNext` advances (last →
+ * first), `findPrev` steps back (first → last). The convention for the active
+ * index is `-1` = "no active match yet" (nothing highlighted). From that state
+ * `findNext` lands on the first match and `findPrev` on the last, matching what
+ * a user expects the first Enter / Shift+Enter to do.
+ *
+ * This is the only piece of find-cursor logic shared by all three viewers, and
+ * it is pure index math (no DOM, no geometry), so it lives in core rather than
+ * being re-derived — with off-by-one wrap bugs — in each package.
+ */
+
+/**
+ * The next active-match index after `findNext`, with wrap-around.
+ *
+ * @param active current active index, or `-1` for "none yet".
+ * @param count  total number of matches.
+ * @returns the new active index in `[0, count)`, or `-1` when `count === 0`.
+ */
+export function nextActive(active: number, count: number): number {
+  if (count <= 0) return -1;
+  if (active < 0) return 0; // no active match yet → first
+  return (active + 1) % count;
+}
+
+/**
+ * The previous active-match index after `findPrev`, with wrap-around.
+ *
+ * @param active current active index, or `-1` for "none yet".
+ * @param count  total number of matches.
+ * @returns the new active index in `[0, count)`, or `-1` when `count === 0`.
+ */
+export function prevActive(active: number, count: number): number {
+  if (count <= 0) return -1;
+  if (active < 0) return count - 1; // no active match yet → last
+  return (active - 1 + count) % count;
+}
+
+/**
+ * Normalize an active index against the current match count: an in-range index
+ * passes through, anything else (negative, or ≥ count because the match set
+ * shrank on a new query) collapses to `-1` (no active match). Used when a
+ * viewer recomputes matches and must decide whether the old active index is
+ * still meaningful.
+ */
+export function clampActive(active: number, count: number): number {
+  if (count <= 0) return -1;
+  if (active < 0 || active >= count) return -1;
+  return active;
+}

--- a/packages/core/src/search/find-match.ts
+++ b/packages/core/src/search/find-match.ts
@@ -1,0 +1,31 @@
+/**
+ * IX2 public find-result shape, shared by all three viewers.
+ *
+ * `findText` returns an ordered list of {@link FindMatch}. Every match carries
+ * its ordinal position (`matchIndex`, 0-based, document order — the same index
+ * `findNext` / `findPrev` cycle through), the matched `text`, and a
+ * format-specific `location`. The location is where the three formats
+ * legitimately differ — a docx match lives on a page, a pptx match on a slide,
+ * an xlsx match in a sheet cell — so `FindMatch` is generic over it rather than
+ * forcing an artificial common shape. Each viewer instantiates it with its own
+ * location type:
+ *
+ *   - `DocxViewer.findText` → `FindMatch<DocxMatchLocation>`  ({ page })
+ *   - `PptxViewer.findText` → `FindMatch<PptxMatchLocation>`  ({ slide })
+ *   - `XlsxViewer.findText` → `FindMatch<XlsxMatchLocation>`  ({ sheet, ref, … })
+ *
+ * The generic default is `unknown` so `FindMatch` can be referenced without a
+ * type argument (e.g. in generic UI code) while each viewer's return type stays
+ * precise.
+ */
+export interface FindMatch<Loc = unknown> {
+  /** 0-based ordinal among all matches, in document order. This is the index
+   *  `findNext`/`findPrev` make active, so a caller can correlate the array it
+   *  got from `findText` with the active-match reported by navigation. */
+  matchIndex: number;
+  /** The text that matched (the query as it appears in the document — its
+   *  original case, not the folded form used for case-insensitive matching). */
+  text: string;
+  /** Where the match is, in the format's own coordinates. */
+  location: Loc;
+}

--- a/packages/core/src/search/highlight-rect.test.ts
+++ b/packages/core/src/search/highlight-rect.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { sliceHorizontalExtent } from './highlight-rect.js';
+
+/**
+ * IX2 highlight geometry. `sliceHorizontalExtent` measures the two prefixes of a
+ * run to place the highlight box flush with the drawn glyphs. A monospace-style
+ * fake measurer (n chars → n×W px) makes the arithmetic checkable.
+ */
+const W = 7;
+const mono = (s: string) => s.length * W;
+
+describe('sliceHorizontalExtent', () => {
+  it('measures a mid-run slice from the two prefix widths', () => {
+    // "the quick" — slice [4,9) = "quick".
+    const { x, width } = sliceHorizontalExtent('the quick', 4, 9, mono);
+    expect(x).toBe(4 * W);
+    expect(width).toBe(5 * W);
+  });
+
+  it('places a leading slice at x=0', () => {
+    const { x, width } = sliceHorizontalExtent('Hello', 0, 3, mono);
+    expect(x).toBe(0);
+    expect(width).toBe(3 * W);
+  });
+
+  it('measures the whole run text for an end-anchored slice', () => {
+    const { x, width } = sliceHorizontalExtent('Hello', 2, 5, mono);
+    expect(x).toBe(2 * W);
+    expect(width).toBe(3 * W);
+  });
+
+  it('covers the entire run for a [0, len) slice', () => {
+    const { x, width } = sliceHorizontalExtent('Hello', 0, 5, mono);
+    expect(x).toBe(0);
+    expect(width).toBe(5 * W);
+  });
+
+  it('never returns a negative width', () => {
+    // Degenerate slice (start === end).
+    const { width } = sliceHorizontalExtent('Hello', 3, 3, mono);
+    expect(width).toBe(0);
+  });
+});

--- a/packages/core/src/search/highlight-rect.ts
+++ b/packages/core/src/search/highlight-rect.ts
@@ -1,0 +1,36 @@
+/**
+ * Turn a matched run-slice (from {@link findMatches}) into the horizontal extent
+ * of the highlight box within its run, using a caller-supplied text-measurer.
+ *
+ * A run's glyphs are laid left-to-right from the run's own origin. A slice
+ * `[start, end)` of the run text therefore starts at the advance width of
+ * `runText[0..start)` and ends at the advance width of `runText[0..end)`. The
+ * caller supplies `measure(s)` — a `CanvasRenderingContext2D.measureText(s).width`
+ * closure already primed with the run's font (`ctx.font = run.font`) — so this
+ * stays a pure arithmetic wrapper with no canvas/DOM dependency of its own and is
+ * shared by the docx and pptx highlight overlays (xlsx measures inside the cell
+ * rect the same way). The vertical extent (top / height) is the run's line box,
+ * owned by each renderer's overlay, so it is not computed here.
+ *
+ * Measuring the two prefixes (rather than measuring the slice text alone and
+ * summing) is deliberate: it accounts for kerning between the run's leading
+ * glyphs and keeps the highlight edges flush with where the canvas actually drew
+ * those characters, exactly as the selection overlay relies on `measureText`
+ * matching `fillText`.
+ *
+ * @param runText   the full text of the run the slice belongs to.
+ * @param start     slice start offset within `runText` (inclusive).
+ * @param end       slice end offset within `runText` (exclusive).
+ * @param measure   advance width in px of a substring, in the run's font.
+ * @returns `x` (left offset from the run origin, px) and `width` (px).
+ */
+export function sliceHorizontalExtent(
+  runText: string,
+  start: number,
+  end: number,
+  measure: (s: string) => number,
+): { x: number; width: number } {
+  const x = start <= 0 ? 0 : measure(runText.slice(0, start));
+  const endX = end >= runText.length ? measure(runText) : measure(runText.slice(0, end));
+  return { x, width: Math.max(0, endX - x) };
+}

--- a/packages/core/src/search/text-index.test.ts
+++ b/packages/core/src/search/text-index.test.ts
@@ -111,6 +111,49 @@ describe('findMatches — cross-run matches', () => {
   });
 });
 
+describe('findMatches — length-changing case folds must not shift offsets', () => {
+  // U+0130 (İ, LATIN CAPITAL LETTER I WITH DOT ABOVE) lowercases to "i" +
+  // U+0307 (combining dot above): 1 → 2 UTF-16 code units. A whole-string
+  // toLowerCase() therefore de-syncs `folded` offsets from `text` offsets and
+  // shifts every later match right by the length delta (reviewer repro:
+  // "İstanbul" + "bul" sliced "ul"). The fold must preserve length — such code
+  // points stay unfolded — so a match offset always indexes `text` correctly.
+  it('finds a match after İ at the correct text offset', () => {
+    const index = buildTextIndex(runs('İstanbul'));
+    expect(index.folded.length).toBe(index.text.length);
+    const m = findMatches(index, 'bul');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([{ runIndex: 0, start: 5, end: 8 }]);
+    // The slice must select the actual matched glyphs in the original text.
+    expect('İstanbul'.slice(m[0].slices[0].start, m[0].slices[0].end)).toBe('bul');
+  });
+
+  it('keeps offsets aligned across a run boundary after İ', () => {
+    const index = buildTextIndex(runs('İst', 'anbul'));
+    const m = findMatches(index, 'STAN');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([
+      { runIndex: 0, start: 1, end: 3 },
+      { runIndex: 1, start: 0, end: 2 },
+    ]);
+  });
+
+  it('matches İ by identity (query İ ↔ text İ, both kept unfolded)', () => {
+    const index = buildTextIndex(runs('İstanbul'));
+    const m = findMatches(index, 'İstan');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([{ runIndex: 0, start: 0, end: 5 }]);
+  });
+
+  it('ordinary folding still applies around the preserved code point', () => {
+    const index = buildTextIndex(runs('İSTANBUL and istanbul'));
+    // The İ variant's trailing letters and the plain-I word both fold normally.
+    const m = findMatches(index, 'stanbul');
+    expect(m).toHaveLength(2);
+    expect(m.map((x) => x.slices[0].start)).toEqual([1, 14]);
+  });
+});
+
 describe('findMatches — edge cases', () => {
   it('returns [] for an empty query', () => {
     const index = buildTextIndex(runs('anything'));

--- a/packages/core/src/search/text-index.test.ts
+++ b/packages/core/src/search/text-index.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { buildTextIndex, findMatches, type SearchRun } from './text-index.js';
+
+/**
+ * IX2 core search index. `buildTextIndex` joins an ordered run list; `findMatches`
+ * locates a query in the joined text and maps each hit back to the run-slices it
+ * covers so a viewer can highlight the right glyphs — including a match that
+ * straddles a run boundary (the sole subtle case). Case-insensitive by default.
+ */
+const runs = (...texts: string[]): SearchRun[] => texts.map((text) => ({ text }));
+
+describe('buildTextIndex', () => {
+  it('joins runs in order and records each run start offset', () => {
+    const index = buildTextIndex(runs('Hello ', 'World'));
+    expect(index.text).toBe('Hello World');
+    expect(index.folded).toBe('hello world');
+    expect(index.runStart).toEqual([0, 6]);
+    expect(index.runCount).toBe(2);
+  });
+
+  it('handles an empty run list', () => {
+    const index = buildTextIndex([]);
+    expect(index.text).toBe('');
+    expect(index.runCount).toBe(0);
+    expect(index.runStart).toEqual([]);
+  });
+});
+
+describe('findMatches — single-run matches', () => {
+  it('finds a substring wholly inside one run', () => {
+    const index = buildTextIndex(runs('the quick brown fox'));
+    const m = findMatches(index, 'quick');
+    expect(m).toHaveLength(1);
+    expect(m[0].matchIndex).toBe(0);
+    expect(m[0].slices).toEqual([{ runIndex: 0, start: 4, end: 9 }]);
+  });
+
+  it('returns non-overlapping matches in document order with ascending matchIndex', () => {
+    const index = buildTextIndex(runs('abababab'));
+    const m = findMatches(index, 'ab');
+    expect(m.map((x) => x.matchIndex)).toEqual([0, 1, 2, 3]);
+    expect(m.map((x) => x.slices[0].start)).toEqual([0, 2, 4, 6]);
+  });
+
+  it('advances past each match so overlapping occurrences are not double-counted', () => {
+    const index = buildTextIndex(runs('aaaa'));
+    const m = findMatches(index, 'aa');
+    // Browser find-in-page semantics: matches at 0 and 2 (not 0,1,2,3).
+    expect(m.map((x) => x.slices[0].start)).toEqual([0, 2]);
+  });
+});
+
+describe('findMatches — case sensitivity', () => {
+  it('is case-insensitive by default', () => {
+    const index = buildTextIndex(runs('Hello HELLO hello'));
+    const m = findMatches(index, 'hello');
+    expect(m).toHaveLength(3);
+  });
+
+  it('honors caseSensitive: true', () => {
+    const index = buildTextIndex(runs('Hello HELLO hello'));
+    const m = findMatches(index, 'hello', { caseSensitive: true });
+    expect(m).toHaveLength(1);
+    expect(m[0].slices[0].start).toBe(12);
+  });
+});
+
+describe('findMatches — cross-run matches', () => {
+  it('resolves a match split across two runs into two slices', () => {
+    // "Hello" split as "Hel" | "lo".
+    const index = buildTextIndex(runs('Hel', 'lo World'));
+    const m = findMatches(index, 'Hello');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([
+      { runIndex: 0, start: 0, end: 3 },
+      { runIndex: 1, start: 0, end: 2 },
+    ]);
+  });
+
+  it('resolves a match spanning three runs (whole middle run)', () => {
+    // "abcdef" as "ab" | "cd" | "ef".
+    const index = buildTextIndex(runs('ab', 'cd', 'ef'));
+    const m = findMatches(index, 'bcde');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([
+      { runIndex: 0, start: 1, end: 2 },
+      { runIndex: 1, start: 0, end: 2 },
+      { runIndex: 2, start: 0, end: 1 },
+    ]);
+  });
+
+  it('skips zero-length runs that fall inside a match range', () => {
+    // Empty run between two text runs must not produce an empty slice.
+    const index = buildTextIndex(runs('ab', '', 'cd'));
+    const m = findMatches(index, 'abcd');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([
+      { runIndex: 0, start: 0, end: 2 },
+      { runIndex: 2, start: 0, end: 2 },
+    ]);
+  });
+
+  it('matches case-insensitively across a run boundary', () => {
+    const index = buildTextIndex(runs('FIND', 'text'));
+    const m = findMatches(index, 'dt');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([
+      { runIndex: 0, start: 3, end: 4 },
+      { runIndex: 1, start: 0, end: 1 },
+    ]);
+  });
+});
+
+describe('findMatches — edge cases', () => {
+  it('returns [] for an empty query', () => {
+    const index = buildTextIndex(runs('anything'));
+    expect(findMatches(index, '')).toEqual([]);
+  });
+
+  it('returns [] when the query is absent', () => {
+    const index = buildTextIndex(runs('hello world'));
+    expect(findMatches(index, 'zzz')).toEqual([]);
+  });
+
+  it('returns [] over an empty document', () => {
+    const index = buildTextIndex([]);
+    expect(findMatches(index, 'x')).toEqual([]);
+  });
+
+  it('matches a query that equals the whole text', () => {
+    const index = buildTextIndex(runs('exact'));
+    const m = findMatches(index, 'exact');
+    expect(m).toHaveLength(1);
+    expect(m[0].slices).toEqual([{ runIndex: 0, start: 0, end: 5 }]);
+  });
+});

--- a/packages/core/src/search/text-index.ts
+++ b/packages/core/src/search/text-index.ts
@@ -22,7 +22,10 @@
  * (`caseSensitive: false`), matching a browser's Ctrl+F. Full-/half-width (zenkaku
  * ↔ hankaku) folding and diacritic-insensitive matching are intentionally NOT
  * done in this minimal pass — they are locale-sensitive and easy to get subtly
- * wrong; a later opt-in can add them without changing this contract.
+ * wrong; a later opt-in can add them without changing this contract. Case
+ * folding is length-preserving (see {@link foldPreservingLength}): the few code
+ * points whose lowercase changes UTF-16 length (e.g. U+0130 İ) match by
+ * identity only, so match offsets always index the original text.
  */
 
 /**
@@ -41,9 +44,12 @@ export interface SearchRun {
  * the character offset in `text` where run `i` begins, so a match position in
  * `text` can be resolved back to a (run, offset-within-run) pair by binary
  * search. `folded` is the case-folded form used for matching when the search is
- * case-insensitive (kept parallel to `text`, same length — folding is 1:1 for
- * the ASCII/Unicode simple case-fold we use, `String.prototype.toLowerCase`,
- * which never changes code-unit count for the scripts these documents contain).
+ * case-insensitive. INVARIANT: `folded.length === text.length` — guaranteed by
+ * {@link foldPreservingLength} — so a match offset found in `folded` indexes
+ * `text` directly. (A whole-string `toLowerCase()` does NOT hold this: e.g.
+ * U+0130 İ lowercases to "i" + U+0307 combining dot, 1 → 2 UTF-16 code units,
+ * which would shift every later match right by the delta and could even push a
+ * match range past `text.length`, hanging the slice walk.)
  */
 export interface TextIndex {
   /** The concatenated run texts, in run order. */
@@ -93,6 +99,39 @@ export interface FindMatchesOptions {
 }
 
 /**
+ * Case-fold `s` for case-insensitive matching WITHOUT changing its UTF-16
+ * length, so every offset in the folded string indexes the original directly.
+ *
+ * `String.prototype.toLowerCase` is not length-preserving: a handful of code
+ * points expand (U+0130 İ → "i" + U+0307, 1 → 2 code units; ligature-style
+ * upper-case mappings likewise). A whole-string lowercase therefore de-syncs
+ * folded offsets from text offsets and corrupts every match after the first
+ * such character. Instead we fold per code point and KEEP a code point
+ * unfolded whenever its lowercase form has a different code-unit length.
+ *
+ * Trade-off (documented contract): those rare code points only match by
+ * identity, not case-insensitively (a query "i̇" will not find "İ"). That is
+ * the correct side of the trade — a slightly narrower match set for a few
+ * exotic characters versus wrong-glyph highlights (or a hang) for every match
+ * that follows one.
+ *
+ * Fast path: when the whole-string lowercase already has the same length
+ * (true for effectively all real documents), use it as-is; the per-code-point
+ * walk only runs for strings containing a length-changing fold.
+ */
+function foldPreservingLength(s: string): string {
+  const whole = s.toLowerCase();
+  if (whole.length === s.length) return whole;
+  let out = '';
+  for (const ch of s) {
+    // `ch` is one code point (1 or 2 code units via the string iterator).
+    const lower = ch.toLowerCase();
+    out += lower.length === ch.length ? lower : ch;
+  }
+  return out;
+}
+
+/**
  * Build a reusable {@link TextIndex} from an ordered run list. O(total chars).
  * The index is independent of the query, so a viewer builds it once per rendered
  * page/slide/sheet and reuses it across `findText` / `findNext` calls until the
@@ -109,7 +148,9 @@ export function buildTextIndex(runs: readonly SearchRun[]): TextIndex {
   }
   return {
     text: joined,
-    folded: joined.toLowerCase(),
+    // Length-preserving fold: folded offsets must index `text` directly (see
+    // the TextIndex invariant).
+    folded: foldPreservingLength(joined),
     runStart,
     runCount: runs.length,
   };
@@ -145,7 +186,13 @@ function sliceRange(index: TextIndex, matchStart: number, matchEnd: number): Mat
   const slices: MatchRunSlice[] = [];
   let run = runAtOffset(index, matchStart);
   let cursor = matchStart;
-  while (cursor < matchEnd) {
+  // `run < runCount` is a termination guard, not a semantic bound: under the
+  // TextIndex invariant (folded.length === text.length) every match range lies
+  // within [0, text.length] and the walk always ends by cursor reaching
+  // matchEnd inside the last run. Without the guard, a range past text.length
+  // (as a length-CHANGING fold used to produce) would loop forever — cursor
+  // pins at text.length while run increments unboundedly.
+  while (cursor < matchEnd && run < runCount) {
     // End of the current run in joined-text coordinates.
     const runEndOffset = run + 1 < runCount ? runStart[run + 1] : text.length;
     const sliceEnd = Math.min(matchEnd, runEndOffset);
@@ -179,7 +226,10 @@ export function findMatches(
   if (query.length === 0) return [];
   const caseSensitive = opts.caseSensitive ?? false;
   const haystack = caseSensitive ? index.text : index.folded;
-  const needle = caseSensitive ? query : query.toLowerCase();
+  // The needle must be folded with the SAME length-preserving fold as the
+  // haystack: a plain toLowerCase() would expand e.g. "İ" to "i" + U+0307 and
+  // never match the haystack, where "İ" was deliberately kept unfolded.
+  const needle = caseSensitive ? query : foldPreservingLength(query);
 
   const matches: TextMatch[] = [];
   let from = 0;

--- a/packages/core/src/search/text-index.ts
+++ b/packages/core/src/search/text-index.ts
@@ -1,0 +1,196 @@
+/**
+ * Format-agnostic in-document text search (IX2 — findText).
+ *
+ * All three formats (docx / pptx / xlsx) already emit their rendered text as an
+ * ordered list of runs through `onTextRun` (the same stream IX1 turned into the
+ * hyperlink-aware selection overlay). A run is the atomic drawn text segment: a
+ * docx line-piece, a pptx shape run, an xlsx cell. Search is therefore the same
+ * problem in every format — concatenate the run texts, match a query against the
+ * joined string, and map each match back to the run(s) it fell on so the viewer
+ * can draw a highlight box over the right glyphs. That reverse mapping is the
+ * only subtle part (a query can straddle two runs — "Hello" split as "Hel"+"lo"),
+ * and it is pure string/index math with no DOM or geometry, so it lives here in
+ * `core` and is shared, not re-implemented per package.
+ *
+ * What stays out of core: turning a matched run-slice into a pixel rectangle
+ * needs the run's font + `measureText`, which is renderer/DOM territory and
+ * differs per format (docx flat spans, pptx shape-relative + rotation, xlsx cell
+ * rects). Each package owns that final step; core owns the index + the match →
+ * run-slice resolution.
+ *
+ * Normalization (IX2 default, integrator may veto): case-insensitive by default
+ * (`caseSensitive: false`), matching a browser's Ctrl+F. Full-/half-width (zenkaku
+ * ↔ hankaku) folding and diacritic-insensitive matching are intentionally NOT
+ * done in this minimal pass — they are locale-sensitive and easy to get subtly
+ * wrong; a later opt-in can add them without changing this contract.
+ */
+
+/**
+ * The minimal shape the index needs from a rendered run: just its text. Each
+ * package passes its own richer run info (which also carries geometry) — this is
+ * structurally satisfied by `DocxTextRunInfo`, `PptxTextRunInfo`,
+ * `XlsxTextRunInfo`, etc., so a caller hands its `runs[]` straight in.
+ */
+export interface SearchRun {
+  text: string;
+}
+
+/**
+ * A precomputed search index over an ordered run list. `text` is the runs joined
+ * in order (no separator — runs are adjacent drawn segments); `runStart[i]` is
+ * the character offset in `text` where run `i` begins, so a match position in
+ * `text` can be resolved back to a (run, offset-within-run) pair by binary
+ * search. `folded` is the case-folded form used for matching when the search is
+ * case-insensitive (kept parallel to `text`, same length — folding is 1:1 for
+ * the ASCII/Unicode simple case-fold we use, `String.prototype.toLowerCase`,
+ * which never changes code-unit count for the scripts these documents contain).
+ */
+export interface TextIndex {
+  /** The concatenated run texts, in run order. */
+  readonly text: string;
+  /** Lower-cased twin of {@link text}, for case-insensitive matching. */
+  readonly folded: string;
+  /** `runStart[i]` = offset in `text` where run `i` starts. Length = run count. */
+  readonly runStart: readonly number[];
+  /** The run count (so callers need not keep the original array alongside). */
+  readonly runCount: number;
+}
+
+/**
+ * The slice of one run a match covers: the run's index in the original `runs[]`
+ * and the `[start, end)` character range within that run's own `text`. A match
+ * that straddles N runs yields N of these (the first sliced from its start
+ * offset to the run end, the last from 0 to its end offset, any middle run
+ * whole). The viewer measures each slice against that run's font to get a pixel
+ * rectangle.
+ */
+export interface MatchRunSlice {
+  /** Index into the original `runs[]` handed to {@link buildTextIndex}. */
+  runIndex: number;
+  /** Start offset within `runs[runIndex].text` (inclusive). */
+  start: number;
+  /** End offset within `runs[runIndex].text` (exclusive). */
+  end: number;
+}
+
+/**
+ * One query match: its ordinal position among all matches (`matchIndex`, 0-based,
+ * in document order) and the run-slices it covers (`slices`, one per run the
+ * match touches, in run order). `slices` is never empty for a non-empty query.
+ */
+export interface TextMatch {
+  matchIndex: number;
+  slices: MatchRunSlice[];
+}
+
+/** Options for {@link findMatches}. */
+export interface FindMatchesOptions {
+  /**
+   * Match case exactly. Default `false` (case-insensitive, like a browser's
+   * find-in-page). IX2 default — an integrator can pass `true`.
+   */
+  caseSensitive?: boolean;
+}
+
+/**
+ * Build a reusable {@link TextIndex} from an ordered run list. O(total chars).
+ * The index is independent of the query, so a viewer builds it once per rendered
+ * page/slide/sheet and reuses it across `findText` / `findNext` calls until the
+ * rendered content changes.
+ */
+export function buildTextIndex(runs: readonly SearchRun[]): TextIndex {
+  const runStart: number[] = new Array(runs.length);
+  let acc = 0;
+  let joined = '';
+  for (let i = 0; i < runs.length; i++) {
+    runStart[i] = acc;
+    joined += runs[i].text;
+    acc += runs[i].text.length;
+  }
+  return {
+    text: joined,
+    folded: joined.toLowerCase(),
+    runStart,
+    runCount: runs.length,
+  };
+}
+
+/**
+ * Resolve a character offset in {@link TextIndex.text} to the index of the run
+ * that contains it, by binary search over `runStart`. Returns the run whose
+ * `[runStart[i], runStart[i+1])` half-open range contains `pos`. `pos` is assumed
+ * in `[0, text.length)`.
+ */
+function runAtOffset(index: TextIndex, pos: number): number {
+  const { runStart } = index;
+  let lo = 0;
+  let hi = runStart.length - 1;
+  // Invariant: runStart[lo] <= pos. Find the greatest i with runStart[i] <= pos.
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (runStart[mid] <= pos) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+/**
+ * Split a `[matchStart, matchEnd)` character range in the joined text into the
+ * per-run slices it covers. Empty runs (zero-length text) inside the range are
+ * skipped — they contribute no glyphs to highlight. The range is assumed
+ * non-empty and within `[0, text.length]`.
+ */
+function sliceRange(index: TextIndex, matchStart: number, matchEnd: number): MatchRunSlice[] {
+  const { runStart, runCount, text } = index;
+  const slices: MatchRunSlice[] = [];
+  let run = runAtOffset(index, matchStart);
+  let cursor = matchStart;
+  while (cursor < matchEnd) {
+    // End of the current run in joined-text coordinates.
+    const runEndOffset = run + 1 < runCount ? runStart[run + 1] : text.length;
+    const sliceEnd = Math.min(matchEnd, runEndOffset);
+    const localStart = cursor - runStart[run];
+    const localEnd = sliceEnd - runStart[run];
+    if (localEnd > localStart) {
+      slices.push({ runIndex: run, start: localStart, end: localEnd });
+    }
+    cursor = sliceEnd;
+    run++;
+  }
+  return slices;
+}
+
+/**
+ * Find every occurrence of `query` in the indexed text and return each as a
+ * {@link TextMatch} carrying the run-slices it covers. Matches are
+ * non-overlapping and returned in document order; scanning resumes just past each
+ * match (so `"aa"` in `"aaaa"` yields two matches at 0 and 2, matching a
+ * browser's find-in-page). An empty (or whitespace-trimmed-to-empty is NOT
+ * applied — only truly empty) query returns `[]`.
+ *
+ * Pure: no DOM, no geometry. The viewer turns `slices` into pixel rectangles
+ * using each run's font.
+ */
+export function findMatches(
+  index: TextIndex,
+  query: string,
+  opts: FindMatchesOptions = {},
+): TextMatch[] {
+  if (query.length === 0) return [];
+  const caseSensitive = opts.caseSensitive ?? false;
+  const haystack = caseSensitive ? index.text : index.folded;
+  const needle = caseSensitive ? query : query.toLowerCase();
+
+  const matches: TextMatch[] = [];
+  let from = 0;
+  let matchIndex = 0;
+  for (;;) {
+    const at = haystack.indexOf(needle, from);
+    if (at === -1) break;
+    matches.push({ matchIndex, slices: sliceRange(index, at, at + needle.length) });
+    matchIndex++;
+    // Advance past this match so occurrences never overlap.
+    from = at + needle.length;
+  }
+  return matches;
+}

--- a/packages/docx/src/find-highlight-layer.test.ts
+++ b/packages/docx/src/find-highlight-layer.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  buildDocxHighlightLayer,
+  DEFAULT_FIND_HIGHLIGHT,
+  DEFAULT_FIND_ACTIVE_HIGHLIGHT,
+  type DocxHighlightMatch,
+} from './find-highlight-layer.js';
+import type { DocxTextRunInfo } from './renderer';
+
+/**
+ * IX2 docx highlight overlay. Same node-env fake-DOM stub as the text-layer
+ * tests (no jsdom in this workspace). buildDocxHighlightLayer draws one absolute
+ * box per matched run-slice, positioned from the run's x/y/h plus the slice's
+ * measured horizontal extent, with the active match in the emphasis colour.
+ */
+interface FakeEl {
+  tag: string;
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  appendChild(c: FakeEl): void;
+}
+
+function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    innerHTML: '',
+    children: [],
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const idx = decl.indexOf(':');
+            if (idx > 0) target[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+  };
+  return el;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+function run(partial: Partial<DocxTextRunInfo>): DocxTextRunInfo {
+  return { text: 'X', x: 0, y: 0, w: 10, h: 12, fontSize: 12, font: '12px serif', ...partial };
+}
+
+// Monospace measurer: each char is 7px wide.
+const W = 7;
+const measureForFont = () => (s: string) => s.length * W;
+
+describe('buildDocxHighlightLayer', () => {
+  it('draws one box per slice, positioned from run x/y + measured extent', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'the quick', x: 100, y: 50, h: 16 })];
+    // Match "quick" = slice [4, 9).
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 4, end: 9 }], active: false },
+    ];
+    buildDocxHighlightLayer(
+      layer as unknown as HTMLDivElement,
+      runs,
+      matches,
+      '700px',
+      '900px',
+      measureForFont,
+    );
+    expect(layer.children).toHaveLength(1);
+    const box = layer.children[0];
+    // left = run.x (100) + prefix "the " width (4*7=28) = 128.
+    expect(box.style.left).toBe('128px');
+    expect(box.style.top).toBe('50px');
+    // width = "quick" (5*7=35).
+    expect(box.style.width).toBe('35px');
+    expect(box.style.height).toBe('16px');
+    expect(box.style.background).toBe(DEFAULT_FIND_HIGHLIGHT);
+    expect(box.style['pointer-events']).toBe('none');
+  });
+
+  it('uses the active colour for the active match', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'abc' })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 3 }], active: true },
+    ];
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    expect(layer.children[0].style.background).toBe(DEFAULT_FIND_ACTIVE_HIGHLIGHT);
+  });
+
+  it('draws a box per run for a cross-run match', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'Hel', x: 0 }), run({ text: 'lo', x: 21 })];
+    const matches: DocxHighlightMatch[] = [
+      {
+        slices: [
+          { runIndex: 0, start: 0, end: 3 },
+          { runIndex: 1, start: 0, end: 2 },
+        ],
+        active: false,
+      },
+    ];
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    expect(layer.children).toHaveLength(2);
+    expect(layer.children[0].style.left).toBe('0px'); // run 0 origin
+    expect(layer.children[1].style.left).toBe('21px'); // run 1 origin
+  });
+
+  it('carries the run transform for a vertical (tbRl) page', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'abc', transform: 'rotate(90deg)' })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 3 }], active: false },
+    ];
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    expect(layer.children[0].style.transform).toBe('rotate(90deg)');
+  });
+
+  it('clears the layer and skips zero-width slices', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    layer.innerHTML = 'stale';
+    const runs = [run({ text: 'abc' })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 1, end: 1 }], active: false }, // degenerate
+    ];
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    expect(layer.innerHTML).toBe('');
+    expect(layer.children).toHaveLength(0);
+  });
+});

--- a/packages/docx/src/find-highlight-layer.ts
+++ b/packages/docx/src/find-highlight-layer.ts
@@ -1,0 +1,100 @@
+/**
+ * IX2 docx find-highlight overlay.
+ *
+ * The mirror image of {@link buildDocxTextLayer}: instead of a transparent
+ * selection span per run, it draws a visible highlight box per matched
+ * run-slice, positioned with the SAME per-run geometry (`DocxTextRunInfo.x/y/h`
+ * + the run's `transform` for vertical pages) so a box lands exactly on the
+ * drawn glyphs. This rides the existing DOM-overlay mechanism (a positioned
+ * layer over the canvas) rather than adding a canvas draw pass — the same
+ * approach the selection / hyperlink overlay uses, so highlights compose with
+ * them and survive re-render the same way.
+ *
+ * The horizontal extent of a slice (its x offset + width within the run) is the
+ * shared core `sliceHorizontalExtent`, measured against the run's font via a
+ * caller-supplied `measure` primed with `ctx.font = run.font` — the same
+ * measureText↔fillText correspondence the selection overlay relies on. The
+ * vertical extent is the run's line box (`y` … `y + h`), owned here.
+ *
+ * The active match (the one `findNext`/`findPrev` last landed on) is drawn in a
+ * distinct emphasis colour so the user can tell it apart from the other hits,
+ * matching a browser find bar's current-vs-other highlighting.
+ */
+import { sliceHorizontalExtent, type MatchRunSlice } from '@silurus/ooxml-core';
+import type { DocxTextRunInfo } from './renderer';
+
+/** One page's highlight input: the run-slices a match covers, and whether that
+ *  match is the active one (emphasis colour). */
+export interface DocxHighlightMatch {
+  slices: MatchRunSlice[];
+  active: boolean;
+}
+
+/** Default highlight colours (browser find-bar palette): a soft yellow for
+ *  every match and a stronger orange for the active one. Both translucent so the
+ *  drawn glyphs beneath stay legible. */
+export const DEFAULT_FIND_HIGHLIGHT = 'rgba(255, 214, 0, 0.42)';
+export const DEFAULT_FIND_ACTIVE_HIGHLIGHT = 'rgba(255, 140, 0, 0.55)';
+
+export interface DocxHighlightColors {
+  /** Fill for non-active matches. */
+  match?: string;
+  /** Fill for the active match. */
+  active?: string;
+}
+
+/**
+ * Populate a highlight overlay layer with one box per matched run-slice.
+ *
+ * @param layer    the overlay div (cleared and re-sized to the canvas here).
+ * @param runs     the page's runs (same array the page was rendered/text-layered from).
+ * @param matches  the page's matches (run-slices + active flag).
+ * @param canvasCssWidth  the rendered canvas's CSS width (e.g. `"700px"`).
+ * @param canvasCssHeight the rendered canvas's CSS height.
+ * @param measureForFont  returns a width-measurer primed with a run's `font`
+ *                        (the viewer closes over a canvas 2d context). Kept as a
+ *                        factory so the font is set once per run, not per glyph.
+ * @param colors   optional colour overrides.
+ */
+export function buildDocxHighlightLayer(
+  layer: HTMLDivElement,
+  runs: DocxTextRunInfo[],
+  matches: DocxHighlightMatch[],
+  canvasCssWidth: string,
+  canvasCssHeight: string,
+  measureForFont: (font: string) => (s: string) => number,
+  colors: DocxHighlightColors = {},
+): void {
+  layer.innerHTML = '';
+  layer.style.width = canvasCssWidth;
+  layer.style.height = canvasCssHeight;
+
+  const matchColor = colors.match ?? DEFAULT_FIND_HIGHLIGHT;
+  const activeColor = colors.active ?? DEFAULT_FIND_ACTIVE_HIGHLIGHT;
+
+  for (const match of matches) {
+    const fill = match.active ? activeColor : matchColor;
+    for (const slice of match.slices) {
+      const run = runs[slice.runIndex];
+      if (!run) continue;
+      const measure = measureForFont(run.font);
+      const { x, width } = sliceHorizontalExtent(run.text, slice.start, slice.end, measure);
+      if (width <= 0) continue;
+      const box = document.createElement('div');
+      // A vertical (tbRl) page reports the run at its physical top-left and
+      // carries a rotate transform; apply the same transform (about the box's
+      // top-left) so the highlight lies along the rotated glyph run, exactly as
+      // the selection span does.
+      const transform = run.transform
+        ? `transform:${run.transform};transform-origin:top left;`
+        : '';
+      box.style.cssText =
+        `position:absolute;` +
+        `left:${run.x + x}px;top:${run.y}px;` +
+        `width:${width}px;height:${run.h}px;` +
+        transform +
+        `background:${fill};pointer-events:none;`;
+      layer.appendChild(box);
+    }
+  }
+}

--- a/packages/docx/src/find.test.ts
+++ b/packages/docx/src/find.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { DocxFindController } from './find.js';
+import type { DocxTextRunInfo } from './renderer';
+
+/**
+ * IX2 docx find controller. Exercised with stubbed per-page runs (no real
+ * render): the controller must join a page's runs, match the query across run
+ * boundaries, aggregate matches in document order tagged with `{ page }`, and
+ * cycle the active match with wrap-around across pages.
+ */
+function run(text: string): DocxTextRunInfo {
+  return { text, x: 0, y: 0, w: text.length, h: 10, fontSize: 10, font: '10px monospace' };
+}
+
+/** Build a controller over fixed per-page run lists. */
+function controllerFor(pages: DocxTextRunInfo[][]): DocxFindController {
+  return new DocxFindController(
+    () => pages.length,
+    (page) => Promise.resolve(pages[page] ?? []),
+  );
+}
+
+describe('DocxFindController.find', () => {
+  it('finds matches across pages and tags each with its page', async () => {
+    const c = controllerFor([
+      [run('hello world')],
+      [run('the world is round')],
+    ]);
+    const matches = await c.find('world');
+    expect(matches).toHaveLength(2);
+    expect(matches[0].location.page).toBe(0);
+    expect(matches[1].location.page).toBe(1);
+    expect(matches.map((m) => m.matchIndex)).toEqual([0, 1]);
+  });
+
+  it('resolves a match that straddles two runs on one page', async () => {
+    const c = controllerFor([[run('Hel'), run('lo World')]]);
+    const matches = await c.find('Hello');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].location.page).toBe(0);
+    // The reported text carries the document's original case.
+    expect(matches[0].text).toBe('Hello');
+  });
+
+  it('is case-insensitive by default and reports original-case text', async () => {
+    const c = controllerFor([[run('The FOO and foo')]]);
+    const matches = await c.find('foo');
+    expect(matches).toHaveLength(2);
+    expect(matches.map((m) => m.text)).toEqual(['FOO', 'foo']);
+  });
+
+  it('honors caseSensitive: true', async () => {
+    const c = controllerFor([[run('FOO foo')]]);
+    const matches = await c.find('foo', { caseSensitive: true });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('foo');
+  });
+
+  it('returns [] for an empty query and clears state', async () => {
+    const c = controllerFor([[run('anything')]]);
+    await c.find('any');
+    const cleared = await c.find('');
+    expect(cleared).toEqual([]);
+  });
+});
+
+describe('DocxFindController active-match cursor', () => {
+  it('next() lands on the first match, then advances with wrap-around', async () => {
+    const c = controllerFor([[run('a a a')]]); // three 'a' matches
+    await c.find('a');
+    expect(c.next()?.matchIndex).toBe(0);
+    expect(c.next()?.matchIndex).toBe(1);
+    expect(c.next()?.matchIndex).toBe(2);
+    expect(c.next()?.matchIndex).toBe(0); // wrap
+  });
+
+  it('prev() from no-active lands on the last match', async () => {
+    const c = controllerFor([[run('a a')]]);
+    await c.find('a');
+    expect(c.prev()?.matchIndex).toBe(1);
+  });
+
+  it('activePage() tracks the active match across pages', async () => {
+    const c = controllerFor([[run('x')], [run('x')]]);
+    await c.find('x');
+    c.next();
+    expect(c.activePage()).toBe(0);
+    c.next();
+    expect(c.activePage()).toBe(1);
+  });
+
+  it('next()/prev() return null when there are no matches', async () => {
+    const c = controllerFor([[run('abc')]]);
+    await c.find('zzz');
+    expect(c.next()).toBeNull();
+    expect(c.prev()).toBeNull();
+    expect(c.activePage()).toBeNull();
+  });
+});
+
+describe('DocxFindController.pageHighlights', () => {
+  it('returns per-page slices and marks the active match', async () => {
+    const c = controllerFor([[run('a a')]]);
+    await c.find('a');
+    c.next(); // active = match 0
+    const hl = c.pageHighlights(0);
+    expect(hl).toHaveLength(2);
+    expect(hl[0].active).toBe(true);
+    expect(hl[1].active).toBe(false);
+    // Each highlight carries the run-slice(s) it covers.
+    expect(hl[0].slices[0]).toMatchObject({ runIndex: 0, start: 0, end: 1 });
+  });
+
+  it('scopes highlights to the requested page', async () => {
+    const c = controllerFor([[run('a')], [run('a')]]);
+    await c.find('a');
+    expect(c.pageHighlights(0)).toHaveLength(1);
+    expect(c.pageHighlights(1)).toHaveLength(1);
+    expect(c.pageHighlights(2)).toHaveLength(0);
+  });
+});
+
+describe('DocxFindController.invalidate', () => {
+  it('drops matches and cached runs', async () => {
+    const c = controllerFor([[run('a')]]);
+    await c.find('a');
+    c.invalidate();
+    expect(c.matches()).toHaveLength(0);
+    expect(c.pageHighlights(0)).toHaveLength(0);
+    expect(c.activePage()).toBeNull();
+  });
+});

--- a/packages/docx/src/find.ts
+++ b/packages/docx/src/find.ts
@@ -51,8 +51,6 @@ export class DocxFindController {
   private _matches: DocxResolvedMatch[] = [];
   /** Active-match index into {@link _matches}, or -1 for none. */
   private _active = -1;
-  /** The current query (empty = no active find). */
-  private _query = '';
 
   constructor(
     private readonly _pageCount: () => number,
@@ -64,7 +62,6 @@ export class DocxFindController {
     this._pageRuns.clear();
     this._matches = [];
     this._active = -1;
-    this._query = '';
   }
 
   /** The runs for a page, if it has been scanned (used by the highlight overlay
@@ -113,7 +110,6 @@ export class DocxFindController {
   /** Run a fresh query across every page, resetting the cursor. Returns the
    *  public match list. An empty query clears matches. */
   async find(query: string, opts: FindMatchesOptions = {}): Promise<FindMatch<DocxMatchLocation>[]> {
-    this._query = query;
     this._matches = [];
     this._active = -1;
     if (query.length === 0) return [];

--- a/packages/docx/src/find.ts
+++ b/packages/docx/src/find.ts
@@ -1,0 +1,166 @@
+/**
+ * IX2 docx find-in-document controller.
+ *
+ * Owns the search state for a {@link DocxViewer}: the per-page run lists (the
+ * same `onTextRun` stream the selection / hyperlink overlay consumes), the
+ * matches for the current query, and the active-match cursor `findNext` /
+ * `findPrev` walk. All the string/index math is core (`buildTextIndex`,
+ * `findMatches`, `nextActive`/`prevActive`); this class just threads a docx run
+ * list per page through it and maps each hit to a `{ page }` location.
+ *
+ * The viewer supplies `collectPageRuns(page)` — render page `page` (to an
+ * offscreen canvas, without disturbing the visible one) and return its
+ * `DocxTextRunInfo[]`. The controller calls it once per page on `find()` and
+ * caches the result until `invalidate()` (a reload / width change). The active
+ * page's cached runs are what the viewer's highlight overlay is drawn from, so
+ * the geometry the highlight boxes use is exactly the geometry the page was
+ * drawn with.
+ */
+import {
+  buildTextIndex,
+  findMatches,
+  nextActive,
+  prevActive,
+  type FindMatch,
+  type FindMatchesOptions,
+  type TextMatch,
+} from '@silurus/ooxml-core';
+import type { DocxTextRunInfo } from './renderer';
+
+/** Where a docx match lives: its 0-based page index. */
+export interface DocxMatchLocation {
+  page: number;
+}
+
+/** One resolved docx match: a page-located {@link FindMatch} plus the run-slices
+ *  (in that page's run list) it covers, kept internally so the highlight overlay
+ *  can turn them into pixel boxes. */
+interface DocxResolvedMatch {
+  /** 0-based page the match is on. */
+  page: number;
+  /** The matched text. */
+  text: string;
+  /** Run-slices within `pageRuns[page]`, from core `findMatches`. */
+  slices: TextMatch['slices'];
+}
+
+export class DocxFindController {
+  /** page index → that page's runs (from a render), or undefined = not scanned. */
+  private _pageRuns = new Map<number, DocxTextRunInfo[]>();
+  /** All matches for the current query, in document order (page asc, then within-page). */
+  private _matches: DocxResolvedMatch[] = [];
+  /** Active-match index into {@link _matches}, or -1 for none. */
+  private _active = -1;
+  /** The current query (empty = no active find). */
+  private _query = '';
+
+  constructor(
+    private readonly _pageCount: () => number,
+    private readonly _collectPageRuns: (page: number) => Promise<DocxTextRunInfo[]>,
+  ) {}
+
+  /** Drop all cached runs + matches (call on reload / render-width change). */
+  invalidate(): void {
+    this._pageRuns.clear();
+    this._matches = [];
+    this._active = -1;
+    this._query = '';
+  }
+
+  /** The runs for a page, if it has been scanned (used by the highlight overlay
+   *  for the currently displayed page). */
+  pageRuns(page: number): DocxTextRunInfo[] | undefined {
+    return this._pageRuns.get(page);
+  }
+
+  /** Cache a page's runs captured from the visible render, so find() reuses
+   *  them instead of re-rendering that page offscreen. */
+  setPageRuns(page: number, runs: DocxTextRunInfo[]): void {
+    this._pageRuns.set(page, runs);
+  }
+
+  /** The resolved match at the given global index (for the highlight overlay). */
+  private _matchAt(index: number): DocxResolvedMatch | undefined {
+    return this._matches[index];
+  }
+
+  /** All match slices that fall on a given page, tagged with whether each is the
+   *  active match — the exact input the highlight overlay needs. */
+  pageHighlights(page: number): { slices: TextMatch['slices']; active: boolean }[] {
+    const out: { slices: TextMatch['slices']; active: boolean }[] = [];
+    for (let i = 0; i < this._matches.length; i++) {
+      const m = this._matches[i];
+      if (m.page === page) out.push({ slices: m.slices, active: i === this._active });
+    }
+    return out;
+  }
+
+  /** The active match's page, or null when there is no active match. */
+  activePage(): number | null {
+    const m = this._matchAt(this._active);
+    return m ? m.page : null;
+  }
+
+  /** The public match list for the current query. */
+  matches(): FindMatch<DocxMatchLocation>[] {
+    return this._matches.map((m, i) => ({
+      matchIndex: i,
+      text: m.text,
+      location: { page: m.page },
+    }));
+  }
+
+  /** Run a fresh query across every page, resetting the cursor. Returns the
+   *  public match list. An empty query clears matches. */
+  async find(query: string, opts: FindMatchesOptions = {}): Promise<FindMatch<DocxMatchLocation>[]> {
+    this._query = query;
+    this._matches = [];
+    this._active = -1;
+    if (query.length === 0) return [];
+
+    const pages = this._pageCount();
+    for (let page = 0; page < pages; page++) {
+      const runs = await this._ensurePageRuns(page);
+      const index = buildTextIndex(runs);
+      for (const tm of findMatches(index, query, opts)) {
+        // The matched text as it appears in the document: read it back from the
+        // run slices so it carries the document's original case (not the folded
+        // query). Slices are in run order, so concatenating their run text
+        // reconstructs the match.
+        const text = tm.slices
+          .map((s) => runs[s.runIndex].text.slice(s.start, s.end))
+          .join('');
+        this._matches.push({ page, text, slices: tm.slices });
+      }
+    }
+    return this.matches();
+  }
+
+  /** Advance the active match (wrap-around) and return its public form, or null
+   *  when there are no matches. */
+  next(): FindMatch<DocxMatchLocation> | null {
+    this._active = nextActive(this._active, this._matches.length);
+    return this._activePublic();
+  }
+
+  /** Step the active match back (wrap-around). */
+  prev(): FindMatch<DocxMatchLocation> | null {
+    this._active = prevActive(this._active, this._matches.length);
+    return this._activePublic();
+  }
+
+  private _activePublic(): FindMatch<DocxMatchLocation> | null {
+    const m = this._matchAt(this._active);
+    if (!m) return null;
+    return { matchIndex: this._active, text: m.text, location: { page: m.page } };
+  }
+
+  /** Get (scanning + caching if needed) the runs for a page. */
+  private async _ensurePageRuns(page: number): Promise<DocxTextRunInfo[]> {
+    const cached = this._pageRuns.get(page);
+    if (cached) return cached;
+    const runs = await this._collectPageRuns(page);
+    this._pageRuns.set(page, runs);
+    return runs;
+  }
+}

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -3,6 +3,15 @@ export type { WireRenderPageOptions } from './worker-protocol';
 export { DocxViewer, type DocxViewerOptions } from './viewer';
 export { DocxScrollViewer, type DocxScrollViewerOptions } from './scroll-viewer';
 export { buildDocxTextLayer } from './text-layer';
+// IX2 find-in-document: the highlight overlay builder + the docx match-location
+// shape. `FindMatch` / `FindMatchesOptions` come from core (shared across formats).
+export {
+  buildDocxHighlightLayer,
+  type DocxHighlightMatch,
+  type DocxHighlightColors,
+} from './find-highlight-layer';
+export type { DocxMatchLocation } from './find';
+export type { FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 // IX1 — the shared hyperlink target shape surfaced by `DocxViewerOptions.
 // onHyperlinkClick`, `DocxTextRunInfo.hyperlink`, and the 5th arg of

--- a/packages/docx/src/viewer-find-destroy.test.ts
+++ b/packages/docx/src/viewer-find-destroy.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxViewer } from './viewer.js';
+import { installDom, makeEl, FakeDocxEngine } from './scroll-viewer-test-dom.js';
+import type { DocxDocument } from './document';
+import type { DocxTextRunInfo } from './renderer';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * IX2 — destroy() must drop the find state. Without `_find.invalidate()` in
+ * destroy(), a findNext()/findPrev() call on a torn-down viewer replays the
+ * stale match list (returning matches into a dead viewer); the contract is
+ * `null`, exactly as if no find were active.
+ */
+function run(text: string): DocxTextRunInfo {
+  return { text, x: 0, y: 0, w: 10, h: 12, fontSize: 12, font: '12px serif' };
+}
+
+/** installDom + a document whose <canvas> els carry a measuring 2d context
+ *  (the highlight layer measures slice extents via the viewer's private
+ *  measure canvas; the shared fake returns a no-op {} for 2d). */
+function installFindDom(): void {
+  installDom();
+  vi.stubGlobal('document', {
+    createElement: (t: string) => {
+      const el = makeEl(t);
+      if (t === 'canvas') {
+        el.getContext = (kind: string) =>
+          kind === '2d'
+            ? { font: '', measureText: (s: string) => ({ width: s.length * 7 }) }
+            : {};
+      }
+      return el;
+    },
+  });
+}
+
+describe('DocxViewer.destroy() — find state invalidation', () => {
+  it('findNext()/findPrev() return null after destroy() (no stale matches)', async () => {
+    installFindDom();
+    const parent = makeEl('div');
+    const canvas = makeEl('canvas');
+    parent.appendChild(canvas);
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement);
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }]);
+    engine.feedTextRuns = [run('hello world')];
+    (v as unknown as { _doc: DocxDocument })._doc = engine.asDoc();
+
+    // A live find with a real active match…
+    const matches = await v.findText('hello');
+    expect(matches).toHaveLength(1);
+    const active = await v.findNext();
+    expect(active).not.toBeNull();
+    expect(active?.matchIndex).toBe(0);
+
+    // …must not survive teardown.
+    v.destroy();
+    expect(await v.findNext()).toBeNull();
+    expect(await v.findPrev()).toBeNull();
+  });
+});

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -319,6 +319,10 @@ export class DocxViewer {
     this._loadGen++;
     this._doc?.destroy();
     this._doc = null;
+    // IX2 — drop the find state (matches + cached runs) so a stale
+    // findNext()/findPrev() after teardown returns null instead of a match
+    // pointing into a dead viewer.
+    this._find.invalidate();
     // Return the caller-owned canvas to its original DOM slot before discarding
     // the wrapper. insertBefore still works if the original parent was itself
     // detached; when there was no original parent the canvas is left detached

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -3,8 +3,10 @@ import type { LoadOptions } from './document';
 import type { RenderPageOptions } from './types';
 import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
+import { buildDocxHighlightLayer, type DocxHighlightMatch } from './find-highlight-layer';
+import { DocxFindController, type DocxMatchLocation } from './find';
 import { openExternalHyperlink } from '@silurus/ooxml-core';
-import type { HyperlinkTarget } from '@silurus/ooxml-core';
+import type { HyperlinkTarget, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 
 export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   container?: HTMLElement;
@@ -39,6 +41,17 @@ export class DocxViewer {
    *  (empty string if it was unset), restored on {@link destroy}. */
   private _originalDisplay = '';
   private _textLayer: HTMLDivElement | null = null;
+  /** IX2 — the find-highlight overlay layer. Always created (independent of
+   *  `enableTextSelection`): highlights ride the same positioned-DOM overlay
+   *  mechanism as the selection layer but are visible boxes, not transparent
+   *  spans. Sits above the text layer so a highlight shows over a link's hit
+   *  region without stealing its clicks (`pointer-events:none`). */
+  private _highlightLayer: HTMLDivElement | null = null;
+  /** IX2 — find state (per-page runs, matches, active cursor). */
+  private _find: DocxFindController;
+  /** A 2d context used only to measure text for highlight geometry (its own
+   *  1×1 offscreen canvas, so measuring never touches the visible canvas). */
+  private _measureCtx: CanvasRenderingContext2D | null = null;
   private _opts: DocxViewerOptions;
   private readonly _mode: 'main' | 'worker';
   /** The canvas's bitmaprenderer context, used only in worker mode (a canvas
@@ -46,6 +59,8 @@ export class DocxViewer {
    *  never used on the same canvas). */
   private _bitmapCtx: ImageBitmapRenderingContext | null = null;
   private _warnedNoTextSelection = false;
+  /** One-shot guard so the worker-mode findText warning prints once. */
+  private _warnedNoFind = false;
   /** Set by {@link destroy} (first line). Guards {@link _reportRenderError} so a
    *  render rejection that lands AFTER teardown is swallowed rather than surfaced
    *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
@@ -107,6 +122,21 @@ export class DocxViewer {
         'overflow:hidden;pointer-events:none;user-select:text;-webkit-user-select:text;';
       this._wrapper.appendChild(this._textLayer);
     }
+
+    // IX2 — the find-highlight overlay layer. Appended last so it stacks above
+    // the text/selection layer; `pointer-events:none` keeps selection + link
+    // clicks working through it. In worker mode `onTextRun` can't fire, so it
+    // stays empty (find is main-mode only, warned at find() time).
+    this._highlightLayer = document.createElement('div');
+    this._highlightLayer.style.cssText =
+      'position:absolute;top:0;left:0;width:100%;height:100%;' +
+      'overflow:hidden;pointer-events:none;';
+    this._wrapper.appendChild(this._highlightLayer);
+
+    this._find = new DocxFindController(
+      () => this.pageCount,
+      (page) => this._collectPageRuns(page),
+    );
   }
 
   /**
@@ -152,6 +182,8 @@ export class DocxViewer {
       this._doc = doc;
       previous?.destroy();
       this._currentPage = 0;
+      // A new document invalidates any prior find state (cached runs / matches).
+      this._find.invalidate();
       await this._render();
     } catch (err) {
       // Superseded loads own no error reporting — the winning load (or destroy())
@@ -188,6 +220,86 @@ export class DocxViewer {
 
   async nextPage(): Promise<void> { await this.goToPage(this._currentPage + 1); }
   async prevPage(): Promise<void> { await this.goToPage(this._currentPage - 1); }
+
+  /**
+   * IX2 — find every occurrence of `query` in the document and highlight them
+   * all (a soft box per match, drawn on the highlight overlay over the drawn
+   * glyphs). Returns every match in document order, each tagged with its
+   * `{ page }` (0-based). Case-insensitive by default (browser find-in-page);
+   * pass `{ caseSensitive: true }` to match case exactly.
+   *
+   * Scans all pages, so a large document renders each page once offscreen to
+   * read its text (the visible page reuses its on-screen render). Not available
+   * in `mode: 'worker'` (the `onTextRun` stream can't cross the worker boundary)
+   * — returns `[]` there after a one-time warning. An empty query clears the
+   * find and returns `[]`.
+   */
+  async findText(
+    query: string,
+    opts: FindMatchesOptions = {},
+  ): Promise<FindMatch<DocxMatchLocation>[]> {
+    if (!this._doc) return [];
+    if (this._mode === 'worker') {
+      if (!this._warnedNoFind) {
+        this._warnedNoFind = true;
+        console.warn(
+          "[ooxml] findText is unavailable in mode: 'worker' (text runs can't cross the worker boundary). Use mode: 'main'.",
+        );
+      }
+      return [];
+    }
+    const matches = await this._find.find(query, opts);
+    // Redraw the current page's highlights (matches on it become visible without
+    // navigating). Cheap DOM geometry — no page re-render.
+    this._redrawHighlights();
+    return matches;
+  }
+
+  /**
+   * IX2 — move to the next match (wrap-around from last to first), navigating to
+   * its page if needed, and draw it in the distinct active-match colour. Returns
+   * the now-active match, or `null` when there are no matches. Call
+   * {@link findText} first.
+   */
+  async findNext(): Promise<FindMatch<DocxMatchLocation> | null> {
+    return this._activateMatch(this._find.next());
+  }
+
+  /** IX2 — move to the previous match (wrap-around from first to last). */
+  async findPrev(): Promise<FindMatch<DocxMatchLocation> | null> {
+    return this._activateMatch(this._find.prev());
+  }
+
+  /** IX2 — clear all highlights and reset the find state. */
+  clearFind(): void {
+    this._find.invalidate();
+    this._redrawHighlights();
+  }
+
+  /** Navigate to the active match's page (if not already there) and redraw the
+   *  highlights so the active box shows in the emphasis colour. */
+  private async _activateMatch(
+    match: FindMatch<DocxMatchLocation> | null,
+  ): Promise<FindMatch<DocxMatchLocation> | null> {
+    if (!match) {
+      this._redrawHighlights();
+      return null;
+    }
+    if (match.location.page !== this._currentPage) {
+      // goToPage re-renders, which rebuilds the highlight layer for the new page.
+      await this.goToPage(match.location.page);
+    } else {
+      this._redrawHighlights();
+    }
+    return match;
+  }
+
+  /** Rebuild the highlight overlay for the current page from cached runs
+   *  (no page re-render). */
+  private _redrawHighlights(): void {
+    const runs = this._find.pageRuns(this._currentPage) ?? [];
+    this._buildHighlightLayer(runs);
+  }
 
   /**
    * Terminate the parser worker and release resources.
@@ -280,14 +392,72 @@ export class DocxViewer {
       this._canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
       this._bitmapCtx?.transferFromImageBitmap(bmp);
     } else {
+      // Collect runs unconditionally (not just when a text layer exists): the
+      // find-highlight overlay needs the current page's run geometry too, and
+      // caching them here means find() reuses the visible render for this page
+      // instead of re-rendering it offscreen.
       const runs: DocxTextRunInfo[] = [];
-      const onTextRun = this._textLayer ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
+      const onTextRun = (r: DocxTextRunInfo) => runs.push(r);
       await this._doc.renderPage(this._canvas, this._currentPage, { ...this._opts, onTextRun });
       if (this._textLayer) {
         this._buildTextLayer(this._textLayer, runs);
       }
+      // Feed the just-rendered page's runs to the find controller so highlight
+      // geometry matches exactly what was drawn, then (re)draw the highlights.
+      this._find.setPageRuns(this._currentPage, runs);
+      this._buildHighlightLayer(runs);
     }
     this._opts.onPageChange?.(this._currentPage, this.pageCount);
+  }
+
+  /** Draw the find-highlight boxes for the current page from its runs. Clears
+   *  the overlay when there is no active find. */
+  private _buildHighlightLayer(runs: DocxTextRunInfo[]): void {
+    const layer = this._highlightLayer;
+    if (!layer) return;
+    const cssWidth = this._canvas.style.width || this._canvas.width + 'px';
+    const cssHeight = this._canvas.style.height || this._canvas.height + 'px';
+    const highlights: DocxHighlightMatch[] = this._find.pageHighlights(this._currentPage);
+    buildDocxHighlightLayer(
+      layer,
+      runs,
+      highlights,
+      cssWidth,
+      cssHeight,
+      (font) => this._measureForFont(font),
+    );
+  }
+
+  /** A width-measurer primed with `font`, backed by a private 1×1 canvas so it
+   *  never disturbs the visible canvas's context state. */
+  private _measureForFont(font: string): (s: string) => number {
+    if (!this._measureCtx) {
+      const c = document.createElement('canvas');
+      this._measureCtx = c.getContext('2d');
+    }
+    const ctx = this._measureCtx;
+    if (!ctx) return (s) => s.length; // measurement unavailable (headless w/o canvas)
+    ctx.font = font;
+    return (s) => ctx.measureText(s).width;
+  }
+
+  /** Render a page to a throwaway offscreen canvas purely to collect its runs
+   *  (text + geometry) for search, without touching the visible canvas. Used by
+   *  the find controller for pages other than the one on screen. */
+  private async _collectPageRuns(page: number): Promise<DocxTextRunInfo[]> {
+    if (!this._doc || this._mode === 'worker') return [];
+    // The currently displayed page's runs are already cached by _renderPage; the
+    // controller only calls this for other pages.
+    const runs: DocxTextRunInfo[] = [];
+    const off =
+      typeof OffscreenCanvas !== 'undefined'
+        ? new OffscreenCanvas(1, 1)
+        : (document.createElement('canvas') as HTMLCanvasElement);
+    await this._doc.renderPage(off, page, {
+      ...this._opts,
+      onTextRun: (r: DocxTextRunInfo) => runs.push(r),
+    });
+    return runs;
   }
 
   private _buildTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {

--- a/packages/node/src/docx-find-highlight.test.ts
+++ b/packages/node/src/docx-find-highlight.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  installImageBitmapShim,
+  installOffscreenCanvasShim,
+  type NodeCanvasFactory,
+} from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+/**
+ * IX2 findText END-TO-END on the real (committed) demo docx: parse → paginate →
+ * render each page capturing the real `onTextRun` runs → DocxFindController →
+ * find a known word → assert its `{ page }` location + reconstructed text, then
+ * feed the real match slices to buildDocxHighlightLayer with a REAL skia
+ * text-measurer and assert the highlight box lands on the drawn glyph run
+ * (numeric geometry, not eyeballing). This proves the whole find + highlight
+ * pipeline against a real document, not stubs.
+ */
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (async () => {
+    throw new Error('unused');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
+const FIND_PATH = resolve(ROOT, 'packages/docx/src/find.ts');
+const HIGHLIGHT_PATH = resolve(ROOT, 'packages/docx/src/find-highlight-layer.ts');
+
+const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
+const rendererMod = skia
+  ? await importForTests(() => import(RENDERER_PATH), 'packages/docx/src/renderer.ts')
+  : null;
+const findMod = skia ? await importForTests(() => import(FIND_PATH), 'packages/docx/src/find.ts') : null;
+const highlightMod = skia
+  ? await importForTests(() => import(HIGHLIGHT_PATH), 'packages/docx/src/find-highlight-layer.ts')
+  : null;
+
+const DEMO = resolve(ROOT, 'packages/docx/public/demo/sample-1.docx');
+const haveDemo = existsSync(DEMO);
+
+// Minimal recording DOM used by buildDocxHighlightLayer in node (no jsdom).
+interface FakeEl {
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  appendChild(c: FakeEl): void;
+}
+function makeEl(): FakeEl {
+  const style: Record<string, string> = {};
+  return {
+    innerHTML: '',
+    children: [],
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(t, p: string, v: string) {
+        if (p === 'cssText') {
+          for (const d of v.split(';')) {
+            const i = d.indexOf(':');
+            if (i > 0) t[d.slice(0, i).trim()] = d.slice(i + 1).trim();
+          }
+          t.cssText = v;
+        } else t[p] = v;
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+  };
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod || !findMod || !highlightMod || !haveDemo)(
+  'IX2 docx findText + highlight on the demo fixture',
+  () => {
+    type Run = {
+      text: string;
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+      font: string;
+      fontSize: number;
+    };
+
+    // Render every page and collect its runs, exactly as DocxViewer does.
+    async function collectAllPages(): Promise<{ pages: Run[][]; controller: unknown }> {
+      const restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
+      try {
+        const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => unknown };
+        const { paginateDocument, renderDocumentToCanvas } = rendererMod as {
+          paginateDocument: (doc: unknown) => unknown[][];
+          renderDocumentToCanvas: (
+            doc: unknown,
+            canvas: unknown,
+            pageIndex: number,
+            opts: Record<string, unknown>,
+          ) => Promise<void>;
+        };
+        const doc = parseDocx(readFileSync(DEMO));
+        const pages = paginateDocument(doc);
+        const perPage: Run[][] = [];
+        for (let p = 0; p < pages.length; p++) {
+          const canvas = new Canvas(800, 1000);
+          const runs: Run[] = [];
+          await renderDocumentToCanvas(doc, canvas, p, {
+            width: 800,
+            dpr: 1,
+            prebuiltPages: pages,
+            totalPages: pages.length,
+            onTextRun: (r: Run) => runs.push(r),
+          });
+          perPage.push(runs);
+        }
+        return { pages: perPage, controller: null };
+      } finally {
+        restore.forEach((r) => r());
+      }
+    }
+
+    it('finds a known word and reports its page + original-case text', async () => {
+      const { pages } = await collectAllPages();
+      const { DocxFindController } = findMod as {
+        DocxFindController: new (
+          count: () => number,
+          collect: (p: number) => Promise<Run[]>,
+        ) => {
+          find: (q: string, o?: unknown) => Promise<{ matchIndex: number; text: string; location: { page: number } }[]>;
+          next: () => { location: { page: number } } | null;
+          pageHighlights: (p: number) => { slices: { runIndex: number; start: number; end: number }[]; active: boolean }[];
+        };
+      };
+      const controller = new DocxFindController(
+        () => pages.length,
+        (p) => Promise.resolve(pages[p] ?? []),
+      );
+
+      // "Cathedral" appears in the demo's feature headline.
+      const matches = await controller.find('cathedral');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      // Case-insensitive match, but the reported text is the document's case.
+      expect(matches[0].text.toLowerCase()).toBe('cathedral');
+      expect(matches[0].location.page).toBeGreaterThanOrEqual(0);
+      expect(matches[0].location.page).toBeLessThan(pages.length);
+
+      // Activate the first match; its page must carry a highlight marked active.
+      controller.next();
+      const hp = controller.pageHighlights(matches[0].location.page);
+      expect(hp.some((h) => h.active)).toBe(true);
+    });
+
+    it('places the highlight box on the drawn glyph run (real skia measure)', async () => {
+      const { pages } = await collectAllPages();
+      const { DocxFindController } = findMod as {
+        DocxFindController: new (
+          count: () => number,
+          collect: (p: number) => Promise<Run[]>,
+        ) => {
+          find: (q: string) => Promise<{ location: { page: number } }[]>;
+          next: () => unknown;
+          pageHighlights: (p: number) => { slices: { runIndex: number; start: number; end: number }[]; active: boolean }[];
+        };
+      };
+      const { buildDocxHighlightLayer } = highlightMod as {
+        buildDocxHighlightLayer: (
+          layer: unknown,
+          runs: Run[],
+          matches: { slices: { runIndex: number; start: number; end: number }[]; active: boolean }[],
+          w: string,
+          h: string,
+          measureForFont: (font: string) => (s: string) => number,
+        ) => void;
+      };
+      const controller = new DocxFindController(
+        () => pages.length,
+        (p) => Promise.resolve(pages[p] ?? []),
+      );
+      const matches = await controller.find('cathedral');
+      const page = matches[0].location.page;
+      const runs = pages[page];
+      const highlights = controller.pageHighlights(page);
+
+      // Real skia measurer, primed per font (same as the viewer's _measureForFont).
+      const measureCanvas = new Canvas(1, 1);
+      const mctx = measureCanvas.getContext('2d') as unknown as {
+        font: string;
+        measureText: (s: string) => { width: number };
+      };
+      const measureForFont = (font: string) => {
+        mctx.font = font;
+        return (s: string) => mctx.measureText(s).width;
+      };
+
+      const layer = makeEl();
+      // buildDocxHighlightLayer creates each box via document.createElement; no
+      // jsdom in node, so provide a minimal recording stub for the call.
+      const prevDoc = (globalThis as { document?: unknown }).document;
+      (globalThis as { document?: unknown }).document = { createElement: () => makeEl() };
+      try {
+        buildDocxHighlightLayer(
+          layer as unknown as HTMLDivElement,
+          runs,
+          highlights,
+          '800px',
+          '1000px',
+          measureForFont,
+        );
+      } finally {
+        (globalThis as { document?: unknown }).document = prevDoc;
+      }
+
+      expect(layer.children.length).toBeGreaterThanOrEqual(1);
+      // Every box must sit within its matched run's drawn extent: left ≥ run.x,
+      // right ≤ run.x + run.w (+1px slack for sub-pixel rounding), top == run.y,
+      // and a positive width. This is the pixel-level "highlight lands on the
+      // glyphs" assertion.
+      const firstSlice = highlights.find((h) => h.slices.length)?.slices[0];
+      expect(firstSlice).toBeDefined();
+      const run = runs[firstSlice!.runIndex];
+      const box = layer.children[0];
+      const left = parseFloat(box.style.left);
+      const width = parseFloat(box.style.width);
+      const top = parseFloat(box.style.top);
+      expect(width).toBeGreaterThan(0);
+      expect(left).toBeGreaterThanOrEqual(run.x - 0.5);
+      expect(left + width).toBeLessThanOrEqual(run.x + run.w + 1);
+      expect(top).toBeCloseTo(run.y, 1);
+      // The box background is the (translucent) highlight fill, not empty.
+      expect(box.style.background).toMatch(/rgba/);
+    });
+  },
+);

--- a/packages/node/src/pptx-find-highlight.test.ts
+++ b/packages/node/src/pptx-find-highlight.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { installImageBitmapShim, installOffscreenCanvasShim, type NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+/**
+ * IX2 findText END-TO-END on the real demo pptx: parse → render each slide
+ * capturing real `onTextRun` runs → PptxFindController → find a known word →
+ * assert its `{ slide }` + reconstructed text, then feed the real match slices
+ * to buildPptxHighlightLayer with a REAL skia measurer and assert the box lands
+ * inside its shape group on the drawn glyph run.
+ */
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) => new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (async () => {
+    throw new Error('unused');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const RENDERER_PATH = resolve(ROOT, 'packages/pptx/src/renderer.ts');
+const FIND_PATH = resolve(ROOT, 'packages/pptx/src/find.ts');
+const HIGHLIGHT_PATH = resolve(ROOT, 'packages/pptx/src/find-highlight-layer.ts');
+
+const pptxMod = skia ? await importForTests(() => import('./pptx.ts'), './pptx.ts (pptx WASM)') : null;
+const rendererMod = skia
+  ? await importForTests(() => import(RENDERER_PATH), 'packages/pptx/src/renderer.ts')
+  : null;
+const findMod = skia ? await importForTests(() => import(FIND_PATH), 'packages/pptx/src/find.ts') : null;
+const highlightMod = skia
+  ? await importForTests(() => import(HIGHLIGHT_PATH), 'packages/pptx/src/find-highlight-layer.ts')
+  : null;
+
+const DEMO = resolve(ROOT, 'packages/pptx/public/demo/sample-1.pptx');
+const haveDemo = existsSync(DEMO);
+
+interface FakeEl {
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  appendChild(c: FakeEl): void;
+}
+function makeEl(): FakeEl {
+  const style: Record<string, string> = {};
+  return {
+    innerHTML: '',
+    children: [],
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(t, p: string, v: string) {
+        if (p === 'cssText') {
+          for (const d of v.split(';')) {
+            const i = d.indexOf(':');
+            if (i > 0) t[d.slice(0, i).trim()] = d.slice(i + 1).trim();
+          }
+          t.cssText = v;
+        } else t[p] = v;
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+  };
+}
+
+type Run = {
+  text: string;
+  inShapeX: number;
+  inShapeY: number;
+  w: number;
+  h: number;
+  font: string;
+  fontSize: number;
+  shapeX: number;
+  shapeY: number;
+  shapeW: number;
+  shapeH: number;
+  rotation: number;
+};
+
+describe.skipIf(!skia || !pptxMod || !rendererMod || !findMod || !highlightMod || !haveDemo)(
+  'IX2 pptx findText + highlight on the demo fixture',
+  () => {
+    async function collectSlides(): Promise<Run[][]> {
+      const restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
+      try {
+        const { parsePptx } = pptxMod as { parsePptx: (b: Uint8Array) => { slides: unknown[]; slideWidth: number; slideHeight: number; defaultTextColor?: string; majorFont?: unknown; minorFont?: unknown; hlinkColor?: unknown } };
+        const { renderSlide } = rendererMod as {
+          renderSlide: (
+            canvas: unknown,
+            slide: unknown,
+            sw: number,
+            sh: number,
+            opts: Record<string, unknown>,
+            onTextRun?: (r: Run) => void,
+          ) => Promise<unknown>;
+        };
+        const pres = parsePptx(readFileSync(DEMO));
+        const out: Run[][] = [];
+        for (let s = 0; s < pres.slides.length; s++) {
+          const canvas = new Canvas(960, 540);
+          const runs: Run[] = [];
+          await renderSlide(
+            canvas,
+            pres.slides[s],
+            pres.slideWidth,
+            pres.slideHeight,
+            {
+              width: 960,
+              dpr: 1,
+              defaultTextColor: pres.defaultTextColor,
+              majorFont: pres.majorFont,
+              minorFont: pres.minorFont,
+              hlinkColor: pres.hlinkColor ?? null,
+              fetchMedia: async () => new Blob([]),
+              fetchImage: async () => new Blob([]),
+              skipMediaControls: true,
+            },
+            (r: Run) => runs.push(r),
+          );
+          out.push(runs);
+        }
+        return out;
+      } finally {
+        restore.forEach((r) => r());
+      }
+    }
+
+    it('finds a known word and reports its slide + original-case text', async () => {
+      const slides = await collectSlides();
+      const { PptxFindController } = findMod as {
+        PptxFindController: new (
+          count: () => number,
+          collect: (s: number) => Promise<Run[]>,
+        ) => {
+          find: (q: string) => Promise<{ text: string; location: { slide: number } }[]>;
+          next: () => unknown;
+          slideHighlights: (s: number) => { slices: { runIndex: number; start: number; end: number }[]; active: boolean }[];
+        };
+      };
+      const ctrl = new PptxFindController(
+        () => slides.length,
+        (s) => Promise.resolve(slides[s] ?? []),
+      );
+      const matches = await ctrl.find('forest');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      expect(matches[0].text.toLowerCase()).toBe('forest');
+      expect(matches[0].location.slide).toBeGreaterThanOrEqual(0);
+    });
+
+    it('places the highlight box inside its shape group on the drawn run', async () => {
+      const slides = await collectSlides();
+      const { PptxFindController } = findMod as {
+        PptxFindController: new (
+          count: () => number,
+          collect: (s: number) => Promise<Run[]>,
+        ) => {
+          find: (q: string) => Promise<{ location: { slide: number } }[]>;
+          slideHighlights: (s: number) => { slices: { runIndex: number; start: number; end: number }[]; active: boolean }[];
+        };
+      };
+      const { buildPptxHighlightLayer } = highlightMod as {
+        buildPptxHighlightLayer: (
+          layer: unknown,
+          runs: Run[],
+          matches: { slices: { runIndex: number; start: number; end: number }[]; active: boolean }[],
+          w: number,
+          h: number,
+          measureForFont: (font: string) => (s: string) => number,
+        ) => void;
+      };
+      const ctrl = new PptxFindController(
+        () => slides.length,
+        (s) => Promise.resolve(slides[s] ?? []),
+      );
+      const matches = await ctrl.find('forest');
+      const slide = matches[0].location.slide;
+      const runs = slides[slide];
+      const highlights = ctrl.slideHighlights(slide);
+
+      const mcanvas = new Canvas(1, 1);
+      const mctx = mcanvas.getContext('2d') as unknown as { font: string; measureText: (s: string) => { width: number } };
+      const measureForFont = (font: string) => {
+        mctx.font = font;
+        return (s: string) => mctx.measureText(s).width;
+      };
+
+      const layer = makeEl();
+      const prevDoc = (globalThis as { document?: unknown }).document;
+      (globalThis as { document?: unknown }).document = { createElement: () => makeEl() };
+      try {
+        buildPptxHighlightLayer(layer as unknown as HTMLDivElement, runs, highlights, 960, 540, measureForFont);
+      } finally {
+        (globalThis as { document?: unknown }).document = prevDoc;
+      }
+
+      // One or more shape group divs, each with box children.
+      expect(layer.children.length).toBeGreaterThanOrEqual(1);
+      const firstSlice = highlights.find((h) => h.slices.length)?.slices[0];
+      expect(firstSlice).toBeDefined();
+      const run = runs[firstSlice!.runIndex];
+      const shapeDiv = layer.children.find((d) => d.children.length > 0);
+      expect(shapeDiv).toBeDefined();
+      const box = shapeDiv!.children[0];
+      const left = parseFloat(box.style.left);
+      const width = parseFloat(box.style.width);
+      const top = parseFloat(box.style.top);
+      // The box sits in the shape's own frame at inShapeX + slice extent.
+      expect(width).toBeGreaterThan(0);
+      expect(left).toBeGreaterThanOrEqual(run.inShapeX - 0.5);
+      expect(top).toBeCloseTo(run.inShapeY, 1);
+      expect(box.style.background).toMatch(/rgba/);
+    });
+  },
+);

--- a/packages/node/src/xlsx-find.test.ts
+++ b/packages/node/src/xlsx-find.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+/**
+ * IX2 findText END-TO-END on the real demo xlsx: parse every sheet → build each
+ * cell's rendered display text via the real formatCellValue → XlsxFindController
+ * → find a known value → assert its `{ sheet, sheetName, ref, row, col }`. xlsx
+ * search is model-based (no render), so this needs no canvas — but it still
+ * gates on the WASM parser being present, so the shared skia/WASM gate is reused.
+ */
+const skia = await loadSkiaForTests();
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const FIND_PATH = resolve(ROOT, 'packages/xlsx/src/find.ts');
+const NUMFMT_PATH = resolve(ROOT, 'packages/xlsx/src/number-format.ts');
+
+const xlsxMod = skia ? await importForTests(() => import('./xlsx.ts'), './xlsx.ts (xlsx WASM)') : null;
+const findMod = skia ? await importForTests(() => import(FIND_PATH), 'packages/xlsx/src/find.ts') : null;
+const numfmtMod = skia
+  ? await importForTests(() => import(NUMFMT_PATH), 'packages/xlsx/src/number-format.ts')
+  : null;
+
+const DEMO = resolve(ROOT, 'packages/xlsx/public/demo/sample-1.xlsx');
+const haveDemo = existsSync(DEMO);
+
+describe.skipIf(!skia || !xlsxMod || !findMod || !numfmtMod || !haveDemo)(
+  'IX2 xlsx findText on the demo fixture',
+  () => {
+    type Cell = { row: number; col: number; value: unknown; styleIndex?: number };
+    type Ws = { rows: { cells: Cell[] }[]; date1904?: boolean };
+
+    function buildController() {
+      const { parseXlsx, parseXlsxAllSheets } = xlsxMod as {
+        parseXlsx: (b: Uint8Array) => { styles: unknown };
+        parseXlsxAllSheets: (b: Uint8Array) => {
+          workbook: { sheets: { name: string }[] };
+          worksheets: Record<string, Ws>;
+        };
+      };
+      const { formatCellValue } = numfmtMod as {
+        formatCellValue: (cell: Cell, styles: unknown, cf: unknown, date1904?: boolean) => string;
+      };
+      const { XlsxFindController } = findMod as {
+        XlsxFindController: new (
+          sheetCount: () => number,
+          sheetName: (s: number) => string,
+          collect: (s: number) => Promise<{ row: number; col: number; text: string }[]>,
+        ) => {
+          find: (q: string, o?: unknown) => Promise<{ text: string; location: { sheet: number; sheetName: string; ref: string; row: number; col: number } }[]>;
+          next: () => { location: { sheet: number } } | null;
+          sheetHighlights: (s: number) => { row: number; col: number; active: boolean }[];
+        };
+      };
+
+      const bytes = readFileSync(DEMO);
+      const styles = parseXlsx(bytes).styles;
+      const all = parseXlsxAllSheets(bytes);
+      const names = all.workbook.sheets.map((s) => s.name);
+
+      return new XlsxFindController(
+        () => names.length,
+        (s) => names[s] ?? '',
+        (s) => {
+          const ws = all.worksheets[names[s]];
+          const cells: { row: number; col: number; text: string }[] = [];
+          for (const row of ws?.rows ?? []) {
+            for (const cell of row.cells) {
+              const text = formatCellValue(cell, styles, null, ws?.date1904);
+              if (text !== '') cells.push({ row: cell.row, col: cell.col, text });
+            }
+          }
+          return Promise.resolve(cells);
+        },
+      );
+    }
+
+    it('finds a known cell value and reports its sheet + A1 ref', async () => {
+      const ctrl = buildController();
+      // "Northridge" is a region name in the demo's Regional Overview table.
+      const matches = await ctrl.find('northridge');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const m = matches[0];
+      expect(m.text.toLowerCase()).toBe('northridge');
+      expect(m.location.sheetName).toBeTruthy();
+      // A1 ref must be well-formed (letters + digits).
+      expect(m.location.ref).toMatch(/^[A-Z]+\d+$/);
+      expect(m.location.row).toBeGreaterThanOrEqual(1);
+      expect(m.location.col).toBeGreaterThanOrEqual(1);
+    });
+
+    it('matches the rendered display text across multiple sheets', async () => {
+      const ctrl = buildController();
+      // "Biodiversity" appears on several sheets (Dashboard + its own sheet).
+      const matches = await ctrl.find('biodiversity');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      // Activating the first match yields a valid sheet + a highlight on it.
+      const active = ctrl.next();
+      expect(active).not.toBeNull();
+      const sheet = active!.location.sheet;
+      expect(ctrl.sheetHighlights(sheet).some((h) => h.active)).toBe(true);
+    });
+
+    it('is case-insensitive by default; caseSensitive narrows', async () => {
+      const ci = await buildController().find('FOREST');
+      const cs = await buildController().find('FOREST', { caseSensitive: true });
+      expect(ci.length).toBeGreaterThanOrEqual(cs.length);
+    });
+  },
+);

--- a/packages/pptx/src/find-highlight-layer.test.ts
+++ b/packages/pptx/src/find-highlight-layer.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  buildPptxHighlightLayer,
+  DEFAULT_FIND_HIGHLIGHT,
+  DEFAULT_FIND_ACTIVE_HIGHLIGHT,
+  type PptxHighlightMatch,
+} from './find-highlight-layer.js';
+import type { PptxTextRunInfo } from './renderer';
+
+// node env: recording DOM stub (same as text-layer.test.ts). Highlights are
+// grouped into one rotated <div> per shape frame; each box sits inside its
+// shape div at inShapeX + slice-x.
+interface FakeEl {
+  tag: string;
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  appendChild(c: FakeEl): void;
+}
+function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    innerHTML: '',
+    children: [],
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const i = decl.indexOf(':');
+            if (i > 0) target[decl.slice(0, i).trim()] = decl.slice(i + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) {
+      this.children.push(c);
+    },
+  };
+  return el;
+}
+afterEach(() => vi.unstubAllGlobals());
+
+function run(p: Partial<PptxTextRunInfo>): PptxTextRunInfo {
+  return {
+    text: 'X',
+    inShapeX: 0,
+    inShapeY: 0,
+    w: 10,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    shapeX: 0,
+    shapeY: 0,
+    shapeW: 100,
+    shapeH: 50,
+    rotation: 0,
+    ...p,
+  };
+}
+
+const W = 7;
+const measureForFont = () => (s: string) => s.length * W;
+
+describe('buildPptxHighlightLayer', () => {
+  it('places a box inside the shape div at inShapeX + slice extent', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'the quick', inShapeX: 5, inShapeY: 8, h: 16 })];
+    const matches: PptxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 4, end: 9 }], active: false }, // "quick"
+    ];
+    buildPptxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 960, 540, measureForFont);
+    // One shape div, containing one box.
+    expect(layer.children).toHaveLength(1);
+    const shapeDiv = layer.children[0];
+    expect(shapeDiv.children).toHaveLength(1);
+    const box = shapeDiv.children[0];
+    // left = inShapeX (5) + "the " (28) = 33; top = inShapeY (8); width = 35.
+    expect(box.style.left).toBe('33px');
+    expect(box.style.top).toBe('8px');
+    expect(box.style.width).toBe('35px');
+    expect(box.style.height).toBe('16px');
+    expect(box.style.background).toBe(DEFAULT_FIND_HIGHLIGHT);
+  });
+
+  it('applies the shape rotation to the group div', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'abc', rotation: 30, textBodyRotation: 90 })];
+    const matches: PptxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 3 }], active: true },
+    ];
+    buildPptxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
+    const shapeDiv = layer.children[0];
+    expect(shapeDiv.style.transform).toBe('rotate(120deg)'); // 30 + 90
+    expect(shapeDiv.children[0].style.background).toBe(DEFAULT_FIND_ACTIVE_HIGHLIGHT);
+  });
+
+  it('groups boxes from the same shape under one div', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [
+      run({ text: 'a', shapeX: 10, shapeY: 20 }),
+      run({ text: 'b', shapeX: 10, shapeY: 20 }),
+    ];
+    const matches: PptxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 1 }], active: false },
+      { slices: [{ runIndex: 1, start: 0, end: 1 }], active: false },
+    ];
+    buildPptxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
+    expect(layer.children).toHaveLength(1); // one shape group
+    expect(layer.children[0].children).toHaveLength(2); // two boxes
+  });
+
+  it('clears the layer on rebuild', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    layer.innerHTML = 'STALE';
+    buildPptxHighlightLayer(layer as unknown as HTMLDivElement, [], [], 100, 100, measureForFont);
+    expect(layer.innerHTML).toBe('');
+    expect(layer.children).toHaveLength(0);
+  });
+});

--- a/packages/pptx/src/find-highlight-layer.ts
+++ b/packages/pptx/src/find-highlight-layer.ts
@@ -1,0 +1,104 @@
+/**
+ * IX2 pptx find-highlight overlay.
+ *
+ * The highlight twin of {@link buildPptxTextLayer}: it draws a visible box per
+ * matched run-slice, grouped into one positioned + rotated `<div>` per shape
+ * frame exactly as the selection overlay groups its transparent spans, so a box
+ * tracks the drawn (rotated) text. Riding the same shape-grouped DOM overlay
+ * (rather than a canvas draw pass) means highlights rotate with their shape and
+ * compose with the selection / hyperlink layer.
+ *
+ * A slice's horizontal extent within its run is the shared core
+ * `sliceHorizontalExtent`, measured against the run's font; the box's vertical
+ * extent is the run's line box (`h`). Boxes are placed in the shape's own
+ * coordinate frame (`inShapeX`/`inShapeY`), so the shape div's `rotate()` lays
+ * them along the glyphs. The active match uses a distinct emphasis colour.
+ */
+import { sliceHorizontalExtent, type MatchRunSlice } from '@silurus/ooxml-core';
+import type { PptxTextRunInfo } from './renderer';
+
+export interface PptxHighlightMatch {
+  slices: MatchRunSlice[];
+  active: boolean;
+}
+
+/** Browser find-bar palette (translucent so glyphs stay legible). */
+export const DEFAULT_FIND_HIGHLIGHT = 'rgba(255, 214, 0, 0.42)';
+export const DEFAULT_FIND_ACTIVE_HIGHLIGHT = 'rgba(255, 140, 0, 0.55)';
+
+export interface PptxHighlightColors {
+  match?: string;
+  active?: string;
+}
+
+/**
+ * Populate a highlight overlay layer with a box per matched run-slice, grouped
+ * by shape frame (with the shape's rotation) so each box lands on the drawn
+ * glyphs.
+ *
+ * @param layer     the overlay div (cleared + re-sized here).
+ * @param runs      the slide's runs (same array the slide was rendered from).
+ * @param matches   the slide's matches (run-slices + active flag).
+ * @param cssWidth  rendered canvas CSS width (px, number).
+ * @param cssHeight rendered canvas CSS height (px, number).
+ * @param measureForFont returns a width-measurer primed with a run's font.
+ * @param colors    optional colour overrides.
+ */
+export function buildPptxHighlightLayer(
+  layer: HTMLDivElement,
+  runs: PptxTextRunInfo[],
+  matches: PptxHighlightMatch[],
+  cssWidth: number,
+  cssHeight: number,
+  measureForFont: (font: string) => (s: string) => number,
+  colors: PptxHighlightColors = {},
+): void {
+  layer.innerHTML = '';
+  layer.style.width = `${cssWidth}px`;
+  layer.style.height = `${cssHeight}px`;
+
+  const matchColor = colors.match ?? DEFAULT_FIND_HIGHLIGHT;
+  const activeColor = colors.active ?? DEFAULT_FIND_ACTIVE_HIGHLIGHT;
+
+  // One positioned + rotated div per shape frame (keyed like the text layer), so
+  // boxes inside it inherit the shape's rotation. Reused across matches/slices.
+  const shapeMap = new Map<string, HTMLDivElement>();
+  const shapeDiv = (run: PptxTextRunInfo): HTMLDivElement => {
+    const totalRot = run.rotation + (run.textBodyRotation ?? 0);
+    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
+    let div = shapeMap.get(key);
+    if (!div) {
+      div = document.createElement('div');
+      div.style.cssText =
+        `position:absolute;` +
+        `left:${run.shapeX}px;top:${run.shapeY}px;` +
+        `width:${run.shapeW}px;height:${run.shapeH}px;` +
+        `pointer-events:none;overflow:hidden;`;
+      if (totalRot !== 0) {
+        div.style.transformOrigin = 'center center';
+        div.style.transform = `rotate(${totalRot}deg)`;
+      }
+      shapeMap.set(key, div);
+      layer.appendChild(div);
+    }
+    return div;
+  };
+
+  for (const match of matches) {
+    const fill = match.active ? activeColor : matchColor;
+    for (const slice of match.slices) {
+      const run = runs[slice.runIndex];
+      if (!run) continue;
+      const measure = measureForFont(run.font);
+      const { x, width } = sliceHorizontalExtent(run.text, slice.start, slice.end, measure);
+      if (width <= 0) continue;
+      const box = document.createElement('div');
+      box.style.cssText =
+        `position:absolute;` +
+        `left:${run.inShapeX + x}px;top:${run.inShapeY}px;` +
+        `width:${width}px;height:${run.h}px;` +
+        `background:${fill};pointer-events:none;`;
+      shapeDiv(run).appendChild(box);
+    }
+  }
+}

--- a/packages/pptx/src/find.test.ts
+++ b/packages/pptx/src/find.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { PptxFindController } from './find.js';
+import type { PptxTextRunInfo } from './renderer';
+
+/**
+ * IX2 pptx find controller. Exercised with stubbed per-slide runs: joins a
+ * slide's runs, matches across run boundaries, aggregates in document order
+ * tagged `{ slide }`, and cycles the active match across slides.
+ */
+function run(text: string): PptxTextRunInfo {
+  return {
+    text,
+    inShapeX: 0,
+    inShapeY: 0,
+    w: text.length,
+    h: 10,
+    fontSize: 10,
+    font: '10px monospace',
+    shapeX: 0,
+    shapeY: 0,
+    shapeW: 100,
+    shapeH: 20,
+    rotation: 0,
+  };
+}
+
+function controllerFor(slides: PptxTextRunInfo[][]): PptxFindController {
+  return new PptxFindController(
+    () => slides.length,
+    (slide) => Promise.resolve(slides[slide] ?? []),
+  );
+}
+
+describe('PptxFindController.find', () => {
+  it('finds matches across slides tagged with their slide index', async () => {
+    const c = controllerFor([[run('hello world')], [run('a world here')]]);
+    const matches = await c.find('world');
+    expect(matches).toHaveLength(2);
+    expect(matches[0].location.slide).toBe(0);
+    expect(matches[1].location.slide).toBe(1);
+  });
+
+  it('resolves a match straddling two runs on one slide', async () => {
+    const c = controllerFor([[run('Hel'), run('lo there')]]);
+    const matches = await c.find('Hello');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('Hello');
+  });
+
+  it('is case-insensitive by default; caseSensitive honored', async () => {
+    const ci = await controllerFor([[run('FOO foo')]]).find('foo');
+    expect(ci).toHaveLength(2);
+    const cs = await controllerFor([[run('FOO foo')]]).find('foo', { caseSensitive: true });
+    expect(cs).toHaveLength(1);
+  });
+});
+
+describe('PptxFindController cursor + highlights', () => {
+  it('cycles the active match with wrap-around across slides', async () => {
+    const c = controllerFor([[run('x')], [run('x')]]);
+    await c.find('x');
+    expect(c.next()?.matchIndex).toBe(0);
+    expect(c.activeSlide()).toBe(0);
+    expect(c.next()?.matchIndex).toBe(1);
+    expect(c.activeSlide()).toBe(1);
+    expect(c.next()?.matchIndex).toBe(0); // wrap
+  });
+
+  it('slideHighlights scopes to slide and marks active', async () => {
+    const c = controllerFor([[run('a a')]]);
+    await c.find('a');
+    c.next();
+    const hl = c.slideHighlights(0);
+    expect(hl).toHaveLength(2);
+    expect(hl[0].active).toBe(true);
+    expect(hl[1].active).toBe(false);
+  });
+
+  it('invalidate clears everything', async () => {
+    const c = controllerFor([[run('a')]]);
+    await c.find('a');
+    c.invalidate();
+    expect(c.matches()).toHaveLength(0);
+    expect(c.activeSlide()).toBeNull();
+  });
+});

--- a/packages/pptx/src/find.ts
+++ b/packages/pptx/src/find.ts
@@ -1,0 +1,132 @@
+/**
+ * IX2 pptx find-in-presentation controller.
+ *
+ * The pptx twin of the docx `DocxFindController`: owns per-slide run lists (the
+ * `onTextRun` stream), the matches for the current query, and the active-match
+ * cursor. All string/index math is core (`buildTextIndex`, `findMatches`,
+ * `nextActive`/`prevActive`); this maps each hit to a `{ slide }` location.
+ *
+ * The viewer supplies `collectSlideRuns(slide)` — render that slide (to an
+ * offscreen canvas) and return its `PptxTextRunInfo[]`. The controller caches
+ * per slide until `invalidate()`. The displayed slide's runs are fed in from the
+ * visible render so highlight geometry matches exactly what was drawn.
+ */
+import {
+  buildTextIndex,
+  findMatches,
+  nextActive,
+  prevActive,
+  type FindMatch,
+  type FindMatchesOptions,
+  type TextMatch,
+} from '@silurus/ooxml-core';
+import type { PptxTextRunInfo } from './renderer';
+
+/** Where a pptx match lives: its 0-based slide index. */
+export interface PptxMatchLocation {
+  slide: number;
+}
+
+interface PptxResolvedMatch {
+  slide: number;
+  text: string;
+  slices: TextMatch['slices'];
+}
+
+export class PptxFindController {
+  private _slideRuns = new Map<number, PptxTextRunInfo[]>();
+  private _matches: PptxResolvedMatch[] = [];
+  private _active = -1;
+
+  constructor(
+    private readonly _slideCount: () => number,
+    private readonly _collectSlideRuns: (slide: number) => Promise<PptxTextRunInfo[]>,
+  ) {}
+
+  /** Drop all cached runs + matches (call on reload). */
+  invalidate(): void {
+    this._slideRuns.clear();
+    this._matches = [];
+    this._active = -1;
+  }
+
+  /** The runs for a slide, if scanned (used by the highlight overlay for the
+   *  displayed slide). */
+  slideRuns(slide: number): PptxTextRunInfo[] | undefined {
+    return this._slideRuns.get(slide);
+  }
+
+  /** Cache a slide's runs captured from the visible render. */
+  setSlideRuns(slide: number, runs: PptxTextRunInfo[]): void {
+    this._slideRuns.set(slide, runs);
+  }
+
+  /** All match slices on a slide, tagged active — the highlight overlay input. */
+  slideHighlights(slide: number): { slices: TextMatch['slices']; active: boolean }[] {
+    const out: { slices: TextMatch['slices']; active: boolean }[] = [];
+    for (let i = 0; i < this._matches.length; i++) {
+      const m = this._matches[i];
+      if (m.slide === slide) out.push({ slices: m.slices, active: i === this._active });
+    }
+    return out;
+  }
+
+  /** The active match's slide, or null. */
+  activeSlide(): number | null {
+    const m = this._matches[this._active];
+    return m ? m.slide : null;
+  }
+
+  /** The public match list for the current query. */
+  matches(): FindMatch<PptxMatchLocation>[] {
+    return this._matches.map((m, i) => ({
+      matchIndex: i,
+      text: m.text,
+      location: { slide: m.slide },
+    }));
+  }
+
+  /** Run a fresh query across every slide, resetting the cursor. */
+  async find(query: string, opts: FindMatchesOptions = {}): Promise<FindMatch<PptxMatchLocation>[]> {
+    this._matches = [];
+    this._active = -1;
+    if (query.length === 0) return [];
+
+    const slides = this._slideCount();
+    for (let slide = 0; slide < slides; slide++) {
+      const runs = await this._ensureSlideRuns(slide);
+      const index = buildTextIndex(runs);
+      for (const tm of findMatches(index, query, opts)) {
+        const text = tm.slices
+          .map((s) => runs[s.runIndex].text.slice(s.start, s.end))
+          .join('');
+        this._matches.push({ slide, text, slices: tm.slices });
+      }
+    }
+    return this.matches();
+  }
+
+  next(): FindMatch<PptxMatchLocation> | null {
+    this._active = nextActive(this._active, this._matches.length);
+    return this._activePublic();
+  }
+
+  prev(): FindMatch<PptxMatchLocation> | null {
+    this._active = prevActive(this._active, this._matches.length);
+    return this._activePublic();
+  }
+
+  private _activePublic(): FindMatch<PptxMatchLocation> | null {
+    const m = this._matches[this._active];
+    if (!m) return null;
+    return { matchIndex: this._active, text: m.text, location: { slide: m.slide } };
+  }
+
+  private async _ensureSlideRuns(slide: number): Promise<PptxTextRunInfo[]> {
+    const cached = this._slideRuns.get(slide);
+    if (cached) return cached;
+    const runs = await this._collectSlideRuns(slide);
+    this._slideRuns.set(slide, runs);
+    return runs;
+  }
+}

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -8,6 +8,15 @@ export {
 } from './presentation';
 export { renderSlide, type RenderOptions, type PptxTextRunInfo, type TextRunCallback } from './renderer';
 export { buildPptxTextLayer } from './text-layer';
+// IX2 find-in-document: the highlight overlay builder + the pptx match-location
+// shape. `FindMatch` / `FindMatchesOptions` come from core (shared across formats).
+export {
+  buildPptxHighlightLayer,
+  type PptxHighlightMatch,
+  type PptxHighlightColors,
+} from './find-highlight-layer';
+export type { PptxMatchLocation } from './find';
+export type { FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 export type { PresentationHandle } from './presentation-handle';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 // IX1 — the shared hyperlink target shape surfaced by `PptxViewerOptions.

--- a/packages/pptx/src/viewer-find-destroy.test.ts
+++ b/packages/pptx/src/viewer-find-destroy.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxViewer } from './viewer.js';
+import { installDom, makeEl, FakePptxEngine } from './scroll-viewer-test-dom.js';
+import type { PptxPresentation } from './presentation';
+import type { PptxTextRunInfo } from './renderer';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * IX2 — destroy() must drop the find state (twin of the DocxViewer test).
+ * findNext()/findPrev() on a torn-down viewer must return null, not a stale
+ * match pointing into a dead viewer.
+ */
+function run(text: string): PptxTextRunInfo {
+  return {
+    text,
+    inShapeX: 0,
+    inShapeY: 0,
+    w: 10,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    shapeX: 0,
+    shapeY: 0,
+    shapeW: 100,
+    shapeH: 50,
+    rotation: 0,
+  };
+}
+
+/** installDom + a document whose <canvas> els carry a measuring 2d context. */
+function installFindDom(): void {
+  installDom();
+  vi.stubGlobal('document', {
+    createElement: (t: string) => {
+      const el = makeEl(t);
+      if (t === 'canvas') {
+        el.getContext = (kind: string) =>
+          kind === '2d'
+            ? { font: '', measureText: (s: string) => ({ width: s.length * 7 }) }
+            : {};
+      }
+      return el;
+    },
+  });
+}
+
+describe('PptxViewer.destroy() — find state invalidation', () => {
+  it('findNext()/findPrev() return null after destroy() (no stale matches)', async () => {
+    installFindDom();
+    const parent = makeEl('div');
+    const canvas = makeEl('canvas');
+    parent.appendChild(canvas);
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement);
+    const engine = new FakePptxEngine(1, 9144000, 6858000);
+    engine.feedTextRuns = [run('hello world')];
+    (v as unknown as { engine: PptxPresentation }).engine = engine.asPres();
+
+    // A live find with a real active match…
+    const matches = await v.findText('hello');
+    expect(matches).toHaveLength(1);
+    const active = await v.findNext();
+    expect(active).not.toBeNull();
+    expect(active?.matchIndex).toBe(0);
+
+    // …must not survive teardown.
+    v.destroy();
+    expect(await v.findNext()).toBeNull();
+    expect(await v.findPrev()).toBeNull();
+  });
+});

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -1,10 +1,17 @@
 import type { RenderOptions, PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
+import { buildPptxHighlightLayer, type PptxHighlightMatch } from './find-highlight-layer';
+import { PptxFindController, type PptxMatchLocation } from './find';
 import { PptxPresentation, type LoadOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible } from './hidden';
 import type { DimOptions } from './types';
-import { type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
+import {
+  type HyperlinkTarget,
+  type FindMatch,
+  type FindMatchesOptions,
+  openExternalHyperlink,
+} from '@silurus/ooxml-core';
 
 /** How {@link PptxViewer} presents hidden slides (`<p:sld show="0">`). */
 export type HiddenSlideMode = 'show' | 'skip' | 'dim';
@@ -84,6 +91,15 @@ export class PptxViewer {
    *  (empty string if it was unset), restored on {@link destroy}. */
   private readonly _originalDisplay: string;
   private textLayer: HTMLDivElement | null = null;
+  /** IX2 — the find-highlight overlay layer (always created, above the text
+   *  layer, `pointer-events:none`). */
+  private highlightLayer: HTMLDivElement | null = null;
+  /** IX2 — find state (per-slide runs, matches, active cursor). */
+  private _find: PptxFindController;
+  /** Private 2d context for measuring highlight text (own 1×1 canvas). */
+  private _measureCtx: CanvasRenderingContext2D | null = null;
+  /** One-shot guard for the worker-mode findText warning. */
+  private _warnedNoFind = false;
   private engine: PptxPresentation | null = null;
   private readonly opts: PptxViewerOptions;
   private currentSlide = 0;
@@ -156,6 +172,19 @@ export class PptxViewer {
         'overflow:hidden;pointer-events:none;user-select:text;-webkit-user-select:text;';
       this.wrapper.appendChild(this.textLayer);
     }
+
+    // IX2 — find-highlight overlay layer, appended last (stacks above the text
+    // layer). `pointer-events:none` keeps selection + link clicks working
+    // through it. Empty in worker mode (onTextRun can't fire there).
+    this.highlightLayer = document.createElement('div');
+    this.highlightLayer.style.cssText =
+      'position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden;pointer-events:none;';
+    this.wrapper.appendChild(this.highlightLayer);
+
+    this._find = new PptxFindController(
+      () => this.slideCount,
+      (slide) => this._collectSlideRuns(slide),
+    );
   }
 
   /**
@@ -205,6 +234,8 @@ export class PptxViewer {
       this.engine = engine;
       previous?.destroy();
       this.currentSlide = this._initialSlide();
+      // A new presentation invalidates any prior find state.
+      this._find.invalidate();
       await this.renderCurrentSlide();
     } catch (err) {
       // Superseded loads own no error reporting — the winning load (or destroy())
@@ -326,8 +357,11 @@ export class PptxViewer {
         "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
       );
     }
+    // Collect runs unconditionally in main mode (not just when a text layer
+    // exists): the find-highlight overlay needs the current slide's run geometry
+    // too, and caching them lets find() reuse the visible render for this slide.
     const runs: PptxTextRunInfo[] = [];
-    const onTextRun = !isWorker && this.textLayer ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    const onTextRun = !isWorker ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
 
     try {
       if (this.opts.enableMediaPlayback) {
@@ -354,6 +388,127 @@ export class PptxViewer {
     if (this.textLayer && !isWorker) {
       this._buildTextLayer(this.textLayer, runs, targetWidth, cssHeight);
     }
+    if (!isWorker) {
+      // Feed the just-rendered slide's runs to the find controller (geometry
+      // matches what was drawn) and (re)draw its highlights.
+      this._find.setSlideRuns(this.currentSlide, runs);
+      this._buildHighlightLayer(runs, targetWidth, cssHeight);
+    }
+  }
+
+  /** Draw the find-highlight boxes for the current slide from its runs. */
+  private _buildHighlightLayer(runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {
+    const layer = this.highlightLayer;
+    if (!layer) return;
+    const highlights: PptxHighlightMatch[] = this._find.slideHighlights(this.currentSlide);
+    buildPptxHighlightLayer(layer, runs, highlights, cssWidth, cssHeight, (font) =>
+      this._measureForFont(font),
+    );
+  }
+
+  /** A width-measurer primed with `font`, backed by a private 1×1 canvas. */
+  private _measureForFont(font: string): (s: string) => number {
+    if (!this._measureCtx) {
+      const c = document.createElement('canvas');
+      this._measureCtx = c.getContext('2d');
+    }
+    const ctx = this._measureCtx;
+    if (!ctx) return (s) => s.length;
+    ctx.font = font;
+    return (s) => ctx.measureText(s).width;
+  }
+
+  /** Render a slide to a throwaway offscreen canvas to collect its runs for
+   *  search, without touching the visible canvas. Used for slides other than the
+   *  one on screen. */
+  private async _collectSlideRuns(slide: number): Promise<PptxTextRunInfo[]> {
+    if (!this.engine || this._mode === 'worker') return [];
+    const runs: PptxTextRunInfo[] = [];
+    const off =
+      typeof OffscreenCanvas !== 'undefined'
+        ? new OffscreenCanvas(1, 1)
+        : (document.createElement('canvas') as HTMLCanvasElement);
+    const targetWidth = this.opts.width ?? (this.canvas.offsetWidth || 960);
+    await this.engine.renderSlide(off, slide, {
+      width: targetWidth,
+      onTextRun: (r: PptxTextRunInfo) => runs.push(r),
+    });
+    return runs;
+  }
+
+  /**
+   * IX2 — find every occurrence of `query` across all slides and highlight them
+   * (a soft box per match on the highlight overlay). Returns every match in
+   * document order, each tagged with its `{ slide }` (0-based). Case-insensitive
+   * by default; pass `{ caseSensitive: true }` for an exact match.
+   *
+   * Scans all slides (each rendered once offscreen to read its text; the visible
+   * slide reuses its on-screen render). Not available in `mode: 'worker'` —
+   * returns `[]` there after a one-time warning. An empty query clears the find.
+   */
+  async findText(
+    query: string,
+    opts: FindMatchesOptions = {},
+  ): Promise<FindMatch<PptxMatchLocation>[]> {
+    if (!this.engine) return [];
+    if (this._mode === 'worker') {
+      if (!this._warnedNoFind) {
+        this._warnedNoFind = true;
+        console.warn(
+          "[ooxml] findText is unavailable in mode: 'worker' (text runs can't cross the worker boundary). Use mode: 'main'.",
+        );
+      }
+      return [];
+    }
+    const matches = await this._find.find(query, opts);
+    this._redrawHighlights();
+    return matches;
+  }
+
+  /**
+   * IX2 — move to the next match (wrap-around), navigating to its slide if
+   * needed, and draw it in the active-match colour. Returns the now-active
+   * match, or `null` when there are none. Call {@link findText} first.
+   */
+  async findNext(): Promise<FindMatch<PptxMatchLocation> | null> {
+    return this._activateMatch(this._find.next());
+  }
+
+  /** IX2 — move to the previous match (wrap-around). */
+  async findPrev(): Promise<FindMatch<PptxMatchLocation> | null> {
+    return this._activateMatch(this._find.prev());
+  }
+
+  /** IX2 — clear all highlights and reset the find state. */
+  clearFind(): void {
+    this._find.invalidate();
+    this._redrawHighlights();
+  }
+
+  private async _activateMatch(
+    match: FindMatch<PptxMatchLocation> | null,
+  ): Promise<FindMatch<PptxMatchLocation> | null> {
+    if (!match) {
+      this._redrawHighlights();
+      return null;
+    }
+    if (match.location.slide !== this.currentSlide) {
+      // goToSlide re-renders, rebuilding the highlight layer for the new slide.
+      await this.goToSlide(match.location.slide);
+    } else {
+      this._redrawHighlights();
+    }
+    return match;
+  }
+
+  /** Rebuild the highlight overlay for the current slide from cached runs. */
+  private _redrawHighlights(): void {
+    const runs = this._find.slideRuns(this.currentSlide) ?? [];
+    const targetWidth = this.opts.width ?? (this.canvas.offsetWidth || 960);
+    const cssHeight = this.engine
+      ? Math.round(this.engine.slideHeight * (targetWidth / this.engine.slideWidth))
+      : 0;
+    this._buildHighlightLayer(runs, targetWidth, cssHeight);
   }
 
   private _buildTextLayer(layer: HTMLDivElement, runs: PptxTextRunInfo[], cssWidth: number, cssHeight: number): void {

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -583,6 +583,10 @@ export class PptxViewer {
     this.handle?.destroy();
     this.handle = null;
     this.engine?.destroy();
+    // IX2 — drop the find state (matches + cached runs) so a stale
+    // findNext()/findPrev() after teardown returns null instead of a match
+    // pointing into a dead viewer.
+    this._find.invalidate();
     // Return the caller-owned canvas to its original DOM slot before discarding
     // the wrapper. insertBefore still works if the original parent was itself
     // detached; when there was no original parent the canvas is left detached

--- a/packages/xlsx/src/a1.test.ts
+++ b/packages/xlsx/src/a1.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseA1, formatA1 } from './a1.js';
+
+describe('formatA1', () => {
+  it('formats single-letter columns', () => {
+    expect(formatA1(1, 1)).toBe('A1');
+    expect(formatA1(7, 2)).toBe('B7');
+    expect(formatA1(10, 26)).toBe('Z10');
+  });
+
+  it('formats multi-letter columns (bijective base-26)', () => {
+    expect(formatA1(1, 27)).toBe('AA1');
+    expect(formatA1(1, 28)).toBe('AB1');
+    expect(formatA1(1, 52)).toBe('AZ1');
+    expect(formatA1(1, 53)).toBe('BA1');
+    expect(formatA1(5, 702)).toBe('ZZ5');
+    expect(formatA1(1, 703)).toBe('AAA1');
+  });
+
+  it('round-trips with parseA1', () => {
+    for (const [row, col] of [
+      [1, 1],
+      [7, 2],
+      [100, 26],
+      [3, 27],
+      [42, 703],
+    ] as const) {
+      const ref = formatA1(row, col);
+      expect(parseA1(ref)).toEqual({ row, col });
+    }
+  });
+});

--- a/packages/xlsx/src/a1.ts
+++ b/packages/xlsx/src/a1.ts
@@ -15,3 +15,20 @@ export function parseA1(ref: string): { row: number; col: number } | null {
   }
   return { row: parseInt(m[2], 10), col };
 }
+
+/**
+ * Inverse of {@link parseA1}: format a 1-based (row, col) as an A1 reference
+ * (e.g. `(7, 2)` → `"B7"`). Used by IX2 findText to report a match's cell in the
+ * A1 notation users know. The column runs the bijective base-26 the spreadsheet
+ * grid uses (1→A, 26→Z, 27→AA). `col`/`row` are assumed ≥ 1.
+ */
+export function formatA1(row: number, col: number): string {
+  let letters = '';
+  let c = col;
+  while (c > 0) {
+    const rem = (c - 1) % 26;
+    letters = String.fromCharCode(65 + rem) + letters;
+    c = Math.floor((c - 1) / 26);
+  }
+  return `${letters}${row}`;
+}

--- a/packages/xlsx/src/find.test.ts
+++ b/packages/xlsx/src/find.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { XlsxFindController, type FindCell } from './find.js';
+
+/**
+ * IX2 xlsx find controller. Cell-based: each non-empty cell's rendered text is
+ * searched; a match lands wholly in one cell and reports `{ sheet, sheetName,
+ * ref, row, col }`. Every occurrence within a cell counts (browser find-count).
+ */
+function controllerFor(sheets: { name: string; cells: FindCell[] }[]): XlsxFindController {
+  return new XlsxFindController(
+    () => sheets.length,
+    (sheet) => sheets[sheet]?.name ?? '',
+    (sheet) => Promise.resolve(sheets[sheet]?.cells ?? []),
+  );
+}
+
+const cell = (row: number, col: number, text: string): FindCell => ({ row, col, text });
+
+describe('XlsxFindController.find', () => {
+  it('finds a match in a cell and reports its A1 ref + row/col', async () => {
+    const c = controllerFor([{ name: 'Sales', cells: [cell(7, 2, 'Revenue')] }]);
+    const matches = await c.find('rev');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].location).toMatchObject({
+      sheet: 0,
+      sheetName: 'Sales',
+      ref: 'B7',
+      row: 7,
+      col: 2,
+    });
+    // Reported text is the matched substring in the cell's original case.
+    expect(matches[0].text).toBe('Rev');
+  });
+
+  it('counts every occurrence within a cell', async () => {
+    const c = controllerFor([{ name: 'S', cells: [cell(1, 1, 'the cat and the dog')] }]);
+    const matches = await c.find('the');
+    expect(matches).toHaveLength(2);
+    expect(matches.every((m) => m.location.ref === 'A1')).toBe(true);
+  });
+
+  it('searches across sheets in document order', async () => {
+    const c = controllerFor([
+      { name: 'One', cells: [cell(1, 1, 'apple')] },
+      { name: 'Two', cells: [cell(2, 3, 'grape')] },
+    ]);
+    const matches = await c.find('ap'); // "apple" and "grape" both contain "ap"
+    expect(matches).toHaveLength(2);
+    expect(matches[0].location.sheet).toBe(0);
+    expect(matches[1].location.sheet).toBe(1);
+    expect(matches[1].location.ref).toBe('C2');
+  });
+
+  it('is case-insensitive by default; caseSensitive honored', async () => {
+    const ci = await controllerFor([{ name: 'S', cells: [cell(1, 1, 'FOO foo')] }]).find('foo');
+    expect(ci).toHaveLength(2);
+    const cs = await controllerFor([{ name: 'S', cells: [cell(1, 1, 'FOO foo')] }]).find('foo', {
+      caseSensitive: true,
+    });
+    expect(cs).toHaveLength(1);
+  });
+
+  it('returns [] for an empty query', async () => {
+    const c = controllerFor([{ name: 'S', cells: [cell(1, 1, 'x')] }]);
+    expect(await c.find('')).toEqual([]);
+  });
+});
+
+describe('XlsxFindController cursor + highlights', () => {
+  it('cycles the active match across sheets with wrap-around', async () => {
+    const c = controllerFor([
+      { name: 'A', cells: [cell(1, 1, 'x')] },
+      { name: 'B', cells: [cell(1, 1, 'x')] },
+    ]);
+    await c.find('x');
+    expect(c.next()?.matchIndex).toBe(0);
+    expect(c.activeLocation()?.sheet).toBe(0);
+    expect(c.next()?.matchIndex).toBe(1);
+    expect(c.activeLocation()?.sheet).toBe(1);
+    expect(c.next()?.matchIndex).toBe(0); // wrap
+    expect(c.prev()?.matchIndex).toBe(1); // wrap back
+  });
+
+  it('sheetHighlights scopes to sheet and marks active', async () => {
+    const c = controllerFor([{ name: 'S', cells: [cell(1, 1, 'a'), cell(2, 1, 'a')] }]);
+    await c.find('a');
+    c.next(); // active = match 0 (A1)
+    const hl = c.sheetHighlights(0);
+    expect(hl).toHaveLength(2);
+    expect(hl.find((h) => h.row === 1)?.active).toBe(true);
+    expect(hl.find((h) => h.row === 2)?.active).toBe(false);
+    expect(c.sheetHighlights(1)).toHaveLength(0);
+  });
+
+  it('invalidate clears matches + cursor', async () => {
+    const c = controllerFor([{ name: 'S', cells: [cell(1, 1, 'a')] }]);
+    await c.find('a');
+    c.invalidate();
+    expect(c.matches()).toHaveLength(0);
+    expect(c.activeLocation()).toBeNull();
+    expect(c.next()).toBeNull();
+  });
+});

--- a/packages/xlsx/src/find.ts
+++ b/packages/xlsx/src/find.ts
@@ -1,0 +1,151 @@
+/**
+ * IX2 xlsx find-in-workbook controller.
+ *
+ * The spreadsheet twin of the docx / pptx find controllers, differing in the
+ * unit searched: a *cell* is the atomic run (one display string), not a
+ * glyph-run, so a match always lands wholly inside one cell and the highlight is
+ * the cell rectangle rather than a sub-cell glyph range. Search runs over each
+ * cell's *rendered* display text (via the viewer-supplied `cellText`, i.e. the
+ * same number-format / date / rich-text flattening the grid draws) so a query
+ * matches what the user sees.
+ *
+ * The core string math is still shared: each cell's text is a one-run
+ * {@link buildTextIndex}, and {@link findMatches} counts every occurrence within
+ * the cell (so "the the" registers two matches, like a browser find bar). The
+ * active-match cursor is core `nextActive`/`prevActive`. A match's location is
+ * `{ sheet, sheetName, ref, row, col }`.
+ */
+import {
+  buildTextIndex,
+  findMatches,
+  nextActive,
+  prevActive,
+  type FindMatch,
+  type FindMatchesOptions,
+} from '@silurus/ooxml-core';
+import { formatA1 } from './a1.js';
+
+/** One cell's searchable content (1-based row/col + its rendered text). */
+export interface FindCell {
+  row: number;
+  col: number;
+  text: string;
+}
+
+/** Where an xlsx match lives: the sheet, its name, and the cell (A1 + row/col). */
+export interface XlsxMatchLocation {
+  /** 0-based sheet index. */
+  sheet: number;
+  /** The sheet's display name. */
+  sheetName: string;
+  /** A1 cell reference, e.g. `"B7"`. */
+  ref: string;
+  /** 1-based row. */
+  row: number;
+  /** 1-based column. */
+  col: number;
+}
+
+interface XlsxResolvedMatch {
+  sheet: number;
+  sheetName: string;
+  row: number;
+  col: number;
+  text: string;
+}
+
+export class XlsxFindController {
+  private _matches: XlsxResolvedMatch[] = [];
+  private _active = -1;
+
+  constructor(
+    private readonly _sheetCount: () => number,
+    private readonly _sheetName: (sheet: number) => string,
+    /** Return every non-empty cell of a sheet, with its rendered display text. */
+    private readonly _collectSheetCells: (sheet: number) => Promise<FindCell[]>,
+  ) {}
+
+  /** Drop matches + cursor (call on reload). */
+  invalidate(): void {
+    this._matches = [];
+    this._active = -1;
+  }
+
+  /** Matched cells on a sheet, each tagged active — the highlight overlay input. */
+  sheetHighlights(sheet: number): { row: number; col: number; active: boolean }[] {
+    const out: { row: number; col: number; active: boolean }[] = [];
+    for (let i = 0; i < this._matches.length; i++) {
+      const m = this._matches[i];
+      if (m.sheet === sheet) out.push({ row: m.row, col: m.col, active: i === this._active });
+    }
+    return out;
+  }
+
+  /** The active match's location, or null. */
+  activeLocation(): XlsxMatchLocation | null {
+    return this._locationAt(this._active);
+  }
+
+  private _locationAt(index: number): XlsxMatchLocation | null {
+    const m = this._matches[index];
+    if (!m) return null;
+    return {
+      sheet: m.sheet,
+      sheetName: m.sheetName,
+      ref: formatA1(m.row, m.col),
+      row: m.row,
+      col: m.col,
+    };
+  }
+
+  /** The public match list for the current query. */
+  matches(): FindMatch<XlsxMatchLocation>[] {
+    return this._matches.map((m, i) => {
+      const loc = this._locationAt(i) as XlsxMatchLocation;
+      return { matchIndex: i, text: m.text, location: loc };
+    });
+  }
+
+  /** Run a fresh query across every sheet, resetting the cursor. Matches are in
+   *  document order: sheet ascending, then a sheet's cells in the order
+   *  `collectSheetCells` returns them (row-major from the parser). */
+  async find(query: string, opts: FindMatchesOptions = {}): Promise<FindMatch<XlsxMatchLocation>[]> {
+    this._matches = [];
+    this._active = -1;
+    if (query.length === 0) return [];
+
+    const sheets = this._sheetCount();
+    for (let sheet = 0; sheet < sheets; sheet++) {
+      const cells = await this._collectSheetCells(sheet);
+      const sheetName = this._sheetName(sheet);
+      for (const cell of cells) {
+        const index = buildTextIndex([{ text: cell.text }]);
+        const hits = findMatches(index, query, opts);
+        // Each occurrence within the cell is one match (browser find-count
+        // semantics); the located text is the matched substring in original case.
+        for (const tm of hits) {
+          const slice = tm.slices[0];
+          const text = cell.text.slice(slice.start, slice.end);
+          this._matches.push({ sheet, sheetName, row: cell.row, col: cell.col, text });
+        }
+      }
+    }
+    return this.matches();
+  }
+
+  next(): FindMatch<XlsxMatchLocation> | null {
+    this._active = nextActive(this._active, this._matches.length);
+    return this._activePublic();
+  }
+
+  prev(): FindMatch<XlsxMatchLocation> | null {
+    this._active = prevActive(this._active, this._matches.length);
+    return this._activePublic();
+  }
+
+  private _activePublic(): FindMatch<XlsxMatchLocation> | null {
+    const loc = this._locationAt(this._active);
+    if (!loc) return null;
+    return { matchIndex: this._active, text: this._matches[this._active].text, location: loc };
+  }
+}

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -4,6 +4,10 @@ export { XlsxViewer } from './viewer.js';
 // Resolved list-validation values (reachable via XlsxWorkbook.resolveValidationList).
 export type { ResolvedList } from './validation-list.js';
 export type { XlsxViewerOptions, HiddenSheetMode, CellAddress, CellRange, SelectionMode } from './viewer.js';
+// IX2 find-in-document: the xlsx match-location shape (sheet + A1 cell ref).
+// `FindMatch` / `FindMatchesOptions` come from core (shared across formats).
+export type { XlsxMatchLocation } from './find.js';
+export type { FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 // IX1 — the shared hyperlink target shape surfaced by `XlsxViewerOptions.
 // onHyperlinkClick`, plus the default "open in a new tab, sanitised" helper.

--- a/packages/xlsx/src/viewer-find-destroy.test.ts
+++ b/packages/xlsx/src/viewer-find-destroy.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { installDom, makeContainer } from './viewer-destroy-test-dom.js';
+import type { XlsxWorkbook } from './workbook.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * IX2 — destroy() must drop the find state (twin of the DocxViewer/PptxViewer
+ * tests). findNext()/findPrev() on a torn-down viewer must return null, not a
+ * stale match (which would even try to sheet-switch/scroll a dead viewer).
+ */
+function makeFakeWorkbook(): XlsxWorkbook {
+  const ws = {
+    rows: [{ index: 1, cells: [{ row: 1, col: 1, value: { type: 'text', text: 'hello world' } }] }],
+  };
+  return {
+    sheetCount: 1,
+    sheetNames: ['Sheet1'],
+    getWorksheet: () => Promise.resolve(ws),
+    cellText: () => 'hello world',
+    destroy: vi.fn(),
+    isHidden: () => false,
+  } as unknown as XlsxWorkbook;
+}
+
+describe('XlsxViewer.destroy() — find state invalidation', () => {
+  it('findNext()/findPrev() return null after destroy() (no stale matches)', async () => {
+    installDom();
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement);
+    (v as unknown as { wb: XlsxWorkbook }).wb = makeFakeWorkbook();
+
+    // A live find with a real active match…
+    const matches = await v.findText('hello');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].location.ref).toBe('A1');
+    const active = await v.findNext();
+    expect(active).not.toBeNull();
+    expect(active?.matchIndex).toBe(0);
+
+    // …must not survive teardown.
+    v.destroy();
+    expect(await v.findNext()).toBeNull();
+    expect(await v.findPrev()).toBeNull();
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -2817,6 +2817,10 @@ export class XlsxViewer {
     if (this.keydownHandler) {
       document.removeEventListener('keydown', this.keydownHandler);
     }
+    // IX2 — drop the find state (matches + cursor) so a stale
+    // findNext()/findPrev() after teardown returns null instead of a match
+    // pointing into a dead viewer (same fix as DocxViewer/PptxViewer.destroy).
+    this._find.invalidate();
     this.wb?.destroy();
     // Remove the whole UI subtree so the container is empty again. This also
     // detaches every listener bound to elements within it (scrollHost pointer/

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,10 +1,11 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.js';
-import type { HyperlinkTarget, LoadOptions } from '@silurus/ooxml-core';
+import type { HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, openExternalHyperlink } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
+import { XlsxFindController, type FindCell, type XlsxMatchLocation } from './find.js';
 import { computeCommentPopupPosition } from './comment-popup.js';
 import {
   computeValidationPanelPosition,
@@ -422,6 +423,10 @@ export class XlsxViewer {
   private selectionMode: SelectionMode = 'cells';
   private isSelecting = false;
   private selectionOverlay: HTMLDivElement;
+  /** IX2 — find-highlight overlay (matched-cell boxes). */
+  private findOverlay!: HTMLDivElement;
+  /** IX2 — find state (matches + active cursor). */
+  private _find!: XlsxFindController;
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
   // Deferred selection press: committed on pointerup only if the pointer
   // neither moved beyond the tap threshold nor caused a scroll. Used for
@@ -505,6 +510,15 @@ export class XlsxViewer {
     this.selectionOverlay.style.cssText =
       `position:absolute;top:0;left:0;z-index:1;pointer-events:none;overflow:hidden;width:100%;height:100%;`;
 
+    // IX2 — find-highlight overlay: a sibling of the selection overlay, drawn
+    // on the same DOM-overlay mechanism (absolutely-positioned boxes over the
+    // canvas) rather than a new canvas pass. z-index 1 like the selection
+    // overlay; `pointer-events:none` keeps the grid interactive underneath. A
+    // matched cell gets a translucent box; the active match a stronger one.
+    this.findOverlay = document.createElement('div');
+    this.findOverlay.style.cssText =
+      `position:absolute;top:0;left:0;z-index:1;pointer-events:none;overflow:hidden;width:100%;height:100%;`;
+
     this.scrollHost = document.createElement('div');
     this.scrollHost.style.cssText = `position:absolute;inset:0;overflow:auto;z-index:2;background:transparent;`;
 
@@ -543,6 +557,7 @@ export class XlsxViewer {
 
     this.canvasArea.appendChild(this.canvas);
     this.canvasArea.appendChild(this.selectionOverlay);
+    this.canvasArea.appendChild(this.findOverlay);
     this.canvasArea.appendChild(this.scrollHost);
     this.canvasArea.appendChild(this.commentPopup);
     this.canvasArea.appendChild(this.validationPanel);
@@ -620,6 +635,7 @@ export class XlsxViewer {
       // track the scroll immediately, so it stays synchronous.
       this.scheduleRender();
       this.updateSelectionOverlay();
+      this.updateFindOverlay();
     });
 
     // Re-render whenever the canvas area changes size. Re-anchor first: a
@@ -633,11 +649,35 @@ export class XlsxViewer {
       // cheap and must reflect the new size at once, so they stay synchronous.
       this.scheduleRender();
       this.updateSelectionOverlay();
+      this.updateFindOverlay();
       this.updateNavButtons();
     });
     this.resizeObserver.observe(this.canvasArea);
 
     this.setupSelectionEvents();
+
+    this._find = new XlsxFindController(
+      () => this.sheetCount,
+      (sheet) => this.wb?.sheetNames[sheet] ?? '',
+      (sheet) => this._collectSheetCells(sheet),
+    );
+  }
+
+  /** Every non-empty cell of a sheet with its rendered display text (IX2 find
+   *  source). Reads the parsed worksheet model directly — no render — so search
+   *  covers the whole sheet, not just the on-screen viewport. */
+  private async _collectSheetCells(sheet: number): Promise<FindCell[]> {
+    const wb = this.wb;
+    if (!wb) return [];
+    const ws = await wb.getWorksheet(sheet);
+    const cells: FindCell[] = [];
+    for (const row of ws.rows) {
+      for (const cell of row.cells) {
+        const text = wb.cellText(ws, cell);
+        if (text !== '') cells.push({ row: cell.row, col: cell.col, text });
+      }
+    }
+    return cells;
   }
 
   /**
@@ -682,6 +722,8 @@ export class XlsxViewer {
       }
       this.wb = wb;
       previous?.destroy();
+      // A new workbook invalidates any prior find state.
+      this._find.invalidate();
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
       await this.showSheet(this._initialSheet());
@@ -725,6 +767,9 @@ export class XlsxViewer {
     // so scrollWidth reflects the new sheet before we read the max offset.
     this.resetHorizontalScroll();
     await this.renderCurrentSheet();
+    // Redraw find highlights for the newly shown sheet (the find state survives
+    // a sheet switch; only the visible sheet's boxes are drawn).
+    this.updateFindOverlay();
     this.opts.onSheetChange?.(index, this.workbook.sheetNames.length);
   }
 
@@ -1445,6 +1490,186 @@ export class XlsxViewer {
       } else {
         this.hideValidationPanel();
       }
+    }
+  }
+
+  // ─── IX2 find-highlight overlay ──────────────────────────────────────────
+
+  /**
+   * Redraw the find-highlight overlay: one translucent box per matched cell on
+   * the current sheet, the active match in a stronger colour. Uses the SAME
+   * `getCellRect` + `screenX` + header/frozen clamp the selection overlay uses,
+   * so a box lands exactly on the drawn cell at any scroll offset / zoom / RTL.
+   * Rebuilt on every render and scroll (cheap DOM geometry, no canvas paint).
+   */
+  private updateFindOverlay(): void {
+    this.findOverlay.innerHTML = '';
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const cs = this.opts.cellScale ?? 1;
+    const sp = (px: number) => Math.round(px * cs);
+    const headerW = sp(HEADER_W);
+    const headerH = sp(HEADER_H);
+    const freezeRows = ws.freezeRows ?? 0;
+    const freezeCols = ws.freezeCols ?? 0;
+    let frozenW = 0;
+    for (let c = 1; c <= freezeCols; c++)
+      frozenW += sp(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws)));
+    let frozenH = 0;
+    for (let r = 1; r <= freezeRows; r++)
+      frozenH += sp(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight));
+    const frozenBoundX = headerW + frozenW;
+    const frozenBoundY = headerH + frozenH;
+
+    // A match accent: same single-color → border + translucent fill derivation
+    // the selection overlay uses. The active match uses a warm accent so it is
+    // distinguishable from other hits and from the (blue) selection box.
+    const other = selectionOverlayStyle('#ffb300'); // amber for all matches
+    const active = selectionOverlayStyle('#fb8c00'); // stronger orange for active
+
+    for (const hl of this._find.sheetHighlights(this.currentSheet)) {
+      const rect = this.getCellRect(hl.row, hl.col);
+      if (!rect) continue;
+      let { x, y, w, h } = rect;
+      // Clamp against headers + the frozen-pane boundary (scrollable cells that
+      // scrolled behind the frozen area are clipped there), mirroring the
+      // selection overlay so a highlight never spills over fixed regions.
+      if (x < headerW) { w -= headerW - x; x = headerW; }
+      if (y < headerH) { h -= headerH - y; y = headerH; }
+      if (hl.col > freezeCols && x < frozenBoundX) { w -= frozenBoundX - x; x = frozenBoundX; }
+      if (hl.row > freezeRows && y < frozenBoundY) { h -= frozenBoundY - y; y = frozenBoundY; }
+      if (w <= 0 || h <= 0) continue;
+      const screenLeft = this.screenX(x, w);
+      const { border, background } = hl.active ? active : other;
+      const box = document.createElement('div');
+      box.style.cssText =
+        `position:absolute;` +
+        `left:${screenLeft}px;top:${y}px;width:${w}px;height:${h}px;` +
+        `box-sizing:border-box;border:${border};background:${background};pointer-events:none;`;
+      this.findOverlay.appendChild(box);
+    }
+  }
+
+  /**
+   * IX2 — find every occurrence of `query` across every sheet and highlight the
+   * matched cells. Returns every match in document order (sheet ascending, then
+   * row-major within a sheet), each tagged with its
+   * `{ sheet, sheetName, ref, row, col }`. A cell is the search unit: search
+   * runs over each cell's *rendered* display text (number formats, dates, rich
+   * text flattened), so a query matches what the grid shows. Case-insensitive by
+   * default; pass `{ caseSensitive: true }` for an exact match. An empty query
+   * clears the find.
+   */
+  async findText(
+    query: string,
+    opts: FindMatchesOptions = {},
+  ): Promise<FindMatch<XlsxMatchLocation>[]> {
+    if (!this.wb) return [];
+    const matches = await this._find.find(query, opts);
+    this.updateFindOverlay();
+    return matches;
+  }
+
+  /**
+   * IX2 — move to the next match (wrap-around), switching sheets and scrolling
+   * the matched cell into view as needed, and highlight it as the active match.
+   * Returns the now-active match, or `null` when there are none. Call
+   * {@link findText} first.
+   */
+  async findNext(): Promise<FindMatch<XlsxMatchLocation> | null> {
+    return this._activateMatch(this._find.next());
+  }
+
+  /** IX2 — move to the previous match (wrap-around). */
+  async findPrev(): Promise<FindMatch<XlsxMatchLocation> | null> {
+    return this._activateMatch(this._find.prev());
+  }
+
+  /** IX2 — clear all highlights and reset the find state. */
+  clearFind(): void {
+    this._find.invalidate();
+    this.updateFindOverlay();
+  }
+
+  private async _activateMatch(
+    match: FindMatch<XlsxMatchLocation> | null,
+  ): Promise<FindMatch<XlsxMatchLocation> | null> {
+    if (!match) {
+      this.updateFindOverlay();
+      return null;
+    }
+    const { sheet, row, col } = match.location;
+    if (sheet !== this.currentSheet) {
+      // showSheet resets scroll/selection and re-renders; the find state (and so
+      // the highlights) survive because they live on the controller, not the
+      // sheet. updateFindOverlay runs after the sheet switch below.
+      await this.goToSheet(sheet);
+    }
+    this._scrollCellIntoView(row, col);
+    // Scrolling schedules a coalesced render; draw the highlights now so the
+    // active box is visible immediately without waiting a frame.
+    this.updateFindOverlay();
+    return match;
+  }
+
+  /**
+   * Scroll the grid so cell (row, col) is comfortably in view. Computes the
+   * cell's absolute logical offset from the axis metrics (the same the renderer
+   * uses) and nudges `scrollHost.scrollTop` / start-anchored horizontal scroll
+   * only when the cell is outside the scrollable viewport — an in-view cell is
+   * left where it is (Excel's find behaviour). Frozen cells are always visible,
+   * so they need no scroll.
+   */
+  private _scrollCellIntoView(row: number, col: number): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const cs = this.opts.cellScale ?? 1;
+    const mdw = getMdwForWorksheet(ws);
+    const axes = getSheetAxes(ws, mdw);
+    const freezeRows = ws.freezeRows ?? 0;
+    const freezeCols = ws.freezeCols ?? 0;
+
+    // Vertical: only scroll for a scrollable-region row.
+    if (row > freezeRows) {
+      const headerH = Math.round(HEADER_H * cs);
+      let frozenH = 0;
+      for (let r = 1; r <= freezeRows; r++) frozenH += Math.round(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight) * cs);
+      const viewTop = headerH + frozenH; // top of the scrollable region (canvasArea px)
+      const viewH = this.canvasArea.clientHeight;
+      // Cell offset from the first scrollable row, in logical px, → scaled px.
+      const cellTopLogical = axes.row.offsetOf(row) - axes.row.offsetOf(freezeRows + 1);
+      const cellHLogical = rowHeightToPx(ws.rowHeights[row] ?? ws.defaultRowHeight);
+      const cellTop = viewTop + (cellTopLogical * cs - this.scrollHost.scrollTop);
+      const cellBot = cellTop + cellHLogical * cs;
+      if (cellTop < viewTop) {
+        this.scrollHost.scrollTop = cellTopLogical * cs;
+      } else if (cellBot > viewH) {
+        this.scrollHost.scrollTop = cellTopLogical * cs - (viewH - viewTop - cellHLogical * cs);
+      }
+    }
+
+    // Horizontal: only scroll for a scrollable-region column. Work in the
+    // start-anchored logical space, then re-derive the native scrollLeft (RTL
+    // safe) via the existing anchor path.
+    if (col > freezeCols) {
+      const headerW = Math.round(HEADER_W * cs);
+      let frozenW = 0;
+      for (let c = 1; c <= freezeCols; c++) frozenW += Math.round(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw) * cs);
+      const viewLeft = headerW + frozenW;
+      const viewW = this.canvasArea.clientWidth;
+      const cellLeftLogical = axes.col.offsetOf(col) - axes.col.offsetOf(freezeCols + 1);
+      const cellWLogical = colWidthToPx(ws.colWidths[col] ?? ws.defaultColWidth, mdw);
+      const cellLeft = viewLeft + (cellLeftLogical * cs - this.effectiveScrollLeft);
+      const cellRight = cellLeft + cellWLogical * cs;
+      let wantEff = this.effectiveScrollLeft;
+      if (cellLeft < viewLeft) {
+        wantEff = cellLeftLogical * cs;
+      } else if (cellRight > viewW) {
+        wantEff = cellLeftLogical * cs - (viewW - viewLeft - cellWLogical * cs);
+      }
+      wantEff = Math.max(0, wantEff);
+      this.effectiveH = wantEff;
+      this.scrollHost.scrollLeft = this.isRtl ? Math.max(0, this.maxScrollLeft - wantEff) : wantEff;
     }
   }
 
@@ -2310,6 +2535,7 @@ export class XlsxViewer {
     }
     void this.renderCurrentSheet();
     this.updateSelectionOverlay();
+    this.updateFindOverlay();
     this.updateNavButtons();
   }
 

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -363,6 +363,20 @@ export class XlsxWorkbook {
     });
   }
 
+  /**
+   * IX2 — the display string a cell shows on the grid, i.e. exactly what
+   * {@link renderViewport} would draw (number formats, dates, booleans, rich
+   * text flattened). Used by {@link XlsxViewer.findText} to search the *rendered*
+   * text rather than the raw stored value, so a search matches what the user
+   * sees. Threads the workbook styles + the sheet's date system through the
+   * shared {@link formatCellValue} (the same call the renderer and
+   * validation-list expansion use). Returns `''` before the workbook is loaded.
+   */
+  cellText(ws: Worksheet, cell: Cell): string {
+    if (!this.parsedWorkbook) return '';
+    return formatCellValue(cell, this.parsedWorkbook.styles, null, ws.date1904);
+  }
+
   async renderViewport(
     target: HTMLCanvasElement | OffscreenCanvas,
     sheetIndex: number,


### PR DESCRIPTION
## Summary

Adds **findText** — in-document text search with highlighting — to all three viewers (`DocxViewer`, `PptxViewer`, `XlsxViewer`), with the shared, pure string/index math factored into `@silurus/ooxml-core`.

Each viewer gains the same API surface:

- `findText(query, opts?): Promise<FindMatch[]>` — finds **all** occurrences across the whole document, highlights them all, and returns every match tagged with its natural location (docx page / pptx slide / xlsx sheet+cell). Case-insensitive by default (`{ caseSensitive: true }` for exact), matching a browser's find-in-page.
- `findNext(): Promise<FindMatch | null>` / `findPrev()` — cycle the **active** match with wrap-around, navigate/scroll to it, and draw it in a distinct emphasis colour.
- `clearFind(): void` — clear highlights and reset state.

## Design

- **Shared core (`packages/core/src/search/`)** — `buildTextIndex` / `findMatches` (join a run list, match, resolve each hit to the run-slices it covers incl. cross-run matches), `sliceHorizontalExtent` (slice → highlight box extent via a `measureText` closure), `find-cursor` (`nextActive`/`prevActive`/`clampActive` wrap-around arithmetic), and the generic `FindMatch<Loc>` result shape. All pure — no DOM, no geometry — so the three viewers share one implementation instead of re-deriving the string math per package (per the repo's cross-package unification principle: share types + parse + pure predicates).
- **Highlights ride the existing DOM-overlay mechanism**, not a new canvas draw pass — the same positioned-overlay approach the selection / hyperlink overlay (IX1) already uses. docx draws a box per matched run-slice from the run's `x/y/h` + measured slice extent (with the run's transform for vertical `tbRl` pages); pptx groups boxes into the same rotated shape-frame `<div>` the selection overlay uses; xlsx draws a cell rectangle on a find overlay layer (sibling of the selection overlay) via `getCellRect` + the same header/frozen-pane clamp.
- **Run collection** reuses the `onTextRun` stream (docx/pptx). `findText` scans every page/slide — the visible one reuses its on-screen render, others render once to a throwaway offscreen canvas to read their text. xlsx is cell-based, so it searches each cell's **rendered** display text (via `XlsxWorkbook.cellText` → the shared `formatCellValue`), so a query matches what the grid shows.
- **Worker mode**: docx/pptx `findText` returns `[]` after a one-time warning (`onTextRun` can't cross the worker boundary). xlsx search is model-based and works in both modes.

## Files

- `packages/core/src/search/{find-cursor,find-match}.ts` (+ existing `text-index`/`highlight-rect`), core `index.ts` exports.
- `packages/docx/src/{find,find-highlight-layer}.ts`, `viewer.ts`, `index.ts`.
- `packages/pptx/src/{find,find-highlight-layer}.ts`, `viewer.ts`, `index.ts`.
- `packages/xlsx/src/{find,a1 (formatA1)}.ts`, `workbook.ts` (`cellText`), `viewer.ts`, `index.ts`.

## Tests & verification

- **Unit (vitest)**: core search (20) + find-cursor (14); per-format find controllers + highlight-layer DOM builders + `formatA1` — **72 new tests**, all green. Full root suite **2488 tests, 0 regressions**.
- **End-to-end on the real committed demo fixtures (headless node + skia)** — proves the whole pipeline, not stubs:
  - docx: `"cathedral"` on `sample-1.docx` → page 0, box computed at left=272.0/width=256.1/top=709.4, exactly flush with the drawn run (run.x=272.0, run.w=256.1, run.y=709.4).
  - pptx: `"forest"` on `sample-1.pptx` → 12 matches; slide-0 run `"THE FOREST"` box lands on the `FOREST` substring (in-shape left=160.6, width=267.8), proving sub-run slice extent.
  - xlsx: `"northridge"` on `sample-1.xlsx` → 4 matches; first at sheet 0 (Dashboard), ref **B18** (row 18, col 2).
- `typecheck` (tsc --build, all packages incl. node) and `ast-grep` lint: clean (no new errors/warnings).

## Notes / follow-ups

- WASM/parser changes were **not** needed — this is TS-only (the `onTextRun` stream and cell model already carry everything).
- Scope is the three single-canvas pager viewers (`DocxViewer`/`PptxViewer`/`XlsxViewer`) as specified. The continuous-scroll variants (`DocxScrollViewer`/`PptxScrollViewer`) share the same run stream and highlight-layer builders, so wiring findText into them is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)